### PR TITLE
fix(macos): bootstrap desktop helpers on daemon startup for auto-updated installs

### DIFF
--- a/agent/cmd/breeze-agent/service_cmd_darwin.go
+++ b/agent/cmd/breeze-agent/service_cmd_darwin.go
@@ -424,7 +424,10 @@ var serviceStatusCmd = &cobra.Command{
 }
 
 // healLaunchdPlistsIfNeeded is the darwin implementation.
-func healLaunchdPlistsIfNeeded() { healLaunchdPlists() }
+func healLaunchdPlistsIfNeeded() {
+	healLaunchdPlists()
+	ensureDesktopHelpersLoaded()
+}
 
 // healLaunchdPlists checks the installed plists for the old SuccessfulExit
 // KeepAlive config and replaces them with KeepAlive=true. This runs on daemon
@@ -462,6 +465,60 @@ func healLaunchdPlists() {
 func isLaunchdLoaded(label string) bool {
 	err := exec.Command("launchctl", "print", "system/"+label).Run()
 	return err == nil
+}
+
+// ensureDesktopHelpersLoaded bootstraps the desktop helper LaunchAgents on
+// daemon startup if they aren't already loaded. Covers the case where an
+// existing install was upgraded via binary-only auto-update and thus never
+// re-ran "service install" to load the helper plists into launchd.
+func ensureDesktopHelpersLoaded() {
+	if os.Geteuid() != 0 {
+		return
+	}
+
+	if fileExists(darwinDesktopUserPlistDst) {
+		if uid := consoleUserUID(); uid != "" {
+			domain := "gui/" + uid
+			label := domain + "/com.breeze.desktop-helper-user"
+			if exec.Command("launchctl", "print", label).Run() != nil {
+				out, err := exec.Command("launchctl", "bootstrap", domain, darwinDesktopUserPlistDst).CombinedOutput()
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Note: could not bootstrap desktop helper for console user %s: %s\n",
+						uid, strings.TrimSpace(string(out)))
+				} else {
+					fmt.Printf("Desktop helper bootstrapped for console user uid %s\n", uid)
+				}
+			}
+		}
+	}
+
+	if fileExists(darwinDesktopLoginWindowPlistDst) {
+		lwLabel := "loginwindow/com.breeze.desktop-helper-loginwindow"
+		if exec.Command("launchctl", "print", lwLabel).Run() != nil {
+			out, err := exec.Command("launchctl", "bootstrap", "loginwindow", darwinDesktopLoginWindowPlistDst).CombinedOutput()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Note: could not bootstrap login-window desktop helper: %s\n",
+					strings.TrimSpace(string(out)))
+			} else {
+				fmt.Println("Login-window desktop helper bootstrapped.")
+			}
+		}
+	}
+}
+
+// consoleUserUID returns the UID of the user logged into the macOS console,
+// or empty string if no one is logged in (e.g., the login window is showing,
+// where /dev/console is owned by root).
+func consoleUserUID() string {
+	out, err := exec.Command("stat", "-f", "%u", "/dev/console").Output()
+	if err != nil {
+		return ""
+	}
+	uid := strings.TrimSpace(string(out))
+	if uid == "" || uid == "0" {
+		return ""
+	}
+	return uid
 }
 
 func fileExists(path string) bool {


### PR DESCRIPTION
## Summary
- Closes the auto-update gap for macOS installs enrolled before v0.62.24 where "Helper Not Connected" persists indefinitely (issue #333).
- Adds `ensureDesktopHelpersLoaded()` to the daemon-startup self-heal path so the user + loginwindow helpers get bootstrapped into launchd even when `service install` is never re-run.
- Uses `stat -f %u /dev/console` to find the console user and skips cleanly when no one is logged in or the helpers are already loaded.

## Why
The prior fix (bb3b1301/f7ff72d5/d16e4cf4) only calls `bootstrapDesktopHelperPlists()` from `service install` / `service start`. Binary-only auto-updates replace `/usr/local/bin/breeze-agent` but never re-run those commands, so devices enrolled before the fix landed continue to show "Helper Not Connected" + "native login-window desktop path not ready" even on v0.62.24.

## Test plan
- [ ] Build: \`cd agent && GOOS=darwin go build ./cmd/breeze-agent/...\`
- [ ] On a Monterey host still showing "Helper Not Connected" on v0.62.24+: install this build, restart \`com.breeze.agent\`, verify Desktop Access flips to a connected mode within one heartbeat.
- [ ] Confirm no-op when no user is logged in (loginwindow): daemon should still bootstrap the loginwindow helper and leave the gui/<uid> path untouched.
- [ ] Confirm no-op when helpers are already loaded: no duplicate bootstrap errors in agent.log.

Relates to #333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)