### PR TITLE
fix(api): ensureCurrentVersionRegistered runs in github BINARY_SOURCE path (catches RCs)

### DIFF
--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -105,6 +105,12 @@ export async function syncBinaries(): Promise<void> {
   if (getBinarySource() === 'github') {
     console.log('[binarySync] BINARY_SOURCE=github, syncing from GitHub releases');
     await syncFromGitHub();
+    // Safety net: syncFromGitHub() with no args hits /releases/latest which
+    // EXCLUDES pre-releases, so RC deploys (APP_VERSION=x.y.z-rc.N) would
+    // otherwise never land in agent_versions. ensureCurrentVersionRegistered()
+    // reads APP_VERSION and explicitly fetches that tag if it's missing.
+    // It's idempotent and cheap for non-RC releases (early-returns on hit).
+    await ensureCurrentVersionRegistered();
     return;
   }
 


### PR DESCRIPTION
## Summary

Fixes a silent failure where RC releases never land in the `agent_versions` table when the API runs with `BINARY_SOURCE=github` — meaning the heartbeat `upgradeTo` path can't direct agents to the RC build.

## The bug

`binarySync.ts:104-109` — in github mode, `syncBinaries()` called `syncFromGitHub()` (no args → fetches `/releases/latest`, which **excludes pre-releases**) and then early-returned, never reaching the `ensureCurrentVersionRegistered()` safety net at line 202. That safety net reads `APP_VERSION` and explicitly syncs that tag if it's not already in the table — which is exactly what the RC path needs.

## Real-world impact

Caught this deploying v0.62.25-rc.2. The API restarted with `APP_VERSION=0.62.25-rc.2`, the startup sync fetched 0.62.24 (the last stable) from `/releases/latest`, and rc.2 was never registered. Downstream, `routes/agents/heartbeat.ts:249` couldn't find an `is_latest=true` row for rc.2, so online release-build devices had no way to auto-upgrade. I had to SQL-insert the 8 rows by hand.

## Fix

Call `ensureCurrentVersionRegistered()` inside the github branch before the early return. The function is idempotent — for non-RC releases it checks `APP_VERSION` is already in `agent_versions` and early-returns, so overhead is one SELECT.

## Diff

6 lines added, 0 removed:

```ts
if (getBinarySource() === 'github') {
  console.log('[binarySync] BINARY_SOURCE=github, syncing from GitHub releases');
  await syncFromGitHub();
  // Safety net: syncFromGitHub() with no args hits /releases/latest which
  // EXCLUDES pre-releases, so RC deploys (APP_VERSION=x.y.z-rc.N) would
  // otherwise never land in agent_versions. ensureCurrentVersionRegistered()
  // reads APP_VERSION and explicitly fetches that tag if it's missing.
  // It's idempotent and cheap for non-RC releases (early-returns on hit).
  await ensureCurrentVersionRegistered();
  return;
}
```

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Deploy v0.62.25-rc.3 (or next RC) and verify `agent_versions` auto-populates without manual SQL

No existing `binarySync.test.ts` — skipped adding a new test file for this literal one-line logic move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)