### PR TITLE
fix(ci): pass POSTGRES_PASSWORD into api container for ensureAppRole

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,10 @@ services:
       # Unprivileged app role connection — RLS policies are enforced against this user.
       # Falls back to DATABASE_URL (superuser) if unset — but RLS will be bypassed in that case.
       DATABASE_URL_APP: postgresql://breeze_app:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-breeze}
+      # ensureAppRole reads one of these from the api container env to CREATE/ALTER the
+      # breeze_app role on first boot. Without one of these, DATABASE_URL_APP fails auth.
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      BREEZE_APP_DB_PASSWORD: ${BREEZE_APP_DB_PASSWORD:-}
       REDIS_URL: redis://:${REDIS_PASSWORD:?Set REDIS_PASSWORD in .env}@redis:6379
       JWT_SECRET: ${JWT_SECRET:?Set JWT_SECRET in .env}
       JWT_EXPIRES_IN: ${JWT_EXPIRES_IN:-15m}


### PR DESCRIPTION
## Summary
- Root `docker-compose.yml` interpolated `POSTGRES_PASSWORD` into `DATABASE_URL_APP` at parse time but never exposed it to the api container environment.
- On a fresh DB volume, `ensureAppRole` (apps/api/src/db/ensureAppRole.ts) found neither `BREEZE_APP_DB_PASSWORD` nor `POSTGRES_PASSWORD` in-container, logged a warning, and skipped creating the `breeze_app` role.
- The api then tried to connect via `DATABASE_URL_APP` and hit `password authentication failed for user "breeze_app"` → container crash → Smoke Test job failure → `CI Success` red.

Introduced by ec3699ba ("close cross-tenant RLS gaps"); ee95dfe9 fixed `deploy/eu/docker-compose.yml` but missed the root compose file used by CI and local builds.

## Impact
Unblocks the `Smoke Test` CI job on main and will unblock every downstream PR once rebased. This was the root cause behind the dependabot backlog — the stale "Test API" failures were from pre-`04245e06` runs; the current real blocker was Smoke Test.

## Test plan
- [x] `docker compose config` renders correctly — `POSTGRES_PASSWORD` now lands inside the api service env
- [ ] CI `Smoke Test` job goes green on this PR
- [ ] Rebase a dependabot PR (e.g. #421 golang.org/x/net) after merge and confirm it also goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)