### PR TITLE
fix(api): isolate logSessionAudit from caller tx + harden #446 tests

### DIFF
--- a/apps/api/src/__tests__/integration/audit-logs-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/audit-logs-rls.integration.test.ts
@@ -2,24 +2,46 @@
  * Integration regression test for issue #437 —
  * `audit_logs` RLS violation on viewer-token session audit.
  *
- * The fix (apps/api/src/routes/remote/helpers.ts) wraps `logSessionAudit`'s
- * insert in `withDbAccessContext({ scope: 'organization', orgId,
- * accessibleOrgIds: [orgId] }, ...)` so the write satisfies the
- * `breeze_org_isolation_insert` policy on `audit_logs`
- * (`WITH CHECK (breeze_has_org_access(org_id))`).
+ * The original fix (helpers.ts) wrapped `logSessionAudit`'s insert in
+ * `withDbAccessContext({ scope: 'organization', orgId, accessibleOrgIds:
+ * [orgId] }, ...)`, which satisfied RLS on the viewer-token path but left
+ * two latent hazards for JWT-authenticated callers:
+ *
+ *   1. Nested `withDbAccessContext` short-circuits to a no-op under an
+ *      existing context, so partner-scope callers wrote the audit row
+ *      under their own scope rather than under org scope.
+ *   2. The audit insert ran inside the caller's request transaction. A
+ *      failing insert aborts the whole caller tx and silently rolls back
+ *      real work (session creation, transfer creation) because
+ *      `logSessionAudit` swallows its own errors.
+ *
+ * The follow-up fix moves `logSessionAudit` to the same pattern as
+ * `services/auditService.createAuditLog`: `runOutsideDbContext` →
+ * `withSystemDbAccessContext`, which forces a fresh system-scope
+ * transaction on a separate pooled connection. That closes both hazards.
  *
  * These tests run against real Postgres as the unprivileged `breeze_app`
- * role (created by `ensureAppRole()` during integration setup), so the
- * RLS policy is actually enforced. They prove:
+ * role so RLS policies are actually enforced. They prove:
  *
- *   1. Without any access context established, a raw insert into
- *      `audit_logs` is rejected by RLS with the exact error message we
- *      saw in production. This reproduces the pre-fix bug.
- *   2. `logSessionAudit` establishes its own org-scoped context internally
- *      and the insert succeeds, with the row visible to a subsequent
- *      org-scoped read.
- *   3. `logSessionAudit` swallows RLS / DB errors so the request path is
- *      not broken when the audit write itself fails.
+ *   1. Pre-fix reproducer: a raw insert into `audit_logs` with no access
+ *      context is rejected by RLS with the exact production error.
+ *      (Acts as a smoke test that the integration harness actually
+ *      enforces RLS — if DATABASE_URL_APP were misconfigured to point at
+ *      the superuser, this test would pass the insert and falsely
+ *      green-light the rest of the suite.)
+ *   2. Positive case: `logSessionAudit` with no outer context lands the
+ *      row. This is the actual regression guard for #437.
+ *   3. Error-swallow contract: a FK violation in the audit insert is
+ *      swallowed rather than thrown so the caller path is unaffected.
+ *   4. Partner-scope outer context: `logSessionAudit` called from inside
+ *      a partner-scope caller context lands the row (proves the
+ *      `runOutsideDbContext` rewrite doesn't narrow or break the caller's
+ *      outer scope, and that the audit write reaches system scope
+ *      regardless of the caller's scope).
+ *   5. Transaction isolation: when the caller's request tx rolls back,
+ *      the audit row written via `logSessionAudit` must persist. This is
+ *      the hazard the rewrite exists to prevent — proves the audit write
+ *      really runs on its own connection, not inside the caller's tx.
  */
 import './setup';
 import { describe, it, expect, vi } from 'vitest';
@@ -31,16 +53,19 @@ import { createPartner, createOrganization } from './db-utils';
 import { getTestDb } from './setup';
 
 describe('audit_logs RLS — logSessionAudit (issue #437)', () => {
-  it('reproduces the pre-fix bug: a raw insert with no access context is rejected by RLS', async () => {
+  it('reproduces the pre-fix bug: raw insert with no access context is rejected by RLS (harness smoke test)', async () => {
     const partner = await createPartner();
     const org = await createOrganization({ partnerId: partner.id });
 
     // Simulate the pre-fix behavior: call the production db pool directly,
-    // without wrapping in withDbAccessContext. As `breeze_app` the session
-    // has scope='none' / accessible_org_ids='' so
-    // breeze_has_org_access(org_id) returns false and the WITH CHECK
-    // clause rejects the row. Drizzle wraps the Postgres error as
-    // DrizzleQueryError — the RLS message lives on `error.cause.message`.
+    // without any access context. As `breeze_app` the session has scope
+    // defaulting to 'none' / accessible_org_ids='', so breeze_has_org_access
+    // returns false and the WITH CHECK clause rejects the row.
+    //
+    // Note: this test reproduces the bug regardless of whether the fix is
+    // applied — its role is to anchor the RLS contract and prove the
+    // integration harness is genuinely running as breeze_app. Test #2
+    // below is the actual regression guard for the fix.
     let caught: unknown;
     try {
       await db.insert(auditLogs).values({
@@ -65,7 +90,7 @@ describe('audit_logs RLS — logSessionAudit (issue #437)', () => {
     );
   });
 
-  it('logSessionAudit establishes an org-scoped context and the insert succeeds', async () => {
+  it('logSessionAudit with no outer context writes the row on its own system-scope connection', async () => {
     const partner = await createPartner();
     const org = await createOrganization({ partnerId: partner.id });
     const sessionId = '11111111-1111-1111-1111-111111111111';
@@ -79,8 +104,7 @@ describe('audit_logs RLS — logSessionAudit (issue #437)', () => {
       '10.0.0.1'
     );
 
-    // Verify the row landed. Read as superuser via the test client to
-    // avoid any RLS interaction on the verification path.
+    // Read back as superuser to avoid any RLS interaction on verification.
     const rows = await getTestDb()
       .select()
       .from(auditLogs)
@@ -98,13 +122,14 @@ describe('audit_logs RLS — logSessionAudit (issue #437)', () => {
     });
   });
 
-  it('logSessionAudit swallows RLS rejection instead of throwing (contract preserved)', async () => {
-    // Pass an org_id for an org the caller has no access to by
-    // constructing a syntactically valid but non-existent UUID. The
-    // helper wraps in an org-scoped context pinned to that id, so the
-    // RLS WITH CHECK passes — but the FK on audit_logs.org_id fails
-    // because no matching `organizations` row exists. The helper must
-    // still resolve without throwing so the request path is unaffected.
+  it('swallows DB errors (FK violation on bogus orgId) so the request path is not broken', async () => {
+    // Under the new system-scope pattern, `breeze_has_org_access` returns
+    // TRUE for any orgId (system scope bypasses the accessible_org_ids
+    // check), so RLS passes regardless of whether the org exists. The
+    // failure exercised here is the `audit_logs.org_id -> organizations.id`
+    // FK, not an RLS rejection. The contract the helper preserves is
+    // "any DB error on the audit insert must resolve rather than throw"
+    // so the caller's request path is unaffected.
     const fakeOrgId = '33333333-3333-3333-3333-333333333333';
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -124,27 +149,31 @@ describe('audit_logs RLS — logSessionAudit (issue #437)', () => {
     errSpy.mockRestore();
   });
 
-  it('nested withDbAccessContext: logSessionAudit runs under the caller\'s existing scope', async () => {
+  it('partner-scope outer context: audit write lands under system scope without affecting caller scope', async () => {
+    // Simulate an MSP-staff JWT-authenticated call: caller is on partner
+    // scope with access to multiple orgs, and calls logSessionAudit for
+    // one of those orgs. Under the previous fix, the helper's nested
+    // withDbAccessContext short-circuited to the outer partner scope, and
+    // the insert ran under whatever scope the caller had. Under the
+    // rewrite, the helper runs outside the caller's context entirely and
+    // writes under system scope.
     const partner = await createPartner();
-    const org = await createOrganization({ partnerId: partner.id });
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const orgB = await createOrganization({ partnerId: partner.id });
     const sessionId = '66666666-6666-6666-6666-666666666666';
 
-    // JWT-authenticated call sites reach logSessionAudit already inside
-    // an access context established by the auth middleware. The helper's
-    // internal withDbAccessContext short-circuits in that case and the
-    // insert runs under the caller's scope — this test proves that path
-    // still satisfies RLS.
     await withDbAccessContext(
       {
-        scope: 'organization',
-        orgId: org.id,
-        accessibleOrgIds: [org.id]
+        scope: 'partner',
+        orgId: null,
+        accessibleOrgIds: [orgA.id, orgB.id],
+        accessiblePartnerIds: [partner.id]
       },
       () =>
         logSessionAudit(
           'session_offer_submitted',
           '77777777-7777-7777-7777-777777777777',
-          org.id,
+          orgA.id,
           { sessionId, type: 'desktop', via: 'jwt' }
         )
     );
@@ -155,5 +184,79 @@ describe('audit_logs RLS — logSessionAudit (issue #437)', () => {
       .where(eq(auditLogs.resourceId, sessionId));
 
     expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ orgId: orgA.id });
+  });
+
+  it('transaction isolation: audit row persists even when caller request tx rolls back', async () => {
+    // The hazard the rewrite fixes: if the audit insert runs inside the
+    // caller's request transaction and something in that transaction
+    // throws, Postgres rolls back the whole tx — including the audit
+    // row. Under the rewrite, `runOutsideDbContext` forces the audit
+    // write onto a separate pooled connection, so rollback of the
+    // caller's tx leaves the audit row committed.
+    //
+    // We prove this by writing two rows inside an org-scoped caller tx:
+    //   (a) a direct `db.insert(auditLogs)` marker — this should roll
+    //       back with the caller tx.
+    //   (b) a `logSessionAudit()` call — this should run outside the
+    //       caller tx and survive rollback.
+    // Then we throw from the caller callback and verify (a) is gone but
+    // (b) remains.
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const rollbackMarkerId = '88888888-8888-8888-8888-888888888888';
+    const auditSurvivorSessionId = '99999999-9999-9999-9999-999999999999';
+
+    await expect(
+      withDbAccessContext(
+        {
+          scope: 'organization',
+          orgId: org.id,
+          accessibleOrgIds: [org.id]
+        },
+        async () => {
+          // (a) Caller's own audit write inside its tx. Will roll back.
+          await db.insert(auditLogs).values({
+            orgId: org.id,
+            actorType: 'user',
+            actorId: '00000000-0000-0000-0000-000000000aaa',
+            action: 'rollback_marker',
+            resourceType: 'remote_session',
+            resourceId: rollbackMarkerId,
+            details: {},
+            result: 'success'
+          });
+
+          // (b) Audit helper — must escape the caller's tx.
+          await logSessionAudit(
+            'session_offer_submitted',
+            '00000000-0000-0000-0000-000000000bbb',
+            org.id,
+            { sessionId: auditSurvivorSessionId, type: 'desktop', via: 'jwt' }
+          );
+
+          throw new Error('simulated caller rollback');
+        }
+      )
+    ).rejects.toThrow('simulated caller rollback');
+
+    // (a) Marker must have been rolled back with the caller tx.
+    const markerRows = await getTestDb()
+      .select()
+      .from(auditLogs)
+      .where(eq(auditLogs.resourceId, rollbackMarkerId));
+    expect(markerRows).toHaveLength(0);
+
+    // (b) logSessionAudit row must have been committed on its own
+    //     connection and survived the rollback.
+    const survivorRows = await getTestDb()
+      .select()
+      .from(auditLogs)
+      .where(eq(auditLogs.resourceId, auditSurvivorSessionId));
+    expect(survivorRows).toHaveLength(1);
+    expect(survivorRows[0]).toMatchObject({
+      orgId: org.id,
+      action: 'session_offer_submitted'
+    });
   });
 });

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -629,15 +629,23 @@ export async function seedRoles() {
     // Assign permissions to role
     for (const permKey of roleDef.permissions) {
       const permId = permMap.get(permKey);
-      if (permId) {
-        try {
-          await db.insert(rolePermissions).values({
-            roleId,
-            permissionId: permId
-          });
-        } catch {
-          // Permission already assigned, ignore
+      if (!permId) {
+        console.warn(`  Role "${roleDef.name}" references unknown permission "${permKey}" — skipping`);
+        continue;
+      }
+      try {
+        await db.insert(rolePermissions).values({
+          roleId,
+          permissionId: permId
+        });
+      } catch (err) {
+        // 23505 = unique_violation. Permission already assigned — safe to
+        // ignore. Any other error (RLS, connection loss, FK) must surface
+        // so a broken seed doesn't silently leave partial role grants.
+        if ((err as { code?: string } | null)?.code === '23505') {
+          continue;
         }
+        throw err;
       }
     }
   }

--- a/apps/api/src/routes/remote/helpers.test.ts
+++ b/apps/api/src/routes/remote/helpers.test.ts
@@ -1,20 +1,33 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { insert, insertValues, withDbAccessContext, captureException } = vi.hoisted(() => {
+const {
+  insert,
+  insertValues,
+  runOutsideDbContext,
+  withSystemDbAccessContext,
+  captureException
+} = vi.hoisted(() => {
   const insertValues = vi.fn(() => Promise.resolve());
   const insert = vi.fn(() => ({ values: insertValues }));
-  // Capture the context passed to withDbAccessContext so we can assert it
-  // matches the org scope of the session being audited.
-  const withDbAccessContext = vi.fn(
-    async (_ctx: unknown, fn: () => unknown) => fn()
-  );
+  // `runOutsideDbContext` is synchronous (wraps AsyncLocalStorage.exit); the
+  // real impl just calls its argument outside the current context. The mock
+  // passes through so we can assert ordering separately.
+  const runOutsideDbContext = vi.fn(<T>(fn: () => T): T => fn());
+  const withSystemDbAccessContext = vi.fn(async (fn: () => unknown) => fn());
   const captureException = vi.fn();
-  return { insert, insertValues, withDbAccessContext, captureException };
+  return {
+    insert,
+    insertValues,
+    runOutsideDbContext,
+    withSystemDbAccessContext,
+    captureException
+  };
 });
 
 vi.mock('../../db', () => ({
   db: { insert },
-  withDbAccessContext
+  runOutsideDbContext,
+  withSystemDbAccessContext
 }));
 
 vi.mock('../../db/schema', () => ({
@@ -38,7 +51,11 @@ describe('logSessionAudit', () => {
   // Regression: the viewer-token desktop WS path has no request-scoped DB
   // context, so the audit insert was hitting `audit_logs` RLS and silently
   // failing. See issue #437.
-  it('wraps the insert in an org-scoped DB access context', async () => {
+  //
+  // Follow-up: the fix must also isolate the audit write from the caller's
+  // request transaction to avoid rolling back real work on audit failure.
+  // See `services/auditService.ts` for the same pattern.
+  it('runs outside the caller context and under a system DB scope', async () => {
     const orgId = '11111111-1111-1111-1111-111111111111';
     const actorId = '22222222-2222-2222-2222-222222222222';
     const sessionId = '33333333-3333-3333-3333-333333333333';
@@ -51,13 +68,13 @@ describe('logSessionAudit', () => {
       '10.0.0.1'
     );
 
-    expect(withDbAccessContext).toHaveBeenCalledTimes(1);
-    const firstCall = withDbAccessContext.mock.calls[0]!;
-    expect(firstCall[0]).toEqual({
-      scope: 'organization',
-      orgId,
-      accessibleOrgIds: [orgId]
-    });
+    expect(runOutsideDbContext).toHaveBeenCalledTimes(1);
+    expect(withSystemDbAccessContext).toHaveBeenCalledTimes(1);
+    // Ordering: runOutsideDbContext must wrap withSystemDbAccessContext so the
+    // nested system-scope call actually opens a fresh tx on its own connection.
+    const outsideOrder = runOutsideDbContext.mock.invocationCallOrder[0]!;
+    const systemOrder = withSystemDbAccessContext.mock.invocationCallOrder[0]!;
+    expect(outsideOrder).toBeLessThan(systemOrder);
 
     expect(insert).toHaveBeenCalledTimes(1);
     expect(insertValues).toHaveBeenCalledWith(

--- a/apps/api/src/routes/remote/helpers.ts
+++ b/apps/api/src/routes/remote/helpers.ts
@@ -1,6 +1,6 @@
 import { and, eq, sql, inArray, lte, or } from 'drizzle-orm';
 import { createHmac } from 'crypto';
-import { db, withDbAccessContext } from '../../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
 import { captureException } from '../../services/sentry';
 import {
   remoteSessions,
@@ -247,12 +247,19 @@ export async function checkUserSessionRateLimit(userId: string, maxConcurrent: n
 
 // Log audit event for session activity.
 //
-// Wraps the insert in an org-scoped DB access context so the write satisfies
-// `audit_logs` RLS on paths that don't otherwise establish one (e.g. the
-// viewer-token desktop WS handlers, which authenticate off a signed session
-// ticket rather than a JWT and have no request-scoped access context).
-// `withDbAccessContext` short-circuits when a context is already active, so
-// JWT-authenticated call sites keep running under the caller's existing scope.
+// Runs on a connection OUTSIDE the caller's request transaction — same pattern
+// as `createAuditLog` in `services/auditService.ts`. Two reasons:
+//   1. RLS satisfaction on paths that don't establish their own DB context
+//      (e.g. the viewer-token desktop WS handlers). A nested `withDbAccessContext`
+//      would short-circuit to a no-op under an existing context, so we explicitly
+//      `runOutsideDbContext` → `withSystemDbAccessContext` to force a fresh
+//      system-scope transaction on a separate pooled connection.
+//   2. Tx isolation. If the audit insert fails inside the caller's request
+//      transaction, Postgres aborts the whole tx and silently rolls back the
+//      caller's real work (session creation, transfer creation) even though
+//      the route returned 200 — because this function swallows the error.
+//      Running outside the caller's tx isolates audit-write failures from
+//      business writes.
 export async function logSessionAudit(
   action: string,
   actorId: string,
@@ -261,14 +268,9 @@ export async function logSessionAudit(
   ipAddress?: string
 ) {
   try {
-    await withDbAccessContext(
-      {
-        scope: 'organization',
-        orgId,
-        accessibleOrgIds: [orgId],
-      },
-      () =>
-        db.insert(auditLogs).values({
+    await runOutsideDbContext(() =>
+      withSystemDbAccessContext(async () => {
+        await db.insert(auditLogs).values({
           orgId,
           actorType: 'user',
           actorId,
@@ -278,7 +280,8 @@ export async function logSessionAudit(
           details,
           ipAddress,
           result: 'success'
-        })
+        });
+      })
     );
   } catch (error) {
     // Escalate to Sentry as well as stdout: #437 went undetected for months


### PR DESCRIPTION
## Summary

Follow-up to #446. The original fix wrapped `logSessionAudit`'s insert in an org-scoped `withDbAccessContext`, which closed the viewer-token RLS drop but left two latent hazards on JWT-authenticated callers:

1. **Nested short-circuit silently dropped the helper's scope.** `withDbAccessContext` no-ops when a context is already active, so partner-scope callers wrote audit rows under their own scope rather than under the org scope the helper intended.
2. **The audit insert ran inside the caller's request transaction.** A failing insert aborts the whole tx and silently rolls back real work (session creation, transfer creation) because `logSessionAudit` swallows its own errors — the exact same class of silent failure #437 exposed, just applied to business writes instead of audit rows.

This PR rewrites `logSessionAudit` to match `services/auditService.createAuditLog`: `runOutsideDbContext(() => withSystemDbAccessContext(...))` forces a fresh system-scope transaction on a separate pooled connection. Closes both hazards in one change.

## What changed

**Fix**

- `apps/api/src/routes/remote/helpers.ts` — `logSessionAudit` now runs outside the caller's AsyncLocalStorage context under `withSystemDbAccessContext`. Comment explains both the RLS and the tx-isolation rationale.
- `apps/api/src/db/seed.ts` — narrows the `seedRoles` → `rolePermissions` catch to `err.code === '23505'` only. Previously swallowed every error, which would have hidden RLS/FK/connection failures on the fresh-DB seed path #446 set up. Also warns when a role references an unknown permission.

**Tests**

- `apps/api/src/routes/remote/helpers.test.ts` — mocks `runOutsideDbContext` + `withSystemDbAccessContext` instead of `withDbAccessContext`; asserts invocation order so the outer-context exit wraps the system-context opener.
- `apps/api/src/__tests__/integration/audit-logs-rls.integration.test.ts` — four tests → five:
  1. Pre-fix reproducer — docstring clarified as a harness smoke test (anchors the RLS contract, not a regression guard).
  2. Positive case — unchanged.
  3. Error swallow — docstring corrected to \"FK violation\" (the new system-scope wrapper makes RLS pass for any orgId; the bogus-UUID failure now fires on the `audit_logs.org_id → organizations.id` FK).
  4. **Replaced:** partner-scope outer context with two accessible orgs — proves the audit write lands correctly regardless of the caller's scope. Previous nested test used the same orgId for outer and inner and was vacuous.
  5. **New:** transaction isolation — writes a rollback marker via direct `db.insert(auditLogs)` and a row via `logSessionAudit()` inside an org-scoped caller tx, throws from the callback, verifies the marker rolled back but the audit row survived. This is the real proof that the rewrite closes the silent-rollback hazard.

## Test plan

- [x] `vitest run src/routes/remote` → 10/10 pass
- [x] `vitest run --config vitest.integration.config.ts` → 10/10 pass (including the new tx-isolation test)
- [x] `vitest run --config vitest.config.rls.ts` → 22/22 pass
- [x] `tsc --noEmit` clean
- [x] Pre-existing failing test files unchanged

## Related

- Follow-up to #446 (which fixed #437)
- Adopts the pattern from `services/auditService.ts` (`createAuditLog`), which already documents the same rollback hazard in its comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)