### PR TITLE
fix: BE-32 code review findings

### DIFF
--- a/agent/internal/remote/tools/incident_response.go
+++ b/agent/internal/remote/tools/incident_response.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"time"
 
@@ -69,6 +70,12 @@ func CollectEvidence(payload map[string]any) CommandResult {
 			evidence["logs"] = map[string]any{
 				"message":  "full log collection requires platform-specific implementation",
 				"platform": runtime.GOOS,
+			}
+
+		case "screenshot":
+			evidence[et] = map[string]any{
+				"note":      "Screenshot evidence collection requires platform-specific implementation",
+				"collected": false,
 			}
 
 		default:
@@ -217,6 +224,16 @@ func executeProcessKill(payload map[string]any, startTime time.Time) CommandResu
 			fmt.Errorf("pid is required in parameters"),
 			time.Since(startTime).Milliseconds(),
 		)
+	}
+
+	// Guard against killing critical system processes
+	if pid <= 1 {
+		return NewErrorResult(fmt.Errorf("cannot kill PID %d: system-critical process", pid), time.Since(startTime).Milliseconds())
+	}
+
+	// Guard against killing the agent itself
+	if pid == os.Getpid() {
+		return NewErrorResult(fmt.Errorf("cannot kill PID %d: this is the agent process", pid), time.Since(startTime).Milliseconds())
 	}
 
 	p, err := process.NewProcess(int32(pid))

--- a/apps/api/migrations/0074-incident-updated-at-trigger.sql
+++ b/apps/api/migrations/0074-incident-updated-at-trigger.sql
@@ -1,0 +1,14 @@
+-- Auto-update updated_at on incidents table
+CREATE OR REPLACE FUNCTION update_incident_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_incidents_updated_at ON incidents;
+CREATE TRIGGER trg_incidents_updated_at
+  BEFORE UPDATE ON incidents
+  FOR EACH ROW
+  EXECUTE FUNCTION update_incident_updated_at();

--- a/apps/api/src/jobs/incidentJobs.ts
+++ b/apps/api/src/jobs/incidentJobs.ts
@@ -76,7 +76,7 @@ async function runIncidentTimelineEnrichmentPass(): Promise<void> {
       .where(
         and(
           ne(incidents.status, 'closed'),
-          sql`jsonb_array_length(${incidents.timeline}) = 0`
+          sql`NOT (${incidents.timeline}::jsonb @> '[{"type":"timeline_enriched"}]'::jsonb)`
         )
       )
       .limit(100);

--- a/apps/api/src/routes/incidentActions.ts
+++ b/apps/api/src/routes/incidentActions.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { eq } from 'drizzle-orm';
+import { and, eq, type SQL } from 'drizzle-orm';
 import type { StatusCode } from 'hono/utils/http-status';
 import { db } from '../db';
 import {
@@ -40,35 +40,46 @@ incidentActionRoutes.post(
     const auth = c.get('auth');
     const { id } = c.req.valid('param');
     const data = c.req.valid('json');
-    const incident = await getIncidentWithOrgCheck(id, auth);
-
-    if (!incident) {
-      return c.json({ error: 'Incident not found' }, 404);
-    }
 
     if (HIGH_RISK_CONTAINMENT_ACTIONS.has(data.actionType) && !data.approvalRef) {
       return c.json({ error: 'High-risk containment actions require an approvalRef' }, 400);
     }
 
-    const actionStatus = data.status ?? 'completed';
-    if (isContainmentSuccess(actionStatus) && !canTransitionStatus(incident.status, 'contained')) {
-      return c.json({ error: `Cannot transition incident from ${incident.status} to contained` }, 400);
-    }
-
-    const executedAt = data.executedAt ? new Date(data.executedAt) : new Date();
-    const timeline = appendTimeline(incident.timeline, {
-      at: new Date().toISOString(),
-      type: isContainmentSuccess(actionStatus) ? 'containment_executed' : 'containment_attempted',
-      actor: data.executedBy ?? 'user',
-      summary: data.description,
-      metadata: {
-        actionType: data.actionType,
-        actionStatus,
-        approvalRef: data.approvalRef,
-      },
-    });
-
     const transactionResult = await db.transaction(async (tx) => {
+      const conditions: SQL[] = [eq(incidents.id, id)];
+      const orgCondition = auth.orgCondition(incidents.orgId);
+      if (orgCondition) {
+        conditions.push(orgCondition);
+      }
+
+      const [incident] = await tx
+        .select()
+        .from(incidents)
+        .where(and(...conditions))
+        .limit(1);
+
+      if (!incident) {
+        return { error: 'Incident not found', status: 404 as const };
+      }
+
+      const actionStatus = data.status ?? 'completed';
+      if (isContainmentSuccess(actionStatus) && !canTransitionStatus(incident.status, 'contained')) {
+        return { error: `Cannot transition incident from ${incident.status} to contained`, status: 400 as const };
+      }
+
+      const executedAt = data.executedAt ? new Date(data.executedAt) : new Date();
+      const timeline = appendTimeline(incident.timeline, {
+        at: new Date().toISOString(),
+        type: isContainmentSuccess(actionStatus) ? 'containment_executed' : 'containment_attempted',
+        actor: data.executedBy ?? 'user',
+        summary: data.description,
+        metadata: {
+          actionType: data.actionType,
+          actionStatus,
+          approvalRef: data.approvalRef,
+        },
+      });
+
       const [action] = await tx
         .insert(incidentActions)
         .values({
@@ -108,16 +119,16 @@ incidentActionRoutes.post(
         throw new Error('Failed to update incident after containment');
       }
 
-      return { action, updatedIncident };
+      return { incident, action, updatedIncident };
     });
 
-    const { action, updatedIncident } = transactionResult;
-
-    if (!action || !updatedIncident) {
-      return c.json({ error: 'Failed to apply containment' }, 500);
+    if ('error' in transactionResult) {
+      return c.json({ error: transactionResult.error }, transactionResult.status);
     }
 
-    if (isContainmentSuccess(actionStatus)) {
+    const { incident, action, updatedIncident } = transactionResult;
+
+    if (isContainmentSuccess(action.status)) {
       try {
         await publishEvent(
           'incident.contained',

--- a/apps/api/src/routes/incidents.test.ts
+++ b/apps/api/src/routes/incidents.test.ts
@@ -83,9 +83,16 @@ function mockOrderedSelect(rows: unknown[]) {
   } as any;
 }
 
-function mockContainmentTransaction(action: unknown, updatedIncident: unknown) {
+function mockContainmentTransaction(incident: unknown, action: unknown, updatedIncident: unknown) {
   vi.mocked(db.transaction).mockImplementationOnce(async (callback: any) => {
     const tx = {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue(incident ? [incident] : []),
+          }),
+        }),
+      }),
       insert: vi.fn().mockReturnValue({
         values: vi.fn().mockReturnValue({
           returning: vi.fn().mockResolvedValue([action]),
@@ -95,6 +102,28 @@ function mockContainmentTransaction(action: unknown, updatedIncident: unknown) {
         set: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
             returning: vi.fn().mockResolvedValue([updatedIncident]),
+          }),
+        }),
+      }),
+    };
+    return callback(tx);
+  });
+}
+
+function mockCloseTransaction(incident: unknown, updated: unknown) {
+  vi.mocked(db.transaction).mockImplementationOnce(async (callback: any) => {
+    const tx = {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue(incident ? [incident] : []),
+          }),
+        }),
+      }),
+      update: vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue(updated ? [updated] : []),
           }),
         }),
       }),
@@ -174,14 +203,6 @@ describe('incidentRoutes', () => {
   });
 
   it('rejects high-risk containment without approvalRef', async () => {
-    vi.mocked(db.select).mockReturnValueOnce(mockSelectSingle({
-      id: '33333333-3333-4333-8333-333333333333',
-      orgId: '22222222-2222-4222-8222-222222222222',
-      title: 'Credential compromise',
-      status: 'analyzing',
-      timeline: [],
-    }));
-
     const res = await app.request('/incidents/33333333-3333-4333-8333-333333333333/contain', {
       method: 'POST',
       headers: {
@@ -200,14 +221,14 @@ describe('incidentRoutes', () => {
   });
 
   it('does not mark incident contained for failed containment actions', async () => {
-    vi.mocked(db.select).mockReturnValueOnce(mockSelectSingle({
-      id: '33333333-3333-4333-8333-333333333333',
-      orgId: '22222222-2222-4222-8222-222222222222',
-      title: 'Credential compromise',
-      status: 'analyzing',
-      timeline: [],
-    }));
     mockContainmentTransaction(
+      {
+        id: '33333333-3333-4333-8333-333333333333',
+        orgId: '22222222-2222-4222-8222-222222222222',
+        title: 'Credential compromise',
+        status: 'analyzing',
+        timeline: [],
+      },
       {
         id: 'action-1',
         actionType: 'process_kill',
@@ -230,6 +251,7 @@ describe('incidentRoutes', () => {
         actionType: 'process_kill',
         description: 'Kill suspicious process',
         status: 'failed',
+        approvalRef: 'APPROVE-001',
       }),
     });
 
@@ -344,13 +366,16 @@ describe('incidentRoutes', () => {
   });
 
   it('rejects close transition from analyzing', async () => {
-    vi.mocked(db.select).mockReturnValueOnce(mockSelectSingle({
-      id: '33333333-3333-4333-8333-333333333333',
-      orgId: '22222222-2222-4222-8222-222222222222',
-      title: 'Credential compromise',
-      status: 'analyzing',
-      timeline: [],
-    }));
+    mockCloseTransaction(
+      {
+        id: '33333333-3333-4333-8333-333333333333',
+        orgId: '22222222-2222-4222-8222-222222222222',
+        title: 'Credential compromise',
+        status: 'analyzing',
+        timeline: [],
+      },
+      null
+    );
 
     const res = await app.request('/incidents/33333333-3333-4333-8333-333333333333/close', {
       method: 'POST',
@@ -369,30 +394,23 @@ describe('incidentRoutes', () => {
   });
 
   it('closes an incident from POST /incidents/:id/close', async () => {
-    vi.mocked(db.select).mockReturnValueOnce(mockSelectSingle({
-      id: '33333333-3333-4333-8333-333333333333',
-      orgId: '22222222-2222-4222-8222-222222222222',
-      title: 'Credential compromise',
-      status: 'contained',
-      timeline: [],
-    }));
-
-    vi.mocked(db.update).mockReturnValueOnce({
-      set: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([
-            {
-              id: '33333333-3333-4333-8333-333333333333',
-              orgId: '22222222-2222-4222-8222-222222222222',
-              title: 'Credential compromise',
-              status: 'closed',
-              resolvedAt: new Date('2026-02-26T10:00:00.000Z'),
-              closedAt: new Date('2026-02-26T10:00:00.000Z'),
-            },
-          ]),
-        }),
-      }),
-    } as any);
+    mockCloseTransaction(
+      {
+        id: '33333333-3333-4333-8333-333333333333',
+        orgId: '22222222-2222-4222-8222-222222222222',
+        title: 'Credential compromise',
+        status: 'contained',
+        timeline: [],
+      },
+      {
+        id: '33333333-3333-4333-8333-333333333333',
+        orgId: '22222222-2222-4222-8222-222222222222',
+        title: 'Credential compromise',
+        status: 'closed',
+        resolvedAt: new Date('2026-02-26T10:00:00.000Z'),
+        closedAt: new Date('2026-02-26T10:00:00.000Z'),
+      }
+    );
 
     const res = await app.request('/incidents/33333333-3333-4333-8333-333333333333/close', {
       method: 'POST',

--- a/apps/api/src/routes/incidents.ts
+++ b/apps/api/src/routes/incidents.ts
@@ -213,12 +213,12 @@ incidentRoutes.get(
       db
         .select()
         .from(incidentEvidence)
-        .where(eq(incidentEvidence.incidentId, id))
+        .where(and(eq(incidentEvidence.incidentId, id), eq(incidentEvidence.orgId, incident.orgId)))
         .orderBy(desc(incidentEvidence.collectedAt), desc(incidentEvidence.createdAt)),
       db
         .select()
         .from(incidentActions)
-        .where(eq(incidentActions.incidentId, id))
+        .where(and(eq(incidentActions.incidentId, id), eq(incidentActions.orgId, incident.orgId)))
         .orderBy(desc(incidentActions.executedAt), desc(incidentActions.createdAt)),
     ]);
 
@@ -240,45 +240,66 @@ incidentRoutes.post(
     const auth = c.get('auth');
     const { id } = c.req.valid('param');
     const data = c.req.valid('json');
-    const incident = await getIncidentWithOrgCheck(id, auth);
 
-    if (!incident) {
-      return c.json({ error: 'Incident not found' }, 404);
-    }
+    const result = await db.transaction(async (tx) => {
+      const conditions: SQL[] = [eq(incidents.id, id)];
+      const orgCondition = auth.orgCondition(incidents.orgId);
+      if (orgCondition) {
+        conditions.push(orgCondition);
+      }
 
-    if (!canTransitionStatus(incident.status, 'closed')) {
-      return c.json({ error: `Cannot transition incident from ${incident.status} to closed` }, 400);
-    }
+      const [incident] = await tx
+        .select()
+        .from(incidents)
+        .where(and(...conditions))
+        .limit(1);
 
-    const resolvedAt = data.resolvedAt ? new Date(data.resolvedAt) : new Date();
-    const closedAt = new Date();
+      if (!incident) {
+        return { error: 'Incident not found', status: 404 as const };
+      }
 
-    const timeline = appendTimeline(incident.timeline, {
-      at: closedAt.toISOString(),
-      type: 'incident_closed',
-      actor: 'user',
-      summary: data.summary,
-      metadata: {
-        lessonsLearned: data.lessonsLearned,
-      },
+      if (!canTransitionStatus(incident.status, 'closed')) {
+        return { error: `Cannot transition incident from ${incident.status} to closed`, status: 400 as const };
+      }
+
+      const resolvedAt = data.resolvedAt ? new Date(data.resolvedAt) : new Date();
+      const closedAt = new Date();
+
+      const timeline = appendTimeline(incident.timeline, {
+        at: closedAt.toISOString(),
+        type: 'incident_closed',
+        actor: 'user',
+        summary: data.summary,
+        metadata: {
+          lessonsLearned: data.lessonsLearned,
+        },
+      });
+
+      const [updated] = await tx
+        .update(incidents)
+        .set({
+          status: 'closed',
+          summary: data.summary,
+          resolvedAt,
+          closedAt,
+          timeline,
+          updatedAt: new Date(),
+        })
+        .where(eq(incidents.id, incident.id))
+        .returning();
+
+      if (!updated) {
+        return { error: 'Failed to close incident', status: 500 as const };
+      }
+
+      return { incident, updated };
     });
 
-    const [updated] = await db
-      .update(incidents)
-      .set({
-        status: 'closed',
-        summary: data.summary,
-        resolvedAt,
-        closedAt,
-        timeline,
-        updatedAt: new Date(),
-      })
-      .where(eq(incidents.id, incident.id))
-      .returning();
-
-    if (!updated) {
-      return c.json({ error: 'Failed to close incident' }, 500);
+    if ('error' in result) {
+      return c.json({ error: result.error }, result.status);
     }
+
+    const { incident, updated } = result;
 
     try {
       await publishEvent(
@@ -329,12 +350,12 @@ incidentRoutes.get(
       db
         .select()
         .from(incidentEvidence)
-        .where(eq(incidentEvidence.incidentId, incident.id))
+        .where(and(eq(incidentEvidence.incidentId, incident.id), eq(incidentEvidence.orgId, incident.orgId)))
         .orderBy(desc(incidentEvidence.collectedAt)),
       db
         .select()
         .from(incidentActions)
-        .where(eq(incidentActions.incidentId, incident.id))
+        .where(and(eq(incidentActions.incidentId, incident.id), eq(incidentActions.orgId, incident.orgId)))
         .orderBy(desc(incidentActions.executedAt)),
     ]);
 

--- a/apps/api/src/routes/incidents.validation.ts
+++ b/apps/api/src/routes/incidents.validation.ts
@@ -77,6 +77,7 @@ export const HIGH_RISK_CONTAINMENT_ACTIONS = new Set([
   'network_isolation',
   'account_disable',
   'usb_block',
+  'process_kill',
 ]);
 
 export const ALLOWED_EVIDENCE_STORAGE_SCHEMES = new Set(

--- a/apps/api/src/services/aiToolsIncident.ts
+++ b/apps/api/src/services/aiToolsIncident.ts
@@ -19,6 +19,7 @@ import { resolveWritableToolOrgId } from './aiTools';
 import { queueCommandForExecution } from './commandQueue';
 import { publishEvent } from './eventBus';
 import type { IncidentTimelineEntry } from '../db/schema/incidentResponse';
+import { HIGH_RISK_CONTAINMENT_ACTIONS } from '../routes/incidents.validation';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -208,8 +209,7 @@ export function registerIncidentTools(aiTools: Map<string, AiTool>): void {
       if (!input.deviceId) return JSON.stringify({ error: 'deviceId is required' });
       if (!input.actionType) return JSON.stringify({ error: 'actionType is required' });
 
-      const HIGH_RISK_ACTIONS = new Set(['network_isolation', 'account_disable', 'usb_block']);
-      if (HIGH_RISK_ACTIONS.has(input.actionType as string) && !input.approvalRef) {
+      if (HIGH_RISK_CONTAINMENT_ACTIONS.has(input.actionType as string) && !input.approvalRef) {
         return JSON.stringify({ error: 'High-risk containment actions require an approvalRef' });
       }
 

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -1396,7 +1396,7 @@ Default rate limits protect the API from abuse:
 
 Breeze includes incident lifecycle workflows under `/api/v1/incidents` for structured triage, containment, evidence collection, and closure.
 
-### 8.1 Incident Lifecycle
+### 10.1 Incident Lifecycle
 
 Incident status transitions follow:
 
@@ -1409,7 +1409,7 @@ Operational notes:
 - Use **evidence** (`POST /api/v1/incidents/{id}/evidence`) for forensic artifacts and chain-of-custody metadata.
 - Use **close** (`POST /api/v1/incidents/{id}/close`) only after remediation and validation are complete.
 
-### 8.2 Required Data for Strong Auditability
+### 10.2 Required Data for Strong Auditability
 
 When handling incidents, record:
 
@@ -1418,7 +1418,7 @@ When handling incidents, record:
 - Evidence metadata (`evidenceType`, collection actor/time, storage path, optional integrity hash)
 - Approval references for high-risk containment (`approvalRef`)
 
-### 8.3 High-Risk Containment Governance
+### 10.3 High-Risk Containment Governance
 
 The following containment actions require an approval reference:
 
@@ -1428,7 +1428,7 @@ The following containment actions require an approval reference:
 
 If these actions are submitted without `approvalRef`, the API rejects the request.
 
-### 8.4 Incident Reporting
+### 10.4 Incident Reporting
 
 Use `GET /api/v1/incidents/{id}/report` to generate a stakeholder-ready summary including:
 
@@ -1437,7 +1437,7 @@ Use `GET /api/v1/incidents/{id}/report` to generate a stakeholder-ready summary 
 - Action success/failure counts
 - Captured lessons learned (from close step)
 
-### 8.5 Event Hooks
+### 10.5 Event Hooks
 
 Incident workflows emit:
 


### PR DESCRIPTION
## Summary
Post-merge code review fixes for BE-32 incident response automation:

- **Critical**: Add orgId defense-in-depth filter on evidence/actions queries
- **Critical**: Add PID safety guards in Go agent process kill (reject PID ≤1 and self)
- **Important**: Add `process_kill` to HIGH_RISK_CONTAINMENT_ACTIONS
- **Important**: Fix TOCTOU race — wrap close in transaction, move contain read inside tx
- **Important**: Fix timeline enricher to use enrichment marker instead of empty check
- **Important**: Fix admin guide subsection numbering
- **Suggestion**: Deduplicate HIGH_RISK set (import from validation)
- **Suggestion**: Add screenshot evidence stub in Go agent
- **Suggestion**: Add updatedAt trigger migration (0074)

## Test plan
- [x] TypeScript compiles — 0 errors
- [x] API tests pass — 10/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)