### PR TITLE
docs: RLS tenancy reference + 04-09 feature plans + session handoff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,35 @@ Breeze is a fast, modern Remote Monitoring and Management (RMM) platform for MSP
 Partner (MSP) → Organization (Customer) → Site (Location) → Device Group → Device
 ```
 
+### Tenant Isolation / RLS (READ BEFORE ADDING TABLES)
+The API connects to Postgres as the unprivileged `breeze_app` role. Every tenant-scoped table MUST have RLS enabled + forced + policies — there is no app-layer-only fallback. Migration `0008-tenant-rls.sql` only auto-loops tables existing at that moment; every table added since must opt in explicitly.
+
+**Five tenancy shapes** (see `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` — the contract test enforces all of them):
+1. **Direct `org_id` column** — standard 4 policies calling `breeze_has_org_access(org_id)`. Auto-discovered by the contract test; no allowlist needed.
+2. **Id-keyed (`organizations`)** — the row's own `id` is the tenant; policy calls `breeze_has_org_access(id)`. Add to `ORG_ID_KEYED_TENANT_TABLES`.
+3. **Partner-axis (`partners`, `partner_users`)** — uses `breeze_has_partner_access(partner_id)` + `breeze.accessible_partner_ids` GUC. Flat membership check, never a tree traversal. Add to `PARTNER_TENANT_TABLES`.
+4. **Dual-axis (`users`)** — partner OR org OR self-read via `breeze_current_user_id()`. Composite FK `(org_id, partner_id) → organizations(id, partner_id)` enforces structural integrity so a user row cannot point at an org from another MSP even through a policy bug.
+5. **Device-id scoped** — for tables joined to `devices`. **Heuristic:** hot agent-write-path tables get a denormalized `org_id` column (Phase 1-4 shape, faster); admin/cold tables use a `EXISTS (SELECT 1 FROM devices d WHERE d.id = t.device_id AND breeze_has_org_access(d.org_id))` join policy (Phase 5 shape, no schema churn). Add join-policy tables to `DEVICE_ID_JOIN_POLICY_TABLES`.
+6. **User-id-scoped** — `push_notifications`, `mobile_devices`, etc. Reference `breeze_current_user_id()`. Add to `USER_ID_SCOPED_TABLES`.
+
+**DB context helpers** (`apps/api/src/db/index.ts`):
+- `withDbAccessContext(ctx, fn)` — sets `breeze.scope`, `breeze.org_id`, `breeze.accessible_org_ids`, `breeze.accessible_partner_ids`, `breeze.user_id` GUCs inside a transaction. Standard request path.
+- `withSystemDbAccessContext(fn)` — system scope (`*` on all axes). Use ONLY for legitimate system-scope work (background workers, seeds, audit log writes, cross-tenant catalog reads).
+- `runOutsideDbContext(fn)` — exits AsyncLocalStorage so the next `db` access uses the bare pool. Required before calling `withSystemDbAccessContext` from inside a request to escape the request-scoped transaction.
+
+**Intentionally system-scoped (do not add RLS):** `device_commands` (agent WS path reads/writes from system scope). Anything else flagged "INTENTIONAL_UNSCOPED" in a plan doc.
+
+**Workflow when adding a new tenant-scoped table:**
+1. Pick the shape from the six above. Add policies in the same migration that creates the table — never defer.
+2. Use `IF NOT EXISTS` / `DO $$` blocks like every other migration. Never edit a shipped migration.
+3. If the new table needs an entry in any of the contract test's allowlists (shapes 2-6), add it to `rls-coverage.integration.test.ts` in the same PR.
+4. Run the contract test locally — it uses `pg_catalog` and needs a real DB.
+5. Verify locally as `breeze_app`: `docker exec -it breeze-postgres psql -U breeze_app -d breeze` and try a forged cross-tenant insert — it should fail with `new row violates row-level security policy`.
+
+**Production rollout for backfilling `org_id` columns on hot tables:** batch with `UPDATE ... WHERE ctid IN (SELECT ctid ... LIMIT N)` loops. The `SET NOT NULL` after backfill takes a brief ACCESS EXCLUSIVE lock — check `pg_stat_user_tables.n_live_tup` on the prod replica first. Tables > 1M rows must use the batched path. JOIN_POLICY shape (Phase 5) is policy-only and safe to apply in one shot regardless of row count.
+
+**Reference doc:** `docs/superpowers/plans/2026-04-11-rls-coverage-gaps.md` — source-of-truth narrative covering Buckets A/B/C (64 tables across 13 commits as of 2026-04-11) and the rationale for each shape choice.
+
 ### Database Schema Location
 - `apps/api/src/db/schema/` - All Drizzle schema definitions
 - Key tables: devices, users, organizations, sites, alerts, scripts, automations

--- a/docs/superpowers/plans/2026-04-09-connections-inventory-400.md
+++ b/docs/superpowers/plans/2026-04-09-connections-inventory-400.md
@@ -1,0 +1,242 @@
+# Connections Inventory 400 Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop Linux agents from receiving HTTP 400 when submitting connections inventory on busy servers (472+ connections), by filtering out unsupported socket types in the agent before sending.
+
+**Architecture:** The agent's `getProtocolString()` returns `"unknown"` for socket types other than TCP (1) and UDP (2) — e.g., Unix domain sockets, raw sockets. These hit the API's strict `z.enum(['tcp', 'tcp6', 'udp', 'udp6'])` and cause the entire payload to be rejected with 400. Fix at the agent (filter before send) and harden the API route (add `bodyLimit` for consistency).
+
+**Tech Stack:** Go (gopsutil), TypeScript (Hono + Zod)
+
+---
+
+## Files
+
+- Modify: `agent/internal/collectors/connections_linux.go` — skip connections where `getProtocolString` returns `"unknown"`
+- Modify: `apps/api/src/routes/agents/connections.ts` — add `bodyLimit` middleware (consistency with other inventory routes)
+- Modify: `apps/api/src/routes/agents/connections.test.ts` — add test confirming `"unknown"` protocol payloads would be caught
+
+---
+
+### Task 1: Filter unknown protocols in the Linux agent collector
+
+**Files:**
+- Modify: `agent/internal/collectors/connections_linux.go`
+- Create: `agent/internal/collectors/connections_linux_test.go`
+
+- [ ] **Step 1: Write a failing test for `getProtocolString`**
+
+  Create `agent/internal/collectors/connections_linux_test.go`:
+
+  ```go
+  //go:build linux
+
+  package collectors
+
+  import (
+  	"testing"
+  )
+
+  func TestGetProtocolString(t *testing.T) {
+  	c := &ConnectionsCollector{}
+  	tests := []struct {
+  		connType uint32
+  		family   uint32
+  		want     string
+  	}{
+  		{connType: 1, family: 2, want: "tcp"},    // SOCK_STREAM, AF_INET
+  		{connType: 1, family: 10, want: "tcp6"},   // SOCK_STREAM, AF_INET6
+  		{connType: 2, family: 2, want: "udp"},     // SOCK_DGRAM, AF_INET
+  		{connType: 2, family: 10, want: "udp6"},   // SOCK_DGRAM, AF_INET6
+  		{connType: 3, family: 1, want: "unknown"}, // SOCK_RAW, AF_UNIX
+  		{connType: 5, family: 1, want: "unknown"}, // SOCK_SEQPACKET, AF_UNIX
+  	}
+
+  	for _, tt := range tests {
+  		got := c.getProtocolString(tt.connType, tt.family)
+  		if got != tt.want {
+  			t.Errorf("getProtocolString(%d, %d) = %q, want %q", tt.connType, tt.family, got, tt.want)
+  		}
+  	}
+  }
+
+  func TestCollectFiltersUnknownProtocols(t *testing.T) {
+  	// Verify that connections with protocol "unknown" are excluded.
+  	// We test getProtocolString directly since Collect() requires root for net.Connections.
+  	c := &ConnectionsCollector{}
+  	if got := c.getProtocolString(1, 2); got == "unknown" {
+  		t.Error("tcp connections should not be filtered")
+  	}
+  	if got := c.getProtocolString(99, 99); got != "unknown" {
+  		t.Errorf("unexpected socket type should return 'unknown', got %q", got)
+  	}
+  }
+  ```
+
+- [ ] **Step 2: Run the test to verify it passes (existing behavior)**
+
+  ```bash
+  cd agent && go test -race ./internal/collectors/... -run TestGetProtocolString -v
+  ```
+  Expected: PASS — `getProtocolString` already behaves correctly; we're testing it explicitly before changing the filter logic.
+
+- [ ] **Step 3: Add the filter in `Collect()`**
+
+  In `agent/internal/collectors/connections_linux.go`, the `Collect()` function appends every connection. Change it to skip connections where protocol is `"unknown"`:
+
+  Replace:
+  ```go
+  		protocol := c.getProtocolString(conn.Type, conn.Family)
+
+  		processName := ""
+  ```
+  With:
+  ```go
+  		protocol := c.getProtocolString(conn.Type, conn.Family)
+  		if protocol == "unknown" {
+  			continue // skip Unix sockets, raw sockets, and other unsupported types
+  		}
+
+  		processName := ""
+  ```
+
+- [ ] **Step 4: Run tests**
+
+  ```bash
+  cd agent && go test -race ./internal/collectors/... -v
+  ```
+  Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add agent/internal/collectors/connections_linux.go agent/internal/collectors/connections_linux_test.go
+  git commit -m "fix(agent): skip unknown-protocol connections before submitting inventory"
+  ```
+
+---
+
+### Task 2: Add `bodyLimit` middleware to the connections route
+
+**Files:**
+- Modify: `apps/api/src/routes/agents/connections.ts`
+
+- [ ] **Step 1: Add the import**
+
+  The current `connections.ts` imports are:
+  ```typescript
+  import { Hono } from 'hono';
+  import { zValidator } from '@hono/zod-validator';
+  import { eq } from 'drizzle-orm';
+  import { db } from '../../db';
+  import { devices, deviceConnections } from '../../db/schema';
+  import { submitConnectionsSchema } from './schemas';
+  ```
+
+  Add `bodyLimit` to the import list:
+  ```typescript
+  import { Hono } from 'hono';
+  import { bodyLimit } from 'hono/body-limit';
+  import { zValidator } from '@hono/zod-validator';
+  import { eq } from 'drizzle-orm';
+  import { db } from '../../db';
+  import { devices, deviceConnections } from '../../db/schema';
+  import { submitConnectionsSchema } from './schemas';
+  ```
+
+- [ ] **Step 2: Add `bodyLimit` to the route**
+
+  Replace:
+  ```typescript
+  connectionsRoutes.put('/:id/connections', zValidator('json', submitConnectionsSchema), async (c) => {
+  ```
+  With:
+  ```typescript
+  connectionsRoutes.put(
+    '/:id/connections',
+    bodyLimit({ maxSize: 5 * 1024 * 1024, onError: (c) => c.json({ error: 'Request body too large' }, 413) }),
+    zValidator('json', submitConnectionsSchema),
+    async (c) => {
+  ```
+
+  Also close the route registration properly. The route currently ends with `});`. That ending is unchanged — you are only modifying the middleware chain at the top.
+
+- [ ] **Step 3: Run the existing tests**
+
+  ```bash
+  pnpm test --filter=@breeze/api -- connections
+  ```
+  Expected: all existing tests pass.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add apps/api/src/routes/agents/connections.ts
+  git commit -m "fix(api): add bodyLimit to connections inventory route (consistent with other inventory routes)"
+  ```
+
+---
+
+### Task 3: Add a test documenting the "unknown protocol" rejection
+
+**Files:**
+- Modify: `apps/api/src/routes/agents/connections.test.ts`
+
+The API correctly rejects `"unknown"` protocol (via the existing `z.enum` test at line 163). Add an explicit test case that names this scenario so it's clear this is deliberate behavior.
+
+- [ ] **Step 1: Add the test**
+
+  In `apps/api/src/routes/agents/connections.test.ts`, inside the `'PUT /agents/:id/connections'` describe block, add after the `'should validate protocol enum'` test:
+
+  ```typescript
+  it('should reject "unknown" protocol (Linux agent must filter before sending)', async () => {
+    const res = await app.request(`/agents/${AGENT_ID}/connections`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        connections: [
+          {
+            protocol: 'unknown',
+            localAddr: '0.0.0.0',
+            localPort: 80,
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+  ```
+
+- [ ] **Step 2: Run tests**
+
+  ```bash
+  pnpm test --filter=@breeze/api -- connections
+  ```
+  Expected: PASS (the existing schema already rejects this — we're just documenting it).
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add apps/api/src/routes/agents/connections.test.ts
+  git commit -m "test(api): document that unknown-protocol connections are rejected"
+  ```
+
+---
+
+### Task 4: Comment on GitHub issue #382
+
+- [ ] **Step 1: Post the fix comment**
+
+  ```bash
+  gh issue comment 382 --repo LanternOps/breeze --body "$(cat <<'EOF'
+  Root cause confirmed and fix committed.
+
+  **Root cause:** `getProtocolString()` in the Linux collector returns `"unknown"` for non-TCP/UDP socket types (Unix domain sockets, raw sockets, etc.). These are common on busy servers with many inter-process connections. The API schema enforces `z.enum(['tcp','tcp6','udp','udp6'])`, so any payload containing an `"unknown"` entry is rejected with 400.
+
+  **Fix:** The agent now skips connections with protocol `"unknown"` before building the PUT payload. The API schema and bodyLimit middleware are unchanged (schema stays strict, bodyLimit added for consistency with other inventory routes).
+
+  Fix: [commit SHA here]
+  EOF
+  )"
+  ```

--- a/docs/superpowers/plans/2026-04-09-linux-agent-autostart.md
+++ b/docs/superpowers/plans/2026-04-09-linux-agent-autostart.md
@@ -1,0 +1,176 @@
+# Linux Agent Auto-Start Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure the Linux Breeze agent automatically restarts after a reboot without requiring the user to manually start it.
+
+**Architecture:** Two locations fail to call `systemctl enable`: the install script and the `service start` CLI command. Both need to call `systemctl enable breeze-agent` before/after starting the service so the systemd unit is marked for auto-start on boot.
+
+**Tech Stack:** Go (Cobra CLI), Bash (install script), systemd
+
+---
+
+## Files
+
+- Modify: `agent/scripts/install/install-linux.sh` (line 80 — add `systemctl enable` after daemon-reload)
+- Modify: `agent/cmd/breeze-agent/service_cmd_linux.go` (line 288 — add `systemctl enable` in `serviceStartCmd` before `systemctl start`)
+
+---
+
+### Task 1: Enable service in the install script
+
+**Files:**
+- Modify: `agent/scripts/install/install-linux.sh`
+
+- [ ] **Step 1: Open the file and locate the daemon-reload call**
+
+  Read `agent/scripts/install/install-linux.sh` lines 78–85. You will see:
+  ```bash
+  systemctl daemon-reload
+  
+  # Install user helper systemd user unit
+  ```
+
+- [ ] **Step 2: Add `systemctl enable` immediately after `daemon-reload`**
+
+  Replace the block:
+  ```bash
+  systemctl daemon-reload
+  
+  # Install user helper systemd user unit
+  ```
+  With:
+  ```bash
+  systemctl daemon-reload
+  systemctl enable breeze-agent
+  
+  # Install user helper systemd user unit
+  ```
+
+- [ ] **Step 3: Update the "Next steps" output to remove the manual enable instruction**
+
+  The existing "Next steps" blocks (lines 132–145) tell users to run `systemctl enable` manually. Remove that step since it now happens automatically.
+
+  Replace (the already-enrolled branch):
+  ```bash
+  echo "Next steps:"
+  echo "  1. Enable:  sudo systemctl enable breeze-agent"
+  echo "  2. Start:   sudo systemctl start breeze-agent"
+  echo "  3. Status:  sudo systemctl status breeze-agent"
+  echo "  4. Logs:    journalctl -u breeze-agent -f"
+  echo "  5. User helper: systemctl --user enable breeze-agent-user (per-user)"
+  ```
+  With:
+  ```bash
+  echo "Next steps:"
+  echo "  1. Start:   sudo systemctl start breeze-agent"
+  echo "  2. Status:  sudo systemctl status breeze-agent"
+  echo "  3. Logs:    journalctl -u breeze-agent -f"
+  echo "  4. User helper: systemctl --user enable breeze-agent-user (per-user)"
+  ```
+
+  Replace (the not-yet-enrolled branch):
+  ```bash
+  echo "Next steps:"
+  echo "  1. Enroll:  sudo breeze-agent enroll <enrollment-key> --server https://your-server [--enrollment-secret <secret>]"
+  echo "  2. Enable:  sudo systemctl enable breeze-agent"
+  echo "  3. Start:   sudo systemctl start breeze-agent"
+  echo "  4. Status:  sudo systemctl status breeze-agent"
+  echo "  5. Logs:    journalctl -u breeze-agent -f"
+  echo "  6. User helper: systemctl --user enable breeze-agent-user (per-user)"
+  ```
+  With:
+  ```bash
+  echo "Next steps:"
+  echo "  1. Enroll:  sudo breeze-agent enroll <enrollment-key> --server https://your-server [--enrollment-secret <secret>]"
+  echo "  2. Start:   sudo systemctl start breeze-agent"
+  echo "  3. Status:  sudo systemctl status breeze-agent"
+  echo "  4. Logs:    journalctl -u breeze-agent -f"
+  echo "  5. User helper: systemctl --user enable breeze-agent-user (per-user)"
+  ```
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add agent/scripts/install/install-linux.sh
+  git commit -m "fix(linux): auto-enable breeze-agent systemd service during install"
+  ```
+
+---
+
+### Task 2: Enable service in `breeze-agent service start`
+
+**Files:**
+- Modify: `agent/cmd/breeze-agent/service_cmd_linux.go`
+
+- [ ] **Step 1: Locate the `serviceStartCmd` `RunE` function**
+
+  Read `agent/cmd/breeze-agent/service_cmd_linux.go` lines 276–297. The relevant section is:
+  ```go
+  out, err := exec.Command("systemctl", "start", linuxServiceName).CombinedOutput()
+  if err != nil {
+      return fmt.Errorf("failed to start service: %s", strings.TrimSpace(string(out)))
+  }
+  
+  fmt.Println("Breeze Agent service started.")
+  fmt.Println("Logs: journalctl -u breeze-agent -f")
+  ```
+
+- [ ] **Step 2: Add `systemctl enable` before `systemctl start`**
+
+  Replace that block with:
+  ```go
+  // Enable the service for auto-start on reboot before starting it.
+  if out, err := exec.Command("systemctl", "enable", linuxServiceName).CombinedOutput(); err != nil {
+      fmt.Fprintf(os.Stderr, "Warning: failed to enable service for auto-start: %s\n", strings.TrimSpace(string(out)))
+  }
+  
+  out, err := exec.Command("systemctl", "start", linuxServiceName).CombinedOutput()
+  if err != nil {
+      return fmt.Errorf("failed to start service: %s", strings.TrimSpace(string(out)))
+  }
+  
+  fmt.Println("Breeze Agent service started and enabled for auto-start.")
+  fmt.Println("Logs: journalctl -u breeze-agent -f")
+  ```
+
+  Note: `os` is already imported. `exec` and `strings` are already imported.
+
+- [ ] **Step 3: Verify the build compiles**
+
+  ```bash
+  cd agent && go build ./cmd/breeze-agent/...
+  ```
+  Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add agent/cmd/breeze-agent/service_cmd_linux.go
+  git commit -m "fix(linux): enable systemd service on start so it survives reboot"
+  ```
+
+---
+
+### Task 3: Verify the reporter can confirm the fix
+
+- [ ] **Step 1: Update GitHub issue #381 with a comment**
+
+  ```bash
+  gh issue comment 381 --repo LanternOps/breeze --body "$(cat <<'EOF'
+  Root cause identified and fix committed.
+
+  **Fix:** `install-linux.sh` now calls `systemctl enable breeze-agent` immediately after `systemctl daemon-reload`, so the service is armed for auto-start the moment the agent is installed. `breeze-agent service start` also now enables the unit before starting it, so users who start via the CLI don't need a separate enable step.
+
+  **Workaround for the reporter right now:**
+  ```bash
+  sudo systemctl enable breeze-agent
+  sudo systemctl status breeze-agent
+  ```
+  This will ensure the existing install survives the next reboot.
+
+  Fix: [commit SHA here]
+  EOF
+  )"
+  ```
+  (Replace `[commit SHA here]` with the actual SHA after merge.)

--- a/docs/superpowers/plans/2026-04-09-macos-helper-not-connected.md
+++ b/docs/superpowers/plans/2026-04-09-macos-helper-not-connected.md
@@ -1,0 +1,192 @@
+# macOS Desktop Helper Not Connected Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the "Helper Not Connected" remote desktop state on macOS by immediately bootstrapping the desktop helper LaunchAgent after `service install`, instead of relying solely on the heartbeat's on-demand kickstart.
+
+**Architecture:** `breeze-agent service install` writes the desktop helper LaunchAgent plists to `/Library/LaunchAgents/` but never loads them into launchd. The helper only gets bootstrapped on-demand during a heartbeat that attempts remote desktop access. If that kickstart fails (e.g., because no GUI session is active yet, or the service was started via a non-interactive path), the helper never connects. Fix: immediately call `launchctl bootstrap gui/<SUDO_UID>` after writing the plists in `service install`, and also call it in `service start`. Both are run with `sudo`, so `SUDO_UID` is available.
+
+**Tech Stack:** Go (Cobra CLI), macOS launchd, `launchctl`
+
+---
+
+## Files
+
+- Modify: `agent/cmd/breeze-agent/service_cmd_darwin.go` — bootstrap helper plists immediately after writing them (in `serviceInstallCmd` and `serviceStartCmd`)
+
+---
+
+### Task 1: Bootstrap helper plists in `service install`
+
+**Files:**
+- Modify: `agent/cmd/breeze-agent/service_cmd_darwin.go`
+
+- [ ] **Step 1: Read the file to understand structure**
+
+  Read `agent/cmd/breeze-agent/service_cmd_darwin.go` lines 145–264. Specifically, the block that writes the desktop helper plists looks like:
+
+  ```go
+  if err := os.WriteFile(darwinDesktopUserPlistDst, []byte(darwinDesktopUserPlist), 0644); err != nil {
+      fmt.Fprintf(os.Stderr, "Warning: failed to write desktop-helper user plist: %v\n", err)
+  } else {
+      fmt.Printf("LaunchAgent plist installed to %s\n", darwinDesktopUserPlistDst)
+  }
+  if err := os.WriteFile(darwinDesktopLoginWindowPlistDst, []byte(darwinDesktopLoginWindowPlist), 0644); err != nil {
+      fmt.Fprintf(os.Stderr, "Warning: failed to write desktop-helper loginwindow plist: %v\n", err)
+  } else {
+      fmt.Printf("LaunchAgent plist installed to %s\n", darwinDesktopLoginWindowPlistDst)
+  }
+  ```
+
+  This is followed by the `dscl` breeze-group creation block.
+
+- [ ] **Step 2: Add a helper function `bootstrapDesktopHelperPlists` at the bottom of `service_cmd_darwin.go`**
+
+  Add this function at the end of the file, before the last closing `}`:
+
+  ```go
+  // bootstrapDesktopHelperPlists immediately loads the desktop helper LaunchAgents
+  // into launchd for the installing user's GUI session (via SUDO_UID) and the
+  // loginwindow domain. Called from service install and service start so the
+  // helper connects right away rather than waiting for the first heartbeat.
+  func bootstrapDesktopHelperPlists() {
+  	// When run via sudo, SUDO_UID holds the real user's UID. Bootstrap the helper
+  	// into that user's GUI session so it can access the display immediately.
+  	if uid := os.Getenv("SUDO_UID"); uid != "" {
+  		domain := "gui/" + uid
+  		out, err := exec.Command("launchctl", "bootstrap", domain, darwinDesktopUserPlistDst).CombinedOutput()
+  		if err != nil {
+  			// Not fatal — kickstart will retry on next heartbeat.
+  			fmt.Fprintf(os.Stderr, "Note: could not bootstrap desktop helper for user %s (will retry on heartbeat): %s\n",
+  				uid, strings.TrimSpace(string(out)))
+  		} else {
+  			fmt.Printf("Desktop helper bootstrapped for GUI session (uid %s)\n", uid)
+  		}
+  	}
+
+  	// Also bootstrap the login-window helper (covers login screen remote access).
+  	out, err := exec.Command("launchctl", "bootstrap", "loginwindow", darwinDesktopLoginWindowPlistDst).CombinedOutput()
+  	if err != nil {
+  		fmt.Fprintf(os.Stderr, "Note: could not bootstrap login-window desktop helper: %s\n",
+  			strings.TrimSpace(string(out)))
+  	} else {
+  		fmt.Println("Login-window desktop helper bootstrapped.")
+  	}
+  }
+  ```
+
+  Verify that `os`, `exec`, `strings`, and `fmt` are already imported (they are — check the import block at the top of the file).
+
+- [ ] **Step 3: Call `bootstrapDesktopHelperPlists()` in `serviceInstallCmd` after writing the plists**
+
+  Find the block that ends with the loginwindow plist write (the two `os.WriteFile` calls for the helper plists). Immediately after that block (before the `dscl` breeze-group section), add:
+
+  ```go
+  	// Immediately load the helper LaunchAgents so the desktop helper connects
+  	// right away rather than waiting for the first heartbeat.
+  	bootstrapDesktopHelperPlists()
+  ```
+
+- [ ] **Step 4: Verify the build compiles**
+
+  ```bash
+  cd agent && GOOS=darwin go build ./cmd/breeze-agent/...
+  ```
+  Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add agent/cmd/breeze-agent/service_cmd_darwin.go
+  git commit -m "fix(macos): bootstrap desktop helper LaunchAgents immediately on service install"
+  ```
+
+---
+
+### Task 2: Also bootstrap helpers in `service start`
+
+**Files:**
+- Modify: `agent/cmd/breeze-agent/service_cmd_darwin.go`
+
+Users who reinstall over a previous version with `service install` may follow up with `service start`. Additionally, users who run `service start` after a failed previous install may have plists on disk but not loaded. Bootstrapping on start (if plists exist) covers both cases.
+
+- [ ] **Step 1: Locate `serviceStartCmd` in `service_cmd_darwin.go`**
+
+  Find the `serviceStartCmd` `RunE` function. It calls `launchctl bootstrap system <plist>` to start the main agent daemon. After that bootstrap succeeds (or if the service is already running), add a call to bootstrap the helpers.
+
+  Read the current start command around lines 316–351. The relevant section loads the main daemon plist:
+
+  ```go
+  // Bootstrap the agent daemon into the System domain.
+  out, err := exec.Command("launchctl", "bootstrap", "system", darwinPlistDst).CombinedOutput()
+  ```
+
+  (The exact structure may vary — find the block that bootstraps `darwinPlistDst` and returns successfully.)
+
+- [ ] **Step 2: Add helper bootstrap after the main daemon starts**
+
+  After the main agent daemon is successfully bootstrapped and the success message is printed, add:
+
+  ```go
+  // Bootstrap the desktop helper LaunchAgents so remote desktop connects promptly.
+  if _, err := os.Stat(darwinDesktopUserPlistDst); err == nil {
+  	bootstrapDesktopHelperPlists()
+  }
+  ```
+
+  The `os.Stat` guard ensures we only try if the plist file exists (i.e., `service install` was previously run).
+
+- [ ] **Step 3: Verify the build compiles**
+
+  ```bash
+  cd agent && GOOS=darwin go build ./cmd/breeze-agent/...
+  ```
+  Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add agent/cmd/breeze-agent/service_cmd_darwin.go
+  git commit -m "fix(macos): bootstrap desktop helper on service start if plists exist"
+  ```
+
+---
+
+### Task 3: Verify the fix closes the issue
+
+- [ ] **Step 1: Manual verification steps (document for reporter)**
+
+  On the affected Mac mini, after the next agent update containing this fix:
+
+  ```bash
+  # Manually bootstrap immediately without reinstalling:
+  sudo launchctl bootstrap gui/$(id -u) /Library/LaunchAgents/com.breeze.desktop-helper-user.plist
+  sudo launchctl bootstrap loginwindow /Library/LaunchAgents/com.breeze.desktop-helper-loginwindow.plist
+
+  # Verify helper is loaded:
+  launchctl print gui/$(id -u)/com.breeze.desktop-helper-user
+  ```
+
+  Within 60 seconds, the next heartbeat should change the Desktop Access status from "Helper Not Connected" to an active mode.
+
+- [ ] **Step 2: Comment on GitHub issue #383**
+
+  ```bash
+  gh issue comment 383 --repo LanternOps/breeze --body "$(cat <<'EOF'
+  Root cause confirmed and fix committed.
+
+  **Root cause:** `service install` writes the desktop helper LaunchAgent plists to `/Library/LaunchAgents/` but never calls `launchctl bootstrap` to load them. The helper only gets bootstrapped on-demand during a heartbeat, and if that kickstart fails (e.g., no active GUI session, launchctl timing issues), the helper never connects. With all permissions already granted (Full Disk Access, Screen Recording, Accessibility confirmed in screenshots), the only missing piece was the helper not being loaded into launchd.
+
+  **Fix:** `service install` and `service start` now call `launchctl bootstrap gui/<SUDO_UID>` and `launchctl bootstrap loginwindow` immediately after writing the plists, so the helper connects within seconds rather than waiting for a heartbeat retry.
+
+  **Workaround for the reporter right now (before the next update):**
+  ```bash
+  sudo launchctl bootstrap gui/$(id -u) /Library/LaunchAgents/com.breeze.desktop-helper-user.plist
+  sudo launchctl bootstrap loginwindow /Library/LaunchAgents/com.breeze.desktop-helper-loginwindow.plist
+  ```
+  Wait 60 seconds for the next heartbeat — the Desktop Access status should change from "Helper Not Connected."
+
+  Fix: [commit SHA here]
+  EOF
+  )"
+  ```

--- a/docs/superpowers/plans/2026-04-09-sidebar-partner-branding.md
+++ b/docs/superpowers/plans/2026-04-09-sidebar-partner-branding.md
@@ -1,0 +1,690 @@
+# Sidebar Partner Branding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let partners upload a logo via the Partner Settings → Branding tab (stored as a base64 data URI in the existing `partner.settings` JSONB column), then render that logo + partner name in the admin sidebar top-left in place of the hard-coded Breeze SVG / "Breeze" text.
+
+**Architecture:** Three layers of work. (1) Extend `sanitizeImageSrc` to accept safe `data:image/…` URIs (PNG/JPEG/WebP only, size-capped). (2) Add a file-upload UI to `PartnerBrandingTab` — canvas-resize client-side to ≤256×256, encode to PNG base64, store in `branding.logoUrl` via the existing `PATCH /orgs/partners/me` endpoint; add a server-side length cap. (3) Build a `BrandHeader` component and wire it into `Sidebar`, which fetches `/orgs/partners/me` on mount to pull branding.
+
+**Tech Stack:** React (Astro Islands), TypeScript, Tailwind, Vitest + React Testing Library, `fetchWithAuth` + `sanitizeImageSrc`, Canvas API (client-side resize), Zod (server-side cap), Hono (`apps/api/src/routes/orgs.ts`).
+
+---
+
+## File Map
+
+- **Modify** `apps/web/src/lib/safeImageSrc.ts` — extend to allow `data:image/(png|jpeg|webp);base64,…` URIs up to 400 000 chars; reject SVG and other MIME types.
+- **Modify** `apps/web/src/lib/safeImageSrc.test.ts` — add data URI test cases.
+- **Modify** `apps/web/src/components/settings/PartnerBrandingTab.tsx` — replace the `<input type="url">` logo field with a file-picker (canvas resize → PNG base64) + preview + remove button + URL fallback.
+- **Modify** `apps/api/src/routes/orgs.ts` — add `.max(400_000)` to the `branding.logoUrl` Zod field (line 359).
+- **Create** `apps/web/src/components/layout/BrandHeader.tsx` — presentational component: renders sanitized `<img>` or Breeze SVG fallback + optional label.
+- **Create** `apps/web/src/components/layout/BrandHeader.test.tsx` — unit tests covering fallback, branded HTTPS URL, data URI, and unsafe URL rejection.
+- **Modify** `apps/web/src/components/layout/Sidebar.tsx` — add branding fetch effect + state; replace desktop + mobile brand blocks with `<BrandHeader />`.
+
+---
+
+## Task 1: Extend `sanitizeImageSrc` to allow safe data URIs (TDD)
+
+**Files:**
+- Modify: `apps/web/src/lib/safeImageSrc.ts`
+- Modify: `apps/web/src/lib/safeImageSrc.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Open `apps/web/src/lib/safeImageSrc.test.ts` and append these cases to the existing `sanitizeImageSrc` describe block:
+
+```ts
+// Data URI cases
+it('accepts a valid PNG data URI within the size limit', () => {
+  const dataUri = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+  expect(sanitizeImageSrc(dataUri)).toBe(dataUri);
+});
+
+it('accepts a valid JPEG data URI', () => {
+  const dataUri = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAARC';
+  expect(sanitizeImageSrc(dataUri)).toBe(dataUri);
+});
+
+it('accepts a valid WebP data URI', () => {
+  const dataUri = 'data:image/webp;base64,UklGRlYAAABXRUJQVlA4IEoAAADQAQCdASoBAAEAAkA4JYgCdAEO/gHOAAA=';
+  expect(sanitizeImageSrc(dataUri)).toBe(dataUri);
+});
+
+it('rejects SVG data URI (XSS risk)', () => {
+  expect(sanitizeImageSrc('data:image/svg+xml;base64,PHN2Zy8+')).toBeNull();
+});
+
+it('rejects HTML data URI', () => {
+  expect(sanitizeImageSrc('data:text/html;base64,PGh0bWwv>')).toBeNull();
+});
+
+it('rejects a data URI that exceeds the size limit', () => {
+  const oversized = 'data:image/png;base64,' + 'A'.repeat(400_001);
+  expect(sanitizeImageSrc(oversized)).toBeNull();
+});
+
+it('rejects a data URI without the base64 marker', () => {
+  expect(sanitizeImageSrc('data:image/png,rawbytes')).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pnpm --filter=@breeze/web test safeImageSrc -- --run`
+Expected: FAIL — the data URI cases return `null` instead of the URI (because the current code rejects `data:` protocol).
+
+- [ ] **Step 3: Implement the change**
+
+Open `apps/web/src/lib/safeImageSrc.ts`. Add the data URI guard immediately before the existing `blob:` check (currently line 25):
+
+```ts
+const DATA_IMAGE_PATTERN = /^data:image\/(png|jpeg|webp);base64,[A-Za-z0-9+/]+=*$/;
+const MAX_DATA_URI_LENGTH = 400_000; // ~300 KB file after base64 inflation
+
+export function sanitizeImageSrc(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const candidate = value.trim();
+  if (!candidate || CONTROL_CHARS_PATTERN.test(candidate)) {
+    return null;
+  }
+
+  // Safe raster data URIs (PNG, JPEG, WebP only — SVG rejected for XSS risk)
+  if (candidate.startsWith('data:')) {
+    if (candidate.length > MAX_DATA_URI_LENGTH) return null;
+    return DATA_IMAGE_PATTERN.test(candidate) ? candidate : null;
+  }
+
+  if (candidate.startsWith('blob:')) {
+    return candidate;
+  }
+
+  // … rest of function unchanged
+```
+
+The full updated file should look like this (replace the entire file contents):
+
+```ts
+const CONTROL_CHARS_PATTERN = /[\u0000-\u001F\u007F]/;
+const DATA_IMAGE_PATTERN = /^data:image\/(png|jpeg|webp);base64,[A-Za-z0-9+/]+=*$/;
+const MAX_DATA_URI_LENGTH = 400_000;
+
+function isSafeRelativePath(value: string): boolean {
+  if (!value.startsWith('/')) {
+    return false;
+  }
+
+  if (value.startsWith('//') || value.startsWith('/\\')) {
+    return false;
+  }
+
+  return !CONTROL_CHARS_PATTERN.test(value);
+}
+
+export function sanitizeImageSrc(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const candidate = value.trim();
+  if (!candidate || CONTROL_CHARS_PATTERN.test(candidate)) {
+    return null;
+  }
+
+  if (candidate.startsWith('data:')) {
+    if (candidate.length > MAX_DATA_URI_LENGTH) return null;
+    return DATA_IMAGE_PATTERN.test(candidate) ? candidate : null;
+  }
+
+  if (candidate.startsWith('blob:')) {
+    return candidate;
+  }
+
+  if (isSafeRelativePath(candidate)) {
+    return candidate;
+  }
+
+  try {
+    const parsed = new URL(candidate);
+    const protocol = parsed.protocol.toLowerCase();
+
+    if (protocol === 'https:' || protocol === 'http:') {
+      return parsed.toString();
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function isSafeImageSrc(value: string | null | undefined): boolean {
+  return sanitizeImageSrc(value) !== null;
+}
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `pnpm --filter=@breeze/web test safeImageSrc -- --run`
+Expected: PASS — all existing tests plus the 7 new data URI cases are green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/safeImageSrc.ts apps/web/src/lib/safeImageSrc.test.ts
+git commit -m "feat(web): allow safe raster data URIs in sanitizeImageSrc"
+```
+
+---
+
+## Task 2: Add server-side size cap to `logoUrl`
+
+**Files:**
+- Modify: `apps/api/src/routes/orgs.ts:359`
+
+- [ ] **Step 1: Update the Zod schema**
+
+In `apps/api/src/routes/orgs.ts`, find line 359 (inside `updatePartnerSettingsSchema`):
+
+```ts
+    logoUrl: z.string().optional(),
+```
+
+Replace with:
+
+```ts
+    logoUrl: z.string().max(400_000, 'Logo data exceeds maximum size (400 KB)').optional(),
+```
+
+- [ ] **Step 2: Type-check the API**
+
+Run: `pnpm --filter=@breeze/api exec tsc --noEmit`
+Expected: PASS — no new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/routes/orgs.ts
+git commit -m "feat(api): enforce 400 KB size cap on partner branding logoUrl"
+```
+
+---
+
+## Task 3: Upload UI in `PartnerBrandingTab`
+
+**Files:**
+- Modify: `apps/web/src/components/settings/PartnerBrandingTab.tsx`
+
+Replaces the plain URL `<input>` with a file-picker that resizes the image client-side to fit 256×256, encodes it as a PNG data URI, and stores it in `data.logoUrl`. A URL text input is still shown as a fallback when no file has been uploaded (i.e. `logoUrl` is empty or an HTTPS URL).
+
+- [ ] **Step 1: Add imports**
+
+At the top of `apps/web/src/components/settings/PartnerBrandingTab.tsx`, replace:
+
+```ts
+import type { InheritableBrandingSettings } from '@breeze/shared';
+```
+
+with:
+
+```ts
+import { useState } from 'react';
+import type { InheritableBrandingSettings } from '@breeze/shared';
+import { sanitizeImageSrc } from '../../lib/safeImageSrc';
+```
+
+- [ ] **Step 2: Add the resize helper and constants above the component**
+
+After the imports, before `const PLACEHOLDER = …`, insert:
+
+```ts
+const MAX_LOGO_BYTES = 300_000; // 300 KB raw file; base64 will be ≤400 KB
+const LOGO_ACCEPT = 'image/png,image/jpeg,image/webp';
+
+/** Resize `file` to fit within 256×256 and return a PNG data URI. */
+function resizeToDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const objectUrl = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(objectUrl);
+      const MAX = 256;
+      let { width, height } = img;
+      if (width > MAX || height > MAX) {
+        const ratio = Math.min(MAX / width, MAX / height);
+        width = Math.round(width * ratio);
+        height = Math.round(height * ratio);
+      }
+      const canvas = document.createElement('canvas');
+      canvas.width = width;
+      canvas.height = height;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) { reject(new Error('Canvas unavailable')); return; }
+      ctx.drawImage(img, 0, 0, width, height);
+      resolve(canvas.toDataURL('image/png'));
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(objectUrl);
+      reject(new Error('Invalid image file'));
+    };
+    img.src = objectUrl;
+  });
+}
+```
+
+- [ ] **Step 3: Add local error state to the component**
+
+Inside `PartnerBrandingTab`, immediately after the `const set = …` line, add:
+
+```ts
+  const [logoError, setLogoError] = useState<string | null>(null);
+```
+
+- [ ] **Step 4: Add the upload handler**
+
+Immediately after the `logoError` state line, add:
+
+```ts
+  const handleLogoFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    setLogoError(null);
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (file.size > MAX_LOGO_BYTES) {
+      setLogoError(`File too large (${Math.round(file.size / 1024)} KB). Maximum is 300 KB.`);
+      e.target.value = '';
+      return;
+    }
+    try {
+      const dataUrl = await resizeToDataUrl(file);
+      set({ logoUrl: dataUrl });
+    } catch {
+      setLogoError('Could not read image. Please try a different file.');
+      e.target.value = '';
+    }
+  };
+```
+
+- [ ] **Step 5: Replace the logo URL JSX**
+
+Find the existing Logo URL section in the JSX:
+
+```tsx
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Logo URL</label>
+          <input
+            type="url"
+            value={data.logoUrl ?? ''}
+            onChange={e => set({ logoUrl: e.target.value || undefined })}
+            placeholder={PLACEHOLDER}
+            className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+          />
+        </div>
+```
+
+Replace it with:
+
+```tsx
+        <div className="space-y-2 col-span-full">
+          <label className="text-sm font-medium">Logo</label>
+          <div className="rounded-lg border bg-muted/40 p-4 space-y-3">
+            <div className="flex items-center gap-4">
+              <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-lg border bg-background overflow-hidden">
+                {sanitizeImageSrc(data.logoUrl) ? (
+                  <img
+                    src={sanitizeImageSrc(data.logoUrl)!}
+                    alt="Logo preview"
+                    className="h-full w-full object-contain"
+                  />
+                ) : (
+                  <span className="text-xs text-muted-foreground text-center px-1">No logo</span>
+                )}
+              </div>
+              <div className="flex flex-col gap-2">
+                <label className="inline-flex cursor-pointer items-center gap-2 rounded-md border bg-background px-3 py-1.5 text-sm font-medium transition hover:bg-muted">
+                  <input
+                    type="file"
+                    accept={LOGO_ACCEPT}
+                    className="hidden"
+                    onChange={handleLogoFile}
+                  />
+                  Upload image
+                </label>
+                {data.logoUrl && (
+                  <button
+                    type="button"
+                    onClick={() => { set({ logoUrl: undefined }); setLogoError(null); }}
+                    className="text-xs text-destructive hover:underline text-left"
+                  >
+                    Remove
+                  </button>
+                )}
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              PNG, JPEG, or WebP · max 300 KB · resized to fit 256×256
+            </p>
+            {logoError && (
+              <p className="text-xs text-destructive">{logoError}</p>
+            )}
+            {/* URL fallback — only shown when no uploaded data URI is set */}
+            {!data.logoUrl?.startsWith('data:') && (
+              <div className="space-y-1">
+                <label className="text-xs text-muted-foreground">Or paste an image URL</label>
+                <input
+                  type="url"
+                  value={data.logoUrl ?? ''}
+                  onChange={e => set({ logoUrl: e.target.value || undefined })}
+                  placeholder={PLACEHOLDER}
+                  className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+                />
+              </div>
+            )}
+          </div>
+        </div>
+```
+
+- [ ] **Step 6: Type-check**
+
+Run: `pnpm --filter=@breeze/web exec tsc --noEmit`
+Expected: PASS — no new errors.
+
+- [ ] **Step 7: Visual smoke test (manual)**
+
+1. Open `/settings/partner` → Branding tab.
+2. Click **Upload image** and select a PNG > 300 KB. Expect error message "File too large".
+3. Select a PNG < 300 KB. Expect a preview to appear in the 56×56 box; "Or paste an image URL" input disappears.
+4. Click **Remove**. Preview clears; URL input reappears.
+5. Paste `https://placehold.co/64x64/png?text=A` in the URL input. Preview shows the placeholder.
+6. Click **Save Settings**. Reload; branding should persist.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/components/settings/PartnerBrandingTab.tsx
+git commit -m "feat(web): add logo upload UI to PartnerBrandingTab (base64 via canvas resize)"
+```
+
+---
+
+## Task 4: Create `BrandHeader` component (TDD)
+
+**Files:**
+- Create: `apps/web/src/components/layout/BrandHeader.tsx`
+- Create: `apps/web/src/components/layout/BrandHeader.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/web/src/components/layout/BrandHeader.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import BrandHeader from './BrandHeader';
+
+const PNG_DATA_URI = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+describe('BrandHeader', () => {
+  it('renders the Breeze SVG fallback when logoUrl is null', () => {
+    const { container } = render(<BrandHeader logoUrl={null} name={null} showLabel />);
+    expect(container.querySelector('svg')).not.toBeNull();
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('renders "Breeze" when name is null and showLabel is true', () => {
+    render(<BrandHeader logoUrl={null} name={null} showLabel />);
+    expect(screen.getByText('Breeze')).toBeInTheDocument();
+  });
+
+  it('renders the partner name when provided and showLabel is true', () => {
+    render(<BrandHeader logoUrl={null} name="Acme MSP" showLabel />);
+    expect(screen.getByText('Acme MSP')).toBeInTheDocument();
+    expect(screen.queryByText('Breeze')).not.toBeInTheDocument();
+  });
+
+  it('hides the label when showLabel is false', () => {
+    render(<BrandHeader logoUrl={null} name="Acme MSP" showLabel={false} />);
+    expect(screen.queryByText('Acme MSP')).not.toBeInTheDocument();
+  });
+
+  it('renders an <img> for a valid HTTPS URL', () => {
+    render(<BrandHeader logoUrl="https://cdn.example.com/logo.png" name="Acme MSP" showLabel />);
+    const img = screen.getByRole('img', { name: /acme msp logo/i }) as HTMLImageElement;
+    expect(img.src).toBe('https://cdn.example.com/logo.png');
+  });
+
+  it('renders an <img> for a valid PNG data URI', () => {
+    render(<BrandHeader logoUrl={PNG_DATA_URI} name="Acme MSP" showLabel />);
+    expect(screen.getByRole('img', { name: /acme msp logo/i })).toBeInTheDocument();
+  });
+
+  it('falls back to the SVG for an unsafe URL', () => {
+    const { container } = render(
+      <BrandHeader logoUrl="javascript:alert(1)" name="Acme MSP" showLabel />
+    );
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('falls back to the SVG for an SVG data URI', () => {
+    const { container } = render(
+      <BrandHeader logoUrl="data:image/svg+xml;base64,PHN2Zy8+" name="Acme MSP" showLabel />
+    );
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pnpm --filter=@breeze/web test BrandHeader -- --run`
+Expected: FAIL — `Cannot find module './BrandHeader'`.
+
+- [ ] **Step 3: Implement the component**
+
+Create `apps/web/src/components/layout/BrandHeader.tsx`:
+
+```tsx
+import { sanitizeImageSrc } from '../../lib/safeImageSrc';
+
+interface BrandHeaderProps {
+  /** Partner logo. Sanitized before render; falls back to the Breeze SVG when null/unsafe. */
+  logoUrl: string | null | undefined;
+  /** Partner name. Falls back to "Breeze" when null/empty. */
+  name: string | null | undefined;
+  /** Whether to render the text label (hidden in collapsed sidebar mode). */
+  showLabel: boolean;
+}
+
+const BREEZE_SVG = (
+  <svg width="14" height="14" viewBox="0 0 64 64" fill="none" className="text-primary">
+    <path
+      d="M12 22C12 22 20 22 28 22C36 22 40 16 48 16C52 16 54 18 54 20C54 22 52 24 48 24C44 24 42 22 42 22"
+      stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"
+    />
+    <path
+      d="M8 34C8 34 18 34 30 34C42 34 46 28 52 28C55 28 57 30 57 32C57 34 55 36 52 36C48 36 46 34 46 34"
+      stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"
+    />
+    <path
+      d="M14 46C14 46 22 46 32 46C40 46 44 40 50 40C53 40 55 42 55 44C55 46 53 48 50 48C46 48 44 46 44 46"
+      stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default function BrandHeader({ logoUrl, name, showLabel }: BrandHeaderProps) {
+  const safeLogoUrl = sanitizeImageSrc(logoUrl);
+  const label = name?.trim() || 'Breeze';
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex h-[22px] w-[22px] shrink-0 items-center justify-center overflow-hidden rounded-[6px] bg-primary/15">
+        {safeLogoUrl ? (
+          <img src={safeLogoUrl} alt={`${label} logo`} className="h-full w-full object-contain" />
+        ) : (
+          BREEZE_SVG
+        )}
+      </div>
+      {showLabel && (
+        <span className="text-lg font-bold tracking-tight text-foreground truncate">{label}</span>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `pnpm --filter=@breeze/web test BrandHeader -- --run`
+Expected: PASS — all 8 tests green.
+
+- [ ] **Step 5: Type-check**
+
+Run: `pnpm --filter=@breeze/web exec tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/layout/BrandHeader.tsx apps/web/src/components/layout/BrandHeader.test.tsx
+git commit -m "feat(web): add BrandHeader component for partner-branded sidebar logo"
+```
+
+---
+
+## Task 5: Wire `BrandHeader` into `Sidebar`
+
+**Files:**
+- Modify: `apps/web/src/components/layout/Sidebar.tsx`
+
+- [ ] **Step 1: Add the `BrandHeader` import**
+
+In `Sidebar.tsx`, add after the `import { WEB_VERSION } from '../../lib/version';` line (line 43):
+
+```tsx
+import BrandHeader from './BrandHeader';
+```
+
+- [ ] **Step 2: Add partner-branding state**
+
+Find the `// Fetch API version once` comment (~line 232) and insert the two state declarations immediately above it:
+
+```tsx
+  const [brandName, setBrandName] = useState<string | null>(null);
+  const [brandLogoUrl, setBrandLogoUrl] = useState<string | null>(null);
+```
+
+- [ ] **Step 3: Add the partner-branding fetch effect**
+
+Immediately after the existing `useEffect` that fetches `/system/version` (its closing `}, []);`), add:
+
+```tsx
+  // Fetch partner branding for the top-left header. Silently falls back on 403/404 (system-scoped users).
+  useEffect(() => {
+    let cancelled = false;
+    fetchWithAuth('/orgs/partners/me')
+      .then((r) => {
+        if (!r.ok) return null;
+        return r.json() as Promise<{ name?: string; settings?: { branding?: { logoUrl?: string } } }>;
+      })
+      .then((data) => {
+        if (cancelled || !data) return;
+        setBrandName(data.name ?? null);
+        setBrandLogoUrl(data.settings?.branding?.logoUrl ?? null);
+      })
+      .catch((err) => {
+        console.warn('[Sidebar] Failed to fetch partner branding:', err);
+      });
+    return () => { cancelled = true; };
+  }, []);
+```
+
+- [ ] **Step 4: Replace the desktop sidebar brand block**
+
+Find (lines 442–453):
+
+```tsx
+        <div className="flex items-center gap-2">
+          <div className="flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-[6px] bg-primary/15">
+            <svg width="14" height="14" viewBox="0 0 64 64" fill="none" className="text-primary">
+              <path d="M12 22C12 22 20 22 28 22C36 22 40 16 48 16C52 16 54 18 54 20C54 22 52 24 48 24C44 24 42 22 42 22" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+              <path d="M8 34C8 34 18 34 30 34C42 34 46 28 52 28C55 28 57 30 57 32C57 34 55 36 52 36C48 36 46 34 46 34" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+              <path d="M14 46C14 46 22 46 32 46C40 46 44 40 50 40C53 40 55 42 55 44C55 46 53 48 50 48C46 48 44 46 44 46" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </div>
+          {showLabels && (
+            <span className="text-lg font-bold tracking-tight text-foreground">Breeze</span>
+          )}
+        </div>
+```
+
+Replace with:
+
+```tsx
+        <BrandHeader logoUrl={brandLogoUrl} name={brandName} showLabel={showLabels} />
+```
+
+- [ ] **Step 5: Replace the mobile overlay brand block**
+
+Find (lines 492–501):
+
+```tsx
+          <div className="flex items-center gap-2">
+            <div className="flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-[6px] bg-primary/15">
+              <svg width="14" height="14" viewBox="0 0 64 64" fill="none" className="text-primary">
+                <path d="M12 22C12 22 20 22 28 22C36 22 40 16 48 16C52 16 54 18 54 20C54 22 52 24 48 24C44 24 42 22 42 22" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+                <path d="M8 34C8 34 18 34 30 34C42 34 46 28 52 28C55 28 57 30 57 32C57 34 55 36 52 36C48 36 46 34 46 34" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+                <path d="M14 46C14 46 22 46 32 46C40 46 44 40 50 40C53 40 55 42 55 44C55 46 53 48 50 48C46 48 44 46 44 46" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </div>
+            <span className="text-lg font-bold tracking-tight text-foreground">Breeze</span>
+          </div>
+```
+
+Replace with:
+
+```tsx
+          <BrandHeader logoUrl={brandLogoUrl} name={brandName} showLabel />
+```
+
+- [ ] **Step 6: Type-check and test**
+
+Run both:
+```bash
+pnpm --filter=@breeze/web exec tsc --noEmit
+pnpm --filter=@breeze/web test -- --run
+```
+Expected: both PASS.
+
+- [ ] **Step 7: Visual smoke test (manual)**
+
+1. Start dev server.
+2. Log in as a partner-scoped user.
+3. Go to `/settings/partner` → Branding → upload a small PNG. Save.
+4. Hard-refresh any page. Top-left of the sidebar shows the partner logo + name instead of the Breeze SVG.
+5. Collapse the sidebar — label hides, logo box stays.
+6. Mobile overlay (< 768px) also shows the branded header.
+7. Log in as a system-scoped user — sidebar falls back silently to Breeze defaults.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/components/layout/Sidebar.tsx
+git commit -m "feat(web): render partner branding logo + name in sidebar header"
+```
+
+---
+
+## Notes / Decisions
+
+- **Storage:** Base64 data URI stored in the existing `partner.settings` JSONB column (`branding.logoUrl`). No new storage infrastructure needed. The ~33% base64 inflation is acceptable for a one-time sidebar fetch on each page load.
+- **Size cap:** 300 KB raw file → ≤400 KB base64 string. Enforced both client-side (before encoding) and server-side (Zod `.max(400_000)`).
+- **Formats accepted:** PNG, JPEG, WebP only. SVG is rejected in both the file picker (`accept=`) and `sanitizeImageSrc` (XSS risk from embedded scripts).
+- **Client-side resize:** Canvas scales the image to fit within 256×256 before encoding, keeping the stored payload small regardless of what the user uploads.
+- **Sanitization:** `sanitizeImageSrc` now allows safe raster data URIs and continues to block `javascript:`, `data:text/html`, `data:image/svg+xml`, and oversized values.
+- **URL fallback:** The URL text input stays visible in `PartnerBrandingTab` when no file has been uploaded — partners with CDN-hosted logos can still paste a URL.
+- **Auth scope:** `/orgs/partners/me` requires `requireScope('partner')`. System-scoped users get a 403, silently ignored by the `if (!r.ok) return null` guard in Sidebar.
+- **Caching:** Branding fetch happens once per Sidebar mount, mirroring the existing `apiVersion` pattern. No store changes — YAGNI.
+- **Out of scope:** primary/secondary color theming, custom CSS, favicon, portal branding, any other branding fields.

--- a/docs/superpowers/plans/2026-04-11-first-customers-triage-followups.md
+++ b/docs/superpowers/plans/2026-04-11-first-customers-triage-followups.md
@@ -47,6 +47,46 @@ what's in flight, and what still needs attention.
   (seed), `olivetech` (personal), `vix-it` (real abandoned prospect), `biglobe`
   (paying customer).
 
+- **`/billing/success` post-checkout page** in `breeze-billing` (PR #1, squash
+  `5f2ccab`). Replaced the inline tri-state banner on `/billing/` with a
+  dedicated route: hero + activation pill polling the subscription endpoint
+  for up to 30s, plan summary card with receipt download (retries the invoice
+  fetch 4× at 3s to work around Stripe's async PDF attachment), and a 3-card
+  "next steps" checklist deep-linking back to the main Breeze app
+  (`/settings/enrollment-keys`, `/settings/users`, `/`). Stripe checkout
+  `success_url` now points at `/billing/success?plan=<plan>`. Reviewed by
+  parallel agent pass (code quality + silent-failure hunt + comment audit);
+  fixes for poll race, `plan!` non-null assertion, receipt URL race, and
+  silent error swallowing all applied before merge.
+
+## Deploy gap (corrected 2026-04-12)
+
+The "Stripe `dahlia` shape migration" and webhook handler hardening above were
+marked **shipped** earlier in the session, but they were merged to
+`breeze-billing:main` only — the running prod containers on `breeze-us` and
+`breeze-eu` were never rebuilt. The container `recreate` after the US
+`STRIPE_WEBHOOK_SECRET` env-var change refreshed env but reused the existing
+`breeze-billing:local` image, which was still at commit `305de60` (pre-dahlia).
+
+**The dahlia fix was running in production for ~6 hours unfixed despite the
+"shipped" label.** Discovered during the `/billing/success` deploy and corrected
+in the same `git pull && docker compose build && up -d` cycle.
+
+**Lesson:** "merged to `breeze-billing:main`" ≠ "deployed". The billing service
+has no CI/CD — both droplets pull from a local git clone at `/opt/breeze-billing`
+and rebuild on demand via `docker compose build billing`. Future PRs to
+`breeze-billing` need an explicit deploy step on each droplet:
+
+```bash
+ssh root@<droplet> 'cd /opt/breeze-billing && git pull && \
+  cd /opt/breeze && docker compose build billing && docker compose up -d billing'
+```
+
+Both droplets are now at `5f2ccab` as of 2026-04-12 ~00:07 UTC. This deploy
+gap is also a candidate for the "Open — not yet scheduled" section: a CI/CD
+pipeline (or even a webhook-triggered pull-and-rebuild script) would prevent
+the next instance.
+
 ## In-flight
 
 - **Agent issue #387** — desktop helper reconnect storm on headless Windows Server.
@@ -114,10 +154,16 @@ not blocking merge. Worth picking up as a follow-up PR or during a refactor pass
   remote-browse code paths and whether any first-hour initialization could leave
   the file-listing handler in a bad state.
 
-- **`/billing/?result=success` landing page polish**. The tri-state banner is a
-  start, but the full page could be redesigned to be a proper post-purchase
-  experience: confirmation of plan, next-step CTA (enroll first device), receipt
-  download link, etc.
+- ~~**`/billing/?result=success` landing page polish**.~~ **Done** (`breeze-billing`
+  PR #1, squash `5f2ccab`). Replaced the inline tri-state banner on `/billing/`
+  with a dedicated `/billing/success` route. Hero with activation pill (polls
+  the subscription endpoint every 2s up to 30s waiting for the Stripe webhook),
+  plan summary card with receipt download (retries the invoice fetch 4× at 3s
+  to work around Stripe's async `invoice_pdf` attachment), and a 3-card "next
+  steps" checklist deep-linking back into the main Breeze app
+  (`/settings/enrollment-keys`, `/settings/users`, `/`). Stripe checkout
+  `success_url` now points at `/billing/success?plan=<plan>`. Deployed to US
+  and EU at 2026-04-12 ~00:07 UTC.
 
 ## Open — not yet scheduled (systemic / infrastructure)
 
@@ -152,6 +198,15 @@ not blocking merge. Worth picking up as a follow-up PR or during a refactor pass
   at the top level, etc.). Could be a simple Github Action. The 17-day silent
   failure window on the `dahlia` migration could have been caught on day 1 with
   this check.
+
+- **`breeze-billing` deploy automation**. Today the service has no CI/CD —
+  both droplets pull from a local git clone at `/opt/breeze-billing` and rebuild
+  on demand. This caused the dahlia fix to sit on `main` for ~6 hours unfixed
+  in prod (see "Deploy gap" above). Minimum viable: a GitHub Action that SSHes
+  to each droplet on push to `main` and runs `git pull && docker compose build
+  billing && docker compose up -d billing`. Better: GHCR-built images pulled
+  by the droplets. Either way, removing the manual step prevents the next
+  "merged ≠ deployed" incident.
 
 - **Agent log-storm protection**. The reconnect-loop bug shipped 1,500+ identical
   warnings in 24h from a single device. There should be a per-component,

--- a/docs/superpowers/plans/2026-04-11-session-handoff.md
+++ b/docs/superpowers/plans/2026-04-11-session-handoff.md
@@ -30,13 +30,31 @@ in a single transaction. Real partners preserved.
 
 ## Immediate next moves (user chooses, roughly priority-ordered)
 
-1. **`file_list` / `file_list_drives` command timeout investigation.** First
-   paying customer hit this on her Windows 11 workstation ~1h after enrollment.
-   Highest visibility per unit effort. Root cause unknown — could be product
-   bug, her network, or first-hour init state. Start by pulling the agent logs
-   around `2026-04-11 16:12:55 UTC` on her MSI device and seeing whether the
-   commands were received / handled / responded to. Full context in tracking
-   doc section 6.
+1. **`file_list` / `file_list_drives` command timeout investigation. — DONE.**
+   Investigated against EU prod logs. Root cause was **client-side DNS
+   flakiness** on the customer's Win11 box: her local resolver logged 9×
+   `dial tcp: lookup eu.2breeze.app: no such host` in the 37 min before her
+   click. No other EU device saw a single DNS failure in the same window;
+   `eu.2breeze.app` resolves fine via 1.1.1.1 / 8.8.8.8 / 9.9.9.9. The agent
+   was unreachable at the moment she clicked, the API still considered her
+   device `online` (offline threshold not yet crossed), so the commands were
+   queued and timed out (15 s / 30 s) with a misleading "device may be
+   offline" message.
+
+   The pre-existing `sessionbroker: auth missing SID on Windows` warnings
+   firing every 30 s on her device are real but **unrelated** — the file_list
+   handler is a trivial sync call that doesn't touch the broker, and #387's
+   SID retry fix was committed 4 hours **after** her timeout anyway (her
+   agent 0.62.11 doesn't have it).
+
+   Three secondary product issues filed as **issue #391**:
+   - File browser routes return generic "device may be offline" on any
+     failure — should distinguish timeout vs offline.
+   - `executeCommand` accepts commands for devices whose WS is actually dead
+     because `devices.status='online'` lags by the offline-threshold window.
+     Should pre-check live WS for interactive commands.
+   - `sendCommandToAgent` failure releases the claim and waits for the full
+     15–30 s timeout. Should retry 3× 500 ms before giving up.
 
 2. **Systemic test infrastructure** (tracking doc: "Open — not yet scheduled").
    Highest leverage for preventing the next class of bugs:
@@ -46,7 +64,11 @@ in a single transaction. Real partners preserved.
    - Agent log-storm protection (generalize `helperWarnLimiter` across all log sites)
    - Customer onboarding watcher (pending >24h → email operator)
 
-3. **Deferred PR #388 review suggestions.** Type-design polish. Low urgency,
+3. **Implement issue #391** (file browser timeout UX). Three changes scoped
+   in the issue body. Good "ship a real customer-facing improvement in one
+   PR" candidate.
+
+4. **Deferred PR #388 review suggestions.** Type-design polish. Low urgency,
    good for a quiet session. See the "Deferred" section in the tracker.
 
 The user's original session backlog (abandoned-cart recovery worker, region


### PR DESCRIPTION
## Summary

Pure-docs PR bundling several drafts:

### CLAUDE.md — RLS Tenancy Reference
Adds a comprehensive "Tenant Isolation / RLS (READ BEFORE ADDING TABLES)" section documenting:
- The unprivileged \`breeze_app\` role enforcement
- All five tenancy shapes (direct \`org_id\`, id-keyed \`organizations\`, partner-axis, dual-axis users, device-id scoped) with the contract test allowlists
- The DB context helpers (\`withDbAccessContext\` / \`withSystemDbAccessContext\` / \`runOutsideDbContext\`)
- Workflow for adding new tables
- Production rollout guidance

This is the reference doc agents need before touching schema or routes that interact with multi-tenant data.

### 04-09 feature plans (4 new)
- \`2026-04-09-connections-inventory-400.md\` — connections inventory page returning HTTP 400
- \`2026-04-09-linux-agent-autostart.md\` — Linux agent systemd autostart
- \`2026-04-09-macos-helper-not-connected.md\` — macOS "Helper not connected" investigation
- \`2026-04-09-sidebar-partner-branding.md\` — partner-scoped sidebar branding

### 04-11 plan updates
- \`2026-04-11-first-customers-triage-followups.md\` — tracker updates reflecting completed buckets
- \`2026-04-11-session-handoff.md\` — handoff notes

## Test plan

- [x] Markdown only — no code or tests affected
- [ ] Markdown lint passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)