### PR TITLE
Improve boot performance ingestion and startup item controls

### DIFF
--- a/agent/internal/collectors/boot_performance_darwin_test.go
+++ b/agent/internal/collectors/boot_performance_darwin_test.go
@@ -69,3 +69,32 @@ func TestEnrichItemsWithPerformance(t *testing.T) {
 		t.Errorf("items[2].CpuTimeMs = %d, want 0", items[2].CpuTimeMs)
 	}
 }
+
+func TestApplyDarwinBootTiming(t *testing.T) {
+	t.Run("desktop ready available", func(t *testing.T) {
+		metrics := &BootPerformanceMetrics{}
+		applyDarwinBootTiming(metrics, 37.5, 120)
+
+		if metrics.TotalBootSeconds != 37.5 {
+			t.Fatalf("TotalBootSeconds = %v, want 37.5", metrics.TotalBootSeconds)
+		}
+		if metrics.DesktopReadySeconds != 37.5 {
+			t.Fatalf("DesktopReadySeconds = %v, want 37.5", metrics.DesktopReadySeconds)
+		}
+		if metrics.OsLoaderSeconds != 0 {
+			t.Fatalf("OsLoaderSeconds = %v, want 0", metrics.OsLoaderSeconds)
+		}
+	})
+
+	t.Run("desktop ready unavailable", func(t *testing.T) {
+		metrics := &BootPerformanceMetrics{}
+		applyDarwinBootTiming(metrics, 0, 245.2)
+
+		if metrics.TotalBootSeconds != 245.2 {
+			t.Fatalf("TotalBootSeconds = %v, want 245.2", metrics.TotalBootSeconds)
+		}
+		if metrics.DesktopReadySeconds != 0 {
+			t.Fatalf("DesktopReadySeconds = %v, want 0", metrics.DesktopReadySeconds)
+		}
+	})
+}

--- a/apps/api/src/db/schema/devices.ts
+++ b/apps/api/src/db/schema/devices.ts
@@ -209,6 +209,7 @@ export const deviceConnections = pgTable('device_connections', {
 
 // Boot performance metrics - stores boot time history and startup item analysis per device
 export interface BootStartupItem {
+  itemId?: string;
   name: string;
   type: 'service' | 'run_key' | 'startup_folder' | 'login_item' | 'launch_agent' | 'launch_daemon' | 'systemd' | 'cron' | 'init_d';
   path: string;

--- a/apps/api/src/routes/agents/bootPerformance.test.ts
+++ b/apps/api/src/routes/agents/bootPerformance.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    execute: vi.fn(),
+  },
+}));
+
+vi.mock('../../db/schema', () => ({
+  devices: {
+    id: 'id',
+    orgId: 'orgId',
+    agentId: 'agentId',
+  },
+  deviceBootMetrics: {
+    deviceId: 'device_id',
+    bootTimestamp: 'boot_timestamp',
+  },
+}));
+
+import { db } from '../../db';
+import { bootPerformanceRoutes } from './bootPerformance';
+
+describe('agent boot performance route', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/agents', bootPerformanceRoutes);
+  });
+
+  it('normalizes startup items and runs single-pass retention cleanup', async () => {
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ id: 'device-1', orgId: 'org-1' }]),
+        }),
+      }),
+    } as never);
+
+    const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+    const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
+    vi.mocked(db.insert).mockReturnValue({ values } as never);
+    vi.mocked(db.execute).mockResolvedValue({} as never);
+
+    const res = await app.request('/agents/agent-1/boot-performance', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        bootTimestamp: '2026-02-21T10:00:00.000Z',
+        totalBootSeconds: 45.5,
+        startupItems: [
+          {
+            name: 'Updater',
+            type: 'service',
+            path: '/usr/bin/updater',
+            enabled: true,
+            cpuTimeMs: 100,
+            diskIoBytes: 2048,
+            impactScore: 3.2,
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(values).toHaveBeenCalledWith(expect.objectContaining({
+      startupItemCount: 1,
+      startupItems: [expect.objectContaining({ itemId: 'service|/usr/bin/updater' })],
+    }));
+    expect(onConflictDoUpdate).toHaveBeenCalledTimes(1);
+    expect(db.execute).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/apps/api/src/routes/devices/bootMetrics.test.ts
+++ b/apps/api/src/routes/devices/bootMetrics.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(),
+  },
+}));
+
+vi.mock('../../db/schema', () => ({
+  deviceBootMetrics: {
+    deviceId: 'device_id',
+    bootTimestamp: 'boot_timestamp',
+  },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', {
+      user: { id: 'user-123' },
+      scope: 'organization',
+      orgId: 'org-123',
+      canAccessOrg: () => true,
+    });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+vi.mock('./helpers', () => ({
+  getDeviceWithOrgCheck: vi.fn(),
+}));
+
+vi.mock('../../services/commandQueue', () => ({
+  executeCommand: vi.fn(),
+}));
+
+import { db } from '../../db';
+import { getDeviceWithOrgCheck } from './helpers';
+import { bootMetricsRoutes } from './bootMetrics';
+
+describe('boot metrics routes', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/devices', bootMetricsRoutes);
+  });
+
+  it('returns startup items with normalized itemId values', async () => {
+    vi.mocked(getDeviceWithOrgCheck).mockResolvedValue({
+      id: 'device-1',
+      status: 'online',
+      orgId: 'org-123',
+    } as never);
+
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              bootTimestamp: new Date('2026-02-21T10:00:00.000Z'),
+              startupItems: [{
+                name: 'Updater',
+                type: 'service',
+                path: '/usr/bin/updater',
+                enabled: true,
+                cpuTimeMs: 0,
+                diskIoBytes: 0,
+                impactScore: 0,
+              }],
+              startupItemCount: 1,
+            }]),
+          }),
+        }),
+      }),
+    } as never);
+
+    const res = await app.request('/devices/device-1/startup-items', {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.totalItems).toBe(1);
+    expect(body.items[0].itemId).toBe('service|/usr/bin/updater');
+  });
+
+  it('returns 409 when startup-item selector is ambiguous', async () => {
+    vi.mocked(getDeviceWithOrgCheck).mockResolvedValue({
+      id: 'device-1',
+      status: 'online',
+      orgId: 'org-123',
+    } as never);
+
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              bootTimestamp: new Date('2026-02-21T10:00:00.000Z'),
+              startupItems: [
+                {
+                  name: 'Updater',
+                  type: 'service',
+                  path: '/usr/bin/updater',
+                  enabled: true,
+                  cpuTimeMs: 0,
+                  diskIoBytes: 0,
+                  impactScore: 0,
+                },
+                {
+                  name: 'Updater',
+                  type: 'run_key',
+                  path: 'HKCU:Updater',
+                  enabled: true,
+                  cpuTimeMs: 0,
+                  diskIoBytes: 0,
+                  impactScore: 0,
+                },
+              ],
+              startupItemCount: 2,
+            }]),
+          }),
+        }),
+      }),
+    } as never);
+
+    const res = await app.request('/devices/device-1/startup-items/Updater/disable', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ reason: 'test' }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toContain('ambiguous');
+    expect(body.candidates).toHaveLength(2);
+  });
+});
+

--- a/apps/api/src/routes/devices/bootMetrics.ts
+++ b/apps/api/src/routes/devices/bootMetrics.ts
@@ -1,13 +1,40 @@
 import { Hono } from 'hono';
 import { db } from '../../db';
-import { devices, deviceBootMetrics } from '../../db/schema';
+import { deviceBootMetrics } from '../../db/schema';
 import { eq, desc } from 'drizzle-orm';
 import { authMiddleware, requireScope } from '../../middleware/auth';
 import { getDeviceWithOrgCheck } from './helpers';
+import {
+  normalizeStartupItems,
+  resolveStartupItem,
+} from '../../services/startupItems';
 
 export const bootMetricsRoutes = new Hono();
 
 bootMetricsRoutes.use('*', authMiddleware);
+
+function parseActionBody(body: unknown): {
+  reason: string;
+  itemId?: string;
+  itemType?: string;
+  itemPath?: string;
+} {
+  const payload = body && typeof body === 'object' ? body as Record<string, unknown> : {};
+  const reason = typeof payload.reason === 'string' && payload.reason.trim() !== ''
+    ? payload.reason.trim().slice(0, 500)
+    : 'No reason provided';
+  const itemId = typeof payload.itemId === 'string' && payload.itemId.trim() !== ''
+    ? payload.itemId.trim()
+    : undefined;
+  const itemType = typeof payload.itemType === 'string' && payload.itemType.trim() !== ''
+    ? payload.itemType.trim()
+    : undefined;
+  const itemPath = typeof payload.itemPath === 'string' && payload.itemPath.trim() !== ''
+    ? payload.itemPath.trim()
+    : undefined;
+
+  return { reason, itemId, itemType, itemPath };
+}
 
 // GET /devices/:id/boot-metrics - Returns boot performance history
 bootMetricsRoutes.get(
@@ -31,16 +58,25 @@ bootMetricsRoutes.get(
         .orderBy(desc(deviceBootMetrics.bootTimestamp))
         .limit(limit);
 
+      const bootsWithNormalizedItems = boots.map((boot) => {
+        const startupItems = normalizeStartupItems(Array.isArray(boot.startupItems) ? boot.startupItems : []);
+        return {
+          ...boot,
+          startupItems,
+          startupItemCount: startupItems.length,
+        };
+      });
+
       // Compute summary
-      const totalBootTimes = boots.map(b => b.totalBootSeconds).filter((t): t is number => t !== null);
+      const totalBootTimes = bootsWithNormalizedItems.map(b => b.totalBootSeconds).filter((t): t is number => t !== null);
       const avgBootTime = totalBootTimes.length > 0
         ? totalBootTimes.reduce((a, b) => a + b, 0) / totalBootTimes.length
         : 0;
 
       return c.json({
-        boots,
+        boots: bootsWithNormalizedItems,
         summary: {
-          totalBoots: boots.length,
+          totalBoots: bootsWithNormalizedItems.length,
           avgBootTimeSeconds: Number(avgBootTime.toFixed(2)),
           fastestBootSeconds: totalBootTimes.length > 0 ? Number(Math.min(...totalBootTimes).toFixed(2)) : null,
           slowestBootSeconds: totalBootTimes.length > 0 ? Number(Math.max(...totalBootTimes).toFixed(2)) : null,
@@ -111,10 +147,14 @@ bootMetricsRoutes.get(
         return c.json({ items: [], bootTimestamp: null, totalItems: 0 });
       }
 
+      const startupItems = normalizeStartupItems(
+        Array.isArray(latestBoot.startupItems) ? latestBoot.startupItems : []
+      );
+
       return c.json({
-        items: latestBoot.startupItems,
+        items: startupItems,
         bootTimestamp: latestBoot.bootTimestamp,
-        totalItems: latestBoot.startupItemCount,
+        totalItems: startupItems.length,
       });
     } catch (err) {
       console.error(`[BootMetrics] GET startup-items failed for device ${deviceId}:`, err);
@@ -132,6 +172,12 @@ bootMetricsRoutes.post(
     try {
       const auth = c.get('auth');
       const itemName = decodeURIComponent(c.req.param('itemName'));
+      let actionBody = parseActionBody({});
+      try {
+        actionBody = parseActionBody(await c.req.json());
+      } catch {
+        // Request body is optional for this endpoint.
+      }
 
       const device = await getDeviceWithOrgCheck(deviceId, auth);
       if (!device) {
@@ -152,17 +198,50 @@ bootMetricsRoutes.post(
         return c.json({ error: 'No boot performance data available' }, 404);
       }
 
-      const items = latestBoot.startupItems as Array<{ name: string; type: string; path: string; enabled: boolean }>;
-      const item = items.find(i => i.name === itemName);
-      if (!item) {
-        return c.json({ error: `Startup item "${itemName}" not found` }, 404);
+      const items = normalizeStartupItems(Array.isArray(latestBoot.startupItems) ? latestBoot.startupItems : []);
+      const match = resolveStartupItem(items, {
+        itemId: actionBody.itemId,
+        itemName,
+        itemType: actionBody.itemType,
+        itemPath: actionBody.itemPath,
+      });
+      if (!match.item) {
+        if (match.candidates && match.candidates.length > 1) {
+          return c.json({
+            error: `Startup item selector for "${itemName}" is ambiguous. Provide itemId or itemType+itemPath.`,
+            candidates: match.candidates.slice(0, 20).map(c => ({
+              itemId: c.itemId,
+              name: c.name,
+              type: c.type,
+              path: c.path,
+              enabled: c.enabled,
+            })),
+          }, 409);
+        }
+        return c.json({
+          error: `Startup item "${itemName}" not found`,
+          availableItems: items.slice(0, 20).map(i => ({
+            itemId: i.itemId,
+            name: i.name,
+            type: i.type,
+            path: i.path,
+            enabled: i.enabled,
+          })),
+        }, 404);
       }
 
       const { executeCommand } = await import('../../services/commandQueue');
       const result = await executeCommand(
         deviceId,
         'manage_startup_item',
-        { itemName, itemType: item.type, itemPath: item.path, action: 'disable' },
+        {
+          itemName: match.item.name,
+          itemType: match.item.type,
+          itemPath: match.item.path,
+          itemId: match.item.itemId,
+          action: 'disable',
+          reason: actionBody.reason,
+        },
         { userId: auth.user.id, timeoutMs: 30000 }
       );
 
@@ -183,6 +262,12 @@ bootMetricsRoutes.post(
     try {
       const auth = c.get('auth');
       const itemName = decodeURIComponent(c.req.param('itemName'));
+      let actionBody = parseActionBody({});
+      try {
+        actionBody = parseActionBody(await c.req.json());
+      } catch {
+        // Request body is optional for this endpoint.
+      }
 
       const device = await getDeviceWithOrgCheck(deviceId, auth);
       if (!device) {
@@ -203,17 +288,50 @@ bootMetricsRoutes.post(
         return c.json({ error: 'No boot performance data available' }, 404);
       }
 
-      const items = latestBoot.startupItems as Array<{ name: string; type: string; path: string; enabled: boolean }>;
-      const item = items.find(i => i.name === itemName);
-      if (!item) {
-        return c.json({ error: `Startup item "${itemName}" not found` }, 404);
+      const items = normalizeStartupItems(Array.isArray(latestBoot.startupItems) ? latestBoot.startupItems : []);
+      const match = resolveStartupItem(items, {
+        itemId: actionBody.itemId,
+        itemName,
+        itemType: actionBody.itemType,
+        itemPath: actionBody.itemPath,
+      });
+      if (!match.item) {
+        if (match.candidates && match.candidates.length > 1) {
+          return c.json({
+            error: `Startup item selector for "${itemName}" is ambiguous. Provide itemId or itemType+itemPath.`,
+            candidates: match.candidates.slice(0, 20).map(c => ({
+              itemId: c.itemId,
+              name: c.name,
+              type: c.type,
+              path: c.path,
+              enabled: c.enabled,
+            })),
+          }, 409);
+        }
+        return c.json({
+          error: `Startup item "${itemName}" not found`,
+          availableItems: items.slice(0, 20).map(i => ({
+            itemId: i.itemId,
+            name: i.name,
+            type: i.type,
+            path: i.path,
+            enabled: i.enabled,
+          })),
+        }, 404);
       }
 
       const { executeCommand } = await import('../../services/commandQueue');
       const result = await executeCommand(
         deviceId,
         'manage_startup_item',
-        { itemName, itemType: item.type, itemPath: item.path, action: 'enable' },
+        {
+          itemName: match.item.name,
+          itemType: match.item.type,
+          itemPath: match.item.path,
+          itemId: match.item.itemId,
+          action: 'enable',
+          reason: actionBody.reason,
+        },
         { userId: auth.user.id, timeoutMs: 30000 }
       );
 

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -692,6 +692,9 @@ export function createBreezeMcpServer(
       {
         deviceId: uuid,
         itemName: z.string().min(1).max(255),
+        itemId: z.string().max(512).optional(),
+        itemType: z.string().max(64).optional(),
+        itemPath: z.string().max(2048).optional(),
         action: z.enum(['disable', 'enable']),
         reason: z.string().max(500).optional(),
       },

--- a/apps/api/src/services/aiToolSchemas.ts
+++ b/apps/api/src/services/aiToolSchemas.ts
@@ -312,6 +312,9 @@ export const toolInputSchemas: Record<string, z.ZodType> = {
   manage_startup_items: z.object({
     deviceId: uuid,
     itemName: z.string().min(1).max(255),
+    itemId: z.string().max(512).optional(),
+    itemType: z.string().max(64).optional(),
+    itemPath: z.string().max(2048).optional(),
     action: z.enum(['disable', 'enable']),
     reason: z.string().max(500).optional(),
   }),

--- a/apps/api/src/services/aiTools.ts
+++ b/apps/api/src/services/aiTools.ts
@@ -47,6 +47,14 @@ import {
   getLatestSecurityPostureForDevice,
   listLatestSecurityPosture
 } from './securityPosture';
+import {
+  mergeBootRecords,
+  parseCollectorBootMetricsFromCommandResult,
+} from './bootPerformance';
+import {
+  normalizeStartupItems,
+  resolveStartupItem,
+} from './startupItems';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -1385,13 +1393,18 @@ registerTool({
 
     // Optionally trigger fresh collection
     let collectionFailed = false;
+    let freshBootRecord: ReturnType<typeof parseCollectorBootMetricsFromCommandResult> = null;
     if (triggerCollection && device.status === 'online') {
       const { executeCommand } = await getCommandQueue();
       try {
-        await executeCommand(deviceId, 'collect_boot_performance', {}, {
+        const commandResult = await executeCommand(deviceId, 'collect_boot_performance', {}, {
           userId: auth.user.id,
           timeoutMs: 15000,
         });
+        freshBootRecord = parseCollectorBootMetricsFromCommandResult(commandResult);
+        if (!freshBootRecord) {
+          collectionFailed = true;
+        }
       } catch (err) {
         collectionFailed = true;
         console.warn(`[AI] Boot performance collection trigger failed for device ${deviceId}:`, err);
@@ -1406,7 +1419,9 @@ registerTool({
       .orderBy(desc(deviceBootMetrics.bootTimestamp))
       .limit(bootsBack);
 
-    if (bootRecords.length === 0) {
+    const mergedBootRecords = mergeBootRecords(bootRecords, freshBootRecord, bootsBack);
+
+    if (mergedBootRecords.length === 0) {
       return JSON.stringify({
         error: collectionFailed
           ? 'Boot performance data collection failed and no cached data exists. The device may not support this feature or may be experiencing issues.'
@@ -1415,19 +1430,18 @@ registerTool({
     }
 
     // Summary statistics
-    const totalBootTimes = bootRecords
+    const totalBootTimes = mergedBootRecords
       .map(b => b.totalBootSeconds)
       .filter((t): t is number => t !== null);
     const avgBootTime = totalBootTimes.length > 0
       ? totalBootTimes.reduce((a, b) => a + b, 0) / totalBootTimes.length
       : 0;
-    const latestBoot = bootRecords[0]!;
+    const latestBoot = mergedBootRecords[0]!;
 
     // Top impact startup items from latest boot
-    const allStartupItems = (latestBoot.startupItems ?? []) as Array<{
-      name: string; type: string; path: string; enabled: boolean;
-      cpuTimeMs: number; diskIoBytes: number; impactScore: number;
-    }>;
+    const allStartupItems = normalizeStartupItems(
+      Array.isArray(latestBoot.startupItems) ? latestBoot.startupItems : []
+    );
     const topImpactItems = [...allStartupItems]
       .sort((a, b) => b.impactScore - a.impactScore)
       .slice(0, 10);
@@ -1440,8 +1454,9 @@ registerTool({
     if (topImpactItems.some(item => item.impactScore > 60)) {
       recommendations.push('Several startup items have high resource usage. Consider disabling non-essential items.');
     }
-    if (latestBoot.startupItemCount > 50) {
-      recommendations.push(`High startup item count (${latestBoot.startupItemCount}). Disable unused services.`);
+    const latestBootStartupItemCount = Number(latestBoot.startupItemCount ?? allStartupItems.length);
+    if (latestBootStartupItemCount > 50) {
+      recommendations.push(`High startup item count (${latestBootStartupItemCount}). Disable unused services.`);
     }
     if (totalBootTimes.length >= 3) {
       const recent = totalBootTimes.slice(0, 3);
@@ -1458,11 +1473,11 @@ registerTool({
     return JSON.stringify({
       device: { id: device.id, hostname: device.hostname, osType: device.osType },
       bootHistory: {
-        totalBoots: bootRecords.length,
+        totalBoots: mergedBootRecords.length,
         avgBootTimeSeconds: Number(avgBootTime.toFixed(2)),
         fastestBootSeconds: totalBootTimes.length > 0 ? Number(Math.min(...totalBootTimes).toFixed(2)) : null,
         slowestBootSeconds: totalBootTimes.length > 0 ? Number(Math.max(...totalBootTimes).toFixed(2)) : null,
-        recentBoots: bootRecords.slice(0, 5).map(b => ({
+        recentBoots: mergedBootRecords.slice(0, 5).map(b => ({
           timestamp: b.bootTimestamp,
           totalSeconds: b.totalBootSeconds,
           biosSeconds: b.biosSeconds,
@@ -1473,8 +1488,9 @@ registerTool({
       latestBoot: {
         timestamp: latestBoot.bootTimestamp,
         totalSeconds: latestBoot.totalBootSeconds,
-        startupItemCount: latestBoot.startupItemCount,
+        startupItemCount: latestBootStartupItemCount,
         topImpactItems: topImpactItems.map(item => ({
+          itemId: item.itemId,
           name: item.name,
           type: item.type,
           path: item.path,
@@ -1500,6 +1516,9 @@ registerTool({
       properties: {
         deviceId: { type: 'string', description: 'The device UUID' },
         itemName: { type: 'string', description: 'The exact name of the startup item to manage' },
+        itemId: { type: 'string', description: 'Stable startup item identifier. Preferred when item names are duplicated.' },
+        itemType: { type: 'string', description: 'Optional startup item type to disambiguate name collisions.' },
+        itemPath: { type: 'string', description: 'Optional startup item path to disambiguate name collisions.' },
         action: { type: 'string', enum: ['disable', 'enable'], description: 'Action to perform' },
         reason: { type: 'string', description: 'Justification for this change' }
       },
@@ -1509,6 +1528,9 @@ registerTool({
   handler: async (input, auth) => {
     const deviceId = input.deviceId as string;
     const itemName = input.itemName as string;
+    const itemId = input.itemId as string | undefined;
+    const itemType = input.itemType as string | undefined;
+    const itemPath = input.itemPath as string | undefined;
     const action = input.action as 'disable' | 'enable';
     const reason = (input.reason as string) || 'No reason provided';
 
@@ -1528,15 +1550,33 @@ registerTool({
       return JSON.stringify({ error: 'No boot performance data available for this device.' });
     }
 
-    const allItems = (latestBoot.startupItems ?? []) as Array<{
-      name: string; type: string; path: string; enabled: boolean;
-    }>;
-    const item = allItems.find(i => i.name === itemName);
-    if (!item) {
+    const allItems = normalizeStartupItems(Array.isArray(latestBoot.startupItems) ? latestBoot.startupItems : []);
+    const match = resolveStartupItem(allItems, { itemId, itemName, itemType, itemPath });
+    if (!match.item) {
+      if (match.candidates && match.candidates.length > 1) {
+        return JSON.stringify({
+          error: `Startup item selector for "${itemName}" is ambiguous. Provide itemId or itemType+itemPath.`,
+          candidates: match.candidates.slice(0, 20).map(i => ({
+            itemId: i.itemId,
+            name: i.name,
+            type: i.type,
+            path: i.path,
+            enabled: i.enabled,
+          })),
+        });
+      }
       return JSON.stringify({
-        error: `Startup item "${itemName}" not found. Available items: ${allItems.map(i => i.name).slice(0, 20).join(', ')}`
+        error: `Startup item "${itemName}" not found.`,
+        availableItems: allItems.slice(0, 20).map(i => ({
+          itemId: i.itemId,
+          name: i.name,
+          type: i.type,
+          path: i.path,
+          enabled: i.enabled,
+        })),
       });
     }
+    const item = match.item;
 
     if (action === 'disable' && !item.enabled) {
       return JSON.stringify({ error: `Startup item "${itemName}" is already disabled.` });
@@ -1554,7 +1594,7 @@ registerTool({
     const result = await executeCommand(
       deviceId,
       'manage_startup_item',
-      { itemName, itemType: item.type, itemPath: item.path, action },
+      { itemName: item.name, itemType: item.type, itemPath: item.path, itemId: item.itemId, action, reason },
       { userId: auth.user.id, timeoutMs: 30000 }
     );
 
@@ -1570,6 +1610,7 @@ registerTool({
       message: `Startup item "${itemName}" ${action}d successfully.`,
       device: { hostname: device.hostname, osType: device.osType },
       item: {
+        itemId: item.itemId,
         name: item.name,
         type: item.type,
         path: item.path,

--- a/apps/api/src/services/bootPerformance.test.ts
+++ b/apps/api/src/services/bootPerformance.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mergeBootRecords,
+  parseCollectorBootMetricsFromCommandResult,
+} from './bootPerformance';
+
+describe('bootPerformance helpers', () => {
+  it('parses collector output from command stdout', () => {
+    const parsed = parseCollectorBootMetricsFromCommandResult({
+      status: 'completed',
+      stdout: JSON.stringify({
+        bootTimestamp: '2026-02-20T10:00:00.000Z',
+        totalBootSeconds: 42.5,
+        startupItems: [
+          {
+            name: 'svc',
+            type: 'service',
+            path: '/usr/bin/svc',
+            enabled: true,
+            cpuTimeMs: 12,
+            diskIoBytes: 1000,
+            impactScore: 1.2,
+          },
+        ],
+      }),
+    });
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.totalBootSeconds).toBe(42.5);
+    expect(parsed?.startupItems).toHaveLength(1);
+    expect((parsed?.startupItems[0] as { itemId?: string }).itemId).toBe('service|/usr/bin/svc');
+  });
+
+  it('merges fresh metrics ahead of stale db history', () => {
+    const merged = mergeBootRecords(
+      [
+        {
+          bootTimestamp: new Date('2026-02-19T10:00:00.000Z'),
+          biosSeconds: 1,
+          osLoaderSeconds: 2,
+          desktopReadySeconds: 3,
+          totalBootSeconds: 60,
+          startupItemCount: 0,
+          startupItems: [],
+        },
+      ],
+      {
+        bootTimestamp: new Date('2026-02-20T10:00:00.000Z'),
+        biosSeconds: 1,
+        osLoaderSeconds: 2,
+        desktopReadySeconds: 3,
+        totalBootSeconds: 45,
+        startupItemCount: 0,
+        startupItems: [],
+      },
+      10
+    );
+
+    expect(merged).toHaveLength(2);
+    expect(new Date(merged[0]!.bootTimestamp).toISOString()).toBe('2026-02-20T10:00:00.000Z');
+    expect(merged[0]!.totalBootSeconds).toBe(45);
+  });
+
+  it('deduplicates by boot timestamp when fresh and db entries overlap', () => {
+    const merged = mergeBootRecords(
+      [
+        {
+          bootTimestamp: new Date('2026-02-20T10:00:00.000Z'),
+          biosSeconds: 0,
+          osLoaderSeconds: 0,
+          desktopReadySeconds: 0,
+          totalBootSeconds: 99,
+          startupItemCount: 1,
+          startupItems: [],
+        },
+      ],
+      {
+        bootTimestamp: new Date('2026-02-20T10:00:00.000Z'),
+        biosSeconds: 1,
+        osLoaderSeconds: 2,
+        desktopReadySeconds: 3,
+        totalBootSeconds: 40,
+        startupItemCount: 0,
+        startupItems: [],
+      },
+      10
+    );
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]!.totalBootSeconds).toBe(40);
+  });
+});
+

--- a/apps/api/src/services/bootPerformance.ts
+++ b/apps/api/src/services/bootPerformance.ts
@@ -1,0 +1,101 @@
+import { normalizeStartupItems } from './startupItems';
+
+export interface BootHistoryRecord {
+  bootTimestamp: Date | string;
+  biosSeconds: number | null;
+  osLoaderSeconds: number | null;
+  desktopReadySeconds: number | null;
+  totalBootSeconds: number | null;
+  startupItemCount: number;
+  startupItems: unknown[];
+}
+
+function parseDate(value: unknown): Date | null {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value;
+  if (typeof value === 'string' || typeof value === 'number') {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) return parsed;
+  }
+  return null;
+}
+
+function parseNumber(value: unknown, fallback = 0): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  return fallback;
+}
+
+function toRecord(raw: Record<string, unknown>): BootHistoryRecord | null {
+  const bootTimestamp = parseDate(raw.bootTimestamp);
+  if (!bootTimestamp) return null;
+
+  const startupItems = normalizeStartupItems(
+    Array.isArray(raw.startupItems) ? raw.startupItems : []
+  );
+
+  return {
+    bootTimestamp,
+    biosSeconds: parseNumber(raw.biosSeconds, 0),
+    osLoaderSeconds: parseNumber(raw.osLoaderSeconds, 0),
+    desktopReadySeconds: parseNumber(raw.desktopReadySeconds, 0),
+    totalBootSeconds: parseNumber(raw.totalBootSeconds, 0),
+    startupItemCount: Number.isFinite(Number(raw.startupItemCount))
+      ? Math.max(0, Math.trunc(Number(raw.startupItemCount)))
+      : startupItems.length,
+    startupItems,
+  };
+}
+
+export function parseCollectorBootMetricsFromCommandResult(result: {
+  status?: string;
+  stdout?: string;
+  data?: unknown;
+}): BootHistoryRecord | null {
+  if (result.status !== 'completed') return null;
+
+  let payload: unknown = result.data;
+  if (payload === undefined && typeof result.stdout === 'string' && result.stdout.trim() !== '') {
+    try {
+      payload = JSON.parse(result.stdout);
+    } catch {
+      return null;
+    }
+  }
+
+  if (!payload || typeof payload !== 'object') return null;
+  return toRecord(payload as Record<string, unknown>);
+}
+
+function bootRecordSortKey(record: BootHistoryRecord): number {
+  const parsed = parseDate(record.bootTimestamp);
+  return parsed?.getTime() ?? 0;
+}
+
+function bootRecordIdentity(record: BootHistoryRecord): string {
+  const parsed = parseDate(record.bootTimestamp);
+  return parsed ? String(parsed.getTime()) : String(record.bootTimestamp);
+}
+
+export function mergeBootRecords(
+  existing: BootHistoryRecord[],
+  fresh: BootHistoryRecord | null,
+  limit: number
+): BootHistoryRecord[] {
+  const merged: BootHistoryRecord[] = [];
+  const seen = new Set<string>();
+
+  const pushIfNew = (record: BootHistoryRecord | null) => {
+    if (!record) return;
+    const key = bootRecordIdentity(record);
+    if (seen.has(key)) return;
+    seen.add(key);
+    merged.push(record);
+  };
+
+  // Fresh collection takes precedence for duplicate timestamps.
+  pushIfNew(fresh);
+  for (const record of existing) pushIfNew(record);
+
+  merged.sort((a, b) => bootRecordSortKey(b) - bootRecordSortKey(a));
+  return merged.slice(0, limit);
+}
+

--- a/apps/api/src/services/commandQueue.test.ts
+++ b/apps/api/src/services/commandQueue.test.ts
@@ -14,7 +14,8 @@ vi.mock('../db', () => ({
     select: vi.fn(),
     insert: vi.fn(),
     update: vi.fn()
-  }
+  },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn())
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -77,6 +77,10 @@ export const CommandTypes = {
 
   // Computer control (AI Computer Use)
   COMPUTER_ACTION: 'computer_action',
+
+  // Boot performance
+  COLLECT_BOOT_PERFORMANCE: 'collect_boot_performance',
+  MANAGE_STARTUP_ITEM: 'manage_startup_item',
 } as const;
 
 export type CommandType = typeof CommandTypes[keyof typeof CommandTypes];
@@ -141,6 +145,7 @@ const AUDITED_COMMANDS: Set<string> = new Set([
   CommandTypes.SECURITY_THREAT_RESTORE,
   CommandTypes.TAKE_SCREENSHOT,
   CommandTypes.COMPUTER_ACTION,
+  CommandTypes.MANAGE_STARTUP_ITEM,
 ]);
 
 /**

--- a/apps/api/src/services/startupItems.test.ts
+++ b/apps/api/src/services/startupItems.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeStartupItemId,
+  normalizeStartupItems,
+  resolveStartupItem,
+} from './startupItems';
+
+describe('startupItems helpers', () => {
+  it('computes deterministic item ids from type/path', () => {
+    const id = computeStartupItemId({
+      type: 'Service',
+      path: 'C:\\Program Files\\Vendor\\App.exe',
+    });
+    expect(id).toBe('service|c:/program files/vendor/app.exe');
+  });
+
+  it('normalizes startup items and de-duplicates by item id', () => {
+    const items = normalizeStartupItems([
+      {
+        name: 'One',
+        type: 'service',
+        path: '/usr/bin/one',
+        enabled: true,
+        cpuTimeMs: 100,
+        diskIoBytes: 50,
+        impactScore: 2.5,
+      },
+      {
+        name: 'One duplicate',
+        type: 'service',
+        path: '/usr/bin/one',
+        enabled: true,
+        cpuTimeMs: 200,
+        diskIoBytes: 100,
+        impactScore: 5,
+      },
+      null,
+    ] as any[]);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.itemId).toBe('service|/usr/bin/one');
+  });
+
+  it('returns ambiguity when name-only selection matches multiple items', () => {
+    const items = normalizeStartupItems([
+      { name: 'Updater', type: 'run_key', path: 'HKCU:Updater', enabled: true, cpuTimeMs: 0, diskIoBytes: 0, impactScore: 0 },
+      { name: 'Updater', type: 'service', path: 'VendorUpdater', enabled: true, cpuTimeMs: 0, diskIoBytes: 0, impactScore: 0 },
+    ] as any[]);
+
+    const result = resolveStartupItem(items, { itemName: 'Updater' });
+    expect(result.item).toBeUndefined();
+    expect(result.error).toContain('ambiguous');
+    expect(result.candidates).toHaveLength(2);
+  });
+
+  it('resolves unique item when itemType and itemPath are supplied', () => {
+    const items = normalizeStartupItems([
+      { name: 'Updater', type: 'run_key', path: 'HKCU:Updater', enabled: true, cpuTimeMs: 0, diskIoBytes: 0, impactScore: 0 },
+      { name: 'Updater', type: 'service', path: 'VendorUpdater', enabled: true, cpuTimeMs: 0, diskIoBytes: 0, impactScore: 0 },
+    ] as any[]);
+
+    const result = resolveStartupItem(items, {
+      itemName: 'Updater',
+      itemType: 'service',
+      itemPath: 'VendorUpdater',
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.item?.type).toBe('service');
+    expect(result.item?.path).toBe('VendorUpdater');
+  });
+});
+

--- a/apps/api/src/services/startupItems.ts
+++ b/apps/api/src/services/startupItems.ts
@@ -1,0 +1,158 @@
+import type { BootStartupItem } from '../db/schema/devices';
+
+const STARTUP_ITEM_TYPES = new Set<BootStartupItem['type']>([
+  'service',
+  'run_key',
+  'startup_folder',
+  'login_item',
+  'launch_agent',
+  'launch_daemon',
+  'systemd',
+  'cron',
+  'init_d',
+]);
+
+export type BootStartupItemWithId = BootStartupItem & { itemId: string };
+
+function normalizeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeIdentityPart(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/\\/g, '/')
+    .replace(/\s+/g, ' ');
+}
+
+function normalizeType(value: unknown): BootStartupItem['type'] {
+  const normalized = normalizeIdentityPart(normalizeString(value));
+  return STARTUP_ITEM_TYPES.has(normalized as BootStartupItem['type'])
+    ? (normalized as BootStartupItem['type'])
+    : 'service';
+}
+
+function normalizeNumber(value: unknown, fallback = 0): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  return fallback;
+}
+
+function normalizeBoolean(value: unknown, fallback = true): boolean {
+  if (typeof value === 'boolean') return value;
+  return fallback;
+}
+
+export function computeStartupItemId(item: {
+  itemId?: string;
+  type?: string;
+  path?: string;
+  name?: string;
+}): string {
+  const explicit = normalizeIdentityPart(normalizeString(item.itemId));
+  if (explicit) return explicit;
+
+  const type = normalizeIdentityPart(normalizeString(item.type)) || 'service';
+  const path = normalizeIdentityPart(normalizeString(item.path));
+  if (path) return `${type}|${path}`;
+
+  const name = normalizeIdentityPart(normalizeString(item.name)) || 'unknown';
+  return `${type}|name:${name}`;
+}
+
+export function normalizeStartupItem(raw: unknown): BootStartupItemWithId | null {
+  if (!raw || typeof raw !== 'object') return null;
+
+  const obj = raw as Record<string, unknown>;
+  const name = normalizeString(obj.name) || normalizeString(obj.path) || 'unnamed_startup_item';
+  const type = normalizeType(obj.type);
+  const path = normalizeString(obj.path);
+  const enabled = normalizeBoolean(obj.enabled, true);
+  const cpuTimeMs = Math.max(0, Math.trunc(normalizeNumber(obj.cpuTimeMs, 0)));
+  const diskIoBytes = Math.max(0, Math.trunc(normalizeNumber(obj.diskIoBytes, 0)));
+  const impactScore = Math.max(0, normalizeNumber(obj.impactScore, 0));
+  const itemId = computeStartupItemId({ itemId: normalizeString(obj.itemId), type, path, name });
+
+  return {
+    itemId,
+    name,
+    type,
+    path,
+    enabled,
+    cpuTimeMs,
+    diskIoBytes,
+    impactScore,
+  };
+}
+
+export function normalizeStartupItems(rawItems: unknown[]): BootStartupItemWithId[] {
+  const normalized: BootStartupItemWithId[] = [];
+  const seen = new Set<string>();
+
+  for (const raw of rawItems) {
+    const item = normalizeStartupItem(raw);
+    if (!item) continue;
+    if (seen.has(item.itemId)) continue;
+    seen.add(item.itemId);
+    normalized.push(item);
+  }
+
+  return normalized;
+}
+
+export interface StartupItemSelector {
+  itemId?: string;
+  itemName?: string;
+  itemType?: string;
+  itemPath?: string;
+}
+
+export interface StartupItemResolveResult {
+  item?: BootStartupItemWithId;
+  candidates?: BootStartupItemWithId[];
+  error?: string;
+}
+
+export function resolveStartupItem(
+  items: BootStartupItemWithId[],
+  selector: StartupItemSelector
+): StartupItemResolveResult {
+  const selectedItemID = normalizeIdentityPart(normalizeString(selector.itemId));
+  const selectedName = normalizeIdentityPart(normalizeString(selector.itemName));
+  const selectedType = normalizeIdentityPart(normalizeString(selector.itemType));
+  const selectedPath = normalizeIdentityPart(normalizeString(selector.itemPath));
+
+  if (!selectedItemID && !selectedName && !selectedType && !selectedPath) {
+    return { error: 'No startup item selector provided.' };
+  }
+
+  let candidates = items;
+
+  if (selectedItemID) {
+    candidates = candidates.filter(i => normalizeIdentityPart(i.itemId) === selectedItemID);
+    if (candidates.length === 1) {
+      return { item: candidates[0] };
+    }
+  }
+  if (selectedName) {
+    candidates = candidates.filter(i => normalizeIdentityPart(i.name) === selectedName);
+  }
+  if (selectedType) {
+    candidates = candidates.filter(i => normalizeIdentityPart(i.type) === selectedType);
+  }
+  if (selectedPath) {
+    candidates = candidates.filter(i => normalizeIdentityPart(i.path) === selectedPath);
+  }
+
+  if (candidates.length === 0) {
+    return { error: 'Startup item not found.' };
+  }
+  if (candidates.length > 1) {
+    return {
+      error: 'Startup item selector is ambiguous.',
+      candidates,
+    };
+  }
+
+  return { item: candidates[0] };
+}


### PR DESCRIPTION
## Summary
- normalize and de-duplicate startup items with stable item IDs
- make boot metric ingestion idempotent with upsert + SQL retention cleanup
- improve startup item enable/disable disambiguation across API and AI tools
- harden Windows startup-item management and service key-name resolution fallback
- refine macOS boot timing fallback behavior and add focused tests

## Validation
- go test ./internal/collectors
- pnpm --dir apps/api exec vitest run src/routes/agents/bootPerformance.test.ts src/routes/devices/bootMetrics.test.ts src/services/startupItems.test.ts src/services/bootPerformance.test.ts