### PR TITLE
fix: harden API error handling across AI tools

### DIFF
--- a/apps/api/src/services/aiTools.ts
+++ b/apps/api/src/services/aiTools.ts
@@ -1404,7 +1404,9 @@ registerTool({
 
     if (bootRecords.length === 0) {
       return JSON.stringify({
-        error: 'No boot performance data available. Try triggerCollection: true if device is online.'
+        error: collectionFailed
+          ? 'Boot performance data collection failed and no cached data exists. The device may not support this feature or may be experiencing issues.'
+          : 'No boot performance data available. Try triggerCollection: true if device is online.'
       });
     }
 

--- a/apps/api/src/services/brainDeviceContext.ts
+++ b/apps/api/src/services/brainDeviceContext.ts
@@ -34,6 +34,7 @@ export async function getActiveDeviceContext(
   const conditions: SQL[] = [
     eq(brainDeviceContext.deviceId, deviceId),
     isNull(brainDeviceContext.resolvedAt),
+    // or() returns undefined only when all args are undefined; isNull() always returns defined SQL
     or(isNull(brainDeviceContext.expiresAt), gt(brainDeviceContext.expiresAt, now))!,
   ];
 


### PR DESCRIPTION
## Summary
- Add `collectionWarning` field to boot perf response when collection is triggered but device is offline
- Wrap fleet tool maintenance window operations in try-catch with structured error logging
- Move brain device context expiry filtering from JS post-query to SQL WHERE clause (`or(isNull(expiresAt), gt(expiresAt, now))`)

## Files changed
- `apps/api/src/services/aiTools.ts` — `collectionWarning` field for boot perf
- `apps/api/src/services/aiToolsFleet.ts` — try-catch blocks for maintenance window operations
- `apps/api/src/services/brainDeviceContext.ts` — SQL expiry filter replacing JS filter

## Test plan
- [ ] Verify boot perf returns `collectionWarning` when device is offline
- [ ] Verify fleet tool maintenance errors are caught and logged, not thrown
- [ ] Verify brain device context only returns non-expired entries via SQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)