### PR TITLE
feat: context-aware help panel, AI docs tool, backup/patch fixes

### DIFF
--- a/apps/api/src/routes/patches/compliance.ts
+++ b/apps/api/src/routes/patches/compliance.ts
@@ -150,9 +150,9 @@ complianceRoutes.get(
         importantCount: sql<number>`count(*) filter (where ${devicePatches.status} in ('pending', 'missing') and ${patches.severity} = 'important')`,
         osMissing: sql<number>`count(*) filter (where ${devicePatches.status} in ('pending', 'missing') and ${patches.source} in ('microsoft', 'apple', 'linux'))`,
         thirdPartyMissing: sql<number>`count(*) filter (where ${devicePatches.status} in ('pending', 'missing') and ${patches.source} in ('third_party', 'custom'))`,
-        lastInstalledAt: sql<string | null>`max(case when ${devicePatches.status} = 'installed' and ${devicePatches.installedAt} is not null then ${devicePatches.installedAt} end)`,
+        lastInstalledAt: sql<string | null>`max(case when ${devicePatches.status} = 'installed' and ${devicePatches.installedAt} is not null then ${devicePatches.installedAt}::timestamptz::text end)`,
         pendingReboot: sql<boolean>`bool_or(${patches.requiresReboot} and ${devicePatches.status} = 'installed' and ${devicePatches.installedAt} is not null)`,
-        lastScannedAt: sql<string | null>`max(${devicePatches.lastCheckedAt})`
+        lastScannedAt: sql<string | null>`max(${devicePatches.lastCheckedAt})::timestamptz::text`
       })
       .from(devicePatches)
       .innerJoin(patches, eq(devicePatches.patchId, patches.id))


### PR DESCRIPTION
## Summary
- **Context-aware help panel**: Slide-out docs panel (Cmd+Shift+H) that opens the correct documentation page based on current app location, with panel swap coordination against AI chat
- **AI documentation search tool**: `search_documentation` AI tool backed by a build-time index of 92 doc pages, with docs links in chat responses opening in the help panel
- **Backup config resolver fix**: Changed backup settings join from INNER to LEFT JOIN so devices with feature links predating the settings migration are still found; added inlineSettings fallback for schedule resolution
- **Patch timestamp fix**: Cast `lastInstalledAt` and `lastScannedAt` to `timestamptz::text` so Drizzle returns ISO strings instead of raw date objects

## Test plan
- [ ] Navigate to different pages (scripts, patches, devices) and click help button — verify correct docs page opens
- [ ] Open AI chat then click help — verify panels swap (and vice versa)
- [ ] Ask AI "how do I create a script?" — verify it uses `search_documentation` and returns docs links
- [ ] Click a docs link in AI response — verify it opens in help panel, not new tab
- [ ] Verify Cmd+Shift+H and Cmd+Shift+A keyboard shortcuts work and swap panels
- [ ] Check sidebar footer shows Web and API version numbers
- [ ] Verify backup dashboard `/status/:deviceId` returns `nextScheduledAt` for devices with inline settings only
- [ ] Verify patch compliance endpoint returns proper ISO timestamp strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)