### PR TITLE
viewer: extract transports into lib/transports/ (no behavior change)

### DIFF
--- a/apps/viewer/src/components/DesktopViewer.tsx
+++ b/apps/viewer/src/components/DesktopViewer.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { buildWsUrl, type ConnectionParams } from '../lib/protocol';
-import { createDesktopWsTicket, exchangeDesktopConnectCode } from '../lib/api';
+import { type ConnectionParams } from '../lib/protocol';
+import { exchangeDesktopConnectCode } from '../lib/api';
 import { scaleVideoCoords, AgentSessionError, type AuthenticatedConnectionParams } from '../lib/webrtc';
 import { connectWebRTC as connectWebRTCTransport, type WebRTCSessionWrapper } from '../lib/transports/webrtc';
+import { connectWebSocket as connectWebSocketTransport, type WebSocketSessionWrapper } from '../lib/transports/websocket';
 import { mapKey, getModifiers, isModifierOnly } from '../lib/keymap';
 import { textToKeyEvents } from '../lib/paste';
 import { DEFAULT_WHEEL_ACCUMULATOR, wheelDeltaToSteps } from '../lib/wheel';
@@ -25,7 +26,7 @@ const RECONNECT_INTERVAL_MS = 3_000;
 export default function DesktopViewer({ params, onDisconnect, onError }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
-  const wsRef = useRef<WebSocket | null>(null);
+  const wsRef = useRef<WebSocketSessionWrapper | null>(null);
   const webrtcRef = useRef<WebRTCSessionWrapper | null>(null);
   const transportRef = useRef<Transport | null>(null);
   const wsCleanupRef = useRef<(() => void) | null>(null);
@@ -111,6 +112,8 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
   // always prefer the latest pending frame.
   const jpegDecodeInFlightRef = useRef(false);
   const jpegPendingFrameRef = useRef<ArrayBuffer | null>(null);
+  // renderFrame is defined after connectWebSocket; use a ref to break the TDZ.
+  const renderFrameRef = useRef<(data: ArrayBuffer) => void>(() => {});
 
   // ── WebRTC connection ──────────────────────────────────────────────
 
@@ -221,116 +224,59 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
   // ── WebSocket connection (fallback) ────────────────────────────────
 
   const connectWebSocket = useCallback(async (auth: AuthenticatedConnectionParams) => {
-    const wsTicket = await createDesktopWsTicket(auth.apiUrl, auth.accessToken, auth.sessionId);
-    if (!wsTicket) {
+    const canvasEl = canvasRef.current;
+    if (!canvasEl) return null;
+
+    const sessionWrapper = await connectWebSocketTransport(auth, {
+      canvasElement: canvasEl,
+      onConnected: ({ hostname: deviceHostname, osType }) => {
+        if (wsRef.current !== sessionWrapper) return;
+        setStatus('connected');
+        setHostname(deviceHostname);
+        if (osType) setRemoteOs(osType);
+        invoke('update_session_hostname', { hostname: deviceHostname }).catch((err) => {
+          console.warn('Failed to update session hostname:', err);
+        });
+        setConnectedAt(new Date());
+        setErrorMessage(null);
+        canvasRef.current?.focus();
+      },
+      onDisconnected: () => {
+        if (wsRef.current !== sessionWrapper) return;
+        setConnectedAt(null);
+        if (!userDisconnectRef.current) {
+          startReconnectRef.current();
+        } else {
+          setStatus('disconnected');
+        }
+      },
+      onError: (message) => {
+        if (wsRef.current !== sessionWrapper) return;
+        setStatus('error');
+        setConnectedAt(null);
+        setErrorMessage(message);
+        onError(message);
+      },
+      onFrame: (data) => renderFrameRef.current(data),
+    });
+
+    if (!sessionWrapper) {
       setStatus('error');
       setErrorMessage('Failed to create connection ticket');
       onError('Failed to create connection ticket');
       return null;
     }
 
-    const wsUrl = buildWsUrl(auth.apiUrl, auth.sessionId, wsTicket);
-    const ws = new WebSocket(wsUrl);
-    ws.binaryType = 'arraybuffer';
-    wsRef.current = ws;
-
-    let closed = false;
-    let hadError = false;
-
-    // Ping keep-alive
-    const pingInterval = setInterval(() => {
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ type: 'ping' }));
-      }
-    }, 15000);
-
-	    const cleanup = () => {
-	      // Always clear the shared cleanup ref, even if already closed (race-safe).
-	      wsCleanupRef.current = null;
-	      if (closed) return;
-	      closed = true;
-	      clearInterval(pingInterval);
-	      wsRef.current = null;
-	      if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
-	        ws.close();
-	      }
-	    };
-
-	    // Expose cleanup immediately so early onerror/onclose can clear it.
-	    wsCleanupRef.current = cleanup;
-
-    ws.onopen = () => {
-      console.log('Desktop WebSocket connected');
-    };
-
-    ws.onmessage = (event) => {
-      if (event.data instanceof ArrayBuffer) {
-        renderFrame(event.data);
-        return;
-      }
-
-      try {
-        const msg = JSON.parse(event.data);
-        switch (msg.type) {
-          case 'connected':
-            setStatus('connected');
-            const deviceHostname = msg.device?.hostname || 'Unknown';
-            setHostname(deviceHostname);
-            if (msg.device?.osType) {
-              setRemoteOs(msg.device.osType);
-            }
-            // Window title set from Rust in update_session_hostname
-            invoke('update_session_hostname', { hostname: deviceHostname }).catch((err) => {
-              console.warn('Failed to update session hostname:', err);
-            });
-            setConnectedAt(new Date());
-            setErrorMessage(null);
-            // Auto-focus the canvas so keyboard events are captured immediately
-            canvasRef.current?.focus();
-            break;
-          case 'pong':
-            break;
-          case 'error':
-            console.error('Server error:', msg.message);
-            setStatus('error');
-            setConnectedAt(null);
-            setErrorMessage(msg.message || 'Remote desktop error');
-            hadError = true;
-            cleanup();
-            onError(msg.message || 'Remote desktop error');
-            break;
-        }
-	      } catch (err) {
-	        console.warn('Failed to parse websocket message:', err);
-	      }
-	    };
-
-    ws.onclose = () => {
-      // If the effect cleanup already called cleanup() (closed=true), this is
-      // a teardown close, not a network disconnection — skip reconnect.
-      const wasCleanedUp = closed;
-      cleanup();
-      if (wasCleanedUp) return;
-      setConnectedAt(null);
-      if (!hadError && !userDisconnectRef.current) {
-        startReconnectRef.current();
-      } else if (!hadError) {
-        setStatus('disconnected');
-      }
-    };
-
-    ws.onerror = () => {
-      hadError = true;
-      setStatus('error');
-      setErrorMessage('WebSocket connection error');
-      setConnectedAt(null);
-      cleanup();
-      onError('WebSocket connection error');
+    wsRef.current = sessionWrapper;
+    wsCleanupRef.current = () => {
+      wsRef.current = null;
+      wsCleanupRef.current = null;
+      sessionWrapper.close();
     };
 
     setTransportState('websocket');
 
-    return cleanup;
+    return wsCleanupRef.current;
   }, [onError]);
 
   // ── Reconnect logic (refs to break circular deps with hooks defined later) ──
@@ -896,6 +842,8 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
       void processJpegFrames();
     }
   }, [processJpegFrames]);
+  // Keep the ref in sync so connectWebSocket (defined earlier) always calls the latest version.
+  renderFrameRef.current = renderFrame;
 
   // Map browser pixel coordinates to remote screen coordinates.
   const scaleCoordsFn = useCallback((clientX: number, clientY: number) => {
@@ -931,9 +879,9 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
       return;
     }
 
-    const ws = wsRef.current;
-    if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify({ type: 'input', event }));
+    const wsSession = wsRef.current;
+    if (wsSession) {
+      wsSession.inputChannel.send(JSON.stringify(event));
     }
   }, []);
 
@@ -1200,15 +1148,12 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
     setMaxFps(newMaxFps);
 
     if (transport === 'websocket') {
-      const ws = wsRef.current;
-      if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({
-          type: 'config',
-          quality: newQuality,
-          scaleFactor: newScale,
-          maxFps: newMaxFps,
-        }));
-      }
+      wsRef.current?.sendRaw(JSON.stringify({
+        type: 'config',
+        quality: newQuality,
+        scaleFactor: newScale,
+        maxFps: newMaxFps,
+      }));
     } else if (transport === 'webrtc') {
       const ch = webrtcRef.current?.controlChannel;
       if (ch && ch.readyState === 'open') {

--- a/apps/viewer/src/components/DesktopViewer.tsx
+++ b/apps/viewer/src/components/DesktopViewer.tsx
@@ -2,7 +2,8 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { buildWsUrl, type ConnectionParams } from '../lib/protocol';
 import { createDesktopWsTicket, exchangeDesktopConnectCode } from '../lib/api';
-import { createWebRTCSession, scaleVideoCoords, AgentSessionError, type AuthenticatedConnectionParams, type WebRTCSession } from '../lib/webrtc';
+import { scaleVideoCoords, AgentSessionError, type AuthenticatedConnectionParams } from '../lib/webrtc';
+import { connectWebRTC as connectWebRTCTransport, type WebRTCSessionWrapper } from '../lib/transports/webrtc';
 import { mapKey, getModifiers, isModifierOnly } from '../lib/keymap';
 import { textToKeyEvents } from '../lib/paste';
 import { DEFAULT_WHEEL_ACCUMULATOR, wheelDeltaToSteps } from '../lib/wheel';
@@ -25,7 +26,7 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
   const wsRef = useRef<WebSocket | null>(null);
-  const webrtcRef = useRef<WebRTCSession | null>(null);
+  const webrtcRef = useRef<WebRTCSessionWrapper | null>(null);
   const transportRef = useRef<Transport | null>(null);
   const wsCleanupRef = useRef<(() => void) | null>(null);
   const authRef = useRef<AuthenticatedConnectionParams | null>(null);
@@ -67,6 +68,7 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
   const [activeSessionId, setActiveSessionId] = useState<number | null>(params.targetSessionId ?? null);
   const [switchingSession, setSwitchingSession] = useState<string | null>(null);
   const switchingSessionRef = useRef(false);
+  const audioElRef = useRef<HTMLAudioElement | null>(null);
   const [audioEnabled, setAudioEnabled] = useState(false);
   const [hasAudioTrack, setHasAudioTrack] = useState(false);
   const [showRemoteCursor, setShowRemoteCursor] = useState(false);
@@ -116,197 +118,105 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
     const videoEl = videoRef.current;
     if (!videoEl) return false;
 
-	    try {
-	      const session = await createWebRTCSession(auth, videoEl, undefined, targetSessionId ?? params.targetSessionId);
-	      webrtcRef.current = session;
-
-	      // Reduce input lag under loss: coalesce mouse moves, and avoid unbounded buffering.
-	      try {
-	        session.inputChannel.bufferedAmountLowThreshold = 256 * 1024;
-	        session.inputChannel.onbufferedamountlow = () => {
-	          if (webrtcMouseMovePendingRef.current && webrtcMouseMoveRafRef.current === null) {
-	            webrtcMouseMoveRafRef.current = requestAnimationFrame(flushWebRTCMouseMove);
-	          }
-	        };
-	      } catch {
-	        // Some environments may not support these fields.
-	      }
-
-	      // Handle audio tracks from the agent (WASAPI loopback)
-	      const origOnTrack = session.pc.ontrack;
-	      session.pc.ontrack = (event) => {
-	        // Call the original handler from webrtc.ts (wires video)
-	        if (origOnTrack) (origOnTrack as (ev: RTCTrackEvent) => void)(event);
-	        if (event.track.kind === 'audio') {
-	          setHasAudioTrack(true);
-	          // Create a dedicated Audio element for the remote audio track.
-          // The video element's MediaStream (set up in webrtc.ts) only carries
-          // the video track, so audio needs its own playback element.
-		          const audioEl = new Audio();
-		          audioEl.srcObject = new MediaStream([event.track]);
-		          audioEl.muted = true; // start muted (user toggles)
-		          audioEl.play().catch((err) => {
-		            console.warn('Failed to auto-play remote audio track:', err);
-		          });
-		          // Store ref for mute toggle
-		          (session as any)._audioEl = audioEl;
-		        }
-	      };
-
-	      // Monitor connection state
-	      session.pc.onconnectionstatechange = () => {
-	        if (webrtcRef.current !== session) return;
-	        const state = session.pc.connectionState;
-	        if (state === 'connected') {
-	          setStatus('connected');
-	          setConnectedAt(new Date());
-	          setErrorMessage(null);
-	          // Ensure keyboard input is captured without an extra click.
-	          videoRef.current?.focus();
-	        } else if (state === 'failed' || state === 'disconnected') {
-	          // If user clicked disconnect, don't auto-reconnect
-	          if (userDisconnectRef.current) return;
-	          startReconnectRef.current();
-	        } else if (state === 'closed') {
-	          if (userDisconnectRef.current) return;
-	          setStatus('disconnected');
-	          setConnectedAt(null);
-	        }
-	      };
-
-      // Listen for agent-created data channels (cursor, clipboard, filedrop)
-      session.pc.ondatachannel = (event) => {
-        if (event.channel.label === 'cursor') {
-          event.channel.onopen = () => setCursorStreamActive(true);
-          event.channel.onclose = () => setCursorStreamActive(false);
-          event.channel.onmessage = (msg) => {
-            const overlay = cursorOverlayRef.current;
-            const videoEl = videoRef.current;
-            if (!overlay || !videoEl) return;
-
-            try {
-              const data = JSON.parse(msg.data);
-              const { x, y, v, s } = data;
-
-              // Update cursor shape when the agent sends a new shape.
-              // "s" is only included when it differs from the last sent value.
-              const VALID_CURSORS = new Set([
-                'default', 'pointer', 'text', 'crosshair', 'move', 'grab', 'grabbing',
-                'ew-resize', 'ns-resize', 'nwse-resize', 'nesw-resize', 'not-allowed',
-                'wait', 'progress', 'help', 'context-menu', 'cell', 'none',
-              ]);
-              if (s && typeof s === 'string' && VALID_CURSORS.has(s)) {
-                remoteCursorShapeRef.current = s;
-                // Apply CSS cursor to the video element immediately. When the
-                // remote cursor overlay is hidden, the user's OS cursor adopts
-                // the remote shape (text beam, pointer hand, resize arrows, etc.).
-                if (!showRemoteCursorRef.current) {
-                  videoEl.style.cursor = s;
-                }
-              }
-
-              if (!showRemoteCursorRef.current) {
-                overlay.style.display = 'none';
-                return;
-              }
-
-              if (!v) {
-                overlay.style.display = 'none';
-                return;
-              }
-
-              const videoW = videoEl.videoWidth;
-              const videoH = videoEl.videoHeight;
-              if (!videoW || !videoH) return;
-
-              const rect = videoEl.getBoundingClientRect();
-              const containerRect = overlay.parentElement?.getBoundingClientRect();
-              if (!containerRect) return;
-
-              // Same letterboxing math as scaleVideoCoords (remote→local)
-              const videoAspect = videoW / videoH;
-              const rectAspect = rect.width / rect.height;
-              let displayW: number, displayH: number, offsetX: number, offsetY: number;
-              if (rectAspect > videoAspect) {
-                displayH = rect.height;
-                displayW = rect.height * videoAspect;
-                offsetX = (rect.width - displayW) / 2;
-                offsetY = 0;
+    const sessionWrapper = await connectWebRTCTransport(auth, {
+      videoElement: videoEl,
+      cursorOverlayRef,
+      targetSessionId: targetSessionId ?? params.targetSessionId,
+      showRemoteCursorRef,
+      remoteCursorShapeRef,
+      onConnected: () => {
+        // Guard: ignore stale session events after the ref has moved on
+        if (webrtcRef.current !== sessionWrapper) return;
+        setStatus('connected');
+        setConnectedAt(new Date());
+        setErrorMessage(null);
+        // Ensure keyboard input is captured without an extra click.
+        videoRef.current?.focus();
+      },
+      onDisconnected: () => {
+        if (webrtcRef.current !== sessionWrapper) return;
+        if (userDisconnectRef.current) return;
+        startReconnectRef.current();
+      },
+      onFailed: () => {
+        if (webrtcRef.current !== sessionWrapper) return;
+        if (userDisconnectRef.current) return;
+        startReconnectRef.current();
+      },
+      onClosed: () => {
+        if (webrtcRef.current !== sessionWrapper) return;
+        if (userDisconnectRef.current) return;
+        setStatus('disconnected');
+        setConnectedAt(null);
+      },
+      onAudioTrack: (audioEl) => {
+        audioElRef.current = audioEl;
+        setHasAudioTrack(true);
+      },
+      onClipboardChannel: (channel) => {
+        clipboardDCRef.current = channel;
+        channel.onmessage = (msg) => {
+          try {
+            const payload = JSON.parse(msg.data);
+            if (payload.type === 'ack' && payload.hash) {
+              const entry = clipboardAckMapRef.current.get(payload.hash);
+              if (entry) {
+                clearTimeout(entry.timer);
+                clipboardAckMapRef.current.delete(payload.hash);
+                entry.resolve();
               } else {
-                displayW = rect.width;
-                displayH = rect.width / videoAspect;
-                offsetX = 0;
-                offsetY = (rect.height - displayH) / 2;
+                console.debug('[clipboard] ack for unknown hash:', payload.hash);
               }
+            } else if (payload.type === 'text' && payload.text) {
+              lastClipboardHashRef.current = payload.text;
+              // navigator.clipboard.writeText requires a user activation in
+              // WKWebView/WebView2; invoking it from an onmessage handler
+              // silently rejects with NotAllowedError. Route through the
+              // Tauri plugin, which goes via the Rust side and does not
+              // require a gesture.
+              import('@tauri-apps/plugin-clipboard-manager').then(({ writeText }) =>
+                writeText(payload.text)
+              ).catch((err) => {
+                console.warn('[clipboard] failed to write remote→local:', err);
+              });
+            }
+          } catch (err) {
+            console.warn('[clipboard] message handling failed:', err);
+          }
+        };
+        channel.onclose = () => {
+          clipboardDCRef.current = null;
+          for (const entry of clipboardAckMapRef.current.values()) {
+            clearTimeout(entry.timer);
+            entry.resolve();
+          }
+          clipboardAckMapRef.current.clear();
+        };
+      },
+      onCursorChannelOpen: () => setCursorStreamActive(true),
+      onCursorChannelClose: () => setCursorStreamActive(false),
+    });
 
-              const remoteX = Math.max(0, Math.min(videoW - 1, Number(x) || 0));
-              const remoteY = Math.max(0, Math.min(videoH - 1, Number(y) || 0));
-              const localX = (remoteX / videoW) * displayW + offsetX + (rect.left - containerRect.left);
-              const localY = (remoteY / videoH) * displayH + offsetY + (rect.top - containerRect.top);
+    if (!sessionWrapper) return false;
 
-              overlay.style.display = 'block';
-              overlay.style.transform = `translate(${localX}px, ${localY}px)`;
-            } catch (err) {
-              console.debug('Cursor message handling failed:', err);
-            }
-          };
-        } else if (event.channel.label === 'clipboard') {
-          clipboardDCRef.current = event.channel;
-          event.channel.onmessage = (msg) => {
-            try {
-              const payload = JSON.parse(msg.data);
-              if (payload.type === 'ack' && payload.hash) {
-                const entry = clipboardAckMapRef.current.get(payload.hash);
-                if (entry) {
-                  clearTimeout(entry.timer);
-                  clipboardAckMapRef.current.delete(payload.hash);
-                  entry.resolve();
-                } else {
-                  console.debug('[clipboard] ack for unknown hash:', payload.hash);
-                }
-              } else if (payload.type === 'text' && payload.text) {
-                lastClipboardHashRef.current = payload.text;
-                // navigator.clipboard.writeText requires a user activation in
-                // WKWebView/WebView2; invoking it from an onmessage handler
-                // silently rejects with NotAllowedError. Route through the
-                // Tauri plugin, which goes via the Rust side and does not
-                // require a gesture.
-                import('@tauri-apps/plugin-clipboard-manager').then(({ writeText }) =>
-                  writeText(payload.text)
-                ).catch((err) => {
-                  console.warn('[clipboard] failed to write remote→local:', err);
-                });
-              }
-            } catch (err) {
-              console.warn('[clipboard] message handling failed:', err);
-            }
-          };
-          event.channel.onclose = () => {
-            clipboardDCRef.current = null;
-            for (const entry of clipboardAckMapRef.current.values()) {
-              clearTimeout(entry.timer);
-              entry.resolve();
-            }
-            clipboardAckMapRef.current.clear();
-          };
+    webrtcRef.current = sessionWrapper;
+
+    // Reduce input lag under loss: coalesce mouse moves, avoid unbounded buffering.
+    try {
+      sessionWrapper.inputChannel.onbufferedamountlow = () => {
+        if (webrtcMouseMovePendingRef.current && webrtcMouseMoveRafRef.current === null) {
+          webrtcMouseMoveRafRef.current = requestAnimationFrame(flushWebRTCMouseMove);
         }
       };
-
-      setTransportState('webrtc');
-      // Hostname is already set from the exchange response before connectWebRTC is called.
-      // Connection state will flip to 'connected' via onconnectionstatechange
-      return true;
-    } catch (err) {
-      // If the agent reported a session failure (e.g. capture unsupported,
-      // no encoder), propagate it so the viewer shows the real error instead
-      // of silently falling back to WebSocket which will also fail.
-      if (err instanceof AgentSessionError) {
-        throw err;
-      }
-      console.warn('WebRTC connection failed:', err);
-      return false;
+    } catch {
+      // Some environments may not support onbufferedamountlow.
     }
-  }, []);
+
+    setTransportState('webrtc');
+    // Hostname is already set from the exchange response before connectWebRTC is called.
+    // Connection state will flip to 'connected' via onConnected callback.
+    return true;
+  }, [params.targetSessionId]);
 
   // ── WebSocket connection (fallback) ────────────────────────────────
 
@@ -1344,10 +1254,11 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
 
     const prevSession = webrtcRef.current;
     webrtcRef.current = null;
-    const audioEl = (prevSession as any)?._audioEl as HTMLAudioElement | undefined;
+    const audioEl = audioElRef.current;
     if (audioEl) {
       audioEl.pause();
       audioEl.srcObject = null;
+      audioElRef.current = null;
     }
     prevSession?.close();
 
@@ -1385,7 +1296,7 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
     const newEnabled = !audioEnabled;
     setAudioEnabled(newEnabled);
     // Mute/unmute the audio element
-    const audioEl = (webrtcRef.current as any)?._audioEl as HTMLAudioElement | undefined;
+    const audioEl = audioElRef.current;
     if (audioEl) {
       audioEl.muted = !newEnabled;
       if (newEnabled) audioEl.play().catch((err) => {
@@ -1443,12 +1354,13 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
     wsCleanupRef.current?.();
     wsCleanupRef.current = null;
     // Clean up audio element to release MediaStream resources
-    const rtcSession = webrtcRef.current;
-    const audioEl = (rtcSession as any)?._audioEl as HTMLAudioElement | undefined;
+    const audioEl = audioElRef.current;
     if (audioEl) {
       audioEl.pause();
       audioEl.srcObject = null;
+      audioElRef.current = null;
     }
+    const rtcSession = webrtcRef.current;
     webrtcRef.current = null;
     rtcSession?.close();
     onDisconnect();

--- a/apps/viewer/src/lib/transports/types.test.ts
+++ b/apps/viewer/src/lib/transports/types.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import type { TransportSession, TransportCapabilities } from './types';
+import { capabilitiesFor } from './types';
+
+describe('capabilitiesFor', () => {
+  it('returns webrtc capabilities', () => {
+    const c: TransportCapabilities = capabilitiesFor('webrtc');
+    expect(c.monitors).toBe(true);
+    expect(c.bitrateControl).toBe(true);
+    expect(c.audio).toBe(true);
+    expect(c.sas).toBe(true);
+    expect(c.sessionSwitch).toBe(true);
+    expect(c.clipboardChannel).toBe(true);
+  });
+
+  it('returns websocket capabilities', () => {
+    const c = capabilitiesFor('websocket');
+    expect(c.monitors).toBe(false);
+    expect(c.bitrateControl).toBe(false);
+    expect(c.audio).toBe(false);
+    expect(c.sas).toBe(false);
+    expect(c.sessionSwitch).toBe(false);
+    expect(c.clipboardChannel).toBe(false);
+  });
+
+  it('returns vnc capabilities', () => {
+    const c = capabilitiesFor('vnc');
+    expect(c.monitors).toBe(false);
+    expect(c.bitrateControl).toBe(false);
+    expect(c.audio).toBe(false);
+    expect(c.sas).toBe(false);
+    expect(c.sessionSwitch).toBe(false);
+    expect(c.clipboardChannel).toBe(true);
+  });
+});

--- a/apps/viewer/src/lib/transports/types.test.ts
+++ b/apps/viewer/src/lib/transports/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { TransportSession, TransportCapabilities } from './types';
+import type { TransportCapabilities } from './types';
 import { capabilitiesFor } from './types';
 
 describe('capabilitiesFor', () => {

--- a/apps/viewer/src/lib/transports/types.ts
+++ b/apps/viewer/src/lib/transports/types.ts
@@ -1,0 +1,37 @@
+export type TransportKind = 'webrtc' | 'websocket' | 'vnc';
+
+export interface TransportCapabilities {
+  monitors: boolean;
+  bitrateControl: boolean;
+  audio: boolean;
+  sas: boolean;
+  sessionSwitch: boolean;
+  clipboardChannel: boolean;
+}
+
+export interface TransportSession {
+  kind: TransportKind;
+  capabilities: TransportCapabilities;
+  close(): void;
+  inputChannel?: { send(json: string): void; readyState?: string };
+  controlChannel?: {
+    send(json: string): void;
+    addEventListener(event: 'open' | 'message' | 'close', cb: (e: unknown) => void): void;
+    removeEventListener(event: 'open' | 'message' | 'close', cb: (e: unknown) => void): void;
+    readyState: string;
+  };
+  videoElement?: HTMLVideoElement;
+  canvasElement?: HTMLCanvasElement;
+  vncContainer?: HTMLDivElement;
+}
+
+export function capabilitiesFor(kind: TransportKind): TransportCapabilities {
+  switch (kind) {
+    case 'webrtc':
+      return { monitors: true, bitrateControl: true, audio: true, sas: true, sessionSwitch: true, clipboardChannel: true };
+    case 'websocket':
+      return { monitors: false, bitrateControl: false, audio: false, sas: false, sessionSwitch: false, clipboardChannel: false };
+    case 'vnc':
+      return { monitors: false, bitrateControl: false, audio: false, sas: false, sessionSwitch: false, clipboardChannel: true };
+  }
+}

--- a/apps/viewer/src/lib/transports/webrtc.ts
+++ b/apps/viewer/src/lib/transports/webrtc.ts
@@ -1,0 +1,196 @@
+/**
+ * WebRTC transport for remote desktop streaming.
+ * Extracted from DesktopViewer.tsx — pure connection logic, no React.
+ * React refs/state are threaded in via WebRTCDeps callbacks.
+ */
+
+import { createWebRTCSession, AgentSessionError, type AuthenticatedConnectionParams } from '../webrtc';
+import type { TransportSession } from './types';
+import { capabilitiesFor } from './types';
+
+export interface WebRTCDeps {
+  videoElement: HTMLVideoElement;
+  cursorOverlayRef: { readonly current: HTMLDivElement | null };
+  targetSessionId?: number;
+  /** Ref-like objects passed in so the cursor handler reads current values at event time */
+  showRemoteCursorRef: { current: boolean };
+  remoteCursorShapeRef: { current: string };
+  // Lifecycle callbacks — fire unconditionally; caller decides what to do
+  onConnected: () => void;
+  onDisconnected: () => void;
+  onFailed: () => void;
+  onClosed: () => void;
+  // Tracks
+  onAudioTrack: (audioEl: HTMLAudioElement) => void;
+  // Data channels
+  onClipboardChannel: (channel: RTCDataChannel) => void;
+  onCursorChannelOpen: () => void;
+  onCursorChannelClose: () => void;
+}
+
+export interface WebRTCSessionWrapper extends TransportSession {
+  kind: 'webrtc';
+  pc: RTCPeerConnection;
+  videoElement: HTMLVideoElement;
+  controlChannel: RTCDataChannel;
+  inputChannel: RTCDataChannel;
+}
+
+export async function connectWebRTC(
+  auth: AuthenticatedConnectionParams,
+  deps: WebRTCDeps,
+): Promise<WebRTCSessionWrapper | null> {
+  const videoEl = deps.videoElement;
+
+  try {
+    const session = await createWebRTCSession(auth, videoEl, undefined, deps.targetSessionId);
+
+    // Reduce input lag under loss: caller manages mouse-move coalescing via the
+    // returned inputChannel, but set the low-water threshold here so it can hook
+    // onbufferedamountlow after we return.
+    try {
+      session.inputChannel.bufferedAmountLowThreshold = 256 * 1024;
+    } catch {
+      // Some environments may not support this field.
+    }
+
+    // Handle audio tracks from the agent (WASAPI loopback).
+    // pc.ontrack is already set by createWebRTCSession for the video track;
+    // we wrap it to intercept audio tracks without breaking the video wiring.
+    const origOnTrack = session.pc.ontrack;
+    session.pc.ontrack = (event) => {
+      // Call the original handler from webrtc.ts (wires video)
+      if (origOnTrack) (origOnTrack as (ev: RTCTrackEvent) => void)(event);
+      if (event.track.kind === 'audio') {
+        // Create a dedicated Audio element for the remote audio track.
+        // The video element's MediaStream (set up in webrtc.ts) only carries
+        // the video track, so audio needs its own playback element.
+        const audioEl = new Audio();
+        audioEl.srcObject = new MediaStream([event.track]);
+        audioEl.muted = true; // start muted (user toggles)
+        audioEl.play().catch((err) => {
+          console.warn('Failed to auto-play remote audio track:', err);
+        });
+        deps.onAudioTrack(audioEl);
+      }
+    };
+
+    // Monitor connection state — callbacks fire unconditionally.
+    // The caller (React component) decides whether to reconnect based on its
+    // own guards (webrtcRef.current !== session, userDisconnectRef.current).
+    session.pc.onconnectionstatechange = () => {
+      const state = session.pc.connectionState;
+      if (state === 'connected') {
+        deps.onConnected();
+      } else if (state === 'failed') {
+        deps.onFailed();
+      } else if (state === 'disconnected') {
+        deps.onDisconnected();
+      } else if (state === 'closed') {
+        deps.onClosed();
+      }
+    };
+
+    // Listen for agent-created data channels (cursor, clipboard)
+    session.pc.ondatachannel = (event) => {
+      if (event.channel.label === 'cursor') {
+        event.channel.onopen = () => deps.onCursorChannelOpen();
+        event.channel.onclose = () => deps.onCursorChannelClose();
+        event.channel.onmessage = (msg) => {
+          const overlay = deps.cursorOverlayRef.current;
+          if (!overlay || !videoEl) return;
+
+          try {
+            const data = JSON.parse(msg.data);
+            const { x, y, v, s } = data;
+
+            // Update cursor shape when the agent sends a new shape.
+            // "s" is only included when it differs from the last sent value.
+            const VALID_CURSORS = new Set([
+              'default', 'pointer', 'text', 'crosshair', 'move', 'grab', 'grabbing',
+              'ew-resize', 'ns-resize', 'nwse-resize', 'nesw-resize', 'not-allowed',
+              'wait', 'progress', 'help', 'context-menu', 'cell', 'none',
+            ]);
+            if (s && typeof s === 'string' && VALID_CURSORS.has(s)) {
+              deps.remoteCursorShapeRef.current = s;
+              // Apply CSS cursor to the video element immediately. When the
+              // remote cursor overlay is hidden, the user's OS cursor adopts
+              // the remote shape (text beam, pointer hand, resize arrows, etc.).
+              if (!deps.showRemoteCursorRef.current) {
+                videoEl.style.cursor = s;
+              }
+            }
+
+            if (!deps.showRemoteCursorRef.current) {
+              overlay.style.display = 'none';
+              return;
+            }
+
+            if (!v) {
+              overlay.style.display = 'none';
+              return;
+            }
+
+            const videoW = videoEl.videoWidth;
+            const videoH = videoEl.videoHeight;
+            if (!videoW || !videoH) return;
+
+            const rect = videoEl.getBoundingClientRect();
+            const containerRect = overlay.parentElement?.getBoundingClientRect();
+            if (!containerRect) return;
+
+            // Same letterboxing math as scaleVideoCoords (remote→local)
+            const videoAspect = videoW / videoH;
+            const rectAspect = rect.width / rect.height;
+            let displayW: number, displayH: number, offsetX: number, offsetY: number;
+            if (rectAspect > videoAspect) {
+              displayH = rect.height;
+              displayW = rect.height * videoAspect;
+              offsetX = (rect.width - displayW) / 2;
+              offsetY = 0;
+            } else {
+              displayW = rect.width;
+              displayH = rect.width / videoAspect;
+              offsetX = 0;
+              offsetY = (rect.height - displayH) / 2;
+            }
+
+            const remoteX = Math.max(0, Math.min(videoW - 1, Number(x) || 0));
+            const remoteY = Math.max(0, Math.min(videoH - 1, Number(y) || 0));
+            const localX = (remoteX / videoW) * displayW + offsetX + (rect.left - containerRect.left);
+            const localY = (remoteY / videoH) * displayH + offsetY + (rect.top - containerRect.top);
+
+            overlay.style.display = 'block';
+            overlay.style.transform = `translate(${localX}px, ${localY}px)`;
+          } catch (err) {
+            console.debug('Cursor message handling failed:', err);
+          }
+        };
+      } else if (event.channel.label === 'clipboard') {
+        // Hand the channel to the caller — they install onmessage (needs Tauri clipboard write)
+        deps.onClipboardChannel(event.channel);
+      }
+    };
+
+    const wrapper: WebRTCSessionWrapper = {
+      kind: 'webrtc',
+      capabilities: capabilitiesFor('webrtc'),
+      pc: session.pc,
+      videoElement: videoEl,
+      controlChannel: session.controlChannel,
+      inputChannel: session.inputChannel,
+      close: () => session.close(),
+    };
+
+    return wrapper;
+  } catch (err) {
+    // If the agent reported a session failure (e.g. capture unsupported,
+    // no encoder), propagate it so the viewer shows the real error instead
+    // of silently falling back to WebSocket which will also fail.
+    if (err instanceof AgentSessionError) {
+      throw err;
+    }
+    console.warn('WebRTC connection failed:', err);
+    return null;
+  }
+}

--- a/apps/viewer/src/lib/transports/websocket.ts
+++ b/apps/viewer/src/lib/transports/websocket.ts
@@ -1,0 +1,140 @@
+/**
+ * WebSocket JPEG-frame fallback transport for remote desktop.
+ * Extracted from DesktopViewer.tsx — pure connection logic, no React.
+ * React refs/state are threaded in via WebSocketDeps callbacks.
+ */
+
+import { buildWsUrl } from '../protocol';
+import { createDesktopWsTicket } from '../api';
+import type { AuthenticatedConnectionParams } from '../webrtc';
+import type { TransportSession } from './types';
+import { capabilitiesFor } from './types';
+
+export interface WebSocketDeps {
+  canvasElement: HTMLCanvasElement;
+  // Lifecycle
+  onConnected: (info: { hostname: string; osType: string | null }) => void;
+  onDisconnected: () => void;
+  onError: (message: string) => void;
+  // Frames
+  onFrame: (data: ArrayBuffer) => void;
+}
+
+export interface WebSocketSessionWrapper extends TransportSession {
+  kind: 'websocket';
+  canvasElement: HTMLCanvasElement;
+  inputChannel: { send(json: string): void };
+  /** For non-input messages like {type:'config', ...} */
+  sendRaw(text: string): void;
+}
+
+/**
+ * Connects a JPEG-over-WebSocket fallback session.
+ * Returns null if the ticket exchange fails.
+ * Lifecycle callbacks fire unconditionally; React stale-session guards belong in the caller.
+ */
+export async function connectWebSocket(
+  auth: AuthenticatedConnectionParams,
+  deps: WebSocketDeps,
+): Promise<WebSocketSessionWrapper | null> {
+  const wsTicket = await createDesktopWsTicket(auth.apiUrl, auth.accessToken, auth.sessionId);
+  if (!wsTicket) {
+    return null;
+  }
+
+  const wsUrl = buildWsUrl(auth.apiUrl, auth.sessionId, wsTicket);
+  const ws = new WebSocket(wsUrl);
+  ws.binaryType = 'arraybuffer';
+
+  let closed = false;
+  let hadError = false;
+
+  // Ping keep-alive
+  const pingInterval = setInterval(() => {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'ping' }));
+    }
+  }, 15000);
+
+  const cleanup = () => {
+    if (closed) return;
+    closed = true;
+    clearInterval(pingInterval);
+    if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+      ws.close();
+    }
+  };
+
+  ws.onopen = () => {
+    console.log('Desktop WebSocket connected');
+  };
+
+  ws.onmessage = (event) => {
+    if (event.data instanceof ArrayBuffer) {
+      deps.onFrame(event.data);
+      return;
+    }
+
+    try {
+      const msg = JSON.parse(event.data as string) as Record<string, unknown>;
+      switch (msg.type) {
+        case 'connected': {
+          const device = msg.device as Record<string, unknown> | undefined;
+          const hostname = (device?.hostname as string) || 'Unknown';
+          const osType = (device?.osType as string | null) ?? null;
+          deps.onConnected({ hostname, osType });
+          break;
+        }
+        case 'pong':
+          break;
+        case 'error': {
+          console.error('Server error:', msg.message);
+          hadError = true;
+          cleanup();
+          deps.onError((msg.message as string) || 'Remote desktop error');
+          break;
+        }
+      }
+    } catch (err) {
+      console.warn('Failed to parse websocket message:', err);
+    }
+  };
+
+  ws.onclose = () => {
+    // If the caller already invoked cleanup() (closed=true), this is a
+    // teardown close, not a network disconnection — skip disconnect callback.
+    const wasCleanedUp = closed;
+    cleanup();
+    if (wasCleanedUp) return;
+    if (!hadError) {
+      deps.onDisconnected();
+    }
+  };
+
+  ws.onerror = () => {
+    hadError = true;
+    cleanup();
+    deps.onError('WebSocket connection error');
+  };
+
+  const wrapper: WebSocketSessionWrapper = {
+    kind: 'websocket',
+    capabilities: capabilitiesFor('websocket'),
+    canvasElement: deps.canvasElement,
+    inputChannel: {
+      send: (json: string) => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'input', event: JSON.parse(json) as unknown }));
+        }
+      },
+    },
+    sendRaw: (text: string) => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(text);
+      }
+    },
+    close: cleanup,
+  };
+
+  return wrapper;
+}


### PR DESCRIPTION
## Summary
- Pure refactor of `DesktopViewer.tsx` — extracted WebRTC and WebSocket connect logic into `apps/viewer/src/lib/transports/` modules behind a unified `TransportSession` interface.
- Sets up the upcoming in-viewer VNC switcher without further inflating the already-large component.
- No intentional behavior change.

## Contents
- `lib/transports/types.ts` — shared `TransportSession` + `TransportCapabilities` (webrtc / websocket / vnc) + `capabilitiesFor()`.
- `lib/transports/webrtc.ts` — lifted WebRTC connect, audio track handling, cursor overlay data-channel pixel math.
- `lib/transports/websocket.ts` — lifted JPEG/WS fallback; exposes `inputChannel.send()` and `sendRaw()` for the config message.

## Regression fixes caught during review
- `wrapper.audioElement` was captured by value at construction → would have silently broken audio mute + audio cleanup. Component now owns an `audioElRef` populated via `onAudioTrack`.
- Cursor overlay handler originally snapshotted `cursorOverlayRef.current` at deps construction → stale on remount. Fixed by passing the ref object and reading `.current` live.
- WebSocket `onConnected` callback was missing the `wsRef.current !== sessionWrapper` stale-session guard that WebRTC has → reconnect races could flip UI back to "connected" on a zombie session. Added.

## Test plan
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm vitest run` — 51/51 tests pass
- [x] `pnpm build` clean
- [x] Manual smoke on macOS device (WebRTC): video, input, clipboard, audio toggle, monitor switcher

## Related
- Spec + plan tracked in PR #469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)