### PR TITLE
feat(ai): auto-generate session titles from first message

### DIFF
--- a/apps/web/src/stores/aiStore.ts
+++ b/apps/web/src/stores/aiStore.ts
@@ -445,6 +445,14 @@ function processStreamEvent(
       }));
       return currentAssistantId;
 
+    case 'title_updated':
+      set((s) => ({
+        sessions: s.sessions.map((sess) =>
+          sess.id === s.sessionId ? { ...sess, title: event.title } : sess
+        )
+      }));
+      return currentAssistantId;
+
     case 'message_end': {
       if (currentAssistantId) {
         set((s) => ({

--- a/packages/shared/src/types/ai.ts
+++ b/packages/shared/src/types/ai.ts
@@ -85,6 +85,7 @@ export type AiStreamEvent =
   | { type: 'tool_use_start'; toolName: string; toolUseId: string; input: Record<string, unknown> }
   | { type: 'tool_result'; toolUseId: string; output: unknown; isError: boolean }
   | { type: 'approval_required'; executionId: string; toolName: string; input: Record<string, unknown>; description: string }
+  | { type: 'title_updated'; title: string }
   | { type: 'message_end'; inputTokens: number; outputTokens: number }
   | { type: 'error'; message: string }
   | { type: 'done' };


### PR DESCRIPTION
## Summary
- Auto-set session title from the user's first message (truncated to 80 chars at word boundary) — sessions no longer show as "Untitled conversation"
- Add `title_updated` SSE event so the sidebar updates in real-time without refresh
- Add `PATCH /ai/sessions/:id` endpoint for manual rename

**Note:** Based on `fix/ai-tool-approval-gate` — merge that first.

## Test plan
- [ ] Open AI chat, send a message — verify sidebar shows the message as the title instead of "Untitled conversation"
- [ ] Long first messages (100+ chars) are truncated at a word boundary with ellipsis
- [ ] Open history panel — previously untitled sessions still show "Untitled conversation", new ones show titles
- [ ] `PATCH /ai/sessions/:id` with `{ "title": "Custom name" }` renames the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)