### PR TITLE
fix: increase MFT VBV buffer to 500ms to eliminate kbps oscillation

### DIFF
--- a/agent/internal/remote/desktop/mft_windows.go
+++ b/agent/internal/remote/desktop/mft_windows.go
@@ -12,6 +12,18 @@ import (
 	"unsafe"
 )
 
+// vbvSizeForBitrate returns the VBV buffer size (in bits) for a given bitrate,
+// targeting 500ms of headroom (bitrate / 2). The floor of 500K bits ensures
+// I-frames remain viable even at MinBitrate (500 Kbps), where the 500ms
+// ratio would yield only 250K — too small for a 1080p keyframe.
+func vbvSizeForBitrate(bitrate int) uint32 {
+	vbvSize := uint32(bitrate / 2)
+	if vbvSize < 500000 {
+		vbvSize = 500000
+	}
+	return vbvSize
+}
+
 // mftEncoder implements encoderBackend using Windows Media Foundation Transform.
 // It discovers and uses hardware H264 encoders (NVENC, QuickSync, AMD VCE)
 // via the MFT enumeration API, falling back to the software H264 MFT.
@@ -246,15 +258,13 @@ func (m *mftEncoder) initialize(width, height, stride int) error {
 
 		// 3. VBV buffer: 500ms of bitrate headroom.
 		//    Per-frame buffers (1-3 frames) are too small — a single 1080p
-		//    I-frame (50-150 KB) exceeds them, forcing the encoder to starve
-		//    P-frames until the budget recovers (visible as kbps oscillation
-		//    between ~34 and ~7000). Half-second buffer gives enough room
-		//    to absorb I-frame bursts without adding latency (MF_LOW_LATENCY
-		//    controls actual encode delay, not VBV size).
-		vbvSize := uint32(m.cfg.Bitrate / 2)
-		if vbvSize < 500000 {
-			vbvSize = 500000
-		}
+		//    I-frame (400K–1.2M bits) exceeds them, forcing the encoder to
+		//    starve P-frames until the budget recovers (visible as kbps
+		//    oscillation between ~34 and ~7000). Half-second buffer gives
+		//    enough room to absorb I-frame bursts without adding latency
+		//    (MF_LOW_LATENCY primarily controls encode pipeline delay,
+		//    not the rate-control buffer window).
+		vbvSize := vbvSizeForBitrate(m.cfg.Bitrate)
 		vbv := comVariant{vt: vtUI4, val: uint64(vbvSize)}
 		if _, err := comCall(codecAPI, vtblCodecAPISetValue,
 			uintptr(unsafe.Pointer(&codecAPIAVEncCommonBufferSize)),
@@ -631,18 +641,17 @@ func (m *mftEncoder) SetBitrate(bitrate int) error {
 	slog.Debug("Dynamic bitrate applied via ICodecAPI", "bitrate", bitrate)
 
 	// Update VBV buffer to maintain 500ms ratio at new bitrate.
-	// Without this, a bitrate reduction leaves the VBV oversized (harmless)
-	// but a bitrate increase leaves it undersized (causes burst-starve).
-	vbvSize := uint32(bitrate / 2)
-	if vbvSize < 500000 {
-		vbvSize = 500000
-	}
+	// Without this, a bitrate reduction leaves the VBV oversized (allows
+	// transient rate spikes, less severe than the inverse) but a bitrate
+	// increase leaves it undersized (causes burst-starve).
+	vbvSize := vbvSizeForBitrate(bitrate)
 	vbv := comVariant{vt: vtUI4, val: uint64(vbvSize)}
 	if _, err := comCall(m.codecAPI, vtblCodecAPISetValue,
 		uintptr(unsafe.Pointer(&codecAPIAVEncCommonBufferSize)),
 		uintptr(unsafe.Pointer(&vbv)),
 	); err != nil {
-		slog.Debug("ICodecAPI SetValue(BufferSize) failed during bitrate update", "vbvSize", vbvSize, "error", err.Error())
+		slog.Warn("ICodecAPI SetValue(BufferSize) failed during bitrate update — encoder VBV/bitrate mismatch",
+			"vbvSize", vbvSize, "bitrate", bitrate, "error", err.Error())
 	}
 
 	return nil

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -186,10 +186,11 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
         .limit(1);
 
       if (latestVersion) {
-        // Dev builds (dev-*) can't be compared via semver — always upgrade them to latest release.
-        if (data.agentVersion.startsWith('dev-')) {
+        // Dev builds (dev-*) can't be parsed as versions — always upgrade to latest release,
+        // unless already running that exact version (avoids upgrade loops).
+        if (data.agentVersion.startsWith('dev-') && latestVersion.version !== data.agentVersion) {
           upgradeTo = latestVersion.version;
-        } else {
+        } else if (!data.agentVersion.startsWith('dev-')) {
           const cmp = compareAgentVersions(latestVersion.version, data.agentVersion);
           if (cmp > 0) {
             upgradeTo = latestVersion.version;

--- a/apps/helper/src-tauri/src/lib.rs
+++ b/apps/helper/src-tauri/src/lib.rs
@@ -57,6 +57,23 @@ fn agent_config_path() -> PathBuf {
     }
 }
 
+/// Log a message to the Breeze helper log file.
+/// In SYSTEM service context, stderr is not connected to anything visible,
+/// so we append to a log file in the Breeze data directory instead.
+fn log_helper_error(msg: &str) {
+    eprintln!("{}", msg); // still try stderr for non-service contexts
+    let log_path = agent_config_path().with_file_name("helper.log");
+    use std::io::Write;
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+    {
+        let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
+        let _ = writeln!(f, "[{}] {}", ts, msg);
+    }
+}
+
 /// Parse the agent YAML config from disk.
 fn load_agent_config_full() -> Result<AgentConfigFull, String> {
     let path = agent_config_path();
@@ -610,8 +627,10 @@ pub fn run() {
             // Create main window manually (not from config) so we can set
             // a custom WebView2 data directory when running as SYSTEM.
             // The agent service spawns this process with a SYSTEM token
-            // (session ID overridden), causing WebView2's default data path
-            // to resolve to system32\config\systemprofile which isn't writable.
+            // (session ID overridden to the user's session), causing WebView2's
+            // default data path to resolve to the SYSTEM profile directory
+            // (systemprofile\AppData\Local) which may not exist or be accessible
+            // when running in a user session rather than Session 0.
             let mut wb = tauri::WebviewWindowBuilder::new(
                 app,
                 "main",
@@ -632,16 +651,25 @@ pub fn run() {
                     let data_dir = PathBuf::from(pd)
                         .join("Breeze")
                         .join("helper-webview");
-                    eprintln!(
+                    if let Err(e) = std::fs::create_dir_all(&data_dir) {
+                        let msg = format!(
+                            "[helper] Failed to create WebView2 data dir {}: {}",
+                            data_dir.display(), e
+                        );
+                        log_helper_error(&msg);
+                        return Err(msg.into());
+                    }
+                    log_helper_error(&format!(
                         "[helper] SYSTEM context detected, WebView2 data dir: {}",
                         data_dir.display()
-                    );
+                    ));
                     wb = wb.data_directory(data_dir);
                 }
             }
 
             wb.build().map_err(|e| {
-                eprintln!("[helper] Failed to create main window: {}", e);
+                let msg = format!("[helper] Failed to create main window: {}", e);
+                log_helper_error(&msg);
                 e
             })?;
 

--- a/apps/viewer/src/components/DesktopViewer.tsx
+++ b/apps/viewer/src/components/DesktopViewer.tsx
@@ -397,6 +397,9 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
 
     reconnectInFlightRef.current = true;
     const originalTransport = transportRef.current;
+    if (!originalTransport) {
+      console.warn('Reconnect: transport ref was null, defaulting to WebRTC');
+    }
     try {
       if (originalTransport === 'websocket') {
         // Original connection was WebSocket — reconnect with WS only

--- a/docker-compose.override.yml.dev
+++ b/docker-compose.override.yml.dev
@@ -30,6 +30,7 @@ services:
         }
         header {
           X-Content-Type-Options "nosniff"
+          X-Frame-Options "DENY"
           Referrer-Policy "strict-origin-when-cross-origin"
         }
       }


### PR DESCRIPTION
## Summary
- Increase MFT encoder VBV buffer from 3-frame (~31 KB) to 500ms-of-bitrate (~156 KB at 2.5 Mbps) so I-frames don't starve subsequent P-frames
- Update VBV buffer dynamically in `SetBitrate()` so the adaptive controller's bitrate changes keep the VBV proportional
- Also includes: helper WebView2 data_directory fix for SYSTEM context, viewer reconnect transport fidelity, dev-agent heartbeat upgrade logic

## Problem
WebRTC stats showed wild kbps oscillation (34 → 7717 → 62), sustained jitter (80-127ms), and 21.5% frame drops on a LAN connection with 4ms RTT. Root cause: the 3-frame VBV buffer (31 KB) couldn't hold a single 1080p I-frame (50-150 KB), forcing a burst-starve cycle where the encoder alternated between dumping oversized frames and producing near-zero output.

## Fix
- `mft_windows.go` init: `bitrate / 2` (500ms) instead of `bitrate / fps * 3` (3 frames), floor 500K bits
- `mft_windows.go` SetBitrate: now also updates `CODECAPI_AVEncCommonBufferSize` to maintain the 500ms ratio

## Test plan
- [ ] Rebuild agent and verify kbps stabilizes around target bitrate (no more 34→7000 swings)
- [ ] Verify jitter stays under 30ms on LAN connections
- [ ] Verify frame drops stay under 2% during active desktop use
- [ ] Confirm adaptive bitrate still degrades on real congestion (>8% loss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)