### PR TITLE
feat: org-level helper chat toggle with heartbeat delivery

### DIFF
--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -16,6 +16,7 @@ import {
   buildPolicyProbeConfigUpdate,
   normalizeAgentArchitecture,
   compareAgentVersions,
+  getOrgHelperSettings,
 } from './helpers';
 
 export const heartbeatRoutes = new Hono();
@@ -151,6 +152,14 @@ heartbeatRoutes.post('/:id/heartbeat', zValidator('json', heartbeatSchema), asyn
     }
   }
 
+  let helperEnabled = false;
+  try {
+    const helperSettings = await getOrgHelperSettings(device.orgId);
+    helperEnabled = helperSettings.enabled;
+  } catch (err) {
+    console.error(`[agents] failed to read helper settings for ${agentId}:`, err);
+  }
+
   return c.json({
     commands: commands.map(cmd => ({
       id: cmd.id,
@@ -159,7 +168,8 @@ heartbeatRoutes.post('/:id/heartbeat', zValidator('json', heartbeatSchema), asyn
     })),
     configUpdate,
     upgradeTo,
-    renewCert: renewCert || undefined
+    renewCert: renewCert || undefined,
+    helperEnabled,
   });
 });
 

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -806,6 +806,18 @@ export function generateApiKey(): string {
 // mTLS
 // ============================================
 
+export async function getOrgHelperSettings(orgId: string): Promise<{ enabled: boolean }> {
+  const [org] = await db
+    .select({ settings: organizations.settings })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+  const settings = isObject(org?.settings) ? org.settings : {};
+  const helper = isObject(settings.helper) ? settings.helper : {};
+  const enabled = typeof helper.enabled === 'boolean' ? helper.enabled : false;
+  return { enabled };
+}
+
 export async function getOrgMtlsSettings(orgId: string): Promise<{ certLifetimeDays: number; expiredCertPolicy: 'auto_reissue' | 'quarantine' }> {
   const [org] = await db
     .select({ settings: organizations.settings })

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -230,6 +230,14 @@ export const orgMtlsSettingsSchema = z.object({
 });
 
 // ============================================
+// Helper Chat Settings Validators
+// ============================================
+
+export const orgHelperSettingsSchema = z.object({
+  enabled: z.boolean().default(false),
+});
+
+// ============================================
 // Agent Validators
 // ============================================
 


### PR DESCRIPTION
## Summary
- Adds org-level setting to enable/disable helper chat feature
- Toggle state delivered to agents via heartbeat response
- Includes upstream changes: S3 binary sync fixes, route subdirectory refactor

## Test plan
- [ ] Verify org setting persists and is returned in heartbeat
- [ ] Test agent receives toggle state and enables/disables helper accordingly
- [ ] Verify default behavior when setting is not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)