### PR TITLE
fix(agent): harden desktop helper against reconnect storm (#387)

### DIFF
--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -857,7 +857,7 @@ func runHelperProcess(name, role, context, binaryKind string) {
 		wait := backoff + time.Duration(rand.Int64N(int64(backoff/2)+1))
 
 		errMsg := err.Error()
-		if emit, suppressed := warnLimiter.shouldLog(errMsg); emit {
+		if emit, suppressed := warnLimiter.shouldLog(errMsg, time.Now()); emit {
 			log.Warn("helper disconnected, reconnecting",
 				"name", name, "error", errMsg, "backoff", wait.String())
 		} else if suppressed > 0 {
@@ -910,11 +910,12 @@ func newHelperWarnLimiter(limit int, window time.Duration) *helperWarnLimiter {
 // shouldLog returns (emitWarn, suppressedCount). If emitWarn is true, the
 // caller should log a WARN. Otherwise, if suppressedCount > 0, the caller
 // should log a single INFO "still disconnected" line with that count.
-func (h *helperWarnLimiter) shouldLog(msg string) (bool, int) {
+// now is passed in by the caller (typically time.Now()) so that tests can
+// control the clock without sleeping.
+func (h *helperWarnLimiter) shouldLog(msg string, now time.Time) (bool, int) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	now := time.Now()
 	if msg != h.lastMsg || now.Sub(h.firstSeenAt) > h.window {
 		// New message or window rolled over — reset counters.
 		h.lastMsg = msg

--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -830,7 +830,7 @@ func runHelperProcess(name, role, context, binaryKind string) {
 				"code", permErr.CodeOr("unknown"),
 				"reason", permErr.ReasonOr(err.Error()),
 			)
-			time.Sleep(1 * time.Second)
+			logging.StopShipper() // flush before os.Exit tears down goroutines
 			os.Exit(2)
 		}
 		if errors.Is(err, userhelper.ErrSIDLookupFailed) {
@@ -839,7 +839,7 @@ func runHelperProcess(name, role, context, binaryKind string) {
 				"code", "sid_lookup_failed",
 				"reason", err.Error(),
 			)
-			time.Sleep(1 * time.Second)
+			logging.StopShipper() // flush before os.Exit tears down goroutines
 			os.Exit(2)
 		}
 
@@ -881,20 +881,27 @@ func runHelperProcess(name, role, context, binaryKind string) {
 
 // helperWarnLimiter rate-limits a repeating warning message. After `limit`
 // emissions of the same message within `window`, further WARN emissions are
-// suppressed; an INFO "still disconnected" line is emitted at most once per
-// `window` with the suppressed count. Call reset() when the condition clears
-// (e.g. connection has been stably authenticated).
+// suppressed; an INFO "still disconnected" summary is emitted every
+// infoInterval so ops can confirm the helper is still thrashing (not silently
+// stuck). Call reset() when the condition clears (e.g. connection has been
+// stably authenticated).
 type helperWarnLimiter struct {
-	mu            sync.Mutex
-	limit         int
-	window        time.Duration
-	lastMsg       string
-	firstSeenAt   time.Time
-	count         int    // total emissions (incl. suppressed) in this window
-	warnsEmitted  int    // warn-level emissions in this window
-	suppressed    int    // warnings suppressed since last info emission
-	lastInfoEmit  time.Time
+	mu                   sync.Mutex
+	limit                int
+	window               time.Duration
+	lastMsg              string
+	firstSeenAt          time.Time
+	count                int // total emissions (incl. suppressed) in this window
+	warnsEmitted         int // warn-level emissions in this window
+	suppressed           int // warnings suppressed since last info emission
+	suppressedSinceInfo  int // count since last INFO — reset on each INFO emit
+	lastInfoEmit         time.Time
 }
+
+// infoInterval is the sub-window cadence for INFO summaries emitted while
+// WARN emissions are suppressed. Short enough to confirm liveliness during
+// log tail, long enough to avoid flooding.
+const infoInterval = 60 * time.Second
 
 func newHelperWarnLimiter(limit int, window time.Duration) *helperWarnLimiter {
 	return &helperWarnLimiter{limit: limit, window: window}
@@ -915,6 +922,7 @@ func (h *helperWarnLimiter) shouldLog(msg string) (bool, int) {
 		h.count = 1
 		h.warnsEmitted = 1
 		h.suppressed = 0
+		h.suppressedSinceInfo = 0
 		h.lastInfoEmit = time.Time{}
 		return true, 0
 	}
@@ -926,12 +934,15 @@ func (h *helperWarnLimiter) shouldLog(msg string) (bool, int) {
 	}
 
 	// Over the warn budget — suppress and maybe emit an INFO summary.
+	// Summaries fire every infoInterval (60s) so ops can see the helper is
+	// still thrashing; each summary reports only the count since the last INFO.
 	h.suppressed++
-	if h.lastInfoEmit.IsZero() || now.Sub(h.lastInfoEmit) >= h.window {
-		suppressed := h.suppressed
-		h.suppressed = 0
+	h.suppressedSinceInfo++
+	if h.lastInfoEmit.IsZero() || now.Sub(h.lastInfoEmit) >= infoInterval {
+		count := h.suppressedSinceInfo
+		h.suppressedSinceInfo = 0
 		h.lastInfoEmit = now
-		return false, suppressed
+		return false, count
 	}
 	return false, 0
 }
@@ -946,6 +957,7 @@ func (h *helperWarnLimiter) reset() {
 	h.count = 0
 	h.warnsEmitted = 0
 	h.suppressed = 0
+	h.suppressedSinceInfo = 0
 	h.lastInfoEmit = time.Time{}
 	h.mu.Unlock()
 }

--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand/v2"
@@ -815,10 +816,32 @@ func runHelperProcess(name, role, context, binaryKind string) {
 		default:
 		}
 
-		// Part B (separate commit) adds a check here for
-		// *userhelper.PermanentRejectError that exits with code 2 so the
-		// lifecycle manager can skip respawn. Until then, all errors fall
-		// through to the rate-limited reconnect path.
+		// Fatal permanent rejection from the broker: exit with code 2 so
+		// the lifecycle manager knows not to respawn immediately. Sleep
+		// briefly to let the log shipper flush the exit reason.
+		//
+		// Exit code 2 semantics: signals to the lifecycle manager that
+		// this helper should not be respawned immediately — the rejection
+		// is permanent (binary hash mismatch, SID lookup failure, etc.).
+		var permErr *userhelper.PermanentRejectError
+		if errors.As(err, &permErr) {
+			log.Error("helper permanently rejected, exiting fatal",
+				"name", name,
+				"code", permErr.CodeOr("unknown"),
+				"reason", permErr.ReasonOr(err.Error()),
+			)
+			time.Sleep(1 * time.Second)
+			os.Exit(2)
+		}
+		if errors.Is(err, userhelper.ErrSIDLookupFailed) {
+			log.Error("helper permanently rejected, exiting fatal",
+				"name", name,
+				"code", "sid_lookup_failed",
+				"reason", err.Error(),
+			)
+			time.Sleep(1 * time.Second)
+			os.Exit(2)
+		}
 
 		// Only reset backoff if the connection was stably authenticated for
 		// >60s. The previous logic reset on wall-clock iteration duration

--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -5,11 +5,13 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -762,11 +764,18 @@ func runHelperProcess(name, role, context, binaryKind string) {
 
 	// Reconnect loop: when the IPC socket disappears (e.g. agent self-update
 	// recreates it), retry with exponential backoff instead of exiting.
+	//
+	// helperMinBackoff is intentionally conservative (30s) because most helper
+	// disconnects in production are caused by permanent identity/auth problems
+	// (binary path mismatch, SID lookup failure on headless Windows, etc.),
+	// not transient socket hiccups. See issue #387.
 	const (
-		helperMinBackoff = 2 * time.Second
-		helperMaxBackoff = 30 * time.Second
+		helperMinBackoff      = 30 * time.Second
+		helperMaxBackoff      = 5 * time.Minute
+		helperStableThreshold = 60 * time.Second
 	)
 
+	warnLimiter := newHelperWarnLimiter(3, 5*time.Minute)
 	backoff := helperMinBackoff
 	for {
 		client := userhelper.NewWithOptions(socketPath, role, binaryKind, context)
@@ -785,9 +794,13 @@ func runHelperProcess(name, role, context, binaryKind string) {
 			}
 		}()
 
-		connStart := time.Now()
 		err := client.Run()
 		close(clientDone)
+
+		// Capture the auth time BEFORE the client is garbage-collected. A
+		// zero value means the client never completed auth on this iteration.
+		authAt := client.AuthenticatedAt()
+
 		if err == nil {
 			// Clean exit (e.g. Stop() was called via signal)
 			log.Info("helper stopped", "name", name)
@@ -802,22 +815,114 @@ func runHelperProcess(name, role, context, binaryKind string) {
 		default:
 		}
 
-		// If the connection was up for a meaningful period, reset backoff
-		// so the next reconnect starts fast.
-		if time.Since(connStart) > helperMaxBackoff {
+		// Part B (separate commit) adds a check here for
+		// *userhelper.PermanentRejectError that exits with code 2 so the
+		// lifecycle manager can skip respawn. Until then, all errors fall
+		// through to the rate-limited reconnect path.
+
+		// Only reset backoff if the connection was stably authenticated for
+		// >60s. The previous logic reset on wall-clock iteration duration
+		// which let the storm keep restarting from 2s after every rate limit
+		// window expired.
+		if !authAt.IsZero() && time.Since(authAt) > helperStableThreshold {
 			backoff = helperMinBackoff
+			warnLimiter.reset()
 		}
 
-		log.Warn("helper disconnected, reconnecting",
-			"name", name, "error", err.Error(), "backoff", backoff)
+		// Add jitter: [backoff, backoff + backoff/2) so concurrent helpers
+		// don't synchronise their reconnect attempts.
+		wait := backoff + time.Duration(rand.Int64N(int64(backoff/2)+1))
+
+		errMsg := err.Error()
+		if emit, suppressed := warnLimiter.shouldLog(errMsg); emit {
+			log.Warn("helper disconnected, reconnecting",
+				"name", name, "error", errMsg, "backoff", wait.String())
+		} else if suppressed > 0 {
+			log.Info("helper still disconnected, suppressing further warnings",
+				"name", name,
+				"error", errMsg,
+				"suppressed_count", suppressed,
+				"backoff", wait.String())
+		}
 
 		// Wait for backoff or shutdown signal.
 		select {
-		case <-time.After(backoff):
+		case <-time.After(wait):
 			backoff = min(backoff*2, helperMaxBackoff)
 		case <-done:
 			log.Info("helper stopped during reconnect backoff", "name", name)
 			return
 		}
 	}
+}
+
+// helperWarnLimiter rate-limits a repeating warning message. After `limit`
+// emissions of the same message within `window`, further WARN emissions are
+// suppressed; an INFO "still disconnected" line is emitted at most once per
+// `window` with the suppressed count. Call reset() when the condition clears
+// (e.g. connection has been stably authenticated).
+type helperWarnLimiter struct {
+	mu            sync.Mutex
+	limit         int
+	window        time.Duration
+	lastMsg       string
+	firstSeenAt   time.Time
+	count         int    // total emissions (incl. suppressed) in this window
+	warnsEmitted  int    // warn-level emissions in this window
+	suppressed    int    // warnings suppressed since last info emission
+	lastInfoEmit  time.Time
+}
+
+func newHelperWarnLimiter(limit int, window time.Duration) *helperWarnLimiter {
+	return &helperWarnLimiter{limit: limit, window: window}
+}
+
+// shouldLog returns (emitWarn, suppressedCount). If emitWarn is true, the
+// caller should log a WARN. Otherwise, if suppressedCount > 0, the caller
+// should log a single INFO "still disconnected" line with that count.
+func (h *helperWarnLimiter) shouldLog(msg string) (bool, int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	now := time.Now()
+	if msg != h.lastMsg || now.Sub(h.firstSeenAt) > h.window {
+		// New message or window rolled over — reset counters.
+		h.lastMsg = msg
+		h.firstSeenAt = now
+		h.count = 1
+		h.warnsEmitted = 1
+		h.suppressed = 0
+		h.lastInfoEmit = time.Time{}
+		return true, 0
+	}
+
+	h.count++
+	if h.warnsEmitted < h.limit {
+		h.warnsEmitted++
+		return true, 0
+	}
+
+	// Over the warn budget — suppress and maybe emit an INFO summary.
+	h.suppressed++
+	if h.lastInfoEmit.IsZero() || now.Sub(h.lastInfoEmit) >= h.window {
+		suppressed := h.suppressed
+		h.suppressed = 0
+		h.lastInfoEmit = now
+		return false, suppressed
+	}
+	return false, 0
+}
+
+// reset clears limiter state so the next message starts a fresh window.
+// Call after a helper has been stably connected — the next disconnect is
+// a new event and deserves a full WARN.
+func (h *helperWarnLimiter) reset() {
+	h.mu.Lock()
+	h.lastMsg = ""
+	h.firstSeenAt = time.Time{}
+	h.count = 0
+	h.warnsEmitted = 0
+	h.suppressed = 0
+	h.lastInfoEmit = time.Time{}
+	h.mu.Unlock()
 }

--- a/agent/cmd/breeze-agent/main_test.go
+++ b/agent/cmd/breeze-agent/main_test.go
@@ -15,16 +15,18 @@ func TestHelperWarnLimiterBudget(t *testing.T) {
 	// limit=3, 5-minute window (matches production default)
 	lim := newHelperWarnLimiter(3, 5*time.Minute)
 	msg := "connect: connect to /var/run/breeze.sock: connection refused"
+	now := time.Now()
 
 	// Calls 1–3 should all emit WARN.
 	for i := 1; i <= 3; i++ {
-		emit, suppressed := lim.shouldLog(msg)
+		emit, suppressed := lim.shouldLog(msg, now)
 		if !emit {
 			t.Errorf("call %d: expected emit=true, got false", i)
 		}
 		if suppressed != 0 {
 			t.Errorf("call %d: expected suppressed=0, got %d", i, suppressed)
 		}
+		now = now.Add(time.Second)
 	}
 
 	// Call 4: over budget, info interval has not elapsed → (false, 0).
@@ -35,7 +37,7 @@ func TestHelperWarnLimiterBudget(t *testing.T) {
 	// suppressedSinceInfo++ → 1. lastInfoEmit.IsZero() is true, so it returns
 	// (false, 1) and resets suppressedSinceInfo to 0. This matches the
 	// "INFO fires immediately at first suppression" behavior.
-	emit4, sup4 := lim.shouldLog(msg)
+	emit4, sup4 := lim.shouldLog(msg, now)
 	if emit4 {
 		t.Errorf("call 4: expected emit=false (over budget), got true")
 	}
@@ -53,15 +55,18 @@ func TestHelperWarnLimiterSuppressedNoInfoYet(t *testing.T) {
 
 	lim := newHelperWarnLimiter(3, 5*time.Minute)
 	msg := "some error"
+	now := time.Now()
 
 	// Exhaust warn budget (3 warns + 1 INFO-emitting call).
 	for i := 0; i < 3; i++ {
-		lim.shouldLog(msg) //nolint: calls 1-3
+		lim.shouldLog(msg, now) //nolint: calls 1-3
+		now = now.Add(time.Second)
 	}
-	lim.shouldLog(msg) // call 4: first INFO fires, resets suppressedSinceInfo
+	lim.shouldLog(msg, now) // call 4: first INFO fires, resets suppressedSinceInfo
+	now = now.Add(time.Second)
 
 	// Call 5: within info interval → (false, 0).
-	emit, sup := lim.shouldLog(msg)
+	emit, sup := lim.shouldLog(msg, now)
 	if emit {
 		t.Errorf("call 5: expected emit=false, got true")
 	}
@@ -73,59 +78,36 @@ func TestHelperWarnLimiterSuppressedNoInfoYet(t *testing.T) {
 // TestHelperWarnLimiterMultipleInfos verifies that each INFO emission within a
 // single 5-minute window reports only the count since the last INFO, not cumulative.
 func TestHelperWarnLimiterMultipleInfos(t *testing.T) {
-	// Not parallel: uses time.Sleep for infoInterval simulation.
-	// Use a very short infoInterval-equivalent by sleeping just past 60s would
-	// be impractical; instead we verify the counter reset by examining state.
-	//
-	// Strategy: exhaust the warn budget (call 1-3), trigger first INFO (call 4),
-	// add more suppressions (calls 5-N), then trigger second INFO after sleeping
-	// 1ms past infoInterval by replacing the limiter's lastInfoEmit via the
-	// public interface — not possible since it's unexported.
-	//
-	// We instead test the logic structurally: after first INFO (suppressedSinceInfo
-	// reset to 0), further calls accumulate a new suppressedSinceInfo. When
-	// infoInterval elapses (tested with real sleep), the second INFO should
-	// report only the count since the first INFO.
-	//
-	// Because infoInterval=60s is too long for a test, we verify the counting
-	// logic is correct by using the fact that the very first INFO fires
-	// immediately (lastInfoEmit.IsZero()). We then check the second INFO
-	// would carry the right count using a short sleep that would exceed a
-	// tiny infoInterval — but infoInterval is a package constant at 60s, so
-	// instead we verify the reset behavior: after the first INFO, subsequent
-	// suppressed calls accumulate in suppressedSinceInfo independently.
-	//
-	// Practical: we confirm that suppressedSinceInfo resets between INFO
-	// emissions by running two suppress-then-INFO cycles back-to-back,
-	// using a sleep that exceeds infoInterval.
-
-	if testing.Short() {
-		t.Skip("skipped in -short mode (requires 61s sleep)")
-	}
+	t.Parallel()
 
 	lim := newHelperWarnLimiter(1, 10*time.Minute) // limit=1 so budget exhausts at call 2
 	msg := "persistent error"
+	now := time.Now()
 
 	// Call 1: first warn (under budget).
-	lim.shouldLog(msg)
+	lim.shouldLog(msg, now)
+	now = now.Add(time.Second)
 
 	// Call 2: over budget, first INFO fires immediately (lastInfoEmit was zero).
-	_, sup1 := lim.shouldLog(msg)
+	_, sup1 := lim.shouldLog(msg, now)
 	if sup1 != 1 {
 		t.Fatalf("first INFO: expected suppressed=1, got %d", sup1)
 	}
+	now = now.Add(time.Second)
 
-	// Calls 3-5: accumulate 3 more suppressions.
-	lim.shouldLog(msg)
-	lim.shouldLog(msg)
-	lim.shouldLog(msg)
+	// Calls 3-5: accumulate 3 more suppressions within infoInterval.
+	lim.shouldLog(msg, now)
+	now = now.Add(time.Second)
+	lim.shouldLog(msg, now)
+	now = now.Add(time.Second)
+	lim.shouldLog(msg, now)
+	now = now.Add(time.Second)
 
-	// Sleep past infoInterval (60s) so the next call triggers a second INFO.
-	t.Log("sleeping 61s for infoInterval…")
-	time.Sleep(61 * time.Second)
+	// Advance past infoInterval (60s) so the next call triggers a second INFO.
+	now = now.Add(61 * time.Second)
 
-	// Call 6: second INFO should report 3 (calls 3-5 since last INFO).
-	_, sup2 := lim.shouldLog(msg)
+	// Call 6: second INFO should report 4 (calls 3-5 plus this call = 4 suppressed since last INFO).
+	_, sup2 := lim.shouldLog(msg, now)
 	if sup2 != 4 {
 		// 3 accumulated + 1 from this call = 4 suppressed since last INFO
 		t.Errorf("second INFO: expected suppressed=4 (accumulated since last INFO), got %d", sup2)
@@ -140,21 +122,24 @@ func TestHelperWarnLimiterDifferentMessages(t *testing.T) {
 	lim := newHelperWarnLimiter(2, 5*time.Minute)
 	msgA := "error A: connection refused"
 	msgB := "error B: tls handshake failure"
+	now := time.Now()
 
 	// Exhaust budget for msgA (2 warns).
 	for i := 0; i < 2; i++ {
-		lim.shouldLog(msgA)
+		lim.shouldLog(msgA, now)
+		now = now.Add(time.Second)
 	}
 
 	// Next msgA call is over budget for A.
-	emitA, _ := lim.shouldLog(msgA)
+	emitA, _ := lim.shouldLog(msgA, now)
 	if emitA {
 		t.Errorf("msgA call 3: expected emit=false (over budget), got true")
 	}
+	now = now.Add(time.Second)
 
 	// msgB is a new message — it gets its own fresh budget.
 	// Window rolls over when msg changes, so call 1 of msgB should emit.
-	emitB, supB := lim.shouldLog(msgB)
+	emitB, supB := lim.shouldLog(msgB, now)
 	if !emitB {
 		t.Errorf("msgB call 1: expected emit=true (fresh message), got false")
 	}
@@ -166,30 +151,30 @@ func TestHelperWarnLimiterDifferentMessages(t *testing.T) {
 // TestHelperWarnLimiterWindowRollover verifies that after the 5-minute window
 // elapses, the limiter resets and emits WARNs again.
 func TestHelperWarnLimiterWindowRollover(t *testing.T) {
-	// Not parallel: uses time.Sleep.
-	if testing.Short() {
-		t.Skip("skipped in -short mode (requires sleep past window)")
-	}
+	t.Parallel()
 
-	// Use a 100ms window for fast testing.
+	// Use a 100ms window — with injectable clock we don't need a real sleep.
 	lim := newHelperWarnLimiter(2, 100*time.Millisecond)
 	msg := "some persistent error"
+	now := time.Now()
 
 	// Exhaust budget.
-	lim.shouldLog(msg)
-	lim.shouldLog(msg)
+	lim.shouldLog(msg, now)
+	now = now.Add(10 * time.Millisecond)
+	lim.shouldLog(msg, now)
+	now = now.Add(10 * time.Millisecond)
 
 	// Over budget.
-	emit3, _ := lim.shouldLog(msg)
+	emit3, _ := lim.shouldLog(msg, now)
 	if emit3 {
 		t.Errorf("call 3: expected emit=false (over budget), got true")
 	}
 
-	// Sleep past the 100ms window.
-	time.Sleep(150 * time.Millisecond)
+	// Advance past the 100ms window without any real sleep.
+	now = now.Add(150 * time.Millisecond)
 
 	// Window rolled over → fresh budget, should emit again.
-	emit4, sup4 := lim.shouldLog(msg)
+	emit4, sup4 := lim.shouldLog(msg, now)
 	if !emit4 {
 		t.Errorf("post-rollover call: expected emit=true (fresh window), got false")
 	}
@@ -205,29 +190,34 @@ func TestHelperWarnLimiterReset(t *testing.T) {
 
 	lim := newHelperWarnLimiter(2, 5*time.Minute)
 	msg := "connection reset by peer"
+	now := time.Now()
 
 	// Exhaust budget.
-	lim.shouldLog(msg)
-	lim.shouldLog(msg)
-	emit3, _ := lim.shouldLog(msg)
+	lim.shouldLog(msg, now)
+	now = now.Add(time.Second)
+	lim.shouldLog(msg, now)
+	now = now.Add(time.Second)
+	emit3, _ := lim.shouldLog(msg, now)
 	if emit3 {
 		t.Errorf("pre-reset call 3: expected emit=false (over budget)")
 	}
+	now = now.Add(time.Second)
 
 	// Reset clears all state.
 	lim.reset()
 
 	// Next call should behave as first call ever.
-	emit1, sup1 := lim.shouldLog(msg)
+	emit1, sup1 := lim.shouldLog(msg, now)
 	if !emit1 {
 		t.Errorf("post-reset call 1: expected emit=true, got false")
 	}
 	if sup1 != 0 {
 		t.Errorf("post-reset call 1: expected suppressed=0, got %d", sup1)
 	}
+	now = now.Add(time.Second)
 
 	// Second call should also emit (still within budget of 2).
-	emit2, sup2 := lim.shouldLog(msg)
+	emit2, sup2 := lim.shouldLog(msg, now)
 	if !emit2 {
 		t.Errorf("post-reset call 2: expected emit=true, got false")
 	}
@@ -255,7 +245,7 @@ func TestHelperWarnLimiterConcurrent(t *testing.T) {
 			for j := 0; j < callsPerGoroutine; j++ {
 				// We don't care about the exact return values here —
 				// just verify that concurrent access doesn't race or panic.
-				lim.shouldLog(msg)
+				lim.shouldLog(msg, time.Now())
 			}
 		}()
 	}
@@ -277,7 +267,7 @@ func TestHelperWarnLimiterResetConcurrent(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 100; i++ {
-			lim.shouldLog(msg)
+			lim.shouldLog(msg, time.Now())
 		}
 	}()
 

--- a/agent/cmd/breeze-agent/main_test.go
+++ b/agent/cmd/breeze-agent/main_test.go
@@ -1,0 +1,292 @@
+package main
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestHelperWarnLimiterBudget verifies that the first `limit` calls with the
+// same message all emit WARN (emit=true, suppressed=0), and that the (limit+1)th
+// call does NOT emit a WARN when the info interval has not elapsed.
+func TestHelperWarnLimiterBudget(t *testing.T) {
+	t.Parallel()
+
+	// limit=3, 5-minute window (matches production default)
+	lim := newHelperWarnLimiter(3, 5*time.Minute)
+	msg := "connect: connect to /var/run/breeze.sock: connection refused"
+
+	// Calls 1–3 should all emit WARN.
+	for i := 1; i <= 3; i++ {
+		emit, suppressed := lim.shouldLog(msg)
+		if !emit {
+			t.Errorf("call %d: expected emit=true, got false", i)
+		}
+		if suppressed != 0 {
+			t.Errorf("call %d: expected suppressed=0, got %d", i, suppressed)
+		}
+	}
+
+	// Call 4: over budget, info interval has not elapsed → (false, 0).
+	// NOTE: suppressedSinceInfo was 0 going in, incremented to 1, then INFO
+	// would only fire if lastInfoEmit is zero. But we check: lastInfoEmit is
+	// zero on entry here, so the first over-budget call WILL return (false, N>0).
+	// Actually, re-reading the code: on call 4, suppressed++ → suppressed=1,
+	// suppressedSinceInfo++ → 1. lastInfoEmit.IsZero() is true, so it returns
+	// (false, 1) and resets suppressedSinceInfo to 0. This matches the
+	// "INFO fires immediately at first suppression" behavior.
+	emit4, sup4 := lim.shouldLog(msg)
+	if emit4 {
+		t.Errorf("call 4: expected emit=false (over budget), got true")
+	}
+	// The limiter fires an INFO summary immediately on first suppression
+	// (lastInfoEmit was zero). sup4 should equal 1.
+	if sup4 != 1 {
+		t.Errorf("call 4: expected suppressed=1 (immediate first INFO), got %d", sup4)
+	}
+}
+
+// TestHelperWarnLimiterSuppressedNoInfoYet verifies that after the first INFO
+// fires, subsequent over-budget calls within the info interval return (false, 0).
+func TestHelperWarnLimiterSuppressedNoInfoYet(t *testing.T) {
+	t.Parallel()
+
+	lim := newHelperWarnLimiter(3, 5*time.Minute)
+	msg := "some error"
+
+	// Exhaust warn budget (3 warns + 1 INFO-emitting call).
+	for i := 0; i < 3; i++ {
+		lim.shouldLog(msg) //nolint: calls 1-3
+	}
+	lim.shouldLog(msg) // call 4: first INFO fires, resets suppressedSinceInfo
+
+	// Call 5: within info interval → (false, 0).
+	emit, sup := lim.shouldLog(msg)
+	if emit {
+		t.Errorf("call 5: expected emit=false, got true")
+	}
+	if sup != 0 {
+		t.Errorf("call 5: expected suppressed=0 (inside info interval), got %d", sup)
+	}
+}
+
+// TestHelperWarnLimiterMultipleInfos verifies that each INFO emission within a
+// single 5-minute window reports only the count since the last INFO, not cumulative.
+func TestHelperWarnLimiterMultipleInfos(t *testing.T) {
+	// Not parallel: uses time.Sleep for infoInterval simulation.
+	// Use a very short infoInterval-equivalent by sleeping just past 60s would
+	// be impractical; instead we verify the counter reset by examining state.
+	//
+	// Strategy: exhaust the warn budget (call 1-3), trigger first INFO (call 4),
+	// add more suppressions (calls 5-N), then trigger second INFO after sleeping
+	// 1ms past infoInterval by replacing the limiter's lastInfoEmit via the
+	// public interface — not possible since it's unexported.
+	//
+	// We instead test the logic structurally: after first INFO (suppressedSinceInfo
+	// reset to 0), further calls accumulate a new suppressedSinceInfo. When
+	// infoInterval elapses (tested with real sleep), the second INFO should
+	// report only the count since the first INFO.
+	//
+	// Because infoInterval=60s is too long for a test, we verify the counting
+	// logic is correct by using the fact that the very first INFO fires
+	// immediately (lastInfoEmit.IsZero()). We then check the second INFO
+	// would carry the right count using a short sleep that would exceed a
+	// tiny infoInterval — but infoInterval is a package constant at 60s, so
+	// instead we verify the reset behavior: after the first INFO, subsequent
+	// suppressed calls accumulate in suppressedSinceInfo independently.
+	//
+	// Practical: we confirm that suppressedSinceInfo resets between INFO
+	// emissions by running two suppress-then-INFO cycles back-to-back,
+	// using a sleep that exceeds infoInterval.
+
+	if testing.Short() {
+		t.Skip("skipped in -short mode (requires 61s sleep)")
+	}
+
+	lim := newHelperWarnLimiter(1, 10*time.Minute) // limit=1 so budget exhausts at call 2
+	msg := "persistent error"
+
+	// Call 1: first warn (under budget).
+	lim.shouldLog(msg)
+
+	// Call 2: over budget, first INFO fires immediately (lastInfoEmit was zero).
+	_, sup1 := lim.shouldLog(msg)
+	if sup1 != 1 {
+		t.Fatalf("first INFO: expected suppressed=1, got %d", sup1)
+	}
+
+	// Calls 3-5: accumulate 3 more suppressions.
+	lim.shouldLog(msg)
+	lim.shouldLog(msg)
+	lim.shouldLog(msg)
+
+	// Sleep past infoInterval (60s) so the next call triggers a second INFO.
+	t.Log("sleeping 61s for infoInterval…")
+	time.Sleep(61 * time.Second)
+
+	// Call 6: second INFO should report 3 (calls 3-5 since last INFO).
+	_, sup2 := lim.shouldLog(msg)
+	if sup2 != 4 {
+		// 3 accumulated + 1 from this call = 4 suppressed since last INFO
+		t.Errorf("second INFO: expected suppressed=4 (accumulated since last INFO), got %d", sup2)
+	}
+}
+
+// TestHelperWarnLimiterDifferentMessages verifies that different error messages
+// are tracked independently within the same window.
+func TestHelperWarnLimiterDifferentMessages(t *testing.T) {
+	t.Parallel()
+
+	lim := newHelperWarnLimiter(2, 5*time.Minute)
+	msgA := "error A: connection refused"
+	msgB := "error B: tls handshake failure"
+
+	// Exhaust budget for msgA (2 warns).
+	for i := 0; i < 2; i++ {
+		lim.shouldLog(msgA)
+	}
+
+	// Next msgA call is over budget for A.
+	emitA, _ := lim.shouldLog(msgA)
+	if emitA {
+		t.Errorf("msgA call 3: expected emit=false (over budget), got true")
+	}
+
+	// msgB is a new message — it gets its own fresh budget.
+	// Window rolls over when msg changes, so call 1 of msgB should emit.
+	emitB, supB := lim.shouldLog(msgB)
+	if !emitB {
+		t.Errorf("msgB call 1: expected emit=true (fresh message), got false")
+	}
+	if supB != 0 {
+		t.Errorf("msgB call 1: expected suppressed=0, got %d", supB)
+	}
+}
+
+// TestHelperWarnLimiterWindowRollover verifies that after the 5-minute window
+// elapses, the limiter resets and emits WARNs again.
+func TestHelperWarnLimiterWindowRollover(t *testing.T) {
+	// Not parallel: uses time.Sleep.
+	if testing.Short() {
+		t.Skip("skipped in -short mode (requires sleep past window)")
+	}
+
+	// Use a 100ms window for fast testing.
+	lim := newHelperWarnLimiter(2, 100*time.Millisecond)
+	msg := "some persistent error"
+
+	// Exhaust budget.
+	lim.shouldLog(msg)
+	lim.shouldLog(msg)
+
+	// Over budget.
+	emit3, _ := lim.shouldLog(msg)
+	if emit3 {
+		t.Errorf("call 3: expected emit=false (over budget), got true")
+	}
+
+	// Sleep past the 100ms window.
+	time.Sleep(150 * time.Millisecond)
+
+	// Window rolled over → fresh budget, should emit again.
+	emit4, sup4 := lim.shouldLog(msg)
+	if !emit4 {
+		t.Errorf("post-rollover call: expected emit=true (fresh window), got false")
+	}
+	if sup4 != 0 {
+		t.Errorf("post-rollover call: expected suppressed=0, got %d", sup4)
+	}
+}
+
+// TestHelperWarnLimiterReset verifies that explicit reset() clears all state
+// so the next call treats the message as brand-new.
+func TestHelperWarnLimiterReset(t *testing.T) {
+	t.Parallel()
+
+	lim := newHelperWarnLimiter(2, 5*time.Minute)
+	msg := "connection reset by peer"
+
+	// Exhaust budget.
+	lim.shouldLog(msg)
+	lim.shouldLog(msg)
+	emit3, _ := lim.shouldLog(msg)
+	if emit3 {
+		t.Errorf("pre-reset call 3: expected emit=false (over budget)")
+	}
+
+	// Reset clears all state.
+	lim.reset()
+
+	// Next call should behave as first call ever.
+	emit1, sup1 := lim.shouldLog(msg)
+	if !emit1 {
+		t.Errorf("post-reset call 1: expected emit=true, got false")
+	}
+	if sup1 != 0 {
+		t.Errorf("post-reset call 1: expected suppressed=0, got %d", sup1)
+	}
+
+	// Second call should also emit (still within budget of 2).
+	emit2, sup2 := lim.shouldLog(msg)
+	if !emit2 {
+		t.Errorf("post-reset call 2: expected emit=true, got false")
+	}
+	if sup2 != 0 {
+		t.Errorf("post-reset call 2: expected suppressed=0, got %d", sup2)
+	}
+}
+
+// TestHelperWarnLimiterConcurrent verifies that concurrent shouldLog calls do
+// not race. Run with go test -race to catch data races.
+func TestHelperWarnLimiterConcurrent(t *testing.T) {
+	t.Parallel()
+
+	lim := newHelperWarnLimiter(3, 5*time.Minute)
+	msg := "concurrent error"
+
+	var wg sync.WaitGroup
+	const goroutines = 20
+	const callsPerGoroutine = 50
+
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < callsPerGoroutine; j++ {
+				// We don't care about the exact return values here —
+				// just verify that concurrent access doesn't race or panic.
+				lim.shouldLog(msg)
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestHelperWarnLimiterResetConcurrent verifies that reset() is safe to call
+// concurrently with shouldLog.
+func TestHelperWarnLimiterResetConcurrent(t *testing.T) {
+	t.Parallel()
+
+	lim := newHelperWarnLimiter(3, 5*time.Minute)
+	msg := "some error"
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			lim.shouldLog(msg)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			lim.reset()
+		}
+	}()
+
+	wg.Wait()
+}

--- a/agent/internal/heartbeat/handlers_desktop_helper.go
+++ b/agent/internal/heartbeat/handlers_desktop_helper.go
@@ -426,7 +426,17 @@ func (h *Heartbeat) spawnHelperForDesktop(targetSession string) error {
 	// to release DXGI Desktop Duplication locks before spawning a new one.
 	h.killDesktopStaleHelpers(targetSession)
 
-	return sessionbroker.SpawnHelperInSession(sessionNum)
+	// The heartbeat path spawns a one-off helper; we don't track its exit
+	// code here. Release the handle immediately — the lifecycle manager,
+	// which does respect exit codes, owns the canonical spawn path.
+	helper, err := sessionbroker.SpawnHelperInSession(sessionNum)
+	if err != nil {
+		return err
+	}
+	if helper != nil {
+		helper.Close()
+	}
+	return nil
 }
 
 // findGUIUserUIDs returns the UIDs of users with a loginwindow process (macOS).

--- a/agent/internal/ipc/message.go
+++ b/agent/internal/ipc/message.go
@@ -61,7 +61,32 @@ const (
 	TypeIntegrityCheck  = "integrity_check"
 	TypeIntegrityResult = "integrity_result"
 	TypeTamperAlert     = "tamper_alert"
+
+	// TypePreAuthReject is sent by the broker to a connecting helper when
+	// the connection is rejected BEFORE the auth-request/auth-response
+	// exchange (e.g. rate limit, peer credential failure, max connections
+	// exceeded, or binary path unknown). Distinct from AuthResponse so the
+	// helper can differentiate "never got to auth" from "auth was rejected".
+	TypePreAuthReject = "pre_auth_reject"
 )
+
+// PreAuthReject codes identify why the broker rejected a connection.
+// Callers can switch on these programmatically without parsing Reason.
+const (
+	PreAuthCodeRateLimited       = "rate_limited"
+	PreAuthCodeBinaryPathUnknown = "binary_path_unknown"
+	PreAuthCodeMaxConnsExceeded  = "max_conns_exceeded"
+	PreAuthCodeCredCheckFailed   = "cred_check_failed"
+)
+
+// PreAuthReject is the payload sent with TypePreAuthReject. Permanent=true
+// signals the helper that retrying will not help — the helper should exit
+// and let the lifecycle manager (on the parent side) decide when to retry.
+type PreAuthReject struct {
+	Code      string `json:"code"`
+	Reason    string `json:"reason,omitempty"`
+	Permanent bool   `json:"permanent,omitempty"`
+}
 
 // MaxMessageSize is the maximum size of a JSON IPC message (16MB).
 const MaxMessageSize = 16 * 1024 * 1024
@@ -123,12 +148,18 @@ type AuthRequest struct {
 }
 
 // AuthResponse is sent by the root daemon back to the user helper.
+//
+// Permanent is set to true when the rejection reason is not transient
+// (SID mismatch, protocol version mismatch, binary hash mismatch, etc.).
+// The helper treats Permanent=true as fatal: it exits with code 2 so the
+// lifecycle manager can back off, instead of immediately reconnecting.
 type AuthResponse struct {
 	Accepted      bool     `json:"accepted"`
 	SessionKey    string   `json:"sessionKey,omitempty"`
 	AgentID       string   `json:"agentId,omitempty"`
 	AllowedScopes []string `json:"allowedScopes,omitempty"`
 	Reason        string   `json:"reason,omitempty"`
+	Permanent     bool     `json:"permanent,omitempty"`
 }
 
 // Capabilities is sent by the user helper after successful auth.

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -664,21 +664,14 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 		return
 	}
 
-	// Step 4: Verify binary path
-	if !b.verifyBinaryPath(creds.BinaryPath) {
-		log.Warn("binary path verification failed",
-			"identity", identityKey,
-			"pid", creds.PID,
-			"path", creds.BinaryPath,
-		)
-		rawConn.Close()
-		return
-	}
-
 	// Wrap connection
 	conn := ipc.NewConn(rawConn)
 
-	// Step 5: Read auth request
+	// Step 4: Read auth request
+	// (Moved ahead of binary-path verification so the hash from the auth
+	// request can serve as the authoritative binary identity signal —
+	// Windows cross-session spawns produce process paths that don't always
+	// match our allowlist after path normalization. See issue #387 part D.)
 	env, err := conn.Recv()
 	if err != nil {
 		log.Warn("auth request read failed", "identity", identityKey, "error", err.Error())
@@ -699,7 +692,7 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 		return
 	}
 
-	// Step 6: Verify protocol version
+	// Step 5: Verify protocol version
 	if authReq.ProtocolVersion != ipc.ProtocolVersion {
 		log.Warn("protocol version mismatch", "got", authReq.ProtocolVersion, "want", ipc.ProtocolVersion)
 		_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
@@ -710,7 +703,7 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 		return
 	}
 
-	// Step 7: Verify identity — SID on Windows, UID on Unix
+	// Step 6: Verify identity — SID on Windows, UID on Unix
 	if runtime.GOOS == "windows" {
 		if authReq.SID == "" {
 			log.Warn("auth missing SID on Windows", "pid", creds.PID)
@@ -742,7 +735,7 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 		}
 	}
 
-	// Step 8: Verify binary hash — reject helpers if no allowed helper hash could be loaded.
+	// Step 7: Verify binary hash — reject helpers if no allowed helper hash could be loaded.
 	if len(b.selfHashes) == 0 {
 		log.Error("rejecting helper connection: helper binary hash allowlist unavailable",
 			"identity", identityKey,
@@ -755,7 +748,8 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 		conn.Close()
 		return
 	}
-	if !b.isAllowedBinaryHash(authReq.BinaryHash) {
+	hashVerified := b.isAllowedBinaryHash(authReq.BinaryHash)
+	if !hashVerified {
 		log.Warn("binary hash mismatch",
 			"identity", identityKey,
 			"expected", "allowed-helper-binary",
@@ -767,6 +761,33 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 		})
 		conn.Close()
 		return
+	}
+
+	// Step 8: Verify binary path (defense in depth). If the hash already
+	// matched the allowlist, the binary is trusted regardless of path — on
+	// Windows, CreateProcessAsUser can report paths that don't match after
+	// normalization (8.3 short names, drive letter case, etc.), and the hash
+	// is the authoritative identity check. Log the path mismatch at DEBUG
+	// for future investigation, but do not reject.
+	if !b.verifyBinaryPath(creds.BinaryPath) {
+		if hashVerified {
+			log.Debug("binary path mismatch but hash verified; accepting",
+				"identity", identityKey,
+				"pid", creds.PID,
+				"path", creds.BinaryPath,
+				"allowed", b.allowedHelperPaths(),
+			)
+		} else {
+			// Unreachable today (hashVerified=false already returned above)
+			// but keep as defense in depth if step 7 ever becomes non-fatal.
+			log.Warn("binary path verification failed",
+				"identity", identityKey,
+				"pid", creds.PID,
+				"path", creds.BinaryPath,
+			)
+			conn.Close()
+			return
+		}
 	}
 
 	// Step 9: Reject duplicate session IDs
@@ -1130,12 +1151,19 @@ func (b *Broker) verifyBinaryPath(peerPath string) bool {
 		// Peer path might not be resolvable if the process has exited
 		peerResolved = peerPath
 	}
-	peerResolved = filepath.Clean(peerResolved)
-	for _, candidate := range b.allowedHelperPaths() {
-		if filepath.Clean(candidate) == peerResolved {
+	peerResolved = normalizeBinaryPath(filepath.Clean(peerResolved))
+	allowed := b.allowedHelperPaths()
+	for _, candidate := range allowed {
+		if normalizeBinaryPath(filepath.Clean(candidate)) == peerResolved {
 			return true
 		}
 	}
+	// Log the mismatch at DEBUG so investigators can see exactly which
+	// paths the broker considered trusted. Cheap and load-bearing.
+	log.Debug("verifyBinaryPath: no match",
+		"peer", peerResolved,
+		"allowed", allowed,
+	)
 	return false
 }
 

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -642,11 +642,19 @@ func sendPreAuthRejectAndClose(rawConn net.Conn, code, reason string, permanent 
 	defer rawConn.Close()
 	conn := ipc.NewConn(rawConn)
 	_ = rawConn.SetWriteDeadline(time.Now().Add(2 * time.Second))
-	_ = conn.SendTyped("pre-auth-reject", ipc.TypePreAuthReject, ipc.PreAuthReject{
+	if err := conn.SendTyped("pre-auth-reject", ipc.TypePreAuthReject, ipc.PreAuthReject{
 		Code:      code,
 		Reason:    reason,
 		Permanent: permanent,
-	})
+	}); err != nil && permanent {
+		// When a permanent rejection can't be delivered, the helper won't know
+		// to back off — it will interpret the dropped connection as a transient
+		// error and resume retrying immediately (reconnect storm risk).
+		log.Warn("failed to deliver permanent pre-auth rejection to helper",
+			"code", code,
+			"error", err.Error(),
+		)
+	}
 }
 
 func (b *Broker) handleConnection(rawConn net.Conn) {
@@ -657,7 +665,7 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 	creds, err := ipc.GetPeerCredentials(rawConn)
 	if err != nil {
 		log.Warn("peer credential check failed", "error", err.Error())
-		sendPreAuthRejectAndClose(rawConn, ipc.PreAuthCodeCredCheckFailed, err.Error(), true)
+		sendPreAuthRejectAndClose(rawConn, ipc.PreAuthCodeCredCheckFailed, err.Error(), false)
 		return
 	}
 
@@ -786,35 +794,18 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 	}
 
 	// Step 8: Verify binary path (defense in depth). If the hash already
-	// matched the allowlist, the binary is trusted regardless of path — on
-	// Windows, CreateProcessAsUser can report paths that don't match after
+	// matched the allowlist (step 7), the binary is trusted regardless of path
+	// — on Windows, CreateProcessAsUser can report paths that don't match after
 	// normalization (8.3 short names, drive letter case, etc.), and the hash
-	// is the authoritative identity check. Log the path mismatch at DEBUG
-	// for future investigation, but do not reject.
+	// is the authoritative identity check. Log the path mismatch at DEBUG for
+	// future investigation, but do not reject; a hash-verified helper is safe.
 	if !b.verifyBinaryPath(creds.BinaryPath) {
-		if hashVerified {
-			log.Debug("binary path mismatch but hash verified; accepting",
-				"identity", identityKey,
-				"pid", creds.PID,
-				"path", creds.BinaryPath,
-				"allowed", b.allowedHelperPaths(),
-			)
-		} else {
-			// Unreachable today (hashVerified=false already returned above)
-			// but keep as defense in depth if step 7 ever becomes non-fatal.
-			log.Warn("binary path verification failed",
-				"identity", identityKey,
-				"pid", creds.PID,
-				"path", creds.BinaryPath,
-			)
-			_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
-				Accepted:  false,
-				Reason:    "binary path unknown",
-				Permanent: true,
-			})
-			conn.Close()
-			return
-		}
+		log.Debug("binary path mismatch but hash verified; accepting",
+			"identity", identityKey,
+			"pid", creds.PID,
+			"path", creds.BinaryPath,
+			"allowed", b.allowedHelperPaths(),
+		)
 	}
 
 	// Step 9: Reject duplicate session IDs

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -633,6 +633,22 @@ func (b *Broker) SendCommandAndWait(session *Session, id, cmdType string, payloa
 	return session.SendCommand(id, cmdType, payload, timeout)
 }
 
+// sendPreAuthRejectAndClose wraps rawConn, sends a PreAuthReject envelope
+// with a short write deadline so the broker isn't held up by a stuck client,
+// then closes the connection. All errors are ignored — this is best-effort.
+// The helper uses the envelope to distinguish fatal ("don't retry") from
+// transient ("retry later") rejections.
+func sendPreAuthRejectAndClose(rawConn net.Conn, code, reason string, permanent bool) {
+	defer rawConn.Close()
+	conn := ipc.NewConn(rawConn)
+	_ = rawConn.SetWriteDeadline(time.Now().Add(2 * time.Second))
+	_ = conn.SendTyped("pre-auth-reject", ipc.TypePreAuthReject, ipc.PreAuthReject{
+		Code:      code,
+		Reason:    reason,
+		Permanent: permanent,
+	})
+}
+
 func (b *Broker) handleConnection(rawConn net.Conn) {
 	// Set handshake deadline
 	rawConn.SetDeadline(time.Now().Add(HandshakeTimeout))
@@ -641,7 +657,7 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 	creds, err := ipc.GetPeerCredentials(rawConn)
 	if err != nil {
 		log.Warn("peer credential check failed", "error", err.Error())
-		rawConn.Close()
+		sendPreAuthRejectAndClose(rawConn, ipc.PreAuthCodeCredCheckFailed, err.Error(), true)
 		return
 	}
 
@@ -650,7 +666,7 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 	// Step 2: Rate limit check (per identity: UID on Unix, SID on Windows)
 	if !b.rateLimiter.Allow(identityKey) {
 		log.Warn("connection rate limited", "identity", identityKey, "pid", creds.PID)
-		rawConn.Close()
+		sendPreAuthRejectAndClose(rawConn, ipc.PreAuthCodeRateLimited, "connection rate limited", false)
 		return
 	}
 
@@ -660,7 +676,7 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 	b.mu.RUnlock()
 	if identityCount >= MaxConnectionsPerIdentity {
 		log.Warn("max connections exceeded", "identity", identityKey, "count", identityCount)
-		rawConn.Close()
+		sendPreAuthRejectAndClose(rawConn, ipc.PreAuthCodeMaxConnsExceeded, "too many connections for identity", false)
 		return
 	}
 
@@ -696,8 +712,9 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 	if authReq.ProtocolVersion != ipc.ProtocolVersion {
 		log.Warn("protocol version mismatch", "got", authReq.ProtocolVersion, "want", ipc.ProtocolVersion)
 		_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
-			Accepted: false,
-			Reason:   fmt.Sprintf("unsupported protocol version %d (expected %d)", authReq.ProtocolVersion, ipc.ProtocolVersion),
+			Accepted:  false,
+			Reason:    fmt.Sprintf("unsupported protocol version %d (expected %d)", authReq.ProtocolVersion, ipc.ProtocolVersion),
+			Permanent: true,
 		})
 		conn.Close()
 		return
@@ -708,8 +725,9 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 		if authReq.SID == "" {
 			log.Warn("auth missing SID on Windows", "pid", creds.PID)
 			_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
-				Accepted: false,
-				Reason:   "SID required on Windows",
+				Accepted:  false,
+				Reason:    "SID required on Windows",
+				Permanent: true,
 			})
 			conn.Close()
 			return
@@ -717,8 +735,9 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 		if authReq.SID != creds.SID {
 			log.Warn("auth SID mismatch", "claimed", authReq.SID, "actual", creds.SID)
 			_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
-				Accepted: false,
-				Reason:   "SID mismatch",
+				Accepted:  false,
+				Reason:    "SID mismatch",
+				Permanent: true,
 			})
 			conn.Close()
 			return
@@ -727,8 +746,9 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 		if authReq.UID != creds.UID {
 			log.Warn("auth UID mismatch", "claimed", authReq.UID, "actual", creds.UID)
 			_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
-				Accepted: false,
-				Reason:   "UID mismatch",
+				Accepted:  false,
+				Reason:    "UID mismatch",
+				Permanent: true,
 			})
 			conn.Close()
 			return
@@ -742,8 +762,9 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 			"pid", creds.PID,
 		)
 		_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
-			Accepted: false,
-			Reason:   "helper binary hash allowlist unavailable",
+			Accepted:  false,
+			Reason:    "helper binary hash allowlist unavailable",
+			Permanent: true,
 		})
 		conn.Close()
 		return
@@ -756,8 +777,9 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 			"got", authReq.BinaryHash,
 		)
 		_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
-			Accepted: false,
-			Reason:   "binary hash mismatch",
+			Accepted:  false,
+			Reason:    "binary hash mismatch",
+			Permanent: true,
 		})
 		conn.Close()
 		return
@@ -785,6 +807,11 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 				"pid", creds.PID,
 				"path", creds.BinaryPath,
 			)
+			_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
+				Accepted:  false,
+				Reason:    "binary path unknown",
+				Permanent: true,
+			})
 			conn.Close()
 			return
 		}
@@ -830,8 +857,9 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 			log.Warn("role/identity mismatch: non-SYSTEM process claiming system role",
 				"sid", creds.SID, "pid", creds.PID)
 			_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
-				Accepted: false,
-				Reason:   "system role requires SYSTEM identity",
+				Accepted:  false,
+				Reason:    "system role requires SYSTEM identity",
+				Permanent: true,
 			})
 			conn.Close()
 			return
@@ -840,8 +868,9 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 			log.Warn("role/identity mismatch: SYSTEM process claiming user role",
 				"sid", creds.SID, "pid", creds.PID)
 			_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
-				Accepted: false,
-				Reason:   "user role requires non-SYSTEM identity",
+				Accepted:  false,
+				Reason:    "user role requires non-SYSTEM identity",
+				Permanent: true,
 			})
 			conn.Close()
 			return
@@ -850,8 +879,9 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 			log.Warn("role/identity mismatch: non-SYSTEM process claiming watchdog role",
 				"sid", creds.SID, "pid", creds.PID)
 			_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
-				Accepted: false,
-				Reason:   "watchdog role requires SYSTEM identity",
+				Accepted:  false,
+				Reason:    "watchdog role requires SYSTEM identity",
+				Permanent: true,
 			})
 			conn.Close()
 			return
@@ -862,8 +892,9 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 			log.Warn("role/identity mismatch: non-root process claiming watchdog role",
 				"uid", creds.UID, "pid", creds.PID)
 			_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
-				Accepted: false,
-				Reason:   "watchdog role requires root identity",
+				Accepted:  false,
+				Reason:    "watchdog role requires root identity",
+				Permanent: true,
 			})
 			conn.Close()
 			return

--- a/agent/internal/sessionbroker/broker_path_other.go
+++ b/agent/internal/sessionbroker/broker_path_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package sessionbroker
+
+// normalizeBinaryPath is a no-op on non-Windows platforms. Unix paths are
+// already canonical after filepath.EvalSymlinks + filepath.Clean.
+func normalizeBinaryPath(path string) string {
+	return path
+}

--- a/agent/internal/sessionbroker/broker_path_windows.go
+++ b/agent/internal/sessionbroker/broker_path_windows.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+package sessionbroker
+
+import (
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+// normalizeBinaryPath converts a Windows file path into a canonical form
+// suitable for equality comparison. It expands 8.3 short names via
+// GetLongPathNameW and lowercases the result. On failure it falls back to
+// a plain lowercased string so the comparison can still succeed for
+// already-long paths.
+//
+// Windows cross-session process spawning (CreateProcessAsUser) can report
+// process paths with mixed case or short-name components, which makes naive
+// string equality fail even when the underlying file is identical.
+func normalizeBinaryPath(path string) string {
+	if path == "" {
+		return ""
+	}
+	ptr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return strings.ToLower(path)
+	}
+	// Probe for required length.
+	n, err := windows.GetLongPathName(ptr, nil, 0)
+	if err != nil || n == 0 {
+		return strings.ToLower(path)
+	}
+	buf := make([]uint16, n)
+	n, err = windows.GetLongPathName(ptr, &buf[0], n)
+	if err != nil || n == 0 {
+		return strings.ToLower(path)
+	}
+	return strings.ToLower(windows.UTF16ToString(buf[:n]))
+}

--- a/agent/internal/sessionbroker/broker_windows_test.go
+++ b/agent/internal/sessionbroker/broker_windows_test.go
@@ -313,7 +313,14 @@ func TestNamedPipeSIDMismatchRejected(t *testing.T) {
 		t.Errorf("expected reason 'SID mismatch', got %q", authResp.Reason)
 	}
 
-	t.Logf("SID mismatch correctly rejected: %s", authResp.Reason)
+	// SID mismatch is a permanent rejection — the helper should not retry.
+	// Verifies that Part A (broker sends Permanent: true for identity rejections)
+	// is wired through to the auth response.
+	if !authResp.Permanent {
+		t.Errorf("expected Permanent=true for SID mismatch rejection, got false")
+	}
+
+	t.Logf("SID mismatch correctly rejected: %s (permanent=%v)", authResp.Reason, authResp.Permanent)
 }
 
 func TestNamedPipeMissingSIDRejected(t *testing.T) {
@@ -374,7 +381,13 @@ func TestNamedPipeMissingSIDRejected(t *testing.T) {
 		t.Fatal("expected auth to be REJECTED for missing SID, but it was accepted")
 	}
 
-	t.Logf("Missing SID correctly rejected: %s", authResp.Reason)
+	// Missing SID is a permanent rejection — helper should not retry with the
+	// same missing SID. Verifies Part A integration.
+	if !authResp.Permanent {
+		t.Errorf("expected Permanent=true for missing SID rejection, got false")
+	}
+
+	t.Logf("Missing SID correctly rejected: %s (permanent=%v)", authResp.Reason, authResp.Permanent)
 }
 
 func TestNamedPipeSessionIDCollisionRejected(t *testing.T) {

--- a/agent/internal/sessionbroker/lifecycle.go
+++ b/agent/internal/sessionbroker/lifecycle.go
@@ -336,10 +336,11 @@ func (m *HelperLifecycleManager) spawnWithRetry(winSessionID, role string) {
 func (m *HelperLifecycleManager) watchHelperExit(trackKey, winSessionID, role string, spawned *SpawnedHelper) {
 	exitCode, err := spawned.Wait()
 	if err != nil {
-		log.Debug("lifecycle: wait on helper process failed",
+		log.Warn("lifecycle: wait on helper process failed",
 			"winSessionID", winSessionID,
 			"role", role,
 			"pid", spawned.PID,
+			"trackKey", trackKey,
 			"error", err.Error(),
 		)
 		return

--- a/agent/internal/sessionbroker/lifecycle.go
+++ b/agent/internal/sessionbroker/lifecycle.go
@@ -29,6 +29,11 @@ type trackedSession struct {
 	spawnedAt   time.Time
 	retryCount  int
 	lastFailure time.Time
+
+	// fatalExitUntil suppresses respawns until this time when the helper
+	// exited with a fatal exit code (typically 2, meaning permanent auth
+	// rejection). Cleared on SCM session change events.
+	fatalExitUntil time.Time
 }
 
 // SCMSessionEvent is a session-change notification forwarded from the Windows
@@ -55,6 +60,15 @@ const (
 	// maxSpawnRetries stops retrying a session that is permanently broken.
 	// Tracking resets when the session disappears and reappears in WTS.
 	maxSpawnRetries = 10
+
+	// fatalCooldown is how long a session+role is blocked from respawn
+	// after a helper exits with a fatal exit code (2 — permanent auth
+	// rejection). Cleared early on SCM session change events.
+	fatalCooldown = 10 * time.Minute
+
+	// helperFatalExitCode is the exit code a helper uses to signal
+	// permanent rejection. Must match main.go's os.Exit(2).
+	helperFatalExitCode = 2
 
 	// WTS event type constants (matching windows.WTS_SESSION_*).
 	wtsSessionLogon     = 0x5
@@ -179,6 +193,18 @@ func (m *HelperLifecycleManager) handleSCMEvent(evt SCMSessionEvent) {
 
 	switch evt.EventType {
 	case wtsSessionLogon, wtsSessionUnlock, wtsSessionCreate:
+		// A session change means the environment changed — worth retrying
+		// a previously-fatal helper. Clear the fatal cooldown for both
+		// roles in this session.
+		m.mu.Lock()
+		if ts, ok := m.tracked[sessionID+"-system"]; ok {
+			ts.fatalExitUntil = time.Time{}
+		}
+		if ts, ok := m.tracked[sessionID+"-user"]; ok {
+			ts.fatalExitUntil = time.Time{}
+		}
+		m.mu.Unlock()
+
 		if !m.broker.HasHelperForWinSessionRole(sessionID, "system") {
 			m.spawnWithRetry(sessionID, "system")
 		}
@@ -216,6 +242,13 @@ func (m *HelperLifecycleManager) spawnWithRetry(winSessionID, role string) {
 		m.tracked[trackKey] = ts
 	}
 
+	// Respect fatal-exit cooldown from a previous helper that exited with
+	// exit code 2 (permanent rejection). Cleared on SCM session changes.
+	if now := time.Now(); !ts.fatalExitUntil.IsZero() && now.Before(ts.fatalExitUntil) {
+		m.mu.Unlock()
+		return
+	}
+
 	// Give up after too many failures. The tracking entry is cleaned up
 	// when the session disappears from WTS, so retries reset naturally
 	// if the user logs out and back in.
@@ -247,11 +280,12 @@ func (m *HelperLifecycleManager) spawnWithRetry(winSessionID, role string) {
 	m.broker.KillStaleHelpers(winSessionID + "-" + role)
 
 	// Spawn the appropriate helper type.
+	var spawned *SpawnedHelper
 	switch role {
 	case "user":
-		err = SpawnUserHelperInSession(uint32(sessionNum))
+		spawned, err = SpawnUserHelperInSession(uint32(sessionNum))
 	default:
-		err = SpawnHelperInSession(uint32(sessionNum))
+		spawned, err = SpawnHelperInSession(uint32(sessionNum))
 	}
 
 	// Count every spawn attempt toward the retry cap, not just errors.
@@ -287,4 +321,51 @@ func (m *HelperLifecycleManager) spawnWithRetry(winSessionID, role string) {
 	m.mu.Unlock()
 
 	log.Info("proactively spawned helper in session", "winSessionID", winSessionID, "role", role)
+
+	// Start a goroutine to wait on the helper process. When it exits, apply
+	// the fatal-cooldown policy if appropriate. SpawnedHelper.Wait() closes
+	// the handle on return.
+	if spawned != nil {
+		go m.watchHelperExit(trackKey, winSessionID, role, spawned)
+	}
+}
+
+// watchHelperExit blocks on the helper process and, when it exits, sets the
+// fatal cooldown on the tracked entry if the helper exited with the fatal
+// exit code (2 — permanent rejection).
+func (m *HelperLifecycleManager) watchHelperExit(trackKey, winSessionID, role string, spawned *SpawnedHelper) {
+	exitCode, err := spawned.Wait()
+	if err != nil {
+		log.Debug("lifecycle: wait on helper process failed",
+			"winSessionID", winSessionID,
+			"role", role,
+			"pid", spawned.PID,
+			"error", err.Error(),
+		)
+		return
+	}
+
+	if exitCode == helperFatalExitCode {
+		m.mu.Lock()
+		ts, ok := m.tracked[trackKey]
+		if ok {
+			ts.fatalExitUntil = time.Now().Add(fatalCooldown)
+		}
+		m.mu.Unlock()
+		log.Warn("lifecycle: helper exited with fatal code, skipping respawn",
+			"winSessionID", winSessionID,
+			"role", role,
+			"pid", spawned.PID,
+			"exitCode", exitCode,
+			"cooldown", fatalCooldown.String(),
+		)
+		return
+	}
+
+	log.Debug("lifecycle: helper exited",
+		"winSessionID", winSessionID,
+		"role", role,
+		"pid", spawned.PID,
+		"exitCode", exitCode,
+	)
 }

--- a/agent/internal/sessionbroker/lifecycle_test.go
+++ b/agent/internal/sessionbroker/lifecycle_test.go
@@ -1,0 +1,329 @@
+//go:build windows
+
+package sessionbroker
+
+import (
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Priority 4: fatalExitUntil suppression in spawnWithRetry
+// ---------------------------------------------------------------------------
+
+// TestSpawnWithRetrySkipsWhenFatalCooldownActive verifies that spawnWithRetry
+// does nothing when the tracked session has a fatalExitUntil set to a future
+// time. It verifies the suppression by checking that the retryCount in the
+// tracked entry remains unchanged after the call.
+func TestSpawnWithRetrySkipsWhenFatalCooldownActive(t *testing.T) {
+	t.Parallel()
+
+	// Build a minimal broker that can be passed to NewHelperLifecycleManager.
+	// We don't start a listener — we just need the struct.
+	broker := New(`\\.\pipe\test-lifecycle-fatal-`+t.Name(), nil)
+	defer broker.Close()
+
+	m := NewHelperLifecycleManager(broker, nil)
+
+	winSessionID := "7"
+	role := "system"
+	trackKey := winSessionID + "-" + role
+
+	// Pre-seed the tracked map with a fatalExitUntil in the future.
+	future := time.Now().Add(fatalCooldown) // 10 minutes from now
+	m.mu.Lock()
+	m.tracked[trackKey] = &trackedSession{
+		fatalExitUntil: future,
+		retryCount:     0,
+	}
+	m.mu.Unlock()
+
+	// spawnWithRetry should detect the cooldown and return without spawning.
+	m.spawnWithRetry(winSessionID, role)
+
+	// Verify: retryCount should still be 0 (no spawn attempt was made).
+	// If a spawn was attempted, retryCount would be incremented to 1.
+	m.mu.Lock()
+	ts := m.tracked[trackKey]
+	m.mu.Unlock()
+
+	if ts == nil {
+		t.Fatal("tracked entry was unexpectedly deleted")
+	}
+	if ts.retryCount != 0 {
+		t.Errorf("retryCount = %d, want 0 (spawnWithRetry should have returned early due to fatalExitUntil)", ts.retryCount)
+	}
+	if ts.fatalExitUntil != future {
+		t.Error("fatalExitUntil was modified unexpectedly")
+	}
+}
+
+// TestSpawnWithRetryProceedsWhenFatalCooldownExpired verifies that spawnWithRetry
+// proceeds past the cooldown check when fatalExitUntil is in the past.
+// We set it 1 nanosecond in the past so that time.Now().Before(ts.fatalExitUntil)
+// is false. The spawn attempt will fail (no real session 7 exists on a test machine),
+// but the key behavioral assertion is that retryCount is incremented — proving
+// the early-return guard was NOT triggered.
+func TestSpawnWithRetryProceedsWhenFatalCooldownExpired(t *testing.T) {
+	t.Parallel()
+
+	broker := New(`\\.\pipe\test-lifecycle-expired-`+t.Name(), nil)
+	defer broker.Close()
+
+	m := NewHelperLifecycleManager(broker, nil)
+
+	winSessionID := "8"
+	role := "system"
+	trackKey := winSessionID + "-" + role
+
+	// Set fatalExitUntil 1 second in the past — cooldown has expired.
+	past := time.Now().Add(-1 * time.Second)
+	m.mu.Lock()
+	m.tracked[trackKey] = &trackedSession{
+		fatalExitUntil: past,
+		retryCount:     0,
+	}
+	m.mu.Unlock()
+
+	// spawnWithRetry should proceed past the cooldown check.
+	// The spawn will likely fail (session 8 probably doesn't exist), but that's OK.
+	m.spawnWithRetry(winSessionID, role)
+
+	// retryCount incremented → the guard was not triggered.
+	m.mu.Lock()
+	ts := m.tracked[trackKey]
+	m.mu.Unlock()
+
+	if ts == nil {
+		t.Fatal("tracked entry was unexpectedly deleted")
+	}
+	if ts.retryCount == 0 {
+		t.Error("retryCount = 0, want > 0 (spawnWithRetry should have proceeded past expired cooldown)")
+	}
+}
+
+// TestSpawnWithRetryProceedsWhenFatalCooldownZero verifies that spawnWithRetry
+// proceeds when fatalExitUntil is zero (never set).
+func TestSpawnWithRetryProceedsWhenFatalCooldownZero(t *testing.T) {
+	t.Parallel()
+
+	broker := New(`\\.\pipe\test-lifecycle-zero-`+t.Name(), nil)
+	defer broker.Close()
+
+	m := NewHelperLifecycleManager(broker, nil)
+
+	winSessionID := "9"
+	role := "system"
+	trackKey := winSessionID + "-" + role
+
+	// No pre-seed — trackedSession will be created fresh with zero fatalExitUntil.
+	m.spawnWithRetry(winSessionID, role)
+
+	m.mu.Lock()
+	ts := m.tracked[trackKey]
+	m.mu.Unlock()
+
+	if ts == nil {
+		t.Fatal("tracked entry was not created")
+	}
+	// retryCount should be 1 — the spawn attempt was made (may have failed,
+	// but the lifecycle counter was incremented).
+	if ts.retryCount == 0 {
+		t.Error("retryCount = 0, want > 0 (spawnWithRetry should have attempted spawn with zero fatalExitUntil)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Priority 5: handleSCMEvent clears fatalExitUntil
+// ---------------------------------------------------------------------------
+
+// TestHandleSCMEventClearsFatalCooldown verifies that session-change events that
+// indicate the environment changed favorably (logon, unlock, create) clear the
+// fatalExitUntil field so a cooling-down helper can try again.
+func TestHandleSCMEventClearsFatalCooldown(t *testing.T) {
+	t.Parallel()
+
+	clearingEvents := []struct {
+		name      string
+		eventType uint32
+	}{
+		{"WTS_SESSION_LOGON", wtsSessionLogon},
+		{"WTS_SESSION_UNLOCK", wtsSessionUnlock},
+		{"WTS_SESSION_CREATE", wtsSessionCreate},
+	}
+
+	for _, evt := range clearingEvents {
+		evt := evt
+		t.Run(evt.name, func(t *testing.T) {
+			t.Parallel()
+
+			broker := New(`\\.\pipe\test-scm-`+evt.name+t.Name(), nil)
+			defer broker.Close()
+
+			m := NewHelperLifecycleManager(broker, nil)
+
+			sessionID := uint32(5)
+			sessionIDStr := "5"
+
+			// Pre-seed both roles with future fatalExitUntil.
+			future := time.Now().Add(fatalCooldown)
+			m.mu.Lock()
+			m.tracked[sessionIDStr+"-system"] = &trackedSession{fatalExitUntil: future}
+			m.tracked[sessionIDStr+"-user"] = &trackedSession{fatalExitUntil: future}
+			m.mu.Unlock()
+
+			// Deliver the event.
+			m.handleSCMEvent(SCMSessionEvent{
+				EventType: evt.eventType,
+				SessionID: sessionID,
+			})
+
+			// Both roles should now have fatalExitUntil cleared (zero).
+			m.mu.Lock()
+			tsSystem := m.tracked[sessionIDStr+"-system"]
+			tsUser := m.tracked[sessionIDStr+"-user"]
+			m.mu.Unlock()
+
+			if tsSystem != nil && !tsSystem.fatalExitUntil.IsZero() {
+				t.Errorf("%s: system role fatalExitUntil not cleared, still %v", evt.name, tsSystem.fatalExitUntil)
+			}
+			if tsUser != nil && !tsUser.fatalExitUntil.IsZero() {
+				t.Errorf("%s: user role fatalExitUntil not cleared, still %v", evt.name, tsUser.fatalExitUntil)
+			}
+		})
+	}
+}
+
+// TestHandleSCMEventLogoffDeletesTracking verifies that logoff/terminate events
+// remove the tracked entries entirely (not just clear fatalExitUntil).
+func TestHandleSCMEventLogoffDeletesTracking(t *testing.T) {
+	t.Parallel()
+
+	deletingEvents := []struct {
+		name      string
+		eventType uint32
+	}{
+		{"WTS_SESSION_LOGOFF", wtsSessionLogoff},
+		{"WTS_SESSION_TERMINATE", wtsSessionTerminate},
+	}
+
+	for _, evt := range deletingEvents {
+		evt := evt
+		t.Run(evt.name, func(t *testing.T) {
+			t.Parallel()
+
+			broker := New(`\\.\pipe\test-scm-delete-`+evt.name+t.Name(), nil)
+			defer broker.Close()
+
+			m := NewHelperLifecycleManager(broker, nil)
+
+			sessionID := uint32(6)
+			sessionIDStr := "6"
+
+			m.mu.Lock()
+			m.tracked[sessionIDStr+"-system"] = &trackedSession{retryCount: 3}
+			m.tracked[sessionIDStr+"-user"] = &trackedSession{retryCount: 2}
+			m.mu.Unlock()
+
+			m.handleSCMEvent(SCMSessionEvent{
+				EventType: evt.eventType,
+				SessionID: sessionID,
+			})
+
+			m.mu.Lock()
+			_, systemExists := m.tracked[sessionIDStr+"-system"]
+			_, userExists := m.tracked[sessionIDStr+"-user"]
+			m.mu.Unlock()
+
+			if systemExists {
+				t.Errorf("%s: system role tracking entry not deleted", evt.name)
+			}
+			if userExists {
+				t.Errorf("%s: user role tracking entry not deleted", evt.name)
+			}
+		})
+	}
+}
+
+// TestHandleSCMEventSkipsSessionZero verifies that session 0 (services) is
+// ignored by handleSCMEvent — it should not create any tracked entries.
+func TestHandleSCMEventSkipsSessionZero(t *testing.T) {
+	t.Parallel()
+
+	broker := New(`\\.\pipe\test-scm-session0-`+t.Name(), nil)
+	defer broker.Close()
+
+	m := NewHelperLifecycleManager(broker, nil)
+
+	// Deliver a logon event for session 0.
+	m.handleSCMEvent(SCMSessionEvent{
+		EventType: wtsSessionLogon,
+		SessionID: 0,
+	})
+
+	m.mu.Lock()
+	_, exists0Sys := m.tracked["0-system"]
+	_, exists0User := m.tracked["0-user"]
+	total := len(m.tracked)
+	m.mu.Unlock()
+
+	if exists0Sys || exists0User {
+		t.Error("session 0 should be ignored by handleSCMEvent but tracking entries were created")
+	}
+	if total != 0 {
+		t.Errorf("expected 0 tracked entries after session-0 event, got %d", total)
+	}
+}
+
+// TestHandleSCMEventLockDoesNotClearCooldown verifies that a lock event (which
+// does NOT indicate a favorable environment change) does NOT clear fatalExitUntil.
+// Only logon/unlock/create trigger the clear.
+func TestHandleSCMEventLockDoesNotClearCooldown(t *testing.T) {
+	t.Parallel()
+
+	broker := New(`\\.\pipe\test-scm-lock-`+t.Name(), nil)
+	defer broker.Close()
+
+	m := NewHelperLifecycleManager(broker, nil)
+
+	sessionID := uint32(3)
+	sessionIDStr := "3"
+	future := time.Now().Add(fatalCooldown)
+
+	m.mu.Lock()
+	m.tracked[sessionIDStr+"-system"] = &trackedSession{fatalExitUntil: future}
+	m.mu.Unlock()
+
+	// Deliver a lock event — this is NOT in the clearing switch cases.
+	m.handleSCMEvent(SCMSessionEvent{
+		EventType: wtsSessionLock,
+		SessionID: sessionID,
+	})
+
+	m.mu.Lock()
+	ts := m.tracked[sessionIDStr+"-system"]
+	m.mu.Unlock()
+
+	// fatalExitUntil should remain set — lock event doesn't clear it.
+	if ts != nil && ts.fatalExitUntil.IsZero() {
+		t.Error("lock event cleared fatalExitUntil, but only logon/unlock/create should clear it")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Priority 6: helperFatalExitCode consistency guard
+// ---------------------------------------------------------------------------
+
+// TestFatalExitCodeConsistency is a compile-time-ish guard that ensures the
+// exit code used by main.go's os.Exit(2) matches the constant recognized by
+// lifecycle.go's watchHelperExit goroutine. A drift between these two values
+// would silently break the fatal-cooldown mechanism.
+func TestFatalExitCodeConsistency(t *testing.T) {
+	// The helper in main.go uses os.Exit(2) as the fatal exit signal.
+	// The lifecycle manager must recognize that exact value.
+	const expectedFatalExitCode = 2
+	if helperFatalExitCode != expectedFatalExitCode {
+		t.Errorf("helperFatalExitCode = %d; if this is intentional, update main.go os.Exit call to match %d",
+			helperFatalExitCode, expectedFatalExitCode)
+	}
+}

--- a/agent/internal/sessionbroker/spawner_stub.go
+++ b/agent/internal/sessionbroker/spawner_stub.go
@@ -4,14 +4,28 @@ package sessionbroker
 
 import "fmt"
 
+// SpawnedHelper is only populated on Windows. On other platforms helper
+// spawning is handled by OS-level mechanisms (launchd LaunchAgent, systemd
+// user service, XDG autostart), so the lifecycle manager does not track
+// child processes directly.
+type SpawnedHelper struct {
+	PID uint32
+}
+
+// Close is a no-op on non-Windows platforms.
+func (s *SpawnedHelper) Close() {}
+
+// Wait is a no-op on non-Windows platforms. Returns (exitCode=-1, nil).
+func (s *SpawnedHelper) Wait() (int, error) { return -1, nil }
+
 // SpawnHelperInSession is only implemented on Windows.
 // On other platforms the user helper is launched by the OS login mechanism
 // (launchd LaunchAgent, systemd user service, XDG autostart).
-func SpawnHelperInSession(sessionID uint32) error {
-	return fmt.Errorf("helper spawning not supported on this platform")
+func SpawnHelperInSession(sessionID uint32) (*SpawnedHelper, error) {
+	return nil, fmt.Errorf("helper spawning not supported on this platform")
 }
 
 // SpawnUserHelperInSession is only implemented on Windows.
-func SpawnUserHelperInSession(sessionID uint32) error {
-	return fmt.Errorf("user helper spawning not supported on this platform")
+func SpawnUserHelperInSession(sessionID uint32) (*SpawnedHelper, error) {
+	return nil, fmt.Errorf("user helper spawning not supported on this platform")
 }

--- a/agent/internal/sessionbroker/spawner_windows.go
+++ b/agent/internal/sessionbroker/spawner_windows.go
@@ -10,20 +10,61 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// SpawnedHelper describes a helper process after a successful spawn. It
+// contains the PID and a duplicated process handle so callers can wait for
+// the process to exit and inspect its exit code. Close() must be called to
+// release the handle.
+type SpawnedHelper struct {
+	PID    uint32
+	Handle windows.Handle
+}
+
+// Close releases the duplicated process handle. Safe to call more than once.
+func (s *SpawnedHelper) Close() {
+	if s == nil || s.Handle == 0 {
+		return
+	}
+	_ = windows.CloseHandle(s.Handle)
+	s.Handle = 0
+}
+
+// Wait blocks until the spawned helper process exits and returns its exit
+// code. Returns -1 + error on failure. The process handle is released
+// automatically after Wait returns so callers do not need to call Close
+// in the normal path.
+func (s *SpawnedHelper) Wait() (int, error) {
+	if s == nil || s.Handle == 0 {
+		return -1, fmt.Errorf("SpawnedHelper: no handle")
+	}
+	defer s.Close()
+	event, err := windows.WaitForSingleObject(s.Handle, windows.INFINITE)
+	if err != nil {
+		return -1, fmt.Errorf("WaitForSingleObject: %w", err)
+	}
+	if event != windows.WAIT_OBJECT_0 {
+		return -1, fmt.Errorf("WaitForSingleObject: unexpected event %d", event)
+	}
+	var exitCode uint32
+	if err := windows.GetExitCodeProcess(s.Handle, &exitCode); err != nil {
+		return -1, fmt.Errorf("GetExitCodeProcess: %w", err)
+	}
+	return int(exitCode), nil
+}
+
 // SpawnHelperInSession launches a user-helper process as SYSTEM in the
-// specified Windows session. The helper inherits our SYSTEM token with the
-// session ID overridden, giving it full desktop access (Default, Winlogon,
-// Screensaver) in the target session.
-func SpawnHelperInSession(sessionID uint32) error {
+// specified Windows session. Returns a SpawnedHelper describing the child
+// process, or nil + an error on failure. The caller is responsible for
+// closing the returned handle.
+func SpawnHelperInSession(sessionID uint32) (*SpawnedHelper, error) {
 	// 1. Open our own process token (SYSTEM).
 	var processToken windows.Token
 	proc, err := windows.GetCurrentProcess()
 	if err != nil {
-		return fmt.Errorf("GetCurrentProcess: %w", err)
+		return nil, fmt.Errorf("GetCurrentProcess: %w", err)
 	}
 	err = windows.OpenProcessToken(proc, windows.TOKEN_DUPLICATE|windows.TOKEN_QUERY, &processToken)
 	if err != nil {
-		return fmt.Errorf("OpenProcessToken: %w", err)
+		return nil, fmt.Errorf("OpenProcessToken: %w", err)
 	}
 	defer processToken.Close()
 
@@ -41,7 +82,7 @@ func SpawnHelperInSession(sessionID uint32) error {
 		&dupToken,
 	)
 	if err != nil {
-		return fmt.Errorf("DuplicateTokenEx: %w", err)
+		return nil, fmt.Errorf("DuplicateTokenEx: %w", err)
 	}
 	defer dupToken.Close()
 
@@ -53,23 +94,23 @@ func SpawnHelperInSession(sessionID uint32) error {
 		uint32(unsafe.Sizeof(sessionID)),
 	)
 	if err != nil {
-		return fmt.Errorf("SetTokenInformation(TokenSessionId=%d): %w", sessionID, err)
+		return nil, fmt.Errorf("SetTokenInformation(TokenSessionId=%d): %w", sessionID, err)
 	}
 
 	// 4. Build the command line: same binary, "user-helper" subcommand.
 	exePath, err := os.Executable()
 	if err != nil {
-		return fmt.Errorf("os.Executable: %w", err)
+		return nil, fmt.Errorf("os.Executable: %w", err)
 	}
 	cmdLine, err := windows.UTF16PtrFromString(fmt.Sprintf(`"%s" user-helper`, exePath))
 	if err != nil {
-		return fmt.Errorf("UTF16PtrFromString: %w", err)
+		return nil, fmt.Errorf("UTF16PtrFromString: %w", err)
 	}
 
 	// 5. Target the interactive window station + default desktop.
 	desktop, err := windows.UTF16PtrFromString(`winsta0\Default`)
 	if err != nil {
-		return fmt.Errorf("UTF16PtrFromString desktop: %w", err)
+		return nil, fmt.Errorf("UTF16PtrFromString desktop: %w", err)
 	}
 
 	si := windows.StartupInfo{
@@ -93,11 +134,12 @@ func SpawnHelperInSession(sessionID uint32) error {
 		&pi,
 	)
 	if err != nil {
-		return fmt.Errorf("CreateProcessAsUser(session=%d): %w", sessionID, err)
+		return nil, fmt.Errorf("CreateProcessAsUser(session=%d): %w", sessionID, err)
 	}
 
+	// Release the thread handle (we don't need it). Keep the process handle
+	// so the lifecycle manager can wait on it and read the exit code.
 	windows.CloseHandle(pi.Thread)
-	windows.CloseHandle(pi.Process)
 
 	log.Info("spawned user helper in session",
 		"sessionId", sessionID,
@@ -105,7 +147,7 @@ func SpawnHelperInSession(sessionID uint32) error {
 		"pid", pi.ProcessId,
 		"exe", exePath,
 	)
-	return nil
+	return &SpawnedHelper{PID: pi.ProcessId, Handle: pi.Process}, nil
 }
 
 // SpawnUserHelperInSession launches a user-helper process using the logged-in
@@ -113,11 +155,14 @@ func SpawnHelperInSession(sessionID uint32) error {
 // falls back to explorer.exe token theft for Azure AD sessions.
 // This helper runs as the interactive user, enabling run_as_user script
 // execution and launching the Breeze Helper Tauri app.
-func SpawnUserHelperInSession(sessionID uint32) error {
+//
+// Returns a SpawnedHelper describing the child process; the caller is
+// responsible for closing the returned handle.
+func SpawnUserHelperInSession(sessionID uint32) (*SpawnedHelper, error) {
 	// Try WTSQueryUserToken first, fall back to explorer.exe token.
 	dupToken, envBlock, method, err := acquireUserToken(sessionID)
 	if err != nil {
-		return fmt.Errorf("acquire user token(session=%d): %w", sessionID, err)
+		return nil, fmt.Errorf("acquire user token(session=%d): %w", sessionID, err)
 	}
 	defer dupToken.Close()
 	if envBlock != nil {
@@ -127,16 +172,16 @@ func SpawnUserHelperInSession(sessionID uint32) error {
 	// Build command line with --role user flag.
 	exePath, err := os.Executable()
 	if err != nil {
-		return fmt.Errorf("os.Executable: %w", err)
+		return nil, fmt.Errorf("os.Executable: %w", err)
 	}
 	cmdLine, err := windows.UTF16PtrFromString(fmt.Sprintf(`"%s" user-helper --role user`, exePath))
 	if err != nil {
-		return fmt.Errorf("UTF16PtrFromString: %w", err)
+		return nil, fmt.Errorf("UTF16PtrFromString: %w", err)
 	}
 
 	desktop, err := windows.UTF16PtrFromString(`winsta0\Default`)
 	if err != nil {
-		return fmt.Errorf("UTF16PtrFromString desktop: %w", err)
+		return nil, fmt.Errorf("UTF16PtrFromString desktop: %w", err)
 	}
 
 	si := windows.StartupInfo{
@@ -158,11 +203,10 @@ func SpawnUserHelperInSession(sessionID uint32) error {
 		&si,
 		&pi,
 	); err != nil {
-		return fmt.Errorf("CreateProcessAsUser(session=%d, role=user): %w", sessionID, err)
+		return nil, fmt.Errorf("CreateProcessAsUser(session=%d, role=user): %w", sessionID, err)
 	}
 
 	windows.CloseHandle(pi.Thread)
-	windows.CloseHandle(pi.Process)
 
 	log.Info("spawned user-token helper in session",
 		"sessionId", sessionID,
@@ -171,5 +215,5 @@ func SpawnUserHelperInSession(sessionID uint32) error {
 		"exe", exePath,
 		"tokenSource", method,
 	)
-	return nil
+	return &SpawnedHelper{PID: pi.ProcessId, Handle: pi.Process}, nil
 }

--- a/agent/internal/userhelper/authenticate_test.go
+++ b/agent/internal/userhelper/authenticate_test.go
@@ -1,0 +1,191 @@
+package userhelper
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
+)
+
+// sendRejectionEnvelope sends a pre-auth reject envelope over conn using
+// ipc.Conn framing (handles HMAC + length-prefix).
+func sendRejectionEnvelope(t *testing.T, conn net.Conn, env *ipc.Envelope) {
+	t.Helper()
+	c := ipc.NewConn(conn)
+	if err := c.Send(env); err != nil {
+		t.Fatalf("sendRejectionEnvelope: %v", err)
+	}
+}
+
+// TestAuthenticate_PermanentPreAuthReject verifies that authenticate() returns
+// a *PermanentRejectError when the broker sends TypePreAuthReject{Permanent: true}.
+func TestAuthenticate_PermanentPreAuthReject(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	// Server goroutine: read one envelope (the auth request), then send back a
+	// permanent pre-auth rejection.
+	go func() {
+		srvIPC := ipc.NewConn(serverConn)
+		_, _ = srvIPC.Recv() // consume the auth_request (may error on conn close — ignore)
+
+		rej := ipc.PreAuthReject{
+			Code:      "binary_path_unknown",
+			Reason:    "binary not registered with broker",
+			Permanent: true,
+		}
+		payload, _ := json.Marshal(rej)
+		env := &ipc.Envelope{
+			Type:    ipc.TypePreAuthReject,
+			ID:      "0",
+			Payload: payload,
+		}
+		_ = srvIPC.Send(env)
+	}()
+
+	// Wire the client-side conn directly (bypass dialIPC).
+	c := New("/unused", ipc.HelperRoleSystem)
+	c.conn = ipc.NewConn(clientConn)
+
+	err := c.authenticate()
+	if err == nil {
+		t.Fatal("authenticate(): expected error, got nil")
+	}
+
+	var permErr *PermanentRejectError
+	if !errors.As(err, &permErr) {
+		t.Fatalf("authenticate(): error is %T (%v), want *PermanentRejectError", err, err)
+	}
+	if permErr.Code != "binary_path_unknown" {
+		t.Errorf("PermanentRejectError.Code = %q, want %q", permErr.Code, "binary_path_unknown")
+	}
+	if permErr.Reason != "binary not registered with broker" {
+		t.Errorf("PermanentRejectError.Reason = %q, want %q", permErr.Reason, "binary not registered with broker")
+	}
+}
+
+// TestAuthenticate_TransientPreAuthReject verifies that authenticate() returns
+// a plain (non-permanent) error when the broker sends TypePreAuthReject{Permanent: false}.
+func TestAuthenticate_TransientPreAuthReject(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	// Server goroutine: read auth request, send transient (non-permanent) rejection.
+	go func() {
+		srvIPC := ipc.NewConn(serverConn)
+		_, _ = srvIPC.Recv()
+
+		rej := ipc.PreAuthReject{
+			Code:      "rate_limited",
+			Reason:    "too many connection attempts",
+			Permanent: false,
+		}
+		payload, _ := json.Marshal(rej)
+		env := &ipc.Envelope{
+			Type:    ipc.TypePreAuthReject,
+			ID:      "0",
+			Payload: payload,
+		}
+		_ = srvIPC.Send(env)
+	}()
+
+	c := New("/unused", ipc.HelperRoleSystem)
+	c.conn = ipc.NewConn(clientConn)
+
+	err := c.authenticate()
+	if err == nil {
+		t.Fatal("authenticate(): expected error for transient rejection, got nil")
+	}
+
+	var permErr *PermanentRejectError
+	if errors.As(err, &permErr) {
+		t.Errorf("authenticate(): got *PermanentRejectError for transient rejection, want plain error")
+	}
+}
+
+// TestAuthenticate_AuthResponsePermanent verifies that authenticate() returns
+// a *PermanentRejectError when the broker sends an AuthResponse with
+// Accepted=false and Permanent=true (auth-rejected path, not pre-auth-reject).
+func TestAuthenticate_AuthResponsePermanent(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	go func() {
+		srvIPC := ipc.NewConn(serverConn)
+		_, _ = srvIPC.Recv()
+
+		resp := ipc.AuthResponse{
+			Accepted:  false,
+			Reason:    "SID mismatch",
+			Permanent: true,
+		}
+		payload, _ := json.Marshal(resp)
+		env := &ipc.Envelope{
+			Type:    ipc.TypeAuthResponse,
+			ID:      "0",
+			Payload: payload,
+		}
+		_ = srvIPC.Send(env)
+	}()
+
+	c := New("/unused", ipc.HelperRoleSystem)
+	c.conn = ipc.NewConn(clientConn)
+
+	err := c.authenticate()
+	if err == nil {
+		t.Fatal("authenticate(): expected error for permanent auth rejection, got nil")
+	}
+
+	var permErr *PermanentRejectError
+	if !errors.As(err, &permErr) {
+		t.Fatalf("authenticate(): error is %T (%v), want *PermanentRejectError", err, err)
+	}
+	if permErr.Code != "auth_rejected" {
+		t.Errorf("PermanentRejectError.Code = %q, want %q", permErr.Code, "auth_rejected")
+	}
+}
+
+// TestAuthenticate_ConnectionClosed verifies that authenticate() returns an
+// error (not panic) when the server closes the connection without sending anything.
+func TestAuthenticate_ConnectionClosed(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+
+	// Server immediately closes after reading the auth request.
+	go func() {
+		srvIPC := ipc.NewConn(serverConn)
+		_, _ = srvIPC.Recv()
+		serverConn.Close()
+	}()
+
+	c := New("/unused", ipc.HelperRoleSystem)
+	c.conn = ipc.NewConn(clientConn)
+
+	err := c.authenticate()
+	if err == nil {
+		t.Fatal("authenticate(): expected error on closed connection, got nil")
+	}
+	// The error may be EOF, closed pipe, or network error — any is acceptable.
+	// What matters is it's not a *PermanentRejectError.
+	var permErr *PermanentRejectError
+	if errors.As(err, &permErr) {
+		t.Errorf("authenticate(): got *PermanentRejectError on connection close, want plain error")
+	}
+	// Log the actual error for diagnostic purposes.
+	_ = io.EOF // imported for completeness
+	t.Logf("authenticate() returned (expected): %v", err)
+}

--- a/agent/internal/userhelper/client.go
+++ b/agent/internal/userhelper/client.go
@@ -184,9 +184,21 @@ func (c *Client) authenticate() error {
 	uid, err := strconv.ParseUint(cu.Uid, 10, 32)
 	var sid string
 	if err != nil {
-		// On Windows, cu.Uid is the SID string (e.g., "S-1-5-21-...")
+		// On Windows, cu.Uid is the SID string (e.g., "S-1-5-21-...").
+		// When the process was spawned cross-session via CreateProcessAsUser,
+		// the first user.Current() call can occasionally return an
+		// empty/malformed Uid while the duplicated token finishes
+		// materializing in the kernel. Retry with backoff, and treat
+		// a permanent failure as fatal so the lifecycle manager can back off.
 		uid = 0
 		sid = cu.Uid
+		if runtime.GOOS == "windows" && !looksLikeSID(sid) {
+			retrySID, retryErr := lookupSIDWithRetry()
+			if retryErr != nil {
+				return retryErr
+			}
+			sid = retrySID
+		}
 	}
 
 	binaryHash, _ := computeSelfHash()

--- a/agent/internal/userhelper/client.go
+++ b/agent/internal/userhelper/client.go
@@ -54,6 +54,27 @@ type Client struct {
 	pendingMu  sync.Mutex
 	pending    map[string]chan *ipc.Envelope
 	sasReqSeq  atomic.Uint64
+
+	// authenticatedAt is set when the broker accepts the helper. Zero when
+	// the client has never completed auth on this Run(). Reset on each Run().
+	authMu          sync.RWMutex
+	authenticatedAt time.Time
+}
+
+// AuthenticatedAt returns the time at which the helper completed auth with
+// the broker on the most recent Run(). Returns the zero time if the client
+// never successfully authenticated.
+func (c *Client) AuthenticatedAt() time.Time {
+	c.authMu.RLock()
+	defer c.authMu.RUnlock()
+	return c.authenticatedAt
+}
+
+// setAuthenticatedAt records the moment auth completed.
+func (c *Client) setAuthenticatedAt(t time.Time) {
+	c.authMu.Lock()
+	c.authenticatedAt = t
+	c.authMu.Unlock()
 }
 
 // New creates a new user helper client with the given role.
@@ -219,6 +240,7 @@ func (c *Client) authenticate() error {
 	c.sessionKey = key
 	c.agentID = authResp.AgentID
 	c.scopes = authResp.AllowedScopes
+	c.setAuthenticatedAt(time.Now())
 
 	return nil
 }

--- a/agent/internal/userhelper/client.go
+++ b/agent/internal/userhelper/client.go
@@ -224,10 +224,22 @@ func (c *Client) authenticate() error {
 		return fmt.Errorf("send auth request: %w", err)
 	}
 
-	// Read auth response
+	// Read auth response (or pre-auth reject, if the broker bounced us
+	// before reading our auth request).
 	env, err := c.conn.Recv()
 	if err != nil {
 		return fmt.Errorf("recv auth response: %w", err)
+	}
+
+	if env.Type == ipc.TypePreAuthReject {
+		var rej ipc.PreAuthReject
+		if err := json.Unmarshal(env.Payload, &rej); err != nil {
+			return fmt.Errorf("unmarshal pre_auth_reject: %w", err)
+		}
+		if rej.Permanent {
+			return &PermanentRejectError{Code: rej.Code, Reason: rej.Reason}
+		}
+		return fmt.Errorf("broker pre-auth reject: %s (%s)", rej.Reason, rej.Code)
 	}
 
 	if env.Type != ipc.TypeAuthResponse {
@@ -240,6 +252,9 @@ func (c *Client) authenticate() error {
 	}
 
 	if !authResp.Accepted {
+		if authResp.Permanent {
+			return &PermanentRejectError{Code: "auth_rejected", Reason: authResp.Reason}
+		}
 		return fmt.Errorf("auth rejected: %s", authResp.Reason)
 	}
 

--- a/agent/internal/userhelper/errors.go
+++ b/agent/internal/userhelper/errors.go
@@ -1,0 +1,62 @@
+package userhelper
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// looksLikeSID returns true if s is plausibly a Windows SID string.
+// Shape check only — does not validate semantics.
+func looksLikeSID(s string) bool {
+	return strings.HasPrefix(s, "S-1-") && len(s) >= 7
+}
+
+// ErrSIDLookupFailed is returned when the Windows SID for the current
+// process token cannot be determined after several retries. This usually
+// indicates a cross-session process spawn (CreateProcessAsUser) where the
+// freshly-duplicated token has not yet been fully materialized by the kernel.
+// Treated as fatal by the reconnect loop — the helper exits with code 2 so
+// the lifecycle manager can back off.
+var ErrSIDLookupFailed = errors.New("userhelper: failed to determine Windows SID after retries")
+
+// PermanentRejectError is returned by Client.Run when the broker has
+// permanently rejected the helper's identity. The reconnect loop treats this
+// as fatal: the helper process exits with code 2 and the lifecycle manager
+// skips respawn for a cooldown period.
+//
+// Fields:
+//   - Code: machine-readable reason (e.g. "binary_path_unknown", "sid_mismatch")
+//   - Reason: human-readable explanation from the broker
+type PermanentRejectError struct {
+	Code   string
+	Reason string
+}
+
+func (e *PermanentRejectError) Error() string {
+	if e == nil {
+		return "permanent reject"
+	}
+	if e.Code == "" {
+		return fmt.Sprintf("broker permanently rejected helper: %s", e.Reason)
+	}
+	return fmt.Sprintf("broker permanently rejected helper: %s (%s)", e.Reason, e.Code)
+}
+
+// CodeOr returns the code, or the fallback if this error is nil or the code
+// is empty. Convenient for logging without having to nil-check.
+func (e *PermanentRejectError) CodeOr(fallback string) string {
+	if e == nil || e.Code == "" {
+		return fallback
+	}
+	return e.Code
+}
+
+// ReasonOr returns the reason, or the fallback if this error is nil or the
+// reason is empty.
+func (e *PermanentRejectError) ReasonOr(fallback string) string {
+	if e == nil || e.Reason == "" {
+		return fallback
+	}
+	return e.Reason
+}

--- a/agent/internal/userhelper/errors_test.go
+++ b/agent/internal/userhelper/errors_test.go
@@ -1,0 +1,285 @@
+package userhelper
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// PermanentRejectError tests
+// ---------------------------------------------------------------------------
+
+func TestPermanentRejectError_Error(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		err    *PermanentRejectError
+		want   string
+	}{
+		{
+			name:  "nil receiver returns sentinel string",
+			err:   nil,
+			want:  "permanent reject",
+		},
+		{
+			name:  "both Code and Reason set — includes both",
+			err:   &PermanentRejectError{Code: "binary_path_unknown", Reason: "binary path not registered"},
+			want:  "broker permanently rejected helper: binary path not registered (binary_path_unknown)",
+		},
+		{
+			name:  "empty Code — omits Code from output",
+			err:   &PermanentRejectError{Code: "", Reason: "some reason"},
+			want:  "broker permanently rejected helper: some reason",
+		},
+		{
+			name:  "empty Reason with Code — only Reason branch, shows empty reason",
+			err:   &PermanentRejectError{Code: "sid_mismatch", Reason: ""},
+			want:  "broker permanently rejected helper:  (sid_mismatch)",
+		},
+		{
+			name:  "both empty — shows empty reason, no code",
+			err:   &PermanentRejectError{Code: "", Reason: ""},
+			want:  "broker permanently rejected helper: ",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.err.Error()
+			if got != tc.want {
+				t.Errorf("Error() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPermanentRejectError_CodeOr(t *testing.T) {
+	t.Parallel()
+
+	fallback := "fallback_code"
+
+	tests := []struct {
+		name string
+		err  *PermanentRejectError
+		want string
+	}{
+		{
+			name: "nil receiver returns fallback",
+			err:  nil,
+			want: fallback,
+		},
+		{
+			name: "non-empty Code returns Code",
+			err:  &PermanentRejectError{Code: "binary_path_unknown"},
+			want: "binary_path_unknown",
+		},
+		{
+			name: "empty Code returns fallback",
+			err:  &PermanentRejectError{Code: ""},
+			want: fallback,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.err.CodeOr(fallback)
+			if got != tc.want {
+				t.Errorf("CodeOr(%q) = %q, want %q", fallback, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPermanentRejectError_ReasonOr(t *testing.T) {
+	t.Parallel()
+
+	fallback := "fallback_reason"
+
+	tests := []struct {
+		name string
+		err  *PermanentRejectError
+		want string
+	}{
+		{
+			name: "nil receiver returns fallback",
+			err:  nil,
+			want: fallback,
+		},
+		{
+			name: "non-empty Reason returns Reason",
+			err:  &PermanentRejectError{Reason: "binary path not registered"},
+			want: "binary path not registered",
+		},
+		{
+			name: "empty Reason returns fallback",
+			err:  &PermanentRejectError{Reason: ""},
+			want: fallback,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.err.ReasonOr(fallback)
+			if got != tc.want {
+				t.Errorf("ReasonOr(%q) = %q, want %q", fallback, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPermanentRejectError_ErrorsIs verifies that PermanentRejectError does NOT
+// implement errors.Is sentinel matching (it has no Is() method and is a pointer
+// type, so errors.Is only matches if the exact same pointer is used).
+func TestPermanentRejectError_ErrorsIs(t *testing.T) {
+	t.Parallel()
+
+	err1 := &PermanentRejectError{Code: "sid_mismatch", Reason: "SID mismatch"}
+	err2 := &PermanentRejectError{Code: "sid_mismatch", Reason: "SID mismatch"}
+
+	// Different pointers with same content — errors.Is should NOT match.
+	if errors.Is(err1, err2) {
+		t.Error("errors.Is(err1, err2): expected false for different pointers, got true")
+	}
+
+	// Same pointer — should match.
+	if !errors.Is(err1, err1) {
+		t.Error("errors.Is(err1, err1): expected true for same pointer, got false")
+	}
+}
+
+// TestPermanentRejectError_ErrorsAs verifies that errors.As correctly extracts
+// a *PermanentRejectError through a wrapping chain.
+func TestPermanentRejectError_ErrorsAs(t *testing.T) {
+	t.Parallel()
+
+	perm := &PermanentRejectError{Code: "binary_path_unknown", Reason: "test rejection"}
+	wrapped := fmt.Errorf("outer: %w", perm)
+
+	var target *PermanentRejectError
+	if !errors.As(wrapped, &target) {
+		t.Fatal("errors.As(wrapped, &target): expected true, got false")
+	}
+	if target.Code != perm.Code {
+		t.Errorf("extracted Code = %q, want %q", target.Code, perm.Code)
+	}
+	if target.Reason != perm.Reason {
+		t.Errorf("extracted Reason = %q, want %q", target.Reason, perm.Reason)
+	}
+}
+
+// TestPermanentRejectError_IsError verifies that *PermanentRejectError satisfies
+// the error interface (compile-time check via assignment).
+func TestPermanentRejectError_IsError(t *testing.T) {
+	t.Parallel()
+
+	var _ error = &PermanentRejectError{Code: "test", Reason: "test"}
+}
+
+// ---------------------------------------------------------------------------
+// looksLikeSID tests
+// ---------------------------------------------------------------------------
+
+func TestLooksLikeSID(t *testing.T) {
+	t.Parallel()
+
+	// looksLikeSID returns true when: strings.HasPrefix(s, "S-1-") && len(s) >= 7
+	// "S-1-" is 4 chars; min valid = "S-1-" + 3 more chars → len 7.
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			// Typical Windows user SID.
+			name:  "valid full SID",
+			input: "S-1-5-21-123-456-789-1000",
+			want:  true,
+		},
+		{
+			// Minimum length that satisfies both conditions: "S-1-5-6" = 7 chars.
+			// HasPrefix("S-1-") = true, len = 7 >= 7.
+			name:  "minimum valid length (7 chars)",
+			input: "S-1-5-6",
+			want:  true,
+		},
+		{
+			// Length exactly 7, starts with "S-1-".
+			name:  "minimum with different suffix",
+			input: "S-1-xxx",
+			want:  true,
+		},
+		{
+			// Length 8 — above minimum, correct prefix.
+			name:  "length 8 valid",
+			input: "S-1-5-18",
+			want:  true,
+		},
+		{
+			// Empty string.
+			name:  "empty string",
+			input: "",
+			want:  false,
+		},
+		{
+			// "S-1-" alone is 4 chars — fails len >= 7.
+			name:  "prefix only (len 4)",
+			input: "S-1-",
+			want:  false,
+		},
+		{
+			// "S-1-5" is 5 chars — fails len >= 7.
+			name:  "5 chars",
+			input: "S-1-5",
+			want:  false,
+		},
+		{
+			// "S-1-55" is 6 chars — fails len >= 7.
+			name:  "6 chars (one short of minimum)",
+			input: "S-1-55",
+			want:  false,
+		},
+		{
+			// Wrong first digit — "S-2-" is not the "S-1-" prefix.
+			name:  "wrong SID revision (S-2-)",
+			input: "S-2-5-21-123-456-789-1000",
+			want:  false,
+		},
+		{
+			// Completely wrong format.
+			name:  "random non-SID string",
+			input: "random-not-a-sid",
+			want:  false,
+		},
+		{
+			// Close but wrong: missing the dash before the revision number.
+			name:  "malformed prefix S-15-",
+			input: "S-15-21-123-456-789-1000",
+			want:  false,
+		},
+		{
+			// Lowercase prefix — should not match (case-sensitive).
+			name:  "lowercase s-1- prefix",
+			input: "s-1-5-21-123",
+			want:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := looksLikeSID(tc.input)
+			if got != tc.want {
+				t.Errorf("looksLikeSID(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/agent/internal/userhelper/sid_other.go
+++ b/agent/internal/userhelper/sid_other.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package userhelper
+
+// lookupSIDWithRetry is a no-op on non-Windows platforms: there's no SID on
+// Unix. Callers should use the UID from user.Current() directly instead.
+// Kept to satisfy cross-platform calling code without build tags at the
+// call site.
+func lookupSIDWithRetry() (string, error) {
+	return "", nil
+}

--- a/agent/internal/userhelper/sid_windows.go
+++ b/agent/internal/userhelper/sid_windows.go
@@ -1,0 +1,53 @@
+//go:build windows
+
+package userhelper
+
+import (
+	"fmt"
+	"os/user"
+	"time"
+)
+
+// lookupSIDWithRetry returns the current process's SID as a string, retrying
+// with backoff if the token isn't fully materialized yet. Freshly-spawned
+// helpers (CreateProcessAsUser from a different session) can observe an
+// empty/malformed SID for the first few hundred ms while the kernel finishes
+// setting up the duplicated token.
+//
+// Backoff schedule: 100ms, 250ms, 500ms, 1s — total < 2s.
+func lookupSIDWithRetry() (string, error) {
+	delays := []time.Duration{0, 100 * time.Millisecond, 250 * time.Millisecond, 500 * time.Millisecond, 1 * time.Second}
+
+	var lastErr error
+	for i, d := range delays {
+		if d > 0 {
+			time.Sleep(d)
+		}
+		cu, err := user.Current()
+		if err != nil {
+			lastErr = err
+			log.Warn("SID lookup: user.Current failed",
+				"attempt", i+1,
+				"error", err.Error(),
+			)
+			continue
+		}
+		// On Windows, cu.Uid is the SID string: "S-1-5-..."
+		if looksLikeSID(cu.Uid) {
+			if i > 0 {
+				log.Info("SID lookup: succeeded after retries", "attempts", i+1, "sid", cu.Uid)
+			}
+			return cu.Uid, nil
+		}
+		lastErr = fmt.Errorf("user.Current returned non-SID Uid %q", cu.Uid)
+		log.Warn("SID lookup: Uid not SID-shaped",
+			"attempt", i+1,
+			"uid", cu.Uid,
+		)
+	}
+	if lastErr == nil {
+		lastErr = ErrSIDLookupFailed
+	}
+	return "", fmt.Errorf("%w: last error: %v", ErrSIDLookupFailed, lastErr)
+}
+


### PR DESCRIPTION
Fixes #387 (parts C, D, E, A, B, F — part G deferred to a follow-up PR).

## Summary

Addresses the production headless-Windows-Server reconnect storm
documented in #387. Six layered fixes that together stop the helper
from thrashing when the broker rejects auth, and stop the broker
from silently dropping socket connections.

**Part C — reconnect loop hardening** (`agent/cmd/breeze-agent/main.go`,
`agent/internal/userhelper/client.go`)
- Raised `helperMinBackoff` from 2s to 30s (cap to 5m).
- Added `[0, backoff/2)` jitter so concurrent helpers don't sync.
- Fixed the backoff-reset bug: only resets after the helper was
  authenticated and stable for >60s, not when the loop iteration ran
  longer than 30s.
- Rate-limited the `helper disconnected, reconnecting` warning:
  3 WARNs per 5-minute window, then a single INFO with suppressed
  count.
- New `Client.AuthenticatedAt()` getter so the loop can tell
  "rejected-fast" from "stably-connected" iterations.

**Part D — Windows binary path verification**
(`agent/internal/sessionbroker/broker.go` + new
`broker_path_windows.go` / `broker_path_other.go`)
- Reordered `handleConnection` so the auth request is read before the
  binary path check. The hash from `AuthRequest.BinaryHash` is now the
  authoritative identity signal; the path check becomes a secondary
  signal logged at DEBUG on mismatch.
- Added `normalizeBinaryPath` (Windows: `GetLongPathName` + lowercase;
  no-op elsewhere) so 8.3 short names and case differences don't cause
  spurious path mismatches on the happy path.

**Part E — SID retry in helper auth**
(`agent/internal/userhelper/sid_windows.go`, `sid_other.go`,
`errors.go`, `client.go`)
- New `lookupSIDWithRetry` with backoff 100ms, 250ms, 500ms, 1s
  (4 attempts, <2s total).
- New `ErrSIDLookupFailed` sentinel — propagated up from the auth
  construction and treated as fatal by the reconnect loop.
- New `PermanentRejectError` typed error introduced in this commit
  for the Part B wiring.

**Part A — broker sends explicit pre-auth rejection messages**
(`agent/internal/ipc/message.go`, `agent/internal/sessionbroker/broker.go`)
- New `TypePreAuthReject` envelope + `PreAuthReject` payload with
  machine-readable `Code`, human-readable `Reason`, and `Permanent`
  flag. Codes: `rate_limited`, `max_conns_exceeded`,
  `binary_path_unknown`, `cred_check_failed`.
- The 4 previously-silent close paths (peer-cred fail, rate limit, max
  conns, binary path unknown) now send a `PreAuthReject` with a 2s
  write deadline before closing.
- `AuthResponse` gains a `Permanent` field. Set to true for protocol
  version mismatch, SID/UID mismatch, missing SID, binary hash
  mismatch, role/identity mismatch, and hash allowlist unavailable.

**Part B — helper interprets rejection and exits fatal**
(`agent/internal/userhelper/client.go`, `agent/cmd/breeze-agent/main.go`)
- `authenticate()` handles `TypePreAuthReject`: returns
  `*PermanentRejectError` if `Permanent=true`, otherwise a generic
  retryable error.
- `authenticate()` honours `AuthResponse.Permanent`: returns
  `*PermanentRejectError` on match.
- `runHelperProcess` uses `errors.As` to catch `*PermanentRejectError`
  and `errors.Is` to catch `ErrSIDLookupFailed`. On match: logs a
  single ERROR, sleeps 1s to flush logs, calls `os.Exit(2)`.

**Part F — lifecycle manager honors fatal exit code**
(`agent/internal/sessionbroker/spawner_windows.go`, `spawner_stub.go`,
`lifecycle.go`, `agent/internal/heartbeat/handlers_desktop_helper.go`)
- `SpawnHelperInSession` and `SpawnUserHelperInSession` now return a
  `*SpawnedHelper` struct (`PID`, `Handle`). The Windows process
  handle is duplicated by `CreateProcessAsUser` and kept so callers
  can `Wait()` on it.
- `SpawnedHelper.Wait()` blocks on the process, reads the exit code
  via `GetExitCodeProcess`, and releases the handle.
- `trackedSession` gains `fatalExitUntil`. `spawnWithRetry` skips
  spawning when `now < fatalExitUntil`.
- After a successful spawn, a `watchHelperExit` goroutine waits on
  the child: exit code 2 sets `fatalExitUntil = now + 10 minutes`
  and logs a WARN; other codes log at DEBUG.
- `handleSCMEvent` clears `fatalExitUntil` on SESSION_LOGON /
  UNLOCK / CREATE — a session change means the environment changed
  and is worth retrying.
- The heartbeat's one-off helper spawn path (not the lifecycle
  manager's canonical path) calls `Close()` immediately on the
  returned handle.

## Not in this PR

- **Part G — heartbeat starvation.** The parent agent stops
  heartbeating when the helper subsystem thrashes. Hypothesis
  (broker mutex contention with `FindCapableSession`) is documented
  in #387 but the fix is deferred to a follow-up PR to keep this one
  reviewable.

## Test plan

- [x] `go build ./...` (darwin/arm64): clean
- [x] `GOOS=windows go build ./...`: clean
- [x] `GOOS=linux GOARCH=amd64 go build ./...`: clean
- [x] `GOOS=darwin GOARCH=amd64 go build ./...`: clean
- [x] `go vet ./...`: clean
- [x] `go test -race ./...`: all packages pass
  (sessionbroker, ipc, userhelper, heartbeat, cmd/... incl.)
- [ ] Manual repro on a headless Windows Server VPS once agent build
      is signed and installable — verify no reconnect storm after 60s
      uptime and no more than 3 "helper disconnected" warnings in logs
- [ ] Regression check on a Windows 11 workstation — verify remote
      desktop still starts on first click (no regression from the
      reconnect-loop changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)