### PR TITLE
test(agent): regression test for enrollment argument trimming

### DIFF
--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -507,18 +507,22 @@ func runAgent() {
 // --quiet (suppress stdout progress, errors still go to stderr). Writes
 // structured logs to the agent log file so MSI-initiated enrollments leave
 // the same diagnostic trail as service-initiated ones.
+// trimEnrollInputs strips whitespace from the three enrollment argument
+// values the MSI passes on the command line. Template MSIs (served by the
+// installerBuilder API) space-pad SERVER_URL / ENROLLMENT_KEY /
+// ENROLLMENT_SECRET to a fixed 512-char width so the API can byte-patch
+// them in-place without relocating any other MSI structures. The padding
+// survives argv all the way to this function, and url.Parse rejects
+// trailing spaces in a host name — the old PowerShell wrapper trimmed the
+// values before exec, and the direct-exe CA has to do the same here.
+func trimEnrollInputs(key, server, secret string) (string, string, string) {
+	return strings.TrimSpace(key), strings.TrimSpace(server), strings.TrimSpace(secret)
+}
+
 func enrollDevice(enrollmentKey string) {
-	// Trim whitespace from flag inputs. Template MSIs (served by the
-	// installerBuilder API) space-pad SERVER_URL / ENROLLMENT_KEY /
-	// ENROLLMENT_SECRET to a fixed 512-char width so the API can byte-
-	// patch them in-place without relocating other MSI structures. The
-	// padding survives all the way to our argv here, and url.Parse
-	// chokes on trailing spaces in a host name. The old PowerShell CA
-	// wrapper trimmed these before exec; the direct-exe CA does not,
-	// so the agent has to handle it.
-	enrollmentKey = strings.TrimSpace(enrollmentKey)
-	serverURL = strings.TrimSpace(serverURL)
-	enrollmentSecret = strings.TrimSpace(enrollmentSecret)
+	enrollmentKey, serverURL, enrollmentSecret = trimEnrollInputs(
+		enrollmentKey, serverURL, enrollmentSecret,
+	)
 
 	cfg, err := config.Load(cfgFile)
 	if err != nil {

--- a/agent/cmd/breeze-agent/main_test.go
+++ b/agent/cmd/breeze-agent/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -279,4 +280,115 @@ func TestHelperWarnLimiterResetConcurrent(t *testing.T) {
 	}()
 
 	wg.Wait()
+}
+
+// TestTrimEnrollInputs verifies that the template-MSI space-padded sentinel
+// format is stripped before the values reach url.Parse / HTTP request
+// construction. Regression test for the v0.62.22 → v0.62.23 hotfix where the
+// direct-exe enrollment CA introduced in #410 dropped the .Trim() calls that
+// the old enroll-agent.ps1 wrapper used to do. Without trimming, a byte-
+// patched template MSI would pass a 512-char right-padded server URL to the
+// agent and url.Parse would reject it with "invalid character \" \" in host
+// name".
+func TestTrimEnrollInputs(t *testing.T) {
+	t.Parallel()
+
+	// Mirrors the padding size used by installer/build-msi.ps1 when -Template
+	// is set. Keep in sync if that padding width changes.
+	const templatePadWidth = 512
+
+	pad := func(s string) string {
+		if len(s) >= templatePadWidth {
+			return s
+		}
+		return s + strings.Repeat(" ", templatePadWidth-len(s))
+	}
+
+	tests := []struct {
+		name                                   string
+		inKey, inServer, inSecret              string
+		wantKey, wantServer, wantSecret        string
+	}{
+		{
+			name:       "all clean",
+			inKey:      "brz_abc123",
+			inServer:   "https://app.example.com",
+			inSecret:   "secret456",
+			wantKey:    "brz_abc123",
+			wantServer: "https://app.example.com",
+			wantSecret: "secret456",
+		},
+		{
+			name:       "empty inputs",
+			inKey:      "",
+			inServer:   "",
+			inSecret:   "",
+			wantKey:    "",
+			wantServer: "",
+			wantSecret: "",
+		},
+		{
+			name:       "whitespace-only inputs collapse to empty",
+			inKey:      "   ",
+			inServer:   "\t\t",
+			inSecret:   " \r\n ",
+			wantKey:    "",
+			wantServer: "",
+			wantSecret: "",
+		},
+		{
+			name:       "trailing space only",
+			inKey:      "brz_abc123 ",
+			inServer:   "https://app.example.com   ",
+			inSecret:   "secret456\n",
+			wantKey:    "brz_abc123",
+			wantServer: "https://app.example.com",
+			wantSecret: "secret456",
+		},
+		{
+			name:       "leading whitespace only",
+			inKey:      "  brz_abc123",
+			inServer:   "\thttps://app.example.com",
+			inSecret:   " secret456",
+			wantKey:    "brz_abc123",
+			wantServer: "https://app.example.com",
+			wantSecret: "secret456",
+		},
+		{
+			name:       "template MSI 512-char space padding (the regression)",
+			inKey:      pad("enroll_b9297caef01ceb804a59af044f5f02aa08605178a06c1833"),
+			inServer:   pad("https://us.2breeze.app"),
+			inSecret:   pad("41d9a8a62f54c28e12b1055dec82173fd7e073c4c7f2314442da7abbc2c5e68d"),
+			wantKey:    "enroll_b9297caef01ceb804a59af044f5f02aa08605178a06c1833",
+			wantServer: "https://us.2breeze.app",
+			wantSecret: "41d9a8a62f54c28e12b1055dec82173fd7e073c4c7f2314442da7abbc2c5e68d",
+		},
+		{
+			name:       "optional secret left empty after padding trim",
+			inKey:      pad("brz_abc123"),
+			inServer:   pad("https://app.example.com"),
+			inSecret:   strings.Repeat(" ", templatePadWidth),
+			wantKey:    "brz_abc123",
+			wantServer: "https://app.example.com",
+			wantSecret: "",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotKey, gotServer, gotSecret := trimEnrollInputs(tc.inKey, tc.inServer, tc.inSecret)
+			if gotKey != tc.wantKey {
+				t.Errorf("key: got %q, want %q", gotKey, tc.wantKey)
+			}
+			if gotServer != tc.wantServer {
+				t.Errorf("server: got %q, want %q", gotServer, tc.wantServer)
+			}
+			if gotSecret != tc.wantSecret {
+				t.Errorf("secret: got %q, want %q", gotSecret, tc.wantSecret)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Adds the unit test that would have caught the v0.62.22 → v0.62.23 hotfix (#413) before it shipped.

## Changes

- **Extract `trimEnrollInputs(key, server, secret)` helper** out of the inline \`strings.TrimSpace\` calls in \`enrollDevice\`. Pure function, trivially testable, no side effects, no globals.
- **Add `TestTrimEnrollInputs`** in \`agent/cmd/breeze-agent/main_test.go\` — table-driven, 7 subtests, one of which exercises the exact 512-char space-padding pattern used by \`installer/build-msi.ps1 -Template\` mode.

## Why

The #410 regression (#413) escaped because:
1. No unit test for \`enrollDevice\` existed — the pr-test-analyzer agent flagged this pre-existing gap and I shipped without addressing it.
2. My smoke test used \`msiexec /i ... SERVER_URL=... ENROLLMENT_KEY=... /qn\` (clean command-line properties, no padding), so the padded-argv code path was never executed.
3. I ported behaviour from \`enroll-agent.ps1\` to Go by reading the script's summary, not line-by-line — and missed the three \`.Trim()\` calls.

This test closes (1). #412 (signed test-MSI CI workflow) will close (2). (3) is a process lesson that lives in my session memory.

## Test plan

- [x] \`go test -race -run TestTrimEnrollInputs ./cmd/breeze-agent/...\` — all 7 subtests pass
- [x] \`go test -race ./cmd/breeze-agent/...\` — full package test run passes
- [x] Cross-compile clean for windows/amd64, darwin/amd64, linux/amd64
- [x] \`go vet ./cmd/breeze-agent/...\` clean

Refs #410 #413 #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)