### PR TITLE
fix: improve Go agent resilience for log shipping

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -1296,6 +1296,11 @@ func (h *Heartbeat) sendHeartbeat() {
 
 	h.healthMon.Update("heartbeat", health.Healthy, "")
 
+	// Heartbeat succeeded — commit (clear) the dropped log counter so it is
+	// not re-reported. If the POST had failed, the count would be preserved
+	// for the next attempt.
+	logging.CommitDroppedLogCount()
+
 	var response HeartbeatResponse
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		log.Error("failed to decode heartbeat response", "error", err)

--- a/agent/internal/logging/logging.go
+++ b/agent/internal/logging/logging.go
@@ -177,8 +177,8 @@ func SetShipperLevel(level string) bool {
 }
 
 // DroppedLogCount returns the number of log entries dropped since the last
-// call and resets the counter to zero. Returns 0 if the shipper is not
-// initialized.
+// commit. The counter is NOT reset; call CommitDroppedLogCount after a
+// successful heartbeat to clear it.
 func DroppedLogCount() int64 {
 	shipperMu.RLock()
 	defer shipperMu.RUnlock()
@@ -187,6 +187,18 @@ func DroppedLogCount() int64 {
 		return globalShipper.DroppedLogCount()
 	}
 	return 0
+}
+
+// CommitDroppedLogCount resets the dropped log counter to zero. Call this
+// after the heartbeat POST succeeds so that the count is preserved for retry
+// if the heartbeat fails. No-op if the shipper is not initialized.
+func CommitDroppedLogCount() {
+	shipperMu.RLock()
+	defer shipperMu.RUnlock()
+
+	if globalShipper != nil {
+		globalShipper.CommitDroppedLogCount()
+	}
 }
 
 // shippingHandler wraps a base slog.Handler to also ship logs remotely.


### PR DESCRIPTION
## Summary
- Add retry logic (2 retries, 1s backoff) for 5xx/network errors in log shipper; skip retry for 4xx
- Add `DroppedLogCount()` atomic counter (`sync/atomic.Int64`) with `Swap(0)` for atomic read-and-reset
- Include `droppedLogs` count in heartbeat payload so the API can track agent log loss
- Log boot performance upload error response body for easier debugging

## Files changed
- `agent/internal/logging/shipper.go` — Retry logic + dropped log counter
- `agent/internal/logging/logging.go` — Package-level `DroppedLogCount()` wrapper
- `agent/internal/heartbeat/heartbeat.go` — DroppedLogs in heartbeat + boot perf error body

## Test plan
- [ ] Verify log shipper retries on 5xx, skips retry on 4xx
- [ ] Verify `DroppedLogCount` returns accumulated count and resets to 0
- [ ] Verify heartbeat includes `droppedLogs` field
- [ ] Verify boot perf upload logs error body on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)