### PR TITLE
fix(agent): build fixes for all platforms (non-Windows stub + Windows field)

### DIFF
--- a/agent/internal/remote/desktop/dxgi_windows.go
+++ b/agent/internal/remote/desktop/dxgi_windows.go
@@ -198,6 +198,10 @@ type dxgiCapturer struct {
 	// may just cause timeouts instead).
 	lastDesktopCheck time.Time
 
+	// Rate limit the "desktop check skipped" diagnostic so logs don't
+	// explode when the skip condition persists across many 500ms ticks.
+	lastDesktopSkipLog time.Time
+
 	// Desktop switch notification for the session layer.
 	desktopSwitchFlag atomic.Bool // set on switch, cleared by ConsumeDesktopSwitch
 	secureDesktopFlag atomic.Bool // true when on Winlogon/Screen-saver

--- a/agent/internal/remote/desktop/prepare_capture_other.go
+++ b/agent/internal/remote/desktop/prepare_capture_other.go
@@ -5,3 +5,8 @@ package desktop
 // prepareCaptureThread is a no-op on non-Windows platforms.
 // Desktop switching is a Windows-specific concern for service/helper processes.
 func prepareCaptureThread() {}
+
+// switchThreadToInputDesktop is a no-op stub on non-Windows platforms.
+// The capture-loop watchdog calls this before forcing a capturer re-attach;
+// on macOS/Linux there is no concept of a "thread desktop" to re-attach to.
+func switchThreadToInputDesktop() bool { return false }


### PR DESCRIPTION
## Summary

Two related fixes that together unblock the agent build on every platform.

### 1. Non-Windows stub for switchThreadToInputDesktop

\`session_capture.go\` calls \`switchThreadToInputDesktop()\` from cross-platform code at lines 310 and 619, but the function was previously defined only in \`dxgi_desktop_windows.go\`. Add a no-op stub in the existing \`prepare_capture_other.go\` (gated to non-Windows). On macOS/Linux there is no "thread desktop" to re-attach to, so \`return false\` is correct.

### 2. Declare lastDesktopSkipLog field on dxgiCapturer

Windows build was failing with:
\`\`\`
dxgi_desktop_windows.go:337:18: c.lastDesktopSkipLog undefined
dxgi_desktop_windows.go:340:4: c.lastDesktopSkipLog undefined
\`\`\`

References were added without the matching field declaration. Add the field on the \`dxgiCapturer\` struct in \`dxgi_windows.go\` alongside \`lastDesktopCheck\`. Used to rate-limit a "desktop check skipped" diagnostic.

## Test plan

- [x] Local Go vet on touched files
- [ ] CI Build Agent (linux/amd64) green
- [ ] CI Build Agent (darwin/amd64) green
- [ ] CI Build Agent (darwin/arm64) green
- [ ] CI Build Agent (windows/amd64) green
- [ ] CI Test Agent green

🤖 Generated with [Claude Code](https://claude.com/claude-code)