### PR TITLE
fix: dashboard stuck on Loading for org-scoped users

### DIFF
--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -390,13 +390,19 @@ const listOrganizationsSchema = z.object({
   limit: z.string().optional()
 });
 
-orgRoutes.get('/organizations', requireScope('partner', 'system'), zValidator('query', listOrganizationsSchema), async (c) => {
+orgRoutes.get('/organizations', requireScope('organization', 'partner', 'system'), zValidator('query', listOrganizationsSchema), async (c) => {
   const auth = c.get('auth') as AuthContext;
   const { partnerId: queryPartnerId, ...pagination } = c.req.valid('query');
   const { page, limit, offset } = getPagination(pagination);
 
   let conditions;
-  if (auth.scope === 'partner') {
+  if (auth.scope === 'organization') {
+    // Organization-scoped users can only see their own organization
+    if (!auth.orgId) {
+      return c.json({ data: [], pagination: { page, limit, total: 0 } });
+    }
+    conditions = and(eq(organizations.id, auth.orgId), isNull(organizations.deletedAt));
+  } else if (auth.scope === 'partner') {
     const orgIds = auth.accessibleOrgIds ?? [];
     if (orgIds.length === 0) {
       return c.json({

--- a/apps/web/src/components/auth/AuthOverlay.tsx
+++ b/apps/web/src/components/auth/AuthOverlay.tsx
@@ -18,6 +18,19 @@ export default function AuthOverlay() {
     return () => clearTimeout(timer);
   }, []);
 
+  // Safety net: if the overlay is still visible after 10 seconds, force redirect to login.
+  // This prevents the user from being stuck on "Loading..." indefinitely.
+  useEffect(() => {
+    const safetyTimer = setTimeout(() => {
+      const state = useAuthStore.getState();
+      if (!state.isAuthenticated || !state.tokens?.accessToken) {
+        redirectToLogin();
+      }
+    }, 10_000);
+
+    return () => clearTimeout(safetyTimer);
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
 

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -267,7 +267,20 @@ export async function fetchWithAuth(url: string, options: RequestInit = {}): Pro
 
   headers.set('Content-Type', 'application/json');
 
-  let response = await fetch(buildApiUrl(url), { ...options, headers, credentials: 'include' });
+  // Use caller-provided signal or create a 30-second timeout to prevent indefinite hangs
+  const externalSignal = options.signal;
+  const controller = !externalSignal ? new AbortController() : null;
+  const timeout = controller ? setTimeout(() => controller.abort(), 30_000) : null;
+  const signal = externalSignal ?? controller!.signal;
+
+  let response: Response;
+  try {
+    response = await fetch(buildApiUrl(url), { ...options, headers, credentials: 'include', signal });
+  } catch (err) {
+    if (timeout) clearTimeout(timeout);
+    throw err;
+  }
+  if (timeout) clearTimeout(timeout);
 
   // If unauthorized, attempt cookie-backed refresh once
   if (response.status === 401) {


### PR DESCRIPTION
## Summary
Fixes #185 — Dashboard shows "Loading..." forever after login.

Three root causes identified and fixed:
- **Org endpoint 403**: `GET /orgs/organizations` denied organization-scoped users entirely. Now returns the user's own org when scope is `organization`
- **No fetch timeout**: `fetchWithAuth()` could hang indefinitely. Added 30s AbortController timeout
- **AuthOverlay stuck**: No safety escape if token recovery hung. Added 10s fallback that redirects to login

## Test plan
- [ ] Login as an organization-scoped user → dashboard loads without hanging
- [ ] Login as a partner-scoped user → dashboard loads (regression check)
- [ ] OrgSwitcher shows the user's org for org-scoped users
- [ ] Simulate unreachable API → dashboard shows error within 30s instead of hanging
- [ ] AuthOverlay redirects to login within 10s if auth state can't resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)