### PR TITLE
feat: invert fallback audit from whitelist to blocklist

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -313,7 +313,7 @@ const FALLBACK_AUDIT_EXCLUDE_PATHS: RegExp[] = [
   /^\/api\/v1\/system-tools\/devices\/[^/]+\/registry\/key$/,
   /^\/api\/v1\/system-tools\/devices\/[^/]+\/files\/upload$/,
   // AI chat streaming is high-volume — exclude from fallback audit
-  /^\/api\/v1\/helper\/sessions\/[^/]+\/messages$/,
+  /^\/api\/v1\/helper\/chat\/sessions\/[^/]+\/messages$/,
 ];
 
 const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
@@ -361,7 +361,10 @@ function fallbackAuditEligible(path: string): boolean {
   if (FALLBACK_AUDIT_EXCLUDE_PATHS.some((pattern) => pattern.test(path))) {
     return false;
   }
-  if (FALLBACK_AUDIT_EXCLUDE_PREFIXES.some((pfx) => path.startsWith(`/api/v1${pfx}`))) {
+  if (FALLBACK_AUDIT_EXCLUDE_PREFIXES.some((pfx) => {
+    const full = `/api/v1${pfx}`;
+    return path === full || path.startsWith(`${full}/`);
+  })) {
     return false;
   }
   return path.startsWith('/api/v1/');


### PR DESCRIPTION
## Summary
- Replaces the `FALLBACK_AUDIT_PREFIXES` whitelist (~36 route prefixes) with a small `FALLBACK_AUDIT_EXCLUDE_PREFIXES` blocklist (6 entries: `/docs`, `/search`, `/metrics`, `/agent-ws`, `/desktop-ws`, `/dev`)
- Any new API route now automatically gets fallback audit coverage without needing to update a whitelist
- Adds high-volume AI chat streaming endpoint (`/helper/sessions/:id/messages`) to the regex exclusion list

## Context
Audit logs were missing events for partner-scoped users (login, password set, user deletion) because many audit calls were gated behind `if (orgId)` checks, and the fallback audit middleware used a whitelist of ~36 route prefixes — any route not in that list got zero fallback coverage. New routes added to the API silently skipped auditing.

## What changed
- **Deleted** `FALLBACK_AUDIT_PREFIXES` (whitelist)
- **Added** `FALLBACK_AUDIT_EXCLUDE_PREFIXES` (blocklist of genuinely non-auditable routes)
- **Rewrote** `fallbackAuditEligible()` to exclude blocklisted paths, then allow any `/api/v1/` route
- Routes with explicit audit calls will produce both their explicit event and a fallback event (marked `{ fallback: true }`) — duplicates are safer than gaps

## Test plan
- [x] `npx tsc --noEmit` passes clean
- [x] Confirmed `FALLBACK_AUDIT_PREFIXES` no longer exists in codebase
- [ ] Manual: mutation request to a previously uncovered route (e.g. `POST /api/v1/scripts`) produces an audit row with `{ fallback: true }`
- [ ] Manual: GET requests and excluded paths (agent heartbeat, docs) do NOT generate fallback audit events

🤖 Generated with [Claude Code](https://claude.com/claude-code)