### PR TITLE
fix: resolve type errors in eventBus and filesystemAnalysis

### DIFF
--- a/apps/api/src/services/eventBus.test.ts
+++ b/apps/api/src/services/eventBus.test.ts
@@ -36,9 +36,9 @@ describe('eventBus service', () => {
 
     expect(mockRedis.xadd).toHaveBeenCalledTimes(1);
     const xaddMock = mockRedis.xadd as ReturnType<typeof vi.fn>;
-    const xaddArgs = xaddMock.mock.calls[0];
+    const xaddArgs = xaddMock.mock.calls[0]!;
     const eventJson = xaddArgs[xaddArgs.length - 1] as string;
-    const event = JSON.parse(eventJson) as { id: string; metadata: { correlationId: string } };
+    const event = JSON.parse(eventJson) as Record<string, unknown> & { metadata: Record<string, unknown> };
 
     expect(event.id).toBe(eventId);
     expect(event.metadata.correlationId).toBe(eventId);

--- a/apps/api/src/services/eventBus.ts
+++ b/apps/api/src/services/eventBus.ts
@@ -172,7 +172,7 @@ class EventBus {
 
     // Invoke local in-process handlers immediately
     // This handles the case where startConsuming() hasn't been called
-    await this.invokeLocalHandlers(event);
+    await this.invokeLocalHandlers(event as BreezeEvent);
 
     return eventId;
   }

--- a/apps/api/src/services/filesystemAnalysis.ts
+++ b/apps/api/src/services/filesystemAnalysis.ts
@@ -37,7 +37,7 @@ function asBoolean(value: unknown, defaultValue = false): boolean {
   return typeof value === 'boolean' ? value : defaultValue;
 }
 
-function asNumber(value: Numberish, defaultValue = 0): number {
+function asNumber(value: unknown, defaultValue = 0): number {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
   if (typeof value === 'string') {
     const parsed = Number(value);


### PR DESCRIPTION
## Summary
- `eventBus.ts`: cast generic `BreezeEvent<T>` to `BreezeEvent` at `invokeLocalHandlers` call site (generic `T` not assignable to `Record<string, unknown>`)
- `eventBus.test.ts`: widen parsed JSON type assertion, add non-null assertion for `xaddArgs`
- `filesystemAnalysis.ts`: widen `asNumber` param from `Numberish` to `unknown` (properties from `AnyObject` are `unknown`)

These are pre-existing type errors exposed when Turbo cache misses on feature branches.

**Note:** The broader CI issue (314 type errors across 40+ files, missing ESLint configs) exists on main too but is masked by Turbo cache. That's a separate effort.

## Test plan
- [ ] `pnpm exec tsc --noEmit --project apps/api/tsconfig.json` no longer reports errors for these 3 files
- [ ] `vitest run src/services/eventBus.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)