### PR TITLE
fix: review followup for deviceRole, systemd, and compose changes

### DIFF
--- a/agent/service/systemd/breeze-agent.service
+++ b/agent/service/systemd/breeze-agent.service
@@ -18,7 +18,6 @@ StartLimitBurst=5
 # script execution, patching, and self-update. ProtectSystem=strict/full
 # breaks sudo in child shells and prevents writes to /usr/local/bin.
 PrivateTmp=true
-NoNewPrivileges=false
 
 # Logging (stdout goes to journald)
 StandardOutput=journal

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -27,6 +27,7 @@ export type Device = {
   lastUser?: string;
   uptimeSeconds?: number;
   deviceRole?: DeviceRole;
+  deviceRoleSource?: string;
 };
 
 type DeviceListProps = {

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -123,7 +123,8 @@ export default function DevicesPage() {
           siteName: '', // Will be resolved from sites
           agentVersion: (d.agentVersion ?? '') as string,
           tags: (d.tags ?? []) as string[],
-          deviceRole: (d.deviceRole as DeviceRole | undefined) ?? undefined
+          deviceRole: d.deviceRole as DeviceRole | undefined,
+          deviceRoleSource: d.deviceRoleSource as string | undefined
         };
       });
 


### PR DESCRIPTION
## Summary
- Wire `deviceRoleSource` through to frontend `Device` type so the API field isn't silently dropped
- Remove redundant `?? undefined` on `deviceRole` cast in DevicesPage
- Remove explicit `NoNewPrivileges=false` from systemd unit (it's already the default)

Follows up on the 4 commits pushed to main: `b458b13`, `27f8ba5`, `fc2475d`, `dd54b43`.

## Review findings addressed
| Finding | Fix |
|---------|-----|
| `deviceRoleSource` returned by API but dropped in frontend transform | Added to `Device` type + mapping |
| `(d.deviceRole as DeviceRole \| undefined) ?? undefined` redundant | Simplified cast |
| `NoNewPrivileges=false` redundant systemd directive | Removed (default is false) |

## Findings confirmed as non-issues
- **SSR breakage from empty `PUBLIC_API_URL`**: All data fetching is client-side (React islands via `useEffect`). No `.astro` pages do SSR fetches.
- **CapabilityBoundingSet removal**: Intentional — RMM agent requires full system access for sudo, patching, self-update.
- **Fire-and-forget update goroutines**: Pre-existing pattern, not introduced by these changes.

## Test plan
- [ ] Verify device list page loads and shows `deviceRole` column correctly
- [ ] Verify systemd service starts without warnings on Linux
- [ ] `npx tsc --noEmit` passes for web app

🤖 Generated with [Claude Code](https://claude.com/claude-code)