### PR TITLE
fix(watchdog): add Windows SCM handler for service startup

### DIFF
--- a/agent/cmd/breeze-watchdog/main.go
+++ b/agent/cmd/breeze-watchdog/main.go
@@ -71,6 +71,13 @@ var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Start the watchdog monitoring loop",
 	Run: func(cmd *cobra.Command, args []string) {
+		if isWindowsService() {
+			if err := runAsWindowsService(); err != nil {
+				fmt.Fprintf(os.Stderr, "Windows service error: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		}
 		runWatchdog()
 	},
 }

--- a/agent/cmd/breeze-watchdog/service_cmd_windows.go
+++ b/agent/cmd/breeze-watchdog/service_cmd_windows.go
@@ -108,6 +108,63 @@ func serviceUninstallCmd() *cobra.Command {
 	}
 }
 
+// isWindowsService checks whether we were launched by the SCM.
+func isWindowsService() bool {
+	ok, err := svc.IsWindowsService()
+	if err != nil {
+		return false
+	}
+	return ok
+}
+
+// watchdogSvc implements svc.Handler for the Windows SCM.
+type watchdogSvc struct {
+	stopCh chan struct{}
+}
+
+// runAsWindowsService wraps runWatchdog under the SCM handler so that the
+// service correctly reports Running/Stopped status.
+func runAsWindowsService() error {
+	return svc.Run(windowsWatchdogServiceName, &watchdogSvc{
+		stopCh: make(chan struct{}),
+	})
+}
+
+// Execute is the SCM callback.
+func (s *watchdogSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
+	changes <- svc.Status{State: svc.StartPending}
+
+	// Start the watchdog loop in a goroutine.
+	done := make(chan struct{})
+	go func() {
+		runWatchdog()
+		close(done)
+	}()
+
+	changes <- svc.Status{State: svc.Running, Accepts: svc.AcceptStop | svc.AcceptShutdown}
+
+	for {
+		select {
+		case cr := <-r:
+			switch cr.Cmd {
+			case svc.Interrogate:
+				changes <- cr.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				changes <- svc.Status{State: svc.StopPending}
+				// Send SIGTERM-equivalent to the watchdog's signal handler.
+				p, _ := os.FindProcess(os.Getpid())
+				if p != nil {
+					p.Signal(os.Interrupt)
+				}
+				<-done
+				return false, 0
+			}
+		case <-done:
+			return false, 0
+		}
+	}
+}
+
 // restartWatchdogService restarts the watchdog Windows service via SCM.
 func restartWatchdogService() error {
 	m, err := mgr.Connect()

--- a/agent/cmd/breeze-watchdog/service_run_unix.go
+++ b/agent/cmd/breeze-watchdog/service_run_unix.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package main
+
+func isWindowsService() bool { return false }
+
+func runAsWindowsService() error { return nil }


### PR DESCRIPTION
## Summary

The watchdog service was stuck at "Starting" on Windows (VOR, Kit) because it never called `svc.Run()` to integrate with the Service Control Manager. The SCM waited indefinitely for the service to report Running status.

### Changes
- Added `watchdogSvc` implementing `svc.Handler` in `service_cmd_windows.go`
- Reports `StartPending` → `Running` → `StopPending` to SCM
- Starts `runWatchdog()` in a goroutine, handles Stop/Shutdown via `os.Interrupt`
- `run` command auto-detects `isWindowsService()` and delegates to SCM handler
- Added `service_run_unix.go` stub for non-Windows platforms

## Test plan
- [ ] `dev-push` to Kit → watchdog service starts and reaches Running status
- [ ] Service stop via `sc stop BreezeWatchdog` works cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)