### PR TITLE
fix(agent/desktop): stop retransmitting P-frames during static idle

### DIFF
--- a/agent/internal/remote/desktop/session_capture.go
+++ b/agent/internal/remote/desktop/session_capture.go
@@ -154,10 +154,27 @@ func (s *Session) maybeResendCachedFrameOnSecureDesktop(cap ScreenCapturer, fram
 	return true
 }
 
-// maybeResendCachedFrameOnIdle resends the last encoded frame when the normal
-// desktop has been static for too long. This prevents WebRTC jitter from
-// accumulating by maintaining a minimum ~2fps floor even with no dirty rects.
+// maybeResendCachedFrameOnIdle bumps the capture-alive heartbeat on a normal
+// (non-secure) desktop that has had no dirty rects for longer than the idle
+// threshold. It intentionally does NOT retransmit the last encoded frame.
+//
+// We used to retransmit the cached H264 sample every ~125ms to keep a minimum
+// framerate floor, but debug logging on Windows Server 2022 (OpenH264, 1024x768)
+// confirmed the browser decodes every resend — framesDecoded climbed in lock-
+// step with the agent's sent counter even while captured/encoded held flat.
+// Resending a P-frame lets the decoder re-apply motion deltas against its
+// drifted reference and paints garbage over static text; resending the cached
+// IDR just replays an older screen state on top of any newer P-frames. The
+// jitter buffer does not need "keepalive samples" — it is happy to hold the
+// last decoded frame indefinitely.
+//
+// We still bump lastVideoWriteUnixNano so the no-video capture watchdog does
+// not confuse "screen is idle, DXGI has no dirty rects" with "capture thread
+// is stuck," which would otherwise force a DXGI reattach every ~5s. A proper
+// fix for that overload (capture-alive vs sample-written are different
+// signals) is tracked as a follow-up.
 func (s *Session) maybeResendCachedFrameOnIdle(frameDuration time.Duration) bool {
+	_ = frameDuration
 	last := s.lastVideoWriteUnixNano.Load()
 	if last == 0 {
 		return false
@@ -165,29 +182,8 @@ func (s *Session) maybeResendCachedFrameOnIdle(frameDuration time.Duration) bool
 	if time.Since(time.Unix(0, last)) < staticDesktopResendInterval {
 		return false
 	}
-
-	s.lastEncodedMu.RLock()
-	cached := s.lastEncodedFrame
-	if len(cached) == 0 {
-		s.lastEncodedMu.RUnlock()
-		return false
-	}
-	frame := make([]byte, len(cached))
-	copy(frame, cached)
-	size := len(frame)
-	s.lastEncodedMu.RUnlock()
-
-	sample := media.Sample{
-		Data:     frame,
-		Duration: frameDuration,
-	}
-	if err := s.videoTrack.WriteSample(sample); err != nil {
-		slog.Debug("Failed to resend cached idle frame", "session", s.id, "error", err.Error())
-		return false
-	}
-	s.metrics.RecordSend(size)
 	s.noteVideoWrite()
-	return true
+	return false
 }
 
 // captureLoop continuously captures and sends encoded H264 frames.


### PR DESCRIPTION
## Summary

Fixes the long-standing remote-desktop artifacting on Windows Server 2022 (1024×768, no-GPU, OpenH264) that persisted across rc.3, rc.4, and rc.6. Verified live on the affected VM: after the fix, static windows (File Explorer, notepad, Local Security Policy) stay crisp; there is no ghost/rainbow overlay when no input is happening.

## Root cause

`maybeResendCachedFrameOnIdle` retransmitted the last encoded H264 sample every ~125ms on a static normal desktop to keep "a minimum ~8fps floor." Debug logging on the affected VM conclusively shows the browser's decoder does **not** dedupe the resends:

| metric | value over ~5 min idle |
|---|---|
| agent encoded | 428 |
| agent sent | 2583 |
| viewer framesDecoded | 2583 |

Every resend is a P-frame whose motion deltas reference a past frame, but the decoder applies them against its now-drifted current output → the signature "garbage over static content" artifacting.

The rc.6 attempt to resend the cached IDR instead was worse because replaying an older IDR rewinds the viewer to that IDR's screen state, painting it over any newer P-frames — the "replaying images" symptom.

## Fix

`maybeResendCachedFrameOnIdle` is now a capture-alive heartbeat:

- Same throttle as before (`staticDesktopResendInterval`).
- No `WriteSample` — the browser jitter buffer happily holds the last decoded frame during idle, and there is no keepalive requirement.
- Still bumps `lastVideoWriteUnixNano` so the no-video capture watchdog does not confuse "no dirty rects" with "capture thread stuck" and fire a spurious DXGI reattach every 5s. Splitting those two signals properly (capture-alive vs sample-written) is a follow-up.
- Return value is now always `false`. The DXGI loop's `frameSent`/`forceDesktopRepaint` gating naturally becomes a no-op during genuine idle, which is the correct behaviour.

## Test plan

- [x] `go build ./internal/remote/desktop/...` (darwin)
- [x] `GOOS=windows CGO_ENABLED=0 go build ./internal/remote/desktop/...`
- [x] `go vet ./internal/remote/desktop/...`
- [x] `go test ./internal/remote/desktop/... -race -count=1`
- [x] **Live smoke on affected Windows Server 2022 VM** — confirmed no artifacting after ≥2 min idle + typing, File Explorer and notepad stay crisp

## Follow-ups (separate PRs)

1. Split the capture-alive signal from the sample-written signal so the no-video watchdog can detect actually-broken capture without needing `noteVideoWrite()` to double as a heartbeat.
2. Consider whether the secure-desktop and DXGI-nudge paths still need their resends; the same decoder-drift reasoning probably applies there too, just less severely because secure desktops have shorter idle windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)