### PR TITLE
fix(agent/desktop): macOS PLI recovery + OpenH264 CPU-bound tuning

### DIFF
--- a/agent/internal/remote/desktop/encoder_openh264.go
+++ b/agent/internal/remote/desktop/encoder_openh264.go
@@ -83,6 +83,20 @@ func newOpenH264Encoder(cfg EncoderConfig) (encoderBackend, error) {
 	return &openH264Encoder{cfg: cfg}, nil
 }
 
+// clampThreads returns a thread count suitable for OpenH264's
+// IMultipleThreadIdc. Realtime H264 sees diminishing returns past 4 threads,
+// and a minimum of 2 lets the encoder overlap slice encode with bitstream
+// emit on even the smallest hosts.
+func clampThreads(n int) int {
+	if n < 2 {
+		return 2
+	}
+	if n > 4 {
+		return 4
+	}
+	return n
+}
+
 // initEncoder creates and configures the OpenH264 encoder. Called lazily on
 // the first Encode() with known dimensions (matching MFT lazy-init pattern).
 func (e *openH264Encoder) initEncoder() error {
@@ -120,8 +134,14 @@ func (e *openH264Encoder) initEncoder() error {
 	params.IRCMode = openh264.RC_BITRATE_MODE
 	params.ISpatialLayerNum = 1
 	params.ITemporalLayerNum = 1
-	params.IMultipleThreadIdc = 1 // single thread for lowest latency
-	params.BEnableFrameSkip = false
+	// Clamp thread count to [2, 4]: realtime H264 sees marginal returns past 4
+	// threads, and leaving headroom avoids stealing CPU from capture/compose
+	// on CPU-bound hosts (e.g., Windows Server VMs with no GPU).
+	params.IMultipleThreadIdc = uint16(clampThreads(runtime.NumCPU()))
+	// Allow the encoder to drop frames when it can't keep up with FPS; without
+	// this, frames queue and end-to-end latency grows without bound on CPU-bound
+	// hosts. Rate control still honors bitrate targets.
+	params.BEnableFrameSkip = true
 	params.BEnableDenoise = false
 	params.BEnableSceneChangeDetect = true
 	params.BEnableBackgroundDetection = true
@@ -131,8 +151,10 @@ func (e *openH264Encoder) initEncoder() error {
 	params.IMinQp = 18
 	params.IMaxQp = 42
 
-	// IDR every 10 seconds
-	idrInterval := uint32(fps * 10)
+	// IDR every 4 seconds — tighter than 10s so packet-loss recovery doesn't
+	// rely solely on PLI, still sparse enough to avoid scene-change-free
+	// keyframes dominating the bitrate budget.
+	idrInterval := uint32(fps * 4)
 	if idrInterval < 30 {
 		idrInterval = 30
 	}

--- a/agent/internal/remote/desktop/encoder_openh264_test.go
+++ b/agent/internal/remote/desktop/encoder_openh264_test.go
@@ -1,0 +1,25 @@
+package desktop
+
+import "testing"
+
+// TestClampThreads locks in the thread-count policy for OpenH264's
+// IMultipleThreadIdc: minimum 2 (so the encoder can overlap slice encode with
+// bitstream emit), maximum 4 (realtime H264 sees marginal returns past 4).
+func TestClampThreads(t *testing.T) {
+	cases := []struct {
+		in, want int
+	}{
+		{0, 2},
+		{1, 2},
+		{2, 2},
+		{3, 3},
+		{4, 4},
+		{8, 4},
+		{64, 4},
+	}
+	for _, tc := range cases {
+		if got := clampThreads(tc.in); got != tc.want {
+			t.Errorf("clampThreads(%d) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}

--- a/agent/internal/remote/desktop/encoder_videotoolbox.go
+++ b/agent/internal/remote/desktop/encoder_videotoolbox.go
@@ -158,7 +158,8 @@ static OSStatus vtEncodeNV12(VTCompressionSessionRef session,
                              int height,
                              int64_t ptsNs,
                              int64_t durNs,
-                             uintptr_t sourceFrameRefCon) {
+                             uintptr_t sourceFrameRefCon,
+                             int forceKeyframe) {
     if (session == NULL || nv12 == NULL || width <= 0 || height <= 0) return -1;
     if (pool == NULL) {
         pool = VTCompressionSessionGetPixelBufferPool(session);
@@ -193,14 +194,28 @@ static OSStatus vtEncodeNV12(VTCompressionSessionRef session,
     CMTime pts = CMTimeMake(ptsNs, 1000000000);
     CMTime dur = CMTimeMake(durNs, 1000000000);
 
+    // Per-frame properties dict: when the caller wants an IDR now (RTCP PLI),
+    // pass kVTEncodeFrameOptionKey_ForceKeyFrame=kCFBooleanTrue so VideoToolbox
+    // emits this frame as a sync/keyframe.
+    CFDictionaryRef frameProps = NULL;
+    if (forceKeyframe) {
+        const void *keys[] = { kVTEncodeFrameOptionKey_ForceKeyFrame };
+        const void *vals[] = { kCFBooleanTrue };
+        frameProps = CFDictionaryCreate(kCFAllocatorDefault,
+                                        keys, vals, 1,
+                                        &kCFTypeDictionaryKeyCallBacks,
+                                        &kCFTypeDictionaryValueCallBacks);
+    }
+
     st = VTCompressionSessionEncodeFrame(session,
                                          pb,
                                          pts,
                                          dur,
-                                         NULL,
+                                         frameProps,
                                          (void *)sourceFrameRefCon,
                                          NULL);
 
+    if (frameProps != NULL) CFRelease(frameProps);
     CVPixelBufferRelease(pb);
     return st;
 }
@@ -339,6 +354,12 @@ type videotoolboxEncoder struct {
 	pool    C.CVPixelBufferPoolRef
 
 	startTime time.Time
+
+	// forceIDR, when true, causes the next Encode to pass
+	// kVTEncodeFrameOptionKey_ForceKeyFrame so VideoToolbox emits a sync
+	// frame. Set by ForceKeyframe (driven by RTCP PLI from the viewer) and
+	// cleared after the encode call is dispatched.
+	forceIDR bool
 }
 
 func init() {
@@ -365,6 +386,8 @@ func (v *videotoolboxEncoder) Encode(frame []byte) ([]byte, error) {
 	stride := v.stride
 	fps := v.cfg.FPS
 	start := v.startTime
+	forceKey := v.forceIDR
+	v.forceIDR = false
 	v.mu.Unlock()
 
 	if session == 0 || width <= 0 || height <= 0 || stride <= 0 {
@@ -396,7 +419,11 @@ func (v *videotoolboxEncoder) Encode(frame []byte) ([]byte, error) {
 		nv12Ptr = (*C.uint8_t)(unsafe.Pointer(&nv12[0]))
 	}
 
-	st := C.vtEncodeNV12(session, pool, nv12Ptr, C.int(width), C.int(height), C.int64_t(ptsNs), C.int64_t(durNs), C.uintptr_t(h))
+	var forceKeyC C.int
+	if forceKey {
+		forceKeyC = 1
+	}
+	st := C.vtEncodeNV12(session, pool, nv12Ptr, C.int(width), C.int(height), C.int64_t(ptsNs), C.int64_t(durNs), C.uintptr_t(h), forceKeyC)
 	if st != 0 {
 		// If encode failed, we own the handle and must delete it.
 		h.Delete()
@@ -555,6 +582,17 @@ func (v *videotoolboxEncoder) SetDimensions(width, height int) error {
 	v.pool = pool
 	v.startTime = time.Now()
 
+	return nil
+}
+
+// ForceKeyframe requests the next encoded frame be an IDR. The flag is
+// consumed by Encode, which passes kVTEncodeFrameOptionKey_ForceKeyFrame to
+// VideoToolbox for that frame. Called from the WebRTC session in response to
+// an RTCP PLI from the viewer.
+func (v *videotoolboxEncoder) ForceKeyframe() error {
+	v.mu.Lock()
+	v.forceIDR = true
+	v.mu.Unlock()
 	return nil
 }
 

--- a/agent/internal/remote/desktop/encoder_videotoolbox_test.go
+++ b/agent/internal/remote/desktop/encoder_videotoolbox_test.go
@@ -1,0 +1,26 @@
+//go:build darwin && cgo
+// +build darwin,cgo
+
+package desktop
+
+import "testing"
+
+// TestVideoToolboxImplementsKeyframeForcer guards the RTCP PLI path: if this
+// assertion regresses, ForceKeyframe on macOS silently becomes a no-op again.
+func TestVideoToolboxImplementsKeyframeForcer(t *testing.T) {
+	var enc encoderBackend = &videotoolboxEncoder{}
+	kf, ok := enc.(optionalKeyframeForcer)
+	if !ok {
+		t.Fatalf("videotoolboxEncoder does not implement optionalKeyframeForcer")
+	}
+	if err := kf.ForceKeyframe(); err != nil {
+		t.Fatalf("ForceKeyframe returned error: %v", err)
+	}
+	// Flag should be set; we can read it without the session being initialized.
+	v := enc.(*videotoolboxEncoder)
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if !v.forceIDR {
+		t.Fatalf("expected forceIDR=true after ForceKeyframe, got false")
+	}
+}


### PR DESCRIPTION
## Summary

Two independent fixes that together explain the artifacting + growing-latency symptom reported on a Windows Server 2022 eval VM (no GPU) and a long-standing hole in macOS PLI recovery.

### a) macOS VideoToolbox — implement `ForceKeyframe`
`VideoEncoder.ForceKeyframe()` in `encoder.go` only dispatches to backends that implement the `optionalKeyframeForcer` interface. The VideoToolbox backend didn't implement it, so every RTCP PLI from the viewer was a silent no-op on macOS. With any packet loss or decoder upset, P-frames kept diffing on a corrupted reference and the viewer's jitter buffer grew waiting for an IDR that never arrived — matching ghost text / color fringing plus progressively increasing latency.

- Added `forceIDR` flag + `ForceKeyframe() error` method on `videotoolboxEncoder`
- Extended the `vtEncodeNV12` CGo helper with a `forceKeyframe` arg; when set it builds a per-frame `CFDictionary` with `kVTEncodeFrameOptionKey_ForceKeyFrame=kCFBooleanTrue` and passes it as `frameProperties` to `VTCompressionSessionEncodeFrame`, then releases it
- Added `encoder_videotoolbox_test.go` (`darwin && cgo`) asserting `*videotoolboxEncoder` satisfies `optionalKeyframeForcer` and that `ForceKeyframe` flips the internal flag — regression guard

### b) OpenH264 tuning for CPU-bound hosts
The Windows Server 2022 VM has no GPU, so encode falls to OpenH264. Previous config was built for lowest latency on fast hosts and handled CPU-bound hosts poorly:

| Param | Before | After | Why |
|---|---|---|---|
| `IMultipleThreadIdc` | `1` | `clampThreads(runtime.NumCPU())` → [2..4] | Serial encode on a multi-core VM was the bottleneck; marginal returns past 4 threads |
| `BEnableFrameSkip` | `false` | `true` | Under load, frames queued instead of dropping → latency grew unbounded |
| `UiIntraPeriod` | `fps*10` (~10s) | `fps*4` (~4s) | Tighter scheduled IDR reduces dependence on PLI for recovery |
| `SSliceArgument.UiSliceMode` | `SM_SINGLE_SLICE` | unchanged | Multi-slice adds WebRTC packetization complexity; defer unless evidence demands it |
| `IComplexityMode` | `MEDIUM_COMPLEXITY` | unchanged | Dropping to LOW costs quality; multi-threading is the bigger win |

- Extracted `clampThreads` helper with a table-driven test covering {0,1,2,3,4,8,64}

## Test plan
- [x] `cd agent && go build ./internal/remote/desktop/...` — darwin, passes
- [x] `cd agent && GOOS=windows go build ./internal/remote/desktop/...` — passes
- [x] `cd agent && go vet ./internal/remote/desktop/...` — passes
- [x] `cd agent && go test ./internal/remote/desktop/... -run "ClampThreads|ForceKeyframe|VideoToolbox|OpenH264" -race -count=1` — passes
- [ ] Smoke: macOS viewer against macOS agent — induce packet loss, confirm PLI → IDR recovery is clean
- [ ] Smoke: viewer against Windows Server / no-GPU Windows host — confirm no progressive latency growth and fewer ghosting artifacts
- [ ] Regression: Windows host with GPU (NVENC/AMF) — unaffected; OpenH264 tuning only takes effect on the software fallback path

## Not included (follow-up candidate)
A companion investigation turned up that the Windows `sessionbroker` rejects helpers whose kernel-verified token SID ≠ `S-1-5-18` when they declare `HelperRoleSystem`. This is working as designed and is **not** the cause of the observed artifacting — the active system helper on the affected VM is running correctly as SYSTEM. Defense-in-depth (log the service's own SID in the spawn message, fail-fast at service startup if not LocalSystem when remote-desktop is enabled, stop the noisy `GDI capture unavailable` loop on headless servers) can go in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)