### PR TITLE
fix(agent): trim template-MSI space padding from enroll flag inputs

### DIFF
--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -508,6 +508,18 @@ func runAgent() {
 // structured logs to the agent log file so MSI-initiated enrollments leave
 // the same diagnostic trail as service-initiated ones.
 func enrollDevice(enrollmentKey string) {
+	// Trim whitespace from flag inputs. Template MSIs (served by the
+	// installerBuilder API) space-pad SERVER_URL / ENROLLMENT_KEY /
+	// ENROLLMENT_SECRET to a fixed 512-char width so the API can byte-
+	// patch them in-place without relocating other MSI structures. The
+	// padding survives all the way to our argv here, and url.Parse
+	// chokes on trailing spaces in a host name. The old PowerShell CA
+	// wrapper trimmed these before exec; the direct-exe CA does not,
+	// so the agent has to handle it.
+	enrollmentKey = strings.TrimSpace(enrollmentKey)
+	serverURL = strings.TrimSpace(serverURL)
+	enrollmentSecret = strings.TrimSpace(enrollmentSecret)
+
 	cfg, err := config.Load(cfgFile)
 	if err != nil {
 		cfg = config.Default()


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced by #410 that breaks enrollment from API-served template MSIs.

## Repro

Download any MSI from the Add Device flow on v0.62.21, install it. Enrollment fails with:

```
level=ERROR msg="enrollment request failed" error="failed to create request: parse \"https://us.2breeze.app                                                                    [512 chars of spaces]                    /api/v1/agents/enroll\": invalid character \" \" in host name" server="https://us.2breeze.app                                                                    [spaces]"
```

## Root cause

The template MSI built by `release.yml` uses 512-char space-padded sentinels for `SERVER_URL`, `ENROLLMENT_KEY`, and `ENROLLMENT_SECRET` so the installerBuilder API can byte-patch them in place without relocating other MSI structures (see `agent/installer/build-msi.ps1` `-Template` mode). After the API patches in real values, the padding stays — the replacement is `<real value>` + enough trailing spaces to fill the 512-byte slot.

The old PowerShell enrollment custom action (`enroll-agent.ps1`) trimmed these before exec:

```powershell
$serverUrl = $serverUrl.Trim()
$enrollmentKey = $enrollmentKey.Trim()
$enrollmentSecret = $enrollmentSecret.Trim()
```

#410 replaced that PS wrapper with a direct type-18 WiX custom action that calls `breeze-agent.exe enroll` with the properties substituted into `ExeCommand`. The properties reach argv with the padding intact, `url.Parse` chokes on trailing spaces in the host name, enrollment dies. The cascade from issue #411 then rolls back the whole install.

My smoke test during #410 used `msiexec /i ... SERVER_URL=... ENROLLMENT_KEY=...` (command-line properties, no space padding), so the padded-input code path was never exercised.

## Fix

`strings.TrimSpace` on the three flag values at the top of `enrollDevice`. Four functional lines plus a comment block explaining the why.

## Verified

Reproduced + fixed end-to-end on a Windows Server 2022 VM:

- **Before fix:** `breeze-agent.exe enroll "<key><spaces>" --server "https://2breeze.app<spaces>" --enrollment-secret "<secret><spaces>" --quiet` → `parse ... invalid character " " in host name`, exit 1.
- **After fix (same padded invocation):** agent.log shows `server=https://2breeze.app` (clean), HTTP request reaches the API, server returns normal enrollment response.

## Follow-ups

- **#412** (test-MSI CI workflow) would have caught this. Worth prioritizing so future installer PRs exercise the template-patch path automatically.
- The smoke test plan in #410 should be amended to always include a template-MSI round-trip, not just a plain `msiexec` install with command-line properties.

Refs #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)