### PR TITLE
feat: enrollment keys, TURN relay, file transfer storage

### DIFF
--- a/agent/internal/heartbeat/handlers_desktop.go
+++ b/agent/internal/heartbeat/handlers_desktop.go
@@ -61,7 +61,23 @@ func handleStartDesktop(h *Heartbeat, cmd Command) tools.CommandResult {
 			DurationMs: time.Since(start).Milliseconds(),
 		}
 	}
-	answer, err := h.desktopMgr.StartSession(sessionID, offer)
+
+	// Parse optional ICE servers from payload
+	var iceServers []desktop.ICEServerConfig
+	if raw, ok := cmd.Payload["iceServers"].([]interface{}); ok {
+		for _, item := range raw {
+			if m, ok := item.(map[string]interface{}); ok {
+				s := desktop.ICEServerConfig{
+					URLs:       m["urls"],
+					Username:   fmt.Sprintf("%v", m["username"]),
+					Credential: fmt.Sprintf("%v", m["credential"]),
+				}
+				iceServers = append(iceServers, s)
+			}
+		}
+	}
+
+	answer, err := h.desktopMgr.StartSession(sessionID, offer, iceServers)
 	if err != nil {
 		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
 	}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -26,6 +26,7 @@ import { reportRoutes } from './routes/reports';
 import { searchRoutes } from './routes/search';
 import { remoteRoutes } from './routes/remote';
 import { apiKeyRoutes } from './routes/apiKeys';
+import { enrollmentKeyRoutes } from './routes/enrollmentKeys';
 import { ssoRoutes } from './routes/sso';
 import { docsRoutes } from './routes/docs';
 import { accessReviewRoutes } from './routes/accessReviews';
@@ -73,6 +74,7 @@ import { initializeSnmpRetention } from './jobs/snmpRetention';
 import { initializePolicyEvaluationWorker } from './jobs/policyEvaluationWorker';
 import { initializePolicyAlertBridge } from './services/policyAlertBridge';
 import { getWebhookWorker, initializeWebhookDelivery } from './workers/webhookDelivery';
+import { initializeTransferCleanup } from './workers/transferCleanup';
 import { isRedisAvailable } from './services/redis';
 import { writeAuditEvent } from './services/auditEvents';
 import { db } from './db';
@@ -416,6 +418,7 @@ api.route('/remote/sessions', createTerminalWsRoutes(upgradeWebSocket)); // WebS
 api.route('/desktop-ws', createDesktopWsRoutes(upgradeWebSocket)); // Desktop WebSocket routes (outside /remote to avoid auth middleware)
 api.route('/remote', remoteRoutes);
 api.route('/api-keys', apiKeyRoutes);
+api.route('/enrollment-keys', enrollmentKeyRoutes);
 api.route('/sso', ssoRoutes);
 api.route('/docs', docsRoutes);
 api.route('/access-reviews', accessReviewRoutes);
@@ -664,3 +667,6 @@ async function initializeWorkers(): Promise<void> {
 initializeWorkers().catch((err) => {
   console.error('[CRITICAL] Worker initialization failed unexpectedly:', err);
 });
+
+// Transfer file cleanup (no Redis required)
+initializeTransferCleanup();

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -1,0 +1,291 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
+import { and, eq, sql, desc, inArray, lt, isNull, or } from 'drizzle-orm';
+import { db } from '../db';
+import { enrollmentKeys } from '../db/schema';
+import { authMiddleware, requireScope, type AuthContext } from '../middleware/auth';
+import { randomBytes } from 'crypto';
+import { createAuditLogAsync } from '../services/auditService';
+
+export const enrollmentKeyRoutes = new Hono();
+
+// ============================================
+// Helper Functions
+// ============================================
+
+function generateEnrollmentKey(): string {
+  return randomBytes(32).toString('hex'); // 64-char hex string
+}
+
+function getPagination(query: { page?: string; limit?: string }) {
+  const page = Math.max(1, Number.parseInt(query.page ?? '1', 10) || 1);
+  const limit = Math.min(100, Math.max(1, Number.parseInt(query.limit ?? '50', 10) || 50));
+  return { page, limit, offset: (page - 1) * limit };
+}
+
+async function ensureOrgAccess(
+  orgId: string,
+  auth: Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds' | 'canAccessOrg'>
+) {
+  if (auth.scope === 'organization') {
+    return auth.orgId === orgId;
+  }
+  if (auth.scope === 'partner') {
+    return auth.canAccessOrg(orgId);
+  }
+  return true;
+}
+
+function writeEnrollmentKeyAudit(
+  c: any,
+  auth: { user: { id: string; email?: string } },
+  event: {
+    orgId: string;
+    action: string;
+    keyId?: string;
+    keyName?: string;
+    details?: Record<string, unknown>;
+  }
+): void {
+  createAuditLogAsync({
+    orgId: event.orgId,
+    actorId: auth.user.id,
+    actorEmail: auth.user.email,
+    action: event.action,
+    resourceType: 'enrollment_key',
+    resourceId: event.keyId,
+    resourceName: event.keyName,
+    details: event.details,
+    ipAddress: c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip'),
+    userAgent: c.req.header('user-agent'),
+    result: 'success'
+  });
+}
+
+// ============================================
+// Validation Schemas
+// ============================================
+
+const listEnrollmentKeysSchema = z.object({
+  page: z.string().optional(),
+  limit: z.string().optional(),
+  orgId: z.string().uuid().optional(),
+  expired: z.enum(['true', 'false']).optional()
+});
+
+const createEnrollmentKeySchema = z.object({
+  orgId: z.string().uuid(),
+  siteId: z.string().uuid().optional(),
+  name: z.string().min(1).max(255),
+  maxUsage: z.number().int().min(1).max(100000).optional(),
+  expiresAt: z.string().datetime().optional()
+});
+
+// ============================================
+// Routes
+// ============================================
+
+enrollmentKeyRoutes.use('*', authMiddleware);
+
+// GET /enrollment-keys - List enrollment keys (org-scoped)
+enrollmentKeyRoutes.get(
+  '/',
+  requireScope('organization', 'partner', 'system'),
+  zValidator('query', listEnrollmentKeysSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const query = c.req.valid('query');
+    const { page, limit, offset } = getPagination(query);
+
+    const conditions: ReturnType<typeof eq>[] = [];
+
+    if (auth.scope === 'organization') {
+      if (!auth.orgId) {
+        return c.json({ error: 'Organization context required' }, 403);
+      }
+      conditions.push(eq(enrollmentKeys.orgId, auth.orgId));
+    } else if (auth.scope === 'partner') {
+      if (query.orgId) {
+        const hasAccess = await ensureOrgAccess(query.orgId, auth);
+        if (!hasAccess) {
+          return c.json({ error: 'Access to this organization denied' }, 403);
+        }
+        conditions.push(eq(enrollmentKeys.orgId, query.orgId));
+      } else {
+        const orgIds = auth.accessibleOrgIds ?? [];
+        if (orgIds.length === 0) {
+          return c.json({ data: [], pagination: { page, limit, total: 0 } });
+        }
+        conditions.push(inArray(enrollmentKeys.orgId, orgIds) as ReturnType<typeof eq>);
+      }
+    } else if (auth.scope === 'system') {
+      if (query.orgId) {
+        conditions.push(eq(enrollmentKeys.orgId, query.orgId));
+      }
+    }
+
+    // Filter by expired status
+    if (query.expired === 'true') {
+      conditions.push(lt(enrollmentKeys.expiresAt, new Date()) as ReturnType<typeof eq>);
+    } else if (query.expired === 'false') {
+      conditions.push(
+        or(
+          isNull(enrollmentKeys.expiresAt),
+          sql`${enrollmentKeys.expiresAt} >= NOW()`
+        ) as ReturnType<typeof eq>
+      );
+    }
+
+    const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const countResult = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(enrollmentKeys)
+      .where(whereCondition);
+    const total = Number(countResult[0]?.count ?? 0);
+
+    const keyList = await db
+      .select()
+      .from(enrollmentKeys)
+      .where(whereCondition)
+      .orderBy(desc(enrollmentKeys.createdAt))
+      .limit(limit)
+      .offset(offset);
+
+    return c.json({
+      data: keyList,
+      pagination: { page, limit, total }
+    });
+  }
+);
+
+// POST /enrollment-keys - Create new enrollment key
+enrollmentKeyRoutes.post(
+  '/',
+  requireScope('organization', 'partner', 'system'),
+  zValidator('json', createEnrollmentKeySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const data = c.req.valid('json');
+
+    if (auth.scope === 'organization') {
+      if (!auth.orgId) {
+        return c.json({ error: 'Organization context required' }, 403);
+      }
+      if (data.orgId !== auth.orgId) {
+        return c.json({ error: 'Can only create enrollment keys for your organization' }, 403);
+      }
+    } else if (auth.scope === 'partner') {
+      const hasAccess = await ensureOrgAccess(data.orgId, auth);
+      if (!hasAccess) {
+        return c.json({ error: 'Access to this organization denied' }, 403);
+      }
+    }
+
+    const key = generateEnrollmentKey();
+
+    const [enrollmentKey] = await db
+      .insert(enrollmentKeys)
+      .values({
+        orgId: data.orgId,
+        siteId: data.siteId ?? null,
+        name: data.name,
+        key,
+        maxUsage: data.maxUsage ?? null,
+        expiresAt: data.expiresAt ? new Date(data.expiresAt) : null,
+        createdBy: auth.user.id
+      })
+      .returning();
+
+    if (!enrollmentKey) {
+      return c.json({ error: 'Failed to create enrollment key' }, 500);
+    }
+
+    writeEnrollmentKeyAudit(c, auth, {
+      orgId: enrollmentKey.orgId,
+      action: 'enrollment_key.create',
+      keyId: enrollmentKey.id,
+      keyName: enrollmentKey.name,
+      details: {
+        siteId: enrollmentKey.siteId,
+        maxUsage: enrollmentKey.maxUsage,
+        expiresAt: enrollmentKey.expiresAt
+      }
+    });
+
+    return c.json(enrollmentKey, 201);
+  }
+);
+
+// GET /enrollment-keys/:id - Get enrollment key details
+enrollmentKeyRoutes.get(
+  '/:id',
+  requireScope('organization', 'partner', 'system'),
+  async (c) => {
+    const auth = c.get('auth');
+    const keyId = c.req.param('id');
+
+    const [enrollmentKey] = await db
+      .select()
+      .from(enrollmentKeys)
+      .where(eq(enrollmentKeys.id, keyId))
+      .limit(1);
+
+    if (!enrollmentKey) {
+      return c.json({ error: 'Enrollment key not found' }, 404);
+    }
+
+    const hasAccess = await ensureOrgAccess(enrollmentKey.orgId, auth);
+    if (!hasAccess) {
+      return c.json({ error: 'Access denied' }, 403);
+    }
+
+    return c.json(enrollmentKey);
+  }
+);
+
+// DELETE /enrollment-keys/:id - Delete enrollment key (hard delete)
+enrollmentKeyRoutes.delete(
+  '/:id',
+  requireScope('organization', 'partner', 'system'),
+  async (c) => {
+    const auth = c.get('auth');
+    const keyId = c.req.param('id');
+
+    const [existingKey] = await db
+      .select()
+      .from(enrollmentKeys)
+      .where(eq(enrollmentKeys.id, keyId))
+      .limit(1);
+
+    if (!existingKey) {
+      return c.json({ error: 'Enrollment key not found' }, 404);
+    }
+
+    const hasAccess = await ensureOrgAccess(existingKey.orgId, auth);
+    if (!hasAccess) {
+      return c.json({ error: 'Access denied' }, 403);
+    }
+
+    await db
+      .delete(enrollmentKeys)
+      .where(eq(enrollmentKeys.id, keyId));
+
+    writeEnrollmentKeyAudit(c, auth, {
+      orgId: existingKey.orgId,
+      action: 'enrollment_key.delete',
+      keyId: existingKey.id,
+      keyName: existingKey.name,
+      details: {
+        usageCount: existingKey.usageCount,
+        maxUsage: existingKey.maxUsage
+      }
+    });
+
+    return c.json({
+      success: true,
+      message: 'Enrollment key deleted successfully'
+    });
+  }
+);

--- a/apps/api/src/services/fileStorage.ts
+++ b/apps/api/src/services/fileStorage.ts
@@ -1,0 +1,164 @@
+import { mkdirSync, existsSync, createReadStream, createWriteStream, readdirSync, unlinkSync, rmdirSync, statSync } from 'fs';
+import { join } from 'path';
+import type { Readable } from 'stream';
+
+const STORAGE_PATH = process.env.TRANSFER_STORAGE_PATH || './data/transfers';
+const MAX_TRANSFER_SIZE_MB = parseInt(process.env.MAX_TRANSFER_SIZE_MB || '500', 10);
+
+export const MAX_TRANSFER_SIZE_BYTES = MAX_TRANSFER_SIZE_MB * 1024 * 1024;
+export const CHUNK_SIZE = 1024 * 1024; // 1MB per chunk
+
+function transferDir(transferId: string): string {
+  return join(STORAGE_PATH, transferId);
+}
+
+function chunkPath(transferId: string, chunkIndex: number): string {
+  return join(transferDir(transferId), `chunk_${String(chunkIndex).padStart(6, '0')}`);
+}
+
+function assembledPath(transferId: string): string {
+  return join(transferDir(transferId), 'assembled');
+}
+
+/**
+ * Ensure the storage directory exists for a transfer.
+ */
+export function ensureTransferDir(transferId: string): void {
+  const dir = transferDir(transferId);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+/**
+ * Save a chunk of data for a transfer.
+ */
+export async function saveChunk(transferId: string, chunkIndex: number, data: Buffer): Promise<void> {
+  ensureTransferDir(transferId);
+  const path = chunkPath(transferId, chunkIndex);
+
+  return new Promise((resolve, reject) => {
+    const ws = createWriteStream(path);
+    ws.on('finish', resolve);
+    ws.on('error', reject);
+    ws.end(data);
+  });
+}
+
+/**
+ * Get the number of chunks saved for a transfer.
+ */
+export function getChunkCount(transferId: string): number {
+  const dir = transferDir(transferId);
+  if (!existsSync(dir)) return 0;
+
+  return readdirSync(dir).filter(f => f.startsWith('chunk_')).length;
+}
+
+/**
+ * Get total bytes received across all chunks for a transfer.
+ */
+export function getTotalBytesReceived(transferId: string): number {
+  const dir = transferDir(transferId);
+  if (!existsSync(dir)) return 0;
+
+  return readdirSync(dir)
+    .filter(f => f.startsWith('chunk_'))
+    .reduce((total, f) => {
+      try {
+        return total + statSync(join(dir, f)).size;
+      } catch {
+        return total;
+      }
+    }, 0);
+}
+
+/**
+ * Assemble all chunks into a single file.
+ * Chunks are concatenated in order (chunk_000000, chunk_000001, ...).
+ */
+export async function assembleChunks(transferId: string): Promise<void> {
+  const dir = transferDir(transferId);
+  const files = readdirSync(dir)
+    .filter(f => f.startsWith('chunk_'))
+    .sort();
+
+  if (files.length === 0) {
+    throw new Error('No chunks found to assemble');
+  }
+
+  const outPath = assembledPath(transferId);
+  const out = createWriteStream(outPath);
+
+  for (const file of files) {
+    await new Promise<void>((resolve, reject) => {
+      const input = createReadStream(join(dir, file));
+      input.on('error', reject);
+      input.on('end', resolve);
+      input.pipe(out, { end: false });
+    });
+  }
+
+  out.end();
+
+  await new Promise<void>((resolve, reject) => {
+    out.on('finish', resolve);
+    out.on('error', reject);
+  });
+
+  // Clean up chunk files
+  for (const file of files) {
+    try {
+      unlinkSync(join(dir, file));
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+}
+
+/**
+ * Get a readable stream for the assembled file.
+ */
+export function getFileStream(transferId: string): Readable | null {
+  const path = assembledPath(transferId);
+  if (!existsSync(path)) return null;
+  return createReadStream(path);
+}
+
+/**
+ * Get the size of the assembled file.
+ */
+export function getFileSize(transferId: string): number {
+  const path = assembledPath(transferId);
+  if (!existsSync(path)) return 0;
+  return statSync(path).size;
+}
+
+/**
+ * Delete all files for a transfer (chunks and assembled).
+ */
+export function deleteTransfer(transferId: string): void {
+  const dir = transferDir(transferId);
+  if (!existsSync(dir)) return;
+
+  for (const file of readdirSync(dir)) {
+    try {
+      unlinkSync(join(dir, file));
+    } catch {
+      // Ignore
+    }
+  }
+
+  try {
+    rmdirSync(dir);
+  } catch {
+    // Ignore
+  }
+}
+
+/**
+ * Check if the assembled file exists for a transfer.
+ */
+export function hasAssembledFile(transferId: string): boolean {
+  return existsSync(assembledPath(transferId));
+}

--- a/apps/api/src/workers/transferCleanup.ts
+++ b/apps/api/src/workers/transferCleanup.ts
@@ -1,0 +1,67 @@
+import { lt, or, eq, and } from 'drizzle-orm';
+import { db } from '../db';
+import { fileTransfers } from '../db/schema';
+import { deleteTransfer } from '../services/fileStorage';
+
+const CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+const MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+let cleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+async function runCleanup() {
+  try {
+    const cutoff = new Date(Date.now() - MAX_AGE_MS);
+
+    // Find old or failed transfers
+    const staleTransfers = await db
+      .select({ id: fileTransfers.id, status: fileTransfers.status })
+      .from(fileTransfers)
+      .where(
+        or(
+          and(
+            lt(fileTransfers.createdAt, cutoff),
+            or(
+              eq(fileTransfers.status, 'completed'),
+              eq(fileTransfers.status, 'failed'),
+              eq(fileTransfers.status, 'pending')
+            )
+          ),
+          eq(fileTransfers.status, 'failed')
+        )
+      )
+      .limit(100);
+
+    if (staleTransfers.length === 0) return;
+
+    let cleaned = 0;
+    for (const transfer of staleTransfers) {
+      try {
+        deleteTransfer(transfer.id);
+        cleaned++;
+      } catch {
+        // Ignore individual cleanup errors
+      }
+    }
+
+    if (cleaned > 0) {
+      console.log(`[TransferCleanup] Cleaned up ${cleaned} transfer file(s)`);
+    }
+  } catch (err) {
+    console.error('[TransferCleanup] Error during cleanup:', err);
+  }
+}
+
+export function initializeTransferCleanup() {
+  if (cleanupTimer) return;
+  cleanupTimer = setInterval(runCleanup, CLEANUP_INTERVAL_MS);
+  // Run once at startup after a short delay
+  setTimeout(runCleanup, 10000);
+  console.log('[TransferCleanup] Initialized (interval: 1h, max age: 24h)');
+}
+
+export function stopTransferCleanup() {
+  if (cleanupTimer) {
+    clearInterval(cleanupTimer);
+    cleanupTimer = null;
+  }
+}

--- a/apps/web/src/components/settings/EnrollmentKeyManager.tsx
+++ b/apps/web/src/components/settings/EnrollmentKeyManager.tsx
@@ -1,0 +1,435 @@
+import { useState, useEffect, useCallback } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+
+interface EnrollmentKey {
+  id: string;
+  orgId: string;
+  siteId: string | null;
+  name: string;
+  key: string;
+  usageCount: number;
+  maxUsage: number | null;
+  expiresAt: string | null;
+  createdBy: string | null;
+  createdAt: string;
+}
+
+interface CreateFormValues {
+  orgId: string;
+  siteId?: string;
+  name: string;
+  maxUsage?: number;
+  expiresAt?: string;
+}
+
+type ModalMode = 'closed' | 'create' | 'delete';
+
+export default function EnrollmentKeyManager() {
+  const [keys, setKeys] = useState<EnrollmentKey[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+  const [modalMode, setModalMode] = useState<ModalMode>('closed');
+  const [selectedKey, setSelectedKey] = useState<EnrollmentKey | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+
+  // Create form state
+  const [formName, setFormName] = useState('');
+  const [formMaxUsage, setFormMaxUsage] = useState('');
+  const [formExpiresAt, setFormExpiresAt] = useState('');
+
+  const fetchKeys = useCallback(async (page = 1) => {
+    try {
+      setLoading(true);
+      setError(undefined);
+      const response = await fetchWithAuth(`/enrollment-keys?page=${page}`);
+      if (!response.ok) {
+        if (response.status === 401) {
+          window.location.href = '/login';
+          return;
+        }
+        throw new Error('Failed to fetch enrollment keys');
+      }
+      const data = await response.json();
+      setKeys(data.data ?? []);
+      const total = data.pagination?.total ?? 0;
+      const limit = data.pagination?.limit ?? 50;
+      setTotalPages(Math.max(1, Math.ceil(total / limit)));
+      setCurrentPage(data.pagination?.page ?? page);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchKeys();
+  }, [fetchKeys]);
+
+  const handleCopyKey = async (key: string, id: string) => {
+    try {
+      await navigator.clipboard.writeText(key);
+      setCopiedId(id);
+      setTimeout(() => setCopiedId(null), 2000);
+    } catch {
+      // Fallback for older browsers
+    }
+  };
+
+  const handleOpenCreate = () => {
+    setFormName('');
+    setFormMaxUsage('');
+    setFormExpiresAt('');
+    setModalMode('create');
+  };
+
+  const handleOpenDelete = (key: EnrollmentKey) => {
+    setSelectedKey(key);
+    setModalMode('delete');
+  };
+
+  const handleCloseModal = () => {
+    setModalMode('closed');
+    setSelectedKey(null);
+  };
+
+  const handleCreateSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      const body: Record<string, unknown> = { name: formName };
+
+      // Use first available orgId from existing keys, or let the server resolve it
+      if (keys.length > 0) {
+        body.orgId = keys[0].orgId;
+      }
+
+      if (formMaxUsage) {
+        body.maxUsage = parseInt(formMaxUsage, 10);
+      }
+      if (formExpiresAt) {
+        body.expiresAt = new Date(formExpiresAt).toISOString();
+      }
+
+      const response = await fetchWithAuth('/enrollment-keys', {
+        method: 'POST',
+        body: JSON.stringify(body)
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || 'Failed to create enrollment key');
+      }
+
+      await fetchKeys(currentPage);
+      handleCloseModal();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!selectedKey) return;
+    setSubmitting(true);
+    try {
+      const response = await fetchWithAuth(`/enrollment-keys/${selectedKey.id}`, {
+        method: 'DELETE'
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to delete enrollment key');
+      }
+
+      await fetchKeys(currentPage);
+      handleCloseModal();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const isExpired = (key: EnrollmentKey) =>
+    key.expiresAt && new Date(key.expiresAt) < new Date();
+
+  const isExhausted = (key: EnrollmentKey) =>
+    key.maxUsage !== null && key.usageCount >= key.maxUsage;
+
+  const getKeyStatus = (key: EnrollmentKey) => {
+    if (isExpired(key)) return { label: 'Expired', className: 'bg-red-500/10 text-red-400 border-red-500/30' };
+    if (isExhausted(key)) return { label: 'Exhausted', className: 'bg-amber-500/10 text-amber-400 border-amber-500/30' };
+    return { label: 'Active', className: 'bg-green-500/10 text-green-400 border-green-500/30' };
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="text-center">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent mx-auto" />
+          <p className="mt-4 text-sm text-muted-foreground">Loading enrollment keys...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error && keys.length === 0) {
+    return (
+      <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-6 text-center">
+        <p className="text-sm text-destructive">{error}</p>
+        <button
+          type="button"
+          onClick={() => fetchKeys()}
+          className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold">Enrollment Keys</h1>
+          <p className="text-muted-foreground">
+            Create and manage keys for agent enrollment. Use these keys with{' '}
+            <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">breeze-agent enroll &lt;key&gt;</code>
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleOpenCreate}
+          className="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+        >
+          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+          </svg>
+          Create Key
+        </button>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {/* Keys Table */}
+      <div className="rounded-lg border bg-card">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-xs uppercase text-muted-foreground">
+                <th className="px-4 py-3 font-medium">Name</th>
+                <th className="px-4 py-3 font-medium">Key</th>
+                <th className="px-4 py-3 font-medium">Status</th>
+                <th className="px-4 py-3 font-medium">Usage</th>
+                <th className="px-4 py-3 font-medium">Expires</th>
+                <th className="px-4 py-3 font-medium">Created</th>
+                <th className="px-4 py-3 font-medium text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {keys.length === 0 ? (
+                <tr>
+                  <td colSpan={7} className="px-4 py-8 text-center text-muted-foreground">
+                    No enrollment keys found. Create one to get started.
+                  </td>
+                </tr>
+              ) : (
+                keys.map((key) => {
+                  const status = getKeyStatus(key);
+                  return (
+                    <tr key={key.id} className="border-b last:border-b-0 hover:bg-muted/50">
+                      <td className="px-4 py-3 font-medium">{key.name}</td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">
+                            {key.key.slice(0, 12)}...
+                          </code>
+                          <button
+                            type="button"
+                            onClick={() => handleCopyKey(key.key, key.id)}
+                            className="text-muted-foreground hover:text-foreground"
+                            title="Copy full key"
+                          >
+                            {copiedId === key.id ? (
+                              <svg className="h-4 w-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                              </svg>
+                            ) : (
+                              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                              </svg>
+                            )}
+                          </button>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${status.className}`}>
+                          {status.label}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 tabular-nums">
+                        {key.usageCount}{key.maxUsage !== null ? ` / ${key.maxUsage}` : ''}
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground">
+                        {key.expiresAt
+                          ? new Date(key.expiresAt).toLocaleDateString()
+                          : 'Never'}
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground">
+                        {new Date(key.createdAt).toLocaleDateString()}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <button
+                          type="button"
+                          onClick={() => handleOpenDelete(key)}
+                          className="rounded-md px-2 py-1 text-xs text-destructive hover:bg-destructive/10"
+                        >
+                          Delete
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-between border-t px-4 py-3">
+            <span className="text-xs text-muted-foreground">
+              Page {currentPage} of {totalPages}
+            </span>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => fetchKeys(currentPage - 1)}
+                disabled={currentPage <= 1}
+                className="rounded-md border px-3 py-1 text-xs disabled:opacity-40"
+              >
+                Previous
+              </button>
+              <button
+                type="button"
+                onClick={() => fetchKeys(currentPage + 1)}
+                disabled={currentPage >= totalPages}
+                className="rounded-md border px-3 py-1 text-xs disabled:opacity-40"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Create Modal */}
+      {modalMode === 'create' && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 py-8">
+          <div className="w-full max-w-lg rounded-lg border bg-card p-6 shadow-sm">
+            <h2 className="text-lg font-semibold">Create Enrollment Key</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Generate a new key for agent enrollment.
+            </p>
+            <form onSubmit={handleCreateSubmit} className="mt-4 space-y-4">
+              <div>
+                <label className="text-sm font-medium">Name</label>
+                <input
+                  type="text"
+                  value={formName}
+                  onChange={(e) => setFormName(e.target.value)}
+                  placeholder="e.g., Production servers"
+                  required
+                  className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+              </div>
+              <div>
+                <label className="text-sm font-medium">Max Usage (optional)</label>
+                <input
+                  type="number"
+                  value={formMaxUsage}
+                  onChange={(e) => setFormMaxUsage(e.target.value)}
+                  placeholder="Unlimited"
+                  min={1}
+                  className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Maximum number of agents that can enroll with this key.
+                </p>
+              </div>
+              <div>
+                <label className="text-sm font-medium">Expires At (optional)</label>
+                <input
+                  type="datetime-local"
+                  value={formExpiresAt}
+                  onChange={(e) => setFormExpiresAt(e.target.value)}
+                  className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+              </div>
+              <div className="flex justify-end gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={handleCloseModal}
+                  className="h-10 rounded-md border px-4 text-sm font-medium text-muted-foreground transition hover:text-foreground"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={submitting || !formName.trim()}
+                  className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {submitting ? 'Creating...' : 'Create Key'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Confirmation Modal */}
+      {modalMode === 'delete' && selectedKey && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 py-8">
+          <div className="w-full max-w-md rounded-lg border bg-card p-6 shadow-sm">
+            <h2 className="text-lg font-semibold">Delete Enrollment Key</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Are you sure you want to delete{' '}
+              <span className="font-medium">{selectedKey.name}</span>? This action cannot be undone.
+            </p>
+            <div className="mt-4 rounded-md border border-destructive/40 bg-destructive/10 p-3">
+              <p className="text-xs text-destructive">
+                Agents will no longer be able to enroll using this key.
+              </p>
+            </div>
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={handleCloseModal}
+                className="h-10 rounded-md border px-4 text-sm font-medium text-muted-foreground transition hover:text-foreground"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirmDelete}
+                disabled={submitting}
+                className="inline-flex h-10 items-center justify-center rounded-md bg-destructive px-4 text-sm font-medium text-destructive-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {submitting ? 'Deleting...' : 'Delete Key'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/settings/enrollment-keys.astro
+++ b/apps/web/src/pages/settings/enrollment-keys.astro
@@ -1,0 +1,8 @@
+---
+import DashboardLayout from '../../layouts/DashboardLayout.astro';
+import EnrollmentKeyManager from '../../components/settings/EnrollmentKeyManager';
+---
+
+<DashboardLayout title="Enrollment Keys">
+  <EnrollmentKeyManager client:load />
+</DashboardLayout>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,10 @@ services:
       SMTP_USER: ${SMTP_USER:-}
       SMTP_PASS: ${SMTP_PASS:-}
       SMTP_FROM: ${SMTP_FROM:-noreply@breeze.local}
+      TURN_HOST: ${TURN_HOST:-}
+      TURN_PORT: ${TURN_PORT:-3478}
+      TURN_SECRET: ${TURN_SECRET:-}
+      TURN_REALM: ${TURN_REALM:-breeze.local}
       # Shared with monitoring/prometheus.yml bearer credentials for /metrics/scrape.
       METRICS_SCRAPE_TOKEN: ${METRICS_SCRAPE_TOKEN:-dev-monitoring-scrape-token-change-me}
     ports:
@@ -141,6 +145,31 @@ services:
       start_period: 10s
     profiles:
       - storage
+
+  # coturn TURN relay for WebRTC behind NAT/firewalls
+  # Enable with: docker compose --profile turn up -d
+  coturn:
+    image: coturn/coturn:latest
+    container_name: breeze-coturn
+    restart: unless-stopped
+    network_mode: host
+    volumes:
+      - ./docker/turnserver.conf:/etc/turnserver.conf:ro
+    environment:
+      TURN_SECRET: ${TURN_SECRET:-breeze-turn-secret-change-me}
+    command: >
+      turnserver
+      --no-tls
+      --no-dtls
+      --listening-port=${TURN_PORT:-3478}
+      --realm=${TURN_REALM:-breeze.local}
+      --use-auth-secret
+      --static-auth-secret=${TURN_SECRET:-breeze-turn-secret-change-me}
+      --log-file=stdout
+      --no-cli
+      --fingerprint
+    profiles:
+      - turn
 
   # ============================================
   # Monitoring Stack (Optional)


### PR DESCRIPTION
## Summary

- **Enrollment Key Management** — Full CRUD API (`/enrollment-keys`) with org-scoped access control, Zod validation, audit logging. React UI with key table, copy-to-clipboard, create/delete modals, Active/Expired/Exhausted status badges, and pagination.
- **TURN Relay Server** — coturn service in docker-compose (profile: `turn`), RFC 5389 time-limited HMAC credential generation via `GET /remote/ice-servers`, ICE servers forwarded through `start_desktop` command to agent. Viewer fetches TURN credentials before creating PeerConnection; agent parses and applies them. Falls back to STUN-only if TURN is not configured.
- **File Transfer Storage Backend** — Local filesystem storage service (`saveChunk`, `assembleChunks`, `getFileStream`, `deleteTransfer`). Chunk upload endpoint (`POST /transfers/:id/chunks`) with multipart parsing, size limit enforcement, auto-assembly on completion. Download endpoint now streams the actual assembled file with `Content-Disposition`. Hourly cleanup worker removes transfer files older than 24h.
- **Offline Device Timeout** — Already fully implemented (`offlineDetector.ts`, BullMQ, 30s interval, 5min threshold). No changes needed.

## Files Changed

| Area | Files | Lines |
|------|-------|-------|
| Enrollment Keys API | `routes/enrollmentKeys.ts` (new), `index.ts` | ~250 |
| Enrollment Keys UI | `EnrollmentKeyManager.tsx` (new), `enrollment-keys.astro` (new) | ~310 |
| TURN Server | `remote.ts`, `webrtc.ts`, `webrtc.go`, `handlers_desktop.go`, `docker-compose.yml` | ~170 |
| File Transfer | `fileStorage.ts` (new), `remote.ts`, `transferCleanup.ts` (new), `index.ts` | ~350 |

## Test plan

- [ ] Create enrollment key via UI → copy key → `breeze-agent enroll <key>` succeeds → usage count increments → delete key → enrollment fails
- [ ] `GET /enrollment-keys` returns paginated, org-scoped list; expired keys show correct status
- [ ] Set `TURN_HOST`/`TURN_SECRET` env vars → `GET /remote/ice-servers` returns STUN + TURN with time-limited credentials
- [ ] Start remote desktop → agent receives `iceServers` in `start_desktop` payload → uses TURN for relay candidates
- [ ] Without TURN configured → viewer falls back to STUN-only (no errors)
- [ ] Upload file via agent chunks → `POST /transfers/:id/chunks` saves to disk → auto-assembles when complete
- [ ] `GET /transfers/:id/download` streams assembled file with correct filename
- [ ] Transfer cleanup worker runs hourly, removes files older than 24h
- [ ] Go build passes, all Go tests pass, TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)