### PR TITLE
fix(watchdog): fix Windows service stop hanging

### DIFF
--- a/agent/cmd/breeze-watchdog/main.go
+++ b/agent/cmd/breeze-watchdog/main.go
@@ -78,7 +78,7 @@ var runCmd = &cobra.Command{
 			}
 			return
 		}
-		runWatchdog()
+		runWatchdog(nil)
 	},
 }
 
@@ -135,7 +135,10 @@ func main() {
 }
 
 // runWatchdog is the main watchdog loop.
-func runWatchdog() {
+// stopCh is an optional channel that, when closed, triggers a clean shutdown.
+// On Unix this is nil (signal handling is used instead). On Windows the SCM
+// handler closes it on Stop/Shutdown.
+func runWatchdog(stopCh <-chan struct{}) {
 	cfg, err := config.Load("")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to load config: %v\n", err)
@@ -257,6 +260,11 @@ func runWatchdog() {
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)
 
+	// If no external stop channel provided, create a dummy that never fires.
+	if stopCh == nil {
+		stopCh = make(chan struct{})
+	}
+
 	// Create tickers for the three check intervals.
 	processTicker := time.NewTicker(wdCfg.ProcessCheckInterval)
 	defer processTicker.Stop()
@@ -274,8 +282,14 @@ func runWatchdog() {
 	for {
 		select {
 		case <-sigChan:
-			journal.Log(watchdog.LevelInfo, "watchdog.shutdown", nil)
+			journal.Log(watchdog.LevelInfo, "watchdog.shutdown", map[string]any{"trigger": "signal"})
 			fmt.Println("Watchdog shutting down")
+			ipcClient.Close()
+			return
+
+		case <-stopCh:
+			journal.Log(watchdog.LevelInfo, "watchdog.shutdown", map[string]any{"trigger": "scm"})
+			fmt.Println("Watchdog shutting down (SCM stop)")
 			ipcClient.Close()
 			return
 

--- a/agent/cmd/breeze-watchdog/service_cmd_windows.go
+++ b/agent/cmd/breeze-watchdog/service_cmd_windows.go
@@ -134,10 +134,10 @@ func runAsWindowsService() error {
 func (s *watchdogSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
 	changes <- svc.Status{State: svc.StartPending}
 
-	// Start the watchdog loop in a goroutine.
+	// Start the watchdog loop in a goroutine with a stop channel.
 	done := make(chan struct{})
 	go func() {
-		runWatchdog()
+		runWatchdog(s.stopCh)
 		close(done)
 	}()
 
@@ -151,11 +151,7 @@ func (s *watchdogSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes
 				changes <- cr.CurrentStatus
 			case svc.Stop, svc.Shutdown:
 				changes <- svc.Status{State: svc.StopPending}
-				// Send SIGTERM-equivalent to the watchdog's signal handler.
-				p, _ := os.FindProcess(os.Getpid())
-				if p != nil {
-					p.Signal(os.Interrupt)
-				}
+				close(s.stopCh) // signals runWatchdog to return
 				<-done
 				return false, 0
 			}


### PR DESCRIPTION
## Summary

The watchdog Windows service was hanging at "Stopping" because `os.Interrupt` doesn't work for Windows services (no console attached). The SCM handler sent the signal, it was silently ignored, and `runWatchdog()` never returned.

### Fix
- Added `stopCh <-chan struct{}` parameter to `runWatchdog()`
- SCM handler closes `stopCh` on Stop/Shutdown instead of sending `os.Interrupt`
- Main select loop listens on `stopCh` alongside `sigChan`
- Unix callers pass `nil` (a dummy channel is created internally)

## Test plan
- [ ] `dev-push` watchdog to Kit → service starts, `sc stop BreezeWatchdog` completes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)