### PR TITLE
feat: DNS security integration + AI DNS tools

### DIFF
--- a/apps/api/src/db/migrations/2026-02-21-dns-security-hardening.sql
+++ b/apps/api/src/db/migrations/2026-02-21-dns-security-hardening.sql
@@ -1,0 +1,21 @@
+BEGIN;
+
+-- Ensure event IDs are always present so deduplication is guaranteed by schema.
+UPDATE dns_security_events
+SET provider_event_id = 'legacy-' || id::text
+WHERE provider_event_id IS NULL OR btrim(provider_event_id) = '';
+
+ALTER TABLE dns_security_events
+  ALTER COLUMN provider_event_id SET NOT NULL;
+
+-- Allow aggregate queries to filter by integration.
+ALTER TABLE dns_event_aggregations
+  ADD COLUMN IF NOT EXISTS integration_id uuid REFERENCES dns_filter_integrations(id);
+
+CREATE INDEX IF NOT EXISTS dns_event_agg_org_date_integration_idx
+  ON dns_event_aggregations (org_id, date DESC, integration_id);
+
+CREATE INDEX IF NOT EXISTS dns_event_agg_integration_id_idx
+  ON dns_event_aggregations (integration_id);
+
+COMMIT;

--- a/apps/api/src/db/migrations/2026-02-21-dns-security.sql
+++ b/apps/api/src/db/migrations/2026-02-21-dns-security.sql
@@ -1,0 +1,213 @@
+BEGIN;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'dns_provider') THEN
+    CREATE TYPE dns_provider AS ENUM ('umbrella', 'cloudflare', 'dnsfilter', 'pihole', 'opendns', 'quad9');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'dns_action') THEN
+    CREATE TYPE dns_action AS ENUM ('allowed', 'blocked', 'redirected');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'dns_threat_category') THEN
+    CREATE TYPE dns_threat_category AS ENUM (
+      'malware',
+      'phishing',
+      'botnet',
+      'cryptomining',
+      'ransomware',
+      'spam',
+      'adware',
+      'adult_content',
+      'gambling',
+      'social_media',
+      'streaming',
+      'unknown'
+    );
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'dns_policy_type') THEN
+    CREATE TYPE dns_policy_type AS ENUM ('blocklist', 'allowlist');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'dns_policy_sync_status') THEN
+    CREATE TYPE dns_policy_sync_status AS ENUM ('pending', 'synced', 'error');
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS dns_filter_integrations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  provider dns_provider NOT NULL,
+  name varchar(200) NOT NULL,
+  description text,
+  api_key text,
+  api_secret text,
+  config jsonb NOT NULL DEFAULT '{}'::jsonb,
+  is_active boolean NOT NULL DEFAULT true,
+  last_sync timestamp,
+  last_sync_status varchar(20),
+  last_sync_error text,
+  total_events_processed integer NOT NULL DEFAULT 0,
+  created_by uuid REFERENCES users(id),
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS dns_filter_integrations_org_id_idx
+  ON dns_filter_integrations (org_id);
+CREATE INDEX IF NOT EXISTS dns_filter_integrations_provider_idx
+  ON dns_filter_integrations (provider);
+
+CREATE TABLE IF NOT EXISTS dns_security_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  integration_id uuid NOT NULL REFERENCES dns_filter_integrations(id),
+  device_id uuid REFERENCES devices(id),
+  timestamp timestamp NOT NULL,
+  domain varchar(500) NOT NULL,
+  query_type varchar(10) NOT NULL DEFAULT 'A',
+  action dns_action NOT NULL,
+  category dns_threat_category,
+  threat_type varchar(100),
+  threat_score integer,
+  source_ip varchar(45),
+  source_hostname varchar(255),
+  provider_event_id varchar(255),
+  metadata jsonb,
+  created_at timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS dns_security_events_org_ts_idx
+  ON dns_security_events (org_id, timestamp DESC);
+CREATE INDEX IF NOT EXISTS dns_security_events_integration_id_idx
+  ON dns_security_events (integration_id);
+CREATE INDEX IF NOT EXISTS dns_security_events_device_id_idx
+  ON dns_security_events (device_id);
+CREATE INDEX IF NOT EXISTS dns_security_events_domain_idx
+  ON dns_security_events (domain);
+CREATE INDEX IF NOT EXISTS dns_security_events_action_cat_idx
+  ON dns_security_events (action, category);
+CREATE INDEX IF NOT EXISTS dns_security_events_provider_id_idx
+  ON dns_security_events (integration_id, provider_event_id);
+CREATE UNIQUE INDEX IF NOT EXISTS dns_security_events_provider_evt_uniq
+  ON dns_security_events (integration_id, provider_event_id);
+
+CREATE TABLE IF NOT EXISTS dns_policies (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  integration_id uuid NOT NULL REFERENCES dns_filter_integrations(id),
+  name varchar(200) NOT NULL,
+  description text,
+  type dns_policy_type NOT NULL,
+  domains jsonb NOT NULL DEFAULT '[]'::jsonb,
+  categories jsonb NOT NULL DEFAULT '[]'::jsonb,
+  sync_status dns_policy_sync_status NOT NULL DEFAULT 'pending',
+  last_synced timestamp,
+  sync_error text,
+  is_active boolean NOT NULL DEFAULT true,
+  created_by uuid REFERENCES users(id),
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS dns_policies_org_id_idx
+  ON dns_policies (org_id);
+CREATE INDEX IF NOT EXISTS dns_policies_integration_id_idx
+  ON dns_policies (integration_id);
+
+CREATE TABLE IF NOT EXISTS dns_event_aggregations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  date date NOT NULL,
+  device_id uuid REFERENCES devices(id),
+  domain varchar(500),
+  category dns_threat_category,
+  total_queries integer NOT NULL DEFAULT 0,
+  blocked_queries integer NOT NULL DEFAULT 0,
+  allowed_queries integer NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS dns_event_agg_org_date_idx
+  ON dns_event_aggregations (org_id, date DESC);
+CREATE INDEX IF NOT EXISTS dns_event_agg_device_id_idx
+  ON dns_event_aggregations (device_id);
+
+ALTER TABLE dns_filter_integrations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE dns_filter_integrations FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS breeze_org_isolation_select ON dns_filter_integrations;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON dns_filter_integrations;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON dns_filter_integrations;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON dns_filter_integrations;
+CREATE POLICY breeze_org_isolation_select ON dns_filter_integrations
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON dns_filter_integrations
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON dns_filter_integrations
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON dns_filter_integrations
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+ALTER TABLE dns_security_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE dns_security_events FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS breeze_org_isolation_select ON dns_security_events;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON dns_security_events;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON dns_security_events;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON dns_security_events;
+CREATE POLICY breeze_org_isolation_select ON dns_security_events
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON dns_security_events
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON dns_security_events
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON dns_security_events
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+ALTER TABLE dns_policies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE dns_policies FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS breeze_org_isolation_select ON dns_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON dns_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON dns_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON dns_policies;
+CREATE POLICY breeze_org_isolation_select ON dns_policies
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON dns_policies
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON dns_policies
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON dns_policies
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+ALTER TABLE dns_event_aggregations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE dns_event_aggregations FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS breeze_org_isolation_select ON dns_event_aggregations;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON dns_event_aggregations;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON dns_event_aggregations;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON dns_event_aggregations;
+CREATE POLICY breeze_org_isolation_select ON dns_event_aggregations
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON dns_event_aggregations
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON dns_event_aggregations
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON dns_event_aggregations
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+COMMIT;

--- a/apps/api/src/db/schema/dnsSecurity.ts
+++ b/apps/api/src/db/schema/dnsSecurity.ts
@@ -1,0 +1,162 @@
+import {
+  pgTable,
+  uuid,
+  varchar,
+  text,
+  timestamp,
+  jsonb,
+  pgEnum,
+  boolean,
+  integer,
+  index,
+  uniqueIndex,
+  date
+} from 'drizzle-orm/pg-core';
+import { organizations } from './orgs';
+import { users } from './users';
+import { devices } from './devices';
+
+export const dnsProviderEnum = pgEnum('dns_provider', [
+  'umbrella',
+  'cloudflare',
+  'dnsfilter',
+  'pihole',
+  'opendns',
+  'quad9'
+]);
+
+export const dnsActionEnum = pgEnum('dns_action', [
+  'allowed',
+  'blocked',
+  'redirected'
+]);
+
+export const dnsThreatCategoryEnum = pgEnum('dns_threat_category', [
+  'malware',
+  'phishing',
+  'botnet',
+  'cryptomining',
+  'ransomware',
+  'spam',
+  'adware',
+  'adult_content',
+  'gambling',
+  'social_media',
+  'streaming',
+  'unknown'
+]);
+
+export const dnsPolicyTypeEnum = pgEnum('dns_policy_type', ['blocklist', 'allowlist']);
+export const dnsPolicySyncStatusEnum = pgEnum('dns_policy_sync_status', ['pending', 'synced', 'error']);
+
+export type DnsProvider = typeof dnsProviderEnum.enumValues[number];
+export type DnsAction = typeof dnsActionEnum.enumValues[number];
+export type DnsThreatCategory = typeof dnsThreatCategoryEnum.enumValues[number];
+export type DnsPolicyType = typeof dnsPolicyTypeEnum.enumValues[number];
+export type DnsPolicySyncStatus = typeof dnsPolicySyncStatusEnum.enumValues[number];
+
+export interface DnsIntegrationConfig {
+  organizationId?: string;
+  accountId?: string;
+  apiEndpoint?: string;
+  syncInterval?: number;
+  retentionDays?: number;
+  categories?: string[];
+  blocklistId?: string;
+  allowlistId?: string;
+}
+
+export interface DnsPolicyDomain {
+  domain: string;
+  reason?: string;
+  addedAt: string;
+  addedBy?: string;
+}
+
+export const dnsFilterIntegrations = pgTable('dns_filter_integrations', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  provider: dnsProviderEnum('provider').notNull(),
+  name: varchar('name', { length: 200 }).notNull(),
+  description: text('description'),
+  apiKey: text('api_key'),
+  apiSecret: text('api_secret'),
+  config: jsonb('config').$type<DnsIntegrationConfig>().notNull().default({}),
+  isActive: boolean('is_active').notNull().default(true),
+  lastSync: timestamp('last_sync'),
+  lastSyncStatus: varchar('last_sync_status', { length: 20 }),
+  lastSyncError: text('last_sync_error'),
+  totalEventsProcessed: integer('total_events_processed').notNull().default(0),
+  createdBy: uuid('created_by').references(() => users.id),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull()
+}, (table) => ({
+  orgIdIdx: index('dns_filter_integrations_org_id_idx').on(table.orgId),
+  providerIdx: index('dns_filter_integrations_provider_idx').on(table.provider)
+}));
+
+export const dnsSecurityEvents = pgTable('dns_security_events', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  integrationId: uuid('integration_id').notNull().references(() => dnsFilterIntegrations.id),
+  deviceId: uuid('device_id').references(() => devices.id),
+  timestamp: timestamp('timestamp').notNull(),
+  domain: varchar('domain', { length: 500 }).notNull(),
+  queryType: varchar('query_type', { length: 10 }).notNull().default('A'),
+  action: dnsActionEnum('action').notNull(),
+  category: dnsThreatCategoryEnum('category'),
+  threatType: varchar('threat_type', { length: 100 }),
+  threatScore: integer('threat_score'),
+  sourceIp: varchar('source_ip', { length: 45 }),
+  sourceHostname: varchar('source_hostname', { length: 255 }),
+  providerEventId: varchar('provider_event_id', { length: 255 }).notNull(),
+  metadata: jsonb('metadata'),
+  createdAt: timestamp('created_at').defaultNow().notNull()
+}, (table) => ({
+  orgTimestampIdx: index('dns_security_events_org_ts_idx').on(table.orgId, table.timestamp),
+  integrationIdIdx: index('dns_security_events_integration_id_idx').on(table.integrationId),
+  deviceIdIdx: index('dns_security_events_device_id_idx').on(table.deviceId),
+  domainIdx: index('dns_security_events_domain_idx').on(table.domain),
+  actionCategoryIdx: index('dns_security_events_action_cat_idx').on(table.action, table.category),
+  providerEventIdIdx: index('dns_security_events_provider_id_idx').on(table.integrationId, table.providerEventId),
+  providerEventIdUnique: uniqueIndex('dns_security_events_provider_evt_uniq').on(table.integrationId, table.providerEventId)
+}));
+
+export const dnsPolicies = pgTable('dns_policies', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  integrationId: uuid('integration_id').notNull().references(() => dnsFilterIntegrations.id),
+  name: varchar('name', { length: 200 }).notNull(),
+  description: text('description'),
+  type: dnsPolicyTypeEnum('type').notNull(),
+  domains: jsonb('domains').$type<DnsPolicyDomain[]>().notNull().default([]),
+  categories: jsonb('categories').$type<string[]>().notNull().default([]),
+  syncStatus: dnsPolicySyncStatusEnum('sync_status').notNull().default('pending'),
+  lastSynced: timestamp('last_synced'),
+  syncError: text('sync_error'),
+  isActive: boolean('is_active').notNull().default(true),
+  createdBy: uuid('created_by').references(() => users.id),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull()
+}, (table) => ({
+  orgIdIdx: index('dns_policies_org_id_idx').on(table.orgId),
+  integrationIdIdx: index('dns_policies_integration_id_idx').on(table.integrationId)
+}));
+
+export const dnsEventAggregations = pgTable('dns_event_aggregations', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  date: date('date').notNull(),
+  integrationId: uuid('integration_id').references(() => dnsFilterIntegrations.id),
+  deviceId: uuid('device_id').references(() => devices.id),
+  domain: varchar('domain', { length: 500 }),
+  category: dnsThreatCategoryEnum('category'),
+  totalQueries: integer('total_queries').notNull().default(0),
+  blockedQueries: integer('blocked_queries').notNull().default(0),
+  allowedQueries: integer('allowed_queries').notNull().default(0)
+}, (table) => ({
+  orgDateIdx: index('dns_event_agg_org_date_idx').on(table.orgId, table.date),
+  orgDateIntegrationIdx: index('dns_event_agg_org_date_integration_idx').on(table.orgId, table.date, table.integrationId),
+  integrationIdIdx: index('dns_event_agg_integration_id_idx').on(table.integrationId),
+  deviceIdIdx: index('dns_event_agg_device_id_idx').on(table.deviceId)
+}));

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -35,3 +35,4 @@ export * from './filesystem';
 export * from './sessions';
 export * from './agentLogs';
 export * from './brainDeviceContext';
+export * from './dnsSecurity';

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -67,6 +67,7 @@ import { aiRoutes } from './routes/ai';
 import { mcpServerRoutes } from './routes/mcpServer';
 import { devPushRoutes } from './routes/devPush';
 import { helperRoutes } from './routes/helper';
+import { dnsSecurityRoutes } from './routes/dnsSecurity';
 
 // Workers
 import { initializeAlertWorkers, shutdownAlertWorkers } from './jobs/alertWorker';
@@ -82,6 +83,7 @@ import { initializePolicyEvaluationWorker, shutdownPolicyEvaluationWorker } from
 import { initializeAutomationWorker, shutdownAutomationWorker } from './jobs/automationWorker';
 import { initializeSecurityPostureWorker, shutdownSecurityPostureWorker } from './jobs/securityPostureWorker';
 import { initializePatchComplianceReportWorker, shutdownPatchComplianceReportWorker } from './jobs/patchComplianceReportWorker';
+import { initializeDnsSyncJob, shutdownDnsSyncJob } from './jobs/dnsSyncJob';
 import { initializePolicyAlertBridge } from './services/policyAlertBridge';
 import { getWebhookWorker, initializeWebhookDelivery } from './workers/webhookDelivery';
 import { initializeTransferCleanup, stopTransferCleanup } from './workers/transferCleanup';
@@ -276,7 +278,8 @@ const FALLBACK_AUDIT_PREFIXES = [
   '/viewers',
   '/devices',
   '/security',
-  '/system-tools'
+  '/system-tools',
+  '/dns-security'
 ];
 
 const FALLBACK_AUDIT_EXCLUDE_PATHS: RegExp[] = [
@@ -601,6 +604,7 @@ api.route('/ai', aiRoutes);
 api.route('/mcp', mcpServerRoutes);
 api.route('/dev', devPushRoutes);
 api.route('/helper', helperRoutes);
+api.route('/dns-security', dnsSecurityRoutes);
 
 app.route('/api/v1', api);
 
@@ -794,6 +798,7 @@ async function initializeWorkers(): Promise<void> {
     ['monitorWorker', initializeMonitorWorker],
     ['snmpRetention', initializeSnmpRetention],
     ['patchComplianceReportWorker', initializePatchComplianceReportWorker],
+    ['dnsSyncWorker', initializeDnsSyncJob],
   ];
 
   await Promise.allSettled(
@@ -878,6 +883,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
 
   const shutdownTasks: Array<() => Promise<void>> = [
     shutdownPatchComplianceReportWorker,
+    shutdownDnsSyncJob,
     shutdownSnmpRetention,
     shutdownMonitorWorker,
     shutdownSnmpWorker,

--- a/apps/api/src/jobs/dnsSyncJob.ts
+++ b/apps/api/src/jobs/dnsSyncJob.ts
@@ -1,0 +1,686 @@
+import { createHash } from 'node:crypto';
+import { Job, type JobsOptions, Queue, Worker } from 'bullmq';
+import { and, eq, isNotNull, lte, sql } from 'drizzle-orm';
+import * as dbModule from '../db';
+import {
+  dnsEventAggregations,
+  devices,
+  deviceNetwork,
+  dnsActionEnum,
+  dnsFilterIntegrations,
+  dnsPolicies,
+  dnsSecurityEvents,
+  dnsThreatCategoryEnum,
+  type DnsAction,
+  type DnsIntegrationConfig,
+  type DnsPolicyDomain,
+  type DnsThreatCategory
+} from '../db/schema';
+import { createDnsProvider, type DnsEvent } from '../services/dnsProviders';
+import { getRedisConnection } from '../services/redis';
+import { decryptSecret } from '../services/secretCrypto';
+
+const { db } = dbModule;
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const withSystem = dbModule.withSystemDbAccessContext;
+  return typeof withSystem === 'function' ? withSystem(fn) : fn();
+};
+
+const DNS_SYNC_QUEUE = 'dns-sync';
+const DEFAULT_SYNC_INTERVAL_MINUTES = 15;
+const MIN_SYNC_INTERVAL_MINUTES = 5;
+const MAX_SYNC_INTERVAL_MINUTES = 1440;
+
+const VALID_ACTIONS = new Set(dnsActionEnum.enumValues);
+const VALID_CATEGORIES = new Set(dnsThreatCategoryEnum.enumValues);
+const DATE_KEY_RE = /^(\d{4}-\d{2}-\d{2})/;
+
+interface SyncIntegrationJobData {
+  type: 'sync-integration';
+  integrationId: string;
+}
+
+interface SyncAllJobData {
+  type: 'sync-all';
+}
+
+interface PolicySyncOperation {
+  add: string[];
+  remove: string[];
+}
+
+interface SyncPolicyJobData {
+  type: 'sync-policy';
+  policyId: string;
+  operations?: PolicySyncOperation;
+}
+
+type DnsSyncJobData = SyncIntegrationJobData | SyncAllJobData | SyncPolicyJobData;
+
+let dnsSyncQueue: Queue<DnsSyncJobData> | null = null;
+let dnsSyncWorker: Worker<DnsSyncJobData> | null = null;
+
+interface EventAggregationDelta {
+  orgId: string;
+  date: string;
+  integrationId: string | null;
+  deviceId: string | null;
+  domain: string | null;
+  category: DnsThreatCategory | null;
+  totalQueries: number;
+  blockedQueries: number;
+  allowedQueries: number;
+}
+
+export function getDnsSyncQueue(): Queue<DnsSyncJobData> {
+  if (!dnsSyncQueue) {
+    dnsSyncQueue = new Queue<DnsSyncJobData>(DNS_SYNC_QUEUE, {
+      connection: getRedisConnection()
+    });
+  }
+  return dnsSyncQueue;
+}
+
+function parseIntegrationConfig(value: unknown): DnsIntegrationConfig {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  return value as DnsIntegrationConfig;
+}
+
+function normalizeDomain(domain: unknown): string | null {
+  if (typeof domain !== 'string') return null;
+  const normalized = domain.trim().toLowerCase().replace(/\.$/, '');
+  if (!normalized || normalized.length > 500) return null;
+  return normalized;
+}
+
+function normalizeAction(action: unknown): DnsAction {
+  if (typeof action === 'string' && VALID_ACTIONS.has(action as DnsAction)) {
+    return action as DnsAction;
+  }
+  const normalized = typeof action === 'string' ? action.toLowerCase() : '';
+  if (normalized.includes('block')) return 'blocked';
+  if (normalized.includes('redirect')) return 'redirected';
+  return 'allowed';
+}
+
+function normalizeThreatCategory(value: unknown): DnsThreatCategory | null {
+  if (typeof value !== 'string' || !value.trim()) return null;
+
+  const normalized = value.trim().toLowerCase().replace(/\s+/g, '_').replace(/-/g, '_');
+  if (VALID_CATEGORIES.has(normalized as DnsThreatCategory)) {
+    return normalized as DnsThreatCategory;
+  }
+
+  if (normalized.includes('phish')) return 'phishing';
+  if (normalized.includes('malware')) return 'malware';
+  if (normalized.includes('bot')) return 'botnet';
+  if (normalized.includes('ransom')) return 'ransomware';
+  if (normalized.includes('crypto')) return 'cryptomining';
+  if (normalized.includes('spam')) return 'spam';
+  if (normalized.includes('ad')) return 'adware';
+  if (normalized.includes('adult')) return 'adult_content';
+  if (normalized.includes('gambl')) return 'gambling';
+  if (normalized.includes('social')) return 'social_media';
+  if (normalized.includes('stream')) return 'streaming';
+
+  return 'unknown';
+}
+
+function normalizeQueryType(value: unknown): string {
+  if (typeof value !== 'string') return 'A';
+  const normalized = value.trim().toUpperCase();
+  return normalized.length > 0 ? normalized.slice(0, 10) : 'A';
+}
+
+function normalizeSourceIp(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  return normalized.length > 0 && normalized.length <= 45 ? normalized : null;
+}
+
+function normalizeSourceHost(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized.slice(0, 255) : null;
+}
+
+function normalizeThreatType(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized.slice(0, 100) : null;
+}
+
+function createFallbackProviderEventId(integrationId: string, event: DnsEvent): string {
+  const seed = [
+    integrationId,
+    event.timestamp.toISOString(),
+    event.domain,
+    event.queryType,
+    event.action,
+    event.sourceIp ?? '',
+    event.sourceHostname ?? ''
+  ].join('|');
+  return createHash('sha256').update(seed).digest('hex').slice(0, 48);
+}
+
+function normalizePolicyDomains(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const output: string[] = [];
+
+  for (const item of value) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
+    const domain = normalizeDomain((item as DnsPolicyDomain).domain);
+    if (!domain || seen.has(domain)) continue;
+    seen.add(domain);
+    output.push(domain);
+  }
+
+  return output;
+}
+
+function normalizeDomainList(domains: string[] | undefined): string[] {
+  if (!Array.isArray(domains)) return [];
+  const seen = new Set<string>();
+  const output: string[] = [];
+  for (const domain of domains) {
+    const normalized = normalizeDomain(domain);
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    output.push(normalized);
+  }
+  return output;
+}
+
+function toDateKey(value: Date): string {
+  const iso = value.toISOString();
+  const match = DATE_KEY_RE.exec(iso);
+  return match?.[1] ?? iso.slice(0, 10);
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  if (items.length === 0) return [];
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+function syncIntervalMinutesFromConfig(config: DnsIntegrationConfig): number {
+  const configured = Number(config.syncInterval);
+  if (!Number.isFinite(configured)) return DEFAULT_SYNC_INTERVAL_MINUTES;
+  return Math.min(MAX_SYNC_INTERVAL_MINUTES, Math.max(MIN_SYNC_INTERVAL_MINUTES, Math.round(configured)));
+}
+
+async function addUniqueJob(
+  queue: Queue<DnsSyncJobData>,
+  name: string,
+  data: DnsSyncJobData,
+  jobId: string,
+  opts: Omit<JobsOptions, 'jobId'> = {}
+): Promise<string> {
+  const existing = await queue.getJob(jobId);
+  if (existing) {
+    const state = await existing.getState();
+    if (
+      state === 'active'
+      || state === 'waiting'
+      || state === 'delayed'
+      || state === 'waiting-children'
+      || state === 'prioritized'
+    ) {
+      return String(existing.id);
+    }
+    await existing.remove().catch(() => undefined);
+  }
+
+  const job = await queue.add(name, data, {
+    jobId,
+    ...opts
+  });
+  return String(job.id);
+}
+
+async function persistAggregationDeltas(deltas: EventAggregationDelta[]): Promise<void> {
+  if (deltas.length === 0) return;
+  for (const batch of chunk(deltas, 500)) {
+    await db.insert(dnsEventAggregations).values(batch);
+  }
+}
+
+async function mapDevicesByIp(orgId: string): Promise<Map<string, string>> {
+  const rows = await db
+    .select({
+      deviceId: deviceNetwork.deviceId,
+      ipAddress: deviceNetwork.ipAddress
+    })
+    .from(deviceNetwork)
+    .innerJoin(devices, eq(deviceNetwork.deviceId, devices.id))
+    .where(
+      and(
+        eq(devices.orgId, orgId),
+        isNotNull(deviceNetwork.ipAddress)
+      )
+    );
+
+  const byIp = new Map<string, string>();
+  for (const row of rows) {
+    if (!row.ipAddress) continue;
+    byIp.set(row.ipAddress, row.deviceId);
+  }
+  return byIp;
+}
+
+export async function scheduleDnsEventSync(integrationId?: string): Promise<string> {
+  const queue = getDnsSyncQueue();
+  if (integrationId) {
+    return addUniqueJob(
+      queue,
+      'sync-integration',
+      { type: 'sync-integration', integrationId },
+      `sync-integration:${integrationId}`,
+      { removeOnComplete: true, removeOnFail: true }
+    );
+  }
+
+  return addUniqueJob(
+    queue,
+    'sync-all',
+    { type: 'sync-all' },
+    'sync-all:manual',
+    { removeOnComplete: true, removeOnFail: true }
+  );
+}
+
+export async function schedulePolicySync(
+  policyId: string,
+  operations?: Partial<PolicySyncOperation>
+): Promise<string> {
+  const queue = getDnsSyncQueue();
+  return addUniqueJob(
+    queue,
+    'sync-policy',
+    {
+      type: 'sync-policy',
+      policyId,
+      operations: operations
+        ? {
+          add: normalizeDomainList(operations.add),
+          remove: normalizeDomainList(operations.remove)
+        }
+        : undefined
+    },
+    `sync-policy:${policyId}`,
+    { removeOnComplete: true, removeOnFail: true }
+  );
+}
+
+async function processSyncAll(): Promise<{ queued: number }> {
+  const queue = getDnsSyncQueue();
+  const now = Date.now();
+
+  const integrations = await db
+    .select({
+      id: dnsFilterIntegrations.id,
+      lastSync: dnsFilterIntegrations.lastSync,
+      config: dnsFilterIntegrations.config
+    })
+    .from(dnsFilterIntegrations)
+    .where(eq(dnsFilterIntegrations.isActive, true));
+
+  const dueIntegrations = integrations.filter((integration) => {
+    const config = parseIntegrationConfig(integration.config);
+    const intervalMinutes = syncIntervalMinutesFromConfig(config);
+    if (!integration.lastSync) return true;
+    const elapsedMs = now - integration.lastSync.getTime();
+    return elapsedMs >= intervalMinutes * 60 * 1000;
+  });
+
+  if (dueIntegrations.length === 0) {
+    return { queued: 0 };
+  }
+
+  await Promise.all(
+    dueIntegrations.map((integration) => addUniqueJob(
+      queue,
+      'sync-integration',
+      { type: 'sync-integration', integrationId: integration.id },
+      `sync-integration:${integration.id}`,
+      { removeOnComplete: true, removeOnFail: true }
+    ))
+  );
+
+  return { queued: dueIntegrations.length };
+}
+
+async function processSyncIntegration(data: SyncIntegrationJobData): Promise<{
+  integrationId: string;
+  fetched: number;
+  inserted: number;
+}> {
+  const [integration] = await db
+    .select()
+    .from(dnsFilterIntegrations)
+    .where(eq(dnsFilterIntegrations.id, data.integrationId))
+    .limit(1);
+
+  if (!integration || !integration.isActive) {
+    return { integrationId: data.integrationId, fetched: 0, inserted: 0 };
+  }
+
+  const config = parseIntegrationConfig(integration.config);
+
+  try {
+    const provider = createDnsProvider({
+      provider: integration.provider,
+      apiKey: decryptSecret(integration.apiKey),
+      apiSecret: decryptSecret(integration.apiSecret),
+      config
+    });
+
+    const since = integration.lastSync
+      ? new Date(integration.lastSync.getTime() - 60 * 1000)
+      : new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const until = new Date();
+
+    const events = await provider.syncEvents(since, until);
+    const categoriesFilter = new Set(
+      (config.categories ?? [])
+        .map((item) => normalizeThreatCategory(item))
+        .filter((item): item is DnsThreatCategory => item !== null)
+    );
+    const devicesByIp = await mapDevicesByIp(integration.orgId);
+
+    const values = events.flatMap((event) => {
+      const domain = normalizeDomain(event.domain);
+      if (!domain) return [];
+
+      const action = normalizeAction(event.action);
+      const category = normalizeThreatCategory(event.category);
+
+      if (categoriesFilter.size > 0) {
+        if (!category || !categoriesFilter.has(category)) {
+          return [];
+        }
+      }
+
+      const sourceIp = normalizeSourceIp(event.sourceIp);
+      const deviceId = sourceIp ? (devicesByIp.get(sourceIp) ?? null) : null;
+
+      return [{
+        orgId: integration.orgId,
+        integrationId: integration.id,
+        deviceId,
+        timestamp: event.timestamp,
+        domain,
+        queryType: normalizeQueryType(event.queryType),
+        action,
+        category,
+        threatType: normalizeThreatType(event.threatType),
+        sourceIp,
+        sourceHostname: normalizeSourceHost(event.sourceHostname),
+        providerEventId: normalizeSourceHost(event.providerEventId) ?? createFallbackProviderEventId(integration.id, event),
+        metadata: event.metadata ?? null
+      }];
+    });
+
+    let insertedCount = 0;
+    const aggregationMap = new Map<string, EventAggregationDelta>();
+
+    for (const batch of chunk(values, 500)) {
+      const inserted = await db
+        .insert(dnsSecurityEvents)
+        .values(batch)
+        .onConflictDoNothing({
+          target: [dnsSecurityEvents.integrationId, dnsSecurityEvents.providerEventId]
+        })
+        .returning({
+          orgId: dnsSecurityEvents.orgId,
+          integrationId: dnsSecurityEvents.integrationId,
+          deviceId: dnsSecurityEvents.deviceId,
+          timestamp: dnsSecurityEvents.timestamp,
+          domain: dnsSecurityEvents.domain,
+          category: dnsSecurityEvents.category,
+          action: dnsSecurityEvents.action
+        });
+
+      insertedCount += inserted.length;
+
+      for (const row of inserted) {
+        const day = toDateKey(row.timestamp);
+        const category = row.category as DnsThreatCategory | null;
+        const key = [
+          row.orgId,
+          day,
+          row.integrationId ?? '',
+          row.deviceId ?? '',
+          row.domain ?? '',
+          category ?? ''
+        ].join('|');
+
+        const current = aggregationMap.get(key) ?? {
+          orgId: row.orgId,
+          date: day,
+          integrationId: row.integrationId,
+          deviceId: row.deviceId,
+          domain: row.domain,
+          category,
+          totalQueries: 0,
+          blockedQueries: 0,
+          allowedQueries: 0
+        };
+
+        current.totalQueries += 1;
+        if (row.action === 'blocked') current.blockedQueries += 1;
+        if (row.action === 'allowed') current.allowedQueries += 1;
+        aggregationMap.set(key, current);
+      }
+    }
+
+    await persistAggregationDeltas(Array.from(aggregationMap.values()));
+
+    const retentionDays = Number(config.retentionDays);
+    if (Number.isFinite(retentionDays) && retentionDays > 0) {
+      const cutoff = new Date(Date.now() - Math.round(retentionDays) * 24 * 60 * 60 * 1000);
+      await db
+        .delete(dnsSecurityEvents)
+        .where(
+          and(
+            eq(dnsSecurityEvents.integrationId, integration.id),
+            lte(dnsSecurityEvents.timestamp, cutoff)
+          )
+        );
+    }
+
+    await db
+      .update(dnsFilterIntegrations)
+      .set({
+        lastSync: until,
+        lastSyncStatus: 'success',
+        lastSyncError: null,
+        totalEventsProcessed: sql`${dnsFilterIntegrations.totalEventsProcessed} + ${insertedCount}`,
+        updatedAt: new Date()
+      })
+      .where(eq(dnsFilterIntegrations.id, integration.id));
+
+    return {
+      integrationId: integration.id,
+      fetched: events.length,
+      inserted: insertedCount
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await db
+      .update(dnsFilterIntegrations)
+      .set({
+        lastSyncStatus: 'error',
+        lastSyncError: message.slice(0, 2000),
+        updatedAt: new Date()
+      })
+      .where(eq(dnsFilterIntegrations.id, integration.id));
+    throw error;
+  }
+}
+
+async function processPolicySync(data: SyncPolicyJobData): Promise<{
+  policyId: string;
+  added: number;
+  removed: number;
+}> {
+  const [row] = await db
+    .select({
+      policy: dnsPolicies,
+      integration: dnsFilterIntegrations
+    })
+    .from(dnsPolicies)
+    .innerJoin(dnsFilterIntegrations, eq(dnsPolicies.integrationId, dnsFilterIntegrations.id))
+    .where(eq(dnsPolicies.id, data.policyId))
+    .limit(1);
+
+  if (!row) {
+    return { policyId: data.policyId, added: 0, removed: 0 };
+  }
+
+  const config = parseIntegrationConfig(row.integration.config);
+
+  try {
+    const provider = createDnsProvider({
+      provider: row.integration.provider,
+      apiKey: decryptSecret(row.integration.apiKey),
+      apiSecret: decryptSecret(row.integration.apiSecret),
+      config
+    });
+
+    const addDomains = data.operations
+      ? normalizeDomainList(data.operations.add)
+      : normalizePolicyDomains(row.policy.domains);
+    const removeDomains = data.operations
+      ? normalizeDomainList(data.operations.remove)
+      : [];
+
+    const runBatched = async (
+      domains: string[],
+      operation: (domain: string) => Promise<void>,
+      concurrency = 10
+    ): Promise<void> => {
+      if (domains.length === 0) return;
+      for (let i = 0; i < domains.length; i += concurrency) {
+        const block = domains.slice(i, i + concurrency);
+        await Promise.all(block.map(operation));
+      }
+    };
+
+    if (row.policy.type === 'blocklist') {
+      await runBatched(addDomains, (domain) => provider.addBlocklistDomain(domain), 10);
+      await runBatched(removeDomains, (domain) => provider.removeBlocklistDomain(domain), 10);
+    } else {
+      await runBatched(addDomains, (domain) => provider.addAllowlistDomain(domain), 10);
+      await runBatched(removeDomains, (domain) => provider.removeAllowlistDomain(domain), 10);
+    }
+
+    await db
+      .update(dnsPolicies)
+      .set({
+        syncStatus: 'synced',
+        lastSynced: new Date(),
+        syncError: null,
+        updatedAt: new Date()
+      })
+      .where(eq(dnsPolicies.id, row.policy.id));
+
+    return {
+      policyId: row.policy.id,
+      added: addDomains.length,
+      removed: removeDomains.length
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await db
+      .update(dnsPolicies)
+      .set({
+        syncStatus: 'error',
+        syncError: message.slice(0, 2000),
+        updatedAt: new Date()
+      })
+      .where(eq(dnsPolicies.id, row.policy.id));
+    throw error;
+  }
+}
+
+function createDnsSyncWorker(): Worker<DnsSyncJobData> {
+  return new Worker<DnsSyncJobData>(
+    DNS_SYNC_QUEUE,
+    async (job: Job<DnsSyncJobData>) => {
+      return runWithSystemDbAccess(async () => {
+        switch (job.data.type) {
+          case 'sync-all':
+            return processSyncAll();
+          case 'sync-integration':
+            return processSyncIntegration(job.data);
+          case 'sync-policy':
+            return processPolicySync(job.data);
+          default:
+            throw new Error(`Unknown DNS sync job type: ${(job.data as { type: string }).type}`);
+        }
+      });
+    },
+    {
+      connection: getRedisConnection(),
+      concurrency: 4
+    }
+  );
+}
+
+async function scheduleRepeatSyncAllJob(): Promise<void> {
+  const queue = getDnsSyncQueue();
+  const repeatables = await queue.getRepeatableJobs();
+  for (const repeatable of repeatables) {
+    if (repeatable.name === 'sync-all') {
+      await queue.removeRepeatableByKey(repeatable.key);
+    }
+  }
+
+  await queue.add(
+    'sync-all',
+    { type: 'sync-all' },
+    {
+      repeat: { every: DEFAULT_SYNC_INTERVAL_MINUTES * 60 * 1000 },
+      removeOnComplete: { count: 10 },
+      removeOnFail: { count: 20 }
+    }
+  );
+}
+
+export async function initializeDnsSyncJob(): Promise<void> {
+  dnsSyncWorker = createDnsSyncWorker();
+
+  dnsSyncWorker.on('error', (error) => {
+    console.error('[DnsSyncJob] Worker error:', error);
+  });
+
+  dnsSyncWorker.on('failed', (job, error) => {
+    console.error(`[DnsSyncJob] Job ${job?.id} failed:`, error);
+  });
+
+  await scheduleRepeatSyncAllJob();
+  await scheduleDnsEventSync();
+
+  console.log('[DnsSyncJob] DNS sync worker initialized');
+}
+
+export async function shutdownDnsSyncJob(): Promise<void> {
+  if (dnsSyncWorker) {
+    await dnsSyncWorker.close();
+    dnsSyncWorker = null;
+  }
+
+  if (dnsSyncQueue) {
+    await dnsSyncQueue.close();
+    dnsSyncQueue = null;
+  }
+
+  console.log('[DnsSyncJob] DNS sync worker shut down');
+}

--- a/apps/api/src/routes/dnsSecurity.ts
+++ b/apps/api/src/routes/dnsSecurity.ts
@@ -1,0 +1,1023 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
+import { and, desc, eq, gte, ilike, lte, sql, type SQL } from 'drizzle-orm';
+import { db } from '../db';
+import {
+  devices,
+  dnsActionEnum,
+  dnsEventAggregations,
+  dnsFilterIntegrations,
+  dnsPolicies,
+  dnsProviderEnum,
+  dnsSecurityEvents,
+  dnsThreatCategoryEnum,
+  type DnsIntegrationConfig,
+  type DnsPolicyDomain
+} from '../db/schema';
+import { authMiddleware, requireScope, type AuthContext } from '../middleware/auth';
+import { scheduleDnsEventSync, schedulePolicySync } from '../jobs/dnsSyncJob';
+import { writeRouteAudit } from '../services/auditEvents';
+import { encryptSecret } from '../services/secretCrypto';
+
+const dnsSecurityRoutes = new Hono();
+
+dnsSecurityRoutes.use('*', authMiddleware);
+
+const MAX_QUERY_WINDOW_DAYS = 90;
+const AGGREGATION_MIN_DAYS = 7;
+
+function normalizeDomain(domain: unknown): string | null {
+  if (typeof domain !== 'string') return null;
+  const normalized = domain.trim().toLowerCase().replace(/\.$/, '');
+  if (!normalized || normalized.length > 500) return null;
+  return normalized;
+}
+
+function parseDateOrNull(value: string | undefined): Date | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function toDateKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function validateTimeWindow(start: Date | null, end: Date | null): string | null {
+  if (!start || !end) return null;
+  if (start.getTime() > end.getTime()) {
+    return 'start must be before or equal to end';
+  }
+  const maxWindowMs = MAX_QUERY_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+  if ((end.getTime() - start.getTime()) > maxWindowMs) {
+    return `Time range cannot exceed ${MAX_QUERY_WINDOW_DAYS} days`;
+  }
+  return null;
+}
+
+function shouldUseAggregations(start: Date | null, end: Date | null): boolean {
+  if (!start || !end) return false;
+  const diffMs = end.getTime() - start.getTime();
+  return diffMs > AGGREGATION_MIN_DAYS * 24 * 60 * 60 * 1000;
+}
+
+function withOrgCondition(conditions: SQL[], condition: SQL | undefined): SQL[] {
+  if (condition) conditions.push(condition);
+  return conditions;
+}
+
+function whereOrUndefined(conditions: SQL[]): SQL | undefined {
+  return conditions.length > 0 ? and(...conditions) : undefined;
+}
+
+function resolveOrgId(
+  auth: Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds' | 'canAccessOrg'>,
+  requestedOrgId?: string
+): { orgId: string } | { error: string; status: 400 | 403 } {
+  if (auth.scope === 'organization') {
+    if (!auth.orgId) {
+      return { error: 'Organization context required', status: 403 };
+    }
+    if (requestedOrgId && requestedOrgId !== auth.orgId) {
+      return { error: 'Access to this organization denied', status: 403 };
+    }
+    return { orgId: auth.orgId };
+  }
+
+  if (requestedOrgId) {
+    if (!auth.canAccessOrg(requestedOrgId)) {
+      return { error: 'Access to this organization denied', status: 403 };
+    }
+    return { orgId: requestedOrgId };
+  }
+
+  if (auth.orgId) {
+    return { orgId: auth.orgId };
+  }
+
+  const orgIds = auth.accessibleOrgIds ?? [];
+  if (orgIds.length === 1 && orgIds[0]) {
+    return { orgId: orgIds[0] };
+  }
+
+  return { error: 'orgId is required for this scope', status: 400 };
+}
+
+const integrationConfigSchema = z.object({
+  organizationId: z.string().min(1).optional(),
+  accountId: z.string().min(1).optional(),
+  apiEndpoint: z.string().url().optional(),
+  syncInterval: z.number().int().min(5).max(1440).optional(),
+  retentionDays: z.number().int().min(1).max(365).optional(),
+  categories: z.array(z.string().min(1).max(100)).max(100).optional(),
+  blocklistId: z.string().min(1).optional(),
+  allowlistId: z.string().min(1).optional()
+});
+
+const createIntegrationSchema = z.object({
+  orgId: z.string().uuid().optional(),
+  provider: z.enum(dnsProviderEnum.enumValues),
+  name: z.string().min(1).max(200),
+  description: z.string().max(2000).optional(),
+  apiKey: z.string().min(1).max(5000),
+  apiSecret: z.string().max(5000).optional(),
+  config: integrationConfigSchema.optional(),
+  isActive: z.boolean().optional()
+}).superRefine((data, ctx) => {
+  if (data.provider === 'umbrella') {
+    if (!data.apiSecret) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['apiSecret'],
+        message: 'apiSecret is required for Cisco Umbrella'
+      });
+    }
+    if (!data.config?.organizationId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['config', 'organizationId'],
+        message: 'organizationId is required for Cisco Umbrella'
+      });
+    }
+  }
+
+  if (data.provider === 'cloudflare' && !data.config?.accountId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['config', 'accountId'],
+      message: 'accountId is required for Cloudflare Gateway'
+    });
+  }
+
+  if (data.provider === 'pihole' && !data.config?.apiEndpoint) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['config', 'apiEndpoint'],
+      message: 'apiEndpoint is required for Pi-hole'
+    });
+  }
+});
+
+const listEventsQuerySchema = z.object({
+  start: z.string().optional(),
+  end: z.string().optional(),
+  action: z.enum(dnsActionEnum.enumValues).optional(),
+  category: z.enum(dnsThreatCategoryEnum.enumValues).optional(),
+  domain: z.string().max(500).optional(),
+  deviceId: z.string().uuid().optional(),
+  integrationId: z.string().uuid().optional(),
+  limit: z.coerce.number().int().min(1).max(500).optional(),
+  offset: z.coerce.number().int().min(0).optional()
+});
+
+const statsQuerySchema = z.object({
+  start: z.string().optional(),
+  end: z.string().optional(),
+  integrationId: z.string().uuid().optional(),
+  deviceId: z.string().uuid().optional(),
+  action: z.enum(dnsActionEnum.enumValues).optional(),
+  category: z.enum(dnsThreatCategoryEnum.enumValues).optional(),
+  topN: z.coerce.number().int().min(1).max(100).optional()
+});
+
+const topBlockedQuerySchema = z.object({
+  start: z.string().optional(),
+  end: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional()
+});
+
+const createPolicySchema = z.object({
+  orgId: z.string().uuid().optional(),
+  integrationId: z.string().uuid(),
+  name: z.string().min(1).max(200),
+  description: z.string().max(2000).optional(),
+  type: z.enum(['blocklist', 'allowlist']),
+  domains: z.array(z.object({
+    domain: z.string().min(1).max(500),
+    reason: z.string().max(2000).optional()
+  })).max(500).optional(),
+  categories: z.array(z.enum(dnsThreatCategoryEnum.enumValues)).max(50).optional(),
+  isActive: z.boolean().optional()
+});
+
+const patchPolicyDomainsSchema = z.object({
+  add: z.array(z.object({
+    domain: z.string().min(1).max(500),
+    reason: z.string().max(2000).optional()
+  })).max(500).optional(),
+  remove: z.array(z.string().min(1).max(500)).max(500).optional()
+}).superRefine((data, ctx) => {
+  const addCount = data.add?.length ?? 0;
+  const removeCount = data.remove?.length ?? 0;
+  if (addCount + removeCount === 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'At least one domain must be provided in add or remove'
+    });
+  }
+});
+
+dnsSecurityRoutes.get(
+  '/integrations',
+  requireScope('organization', 'partner', 'system'),
+  async (c) => {
+    const auth = c.get('auth');
+
+    const conditions: SQL[] = [];
+    withOrgCondition(conditions, auth.orgCondition(dnsFilterIntegrations.orgId));
+
+    const integrations = await db
+      .select({
+        id: dnsFilterIntegrations.id,
+        orgId: dnsFilterIntegrations.orgId,
+        provider: dnsFilterIntegrations.provider,
+        name: dnsFilterIntegrations.name,
+        description: dnsFilterIntegrations.description,
+        config: dnsFilterIntegrations.config,
+        isActive: dnsFilterIntegrations.isActive,
+        lastSync: dnsFilterIntegrations.lastSync,
+        lastSyncStatus: dnsFilterIntegrations.lastSyncStatus,
+        lastSyncError: dnsFilterIntegrations.lastSyncError,
+        totalEventsProcessed: dnsFilterIntegrations.totalEventsProcessed,
+        createdAt: dnsFilterIntegrations.createdAt,
+        updatedAt: dnsFilterIntegrations.updatedAt
+      })
+      .from(dnsFilterIntegrations)
+      .where(whereOrUndefined(conditions))
+      .orderBy(desc(dnsFilterIntegrations.createdAt));
+
+    return c.json({ data: integrations });
+  }
+);
+
+dnsSecurityRoutes.post(
+  '/integrations',
+  requireScope('organization', 'partner', 'system'),
+  zValidator('json', createIntegrationSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const body = c.req.valid('json');
+
+    const orgResult = resolveOrgId(auth, body.orgId);
+    if ('error' in orgResult) {
+      return c.json({ error: orgResult.error }, orgResult.status);
+    }
+
+    const [integration] = await db
+      .insert(dnsFilterIntegrations)
+      .values({
+        orgId: orgResult.orgId,
+        provider: body.provider,
+        name: body.name,
+        description: body.description,
+        apiKey: encryptSecret(body.apiKey),
+        apiSecret: encryptSecret(body.apiSecret),
+        config: (body.config ?? {}) as DnsIntegrationConfig,
+        isActive: body.isActive ?? true,
+        createdBy: auth.user.id
+      })
+      .returning({
+        id: dnsFilterIntegrations.id,
+        orgId: dnsFilterIntegrations.orgId,
+        name: dnsFilterIntegrations.name,
+        provider: dnsFilterIntegrations.provider
+      });
+
+    if (!integration) {
+      return c.json({ error: 'Failed to create integration' }, 500);
+    }
+
+    let syncScheduled = false;
+    let warning: string | undefined;
+
+    try {
+      await scheduleDnsEventSync(integration.id);
+      syncScheduled = true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      warning = `Integration created but initial sync scheduling failed: ${message}`;
+      console.error('[dns-security] Initial sync scheduling failed:', error);
+    }
+
+    writeRouteAudit(c, {
+      orgId: integration.orgId,
+      action: 'dns.integration.create',
+      resourceType: 'dns_integration',
+      resourceId: integration.id,
+      resourceName: integration.name,
+      details: { provider: integration.provider, syncScheduled }
+    });
+
+    return c.json({
+      id: integration.id,
+      orgId: integration.orgId,
+      provider: integration.provider,
+      name: integration.name,
+      syncScheduled,
+      warning
+    }, 201);
+  }
+);
+
+dnsSecurityRoutes.delete(
+  '/integrations/:id',
+  requireScope('organization', 'partner', 'system'),
+  async (c) => {
+    const auth = c.get('auth');
+    const integrationId = c.req.param('id');
+
+    const conditions: SQL[] = [eq(dnsFilterIntegrations.id, integrationId)];
+    withOrgCondition(conditions, auth.orgCondition(dnsFilterIntegrations.orgId));
+
+    const [integration] = await db
+      .select({
+        id: dnsFilterIntegrations.id,
+        orgId: dnsFilterIntegrations.orgId,
+        name: dnsFilterIntegrations.name
+      })
+      .from(dnsFilterIntegrations)
+      .where(and(...conditions))
+      .limit(1);
+
+    if (!integration) {
+      return c.json({ error: 'Integration not found' }, 404);
+    }
+
+    await db.transaction(async (tx) => {
+      await tx.delete(dnsPolicies).where(eq(dnsPolicies.integrationId, integration.id));
+      await tx.delete(dnsSecurityEvents).where(eq(dnsSecurityEvents.integrationId, integration.id));
+      await tx.delete(dnsFilterIntegrations).where(eq(dnsFilterIntegrations.id, integration.id));
+    });
+
+    writeRouteAudit(c, {
+      orgId: integration.orgId,
+      action: 'dns.integration.delete',
+      resourceType: 'dns_integration',
+      resourceId: integration.id,
+      resourceName: integration.name
+    });
+
+    return c.json({ success: true });
+  }
+);
+
+dnsSecurityRoutes.post(
+  '/integrations/:id/sync',
+  requireScope('organization', 'partner', 'system'),
+  async (c) => {
+    const auth = c.get('auth');
+    const integrationId = c.req.param('id');
+
+    const conditions: SQL[] = [eq(dnsFilterIntegrations.id, integrationId)];
+    withOrgCondition(conditions, auth.orgCondition(dnsFilterIntegrations.orgId));
+
+    const [integration] = await db
+      .select({
+        id: dnsFilterIntegrations.id,
+        orgId: dnsFilterIntegrations.orgId
+      })
+      .from(dnsFilterIntegrations)
+      .where(and(...conditions))
+      .limit(1);
+
+    if (!integration) {
+      return c.json({ error: 'Integration not found' }, 404);
+    }
+
+    const jobId = await scheduleDnsEventSync(integration.id);
+    return c.json({ success: true, jobId });
+  }
+);
+
+dnsSecurityRoutes.get(
+  '/events',
+  requireScope('organization', 'partner', 'system'),
+  zValidator('query', listEventsQuerySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const query = c.req.valid('query');
+
+    const start = parseDateOrNull(query.start);
+    if (query.start && !start) {
+      return c.json({ error: 'Invalid start date' }, 400);
+    }
+
+    const end = parseDateOrNull(query.end);
+    if (query.end && !end) {
+      return c.json({ error: 'Invalid end date' }, 400);
+    }
+
+    const windowError = validateTimeWindow(start, end);
+    if (windowError) {
+      return c.json({ error: windowError }, 400);
+    }
+
+    const conditions: SQL[] = [];
+    withOrgCondition(conditions, auth.orgCondition(dnsSecurityEvents.orgId));
+    if (start) conditions.push(gte(dnsSecurityEvents.timestamp, start));
+    if (end) conditions.push(lte(dnsSecurityEvents.timestamp, end));
+    if (query.action) conditions.push(eq(dnsSecurityEvents.action, query.action));
+    if (query.category) conditions.push(eq(dnsSecurityEvents.category, query.category));
+    if (query.deviceId) conditions.push(eq(dnsSecurityEvents.deviceId, query.deviceId));
+    if (query.integrationId) conditions.push(eq(dnsSecurityEvents.integrationId, query.integrationId));
+    if (query.domain) conditions.push(ilike(dnsSecurityEvents.domain, `%${query.domain}%`));
+
+    const limit = query.limit ?? 100;
+    const offset = query.offset ?? 0;
+    const where = whereOrUndefined(conditions);
+
+    const [events, totalRows] = await Promise.all([
+      db
+        .select({
+          id: dnsSecurityEvents.id,
+          orgId: dnsSecurityEvents.orgId,
+          integrationId: dnsSecurityEvents.integrationId,
+          deviceId: dnsSecurityEvents.deviceId,
+          timestamp: dnsSecurityEvents.timestamp,
+          domain: dnsSecurityEvents.domain,
+          queryType: dnsSecurityEvents.queryType,
+          action: dnsSecurityEvents.action,
+          category: dnsSecurityEvents.category,
+          threatType: dnsSecurityEvents.threatType,
+          sourceIp: dnsSecurityEvents.sourceIp,
+          sourceHostname: dnsSecurityEvents.sourceHostname,
+          providerEventId: dnsSecurityEvents.providerEventId,
+          metadata: dnsSecurityEvents.metadata,
+          deviceHostname: devices.hostname
+        })
+        .from(dnsSecurityEvents)
+        .leftJoin(devices, eq(dnsSecurityEvents.deviceId, devices.id))
+        .where(where)
+        .orderBy(desc(dnsSecurityEvents.timestamp))
+        .limit(limit)
+        .offset(offset),
+      db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(dnsSecurityEvents)
+        .where(where)
+    ]);
+
+    return c.json({
+      data: events,
+      pagination: {
+        limit,
+        offset,
+        total: Number(totalRows[0]?.count ?? 0)
+      }
+    });
+  }
+);
+
+dnsSecurityRoutes.get(
+  '/stats',
+  requireScope('organization', 'partner', 'system'),
+  zValidator('query', statsQuerySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const query = c.req.valid('query');
+
+    const start = parseDateOrNull(query.start);
+    if (query.start && !start) {
+      return c.json({ error: 'Invalid start date' }, 400);
+    }
+
+    const end = parseDateOrNull(query.end);
+    if (query.end && !end) {
+      return c.json({ error: 'Invalid end date' }, 400);
+    }
+
+    const windowError = validateTimeWindow(start, end);
+    if (windowError) {
+      return c.json({ error: windowError }, 400);
+    }
+
+    const conditions: SQL[] = [];
+    withOrgCondition(conditions, auth.orgCondition(dnsSecurityEvents.orgId));
+    if (start) conditions.push(gte(dnsSecurityEvents.timestamp, start));
+    if (end) conditions.push(lte(dnsSecurityEvents.timestamp, end));
+    if (query.integrationId) conditions.push(eq(dnsSecurityEvents.integrationId, query.integrationId));
+    if (query.deviceId) conditions.push(eq(dnsSecurityEvents.deviceId, query.deviceId));
+    if (query.action) conditions.push(eq(dnsSecurityEvents.action, query.action));
+    if (query.category) conditions.push(eq(dnsSecurityEvents.category, query.category));
+
+    const topN = query.topN ?? 10;
+    const where = whereOrUndefined(conditions);
+
+    if (shouldUseAggregations(start, end)) {
+      const aggConditions: SQL[] = [];
+      withOrgCondition(aggConditions, auth.orgCondition(dnsEventAggregations.orgId));
+      if (start) aggConditions.push(gte(dnsEventAggregations.date, toDateKey(start)));
+      if (end) aggConditions.push(lte(dnsEventAggregations.date, toDateKey(end)));
+      if (query.integrationId) aggConditions.push(eq(dnsEventAggregations.integrationId, query.integrationId));
+      if (query.deviceId) aggConditions.push(eq(dnsEventAggregations.deviceId, query.deviceId));
+      if (query.category) aggConditions.push(eq(dnsEventAggregations.category, query.category));
+
+      const aggWhere = whereOrUndefined(aggConditions);
+      const [aggCountRow] = await db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(dnsEventAggregations)
+        .where(aggWhere);
+
+      if (Number(aggCountRow?.count ?? 0) > 0) {
+        const aggTopBlockedConditions = [
+          ...aggConditions,
+          sql`${dnsEventAggregations.blockedQueries} > 0`,
+          sql`${dnsEventAggregations.domain} is not null`
+        ];
+        const aggTopDevicesConditions = [
+          ...aggConditions,
+          sql`${dnsEventAggregations.blockedQueries} > 0`
+        ];
+        const topCategoryCountExpr: SQL<number> = query.action === 'blocked'
+          ? sql<number>`coalesce(sum(${dnsEventAggregations.blockedQueries}), 0)::int`
+          : query.action === 'allowed'
+            ? sql<number>`coalesce(sum(${dnsEventAggregations.allowedQueries}), 0)::int`
+            : query.action === 'redirected'
+              ? sql<number>`coalesce(sum(${dnsEventAggregations.totalQueries} - ${dnsEventAggregations.blockedQueries} - ${dnsEventAggregations.allowedQueries}), 0)::int`
+              : sql<number>`coalesce(sum(${dnsEventAggregations.totalQueries}), 0)::int`;
+
+        const [rawSummary, topBlockedDomains, topCategories, topDevices] = await Promise.all([
+          db
+            .select({
+              totalQueries: sql<number>`coalesce(sum(${dnsEventAggregations.totalQueries}), 0)::int`,
+              blockedQueries: sql<number>`coalesce(sum(${dnsEventAggregations.blockedQueries}), 0)::int`,
+              allowedQueries: sql<number>`coalesce(sum(${dnsEventAggregations.allowedQueries}), 0)::int`
+            })
+            .from(dnsEventAggregations)
+            .where(aggWhere),
+          query.action && query.action !== 'blocked'
+            ? Promise.resolve([])
+            : db
+              .select({
+                domain: dnsEventAggregations.domain,
+                category: dnsEventAggregations.category,
+                count: sql<number>`coalesce(sum(${dnsEventAggregations.blockedQueries}), 0)::int`
+              })
+              .from(dnsEventAggregations)
+              .where(and(...aggTopBlockedConditions))
+              .groupBy(dnsEventAggregations.domain, dnsEventAggregations.category)
+              .orderBy(desc(sql`coalesce(sum(${dnsEventAggregations.blockedQueries}), 0)`))
+              .limit(topN),
+          db
+            .select({
+              category: dnsEventAggregations.category,
+              count: topCategoryCountExpr
+            })
+            .from(dnsEventAggregations)
+            .where(and(...aggConditions, sql`${dnsEventAggregations.category} is not null`))
+            .groupBy(dnsEventAggregations.category)
+            .orderBy(desc(topCategoryCountExpr))
+            .limit(topN),
+          query.action && query.action !== 'blocked'
+            ? Promise.resolve([])
+            : db
+              .select({
+                deviceId: dnsEventAggregations.deviceId,
+                hostname: devices.hostname,
+                blockedCount: sql<number>`coalesce(sum(${dnsEventAggregations.blockedQueries}), 0)::int`
+              })
+              .from(dnsEventAggregations)
+              .leftJoin(devices, eq(dnsEventAggregations.deviceId, devices.id))
+              .where(and(...aggTopDevicesConditions))
+              .groupBy(dnsEventAggregations.deviceId, devices.hostname)
+              .orderBy(desc(sql`coalesce(sum(${dnsEventAggregations.blockedQueries}), 0)`))
+              .limit(topN)
+        ]);
+
+        const summaryBase = rawSummary[0] ?? {
+          totalQueries: 0,
+          blockedQueries: 0,
+          allowedQueries: 0
+        };
+        const redirectedFromTotals = Math.max(
+          0,
+          summaryBase.totalQueries - summaryBase.blockedQueries - summaryBase.allowedQueries
+        );
+
+        const summaryRow = query.action === 'blocked'
+          ? {
+            totalQueries: summaryBase.blockedQueries,
+            blockedQueries: summaryBase.blockedQueries,
+            allowedQueries: 0,
+            redirectedQueries: 0
+          }
+          : query.action === 'allowed'
+            ? {
+              totalQueries: summaryBase.allowedQueries,
+              blockedQueries: 0,
+              allowedQueries: summaryBase.allowedQueries,
+              redirectedQueries: 0
+            }
+            : query.action === 'redirected'
+              ? {
+                totalQueries: redirectedFromTotals,
+                blockedQueries: 0,
+                allowedQueries: 0,
+                redirectedQueries: redirectedFromTotals
+              }
+              : {
+                totalQueries: summaryBase.totalQueries,
+                blockedQueries: summaryBase.blockedQueries,
+                allowedQueries: summaryBase.allowedQueries,
+                redirectedQueries: redirectedFromTotals
+              };
+
+        const blockedRate = summaryRow.totalQueries > 0
+          ? Number(((summaryRow.blockedQueries / summaryRow.totalQueries) * 100).toFixed(2))
+          : 0;
+
+        return c.json({
+          summary: {
+            ...summaryRow,
+            blockedRate
+          },
+          topBlockedDomains,
+          topCategories,
+          topDevices,
+          source: 'aggregated'
+        });
+      }
+    }
+
+    const topBlockedConditions = [...conditions, eq(dnsSecurityEvents.action, 'blocked')];
+    const topCategoryConditions = [...conditions, sql`${dnsSecurityEvents.category} is not null`];
+    const topDeviceConditions = [...conditions, eq(dnsSecurityEvents.action, 'blocked')];
+
+    const [summary, topBlockedDomains, topCategories, topDevices] = await Promise.all([
+      db
+        .select({
+          totalQueries: sql<number>`count(*)::int`,
+          blockedQueries: sql<number>`sum(case when ${dnsSecurityEvents.action} = 'blocked' then 1 else 0 end)::int`,
+          allowedQueries: sql<number>`sum(case when ${dnsSecurityEvents.action} = 'allowed' then 1 else 0 end)::int`,
+          redirectedQueries: sql<number>`sum(case when ${dnsSecurityEvents.action} = 'redirected' then 1 else 0 end)::int`,
+        })
+        .from(dnsSecurityEvents)
+        .where(where),
+      db
+        .select({
+          domain: dnsSecurityEvents.domain,
+          category: dnsSecurityEvents.category,
+          count: sql<number>`count(*)::int`
+        })
+        .from(dnsSecurityEvents)
+        .where(and(...topBlockedConditions))
+        .groupBy(dnsSecurityEvents.domain, dnsSecurityEvents.category)
+        .orderBy(desc(sql`count(*)`))
+        .limit(topN),
+      db
+        .select({
+          category: dnsSecurityEvents.category,
+          count: sql<number>`count(*)::int`
+        })
+        .from(dnsSecurityEvents)
+        .where(and(...topCategoryConditions))
+        .groupBy(dnsSecurityEvents.category)
+        .orderBy(desc(sql`count(*)`))
+        .limit(topN),
+      db
+        .select({
+          deviceId: dnsSecurityEvents.deviceId,
+          hostname: devices.hostname,
+          blockedCount: sql<number>`count(*)::int`
+        })
+        .from(dnsSecurityEvents)
+        .leftJoin(devices, eq(dnsSecurityEvents.deviceId, devices.id))
+        .where(and(...topDeviceConditions))
+        .groupBy(dnsSecurityEvents.deviceId, devices.hostname)
+        .orderBy(desc(sql`count(*)`))
+        .limit(topN)
+    ]);
+
+    const summaryRow = summary[0] ?? {
+      totalQueries: 0,
+      blockedQueries: 0,
+      allowedQueries: 0,
+      redirectedQueries: 0
+    };
+    const blockedRate = summaryRow.totalQueries > 0
+      ? Number(((summaryRow.blockedQueries / summaryRow.totalQueries) * 100).toFixed(2))
+      : 0;
+
+    return c.json({
+      summary: {
+        ...summaryRow,
+        blockedRate
+      },
+      topBlockedDomains,
+      topCategories,
+      topDevices,
+      source: 'raw'
+    });
+  }
+);
+
+dnsSecurityRoutes.get(
+  '/top-blocked',
+  requireScope('organization', 'partner', 'system'),
+  zValidator('query', topBlockedQuerySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const query = c.req.valid('query');
+
+    const start = parseDateOrNull(query.start);
+    if (query.start && !start) {
+      return c.json({ error: 'Invalid start date' }, 400);
+    }
+
+    const end = parseDateOrNull(query.end);
+    if (query.end && !end) {
+      return c.json({ error: 'Invalid end date' }, 400);
+    }
+
+    const windowError = validateTimeWindow(start, end);
+    if (windowError) {
+      return c.json({ error: windowError }, 400);
+    }
+
+    const conditions: SQL[] = [eq(dnsSecurityEvents.action, 'blocked')];
+    withOrgCondition(conditions, auth.orgCondition(dnsSecurityEvents.orgId));
+    if (start) conditions.push(gte(dnsSecurityEvents.timestamp, start));
+    if (end) conditions.push(lte(dnsSecurityEvents.timestamp, end));
+
+    if (shouldUseAggregations(start, end)) {
+      const aggConditions: SQL[] = [];
+      withOrgCondition(aggConditions, auth.orgCondition(dnsEventAggregations.orgId));
+      if (start) aggConditions.push(gte(dnsEventAggregations.date, toDateKey(start)));
+      if (end) aggConditions.push(lte(dnsEventAggregations.date, toDateKey(end)));
+
+      const [aggCountRow] = await db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(dnsEventAggregations)
+        .where(whereOrUndefined(aggConditions));
+
+      if (Number(aggCountRow?.count ?? 0) > 0) {
+        const aggTopBlockedConditions = [
+          ...aggConditions,
+          sql`${dnsEventAggregations.blockedQueries} > 0`,
+          sql`${dnsEventAggregations.domain} is not null`
+        ];
+
+        const topBlockedAgg = await db
+          .select({
+            domain: dnsEventAggregations.domain,
+            category: dnsEventAggregations.category,
+            count: sql<number>`coalesce(sum(${dnsEventAggregations.blockedQueries}), 0)::int`,
+            devices: sql<number>`count(distinct ${dnsEventAggregations.deviceId})::int`
+          })
+          .from(dnsEventAggregations)
+          .where(and(...aggTopBlockedConditions))
+          .groupBy(dnsEventAggregations.domain, dnsEventAggregations.category)
+          .orderBy(desc(sql`coalesce(sum(${dnsEventAggregations.blockedQueries}), 0)`))
+          .limit(query.limit ?? 20);
+
+        return c.json({ data: topBlockedAgg, source: 'aggregated' });
+      }
+    }
+
+    const topBlocked = await db
+      .select({
+        domain: dnsSecurityEvents.domain,
+        category: dnsSecurityEvents.category,
+        count: sql<number>`count(*)::int`,
+        devices: sql<number>`count(distinct ${dnsSecurityEvents.deviceId})::int`
+      })
+      .from(dnsSecurityEvents)
+      .where(and(...conditions))
+      .groupBy(dnsSecurityEvents.domain, dnsSecurityEvents.category)
+      .orderBy(desc(sql`count(*)`))
+      .limit(query.limit ?? 20);
+
+    return c.json({ data: topBlocked, source: 'raw' });
+  }
+);
+
+dnsSecurityRoutes.get(
+  '/policies',
+  requireScope('organization', 'partner', 'system'),
+  async (c) => {
+    const auth = c.get('auth');
+    const conditions: SQL[] = [];
+    withOrgCondition(conditions, auth.orgCondition(dnsPolicies.orgId));
+
+    const policies = await db
+      .select({
+        id: dnsPolicies.id,
+        orgId: dnsPolicies.orgId,
+        integrationId: dnsPolicies.integrationId,
+        integrationName: dnsFilterIntegrations.name,
+        provider: dnsFilterIntegrations.provider,
+        name: dnsPolicies.name,
+        description: dnsPolicies.description,
+        type: dnsPolicies.type,
+        domains: dnsPolicies.domains,
+        categories: dnsPolicies.categories,
+        syncStatus: dnsPolicies.syncStatus,
+        lastSynced: dnsPolicies.lastSynced,
+        syncError: dnsPolicies.syncError,
+        isActive: dnsPolicies.isActive,
+        createdAt: dnsPolicies.createdAt,
+        updatedAt: dnsPolicies.updatedAt
+      })
+      .from(dnsPolicies)
+      .innerJoin(dnsFilterIntegrations, eq(dnsPolicies.integrationId, dnsFilterIntegrations.id))
+      .where(whereOrUndefined(conditions))
+      .orderBy(desc(dnsPolicies.createdAt));
+
+    return c.json({ data: policies });
+  }
+);
+
+dnsSecurityRoutes.post(
+  '/policies',
+  requireScope('organization', 'partner', 'system'),
+  zValidator('json', createPolicySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const body = c.req.valid('json');
+
+    const orgResult = resolveOrgId(auth, body.orgId);
+    if ('error' in orgResult) {
+      return c.json({ error: orgResult.error }, orgResult.status);
+    }
+
+    const [integration] = await db
+      .select({
+        id: dnsFilterIntegrations.id,
+        orgId: dnsFilterIntegrations.orgId
+      })
+      .from(dnsFilterIntegrations)
+      .where(
+        and(
+          eq(dnsFilterIntegrations.id, body.integrationId),
+          eq(dnsFilterIntegrations.orgId, orgResult.orgId)
+        )
+      )
+      .limit(1);
+
+    if (!integration) {
+      return c.json({ error: 'Integration not found' }, 404);
+    }
+
+    const nowIso = new Date().toISOString();
+    const normalizedDomains: DnsPolicyDomain[] = (body.domains ?? [])
+      .flatMap((entry): DnsPolicyDomain[] => {
+        const domain = normalizeDomain(entry.domain);
+        if (!domain) return [];
+        return [{
+          domain,
+          reason: entry.reason,
+          addedAt: nowIso,
+          addedBy: auth.user.id
+        }];
+      });
+
+    const [policy] = await db
+      .insert(dnsPolicies)
+      .values({
+        orgId: integration.orgId,
+        integrationId: integration.id,
+        name: body.name,
+        description: body.description,
+        type: body.type,
+        domains: normalizedDomains,
+        categories: body.categories ?? [],
+        syncStatus: 'pending',
+        isActive: body.isActive ?? true,
+        createdBy: auth.user.id
+      })
+      .returning();
+
+    if (!policy) {
+      return c.json({ error: 'Failed to create policy' }, 500);
+    }
+
+    try {
+      await schedulePolicySync(policy.id, {
+        add: normalizedDomains.map((entry) => entry.domain),
+        remove: []
+      });
+    } catch (error) {
+      console.error('[dns-security] Policy sync scheduling failed:', error);
+    }
+
+    writeRouteAudit(c, {
+      orgId: policy.orgId,
+      action: 'dns.policy.create',
+      resourceType: 'dns_policy',
+      resourceId: policy.id,
+      resourceName: policy.name,
+      details: {
+        type: policy.type,
+        domainCount: normalizedDomains.length
+      }
+    });
+
+    return c.json(policy, 201);
+  }
+);
+
+dnsSecurityRoutes.patch(
+  '/policies/:id/domains',
+  requireScope('organization', 'partner', 'system'),
+  zValidator('json', patchPolicyDomainsSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const policyId = c.req.param('id');
+    const body = c.req.valid('json');
+
+    const conditions: SQL[] = [eq(dnsPolicies.id, policyId)];
+    withOrgCondition(conditions, auth.orgCondition(dnsPolicies.orgId));
+
+    const [policy] = await db
+      .select()
+      .from(dnsPolicies)
+      .where(and(...conditions))
+      .limit(1);
+
+    if (!policy) {
+      return c.json({ error: 'Policy not found' }, 404);
+    }
+
+    const existingDomains = Array.isArray(policy.domains) ? policy.domains : [];
+    const byDomain = new Map<string, DnsPolicyDomain>();
+    for (const item of existingDomains) {
+      const normalized = normalizeDomain(item.domain);
+      if (!normalized) continue;
+      byDomain.set(normalized, {
+        domain: normalized,
+        reason: item.reason,
+        addedAt: item.addedAt,
+        addedBy: item.addedBy
+      });
+    }
+
+    const removedDomains: string[] = [];
+    for (const domain of body.remove ?? []) {
+      const normalized = normalizeDomain(domain);
+      if (!normalized) continue;
+      if (byDomain.delete(normalized)) {
+        removedDomains.push(normalized);
+      }
+    }
+
+    const addedDomains: string[] = [];
+    for (const entry of body.add ?? []) {
+      const normalized = normalizeDomain(entry.domain);
+      if (!normalized) continue;
+      if (byDomain.has(normalized)) continue;
+      byDomain.set(normalized, {
+        domain: normalized,
+        reason: entry.reason,
+        addedAt: new Date().toISOString(),
+        addedBy: auth.user.id
+      });
+      addedDomains.push(normalized);
+    }
+
+    const updatedDomains = Array.from(byDomain.values());
+
+    await db
+      .update(dnsPolicies)
+      .set({
+        domains: updatedDomains,
+        syncStatus: 'pending',
+        syncError: null,
+        updatedAt: new Date()
+      })
+      .where(eq(dnsPolicies.id, policy.id));
+
+    if (addedDomains.length > 0 || removedDomains.length > 0) {
+      try {
+        await schedulePolicySync(policy.id, {
+          add: addedDomains,
+          remove: removedDomains
+        });
+      } catch (error) {
+        console.error('[dns-security] Policy domain sync scheduling failed:', error);
+      }
+    }
+
+    writeRouteAudit(c, {
+      orgId: policy.orgId,
+      action: 'dns.policy.update_domains',
+      resourceType: 'dns_policy',
+      resourceId: policy.id,
+      resourceName: policy.name,
+      details: {
+        added: addedDomains.length,
+        removed: removedDomains.length
+      }
+    });
+
+    return c.json({
+      success: true,
+      policyId: policy.id,
+      domainCount: updatedDomains.length,
+      added: addedDomains,
+      removed: removedDomains
+    });
+  }
+);
+
+export { dnsSecurityRoutes };

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -46,6 +46,8 @@ export const TOOL_TIERS = {
   get_active_users: 1,
   get_user_experience_metrics: 1,
   manage_alerts: 1, // Base tier; action-level escalation handled in guardrails
+  get_dns_security: 1,
+  manage_dns_policy: 2,
   execute_command: 3,
   run_script: 3,
   manage_services: 3,
@@ -312,6 +314,35 @@ export function createBreezeMcpServer(
         resolutionNote: z.string().max(1000).optional(),
       },
       makeHandler('manage_alerts', getAuth, onPreToolUse, onPostToolUse)
+    ),
+
+    tool(
+      'get_dns_security',
+      'Get DNS security statistics: blocked domains, threat categories, and top offending devices.',
+      {
+        timeRange: z.object({
+          start: z.string().datetime({ offset: true }),
+          end: z.string().datetime({ offset: true }),
+        }),
+        deviceId: uuid.optional(),
+        integrationId: uuid.optional(),
+        action: z.enum(['allowed', 'blocked', 'redirected']).optional(),
+        category: z.string().max(100).optional(),
+        topN: z.number().int().min(1).max(100).optional(),
+      },
+      makeHandler('get_dns_security', getAuth, onPreToolUse, onPostToolUse)
+    ),
+
+    tool(
+      'manage_dns_policy',
+      'Add or remove domains from DNS blocklist/allowlist and synchronize with the provider.',
+      {
+        integrationId: uuid,
+        action: z.enum(['add_block', 'remove_block', 'add_allow', 'remove_allow']),
+        domains: z.array(z.string().min(1).max(500)).min(1).max(500),
+        reason: z.string().max(2000).optional(),
+      },
+      makeHandler('manage_dns_policy', getAuth, onPreToolUse, onPostToolUse)
     ),
 
     tool(

--- a/apps/api/src/services/aiTools.ts
+++ b/apps/api/src/services/aiTools.ts
@@ -20,12 +20,19 @@ import {
   auditLogs,
   deviceCommands,
   deviceFilesystemCleanupRuns,
-  deviceSessions
+  deviceSessions,
+  dnsFilterIntegrations,
+  dnsEventAggregations,
+  dnsPolicies,
+  dnsSecurityEvents,
+  dnsThreatCategoryEnum,
+  type DnsPolicyDomain
 } from '../db/schema';
 import { eq, and, desc, sql, like, inArray, gte, lte, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import { escapeLike } from '../utils/sql';
 import { validateToolInput } from './aiToolSchemas';
+import { schedulePolicySync } from '../jobs/dnsSyncJob';
 import { registerAgentLogTools } from './aiToolsAgentLogs';
 import { registerConfigPolicyTools } from './aiToolsConfigPolicy';
 import { registerFleetTools } from './aiToolsFleet';
@@ -84,6 +91,33 @@ async function findAlertWithAccess(alertId: string, auth: AuthContext) {
   if (orgCond) conditions.push(orgCond);
   const [alert] = await db.select().from(alerts).where(and(...conditions)).limit(1);
   return alert || null;
+}
+
+function normalizeDnsDomain(domain: unknown): string | null {
+  if (typeof domain !== 'string') return null;
+  const normalized = domain.trim().toLowerCase().replace(/\.$/, '');
+  if (!normalized || normalized.length > 500) return null;
+  return normalized;
+}
+
+function normalizeDnsCategory(category: unknown): string | null {
+  if (typeof category !== 'string' || !category.trim()) return null;
+  const normalized = category.trim().toLowerCase().replace(/\s+/g, '_').replace(/-/g, '_');
+  if (dnsThreatCategoryEnum.enumValues.includes(normalized as typeof dnsThreatCategoryEnum.enumValues[number])) {
+    return normalized;
+  }
+  if (normalized.includes('phish')) return 'phishing';
+  if (normalized.includes('malware')) return 'malware';
+  if (normalized.includes('bot')) return 'botnet';
+  if (normalized.includes('ransom')) return 'ransomware';
+  if (normalized.includes('crypto')) return 'cryptomining';
+  if (normalized.includes('spam')) return 'spam';
+  if (normalized.includes('adult')) return 'adult_content';
+  if (normalized.includes('ad')) return 'adware';
+  if (normalized.includes('gambl')) return 'gambling';
+  if (normalized.includes('social')) return 'social_media';
+  if (normalized.includes('stream')) return 'streaming';
+  return 'unknown';
 }
 
 // ============================================
@@ -691,6 +725,463 @@ registerTool({
     }
 
     return JSON.stringify({ error: `Unknown action: ${action}` });
+  }
+});
+
+// ============================================
+// get_dns_security - Tier 1 (auto-execute)
+// ============================================
+
+registerTool({
+  tier: 1,
+  definition: {
+    name: 'get_dns_security',
+    description: 'Get DNS security statistics including blocked domains, threat categories, and top offending devices.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        timeRange: {
+          type: 'object',
+          properties: {
+            start: { type: 'string', description: 'Start time (ISO 8601)' },
+            end: { type: 'string', description: 'End time (ISO 8601)' }
+          },
+          required: ['start', 'end']
+        },
+        deviceId: { type: 'string', description: 'Filter by device ID' },
+        integrationId: { type: 'string', description: 'Filter by integration ID' },
+        action: { type: 'string', enum: ['allowed', 'blocked', 'redirected'], description: 'Filter by DNS action' },
+        category: { type: 'string', description: 'Filter by threat category' },
+        topN: { type: 'number', description: 'Number of top results to return (default 10, max 100)' }
+      },
+      required: ['timeRange']
+    }
+  },
+  handler: async (input, auth) => {
+    const AGGREGATION_MIN_DAYS = 7;
+    const toDateKey = (value: Date): string => value.toISOString().slice(0, 10);
+    const shouldUseAggregations = (startDate: Date, endDate: Date): boolean => {
+      const diffMs = endDate.getTime() - startDate.getTime();
+      return diffMs > AGGREGATION_MIN_DAYS * 24 * 60 * 60 * 1000;
+    };
+
+    const timeRange = (input.timeRange ?? {}) as { start?: string; end?: string };
+    const start = timeRange.start ? new Date(timeRange.start) : null;
+    const end = timeRange.end ? new Date(timeRange.end) : null;
+
+    if (!start || !end || Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+      return JSON.stringify({ error: 'timeRange.start and timeRange.end must be valid ISO timestamps' });
+    }
+    if (start.getTime() > end.getTime()) {
+      return JSON.stringify({ error: 'timeRange.start must be before or equal to timeRange.end' });
+    }
+    const maxWindowMs = 90 * 24 * 60 * 60 * 1000;
+    if ((end.getTime() - start.getTime()) > maxWindowMs) {
+      return JSON.stringify({ error: 'timeRange cannot exceed 90 days' });
+    }
+
+    const conditions: SQL[] = [
+      gte(dnsSecurityEvents.timestamp, start),
+      lte(dnsSecurityEvents.timestamp, end)
+    ];
+    const orgCondition = auth.orgCondition(dnsSecurityEvents.orgId);
+    if (orgCondition) conditions.push(orgCondition);
+
+    if (input.deviceId) conditions.push(eq(dnsSecurityEvents.deviceId, input.deviceId as string));
+    if (input.integrationId) conditions.push(eq(dnsSecurityEvents.integrationId, input.integrationId as string));
+    if (input.action) conditions.push(eq(dnsSecurityEvents.action, input.action as typeof dnsSecurityEvents.action.enumValues[number]));
+    const normalizedCategory = input.category ? normalizeDnsCategory(input.category) : null;
+    if (normalizedCategory) {
+      conditions.push(eq(dnsSecurityEvents.category, normalizedCategory as typeof dnsSecurityEvents.category.enumValues[number]));
+    }
+
+    const topN = Math.min(Math.max(1, Number(input.topN) || 10), 100);
+    const where = and(...conditions);
+
+    if (shouldUseAggregations(start, end)) {
+      const aggConditions: SQL[] = [
+        gte(dnsEventAggregations.date, toDateKey(start)),
+        lte(dnsEventAggregations.date, toDateKey(end))
+      ];
+      const aggOrgCondition = auth.orgCondition(dnsEventAggregations.orgId);
+      if (aggOrgCondition) aggConditions.push(aggOrgCondition);
+      if (input.deviceId) aggConditions.push(eq(dnsEventAggregations.deviceId, input.deviceId as string));
+      if (input.integrationId) aggConditions.push(eq(dnsEventAggregations.integrationId, input.integrationId as string));
+      if (normalizedCategory) {
+        aggConditions.push(
+          eq(dnsEventAggregations.category, normalizedCategory as typeof dnsEventAggregations.category.enumValues[number])
+        );
+      }
+
+      const aggWhere = and(...aggConditions);
+      const [aggCountRow] = await db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(dnsEventAggregations)
+        .where(aggWhere);
+
+      if (Number(aggCountRow?.count ?? 0) > 0) {
+        const topCategoryCountExpr: SQL<number> = input.action === 'blocked'
+          ? sql<number>`coalesce(sum(${dnsEventAggregations.blockedQueries}), 0)::int`
+          : input.action === 'allowed'
+            ? sql<number>`coalesce(sum(${dnsEventAggregations.allowedQueries}), 0)::int`
+            : input.action === 'redirected'
+              ? sql<number>`coalesce(sum(${dnsEventAggregations.totalQueries} - ${dnsEventAggregations.blockedQueries} - ${dnsEventAggregations.allowedQueries}), 0)::int`
+              : sql<number>`coalesce(sum(${dnsEventAggregations.totalQueries}), 0)::int`;
+
+        const [rawSummary, topBlockedDomains, topCategories, topDevices] = await Promise.all([
+          db
+            .select({
+              totalQueries: sql<number>`coalesce(sum(${dnsEventAggregations.totalQueries}), 0)::int`,
+              blockedQueries: sql<number>`coalesce(sum(${dnsEventAggregations.blockedQueries}), 0)::int`,
+              allowedQueries: sql<number>`coalesce(sum(${dnsEventAggregations.allowedQueries}), 0)::int`
+            })
+            .from(dnsEventAggregations)
+            .where(aggWhere),
+          input.action && input.action !== 'blocked'
+            ? Promise.resolve([])
+            : db
+              .select({
+                domain: dnsEventAggregations.domain,
+                category: dnsEventAggregations.category,
+                count: sql<number>`coalesce(sum(${dnsEventAggregations.blockedQueries}), 0)::int`
+              })
+              .from(dnsEventAggregations)
+              .where(and(
+                ...aggConditions,
+                sql`${dnsEventAggregations.blockedQueries} > 0`,
+                sql`${dnsEventAggregations.domain} is not null`
+              ))
+              .groupBy(dnsEventAggregations.domain, dnsEventAggregations.category)
+              .orderBy(desc(sql`coalesce(sum(${dnsEventAggregations.blockedQueries}), 0)`))
+              .limit(topN),
+          db
+            .select({
+              category: dnsEventAggregations.category,
+              count: topCategoryCountExpr
+            })
+            .from(dnsEventAggregations)
+            .where(and(...aggConditions, sql`${dnsEventAggregations.category} is not null`))
+            .groupBy(dnsEventAggregations.category)
+            .orderBy(desc(topCategoryCountExpr))
+            .limit(topN),
+          input.action && input.action !== 'blocked'
+            ? Promise.resolve([])
+            : db
+              .select({
+                deviceId: dnsEventAggregations.deviceId,
+                hostname: devices.hostname,
+                blockedCount: sql<number>`coalesce(sum(${dnsEventAggregations.blockedQueries}), 0)::int`
+              })
+              .from(dnsEventAggregations)
+              .leftJoin(devices, eq(dnsEventAggregations.deviceId, devices.id))
+              .where(and(...aggConditions, sql`${dnsEventAggregations.blockedQueries} > 0`))
+              .groupBy(dnsEventAggregations.deviceId, devices.hostname)
+              .orderBy(desc(sql`coalesce(sum(${dnsEventAggregations.blockedQueries}), 0)`))
+              .limit(topN)
+        ]);
+
+        const summaryBase = rawSummary[0] ?? {
+          totalQueries: 0,
+          blockedQueries: 0,
+          allowedQueries: 0
+        };
+        const redirectedFromTotals = Math.max(
+          0,
+          summaryBase.totalQueries - summaryBase.blockedQueries - summaryBase.allowedQueries
+        );
+
+        const summaryRow = input.action === 'blocked'
+          ? {
+            totalQueries: summaryBase.blockedQueries,
+            blockedQueries: summaryBase.blockedQueries,
+            allowedQueries: 0,
+            redirectedQueries: 0
+          }
+          : input.action === 'allowed'
+            ? {
+              totalQueries: summaryBase.allowedQueries,
+              blockedQueries: 0,
+              allowedQueries: summaryBase.allowedQueries,
+              redirectedQueries: 0
+            }
+            : input.action === 'redirected'
+              ? {
+                totalQueries: redirectedFromTotals,
+                blockedQueries: 0,
+                allowedQueries: 0,
+                redirectedQueries: redirectedFromTotals
+              }
+              : {
+                totalQueries: summaryBase.totalQueries,
+                blockedQueries: summaryBase.blockedQueries,
+                allowedQueries: summaryBase.allowedQueries,
+                redirectedQueries: redirectedFromTotals
+              };
+        const blockedRate = summaryRow.totalQueries > 0
+          ? Number(((summaryRow.blockedQueries / summaryRow.totalQueries) * 100).toFixed(2))
+          : 0;
+
+        return JSON.stringify({
+          summary: {
+            ...summaryRow,
+            blockedRate,
+            timeRange: { start: start.toISOString(), end: end.toISOString() }
+          },
+          topBlockedDomains,
+          topCategories,
+          topDevices,
+          source: 'aggregated'
+        });
+      }
+    }
+
+    const [summary, topBlockedDomains, topCategories, topDevices] = await Promise.all([
+      db
+        .select({
+          totalQueries: sql<number>`count(*)::int`,
+          blockedQueries: sql<number>`coalesce(sum(case when ${dnsSecurityEvents.action} = 'blocked' then 1 else 0 end), 0)::int`,
+          allowedQueries: sql<number>`coalesce(sum(case when ${dnsSecurityEvents.action} = 'allowed' then 1 else 0 end), 0)::int`,
+          redirectedQueries: sql<number>`coalesce(sum(case when ${dnsSecurityEvents.action} = 'redirected' then 1 else 0 end), 0)::int`
+        })
+        .from(dnsSecurityEvents)
+        .where(where),
+      db
+        .select({
+          domain: dnsSecurityEvents.domain,
+          category: dnsSecurityEvents.category,
+          count: sql<number>`count(*)::int`
+        })
+        .from(dnsSecurityEvents)
+        .where(and(where, eq(dnsSecurityEvents.action, 'blocked')))
+        .groupBy(dnsSecurityEvents.domain, dnsSecurityEvents.category)
+        .orderBy(desc(sql`count(*)`))
+        .limit(topN),
+      db
+        .select({
+          category: dnsSecurityEvents.category,
+          count: sql<number>`count(*)::int`
+        })
+        .from(dnsSecurityEvents)
+        .where(and(where, sql`${dnsSecurityEvents.category} is not null`))
+        .groupBy(dnsSecurityEvents.category)
+        .orderBy(desc(sql`count(*)`))
+        .limit(topN),
+      db
+        .select({
+          deviceId: dnsSecurityEvents.deviceId,
+          hostname: devices.hostname,
+          blockedCount: sql<number>`count(*)::int`
+        })
+        .from(dnsSecurityEvents)
+        .leftJoin(devices, eq(dnsSecurityEvents.deviceId, devices.id))
+        .where(and(where, eq(dnsSecurityEvents.action, 'blocked')))
+        .groupBy(dnsSecurityEvents.deviceId, devices.hostname)
+        .orderBy(desc(sql`count(*)`))
+        .limit(topN)
+    ]);
+
+    const summaryRow = summary[0] ?? {
+      totalQueries: 0,
+      blockedQueries: 0,
+      allowedQueries: 0,
+      redirectedQueries: 0
+    };
+    const blockedRate = summaryRow.totalQueries > 0
+      ? Number(((summaryRow.blockedQueries / summaryRow.totalQueries) * 100).toFixed(2))
+      : 0;
+
+    return JSON.stringify({
+      summary: {
+        ...summaryRow,
+        blockedRate,
+        timeRange: { start: start.toISOString(), end: end.toISOString() }
+      },
+      topBlockedDomains,
+      topCategories,
+      topDevices,
+      source: 'raw'
+    });
+  }
+});
+
+// ============================================
+// manage_dns_policy - Tier 2 (confirm before execute)
+// ============================================
+
+registerTool({
+  tier: 2,
+  definition: {
+    name: 'manage_dns_policy',
+    description: 'Add or remove domains from DNS blocklist/allowlist and schedule provider synchronization.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        integrationId: { type: 'string', description: 'DNS integration UUID' },
+        action: { type: 'string', enum: ['add_block', 'remove_block', 'add_allow', 'remove_allow'], description: 'Policy action' },
+        domains: { type: 'array', items: { type: 'string' }, description: 'Domains to add or remove' },
+        reason: { type: 'string', description: 'Optional reason for policy changes' }
+      },
+      required: ['integrationId', 'action', 'domains']
+    }
+  },
+  handler: async (input, auth) => {
+    const integrationId = input.integrationId as string;
+    const action = input.action as 'add_block' | 'remove_block' | 'add_allow' | 'remove_allow';
+    const domainsInput = Array.isArray(input.domains) ? input.domains : [];
+    const reason = typeof input.reason === 'string' ? input.reason : undefined;
+
+    const domains = domainsInput
+      .map((domain) => normalizeDnsDomain(domain))
+      .filter((domain): domain is string => domain !== null);
+    const uniqueDomains = Array.from(new Set(domains));
+
+    if (uniqueDomains.length === 0) {
+      return JSON.stringify({ error: 'No valid domains were provided' });
+    }
+
+    const integrationConditions: SQL[] = [eq(dnsFilterIntegrations.id, integrationId)];
+    const orgCondition = auth.orgCondition(dnsFilterIntegrations.orgId);
+    if (orgCondition) integrationConditions.push(orgCondition);
+
+    const [integration] = await db
+      .select({
+        id: dnsFilterIntegrations.id,
+        orgId: dnsFilterIntegrations.orgId
+      })
+      .from(dnsFilterIntegrations)
+      .where(and(...integrationConditions))
+      .limit(1);
+
+    if (!integration) {
+      return JSON.stringify({ error: 'Integration not found or access denied' });
+    }
+
+    const policyType = action === 'add_block' || action === 'remove_block' ? 'blocklist' : 'allowlist';
+    const policyName = policyType === 'blocklist' ? 'AI Managed Blocklist' : 'AI Managed Allowlist';
+    const isAddAction = action === 'add_block' || action === 'add_allow';
+    const isRemoveAction = action === 'remove_block' || action === 'remove_allow';
+
+    const policyConditions: SQL[] = [
+      eq(dnsPolicies.integrationId, integration.id),
+      eq(dnsPolicies.type, policyType),
+    ];
+    const policyOrgCondition = auth.orgCondition(dnsPolicies.orgId);
+    if (policyOrgCondition) policyConditions.push(policyOrgCondition);
+
+    let [policy] = await db
+      .select()
+      .from(dnsPolicies)
+      .where(and(...policyConditions))
+      .orderBy(desc(dnsPolicies.createdAt))
+      .limit(1);
+
+    if (!policy && isRemoveAction) {
+      return JSON.stringify({
+        success: true,
+        policyId: null,
+        integrationId: integration.id,
+        action,
+        requested: uniqueDomains.length,
+        added: 0,
+        removed: 0,
+        syncScheduled: false,
+        warning: 'No policy exists for the requested remove action'
+      });
+    }
+
+    if (!policy && isAddAction) {
+      const [created] = await db
+        .insert(dnsPolicies)
+        .values({
+          orgId: integration.orgId,
+          integrationId: integration.id,
+          name: policyName,
+          description: 'Managed by AI assistant',
+          type: policyType,
+          domains: [],
+          categories: [],
+          syncStatus: 'pending',
+          isActive: true,
+          createdBy: auth.user.id
+        })
+        .returning();
+      policy = created;
+    }
+
+    if (!policy) {
+      return JSON.stringify({ error: 'Failed to create or load DNS policy' });
+    }
+
+    const existing = Array.isArray(policy.domains) ? policy.domains : [];
+    const domainMap = new Map<string, DnsPolicyDomain>();
+
+    for (const item of existing) {
+      const normalized = normalizeDnsDomain(item.domain);
+      if (!normalized) continue;
+      domainMap.set(normalized, {
+        domain: normalized,
+        reason: item.reason,
+        addedAt: item.addedAt,
+        addedBy: item.addedBy
+      });
+    }
+
+    const added: string[] = [];
+    const removed: string[] = [];
+    const nowIso = new Date().toISOString();
+
+    if (action === 'add_block' || action === 'add_allow') {
+      for (const domain of uniqueDomains) {
+        if (domainMap.has(domain)) continue;
+        domainMap.set(domain, {
+          domain,
+          reason,
+          addedAt: nowIso,
+          addedBy: auth.user.id
+        });
+        added.push(domain);
+      }
+    } else {
+      for (const domain of uniqueDomains) {
+        if (domainMap.delete(domain)) {
+          removed.push(domain);
+        }
+      }
+    }
+
+    await db
+      .update(dnsPolicies)
+      .set({
+        domains: Array.from(domainMap.values()),
+        syncStatus: 'pending',
+        syncError: null,
+        updatedAt: new Date()
+      })
+      .where(eq(dnsPolicies.id, policy.id));
+
+    let syncScheduled = false;
+    let warning: string | undefined;
+    if (added.length > 0 || removed.length > 0) {
+      try {
+        await schedulePolicySync(policy.id, { add: added, remove: removed });
+        syncScheduled = true;
+      } catch (error) {
+        console.error('[AiTools] Failed to schedule DNS policy sync:', error);
+        warning = 'Policy changes were saved, but provider sync could not be scheduled';
+      }
+    }
+
+    return JSON.stringify({
+      success: true,
+      policyId: policy.id,
+      integrationId: integration.id,
+      action,
+      requested: uniqueDomains.length,
+      added: added.length,
+      removed: removed.length,
+      syncScheduled,
+      warning
+    });
   }
 });
 

--- a/apps/api/src/services/dnsProviders/cloudflare.ts
+++ b/apps/api/src/services/dnsProviders/cloudflare.ts
@@ -1,0 +1,184 @@
+import type { DnsEvent, DnsProvider } from './index';
+import { requestJson } from './http';
+import { asArray, asBoolean, asNumber, asRecord, asString, asStringArray } from './helpers';
+
+export interface CloudflareGatewayConfig {
+  accountId?: string;
+  blocklistId?: string;
+  allowlistId?: string;
+}
+
+interface CloudflareApiResponse<T> {
+  success?: boolean;
+  result?: T;
+  errors?: Array<{ message?: string }>;
+  result_info?: Record<string, unknown>;
+}
+
+export class CloudflareGatewayProvider implements DnsProvider {
+  constructor(
+    private readonly apiToken: string,
+    private readonly config: CloudflareGatewayConfig
+  ) {}
+
+  private requireAccountId(): string {
+    if (!this.config.accountId) {
+      throw new Error('Cloudflare Gateway integration requires config.accountId');
+    }
+    return this.config.accountId;
+  }
+
+  private async call<T>(
+    path: string,
+    init: RequestInit = {}
+  ): Promise<CloudflareApiResponse<T>> {
+    const accountId = this.requireAccountId();
+    const response = await requestJson<CloudflareApiResponse<T>>(
+      `https://api.cloudflare.com/client/v4/accounts/${accountId}${path}`,
+      {
+        ...init,
+        headers: {
+          Authorization: `Bearer ${this.apiToken}`,
+          ...(init.headers ?? {})
+        }
+      }
+    );
+
+    if (!response.success) {
+      const errors = (response.errors ?? []).map((item) => item.message).filter(Boolean).join('; ');
+      throw new Error(errors || 'Cloudflare API request failed');
+    }
+
+    return response;
+  }
+
+  async syncEvents(since: Date, until: Date): Promise<DnsEvent[]> {
+    const perPage = 1000;
+    const maxPages = 100;
+    const events: DnsEvent[] = [];
+    const seenCursors = new Set<string>();
+    let page = 1;
+    let cursor: string | undefined;
+
+    for (let i = 0; i < maxPages; i++) {
+      const query = new URLSearchParams({
+        since: since.toISOString(),
+        until: until.toISOString(),
+        per_page: String(perPage),
+      });
+      if (cursor) {
+        query.set('cursor', cursor);
+      } else {
+        query.set('page', String(page));
+      }
+
+      const payload = await this.call<unknown[]>(`/gateway/logs?${query.toString()}`);
+      const result = asArray(payload.result);
+      const mapped = result.flatMap((entry): DnsEvent[] => {
+        const record = asRecord(entry);
+        if (!record) return [];
+
+        const timestampRaw = asString(record.timestamp);
+        const domain = asString(record.query_name) ?? asString(record.domain);
+        if (!timestampRaw || !domain) return [];
+
+        const timestamp = new Date(timestampRaw);
+        if (Number.isNaN(timestamp.getTime())) return [];
+
+        const actionRaw = (asString(record.action) ?? '').toLowerCase();
+        const categories = asStringArray(record.categories);
+
+        return [{
+          timestamp,
+          domain,
+          queryType: asString(record.query_type) ?? 'A',
+          action: actionRaw.includes('block') ? 'blocked' : actionRaw.includes('redirect') ? 'redirected' : 'allowed',
+          category: asString(record.category) ?? categories[0],
+          sourceIp: asString(record.source_ip) ?? asString(asRecord(record.source)?.ip),
+          providerEventId: asString(record.id),
+          metadata: record
+        }];
+      });
+      events.push(...mapped);
+
+      const info = asRecord(payload.result_info);
+      const nextCursor = asString(info?.cursor)
+        ?? asString(info?.next_cursor)
+        ?? asString(info?.next);
+      const hasMore = asBoolean(info?.has_more);
+      const totalPages = asNumber(info?.total_pages);
+      const currentPage = asNumber(info?.page) ?? page;
+
+      if (nextCursor) {
+        if (seenCursors.has(nextCursor)) break;
+        seenCursors.add(nextCursor);
+        cursor = nextCursor;
+        continue;
+      }
+
+      if (hasMore === true) {
+        cursor = undefined;
+        page = currentPage + 1;
+        continue;
+      }
+
+      if (typeof totalPages === 'number' && currentPage < totalPages) {
+        cursor = undefined;
+        page = currentPage + 1;
+        continue;
+      }
+
+      if (result.length >= perPage) {
+        cursor = undefined;
+        page = currentPage + 1;
+        continue;
+      }
+
+      break;
+    }
+
+    return events;
+  }
+
+  private requireListId(type: 'block' | 'allow'): string {
+    const listId = type === 'block' ? this.config.blocklistId : this.config.allowlistId;
+    if (!listId) {
+      throw new Error(`Cloudflare ${type}list sync requires ${type}listId in integration config`);
+    }
+    return listId;
+  }
+
+  async addBlocklistDomain(domain: string, reason?: string): Promise<void> {
+    const listId = this.requireListId('block');
+    await this.call<unknown>(`/gateway/lists/${listId}/items`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ value: domain, description: reason })
+    });
+  }
+
+  async removeBlocklistDomain(domain: string): Promise<void> {
+    const listId = this.requireListId('block');
+    const query = new URLSearchParams({ value: domain });
+    await this.call<unknown>(`/gateway/lists/${listId}/items?${query.toString()}`, {
+      method: 'DELETE'
+    });
+  }
+
+  async addAllowlistDomain(domain: string): Promise<void> {
+    const listId = this.requireListId('allow');
+    await this.call<unknown>(`/gateway/lists/${listId}/items`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ value: domain })
+    });
+  }
+
+  async removeAllowlistDomain(domain: string): Promise<void> {
+    const listId = this.requireListId('allow');
+    const query = new URLSearchParams({ value: domain });
+    await this.call<unknown>(`/gateway/lists/${listId}/items?${query.toString()}`, {
+      method: 'DELETE'
+    });
+  }
+}

--- a/apps/api/src/services/dnsProviders/dnsfilter.ts
+++ b/apps/api/src/services/dnsProviders/dnsfilter.ts
@@ -1,0 +1,197 @@
+import type { DnsEvent, DnsProvider } from './index';
+import { requestJson } from './http';
+import { asArray, asBoolean, asNumber, asRecord, asString, asStringArray } from './helpers';
+
+export interface DnsFilterProviderConfig {
+  apiEndpoint?: string;
+  accountId?: string;
+  blocklistId?: string;
+  allowlistId?: string;
+}
+
+export class DnsFilterProvider implements DnsProvider {
+  constructor(
+    private readonly apiToken: string,
+    private readonly config: DnsFilterProviderConfig
+  ) {}
+
+  private baseUrl(): string {
+    return (this.config.apiEndpoint ?? 'https://api.dnsfilter.com').replace(/\/+$/, '');
+  }
+
+  private async call<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const url = `${this.baseUrl()}${path}`;
+    return requestJson<T>(url, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${this.apiToken}`,
+        ...(init.headers ?? {})
+      }
+    });
+  }
+
+  async syncEvents(since: Date, until: Date): Promise<DnsEvent[]> {
+    const limit = 1000;
+    const maxPages = 100;
+    const allEvents: DnsEvent[] = [];
+    const seenPageKeys = new Set<string>();
+    let page = 1;
+    let cursor: string | undefined;
+
+    for (let i = 0; i < maxPages; i++) {
+      const query = new URLSearchParams({
+        from: since.toISOString(),
+        to: until.toISOString(),
+        limit: String(limit)
+      });
+
+      if (this.config.accountId) {
+        query.set('accountId', this.config.accountId);
+      }
+
+      if (cursor) {
+        query.set('cursor', cursor);
+      } else {
+        query.set('page', String(page));
+      }
+
+      const payload = await this.call<Record<string, unknown>>(`/v1/dns-events?${query.toString()}`);
+      const rows = asArray(payload.events ?? payload.data ?? payload.results);
+      const mapped = rows.flatMap((entry): DnsEvent[] => {
+        const record = asRecord(entry);
+        if (!record) return [];
+
+        const timestampRaw = asString(record.timestamp) ?? asString(record.datetime);
+        const domain = asString(record.domain) ?? asString(record.query);
+        if (!timestampRaw || !domain) return [];
+
+        const timestamp = new Date(timestampRaw);
+        if (Number.isNaN(timestamp.getTime())) return [];
+
+        const actionRaw = (asString(record.action) ?? asString(record.decision) ?? '').toLowerCase();
+        const categories = asStringArray(record.categories);
+
+        return [{
+          timestamp,
+          domain,
+          queryType: asString(record.query_type) ?? asString(record.queryType) ?? 'A',
+          action: actionRaw.includes('block') ? 'blocked' : actionRaw.includes('redirect') ? 'redirected' : 'allowed',
+          category: asString(record.category) ?? categories[0],
+          threatType: asString(record.threat_type),
+          sourceIp: asString(record.source_ip),
+          sourceHostname: asString(record.source_hostname),
+          providerEventId: asString(record.id) ?? asString(record.event_id),
+          metadata: record
+        }];
+      });
+      allEvents.push(...mapped);
+
+      const paging = asRecord(payload.paging)
+        ?? asRecord(payload.meta)
+        ?? asRecord(payload.metadata)
+        ?? asRecord(payload.result_info);
+      const links = asRecord(payload.links);
+
+      const nextCursor = asString(payload.next_cursor)
+        ?? asString(paging?.next_cursor)
+        ?? asString(paging?.cursor)
+        ?? asString(links?.next)
+        ?? asString(payload.next);
+      const nextPage = asNumber(payload.next_page) ?? asNumber(paging?.next_page);
+      const hasMore = asBoolean(payload.has_more) ?? asBoolean(paging?.has_more);
+      const totalPages = asNumber(payload.total_pages) ?? asNumber(paging?.total_pages);
+      const currentPage = asNumber(payload.page) ?? asNumber(paging?.page) ?? page;
+
+      if (nextCursor) {
+        const key = `cursor:${nextCursor}`;
+        if (seenPageKeys.has(key)) break;
+        seenPageKeys.add(key);
+
+        if (nextCursor.startsWith('http')) {
+          const nextUrl = new URL(nextCursor);
+          cursor = asString(nextUrl.searchParams.get('cursor')) ?? undefined;
+          page = asNumber(nextUrl.searchParams.get('page')) ?? (page + 1);
+        } else if (/^\d+$/.test(nextCursor)) {
+          cursor = undefined;
+          page = Number(nextCursor);
+        } else {
+          cursor = nextCursor;
+        }
+        continue;
+      }
+
+      if (typeof nextPage === 'number' && nextPage > currentPage) {
+        const key = `page:${nextPage}`;
+        if (seenPageKeys.has(key)) break;
+        seenPageKeys.add(key);
+        cursor = undefined;
+        page = nextPage;
+        continue;
+      }
+
+      if (typeof totalPages === 'number' && currentPage < totalPages) {
+        const candidate = currentPage + 1;
+        const key = `page:${candidate}`;
+        if (seenPageKeys.has(key)) break;
+        seenPageKeys.add(key);
+        cursor = undefined;
+        page = candidate;
+        continue;
+      }
+
+      if (hasMore === true && rows.length >= limit) {
+        const candidate = currentPage + 1;
+        const key = `page:${candidate}`;
+        if (seenPageKeys.has(key)) break;
+        seenPageKeys.add(key);
+        cursor = undefined;
+        page = candidate;
+        continue;
+      }
+
+      break;
+    }
+
+    return allEvents;
+  }
+
+  private requireListId(type: 'block' | 'allow'): string {
+    const listId = type === 'block' ? this.config.blocklistId : this.config.allowlistId;
+    if (!listId) {
+      throw new Error(`DNSFilter ${type}list sync requires ${type}listId in integration config`);
+    }
+    return listId;
+  }
+
+  async addBlocklistDomain(domain: string, reason?: string): Promise<void> {
+    const listId = this.requireListId('block');
+    await this.call(`/v1/lists/${listId}/domains`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ domain, reason })
+    });
+  }
+
+  async removeBlocklistDomain(domain: string): Promise<void> {
+    const listId = this.requireListId('block');
+    await this.call(`/v1/lists/${listId}/domains/${encodeURIComponent(domain)}`, {
+      method: 'DELETE'
+    });
+  }
+
+  async addAllowlistDomain(domain: string): Promise<void> {
+    const listId = this.requireListId('allow');
+    await this.call(`/v1/lists/${listId}/domains`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ domain })
+    });
+  }
+
+  async removeAllowlistDomain(domain: string): Promise<void> {
+    const listId = this.requireListId('allow');
+    await this.call(`/v1/lists/${listId}/domains/${encodeURIComponent(domain)}`, {
+      method: 'DELETE'
+    });
+  }
+}

--- a/apps/api/src/services/dnsProviders/helpers.ts
+++ b/apps/api/src/services/dnsProviders/helpers.ts
@@ -1,0 +1,41 @@
+export function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+export function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+export function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+export function asNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+export function asBoolean(value: unknown): boolean | undefined {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true' || normalized === '1') return true;
+    if (normalized === 'false' || normalized === '0') return false;
+  }
+  return undefined;
+}
+
+export function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is string => typeof item === 'string' && item.length > 0);
+}

--- a/apps/api/src/services/dnsProviders/http.ts
+++ b/apps/api/src/services/dnsProviders/http.ts
@@ -1,0 +1,96 @@
+const DEFAULT_TIMEOUT_MS = 20_000;
+const DEFAULT_MAX_RETRIES = 3;
+
+interface RequestJsonInit extends RequestInit {
+  timeoutMs?: number;
+  maxRetries?: number;
+}
+
+function toErrorMessage(status: number, statusText: string, body: string): string {
+  const trimmed = body.trim();
+  const bodyPreview = trimmed.length > 0 ? trimmed.slice(0, 400) : '<empty>';
+  return `HTTP ${status} ${statusText}: ${bodyPreview}`;
+}
+
+export async function requestJson<T>(
+  input: string | URL,
+  init: RequestJsonInit = {}
+): Promise<T> {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, maxRetries = DEFAULT_MAX_RETRIES, ...fetchInit } = init;
+
+  const parseRetryAfterMs = (header: string | null): number | null => {
+    if (!header) return null;
+    const asSeconds = Number(header);
+    if (Number.isFinite(asSeconds) && asSeconds >= 0) {
+      return Math.min(asSeconds * 1000, 60_000);
+    }
+    const at = Date.parse(header);
+    if (!Number.isNaN(at)) {
+      return Math.max(0, Math.min(at - Date.now(), 60_000));
+    }
+    return null;
+  };
+
+  const computeBackoffMs = (attempt: number, retryAfterHeader: string | null): number => {
+    const retryAfterMs = parseRetryAfterMs(retryAfterHeader);
+    if (retryAfterMs !== null) return retryAfterMs;
+    const base = 500 * (2 ** attempt);
+    const jitter = Math.floor(Math.random() * 250);
+    return Math.min(base + jitter, 10_000);
+  };
+
+  const sleep = (ms: number) => new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+  const isRetriableStatus = (status: number): boolean => {
+    return status === 429 || status >= 500;
+  };
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetch(input, {
+        ...fetchInit,
+        signal: controller.signal,
+        headers: {
+          Accept: 'application/json',
+          ...(fetchInit.headers ?? {})
+        }
+      });
+
+      const text = await response.text();
+      if (!response.ok) {
+        if (attempt < maxRetries && isRetriableStatus(response.status)) {
+          await sleep(computeBackoffMs(attempt, response.headers.get('retry-after')));
+          continue;
+        }
+        throw new Error(toErrorMessage(response.status, response.statusText, text));
+      }
+
+      if (!text.trim()) {
+        return {} as T;
+      }
+
+      try {
+        return JSON.parse(text) as T;
+      } catch {
+        throw new Error(`Provider returned invalid JSON payload: ${text.slice(0, 300)}`);
+      }
+    } catch (error) {
+      const isAbort = error instanceof Error && error.name === 'AbortError';
+      const isNetwork = error instanceof TypeError;
+      if (attempt < maxRetries && (isAbort || isNetwork)) {
+        await sleep(computeBackoffMs(attempt, null));
+        continue;
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  throw new Error('Provider request failed after retries');
+}

--- a/apps/api/src/services/dnsProviders/index.ts
+++ b/apps/api/src/services/dnsProviders/index.ts
@@ -1,0 +1,62 @@
+import type { DnsAction, DnsIntegrationConfig, DnsProvider as DnsProviderType } from '../../db/schema';
+import { UmbrellaProvider } from './umbrella';
+import { CloudflareGatewayProvider } from './cloudflare';
+import { DnsFilterProvider } from './dnsfilter';
+import { PiHoleProvider } from './pihole';
+
+export interface DnsEvent {
+  timestamp: Date;
+  domain: string;
+  queryType: string;
+  action: DnsAction;
+  category?: string;
+  threatType?: string;
+  sourceIp?: string;
+  sourceHostname?: string;
+  providerEventId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface DnsProvider {
+  syncEvents(since: Date, until: Date): Promise<DnsEvent[]>;
+  addBlocklistDomain(domain: string, reason?: string): Promise<void>;
+  removeBlocklistDomain(domain: string): Promise<void>;
+  addAllowlistDomain(domain: string): Promise<void>;
+  removeAllowlistDomain(domain: string): Promise<void>;
+}
+
+export interface DnsProviderFactoryInput {
+  provider: DnsProviderType;
+  apiKey: string | null;
+  apiSecret: string | null;
+  config: DnsIntegrationConfig;
+}
+
+export function createDnsProvider(input: DnsProviderFactoryInput): DnsProvider {
+  if (!input.apiKey) {
+    throw new Error(`Missing apiKey for DNS provider ${input.provider}`);
+  }
+
+  switch (input.provider) {
+    case 'umbrella':
+      return new UmbrellaProvider(input.apiKey, input.apiSecret, input.config);
+    case 'cloudflare':
+      return new CloudflareGatewayProvider(input.apiKey, input.config);
+    case 'dnsfilter':
+      return new DnsFilterProvider(input.apiKey, input.config);
+    case 'pihole':
+      return new PiHoleProvider(input.apiKey, input.config);
+    case 'opendns':
+    case 'quad9':
+      throw new Error(`Provider ${input.provider} is not yet supported for API sync`);
+    default:
+      throw new Error(`Unsupported DNS provider: ${String(input.provider)}`);
+  }
+}
+
+export {
+  UmbrellaProvider,
+  CloudflareGatewayProvider,
+  DnsFilterProvider,
+  PiHoleProvider
+};

--- a/apps/api/src/services/dnsProviders/pihole.ts
+++ b/apps/api/src/services/dnsProviders/pihole.ts
@@ -1,0 +1,94 @@
+import type { DnsEvent, DnsProvider } from './index';
+import { requestJson } from './http';
+import { asArray, asNumber, asRecord, asString } from './helpers';
+
+export interface PiHoleProviderConfig {
+  apiEndpoint?: string;
+}
+
+export class PiHoleProvider implements DnsProvider {
+  constructor(
+    private readonly apiKey: string,
+    private readonly config: PiHoleProviderConfig
+  ) {}
+
+  private baseUrl(): string {
+    const endpoint = this.config.apiEndpoint;
+    if (!endpoint) {
+      throw new Error('Pi-hole integration requires config.apiEndpoint');
+    }
+    return endpoint.replace(/\/+$/, '');
+  }
+
+  private async callApi(params: Record<string, string>): Promise<Record<string, unknown>> {
+    const url = new URL(`${this.baseUrl()}/admin/api.php`);
+    for (const [key, value] of Object.entries(params)) {
+      url.searchParams.set(key, value);
+    }
+    url.searchParams.set('auth', this.apiKey);
+    return requestJson<Record<string, unknown>>(url);
+  }
+
+  async syncEvents(since: Date, until: Date): Promise<DnsEvent[]> {
+    const payload = await this.callApi({
+      getAllQueries: 'true'
+    });
+
+    const rows = asArray(payload.data);
+    return rows.flatMap((entry): DnsEvent[] => {
+      if (!Array.isArray(entry)) return [];
+
+      const epoch = asNumber(entry[0]);
+      const queryType = asString(entry[1]) ?? 'A';
+      const domain = asString(entry[2]);
+      const sourceIp = asString(entry[3]);
+      const status = asString(entry[4]) ?? '';
+
+      if (!epoch || !domain) return [];
+
+      const timestamp = new Date(epoch * 1000);
+      if (Number.isNaN(timestamp.getTime())) return [];
+      if (timestamp < since || timestamp > until) return [];
+
+      return [{
+        timestamp,
+        domain,
+        queryType,
+        action: status.toLowerCase().includes('block') ? 'blocked' : 'allowed',
+        sourceIp,
+        providerEventId: `${epoch}-${domain}-${sourceIp ?? 'unknown'}`,
+        metadata: {
+          raw: entry
+        }
+      }];
+    });
+  }
+
+  async addBlocklistDomain(domain: string): Promise<void> {
+    await this.callApi({
+      list: 'black',
+      add: domain
+    });
+  }
+
+  async removeBlocklistDomain(domain: string): Promise<void> {
+    await this.callApi({
+      list: 'black',
+      sub: domain
+    });
+  }
+
+  async addAllowlistDomain(domain: string): Promise<void> {
+    await this.callApi({
+      list: 'white',
+      add: domain
+    });
+  }
+
+  async removeAllowlistDomain(domain: string): Promise<void> {
+    await this.callApi({
+      list: 'white',
+      sub: domain
+    });
+  }
+}

--- a/apps/api/src/services/dnsProviders/umbrella.ts
+++ b/apps/api/src/services/dnsProviders/umbrella.ts
@@ -1,0 +1,209 @@
+import type { DnsEvent, DnsProvider } from './index';
+import { requestJson } from './http';
+import { asArray, asBoolean, asNumber, asRecord, asString, asStringArray } from './helpers';
+
+export interface UmbrellaProviderConfig {
+  organizationId?: string;
+  blocklistId?: string;
+  allowlistId?: string;
+}
+
+export class UmbrellaProvider implements DnsProvider {
+  constructor(
+    private readonly apiKey: string,
+    private readonly apiSecret: string | null | undefined,
+    private readonly config: UmbrellaProviderConfig
+  ) {}
+
+  private basicAuthHeader(): string {
+    if (!this.apiSecret) {
+      throw new Error('Cisco Umbrella integration requires apiSecret');
+    }
+    const token = Buffer.from(`${this.apiKey}:${this.apiSecret}`).toString('base64');
+    return `Basic ${token}`;
+  }
+
+  async syncEvents(since: Date, until: Date): Promise<DnsEvent[]> {
+    const orgId = this.config.organizationId;
+    if (!orgId) {
+      throw new Error('Cisco Umbrella integration requires config.organizationId');
+    }
+
+    const limit = 1000;
+    const maxPages = 100;
+    const allEvents: DnsEvent[] = [];
+    const seenPageKeys = new Set<string>();
+    let page = 1;
+    let cursor: string | undefined;
+
+    for (let i = 0; i < maxPages; i++) {
+      const url = new URL(`https://reports.api.umbrella.com/v2/organizations/${orgId}/security-activity`);
+      url.searchParams.set('from', since.toISOString());
+      url.searchParams.set('to', until.toISOString());
+      url.searchParams.set('limit', String(limit));
+      if (cursor) {
+        url.searchParams.set('cursor', cursor);
+      } else {
+        url.searchParams.set('page', String(page));
+      }
+
+      const payload = await requestJson<Record<string, unknown>>(url, {
+        headers: {
+          Authorization: this.basicAuthHeader(),
+        }
+      });
+
+      const requests = asArray(payload.requests ?? payload.data);
+      const mapped = requests.flatMap((entry): DnsEvent[] => {
+        const record = asRecord(entry);
+        if (!record) return [];
+
+        const timestampRaw = asString(record.datetime);
+        const domain = asString(record.domain);
+        if (!timestampRaw || !domain) return [];
+
+        const timestamp = new Date(timestampRaw);
+        if (Number.isNaN(timestamp.getTime())) return [];
+
+        const verdict = asString(record.verdict)?.toLowerCase();
+        const categories = asStringArray(record.categories);
+
+        return [{
+          timestamp,
+          domain,
+          queryType: asString(record.query_type) ?? 'A',
+          action: verdict?.includes('block') ? 'blocked' : 'allowed',
+          category: categories[0],
+          threatType: asString(record.threat_type),
+          sourceIp: asString(record.internal_ip) ?? asString(record.src_ip),
+          sourceHostname: asString(record.identity),
+          providerEventId: asString(record.request_id),
+          metadata: {
+            categories
+          }
+        }];
+      });
+      allEvents.push(...mapped);
+
+      const paging = asRecord(payload.paging)
+        ?? asRecord(payload.meta)
+        ?? asRecord(payload.metadata)
+        ?? asRecord(payload.result_info);
+      const links = asRecord(payload.links);
+
+      const nextCursor = asString(payload.next_cursor)
+        ?? asString(paging?.next_cursor)
+        ?? asString(paging?.cursor)
+        ?? asString(links?.next)
+        ?? asString(payload.next);
+      const nextPage = asNumber(payload.next_page) ?? asNumber(paging?.next_page);
+      const hasMore = asBoolean(payload.has_more) ?? asBoolean(paging?.has_more);
+
+      if (nextCursor) {
+        const key = `cursor:${nextCursor}`;
+        if (seenPageKeys.has(key)) break;
+        seenPageKeys.add(key);
+        if (nextCursor.startsWith('http')) {
+          const nextUrl = new URL(nextCursor);
+          cursor = asString(nextUrl.searchParams.get('cursor')) ?? undefined;
+          page = asNumber(nextUrl.searchParams.get('page')) ?? (page + 1);
+        } else if (/^\d+$/.test(nextCursor)) {
+          cursor = undefined;
+          page = Number(nextCursor);
+        } else {
+          cursor = nextCursor;
+        }
+        continue;
+      }
+
+      if (typeof nextPage === 'number' && nextPage > page) {
+        const key = `page:${nextPage}`;
+        if (seenPageKeys.has(key)) break;
+        seenPageKeys.add(key);
+        cursor = undefined;
+        page = nextPage;
+        continue;
+      }
+
+      if (hasMore === true && requests.length >= limit) {
+        const candidate = page + 1;
+        const key = `page:${candidate}`;
+        if (seenPageKeys.has(key)) break;
+        seenPageKeys.add(key);
+        cursor = undefined;
+        page = candidate;
+        continue;
+      }
+
+      break;
+    }
+
+    return allEvents;
+  }
+
+  private getDestinationListId(type: 'block' | 'allow'): string {
+    const listId = type === 'block' ? this.config.blocklistId : this.config.allowlistId;
+    if (!listId) {
+      throw new Error(`Cisco Umbrella ${type}list sync requires ${type}listId in integration config`);
+    }
+    return listId;
+  }
+
+  async addBlocklistDomain(domain: string, reason?: string): Promise<void> {
+    const listId = this.getDestinationListId('block');
+    const url = `https://api.umbrella.com/policies/v2/destinationlists/${listId}/destinations`;
+    await requestJson(url, {
+      method: 'POST',
+      headers: {
+        Authorization: this.basicAuthHeader(),
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        destination: domain,
+        comment: reason
+      })
+    });
+  }
+
+  async removeBlocklistDomain(domain: string): Promise<void> {
+    const listId = this.getDestinationListId('block');
+    const url = new URL(`https://api.umbrella.com/policies/v2/destinationlists/${listId}/destinations`);
+    url.searchParams.set('destination', domain);
+
+    await requestJson(url, {
+      method: 'DELETE',
+      headers: {
+        Authorization: this.basicAuthHeader()
+      }
+    });
+  }
+
+  async addAllowlistDomain(domain: string): Promise<void> {
+    const listId = this.getDestinationListId('allow');
+    const url = `https://api.umbrella.com/policies/v2/destinationlists/${listId}/destinations`;
+
+    await requestJson(url, {
+      method: 'POST',
+      headers: {
+        Authorization: this.basicAuthHeader(),
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        destination: domain
+      })
+    });
+  }
+
+  async removeAllowlistDomain(domain: string): Promise<void> {
+    const listId = this.getDestinationListId('allow');
+    const url = new URL(`https://api.umbrella.com/policies/v2/destinationlists/${listId}/destinations`);
+    url.searchParams.set('destination', domain);
+
+    await requestJson(url, {
+      method: 'DELETE',
+      headers: {
+        Authorization: this.basicAuthHeader()
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add DNS security schema, migrations, provider adapters, routes, and sync worker
- register DNS security routes and worker lifecycle in API bootstrap
- add AI tools for DNS security analytics and DNS policy management
- harden manage_dns_policy behavior for scheduling failures and remove-only actions
- normalize DNS category mapping and stabilize empty-summary numeric fields

## Validation
- pnpm -C apps/api build
- pnpm -C apps/api exec vitest run src/services/aiToolSchemas.security.test.ts src/services/aiGuardrails.test.ts src/routes/mcpServer.test.ts