### PR TITLE
fix(agent): CLI service install auto-bootstraps the watchdog (#407)

### DIFF
--- a/agent/cmd/breeze-agent/service_cmd_darwin.go
+++ b/agent/cmd/breeze-agent/service_cmd_darwin.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/breeze-rmm/agent/internal/config"
@@ -131,6 +132,7 @@ var serviceCmd = &cobra.Command{
 }
 
 var withUserHelper bool
+var noWatchdog bool
 
 func init() {
 	rootCmd.AddCommand(serviceCmd)
@@ -140,6 +142,7 @@ func init() {
 	serviceCmd.AddCommand(serviceStopCmd)
 	serviceCmd.AddCommand(serviceStatusCmd)
 	serviceInstallCmd.Flags().BoolVar(&withUserHelper, "with-user-helper", false, "Also install the per-user desktop helper LaunchAgent")
+	serviceInstallCmd.Flags().BoolVar(&noWatchdog, "no-watchdog", false, "Skip automatic watchdog installation")
 }
 
 var serviceInstallCmd = &cobra.Command{
@@ -263,6 +266,21 @@ var serviceInstallCmd = &cobra.Command{
 			fmt.Printf("  3. Status:  sudo breeze-agent service status\n")
 			fmt.Printf("  4. Logs:    tail -f %s/agent.log\n", darwinLogDir)
 		}
+		if !noWatchdog {
+			err := bootstrapWatchdog(bootstrapOptions{
+				agentPath: darwinBinaryPath,
+				version:   version,
+				goos:      runtime.GOOS,
+				goarch:    runtime.GOARCH,
+			})
+			if err != nil {
+				fmt.Fprintf(os.Stderr,
+					"Warning: watchdog bootstrap failed: %v\n"+
+						"The agent service is installed. To install the watchdog manually, run:\n"+
+						"    sudo breeze-watchdog service install\n", err)
+			}
+		}
+
 		return nil
 	},
 }

--- a/agent/cmd/breeze-agent/service_cmd_darwin.go
+++ b/agent/cmd/breeze-agent/service_cmd_darwin.go
@@ -276,8 +276,13 @@ var serviceInstallCmd = &cobra.Command{
 			if err != nil {
 				fmt.Fprintf(os.Stderr,
 					"Warning: watchdog bootstrap failed: %v\n"+
-						"The agent service is installed. To install the watchdog manually, run:\n"+
-						"    sudo breeze-watchdog service install\n", err)
+						"The agent service is installed and running. The watchdog is NOT installed.\n"+
+						"To retry, choose one of:\n"+
+						"  1. Re-run `sudo breeze-agent service install` (will retry the download).\n"+
+						"  2. Download %s manually, place it next to breeze-agent,\n"+
+						"     then run `sudo breeze-watchdog service install`.\n"+
+						"  3. To skip the watchdog entirely, use `--no-watchdog`.\n",
+					err, watchdogDownloadURL(version, runtime.GOOS, runtime.GOARCH))
 			}
 		}
 

--- a/agent/cmd/breeze-agent/service_cmd_darwin.go
+++ b/agent/cmd/breeze-agent/service_cmd_darwin.go
@@ -268,7 +268,7 @@ var serviceInstallCmd = &cobra.Command{
 		}
 		if !noWatchdog {
 			err := bootstrapWatchdog(bootstrapOptions{
-				agentPath: darwinBinaryPath,
+				agentPath: exePath,
 				version:   version,
 				goos:      runtime.GOOS,
 				goarch:    runtime.GOARCH,

--- a/agent/cmd/breeze-agent/service_cmd_linux.go
+++ b/agent/cmd/breeze-agent/service_cmd_linux.go
@@ -240,8 +240,13 @@ var serviceInstallCmd = &cobra.Command{
 			if err != nil {
 				fmt.Fprintf(os.Stderr,
 					"Warning: watchdog bootstrap failed: %v\n"+
-						"The agent service is installed. To install the watchdog manually, run:\n"+
-						"    sudo breeze-watchdog service install\n", err)
+						"The agent service is installed and running. The watchdog is NOT installed.\n"+
+						"To retry, choose one of:\n"+
+						"  1. Re-run `sudo breeze-agent service install` (will retry the download).\n"+
+						"  2. Download %s manually, place it next to breeze-agent,\n"+
+						"     then run `sudo breeze-watchdog service install`.\n"+
+						"  3. To skip the watchdog entirely, use `--no-watchdog`.\n",
+					err, watchdogDownloadURL(version, runtime.GOOS, runtime.GOARCH))
 			}
 		}
 

--- a/agent/cmd/breeze-agent/service_cmd_linux.go
+++ b/agent/cmd/breeze-agent/service_cmd_linux.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/breeze-rmm/agent/internal/config"
@@ -82,6 +83,7 @@ var serviceCmd = &cobra.Command{
 }
 
 var withUserHelper bool
+var noWatchdog bool
 
 // healLaunchdPlistsIfNeeded is a no-op on Linux.
 func healLaunchdPlistsIfNeeded() {}
@@ -94,6 +96,7 @@ func init() {
 	serviceCmd.AddCommand(serviceStopCmd)
 	serviceCmd.AddCommand(serviceStatusCmd)
 	serviceInstallCmd.Flags().BoolVar(&withUserHelper, "with-user-helper", false, "Also install the per-user desktop helper systemd unit")
+	serviceInstallCmd.Flags().BoolVar(&noWatchdog, "no-watchdog", false, "Skip automatic watchdog installation")
 }
 
 var serviceInstallCmd = &cobra.Command{
@@ -226,6 +229,22 @@ var serviceInstallCmd = &cobra.Command{
 			fmt.Printf("  3. Status:  sudo breeze-agent service status\n")
 			fmt.Println("  4. Logs:    journalctl -u breeze-agent -f")
 		}
+
+		if !noWatchdog {
+			err := bootstrapWatchdog(bootstrapOptions{
+				agentPath: linuxBinaryPath,
+				version:   version,
+				goos:      runtime.GOOS,
+				goarch:    runtime.GOARCH,
+			})
+			if err != nil {
+				fmt.Fprintf(os.Stderr,
+					"Warning: watchdog bootstrap failed: %v\n"+
+						"The agent service is installed. To install the watchdog manually, run:\n"+
+						"    sudo breeze-watchdog service install\n", err)
+			}
+		}
+
 		return nil
 	},
 }

--- a/agent/cmd/breeze-agent/service_cmd_linux.go
+++ b/agent/cmd/breeze-agent/service_cmd_linux.go
@@ -232,7 +232,7 @@ var serviceInstallCmd = &cobra.Command{
 
 		if !noWatchdog {
 			err := bootstrapWatchdog(bootstrapOptions{
-				agentPath: linuxBinaryPath,
+				agentPath: exePath,
 				version:   version,
 				goos:      runtime.GOOS,
 				goarch:    runtime.GOARCH,

--- a/agent/cmd/breeze-agent/service_cmd_windows.go
+++ b/agent/cmd/breeze-agent/service_cmd_windows.go
@@ -5,6 +5,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -22,12 +23,15 @@ var serviceCmd = &cobra.Command{
 // healLaunchdPlistsIfNeeded is a no-op on Windows.
 func healLaunchdPlistsIfNeeded() {}
 
+var noWatchdog bool
+
 func init() {
 	rootCmd.AddCommand(serviceCmd)
 	serviceCmd.AddCommand(serviceInstallCmd)
 	serviceCmd.AddCommand(serviceUninstallCmd)
 	serviceCmd.AddCommand(serviceStartCmd)
 	serviceCmd.AddCommand(serviceStopCmd)
+	serviceInstallCmd.Flags().BoolVar(&noWatchdog, "no-watchdog", false, "Skip automatic watchdog installation")
 }
 
 var serviceInstallCmd = &cobra.Command{
@@ -67,6 +71,22 @@ var serviceInstallCmd = &cobra.Command{
 		}
 
 		fmt.Printf("Service %q installed successfully.\n", windowsServiceName)
+
+		if !noWatchdog {
+			err := bootstrapWatchdog(bootstrapOptions{
+				agentPath: exePath,
+				version:   version,
+				goos:      runtime.GOOS,
+				goarch:    runtime.GOARCH,
+			})
+			if err != nil {
+				fmt.Fprintf(os.Stderr,
+					"Warning: watchdog bootstrap failed: %v\n"+
+						"The agent service is installed. To install the watchdog manually, run:\n"+
+						"    breeze-watchdog.exe service install\n", err)
+			}
+		}
+
 		return nil
 	},
 }

--- a/agent/cmd/breeze-agent/service_cmd_windows.go
+++ b/agent/cmd/breeze-agent/service_cmd_windows.go
@@ -82,8 +82,13 @@ var serviceInstallCmd = &cobra.Command{
 			if err != nil {
 				fmt.Fprintf(os.Stderr,
 					"Warning: watchdog bootstrap failed: %v\n"+
-						"The agent service is installed. To install the watchdog manually, run:\n"+
-						"    breeze-watchdog.exe service install\n", err)
+						"The agent service is installed and running. The watchdog is NOT installed.\n"+
+						"To retry, choose one of:\n"+
+						"  1. Re-run `breeze-agent.exe service install` (will retry the download).\n"+
+						"  2. Download %s manually, place it next to breeze-agent.exe,\n"+
+						"     then run `breeze-watchdog.exe service install`.\n"+
+						"  3. To skip the watchdog entirely, use `--no-watchdog`.\n",
+					err, watchdogDownloadURL(version, runtime.GOOS, runtime.GOARCH))
 			}
 		}
 

--- a/agent/cmd/breeze-agent/watchdog_bootstrap.go
+++ b/agent/cmd/breeze-agent/watchdog_bootstrap.go
@@ -5,8 +5,10 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 )
 
@@ -89,6 +91,48 @@ func downloadWatchdog(url, destPath string) error {
 	if err := os.Rename(tmpPath, destPath); err != nil {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("rename %s -> %s: %w", tmpPath, destPath, err)
+	}
+	return nil
+}
+
+// bootstrapOptions is the inputs for bootstrapWatchdog. Kept as a struct so the
+// callers on each OS stay short and the test helpers don't need long arg lists.
+type bootstrapOptions struct {
+	agentPath string // absolute path to the currently running agent binary
+	version   string // agent version (main.version), e.g. "0.62.24" or "dev"
+	goos      string // runtime.GOOS
+	goarch    string // runtime.GOARCH
+
+	// urlOverride, if non-empty, replaces the full download URL. Test-only.
+	urlOverride string
+}
+
+// bootstrapWatchdog resolves a watchdog binary (sibling first, GitHub download
+// fallback) and then invokes `<watchdog> service install` to register it as a
+// system service. All errors are returned — callers are expected to downgrade
+// them to warnings so that a watchdog problem never aborts the agent install.
+func bootstrapWatchdog(opts bootstrapOptions) error {
+	watchdogPath, ok := locateSiblingWatchdog(opts.agentPath)
+	if !ok {
+		if opts.version == "" || opts.version == "dev" || strings.HasPrefix(opts.version, "dev-") {
+			return fmt.Errorf("no sibling watchdog found and agent is a dev build (version=%q); run `breeze-watchdog service install` manually", opts.version)
+		}
+		url := opts.urlOverride
+		if url == "" {
+			url = watchdogDownloadURL(opts.version, opts.goos, opts.goarch)
+		}
+		watchdogPath = filepath.Join(filepath.Dir(opts.agentPath), watchdogBinaryName(opts.goos))
+		fmt.Fprintf(os.Stderr, "Downloading watchdog from %s ...\n", url)
+		if err := downloadWatchdog(url, watchdogPath); err != nil {
+			return fmt.Errorf("download watchdog: %w", err)
+		}
+	}
+
+	cmd := exec.Command(watchdogPath, "service", "install")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("run %s service install: %w", watchdogPath, err)
 	}
 	return nil
 }

--- a/agent/cmd/breeze-agent/watchdog_bootstrap.go
+++ b/agent/cmd/breeze-agent/watchdog_bootstrap.go
@@ -1,6 +1,11 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
 
 // NOTE: Keep this URL base in sync with agent/internal/updater/pkg_darwin.go.
 // Both point at the same GitHub releases. If one ever moves to an env var,
@@ -24,4 +29,15 @@ func watchdogDownloadURL(version, goos, goarch string) string {
 	}
 	return fmt.Sprintf("%s/v%s/breeze-watchdog-%s-%s%s",
 		watchdogReleasesBase, version, goos, goarch, ext)
+}
+
+// locateSiblingWatchdog checks for the watchdog binary in the same directory
+// as the agent binary. Returns (path, true) if found.
+func locateSiblingWatchdog(agentPath string) (string, bool) {
+	candidate := filepath.Join(filepath.Dir(agentPath), watchdogBinaryName(runtime.GOOS))
+	info, err := os.Stat(candidate)
+	if err != nil || info.IsDir() {
+		return "", false
+	}
+	return candidate, true
 }

--- a/agent/cmd/breeze-agent/watchdog_bootstrap.go
+++ b/agent/cmd/breeze-agent/watchdog_bootstrap.go
@@ -1,0 +1,27 @@
+package main
+
+import "fmt"
+
+// NOTE: Keep this URL base in sync with agent/internal/updater/pkg_darwin.go.
+// Both point at the same GitHub releases. If one ever moves to an env var,
+// migrate both call sites together.
+const watchdogReleasesBase = "https://github.com/LanternOps/breeze/releases/download"
+
+// watchdogBinaryName returns the filename for the watchdog binary on the given GOOS.
+func watchdogBinaryName(goos string) string {
+	if goos == "windows" {
+		return "breeze-watchdog.exe"
+	}
+	return "breeze-watchdog"
+}
+
+// watchdogDownloadURL returns the GitHub release download URL for the watchdog
+// binary matching the given agent version / OS / arch.
+func watchdogDownloadURL(version, goos, goarch string) string {
+	ext := ""
+	if goos == "windows" {
+		ext = ".exe"
+	}
+	return fmt.Sprintf("%s/v%s/breeze-watchdog-%s-%s%s",
+		watchdogReleasesBase, version, goos, goarch, ext)
+}

--- a/agent/cmd/breeze-agent/watchdog_bootstrap.go
+++ b/agent/cmd/breeze-agent/watchdog_bootstrap.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
+	"time"
 )
 
 // NOTE: Keep this URL base in sync with agent/internal/updater/pkg_darwin.go.
@@ -40,4 +43,52 @@ func locateSiblingWatchdog(agentPath string) (string, bool) {
 		return "", false
 	}
 	return candidate, true
+}
+
+const (
+	watchdogMinSize       = 1 * 1024 * 1024 // 1 MB sanity check (real binary is several MB)
+	watchdogDownloadTimeo = 60 * time.Second
+)
+
+// downloadWatchdog fetches the watchdog binary from url and writes it to destPath.
+// The file is streamed to a sibling temp file and atomically renamed on success,
+// so a partial download never leaves a broken binary behind. On unix the file is
+// marked executable (0755).
+func downloadWatchdog(url, destPath string) error {
+	client := &http.Client{Timeout: watchdogDownloadTimeo}
+	resp, err := client.Get(url)
+	if err != nil {
+		return fmt.Errorf("http get %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("http get %s: status %d", url, resp.StatusCode)
+	}
+
+	tmpPath := destPath + ".download"
+	tmp, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", tmpPath, err)
+	}
+	n, copyErr := io.Copy(tmp, resp.Body)
+	closeErr := tmp.Close()
+	if copyErr != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("download body: %w", copyErr)
+	}
+	if closeErr != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close %s: %w", tmpPath, closeErr)
+	}
+	if n < watchdogMinSize {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("downloaded body too small (%d bytes); URL likely returned an error page", n)
+	}
+
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename %s -> %s: %w", tmpPath, destPath, err)
+	}
+	return nil
 }

--- a/agent/cmd/breeze-agent/watchdog_bootstrap.go
+++ b/agent/cmd/breeze-agent/watchdog_bootstrap.go
@@ -49,7 +49,7 @@ func locateSiblingWatchdog(agentPath string) (string, bool) {
 
 const (
 	watchdogMinSize       = 1 * 1024 * 1024 // 1 MB sanity check (real binary is several MB)
-	watchdogDownloadTimeo = 60 * time.Second
+	watchdogDownloadTimeout = 60 * time.Second
 )
 
 // downloadWatchdog fetches the watchdog binary from url and writes it to destPath.
@@ -57,7 +57,7 @@ const (
 // so a partial download never leaves a broken binary behind. On unix the file is
 // marked executable (0755).
 func downloadWatchdog(url, destPath string) error {
-	client := &http.Client{Timeout: watchdogDownloadTimeo}
+	client := &http.Client{Timeout: watchdogDownloadTimeout}
 	resp, err := client.Get(url)
 	if err != nil {
 		return fmt.Errorf("http get %s: %w", url, err)

--- a/agent/cmd/breeze-agent/watchdog_bootstrap_test.go
+++ b/agent/cmd/breeze-agent/watchdog_bootstrap_test.go
@@ -156,3 +156,79 @@ func TestDownloadWatchdog_TooSmall(t *testing.T) {
 		t.Errorf("downloadWatchdog: dest file should not exist after failure")
 	}
 }
+
+func TestBootstrapWatchdog_SiblingFound_RunsInstall(t *testing.T) {
+	dir := t.TempDir()
+	agentPath := filepath.Join(dir, "breeze-agent")
+	if err := os.WriteFile(agentPath, []byte("fake"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	siblingPath := filepath.Join(dir, watchdogBinaryName(runtime.GOOS))
+	marker := filepath.Join(dir, "invoked")
+	var script string
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping exec-sibling test on Windows (need real .exe)")
+	} else {
+		script = "#!/bin/sh\necho invoked > \"" + marker + "\"\n"
+	}
+	if err := os.WriteFile(siblingPath, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := bootstrapOptions{
+		agentPath: agentPath,
+		version:   "0.62.24",
+		goos:      runtime.GOOS,
+		goarch:    runtime.GOARCH,
+	}
+	if err := bootstrapWatchdog(opts); err != nil {
+		t.Fatalf("bootstrapWatchdog: %v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Errorf("expected sibling watchdog to be invoked (marker %q not found): %v", marker, err)
+	}
+}
+
+func TestBootstrapWatchdog_DevVersionSkipsDownload(t *testing.T) {
+	dir := t.TempDir()
+	agentPath := filepath.Join(dir, "breeze-agent")
+	if err := os.WriteFile(agentPath, []byte("fake"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := bootstrapOptions{
+		agentPath: agentPath,
+		version:   "dev",
+		goos:      runtime.GOOS,
+		goarch:    runtime.GOARCH,
+	}
+	err := bootstrapWatchdog(opts)
+	if err == nil {
+		t.Fatalf("bootstrapWatchdog: expected error for dev version, got nil")
+	}
+}
+
+func TestBootstrapWatchdog_DownloadFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	agentPath := filepath.Join(dir, "breeze-agent")
+	if err := os.WriteFile(agentPath, []byte("fake"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := bootstrapOptions{
+		agentPath:   agentPath,
+		version:     "0.62.24",
+		goos:        runtime.GOOS,
+		goarch:      runtime.GOARCH,
+		urlOverride: srv.URL,
+	}
+	err := bootstrapWatchdog(opts)
+	if err == nil {
+		t.Fatalf("bootstrapWatchdog: expected error on download 404, got nil")
+	}
+}

--- a/agent/cmd/breeze-agent/watchdog_bootstrap_test.go
+++ b/agent/cmd/breeze-agent/watchdog_bootstrap_test.go
@@ -190,21 +190,24 @@ func TestBootstrapWatchdog_SiblingFound_RunsInstall(t *testing.T) {
 }
 
 func TestBootstrapWatchdog_DevVersionSkipsDownload(t *testing.T) {
-	dir := t.TempDir()
-	agentPath := filepath.Join(dir, "breeze-agent")
-	if err := os.WriteFile(agentPath, []byte("fake"), 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	opts := bootstrapOptions{
-		agentPath: agentPath,
-		version:   "dev",
-		goos:      runtime.GOOS,
-		goarch:    runtime.GOARCH,
-	}
-	err := bootstrapWatchdog(opts)
-	if err == nil {
-		t.Fatalf("bootstrapWatchdog: expected error for dev version, got nil")
+	cases := []string{"dev", "dev-abc123", ""}
+	for _, v := range cases {
+		t.Run(v, func(t *testing.T) {
+			dir := t.TempDir()
+			agentPath := filepath.Join(dir, "breeze-agent")
+			if err := os.WriteFile(agentPath, []byte("fake"), 0755); err != nil {
+				t.Fatal(err)
+			}
+			opts := bootstrapOptions{
+				agentPath: agentPath,
+				version:   v,
+				goos:      runtime.GOOS,
+				goarch:    runtime.GOARCH,
+			}
+			if err := bootstrapWatchdog(opts); err == nil {
+				t.Fatalf("bootstrapWatchdog(version=%q): expected error, got nil", v)
+			}
+		})
 	}
 }
 
@@ -230,5 +233,30 @@ func TestBootstrapWatchdog_DownloadFailure(t *testing.T) {
 	err := bootstrapWatchdog(opts)
 	if err == nil {
 		t.Fatalf("bootstrapWatchdog: expected error on download 404, got nil")
+	}
+}
+
+func TestBootstrapWatchdog_SiblingExitsNonZero(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping exec-sibling test on Windows (need real .exe)")
+	}
+	dir := t.TempDir()
+	agentPath := filepath.Join(dir, "breeze-agent")
+	if err := os.WriteFile(agentPath, []byte("fake"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	siblingPath := filepath.Join(dir, watchdogBinaryName(runtime.GOOS))
+	if err := os.WriteFile(siblingPath, []byte("#!/bin/sh\nexit 1\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := bootstrapOptions{
+		agentPath: agentPath,
+		version:   "0.62.24",
+		goos:      runtime.GOOS,
+		goarch:    runtime.GOARCH,
+	}
+	if err := bootstrapWatchdog(opts); err == nil {
+		t.Fatalf("bootstrapWatchdog: expected error when sibling exits non-zero, got nil")
 	}
 }

--- a/agent/cmd/breeze-agent/watchdog_bootstrap_test.go
+++ b/agent/cmd/breeze-agent/watchdog_bootstrap_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
 
 func TestWatchdogBinaryName(t *testing.T) {
 	tests := []struct {
@@ -42,5 +47,41 @@ func TestWatchdogDownloadURL(t *testing.T) {
 			t.Errorf("watchdogDownloadURL(%q,%q,%q) = %q, want %q",
 				tc.version, tc.goos, tc.goarch, got, tc.want)
 		}
+	}
+}
+
+func TestLocateSiblingWatchdog_Found(t *testing.T) {
+	dir := t.TempDir()
+	agentPath := filepath.Join(dir, "breeze-agent")
+	if runtime.GOOS == "windows" {
+		agentPath += ".exe"
+	}
+	if err := os.WriteFile(agentPath, []byte("fake agent"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	siblingPath := filepath.Join(dir, watchdogBinaryName(runtime.GOOS))
+	if err := os.WriteFile(siblingPath, []byte("fake watchdog"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := locateSiblingWatchdog(agentPath)
+	if !ok {
+		t.Fatalf("locateSiblingWatchdog returned ok=false, want true")
+	}
+	if got != siblingPath {
+		t.Errorf("locateSiblingWatchdog = %q, want %q", got, siblingPath)
+	}
+}
+
+func TestLocateSiblingWatchdog_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	agentPath := filepath.Join(dir, "breeze-agent")
+	if err := os.WriteFile(agentPath, []byte("fake agent"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, ok := locateSiblingWatchdog(agentPath)
+	if ok {
+		t.Errorf("locateSiblingWatchdog returned ok=true, want false")
 	}
 }

--- a/agent/cmd/breeze-agent/watchdog_bootstrap_test.go
+++ b/agent/cmd/breeze-agent/watchdog_bootstrap_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -83,5 +85,74 @@ func TestLocateSiblingWatchdog_NotFound(t *testing.T) {
 	_, ok := locateSiblingWatchdog(agentPath)
 	if ok {
 		t.Errorf("locateSiblingWatchdog returned ok=true, want false")
+	}
+}
+
+func TestDownloadWatchdog_Success(t *testing.T) {
+	body := make([]byte, 2*1024*1024)
+	for i := range body {
+		body[i] = byte(i % 256)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	destDir := t.TempDir()
+	destPath := filepath.Join(destDir, "breeze-watchdog")
+
+	if err := downloadWatchdog(srv.URL, destPath); err != nil {
+		t.Fatalf("downloadWatchdog: %v", err)
+	}
+
+	got, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if len(got) != len(body) {
+		t.Errorf("downloaded size = %d, want %d", len(got), len(body))
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(destPath)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if info.Mode().Perm()&0100 == 0 {
+			t.Errorf("downloaded file is not executable: mode=%v", info.Mode())
+		}
+	}
+}
+
+func TestDownloadWatchdog_404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	destPath := filepath.Join(t.TempDir(), "breeze-watchdog")
+	err := downloadWatchdog(srv.URL, destPath)
+	if err == nil {
+		t.Fatalf("downloadWatchdog: expected error on 404, got nil")
+	}
+	if _, statErr := os.Stat(destPath); statErr == nil {
+		t.Errorf("downloadWatchdog: dest file should not exist after failure")
+	}
+}
+
+func TestDownloadWatchdog_TooSmall(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not a real binary"))
+	}))
+	defer srv.Close()
+
+	destPath := filepath.Join(t.TempDir(), "breeze-watchdog")
+	err := downloadWatchdog(srv.URL, destPath)
+	if err == nil {
+		t.Fatalf("downloadWatchdog: expected error on too-small body, got nil")
+	}
+	if _, statErr := os.Stat(destPath); statErr == nil {
+		t.Errorf("downloadWatchdog: dest file should not exist after failure")
 	}
 }

--- a/agent/cmd/breeze-agent/watchdog_bootstrap_test.go
+++ b/agent/cmd/breeze-agent/watchdog_bootstrap_test.go
@@ -1,0 +1,46 @@
+package main
+
+import "testing"
+
+func TestWatchdogBinaryName(t *testing.T) {
+	tests := []struct {
+		goos string
+		want string
+	}{
+		{"windows", "breeze-watchdog.exe"},
+		{"linux", "breeze-watchdog"},
+		{"darwin", "breeze-watchdog"},
+	}
+	for _, tc := range tests {
+		got := watchdogBinaryName(tc.goos)
+		if got != tc.want {
+			t.Errorf("watchdogBinaryName(%q) = %q, want %q", tc.goos, got, tc.want)
+		}
+	}
+}
+
+func TestWatchdogDownloadURL(t *testing.T) {
+	tests := []struct {
+		version, goos, goarch, want string
+	}{
+		{
+			"0.62.24", "windows", "amd64",
+			"https://github.com/LanternOps/breeze/releases/download/v0.62.24/breeze-watchdog-windows-amd64.exe",
+		},
+		{
+			"0.62.24", "linux", "arm64",
+			"https://github.com/LanternOps/breeze/releases/download/v0.62.24/breeze-watchdog-linux-arm64",
+		},
+		{
+			"0.62.24", "darwin", "amd64",
+			"https://github.com/LanternOps/breeze/releases/download/v0.62.24/breeze-watchdog-darwin-amd64",
+		},
+	}
+	for _, tc := range tests {
+		got := watchdogDownloadURL(tc.version, tc.goos, tc.goarch)
+		if got != tc.want {
+			t.Errorf("watchdogDownloadURL(%q,%q,%q) = %q, want %q",
+				tc.version, tc.goos, tc.goarch, got, tc.want)
+		}
+	}
+}

--- a/apps/docs/src/content/docs/agents/installation.mdx
+++ b/apps/docs/src/content/docs/agents/installation.mdx
@@ -128,7 +128,7 @@ When running `breeze-agent service install` manually, the agent fetches the matc
   </TabItem>
 </Tabs>
 
-If a previously agent-only install needs the watchdog added, simply re-run `breeze-agent service install` (without `--no-watchdog`). The agent service is unaffected; only the watchdog is added.
+If a previously agent-only install needs the watchdog added, re-run `breeze-agent service install`. This reinstalls the agent binary and restarts the agent service (safe for upgrades) and registers the missing watchdog. To add *only* the watchdog without touching the agent service, run `breeze-watchdog service install` directly.
 
 ---
 

--- a/apps/docs/src/content/docs/agents/installation.mdx
+++ b/apps/docs/src/content/docs/agents/installation.mdx
@@ -113,6 +113,23 @@ All platform installers (MSI, PKG, and manual service install) include two compo
 
 The watchdog runs alongside the agent as a separate process. You do not need to configure it -- it starts automatically with the agent service. See the [Watchdog documentation](/features/watchdog) for details.
 
+When running `breeze-agent service install` manually, the agent fetches the matching-version watchdog binary from GitHub releases if one is not already present next to the agent executable. If you need to skip this (for example on an air-gapped host), pass `--no-watchdog`:
+
+<Tabs>
+  <TabItem label="Linux / macOS">
+    ```bash
+    sudo ./breeze-agent service install --no-watchdog
+    ```
+  </TabItem>
+  <TabItem label="Windows">
+    ```powershell
+    .\breeze-agent.exe service install --no-watchdog
+    ```
+  </TabItem>
+</Tabs>
+
+If a previously agent-only install needs the watchdog added, simply re-run `breeze-agent service install` (without `--no-watchdog`). The agent service is unaffected; only the watchdog is added.
+
 ---
 
 ## What Enrollment Does


### PR DESCRIPTION
Fixes #407.

## Summary

Before this PR, the Windows MSI and macOS PKG installed both the agent and the watchdog, but `breeze-agent service install` (the CLI path used by the dashboard one-liner) only installed the agent. CLI-installed devices therefore lacked agent self-recovery.

This PR teaches `breeze-agent service install` to bootstrap the watchdog so every install path ends up in the same state (agent + watchdog, both running, both auto-start).

## How it works

1. **Sibling lookup first** — check for `breeze-watchdog[.exe]` next to the running agent binary (covers MSI/PKG/manual side-by-side downloads, no network needed).
2. **Download fallback** — fetch the matching-version watchdog from `https://github.com/LanternOps/breeze/releases/download/v<version>/breeze-watchdog-<os>-<arch>[.exe]` (same pattern as `pkg_darwin.go`). Streams to a temp file with atomic rename, 1 MB sanity floor, 60 s timeout.
3. **Exec `<watchdog> service install`** — reuses the watchdog's existing SCM / systemd / launchd registration logic; no duplication.
4. **Non-fatal failure** — watchdog problems never abort agent install. The warning points at three actionable recovery paths (re-run, manual download + install, `--no-watchdog`).
5. **`--no-watchdog` opt-out** — for air-gapped / explicit-skip scenarios.

## Notes

- No UI changes — the existing dashboard one-liners automatically get the fix.
- Docs updated to reflect the new behavior.
- Dev builds (`version == "" | "dev" | "dev-*"`) short-circuit the download path.

## Test plan

- [x] Cross-compile windows/amd64, linux/amd64, darwin/arm64
- [x] Unit tests for URL construction, sibling lookup, download (success/404/too-small), atomic rename cleanup, dev-version skip (including `dev-<sha>`), exec-failure, sibling-found-runs-install
- [x] `--no-watchdog` flag registered and visible in `service install --help`
- [x] Non-root invocation refused cleanly (bootstrap never runs)
- [ ] Linux systemd host: both units `active (running)` after `sudo breeze-agent service install`
- [ ] Windows VM: `sc query BreezeAgent` + `sc query BreezeWatchdog` both RUNNING after `breeze-agent.exe service install`
- [ ] Re-run repair: agent-only → re-run `service install` → watchdog added

Spec: `docs/superpowers/specs/2026-04-16-cli-install-watchdog-bootstrap-design.md`
Plan: `docs/superpowers/plans/2026-04-16-cli-install-watchdog-bootstrap.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)