### PR TITLE
fix(agent): heartbeat starvation instrumentation + atomic session snapshot (#387, Part G)

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -201,6 +201,11 @@ type Heartbeat struct {
 
 	// Path to the agent state file, set by main after startup.
 	statePath string
+
+	// sendHeartbeatFn is an optional override used by tests to replace the
+	// real sendHeartbeat call inside sendHeartbeatWithWatchdog. nil in
+	// production — the real sendHeartbeat method is invoked.
+	sendHeartbeatFn func()
 }
 
 func New(cfg *config.Config) *Heartbeat {
@@ -1826,41 +1831,82 @@ func (h *Heartbeat) sendReliabilityMetrics() {
 		"hardwareErrors", len(metrics.HardwareErrors))
 }
 
-// sendHeartbeatWithWatchdog wraps sendHeartbeat with a 15-second watchdog that
-// dumps all goroutine stacks if the call blocks. This instruments the heartbeat
-// starvation symptom described in issue #387: the heartbeat loop can block
-// indefinitely waiting on broker mutex reads while the reconnect storm holds
-// write locks.
+// heartbeatWatchdogTimeoutNs is the duration (in nanoseconds) after which
+// sendHeartbeatWithWatchdog dumps all goroutine stacks if the wrapped send
+// has not returned. Stored as an int64 via sync/atomic so tests can override
+// it from another goroutine without tripping -race. Production default is
+// 15s; tests may shorten it via setHeartbeatWatchdogTimeout().
+var heartbeatWatchdogTimeoutNs atomic.Int64
+
+func init() {
+	heartbeatWatchdogTimeoutNs.Store(int64(15 * time.Second))
+}
+
+// heartbeatWatchdogTimeout returns the current watchdog timeout as a duration.
+func heartbeatWatchdogTimeout() time.Duration {
+	return time.Duration(heartbeatWatchdogTimeoutNs.Load())
+}
+
+// setHeartbeatWatchdogTimeout overrides the watchdog timeout and returns the
+// previous value. Intended for tests — production code should leave the
+// default alone.
+func setHeartbeatWatchdogTimeout(d time.Duration) time.Duration {
+	return time.Duration(heartbeatWatchdogTimeoutNs.Swap(int64(d)))
+}
+
+// sendHeartbeatFn is the function invoked inside sendHeartbeatWithWatchdog.
+// Tests may replace it via the sendHeartbeatFn field on *Heartbeat to inject
+// a blocking/fast implementation without spawning a real HTTP client.
+// In production it's always h.sendHeartbeat.
+func (h *Heartbeat) runHeartbeat() {
+	if fn := h.sendHeartbeatFn; fn != nil {
+		fn()
+		return
+	}
+	h.sendHeartbeat()
+}
+
+// sendHeartbeatWithWatchdog wraps sendHeartbeat with a watchdog that dumps all
+// goroutine stacks if the call blocks longer than heartbeatWatchdogTimeout.
+// This instruments the heartbeat starvation symptom described in issue #387:
+// the heartbeat loop can block indefinitely waiting on broker mutex reads
+// while the reconnect storm holds write locks.
+//
+// `done` is closed via defer so that a panic in sendHeartbeat still cancels
+// the watchdog instead of letting it fire a misleading "exceeded" warning.
 func (h *Heartbeat) sendHeartbeatWithWatchdog() {
 	start := time.Now()
+	// Snapshot the current timeout into a local so any test that overrides
+	// heartbeatWatchdogTimeoutNs after this call returns cannot race with
+	// the watchdog goroutine.
+	timeout := heartbeatWatchdogTimeout()
 	done := make(chan struct{})
-	var dumpOnce sync.Once
+	defer close(done)
 
 	go func() {
-		const watchdogTimeout = 15 * time.Second
 		const maxDumpBytes = 100 * 1024 // 100 KB cap to avoid log storm
 
+		// The select fires at most once per invocation, so sync.Once is
+		// unnecessary — a plain select is sufficient.
 		select {
 		case <-done:
 			// Normal return — watchdog cancelled.
-		case <-time.After(watchdogTimeout):
-			dumpOnce.Do(func() {
-				buf := make([]byte, 1<<20) // 1 MiB stack buffer
-				n := runtime.Stack(buf, true)
-				dump := string(buf[:n])
-				if len(dump) > maxDumpBytes {
-					dump = dump[:maxDumpBytes] + "\n... [truncated]"
-				}
-				log.Warn("heartbeat send exceeded 15s — dumping goroutine stacks",
-					"elapsed_ms", time.Since(start).Milliseconds(),
-					"goroutines", dump)
-			})
+		case <-time.After(timeout):
+			buf := make([]byte, 1<<20) // 1 MiB stack buffer
+			n := runtime.Stack(buf, true)
+			dump := string(buf[:n])
+			if len(dump) > maxDumpBytes {
+				dump = dump[:maxDumpBytes] + "\n... [truncated]"
+			}
+			log.Warn("heartbeat send exceeded watchdog timeout — dumping goroutine stacks",
+				"elapsed_ms", time.Since(start).Milliseconds(),
+				"timeout_ms", timeout.Milliseconds(),
+				"goroutines", dump)
 		}
 	}()
 
-	h.sendHeartbeat()
+	h.runHeartbeat()
 
-	close(done)
 	log.Debug("heartbeat sent", "duration_ms", time.Since(start).Milliseconds())
 }
 

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -670,7 +670,7 @@ func (h *Heartbeat) Start() {
 	var lastBootCheck time.Time
 
 	// Send initial heartbeat after jitter
-	h.sendHeartbeat()
+	h.sendHeartbeatWithWatchdog()
 
 	// Send initial inventory in background
 	go h.sendInventory()
@@ -683,7 +683,7 @@ func (h *Heartbeat) Start() {
 	for {
 		select {
 		case <-ticker.C:
-			h.sendHeartbeat()
+			h.sendHeartbeatWithWatchdog()
 			now := time.Now()
 			// Send inventory every 15 minutes
 			h.mu.Lock()
@@ -1824,6 +1824,44 @@ func (h *Heartbeat) sendReliabilityMetrics() {
 		"hangs", len(metrics.AppHangs),
 		"serviceFailures", len(metrics.ServiceFailures),
 		"hardwareErrors", len(metrics.HardwareErrors))
+}
+
+// sendHeartbeatWithWatchdog wraps sendHeartbeat with a 15-second watchdog that
+// dumps all goroutine stacks if the call blocks. This instruments the heartbeat
+// starvation symptom described in issue #387: the heartbeat loop can block
+// indefinitely waiting on broker mutex reads while the reconnect storm holds
+// write locks.
+func (h *Heartbeat) sendHeartbeatWithWatchdog() {
+	start := time.Now()
+	done := make(chan struct{})
+	var dumpOnce sync.Once
+
+	go func() {
+		const watchdogTimeout = 15 * time.Second
+		const maxDumpBytes = 100 * 1024 // 100 KB cap to avoid log storm
+
+		select {
+		case <-done:
+			// Normal return — watchdog cancelled.
+		case <-time.After(watchdogTimeout):
+			dumpOnce.Do(func() {
+				buf := make([]byte, 1<<20) // 1 MiB stack buffer
+				n := runtime.Stack(buf, true)
+				dump := string(buf[:n])
+				if len(dump) > maxDumpBytes {
+					dump = dump[:maxDumpBytes] + "\n... [truncated]"
+				}
+				log.Warn("heartbeat send exceeded 15s — dumping goroutine stacks",
+					"elapsed_ms", time.Since(start).Milliseconds(),
+					"goroutines", dump)
+			})
+		}
+	}()
+
+	h.sendHeartbeat()
+
+	close(done)
+	log.Debug("heartbeat sent", "duration_ms", time.Since(start).Milliseconds())
 }
 
 func (h *Heartbeat) sendHeartbeat() {

--- a/agent/internal/heartbeat/heartbeat_watchdog_test.go
+++ b/agent/internal/heartbeat/heartbeat_watchdog_test.go
@@ -1,0 +1,134 @@
+package heartbeat
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/logging"
+)
+
+// syncBuffer is a goroutine-safe wrapper around bytes.Buffer for concurrent
+// writers (the test goroutine and the watchdog goroutine both emit logs).
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// watchdogTestHarness installs a tiny heartbeatWatchdogTimeout and redirects
+// the logger into a buffer. Everything is restored via t.Cleanup.
+func watchdogTestHarness(t *testing.T, timeout time.Duration) *syncBuffer {
+	t.Helper()
+	prev := setHeartbeatWatchdogTimeout(timeout)
+	t.Cleanup(func() { setHeartbeatWatchdogTimeout(prev) })
+
+	buf := &syncBuffer{}
+	logging.Init("text", "debug", buf)
+	t.Cleanup(func() { logging.Init("text", "info", nil) })
+	return buf
+}
+
+// TestSendHeartbeatWatchdogFiresWhenBlocked verifies that a sendHeartbeat
+// impl that blocks longer than heartbeatWatchdogTimeout causes the watchdog
+// to log a stack dump.
+func TestSendHeartbeatWatchdogFiresWhenBlocked(t *testing.T) {
+	buf := watchdogTestHarness(t, 50*time.Millisecond)
+
+	release := make(chan struct{})
+	started := make(chan struct{})
+	var once sync.Once
+
+	h := &Heartbeat{
+		sendHeartbeatFn: func() {
+			once.Do(func() { close(started) })
+			<-release
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		h.sendHeartbeatWithWatchdog()
+		close(done)
+	}()
+
+	<-started
+	// Wait well past the 50ms watchdog timeout so the goroutine-dump warn fires.
+	time.Sleep(150 * time.Millisecond)
+	close(release)
+	<-done
+
+	output := buf.String()
+	if !strings.Contains(output, "heartbeat send exceeded watchdog timeout") {
+		t.Fatalf("expected watchdog warning, got:\n%s", output)
+	}
+	if !strings.Contains(output, "goroutines=") {
+		t.Fatalf("expected goroutines= stack-dump field, got:\n%s", output)
+	}
+}
+
+// TestSendHeartbeatWatchdogDoesNotFireOnFastPath verifies that a
+// sendHeartbeat that returns quickly does NOT trip the watchdog warning.
+func TestSendHeartbeatWatchdogDoesNotFireOnFastPath(t *testing.T) {
+	buf := watchdogTestHarness(t, 100*time.Millisecond)
+
+	h := &Heartbeat{
+		sendHeartbeatFn: func() {
+			// Return immediately.
+		},
+	}
+
+	h.sendHeartbeatWithWatchdog()
+
+	// Give any late-firing watchdog goroutine a chance to warn (it should NOT).
+	time.Sleep(250 * time.Millisecond)
+
+	if strings.Contains(buf.String(), "heartbeat send exceeded watchdog timeout") {
+		t.Fatalf("watchdog should not fire on fast path, got:\n%s", buf.String())
+	}
+}
+
+// TestSendHeartbeatWatchdogCancelsOnPanic verifies that a panic inside
+// sendHeartbeat still closes the watchdog done channel via the deferred
+// close(done), so the watchdog goroutine does not emit a misleading
+// "exceeded" warning after the wrapper unwinds the panic.
+func TestSendHeartbeatWatchdogCancelsOnPanic(t *testing.T) {
+	buf := watchdogTestHarness(t, 50*time.Millisecond)
+
+	h := &Heartbeat{
+		sendHeartbeatFn: func() {
+			panic("intentional test panic")
+		},
+	}
+
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("expected panic to propagate out of watchdog wrapper")
+			}
+		}()
+		h.sendHeartbeatWithWatchdog()
+	}()
+
+	// Wait longer than the watchdog timeout. The deferred close(done) must
+	// have fired as the panic unwound, so no warning should be emitted.
+	time.Sleep(150 * time.Millisecond)
+
+	if strings.Contains(buf.String(), "heartbeat send exceeded watchdog timeout") {
+		t.Fatalf("watchdog fired after panic unwound; deferred close(done) must cancel it:\n%s",
+			buf.String())
+	}
+}

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -14,24 +14,67 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
-
 	"sync/atomic"
+	"time"
 
 	"github.com/breeze-rmm/agent/internal/backupipc"
 	"github.com/breeze-rmm/agent/internal/ipc"
 )
 
-// timedRWMutex wraps sync.RWMutex and logs a warning when Lock or RLock
-// acquisition takes longer than 1 second. This instruments the heartbeat
-// starvation symptom in issue #387: a reconnect storm generating many
-// removeSession write-locks can starve heartbeat read-path callers.
+// slowLockThresholdNs is the duration (in nanoseconds, via sync/atomic) above
+// which a broker lock acquisition wait OR a broker write-lock hold triggers a
+// WARN log. Atomic storage lets tests safely override it from other
+// goroutines without tripping -race. Production default is 1s.
+var slowLockThresholdNs atomic.Int64
+
+func init() {
+	slowLockThresholdNs.Store(int64(time.Second))
+}
+
+// slowLockThreshold returns the current threshold as a duration.
+func slowLockThreshold() time.Duration {
+	return time.Duration(slowLockThresholdNs.Load())
+}
+
+// setSlowLockThreshold overrides the threshold and returns the previous
+// value. Intended for tests — production code should leave the default alone.
+func setSlowLockThreshold(d time.Duration) time.Duration {
+	return time.Duration(slowLockThresholdNs.Swap(int64(d)))
+}
+
+// timedRWMutex wraps sync.RWMutex and logs a warning when:
+//  1. Lock or RLock acquisition waits longer than slowLockThreshold (a sign
+//     of contention on the broker).
+//  2. A write-lock (Lock) is HELD longer than slowLockThreshold. Long write
+//     holds under contention are the direct starvation cause described in
+//     issue #387 — e.g. handleConnection holding b.mu.Lock() across a
+//     15-second SendCommandAndWait while heartbeat readers pile up.
+//
+// Read-lock HOLD time is not instrumented. A single `acquiredAt` field cannot
+// safely track multiple concurrent RLock holders, and the alternatives
+// (goroutine-ID maps, returning tokens from RLock, atomic pointers) either
+// race or uglify the API. In this broker, RLock holders never perform
+// long-blocking work — the starvation bug is caused by WRITE-lock holders —
+// so instrumenting Lock holds alone captures the dangerous class of bug.
 //
 // The wrapper uses runtime.Callers to automatically identify the calling
 // function — no changes are required at individual call sites.
+//
+// Do not copy by value: the embedded RWMutex and acquiredAt timestamp are
+// stateful and must be accessed via pointer.
 type timedRWMutex struct {
-	mu sync.RWMutex
+	_          noCopy
+	mu         sync.RWMutex
+	acquiredAt time.Time // only valid while write lock is held; read only in Unlock
 }
+
+// noCopy may be embedded into structs which must not be copied after the first
+// use. See https://golang.org/issues/8005#issuecomment-190753527 — `go vet`
+// recognises this pattern.
+type noCopy struct{}
+
+func (*noCopy) Lock()   {}
+func (*noCopy) Unlock() {}
 
 func callerName(skip int) string {
 	var pcs [3]uintptr
@@ -41,36 +84,66 @@ func callerName(skip int) string {
 	}
 	frames := runtime.CallersFrames(pcs[:n])
 	f, _ := frames.Next()
-	// Trim package prefix for brevity: "sessionbroker.(*Broker).handleConnection"
-	// → "handleConnection"
 	name := f.Function
-	if i := strings.LastIndexByte(name, '.'); i >= 0 {
-		name = name[i+1:]
+	// Strip the package prefix ("sessionbroker/broker.Foo" → "Foo"). Use the
+	// last '/' to locate the final path segment, then the first '.' inside
+	// that segment to skip the package name. Everything after is the
+	// method/function name (possibly with receiver and suffixes).
+	if slash := strings.LastIndexByte(name, '/'); slash >= 0 {
+		name = name[slash+1:]
 	}
-	// Strip go method closure suffixes like "func1"
+	if dot := strings.IndexByte(name, '.'); dot >= 0 {
+		name = name[dot+1:]
+	}
+	// Strip receiver: "(*Broker).handleConnection" → "handleConnection"
+	if close := strings.LastIndexByte(name, ')'); close >= 0 && close+1 < len(name) && name[close+1] == '.' {
+		name = name[close+2:]
+	}
+	// Strip method-value ("-fm") and closure ("-func1") suffixes introduced by
+	// the compiler.
 	if i := strings.IndexByte(name, '-'); i >= 0 {
+		name = name[:i]
+	}
+	// Strip nested closure suffixes ("handleConnection.func1" → "handleConnection").
+	// The compiler uses '.' as the closure separator on nested anonymous funcs.
+	if i := strings.IndexByte(name, '.'); i >= 0 {
 		name = name[:i]
 	}
 	return name
 }
 
 func (t *timedRWMutex) Lock() {
+	// Snapshot threshold once so the warn comparisons inside Lock and Unlock
+	// see a consistent value even if a test overrides it mid-call.
+	threshold := slowLockThreshold()
 	start := time.Now()
 	t.mu.Lock()
-	if waited := time.Since(start); waited > time.Second {
+	if waited := time.Since(start); waited > threshold {
 		log.Warn("broker write-lock acquisition slow",
 			"op", "Lock", "caller", callerName(1), "waited_ms", waited.Milliseconds())
 	}
+	// Record hold-start timestamp. Safe without additional sync: exactly one
+	// writer holds the lock at a time, and the field is only read in Unlock
+	// (also under the exclusive lock).
+	t.acquiredAt = time.Now()
 }
 
 func (t *timedRWMutex) Unlock() {
+	// Capture hold duration before releasing — `acquiredAt` is only valid
+	// while the write lock is held.
+	held := time.Since(t.acquiredAt)
+	t.acquiredAt = time.Time{}
 	t.mu.Unlock()
+	if held > slowLockThreshold() {
+		log.Warn("broker write-lock held too long",
+			"op", "Lock", "caller", callerName(1), "held_ms", held.Milliseconds())
+	}
 }
 
 func (t *timedRWMutex) RLock() {
 	start := time.Now()
 	t.mu.RLock()
-	if waited := time.Since(start); waited > time.Second {
+	if waited := time.Since(start); waited > slowLockThreshold() {
 		log.Warn("broker read-lock acquisition slow",
 			"op", "RLock", "caller", callerName(1), "waited_ms", waited.Milliseconds())
 	}
@@ -149,6 +222,12 @@ type Broker struct {
 	// when the write-lock storm from reconnect loops is in progress.
 	snap atomic.Pointer[sessionSnapshot]
 
+	// snapFallbackWarned fires a single WARN the first time snapshotSessions
+	// hits the nil-snapshot fallback path. This should only ever happen in
+	// tests that construct Broker{} directly; a production occurrence means
+	// New() was bypassed somewhere.
+	snapFallbackWarned atomic.Bool
+
 	onMessage       MessageHandler
 	onSessionClosed SessionClosedHandler
 	selfHashes      map[string]struct{} // SHA-256 of allowed helper binaries
@@ -171,7 +250,7 @@ func New(socketPath string, onMessage MessageHandler) *Broker {
 }
 
 // snapshotSessions returns the sessions map and consoleUser via the atomic
-// snapshot if available, falling back to a locked read for Broker instances
+// snapshot if available, falling back to a locked *copy* for Broker instances
 // that were not created via New() (e.g., test fixtures that construct Broker{} directly).
 //
 // The returned map must be treated as read-only by callers.
@@ -179,9 +258,21 @@ func (b *Broker) snapshotSessions() (map[string]*Session, string) {
 	if snap := b.snap.Load(); snap != nil {
 		return snap.sessions, snap.consoleUser
 	}
+	// Fallback path: Broker was constructed directly (likely a test fixture).
+	// Warn once if this ever happens — production code should always go
+	// through New(), which initialises b.snap. Returning the live map
+	// without copying would race with any concurrent writer once the
+	// deferred RUnlock below fires.
+	if b.snapFallbackWarned.CompareAndSwap(false, true) {
+		log.Warn("sessionbroker: snapshotSessions hit nil-snapshot fallback; Broker not initialised via New()")
+	}
 	b.mu.RLock()
 	defer b.mu.RUnlock()
-	return b.sessions, b.consoleUser
+	sessions := make(map[string]*Session, len(b.sessions))
+	for k, v := range b.sessions {
+		sessions[k] = v
+	}
+	return sessions, b.consoleUser
 }
 
 // publishSnapshotLocked builds a new immutable sessionSnapshot from the current
@@ -407,6 +498,11 @@ func (b *Broker) PreferredDesktopSession() *Session {
 // preferredDesktopSessionFromSnap is the lock-free variant of
 // preferredDesktopSessionLocked. It reads from an already-loaded snapshot
 // so callers on the heartbeat hot path avoid acquiring b.mu.RLock().
+//
+// Capabilities are read via Session.GetCapabilities() (which takes s.mu)
+// because the snapshot does not protect *Session internal fields — only the
+// outer map identity. Direct access to s.Capabilities would race with
+// SetCapabilities under -race.
 func preferredDesktopSessionFromSnap(snap *sessionSnapshot) *Session {
 	atLoginWindow := snap.consoleUser == "loginwindow"
 
@@ -414,7 +510,8 @@ func preferredDesktopSessionFromSnap(snap *sessionSnapshot) *Session {
 	if atLoginWindow {
 		var best *Session
 		for _, s := range snap.sessions {
-			if !s.HasScope("desktop") || s.Capabilities == nil || !s.Capabilities.CanCapture {
+			caps := s.GetCapabilities()
+			if !s.HasScope("desktop") || caps == nil || !caps.CanCapture {
 				continue
 			}
 			if s.DesktopContext == ipc.DesktopContextLoginWindow {
@@ -434,7 +531,8 @@ func preferredDesktopSessionFromSnap(snap *sessionSnapshot) *Session {
 	// Pass 2: best available session (normal selection or login window fallback).
 	var best *Session
 	for _, s := range snap.sessions {
-		if !s.HasScope("desktop") || s.Capabilities == nil || !s.Capabilities.CanCapture {
+		caps := s.GetCapabilities()
+		if !s.HasScope("desktop") || caps == nil || !caps.CanCapture {
 			continue
 		}
 		if best == nil || betterDesktopSession(s, best) {
@@ -451,7 +549,8 @@ func (b *Broker) preferredDesktopSessionLocked() *Session {
 	if atLoginWindow {
 		var best *Session
 		for _, s := range b.sessions {
-			if !s.HasScope("desktop") || s.Capabilities == nil || !s.Capabilities.CanCapture {
+			caps := s.GetCapabilities()
+			if !s.HasScope("desktop") || caps == nil || !caps.CanCapture {
 				continue
 			}
 			if s.DesktopContext == ipc.DesktopContextLoginWindow {
@@ -471,7 +570,8 @@ func (b *Broker) preferredDesktopSessionLocked() *Session {
 	// Pass 2: best available session (normal selection or login window fallback).
 	var best *Session
 	for _, s := range b.sessions {
-		if !s.HasScope("desktop") || s.Capabilities == nil || !s.Capabilities.CanCapture {
+		caps := s.GetCapabilities()
+		if !s.HasScope("desktop") || caps == nil || !caps.CanCapture {
 			continue
 		}
 		if best == nil || betterDesktopSession(s, best) {
@@ -487,18 +587,29 @@ func (b *Broker) preferredDesktopSessionLocked() *Session {
 // of session-internal state.
 // Uses the atomic snapshot to avoid lock contention on the heartbeat hot path.
 func (b *Broker) TCCStatus() *ipc.TCCStatus {
-	sessions, consoleUser := b.snapshotSessions()
+	// Prefer the full atomic snapshot — it has all three fields populated
+	// (sessions, byIdentity, consoleUser), so passing it to snapshot-based
+	// helpers like preferredDesktopSessionFromSnap is safe even as those
+	// helpers evolve to read additional fields. Fall back to a locked copy
+	// only when the broker was constructed directly without New() (tests).
+	snap := b.snap.Load()
+	if snap == nil {
+		sessions, consoleUser := b.snapshotSessions()
+		snap = &sessionSnapshot{
+			sessions:    sessions,
+			byIdentity:  nil, // fallback path: not populated, do not read
+			consoleUser: consoleUser,
+		}
+	}
 
-	snapView := &sessionSnapshot{sessions: sessions, consoleUser: consoleUser}
-
-	if preferred := preferredDesktopSessionFromSnap(snapView); preferred != nil {
+	if preferred := preferredDesktopSessionFromSnap(snap); preferred != nil {
 		if tcc := preferred.GetTCCStatus(); tcc != nil {
 			cp := *tcc
 			return &cp
 		}
 	}
 
-	for _, s := range sessions {
+	for _, s := range snap.sessions {
 		if !s.HasScope("desktop") {
 			continue
 		}
@@ -508,7 +619,7 @@ func (b *Broker) TCCStatus() *ipc.TCCStatus {
 		}
 	}
 
-	for _, s := range sessions {
+	for _, s := range snap.sessions {
 		if tcc := s.GetTCCStatus(); tcc != nil {
 			cp := *tcc
 			return &cp
@@ -591,16 +702,21 @@ func (b *Broker) FindCapableSession(capability string, targetWinSession string) 
 	}
 
 	hasCapability := func(s *Session) bool {
-		if s.Capabilities == nil {
+		// GetCapabilities takes s.mu — required because the atomic snapshot
+		// only protects the outer map identity, not per-session fields. A
+		// direct read of s.Capabilities races with SetCapabilities writers
+		// (which run under s.mu.Lock()) and trips -race under contention.
+		caps := s.GetCapabilities()
+		if caps == nil {
 			return false
 		}
 		switch capability {
 		case "capture":
-			return s.Capabilities.CanCapture
+			return caps.CanCapture
 		case "clipboard":
-			return s.Capabilities.CanClipboard
+			return caps.CanClipboard
 		case "notify":
-			return s.Capabilities.CanNotify
+			return caps.CanNotify
 		}
 		return false
 	}
@@ -1159,14 +1275,17 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 			if err := json.Unmarshal(env.Payload, &caps); err != nil {
 				log.Warn("invalid capabilities payload", "uid", s.UID, "error", err.Error())
 			} else {
-				s.SetCapabilities(sanitizeCapabilitiesForSession(s, &caps))
+				sanitized := sanitizeCapabilitiesForSession(s, &caps)
+				s.SetCapabilities(sanitized)
+				// Log from the locally-held copy to avoid a post-Set read of
+				// s.Capabilities that would race with any concurrent reader.
 				log.Info("capabilities received",
 					"uid", s.UID,
-					"canNotify", s.Capabilities.CanNotify,
-					"canTray", s.Capabilities.CanTray,
-					"canCapture", s.Capabilities.CanCapture,
-					"canClipboard", s.Capabilities.CanClipboard,
-					"displayServer", s.Capabilities.DisplayServer,
+					"canNotify", sanitized.CanNotify,
+					"canTray", sanitized.CanTray,
+					"canCapture", sanitized.CanCapture,
+					"canClipboard", sanitized.CanClipboard,
+					"displayServer", sanitized.DisplayServer,
 				)
 			}
 		case ipc.TypeTCCStatus:
@@ -1319,6 +1438,14 @@ func (b *Broker) KillStaleHelpers(winSessionID string) {
 // CloseSessionsByDesktopContext closes all sessions with the given desktop
 // context (e.g., "user_session"). Used on macOS to tear down stale helpers
 // after a logout event. Returns the number of sessions closed.
+//
+// Note: this method iterates b.sessions under b.mu.Lock() and queues matching
+// sessions into a local slice before releasing the lock and calling Close on
+// each one. Because the atomic snapshot is NOT refreshed until removeSession
+// runs (via the RecvLoop exit path for each closed session), snapshot-path
+// readers may briefly see closed sessions during that window. This is an
+// acceptable trade-off: Close() is idempotent, and the calling code tolerates
+// a best-effort teardown on macOS logout.
 func (b *Broker) CloseSessionsByDesktopContext(ctx string) int {
 	b.mu.Lock()
 	var toClose []*Session
@@ -1482,7 +1609,8 @@ func (b *Broker) reapIdleSessions() {
 	b.mu.RLock()
 	var toClose []*Session
 	for _, s := range b.sessions {
-		if s.Capabilities != nil && s.Capabilities.CanCapture {
+		caps := s.GetCapabilities()
+		if caps != nil && caps.CanCapture {
 			continue
 		}
 		if s.IdleDuration() > IdleTimeout {

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -16,6 +16,8 @@ import (
 	"sync"
 	"time"
 
+	"sync/atomic"
+
 	"github.com/breeze-rmm/agent/internal/backupipc"
 	"github.com/breeze-rmm/agent/internal/ipc"
 )
@@ -112,6 +114,20 @@ type MessageHandler func(session *Session, env *ipc.Envelope)
 // SessionClosedHandler is called after a helper session has been removed.
 type SessionClosedHandler func(session *Session)
 
+// sessionSnapshot is an immutable point-in-time view of the broker's session
+// maps. It is stored via an atomic.Pointer so lock-free readers (FindCapableSession,
+// AllSessions, TCCStatus) can avoid acquiring b.mu.RLock() entirely, preventing
+// heartbeat starvation when a write-lock storm (reconnect loop) is in progress.
+//
+// The snapshot maps are shallow copies of the outer maps: the keys/values are
+// copied but the *Session values themselves are not deep-copied. Callers must
+// not mutate sessions obtained from a snapshot.
+type sessionSnapshot struct {
+	sessions    map[string]*Session   // sessionID -> Session
+	byIdentity  map[string][]*Session // identity key -> Sessions
+	consoleUser string
+}
+
 // Broker manages IPC connections from user helper processes.
 type Broker struct {
 	socketPath  string
@@ -126,6 +142,12 @@ type Broker struct {
 	consoleUser  string                // macOS: current console user ("loginwindow" at login screen)
 	backup       *backupHelper         // backup helper process and session
 	closed       bool
+
+	// snap is an atomically updated snapshot of sessions/byIdentity/consoleUser.
+	// Updated under b.mu.Lock() on every mutation. Read-only hot paths use
+	// snap.Load() instead of acquiring b.mu.RLock(), eliminating reader starvation
+	// when the write-lock storm from reconnect loops is in progress.
+	snap atomic.Pointer[sessionSnapshot]
 
 	onMessage       MessageHandler
 	onSessionClosed SessionClosedHandler
@@ -144,7 +166,42 @@ func New(socketPath string, onMessage MessageHandler) *Broker {
 		onMessage:    onMessage,
 	}
 	b.selfHashes = b.computeAllowedHashes()
+	b.publishSnapshotLocked() // initialise with empty maps
 	return b
+}
+
+// snapshotSessions returns the sessions map and consoleUser via the atomic
+// snapshot if available, falling back to a locked read for Broker instances
+// that were not created via New() (e.g., test fixtures that construct Broker{} directly).
+//
+// The returned map must be treated as read-only by callers.
+func (b *Broker) snapshotSessions() (map[string]*Session, string) {
+	if snap := b.snap.Load(); snap != nil {
+		return snap.sessions, snap.consoleUser
+	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.sessions, b.consoleUser
+}
+
+// publishSnapshotLocked builds a new immutable sessionSnapshot from the current
+// state and atomically replaces the stored snapshot. Must be called under b.mu.Lock().
+func (b *Broker) publishSnapshotLocked() {
+	sessionsCopy := make(map[string]*Session, len(b.sessions))
+	for k, v := range b.sessions {
+		sessionsCopy[k] = v
+	}
+	byIdentityCopy := make(map[string][]*Session, len(b.byIdentity))
+	for k, v := range b.byIdentity {
+		cp := make([]*Session, len(v))
+		copy(cp, v)
+		byIdentityCopy[k] = cp
+	}
+	b.snap.Store(&sessionSnapshot{
+		sessions:    sessionsCopy,
+		byIdentity:  byIdentityCopy,
+		consoleUser: b.consoleUser,
+	})
 }
 
 func (b *Broker) SetSessionClosedHandler(handler SessionClosedHandler) {
@@ -159,6 +216,7 @@ func (b *Broker) SetConsoleUser(username string) {
 	b.mu.Lock()
 	prev := b.consoleUser
 	b.consoleUser = username
+	b.publishSnapshotLocked()
 	b.mu.Unlock()
 	if prev != username {
 		log.Debug("console user changed", "from", prev, "to", username)
@@ -286,11 +344,11 @@ func (b *Broker) SessionForUID(uid uint32) *Session {
 }
 
 // AllSessions returns info about all connected sessions.
+// Uses the atomic snapshot to avoid lock contention on the hot path.
 func (b *Broker) AllSessions() []SessionInfo {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-	infos := make([]SessionInfo, 0, len(b.sessions))
-	for _, s := range b.sessions {
+	sessions, _ := b.snapshotSessions()
+	infos := make([]SessionInfo, 0, len(sessions))
+	for _, s := range sessions {
 		infos = append(infos, s.Info())
 	}
 	return infos
@@ -346,6 +404,46 @@ func (b *Broker) PreferredDesktopSession() *Session {
 	return b.preferredDesktopSessionLocked()
 }
 
+// preferredDesktopSessionFromSnap is the lock-free variant of
+// preferredDesktopSessionLocked. It reads from an already-loaded snapshot
+// so callers on the heartbeat hot path avoid acquiring b.mu.RLock().
+func preferredDesktopSessionFromSnap(snap *sessionSnapshot) *Session {
+	atLoginWindow := snap.consoleUser == "loginwindow"
+
+	// Pass 1: if at login window, try login_window helpers first.
+	if atLoginWindow {
+		var best *Session
+		for _, s := range snap.sessions {
+			if !s.HasScope("desktop") || s.Capabilities == nil || !s.Capabilities.CanCapture {
+				continue
+			}
+			if s.DesktopContext == ipc.DesktopContextLoginWindow {
+				if best == nil || betterDesktopSession(s, best) {
+					best = s
+				}
+			}
+		}
+		if best != nil {
+			return best
+		}
+		// No login_window helper — fall through to user_session helpers.
+		// They can still capture the login screen on macOS; input will
+		// use IOHIDPostEvent via dynamic switching.
+	}
+
+	// Pass 2: best available session (normal selection or login window fallback).
+	var best *Session
+	for _, s := range snap.sessions {
+		if !s.HasScope("desktop") || s.Capabilities == nil || !s.Capabilities.CanCapture {
+			continue
+		}
+		if best == nil || betterDesktopSession(s, best) {
+			best = s
+		}
+	}
+	return best
+}
+
 func (b *Broker) preferredDesktopSessionLocked() *Session {
 	atLoginWindow := b.consoleUser == "loginwindow"
 
@@ -387,18 +485,20 @@ func (b *Broker) preferredDesktopSessionLocked() *Session {
 // session that has reported one, or nil if none have. In practice, only one
 // macOS helper per user reports TCC status. Returns a copy to prevent mutation
 // of session-internal state.
+// Uses the atomic snapshot to avoid lock contention on the heartbeat hot path.
 func (b *Broker) TCCStatus() *ipc.TCCStatus {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
+	sessions, consoleUser := b.snapshotSessions()
 
-	if preferred := b.preferredDesktopSessionLocked(); preferred != nil {
+	snapView := &sessionSnapshot{sessions: sessions, consoleUser: consoleUser}
+
+	if preferred := preferredDesktopSessionFromSnap(snapView); preferred != nil {
 		if tcc := preferred.GetTCCStatus(); tcc != nil {
 			cp := *tcc
 			return &cp
 		}
 	}
 
-	for _, s := range b.sessions {
+	for _, s := range sessions {
 		if !s.HasScope("desktop") {
 			continue
 		}
@@ -408,7 +508,7 @@ func (b *Broker) TCCStatus() *ipc.TCCStatus {
 		}
 	}
 
-	for _, s := range b.sessions {
+	for _, s := range sessions {
 		if tcc := s.GetTCCStatus(); tcc != nil {
 			cp := *tcc
 			return &cp
@@ -456,7 +556,12 @@ func (b *Broker) BroadcastToDesktopSessions(msgType string, payload any) {
 }
 
 // SessionCount returns the number of active sessions.
+// Uses the atomic snapshot to avoid lock contention on the heartbeat hot path.
 func (b *Broker) SessionCount() int {
+	if snap := b.snap.Load(); snap != nil {
+		return len(snap.sessions)
+	}
+	// Fallback for Broker instances not created via New() (e.g., test fixtures).
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	return len(b.sessions)
@@ -467,11 +572,20 @@ func (b *Broker) SessionCount() int {
 // only sessions in that Windows session are considered. Otherwise, the console
 // session (physical monitor) is preferred over RDP sessions, and disconnected
 // sessions are skipped.
+//
+// Uses the atomic snapshot to avoid holding b.mu.RLock() across OS API calls
+// (GetConsoleSessionID, IsSessionDisconnected) that can block under system load.
+// This prevents reader starvation of the heartbeat path when write-lock storms
+// (reconnect loops) are in progress.
 func (b *Broker) FindCapableSession(capability string, targetWinSession string) *Session {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
+	// snapshotSessions returns the atomic snapshot if available, or falls back
+	// to a locked read for test fixtures. On the hot path the snapshot is always
+	// available, so no lock is held during the OS calls below.
+	sessions, _ := b.snapshotSessions()
 
 	// When no target specified, prefer the console session (physical display).
+	// NOTE: GetConsoleSessionID() is called outside any lock — safe because we
+	// read from an immutable snapshot and no lock is needed for this OS call.
 	if targetWinSession == "" || targetWinSession == "0" {
 		targetWinSession = GetConsoleSessionID()
 	}
@@ -494,7 +608,7 @@ func (b *Broker) FindCapableSession(capability string, targetWinSession string) 
 	var best *Session
 
 	// First pass: find a capable session in the target (console) session.
-	for _, s := range b.sessions {
+	for _, s := range sessions {
 		if s.WinSessionID != targetWinSession {
 			continue
 		}
@@ -509,7 +623,8 @@ func (b *Broker) FindCapableSession(capability string, targetWinSession string) 
 	}
 
 	// Second pass: fall back to any capable session that isn't disconnected.
-	for _, s := range b.sessions {
+	// IsSessionDisconnected makes a WTS syscall — safe outside any lock.
+	for _, s := range sessions {
 		if !hasCapability(s) {
 			continue
 		}
@@ -1017,6 +1132,7 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 		}
 		b.backup.session = session
 	}
+	b.publishSnapshotLocked()
 	b.mu.Unlock()
 
 	log.Info("user helper connected",
@@ -1163,6 +1279,7 @@ func (b *Broker) removeSession(session *Session) {
 		staleKey := session.WinSessionID + "-" + session.HelperRole
 		b.trackStaleHelper(staleKey, session.PID)
 	}
+	b.publishSnapshotLocked()
 	onSessionClosed := b.onSessionClosed
 	b.mu.Unlock()
 

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -20,6 +20,64 @@ import (
 	"github.com/breeze-rmm/agent/internal/ipc"
 )
 
+// timedRWMutex wraps sync.RWMutex and logs a warning when Lock or RLock
+// acquisition takes longer than 1 second. This instruments the heartbeat
+// starvation symptom in issue #387: a reconnect storm generating many
+// removeSession write-locks can starve heartbeat read-path callers.
+//
+// The wrapper uses runtime.Callers to automatically identify the calling
+// function — no changes are required at individual call sites.
+type timedRWMutex struct {
+	mu sync.RWMutex
+}
+
+func callerName(skip int) string {
+	var pcs [3]uintptr
+	n := runtime.Callers(skip+2, pcs[:])
+	if n == 0 {
+		return "unknown"
+	}
+	frames := runtime.CallersFrames(pcs[:n])
+	f, _ := frames.Next()
+	// Trim package prefix for brevity: "sessionbroker.(*Broker).handleConnection"
+	// → "handleConnection"
+	name := f.Function
+	if i := strings.LastIndexByte(name, '.'); i >= 0 {
+		name = name[i+1:]
+	}
+	// Strip go method closure suffixes like "func1"
+	if i := strings.IndexByte(name, '-'); i >= 0 {
+		name = name[:i]
+	}
+	return name
+}
+
+func (t *timedRWMutex) Lock() {
+	start := time.Now()
+	t.mu.Lock()
+	if waited := time.Since(start); waited > time.Second {
+		log.Warn("broker write-lock acquisition slow",
+			"op", "Lock", "caller", callerName(1), "waited_ms", waited.Milliseconds())
+	}
+}
+
+func (t *timedRWMutex) Unlock() {
+	t.mu.Unlock()
+}
+
+func (t *timedRWMutex) RLock() {
+	start := time.Now()
+	t.mu.RLock()
+	if waited := time.Since(start); waited > time.Second {
+		log.Warn("broker read-lock acquisition slow",
+			"op", "RLock", "caller", callerName(1), "waited_ms", waited.Milliseconds())
+	}
+}
+
+func (t *timedRWMutex) RUnlock() {
+	t.mu.RUnlock()
+}
+
 const (
 	// HandshakeTimeout is the deadline for completing auth after connecting.
 	HandshakeTimeout = 5 * time.Second
@@ -61,7 +119,7 @@ type Broker struct {
 	rateLimiter *ipc.RateLimiter
 	startTime   time.Time // broker creation time, used for watchdog uptime
 
-	mu           sync.RWMutex
+	mu           timedRWMutex
 	sessions     map[string]*Session   // sessionID -> Session
 	byIdentity   map[string][]*Session // identity key -> Sessions (UID string on Unix, SID on Windows)
 	staleHelpers map[string][]int      // winSessionID -> PIDs of disconnected helpers

--- a/agent/internal/sessionbroker/broker_test.go
+++ b/agent/internal/sessionbroker/broker_test.go
@@ -657,7 +657,15 @@ func BenchmarkFindCapableSessionUnderConcurrentConnections(b *testing.B) {
 
 	b.ResetTimer()
 	for range b.N {
-		_ = broker.FindCapableSession("capture", "1")
+		s := broker.FindCapableSession("capture", "1")
+		if s == nil {
+			// The benchmark pre-registers five capture-capable sessions in
+			// WinSessionID "1"; the write-storm goroutines only churn their
+			// own "storm-*" sessions without touching the pre-registered
+			// ones, so FindCapableSession must never return nil. A nil
+			// result indicates a regression in the atomic-snapshot path.
+			b.Fatal("FindCapableSession returned nil under concurrent writes")
+		}
 	}
 	b.StopTimer()
 

--- a/agent/internal/sessionbroker/broker_test.go
+++ b/agent/internal/sessionbroker/broker_test.go
@@ -2,6 +2,8 @@ package sessionbroker
 
 import (
 	"encoding/json"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -584,4 +586,81 @@ func TestCloseSessionsByDesktopContext_MultipleMatches(t *testing.T) {
 	if b.CloseSessionsByDesktopContext("nonexistent") != 0 {
 		t.Fatal("expected 0 for nonexistent context")
 	}
+}
+
+// BenchmarkFindCapableSessionUnderConcurrentConnections measures FindCapableSession
+// throughput while K goroutines simultaneously simulate the write-lock storm
+// (removeSession) from the reconnect loop described in issue #387.
+//
+// Before the atomic-snapshot refactor, FindCapableSession acquired b.mu.RLock()
+// and was starved when write-lock goroutines competed. After the refactor it
+// reads from an atomic pointer, so throughput should be unaffected by writers.
+func BenchmarkFindCapableSessionUnderConcurrentConnections(b *testing.B) {
+	const nSessions = 5
+	const nWriters = 10 // simulates reconnect storm goroutines
+
+	// Build broker via New() so the snapshot is initialised.
+	broker := New("/tmp/bench.sock", nil)
+
+	// Populate sessions with capture capability.
+	// Sessions are created with a nil conn because FindCapableSession only reads
+	// metadata fields (Capabilities, WinSessionID) — no IPC I/O is performed.
+	for i := range nSessions {
+		s := &Session{
+			SessionID:     fmt.Sprintf("sess-%d", i),
+			IdentityKey:   fmt.Sprintf("%d", 1000+i),
+			AllowedScopes: systemHelperScopes,
+			Capabilities:  &ipc.Capabilities{CanCapture: true, CanClipboard: true},
+			WinSessionID:  "1",
+		}
+		broker.mu.Lock()
+		broker.sessions[s.SessionID] = s
+		broker.byIdentity[s.IdentityKey] = append(broker.byIdentity[s.IdentityKey], s)
+		broker.publishSnapshotLocked()
+		broker.mu.Unlock()
+	}
+
+	// Launch write-storm goroutines that repeatedly add and remove a session
+	// to simulate the handleConnection/removeSession lock contention.
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for w := range nWriters {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				sessID := fmt.Sprintf("storm-%d", id)
+				idKey := fmt.Sprintf("storm-identity-%d", id)
+				s := &Session{
+					SessionID:   sessID,
+					IdentityKey: idKey,
+				}
+				broker.mu.Lock()
+				broker.sessions[sessID] = s
+				broker.byIdentity[idKey] = []*Session{s}
+				broker.publishSnapshotLocked()
+				broker.mu.Unlock()
+
+				broker.mu.Lock()
+				delete(broker.sessions, sessID)
+				delete(broker.byIdentity, idKey)
+				broker.publishSnapshotLocked()
+				broker.mu.Unlock()
+			}
+		}(w)
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		_ = broker.FindCapableSession("capture", "1")
+	}
+	b.StopTimer()
+
+	close(stop)
+	wg.Wait()
 }

--- a/agent/internal/sessionbroker/broker_test.go
+++ b/agent/internal/sessionbroker/broker_test.go
@@ -1,14 +1,61 @@
 package sessionbroker
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/breeze-rmm/agent/internal/ipc"
+	"github.com/breeze-rmm/agent/internal/logging"
 )
+
+// syncBuffer is a goroutine-safe wrapper around bytes.Buffer so multiple
+// concurrent writers (e.g. the acquiring goroutine and the holding goroutine
+// in TestTimedRWMutexWarnsOnSlowAcquire) can emit logs without racing on
+// bytes.Buffer's internal grow/write state.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// captureLogs redirects the global logger to a buffer for the duration of the
+// test via t.Cleanup. Returns the buffer — call String() to inspect.
+func captureLogs(t *testing.T) *syncBuffer {
+	t.Helper()
+	buf := &syncBuffer{}
+	logging.Init("text", "debug", buf)
+	t.Cleanup(func() {
+		// Best-effort restore: reset to stdout so other tests see normal logs.
+		logging.Init("text", "info", nil)
+	})
+	return buf
+}
+
+// withShortLockThreshold temporarily shortens slowLockThreshold for the test
+// and restores it via t.Cleanup.
+func withShortLockThreshold(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := setSlowLockThreshold(d)
+	t.Cleanup(func() {
+		setSlowLockThreshold(prev)
+	})
+}
 
 func newTestUserSession(t *testing.T, sessionID, username string, lastSeen time.Time) (*Session, *ipc.Conn) {
 	t.Helper()
@@ -671,4 +718,149 @@ func BenchmarkFindCapableSessionUnderConcurrentConnections(b *testing.B) {
 
 	close(stop)
 	wg.Wait()
+}
+
+// TestSnapshotReadAfterWrite verifies that a Broker constructed via New()
+// registers a session under b.mu.Lock() + publishSnapshotLocked(), and that
+// read-only hot-path APIs (SessionCount, AllSessions, FindCapableSession)
+// immediately observe the new session via the atomic snapshot path — not
+// via the locked-fallback path.
+func TestSnapshotReadAfterWrite(t *testing.T) {
+	broker := New("/tmp/snapshot-test.sock", nil)
+
+	// Before registering anything, the snapshot is present but empty.
+	if snap := broker.snap.Load(); snap == nil {
+		t.Fatal("New() must initialise broker.snap")
+	}
+	if got := broker.SessionCount(); got != 0 {
+		t.Fatalf("empty broker SessionCount = %d, want 0", got)
+	}
+
+	// Register a session via the same locked + publish pattern that
+	// handleConnection uses internally.
+	session := &Session{
+		SessionID:     "snap-sess-1",
+		IdentityKey:   "1001",
+		Username:      "alice",
+		WinSessionID:  "1",
+		AllowedScopes: systemHelperScopes,
+		Capabilities:  &ipc.Capabilities{CanCapture: true, CanClipboard: true, CanNotify: true},
+		HelperRole:    ipc.HelperRoleSystem,
+	}
+	broker.mu.Lock()
+	broker.sessions[session.SessionID] = session
+	broker.byIdentity[session.IdentityKey] = append(broker.byIdentity[session.IdentityKey], session)
+	broker.publishSnapshotLocked()
+	broker.mu.Unlock()
+
+	// SessionCount must go through the atomic snapshot (snap.Load() branch).
+	if got := broker.SessionCount(); got != 1 {
+		t.Fatalf("SessionCount after register = %d, want 1", got)
+	}
+
+	// AllSessions must see the session.
+	infos := broker.AllSessions()
+	if len(infos) != 1 || infos[0].SessionID != session.SessionID {
+		t.Fatalf("AllSessions = %+v, want one session %q", infos, session.SessionID)
+	}
+
+	// FindCapableSession must see it via the capture capability.
+	got := broker.FindCapableSession("capture", "1")
+	if got == nil || got.SessionID != session.SessionID {
+		t.Fatalf("FindCapableSession(capture, 1) = %v, want %q", got, session.SessionID)
+	}
+
+	// Verify we really exercised the snapshot path — the snapshot must be
+	// non-nil and the snapFallbackWarned flag must NOT have been tripped.
+	if broker.snap.Load() == nil {
+		t.Fatal("expected non-nil snapshot after register")
+	}
+	if broker.snapFallbackWarned.Load() {
+		t.Fatal("snapshot fallback should not have been triggered on a New()-constructed broker")
+	}
+
+	// Remove the session and verify snapshot reflects the removal.
+	broker.mu.Lock()
+	delete(broker.sessions, session.SessionID)
+	delete(broker.byIdentity, session.IdentityKey)
+	broker.publishSnapshotLocked()
+	broker.mu.Unlock()
+
+	if got := broker.SessionCount(); got != 0 {
+		t.Fatalf("SessionCount after remove = %d, want 0", got)
+	}
+	if broker.FindCapableSession("capture", "1") != nil {
+		t.Fatal("FindCapableSession should return nil after removal")
+	}
+}
+
+// TestTimedRWMutexWarnsOnLongHold verifies that holding a write lock past
+// slowLockThreshold emits a WARN log with held_ms and caller fields. Uses a
+// short test threshold (25ms) so the test runs fast.
+func TestTimedRWMutexWarnsOnLongHold(t *testing.T) {
+	withShortLockThreshold(t, 25*time.Millisecond)
+	buf := captureLogs(t)
+
+	var mu timedRWMutex
+	mu.Lock()
+	time.Sleep(60 * time.Millisecond) // > 25ms threshold
+	mu.Unlock()
+
+	output := buf.String()
+	if !strings.Contains(output, "broker write-lock held too long") {
+		t.Fatalf("expected hold-time warning in log output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "held_ms=") {
+		t.Fatalf("expected held_ms field in log output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "caller=") {
+		t.Fatalf("expected caller field in log output, got:\n%s", output)
+	}
+}
+
+// TestTimedRWMutexNoWarnOnFastHold verifies that a short write-lock hold
+// does NOT emit a warning.
+func TestTimedRWMutexNoWarnOnFastHold(t *testing.T) {
+	withShortLockThreshold(t, 100*time.Millisecond)
+	buf := captureLogs(t)
+
+	var mu timedRWMutex
+	mu.Lock()
+	// No sleep — hold is effectively zero.
+	mu.Unlock()
+
+	if strings.Contains(buf.String(), "broker write-lock held too long") {
+		t.Fatalf("unexpected hold-time warning on fast hold:\n%s", buf.String())
+	}
+}
+
+// TestTimedRWMutexWarnsOnSlowAcquire verifies that slow Lock acquisition
+// (contention wait) still emits the existing wait-time warning.
+func TestTimedRWMutexWarnsOnSlowAcquire(t *testing.T) {
+	withShortLockThreshold(t, 25*time.Millisecond)
+	buf := captureLogs(t)
+
+	var mu timedRWMutex
+	// Acquire-and-hold on a goroutine to starve the second acquire.
+	started := make(chan struct{})
+	release := make(chan struct{})
+	go func() {
+		mu.Lock()
+		close(started)
+		<-release
+		mu.Unlock()
+	}()
+	<-started
+	// Second acquire must wait until we release; wait ~60ms before releasing.
+	time.AfterFunc(60*time.Millisecond, func() { close(release) })
+	mu.Lock()
+	mu.Unlock()
+
+	output := buf.String()
+	if !strings.Contains(output, "broker write-lock acquisition slow") {
+		t.Fatalf("expected acquisition-slow warning, got:\n%s", output)
+	}
+	if !strings.Contains(output, "waited_ms=") {
+		t.Fatalf("expected waited_ms field, got:\n%s", output)
+	}
 }

--- a/agent/internal/sessionbroker/session.go
+++ b/agent/internal/sessionbroker/session.go
@@ -165,6 +165,25 @@ func (s *Session) SetCapabilities(caps *ipc.Capabilities) {
 	s.mu.Unlock()
 }
 
+// GetCapabilities returns a copy of the session's reported capabilities, or
+// nil if none have been received yet. Safe to call from any goroutine; takes
+// s.mu to serialise with SetCapabilities.
+//
+// Snapshot-path readers (FindCapableSession, preferredDesktopSessionFromSnap,
+// etc.) must use this accessor instead of reading s.Capabilities directly.
+// Before the atomic-snapshot refactor, b.mu.RLock() accidentally serialised
+// those reads with SetCapabilities writers; without it, direct reads race
+// under -race.
+func (s *Session) GetCapabilities() *ipc.Capabilities {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.Capabilities == nil {
+		return nil
+	}
+	cp := *s.Capabilities
+	return &cp
+}
+
 // SetTCCStatus updates the session's macOS TCC permission status.
 func (s *Session) SetTCCStatus(status *ipc.TCCStatus) {
 	s.mu.Lock()


### PR DESCRIPTION
Fixes #387 (Part G — follow-up to #388 Parts A-F).

## Summary

- **Phase 1**: Instruments the heartbeat starvation symptom to prove the broker-mutex hypothesis
- **Phase 2**: Atomic snapshot refactor eliminates the reader starvation on the hot path

## Phase 1 — Instrumentation

**`sendHeartbeatWithWatchdog()`** (`heartbeat.go`): wraps every `sendHeartbeat()` call with a 15-second watchdog goroutine. If the call blocks >15s, all goroutine stacks are dumped at WARN level (1 MiB buffer, 100 KB log cap) with the greppable message `"heartbeat send exceeded 15s — dumping goroutine stacks"`. On normal return, logs duration at DEBUG.

**`timedRWMutex`** (`broker.go`): drop-in replacement for `sync.RWMutex` in `Broker.mu`. `Lock()` and `RLock()` time their acquisition; if >1s, a WARN is emitted with the auto-detected caller function name (via `runtime.Callers`). Zero call-site changes required — all 50+ lock sites covered automatically.

## Phase 2 — Atomic snapshot refactor

**Conditions confirmed by static reading (both required):**
1. `FindCapableSession` held `b.mu.RLock()` across `GetConsoleSessionID()` (Windows API syscall) and `IsSessionDisconnected()` (WTS syscall per session) — non-trivial blocking time under system load.
2. `removeSession` holds `b.mu.Lock()` on every rejected helper disconnect (15/min in the storm). Go's `sync.RWMutex` semantics: pending writer blocks ALL new readers — including `AllSessions()` and `TCCStatus()` called from `sendHeartbeat()`.

**Implementation:**
- `sessionSnapshot` struct: immutable shallow copy of `sessions`, `byIdentity`, `consoleUser`
- `Broker.snap atomic.Pointer[sessionSnapshot]`: atomically updated on every write
- `publishSnapshotLocked()`: called under `b.mu.Lock()` at all mutation sites
- `FindCapableSession`, `AllSessions`, `TCCStatus`, `SessionCount`: now lock-free — read from snapshot, OS API calls outside any lock
- Write path unchanged: `b.mu.Lock()` still guards all mutations
- `timedRWMutex` from Phase 1 retained for write-path and non-hot read-path monitoring

## Benchmark

```
BenchmarkFindCapableSessionUnderConcurrentConnections-14    6689602    157.1 ns/op    199 B/op    2 allocs/op
```

10 concurrent write-storm goroutines, 5 sessions — `FindCapableSession` throughput unaffected by writers because it reads from an atomic snapshot.

## Test plan

- [ ] `go test -race ./internal/heartbeat/... ./internal/sessionbroker/...` — all pass ✓
- [ ] `go build ./...` (darwin, linux/amd64, windows) — all pass ✓
- [ ] `go vet ./...` — clean ✓
- [ ] Deploy to a Windows Server VPS (ideally the Contabo-style host from the original report) and reproduce the reconnect storm, then verify:
  - `heartbeat send exceeded 15s` WARN appears and contains goroutine stack with broker lock contention evidence
  - `broker read-lock acquisition slow` / `broker write-lock acquisition slow` WARNs appear during storm
  - After Phase 2 ships: heartbeat resumes within 1-2 ticks even under active storm

## Links

- Issue: #387
- Parts A-F: #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)