### PR TITLE
docs: add security practices whitepaper with SOC 2 alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 </p>
 
 <p align="center">
+  <a href="#security">Security</a> •
   <a href="#quick-start">Quick Start</a> •
   <a href="#features">Features</a> •
   <a href="#ai-brain">AI Brain</a> •
@@ -46,6 +47,29 @@ Breeze is free, open source (AGPL-3.0), and designed to be self-hosted or [cloud
 - **Actually open source.** AGPL-3.0. Read every line. Fork it. Contribute. No bait-and-switch.
 - **Multi-tenant from day one.** Built for MSPs managing multiple clients, not retrofitted from a single-tenant architecture.
 - **Modern stack.** Not a legacy codebase with 15 years of technical debt. Clean, fast, extensible.
+
+---
+
+## Security
+
+Breeze has privileged access to every device it manages. We take that seriously.
+
+| Layer | What We Do |
+|---|---|
+| **Authentication** | Argon2id passwords, JWT with 15-min expiry, TOTP MFA, SHA-256 hashed tokens |
+| **Authorization** | RBAC with scope-based multi-tenancy, database-level tenant isolation via PostgreSQL session variables |
+| **Encryption** | AES-256-GCM at rest, TLS 1.2+ in transit, HSTS preload, no plaintext secrets stored anywhere |
+| **Agent hardening** | Bearer token auth (SHA-256 hashed), 0600 config file permissions, optional Cloudflare mTLS |
+| **Rate limiting** | Redis sliding window on all auth endpoints and agent APIs — fail-closed if Redis is unavailable |
+| **Input validation** | Zod schemas on every external input — API requests, WebSocket messages, query parameters |
+| **AI safety** | Risk-classified action engine — dangerous operations require human approval, critical operations blocked entirely |
+| **Supply chain** | 5 automated scanners in CI: CodeQL SAST, Gitleaks, npm audit, govulncheck, Trivy CVE scanning |
+| **Audit trail** | Structured audit logging with actor tracking, org-scoped retention policies, S3 archival |
+| **Operational** | Secret rotation runbooks, disaster recovery procedures (RTO < 1 hour, RPO < 15 minutes) |
+
+For the full security whitepaper, including SOC 2 alignment mapping, see **[Security Practices](docs/SECURITY_PRACTICES.md)**.
+
+To report a vulnerability: **[security@lanternops.io](mailto:security@lanternops.io)** — see [SECURITY.md](SECURITY.md) for our disclosure policy.
 
 ---
 
@@ -356,7 +380,7 @@ Absolutely. The multi-tenant hierarchy works for internal IT too — just use Or
 Breeze uses the Claude Agent SDK (Anthropic). BYOK mode requires an Anthropic API key. We chose Claude for its tool-use capabilities and reasoning quality. We're open to community contributions for other model support.
 
 **Is my data safe?**
-Self-hosted: your data never leaves your infrastructure. Cloud-hosted: data is isolated per partner with strict tenant separation. See our security practices in the [Admin Guide](docs/ADMIN_GUIDE.md).
+Self-hosted: your data never leaves your infrastructure. Cloud-hosted: data is isolated per partner with strict tenant separation. See our [Security Practices](docs/SECURITY_PRACTICES.md) for the full security whitepaper, including SOC 2 alignment mapping, encryption standards, and audit controls.
 
 ---
 

--- a/docs/SECURITY_PRACTICES.md
+++ b/docs/SECURITY_PRACTICES.md
@@ -1,0 +1,573 @@
+# Security Practices
+
+Breeze is an RMM platform — it has privileged access to every device it manages. We treat that responsibility as seriously as you do. Security is not a feature we bolted on; it is foundational to every layer of the architecture.
+
+This document describes the security controls, practices, and design decisions in Breeze. It is intended for MSPs evaluating Breeze, security teams conducting assessments, and contributors building on the platform.
+
+---
+
+## Table of Contents
+
+- [Security Architecture Overview](#security-architecture-overview)
+- [Authentication](#authentication)
+- [Authorization & Multi-Tenancy](#authorization--multi-tenancy)
+- [Agent Security](#agent-security)
+- [Encryption](#encryption)
+- [Rate Limiting & Abuse Prevention](#rate-limiting--abuse-prevention)
+- [Input Validation](#input-validation)
+- [HTTP Security Headers](#http-security-headers)
+- [Audit Logging](#audit-logging)
+- [AI Risk Classification](#ai-risk-classification)
+- [Infrastructure Security](#infrastructure-security)
+- [Supply Chain Security](#supply-chain-security)
+- [Secret Management](#secret-management)
+- [Operational Security](#operational-security)
+- [Vulnerability Disclosure](#vulnerability-disclosure)
+- [SOC 2 Alignment](#soc-2-alignment)
+
+---
+
+## Security Architecture Overview
+
+```
+                         ┌──────────────────────────────────────────┐
+                         │            Security Layers               │
+                         ├──────────────────────────────────────────┤
+                         │  TLS/HSTS ─── Transport Encryption       │
+                         │  CORS ─────── Origin Allowlist           │
+                         │  CSP ──────── Content Security Policy    │
+                         │  CSRF ─────── State-Change Protection    │
+                         │  Rate Limit ─ Redis Sliding Window       │
+                         │  Auth ─────── JWT + MFA + Sessions       │
+                         │  RBAC ─────── Permission Enforcement     │
+                         │  Tenant ───── PostgreSQL Row Isolation   │
+                         │  Audit ────── Structured Event Logging   │
+                         │  Encryption ─ AES-256-GCM At Rest        │
+                         └──────────────────────────────────────────┘
+```
+
+Every request passes through multiple security layers before reaching application logic. No single layer is relied upon in isolation.
+
+---
+
+## Authentication
+
+### User Authentication
+
+Breeze implements a multi-factor authentication system with defense-in-depth:
+
+| Control | Implementation |
+|---|---|
+| **Password hashing** | Argon2id — 64 MB memory, 3 iterations, 4 threads |
+| **Password policy** | 8-128 chars, mixed case, numeric required |
+| **Access tokens** | JWT (HS256), 15-minute lifetime, audience/issuer-scoped |
+| **Refresh tokens** | JWT, 7-day lifetime, unique JTI, revocable |
+| **Session tokens** | cryptographically random (nanoid 48), SHA-256 hashed in DB |
+| **MFA** | TOTP (RFC 6238), 10 recovery codes (XXXX-XXXX format) |
+| **SMS MFA** | Optional Twilio integration for SMS-based codes |
+| **Token revocation** | Explicit session invalidation, bulk logout per user |
+
+Plaintext tokens are never stored. All token storage uses SHA-256 hashes.
+
+### API Key Authentication
+
+API keys follow the same security model as agent tokens:
+
+- **Format**: `brz_` prefix for identification
+- **Storage**: SHA-256 hash only — the plaintext key is shown once at creation, never again
+- **Scoping**: JSONB scope array with wildcard support (`*` for full access)
+- **Lifecycle**: Configurable expiration, revocable, status tracking (active/revoked/expired)
+- **Rate limiting**: Per-key configurable request limits
+- **Audit trail**: `lastUsedAt` timestamp and `usageCount` updated on every use
+
+### Agent Authentication
+
+See [Agent Security](#agent-security) below.
+
+---
+
+## Authorization & Multi-Tenancy
+
+### Multi-Tenant Hierarchy
+
+```
+Partner (MSP) → Organization (Customer) → Site (Location) → Device Group → Device
+```
+
+Every entity is scoped to this hierarchy. A user at one organization can never access another organization's data — this is enforced at the database layer, not just the application layer.
+
+### Database-Level Tenant Isolation
+
+Breeze sets PostgreSQL session variables on every request:
+
+```
+breeze.scope           = 'system' | 'partner' | 'organization'
+breeze.org_id          = UUID of current organization
+breeze.accessible_org_ids = comma-separated list or '*'
+```
+
+These variables are set via `set_config()` within the request transaction context using Node.js `AsyncLocalStorage`. Queries that don't have proper context set will fail — there is no default permissive state.
+
+### Role-Based Access Control
+
+| Component | Description |
+|---|---|
+| **Roles** | Named definitions scoped to system, partner, or organization level |
+| **Permissions** | Atomic `resource:action` pairs (e.g., `devices:read`, `scripts:execute`) |
+| **Wildcards** | `*:*` grants all permissions (system admin only) |
+| **Middleware** | `requirePermission(resource, action)` enforced on every protected route |
+| **Caching** | 5-minute in-memory permission cache to reduce DB lookups |
+
+### Scope Enforcement
+
+Three scope levels control data visibility:
+
+- **System**: Full access to all organizations (super-admin only)
+- **Partner**: MSP access to their portfolio, configurable per-org (`all`, `selected`, `none`)
+- **Organization**: Single-tenant access, no cross-org visibility
+
+Scope is computed once per request via `resolveOrgAccess()` and applied to all downstream queries.
+
+---
+
+## Agent Security
+
+The agent runs on customer endpoints with elevated privileges. Its security is paramount.
+
+### Token Security
+
+- **Format**: `brz_` prefix tokens generated during enrollment
+- **Hashing**: SHA-256 hash stored in `devices.agentTokenHash` — plaintext never persisted server-side
+- **Validation**: Every agent REST request and WebSocket connection validates the bearer token against the stored hash
+- **Status checks**: Decommissioned and quarantined devices are rejected with 403
+
+### Config File Permissions
+
+The agent stores sensitive configuration (auth token, org/site IDs) on disk with restricted permissions:
+
+| Resource | Permission | Rationale |
+|---|---|---|
+| Config directory | `0700` (rwx------) | No access for other users or groups |
+| Config file | `0600` (rw-------) | Read/write only by the agent process |
+
+### Mutual TLS (mTLS) — Optional
+
+For organizations requiring proof-of-possession at the TLS layer:
+
+- **Certificate authority**: Cloudflare Client Certificates API
+- **Enrollment**: mTLS cert issued during agent enrollment, PEM + private key delivered to agent
+- **Renewal**: Automatic at 2/3 certificate lifetime via heartbeat signal
+- **Quarantine policy**: Devices with expired/revoked certs are quarantined pending admin review
+- **WAF integration**: Cloudflare API Shield enforces client certificate validation at the edge
+- **No behavior change by default**: mTLS is entirely optional and requires explicit Cloudflare credentials
+
+Full setup guide: [cloudflare-mtls-setup.md](cloudflare-mtls-setup.md)
+
+### WebSocket Security
+
+Agent WebSocket connections are validated on connect:
+
+1. Bearer token extracted from `Authorization` header (or `?token=` query param as fallback)
+2. Token hashed with SHA-256 and compared against device record
+3. Device status verified (online, not decommissioned/quarantined)
+4. All incoming messages validated against Zod discriminated union schema
+5. Device status updated on connect/disconnect
+
+### Command Execution Auditing
+
+Mutating commands sent to agents are logged to the audit trail:
+
+- Registry modifications (`REGISTRY_DELETE`, `REGISTRY_KEY_DELETE`)
+- File operations (`FILE_DELETE`)
+- Patch operations (`PATCH_SCAN`, `INSTALL_PATCHES`, `ROLLBACK_PATCHES`)
+
+Each audit entry captures: command type, target device, exit code, stderr output, and the actor who initiated the command.
+
+---
+
+## Encryption
+
+### In Transit
+
+| Control | Implementation |
+|---|---|
+| **TLS termination** | Caddy reverse proxy with automatic Let's Encrypt certificates |
+| **HSTS** | `max-age=31536000; includeSubDomains; preload` |
+| **HTTP redirect** | Optional `FORCE_HTTPS` environment variable |
+| **WebSocket** | WSS (encrypted WebSocket) for all agent communication |
+| **Internal traffic** | API listens on localhost only — no unencrypted external exposure |
+
+### At Rest
+
+| Data | Algorithm | Details |
+|---|---|---|
+| **Passwords** | Argon2id | 64 MB memory, 3 iterations, 4 threads, 32-byte hash |
+| **Auth tokens** | SHA-256 | One-way hash — tokens, API keys, session tokens, enrollment keys |
+| **Secrets** | AES-256-GCM | Authenticated encryption with per-operation random IV |
+| **MFA secrets** | AES-256-GCM | Encrypted before storage, decrypted only during verification |
+
+### Secret Encryption Details
+
+Secrets encrypted at rest use the format: `enc:v1:{base64url(iv)}.{base64url(authTag)}.{base64url(ciphertext)}`
+
+- 12-byte random IV generated per encryption (never reused)
+- GCM authentication tag prevents tampering
+- `isEncryptedSecret()` check prevents double-encryption
+- Key hierarchy: dedicated `APP_ENCRYPTION_KEY` in production, with fallback chain for development
+
+---
+
+## Rate Limiting & Abuse Prevention
+
+Breeze uses Redis-backed sliding window rate limiting. The implementation is **fail-closed** — if Redis is unavailable, requests are denied.
+
+### Configured Limits
+
+| Endpoint | Limit | Window | Key |
+|---|---|---|---|
+| Login attempts | 5 | 5 minutes | Per email |
+| Password reset | 3 | 1 hour | Per email |
+| MFA verification | 5 | 5 minutes | Per user |
+| SMS verification | 3 | 1 hour | Per phone |
+| SMS login | 3 | 5 minutes | Per email |
+| Agent requests | 120 | 60 seconds | Per device |
+| API key requests | Configurable | 1 hour | Per key |
+
+### Implementation
+
+- **Algorithm**: Redis sorted set (ZSET) sliding window
+- **Atomicity**: `MULTI` pipeline for race-condition-free counting
+- **Auto-cleanup**: Keys expire after the window elapses
+- **Response**: Standard `X-RateLimit-*` headers and `429` with `Retry-After`
+
+---
+
+## Input Validation
+
+All external input is validated using Zod schemas before processing:
+
+| Input Type | Validation |
+|---|---|
+| **Email** | `z.string().email()` |
+| **UUIDs** | `z.string().uuid()` |
+| **Phone numbers** | E.164 regex (`^\+[1-9]\d{6,14}$`) |
+| **MFA codes** | Exact 6-character length |
+| **Passwords** | 8-128 chars with complexity requirements |
+| **Pagination** | `min: 1, max: 100` limit enforcement |
+| **Agent messages** | Zod discriminated union for WebSocket payloads |
+| **API request bodies** | `@hono/zod-validator` middleware on every route |
+
+Validation errors return structured error objects with field paths. Sensitive values are never echoed in error responses.
+
+---
+
+## HTTP Security Headers
+
+Every response includes the following security headers:
+
+```
+Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+Referrer-Policy: strict-origin-when-cross-origin
+Permissions-Policy: camera=(), microphone=(), geolocation=()
+Content-Security-Policy:
+    default-src 'self';
+    script-src 'self' 'unsafe-inline';
+    style-src 'self' 'unsafe-inline';
+    img-src 'self' data: blob:;
+    font-src 'self';
+    connect-src 'self' ws: wss:;
+    frame-ancestors 'none';
+    base-uri 'self';
+    form-action 'self'
+```
+
+### CORS
+
+- **Production**: Only explicitly configured origins allowed via `CORS_ALLOWED_ORIGINS`
+- **No wildcards**: Wildcard (`*`) origin is explicitly rejected in production
+- **Development**: localhost origins only, excluded from production builds unless opted in
+- **Validation**: No `Access-Control-Allow-Origin` header emitted for disallowed origins
+
+### CSRF Protection
+
+State-changing operations (POST, PUT, DELETE) on sensitive endpoints require a `x-breeze-csrf` header. Requests without the header return `403`.
+
+---
+
+## Audit Logging
+
+### What Gets Logged
+
+Every security-relevant operation is recorded in the `audit_logs` table:
+
+| Field | Description |
+|---|---|
+| `actorType` | `user`, `api_key`, `agent`, or `system` |
+| `actorId` | UUID of the actor |
+| `action` | Specific operation (e.g., `device.command.execute`) |
+| `resourceType` | Target entity type |
+| `resourceId` | Target entity UUID |
+| `result` | `success`, `failure`, or `denied` |
+| `ipAddress` | Source IP (IPv4/IPv6) |
+| `userAgent` | Client identifier |
+| `details` | JSONB metadata (command type, exit codes, etc.) |
+| `errorMessage` | Failure reason (if applicable) |
+
+### Retention
+
+- **Default**: 365 days per organization
+- **Configurable**: Per-org retention policies via `audit_retention_policies`
+- **Archival**: Optional S3 archival before deletion
+
+### Logging Modes
+
+- **Synchronous**: `createAuditLog()` — blocks until written (critical operations)
+- **Asynchronous**: `createAuditLogAsync()` — fire-and-forget (non-critical operations)
+
+---
+
+## AI Risk Classification
+
+The AI brain has access to powerful tools. Every AI-initiated action passes through a risk classification engine **enforced by the RMM, not the AI**.
+
+| Risk Level | Behavior | Examples |
+|---|---|---|
+| **Low** | Auto-execute, logged | Query devices, read logs, generate reports |
+| **Medium** | Execute + notify technician | Read-only scripts, pre-approved patch deployments |
+| **High** | Requires human approval | State-changing scripts, patches outside maintenance windows |
+| **Critical** | Blocked entirely | Device wipe, bulk destructive operations |
+
+- Risk policies are configurable per partner, organization, site, or device group
+- The AI cannot bypass the risk engine — it is enforced at the tool execution layer
+- BYOK mode: your API key, your data, your infrastructure — nothing sent to LanternOps unless you opt in
+
+---
+
+## Infrastructure Security
+
+### Docker Hardening
+
+| Control | Implementation |
+|---|---|
+| **Base image** | `node:20-alpine` (minimal attack surface) |
+| **Multi-stage build** | `deps → builder → runner` (no build tools in production) |
+| **Non-root execution** | Dedicated `hono` user (UID 1001), `nodejs` group (GID 1001) |
+| **File ownership** | `--chown=hono:nodejs` on all copied assets |
+| **Minimal exposure** | Single port (3001) exposed |
+
+### TLS Termination
+
+Caddy reverse proxy handles TLS termination with:
+
+- Automatic Let's Encrypt certificate provisioning (ACME)
+- HSTS with preload
+- zstd and gzip compression
+- Separate routing for `/api/*`, `/metrics/*`, and frontend assets
+
+Full setup guide: [TLS_SETUP.md](TLS_SETUP.md)
+
+### Environment Isolation
+
+- API server listens on localhost — never directly exposed
+- Database and Redis accessible only within the Docker network
+- Metrics endpoint (`/metrics/*`) separated from public routes
+
+---
+
+## Supply Chain Security
+
+### Automated Scanning
+
+| Scanner | What It Checks | Trigger |
+|---|---|---|
+| **CodeQL** | Static analysis (SAST) for JS/TS vulnerabilities | Every push and PR to main |
+| **Gitleaks** | Hardcoded secrets in source code | Every push and PR to main |
+| **npm audit** | Node.js dependency vulnerabilities (high+) | Every push and PR to main + weekly |
+| **govulncheck** | Go dependency vulnerabilities | Every push and PR to main + weekly |
+| **Trivy** | Filesystem CVE scan (high + critical) | Every push and PR to main + weekly |
+
+All scanners run in CI and **block merges** on failure.
+
+### Dependency Management
+
+- **Lock file**: `pnpm-lock.yaml` committed for reproducible builds
+- **Package manager**: pnpm with strict dependency resolution
+- **Version pinning**: All dependencies pinned to exact versions via lock file
+
+---
+
+## Secret Management
+
+### Required Secrets
+
+| Secret | Purpose | Minimum Strength |
+|---|---|---|
+| `JWT_SECRET` | Token signing | 32+ characters |
+| `APP_ENCRYPTION_KEY` | AES-256-GCM encryption | 32-byte hex |
+| `MFA_ENCRYPTION_KEY` | MFA secret encryption | 32-byte hex |
+| `AGENT_ENROLLMENT_SECRET` | Agent enrollment | 32-byte hex |
+
+### Production Enforcement
+
+Breeze validates environment configuration on startup:
+
+- Rejects 24 known placeholder/default values
+- Requires explicit `CORS_ALLOWED_ORIGINS` (no wildcards)
+- Enforces minimum secret strength
+- Logs warnings for non-critical misconfigurations
+
+### Secret Rotation
+
+Comprehensive rotation procedures are documented for 16 secret categories with defined intervals:
+
+| Category | Rotation Interval |
+|---|---|
+| JWT secrets | 90 days |
+| Encryption keys | Annually |
+| Database credentials | 90 days |
+| Redis credentials | 90 days |
+| API provider keys | 90 days |
+| Agent enrollment secret | 90 days |
+
+Full rotation runbook: [SECRET_ROTATION.md](SECRET_ROTATION.md)
+
+### Secrets Never Stored in Plaintext
+
+The following are always hashed or encrypted before persistence:
+
+- User passwords (Argon2id)
+- Session tokens (SHA-256)
+- API keys (SHA-256)
+- Agent auth tokens (SHA-256)
+- Enrollment keys (SHA-256 with pepper)
+- MFA secrets (AES-256-GCM)
+
+---
+
+## Operational Security
+
+### Backup & Recovery
+
+- **RTO**: < 1 hour
+- **RPO**: < 15 minutes (with WAL archiving) or last backup interval
+- **Components**: PostgreSQL, object storage (MinIO/S3), encrypted configuration
+- **Encryption**: Config backups encrypted at rest using OpenSSL
+
+Full procedures: [BACKUP_RESTORE.md](BACKUP_RESTORE.md)
+
+### Disaster Recovery
+
+Five documented failure scenarios with step-by-step recovery:
+
+1. Single service crash
+2. Database failure
+3. Complete infrastructure loss
+4. Data corruption
+5. Security incident
+
+Full runbook: [DISASTER_RECOVERY.md](DISASTER_RECOVERY.md)
+
+### Error Handling
+
+- Generic error messages returned to clients — internal details never exposed
+- No stack traces in production responses
+- Structured JSON logging (`LOG_JSON=true`) for log aggregation
+- Optional Sentry integration for error tracking (`SENTRY_DSN`)
+- Sensitive data (tokens, passwords) never logged
+
+---
+
+## Vulnerability Disclosure
+
+We follow coordinated disclosure. See [SECURITY.md](../SECURITY.md) for:
+
+- How to report vulnerabilities
+- Response timelines (48-hour acknowledgment, severity-based fix targets)
+- Scope and disclosure policy
+
+**Email**: [security@lanternops.io](mailto:security@lanternops.io)
+
+---
+
+## SOC 2 Alignment
+
+Breeze's security controls align with SOC 2 Trust Service Criteria:
+
+### CC6 — Logical and Physical Access Controls
+
+| Criteria | Breeze Implementation |
+|---|---|
+| CC6.1 — Logical access security | JWT + MFA + RBAC + API key scoping |
+| CC6.2 — Credentials management | Argon2id passwords, SHA-256 token hashing, AES-256-GCM secrets |
+| CC6.3 — Access authorization | Role-based permissions, scope enforcement, `requirePermission()` middleware |
+| CC6.6 — External access restrictions | CORS allowlist, CSP, rate limiting, CSRF protection |
+| CC6.7 — Data transmission security | TLS 1.2+, HSTS preload, WSS for agent communication |
+| CC6.8 — Unauthorized access prevention | Fail-closed rate limiting, device quarantine, session invalidation |
+
+### CC7 — System Operations
+
+| Criteria | Breeze Implementation |
+|---|---|
+| CC7.1 — Infrastructure monitoring | Agent health checks, heartbeat monitoring, configurable alerting |
+| CC7.2 — Anomaly detection | Rate limit violation tracking, audit log analysis |
+| CC7.3 — Vulnerability management | CodeQL SAST, Trivy CVE scanning, npm audit, govulncheck |
+| CC7.4 — Incident response | Disaster recovery runbook, security incident procedures |
+
+### CC8 — Change Management
+
+| Criteria | Breeze Implementation |
+|---|---|
+| CC8.1 — Change authorization | PR-based workflow, CI gate enforcement, code review requirements |
+
+### CC9 — Risk Mitigation
+
+| Criteria | Breeze Implementation |
+|---|---|
+| CC9.1 — Risk identification | Automated security scanning (5 scanners), AI risk classification engine |
+| CC9.2 — Vendor risk management | Dependency lock files, supply chain scanning, known vulnerability databases |
+
+### A1 — Availability
+
+| Criteria | Breeze Implementation |
+|---|---|
+| A1.1 — Processing capacity | Redis-backed rate limiting, BullMQ queue management |
+| A1.2 — Recovery objectives | RTO < 1 hour, RPO < 15 minutes |
+| A1.3 — Recovery testing | Documented procedures for 5 failure scenarios |
+
+### C1 — Confidentiality
+
+| Criteria | Breeze Implementation |
+|---|---|
+| C1.1 — Confidential data identification | Multi-tenant isolation, encryption key hierarchy |
+| C1.2 — Confidential data disposal | Audit log retention policies, S3 archival, configurable retention |
+
+---
+
+## Security Controls Summary
+
+| Domain | Controls | Status |
+|---|---|---|
+| Authentication | JWT + MFA + Sessions + API Keys | Implemented |
+| Authorization | RBAC + Scope-based multi-tenancy | Implemented |
+| Encryption (at rest) | AES-256-GCM, Argon2id, SHA-256 | Implemented |
+| Encryption (in transit) | TLS 1.2+ / HSTS / WSS | Implemented |
+| Rate limiting | Redis sliding window (fail-closed) | Implemented |
+| Audit logging | Structured, org-scoped, async-capable | Implemented |
+| Input validation | Zod schemas on all external input | Implemented |
+| Security headers | CSP, HSTS, X-Frame-Options, Permissions-Policy | Implemented |
+| CORS | Strict allowlist, no production wildcards | Implemented |
+| CSRF protection | Header-based validation on state changes | Implemented |
+| Agent security | Token hashing + optional mTLS + file permissions | Implemented |
+| AI safety | Risk classification engine with human approval gates | Implemented |
+| Supply chain | 5 automated scanners blocking on failure | Implemented |
+| Docker hardening | Multi-stage, non-root, Alpine base | Implemented |
+| Secret management | Rotation procedures, production validation, no plaintext | Implemented |
+| Disaster recovery | Documented runbooks, defined RTO/RPO | Implemented |
+
+---
+
+*Last updated: February 2026*
+
+*For questions about Breeze security practices, contact [security@lanternops.io](mailto:security@lanternops.io).*


### PR DESCRIPTION
## Summary
- Add comprehensive `docs/SECURITY_PRACTICES.md` (573 lines) documenting every security control implemented in Breeze — authentication, encryption, multi-tenancy isolation, agent hardening, rate limiting, audit logging, supply chain scanning, and more
- Add prominent **Security** section to README as the first nav item, with a summary table linking to the full whitepaper
- Map all existing controls to SOC 2 Trust Service Criteria (CC6, CC7, CC8, CC9, A1, C1)
- Update FAQ "Is my data safe?" answer to reference the security practices doc

## What this covers
Every item in the document is based on what's actually implemented in the codebase — not aspirational. Source files were traced to verify each claim.

## Test plan
- [ ] Verify all internal doc links resolve (`SECRET_ROTATION.md`, `BACKUP_RESTORE.md`, `DISASTER_RECOVERY.md`, `TLS_SETUP.md`, `cloudflare-mtls-setup.md`)
- [ ] Verify README Security section renders correctly on GitHub
- [ ] Verify SOC 2 mapping table is accurate against current controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)