### PR TITLE
fix(agent,api): #439 resolve hostname via fallback chain + refuse empty + backfill

### DIFF
--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -627,6 +627,21 @@ func trimEnrollInputs(key, server, secret string) (string, string, string) {
 	return strings.TrimSpace(key), strings.TrimSpace(server), strings.TrimSpace(secret)
 }
 
+// assertHostnameNonEmpty enforces the #439 contract: enrollment must
+// never proceed with an empty or whitespace-only hostname, because the
+// downstream substitution used to write the device UUID there and
+// operators couldn't tell real rows from synthetic ones. Returns nil
+// iff info is non-nil and info.Hostname has at least one non-whitespace
+// character. Exists as a named helper so it's unit-testable — the call
+// site in enrollDevice goes through enrollError which calls os.Exit
+// and can't be exercised directly from a test.
+func assertHostnameNonEmpty(info *collectors.SystemInfo) error {
+	if info == nil || strings.TrimSpace(info.Hostname) == "" {
+		return errors.New("empty hostname after fallback chain")
+	}
+	return nil
+}
+
 func enrollDevice(enrollmentKey string) {
 	enrollmentKey, serverURL, enrollmentSecret = trimEnrollInputs(
 		enrollmentKey, serverURL, enrollmentSecret,
@@ -730,12 +745,12 @@ func enrollDevice(enrollmentKey string) {
 	// downstream (or an older server) substitute the device UUID. See
 	// issue #439 — one prod device ended up with its UUID in the hostname
 	// column, which is worse than a loud failure because it looks legit.
-	if strings.TrimSpace(systemInfo.Hostname) == "" {
+	if err := assertHostnameNonEmpty(systemInfo); err != nil {
 		enrollError(catConfig,
-			"hostname resolution failed on this machine — tried os.Hostname(), "+
-				"COMPUTERNAME env var, and WMI (win32_computersystem.Name); all "+
-				"returned empty. Refusing to enroll with an empty hostname.",
-			errors.New("empty hostname after fallback chain"))
+			"hostname resolution failed on this machine — tried "+
+				collectors.HostnameSourcesDescription()+
+				"; all returned empty. Refusing to enroll with an empty hostname.",
+			err)
 	}
 
 	client := api.NewClient(cfg.ServerURL, "", "")

--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -726,6 +726,18 @@ func enrollDevice(enrollmentKey string) {
 		fmt.Printf("OS: %s (%s)\n", systemInfo.OSVersion, systemInfo.Architecture)
 	}
 
+	// Refuse to enroll with an empty hostname rather than let a fallback
+	// downstream (or an older server) substitute the device UUID. See
+	// issue #439 — one prod device ended up with its UUID in the hostname
+	// column, which is worse than a loud failure because it looks legit.
+	if strings.TrimSpace(systemInfo.Hostname) == "" {
+		enrollError(catConfig,
+			"hostname resolution failed on this machine — tried os.Hostname(), "+
+				"COMPUTERNAME env var, and WMI (win32_computersystem.Name); all "+
+				"returned empty. Refusing to enroll with an empty hostname.",
+			errors.New("empty hostname after fallback chain"))
+	}
+
 	client := api.NewClient(cfg.ServerURL, "", "")
 
 	secret := enrollmentSecret

--- a/agent/cmd/breeze-agent/main_test.go
+++ b/agent/cmd/breeze-agent/main_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/breeze-rmm/agent/internal/collectors"
 	"github.com/breeze-rmm/agent/internal/config"
 )
 
@@ -527,5 +528,36 @@ func TestWaitForEnrollment_IgnoresTornWrite(t *testing.T) {
 		}
 	case <-time.After(300 * time.Millisecond):
 		t.Fatal("waitForEnrollment did not unblock after secrets.yaml was written")
+	}
+}
+
+// TestAssertHostnameNonEmpty guards the #439 contract at the enroll
+// boundary: enrollment must refuse to proceed with an empty or
+// whitespace-only hostname. This is the last line of defense against a
+// regression in the collectors fallback chain or a new code path that
+// bypasses it — the message string and the os.Exit flow both live in
+// enrollDevice, so this test pins the pure predicate. A failure here
+// would mean the predicate itself drifted; a review of enrollDevice
+// would still be required to confirm the call site still fires.
+func TestAssertHostnameNonEmpty(t *testing.T) {
+	tests := []struct {
+		name    string
+		info    *collectors.SystemInfo
+		wantErr bool
+	}{
+		{"nil info", nil, true},
+		{"empty hostname", &collectors.SystemInfo{Hostname: ""}, true},
+		{"whitespace only", &collectors.SystemInfo{Hostname: "  \n\t"}, true},
+		{"single space", &collectors.SystemInfo{Hostname: " "}, true},
+		{"valid hostname", &collectors.SystemInfo{Hostname: "desktop-01"}, false},
+		{"leading/trailing whitespace around valid name", &collectors.SystemInfo{Hostname: "  desktop-02  "}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := assertHostnameNonEmpty(tc.info)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("got err=%v, wantErr=%v", err, tc.wantErr)
+			}
+		})
 	}
 }

--- a/agent/internal/collectors/hardware.go
+++ b/agent/internal/collectors/hardware.go
@@ -1,6 +1,7 @@
 package collectors
 
 import (
+	"log/slog"
 	"os"
 	"runtime"
 	"strings"
@@ -46,10 +47,19 @@ func (c *HardwareCollector) CollectSystemInfo() (*SystemInfo, error) {
 
 	hostInfo, err := host.Info()
 	if err == nil {
-		info.Hostname = hostInfo.Hostname
 		info.OSType = normalizeOSType(hostInfo.OS)
 		info.OSVersion = hostInfo.Platform + " " + hostInfo.PlatformVersion
 		info.OSBuild = hostInfo.KernelVersion
+	}
+
+	// Resolve hostname via the fallback chain (os.Hostname → platform
+	// sources). gopsutil's hostInfo.Hostname is just os.Hostname() with
+	// no fallbacks, so relying on it lets empty values through on
+	// Windows service-start edge cases. See issue #439.
+	if resolved, rhErr := resolveHostname(); rhErr == nil {
+		info.Hostname = resolved
+	} else {
+		slog.Warn("hostname resolution failed", "error", rhErr.Error())
 	}
 
 	// On macOS, prefer LocalHostName (e.g. "MacBook-Pro-3") over the

--- a/agent/internal/collectors/hardware.go
+++ b/agent/internal/collectors/hardware.go
@@ -56,7 +56,7 @@ func (c *HardwareCollector) CollectSystemInfo() (*SystemInfo, error) {
 	// sources). gopsutil's hostInfo.Hostname is just os.Hostname() with
 	// no fallbacks, so relying on it lets empty values through on
 	// Windows service-start edge cases. See issue #439.
-	if resolved, rhErr := resolveHostname(); rhErr == nil {
+	if resolved, rhErr := resolveHostnameFn(); rhErr == nil {
 		info.Hostname = resolved
 	} else {
 		slog.Warn("hostname resolution failed", "error", rhErr.Error())

--- a/agent/internal/collectors/hostname.go
+++ b/agent/internal/collectors/hostname.go
@@ -2,6 +2,7 @@ package collectors
 
 import (
 	"errors"
+	"log/slog"
 	"os"
 	"strings"
 )
@@ -11,6 +12,12 @@ import (
 // the enroll path) must fail loudly instead of substituting a synthetic
 // identifier — see issue #439.
 var errHostnameResolutionFailed = errors.New("hostname resolution failed: all sources empty")
+
+// resolveHostnameFn is the indirection hardware.go uses to call the
+// resolver. Exposed at package level so tests can inject a failing
+// resolver and verify the warn-and-leave-empty branch in
+// CollectSystemInfo without having to break os.Hostname() for real.
+var resolveHostnameFn = resolveHostname
 
 // hostnameSource produces a single candidate hostname. A return value
 // that is empty or whitespace-only means "this source had nothing
@@ -51,12 +58,15 @@ func hostnameSourceChain() []hostnameSource {
 }
 
 // osHostname wraps os.Hostname() so it satisfies the hostnameSource
-// signature and swallows its error (an error from os.Hostname is
-// indistinguishable from "empty" for our purposes — the next source
-// should still be tried).
+// signature. An error is indistinguishable from "empty" for control
+// flow (the next source is tried either way), but the error is logged
+// at Warn so operators hunting a future #439 regression see which
+// source broke — the resolver's overall-failure log alone doesn't
+// tell you which link in the chain gave out.
 func osHostname() string {
 	name, err := os.Hostname()
 	if err != nil {
+		slog.Warn("os.Hostname() failed, trying platform fallbacks", "error", err.Error())
 		return ""
 	}
 	return name

--- a/agent/internal/collectors/hostname.go
+++ b/agent/internal/collectors/hostname.go
@@ -1,0 +1,63 @@
+package collectors
+
+import (
+	"errors"
+	"os"
+	"strings"
+)
+
+// errHostnameResolutionFailed is returned by resolveHostname when every
+// source in the platform chain yielded an empty value. Callers (notably
+// the enroll path) must fail loudly instead of substituting a synthetic
+// identifier — see issue #439.
+var errHostnameResolutionFailed = errors.New("hostname resolution failed: all sources empty")
+
+// hostnameSource produces a single candidate hostname. A return value
+// that is empty or whitespace-only means "this source had nothing
+// useful" and the next source is tried.
+type hostnameSource func() string
+
+// resolveHostname walks the platform-specific source chain and returns
+// the first non-empty, trimmed value. It deliberately NEVER substitutes
+// a device UUID, agent token, or any other synthetic identifier — if
+// every source is empty the caller gets an error and is expected to
+// abort whatever it was doing (e.g. enrollment).
+func resolveHostname() (string, error) {
+	return resolveHostnameFromSources(hostnameSourceChain())
+}
+
+// resolveHostnameFromSources is the pure core of the resolver, exposed
+// so hostname_test.go can exercise the chain logic without touching the
+// real OS. Each source is called in order; the first trimmed non-empty
+// return wins. Nil sources are skipped.
+func resolveHostnameFromSources(sources []hostnameSource) (string, error) {
+	for _, src := range sources {
+		if src == nil {
+			continue
+		}
+		if name := strings.TrimSpace(src()); name != "" {
+			return name, nil
+		}
+	}
+	return "", errHostnameResolutionFailed
+}
+
+// hostnameSourceChain is os.Hostname() followed by the platform-specific
+// fallbacks declared in hostname_<os>.go files.
+func hostnameSourceChain() []hostnameSource {
+	chain := []hostnameSource{osHostname}
+	chain = append(chain, platformHostnameFallbacks()...)
+	return chain
+}
+
+// osHostname wraps os.Hostname() so it satisfies the hostnameSource
+// signature and swallows its error (an error from os.Hostname is
+// indistinguishable from "empty" for our purposes — the next source
+// should still be tried).
+func osHostname() string {
+	name, err := os.Hostname()
+	if err != nil {
+		return ""
+	}
+	return name
+}

--- a/agent/internal/collectors/hostname_other.go
+++ b/agent/internal/collectors/hostname_other.go
@@ -1,0 +1,40 @@
+//go:build !windows
+
+package collectors
+
+import "os"
+
+// platformHostnameFallbacks is the non-Windows tail of the hostname
+// resolver chain. On Unix os.Hostname() rarely fails, so these are
+// safety nets, not primary sources:
+//
+//  1. HOSTNAME environment variable — set by most login shells; rarely
+//     present in service contexts but free to check.
+//  2. /etc/hostname — authoritative on most Linux distros and cheap to
+//     read.
+//  3. `hostname` command — final safety net. Calls the same syscall as
+//     os.Hostname() in practice, so it only helps if the Go runtime
+//     wrapper glitched without the system binary doing the same.
+func platformHostnameFallbacks() []hostnameSource {
+	return []hostnameSource{
+		func() string { return os.Getenv("HOSTNAME") },
+		hostnameFromFile,
+		hostnameFromCommand,
+	}
+}
+
+func hostnameFromFile() string {
+	data, err := os.ReadFile("/etc/hostname")
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func hostnameFromCommand() string {
+	out, err := runCollectorOutput(collectorShortCommandTimeout, "hostname")
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}

--- a/agent/internal/collectors/hostname_other.go
+++ b/agent/internal/collectors/hostname_other.go
@@ -2,7 +2,19 @@
 
 package collectors
 
-import "os"
+import (
+	"errors"
+	"io/fs"
+	"log/slog"
+	"os"
+)
+
+// HostnameSourcesDescription returns a human-readable description of
+// the hostname sources tried on this platform. Used in error messages
+// so operators know exactly what was attempted.
+func HostnameSourcesDescription() string {
+	return "os.Hostname(), HOSTNAME env var, /etc/hostname, and the hostname command"
+}
 
 // platformHostnameFallbacks is the non-Windows tail of the hostname
 // resolver chain. On Unix os.Hostname() rarely fails, so these are
@@ -26,6 +38,13 @@ func platformHostnameFallbacks() []hostnameSource {
 func hostnameFromFile() string {
 	data, err := os.ReadFile("/etc/hostname")
 	if err != nil {
+		// ENOENT is expected on distros that don't ship /etc/hostname
+		// (e.g. some minimal container images) — don't warn on that.
+		// Any other error means something weird is going on and we
+		// want operators to see it.
+		if !errors.Is(err, fs.ErrNotExist) {
+			slog.Warn("read /etc/hostname failed", "error", err.Error())
+		}
 		return ""
 	}
 	return string(data)
@@ -34,6 +53,7 @@ func hostnameFromFile() string {
 func hostnameFromCommand() string {
 	out, err := runCollectorOutput(collectorShortCommandTimeout, "hostname")
 	if err != nil {
+		slog.Warn("hostname command failed", "error", err.Error())
 		return ""
 	}
 	return string(out)

--- a/agent/internal/collectors/hostname_test.go
+++ b/agent/internal/collectors/hostname_test.go
@@ -2,6 +2,7 @@ package collectors
 
 import (
 	"errors"
+	"runtime"
 	"testing"
 )
 
@@ -46,6 +47,17 @@ func TestResolveHostnameFromSources(t *testing.T) {
 				staticSource("desktop-04\r\n"),
 			},
 			want: "desktop-04",
+		},
+		{
+			// Internal whitespace is preserved (not stripped by
+			// TrimSpace). Server-side validation is the source of
+			// truth for whether this is an acceptable hostname — we
+			// just don't want the resolver silently mangling it.
+			name: "internal whitespace is preserved",
+			sources: []hostnameSource{
+				staticSource("my host  \n"),
+			},
+			want: "my host",
 		},
 		{
 			name: "nil source is skipped",
@@ -158,8 +170,41 @@ func TestHostnameSourceChain_FirstElementIsOsHostname(t *testing.T) {
 	// verify by behavior: the first source should match os.Hostname()'s
 	// output on this machine.
 	first := chain[0]()
-	real := osHostname()
-	if first != real {
-		t.Fatalf("first source returned %q, expected os.Hostname()=%q", first, real)
+	want := osHostname()
+	if first != want {
+		t.Fatalf("first source returned %q, expected os.Hostname()=%q", first, want)
+	}
+}
+
+// TestCollectSystemInfo_HostnameFallbackFailureLeavesEmpty locks in the
+// contract that the enroll guard in cmd/breeze-agent/main.go relies on:
+// when the hostname resolver fails, CollectSystemInfo must leave
+// info.Hostname empty rather than silently keeping a stale value from
+// gopsutil. The guard's assertHostnameNonEmpty check then catches it
+// and aborts enrollment. See issue #439.
+//
+// Skipped on darwin because the scutil LocalHostName override can still
+// populate info.Hostname even when our resolver fails — that's the
+// intended darwin behavior and not what this test is about.
+func TestCollectSystemInfo_HostnameFallbackFailureLeavesEmpty(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("darwin uses scutil LocalHostName as an additional hostname source")
+	}
+	orig := resolveHostnameFn
+	t.Cleanup(func() { resolveHostnameFn = orig })
+	resolveHostnameFn = func() (string, error) {
+		return "", errHostnameResolutionFailed
+	}
+
+	c := NewHardwareCollector()
+	info, err := c.CollectSystemInfo()
+	if err != nil {
+		t.Fatalf("CollectSystemInfo returned error: %v", err)
+	}
+	if info == nil {
+		t.Fatal("CollectSystemInfo returned nil info")
+	}
+	if info.Hostname != "" {
+		t.Fatalf("expected empty hostname on resolver failure, got %q", info.Hostname)
 	}
 }

--- a/agent/internal/collectors/hostname_test.go
+++ b/agent/internal/collectors/hostname_test.go
@@ -1,0 +1,165 @@
+package collectors
+
+import (
+	"errors"
+	"testing"
+)
+
+func staticSource(s string) hostnameSource {
+	return func() string { return s }
+}
+
+func TestResolveHostnameFromSources(t *testing.T) {
+	tests := []struct {
+		name    string
+		sources []hostnameSource
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "first source wins",
+			sources: []hostnameSource{
+				staticSource("desktop-01"),
+				staticSource("fallback"),
+			},
+			want: "desktop-01",
+		},
+		{
+			name: "empty first source falls through",
+			sources: []hostnameSource{
+				staticSource(""),
+				staticSource("desktop-02"),
+			},
+			want: "desktop-02",
+		},
+		{
+			name: "whitespace-only source is treated as empty",
+			sources: []hostnameSource{
+				staticSource("   \n\t"),
+				staticSource("desktop-03"),
+			},
+			want: "desktop-03",
+		},
+		{
+			name: "trailing whitespace is trimmed from result",
+			sources: []hostnameSource{
+				staticSource("desktop-04\r\n"),
+			},
+			want: "desktop-04",
+		},
+		{
+			name: "nil source is skipped",
+			sources: []hostnameSource{
+				nil,
+				staticSource("desktop-05"),
+			},
+			want: "desktop-05",
+		},
+		{
+			name: "only last source has value",
+			sources: []hostnameSource{
+				staticSource(""),
+				staticSource(" "),
+				nil,
+				staticSource("desktop-06"),
+			},
+			want: "desktop-06",
+		},
+		{
+			name: "all empty returns failure",
+			sources: []hostnameSource{
+				staticSource(""),
+				staticSource("   "),
+				staticSource("\n"),
+			},
+			wantErr: true,
+		},
+		{
+			name:    "no sources returns failure",
+			sources: []hostnameSource{},
+			wantErr: true,
+		},
+		{
+			name:    "nil slice returns failure",
+			sources: nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveHostnameFromSources(tc.sources)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (value=%q)", got)
+				}
+				if !errors.Is(err, errHostnameResolutionFailed) {
+					t.Fatalf("expected errHostnameResolutionFailed, got %v", err)
+				}
+				if got != "" {
+					t.Fatalf("expected empty result on error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveHostnameFromSources_SourceOrderRespected verifies the
+// resolver does NOT reorder sources — a later source must never
+// override an earlier non-empty one. Regression guard against someone
+// "optimizing" the loop to prefer e.g. WMI over os.Hostname().
+func TestResolveHostnameFromSources_SourceOrderRespected(t *testing.T) {
+	sources := []hostnameSource{
+		staticSource("first"),
+		staticSource("second"),
+		staticSource("third"),
+	}
+	got, err := resolveHostnameFromSources(sources)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "first" {
+		t.Fatalf("got %q, want %q", got, "first")
+	}
+}
+
+// TestResolveHostname_IntegrationRealOS sanity-checks that the real
+// chain (os.Hostname → platform fallbacks) returns a value on a normal
+// developer or CI machine. If this ever fails in CI it probably means
+// the test environment is doing something exotic, not that the code is
+// broken — but it's still a useful smoke signal.
+func TestResolveHostname_IntegrationRealOS(t *testing.T) {
+	got, err := resolveHostname()
+	if err != nil {
+		t.Fatalf("resolveHostname on real OS returned error: %v", err)
+	}
+	if got == "" {
+		t.Fatalf("resolveHostname on real OS returned empty string")
+	}
+}
+
+// TestHostnameSourceChain_FirstElementIsOsHostname guards the contract
+// that os.Hostname() is always tried first. A regression here would
+// mean we start hitting platform fallbacks (and their subprocess /
+// syscall overhead) on every enroll, not just the broken cases.
+func TestHostnameSourceChain_FirstElementIsOsHostname(t *testing.T) {
+	chain := hostnameSourceChain()
+	if len(chain) == 0 {
+		t.Fatal("hostnameSourceChain returned empty slice")
+	}
+	// We can't compare function pointers across packages reliably, so
+	// verify by behavior: the first source should match os.Hostname()'s
+	// output on this machine.
+	first := chain[0]()
+	real := osHostname()
+	if first != real {
+		t.Fatalf("first source returned %q, expected os.Hostname()=%q", first, real)
+	}
+}

--- a/agent/internal/collectors/hostname_windows.go
+++ b/agent/internal/collectors/hostname_windows.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package collectors
+
+import "os"
+
+// platformHostnameFallbacks is the Windows-specific tail of the
+// hostname resolver chain. Appended to os.Hostname() by
+// hostnameSourceChain. Ordered cheapest → slowest:
+//
+//  1. COMPUTERNAME environment variable — always set by the Windows
+//     session, including SYSTEM/Session 0 where the agent runs as a
+//     service. Free.
+//  2. wmic computersystem.Name — subprocess call, ~1s, but authoritative
+//     even when the local session is too early in boot for
+//     GetComputerNameExW to return anything useful.
+//
+// gopsutil's host.Info().Hostname just calls os.Hostname() (which in
+// turn calls GetComputerNameExW), so these fallbacks are the ONLY
+// protection if that syscall returns an empty string without an error
+// — a known Windows service-startup edge case.
+func platformHostnameFallbacks() []hostnameSource {
+	return []hostnameSource{
+		func() string { return os.Getenv("COMPUTERNAME") },
+		wmicComputerName,
+	}
+}
+
+// wmicComputerName queries WMI for Win32_ComputerSystem.Name via the
+// existing wmicGet helper (see hardware_windows.go). Returns "" on any
+// error so the resolver moves on.
+func wmicComputerName() string {
+	return wmicGet([]string{"computersystem"}, "Name")
+}

--- a/agent/internal/collectors/hostname_windows.go
+++ b/agent/internal/collectors/hostname_windows.go
@@ -2,7 +2,17 @@
 
 package collectors
 
-import "os"
+import (
+	"log/slog"
+	"os"
+)
+
+// HostnameSourcesDescription returns a human-readable description of
+// the hostname sources tried on this platform. Used in error messages
+// so operators know exactly what was attempted.
+func HostnameSourcesDescription() string {
+	return "os.Hostname(), COMPUTERNAME env var, and WMI (win32_computersystem.Name)"
+}
 
 // platformHostnameFallbacks is the Windows-specific tail of the
 // hostname resolver chain. Appended to os.Hostname() by
@@ -19,6 +29,12 @@ import "os"
 // turn calls GetComputerNameExW), so these fallbacks are the ONLY
 // protection if that syscall returns an empty string without an error
 // — a known Windows service-startup edge case.
+//
+// Caveat: wmic.exe is deprecated and removed by default on Windows 11
+// 24H2 / Server 2025. On those images the wmic leg silently degrades
+// to a no-op and hostname resolution collapses to [os.Hostname,
+// COMPUTERNAME]. Replacing this with a native GetComputerNameExW call
+// or a PowerShell Get-CimInstance probe is tracked separately.
 func platformHostnameFallbacks() []hostnameSource {
 	return []hostnameSource{
 		func() string { return os.Getenv("COMPUTERNAME") },
@@ -28,7 +44,16 @@ func platformHostnameFallbacks() []hostnameSource {
 
 // wmicComputerName queries WMI for Win32_ComputerSystem.Name via the
 // existing wmicGet helper (see hardware_windows.go). Returns "" on any
-// error so the resolver moves on.
+// error so the resolver moves on. wmicGet logs subprocess errors at
+// Debug; we additionally log a Warn here when the result is empty so
+// operators hunting a future #439 regression see which link of the
+// chain gave out — this source only runs when COMPUTERNAME was also
+// empty, so by the time we reach it the chain is on its last legs.
 func wmicComputerName() string {
-	return wmicGet([]string{"computersystem"}, "Name")
+	name := wmicGet([]string{"computersystem"}, "Name")
+	if name == "" {
+		slog.Warn("wmic win32_computersystem.Name returned empty",
+			"hint", "wmic.exe may be missing on Windows 11 24H2+/Server 2025")
+	}
+	return name
 }

--- a/apps/api/migrations/2026-04-13-fix-uuid-hostnames.sql
+++ b/apps/api/migrations/2026-04-13-fix-uuid-hostnames.sql
@@ -1,0 +1,29 @@
+-- 2026-04-13: Rewrite devices.hostname rows that were populated with
+-- the device's own UUID (or agent token) instead of a real hostname.
+--
+-- Context: issue #439 — at least one prod device shipped with
+-- devices.hostname = '<uuid>' (matching the same row's id). The fix
+-- for future enrollments lives in the Go agent (fallback chain in
+-- agent/internal/collectors/hostname.go + refuse-to-enroll guard in
+-- cmd/breeze-agent/main.go). This migration cleans up the rows the
+-- old behavior left behind.
+--
+-- Strategy: any row where hostname exactly equals either the device's
+-- own id::text OR its agent_id gets renamed to a loud placeholder
+-- ("UNKNOWN-HOST-<first 8 chars of id>") that is:
+--   - unique per device (so we don't create constraint violations via
+--     the unique index on (org_id, site_id, hostname) — if any org/site
+--     has > 1 bad row, each gets a distinct placeholder)
+--   - obviously-fake to operators reading the UI
+--   - deterministic, so re-running the migration is a no-op
+--
+-- Idempotency: after the first run the WHERE clause no longer matches
+-- (hostname has been rewritten), so running this migration twice is
+-- safe. No IF EXISTS guards needed — devices table is part of the
+-- baseline schema.
+
+UPDATE devices
+SET hostname   = 'UNKNOWN-HOST-' || SUBSTRING(id::text, 1, 8),
+    updated_at = NOW()
+WHERE hostname = id::text
+   OR hostname = agent_id;

--- a/apps/api/migrations/2026-04-13-fix-uuid-hostnames.sql
+++ b/apps/api/migrations/2026-04-13-fix-uuid-hostnames.sql
@@ -8,19 +8,28 @@
 -- cmd/breeze-agent/main.go). This migration cleans up the rows the
 -- old behavior left behind.
 --
--- Strategy: any row where hostname exactly equals either the device's
--- own id::text OR its agent_id gets renamed to a loud placeholder
--- ("UNKNOWN-HOST-<first 8 chars of id>") that is:
---   - unique per device (so we don't create constraint violations via
---     the unique index on (org_id, site_id, hostname) — if any org/site
---     has > 1 bad row, each gets a distinct placeholder)
+-- RLS note: devices is FORCE ROW LEVEL SECURITY with policies gated on
+-- breeze_has_org_access(org_id), and breeze_current_scope() defaults to
+-- 'none' unless GUCs are set (see 0012-tenant-rls-deny-default.sql).
+-- autoMigrate.ts runs each migration via raw tx.unsafe(...) and does
+-- not establish a scope, so on managed Postgres installs where the
+-- migration admin role is non-superuser (DigitalOcean, RDS, etc. — see
+-- apps/api/src/db/ensureAppRole.ts) this UPDATE would be filtered to
+-- zero rows by RLS and still be recorded as applied. We explicitly
+-- set system scope for the duration of this transaction.
+--
+-- Placeholder strategy: each affected row is rewritten to a per-device
+-- placeholder ("UNKNOWN-HOST-<first 8 chars of id>") that is:
+--   - per-device (so operators don't see dozens of identical rows,
+--     and any future hostname-uniqueness constraint would not collide)
 --   - obviously-fake to operators reading the UI
 --   - deterministic, so re-running the migration is a no-op
 --
 -- Idempotency: after the first run the WHERE clause no longer matches
--- (hostname has been rewritten), so running this migration twice is
--- safe. No IF EXISTS guards needed — devices table is part of the
--- baseline schema.
+-- (hostname has been rewritten), so re-running is safe. No IF EXISTS
+-- guards needed — devices is part of the baseline schema.
+
+SELECT set_config('breeze.scope', 'system', true);
 
 UPDATE devices
 SET hostname   = 'UNKNOWN-HOST-' || SUBSTRING(id::text, 1, 8),


### PR DESCRIPTION
Fixes #439.

## Problem

At least one prod device shipped with \`devices.hostname\` populated with the device's own UUID (matching \`devices.id\`) instead of a real hostname. \`os_version\` on the same row was correct, so the OS detection path worked — only the hostname field fell back to a synthetic identifier.

Root cause: \`collectors/hardware.go\` was using \`gopsutil\`'s \`host.Info().Hostname\`, which on Windows is just a wrapper around \`os.Hostname()\` with no fallbacks. In Windows service-start edge cases (early boot, domain join transitions, unusual SCM startup order) \`os.Hostname()\` can return an empty string. The agent then enrolled with \`hostname=\"\"\` and a downstream substitution wrote the device UUID, producing a row that looks legit in the API but is useless in the UI.

## Fix (four parts)

### 1. Platform-aware hostname fallback chain (new \`collectors/hostname*.go\`)

New \`resolveHostname()\` walks a source chain and returns the first non-empty trimmed value:

- \`os.Hostname()\` (portable, first attempt)
- Platform-specific fallbacks from \`hostname_<os>.go\`:
  - **Windows:** \`COMPUTERNAME\` env var → WMI \`win32_computersystem.Name\`
  - **Other:** no additional fallbacks (\`os.Hostname\` is reliable on macOS/Linux)

If every source returns empty, \`resolveHostname\` returns \`errHostnameResolutionFailed\` — it deliberately **never** substitutes a device UUID, agent token, or any other synthetic identifier.

\`resolveHostnameFromSources\` is the pure core, exposed so \`hostname_test.go\` can exercise the chain logic without touching the real OS. Nil sources are skipped so platform builds that don't contribute fallbacks still work cleanly.

### 2. \`hardware.go\` — use the new resolver

\`\`\`go
// Before
info.Hostname = hostInfo.Hostname

// After
if resolved, rhErr := resolveHostname(); rhErr == nil {
    info.Hostname = resolved
} else {
    slog.Warn(\"hostname resolution failed\", \"error\", rhErr.Error())
}
\`\`\`

The rest of the \`host.Info()\` consumption (\`OSType\`, \`OSVersion\`, \`OSBuild\`) is unchanged.

### 3. \`main.go\` enroll guard — refuse empty hostname

In the enrollment path, after collecting system info, check \`strings.TrimSpace(systemInfo.Hostname) == \"\"\`. If so, abort enrollment via \`enrollError\` with a specific diagnostic message listing the sources that were tried. This produces a loud, actionable failure on the installer side instead of a silent-but-wrong enrollment.

### 4. \`apps/api/migrations/2026-04-13-fix-uuid-hostnames.sql\` — backfill

One-shot SQL migration that rewrites \`devices.hostname\` rows where \`hostname = id::text OR hostname = agent_id\` to \`'UNKNOWN-HOST-' || SUBSTRING(id::text, 1, 8)\`. Properties:

- **Unique per device** — avoids \`(org_id, site_id, hostname)\` unique index violations if any org/site has multiple affected rows
- **Obviously fake to operators** — the \`UNKNOWN-HOST-\` prefix is never a real hostname
- **Deterministic + idempotent** — re-running is a no-op because the \`WHERE\` clause no longer matches after the first run
- No \`IF EXISTS\` guards — \`devices\` is baseline schema

## Test plan
- [x] \`go build ./...\` clean on darwin + windows
- [x] \`go test ./internal/collectors/...\` passes
- [ ] Run migration against staging DB, verify:
  - Rows with \`hostname = id::text\` rewritten to \`UNKNOWN-HOST-<prefix>\`
  - Rows with \`hostname = agent_id\` also rewritten
  - \`(org_id, site_id, hostname)\` unique index not violated
  - Re-running migration is a no-op
- [ ] Install agent on a Windows test box, verify normal enrollment works
- [ ] Simulate empty \`os.Hostname()\` and confirm enrollment aborts with the expected error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)