### PR TITLE
fix(api): escape request transaction before writing audit logs

### DIFF
--- a/apps/api/src/services/auditService.ts
+++ b/apps/api/src/services/auditService.ts
@@ -1,4 +1,4 @@
-import { db, withSystemDbAccessContext } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { auditLogs } from '../db/schema';
 import { captureException } from './sentry';
 
@@ -22,17 +22,30 @@ export interface CreateAuditLogParams {
 }
 
 export async function createAuditLog(params: CreateAuditLogParams): Promise<void> {
-  // Audit writes run under system scope because they are called from both
-  // authenticated handlers (where the request's org scope would match) AND
-  // pre-auth paths like failed-login tracking (where no scope is set yet,
-  // e.g. apps/api/src/routes/auth/login.ts:91 auditUserLoginFailure).
-  // Running in system scope keeps the audit path reliable regardless of
-  // caller context — the orgId in the row itself still identifies which
-  // tenant the event belongs to.
-  return withSystemDbAccessContext(async () => {
-    const { actorType = 'user', ...rest } = params;
-    await db.insert(auditLogs).values({ actorType, ...rest });
-  });
+  // Audit writes must run on a connection OUTSIDE the caller's request
+  // transaction. Two reasons:
+  //   1. System-scope semantics. Audits are written from both pre-auth paths
+  //      (no tx yet) and authenticated handlers where the caller's scope
+  //      can't insert rows with NULL or cross-org org_id under RLS. The
+  //      previous `withSystemDbAccessContext` call was a no-op when already
+  //      inside a tx (see `withDbAccessContext`'s short-circuit), leaving
+  //      the insert running under the caller's scope and failing the
+  //      `audit_logs` insert policy for partner-scope callers with a
+  //      NULL-org audit row.
+  //   2. Tx isolation. A failed audit insert inside the request tx aborts
+  //      the whole transaction in Postgres, silently rolling back the
+  //      caller's real work (e.g. password change) even though the route
+  //      returned 200 — because `createAuditLogAsync` swallows the error.
+  //
+  // `runOutsideDbContext` exits the AsyncLocalStorage so the nested
+  // `withSystemDbAccessContext` actually opens a fresh system-scope
+  // transaction on its own pooled connection.
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const { actorType = 'user', ...rest } = params;
+      await db.insert(auditLogs).values({ actorType, ...rest });
+    })
+  );
 }
 
 export function createAuditLogAsync(params: CreateAuditLogParams): void {


### PR DESCRIPTION
## Summary

\`createAuditLog\` wrapped its insert in \`withSystemDbAccessContext\`, but that call was a **no-op** when invoked from inside a request transaction (the AsyncLocalStorage scope-set short-circuits when a context already exists). The insert ran under the caller's scope, breaking two distinct things:

### 1. RLS

Partner-scope callers writing a NULL-org or cross-org audit row would fail the \`audit_logs\` insert policy, masking the real tenant of the event behind a generic policy denial.

### 2. Transaction abort (the worse one)

A failed audit insert inside the request tx **aborts the whole transaction** in Postgres, silently rolling back the caller's actual work (e.g. a password change committed by the route) even though the route returned 200 — because \`createAuditLogAsync\` swallows the error.

## Fix

Wrap the body in \`runOutsideDbContext\` so the nested \`withSystemDbAccessContext\` opens a fresh system-scope transaction on its own pooled connection. Audits now run independently of the caller's tx and scope. Matches the pattern already in \`commandQueue.ts\`.

## Test plan

- [ ] Existing audit log tests still pass
- [ ] Manual: trigger an audit-logged action from a partner-scope user, verify the audit row is written and the route's primary work is not silently rolled back

🤖 Generated with [Claude Code](https://claude.com/claude-code)