### PR TITLE
fix(api): audit_logs actor_id UUID parse failure on public-download (#444)

### DIFF
--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -81,6 +81,7 @@ vi.mock('../services/rate-limit', () => ({
 // ============================================================
 import { enrollmentKeyRoutes, publicEnrollmentRoutes, publicShortLinkRoutes } from './enrollmentKeys';
 import { db, withSystemDbAccessContext } from '../db';
+import { createAuditLogAsync } from '../services/auditService';
 
 // ============================================================
 // Helpers
@@ -518,5 +519,44 @@ describe('GET /public-download/:platform', () => {
 
     expect(res.status).toBe(200);
     expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('writes the public-download audit with a UUID actorId, not the literal "public"', async () => {
+    // Regression for #444. The public-download path previously passed
+    // `actorId: 'public'` to createAuditLogAsync. Because audit_logs.actor_id
+    // is `uuid NOT NULL`, Postgres rejected every insert with
+    // `invalid input syntax for type uuid: "public"` and the audit row was
+    // silently dropped via createAuditLogAsync's catch. The path has no
+    // authenticated user, so the actor must be represented as system-scope
+    // with a real UUID sentinel.
+    const row = makeKeyRow({
+      shortCode: 'pubcode1234',
+      installerPlatform: 'windows',
+      maxUsage: 1,
+      usageCount: 0,
+    });
+
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([row]),
+        }),
+      }),
+    } as any);
+
+    const res = await app.request(
+      '/enrollment-keys/public-download/windows?token=abc123',
+    );
+
+    expect(res.status).toBe(200);
+    expect(createAuditLogAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'enrollment_key.public_download',
+        actorType: 'system',
+        actorId: expect.stringMatching(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+        ),
+      }),
+    );
   });
 });

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -9,6 +9,7 @@ import { enrollmentKeys } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import { randomBytes } from 'crypto';
 import { createAuditLogAsync } from '../services/auditService';
+import { ANONYMOUS_ACTOR_ID } from '../services/auditEvents';
 import { PERMISSIONS } from '../services/permissions';
 import { hashEnrollmentKey } from '../services/enrollmentKeySecurity';
 import {
@@ -891,9 +892,16 @@ async function serveInstaller(
     // so the slot is only consumed when enrollment actually succeeds.
     // Downloads are still tracked, but via the audit log below.
 
+    // Public endpoint — no authenticated user. `audit_logs.actor_id` is a
+    // non-null UUID column, so a string literal like 'public' fails parsing
+    // and Postgres drops the row (silently, via createAuditLogAsync's catch).
+    // Represent the caller as system-scope with the nil-UUID sentinel; the
+    // `enrollment_key.public_download` action name already carries the
+    // "unauthenticated public download" semantic.
     createAuditLogAsync({
       orgId: keyRow.orgId,
-      actorId: 'public',
+      actorType: 'system',
+      actorId: ANONYMOUS_ACTOR_ID,
       action: 'enrollment_key.public_download',
       resourceType: 'enrollment_key',
       resourceId: keyRow.id,

--- a/apps/api/src/services/auditEvents.ts
+++ b/apps/api/src/services/auditEvents.ts
@@ -1,7 +1,7 @@
 import { createAuditLogAsync, type InitiatedByType } from './auditService';
 import { getTrustedClientIpOrUndefined } from './clientIp';
 
-const ANONYMOUS_ACTOR_ID = '00000000-0000-0000-0000-000000000000';
+export const ANONYMOUS_ACTOR_ID = '00000000-0000-0000-0000-000000000000';
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 type AuditActorType = 'user' | 'api_key' | 'agent' | 'system';


### PR DESCRIPTION
## Summary

- Fixes #444. `enrollmentKeys.ts` serveInstaller passed `actorId: 'public'` to `createAuditLogAsync`. `audit_logs.actor_id` is `uuid NOT NULL`, so Postgres rejected every insert with `invalid input syntax for type uuid: "public"` and the row was silently dropped via `createAuditLogAsync`'s catch — 100% failure rate on the public-download audit write.
- The issue report guessed the failing column was `resource_id`; it was actually `actor_id` (`resourceId: keyRow.id` was already a valid UUID). Postgres' parse error names the bad value, not the column.
- Represent the unauthenticated caller as system-scope with the existing `ANONYMOUS_ACTOR_ID` nil-UUID sentinel (now exported from `auditEvents.ts`). The `enrollment_key.public_download` action name already carries the "unauthenticated public download" semantic.

## Test plan

- [x] New regression test in `enrollmentKeys.test.ts` asserts `createAuditLogAsync` is called with a UUID-shaped `actorId` and `actorType: 'system'` on the public-download path. Fails against the old code, passes with the fix.
- [x] `enrollmentKeys.test.ts` — 12/12 pass
- [x] `auditEvents.test.ts` — 3/3 pass
- [x] `tsc --noEmit` clean on all touched files
- [ ] Manual verification against a real Postgres in dev after merge — no more `invalid input syntax for type uuid: "public"` in API logs when hitting `GET /api/v1/enrollment-keys/public-download/:platform`

## Notes

- Six pre-existing failures in `enrollmentKeys_installer.test.ts` (unrelated, in `allocateShortCode`) also reproduce on `main`; not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)