### PR TITLE
fix(api): file browser timeout UX + RLS app role bootstrap

### DIFF
--- a/apps/api/migrations/2026-04-11-a-rls-function-bootstrap.sql
+++ b/apps/api/migrations/2026-04-11-a-rls-function-bootstrap.sql
@@ -1,0 +1,117 @@
+-- 2026-04-11: RLS helper-function and column bootstrap.
+--
+-- Why this file exists, and why it sorts first among the 2026-04-11
+-- migration group:
+--
+--   The 2026-04-11 RLS work was developed incrementally against a dev
+--   database and shipped as many small files. On dev they were applied
+--   in *creation* order (each merge timestamp), so cross-file
+--   dependencies never surfaced. But autoMigrate applies migrations in
+--   *alphabetical* order, and on a fresh install (new self-hosted user,
+--   prod container on first boot) the alphabetical ordering violates
+--   three real dependencies:
+--
+--     bucket-c-phase-6-user-scoped-rls.sql  →  references
+--       public.breeze_current_user_id()        (defined in users-rls.sql)
+--       public.breeze_has_partner_access(uuid) (defined in partners-rls.sql)
+--       users.partner_id / users.org_id        (added in users-rls.sql)
+--
+--     bucket-c-sessions-rls.sql              →  references
+--       public.breeze_current_user_id()        (defined in users-rls.sql)
+--
+--   Both consumer files sort BEFORE both producer files ("bucket" < "u",
+--   "bucket" < "p"), so CREATE POLICY would fail at parse time with
+--   "function does not exist" or "column does not exist".
+--
+--   This bootstrap file sorts BEFORE every 2026-04-11 file because of the
+--   single-character "-a-" segment ("a" < "b" of "bucket", "c" of
+--   "cis", "d" of "device", "o" of "organizations", "p" of "partners",
+--   "r" of "rewrite"/"roles", "u" of "users"). It pre-creates the three
+--   dependencies in idempotent form. When users-rls.sql and partners-rls.sql
+--   later run, their CREATE OR REPLACE FUNCTION and ADD COLUMN IF NOT EXISTS
+--   statements are no-ops against the objects already created here, so the
+--   behavior on dev (where this file is new and applies after everything
+--   else) is identical to the behavior on a fresh install.
+--
+--   DO NOT edit the function bodies here without editing the originating
+--   migration files in lockstep. The two definitions are required to be
+--   byte-identical so CREATE OR REPLACE is a true no-op and downstream
+--   policies see the same semantics regardless of which file applied last.
+--
+-- Fully idempotent — safe to re-run.
+
+BEGIN;
+
+-- ============================================================
+-- 1. breeze_current_user_id() — verbatim from users-rls.sql.
+--    Reads breeze.user_id GUC, casts to uuid, returns NULL when unset.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.breeze_current_user_id()
+  RETURNS uuid
+  LANGUAGE sql
+  STABLE
+AS $function$
+  SELECT NULLIF(current_setting('breeze.user_id', true), '')::uuid;
+$function$;
+
+-- ============================================================
+-- 2. users.partner_id and users.org_id — verbatim from users-rls.sql.
+--    Added nullable here so CREATE POLICY in phase-6 can reference them.
+--    users-rls.sql later backfills and (on the one-time migration path)
+--    sets partner_id NOT NULL. On fresh install the users table is empty
+--    when that runs so SET NOT NULL is a no-op.
+-- ============================================================
+ALTER TABLE users ADD COLUMN IF NOT EXISTS partner_id uuid;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS org_id uuid;
+
+-- ============================================================
+-- 3. breeze_accessible_partner_ids() — verbatim from partners-rls.sql.
+--    Reads the breeze.accessible_partner_ids GUC, fail-closed on
+--    malformed values.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.breeze_accessible_partner_ids()
+  RETURNS uuid[]
+  LANGUAGE plpgsql
+  STABLE
+AS $function$
+DECLARE
+  raw text;
+BEGIN
+  raw := current_setting('breeze.accessible_partner_ids', true);
+
+  -- "*" means unrestricted partner access (system scope).
+  IF raw = '*' THEN
+    RETURN NULL;
+  END IF;
+
+  -- Empty/missing means no partner access.
+  IF raw IS NULL OR raw = '' THEN
+    RETURN ARRAY[]::uuid[];
+  END IF;
+
+  RETURN string_to_array(raw, ',')::uuid[];
+EXCEPTION
+  WHEN others THEN
+    -- Fail closed on malformed values.
+    RETURN ARRAY[]::uuid[];
+END;
+$function$;
+
+-- ============================================================
+-- 4. breeze_has_partner_access() — verbatim from partners-rls.sql.
+--    Depends on breeze_current_scope() from 0008-tenant-rls.sql, which
+--    is always available on any DB that has ever run migrations.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.breeze_has_partner_access(target_partner_id uuid)
+  RETURNS boolean
+  LANGUAGE sql
+  STABLE
+AS $function$
+  SELECT CASE
+    WHEN public.breeze_current_scope() = 'system' THEN TRUE
+    WHEN target_partner_id IS NULL THEN FALSE
+    ELSE COALESCE(target_partner_id = ANY(public.breeze_accessible_partner_ids()), FALSE)
+  END;
+$function$;
+
+COMMIT;

--- a/apps/api/src/db/autoMigrate.test.ts
+++ b/apps/api/src/db/autoMigrate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { detectState, hashSql } from './autoMigrate';
+import { detectState, hashSql, deriveAppConnectionString } from './autoMigrate';
 import { createHash } from 'node:crypto';
 
 describe('autoMigrate', () => {
@@ -57,6 +57,76 @@ describe('autoMigrate', () => {
       `;
       const expected = createHash('sha256').update(sql).digest('hex');
       expect(hashSql(sql)).toBe(expected);
+    });
+  });
+
+  describe('deriveAppConnectionString', () => {
+    it('swaps user and password on a basic URL', () => {
+      const result = deriveAppConnectionString(
+        'postgresql://breeze:secret@db:5432/breeze',
+        'breeze_app',
+        'app_secret',
+      );
+      expect(result).toBe('postgresql://breeze_app:app_secret@db:5432/breeze');
+    });
+
+    it('preserves query params like sslmode', () => {
+      const result = deriveAppConnectionString(
+        'postgresql://breeze:secret@db:5432/breeze?sslmode=require',
+        'breeze_app',
+        'app_secret',
+      );
+      expect(result).toBe('postgresql://breeze_app:app_secret@db:5432/breeze?sslmode=require');
+    });
+
+    it('preserves host and port', () => {
+      const result = deriveAppConnectionString(
+        'postgresql://admin:x@pg.internal.example.com:6432/production',
+        'breeze_app',
+        'pw',
+      );
+      expect(result).toBe('postgresql://breeze_app:pw@pg.internal.example.com:6432/production');
+    });
+
+    it('URL-encodes special characters in the password', () => {
+      const result = deriveAppConnectionString(
+        'postgresql://breeze:x@db:5432/breeze',
+        'breeze_app',
+        'p@ss/word:with spaces',
+      );
+      // The URL class percent-encodes @ / : and space in password position.
+      expect(result).toContain('breeze_app:');
+      // parsed.password returns the raw percent-encoded form; decoding it
+      // should round-trip to the original (that's what postgres-js does
+      // when it parses the connection string).
+      const parsed = new URL(result!);
+      expect(decodeURIComponent(parsed.password)).toBe('p@ss/word:with spaces');
+      expect(parsed.username).toBe('breeze_app');
+    });
+
+    it('returns null when password is undefined', () => {
+      expect(
+        deriveAppConnectionString('postgresql://breeze:x@db:5432/breeze', 'breeze_app', undefined),
+      ).toBeNull();
+    });
+
+    it('returns null when password is empty string', () => {
+      expect(
+        deriveAppConnectionString('postgresql://breeze:x@db:5432/breeze', 'breeze_app', ''),
+      ).toBeNull();
+    });
+
+    it('returns null when admin URL is unparseable', () => {
+      expect(deriveAppConnectionString('not a url', 'breeze_app', 'pw')).toBeNull();
+    });
+
+    it('works with postgres:// scheme as well as postgresql://', () => {
+      const result = deriveAppConnectionString(
+        'postgres://breeze:secret@db:5432/breeze',
+        'breeze_app',
+        'app_secret',
+      );
+      expect(result).toBe('postgres://breeze_app:app_secret@db:5432/breeze');
     });
   });
 

--- a/apps/api/src/db/autoMigrate.ts
+++ b/apps/api/src/db/autoMigrate.ts
@@ -18,6 +18,30 @@ export function hashSql(content: string): string {
 }
 
 /**
+ * Build a connection string for the unprivileged `breeze_app` role by taking
+ * an admin DATABASE_URL and swapping in the app user+password. Returns null
+ * if no password is available or the admin URL can't be parsed — callers
+ * should treat null as "cannot auto-configure, require DATABASE_URL_APP".
+ *
+ * Exported for unit testing.
+ */
+export function deriveAppConnectionString(
+  adminUrl: string,
+  appUser: string,
+  appPassword: string | undefined,
+): string | null {
+  if (!appPassword) return null;
+  try {
+    const url = new URL(adminUrl);
+    url.username = appUser;
+    url.password = appPassword;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Determine the database state based on whether key tables exist.
  *
  * - `fresh`  — no `users` table → run every migration from scratch
@@ -242,40 +266,50 @@ export async function autoMigrate(): Promise<void> {
     //        an admin connection and runs before the main app connects.
     await ensureAppRole();
 
-    const appConnString =
-      process.env.DATABASE_URL_APP
-      || process.env.DATABASE_URL
-      || 'postgresql://breeze:breeze@localhost:5432/breeze';
+    // Resolve the app connection string. Preference order:
+    //   1. DATABASE_URL_APP (explicit, operator-provided)
+    //   2. Derived from DATABASE_URL by swapping user → breeze_app and
+    //      password → BREEZE_APP_DB_PASSWORD / POSTGRES_PASSWORD
+    //   3. DATABASE_URL itself — but the probe below will then hard-fail
+    //      because that's the superuser connection
+    const explicitAppUrl = process.env.DATABASE_URL_APP;
+    const derivedAppUrl = explicitAppUrl
+      ? null
+      : deriveAppConnectionString(
+          connectionString,
+          'breeze_app',
+          process.env.BREEZE_APP_DB_PASSWORD || process.env.POSTGRES_PASSWORD,
+        );
+    if (!explicitAppUrl && derivedAppUrl) {
+      console.log(
+        '[auto-migrate] DATABASE_URL_APP not set — derived unprivileged app connection from DATABASE_URL',
+      );
+    }
+    const appConnString = explicitAppUrl || derivedAppUrl || connectionString;
+
     const appClient = postgres(appConnString, { max: 1 });
     try {
       const rows = await appClient`
-        SELECT current_user AS user, rolsuper, rolbypassrls
+        SELECT current_user AS "user", rolsuper, rolbypassrls
         FROM pg_roles
         WHERE rolname = current_user
       `;
       const me = rows[0];
-      if (me) {
-        console.log(
-          `[auto-migrate] App DB user: ${me.user} (super=${me.rolsuper}, bypassrls=${me.rolbypassrls})`,
-        );
-        if (me.rolbypassrls || me.rolsuper) {
-          console.warn(
-            `[auto-migrate] WARNING: App DB user "${me.user}" has BYPASSRLS/SUPERUSER — RLS policies are NOT enforced. Set DATABASE_URL_APP to postgresql://breeze_app:<pw>@... to connect as the unprivileged role.`,
-          );
-        }
-      } else {
-        console.warn(
-          '[auto-migrate] WARNING: Could not verify app DB role privileges — pg_roles returned no row for current_user. This may indicate a misconfigured role setup.',
+      if (!me) {
+        throw new Error(
+          'App DB role verification returned no row for current_user — cannot confirm RLS enforcement. Refusing to start.',
         );
       }
-    } catch (err) {
-      // Non-fatal: the probe itself failed (e.g., transient connectivity,
-      // auth mismatch). Log loudly so operators can see it, but continue
-      // startup so a flaky probe doesn't block the whole API.
-      const message = err instanceof Error ? err.message : String(err);
-      console.error(
-        `[auto-migrate] WARNING: BYPASSRLS assertion probe failed — RLS enforcement status unknown: ${message}`,
+      console.log(
+        `[auto-migrate] App DB user: ${me.user} (super=${me.rolsuper}, bypassrls=${me.rolbypassrls})`,
       );
+      if (me.rolbypassrls || me.rolsuper) {
+        throw new Error(
+          `App DB user "${me.user}" has BYPASSRLS or SUPERUSER — RLS policies would not be enforced. `
+            + 'Refusing to start. Either set DATABASE_URL_APP to a non-superuser connection string, '
+            + 'or set BREEZE_APP_DB_PASSWORD / POSTGRES_PASSWORD so the app URL can be derived automatically.',
+        );
+      }
     } finally {
       await appClient.end();
     }

--- a/apps/api/src/routes/systemTools/fileBrowser.ts
+++ b/apps/api/src/routes/systemTools/fileBrowser.ts
@@ -5,6 +5,12 @@ import { authMiddleware, requireScope } from '../../middleware/auth';
 import { executeCommand, CommandTypes } from '../../services/commandQueue';
 import { createAuditLog } from '../../services/auditService';
 import { getDeviceWithOrgCheck } from './helpers';
+import {
+  isCommandFailure,
+  mapCommandFailure,
+  buildBulkItemFailure,
+  auditErrorMessage,
+} from './fileBrowserHelpers';
 import { deviceIdParamSchema, fileListQuerySchema, fileDownloadQuerySchema, fileCopyBodySchema, fileMoveBodySchema, fileDeleteBodySchema, fileTrashRestoreBodySchema, fileTrashPurgeBodySchema, fileUploadBodySchema } from './schemas';
 
 export const fileBrowserRoutes = new Hono();
@@ -30,8 +36,9 @@ fileBrowserRoutes.get(
       path
     }, { userId: auth.user?.id, timeoutMs: 30000 });
 
-    if (result.status === 'failed') {
-      return c.json({ error: result.error || 'Agent failed to list files. The device may be offline.' }, 502);
+    if (isCommandFailure(result)) {
+      const { message, status } = mapCommandFailure(result, 'Failed to list files.');
+      return c.json({ error: message }, status);
     }
 
     try {
@@ -63,8 +70,9 @@ fileBrowserRoutes.get(
       timeoutMs: 15000,
     });
 
-    if (result.status === 'failed') {
-      return c.json({ error: result.error || 'Agent failed to list drives. The device may be offline.' }, 502);
+    if (isCommandFailure(result)) {
+      const { message, status } = mapCommandFailure(result, 'Failed to list drives.');
+      return c.json({ error: message }, status);
     }
 
     try {
@@ -98,9 +106,13 @@ fileBrowserRoutes.get(
       encoding: 'base64'
     }, { userId: auth.user?.id, timeoutMs: 30000 });
 
-    if (result.status === 'failed') {
-      const error = result.error || 'Failed to read file';
-      return c.json({ error }, error.toLowerCase().includes('not found') ? 404 : 500);
+    if (isCommandFailure(result)) {
+      const raw = result.error || '';
+      if (raw.toLowerCase().includes('not found')) {
+        return c.json({ error: raw }, 404);
+      }
+      const { message, status } = mapCommandFailure(result, 'Failed to read file.');
+      return c.json({ error: message }, status);
     }
 
     try {
@@ -173,11 +185,13 @@ fileBrowserRoutes.post(
         sizeBytes: body.content.length
       },
       ipAddress: c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip'),
-      result: result.status === 'failed' ? 'failure' : 'success'
+      result: isCommandFailure(result) ? 'failure' : 'success',
+      errorMessage: isCommandFailure(result) ? auditErrorMessage(result) : undefined,
     });
 
-    if (result.status === 'failed') {
-      return c.json({ error: result.error || 'Failed to write file' }, 500);
+    if (isCommandFailure(result)) {
+      const { message, status } = mapCommandFailure(result, 'Failed to write file.', { mutating: true });
+      return c.json({ error: message }, status);
     }
 
     try {
@@ -224,12 +238,14 @@ fileBrowserRoutes.post(
           destPath: item.destPath,
         }, { userId: auth.user?.id, timeoutMs: 60000 });
 
-        const success = result.status !== 'failed';
+        const success = !isCommandFailure(result);
+        const failure = success ? null : buildBulkItemFailure(result);
         results.push({
           sourcePath: item.sourcePath,
           destPath: item.destPath,
           status: success ? 'success' : 'failure',
-          error: success ? undefined : result.error,
+          error: failure?.message,
+          unverified: failure?.unverified || undefined,
         });
 
         await createAuditLog({
@@ -240,10 +256,10 @@ fileBrowserRoutes.post(
           resourceType: 'device',
           resourceId: deviceId,
           resourceName: device.hostname ?? device.id,
-          details: { sourcePath: item.sourcePath, destPath: item.destPath },
+          details: { sourcePath: item.sourcePath, destPath: item.destPath, unverified: failure?.unverified || undefined },
           ipAddress: c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip'),
           result: success ? 'success' : 'failure',
-          errorMessage: success ? undefined : result.error,
+          errorMessage: success ? undefined : auditErrorMessage(result),
         }).catch(auditErr => console.error(`[fileBrowser] audit log failed for device ${deviceId}:`, auditErr instanceof Error ? auditErr.message : auditErr));
       } catch (err) {
         results.push({
@@ -285,12 +301,14 @@ fileBrowserRoutes.post(
           newPath: item.destPath,
         }, { userId: auth.user?.id, timeoutMs: 60000 });
 
-        const success = result.status !== 'failed';
+        const success = !isCommandFailure(result);
+        const failure = success ? null : buildBulkItemFailure(result);
         results.push({
           sourcePath: item.sourcePath,
           destPath: item.destPath,
           status: success ? 'success' : 'failure',
-          error: success ? undefined : result.error,
+          error: failure?.message,
+          unverified: failure?.unverified || undefined,
         });
 
         await createAuditLog({
@@ -301,10 +319,10 @@ fileBrowserRoutes.post(
           resourceType: 'device',
           resourceId: deviceId,
           resourceName: device.hostname ?? device.id,
-          details: { sourcePath: item.sourcePath, destPath: item.destPath },
+          details: { sourcePath: item.sourcePath, destPath: item.destPath, unverified: failure?.unverified || undefined },
           ipAddress: c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip'),
           result: success ? 'success' : 'failure',
-          errorMessage: success ? undefined : result.error,
+          errorMessage: success ? undefined : auditErrorMessage(result),
         }).catch(auditErr => console.error(`[fileBrowser] audit log failed for device ${deviceId}:`, auditErr instanceof Error ? auditErr.message : auditErr));
       } catch (err) {
         results.push({
@@ -348,11 +366,13 @@ fileBrowserRoutes.post(
           deletedBy: auth.user?.email || auth.user?.id,
         }, { userId: auth.user?.id, timeoutMs: 30000 });
 
-        const success = result.status !== 'failed';
+        const success = !isCommandFailure(result);
+        const failure = success ? null : buildBulkItemFailure(result);
         results.push({
           path,
           status: success ? 'success' : 'failure',
-          error: success ? undefined : result.error,
+          error: failure?.message,
+          unverified: failure?.unverified || undefined,
         });
 
         await createAuditLog({
@@ -363,10 +383,10 @@ fileBrowserRoutes.post(
           resourceType: 'device',
           resourceId: deviceId,
           resourceName: device.hostname ?? device.id,
-          details: { path, permanent },
+          details: { path, permanent, unverified: failure?.unverified || undefined },
           ipAddress: c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip'),
           result: success ? 'success' : 'failure',
-          errorMessage: success ? undefined : result.error,
+          errorMessage: success ? undefined : auditErrorMessage(result),
         }).catch(auditErr => console.error(`[fileBrowser] audit log failed for device ${deviceId}:`, auditErr instanceof Error ? auditErr.message : auditErr));
       } catch (err) {
         results.push({
@@ -399,8 +419,9 @@ fileBrowserRoutes.get(
 
     const result = await executeCommand(deviceId, CommandTypes.FILE_TRASH_LIST, {}, { userId: auth.user?.id, timeoutMs: 30000 });
 
-    if (result.status === 'failed') {
-      return c.json({ error: result.error || 'Failed to list trash' }, 502);
+    if (isCommandFailure(result)) {
+      const { message, status } = mapCommandFailure(result, 'Failed to list trash.');
+      return c.json({ error: message }, status);
     }
 
     try {
@@ -436,7 +457,8 @@ fileBrowserRoutes.post(
           trashId,
         }, { userId: auth.user?.id, timeoutMs: 30000 });
 
-        const success = result.status !== 'failed';
+        const success = !isCommandFailure(result);
+        const failure = success ? null : buildBulkItemFailure(result);
         let restoredPath: string | undefined;
         if (success) {
           try {
@@ -451,7 +473,8 @@ fileBrowserRoutes.post(
           trashId,
           status: success ? 'success' : 'failure',
           restoredPath,
-          error: success ? undefined : result.error,
+          error: failure?.message,
+          unverified: failure?.unverified || undefined,
         });
 
         await createAuditLog({
@@ -462,10 +485,10 @@ fileBrowserRoutes.post(
           resourceType: 'device',
           resourceId: deviceId,
           resourceName: device.hostname ?? device.id,
-          details: { trashId, restoredPath },
+          details: { trashId, restoredPath, unverified: failure?.unverified || undefined },
           ipAddress: c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip'),
           result: success ? 'success' : 'failure',
-          errorMessage: success ? undefined : result.error,
+          errorMessage: success ? undefined : auditErrorMessage(result),
         }).catch(auditErr => console.error(`[fileBrowser] audit log failed for device ${deviceId}:`, auditErr instanceof Error ? auditErr.message : auditErr));
       } catch (err) {
         results.push({
@@ -501,7 +524,7 @@ fileBrowserRoutes.post(
       trashIds: body.trashIds || [],
     }, { userId: auth.user?.id, timeoutMs: 30000 });
 
-    const success = result.status !== 'failed';
+    const success = !isCommandFailure(result);
 
     await createAuditLog({
       orgId: device.orgId,
@@ -511,14 +534,19 @@ fileBrowserRoutes.post(
       resourceType: 'device',
       resourceId: deviceId,
       resourceName: device.hostname ?? device.id,
-      details: { trashIds: body.trashIds, purgeAll: !body.trashIds },
+      details: {
+        trashIds: body.trashIds,
+        purgeAll: !body.trashIds,
+        unverified: result.status === 'timeout' ? true : undefined,
+      },
       ipAddress: c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip'),
       result: success ? 'success' : 'failure',
-      errorMessage: success ? undefined : result.error,
+      errorMessage: success ? undefined : auditErrorMessage(result),
     }).catch(auditErr => console.error(`[fileBrowser] audit log failed for device ${deviceId}:`, auditErr instanceof Error ? auditErr.message : auditErr));
 
-    if (result.status === 'failed') {
-      return c.json({ error: result.error || 'Failed to purge trash' }, 502);
+    if (isCommandFailure(result)) {
+      const { message, status } = mapCommandFailure(result, 'Failed to purge trash.', { mutating: true });
+      return c.json({ error: message }, status);
     }
 
     try {

--- a/apps/api/src/routes/systemTools/fileBrowserHelpers.test.ts
+++ b/apps/api/src/routes/systemTools/fileBrowserHelpers.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isCommandFailure,
+  mapCommandFailure,
+  buildBulkItemFailure,
+  auditErrorMessage,
+} from './fileBrowserHelpers';
+import { DEVICE_UNREACHABLE_ERROR, type CommandResult } from '../../services/commandQueue';
+
+describe('isCommandFailure', () => {
+  it('treats failed status as a failure', () => {
+    expect(isCommandFailure({ status: 'failed', error: 'boom' })).toBe(true);
+  });
+
+  it('treats timeout status as a failure (this is the latent-bug fix)', () => {
+    // The pre-fix code only checked status === 'failed', which let timeouts
+    // fall through to JSON.parse(result.stdout) and surface a confusing 500.
+    expect(isCommandFailure({ status: 'timeout', error: 'timed out' })).toBe(true);
+  });
+
+  it('treats completed status as success', () => {
+    expect(isCommandFailure({ status: 'completed', stdout: '{}' })).toBe(false);
+  });
+});
+
+describe('mapCommandFailure', () => {
+  it('maps DEVICE_UNREACHABLE_ERROR to 503 with the sentinel message', () => {
+    const result: CommandResult = { status: 'failed', error: DEVICE_UNREACHABLE_ERROR };
+    expect(mapCommandFailure(result, 'fallback')).toEqual({
+      message: DEVICE_UNREACHABLE_ERROR,
+      status: 503,
+    });
+  });
+
+  it('maps timeout status to 504 with the friendly retry message', () => {
+    const result: CommandResult = { status: 'timeout', error: 'Command timed out after 30000ms' };
+    const mapped = mapCommandFailure(result, 'fallback');
+    expect(mapped.status).toBe(504);
+    expect(mapped.message).toMatch(/didn't respond in time/i);
+    expect(mapped.message).toMatch(/please try again/i);
+  });
+
+  it('maps "timed out" error string to 504 even when status is failed', () => {
+    // Some agent paths return status='failed' with a timeout-shaped error
+    // string. The regex fallback must still classify these as timeouts so the
+    // user gets the same UI treatment.
+    const result: CommandResult = { status: 'failed', error: 'agent: command timed out at 30s' };
+    const mapped = mapCommandFailure(result, 'fallback');
+    expect(mapped.status).toBe(504);
+    expect(mapped.message).toMatch(/didn't respond in time/i);
+  });
+
+  it('maps "did not complete" error string to 504', () => {
+    const result: CommandResult = { status: 'failed', error: 'Command did not complete' };
+    expect(mapCommandFailure(result, 'fallback').status).toBe(504);
+  });
+
+  it('regex matching is case-insensitive', () => {
+    const result: CommandResult = { status: 'failed', error: 'COMMAND TIMED OUT' };
+    expect(mapCommandFailure(result, 'fallback').status).toBe(504);
+  });
+
+  it('uses the mutating message when opts.mutating is true', () => {
+    const result: CommandResult = { status: 'timeout', error: 'Command timed out after 60000ms' };
+    const mapped = mapCommandFailure(result, 'fallback', { mutating: true });
+    expect(mapped.message).toMatch(/may have completed/i);
+    expect(mapped.message).toMatch(/refresh to verify/i);
+    // Critical: must NOT tell the user to "try again" — that's dangerous for
+    // mutations whose final state is unknown.
+    expect(mapped.message).not.toMatch(/please try again/i);
+  });
+
+  it('maps offline-shaped errors to 503 with a clean message', () => {
+    const result: CommandResult = {
+      status: 'failed',
+      error: 'Device is offline, cannot execute command',
+    };
+    expect(mapCommandFailure(result, 'fallback')).toEqual({
+      message: 'The device is offline.',
+      status: 503,
+    });
+  });
+
+  it('maps unknown-status devices to 503', () => {
+    const result: CommandResult = { status: 'failed', error: 'Device is unknown' };
+    expect(mapCommandFailure(result, 'fallback').status).toBe(503);
+  });
+
+  it('falls through to 502 with the raw error for generic failures', () => {
+    const result: CommandResult = { status: 'failed', error: 'Permission denied' };
+    expect(mapCommandFailure(result, 'fallback')).toEqual({
+      message: 'Permission denied',
+      status: 502,
+    });
+  });
+
+  it('uses the fallback string when no error is present', () => {
+    const result: CommandResult = { status: 'failed' };
+    expect(mapCommandFailure(result, 'Failed to do the thing.')).toEqual({
+      message: 'Failed to do the thing.',
+      status: 502,
+    });
+  });
+
+  it('does NOT mistake DEVICE_UNREACHABLE_ERROR for offline (sentinel takes precedence)', () => {
+    // The unreachable sentinel must always map to 503 with its own message,
+    // even though it contains words that the offline regex might match.
+    const result: CommandResult = { status: 'failed', error: DEVICE_UNREACHABLE_ERROR };
+    const mapped = mapCommandFailure(result, 'fallback');
+    expect(mapped.message).toBe(DEVICE_UNREACHABLE_ERROR);
+    expect(mapped.message).not.toBe('The device is offline.');
+  });
+});
+
+describe('buildBulkItemFailure', () => {
+  it('marks timeouts as unverified with refresh-to-verify guidance', () => {
+    const result: CommandResult = { status: 'timeout', error: 'Command timed out after 60000ms' };
+    const failure = buildBulkItemFailure(result);
+    expect(failure.unverified).toBe(true);
+    expect(failure.message).toMatch(/may have completed on the device/i);
+    expect(failure.message).toMatch(/refresh to verify/i);
+  });
+
+  it('non-timeout failures are not flagged as unverified', () => {
+    const result: CommandResult = { status: 'failed', error: 'Permission denied' };
+    const failure = buildBulkItemFailure(result);
+    expect(failure.unverified).toBe(false);
+    expect(failure.message).toBe('Permission denied');
+  });
+
+  it('passes the unreachable sentinel through with unverified=false', () => {
+    // When the API short-circuits with DEVICE_UNREACHABLE_ERROR the operation
+    // never reached the device, so there is nothing to verify.
+    const result: CommandResult = { status: 'failed', error: DEVICE_UNREACHABLE_ERROR };
+    const failure = buildBulkItemFailure(result);
+    expect(failure.unverified).toBe(false);
+    expect(failure.message).toBe(DEVICE_UNREACHABLE_ERROR);
+  });
+});
+
+describe('auditErrorMessage', () => {
+  it('tags timeouts with [unverified] so admins can spot them in audit logs', () => {
+    const result: CommandResult = { status: 'timeout', error: 'Command timed out after 60000ms' };
+    expect(auditErrorMessage(result)).toBe('[unverified] Command timed out after 60000ms');
+  });
+
+  it('tags timeouts even when result.error is missing', () => {
+    const result: CommandResult = { status: 'timeout' };
+    const msg = auditErrorMessage(result);
+    expect(msg).toMatch(/^\[unverified\]/);
+    expect(msg).toMatch(/timed out|not confirmed/i);
+  });
+
+  it('returns the raw error untouched for non-timeout failures', () => {
+    const result: CommandResult = { status: 'failed', error: 'Permission denied' };
+    expect(auditErrorMessage(result)).toBe('Permission denied');
+  });
+
+  it('returns undefined when there is no error to record', () => {
+    const result: CommandResult = { status: 'completed' };
+    expect(auditErrorMessage(result)).toBeUndefined();
+  });
+});

--- a/apps/api/src/routes/systemTools/fileBrowserHelpers.ts
+++ b/apps/api/src/routes/systemTools/fileBrowserHelpers.ts
@@ -1,0 +1,77 @@
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
+import {
+  DEVICE_UNREACHABLE_ERROR,
+  type CommandResult,
+} from '../../services/commandQueue';
+
+// True for any agent CommandResult that should map to an HTTP error response.
+// Both 'failed' and 'timeout' must be treated as failures: previously the
+// route code only checked 'failed', which let timeouts silently fall through
+// to the JSON.parse path and surface a generic 500.
+export function isCommandFailure(result: CommandResult): boolean {
+  return result.status === 'failed' || result.status === 'timeout';
+}
+
+// Map a failed/timed-out agent CommandResult to a user-facing message + HTTP
+// status. The shared sentinels (DEVICE_UNREACHABLE_ERROR, status === 'timeout')
+// let us distinguish "device is gone" from "we lost a packet to a brief
+// hiccup", which the user otherwise has no way to tell apart.
+//
+// `mutating` flips the timeout-branch message to warn the user that the
+// operation may have already completed on the device, so they verify before
+// retrying. Use it for any route that changes state on success.
+export function mapCommandFailure(
+  result: CommandResult,
+  fallback: string,
+  opts: { mutating?: boolean } = {},
+): { message: string; status: ContentfulStatusCode } {
+  const raw = result.error || '';
+  if (raw === DEVICE_UNREACHABLE_ERROR) {
+    return { message: DEVICE_UNREACHABLE_ERROR, status: 503 };
+  }
+  if (result.status === 'timeout' || /timed out|did not complete/i.test(raw)) {
+    return {
+      message: opts.mutating
+        ? "The device didn't respond in time. The operation may have completed — refresh to verify before retrying."
+        : "The device didn't respond in time. This usually means a brief network issue. Please try again.",
+      status: 504,
+    };
+  }
+  if (/cannot execute command|is offline|is unknown/i.test(raw)) {
+    return { message: 'The device is offline.', status: 503 };
+  }
+  return { message: raw || fallback, status: 502 };
+}
+
+// Bulk-item variant for routes that mutate state per item (copy/move/delete/
+// restore/trash-purge). On a timeout we cannot tell whether the agent
+// completed the operation or not — telling the user "brief network issue,
+// please try again" is dangerous because re-running a delete/move/purge
+// against a half-completed state can compound the damage. Mark these as
+// `unverified` so the UI can prompt the user to refresh and check.
+export function buildBulkItemFailure(result: CommandResult): {
+  message: string;
+  unverified: boolean;
+} {
+  if (result.status === 'timeout') {
+    return {
+      message:
+        "The device didn't respond in time. The operation may have completed on the device — refresh to verify before retrying.",
+      unverified: true,
+    };
+  }
+  return {
+    message: mapCommandFailure(result, 'Operation failed.').message,
+    unverified: false,
+  };
+}
+
+// Tag audit-log errorMessage so admins reviewing the audit trail can spot
+// commands whose final state on the device is unverified. Returns undefined
+// for successes so callers can pass the result through unchanged.
+export function auditErrorMessage(result: CommandResult): string | undefined {
+  if (result.status === 'timeout') {
+    return `[unverified] ${result.error || 'Command timed out — agent state not confirmed.'}`;
+  }
+  return result.error || undefined;
+}

--- a/apps/api/src/services/commandQueue.test.ts
+++ b/apps/api/src/services/commandQueue.test.ts
@@ -5,9 +5,17 @@ import {
   executeCommand,
   getPendingCommands,
   markCommandsSent,
-  submitCommandResult
+  submitCommandResult,
+  DEVICE_UNREACHABLE_ERROR,
+  SEND_RETRY_ATTEMPTS,
+  CommandTypes,
 } from './commandQueue';
 import { db } from '../db';
+import { sendCommandToAgent, isAgentConnected } from '../routes/agentWs';
+import {
+  claimPendingCommandForDelivery,
+  releaseClaimedCommandDelivery,
+} from './commandDispatch';
 
 vi.mock('../db', () => ({
   db: {
@@ -15,7 +23,23 @@ vi.mock('../db', () => ({
     insert: vi.fn(),
     update: vi.fn()
   },
-  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn())
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../routes/agentWs', () => ({
+  sendCommandToAgent: vi.fn(),
+  isAgentConnected: vi.fn(),
+}));
+
+vi.mock('./commandDispatch', () => ({
+  claimPendingCommandForDelivery: vi.fn(),
+  releaseClaimedCommandDelivery: vi.fn(),
+}));
+
+vi.mock('./sentry', () => ({
+  captureException: vi.fn(),
 }));
 
 vi.mock('./backupMetrics', () => ({
@@ -247,5 +271,186 @@ describe('command queue service', () => {
       status: 'completed',
       result: expect.objectContaining({ status: 'completed' })
     }));
+  });
+
+  describe('executeCommand interactive WS handling', () => {
+    // Wires up the mocks executeCommand needs once it gets past the device
+    // lookup: DB row for the command, an audit-log insert, the dispatch
+    // claim, and the polling fetch that returns a completed result.
+    function setupOnlineDeviceMocks(opts: {
+      completedResult?: unknown;
+      pollFirst?: unknown;
+    } = {}) {
+      const device = {
+        id: 'dev-online',
+        status: 'online',
+        agentId: 'agent-1',
+        orgId: 'org-1',
+        hostname: 'host-1',
+      };
+      const queued = { id: 'cmd-x' };
+      const completed = opts.completedResult ?? {
+        id: 'cmd-x',
+        status: 'completed',
+        result: { status: 'completed', stdout: 'ok' },
+      };
+
+      let pollCall = 0;
+      vi.mocked(db.select).mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockImplementation(() => {
+              pollCall += 1;
+              if (pollCall === 1) return Promise.resolve([device]);
+              if (pollCall === 2 && opts.pollFirst) return Promise.resolve([opts.pollFirst]);
+              return Promise.resolve([completed]);
+            }),
+          }),
+        }),
+      }) as any);
+
+      vi.mocked(db.insert).mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([queued]),
+          execute: vi.fn().mockResolvedValue(undefined),
+        }),
+      } as any);
+
+      vi.mocked(claimPendingCommandForDelivery).mockResolvedValue({
+        id: 'cmd-x',
+        executedAt: new Date(),
+      });
+      vi.mocked(releaseClaimedCommandDelivery).mockResolvedValue(undefined);
+    }
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('fast-fails interactive command when WS pool has no live connection', async () => {
+      const device = {
+        id: 'dev-online',
+        status: 'online',
+        agentId: 'agent-1',
+        orgId: 'org-1',
+        hostname: 'host-1',
+      };
+
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([device]),
+          }),
+        }),
+      } as any);
+      vi.mocked(isAgentConnected).mockReturnValue(false);
+
+      const result = await executeCommand('dev-online', CommandTypes.FILE_LIST, { path: '/' });
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toBe(DEVICE_UNREACHABLE_ERROR);
+      // Must NOT have queued a row or attempted dispatch.
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(claimPendingCommandForDelivery).not.toHaveBeenCalled();
+      expect(sendCommandToAgent).not.toHaveBeenCalled();
+    });
+
+    it('does NOT fast-fail non-interactive commands when WS is dead', async () => {
+      // Backup commands and similar must still queue normally so the agent
+      // can pick them up via heartbeat after reconnect.
+      setupOnlineDeviceMocks();
+      vi.mocked(isAgentConnected).mockReturnValue(false);
+      vi.mocked(sendCommandToAgent).mockReturnValue(false);
+
+      const result = await executeCommand('dev-online', CommandTypes.PATCH_SCAN);
+
+      // It still goes through queue → dispatch attempts → poll completion.
+      expect(db.insert).toHaveBeenCalled();
+      expect(result.status).toBe('completed');
+    });
+
+    it('retries sendCommandToAgent and succeeds on a later attempt', async () => {
+      vi.useFakeTimers();
+      setupOnlineDeviceMocks();
+      vi.mocked(isAgentConnected).mockReturnValue(true);
+      vi.mocked(sendCommandToAgent)
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true);
+
+      const promise = executeCommand('dev-online', CommandTypes.FILE_LIST, { path: '/' });
+      // Advance through the 500ms retry sleep + the polling loop interval.
+      await vi.advanceTimersByTimeAsync(2000);
+      const result = await promise;
+
+      expect(sendCommandToAgent).toHaveBeenCalledTimes(2);
+      // Claim must NOT be released — the second send succeeded.
+      expect(releaseClaimedCommandDelivery).not.toHaveBeenCalled();
+      expect(result.status).toBe('completed');
+    });
+
+    it('releases the claim and short-circuits with DEVICE_UNREACHABLE_ERROR after exhausting all retries', async () => {
+      vi.useFakeTimers();
+      setupOnlineDeviceMocks();
+      vi.mocked(isAgentConnected).mockReturnValue(true);
+      vi.mocked(sendCommandToAgent).mockReturnValue(false);
+
+      const promise = executeCommand(
+        'dev-online',
+        CommandTypes.FILE_LIST,
+        { path: '/' },
+        // Use a long timeout to prove we DON'T wait for it; the short-circuit
+        // must return promptly after the retry loop, not after timeoutMs.
+        { timeoutMs: 30000 },
+      );
+      // Only need to advance through the retry sleeps (~1s total).
+      await vi.advanceTimersByTimeAsync(2000);
+      const result = await promise;
+
+      // SEND_RETRY_ATTEMPTS attempts, then release exactly once.
+      expect(sendCommandToAgent).toHaveBeenCalledTimes(SEND_RETRY_ATTEMPTS);
+      expect(releaseClaimedCommandDelivery).toHaveBeenCalledTimes(1);
+      // Caller sees the unreachable sentinel — the file browser maps this to
+      // the "device unreachable" UI message rather than burning the timeout.
+      expect(result.status).toBe('failed');
+      expect(result.error).toBe(DEVICE_UNREACHABLE_ERROR);
+    });
+
+    it('skips dispatch entirely when claimPendingCommandForDelivery returns null', async () => {
+      // Simulates another worker (or the heartbeat path) having already
+      // claimed the command. The send path must be a no-op so we don't
+      // double-dispatch, and we must still poll for the eventual result.
+      setupOnlineDeviceMocks();
+      vi.mocked(isAgentConnected).mockReturnValue(true);
+      vi.mocked(claimPendingCommandForDelivery).mockResolvedValue(null);
+
+      const result = await executeCommand('dev-online', CommandTypes.FILE_LIST, { path: '/' });
+
+      expect(sendCommandToAgent).not.toHaveBeenCalled();
+      expect(releaseClaimedCommandDelivery).not.toHaveBeenCalled();
+      // Polling still happens — the other worker will fulfill the command.
+      expect(result.status).toBe('completed');
+    });
+
+    it('skips the WS pre-check when preferHeartbeat is true', async () => {
+      // Heartbeat-preferred callers (e.g. Tauri helper) intentionally let the
+      // command queue and wait for the next agent poll, so the WS pre-check
+      // must not short-circuit them even when isAgentConnected is false.
+      setupOnlineDeviceMocks();
+      vi.mocked(isAgentConnected).mockReturnValue(false);
+
+      const result = await executeCommand(
+        'dev-online',
+        CommandTypes.FILE_LIST,
+        { path: '/' },
+        { preferHeartbeat: true },
+      );
+
+      // Must NOT have fast-failed: the row should have been queued and the
+      // poll should have returned the completed result.
+      expect(db.insert).toHaveBeenCalled();
+      expect(result.status).toBe('completed');
+      // Dispatch path is skipped entirely because preferHeartbeat is true.
+      expect(sendCommandToAgent).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -1,13 +1,26 @@
 import { eq, and, inArray } from 'drizzle-orm';
 import { db, runOutsideDbContext, withDbAccessContext, withSystemDbAccessContext } from '../db';
 import { deviceCommands, devices, auditLogs } from '../db/schema';
-import { sendCommandToAgent } from '../routes/agentWs';
+import { sendCommandToAgent, isAgentConnected } from '../routes/agentWs';
 import { captureException } from './sentry';
 import { recordBackupCommandTimeout, recordRestoreTimeout } from './backupMetrics';
 import {
   claimPendingCommandForDelivery,
   releaseClaimedCommandDelivery,
 } from './commandDispatch';
+
+// Sentinel error string for the WS-pre-check fast-fail path. The fileBrowser
+// route (and any other interactive caller) matches on this substring to map
+// the failure to a "transiently unreachable" UI message distinct from offline.
+export const DEVICE_UNREACHABLE_ERROR =
+  'Device is not currently reachable over the live connection. Please try again in a moment.';
+
+// Number of times we attempt sendCommandToAgent before releasing the claim
+// and short-circuiting with DEVICE_UNREACHABLE_ERROR. With a 500 ms gap this
+// gives a transient WS hiccup ~1s of grace before the user sees a failure.
+// Exported so tests can derive the expected call count.
+export const SEND_RETRY_ATTEMPTS = 3;
+export const SEND_RETRY_DELAY_MS = 500;
 
 // Command types for system tools
 export const CommandTypes = {
@@ -272,6 +285,30 @@ const AUDITED_COMMANDS: Set<string> = new Set([
   // Incident response
   CommandTypes.COLLECT_EVIDENCE,
   CommandTypes.EXECUTE_CONTAINMENT,
+]);
+
+// User-interactive command types — the UI is actively waiting on the result
+// and a 15–30 s silent timeout is a bad experience. For these, executeCommand
+// pre-checks the WS pool and short-circuits with DEVICE_UNREACHABLE_ERROR if
+// no live connection exists, instead of queueing and waiting for the timeout.
+const INTERACTIVE_COMMAND_TYPES: Set<string> = new Set([
+  CommandTypes.FILE_LIST,
+  CommandTypes.FILE_LIST_DRIVES,
+  CommandTypes.FILE_READ,
+  CommandTypes.FILE_WRITE,
+  CommandTypes.FILE_DELETE,
+  CommandTypes.FILE_MKDIR,
+  CommandTypes.FILE_RENAME,
+  CommandTypes.FILE_COPY,
+  CommandTypes.FILE_TRASH_LIST,
+  CommandTypes.FILE_TRASH_RESTORE,
+  CommandTypes.FILE_TRASH_PURGE,
+  CommandTypes.TERMINAL_START,
+  CommandTypes.TERMINAL_DATA,
+  CommandTypes.TERMINAL_RESIZE,
+  CommandTypes.TERMINAL_STOP,
+  CommandTypes.TAKE_SCREENSHOT,
+  CommandTypes.COMPUTER_ACTION,
 ]);
 
 /**
@@ -548,6 +585,28 @@ export async function executeCommand(
     return { status: 'failed', error: `Device is ${device.status}, cannot execute command` };
   }
 
+  // Fast-fail interactive commands when the WS is known-dead. The user is
+  // actively waiting in the UI; queueing and burning the full timeout when
+  // we already know the connection is gone wastes ~15–30 s and surfaces a
+  // misleading error. Non-interactive callers (and the heartbeat fallback)
+  // can still queue normally.
+  if (
+    device.agentId &&
+    !preferHeartbeat &&
+    INTERACTIVE_COMMAND_TYPES.has(type) &&
+    !isAgentConnected(device.agentId)
+  ) {
+    // Log so ops can correlate spikes of unreachable-fast-fails with WS pool
+    // health. This is the single most useful signal for diagnosing recurrences
+    // of issue #391 — without it the failure is invisible until users complain.
+    console.warn('[commandQueue] interactive command fast-fail (WS not connected)', {
+      deviceId,
+      agentId: device.agentId,
+      type,
+    });
+    return { status: 'failed' as const, error: DEVICE_UNREACHABLE_ERROR };
+  }
+
   // 2. Queue, dispatch, and poll OUTSIDE the auth transaction so the
   //    INSERT commits immediately and is visible to the WS handler.
   return runOutsideDbContextSafe(async () => {
@@ -605,17 +664,62 @@ export async function executeCommand(
         });
     }
 
-    // Dispatch via WebSocket
+    // Dispatch via WebSocket. Retry briefly on send failure: a transient WS
+    // hiccup (e.g. mid-reconnect) can fail a single send even when the
+    // connection comes back ~hundreds of ms later. Retrying gives the pool a
+    // chance to recover before we fall through to the multi-second timeout.
     if (device.agentId && !preferHeartbeat) {
       const claimed = await claimPendingCommandForDelivery(command.id);
       if (claimed) {
-        const sent = sendCommandToAgent(device.agentId, {
-          id: command.id,
-          type,
-          payload,
-        });
+        let sent = false;
+        for (let attempt = 0; attempt < SEND_RETRY_ATTEMPTS; attempt++) {
+          sent = sendCommandToAgent(device.agentId, {
+            id: command.id,
+            type,
+            payload,
+          });
+          if (sent) {
+            if (attempt > 0) {
+              console.warn('[commandQueue] sendCommandToAgent recovered after retry', {
+                commandId: command.id,
+                deviceId,
+                agentId: device.agentId,
+                type,
+                attempt: attempt + 1,
+              });
+            }
+            break;
+          }
+          console.warn('[commandQueue] sendCommandToAgent failed, will retry', {
+            commandId: command.id,
+            deviceId,
+            agentId: device.agentId,
+            type,
+            attempt: attempt + 1,
+            maxAttempts: SEND_RETRY_ATTEMPTS,
+          });
+          if (attempt < SEND_RETRY_ATTEMPTS - 1) {
+            await new Promise((resolve) => setTimeout(resolve, SEND_RETRY_DELAY_MS));
+          }
+        }
         if (!sent) {
           await releaseClaimedCommandDelivery(command.id, claimed.executedAt);
+          console.warn('[commandQueue] sendCommandToAgent exhausted retries', {
+            commandId: command.id,
+            deviceId,
+            agentId: device.agentId,
+            type,
+            attempts: SEND_RETRY_ATTEMPTS,
+          });
+          // All retries exhausted with no successful send. For interactive
+          // commands the user is staring at a spinner — short-circuit with
+          // the unreachable error rather than burning the full poll timeout.
+          // For non-interactive commands, fall through to polling: the agent
+          // may still pick the command up via the heartbeat path before the
+          // timeout fires, in which case the user gets a real result.
+          if (INTERACTIVE_COMMAND_TYPES.has(type)) {
+            return { status: 'failed' as const, error: DEVICE_UNREACHABLE_ERROR };
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

Two fixes bundled:

### 1. File browser timeout UX (#391)

Distinguishes "device transiently unreachable" from "device offline" so users get accurate, actionable errors instead of a misleading 30s silent timeout.

- **Fast-fail interactive commands** when the WS pool has no live connection — returns `DEVICE_UNREACHABLE_ERROR` immediately instead of queueing and waiting for timeout. Applies to `FILE_*`, `TERMINAL_*`, `TAKE_SCREENSHOT`, `COMPUTER_ACTION`.
- **Retry `sendCommandToAgent` 3× × 500ms** before releasing the dispatch claim, absorbing brief WS hiccups (~1s grace before user-visible failure).
- **Short-circuit poll wait after retry exhaustion** (interactive commands only) — non-interactive commands still get the heartbeat-pickup polling path.
- **`mapCommandFailure()` helper** in new `fileBrowserHelpers.ts` distinguishes timeout / unreachable / offline / generic across all file browser routes.
- **Latent bug fix:** previous code only checked `result.status === 'failed'`; `'timeout'` was falling through to `JSON.parse(result.stdout)` and surfacing a confusing 500. New `isCommandFailure()` catches both.
- **Destructive bulk-op timeouts flagged `unverified: true`** in per-item responses + audit logs (`[unverified]` errorMessage tag) — UI tells users to refresh and verify rather than safely retry a possibly-completed mutation.
- **Observability:** retry attempts, recover-after-retry, exhaustion, and fast-fail now log with `commandId/deviceId/agentId/type` so ops can correlate WS pool health with command failures.

### 2. RLS app role bootstrap (pre-existing commit `4e7c9993`)

Self-configures RLS app role + fixes fresh-install ordering. Unrelated to #391, included in this branch as it was already on local main.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/services/commandQueue.test.ts src/routes/systemTools/fileBrowserHelpers.test.ts src/services/commandQueueTransitions.test.ts` — 38/38 pass
- [x] New unit tests cover: fast-fail interactive, non-interactive bypass, retry success, retry exhaustion + short-circuit, claim returning null, preferHeartbeat bypass, all `mapCommandFailure` branches, `buildBulkItemFailure` unverified flag, `auditErrorMessage` tagging
- [ ] Manual: trigger a file browser timeout against a device with intermittent connectivity, confirm "didn't respond in time" message instead of "device may be offline"
- [ ] Manual: kill the agent WS mid-bulk-delete, confirm per-item responses include `unverified: true` and the UI shows the verify-before-retry message

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)