### PR TITLE
feat(viewer): focus existing window when reconnecting same device

### DIFF
--- a/apps/viewer/src-tauri/src/lib.rs
+++ b/apps/viewer/src-tauri/src/lib.rs
@@ -553,3 +553,27 @@ pub fn run() {
         }
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_device_id_cases() {
+        let cases = [
+            ("breeze://connect?session=s&device=d1", Some("d1")),
+            ("breeze://connect?device=d1&session=s", Some("d1")),
+            ("breeze://connect?session=s&device=", None),
+            ("breeze://connect?session=s", None),
+            ("breeze://connect", None),
+            ("breeze://connect?session=s&xdevice=d1", None),
+        ];
+        for (url, expected) in cases {
+            assert_eq!(
+                extract_device_id(url).as_deref(),
+                expected,
+                "extract_device_id({url:?})"
+            );
+        }
+    }
+}

--- a/apps/viewer/src-tauri/src/lib.rs
+++ b/apps/viewer/src-tauri/src/lib.rs
@@ -205,10 +205,31 @@ fn focus_any_session_window(app: &tauri::AppHandle) {
 /// - If the session is already active in a window, focus that window.
 /// - Otherwise, create a new session window for it.
 fn route_deep_link(app: &tauri::AppHandle, url: String) {
-    // Check if this session is already being viewed.
-    // Clone the label and drop the lock BEFORE calling set_focus(),
-    // which on macOS pumps the AppKit run loop and can re-enter Tauri
-    // command handlers that also need the SessionMap lock.
+    // Check device-id dedup first: if a window is already viewing this device,
+    // focus it and discard the new deep link entirely.
+    // Clone the label and drop the lock BEFORE calling set_focus(); on macOS
+    // set_focus pumps the AppKit run loop and can re-enter Tauri command
+    // handlers that also need this lock.
+    if let Some(device_id) = extract_device_id(&url) {
+        let existing_label = {
+            let devices = app.state::<DeviceMap>();
+            let map = lock_or_recover(&devices.0, "device_map");
+            map.get(&device_id).cloned()
+        }; // lock released here
+        if let Some(label) = existing_label {
+            if let Some(window) = app.get_webview_window(&label) {
+                if let Err(err) = window.set_focus() {
+                    eprintln!(
+                        "Failed to focus existing device window {}: {}",
+                        label, err
+                    );
+                }
+                return;
+            }
+        }
+    }
+
+    // Fallback: dedup by session id (covers older web builds and edge cases).
     if let Some(session_id) = extract_session_id(&url) {
         let existing_label = {
             let sessions = app.state::<SessionMap>();
@@ -228,8 +249,7 @@ fn route_deep_link(app: &tauri::AppHandle, url: String) {
         }
     }
 
-    // Always open a new session window immediately.
-    // Updates are handled by the background auto_update task at startup.
+    // No existing window matched — open a new session window.
     create_session_window(app, url);
 }
 

--- a/apps/viewer/src-tauri/src/lib.rs
+++ b/apps/viewer/src-tauri/src/lib.rs
@@ -48,6 +48,10 @@ struct SessionEntry {
 /// Used to detect duplicate deep links and focus the existing window.
 struct SessionMap(Mutex<HashMap<String, SessionEntry>>);
 
+/// Maps device_id → window_label for active sessions.
+/// Used to focus an existing window when the same device is connected again.
+struct DeviceMap(Mutex<HashMap<String, String>>);
+
 /// Monotonic counter for unique window labels.
 struct WindowCounter(Mutex<u32>);
 
@@ -83,6 +87,23 @@ fn extract_session_id(url: &str) -> Option<String> {
         }
     }
     eprintln!("Deep link missing session parameter");
+    None
+}
+
+/// Extract the `device=` query parameter from a breeze:// deep link URL.
+fn extract_device_id(url: &str) -> Option<String> {
+    let query_start = url.find('?')?;
+    let query = &url[query_start + 1..];
+    for pair in query.split('&') {
+        if let Some(value) = pair.strip_prefix("device=") {
+            let end = value.find('&').unwrap_or(value.len());
+            let id = &value[..end];
+            if !id.is_empty() {
+                return Some(id.to_string());
+            }
+            return None;
+        }
+    }
     None
 }
 
@@ -403,6 +424,7 @@ pub fn run() {
 
             app.manage(DeepLinkState(Mutex::new(HashMap::new())));
             app.manage(SessionMap(Mutex::new(HashMap::new())));
+            app.manage(DeviceMap(Mutex::new(HashMap::new())));
             app.manage(WindowCounter(Mutex::new(0)));
 
             // If launched with a deep link, defer session window creation to

--- a/apps/viewer/src-tauri/src/lib.rs
+++ b/apps/viewer/src-tauri/src/lib.rs
@@ -139,10 +139,27 @@ fn register_session(
 
 /// Called by the frontend on disconnect (session no longer active).
 #[tauri::command]
-fn unregister_session(window: tauri::WebviewWindow, state: tauri::State<'_, SessionMap>) {
-    let mut map = lock_or_recover(&state.0, "session_map");
-    // Remove all entries that point to this window
-    map.retain(|_, entry| entry.window_label != window.label());
+fn unregister_session(
+    window: tauri::WebviewWindow,
+    sessions: tauri::State<'_, SessionMap>,
+    devices: tauri::State<'_, DeviceMap>,
+) {
+    let mut session_map = lock_or_recover(&sessions.0, "session_map");
+    session_map.retain(|_, entry| entry.window_label != window.label());
+    let mut device_map = lock_or_recover(&devices.0, "device_map");
+    device_map.retain(|_, label| label != window.label());
+}
+
+/// Called by DesktopViewer when the device id is known.
+/// Maps device_id → calling window so duplicate connects to the same device focus it.
+#[tauri::command]
+fn register_device(
+    window: tauri::WebviewWindow,
+    device_id: String,
+    state: tauri::State<'_, DeviceMap>,
+) {
+    let mut map = lock_or_recover(&state.0, "device_map");
+    map.insert(device_id, window.label().to_string());
 }
 
 /// Called by DesktopViewer when the remote hostname is learned.
@@ -380,6 +397,7 @@ pub fn run() {
             clear_pending_deep_link,
             register_session,
             unregister_session,
+            register_device,
             update_session_hostname,
         ]);
 
@@ -474,6 +492,10 @@ pub fn run() {
                     if let Some(sessions) = app_handle.try_state::<SessionMap>() {
                         let mut map = lock_or_recover(&sessions.0, "session_map");
                         map.retain(|_, entry| entry.window_label != label);
+                    }
+                    if let Some(devices) = app_handle.try_state::<DeviceMap>() {
+                        let mut map = lock_or_recover(&devices.0, "device_map");
+                        map.retain(|_, l| l != &label);
                     }
                     if let Some(links) = app_handle.try_state::<DeepLinkState>() {
                         let mut map = lock_or_recover(&links.0, "deep_link_state");

--- a/apps/viewer/src/components/DesktopViewer.tsx
+++ b/apps/viewer/src/components/DesktopViewer.tsx
@@ -692,6 +692,11 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
 	      invoke('register_session', { sessionId: params.sessionId }).catch((err) => {
 	        console.error('Failed to register desktop session:', err);
 	      });
+	      if (params.deviceId) {
+	        invoke('register_device', { deviceId: params.deviceId }).catch((err) => {
+	          console.error('Failed to register desktop device:', err);
+	        });
+	      }
 	      return;
 	    }
 	    if (status !== 'connected' && status !== 'reconnecting' && sessionRegisteredRef.current) {
@@ -700,7 +705,7 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
 	        console.error('Failed to unregister desktop session:', err);
 	      });
 	    }
-	  }, [status, params.sessionId]);
+	  }, [status, params.sessionId, params.deviceId]);
 
   // Count WebRTC video frames via requestVideoFrameCallback
   useEffect(() => {

--- a/apps/viewer/src/lib/protocol.test.ts
+++ b/apps/viewer/src/lib/protocol.test.ts
@@ -63,6 +63,13 @@ describe('parseDeepLink', () => {
     expect(result).not.toBeNull();
     expect(result!).not.toHaveProperty('deviceId');
   });
+
+  it('omits deviceId when device param is empty', () => {
+    const url = 'breeze://connect?session=abc&code=def&api=https%3A%2F%2Fexample.com&device=';
+    const result = parseDeepLink(url);
+    expect(result).not.toBeNull();
+    expect(result!).not.toHaveProperty('deviceId');
+  });
 });
 
 describe('buildWsUrl', () => {

--- a/apps/viewer/src/lib/protocol.test.ts
+++ b/apps/viewer/src/lib/protocol.test.ts
@@ -46,6 +46,23 @@ describe('parseDeepLink', () => {
   it('returns null when required params are missing', () => {
     expect(parseDeepLink('breeze://connect?session=abc')).toBeNull();
   });
+
+  it('parses optional device param', () => {
+    const url = 'breeze://connect?session=abc&code=def&api=https%3A%2F%2Fexample.com&device=dev-123';
+    expect(parseDeepLink(url)).toEqual({
+      sessionId: 'abc',
+      connectCode: 'def',
+      apiUrl: 'https://example.com',
+      deviceId: 'dev-123',
+    });
+  });
+
+  it('omits deviceId when device param is absent', () => {
+    const url = 'breeze://connect?session=abc&code=def&api=https%3A%2F%2Fexample.com';
+    const result = parseDeepLink(url);
+    expect(result).not.toBeNull();
+    expect(result!).not.toHaveProperty('deviceId');
+  });
 });
 
 describe('buildWsUrl', () => {

--- a/apps/viewer/src/lib/protocol.ts
+++ b/apps/viewer/src/lib/protocol.ts
@@ -7,6 +7,7 @@ export interface ConnectionParams {
   connectCode: string;
   apiUrl: string;
   targetSessionId?: number;
+  deviceId?: string;
 }
 
 function isPrivateHost(hostname: string): boolean {
@@ -47,6 +48,7 @@ export function parseDeepLink(url: string): ConnectionParams | null {
     const connectCode = parsed.searchParams.get('code');
     const apiUrl = parsed.searchParams.get('api');
     const targetSessionIdRaw = parsed.searchParams.get('targetSessionId');
+    const deviceIdRaw = parsed.searchParams.get('device');
 
     if (!sessionId || !connectCode || !apiUrl) {
       return null;
@@ -70,7 +72,16 @@ export function parseDeepLink(url: string): ConnectionParams | null {
       }
     }
 
-    return { sessionId, connectCode, apiUrl: api.toString().replace(/\/$/, ''), ...(targetSessionId != null ? { targetSessionId } : {}) };
+    // Parse optional deviceId
+    const deviceId = deviceIdRaw && deviceIdRaw.length > 0 ? deviceIdRaw : undefined;
+
+    return {
+      sessionId,
+      connectCode,
+      apiUrl: api.toString().replace(/\/$/, ''),
+      ...(targetSessionId != null ? { targetSessionId } : {}),
+      ...(deviceId != null ? { deviceId } : {}),
+    };
   } catch {
     return null;
   }

--- a/apps/web/src/components/remote/ConnectDesktopButton.tsx
+++ b/apps/web/src/components/remote/ConnectDesktopButton.tsx
@@ -183,7 +183,7 @@ export default function ConnectDesktopButton({ deviceId, className = '', compact
 
       // Build deep link URL
       const apiUrl = import.meta.env.PUBLIC_API_URL || window.location.origin;
-      const deepLink = `breeze://connect?session=${encodeURIComponent(session.id)}&code=${encodeURIComponent(codeData.code)}&api=${encodeURIComponent(apiUrl)}`;
+      const deepLink = `breeze://connect?session=${encodeURIComponent(session.id)}&code=${encodeURIComponent(codeData.code)}&api=${encodeURIComponent(apiUrl)}&device=${encodeURIComponent(deviceId)}`;
 
       setStatus('launching');
 


### PR DESCRIPTION
## Summary

When a user clicks "Connect" on a device that already has an open Breeze Viewer window, focus the existing window instead of opening a new one. Previously each click created a new session id, which defeated the existing session-id dedup and resulted in duplicate windows.

- Web app appends `&device=<deviceId>` to the `breeze://connect` deep link.
- Viewer Rust backend keeps a `device_id → window_label` map and checks it first in `route_deep_link`, then falls back to the existing session-id dedup, then to creating a new window.
- Backward-compatible: deep links without `device=` keep current behavior.

The just-created server-side session for the suppressed click becomes stale and is cleaned up by the existing `DELETE /remote/sessions/stale` sweep that already runs on every connect.

Spec: `docs/superpowers/specs/2026-04-16-viewer-device-dedup-design.md`
Plan: `docs/superpowers/plans/2026-04-16-viewer-device-dedup.md`

## Test plan
- [x] `cargo test --lib` in `apps/viewer/src-tauri` — `extract_device_id` table-driven cases (6 scenarios)
- [x] `pnpm test -- protocol` in `apps/viewer` — 13/13 passing including new empty-`device=` case
- [x] `tsc --noEmit` clean for both web and viewer
- [ ] Manual: open a device, click Connect again on the same device → existing window focuses; click Connect on a different device → second window opens
- [ ] Manual: deep link without `device=` still opens a window (backward-compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)