### PR TITLE
fix: add watchdog to IPC binary allowlist, fix Windows named pipe dial

### DIFF
--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -1074,11 +1074,16 @@ func (b *Broker) allowedHelperPaths() []string {
 	if err != nil {
 		exePath = filepath.Clean(exePath)
 	}
+	dir := filepath.Dir(exePath)
 	paths := []string{
 		exePath,
-		filepath.Join(filepath.Dir(exePath), "breeze-desktop-helper"),
+		filepath.Join(dir, "breeze-desktop-helper"),
+		filepath.Join(dir, "breeze-watchdog"),
+		filepath.Join(dir, "breeze-desktop-helper.exe"),
+		filepath.Join(dir, "breeze-watchdog.exe"),
 		"/usr/local/bin/breeze-agent",
 		"/usr/local/bin/breeze-desktop-helper",
+		"/usr/local/bin/breeze-watchdog",
 	}
 	seen := make(map[string]struct{}, len(paths))
 	out := make([]string, 0, len(paths))

--- a/agent/internal/watchdog/dial_unix.go
+++ b/agent/internal/watchdog/dial_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package watchdog
+
+import (
+	"fmt"
+	"net"
+	"time"
+)
+
+func dialIPC(socketPath string) (net.Conn, error) {
+	conn, err := net.DialTimeout("unix", socketPath, 5*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("dial unix %s: %w", socketPath, err)
+	}
+	return conn, nil
+}

--- a/agent/internal/watchdog/dial_windows.go
+++ b/agent/internal/watchdog/dial_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package watchdog
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+)
+
+func dialIPC(socketPath string) (net.Conn, error) {
+	timeout := 5 * time.Second
+	conn, err := winio.DialPipe(socketPath, &timeout)
+	if err != nil {
+		return nil, fmt.Errorf("dial pipe %s: %w", socketPath, err)
+	}
+	return conn, nil
+}

--- a/agent/internal/watchdog/ipcclient.go
+++ b/agent/internal/watchdog/ipcclient.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"path/filepath"
 	"sync"
@@ -41,7 +40,7 @@ func NewIPCClient(socketPath string, onMessage func(*ipc.Envelope)) *IPCClient {
 // Connect dials the Unix socket, authenticates as a watchdog role client,
 // and starts the receive loop. It must be called before Ping.
 func (c *IPCClient) Connect() error {
-	raw, err := net.DialTimeout("unix", c.socketPath, 5*time.Second)
+	raw, err := dialIPC(c.socketPath)
 	if err != nil {
 		return fmt.Errorf("watchdog ipc: connect to %s: %w", c.socketPath, err)
 	}


### PR DESCRIPTION
## Summary

Two bugs preventing the watchdog from connecting to the agent:

1. **Binary allowlist missing watchdog** — the session broker's `allowedHelperPaths()` only included `breeze-agent` and `breeze-desktop-helper`. The watchdog binary hash was rejected with "binary path verification failed" on both VOR (Windows) and MacBook-Pro-3 (macOS).

2. **Windows named pipe dial** — the watchdog IPC client used `net.DialTimeout("unix", ...)` which doesn't work for Windows named pipes. Split into platform-specific files matching the existing `userhelper/client_{unix,windows}.go` pattern.

## Test plan

- [ ] `dev-push` updated agent to VOR → watchdog connects, enters MONITORING
- [ ] `dev-push` updated agent to MacBook → watchdog connects, enters MONITORING
- [ ] Session broker logs show successful watchdog auth instead of "binary path verification failed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)