### PR TITLE
fix(agent): bypass os/user sync.Once cache for Windows SID lookup (#442)

### DIFF
--- a/agent/internal/userhelper/client.go
+++ b/agent/internal/userhelper/client.go
@@ -176,40 +176,57 @@ func (c *Client) connect() error {
 // dialIPC is implemented in client_windows.go and client_unix.go.
 
 func (c *Client) authenticate() error {
-	cu, err := user.Current()
-	if err != nil {
-		return fmt.Errorf("get current user: %w", err)
+	var (
+		uid      uint64
+		sid      string
+		username string
+	)
+
+	if runtime.GOOS == "windows" {
+		// Bypass os/user on Windows entirely: user.Current() caches its
+		// result via sync.Once, so a CreateProcessAsUser race that fails
+		// the first lookup poisons every subsequent call. Query the kernel
+		// token directly instead (see sid_windows.go).
+		retrySID, retryErr := lookupSIDWithRetry()
+		if retryErr != nil {
+			return retryErr
+		}
+		sid = retrySID
+
+		uname, unameErr := lookupUsernameDirect()
+		if unameErr != nil {
+			return fmt.Errorf("get current username: %w", unameErr)
+		}
+		username = uname
+	} else {
+		cu, err := user.Current()
+		if err != nil {
+			return fmt.Errorf("get current user: %w", err)
+		}
+		parsed, parseErr := strconv.ParseUint(cu.Uid, 10, 32)
+		if parseErr != nil {
+			return fmt.Errorf("parse uid %q: %w", cu.Uid, parseErr)
+		}
+		uid = parsed
+		username = cu.Username
 	}
 
-	uid, err := strconv.ParseUint(cu.Uid, 10, 32)
-	var sid string
-	if err != nil {
-		// On Windows, cu.Uid is the SID string (e.g., "S-1-5-21-...").
-		// When the process was spawned cross-session via CreateProcessAsUser,
-		// the first user.Current() call can occasionally return an
-		// empty/malformed Uid while the duplicated token finishes
-		// materializing in the kernel. Retry with backoff, and treat
-		// a permanent failure as fatal so the lifecycle manager can back off.
-		uid = 0
-		sid = cu.Uid
-		if runtime.GOOS == "windows" && !looksLikeSID(sid) {
-			retrySID, retryErr := lookupSIDWithRetry()
-			if retryErr != nil {
-				return retryErr
-			}
-			sid = retrySID
-		}
+	if username == "" {
+		return fmt.Errorf("authenticate: empty username after platform lookup")
+	}
+	if runtime.GOOS == "windows" && !looksLikeSID(sid) {
+		return fmt.Errorf("authenticate: invalid SID %q after platform lookup", sid)
 	}
 
 	binaryHash, _ := computeSelfHash()
 	displayEnv := detectDisplayEnv()
-	sessionID := fmt.Sprintf("helper-%s-%d", cu.Username, os.Getpid())
+	sessionID := fmt.Sprintf("helper-%s-%d", username, os.Getpid())
 
 	authReq := ipc.AuthRequest{
 		ProtocolVersion: ipc.ProtocolVersion,
 		UID:             uint32(uid),
 		SID:             sid,
-		Username:        cu.Username,
+		Username:        username,
 		SessionID:       sessionID,
 		DisplayEnv:      displayEnv,
 		PID:             os.Getpid(),

--- a/agent/internal/userhelper/sid_other.go
+++ b/agent/internal/userhelper/sid_other.go
@@ -2,10 +2,17 @@
 
 package userhelper
 
-// lookupSIDWithRetry is a no-op on non-Windows platforms: there's no SID on
-// Unix. Callers should use the UID from user.Current() directly instead.
-// Kept to satisfy cross-platform calling code without build tags at the
-// call site.
+import "errors"
+
+// lookupSIDWithRetry only exists on Windows. The non-Windows stub returns
+// an explicit error so any accidental cross-platform call fails loudly
+// rather than silently returning an empty SID. client.go gates the call
+// behind runtime.GOOS == "windows".
 func lookupSIDWithRetry() (string, error) {
-	return "", nil
+	return "", errors.New("lookupSIDWithRetry: not supported on non-Windows")
+}
+
+// lookupUsernameDirect only exists on Windows. See lookupSIDWithRetry.
+func lookupUsernameDirect() (string, error) {
+	return "", errors.New("lookupUsernameDirect: not supported on non-Windows")
 }

--- a/agent/internal/userhelper/sid_windows.go
+++ b/agent/internal/userhelper/sid_windows.go
@@ -4,8 +4,9 @@ package userhelper
 
 import (
 	"fmt"
-	"os/user"
 	"time"
+
+	"golang.org/x/sys/windows"
 )
 
 // lookupSIDWithRetry returns the current process's SID as a string, retrying
@@ -14,7 +15,12 @@ import (
 // empty/malformed SID for the first few hundred ms while the kernel finishes
 // setting up the duplicated token.
 //
-// Backoff schedule: 100ms, 250ms, 500ms, 1s — total < 2s.
+// Backoff schedule: 0, 100ms, 250ms, 500ms, 1s — total < 2s.
+//
+// We deliberately bypass Go's os/user package here: user.Current() caches
+// its result via sync.Once, so a single early failure poisons every retry
+// with the same stale error. Calling OpenProcessToken + GetTokenUser each
+// attempt actually re-queries the kernel.
 func lookupSIDWithRetry() (string, error) {
 	delays := []time.Duration{0, 100 * time.Millisecond, 250 * time.Millisecond, 500 * time.Millisecond, 1 * time.Second}
 
@@ -23,26 +29,25 @@ func lookupSIDWithRetry() (string, error) {
 		if d > 0 {
 			time.Sleep(d)
 		}
-		cu, err := user.Current()
+		sid, err := queryProcessSID()
 		if err != nil {
 			lastErr = err
-			log.Warn("SID lookup: user.Current failed",
+			log.Warn("SID lookup: token query failed",
 				"attempt", i+1,
 				"error", err.Error(),
 			)
 			continue
 		}
-		// On Windows, cu.Uid is the SID string: "S-1-5-..."
-		if looksLikeSID(cu.Uid) {
+		if looksLikeSID(sid) {
 			if i > 0 {
-				log.Info("SID lookup: succeeded after retries", "attempts", i+1, "sid", cu.Uid)
+				log.Info("SID lookup: succeeded after retries", "attempts", i+1, "sid", sid)
 			}
-			return cu.Uid, nil
+			return sid, nil
 		}
-		lastErr = fmt.Errorf("user.Current returned non-SID Uid %q", cu.Uid)
-		log.Warn("SID lookup: Uid not SID-shaped",
+		lastErr = fmt.Errorf("token returned non-SID string %q", sid)
+		log.Warn("SID lookup: token SID not SID-shaped",
 			"attempt", i+1,
-			"uid", cu.Uid,
+			"sid", sid,
 		)
 	}
 	if lastErr == nil {
@@ -51,3 +56,45 @@ func lookupSIDWithRetry() (string, error) {
 	return "", fmt.Errorf("%w: last error: %v", ErrSIDLookupFailed, lastErr)
 }
 
+// queryProcessSID opens the current process token and returns its user SID
+// as a string. No caching — every call hits the kernel.
+func queryProcessSID() (string, error) {
+	var token windows.Token
+	if err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_QUERY, &token); err != nil {
+		return "", fmt.Errorf("OpenProcessToken: %w", err)
+	}
+	defer token.Close()
+
+	tokenUser, err := token.GetTokenUser()
+	if err != nil {
+		return "", fmt.Errorf("GetTokenUser: %w", err)
+	}
+	return tokenUser.User.Sid.String(), nil
+}
+
+// lookupUsernameDirect returns the current process's username in
+// DOMAIN\user (SAM) format, querying secur32 directly rather than via
+// os/user — same sync.Once cache trap as lookupSIDWithRetry.
+func lookupUsernameDirect() (string, error) {
+	// GetUserNameExW signals a too-small buffer with ERROR_MORE_DATA (234),
+	// not ERROR_INSUFFICIENT_BUFFER — unlike most Win32 sizing APIs.
+	n := uint32(256)
+	for attempt := 0; attempt < 5; attempt++ {
+		buf := make([]uint16, n)
+		err := windows.GetUserNameEx(windows.NameSamCompatible, &buf[0], &n)
+		if err == nil {
+			name := windows.UTF16ToString(buf[:n])
+			if name == "" {
+				return "", fmt.Errorf("GetUserNameEx: returned empty username")
+			}
+			return name, nil
+		}
+		if err != windows.ERROR_MORE_DATA {
+			return "", fmt.Errorf("GetUserNameEx: %w", err)
+		}
+		if n <= uint32(len(buf)) {
+			return "", fmt.Errorf("GetUserNameEx: buffer size did not grow (n=%d)", n)
+		}
+	}
+	return "", fmt.Errorf("GetUserNameEx: exceeded buffer-growth retries")
+}

--- a/agent/internal/userhelper/sid_windows_test.go
+++ b/agent/internal/userhelper/sid_windows_test.go
@@ -1,0 +1,72 @@
+//go:build windows
+
+package userhelper
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLookupSIDWithRetry_ReturnsValidSID verifies that the direct-kernel
+// SID lookup returns a well-formed Windows SID when called from a normal
+// (non-racing) process. The real race bug it fixes — a kernel token that
+// isn't yet materialized after CreateProcessAsUser — can't reasonably be
+// simulated in a unit test, so this test is primarily a smoke test for
+// "the replacement API works at all and doesn't panic under repeated use".
+func TestLookupSIDWithRetry_ReturnsValidSID(t *testing.T) {
+	cases := []struct {
+		name string
+	}{
+		{name: "first call"},
+		{name: "repeat call 1"},
+		{name: "repeat call 2"},
+		{name: "repeat call 3"},
+		{name: "repeat call 4"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sid, err := lookupSIDWithRetry()
+			if err != nil {
+				t.Fatalf("lookupSIDWithRetry returned error: %v", err)
+			}
+			if sid == "" {
+				t.Fatal("lookupSIDWithRetry returned empty SID")
+			}
+			if !strings.HasPrefix(sid, "S-1-5-") {
+				t.Errorf("SID %q does not have expected S-1-5- prefix", sid)
+			}
+			if !looksLikeSID(sid) {
+				t.Errorf("SID %q did not pass looksLikeSID", sid)
+			}
+		})
+	}
+}
+
+// TestQueryProcessSID_NoPanicInTightLoop calls the direct kernel query in
+// a tight loop to confirm we're not leaking token handles and don't panic.
+func TestQueryProcessSID_NoPanicInTightLoop(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		sid, err := queryProcessSID()
+		if err != nil {
+			t.Fatalf("iteration %d: queryProcessSID error: %v", i, err)
+		}
+		if !looksLikeSID(sid) {
+			t.Fatalf("iteration %d: SID %q not SID-shaped", i, sid)
+		}
+	}
+}
+
+// TestLookupUsernameDirect_ReturnsDomainUser verifies the GetUserNameEx
+// wrapper returns a non-empty username. Format is typically DOMAIN\user
+// (SAM compatible), but this test only asserts non-empty to stay robust
+// across runner identities (SYSTEM, user, CI service account, etc).
+func TestLookupUsernameDirect_ReturnsDomainUser(t *testing.T) {
+	uname, err := lookupUsernameDirect()
+	if err != nil {
+		t.Fatalf("lookupUsernameDirect error: %v", err)
+	}
+	if uname == "" {
+		t.Fatal("lookupUsernameDirect returned empty string")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #442.

The helper's `lookupSIDWithRetry` called `user.Current()` in a retry loop, but Go's stdlib `os/user` caches the result in a package-level `sync.Once`. The first failure stuck for the process lifetime — every retry returned the cached empty SID. When `CreateProcessAsUser` spawned the helper before the duplicated token was fully materialized, the helper sent `AuthRequest.SID=""`, the sessionbroker rejected with `"auth missing SID on Windows"` (`broker.go:1023`), and the helper entered a reconnect storm.

## Changes

- `sid_windows.go` — rewrote `lookupSIDWithRetry` to call `windows.OpenProcessToken` → `GetTokenUser` → `Sid.String()` directly on each attempt, matching the pattern already used in `ipc/auth_windows.go`. Retries now actually re-query the kernel.
- `client.go` — fixed the parallel `Username` path used by the broker for session-by-user lookup (broker.go:382-403), via `GetUserNameEx(NameSamCompatible)`. Unix path unchanged.
- `sid_other.go` — non-Windows no-op shim for `lookupUsernameDirect`.
- `sid_windows_test.go` — new unit test (build-tagged `windows`) exercising the direct SID path in a loop.

One inline comment on each bypass explains the `sync.Once` trap so a future reader doesn't "fix" it back.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./internal/userhelper/...` — clean
- [x] `GOOS=windows go build ./internal/userhelper/...` — clean
- [x] `GOOS=windows go vet ./internal/userhelper/...` — clean
- [x] `go test -race ./internal/userhelper/...` — pass
- [ ] Manual verification on a Windows VM after merge: spawn helper immediately post-logon, confirm no `"auth missing SID"` warnings in broker logs and no helper reconnect storm

🤖 Generated with [Claude Code](https://claude.com/claude-code)