### PR TITLE
fix(api): stop burning enroll slot on download + disambiguate 401 + fresh child TTL

### DIFF
--- a/apps/api/src/routes/agents/enrollment.test.ts
+++ b/apps/api/src/routes/agents/enrollment.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+// ---------- mocks ----------
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(),
+    update: vi.fn(),
+  },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../../db/schema', () => ({
+  enrollmentKeys: {
+    id: 'id',
+    orgId: 'orgId',
+    siteId: 'siteId',
+    key: 'key',
+    keySecretHash: 'keySecretHash',
+    expiresAt: 'expiresAt',
+    maxUsage: 'maxUsage',
+    usageCount: 'usageCount',
+  },
+  devices: { id: 'id', hostname: 'hostname', orgId: 'orgId', siteId: 'siteId', status: 'status' },
+  deviceHardware: {},
+  deviceNetwork: {},
+  organizations: { id: 'id', partnerId: 'partnerId' },
+  partners: { id: 'id', maxDevices: 'maxDevices' },
+}));
+
+vi.mock('../../services/auditEvents', () => ({
+  writeAuditEvent: vi.fn(),
+}));
+
+vi.mock('../../services/enrollmentKeySecurity', () => ({
+  hashEnrollmentKey: vi.fn((k: string) => `hashed:${k}`),
+}));
+
+vi.mock('../../services/clientIp', () => ({
+  getTrustedClientIp: vi.fn(() => '127.0.0.1'),
+}));
+
+vi.mock('../../services/redis', () => ({
+  getRedis: vi.fn(() => ({})),
+}));
+
+vi.mock('../../services/rate-limit', () => ({
+  rateLimiter: vi.fn(async () => ({ allowed: true, resetAt: new Date(Date.now() + 60000) })),
+}));
+
+vi.mock('./helpers', () => ({
+  generateAgentId: vi.fn(() => 'agent-id-1'),
+  generateApiKey: vi.fn(() => 'brz_token'),
+  issueMtlsCertForDevice: vi.fn(async () => null),
+}));
+
+vi.mock('../../services/warrantyWorker', () => ({
+  queueWarrantySyncForDevice: vi.fn(),
+}));
+
+vi.mock('../../services/partnerHooks', () => ({
+  dispatchHook: vi.fn(),
+}));
+
+// ---------- imports after mocks ----------
+
+import { db } from '../../db';
+import { writeAuditEvent } from '../../services/auditEvents';
+import { enrollmentRoutes } from './enrollment';
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route('/agents', enrollmentRoutes);
+  return app;
+}
+
+const baseEnrollBody = {
+  enrollmentKey: 'e2e-test-key',
+  hostname: 'host-1',
+  osType: 'windows',
+  osVersion: 'Windows Server 2022',
+  architecture: 'amd64',
+  agentVersion: '0.62.24',
+  deviceRole: 'server',
+};
+
+function mockKeyLookup(row: Record<string, unknown> | undefined) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({
+        limit: vi.fn().mockResolvedValue(row ? [row] : []),
+      })),
+    })),
+  } as any);
+}
+
+// ---------- tests ----------
+
+describe('POST /agents/enroll — 401 reason disambiguation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.AGENT_ENROLLMENT_SECRET;
+    process.env.NODE_ENV = 'test';
+  });
+
+  it('returns reason=enrollment_key_not_found when the hash has no matching row', async () => {
+    mockKeyLookup(undefined);
+
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody),
+    });
+
+    expect(resp.status).toBe(401);
+    const body = await resp.json();
+    expect(body).toEqual({
+      error: 'Enrollment key not recognized',
+      reason: 'enrollment_key_not_found',
+    });
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        details: { reason: 'enrollment_key_not_found' },
+        result: 'denied',
+      })
+    );
+  });
+
+  it('returns reason=enrollment_key_expired when the row exists but expiresAt is in the past', async () => {
+    mockKeyLookup({
+      id: 'key-1',
+      orgId: 'org-1',
+      siteId: 'site-1',
+      keySecretHash: null,
+      expiresAt: new Date(Date.now() - 60_000),
+      maxUsage: null,
+      usageCount: 0,
+    });
+
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody),
+    });
+
+    expect(resp.status).toBe(401);
+    const body = await resp.json();
+    expect(body.reason).toBe('enrollment_key_expired');
+    expect(body.error).toContain('expired');
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        orgId: 'org-1',
+        details: { reason: 'enrollment_key_expired', keyId: 'key-1' },
+      })
+    );
+  });
+
+  it('returns reason=enrollment_key_exhausted when usageCount >= maxUsage', async () => {
+    mockKeyLookup({
+      id: 'key-2',
+      orgId: 'org-2',
+      siteId: 'site-2',
+      keySecretHash: null,
+      expiresAt: new Date(Date.now() + 3600_000),
+      maxUsage: 3,
+      usageCount: 3,
+    });
+
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody),
+    });
+
+    expect(resp.status).toBe(401);
+    const body = await resp.json();
+    expect(body.reason).toBe('enrollment_key_exhausted');
+    expect(body.error).toContain('maximum usage');
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        orgId: 'org-2',
+        details: { reason: 'enrollment_key_exhausted', keyId: 'key-2' },
+      })
+    );
+  });
+
+  it('accepts a valid (unexpired, non-exhausted) row and does not return 401 at the lookup stage', async () => {
+    // Valid lookup → then downstream update fetch returns no row → race-lost branch.
+    // We just want to assert the 401 reason is NOT one of the three above.
+    mockKeyLookup({
+      id: 'key-3',
+      orgId: 'org-3',
+      siteId: 'site-3',
+      keySecretHash: null,
+      expiresAt: new Date(Date.now() + 3600_000),
+      maxUsage: 10,
+      usageCount: 0,
+    });
+
+    // Downstream update: return empty (race condition path) so we stop there
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn().mockResolvedValue([]),
+        })),
+      })),
+    } as any);
+
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody),
+    });
+
+    expect(resp.status).toBe(401);
+    const body = await resp.json();
+    expect(body.reason).toBe('enrollment_key_race_lost');
+  });
+});

--- a/apps/api/src/routes/agents/enrollment.ts
+++ b/apps/api/src/routes/agents/enrollment.ts
@@ -72,21 +72,29 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
   const hashedEnrollmentKey = hashEnrollmentKey(data.enrollmentKey);
 
   return withSystemDbAccessContext(async () => {
+    // Re-validated in the UPDATE WHERE below to close the TOCTOU window between
+    // this initial lookup and the usage_count bump.
     const validEnrollmentKeyConditions = [
       eq(enrollmentKeys.key, hashedEnrollmentKey),
       sql`(${enrollmentKeys.expiresAt} IS NULL OR ${enrollmentKeys.expiresAt} > NOW())`,
       sql`(${enrollmentKeys.maxUsage} IS NULL OR ${enrollmentKeys.usageCount} < ${enrollmentKeys.maxUsage})`,
     ] as const;
 
+    // Step 1: look up by hash ONLY, so we can tell the admin *why* the key
+    // was rejected instead of conflating three distinct failure modes into
+    // one opaque "Invalid or expired enrollment key" string.
     const [matchingKey] = await db
       .select({
         id: enrollmentKeys.id,
         orgId: enrollmentKeys.orgId,
         siteId: enrollmentKeys.siteId,
         keySecretHash: enrollmentKeys.keySecretHash,
+        expiresAt: enrollmentKeys.expiresAt,
+        maxUsage: enrollmentKeys.maxUsage,
+        usageCount: enrollmentKeys.usageCount,
       })
       .from(enrollmentKeys)
-      .where(and(...validEnrollmentKeyConditions))
+      .where(eq(enrollmentKeys.key, hashedEnrollmentKey))
       .limit(1);
 
     if (!matchingKey) {
@@ -96,11 +104,51 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
         action: 'agent.enroll',
         resourceType: 'device',
         resourceName: data.hostname,
-        details: { reason: 'invalid_or_expired_enrollment_key' },
+        details: { reason: 'enrollment_key_not_found' },
         result: 'denied',
-        errorMessage: 'Invalid or expired enrollment key',
+        errorMessage: 'Enrollment key not recognized',
       });
-      return c.json({ error: 'Invalid or expired enrollment key' }, 401);
+      return c.json({
+        error: 'Enrollment key not recognized',
+        reason: 'enrollment_key_not_found',
+      }, 401);
+    }
+
+    // Step 2: the row exists — now tell the admin precisely which invariant
+    // it's violating. Both branches stay on 401 for backwards compatibility
+    // with older agents that don't parse `reason`.
+    if (matchingKey.expiresAt && new Date(matchingKey.expiresAt) <= new Date()) {
+      writeAuditEvent(c, {
+        orgId: matchingKey.orgId,
+        actorType: 'system',
+        action: 'agent.enroll',
+        resourceType: 'device',
+        resourceName: data.hostname,
+        details: { reason: 'enrollment_key_expired', keyId: matchingKey.id },
+        result: 'denied',
+        errorMessage: 'Enrollment key has expired',
+      });
+      return c.json({
+        error: 'Enrollment key has expired — regenerate the key or installer link and retry',
+        reason: 'enrollment_key_expired',
+      }, 401);
+    }
+
+    if (matchingKey.maxUsage !== null && matchingKey.usageCount >= matchingKey.maxUsage) {
+      writeAuditEvent(c, {
+        orgId: matchingKey.orgId,
+        actorType: 'system',
+        action: 'agent.enroll',
+        resourceType: 'device',
+        resourceName: data.hostname,
+        details: { reason: 'enrollment_key_exhausted', keyId: matchingKey.id },
+        result: 'denied',
+        errorMessage: 'Enrollment key usage exhausted',
+      });
+      return c.json({
+        error: 'Enrollment key has reached its maximum usage count — regenerate a fresh key or installer link',
+        reason: 'enrollment_key_exhausted',
+      }, 401);
     }
 
     const providedSecret = getProvidedEnrollmentSecret(c, data);
@@ -199,17 +247,24 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
       .returning();
 
     if (!key) {
+      // The row existed at step 1 but the re-validated UPDATE affected 0
+      // rows — the key expired or was exhausted between the initial lookup
+      // and the claim. Distinct reason so this specific race is visible in
+      // the audit log and the client can retry with a fresh installer.
       writeAuditEvent(c, {
-        orgId: null,
+        orgId: matchingKey.orgId,
         actorType: 'system',
         action: 'agent.enroll',
         resourceType: 'device',
         resourceName: data.hostname,
-        details: { reason: 'invalid_or_expired_enrollment_key' },
+        details: { reason: 'enrollment_key_race_lost', keyId: matchingKey.id },
         result: 'denied',
-        errorMessage: 'Invalid or expired enrollment key',
+        errorMessage: 'Enrollment key was claimed by another enrollment in the same moment',
       });
-      return c.json({ error: 'Invalid or expired enrollment key' }, 401);
+      return c.json({
+        error: 'Enrollment key was just exhausted or expired — regenerate a fresh key or installer link',
+        reason: 'enrollment_key_race_lost',
+      }, 401);
     }
 
     const siteId = key.siteId!; // non-null asserted: matchingKey.siteId guard at line 180

--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -79,8 +79,8 @@ vi.mock('../services/rate-limit', () => ({
 // ============================================================
 // Import after mocks
 // ============================================================
-import { enrollmentKeyRoutes, publicShortLinkRoutes } from './enrollmentKeys';
-import { db } from '../db';
+import { enrollmentKeyRoutes, publicEnrollmentRoutes, publicShortLinkRoutes } from './enrollmentKeys';
+import { db, withSystemDbAccessContext } from '../db';
 
 // ============================================================
 // Helpers
@@ -183,6 +183,88 @@ describe('POST /enrollment-keys/:id/installer-link', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.shortUrl).toMatch(/^https?:\/\/.+\/s\/[A-Za-z0-9]{10}$/);
+  });
+
+  it('refuses to build an installer when parent key is within 60s of expiry', async () => {
+    // Parent with only 30s of life left. Previously the child inherited this
+    // and was DOA. Now the route refuses with 410 so the admin can regenerate.
+    // NOTE: handler returns 410 before calling db.insert. Using the persistent
+    // mockReturnValue here (not mockReturnValueOnce) so unconsumed entries
+    // do not leak onto the queue and poison subsequent tests.
+    const parentRow = makeKeyRow({
+      expiresAt: new Date(Date.now() + 30_000),
+    });
+
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([parentRow]),
+        }),
+      }),
+    } as any);
+
+    const insertValues = vi.fn();
+    vi.mocked(db.insert).mockReturnValue({ values: insertValues } as any);
+
+    const res = await app.request(`/enrollment-keys/${KEY_ID}/installer-link`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ platform: 'windows' }),
+    });
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body.error).toContain('expires too soon');
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it('child key gets a 24h TTL when parent has enough remaining life', async () => {
+    // Parent has 1h remaining (plenty) — child insert should fire with a
+    // fresh ~24h expiresAt, independent of parent.
+    const parentRow = makeKeyRow({
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000), // 1h
+    });
+    const childRow = makeChildKeyRow();
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([parentRow]),
+          }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as any);
+
+    const insertValues = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([childRow]),
+    });
+    vi.mocked(db.insert).mockReturnValue({ values: insertValues } as any);
+
+    const before = Date.now();
+    const res = await app.request(`/enrollment-keys/${KEY_ID}/installer-link`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ platform: 'windows' }),
+    });
+    const after = Date.now();
+    expect(res.status).toBe(200);
+
+    expect(insertValues).toHaveBeenCalledTimes(1);
+    const firstCall = insertValues.mock.calls[0]!;
+    const insertedRow = firstCall[0] as { expiresAt: Date };
+    const childExpiryMs = insertedRow.expiresAt.getTime();
+    // Child TTL must be at least 23 hours past "before" (well above parent's 1h)
+    expect(childExpiryMs).toBeGreaterThan(before + 23 * 60 * 60 * 1000);
+    // And no more than 25 hours past "after" (guards against runaway values)
+    expect(childExpiryMs).toBeLessThan(after + 25 * 60 * 60 * 1000);
+    // Explicitly NOT the parent's expiresAt
+    expect(childExpiryMs).not.toBe(parentRow.expiresAt.getTime());
   });
 
   it('shortUrl and url share the same origin', async () => {
@@ -375,5 +457,78 @@ describe('GET /s/:code', () => {
 
     const res = await app.request('/s/noplatform1');
     expect(res.status).toBe(404);
+  });
+});
+
+// ============================================================
+// GET /public-download/:platform — RLS scoping regression test
+// ============================================================
+
+describe('GET /public-download/:platform', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.PUBLIC_API_URL = 'https://api.example.com';
+    app = new Hono();
+    app.route('/enrollment-keys', publicEnrollmentRoutes);
+  });
+
+  it('runs usage_count bump inside withSystemDbAccessContext (not the bare pool)', async () => {
+    // Regression test: the public-download handler previously wrapped only
+    // the initial SELECT in withSystemDbAccessContext and then called
+    // serveInstaller OUTSIDE that wrapper. serveInstaller's usage_count
+    // UPDATE therefore ran under the request's default (bare-pool, no
+    // breeze_app GUCs set) scope, and the RLS policy on enrollment_keys
+    // silently dropped the UPDATE. Download quotas were never enforced.
+    //
+    // This test asserts that after entering the public-download handler,
+    // the first call into db.update happens INSIDE a withSystemDbAccessContext
+    // scope — i.e. the system-context mock was called BEFORE db.update.
+    const row = makeKeyRow({
+      shortCode: 'pubcode1234',
+      installerPlatform: 'windows',
+    });
+
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([row]),
+        }),
+      }),
+    } as any);
+
+    const callOrder: string[] = [];
+    vi.mocked(withSystemDbAccessContext).mockImplementation(async (fn: () => Promise<unknown>) => {
+      callOrder.push('withSystemDbAccessContext:enter');
+      const result = await fn();
+      callOrder.push('withSystemDbAccessContext:exit');
+      return result;
+    });
+
+    vi.mocked(db.update).mockImplementation(
+      ((..._args: unknown[]) => {
+        callOrder.push('db.update');
+        return {
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(undefined),
+          }),
+        } as any;
+      }) as any
+    );
+
+    const res = await app.request(
+      '/enrollment-keys/public-download/windows?token=abc123',
+    );
+
+    expect(res.status).toBe(200);
+    // withSystemDbAccessContext must have been entered first, and the
+    // db.update must have been invoked between its enter and exit.
+    const enterIdx = callOrder.indexOf('withSystemDbAccessContext:enter');
+    const updateIdx = callOrder.indexOf('db.update');
+    const exitIdx = callOrder.indexOf('withSystemDbAccessContext:exit');
+    expect(enterIdx).toBeGreaterThanOrEqual(0);
+    expect(updateIdx).toBeGreaterThan(enterIdx);
+    expect(exitIdx).toBeGreaterThan(updateIdx);
   });
 });

--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -474,20 +474,27 @@ describe('GET /public-download/:platform', () => {
     app.route('/enrollment-keys', publicEnrollmentRoutes);
   });
 
-  it('runs usage_count bump inside withSystemDbAccessContext (not the bare pool)', async () => {
-    // Regression test: the public-download handler previously wrapped only
-    // the initial SELECT in withSystemDbAccessContext and then called
-    // serveInstaller OUTSIDE that wrapper. serveInstaller's usage_count
-    // UPDATE therefore ran under the request's default (bare-pool, no
-    // breeze_app GUCs set) scope, and the RLS policy on enrollment_keys
-    // silently dropped the UPDATE. Download quotas were never enforced.
-    //
-    // This test asserts that after entering the public-download handler,
-    // the first call into db.update happens INSIDE a withSystemDbAccessContext
-    // scope — i.e. the system-context mock was called BEFORE db.update.
+  it('does not bump child key usage_count on download — leaves the slot for the agent enroll call', async () => {
+    // Regression test for the root cause of the MSI "401 Invalid or
+    // expired enrollment key" bug. Previously serveInstaller ran
+    // `UPDATE enrollment_keys SET usage_count = usage_count + 1 WHERE
+    // id = :keyRow.id` right after a successful build. Combined with
+    // max_usage = 1 on single-use child keys (short-link downloads and
+    // single-count installer links), this burned the enrollment slot
+    // at *download* time: by the time the agent POSTed to
+    // /agents/enroll, the child row already had usage_count >=
+    // max_usage, the enroll endpoint's `usage_count < max_usage`
+    // filter rejected the row, and the agent saw the deliberately-opaque
+    // "Invalid or expired enrollment key" 401. The enroll endpoint
+    // itself owns the slot-consuming UPDATE under a TOCTOU-safe
+    // `UPDATE ... WHERE usage_count < max_usage`, so downloads must
+    // NOT bump usage_count. max_usage is "max successful enrollments,"
+    // not "max downloads."
     const row = makeKeyRow({
       shortCode: 'pubcode1234',
       installerPlatform: 'windows',
+      maxUsage: 1,
+      usageCount: 0,
     });
 
     vi.mocked(db.select).mockReturnValue({
@@ -498,37 +505,18 @@ describe('GET /public-download/:platform', () => {
       }),
     } as any);
 
-    const callOrder: string[] = [];
-    vi.mocked(withSystemDbAccessContext).mockImplementation(async (fn: () => Promise<unknown>) => {
-      callOrder.push('withSystemDbAccessContext:enter');
-      const result = await fn();
-      callOrder.push('withSystemDbAccessContext:exit');
-      return result;
+    // Fail loudly if anything inside the download path touches
+    // db.update — the whole point of the fix is that the download path
+    // is now read-only against the enrollment_keys row.
+    vi.mocked(db.update).mockImplementation(() => {
+      throw new Error('db.update called on public-download — regression of the usage_count-burn bug');
     });
-
-    vi.mocked(db.update).mockImplementation(
-      ((..._args: unknown[]) => {
-        callOrder.push('db.update');
-        return {
-          set: vi.fn().mockReturnValue({
-            where: vi.fn().mockResolvedValue(undefined),
-          }),
-        } as any;
-      }) as any
-    );
 
     const res = await app.request(
       '/enrollment-keys/public-download/windows?token=abc123',
     );
 
     expect(res.status).toBe(200);
-    // withSystemDbAccessContext must have been entered first, and the
-    // db.update must have been invoked between its enter and exit.
-    const enterIdx = callOrder.indexOf('withSystemDbAccessContext:enter');
-    const updateIdx = callOrder.indexOf('db.update');
-    const exitIdx = callOrder.indexOf('withSystemDbAccessContext:exit');
-    expect(enterIdx).toBeGreaterThanOrEqual(0);
-    expect(updateIdx).toBeGreaterThan(enterIdx);
-    expect(exitIdx).toBeGreaterThan(updateIdx);
+    expect(db.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -32,8 +32,39 @@ function envInt(name: string, defaultValue: number): number {
 
 const DEFAULT_ENROLLMENT_KEY_TTL_MINUTES = envInt('ENROLLMENT_KEY_DEFAULT_TTL_MINUTES', 60);
 
+// Child enrollment keys (installer downloads, installer-link downloads, and
+// short-link redemptions) get a fresh, independent TTL rather than inheriting
+// the parent's remaining lifetime. The previous "inherit parentKey.expiresAt"
+// behaviour made installers DOA whenever the parent was near expiry at
+// download time — a minute-59 download against a 60-minute parent produced a
+// child good for only 60 seconds. 24h by default, overridable.
+const CHILD_ENROLLMENT_KEY_TTL_MINUTES = envInt('CHILD_ENROLLMENT_KEY_TTL_MINUTES', 60 * 24);
+
+// Parent keys that are within this window of expiry are refused as installer
+// sources. Prevents a race where the admin-side parent is already live on
+// this side of the API but the install on a remote device fires 30 seconds
+// later, after the parent expired.
+const INSTALLER_PARENT_MIN_REMAINING_SECONDS = envInt('INSTALLER_PARENT_MIN_REMAINING_SECONDS', 60);
+
 function generateEnrollmentKey(): string {
   return randomBytes(32).toString('hex'); // 64-char hex string
+}
+
+/** Fresh absolute expiry for a child enrollment key, independent of parent. */
+function freshChildExpiresAt(): Date {
+  return new Date(Date.now() + CHILD_ENROLLMENT_KEY_TTL_MINUTES * 60 * 1000);
+}
+
+/**
+ * Guard against building an installer from a parent key whose remaining
+ * lifetime is so short the child would already be dead by the time the
+ * installer reaches the target machine. Callers that hit this should
+ * surface the returned error directly.
+ */
+function parentKeyTooCloseToExpiry(expiresAt: Date | null): boolean {
+  if (!expiresAt) return false;
+  const remainingMs = expiresAt.getTime() - Date.now();
+  return remainingMs < INSTALLER_PARENT_MIN_REMAINING_SECONDS * 1000;
 }
 
 function getPagination(query: { page?: string; limit?: string }) {
@@ -483,6 +514,11 @@ enrollmentKeyRoutes.get(
     if (parentKey.maxUsage !== null && parentKey.usageCount >= parentKey.maxUsage) {
       return c.json({ error: 'Enrollment key usage exhausted' }, 410);
     }
+    if (parentKeyTooCloseToExpiry(parentKey.expiresAt)) {
+      return c.json({
+        error: 'Parent enrollment key expires too soon to build an installer — regenerate the key with a longer TTL',
+      }, 410);
+    }
 
     // Require siteId on the parent key
     if (!parentKey.siteId) {
@@ -515,7 +551,9 @@ enrollmentKeyRoutes.get(
       return c.json({ error: `${platform === 'windows' ? 'MSI' : 'macOS PKG'} not available` }, 503);
     }
 
-    // Generate a child enrollment key (single-use, same org/site/expiry)
+    // Generate a child enrollment key. Child gets a FRESH TTL independent
+    // of the parent's remaining lifetime — otherwise late-in-life parents
+    // produce dead-on-arrival installers (see CHILD_ENROLLMENT_KEY_TTL_MINUTES).
     const rawChildKey = generateEnrollmentKey();
     const childKeyHash = hashEnrollmentKey(rawChildKey);
     const shortCode = await allocateShortCode();
@@ -529,7 +567,7 @@ enrollmentKeyRoutes.get(
         key: childKeyHash,
         keySecretHash: parentKey.keySecretHash,
         maxUsage: childMaxUsage,
-        expiresAt: parentKey.expiresAt,
+        expiresAt: freshChildExpiresAt(),
         createdBy: auth.user.id,
         shortCode,
         installerPlatform: platform,
@@ -668,6 +706,11 @@ enrollmentKeyRoutes.post(
     if (parentKey.maxUsage !== null && parentKey.usageCount >= parentKey.maxUsage) {
       return c.json({ error: 'Enrollment key usage exhausted' }, 410);
     }
+    if (parentKeyTooCloseToExpiry(parentKey.expiresAt)) {
+      return c.json({
+        error: 'Parent enrollment key expires too soon to build an installer link — regenerate the key with a longer TTL',
+      }, 410);
+    }
 
     // Require siteId on the parent key
     if (!parentKey.siteId) {
@@ -686,7 +729,7 @@ enrollmentKeyRoutes.post(
       return c.json({ error: `${platform === 'windows' ? 'MSI' : 'macOS PKG'} not available` }, 503);
     }
 
-    // Generate a child enrollment key
+    // Generate a child enrollment key with a fresh TTL independent of parent
     const rawChildKey = generateEnrollmentKey();
     const childKeyHash = hashEnrollmentKey(rawChildKey);
     const shortCode = await allocateShortCode();
@@ -700,7 +743,7 @@ enrollmentKeyRoutes.post(
         key: childKeyHash,
         keySecretHash: parentKey.keySecretHash,
         maxUsage: childMaxUsage,
-        expiresAt: parentKey.expiresAt,
+        expiresAt: freshChildExpiresAt(),
         createdBy: auth.user.id,
         shortCode,
         installerPlatform: platform,
@@ -892,22 +935,26 @@ publicEnrollmentRoutes.get(
       return c.json({ error: 'Invalid platform. Must be "windows" or "macos".' }, 400);
     }
 
-    // Look up enrollment key by token hash
-    // System context required: public endpoint with no authenticated user, RLS has no org context
+    // System context required: public endpoint with no authenticated user,
+    // RLS has no org context. The system context wraps BOTH the lookup and
+    // serveInstaller so that the usage_count bump inside serveInstaller is
+    // also scoped correctly — otherwise the breeze_app role's RLS UPDATE
+    // policy silently drops the row modification and download quotas are
+    // never enforced.
     const keyHash = hashEnrollmentKey(token);
-    const [enrollmentKey] = await withSystemDbAccessContext(async () =>
-      db
+    return withSystemDbAccessContext(async () => {
+      const [enrollmentKey] = await db
         .select()
         .from(enrollmentKeys)
         .where(eq(enrollmentKeys.key, keyHash))
-        .limit(1)
-    );
+        .limit(1);
 
-    if (!enrollmentKey) {
-      return c.json({ error: 'Invalid or expired download link' }, 404);
-    }
+      if (!enrollmentKey) {
+        return c.json({ error: 'Invalid or expired download link' }, 404);
+      }
 
-    return serveInstaller(c, enrollmentKey, platform, token);
+      return serveInstaller(c, enrollmentKey, platform, token);
+    });
   }
 );
 
@@ -946,6 +993,9 @@ publicShortLinkRoutes.get('/:code', async (c) => {
 
     // The short-link row holds only the hashed token — the raw token was never stored.
     // Spawn a fresh single-use child key FIRST so we have something to embed in the installer.
+    // Child gets a FRESH TTL independent of the short-link row's remaining
+    // lifetime so the installer survives the trip to the target machine even
+    // if the short-link row is near its own expiry.
     const rawToken = generateEnrollmentKey();
     const tokenHash = hashEnrollmentKey(rawToken);
 
@@ -958,7 +1008,7 @@ publicShortLinkRoutes.get('/:code', async (c) => {
         key: tokenHash,
         keySecretHash: row.keySecretHash,
         maxUsage: 1,
-        expiresAt: row.expiresAt,
+        expiresAt: freshChildExpiresAt(),
         createdBy: null,
         installerPlatform: row.installerPlatform,
       })

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -881,11 +881,15 @@ async function serveInstaller(
       filename = 'breeze-agent-macos.zip';
     }
 
-    // Increment usage only after successful build
-    await db
-      .update(enrollmentKeys)
-      .set({ usageCount: sql`${enrollmentKeys.usageCount} + 1` })
-      .where(eq(enrollmentKeys.id, keyRow.id));
+    // NOTE: we DO NOT bump keyRow.usageCount here. The child key's
+    // max_usage semantic is "max successful enrollments," not "max
+    // downloads" — bumping on download burns the slot before the agent
+    // has even tried to enroll, and the subsequent /agents/enroll call
+    // then sees usage_count >= max_usage and returns an opaque 401.
+    // The enroll endpoint at routes/agents/enrollment.ts owns the
+    // increment via a TOCTOU-safe UPDATE ... WHERE usage_count < max_usage
+    // so the slot is only consumed when enrollment actually succeeds.
+    // Downloads are still tracked, but via the audit log below.
 
     createAuditLogAsync({
       orgId: keyRow.orgId,


### PR DESCRIPTION
## TL;DR — this is the fix for the 401 "Invalid or expired enrollment key" failure blocking MSI installs

Three server-side fixes that together make the v0.62.23 MSI on GitHub actually enroll when users download it via the installer-link / short-link flow. **No new MSI release needed** — deploy this to `us.2breeze.app` and the existing `breeze-agent-template.msi` from v0.62.23 will enroll cleanly.

Follow-up to #432 (which fixes *reporting* of enrollment failures on the agent side). This PR fixes the *underlying cause* on the server.

## The three fixes

### 1. Root cause: stop burning the enrollment slot at download time (`549e14d0`)

`enrollmentKeys.ts:884-888` — `serveInstaller` was running `UPDATE enrollment_keys SET usage_count = usage_count + 1 WHERE id = :keyRow.id` right after a successful installer build. Combined with `max_usage: 1` on single-use child keys (short-link redemptions and single-count installer links), this burned the enrollment slot at **download** time: by the time the agent POSTed to `/agents/enroll`, the child row had `usage_count >= max_usage`, the enroll endpoint's `usage_count < max_usage` filter rejected the row, and the agent saw the deliberately-opaque 401.

**Confirmed live during debugging:** the child row the user's install attempted (`52f9816b...`) had `usage_count=1 / max_usage=1` at the exact moment the agent log captured the 401. Row was in the DB, within TTL, hash matched, secret matched — slot was already consumed by the download.

Fix: remove the download-side `usage_count` bump. `max_usage` now means "max successful enrollments" (the semantic admins actually expect). Downloads are still tracked via `createAuditLogAsync` (unchanged). The enroll endpoint at `agents/enrollment.ts` already owns the increment under a TOCTOU-safe `UPDATE ... WHERE usage_count < max_usage`.

The direct `/installer/:platform` download path was never affected (it doesn't touch the child's `usage_count`), which is why every local direct-patched MSI test in the debugging session enrolled cleanly. Only paths through `serveInstaller` (public-download and short-link) hit this.

### 2. Disambiguate the enrollment 401 into four distinct reasons (`7669a534`)

Split the conflated `Invalid or expired enrollment key` 401 into four machine-readable reasons returned in the response body alongside the existing human-readable `error` string, plus matching `audit_logs.details.reason` values:

- `enrollment_key_not_found` — hash does not match any row
- `enrollment_key_expired` — row exists but `expires_at <= NOW()`
- `enrollment_key_exhausted` — row exists but `usage_count >= max_usage`
- `enrollment_key_race_lost` — row valid at lookup but TOCTOU UPDATE affected 0 rows

Without this, the fix in (1) would have been much harder to find — the server was effectively lying about whether the key was missing, expired, or exhausted. With this, an admin staring at `enroll-last-error.txt` (from #432) sees exactly which invariant broke.

Backwards compatible: HTTP 401 and `error` field unchanged. `reason` is additive.

### 3. Fresh independent TTL for child keys (`50921c6f`)

Three child-insert sites (direct download, installer-link, short-link redemption) previously wrote `expiresAt: parentKey.expiresAt`. A parent with 59 minutes elapsed produced a child with 1 minute of life, DOA after any network hop. Fix:

- New `CHILD_ENROLLMENT_KEY_TTL_MINUTES` env var (default 24h = 1440) sets an independent fresh TTL.
- New `INSTALLER_PARENT_MIN_REMAINING_SECONDS` env var (default 60s). Direct-download and installer-link handlers refuse to build an installer if the parent has less than this remaining, returning 410 with `Parent enrollment key expires too soon to build an installer — regenerate the key with a longer TTL`.

Short-link handler skips the 60s guard because its "parent" is itself a child row with a pre-computed TTL. Only human-created parent keys go through the guard.

## Deploy path (ASAP)

```bash
# Merge this PR, then on the US droplet:
ssh root@143.198.144.173 'cd /opt/breeze && docker compose pull api && docker compose up -d api'

# Verify:
curl -sI https://us.2breeze.app/api/v1/enrollment-keys/healthcheck
```

Then redownload the MSI from us.2breeze.app and install — the existing v0.62.23 template on GitHub already has the correct agent binary and WiX flow, it just needs a clean child key row on the server side.

## Tests

- `apps/api/src/routes/agents/enrollment.test.ts` — new file, 4 cases covering each 401 reason, all pass.
- `apps/api/src/routes/enrollmentKeys.test.ts` — 3 new cases: parent-too-close-to-expiry returns 410, child gets 24h TTL independent of parent, and public-download path never issues `db.update` against `enrollment_keys` (regression guard for the root-cause fix). 11/11 total pass.
- `npx tsc --noEmit` clean in `apps/api`.

## Known pre-existing failures (NOT introduced by this PR)

`apps/api/src/routes/enrollmentKeys_installer.test.ts` has 6 failing tests on `main` (`TypeError: Cannot read properties of undefined (reading 'from')` at `allocateShortCode`). Same 6 failures on this branch. Unrelated — happy to fix in a follow-up.