### PR TITLE
diag(agent): restore lost remote-desktop diagnostics for #434

### DIFF
--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"syscall"
@@ -980,6 +981,30 @@ func runHelperProcess(name, role, context, binaryKind string) {
 		})
 		defer logging.StopShipper()
 	}
+
+	// Top-level panic recovery. Without this, a goroutine panic crashes
+	// the helper with a stderr stack trace that never reaches the shipper,
+	// and the lifecycle manager sees "exit code 2" (Go's panic default)
+	// and misclassifies the death as a permanent-reject cooldown. Catch
+	// the panic, log the stack trace at error level (which ships), flush
+	// synchronously, then exit with code 3 so the lifecycle manager
+	// treats it as transient and respawns normally.
+	defer func() {
+		if r := recover(); r != nil {
+			stack := debug.Stack()
+			log.Error("helper panic caught at top level",
+				"name", name,
+				"role", role,
+				"panic", fmt.Sprint(r),
+				"stack", string(stack),
+			)
+			// Also write directly to stderr so the panic is in the on-disk
+			// log file regardless of the shipper state.
+			fmt.Fprintf(os.Stderr, "helper panic: %v\n%s\n", r, stack)
+			logging.StopShipper() // synchronous flush
+			os.Exit(3)            // code 3 = panic, not permanent reject
+		}
+	}()
 
 	log.Info("starting helper",
 		"name", name,

--- a/agent/internal/heartbeat/handlers_desktop_helper.go
+++ b/agent/internal/heartbeat/handlers_desktop_helper.go
@@ -211,15 +211,23 @@ func (h *Heartbeat) findActiveHelper(targetSession string, allowDisconnected ...
 
 		// If the best session IS the console and it's not disconnected, use it.
 		if session.WinSessionID == consoleID && !isWinSessionDisconnected(session.WinSessionID) {
+			log.Warn("findActiveHelper: picked console session directly",
+				"winSession", session.WinSessionID, "helperSession", session.SessionID,
+				"consoleID", consoleID)
 			return session
 		}
 
 		// Otherwise, look for a better alternative among all capable sessions.
 		if alternatives := h.sessionBroker.SessionsWithScope("desktop"); len(alternatives) > 0 {
 			var consoleAlt, nonDisconnectedAlt *sessionbroker.Session
+			altSummaries := make([]string, 0, len(alternatives))
 			for _, alt := range alternatives {
 				caps := alt.GetCapabilities()
-				if caps == nil || !caps.CanCapture {
+				canCapture := caps != nil && caps.CanCapture
+				altSummaries = append(altSummaries,
+					fmt.Sprintf("{win=%s disc=%v cap=%v}",
+						alt.WinSessionID, isWinSessionDisconnected(alt.WinSessionID), canCapture))
+				if !canCapture {
 					continue
 				}
 				// Console session is always preferred
@@ -231,14 +239,24 @@ func (h *Heartbeat) findActiveHelper(targetSession string, allowDisconnected ...
 				}
 			}
 			if consoleAlt != nil && !isWinSessionDisconnected(consoleAlt.WinSessionID) {
+				log.Warn("findActiveHelper: picked console alternative",
+					"winSession", consoleAlt.WinSessionID, "helperSession", consoleAlt.SessionID,
+					"consoleID", consoleID, "firstPick", session.WinSessionID,
+					"alternatives", strings.Join(altSummaries, ","))
 				return consoleAlt
 			}
 			if nonDisconnectedAlt != nil {
+				log.Warn("findActiveHelper: picked non-disconnected alternative (no live console helper)",
+					"winSession", nonDisconnectedAlt.WinSessionID, "helperSession", nonDisconnectedAlt.SessionID,
+					"consoleID", consoleID, "firstPick", session.WinSessionID,
+					"alternatives", strings.Join(altSummaries, ","))
 				return nonDisconnectedAlt
 			}
 			// Console is disconnected but exists — prefer it over other disconnected sessions
 			if consoleAlt != nil {
 				if len(allowDisconnected) > 0 && allowDisconnected[0] {
+					log.Warn("findActiveHelper: picked disconnected console as last resort",
+						"winSession", consoleAlt.WinSessionID, "consoleID", consoleID)
 					return consoleAlt
 				}
 				return nil
@@ -251,6 +269,9 @@ func (h *Heartbeat) findActiveHelper(targetSession string, allowDisconnected ...
 				return nil
 			}
 		}
+		log.Warn("findActiveHelper: falling through to first-pick session",
+			"winSession", session.WinSessionID, "helperSession", session.SessionID,
+			"consoleID", consoleID)
 	}
 	return session
 }

--- a/agent/internal/remote/desktop/session_capture.go
+++ b/agent/internal/remote/desktop/session_capture.go
@@ -957,7 +957,9 @@ func (s *Session) captureAndSendFrameGPU(tp TextureProvider, frameDuration time.
 
 	s.frameIdx++
 	// Log the first 5 frames sent (catches monitor switch + encoder re-init)
-	if s.frameIdx <= 5 {
+	// and a heartbeat every 150 frames (~5s at 30fps) so we can see whether
+	// frames are still flowing past the initial burst when diagnosing stalls.
+	if s.frameIdx <= 5 || s.frameIdx%150 == 0 {
 		slog.Warn("H264 frame sent",
 			"session", s.id,
 			"frameIdx", s.frameIdx,
@@ -972,7 +974,7 @@ func (s *Session) captureAndSendFrameGPU(tp TextureProvider, frameDuration time.
 	// Skip the check for the first 5 frames to allow initial keyframes through.
 	// Never drop IDR keyframes — without them the decoder accumulates corruption.
 	if s.frameIdx > 5 && len(h264Data) > maxFrameSizeBytes && !h264ContainsIDR(h264Data) {
-		slog.Debug("Dropping oversized P-frame to prevent jitter burst",
+		slog.Warn("Dropping oversized P-frame to prevent jitter burst",
 			"session", s.id, "bytes", len(h264Data), "maxBytes", maxFrameSizeBytes)
 		s.metrics.RecordDrop()
 		// Force a keyframe so the encoder produces a fresh IDR for decoder recovery.
@@ -985,7 +987,7 @@ func (s *Session) captureAndSendFrameGPU(tp TextureProvider, frameDuration time.
 		Duration: frameDuration,
 	}
 	if err := s.videoTrack.WriteSample(sample); err != nil {
-		slog.Debug("Failed to write H264 sample (GPU)", "session", s.id, "error", err.Error())
+		slog.Warn("Failed to write H264 sample (GPU)", "session", s.id, "error", err.Error())
 		s.metrics.RecordDrop()
 		return true, false, false
 	}

--- a/agent/internal/remote/desktop/session_webrtc.go
+++ b/agent/internal/remote/desktop/session_webrtc.go
@@ -406,9 +406,19 @@ func (m *SessionManager) StartSession(sessionID string, offer string, iceServers
 	// On "disconnected", wait a grace period for ICE to recover (NAT rebinding,
 	// TURN fallback) before tearing down. This prevents premature session kills
 	// on transient network blips.
+	// Log ICE connection state transitions at warn level so they ship from
+	// the helper process. Helps distinguish ICE-level failures (network /
+	// STUN / TURN) from peer-connection-level failures (DTLS / cert).
+	peerConn.OnICEConnectionStateChange(func(state webrtc.ICEConnectionState) {
+		slog.Warn("Desktop WebRTC ICE state", "session", sessionID, "state", state.String())
+	})
+
 	var disconnectTimer *time.Timer
 	peerConn.OnConnectionStateChange(func(state webrtc.PeerConnectionState) {
-		slog.Info("Desktop WebRTC connection state", "session", sessionID, "state", state.String())
+		// Promoted to warn so helper state transitions ship — we need to
+		// see exactly when a session enters Disconnected state relative to
+		// the last video frame. Revert to info once 5-frame death is fixed.
+		slog.Warn("Desktop WebRTC connection state", "session", sessionID, "state", state.String())
 
 		// Cancel any pending disconnect timer when state changes
 		if disconnectTimer != nil {

--- a/agent/internal/sessionbroker/lifecycle.go
+++ b/agent/internal/sessionbroker/lifecycle.go
@@ -70,6 +70,11 @@ const (
 	// permanent rejection. Must match main.go's os.Exit(2).
 	helperFatalExitCode = 2
 
+	// helperPanicExitCode is the exit code the helper uses from its
+	// top-level panic recovery. Must match main.go's os.Exit(3). Treated
+	// as transient — no fatal cooldown.
+	helperPanicExitCode = 3
+
 	// WTS event type constants (matching windows.WTS_SESSION_*).
 	wtsSessionLogon     = 0x5
 	wtsSessionLogoff    = 0x6
@@ -359,6 +364,21 @@ func (m *HelperLifecycleManager) watchHelperExit(trackKey, winSessionID, role st
 			"pid", spawned.PID,
 			"exitCode", exitCode,
 			"cooldown", fatalCooldown.String(),
+		)
+		return
+	}
+
+	if exitCode == helperPanicExitCode {
+		// Panic, not permanent rejection. No fatal cooldown — the helper
+		// caught the panic at the top level, logged the stack trace, and
+		// exited with code 3. Respawn normally so the next desk-start can
+		// retry; if the panic reproduces the on-disk log and the shipped
+		// error will tell us what's broken.
+		log.Warn("lifecycle: helper panicked (exit code 3), will respawn",
+			"winSessionID", winSessionID,
+			"role", role,
+			"pid", spawned.PID,
+			"exitCode", exitCode,
 		)
 		return
 	}


### PR DESCRIPTION
## Summary

Restores three diagnostic/fix commits that were on main locally but got wiped when main was reset backwards at \`main@{7}\` (Apr 12). Needed to investigate #434 (viewer disconnects on Windows logout instead of handing off to login screen) — without this logging we can't tell whether the helper dies, the WS drops, or the broker stalls.

Cherry-picked from reflog:

- **\`b8efe53c\`** (from \`ad2f1849\`) — 5-frame session death diagnostics: \`OnICEConnectionStateChange\` handler, \`OnConnectionStateChange\` promoted to warn, 150-frame H264 heartbeat, \`WriteSample\`/oversized P-frame errors at warn.
- **\`523856b2\`** (from \`48a75d7e\`) — \`findActiveHelper\` selection logging: which Windows session was picked, the \`consoleID\` that \`GetConsoleSessionID\` returned, and a summary of all capable alternatives.
- **\`3ca7efce\`** (panic-recovery half of \`7d36cff2\`) — top-level \`defer recover()\` in \`runHelperProcess\` so a helper panic logs its stack trace at error level (ships via the log shipper) and exits with code 3; lifecycle manager treats code 3 as transient instead of a 10-minute fatal cooldown. Left the selection-logic revert portion of \`7d36cff2\` out — current main has its own \`findActiveHelper\` logic that doesn't need it.

All three are marked temporary in their original commit messages — intended to be reverted once the session-death / handoff root cause is identified.

## Test plan
- [x] \`go build ./...\` on darwin/arm64 clean
- [x] \`GOOS=windows GOARCH=amd64 go build ./...\` clean
- [ ] Deploy to WIN-IMDR2GAIDMV (device \`3fef59\`), reproduce logout handoff, collect agent + helper logs via diagnostic logs API

Related: #434, #387 (lost reset context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)