### PR TITLE
fix(watchdog): allow IPC reconnection from FAILOVER/RECOVERING states

### DIFF
--- a/agent/internal/watchdog/watchdog.go
+++ b/agent/internal/watchdog/watchdog.go
@@ -39,6 +39,7 @@ var transitions = map[string]map[string]string{
 	},
 	StateRecovering: {
 		EventAgentRecovered:    StateMonitoring,
+		EventIPCConnected:      StateMonitoring,
 		EventRecoveryExhausted: StateFailover,
 	},
 	StateStandby: {
@@ -48,6 +49,7 @@ var transitions = map[string]map[string]string{
 	},
 	StateFailover: {
 		EventAgentRecovered: StateMonitoring,
+		EventIPCConnected:   StateMonitoring,
 	},
 }
 

--- a/agent/internal/watchdog/watchdog_test.go
+++ b/agent/internal/watchdog/watchdog_test.go
@@ -137,6 +137,31 @@ func TestConnectingToRecovering(t *testing.T) {
 	}
 }
 
+func TestFailoverToMonitoringViaIPC(t *testing.T) {
+	w := NewWatchdog(DefaultTestConfig())
+	w.HandleEvent(EventAgentNotFound)     // CONNECTING → RECOVERING
+	w.HandleEvent(EventRecoveryExhausted) // RECOVERING → FAILOVER
+	next, ok := w.HandleEvent(EventIPCConnected)
+	if !ok {
+		t.Fatal("expected transition to succeed")
+	}
+	if next != StateMonitoring {
+		t.Fatalf("expected %s, got %s", StateMonitoring, next)
+	}
+}
+
+func TestRecoveringToMonitoringViaIPC(t *testing.T) {
+	w := NewWatchdog(DefaultTestConfig())
+	w.HandleEvent(EventAgentNotFound) // CONNECTING → RECOVERING
+	next, ok := w.HandleEvent(EventIPCConnected)
+	if !ok {
+		t.Fatal("expected transition to succeed")
+	}
+	if next != StateMonitoring {
+		t.Fatalf("expected %s, got %s", StateMonitoring, next)
+	}
+}
+
 func TestInvalidTransitionIgnored(t *testing.T) {
 	w := NewWatchdog(DefaultTestConfig())
 	// CONNECTING has no transition for EventAgentRecovered


### PR DESCRIPTION
## Summary

The watchdog stayed in FAILOVER indefinitely even after the agent recovered because `EventIPCConnected` had no transition defined for the FAILOVER or RECOVERING states.

Added `EventIPCConnected → MONITORING` to both states' transition tables. When the IPC reconnect succeeds (every 30s probe), the watchdog now correctly transitions back to MONITORING and stops failover API polling.

## Test plan
- [x] `TestFailoverToMonitoringViaIPC` — new test
- [x] `TestRecoveringToMonitoringViaIPC` — new test  
- [x] All 29 watchdog tests pass with `-race`

🤖 Generated with [Claude Code](https://claude.com/claude-code)