### PR TITLE
vnc: sunset legacy password path + stream desktop_state to viewers (macOS)

### DIFF
--- a/agent/internal/heartbeat/desktop_handoff_darwin.go
+++ b/agent/internal/heartbeat/desktop_handoff_darwin.go
@@ -24,11 +24,17 @@ func (h *Heartbeat) startDarwinDesktopWatcher() {
 		log.Warn("failed to detect initial console user, assuming login window",
 			"error", err.Error())
 	}
+	var initialConsoleUser string
 	if len(sessions) > 0 {
-		h.sessionBroker.SetConsoleUser(sessions[0].Username)
+		initialConsoleUser = sessions[0].Username
 	} else {
-		h.sessionBroker.SetConsoleUser("loginwindow")
+		initialConsoleUser = "loginwindow"
 	}
+	h.sessionBroker.SetConsoleUser(initialConsoleUser)
+
+	// Broadcast the initial desktop state so any viewer that connects early
+	// knows whether we are at the login window or in a user session.
+	h.broadcastDarwinDesktopState(initialConsoleUser)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
@@ -93,6 +99,10 @@ func (h *Heartbeat) handleDarwinSessionEvent(event sessionbroker.SessionEvent) {
 
 		_ = h.spawnDesktopHelper("")
 		h.reconcileDarwinDesktopOwners("session_" + string(event.Type))
+
+		// Broadcast the new desktop state over any active WebRTC control
+		// channels so the viewer can auto-handoff between WebRTC and VNC.
+		h.broadcastDarwinDesktopState(newConsoleUser)
 	}()
 }
 
@@ -121,6 +131,23 @@ func (h *Heartbeat) reconcileDarwinDesktopOwners(reason string) {
 
 		return true
 	})
+}
+
+// broadcastDarwinDesktopState sends a desktop_state event to every active
+// WebRTC session's control data channel. consoleUser is the current macOS
+// console user as tracked by the session broker: "loginwindow" at the login
+// screen, a real username when a user session is active.
+func (h *Heartbeat) broadcastDarwinDesktopState(consoleUser string) {
+	if h.desktopMgr == nil {
+		return
+	}
+	state := "user_session"
+	userName := consoleUser
+	if consoleUser == "loginwindow" || consoleUser == "" {
+		state = "loginwindow"
+		userName = ""
+	}
+	h.desktopMgr.BroadcastDesktopState(state, userName)
 }
 
 func (h *Heartbeat) disconnectDarwinDesktopOwner(desktopSessionID string, owner *sessionbroker.Session, reason string) {

--- a/agent/internal/heartbeat/handlers_tunnel.go
+++ b/agent/internal/heartbeat/handlers_tunnel.go
@@ -89,8 +89,7 @@ func handleTunnelOpen(h *Heartbeat, cmd Command) tools.CommandResult {
 			}
 		}
 		if managedByPolicy && !running {
-			vncPassword, _ := cmd.Payload["vncPassword"].(string)
-			if err := tunnel.EnableScreenSharing(vncPassword); err != nil {
+			if err := tunnel.EnableScreenSharing(); err != nil {
 				return tools.CommandResult{
 					Status:     "failed",
 					Error:      fmt.Sprintf("failed to enable VNC screen sharing: %s", err.Error()),

--- a/agent/internal/remote/desktop/desktop_state_broadcast.go
+++ b/agent/internal/remote/desktop/desktop_state_broadcast.go
@@ -1,0 +1,62 @@
+package desktop
+
+import (
+	"encoding/json"
+	"log/slog"
+
+	"github.com/pion/webrtc/v4"
+)
+
+// BroadcastDesktopState sends a desktop_state event over the control data
+// channel of every active WebRTC desktop session. No-op when no sessions are
+// active or when a session's control channel is not yet open.
+//
+// Called from the macOS handoff reconciler (heartbeat/desktop_handoff_darwin.go)
+// on helper attach and on every login/logout/fast-user-switch event. The viewer
+// uses these events to decide whether to auto-fall-back to VNC (loginwindow) or
+// offer a switch back to WebRTC (user_session).
+//
+// state must be "loginwindow" or "user_session".
+// userName is included in the message only when non-empty.
+func (m *SessionManager) BroadcastDesktopState(state string, userName string) {
+	msg := map[string]any{
+		"type":  "desktop_state",
+		"state": state,
+	}
+	if userName != "" {
+		msg["userName"] = userName
+	}
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		slog.Warn("BroadcastDesktopState: failed to marshal message", "error", err.Error())
+		return
+	}
+
+	m.mu.RLock()
+	sessions := make([]*Session, 0, len(m.sessions))
+	for _, s := range m.sessions {
+		sessions = append(sessions, s)
+	}
+	m.mu.RUnlock()
+
+	for _, s := range sessions {
+		s.mu.RLock()
+		dc := s.controlDC
+		active := s.isActive
+		s.mu.RUnlock()
+
+		if !active || dc == nil {
+			continue
+		}
+		if dc.ReadyState() != webrtc.DataChannelStateOpen {
+			continue
+		}
+		if err := dc.SendText(string(payload)); err != nil {
+			slog.Warn("BroadcastDesktopState: send failed",
+				"session", s.id,
+				"state", state,
+				"error", err.Error(),
+			)
+		}
+	}
+}

--- a/agent/internal/remote/desktop/desktop_state_broadcast.go
+++ b/agent/internal/remote/desktop/desktop_state_broadcast.go
@@ -19,14 +19,13 @@ import (
 // state must be "loginwindow" or "user_session".
 // userName is included in the message only when non-empty.
 func (m *SessionManager) BroadcastDesktopState(state string, userName string) {
-	msg := map[string]any{
-		"type":  "desktop_state",
-		"state": state,
-	}
-	if userName != "" {
-		msg["userName"] = userName
-	}
-	payload, err := json.Marshal(msg)
+	// Cache the state so late-connecting viewers receive it on control-channel open.
+	m.mu.Lock()
+	m.lastDesktopState = state
+	m.lastDesktopUsername = userName
+	m.mu.Unlock()
+
+	payload, err := buildDesktopStatePayload(state, userName)
 	if err != nil {
 		slog.Warn("BroadcastDesktopState: failed to marshal message", "error", err.Error())
 		return
@@ -59,4 +58,59 @@ func (m *SessionManager) BroadcastDesktopState(state string, userName string) {
 			)
 		}
 	}
+}
+
+// SendDesktopStateTo sends the current cached desktop state to a single session
+// identified by sessionID. No-op when the session is not found, its control
+// channel is not open, or no state has been cached yet.
+//
+// Called when a new viewer's control data channel opens so it receives an
+// immediate initial state without waiting for the next event-driven broadcast.
+func (m *SessionManager) SendDesktopStateTo(sessionID string) {
+	m.mu.RLock()
+	state := m.lastDesktopState
+	userName := m.lastDesktopUsername
+	session := m.sessions[sessionID]
+	m.mu.RUnlock()
+
+	if state == "" || session == nil {
+		return
+	}
+
+	payload, err := buildDesktopStatePayload(state, userName)
+	if err != nil {
+		slog.Warn("SendDesktopStateTo: failed to marshal message", "session", sessionID, "error", err.Error())
+		return
+	}
+
+	session.mu.RLock()
+	dc := session.controlDC
+	active := session.isActive
+	session.mu.RUnlock()
+
+	if !active || dc == nil {
+		return
+	}
+	if dc.ReadyState() != webrtc.DataChannelStateOpen {
+		return
+	}
+	if err := dc.SendText(string(payload)); err != nil {
+		slog.Warn("SendDesktopStateTo: send failed",
+			"session", sessionID,
+			"state", state,
+			"error", err.Error(),
+		)
+	}
+}
+
+// buildDesktopStatePayload marshals a desktop_state control message.
+func buildDesktopStatePayload(state, userName string) ([]byte, error) {
+	msg := map[string]any{
+		"type":  "desktop_state",
+		"state": state,
+	}
+	if userName != "" {
+		msg["username"] = userName
+	}
+	return json.Marshal(msg)
 }

--- a/agent/internal/remote/desktop/session.go
+++ b/agent/internal/remote/desktop/session.go
@@ -152,6 +152,12 @@ type SessionManager struct {
 	// Failed or Closed. Used to notify the API so it can mark the session as
 	// disconnected and allow reconnection.
 	OnSessionStopped func(sessionID string)
+
+	// lastDesktopState caches the most recently broadcast desktop state so
+	// late-connecting viewers can receive an initial state when their control
+	// channel opens. Protected by mu.
+	lastDesktopState    string
+	lastDesktopUsername string
 }
 
 // NewSessionManager creates a new session manager.

--- a/agent/internal/remote/desktop/session_webrtc.go
+++ b/agent/internal/remote/desktop/session_webrtc.go
@@ -410,6 +410,13 @@ func (m *SessionManager) StartSession(sessionID string, offer string, iceServers
 			dc.OnMessage(func(msg webrtc.DataChannelMessage) {
 				session.handleControlMessage(msg.Data)
 			})
+			dc.OnOpen(func() {
+				// Send the current cached desktop state to this viewer so it
+				// gets an initial state even if it connected after the watcher
+				// quiesced. Non-darwin platforms have no cached state and this
+				// is a no-op.
+				m.SendDesktopStateTo(sessionID)
+			})
 		}
 	})
 

--- a/agent/internal/tunnel/vnc_darwin.go
+++ b/agent/internal/tunnel/vnc_darwin.go
@@ -24,33 +24,26 @@ func IsScreenSharingSupported() bool {
 
 // ErrScreenSharingRequiresManualEnable indicates that kickstart refused to
 // enable Screen Sharing programmatically — the user (or MDM) must enable it
-// via System Settings > General > Sharing > Screen Sharing, and set a VNC
-// legacy password under "Computer Settings…".
+// via System Settings > General > Sharing > Screen Sharing.
 var ErrScreenSharingRequiresManualEnable = fmt.Errorf(
 	"macOS Screen Sharing is not enabled and kickstart cannot enable it on this macOS version. " +
-		"Enable it in System Settings > General > Sharing > Screen Sharing, click Options…, turn on " +
-		"\"VNC viewers may control screen with password\", and set a password")
+		"Enable it in System Settings > General > Sharing > Screen Sharing.")
 
-// EnableScreenSharing enables macOS Screen Sharing (VNC) with an optional
-// VNC legacy password. If password is empty, VNC legacy auth is not configured.
-// The agent runs as root, so kickstart works without sudo.
+// EnableScreenSharing enables macOS Screen Sharing (VNC). Auth is delegated
+// to whatever the user / MDM has configured — typically Apple Remote Desktop
+// (the user authenticates with their macOS account credentials when the
+// noVNC client prompts).
 //
 // On recent macOS (13+), Apple's kickstart tool can no longer flip Screen
-// Sharing on from a non-interactive / LaunchDaemon context — it exits with
-// "Screen Sharing or Remote Management must be enabled from System Settings
-// or via MDM" and a Perl nil-pointer error. If Screen Sharing is already
-// running (user enabled it manually or via MDM), we skip kickstart entirely
-// and use the existing listener. In that case `password` is ignored — the
-// VNC session authenticates with whatever the user configured.
-func EnableScreenSharing(password string) error {
-	// Fast path: if port 5900 is already listening, Screen Sharing is already
-	// on. This is the modern macOS path where the user enabled it manually.
+// Sharing on from a non-interactive / LaunchDaemon context. The fast path
+// checks if port 5900 is already listening and returns nil if so.
+func EnableScreenSharing() error {
 	if isPortListening("127.0.0.1", vncPort) {
 		log.Info("macOS Screen Sharing already running — skipping kickstart")
 		return nil
 	}
 
-	log.Info("enabling macOS Screen Sharing via kickstart", "hasPassword", password != "")
+	log.Info("enabling macOS Screen Sharing via kickstart")
 
 	args := []string{
 		"-activate",
@@ -59,23 +52,13 @@ func EnableScreenSharing(password string) error {
 		"-privs", "-all",
 	}
 
-	if password != "" {
-		args = append(args, "-configure", "-clientopts",
-			"-setvnclegacy", "-vnclegacy", "yes",
-			"-setvncpw", "-vncpw", password,
-		)
-	}
-
 	cmd := exec.Command(kickstartPath, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		// Atomic rollback: disable if enable failed partway
 		if rollbackErr := DisableScreenSharing(); rollbackErr != nil {
 			log.Error("rollback of screen sharing failed — port may be left open",
 				"enableError", err.Error(), "rollbackError", rollbackErr.Error())
 		}
-		// Recent macOS: surface a friendly error the UI can show the user
-		// instead of the raw Perl crash.
 		if strings.Contains(string(output), "must be enabled from System Settings") ||
 			strings.Contains(string(output), "Can't call method") {
 			return ErrScreenSharingRequiresManualEnable
@@ -83,12 +66,9 @@ func EnableScreenSharing(password string) error {
 		return fmt.Errorf("kickstart failed: %w (output: %s)", err, string(output))
 	}
 
-	// Give the VNC server a moment to start listening.
 	time.Sleep(vncCheckDelay)
-
 	if !isPortListening("127.0.0.1", vncPort) {
 		portErr := fmt.Errorf("VNC server not listening on port %d after kickstart", vncPort)
-		// Atomic rollback: disable if port never came up
 		if rollbackErr := DisableScreenSharing(); rollbackErr != nil {
 			log.Error("rollback of screen sharing failed — port may be left open",
 				"enableError", portErr.Error(), "rollbackError", rollbackErr.Error())
@@ -105,11 +85,15 @@ func EnableScreenSharing(password string) error {
 func DisableScreenSharing() error {
 	log.Info("disabling macOS Screen Sharing via kickstart")
 
-	// Clear VNC legacy password before deactivating
+	// Clear any legacy VNC password left over from older agent versions that
+	// supported ephemeral per-session passwords. Idempotent — no-op when unset.
+	// We standardize on ARD authentication (macOS user accounts) so any
+	// legacy password must not linger on upgraded hosts.
 	clearCmd := exec.Command(kickstartPath, "-configure", "-clientopts",
 		"-setvnclegacy", "-vnclegacy", "no")
 	if output, err := clearCmd.CombinedOutput(); err != nil {
-		log.Warn("failed to clear VNC legacy password", "error", err.Error(), "output", string(output))
+		log.Warn("failed to clear legacy VNC password (older agent residue)",
+			"error", err.Error(), "output", string(output))
 	}
 
 	cmd := exec.Command(kickstartPath, "-deactivate", "-stop")
@@ -117,7 +101,6 @@ func DisableScreenSharing() error {
 	if err != nil {
 		return fmt.Errorf("kickstart deactivate failed: %w (output: %s)", err, string(output))
 	}
-
 	log.Info("macOS Screen Sharing disabled")
 	return nil
 }

--- a/agent/internal/tunnel/vnc_other.go
+++ b/agent/internal/tunnel/vnc_other.go
@@ -9,7 +9,7 @@ func IsScreenSharingSupported() bool {
 
 // EnableScreenSharing is a no-op on non-macOS platforms.
 // VNC tunnels can still work if a VNC server is running.
-func EnableScreenSharing(_ string) error {
+func EnableScreenSharing() error {
 	return nil
 }
 

--- a/apps/api/src/routes/tunnels.test.ts
+++ b/apps/api/src/routes/tunnels.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import { tunnelRoutes } from './tunnels';
+
+// --- UUID constants ---
+const DEVICE_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+const ORG_ID    = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const USER_ID   = 'uuuuuuuu-uuuu-4uuu-8uuu-uuuuuuuuuuuu';
+const SESSION_ID = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
+
+// --- DB mock ---
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+  runOutsideDbContext: vi.fn((fn: () => any) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => any) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  tunnelSessions: {},
+  tunnelAllowlists: {},
+  devices: {},
+  users: {},
+}));
+
+// --- Auth middleware ---
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', {
+      scope: 'organization',
+      partnerId: null,
+      orgId: ORG_ID,
+      user: { id: USER_ID, email: 'test@example.com' },
+      canAccessOrg: (id: string) => id === ORG_ID,
+    });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+// --- Agent WS helpers ---
+vi.mock('./agentWs', () => ({
+  sendCommandToAgent: vi.fn(() => true),
+  isAgentConnected: vi.fn(() => true),
+}));
+
+// --- Remote access policy ---
+vi.mock('../services/remoteAccessPolicy', () => ({
+  checkRemoteAccess: vi.fn(async () => ({ allowed: true })),
+}));
+
+// --- WS ticket ---
+vi.mock('../services/remoteSessionAuth', () => ({
+  createWsTicket: vi.fn(async () => 'ws-ticket-abc'),
+}));
+
+import { db } from '../db';
+import { sendCommandToAgent } from './agentWs';
+
+// Reusable device fixture (online, agent connected)
+const onlineDevice = {
+  id: DEVICE_ID,
+  orgId: ORG_ID,
+  agentId: 'agent-abc',
+  status: 'online',
+};
+
+// Reusable session fixture (what the DB insert returns)
+const sessionRecord = {
+  id: SESSION_ID,
+  deviceId: DEVICE_ID,
+  userId: USER_ID,
+  orgId: ORG_ID,
+  type: 'vnc',
+  status: 'pending',
+  targetHost: '127.0.0.1',
+  targetPort: 5900,
+  sourceIp: '127.0.0.1',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  endedAt: null,
+  errorMessage: null,
+};
+
+/**
+ * makeSelectChain — resolves `rows` for both:
+ *   db.select().from(t).where(cond).limit(n)  → device lookup
+ *   db.select().from(t).where(cond)            → allowlist queries (awaited directly)
+ */
+function makeSelectChain(rows: any[]) {
+  const whereResult = Object.assign(Promise.resolve(rows), {
+    limit: vi.fn().mockResolvedValue(rows),
+    orderBy: vi.fn().mockReturnValue({
+      limit: vi.fn().mockResolvedValue(rows),
+    }),
+  });
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue(whereResult),
+    }),
+  };
+}
+
+function makeInsertChain(rows: any[]) {
+  return {
+    values: vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue(rows),
+    }),
+  };
+}
+
+describe('POST /tunnels (VNC)', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/tunnels', tunnelRoutes);
+
+    // Default select: device lookup returns onlineDevice, allowlist returns []
+    vi.mocked(db.select)
+      .mockReturnValueOnce(makeSelectChain([onlineDevice]) as any)  // device lookup
+      .mockReturnValueOnce(makeSelectChain([]) as any);              // source-IP allowlist (no rules = allowed)
+
+    // Insert returns the session record
+    vi.mocked(db.insert).mockReturnValue(makeInsertChain([sessionRecord]) as any);
+  });
+
+  it('does not include vncPassword in the 201 response body (ARD auth is used at the client)', async () => {
+    const res = await app.request('/tunnels', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ deviceId: DEVICE_ID, type: 'vnc' }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body).not.toHaveProperty('vncPassword');
+  });
+
+  it('does not include vncPassword in the tunnel_open command payload sent to the agent', async () => {
+    const res = await app.request('/tunnels', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ deviceId: DEVICE_ID, type: 'vnc' }),
+    });
+
+    expect(res.status).toBe(201);
+
+    // Verify the command dispatched to the agent has no vncPassword
+    expect(sendCommandToAgent).toHaveBeenCalledOnce();
+    const [, command] = vi.mocked(sendCommandToAgent).mock.calls[0]!;
+    expect(command.payload).not.toHaveProperty('vncPassword');
+  });
+
+  it('returns session fields in the 201 response body', async () => {
+    const res = await app.request('/tunnels', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ deviceId: DEVICE_ID, type: 'vnc' }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body).toHaveProperty('id', SESSION_ID);
+    expect(body).toHaveProperty('type', 'vnc');
+    expect(body).toHaveProperty('status', 'pending');
+  });
+});

--- a/apps/api/src/routes/tunnels.ts
+++ b/apps/api/src/routes/tunnels.ts
@@ -1,4 +1,3 @@
-import { randomBytes } from 'node:crypto';
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
@@ -243,9 +242,6 @@ tunnelRoutes.post(
       })
       .returning();
 
-    // Generate ephemeral VNC password for JIT Screen Sharing
-    const vncPassword = isVNC ? randomBytes(6).toString('base64url').slice(0, 8) : undefined;
-
     // Send tunnel_open command to agent
     const allowlistPatterns = isVNC ? [] : await getActiveAllowlistPatterns(device.orgId);
     const sent = sendCommandToAgent(device.agentId!, {
@@ -257,7 +253,6 @@ tunnelRoutes.post(
         targetPort,
         tunnelType: body.type,
         allowlistRules: allowlistPatterns,
-        ...(vncPassword && { vncPassword }),
       },
     });
     if (!sent) {
@@ -267,7 +262,7 @@ tunnelRoutes.post(
       return c.json({ error: 'Agent disconnected before tunnel could be opened' }, 503);
     }
 
-    return c.json({ ...session, ...(vncPassword && { vncPassword }) }, 201);
+    return c.json(session, 201);
   }
 );
 

--- a/apps/viewer/src/lib/tunnel.test.ts
+++ b/apps/viewer/src/lib/tunnel.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createVncTunnel, closeTunnel } from './tunnel';
+
+type FetchResponse = { status: number; body: unknown };
+
+function makeFetch(responses: FetchResponse[]) {
+  let i = 0;
+  return vi.fn(async () => {
+    const r = responses[i++];
+    return new Response(r.body == null ? null : JSON.stringify(r.body), { status: r.status });
+  });
+}
+
+describe('createVncTunnel', () => {
+  beforeEach(() => { vi.restoreAllMocks(); });
+
+  it('POSTs /tunnels then /tunnels/:id/ws-ticket and returns a wss:// url for https apiUrl', async () => {
+    const fetchMock = makeFetch([
+      { status: 201, body: { id: 'tun-123' } },
+      { status: 200, body: { ticket: 'tkt-abc' } },
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await createVncTunnel('dev-1', {
+      apiUrl: 'https://api.example.com',
+      accessToken: 'token-xyz',
+    });
+
+    expect(res).toEqual({
+      tunnelId: 'tun-123',
+      wsUrl: 'wss://api.example.com/api/v1/tunnel-ws/tun-123/ws?ticket=tkt-abc',
+    });
+
+    const calls = fetchMock.mock.calls as unknown as Array<[string, RequestInit]>;
+    expect(calls[0][0]).toBe('https://api.example.com/tunnels');
+    expect(calls[0][1].method).toBe('POST');
+    const body = JSON.parse(calls[0][1].body as string);
+    expect(body).toEqual({ deviceId: 'dev-1', type: 'vnc' });
+    expect((calls[0][1].headers as Record<string, string>).Authorization).toBe('Bearer token-xyz');
+    expect((calls[0][1].headers as Record<string, string>)['Content-Type']).toBe('application/json');
+
+    expect(calls[1][0]).toBe('https://api.example.com/tunnels/tun-123/ws-ticket');
+    expect(calls[1][1].method).toBe('POST');
+    expect((calls[1][1].headers as Record<string, string>).Authorization).toBe('Bearer token-xyz');
+  });
+
+  it('uses ws:// when apiUrl is http://', async () => {
+    vi.stubGlobal('fetch', makeFetch([
+      { status: 201, body: { id: 'tun-9' } },
+      { status: 200, body: { ticket: 'tkt-9' } },
+    ]));
+    const res = await createVncTunnel('dev-x', { apiUrl: 'http://localhost:3000', accessToken: 'tok' });
+    expect(res.wsUrl).toBe('ws://localhost:3000/api/v1/tunnel-ws/tun-9/ws?ticket=tkt-9');
+  });
+
+  it('throws when POST /tunnels returns non-ok with an error message from the body', async () => {
+    vi.stubGlobal('fetch', makeFetch([{ status: 403, body: { error: 'policy denied' } }]));
+    await expect(createVncTunnel('dev-1', { apiUrl: 'https://x', accessToken: 't' }))
+      .rejects.toThrow(/policy denied/);
+  });
+
+  it('throws a generic error when POST /tunnels returns non-ok with no parseable body', async () => {
+    vi.stubGlobal('fetch', makeFetch([{ status: 500, body: null }]));
+    await expect(createVncTunnel('dev-1', { apiUrl: 'https://x', accessToken: 't' }))
+      .rejects.toThrow(/500/);
+  });
+
+  it('closes the tunnel (best effort) when the ws-ticket call fails', async () => {
+    const fetchMock = makeFetch([
+      { status: 201, body: { id: 'tun-zz' } },
+      { status: 500, body: null },
+      { status: 204, body: null }, // DELETE cleanup
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(createVncTunnel('dev-1', { apiUrl: 'https://api.example.com', accessToken: 'tok' }))
+      .rejects.toThrow(/ticket/);
+
+    // Third call should be DELETE to clean up the dangling tunnel
+    const calls = fetchMock.mock.calls as unknown as Array<[string, RequestInit]>;
+    expect(calls[2][0]).toBe('https://api.example.com/tunnels/tun-zz');
+    expect(calls[2][1].method).toBe('DELETE');
+  });
+});
+
+describe('closeTunnel', () => {
+  beforeEach(() => { vi.restoreAllMocks(); });
+
+  it('DELETEs /tunnels/:id with Bearer auth', async () => {
+    const fetchMock = makeFetch([{ status: 204, body: null }]);
+    vi.stubGlobal('fetch', fetchMock);
+    await closeTunnel('tun-1', { apiUrl: 'https://api.example.com', accessToken: 'tok' });
+    const calls = fetchMock.mock.calls as unknown as Array<[string, RequestInit]>;
+    expect(calls[0][0]).toBe('https://api.example.com/tunnels/tun-1');
+    expect(calls[0][1].method).toBe('DELETE');
+    expect((calls[0][1].headers as Record<string, string>).Authorization).toBe('Bearer tok');
+  });
+
+  it('swallows errors so callers can safely call it on cleanup paths', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network gone'); }));
+    await expect(closeTunnel('tun-2', { apiUrl: 'https://x', accessToken: 't' })).resolves.toBeUndefined();
+  });
+});

--- a/apps/viewer/src/lib/tunnel.ts
+++ b/apps/viewer/src/lib/tunnel.ts
@@ -1,0 +1,62 @@
+export interface TunnelAuth {
+  apiUrl: string;
+  accessToken: string;
+}
+
+export interface VncTunnelInfo {
+  tunnelId: string;
+  wsUrl: string;
+}
+
+/**
+ * Creates a VNC tunnel to the device and fetches a WS ticket in one call.
+ * On ws-ticket failure, attempts to DELETE the dangling tunnel before throwing.
+ */
+export async function createVncTunnel(deviceId: string, auth: TunnelAuth): Promise<VncTunnelInfo> {
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${auth.accessToken}`,
+  };
+
+  const tunnelRes = await fetch(`${auth.apiUrl}/tunnels`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ deviceId, type: 'vnc' }),
+  });
+  if (!tunnelRes.ok) {
+    const err = await tunnelRes.json().catch(() => null) as { error?: string } | null;
+    throw new Error(err?.error ?? `Tunnel create failed (${tunnelRes.status})`);
+  }
+  const { id: tunnelId } = await tunnelRes.json() as { id: string };
+
+  const ticketRes = await fetch(`${auth.apiUrl}/tunnels/${tunnelId}/ws-ticket`, {
+    method: 'POST',
+    headers,
+  });
+  if (!ticketRes.ok) {
+    await closeTunnel(tunnelId, auth);
+    throw new Error(`Failed to get tunnel ws-ticket (${ticketRes.status})`);
+  }
+  const { ticket } = await ticketRes.json() as { ticket: string };
+
+  const wsProtocol = auth.apiUrl.startsWith('https') ? 'wss' : 'ws';
+  const wsHost = auth.apiUrl.replace(/^https?:\/\//, '');
+  const wsUrl = `${wsProtocol}://${wsHost}/api/v1/tunnel-ws/${tunnelId}/ws?ticket=${ticket}`;
+
+  return { tunnelId, wsUrl };
+}
+
+/**
+ * Best-effort close. Swallows errors — callers invoke this from cleanup paths
+ * where surfacing an error would just mask the real cleanup reason.
+ */
+export async function closeTunnel(tunnelId: string, auth: TunnelAuth): Promise<void> {
+  try {
+    await fetch(`${auth.apiUrl}/tunnels/${tunnelId}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${auth.accessToken}` },
+    });
+  } catch {
+    // Intentionally swallowed
+  }
+}

--- a/apps/web/src/components/remote/ConnectDesktopButton.tsx
+++ b/apps/web/src/components/remote/ConnectDesktopButton.tsx
@@ -107,7 +107,7 @@ export default function ConnectDesktopButton({ deviceId, className = '', compact
       const needsVNC = canFallbackToVNC(desktopAccess, remoteAccessPolicy);
 
       if (needsVNC) {
-        // Create VNC tunnel — API generates ephemeral password
+        // Create VNC tunnel — user provides their macOS credentials in the noVNC prompt
         const tunnelRes = await fetchWithAuth('/tunnels', {
           method: 'POST',
           body: JSON.stringify({ deviceId, type: 'vnc' }),

--- a/apps/web/src/components/remote/VncViewer.tsx
+++ b/apps/web/src/components/remote/VncViewer.tsx
@@ -17,7 +17,6 @@ type ConnectionStatus = 'connecting' | 'connected' | 'disconnected' | 'error' | 
 interface VncViewerProps {
   wsUrl: string;
   tunnelId: string;
-  password?: string;
   onDisconnect?: () => void;
   className?: string;
 }
@@ -30,7 +29,7 @@ const statusConfig: Record<ConnectionStatus, { label: string; color: string }> =
   password_required: { label: 'Password required', color: 'text-amber-500' },
 };
 
-export default function VncViewer({ wsUrl, tunnelId, password, onDisconnect, className }: VncViewerProps) {
+export default function VncViewer({ wsUrl, tunnelId, onDisconnect, className }: VncViewerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const rfbRef = useRef<any>(null);
 
@@ -89,14 +88,11 @@ export default function VncViewer({ wsUrl, tunnelId, password, onDisconnect, cla
         // `detail.types` tells us what the selected security scheme needs.
         // Apple Remote Desktop auth (type 30) requires ["username", "password"];
         // standard VNC auth (type 2) requires just ["password"].
+        // Always prompt the operator — the agent no longer generates ephemeral passwords.
         const types = (e.detail?.types ?? ['password']) as string[];
         const requiresUsername = types.includes('username');
-        if (password && !requiresUsername) {
-          rfb.sendCredentials({ password });
-        } else {
-          setNeedsUsername(requiresUsername);
-          setStatus('password_required');
-        }
+        setNeedsUsername(requiresUsername);
+        setStatus('password_required');
       });
 
       // Diagnostic: framebuffer updates, resize, errors
@@ -206,7 +202,7 @@ export default function VncViewer({ wsUrl, tunnelId, password, onDisconnect, cla
       }
       rfbRef.current = null;
     };
-  }, [wsUrl, password, onDisconnect]);
+  }, [wsUrl, onDisconnect]);
 
   // Sync scale setting to RFB instance
   useEffect(() => {

--- a/apps/web/src/components/remote/VncViewerPage.tsx
+++ b/apps/web/src/components/remote/VncViewerPage.tsx
@@ -1,45 +1,20 @@
-import { useCallback, useState, useEffect } from 'react';
-import { ArrowLeft, X, Key, Copy, Check } from 'lucide-react';
+import { useCallback } from 'react';
+import { ArrowLeft, X } from 'lucide-react';
 import VncViewer from './VncViewer';
 import { fetchWithAuth } from '@/stores/auth';
 
 interface Props {
   tunnelId: string;
   wsUrl: string;
-  password?: string;
 }
 
-export default function VncViewerPage({ tunnelId, wsUrl, password: initialPassword }: Props) {
-  const [copied, setCopied] = useState(false);
-  const [password, setPassword] = useState(initialPassword || '');
-
-  // Read password from sessionStorage (set by ConnectDesktopButton before navigation)
-  useEffect(() => {
-    const key = `vnc-pwd-${tunnelId}`;
-    const pwd = sessionStorage.getItem(key);
-    if (pwd) {
-      setPassword(pwd);
-      sessionStorage.removeItem(key);
-    }
-  }, [tunnelId]);
-
+export default function VncViewerPage({ tunnelId, wsUrl }: Props) {
   const handleDisconnect = useCallback(() => {
     fetchWithAuth(`/tunnels/${tunnelId}`, { method: 'DELETE' }).catch((err) => {
       console.error(`[VncViewerPage] Failed to close tunnel ${tunnelId}:`, err);
     });
     window.location.href = '/remote';
   }, [tunnelId]);
-
-  const handleCopyPassword = useCallback(async () => {
-    if (!password) return;
-    try {
-      await navigator.clipboard.writeText(password);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Clipboard API may be blocked
-    }
-  }, [password]);
 
   return (
     <div className="flex h-full flex-col bg-black">
@@ -59,18 +34,6 @@ export default function VncViewerPage({ tunnelId, wsUrl, password: initialPasswo
           <span className="text-xs text-gray-500">{tunnelId.slice(0, 8)}</span>
         </div>
         <div className="flex items-center gap-2">
-          {password && (
-            <button
-              type="button"
-              onClick={handleCopyPassword}
-              className="flex items-center gap-1.5 rounded-md bg-gray-800 px-2.5 py-1 text-xs text-gray-300 hover:bg-gray-700 transition"
-              title="Copy VNC password"
-            >
-              <Key className="h-3 w-3" />
-              <span className="font-mono">{password}</span>
-              {copied ? <Check className="h-3 w-3 text-green-400" /> : <Copy className="h-3 w-3" />}
-            </button>
-          )}
           <button
             type="button"
             onClick={handleDisconnect}
@@ -85,7 +48,6 @@ export default function VncViewerPage({ tunnelId, wsUrl, password: initialPasswo
         <VncViewer
           wsUrl={wsUrl}
           tunnelId={tunnelId}
-          password={password}
           onDisconnect={handleDisconnect}
           className="h-full"
         />


### PR DESCRIPTION
## Summary

Phase 2 of the in-viewer WebRTC↔VNC switcher (plan in PR #469). Drops the dead ephemeral-VNC-password path across all four layers (agent, API, web, viewer tunnel client) and stands up the agent → viewer `desktop_state` event stream that Phase 3 needs for auto-handoff. Web VNC sessions now authenticate exclusively via Apple Remote Desktop using the user's macOS account credentials.

## What's in this PR

**Agent (`66515145`, `39967103`, `0fb6e2ad`)**
- `EnableScreenSharing()` drops the password parameter. `DisableScreenSharing` keeps a `-setvnclegacy -vnclegacy no` sweep so Macs upgraded from older agents don't keep residual legacy VNC password state.
- New `(*SessionManager).BroadcastDesktopState(state, username)` method sends `{"type":"desktop_state","state":"loginwindow"|"user_session","username":"…"}` over every open WebRTC control channel.
- Hooked from `desktop_handoff_darwin.go` at watcher startup and after each session-event reconcile.
- Control-channel `OnOpen` now sends the cached current state to the new viewer — late-joining viewers aren't stuck guessing the initial state.
- Proper lock discipline: manager RLock for snapshot, per-session RLock for channel read, lock NOT held across SCTP writes.

**API (`d66192cf`)**
- `POST /tunnels` no longer generates a `vncPassword`, no longer includes it in the `tunnel_open` payload, no longer returns it in the 201 body.
- New `apps/api/src/routes/tunnels.test.ts` with 3 route-level regression tests asserting the field is absent in response + agent payload.

**Web (`5a2b6503`)**
- `VncViewer` drops `password` prop; `credentialsrequired` always shows the ARD username + password prompt (no auto-inject).
- `VncViewerPage` drops the password badge + copy button + dead `sessionStorage('vnc-pwd-…')` readback.
- `ConnectDesktopButton` stale comment corrected.

**Viewer (`b1258327`)**
- New `apps/viewer/src/lib/tunnel.ts` — `createVncTunnel` / `closeTunnel` REST client with Bearer auth. On ws-ticket failure, best-effort DELETEs the dangling tunnel. `closeTunnel` swallows errors so it's safe to call from cleanup paths. 7 unit tests.
- Phase 3 will wire this into the in-viewer transport switcher. Not currently called by any runtime path.

## Test plan
- [x] `pnpm tsc --noEmit && pnpm vitest run` clean in `apps/viewer`, `apps/api`, `apps/web`
- [x] `go build ./... && go test -race ./...` clean in `agent`
- [x] `grep -rn "vncPassword\|vnc-pwd-\|setvncpw" apps/ agent/ packages/` — zero matches outside `not.toHaveProperty` assertions and archival docs
- [ ] Manual: web VNC client prompts for + accepts macOS user credentials against device \`804d096a-6400-4c6d-ab2a-8bee3e69268a\`
- [ ] Manual: \`device_commands.payload\` for a new VNC tunnel has no \`vncPassword\` field
- [ ] Manual: WebRTC desktop session receives a \`desktop_state\` message on connect and on login/logout
- [ ] Manual: after VNC disconnect, \`lsof -i :5900\` on the Mac is empty within 30s

## Related
- Docs PR: #469 (spec + plan)
- Phase 1: #471 (merged)
- Phase 3 (pending): VNC transport in viewer + switcher UI + auto-handoff state machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)