### PR TITLE
fix: harden assist launcher security

### DIFF
--- a/agent/internal/heartbeat/handlers_desktop_helper.go
+++ b/agent/internal/heartbeat/handlers_desktop_helper.go
@@ -13,8 +13,16 @@ import (
 	"github.com/breeze-rmm/agent/internal/sessionbroker"
 )
 
-// spawnGuard prevents concurrent helper spawns for the same target session.
-var spawnGuard sync.Mutex
+// spawnGuards holds a per-session mutex so that spawns into different Windows
+// sessions can proceed in parallel. The sync.Map key is the target session ID
+// string (or "" for auto-detect).
+var spawnGuards sync.Map
+
+// sessionSpawnMu returns a mutex for the given session key, creating one if needed.
+func sessionSpawnMu(sessionKey string) *sync.Mutex {
+	val, _ := spawnGuards.LoadOrStore(sessionKey, &sync.Mutex{})
+	return val.(*sync.Mutex)
+}
 
 // isWinSessionDisconnected checks whether the given Windows session ID is
 // disconnected (no active display). Helpers in disconnected sessions cannot
@@ -50,8 +58,9 @@ func (h *Heartbeat) startDesktopViaHelper(sessionID, offer string, iceServers []
 	}
 
 	if session == nil {
-		// Serialize spawns to prevent duplicate helpers for the same session
-		spawnGuard.Lock()
+		// Serialize spawns per target session so independent sessions can spawn concurrently
+		mu := sessionSpawnMu(targetSession)
+		mu.Lock()
 		// Re-check after acquiring lock — another goroutine may have spawned it
 		session = h.sessionBroker.FindCapableSession("capture", targetSession)
 		if session != nil && isWinSessionDisconnected(session.WinSessionID) {
@@ -60,7 +69,7 @@ func (h *Heartbeat) startDesktopViaHelper(sessionID, offer string, iceServers []
 		}
 		if session == nil {
 			if err := h.spawnHelperForDesktop(targetSession); err != nil {
-				spawnGuard.Unlock()
+				mu.Unlock()
 				return tools.NewErrorResult(fmt.Errorf("no capable helper session and spawn failed: %w", err), 0)
 			}
 			// Poll for the helper to connect (up to 5s, every 100ms)
@@ -73,7 +82,7 @@ func (h *Heartbeat) startDesktopViaHelper(sessionID, offer string, iceServers []
 				session = nil
 			}
 		}
-		spawnGuard.Unlock()
+		mu.Unlock()
 		if session == nil {
 			return tools.NewErrorResult(fmt.Errorf("helper spawned but did not connect within 5s"), 0)
 		}

--- a/agent/internal/heartbeat/handlers_screenshot.go
+++ b/agent/internal/heartbeat/handlers_screenshot.go
@@ -30,12 +30,13 @@ func handleTakeScreenshot(h *Heartbeat, cmd Command) tools.CommandResult {
 func (h *Heartbeat) executeToolViaHelper(cmdType string, payload map[string]any, start time.Time) tools.CommandResult {
 	session := h.sessionBroker.FindCapableSession("capture", "")
 	if session == nil {
-		// Try spawning a helper
-		spawnGuard.Lock()
+		// Try spawning a helper (use per-session lock for auto-detect "")
+		mu := sessionSpawnMu("")
+		mu.Lock()
 		session = h.sessionBroker.FindCapableSession("capture", "")
 		if session == nil {
 			if err := h.spawnHelperForDesktop(""); err != nil {
-				spawnGuard.Unlock()
+				mu.Unlock()
 				return tools.NewErrorResult(
 					fmt.Errorf("no user helper available for %s (spawn failed: %w)", cmdType, err),
 					time.Since(start).Milliseconds(),
@@ -49,7 +50,7 @@ func (h *Heartbeat) executeToolViaHelper(cmdType string, payload map[string]any,
 				}
 			}
 		}
-		spawnGuard.Unlock()
+		mu.Unlock()
 		if session == nil {
 			return tools.NewErrorResult(
 				fmt.Errorf("helper spawned but did not connect within 5s for %s", cmdType),

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -360,8 +360,20 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 		}
 	}
 
-	// Step 7: Verify binary hash (require non-empty hash from client)
-	if b.selfHash != "" && authReq.BinaryHash != b.selfHash {
+	// Step 8: Verify binary hash — reject ALL helpers if our own hash is unavailable
+	if b.selfHash == "" {
+		log.Error("rejecting helper connection: agent binary hash unavailable — cannot verify helper integrity",
+			"identity", identityKey,
+			"pid", creds.PID,
+		)
+		_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
+			Accepted: false,
+			Reason:   "agent binary hash unavailable",
+		})
+		conn.Close()
+		return
+	}
+	if authReq.BinaryHash != b.selfHash {
 		log.Warn("binary hash mismatch",
 			"identity", identityKey,
 			"expected", b.selfHash,

--- a/agent/internal/sessionbroker/spawner_windows.go
+++ b/agent/internal/sessionbroker/spawner_windows.go
@@ -28,12 +28,15 @@ func SpawnHelperInSession(sessionID uint32) error {
 	defer processToken.Close()
 
 	// 2. Duplicate as a primary token we can modify.
+	// SecurityImpersonation is sufficient for local DXGI desktop capture;
+	// SecurityDelegation is only needed for credential delegation to remote
+	// machines, which the helper never performs.
 	var dupToken windows.Token
 	err = windows.DuplicateTokenEx(
 		processToken,
 		windows.MAXIMUM_ALLOWED,
 		nil, // default security attributes
-		windows.SecurityDelegation, // Delegation required for CreateProcessAsUser + cross-session GPU access
+		windows.SecurityImpersonation,
 		windows.TokenPrimary,
 		&dupToken,
 	)

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -78,6 +78,7 @@ const envSchema = z
     REDIS_URL: z.string().default('redis://localhost:6379'),
     NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
     PARTNER_HOOKS_URL: z.string().url().optional(),
+    PARTNER_HOOKS_SECRET: z.string().min(16).optional(),
   })
   // --- Cross-field refinements (insecure defaults for required secrets) -------
   .superRefine((data, ctx) => {
@@ -256,6 +257,7 @@ export function validateConfig(): AppConfig {
     NODE_ENV: env.NODE_ENV,
     E2E_MODE: env.E2E_MODE,
     PARTNER_HOOKS_URL: env.PARTNER_HOOKS_URL,
+    PARTNER_HOOKS_SECRET: env.PARTNER_HOOKS_SECRET,
   });
 
   if (!result.success) {

--- a/apps/api/src/services/partnerHooks.ts
+++ b/apps/api/src/services/partnerHooks.ts
@@ -1,3 +1,4 @@
+import { createHmac } from 'node:crypto';
 import { getConfig } from '../config/validate';
 
 interface HookPayload {
@@ -35,6 +36,16 @@ export async function dispatchHook(
 
   const url = `${baseUrl}/${event}`;
   const payload: HookPayload = { event, partnerId, data };
+  const bodyString = JSON.stringify(payload);
+
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+
+  // When PARTNER_HOOKS_SECRET is set, sign the payload with HMAC-SHA256
+  const secret = process.env.PARTNER_HOOKS_SECRET;
+  if (secret) {
+    const signature = createHmac('sha256', secret).update(bodyString).digest('hex');
+    headers['X-Breeze-Signature'] = `sha256=${signature}`;
+  }
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 5000);
@@ -42,8 +53,8 @@ export async function dispatchHook(
   try {
     const res = await fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
+      headers,
+      body: bodyString,
       signal: controller.signal,
     });
 


### PR DESCRIPTION
## Summary
- **Per-session spawn guard**: Replaced the global `spawnGuard sync.Mutex` with a `sync.Map` of per-session mutexes keyed by Windows session ID, so spawning a helper into Session 1 no longer blocks Session 2
- **Binary hash enforcement**: When the agent's own binary hash is unavailable (computation failed at startup), ALL helper connections are now rejected with an error log instead of silently skipping verification
- **HMAC webhook signing**: Added `PARTNER_HOOKS_SECRET` env var support — when set, outbound partner webhook requests include an `X-Breeze-Signature: sha256=<hex>` header computed via HMAC-SHA256; backwards compatible (no signature when unset)
- **Reduced token impersonation level**: Changed `DuplicateTokenEx` from `SecurityDelegation` to `SecurityImpersonation` in the helper spawner, since delegation-level tokens are only needed for remote credential forwarding, not local DXGI desktop capture

## Test plan
- [ ] Verify Go agent compiles: `cd agent && go build ./...`
- [ ] Verify API TypeScript compiles: `cd apps/api && npx tsc --noEmit`
- [ ] Test concurrent desktop sessions targeting different Windows sessions spawn independently
- [ ] Confirm helper connections are rejected when binary hash computation fails (e.g., simulate by making the executable unreadable briefly)
- [ ] Test webhook signing: set `PARTNER_HOOKS_SECRET`, trigger a hook, verify `X-Breeze-Signature` header is present and correct
- [ ] Test webhook without secret: unset `PARTNER_HOOKS_SECRET`, verify hooks still fire without signature header
- [ ] Verify helper spawning still works with `SecurityImpersonation` token on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)