### PR TITLE
fix(watchdog): add required status field to failover heartbeat

### DIFF
--- a/agent/internal/watchdog/failover.go
+++ b/agent/internal/watchdog/failover.go
@@ -69,6 +69,7 @@ func (c *FailoverClient) SendHeartbeat(watchdogVersion, currentState string, jou
 	body := map[string]any{
 		"role":           "watchdog",
 		"watchdogState":  currentState,
+		"status":         "ok",
 		"agentVersion":   watchdogVersion,
 		"journalExcerpt": journalEntries,
 		"timestamp":      time.Now().UTC().Format(time.RFC3339),


### PR DESCRIPTION
## Summary

The watchdog failover heartbeat was rejected with 400 because the API's Zod schema requires `status: 'ok' | 'warning' | 'error'` but the watchdog wasn't sending it. Adds `"status": "ok"` to the failover heartbeat payload.

Found during live testing on Kit — watchdog entered FAILOVER but couldn't heartbeat to the API.

## Test plan
- [x] Tested on Kit — watchdog now heartbeats successfully in failover mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)