### PR TITLE
fix(agent): backoff on persistent 401 via authstate.Monitor (#401)

### DIFF
--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/breeze-rmm/agent/internal/audit"
+	"github.com/breeze-rmm/agent/internal/authstate"
 	"github.com/breeze-rmm/agent/internal/collectors"
 	"github.com/breeze-rmm/agent/internal/config"
 	"github.com/breeze-rmm/agent/internal/eventlog"
@@ -344,6 +345,11 @@ func startAgent(cfg *config.Config) (*agentComponents, error) {
 	secureToken := secmem.NewSecureString(cfg.AuthToken)
 	cfg.AuthToken = "" // Clear plaintext from config struct
 
+	// Shared auth-failure monitor — gates heartbeat and log shipper
+	// HTTP calls after 3 consecutive 401s so a deauthorized agent
+	// stops spamming the API (#401).
+	authMon := authstate.NewMonitor(3)
+
 	// Initialize log shipper for centralized diagnostics
 	if cfg.AgentID != "" && cfg.ServerURL != "" {
 		logging.InitShipper(logging.ShipperConfig{
@@ -353,6 +359,7 @@ func startAgent(cfg *config.Config) (*agentComponents, error) {
 			AgentVersion: version,
 			HTTPClient:   nil, // will use default
 			MinLevel:     cfg.LogShippingLevel,
+			AuthMonitor:  authMon,
 		})
 		// Dev builds ship info-level logs for performance tuning and diagnostics.
 		if strings.HasPrefix(version, "dev-") && cfg.LogShippingLevel == "warn" {
@@ -449,6 +456,7 @@ func startAgent(cfg *config.Config) (*agentComponents, error) {
 
 	// Start heartbeat - this implements the main agent run loop
 	hb := heartbeat.NewWithVersion(cfg, version, secureToken, tlsCfg)
+	hb.SetAuthMonitor(authMon)
 
 	// Log agent start audit event (nil-safe: Log() is a no-op on nil receiver)
 	hb.AuditLog().Log(audit.EventAgentStart, "", map[string]any{
@@ -1005,12 +1013,14 @@ func runHelperProcess(name, role, context, binaryKind string) {
 	if cfg.AgentID != "" && cfg.ServerURL != "" && cfg.AuthToken != "" {
 		helperToken := secmem.NewSecureString(cfg.AuthToken)
 		cfg.AuthToken = "" // Clear plaintext from config struct
+		helperAuthMon := authstate.NewMonitor(3)
 		logging.InitShipper(logging.ShipperConfig{
 			ServerURL:    cfg.ServerURL,
 			AgentID:      cfg.AgentID,
 			AuthToken:    helperToken,
 			AgentVersion: version + "-helper",
 			MinLevel:     cfg.LogShippingLevel,
+			AuthMonitor:  helperAuthMon,
 		})
 		// Dev builds ship info-level logs for performance tuning and diagnostics.
 		if strings.HasPrefix(version, "dev-") && cfg.LogShippingLevel == "warn" {

--- a/agent/cmd/breeze-desktop-helper/main.go
+++ b/agent/cmd/breeze-desktop-helper/main.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/breeze-rmm/agent/internal/authstate"
 	"github.com/breeze-rmm/agent/internal/config"
 	"github.com/breeze-rmm/agent/internal/ipc"
 	"github.com/breeze-rmm/agent/internal/logging"
@@ -77,12 +78,14 @@ func runDesktopHelper() {
 	if cfg.AgentID != "" && cfg.ServerURL != "" && cfg.AuthToken != "" {
 		helperToken := secmem.NewSecureString(cfg.AuthToken)
 		cfg.AuthToken = ""
+		authMon := authstate.NewMonitor(3)
 		logging.InitShipper(logging.ShipperConfig{
 			ServerURL:    cfg.ServerURL,
 			AgentID:      cfg.AgentID,
 			AuthToken:    helperToken,
 			AgentVersion: version + "-desktop-helper",
 			MinLevel:     cfg.LogShippingLevel,
+			AuthMonitor:  authMon,
 		})
 		defer logging.StopShipper()
 	}

--- a/agent/internal/authstate/monitor.go
+++ b/agent/internal/authstate/monitor.go
@@ -29,9 +29,9 @@ type Monitor struct {
 
 // NewMonitor creates an auth monitor that trips after `threshold`
 // consecutive 401 responses.
-func NewMonitor(threshold int32) *Monitor {
+func NewMonitor(threshold int) *Monitor {
 	return &Monitor{
-		threshold: threshold,
+		threshold: int32(threshold),
 		backoff:   initialBackoff,
 	}
 }
@@ -40,34 +40,40 @@ func NewMonitor(threshold int32) *Monitor {
 // reaches the threshold, the monitor enters auth-dead state.
 func (m *Monitor) RecordAuthFailure() {
 	n := m.consecutive.Add(1)
-	if n >= m.threshold {
-		if m.dead.CompareAndSwap(false, true) {
-			slog.Warn("auth-dead: consecutive 401s reached threshold, backing off",
-				"consecutive", n, "threshold", m.threshold)
-			// First trip: backoff stays at initialBackoff (1s).
-			return
-		}
-		// Already dead: advance backoff for each additional failure.
-		m.mu.Lock()
-		m.backoff = time.Duration(float64(m.backoff) * backoffFactor)
-		if m.backoff > maxBackoff {
-			m.backoff = maxBackoff
-		}
-		m.mu.Unlock()
+	if n < m.threshold {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	firstTrip := m.dead.CompareAndSwap(false, true)
+	if firstTrip {
+		slog.Warn("auth-dead: consecutive 401s reached threshold, backing off",
+			"consecutive", n, "threshold", m.threshold)
+		// Keep backoff at initialBackoff for the first trip — do NOT advance here.
+		return
+	}
+
+	// Already dead — advance backoff for the subsequent failure.
+	m.backoff = time.Duration(float64(m.backoff) * backoffFactor)
+	if m.backoff > maxBackoff {
+		m.backoff = maxBackoff
 	}
 }
 
 // RecordSuccess clears the auth-dead state and resets the counter
 // and backoff.
 func (m *Monitor) RecordSuccess() {
-	m.consecutive.Store(0)
+	m.mu.Lock()
 	wasDead := m.dead.Swap(false)
+	m.consecutive.Store(0)
+	m.backoff = initialBackoff
+	m.mu.Unlock()
+
 	if wasDead {
 		slog.Info("auth recovered, resuming normal cadence")
 	}
-	m.mu.Lock()
-	m.backoff = initialBackoff
-	m.mu.Unlock()
 }
 
 // ShouldSkip returns true if the agent is in auth-dead state.

--- a/agent/internal/authstate/monitor.go
+++ b/agent/internal/authstate/monitor.go
@@ -1,0 +1,91 @@
+package authstate
+
+import (
+	"log/slog"
+	"math/rand/v2"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	initialBackoff = 1 * time.Second
+	maxBackoff     = 30 * time.Second
+	backoffFactor  = 2.0
+	jitterFrac     = 0.2
+)
+
+// Monitor tracks consecutive HTTP 401 responses across all agent HTTP
+// callers. When the failure count reaches the threshold, ShouldSkip()
+// returns true and callers should skip their HTTP work.
+type Monitor struct {
+	dead        atomic.Bool
+	consecutive atomic.Int32
+	threshold   int32
+
+	mu      sync.Mutex
+	backoff time.Duration
+}
+
+// NewMonitor creates an auth monitor that trips after `threshold`
+// consecutive 401 responses.
+func NewMonitor(threshold int32) *Monitor {
+	return &Monitor{
+		threshold: threshold,
+		backoff:   initialBackoff,
+	}
+}
+
+// RecordAuthFailure records a 401 response. If the consecutive count
+// reaches the threshold, the monitor enters auth-dead state.
+func (m *Monitor) RecordAuthFailure() {
+	n := m.consecutive.Add(1)
+	if n >= m.threshold {
+		if m.dead.CompareAndSwap(false, true) {
+			slog.Warn("auth-dead: consecutive 401s reached threshold, backing off",
+				"consecutive", n, "threshold", m.threshold)
+			// First trip: backoff stays at initialBackoff (1s).
+			return
+		}
+		// Already dead: advance backoff for each additional failure.
+		m.mu.Lock()
+		m.backoff = time.Duration(float64(m.backoff) * backoffFactor)
+		if m.backoff > maxBackoff {
+			m.backoff = maxBackoff
+		}
+		m.mu.Unlock()
+	}
+}
+
+// RecordSuccess clears the auth-dead state and resets the counter
+// and backoff.
+func (m *Monitor) RecordSuccess() {
+	m.consecutive.Store(0)
+	wasDead := m.dead.Swap(false)
+	if wasDead {
+		slog.Info("auth recovered, resuming normal cadence")
+	}
+	m.mu.Lock()
+	m.backoff = initialBackoff
+	m.mu.Unlock()
+}
+
+// ShouldSkip returns true if the agent is in auth-dead state.
+// This is a single atomic read — safe to call on every tick.
+func (m *Monitor) ShouldSkip() bool {
+	return m.dead.Load()
+}
+
+// BackoffDuration returns the current backoff delay with jitter.
+func (m *Monitor) BackoffDuration() time.Duration {
+	m.mu.Lock()
+	base := m.backoff
+	m.mu.Unlock()
+
+	jitter := float64(base) * jitterFrac * (2*rand.Float64() - 1)
+	d := time.Duration(float64(base) + jitter)
+	if d < 0 {
+		return 0
+	}
+	return d
+}

--- a/agent/internal/authstate/monitor_test.go
+++ b/agent/internal/authstate/monitor_test.go
@@ -1,0 +1,121 @@
+package authstate
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestMonitor_NotDeadInitially(t *testing.T) {
+	m := NewMonitor(3)
+	if m.ShouldSkip() {
+		t.Fatal("expected ShouldSkip()=false on fresh monitor")
+	}
+}
+
+func TestMonitor_NotDeadBeforeThreshold(t *testing.T) {
+	m := NewMonitor(3)
+	m.RecordAuthFailure()
+	m.RecordAuthFailure()
+	if m.ShouldSkip() {
+		t.Fatal("expected ShouldSkip()=false after 2 failures (threshold=3)")
+	}
+}
+
+func TestMonitor_DeadAtThreshold(t *testing.T) {
+	m := NewMonitor(3)
+	m.RecordAuthFailure()
+	m.RecordAuthFailure()
+	m.RecordAuthFailure()
+	if !m.ShouldSkip() {
+		t.Fatal("expected ShouldSkip()=true after 3 failures")
+	}
+}
+
+func TestMonitor_SuccessClearsDead(t *testing.T) {
+	m := NewMonitor(3)
+	m.RecordAuthFailure()
+	m.RecordAuthFailure()
+	m.RecordAuthFailure()
+	if !m.ShouldSkip() {
+		t.Fatal("expected dead after 3 failures")
+	}
+	m.RecordSuccess()
+	if m.ShouldSkip() {
+		t.Fatal("expected ShouldSkip()=false after RecordSuccess()")
+	}
+}
+
+func TestMonitor_SuccessResetsCounter(t *testing.T) {
+	m := NewMonitor(3)
+	m.RecordAuthFailure()
+	m.RecordAuthFailure()
+	m.RecordSuccess() // reset
+	m.RecordAuthFailure()
+	m.RecordAuthFailure()
+	if m.ShouldSkip() {
+		t.Fatal("expected not dead — counter was reset by success")
+	}
+}
+
+func TestMonitor_BackoffProgression(t *testing.T) {
+	m := NewMonitor(1) // threshold=1 so first failure trips it
+
+	m.RecordAuthFailure()
+	d1 := m.BackoffDuration()
+	if d1 < 800*time.Millisecond || d1 > 1200*time.Millisecond {
+		t.Fatalf("expected first backoff ~1s, got %v", d1)
+	}
+
+	m.RecordAuthFailure()
+	d2 := m.BackoffDuration()
+	if d2 < 1600*time.Millisecond || d2 > 2400*time.Millisecond {
+		t.Fatalf("expected second backoff ~2s, got %v", d2)
+	}
+}
+
+func TestMonitor_BackoffCapsAt30s(t *testing.T) {
+	m := NewMonitor(1)
+	for i := 0; i < 20; i++ {
+		m.RecordAuthFailure()
+	}
+	d := m.BackoffDuration()
+	if d > 36*time.Second { // 30s + 20% jitter
+		t.Fatalf("expected backoff capped near 30s, got %v", d)
+	}
+}
+
+func TestMonitor_SuccessResetsBackoff(t *testing.T) {
+	m := NewMonitor(1)
+	for i := 0; i < 10; i++ {
+		m.RecordAuthFailure()
+	}
+	m.RecordSuccess()
+	m.RecordAuthFailure() // re-trip
+	d := m.BackoffDuration()
+	if d > 1500*time.Millisecond {
+		t.Fatalf("expected backoff reset to ~1s after success, got %v", d)
+	}
+}
+
+func TestMonitor_ConcurrentAccess(t *testing.T) {
+	m := NewMonitor(3)
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			m.RecordAuthFailure()
+		}()
+		go func() {
+			defer wg.Done()
+			m.ShouldSkip()
+		}()
+		go func() {
+			defer wg.Done()
+			m.RecordSuccess()
+		}()
+	}
+	wg.Wait()
+	// No race detector failures = pass
+}

--- a/agent/internal/authstate/monitor_test.go
+++ b/agent/internal/authstate/monitor_test.go
@@ -80,8 +80,11 @@ func TestMonitor_BackoffCapsAt30s(t *testing.T) {
 		m.RecordAuthFailure()
 	}
 	d := m.BackoffDuration()
-	if d > 36*time.Second { // 30s + 20% jitter
+	if d > 36*time.Second {
 		t.Fatalf("expected backoff capped near 30s, got %v", d)
+	}
+	if d < 24*time.Second {
+		t.Fatalf("expected backoff near 30s cap (>=24s with jitter), got %v", d)
 	}
 }
 

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -172,7 +172,7 @@ type Heartbeat struct {
 	inventoryWg sync.WaitGroup
 	retryCfg    httputil.RetryConfig
 	stopOnce    sync.Once
-	authMon     *authstate.Monitor // NEW
+	authMon     *authstate.Monitor
 
 	// Command deduplication: prevents the same commandId from being
 	// executed twice when delivered via both WebSocket and heartbeat.
@@ -698,6 +698,9 @@ func (h *Heartbeat) Start() {
 			if h.authMon != nil && h.authMon.ShouldSkip() {
 				log.Debug("skipping heartbeat tick, auth-dead",
 					"backoff", h.authMon.BackoffDuration())
+				// continue here re-arms the ticker without running
+				// sendHeartbeatWithWatchdog or any inventory/posture/security
+				// scheduling — all of that work requires a valid auth token.
 				continue
 			}
 			h.sendHeartbeatWithWatchdog()

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -23,6 +23,7 @@ import (
 	"github.com/shirou/gopsutil/v3/host"
 
 	"github.com/breeze-rmm/agent/internal/audit"
+	"github.com/breeze-rmm/agent/internal/authstate"
 	"github.com/breeze-rmm/agent/internal/backupipc"
 	"github.com/breeze-rmm/agent/internal/collectors"
 	"github.com/breeze-rmm/agent/internal/config"
@@ -171,6 +172,7 @@ type Heartbeat struct {
 	inventoryWg sync.WaitGroup
 	retryCfg    httputil.RetryConfig
 	stopOnce    sync.Once
+	authMon     *authstate.Monitor // NEW
 
 	// Command deduplication: prevents the same commandId from being
 	// executed twice when delivered via both WebSocket and heartbeat.
@@ -428,6 +430,11 @@ func NewWithVersion(cfg *config.Config, version string, token *secmem.SecureStri
 // SetWebSocketClient sets the WebSocket client for terminal output streaming
 func (h *Heartbeat) SetWebSocketClient(ws *websocket.Client) {
 	h.wsClient = ws
+}
+
+// SetAuthMonitor sets the shared auth-failure monitor.
+func (h *Heartbeat) SetAuthMonitor(m *authstate.Monitor) {
+	h.authMon = m
 }
 
 // SetStatePath sets the path to the agent state file for heartbeat updates.
@@ -688,6 +695,11 @@ func (h *Heartbeat) Start() {
 	for {
 		select {
 		case <-ticker.C:
+			if h.authMon != nil && h.authMon.ShouldSkip() {
+				log.Debug("skipping heartbeat tick, auth-dead",
+					"backoff", h.authMon.BackoffDuration())
+				continue
+			}
 			h.sendHeartbeatWithWatchdog()
 			now := time.Now()
 			// Send inventory every 15 minutes
@@ -2061,6 +2073,15 @@ func (h *Heartbeat) sendHeartbeat() {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		log.Warn("heartbeat returned 401")
+		h.healthMon.Update("heartbeat", health.Degraded, "unauthorized")
+		if h.authMon != nil {
+			h.authMon.RecordAuthFailure()
+		}
+		return
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		log.Warn("heartbeat returned non-OK status", "status", resp.StatusCode)
 		h.healthMon.Update("heartbeat", health.Degraded, fmt.Sprintf("status %d", resp.StatusCode))
@@ -2068,6 +2089,9 @@ func (h *Heartbeat) sendHeartbeat() {
 	}
 
 	h.healthMon.Update("heartbeat", health.Healthy, "")
+	if h.authMon != nil {
+		h.authMon.RecordSuccess()
+	}
 
 	// Update state file with latest heartbeat timestamp so the watchdog
 	// can detect stale heartbeats.

--- a/agent/internal/logging/shipper.go
+++ b/agent/internal/logging/shipper.go
@@ -22,6 +22,15 @@ type TokenRevealer interface {
 	Reveal() string
 }
 
+// AuthSkipper is implemented by authstate.Monitor. Using an interface
+// here avoids taking on a hard dependency on authstate from the logging
+// package (logging is very low-level and many other packages import it).
+type AuthSkipper interface {
+	ShouldSkip() bool
+	RecordAuthFailure()
+	RecordSuccess()
+}
+
 const (
 	defaultBatchInterval = 60 * time.Second
 	defaultMaxBatchSize  = 500
@@ -52,6 +61,7 @@ type Shipper struct {
 	minLevel     slog.Level
 	mu           sync.RWMutex // protects minLevel
 	droppedCount atomic.Int64
+	authMon      AuthSkipper
 }
 
 // ShipperConfig configures the log shipper.
@@ -62,6 +72,7 @@ type ShipperConfig struct {
 	AgentVersion string
 	HTTPClient   *http.Client
 	MinLevel     string // "debug", "info", "warn", "error"
+	AuthMonitor  AuthSkipper
 }
 
 // NewShipper creates a new log shipper.
@@ -79,6 +90,7 @@ func NewShipper(cfg ShipperConfig) *Shipper {
 		buffer:       make(chan LogEntry, defaultBufferSize),
 		stopChan:     make(chan struct{}),
 		minLevel:     parseLevel(cfg.MinLevel),
+		authMon:      cfg.AuthMonitor,
 	}
 }
 
@@ -175,6 +187,20 @@ const (
 )
 
 func (s *Shipper) shipBatch(entries []LogEntry) {
+	if s.authMon != nil && s.authMon.ShouldSkip() {
+		// Auth-dead: don't drop entries, re-buffer them. If the buffer is
+		// full, drop with count — callers will see the drop count in the
+		// next successful heartbeat.
+		for _, e := range entries {
+			select {
+			case s.buffer <- e:
+			default:
+				s.droppedCount.Add(1)
+			}
+		}
+		return
+	}
+
 	payload, err := json.Marshal(map[string]any{
 		"logs": entries,
 	})
@@ -254,6 +280,9 @@ func (s *Shipper) shipBatch(entries []LogEntry) {
 			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 			resp.Body.Close()
 			cancel()
+			if resp.StatusCode == http.StatusUnauthorized && s.authMon != nil {
+				s.authMon.RecordAuthFailure()
+			}
 			fmt.Fprintf(os.Stderr, "[log-shipper] server returned %d for %d entries: %s\n",
 				resp.StatusCode, len(entries), string(body))
 			s.droppedCount.Add(int64(len(entries)))
@@ -264,6 +293,9 @@ func (s *Shipper) shipBatch(entries []LogEntry) {
 		io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
 		cancel()
+		if s.authMon != nil {
+			s.authMon.RecordSuccess()
+		}
 		return
 	}
 }

--- a/agent/internal/logging/shipper.go
+++ b/agent/internal/logging/shipper.go
@@ -197,11 +197,14 @@ func (s *Shipper) shipBatch(entries []LogEntry) {
 		// stopChan is checked first (priority select) before attempting
 		// the buffer send, because when both are ready Go picks randomly
 		// and we need shutdown to win deterministically.
-		for _, e := range entries {
+		for i, e := range entries {
 			select {
 			case <-s.stopChan:
-				// Shutting down: drop all remaining entries with count.
-				s.droppedCount.Add(int64(len(entries)))
+				// Shutting down: drop entries we haven't re-buffered yet.
+				// Entries [0..i-1] are already back in the buffer and will
+				// be handled by the drain path (which also drops when
+				// auth-dead).
+				s.droppedCount.Add(int64(len(entries) - i))
 				return
 			default:
 			}

--- a/agent/internal/logging/shipper.go
+++ b/agent/internal/logging/shipper.go
@@ -188,10 +188,23 @@ const (
 
 func (s *Shipper) shipBatch(entries []LogEntry) {
 	if s.authMon != nil && s.authMon.ShouldSkip() {
-		// Auth-dead: don't drop entries, re-buffer them. If the buffer is
-		// full, drop with count — callers will see the drop count in the
-		// next successful heartbeat.
+		// Auth-dead: don't drop entries on the ticker path — re-buffer
+		// them so they ship once auth recovers. On the drain path
+		// (stopChan closed) we must NOT re-buffer, or the drain loop
+		// pulls them right back out and hangs forever. Drop with count
+		// in that case.
+		//
+		// stopChan is checked first (priority select) before attempting
+		// the buffer send, because when both are ready Go picks randomly
+		// and we need shutdown to win deterministically.
 		for _, e := range entries {
+			select {
+			case <-s.stopChan:
+				// Shutting down: drop all remaining entries with count.
+				s.droppedCount.Add(int64(len(entries)))
+				return
+			default:
+			}
 			select {
 			case s.buffer <- e:
 			default:

--- a/agent/internal/logging/shipper_auth_test.go
+++ b/agent/internal/logging/shipper_auth_test.go
@@ -1,0 +1,158 @@
+package logging
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// testAuthSkipper is a minimal AuthSkipper for tests.
+type testAuthSkipper struct {
+	skip      atomic.Bool
+	failures  atomic.Int32
+	successes atomic.Int32
+}
+
+func (t *testAuthSkipper) ShouldSkip() bool    { return t.skip.Load() }
+func (t *testAuthSkipper) RecordAuthFailure()  { t.failures.Add(1) }
+func (t *testAuthSkipper) RecordSuccess()      { t.successes.Add(1) }
+
+// testTokenRevealer is a fake TokenRevealer that never reveals anything.
+type testTokenRevealer struct{}
+
+func (testTokenRevealer) Reveal() string { return "test-token" }
+
+func TestShipBatch_SkipsWhenAuthDead(t *testing.T) {
+	// Server that fails the test if called.
+	var called atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Add(1)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	auth := &testAuthSkipper{}
+	auth.skip.Store(true)
+
+	s := NewShipper(ShipperConfig{
+		ServerURL:   srv.URL,
+		AgentID:     "test-agent",
+		AuthToken:   testTokenRevealer{},
+		MinLevel:    "info",
+		AuthMonitor: auth,
+	})
+
+	// Drain the shipper's buffer so we can observe re-buffering.
+	s.shipBatch([]LogEntry{
+		{Timestamp: time.Now(), Level: "info", Message: "entry1"},
+		{Timestamp: time.Now(), Level: "info", Message: "entry2"},
+	})
+
+	if called.Load() != 0 {
+		t.Fatalf("expected 0 HTTP calls while auth-dead, got %d", called.Load())
+	}
+	if auth.failures.Load() != 0 {
+		t.Fatalf("expected no recorded failures (we never hit the network), got %d", auth.failures.Load())
+	}
+	if auth.successes.Load() != 0 {
+		t.Fatalf("expected no recorded successes, got %d", auth.successes.Load())
+	}
+
+	// Re-buffered entries should be sitting in the channel.
+	if len(s.buffer) != 2 {
+		t.Fatalf("expected 2 entries re-buffered, got %d", len(s.buffer))
+	}
+}
+
+func TestShipBatch_RecordsAuthFailureOn401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+	}))
+	defer srv.Close()
+
+	auth := &testAuthSkipper{}
+
+	s := NewShipper(ShipperConfig{
+		ServerURL:   srv.URL,
+		AgentID:     "test-agent",
+		AuthToken:   testTokenRevealer{},
+		MinLevel:    "info",
+		AuthMonitor: auth,
+	})
+
+	s.shipBatch([]LogEntry{
+		{Timestamp: time.Now(), Level: "info", Message: "entry1"},
+	})
+
+	if auth.failures.Load() != 1 {
+		t.Fatalf("expected 1 recorded failure, got %d", auth.failures.Load())
+	}
+	if auth.successes.Load() != 0 {
+		t.Fatalf("expected no successes, got %d", auth.successes.Load())
+	}
+}
+
+func TestShipBatch_RecordsSuccessOn200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	auth := &testAuthSkipper{}
+
+	s := NewShipper(ShipperConfig{
+		ServerURL:   srv.URL,
+		AgentID:     "test-agent",
+		AuthToken:   testTokenRevealer{},
+		MinLevel:    "info",
+		AuthMonitor: auth,
+	})
+
+	s.shipBatch([]LogEntry{
+		{Timestamp: time.Now(), Level: "info", Message: "entry1"},
+	})
+
+	if auth.successes.Load() != 1 {
+		t.Fatalf("expected 1 recorded success, got %d", auth.successes.Load())
+	}
+	if auth.failures.Load() != 0 {
+		t.Fatalf("expected no failures, got %d", auth.failures.Load())
+	}
+}
+
+func TestShipBatch_SkipDropsWhenStopping(t *testing.T) {
+	// Verify the critical shutdown-drain fix: when auth-dead and stopChan
+	// is closed, entries must be dropped (not re-buffered), to prevent
+	// the drain loop from spinning forever.
+	auth := &testAuthSkipper{}
+	auth.skip.Store(true)
+
+	s := NewShipper(ShipperConfig{
+		ServerURL:   "http://unused", // never called
+		AgentID:     "test-agent",
+		AuthToken:   testTokenRevealer{},
+		MinLevel:    "info",
+		AuthMonitor: auth,
+	})
+
+	// Simulate shutdown: close stopChan manually (Stop() would normally
+	// do this and then wait, but we never called Start() so there's no
+	// loop to wait on).
+	close(s.stopChan)
+
+	entries := []LogEntry{
+		{Timestamp: time.Now(), Level: "info", Message: "e1"},
+		{Timestamp: time.Now(), Level: "info", Message: "e2"},
+		{Timestamp: time.Now(), Level: "info", Message: "e3"},
+	}
+	s.shipBatch(entries)
+
+	if len(s.buffer) != 0 {
+		t.Fatalf("expected buffer empty (entries dropped on shutdown drain), got %d buffered", len(s.buffer))
+	}
+	if got := s.droppedCount.Load(); got != 3 {
+		t.Fatalf("expected 3 dropped entries, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the fix for issue #401 — agent spammed every HTTP endpoint at full cadence forever once its token was deauthorized. The work was committed on `fix/agent-401-backoff` on 2026-04-12 and #401 was closed on 2026-04-15, but the branch was **never pushed or merged**. The bug is still present on `main`. Opening this PR to actually land the fix.

New `authstate.Monitor` package tracks consecutive 401s across all agent HTTP callers. After 3 consecutive failures the monitor enters "auth-dead" state, and callers short-circuit their HTTP work via a cheap atomic `ShouldSkip()` check before building a request. Any 200 response clears the state immediately.

### Architecture
- `agent/internal/authstate/monitor.go` — shared monitor (atomic dead flag + mutex-protected backoff). Backoff 1s→30s cap for logging; ticker cadence unchanged so recovery is fast on re-auth.
- `agent/internal/heartbeat/heartbeat.go` — checks `ShouldSkip()` before `sendHeartbeatWithWatchdog()`; records `RecordAuthFailure()` on 401, `RecordSuccess()` on 200. Guards heartbeat + sessions + security + eventlogs + posture + reliability.
- `agent/internal/logging/shipper.go` — local `AuthSkipper` interface (avoids circular import); `shipBatch` re-buffers entries when auth-dead, drops-with-count on shutdown drain to avoid spin loop.
- `agent/cmd/breeze-agent/main.go` + `agent/cmd/breeze-desktop-helper/main.go` — each process gets its own `authstate.NewMonitor(3)`; main agent shares one between heartbeat and log shipper.

WebSocket client was already correct (exponential backoff on any connection failure).

## Test plan
- [x] `go test -race ./internal/authstate/...` — passes (9 unit tests: threshold, backoff progression, 30s cap, success reset, concurrent access)
- [x] `go test -race ./internal/logging/...` — passes (4 new auth tests: skip on auth-dead, record 401/200, drop on shutdown drain)
- [x] `go test -race ./internal/heartbeat/...` — passes
- [x] Clean rebase onto current `main` (no conflicts despite 58 main commits since branch base)
- [ ] Cross-compile windows/amd64, linux/amd64, darwin/arm64 (last verified 2026-04-12; CI will re-verify)
- [ ] Smoke: deauth a dev agent, confirm HTTP request rate drops to backoff cadence within ~3 ticks

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)