### PR TITLE
docs: fix Quick Start instructions to match deploy flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,9 +44,11 @@ NODE_ENV=production
 API_PORT=3001
 WEB_PORT=4321
 
-# Public URL for the API (used by web frontend)
-PUBLIC_API_URL=http://localhost:3001
-CORS_ALLOWED_ORIGINS=http://localhost:4321,http://localhost:3000
+# Public URL for the API (used by web frontend in development)
+# Leave empty for Docker deployment — the web app uses relative URLs through Caddy.
+# Only set this for local dev when running outside Docker (e.g., pnpm dev).
+PUBLIC_API_URL=
+CORS_ALLOWED_ORIGINS=https://localhost
 
 # --------------------------------------------
 # Production Deploy
@@ -185,8 +187,9 @@ GRAFANA_ADMIN_PASSWORD=changeme
 # Application URLs
 # --------------------------------------------
 # Used for links in emails and notifications
-DASHBOARD_URL=http://localhost:4321
-PUBLIC_APP_URL=http://localhost:4321
+# For Docker deployment, use your BREEZE_DOMAIN with https
+DASHBOARD_URL=https://breeze.yourdomain.com
+PUBLIC_APP_URL=https://breeze.yourdomain.com
 
 # --------------------------------------------
 # Proxy Configuration
@@ -245,7 +248,7 @@ CLOUDFLARE_ZONE_ID=
 # Docker Deployment
 # --------------------------------------------
 # Pin to a specific release (default: latest stable)
-# BREEZE_VERSION=0.2.0
+# BREEZE_VERSION=0.1.3
 #
 # Version tagging works like this:
 #   git tag v0.3.0 && git push --tags   → stable release, tagged as "latest" + "0.3.0"

--- a/README.md
+++ b/README.md
@@ -95,23 +95,33 @@ cd breeze
 
 # Copy and configure environment
 cp .env.example .env
-# Edit .env with your database credentials and settings
-# REQUIRED: Generate real secrets for these values
-# JWT_SECRET: openssl rand -base64 64
-# AGENT_ENROLLMENT_SECRET: openssl rand -hex 32
-# APP_ENCRYPTION_KEY: openssl rand -hex 32
+
+# REQUIRED: Set your domain (use "localhost" for local testing)
+# BREEZE_DOMAIN=breeze.yourdomain.com
+# ACME_EMAIL=admin@yourdomain.com
+
+# REQUIRED: Generate real secrets
+# JWT_SECRET:               openssl rand -base64 64
+# AGENT_ENROLLMENT_SECRET:  openssl rand -hex 32
+# APP_ENCRYPTION_KEY:       openssl rand -hex 32
+# MFA_ENCRYPTION_KEY:       openssl rand -hex 32
 
 # Start everything
 docker compose up -d
 
-# Push the database schema
-pnpm db:push
-
-# Seed default roles and permissions
-pnpm db:seed
+# Push the database schema and seed default data
+# (requires Node.js + pnpm on the host — install with: npm i -g pnpm)
+DATABASE_URL="postgresql://breeze:YOUR_POSTGRES_PASSWORD@localhost:5432/breeze" \
+  pnpm install && pnpm --filter @breeze/api db:push && pnpm --filter @breeze/api db:seed
 ```
 
-Breeze will be running at `http://localhost:4321`.
+> **Note:** The `db:push` command above requires Postgres to be reachable from
+> the host. Add a temporary port mapping to docker-compose.yml under the
+> `postgres` service: `ports: ["5432:5432"]`, then remove it after seeding.
+
+Breeze will be running at `https://localhost` (self-signed cert for localhost).
+
+Default admin login: `admin@breeze.local` / `BreezeAdmin123!` — **change this immediately**.
 
 ### Install the Agent
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,13 @@
 # Breeze RMM - Production Deployment
 # Pull pre-built images from GHCR. No build step required.
-# This is the ONLY file you need (plus a .env).
 #
-# Quick start:
-#   curl -fsSL https://raw.githubusercontent.com/LanternOps/breeze/main/docker-compose.yml -o docker-compose.yml
-#   curl -fsSL https://raw.githubusercontent.com/LanternOps/breeze/main/.env.example -o .env
-#   # Edit .env with your secrets and domain
+# Quick start (see README for full instructions):
+#   git clone https://github.com/LanternOps/breeze.git && cd breeze
+#   cp .env.example .env  # Edit with your secrets and domain
 #   docker compose up -d
+#   # Then push schema + seed (requires pnpm on host, see README)
 #
 # Optional monitoring stack:
-#   curl -fsSL https://raw.githubusercontent.com/LanternOps/breeze/main/docker-compose.monitoring.yml -o docker-compose.monitoring.yml
 #   docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d
 
 x-healthcheck-defaults: &healthcheck


### PR DESCRIPTION
## Summary

- Updated Quick Start instructions based on issues found during actual v0.1.3 deploy testing
- Fixed `.env.example` defaults for Docker deployment
- Updated `docker-compose.yml` header comments

## Changes

**README Quick Start fixes:**
- Added missing required secrets: `MFA_ENCRYPTION_KEY`
- Added required env vars: `BREEZE_DOMAIN`, `ACME_EMAIL`
- Fixed `db:push`/`db:seed` command — needs `DATABASE_URL` env var and pnpm on host
- Added note about Postgres port exposure for schema push
- Fixed URL: `http://localhost:4321` → `https://localhost` (Caddy with self-signed cert)
- Added default admin credentials after seed

**.env.example fixes:**
- `PUBLIC_API_URL`: now empty by default (Docker uses relative URLs through Caddy)
- `CORS_ALLOWED_ORIGINS`: `https://localhost` instead of http dev URLs
- `DASHBOARD_URL` / `PUBLIC_APP_URL`: HTTPS domain instead of localhost:4321
- `BREEZE_VERSION` example updated to `0.1.3`

## Test plan

- [x] All changes verified during live Docker deploy testing (v0.1.3)
- [x] Instructions match the actual steps needed for a working deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)