### PR TITLE
fix(api): route agent upgrade commands to watchdog

### DIFF
--- a/apps/api/src/services/aiToolsAgentMgmt.ts
+++ b/apps/api/src/services/aiToolsAgentMgmt.ts
@@ -220,9 +220,19 @@ export function registerAgentMgmtTools(aiTools: Map<string, AiTool>): void {
 
       for (const deviceId of deviceIds) {
         try {
-          await executeCommand(deviceId, 'agent_upgrade', {
-            targetVersion,
-          }, { userId: auth.user.id, timeoutMs: 60000 });
+          // Agent upgrades are executed by the breeze-watchdog process, not
+          // the agent. The watchdog handles type `update_agent` and reads
+          // `payload.version` — see agent/cmd/breeze-watchdog/main.go:605.
+          // It has no WS connection and polls via heartbeat, so we must tag
+          // the command with target_role='watchdog' or it will be dispatched
+          // to the agent WS and never picked up.
+          await executeCommand(deviceId, 'update_agent', {
+            version: targetVersion,
+          }, {
+            userId: auth.user.id,
+            timeoutMs: 60000,
+            targetRole: 'watchdog',
+          });
           queued++;
         } catch (err) {
           errors[deviceId] = err instanceof Error ? err.message : 'Failed to queue upgrade';

--- a/apps/api/src/services/commandQueue.test.ts
+++ b/apps/api/src/services/commandQueue.test.ts
@@ -588,6 +588,109 @@ describe('command queue service', () => {
       expect(result.status).toBe('completed');
     });
 
+    // Regression guard: executeCommand with targetRole='watchdog' must
+    // insert target_role='watchdog' on the row AND must skip the WS
+    // dispatch path entirely — the watchdog has no WS connection and is
+    // picked up by the heartbeat claim query
+    // (routes/agents/heartbeat.ts -> claimPendingCommandsForDevice(..., 'watchdog')).
+    // Before the fix, the AI upgrade tool queued `agent_upgrade` with default
+    // target_role='agent', which dispatched to the agent WS (wrong handler)
+    // and never reached the watchdog heartbeat poll.
+    it('routes watchdog-targeted commands to the row insert without WS dispatch', async () => {
+      const device = {
+        id: 'dev-watchdog',
+        status: 'online',
+        agentId: 'agent-wd',
+        orgId: 'org-1',
+        hostname: 'host-wd',
+      };
+      const queued = { id: 'cmd-wd', type: 'update_agent' };
+      const completed = {
+        id: 'cmd-wd',
+        type: 'update_agent',
+        status: 'completed',
+        result: { status: 'completed', stdout: 'updated' },
+      };
+
+      let pollCall = 0;
+      vi.mocked(db.select).mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockImplementation(() => {
+              pollCall += 1;
+              if (pollCall === 1) return Promise.resolve([device]);
+              return Promise.resolve([completed]);
+            }),
+          }),
+        }),
+      }) as any);
+
+      const insertValues = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([queued]),
+        execute: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.mocked(db.insert).mockReturnValue({
+        values: insertValues,
+      } as any);
+
+      // Even if the WS pool says the agent is connected, a watchdog-targeted
+      // command must NOT hit the WS dispatch path.
+      vi.mocked(isAgentConnected).mockReturnValue(true);
+
+      const result = await executeCommand(
+        'dev-watchdog',
+        'update_agent',
+        { version: '0.62.25-rc.2' },
+        { userId: 'user-1', targetRole: 'watchdog' },
+      );
+
+      // Row must be inserted with target_role='watchdog'.
+      expect(insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deviceId: 'dev-watchdog',
+          type: 'update_agent',
+          payload: { version: '0.62.25-rc.2' },
+          status: 'pending',
+          targetRole: 'watchdog',
+        }),
+      );
+      // WS dispatch path must be fully skipped.
+      expect(claimPendingCommandForDelivery).not.toHaveBeenCalled();
+      expect(sendCommandToAgent).not.toHaveBeenCalled();
+      expect(releaseClaimedCommandDelivery).not.toHaveBeenCalled();
+      // Polling still returns the completed result (set by the watchdog's
+      // command_result path, same as agent commands).
+      expect(result.status).toBe('completed');
+    });
+
+    // Regression guard: default options (no targetRole) must still insert
+    // target_role='agent' so existing agent-bound commands continue working.
+    // A subtle regression here would break every non-watchdog command.
+    it("defaults target_role to 'agent' when targetRole is not provided", async () => {
+      setupOnlineDeviceMocks();
+      vi.mocked(isAgentConnected).mockReturnValue(true);
+      vi.mocked(sendCommandToAgent).mockReturnValue(true);
+
+      // Capture the values passed to db.insert(...).values(...).
+      const insertValues = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: 'cmd-x' }]),
+        execute: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.mocked(db.insert).mockReturnValue({
+        values: insertValues,
+      } as any);
+
+      await executeCommand('dev-online', CommandTypes.PATCH_SCAN);
+
+      expect(insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targetRole: 'agent',
+        }),
+      );
+      // Normal agent path must still dispatch over WS.
+      expect(sendCommandToAgent).toHaveBeenCalled();
+    });
+
     it('skips the WS pre-check when preferHeartbeat is true', async () => {
       // Heartbeat-preferred callers (e.g. Tauri helper) intentionally let the
       // command queue and wait for the next agent poll, so the WS pre-check

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -572,9 +572,35 @@ export async function executeCommand(
     userId?: string;
     timeoutMs?: number;
     preferHeartbeat?: boolean;
+    /**
+     * Which polling consumer on the device picks up this command.
+     * - 'agent' (default): the long-lived Go agent. Has a WS connection, so
+     *   executeCommand dispatches over WS for low latency.
+     * - 'watchdog': the separate breeze-watchdog process. Has NO WebSocket —
+     *   it polls via heartbeat (`claimPendingCommandsForDevice(..., 'watchdog')`
+     *   in routes/agents/heartbeat.ts). When targetRole is 'watchdog' we
+     *   MUST skip the WS dispatch path entirely and just write the row;
+     *   otherwise the command is sent to the agent WS (wrong consumer) and
+     *   the row's default target_role='agent' hides it from the heartbeat
+     *   claim query, leaving it pending forever.
+     *
+     * NOTE: because the watchdog polls every heartbeat (~5–10s per device,
+     * sometimes slower), callers targeting the watchdog should pass a larger
+     * timeoutMs than they would for an agent command.
+     */
+    targetRole?: 'agent' | 'watchdog';
   } = {}
 ): Promise<CommandResult> {
-  const { timeoutMs = 30000, userId, preferHeartbeat = false } = options;
+  const {
+    timeoutMs = 30000,
+    userId,
+    preferHeartbeat = false,
+    targetRole = 'agent',
+  } = options;
+  // Watchdog-targeted commands have no WS consumer; the WS pre-check /
+  // dispatch path below must be skipped entirely for them. The heartbeat
+  // poll path in routes/agents/heartbeat.ts picks them up.
+  const dispatchViaWs = targetRole === 'agent' && !preferHeartbeat;
 
   // 1. Verify device inside the auth transaction (RLS-protected).
   const [device] = await db
@@ -604,7 +630,7 @@ export async function executeCommand(
   // can still queue normally.
   if (
     device.agentId &&
-    !preferHeartbeat &&
+    dispatchViaWs &&
     INTERACTIVE_COMMAND_TYPES.has(type) &&
     !isAgentConnected(device.agentId)
   ) {
@@ -636,6 +662,7 @@ export async function executeCommand(
         payload,
         status: 'pending',
         createdBy: safeUserId,
+        targetRole,
       })
       .returning();
 
@@ -680,7 +707,9 @@ export async function executeCommand(
     // hiccup (e.g. mid-reconnect) can fail a single send even when the
     // connection comes back ~hundreds of ms later. Retrying gives the pool a
     // chance to recover before we fall through to the multi-second timeout.
-    if (device.agentId && !preferHeartbeat) {
+    // Watchdog-targeted commands skip this entirely — the watchdog has no WS
+    // and is picked up by the heartbeat claim query in heartbeat.ts.
+    if (device.agentId && dispatchViaWs) {
       const claimed = await claimPendingCommandForDelivery(command.id);
       if (claimed) {
         let sent = false;


### PR DESCRIPTION
## Summary

Fixes a silent-failure bug in the AI agent-upgrade tool that I discovered while trying to push v0.62.25-rc.2 to test devices.

`aiToolsAgentMgmt.ts` was dispatching upgrade commands that **never reached any handler**:

| | Was sent | Handler expects |
|---|---|---|
| Command type | `agent_upgrade` | `update_agent` (`agent/cmd/breeze-watchdog/main.go:605`) |
| Payload key | `targetVersion` | `version` (`main.go:606`) |
| `target_role` | `agent` (default) | `watchdog` (claimed in `routes/agents/heartbeat.ts:64`) |

Result: the AI tool returned `{queued: N, targetVersion: '...'}` to the user, but the row sat `pending` forever. No command ever executed. Pure false-positive.

## Changes

- **`commandQueue.ts`** — `executeCommand` now accepts `options.targetRole?: 'agent' | 'watchdog'`. When `'watchdog'`:
  - The WS dispatch block is skipped (watchdog has no WebSocket — it polls via heartbeat)
  - The `claimPendingCommandForDelivery` / `sendCommandToAgent` / release path is skipped
  - The row is inserted with `target_role='watchdog'`
  - Result polling is unchanged (keys on `commandId` only)
- **`aiToolsAgentMgmt.ts`** — call site now sends `update_agent` with `{version: targetVersion}` and `targetRole: 'watchdog'`
- **`commandQueue.test.ts`** — two new tests: watchdog-path skips WS dispatch and inserts with `target_role='watchdog'`; default path still dispatches over WS with `target_role='agent'` (regression guard)

## Test plan
- [x] 18 tests pass (16 existing + 2 new) under vitest
- [x] `npx tsc --noEmit` clean
- [ ] Manual smoke after merge: ask the AI chat to upgrade a device with a live watchdog and confirm the command completes

## Related
- Discovered while cutting v0.62.25-rc.2 (#442/#443 fixes). A sibling PR (#binarySync) fixes a separate silent failure where RC versions never get registered in `agent_versions` under `BINARY_SOURCE=github`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)