### PR TITLE
fix(installer): MSI enrollment failure reporting — fix 1603 cascade, surface cause (#411)

### DIFF
--- a/agent/cmd/breeze-agent/enroll_error.go
+++ b/agent/cmd/breeze-agent/enroll_error.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/config"
+	"github.com/breeze-rmm/agent/internal/eventlog"
+	"github.com/breeze-rmm/agent/pkg/api"
+)
+
+// enrollErrCategory classifies an enrollment failure for exit-code
+// stability and human-readable messaging. Exit codes are mapped to
+// 10..16 to keep each category distinguishable in msiexec install.log
+// without colliding with Go's default runtime-error exit code (2).
+type enrollErrCategory int
+
+const (
+	catNetwork   enrollErrCategory = iota // dial/DNS/TLS/timeout/conn refused
+	catAuth                               // 401, 403
+	catNotFound                           // 404
+	catRateLimit                          // 429
+	catServer                             // 5xx
+	catConfig                             // pre-flight validation or save failed
+	catUnknown                            // fallback — message comes from raw error
+)
+
+func (c enrollErrCategory) exitCode() int { return int(c) + 10 }
+
+// Package-level test seams. Production assigns them to the real
+// implementations in init(); tests override with t.Cleanup-guarded
+// stubs in enroll_error_test.go.
+var (
+	osExit             = os.Exit
+	writeLastErrorFile = defaultWriteLastErrorFile
+	eventLogError      = eventlog.Error
+	enrollLastErrorPath = defaultEnrollLastErrorPath
+)
+
+// defaultEnrollLastErrorPath returns the platform-specific path to the
+// single-line enrollment error marker. Windows: under ProgramData\Breeze\logs.
+// Unix: under LogDir().
+func defaultEnrollLastErrorPath() string {
+	return filepath.Join(config.LogDir(), "enroll-last-error.txt")
+}
+
+// defaultWriteLastErrorFile overwrites enroll-last-error.txt with a
+// single line containing the RFC3339 timestamp and the friendly message.
+// Silently ignores errors — this is a diagnostic aid, not a critical
+// path.
+func defaultWriteLastErrorFile(line string) {
+	path := enrollLastErrorPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	content := fmt.Sprintf("%s — %s\n", time.Now().Format(time.RFC3339), line)
+	_ = os.WriteFile(path, []byte(content), 0o644)
+}
+
+// clearEnrollLastError removes enroll-last-error.txt if present. Called
+// at the start of every enrollment attempt so a successful retry leaves
+// no residual error file. Errors from os.Remove are silently ignored
+// (the file may legitimately not exist, and cleanup bookkeeping must
+// not fail an enrollment attempt).
+func clearEnrollLastError() {
+	path := enrollLastErrorPath()
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		// Log at debug level only — not worth bothering admins. The scoped
+		// enrollLog is initialized by initEnrollLogging before this helper
+		// is called.
+		log.Debug("could not clear stale enroll-last-error file",
+			"path", path, "error", err.Error())
+	}
+}
+
+// enrollError writes a human-readable failure line to all four sinks
+// (stderr → msiexec install.log, agent.log via slog, enroll-last-error.txt,
+// Windows Event Log) and exits the process with a category-specific
+// code. Never returns in production; tests inject a panicking osExit
+// stub so assertion code after the call is reachable via defer+recover.
+func enrollError(cat enrollErrCategory, friendly string, detail error) {
+	line := fmt.Sprintf("Enrollment failed: %s", friendly)
+	if detail != nil {
+		line += fmt.Sprintf(" (%v)", detail)
+	}
+
+	// Sink 1: stderr → msiexec /l*v captures into install.log.
+	fmt.Fprintln(os.Stderr, line)
+
+	// Sink 2: agent.log via slog. The scoped enrollLog is initialized
+	// by initEnrollLogging in enrollDevice before any failure path
+	// can fire; fall back to the main log if called from an unexpected
+	// context.
+	log.Error("enrollment failed",
+		"category", cat,
+		"friendly", friendly,
+		"error", fmt.Sprint(detail))
+
+	// Sink 3: enroll-last-error.txt — single-line timestamped marker.
+	writeLastErrorFile(line)
+
+	// Sink 4: Windows Event Log (no-op on macOS/Linux).
+	eventLogError("BreezeAgent", line)
+
+	osExit(cat.exitCode())
+}
+
+// classifyEnrollError inspects an error returned by api.Client.Enroll
+// and maps it to the appropriate category + user-facing friendly
+// message. The serverURL is threaded through so friendly messages can
+// echo it back to the admin ("check that SERVER_URL is correct").
+func classifyEnrollError(err error, serverURL string) (enrollErrCategory, string) {
+	if err == nil {
+		return catUnknown, ""
+	}
+
+	var httpErr *api.ErrHTTPStatus
+	if errors.As(err, &httpErr) {
+		switch {
+		case httpErr.StatusCode == 401 || httpErr.StatusCode == 403:
+			return catAuth, "enrollment key not recognized — verify the key is active in Settings → Enrollment on the server"
+		case httpErr.StatusCode == 404:
+			return catNotFound, fmt.Sprintf(
+				"enrollment endpoint not found on %s — check that SERVER_URL is correct (did you include /api or point at the wrong host?)",
+				serverURL)
+		case httpErr.StatusCode == 429:
+			return catRateLimit, "rate limited by server — wait one minute and retry the install"
+		case httpErr.StatusCode >= 500:
+			return catServer, fmt.Sprintf(
+				"server error %d — contact Breeze support if this persists",
+				httpErr.StatusCode)
+		}
+	}
+
+	// Network-layer errors come through as *url.Error wrapping dial/DNS/TLS/timeout.
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return catNetwork, fmt.Sprintf(
+			"server unreachable at %s — check firewall, DNS, and that SERVER_URL is correct",
+			serverURL)
+	}
+
+	return catUnknown, err.Error()
+}

--- a/agent/cmd/breeze-agent/enroll_error_test.go
+++ b/agent/cmd/breeze-agent/enroll_error_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/breeze-rmm/agent/pkg/api"
+)
+
+func TestEnrollErrCategory_ExitCode(t *testing.T) {
+	if got, want := catNetwork.exitCode(), 10; got != want {
+		t.Errorf("catNetwork.exitCode() = %d, want %d", got, want)
+	}
+	if got, want := catUnknown.exitCode(), 16; got != want {
+		t.Errorf("catUnknown.exitCode() = %d, want %d", got, want)
+	}
+}
+
+func TestClassifyEnrollError_HTTPStatuses(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		wantCat enrollErrCategory
+	}{
+		{"401 unauthorized", 401, catAuth},
+		{"403 forbidden", 403, catAuth},
+		{"404 not found", 404, catNotFound},
+		{"429 rate limited", 429, catRateLimit},
+		{"500 internal error", 500, catServer},
+		{"503 service unavailable", 503, catServer},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &api.ErrHTTPStatus{StatusCode: tt.status, Body: "body"}
+			cat, friendly := classifyEnrollError(err, "https://example.com")
+			if cat != tt.wantCat {
+				t.Errorf("category = %v, want %v", cat, tt.wantCat)
+			}
+			if friendly == "" {
+				t.Error("friendly message should not be empty")
+			}
+		})
+	}
+}
+
+func TestClassifyEnrollError_NetworkError(t *testing.T) {
+	urlErr := &url.Error{Op: "Post", URL: "https://unreachable.example", Err: errors.New("dial tcp: connection refused")}
+	cat, friendly := classifyEnrollError(urlErr, "https://unreachable.example")
+	if cat != catNetwork {
+		t.Errorf("category = %v, want catNetwork", cat)
+	}
+	if !strings.Contains(friendly, "server unreachable") {
+		t.Errorf("friendly = %q, should contain 'server unreachable'", friendly)
+	}
+}
+
+func TestClassifyEnrollError_Unknown(t *testing.T) {
+	cat, friendly := classifyEnrollError(errors.New("something weird"), "https://example.com")
+	if cat != catUnknown {
+		t.Errorf("category = %v, want catUnknown", cat)
+	}
+	if friendly == "" {
+		t.Error("friendly should echo the raw error string")
+	}
+}
+
+func TestEnrollError_WritesAllFourSinks(t *testing.T) {
+	// Redirect stderr to a buffer for observation.
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = oldStderr })
+
+	// Capture last-error file writes.
+	var lastErrorCaptured string
+	origWrite := writeLastErrorFile
+	writeLastErrorFile = func(line string) { lastErrorCaptured = line }
+	t.Cleanup(func() { writeLastErrorFile = origWrite })
+
+	// Capture event-log writes.
+	var eventLogCaptured string
+	origEventLog := eventLogError
+	eventLogError = func(source, message string) { eventLogCaptured = message }
+	t.Cleanup(func() { eventLogError = origEventLog })
+
+	// Capture exit code.
+	var exitCapturedCode int
+	origExit := osExit
+	osExit = func(code int) {
+		exitCapturedCode = code
+		panic("test exit") // unwind the stack so enrollError's "never returns" is testable
+	}
+	t.Cleanup(func() { osExit = origExit })
+
+	defer func() {
+		recover() // swallow the test-exit panic
+		w.Close()
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		stderrOutput := buf.String()
+
+		if !strings.Contains(stderrOutput, "Enrollment failed:") {
+			t.Errorf("stderr = %q, should contain 'Enrollment failed:'", stderrOutput)
+		}
+		if !strings.Contains(lastErrorCaptured, "Enrollment failed:") {
+			t.Errorf("last error file = %q, should contain 'Enrollment failed:'", lastErrorCaptured)
+		}
+		if !strings.Contains(eventLogCaptured, "Enrollment failed:") {
+			t.Errorf("event log = %q, should contain 'Enrollment failed:'", eventLogCaptured)
+		}
+		if exitCapturedCode != catAuth.exitCode() {
+			t.Errorf("exit code = %d, want %d", exitCapturedCode, catAuth.exitCode())
+		}
+	}()
+
+	enrollError(catAuth, "enrollment key not recognized", errors.New("http 401"))
+}
+
+func TestClearEnrollLastError_RemovesStaleFile(t *testing.T) {
+	tmp := t.TempDir()
+	// Override the path helper so the test doesn't touch real ProgramData.
+	origPath := enrollLastErrorPath
+	enrollLastErrorPath = func() string { return filepath.Join(tmp, "enroll-last-error.txt") }
+	t.Cleanup(func() { enrollLastErrorPath = origPath })
+
+	// Create a stale file.
+	if err := os.WriteFile(enrollLastErrorPath(), []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	clearEnrollLastError()
+
+	if _, err := os.Stat(enrollLastErrorPath()); !os.IsNotExist(err) {
+		t.Errorf("stale file should have been removed, stat err = %v", err)
+	}
+}
+
+func TestClearEnrollLastError_NoFileIsNoError(t *testing.T) {
+	tmp := t.TempDir()
+	origPath := enrollLastErrorPath
+	enrollLastErrorPath = func() string { return filepath.Join(tmp, "never-existed.txt") }
+	t.Cleanup(func() { enrollLastErrorPath = origPath })
+
+	// Should not panic or log at error level.
+	clearEnrollLastError()
+}

--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -540,10 +540,17 @@ func enrollDevice(enrollmentKey string) {
 
 	enrollLog := logging.L("enroll")
 
+	// Clear any stale enroll-last-error.txt from a previous failed
+	// attempt BEFORE any validation or early return. Every attempt
+	// starts from a clean marker state; a validation failure later
+	// in this function must not leave a stale file behind (spec
+	// decision 8, issue #411).
+	clearEnrollLastError()
+
 	if cfg.ServerURL == "" {
-		enrollLog.Error("server URL required, use --server or set in config")
-		fmt.Fprintln(os.Stderr, "Server URL required. Use --server flag or set in config.")
-		os.Exit(1)
+		enrollError(catConfig,
+			"server URL required — pass --server or set it in config",
+			nil)
 	}
 
 	if cfg.AgentID != "" && !forceEnroll {
@@ -657,11 +664,8 @@ func enrollDevice(enrollmentKey string) {
 
 	enrollResp, err := client.Enroll(enrollReq)
 	if err != nil {
-		enrollLog.Error("enrollment request failed",
-			"error", err.Error(),
-			"server", cfg.ServerURL)
-		fmt.Fprintf(os.Stderr, "Enrollment failed: %v\n", err)
-		os.Exit(1)
+		cat, friendly := classifyEnrollError(err, cfg.ServerURL)
+		enrollError(cat, friendly, err)
 	}
 
 	cfg.AgentID = enrollResp.AgentID
@@ -690,13 +694,11 @@ func enrollDevice(enrollmentKey string) {
 	}
 
 	if err := config.SaveTo(cfg, cfgFile); err != nil {
-		enrollLog.Error("enrollment succeeded but failed to save config",
-			"error", err.Error(),
-			"agentId", cfg.AgentID)
-		fmt.Fprintf(os.Stderr, "Warning: Failed to save config: %v\n", err)
-		fmt.Fprintf(os.Stderr, "Agent ID: %s\n", cfg.AgentID)
-		fmt.Fprintln(os.Stderr, "You may need to manually save the configuration.")
-		os.Exit(1)
+		enrollError(catConfig,
+			fmt.Sprintf(
+				"enrollment succeeded but could not save config to %s — check that the directory exists and SYSTEM has write access (agentID=%s)",
+				cfgFile, cfg.AgentID),
+			err)
 	}
 
 	enrollLog.Info("enrollment successful",

--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -63,8 +63,8 @@ var waitForEnrollmentPollInterval = 10 * time.Second
 // is defined in service_seams_windows.go because its signature references
 // Windows-only types.
 var (
-	startAgentFn        func() (*agentComponents, error)             = startAgent
-	waitForEnrollmentFn func(context.Context, string) *config.Config = waitForEnrollment
+	startAgentFn        func(*config.Config) (*agentComponents, error) = startAgent
+	waitForEnrollmentFn func(context.Context, string) *config.Config   = waitForEnrollment
 )
 
 // initBootstrapLogging initializes the logging package with stderr +
@@ -307,17 +307,16 @@ func shutdownAgent(comps *agentComponents) {
 	}
 }
 
-// startAgent performs all agent initialisation and returns the running
-// components. It is used by both the console-mode runAgent and the Windows
-// SCM service wrapper so the startup logic lives in one place.
-func startAgent() (*agentComponents, error) {
-	cfg, err := config.Load(cfgFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load config: %w", err)
-	}
-
-	if cfg.AgentID == "" {
-		return nil, fmt.Errorf("agent not enrolled — run 'breeze-agent enroll <key>' first")
+// startAgent performs all agent initialisation assuming cfg is already
+// enrolled. Returns the running components or an error if any
+// initialization step fails (mTLS load, log shipper init, heartbeat
+// bring-up, etc.). Callers (runAgent on console/Unix, the Windows
+// service wrapper) MUST check config.IsEnrolled first and call
+// waitForEnrollment if needed — this function no longer performs the
+// enrollment check itself.
+func startAgent(cfg *config.Config) (*agentComponents, error) {
+	if !config.IsEnrolled(cfg) {
+		return nil, fmt.Errorf("startAgent called with unenrolled config — caller must waitForEnrollment first")
 	}
 
 	// Loosen config directory (0755) and agent.yaml (0644) so the Helper can read
@@ -540,17 +539,43 @@ func runAgent() {
 	healLaunchdPlistsIfNeeded()
 
 	// On Windows, if launched by the SCM, run under the service framework
-	// so we report Running/Stopped status back to the SCM correctly.
+	// so we report Running/Stopped status back to the SCM correctly. The
+	// service wrapper owns its own config loading, enrollment check, and
+	// cancellation via the SCM request channel.
 	if isWindowsService() {
-		if err := runAsService(startAgent); err != nil {
+		if err := runAsService(cfgFile); err != nil {
 			log.Error("service failed", "error", err.Error())
 			os.Exit(1)
 		}
 		return
 	}
 
-	// Console mode — start components and wait for OS signal.
-	comps, err := startAgent()
+	// Console / Unix service-manager mode. Load config, prepare bootstrap
+	// logging, and wait for enrollment if needed. signal.NotifyContext
+	// wires SIGINT/SIGTERM to ctx so Ctrl+C in a terminal and
+	// `systemctl stop` / `launchctl kickstart -k` all cancel any active
+	// wait cleanly.
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load config: %v\n", err)
+		os.Exit(1)
+	}
+	initBootstrapLogging(cfg)
+
+	ctx, stop := signal.NotifyContext(context.Background(),
+		os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if !config.IsEnrolled(cfg) {
+		cfg = waitForEnrollmentFn(ctx, cfgFile)
+		if cfg == nil {
+			log.Info("agent shutting down without enrollment",
+				"reason", ctx.Err().Error())
+			return
+		}
+	}
+
+	comps, err := startAgentFn(cfg)
 	if err != nil {
 		if isPermissionError(err) {
 			fmt.Fprintln(os.Stderr, "Error: Permission denied reading agent configuration.")
@@ -573,16 +598,13 @@ func runAgent() {
 	}
 	defer logging.StopShipper()
 
-	// Ignore SIGINT — as a daemon, PTY child processes can propagate
-	// SIGINT to our process group via Ctrl+C. Only SIGTERM should trigger shutdown.
-	signal.Ignore(syscall.SIGINT)
-
-	// Wait for shutdown signal
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGTERM)
-
-	<-sigChan
-	log.Info("shutting down agent")
+	// Wait for ctx to be cancelled — SIGINT or SIGTERM via
+	// signal.NotifyContext above. Behaviour change: console-mode
+	// breeze-agent now treats SIGINT as shutdown instead of ignoring
+	// it. The Windows service path is unaffected (SCM signals arrive
+	// via the request channel, not Unix signals).
+	<-ctx.Done()
+	log.Info("shutting down agent", "reason", ctx.Err().Error())
 
 	shutdownAgent(comps)
 	log.Info("agent stopped")

--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/breeze-rmm/agent/internal/audit"
 	"github.com/breeze-rmm/agent/internal/collectors"
 	"github.com/breeze-rmm/agent/internal/config"
+	"github.com/breeze-rmm/agent/internal/eventlog"
 	"github.com/breeze-rmm/agent/internal/heartbeat"
 	"github.com/breeze-rmm/agent/internal/ipc"
 	"github.com/breeze-rmm/agent/internal/logging"
@@ -47,6 +48,91 @@ var (
 )
 
 var log = logging.L("main")
+
+// waitForEnrollmentPollInterval is the interval between config reloads
+// in the wait-for-enrollment loop. Tests override this via t.Cleanup to
+// shrink the loop to milliseconds.
+var waitForEnrollmentPollInterval = 10 * time.Second
+
+// Package-level indirection for testability. Tests override these in
+// t.Cleanup-guarded setup to observe Execute and runAgent ordering
+// without running the real startup pipeline. Production callers MUST
+// use these vars, not the unexported symbols they wrap.
+//
+// startAgentFn and waitForEnrollmentFn are cross-platform; runServiceLoopFn
+// is defined in service_seams_windows.go because its signature references
+// Windows-only types.
+var (
+	startAgentFn        func() (*agentComponents, error)             = startAgent
+	waitForEnrollmentFn func(context.Context, string) *config.Config = waitForEnrollment
+)
+
+// initBootstrapLogging initializes the logging package with stderr +
+// the configured log file so waitForEnrollment can emit Warn/Info
+// lines before full startAgent runs. Does NOT start the log shipper,
+// heartbeat, or any network I/O — those are initialized later in
+// startAgent once enrollment is complete. Safe to call multiple times
+// (logging.Init is idempotent).
+func initBootstrapLogging(cfg *config.Config) {
+	logFile := cfg.LogFile
+	if logFile == "" {
+		logFile = filepath.Join(config.LogDir(), "agent.log")
+	}
+	// Best effort: if the log file can't be opened (permissions, missing
+	// dir), fall back to stderr only. Bootstrap logging must never fail
+	// the agent start.
+	if err := os.MkdirAll(filepath.Dir(logFile), 0o755); err != nil {
+		logging.Init(cfg.LogFormat, cfg.LogLevel, os.Stderr)
+		return
+	}
+	rw, err := logging.NewRotatingWriter(logFile, cfg.LogMaxSizeMB, cfg.LogMaxBackups)
+	if err != nil {
+		logging.Init(cfg.LogFormat, cfg.LogLevel, os.Stderr)
+		return
+	}
+	logging.Init(cfg.LogFormat, cfg.LogLevel, logging.TeeWriter(os.Stderr, rw))
+}
+
+// waitForEnrollment polls agent.yaml + secrets.yaml every
+// waitForEnrollmentPollInterval until config.IsEnrolled returns true,
+// then returns the enrolled config. Returns nil if ctx is cancelled
+// before enrollment completes.
+//
+// Intended for post-MSI-install scenarios where the service starts
+// before a later `breeze-agent enroll` call populates the config. The
+// ctx allows the caller to cancel the wait on shutdown (SIGINT/SIGTERM
+// via signal.NotifyContext in runAgent, or SCM Stop in the Windows
+// service wrapper).
+func waitForEnrollment(ctx context.Context, cfgFile string) *config.Config {
+	log.Warn("agent not enrolled — waiting for enrollment. "+
+		"Run 'breeze-agent enroll <key> --server <url>' to complete setup.",
+		"pollInterval", waitForEnrollmentPollInterval)
+	eventlog.Info("BreezeAgent",
+		"Waiting for enrollment. Run 'breeze-agent enroll <key> --server <url>'.")
+
+	ticker := time.NewTicker(waitForEnrollmentPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("waitForEnrollment cancelled", "reason", ctx.Err().Error())
+			return nil
+		case <-ticker.C:
+			cfg, err := config.Load(cfgFile)
+			if err != nil {
+				log.Debug("config reload failed while waiting for enrollment",
+					"error", err.Error())
+				continue
+			}
+			if config.IsEnrolled(cfg) {
+				log.Info("enrollment detected, continuing startup",
+					"agentId", cfg.AgentID)
+				return cfg
+			}
+		}
+	}
+}
 
 var rootCmd = &cobra.Command{
 	Use:   "breeze-agent",

--- a/agent/cmd/breeze-agent/main_test.go
+++ b/agent/cmd/breeze-agent/main_test.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/breeze-rmm/agent/internal/config"
 )
 
 // TestHelperWarnLimiterBudget verifies that the first `limit` calls with the
@@ -390,5 +395,137 @@ func TestTrimEnrollInputs(t *testing.T) {
 				t.Errorf("secret: got %q, want %q", gotSecret, tc.wantSecret)
 			}
 		})
+	}
+}
+
+// writeEnrolledConfig writes a minimal agent.yaml + secrets.yaml pair
+// that config.Load will parse into a config with both AgentID and
+// AuthToken set (IsEnrolled returns true).
+func writeEnrolledConfig(t *testing.T, dir string) string {
+	t.Helper()
+	agentPath := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(agentPath, []byte("agent_id: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\nserver_url: https://test.example\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	secretsPath := filepath.Join(dir, "secrets.yaml")
+	if err := os.WriteFile(secretsPath, []byte("auth_token: test-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return agentPath
+}
+
+// writeTornConfig writes only agent.yaml (with AgentID) but no secrets
+// file, simulating the race window where SaveTo has flushed agent.yaml
+// but not yet written secrets.yaml.
+func writeTornConfig(t *testing.T, dir string) string {
+	t.Helper()
+	agentPath := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(agentPath, []byte("agent_id: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\nserver_url: https://test.example\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return agentPath
+}
+
+func TestWaitForEnrollment_UnblocksWhenConfigBecomesValid(t *testing.T) {
+	origInterval := waitForEnrollmentPollInterval
+	waitForEnrollmentPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { waitForEnrollmentPollInterval = origInterval })
+
+	dir := t.TempDir()
+	agentPath := filepath.Join(dir, "agent.yaml")
+
+	// Start with no config file at all.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan *config.Config, 1)
+	go func() {
+		done <- waitForEnrollment(ctx, agentPath)
+	}()
+
+	// Write a valid enrolled config after 50ms.
+	time.Sleep(50 * time.Millisecond)
+	_ = writeEnrolledConfig(t, dir)
+
+	select {
+	case cfg := <-done:
+		if cfg == nil {
+			t.Fatal("waitForEnrollment returned nil; expected enrolled config")
+		}
+		if cfg.AgentID != "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" {
+			t.Errorf("AgentID = %q, want aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", cfg.AgentID)
+		}
+	case <-time.After(1500 * time.Millisecond):
+		t.Fatal("waitForEnrollment did not return within 1.5s")
+	}
+}
+
+func TestWaitForEnrollment_RespectsContextCancel(t *testing.T) {
+	origInterval := waitForEnrollmentPollInterval
+	waitForEnrollmentPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { waitForEnrollmentPollInterval = origInterval })
+
+	dir := t.TempDir()
+	agentPath := filepath.Join(dir, "does-not-exist.yaml")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan *config.Config, 1)
+	go func() {
+		done <- waitForEnrollment(ctx, agentPath)
+	}()
+
+	// Cancel after 30ms — waitForEnrollment should return nil within
+	// another 30ms (next ticker fire).
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+
+	select {
+	case cfg := <-done:
+		if cfg != nil {
+			t.Errorf("expected nil on ctx cancel, got %+v", cfg)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("waitForEnrollment did not return within 500ms of cancel")
+	}
+}
+
+func TestWaitForEnrollment_IgnoresTornWrite(t *testing.T) {
+	origInterval := waitForEnrollmentPollInterval
+	waitForEnrollmentPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { waitForEnrollmentPollInterval = origInterval })
+
+	dir := t.TempDir()
+	// Write only agent.yaml — no secrets file (torn SaveTo state).
+	agentPath := writeTornConfig(t, dir)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	done := make(chan *config.Config, 1)
+	go func() {
+		done <- waitForEnrollment(ctx, agentPath)
+	}()
+
+	// Verify it stays blocked for 100ms (IsEnrolled returns false on torn state).
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case cfg := <-done:
+		t.Fatalf("waitForEnrollment returned %+v on torn write; must stay blocked until secrets.yaml lands", cfg)
+	default:
+	}
+
+	// Now write secrets.yaml — waitForEnrollment should unblock on the next tick.
+	secretsPath := filepath.Join(dir, "secrets.yaml")
+	if err := os.WriteFile(secretsPath, []byte("auth_token: test-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case cfg := <-done:
+		if cfg == nil {
+			t.Fatal("expected enrolled config, got nil")
+		}
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("waitForEnrollment did not unblock after secrets.yaml was written")
 	}
 }

--- a/agent/cmd/breeze-agent/service_seams_windows.go
+++ b/agent/cmd/breeze-agent/service_seams_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package main
+
+import "golang.org/x/sys/windows/svc"
+
+// runServiceLoopFn is the package-level test seam for the post-startup
+// SCM control loop. Production assigns it to runServiceLoop (defined
+// in service_windows.go); tests in service_windows_test.go override
+// it to skip the real loop (which would dereference comps.hb and
+// comps.wsClient in shutdownAgent).
+var runServiceLoopFn func(
+	comps *agentComponents,
+	r <-chan svc.ChangeRequest,
+	changes chan<- svc.Status,
+) (bool, uint32) = runServiceLoop

--- a/agent/cmd/breeze-agent/service_unix.go
+++ b/agent/cmd/breeze-agent/service_unix.go
@@ -3,11 +3,14 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"os/signal"
 	"runtime"
 	"syscall"
 
+	"github.com/breeze-rmm/agent/internal/config"
 	"github.com/breeze-rmm/agent/internal/logging"
 )
 
@@ -83,21 +86,37 @@ func redirectStderr(f *os.File) {
 }
 
 // runAsService runs the agent as a system daemon on Unix (launchd / systemd).
-// Unlike Windows, there is no SCM handshake — just start components and block
-// on SIGTERM, same as console mode.
-func runAsService(start func() (*agentComponents, error)) error {
-	comps, err := start()
+// Unlike Windows, there is no SCM handshake. We load config, wait for
+// enrollment if needed, then start components and block on SIGTERM.
+// cfgFile is the path to the agent config file (same as the global cfgFile var).
+func runAsService(cfgFile string) error {
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+	initBootstrapLogging(cfg)
+
+	ctx, cancel := signal.NotifyContext(context.Background(),
+		os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	if !config.IsEnrolled(cfg) {
+		cfg = waitForEnrollmentFn(ctx, cfgFile)
+		if cfg == nil {
+			log.Info("agent shutting down without enrollment (service mode)",
+				"reason", ctx.Err().Error())
+			return nil
+		}
+	}
+
+	comps, err := startAgentFn(cfg)
 	if err != nil {
 		return err
 	}
 	defer logging.StopShipper()
 
-	signal.Ignore(syscall.SIGINT)
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGTERM)
-	<-sigChan
-
-	log.Info("shutting down agent (service mode)")
+	<-ctx.Done()
+	log.Info("shutting down agent (service mode)", "reason", ctx.Err().Error())
 	shutdownAgent(comps)
 	return nil
 }

--- a/agent/cmd/breeze-agent/service_windows.go
+++ b/agent/cmd/breeze-agent/service_windows.go
@@ -193,7 +193,13 @@ waitLoop:
 	}
 
 	if enrolledCfg == nil {
-		// ctx cancelled without enrollment; handled above.
+		// Defensive guard. In the current control flow this is
+		// unreachable — the Stop/Shutdown branch of waitLoop returns
+		// directly, so no break path exits waitLoop with a nil
+		// enrolledCfg. If a future change makes it reachable (e.g.
+		// switching to a deadline context), emit StopPending so the
+		// SCM sees a clean transition.
+		changes <- svc.Status{State: svc.StopPending}
 		return false, 0
 	}
 

--- a/agent/cmd/breeze-agent/service_windows.go
+++ b/agent/cmd/breeze-agent/service_windows.go
@@ -3,10 +3,10 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 	"syscall"
 	"time"
 	"unsafe"
@@ -92,75 +92,160 @@ func ensureSASPolicy() {
 
 // breezeService implements svc.Handler for the Windows SCM.
 type breezeService struct {
-	startFn  func() (*agentComponents, error)
-	stopOnce sync.Once
-	stopCh   chan struct{}
+	cfgFile string
 }
 
 // runAsService runs the agent under the Windows Service Control Manager.
-// startFn is called once the SCM has accepted the service start; it must
-// return the running components so they can be shut down on SCM stop.
-func runAsService(startFn func() (*agentComponents, error)) error {
+// It takes the cfgFile path instead of a startFn closure so Execute can
+// load config synchronously and decide whether to use the enrolled
+// (synchronous) or unenrolled (async-after-Running) start path.
+func runAsService(cfgFile string) error {
 	h := &breezeService{
-		startFn: startFn,
-		stopCh:  make(chan struct{}),
+		cfgFile: cfgFile,
 	}
 	return svc.Run("BreezeAgent", h)
 }
 
-// Execute is the SCM callback. It signals StartPending, runs startFn
-// synchronously, then signals Running and enters the SCM control loop.
-// SCM requires services to report Running via the changes channel within
-// its start timeout, so startFn itself must not block — any long-running
-// initialisation (e.g. hardware collection) must be backgrounded by the
-// caller before Execute is reached.
+// Execute is the SCM callback. It loads config synchronously, then
+// splits on config.IsEnrolled:
+//
+//   - Enrolled: run startAgent synchronously (preserves today's
+//     "post-enroll mTLS/heartbeat init failures fail the install"
+//     guarantee — Decision 6 from the spec).
+//   - Unenrolled: signal Running immediately (SCM start deadline
+//     would otherwise kill us while waitForEnrollment blocks), then
+//     wait for enrollment while staying responsive to Stop/Shutdown,
+//     then run startAgent. Failures here are post-install and stop
+//     the service but cannot roll back the MSI.
+//
+// Both branches converge on runServiceLoopFn for the steady-state SCM
+// control loop. runServiceLoopFn is a test seam — production assigns
+// it to runServiceLoop at package init.
 func (s *breezeService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
 	const accepted = svc.AcceptStop | svc.AcceptShutdown | svc.AcceptSessionChange
 
 	changes <- svc.Status{State: svc.StartPending}
 
-	comps, err := s.startFn()
+	cfg, err := config.Load(s.cfgFile)
 	if err != nil {
-		log.Error("agent start failed", "error", err.Error())
+		log.Error("failed to load config", "error", err.Error())
 		writeStartupFailureMarker(err)
 		changes <- svc.Status{State: svc.StopPending}
 		return true, 1
 	}
+	initBootstrapLogging(cfg)
 
-	scmCh := comps.hb.SCMSessionCh()
+	if config.IsEnrolled(cfg) {
+		// --- Synchronous enrolled path (today's behaviour) ---
+		// startAgentFn is a package-level test seam defaulting to
+		// startAgent. Any failure here (mTLS, heartbeat, log shipper,
+		// state file) reaches SCM as a start failure, which the MSI
+		// installer promotes to Error 1920 → 1603 rollback.
+		comps, err := startAgentFn(cfg)
+		if err != nil {
+			log.Error("agent start failed", "error", err.Error())
+			writeStartupFailureMarker(err)
+			changes <- svc.Status{State: svc.StopPending}
+			return true, 1
+		}
+		changes <- svc.Status{State: svc.Running, Accepts: accepted}
+		log.Info("agent running as Windows service")
+		return runServiceLoopFn(comps, r, changes)
+	}
 
+	// --- Async unenrolled path (MSI install with no creds) ---
+	// SCM MUST see Running before we block in waitForEnrollmentFn or
+	// the service start deadline (~30s) will kill the process.
 	changes <- svc.Status{State: svc.Running, Accepts: accepted}
-	log.Info("agent running as Windows service")
+	log.Info("agent running as Windows service (waiting for enrollment)")
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	enrolledCh := make(chan *config.Config, 1)
+	go func() {
+		enrolledCh <- waitForEnrollmentFn(ctx, s.cfgFile)
+	}()
+
+	// Stay responsive to SCM control requests while waiting. Drop
+	// session change events — we have no heartbeat wired up yet, and
+	// the session broker's reconciliation loop will catch up once
+	// startAgent completes.
+	var enrolledCfg *config.Config
+waitLoop:
 	for {
 		select {
+		case cfg := <-enrolledCh:
+			enrolledCfg = cfg
+			break waitLoop
 		case cr := <-r:
 			switch cr.Cmd {
 			case svc.Interrogate:
 				changes <- cr.CurrentStatus
 			case svc.Stop, svc.Shutdown:
-				log.Info("SCM requested stop")
+				log.Info("SCM stop while waiting for enrollment")
+				cancel()
 				changes <- svc.Status{State: svc.StopPending}
-				shutdownAgent(comps)
 				return false, 0
-			case svc.SessionChange:
-				if scmCh != nil {
-					sessionID := extractSessionID(cr.EventData)
-					select {
-					case scmCh <- sessionbroker.SCMSessionEvent{
-						EventType: cr.EventType,
-						SessionID: sessionID,
-					}:
-					default:
-						// Channel full — lifecycle manager will catch up
-						// on the next reconcile tick.
-					}
-				}
-			default:
-				log.Warn(fmt.Sprintf("unexpected SCM control request #%d", cr.Cmd))
 			}
+			// svc.SessionChange: ignore. No comps yet.
 		}
 	}
+
+	if enrolledCfg == nil {
+		// ctx cancelled without enrollment; handled above.
+		return false, 0
+	}
+
+	// Run the real startup pipeline. Failures here are post-install
+	// and cannot roll back the MSI — we log, write the failure marker,
+	// and stop the service.
+	comps, err := startAgentFn(enrolledCfg)
+	if err != nil {
+		log.Error("agent start failed after deferred enrollment",
+			"error", err.Error())
+		writeStartupFailureMarker(err)
+		changes <- svc.Status{State: svc.StopPending}
+		return true, 1
+	}
+	return runServiceLoopFn(comps, r, changes)
+}
+
+// runServiceLoop is the post-startup SCM control loop shared by both
+// Execute branches. It handles Interrogate, Stop, Shutdown, and
+// SessionChange requests, and calls shutdownAgent(comps) on stop.
+// Extracted from the old Execute body so the enrolled and unenrolled
+// paths can share it.
+func runServiceLoop(comps *agentComponents, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
+	scmCh := comps.hb.SCMSessionCh()
+
+	for cr := range r {
+		switch cr.Cmd {
+		case svc.Interrogate:
+			changes <- cr.CurrentStatus
+		case svc.Stop, svc.Shutdown:
+			log.Info("SCM requested stop")
+			changes <- svc.Status{State: svc.StopPending}
+			shutdownAgent(comps)
+			return false, 0
+		case svc.SessionChange:
+			if scmCh != nil {
+				sessionID := extractSessionID(cr.EventData)
+				select {
+				case scmCh <- sessionbroker.SCMSessionEvent{
+					EventType: cr.EventType,
+					SessionID: sessionID,
+				}:
+				default:
+					// Channel full — lifecycle manager will catch up
+					// on the next reconcile tick.
+				}
+			}
+		default:
+			log.Warn(fmt.Sprintf("unexpected SCM control request #%d", cr.Cmd))
+		}
+	}
+	return false, 0
 }
 
 // extractSessionID reads the session ID from the WTSSESSION_NOTIFICATION

--- a/agent/cmd/breeze-agent/service_windows_test.go
+++ b/agent/cmd/breeze-agent/service_windows_test.go
@@ -1,0 +1,235 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/config"
+	"golang.org/x/sys/windows/svc"
+)
+
+// installServiceStubs wires all three Execute test seams to stubs that
+// record call ordering into events. Returns a release() func that
+// unblocks any stub waiting on releaseCh (used by the unenrolled-path
+// tests). Registers t.Cleanup to restore originals.
+func installServiceStubs(t *testing.T) (events chan string, release func()) {
+	t.Helper()
+	origStart := startAgentFn
+	origWait := waitForEnrollmentFn
+	origLoop := runServiceLoopFn
+	t.Cleanup(func() {
+		startAgentFn = origStart
+		waitForEnrollmentFn = origWait
+		runServiceLoopFn = origLoop
+	})
+
+	events = make(chan string, 16)
+	releaseCh := make(chan struct{})
+	release = func() { close(releaseCh) }
+
+	startAgentFn = func(cfg *config.Config) (*agentComponents, error) {
+		events <- "startAgent"
+		return &agentComponents{}, nil // zero-value; runServiceLoopFn never dereferences
+	}
+	waitForEnrollmentFn = func(ctx context.Context, cfgFile string) *config.Config {
+		events <- "waitForEnrollment.enter"
+		select {
+		case <-releaseCh:
+			events <- "waitForEnrollment.release"
+			cfg, _ := config.Load(cfgFile)
+			return cfg
+		case <-ctx.Done():
+			events <- "waitForEnrollment.cancelled"
+			return nil
+		}
+	}
+	runServiceLoopFn = func(comps *agentComponents, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
+		events <- "runServiceLoop"
+		for cr := range r {
+			if cr.Cmd == svc.Stop || cr.Cmd == svc.Shutdown {
+				changes <- svc.Status{State: svc.StopPending}
+				return false, 0
+			}
+		}
+		return false, 0
+	}
+	return events, release
+}
+
+// writeEnrolledConfigFile writes agent.yaml + secrets.yaml that
+// config.Load + IsEnrolled will accept as enrolled. Returns the
+// agent.yaml path. Uses a valid UUID format that passes
+// config.ValidateTiered.
+func writeEnrolledConfigFile(t *testing.T, dir string) string {
+	t.Helper()
+	agentPath := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(agentPath, []byte("agent_id: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\nserver_url: https://test.example\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	secretsPath := filepath.Join(dir, "secrets.yaml")
+	if err := os.WriteFile(secretsPath, []byte("auth_token: test-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return agentPath
+}
+
+// writeUnenrolledConfigFile writes an empty agent.yaml (no AgentID,
+// no AuthToken) so config.Load succeeds but IsEnrolled returns false.
+func writeUnenrolledConfigFile(t *testing.T, dir string) string {
+	t.Helper()
+	agentPath := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(agentPath, []byte("server_url: https://test.example\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return agentPath
+}
+
+// runExecuteInGoroutine starts Execute in a goroutine with mock changes
+// and request channels. Returns channels the test can drive.
+func runExecuteInGoroutine(t *testing.T, s *breezeService) (changes chan svc.Status, requests chan svc.ChangeRequest, done chan struct{}) {
+	t.Helper()
+	changes = make(chan svc.Status, 16)
+	requests = make(chan svc.ChangeRequest, 4)
+	done = make(chan struct{})
+	go func() {
+		defer close(done)
+		s.Execute(nil, requests, changes)
+	}()
+	return
+}
+
+func TestExecute_EnrolledPath_SignalsRunningAfterStartFn(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := writeEnrolledConfigFile(t, dir)
+
+	events, _ := installServiceStubs(t)
+	s := &breezeService{cfgFile: cfgFile}
+
+	changes, requests, done := runExecuteInGoroutine(t, s)
+
+	// Expected event sequence on enrolled path:
+	// 1. startAgent (from stubbed startAgentFn)
+	// 2. runServiceLoop (from stubbed runServiceLoopFn)
+	if got := <-events; got != "startAgent" {
+		t.Errorf("first event = %q, want startAgent", got)
+	}
+	if got := <-events; got != "runServiceLoop" {
+		t.Errorf("second event = %q, want runServiceLoop", got)
+	}
+
+	// Drain changes. Expected: StartPending, Running. The Running signal
+	// MUST arrive after the stubbed startAgentFn observed its call.
+	first := <-changes
+	if first.State != svc.StartPending {
+		t.Errorf("first state = %v, want StartPending", first.State)
+	}
+	second := <-changes
+	if second.State != svc.Running {
+		t.Errorf("second state = %v, want Running", second.State)
+	}
+
+	// Tell Execute to stop so the goroutine terminates.
+	requests <- svc.ChangeRequest{Cmd: svc.Stop}
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Execute did not return within 1s of Stop")
+	}
+}
+
+func TestExecute_UnenrolledPath_SignalsRunningBeforeWait(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := writeUnenrolledConfigFile(t, dir)
+
+	events, release := installServiceStubs(t)
+	s := &breezeService{cfgFile: cfgFile}
+
+	changes, requests, done := runExecuteInGoroutine(t, s)
+
+	// Expected: StartPending, Running before any waitForEnrollment.enter.
+	first := <-changes
+	if first.State != svc.StartPending {
+		t.Errorf("first state = %v, want StartPending", first.State)
+	}
+	second := <-changes
+	if second.State != svc.Running {
+		t.Errorf("second state = %v, want Running", second.State)
+	}
+
+	// Now the stub should record that it entered waitForEnrollment.
+	if got := <-events; got != "waitForEnrollment.enter" {
+		t.Errorf("first event = %q, want waitForEnrollment.enter", got)
+	}
+
+	// Upgrade the on-disk config to enrolled, then release the stub
+	// so the post-wait branch runs startAgentFn.
+	_ = writeEnrolledConfigFile(t, dir)
+	release()
+
+	// Expected remaining event sequence: release, startAgent, runServiceLoop.
+	if got := <-events; got != "waitForEnrollment.release" {
+		t.Errorf("event after release = %q, want waitForEnrollment.release", got)
+	}
+	if got := <-events; got != "startAgent" {
+		t.Errorf("event = %q, want startAgent", got)
+	}
+	if got := <-events; got != "runServiceLoop" {
+		t.Errorf("event = %q, want runServiceLoop", got)
+	}
+
+	// Terminate.
+	requests <- svc.ChangeRequest{Cmd: svc.Stop}
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Execute did not return within 1s of Stop")
+	}
+}
+
+func TestExecute_StopWhileWaiting(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := writeUnenrolledConfigFile(t, dir)
+
+	events, _ := installServiceStubs(t)
+	s := &breezeService{cfgFile: cfgFile}
+
+	changes, requests, done := runExecuteInGoroutine(t, s)
+
+	// Drain StartPending + Running.
+	<-changes
+	<-changes
+
+	// Wait until the stub has entered waitForEnrollment.
+	if got := <-events; got != "waitForEnrollment.enter" {
+		t.Errorf("event = %q, want waitForEnrollment.enter", got)
+	}
+
+	// Stop without releasing the stub. The stub's ctx.Done() branch
+	// should fire and the unenrolled path should cleanly return.
+	requests <- svc.ChangeRequest{Cmd: svc.Stop}
+
+	if got := <-events; got != "waitForEnrollment.cancelled" {
+		t.Errorf("event = %q, want waitForEnrollment.cancelled", got)
+	}
+
+	// Expect a StopPending signal.
+	select {
+	case state := <-changes:
+		if state.State != svc.StopPending {
+			t.Errorf("state = %v, want StopPending", state.State)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("no StopPending signal within 1s")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Execute did not return within 1s of Stop")
+	}
+}

--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -191,23 +191,33 @@
       ExeCommand="enroll &quot;[ENROLLMENT_KEY]&quot; --server &quot;[SERVER_URL]&quot; --enrollment-secret &quot;[ENROLLMENT_SECRET]&quot; --quiet"
       Execute="deferred"
       Impersonate="no"
-      Return="ignore"
+      Return="check"
       HideTarget="yes" />
 
     <InstallExecuteSequence>
       <Custom Action="SetPowerShellPath" After="InstallInitialize" />
       <Custom Action="RollbackRegisterUserHelperTask" Before="RegisterUserHelperTask" Condition="NOT Installed AND NOT REMOVE AND NOT WIX_UPGRADE_DETECTED" />
       <Custom Action="RegisterUserHelperTask" After="InstallServices" Condition="NOT Installed AND NOT REMOVE" />
-      <!-- Run enrollment after file copy but before InstallServices so the
-           BreezeAgent service starts with a valid agent.yaml already in
-           place; no restart dance required.
+      <!-- Enrollment runs after file copy but before InstallServices.
 
-           Return="ignore" on the EnrollAgent CA means enrollment failure
-           does NOT roll back the install. If enrollment fails, the service
-           will still start but the device stays unenrolled. To debug:
-           check %ProgramData%\Breeze\logs\agent.log for the structured
-           error trail, or re-run breeze-agent.exe enroll manually from an
-           elevated shell with the enrollment key and server flags. -->
+           Return="check" on the EnrollAgent CA means a non-zero exit
+           from breeze-agent.exe enroll rolls back the install cleanly.
+           Admins see a specific cause in four places:
+
+             1. install.log (captured from the CA's stderr)
+             2. C:\ProgramData\Breeze\logs\agent.log (slog structured)
+             3. C:\ProgramData\Breeze\logs\enroll-last-error.txt
+                (single-line timestamped, survives rollback because
+                CA-written files are opaque to MSI)
+             4. Event Viewer, Application, BreezeAgent (Error)
+
+           Installs without ENROLLMENT_KEY skip this CA entirely
+           (condition below requires both SERVER_URL and ENROLLMENT_KEY).
+           The service starts anyway and idles in a wait-for-enrollment
+           loop (see waitForEnrollment in cmd/breeze-agent/main.go), so
+           a later "breeze-agent enroll KEY -server URL" is picked up
+           live without a service restart. This is the intended flow
+           for imaged/sysprep'd deployments. -->
       <Custom Action="EnrollAgent" Before="InstallServices" Condition="NOT Installed AND SERVER_URL AND ENROLLMENT_KEY" />
       <Custom Action="UnregisterUserHelperTask" Before="RemoveFiles" Condition="REMOVE=&quot;ALL&quot;" />
     </InstallExecuteSequence>

--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -215,9 +215,11 @@
            (condition below requires both SERVER_URL and ENROLLMENT_KEY).
            The service starts anyway and idles in a wait-for-enrollment
            loop (see waitForEnrollment in cmd/breeze-agent/main.go), so
-           a later "breeze-agent enroll KEY -server URL" is picked up
-           live without a service restart. This is the intended flow
-           for imaged/sysprep'd deployments. -->
+           a later manual enrollment (running breeze-agent.exe enroll
+           with the key and the server URL flag, same arguments used
+           by the CA above) is picked up live without a service
+           restart. This is the intended flow for imaged/sysprep'd
+           deployments. -->
       <Custom Action="EnrollAgent" Before="InstallServices" Condition="NOT Installed AND SERVER_URL AND ENROLLMENT_KEY" />
       <Custom Action="UnregisterUserHelperTask" Before="RemoveFiles" Condition="REMOVE=&quot;ALL&quot;" />
     </InstallExecuteSequence>

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -119,6 +119,17 @@ type Config struct {
 	IsHeadless bool `mapstructure:"-"`
 }
 
+// IsEnrolled reports whether cfg represents a complete enrollment — both
+// the AgentID (written to agent.yaml) and the AuthToken (written to
+// secrets.yaml). Callers that poll for enrollment readiness MUST use
+// this predicate rather than checking AgentID alone, because SaveTo
+// writes agent.yaml before secrets.yaml and a concurrent reader can
+// otherwise observe a torn write (AgentID set but AuthToken not yet
+// persisted). A torn read simply causes one more poll cycle.
+func IsEnrolled(cfg *Config) bool {
+	return cfg != nil && cfg.AgentID != "" && cfg.AuthToken != ""
+}
+
 // defaultLogFile returns the platform-specific default log file path.
 func defaultLogFile() string {
 	switch runtime.GOOS {

--- a/agent/internal/config/config_test.go
+++ b/agent/internal/config/config_test.go
@@ -1,0 +1,24 @@
+package config
+
+import "testing"
+
+func TestIsEnrolled(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+		want bool
+	}{
+		{"nil config", nil, false},
+		{"empty config", &Config{}, false},
+		{"agent id only (torn write)", &Config{AgentID: "abc"}, false},
+		{"auth token only (torn write)", &Config{AuthToken: "tok"}, false},
+		{"both present", &Config{AgentID: "abc", AuthToken: "tok"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsEnrolled(tt.cfg); got != tt.want {
+				t.Errorf("IsEnrolled(%+v) = %v, want %v", tt.cfg, got, tt.want)
+			}
+		})
+	}
+}

--- a/agent/internal/eventlog/eventlog.go
+++ b/agent/internal/eventlog/eventlog.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+// Package eventlog writes informational, warning, and error events to
+// the OS event log. On Windows this wraps the Application log; on
+// macOS and Linux the calls compile to no-ops so agent call sites can
+// stay cross-platform.
+package eventlog
+
+// Info writes an informational event to the OS event log (no-op on
+// non-Windows platforms). source is a short registered name like
+// "BreezeAgent".
+func Info(source, message string) {}
+
+// Warning writes a warning event.
+func Warning(source, message string) {}
+
+// Error writes an error event.
+func Error(source, message string) {}

--- a/agent/internal/eventlog/eventlog_test.go
+++ b/agent/internal/eventlog/eventlog_test.go
@@ -1,0 +1,34 @@
+package eventlog
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestNoPanicOnAllPlatforms(t *testing.T) {
+	// Calling any of these from a non-admin context on Windows, or
+	// anywhere on macOS/Linux, must not panic. Registration errors
+	// are silently swallowed per package contract.
+	Info("BreezeAgent", "test info message")
+	Warning("BreezeAgent", "test warning message")
+	Error("BreezeAgent", "test error message")
+}
+
+func TestConcurrentLogging(t *testing.T) {
+	// Verify concurrent calls from multiple goroutines don't panic
+	// or race. On non-Windows this exercises the no-op stubs; on
+	// Windows it exercises the sync.Mutex + per-source sync.Once
+	// guarding lazy registration in lookupOrRegister.
+	const numGoroutines = 50
+	var wg sync.WaitGroup
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			Info("BreezeAgent", "concurrent info")
+			Warning("BreezeAgent", "concurrent warning")
+			Error("BreezeAgent", "concurrent error")
+		}()
+	}
+	wg.Wait()
+}

--- a/agent/internal/eventlog/eventlog_windows.go
+++ b/agent/internal/eventlog/eventlog_windows.go
@@ -1,0 +1,83 @@
+//go:build windows
+
+// Package eventlog writes informational, warning, and error events to
+// the Windows Application Event Log. Registration is lazy: on first
+// use per source, we attempt InstallAsEventCreate, and if that fails
+// because the source already exists we fall back to Open. Both
+// failures are silently swallowed — the package's contract is that
+// logging is best-effort and never returns errors to callers.
+package eventlog
+
+import (
+	"sync"
+
+	"golang.org/x/sys/windows/svc/eventlog"
+)
+
+// Event IDs used by this package. Fixed values keep the Windows
+// Application log filterable by event ID in SIEM tools.
+const (
+	eventIDInfo    uint32 = 1001
+	eventIDWarning uint32 = 1002
+	eventIDError   uint32 = 1003
+)
+
+var (
+	registryMu sync.Mutex
+	registry   = map[string]*sourceEntry{}
+)
+
+type sourceEntry struct {
+	once sync.Once
+	log  *eventlog.Log // nil if registration failed
+}
+
+func lookupOrRegister(source string) *eventlog.Log {
+	registryMu.Lock()
+	entry, ok := registry[source]
+	if !ok {
+		entry = &sourceEntry{}
+		registry[source] = entry
+	}
+	registryMu.Unlock()
+
+	entry.once.Do(func() {
+		// Try to install the source with all three severities. Most
+		// Windows environments require admin to install a new event
+		// source; if the source already exists, Install returns an
+		// "already exists" error which we treat as benign.
+		_ = eventlog.InstallAsEventCreate(
+			source,
+			eventlog.Info|eventlog.Warning|eventlog.Error,
+		)
+		// Open returns a handle usable for Info/Warning/Error regardless
+		// of whether we just installed it or it already existed.
+		logHandle, openErr := eventlog.Open(source)
+		if openErr != nil {
+			return // entry.log stays nil; subsequent calls are no-ops
+		}
+		entry.log = logHandle
+	})
+	return entry.log
+}
+
+// Info writes an informational event to the Windows Application log.
+func Info(source, message string) {
+	if handle := lookupOrRegister(source); handle != nil {
+		_ = handle.Info(eventIDInfo, message)
+	}
+}
+
+// Warning writes a warning event.
+func Warning(source, message string) {
+	if handle := lookupOrRegister(source); handle != nil {
+		_ = handle.Warning(eventIDWarning, message)
+	}
+}
+
+// Error writes an error event.
+func Error(source, message string) {
+	if handle := lookupOrRegister(source); handle != nil {
+		_ = handle.Error(eventIDError, message)
+	}
+}

--- a/agent/pkg/api/client.go
+++ b/agent/pkg/api/client.go
@@ -10,6 +10,19 @@ import (
 	"time"
 )
 
+// ErrHTTPStatus is returned by the api client when an HTTP request
+// completes but the server returned a non-success status code. Callers
+// can type-assert via errors.As to classify the failure (auth, not
+// found, rate limit, server error).
+type ErrHTTPStatus struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *ErrHTTPStatus) Error() string {
+	return fmt.Sprintf("http %d: %s", e.StatusCode, e.Body)
+}
+
 type Client struct {
 	baseURL    string
 	authToken  string
@@ -124,7 +137,7 @@ func (c *Client) Enroll(req *EnrollRequest) (*EnrollResponse, error) {
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		bodyBytes, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("enrollment failed with status %d: %s", resp.StatusCode, string(bodyBytes))
+		return nil, &ErrHTTPStatus{StatusCode: resp.StatusCode, Body: string(bodyBytes)}
 	}
 
 	var enrollResp EnrollResponse

--- a/agent/pkg/api/client_test.go
+++ b/agent/pkg/api/client_test.go
@@ -1,10 +1,31 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 )
+
+func TestErrHTTPStatus_Error(t *testing.T) {
+	err := &ErrHTTPStatus{StatusCode: 401, Body: `{"error":"invalid key"}`}
+	got := err.Error()
+	want := `http 401: {"error":"invalid key"}`
+	if got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestErrHTTPStatus_ErrorsAs(t *testing.T) {
+	var wrapped error = &ErrHTTPStatus{StatusCode: 404, Body: "not found"}
+	var target *ErrHTTPStatus
+	if !errors.As(wrapped, &target) {
+		t.Fatal("errors.As should match *ErrHTTPStatus")
+	}
+	if target.StatusCode != 404 {
+		t.Errorf("StatusCode = %d, want 404", target.StatusCode)
+	}
+}
 
 func TestRotateToken(t *testing.T) {
 	t.Parallel()

--- a/docs/superpowers/plans/2026-04-13-msi-enrollment-failure-reporting.md
+++ b/docs/superpowers/plans/2026-04-13-msi-enrollment-failure-reporting.md
@@ -1,0 +1,2788 @@
+# MSI Enrollment Failure Reporting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix issue #411 — MSI installs no longer roll back with a cryptic 1603 when enrollment is missing or fails. Bad-creds installs fail loudly with a human-readable cause written to four sinks (msiexec install.log, agent.log, `enroll-last-error.txt`, Windows Event Log). No-creds installs succeed; the service starts into a wait-for-enrollment loop so imaged/sysprep'd deployments work.
+
+**Architecture:** On the Go side, split `startAgent` so the caller decides whether to wait. Add a cross-platform `waitForEnrollment(ctx, cfgFile)` helper gated on a complete `config.IsEnrolled(cfg)` check (both AgentID AND AuthToken, to survive torn `SaveTo` writes). The Windows service wrapper forks on enrollment state: enrolled → synchronous start (preserves today's "bad mTLS init fails the install" guarantee), unenrolled → signal `Running` immediately, wait, then start. Three package-level function vars (`startAgentFn`, `waitForEnrollmentFn`, `runServiceLoopFn`) act as test seams so Windows-gated tests can verify state-transition ordering without constructing real `heartbeat.Heartbeat` + `websocket.Client` fixtures. Enrollment failures route through a new `enrollError(cat, friendly, err)` helper that writes stderr + agent.log + `enroll-last-error.txt` + Event Log in one call and exits with a category-specific code. The MSI custom action is changed from `Return="ignore"` to `Return="check"` so bad-creds attempts cleanly roll back with a discoverable error trail; no-creds attempts skip the CA entirely and the install succeeds.
+
+**Tech Stack:** Go 1.25.x (cobra + slog via `internal/logging`, `golang.org/x/sys/windows/svc/eventlog`), WiX Toolset v4 (`breeze.wxs`), Go standard `testing` + `t.Cleanup` for seams.
+
+**Target release:** v0.63.x (not a hotfix).
+
+**Spec:** `docs/superpowers/specs/2026-04-13-msi-enrollment-failure-reporting-design.md` — source of truth for design decisions. This plan implements it task-by-task.
+
+---
+
+## File Structure
+
+**Create:**
+- `agent/internal/eventlog/eventlog.go` — cross-platform no-op stubs (build tag `!windows`)
+- `agent/internal/eventlog/eventlog_windows.go` — Windows implementation wrapping `golang.org/x/sys/windows/svc/eventlog`
+- `agent/internal/eventlog/eventlog_test.go` — no-op compile test
+- `agent/cmd/breeze-agent/enroll_error.go` — `enrollError` helper, category enum, classifier, sinks
+- `agent/cmd/breeze-agent/enroll_error_test.go` — unit tests for the helper
+- `agent/cmd/breeze-agent/service_windows_test.go` — Windows-gated tests for Execute ordering (create if absent)
+
+**Modify:**
+- `agent/pkg/api/client.go` — add `ErrHTTPStatus` type; `Enroll` returns it on non-200
+- `agent/pkg/api/client_test.go` — test for `ErrHTTPStatus` (create if absent)
+- `agent/internal/config/config.go` — add `IsEnrolled(cfg *Config) bool`
+- `agent/internal/config/config_test.go` — table test for `IsEnrolled` (create if absent)
+- `agent/cmd/breeze-agent/main.go` — split `startAgent`, add `waitForEnrollment`, `waitForEnrollmentPollInterval`, `initBootstrapLogging`, package-level test seams, rewrite `runAgent` to use `signal.NotifyContext`, route `enrollDevice` failures through `enrollError`, call `clearEnrollLastError` at attempt start
+- `agent/cmd/breeze-agent/main_test.go` — three `waitForEnrollment` tests
+- `agent/cmd/breeze-agent/service_windows.go` — `runAsService` takes `cfgFile`; `Execute` splits into enrolled/unenrolled paths; extract `runServiceLoop` helper
+- `agent/installer/breeze.wxs` — `EnrollAgent` CA `Return="check"`; updated XML comment
+
+**Not touched:**
+- `agent/installer/build-msi.ps1` — no changes
+- `agent/internal/heartbeat/`, `agent/internal/websocket/` — reused as-is
+- `.github/workflows/release.yml` — no changes
+
+---
+
+## Task 1: Add `ErrHTTPStatus` to `pkg/api/client.go`
+
+**Context for engineer:** The Go agent's API client today returns a generic `fmt.Errorf("enrollment failed with status %d: %s", ...)` on non-200 responses. The enrollment classifier (Task 4) needs to distinguish auth failures (401/403) from not-found (404), rate-limit (429), and server errors (5xx). We add a typed error that callers can `errors.As` on.
+
+**Files:**
+- Modify: `agent/pkg/api/client.go:106-136`
+- Create: `agent/pkg/api/client_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agent/pkg/api/client_test.go`:
+
+```go
+package api
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestErrHTTPStatus_Error(t *testing.T) {
+	err := &ErrHTTPStatus{StatusCode: 401, Body: `{"error":"invalid key"}`}
+	got := err.Error()
+	want := `http 401: {"error":"invalid key"}`
+	if got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestErrHTTPStatus_ErrorsAs(t *testing.T) {
+	var wrapped error = &ErrHTTPStatus{StatusCode: 404, Body: "not found"}
+	var target *ErrHTTPStatus
+	if !errors.As(wrapped, &target) {
+		t.Fatal("errors.As should match *ErrHTTPStatus")
+	}
+	if target.StatusCode != 404 {
+		t.Errorf("StatusCode = %d, want 404", target.StatusCode)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run from `agent/`:
+
+```bash
+go test ./pkg/api/... -run 'TestErrHTTPStatus' -v
+```
+
+Expected: FAIL with `undefined: ErrHTTPStatus`.
+
+- [ ] **Step 3: Add the type to `pkg/api/client.go`**
+
+Use `Edit` to add the type after the imports, before `type Client struct` at line 13. Find line 11 (`)` closing the imports block) and insert the new type between it and `type Client struct`.
+
+**old_string:**
+
+```go
+)
+
+type Client struct {
+```
+
+**new_string:**
+
+```go
+)
+
+// ErrHTTPStatus is returned by the api client when an HTTP request
+// completes but the server returned a non-success status code. Callers
+// can type-assert via errors.As to classify the failure (auth, not
+// found, rate limit, server error).
+type ErrHTTPStatus struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *ErrHTTPStatus) Error() string {
+	return fmt.Sprintf("http %d: %s", e.StatusCode, e.Body)
+}
+
+type Client struct {
+```
+
+- [ ] **Step 4: Update `Enroll` to return `*ErrHTTPStatus` on non-200**
+
+Use `Edit` to change the non-200 branch at line 125-128.
+
+**old_string:**
+
+```go
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("enrollment failed with status %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+```
+
+**new_string:**
+
+```go
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return nil, &ErrHTTPStatus{StatusCode: resp.StatusCode, Body: string(bodyBytes)}
+	}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run from `agent/`:
+
+```bash
+go test ./pkg/api/... -run 'TestErrHTTPStatus' -v
+```
+
+Expected: `PASS` on both `TestErrHTTPStatus_Error` and `TestErrHTTPStatus_ErrorsAs`.
+
+Also run the full api package tests to confirm nothing regressed:
+
+```bash
+go test ./pkg/api/... -v
+```
+
+Expected: all existing tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add agent/pkg/api/client.go agent/pkg/api/client_test.go
+git commit -m "$(cat <<'EOF'
+feat(api): add ErrHTTPStatus type for enroll failure classification
+
+Enroll now returns *ErrHTTPStatus on non-200 responses so callers can
+errors.As and branch on StatusCode. Replaces the previous generic
+fmt.Errorf which stringified the status and body together.
+
+Needed by the upcoming enrollment failure classifier (issue #411).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Add `IsEnrolled` helper to `internal/config/config.go`
+
+**Context for engineer:** `config.SaveTo` writes `agent.yaml` first (with `AgentID`) then `secrets.yaml` (with `AuthToken`) — verified at `agent/internal/config/config.go:313-376`. A concurrent reader polling for enrollment readiness that only checks `AgentID != ""` can observe a torn write: the new `AgentID` is visible but `AuthToken` is still empty. The wait loop (Task 7) needs a predicate that checks both fields so a torn read simply causes one more poll cycle instead of a bogus "enrolled" bring-up.
+
+**Files:**
+- Modify: `agent/internal/config/config.go` (add helper near the top of the file, after the `Config` struct definition around line 120)
+- Create or modify: `agent/internal/config/config_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agent/internal/config/config_test.go` if it doesn't exist, or append to it. If creating, use this full file:
+
+```go
+package config
+
+import "testing"
+
+func TestIsEnrolled(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+		want bool
+	}{
+		{"nil config", nil, false},
+		{"empty config", &Config{}, false},
+		{"agent id only (torn write)", &Config{AgentID: "abc"}, false},
+		{"auth token only (torn write)", &Config{AuthToken: "tok"}, false},
+		{"both present", &Config{AgentID: "abc", AuthToken: "tok"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsEnrolled(tt.cfg); got != tt.want {
+				t.Errorf("IsEnrolled(%+v) = %v, want %v", tt.cfg, got, tt.want)
+			}
+		})
+	}
+}
+```
+
+If `config_test.go` already exists, append only the `TestIsEnrolled` function (ensure imports include `"testing"`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run from `agent/`:
+
+```bash
+go test ./internal/config/... -run 'TestIsEnrolled' -v
+```
+
+Expected: FAIL with `undefined: IsEnrolled`.
+
+- [ ] **Step 3: Add the helper to `config.go`**
+
+Use `Edit` to add the helper immediately after the `Config` struct definition at line 120 (the closing `}` of the struct).
+
+**old_string:**
+
+```go
+	// IsHeadless is a runtime flag set when no console/TTY is attached (launchd
+	// daemon, systemd service, etc.). Desktop commands route through IPC when set.
+	IsHeadless bool `mapstructure:"-"`
+}
+
+// defaultLogFile returns the platform-specific default log file path.
+```
+
+**new_string:**
+
+```go
+	// IsHeadless is a runtime flag set when no console/TTY is attached (launchd
+	// daemon, systemd service, etc.). Desktop commands route through IPC when set.
+	IsHeadless bool `mapstructure:"-"`
+}
+
+// IsEnrolled reports whether cfg represents a complete enrollment — both
+// the AgentID (written to agent.yaml) and the AuthToken (written to
+// secrets.yaml). Callers that poll for enrollment readiness MUST use
+// this predicate rather than checking AgentID alone, because SaveTo
+// writes agent.yaml before secrets.yaml and a concurrent reader can
+// otherwise observe a torn write (AgentID set but AuthToken not yet
+// persisted). A torn read simply causes one more poll cycle.
+func IsEnrolled(cfg *Config) bool {
+	return cfg != nil && cfg.AgentID != "" && cfg.AuthToken != ""
+}
+
+// defaultLogFile returns the platform-specific default log file path.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run from `agent/`:
+
+```bash
+go test ./internal/config/... -run 'TestIsEnrolled' -v
+```
+
+Expected: PASS on all five sub-tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/internal/config/config.go agent/internal/config/config_test.go
+git commit -m "$(cat <<'EOF'
+feat(config): add IsEnrolled(cfg) predicate for complete enrollment check
+
+Checks both AgentID and AuthToken because SaveTo writes agent.yaml
+before secrets.yaml — a reader that only checked AgentID could observe
+a torn write and bring up the agent with an empty auth token.
+
+Used by the upcoming waitForEnrollment loop (issue #411).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Create `internal/eventlog` package
+
+**Context for engineer:** We need to write enrollment failures to the Windows Application Event Log under source `BreezeAgent`. The stdlib-adjacent package `golang.org/x/sys/windows/svc/eventlog` provides `Install`/`InstallAsEventCreate`/`Open`, but it's Windows-only. We wrap it with a small cross-platform API (`Info` / `Warning` / `Error`) that compiles on macOS and Linux as no-ops. Registration is lazy and guarded by `sync.Once`; if registration fails (non-admin, already registered, etc.) we fall back to `eventlog.Open` and then silently drop if that also fails — the other three sinks cover the failure.
+
+**Files:**
+- Create: `agent/internal/eventlog/eventlog.go` (build tag `!windows`)
+- Create: `agent/internal/eventlog/eventlog_windows.go`
+- Create: `agent/internal/eventlog/eventlog_test.go`
+
+- [ ] **Step 1: Write the cross-platform no-op test**
+
+Create `agent/internal/eventlog/eventlog_test.go`:
+
+```go
+package eventlog
+
+import "testing"
+
+func TestNoPanicOnAllPlatforms(t *testing.T) {
+	// Calling any of these from a non-admin context on Windows, or
+	// anywhere on macOS/Linux, must not panic. Registration errors
+	// are silently swallowed per package contract.
+	Info("BreezeAgent", "test info message")
+	Warning("BreezeAgent", "test warning message")
+	Error("BreezeAgent", "test error message")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run from `agent/`:
+
+```bash
+go test ./internal/eventlog/... -v
+```
+
+Expected: FAIL with `no Go files in .../eventlog`.
+
+- [ ] **Step 3: Create the non-Windows stub**
+
+Create `agent/internal/eventlog/eventlog.go`:
+
+```go
+//go:build !windows
+
+// Package eventlog writes informational, warning, and error events to
+// the OS event log. On Windows this wraps the Application log; on
+// macOS and Linux the calls compile to no-ops so agent call sites can
+// stay cross-platform.
+package eventlog
+
+// Info writes an informational event to the OS event log (no-op on
+// non-Windows platforms). source is a short registered name like
+// "BreezeAgent".
+func Info(source, message string) {}
+
+// Warning writes a warning event.
+func Warning(source, message string) {}
+
+// Error writes an error event.
+func Error(source, message string) {}
+```
+
+- [ ] **Step 4: Create the Windows implementation**
+
+Create `agent/internal/eventlog/eventlog_windows.go`:
+
+```go
+//go:build windows
+
+// Package eventlog writes informational, warning, and error events to
+// the Windows Application Event Log. Registration is lazy: on first
+// use per source, we attempt InstallAsEventCreate, and if that fails
+// because the source already exists we fall back to Open. Both
+// failures are silently swallowed — the package's contract is that
+// logging is best-effort and never returns errors to callers.
+package eventlog
+
+import (
+	"sync"
+
+	"golang.org/x/sys/windows/svc/eventlog"
+)
+
+// Event IDs used by this package. Fixed values keep the Windows
+// Application log filterable by event ID in SIEM tools.
+const (
+	eventIDInfo    uint32 = 1001
+	eventIDWarning uint32 = 1002
+	eventIDError   uint32 = 1003
+)
+
+var (
+	registryMu sync.Mutex
+	registry   = map[string]*sourceEntry{}
+)
+
+type sourceEntry struct {
+	once sync.Once
+	log  *eventlog.Log // nil if registration failed
+}
+
+func lookupOrRegister(source string) *eventlog.Log {
+	registryMu.Lock()
+	entry, ok := registry[source]
+	if !ok {
+		entry = &sourceEntry{}
+		registry[source] = entry
+	}
+	registryMu.Unlock()
+
+	entry.once.Do(func() {
+		// Try to install the source with all three severities. Most
+		// Windows environments require admin to install a new event
+		// source; if the source already exists, Install returns an
+		// "already exists" error which we treat as benign.
+		_ = eventlog.InstallAsEventCreate(
+			source,
+			eventlog.Info|eventlog.Warning|eventlog.Error,
+		)
+		// Open returns a handle usable for Info/Warning/Error regardless
+		// of whether we just installed it or it already existed.
+		logHandle, openErr := eventlog.Open(source)
+		if openErr != nil {
+			return // entry.log stays nil; subsequent calls are no-ops
+		}
+		entry.log = logHandle
+	})
+	return entry.log
+}
+
+// Info writes an informational event to the Windows Application log.
+func Info(source, message string) {
+	if handle := lookupOrRegister(source); handle != nil {
+		_ = handle.Info(eventIDInfo, message)
+	}
+}
+
+// Warning writes a warning event.
+func Warning(source, message string) {
+	if handle := lookupOrRegister(source); handle != nil {
+		_ = handle.Warning(eventIDWarning, message)
+	}
+}
+
+// Error writes an error event.
+func Error(source, message string) {
+	if handle := lookupOrRegister(source); handle != nil {
+		_ = handle.Error(eventIDError, message)
+	}
+}
+```
+
+- [ ] **Step 5: Verify the cross-compile for all three platforms**
+
+Run from `agent/`:
+
+```bash
+GOOS=windows GOARCH=amd64 go build ./internal/eventlog/...
+GOOS=darwin  GOARCH=amd64 go build ./internal/eventlog/...
+GOOS=linux   GOARCH=amd64 go build ./internal/eventlog/...
+```
+
+Expected: all three exit 0 with no output. If the Windows build fails with a missing dependency, run:
+
+```bash
+go mod tidy
+```
+
+and re-try. The `golang.org/x/sys` module should already be in go.mod — it's used elsewhere in the agent.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run from `agent/`:
+
+```bash
+go test ./internal/eventlog/... -v
+```
+
+Expected: `PASS` on `TestNoPanicOnAllPlatforms` on the current host platform (macOS). The test is a smoke test — it verifies the package compiles and the entry points don't panic.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add agent/internal/eventlog/
+git commit -m "$(cat <<'EOF'
+feat(agent): add internal/eventlog — cross-platform event log wrapper
+
+Windows implementation wraps golang.org/x/sys/windows/svc/eventlog with
+lazy registration per source, guarded by sync.Once. Registration errors
+(non-admin, already-exists) are silently swallowed — the package's
+contract is best-effort logging. macOS/Linux stubs compile to no-ops.
+
+Fixed event IDs: 1001 Info, 1002 Warning, 1003 Error for SIEM filter
+stability. Used by the upcoming enrollError helper (issue #411).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Create `cmd/breeze-agent/enroll_error.go`
+
+**Context for engineer:** This is the four-sink writer for enrollment failures. Every failure site in `enrollDevice` (Task 5) will call `enrollError(cat, friendly, detail)`. The helper writes the line to stderr (→ captured by msiexec `/l*v` into install.log), emits a slog `error` event (→ agent.log, diagnostic logs API), overwrites `enroll-last-error.txt` with a single-line timestamped message, and writes a Windows Event Log error. Then it exits with a category-specific code in the range 10-16 so admins can `echo %errorlevel%` and distinguish network from auth from server errors.
+
+The helper also exposes `clearEnrollLastError()` — called at the start of every attempt (Task 5) so a successful retry leaves no residual error file for admins to find.
+
+The file uses package-level vars (`osExit`, `writeLastErrorFile`, `eventLogError`) as test seams so `enroll_error_test.go` can intercept without patching `os.Exit`.
+
+**Files:**
+- Create: `agent/cmd/breeze-agent/enroll_error.go`
+- Create: `agent/cmd/breeze-agent/enroll_error_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `agent/cmd/breeze-agent/enroll_error_test.go`:
+
+```go
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/breeze-rmm/agent/pkg/api"
+)
+
+func TestEnrollErrCategory_ExitCode(t *testing.T) {
+	if got, want := catNetwork.exitCode(), 10; got != want {
+		t.Errorf("catNetwork.exitCode() = %d, want %d", got, want)
+	}
+	if got, want := catUnknown.exitCode(), 16; got != want {
+		t.Errorf("catUnknown.exitCode() = %d, want %d", got, want)
+	}
+}
+
+func TestClassifyEnrollError_HTTPStatuses(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		wantCat enrollErrCategory
+	}{
+		{"401 unauthorized", 401, catAuth},
+		{"403 forbidden", 403, catAuth},
+		{"404 not found", 404, catNotFound},
+		{"429 rate limited", 429, catRateLimit},
+		{"500 internal error", 500, catServer},
+		{"503 service unavailable", 503, catServer},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &api.ErrHTTPStatus{StatusCode: tt.status, Body: "body"}
+			cat, friendly := classifyEnrollError(err, "https://example.com")
+			if cat != tt.wantCat {
+				t.Errorf("category = %v, want %v", cat, tt.wantCat)
+			}
+			if friendly == "" {
+				t.Error("friendly message should not be empty")
+			}
+		})
+	}
+}
+
+func TestClassifyEnrollError_NetworkError(t *testing.T) {
+	urlErr := &url.Error{Op: "Post", URL: "https://unreachable.example", Err: errors.New("dial tcp: connection refused")}
+	cat, friendly := classifyEnrollError(urlErr, "https://unreachable.example")
+	if cat != catNetwork {
+		t.Errorf("category = %v, want catNetwork", cat)
+	}
+	if !strings.Contains(friendly, "server unreachable") {
+		t.Errorf("friendly = %q, should contain 'server unreachable'", friendly)
+	}
+}
+
+func TestClassifyEnrollError_Unknown(t *testing.T) {
+	cat, friendly := classifyEnrollError(errors.New("something weird"), "https://example.com")
+	if cat != catUnknown {
+		t.Errorf("category = %v, want catUnknown", cat)
+	}
+	if friendly == "" {
+		t.Error("friendly should echo the raw error string")
+	}
+}
+
+func TestEnrollError_WritesAllFourSinks(t *testing.T) {
+	// Redirect stderr to a buffer for observation.
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = oldStderr })
+
+	// Capture last-error file writes.
+	var lastErrorCaptured string
+	origWrite := writeLastErrorFile
+	writeLastErrorFile = func(line string) { lastErrorCaptured = line }
+	t.Cleanup(func() { writeLastErrorFile = origWrite })
+
+	// Capture event-log writes.
+	var eventLogCaptured string
+	origEventLog := eventLogError
+	eventLogError = func(source, message string) { eventLogCaptured = message }
+	t.Cleanup(func() { eventLogError = origEventLog })
+
+	// Capture exit code.
+	var exitCapturedCode int
+	origExit := osExit
+	osExit = func(code int) {
+		exitCapturedCode = code
+		panic("test exit") // unwind the stack so enrollError's "never returns" is testable
+	}
+	t.Cleanup(func() { osExit = origExit })
+
+	defer func() {
+		recover() // swallow the test-exit panic
+		w.Close()
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		stderrOutput := buf.String()
+
+		if !strings.Contains(stderrOutput, "Enrollment failed:") {
+			t.Errorf("stderr = %q, should contain 'Enrollment failed:'", stderrOutput)
+		}
+		if !strings.Contains(lastErrorCaptured, "Enrollment failed:") {
+			t.Errorf("last error file = %q, should contain 'Enrollment failed:'", lastErrorCaptured)
+		}
+		if !strings.Contains(eventLogCaptured, "Enrollment failed:") {
+			t.Errorf("event log = %q, should contain 'Enrollment failed:'", eventLogCaptured)
+		}
+		if exitCapturedCode != catAuth.exitCode() {
+			t.Errorf("exit code = %d, want %d", exitCapturedCode, catAuth.exitCode())
+		}
+	}()
+
+	enrollError(catAuth, "enrollment key not recognized", errors.New("http 401"))
+}
+
+func TestClearEnrollLastError_RemovesStaleFile(t *testing.T) {
+	tmp := t.TempDir()
+	// Override the path helper so the test doesn't touch real ProgramData.
+	origPath := enrollLastErrorPath
+	enrollLastErrorPath = func() string { return filepath.Join(tmp, "enroll-last-error.txt") }
+	t.Cleanup(func() { enrollLastErrorPath = origPath })
+
+	// Create a stale file.
+	if err := os.WriteFile(enrollLastErrorPath(), []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	clearEnrollLastError()
+
+	if _, err := os.Stat(enrollLastErrorPath()); !os.IsNotExist(err) {
+		t.Errorf("stale file should have been removed, stat err = %v", err)
+	}
+}
+
+func TestClearEnrollLastError_NoFileIsNoError(t *testing.T) {
+	tmp := t.TempDir()
+	origPath := enrollLastErrorPath
+	enrollLastErrorPath = func() string { return filepath.Join(tmp, "never-existed.txt") }
+	t.Cleanup(func() { enrollLastErrorPath = origPath })
+
+	// Should not panic or log at error level.
+	clearEnrollLastError()
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run from `agent/`:
+
+```bash
+go test ./cmd/breeze-agent/... -run 'TestEnrollErr|TestClassify|TestClearEnrollLastError' -v
+```
+
+Expected: FAIL with `undefined: catNetwork`, `undefined: enrollError`, etc.
+
+- [ ] **Step 3: Create `enroll_error.go`**
+
+Create `agent/cmd/breeze-agent/enroll_error.go`:
+
+```go
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/config"
+	"github.com/breeze-rmm/agent/internal/eventlog"
+	"github.com/breeze-rmm/agent/pkg/api"
+)
+
+// enrollErrCategory classifies an enrollment failure for exit-code
+// stability and human-readable messaging. Exit codes are mapped to
+// 10..16 to keep each category distinguishable in msiexec install.log
+// without colliding with Go's default runtime-error exit code (2).
+type enrollErrCategory int
+
+const (
+	catNetwork   enrollErrCategory = iota // dial/DNS/TLS/timeout/conn refused
+	catAuth                               // 401, 403
+	catNotFound                           // 404
+	catRateLimit                          // 429
+	catServer                             // 5xx
+	catConfig                             // pre-flight validation or save failed
+	catUnknown                            // fallback — message comes from raw error
+)
+
+func (c enrollErrCategory) exitCode() int { return int(c) + 10 }
+
+// Package-level test seams. Production assigns them to the real
+// implementations in init(); tests override with t.Cleanup-guarded
+// stubs in enroll_error_test.go.
+var (
+	osExit             = os.Exit
+	writeLastErrorFile = defaultWriteLastErrorFile
+	eventLogError      = eventlog.Error
+	enrollLastErrorPath = defaultEnrollLastErrorPath
+)
+
+// defaultEnrollLastErrorPath returns the platform-specific path to the
+// single-line enrollment error marker. Windows: under ProgramData\Breeze\logs.
+// Unix: under LogDir().
+func defaultEnrollLastErrorPath() string {
+	return filepath.Join(config.LogDir(), "enroll-last-error.txt")
+}
+
+// defaultWriteLastErrorFile overwrites enroll-last-error.txt with a
+// single line containing the RFC3339 timestamp and the friendly message.
+// Silently ignores errors — this is a diagnostic aid, not a critical
+// path.
+func defaultWriteLastErrorFile(line string) {
+	path := enrollLastErrorPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	content := fmt.Sprintf("%s — %s\n", time.Now().Format(time.RFC3339), line)
+	_ = os.WriteFile(path, []byte(content), 0o644)
+}
+
+// clearEnrollLastError removes enroll-last-error.txt if present. Called
+// at the start of every enrollment attempt so a successful retry leaves
+// no residual error file. Errors from os.Remove are silently ignored
+// (the file may legitimately not exist, and cleanup bookkeeping must
+// not fail an enrollment attempt).
+func clearEnrollLastError() {
+	path := enrollLastErrorPath()
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		// Log at debug level only — not worth bothering admins. The scoped
+		// enrollLog is initialized by initEnrollLogging before this helper
+		// is called.
+		log.Debug("could not clear stale enroll-last-error file",
+			"path", path, "error", err.Error())
+	}
+}
+
+// enrollError writes a human-readable failure line to all four sinks
+// (stderr → msiexec install.log, agent.log via slog, enroll-last-error.txt,
+// Windows Event Log) and exits the process with a category-specific
+// code. Never returns in production; tests inject a panicking osExit
+// stub so assertion code after the call is reachable via defer+recover.
+func enrollError(cat enrollErrCategory, friendly string, detail error) {
+	line := fmt.Sprintf("Enrollment failed: %s", friendly)
+	if detail != nil {
+		line += fmt.Sprintf(" (%v)", detail)
+	}
+
+	// Sink 1: stderr → msiexec /l*v captures into install.log.
+	fmt.Fprintln(os.Stderr, line)
+
+	// Sink 2: agent.log via slog. The scoped enrollLog is initialized
+	// by initEnrollLogging in enrollDevice before any failure path
+	// can fire; fall back to the main log if called from an unexpected
+	// context.
+	log.Error("enrollment failed",
+		"category", cat,
+		"friendly", friendly,
+		"error", fmt.Sprint(detail))
+
+	// Sink 3: enroll-last-error.txt — single-line timestamped marker.
+	writeLastErrorFile(line)
+
+	// Sink 4: Windows Event Log (no-op on macOS/Linux).
+	eventLogError("BreezeAgent", line)
+
+	osExit(cat.exitCode())
+}
+
+// classifyEnrollError inspects an error returned by api.Client.Enroll
+// and maps it to the appropriate category + user-facing friendly
+// message. The serverURL is threaded through so friendly messages can
+// echo it back to the admin ("check that SERVER_URL is correct").
+func classifyEnrollError(err error, serverURL string) (enrollErrCategory, string) {
+	if err == nil {
+		return catUnknown, ""
+	}
+
+	var httpErr *api.ErrHTTPStatus
+	if errors.As(err, &httpErr) {
+		switch {
+		case httpErr.StatusCode == 401 || httpErr.StatusCode == 403:
+			return catAuth, "enrollment key not recognized — verify the key is active in Settings → Enrollment on the server"
+		case httpErr.StatusCode == 404:
+			return catNotFound, fmt.Sprintf(
+				"enrollment endpoint not found on %s — check that SERVER_URL is correct (did you include /api or point at the wrong host?)",
+				serverURL)
+		case httpErr.StatusCode == 429:
+			return catRateLimit, "rate limited by server — wait one minute and retry the install"
+		case httpErr.StatusCode >= 500:
+			return catServer, fmt.Sprintf(
+				"server error %d — contact Breeze support if this persists",
+				httpErr.StatusCode)
+		}
+	}
+
+	// Network-layer errors come through as *url.Error wrapping dial/DNS/TLS/timeout.
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return catNetwork, fmt.Sprintf(
+			"server unreachable at %s — check firewall, DNS, and that SERVER_URL is correct",
+			serverURL)
+	}
+
+	return catUnknown, err.Error()
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run from `agent/`:
+
+```bash
+go test ./cmd/breeze-agent/... -run 'TestEnrollErr|TestClassify|TestClearEnrollLastError' -v
+```
+
+Expected: PASS on all tests. If `TestEnrollError_WritesAllFourSinks` fails with a "panic recovered" message that doesn't match the expected string, verify the stubs are wired correctly via `t.Cleanup`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/cmd/breeze-agent/enroll_error.go agent/cmd/breeze-agent/enroll_error_test.go
+git commit -m "$(cat <<'EOF'
+feat(agent): add enrollError helper — four-sink failure reporter
+
+Routes every enrollment failure through one helper that writes the
+friendly cause to stderr (captured by msiexec /l*v into install.log),
+slog (agent.log + diagnostic logs API), enroll-last-error.txt (a
+single-line timestamped marker in the logs directory), and the
+Windows Event Log (Application / BreezeAgent / Error).
+
+Categories map to exit codes 10..16 so admins can distinguish
+network/auth/not-found/rate-limit/server/config/unknown failures from
+the install.log verbose output.
+
+clearEnrollLastError() removes stale markers at the start of every
+attempt so a successful retry leaves no residual.
+
+Issue #411.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Wire `enrollDevice` through `enrollError`
+
+**Context for engineer:** The existing `enrollDevice` function at `agent/cmd/breeze-agent/main.go:522` already uses `initEnrollLogging`, has a scoped `enrollLog`, and prints failures via `fmt.Fprintf(os.Stderr, ...)` + `os.Exit(1)`. We keep the logging init and replace the stderr/exit pairs with `enrollError` calls. We also insert a `clearEnrollLastError()` call immediately after logging init and before any validation or early return — so a server-URL validation failure still clears the stale marker from a previous attempt.
+
+The three failure sites to replace:
+1. Line ~543 — `cfg.ServerURL == ""` → `catConfig`
+2. Line ~670ish — `client.Enroll(enrollReq)` error → classified via `classifyEnrollError`
+3. Line ~720ish — `config.SaveTo` error → `catConfig`
+
+**Files:**
+- Modify: `agent/cmd/breeze-agent/main.go:522-750` (approximately)
+
+- [ ] **Step 1: Read the current `enrollDevice` body**
+
+The engineer must read lines 522-750 of `agent/cmd/breeze-agent/main.go` to get current line numbers before editing. The numbers in this task are approximate because the merged #410 code has evolved.
+
+Run:
+
+```bash
+grep -n 'func enrollDevice\|os.Exit(1)\|Enrollment failed' agent/cmd/breeze-agent/main.go
+```
+
+Expected output lists `func enrollDevice` plus several `os.Exit(1)` lines and any `fmt.Fprintf(os.Stderr, "Enrollment failed: ..."` lines.
+
+- [ ] **Step 2: Add `clearEnrollLastError()` after `initEnrollLogging`**
+
+Use `Edit` to add the clear call immediately after the `initEnrollLogging(cfg, quietEnroll)` line and BEFORE the server-URL validation. Decision 8 from the spec requires every attempt to start with a clean slate, including attempts that fail on pre-flight validation.
+
+**old_string:**
+
+```go
+	// Initialise logging so this enrollment leaves a record in agent.log.
+	// In quiet mode, force file-only output — errors still reach stderr
+	// via explicit fmt.Fprintln calls at error sites below.
+	initEnrollLogging(cfg, quietEnroll)
+
+	enrollLog := logging.L("enroll")
+
+	if cfg.ServerURL == "" {
+```
+
+**new_string:**
+
+```go
+	// Initialise logging so this enrollment leaves a record in agent.log.
+	// In quiet mode, force file-only output — errors still reach stderr
+	// via explicit fmt.Fprintln calls at error sites below.
+	initEnrollLogging(cfg, quietEnroll)
+
+	enrollLog := logging.L("enroll")
+
+	// Clear any stale enroll-last-error.txt from a previous failed
+	// attempt BEFORE any validation or early return. Every attempt
+	// starts from a clean marker state; a validation failure later
+	// in this function must not leave a stale file behind (spec
+	// decision 8, issue #411).
+	clearEnrollLastError()
+
+	if cfg.ServerURL == "" {
+```
+
+- [ ] **Step 3: Replace the server-URL validation failure with `enrollError`**
+
+**old_string:**
+
+```go
+	if cfg.ServerURL == "" {
+		enrollLog.Error("server URL required, use --server or set in config")
+		fmt.Fprintln(os.Stderr, "Server URL required. Use --server flag or set in config.")
+		os.Exit(1)
+	}
+```
+
+**new_string:**
+
+```go
+	if cfg.ServerURL == "" {
+		enrollError(catConfig,
+			"server URL required — pass --server or set it in config",
+			nil)
+	}
+```
+
+- [ ] **Step 4: Replace the `client.Enroll` failure with classification + `enrollError`**
+
+Grep for the existing block:
+
+```bash
+grep -n 'enrollResp, err := client.Enroll\|Enrollment failed: %v' agent/cmd/breeze-agent/main.go
+```
+
+Then edit the block. The exact `old_string` depends on surrounding context; the engineer should read 10-15 lines around the match and construct a unique `old_string`. Example based on the pre-Task-5 state:
+
+**old_string:**
+
+```go
+	enrollResp, err := client.Enroll(enrollReq)
+	if err != nil {
+		enrollLog.Error("enrollment request failed",
+			"error", err.Error(),
+			"server", cfg.ServerURL)
+		fmt.Fprintf(os.Stderr, "Enrollment failed: %v\n", err)
+		os.Exit(1)
+	}
+```
+
+**new_string:**
+
+```go
+	enrollResp, err := client.Enroll(enrollReq)
+	if err != nil {
+		cat, friendly := classifyEnrollError(err, cfg.ServerURL)
+		enrollError(cat, friendly, err)
+	}
+```
+
+- [ ] **Step 5: Replace the `config.SaveTo` failure with `enrollError`**
+
+Grep for the existing block:
+
+```bash
+grep -n 'config.SaveTo(cfg, cfgFile)\|Warning: Failed to save config' agent/cmd/breeze-agent/main.go
+```
+
+**old_string:**
+
+```go
+	if err := config.SaveTo(cfg, cfgFile); err != nil {
+		enrollLog.Error("enrollment succeeded but failed to save config",
+			"error", err.Error(),
+			"agentId", cfg.AgentID)
+		fmt.Fprintf(os.Stderr, "Warning: Failed to save config: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Agent ID: %s\n", cfg.AgentID)
+		fmt.Fprintln(os.Stderr, "You may need to manually save the configuration.")
+		os.Exit(1)
+	}
+```
+
+**new_string:**
+
+```go
+	if err := config.SaveTo(cfg, cfgFile); err != nil {
+		enrollError(catConfig,
+			fmt.Sprintf(
+				"enrollment succeeded but could not save config to %s — check that the directory exists and SYSTEM has write access (agentID=%s)",
+				cfgFile, cfg.AgentID),
+			err)
+	}
+```
+
+- [ ] **Step 6: Verify the package still builds**
+
+Run from `agent/`:
+
+```bash
+go build ./cmd/breeze-agent/...
+```
+
+Expected: exit 0 with no output.
+
+- [ ] **Step 7: Run the enroll-related tests**
+
+```bash
+go test ./cmd/breeze-agent/... -run 'TestEnrollErr|TestClassify|TestClearEnrollLastError' -v
+```
+
+Expected: still PASS. These tests exercise `enroll_error.go` directly and don't depend on `enrollDevice`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add agent/cmd/breeze-agent/main.go
+git commit -m "$(cat <<'EOF'
+refactor(agent): route enrollDevice failures through enrollError
+
+All three failure sites in enrollDevice (missing server URL, HTTP
+error from client.Enroll, config.SaveTo write error) now call
+enrollError with a category-specific friendly message instead of
+fmt.Fprintf+os.Exit(1). Admins get a readable cause in install.log,
+agent.log, enroll-last-error.txt, and Event Viewer instead of a bare
+"Enrollment failed: enrollment failed with status 401: ..." line.
+
+clearEnrollLastError is called immediately after logging init,
+before any validation, so a fresh attempt always starts from a
+clean marker state — even when it fails on pre-flight checks.
+
+Issue #411.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Add test seams, `waitForEnrollment`, and `initBootstrapLogging`
+
+**Context for engineer:** This task introduces three pieces in one commit because they're tightly coupled: the package-level function vars (test seams), the `waitForEnrollment` helper the service wrapper will use in Task 8, and a minimal `initBootstrapLogging` helper that prepares logging before the wait loop runs (Component 1's caveat).
+
+- The test seams are `startAgentFn`, `waitForEnrollmentFn`, `runServiceLoopFn`. They're assigned at package scope to the bare implementations; tests in Task 7 and Task 10 override them with stubs.
+- `waitForEnrollment(ctx, cfgFile)` polls `config.Load` every `waitForEnrollmentPollInterval` (default 10s, overridable for tests) and returns the enrolled config when `config.IsEnrolled` returns true, or `nil` if ctx is cancelled.
+- `initBootstrapLogging(cfg)` initializes the logging package to write to stderr + the configured log file (no shipper, no network) so `waitForEnrollment` can emit Warn/Info lines before full `startAgent` runs.
+
+**Note on circular dependencies:** `runServiceLoopFn` references `agentComponents` and `svc.ChangeRequest`, which are Windows-only. Declare the var type using interface-free signatures inside a `//go:build windows` file.
+
+**Files:**
+- Modify: `agent/cmd/breeze-agent/main.go` (add helpers + cross-platform seams)
+- Create or modify: `agent/cmd/breeze-agent/service_seams_windows.go` (Windows-only seam for `runServiceLoopFn`)
+
+- [ ] **Step 1: Check existing imports in main.go**
+
+Run:
+
+```bash
+grep -n 'import\|"context"\|"time"' agent/cmd/breeze-agent/main.go | head -25
+```
+
+If `"context"` is missing from the imports block, Task 6 will add it.
+
+- [ ] **Step 2: Add the cross-platform seams and helpers to main.go**
+
+Use `Edit` to add a block just after the package-level `var (...)` block at lines 37-46. The existing block currently declares `version`, `cfgFile`, `serverURL`, etc. Find a stable anchor (the `var log = logging.L("main")` line, around line 48) and insert the new block after it.
+
+**old_string:**
+
+```go
+var log = logging.L("main")
+
+var rootCmd = &cobra.Command{
+```
+
+**new_string:**
+
+```go
+var log = logging.L("main")
+
+// waitForEnrollmentPollInterval is the interval between config reloads
+// in the wait-for-enrollment loop. Tests override this via t.Cleanup to
+// shrink the loop to milliseconds.
+var waitForEnrollmentPollInterval = 10 * time.Second
+
+// Package-level indirection for testability. Tests override these in
+// t.Cleanup-guarded setup to observe Execute and runAgent ordering
+// without running the real startup pipeline. Production callers MUST
+// use these vars, not the unexported symbols they wrap.
+//
+// startAgentFn and waitForEnrollmentFn are cross-platform; runServiceLoopFn
+// is defined in service_seams_windows.go because its signature references
+// Windows-only types.
+var (
+	startAgentFn        func(*config.Config) (*agentComponents, error) = startAgent
+	waitForEnrollmentFn func(context.Context, string) *config.Config   = waitForEnrollment
+)
+
+// initBootstrapLogging initializes the logging package with stderr +
+// the configured log file so waitForEnrollment can emit Warn/Info
+// lines before full startAgent runs. Does NOT start the log shipper,
+// heartbeat, or any network I/O — those are initialized later in
+// startAgent once enrollment is complete. Safe to call multiple times
+// (logging.Init is idempotent).
+func initBootstrapLogging(cfg *config.Config) {
+	logFile := cfg.LogFile
+	if logFile == "" {
+		logFile = filepath.Join(config.LogDir(), "agent.log")
+	}
+	// Best effort: if the log file can't be opened (permissions, missing
+	// dir), fall back to stderr only. Bootstrap logging must never fail
+	// the agent start.
+	if err := os.MkdirAll(filepath.Dir(logFile), 0o755); err != nil {
+		logging.Init(cfg.LogFormat, cfg.LogLevel, os.Stderr)
+		return
+	}
+	rw, err := logging.NewRotatingWriter(logFile, cfg.LogMaxSizeMB, cfg.LogMaxBackups)
+	if err != nil {
+		logging.Init(cfg.LogFormat, cfg.LogLevel, os.Stderr)
+		return
+	}
+	logging.Init(cfg.LogFormat, cfg.LogLevel, logging.TeeWriter(os.Stderr, rw))
+}
+
+// waitForEnrollment polls agent.yaml + secrets.yaml every
+// waitForEnrollmentPollInterval until config.IsEnrolled returns true,
+// then returns the enrolled config. Returns nil if ctx is cancelled
+// before enrollment completes.
+//
+// Intended for post-MSI-install scenarios where the service starts
+// before a later `breeze-agent enroll` call populates the config. The
+// ctx allows the caller to cancel the wait on shutdown (SIGINT/SIGTERM
+// via signal.NotifyContext in runAgent, or SCM Stop in the Windows
+// service wrapper).
+func waitForEnrollment(ctx context.Context, cfgFile string) *config.Config {
+	log.Warn("agent not enrolled — waiting for enrollment. "+
+		"Run 'breeze-agent enroll <key> --server <url>' to complete setup.",
+		"pollInterval", waitForEnrollmentPollInterval)
+	eventlog.Info("BreezeAgent",
+		"Waiting for enrollment. Run 'breeze-agent enroll <key> --server <url>'.")
+
+	ticker := time.NewTicker(waitForEnrollmentPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("waitForEnrollment cancelled", "reason", ctx.Err().Error())
+			return nil
+		case <-ticker.C:
+			cfg, err := config.Load(cfgFile)
+			if err != nil {
+				log.Debug("config reload failed while waiting for enrollment",
+					"error", err.Error())
+				continue
+			}
+			if config.IsEnrolled(cfg) {
+				log.Info("enrollment detected, continuing startup",
+					"agentId", cfg.AgentID)
+				return cfg
+			}
+		}
+	}
+}
+
+var rootCmd = &cobra.Command{
+```
+
+- [ ] **Step 3: Add `context` and `eventlog` to the import block**
+
+Run:
+
+```bash
+grep -n '"github.com/breeze-rmm/agent/internal/logging"\|"context"\|"github.com/breeze-rmm/agent/internal/eventlog"' agent/cmd/breeze-agent/main.go
+```
+
+If `"context"` is missing, add it to the imports. The imports block is at the top of the file (lines 3-35).
+
+**old_string:**
+
+```go
+import (
+	"context"
+```
+
+If `"context"` is already present, skip the context insertion. If not, use this edit on the imports block:
+
+**old_string:**
+
+```go
+import (
+	"crypto/tls"
+```
+
+**new_string:**
+
+```go
+import (
+	"context"
+	"crypto/tls"
+```
+
+Then add the eventlog import. Find the existing `"github.com/breeze-rmm/agent/internal/logging"` line:
+
+**old_string:**
+
+```go
+	"github.com/breeze-rmm/agent/internal/logging"
+```
+
+**new_string:**
+
+```go
+	"github.com/breeze-rmm/agent/internal/eventlog"
+	"github.com/breeze-rmm/agent/internal/logging"
+```
+
+- [ ] **Step 4: Create the Windows-only seam file**
+
+Create `agent/cmd/breeze-agent/service_seams_windows.go`:
+
+```go
+//go:build windows
+
+package main
+
+import "golang.org/x/sys/windows/svc"
+
+// runServiceLoopFn is the package-level test seam for the post-startup
+// SCM control loop. Production assigns it to runServiceLoop (defined
+// in service_windows.go); tests in service_windows_test.go override
+// it to skip the real loop (which would dereference comps.hb and
+// comps.wsClient in shutdownAgent).
+var runServiceLoopFn func(
+	comps *agentComponents,
+	r <-chan svc.ChangeRequest,
+	changes chan<- svc.Status,
+) (bool, uint32) = runServiceLoop
+```
+
+Note: `runServiceLoop` does not yet exist — it will be extracted from `service_windows.go` in Task 8. This file will fail to compile on Windows until Task 8 lands. That's expected — this task and Task 8 will compile together. The macOS/Linux build is unaffected because the file has a Windows build tag.
+
+- [ ] **Step 5: Verify the non-Windows build still works**
+
+Run from `agent/`:
+
+```bash
+GOOS=darwin  GOARCH=amd64 go build ./cmd/breeze-agent/...
+GOOS=linux   GOARCH=amd64 go build ./cmd/breeze-agent/...
+```
+
+Expected: both exit 0.
+
+The Windows build will FAIL at this point because `runServiceLoop` is undefined — the Windows side is completed in Task 8. This is expected and explicit.
+
+```bash
+GOOS=windows GOARCH=amd64 go build ./cmd/breeze-agent/... 2>&1 || echo "expected failure — Task 8 adds runServiceLoop"
+```
+
+Expected: failure with `undefined: runServiceLoop`, followed by the "expected failure" echo.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add agent/cmd/breeze-agent/main.go agent/cmd/breeze-agent/service_seams_windows.go
+git commit -m "$(cat <<'EOF'
+feat(agent): add waitForEnrollment, bootstrap logging, and test seams
+
+Adds three pieces needed by the MSI enrollment failure work:
+- waitForEnrollment(ctx, cfgFile) polls config.Load every
+  waitForEnrollmentPollInterval until config.IsEnrolled returns true,
+  then returns the enrolled config. Context cancellation returns nil
+  cleanly (no goroutine leaks in tests).
+- initBootstrapLogging(cfg) wires up stderr + rotating file writers
+  so the wait loop can emit Warn/Info lines before the full startAgent
+  pipeline runs.
+- Package-level function vars startAgentFn / waitForEnrollmentFn /
+  runServiceLoopFn act as test seams so Windows service tests can
+  observe Execute's state-transition ordering without constructing
+  real heartbeat/websocket fixtures. runServiceLoopFn lives in a
+  Windows-only file because its signature references svc.ChangeRequest.
+
+Windows build intentionally fails until Task 8 extracts runServiceLoop
+from service_windows.go. Non-Windows builds compile cleanly.
+
+Issue #411.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: `waitForEnrollment` tests in `main_test.go`
+
+**Context for engineer:** Three tests exercise the helper from Task 6. All three use `waitForEnrollmentPollInterval = 10 * time.Millisecond` (reset via `t.Cleanup`) so they finish in under a second instead of waiting 10s. The tests write config files to a `t.TempDir()` and point `cfgFile` at them.
+
+**Files:**
+- Modify: `agent/cmd/breeze-agent/main_test.go` (create if absent)
+
+- [ ] **Step 1: Check whether main_test.go exists**
+
+```bash
+ls agent/cmd/breeze-agent/main_test.go
+```
+
+If absent, the test file will be created from scratch. If present, append the three new tests.
+
+- [ ] **Step 2: Write the three tests**
+
+If `main_test.go` exists, add the three test functions plus any missing imports. If not, create the file with this content:
+
+```go
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeEnrolledConfig writes a minimal agent.yaml + secrets.yaml pair
+// that config.Load will parse into a config with both AgentID and
+// AuthToken set (IsEnrolled returns true).
+func writeEnrolledConfig(t *testing.T, dir string) string {
+	t.Helper()
+	agentPath := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(agentPath, []byte("agent_id: test-agent-id\nserver_url: https://test.example\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	secretsPath := filepath.Join(dir, "secrets.yaml")
+	if err := os.WriteFile(secretsPath, []byte("auth_token: test-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return agentPath
+}
+
+// writeTornConfig writes only agent.yaml (with AgentID) but no secrets
+// file, simulating the race window where SaveTo has flushed agent.yaml
+// but not yet written secrets.yaml.
+func writeTornConfig(t *testing.T, dir string) string {
+	t.Helper()
+	agentPath := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(agentPath, []byte("agent_id: test-agent-id\nserver_url: https://test.example\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return agentPath
+}
+
+func TestWaitForEnrollment_UnblocksWhenConfigBecomesValid(t *testing.T) {
+	origInterval := waitForEnrollmentPollInterval
+	waitForEnrollmentPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { waitForEnrollmentPollInterval = origInterval })
+
+	dir := t.TempDir()
+	agentPath := filepath.Join(dir, "agent.yaml")
+
+	// Start with no config file at all.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan *config.Config, 1)
+	go func() {
+		done <- waitForEnrollment(ctx, agentPath)
+	}()
+
+	// Write a valid enrolled config after 50ms.
+	time.Sleep(50 * time.Millisecond)
+	_ = writeEnrolledConfig(t, dir)
+
+	select {
+	case cfg := <-done:
+		if cfg == nil {
+			t.Fatal("waitForEnrollment returned nil; expected enrolled config")
+		}
+		if cfg.AgentID != "test-agent-id" {
+			t.Errorf("AgentID = %q, want test-agent-id", cfg.AgentID)
+		}
+	case <-time.After(1500 * time.Millisecond):
+		t.Fatal("waitForEnrollment did not return within 1.5s")
+	}
+}
+
+func TestWaitForEnrollment_RespectsContextCancel(t *testing.T) {
+	origInterval := waitForEnrollmentPollInterval
+	waitForEnrollmentPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { waitForEnrollmentPollInterval = origInterval })
+
+	dir := t.TempDir()
+	agentPath := filepath.Join(dir, "does-not-exist.yaml")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan *config.Config, 1)
+	go func() {
+		done <- waitForEnrollment(ctx, agentPath)
+	}()
+
+	// Cancel after 30ms — waitForEnrollment should return nil within
+	// another 30ms (next ticker fire).
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+
+	select {
+	case cfg := <-done:
+		if cfg != nil {
+			t.Errorf("expected nil on ctx cancel, got %+v", cfg)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("waitForEnrollment did not return within 500ms of cancel")
+	}
+}
+
+func TestWaitForEnrollment_IgnoresTornWrite(t *testing.T) {
+	origInterval := waitForEnrollmentPollInterval
+	waitForEnrollmentPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { waitForEnrollmentPollInterval = origInterval })
+
+	dir := t.TempDir()
+	// Write only agent.yaml — no secrets file (torn SaveTo state).
+	agentPath := writeTornConfig(t, dir)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	done := make(chan *config.Config, 1)
+	go func() {
+		done <- waitForEnrollment(ctx, agentPath)
+	}()
+
+	// Verify it stays blocked for 100ms (IsEnrolled returns false on torn state).
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case cfg := <-done:
+		t.Fatalf("waitForEnrollment returned %+v on torn write; must stay blocked until secrets.yaml lands", cfg)
+	default:
+	}
+
+	// Now write secrets.yaml — waitForEnrollment should unblock on the next tick.
+	secretsPath := filepath.Join(dir, "secrets.yaml")
+	if err := os.WriteFile(secretsPath, []byte("auth_token: test-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case cfg := <-done:
+		if cfg == nil {
+			t.Fatal("expected enrolled config, got nil")
+		}
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("waitForEnrollment did not unblock after secrets.yaml was written")
+	}
+}
+```
+
+If the file already exists, also import the `config` package if it's not already imported.
+
+**Note:** the existing `main_test.go` (if present) may declare `package main` in a different ordering. Harmonize imports so both `context` and the `config` package are available.
+
+- [ ] **Step 3: Run the new tests**
+
+Run from `agent/`:
+
+```bash
+go test ./cmd/breeze-agent/... -run 'TestWaitForEnrollment' -v
+```
+
+Expected: PASS on all three tests within ~3 seconds total.
+
+- [ ] **Step 4: Run with `-race` to catch any races**
+
+```bash
+go test ./cmd/breeze-agent/... -run 'TestWaitForEnrollment' -race -v
+```
+
+Expected: PASS with no race warnings. The `waitForEnrollmentPollInterval` package var is written once per test inside `t.Cleanup`, which serializes with other tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/cmd/breeze-agent/main_test.go
+git commit -m "$(cat <<'EOF'
+test(agent): waitForEnrollment — unblock, cancel, torn-write coverage
+
+TestWaitForEnrollment_UnblocksWhenConfigBecomesValid verifies the
+loop returns the enrolled config when agent.yaml + secrets.yaml appear
+mid-wait. TestWaitForEnrollment_RespectsContextCancel verifies
+context.Cancel unblocks the loop with a nil return (no goroutine
+leak). TestWaitForEnrollment_IgnoresTornWrite verifies IsEnrolled
+prevents the wait loop from unblocking on a state where only agent.yaml
+has been flushed but secrets.yaml hasn't — exactly the race that
+config.SaveTo can produce between its two file writes.
+
+All three use waitForEnrollmentPollInterval = 10ms so they finish in
+under a second instead of 10+ seconds.
+
+Issue #411.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Split `startAgent`, extract `runServiceLoop`, rewrite Windows `Execute`
+
+**Context for engineer:** This is the biggest task. Three tightly-coupled changes in one commit:
+
+1. Change `startAgent()` (no args) → `startAgent(cfg *config.Config) (*agentComponents, error)`. Remove the enrollment check at lines 230-240; callers now supply an already-enrolled config.
+2. Extract the post-startup `for { select { r } }` block from `service_windows.go:135-163` into a standalone `runServiceLoop(comps, r, changes) (bool, uint32)` function that also handles the `shutdownAgent(comps)` call on Stop.
+3. Rewrite `breezeService.Execute` to: load config synchronously, call `initBootstrapLogging`, branch on `config.IsEnrolled(cfg)`, and either run the synchronous enrolled path (preserving today's failure semantics) or the async unenrolled path (signal Running early, `waitForEnrollmentFn`, then `startAgentFn`).
+
+Also change `runAsService`'s signature from `runAsService(startFn func() (*agentComponents, error))` to `runAsService(cfgFile string)`.
+
+**Files:**
+- Modify: `agent/cmd/breeze-agent/main.go:224-241` (startAgent signature change)
+- Modify: `agent/cmd/breeze-agent/service_windows.go:100-165` (full rewrite of runAsService + Execute + extract runServiceLoop)
+
+- [ ] **Step 1: Change `startAgent` signature**
+
+Use `Edit` on `agent/cmd/breeze-agent/main.go` around line 224-241.
+
+**old_string:**
+
+```go
+// startAgent performs all agent initialisation and returns the running
+// components. It is used by both the console-mode runAgent and the Windows
+// SCM service wrapper so the startup logic lives in one place.
+func startAgent() (*agentComponents, error) {
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if cfg.AgentID == "" {
+		// Check for pending enrollment from a failed MSI install
+		if tryPendingEnrollment() {
+			cfg, err = config.Load(cfgFile)
+			if err != nil {
+				return nil, fmt.Errorf("failed to reload config after pending enrollment: %w", err)
+			}
+		}
+		if cfg.AgentID == "" {
+			return nil, fmt.Errorf("agent not enrolled — run 'breeze-agent enroll <key>' first")
+		}
+	}
+```
+
+**new_string:**
+
+```go
+// startAgent performs all agent initialisation assuming cfg is already
+// enrolled. Returns the running components or an error if any
+// initialization step fails (mTLS load, log shipper init, heartbeat
+// bring-up, etc.). Callers (runAgent on console/Unix, the Windows
+// service wrapper) MUST check config.IsEnrolled first and call
+// waitForEnrollment if needed — this function no longer performs the
+// enrollment check itself.
+func startAgent(cfg *config.Config) (*agentComponents, error) {
+	if !config.IsEnrolled(cfg) {
+		return nil, fmt.Errorf("startAgent called with unenrolled config — caller must waitForEnrollment first")
+	}
+```
+
+Note that the `cfg, err := config.Load(cfgFile)` line is gone — the caller loads the config and passes it in. The downstream code inside `startAgent` that used `cfg` continues to work.
+
+- [ ] **Step 2: Update the only other caller of `startAgent` — `runAgent`'s console-mode path**
+
+The console-mode path currently calls `startAgent()` at main.go:467. Update it to load config, check IsEnrolled, optionally wait, then call `startAgentFn(cfg)`. Also wire `signal.NotifyContext` for cancel-on-SIGTERM.
+
+Grep for context:
+
+```bash
+grep -n 'func runAgent\|isWindowsService()\|runAsService(startAgent)\|comps, err := startAgent' agent/cmd/breeze-agent/main.go
+```
+
+**old_string:**
+
+```go
+func runAgent() {
+	// Self-heal launchd plists on macOS (fixes KeepAlive config from older installs).
+	healLaunchdPlistsIfNeeded()
+
+	// On Windows, if launched by the SCM, run under the service framework
+	// so we report Running/Stopped status back to the SCM correctly.
+	if isWindowsService() {
+		if err := runAsService(startAgent); err != nil {
+			log.Error("service failed", "error", err.Error())
+			os.Exit(1)
+		}
+		return
+	}
+
+	// Console mode — start components and wait for OS signal.
+	comps, err := startAgent()
+	if err != nil {
+```
+
+**new_string:**
+
+```go
+func runAgent() {
+	// Self-heal launchd plists on macOS (fixes KeepAlive config from older installs).
+	healLaunchdPlistsIfNeeded()
+
+	// On Windows, if launched by the SCM, run under the service framework
+	// so we report Running/Stopped status back to the SCM correctly. The
+	// service wrapper owns its own config loading, enrollment check, and
+	// cancellation via the SCM request channel.
+	if isWindowsService() {
+		if err := runAsService(cfgFile); err != nil {
+			log.Error("service failed", "error", err.Error())
+			os.Exit(1)
+		}
+		return
+	}
+
+	// Console / Unix service-manager mode. Load config, prepare bootstrap
+	// logging, and wait for enrollment if needed. signal.NotifyContext
+	// wires SIGINT/SIGTERM to ctx so Ctrl+C in a terminal and
+	// `systemctl stop` / `launchctl kickstart -k` all cancel any active
+	// wait cleanly.
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load config: %v\n", err)
+		os.Exit(1)
+	}
+	initBootstrapLogging(cfg)
+
+	ctx, stop := signal.NotifyContext(context.Background(),
+		os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if !config.IsEnrolled(cfg) {
+		cfg = waitForEnrollmentFn(ctx, cfgFile)
+		if cfg == nil {
+			log.Info("agent shutting down without enrollment",
+				"reason", ctx.Err().Error())
+			return
+		}
+	}
+
+	comps, err := startAgentFn(cfg)
+	if err != nil {
+```
+
+- [ ] **Step 3: Update the existing SIGINT-ignore + SIGTERM block**
+
+The current block right after the error handling uses a separate `sigChan` and ignores SIGINT. With `signal.NotifyContext` wired in, the ctx already covers SIGTERM. Replace the bottom half of runAgent to use ctx.
+
+Grep for context:
+
+```bash
+grep -n 'signal.Ignore(syscall.SIGINT)\|sigChan := make(chan os.Signal' agent/cmd/breeze-agent/main.go
+```
+
+**old_string:**
+
+```go
+	defer logging.StopShipper()
+
+	// Ignore SIGINT — as a daemon, PTY child processes can propagate
+	// SIGINT to our process group via Ctrl+C. Only SIGTERM should trigger shutdown.
+	signal.Ignore(syscall.SIGINT)
+
+	// Wait for shutdown signal
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGTERM)
+
+	<-sigChan
+	log.Info("shutting down agent")
+
+	shutdownAgent(comps)
+	log.Info("agent stopped")
+}
+```
+
+**new_string:**
+
+```go
+	defer logging.StopShipper()
+
+	// Wait for ctx to be cancelled — SIGINT or SIGTERM via
+	// signal.NotifyContext. For daemonized agents we'd normally ignore
+	// SIGINT (PTY child processes can propagate it via Ctrl+C), but
+	// console-mode breeze-agent is interactive and SIGINT should
+	// shutdown cleanly just like SIGTERM.
+	<-ctx.Done()
+	log.Info("shutting down agent", "reason", ctx.Err().Error())
+
+	shutdownAgent(comps)
+	log.Info("agent stopped")
+}
+```
+
+**Note:** the behavior change here is that console-mode breeze-agent now handles SIGINT as a shutdown signal instead of ignoring it. This is intentional — the old SIGINT-ignore behavior was defensive against PTY child processes on Unix daemons, but console mode is not daemonized and Ctrl+C should mean "stop the agent." The Windows service path is unaffected (SCM signals come via the request channel, not Unix signals).
+
+- [ ] **Step 4: Rewrite `service_windows.go` `runAsService` and `Execute`**
+
+Edit `agent/cmd/breeze-agent/service_windows.go`. This is a substantial rewrite of lines 100-165.
+
+**old_string:**
+
+```go
+// breezeService implements svc.Handler for the Windows SCM.
+type breezeService struct {
+	startFn  func() (*agentComponents, error)
+	stopOnce sync.Once
+	stopCh   chan struct{}
+}
+
+// runAsService runs the agent under the Windows Service Control Manager.
+// startFn is called once the SCM has accepted the service start; it must
+// return the running components so they can be shut down on SCM stop.
+func runAsService(startFn func() (*agentComponents, error)) error {
+	h := &breezeService{
+		startFn: startFn,
+		stopCh:  make(chan struct{}),
+	}
+	return svc.Run("BreezeAgent", h)
+}
+
+// Execute is the SCM callback. It signals StartPending, runs startFn
+// synchronously, then signals Running and enters the SCM control loop.
+// SCM requires services to report Running via the changes channel within
+// its start timeout, so startFn itself must not block — any long-running
+// initialisation (e.g. hardware collection) must be backgrounded by the
+// caller before Execute is reached.
+func (s *breezeService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
+	const accepted = svc.AcceptStop | svc.AcceptShutdown | svc.AcceptSessionChange
+
+	changes <- svc.Status{State: svc.StartPending}
+
+	comps, err := s.startFn()
+	if err != nil {
+		log.Error("agent start failed", "error", err.Error())
+		writeStartupFailureMarker(err)
+		changes <- svc.Status{State: svc.StopPending}
+		return true, 1
+	}
+
+	scmCh := comps.hb.SCMSessionCh()
+
+	changes <- svc.Status{State: svc.Running, Accepts: accepted}
+	log.Info("agent running as Windows service")
+
+	for {
+		select {
+		case cr := <-r:
+			switch cr.Cmd {
+			case svc.Interrogate:
+				changes <- cr.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				log.Info("SCM requested stop")
+				changes <- svc.Status{State: svc.StopPending}
+				shutdownAgent(comps)
+				return false, 0
+			case svc.SessionChange:
+				if scmCh != nil {
+					sessionID := extractSessionID(cr.EventData)
+					select {
+					case scmCh <- sessionbroker.SCMSessionEvent{
+						EventType: cr.EventType,
+						SessionID: sessionID,
+					}:
+					default:
+						// Channel full — lifecycle manager will catch up
+						// on the next reconcile tick.
+					}
+				}
+			default:
+				log.Warn(fmt.Sprintf("unexpected SCM control request #%d", cr.Cmd))
+			}
+		}
+	}
+}
+```
+
+**new_string:**
+
+```go
+// breezeService implements svc.Handler for the Windows SCM.
+type breezeService struct {
+	cfgFile  string
+	stopOnce sync.Once
+	stopCh   chan struct{}
+}
+
+// runAsService runs the agent under the Windows Service Control Manager.
+// It takes the cfgFile path instead of a startFn closure so Execute can
+// load config synchronously and decide whether to use the enrolled
+// (synchronous) or unenrolled (async-after-Running) start path.
+func runAsService(cfgFile string) error {
+	h := &breezeService{
+		cfgFile: cfgFile,
+		stopCh:  make(chan struct{}),
+	}
+	return svc.Run("BreezeAgent", h)
+}
+
+// Execute is the SCM callback. It loads config synchronously, then
+// splits on config.IsEnrolled:
+//
+//   - Enrolled: run startAgent synchronously (preserves today's
+//     "post-enroll mTLS/heartbeat init failures fail the install"
+//     guarantee — Decision 6 from the spec).
+//   - Unenrolled: signal Running immediately (SCM start deadline
+//     would otherwise kill us while waitForEnrollment blocks), then
+//     wait for enrollment while staying responsive to Stop/Shutdown,
+//     then run startAgent. Failures here are post-install and stop
+//     the service but cannot roll back the MSI.
+//
+// Both branches converge on runServiceLoopFn for the steady-state SCM
+// control loop. runServiceLoopFn is a test seam — production assigns
+// it to runServiceLoop at package init.
+func (s *breezeService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
+	const accepted = svc.AcceptStop | svc.AcceptShutdown | svc.AcceptSessionChange
+
+	changes <- svc.Status{State: svc.StartPending}
+
+	cfg, err := config.Load(s.cfgFile)
+	if err != nil {
+		log.Error("failed to load config", "error", err.Error())
+		writeStartupFailureMarker(err)
+		changes <- svc.Status{State: svc.StopPending}
+		return true, 1
+	}
+	initBootstrapLogging(cfg)
+
+	if config.IsEnrolled(cfg) {
+		// --- Synchronous enrolled path (today's behaviour) ---
+		// startAgentFn is a package-level test seam defaulting to
+		// startAgent. Any failure here (mTLS, heartbeat, log shipper,
+		// state file) reaches SCM as a start failure, which the MSI
+		// installer promotes to Error 1920 → 1603 rollback.
+		comps, err := startAgentFn(cfg)
+		if err != nil {
+			log.Error("agent start failed", "error", err.Error())
+			writeStartupFailureMarker(err)
+			changes <- svc.Status{State: svc.StopPending}
+			return true, 1
+		}
+		changes <- svc.Status{State: svc.Running, Accepts: accepted}
+		log.Info("agent running as Windows service")
+		return runServiceLoopFn(comps, r, changes)
+	}
+
+	// --- Async unenrolled path (MSI install with no creds) ---
+	// SCM MUST see Running before we block in waitForEnrollmentFn or
+	// the service start deadline (~30s) will kill the process.
+	changes <- svc.Status{State: svc.Running, Accepts: accepted}
+	log.Info("agent running as Windows service (waiting for enrollment)")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	enrolledCh := make(chan *config.Config, 1)
+	go func() {
+		enrolledCh <- waitForEnrollmentFn(ctx, s.cfgFile)
+	}()
+
+	// Stay responsive to SCM control requests while waiting. Drop
+	// session change events — we have no heartbeat wired up yet, and
+	// the session broker's reconciliation loop will catch up once
+	// startAgent completes.
+	var enrolledCfg *config.Config
+waitLoop:
+	for {
+		select {
+		case cfg := <-enrolledCh:
+			enrolledCfg = cfg
+			break waitLoop
+		case cr := <-r:
+			switch cr.Cmd {
+			case svc.Interrogate:
+				changes <- cr.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				log.Info("SCM stop while waiting for enrollment")
+				cancel()
+				changes <- svc.Status{State: svc.StopPending}
+				return false, 0
+			}
+			// svc.SessionChange: ignore. No comps yet.
+		}
+	}
+
+	if enrolledCfg == nil {
+		// ctx cancelled without enrollment; handled above.
+		return false, 0
+	}
+
+	// Run the real startup pipeline. Failures here are post-install
+	// and cannot roll back the MSI — we log, write the failure marker,
+	// and stop the service.
+	comps, err := startAgentFn(enrolledCfg)
+	if err != nil {
+		log.Error("agent start failed after deferred enrollment",
+			"error", err.Error())
+		writeStartupFailureMarker(err)
+		changes <- svc.Status{State: svc.StopPending}
+		return true, 1
+	}
+	return runServiceLoopFn(comps, r, changes)
+}
+
+// runServiceLoop is the post-startup SCM control loop shared by both
+// Execute branches. It handles Interrogate, Stop, Shutdown, and
+// SessionChange requests, and calls shutdownAgent(comps) on stop.
+// Extracted from the old Execute body so the enrolled and unenrolled
+// paths can share it.
+func runServiceLoop(comps *agentComponents, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
+	scmCh := comps.hb.SCMSessionCh()
+
+	for cr := range r {
+		switch cr.Cmd {
+		case svc.Interrogate:
+			changes <- cr.CurrentStatus
+		case svc.Stop, svc.Shutdown:
+			log.Info("SCM requested stop")
+			changes <- svc.Status{State: svc.StopPending}
+			shutdownAgent(comps)
+			return false, 0
+		case svc.SessionChange:
+			if scmCh != nil {
+				sessionID := extractSessionID(cr.EventData)
+				select {
+				case scmCh <- sessionbroker.SCMSessionEvent{
+					EventType: cr.EventType,
+					SessionID: sessionID,
+				}:
+				default:
+					// Channel full — lifecycle manager will catch up
+					// on the next reconcile tick.
+				}
+			}
+		default:
+			log.Warn(fmt.Sprintf("unexpected SCM control request #%d", cr.Cmd))
+		}
+	}
+	return false, 0
+}
+```
+
+- [ ] **Step 5: Add `context` and `config` imports to `service_windows.go`**
+
+Grep for existing imports:
+
+```bash
+grep -n '"context"\|"github.com/breeze-rmm/agent/internal/config"' agent/cmd/breeze-agent/service_windows.go
+```
+
+If missing, add to the import block. The current imports at lines 5-19 already include `"github.com/breeze-rmm/agent/internal/config"` — verify before editing.
+
+- [ ] **Step 6: Cross-compile for all three platforms**
+
+Run from `agent/`:
+
+```bash
+GOOS=windows GOARCH=amd64 go build ./cmd/breeze-agent/...
+GOOS=darwin  GOARCH=amd64 go build ./cmd/breeze-agent/...
+GOOS=linux   GOARCH=amd64 go build ./cmd/breeze-agent/...
+```
+
+Expected: all three exit 0 with no output. If the Windows build fails with `undefined: runServiceLoop`, verify Task 6's `service_seams_windows.go` references `runServiceLoop` by the same name as defined in this task.
+
+- [ ] **Step 7: Run the full cmd/breeze-agent test suite**
+
+```bash
+go test ./cmd/breeze-agent/... -race
+```
+
+Expected: all tests pass on the current host platform (macOS). Windows-gated tests (service_windows_test.go) don't exist yet — they come in Task 9.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add agent/cmd/breeze-agent/main.go agent/cmd/breeze-agent/service_windows.go
+git commit -m "$(cat <<'EOF'
+refactor(agent): split startAgent; service wrapper forks on IsEnrolled
+
+startAgent now takes an already-enrolled *config.Config and fails
+fast if the caller supplied an unenrolled one. The enrollment check
++ error return that lived at the top of startAgent is gone; callers
+are responsible for checking IsEnrolled and waiting if needed.
+
+runAgent (console / Unix service path) loads config, calls
+initBootstrapLogging, wires signal.NotifyContext to SIGINT/SIGTERM,
+and waits for enrollment via waitForEnrollmentFn when needed before
+calling startAgentFn.
+
+runAsService now takes cfgFile instead of a startFn closure.
+Execute splits into two branches:
+
+ - Enrolled: synchronous startAgentFn, Running signaled after success.
+   Preserves today's "post-enroll init failure fails the MSI install"
+   guarantee (spec decision 6).
+
+ - Unenrolled: Running signaled immediately (SCM start deadline),
+   then waitForEnrollmentFn in a goroutine while the main Execute
+   stays responsive to Stop/Shutdown, then startAgentFn. Failures
+   on this path stop the service but cannot roll back the MSI.
+
+Both branches converge on runServiceLoop(comps, r, changes) — the
+post-startup SCM control loop extracted from the old Execute body
+into its own function.
+
+Behaviour change: console-mode breeze-agent now treats SIGINT as
+shutdown instead of ignoring it. The Windows service is unaffected
+(SCM signals arrive via the request channel).
+
+Issue #411.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Windows service tests
+
+**Context for engineer:** These tests only run with `GOOS=windows`, but the implementer may write them on macOS/Linux and verify compilation via `GOOS=windows go build ./cmd/breeze-agent/...`. The three tests exercise the enrolled path, the unenrolled path, and the stop-while-waiting path using `installServiceStubs(t)` — a shared helper that swaps `startAgentFn`, `waitForEnrollmentFn`, and `runServiceLoopFn` with stubs that record call ordering into an events channel. The stubbed `runServiceLoopFn` returns on the first Stop request so tests can cleanly terminate `Execute`.
+
+**Files:**
+- Create: `agent/cmd/breeze-agent/service_windows_test.go`
+
+- [ ] **Step 1: Create the test file**
+
+Create `agent/cmd/breeze-agent/service_windows_test.go`:
+
+```go
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/config"
+	"golang.org/x/sys/windows/svc"
+)
+
+// installServiceStubs wires all three Execute test seams to stubs that
+// record call ordering into events. Returns a release() func that
+// unblocks any stub waiting on releaseCh (used by the unenrolled-path
+// tests). Registers t.Cleanup to restore originals.
+func installServiceStubs(t *testing.T) (events chan string, release func()) {
+	t.Helper()
+	origStart := startAgentFn
+	origWait := waitForEnrollmentFn
+	origLoop := runServiceLoopFn
+	t.Cleanup(func() {
+		startAgentFn = origStart
+		waitForEnrollmentFn = origWait
+		runServiceLoopFn = origLoop
+	})
+
+	events = make(chan string, 16)
+	releaseCh := make(chan struct{})
+	release = func() { close(releaseCh) }
+
+	startAgentFn = func(cfg *config.Config) (*agentComponents, error) {
+		events <- "startAgent"
+		return &agentComponents{}, nil // zero-value; runServiceLoopFn never dereferences
+	}
+	waitForEnrollmentFn = func(ctx context.Context, cfgFile string) *config.Config {
+		events <- "waitForEnrollment.enter"
+		select {
+		case <-releaseCh:
+			events <- "waitForEnrollment.release"
+			cfg, _ := config.Load(cfgFile)
+			return cfg
+		case <-ctx.Done():
+			events <- "waitForEnrollment.cancelled"
+			return nil
+		}
+	}
+	runServiceLoopFn = func(comps *agentComponents, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
+		events <- "runServiceLoop"
+		for cr := range r {
+			if cr.Cmd == svc.Stop || cr.Cmd == svc.Shutdown {
+				changes <- svc.Status{State: svc.StopPending}
+				return false, 0
+			}
+		}
+		return false, 0
+	}
+	return events, release
+}
+
+// writeEnrolledConfigFile writes agent.yaml + secrets.yaml that
+// config.Load + IsEnrolled will accept as enrolled. Returns the
+// agent.yaml path.
+func writeEnrolledConfigFile(t *testing.T, dir string) string {
+	t.Helper()
+	agentPath := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(agentPath, []byte("agent_id: test-agent-id\nserver_url: https://test.example\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	secretsPath := filepath.Join(dir, "secrets.yaml")
+	if err := os.WriteFile(secretsPath, []byte("auth_token: test-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return agentPath
+}
+
+// writeUnenrolledConfigFile writes an empty agent.yaml (no AgentID,
+// no AuthToken) so config.Load succeeds but IsEnrolled returns false.
+func writeUnenrolledConfigFile(t *testing.T, dir string) string {
+	t.Helper()
+	agentPath := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(agentPath, []byte("server_url: https://test.example\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return agentPath
+}
+
+// execResult captures the return values from breezeService.Execute for
+// goroutine-based tests.
+type execResult struct {
+	ssec      bool
+	errno     uint32
+	changes   []svc.Status
+	changesMu *atomic.Int32
+}
+
+// runExecuteInGoroutine starts Execute in a goroutine with mock changes
+// and request channels. Returns channels the test can drive.
+func runExecuteInGoroutine(t *testing.T, s *breezeService) (changes chan svc.Status, requests chan svc.ChangeRequest, done chan struct{}) {
+	t.Helper()
+	changes = make(chan svc.Status, 16)
+	requests = make(chan svc.ChangeRequest, 4)
+	done = make(chan struct{})
+	go func() {
+		defer close(done)
+		s.Execute(nil, requests, changes)
+	}()
+	return
+}
+
+func TestExecute_EnrolledPath_SignalsRunningAfterStartFn(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := writeEnrolledConfigFile(t, dir)
+
+	events, _ := installServiceStubs(t)
+	s := &breezeService{cfgFile: cfgFile, stopCh: make(chan struct{})}
+
+	changes, requests, done := runExecuteInGoroutine(t, s)
+
+	// Expected event sequence on enrolled path:
+	// 1. startAgent (from stubbed startAgentFn)
+	// 2. runServiceLoop (from stubbed runServiceLoopFn)
+	if got := <-events; got != "startAgent" {
+		t.Errorf("first event = %q, want startAgent", got)
+	}
+	if got := <-events; got != "runServiceLoop" {
+		t.Errorf("second event = %q, want runServiceLoop", got)
+	}
+
+	// Drain changes. Expected: StartPending, Running. The Running signal
+	// MUST arrive after the stubbed startAgentFn observed its call.
+	first := <-changes
+	if first.State != svc.StartPending {
+		t.Errorf("first state = %v, want StartPending", first.State)
+	}
+	second := <-changes
+	if second.State != svc.Running {
+		t.Errorf("second state = %v, want Running", second.State)
+	}
+
+	// Tell Execute to stop so the goroutine terminates.
+	requests <- svc.ChangeRequest{Cmd: svc.Stop}
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Execute did not return within 1s of Stop")
+	}
+}
+
+func TestExecute_UnenrolledPath_SignalsRunningBeforeWait(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := writeUnenrolledConfigFile(t, dir)
+
+	events, release := installServiceStubs(t)
+	s := &breezeService{cfgFile: cfgFile, stopCh: make(chan struct{})}
+
+	changes, requests, done := runExecuteInGoroutine(t, s)
+
+	// Expected: StartPending, Running before any waitForEnrollment.enter.
+	first := <-changes
+	if first.State != svc.StartPending {
+		t.Errorf("first state = %v, want StartPending", first.State)
+	}
+	second := <-changes
+	if second.State != svc.Running {
+		t.Errorf("second state = %v, want Running", second.State)
+	}
+
+	// Now the stub should record that it entered waitForEnrollment.
+	if got := <-events; got != "waitForEnrollment.enter" {
+		t.Errorf("first event = %q, want waitForEnrollment.enter", got)
+	}
+
+	// Upgrade the on-disk config to enrolled, then release the stub
+	// so the post-wait branch runs startAgentFn.
+	_ = writeEnrolledConfigFile(t, dir)
+	release()
+
+	// Expected remaining event sequence: release, startAgent, runServiceLoop.
+	if got := <-events; got != "waitForEnrollment.release" {
+		t.Errorf("event after release = %q, want waitForEnrollment.release", got)
+	}
+	if got := <-events; got != "startAgent" {
+		t.Errorf("event = %q, want startAgent", got)
+	}
+	if got := <-events; got != "runServiceLoop" {
+		t.Errorf("event = %q, want runServiceLoop", got)
+	}
+
+	// Terminate.
+	requests <- svc.ChangeRequest{Cmd: svc.Stop}
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Execute did not return within 1s of Stop")
+	}
+}
+
+func TestExecute_StopWhileWaiting(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := writeUnenrolledConfigFile(t, dir)
+
+	events, _ := installServiceStubs(t)
+	s := &breezeService{cfgFile: cfgFile, stopCh: make(chan struct{})}
+
+	changes, requests, done := runExecuteInGoroutine(t, s)
+
+	// Drain StartPending + Running.
+	<-changes
+	<-changes
+
+	// Wait until the stub has entered waitForEnrollment.
+	if got := <-events; got != "waitForEnrollment.enter" {
+		t.Errorf("event = %q, want waitForEnrollment.enter", got)
+	}
+
+	// Stop without releasing the stub. The stub's ctx.Done() branch
+	// should fire and the unenrolled path should cleanly return.
+	requests <- svc.ChangeRequest{Cmd: svc.Stop}
+
+	if got := <-events; got != "waitForEnrollment.cancelled" {
+		t.Errorf("event = %q, want waitForEnrollment.cancelled", got)
+	}
+
+	// Expect a StopPending signal.
+	select {
+	case state := <-changes:
+		if state.State != svc.StopPending {
+			t.Errorf("state = %v, want StopPending", state.State)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("no StopPending signal within 1s")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Execute did not return within 1s of Stop")
+	}
+}
+```
+
+- [ ] **Step 2: Verify the test file compiles for Windows**
+
+Run from `agent/`:
+
+```bash
+GOOS=windows GOARCH=amd64 go vet ./cmd/breeze-agent/...
+```
+
+Expected: exit 0. `go vet` will report any unused imports, type mismatches, or signature drift between the stubs and the production code.
+
+Also run:
+
+```bash
+GOOS=windows GOARCH=amd64 go test -c -o /dev/null ./cmd/breeze-agent/
+```
+
+Expected: exit 0. This compiles the Windows test binary to a throwaway file, which catches any issues that `go vet` misses (e.g., missing types).
+
+- [ ] **Step 3: Verify non-Windows builds are unaffected**
+
+```bash
+GOOS=darwin  GOARCH=amd64 go build ./cmd/breeze-agent/...
+GOOS=linux   GOARCH=amd64 go build ./cmd/breeze-agent/...
+```
+
+Expected: both exit 0. The test file has a `//go:build windows` tag so these builds ignore it entirely.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add agent/cmd/breeze-agent/service_windows_test.go
+git commit -m "$(cat <<'EOF'
+test(agent): Windows service wrapper state-transition coverage
+
+Three Windows-gated tests exercise breezeService.Execute on the
+enrolled path, the unenrolled path, and the stop-while-waiting path
+via a shared installServiceStubs(t) helper that swaps startAgentFn,
+waitForEnrollmentFn, and runServiceLoopFn with stubs that record
+call ordering into an events channel.
+
+Stubbed runServiceLoopFn returns on Stop so Execute can terminate
+cleanly; stubbed startAgentFn returns a zero-value *agentComponents
+that never gets dereferenced (bypassing shutdownAgent's comps.hb
+and comps.wsClient nil dereferences entirely).
+
+Proves spec decision 6: enrolled path signals Running AFTER
+startAgentFn; unenrolled path signals Running BEFORE waiting; Stop
+during wait cleanly cancels the ctx and returns.
+
+Tests run with go test on Windows only; verified compilable via
+GOOS=windows go test -c on macOS/Linux.
+
+Issue #411.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Update `breeze.wxs` — `EnrollAgent` CA `Return="check"`
+
+**Context for engineer:** The Go side is now safe: the unenrolled path starts a service that sits in a wait loop, and enrollment failures route through `enrollError` with exit codes 10-16. Now we make the MSI actually surface those failures by changing the EnrollAgent custom action from `Return="ignore"` to `Return="check"`. When creds are supplied and the Go binary exits non-zero, MSI will roll back the install cleanly.
+
+No changes to `<ServiceControl Start="install" Wait="yes" />` — the service still starts during install, and the wait-loop path makes that start succeed even without enrollment.
+
+**Files:**
+- Modify: `agent/installer/breeze.wxs` (find the `<CustomAction Id="EnrollAgent"` block around line 170)
+
+- [ ] **Step 1: Read the current EnrollAgent block**
+
+Run:
+
+```bash
+grep -n 'Id="EnrollAgent"\|Return="ignore"\|Return="check"' agent/installer/breeze.wxs
+```
+
+Expected: one line showing `Id="EnrollAgent"` and one showing `Return="ignore"` (currently).
+
+- [ ] **Step 2: Change `Return="ignore"` to `Return="check"` and update the comment**
+
+**old_string:**
+
+```xml
+    <CustomAction
+      Id="EnrollAgent"
+      FileRef="filBreezeAgentExe"
+      ExeCommand="enroll &quot;[ENROLLMENT_KEY]&quot; --server &quot;[SERVER_URL]&quot; --enrollment-secret &quot;[ENROLLMENT_SECRET]&quot; --quiet"
+      Execute="deferred"
+      Impersonate="no"
+      Return="ignore"
+      HideTarget="yes" />
+```
+
+**new_string:**
+
+```xml
+    <CustomAction
+      Id="EnrollAgent"
+      FileRef="filBreezeAgentExe"
+      ExeCommand="enroll &quot;[ENROLLMENT_KEY]&quot; --server &quot;[SERVER_URL]&quot; --enrollment-secret &quot;[ENROLLMENT_SECRET]&quot; --quiet"
+      Execute="deferred"
+      Impersonate="no"
+      Return="check"
+      HideTarget="yes" />
+```
+
+- [ ] **Step 3: Update the InstallExecuteSequence XML comment**
+
+Grep for the existing comment:
+
+```bash
+grep -n 'Return="ignore" on the EnrollAgent CA\|Enrollment runs after file copy' agent/installer/breeze.wxs
+```
+
+Replace with the new comment that describes the `Return="check"` semantics + the wait-loop deferred-enrollment path.
+
+**old_string:**
+
+```xml
+      <!-- Run enrollment after file copy but before InstallServices so the
+           BreezeAgent service starts with a valid agent.yaml already in
+           place; no restart dance required.
+
+           Return="ignore" on the EnrollAgent CA means enrollment failure
+           does NOT roll back the install. If enrollment fails, the service
+           will still start but the device stays unenrolled. To debug:
+           check %ProgramData%\Breeze\logs\agent.log for the structured
+           error trail, or re-run breeze-agent.exe enroll manually from an
+           elevated shell with the enrollment key and server flags. -->
+      <Custom Action="EnrollAgent" Before="InstallServices" Condition="NOT Installed AND SERVER_URL AND ENROLLMENT_KEY" />
+```
+
+**new_string:**
+
+```xml
+      <!-- Enrollment runs after file copy but before InstallServices.
+
+           Return="check" on the EnrollAgent CA means a non-zero exit
+           from breeze-agent.exe enroll rolls back the install cleanly.
+           Admins see a specific cause in four places:
+
+             1. install.log (captured from the CA's stderr)
+             2. C:\ProgramData\Breeze\logs\agent.log (slog structured)
+             3. C:\ProgramData\Breeze\logs\enroll-last-error.txt
+                (single-line timestamped, survives rollback because
+                CA-written files are opaque to MSI)
+             4. Event Viewer → Application → BreezeAgent (Error)
+
+           Installs without ENROLLMENT_KEY skip this CA entirely
+           (condition below requires both SERVER_URL and ENROLLMENT_KEY).
+           The service starts anyway and idles in a wait-for-enrollment
+           loop (see waitForEnrollment in cmd/breeze-agent/main.go), so
+           a later `breeze-agent enroll KEY --server URL` is picked up
+           live without a service restart. This is the intended flow
+           for imaged/sysprep'd deployments. -->
+      <Custom Action="EnrollAgent" Before="InstallServices" Condition="NOT Installed AND SERVER_URL AND ENROLLMENT_KEY" />
+```
+
+- [ ] **Step 4: Validate the WiX file syntax**
+
+If WiX is available in the environment, run:
+
+```bash
+# Optional — only if wix.exe / candle.exe are installed
+which wix 2>/dev/null && wix build --help >/dev/null
+```
+
+If WiX isn't available locally (macOS/Linux dev environment), rely on the CI pipeline that #410 already runs to catch XML errors. This task's change is a two-character attribute edit and a comment rewrite — low risk of WiX syntax breakage.
+
+Verify the XML still parses as well-formed:
+
+```bash
+xmllint --noout agent/installer/breeze.wxs
+```
+
+Expected: exit 0 with no output. If `xmllint` isn't installed, skip this step — manual smoke testing in Task 11 will catch any breakage.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/installer/breeze.wxs
+git commit -m "$(cat <<'EOF'
+fix(installer): EnrollAgent CA Return=check — surface enroll failures
+
+Previously Return="ignore" swallowed the Go enroll binary's non-zero
+exit codes. A bad ENROLLMENT_KEY typo would cause the CA to silently
+fail, then InstallServices would try to start BreezeAgent with an
+unenrolled config, the service would exit with an error, SCM would
+report Error 1920, and Vital="yes" on ServiceInstall would roll back
+the whole install with exit 1603. Admins saw "Error 1603" in the
+install log and nothing else.
+
+Return="check" makes the CA's exit code fatal to the install, and
+the Go enroll binary now writes a human-readable cause to four sinks
+before exiting. Admins can find the actual cause without guessing.
+
+Installs without ENROLLMENT_KEY skip the CA entirely thanks to the
+pre-existing condition; the Go side's waitForEnrollment loop means
+the service still starts and waits for a later `breeze-agent enroll`
+call (needed for imaged/sysprep deployments).
+
+Issue #411.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Final verification — full test suite + cross-compile
+
+**Context for engineer:** This is a verification-only task. No code changes. Confirm the whole agent package still builds and tests pass on all three platforms before handing off for manual MSI smoke testing.
+
+- [ ] **Step 1: Full test suite with race detection**
+
+Run from `agent/`:
+
+```bash
+go test -race ./...
+```
+
+Expected: PASS on all packages. If any test fails, the engineer must stop and debug before proceeding.
+
+- [ ] **Step 2: Cross-compile for all three platforms**
+
+```bash
+GOOS=windows GOARCH=amd64 go build ./cmd/breeze-agent/...
+GOOS=darwin  GOARCH=amd64 go build ./cmd/breeze-agent/...
+GOOS=darwin  GOARCH=arm64 go build ./cmd/breeze-agent/...
+GOOS=linux   GOARCH=amd64 go build ./cmd/breeze-agent/...
+```
+
+Expected: all four exit 0 with no output.
+
+- [ ] **Step 3: `go vet` on the whole tree**
+
+```bash
+go vet ./...
+```
+
+Expected: exit 0 with no output.
+
+- [ ] **Step 4: Windows test compilation check**
+
+```bash
+GOOS=windows GOARCH=amd64 go test -c -o /dev/null ./cmd/breeze-agent/
+```
+
+Expected: exit 0. Confirms service_windows_test.go compiles for Windows.
+
+- [ ] **Step 5: No commit needed — this is a verification pass**
+
+If all four steps pass, move to Task 12. If any fail, roll back to Task 10 and debug.
+
+---
+
+## Task 12: Manual MSI smoke test checklist
+
+**Context for engineer:** The automated tests cover the Go side end-to-end, but the MSI rollback semantics require a real Windows VM. This task is a manual checklist, not an automated task. Run each scenario on a fresh Windows Server 2022 VM (or a throwaway Win11 VM). Build the MSI from the current branch using the existing `build-msi.ps1` script.
+
+Building the MSI is OUT of scope for this plan — #412 is the follow-up to automate signed-MSI builds in CI without cutting a full release. For now, the engineer runs `.github/workflows/release.yml` manually or uses the existing signing pipeline.
+
+- [ ] **Step 1: Build an unsigned MSI for local testing**
+
+On a Windows build host with WiX 4.0.5 and Go 1.25.x installed:
+
+```powershell
+cd agent
+go build -o breeze-agent-windows-amd64.exe .\cmd\breeze-agent\
+go build -o breeze-backup-windows-amd64.exe .\cmd\breeze-backup\
+go build -o breeze-watchdog-windows-amd64.exe .\cmd\breeze-watchdog\
+cd installer
+.\build-msi.ps1 -Version 0.63.0-test
+```
+
+Copy the resulting `breeze-agent.msi` to the test VM.
+
+- [ ] **Step 2: Scenario 1 — No credentials (imaged deployment)**
+
+On the test VM, in an elevated PowerShell:
+
+```powershell
+msiexec /i breeze-agent.msi /qn /l*v install.log
+echo "exit code: $LASTEXITCODE"
+```
+
+Expected:
+- Exit code 0
+- `install.log` contains no `Enrollment failed` lines
+- `C:\ProgramData\Breeze\logs\enroll-last-error.txt` is absent
+- `sc query BreezeAgent` shows `STATE: 4 RUNNING`
+- Event Viewer → Windows Logs → Application → BreezeAgent info entry: "Waiting for enrollment..."
+- `C:\ProgramData\Breeze\logs\agent.log` shows the `waitForEnrollment` warning line
+
+- [ ] **Step 3: Scenario 2 — Good credentials (happy path)**
+
+Pick up where Scenario 1 left off. Open an elevated cmd:
+
+```cmd
+"C:\Program Files\Breeze\breeze-agent.exe" enroll brz_validkey --server https://valid.example
+```
+
+Or uninstall first and retest with credentials via msiexec:
+
+```powershell
+msiexec /x breeze-agent.msi /qn
+msiexec /i breeze-agent.msi ENROLLMENT_KEY=brz_validkey SERVER_URL=https://valid.example /qn /l*v install2.log
+echo "exit code: $LASTEXITCODE"
+```
+
+Expected:
+- Exit code 0
+- `install2.log` shows enrollment CA succeeded (exit 0)
+- `C:\ProgramData\Breeze\agent.yaml` contains `agent_id: <uuid>`
+- `C:\ProgramData\Breeze\secrets.yaml` exists with `auth_token`
+- `sc query BreezeAgent` shows `STATE: 4 RUNNING`
+- `enroll-last-error.txt` is absent
+- Event Viewer: no BreezeAgent error entries
+
+- [ ] **Step 4: Scenario 3 — Bad credentials (typo key)**
+
+Uninstall first, then:
+
+```powershell
+msiexec /x breeze-agent.msi /qn
+msiexec /i breeze-agent.msi ENROLLMENT_KEY=brz_typokey SERVER_URL=https://valid.example /qn /l*v install3.log
+echo "exit code: $LASTEXITCODE"
+```
+
+Expected:
+- Exit code 1603 (full rollback)
+- `C:\Program Files\Breeze\` does not exist or is empty
+- `sc query BreezeAgent` returns "service does not exist"
+- `install3.log` contains a line like `Enrollment failed: enrollment key not recognized — verify the key is active in Settings → Enrollment`
+- `C:\ProgramData\Breeze\logs\enroll-last-error.txt` EXISTS with a single line like `2026-04-13T14:02:00Z — Enrollment failed: enrollment key not recognized (http 401: ...)`
+- Event Viewer → Application → BreezeAgent has one Error entry with event ID 1003 and the same message
+
+- [ ] **Step 5: Scenario 4 — Server unreachable**
+
+```powershell
+msiexec /i breeze-agent.msi ENROLLMENT_KEY=brz_any SERVER_URL=https://unreachable.example /qn /l*v install4.log
+echo "exit code: $LASTEXITCODE"
+```
+
+Expected:
+- Exit code 1603
+- `install4.log` contains `Enrollment failed: server unreachable at https://unreachable.example — check firewall, DNS, and that SERVER_URL is correct`
+- `enroll-last-error.txt` contains the same message
+- Event Viewer entry present
+
+- [ ] **Step 6: Scenario 5 — Deferred enrollment (imaged deployment flow)**
+
+Starting from a clean state after Scenario 1's install:
+
+```cmd
+"C:\Program Files\Breeze\breeze-agent.exe" enroll brz_validkey --server https://valid.example
+```
+
+Expected:
+- Command exits 0
+- `agent.yaml` and `secrets.yaml` both written
+- Within 10 seconds (one wait-loop tick), `C:\ProgramData\Breeze\logs\agent.log` shows `enrollment detected, continuing startup`
+- `sc query BreezeAgent` still shows `STATE: 4 RUNNING` (no restart occurred)
+- Heartbeats appear in the Breeze UI for the new device within ~30s
+
+- [ ] **Step 7: Document scenario results**
+
+Record the results in a comment on issue #411. Include:
+- MSI version tested
+- Windows VM version (Server 2022, Win11, etc.)
+- Pass/fail for each of Scenarios 1-5
+- Full path to `enroll-last-error.txt` content for Scenarios 3 and 4
+- Any surprises (UAC prompts, SmartScreen blocks, etc.)
+
+---
+
+## Task 13: Open the pull request
+
+**Context for engineer:** Once Task 11 passes and Task 12's manual smoke tests look clean, open a PR from `fix/msi-enroll-failure-reporting` (or whatever branch name you're using) to `main`.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin worktree-msi-enroll-failure-reporting:fix/msi-enroll-failure-reporting
+```
+
+Or if the worktree branch has already been renamed to `fix/msi-enroll-failure-reporting`:
+
+```bash
+git push -u origin HEAD:fix/msi-enroll-failure-reporting
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --title "fix(installer): MSI enrollment failure reporting — fix 1603 cascade, surface cause (#411)" --body "$(cat <<'EOF'
+## Summary
+
+Fixes #411.
+
+- MSI installs without credentials now succeed; the service starts into a wait-for-enrollment loop for imaged/sysprep'd deployments.
+- MSI installs with bad credentials fail cleanly (exit 1603) with a human-readable cause written to four sinks: `install.log` (via stderr), `agent.log` (via slog), `C:\ProgramData\Breeze\logs\enroll-last-error.txt` (single-line timestamped marker), and Windows Event Log (Application / BreezeAgent / Error).
+- MSI installs with good credentials continue to work exactly as before (happy path preserved end-to-end).
+
+## Design
+
+See `docs/superpowers/specs/2026-04-13-msi-enrollment-failure-reporting-design.md` for the full design doc with four rounds of review feedback resolved.
+
+## Test plan
+
+- [x] `go test -race ./...` passes on macOS
+- [x] Cross-compile clean for windows/amd64, darwin/amd64, darwin/arm64, linux/amd64
+- [x] `GOOS=windows go test -c` compiles the Windows-only test binary
+- [ ] Manual smoke test on Windows Server 2022 (5 scenarios per Task 12 in the plan)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Post Task 12 results as a PR comment**
+
+Once the manual smoke tests have been completed per Task 12, paste the results as a comment on the PR so reviewers can see the real-world verification without having to run the tests themselves.
+
+---
+
+## Spec Self-Review
+
+Mapping the spec's components onto plan tasks:
+
+| Spec component | Plan task(s) |
+|---|---|
+| Component 1.a — `config.IsEnrolled` | Task 2 |
+| Component 1.b — package-level test seams | Task 6 (cross-platform) + Task 6 (Windows-only file) |
+| Component 1.c — split `startAgent` to take cfg | Task 8 |
+| Component 1.d — `waitForEnrollment` + poll interval | Task 6 (helper) + Task 7 (tests) |
+| Component 1.e — `runAgent` with `signal.NotifyContext` | Task 8 |
+| Component 2 — `ErrHTTPStatus` type | Task 1 |
+| Component 2 — `enrollError` helper + category enum + classifier + `clearEnrollLastError` + `writeLastErrorFile` + `enrollLastErrorPath` | Task 4 |
+| Component 2 — `enrollDevice` failure-site swaps + clear call | Task 5 |
+| Component 3 — WiX `Return="check"` + updated comment | Task 10 |
+| Component 4 — `Execute` split into enrolled/unenrolled + `runServiceLoop` extraction | Task 8 |
+| Component 5 — `internal/eventlog` package | Task 3 |
+| Testing — `IsEnrolled` table test | Task 2 |
+| Testing — `ErrHTTPStatus` tests | Task 1 |
+| Testing — `enroll_error_test.go` | Task 4 |
+| Testing — `eventlog_test.go` | Task 3 |
+| Testing — `main_test.go` waitForEnrollment trio | Task 7 |
+| Testing — `service_windows_test.go` trio with `installServiceStubs` | Task 9 |
+| Manual MSI smoke tests (5 scenarios) | Task 12 |
+
+All 17 spec elements are covered. No gaps.
+
+**Placeholder scan:** searched the plan for "TBD", "TODO", "fill in", "similar to", "add appropriate", "handle edge cases". None found. Every step contains actual code or an actual command.
+
+**Type consistency check:**
+- `enrollErrCategory` constants are consistent: Task 4 defines `catNetwork`, `catAuth`, `catNotFound`, `catRateLimit`, `catServer`, `catConfig`, `catUnknown`. Task 5 uses `catConfig` and `classifyEnrollError` (which returns `catAuth`/`catNotFound`/etc.). Match.
+- `enrollError(cat, friendly, detail)` signature: defined in Task 4, used in Task 5. Match.
+- `startAgentFn` / `waitForEnrollmentFn` / `runServiceLoopFn`: defined in Task 6, used in Tasks 8 and 9. Match.
+- `waitForEnrollmentPollInterval`: defined in Task 6, used in Task 7. Match.
+- `installServiceStubs(t) (events chan string, release func())`: defined and used in Task 9. Match.
+- `config.IsEnrolled(cfg *Config) bool`: defined in Task 2, used in Tasks 6, 8. Match.
+- `startAgent(cfg *config.Config)`: signature change in Task 8; callers in Task 8 use `startAgentFn(cfg)`. Match.
+- `runAsService(cfgFile string)`: signature change in Task 8; caller in `runAgent` (Task 8) uses it. Match.
+
+All signatures internally consistent.

--- a/docs/superpowers/specs/2026-04-13-msi-enrollment-failure-reporting-design.md
+++ b/docs/superpowers/specs/2026-04-13-msi-enrollment-failure-reporting-design.md
@@ -124,7 +124,24 @@ func IsEnrolled(cfg *Config) bool {
 }
 ```
 
-**Change 1.b — split `startAgent` into config load + real startup:**
+**Change 1.b — package-level test seams:**
+
+Declare two package-level function vars in `main.go` that the service wrapper and console runner call instead of the bare symbols. Production code assigns them to the real implementations at package-init time; `main_test.go` and `service_windows_test.go` override them in `t.Cleanup`-guarded setup. This matches the pattern already used by `osExit`, `writeLastErrorFile`, and `eventLogError` in Component 2.
+
+```go
+// Package-level indirection for testability. Tests override these in
+// TestMain or per-test setup to observe Execute/runAgent ordering
+// without running the real startup pipeline. Production callers must
+// use these vars, not the unexported symbols they wrap.
+var (
+    startAgentFn        func(*config.Config) (*agentComponents, error) = startAgent
+    waitForEnrollmentFn func(context.Context, string) *config.Config   = waitForEnrollment
+)
+```
+
+Every call site described in Components 1.d and 4 uses `startAgentFn(cfg)` and `waitForEnrollmentFn(ctx, cfgFile)` — the unadorned symbols `startAgent` and `waitForEnrollment` are referenced only by the vars themselves and by tests that want to exercise the real implementations. A linter/CI check could enforce this; for now it's a code-review discipline.
+
+**Change 1.c — split `startAgent` into config load + real startup:**
 
 `startAgent()` today does three things: load config, check enrollment, and run the full startup pipeline. Split those:
 
@@ -143,7 +160,7 @@ func startAgent(cfg *config.Config) (*agentComponents, error) {
 
 The enrollment check currently at `main.go:230-240` is removed from `startAgent`; callers (the service wrapper and the console-mode runner) are responsible for ensuring the config is enrolled before calling `startAgent`.
 
-**Change 1.c — `waitForEnrollment` with context and pluggable interval:**
+**Change 1.d — `waitForEnrollment` with context and pluggable interval:**
 
 ```go
 // waitForEnrollmentPollInterval is the default wait-loop poll interval.
@@ -192,7 +209,7 @@ func waitForEnrollment(ctx context.Context, cfgFile string) *config.Config {
 }
 ```
 
-**Change 1.d — console-mode runner (`runAgent`):**
+**Change 1.e — console-mode runner (`runAgent`):**
 
 The cross-platform console-mode path (invoked by `breeze-agent run` from a terminal, and by the macOS/Linux service managers that exec the agent binary as PID 1 of their service unit) now handles the wait loop directly before calling `startAgent`. The context is wired to `SIGINT`/`SIGTERM` via `signal.NotifyContext` so Ctrl+C in a terminal and `systemctl stop` / `launchctl kickstart -k` from the service manager all cancel the wait cleanly:
 
@@ -211,7 +228,7 @@ func runAgent() {
     defer stop()
 
     if !config.IsEnrolled(cfg) {
-        cfg = waitForEnrollment(ctx, cfgFile)
+        cfg = waitForEnrollmentFn(ctx, cfgFile)
         if cfg == nil {
             // ctx cancelled before enrollment arrived — clean exit.
             log.Info("agent shutting down without enrollment",
@@ -220,7 +237,7 @@ func runAgent() {
         }
     }
 
-    comps, err := startAgent(cfg)
+    comps, err := startAgentFn(cfg)
     if err != nil { /* fatal */ }
     // enter run loop as today; ctx is passed through to shutdown plumbing
     // where it replaces the existing ad-hoc signal handling.
@@ -492,7 +509,10 @@ func (s *breezeService) Execute(args []string, r <-chan svc.ChangeRequest, chang
 
     if config.IsEnrolled(cfg) {
         // --- Synchronous enrolled path (preserves today's behaviour) ---
-        comps, err := startAgent(cfg)
+        // startAgentFn is a package-level var defaulting to startAgent;
+        // tests override it to observe Execute's state-transition
+        // ordering without running the real startup pipeline.
+        comps, err := startAgentFn(cfg)
         if err != nil {
             log.Error("agent start failed", "error", err.Error())
             writeStartupFailureMarker(err)
@@ -505,7 +525,7 @@ func (s *breezeService) Execute(args []string, r <-chan svc.ChangeRequest, chang
     }
 
     // --- Async unenrolled path (MSI install with no creds) ---
-    // SCM MUST see Running before we block in waitForEnrollment or the
+    // SCM MUST see Running before we block in waitForEnrollmentFn or the
     // service start deadline (~30s) will kill the process.
     changes <- svc.Status{State: svc.Running, Accepts: accepted}
     log.Info("agent running as Windows service (waiting for enrollment)")
@@ -515,7 +535,9 @@ func (s *breezeService) Execute(args []string, r <-chan svc.ChangeRequest, chang
 
     enrolledCh := make(chan *config.Config, 1)
     go func() {
-        enrolledCh <- waitForEnrollment(ctx, s.cfgFile)
+        // waitForEnrollmentFn is the test seam — real waitForEnrollment
+        // in production, a channel-gated stub in Windows service tests.
+        enrolledCh <- waitForEnrollmentFn(ctx, s.cfgFile)
     }()
 
     // Stay responsive to SCM control requests while waiting. Drop session
@@ -551,7 +573,7 @@ waitLoop:
     // Now run the real startup pipeline. Failures here are post-install
     // (the MSI already believes the service started); we log, write the
     // failure marker, and stop the service.
-    comps, err := startAgent(enrolledCfg)
+    comps, err := startAgentFn(enrolledCfg)
     if err != nil {
         log.Error("agent start failed after deferred enrollment",
             "error", err.Error())
@@ -632,10 +654,26 @@ func Error(source, message string)   {}
 **`agent/internal/config/config_test.go`**:
 - `TestIsEnrolled`: table-driven — `{nil → false, empty → false, agentIDOnly → false, tokenOnly → false, both → true}`.
 
-**`agent/cmd/breeze-agent/service_windows_test.go`** (`//go:build windows`) — create if absent:
-- `TestExecute_EnrolledPath_SignalsRunningAfterStartFn`: write a valid enrolled config to a temp file, stub `startAgent` to return a fake `*agentComponents` without doing real work (via a package-level hook, similar to `waitForEnrollmentPollInterval`), drive `Execute` with a mock `changes` chan, assert the order of emitted states is `StartPending → Running` and that `Running` arrives *after* the stub `startAgent` is called.
-- `TestExecute_UnenrolledPath_SignalsRunningBeforeWait`: write an empty config to a temp file, stub `waitForEnrollment` to block on a test-controlled channel, assert `Execute` emits `StartPending → Running` *before* any interaction with the stub. Then unblock the stub and assert it proceeds into `startAgent`.
-- `TestExecute_StopWhileWaiting`: same setup as above, emit `svc.Stop` on the request channel while `waitForEnrollment` is still blocked, assert `Execute` cancels the wait context and returns.
+**`agent/cmd/breeze-agent/service_windows_test.go`** (`//go:build windows`) — create if absent. All three tests rely on the package-level hooks declared in Component 1.b (`startAgentFn`, `waitForEnrollmentFn`). Each test saves the original hook value, installs a stub, and restores in `t.Cleanup`:
+
+```go
+func TestExecute_EnrolledPath_SignalsRunningAfterStartFn(t *testing.T) {
+    origStart := startAgentFn
+    t.Cleanup(func() { startAgentFn = origStart })
+
+    var startCalled atomic.Bool
+    startAgentFn = func(cfg *config.Config) (*agentComponents, error) {
+        startCalled.Store(true)
+        return &agentComponents{ /* minimal fake */ }, nil
+    }
+    // ... write enrolled config, drive Execute with mock changes chan,
+    // assert order: StartPending → (startCalled=true) → Running.
+}
+```
+
+- `TestExecute_EnrolledPath_SignalsRunningAfterStartFn`: override `startAgentFn` to return a fake `*agentComponents` after recording that it was called. Write a valid enrolled config to a temp file, drive `Execute` with a mock `changes` chan, assert the ordering `StartPending → (startAgentFn called) → Running` — the Running signal MUST arrive only after the stub observed its call. Proves the enrolled path is still synchronous (Decision 6).
+- `TestExecute_UnenrolledPath_SignalsRunningBeforeWait`: override `waitForEnrollmentFn` to block on a test-controlled channel until released. Write an empty config, drive `Execute`, assert `Running` is emitted *before* the stub is released. Then write an enrolled config to the temp file and release the stub by returning the loaded config; assert `Execute` proceeds into `startAgentFn` (also stubbed) and emits no additional Running transitions.
+- `TestExecute_StopWhileWaiting`: same stubs as the previous test, send `svc.Stop` on the mock request channel while `waitForEnrollmentFn` is still blocked. Assert the stub's `ctx.Done()` fires (i.e., the test stub observes cancellation) and that `Execute` emits `StopPending` and returns `false, 0`. Proves the SCM control loop stays responsive during the wait.
 
 ### Manual MSI smoke tests
 

--- a/docs/superpowers/specs/2026-04-13-msi-enrollment-failure-reporting-design.md
+++ b/docs/superpowers/specs/2026-04-13-msi-enrollment-failure-reporting-design.md
@@ -1,0 +1,487 @@
+# MSI Enrollment Failure Reporting — Design
+
+**Date:** 2026-04-13
+**Issue:** [#411](https://github.com/LanternOps/breeze/issues/411) — `[Installer] MSI install rolls back with 1603 when enrollment fails or is skipped`
+**Status:** Draft — pending user review
+**Target release:** v0.63.x (not a hotfix)
+
+## Problem
+
+The Breeze MSI currently fails with exit code 1603 (full rollback) whenever the `BreezeAgent` Windows service cannot start during the `InstallServices` standard action. The cascade is:
+
+1. `EnrollAgent` custom action runs (or is skipped if no creds were supplied).
+2. `InstallServices` starts `BreezeAgent` because `<ServiceControl Start="install" Wait="yes" />`.
+3. `breeze-agent run` → `startAgent()` → `cfg.AgentID == ""` → returns `"agent not enrolled — run 'breeze-agent enroll <key>' first"` → process exits non-zero.
+4. Windows SCM reports `Error 1920: Service 'Breeze Agent' failed to start`.
+5. `<ServiceInstall Vital="yes" />` promotes that to a fatal install failure → MSI rolls back everything → `msiexec` exits 1603.
+
+Two real failure modes both hit this cascade:
+- **No creds supplied** (`msiexec /i breeze-agent.msi /qn`) — the Launch condition explicitly allows this for deferred enrollment, yet the install fails.
+- **Bad creds supplied** (typo in key, wrong server URL, server unreachable) — the enroll CA exits non-zero but `Return="ignore"` swallows it; the cascade then fires on the unenrolled service.
+
+In both cases the *cause* of the failure is invisible to the admin. `install.log` shows `Error 1920` but not `"401 Unauthorized: enrollment key not recognized"`. The admin sees 1603 and has no actionable signal.
+
+## Goals
+
+1. **`msiexec /qn` with no credentials succeeds.** Service is installed and starts into a "waiting for enrollment" idle loop. A later `breeze-agent enroll KEY --server URL` is picked up live without a service restart. Required for imaged/sysprep'd deployments and golden images.
+2. **`msiexec /qn` with bad credentials fails loudly.** Install cleanly rolls back, msiexec exits non-zero, and a human-readable cause lands in *at least four* places the admin can find without knowing Breeze's internals.
+3. **`msiexec /qn` with good credentials continues to work** exactly as it does today on the happy path.
+
+## Non-goals
+
+- MSI UI-mode error dialogs with specific cause text. Would require a DLL custom action wrapper; not worth the build complexity for this PR. Dialogs stay generic ("A custom action failed"); the actionable text is in install.log and Event Viewer.
+- Automatic retry of failed enrollment from inside the MSI. A failed enroll rolls back; re-running msiexec with a fixed key is the retry path.
+- Cross-platform enrollment failure reporting (.pkg, .deb, .rpm). The four output sinks are cross-platform but the MSI-specific plumbing is Windows-only.
+- Changing the enrollment API endpoint or payload.
+
+## Design decisions (confirmed with user in brainstorming)
+
+| # | Decision | Reason |
+|---|---|---|
+| 1 | Scenario "no creds" → install succeeds, service runs idle | Imaged/sysprep'd deployment, golden images. Matches modern agent UX (Datto, Ninja). |
+| 2 | Scenario "bad creds" → install fails cleanly | Prevents silent half-success on typos in mass deployments. |
+| 3 | `startAgent` wait-for-enrollment loop is **unconditional**, not gated on a config flag | Gating on `cfg.WaitForEnrollment` is a chicken-and-egg problem — the flag lives in `agent.yaml` which is exactly what's missing. Applies cross-platform for symmetry. |
+| 4 | Error text is delivered via **four sinks simultaneously**: stderr, `agent.log`, `enroll-last-error.txt`, Windows Event Log | Admins look in different places depending on deployment tool (GPO, Intune, manual msiexec). Write once, route everywhere. |
+| 5 | No MSI dialog path (no DLL CA wrapper) | Keeps build simple. `/qn` is the dominant deployment mode; dialog value is marginal. |
+
+## Architecture
+
+```
+  msiexec /i breeze.msi [ENROLLMENT_KEY=... SERVER_URL=...] /qn /l*v install.log
+                              │
+                              ▼
+                      InstallFiles (copies breeze-agent.exe, etc.)
+                              │
+                              ▼
+     ┌─────── EnrollAgent CA: breeze-agent.exe enroll --quiet ───────┐
+     │                                                                │
+     │  ENROLLMENT_KEY missing?  →  CA condition false, CA skipped    │
+     │                                                                │
+     │  enroll succeeds           →  exit 0                           │
+     │                                                                │
+     │  enroll fails (401/404/   →  enrollError() routes to 4 sinks:  │
+     │    network/timeout/5xx)      1. stderr  → install.log          │
+     │                              2. agent.log (slog)               │
+     │                              3. enroll-last-error.txt          │
+     │                              4. Windows Event Log              │
+     │                             exit 10..16 (category)             │
+     │                             Return="check" → MSI rolls back    │
+     └────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+                      InstallServices
+                              │
+                              ▼
+               BreezeAgent service starts
+                              │
+                              ▼
+              startAgent() — configuration check
+                              │
+         ┌────────── AgentID present? ──────────┐
+         │                                      │
+         │ yes                                  │ no
+         ▼                                      ▼
+  Normal startup path              waitForEnrollment() loop:
+  (heartbeat, shipper, mTLS,         reload config every 10s;
+   WS connection)                    unblock on non-empty AgentID.
+                                     SCM sees Running throughout.
+```
+
+The service is always in `Running` state from SCM's perspective, whether or not enrollment has completed. "Enrolled" is an internal state, not an SCM state. This matches how Datto/Ninja/etc. behave and avoids the "did I start the service" footgun.
+
+## Components
+
+### Component 1 — Go agent: wait-for-enrollment loop
+
+**File:** `agent/cmd/breeze-agent/main.go`
+
+**Change:** Replace the hard error at line 239 (`return nil, fmt.Errorf("agent not enrolled ...")`) with a new helper `waitForEnrollment()` that polls `config.Load(cfgFile)` every 10 seconds until `AgentID` is non-empty.
+
+```go
+// waitForEnrollment blocks until agent.yaml contains a valid AgentID.
+// Intended for post-MSI-install scenarios where the service starts before
+// a later breeze-agent enroll call populates the config. Unconditional on
+// all platforms; callers that need a timeout must wrap this.
+func waitForEnrollment() *config.Config {
+    log.Warn("agent not enrolled — waiting for enrollment (poll every 10s). " +
+        "Run 'breeze-agent enroll <key> --server <url>' to complete setup.")
+    eventlog.Info("BreezeAgent",
+        "Waiting for enrollment. Run 'breeze-agent enroll <key> --server <url>'.")
+
+    for {
+        time.Sleep(10 * time.Second)
+        cfg, err := config.Load(cfgFile)
+        if err != nil {
+            log.Debug("config reload failed while waiting for enrollment",
+                "error", err.Error())
+            continue
+        }
+        if cfg.AgentID != "" {
+            log.Info("enrollment detected, continuing startup",
+                "agentId", cfg.AgentID)
+            return cfg
+        }
+    }
+}
+```
+
+Inside `startAgent()`:
+
+```go
+if cfg.AgentID == "" {
+    cfg = waitForEnrollment()
+}
+```
+
+**Caveat — logging order:** today's `startAgent` calls `initLogging(cfg)` *after* the AgentID check. For the wait loop to log, `initLogging(cfg)` must be hoisted to run *before* the check. This is safe: `config.Load` returns `config.Default()` with env merges when `agent.yaml` is absent (verified in `agent/internal/config/config.go:185-204`), so `cfg.LogFile` has a default value and the file logger can initialize. Log shipping, heartbeat registration, and mTLS init stay downstream of the wait loop — they require an AgentID to function and are meaningless until enrollment completes.
+
+**Platform behaviour:**
+- **Windows service:** relies on Component 4 to signal Running before this blocks.
+- **macOS launchd / Linux systemd:** no start deadline, wait loop is free. Service state is "running" from the init system's view throughout.
+- **Console mode (`breeze-agent run` from a terminal):** identical wait loop, prints the Warn line to the terminal and idles until interrupted or enrolled.
+
+### Component 2 — Go enroll command: structured errors + four output sinks
+
+**Files:**
+- Create: `agent/cmd/breeze-agent/enroll_error.go`
+- Create: `agent/cmd/breeze-agent/enroll_error_test.go`
+- Modify: `agent/cmd/breeze-agent/main.go` (route all enroll failure paths through `enrollError`)
+- Modify: `agent/pkg/api/client.go` (add `ErrHTTPStatus` type; return it from `Enroll` on non-200)
+
+**New type in `agent/pkg/api/client.go`:**
+
+```go
+// ErrHTTPStatus is returned by the api client when an HTTP request completes
+// but the server returned a non-success status code. Callers can type-assert
+// to classify the failure (auth, not found, rate limit, server error).
+type ErrHTTPStatus struct {
+    StatusCode int
+    Body       string
+}
+
+func (e *ErrHTTPStatus) Error() string {
+    return fmt.Sprintf("http %d: %s", e.StatusCode, e.Body)
+}
+```
+
+Modify `Client.Enroll` line 125-127 to return `&ErrHTTPStatus{StatusCode: resp.StatusCode, Body: string(bodyBytes)}` instead of the current generic `fmt.Errorf`.
+
+**New helper in `agent/cmd/breeze-agent/enroll_error.go`:**
+
+```go
+type enrollErrCategory int
+
+const (
+    catNetwork   enrollErrCategory = iota // dial/DNS/TLS/timeout
+    catAuth                               // 401, 403
+    catNotFound                           // 404
+    catRateLimit                          // 429
+    catServer                             // 5xx
+    catConfig                             // save failed, perms
+    catUnknown
+)
+
+// exitCode returns the process exit code for this category.
+// Range 10..16 keeps the categories distinguishable in install.log
+// without colliding with Go's default exit code (2 for runtime errors).
+func (c enrollErrCategory) exitCode() int { return int(c) + 10 }
+
+// enrollError writes a human-readable failure line to all four sinks
+// (stderr → install.log, agent.log, enroll-last-error.txt, Windows Event
+// Log) and exits the process with a category-specific code. Never returns.
+//
+// Injectable dependencies (exit, writeLastErrorFile, eventLogError) are
+// package-level vars so tests can intercept without patching os.Exit.
+func enrollError(cat enrollErrCategory, friendly string, detail error) {
+    line := fmt.Sprintf("Enrollment failed: %s", friendly)
+    if detail != nil {
+        line += fmt.Sprintf(" (%v)", detail)
+    }
+    fmt.Fprintln(os.Stderr, line)
+    log.Error("enrollment failed",
+        "category", cat, "friendly", friendly, "error", detail)
+    writeLastErrorFile(line)
+    eventLogError("BreezeAgent", line)
+    osExit(cat.exitCode())
+}
+
+// classifyEnrollError inspects an error from api.Client.Enroll and returns
+// the appropriate category + user-facing message.
+func classifyEnrollError(err error, serverURL string) (enrollErrCategory, string) {
+    if err == nil {
+        return catUnknown, ""
+    }
+    var httpErr *api.ErrHTTPStatus
+    if errors.As(err, &httpErr) {
+        switch {
+        case httpErr.StatusCode == 401 || httpErr.StatusCode == 403:
+            return catAuth, "enrollment key not recognized — verify the key " +
+                "is active in Settings → Enrollment on the server"
+        case httpErr.StatusCode == 404:
+            return catNotFound, fmt.Sprintf(
+                "enrollment endpoint not found on %s — check that SERVER_URL "+
+                    "is correct (did you include /api or point at the wrong host?)",
+                serverURL)
+        case httpErr.StatusCode == 429:
+            return catRateLimit, "rate limited by server — wait one minute " +
+                "and retry the install"
+        case httpErr.StatusCode >= 500:
+            return catServer, fmt.Sprintf(
+                "server error %d — contact Breeze support if this persists",
+                httpErr.StatusCode)
+        }
+    }
+    // Network-layer errors: dial, DNS, TLS, timeout, conn refused
+    var urlErr *url.Error
+    if errors.As(err, &urlErr) {
+        return catNetwork, fmt.Sprintf(
+            "server unreachable at %s — check firewall, DNS, and that "+
+                "SERVER_URL is correct",
+            serverURL)
+    }
+    return catUnknown, err.Error()
+}
+```
+
+**Changes to `enrollDevice` in `main.go`:**
+
+Every `fmt.Fprintf(os.Stderr, ...)` + `os.Exit(1)` pair gets replaced with a call to `enrollError`:
+
+| Line | Before | After |
+|---|---|---|
+| 620-622 | "Server URL required" → exit 1 | `enrollError(catConfig, "server URL required — pass --server or set in config", nil)` |
+| 701-704 | `client.Enroll` error → exit 1 | `cat, friendly := classifyEnrollError(err, cfg.ServerURL); enrollError(cat, friendly, err)` |
+| 730-735 | `config.SaveTo` error → exit 1 | `enrollError(catConfig, "could not save agent.yaml — check that "+filepath.Dir(cfgFile)+" exists and is writable", err)` |
+
+**Sinks:**
+
+1. **stderr** — written directly by `enrollError`. Captured by `msiexec /l*v install.log` into the CustomAction section.
+2. **agent.log** — written via the existing `logging` package's slog output. Requires minimal logging init in `enrollDevice` before the first failure can fire. The merged #410 PR already added structured logging init to `enrollDevice`; we reuse it.
+3. **`enroll-last-error.txt`** — a new single-line plain-text file at `filepath.Join(config.ConfigDir(), "logs", "enroll-last-error.txt")`. Overwritten on each attempt. Format: `<RFC3339 timestamp> — <line>\n`. World-readable (0644). Mirrors the existing `writeStartupFailureMarker` pattern at `service_windows.go:24` but serves the enroll scope.
+4. **Windows Event Log** — a new `internal/eventlog` package wrapping `golang.org/x/sys/windows/svc/eventlog`. Source name `BreezeAgent`. Event IDs: 1001 (info), 1002 (warning), 1003 (error). No-op stubs on macOS and Linux so the main.go call sites stay cross-platform.
+
+### Component 3 — WiX MSI: enroll CA now fails cleanly
+
+**File:** `agent/installer/breeze.wxs`
+
+**Change A:** `<CustomAction Id="EnrollAgent" ... Return="ignore" />` → `Return="check"`.
+
+When the enroll CA exits non-zero, `Return="check"` makes MSI treat it as fatal and rolls back the install. Because the CA is conditional on `SERVER_URL AND ENROLLMENT_KEY`, this only affects the "creds supplied" scenario — the "no creds" path skips the CA entirely and can never trigger a rollback.
+
+**Change B:** `<ServiceInstall ... Vital="yes" />` and `<ServiceControl Start="install" Wait="yes" />` are **unchanged**. The service still starts during `InstallServices`; Component 1 makes that start succeed even without enrollment.
+
+**Change C:** Replace the existing WiX XML comment above the `EnrollAgent` action with:
+
+```xml
+<!-- Enrollment runs after file copy but before InstallServices.
+     Return="check" means a failure rolls back the install cleanly — admins
+     see a specific cause in install.log and Event Viewer instead of 1603
+     with no explanation.
+
+     Installs without ENROLLMENT_KEY skip this CA entirely. The service
+     starts anyway and idles in a wait-for-enrollment loop (see
+     waitForEnrollment in cmd/breeze-agent/main.go), so a later
+     `breeze-agent enroll KEY --server URL` is picked up live without a
+     service restart. This is the intended flow for imaged/sysprep'd
+     deployments. -->
+```
+
+**No change** to `InstallExecuteSequence` conditions, `SetEnrollAgentData` (already removed by #410), or the launch conditions.
+
+### Component 4 — Windows service wrapper: signal Running before startFn blocks
+
+**File:** `agent/cmd/breeze-agent/service_windows.go`
+
+**Current code (lines 117-133):**
+
+```go
+func (s *breezeService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
+    const accepted = svc.AcceptStop | svc.AcceptShutdown | svc.AcceptSessionChange
+
+    changes <- svc.Status{State: svc.StartPending}
+
+    comps, err := s.startFn()        // BLOCKS if wait loop is active
+    if err != nil {
+        ...
+    }
+
+    changes <- svc.Status{State: svc.Running, Accepts: accepted}  // too late
+    log.Info("agent running as Windows service")
+
+    for { /* SCM control loop */ }
+}
+```
+
+The Running transition happens *after* `startFn` returns, which is fine today (startFn exits quickly) but breaks once `waitForEnrollment` can block for minutes or hours. SCM's default start deadline is 30 seconds; exceeding it kills the process.
+
+**New flow:**
+
+```go
+func (s *breezeService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
+    const accepted = svc.AcceptStop | svc.AcceptShutdown | svc.AcceptSessionChange
+
+    changes <- svc.Status{State: svc.StartPending}
+    // Promote to Running immediately. The startFn goroutine may spend a
+    // long time in waitForEnrollment, but from SCM's perspective the
+    // service is healthy and responding to control requests.
+    changes <- svc.Status{State: svc.Running, Accepts: accepted}
+    log.Info("agent running as Windows service (enrollment status pending)")
+
+    compsCh := make(chan *agentComponents, 1)
+    errCh := make(chan error, 1)
+    go func() {
+        comps, err := s.startFn()
+        if err != nil {
+            errCh <- err
+            return
+        }
+        compsCh <- comps
+    }()
+
+    var comps *agentComponents
+    for {
+        select {
+        case c := <-compsCh:
+            comps = c
+            // SCM session dispatch only works once comps is available.
+            if comps != nil {
+                // wire up session change channel as before
+            }
+        case err := <-errCh:
+            log.Error("agent start failed", "error", err.Error())
+            writeStartupFailureMarker(err)
+            changes <- svc.Status{State: svc.StopPending}
+            return true, 1
+        case cr := <-r:
+            // (existing SCM control request handling, gated on comps != nil
+            //  for session-change events)
+        }
+    }
+}
+```
+
+**Implication:** the `SessionChange` event handling (lines 146-158) currently dereferences `comps.hb` directly. Once we make start asynchronous, those events may arrive before `comps` is set. The fix is to buffer the most recent session-change event and replay it once `comps` becomes available, or to simply drop events that arrive before startup completes (the session broker will catch up on its next reconcile tick). The design prefers the drop-and-reconcile path — session change events are advisory, and the reconciliation loop is already the authoritative source for session state.
+
+### Component 5 — Event log wrapper
+
+**Files:**
+- Create: `agent/internal/eventlog/eventlog.go` (no-op stub, build tag `!windows`)
+- Create: `agent/internal/eventlog/eventlog_windows.go` (wraps `golang.org/x/sys/windows/svc/eventlog`)
+- Create: `agent/internal/eventlog/eventlog_test.go`
+
+**API:**
+
+```go
+package eventlog
+
+// Info writes an informational event to the OS event log (Windows
+// Application log; no-op on other platforms). Source is a short name
+// like "BreezeAgent". Safe to call before the event source is formally
+// registered — on Windows, the package lazily registers via
+// InstallAsEventCreate on first use, wrapped in sync.Once.
+func Info(source, message string)
+
+// Warning writes a warning event.
+func Warning(source, message string)
+
+// Error writes an error event.
+func Error(source, message string)
+```
+
+**Windows implementation notes:**
+
+- Lazy registration via `eventlog.InstallAsEventCreate(source, eventlog.Info|eventlog.Warning|eventlog.Error)`. If registration fails because the source already exists, fall back to `eventlog.Open(source)`. If that also fails (non-admin process, corrupted registry), drop silently — the other three sinks already cover the failure.
+- Event IDs are fixed at 1001/1002/1003 for now. A future refinement could use per-component IDs.
+- `sync.Once` guards registration. Package-level `registeredSources map[string]*eventlog.Log` caches open handles keyed by source name.
+
+**Non-Windows stub:**
+
+```go
+//go:build !windows
+package eventlog
+func Info(source, message string)    {}
+func Warning(source, message string) {}
+func Error(source, message string)   {}
+```
+
+## Testing
+
+### Unit tests
+
+**`agent/cmd/breeze-agent/enroll_error_test.go`** (cross-platform):
+- `classifyEnrollError` with fake `api.ErrHTTPStatus` at every category boundary (401, 403, 404, 429, 500, 503) → assert correct category + message.
+- `classifyEnrollError` with a synthetic `url.Error` wrapping `net.OpError` → asserts `catNetwork`.
+- `enrollError` with injectable `osExit` and `writeLastErrorFile` hooks → assert stderr received the line, the last-error file hook was called, the event-log hook was called, and `osExit` received the category's exit code.
+
+**`agent/internal/eventlog/eventlog_test.go`** (cross-platform):
+- Non-Windows: calling `Info/Warning/Error` is a no-op and does not panic.
+- Windows-gated: compile only (runtime registration requires admin in CI, skip).
+
+**`agent/cmd/breeze-agent/main_test.go`** (cross-platform):
+- Add `TestWaitForEnrollment` — writes an empty agent.yaml, spawns `waitForEnrollment` in a goroutine, writes a valid agent.yaml 500ms later, asserts the goroutine returns with the populated config. Use a test hook to shrink the poll interval from 10s to 50ms.
+- Add `TestWaitForEnrollmentStaysBlockedOnEmptyConfig` — poll never unblocks for 1s, test cancels via `runtime.Goexit` or a context.
+
+**`agent/cmd/breeze-agent/service_windows_test.go`** (`//go:build windows`):
+- Mock `svc.Handler` — drive `Execute` with a fake `changes` channel, assert `svc.Running` is sent *before* `startFn` is called. Use a `startFn` that blocks on a channel so the test can observe the state transition without racing.
+
+### Manual MSI smoke tests
+
+The following scenarios must be verified on a Windows Server 2022 VM before merge. Documented here, not automated in this PR — automation is #412.
+
+| # | Command | Expected |
+|---|---|---|
+| 1 | `msiexec /i breeze-agent.msi /qn /l*v install.log` (no creds) | msiexec exit 0. Service installed + Running. `agent.yaml` absent. `enroll-last-error.txt` absent. Event Viewer: BreezeAgent info "Waiting for enrollment". |
+| 2 | `msiexec /i breeze-agent.msi ENROLLMENT_KEY=brz_valid SERVER_URL=https://valid.example /qn /l*v install.log` (good creds) | msiexec exit 0. Service installed + Running. `agent.yaml` present with AgentID. No enroll error files. |
+| 3 | `msiexec /i breeze-agent.msi ENROLLMENT_KEY=brz_typo SERVER_URL=https://valid.example /qn /l*v install.log` (bad key) | msiexec exit 1603. No residual files in `C:\Program Files\Breeze`. Service not installed. `install.log` contains `Enrollment failed: enrollment key not recognized`. `enroll-last-error.txt` absent (it's in ProgramData which is also rolled back? verify — may need to be in a non-rollback directory). Event Viewer: BreezeAgent error entry. |
+| 4 | `msiexec /i breeze-agent.msi ENROLLMENT_KEY=brz_valid SERVER_URL=https://unreachable.example /qn /l*v install.log` (network) | msiexec exit 1603. Install.log contains `Enrollment failed: server unreachable ...`. |
+| 5 | Scenario 1 followed by `breeze-agent enroll brz_valid --server https://valid.example` run interactively (elevated shell) | Enroll succeeds. Running service picks up new config within 10s (one wait-loop tick). No service restart required. |
+
+**Caveat on test 3:** `enroll-last-error.txt` lives in `C:\ProgramData\Breeze\logs\`, which is managed by `cmpProgramDataLogs` with `Permanent="yes"`. The `Permanent` attribute means the directory is not removed on rollback, so the file should survive a 1603 rollback. Must verify during testing — if the file does get removed, move the last-error path to `%TEMP%\breeze-enroll-last-error.txt` as a fallback.
+
+## File-by-file summary
+
+**Create:**
+- `agent/cmd/breeze-agent/enroll_error.go`
+- `agent/cmd/breeze-agent/enroll_error_test.go`
+- `agent/internal/eventlog/eventlog.go` (`//go:build !windows`)
+- `agent/internal/eventlog/eventlog_windows.go`
+- `agent/internal/eventlog/eventlog_test.go`
+- `docs/superpowers/specs/2026-04-13-msi-enrollment-failure-reporting-design.md` (this file)
+
+**Modify:**
+- `agent/cmd/breeze-agent/main.go` — `startAgent` calls `waitForEnrollment` instead of erroring; `enrollDevice` routes all failure paths through `enrollError`; add `waitForEnrollment` helper.
+- `agent/cmd/breeze-agent/service_windows.go` — `Execute` signals Running before `startFn`, runs `startFn` in a goroutine, handles session-change events defensively.
+- `agent/cmd/breeze-agent/main_test.go` — `TestWaitForEnrollment` + staying-blocked variant.
+- `agent/cmd/breeze-agent/service_windows_test.go` — may not exist; create if absent. Windows-gated test for Running-before-startFn ordering.
+- `agent/pkg/api/client.go` — add `ErrHTTPStatus` type; `Enroll` returns it on non-200.
+- `agent/installer/breeze.wxs` — `EnrollAgent` CA `Return="check"`; updated XML comment.
+
+**Not touched:**
+- `agent/internal/config/` — no schema changes.
+- `agent/internal/logging/` — reused as-is.
+- `agent/installer/build-msi.ps1` — no changes.
+- `.github/workflows/release.yml` — no changes.
+- `docs/superpowers/plans/2026-04-12-registry-based-msi-enrollment.md` — #410 is already merged; this design builds on that foundation without touching it.
+
+## Risks and mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| SCM start deadline fires during startFn before `comps` is ready | Low (Running is signaled immediately) | Component 4 signals Running on Execute entry; SCM treats the process as started regardless of startFn progress. |
+| Session change events arrive before `comps` is wired up | Medium | Drop events during the pre-comps window; session broker reconciliation loop is the authoritative source and will catch up. |
+| `enroll-last-error.txt` is removed during MSI rollback | Medium | `cmpProgramDataLogs` uses `Permanent="yes"`; verify during manual testing. Fallback: write to `%TEMP%`. |
+| Event Log source registration fails (non-admin helper process) | Low | Registration is best-effort wrapped in `sync.Once`; failure is silent and the other three sinks still fire. |
+| `classifyEnrollError` miscategorizes a new server response | Low | The classifier falls through to `catUnknown` which still produces a readable error message using the raw error string. |
+| Cross-platform `waitForEnrollment` blocks macOS/Linux console users unexpectedly | Low | The Warn line is explicit about what's happening and how to exit. Console users can Ctrl+C. Systemd/launchd users see the wait state in `journalctl` / `log show`. |
+| A running service that's waiting for enrollment wastes memory/CPU indefinitely | Very low | The poll loop sleeps 10s between parses of a 2KB YAML file. Baseline cost is negligible; far cheaper than a failed install plus a support ticket. |
+
+## Open questions
+
+None. All questions raised during brainstorming (Q1/Q2/Q3) were resolved with the user.
+
+## Follow-ups (not in scope)
+
+- **#412** — CI workflow to build and test a signed MSI without cutting a full release. Would let us automate the five manual smoke-test scenarios above.
+- **Dialog-mode error presentation** — a small DLL CA wrapper that calls `MsiProcessMessage` with the friendly text, so UI-mode installs also show the specific cause. Deferred pending demand.
+- **Per-component Event Log IDs** — currently all events use 1001/1002/1003. Could add a registry of stable event IDs per subsystem (enroll=2001, heartbeat=3001, etc.) for easier filtering in SIEM tools.
+- **`BreezeAgent` Event Log source registration at install time** — currently we register lazily on first use, which races with non-admin processes. A dedicated MSI custom action could register the source during install with SYSTEM credentials. Low priority — lazy registration has worked fine for every other agent-style product.

--- a/docs/superpowers/specs/2026-04-13-msi-enrollment-failure-reporting-design.md
+++ b/docs/superpowers/specs/2026-04-13-msi-enrollment-failure-reporting-design.md
@@ -194,7 +194,7 @@ func waitForEnrollment(ctx context.Context, cfgFile string) *config.Config {
 
 **Change 1.d — console-mode runner (`runAgent`):**
 
-The cross-platform console-mode path (invoked by `breeze-agent run` from a terminal) now handles the wait loop directly before calling `startAgent`:
+The cross-platform console-mode path (invoked by `breeze-agent run` from a terminal, and by the macOS/Linux service managers that exec the agent binary as PID 1 of their service unit) now handles the wait loop directly before calling `startAgent`. The context is wired to `SIGINT`/`SIGTERM` via `signal.NotifyContext` so Ctrl+C in a terminal and `systemctl stop` / `launchctl kickstart -k` from the service manager all cancel the wait cleanly:
 
 ```go
 func runAgent() {
@@ -202,20 +202,32 @@ func runAgent() {
     if err != nil { /* fatal */ }
     initBootstrapLogging(cfg) // minimal init; full init happens in startAgent
 
+    // Wire cancellation to OS signals so waitForEnrollment, startAgent,
+    // and the main event loop all observe the same shutdown trigger.
+    // signal.NotifyContext installs a signal handler that cancels ctx
+    // on SIGINT or SIGTERM and restores the default handler on stop().
+    ctx, stop := signal.NotifyContext(context.Background(),
+        os.Interrupt, syscall.SIGTERM)
+    defer stop()
+
     if !config.IsEnrolled(cfg) {
-        ctx, cancel := context.WithCancel(context.Background())
-        defer cancel()
         cfg = waitForEnrollment(ctx, cfgFile)
         if cfg == nil {
-            os.Exit(0) // cancelled, clean exit
+            // ctx cancelled before enrollment arrived — clean exit.
+            log.Info("agent shutting down without enrollment",
+                "reason", ctx.Err().Error())
+            return
         }
     }
 
     comps, err := startAgent(cfg)
     if err != nil { /* fatal */ }
-    // enter run loop as today
+    // enter run loop as today; ctx is passed through to shutdown plumbing
+    // where it replaces the existing ad-hoc signal handling.
 }
 ```
+
+**Note on `service_windows.go`:** the Windows SCM service wrapper does NOT use `signal.NotifyContext` — SCM `Stop`/`Shutdown` requests arrive on the `<-chan svc.ChangeRequest` channel, not via `os.Interrupt`. The Windows wait loop uses its own `context.WithCancel` and cancels explicitly when it observes `svc.Stop` / `svc.Shutdown` on the request channel (see Component 4). Both paths converge on the same guarantee: `ctx.Done()` fires on legitimate shutdown signals for the host platform, and `waitForEnrollment` returns `nil` cleanly.
 
 **Caveat — bootstrap logging:** today's `startAgent` calls `initLogging(cfg)` once, inline. We need logging available *before* the enrollment check (so `waitForEnrollment` can emit Warn/Info lines). Introduce a small `initBootstrapLogging(cfg)` that initializes only the stderr + file writers — no log shipper, no event-log init beyond the eventlog package's lazy path. `startAgent` retains `initLogging(cfg)` as today for any call-site that needs a re-init after enrollment arrives (if logging configuration can change on enrollment — it probably can't, but the re-init is a no-op in that case). Verify during implementation that `logging.Init` is idempotent.
 
@@ -362,12 +374,30 @@ func classifyEnrollError(err error, serverURL string) (enrollErrCategory, string
 
 **Changes to `enrollDevice` in `main.go`:**
 
-Every `fmt.Fprintf(os.Stderr, ...)` + `os.Exit(1)` pair gets replaced with a call to `enrollError`. Additionally, `enrollDevice` now clears any stale `enroll-last-error.txt` **at the start of every attempt** (P3 fix) so a successful retry leaves no residual error file for admins to find:
+Every `fmt.Fprintf(os.Stderr, ...)` + `os.Exit(1)` pair gets replaced with a call to `enrollError`. Additionally, `enrollDevice` now clears any stale `enroll-last-error.txt` **immediately after logging init and before any validation or early return** — Decision 8's contract is that every attempt starts with a clean slate, including attempts that fail on server-URL validation before reaching the HTTP call. Placing the clear after validation would leave a stale marker behind whenever the current attempt fails early, which defeats the point:
 
 ```go
-// Near the top of enrollDevice, after arg validation:
-clearEnrollLastError() // removes enroll-last-error.txt if present;
-                       // no-op if it doesn't exist.
+func enrollDevice(enrollmentKey string) {
+    cfg, err := config.Load(cfgFile)
+    if err != nil {
+        cfg = config.Default()
+    }
+    initEnrollLogging(cfg, quietEnroll)
+
+    // Clear any stale marker from a previous failed attempt FIRST —
+    // before any validation or early return. Decision 8 says every
+    // attempt starts from a clean state; a validation failure later in
+    // this function must not leave a stale file behind.
+    clearEnrollLastError()
+
+    if serverURL != "" {
+        cfg.ServerURL = serverURL
+    }
+    if cfg.ServerURL == "" {
+        enrollError(catConfig, "server URL required — pass --server or set in config", nil)
+    }
+    // ... rest of enrollDevice unchanged apart from the failure-site swaps below.
+}
 ```
 
 On the success path (after `config.SaveTo` returns nil), nothing further is required — the file was already removed at the start of the attempt.
@@ -615,11 +645,13 @@ The following scenarios must be verified on a Windows Server 2022 VM before merg
 |---|---|---|
 | 1 | `msiexec /i breeze-agent.msi /qn /l*v install.log` (no creds) | msiexec exit 0. Service installed + Running. `agent.yaml` absent. `enroll-last-error.txt` absent. Event Viewer: BreezeAgent info "Waiting for enrollment". |
 | 2 | `msiexec /i breeze-agent.msi ENROLLMENT_KEY=brz_valid SERVER_URL=https://valid.example /qn /l*v install.log` (good creds) | msiexec exit 0. Service installed + Running. `agent.yaml` present with AgentID. No enroll error files. |
-| 3 | `msiexec /i breeze-agent.msi ENROLLMENT_KEY=brz_typo SERVER_URL=https://valid.example /qn /l*v install.log` (bad key) | msiexec exit 1603. No residual files in `C:\Program Files\Breeze`. Service not installed. `install.log` contains `Enrollment failed: enrollment key not recognized`. `enroll-last-error.txt` absent (it's in ProgramData which is also rolled back? verify — may need to be in a non-rollback directory). Event Viewer: BreezeAgent error entry. |
-| 4 | `msiexec /i breeze-agent.msi ENROLLMENT_KEY=brz_valid SERVER_URL=https://unreachable.example /qn /l*v install.log` (network) | msiexec exit 1603. Install.log contains `Enrollment failed: server unreachable ...`. |
-| 5 | Scenario 1 followed by `breeze-agent enroll brz_valid --server https://valid.example` run interactively (elevated shell) | Enroll succeeds. Running service picks up new config within 10s (one wait-loop tick). No service restart required. |
+| 3 | `msiexec /i breeze-agent.msi ENROLLMENT_KEY=brz_typo SERVER_URL=https://valid.example /qn /l*v install.log` (bad key) | msiexec exit 1603. No residual files in `C:\Program Files\Breeze` (InstallFiles rolled back). Service not installed. `C:\ProgramData\Breeze\logs\` **directory exists** (kept by `cmpProgramDataLogs Permanent="yes"`). `C:\ProgramData\Breeze\logs\enroll-last-error.txt` **PRESENT**, one line, containing `<RFC3339 timestamp> — Enrollment failed: enrollment key not recognized ...`. `install.log` contains the same friendly line captured from the CA's stderr. Event Viewer → Windows Logs → Application → source `BreezeAgent` → one Error entry. |
+| 4 | `msiexec /i breeze-agent.msi ENROLLMENT_KEY=brz_valid SERVER_URL=https://unreachable.example /qn /l*v install.log` (network) | Same as scenario 3 but the friendly line is `Enrollment failed: server unreachable at https://unreachable.example — check firewall, DNS, and that SERVER_URL is correct ...`. `enroll-last-error.txt` PRESENT with this content. |
+| 5 | Scenario 1 followed by `breeze-agent enroll brz_valid --server https://valid.example` run interactively (elevated shell) | Enroll succeeds. Running service picks up new config within 10s (one wait-loop tick). No service restart required. `enroll-last-error.txt` still absent (scenario 1 never created it; scenario 5 is a clean success). |
 
-**Caveat on test 3:** `enroll-last-error.txt` lives in `C:\ProgramData\Breeze\logs\`, which is managed by `cmpProgramDataLogs` with `Permanent="yes"`. The `Permanent` attribute means the directory is not removed on rollback, so the file should survive a 1603 rollback. Must verify during testing — if the file does get removed, move the last-error path to `%TEMP%\breeze-enroll-last-error.txt` as a fallback.
+**On `enroll-last-error.txt` surviving rollback (definitive expected state for scenarios 3 and 4):** the file **is expected to survive**, and scenarios 3/4 assert its presence. Rationale: MSI's rollback reverses actions that MSI tracked (`InstallFiles`, `InstallServices`, property table writes). Files written by a CA via `os.WriteFile` are opaque to MSI — the installer has no record that they were created and therefore has no mechanism to remove them on rollback. The parent directory (`C:\ProgramData\Breeze\logs\`) additionally has `Permanent="yes"` on its component, so even the directory itself is preserved through rollback (which in turn preserves the file). This is not reliance on a fragile edge case — it is the standard MSI contract for CA-written artifacts, and it is what makes the "read the error after 1603" design possible.
+
+Manual verification is still required to confirm no surprise (UAC redirection, `ProgramData` permissions on non-English locales, antivirus auto-quarantine of freshly-written root-owned files, etc.). If verification fails in a specific environment, the documented fallback is `%ProgramData%\Breeze\logs\` → `%TEMP%\breeze-enroll-last-error.txt`. `%TEMP%` is out of the MSI's purview for the same reason and is writable from any CA context. The spec does not switch preemptively because `%ProgramData%` is the discoverable path an admin would look in for a persistent agent-managed log.
 
 ## File-by-file summary
 
@@ -664,7 +696,7 @@ The following scenarios must be verified on a Windows Server 2022 VM before merg
 | Waiter observes torn SaveTo write (AgentID set but AuthToken not yet persisted) | Low | `IsEnrolled` checks both fields. Torn read causes one extra poll cycle (10s); no incorrect bring-up. |
 | `startAgent` fails on the async post-enrollment path and the service ends up Stopped without rolling back the install | **Accepted** | The admin chose `/qn` with no creds; a failure after deferred enrollment is debugged via `agent-start-failed.txt`, `agent.log`, and Event Log. They re-run `breeze-agent enroll` with corrected parameters and `sc start BreezeAgent`. |
 | Session change events arrive during `waitLoop` before `comps` is wired up | Medium | Drop events during the wait window; session broker reconciliation loop is the authoritative source and will catch up once `startAgent` completes. Only `Interrogate`/`Stop`/`Shutdown` are handled during the wait. |
-| `enroll-last-error.txt` is removed during MSI rollback on the bad-creds path | Medium | `cmpProgramDataLogs` uses `Permanent="yes"`; verify during manual testing. Fallback: write to `%TEMP%\breeze-enroll-last-error.txt`. |
+| `enroll-last-error.txt` is removed during MSI rollback on the bad-creds path | Low | The file is written by a CA via `os.WriteFile` — MSI has no record of it and cannot roll it back. `cmpProgramDataLogs` is `Permanent="yes"` so the parent directory also survives. Expected state is codified in smoke-test scenarios 3 and 4 (file PRESENT post-1603). Fallback if a specific environment breaks this: write to `%TEMP%\breeze-enroll-last-error.txt`. |
 | Stale `enroll-last-error.txt` from an earlier failed attempt confuses admins after a successful retry | **Avoided** — `enrollDevice` calls `clearEnrollLastError()` at the start of every attempt (Decision 8). |
 | Goroutine leak in `waitForEnrollment` tests | **Avoided** — `waitForEnrollment` takes `context.Context`, tests cancel via `context.WithCancel` (Decision 9). |
 | Event Log source registration fails (non-admin helper process) | Low | Registration is best-effort wrapped in `sync.Once`; failure is silent and the other three sinks still fire. |

--- a/docs/superpowers/specs/2026-04-13-msi-enrollment-failure-reporting-design.md
+++ b/docs/superpowers/specs/2026-04-13-msi-enrollment-failure-reporting-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-13
 **Issue:** [#411](https://github.com/LanternOps/breeze/issues/411) — `[Installer] MSI install rolls back with 1603 when enrollment fails or is skipped`
-**Status:** Draft — pending user review
+**Status:** Draft v2 — addresses P1/P2/P3/P4 from first review
 **Target release:** v0.63.x (not a hotfix)
 
 ## Problem
@@ -40,9 +40,13 @@ In both cases the *cause* of the failure is invisible to the admin. `install.log
 |---|---|---|
 | 1 | Scenario "no creds" → install succeeds, service runs idle | Imaged/sysprep'd deployment, golden images. Matches modern agent UX (Datto, Ninja). |
 | 2 | Scenario "bad creds" → install fails cleanly | Prevents silent half-success on typos in mass deployments. |
-| 3 | `startAgent` wait-for-enrollment loop is **unconditional**, not gated on a config flag | Gating on `cfg.WaitForEnrollment` is a chicken-and-egg problem — the flag lives in `agent.yaml` which is exactly what's missing. Applies cross-platform for symmetry. |
+| 3 | Wait-for-enrollment loop is **unconditional** (not gated on a config flag) but runs **only on the unenrolled branch** | Gating on `cfg.WaitForEnrollment` is a chicken-and-egg problem — the flag lives in `agent.yaml` which is exactly what's missing. But the enrolled path must stay synchronous (see Decision 6) so today's "bad mTLS / bad heartbeat init fails the install" guarantee is preserved. |
 | 4 | Error text is delivered via **four sinks simultaneously**: stderr, `agent.log`, `enroll-last-error.txt`, Windows Event Log | Admins look in different places depending on deployment tool (GPO, Intune, manual msiexec). Write once, route everywhere. |
 | 5 | No MSI dialog path (no DLL CA wrapper) | Keeps build simple. `/qn` is the dominant deployment mode; dialog value is marginal. |
+| 6 | Service `Execute` uses **two distinct start paths**: synchronous when already enrolled (today's behavior), async-after-Running when waiting for enrollment | P1 fix. Keeps today's "post-enroll mTLS / heartbeat / state-file failures fail the MSI install" guarantee on the happy path. Only the deferred-enrollment branch signals Running early, and only there can post-Running startup failures occur — which is acceptable because the install was intentionally no-creds and the admin expects async completion. |
+| 7 | Waiter gates on a **complete enrolled state** (`AgentID != "" && AuthToken != ""`), exposed as `config.IsEnrolled(cfg)` | P2 fix. `config.SaveTo` writes `agent.yaml` before `secrets.yaml` (`agent/internal/config/config.go:313-376`); `AgentID` alone would let the waiter observe a torn write. Checking both fields is self-healing — on the rare torn read, the loop simply tries again 10s later. |
+| 8 | `enroll-last-error.txt` is **removed at the start of each enroll attempt**, and `enrollError` rewrites it on failure | P3 fix. Prevents stale error files from lingering after a successful retry. Smoke-test scenario 1 (no-creds success) now verifies the file is absent. |
+| 9 | `waitForEnrollment` takes `context.Context` and a pluggable `pollInterval` | P4 fix. Tests pass a cancellable context and a short interval (e.g. 10ms) so they can assert wait/unblock behavior without leaking goroutines or waiting 10s. Production callers pass `context.Background()` and the default 10s interval. |
 
 ## Architecture
 
@@ -75,70 +79,150 @@ In both cases the *cause* of the failure is invisible to the admin. `install.log
                BreezeAgent service starts
                               │
                               ▼
-              startAgent() — configuration check
+              Execute() — config.Load + IsEnrolled(cfg)
                               │
-         ┌────────── AgentID present? ──────────┐
-         │                                      │
-         │ yes                                  │ no
-         ▼                                      ▼
-  Normal startup path              waitForEnrollment() loop:
-  (heartbeat, shipper, mTLS,         reload config every 10s;
-   WS connection)                    unblock on non-empty AgentID.
-                                     SCM sees Running throughout.
+         ┌── IsEnrolled(cfg)? ──┐
+         │                      │
+         │ yes                  │ no
+         ▼                      ▼
+  Synchronous path        Async path
+  (today's behavior)      ───────────
+  ────────────────        1. signal Running immediately
+  1. startAgent(cfg)      2. waitForEnrollment(ctx, cfgFile)
+     initializes heart-      polls every 10s, unblocks on
+     beat, shipper,          IsEnrolled; SCM control loop
+     mTLS, WS                still processes Stop/Shutdown
+  2. any failure →        3. startAgent(enrolledCfg) runs
+     MSI rollback           post-install; failures are
+     (goal 3 preserved)     logged and stop the service
+  3. signal Running         but cannot roll back the MSI
+  4. enter service          (install already succeeded)
+     control loop        4. enter service control loop
 ```
 
-The service is always in `Running` state from SCM's perspective, whether or not enrollment has completed. "Enrolled" is an internal state, not an SCM state. This matches how Datto/Ninja/etc. behave and avoids the "did I start the service" footgun.
+Decision 6 is the key architectural principle: enrolled installs keep today's strict semantics (any post-enroll init failure fails the install), while unenrolled installs are allowed to succeed early and finish setup later. This preserves goal 3 for the happy path and delivers goal 1 for imaged/sysprep'd deployments, without conflating the two.
 
 ## Components
 
-### Component 1 — Go agent: wait-for-enrollment loop
+### Component 1 — Go agent: split startAgent, add `waitForEnrollment` and `IsEnrolled`
 
-**File:** `agent/cmd/breeze-agent/main.go`
+**Files:**
+- Modify: `agent/cmd/breeze-agent/main.go`
+- Modify: `agent/internal/config/config.go` (add `IsEnrolled` helper)
 
-**Change:** Replace the hard error at line 239 (`return nil, fmt.Errorf("agent not enrolled ...")`) with a new helper `waitForEnrollment()` that polls `config.Load(cfgFile)` every 10 seconds until `AgentID` is non-empty.
+**Change 1.a — `config.IsEnrolled` helper:**
 
 ```go
-// waitForEnrollment blocks until agent.yaml contains a valid AgentID.
+// IsEnrolled reports whether cfg represents a complete enrollment — both
+// the AgentID (written to agent.yaml) and the AuthToken (written to
+// secrets.yaml). Callers that poll for enrollment readiness MUST use this
+// predicate rather than checking AgentID alone, because SaveTo writes
+// agent.yaml before secrets.yaml and a concurrent reader can otherwise
+// observe a torn write.
+func IsEnrolled(cfg *Config) bool {
+    return cfg != nil && cfg.AgentID != "" && cfg.AuthToken != ""
+}
+```
+
+**Change 1.b — split `startAgent` into config load + real startup:**
+
+`startAgent()` today does three things: load config, check enrollment, and run the full startup pipeline. Split those:
+
+```go
+// startAgent performs the full startup pipeline assuming cfg is already
+// enrolled. Returns the running components or an error if any
+// initialization step fails (mTLS load, log shipper init, heartbeat
+// bring-up, etc.). This function MUST NOT be called with an unenrolled
+// cfg — callers must check config.IsEnrolled first and wait if needed.
+func startAgent(cfg *config.Config) (*agentComponents, error) {
+    // (existing body of startAgent from line 243 onward — FixConfigPermissions,
+    //  initLogging, safemode check, mTLS cert load, log shipper, heartbeat,
+    //  websocket connect. No behavior change.)
+}
+```
+
+The enrollment check currently at `main.go:230-240` is removed from `startAgent`; callers (the service wrapper and the console-mode runner) are responsible for ensuring the config is enrolled before calling `startAgent`.
+
+**Change 1.c — `waitForEnrollment` with context and pluggable interval:**
+
+```go
+// waitForEnrollmentPollInterval is the default wait-loop poll interval.
+// Exposed as a package-level var so tests can shrink it without waiting
+// real seconds.
+var waitForEnrollmentPollInterval = 10 * time.Second
+
+// waitForEnrollment polls agent.yaml + secrets.yaml every pollInterval
+// until config.IsEnrolled(cfg) returns true, then returns the enrolled
+// config. Returns nil if ctx is cancelled before enrollment completes.
+//
 // Intended for post-MSI-install scenarios where the service starts before
-// a later breeze-agent enroll call populates the config. Unconditional on
-// all platforms; callers that need a timeout must wrap this.
-func waitForEnrollment() *config.Config {
-    log.Warn("agent not enrolled — waiting for enrollment (poll every 10s). " +
-        "Run 'breeze-agent enroll <key> --server <url>' to complete setup.")
+// a later `breeze-agent enroll` call populates the config. The ctx allows
+// the caller (service wrapper or console-mode runner) to cancel the wait
+// on shutdown, preventing goroutine leaks in tests and clean service
+// stops in production.
+func waitForEnrollment(ctx context.Context, cfgFile string) *config.Config {
+    log.Warn("agent not enrolled — waiting for enrollment. " +
+        "Run 'breeze-agent enroll <key> --server <url>' to complete setup.",
+        "pollInterval", waitForEnrollmentPollInterval)
     eventlog.Info("BreezeAgent",
         "Waiting for enrollment. Run 'breeze-agent enroll <key> --server <url>'.")
 
+    ticker := time.NewTicker(waitForEnrollmentPollInterval)
+    defer ticker.Stop()
+
     for {
-        time.Sleep(10 * time.Second)
-        cfg, err := config.Load(cfgFile)
-        if err != nil {
-            log.Debug("config reload failed while waiting for enrollment",
-                "error", err.Error())
-            continue
-        }
-        if cfg.AgentID != "" {
-            log.Info("enrollment detected, continuing startup",
-                "agentId", cfg.AgentID)
-            return cfg
+        select {
+        case <-ctx.Done():
+            log.Info("waitForEnrollment cancelled", "reason", ctx.Err().Error())
+            return nil
+        case <-ticker.C:
+            cfg, err := config.Load(cfgFile)
+            if err != nil {
+                log.Debug("config reload failed while waiting for enrollment",
+                    "error", err.Error())
+                continue
+            }
+            if config.IsEnrolled(cfg) {
+                log.Info("enrollment detected, continuing startup",
+                    "agentId", cfg.AgentID)
+                return cfg
+            }
         }
     }
 }
 ```
 
-Inside `startAgent()`:
+**Change 1.d — console-mode runner (`runAgent`):**
+
+The cross-platform console-mode path (invoked by `breeze-agent run` from a terminal) now handles the wait loop directly before calling `startAgent`:
 
 ```go
-if cfg.AgentID == "" {
-    cfg = waitForEnrollment()
+func runAgent() {
+    cfg, err := config.Load(cfgFile)
+    if err != nil { /* fatal */ }
+    initBootstrapLogging(cfg) // minimal init; full init happens in startAgent
+
+    if !config.IsEnrolled(cfg) {
+        ctx, cancel := context.WithCancel(context.Background())
+        defer cancel()
+        cfg = waitForEnrollment(ctx, cfgFile)
+        if cfg == nil {
+            os.Exit(0) // cancelled, clean exit
+        }
+    }
+
+    comps, err := startAgent(cfg)
+    if err != nil { /* fatal */ }
+    // enter run loop as today
 }
 ```
 
-**Caveat — logging order:** today's `startAgent` calls `initLogging(cfg)` *after* the AgentID check. For the wait loop to log, `initLogging(cfg)` must be hoisted to run *before* the check. This is safe: `config.Load` returns `config.Default()` with env merges when `agent.yaml` is absent (verified in `agent/internal/config/config.go:185-204`), so `cfg.LogFile` has a default value and the file logger can initialize. Log shipping, heartbeat registration, and mTLS init stay downstream of the wait loop — they require an AgentID to function and are meaningless until enrollment completes.
+**Caveat — bootstrap logging:** today's `startAgent` calls `initLogging(cfg)` once, inline. We need logging available *before* the enrollment check (so `waitForEnrollment` can emit Warn/Info lines). Introduce a small `initBootstrapLogging(cfg)` that initializes only the stderr + file writers — no log shipper, no event-log init beyond the eventlog package's lazy path. `startAgent` retains `initLogging(cfg)` as today for any call-site that needs a re-init after enrollment arrives (if logging configuration can change on enrollment — it probably can't, but the re-init is a no-op in that case). Verify during implementation that `logging.Init` is idempotent.
 
 **Platform behaviour:**
-- **Windows service:** relies on Component 4 to signal Running before this blocks.
-- **macOS launchd / Linux systemd:** no start deadline, wait loop is free. Service state is "running" from the init system's view throughout.
-- **Console mode (`breeze-agent run` from a terminal):** identical wait loop, prints the Warn line to the terminal and idles until interrupted or enrolled.
+- **Windows service:** the service wrapper (Component 4) decides which path to take and only the unenrolled branch enters `waitForEnrollment`. The enrolled branch calls `startAgent` directly with its existing synchronous failure semantics.
+- **macOS launchd / Linux systemd:** no SCM deadline concerns. The console-mode `runAgent` path above is what's invoked by the service; the wait loop is free.
+- **Manual console (`breeze-agent run` from a terminal):** identical wait loop, prints the Warn line to the terminal and idles until Ctrl+C or enrollment arrives.
 
 ### Component 2 — Go enroll command: structured errors + four output sinks
 
@@ -205,6 +289,39 @@ func enrollError(cat enrollErrCategory, friendly string, detail error) {
     osExit(cat.exitCode())
 }
 
+// clearEnrollLastError removes enroll-last-error.txt if present. Called
+// at the start of every enrollment attempt so a successful retry leaves
+// no residual error file for admins to find. Errors from os.Remove are
+// silently ignored — the file may legitimately not exist, and we cannot
+// fail an enrollment attempt over cleanup bookkeeping.
+func clearEnrollLastError() {
+    path := enrollLastErrorPath()
+    if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+        log.Debug("could not clear stale enroll-last-error file",
+            "path", path, "error", err.Error())
+    }
+}
+
+// enrollLastErrorPath returns the platform-specific path to the
+// single-line enrollment error marker. Windows: under ProgramData\Breeze\logs.
+// Unix: under the existing LogDir() path.
+func enrollLastErrorPath() string {
+    return filepath.Join(config.LogDir(), "enroll-last-error.txt")
+}
+
+// writeLastErrorFile overwrites enroll-last-error.txt with a single line
+// containing the RFC3339 timestamp and the friendly failure message.
+// Intended to be called only by enrollError; exposed as a package-level
+// var so tests can inject a fake.
+var writeLastErrorFile = func(line string) {
+    path := enrollLastErrorPath()
+    if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+        return
+    }
+    content := fmt.Sprintf("%s — %s\n", time.Now().Format(time.RFC3339), line)
+    _ = os.WriteFile(path, []byte(content), 0o644)
+}
+
 // classifyEnrollError inspects an error from api.Client.Enroll and returns
 // the appropriate category + user-facing message.
 func classifyEnrollError(err error, serverURL string) (enrollErrCategory, string) {
@@ -245,7 +362,17 @@ func classifyEnrollError(err error, serverURL string) (enrollErrCategory, string
 
 **Changes to `enrollDevice` in `main.go`:**
 
-Every `fmt.Fprintf(os.Stderr, ...)` + `os.Exit(1)` pair gets replaced with a call to `enrollError`:
+Every `fmt.Fprintf(os.Stderr, ...)` + `os.Exit(1)` pair gets replaced with a call to `enrollError`. Additionally, `enrollDevice` now clears any stale `enroll-last-error.txt` **at the start of every attempt** (P3 fix) so a successful retry leaves no residual error file for admins to find:
+
+```go
+// Near the top of enrollDevice, after arg validation:
+clearEnrollLastError() // removes enroll-last-error.txt if present;
+                       // no-op if it doesn't exist.
+```
+
+On the success path (after `config.SaveTo` returns nil), nothing further is required — the file was already removed at the start of the attempt.
+
+The failure-site replacements:
 
 | Line | Before | After |
 |---|---|---|
@@ -288,79 +415,129 @@ When the enroll CA exits non-zero, `Return="check"` makes MSI treat it as fatal 
 
 **No change** to `InstallExecuteSequence` conditions, `SetEnrollAgentData` (already removed by #410), or the launch conditions.
 
-### Component 4 — Windows service wrapper: signal Running before startFn blocks
+### Component 4 — Windows service wrapper: split sync/async by enrollment state
 
 **File:** `agent/cmd/breeze-agent/service_windows.go`
+
+**Goal:** preserve today's synchronous failure semantics on the enrolled path (Decision 6) while allowing the unenrolled path to report `Running` early and finish startup later.
 
 **Current code (lines 117-133):**
 
 ```go
 func (s *breezeService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
     const accepted = svc.AcceptStop | svc.AcceptShutdown | svc.AcceptSessionChange
-
     changes <- svc.Status{State: svc.StartPending}
-
-    comps, err := s.startFn()        // BLOCKS if wait loop is active
-    if err != nil {
-        ...
-    }
-
-    changes <- svc.Status{State: svc.Running, Accepts: accepted}  // too late
-    log.Info("agent running as Windows service")
-
+    comps, err := s.startFn()        // synchronous — failures fail install
+    if err != nil { ... }
+    changes <- svc.Status{State: svc.Running, Accepts: accepted}
     for { /* SCM control loop */ }
 }
 ```
 
-The Running transition happens *after* `startFn` returns, which is fine today (startFn exits quickly) but breaks once `waitForEnrollment` can block for minutes or hours. SCM's default start deadline is 30 seconds; exceeding it kills the process.
-
-**New flow:**
+**New shape.** `runAsService` is updated to take a `cfgFile` and pass it through instead of wrapping a `startFn` closure (so the service wrapper can do its own config load and decide which path to use):
 
 ```go
+func runAsService(cfgFile string) error {
+    h := &breezeService{
+        cfgFile: cfgFile,
+        stopCh:  make(chan struct{}),
+    }
+    return svc.Run("BreezeAgent", h)
+}
+
 func (s *breezeService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
     const accepted = svc.AcceptStop | svc.AcceptShutdown | svc.AcceptSessionChange
-
     changes <- svc.Status{State: svc.StartPending}
-    // Promote to Running immediately. The startFn goroutine may spend a
-    // long time in waitForEnrollment, but from SCM's perspective the
-    // service is healthy and responding to control requests.
-    changes <- svc.Status{State: svc.Running, Accepts: accepted}
-    log.Info("agent running as Windows service (enrollment status pending)")
 
-    compsCh := make(chan *agentComponents, 1)
-    errCh := make(chan error, 1)
-    go func() {
-        comps, err := s.startFn()
+    // Load config synchronously to decide which path to take. A load
+    // error is fatal on both paths — fail the install.
+    cfg, err := config.Load(s.cfgFile)
+    if err != nil {
+        log.Error("failed to load config", "error", err.Error())
+        writeStartupFailureMarker(err)
+        changes <- svc.Status{State: svc.StopPending}
+        return true, 1
+    }
+    initBootstrapLogging(cfg)
+
+    if config.IsEnrolled(cfg) {
+        // --- Synchronous enrolled path (preserves today's behaviour) ---
+        comps, err := startAgent(cfg)
         if err != nil {
-            errCh <- err
-            return
-        }
-        compsCh <- comps
-    }()
-
-    var comps *agentComponents
-    for {
-        select {
-        case c := <-compsCh:
-            comps = c
-            // SCM session dispatch only works once comps is available.
-            if comps != nil {
-                // wire up session change channel as before
-            }
-        case err := <-errCh:
             log.Error("agent start failed", "error", err.Error())
             writeStartupFailureMarker(err)
             changes <- svc.Status{State: svc.StopPending}
             return true, 1
+        }
+        changes <- svc.Status{State: svc.Running, Accepts: accepted}
+        log.Info("agent running as Windows service")
+        return runServiceLoop(comps, r, changes)
+    }
+
+    // --- Async unenrolled path (MSI install with no creds) ---
+    // SCM MUST see Running before we block in waitForEnrollment or the
+    // service start deadline (~30s) will kill the process.
+    changes <- svc.Status{State: svc.Running, Accepts: accepted}
+    log.Info("agent running as Windows service (waiting for enrollment)")
+
+    ctx, cancel := context.WithCancel(context.Background())
+    defer cancel()
+
+    enrolledCh := make(chan *config.Config, 1)
+    go func() {
+        enrolledCh <- waitForEnrollment(ctx, s.cfgFile)
+    }()
+
+    // Stay responsive to SCM control requests while waiting. Drop session
+    // change events — we have no heartbeat wired up yet, and the session
+    // broker's reconciliation loop will catch up once startAgent runs.
+    var enrolledCfg *config.Config
+waitLoop:
+    for {
+        select {
+        case cfg := <-enrolledCh:
+            enrolledCfg = cfg
+            break waitLoop
         case cr := <-r:
-            // (existing SCM control request handling, gated on comps != nil
-            //  for session-change events)
+            switch cr.Cmd {
+            case svc.Interrogate:
+                changes <- cr.CurrentStatus
+            case svc.Stop, svc.Shutdown:
+                log.Info("SCM stop while waiting for enrollment")
+                cancel()
+                changes <- svc.Status{State: svc.StopPending}
+                return false, 0
+            }
+            // svc.SessionChange: ignore. No comps yet.
         }
     }
+
+    if enrolledCfg == nil {
+        // ctx was cancelled without enrollment — SCM stop path above
+        // already handled the status transition.
+        return false, 0
+    }
+
+    // Now run the real startup pipeline. Failures here are post-install
+    // (the MSI already believes the service started); we log, write the
+    // failure marker, and stop the service.
+    comps, err := startAgent(enrolledCfg)
+    if err != nil {
+        log.Error("agent start failed after deferred enrollment",
+            "error", err.Error())
+        writeStartupFailureMarker(err)
+        changes <- svc.Status{State: svc.StopPending}
+        return true, 1
+    }
+    return runServiceLoop(comps, r, changes)
 }
 ```
 
-**Implication:** the `SessionChange` event handling (lines 146-158) currently dereferences `comps.hb` directly. Once we make start asynchronous, those events may arrive before `comps` is set. The fix is to buffer the most recent session-change event and replay it once `comps` becomes available, or to simply drop events that arrive before startup completes (the session broker will catch up on its next reconcile tick). The design prefers the drop-and-reconcile path — session change events are advisory, and the reconciliation loop is already the authoritative source for session state.
+`runServiceLoop(comps, r, changes)` is a small refactor of the current `for { select { r }}` block at lines 135-163 — extracted so both paths can share it.
+
+**Post-install failure semantics.** On the async path, a failure from `startAgent(enrolledCfg)` cannot roll back the MSI (the install has long completed). The failure is logged to `agent.log`, `agent-start-failed.txt`, and Event Log, and the service transitions to Stopped. Admins debug by checking those sinks and re-running `breeze-agent enroll` with corrected parameters plus `sc start BreezeAgent`. This matches how every other agent-style product handles deferred-enrollment startup failures and is an acceptable trade-off because the admin explicitly chose a no-creds install.
+
+**Why the enrolled path is unchanged for SCM purposes.** Today's behaviour — post-enroll mTLS failure, heartbeat init error, log shipper failure → SCM Error 1920 → MSI 1603 — is preserved exactly. The enrolled path never reaches the async code.
 
 ### Component 5 — Event log wrapper
 
@@ -418,11 +595,17 @@ func Error(source, message string)   {}
 - Windows-gated: compile only (runtime registration requires admin in CI, skip).
 
 **`agent/cmd/breeze-agent/main_test.go`** (cross-platform):
-- Add `TestWaitForEnrollment` — writes an empty agent.yaml, spawns `waitForEnrollment` in a goroutine, writes a valid agent.yaml 500ms later, asserts the goroutine returns with the populated config. Use a test hook to shrink the poll interval from 10s to 50ms.
-- Add `TestWaitForEnrollmentStaysBlockedOnEmptyConfig` — poll never unblocks for 1s, test cancels via `runtime.Goexit` or a context.
+- `TestWaitForEnrollment_UnblocksWhenConfigBecomesValid`: set `waitForEnrollmentPollInterval = 10 * time.Millisecond` for the test (restore via `t.Cleanup`), write a minimal agent.yaml + secrets.yaml with both `AgentID` and `AuthToken` populated after ~30ms, spawn `waitForEnrollment(ctx, tmpCfgFile)` in a goroutine, assert it returns the populated config within 500ms.
+- `TestWaitForEnrollment_RespectsContextCancel`: point at a non-existent config file, `ctx, cancel := context.WithCancel(context.Background())`, run `waitForEnrollment` in a goroutine, cancel the context after 50ms, assert the goroutine returns `nil` within another 50ms. This is the test the previous draft could not implement — now the `ctx.Done()` branch in the select makes it trivial.
+- `TestWaitForEnrollment_IgnoresTornWrite`: write only agent.yaml (with AgentID) but no secrets.yaml; `waitForEnrollment` must stay blocked. After 100ms, add secrets.yaml with AuthToken; waitForEnrollment must unblock. This is the P2 regression test — `IsEnrolled` prevents the torn-read footgun.
 
-**`agent/cmd/breeze-agent/service_windows_test.go`** (`//go:build windows`):
-- Mock `svc.Handler` — drive `Execute` with a fake `changes` channel, assert `svc.Running` is sent *before* `startFn` is called. Use a `startFn` that blocks on a channel so the test can observe the state transition without racing.
+**`agent/internal/config/config_test.go`**:
+- `TestIsEnrolled`: table-driven — `{nil → false, empty → false, agentIDOnly → false, tokenOnly → false, both → true}`.
+
+**`agent/cmd/breeze-agent/service_windows_test.go`** (`//go:build windows`) — create if absent:
+- `TestExecute_EnrolledPath_SignalsRunningAfterStartFn`: write a valid enrolled config to a temp file, stub `startAgent` to return a fake `*agentComponents` without doing real work (via a package-level hook, similar to `waitForEnrollmentPollInterval`), drive `Execute` with a mock `changes` chan, assert the order of emitted states is `StartPending → Running` and that `Running` arrives *after* the stub `startAgent` is called.
+- `TestExecute_UnenrolledPath_SignalsRunningBeforeWait`: write an empty config to a temp file, stub `waitForEnrollment` to block on a test-controlled channel, assert `Execute` emits `StartPending → Running` *before* any interaction with the stub. Then unblock the stub and assert it proceeds into `startAgent`.
+- `TestExecute_StopWhileWaiting`: same setup as above, emit `svc.Stop` on the request channel while `waitForEnrollment` is still blocked, assert `Execute` cancels the wait context and returns.
 
 ### Manual MSI smoke tests
 
@@ -449,10 +632,20 @@ The following scenarios must be verified on a Windows Server 2022 VM before merg
 - `docs/superpowers/specs/2026-04-13-msi-enrollment-failure-reporting-design.md` (this file)
 
 **Modify:**
-- `agent/cmd/breeze-agent/main.go` — `startAgent` calls `waitForEnrollment` instead of erroring; `enrollDevice` routes all failure paths through `enrollError`; add `waitForEnrollment` helper.
-- `agent/cmd/breeze-agent/service_windows.go` — `Execute` signals Running before `startFn`, runs `startFn` in a goroutine, handles session-change events defensively.
-- `agent/cmd/breeze-agent/main_test.go` — `TestWaitForEnrollment` + staying-blocked variant.
-- `agent/cmd/breeze-agent/service_windows_test.go` — may not exist; create if absent. Windows-gated test for Running-before-startFn ordering.
+- `agent/cmd/breeze-agent/main.go` —
+  - Refactor `startAgent` to take `cfg *config.Config` and assume it is already enrolled (callers do the wait).
+  - Add `waitForEnrollment(ctx, cfgFile)` helper + `waitForEnrollmentPollInterval` package var.
+  - Add `initBootstrapLogging(cfg)` for pre-start logging used by the wait loop.
+  - Update `runAgent` console-mode path to call `config.Load` → `IsEnrolled` check → `waitForEnrollment` → `startAgent`.
+  - `enrollDevice`: call `clearEnrollLastError()` at the start of every attempt; route all failure paths through `enrollError`.
+- `agent/cmd/breeze-agent/service_windows.go` —
+  - `runAsService` now takes `cfgFile string` instead of a `startFn` closure.
+  - `Execute` splits into enrolled (synchronous, preserves today's failure semantics) and unenrolled (reports Running early, then `waitForEnrollment` with SCM control-loop responsiveness, then `startAgent`) branches.
+  - Extract the post-startup `for { select { r } }` block into a shared `runServiceLoop(comps, r, changes)` helper used by both branches.
+- `agent/cmd/breeze-agent/main_test.go` — `TestWaitForEnrollment_UnblocksWhenConfigBecomesValid`, `TestWaitForEnrollment_RespectsContextCancel`, `TestWaitForEnrollment_IgnoresTornWrite`.
+- `agent/cmd/breeze-agent/service_windows_test.go` — may not exist; create if absent. `TestExecute_EnrolledPath_SignalsRunningAfterStartFn`, `TestExecute_UnenrolledPath_SignalsRunningBeforeWait`, `TestExecute_StopWhileWaiting`.
+- `agent/internal/config/config.go` — add `IsEnrolled(cfg *Config) bool` helper.
+- `agent/internal/config/config_test.go` — `TestIsEnrolled` table test.
 - `agent/pkg/api/client.go` — add `ErrHTTPStatus` type; `Enroll` returns it on non-200.
 - `agent/installer/breeze.wxs` — `EnrollAgent` CA `Return="check"`; updated XML comment.
 
@@ -467,9 +660,13 @@ The following scenarios must be verified on a Windows Server 2022 VM before merg
 
 | Risk | Likelihood | Mitigation |
 |---|---|---|
-| SCM start deadline fires during startFn before `comps` is ready | Low (Running is signaled immediately) | Component 4 signals Running on Execute entry; SCM treats the process as started regardless of startFn progress. |
-| Session change events arrive before `comps` is wired up | Medium | Drop events during the pre-comps window; session broker reconciliation loop is the authoritative source and will catch up. |
-| `enroll-last-error.txt` is removed during MSI rollback | Medium | `cmpProgramDataLogs` uses `Permanent="yes"`; verify during manual testing. Fallback: write to `%TEMP%`. |
+| Enrolled-path install fails more silently than today (post-enroll mTLS/heartbeat init errors no longer fail the install) | **Avoided** — Decision 6 explicitly preserves synchronous start semantics on the enrolled path. Only the unenrolled branch reports Running early. |
+| Waiter observes torn SaveTo write (AgentID set but AuthToken not yet persisted) | Low | `IsEnrolled` checks both fields. Torn read causes one extra poll cycle (10s); no incorrect bring-up. |
+| `startAgent` fails on the async post-enrollment path and the service ends up Stopped without rolling back the install | **Accepted** | The admin chose `/qn` with no creds; a failure after deferred enrollment is debugged via `agent-start-failed.txt`, `agent.log`, and Event Log. They re-run `breeze-agent enroll` with corrected parameters and `sc start BreezeAgent`. |
+| Session change events arrive during `waitLoop` before `comps` is wired up | Medium | Drop events during the wait window; session broker reconciliation loop is the authoritative source and will catch up once `startAgent` completes. Only `Interrogate`/`Stop`/`Shutdown` are handled during the wait. |
+| `enroll-last-error.txt` is removed during MSI rollback on the bad-creds path | Medium | `cmpProgramDataLogs` uses `Permanent="yes"`; verify during manual testing. Fallback: write to `%TEMP%\breeze-enroll-last-error.txt`. |
+| Stale `enroll-last-error.txt` from an earlier failed attempt confuses admins after a successful retry | **Avoided** — `enrollDevice` calls `clearEnrollLastError()` at the start of every attempt (Decision 8). |
+| Goroutine leak in `waitForEnrollment` tests | **Avoided** — `waitForEnrollment` takes `context.Context`, tests cancel via `context.WithCancel` (Decision 9). |
 | Event Log source registration fails (non-admin helper process) | Low | Registration is best-effort wrapped in `sync.Once`; failure is silent and the other three sinks still fire. |
 | `classifyEnrollError` miscategorizes a new server response | Low | The classifier falls through to `catUnknown` which still produces a readable error message using the raw error string. |
 | Cross-platform `waitForEnrollment` blocks macOS/Linux console users unexpectedly | Low | The Warn line is explicit about what's happening and how to exit. Console users can Ctrl+C. Systemd/launchd users see the wait state in `journalctl` / `log show`. |

--- a/docs/superpowers/specs/2026-04-13-msi-enrollment-failure-reporting-design.md
+++ b/docs/superpowers/specs/2026-04-13-msi-enrollment-failure-reporting-design.md
@@ -134,12 +134,17 @@ Declare two package-level function vars in `main.go` that the service wrapper an
 // without running the real startup pipeline. Production callers must
 // use these vars, not the unexported symbols they wrap.
 var (
-    startAgentFn        func(*config.Config) (*agentComponents, error) = startAgent
-    waitForEnrollmentFn func(context.Context, string) *config.Config   = waitForEnrollment
+    startAgentFn        func(*config.Config) (*agentComponents, error)                              = startAgent
+    waitForEnrollmentFn func(context.Context, string) *config.Config                                = waitForEnrollment
+    runServiceLoopFn    func(*agentComponents, <-chan svc.ChangeRequest, chan<- svc.Status) (bool, uint32) = runServiceLoop
 )
 ```
 
-Every call site described in Components 1.d and 4 uses `startAgentFn(cfg)` and `waitForEnrollmentFn(ctx, cfgFile)` — the unadorned symbols `startAgent` and `waitForEnrollment` are referenced only by the vars themselves and by tests that want to exercise the real implementations. A linter/CI check could enforce this; for now it's a code-review discipline.
+Every call site described in Components 1.e and 4 uses `startAgentFn(cfg)`, `waitForEnrollmentFn(ctx, cfgFile)`, and `runServiceLoopFn(comps, r, changes)`. The unadorned symbols are referenced only by the vars themselves and by tests that want to exercise the real implementations. A linter/CI check could enforce this; for now it's a code-review discipline.
+
+**Why `runServiceLoopFn` is needed as a seam:** today's `shutdownAgent` (at `main.go:187-222`) unconditionally dereferences `comps.hb.SessionBroker()`, `comps.hb.StopAcceptingCommands()`, `comps.hb.DrainAndWait(ctx)`, `comps.wsClient.Stop()`, and `comps.hb.Stop()`. Any test that lets `Execute` reach `runServiceLoop` with a nil-filled fake `*agentComponents` will panic on the first stop/shutdown. A stub `runServiceLoopFn` that ignores its `*agentComponents` argument lets tests verify the state-transition ordering (`StartPending → startAgentFn → Running → runServiceLoopFn entered`) without constructing a real `Heartbeat` + `websocket.Client` + `SecureString` — which would otherwise require real network I/O, a running API server, and a valid auth token. The seam adds 1 line of production code and eliminates an entire class of "tests need integration fixtures" problems.
+
+`runServiceLoopFn` takes the same signature as the extracted `runServiceLoop` helper mentioned in Component 4 (which encapsulates the `for { select { r } }` block and the call to `shutdownAgent` on stop).
 
 **Change 1.c — split `startAgent` into config load + real startup:**
 
@@ -521,7 +526,7 @@ func (s *breezeService) Execute(args []string, r <-chan svc.ChangeRequest, chang
         }
         changes <- svc.Status{State: svc.Running, Accepts: accepted}
         log.Info("agent running as Windows service")
-        return runServiceLoop(comps, r, changes)
+        return runServiceLoopFn(comps, r, changes)
     }
 
     // --- Async unenrolled path (MSI install with no creds) ---
@@ -581,11 +586,11 @@ waitLoop:
         changes <- svc.Status{State: svc.StopPending}
         return true, 1
     }
-    return runServiceLoop(comps, r, changes)
+    return runServiceLoopFn(comps, r, changes)
 }
 ```
 
-`runServiceLoop(comps, r, changes)` is a small refactor of the current `for { select { r }}` block at lines 135-163 — extracted so both paths can share it.
+`runServiceLoopFn(comps, r, changes)` is a small refactor of the current `for { select { r }}` block at lines 135-163 — extracted so both paths can share it.
 
 **Post-install failure semantics.** On the async path, a failure from `startAgent(enrolledCfg)` cannot roll back the MSI (the install has long completed). The failure is logged to `agent.log`, `agent-start-failed.txt`, and Event Log, and the service transitions to Stopped. Admins debug by checking those sinks and re-running `breeze-agent enroll` with corrected parameters plus `sc start BreezeAgent`. This matches how every other agent-style product handles deferred-enrollment startup failures and is an acceptable trade-off because the admin explicitly chose a no-creds install.
 
@@ -654,26 +659,63 @@ func Error(source, message string)   {}
 **`agent/internal/config/config_test.go`**:
 - `TestIsEnrolled`: table-driven — `{nil → false, empty → false, agentIDOnly → false, tokenOnly → false, both → true}`.
 
-**`agent/cmd/breeze-agent/service_windows_test.go`** (`//go:build windows`) — create if absent. All three tests rely on the package-level hooks declared in Component 1.b (`startAgentFn`, `waitForEnrollmentFn`). Each test saves the original hook value, installs a stub, and restores in `t.Cleanup`:
+**`agent/cmd/breeze-agent/service_windows_test.go`** (`//go:build windows`) — create if absent. All three tests rely on the package-level hooks declared in Component 1.b (`startAgentFn`, `waitForEnrollmentFn`, `runServiceLoopFn`). Because `runServiceLoopFn` is stubbed in every test, the `*agentComponents` value returned by the stubbed `startAgentFn` never reaches any code that dereferences `comps.hb` or `comps.wsClient` — a zero-value pointer or a nil is sufficient. No `heartbeat.Heartbeat`, `websocket.Client`, or `secmem.SecureString` is constructed in these tests.
+
+Shared test helper:
 
 ```go
-func TestExecute_EnrolledPath_SignalsRunningAfterStartFn(t *testing.T) {
-    origStart := startAgentFn
-    t.Cleanup(func() { startAgentFn = origStart })
+// installServiceStubs wires all three test seams to stubs that record
+// call ordering into events. Returns a release() func that unblocks any
+// stub waiting on releaseCh (used by the unenrolled-path tests). The
+// t.Cleanup restoration is registered automatically.
+func installServiceStubs(t *testing.T) (events chan string, release func()) {
+    t.Helper()
+    origStart, origWait, origLoop := startAgentFn, waitForEnrollmentFn, runServiceLoopFn
+    t.Cleanup(func() {
+        startAgentFn, waitForEnrollmentFn, runServiceLoopFn = origStart, origWait, origLoop
+    })
+    events = make(chan string, 16)
+    releaseCh := make(chan struct{})
+    release = func() { close(releaseCh) }
 
-    var startCalled atomic.Bool
     startAgentFn = func(cfg *config.Config) (*agentComponents, error) {
-        startCalled.Store(true)
-        return &agentComponents{ /* minimal fake */ }, nil
+        events <- "startAgent"
+        return &agentComponents{}, nil // zero-value; runServiceLoopFn never dereferences
     }
-    // ... write enrolled config, drive Execute with mock changes chan,
-    // assert order: StartPending → (startCalled=true) → Running.
+    waitForEnrollmentFn = func(ctx context.Context, cfgFile string) *config.Config {
+        events <- "waitForEnrollment.enter"
+        select {
+        case <-releaseCh:
+            events <- "waitForEnrollment.release"
+            // Re-load cfg from disk so the post-wait startAgentFn sees
+            // the enrolled state the test arranged.
+            cfg, _ := config.Load(cfgFile)
+            return cfg
+        case <-ctx.Done():
+            events <- "waitForEnrollment.cancelled"
+            return nil
+        }
+    }
+    runServiceLoopFn = func(comps *agentComponents, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
+        events <- "runServiceLoop"
+        // Wait for a stop request so the test can terminate Execute cleanly.
+        for cr := range r {
+            if cr.Cmd == svc.Stop || cr.Cmd == svc.Shutdown {
+                changes <- svc.Status{State: svc.StopPending}
+                return false, 0
+            }
+        }
+        return false, 0
+    }
+    return events, release
 }
 ```
 
-- `TestExecute_EnrolledPath_SignalsRunningAfterStartFn`: override `startAgentFn` to return a fake `*agentComponents` after recording that it was called. Write a valid enrolled config to a temp file, drive `Execute` with a mock `changes` chan, assert the ordering `StartPending → (startAgentFn called) → Running` — the Running signal MUST arrive only after the stub observed its call. Proves the enrolled path is still synchronous (Decision 6).
-- `TestExecute_UnenrolledPath_SignalsRunningBeforeWait`: override `waitForEnrollmentFn` to block on a test-controlled channel until released. Write an empty config, drive `Execute`, assert `Running` is emitted *before* the stub is released. Then write an enrolled config to the temp file and release the stub by returning the loaded config; assert `Execute` proceeds into `startAgentFn` (also stubbed) and emits no additional Running transitions.
-- `TestExecute_StopWhileWaiting`: same stubs as the previous test, send `svc.Stop` on the mock request channel while `waitForEnrollmentFn` is still blocked. Assert the stub's `ctx.Done()` fires (i.e., the test stub observes cancellation) and that `Execute` emits `StopPending` and returns `false, 0`. Proves the SCM control loop stays responsive during the wait.
+- **`TestExecute_EnrolledPath_SignalsRunningAfterStartFn`**: write a valid enrolled `agent.yaml` + `secrets.yaml` to a temp dir. Call `installServiceStubs(t)`. Drive `Execute` in a goroutine with a mock `changes` channel and a mock request channel; send `svc.Stop` on the request channel to terminate the stubbed `runServiceLoopFn`. Assert: the `events` channel records `startAgent` before any `runServiceLoop` event, and the `changes` channel records `StartPending, Running` with the `Running` state arriving strictly after the `events` channel's `startAgent` entry. Proves the enrolled path remains synchronous (Decision 6) — if the implementation regressed and moved `Running` before `startAgentFn`, the assertion on `changes[Running]` vs `events[startAgent]` ordering would fail.
+
+- **`TestExecute_UnenrolledPath_SignalsRunningBeforeWait`**: write an empty `agent.yaml` (no AgentID, no AuthToken) to a temp dir. Call `installServiceStubs(t)`. Drive `Execute` in a goroutine. Assert the `changes` channel records `StartPending, Running` and the `events` channel records `waitForEnrollment.enter` — the `Running` signal MUST arrive before `waitForEnrollment.enter`. Then overwrite the config files with an enrolled state, call `release()`, and assert the events sequence continues with `waitForEnrollment.release, startAgent, runServiceLoop`. Send `svc.Stop` to terminate.
+
+- **`TestExecute_StopWhileWaiting`**: same temp-dir setup as the previous test, same `installServiceStubs`. Drive `Execute` in a goroutine. Wait for `events` to record `waitForEnrollment.enter`. Send `svc.Stop` on the request channel WITHOUT calling `release()`. Assert `events` records `waitForEnrollment.cancelled` (proves the stub observed `ctx.Done()`), `changes` records `StopPending`, and `Execute` returns `false, 0`. Proves the SCM control loop is responsive to Stop while waiting.
 
 ### Manual MSI smoke tests
 
@@ -711,7 +753,8 @@ Manual verification is still required to confirm no surprise (UAC redirection, `
 - `agent/cmd/breeze-agent/service_windows.go` —
   - `runAsService` now takes `cfgFile string` instead of a `startFn` closure.
   - `Execute` splits into enrolled (synchronous, preserves today's failure semantics) and unenrolled (reports Running early, then `waitForEnrollment` with SCM control-loop responsiveness, then `startAgent`) branches.
-  - Extract the post-startup `for { select { r } }` block into a shared `runServiceLoop(comps, r, changes)` helper used by both branches.
+  - Extract the post-startup `for { select { r } }` block and its `shutdownAgent(comps)` call into a shared `runServiceLoop(comps, r, changes)` helper used by both branches via the `runServiceLoopFn` seam.
+  - All three call paths (`startAgentFn`, `waitForEnrollmentFn`, `runServiceLoopFn`) use the package-level function vars declared in Component 1.b so Windows service tests can stub them without constructing real `*agentComponents`.
 - `agent/cmd/breeze-agent/main_test.go` — `TestWaitForEnrollment_UnblocksWhenConfigBecomesValid`, `TestWaitForEnrollment_RespectsContextCancel`, `TestWaitForEnrollment_IgnoresTornWrite`.
 - `agent/cmd/breeze-agent/service_windows_test.go` — may not exist; create if absent. `TestExecute_EnrolledPath_SignalsRunningAfterStartFn`, `TestExecute_UnenrolledPath_SignalsRunningBeforeWait`, `TestExecute_StopWhileWaiting`.
 - `agent/internal/config/config.go` — add `IsEnrolled(cfg *Config) bool` helper.


### PR DESCRIPTION
## Summary

Fixes #411.

- **MSI installs without credentials now succeed.** The service starts into a wait-for-enrollment loop so imaged/sysprep'd deployments can enroll later via a separate `breeze-agent enroll` call without a service restart.
- **MSI installs with bad credentials fail cleanly** (exit 1603) with a human-readable cause written to four sinks: `install.log` (via stderr), `agent.log` (via slog), `C:\ProgramData\Breeze\logs\enroll-last-error.txt` (single-line timestamped marker), and Windows Event Log (Application / BreezeAgent / Error).
- **MSI installs with good credentials continue to work exactly as before** — the enrolled path in the Windows service wrapper still signals `Running` only after `startAgent` succeeds, so any post-enroll init failure (mTLS, heartbeat, log shipper) still fails the install (spec decision 6).

## Design

Full design doc with four rounds of review feedback resolved lives at `docs/superpowers/specs/2026-04-13-msi-enrollment-failure-reporting-design.md`. Implementation plan at `docs/superpowers/plans/2026-04-13-msi-enrollment-failure-reporting.md`.

Key decisions:
1. `startAgent` is split so callers decide whether to wait — the Windows service `Execute` forks on `config.IsEnrolled(cfg)` into a synchronous enrolled path (today's semantics) or an async unenrolled path (signals `Running` immediately before blocking on `waitForEnrollment`, to avoid the ~30s SCM start deadline).
2. `config.IsEnrolled(cfg)` checks both `AgentID` and `AuthToken` so the wait loop survives torn `SaveTo` writes (agent.yaml is written before secrets.yaml at `internal/config/config.go:313-376`).
3. Package-level test seams (`startAgentFn`, `waitForEnrollmentFn`, `runServiceLoopFn`) let Windows service tests observe state-transition ordering without constructing real `heartbeat.Heartbeat` + `websocket.Client` fixtures.
4. `enrollError(cat, friendly, detail)` routes every failure site in `enrollDevice` through one helper that writes to all four sinks and exits with a category-specific code (10-16) so admins can `echo %errorlevel%` to distinguish network/auth/not-found/rate-limit/server/config/unknown failures.
5. `enroll-last-error.txt` lives at `%ProgramData%\Breeze\logs\` — survives MSI rollback because CA-written files are opaque to MSI's rollback mechanism (the installer has no record they were created).
6. `clearEnrollLastError()` is called at the start of every enroll attempt so a successful retry leaves no stale marker behind.
7. WiX CA `Return="ignore"` → `Return="check"` — bad credentials now roll back the install cleanly instead of silently cascading into a service start failure.

## Task breakdown

13 tasks, executed via `superpowers:subagent-driven-development` with two-stage review (spec compliance + code quality) after every task:

1. `feat(api): add ErrHTTPStatus type for enroll failure classification`
2. `feat(config): add IsEnrolled(cfg) predicate for complete enrollment check`
3. `feat(agent): add internal/eventlog — cross-platform event log wrapper`
4. `feat(agent): add enrollError helper — four-sink failure reporter`
5. `refactor(agent): route enrollDevice failures through enrollError`
6. `feat(agent): add waitForEnrollment, bootstrap logging, and test seams`
7. `test(agent): waitForEnrollment — unblock, cancel, torn-write coverage`
8. `refactor(agent): split startAgent; service wrapper forks on IsEnrolled` (+ defensive `StopPending` fixup)
9. `test(agent): Windows service wrapper state-transition coverage`
10. `fix(installer): EnrollAgent CA Return=check — surface enroll failures` (+ comment paraphrase fixup)
11. Full verification pass (tests + cross-compile + vet)
12. Manual MSI smoke test checklist (deferred — needs Windows VM)
13. This PR

## Test plan

### Automated (in this PR)

- [x] `go test -race ./cmd/breeze-agent/... ./internal/eventlog/... ./internal/config/... ./pkg/api/...` passes on macOS
- [x] Cross-compile clean for `windows/amd64`, `darwin/amd64`, `darwin/arm64`, `linux/amd64`
- [x] `GOOS=windows go vet ./cmd/breeze-agent/...` — only a pre-existing `unsafe.Pointer` warning in `extractSessionID` (blamed to commit 291b56610, Feb 2026)
- [x] `service_windows_test.go` compiles for Windows via `GOOS=windows go test -c`
- [x] `TestIsEnrolled` table test (5 cases including the torn-write scenarios)
- [x] `TestWaitForEnrollment_*` trio — unblock, context cancel, torn-write regression
- [x] `TestExecute_*` trio (Windows-gated) — enrolled path Running-after-startFn, unenrolled path Running-before-wait, stop-while-waiting
- [x] `classifyEnrollError` table test across 401/403/404/429/500/503/network/unknown
- [x] `TestEnrollError_WritesAllFourSinks` — panic-on-exit trick verifies all four sinks fire and exit code matches category

### Manual (before merge)

On a Windows Server 2022 VM, verify the five scenarios documented in Task 12 of the plan:

- [ ] **Scenario 1 — No credentials**: `msiexec /i breeze-agent.msi /qn /l*v install.log` succeeds, service is Running + idle in wait loop, `enroll-last-error.txt` absent, Event Viewer shows info \"Waiting for enrollment\"
- [ ] **Scenario 2 — Good credentials**: `msiexec /i breeze-agent.msi ENROLLMENT_KEY=brz_valid SERVER_URL=https://valid.example /qn /l*v install.log` succeeds, `agent.yaml` + `secrets.yaml` written, service is Running + enrolled
- [ ] **Scenario 3 — Bad key**: `msiexec /i breeze-agent.msi ENROLLMENT_KEY=brz_typo SERVER_URL=https://valid.example /qn /l*v install.log` fails 1603, clean rollback of `C:\Program Files\Breeze`, `enroll-last-error.txt` present with \"enrollment key not recognized\" message, Event Viewer error entry
- [ ] **Scenario 4 — Server unreachable**: same as scenario 3 with `SERVER_URL=https://unreachable.example`, friendly message is \"server unreachable at ...\"
- [ ] **Scenario 5 — Deferred enrollment flow**: scenario 1 install → elevated `breeze-agent.exe enroll brz_valid --server https://valid.example` → within 10 seconds the running service picks up the new config and starts heartbeating, with no restart

## Known follow-ups

- **#412** (pre-existing): CI workflow to build and test a signed MSI without cutting a full release — would automate the five manual smoke tests above.
- **Dialog-mode error presentation**: UI-mode MSI installs show a generic \"custom action failed\" dialog rather than the specific cause. Wiring up a DLL CA wrapper to call `MsiProcessMessage` would fix this, but it's out of scope here — `/qn` is the dominant deployment mode and the four sinks cover it.
- **Log shipper flush on Windows service shutdown**: pre-existing gap (not introduced by this PR) — `shutdownAgent` never calls `logging.StopShipper`, so the last batch of logs may be dropped on clean service stop. Flagged for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)