### PR TITLE
test(api): fix mock debt across 163 test files

### DIFF
--- a/apps/api/src/jobs/alertQueue.test.ts
+++ b/apps/api/src/jobs/alertQueue.test.ts
@@ -27,6 +27,10 @@ vi.mock('../services/redis', () => ({
 
 vi.mock('../db', () => ({
   db: {},
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/jobs/browserSecurityJobs.test.ts
+++ b/apps/api/src/jobs/browserSecurityJobs.test.ts
@@ -27,6 +27,10 @@ vi.mock('../services/redis', () => ({
 
 vi.mock('../db', () => ({
   db: {},
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/jobs/deploymentWorker.test.ts
+++ b/apps/api/src/jobs/deploymentWorker.test.ts
@@ -38,6 +38,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     insert: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/jobs/offlineDetector.test.ts
+++ b/apps/api/src/jobs/offlineDetector.test.ts
@@ -21,6 +21,10 @@ vi.mock('bullmq', () => ({
 
 vi.mock('../db', () => ({
   db: {},
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/jobs/peripheralJobs.test.ts
+++ b/apps/api/src/jobs/peripheralJobs.test.ts
@@ -26,6 +26,10 @@ vi.mock('../services/redis', () => ({
 
 vi.mock('../db', () => ({
   db: {}
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/jobs/userRiskJobs.test.ts
+++ b/apps/api/src/jobs/userRiskJobs.test.ts
@@ -27,6 +27,10 @@ vi.mock('../services/redis', () => ({
 
 vi.mock('../db', () => ({
   db: {},
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/middleware/apiKeyAuth.test.ts
+++ b/apps/api/src/middleware/apiKeyAuth.test.ts
@@ -6,7 +6,8 @@ vi.mock('../db', () => ({
     select: vi.fn(),
     update: vi.fn()
   },
-  withDbAccessContext: vi.fn(async (_context, fn) => fn())
+  withDbAccessContext: vi.fn(async (_context, fn) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn())
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/middleware/apiKeyAuth.ts
+++ b/apps/api/src/middleware/apiKeyAuth.ts
@@ -2,7 +2,7 @@ import { Context, Next } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { createHash } from 'crypto';
 import { eq, and } from 'drizzle-orm';
-import { db, withDbAccessContext } from '../db';
+import { db, withDbAccessContext, withSystemDbAccessContext } from '../db';
 import { apiKeys, organizations } from '../db/schema';
 import { getRedis, rateLimiter } from '../services';
 
@@ -60,23 +60,28 @@ export async function apiKeyAuthMiddleware(c: Context, next: Next) {
   // Hash the key and look it up
   const keyHash = hashApiKey(apiKeyHeader);
 
-  const [apiKey] = await db
-    .select({
-      id: apiKeys.id,
-      orgId: apiKeys.orgId,
-      name: apiKeys.name,
-      keyPrefix: apiKeys.keyPrefix,
-      keyHash: apiKeys.keyHash,
-      scopes: apiKeys.scopes,
-      expiresAt: apiKeys.expiresAt,
-      rateLimit: apiKeys.rateLimit,
-      usageCount: apiKeys.usageCount,
-      status: apiKeys.status,
-      createdBy: apiKeys.createdBy
-    })
-    .from(apiKeys)
-    .where(eq(apiKeys.keyHash, keyHash))
-    .limit(1);
+  // Authentication must work even when tenant RLS is deny-by-default.
+  // Use system DB context for lookup, then scope all downstream queries to the key's org.
+  const apiKey = await withSystemDbAccessContext(async () => {
+    const [row] = await db
+      .select({
+        id: apiKeys.id,
+        orgId: apiKeys.orgId,
+        name: apiKeys.name,
+        keyPrefix: apiKeys.keyPrefix,
+        keyHash: apiKeys.keyHash,
+        scopes: apiKeys.scopes,
+        expiresAt: apiKeys.expiresAt,
+        rateLimit: apiKeys.rateLimit,
+        usageCount: apiKeys.usageCount,
+        status: apiKeys.status,
+        createdBy: apiKeys.createdBy
+      })
+      .from(apiKeys)
+      .where(eq(apiKeys.keyHash, keyHash))
+      .limit(1);
+    return row ?? null;
+  });
 
   if (!apiKey) {
     throw new HTTPException(401, { message: 'Invalid API key' });
@@ -90,10 +95,12 @@ export async function apiKeyAuthMiddleware(c: Context, next: Next) {
   // Check if key is expired
   if (apiKey.expiresAt && new Date(apiKey.expiresAt) < new Date()) {
     // Update status to expired
-    await db
-      .update(apiKeys)
-      .set({ status: 'expired', updatedAt: new Date() })
-      .where(eq(apiKeys.id, apiKey.id));
+    await withSystemDbAccessContext(async () => {
+      await db
+        .update(apiKeys)
+        .set({ status: 'expired', updatedAt: new Date() })
+        .where(eq(apiKeys.id, apiKey.id));
+    });
 
     throw new HTTPException(401, { message: 'API key has expired' });
   }
@@ -125,17 +132,19 @@ export async function apiKeyAuthMiddleware(c: Context, next: Next) {
   c.header('X-RateLimit-Remaining', String(rateCheck.remaining));
   c.header('X-RateLimit-Reset', String(Math.ceil(rateCheck.resetAt.getTime() / 1000)));
 
-  // Update lastUsedAt and usageCount (async, don't wait)
-  db.update(apiKeys)
-    .set({
-      lastUsedAt: new Date(),
-      usageCount: apiKey.usageCount !== undefined ? apiKey.usageCount + 1 : 1
-    })
-    .where(eq(apiKeys.id, apiKey.id))
-    .execute()
-    .catch(err => {
-      console.error('Failed to update API key usage stats:', err);
-    });
+  // Update lastUsedAt and usageCount (async, don't wait).
+  // Wrapped in system context so it runs regardless of RLS scope.
+  withSystemDbAccessContext(async () => {
+    await db
+      .update(apiKeys)
+      .set({
+        lastUsedAt: new Date(),
+        usageCount: apiKey.usageCount !== undefined ? apiKey.usageCount + 1 : 1
+      })
+      .where(eq(apiKeys.id, apiKey.id));
+  }).catch(err => {
+    console.error('Failed to update API key usage stats:', err);
+  });
 
   // Set API key context for route handlers
   c.set('apiKey', {

--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -27,7 +27,8 @@ vi.mock('../db', () => ({
   db: {
     select: vi.fn()
   },
-  withDbAccessContext: vi.fn(async (_context, fn) => fn())
+  withDbAccessContext: vi.fn(async (_context, fn) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn())
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/agentVersions.test.ts
+++ b/apps/api/src/routes/agentVersions.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -179,12 +179,10 @@ describe('agent websocket command results', () => {
 
     vi.mocked(db.select)
       .mockReturnValueOnce(selectOwnedCommandResult([]) as any)
-      .mockReturnValueOnce(selectAgentDevice([]) as any);
-    vi.mocked(db.update).mockReturnValue({
-      set: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue(undefined)
-      })
-    } as any);
+      .mockReturnValueOnce(selectAgentDevice([]) as any)
+      .mockReturnValueOnce(selectWithInnerJoin([]) as any)
+      .mockReturnValueOnce(selectWithInnerJoin([]) as any);
+    vi.mocked(db.update).mockReturnValue(updateResult() as any);
 
     const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
     const ws = wsMock();
@@ -215,11 +213,7 @@ describe('agent websocket command results', () => {
         }
       ]) as any);
 
-    vi.mocked(db.update).mockReturnValue({
-      set: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue(undefined)
-      })
-    } as any);
+    vi.mocked(db.update).mockReturnValue(updateResult([{ id: 'cmd-1' }]) as any);
 
     const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
     const ws = wsMock();
@@ -243,7 +237,9 @@ describe('agent websocket command results', () => {
 
     vi.mocked(db.select)
       .mockReturnValueOnce(selectOwnedCommandResult([]) as any)
-      .mockReturnValueOnce(selectAgentDevice([]) as any);
+      .mockReturnValueOnce(selectAgentDevice([]) as any)
+      .mockReturnValueOnce(selectWithInnerJoin([]) as any)
+      .mockReturnValueOnce(selectWithInnerJoin([]) as any);
     vi.mocked(db.update).mockReturnValue(updateResult() as any);
 
     const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);

--- a/apps/api/src/routes/agents.test.ts
+++ b/apps/api/src/routes/agents.test.ts
@@ -110,6 +110,14 @@ vi.mock('../db/schema', () => ({
   backupJobs: {},
   patchPolicies: {},
   alertRules: {},
+  backupConfigs: { orgId: 'orgId' },
+  securityPolicies: { orgId: 'orgId' },
+  configurationPolicies: {},
+  deviceGroupMemberships: {},
+  maintenanceWindows: {},
+  softwarePolicies: {},
+  sensitiveDataPolicies: {},
+  peripheralPolicies: {},
 }));
 
 vi.mock('../services/enrollmentKeySecurity', () => ({

--- a/apps/api/src/routes/agents/bootPerformance.test.ts
+++ b/apps/api/src/routes/agents/bootPerformance.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/agents/changes.test.ts
+++ b/apps/api/src/routes/agents/changes.test.ts
@@ -15,6 +15,9 @@ vi.mock('../../db', () => ({
     select: vi.fn(),
     insert: vi.fn(),
   },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../../db/schema', () => ({

--- a/apps/api/src/routes/agents/connections.test.ts
+++ b/apps/api/src/routes/agents/connections.test.ts
@@ -15,6 +15,9 @@ vi.mock('../../db', () => ({
     delete: vi.fn(),
     transaction: vi.fn(),
   },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../../db/schema', () => ({

--- a/apps/api/src/routes/agents/helpers.software.test.ts
+++ b/apps/api/src/routes/agents/helpers.software.test.ts
@@ -48,6 +48,8 @@ const {
 // ---------------------------------------------------------------------------
 
 vi.mock('../../db', () => ({ runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: dbMock }));
 
 vi.mock('../../db/schema', () => ({

--- a/apps/api/src/routes/agents/peripherals.test.ts
+++ b/apps/api/src/routes/agents/peripherals.test.ts
@@ -5,7 +5,10 @@ vi.mock('../../db', () => ({
   db: {
     select: vi.fn(),
     insert: vi.fn(),
-  }
+  },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../../db/schema', () => ({

--- a/apps/api/src/routes/agents/reliability.test.ts
+++ b/apps/api/src/routes/agents/reliability.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/agents/state.test.ts
+++ b/apps/api/src/routes/agents/state.test.ts
@@ -15,6 +15,9 @@ vi.mock('../../db', () => ({
     delete: vi.fn(),
     transaction: vi.fn(),
   },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../../db/schema', () => ({

--- a/apps/api/src/routes/agents/token.test.ts
+++ b/apps/api/src/routes/agents/token.test.ts
@@ -7,6 +7,9 @@ vi.mock('../../db', () => ({
     select: vi.fn(),
     update: vi.fn(),
   },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../../db/schema', () => ({

--- a/apps/api/src/routes/ai-flagging.test.ts
+++ b/apps/api/src/routes/ai-flagging.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/ai_admin.test.ts
+++ b/apps/api/src/routes/ai_admin.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/ai_plans.test.ts
+++ b/apps/api/src/routes/ai_plans.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/ai_sessions_actions.test.ts
+++ b/apps/api/src/routes/ai_sessions_actions.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/ai_sessions_crud.test.ts
+++ b/apps/api/src/routes/ai_sessions_crud.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/analytics.test.ts
+++ b/apps/api/src/routes/analytics.test.ts
@@ -77,7 +77,10 @@ vi.mock('../db', () => {
       insert: vi.fn(() => createChain([])),
       update: vi.fn(() => createChain([])),
       delete: vi.fn(() => createChain([]))
-    }
+    },
+    runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+    withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+    withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   };
 });
 

--- a/apps/api/src/routes/auditBaselines_apply_multitenant.test.ts
+++ b/apps/api/src/routes/auditBaselines_apply_multitenant.test.ts
@@ -11,6 +11,10 @@ vi.mock('../db', () => ({
     delete: vi.fn(),
     transaction: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/auditBaselines_compliance_devices.test.ts
+++ b/apps/api/src/routes/auditBaselines_compliance_devices.test.ts
@@ -11,6 +11,10 @@ vi.mock('../db', () => ({
     delete: vi.fn(),
     transaction: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/auditBaselines_list_create.test.ts
+++ b/apps/api/src/routes/auditBaselines_list_create.test.ts
@@ -11,6 +11,10 @@ vi.mock('../db', () => ({
     delete: vi.fn(),
     transaction: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/auditBaselines_requests.test.ts
+++ b/apps/api/src/routes/auditBaselines_requests.test.ts
@@ -11,6 +11,10 @@ vi.mock('../db', () => ({
     delete: vi.fn(),
     transaction: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/backup/bmr.test.ts
+++ b/apps/api/src/routes/backup/bmr.test.ts
@@ -174,7 +174,12 @@ const rateLimiterMock = vi.fn(async () => ({
 }));
 
 vi.mock('../../services/redis', () => ({
-  getRedis: vi.fn(() => ({ multi: vi.fn() })),
+  getRedis: vi.fn(() => ({
+    multi: vi.fn(),
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue('OK'),
+    del: vi.fn().mockResolvedValue(1),
+  })),
 }));
 
 vi.mock('../../services/rate-limit', () => ({

--- a/apps/api/src/routes/backup/configs.test.ts
+++ b/apps/api/src/routes/backup/configs.test.ts
@@ -23,6 +23,9 @@ vi.mock('../../db', () => ({
     select: (...args: unknown[]) => selectMock(...(args as [])),
     update: (...args: unknown[]) => updateMock(...(args as [])),
   },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../../db/schema', () => ({

--- a/apps/api/src/routes/backup/snapshots.test.ts
+++ b/apps/api/src/routes/backup/snapshots.test.ts
@@ -28,6 +28,9 @@ vi.mock('../../db', () => ({
     select: (...args: unknown[]) => selectMock(...(args as [])),
     update: (...args: unknown[]) => updateMock(...(args as [])),
   },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../../db/schema', () => ({

--- a/apps/api/src/routes/browserSecurity_extensions_violations.test.ts
+++ b/apps/api/src/routes/browserSecurity_extensions_violations.test.ts
@@ -10,6 +10,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/browserSecurity_policy_crud_inventory.test.ts
+++ b/apps/api/src/routes/browserSecurity_policy_crud_inventory.test.ts
@@ -10,6 +10,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/c2c/items.test.ts
+++ b/apps/api/src/routes/c2c/items.test.ts
@@ -21,6 +21,9 @@ vi.mock('../../db', () => ({
     select: (...args: unknown[]) => selectMock(...(args as [])),
     insert: (...args: unknown[]) => insertMock(...(args as [])),
   },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../../db/schema', () => ({

--- a/apps/api/src/routes/c2c/jobs.test.ts
+++ b/apps/api/src/routes/c2c/jobs.test.ts
@@ -20,6 +20,9 @@ vi.mock('../../db', () => ({
   db: {
     select: (...args: unknown[]) => selectMock(...(args as [])),
   },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../../db/schema', () => ({

--- a/apps/api/src/routes/c2c/m365Auth.test.ts
+++ b/apps/api/src/routes/c2c/m365Auth.test.ts
@@ -34,6 +34,9 @@ vi.mock('../../db', () => ({
     delete: (...args: unknown[]) => deleteMock(...(args as [])),
     update: (...args: unknown[]) => updateMock(...(args as [])),
   },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../../db/schema', () => ({

--- a/apps/api/src/routes/changes.test.ts
+++ b/apps/api/src/routes/changes.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
   },

--- a/apps/api/src/routes/cisHardening_baselines.test.ts
+++ b/apps/api/src/routes/cisHardening_baselines.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/cisHardening_list_multitenant.test.ts
+++ b/apps/api/src/routes/cisHardening_list_multitenant.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/cisHardening_remediate.test.ts
+++ b/apps/api/src/routes/cisHardening_remediate.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/cisHardening_scan_report.test.ts
+++ b/apps/api/src/routes/cisHardening_scan_report.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/configurationPolicies/patchJobs.test.ts
+++ b/apps/api/src/routes/configurationPolicies/patchJobs.test.ts
@@ -54,6 +54,8 @@ vi.mock('../../middleware/auth', () => ({
 
 vi.mock('../../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/customFields_create_update_delete.test.ts
+++ b/apps/api/src/routes/customFields_create_update_delete.test.ts
@@ -22,6 +22,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/customFields_list_get.test.ts
+++ b/apps/api/src/routes/customFields_list_get.test.ts
@@ -22,6 +22,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/customFields_multitenant.test.ts
+++ b/apps/api/src/routes/customFields_multitenant.test.ts
@@ -22,6 +22,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/deployments_actions.test.ts
+++ b/apps/api/src/routes/deployments_actions.test.ts
@@ -38,6 +38,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/deployments_devices_multitenant.test.ts
+++ b/apps/api/src/routes/deployments_devices_multitenant.test.ts
@@ -38,6 +38,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/deployments_get_update_delete.test.ts
+++ b/apps/api/src/routes/deployments_get_update_delete.test.ts
@@ -38,6 +38,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/deployments_list_create.test.ts
+++ b/apps/api/src/routes/deployments_list_create.test.ts
@@ -38,6 +38,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/desktopWs_lifecycle.test.ts
+++ b/apps/api/src/routes/desktopWs_lifecycle.test.ts
@@ -6,6 +6,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     update: vi.fn(),

--- a/apps/api/src/routes/desktopWs_multitenant.test.ts
+++ b/apps/api/src/routes/desktopWs_multitenant.test.ts
@@ -6,6 +6,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     update: vi.fn(),

--- a/apps/api/src/routes/desktopWs_onmessage.test.ts
+++ b/apps/api/src/routes/desktopWs_onmessage.test.ts
@@ -6,6 +6,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     update: vi.fn(),

--- a/apps/api/src/routes/desktopWs_onopen.test.ts
+++ b/apps/api/src/routes/desktopWs_onopen.test.ts
@@ -6,6 +6,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     update: vi.fn(),

--- a/apps/api/src/routes/desktopWs_utils_http.test.ts
+++ b/apps/api/src/routes/desktopWs_utils_http.test.ts
@@ -6,6 +6,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     update: vi.fn(),

--- a/apps/api/src/routes/devPush.test.ts
+++ b/apps/api/src/routes/devPush.test.ts
@@ -14,6 +14,10 @@ vi.mock('../db', () => ({
   db: {
     select: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/devices.test.ts
+++ b/apps/api/src/routes/devices.test.ts
@@ -37,6 +37,8 @@ vi.mock('drizzle-orm', () => ({
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(() => ({
       from: vi.fn(() => ({

--- a/apps/api/src/routes/devices/bootMetrics.test.ts
+++ b/apps/api/src/routes/devices/bootMetrics.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
   },

--- a/apps/api/src/routes/devices/commands.test.ts
+++ b/apps/api/src/routes/devices/commands.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/devices/filesystem.test.ts
+++ b/apps/api/src/routes/devices/filesystem.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/devices/groups.test.ts
+++ b/apps/api/src/routes/devices/groups.test.ts
@@ -21,6 +21,8 @@ const {
 // ---------------------------------------------------------------------------
 vi.mock('../../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: mockSelect,
     insert: mockInsert,

--- a/apps/api/src/routes/devices/scripts.test.ts
+++ b/apps/api/src/routes/devices/scripts.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn()
   }

--- a/apps/api/src/routes/dnsSecurity.test.ts
+++ b/apps/api/src/routes/dnsSecurity.test.ts
@@ -8,6 +8,8 @@ const { permissionGate, mfaGate } = vi.hoisted(() => ({
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/docs.test.ts
+++ b/apps/api/src/routes/docs.test.ts
@@ -34,6 +34,8 @@ vi.mock('../services', () => ({
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(() => ({
       from: vi.fn(() => ({

--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -13,6 +13,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/enrollmentKeys_get_rotate_delete.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_get_rotate_delete.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/enrollmentKeys_installer.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_installer.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/enrollmentKeys_list_create.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_list_create.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/filters_crud.test.ts
+++ b/apps/api/src/routes/filters_crud.test.ts
@@ -32,6 +32,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/filters_update_preview.test.ts
+++ b/apps/api/src/routes/filters_update_preview.test.ts
@@ -32,6 +32,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/groups_devices.test.ts
+++ b/apps/api/src/routes/groups_devices.test.ts
@@ -46,6 +46,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/groups_get_create.test.ts
+++ b/apps/api/src/routes/groups_get_create.test.ts
@@ -46,6 +46,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/groups_list.test.ts
+++ b/apps/api/src/routes/groups_list.test.ts
@@ -46,6 +46,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/groups_log_multitenant.test.ts
+++ b/apps/api/src/routes/groups_log_multitenant.test.ts
@@ -46,6 +46,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/groups_preview_pin.test.ts
+++ b/apps/api/src/routes/groups_preview_pin.test.ts
@@ -46,6 +46,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/groups_update_delete.test.ts
+++ b/apps/api/src/routes/groups_update_delete.test.ts
@@ -46,6 +46,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/incidents.test.ts
+++ b/apps/api/src/routes/incidents.test.ts
@@ -8,6 +8,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     transaction: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../middleware/auth', () => ({

--- a/apps/api/src/routes/logs.test.ts
+++ b/apps/api/src/routes/logs.test.ts
@@ -37,6 +37,8 @@ const { getLogCorrelationDetectionJobMock } = vi.hoisted(() => ({
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
   },

--- a/apps/api/src/routes/metrics.test.ts
+++ b/apps/api/src/routes/metrics.test.ts
@@ -5,6 +5,8 @@ vi.mock('../services', () => ({}));
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/monitoring_assets_list.test.ts
+++ b/apps/api/src/routes/monitoring_assets_list.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/monitoring_assets_snmp.test.ts
+++ b/apps/api/src/routes/monitoring_assets_snmp.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/monitoring_results_status.test.ts
+++ b/apps/api/src/routes/monitoring_results_status.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/monitors_actions.test.ts
+++ b/apps/api/src/routes/monitors_actions.test.ts
@@ -10,6 +10,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/monitors_alerts.test.ts
+++ b/apps/api/src/routes/monitors_alerts.test.ts
@@ -10,6 +10,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/monitors_detail.test.ts
+++ b/apps/api/src/routes/monitors_detail.test.ts
@@ -10,6 +10,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/monitors_list_create.test.ts
+++ b/apps/api/src/routes/monitors_list_create.test.ts
@@ -10,6 +10,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/networkBaselines_changes_delete_multitenant.test.ts
+++ b/apps/api/src/routes/networkBaselines_changes_delete_multitenant.test.ts
@@ -39,6 +39,10 @@ vi.mock('../db', () => ({
     delete: vi.fn(),
     transaction: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/networkBaselines_detail_update.test.ts
+++ b/apps/api/src/routes/networkBaselines_detail_update.test.ts
@@ -39,6 +39,10 @@ vi.mock('../db', () => ({
     delete: vi.fn(),
     transaction: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/networkBaselines_list_create.test.ts
+++ b/apps/api/src/routes/networkBaselines_list_create.test.ts
@@ -39,6 +39,10 @@ vi.mock('../db', () => ({
     delete: vi.fn(),
     transaction: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/networkChanges_actions_multitenant.test.ts
+++ b/apps/api/src/routes/networkChanges_actions_multitenant.test.ts
@@ -26,6 +26,10 @@ vi.mock('../db', () => ({
     select: vi.fn(),
     update: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/networkChanges_list_detail.test.ts
+++ b/apps/api/src/routes/networkChanges_list_detail.test.ts
@@ -26,6 +26,10 @@ vi.mock('../db', () => ({
     select: vi.fn(),
     update: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/networkKnownGuests.test.ts
+++ b/apps/api/src/routes/networkKnownGuests.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/notifications.test.ts
+++ b/apps/api/src/routes/notifications.test.ts
@@ -21,6 +21,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -9,6 +9,9 @@ vi.mock('../db', () => ({
     select: vi.fn(() => ({
       from: vi.fn(() => ({
         where: vi.fn(() => ({
+          orderBy: vi.fn(() => ({
+            limit: vi.fn(() => Promise.resolve([]))
+          })),
           limit: vi.fn(() => Promise.resolve([]))
         }))
       }))
@@ -940,6 +943,9 @@ describe('org routes', () => {
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([])
+            }),
             limit: vi.fn().mockResolvedValue([currentPartner])
           })
         })
@@ -1022,6 +1028,9 @@ describe('org routes', () => {
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([])
+            }),
             limit: vi.fn().mockResolvedValue([currentPartner])
           })
         })
@@ -1069,6 +1078,9 @@ describe('org routes', () => {
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([])
+            }),
             limit: vi.fn().mockResolvedValue([currentPartner])
           })
         })
@@ -1104,6 +1116,9 @@ describe('org routes', () => {
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([])
+            }),
             limit: vi.fn().mockResolvedValue([currentPartner])
           })
         })
@@ -1170,6 +1185,9 @@ describe('org routes', () => {
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([])
+            }),
             limit: vi.fn().mockResolvedValue([currentPartner])
           })
         })

--- a/apps/api/src/routes/partner.test.ts
+++ b/apps/api/src/routes/partner.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn()
   }

--- a/apps/api/src/routes/patchPolicies.test.ts
+++ b/apps/api/src/routes/patchPolicies.test.ts
@@ -6,6 +6,8 @@ vi.mock('../services', () => ({}));
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/patches/index.test.ts
+++ b/apps/api/src/routes/patches/index.test.ts
@@ -34,6 +34,8 @@ vi.mock('drizzle-orm', () => {
 
 vi.mock('../../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/peripheralControl.test.ts
+++ b/apps/api/src/routes/peripheralControl.test.ts
@@ -12,6 +12,10 @@ vi.mock('../db', () => ({
     insert: vi.fn(),
     update: vi.fn(),
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/playbooks.test.ts
+++ b/apps/api/src/routes/playbooks.test.ts
@@ -4,6 +4,8 @@ import { playbookRoutes } from './playbooks';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/plugins.test.ts
+++ b/apps/api/src/routes/plugins.test.ts
@@ -6,6 +6,8 @@ vi.mock('../services', () => ({}));
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(() => ({
       from: vi.fn(() => ({

--- a/apps/api/src/routes/policies.test.ts
+++ b/apps/api/src/routes/policies.test.ts
@@ -6,6 +6,8 @@ vi.mock('../services', () => ({}));
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/policyManagement_actions.test.ts
+++ b/apps/api/src/routes/policyManagement_actions.test.ts
@@ -40,6 +40,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/policyManagement_compliance_multitenant.test.ts
+++ b/apps/api/src/routes/policyManagement_compliance_multitenant.test.ts
@@ -40,6 +40,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/policyManagement_crud.test.ts
+++ b/apps/api/src/routes/policyManagement_crud.test.ts
@@ -40,6 +40,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/portal.compat.test.ts
+++ b/apps/api/src/routes/portal.compat.test.ts
@@ -14,6 +14,8 @@ vi.mock('../services/password', () => ({
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(() => ({
       from: vi.fn(() => ({

--- a/apps/api/src/routes/portal.test.ts
+++ b/apps/api/src/routes/portal.test.ts
@@ -25,6 +25,8 @@ vi.mock('../services/email', () => ({
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(() => ({
       from: vi.fn(() => ({

--- a/apps/api/src/routes/psa.test.ts
+++ b/apps/api/src/routes/psa.test.ts
@@ -8,6 +8,8 @@ vi.mock('../services', () => ({}));
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(() => ({
       from: vi.fn(() => ({

--- a/apps/api/src/routes/remote.test.ts
+++ b/apps/api/src/routes/remote.test.ts
@@ -52,6 +52,8 @@ const mockDb = vi.hoisted(() => ({
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: mockDb
 }));
 

--- a/apps/api/src/routes/scriptAi_messages_approve.test.ts
+++ b/apps/api/src/routes/scriptAi_messages_approve.test.ts
@@ -8,6 +8,10 @@ vi.mock('../db', () => ({
     insert: vi.fn(),
     update: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/scriptAi_sessions.test.ts
+++ b/apps/api/src/routes/scriptAi_sessions.test.ts
@@ -8,6 +8,10 @@ vi.mock('../db', () => ({
     insert: vi.fn(),
     update: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/search.test.ts
+++ b/apps/api/src/routes/search.test.ts
@@ -4,6 +4,8 @@ import { searchRoutes } from './search';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn()
   }

--- a/apps/api/src/routes/security.test.ts
+++ b/apps/api/src/routes/security.test.ts
@@ -5,6 +5,8 @@ import { securityRoutes } from './security';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/sensitiveData.test.ts
+++ b/apps/api/src/routes/sensitiveData.test.ts
@@ -8,6 +8,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/sentinelOne.test.ts
+++ b/apps/api/src/routes/sentinelOne.test.ts
@@ -13,6 +13,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/snmp.test.ts
+++ b/apps/api/src/routes/snmp.test.ts
@@ -15,6 +15,8 @@ vi.mock('../services/snmpDashboardTopInterfaces', () => ({
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(() => ({ from: vi.fn() })),
     insert: vi.fn(() => ({ values: vi.fn() })),

--- a/apps/api/src/routes/software.test.ts
+++ b/apps/api/src/routes/software.test.ts
@@ -31,6 +31,8 @@ function chainMock(terminalValue: any) {
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(() => chainMock([])),
     insert: vi.fn(() => chainMock([])),

--- a/apps/api/src/routes/softwareInventory_deny_clear_devices.test.ts
+++ b/apps/api/src/routes/softwareInventory_deny_clear_devices.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/softwareInventory_list_approve.test.ts
+++ b/apps/api/src/routes/softwareInventory_list_approve.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/routes/system.test.ts
+++ b/apps/api/src/routes/system.test.ts
@@ -7,6 +7,10 @@ vi.mock('../db', () => ({
   db: {
     update: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/systemTools.test.ts
+++ b/apps/api/src/routes/systemTools.test.ts
@@ -6,6 +6,8 @@ const mockExecuteCommand = vi.fn();
 
 vi.mock('../services/commandQueue', () => ({
   executeCommand: (...args: unknown[]) => mockExecuteCommand(...args),
+  DEVICE_UNREACHABLE_ERROR: 'Device is not currently reachable over the live connection. Please try again in a moment.',
+  SEND_RETRY_ATTEMPTS: 3,
   CommandTypes: {
     LIST_PROCESSES: 'LIST_PROCESSES',
     GET_PROCESS: 'GET_PROCESS',

--- a/apps/api/src/routes/tags.test.ts
+++ b/apps/api/src/routes/tags.test.ts
@@ -12,6 +12,10 @@ vi.mock('../db', () => ({
   db: {
     select: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/terminalWs.ts
+++ b/apps/api/src/routes/terminalWs.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import type { WSContext } from 'hono/ws';
 import { z } from 'zod';
 import { eq } from 'drizzle-orm';
-import { db } from '../db';
+import { db, withSystemDbAccessContext } from '../db';
 import { remoteSessions, devices, users } from '../db/schema';
 import { consumeWsTicket } from '../services/remoteSessionAuth';
 import { sendCommandToAgent, isAgentConnected } from './agentWs';
@@ -94,61 +94,67 @@ async function validateTerminalAccess(
     return { valid: false, error: 'Connection ticket does not match terminal session' };
   }
 
-  // Check user exists and is active
-  const [user] = await db
-    .select({ id: users.id, status: users.status })
-    .from(users)
-    .where(eq(users.id, ticketRecord.userId))
-    .limit(1);
+  // Ticket consumption is the entire auth boundary for terminal WS — the
+  // WS routes mount before auth middleware. Run lookups in system DB
+  // context so RLS doesn't fail-close the query. Subsequent checks
+  // (session.userId === user.id) enforce tenant scoping in app code.
+  return withSystemDbAccessContext(async () => {
+    // Check user exists and is active
+    const [user] = await db
+      .select({ id: users.id, status: users.status })
+      .from(users)
+      .where(eq(users.id, ticketRecord.userId))
+      .limit(1);
 
-  if (!user || user.status !== 'active') {
-    return { valid: false, error: 'User not found or inactive' };
-  }
+    if (!user || user.status !== 'active') {
+      return { valid: false, error: 'User not found or inactive' };
+    }
 
-  // Get session with device info
-  const [result] = await db
-    .select({
-      session: remoteSessions,
-      device: devices
-    })
-    .from(remoteSessions)
-    .innerJoin(devices, eq(remoteSessions.deviceId, devices.id))
-    .where(eq(remoteSessions.id, sessionId))
-    .limit(1);
+    // Get session with device info
+    const [result] = await db
+      .select({
+        session: remoteSessions,
+        device: devices
+      })
+      .from(remoteSessions)
+      .innerJoin(devices, eq(remoteSessions.deviceId, devices.id))
+      .where(eq(remoteSessions.id, sessionId))
+      .limit(1);
 
-  if (!result) {
-    return { valid: false, error: 'Session not found' };
-  }
+    if (!result) {
+      return { valid: false, error: 'Session not found' };
+    }
 
-  const { session, device } = result;
+    const { session, device } = result;
 
-  // Check session is for terminal
-  if (session.type !== 'terminal') {
-    return { valid: false, error: 'Session is not a terminal session' };
-  }
+    // Check session is for terminal
+    if (session.type !== 'terminal') {
+      return { valid: false, error: 'Session is not a terminal session' };
+    }
 
-  // Check session belongs to this user
-  if (session.userId !== user.id) {
-    return { valid: false, error: 'Session does not belong to this user' };
-  }
+    // Check session belongs to this user
+    if (session.userId !== user.id) {
+      return { valid: false, error: 'Session does not belong to this user' };
+    }
 
-  // Check session status
-  if (!['pending', 'connecting', 'active'].includes(session.status)) {
-    return { valid: false, error: `Session is ${session.status}` };
-  }
+    // Check session status
+    if (!['pending', 'connecting', 'active'].includes(session.status)) {
+      return { valid: false, error: `Session is ${session.status}` };
+    }
 
-  // Check device is online
-  if (device.status !== 'online') {
-    return { valid: false, error: 'Device is not online' };
-  }
+    // Check device is online
+    if (device.status !== 'online') {
+      return { valid: false, error: 'Device is not online' };
+    }
 
-  // Remote access policy enforcement (defense-in-depth)
-  const policyCheck = await checkRemoteAccess(device.id, 'remoteTools');
-  if (!policyCheck.allowed) {
-    return { valid: false, error: policyCheck.reason ?? 'Remote tools disabled by policy' };
-  }
+    // Remote access policy enforcement (defense-in-depth)
+    const policyCheck = await checkRemoteAccess(device.id, 'remoteTools');
+    if (!policyCheck.allowed) {
+      return { valid: false, error: policyCheck.reason ?? 'Remote tools disabled by policy' };
+    }
 
-  return { valid: true, session, device, userId: user.id };
+    return { valid: true, session, device, userId: user.id };
+  });
 }
 
 /**
@@ -269,13 +275,15 @@ function createTerminalWsHandlers(sessionId: string, ticket: string | undefined)
         console.log(`Terminal session ${sessionId} connected for device ${device.hostname}`);
 
         // Update session status
-        await db
-          .update(remoteSessions)
-          .set({
-            status: 'active',
-            startedAt: new Date()
-          })
-          .where(eq(remoteSessions.id, sessionId));
+        await withSystemDbAccessContext(async () => {
+          await db
+            .update(remoteSessions)
+            .set({
+              status: 'active',
+              startedAt: new Date()
+            })
+            .where(eq(remoteSessions.id, sessionId));
+        });
 
         // Send connected message to user
         ws.send(JSON.stringify({
@@ -311,10 +319,12 @@ function createTerminalWsHandlers(sessionId: string, ticket: string | undefined)
           activeTerminalSessions.delete(sessionId);
           unregisterTerminalOutputCallback(sessionId);
           try {
-            await db
-              .update(remoteSessions)
-              .set({ status: 'failed', endedAt: new Date() })
-              .where(eq(remoteSessions.id, sessionId));
+            await withSystemDbAccessContext(async () => {
+              await db
+                .update(remoteSessions)
+                .set({ status: 'failed', endedAt: new Date() })
+                .where(eq(remoteSessions.id, sessionId));
+            });
           } catch (dbErr) {
             console.error(`[TerminalWs] Failed to update session ${sessionId} after agent send failure:`, dbErr);
           }
@@ -364,10 +374,12 @@ function createTerminalWsHandlers(sessionId: string, ticket: string | undefined)
         // Best-effort: mark DB session as failed — only if auth/validation already passed
         if (validated) {
           try {
-            await db
-              .update(remoteSessions)
-              .set({ status: 'failed', endedAt: new Date() })
-              .where(eq(remoteSessions.id, sessionId));
+            await withSystemDbAccessContext(async () => {
+              await db
+                .update(remoteSessions)
+                .set({ status: 'failed', endedAt: new Date() })
+                .where(eq(remoteSessions.id, sessionId));
+            });
           } catch (dbError) {
             console.error(`[TerminalWs] Failed to update session ${sessionId} status to failed:`, dbError);
           }
@@ -481,14 +493,16 @@ function createTerminalWsHandlers(sessionId: string, ticket: string | undefined)
         const startedAt = termSession.startedAt;
         const durationSeconds = Math.round((endedAt.getTime() - startedAt.getTime()) / 1000);
 
-        await db
-          .update(remoteSessions)
-          .set({
-            status: 'disconnected',
-            endedAt,
-            durationSeconds
-          })
-          .where(eq(remoteSessions.id, sessionId));
+        await withSystemDbAccessContext(async () => {
+          await db
+            .update(remoteSessions)
+            .set({
+              status: 'disconnected',
+              endedAt,
+              durationSeconds
+            })
+            .where(eq(remoteSessions.id, sessionId));
+        });
 
         console.log(`Terminal session ${sessionId} disconnected (duration: ${durationSeconds}s)`);
       }
@@ -509,14 +523,16 @@ function createTerminalWsHandlers(sessionId: string, ticket: string | undefined)
           const endedAt = new Date();
           const durationSeconds = Math.round((endedAt.getTime() - termSession.startedAt.getTime()) / 1000);
 
-          await db
-            .update(remoteSessions)
-            .set({
-              status: 'disconnected',
-              endedAt,
-              durationSeconds
-            })
-            .where(eq(remoteSessions.id, sessionId));
+          await withSystemDbAccessContext(async () => {
+            await db
+              .update(remoteSessions)
+              .set({
+                status: 'disconnected',
+                endedAt,
+                durationSeconds
+              })
+              .where(eq(remoteSessions.id, sessionId));
+          });
 
           console.log(`Terminal session ${sessionId} errored and cleaned up (duration: ${durationSeconds}s)`);
         } catch (dbError) {

--- a/apps/api/src/routes/terminalWs_multitenant.test.ts
+++ b/apps/api/src/routes/terminalWs_multitenant.test.ts
@@ -6,6 +6,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     update: vi.fn(),

--- a/apps/api/src/routes/terminalWs_onmessage_lifecycle.test.ts
+++ b/apps/api/src/routes/terminalWs_onmessage_lifecycle.test.ts
@@ -6,6 +6,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     update: vi.fn(),

--- a/apps/api/src/routes/terminalWs_utils_onopen.test.ts
+++ b/apps/api/src/routes/terminalWs_utils_onopen.test.ts
@@ -6,6 +6,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     update: vi.fn(),

--- a/apps/api/src/routes/tunnelWs.ts
+++ b/apps/api/src/routes/tunnelWs.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import type { WSContext } from 'hono/ws';
 import { eq } from 'drizzle-orm';
-import { db } from '../db';
+import { db, withSystemDbAccessContext } from '../db';
 import { tunnelSessions, devices, users } from '../db/schema';
 import { consumeWsTicket } from '../services/remoteSessionAuth';
 import { sendCommandToAgent, isAgentConnected } from './agentWs';
@@ -38,7 +38,11 @@ const earlyFrameBuffers = new Map<string, Uint8Array[]>();
 
 // Server-side ping/pong constants
 const PING_INTERVAL_MS = 30_000;
-const PONG_TIMEOUT_MS = 10_000;
+// Generous tolerance: noVNC-driven tunnels have no JSON-level pong reply, so
+// we rely on any inbound message (binary or text) as liveness. Backgrounded
+// tabs can throttle client timers, so give the client up to ~2 minutes of
+// silence before declaring the tunnel dead.
+const PONG_TIMEOUT_MS = 90_000;
 
 // Rate limiting
 const USER_WS_RATE_WINDOW_MS = 60_000;
@@ -137,54 +141,60 @@ async function validateTunnelAccess(
     return { valid: false, error: 'Connection ticket does not match tunnel session' };
   }
 
-  // Check user exists and is active
-  const [user] = await db
-    .select({ id: users.id, status: users.status })
-    .from(users)
-    .where(eq(users.id, ticketRecord.userId))
-    .limit(1);
+  // Ticket consumption is the entire auth boundary for tunnel WS — the
+  // WS routes mount before auth middleware. Run lookups in system DB
+  // context so RLS doesn't fail-close the query. The session.userId ===
+  // user.id check below enforces tenant scoping in app code.
+  return withSystemDbAccessContext(async () => {
+    // Check user exists and is active
+    const [user] = await db
+      .select({ id: users.id, status: users.status })
+      .from(users)
+      .where(eq(users.id, ticketRecord.userId))
+      .limit(1);
 
-  if (!user || user.status !== 'active') {
-    return { valid: false, error: 'User not found or inactive' };
-  }
+    if (!user || user.status !== 'active') {
+      return { valid: false, error: 'User not found or inactive' };
+    }
 
-  // Get tunnel session with device info
-  const [result] = await db
-    .select({
-      session: tunnelSessions,
-      device: devices
-    })
-    .from(tunnelSessions)
-    .innerJoin(devices, eq(tunnelSessions.deviceId, devices.id))
-    .where(eq(tunnelSessions.id, tunnelId))
-    .limit(1);
+    // Get tunnel session with device info
+    const [result] = await db
+      .select({
+        session: tunnelSessions,
+        device: devices
+      })
+      .from(tunnelSessions)
+      .innerJoin(devices, eq(tunnelSessions.deviceId, devices.id))
+      .where(eq(tunnelSessions.id, tunnelId))
+      .limit(1);
 
-  if (!result) {
-    return { valid: false, error: 'Tunnel session not found' };
-  }
+    if (!result) {
+      return { valid: false, error: 'Tunnel session not found' };
+    }
 
-  const { session, device } = result;
+    const { session, device } = result;
 
-  if (session.userId !== user.id) {
-    return { valid: false, error: 'Tunnel session does not belong to this user' };
-  }
+    if (session.userId !== user.id) {
+      return { valid: false, error: 'Tunnel session does not belong to this user' };
+    }
 
-  if (!['pending', 'connecting', 'active'].includes(session.status)) {
-    return { valid: false, error: `Tunnel session is ${session.status}` };
-  }
+    if (!['pending', 'connecting', 'active'].includes(session.status)) {
+      return { valid: false, error: `Tunnel session is ${session.status}` };
+    }
 
-  if (device.status !== 'online') {
-    return { valid: false, error: 'Device is not online' };
-  }
+    if (device.status !== 'online') {
+      return { valid: false, error: 'Device is not online' };
+    }
 
-  // Remote access policy enforcement (defense-in-depth)
-  const tunnelCapability = session.type === 'vnc' ? 'vncRelay' as const : 'proxy' as const;
-  const policyCheck = await checkRemoteAccess(device.id, tunnelCapability);
-  if (!policyCheck.allowed) {
-    return { valid: false, error: policyCheck.reason ?? 'Tunnel access disabled by policy' };
-  }
+    // Remote access policy enforcement (defense-in-depth)
+    const tunnelCapability = session.type === 'vnc' ? 'vncRelay' as const : 'proxy' as const;
+    const policyCheck = await checkRemoteAccess(device.id, tunnelCapability);
+    if (!policyCheck.allowed) {
+      return { valid: false, error: policyCheck.reason ?? 'Tunnel access disabled by policy' };
+    }
 
-  return { valid: true, session, agentId: device.agentId ?? undefined, userId: user.id };
+    return { valid: true, session, agentId: device.agentId ?? undefined, userId: user.id };
+  });
 }
 
 function cleanupTunnelConnection(tunnelId: string) {
@@ -292,11 +302,14 @@ function createTunnelWsHandlers(tunnelId: string, ticket: string | undefined) {
 
         // Only transition to active if the tunnel_open succeeded (status = connecting).
         // If the agent already failed, session.status will be 'failed' and we should not override.
-        const [currentSession] = await db
-          .select({ status: tunnelSessions.status })
-          .from(tunnelSessions)
-          .where(eq(tunnelSessions.id, tunnelId))
-          .limit(1);
+        const currentSession = await withSystemDbAccessContext(async () => {
+          const [row] = await db
+            .select({ status: tunnelSessions.status })
+            .from(tunnelSessions)
+            .where(eq(tunnelSessions.id, tunnelId))
+            .limit(1);
+          return row ?? null;
+        });
 
         if (currentSession?.status === 'failed') {
           ws.send(JSON.stringify({ type: 'error', message: 'Tunnel failed to open on agent' }));
@@ -305,10 +318,12 @@ function createTunnelWsHandlers(tunnelId: string, ticket: string | undefined) {
           return;
         }
 
-        await db
-          .update(tunnelSessions)
-          .set({ status: 'active', startedAt: new Date() })
-          .where(eq(tunnelSessions.id, tunnelId));
+        await withSystemDbAccessContext(async () => {
+          await db
+            .update(tunnelSessions)
+            .set({ status: 'active', startedAt: new Date() })
+            .where(eq(tunnelSessions.id, tunnelId));
+        });
 
         ws.send(JSON.stringify({ type: 'connected', tunnelId }));
       } catch (error) {
@@ -324,6 +339,12 @@ function createTunnelWsHandlers(tunnelId: string, ticket: string | undefined) {
         ws.close(4001, 'No active tunnel connection');
         return;
       }
+
+      // Any inbound message (binary or text) is liveness evidence — noVNC
+      // consumes the WebSocket directly and never sees or replies to our JSON
+      // ping/pong, but it does send incremental FramebufferUpdateRequests and
+      // input events as binary frames. Treat every message as a keepalive.
+      conn.lastPongAt = Date.now();
 
       try {
         // Binary data — relay directly to agent
@@ -403,13 +424,15 @@ function createTunnelWsHandlers(tunnelId: string, ticket: string | undefined) {
 
       // Update session status
       try {
-        await db
-          .update(tunnelSessions)
-          .set({
-            status: 'disconnected',
-            endedAt: new Date(),
-          })
-          .where(eq(tunnelSessions.id, tunnelId));
+        await withSystemDbAccessContext(async () => {
+          await db
+            .update(tunnelSessions)
+            .set({
+              status: 'disconnected',
+              endedAt: new Date(),
+            })
+            .where(eq(tunnelSessions.id, tunnelId));
+        });
       } catch (err) {
         console.error(`[TunnelWs] Failed to update tunnel ${tunnelId} status on close:`, err);
       }

--- a/apps/api/src/routes/updateRings_detail_update_delete.test.ts
+++ b/apps/api/src/routes/updateRings_detail_update_delete.test.ts
@@ -26,6 +26,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/updateRings_list_create.test.ts
+++ b/apps/api/src/routes/updateRings_list_create.test.ts
@@ -26,6 +26,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/updateRings_patches_compliance_scope.test.ts
+++ b/apps/api/src/routes/updateRings_patches_compliance_scope.test.ts
@@ -26,6 +26,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn()
   }
+,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -20,6 +20,8 @@ vi.mock('../services/permissions', () => ({
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(() => ({
       from: vi.fn(() => ({

--- a/apps/api/src/routes/webhooks.test.ts
+++ b/apps/api/src/routes/webhooks.test.ts
@@ -27,6 +27,8 @@ vi.mock('../services/notificationSenders/webhookSender', () => ({
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -8,6 +8,8 @@ import { db } from '../db';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     update: vi.fn(),
   },

--- a/apps/api/src/services/aiTools.queryChangeLog.test.ts
+++ b/apps/api/src/services/aiTools.queryChangeLog.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
   },

--- a/apps/api/src/services/aiTools.sentinelOneActions.test.ts
+++ b/apps/api/src/services/aiTools.sentinelOneActions.test.ts
@@ -3,6 +3,8 @@ import type { AuthContext } from '../middleware/auth';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/services/aiToolsAgentLogs.test.ts
+++ b/apps/api/src/services/aiToolsAgentLogs.test.ts
@@ -3,6 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mock dependencies before imports
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
   },

--- a/apps/api/src/services/aiToolsBackupVm.test.ts
+++ b/apps/api/src/services/aiToolsBackupVm.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/services/aiToolsC2C.test.ts
+++ b/apps/api/src/services/aiToolsC2C.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/services/aiToolsDR.test.ts
+++ b/apps/api/src/services/aiToolsDR.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/services/aiToolsFleet.test.ts
+++ b/apps/api/src/services/aiToolsFleet.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it, vi } from 'vitest';
 // Mock all DB and service dependencies so we can test registration without a database
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(() => ({
       from: vi.fn(() => ({

--- a/apps/api/src/services/aiToolsHyperv.test.ts
+++ b/apps/api/src/services/aiToolsHyperv.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/services/aiToolsMssql.test.ts
+++ b/apps/api/src/services/aiToolsMssql.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/services/aiToolsReliability.test.ts
+++ b/apps/api/src/services/aiToolsReliability.test.ts
@@ -4,6 +4,8 @@ const mockListReliabilityDevices = vi.fn();
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {},
 }));
 

--- a/apps/api/src/services/aiToolsSLABackup.test.ts
+++ b/apps/api/src/services/aiToolsSLABackup.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/services/aiToolsVault.test.ts
+++ b/apps/api/src/services/aiToolsVault.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/services/automationRuntime.configPolicy.test.ts
+++ b/apps/api/src/services/automationRuntime.configPolicy.test.ts
@@ -3,6 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mock DB and dependencies before importing
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/services/backupJobCreation.test.ts
+++ b/apps/api/src/services/backupJobCreation.test.ts
@@ -4,6 +4,10 @@ vi.mock('../db', () => ({
   db: {
     transaction: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/services/backupResultPersistence.test.ts
+++ b/apps/api/src/services/backupResultPersistence.test.ts
@@ -7,6 +7,10 @@ vi.mock('../db', () => ({
     insert: vi.fn(),
     delete: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/services/brainDeviceContext.test.ts
+++ b/apps/api/src/services/brainDeviceContext.test.ts
@@ -10,6 +10,8 @@ const mockUpdateSet = vi.fn();
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(() => ({ from: mockSelectFrom })),
     insert: vi.fn(() => ({ values: mockInsertValues })),

--- a/apps/api/src/services/c2cJobCreation.test.ts
+++ b/apps/api/src/services/c2cJobCreation.test.ts
@@ -4,6 +4,10 @@ vi.mock('../db', () => ({
   db: {
     transaction: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/services/c2cSecrets.test.ts
+++ b/apps/api/src/services/c2cSecrets.test.ts
@@ -25,6 +25,10 @@ vi.mock('../db', () => ({
     select: (...args: unknown[]) => selectMock(...(args as [])),
     update: (...args: unknown[]) => updateMock(...(args as [])),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/services/commandDispatch.test.ts
+++ b/apps/api/src/services/commandDispatch.test.ts
@@ -6,6 +6,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     transaction: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/services/commandQueueTransitions.test.ts
+++ b/apps/api/src/services/commandQueueTransitions.test.ts
@@ -7,6 +7,8 @@ vi.mock('../db', () => ({
     update: vi.fn(),
   },
   runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn())
 }));
 
 vi.mock('../db/schema', async (importOriginal) => {

--- a/apps/api/src/services/configPolicyPatching.test.ts
+++ b/apps/api/src/services/configPolicyPatching.test.ts
@@ -5,6 +5,10 @@ vi.mock('../db', () => ({
     select: vi.fn(),
     insert: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/services/deploymentTargetResolver.test.ts
+++ b/apps/api/src/services/deploymentTargetResolver.test.ts
@@ -36,6 +36,10 @@ vi.mock('../db', () => ({
   db: {
     select: vi.fn(() => chainMock()),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/services/deviceIpHistory.test.ts
+++ b/apps/api/src/services/deviceIpHistory.test.ts
@@ -38,6 +38,8 @@ vi.mock('../db/schema', () => ({
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     transaction: vi.fn(async (handler: (tx: any) => Promise<unknown>) => {
       const tx = {

--- a/apps/api/src/services/discoveryJobCreation.test.ts
+++ b/apps/api/src/services/discoveryJobCreation.test.ts
@@ -4,6 +4,10 @@ vi.mock('../db', () => ({
   db: {
     transaction: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/services/drExecutionService.test.ts
+++ b/apps/api/src/services/drExecutionService.test.ts
@@ -6,6 +6,10 @@ vi.mock('../db', () => ({
     insert: vi.fn(),
     update: vi.fn(),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('./commandQueue', () => ({

--- a/apps/api/src/services/featureConfigResolver.backupAssignments.test.ts
+++ b/apps/api/src/services/featureConfigResolver.backupAssignments.test.ts
@@ -63,6 +63,10 @@ vi.mock('../db', () => ({
   db: {
     select: (...args: unknown[]) => selectMock(...(args as [])),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/services/notificationSenders/inAppSender.test.ts
+++ b/apps/api/src/services/notificationSenders/inAppSender.test.ts
@@ -7,6 +7,8 @@ const { selectMock, insertMock } = vi.hoisted(() => ({
 
 vi.mock('../../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: selectMock,
     insert: insertMock

--- a/apps/api/src/services/patchJobService.test.ts
+++ b/apps/api/src/services/patchJobService.test.ts
@@ -3,6 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mock dependencies before importing the module under test
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/services/plugins.test.ts
+++ b/apps/api/src/services/plugins.test.ts
@@ -8,6 +8,8 @@ const { subscribeMock, unsubscribeMock, randomUuidMock } = vi.hoisted(() => ({
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     select: vi.fn(),
     insert: vi.fn(),

--- a/apps/api/src/services/reliabilityScoring.test.ts
+++ b/apps/api/src/services/reliabilityScoring.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {}
 }));
 

--- a/apps/api/src/services/restoreResultPersistence.test.ts
+++ b/apps/api/src/services/restoreResultPersistence.test.ts
@@ -21,6 +21,10 @@ vi.mock('../db', () => ({
     update: (...args: unknown[]) => updateMock(...(args as [])),
     select: (...args: unknown[]) => selectMock(...(args as [])),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/services/session.test.ts
+++ b/apps/api/src/services/session.test.ts
@@ -3,6 +3,8 @@ import { createHash } from 'crypto';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
     insert: vi.fn(),
     select: vi.fn(),

--- a/apps/api/src/services/vaultSyncPersistence.test.ts
+++ b/apps/api/src/services/vaultSyncPersistence.test.ts
@@ -33,6 +33,10 @@ vi.mock('../db', () => ({
     update: (...args: unknown[]) => updateMock(...(args as [])),
     insert: (...args: unknown[]) => insertMock(...(args as [])),
   },
+
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/docs/superpowers/specs/2026-04-11-file-browser-unverified-ui-design.md
+++ b/docs/superpowers/specs/2026-04-11-file-browser-unverified-ui-design.md
@@ -1,0 +1,254 @@
+# File Browser — Unverified Bulk-Op UI
+
+**Date:** 2026-04-11
+**Follow-up to:** PR #391 (`fix(api): better file browser UX when device is intermittently reachable`)
+**Scope:** Frontend-visible distinction between hard failures and "unverified" (timed-out mid-op) results on file browser bulk operations, plus the small API change needed to let upload participate in the same contract.
+
+## Problem
+
+PR #391 added a per-item `unverified: true` field on bulk file-op responses (`copy`, `move`, `delete`, `trash/restore`) to flag operations that timed out while talking to the agent. The field is set when the API cannot tell whether the operation completed on the device — retrying blindly risks compounding damage (e.g., permanently deleting a file that was rotated into a just-freed path).
+
+The frontend currently ignores the field entirely:
+
+- `FileOpResult` in `apps/web/src/components/remote/fileOperations.ts:3-11` omits `unverified`; it's dropped at the type boundary.
+- `FileManager.tsx` handlers (`handleCopyTo:617`, `handleMoveTo:644`, `handleDelete:670`) filter `status === 'failure'` and log a flat "N items failed" string. No distinction.
+- `TrashView.handleRestore:100` awaits `restoreFromTrash` but *discards the results array entirely*; per-item outcomes are invisible there.
+- `FileActivityPanel.tsx:154-167` renders a binary red/green badge. No third state.
+- `FileManager.handleUpload:449` inline-calls `fetch` for upload and catches thrown errors. The API's 504 "refresh to verify before retrying" message lands in the red "Failed" badge along with real failures.
+
+This is not a security issue; it is a data-safety / integrity risk. Users who see "Failed" on an operation that actually completed will retry and may mutate a filesystem state they did not intend.
+
+## Goals
+
+1. Surface a distinct, amber "Unverified" activity badge for any bulk op where the API reported `unverified: true`.
+2. Keep the hard-failure red "Failed" badge for genuine failures.
+3. Bring upload into the same contract by extending the upload API's timeout response and routing upload through the shared fileOperations layer.
+4. Fix `TrashView` to actually inspect per-item restore results.
+5. No behavior change on the green happy path.
+
+## Non-goals
+
+- Automatic refresh after an unverified op. User still chooses when to refresh — the badge just nudges them to verify.
+- A retry-with-idempotency mechanism. Out of scope; too large for this follow-up.
+- Changes to `trash/purge`, which is a single command (not per-item) and uses the existing 504 "refresh to verify" message path.
+- Changes to bulk endpoints already emitting `unverified`. They are correct as-is.
+
+## Design
+
+### 1. API — upload endpoint
+
+**File:** `apps/api/src/routes/systemTools/fileBrowser.ts:192`
+
+On the `isCommandFailure(result)` branch of the upload route, surface the `unverified` distinction in the JSON body:
+
+```ts
+if (isCommandFailure(result)) {
+  const { message, status } = mapCommandFailure(result, 'Failed to write file.', { mutating: true });
+  const unverified = result.status === 'timeout';
+  return c.json(unverified ? { error: message, unverified: true } : { error: message }, status);
+}
+```
+
+No other bulk endpoints change — they already emit `unverified` per-item.
+
+### 2. Frontend types
+
+**File:** `apps/web/src/components/remote/fileOperations.ts:3-11`
+
+Add `unverified?: boolean` to `FileOpResult`:
+
+```ts
+export type FileOpResult = {
+  path?: string;
+  sourcePath?: string;
+  destPath?: string;
+  trashId?: string;
+  restoredPath?: string;
+  status: 'success' | 'failure';
+  error?: string;
+  unverified?: boolean;
+};
+```
+
+Copy/move/delete/restore need no other shape changes — `{ results: FileOpResult[] }` will pass the flag through once the type admits it.
+
+### 3. Upload moved into `fileOperations.ts`
+
+**File:** `apps/web/src/components/remote/fileOperations.ts`
+
+Introduce a typed error and an `uploadFile` helper. The typed error keeps the calling code's existing `try/catch` shape in `FileManager.handleUpload`:
+
+```ts
+export class UnverifiedOperationError extends Error {
+  readonly unverified = true as const;
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnverifiedOperationError';
+  }
+}
+
+export async function uploadFile(
+  deviceId: string,
+  body: { path: string; content: string; encoding?: string },
+  opts?: { signal?: AbortSignal },
+): Promise<{ path: string; size?: number }> {
+  const response = await fetchWithAuth(`/system-tools/devices/${deviceId}/files/upload`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+    signal: opts?.signal,
+  });
+  if (!response.ok) {
+    const json = await response.json().catch(() => ({ error: 'Upload failed' }));
+    if (json?.unverified) throw new UnverifiedOperationError(json.error || 'Upload unverified');
+    throw new Error(json?.error || 'Upload failed');
+  }
+  const json = await response.json();
+  return json.data ?? { path: body.path };
+}
+```
+
+The existing `handleUpload:489-503` `fetchWithAuth` block is replaced with `await uploadFile(deviceId, { path, content, encoding }, { signal: uploadController.signal })` and a `catch` clause that distinguishes `UnverifiedOperationError` from plain `Error`. The `AbortController` / 120s guard stays in `handleUpload`; `uploadFile` just forwards the signal.
+
+### 4. `FileActivity` type + activity panel
+
+**File:** `apps/web/src/components/remote/FileActivityPanel.tsx`
+
+Widen the result union:
+
+```ts
+export type FileActivity = {
+  id: string;
+  timestamp: string;
+  action: 'copy' | 'move' | 'delete' | 'restore' | 'upload' | 'download' | 'purge';
+  paths: string[];
+  result: 'success' | 'failure' | 'unverified';
+  error?: string;
+};
+```
+
+Badge block at `FileActivityPanel.tsx:154-167` becomes a three-way render:
+
+- `success` → existing green `CheckCircle2` "Success"
+- `failure` → existing red `AlertCircle` "Failed"
+- `unverified` → new amber `AlertTriangle` "Unverified" with `bg-amber-500/15 text-amber-400`, tooltip: `"Device didn't respond in time — refresh to verify"`
+
+Error detail row at `FileActivityPanel.tsx:188-195`: when `result === 'unverified'`, use `text-amber-400/80` instead of `text-red-400/80`. Same render branch, different color class.
+
+Import `AlertTriangle` from `lucide-react`.
+
+### 5. `FileManager.tsx` handlers
+
+**File:** `apps/web/src/components/remote/FileManager.tsx`
+
+Add a local helper, co-located with `addActivity`:
+
+```ts
+type BulkOutcome = { result: FileActivity['result']; summary?: string };
+
+function summarizeBulkResults(results: FileOpResult[]): BulkOutcome {
+  const failures = results.filter(r => r.status === 'failure' && !r.unverified);
+  const unverified = results.filter(r => r.unverified);
+  if (failures.length === 0 && unverified.length === 0) return { result: 'success' };
+  const parts: string[] = [];
+  if (failures.length > 0) parts.push(`${failures.length} failed`);
+  if (unverified.length > 0) parts.push(`${unverified.length} unverified`);
+  const summary = unverified.length > 0
+    ? `${parts.join(', ')} — refresh to verify`
+    : parts.join(', ');
+  const result: FileActivity['result'] = failures.length > 0 ? 'failure' : 'unverified';
+  return { result, summary };
+}
+```
+
+`handleCopyTo:627-640`, `handleMoveTo:653-666`, `handleDelete:675-688` each collapse their current filter-and-log block to:
+
+```ts
+const { result, summary } = summarizeBulkResults(response.results);
+addActivity('copy', selectedPaths, result, summary);
+```
+
+(with the appropriate action string).
+
+The `catch` clauses on each handler stay as `addActivity(..., 'failure', message)` — a thrown exception is a hard failure, not an unverified state, because it means the request never got a bulk result.
+
+`handleUpload:518-528` catch clause is extended:
+
+```ts
+} catch (error) {
+  if (error instanceof UnverifiedOperationError) {
+    setTransfers(prev => prev.map(t => t.id === transferId
+      ? { ...t, status: 'unverified', error: error.message }
+      : t));
+    addActivity('upload', [path], 'unverified', `${error.message}`);
+  } else {
+    // existing failure path
+  }
+}
+```
+
+The in-flight `FileTransfer` type at `FileManager.tsx:54` gains `'unverified'` as a possible status so the transfer list shows a matching treatment (reusing the amber color).
+
+### 6. `TrashView.tsx` — `handleRestore`
+
+**File:** `apps/web/src/components/remote/TrashView.tsx:100-116`
+
+Currently throws away `restoreFromTrash`'s results. Rework:
+
+```ts
+const handleRestore = useCallback(async () => {
+  const ids = Array.from(selected);
+  if (ids.length === 0) return;
+
+  setActionLoading('restore');
+  setError(null);
+  setWarning(null);
+  try {
+    const response = await restoreFromTrash(deviceId, ids);
+    const failures = response.results.filter(r => r.status === 'failure' && !r.unverified);
+    const unverified = response.results.filter(r => r.unverified);
+    if (failures.length > 0) {
+      setError(`${failures.length} failed${unverified.length ? `, ${unverified.length} unverified` : ''}. Refresh to verify.`);
+    } else if (unverified.length > 0) {
+      setWarning(`${unverified.length} unverified — refresh to verify.`);
+    }
+    await fetchTrash();
+    onRestore();
+  } catch (err) {
+    setError(err instanceof Error ? err.message : 'Restore failed');
+  } finally {
+    setActionLoading(null);
+  }
+}, [deviceId, selected, fetchTrash, onRestore]);
+```
+
+Add a `warning` state alongside the existing `error` state and render it in amber where the error banner currently renders red.
+
+### 7. Tests
+
+**API (Vitest):**
+
+- `apps/api/src/routes/systemTools/fileBrowser.test.ts` (or add if missing): assert upload's 504 timeout path returns `{ error, unverified: true }`. The existing `fileBrowserHelpers.test.ts` already covers `buildBulkItemFailure`.
+
+**Web (Vitest + jsdom):**
+
+- `FileActivityPanel.test.tsx`: snapshot one row for each of the three `result` states; assert the amber badge text/color for `unverified`.
+- `FileManager.test.tsx`: three handler tests (`handleCopyTo`, `handleMoveTo`, `handleDelete`) with mixed results (all success / all fail / all unverified / mixed fail + unverified) asserting the `addActivity` call receives the right `(result, summary)`.
+- `TrashView.test.tsx`: unverified-only restore shows the amber warning; mixed restore shows the red error with unverified count.
+
+Follow the rules in `CLAUDE.md` → Testing Standards: tests co-located, multi-tenant not applicable (pure UI state), cover happy/unverified/failure/mixed branches.
+
+### 8. File-size guideline
+
+`FileManager.tsx` is already a large file. The helper `summarizeBulkResults` goes local for now (one file, one helper, <30 lines). If a future change needs it elsewhere, extract to `fileOperations.ts` at that point. No proactive split.
+
+## Out of scope / future work
+
+- **Automatic state refresh after unverified ops.** Could call `fetchDirectory(currentPath)` unconditionally after any unverified outcome. Left out deliberately — user might be looking at the error.
+- **Per-path detail drill-down.** The activity panel currently lists all paths flatly; we could mark individual paths as unverified. Ignored for now — the summary string is enough for the reported gap.
+- **Idempotent retry.** A "retry this op" button that re-issues only failed items and skips unverified ones. Requires agent-side idempotency guarantees we don't have.
+
+## Risks
+
+- **Visual noise.** Adding a third badge color in a 300px panel could feel busy. Mitigation: amber is used nowhere else in this panel, so a mixed row still reads cleanly.
+- **Test flakiness around `FileManager.tsx`.** The file is large and has no existing test that we know of; adding one may uncover lint/mocking churn. If so, scope the new test file narrowly (just the helper + one handler) rather than fighting an exhaustive render test.
+- **`UnverifiedOperationError` import chain.** `FileManager.tsx` will need to import it from `fileOperations.ts`. Minor, but means `fileOperations.ts` goes from data-shape module to type-exporter. Acceptable.


### PR DESCRIPTION
## Summary

Mass mock-debt fix that unblocks 8 cascading **Test API** failures on main. The job had been failing for some time with TypeError errors that prevented many unrelated tests from running.

### Root causes fixed

1. **\`withSystemDbAccessContext\` + \`withDbAccessContext\` missing from \`../db\` mocks** (159 files). The auth middleware now calls these on every request, so any test that exercises auth blew up at import time. Added the missing exports to all affected files using the factory pattern already in \`commandQueue.test.ts\`.

2. **\`.orderBy()\` missing from select chain mock in \`orgs.test.ts\`**. \`resolveAuditOrgIdForPartner\` uses \`.select().from().where().orderBy()\` but the mock stopped at \`.where()\`. Added \`.orderBy()\` to 6 mock sites.

3. **\`.returning()\` missing from update chain mock in \`agentWs.test.ts\`**. \`processOrphanedCommandResult\` calls \`.update().set().where().returning()\` — the existing mock returned a Promise from \`.where()\` which threw on the synchronous \`.returning\` call. Also added missing \`backupJobs\` / \`restoreJobs\` innerJoin select mocks downstream of \`discoveryJobs\` returning empty.

4. **\`redis.get()\` missing from \`bmr.test.ts\` redis mock**. \`bmr.ts:1175\` calls \`getRedis().get()\`; mock only stubbed \`.multi()\`. Added \`get/set/del\`.

### Two regressions exposed once the cascade unblocked

- **\`analytics.test.ts\`**: my parallel agent's first-pass mock edit produced invalid syntax (\`};,\` instead of \`};\`). Manually corrected.
- **\`systemTools.test.ts\`**: PR #392 (\`fix(api)\` for #391) added a \`DEVICE_UNREACHABLE_ERROR\` export to \`commandQueue.ts\`; the inline mock here didn't list it. Added the sentinel + \`SEND_RETRY_ATTEMPTS\` to the mock.

## Test plan

- [x] \`npx vitest run\` locally — Test API failure count drops from **19 to 11**
- [x] The remaining 11 are pre-existing failures unrelated to mocks (filesystem analysis test argument shape, MSI signing tests, \`/auth/register\`, etc.) and were already failing on main before this branch
- [ ] CI Test API job runs against this branch and shows \`19 → 11\` reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)