### PR TITLE
fix(agent/desktop): resend cached IDR (not P-frame) during idle

### DIFF
--- a/agent/internal/remote/desktop/session.go
+++ b/agent/internal/remote/desktop/session.go
@@ -120,9 +120,14 @@ type Session struct {
 	gpuVendor string
 
 	// Cached encoded H264 frame used as a fallback resend source when secure
-	// desktop capture yields temporary no-frame periods.
+	// desktop capture yields temporary no-frame periods. lastEncodedIDR holds
+	// the most recent frame that contained an IDR NAL unit — idle resend paths
+	// must prefer this over lastEncodedFrame, because re-sending a P-frame as
+	// a new RTP sample drifts the decoder's reference state and produces the
+	// classic "garbage over static content" artifacting.
 	lastEncodedMu    sync.RWMutex
 	lastEncodedFrame []byte
+	lastEncodedIDR   []byte
 	// Nanoseconds since epoch of the last successful video sample write.
 	lastVideoWriteUnixNano atomic.Int64
 

--- a/agent/internal/remote/desktop/session_capture.go
+++ b/agent/internal/remote/desktop/session_capture.go
@@ -72,23 +72,43 @@ func (s *Session) cacheEncodedFrame(data []byte) {
 	cp := getEncodedFrameBuf(len(data))
 	copy(cp, data)
 
+	var idrCopy []byte
+	isIDR := h264ContainsIDR(data)
+	if isIDR {
+		idrCopy = getEncodedFrameBuf(len(data))
+		copy(idrCopy, data)
+	}
+
 	s.lastEncodedMu.Lock()
 	old := s.lastEncodedFrame
 	s.lastEncodedFrame = cp
+	var oldIDR []byte
+	if isIDR {
+		oldIDR = s.lastEncodedIDR
+		s.lastEncodedIDR = idrCopy
+	}
 	s.lastEncodedMu.Unlock()
 
 	if len(old) != 0 {
 		putEncodedFrameBuf(old)
+	}
+	if len(oldIDR) != 0 {
+		putEncodedFrameBuf(oldIDR)
 	}
 }
 
 func (s *Session) clearCachedEncodedFrame() {
 	s.lastEncodedMu.Lock()
 	old := s.lastEncodedFrame
+	oldIDR := s.lastEncodedIDR
 	s.lastEncodedFrame = nil
+	s.lastEncodedIDR = nil
 	s.lastEncodedMu.Unlock()
 	if len(old) != 0 {
 		putEncodedFrameBuf(old)
+	}
+	if len(oldIDR) != 0 {
+		putEncodedFrameBuf(oldIDR)
 	}
 }
 
@@ -130,7 +150,13 @@ func (s *Session) maybeResendCachedFrameOnSecureDesktop(cap ScreenCapturer, fram
 	}
 
 	s.lastEncodedMu.RLock()
-	cached := s.lastEncodedFrame
+	// Prefer the cached IDR so the decoder can resync standalone. Resending a
+	// P-frame as a fresh RTP sample accumulates reference-frame drift in the
+	// viewer decoder and paints garbage over static content.
+	cached := s.lastEncodedIDR
+	if len(cached) == 0 {
+		cached = s.lastEncodedFrame
+	}
 	if len(cached) == 0 {
 		s.lastEncodedMu.RUnlock()
 		return false
@@ -154,9 +180,13 @@ func (s *Session) maybeResendCachedFrameOnSecureDesktop(cap ScreenCapturer, fram
 	return true
 }
 
-// maybeResendCachedFrameOnIdle resends the last encoded frame when the normal
-// desktop has been static for too long. This prevents WebRTC jitter from
-// accumulating by maintaining a minimum ~2fps floor even with no dirty rects.
+// maybeResendCachedFrameOnIdle resends the last encoded keyframe when the
+// normal desktop has been static for too long. This prevents WebRTC jitter
+// from accumulating by maintaining a minimum ~8fps floor even with no dirty
+// rects. We deliberately resend only an IDR — re-sending a P-frame as a fresh
+// RTP sample drifts the decoder's reference state and paints garbage over
+// static content (the classic "corrupted-over-text" artifact). If we haven't
+// produced an IDR yet, skip; the next real frame change will emit one.
 func (s *Session) maybeResendCachedFrameOnIdle(frameDuration time.Duration) bool {
 	last := s.lastVideoWriteUnixNano.Load()
 	if last == 0 {
@@ -167,9 +197,14 @@ func (s *Session) maybeResendCachedFrameOnIdle(frameDuration time.Duration) bool
 	}
 
 	s.lastEncodedMu.RLock()
-	cached := s.lastEncodedFrame
+	cached := s.lastEncodedIDR
 	if len(cached) == 0 {
 		s.lastEncodedMu.RUnlock()
+		// No IDR cached yet; ask the encoder to produce one on the next frame
+		// so subsequent idle periods can resend safely.
+		if enc := s.encoder.Load(); enc != nil {
+			_ = enc.ForceKeyframe()
+		}
 		return false
 	}
 	frame := make([]byte, len(cached))

--- a/agent/internal/remote/desktop/session_capture_idr_test.go
+++ b/agent/internal/remote/desktop/session_capture_idr_test.go
@@ -1,0 +1,67 @@
+package desktop
+
+import (
+	"bytes"
+	"testing"
+)
+
+// H.264 Annex B NAL units. Each buffer starts with 00 00 00 01; the 5th byte's
+// low 5 bits are the nal_unit_type. Type 5 = IDR, type 1 = non-IDR P-frame.
+var (
+	idrNALU    = []byte{0x00, 0x00, 0x00, 0x01, 0x65, 0xDE, 0xAD, 0xBE, 0xEF}
+	pFrameNALU = []byte{0x00, 0x00, 0x00, 0x01, 0x41, 0xCA, 0xFE, 0xBA, 0xBE}
+)
+
+func TestCacheEncodedFrame_TracksIDRSeparately(t *testing.T) {
+	s := &Session{}
+
+	// P-frame first — no IDR should be cached yet.
+	s.cacheEncodedFrame(pFrameNALU)
+	s.lastEncodedMu.RLock()
+	if len(s.lastEncodedFrame) == 0 {
+		s.lastEncodedMu.RUnlock()
+		t.Fatalf("lastEncodedFrame should hold the P-frame")
+	}
+	if len(s.lastEncodedIDR) != 0 {
+		s.lastEncodedMu.RUnlock()
+		t.Fatalf("lastEncodedIDR should be empty before any IDR is cached")
+	}
+	s.lastEncodedMu.RUnlock()
+
+	// IDR — both slots should hold the IDR bytes.
+	s.cacheEncodedFrame(idrNALU)
+	s.lastEncodedMu.RLock()
+	if !bytes.Equal(s.lastEncodedFrame, idrNALU) {
+		s.lastEncodedMu.RUnlock()
+		t.Fatalf("lastEncodedFrame should mirror the latest encoded frame")
+	}
+	if !bytes.Equal(s.lastEncodedIDR, idrNALU) {
+		s.lastEncodedMu.RUnlock()
+		t.Fatalf("lastEncodedIDR should capture the IDR payload")
+	}
+	s.lastEncodedMu.RUnlock()
+
+	// Another P-frame — latest frame updates, but the IDR cache must stick so
+	// idle resends have a standalone-decodable payload to emit.
+	s.cacheEncodedFrame(pFrameNALU)
+	s.lastEncodedMu.RLock()
+	defer s.lastEncodedMu.RUnlock()
+	if !bytes.Equal(s.lastEncodedFrame, pFrameNALU) {
+		t.Fatalf("lastEncodedFrame should track the most recent frame")
+	}
+	if !bytes.Equal(s.lastEncodedIDR, idrNALU) {
+		t.Fatalf("lastEncodedIDR should persist across subsequent P-frames, got %x", s.lastEncodedIDR)
+	}
+}
+
+func TestClearCachedEncodedFrame_ClearsBothSlots(t *testing.T) {
+	s := &Session{}
+	s.cacheEncodedFrame(idrNALU)
+	s.clearCachedEncodedFrame()
+
+	s.lastEncodedMu.RLock()
+	defer s.lastEncodedMu.RUnlock()
+	if len(s.lastEncodedFrame) != 0 || len(s.lastEncodedIDR) != 0 {
+		t.Fatalf("clearCachedEncodedFrame must reset both lastEncodedFrame and lastEncodedIDR")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the Windows Server 2022 (1024x768, no-GPU, OpenH264) artifacting reported against rc.4 after the odd-dimension fix shipped. The dimension fix is not the issue here — 1024x768 is already even — the culprit is the idle-resend path.

`maybeResendCachedFrameOnIdle` keeps the WebRTC jitter buffer warm by retransmitting the last encoded sample every ~125ms when DXGI reports no dirty rects. But `lastEncodedFrame` is almost always a P-frame, so each idle retransmit was a P-frame with motion deltas against a reference the decoder had already advanced past. Decoder state drifts, and the first real P-frame after idle paints garbage on top of static content — matching the screenshots exactly.

## Fix

- `Session.lastEncodedIDR` shadows `lastEncodedFrame` whenever `cacheEncodedFrame` sees an Annex B NAL type 5.
- `maybeResendCachedFrameOnIdle` prefers the cached IDR and calls `ForceKeyframe()` on first miss so the next encoded frame is a resendable IDR.
- `maybeResendCachedFrameOnSecureDesktop` prefers the IDR with a fallback to the latest frame so the existing secure-desktop keyframe loop is unaffected.

## Test plan

- [x] `go build ./internal/remote/desktop/...` (darwin)
- [x] `GOOS=windows go build ./internal/remote/desktop/...`
- [x] `go vet ./internal/remote/desktop/...`
- [x] `go test ./internal/remote/desktop/... -race -count=1`
- [ ] Smoke on the affected Windows Server 2022 VM — sit idle for 30s, move a window, confirm no ghosting/color-fringe artifacts on newly drawn regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)