### PR TITLE
fix(agent): exclude watchdog from sessionbroker keepalive

### DIFF
--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -186,6 +186,17 @@ var (
 	keepaliveTimeout      = 45 * time.Second
 )
 
+// roleSupportsKeepalive reports whether the broker should drive its generic
+// TypePing/TypePong keepalive on a session of the given helper role.
+//
+// Watchdog is excluded: its IPC client (internal/watchdog/ipcclient.go) only
+// handles TypeWatchdogPong and never replies to TypePing, so running keepalive
+// against it would evict every watchdog connection at keepaliveTimeout.
+// Watchdog has its own end-to-end liveness probe via WatchdogPing/Pong.
+func roleSupportsKeepalive(role string) bool {
+	return role != ipc.HelperRoleWatchdog
+}
+
 // Role-based scopes: SYSTEM helpers own desktop capture, user-token helpers own script execution.
 var (
 	systemHelperScopes   = []string{"notify", "tray", "clipboard", "desktop"}
@@ -1388,7 +1399,9 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 	// arriving. Without this, a wedged helper (e.g. a capture process killed
 	// mid-stream) can hold a slot forever because RecvLoop blocks on a read
 	// with no deadline. See issue #443.
-	go b.runKeepalive(session)
+	if roleSupportsKeepalive(helperRole) {
+		go b.runKeepalive(session)
+	}
 
 	// Start receive loop — blocks until disconnect
 	session.RecvLoop(b.dispatchHelperMessage)

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -197,6 +197,15 @@ func roleSupportsKeepalive(role string) bool {
 	return role != ipc.HelperRoleWatchdog
 }
 
+// maybeStartKeepalive starts the keepalive goroutine for the session if its
+// role supports it. Extracted from handleConnection so the gating is testable
+// without driving the full IPC handshake (which needs OS-specific peer creds).
+func (b *Broker) maybeStartKeepalive(session *Session, role string) {
+	if roleSupportsKeepalive(role) {
+		go b.runKeepalive(session)
+	}
+}
+
 // Role-based scopes: SYSTEM helpers own desktop capture, user-token helpers own script execution.
 var (
 	systemHelperScopes   = []string{"notify", "tray", "clipboard", "desktop"}
@@ -1398,10 +1407,9 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 	// Keepalive: send periodic pings and close the session if pongs stop
 	// arriving. Without this, a wedged helper (e.g. a capture process killed
 	// mid-stream) can hold a slot forever because RecvLoop blocks on a read
-	// with no deadline. See issue #443.
-	if roleSupportsKeepalive(helperRole) {
-		go b.runKeepalive(session)
-	}
+	// with no deadline. See issue #443. Watchdog is exempt — see
+	// roleSupportsKeepalive.
+	b.maybeStartKeepalive(session, helperRole)
 
 	// Start receive loop — blocks until disconnect
 	session.RecvLoop(b.dispatchHelperMessage)

--- a/agent/internal/sessionbroker/broker_leak_test.go
+++ b/agent/internal/sessionbroker/broker_leak_test.go
@@ -150,6 +150,28 @@ func TestKeepaliveKeepsHealthySessionAlive(t *testing.T) {
 	}
 }
 
+// roleSupportsKeepalive must keep watchdog connections out of the generic
+// keepalive path. Regression for the eviction loop introduced when PR #443
+// added unconditional runKeepalive: the watchdog IPC client only handles
+// TypeWatchdogPong and never replies to TypePing, so every watchdog
+// connection was being evicted at keepaliveTimeout and reconnecting forever.
+func TestRoleSupportsKeepalive_ExcludesWatchdog(t *testing.T) {
+	cases := []struct {
+		role string
+		want bool
+	}{
+		{ipc.HelperRoleSystem, true},
+		{ipc.HelperRoleUser, true},
+		{ipc.HelperRoleWatchdog, false},
+		{"", true}, // unknown roles default to system in handleConnection — keepalive applies
+	}
+	for _, c := range cases {
+		if got := roleSupportsKeepalive(c.role); got != c.want {
+			t.Errorf("roleSupportsKeepalive(%q) = %v, want %v", c.role, got, c.want)
+		}
+	}
+}
+
 // When the cap is hit, a new connection for the same identity must evict the
 // oldest-idle existing session rather than being rejected.
 func TestAdmitOrEvictEvictsIdleSession(t *testing.T) {

--- a/agent/internal/sessionbroker/broker_leak_test.go
+++ b/agent/internal/sessionbroker/broker_leak_test.go
@@ -172,6 +172,77 @@ func TestRoleSupportsKeepalive_ExcludesWatchdog(t *testing.T) {
 	}
 }
 
+// maybeStartKeepalive must NOT start the keepalive goroutine for a watchdog
+// session: a never-ponging watchdog session must remain alive past the
+// keepalive timeout. This is the integration-level guard against a future
+// refactor accidentally re-introducing the unconditional runKeepalive call
+// at the handleConnection site. See PR #443 / #462.
+func TestMaybeStartKeepalive_WatchdogSessionStaysAlive(t *testing.T) {
+	withKeepaliveTiming(t, 10*time.Millisecond, 25*time.Millisecond)
+
+	session, clientIPC := newPairedSession(t, "watchdog-1", "S-1-5-18")
+	defer clientIPC.Close()
+
+	// Force lastPongAt deep into the past so that IF runKeepalive ran, the
+	// very first tick would close the session. The test asserts the opposite.
+	session.lastPongAt.Store(time.Now().Add(-time.Hour).UnixNano())
+
+	b := &Broker{
+		sessions:     map[string]*Session{session.SessionID: session},
+		byIdentity:   map[string][]*Session{session.IdentityKey: {session}},
+		staleHelpers: make(map[string][]int),
+	}
+
+	b.maybeStartKeepalive(session, ipc.HelperRoleWatchdog)
+
+	// Wait well past 2× keepaliveTimeout to give any rogue keepalive goroutine
+	// multiple ticks to fire. Session must still be open.
+	time.Sleep(60 * time.Millisecond)
+
+	if session.IsClosed() {
+		t.Fatal("watchdog session was closed by keepalive — gating regressed")
+	}
+
+	_ = session.Close()
+}
+
+// Conversely, maybeStartKeepalive MUST start the keepalive goroutine for a
+// system-role session, so a stranded system helper is still reaped. Pairs
+// with the watchdog test above to lock in the gating direction.
+func TestMaybeStartKeepalive_SystemSessionIsReaped(t *testing.T) {
+	withKeepaliveTiming(t, 10*time.Millisecond, 20*time.Millisecond)
+
+	session, clientIPC := newPairedSession(t, "system-1", "S-1-5-18")
+	defer clientIPC.Close()
+
+	session.lastPongAt.Store(time.Now().Add(-time.Hour).UnixNano())
+
+	go func() {
+		for {
+			if _, err := clientIPC.Recv(); err != nil {
+				return
+			}
+		}
+	}()
+
+	b := &Broker{
+		sessions:     map[string]*Session{session.SessionID: session},
+		byIdentity:   map[string][]*Session{session.IdentityKey: {session}},
+		staleHelpers: make(map[string][]int),
+	}
+
+	b.maybeStartKeepalive(session, ipc.HelperRoleSystem)
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if session.IsClosed() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("system session was not closed by keepalive within deadline")
+}
+
 // When the cap is hit, a new connection for the same identity must evict the
 // oldest-idle existing session rather than being rejected.
 func TestAdmitOrEvictEvictsIdleSession(t *testing.T) {

--- a/apps/viewer/src/components/DesktopViewer.tsx
+++ b/apps/viewer/src/components/DesktopViewer.tsx
@@ -1170,7 +1170,24 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     e.preventDefault();
-    if (isModifierOnly(e.nativeEvent)) return;
+
+    // Modifier keys pressed alone: forward as key_down so Shift+Click,
+    // Ctrl+Click, etc. hold the modifier on the remote machine for
+    // multi-select. Skip the rest of the handler (no modifiers bundle,
+    // no paste shortcut — those are handled when a non-modifier follows).
+    if (isModifierOnly(e.nativeEvent)) {
+      let modKey = mapKey(e.nativeEvent);
+      if (!modKey) return;
+      if (remapCmdCtrl) {
+        if (modKey === 'ctrl') modKey = 'meta';
+        else if (modKey === 'meta') modKey = 'ctrl';
+      }
+      if (e.repeat) return;
+      if (pressedKeysRef.current.has(modKey)) return;
+      pressedKeysRef.current.add(modKey);
+      sendInputFn({ type: 'key_down', key: modKey });
+      return;
+    }
 
     // Ctrl+Shift+V / Cmd+Shift+V → paste as keystrokes
     const ne = e.nativeEvent;
@@ -1244,15 +1261,21 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
 
   const handleKeyUp = useCallback((e: React.KeyboardEvent) => {
     e.preventDefault();
-    if (isModifierOnly(e.nativeEvent)) return;
 
-    const key = mapKey(e.nativeEvent);
+    let key = mapKey(e.nativeEvent);
     if (!key) return;
+
+    // Apply the same ctrl↔meta remap used on key_down so the agent sees
+    // the matching release for the key that was pressed.
+    if (isModifierOnly(e.nativeEvent) && remapCmdCtrl) {
+      if (key === 'ctrl') key = 'meta';
+      else if (key === 'meta') key = 'ctrl';
+    }
 
     if (!pressedKeysRef.current.has(key)) return;
     pressedKeysRef.current.delete(key);
     sendInputFn({ type: 'key_up', key });
-  }, [sendInputFn]);
+  }, [sendInputFn, remapCmdCtrl]);
 
   // ── Toolbar: config changes ────────────────────────────────────────
 

--- a/apps/viewer/src/lib/keymap.ts
+++ b/apps/viewer/src/lib/keymap.ts
@@ -45,6 +45,13 @@ const codeToKey: Record<string, string> = {
   // Other
   PrintScreen: 'printscreen', ScrollLock: 'scrolllock',
   Pause: 'pause', NumLock: 'numlock', CapsLock: 'capslock',
+
+  // Modifiers — forwarded as standalone key_down/key_up so Shift+Click,
+  // Ctrl+Click, etc. work for multi-select on the remote machine.
+  ShiftLeft: 'shift', ShiftRight: 'shift',
+  ControlLeft: 'ctrl', ControlRight: 'ctrl',
+  AltLeft: 'alt', AltRight: 'alt',
+  MetaLeft: 'meta', MetaRight: 'meta',
 };
 
 /**

--- a/docs/superpowers/plans/2026-04-16-cli-install-watchdog-bootstrap.md
+++ b/docs/superpowers/plans/2026-04-16-cli-install-watchdog-bootstrap.md
@@ -1,0 +1,970 @@
+# CLI Install: Watchdog Bootstrap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `breeze-agent service install` automatically install the watchdog service on all three platforms so that CLI-installed devices reach the same end state as MSI/PKG-installed devices.
+
+**Architecture:** Add a shared `watchdog_bootstrap.go` file in `agent/cmd/breeze-agent` that locates the watchdog binary (sibling first, GitHub download fallback) and then execs the watchdog's own `service install` subcommand — which already contains the correct SCM/systemd/launchd registration logic. Each platform-specific `service_cmd_*.go` calls the bootstrap after its own successful install, with a `--no-watchdog` opt-out flag. Failures are non-fatal.
+
+**Tech Stack:** Go (stdlib `net/http`, `os/exec`), cobra CLI flags.
+
+**Spec:** `docs/superpowers/specs/2026-04-16-cli-install-watchdog-bootstrap-design.md`
+
+---
+
+## File Structure
+
+- **Create:** `agent/cmd/breeze-agent/watchdog_bootstrap.go` — platform-independent bootstrap function (`bootstrapWatchdog`) and helpers (`locateSiblingWatchdog`, `downloadWatchdog`, `watchdogDownloadURL`, `watchdogBinaryName`).
+- **Create:** `agent/cmd/breeze-agent/watchdog_bootstrap_test.go` — unit tests for URL construction, sibling lookup, download success/failure, dev-version skip.
+- **Modify:** `agent/cmd/breeze-agent/service_cmd_windows.go` — add `--no-watchdog` flag; call `bootstrapWatchdog` after `CreateService` succeeds.
+- **Modify:** `agent/cmd/breeze-agent/service_cmd_linux.go` — same.
+- **Modify:** `agent/cmd/breeze-agent/service_cmd_darwin.go` — same.
+- **Modify:** `apps/docs/src/content/docs/agents/installation.mdx` — add troubleshooting note about `--no-watchdog` and re-run-to-repair semantics.
+
+---
+
+### Task 1: Create the bootstrap skeleton (types, URL helper, binary name helper)
+
+**Files:**
+- Create: `agent/cmd/breeze-agent/watchdog_bootstrap.go`
+- Create: `agent/cmd/breeze-agent/watchdog_bootstrap_test.go`
+
+- [ ] **Step 1: Write the failing tests for `watchdogBinaryName` and `watchdogDownloadURL`**
+
+Create `agent/cmd/breeze-agent/watchdog_bootstrap_test.go`:
+
+```go
+package main
+
+import "testing"
+
+func TestWatchdogBinaryName(t *testing.T) {
+	tests := []struct {
+		goos string
+		want string
+	}{
+		{"windows", "breeze-watchdog.exe"},
+		{"linux", "breeze-watchdog"},
+		{"darwin", "breeze-watchdog"},
+	}
+	for _, tc := range tests {
+		got := watchdogBinaryName(tc.goos)
+		if got != tc.want {
+			t.Errorf("watchdogBinaryName(%q) = %q, want %q", tc.goos, got, tc.want)
+		}
+	}
+}
+
+func TestWatchdogDownloadURL(t *testing.T) {
+	tests := []struct {
+		version, goos, goarch, want string
+	}{
+		{
+			"0.62.24", "windows", "amd64",
+			"https://github.com/LanternOps/breeze/releases/download/v0.62.24/breeze-watchdog-windows-amd64.exe",
+		},
+		{
+			"0.62.24", "linux", "arm64",
+			"https://github.com/LanternOps/breeze/releases/download/v0.62.24/breeze-watchdog-linux-arm64",
+		},
+		{
+			"0.62.24", "darwin", "amd64",
+			"https://github.com/LanternOps/breeze/releases/download/v0.62.24/breeze-watchdog-darwin-amd64",
+		},
+	}
+	for _, tc := range tests {
+		got := watchdogDownloadURL(tc.version, tc.goos, tc.goarch)
+		if got != tc.want {
+			t.Errorf("watchdogDownloadURL(%q,%q,%q) = %q, want %q",
+				tc.version, tc.goos, tc.goarch, got, tc.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+cd agent && go test ./cmd/breeze-agent/ -run 'TestWatchdogBinaryName|TestWatchdogDownloadURL' -v
+```
+Expected: FAIL with "undefined: watchdogBinaryName" / "undefined: watchdogDownloadURL".
+
+- [ ] **Step 3: Create `watchdog_bootstrap.go` with URL + name helpers**
+
+Create `agent/cmd/breeze-agent/watchdog_bootstrap.go`:
+
+```go
+package main
+
+import "fmt"
+
+// NOTE: Keep this URL base in sync with agent/internal/updater/pkg_darwin.go.
+// Both point at the same GitHub releases. If one ever moves to an env var,
+// migrate both call sites together.
+const watchdogReleasesBase = "https://github.com/LanternOps/breeze/releases/download"
+
+// watchdogBinaryName returns the filename for the watchdog binary on the given GOOS.
+func watchdogBinaryName(goos string) string {
+	if goos == "windows" {
+		return "breeze-watchdog.exe"
+	}
+	return "breeze-watchdog"
+}
+
+// watchdogDownloadURL returns the GitHub release download URL for the watchdog
+// binary matching the given agent version / OS / arch.
+func watchdogDownloadURL(version, goos, goarch string) string {
+	ext := ""
+	if goos == "windows" {
+		ext = ".exe"
+	}
+	return fmt.Sprintf("%s/v%s/breeze-watchdog-%s-%s%s",
+		watchdogReleasesBase, version, goos, goarch, ext)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+cd agent && go test ./cmd/breeze-agent/ -run 'TestWatchdogBinaryName|TestWatchdogDownloadURL' -v
+```
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/cmd/breeze-agent/watchdog_bootstrap.go agent/cmd/breeze-agent/watchdog_bootstrap_test.go
+git commit -m "feat(agent): add watchdog binary name + download URL helpers"
+```
+
+---
+
+### Task 2: Sibling-binary lookup
+
+**Files:**
+- Modify: `agent/cmd/breeze-agent/watchdog_bootstrap.go`
+- Modify: `agent/cmd/breeze-agent/watchdog_bootstrap_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `agent/cmd/breeze-agent/watchdog_bootstrap_test.go`:
+
+```go
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestLocateSiblingWatchdog_Found(t *testing.T) {
+	dir := t.TempDir()
+	agentPath := filepath.Join(dir, "breeze-agent")
+	if runtime.GOOS == "windows" {
+		agentPath += ".exe"
+	}
+	if err := os.WriteFile(agentPath, []byte("fake agent"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	siblingPath := filepath.Join(dir, watchdogBinaryName(runtime.GOOS))
+	if err := os.WriteFile(siblingPath, []byte("fake watchdog"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := locateSiblingWatchdog(agentPath)
+	if !ok {
+		t.Fatalf("locateSiblingWatchdog returned ok=false, want true")
+	}
+	if got != siblingPath {
+		t.Errorf("locateSiblingWatchdog = %q, want %q", got, siblingPath)
+	}
+}
+
+func TestLocateSiblingWatchdog_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	agentPath := filepath.Join(dir, "breeze-agent")
+	if err := os.WriteFile(agentPath, []byte("fake agent"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, ok := locateSiblingWatchdog(agentPath)
+	if ok {
+		t.Errorf("locateSiblingWatchdog returned ok=true, want false")
+	}
+}
+```
+
+Note: the existing `import "testing"` at top of file should be merged — replace the single-line import with the multi-import block above.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+cd agent && go test ./cmd/breeze-agent/ -run 'TestLocateSiblingWatchdog' -v
+```
+Expected: FAIL with "undefined: locateSiblingWatchdog".
+
+- [ ] **Step 3: Implement `locateSiblingWatchdog`**
+
+Append to `agent/cmd/breeze-agent/watchdog_bootstrap.go`:
+
+```go
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// locateSiblingWatchdog checks for the watchdog binary in the same directory
+// as the agent binary. Returns (path, true) if found.
+func locateSiblingWatchdog(agentPath string) (string, bool) {
+	candidate := filepath.Join(filepath.Dir(agentPath), watchdogBinaryName(runtime.GOOS))
+	info, err := os.Stat(candidate)
+	if err != nil || info.IsDir() {
+		return "", false
+	}
+	return candidate, true
+}
+```
+
+Replace the top-of-file `import "fmt"` with the merged block:
+
+```go
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+cd agent && go test ./cmd/breeze-agent/ -run 'TestLocateSiblingWatchdog' -v
+```
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/cmd/breeze-agent/watchdog_bootstrap.go agent/cmd/breeze-agent/watchdog_bootstrap_test.go
+git commit -m "feat(agent): add sibling-binary lookup for watchdog bootstrap"
+```
+
+---
+
+### Task 3: Download helper
+
+**Files:**
+- Modify: `agent/cmd/breeze-agent/watchdog_bootstrap.go`
+- Modify: `agent/cmd/breeze-agent/watchdog_bootstrap_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `agent/cmd/breeze-agent/watchdog_bootstrap_test.go`:
+
+```go
+import (
+	"net/http"
+	"net/http/httptest"
+)
+
+func TestDownloadWatchdog_Success(t *testing.T) {
+	// Serve a fake binary > 1MB so the sanity check passes.
+	body := make([]byte, 2*1024*1024)
+	for i := range body {
+		body[i] = byte(i % 256)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	destDir := t.TempDir()
+	destPath := filepath.Join(destDir, "breeze-watchdog")
+
+	if err := downloadWatchdog(srv.URL, destPath); err != nil {
+		t.Fatalf("downloadWatchdog: %v", err)
+	}
+
+	got, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if len(got) != len(body) {
+		t.Errorf("downloaded size = %d, want %d", len(got), len(body))
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(destPath)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if info.Mode().Perm()&0100 == 0 {
+			t.Errorf("downloaded file is not executable: mode=%v", info.Mode())
+		}
+	}
+}
+
+func TestDownloadWatchdog_404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	destPath := filepath.Join(t.TempDir(), "breeze-watchdog")
+	err := downloadWatchdog(srv.URL, destPath)
+	if err == nil {
+		t.Fatalf("downloadWatchdog: expected error on 404, got nil")
+	}
+	if _, statErr := os.Stat(destPath); statErr == nil {
+		t.Errorf("downloadWatchdog: dest file should not exist after failure")
+	}
+}
+
+func TestDownloadWatchdog_TooSmall(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not a real binary"))
+	}))
+	defer srv.Close()
+
+	destPath := filepath.Join(t.TempDir(), "breeze-watchdog")
+	err := downloadWatchdog(srv.URL, destPath)
+	if err == nil {
+		t.Fatalf("downloadWatchdog: expected error on too-small body, got nil")
+	}
+	if _, statErr := os.Stat(destPath); statErr == nil {
+		t.Errorf("downloadWatchdog: dest file should not exist after failure")
+	}
+}
+```
+
+Merge the new imports (`net/http`, `net/http/httptest`) into the top-of-file import block.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+cd agent && go test ./cmd/breeze-agent/ -run 'TestDownloadWatchdog' -v
+```
+Expected: FAIL with "undefined: downloadWatchdog".
+
+- [ ] **Step 3: Implement `downloadWatchdog`**
+
+Append to `agent/cmd/breeze-agent/watchdog_bootstrap.go`:
+
+```go
+import (
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	watchdogMinSize       = 1 * 1024 * 1024 // 1 MB sanity check (real binary is several MB)
+	watchdogDownloadTimeo = 60 * time.Second
+)
+
+// downloadWatchdog fetches the watchdog binary from url and writes it to destPath.
+// The file is streamed to a sibling temp file and atomically renamed on success,
+// so a partial download never leaves a broken binary behind. On unix the file is
+// marked executable (0755).
+func downloadWatchdog(url, destPath string) error {
+	client := &http.Client{Timeout: watchdogDownloadTimeo}
+	resp, err := client.Get(url)
+	if err != nil {
+		return fmt.Errorf("http get %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("http get %s: status %d", url, resp.StatusCode)
+	}
+
+	tmpPath := destPath + ".download"
+	tmp, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", tmpPath, err)
+	}
+	n, copyErr := io.Copy(tmp, resp.Body)
+	closeErr := tmp.Close()
+	if copyErr != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("download body: %w", copyErr)
+	}
+	if closeErr != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close %s: %w", tmpPath, closeErr)
+	}
+	if n < watchdogMinSize {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("downloaded body too small (%d bytes); URL likely returned an error page", n)
+	}
+
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename %s -> %s: %w", tmpPath, destPath, err)
+	}
+	return nil
+}
+```
+
+Merge the new imports (`io`, `net/http`, `time`) into the top-of-file import block so the file's single import block contains: `fmt, io, net/http, os, path/filepath, runtime, time`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+cd agent && go test ./cmd/breeze-agent/ -run 'TestDownloadWatchdog' -v
+```
+Expected: PASS (all three tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/cmd/breeze-agent/watchdog_bootstrap.go agent/cmd/breeze-agent/watchdog_bootstrap_test.go
+git commit -m "feat(agent): add watchdog download helper with atomic write + size sanity"
+```
+
+---
+
+### Task 4: `bootstrapWatchdog` orchestrator
+
+**Files:**
+- Modify: `agent/cmd/breeze-agent/watchdog_bootstrap.go`
+- Modify: `agent/cmd/breeze-agent/watchdog_bootstrap_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `agent/cmd/breeze-agent/watchdog_bootstrap_test.go`:
+
+```go
+func TestBootstrapWatchdog_SiblingFound_RunsInstall(t *testing.T) {
+	dir := t.TempDir()
+	agentPath := filepath.Join(dir, "breeze-agent")
+	if err := os.WriteFile(agentPath, []byte("fake"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Put a sibling watchdog script that records it was invoked.
+	siblingPath := filepath.Join(dir, watchdogBinaryName(runtime.GOOS))
+	marker := filepath.Join(dir, "invoked")
+	var script string
+	if runtime.GOOS == "windows" {
+		script = "@echo off\r\necho invoked > \"" + marker + "\"\r\n"
+		siblingPath = filepath.Join(dir, "breeze-watchdog.exe")
+		// On Windows we can't easily exec a .bat as .exe; skip this test there.
+		t.Skip("skipping exec-sibling test on Windows (need real .exe)")
+	} else {
+		script = "#!/bin/sh\necho invoked > \"" + marker + "\"\n"
+	}
+	if err := os.WriteFile(siblingPath, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := bootstrapOptions{
+		agentPath: agentPath,
+		version:   "0.62.24",
+		goos:      runtime.GOOS,
+		goarch:    runtime.GOARCH,
+		// nil httpBase → real URL, but we won't hit it because sibling is found.
+	}
+	if err := bootstrapWatchdog(opts); err != nil {
+		t.Fatalf("bootstrapWatchdog: %v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Errorf("expected sibling watchdog to be invoked (marker %q not found): %v", marker, err)
+	}
+}
+
+func TestBootstrapWatchdog_DevVersionSkipsDownload(t *testing.T) {
+	dir := t.TempDir()
+	agentPath := filepath.Join(dir, "breeze-agent")
+	if err := os.WriteFile(agentPath, []byte("fake"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := bootstrapOptions{
+		agentPath: agentPath,
+		version:   "dev",
+		goos:      runtime.GOOS,
+		goarch:    runtime.GOARCH,
+	}
+	err := bootstrapWatchdog(opts)
+	if err == nil {
+		t.Fatalf("bootstrapWatchdog: expected error for dev version, got nil")
+	}
+}
+
+func TestBootstrapWatchdog_DownloadFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	agentPath := filepath.Join(dir, "breeze-agent")
+	if err := os.WriteFile(agentPath, []byte("fake"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := bootstrapOptions{
+		agentPath:   agentPath,
+		version:     "0.62.24",
+		goos:        runtime.GOOS,
+		goarch:      runtime.GOARCH,
+		urlOverride: srv.URL, // force fallback to fail
+	}
+	err := bootstrapWatchdog(opts)
+	if err == nil {
+		t.Fatalf("bootstrapWatchdog: expected error on download 404, got nil")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+cd agent && go test ./cmd/breeze-agent/ -run 'TestBootstrapWatchdog' -v
+```
+Expected: FAIL with "undefined: bootstrapWatchdog" / "undefined: bootstrapOptions".
+
+- [ ] **Step 3: Implement `bootstrapOptions` + `bootstrapWatchdog`**
+
+Append to `agent/cmd/breeze-agent/watchdog_bootstrap.go`:
+
+```go
+import "os/exec"
+
+// bootstrapOptions is the inputs for bootstrapWatchdog. Kept as a struct so the
+// callers on each OS stay short and the test helpers don't need long arg lists.
+type bootstrapOptions struct {
+	agentPath string // absolute path to the currently running agent binary
+	version   string // agent version (main.version), e.g. "0.62.24" or "dev"
+	goos      string // runtime.GOOS
+	goarch    string // runtime.GOARCH
+
+	// urlOverride, if non-empty, replaces the full download URL. Test-only.
+	urlOverride string
+}
+
+// bootstrapWatchdog resolves a watchdog binary (sibling first, GitHub download
+// fallback) and then invokes `<watchdog> service install` to register it as a
+// system service. All errors are returned — callers are expected to downgrade
+// them to warnings so that a watchdog problem never aborts the agent install.
+func bootstrapWatchdog(opts bootstrapOptions) error {
+	watchdogPath, ok := locateSiblingWatchdog(opts.agentPath)
+	if !ok {
+		if opts.version == "" || opts.version == "dev" || strings.HasPrefix(opts.version, "dev-") {
+			return fmt.Errorf("no sibling watchdog found and agent is a dev build (version=%q); run `breeze-watchdog service install` manually", opts.version)
+		}
+		url := opts.urlOverride
+		if url == "" {
+			url = watchdogDownloadURL(opts.version, opts.goos, opts.goarch)
+		}
+		watchdogPath = filepath.Join(filepath.Dir(opts.agentPath), watchdogBinaryName(opts.goos))
+		fmt.Fprintf(os.Stderr, "Downloading watchdog from %s ...\n", url)
+		if err := downloadWatchdog(url, watchdogPath); err != nil {
+			return fmt.Errorf("download watchdog: %w", err)
+		}
+	}
+
+	cmd := exec.Command(watchdogPath, "service", "install")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("run %s service install: %w", watchdogPath, err)
+	}
+	return nil
+}
+```
+
+Add `os/exec` and `strings` to the merged import block.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+cd agent && go test ./cmd/breeze-agent/ -v
+```
+Expected: all bootstrap tests PASS. On macOS/Linux the sibling-exec test runs; on Windows it is skipped.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/cmd/breeze-agent/watchdog_bootstrap.go agent/cmd/breeze-agent/watchdog_bootstrap_test.go
+git commit -m "feat(agent): add bootstrapWatchdog orchestrator (sibling → download → service install)"
+```
+
+---
+
+### Task 5: Wire into Windows `service install`
+
+**Files:**
+- Modify: `agent/cmd/breeze-agent/service_cmd_windows.go`
+
+- [ ] **Step 1: Add `--no-watchdog` flag and the bootstrap call**
+
+In `agent/cmd/breeze-agent/service_cmd_windows.go`, make these three edits:
+
+(a) After the `init()` function (around line 31), add a package-level flag variable and register it:
+
+Replace:
+```go
+func init() {
+	rootCmd.AddCommand(serviceCmd)
+	serviceCmd.AddCommand(serviceInstallCmd)
+	serviceCmd.AddCommand(serviceUninstallCmd)
+	serviceCmd.AddCommand(serviceStartCmd)
+	serviceCmd.AddCommand(serviceStopCmd)
+}
+```
+
+With:
+```go
+var noWatchdog bool
+
+func init() {
+	rootCmd.AddCommand(serviceCmd)
+	serviceCmd.AddCommand(serviceInstallCmd)
+	serviceCmd.AddCommand(serviceUninstallCmd)
+	serviceCmd.AddCommand(serviceStartCmd)
+	serviceCmd.AddCommand(serviceStopCmd)
+	serviceInstallCmd.Flags().BoolVar(&noWatchdog, "no-watchdog", false, "Skip automatic watchdog installation")
+}
+```
+
+(b) Add `runtime` to the imports block at the top of the file.
+
+(c) Replace the final lines of `serviceInstallCmd` (the `fmt.Printf("Service %q installed successfully.\n", ...)` and the `return nil`) with:
+
+```go
+		fmt.Printf("Service %q installed successfully.\n", windowsServiceName)
+
+		if !noWatchdog {
+			err := bootstrapWatchdog(bootstrapOptions{
+				agentPath: exePath,
+				version:   version,
+				goos:      runtime.GOOS,
+				goarch:    runtime.GOARCH,
+			})
+			if err != nil {
+				fmt.Fprintf(os.Stderr,
+					"Warning: watchdog bootstrap failed: %v\n"+
+						"The agent service is installed. To install the watchdog manually, run:\n"+
+						"    breeze-watchdog.exe service install\n", err)
+			}
+		}
+
+		return nil
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run:
+```bash
+cd agent && GOOS=windows GOARCH=amd64 go build ./cmd/breeze-agent
+```
+Expected: build succeeds, no output.
+
+- [ ] **Step 3: Verify existing tests still pass**
+
+Run:
+```bash
+cd agent && GOOS=windows GOARCH=amd64 go vet ./cmd/breeze-agent
+cd agent && go test ./cmd/breeze-agent/ -v
+```
+Expected: vet clean, all tests still PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add agent/cmd/breeze-agent/service_cmd_windows.go
+git commit -m "feat(agent): windows service install bootstraps watchdog by default"
+```
+
+---
+
+### Task 6: Wire into Linux `service install`
+
+**Files:**
+- Modify: `agent/cmd/breeze-agent/service_cmd_linux.go`
+
+- [ ] **Step 1: Add `--no-watchdog` flag and the bootstrap call**
+
+(a) Find the existing `var withUserHelper bool` declaration and the `init()` function. Add the new flag alongside:
+
+Replace the existing flag registration in `init()`:
+```go
+	serviceInstallCmd.Flags().BoolVar(&withUserHelper, "with-user-helper", false, "Also install the per-user desktop helper systemd unit")
+```
+
+With:
+```go
+	serviceInstallCmd.Flags().BoolVar(&withUserHelper, "with-user-helper", false, "Also install the per-user desktop helper systemd unit")
+	serviceInstallCmd.Flags().BoolVar(&noWatchdog, "no-watchdog", false, "Skip automatic watchdog installation")
+```
+
+Add a package-level declaration near `withUserHelper`:
+```go
+var noWatchdog bool
+```
+
+(b) Add `runtime` to the imports block.
+
+(c) Insert the bootstrap call immediately before the final `return nil` of `serviceInstallCmd.RunE`, after all the "Next steps" messaging. The final block should read:
+
+```go
+		// ... existing next-steps fmt.Println calls end here ...
+
+		if !noWatchdog {
+			err := bootstrapWatchdog(bootstrapOptions{
+				agentPath: linuxBinaryPath, // the freshly-copied /usr/local/bin/breeze-agent
+				version:   version,
+				goos:      runtime.GOOS,
+				goarch:    runtime.GOARCH,
+			})
+			if err != nil {
+				fmt.Fprintf(os.Stderr,
+					"Warning: watchdog bootstrap failed: %v\n"+
+						"The agent service is installed. To install the watchdog manually, run:\n"+
+						"    sudo breeze-watchdog service install\n", err)
+			}
+		}
+
+		return nil
+```
+
+Note: pass `linuxBinaryPath` (the installed location) rather than the `exePath` used during the copy — the agent has just been copied there, so the sibling-lookup test will check `/usr/local/bin/breeze-watchdog`, which is the watchdog's canonical install location.
+
+- [ ] **Step 2: Verify it compiles**
+
+Run:
+```bash
+cd agent && GOOS=linux GOARCH=amd64 go build ./cmd/breeze-agent
+```
+Expected: build succeeds.
+
+- [ ] **Step 3: Verify vet + tests**
+
+Run:
+```bash
+cd agent && GOOS=linux GOARCH=amd64 go vet ./cmd/breeze-agent
+cd agent && go test ./cmd/breeze-agent/ -v
+```
+Expected: vet clean, all tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add agent/cmd/breeze-agent/service_cmd_linux.go
+git commit -m "feat(agent): linux service install bootstraps watchdog by default"
+```
+
+---
+
+### Task 7: Wire into macOS `service install`
+
+**Files:**
+- Modify: `agent/cmd/breeze-agent/service_cmd_darwin.go`
+
+- [ ] **Step 1: Add `--no-watchdog` flag and the bootstrap call**
+
+(a) Locate the existing `var withUserHelper bool` and `init()`. Add the new flag the same way as Linux:
+
+```go
+var noWatchdog bool
+```
+
+In `init()`:
+```go
+	serviceInstallCmd.Flags().BoolVar(&withUserHelper, "with-user-helper", false, "Also install the per-user desktop helper LaunchAgent")
+	serviceInstallCmd.Flags().BoolVar(&noWatchdog, "no-watchdog", false, "Skip automatic watchdog installation")
+```
+
+(b) Add `runtime` to the imports.
+
+(c) Before the final `return nil` of `serviceInstallCmd.RunE`, append:
+
+```go
+		if !noWatchdog {
+			err := bootstrapWatchdog(bootstrapOptions{
+				agentPath: darwinBinaryPath,
+				version:   version,
+				goos:      runtime.GOOS,
+				goarch:    runtime.GOARCH,
+			})
+			if err != nil {
+				fmt.Fprintf(os.Stderr,
+					"Warning: watchdog bootstrap failed: %v\n"+
+						"The agent service is installed. To install the watchdog manually, run:\n"+
+						"    sudo breeze-watchdog service install\n", err)
+			}
+		}
+
+		return nil
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run:
+```bash
+cd agent && GOOS=darwin GOARCH=arm64 go build ./cmd/breeze-agent
+cd agent && GOOS=darwin GOARCH=amd64 go build ./cmd/breeze-agent
+```
+Expected: both builds succeed.
+
+- [ ] **Step 3: Verify vet + tests**
+
+Run:
+```bash
+cd agent && GOOS=darwin GOARCH=arm64 go vet ./cmd/breeze-agent
+cd agent && go test ./cmd/breeze-agent/ -v
+```
+Expected: vet clean, all tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add agent/cmd/breeze-agent/service_cmd_darwin.go
+git commit -m "feat(agent): darwin service install bootstraps watchdog by default"
+```
+
+---
+
+### Task 8: Update docs
+
+**Files:**
+- Modify: `apps/docs/src/content/docs/agents/installation.mdx`
+
+- [ ] **Step 1: Update the "What Gets Installed" section**
+
+In `apps/docs/src/content/docs/agents/installation.mdx`, the existing paragraph after the component table (around line 114) is:
+
+```
+The watchdog runs alongside the agent as a separate process. You do not need to configure it -- it starts automatically with the agent service. See the [Watchdog documentation](/features/watchdog) for details.
+```
+
+Replace the paragraph with:
+
+```
+The watchdog runs alongside the agent as a separate process. You do not need to configure it -- it starts automatically with the agent service. See the [Watchdog documentation](/features/watchdog) for details.
+
+When running `breeze-agent service install` manually, the agent fetches the matching-version watchdog binary from GitHub releases if one is not already present next to the agent executable. If you need to skip this (for example on an air-gapped host), pass `--no-watchdog`:
+
+<Tabs>
+  <TabItem label="Linux / macOS">
+    ```bash
+    sudo ./breeze-agent service install --no-watchdog
+    ```
+  </TabItem>
+  <TabItem label="Windows">
+    ```powershell
+    .\breeze-agent.exe service install --no-watchdog
+    ```
+  </TabItem>
+</Tabs>
+
+If a previously agent-only install needs the watchdog added, simply re-run `breeze-agent service install` (without `--no-watchdog`). The agent service is unaffected; only the watchdog is added.
+```
+
+- [ ] **Step 2: Verify the docs site builds**
+
+Run:
+```bash
+pnpm --filter @breeze/docs build
+```
+Expected: build completes without errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/docs/src/content/docs/agents/installation.mdx
+git commit -m "docs: document watchdog bootstrap in breeze-agent service install"
+```
+
+---
+
+### Task 9: Manual smoke verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Cross-compile binaries for all three platforms**
+
+Run:
+```bash
+cd agent && make build-all-agent build-all && ls bin/breeze-agent-* bin/breeze-watchdog-*
+```
+Expected: agent + watchdog binaries for linux/darwin/windows × amd64/arm64 exist.
+
+- [ ] **Step 2: Linux smoke (container)**
+
+On a Linux VM or container with systemd:
+```bash
+# Copy binary
+scp agent/bin/breeze-agent-linux-amd64 root@<host>:/tmp/breeze-agent
+ssh root@<host> '
+  chmod +x /tmp/breeze-agent &&
+  /tmp/breeze-agent service install &&
+  systemctl status breeze-agent breeze-watchdog
+'
+```
+Expected: both units are `active (running)`. If the bootstrap had to download, you will see the download URL echoed.
+
+- [ ] **Step 3: Windows smoke**
+
+On the Windows test VM (Tailscale `100.101.150.55`):
+```bash
+scp agent/bin/breeze-agent-windows-amd64.exe administrator@100.101.150.55:breeze-agent.exe
+ssh administrator@100.101.150.55
+# Then in Powershell:
+.\breeze-agent.exe service install
+sc query BreezeAgent
+sc query BreezeWatchdog
+```
+Expected: both `STATE : 4 RUNNING`.
+
+- [ ] **Step 4: Re-run repair smoke (any platform)**
+
+On a machine with agent installed but watchdog uninstalled:
+- Linux: `sudo systemctl stop breeze-watchdog; sudo breeze-watchdog service uninstall`
+- Windows: `.\breeze-watchdog.exe service uninstall`
+
+Then re-run:
+- Linux: `sudo breeze-agent service install`
+- Windows: `.\breeze-agent.exe service install`
+
+Expected: agent-install reports "already installed" (or behaves idempotently), and watchdog is registered fresh.
+
+- [ ] **Step 5: Air-gap smoke with `--no-watchdog`**
+
+On any platform, remove the sibling watchdog file (if any) and run with `--no-watchdog`. Watch for the absence of any download attempt (no HTTP call, no "Downloading watchdog from ..." line).
+
+Expected: agent-install succeeds, no watchdog service registered.
+
+- [ ] **Step 6: Record results in the PR description**
+
+When opening the PR for this work, include a checklist of which smoke scenarios passed and any issues observed.
+
+---
+
+## Spec coverage checklist
+
+| Spec requirement | Task |
+|---|---|
+| Sibling-binary lookup first | Task 2 + 4 |
+| GitHub-release download fallback | Task 3 + 4 |
+| URL pattern matches `pkg_darwin.go` | Task 1 (with in-code comment) |
+| Version from agent `main.version` | Tasks 5-7 (pass `version` into `bootstrapOptions`) |
+| Dev version skip | Task 4 (test + impl) |
+| Non-fatal failure, actionable warning | Tasks 5-7 |
+| `--no-watchdog` flag | Tasks 5-7 |
+| Re-run repair semantics | Task 8 (docs) + Task 9 Step 4 (manual) |
+| Docs update | Task 8 |
+| Unit tests (URL, sibling, download, dev skip, download failure) | Tasks 1-4 |
+| Windows + Linux + macOS smoke | Task 9 |

--- a/docs/superpowers/specs/2026-04-16-cli-install-watchdog-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-04-16-cli-install-watchdog-bootstrap-design.md
@@ -1,0 +1,111 @@
+# CLI install: auto-bootstrap the watchdog
+
+**Issue:** [#407](https://github.com/lanternops/breeze/issues/407) — command-line install method does not install the watchdog service.
+
+## Problem
+
+Today, installation paths diverge:
+
+| Path | Installs agent | Installs watchdog |
+|---|---|---|
+| Windows MSI | ✅ | ✅ (WiX `ServiceInstall`) |
+| macOS PKG | ✅ | ✅ (postinstall loads `com.breeze.watchdog.plist`) |
+| `breeze-agent service install` (CLI) | ✅ | ❌ |
+
+The one-liner install commands shown in the Breeze dashboard (`AddDeviceModal.tsx`, `EnrollDeviceStep.tsx`) and in the docs (`apps/docs/src/content/docs/agents/installation.mdx`) use the CLI path on Windows and Linux. The docs at `installation.mdx:107-114` already claim manual install includes the watchdog — that claim is currently false.
+
+CLI-installed devices therefore lack agent self-recovery (watchdog restarts the agent on crash / hang and drives watchdog-mediated upgrades). This is a reliability regression vs. MSI/PKG-installed devices.
+
+## Goal
+
+Make `breeze-agent service install` install the watchdog service as a side-effect, so that every install path produces the same end state (agent + watchdog, both running, both set to auto-start).
+
+## Non-goals
+
+- Embedding the watchdog binary inside the agent binary (doubles binary size, complicates upgrades).
+- Changing how the MSI or PKG install the watchdog — those already work.
+- Replacing the existing `breeze-watchdog service install` command — it remains the source of truth for service registration. The agent just calls it.
+- Adding a new env var for the download base URL. We match the existing hardcoded pattern (`agent/internal/updater/pkg_darwin.go`); if that ever becomes configurable, both call sites migrate together.
+
+## Design
+
+### `breeze-agent service install` flow
+
+After the existing agent service registration succeeds, run a best-effort watchdog bootstrap step:
+
+1. **Locate watchdog binary.**
+   - **Sibling lookup first.** Check for `breeze-watchdog[.exe]` in the directory containing the current agent executable (`os.Executable()` → `filepath.Dir`). If it exists and is executable, use that path. This covers MSI/PKG contexts, `make install` contexts, and any user who downloaded both binaries manually.
+   - **Download fallback.** Otherwise, download the matching-version watchdog binary from GitHub releases to the same directory as the agent executable. URL pattern (matches `pkg_darwin.go`):
+     ```
+     https://github.com/LanternOps/breeze/releases/download/v<version>/breeze-watchdog-<goos>-<goarch>[.exe]
+     ```
+     `<version>` is the agent's compiled-in `main.version`. If `main.version` is empty or `"dev"`, skip the download (dev builds don't have a matching release) and warn.
+   - On Unix, `chmod 0755` the downloaded file.
+
+2. **Exec the watchdog's own installer.** Run `<watchdog-path> service install` as a child process, inheriting stdout/stderr. All SCM / systemd / launchd logic already lives in `agent/cmd/breeze-watchdog/service_cmd_{windows,linux,darwin}.go` — we don't duplicate it.
+
+3. **Failure is non-fatal.** If any of the above fails (network error, 404, exec failure, watchdog install returned non-zero), log a clear warning to stderr explaining what failed and how to retry manually (`breeze-watchdog service install`). The agent install command itself still exits 0.
+
+4. **Opt-out flag.** Add `--no-watchdog` on `breeze-agent service install` to skip steps 1-3 entirely. For air-gapped / explicit-opt-out scenarios.
+
+### Download implementation
+
+- Use `net/http` with a 60s timeout for the download.
+- Stream to a temp file in the same directory, then atomic rename to final path. Avoids leaving partial binaries on disk.
+- Verify the downloaded file is non-empty and >1MB (sanity check — the real watchdog is several MB; a 404 HTML body is small).
+- No checksum verification in this change. GitHub serves over HTTPS; signature verification is a separate concern (tracked elsewhere — the agent updater has the same posture today).
+
+### Re-run semantics
+
+Running `breeze-agent service install` twice is already idempotent for the agent side (second call fails with "already exists" from SCM/systemd/launchd). The watchdog bootstrap step is likewise idempotent:
+- Sibling lookup: finds existing binary, no download.
+- Watchdog's own `service install`: errors cleanly if already installed, surfaced as a warning.
+
+This means a user who ran the old one-liner and got an agent-only install can re-run `breeze-agent service install` to add the missing watchdog, without reinstalling the agent.
+
+### Uninstall
+
+Out of scope for this change. `breeze-agent service uninstall` today removes only the agent service. We should mirror the install symmetry (also uninstall the watchdog), but it's a separate, safer-as-its-own-change edit. File follow-up if needed.
+
+## Files changed
+
+1. **`agent/cmd/breeze-agent/service_cmd_windows.go`** — add watchdog bootstrap after the agent `CreateService` succeeds; add `--no-watchdog` flag.
+2. **`agent/cmd/breeze-agent/service_cmd_linux.go`** — same.
+3. **`agent/cmd/breeze-agent/service_cmd_darwin.go`** — same. (macOS PKG already handles watchdog; this path is only hit by users running the binary directly.)
+4. **`agent/cmd/breeze-agent/watchdog_bootstrap.go`** (new, build-tagged or plain) — shared logic: `locateOrDownloadWatchdog`, `installWatchdog`. Platform-specific bits (binary extension, chmod) handled via `runtime.GOOS` + small helpers.
+5. **`agent/cmd/breeze-agent/watchdog_bootstrap_test.go`** (new) — unit tests for URL construction, sibling-lookup precedence, download-error paths (using `httptest.Server`), `--no-watchdog` opt-out.
+6. **`apps/docs/src/content/docs/agents/installation.mdx`** — the claim at lines 107-114 becomes true; no edit needed to the claim itself, but add a note that re-running `service install` repairs a missing watchdog. Optionally add the `--no-watchdog` flag to a troubleshooting section.
+
+The UI command templates in `AddDeviceModal.tsx` and `EnrollDeviceStep.tsx` do **not** need changes — the existing `breeze-agent.exe service install` / `sudo breeze-agent service install` step now implicitly installs the watchdog.
+
+## Testing
+
+### Unit tests (`watchdog_bootstrap_test.go`)
+
+- URL construction: given `version=0.62.24`, `goos=windows`, `goarch=amd64` → expected URL.
+- Sibling lookup: tmpdir with a fake `breeze-watchdog[.exe]` next to a fake agent binary → returns sibling path, no HTTP.
+- Download path: `httptest.Server` serving a fake binary → file is written next to agent path, mode 0755 on unix.
+- Download failure: 404 → returns error with actionable message; agent install does not abort.
+- Dev version (`main.version == "" || "dev"`) → skips download with a warning.
+- `--no-watchdog` flag: bootstrap is not called.
+
+### Manual smoke
+
+Order of verification:
+1. **Windows VM** (Tailscale `100.101.150.55`, per memory) — run the dashboard one-liner; confirm `sc query BreezeWatchdog` shows RUNNING and `sc query BreezeAgent` shows RUNNING.
+2. **Linux** (Docker container or local VM) — run the Linux one-liner; confirm `systemctl status breeze-agent breeze-watchdog` both active.
+3. **macOS** manual binary path — run `./breeze-agent service install`; confirm both LaunchDaemons loaded.
+4. **Re-run repair** — on a machine with agent-only install (simulate by uninstalling watchdog), re-run `breeze-agent service install`; confirm watchdog is now present without reinstalling the agent.
+5. **Air-gapped** — run with `--no-watchdog`; confirm only the agent is installed and no network call was attempted (verify via `strace`/Process Monitor or by running on a host with no route to github.com and seeing no delay).
+
+No CI changes required — Go tests are picked up automatically per the repo convention.
+
+## Risks
+
+- **Network dependency at install time.** Mitigated by sibling lookup (covers MSI/PKG), non-fatal failure, `--no-watchdog`, and clear warning text pointing at the manual-retry command.
+- **Version mismatch.** The agent downloads the watchdog at its own `main.version` (tag `v<version>`). If that tag doesn't exist (e.g. someone runs a locally-built agent without a matching release), the download 404s and we fall through to the warning. Dev builds are explicitly skipped.
+- **Silent drift from `pkg_darwin.go`.** Both files hardcode the same `https://github.com/LanternOps/breeze/releases/download/v<version>/...` base. Adding a code comment in each referencing the other, so anyone changing one remembers to change both. If this base needs to change three or more times, extract to a shared helper — YAGNI until then.
+
+## Rollout
+
+Single PR, merges to `main`, ships in the next agent release. No migration needed — existing deployments keep their current watchdog state (present if MSI/PKG, absent if CLI-installed). CLI-installed devices can be repaired by re-running `breeze-agent service install` at the admin's convenience, or will pick up the watchdog on the next agent reinstall / upgrade.

--- a/docs/superpowers/specs/2026-04-16-viewer-device-dedup-design.md
+++ b/docs/superpowers/specs/2026-04-16-viewer-device-dedup-design.md
@@ -1,0 +1,98 @@
+# Viewer: Dedupe Sessions by Device
+
+**Date:** 2026-04-16
+**Status:** Approved (design); awaiting implementation plan
+
+## Problem
+
+When the user clicks "Connect" on a device that already has an open Breeze Viewer window for that device, a second window opens instead of focusing the existing one.
+
+The viewer already dedupes by `session=<uuid>` in the `breeze://connect` deep link, but the web app generates a *new* session id on every click, so the existing dedup never fires. To dedupe properly, the viewer needs a stable identifier — the device id.
+
+## Goal
+
+Clicking "Connect" for a device that already has an open viewer window focuses the existing window instead of opening a new one.
+
+## Non-Goals
+
+- Reusing or restarting the underlying remote session. The existing WebRTC session in the focused window keeps running; the freshly created server-side session for the duplicate click is left to the existing stale-session sweep to clean up.
+- Detecting the duplicate in the web app before creating a new session. That requires viewer-state visibility the web app does not have.
+
+## Design
+
+### 1. Web app — add `device` to the deep link
+
+`apps/web/src/components/remote/ConnectDesktopButton.tsx`
+
+Append `&device=<deviceId>` to the deep link constructed at line 186:
+
+```ts
+const deepLink =
+  `breeze://connect?session=${encodeURIComponent(session.id)}` +
+  `&code=${encodeURIComponent(codeData.code)}` +
+  `&api=${encodeURIComponent(apiUrl)}` +
+  `&device=${encodeURIComponent(deviceId)}`;
+```
+
+`deviceId` is already in scope in the request body above.
+
+### 2. Viewer protocol parser — expose `deviceId`
+
+`apps/viewer/src/lib/protocol.ts`
+
+Add `deviceId?: string` to the parser return shape and read the `device` query param. Parser remains permissive: missing `device` is not an error (backward-compatible with older web builds).
+
+`apps/viewer/src/lib/protocol.test.ts`: add a test asserting `deviceId` is parsed when present, and is `undefined` when absent.
+
+### 3. Viewer Rust — device-keyed session map
+
+`apps/viewer/src-tauri/src/lib.rs`
+
+- Add `extract_device_id(url)` mirroring `extract_session_id`.
+- Add managed state `DeviceMap(Mutex<HashMap<String, String>>)` mapping `device_id → window_label`.
+- New Tauri command:
+  ```rust
+  #[tauri::command]
+  fn register_device(window: WebviewWindow, device_id: String, state: State<DeviceMap>)
+  ```
+  Inserts/updates the entry for the calling window.
+- In `route_deep_link`, before the existing `SessionMap` check, look up the URL's `device` param in `DeviceMap`. If a window exists, focus it and return early (do not create a new window, do not emit the deep link). Use the same lock-then-drop pattern as the session check to avoid macOS re-entrancy.
+- Cleanup wiring (mirror `SessionMap`):
+  - `WindowEvent::Destroyed` handler: drop entries pointing to the destroyed label.
+  - `unregister_session` command: drop entries pointing to the calling window.
+- Register the new command in `invoke_handler!` and `app.manage(DeviceMap(...))` in `setup`.
+
+### 4. Viewer frontend — register the device
+
+`apps/viewer/src/components/DesktopViewer.tsx`
+
+When the parsed deep link includes `deviceId`, call `invoke('register_device', { deviceId })` alongside the existing `register_session` invocation. No-op if `deviceId` is missing.
+
+## Backward Compatibility
+
+- Older web builds that don't include `device=` keep current behavior: per-session dedup + new window each click.
+- Older viewers that don't know about `device=` ignore the extra query param. Web app change is safe to ship independently.
+
+## Orphan Server-Side Sessions
+
+When a duplicate click is suppressed by device dedup, the new server-side session created in `ConnectDesktopButton` becomes immediately stale. This is acceptable:
+
+- The next click already runs `DELETE /remote/sessions/stale` in parallel before creating a new session.
+- Server-side session TTL evicts orphans on its own.
+
+No additional cleanup logic is added in this change.
+
+## Tests
+
+- `apps/viewer/src/lib/protocol.test.ts`: parses `device=` param; absent `device` yields `undefined`.
+- Manual: open a session, click "Connect" again on the same device → existing window focuses, no second window. Verify on macOS (where `set_focus` re-entrancy was historically a problem) and Windows.
+
+Rust unit tests are not currently present in `lib.rs`; not adding them in this change.
+
+## Files Touched
+
+- `apps/web/src/components/remote/ConnectDesktopButton.tsx` (1 line)
+- `apps/viewer/src/lib/protocol.ts` (add `deviceId` to return shape)
+- `apps/viewer/src/lib/protocol.test.ts` (one new test case)
+- `apps/viewer/src/components/DesktopViewer.tsx` (one extra `invoke`)
+- `apps/viewer/src-tauri/src/lib.rs` (new state, command, route check, cleanup)


### PR DESCRIPTION
## Summary
- PR #443 added a generic `TypePing`/`TypePong` keepalive to every accepted helper session in the sessionbroker.
- The watchdog IPC client (`agent/internal/watchdog/ipcclient.go`) only handles `TypeWatchdogPong` and silently drops inbound `TypePing` — so every watchdog connection was evicted as a stranded session at `keepaliveTimeout` (~60s) and reconnected in a loop.
- Gates the broker keepalive on a tiny `roleSupportsKeepalive(role)` predicate so watchdog sessions are skipped. Watchdog already has its own end-to-end liveness via `WatchdogPing`/`WatchdogPong`.
- Stranded-session protection that PR #443 added for user/system helpers is unchanged.

## Repro on Kit (0.62.25-rc.3)
```
keepalive pong timeout, closing stranded session  identity=S-1-5-18 role=watchdog ageMs=60000
user helper connected                              role=watchdog
keepalive pong timeout, closing stranded session  identity=S-1-5-18 role=watchdog ageMs=60000
... (every ~90s, indefinitely)
```

## Test plan
- [x] `go test -race -count=1 ./internal/sessionbroker/...` — added `TestRoleSupportsKeepalive_ExcludesWatchdog` covering system/user/watchdog/empty roles. All existing keepalive + admit-or-evict tests still pass.
- [ ] Deploy to Kit and confirm the watchdog `keepalive pong timeout` log no longer fires while user/system helpers can still be evicted when stranded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)