### PR TITLE
fix(agent): helper reconnect loop, stale version guard, installer messaging

### DIFF
--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -736,21 +736,74 @@ func runHelperProcess(name, role, context, binaryKind string) {
 		"binaryKind", binaryKind,
 	)
 
-	client := userhelper.NewWithOptions(socketPath, role, binaryKind, context)
-
-	// Handle shutdown signals
+	// Handle shutdown signals via a done channel so multiple selects
+	// can observe the shutdown without racing on a buffered sigChan.
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	done := make(chan struct{})
 	go func() {
 		<-sigChan
-		log.Info("shutting down helper", "name", name)
-		client.Stop()
+		close(done)
 	}()
 
-	if err := client.Run(); err != nil {
-		log.Error("helper error", "name", name, "error", err)
-		os.Exit(1)
-	}
+	// Reconnect loop: when the IPC socket disappears (e.g. agent self-update
+	// recreates it), retry with exponential backoff instead of exiting.
+	const (
+		helperMinBackoff = 2 * time.Second
+		helperMaxBackoff = 30 * time.Second
+	)
 
-	log.Info("helper stopped", "name", name)
+	backoff := helperMinBackoff
+	for {
+		client := userhelper.NewWithOptions(socketPath, role, binaryKind, context)
+
+		// Stop the current client when shutdown is signaled. The clientDone
+		// channel lets this goroutine exit when Run() returns on its own,
+		// preventing a goroutine leak per reconnect iteration.
+		clientDone := make(chan struct{})
+		go func() {
+			select {
+			case <-done:
+				log.Info("shutting down helper", "name", name)
+				client.Stop()
+			case <-clientDone:
+				// Run() returned on its own; nothing to do.
+			}
+		}()
+
+		connStart := time.Now()
+		err := client.Run()
+		close(clientDone)
+		if err == nil {
+			// Clean exit (e.g. Stop() was called via signal)
+			log.Info("helper stopped", "name", name)
+			return
+		}
+
+		// Check if we were signaled to stop — don't retry after shutdown.
+		select {
+		case <-done:
+			log.Info("helper stopped after error", "name", name)
+			return
+		default:
+		}
+
+		// If the connection was up for a meaningful period, reset backoff
+		// so the next reconnect starts fast.
+		if time.Since(connStart) > helperMaxBackoff {
+			backoff = helperMinBackoff
+		}
+
+		log.Warn("helper disconnected, reconnecting",
+			"name", name, "error", err.Error(), "backoff", backoff)
+
+		// Wait for backoff or shutdown signal.
+		select {
+		case <-time.After(backoff):
+			backoff = min(backoff*2, helperMaxBackoff)
+		case <-done:
+			log.Info("helper stopped during reconnect backoff", "name", name)
+			return
+		}
+	}
 }

--- a/agent/cmd/breeze-agent/service_cmd_linux.go
+++ b/agent/cmd/breeze-agent/service_cmd_linux.go
@@ -201,9 +201,17 @@ var serviceInstallCmd = &cobra.Command{
 		running := isSystemServiceRunning()
 
 		if enrolled && running {
-			// Already enrolled and running — nothing more to do.
-			fmt.Printf("\nAgent is enrolled and the service is running.\n")
+			// Already enrolled and running — show current status automatically.
+			fmt.Println()
+			statusCmd := exec.Command(linuxBinaryPath, "status")
+			statusCmd.Stdout = os.Stdout
+			statusCmd.Stderr = os.Stderr
+			statusCmd.Run() // best-effort; ignore error
+
+			fmt.Println("\nHelpful Commands:")
 			fmt.Println("  Logs:    journalctl -u breeze-agent -f")
+			fmt.Println("  Status:  sudo breeze-agent service status")
+			fmt.Println("  Restart: sudo breeze-agent service start")
 		} else if enrolled {
 			fmt.Println()
 			fmt.Println("Next steps:")

--- a/agent/internal/heartbeat/handlers_desktop_helper.go
+++ b/agent/internal/heartbeat/handlers_desktop_helper.go
@@ -443,6 +443,34 @@ func findGUIUserUIDs() []string {
 	return parseGUIUserUIDs(string(out))
 }
 
+// kickstartDarwinDesktopHelpers re-kickstarts the macOS desktop helper
+// LaunchAgents for every logged-in GUI user session. This is called after a
+// self-update restart to force helpers to reconnect to the new IPC socket
+// immediately instead of waiting for their reconnect backoff.
+func kickstartDarwinDesktopHelpers() {
+	ensureDarwinHelperPlists()
+
+	uids := findGUIUserUIDs()
+	for _, uid := range uids {
+		label := "gui/" + uid + "/com.breeze.desktop-helper-user"
+		if err := exec.Command("launchctl", "kickstart", "-k", label).Run(); err != nil {
+			log.Warn("post-update: launchctl kickstart failed",
+				"uid", uid, "label", label, "error", err.Error())
+		} else {
+			log.Info("post-update: kickstarted desktop helper", "uid", uid)
+		}
+	}
+
+	// Also kickstart the login-window helper.
+	if err := exec.Command("launchctl", "kickstart", "-k",
+		"loginwindow/com.breeze.desktop-helper-loginwindow").Run(); err != nil {
+		log.Warn("post-update: launchctl kickstart login-window helper failed",
+			"error", err.Error())
+	} else {
+		log.Info("post-update: kickstarted login-window desktop helper")
+	}
+}
+
 func parseGUIUserUIDs(output string) []string {
 	seen := map[string]bool{}
 	var uids []string

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -627,6 +627,15 @@ func (h *Heartbeat) Start() {
 	interval := time.Duration(h.config.HeartbeatIntervalSeconds) * time.Second
 	if checkUpdateMarker() {
 		log.Info("post-update restart: sending immediate heartbeat (jitter skipped)")
+		// On macOS, the agent self-update recreates the IPC socket. The
+		// desktop helpers lose their connection and may be waiting on
+		// backoff. Kickstart them so remote desktop recovers immediately.
+		if runtime.GOOS == "darwin" {
+			go func() {
+				time.Sleep(500 * time.Millisecond) // let IPC socket bind before kickstarting
+				kickstartDarwinDesktopHelpers()
+			}()
+		}
 	} else {
 		jitter := time.Duration(rand.Int64N(int64(interval)))
 		log.Info("initial heartbeat jitter", "delay", jitter)
@@ -1800,6 +1809,13 @@ func (h *Heartbeat) sendReliabilityMetrics() {
 }
 
 func (h *Heartbeat) sendHeartbeat() {
+	// After a successful self-update, the old process continues running until
+	// the service manager kills it. Don't send heartbeats with stale version info.
+	if h.upgradeInProgress.Load() {
+		log.Debug("skipping heartbeat, upgrade in progress")
+		return
+	}
+
 	metrics, err := h.metricsCol.Collect()
 	metricsAvailable := true
 	if err != nil {
@@ -2749,6 +2765,11 @@ func (h *Heartbeat) doUpgrade(targetVersion string) {
 	log.Info("upgrade requested", "targetVersion", targetVersion)
 
 	h.sendUpdateStatus(targetVersion)
+	// Give the WebSocket write goroutine time to flush the update_status
+	// message to the server before the binary is replaced and the process
+	// is restarted (e.g. via launchctl kickstart). Without this, the device
+	// may appear "Offline" instead of "Updating" in the dashboard.
+	time.Sleep(500 * time.Millisecond)
 
 	binaryPath, err := os.Executable()
 	if err != nil {
@@ -2805,7 +2826,14 @@ func (h *Heartbeat) doUpgrade(targetVersion string) {
 		return
 	}
 
-	log.Info("update successful", "targetVersion", targetVersion)
+	log.Info("update successful, blocking old process to prevent stale heartbeats", "targetVersion", targetVersion)
+
+	// On macOS/Linux, launchctl kickstart -k / systemctl restart return
+	// immediately while the old process keeps running. If we return here,
+	// the heartbeat loop will send another heartbeat with the OLD version,
+	// overwriting the new version in the database. Block forever so the
+	// service manager kills us.
+	select {}
 }
 
 // makeUserExecFunc returns a UserExecFunc that dispatches commands to a connected


### PR DESCRIPTION
## Summary

- **#372**: macOS desktop helper now reconnects with exponential backoff (2s–30s) when the IPC socket is recreated during a self-update, instead of exiting permanently. Post-update restart also kickstarts helpers via `launchctl` so remote desktop recovers immediately.
- **#373**: Old agent process blocks after successful restart and suppresses heartbeats to prevent stale version from overwriting the new version in the DB.
- **#374**: Linux service install auto-shows `breeze-agent status` output and uses "Helpful Commands" header when agent is already enrolled and running.

## Test plan

- [ ] macOS agent self-update: verify Remote Desktop stays available after update (helper reconnects)
- [ ] macOS agent self-update: verify correct version shown in dashboard after update
- [ ] macOS agent self-update: verify "Updating" status appears during update
- [ ] Linux `breeze-agent service install` on enrolled+running agent: verify status auto-displays and "Helpful Commands" header
- [ ] Linux `breeze-agent service install` on unenrolled agent: verify "Next steps" header unchanged
- [ ] Helper SIGTERM: verify clean shutdown without reconnect attempt
- [ ] Agent build: `cd agent && go build ./cmd/breeze-agent/` passes
- [ ] Agent tests: `cd agent && go test -race ./internal/heartbeat/...` passes

Closes #372, closes #373, closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)