### PR TITLE
feat: add watchdog to all platform installers

### DIFF
--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -8,6 +8,9 @@
 <?ifndef BackupExePath?>
 <?define BackupExePath=..\breeze-backup-windows-amd64.exe?>
 <?endif?>
+<?ifndef WatchdogExePath?>
+<?define WatchdogExePath=..\breeze-watchdog-windows-amd64.exe?>
+<?endif?>
 <?ifndef UserTaskXmlPath?>
 <?define UserTaskXmlPath=..\service\windows\breeze-agent-user-task.xml?>
 <?endif?>
@@ -72,6 +75,25 @@
         <Component Id="cmpBreezeBackupExe" Guid="*">
           <File Id="filBreezeBackupExe" Name="breeze-backup.exe"
                 Source="$(var.BackupExePath)" KeyPath="yes" />
+        </Component>
+
+        <Component Id="cmpBreezeWatchdogExe" Guid="*">
+          <File Id="filBreezeWatchdogExe" Name="breeze-watchdog.exe"
+                Source="$(var.WatchdogExePath)" KeyPath="yes" />
+          <ServiceInstall Id="svcInstallWatchdog"
+                          Name="BreezeWatchdog"
+                          DisplayName="Breeze RMM Watchdog"
+                          Description="Monitors and recovers the Breeze RMM Agent"
+                          Start="auto"
+                          Type="ownProcess"
+                          ErrorControl="normal"
+                          Arguments="run" />
+          <ServiceControl Id="svcControlWatchdog"
+                          Name="BreezeWatchdog"
+                          Start="install"
+                          Stop="both"
+                          Remove="uninstall"
+                          Wait="yes" />
         </Component>
 
         <!-- Register BreezeAgent to run in Safe Mode with Networking. Without this,
@@ -175,6 +197,7 @@
     <Feature Id="MainFeature" Title="Breeze Agent" Level="1">
       <ComponentRef Id="cmpBreezeAgentExe" />
       <ComponentRef Id="cmpBreezeBackupExe" />
+      <ComponentRef Id="cmpBreezeWatchdogExe" />
       <ComponentRef Id="cmpSafeBootNetworkReg" />
       <ComponentRef Id="cmpUserTaskXml" />
       <ComponentRef Id="cmpInstallWindowsPs1" />

--- a/agent/installer/build-msi.ps1
+++ b/agent/installer/build-msi.ps1
@@ -9,6 +9,9 @@ param(
     [string]$BackupExePath = "",
 
     [Parameter(Mandatory = $false)]
+    [string]$WatchdogExePath = "",
+
+    [Parameter(Mandatory = $false)]
     [string]$OutputPath = ""
 )
 
@@ -27,6 +30,9 @@ if ([string]::IsNullOrWhiteSpace($AgentExePath)) {
 if ([string]::IsNullOrWhiteSpace($BackupExePath)) {
     $BackupExePath = Join-Path $repoRoot "breeze-backup-windows-amd64.exe"
 }
+if ([string]::IsNullOrWhiteSpace($WatchdogExePath)) {
+    $WatchdogExePath = Join-Path $repoRoot "breeze-watchdog-windows-amd64.exe"
+}
 if ([string]::IsNullOrWhiteSpace($OutputPath)) {
     $OutputPath = Join-Path $repoRoot "..\\dist\\breeze-agent.msi"
 }
@@ -43,6 +49,9 @@ if (-not (Test-Path $AgentExePath)) {
 }
 if (-not (Test-Path $BackupExePath)) {
     throw "Backup executable not found: $BackupExePath"
+}
+if (-not (Test-Path $WatchdogExePath)) {
+    throw "Watchdog executable not found: $WatchdogExePath"
 }
 if (-not (Test-Path $taskXmlPath)) {
     throw "Task XML not found: $taskXmlPath"
@@ -74,6 +83,7 @@ $wixArgs = @(
     "-d", "Version=$msiVersion",
     "-d", "AgentExePath=$AgentExePath",
     "-d", "BackupExePath=$BackupExePath",
+    "-d", "WatchdogExePath=$WatchdogExePath",
     "-d", "UserTaskXmlPath=$taskXmlPath",
     "-d", "InstallUserHelperScriptPath=$installUserHelperScriptPath",
     "-d", "RemoveUserHelperScriptPath=$removeUserHelperScriptPath",

--- a/agent/installer/macos/build-pkg.sh
+++ b/agent/installer/macos/build-pkg.sh
@@ -3,10 +3,10 @@
 # Breeze Agent macOS .pkg Builder
 # ============================================
 # Usage:
-#   ./build-pkg.sh <agent-binary> <desktop-helper-binary> <backup-binary> <version> <arch> <output-path>
+#   ./build-pkg.sh <agent-binary> <desktop-helper-binary> <backup-binary> <watchdog-binary> <version> <arch> <output-path>
 #
 # Example:
-#   ./build-pkg.sh ./breeze-agent-darwin-amd64 ./breeze-desktop-helper-darwin-amd64 ./breeze-backup-darwin-amd64 0.13.3 amd64 ./dist/breeze-agent-darwin-amd64.pkg
+#   ./build-pkg.sh ./breeze-agent-darwin-amd64 ./breeze-desktop-helper-darwin-amd64 ./breeze-backup-darwin-amd64 ./breeze-watchdog-darwin-amd64 0.13.3 amd64 ./dist/breeze-agent-darwin-amd64.pkg
 # ============================================
 
 set -euo pipefail
@@ -14,21 +14,23 @@ set -euo pipefail
 AGENT_BIN="$1"
 DESKTOP_HELPER_BIN="$2"
 BACKUP_BIN="$3"
-VERSION="$4"
-ARCH="$5"
-OUTPUT="$6"
+WATCHDOG_BIN="$4"
+VERSION="$5"
+ARCH="$6"
+OUTPUT="$7"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT
 
 echo "Building Breeze Agent .pkg"
-echo "  Agent:   $AGENT_BIN"
-echo "  Desktop: $DESKTOP_HELPER_BIN"
-echo "  Backup:  $BACKUP_BIN"
-echo "  Version: $VERSION"
-echo "  Arch:    $ARCH"
-echo "  Output:  $OUTPUT"
+echo "  Agent:    $AGENT_BIN"
+echo "  Desktop:  $DESKTOP_HELPER_BIN"
+echo "  Backup:   $BACKUP_BIN"
+echo "  Watchdog: $WATCHDOG_BIN"
+echo "  Version:  $VERSION"
+echo "  Arch:     $ARCH"
+echo "  Output:   $OUTPUT"
 echo ""
 
 # ----- Build payload root -----
@@ -48,6 +50,10 @@ chmod 755 "$PAYLOAD/usr/local/bin/breeze-desktop-helper"
 cp "$BACKUP_BIN" "$PAYLOAD/usr/local/bin/breeze-backup"
 chmod 755 "$PAYLOAD/usr/local/bin/breeze-backup"
 
+# Install watchdog binary
+cp "$WATCHDOG_BIN" "$PAYLOAD/usr/local/bin/breeze-watchdog"
+chmod 755 "$PAYLOAD/usr/local/bin/breeze-watchdog"
+
 cp "$SCRIPT_DIR/../../service/launchd/com.breeze.agent.plist" \
    "$PAYLOAD/Library/LaunchDaemons/com.breeze.agent.plist"
 
@@ -56,6 +62,10 @@ cp "$SCRIPT_DIR/../../service/launchd/com.breeze.desktop-helper-user.plist" \
 
 cp "$SCRIPT_DIR/../../service/launchd/com.breeze.desktop-helper-loginwindow.plist" \
    "$PAYLOAD/Library/LaunchAgents/com.breeze.desktop-helper-loginwindow.plist"
+
+# Install watchdog launchd plist
+cp "$SCRIPT_DIR/com.breeze.watchdog.plist" \
+   "$PAYLOAD/Library/LaunchDaemons/com.breeze.watchdog.plist"
 
 # ----- Prepare install scripts -----
 SCRIPTS="$WORK_DIR/scripts"

--- a/agent/installer/macos/com.breeze.watchdog.plist
+++ b/agent/installer/macos/com.breeze.watchdog.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.breeze.watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/breeze-watchdog</string>
+        <string>run</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>5</integer>
+    <key>WorkingDirectory</key>
+    <string>/Library/Application Support/Breeze</string>
+    <key>StandardOutPath</key>
+    <string>/Library/Logs/Breeze/watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Library/Logs/Breeze/watchdog.err</string>
+</dict>
+</plist>

--- a/agent/installer/macos/postinstall
+++ b/agent/installer/macos/postinstall
@@ -30,6 +30,21 @@ chmod 0644 "$DAEMON_PLIST"
 chmod 0644 "$DESKTOP_USER_PLIST"
 chmod 0644 "$DESKTOP_LOGINWINDOW_PLIST"
 
+# Watchdog
+WATCHDOG_BINARY="/usr/local/bin/breeze-watchdog"
+if [ -f "$WATCHDOG_BINARY" ]; then
+    xattr -d com.apple.quarantine "$WATCHDOG_BINARY" 2>/dev/null || true
+    chmod 0755 "$WATCHDOG_BINARY"
+fi
+
+# Bootstrap watchdog daemon
+WATCHDOG_PLIST="/Library/LaunchDaemons/com.breeze.watchdog.plist"
+if [ -f "$WATCHDOG_PLIST" ]; then
+    launchctl bootout system/com.breeze.watchdog 2>/dev/null || true
+    launchctl bootstrap system "$WATCHDOG_PLIST" 2>/dev/null || \
+        launchctl load "$WATCHDOG_PLIST" 2>/dev/null || true
+fi
+
 # Create breeze group for IPC socket access (best-effort)
 if ! dscl . -read /Groups/breeze &>/dev/null; then
     dscl . -create /Groups/breeze 2>/dev/null || true

--- a/agent/installer/macos/preinstall
+++ b/agent/installer/macos/preinstall
@@ -2,6 +2,9 @@
 # Breeze Agent macOS .pkg preinstall script
 # Stops the existing agent service before files are replaced.
 
+# Stop watchdog
+launchctl bootout system/com.breeze.watchdog 2>/dev/null || true
+
 # Stop existing daemon gracefully
 launchctl bootout system/com.breeze.agent 2>/dev/null || true
 

--- a/agent/scripts/install/install-darwin.sh
+++ b/agent/scripts/install/install-darwin.sh
@@ -50,6 +50,17 @@ elif [ -f "breeze-watchdog" ]; then
     chmod 755 /usr/local/bin/breeze-watchdog
 fi
 
+# Register watchdog service
+if [ -f "/usr/local/bin/breeze-watchdog" ]; then
+    if [ ! -f "/Library/LaunchDaemons/com.breeze.watchdog.plist" ]; then
+        echo "Registering watchdog service..."
+        /usr/local/bin/breeze-watchdog service install
+    else
+        echo "Restarting watchdog service..."
+        launchctl kickstart -k system/com.breeze.watchdog 2>/dev/null || true
+    fi
+fi
+
 # Install launchd plist
 if [ -f "$PLIST_SRC" ]; then
     cp "$PLIST_SRC" "$PLIST_DST"

--- a/agent/scripts/install/install-linux.sh
+++ b/agent/scripts/install/install-linux.sh
@@ -51,6 +51,17 @@ elif [ -f "breeze-watchdog" ]; then
     chmod 755 /usr/local/bin/breeze-watchdog
 fi
 
+# Install watchdog systemd unit if not already present
+if [ -f "/usr/local/bin/breeze-watchdog" ]; then
+    if [ ! -f "/etc/systemd/system/breeze-watchdog.service" ]; then
+        echo "Registering watchdog service..."
+        /usr/local/bin/breeze-watchdog service install
+    else
+        echo "Restarting watchdog service..."
+        systemctl restart breeze-watchdog || true
+    fi
+fi
+
 # Install systemd unit
 if [ -f "$SERVICE_SRC" ]; then
     cp "$SERVICE_SRC" "$SERVICE_DST"


### PR DESCRIPTION
## Summary

Adds `breeze-watchdog` binary and service registration to all platform installers so the watchdog deploys automatically with fresh installs and upgrades.

- macOS `.pkg`: watchdog binary + launchd plist in payload, postinstall bootstraps daemon, preinstall stops before upgrade
- Windows MSI: `BreezeWatchdog` service component with auto-start
- Linux/macOS install scripts: register service on first install, restart on upgrade

**Follow-up to** #339

## Test plan

- [ ] macOS .pkg fresh install registers `com.breeze.watchdog`
- [ ] Linux `install-linux.sh` registers `breeze-watchdog.service`
- [ ] Windows MSI installs `BreezeWatchdog` service
- [ ] Upgrade restarts existing watchdog service

🤖 Generated with [Claude Code](https://claude.com/claude-code)