### PR TITLE
Add user risk scoring APIs, jobs, and AI tooling

### DIFF
--- a/apps/api/drizzle/0002_user_risk_scoring.sql
+++ b/apps/api/drizzle/0002_user_risk_scoring.sql
@@ -1,0 +1,45 @@
+CREATE TABLE "user_risk_scores" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"org_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"score" integer NOT NULL,
+	"factors" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"trend_direction" varchar(20),
+	"calculated_at" timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "user_risk_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"org_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"event_type" varchar(60) NOT NULL,
+	"severity" varchar(20),
+	"score_impact" integer DEFAULT 0 NOT NULL,
+	"description" text NOT NULL,
+	"details" jsonb,
+	"occurred_at" timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "user_risk_policies" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"org_id" uuid NOT NULL,
+	"weights" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"thresholds" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"interventions" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"updated_by" uuid,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "user_risk_scores" ADD CONSTRAINT "user_risk_scores_org_id_organizations_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."organizations"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_risk_scores" ADD CONSTRAINT "user_risk_scores_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_risk_events" ADD CONSTRAINT "user_risk_events_org_id_organizations_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."organizations"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_risk_events" ADD CONSTRAINT "user_risk_events_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_risk_policies" ADD CONSTRAINT "user_risk_policies_org_id_organizations_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."organizations"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_risk_policies" ADD CONSTRAINT "user_risk_policies_updated_by_users_id_fk" FOREIGN KEY ("updated_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "user_risk_org_user_calc_idx" ON "user_risk_scores" USING btree ("org_id","user_id","calculated_at");--> statement-breakpoint
+CREATE INDEX "user_risk_score_idx" ON "user_risk_scores" USING btree ("score");--> statement-breakpoint
+CREATE INDEX "user_risk_org_score_idx" ON "user_risk_scores" USING btree ("org_id","score");--> statement-breakpoint
+CREATE INDEX "user_risk_org_user_idx" ON "user_risk_scores" USING btree ("org_id","user_id");--> statement-breakpoint
+CREATE INDEX "user_risk_events_org_user_time_idx" ON "user_risk_events" USING btree ("org_id","user_id","occurred_at");--> statement-breakpoint
+CREATE INDEX "user_risk_events_org_event_type_time_idx" ON "user_risk_events" USING btree ("org_id","event_type","occurred_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "user_risk_policy_org_idx" ON "user_risk_policies" USING btree ("org_id");

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1771660800000,
       "tag": "0001_software_policies",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1772064000000,
+      "tag": "0002_user_risk_scoring",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -32,6 +32,7 @@ export * from './agentVersions';
 export * from './eventLogs';
 export * from './auditBaselines';
 export * from './reliability';
+export * from './userRisk';
 export * from './ai';
 export * from './monitors';
 export * from './filesystem';

--- a/apps/api/src/db/schema/userRisk.ts
+++ b/apps/api/src/db/schema/userRisk.ts
@@ -1,0 +1,71 @@
+import {
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar
+} from 'drizzle-orm/pg-core';
+import { organizations } from './orgs';
+import { users } from './users';
+
+export type UserRiskFactorBreakdown = Record<string, number>;
+export type UserRiskPolicyWeights = Record<string, number>;
+export type UserRiskPolicyThresholds = {
+  medium?: number;
+  high?: number;
+  critical?: number;
+  spikeDelta?: number;
+  autoAssignTrainingAtOrAbove?: number;
+};
+export type UserRiskPolicyInterventions = {
+  autoAssignTraining?: boolean;
+  trainingModuleId?: string;
+  notifyOnHighRisk?: boolean;
+  notifyOnRiskSpike?: boolean;
+};
+
+export const userRiskScores = pgTable('user_risk_scores', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  userId: uuid('user_id').notNull().references(() => users.id),
+  score: integer('score').notNull(),
+  factors: jsonb('factors').$type<UserRiskFactorBreakdown>().notNull().default({}),
+  trendDirection: varchar('trend_direction', { length: 20 }),
+  calculatedAt: timestamp('calculated_at').notNull(),
+}, (table) => ({
+  orgUserCalcIdx: uniqueIndex('user_risk_org_user_calc_idx').on(table.orgId, table.userId, table.calculatedAt),
+  scoreIdx: index('user_risk_score_idx').on(table.score),
+  orgScoreIdx: index('user_risk_org_score_idx').on(table.orgId, table.score),
+  orgUserIdx: index('user_risk_org_user_idx').on(table.orgId, table.userId),
+}));
+
+export const userRiskEvents = pgTable('user_risk_events', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  userId: uuid('user_id').notNull().references(() => users.id),
+  eventType: varchar('event_type', { length: 60 }).notNull(),
+  severity: varchar('severity', { length: 20 }),
+  scoreImpact: integer('score_impact').notNull().default(0),
+  description: text('description').notNull(),
+  details: jsonb('details'),
+  occurredAt: timestamp('occurred_at').notNull(),
+}, (table) => ({
+  orgUserTimeIdx: index('user_risk_events_org_user_time_idx').on(table.orgId, table.userId, table.occurredAt),
+  orgEventTypeTimeIdx: index('user_risk_events_org_event_type_time_idx').on(table.orgId, table.eventType, table.occurredAt),
+}));
+
+export const userRiskPolicies = pgTable('user_risk_policies', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  weights: jsonb('weights').$type<UserRiskPolicyWeights>().notNull().default({}),
+  thresholds: jsonb('thresholds').$type<UserRiskPolicyThresholds>().notNull().default({}),
+  interventions: jsonb('interventions').$type<UserRiskPolicyInterventions>().notNull().default({}),
+  updatedBy: uuid('updated_by').references(() => users.id),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (table) => ({
+  orgIdx: uniqueIndex('user_risk_policy_org_idx').on(table.orgId),
+}));

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -52,6 +52,7 @@ import { maintenanceRoutes } from './routes/maintenance';
 import { securityRoutes } from './routes/security';
 import { cisHardeningRoutes } from './routes/cisHardening';
 import { reliabilityRoutes } from './routes/reliability';
+import { userRiskRoutes } from './routes/userRisk';
 import { snmpRoutes } from './routes/snmp';
 import { monitorRoutes } from './routes/monitors';
 import { monitoringRoutes } from './routes/monitoring';
@@ -112,6 +113,8 @@ import { initializePolicyEvaluationWorker, shutdownPolicyEvaluationWorker } from
 import { initializeAutomationWorker, shutdownAutomationWorker } from './jobs/automationWorker';
 import { initializeSecurityPostureWorker, shutdownSecurityPostureWorker } from './jobs/securityPostureWorker';
 import { initializeReliabilityWorker, shutdownReliabilityWorker } from './jobs/reliabilityWorker';
+import { initializeUserRiskJobs, shutdownUserRiskJobs } from './jobs/userRiskJobs';
+import { initializeUserRiskRetention, shutdownUserRiskRetention } from './jobs/userRiskRetention';
 import { initializePatchComplianceReportWorker, shutdownPatchComplianceReportWorker } from './jobs/patchComplianceReportWorker';
 import { initializeSoftwareComplianceWorker, shutdownSoftwareComplianceWorker } from './jobs/softwareComplianceWorker';
 import { initializeSoftwareRemediationWorker, shutdownSoftwareRemediationWorker } from './jobs/softwareRemediationWorker';
@@ -629,6 +632,7 @@ api.route('/maintenance', maintenanceRoutes);
 api.route('/security', securityRoutes);
 api.route('/cis', cisHardeningRoutes);
 api.route('/reliability', reliabilityRoutes);
+api.route('/user-risk', userRiskRoutes);
 api.route('/snmp', snmpRoutes);
 api.route('/monitors', monitorRoutes);
 api.route('/monitoring', monitoringRoutes);
@@ -855,6 +859,8 @@ async function initializeWorkers(): Promise<void> {
     ['automationWorker', initializeAutomationWorker],
     ['securityPostureWorker', initializeSecurityPostureWorker],
     ['reliabilityWorker', initializeReliabilityWorker],
+    ['userRiskWorker', initializeUserRiskJobs],
+    ['userRiskRetention', initializeUserRiskRetention],
     ['policyAlertBridge', initializePolicyAlertBridge],
     ['eventLogRetention', initializeEventLogRetention],
     ['logCorrelationWorker', initializeLogCorrelationWorker],
@@ -987,6 +993,8 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownPlaybookRetention,
     shutdownSecurityPostureWorker,
     shutdownReliabilityWorker,
+    shutdownUserRiskJobs,
+    shutdownUserRiskRetention,
     shutdownAutomationWorker,
     shutdownSoftwareRemediationWorker,
     shutdownSoftwareComplianceWorker,

--- a/apps/api/src/jobs/userRiskJobs.ts
+++ b/apps/api/src/jobs/userRiskJobs.ts
@@ -1,0 +1,274 @@
+import { Job, Queue, Worker } from 'bullmq';
+import { sql } from 'drizzle-orm';
+
+import * as dbModule from '../db';
+import { organizationUsers } from '../db/schema';
+import { getRedisConnection } from '../services/redis';
+import {
+  appendUserRiskSignalEvent,
+  computeAndPersistUserRiskForUser,
+  computeAndPersistOrgUserRisk,
+  publishUserRiskScoreEvents
+} from '../services/userRiskScoring';
+
+const { db } = dbModule;
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const withSystem = dbModule.withSystemDbAccessContext;
+  return typeof withSystem === 'function' ? withSystem(fn) : fn();
+};
+
+const USER_RISK_QUEUE = 'user-risk-scoring';
+function parsePositiveIntEnv(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  if (!raw) return defaultValue;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.warn(`[UserRiskJobs] Invalid ${name}="${raw}", using default ${defaultValue}`);
+    return defaultValue;
+  }
+  return parsed;
+}
+
+const SCAN_INTERVAL_MS = parsePositiveIntEnv('USER_RISK_SCAN_INTERVAL_MS', 6 * 60 * 60 * 1000);
+const USER_RISK_WORKER_CONCURRENCY = parsePositiveIntEnv('USER_RISK_WORKER_CONCURRENCY', 3);
+
+type ScanOrgsJobData = {
+  type: 'scan-orgs';
+  queuedAt: string;
+};
+
+type ComputeOrgJobData = {
+  type: 'compute-org';
+  orgId: string;
+  queuedAt: string;
+};
+
+type ProcessSignalEventJobData = {
+  type: 'process-signal-event';
+  orgId: string;
+  userId: string;
+  eventType: string;
+  severity?: 'low' | 'medium' | 'high' | 'critical';
+  scoreImpact?: number;
+  description: string;
+  details?: Record<string, unknown>;
+  occurredAt?: string;
+  queuedAt: string;
+};
+
+type UserRiskJobData = ScanOrgsJobData | ComputeOrgJobData | ProcessSignalEventJobData;
+
+let userRiskQueue: Queue<UserRiskJobData> | null = null;
+let userRiskWorker: Worker<UserRiskJobData> | null = null;
+
+export function getUserRiskQueue(): Queue<UserRiskJobData> {
+  if (!userRiskQueue) {
+    userRiskQueue = new Queue<UserRiskJobData>(USER_RISK_QUEUE, {
+      connection: getRedisConnection()
+    });
+  }
+  return userRiskQueue;
+}
+
+async function processScanOrgs(data: ScanOrgsJobData): Promise<{ queued: number }> {
+  const orgRows = await db
+    .select({ orgId: organizationUsers.orgId })
+    .from(organizationUsers)
+    .where(sql`${organizationUsers.orgId} is not null`)
+    .groupBy(organizationUsers.orgId);
+
+  if (orgRows.length === 0) {
+    return { queued: 0 };
+  }
+
+  const queue = getUserRiskQueue();
+  const slotKey = data.queuedAt.slice(0, 13);
+  await queue.addBulk(
+    orgRows.map((row) => ({
+      name: 'compute-org',
+      data: {
+        type: 'compute-org' as const,
+        orgId: row.orgId,
+        queuedAt: data.queuedAt
+      },
+      opts: {
+        jobId: `user-risk-${row.orgId}-${slotKey}`,
+        removeOnComplete: { count: 50 },
+        removeOnFail: { count: 200 }
+      }
+    }))
+  );
+
+  return { queued: orgRows.length };
+}
+
+async function processComputeOrg(data: ComputeOrgJobData): Promise<{
+  orgId: string;
+  usersProcessed: number;
+  changedUsers: number;
+  autoTrainingAssigned: number;
+  publishedHigh: number;
+  publishedSpikes: number;
+  publishFailures: number;
+}> {
+  const result = await computeAndPersistOrgUserRisk(data.orgId);
+  const published = await publishUserRiskScoreEvents({
+    orgId: data.orgId,
+    changedUsers: result.changedUsers,
+    thresholds: result.policy.thresholds,
+    interventions: result.policy.interventions
+  });
+
+  return {
+    orgId: data.orgId,
+    usersProcessed: result.usersProcessed,
+    changedUsers: result.changedUsers.length,
+    autoTrainingAssigned: result.autoTrainingAssigned,
+    publishedHigh: published.publishedHigh,
+    publishedSpikes: published.publishedSpikes,
+    publishFailures: published.failed
+  };
+}
+
+async function processSignalEvent(data: ProcessSignalEventJobData): Promise<{
+  orgId: string;
+  userId: string;
+  eventId: string;
+  recomputed: boolean;
+  changedUsers: number;
+  publishedHigh: number;
+  publishedSpikes: number;
+  publishFailures: number;
+}> {
+  const eventId = await appendUserRiskSignalEvent({
+    orgId: data.orgId,
+    userId: data.userId,
+    eventType: data.eventType,
+    severity: data.severity,
+    scoreImpact: data.scoreImpact,
+    description: data.description,
+    details: data.details,
+    occurredAt: data.occurredAt ? new Date(data.occurredAt) : undefined
+  });
+
+  const result = await computeAndPersistUserRiskForUser(data.orgId, data.userId);
+  const published = await publishUserRiskScoreEvents({
+    orgId: data.orgId,
+    changedUsers: result.changedUsers,
+    thresholds: result.policy.thresholds,
+    interventions: result.policy.interventions
+  });
+
+  return {
+    orgId: data.orgId,
+    userId: data.userId,
+    eventId,
+    recomputed: true,
+    changedUsers: result.changedUsers.length,
+    publishedHigh: published.publishedHigh,
+    publishedSpikes: published.publishedSpikes,
+    publishFailures: published.failed
+  };
+}
+
+export function createUserRiskWorker(): Worker<UserRiskJobData> {
+  return new Worker<UserRiskJobData>(
+    USER_RISK_QUEUE,
+    async (job: Job<UserRiskJobData>) => {
+      return runWithSystemDbAccess(async () => {
+        if (job.data.type === 'scan-orgs') {
+          return processScanOrgs(job.data);
+        }
+        if (job.data.type === 'compute-org') {
+          return processComputeOrg(job.data);
+        }
+        return processSignalEvent(job.data);
+      });
+    },
+    {
+      connection: getRedisConnection(),
+      concurrency: USER_RISK_WORKER_CONCURRENCY
+    }
+  );
+}
+
+async function scheduleUserRiskScan(): Promise<void> {
+  const queue = getUserRiskQueue();
+  const existing = await queue.getRepeatableJobs();
+  for (const job of existing) {
+    if (job.name === 'scan-orgs') {
+      await queue.removeRepeatableByKey(job.key);
+    }
+  }
+
+  await queue.add(
+    'scan-orgs',
+    {
+      type: 'scan-orgs',
+      queuedAt: new Date().toISOString()
+    },
+    {
+      repeat: { every: SCAN_INTERVAL_MS },
+      removeOnComplete: { count: 10 },
+      removeOnFail: { count: 50 }
+    }
+  );
+}
+
+export async function initializeUserRiskJobs(): Promise<void> {
+  userRiskWorker = createUserRiskWorker();
+  userRiskWorker.on('error', (error) => {
+    console.error('[UserRiskJobs] Worker error:', error);
+  });
+  userRiskWorker.on('failed', (job, error) => {
+    console.error(`[UserRiskJobs] Job ${job?.id} (${job?.data?.type}) failed:`, error);
+  });
+
+  await scheduleUserRiskScan();
+  console.log('[UserRiskJobs] User risk worker initialized');
+}
+
+export async function shutdownUserRiskJobs(): Promise<void> {
+  if (userRiskWorker) {
+    await userRiskWorker.close();
+    userRiskWorker = null;
+  }
+  if (userRiskQueue) {
+    await userRiskQueue.close();
+    userRiskQueue = null;
+  }
+}
+
+export async function triggerUserRiskRecompute(orgId: string): Promise<string> {
+  const queue = getUserRiskQueue();
+  const job = await queue.add(
+    'compute-org',
+    {
+      type: 'compute-org',
+      orgId,
+      queuedAt: new Date().toISOString()
+    },
+    {
+      removeOnComplete: { count: 50 },
+      removeOnFail: { count: 200 }
+    }
+  );
+  return String(job.id);
+}
+
+export async function enqueueUserRiskSignalEvent(input: Omit<ProcessSignalEventJobData, 'type' | 'queuedAt'>): Promise<string> {
+  const queue = getUserRiskQueue();
+  const job = await queue.add(
+    'process-signal-event',
+    {
+      type: 'process-signal-event',
+      ...input,
+      queuedAt: new Date().toISOString()
+    },
+    {
+      removeOnComplete: { count: 50 },
+      removeOnFail: { count: 200 }
+    }
+  );
+  return String(job.id);
+}

--- a/apps/api/src/jobs/userRiskRetention.ts
+++ b/apps/api/src/jobs/userRiskRetention.ts
@@ -1,0 +1,131 @@
+/**
+ * User Risk Score Retention Worker
+ *
+ * Keeps dense snapshots for recent data while compacting older data to one
+ * snapshot per user per day.
+ */
+
+import { Job, Queue, Worker } from 'bullmq';
+import { sql } from 'drizzle-orm';
+
+import * as dbModule from '../db';
+import { getRedisConnection } from '../services/redis';
+
+const { db } = dbModule;
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const withSystem = dbModule.withSystemDbAccessContext;
+  return typeof withSystem === 'function' ? withSystem(fn) : fn();
+};
+
+const QUEUE_NAME = 'user-risk-retention';
+
+function parsePositiveIntEnv(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  if (!raw) return defaultValue;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.warn(`[UserRiskRetention] Invalid ${name}="${raw}", using default ${defaultValue}`);
+    return defaultValue;
+  }
+  return parsed;
+}
+
+const DEFAULT_RETENTION_DAYS = Math.max(30, parsePositiveIntEnv('USER_RISK_RETENTION_DAYS', 90));
+const DEFAULT_RETENTION_INTERVAL_MS = parsePositiveIntEnv('USER_RISK_RETENTION_INTERVAL_MS', 24 * 60 * 60 * 1000);
+
+type RetentionJobData = {
+  retentionDays?: number;
+};
+
+let retentionQueue: Queue<RetentionJobData> | null = null;
+let retentionWorker: Worker<RetentionJobData> | null = null;
+
+export function getUserRiskRetentionQueue(): Queue<RetentionJobData> {
+  if (!retentionQueue) {
+    retentionQueue = new Queue<RetentionJobData>(QUEUE_NAME, {
+      connection: getRedisConnection()
+    });
+  }
+  return retentionQueue;
+}
+
+export function createUserRiskRetentionWorker(): Worker<RetentionJobData> {
+  return new Worker<RetentionJobData>(
+    QUEUE_NAME,
+    async (job: Job<RetentionJobData>) => {
+      return runWithSystemDbAccess(async () => {
+        const retentionDays = Math.max(30, job.data.retentionDays ?? DEFAULT_RETENTION_DAYS);
+        const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+        const start = Date.now();
+
+        const result = await db.execute(sql`
+          WITH ranked AS (
+            SELECT
+              id,
+              ROW_NUMBER() OVER (
+                PARTITION BY org_id, user_id, DATE(calculated_at)
+                ORDER BY calculated_at DESC
+              ) AS rn
+            FROM user_risk_scores
+            WHERE calculated_at < ${cutoff}
+          )
+          DELETE FROM user_risk_scores urs
+          USING ranked r
+          WHERE urs.id = r.id
+            AND r.rn > 1
+        `);
+
+        const durationMs = Date.now() - start;
+        const raw = result as unknown as { rowCount?: number };
+        const deleted = typeof raw.rowCount === 'number' ? raw.rowCount : 'unknown';
+        console.log(
+          `[UserRiskRetention] Compacted user risk snapshots older than ${retentionDays} days (deleted=${deleted}) in ${durationMs}ms`
+        );
+        return { retentionDays, deleted, durationMs };
+      });
+    },
+    {
+      connection: getRedisConnection(),
+      concurrency: 1
+    }
+  );
+}
+
+export async function initializeUserRiskRetention(): Promise<void> {
+  retentionWorker = createUserRiskRetentionWorker();
+  retentionWorker.on('error', (error) => {
+    console.error('[UserRiskRetention] Worker error:', error);
+  });
+  retentionWorker.on('failed', (job, error) => {
+    console.error(`[UserRiskRetention] Job ${job?.id} failed:`, error);
+  });
+
+  const queue = getUserRiskRetentionQueue();
+  const existing = await queue.getRepeatableJobs();
+  for (const job of existing) {
+    await queue.removeRepeatableByKey(job.key);
+  }
+
+  await queue.add(
+    'cleanup',
+    { retentionDays: DEFAULT_RETENTION_DAYS },
+    {
+      repeat: { every: DEFAULT_RETENTION_INTERVAL_MS },
+      removeOnComplete: { count: 5 },
+      removeOnFail: { count: 20 }
+    }
+  );
+
+  console.log('[UserRiskRetention] Retention worker initialized');
+}
+
+export async function shutdownUserRiskRetention(): Promise<void> {
+  if (retentionWorker) {
+    await retentionWorker.close();
+    retentionWorker = null;
+  }
+  if (retentionQueue) {
+    await retentionQueue.close();
+    retentionQueue = null;
+  }
+}

--- a/apps/api/src/routes/userRisk.test.ts
+++ b/apps/api/src/routes/userRisk.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: async (_c: unknown, next: () => Promise<void>) => await next(),
+  requireScope: () => async (_c: unknown, next: () => Promise<void>) => await next(),
+  requirePermission: () => async (_c: unknown, next: () => Promise<void>) => await next(),
+  resolveOrgAccess: vi.fn()
+}));
+
+vi.mock('../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn()
+}));
+
+vi.mock('../services/userRiskScoring', () => ({
+  listUserRiskScores: vi.fn(),
+  getUserRiskDetail: vi.fn(),
+  getUserRiskOrgMembership: vi.fn(),
+  listUserRiskEvents: vi.fn(),
+  getOrCreateUserRiskPolicy: vi.fn(),
+  updateUserRiskPolicy: vi.fn(),
+  assignSecurityTraining: vi.fn()
+}));
+
+import { userRiskRoutes } from './userRisk';
+import {
+  assignSecurityTraining,
+  getOrCreateUserRiskPolicy,
+  getUserRiskDetail,
+  listUserRiskEvents,
+  listUserRiskScores,
+  updateUserRiskPolicy
+} from '../services/userRiskScoring';
+import { resolveOrgAccess } from '../middleware/auth';
+
+const ORG_ID = '00000000-0000-0000-0000-000000000001';
+const ORG_ID_2 = '00000000-0000-0000-0000-000000000002';
+const USER_ID = '00000000-0000-0000-0000-000000000010';
+
+function buildApp(authOverrides?: Partial<{
+  scope: 'organization' | 'partner' | 'system';
+  orgId: string | null;
+  accessibleOrgIds: string[] | null;
+  canAccessOrg: (orgId: string) => boolean;
+}>): Hono {
+  const authSetter = async (c: any, next: any) => {
+    c.set('auth', {
+      user: { id: '00000000-0000-0000-0000-000000000099', email: 'tester@example.com', name: 'Tester' },
+      scope: authOverrides?.scope ?? 'organization',
+      orgId: authOverrides?.orgId ?? ORG_ID,
+      accessibleOrgIds: authOverrides?.accessibleOrgIds ?? [ORG_ID],
+      canAccessOrg: authOverrides?.canAccessOrg ?? ((id: string) => id === ORG_ID)
+    });
+    await next();
+  };
+
+  const app = new Hono();
+  app.use('/user-risk', authSetter);
+  app.use('/user-risk/*', authSetter);
+  app.route('/user-risk', userRiskRoutes);
+  return app;
+}
+
+describe('userRiskRoutes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(resolveOrgAccess).mockResolvedValue({ type: 'single', orgId: ORG_ID });
+  });
+
+  it('GET /scores returns ranked scores with pagination', async () => {
+    vi.mocked(listUserRiskScores).mockResolvedValue({
+      total: 1,
+      rows: [
+        {
+          orgId: ORG_ID,
+          userId: USER_ID,
+          userName: 'Alice',
+          userEmail: 'alice@example.com',
+          score: 78,
+          trendDirection: 'up',
+          calculatedAt: '2026-02-26T00:00:00.000Z',
+          factors: { mfaRisk: 90 }
+        }
+      ]
+    });
+
+    const app = buildApp();
+    const res = await app.request('/user-risk/scores');
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.pagination.total).toBe(1);
+    expect(body.summary.highRiskUsers).toBe(1);
+  });
+
+  it('GET /scores returns 403 for inaccessible org filter', async () => {
+    const app = buildApp();
+    const res = await app.request(`/user-risk/scores?orgId=${ORG_ID_2}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('GET /users/:userId returns detail payload', async () => {
+    vi.mocked(getUserRiskDetail).mockResolvedValue({
+      user: {
+        id: USER_ID,
+        name: 'Alice',
+        email: 'alice@example.com',
+        mfaEnabled: true,
+        lastLoginAt: '2026-02-25T00:00:00.000Z'
+      },
+      latestScore: {
+        score: 55,
+        factors: { mfaRisk: 10 },
+        trendDirection: 'stable',
+        calculatedAt: '2026-02-26T00:00:00.000Z',
+        deltaFromPrevious: 0,
+        severity: 'medium'
+      },
+      recentEvents: [],
+      history: [],
+      policy: {
+        orgId: ORG_ID,
+        weights: {},
+        thresholds: {},
+        interventions: {},
+        updatedAt: '2026-02-26T00:00:00.000Z',
+        updatedBy: null
+      }
+    });
+
+    const app = buildApp();
+    const res = await app.request(`/user-risk/users/${USER_ID}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.user.id).toBe(USER_ID);
+    expect(body.data.latestScore.score).toBe(55);
+  });
+
+  it('GET /events returns event history', async () => {
+    vi.mocked(listUserRiskEvents).mockResolvedValue({
+      total: 1,
+      rows: [
+        {
+          id: '00000000-0000-0000-0000-000000000020',
+          orgId: ORG_ID,
+          userId: USER_ID,
+          userName: 'Alice',
+          userEmail: 'alice@example.com',
+          eventType: 'training_assigned',
+          severity: 'low',
+          scoreImpact: -5,
+          description: 'Assigned training',
+          details: {},
+          occurredAt: '2026-02-26T00:00:00.000Z'
+        }
+      ]
+    });
+
+    const app = buildApp();
+    const res = await app.request('/user-risk/events');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.pagination.total).toBe(1);
+  });
+
+  it('PUT /policy updates policy', async () => {
+    vi.mocked(updateUserRiskPolicy).mockResolvedValue({
+      orgId: ORG_ID,
+      weights: { mfaRisk: 0.2 },
+      thresholds: { high: 70 },
+      interventions: { autoAssignTraining: true },
+      updatedAt: '2026-02-26T00:00:00.000Z',
+      updatedBy: '00000000-0000-0000-0000-000000000099'
+    });
+
+    const app = buildApp();
+    const res = await app.request('/user-risk/policy', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ thresholds: { high: 70 } })
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.orgId).toBe(ORG_ID);
+  });
+
+  it('GET /policy returns org policy', async () => {
+    vi.mocked(getOrCreateUserRiskPolicy).mockResolvedValue({
+      orgId: ORG_ID,
+      weights: {},
+      thresholds: {},
+      interventions: {},
+      updatedAt: '2026-02-26T00:00:00.000Z',
+      updatedBy: null
+    });
+
+    const app = buildApp();
+    const res = await app.request('/user-risk/policy');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.orgId).toBe(ORG_ID);
+  });
+
+  it('POST /assign-training triggers assignment workflow', async () => {
+    vi.mocked(assignSecurityTraining).mockResolvedValue({
+      assignmentEventId: '00000000-0000-0000-0000-000000000020',
+      moduleId: 'security-awareness-baseline',
+      deduplicated: false,
+      eventPublished: true
+    });
+
+    const app = buildApp();
+    const res = await app.request('/user-risk/assign-training', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ userId: USER_ID })
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.assignmentEventId).toBeDefined();
+  });
+});

--- a/apps/api/src/routes/userRisk.ts
+++ b/apps/api/src/routes/userRisk.ts
@@ -1,0 +1,343 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { zValidator } from '@hono/zod-validator';
+
+import { authMiddleware, requirePermission, requireScope, resolveOrgAccess } from '../middleware/auth';
+import { writeRouteAudit } from '../services/auditEvents';
+import {
+  assignSecurityTraining,
+  getUserRiskDetail,
+  getUserRiskOrgMembership,
+  getOrCreateUserRiskPolicy,
+  listUserRiskEvents,
+  listUserRiskScores,
+  updateUserRiskPolicy
+} from '../services/userRiskScoring';
+
+const listScoresQuerySchema = z.object({
+  orgId: z.string().uuid().optional(),
+  siteId: z.string().uuid().optional(),
+  minScore: z.coerce.number().int().min(0).max(100).optional(),
+  maxScore: z.coerce.number().int().min(0).max(100).optional(),
+  trendDirection: z.enum(['up', 'down', 'stable']).optional(),
+  search: z.string().min(1).max(255).optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(200).default(25)
+});
+
+const detailParamSchema = z.object({
+  userId: z.string().uuid()
+});
+
+const detailQuerySchema = z.object({
+  orgId: z.string().uuid().optional()
+});
+
+const eventsQuerySchema = z.object({
+  orgId: z.string().uuid().optional(),
+  userId: z.string().uuid().optional(),
+  eventType: z.string().max(60).optional(),
+  severity: z.enum(['low', 'medium', 'high', 'critical']).optional(),
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(500).default(50)
+});
+
+const policyPayloadSchema = z.object({
+  orgId: z.string().uuid().optional(),
+  weights: z.record(z.string(), z.number().min(0)).optional(),
+  thresholds: z.record(z.string(), z.number()).optional(),
+  interventions: z.record(z.string(), z.unknown()).optional()
+});
+
+const assignTrainingSchema = z.object({
+  orgId: z.string().uuid().optional(),
+  userId: z.string().uuid(),
+  moduleId: z.string().min(1).max(120).optional(),
+  reason: z.string().min(1).max(500).optional()
+});
+
+function resolveWriteOrgId(
+  auth: {
+    scope: 'system' | 'partner' | 'organization';
+    orgId: string | null;
+    accessibleOrgIds: string[] | null;
+    canAccessOrg: (orgId: string) => boolean;
+  },
+  requestedOrgId?: string
+): { orgId?: string; error?: string; status?: 400 | 403 } {
+  if (auth.scope === 'organization') {
+    if (!auth.orgId) {
+      return { error: 'Organization context required', status: 403 };
+    }
+    if (requestedOrgId && requestedOrgId !== auth.orgId) {
+      return { error: 'Access denied to this organization', status: 403 };
+    }
+    return { orgId: auth.orgId };
+  }
+
+  if (requestedOrgId) {
+    if (!auth.canAccessOrg(requestedOrgId)) {
+      return { error: 'Access denied to this organization', status: 403 };
+    }
+    return { orgId: requestedOrgId };
+  }
+
+  if (auth.orgId) {
+    return { orgId: auth.orgId };
+  }
+
+  if (auth.accessibleOrgIds && auth.accessibleOrgIds.length === 1) {
+    return { orgId: auth.accessibleOrgIds[0] };
+  }
+
+  return { error: 'orgId is required for this scope', status: 400 };
+}
+
+export const userRiskRoutes = new Hono();
+
+userRiskRoutes.use('*', authMiddleware);
+userRiskRoutes.use('*', requireScope('organization', 'partner', 'system'));
+
+userRiskRoutes.get(
+  '/scores',
+  requirePermission('users', 'read'),
+  zValidator('query', listScoresQuerySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const query = c.req.valid('query');
+
+    if (query.orgId && !auth.canAccessOrg(query.orgId)) {
+      return c.json({ error: 'Access denied to this organization' }, 403);
+    }
+
+    const orgIds = query.orgId
+      ? [query.orgId]
+      : auth.orgId
+        ? [auth.orgId]
+        : (auth.accessibleOrgIds?.length ? auth.accessibleOrgIds : undefined);
+
+    if (!orgIds && auth.scope !== 'system') {
+      return c.json({ error: 'Organization context required' }, 400);
+    }
+
+    const offset = (query.page - 1) * query.limit;
+    const result = await listUserRiskScores({
+      orgIds,
+      siteId: query.siteId,
+      minScore: query.minScore,
+      maxScore: query.maxScore,
+      trendDirection: query.trendDirection,
+      search: query.search,
+      limit: query.limit,
+      offset
+    });
+
+    return c.json({
+      data: result.rows,
+      pagination: {
+        total: result.total,
+        page: query.page,
+        limit: query.limit,
+        totalPages: Math.max(1, Math.ceil(result.total / query.limit))
+      },
+      summary: {
+        averageScore: result.rows.length > 0
+          ? Math.round(result.rows.reduce((sum, row) => sum + row.score, 0) / result.rows.length)
+          : 0,
+        highRiskUsers: result.rows.filter((row) => row.score >= 70).length,
+        criticalRiskUsers: result.rows.filter((row) => row.score >= 85).length
+      }
+    });
+  }
+);
+
+userRiskRoutes.get(
+  '/users/:userId',
+  requirePermission('users', 'read'),
+  zValidator('param', detailParamSchema),
+  zValidator('query', detailQuerySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { userId } = c.req.valid('param');
+    const query = c.req.valid('query');
+
+    const orgResolution = await resolveOrgAccess(auth, query.orgId);
+    if (orgResolution.type === 'error') {
+      return c.json({ error: orgResolution.error }, orgResolution.status);
+    }
+
+    if (orgResolution.type === 'multiple') {
+      const memberships = await Promise.all(
+        orgResolution.orgIds.map(async (orgId) => ({
+          orgId,
+          member: await getUserRiskOrgMembership(userId, orgId)
+        }))
+      );
+
+      const matches = memberships.filter((entry) => entry.member).map((entry) => entry.orgId);
+      if (matches.length === 0) {
+        return c.json({ error: 'User not found in accessible organizations' }, 404);
+      }
+      if (matches.length > 1) {
+        return c.json({ error: 'orgId is required for users mapped to multiple organizations' }, 400);
+      }
+
+      const detail = await getUserRiskDetail(matches[0], userId);
+      if (!detail) return c.json({ error: 'No user risk data available for this user' }, 404);
+      return c.json({ data: detail });
+    }
+
+    const resolvedOrgId = orgResolution.type === 'single'
+      ? orgResolution.orgId
+      : query.orgId;
+
+    if (!resolvedOrgId) {
+      return c.json({ error: 'Organization context required' }, 400);
+    }
+
+    const detail = await getUserRiskDetail(resolvedOrgId, userId);
+    if (!detail) {
+      return c.json({ error: 'No user risk data available for this user' }, 404);
+    }
+
+    return c.json({ data: detail });
+  }
+);
+
+userRiskRoutes.get(
+  '/events',
+  requirePermission('users', 'read'),
+  zValidator('query', eventsQuerySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const query = c.req.valid('query');
+
+    if (query.orgId && !auth.canAccessOrg(query.orgId)) {
+      return c.json({ error: 'Access denied to this organization' }, 403);
+    }
+
+    const orgIds = query.orgId
+      ? [query.orgId]
+      : auth.orgId
+        ? [auth.orgId]
+        : (auth.accessibleOrgIds?.length ? auth.accessibleOrgIds : undefined);
+
+    if (!orgIds && auth.scope !== 'system') {
+      return c.json({ error: 'Organization context required' }, 400);
+    }
+
+    const offset = (query.page - 1) * query.limit;
+    const result = await listUserRiskEvents({
+      orgIds,
+      userId: query.userId,
+      eventType: query.eventType,
+      severity: query.severity,
+      from: query.from ? new Date(query.from) : undefined,
+      to: query.to ? new Date(query.to) : undefined,
+      limit: query.limit,
+      offset
+    });
+
+    return c.json({
+      data: result.rows,
+      pagination: {
+        total: result.total,
+        page: query.page,
+        limit: query.limit,
+        totalPages: Math.max(1, Math.ceil(result.total / query.limit))
+      }
+    });
+  }
+);
+
+userRiskRoutes.put(
+  '/policy',
+  requirePermission('users', 'write'),
+  zValidator('json', policyPayloadSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const payload = c.req.valid('json');
+
+    const resolved = resolveWriteOrgId(auth, payload.orgId);
+    if (!resolved.orgId) {
+      return c.json({ error: resolved.error ?? 'Organization resolution failed' }, resolved.status ?? 400);
+    }
+
+    const policy = await updateUserRiskPolicy({
+      orgId: resolved.orgId,
+      updatedBy: auth.user.id,
+      weights: payload.weights,
+      thresholds: payload.thresholds,
+      interventions: payload.interventions
+    });
+
+    writeRouteAudit(c, {
+      orgId: resolved.orgId,
+      action: 'user_risk.policy.update',
+      resourceType: 'user_risk_policy',
+      details: {
+        orgId: resolved.orgId,
+        updatedBy: auth.user.id
+      }
+    });
+
+    return c.json({ data: policy });
+  }
+);
+
+userRiskRoutes.get('/policy', requirePermission('users', 'read'), zValidator('query', z.object({ orgId: z.string().uuid().optional() })), async (c) => {
+  const auth = c.get('auth');
+  const { orgId } = c.req.valid('query');
+
+  const resolved = resolveWriteOrgId(auth, orgId);
+  if (!resolved.orgId) {
+    return c.json({ error: resolved.error ?? 'Organization resolution failed' }, resolved.status ?? 400);
+  }
+
+  const policy = await getOrCreateUserRiskPolicy(resolved.orgId);
+  return c.json({ data: policy });
+});
+
+userRiskRoutes.post(
+  '/assign-training',
+  requirePermission('users', 'write'),
+  zValidator('json', assignTrainingSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const payload = c.req.valid('json');
+
+    const resolved = resolveWriteOrgId(auth, payload.orgId);
+    if (!resolved.orgId) {
+      return c.json({ error: resolved.error ?? 'Organization resolution failed' }, resolved.status ?? 400);
+    }
+
+    const assignment = await assignSecurityTraining({
+      orgId: resolved.orgId,
+      userId: payload.userId,
+      moduleId: payload.moduleId,
+      reason: payload.reason,
+      assignedBy: auth.user.id
+    });
+
+    writeRouteAudit(c, {
+      orgId: resolved.orgId,
+      action: 'user_risk.training.assign',
+      resourceType: 'user',
+      resourceId: payload.userId,
+      details: {
+        moduleId: assignment.moduleId,
+        reason: payload.reason ?? null
+      }
+    });
+
+    return c.json({
+      success: true,
+      assignmentEventId: assignment.assignmentEventId,
+      moduleId: assignment.moduleId,
+      deduplicated: assignment.deduplicated,
+      eventPublished: assignment.eventPublished
+    }, 201);
+  }
+);

--- a/apps/api/src/services/aiGuardrails.ts
+++ b/apps/api/src/services/aiGuardrails.ts
@@ -242,7 +242,6 @@ const TOOL_PERMISSIONS: Record<string, { resource: string; action: string } | Re
   // Security + reliability read tools
   get_security_posture: { resource: 'devices', action: 'read' },
   get_fleet_health: { resource: 'devices', action: 'read' },
-<<<<<<< HEAD
   // Tags, custom fields, and registry tools
   manage_tags: {
     list: { resource: 'devices', action: 'read' },
@@ -305,6 +304,10 @@ const TOOL_PERMISSIONS: Record<string, { resource: string; action: string } | Re
   get_huntress_status: { resource: 'devices', action: 'read' },
   get_huntress_incidents: { resource: 'devices', action: 'read' },
   sync_huntress_data: { resource: 'organizations', action: 'write' },
+  // User risk scoring tools
+  get_user_risk_scores: { resource: 'users', action: 'read' },
+  get_user_risk_detail: { resource: 'users', action: 'read' },
+  assign_security_training: { resource: 'users', action: 'write' },
 };
 
 // Per-tool rate limits: { limit, windowSeconds }
@@ -349,7 +352,6 @@ const TOOL_RATE_LIMITS: Record<string, { limit: number; windowSeconds: number }>
   remove_configuration_policy_assignment: { limit: 10, windowSeconds: 300 },
   // Playbook tools
   execute_playbook: { limit: 5, windowSeconds: 600 },
-<<<<<<< HEAD
   manage_processes: { limit: 15, windowSeconds: 300 },
   // Tags and registry tools
   manage_tags: { limit: 20, windowSeconds: 300 },
@@ -373,6 +375,8 @@ const TOOL_RATE_LIMITS: Record<string, { limit: number; windowSeconds: number }>
   apply_cis_remediation: { limit: 10, windowSeconds: 600 },
   // Huntress integration tools
   sync_huntress_data: { limit: 10, windowSeconds: 300 },
+  // User risk tools
+  assign_security_training: { limit: 10, windowSeconds: 300 },
 };
 
 export interface GuardrailCheck {

--- a/apps/api/src/services/aiToolSchemas.ts
+++ b/apps/api/src/services/aiToolSchemas.ts
@@ -484,6 +484,28 @@ export const toolInputSchemas: Record<string, z.ZodType> = {
     limit: z.number().int().min(1).max(100).optional(),
   }),
 
+  get_user_risk_scores: z.object({
+    orgId: uuid.optional(),
+    siteId: uuid.optional(),
+    minScore: z.number().int().min(0).max(100).optional(),
+    maxScore: z.number().int().min(0).max(100).optional(),
+    trendDirection: z.enum(['up', 'down', 'stable']).optional(),
+    search: z.string().max(255).optional(),
+    limit: z.number().int().min(1).max(200).optional(),
+  }),
+
+  get_user_risk_detail: z.object({
+    userId: uuid,
+    orgId: uuid.optional(),
+  }),
+
+  assign_security_training: z.object({
+    userId: uuid,
+    orgId: uuid.optional(),
+    moduleId: z.string().min(1).max(120).optional(),
+    reason: z.string().min(1).max(500).optional(),
+  }),
+
   file_operations: z.object({
     deviceId: uuid,
     action: z.enum(['list', 'read', 'write', 'delete', 'mkdir', 'rename']),

--- a/apps/api/src/services/aiTools.ts
+++ b/apps/api/src/services/aiTools.ts
@@ -120,6 +120,7 @@ import { checkPlaybookRequiredPermissions } from './playbookPermissions';
 import { normalizeSoftwarePolicyRules } from './softwarePolicyService';
 import { listReliabilityDevices } from './reliabilityScoring';
 import { resolveSensitiveDataKeySelection } from './sensitiveDataKeys';
+import { assignSecurityTraining, getUserRiskDetail, listUserRiskScores } from './userRiskScoring';
 import {
   mergeBootRecords,
   parseCollectorBootMetricsFromCommandResult,
@@ -4063,6 +4064,165 @@ registerTool({
       const message = err instanceof Error ? err.message : 'Internal error';
       console.error('[fleet:get_fleet_health]', message, err);
       return JSON.stringify({ error: 'Operation failed. Check server logs for details.' });
+    }
+  }
+});
+
+// ============================================
+// get_user_risk_scores - Tier 1 (read-only)
+// ============================================
+
+registerTool({
+  tier: 1,
+  definition: {
+    name: 'get_user_risk_scores',
+    description: 'Return ranked user risk scores with factor breakdowns and trend direction for accessible organizations.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        orgId: { type: 'string', description: 'Optional org UUID (must be accessible)' },
+        siteId: { type: 'string', description: 'Optional site UUID filter' },
+        minScore: { type: 'number', description: 'Minimum score filter (0-100)' },
+        maxScore: { type: 'number', description: 'Maximum score filter (0-100)' },
+        trendDirection: { type: 'string', enum: ['up', 'down', 'stable'], description: 'Trend filter' },
+        search: { type: 'string', description: 'Match user name/email' },
+        limit: { type: 'number', description: 'Maximum rows (default 25, max 200)' }
+      }
+    }
+  },
+  handler: async (input, auth) => {
+    if (typeof input.orgId === 'string' && input.orgId && !auth.canAccessOrg(input.orgId)) {
+      return JSON.stringify({ error: 'Access denied to this organization' });
+    }
+
+    const orgIds = typeof input.orgId === 'string' && input.orgId
+      ? [input.orgId]
+      : auth.orgId
+        ? [auth.orgId]
+        : (auth.accessibleOrgIds && auth.accessibleOrgIds.length > 0 ? auth.accessibleOrgIds : undefined);
+
+    if (!orgIds && auth.scope !== 'system') {
+      return JSON.stringify({ error: 'Organization context required' });
+    }
+
+    const limit = Math.min(Math.max(1, Number(input.limit) || 25), 200);
+    const result = await listUserRiskScores({
+      orgIds,
+      siteId: typeof input.siteId === 'string' ? input.siteId : undefined,
+      minScore: typeof input.minScore === 'number' ? input.minScore : undefined,
+      maxScore: typeof input.maxScore === 'number' ? input.maxScore : undefined,
+      trendDirection: (typeof input.trendDirection === 'string'
+        && ['up', 'down', 'stable'].includes(input.trendDirection))
+        ? input.trendDirection as 'up' | 'down' | 'stable'
+        : undefined,
+      search: typeof input.search === 'string' ? input.search : undefined,
+      limit,
+      offset: 0
+    });
+
+    const rows = result.rows;
+    return JSON.stringify({
+      total: result.total,
+      users: rows,
+      summary: {
+        averageScore: rows.length ? Math.round(rows.reduce((sum, row) => sum + row.score, 0) / rows.length) : 0,
+        highRiskUsers: rows.filter((row) => row.score >= 70).length,
+        criticalRiskUsers: rows.filter((row) => row.score >= 85).length
+      }
+    });
+  }
+});
+
+// ============================================
+// get_user_risk_detail - Tier 1 (read-only)
+// ============================================
+
+registerTool({
+  tier: 1,
+  definition: {
+    name: 'get_user_risk_detail',
+    description: 'Fetch a single user risk profile including latest score, factors, trend history, and risk-impacting events.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        userId: { type: 'string', description: 'User UUID' },
+        orgId: { type: 'string', description: 'Organization UUID for disambiguation' }
+      },
+      required: ['userId']
+    }
+  },
+  handler: async (input, auth) => {
+    if (typeof input.userId !== 'string' || !input.userId) {
+      return JSON.stringify({ error: 'userId is required' });
+    }
+
+    const resolved = resolveWritableToolOrgId(
+      auth,
+      typeof input.orgId === 'string' ? input.orgId : undefined
+    );
+    if (resolved.error || !resolved.orgId) {
+      return JSON.stringify({ error: resolved.error ?? 'orgId is required for this operation' });
+    }
+
+    const detail = await getUserRiskDetail(resolved.orgId, input.userId);
+    if (!detail) {
+      return JSON.stringify({ error: 'No user risk data available for this user' });
+    }
+
+    return JSON.stringify({ userRisk: detail });
+  }
+});
+
+// ============================================
+// assign_security_training - Tier 2 (write)
+// ============================================
+
+registerTool({
+  tier: 2,
+  definition: {
+    name: 'assign_security_training',
+    description: 'Assign security awareness training to a user and emit auditable events.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        userId: { type: 'string', description: 'User UUID' },
+        orgId: { type: 'string', description: 'Organization UUID (required for partner/system contexts with multiple orgs)' },
+        moduleId: { type: 'string', description: 'Training module key (optional)' },
+        reason: { type: 'string', description: 'Optional assignment reason' }
+      },
+      required: ['userId']
+    }
+  },
+  handler: async (input, auth) => {
+    if (typeof input.userId !== 'string' || !input.userId) {
+      return JSON.stringify({ error: 'userId is required' });
+    }
+
+    const resolved = resolveWritableToolOrgId(
+      auth,
+      typeof input.orgId === 'string' ? input.orgId : undefined
+    );
+    if (resolved.error || !resolved.orgId) {
+      return JSON.stringify({ error: resolved.error ?? 'orgId is required for this operation' });
+    }
+
+    try {
+      const result = await assignSecurityTraining({
+        orgId: resolved.orgId,
+        userId: input.userId,
+        moduleId: typeof input.moduleId === 'string' ? input.moduleId : undefined,
+        reason: typeof input.reason === 'string' ? input.reason : undefined,
+        assignedBy: auth.user.id
+      });
+
+      return JSON.stringify({
+        success: true,
+        ...result
+      });
+    } catch (error) {
+      return JSON.stringify({
+        error: error instanceof Error ? error.message : 'Failed to assign security training'
+      });
     }
   }
 });

--- a/apps/api/src/services/eventBus.ts
+++ b/apps/api/src/services/eventBus.ts
@@ -65,6 +65,9 @@ export type EventType =
   | 'user.login'
   | 'user.logout'
   | 'user.mfa.enabled'
+  | 'user.risk_score_high'
+  | 'user.risk_score_spike'
+  | 'user.training_assigned'
   // Device user-session events (BE-8)
   | 'session.login'
   | 'session.logout';

--- a/apps/api/src/services/userRiskScoring.test.ts
+++ b/apps/api/src/services/userRiskScoring.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./eventBus', () => ({
+  publishEvent: vi.fn(async () => 'evt-1')
+}));
+
+import { publishEvent } from './eventBus';
+import {
+  classifyUserRiskSeverity,
+  computeUserRiskScoreFromFactors,
+  deriveUserRiskTrendDirection,
+  normalizeUserRiskInterventions,
+  normalizeUserRiskThresholds,
+  normalizeUserRiskWeights,
+  publishUserRiskScoreEvents
+} from './userRiskScoring';
+
+describe('userRiskScoring helpers', () => {
+  it('normalizes weights and preserves deterministic scoring', () => {
+    const weights = normalizeUserRiskWeights({
+      mfaRisk: 2,
+      authFailureRisk: 3,
+      threatExposureRisk: 5
+    });
+    const total = Object.values(weights).reduce((sum, value) => sum + value, 0);
+    expect(Math.abs(total - 1)).toBeLessThan(0.02);
+
+    const factors = {
+      mfaRisk: 80,
+      authFailureRisk: 60,
+      sessionAnomalyRisk: 40,
+      threatExposureRisk: 50,
+      softwareViolationRisk: 30,
+      deviceSecurityRisk: 20,
+      staleAccessRisk: 10,
+      recentImpactRisk: 70
+    };
+
+    const first = computeUserRiskScoreFromFactors(factors, weights);
+    const second = computeUserRiskScoreFromFactors(factors, weights);
+    expect(first).toBe(second);
+  });
+
+  it('applies threshold normalization and risk severity classification', () => {
+    const thresholds = normalizeUserRiskThresholds({
+      medium: 45,
+      high: 75,
+      critical: 92
+    });
+
+    expect(classifyUserRiskSeverity(40, thresholds)).toBe('low');
+    expect(classifyUserRiskSeverity(60, thresholds)).toBe('medium');
+    expect(classifyUserRiskSeverity(80, thresholds)).toBe('high');
+    expect(classifyUserRiskSeverity(95, thresholds)).toBe('critical');
+  });
+
+  it('derives trend direction from score deltas', () => {
+    expect(deriveUserRiskTrendDirection(null, 50)).toBe('stable');
+    expect(deriveUserRiskTrendDirection(50, 55)).toBe('up');
+    expect(deriveUserRiskTrendDirection(50, 45)).toBe('down');
+    expect(deriveUserRiskTrendDirection(50, 52)).toBe('stable');
+  });
+});
+
+describe('publishUserRiskScoreEvents', () => {
+  it('publishes high and spike events when enabled', async () => {
+    const result = await publishUserRiskScoreEvents({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      changedUsers: [
+        {
+          userId: '00000000-0000-0000-0000-000000000010',
+          score: 88,
+          previousScore: 60,
+          delta: 28,
+          trendDirection: 'up',
+          crossedHighThreshold: true,
+          spiked: true
+        }
+      ],
+      thresholds: { high: 70, spikeDelta: 15 },
+      interventions: normalizeUserRiskInterventions({
+        notifyOnHighRisk: true,
+        notifyOnRiskSpike: true
+      })
+    });
+
+    expect(result.publishedHigh).toBe(1);
+    expect(result.publishedSpikes).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(vi.mocked(publishEvent)).toHaveBeenCalledTimes(2);
+  });
+
+  it('respects intervention flags and suppresses notifications', async () => {
+    vi.mocked(publishEvent).mockClear();
+
+    const result = await publishUserRiskScoreEvents({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      changedUsers: [
+        {
+          userId: '00000000-0000-0000-0000-000000000010',
+          score: 88,
+          previousScore: 60,
+          delta: 28,
+          trendDirection: 'up',
+          crossedHighThreshold: true,
+          spiked: true
+        }
+      ],
+      thresholds: { high: 70, spikeDelta: 15 },
+      interventions: normalizeUserRiskInterventions({
+        notifyOnHighRisk: false,
+        notifyOnRiskSpike: false
+      })
+    });
+
+    expect(result.publishedHigh).toBe(0);
+    expect(result.publishedSpikes).toBe(0);
+    expect(vi.mocked(publishEvent)).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/userRiskScoring.ts
+++ b/apps/api/src/services/userRiskScoring.ts
@@ -1,0 +1,1457 @@
+import {
+  and,
+  desc,
+  eq,
+  gte,
+  ilike,
+  inArray,
+  isNotNull,
+  lte,
+  or,
+  sql,
+  type SQL
+} from 'drizzle-orm';
+
+import { db } from '../db';
+import {
+  auditLogs,
+  deviceSessions,
+  devices,
+  organizationUsers,
+  securityPostureSnapshots,
+  securityThreats,
+  sessions,
+  softwareComplianceStatus,
+  userRiskEvents,
+  userRiskPolicies,
+  userRiskScores,
+  users,
+  type UserRiskFactorBreakdown,
+  type UserRiskPolicyInterventions,
+  type UserRiskPolicyThresholds,
+  type UserRiskPolicyWeights
+} from '../db/schema';
+import { publishEvent } from './eventBus';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const HIGH_EVENT_TYPE = 'user.risk_score_high';
+const SPIKE_EVENT_TYPE = 'user.risk_score_spike';
+const TRAINING_ASSIGNED_EVENT_TYPE = 'user.training_assigned';
+
+const DEFAULT_USER_RISK_WEIGHTS: UserRiskPolicyWeights = {
+  mfaRisk: 0.14,
+  authFailureRisk: 0.2,
+  sessionAnomalyRisk: 0.1,
+  threatExposureRisk: 0.2,
+  softwareViolationRisk: 0.15,
+  deviceSecurityRisk: 0.1,
+  staleAccessRisk: 0.06,
+  recentImpactRisk: 0.05
+};
+
+const DEFAULT_USER_RISK_THRESHOLDS: UserRiskPolicyThresholds = {
+  medium: 50,
+  high: 70,
+  critical: 85,
+  spikeDelta: 15,
+  autoAssignTrainingAtOrAbove: 80
+};
+
+const DEFAULT_USER_RISK_INTERVENTIONS: UserRiskPolicyInterventions = {
+  autoAssignTraining: false,
+  trainingModuleId: 'security-awareness-baseline',
+  notifyOnHighRisk: true,
+  notifyOnRiskSpike: true
+};
+
+const USER_RISK_FACTOR_KEYS = Object.keys(DEFAULT_USER_RISK_WEIGHTS);
+const TRAINING_REASSIGN_COOLDOWN_DAYS = 30;
+const TRAINING_DEDUP_HOURS = Math.max(1, parseInt(process.env.USER_RISK_TRAINING_DEDUP_HOURS || '24', 10));
+
+function clampScore(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function readFiniteNumber(value: unknown, fallback: number): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  return fallback;
+}
+
+function round2(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.round(value * 100) / 100;
+}
+
+function normalizeFactorMap(value: unknown): UserRiskFactorBreakdown {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  const out: UserRiskFactorBreakdown = {};
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof raw !== 'number' || !Number.isFinite(raw)) continue;
+    out[key] = clampScore(raw);
+  }
+  return out;
+}
+
+export function normalizeUserRiskWeights(value: unknown): UserRiskPolicyWeights {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return { ...DEFAULT_USER_RISK_WEIGHTS };
+  }
+
+  const raw = value as Record<string, unknown>;
+  const merged: UserRiskPolicyWeights = { ...DEFAULT_USER_RISK_WEIGHTS };
+  for (const key of USER_RISK_FACTOR_KEYS) {
+    const input = raw[key];
+    if (typeof input === 'number' && Number.isFinite(input) && input >= 0) {
+      merged[key] = input;
+    }
+  }
+
+  const total = Object.values(merged).reduce((sum, weight) => sum + weight, 0);
+  if (total <= 0) {
+    return { ...DEFAULT_USER_RISK_WEIGHTS };
+  }
+
+  for (const key of USER_RISK_FACTOR_KEYS) {
+    merged[key] = round2((merged[key] ?? 0) / total);
+  }
+  return merged;
+}
+
+export function normalizeUserRiskThresholds(value: unknown): UserRiskPolicyThresholds {
+  const raw = value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+
+  const medium = clampScore(readFiniteNumber(raw.medium, DEFAULT_USER_RISK_THRESHOLDS.medium ?? 50));
+  const high = Math.max(medium, clampScore(readFiniteNumber(raw.high, DEFAULT_USER_RISK_THRESHOLDS.high ?? 70)));
+  const critical = Math.max(high, clampScore(readFiniteNumber(raw.critical, DEFAULT_USER_RISK_THRESHOLDS.critical ?? 85)));
+  const spikeDelta = Math.max(
+    1,
+    Math.min(100, Math.round(readFiniteNumber(raw.spikeDelta, DEFAULT_USER_RISK_THRESHOLDS.spikeDelta ?? 15)))
+  );
+  const autoAssignTrainingAtOrAbove = Math.max(
+    high,
+    clampScore(readFiniteNumber(raw.autoAssignTrainingAtOrAbove, DEFAULT_USER_RISK_THRESHOLDS.autoAssignTrainingAtOrAbove ?? 80))
+  );
+
+  return {
+    medium,
+    high,
+    critical,
+    spikeDelta,
+    autoAssignTrainingAtOrAbove
+  };
+}
+
+export function normalizeUserRiskInterventions(value: unknown): UserRiskPolicyInterventions {
+  const raw = value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+
+  const moduleIdRaw = typeof raw.trainingModuleId === 'string' ? raw.trainingModuleId.trim() : '';
+  return {
+    autoAssignTraining: raw.autoAssignTraining === true,
+    trainingModuleId: moduleIdRaw || DEFAULT_USER_RISK_INTERVENTIONS.trainingModuleId,
+    notifyOnHighRisk: raw.notifyOnHighRisk !== false,
+    notifyOnRiskSpike: raw.notifyOnRiskSpike !== false
+  };
+}
+
+function aliasesForUser(user: { email: string; name: string }): Set<string> {
+  const aliases = new Set<string>();
+
+  const email = user.email.trim().toLowerCase();
+  aliases.add(email);
+  const localPart = email.split('@')[0] ?? '';
+  if (localPart) {
+    aliases.add(localPart);
+  }
+
+  const normalizedName = user.name.trim().toLowerCase();
+  if (normalizedName) {
+    aliases.add(normalizedName);
+    aliases.add(normalizedName.replace(/\s+/g, '.'));
+    aliases.add(normalizedName.replace(/\s+/g, '_'));
+  }
+
+  return aliases;
+}
+
+function normalizeIdentityValue(value: string | null | undefined): Set<string> {
+  const out = new Set<string>();
+  if (!value) return out;
+
+  const base = value.trim().toLowerCase();
+  if (!base) return out;
+  out.add(base);
+
+  const slashIdx = Math.max(base.lastIndexOf('\\'), base.lastIndexOf('/'));
+  if (slashIdx >= 0 && slashIdx < base.length - 1) {
+    out.add(base.slice(slashIdx + 1));
+  }
+
+  if (base.includes('@')) {
+    const localPart = base.split('@')[0];
+    if (localPart) {
+      out.add(localPart);
+    }
+  }
+
+  return out;
+}
+
+function daysSince(now: Date, value: Date | null | undefined): number {
+  if (!value) return 365;
+  return Math.max(0, Math.floor((now.getTime() - value.getTime()) / DAY_MS));
+}
+
+function scoreFromStaleAccess(days: number): number {
+  if (days <= 7) return 10;
+  if (days <= 30) return 30;
+  if (days <= 90) return 60;
+  return 85;
+}
+
+export function deriveUserRiskTrendDirection(previousScore: number | null, currentScore: number): 'up' | 'down' | 'stable' {
+  if (previousScore === null) return 'stable';
+  const delta = currentScore - previousScore;
+  if (delta >= 3) return 'up';
+  if (delta <= -3) return 'down';
+  return 'stable';
+}
+
+export function classifyUserRiskSeverity(
+  score: number,
+  thresholds: UserRiskPolicyThresholds
+): 'low' | 'medium' | 'high' | 'critical' {
+  const critical = thresholds.critical ?? DEFAULT_USER_RISK_THRESHOLDS.critical ?? 85;
+  const high = thresholds.high ?? DEFAULT_USER_RISK_THRESHOLDS.high ?? 70;
+  const medium = thresholds.medium ?? DEFAULT_USER_RISK_THRESHOLDS.medium ?? 50;
+
+  if (score >= critical) return 'critical';
+  if (score >= high) return 'high';
+  if (score >= medium) return 'medium';
+  return 'low';
+}
+
+export function computeUserRiskScoreFromFactors(
+  factors: UserRiskFactorBreakdown,
+  weights: UserRiskPolicyWeights
+): number {
+  const normalized = normalizeUserRiskWeights(weights);
+  const weighted = USER_RISK_FACTOR_KEYS.reduce((sum, key) => {
+    const factorScore = clampScore(factors[key] ?? 0);
+    return sum + factorScore * (normalized[key] ?? 0);
+  }, 0);
+  return clampScore(weighted);
+}
+
+export type UserRiskPolicy = {
+  orgId: string;
+  weights: UserRiskPolicyWeights;
+  thresholds: UserRiskPolicyThresholds;
+  interventions: UserRiskPolicyInterventions;
+  updatedAt: string;
+  updatedBy: string | null;
+};
+
+export type UserRiskScoreListFilter = {
+  orgIds?: string[];
+  orgId?: string;
+  siteId?: string;
+  minScore?: number;
+  maxScore?: number;
+  trendDirection?: 'up' | 'down' | 'stable';
+  search?: string;
+  limit?: number;
+  offset?: number;
+};
+
+export type UserRiskEventFilter = {
+  orgIds?: string[];
+  orgId?: string;
+  userId?: string;
+  eventType?: string;
+  severity?: 'low' | 'medium' | 'high' | 'critical';
+  from?: Date;
+  to?: Date;
+  limit?: number;
+  offset?: number;
+};
+
+type ComputedUserRisk = {
+  orgId: string;
+  userId: string;
+  score: number;
+  factors: UserRiskFactorBreakdown;
+  previousScore: number | null;
+  delta: number;
+  trendDirection: 'up' | 'down' | 'stable';
+};
+
+export type UserRiskRecomputeResult = {
+  orgId: string;
+  calculatedAt: string;
+  usersProcessed: number;
+  changedUsers: Array<{
+    userId: string;
+    score: number;
+    previousScore: number | null;
+    delta: number;
+    trendDirection: 'up' | 'down' | 'stable';
+    crossedHighThreshold: boolean;
+    spiked: boolean;
+  }>;
+  autoTrainingAssigned: number;
+  policy: UserRiskPolicy;
+};
+
+export async function getOrCreateUserRiskPolicy(orgId: string): Promise<UserRiskPolicy> {
+  const [existing] = await db
+    .select()
+    .from(userRiskPolicies)
+    .where(eq(userRiskPolicies.orgId, orgId))
+    .limit(1);
+
+  if (existing) {
+    return {
+      orgId: existing.orgId,
+      weights: normalizeUserRiskWeights(existing.weights),
+      thresholds: normalizeUserRiskThresholds(existing.thresholds),
+      interventions: normalizeUserRiskInterventions(existing.interventions),
+      updatedAt: existing.updatedAt.toISOString(),
+      updatedBy: existing.updatedBy ?? null
+    };
+  }
+
+  await db
+    .insert(userRiskPolicies)
+    .values({
+      orgId,
+      weights: DEFAULT_USER_RISK_WEIGHTS,
+      thresholds: DEFAULT_USER_RISK_THRESHOLDS,
+      interventions: DEFAULT_USER_RISK_INTERVENTIONS
+    })
+    .onConflictDoNothing({ target: userRiskPolicies.orgId });
+
+  const [created] = await db
+    .select()
+    .from(userRiskPolicies)
+    .where(eq(userRiskPolicies.orgId, orgId))
+    .limit(1);
+
+  if (!created) {
+    throw new Error(`Failed to initialize user risk policy for org ${orgId}`);
+  }
+
+  return {
+    orgId: created.orgId,
+    weights: normalizeUserRiskWeights(created.weights),
+    thresholds: normalizeUserRiskThresholds(created.thresholds),
+    interventions: normalizeUserRiskInterventions(created.interventions),
+    updatedAt: created.updatedAt.toISOString(),
+    updatedBy: created.updatedBy ?? null
+  };
+}
+
+export async function updateUserRiskPolicy(input: {
+  orgId: string;
+  updatedBy: string;
+  weights?: unknown;
+  thresholds?: unknown;
+  interventions?: unknown;
+}): Promise<UserRiskPolicy> {
+  const current = await getOrCreateUserRiskPolicy(input.orgId);
+
+  const nextWeights = input.weights !== undefined
+    ? normalizeUserRiskWeights({ ...current.weights, ...(input.weights as Record<string, unknown>) })
+    : current.weights;
+  const nextThresholds = input.thresholds !== undefined
+    ? normalizeUserRiskThresholds({ ...current.thresholds, ...(input.thresholds as Record<string, unknown>) })
+    : current.thresholds;
+  const nextInterventions = input.interventions !== undefined
+    ? normalizeUserRiskInterventions({ ...current.interventions, ...(input.interventions as Record<string, unknown>) })
+    : current.interventions;
+
+  const [updated] = await db
+    .update(userRiskPolicies)
+    .set({
+      weights: nextWeights,
+      thresholds: nextThresholds,
+      interventions: nextInterventions,
+      updatedBy: input.updatedBy,
+      updatedAt: new Date()
+    })
+    .where(eq(userRiskPolicies.orgId, input.orgId))
+    .returning();
+
+  if (!updated) {
+    throw new Error(`Failed to update user risk policy for org ${input.orgId}`);
+  }
+
+  return {
+    orgId: updated.orgId,
+    weights: normalizeUserRiskWeights(updated.weights),
+    thresholds: normalizeUserRiskThresholds(updated.thresholds),
+    interventions: normalizeUserRiskInterventions(updated.interventions),
+    updatedAt: updated.updatedAt.toISOString(),
+    updatedBy: updated.updatedBy ?? null
+  };
+}
+
+async function fetchPreviousScores(orgId: string): Promise<Map<string, number>> {
+  const rows = await db
+    .select({
+      userId: userRiskScores.userId,
+      score: userRiskScores.score
+    })
+    .from(userRiskScores)
+    .where(eq(userRiskScores.orgId, orgId))
+    .orderBy(desc(userRiskScores.calculatedAt));
+
+  const latestByUser = new Map<string, number>();
+  for (const row of rows) {
+    if (!latestByUser.has(row.userId)) {
+      latestByUser.set(row.userId, row.score);
+    }
+  }
+  return latestByUser;
+}
+
+async function fetchRecentTrainingAssignments(orgId: string): Promise<Map<string, Date>> {
+  const since = new Date(Date.now() - TRAINING_REASSIGN_COOLDOWN_DAYS * DAY_MS);
+  const rows = await db
+    .select({
+      userId: userRiskEvents.userId,
+      occurredAt: userRiskEvents.occurredAt
+    })
+    .from(userRiskEvents)
+    .where(
+      and(
+        eq(userRiskEvents.orgId, orgId),
+        eq(userRiskEvents.eventType, 'training_assigned'),
+        gte(userRiskEvents.occurredAt, since)
+      )
+    )
+    .orderBy(desc(userRiskEvents.occurredAt));
+
+  const latestByUser = new Map<string, Date>();
+  for (const row of rows) {
+    if (!latestByUser.has(row.userId)) {
+      latestByUser.set(row.userId, row.occurredAt);
+    }
+  }
+  return latestByUser;
+}
+
+type UserMembership = {
+  userId: string;
+  email: string;
+  name: string;
+  mfaEnabled: boolean;
+  lastLoginAt: Date | null;
+};
+
+async function fetchOrgUsers(orgId: string, targetUserIds?: string[]): Promise<UserMembership[]> {
+  if (Array.isArray(targetUserIds) && targetUserIds.length === 0) {
+    return [];
+  }
+
+  const conditions: SQL[] = [
+    eq(organizationUsers.orgId, orgId),
+    eq(users.status, 'active')
+  ];
+  if (targetUserIds && targetUserIds.length > 0) {
+    conditions.push(inArray(users.id, targetUserIds));
+  }
+
+  const rows = await db
+    .select({
+      userId: users.id,
+      email: users.email,
+      name: users.name,
+      mfaEnabled: users.mfaEnabled,
+      lastLoginAt: users.lastLoginAt
+    })
+    .from(organizationUsers)
+    .innerJoin(users, eq(organizationUsers.userId, users.id))
+    .where(and(...conditions));
+
+  return rows.map((row) => ({
+    userId: row.userId,
+    email: row.email,
+    name: row.name,
+    mfaEnabled: row.mfaEnabled,
+    lastLoginAt: row.lastLoginAt ?? null
+  }));
+}
+
+async function computeOrgUserRiskRows(
+  orgId: string,
+  policy: UserRiskPolicy,
+  targetUserIds?: string[]
+): Promise<ComputedUserRisk[]> {
+  const now = new Date();
+  const since30d = new Date(now.getTime() - 30 * DAY_MS);
+  const since14d = new Date(now.getTime() - 14 * DAY_MS);
+
+  const memberships = await fetchOrgUsers(orgId, targetUserIds);
+  if (memberships.length === 0) {
+    return [];
+  }
+
+  const userIds = memberships.map((entry) => entry.userId);
+  const usersByAlias = new Map<string, Set<string>>();
+  for (const user of memberships) {
+    const aliases = aliasesForUser({ email: user.email, name: user.name });
+    for (const alias of aliases) {
+      const bucket = usersByAlias.get(alias) ?? new Set<string>();
+      bucket.add(user.userId);
+      usersByAlias.set(alias, bucket);
+    }
+  }
+
+  const [orgDevices, recentSessions, authFailures, activeThreats, policyViolations, recentSnapshots, recentRiskEvents, previousScores] = await Promise.all([
+    db
+      .select({
+        deviceId: devices.id,
+        lastUser: devices.lastUser
+      })
+      .from(devices)
+      .where(
+        and(
+          eq(devices.orgId, orgId),
+          isNotNull(devices.lastUser),
+          or(eq(devices.status, 'online'), eq(devices.status, 'offline'), eq(devices.status, 'maintenance'), eq(devices.status, 'quarantined'))
+        )
+      ),
+    db
+      .select({
+        userId: sessions.userId,
+        ipAddress: sessions.ipAddress
+      })
+      .from(sessions)
+      .where(
+        and(
+          inArray(sessions.userId, userIds),
+          gte(sessions.createdAt, since30d)
+        )
+      ),
+    db
+      .select({
+        actorId: auditLogs.actorId,
+        result: auditLogs.result
+      })
+      .from(auditLogs)
+      .where(
+        and(
+          eq(auditLogs.orgId, orgId),
+          inArray(auditLogs.actorId, userIds),
+          gte(auditLogs.timestamp, since30d),
+          inArray(auditLogs.result, ['failure', 'denied'])
+        )
+      ),
+    db
+      .select({
+        deviceId: securityThreats.deviceId,
+        severity: securityThreats.severity
+      })
+      .from(securityThreats)
+      .innerJoin(devices, eq(securityThreats.deviceId, devices.id))
+      .where(
+        and(
+          eq(devices.orgId, orgId),
+          gte(securityThreats.detectedAt, since30d),
+          inArray(securityThreats.status, ['detected', 'failed', 'quarantined'])
+        )
+      ),
+    db
+      .select({
+        deviceId: softwareComplianceStatus.deviceId,
+        status: softwareComplianceStatus.status
+      })
+      .from(softwareComplianceStatus)
+      .innerJoin(devices, eq(softwareComplianceStatus.deviceId, devices.id))
+      .where(
+        and(
+          eq(devices.orgId, orgId),
+          gte(softwareComplianceStatus.lastChecked, since30d),
+          eq(softwareComplianceStatus.status, 'violation')
+        )
+      ),
+    db
+      .select({
+        deviceId: securityPostureSnapshots.deviceId,
+        capturedAt: securityPostureSnapshots.capturedAt,
+        overallScore: securityPostureSnapshots.overallScore
+      })
+      .from(securityPostureSnapshots)
+      .where(
+        and(
+          eq(securityPostureSnapshots.orgId, orgId),
+          gte(securityPostureSnapshots.capturedAt, since30d)
+        )
+      )
+      .orderBy(desc(securityPostureSnapshots.capturedAt)),
+    db
+      .select({
+        userId: userRiskEvents.userId,
+        scoreImpact: userRiskEvents.scoreImpact
+      })
+      .from(userRiskEvents)
+      .where(
+        and(
+          eq(userRiskEvents.orgId, orgId),
+          inArray(userRiskEvents.userId, userIds),
+          gte(userRiskEvents.occurredAt, since14d)
+        )
+      ),
+    fetchPreviousScores(orgId)
+  ]);
+
+  const deviceIdsByUser = new Map<string, Set<string>>();
+  for (const user of memberships) {
+    deviceIdsByUser.set(user.userId, new Set());
+  }
+
+  for (const row of orgDevices) {
+    const normalized = normalizeIdentityValue(row.lastUser ?? null);
+    if (normalized.size === 0) continue;
+    const matchedUserIds = new Set<string>();
+    for (const candidate of normalized) {
+      const matched = usersByAlias.get(candidate);
+      if (!matched) continue;
+      for (const userId of matched) {
+        matchedUserIds.add(userId);
+      }
+    }
+    for (const userId of matchedUserIds) {
+      deviceIdsByUser.get(userId)?.add(row.deviceId);
+    }
+  }
+
+  const sessionsByUser = new Map<string, Array<{ ipAddress: string | null }>>();
+  for (const row of recentSessions) {
+    const bucket = sessionsByUser.get(row.userId) ?? [];
+    bucket.push({ ipAddress: row.ipAddress ?? null });
+    sessionsByUser.set(row.userId, bucket);
+  }
+
+  const authFailureCountByUser = new Map<string, number>();
+  for (const row of authFailures) {
+    authFailureCountByUser.set(row.actorId, (authFailureCountByUser.get(row.actorId) ?? 0) + 1);
+  }
+
+  const threatByDevice = new Map<string, Array<'low' | 'medium' | 'high' | 'critical'>>();
+  for (const row of activeThreats) {
+    const bucket = threatByDevice.get(row.deviceId) ?? [];
+    bucket.push(row.severity);
+    threatByDevice.set(row.deviceId, bucket);
+  }
+
+  const violationByDevice = new Set(
+    policyViolations
+      .filter((row) => row.status === 'violation')
+      .map((row) => row.deviceId)
+  );
+
+  const latestSnapshotByDevice = new Map<string, number>();
+  for (const row of recentSnapshots) {
+    if (!latestSnapshotByDevice.has(row.deviceId)) {
+      latestSnapshotByDevice.set(row.deviceId, row.overallScore);
+    }
+  }
+
+  const recentEventImpactByUser = new Map<string, number>();
+  for (const row of recentRiskEvents) {
+    recentEventImpactByUser.set(row.userId, (recentEventImpactByUser.get(row.userId) ?? 0) + row.scoreImpact);
+  }
+
+  const results: ComputedUserRisk[] = [];
+  for (const user of memberships) {
+    const userDeviceIds = Array.from(deviceIdsByUser.get(user.userId) ?? []);
+    const mfaRisk = user.mfaEnabled ? 10 : 90;
+    const failedAuthCount = authFailureCountByUser.get(user.userId) ?? 0;
+    const authFailureRisk = clampScore(failedAuthCount * 18);
+
+    const sessionRows = sessionsByUser.get(user.userId) ?? [];
+    const uniqueIps = new Set(
+      sessionRows
+        .map((row) => row.ipAddress?.trim())
+        .filter((value): value is string => !!value)
+    );
+    const sessionAnomalyRisk = clampScore(
+      Math.max(0, (uniqueIps.size - 2) * 18)
+      + Math.max(0, sessionRows.length - 40) * 2
+    );
+
+    let lowThreats = 0;
+    let mediumThreats = 0;
+    let highThreats = 0;
+    let criticalThreats = 0;
+    for (const deviceId of userDeviceIds) {
+      const severities = threatByDevice.get(deviceId) ?? [];
+      for (const severity of severities) {
+        if (severity === 'critical') criticalThreats++;
+        else if (severity === 'high') highThreats++;
+        else if (severity === 'medium') mediumThreats++;
+        else lowThreats++;
+      }
+    }
+    const threatExposureRisk = clampScore(
+      criticalThreats * 35
+      + highThreats * 22
+      + mediumThreats * 12
+      + lowThreats * 5
+    );
+
+    const violationCount = userDeviceIds.filter((id) => violationByDevice.has(id)).length;
+    const violationRatio = userDeviceIds.length > 0 ? (violationCount / userDeviceIds.length) : 0;
+    const softwareViolationRisk = clampScore((violationCount * 18) + (violationRatio * 50));
+
+    const associatedSnapshotScores = userDeviceIds
+      .map((deviceId) => latestSnapshotByDevice.get(deviceId))
+      .filter((value): value is number => typeof value === 'number');
+    const avgDeviceScore = associatedSnapshotScores.length > 0
+      ? associatedSnapshotScores.reduce((sum, score) => sum + score, 0) / associatedSnapshotScores.length
+      : 80;
+    const deviceSecurityRisk = clampScore(100 - avgDeviceScore);
+
+    const staleAccessRisk = scoreFromStaleAccess(daysSince(now, user.lastLoginAt));
+    const recentImpactRisk = clampScore((recentEventImpactByUser.get(user.userId) ?? 0) * 4);
+
+    const factors: UserRiskFactorBreakdown = {
+      mfaRisk,
+      authFailureRisk,
+      sessionAnomalyRisk,
+      threatExposureRisk,
+      softwareViolationRisk,
+      deviceSecurityRisk,
+      staleAccessRisk,
+      recentImpactRisk
+    };
+
+    const score = computeUserRiskScoreFromFactors(factors, policy.weights);
+    const previousScore = previousScores.get(user.userId) ?? null;
+    const delta = previousScore === null ? 0 : score - previousScore;
+    const trendDirection = deriveUserRiskTrendDirection(previousScore, score);
+
+    results.push({
+      orgId,
+      userId: user.userId,
+      score,
+      factors,
+      previousScore,
+      delta,
+      trendDirection
+    });
+  }
+
+  return results;
+}
+
+async function autoAssignTrainingIfNeeded(input: {
+  computedRows: ComputedUserRisk[];
+  policy: UserRiskPolicy;
+  orgId: string;
+  actorSource: string;
+}): Promise<number> {
+  if (!input.policy.interventions.autoAssignTraining) {
+    return 0;
+  }
+
+  const threshold = input.policy.thresholds.autoAssignTrainingAtOrAbove
+    ?? input.policy.thresholds.high
+    ?? DEFAULT_USER_RISK_THRESHOLDS.high
+    ?? 70;
+
+  const recentAssignments = await fetchRecentTrainingAssignments(input.orgId);
+  let assigned = 0;
+
+  for (const row of input.computedRows) {
+    if (row.score < threshold) continue;
+    if (recentAssignments.has(row.userId)) continue;
+
+    const moduleId = input.policy.interventions.trainingModuleId
+      ?? DEFAULT_USER_RISK_INTERVENTIONS.trainingModuleId
+      ?? 'security-awareness-baseline';
+
+    const assignment = await recordTrainingAssignment({
+      orgId: input.orgId,
+      userId: row.userId,
+      moduleId,
+      assignedBy: null,
+      source: input.actorSource,
+      reason: `Auto-assigned for user risk score ${row.score}`
+    });
+
+    if (!assignment.deduplicated) {
+      assigned += 1;
+    }
+  }
+
+  return assigned;
+}
+
+function buildChangedUsers(
+  computedRows: ComputedUserRisk[],
+  thresholds: UserRiskPolicyThresholds
+): UserRiskRecomputeResult['changedUsers'] {
+  const highThreshold = thresholds.high ?? DEFAULT_USER_RISK_THRESHOLDS.high ?? 70;
+  const spikeDelta = thresholds.spikeDelta ?? DEFAULT_USER_RISK_THRESHOLDS.spikeDelta ?? 15;
+
+  return computedRows
+    .map((row) => ({
+      userId: row.userId,
+      score: row.score,
+      previousScore: row.previousScore,
+      delta: row.delta,
+      trendDirection: row.trendDirection,
+      crossedHighThreshold: row.score >= highThreshold && (row.previousScore ?? 0) < highThreshold,
+      spiked: row.delta >= spikeDelta
+    }))
+    .filter((row) => row.crossedHighThreshold || row.spiked || Math.abs(row.delta) >= 5);
+}
+
+async function persistUserRiskSnapshots(computedRows: ComputedUserRisk[], calculatedAt: Date): Promise<void> {
+  if (computedRows.length === 0) return;
+  await db.insert(userRiskScores).values(
+    computedRows.map((row) => ({
+      orgId: row.orgId,
+      userId: row.userId,
+      score: row.score,
+      factors: row.factors,
+      trendDirection: row.trendDirection,
+      calculatedAt
+    }))
+  );
+}
+
+export async function computeAndPersistOrgUserRisk(orgId: string): Promise<UserRiskRecomputeResult> {
+  const policy = await getOrCreateUserRiskPolicy(orgId);
+  const calculatedAt = new Date();
+  const computedRows = await computeOrgUserRiskRows(orgId, policy);
+  await persistUserRiskSnapshots(computedRows, calculatedAt);
+
+  const changedUsers = buildChangedUsers(computedRows, policy.thresholds);
+
+  const autoTrainingAssigned = await autoAssignTrainingIfNeeded({
+    computedRows,
+    policy,
+    orgId,
+    actorSource: 'user-risk-intervention-evaluator'
+  });
+
+  return {
+    orgId,
+    calculatedAt: calculatedAt.toISOString(),
+    usersProcessed: computedRows.length,
+    changedUsers,
+    autoTrainingAssigned,
+    policy
+  };
+}
+
+export async function computeAndPersistUserRiskForUser(orgId: string, userId: string): Promise<UserRiskRecomputeResult> {
+  const policy = await getOrCreateUserRiskPolicy(orgId);
+  const calculatedAt = new Date();
+  const computedRows = await computeOrgUserRiskRows(orgId, policy, [userId]);
+  await persistUserRiskSnapshots(computedRows, calculatedAt);
+
+  const changedUsers = buildChangedUsers(computedRows, policy.thresholds);
+  const autoTrainingAssigned = await autoAssignTrainingIfNeeded({
+    computedRows,
+    policy,
+    orgId,
+    actorSource: 'user-risk-intervention-evaluator'
+  });
+
+  return {
+    orgId,
+    calculatedAt: calculatedAt.toISOString(),
+    usersProcessed: computedRows.length,
+    changedUsers,
+    autoTrainingAssigned,
+    policy
+  };
+}
+
+export async function listUserRiskScores(filter: UserRiskScoreListFilter): Promise<{
+  total: number;
+  rows: Array<{
+    orgId: string;
+    userId: string;
+    userName: string;
+    userEmail: string;
+    score: number;
+    trendDirection: 'up' | 'down' | 'stable' | null;
+    calculatedAt: string;
+    factors: UserRiskFactorBreakdown;
+  }>;
+}> {
+  const scopeConditions: SQL[] = [];
+  if (filter.orgId) {
+    scopeConditions.push(eq(userRiskScores.orgId, filter.orgId));
+  } else if (filter.orgIds && filter.orgIds.length > 0) {
+    scopeConditions.push(inArray(userRiskScores.orgId, filter.orgIds));
+  }
+
+  const latestByUser = db
+    .select({
+      orgId: userRiskScores.orgId,
+      userId: userRiskScores.userId,
+      calculatedAt: sql<Date>`max(${userRiskScores.calculatedAt})`.as('calculated_at')
+    })
+    .from(userRiskScores)
+    .where(scopeConditions.length > 0 ? and(...scopeConditions) : undefined)
+    .groupBy(userRiskScores.orgId, userRiskScores.userId)
+    .as('latest_user_risk_scores');
+
+  const conditions: SQL[] = [
+    eq(userRiskScores.orgId, latestByUser.orgId),
+    eq(userRiskScores.userId, latestByUser.userId),
+    eq(userRiskScores.calculatedAt, latestByUser.calculatedAt)
+  ];
+  if (filter.minScore !== undefined) conditions.push(gte(userRiskScores.score, clampScore(filter.minScore)));
+  if (filter.maxScore !== undefined) conditions.push(lte(userRiskScores.score, clampScore(filter.maxScore)));
+  if (filter.trendDirection) conditions.push(eq(userRiskScores.trendDirection, filter.trendDirection));
+  if (filter.search) {
+    const pattern = `%${filter.search}%`;
+    conditions.push(
+      or(
+        ilike(users.name, pattern),
+        ilike(users.email, pattern)
+      )!
+    );
+  }
+  if (filter.siteId) {
+    conditions.push(sql`${organizationUsers.siteIds} @> ARRAY[${filter.siteId}]::uuid[]`);
+  }
+
+  const whereClause = and(...conditions);
+  const limit = Math.min(Math.max(1, filter.limit ?? 25), 200);
+  const offset = Math.max(0, filter.offset ?? 0);
+
+  const [countRow, rows] = await Promise.all([
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(userRiskScores)
+      .innerJoin(latestByUser, eq(userRiskScores.orgId, latestByUser.orgId))
+      .innerJoin(users, eq(userRiskScores.userId, users.id))
+      .innerJoin(
+        organizationUsers,
+        and(
+          eq(organizationUsers.orgId, userRiskScores.orgId),
+          eq(organizationUsers.userId, users.id)
+        )
+      )
+      .where(whereClause)
+      .then((result) => result[0]?.count ?? 0),
+    db
+      .select({
+        orgId: userRiskScores.orgId,
+        userId: userRiskScores.userId,
+        userName: users.name,
+        userEmail: users.email,
+        score: userRiskScores.score,
+        trendDirection: userRiskScores.trendDirection,
+        calculatedAt: userRiskScores.calculatedAt,
+        factors: userRiskScores.factors
+      })
+      .from(userRiskScores)
+      .innerJoin(latestByUser, eq(userRiskScores.orgId, latestByUser.orgId))
+      .innerJoin(users, eq(userRiskScores.userId, users.id))
+      .innerJoin(
+        organizationUsers,
+        and(
+          eq(organizationUsers.orgId, userRiskScores.orgId),
+          eq(organizationUsers.userId, users.id)
+        )
+      )
+      .where(whereClause)
+      .orderBy(desc(userRiskScores.score), desc(userRiskScores.calculatedAt))
+      .limit(limit)
+      .offset(offset)
+  ]);
+
+  return {
+    total: Number(countRow),
+    rows: rows.map((row) => ({
+      orgId: row.orgId,
+      userId: row.userId,
+      userName: row.userName,
+      userEmail: row.userEmail,
+      score: row.score,
+      trendDirection: (row.trendDirection as 'up' | 'down' | 'stable' | null) ?? null,
+      calculatedAt: row.calculatedAt.toISOString(),
+      factors: normalizeFactorMap(row.factors)
+    }))
+  };
+}
+
+export async function getUserRiskDetail(orgId: string, userId: string): Promise<{
+  user: { id: string; name: string; email: string; mfaEnabled: boolean; lastLoginAt: string | null };
+  latestScore: {
+    score: number;
+    factors: UserRiskFactorBreakdown;
+    trendDirection: 'up' | 'down' | 'stable' | null;
+    calculatedAt: string;
+    deltaFromPrevious: number;
+    severity: 'low' | 'medium' | 'high' | 'critical';
+  };
+  recentEvents: Array<{
+    id: string;
+    eventType: string;
+    severity: string | null;
+    scoreImpact: number;
+    description: string;
+    occurredAt: string;
+    details: Record<string, unknown> | null;
+  }>;
+  history: Array<{
+    score: number;
+    trendDirection: 'up' | 'down' | 'stable' | null;
+    calculatedAt: string;
+  }>;
+  policy: UserRiskPolicy;
+} | null> {
+  const [membership] = await db
+    .select({
+      userId: users.id,
+      name: users.name,
+      email: users.email,
+      mfaEnabled: users.mfaEnabled,
+      lastLoginAt: users.lastLoginAt
+    })
+    .from(organizationUsers)
+    .innerJoin(users, eq(organizationUsers.userId, users.id))
+    .where(
+      and(
+        eq(organizationUsers.orgId, orgId),
+        eq(organizationUsers.userId, userId)
+      )
+    )
+    .limit(1);
+
+  if (!membership) return null;
+
+  const [history, events, policy] = await Promise.all([
+    db
+      .select({
+        score: userRiskScores.score,
+        trendDirection: userRiskScores.trendDirection,
+        calculatedAt: userRiskScores.calculatedAt,
+        factors: userRiskScores.factors
+      })
+      .from(userRiskScores)
+      .where(
+        and(
+          eq(userRiskScores.orgId, orgId),
+          eq(userRiskScores.userId, userId)
+        )
+      )
+      .orderBy(desc(userRiskScores.calculatedAt))
+      .limit(30),
+    db
+      .select({
+        id: userRiskEvents.id,
+        eventType: userRiskEvents.eventType,
+        severity: userRiskEvents.severity,
+        scoreImpact: userRiskEvents.scoreImpact,
+        description: userRiskEvents.description,
+        occurredAt: userRiskEvents.occurredAt,
+        details: userRiskEvents.details
+      })
+      .from(userRiskEvents)
+      .where(
+        and(
+          eq(userRiskEvents.orgId, orgId),
+          eq(userRiskEvents.userId, userId)
+        )
+      )
+      .orderBy(desc(userRiskEvents.occurredAt))
+      .limit(100),
+    getOrCreateUserRiskPolicy(orgId)
+  ]);
+
+  if (history.length === 0) return null;
+
+  const latest = history[0];
+  const previous = history[1] ?? null;
+  const deltaFromPrevious = previous ? latest.score - previous.score : 0;
+
+  return {
+    user: {
+      id: membership.userId,
+      name: membership.name,
+      email: membership.email,
+      mfaEnabled: membership.mfaEnabled,
+      lastLoginAt: membership.lastLoginAt?.toISOString() ?? null
+    },
+    latestScore: {
+      score: latest.score,
+      factors: normalizeFactorMap(latest.factors),
+      trendDirection: (latest.trendDirection as 'up' | 'down' | 'stable' | null) ?? null,
+      calculatedAt: latest.calculatedAt.toISOString(),
+      deltaFromPrevious,
+      severity: classifyUserRiskSeverity(latest.score, policy.thresholds)
+    },
+    recentEvents: events.map((event) => ({
+      id: event.id,
+      eventType: event.eventType,
+      severity: event.severity,
+      scoreImpact: event.scoreImpact,
+      description: event.description,
+      occurredAt: event.occurredAt.toISOString(),
+      details: (event.details as Record<string, unknown> | null) ?? null
+    })),
+    history: history.map((row) => ({
+      score: row.score,
+      trendDirection: (row.trendDirection as 'up' | 'down' | 'stable' | null) ?? null,
+      calculatedAt: row.calculatedAt.toISOString()
+    })),
+    policy
+  };
+}
+
+export async function listUserRiskEvents(filter: UserRiskEventFilter): Promise<{
+  total: number;
+  rows: Array<{
+    id: string;
+    orgId: string;
+    userId: string;
+    userName: string;
+    userEmail: string;
+    eventType: string;
+    severity: string | null;
+    scoreImpact: number;
+    description: string;
+    details: Record<string, unknown> | null;
+    occurredAt: string;
+  }>;
+}> {
+  const conditions: SQL[] = [];
+  if (filter.orgId) {
+    conditions.push(eq(userRiskEvents.orgId, filter.orgId));
+  } else if (filter.orgIds && filter.orgIds.length > 0) {
+    conditions.push(inArray(userRiskEvents.orgId, filter.orgIds));
+  }
+  if (filter.userId) conditions.push(eq(userRiskEvents.userId, filter.userId));
+  if (filter.eventType) conditions.push(eq(userRiskEvents.eventType, filter.eventType));
+  if (filter.severity) conditions.push(eq(userRiskEvents.severity, filter.severity));
+  if (filter.from) conditions.push(gte(userRiskEvents.occurredAt, filter.from));
+  if (filter.to) conditions.push(lte(userRiskEvents.occurredAt, filter.to));
+
+  const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+  const limit = Math.min(Math.max(1, filter.limit ?? 50), 500);
+  const offset = Math.max(0, filter.offset ?? 0);
+
+  const [count, rows] = await Promise.all([
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(userRiskEvents)
+      .where(whereClause)
+      .then((result) => result[0]?.count ?? 0),
+    db
+      .select({
+        id: userRiskEvents.id,
+        orgId: userRiskEvents.orgId,
+        userId: userRiskEvents.userId,
+        userName: users.name,
+        userEmail: users.email,
+        eventType: userRiskEvents.eventType,
+        severity: userRiskEvents.severity,
+        scoreImpact: userRiskEvents.scoreImpact,
+        description: userRiskEvents.description,
+        details: userRiskEvents.details,
+        occurredAt: userRiskEvents.occurredAt
+      })
+      .from(userRiskEvents)
+      .innerJoin(users, eq(userRiskEvents.userId, users.id))
+      .where(whereClause)
+      .orderBy(desc(userRiskEvents.occurredAt))
+      .limit(limit)
+      .offset(offset)
+  ]);
+
+  return {
+    total: Number(count),
+    rows: rows.map((row) => ({
+      id: row.id,
+      orgId: row.orgId,
+      userId: row.userId,
+      userName: row.userName,
+      userEmail: row.userEmail,
+      eventType: row.eventType,
+      severity: row.severity,
+      scoreImpact: row.scoreImpact,
+      description: row.description,
+      details: (row.details as Record<string, unknown> | null) ?? null,
+      occurredAt: row.occurredAt.toISOString()
+    }))
+  };
+}
+
+type RecordTrainingInput = {
+  orgId: string;
+  userId: string;
+  moduleId: string;
+  assignedBy: string | null;
+  source: string;
+  reason?: string;
+};
+
+type RecordTrainingResult = {
+  id: string;
+  deduplicated: boolean;
+  eventPublished: boolean;
+};
+
+async function recordTrainingAssignment(input: RecordTrainingInput): Promise<RecordTrainingResult> {
+  const dedupCutoff = new Date(Date.now() - TRAINING_DEDUP_HOURS * 60 * 60 * 1000);
+  const [existing] = await db
+    .select({ id: userRiskEvents.id })
+    .from(userRiskEvents)
+    .where(
+      and(
+        eq(userRiskEvents.orgId, input.orgId),
+        eq(userRiskEvents.userId, input.userId),
+        eq(userRiskEvents.eventType, 'training_assigned'),
+        gte(userRiskEvents.occurredAt, dedupCutoff),
+        sql`${userRiskEvents.details}->>'moduleId' = ${input.moduleId}`
+      )
+    )
+    .orderBy(desc(userRiskEvents.occurredAt))
+    .limit(1);
+
+  if (existing) {
+    return {
+      id: existing.id,
+      deduplicated: true,
+      eventPublished: false
+    };
+  }
+
+  const now = new Date();
+  const description = input.reason
+    ? `Security training assigned: ${input.reason}`
+    : 'Security training assigned';
+
+  const [eventRow] = await db
+    .insert(userRiskEvents)
+    .values({
+      orgId: input.orgId,
+      userId: input.userId,
+      eventType: 'training_assigned',
+      severity: 'low',
+      scoreImpact: -5,
+      description,
+      details: {
+        moduleId: input.moduleId,
+        source: input.source,
+        assignedBy: input.assignedBy
+      },
+      occurredAt: now
+    })
+    .returning({ id: userRiskEvents.id });
+
+  let eventPublished = false;
+  try {
+    await publishEvent(
+      TRAINING_ASSIGNED_EVENT_TYPE,
+      input.orgId,
+      {
+        userId: input.userId,
+        moduleId: input.moduleId,
+        assignedBy: input.assignedBy,
+        assignedAt: now.toISOString(),
+        source: input.source
+      },
+      input.source
+    );
+    eventPublished = true;
+  } catch (error) {
+    console.error(`[UserRisk] Failed to publish ${TRAINING_ASSIGNED_EVENT_TYPE} for user ${input.userId}:`, error);
+  }
+
+  return {
+    id: eventRow?.id ?? '',
+    deduplicated: false,
+    eventPublished
+  };
+}
+
+export async function assignSecurityTraining(input: {
+  orgId: string;
+  userId: string;
+  moduleId?: string;
+  reason?: string;
+  assignedBy: string;
+}): Promise<{ assignmentEventId: string; moduleId: string; deduplicated: boolean; eventPublished: boolean }> {
+  const [membership] = await db
+    .select({ userId: organizationUsers.userId })
+    .from(organizationUsers)
+    .where(
+      and(
+        eq(organizationUsers.orgId, input.orgId),
+        eq(organizationUsers.userId, input.userId)
+      )
+    )
+    .limit(1);
+
+  if (!membership) {
+    throw new Error('User is not part of this organization');
+  }
+
+  const moduleId = input.moduleId?.trim() || DEFAULT_USER_RISK_INTERVENTIONS.trainingModuleId || 'security-awareness-baseline';
+  const assignment = await recordTrainingAssignment({
+    orgId: input.orgId,
+    userId: input.userId,
+    moduleId,
+    assignedBy: input.assignedBy,
+    source: 'user-risk-api',
+    reason: input.reason
+  });
+
+  return {
+    assignmentEventId: assignment.id,
+    moduleId,
+    deduplicated: assignment.deduplicated,
+    eventPublished: assignment.eventPublished
+  };
+}
+
+export async function publishUserRiskScoreEvents(input: {
+  orgId: string;
+  changedUsers: UserRiskRecomputeResult['changedUsers'];
+  thresholds: UserRiskPolicyThresholds;
+  interventions: UserRiskPolicyInterventions;
+}): Promise<{ publishedHigh: number; publishedSpikes: number; failed: number }> {
+  let publishedHigh = 0;
+  let publishedSpikes = 0;
+  let failed = 0;
+
+  for (const user of input.changedUsers) {
+    if (user.crossedHighThreshold && input.interventions.notifyOnHighRisk !== false) {
+      try {
+        await publishEvent(
+          HIGH_EVENT_TYPE,
+          input.orgId,
+          {
+            userId: user.userId,
+            score: user.score,
+            previousScore: user.previousScore,
+            delta: user.delta,
+            threshold: input.thresholds.high ?? DEFAULT_USER_RISK_THRESHOLDS.high
+          },
+          'user-risk-jobs'
+        );
+        publishedHigh++;
+      } catch (error) {
+        failed++;
+        console.error(`[UserRiskJobs] Failed to publish ${HIGH_EVENT_TYPE} for user ${user.userId}:`, error);
+      }
+    }
+
+    if (user.spiked && input.interventions.notifyOnRiskSpike !== false) {
+      try {
+        await publishEvent(
+          SPIKE_EVENT_TYPE,
+          input.orgId,
+          {
+            userId: user.userId,
+            score: user.score,
+            previousScore: user.previousScore,
+            delta: user.delta,
+            threshold: input.thresholds.spikeDelta ?? DEFAULT_USER_RISK_THRESHOLDS.spikeDelta
+          },
+          'user-risk-jobs'
+        );
+        publishedSpikes++;
+      } catch (error) {
+        failed++;
+        console.error(`[UserRiskJobs] Failed to publish ${SPIKE_EVENT_TYPE} for user ${user.userId}:`, error);
+      }
+    }
+  }
+
+  return {
+    publishedHigh,
+    publishedSpikes,
+    failed
+  };
+}
+
+export async function appendUserRiskSignalEvent(input: {
+  orgId: string;
+  userId: string;
+  eventType: string;
+  severity?: 'low' | 'medium' | 'high' | 'critical';
+  scoreImpact?: number;
+  description: string;
+  details?: Record<string, unknown>;
+  occurredAt?: Date;
+}): Promise<string> {
+  const [row] = await db
+    .insert(userRiskEvents)
+    .values({
+      orgId: input.orgId,
+      userId: input.userId,
+      eventType: input.eventType,
+      severity: input.severity ?? null,
+      scoreImpact: input.scoreImpact ?? 0,
+      description: input.description,
+      details: input.details ?? null,
+      occurredAt: input.occurredAt ?? new Date()
+    })
+    .returning({ id: userRiskEvents.id });
+
+  return row?.id ?? '';
+}
+
+export async function getUserRiskOrgMembership(userId: string, orgId: string): Promise<boolean> {
+  const [membership] = await db
+    .select({ id: organizationUsers.id })
+    .from(organizationUsers)
+    .where(
+      and(
+        eq(organizationUsers.userId, userId),
+        eq(organizationUsers.orgId, orgId)
+      )
+    )
+    .limit(1);
+  return !!membership;
+}
+
+export async function listActiveDeviceSessionsForUserInOrg(input: {
+  orgId: string;
+  userEmail: string;
+}): Promise<{ activeSessions: number; idleSessions: number }> {
+  const usernameCandidates = Array.from(normalizeIdentityValue(input.userEmail));
+  if (usernameCandidates.length === 0) {
+    return { activeSessions: 0, idleSessions: 0 };
+  }
+
+  const rows = await db
+    .select({
+      activityState: deviceSessions.activityState
+    })
+    .from(deviceSessions)
+    .where(
+      and(
+        eq(deviceSessions.orgId, input.orgId),
+        eq(deviceSessions.isActive, true),
+        inArray(deviceSessions.username, usernameCandidates)
+      )
+    );
+
+  return {
+    activeSessions: rows.length,
+    idleSessions: rows.filter((row) => row.activityState === 'idle' || row.activityState === 'away').length
+  };
+}

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -14,6 +14,7 @@ This comprehensive guide covers all administrative functions in the Breeze RMM p
 6. [Audit & Compliance](#6-audit--compliance)
 7. [System Settings](#7-system-settings)
 8. [Troubleshooting](#8-troubleshooting)
+9. [User Risk Scoring](#9-user-risk-scoring)
 
 ---
 
@@ -1544,6 +1545,66 @@ When contacting support, provide:
    - Recent changes
 
 ---
+
+## 9. User Risk Scoring
+
+The User Risk feature provides per-user behavioral risk scoring to prioritize interventions.
+
+### 9.1 Endpoints
+
+- `GET /api/v1/user-risk/scores` — ranked user risk list with filters and pagination
+- `GET /api/v1/user-risk/users/{userId}` — detailed factors, history, and recent risk events
+- `GET /api/v1/user-risk/events` — event history with severity/type/date filters
+- `GET /api/v1/user-risk/policy` — retrieve effective org policy
+- `PUT /api/v1/user-risk/policy` — update weights, thresholds, and interventions
+- `POST /api/v1/user-risk/assign-training` — assign training to a user
+
+### 9.2 Policy Tuning
+
+User risk policy is organization-scoped and supports:
+
+- `weights`: relative weighting for factors such as MFA risk, auth failures, threat exposure, and stale access
+- `thresholds`: boundary values for `medium`, `high`, `critical`, plus spike and auto-assignment thresholds
+- `interventions`: controls for notifications and auto-training behavior
+
+Example update:
+
+```bash
+PUT /api/v1/user-risk/policy
+Content-Type: application/json
+
+{
+  "orgId": "org-uuid",
+  "thresholds": {
+    "high": 75,
+    "critical": 90,
+    "spikeDelta": 20,
+    "autoAssignTrainingAtOrAbove": 85
+  },
+  "interventions": {
+    "autoAssignTraining": true,
+    "notifyOnHighRisk": true,
+    "notifyOnRiskSpike": true,
+    "trainingModuleId": "security-awareness-q1"
+  }
+}
+```
+
+### 9.3 Intervention Workflow
+
+1. Background jobs compute and persist user risk snapshots every 6 hours.
+2. High-signal risk events trigger targeted per-user recomputation for faster deltas.
+3. Threshold crossings/spikes emit user-risk events to the event bus.
+3. If enabled, high-risk users receive auto-assigned training with cooldown controls.
+4. Manual assignment remains available through `/assign-training`.
+5. All writes are auditable via route-level audit events.
+
+### 9.4 Operational Notes
+
+- For partner/system users spanning multiple orgs, pass `orgId` explicitly for writes.
+- Use `/events` to review explainability context for score changes.
+- Use policy tuning conservatively to prevent alert fatigue.
+- Job cadence is configurable via environment variables (for example: `USER_RISK_SCAN_INTERVAL_MS`).
 
 ## Appendix A: API Quick Reference
 


### PR DESCRIPTION
## Summary
- add user risk scoring schema, migration, scoring service, background jobs, and retention job
- add user risk API routes with tests and wire routes/workers into app bootstrap/shutdown
- expose user risk capabilities in AI tools/guardrails/schemas and document admin usage

## Validation
- pnpm -C apps/api test:run src/routes/userRisk.test.ts src/services/userRiskScoring.test.ts