### PR TITLE
feat(infra): proxy /s/* short-link path to API

### DIFF
--- a/Caddyfile.dev
+++ b/Caddyfile.dev
@@ -5,7 +5,7 @@
 :80 {
 	encode zstd gzip
 
-	@api path /api/* /health /ready /metrics /metrics/*
+	@api path /api/* /s/* /health /ready /metrics /metrics/*
 	handle @api {
 		reverse_proxy host.docker.internal:3001
 	}

--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -75,6 +75,10 @@ export default defineConfig({
           changeOrigin: true,
           ws: true,
           rewrite: (path) => (path.startsWith('/api/v1') ? path : path.replace(/^\/api/, '/api/v1'))
+        },
+        '^/s/': {
+          target: process.env.API_URL || 'http://localhost:3001',
+          changeOrigin: true
         }
       }
     }

--- a/docker-compose.override.yml.dev
+++ b/docker-compose.override.yml.dev
@@ -19,7 +19,7 @@ services:
       }
       :80 {
         encode zstd gzip
-        @api path /api/* /health /ready /metrics/*
+        @api path /api/* /s/* /health /ready /metrics/*
         handle @api {
           reverse_proxy api:3001
         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       }
       $${BREEZE_DOMAIN} {
         encode zstd gzip
-        @api path /api/* /health /ready /metrics/*
+        @api path /api/* /s/* /health /ready /metrics/*
         handle @api {
           reverse_proxy api:3001
         }

--- a/docker/Caddyfile.prod
+++ b/docker/Caddyfile.prod
@@ -15,7 +15,7 @@
   }
 
   # Regular API routes (with compression)
-  @api path /api/* /health /ready /metrics/*
+  @api path /api/* /s/* /health /ready /metrics/*
   handle @api {
     encode zstd gzip
     reverse_proxy api:3001


### PR DESCRIPTION
## Summary

\`publicShortLinkRoutes\` is already mounted on \`/s\` in the API (\`apps/api/src/index.ts:343\`, defined in \`routes/enrollmentKeys.ts:915\` as \`GET /s/:code\`) — it's the public-facing short link that turns installer share codes into a redirect/download. But the reverse proxies in front of the API never knew about it: by default \`/s/*\` requests were hitting the web frontend (a 404 from Astro) instead of the API.

## Changes

Add \`/s/*\` to the \`@api\` match block in all four Caddy configs:
- \`Caddyfile.dev\`
- \`docker-compose.yml\`
- \`docker-compose.override.yml.dev\`
- \`docker/Caddyfile.prod\`

And add a matching proxy entry to \`apps/web/astro.config.mjs\` so dev \`pnpm dev\` also routes \`/s/*\` to the local API on :3001.

5-line diff across 5 files. No code changes — purely routing.

## Test plan

- [ ] Hit \`/s/<some-code>\` against a dev environment, confirm the request reaches the API and serves the redirect/download instead of returning a 404 from Astro
- [ ] Hit \`/s/<some-code>\` against a containerized environment to verify the docker Caddy configs route correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)