### PR TITLE
Improve security posture query performance and trend metrics

### DIFF
--- a/apps/api/src/db/migrations/2026-02-22-security-posture-query-indexes.sql
+++ b/apps/api/src/db/migrations/2026-02-22-security-posture-query-indexes.sql
@@ -1,0 +1,22 @@
+BEGIN;
+
+-- Latest posture snapshot resolution per org/device.
+CREATE INDEX IF NOT EXISTS security_posture_snapshots_org_device_captured_idx
+  ON security_posture_snapshots (org_id, device_id, captured_at);
+
+-- Active threat and per-device status lookups.
+CREATE INDEX IF NOT EXISTS security_threats_device_status_detected_idx
+  ON security_threats (device_id, status, detected_at);
+
+-- Connection aggregation paths for posture scoring.
+CREATE INDEX IF NOT EXISTS device_connections_device_port_state_idx
+  ON device_connections (device_id, local_port, state);
+
+CREATE INDEX IF NOT EXISTS device_connections_device_updated_idx
+  ON device_connections (device_id, updated_at);
+
+CREATE INDEX IF NOT EXISTS device_connections_device_listening_port_idx
+  ON device_connections (device_id, local_port)
+  WHERE remote_addr IS NULL OR lower(state) LIKE 'listen%';
+
+COMMIT;

--- a/apps/api/src/db/schema/devices.ts
+++ b/apps/api/src/db/schema/devices.ts
@@ -234,7 +234,14 @@ export const deviceConnections = pgTable('device_connections', {
   pid: integer('pid'),
   processName: varchar('process_name', { length: 255 }),
   updatedAt: timestamp('updated_at').defaultNow().notNull()
-});
+}, (table) => ({
+  devicePortStateIdx: index('device_connections_device_port_state_idx').on(
+    table.deviceId,
+    table.localPort,
+    table.state
+  ),
+  deviceUpdatedIdx: index('device_connections_device_updated_idx').on(table.deviceId, table.updatedAt)
+}));
 
 // Boot performance metrics - stores boot time history and startup item analysis per device
 export interface BootStartupItem {

--- a/apps/api/src/db/schema/security.ts
+++ b/apps/api/src/db/schema/security.ts
@@ -88,7 +88,8 @@ export const securityThreats = pgTable('security_threats', {
   details: jsonb('details')
 }, (table) => ({
   deviceDetectedIdx: index('security_threats_device_detected_idx').on(table.deviceId, table.detectedAt),
-  statusIdx: index('security_threats_status_idx').on(table.status)
+  statusIdx: index('security_threats_status_idx').on(table.status),
+  deviceStatusDetectedIdx: index('security_threats_device_status_detected_idx').on(table.deviceId, table.status, table.detectedAt)
 }));
 
 export const securityScans = pgTable('security_scans', {
@@ -138,7 +139,8 @@ export const securityPostureSnapshots = pgTable('security_posture_snapshots', {
 }, (table) => ({
   orgCapturedIdx: index('security_posture_snapshots_org_captured_idx').on(table.orgId, table.capturedAt),
   deviceCapturedIdx: index('security_posture_snapshots_device_captured_idx').on(table.deviceId, table.capturedAt),
-  orgScoreIdx: index('security_posture_snapshots_org_score_idx').on(table.orgId, table.overallScore)
+  orgScoreIdx: index('security_posture_snapshots_org_score_idx').on(table.orgId, table.overallScore),
+  orgDeviceCapturedIdx: index('security_posture_snapshots_org_device_captured_idx').on(table.orgId, table.deviceId, table.capturedAt)
 }));
 
 export const securityPostureOrgSnapshots = pgTable('security_posture_org_snapshots', {

--- a/apps/api/src/jobs/securityPostureWorker.test.ts
+++ b/apps/api/src/jobs/securityPostureWorker.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('bullmq', () => ({
+  Queue: class {},
+  Worker: class {},
+  Job: class {}
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn()
+  },
+  withSystemDbAccessContext: undefined
+}));
+
+vi.mock('../db/schema', () => ({
+  devices: {
+    orgId: 'org_id',
+    status: 'status'
+  }
+}));
+
+vi.mock('../services/redis', () => ({
+  getRedisConnection: vi.fn(() => ({}))
+}));
+
+vi.mock('../services/securityPosture', () => ({
+  computeAndPersistOrgSecurityPosture: vi.fn()
+}));
+
+vi.mock('../services/eventBus', () => ({
+  publishEvent: vi.fn()
+}));
+
+import { publishEvent } from '../services/eventBus';
+import { publishSecurityScoreChangedEvents } from './securityPostureWorker';
+
+function buildChanges(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    orgId: '11111111-1111-1111-1111-111111111111',
+    deviceId: `00000000-0000-0000-0000-${String(index).padStart(12, '0')}`,
+    previousScore: 70,
+    currentScore: 75,
+    delta: 5,
+    previousRiskLevel: 'medium' as const,
+    currentRiskLevel: 'low' as const,
+    changedFactors: ['patch_compliance']
+  }));
+}
+
+describe('publishSecurityScoreChangedEvents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(publishEvent).mockResolvedValue('event-id');
+  });
+
+  it('caps published events at the configured limit', async () => {
+    const changes = buildChanges(250);
+    const result = await publishSecurityScoreChangedEvents(changes, '2026-02-22T00:00:00.000Z', {
+      limit: 200,
+      concurrency: 8
+    });
+
+    expect(vi.mocked(publishEvent)).toHaveBeenCalledTimes(200);
+    expect(result).toEqual({
+      attempted: 200,
+      published: 200,
+      failed: 0
+    });
+  });
+
+  it('continues publishing when some events fail', async () => {
+    let callCount = 0;
+    vi.mocked(publishEvent).mockImplementation(async () => {
+      callCount++;
+      if (callCount === 4) {
+        throw new Error('publish failed');
+      }
+      return 'event-id';
+    });
+
+    const changes = buildChanges(10);
+    const result = await publishSecurityScoreChangedEvents(changes, '2026-02-22T00:00:00.000Z', {
+      limit: 10,
+      concurrency: 4
+    });
+
+    expect(vi.mocked(publishEvent)).toHaveBeenCalledTimes(10);
+    expect(result).toEqual({
+      attempted: 10,
+      published: 9,
+      failed: 1
+    });
+  });
+
+  it('respects bounded concurrency', async () => {
+    let active = 0;
+    let maxActive = 0;
+    vi.mocked(publishEvent).mockImplementation(async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active--;
+      return 'event-id';
+    });
+
+    const changes = buildChanges(12);
+    const result = await publishSecurityScoreChangedEvents(changes, '2026-02-22T00:00:00.000Z', {
+      limit: 12,
+      concurrency: 3
+    });
+
+    expect(result.failed).toBe(0);
+    expect(result.published).toBe(12);
+    expect(maxActive).toBeLessThanOrEqual(3);
+  });
+});

--- a/apps/api/src/routes/security.test.ts
+++ b/apps/api/src/routes/security.test.ts
@@ -520,6 +520,53 @@ describe('security routes', () => {
     });
   });
 
+  describe('GET /security/trends', () => {
+    it('should include exposure factors and vulnerability management trend points', async () => {
+      vi.mocked(getSecurityPostureTrend).mockResolvedValue([
+        {
+          timestamp: '2026-02-20',
+          overall: 70,
+          antivirus: 78,
+          firewall: 80,
+          encryption: 82,
+          open_ports: 65,
+          password_policy: 76,
+          os_currency: 75,
+          admin_accounts: 79,
+          patch_compliance: 73,
+          vulnerability_management: 70
+        },
+        {
+          timestamp: '2026-02-21',
+          overall: 72,
+          antivirus: 79,
+          firewall: 81,
+          encryption: 83,
+          open_ports: 68,
+          password_policy: 77,
+          os_currency: 78,
+          admin_accounts: 80,
+          patch_compliance: 74,
+          vulnerability_management: 73
+        }
+      ] as any);
+
+      const res = await app.request('/security/trends?period=30d', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.dataPoints).toHaveLength(2);
+      expect(body.data.dataPoints[0].open_ports).toBe(65);
+      expect(body.data.dataPoints[0].os_currency).toBe(75);
+      expect(body.data.dataPoints[0].vulnerability_management).toBe(70);
+      expect(body.data.summary.previous).toBe(70);
+      expect(body.data.summary.current).toBe(72);
+    });
+  });
+
   describe('GET /security/password-policy', () => {
     it('should use ingested password policy telemetry for compliance and checks', async () => {
       mockStatusSelect([

--- a/apps/api/src/routes/security/helpers.ts
+++ b/apps/api/src/routes/security/helpers.ts
@@ -810,22 +810,30 @@ export async function buildBe9Recommendations(
     threats.filter((threat) => threat.status === 'active').map((threat) => threat.deviceId)
   );
 
+  const affectedCounts = {
+    antivirus: 0,
+    firewall: 0,
+    encryption: 0,
+    password_policy: 0,
+    admin_accounts: 0,
+    patch_compliance: 0,
+    vulnerability_management: 0
+  };
+
   const vulnerabilityDevices = new Set(activeThreatDevices);
   for (const item of posture) {
+    if (item.factors.av_health.score < 80) affectedCounts.antivirus++;
+    if (item.factors.firewall.score < 90) affectedCounts.firewall++;
+    if (item.factors.encryption.score < 90) affectedCounts.encryption++;
+    if (item.factors.password_policy.score < 85) affectedCounts.password_policy++;
+    if (item.factors.admin_exposure.score < 85) affectedCounts.admin_accounts++;
+    if (item.factors.patch_compliance.score < 90) affectedCounts.patch_compliance++;
+
     if (item.factors.open_ports.score < 70 || item.factors.os_currency.score < 70) {
       vulnerabilityDevices.add(item.deviceId);
     }
   }
-
-  const affectedCounts = {
-    antivirus: countFactorBelow(posture, 'av_health', 80),
-    firewall: countFactorBelow(posture, 'firewall', 90),
-    encryption: countFactorBelow(posture, 'encryption', 90),
-    password_policy: countFactorBelow(posture, 'password_policy', 85),
-    admin_accounts: countFactorBelow(posture, 'admin_exposure', 85),
-    patch_compliance: countFactorBelow(posture, 'patch_compliance', 90),
-    vulnerability_management: vulnerabilityDevices.size
-  };
+  affectedCounts.vulnerability_management = vulnerabilityDevices.size;
 
   const definitions: Array<{
     id: string;

--- a/apps/api/src/services/securityPosture.test.ts
+++ b/apps/api/src/services/securityPosture.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeTrendPoint } from './securityPosture';
+
+describe('computeTrendPoint', () => {
+  it('derives vulnerability_management from open_ports and os_currency averages', () => {
+    const point = computeTrendPoint('2026-02-22', [
+      {
+        overallScore: 70,
+        patchComplianceScore: 72,
+        encryptionScore: 80,
+        avHealthScore: 78,
+        firewallScore: 76,
+        openPortsScore: 50,
+        passwordPolicyScore: 74,
+        osCurrencyScore: 80,
+        adminExposureScore: 75
+      },
+      {
+        overallScore: 74,
+        patchComplianceScore: 76,
+        encryptionScore: 82,
+        avHealthScore: 80,
+        firewallScore: 78,
+        openPortsScore: 70,
+        passwordPolicyScore: 78,
+        osCurrencyScore: 60,
+        adminExposureScore: 77
+      }
+    ]);
+
+    expect(point.open_ports).toBe(60);
+    expect(point.os_currency).toBe(70);
+    expect(point.vulnerability_management).toBe(65);
+  });
+
+  it('returns zeroed factors for empty input', () => {
+    const point = computeTrendPoint('2026-02-22', []);
+
+    expect(point.timestamp).toBe('2026-02-22');
+    expect(point.overall).toBe(0);
+    expect(point.open_ports).toBe(0);
+    expect(point.os_currency).toBe(0);
+    expect(point.vulnerability_management).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add targeted DB indexes for security posture and connection query patterns
- optimize posture snapshot retrieval and latest posture filtering using windowed SQL queries
- compute open-port posture from aggregated DB stats and align vulnerability trend/recommendation logic with open ports + OS currency
- make security score change event publishing bounded/concurrent with configurable limits and add focused tests

## Testing
- pnpm -C apps/api test:run src/routes/security.test.ts src/services/securityPosture.test.ts
- pnpm -C apps/api test:run src/jobs/securityPostureWorker.test.ts