### PR TITLE
feat: macOS GUI installer app (bootstrap tokens + Swift installer + CI)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -768,6 +768,102 @@ jobs:
         if: always() && vars.ENABLE_MACOS_SIGNING == 'true'
         run: security delete-keychain "$RUNNER_TEMP/signing.keychain-db" || true
 
+  build-macos-installer-app:
+    name: Build macOS Installer App
+    needs: [build-macos-agent]
+    runs-on: macos-latest
+    if: vars.ENABLE_MACOS_SIGNING == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download .pkg darwin/amd64
+        uses: actions/download-artifact@v8
+        with:
+          name: breeze-agent-darwin-amd64-pkg
+          path: installer-pkgs/
+
+      - name: Download .pkg darwin/arm64
+        uses: actions/download-artifact@v8
+        with:
+          name: breeze-agent-darwin-arm64-pkg
+          path: installer-pkgs/
+
+      - name: Import certificate into keychain
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          CERT_PATH="$RUNNER_TEMP/cert.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 16)"
+
+          echo "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" \
+            $(security list-keychains -d user | tr -d '"')
+
+          rm -f "$CERT_PATH"
+
+      - name: Build .app bundle
+        run: |
+          chmod +x agent/installer/macos-app/build-app-bundle.sh
+          agent/installer/macos-app/build-app-bundle.sh \
+            --pkg-amd64 installer-pkgs/breeze-agent-darwin-amd64.pkg \
+            --pkg-arm64 installer-pkgs/breeze-agent-darwin-arm64.pkg \
+            --output "build/Breeze Installer.app"
+
+      - name: Sign .app
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          codesign --force --options runtime \
+            --entitlements agent/installer/macos-app/entitlements.plist \
+            --sign "$APPLE_SIGNING_IDENTITY" --timestamp \
+            --deep "build/Breeze Installer.app"
+          codesign --verify --verbose=2 "build/Breeze Installer.app"
+
+      - name: Notarize + staple
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          ditto -c -k --keepParent "build/Breeze Installer.app" build/installer-notarize.zip
+          xcrun notarytool submit build/installer-notarize.zip \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait --timeout 30m
+          xcrun stapler staple "build/Breeze Installer.app"
+          xcrun stapler validate "build/Breeze Installer.app"
+          spctl -a -t exec -vv "build/Breeze Installer.app"
+
+      - name: Package for release
+        run: |
+          ditto -c -k --sequesterRsrc --keepParent \
+            "build/Breeze Installer.app" \
+            "build/Breeze Installer.app.zip"
+          ls -lh build/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: breeze-installer-app
+          path: build/Breeze Installer.app.zip
+          retention-days: 30
+
+      - name: Cleanup keychain
+        if: always()
+        run: security delete-keychain "$RUNNER_TEMP/signing.keychain-db" || true
+
   build-viewer:
     name: Build Viewer
     strategy:
@@ -1548,7 +1644,7 @@ jobs:
   create-release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [build-api, build-web, build-agent, build-windows-msi, build-macos-agent, sign-windows-tauri, build-viewer, build-helper, build-viewer-macos, build-helper-macos, merge-viewer-update-manifest, package-windows-updater]
+    needs: [build-api, build-web, build-agent, build-windows-msi, build-macos-agent, build-macos-installer-app, sign-windows-tauri, build-viewer, build-helper, build-viewer-macos, build-helper-macos, merge-viewer-update-manifest, package-windows-updater]
     if: >-
       !cancelled()
       && needs.build-api.result == 'success'
@@ -1556,6 +1652,7 @@ jobs:
       && needs.build-agent.result == 'success'
       && (needs.build-windows-msi.result == 'success' || needs.build-windows-msi.result == 'skipped')
       && (needs.build-macos-agent.result == 'success' || needs.build-macos-agent.result == 'skipped')
+      && (needs.build-macos-installer-app.result == 'success' || needs.build-macos-installer-app.result == 'skipped')
       && (needs.sign-windows-tauri.result == 'success' || needs.sign-windows-tauri.result == 'skipped')
       && (needs.package-windows-updater.result == 'success' || needs.package-windows-updater.result == 'skipped')
       && (needs.build-viewer.result == 'success' || needs.build-viewer.result == 'skipped')
@@ -1574,7 +1671,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           path: artifacts
-          pattern: '{api-dist,web-dist,breeze-agent-*,breeze-backup-*,breeze-desktop-helper-*,breeze-watchdog-*,breeze-viewer-*,breeze-helper-*,viewer-latest-json}'
+          pattern: '{api-dist,web-dist,breeze-agent-*,breeze-backup-*,breeze-desktop-helper-*,breeze-watchdog-*,breeze-viewer-*,breeze-helper-*,breeze-installer-app,viewer-latest-json}'
           merge-multiple: false
 
       - name: Prepare release assets
@@ -1627,6 +1724,11 @@ jobs:
               cp "$dir"/* release-assets/
             fi
           done
+
+          # Copy macOS installer app
+          if [ -d "artifacts/breeze-installer-app" ] && ls "artifacts/breeze-installer-app/"* >/dev/null 2>&1; then
+            cp "artifacts/breeze-installer-app/"* release-assets/
+          fi
 
           # Create archives for API and Web
           if [ -d "artifacts/api-dist" ]; then

--- a/agent/installer/macos-app/.gitignore
+++ b/agent/installer/macos-app/.gitignore
@@ -1,0 +1,5 @@
+.build/
+.swiftpm/
+DerivedData/
+build/
+*.xcodeproj

--- a/agent/installer/macos-app/Package.swift
+++ b/agent/installer/macos-app/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "BreezeInstaller",
-    platforms: [.macOS(.v12)],
+    platforms: [.macOS(.v13)],
     products: [
         .executable(name: "BreezeInstaller", targets: ["BreezeInstaller"]),
     ],

--- a/agent/installer/macos-app/Package.swift
+++ b/agent/installer/macos-app/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "BreezeInstaller",
-    platforms: [.macOS(.v11)],
+    platforms: [.macOS(.v12)],
     products: [
         .executable(name: "BreezeInstaller", targets: ["BreezeInstaller"]),
     ],

--- a/agent/installer/macos-app/Package.swift
+++ b/agent/installer/macos-app/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "BreezeInstaller",
+    platforms: [.macOS(.v11)],
+    products: [
+        .executable(name: "BreezeInstaller", targets: ["BreezeInstaller"]),
+    ],
+    targets: [
+        .executableTarget(
+            name: "BreezeInstaller",
+            path: "Sources/BreezeInstaller"
+        ),
+        .testTarget(
+            name: "BreezeInstallerTests",
+            dependencies: ["BreezeInstaller"],
+            path: "Tests/BreezeInstallerTests"
+        ),
+    ]
+)

--- a/agent/installer/macos-app/Resources/Info.plist
+++ b/agent/installer/macos-app/Resources/Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>BreezeInstaller</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.breeze.installer</string>
+    <key>CFBundleName</key>
+    <string>Breeze Installer</string>
+    <key>CFBundleDisplayName</key>
+    <string>Breeze Installer</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>13.0</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSHumanReadableCopyright</key>
+    <string>Copyright © 2026 Olive Technologies LLC.</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+</dict>
+</plist>

--- a/agent/installer/macos-app/Sources/BreezeInstaller/Architecture.swift
+++ b/agent/installer/macos-app/Sources/BreezeInstaller/Architecture.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+enum Architecture: String {
+    case arm64
+    case amd64
+
+    var pkgResourceName: String {
+        switch self {
+        case .arm64: return "breeze-agent-arm64.pkg"
+        case .amd64: return "breeze-agent-amd64.pkg"
+        }
+    }
+
+    /// Parses `uname -m` output. Returns nil for anything we don't ship a PKG for.
+    static func fromUname(_ output: String) -> Architecture? {
+        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch trimmed {
+        case "arm64": return .arm64
+        case "x86_64": return .amd64
+        default: return nil
+        }
+    }
+
+    /// Detects the running host's architecture by invoking `/usr/bin/uname -m`.
+    static func current() -> Architecture? {
+        let task = Process()
+        task.launchPath = "/usr/bin/uname"
+        task.arguments = ["-m"]
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        do {
+            try task.run()
+            task.waitUntilExit()
+        } catch {
+            return nil
+        }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8) ?? ""
+        return fromUname(output)
+    }
+}

--- a/agent/installer/macos-app/Sources/BreezeInstaller/BootstrapClient.swift
+++ b/agent/installer/macos-app/Sources/BreezeInstaller/BootstrapClient.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Fetches the enrollment payload from the Plan A bootstrap endpoint.
+struct BootstrapClient {
+    struct Payload: Decodable {
+        let serverUrl: String
+        let enrollmentKey: String
+        let enrollmentSecret: String?
+        let siteId: String?
+        let orgName: String
+    }
+
+    enum Error: Swift.Error, LocalizedError {
+        case network(underlying: Swift.Error)
+        case http(status: Int, body: String)
+        case decoding(underlying: Swift.Error)
+
+        var errorDescription: String? {
+            switch self {
+            case .network(let e):
+                return "Network error: \(e.localizedDescription)"
+            case .http(let status, _) where status == 404:
+                return "This installer link has expired or already been used. Please re-download from your Breeze web console."
+            case .http(let status, let body):
+                return "Server error (\(status)): \(body.prefix(200))"
+            case .decoding:
+                return "Server returned an unexpected response. Please re-download the installer."
+            }
+        }
+    }
+
+    let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func fetch(token: String, apiHost: String) async throws -> Payload {
+        guard let url = URL(string: "https://\(apiHost)/api/v1/installer/bootstrap/\(token)") else {
+            throw Error.http(status: 0, body: "constructed URL is invalid")
+        }
+        var req = URLRequest(url: url)
+        req.timeoutInterval = 30
+        req.setValue("BreezeInstaller/1.0", forHTTPHeaderField: "User-Agent")
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: req)
+        } catch {
+            throw Error.network(underlying: error)
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw Error.http(status: 0, body: "non-HTTP response")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw Error.http(status: http.statusCode, body: body)
+        }
+        do {
+            return try JSONDecoder().decode(Payload.self, from: data)
+        } catch {
+            throw Error.decoding(underlying: error)
+        }
+    }
+}

--- a/agent/installer/macos-app/Sources/BreezeInstaller/FilenameTokenParser.swift
+++ b/agent/installer/macos-app/Sources/BreezeInstaller/FilenameTokenParser.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Parses the bootstrap token + API host out of the installer app's own
+/// bundle filename. Format: `Breeze Installer [TOKEN@host.example].app`
+/// where TOKEN is exactly 6 chars of [A-Z0-9] and host matches a relaxed
+/// hostname pattern (letters, digits, dots, hyphens).
+enum FilenameTokenParser {
+    struct Result: Equatable {
+        let token: String
+        let apiHost: String
+    }
+
+    enum Error: Swift.Error, Equatable {
+        case invalidFormat
+    }
+
+    private static let pattern = #"\[([A-Z0-9]{6})@([a-zA-Z0-9.\-]+)\]"#
+
+    static func parse(bundleName: String) throws -> Result {
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(
+                in: bundleName,
+                range: NSRange(bundleName.startIndex..., in: bundleName)
+              ),
+              match.numberOfRanges == 3,
+              let tokenRange = Range(match.range(at: 1), in: bundleName),
+              let hostRange = Range(match.range(at: 2), in: bundleName)
+        else {
+            throw Error.invalidFormat
+        }
+        return Result(
+            token: String(bundleName[tokenRange]),
+            apiHost: String(bundleName[hostRange])
+        )
+    }
+}

--- a/agent/installer/macos-app/Sources/BreezeInstaller/FilenameTokenParser.swift
+++ b/agent/installer/macos-app/Sources/BreezeInstaller/FilenameTokenParser.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Parses the bootstrap token + API host out of the installer app's own
 /// bundle filename. Format: `Breeze Installer [TOKEN@host.example].app`
-/// where TOKEN is exactly 6 chars of [A-Z0-9] and host matches a relaxed
+/// where TOKEN is exactly 10 chars of [A-Z0-9] and host matches a relaxed
 /// hostname pattern (letters, digits, dots, hyphens).
 enum FilenameTokenParser {
     struct Result: Equatable {
@@ -14,7 +14,7 @@ enum FilenameTokenParser {
         case invalidFormat
     }
 
-    private static let pattern = #"\[([A-Z0-9]{6})@([a-zA-Z0-9.\-]+)\]"#
+    private static let pattern = #"\[([A-Z0-9]{10})@([a-zA-Z0-9.\-]+)\]"#
 
     static func parse(bundleName: String) throws -> Result {
         guard let regex = try? NSRegularExpression(pattern: pattern),

--- a/agent/installer/macos-app/Sources/BreezeInstaller/Installer.swift
+++ b/agent/installer/macos-app/Sources/BreezeInstaller/Installer.swift
@@ -1,0 +1,75 @@
+import Foundation
+import AppKit
+
+/// Runs `installer -pkg` and `breeze-agent enroll` as root via the native
+/// macOS admin-password dialog. Uses `NSAppleScript` because it is the
+/// supported way to trigger the system auth prompt for a one-shot
+/// administrator command — `AuthorizationExecuteWithPrivileges` is
+/// deprecated and SMJobBless is overkill for this scope.
+struct Installer {
+    enum Error: Swift.Error, LocalizedError {
+        case appleScriptFailed(message: String, code: Int)
+        case scriptCreationFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .scriptCreationFailed:
+                return "Could not construct installer script"
+            case .appleScriptFailed(_, let code) where code == -128:
+                return "Administrator authentication was cancelled"
+            case .appleScriptFailed(let message, let code):
+                return "Install failed (\(code)): \(message)"
+            }
+        }
+    }
+
+    /// Escapes a single value for safe interpolation inside an AppleScript
+    /// `do shell script` POSIX string. Wraps in single quotes and escapes
+    /// any embedded single quotes by closing/escaping/reopening.
+    ///
+    /// Note: values containing literal double quotes (e.g. an enrollment
+    /// secret with `"` in it) would break the enclosing AppleScript
+    /// double-quoted string literal. For v1 this is acceptable — enrollment
+    /// secrets are admin-configured, not end-user input — but should be
+    /// addressed before allowing arbitrary user-provided secrets.
+    static func shellEscape(_ value: String) -> String {
+        let escaped = value.replacingOccurrences(of: "'", with: "'\\''")
+        return "'\(escaped)'"
+    }
+
+    func run(
+        pkgPath: String,
+        serverUrl: String,
+        enrollmentKey: String,
+        enrollmentSecret: String?,
+        siteId: String?
+    ) throws {
+        var enrollArgs = [
+            Installer.shellEscape(enrollmentKey),
+            "--server", Installer.shellEscape(serverUrl),
+            "--quiet",
+        ]
+        if let secret = enrollmentSecret, !secret.isEmpty {
+            enrollArgs += ["--enrollment-secret", Installer.shellEscape(secret)]
+        }
+        if let site = siteId, !site.isEmpty {
+            enrollArgs += ["--site-id", Installer.shellEscape(site)]
+        }
+        let enrollCmd = enrollArgs.joined(separator: " ")
+
+        let script = """
+        do shell script "/usr/sbin/installer -pkg \(Installer.shellEscape(pkgPath)) -target / && /usr/local/bin/breeze-agent enroll \(enrollCmd)" with administrator privileges
+        """
+
+        guard let appleScript = NSAppleScript(source: script) else {
+            throw Error.scriptCreationFailed
+        }
+        var errorDict: NSDictionary?
+        appleScript.executeAndReturnError(&errorDict)
+        if let err = errorDict {
+            let message = err[NSAppleScript.errorMessage] as? String ?? "unknown"
+            let code = err[NSAppleScript.errorNumber] as? Int ?? -1
+            throw Error.appleScriptFailed(message: message, code: code)
+        }
+    }
+}

--- a/agent/installer/macos-app/Sources/BreezeInstaller/InstallerApp.swift
+++ b/agent/installer/macos-app/Sources/BreezeInstaller/InstallerApp.swift
@@ -1,0 +1,128 @@
+// agent/installer/macos-app/Sources/BreezeInstaller/InstallerApp.swift
+import SwiftUI
+
+enum InstallState {
+    case loading
+    case confirm(payload: BootstrapClient.Payload)
+    case installing
+    case done(orgName: String)
+    case error(message: String, recoverable: Bool)
+}
+
+@MainActor
+final class InstallController: ObservableObject {
+    @Published var state: InstallState = .loading
+
+    private var token: String?
+    private var apiHost: String?
+    private var payload: BootstrapClient.Payload?
+
+    func start() {
+        Task { await self.bootstrap() }
+    }
+
+    private func bootstrap() async {
+        let bundleName = Bundle.main.bundleURL.lastPathComponent
+        let parsed: FilenameTokenParser.Result
+        do {
+            parsed = try FilenameTokenParser.parse(bundleName: bundleName)
+        } catch {
+            state = .error(
+                message: "This installer needs its original filename. Please re-download from your Breeze web console.",
+                recoverable: false
+            )
+            return
+        }
+        token = parsed.token
+        apiHost = parsed.apiHost
+
+        let client = BootstrapClient()
+        do {
+            let p = try await client.fetch(token: parsed.token, apiHost: parsed.apiHost)
+            payload = p
+            state = .confirm(payload: p)
+        } catch let err as BootstrapClient.Error {
+            state = .error(message: err.errorDescription ?? "Unknown error", recoverable: true)
+        } catch {
+            state = .error(message: error.localizedDescription, recoverable: true)
+        }
+    }
+
+    func confirmInstall() {
+        guard let payload else { return }
+        state = .installing
+        Task { await self.runInstall(payload: payload) }
+    }
+
+    func retry() {
+        state = .loading
+        start()
+    }
+
+    private func runInstall(payload: BootstrapClient.Payload) async {
+        guard let arch = Architecture.current() else {
+            state = .error(message: "Unsupported CPU architecture", recoverable: false)
+            return
+        }
+        guard let resourcesURL = Bundle.main.resourceURL else {
+            state = .error(message: "Could not locate installer resources", recoverable: false)
+            return
+        }
+        let pkgURL = resourcesURL.appendingPathComponent(arch.pkgResourceName)
+        guard FileManager.default.fileExists(atPath: pkgURL.path) else {
+            state = .error(message: "Bundled installer is missing \(arch.pkgResourceName). Please re-download.", recoverable: false)
+            return
+        }
+
+        do {
+            try Installer().run(
+                pkgPath: pkgURL.path,
+                serverUrl: payload.serverUrl,
+                enrollmentKey: payload.enrollmentKey,
+                enrollmentSecret: payload.enrollmentSecret,
+                siteId: payload.siteId
+            )
+            state = .done(orgName: payload.orgName)
+        } catch let err as Installer.Error {
+            state = .error(message: err.errorDescription ?? "Install failed", recoverable: true)
+        } catch {
+            state = .error(message: error.localizedDescription, recoverable: true)
+        }
+    }
+}
+
+@main
+struct BreezeInstallerApp: App {
+    @StateObject private var controller = InstallController()
+
+    var body: some Scene {
+        WindowGroup("Breeze Installer") {
+            RootView(controller: controller)
+                .frame(width: 480, height: 320)
+                .onAppear { controller.start() }
+        }
+        .windowResizability(.contentSize)
+    }
+}
+
+struct RootView: View {
+    @ObservedObject var controller: InstallController
+
+    var body: some View {
+        Group {
+            switch controller.state {
+            case .loading:
+                LoadingView()
+            case .confirm(let payload):
+                ConfirmView(payload: payload, onInstall: controller.confirmInstall)
+            case .installing:
+                InstallingView()
+            case .done(let orgName):
+                DoneView(orgName: orgName)
+            case .error(let message, let recoverable):
+                ErrorView(message: message, recoverable: recoverable, onRetry: controller.retry)
+            }
+        }
+        .padding(24)
+    }
+}

--- a/agent/installer/macos-app/Sources/BreezeInstaller/Views/ConfirmView.swift
+++ b/agent/installer/macos-app/Sources/BreezeInstaller/Views/ConfirmView.swift
@@ -1,0 +1,26 @@
+// agent/installer/macos-app/Sources/BreezeInstaller/Views/ConfirmView.swift
+import SwiftUI
+
+struct ConfirmView: View {
+    let payload: BootstrapClient.Payload
+    let onInstall: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Install Breeze Agent")
+                .font(.title2).bold()
+            Text("This will install the Breeze monitoring agent for **\(payload.orgName)**. You will be prompted for your administrator password.")
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer()
+            HStack {
+                Spacer()
+                Button("Quit") { NSApp.terminate(nil) }
+                    .keyboardShortcut(.cancelAction)
+                Button("Install") { onInstall() }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/agent/installer/macos-app/Sources/BreezeInstaller/Views/DoneView.swift
+++ b/agent/installer/macos-app/Sources/BreezeInstaller/Views/DoneView.swift
@@ -1,0 +1,25 @@
+// agent/installer/macos-app/Sources/BreezeInstaller/Views/DoneView.swift
+import SwiftUI
+
+struct DoneView: View {
+    let orgName: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(.green)
+            Text("Breeze Agent installed")
+                .font(.title2).bold()
+            Text("Your Mac is now monitored under **\(orgName)**.")
+            Spacer()
+            HStack {
+                Spacer()
+                Button("Quit") { NSApp.terminate(nil) }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/agent/installer/macos-app/Sources/BreezeInstaller/Views/ErrorView.swift
+++ b/agent/installer/macos-app/Sources/BreezeInstaller/Views/ErrorView.swift
@@ -1,0 +1,32 @@
+// agent/installer/macos-app/Sources/BreezeInstaller/Views/ErrorView.swift
+import SwiftUI
+
+struct ErrorView: View {
+    let message: String
+    let recoverable: Bool
+    let onRetry: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 36))
+                .foregroundStyle(.orange)
+            Text("Install could not continue")
+                .font(.title3).bold()
+            Text(message)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer()
+            HStack {
+                Spacer()
+                Button("Quit") { NSApp.terminate(nil) }
+                    .keyboardShortcut(.cancelAction)
+                if recoverable {
+                    Button("Try again") { onRetry() }
+                        .keyboardShortcut(.defaultAction)
+                        .buttonStyle(.borderedProminent)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/agent/installer/macos-app/Sources/BreezeInstaller/Views/InstallingView.swift
+++ b/agent/installer/macos-app/Sources/BreezeInstaller/Views/InstallingView.swift
@@ -1,0 +1,17 @@
+// agent/installer/macos-app/Sources/BreezeInstaller/Views/InstallingView.swift
+import SwiftUI
+
+struct InstallingView: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .scaleEffect(1.2)
+            Text("Installing Breeze Agent…")
+                .font(.headline)
+            Text("This usually takes about 10 seconds.")
+                .foregroundStyle(.secondary)
+                .font(.subheadline)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/agent/installer/macos-app/Sources/BreezeInstaller/Views/LoadingView.swift
+++ b/agent/installer/macos-app/Sources/BreezeInstaller/Views/LoadingView.swift
@@ -1,0 +1,13 @@
+// agent/installer/macos-app/Sources/BreezeInstaller/Views/LoadingView.swift
+import SwiftUI
+
+struct LoadingView: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+            Text("Preparing installer…")
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/agent/installer/macos-app/Sources/BreezeInstaller/main.swift
+++ b/agent/installer/macos-app/Sources/BreezeInstaller/main.swift
@@ -1,2 +1,0 @@
-import Foundation
-print("BreezeInstaller stub")

--- a/agent/installer/macos-app/Sources/BreezeInstaller/main.swift
+++ b/agent/installer/macos-app/Sources/BreezeInstaller/main.swift
@@ -1,0 +1,2 @@
+import Foundation
+print("BreezeInstaller stub")

--- a/agent/installer/macos-app/Tests/BreezeInstallerTests/ArchitectureTests.swift
+++ b/agent/installer/macos-app/Tests/BreezeInstallerTests/ArchitectureTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import BreezeInstaller
+
+final class ArchitectureTests: XCTestCase {
+    func testMapsArm64() {
+        XCTAssertEqual(Architecture.fromUname("arm64\n"), .arm64)
+        XCTAssertEqual(Architecture.fromUname("arm64"), .arm64)
+    }
+
+    func testMapsAmd64() {
+        XCTAssertEqual(Architecture.fromUname("x86_64\n"), .amd64)
+        XCTAssertEqual(Architecture.fromUname("x86_64"), .amd64)
+    }
+
+    func testRejectsUnknown() {
+        XCTAssertNil(Architecture.fromUname("ppc"))
+        XCTAssertNil(Architecture.fromUname(""))
+    }
+
+    func testPickPkgFilenames() {
+        XCTAssertEqual(Architecture.arm64.pkgResourceName, "breeze-agent-arm64.pkg")
+        XCTAssertEqual(Architecture.amd64.pkgResourceName, "breeze-agent-amd64.pkg")
+    }
+}

--- a/agent/installer/macos-app/Tests/BreezeInstallerTests/FilenameTokenParserTests.swift
+++ b/agent/installer/macos-app/Tests/BreezeInstallerTests/FilenameTokenParserTests.swift
@@ -4,22 +4,22 @@ import XCTest
 final class FilenameTokenParserTests: XCTestCase {
     func testExtractsTokenAndHostFromCanonicalFilename() throws {
         let result = try FilenameTokenParser.parse(
-            bundleName: "Breeze Installer [A7K2XQ@us.2breeze.app].app"
+            bundleName: "Breeze Installer [A7K2XQMN4P@us.2breeze.app].app"
         )
-        XCTAssertEqual(result.token, "A7K2XQ")
+        XCTAssertEqual(result.token, "A7K2XQMN4P")
         XCTAssertEqual(result.apiHost, "us.2breeze.app")
     }
 
     func testHandlesNumericOnlyToken() throws {
         let result = try FilenameTokenParser.parse(
-            bundleName: "Breeze Installer [123456@eu.2breeze.app].app"
+            bundleName: "Breeze Installer [1234567890@eu.2breeze.app].app"
         )
-        XCTAssertEqual(result.token, "123456")
+        XCTAssertEqual(result.token, "1234567890")
     }
 
     func testRejectsLowercaseToken() {
         XCTAssertThrowsError(try FilenameTokenParser.parse(
-            bundleName: "Breeze Installer [a7k2xq@us.2breeze.app].app"
+            bundleName: "Breeze Installer [a7k2xqmn4p@us.2breeze.app].app"
         )) { error in
             XCTAssertEqual(error as? FilenameTokenParser.Error, .invalidFormat)
         }
@@ -35,7 +35,7 @@ final class FilenameTokenParserTests: XCTestCase {
 
     func testRejectsTooShortToken() {
         XCTAssertThrowsError(try FilenameTokenParser.parse(
-            bundleName: "Breeze Installer [A7K2X@us.2breeze.app].app"
+            bundleName: "Breeze Installer [A7K2XQMN4@us.2breeze.app].app"
         )) { error in
             XCTAssertEqual(error as? FilenameTokenParser.Error, .invalidFormat)
         }
@@ -43,7 +43,7 @@ final class FilenameTokenParserTests: XCTestCase {
 
     func testRejectsTooLongToken() {
         XCTAssertThrowsError(try FilenameTokenParser.parse(
-            bundleName: "Breeze Installer [A7K2XQ7@us.2breeze.app].app"
+            bundleName: "Breeze Installer [A7K2XQMN4PZ@us.2breeze.app].app"
         )) { error in
             XCTAssertEqual(error as? FilenameTokenParser.Error, .invalidFormat)
         }
@@ -51,13 +51,13 @@ final class FilenameTokenParserTests: XCTestCase {
 
     func testRejectsHostWithSpaces() {
         XCTAssertThrowsError(try FilenameTokenParser.parse(
-            bundleName: "Breeze Installer [A7K2XQ@us 2breeze.app].app"
+            bundleName: "Breeze Installer [A7K2XQMN4P@us 2breeze.app].app"
         ))
     }
 
     func testAcceptsCustomHostForSelfHosters() throws {
         let result = try FilenameTokenParser.parse(
-            bundleName: "Breeze Installer [A7K2XQ@rmm.acme.example].app"
+            bundleName: "Breeze Installer [A7K2XQMN4P@rmm.acme.example].app"
         )
         XCTAssertEqual(result.apiHost, "rmm.acme.example")
     }

--- a/agent/installer/macos-app/Tests/BreezeInstallerTests/FilenameTokenParserTests.swift
+++ b/agent/installer/macos-app/Tests/BreezeInstallerTests/FilenameTokenParserTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import BreezeInstaller
+
+final class FilenameTokenParserTests: XCTestCase {
+    func testExtractsTokenAndHostFromCanonicalFilename() throws {
+        let result = try FilenameTokenParser.parse(
+            bundleName: "Breeze Installer [A7K2XQ@us.2breeze.app].app"
+        )
+        XCTAssertEqual(result.token, "A7K2XQ")
+        XCTAssertEqual(result.apiHost, "us.2breeze.app")
+    }
+
+    func testHandlesNumericOnlyToken() throws {
+        let result = try FilenameTokenParser.parse(
+            bundleName: "Breeze Installer [123456@eu.2breeze.app].app"
+        )
+        XCTAssertEqual(result.token, "123456")
+    }
+
+    func testRejectsLowercaseToken() {
+        XCTAssertThrowsError(try FilenameTokenParser.parse(
+            bundleName: "Breeze Installer [a7k2xq@us.2breeze.app].app"
+        )) { error in
+            XCTAssertEqual(error as? FilenameTokenParser.Error, .invalidFormat)
+        }
+    }
+
+    func testRejectsMissingBracket() {
+        XCTAssertThrowsError(try FilenameTokenParser.parse(
+            bundleName: "Breeze Installer.app"
+        )) { error in
+            XCTAssertEqual(error as? FilenameTokenParser.Error, .invalidFormat)
+        }
+    }
+
+    func testRejectsTooShortToken() {
+        XCTAssertThrowsError(try FilenameTokenParser.parse(
+            bundleName: "Breeze Installer [A7K2X@us.2breeze.app].app"
+        )) { error in
+            XCTAssertEqual(error as? FilenameTokenParser.Error, .invalidFormat)
+        }
+    }
+
+    func testRejectsTooLongToken() {
+        XCTAssertThrowsError(try FilenameTokenParser.parse(
+            bundleName: "Breeze Installer [A7K2XQ7@us.2breeze.app].app"
+        )) { error in
+            XCTAssertEqual(error as? FilenameTokenParser.Error, .invalidFormat)
+        }
+    }
+
+    func testRejectsHostWithSpaces() {
+        XCTAssertThrowsError(try FilenameTokenParser.parse(
+            bundleName: "Breeze Installer [A7K2XQ@us 2breeze.app].app"
+        ))
+    }
+
+    func testAcceptsCustomHostForSelfHosters() throws {
+        let result = try FilenameTokenParser.parse(
+            bundleName: "Breeze Installer [A7K2XQ@rmm.acme.example].app"
+        )
+        XCTAssertEqual(result.apiHost, "rmm.acme.example")
+    }
+}

--- a/agent/installer/macos-app/Tests/BreezeInstallerTests/InstallerShellEscapeTests.swift
+++ b/agent/installer/macos-app/Tests/BreezeInstallerTests/InstallerShellEscapeTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import BreezeInstaller
+
+final class InstallerShellEscapeTests: XCTestCase {
+    func testSimpleString() {
+        XCTAssertEqual(Installer.shellEscape("hello"), "'hello'")
+    }
+
+    func testEmptyString() {
+        XCTAssertEqual(Installer.shellEscape(""), "''")
+    }
+
+    func testStringWithSpaces() {
+        XCTAssertEqual(Installer.shellEscape("hello world"), "'hello world'")
+    }
+
+    func testStringWithSingleQuote() {
+        // Classic POSIX single-quote escape: close quote, escaped quote, reopen quote
+        XCTAssertEqual(Installer.shellEscape("it's"), "'it'\\''s'")
+    }
+
+    func testStringWithMultipleSingleQuotes() {
+        XCTAssertEqual(Installer.shellEscape("'a' 'b'"), "''\\''a'\\'' '\\''b'\\'''")
+    }
+
+    func testStringWithDollarSignAndBacktick() {
+        // Inside single quotes these are literal; no escaping required
+        XCTAssertEqual(Installer.shellEscape("$USER `whoami`"), "'$USER `whoami`'")
+    }
+}

--- a/agent/installer/macos-app/Tests/BreezeInstallerTests/Placeholder.swift
+++ b/agent/installer/macos-app/Tests/BreezeInstallerTests/Placeholder.swift
@@ -1,0 +1,1 @@
+import XCTest

--- a/agent/installer/macos-app/build-app-bundle.sh
+++ b/agent/installer/macos-app/build-app-bundle.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# agent/installer/macos-app/build-app-bundle.sh
+#
+# Assembles Breeze Installer.app from the SPM-built executable.
+# Produces a universal (arm64 + x86_64) .app bundle.
+#
+# Usage:
+#   ./build-app-bundle.sh \
+#     --pkg-amd64 /path/to/breeze-agent-darwin-amd64.pkg \
+#     --pkg-arm64 /path/to/breeze-agent-darwin-arm64.pkg \
+#     --output    /path/to/output/Breeze\ Installer.app
+#
+# Requires Swift 5.9+ toolchain and macOS 13+ SDK (matches Package.swift target).
+set -euo pipefail
+
+PKG_AMD64=""
+PKG_ARM64=""
+OUTPUT=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pkg-amd64) PKG_AMD64="$2"; shift 2 ;;
+        --pkg-arm64) PKG_ARM64="$2"; shift 2 ;;
+        --output)    OUTPUT="$2";    shift 2 ;;
+        *) echo "Unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [[ -z "$PKG_AMD64" || -z "$PKG_ARM64" || -z "$OUTPUT" ]]; then
+    echo "Usage: $0 --pkg-amd64 PATH --pkg-arm64 PATH --output PATH" >&2
+    exit 1
+fi
+for f in "$PKG_AMD64" "$PKG_ARM64"; do
+    [[ -f "$f" ]] || { echo "Missing PKG: $f" >&2; exit 1; }
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "-> Building universal binary..."
+swift build -c release --arch arm64
+swift build -c release --arch x86_64
+ARM_BIN=".build/arm64-apple-macosx/release/BreezeInstaller"
+X86_BIN=".build/x86_64-apple-macosx/release/BreezeInstaller"
+[[ -f "$ARM_BIN" && -f "$X86_BIN" ]] || { echo "SPM build did not produce expected binaries" >&2; exit 1; }
+
+UNIVERSAL_BIN="$(mktemp -d)/BreezeInstaller"
+lipo -create "$ARM_BIN" "$X86_BIN" -output "$UNIVERSAL_BIN"
+file "$UNIVERSAL_BIN"
+
+echo "-> Assembling .app bundle at $OUTPUT..."
+rm -rf "$OUTPUT"
+mkdir -p "$OUTPUT/Contents/MacOS"
+mkdir -p "$OUTPUT/Contents/Resources"
+
+cp "$UNIVERSAL_BIN" "$OUTPUT/Contents/MacOS/BreezeInstaller"
+chmod 755 "$OUTPUT/Contents/MacOS/BreezeInstaller"
+
+cp Resources/Info.plist "$OUTPUT/Contents/Info.plist"
+if [[ -f Resources/AppIcon.icns ]]; then
+    cp Resources/AppIcon.icns "$OUTPUT/Contents/Resources/AppIcon.icns"
+fi
+
+cp "$PKG_AMD64" "$OUTPUT/Contents/Resources/breeze-agent-amd64.pkg"
+cp "$PKG_ARM64" "$OUTPUT/Contents/Resources/breeze-agent-arm64.pkg"
+
+echo "-> .app bundle assembled:"
+ls -la "$OUTPUT/Contents/"
+echo "Done. Sign + notarize with the CI workflow or manually:"
+echo "    codesign --force --options runtime --entitlements entitlements.plist \\"
+echo "      --sign \"Developer ID Application: ...\" --timestamp \"$OUTPUT\""

--- a/agent/installer/macos-app/entitlements.plist
+++ b/agent/installer/macos-app/entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <false/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <false/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <false/>
+</dict>
+</plist>

--- a/apps/api/migrations/2026-04-19-installer-bootstrap-tokens-constraints.sql
+++ b/apps/api/migrations/2026-04-19-installer-bootstrap-tokens-constraints.sql
@@ -1,0 +1,31 @@
+-- 2026-04-19 followup: tighten invariants on installer_bootstrap_tokens
+-- Adds CHECK constraints for max_usage, expires_at vs created_at,
+-- and sets ON DELETE SET NULL for the site_id FK (it was unset before,
+-- leaving orphan-risk if a site is deleted while a token still references it).
+--
+-- Fully idempotent.
+BEGIN;
+
+-- max_usage must be at least 1
+ALTER TABLE installer_bootstrap_tokens
+  DROP CONSTRAINT IF EXISTS installer_bootstrap_tokens_max_usage_positive;
+ALTER TABLE installer_bootstrap_tokens
+  ADD CONSTRAINT installer_bootstrap_tokens_max_usage_positive
+  CHECK (max_usage >= 1);
+
+-- expires_at must be strictly after created_at
+ALTER TABLE installer_bootstrap_tokens
+  DROP CONSTRAINT IF EXISTS installer_bootstrap_tokens_expires_after_created;
+ALTER TABLE installer_bootstrap_tokens
+  ADD CONSTRAINT installer_bootstrap_tokens_expires_after_created
+  CHECK (expires_at > created_at);
+
+-- site_id: set NULL on site deletion (was NO ACTION originally, causing orphan risk)
+-- Need to drop + re-add the FK to change onDelete behavior.
+ALTER TABLE installer_bootstrap_tokens
+  DROP CONSTRAINT IF EXISTS installer_bootstrap_tokens_site_id_fkey;
+ALTER TABLE installer_bootstrap_tokens
+  ADD CONSTRAINT installer_bootstrap_tokens_site_id_fkey
+  FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE SET NULL;
+
+COMMIT;

--- a/apps/api/migrations/2026-04-19-installer-bootstrap-tokens.sql
+++ b/apps/api/migrations/2026-04-19-installer-bootstrap-tokens.sql
@@ -1,0 +1,51 @@
+-- 2026-04-19: installer_bootstrap_tokens — single-use, short-TTL tokens for
+-- the macOS GUI installer. Tokens are issued at installer-download time and
+-- consumed by the unauthenticated /api/v1/installer/bootstrap/:token route.
+--
+-- RLS Shape 1 (direct org_id) — auto-discovered by the rls-coverage
+-- integration test, no allowlist entry needed.
+--
+-- Fully idempotent — safe to re-run.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS installer_bootstrap_tokens (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  token TEXT NOT NULL UNIQUE,
+  org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  parent_enrollment_key_id UUID NOT NULL REFERENCES enrollment_keys(id) ON DELETE CASCADE,
+  site_id UUID REFERENCES sites(id),
+  max_usage INTEGER NOT NULL DEFAULT 1,
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  consumed_at TIMESTAMPTZ,
+  consumed_from_ip TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_installer_bootstrap_tokens_expires
+  ON installer_bootstrap_tokens(expires_at);
+
+-- ============================================================
+-- RLS — Shape 1, direct org_id, standard four breeze_org_isolation policies
+-- ============================================================
+
+ALTER TABLE installer_bootstrap_tokens ENABLE ROW LEVEL SECURITY;
+ALTER TABLE installer_bootstrap_tokens FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON installer_bootstrap_tokens;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON installer_bootstrap_tokens;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON installer_bootstrap_tokens;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON installer_bootstrap_tokens;
+
+CREATE POLICY breeze_org_isolation_select ON installer_bootstrap_tokens
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON installer_bootstrap_tokens
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON installer_bootstrap_tokens
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON installer_bootstrap_tokens
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+COMMIT;

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -44,6 +44,7 @@
     "ioredis": "^5.10.1",
     "jose": "^6.1.3",
     "nanoid": "^5.1.7",
+    "node-stream-zip": "^1.15.0",
     "nodemailer": "^8.0.4",
     "otplib": "^13.1.0",
     "pg": "^8.13.1",

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -61,3 +61,4 @@ export * from './drPlans';
 export * from './localVault';
 export * from './incidentResponse';
 export * from './tunnels';
+export * from './installerBootstrapTokens';

--- a/apps/api/src/db/schema/installerBootstrapTokens.ts
+++ b/apps/api/src/db/schema/installerBootstrapTokens.ts
@@ -21,10 +21,12 @@ export const installerBootstrapTokens = pgTable(
     parentEnrollmentKeyId: uuid('parent_enrollment_key_id')
       .notNull()
       .references(() => enrollmentKeys.id, { onDelete: 'cascade' }),
-    siteId: uuid('site_id').references(() => sites.id),
+    siteId: uuid('site_id').references(() => sites.id, { onDelete: 'set null' }),
+    /** Must be >= 1; enforced by DB CHECK installer_bootstrap_tokens_max_usage_positive */
     maxUsage: integer('max_usage').notNull().default(1),
     createdBy: uuid('created_by').references(() => users.id, { onDelete: 'set null' }),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    /** Must be strictly after created_at; enforced by DB CHECK installer_bootstrap_tokens_expires_after_created */
     expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
     consumedAt: timestamp('consumed_at', { withTimezone: true }),
     consumedFromIp: text('consumed_from_ip'),

--- a/apps/api/src/db/schema/installerBootstrapTokens.ts
+++ b/apps/api/src/db/schema/installerBootstrapTokens.ts
@@ -1,0 +1,35 @@
+import { pgTable, uuid, text, integer, timestamp, index } from 'drizzle-orm/pg-core';
+import { organizations, sites, enrollmentKeys } from './orgs';
+import { users } from './users';
+
+/**
+ * Single-use, short-TTL token issued at installer-download time. The token
+ * is embedded in the macOS installer app filename (`Breeze Installer
+ * [TOKEN@host].app`) and exchanged for enrollment values on first launch via
+ * the unauthenticated `/api/v1/installer/bootstrap/:token` route.
+ *
+ * Stored as plain text (not hashed) intentionally: tokens are ephemeral
+ * (24h max), single-use, and hashing adds ceremony without a meaningful
+ * security win for this lifetime. Compare by equality.
+ */
+export const installerBootstrapTokens = pgTable(
+  'installer_bootstrap_tokens',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    token: text('token').notNull().unique(),
+    orgId: uuid('org_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
+    parentEnrollmentKeyId: uuid('parent_enrollment_key_id')
+      .notNull()
+      .references(() => enrollmentKeys.id, { onDelete: 'cascade' }),
+    siteId: uuid('site_id').references(() => sites.id),
+    maxUsage: integer('max_usage').notNull().default(1),
+    createdBy: uuid('created_by').references(() => users.id, { onDelete: 'set null' }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    consumedAt: timestamp('consumed_at', { withTimezone: true }),
+    consumedFromIp: text('consumed_from_ip'),
+  },
+  (t) => ({
+    expiresIdx: index('idx_installer_bootstrap_tokens_expires').on(t.expiresAt),
+  }),
+);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -32,6 +32,7 @@ import { logsRoutes } from './routes/logs';
 import { remoteRoutes } from './routes/remote';
 import { apiKeyRoutes } from './routes/apiKeys';
 import { enrollmentKeyRoutes, publicEnrollmentRoutes, publicShortLinkRoutes } from './routes/enrollmentKeys';
+import { installerRoutes } from './routes/installer';
 import { ssoRoutes } from './routes/sso';
 import { docsRoutes } from './routes/docs';
 import { accessReviewRoutes } from './routes/accessReviews';
@@ -670,6 +671,7 @@ api.route('/remote', remoteRoutes);
 api.route('/api-keys', apiKeyRoutes);
 api.route('/enrollment-keys', publicEnrollmentRoutes); // Public download (no auth) — must precede auth-protected routes
 api.route('/enrollment-keys', enrollmentKeyRoutes);
+api.route('/installer', installerRoutes);
 api.route('/sso', ssoRoutes);
 api.route('/docs', docsRoutes);
 api.route('/access-reviews', accessReviewRoutes);

--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -33,9 +33,9 @@ vi.mock('../db/schema/installerBootstrapTokens', () => ({
 }));
 
 vi.mock('../services/installerBootstrapToken', () => ({
-  generateBootstrapToken: vi.fn(() => 'ABC123'),
+  generateBootstrapToken: vi.fn(() => 'ABC1234567'),
   bootstrapTokenExpiresAt: vi.fn(() => new Date('2026-04-20T00:00:00.000Z')),
-  BOOTSTRAP_TOKEN_PATTERN: /^[A-Z0-9]{6}$/,
+  BOOTSTRAP_TOKEN_PATTERN: /^[A-Z0-9]{10}$/,
 }));
 
 vi.mock('../middleware/auth', () => ({
@@ -633,9 +633,11 @@ describe('POST /:id/bootstrap-token', () => {
       .mockReturnValueOnce(parentSelectMock)
       .mockReturnValueOnce(parentSelectMock);
 
-    // insert: create bootstrap token row (helper does not use .returning())
+    // insert: create bootstrap token row — helper now uses .returning() to get the row id
     vi.mocked(db.insert).mockReturnValueOnce({
-      values: vi.fn().mockResolvedValue(undefined),
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: 'token-row-uuid-1' }]),
+      }),
     } as any);
 
     const res = await app.request(`/enrollment-keys/${KEY_ID}/bootstrap-token`, {
@@ -646,7 +648,7 @@ describe('POST /:id/bootstrap-token', () => {
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.token).toMatch(/^[A-Z0-9]{6}$/);
+    expect(body.token).toMatch(/^[A-Z0-9]{10}$/);
     expect(body.expiresAt).toBeTypeOf('string');
     expect(body.maxUsage).toBe(1);
   });
@@ -749,7 +751,8 @@ describe('GET /:id/installer/macos — app-bundle path', () => {
 
     // Default: issueBootstrapTokenForKey succeeds with a fixed token
     issueSpy = vi.spyOn(installerBootstrapTokenIssuance, 'issueBootstrapTokenForKey').mockResolvedValue({
-      token: 'ABC123',
+      id: 'token-row-uuid-1',
+      token: 'ABC1234567',
       expiresAt: new Date('2026-04-20T00:00:00.000Z'),
       parentKeyName: 'Test Key',
     });
@@ -785,7 +788,7 @@ describe('GET /:id/installer/macos — app-bundle path', () => {
     expect(res.headers.get('Content-Type')).toBe('application/zip');
     const cd = res.headers.get('Content-Disposition') ?? '';
     // Should contain the bootstrap token + api host embedded in the filename
-    expect(cd).toMatch(/Breeze Installer \[ABC123@api\.example\.com\]\.app\.zip/);
+    expect(cd).toMatch(/Breeze Installer \[ABC1234567@api\.example\.com\]\.app\.zip/);
     expect(res.headers.get('Cache-Control')).toBe('no-store');
 
     // renameAppInZip was called with correct args
@@ -793,7 +796,7 @@ describe('GET /:id/installer/macos — app-bundle path', () => {
       Buffer.from('fixture-app-zip'),
       expect.objectContaining({
         oldAppName: 'Breeze Installer.app',
-        newAppName: 'Breeze Installer [ABC123@api.example.com].app',
+        newAppName: 'Breeze Installer [ABC1234567@api.example.com].app',
       }),
     );
   });

--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -24,6 +24,14 @@ vi.mock('../db/schema', () => ({
   installerBootstrapTokens: {},
 }));
 
+vi.mock('../db/schema/orgs', () => ({
+  enrollmentKeys: {},
+}));
+
+vi.mock('../db/schema/installerBootstrapTokens', () => ({
+  installerBootstrapTokens: {},
+}));
+
 vi.mock('../services/installerBootstrapToken', () => ({
   generateBootstrapToken: vi.fn(() => 'ABC123'),
   bootstrapTokenExpiresAt: vi.fn(() => new Date('2026-04-20T00:00:00.000Z')),
@@ -604,34 +612,22 @@ describe('POST /:id/bootstrap-token', () => {
 
   it('issues a bootstrap token for a valid parent key', async () => {
     const parent = makeKeyRow();
-    const tokenRow = {
-      id: randomUUID(),
-      token: 'ABC123',
-      orgId: ORG_ID,
-      parentEnrollmentKeyId: parent.id,
-      siteId: SITE_ID,
-      maxUsage: 1,
-      createdBy: 'user-system',
-      createdAt: new Date(),
-      expiresAt: new Date('2026-04-20T00:00:00.000Z'),
-      consumedAt: null,
-      consumedFromIp: null,
-    };
 
-    // select: look up parent key
-    vi.mocked(db.select).mockReturnValueOnce({
+    // select x2: route's access-control lookup + helper's business-rule lookup
+    const parentSelectMock = {
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
           limit: vi.fn().mockResolvedValue([parent]),
         }),
       }),
-    } as any);
+    } as any;
+    vi.mocked(db.select)
+      .mockReturnValueOnce(parentSelectMock)
+      .mockReturnValueOnce(parentSelectMock);
 
-    // insert: create bootstrap token row
+    // insert: create bootstrap token row (helper does not use .returning())
     vi.mocked(db.insert).mockReturnValueOnce({
-      values: vi.fn().mockReturnValue({
-        returning: vi.fn().mockResolvedValue([tokenRow]),
-      }),
+      values: vi.fn().mockResolvedValue(undefined),
     } as any);
 
     const res = await app.request(`/enrollment-keys/${KEY_ID}/bootstrap-token`, {
@@ -706,13 +702,17 @@ describe('POST /:id/bootstrap-token', () => {
       expiresAt: new Date(Date.now() - 10_000), // past
     });
 
-    vi.mocked(db.select).mockReturnValueOnce({
+    // select x2: route's access-control lookup + helper's business-rule lookup
+    const expiredSelectMock = {
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
           limit: vi.fn().mockResolvedValue([expiredParent]),
         }),
       }),
-    } as any);
+    } as any;
+    vi.mocked(db.select)
+      .mockReturnValueOnce(expiredSelectMock)
+      .mockReturnValueOnce(expiredSelectMock);
 
     const res = await app.request(`/enrollment-keys/${KEY_ID}/bootstrap-token`, {
       method: 'POST',

--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -21,6 +21,13 @@ vi.mock('../db', () => ({
 
 vi.mock('../db/schema', () => ({
   enrollmentKeys: {},
+  installerBootstrapTokens: {},
+}));
+
+vi.mock('../services/installerBootstrapToken', () => ({
+  generateBootstrapToken: vi.fn(() => 'ABC123'),
+  bootstrapTokenExpiresAt: vi.fn(() => new Date('2026-04-20T00:00:00.000Z')),
+  BOOTSTRAP_TOKEN_PATTERN: /^[A-Z0-9]{6}$/,
 }));
 
 vi.mock('../middleware/auth', () => ({
@@ -578,5 +585,141 @@ describe('GET /public-download/:platform', () => {
     );
 
     delete process.env.BINARY_VERSION;
+  });
+});
+
+// ============================================================
+// POST /:id/bootstrap-token
+// ============================================================
+
+describe('POST /:id/bootstrap-token', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.PUBLIC_API_URL = 'https://api.example.com';
+    app = new Hono();
+    app.route('/enrollment-keys', enrollmentKeyRoutes);
+  });
+
+  it('issues a bootstrap token for a valid parent key', async () => {
+    const parent = makeKeyRow();
+    const tokenRow = {
+      id: randomUUID(),
+      token: 'ABC123',
+      orgId: ORG_ID,
+      parentEnrollmentKeyId: parent.id,
+      siteId: SITE_ID,
+      maxUsage: 1,
+      createdBy: 'user-system',
+      createdAt: new Date(),
+      expiresAt: new Date('2026-04-20T00:00:00.000Z'),
+      consumedAt: null,
+      consumedFromIp: null,
+    };
+
+    // select: look up parent key
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([parent]),
+        }),
+      }),
+    } as any);
+
+    // insert: create bootstrap token row
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([tokenRow]),
+      }),
+    } as any);
+
+    const res = await app.request(`/enrollment-keys/${KEY_ID}/bootstrap-token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ maxUsage: 1 }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.token).toMatch(/^[A-Z0-9]{6}$/);
+    expect(body.expiresAt).toBeTypeOf('string');
+    expect(body.maxUsage).toBe(1);
+  });
+
+  it('rejects unknown parent key with 404', async () => {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    } as any);
+
+    const res = await app.request('/enrollment-keys/missing/bootstrap-token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ maxUsage: 1 }),
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects when caller has no org access (403)', async () => {
+    // Override authMiddleware to return a scope where canAccessOrg returns false
+    const { authMiddleware: mockAuth } = await import('../middleware/auth');
+    vi.mocked(mockAuth).mockImplementationOnce((c: any, next: any) => {
+      c.set('auth', {
+        scope: 'partner',
+        orgId: null,
+        user: { id: 'user-partner', email: 'partner@example.com' },
+        canAccessOrg: () => false,
+        accessibleOrgIds: [],
+      });
+      return next();
+    });
+
+    const restrictedApp = new Hono();
+    restrictedApp.route('/enrollment-keys', enrollmentKeyRoutes);
+
+    const parent = makeKeyRow();
+
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([parent]),
+        }),
+      }),
+    } as any);
+
+    const res = await restrictedApp.request(`/enrollment-keys/${KEY_ID}/bootstrap-token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ maxUsage: 1 }),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects expired parent key with 410', async () => {
+    const expiredParent = makeKeyRow({
+      expiresAt: new Date(Date.now() - 10_000), // past
+    });
+
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([expiredParent]),
+        }),
+      }),
+    } as any);
+
+    const res = await app.request(`/enrollment-keys/${KEY_ID}/bootstrap-token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ maxUsage: 1 }),
+    });
+
+    expect(res.status).toBe(410);
   });
 });

--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Hono } from 'hono';
 import { randomUUID } from 'crypto';
 
@@ -78,6 +78,11 @@ vi.mock('../services/installerBuilder', () => ({
   buildMacosInstallerZip: vi.fn(async () => Buffer.from('macos-zip')),
   fetchRegularMsi: vi.fn(async () => Buffer.from('regular-msi')),
   fetchMacosPkg: vi.fn(async () => Buffer.from('macos-pkg')),
+  fetchMacosInstallerAppZip: vi.fn(async () => null),
+}));
+
+vi.mock('../services/installerAppZip', () => ({
+  renameAppInZip: vi.fn(async (buf: Buffer) => buf),
 }));
 
 // Mock dynamic imports inside serveInstaller
@@ -95,6 +100,9 @@ vi.mock('../services/rate-limit', () => ({
 import { enrollmentKeyRoutes, publicEnrollmentRoutes, publicShortLinkRoutes } from './enrollmentKeys';
 import { db, withSystemDbAccessContext } from '../db';
 import { MsiSigningService } from '../services/msiSigning';
+import { fetchMacosInstallerAppZip } from '../services/installerBuilder';
+import { renameAppInZip } from '../services/installerAppZip';
+import * as installerBootstrapTokenIssuance from '../services/installerBootstrapTokenIssuance';
 
 // ============================================================
 // Helpers
@@ -721,5 +729,153 @@ describe('POST /:id/bootstrap-token', () => {
     });
 
     expect(res.status).toBe(410);
+  });
+});
+
+// ============================================================
+// GET /:id/installer/macos — app-bundle path
+// ============================================================
+
+describe('GET /:id/installer/macos — app-bundle path', () => {
+  let app: Hono;
+  let issueSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(MsiSigningService.fromEnv).mockReturnValue(null);
+    process.env.PUBLIC_API_URL = 'https://api.example.com';
+    app = new Hono();
+    app.route('/enrollment-keys', enrollmentKeyRoutes);
+
+    // Default: issueBootstrapTokenForKey succeeds with a fixed token
+    issueSpy = vi.spyOn(installerBootstrapTokenIssuance, 'issueBootstrapTokenForKey').mockResolvedValue({
+      token: 'ABC123',
+      expiresAt: new Date('2026-04-20T00:00:00.000Z'),
+      parentKeyName: 'Test Key',
+    });
+  });
+
+  afterEach(() => {
+    issueSpy.mockRestore();
+  });
+
+  it('returns a renamed app zip when installer app is available', async () => {
+    const parentRow = makeKeyRow();
+
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([parentRow]),
+        }),
+      }),
+    } as any);
+
+    // fetchMacosInstallerAppZip returns a fixture buffer
+    vi.mocked(fetchMacosInstallerAppZip).mockResolvedValueOnce(Buffer.from('fixture-app-zip'));
+
+    // renameAppInZip returns a renamed buffer
+    vi.mocked(renameAppInZip).mockResolvedValueOnce(Buffer.from('renamed-app-zip'));
+
+    const res = await app.request(
+      `/enrollment-keys/${KEY_ID}/installer/macos?count=1`,
+      { headers: { authorization: 'Bearer jwt' } },
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/zip');
+    const cd = res.headers.get('Content-Disposition') ?? '';
+    // Should contain the bootstrap token + api host embedded in the filename
+    expect(cd).toMatch(/Breeze Installer \[ABC123@api\.example\.com\]\.app\.zip/);
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+
+    // renameAppInZip was called with correct args
+    expect(vi.mocked(renameAppInZip)).toHaveBeenCalledWith(
+      Buffer.from('fixture-app-zip'),
+      expect.objectContaining({
+        oldAppName: 'Breeze Installer.app',
+        newAppName: 'Breeze Installer [ABC123@api.example.com].app',
+      }),
+    );
+  });
+
+  it('falls back to legacy zip when ?legacy=1 is passed', async () => {
+    const parentRow = makeKeyRow();
+    const childRow = makeChildKeyRow({ installerPlatform: 'macos' });
+
+    // select: parent key lookup + allocateShortCode dedup check
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([parentRow]),
+          }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]), // no existing short code → unique
+          }),
+        }),
+      } as any);
+
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([childRow]),
+      }),
+    } as any);
+
+    // fetchMacosInstallerAppZip is NOT called when ?legacy=1 is passed
+    // (wantLegacy=true → appZip=null without calling the function)
+
+    const res = await app.request(
+      `/enrollment-keys/${KEY_ID}/installer/macos?count=1&legacy=1`,
+      { headers: { authorization: 'Bearer jwt' } },
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Disposition')).toContain('breeze-agent-macos.zip');
+    // The app-bundle path must NOT have been called
+    expect(vi.mocked(renameAppInZip)).not.toHaveBeenCalled();
+    expect(issueSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to legacy zip when installer app asset is missing (returns null)', async () => {
+    const parentRow = makeKeyRow();
+    const childRow = makeChildKeyRow({ installerPlatform: 'macos' });
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([parentRow]),
+          }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as any);
+
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([childRow]),
+      }),
+    } as any);
+
+    // fetchMacosInstallerAppZip default mock returns null → falls back to legacy path
+
+    const res = await app.request(
+      `/enrollment-keys/${KEY_ID}/installer/macos?count=1`,
+      { headers: { authorization: 'Bearer jwt' } },
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Disposition')).toContain('breeze-agent-macos.zip');
+    expect(vi.mocked(renameAppInZip)).not.toHaveBeenCalled();
+    expect(issueSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -602,24 +602,37 @@ enrollmentKeyRoutes.get(
 
         const apiHost = new URL(serverUrl).host;
         const newAppName = `Breeze Installer [${issued.token}@${apiHost}].app`;
-        const renamedZip = await renameAppInZip(appZip, {
-          oldAppName: 'Breeze Installer.app',
-          newAppName,
-        });
 
-        writeEnrollmentKeyAudit(c, auth, {
-          orgId: parentKey.orgId,
-          action: 'enrollment_key.installer_download',
-          keyId: parentKey.id,
-          keyName: parentKey.name,
-          details: { platform, mode: 'app-bundle', token: issued.token, count: childMaxUsage },
-        });
+        let renamedZip: Buffer | undefined;
+        try {
+          renamedZip = await renameAppInZip(appZip, {
+            oldAppName: 'Breeze Installer.app',
+            newAppName,
+          });
+        } catch (err) {
+          console.error('[installer] renameAppInZip failed, falling back to legacy zip', {
+            parentKeyId: parentKey.id,
+            tokenId: issued.id, // orphaned bootstrap token — will expire normally
+            error: err instanceof Error ? err.message : String(err),
+          });
+          // Fall through to legacy path — do NOT return.
+        }
 
-        c.header('Content-Type', 'application/zip');
-        c.header('Content-Disposition', `attachment; filename="${newAppName}.zip"`);
-        c.header('Content-Length', String(renamedZip.length));
-        c.header('Cache-Control', 'no-store');
-        return c.body(renamedZip as unknown as ArrayBuffer);
+        if (renamedZip) {
+          writeEnrollmentKeyAudit(c, auth, {
+            orgId: parentKey.orgId,
+            action: 'enrollment_key.installer_download',
+            keyId: parentKey.id,
+            keyName: parentKey.name,
+            details: { platform, mode: 'app-bundle', tokenId: issued.id, count: childMaxUsage },
+          });
+
+          c.header('Content-Type', 'application/zip');
+          c.header('Content-Disposition', `attachment; filename="${newAppName}.zip"`);
+          c.header('Content-Length', String(renamedZip.length));
+          c.header('Cache-Control', 'no-store');
+          return c.body(renamedZip as unknown as ArrayBuffer);
+        }
       }
 
       // Falls through to legacy path below.
@@ -810,7 +823,7 @@ enrollmentKeyRoutes.post(
     }
 
     try {
-      const { token, expiresAt } = await issueBootstrapTokenForKey({
+      const { id: tokenId, token, expiresAt } = await issueBootstrapTokenForKey({
         parentEnrollmentKeyId: parent.id,
         createdByUserId: auth.user.id,
         maxUsage,
@@ -821,7 +834,7 @@ enrollmentKeyRoutes.post(
         action: 'enrollment_key.bootstrap_token_issued',
         keyId: parent.id,
         keyName: parent.name,
-        details: { maxUsage },
+        details: { maxUsage, tokenId },
       });
 
       return c.json({ token, expiresAt: expiresAt.toISOString(), maxUsage });

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -13,8 +13,9 @@ import { PERMISSIONS } from '../services/permissions';
 import { hashEnrollmentKey } from '../services/enrollmentKeySecurity';
 import {
   buildMacosInstallerZip, buildWindowsInstallerZip,
-  fetchRegularMsi, fetchMacosPkg,
+  fetchRegularMsi, fetchMacosPkg, fetchMacosInstallerAppZip,
 } from '../services/installerBuilder';
+import { renameAppInZip } from '../services/installerAppZip';
 import {
   issueBootstrapTokenForKey,
   BootstrapTokenIssuanceError,
@@ -568,6 +569,60 @@ enrollmentKeyRoutes.get(
     const globalSecret = process.env.AGENT_ENROLLMENT_SECRET || '';
     if (!globalSecret && parentKey.keySecretHash) {
       console.warn('[installer] AGENT_ENROLLMENT_SECRET not configured but parent key has a secret hash — agents may fail to enroll');
+    }
+
+    // ----------------------------------------------------------------
+    // macOS — new app-bundle path (bootstrap token + renamed app zip)
+    // Runs before the legacy binary fetch and child key creation.
+    // Falls through to the legacy path when:
+    //   (a) caller passed ?legacy=1, OR
+    //   (b) the installer-app asset is not yet published on GitHub.
+    // ----------------------------------------------------------------
+    if (platform === 'macos') {
+      const wantLegacy = c.req.query('legacy') === '1';
+      const appZip = wantLegacy ? null : await fetchMacosInstallerAppZip();
+
+      if (appZip) {
+        // New path — bootstrap token + renamed app zip. No child enrollment key
+        // is created here; the bootstrap endpoint creates it lazily on consume.
+        let issued;
+        try {
+          issued = await issueBootstrapTokenForKey({
+            parentEnrollmentKeyId: parentKey.id,
+            createdByUserId: auth.user.id,
+            maxUsage: childMaxUsage,
+          });
+        } catch (err) {
+          if (err instanceof BootstrapTokenIssuanceError) {
+            if (err.code === 'parent_not_found') return c.json({ error: err.message }, 404);
+            return c.json({ error: err.message }, 410);
+          }
+          throw err;
+        }
+
+        const apiHost = new URL(serverUrl).host;
+        const newAppName = `Breeze Installer [${issued.token}@${apiHost}].app`;
+        const renamedZip = await renameAppInZip(appZip, {
+          oldAppName: 'Breeze Installer.app',
+          newAppName,
+        });
+
+        writeEnrollmentKeyAudit(c, auth, {
+          orgId: parentKey.orgId,
+          action: 'enrollment_key.installer_download',
+          keyId: parentKey.id,
+          keyName: parentKey.name,
+          details: { platform, mode: 'app-bundle', token: issued.token, count: childMaxUsage },
+        });
+
+        c.header('Content-Type', 'application/zip');
+        c.header('Content-Disposition', `attachment; filename="${newAppName}.zip"`);
+        c.header('Content-Length', String(renamedZip.length));
+        c.header('Cache-Control', 'no-store');
+        return c.body(renamedZip as unknown as ArrayBuffer);
+      }
+
+      // Falls through to legacy path below.
     }
 
     // Determine signing availability and fetch the binary BEFORE creating

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -15,8 +15,10 @@ import {
   buildMacosInstallerZip, buildWindowsInstallerZip,
   fetchRegularMsi, fetchMacosPkg,
 } from '../services/installerBuilder';
-import { generateBootstrapToken, bootstrapTokenExpiresAt } from '../services/installerBootstrapToken';
-import { installerBootstrapTokens } from '../db/schema/installerBootstrapTokens';
+import {
+  issueBootstrapTokenForKey,
+  BootstrapTokenIssuanceError,
+} from '../services/installerBootstrapTokenIssuance';
 import { MsiSigningService } from '../services/msiSigning';
 import { getGithubReleaseVersion } from '../services/binarySource';
 import { captureException } from '../services/sentry';
@@ -752,42 +754,29 @@ enrollmentKeyRoutes.post(
       return c.json({ error: 'Access denied' }, 403);
     }
 
-    if (parent.expiresAt && new Date(parent.expiresAt) < new Date()) {
-      return c.json({ error: 'Enrollment key has expired' }, 410);
-    }
-    if (parent.maxUsage !== null && parent.usageCount >= parent.maxUsage) {
-      return c.json({ error: 'Enrollment key usage exhausted' }, 410);
-    }
-
-    const token = generateBootstrapToken();
-    const expiresAt = bootstrapTokenExpiresAt();
-
-    const [row] = await db
-      .insert(installerBootstrapTokens)
-      .values({
-        token,
-        orgId: parent.orgId,
+    try {
+      const { token, expiresAt } = await issueBootstrapTokenForKey({
         parentEnrollmentKeyId: parent.id,
-        siteId: parent.siteId,
+        createdByUserId: auth.user.id,
         maxUsage,
-        createdBy: auth.user.id,
-        expiresAt,
-      })
-      .returning();
+      });
 
-    writeEnrollmentKeyAudit(c, auth, {
-      orgId: parent.orgId,
-      action: 'enrollment_key.bootstrap_token_issued',
-      keyId: parent.id,
-      keyName: parent.name,
-      details: { tokenId: row.id, maxUsage },
-    });
+      writeEnrollmentKeyAudit(c, auth, {
+        orgId: parent.orgId,
+        action: 'enrollment_key.bootstrap_token_issued',
+        keyId: parent.id,
+        keyName: parent.name,
+        details: { maxUsage },
+      });
 
-    return c.json({
-      token,
-      expiresAt: expiresAt.toISOString(),
-      maxUsage,
-    });
+      return c.json({ token, expiresAt: expiresAt.toISOString(), maxUsage });
+    } catch (err) {
+      if (err instanceof BootstrapTokenIssuanceError) {
+        if (err.code === 'parent_not_found') return c.json({ error: err.message }, 404);
+        return c.json({ error: err.message }, 410);
+      }
+      throw err;
+    }
   },
 );
 

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -15,6 +15,8 @@ import {
   buildMacosInstallerZip, buildWindowsInstallerZip,
   fetchRegularMsi, fetchMacosPkg,
 } from '../services/installerBuilder';
+import { generateBootstrapToken, bootstrapTokenExpiresAt } from '../services/installerBootstrapToken';
+import { installerBootstrapTokens } from '../db/schema/installerBootstrapTokens';
 import { MsiSigningService } from '../services/msiSigning';
 import { getGithubReleaseVersion } from '../services/binarySource';
 import { captureException } from '../services/sentry';
@@ -714,6 +716,79 @@ enrollmentKeyRoutes.get(
       return c.json({ error: 'Failed to build installer', detail }, 500);
     }
   }
+);
+
+// ============================================
+// POST /:id/bootstrap-token — issue a single-use installer bootstrap token
+// ============================================
+
+const bootstrapTokenBodySchema = z.object({
+  maxUsage: z.number().int().min(1).max(1000).default(1),
+});
+
+enrollmentKeyRoutes.post(
+  '/:id/bootstrap-token',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action),
+  requireMfa(),
+  zValidator('json', bootstrapTokenBodySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const keyId = c.req.param('id')!;
+    const { maxUsage } = c.req.valid('json');
+
+    const [parent] = await db
+      .select()
+      .from(enrollmentKeys)
+      .where(eq(enrollmentKeys.id, keyId))
+      .limit(1);
+
+    if (!parent) {
+      return c.json({ error: 'Enrollment key not found' }, 404);
+    }
+
+    const hasAccess = await ensureOrgAccess(parent.orgId, auth);
+    if (!hasAccess) {
+      return c.json({ error: 'Access denied' }, 403);
+    }
+
+    if (parent.expiresAt && new Date(parent.expiresAt) < new Date()) {
+      return c.json({ error: 'Enrollment key has expired' }, 410);
+    }
+    if (parent.maxUsage !== null && parent.usageCount >= parent.maxUsage) {
+      return c.json({ error: 'Enrollment key usage exhausted' }, 410);
+    }
+
+    const token = generateBootstrapToken();
+    const expiresAt = bootstrapTokenExpiresAt();
+
+    const [row] = await db
+      .insert(installerBootstrapTokens)
+      .values({
+        token,
+        orgId: parent.orgId,
+        parentEnrollmentKeyId: parent.id,
+        siteId: parent.siteId,
+        maxUsage,
+        createdBy: auth.user.id,
+        expiresAt,
+      })
+      .returning();
+
+    writeEnrollmentKeyAudit(c, auth, {
+      orgId: parent.orgId,
+      action: 'enrollment_key.bootstrap_token_issued',
+      keyId: parent.id,
+      keyName: parent.name,
+      details: { tokenId: row.id, maxUsage },
+    });
+
+    return c.json({
+      token,
+      expiresAt: expiresAt.toISOString(),
+      maxUsage,
+    });
+  },
 );
 
 // ============================================

--- a/apps/api/src/routes/enrollmentKeys_installer.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_installer.test.ts
@@ -67,6 +67,22 @@ vi.mock('../services/installerBuilder', () => ({
   buildWindowsInstallerZip: vi.fn(async () => Buffer.from('fake-windows-zip')),
   fetchRegularMsi: vi.fn(async () => Buffer.alloc(2048, 0xbb)),
   fetchMacosPkg: vi.fn(async () => Buffer.alloc(2048, 0xcc)),
+  // Plan C — returns null so macOS tests fall through to the legacy pkg path.
+  fetchMacosInstallerAppZip: vi.fn(async () => null),
+}));
+
+// Plan C imports — mocked so Vitest can resolve them even though neither is
+// called in the legacy (fetchMacosInstallerAppZip → null) code path.
+vi.mock('../services/installerAppZip', () => ({
+  renameAppInZip: vi.fn(),
+}));
+
+vi.mock('../services/installerBootstrapTokenIssuance', () => ({
+  issueBootstrapTokenForKey: vi.fn(),
+  BootstrapTokenIssuanceError: class BootstrapTokenIssuanceError extends Error {
+    code: string;
+    constructor(code: string, msg: string) { super(msg); this.code = code; }
+  },
 }));
 
 vi.mock('../services/msiSigning', () => ({

--- a/apps/api/src/routes/installer.test.ts
+++ b/apps/api/src/routes/installer.test.ts
@@ -9,6 +9,7 @@ vi.mock('../db', () => ({
     select: vi.fn(),
     update: vi.fn(),
     insert: vi.fn(),
+    delete: vi.fn(),
   },
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
@@ -48,7 +49,7 @@ describe('GET /api/v1/installer/bootstrap/:token', () => {
     } as any);
 
     const app = makeApp();
-    const res = await app.request('/api/v1/installer/bootstrap/AAAAAA');
+    const res = await app.request('/api/v1/installer/bootstrap/AAAAAAAAAA');
     expect(res.status).toBe(404);
     expect(await res.json()).toEqual({ error: 'token invalid, expired, or already used' });
   });
@@ -58,7 +59,7 @@ describe('GET /api/v1/installer/bootstrap/:token', () => {
       from: () => ({
         where: () => ({
           limit: () => Promise.resolve([{
-            id: 't1', token: 'BBBBBB', orgId: 'o1',
+            id: 't1', token: 'BBBBBBBBBB', orgId: 'o1',
             parentEnrollmentKeyId: 'pk1', siteId: 's1', maxUsage: 1,
             consumedAt: new Date(), expiresAt: new Date(Date.now() + 60_000),
           }]),
@@ -67,7 +68,7 @@ describe('GET /api/v1/installer/bootstrap/:token', () => {
     } as any);
 
     const app = makeApp();
-    const res = await app.request('/api/v1/installer/bootstrap/BBBBBB');
+    const res = await app.request('/api/v1/installer/bootstrap/BBBBBBBBBB');
     expect(res.status).toBe(404);
   });
 
@@ -76,7 +77,7 @@ describe('GET /api/v1/installer/bootstrap/:token', () => {
       from: () => ({
         where: () => ({
           limit: () => Promise.resolve([{
-            id: 't1', token: 'CCCCCC', orgId: 'o1',
+            id: 't1', token: 'CCCCCCCCCC', orgId: 'o1',
             parentEnrollmentKeyId: 'pk1', siteId: 's1', maxUsage: 1,
             consumedAt: null, expiresAt: new Date(Date.now() - 1000),
           }]),
@@ -85,7 +86,7 @@ describe('GET /api/v1/installer/bootstrap/:token', () => {
     } as any);
 
     const app = makeApp();
-    const res = await app.request('/api/v1/installer/bootstrap/CCCCCC');
+    const res = await app.request('/api/v1/installer/bootstrap/CCCCCCCCCC');
     expect(res.status).toBe(404);
   });
 
@@ -94,7 +95,7 @@ describe('GET /api/v1/installer/bootstrap/:token', () => {
     process.env.AGENT_ENROLLMENT_SECRET = 'shared-secret-test';
 
     const tokenRow = {
-      id: 't1', token: 'DDDDDD', orgId: 'o1',
+      id: 't1', token: 'DDDDDDDDDD', orgId: 'o1',
       parentEnrollmentKeyId: 'pk1', siteId: 's1', maxUsage: 3,
       createdBy: 'u1',
       consumedAt: null, expiresAt: new Date(Date.now() + 60_000),
@@ -102,9 +103,11 @@ describe('GET /api/v1/installer/bootstrap/:token', () => {
     const parentKey = {
       id: 'pk1', name: 'Acme parent', orgId: 'o1', siteId: 's1',
       keySecretHash: 'parent-secret-hash',
+      expiresAt: new Date(Date.now() + 60_000 * 60),
     };
     const org = { id: 'o1', name: 'Acme Corp' };
 
+    // Select call order: (1) token row, (2) parent key, (3) org name
     vi.mocked(db.select)
       .mockReturnValueOnce({
         from: () => ({ where: () => ({ limit: () => Promise.resolve([tokenRow]) }) }),
@@ -116,6 +119,14 @@ describe('GET /api/v1/installer/bootstrap/:token', () => {
         from: () => ({ where: () => ({ limit: () => Promise.resolve([org]) }) }),
       } as any);
 
+    // INSERT child key
+    vi.mocked(db.insert).mockReturnValue({
+      values: () => ({
+        returning: () => Promise.resolve([{ id: 'ck1', orgId: 'o1', siteId: 's1' }]),
+      }),
+    } as any);
+
+    // UPDATE consume (returns consumed row)
     vi.mocked(db.update).mockReturnValue({
       set: () => ({
         where: () => ({
@@ -124,14 +135,8 @@ describe('GET /api/v1/installer/bootstrap/:token', () => {
       }),
     } as any);
 
-    vi.mocked(db.insert).mockReturnValue({
-      values: () => ({
-        returning: () => Promise.resolve([{ id: 'ck1', orgId: 'o1', siteId: 's1' }]),
-      }),
-    } as any);
-
     const app = makeApp();
-    const res = await app.request('/api/v1/installer/bootstrap/DDDDDD');
+    const res = await app.request('/api/v1/installer/bootstrap/DDDDDDDDDD');
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.serverUrl).toBe('https://us.2breeze.app');

--- a/apps/api/src/routes/installer.test.ts
+++ b/apps/api/src/routes/installer.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ============================================================
+// Mocks — must appear before any `import` of the source
+// ============================================================
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(),
+    update: vi.fn(),
+    insert: vi.fn(),
+  },
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../services/enrollmentKeySecurity', () => ({
+  hashEnrollmentKey: vi.fn((k: string) => `hashed:${k}`),
+}));
+
+// ============================================================
+// Imports after mocks
+// ============================================================
+
+import { Hono } from 'hono';
+import { installerRoutes } from './installer';
+import { db } from '../db';
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/api/v1/installer', installerRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /api/v1/installer/bootstrap/:token', () => {
+  it('returns 400 for malformed token', async () => {
+    const app = makeApp();
+    const res = await app.request('/api/v1/installer/bootstrap/lowercase');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for unknown token', async () => {
+    vi.mocked(db.select).mockReturnValue({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve([]) }) }),
+    } as any);
+
+    const app = makeApp();
+    const res = await app.request('/api/v1/installer/bootstrap/AAAAAA');
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'token invalid, expired, or already used' });
+  });
+
+  it('returns 404 for already-consumed token', async () => {
+    vi.mocked(db.select).mockReturnValue({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve([{
+            id: 't1', token: 'BBBBBB', orgId: 'o1',
+            parentEnrollmentKeyId: 'pk1', siteId: 's1', maxUsage: 1,
+            consumedAt: new Date(), expiresAt: new Date(Date.now() + 60_000),
+          }]),
+        }),
+      }),
+    } as any);
+
+    const app = makeApp();
+    const res = await app.request('/api/v1/installer/bootstrap/BBBBBB');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for expired token', async () => {
+    vi.mocked(db.select).mockReturnValue({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve([{
+            id: 't1', token: 'CCCCCC', orgId: 'o1',
+            parentEnrollmentKeyId: 'pk1', siteId: 's1', maxUsage: 1,
+            consumedAt: null, expiresAt: new Date(Date.now() - 1000),
+          }]),
+        }),
+      }),
+    } as any);
+
+    const app = makeApp();
+    const res = await app.request('/api/v1/installer/bootstrap/CCCCCC');
+    expect(res.status).toBe(404);
+  });
+
+  it('happy path: consumes token, creates child key, returns enrollment payload', async () => {
+    process.env.PUBLIC_API_URL = 'https://us.2breeze.app';
+    process.env.AGENT_ENROLLMENT_SECRET = 'shared-secret-test';
+
+    const tokenRow = {
+      id: 't1', token: 'DDDDDD', orgId: 'o1',
+      parentEnrollmentKeyId: 'pk1', siteId: 's1', maxUsage: 3,
+      createdBy: 'u1',
+      consumedAt: null, expiresAt: new Date(Date.now() + 60_000),
+    };
+    const parentKey = {
+      id: 'pk1', name: 'Acme parent', orgId: 'o1', siteId: 's1',
+      keySecretHash: 'parent-secret-hash',
+    };
+    const org = { id: 'o1', name: 'Acme Corp' };
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: () => ({ where: () => ({ limit: () => Promise.resolve([tokenRow]) }) }),
+      } as any)
+      .mockReturnValueOnce({
+        from: () => ({ where: () => ({ limit: () => Promise.resolve([parentKey]) }) }),
+      } as any)
+      .mockReturnValueOnce({
+        from: () => ({ where: () => ({ limit: () => Promise.resolve([org]) }) }),
+      } as any);
+
+    vi.mocked(db.update).mockReturnValue({
+      set: () => ({
+        where: () => ({
+          returning: () => Promise.resolve([{ ...tokenRow, consumedAt: new Date() }]),
+        }),
+      }),
+    } as any);
+
+    vi.mocked(db.insert).mockReturnValue({
+      values: () => ({
+        returning: () => Promise.resolve([{ id: 'ck1', orgId: 'o1', siteId: 's1' }]),
+      }),
+    } as any);
+
+    const app = makeApp();
+    const res = await app.request('/api/v1/installer/bootstrap/DDDDDD');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.serverUrl).toBe('https://us.2breeze.app');
+    expect(body.enrollmentSecret).toBe('shared-secret-test');
+    expect(body.siteId).toBe('s1');
+    expect(body.orgName).toBe('Acme Corp');
+    expect(body.enrollmentKey).toMatch(/^[a-f0-9]{64}$/);
+  });
+});

--- a/apps/api/src/routes/installer.ts
+++ b/apps/api/src/routes/installer.ts
@@ -11,8 +11,24 @@ const CHILD_TTL_MIN = Number(
   process.env.CHILD_ENROLLMENT_KEY_TTL_MINUTES ?? 24 * 60,
 );
 
-function freshChildExpiresAt(): Date {
-  return new Date(Date.now() + CHILD_TTL_MIN * 60 * 1000);
+/**
+ * Returns the child enrollment key expiry: the earlier of
+ *   (a) the parent's own expiry, or
+ *   (b) now + CHILD_TTL_MIN
+ *
+ * This prevents a child key from outliving its parent, which would
+ * implicitly extend access for a revoked/expired parent key.
+ *
+ * Returns null if the parent is already expired — callers should treat
+ * null as a signal to reject the request.
+ */
+function freshChildExpiresAt(parentExpiresAt: Date): Date | null {
+  const now = Date.now();
+  if (parentExpiresAt.getTime() <= now) {
+    return null; // parent already expired — reject
+  }
+  const childTtlMs = CHILD_TTL_MIN * 60 * 1000;
+  return new Date(Math.min(parentExpiresAt.getTime(), now + childTtlMs));
 }
 
 function generateChildEnrollmentKey(): string {
@@ -33,6 +49,14 @@ export const installerRoutes = new Hono();
  *
  * Invalid / expired / already-used tokens all return the same 404 to
  * avoid leaking which condition was hit.
+ *
+ * C1 (atomicity): We INSERT the child enrollment key BEFORE marking the
+ * token consumed. If the atomic UPDATE returns empty (concurrent consume),
+ * we DELETE the child key we just created and return 404. This reorder
+ * approach avoids nested transactions (withSystemDbAccessContext already
+ * wraps everything in a Postgres transaction for RLS context injection),
+ * while ensuring the token is never permanently burned without a usable
+ * child key.
  */
 installerRoutes.get('/bootstrap/:token', async (c) => {
   const token = c.req.param('token');
@@ -40,44 +64,65 @@ installerRoutes.get('/bootstrap/:token', async (c) => {
     return c.json({ error: 'invalid token' }, 400);
   }
 
+  const ip = c.req.header('cf-connecting-ip') ?? 'unknown';
+
   const result = await withSystemDbAccessContext(async () => {
+    // ── 1. Look up token ──────────────────────────────────────────────
     const [row] = await db
       .select()
       .from(installerBootstrapTokens)
       .where(eq(installerBootstrapTokens.token, token))
       .limit(1);
-    if (!row) return null;
-    if (row.consumedAt) return null;
-    if (new Date(row.expiresAt) < new Date()) return null;
 
-    // Atomic single-use guard: UPDATE ... WHERE consumed_at IS NULL.
-    // Two concurrent requests both read row.consumedAt = null but only one
-    // UPDATE will return a row (Postgres serializes the write).
-    const [updated] = await db
-      .update(installerBootstrapTokens)
-      .set({
-        consumedAt: new Date(),
-        consumedFromIp: c.req.header('cf-connecting-ip') ?? null,
-      })
-      .where(
-        and(
-          eq(installerBootstrapTokens.id, row.id),
-          isNull(installerBootstrapTokens.consumedAt),
-        ),
-      )
-      .returning();
-    if (!updated) return null;
+    if (!row) {
+      console.error('[installer] bootstrap 404', { reason: 'no_row', token, ip });
+      return null;
+    }
 
+    if (row.consumedAt) {
+      console.error('[installer] bootstrap 404', { reason: 'already_consumed', tokenId: row.id, ip });
+      return null;
+    }
+
+    if (new Date(row.expiresAt) < new Date()) {
+      console.error('[installer] bootstrap 404', { reason: 'expired', tokenId: row.id, ip });
+      return null;
+    }
+
+    // ── 2. Resolve parent enrollment key; validate it's not expired ───
     const [parent] = await db
       .select()
       .from(enrollmentKeys)
       .where(eq(enrollmentKeys.id, row.parentEnrollmentKeyId))
       .limit(1);
-    if (!parent) return null;
 
+    if (!parent) {
+      // Data-integrity anomaly: token references a parent key that no longer exists.
+      console.error('[installer] bootstrap orphaned parent — data integrity incident', {
+        reason: 'orphaned_parent',
+        tokenId: row.id,
+        parentEnrollmentKeyId: row.parentEnrollmentKeyId,
+        ip,
+      });
+      return null;
+    }
+
+    // If the parent has no expiry set, fall back to the child TTL only
+    // (no upper bound from parent). If it does have an expiry, bound by it.
+    const parentExpiresAt = parent.expiresAt ? new Date(parent.expiresAt) : null;
+    const childExpiresAt = parentExpiresAt
+      ? freshChildExpiresAt(parentExpiresAt)
+      : new Date(Date.now() + CHILD_TTL_MIN * 60 * 1000);
+    if (!childExpiresAt) {
+      console.error('[installer] bootstrap 404', { reason: 'parent_already_expired', tokenId: row.id, ip });
+      return null;
+    }
+
+    // ── 3. INSERT child key BEFORE consuming the token (C1 reorder) ──
+    // If the consume UPDATE loses a race, we'll DELETE this row below.
     const rawChildKey = generateChildEnrollmentKey();
     const childKeyHash = hashEnrollmentKey(rawChildKey);
-    await db
+    const [childKey] = await db
       .insert(enrollmentKeys)
       .values({
         orgId: row.orgId,
@@ -86,12 +131,40 @@ installerRoutes.get('/bootstrap/:token', async (c) => {
         key: childKeyHash,
         keySecretHash: parent.keySecretHash,
         maxUsage: row.maxUsage,
-        expiresAt: freshChildExpiresAt(),
+        expiresAt: childExpiresAt,
         createdBy: row.createdBy,
         installerPlatform: 'macos',
       })
       .returning();
 
+    // ── 4. Atomic single-use consume guard ────────────────────────────
+    // Two concurrent requests both read row.consumedAt = null, but only one
+    // UPDATE will return a row (Postgres serializes the write).
+    const [updated] = await db
+      .update(installerBootstrapTokens)
+      .set({
+        consumedAt: new Date(),
+        consumedFromIp: ip === 'unknown' ? null : ip,
+      })
+      .where(
+        and(
+          eq(installerBootstrapTokens.id, row.id),
+          isNull(installerBootstrapTokens.consumedAt),
+        ),
+      )
+      .returning();
+
+    if (!updated) {
+      // Lost the race — delete the child key we just created so we don't
+      // leave orphaned enrollment keys accumulating on repeated replays.
+      console.error('[installer] bootstrap 404', { reason: 'lost_race', tokenId: row.id, ip });
+      if (childKey) {
+        await db.delete(enrollmentKeys).where(eq(enrollmentKeys.id, childKey.id));
+      }
+      return null;
+    }
+
+    // ── 5. Fetch org name for response ────────────────────────────────
     const [org] = await db
       .select()
       .from(organizations)

--- a/apps/api/src/routes/installer.ts
+++ b/apps/api/src/routes/installer.ts
@@ -1,0 +1,119 @@
+import { Hono } from 'hono';
+import { and, eq, isNull } from 'drizzle-orm';
+import { randomBytes } from 'node:crypto';
+import { db, withSystemDbAccessContext } from '../db';
+import { installerBootstrapTokens } from '../db/schema/installerBootstrapTokens';
+import { enrollmentKeys, organizations } from '../db/schema/orgs';
+import { hashEnrollmentKey } from '../services/enrollmentKeySecurity';
+import { BOOTSTRAP_TOKEN_PATTERN } from '../services/installerBootstrapToken';
+
+const CHILD_TTL_MIN = Number(
+  process.env.CHILD_ENROLLMENT_KEY_TTL_MINUTES ?? 24 * 60,
+);
+
+function freshChildExpiresAt(): Date {
+  return new Date(Date.now() + CHILD_TTL_MIN * 60 * 1000);
+}
+
+function generateChildEnrollmentKey(): string {
+  return randomBytes(32).toString('hex'); // 64-char hex
+}
+
+const INVALID_TOKEN_RESPONSE = {
+  body: { error: 'token invalid, expired, or already used' as const },
+  status: 404 as const,
+};
+
+export const installerRoutes = new Hono();
+
+/**
+ * Public bootstrap endpoint. The token IS the auth — no JWT, no API key,
+ * no session. Resolves the token to an enrollment payload, atomically
+ * marks it consumed, and lazily creates a short-lived child enrollment key.
+ *
+ * Invalid / expired / already-used tokens all return the same 404 to
+ * avoid leaking which condition was hit.
+ */
+installerRoutes.get('/bootstrap/:token', async (c) => {
+  const token = c.req.param('token');
+  if (!BOOTSTRAP_TOKEN_PATTERN.test(token)) {
+    return c.json({ error: 'invalid token' }, 400);
+  }
+
+  const result = await withSystemDbAccessContext(async () => {
+    const [row] = await db
+      .select()
+      .from(installerBootstrapTokens)
+      .where(eq(installerBootstrapTokens.token, token))
+      .limit(1);
+    if (!row) return null;
+    if (row.consumedAt) return null;
+    if (new Date(row.expiresAt) < new Date()) return null;
+
+    // Atomic single-use guard: UPDATE ... WHERE consumed_at IS NULL.
+    // Two concurrent requests both read row.consumedAt = null but only one
+    // UPDATE will return a row (Postgres serializes the write).
+    const [updated] = await db
+      .update(installerBootstrapTokens)
+      .set({
+        consumedAt: new Date(),
+        consumedFromIp: c.req.header('cf-connecting-ip') ?? null,
+      })
+      .where(
+        and(
+          eq(installerBootstrapTokens.id, row.id),
+          isNull(installerBootstrapTokens.consumedAt),
+        ),
+      )
+      .returning();
+    if (!updated) return null;
+
+    const [parent] = await db
+      .select()
+      .from(enrollmentKeys)
+      .where(eq(enrollmentKeys.id, row.parentEnrollmentKeyId))
+      .limit(1);
+    if (!parent) return null;
+
+    const rawChildKey = generateChildEnrollmentKey();
+    const childKeyHash = hashEnrollmentKey(rawChildKey);
+    await db
+      .insert(enrollmentKeys)
+      .values({
+        orgId: row.orgId,
+        siteId: row.siteId,
+        name: `${parent.name} (mac-installer ${token})`,
+        key: childKeyHash,
+        keySecretHash: parent.keySecretHash,
+        maxUsage: row.maxUsage,
+        expiresAt: freshChildExpiresAt(),
+        createdBy: row.createdBy,
+        installerPlatform: 'macos',
+      })
+      .returning();
+
+    const [org] = await db
+      .select()
+      .from(organizations)
+      .where(eq(organizations.id, row.orgId))
+      .limit(1);
+
+    return {
+      rawChildKey,
+      siteId: row.siteId,
+      orgName: org?.name ?? 'your organization',
+    };
+  });
+
+  if (!result) {
+    return c.json(INVALID_TOKEN_RESPONSE.body, INVALID_TOKEN_RESPONSE.status);
+  }
+
+  return c.json({
+    serverUrl: process.env.PUBLIC_API_URL ?? process.env.API_URL ?? '',
+    enrollmentKey: result.rawChildKey,
+    enrollmentSecret: process.env.AGENT_ENROLLMENT_SECRET || null,
+    siteId: result.siteId,
+    orgName: result.orgName,
+  });
+});

--- a/apps/api/src/services/binarySource.ts
+++ b/apps/api/src/services/binarySource.ts
@@ -78,3 +78,11 @@ export function getGithubHelperUrl(os: string): string {
   if (!filename) throw new Error(`Unknown helper OS: ${os}`);
   return `${githubDownloadBase()}/${filename}`;
 }
+
+/**
+ * URL of the notarized Breeze Installer.app.zip for the current release.
+ * Asset is uploaded by the build-macos-installer-app job in release.yml.
+ */
+export function getGithubInstallerAppUrl(): string {
+  return `${githubDownloadBase()}/Breeze%20Installer.app.zip`;
+}

--- a/apps/api/src/services/installerAppZip.test.ts
+++ b/apps/api/src/services/installerAppZip.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import archiver from 'archiver';
+import StreamZip from 'node-stream-zip';
+import { writeFile, unlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { renameAppInZip } from './installerAppZip';
+
+/** Build a fixture zip containing a fake `.app` directory. */
+async function buildFixtureZip(appName: string): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const archive = archiver('zip', { zlib: { level: 0 } });
+    const chunks: Buffer[] = [];
+    archive.on('data', (c: Buffer) => chunks.push(c));
+    archive.on('end', () => resolve(Buffer.concat(chunks)));
+    archive.on('error', reject);
+
+    archive.append('fake-binary', { name: `${appName}/Contents/MacOS/BreezeInstaller`, mode: 0o755 });
+    archive.append('<plist/>', { name: `${appName}/Contents/Info.plist` });
+    archive.append('codesign-data', { name: `${appName}/Contents/_CodeSignature/CodeResources` });
+    archive.append('pkg-bytes', { name: `${appName}/Contents/Resources/breeze-agent-amd64.pkg` });
+    archive.append('pkg-bytes', { name: `${appName}/Contents/Resources/breeze-agent-arm64.pkg` });
+    archive.finalize().catch(reject);
+  });
+}
+
+async function listEntries(zipBuf: Buffer): Promise<string[]> {
+  const tmp = join(tmpdir(), `installer-zip-test-${Date.now()}.zip`);
+  await writeFile(tmp, zipBuf);
+  try {
+    const z = new StreamZip.async({ file: tmp });
+    const entries = Object.keys(await z.entries());
+    await z.close();
+    return entries.sort();
+  } finally {
+    await unlink(tmp).catch(() => {});
+  }
+}
+
+describe('renameAppInZip', () => {
+  it('renames the app directory in every entry path', async () => {
+    const input = await buildFixtureZip('Breeze Installer.app');
+    const out = await renameAppInZip(input, {
+      oldAppName: 'Breeze Installer.app',
+      newAppName: 'Breeze Installer [A7K2XQ@us.2breeze.app].app',
+    });
+    const entries = await listEntries(out);
+    expect(entries).toEqual([
+      'Breeze Installer [A7K2XQ@us.2breeze.app].app/Contents/Info.plist',
+      'Breeze Installer [A7K2XQ@us.2breeze.app].app/Contents/MacOS/BreezeInstaller',
+      'Breeze Installer [A7K2XQ@us.2breeze.app].app/Contents/Resources/breeze-agent-amd64.pkg',
+      'Breeze Installer [A7K2XQ@us.2breeze.app].app/Contents/Resources/breeze-agent-arm64.pkg',
+      'Breeze Installer [A7K2XQ@us.2breeze.app].app/Contents/_CodeSignature/CodeResources',
+    ]);
+  });
+
+  it('preserves entry contents byte-for-byte', async () => {
+    const input = await buildFixtureZip('Breeze Installer.app');
+    const out = await renameAppInZip(input, {
+      oldAppName: 'Breeze Installer.app',
+      newAppName: 'Breeze Installer [BBBBBB@host.local].app',
+    });
+    const tmp = join(tmpdir(), `installer-zip-content-${Date.now()}.zip`);
+    await writeFile(tmp, out);
+    const z = new StreamZip.async({ file: tmp });
+    const data = await z.entryData('Breeze Installer [BBBBBB@host.local].app/Contents/Info.plist');
+    await z.close();
+    await unlink(tmp);
+    expect(data.toString()).toBe('<plist/>');
+  });
+
+  it('throws if no entry matches the old app name', async () => {
+    const input = await buildFixtureZip('Different.app');
+    await expect(
+      renameAppInZip(input, {
+        oldAppName: 'Breeze Installer.app',
+        newAppName: 'Breeze Installer [A7K2XQ@x.example].app',
+      }),
+    ).rejects.toThrow(/no entries matched/i);
+  });
+});

--- a/apps/api/src/services/installerAppZip.ts
+++ b/apps/api/src/services/installerAppZip.ts
@@ -1,0 +1,77 @@
+import archiver from 'archiver';
+import StreamZip from 'node-stream-zip';
+import { writeFile, mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+export interface RenameAppInZipOpts {
+  oldAppName: string;  // e.g. "Breeze Installer.app"
+  newAppName: string;  // e.g. "Breeze Installer [A7K2XQ@us.2breeze.app].app"
+}
+
+/**
+ * Walks every entry in `sourceZip` and rewrites its path so that the
+ * leading `oldAppName` directory becomes `newAppName`. Entry contents
+ * are preserved byte-for-byte — this is just a metadata rewrite.
+ *
+ * The Mac code signature lives inside `Contents/_CodeSignature/` and
+ * is hashed from `Contents/` contents, NOT the bundle's own directory
+ * name. Renaming the top-level folder leaves both `codesign --verify`
+ * and `xcrun stapler validate` passing.
+ *
+ * Throws if no entry begins with `oldAppName/` — guards against feeding
+ * in the wrong fixture (e.g. a release where the build output renamed
+ * its top-level directory).
+ */
+export async function renameAppInZip(
+  sourceZip: Buffer,
+  opts: RenameAppInZipOpts,
+): Promise<Buffer> {
+  const workDir = await mkdtemp(join(tmpdir(), 'installer-app-zip-'));
+  const inputPath = join(workDir, 'in.zip');
+  await writeFile(inputPath, sourceZip);
+  try {
+    const reader = new StreamZip.async({ file: inputPath });
+    const entries = await reader.entries();
+    let matched = 0;
+
+    const out = archiver('zip', { zlib: { level: 0 } }); // store-only; .app contents already small or pre-compressed
+    const chunks: Buffer[] = [];
+    out.on('data', (c: Buffer) => chunks.push(c));
+    const done = new Promise<void>((resolve, reject) => {
+      out.on('end', () => resolve());
+      out.on('error', reject);
+    });
+
+    for (const entry of Object.values(entries)) {
+      const oldPrefix = `${opts.oldAppName}/`;
+      let newPath = entry.name;
+      if (entry.name === opts.oldAppName) {
+        newPath = opts.newAppName;
+        matched++;
+      } else if (entry.name.startsWith(oldPrefix)) {
+        newPath = opts.newAppName + entry.name.slice(opts.oldAppName.length);
+        matched++;
+      }
+      if (entry.isDirectory) {
+        out.append('', { name: newPath, mode: entry.attr });
+      } else {
+        const data = await reader.entryData(entry.name);
+        out.append(data, { name: newPath, mode: entry.attr });
+      }
+    }
+    await reader.close();
+
+    if (matched === 0) {
+      throw new Error(
+        `installerAppZip: no entries matched old app name "${opts.oldAppName}" — wrong fixture?`,
+      );
+    }
+
+    await out.finalize();
+    await done;
+    return Buffer.concat(chunks);
+  } finally {
+    await rm(workDir, { recursive: true, force: true });
+  }
+}

--- a/apps/api/src/services/installerBootstrapToken.test.ts
+++ b/apps/api/src/services/installerBootstrapToken.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { generateBootstrapToken, BOOTSTRAP_TOKEN_PATTERN } from './installerBootstrapToken';
+
+describe('generateBootstrapToken', () => {
+  it('returns a 6-char token of [A-Z0-9]', () => {
+    const t = generateBootstrapToken();
+    expect(t).toMatch(BOOTSTRAP_TOKEN_PATTERN);
+  });
+
+  it('returns 6 chars exactly', () => {
+    expect(generateBootstrapToken()).toHaveLength(6);
+  });
+
+  it('is statistically unique across 1000 calls', () => {
+    const tokens = new Set<string>();
+    for (let i = 0; i < 1000; i++) tokens.add(generateBootstrapToken());
+    // 36^6 ≈ 2.2B values; collisions in 1000 samples are essentially impossible.
+    // Allow a single collision before flagging — defensive against an unlucky CI run.
+    expect(tokens.size).toBeGreaterThanOrEqual(999);
+  });
+
+  it('emits only uppercase letters and digits', () => {
+    for (let i = 0; i < 100; i++) {
+      expect(generateBootstrapToken()).toMatch(/^[A-Z0-9]+$/);
+    }
+  });
+});
+
+describe('BOOTSTRAP_TOKEN_PATTERN', () => {
+  it('matches the canonical 6-char form', () => {
+    expect(BOOTSTRAP_TOKEN_PATTERN.test('A7K2XQ')).toBe(true);
+    expect(BOOTSTRAP_TOKEN_PATTERN.test('123456')).toBe(true);
+  });
+
+  it('rejects shorter, longer, or lowercase variants', () => {
+    expect(BOOTSTRAP_TOKEN_PATTERN.test('a7k2xq')).toBe(false);
+    expect(BOOTSTRAP_TOKEN_PATTERN.test('A7K2X')).toBe(false);
+    expect(BOOTSTRAP_TOKEN_PATTERN.test('A7K2XQA')).toBe(false);
+    expect(BOOTSTRAP_TOKEN_PATTERN.test('A7-2XQ')).toBe(false);
+  });
+});

--- a/apps/api/src/services/installerBootstrapToken.test.ts
+++ b/apps/api/src/services/installerBootstrapToken.test.ts
@@ -2,19 +2,19 @@ import { describe, it, expect } from 'vitest';
 import { generateBootstrapToken, BOOTSTRAP_TOKEN_PATTERN } from './installerBootstrapToken';
 
 describe('generateBootstrapToken', () => {
-  it('returns a 6-char token of [A-Z0-9]', () => {
+  it('returns a 10-char token of [A-Z0-9]', () => {
     const t = generateBootstrapToken();
     expect(t).toMatch(BOOTSTRAP_TOKEN_PATTERN);
   });
 
-  it('returns 6 chars exactly', () => {
-    expect(generateBootstrapToken()).toHaveLength(6);
+  it('returns 10 chars exactly', () => {
+    expect(generateBootstrapToken()).toHaveLength(10);
   });
 
   it('is statistically unique across 1000 calls', () => {
     const tokens = new Set<string>();
     for (let i = 0; i < 1000; i++) tokens.add(generateBootstrapToken());
-    // 36^6 ≈ 2.2B values; collisions in 1000 samples are essentially impossible.
+    // 36^10 ≈ 3.7T values (~52 bits); collisions in 1000 samples are essentially impossible.
     // Allow a single collision before flagging — defensive against an unlucky CI run.
     expect(tokens.size).toBeGreaterThanOrEqual(999);
   });
@@ -27,15 +27,15 @@ describe('generateBootstrapToken', () => {
 });
 
 describe('BOOTSTRAP_TOKEN_PATTERN', () => {
-  it('matches the canonical 6-char form', () => {
-    expect(BOOTSTRAP_TOKEN_PATTERN.test('A7K2XQ')).toBe(true);
-    expect(BOOTSTRAP_TOKEN_PATTERN.test('123456')).toBe(true);
+  it('matches the canonical 10-char form', () => {
+    expect(BOOTSTRAP_TOKEN_PATTERN.test('A7K2XQRP4N')).toBe(true);
+    expect(BOOTSTRAP_TOKEN_PATTERN.test('1234567890')).toBe(true);
   });
 
   it('rejects shorter, longer, or lowercase variants', () => {
-    expect(BOOTSTRAP_TOKEN_PATTERN.test('a7k2xq')).toBe(false);
-    expect(BOOTSTRAP_TOKEN_PATTERN.test('A7K2X')).toBe(false);
-    expect(BOOTSTRAP_TOKEN_PATTERN.test('A7K2XQA')).toBe(false);
-    expect(BOOTSTRAP_TOKEN_PATTERN.test('A7-2XQ')).toBe(false);
+    expect(BOOTSTRAP_TOKEN_PATTERN.test('a7k2xqrp4n')).toBe(false);
+    expect(BOOTSTRAP_TOKEN_PATTERN.test('A7K2XQRP4')).toBe(false);   // 9 chars
+    expect(BOOTSTRAP_TOKEN_PATTERN.test('A7K2XQRP4NA')).toBe(false); // 11 chars
+    expect(BOOTSTRAP_TOKEN_PATTERN.test('A7-2XQRP4N')).toBe(false);
   });
 });

--- a/apps/api/src/services/installerBootstrapToken.ts
+++ b/apps/api/src/services/installerBootstrapToken.ts
@@ -1,22 +1,22 @@
 import { randomInt } from 'node:crypto';
 
 /**
- * Canonical shape of a bootstrap token: 6 chars of base36 (uppercase
- * letters + digits). 36^6 ≈ 2.2 billion values — sufficient entropy for
- * a single-use 24h-TTL token. Used by both the generator and the
- * route-side input validator.
+ * Canonical shape of a bootstrap token: 10 chars of base36 (uppercase
+ * letters + digits). 36^10 ≈ 3.7 trillion values (~52 bits) — strong
+ * entropy for a single-use 24h-TTL token. Used by both the generator and
+ * the route-side input validator.
  */
-export const BOOTSTRAP_TOKEN_PATTERN = /^[A-Z0-9]{6}$/;
+export const BOOTSTRAP_TOKEN_PATTERN = /^[A-Z0-9]{10}$/;
 
 const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 
 /**
- * Generates a 6-character base36 bootstrap token using a CSPRNG.
- * Output is always 6 chars of [A-Z0-9].
+ * Generates a 10-character base36 bootstrap token using a CSPRNG.
+ * Output is always 10 chars of [A-Z0-9] (~52 bits of entropy).
  */
 export function generateBootstrapToken(): string {
   let out = '';
-  for (let i = 0; i < 6; i++) {
+  for (let i = 0; i < 10; i++) {
     out += ALPHABET[randomInt(0, ALPHABET.length)];
   }
   return out;

--- a/apps/api/src/services/installerBootstrapToken.ts
+++ b/apps/api/src/services/installerBootstrapToken.ts
@@ -1,0 +1,34 @@
+import { randomInt } from 'node:crypto';
+
+/**
+ * Canonical shape of a bootstrap token: 6 chars of base36 (uppercase
+ * letters + digits). 36^6 ≈ 2.2 billion values — sufficient entropy for
+ * a single-use 24h-TTL token. Used by both the generator and the
+ * route-side input validator.
+ */
+export const BOOTSTRAP_TOKEN_PATTERN = /^[A-Z0-9]{6}$/;
+
+const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+
+/**
+ * Generates a 6-character base36 bootstrap token using a CSPRNG.
+ * Output is always 6 chars of [A-Z0-9].
+ */
+export function generateBootstrapToken(): string {
+  let out = '';
+  for (let i = 0; i < 6; i++) {
+    out += ALPHABET[randomInt(0, ALPHABET.length)];
+  }
+  return out;
+}
+
+/**
+ * Default TTL for a freshly-issued bootstrap token. Tunable via env
+ * for testing; production default is 24 hours which matches the
+ * "admin downloads installer, sends to user, user runs sometime
+ * within a day" mental model.
+ */
+export function bootstrapTokenExpiresAt(): Date {
+  const ttlMin = Number(process.env.INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES ?? 24 * 60);
+  return new Date(Date.now() + ttlMin * 60 * 1000);
+}

--- a/apps/api/src/services/installerBootstrapTokenIssuance.ts
+++ b/apps/api/src/services/installerBootstrapTokenIssuance.ts
@@ -1,0 +1,74 @@
+import { db } from '../db';
+import { eq } from 'drizzle-orm';
+import { enrollmentKeys } from '../db/schema/orgs';
+import { installerBootstrapTokens } from '../db/schema/installerBootstrapTokens';
+import {
+  generateBootstrapToken,
+  bootstrapTokenExpiresAt,
+} from './installerBootstrapToken';
+
+export interface IssueBootstrapTokenInput {
+  parentEnrollmentKeyId: string;
+  createdByUserId: string;
+  maxUsage?: number;
+}
+
+export interface IssuedBootstrapToken {
+  token: string;
+  expiresAt: Date;
+  parentKeyName: string;
+}
+
+export class BootstrapTokenIssuanceError extends Error {
+  constructor(public code: 'parent_not_found' | 'parent_expired' | 'parent_exhausted', message: string) {
+    super(message);
+    this.name = 'BootstrapTokenIssuanceError';
+  }
+}
+
+/**
+ * Issues a single-use bootstrap token tied to an existing parent enrollment
+ * key. Used by both the standalone POST /enrollment-keys/:id/bootstrap-token
+ * route AND the macOS installer download route — they were two duplicate
+ * code paths in Plan A; this helper unifies them.
+ *
+ * Caller is responsible for:
+ *  - access control (ensureOrgAccess on parentKey.orgId)
+ *  - audit logging
+ *
+ * Throws BootstrapTokenIssuanceError on parent-key validation failures so
+ * the caller can map to its own HTTP shape.
+ */
+export async function issueBootstrapTokenForKey(
+  input: IssueBootstrapTokenInput,
+): Promise<IssuedBootstrapToken> {
+  const [parent] = await db
+    .select()
+    .from(enrollmentKeys)
+    .where(eq(enrollmentKeys.id, input.parentEnrollmentKeyId))
+    .limit(1);
+  if (!parent) {
+    throw new BootstrapTokenIssuanceError('parent_not_found', 'Enrollment key not found');
+  }
+  if (parent.expiresAt && new Date(parent.expiresAt) < new Date()) {
+    throw new BootstrapTokenIssuanceError('parent_expired', 'Enrollment key has expired');
+  }
+  if (parent.maxUsage !== null && parent.usageCount >= parent.maxUsage) {
+    throw new BootstrapTokenIssuanceError('parent_exhausted', 'Enrollment key usage exhausted');
+  }
+
+  const token = generateBootstrapToken();
+  const expiresAt = bootstrapTokenExpiresAt();
+
+  await db.insert(installerBootstrapTokens).values({
+    token,
+    orgId: parent.orgId,
+    parentEnrollmentKeyId: parent.id,
+    siteId: parent.siteId,
+    maxUsage: input.maxUsage ?? 1,
+    createdBy: input.createdByUserId,
+    expiresAt,
+  });
+
+  return { token, expiresAt, parentKeyName: parent.name };
+}

--- a/apps/api/src/services/installerBootstrapTokenIssuance.ts
+++ b/apps/api/src/services/installerBootstrapTokenIssuance.ts
@@ -70,6 +70,9 @@ export async function issueBootstrapTokenForKey(
     createdBy: input.createdByUserId,
     expiresAt,
   }).returning();
+  if (!row) {
+    throw new Error('installerBootstrapTokens insert returned no row');
+  }
 
   return { id: row.id, token, expiresAt, parentKeyName: parent.name };
 }

--- a/apps/api/src/services/installerBootstrapTokenIssuance.ts
+++ b/apps/api/src/services/installerBootstrapTokenIssuance.ts
@@ -14,6 +14,7 @@ export interface IssueBootstrapTokenInput {
 }
 
 export interface IssuedBootstrapToken {
+  id: string;
   token: string;
   expiresAt: Date;
   parentKeyName: string;
@@ -60,7 +61,7 @@ export async function issueBootstrapTokenForKey(
   const token = generateBootstrapToken();
   const expiresAt = bootstrapTokenExpiresAt();
 
-  await db.insert(installerBootstrapTokens).values({
+  const [row] = await db.insert(installerBootstrapTokens).values({
     token,
     orgId: parent.orgId,
     parentEnrollmentKeyId: parent.id,
@@ -68,7 +69,7 @@ export async function issueBootstrapTokenForKey(
     maxUsage: input.maxUsage ?? 1,
     createdBy: input.createdByUserId,
     expiresAt,
-  });
+  }).returning();
 
-  return { token, expiresAt, parentKeyName: parent.name };
+  return { id: row.id, token, expiresAt, parentKeyName: parent.name };
 }

--- a/apps/api/src/services/installerBuilder.ts
+++ b/apps/api/src/services/installerBuilder.ts
@@ -235,7 +235,10 @@ export async function probeMacosInstallerApp(): Promise<boolean> {
       });
       if (resp.status === 404) return false;
       return resp.ok;
-    } catch {
+    } catch (err) {
+      console.warn('[installer] probeMacosInstallerApp: GitHub HEAD failed, treating as unavailable', {
+        error: err instanceof Error ? err.message : String(err),
+      });
       return false;
     }
   }
@@ -243,7 +246,10 @@ export async function probeMacosInstallerApp(): Promise<boolean> {
   try {
     await stat(join(binaryDir, 'Breeze Installer.app.zip'));
     return true;
-  } catch {
+  } catch (err) {
+    console.warn('[installer] probeMacosInstallerApp: filesystem stat failed, treating as unavailable', {
+      error: err instanceof Error ? err.message : String(err),
+    });
     return false;
   }
 }

--- a/apps/api/src/services/installerBuilder.ts
+++ b/apps/api/src/services/installerBuilder.ts
@@ -1,7 +1,7 @@
 import archiver from 'archiver';
-import { readFile } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
 import { resolve, join } from 'node:path';
-import { getBinarySource, getGithubAgentPkgUrl, getGithubRegularMsiUrl } from './binarySource';
+import { getBinarySource, getGithubAgentPkgUrl, getGithubInstallerAppUrl, getGithubRegularMsiUrl } from './binarySource';
 
 // --- Windows zip bundle builder (fallback when remote signing service is not configured) ---
 
@@ -194,4 +194,56 @@ export async function fetchMacosPkg(): Promise<Buffer> {
   }
   const binaryDir = resolve(process.env.AGENT_BINARY_DIR || './agent/bin');
   return readFile(join(binaryDir, 'breeze-agent-darwin-arm64.pkg'));
+}
+
+/**
+ * Fetches the notarized Breeze Installer.app.zip from the GitHub release.
+ * Returns null if the asset is not available (e.g. first release after
+ * Plan B merged but before the next tag is cut). Caller falls back to
+ * the legacy install.sh zip in that case.
+ */
+export async function fetchMacosInstallerAppZip(): Promise<Buffer | null> {
+  if (getBinarySource() === 'github') {
+    const url = getGithubInstallerAppUrl();
+    const resp = await fetch(url, { redirect: 'follow' });
+    if (resp.status === 404) return null;
+    if (!resp.ok) throw new Error(`Failed to fetch installer app zip: ${resp.status}`);
+    return Buffer.from(await resp.arrayBuffer());
+  }
+  const binaryDir = resolve(process.env.AGENT_BINARY_DIR || './agent/bin');
+  const path = join(binaryDir, 'Breeze Installer.app.zip');
+  try {
+    return await readFile(path);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+/**
+ * HEAD probe for the installer app asset. Mirrors probeMacosPkg.
+ * Returns true if reachable, false if 404, throws otherwise.
+ */
+export async function probeMacosInstallerApp(): Promise<boolean> {
+  if (getBinarySource() === 'github') {
+    const url = getGithubInstallerAppUrl();
+    try {
+      const resp = await fetch(url, {
+        method: 'HEAD',
+        redirect: 'follow',
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (resp.status === 404) return false;
+      return resp.ok;
+    } catch {
+      return false;
+    }
+  }
+  const binaryDir = resolve(process.env.AGENT_BINARY_DIR || './agent/bin');
+  try {
+    await stat(join(binaryDir, 'Breeze Installer.app.zip'));
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/docs/superpowers/plans/2026-04-19-macos-installer-plan-a-bootstrap-tokens.md
+++ b/docs/superpowers/plans/2026-04-19-macos-installer-plan-a-bootstrap-tokens.md
@@ -1,0 +1,941 @@
+# macOS Installer App — Plan A: Bootstrap Token Infrastructure
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a single-use, 24h-TTL `installer_bootstrap_tokens` table and a public `GET /api/v1/installer/bootstrap/:token` endpoint that lazily creates a child enrollment key on consumption. This is the foundation for the macOS installer app design (`docs/superpowers/specs/2026-04-19-macos-installer-app-design.md`); Plan A ships and is testable on its own — the installer route is unchanged here, and the new endpoint can be exercised end-to-end with `curl`.
+
+**Architecture:** New tenant-scoped table (RLS Shape 1, direct `org_id`). New unauthenticated route at `/api/v1/installer/bootstrap/:token` that resolves a token, atomically marks it consumed, lazily creates the child enrollment key, and returns enrollment values. Token issuance is added as a second new endpoint on the enrollment-keys router so admins can mint a token for a parent key without touching the existing installer-download route. Plan C will wire the installer route to call this issuance helper.
+
+**Tech Stack:** Drizzle ORM, PostgreSQL RLS (`breeze_app` role), Hono, Vitest, hand-written SQL migrations.
+
+---
+
+## File Structure
+
+**Create:**
+- `apps/api/migrations/2026-04-19-installer-bootstrap-tokens.sql` — table + RLS policies + index, fully idempotent
+- `apps/api/src/db/schema/installerBootstrapTokens.ts` — Drizzle table definition
+- `apps/api/src/services/installerBootstrapToken.ts` — generator + helpers
+- `apps/api/src/services/installerBootstrapToken.test.ts` — unit tests for generator
+- `apps/api/src/routes/installer.ts` — public `/installer/bootstrap/:token` route
+- `apps/api/src/routes/installer.test.ts` — integration tests for bootstrap endpoint
+
+**Modify:**
+- `apps/api/src/db/schema/index.ts` (or wherever the schema barrel lives — see Task 1) — re-export new schema
+- `apps/api/src/index.ts` line ~672 — mount the installer route at `/api/v1/installer`
+- `apps/api/src/routes/enrollmentKeys.ts` — add `POST /:id/bootstrap-token` issuance helper (used by Plan C)
+- `apps/api/src/routes/enrollmentKeys.test.ts` — test for the new issuance route
+
+**No-op (verification):**
+- `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` — should auto-discover the new table via its `org_id` column; no allowlist edits needed. Run to confirm.
+
+---
+
+## Task 1: Drizzle schema for `installer_bootstrap_tokens`
+
+**Files:**
+- Create: `apps/api/src/db/schema/installerBootstrapTokens.ts`
+- Modify: schema barrel (find via `grep -rn "from './installerBootstrapTokens\|export.*from.*schema'" apps/api/src/db/`)
+
+- [ ] **Step 1: Locate the schema barrel**
+
+```bash
+ls apps/api/src/db/schema/index.ts 2>/dev/null && head -30 apps/api/src/db/schema/index.ts
+# If no index.ts, check what drizzle.config.ts points at:
+grep -A2 "schema" apps/api/drizzle.config.ts
+```
+
+Expected: either an `index.ts` re-exports each schema file, OR `drizzle.config.ts` points at the directory directly (in which case any new `.ts` file is auto-picked-up).
+
+- [ ] **Step 2: Create the schema file**
+
+```ts
+// apps/api/src/db/schema/installerBootstrapTokens.ts
+import { pgTable, uuid, text, integer, timestamp, index } from 'drizzle-orm/pg-core';
+import { organizations, sites, enrollmentKeys } from './orgs';
+import { users } from './users';
+
+/**
+ * Single-use, short-TTL token issued at installer-download time. The token
+ * is embedded in the macOS installer app filename (`Breeze Installer
+ * [TOKEN@host].app`) and exchanged for enrollment values on first launch via
+ * the unauthenticated `/api/v1/installer/bootstrap/:token` route.
+ *
+ * Stored as plain text (not hashed) intentionally: tokens are ephemeral
+ * (24h max), single-use, and hashing adds ceremony without a meaningful
+ * security win for this lifetime. Compare by equality.
+ */
+export const installerBootstrapTokens = pgTable(
+  'installer_bootstrap_tokens',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    token: text('token').notNull().unique(),
+    orgId: uuid('org_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
+    parentEnrollmentKeyId: uuid('parent_enrollment_key_id')
+      .notNull()
+      .references(() => enrollmentKeys.id, { onDelete: 'cascade' }),
+    siteId: uuid('site_id').references(() => sites.id),
+    maxUsage: integer('max_usage').notNull().default(1),
+    createdBy: uuid('created_by').references(() => users.id, { onDelete: 'set null' }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    consumedAt: timestamp('consumed_at', { withTimezone: true }),
+    consumedFromIp: text('consumed_from_ip'),
+  },
+  (t) => ({
+    expiresIdx: index('idx_installer_bootstrap_tokens_expires').on(t.expiresAt),
+  }),
+);
+```
+
+- [ ] **Step 3: Re-export from the barrel (if there is one)**
+
+If `apps/api/src/db/schema/index.ts` exists, add:
+```ts
+export * from './installerBootstrapTokens';
+```
+
+If schemas are auto-discovered from the directory by `drizzle.config.ts`, no change needed.
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd apps/api && npx tsc --noEmit 2>&1 | grep -i installerBootstrap
+```
+Expected: no errors mentioning the new file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/db/schema/installerBootstrapTokens.ts apps/api/src/db/schema/index.ts
+git commit -m "schema: add installer_bootstrap_tokens table"
+```
+
+---
+
+## Task 2: Hand-written migration with RLS policies
+
+**Files:**
+- Create: `apps/api/migrations/2026-04-19-installer-bootstrap-tokens.sql`
+
+- [ ] **Step 1: Confirm migration filename convention**
+
+```bash
+ls apps/api/migrations/ | tail -5
+```
+Expected: date-prefixed files like `2026-04-13-fix-uuid-hostnames.sql`. Use `2026-04-19-installer-bootstrap-tokens.sql`. (If the directory has switched to numeric NNNN- prefixes — CLAUDE.md mentions both — use the next available number.)
+
+- [ ] **Step 2: Write the migration**
+
+```sql
+-- 2026-04-19: installer_bootstrap_tokens — single-use, short-TTL tokens for
+-- the macOS GUI installer. Tokens are issued at installer-download time and
+-- consumed by the unauthenticated /api/v1/installer/bootstrap/:token route.
+--
+-- RLS Shape 1 (direct org_id) — auto-discovered by the rls-coverage
+-- integration test, no allowlist entry needed.
+--
+-- Fully idempotent — safe to re-run.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS installer_bootstrap_tokens (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  token TEXT NOT NULL UNIQUE,
+  org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  parent_enrollment_key_id UUID NOT NULL REFERENCES enrollment_keys(id) ON DELETE CASCADE,
+  site_id UUID REFERENCES sites(id),
+  max_usage INTEGER NOT NULL DEFAULT 1,
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  consumed_at TIMESTAMPTZ,
+  consumed_from_ip TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_installer_bootstrap_tokens_expires
+  ON installer_bootstrap_tokens(expires_at)
+  WHERE consumed_at IS NULL;
+
+-- ============================================================
+-- RLS — Shape 1, direct org_id, standard four breeze_org_isolation policies
+-- ============================================================
+
+ALTER TABLE installer_bootstrap_tokens ENABLE ROW LEVEL SECURITY;
+ALTER TABLE installer_bootstrap_tokens FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON installer_bootstrap_tokens;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON installer_bootstrap_tokens;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON installer_bootstrap_tokens;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON installer_bootstrap_tokens;
+
+CREATE POLICY breeze_org_isolation_select ON installer_bootstrap_tokens
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON installer_bootstrap_tokens
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON installer_bootstrap_tokens
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON installer_bootstrap_tokens
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+COMMIT;
+```
+
+- [ ] **Step 3: Apply migration**
+
+```bash
+docker exec -i breeze-postgres psql -U breeze -d breeze < apps/api/migrations/2026-04-19-installer-bootstrap-tokens.sql
+```
+Expected: `BEGIN`, `CREATE TABLE`, `CREATE INDEX`, multiple `ALTER`/`CREATE POLICY`, `COMMIT`.
+
+- [ ] **Step 4: Run drift check**
+
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+pnpm db:check-drift
+```
+Expected: no drift detected. If drift appears, the Drizzle schema file (Task 1) and the SQL must be reconciled — column types/nullability/defaults must match exactly.
+
+- [ ] **Step 5: Verify RLS as `breeze_app`**
+
+```bash
+docker exec -i breeze-postgres psql -U breeze_app -d breeze -c "
+  INSERT INTO installer_bootstrap_tokens (token, org_id, parent_enrollment_key_id, expires_at)
+  VALUES ('TESTXX', '00000000-0000-0000-0000-000000000000',
+          '00000000-0000-0000-0000-000000000000', NOW() + interval '1 hour');
+"
+```
+Expected: `ERROR:  new row violates row-level security policy for table "installer_bootstrap_tokens"` — confirms RLS is forced and `breeze_app` cannot bypass.
+
+- [ ] **Step 6: Run RLS coverage integration test**
+
+```bash
+cd apps/api && pnpm test --config vitest.config.rls.ts -- rls-coverage
+```
+Expected: all assertions pass, including auto-discovered policies on the new table.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/migrations/2026-04-19-installer-bootstrap-tokens.sql
+git commit -m "migration: installer_bootstrap_tokens with RLS"
+```
+
+---
+
+## Task 3: Bootstrap token generator helper + unit tests
+
+**Files:**
+- Create: `apps/api/src/services/installerBootstrapToken.ts`
+- Test: `apps/api/src/services/installerBootstrapToken.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/api/src/services/installerBootstrapToken.test.ts
+import { describe, it, expect } from 'vitest';
+import { generateBootstrapToken, BOOTSTRAP_TOKEN_PATTERN } from './installerBootstrapToken';
+
+describe('generateBootstrapToken', () => {
+  it('returns a 6-char token of [A-Z0-9]', () => {
+    const t = generateBootstrapToken();
+    expect(t).toMatch(BOOTSTRAP_TOKEN_PATTERN);
+  });
+
+  it('returns 6 chars exactly', () => {
+    expect(generateBootstrapToken()).toHaveLength(6);
+  });
+
+  it('is statistically unique across 1000 calls', () => {
+    const tokens = new Set<string>();
+    for (let i = 0; i < 1000; i++) tokens.add(generateBootstrapToken());
+    // 36^6 ≈ 2.2B values; collisions in 1000 samples are essentially impossible.
+    // Allow a single collision before flagging — defensive against an unlucky CI run.
+    expect(tokens.size).toBeGreaterThanOrEqual(999);
+  });
+
+  it('emits only uppercase letters and digits', () => {
+    for (let i = 0; i < 100; i++) {
+      expect(generateBootstrapToken()).toMatch(/^[A-Z0-9]+$/);
+    }
+  });
+});
+
+describe('BOOTSTRAP_TOKEN_PATTERN', () => {
+  it('matches the canonical 6-char form', () => {
+    expect(BOOTSTRAP_TOKEN_PATTERN.test('A7K2XQ')).toBe(true);
+    expect(BOOTSTRAP_TOKEN_PATTERN.test('123456')).toBe(true);
+  });
+
+  it('rejects shorter, longer, or lowercase variants', () => {
+    expect(BOOTSTRAP_TOKEN_PATTERN.test('a7k2xq')).toBe(false);
+    expect(BOOTSTRAP_TOKEN_PATTERN.test('A7K2X')).toBe(false);
+    expect(BOOTSTRAP_TOKEN_PATTERN.test('A7K2XQA')).toBe(false);
+    expect(BOOTSTRAP_TOKEN_PATTERN.test('A7-2XQ')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+```bash
+cd apps/api && npx vitest run src/services/installerBootstrapToken.test.ts
+```
+Expected: FAIL — `Cannot find module './installerBootstrapToken'`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// apps/api/src/services/installerBootstrapToken.ts
+import { randomInt } from 'node:crypto';
+
+/**
+ * Canonical shape of a bootstrap token: 6 chars of base36 (uppercase
+ * letters + digits). 36^6 ≈ 2.2 billion values — sufficient entropy for
+ * a single-use 24h-TTL token. Used by both the generator and the
+ * route-side input validator.
+ */
+export const BOOTSTRAP_TOKEN_PATTERN = /^[A-Z0-9]{6}$/;
+
+const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+
+/**
+ * Generates a 6-character base36 bootstrap token using a CSPRNG.
+ * Output is always 6 chars of [A-Z0-9].
+ */
+export function generateBootstrapToken(): string {
+  let out = '';
+  for (let i = 0; i < 6; i++) {
+    out += ALPHABET[randomInt(0, ALPHABET.length)];
+  }
+  return out;
+}
+
+/**
+ * Default TTL for a freshly-issued bootstrap token. Tunable via env
+ * for testing; production default is 24 hours which matches the
+ * "admin downloads installer, sends to user, user runs sometime
+ * within a day" mental model.
+ */
+export function bootstrapTokenExpiresAt(): Date {
+  const ttlMin = Number(process.env.INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES ?? 24 * 60);
+  return new Date(Date.now() + ttlMin * 60 * 1000);
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+```bash
+cd apps/api && npx vitest run src/services/installerBootstrapToken.test.ts
+```
+Expected: 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/installerBootstrapToken.ts apps/api/src/services/installerBootstrapToken.test.ts
+git commit -m "feat(api): bootstrap token generator for installer"
+```
+
+---
+
+## Task 4: Bootstrap endpoint — failing integration tests first
+
+**Files:**
+- Create: `apps/api/src/routes/installer.test.ts`
+
+- [ ] **Step 1: Write five integration test cases (failing)**
+
+```ts
+// apps/api/src/routes/installer.test.ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock the database, mirroring patterns from existing route tests.
+// See enrollmentKeys.test.ts for the full mock shape — we reuse the same
+// withSystemDbAccessContext stub.
+const mockTx = {
+  select: vi.fn(),
+  update: vi.fn(),
+  insert: vi.fn(),
+};
+
+vi.mock('../db', () => ({
+  withSystemDbAccessContext: vi.fn(async (fn: any) => fn(mockTx)),
+}));
+
+vi.mock('../services/enrollmentKeySecurity', () => ({
+  hashEnrollmentKey: vi.fn((k: string) => `hashed:${k}`),
+}));
+
+import { Hono } from 'hono';
+import { installerRoutes } from './installer';
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/api/v1/installer', installerRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /api/v1/installer/bootstrap/:token', () => {
+  it('returns 400 for malformed token', async () => {
+    const app = makeApp();
+    const res = await app.request('/api/v1/installer/bootstrap/lowercase');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for unknown token', async () => {
+    mockTx.select.mockReturnValue({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve([]) }) }),
+    });
+    const app = makeApp();
+    const res = await app.request('/api/v1/installer/bootstrap/AAAAAA');
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'token invalid, expired, or already used' });
+  });
+
+  it('returns 404 for already-consumed token', async () => {
+    mockTx.select.mockReturnValue({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve([{
+            id: 't1', token: 'BBBBBB', orgId: 'o1',
+            parentEnrollmentKeyId: 'pk1', siteId: 's1', maxUsage: 1,
+            consumedAt: new Date(), expiresAt: new Date(Date.now() + 60_000),
+          }]),
+        }),
+      }),
+    });
+    const app = makeApp();
+    const res = await app.request('/api/v1/installer/bootstrap/BBBBBB');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for expired token', async () => {
+    mockTx.select.mockReturnValue({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve([{
+            id: 't1', token: 'CCCCCC', orgId: 'o1',
+            parentEnrollmentKeyId: 'pk1', siteId: 's1', maxUsage: 1,
+            consumedAt: null, expiresAt: new Date(Date.now() - 1000),
+          }]),
+        }),
+      }),
+    });
+    const app = makeApp();
+    const res = await app.request('/api/v1/installer/bootstrap/CCCCCC');
+    expect(res.status).toBe(404);
+  });
+
+  it('happy path: consumes token, creates child key, returns enrollment payload', async () => {
+    process.env.PUBLIC_API_URL = 'https://us.2breeze.app';
+    process.env.AGENT_ENROLLMENT_SECRET = 'shared-secret-test';
+
+    const tokenRow = {
+      id: 't1', token: 'DDDDDD', orgId: 'o1',
+      parentEnrollmentKeyId: 'pk1', siteId: 's1', maxUsage: 3,
+      createdBy: 'u1',
+      consumedAt: null, expiresAt: new Date(Date.now() + 60_000),
+    };
+    const parentKey = {
+      id: 'pk1', name: 'Acme parent', orgId: 'o1', siteId: 's1',
+      keySecretHash: 'parent-secret-hash',
+    };
+    const org = { id: 'o1', name: 'Acme Corp' };
+
+    mockTx.select
+      .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([tokenRow]) }) }) })
+      .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([parentKey]) }) }) })
+      .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([org]) }) }) });
+
+    mockTx.update.mockReturnValue({
+      set: () => ({ where: () => ({ returning: () => Promise.resolve([{ ...tokenRow, consumedAt: new Date() }]) }) }),
+    });
+    mockTx.insert.mockReturnValue({
+      values: () => ({ returning: () => Promise.resolve([{ id: 'ck1', orgId: 'o1', siteId: 's1' }]) }),
+    });
+
+    const app = makeApp();
+    const res = await app.request('/api/v1/installer/bootstrap/DDDDDD');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.serverUrl).toBe('https://us.2breeze.app');
+    expect(body.enrollmentSecret).toBe('shared-secret-test');
+    expect(body.siteId).toBe('s1');
+    expect(body.orgName).toBe('Acme Corp');
+    expect(body.enrollmentKey).toMatch(/^[a-f0-9]{64}$/);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+```bash
+cd apps/api && npx vitest run src/routes/installer.test.ts
+```
+Expected: FAIL — `Cannot find module './installer'` for all 5 tests.
+
+- [ ] **Step 3: Commit (tests only)**
+
+```bash
+git add apps/api/src/routes/installer.test.ts
+git commit -m "test(api): bootstrap endpoint integration cases"
+```
+
+---
+
+## Task 5: Implement the bootstrap endpoint
+
+**Files:**
+- Create: `apps/api/src/routes/installer.ts`
+
+- [ ] **Step 1: Implement**
+
+```ts
+// apps/api/src/routes/installer.ts
+import { Hono } from 'hono';
+import { and, eq, isNull } from 'drizzle-orm';
+import { randomBytes } from 'node:crypto';
+import { withSystemDbAccessContext } from '../db';
+import { installerBootstrapTokens } from '../db/schema/installerBootstrapTokens';
+import { enrollmentKeys, organizations } from '../db/schema/orgs';
+import { hashEnrollmentKey } from '../services/enrollmentKeySecurity';
+import { BOOTSTRAP_TOKEN_PATTERN } from '../services/installerBootstrapToken';
+
+const CHILD_TTL_MIN = Number(
+  process.env.CHILD_ENROLLMENT_KEY_TTL_MINUTES ?? 24 * 60,
+);
+
+function freshChildExpiresAt(): Date {
+  return new Date(Date.now() + CHILD_TTL_MIN * 60 * 1000);
+}
+
+function generateChildEnrollmentKey(): string {
+  return randomBytes(32).toString('hex'); // 64-char hex, matches enrollmentKeys.ts:66
+}
+
+const INVALID_TOKEN_RESPONSE = {
+  body: { error: 'token invalid, expired, or already used' as const },
+  status: 404 as const,
+};
+
+export const installerRoutes = new Hono();
+
+/**
+ * Public bootstrap endpoint. The token IS the auth — no JWT, no API key,
+ * no session. Resolves the token to an enrollment payload, atomically
+ * marks it consumed, and lazily creates the child enrollment key.
+ *
+ * Invalid / expired / already-used tokens all return the same 404 to
+ * avoid leaking which condition was hit. (Same pattern as enrollment
+ * key validation in agents/enrollment.ts.)
+ */
+installerRoutes.get('/bootstrap/:token', async (c) => {
+  const token = c.req.param('token');
+  if (!BOOTSTRAP_TOKEN_PATTERN.test(token)) {
+    return c.json({ error: 'invalid token' }, 400);
+  }
+
+  const result = await withSystemDbAccessContext(async (tx) => {
+    const [row] = await tx
+      .select()
+      .from(installerBootstrapTokens)
+      .where(eq(installerBootstrapTokens.token, token))
+      .limit(1);
+    if (!row) return null;
+    if (row.consumedAt) return null;
+    if (new Date(row.expiresAt) < new Date()) return null;
+
+    // Atomic single-use guard: UPDATE ... WHERE consumed_at IS NULL.
+    // Two concurrent requests both read row.consumedAt = null but only one
+    // UPDATE will return a row.
+    const [updated] = await tx
+      .update(installerBootstrapTokens)
+      .set({
+        consumedAt: new Date(),
+        consumedFromIp: c.req.header('cf-connecting-ip') ?? null,
+      })
+      .where(
+        and(
+          eq(installerBootstrapTokens.id, row.id),
+          isNull(installerBootstrapTokens.consumedAt),
+        ),
+      )
+      .returning();
+    if (!updated) return null;
+
+    const [parent] = await tx
+      .select()
+      .from(enrollmentKeys)
+      .where(eq(enrollmentKeys.id, row.parentEnrollmentKeyId))
+      .limit(1);
+    if (!parent) return null;
+
+    const rawChildKey = generateChildEnrollmentKey();
+    const childKeyHash = hashEnrollmentKey(rawChildKey);
+    await tx
+      .insert(enrollmentKeys)
+      .values({
+        orgId: row.orgId,
+        siteId: row.siteId,
+        name: `${parent.name} (mac-installer ${token})`,
+        key: childKeyHash,
+        keySecretHash: parent.keySecretHash,
+        maxUsage: row.maxUsage,
+        expiresAt: freshChildExpiresAt(),
+        createdBy: row.createdBy,
+        installerPlatform: 'macos',
+      })
+      .returning();
+
+    const [org] = await tx
+      .select()
+      .from(organizations)
+      .where(eq(organizations.id, row.orgId))
+      .limit(1);
+
+    return {
+      rawChildKey,
+      siteId: row.siteId,
+      orgName: org?.name ?? 'your organization',
+    };
+  });
+
+  if (!result) {
+    return c.json(INVALID_TOKEN_RESPONSE.body, INVALID_TOKEN_RESPONSE.status);
+  }
+
+  return c.json({
+    serverUrl: process.env.PUBLIC_API_URL ?? process.env.API_URL ?? '',
+    enrollmentKey: result.rawChildKey,
+    enrollmentSecret: process.env.AGENT_ENROLLMENT_SECRET || null,
+    siteId: result.siteId,
+    orgName: result.orgName,
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify pass**
+
+```bash
+cd apps/api && npx vitest run src/routes/installer.test.ts
+```
+Expected: 5 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/routes/installer.ts
+git commit -m "feat(api): bootstrap endpoint /api/v1/installer/bootstrap/:token"
+```
+
+---
+
+## Task 6: Mount the installer route
+
+**Files:**
+- Modify: `apps/api/src/index.ts` (around line 672 where other routes are mounted)
+
+- [ ] **Step 1: Add import**
+
+In `apps/api/src/index.ts`, add near the existing route imports (around line 34):
+```ts
+import { installerRoutes } from './routes/installer';
+```
+
+- [ ] **Step 2: Mount the route**
+
+Below the existing `api.route('/enrollment-keys', enrollmentKeyRoutes);` line (around 672):
+```ts
+api.route('/installer', installerRoutes);
+```
+
+- [ ] **Step 3: Verify type check**
+
+```bash
+cd apps/api && npx tsc --noEmit 2>&1 | grep -E "installer|index.ts"
+```
+Expected: no new errors. (Existing pre-existing errors in `agents.test.ts` / `apiKeyAuth.test.ts` per project memory are unrelated.)
+
+- [ ] **Step 4: Smoke-test mounting locally**
+
+```bash
+# In one terminal, with docker compose up:
+cd apps/api && pnpm dev
+# In another:
+curl -i http://localhost:3001/api/v1/installer/bootstrap/lowercase
+# Expected: HTTP/1.1 400, body {"error":"invalid token"}
+
+curl -i http://localhost:3001/api/v1/installer/bootstrap/AAAAAA
+# Expected: HTTP/1.1 404, body {"error":"token invalid, expired, or already used"}
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/index.ts
+git commit -m "feat(api): mount /api/v1/installer routes"
+```
+
+---
+
+## Task 7: Token issuance helper for parent enrollment keys
+
+**Files:**
+- Modify: `apps/api/src/routes/enrollmentKeys.ts` — add `POST /:id/bootstrap-token` handler
+- Modify: `apps/api/src/routes/enrollmentKeys.test.ts` — add tests
+
+This issuance route is what Plan C will call from the installer-download path. Building it here so Plan A is self-contained and Plan C is a one-line route change.
+
+- [ ] **Step 1: Write failing tests**
+
+In `apps/api/src/routes/enrollmentKeys.test.ts`, add a new `describe` block:
+
+```ts
+describe('POST /:id/bootstrap-token', () => {
+  it('issues a bootstrap token for a valid parent key', async () => {
+    // Mock the parent key lookup (existing pattern in this file)
+    const parent = {
+      id: 'pk1', orgId: 'o1', siteId: 's1', name: 'Acme parent',
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      maxUsage: 100, usageCount: 0,
+    };
+    // ... use the existing select/insert mock setup pattern from the file ...
+
+    const res = await app.request('/enrollment-keys/pk1/bootstrap-token', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${jwt}` },
+      body: JSON.stringify({ maxUsage: 1 }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.token).toMatch(/^[A-Z0-9]{6}$/);
+    expect(body.expiresAt).toBeTypeOf('string');
+  });
+
+  it('rejects unknown parent key with 404', async () => {
+    // ... mock select returns [] ...
+    const res = await app.request('/enrollment-keys/missing/bootstrap-token', {
+      method: 'POST', headers: { authorization: `Bearer ${jwt}` },
+      body: JSON.stringify({ maxUsage: 1 }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects when caller has no org access (403)', async () => {
+    // ... mock ensureOrgAccess returns false ...
+    const res = await app.request('/enrollment-keys/pk1/bootstrap-token', {
+      method: 'POST', headers: { authorization: `Bearer ${jwt}` },
+      body: JSON.stringify({ maxUsage: 1 }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects expired parent key with 410', async () => {
+    // ... parent.expiresAt = past ...
+    const res = await app.request('/enrollment-keys/pk1/bootstrap-token', {
+      method: 'POST', headers: { authorization: `Bearer ${jwt}` },
+      body: JSON.stringify({ maxUsage: 1 }),
+    });
+    expect(res.status).toBe(410);
+  });
+});
+```
+
+(Use the existing test file's mock harness — the `select`/`insert`/`auth` patterns are already wired. The full mock setup may take a few extra lines per case; copy from the existing `GET /:id/installer/:platform` block in this file as the reference, since it has the same access-control + parent-key-validation shape.)
+
+- [ ] **Step 2: Run tests, verify failure**
+
+```bash
+cd apps/api && npx vitest run src/routes/enrollmentKeys.test.ts -t "bootstrap-token"
+```
+Expected: FAIL — route returns 404 for the path.
+
+- [ ] **Step 3: Implement the route**
+
+Add to `apps/api/src/routes/enrollmentKeys.ts`, after the existing `GET /:id/installer/:platform` handler:
+
+```ts
+import { generateBootstrapToken, bootstrapTokenExpiresAt } from '../services/installerBootstrapToken';
+import { installerBootstrapTokens } from '../db/schema/installerBootstrapTokens';
+
+// ============================================
+// POST /:id/bootstrap-token — issue a single-use installer bootstrap token
+// ============================================
+
+const bootstrapTokenBodySchema = z.object({
+  maxUsage: z.number().int().min(1).max(1000).default(1),
+});
+
+enrollmentKeyRoutes.post(
+  '/:id/bootstrap-token',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action),
+  requireMfa(),
+  zValidator('json', bootstrapTokenBodySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const keyId = c.req.param('id')!;
+    const { maxUsage } = c.req.valid('json');
+
+    const [parent] = await db
+      .select()
+      .from(enrollmentKeys)
+      .where(eq(enrollmentKeys.id, keyId))
+      .limit(1);
+    if (!parent) {
+      return c.json({ error: 'Enrollment key not found' }, 404);
+    }
+
+    const hasAccess = await ensureOrgAccess(parent.orgId, auth);
+    if (!hasAccess) {
+      return c.json({ error: 'Access denied' }, 403);
+    }
+
+    if (parent.expiresAt && new Date(parent.expiresAt) < new Date()) {
+      return c.json({ error: 'Enrollment key has expired' }, 410);
+    }
+    if (parent.maxUsage !== null && parent.usageCount >= parent.maxUsage) {
+      return c.json({ error: 'Enrollment key usage exhausted' }, 410);
+    }
+
+    const token = generateBootstrapToken();
+    const expiresAt = bootstrapTokenExpiresAt();
+
+    const [row] = await db
+      .insert(installerBootstrapTokens)
+      .values({
+        token,
+        orgId: parent.orgId,
+        parentEnrollmentKeyId: parent.id,
+        siteId: parent.siteId,
+        maxUsage,
+        createdBy: auth.user.id,
+        expiresAt,
+      })
+      .returning();
+
+    writeEnrollmentKeyAudit(c, auth, {
+      orgId: parent.orgId,
+      action: 'enrollment_key.bootstrap_token_issued',
+      keyId: parent.id,
+      keyName: parent.name,
+      details: { tokenId: row.id, maxUsage },
+    });
+
+    return c.json({
+      token,
+      expiresAt: expiresAt.toISOString(),
+      maxUsage,
+    });
+  },
+);
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+```bash
+cd apps/api && npx vitest run src/routes/enrollmentKeys.test.ts -t "bootstrap-token"
+```
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/enrollmentKeys.ts apps/api/src/routes/enrollmentKeys.test.ts
+git commit -m "feat(api): POST /enrollment-keys/:id/bootstrap-token issues installer token"
+```
+
+---
+
+## Task 8: End-to-end smoke test with `curl`
+
+**Files:** none (manual verification)
+
+- [ ] **Step 1: Start a clean local environment**
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.override.yml.dev up -d
+cd apps/api && pnpm dev
+```
+
+- [ ] **Step 2: Issue a bootstrap token**
+
+```bash
+# Get a JWT (use existing dev login or seed script)
+JWT=$(./scripts/dev-login.sh 2>/dev/null || echo "REPLACE_WITH_JWT")
+KEY_ID="REPLACE_WITH_REAL_PARENT_KEY_ID"
+
+curl -sS -X POST http://localhost:3001/api/v1/enrollment-keys/$KEY_ID/bootstrap-token \
+  -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"maxUsage": 1}' | jq
+```
+Expected: `{ "token": "A7K2XQ", "expiresAt": "2026-04-20T...", "maxUsage": 1 }`.
+
+- [ ] **Step 3: Consume the token**
+
+```bash
+TOKEN="A7K2XQ"   # use the value from step 2
+curl -sS http://localhost:3001/api/v1/installer/bootstrap/$TOKEN | jq
+```
+Expected: `{ "serverUrl": "...", "enrollmentKey": "<64 hex>", "enrollmentSecret": "...", "siteId": "...", "orgName": "..." }`.
+
+- [ ] **Step 4: Verify single-use — second call should 404**
+
+```bash
+curl -sS -i http://localhost:3001/api/v1/installer/bootstrap/$TOKEN
+```
+Expected: `HTTP/1.1 404`, body `{"error":"token invalid, expired, or already used"}`.
+
+- [ ] **Step 5: Verify enrollment key was created**
+
+```bash
+docker exec -i breeze-postgres psql -U breeze -d breeze -c "
+  SELECT id, name, max_usage, expires_at FROM enrollment_keys
+  WHERE name LIKE '%mac-installer%' ORDER BY created_at DESC LIMIT 3;
+"
+```
+Expected: a row with name like `<parent>  (mac-installer A7K2XQ)`, max_usage=1, expires_at ~24h in the future.
+
+- [ ] **Step 6: Verify enrollment key actually works**
+
+Take the `enrollmentKey` value from step 3 and try a real `agent enroll`:
+```bash
+cd agent
+./bin/breeze-agent enroll <enrollmentKey> --server http://localhost:3001 --quiet
+```
+Expected: enrollment succeeds, agent.yaml is written with valid config.
+
+- [ ] **Step 7: Confirm CI green**
+
+```bash
+cd apps/api && pnpm test
+cd apps/api && pnpm test --config vitest.config.rls.ts -- rls-coverage
+```
+Expected: all green, no new failures.
+
+No commit — Task 8 is verification only.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Plan A delivers Spec §"Components #2 — API — bootstrap token endpoint" entirely (table, RLS, route, single-use semantics, lazy child-key creation, uniform 404). Spec §"Components #5 — installer builder service" (zip-rename helper) is deferred to Plan C. Spec §"Components #1 — Swift installer app" and §"#4 — CI" are Plan B.
+- **No placeholders:** all SQL, all TypeScript, all curl commands are concrete.
+- **Type consistency:** `BOOTSTRAP_TOKEN_PATTERN`, `generateBootstrapToken`, `bootstrapTokenExpiresAt`, `installerBootstrapTokens` table, `freshChildExpiresAt`, `generateChildEnrollmentKey` — all defined where first used and referenced consistently downstream.
+- **One known gap:** the plan does not explicitly add an OpenAPI annotation for the new routes. If `apps/api/src/openapi.ts` auto-discovers routes, this is a no-op; if it requires manual registration, add a follow-up task. Verify with `grep -n "enrollment-keys" apps/api/src/openapi.ts` after Task 6.
+- **One known omission by design:** rate-limiting on the bootstrap endpoint. Spec defers it ("no rate limit for v1; add a global 1000/min if abuse appears"). Same here — call out as a Plan A followup if the security review flags it.
+
+---
+
+## Plan A Followups (not in this plan)
+
+- OpenAPI registration for `/installer/bootstrap/:token` and `/enrollment-keys/:id/bootstrap-token` (if the `openapi.ts` registry is manual).
+- Global rate limit on `/installer/bootstrap/:token` (e.g. 1000 req/min from Redis sliding window — `services/rate-limit.ts` pattern).
+- Garbage-collection job for expired-but-never-consumed token rows (cron in `apps/api/src/jobs/` running daily — keep one week for audit).

--- a/docs/superpowers/plans/2026-04-19-macos-installer-plan-b-swift-app-and-ci.md
+++ b/docs/superpowers/plans/2026-04-19-macos-installer-plan-b-swift-app-and-ci.md
@@ -1,0 +1,1270 @@
+# macOS Installer App — Plan B: Swift Installer App + CI Notarization
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the static `Breeze Installer.app` — signed + notarized once per release in CI — and produce a `Breeze Installer.app.zip` GitHub release asset. The app reads a token from its own bundle filename, fetches enrollment values from the Plan A bootstrap endpoint, prompts for admin password via native macOS dialog, installs the embedded PKG, and runs `breeze-agent enroll`.
+
+**Architecture:** Swift Package Manager project (no Xcode project needed) + a build script that assembles the `.app` bundle from the SPM-built executable + Resources + Info.plist. CI job mirrors the existing `build-macos-agent` pattern: codesign with `Developer ID Application`, notarize via `notarytool`, staple, ship as a release asset. Plan A's bootstrap endpoint must be deployed before this app can be smoke-tested end-to-end, but the app itself ships as a static artifact independent of API state.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, AppKit (`NSAppleScript`), Swift Package Manager, `xcodebuild` not required, `codesign` + `xcrun notarytool` + `xcrun stapler`, GitHub Actions on `macos-latest`.
+
+---
+
+## File Structure
+
+**Create (everything new under `agent/installer/macos-app/`):**
+- `agent/installer/macos-app/Package.swift` — SPM manifest, executable target
+- `agent/installer/macos-app/Sources/BreezeInstaller/main.swift` — entry point
+- `agent/installer/macos-app/Sources/BreezeInstaller/FilenameTokenParser.swift` — extracts `[TOKEN@host]` from bundle name
+- `agent/installer/macos-app/Sources/BreezeInstaller/BootstrapClient.swift` — HTTP call to `/installer/bootstrap/:token`
+- `agent/installer/macos-app/Sources/BreezeInstaller/Architecture.swift` — `uname -m` detection
+- `agent/installer/macos-app/Sources/BreezeInstaller/Installer.swift` — AppleScript-driven install runner
+- `agent/installer/macos-app/Sources/BreezeInstaller/InstallerApp.swift` — `@main` SwiftUI app + state machine
+- `agent/installer/macos-app/Sources/BreezeInstaller/Views/` — `LoadingView`, `ConfirmView`, `InstallingView`, `DoneView`, `ErrorView`
+- `agent/installer/macos-app/Tests/BreezeInstallerTests/FilenameTokenParserTests.swift`
+- `agent/installer/macos-app/Resources/Info.plist`
+- `agent/installer/macos-app/Resources/AppIcon.icns` (placeholder; replace before ship)
+- `agent/installer/macos-app/Resources/.gitkeep` for arm64/amd64 PKG slots
+- `agent/installer/macos-app/build-app-bundle.sh` — assembles `.app` from SPM build output
+- `agent/installer/macos-app/entitlements.plist` — minimal hardened-runtime entitlements
+- `agent/installer/macos-app/README.md` — local dev + signing instructions
+
+**Modify:**
+- `.github/workflows/release.yml` — add `build-macos-installer-app` job after `build-macos-agent`
+
+---
+
+## Task 1: Swift Package skeleton
+
+**Files:**
+- Create: `agent/installer/macos-app/Package.swift`
+- Create: `agent/installer/macos-app/Sources/BreezeInstaller/main.swift` (placeholder)
+- Create: `agent/installer/macos-app/.gitignore`
+
+- [ ] **Step 1: Create `Package.swift`**
+
+```swift
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "BreezeInstaller",
+    platforms: [.macOS(.v11)],
+    products: [
+        .executable(name: "BreezeInstaller", targets: ["BreezeInstaller"]),
+    ],
+    targets: [
+        .executableTarget(
+            name: "BreezeInstaller",
+            path: "Sources/BreezeInstaller"
+        ),
+        .testTarget(
+            name: "BreezeInstallerTests",
+            dependencies: ["BreezeInstaller"],
+            path: "Tests/BreezeInstallerTests"
+        ),
+    ]
+)
+```
+
+- [ ] **Step 2: Placeholder entry point**
+
+```swift
+// agent/installer/macos-app/Sources/BreezeInstaller/main.swift
+import Foundation
+print("BreezeInstaller stub")
+```
+
+- [ ] **Step 3: `.gitignore`**
+
+```
+.build/
+.swiftpm/
+DerivedData/
+build/
+*.xcodeproj
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+```bash
+cd agent/installer/macos-app && swift build
+```
+Expected: builds cleanly, produces `.build/debug/BreezeInstaller`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/installer/macos-app/
+git commit -m "installer-app: SPM skeleton"
+```
+
+---
+
+## Task 2: Filename token parser (TDD)
+
+**Files:**
+- Create: `agent/installer/macos-app/Sources/BreezeInstaller/FilenameTokenParser.swift`
+- Create: `agent/installer/macos-app/Tests/BreezeInstallerTests/FilenameTokenParserTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+```swift
+// agent/installer/macos-app/Tests/BreezeInstallerTests/FilenameTokenParserTests.swift
+import XCTest
+@testable import BreezeInstaller
+
+final class FilenameTokenParserTests: XCTestCase {
+    func testExtractsTokenAndHostFromCanonicalFilename() throws {
+        let result = try FilenameTokenParser.parse(
+            bundleName: "Breeze Installer [A7K2XQ@us.2breeze.app].app"
+        )
+        XCTAssertEqual(result.token, "A7K2XQ")
+        XCTAssertEqual(result.apiHost, "us.2breeze.app")
+    }
+
+    func testHandlesNumericOnlyToken() throws {
+        let result = try FilenameTokenParser.parse(
+            bundleName: "Breeze Installer [123456@eu.2breeze.app].app"
+        )
+        XCTAssertEqual(result.token, "123456")
+    }
+
+    func testRejectsLowercaseToken() {
+        XCTAssertThrowsError(try FilenameTokenParser.parse(
+            bundleName: "Breeze Installer [a7k2xq@us.2breeze.app].app"
+        )) { error in
+            XCTAssertEqual(error as? FilenameTokenParser.Error, .invalidFormat)
+        }
+    }
+
+    func testRejectsMissingBracket() {
+        XCTAssertThrowsError(try FilenameTokenParser.parse(
+            bundleName: "Breeze Installer.app"
+        )) { error in
+            XCTAssertEqual(error as? FilenameTokenParser.Error, .invalidFormat)
+        }
+    }
+
+    func testRejectsTooShortToken() {
+        XCTAssertThrowsError(try FilenameTokenParser.parse(
+            bundleName: "Breeze Installer [A7K2X@us.2breeze.app].app"
+        )) { error in
+            XCTAssertEqual(error as? FilenameTokenParser.Error, .invalidFormat)
+        }
+    }
+
+    func testRejectsTooLongToken() {
+        XCTAssertThrowsError(try FilenameTokenParser.parse(
+            bundleName: "Breeze Installer [A7K2XQ7@us.2breeze.app].app"
+        )) { error in
+            XCTAssertEqual(error as? FilenameTokenParser.Error, .invalidFormat)
+        }
+    }
+
+    func testRejectsHostWithSpaces() {
+        XCTAssertThrowsError(try FilenameTokenParser.parse(
+            bundleName: "Breeze Installer [A7K2XQ@us 2breeze.app].app"
+        ))
+    }
+
+    func testAcceptsCustomHostForSelfHosters() throws {
+        let result = try FilenameTokenParser.parse(
+            bundleName: "Breeze Installer [A7K2XQ@rmm.acme.example].app"
+        )
+        XCTAssertEqual(result.apiHost, "rmm.acme.example")
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+```bash
+cd agent/installer/macos-app && swift test
+```
+Expected: build error — `FilenameTokenParser` not defined.
+
+- [ ] **Step 3: Implement**
+
+```swift
+// agent/installer/macos-app/Sources/BreezeInstaller/FilenameTokenParser.swift
+import Foundation
+
+/// Parses the bootstrap token + API host out of the installer app's own
+/// bundle filename. Format: `Breeze Installer [TOKEN@host.example].app`
+/// where TOKEN is exactly 6 chars of [A-Z0-9] and host matches a relaxed
+/// hostname pattern (letters, digits, dots, hyphens).
+enum FilenameTokenParser {
+    struct Result: Equatable {
+        let token: String
+        let apiHost: String
+    }
+
+    enum Error: Swift.Error, Equatable {
+        case invalidFormat
+    }
+
+    private static let pattern = #"\[([A-Z0-9]{6})@([a-zA-Z0-9.\-]+)\]"#
+
+    static func parse(bundleName: String) throws -> Result {
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(
+                in: bundleName,
+                range: NSRange(bundleName.startIndex..., in: bundleName)
+              ),
+              match.numberOfRanges == 3,
+              let tokenRange = Range(match.range(at: 1), in: bundleName),
+              let hostRange = Range(match.range(at: 2), in: bundleName)
+        else {
+            throw Error.invalidFormat
+        }
+        return Result(
+            token: String(bundleName[tokenRange]),
+            apiHost: String(bundleName[hostRange])
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+```bash
+cd agent/installer/macos-app && swift test
+```
+Expected: 8 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/installer/macos-app/Sources agent/installer/macos-app/Tests
+git commit -m "installer-app: filename token parser"
+```
+
+---
+
+## Task 3: Bootstrap HTTP client
+
+**Files:**
+- Create: `agent/installer/macos-app/Sources/BreezeInstaller/BootstrapClient.swift`
+
+No tests — testing real HTTP calls in CI requires a mock server, which is overkill for an internal tool. Smoke-tested manually against the live API in Task 9.
+
+- [ ] **Step 1: Implement**
+
+```swift
+// agent/installer/macos-app/Sources/BreezeInstaller/BootstrapClient.swift
+import Foundation
+
+/// Fetches the enrollment payload from the Plan A bootstrap endpoint.
+struct BootstrapClient {
+    struct Payload: Decodable {
+        let serverUrl: String
+        let enrollmentKey: String
+        let enrollmentSecret: String?
+        let siteId: String?
+        let orgName: String
+    }
+
+    enum Error: Swift.Error, LocalizedError {
+        case network(underlying: Swift.Error)
+        case http(status: Int, body: String)
+        case decoding(underlying: Swift.Error)
+
+        var errorDescription: String? {
+            switch self {
+            case .network(let e):
+                return "Network error: \(e.localizedDescription)"
+            case .http(let status, _) where status == 404:
+                return "This installer link has expired or already been used. Please re-download from your Breeze web console."
+            case .http(let status, let body):
+                return "Server error (\(status)): \(body.prefix(200))"
+            case .decoding:
+                return "Server returned an unexpected response. Please re-download the installer."
+            }
+        }
+    }
+
+    let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func fetch(token: String, apiHost: String) async throws -> Payload {
+        guard let url = URL(string: "https://\(apiHost)/api/v1/installer/bootstrap/\(token)") else {
+            throw Error.http(status: 0, body: "constructed URL is invalid")
+        }
+        var req = URLRequest(url: url)
+        req.timeoutInterval = 30
+        req.setValue("BreezeInstaller/1.0", forHTTPHeaderField: "User-Agent")
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: req)
+        } catch {
+            throw Error.network(underlying: error)
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw Error.http(status: 0, body: "non-HTTP response")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw Error.http(status: http.statusCode, body: body)
+        }
+        do {
+            return try JSONDecoder().decode(Payload.self, from: data)
+        } catch {
+            throw Error.decoding(underlying: error)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+cd agent/installer/macos-app && swift build
+```
+Expected: clean build.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add agent/installer/macos-app/Sources/BreezeInstaller/BootstrapClient.swift
+git commit -m "installer-app: bootstrap HTTP client"
+```
+
+---
+
+## Task 4: Architecture detection
+
+**Files:**
+- Create: `agent/installer/macos-app/Sources/BreezeInstaller/Architecture.swift`
+- Modify: `agent/installer/macos-app/Tests/BreezeInstallerTests/FilenameTokenParserTests.swift` (no — separate test file)
+- Create: `agent/installer/macos-app/Tests/BreezeInstallerTests/ArchitectureTests.swift`
+
+- [ ] **Step 1: Write test**
+
+```swift
+// agent/installer/macos-app/Tests/BreezeInstallerTests/ArchitectureTests.swift
+import XCTest
+@testable import BreezeInstaller
+
+final class ArchitectureTests: XCTestCase {
+    func testMapsArm64() {
+        XCTAssertEqual(Architecture.fromUname("arm64\n"), .arm64)
+        XCTAssertEqual(Architecture.fromUname("arm64"), .arm64)
+    }
+
+    func testMapsAmd64() {
+        XCTAssertEqual(Architecture.fromUname("x86_64\n"), .amd64)
+        XCTAssertEqual(Architecture.fromUname("x86_64"), .amd64)
+    }
+
+    func testRejectsUnknown() {
+        XCTAssertNil(Architecture.fromUname("ppc"))
+        XCTAssertNil(Architecture.fromUname(""))
+    }
+
+    func testPickPkgFilenames() {
+        XCTAssertEqual(Architecture.arm64.pkgResourceName, "breeze-agent-arm64.pkg")
+        XCTAssertEqual(Architecture.amd64.pkgResourceName, "breeze-agent-amd64.pkg")
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+```bash
+cd agent/installer/macos-app && swift test
+```
+Expected: build error — `Architecture` not defined.
+
+- [ ] **Step 3: Implement**
+
+```swift
+// agent/installer/macos-app/Sources/BreezeInstaller/Architecture.swift
+import Foundation
+
+enum Architecture: String {
+    case arm64
+    case amd64
+
+    var pkgResourceName: String {
+        switch self {
+        case .arm64: return "breeze-agent-arm64.pkg"
+        case .amd64: return "breeze-agent-amd64.pkg"
+        }
+    }
+
+    /// Parses `uname -m` output. Returns nil for anything we don't ship a PKG for.
+    static func fromUname(_ output: String) -> Architecture? {
+        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch trimmed {
+        case "arm64": return .arm64
+        case "x86_64": return .amd64
+        default: return nil
+        }
+    }
+
+    /// Detects the running host's architecture by invoking `/usr/bin/uname -m`.
+    static func current() -> Architecture? {
+        let task = Process()
+        task.launchPath = "/usr/bin/uname"
+        task.arguments = ["-m"]
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        do {
+            try task.run()
+            task.waitUntilExit()
+        } catch {
+            return nil
+        }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8) ?? ""
+        return fromUname(output)
+    }
+}
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+```bash
+cd agent/installer/macos-app && swift test
+```
+Expected: all tests (parser + arch) pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/installer/macos-app/Sources/BreezeInstaller/Architecture.swift agent/installer/macos-app/Tests/BreezeInstallerTests/ArchitectureTests.swift
+git commit -m "installer-app: architecture detection"
+```
+
+---
+
+## Task 5: Install runner via AppleScript
+
+**Files:**
+- Create: `agent/installer/macos-app/Sources/BreezeInstaller/Installer.swift`
+
+No unit test — `NSAppleScript` invocations are side-effecting and would require a real admin-password prompt, which we cannot script in CI. Smoke-tested manually in Task 9.
+
+- [ ] **Step 1: Implement**
+
+```swift
+// agent/installer/macos-app/Sources/BreezeInstaller/Installer.swift
+import Foundation
+import AppKit
+
+/// Runs `installer -pkg` and `breeze-agent enroll` as root via the native
+/// macOS admin-password dialog. Uses `NSAppleScript` because it is the
+/// supported way to trigger the system auth prompt for a one-shot
+/// administrator command — `AuthorizationExecuteWithPrivileges` is
+/// deprecated and SMJobBless is overkill for this scope.
+struct Installer {
+    enum Error: Swift.Error, LocalizedError {
+        case appleScriptFailed(message: String, code: Int)
+        case scriptCreationFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .scriptCreationFailed:
+                return "Could not construct installer script"
+            case .appleScriptFailed(let message, let code) where code == -128:
+                return "Administrator authentication was cancelled"
+            case .appleScriptFailed(let message, let code):
+                return "Install failed (\(code)): \(message)"
+            }
+        }
+    }
+
+    /// Escapes a single value for safe interpolation inside an AppleScript
+    /// `do shell script` POSIX string. Wraps in single quotes and escapes
+    /// any embedded single quotes by closing/escaping/reopening.
+    static func shellEscape(_ value: String) -> String {
+        let escaped = value.replacingOccurrences(of: "'", with: "'\\''")
+        return "'\(escaped)'"
+    }
+
+    func run(
+        pkgPath: String,
+        serverUrl: String,
+        enrollmentKey: String,
+        enrollmentSecret: String?,
+        siteId: String?
+    ) throws {
+        var enrollArgs = [
+            shellEscape(enrollmentKey),
+            "--server", shellEscape(serverUrl),
+            "--quiet",
+        ]
+        if let secret = enrollmentSecret, !secret.isEmpty {
+            enrollArgs += ["--enrollment-secret", Installer.shellEscape(secret)]
+        }
+        if let site = siteId, !site.isEmpty {
+            enrollArgs += ["--site-id", Installer.shellEscape(site)]
+        }
+        let enrollCmd = enrollArgs.joined(separator: " ")
+
+        let script = """
+        do shell script "/usr/sbin/installer -pkg \(Installer.shellEscape(pkgPath)) -target / && /usr/local/bin/breeze-agent enroll \(enrollCmd)" with administrator privileges
+        """
+
+        guard let appleScript = NSAppleScript(source: script) else {
+            throw Error.scriptCreationFailed
+        }
+        var errorDict: NSDictionary?
+        appleScript.executeAndReturnError(&errorDict)
+        if let err = errorDict {
+            let message = err[NSAppleScript.errorMessage] as? String ?? "unknown"
+            let code = err[NSAppleScript.errorNumber] as? Int ?? -1
+            throw Error.appleScriptFailed(message: message, code: code)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+cd agent/installer/macos-app && swift build
+```
+Expected: clean build.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add agent/installer/macos-app/Sources/BreezeInstaller/Installer.swift
+git commit -m "installer-app: AppleScript-driven install runner"
+```
+
+---
+
+## Task 6: SwiftUI app + state machine
+
+**Files:**
+- Replace: `agent/installer/macos-app/Sources/BreezeInstaller/main.swift` (delete or convert to `@main`)
+- Create: `agent/installer/macos-app/Sources/BreezeInstaller/InstallerApp.swift`
+- Create: `agent/installer/macos-app/Sources/BreezeInstaller/Views/LoadingView.swift`
+- Create: `agent/installer/macos-app/Sources/BreezeInstaller/Views/ConfirmView.swift`
+- Create: `agent/installer/macos-app/Sources/BreezeInstaller/Views/InstallingView.swift`
+- Create: `agent/installer/macos-app/Sources/BreezeInstaller/Views/DoneView.swift`
+- Create: `agent/installer/macos-app/Sources/BreezeInstaller/Views/ErrorView.swift`
+
+- [ ] **Step 1: Delete the placeholder `main.swift`**
+
+```bash
+rm agent/installer/macos-app/Sources/BreezeInstaller/main.swift
+```
+
+- [ ] **Step 2: Create `InstallerApp.swift` (entry point + state machine)**
+
+```swift
+// agent/installer/macos-app/Sources/BreezeInstaller/InstallerApp.swift
+import SwiftUI
+
+enum InstallState {
+    case loading
+    case confirm(payload: BootstrapClient.Payload)
+    case installing
+    case done(orgName: String)
+    case error(message: String, recoverable: Bool)
+}
+
+@MainActor
+final class InstallController: ObservableObject {
+    @Published var state: InstallState = .loading
+
+    private var token: String?
+    private var apiHost: String?
+    private var payload: BootstrapClient.Payload?
+
+    func start() {
+        Task { await self.bootstrap() }
+    }
+
+    private func bootstrap() async {
+        let bundleName = Bundle.main.bundleURL.lastPathComponent
+        let parsed: FilenameTokenParser.Result
+        do {
+            parsed = try FilenameTokenParser.parse(bundleName: bundleName)
+        } catch {
+            state = .error(
+                message: "This installer needs its original filename. Please re-download from your Breeze web console.",
+                recoverable: false
+            )
+            return
+        }
+        token = parsed.token
+        apiHost = parsed.apiHost
+
+        let client = BootstrapClient()
+        do {
+            let p = try await client.fetch(token: parsed.token, apiHost: parsed.apiHost)
+            payload = p
+            state = .confirm(payload: p)
+        } catch let err as BootstrapClient.Error {
+            state = .error(message: err.errorDescription ?? "Unknown error", recoverable: true)
+        } catch {
+            state = .error(message: error.localizedDescription, recoverable: true)
+        }
+    }
+
+    func confirmInstall() {
+        guard let payload else { return }
+        state = .installing
+        Task { await self.runInstall(payload: payload) }
+    }
+
+    func retry() {
+        state = .loading
+        start()
+    }
+
+    private func runInstall(payload: BootstrapClient.Payload) async {
+        guard let arch = Architecture.current() else {
+            state = .error(message: "Unsupported CPU architecture", recoverable: false)
+            return
+        }
+        guard let resourcesURL = Bundle.main.resourceURL else {
+            state = .error(message: "Could not locate installer resources", recoverable: false)
+            return
+        }
+        let pkgURL = resourcesURL.appendingPathComponent(arch.pkgResourceName)
+        guard FileManager.default.fileExists(atPath: pkgURL.path) else {
+            state = .error(message: "Bundled installer is missing \(arch.pkgResourceName). Please re-download.", recoverable: false)
+            return
+        }
+
+        do {
+            try Installer().run(
+                pkgPath: pkgURL.path,
+                serverUrl: payload.serverUrl,
+                enrollmentKey: payload.enrollmentKey,
+                enrollmentSecret: payload.enrollmentSecret,
+                siteId: payload.siteId
+            )
+            state = .done(orgName: payload.orgName)
+        } catch let err as Installer.Error {
+            state = .error(message: err.errorDescription ?? "Install failed", recoverable: true)
+        } catch {
+            state = .error(message: error.localizedDescription, recoverable: true)
+        }
+    }
+}
+
+@main
+struct BreezeInstallerApp: App {
+    @StateObject private var controller = InstallController()
+
+    var body: some Scene {
+        WindowGroup("Breeze Installer") {
+            RootView(controller: controller)
+                .frame(width: 480, height: 320)
+                .onAppear { controller.start() }
+        }
+        .windowResizability(.contentSize)
+    }
+}
+
+struct RootView: View {
+    @ObservedObject var controller: InstallController
+
+    var body: some View {
+        Group {
+            switch controller.state {
+            case .loading:
+                LoadingView()
+            case .confirm(let payload):
+                ConfirmView(payload: payload, onInstall: controller.confirmInstall)
+            case .installing:
+                InstallingView()
+            case .done(let orgName):
+                DoneView(orgName: orgName)
+            case .error(let message, let recoverable):
+                ErrorView(message: message, recoverable: recoverable, onRetry: controller.retry)
+            }
+        }
+        .padding(24)
+    }
+}
+```
+
+- [ ] **Step 3: Create `LoadingView.swift`**
+
+```swift
+// agent/installer/macos-app/Sources/BreezeInstaller/Views/LoadingView.swift
+import SwiftUI
+
+struct LoadingView: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+            Text("Preparing installer…")
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+```
+
+- [ ] **Step 4: Create `ConfirmView.swift`**
+
+```swift
+// agent/installer/macos-app/Sources/BreezeInstaller/Views/ConfirmView.swift
+import SwiftUI
+
+struct ConfirmView: View {
+    let payload: BootstrapClient.Payload
+    let onInstall: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Install Breeze Agent")
+                .font(.title2).bold()
+            Text("This will install the Breeze monitoring agent for **\(payload.orgName)**. You will be prompted for your administrator password.")
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer()
+            HStack {
+                Spacer()
+                Button("Quit") { NSApp.terminate(nil) }
+                    .keyboardShortcut(.cancelAction)
+                Button("Install") { onInstall() }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+```
+
+- [ ] **Step 5: Create `InstallingView.swift`**
+
+```swift
+// agent/installer/macos-app/Sources/BreezeInstaller/Views/InstallingView.swift
+import SwiftUI
+
+struct InstallingView: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .scaleEffect(1.2)
+            Text("Installing Breeze Agent…")
+                .font(.headline)
+            Text("This usually takes about 10 seconds.")
+                .foregroundStyle(.secondary)
+                .font(.subheadline)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+```
+
+- [ ] **Step 6: Create `DoneView.swift`**
+
+```swift
+// agent/installer/macos-app/Sources/BreezeInstaller/Views/DoneView.swift
+import SwiftUI
+
+struct DoneView: View {
+    let orgName: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(.green)
+            Text("Breeze Agent installed")
+                .font(.title2).bold()
+            Text("Your Mac is now monitored under **\(orgName)**.")
+            Spacer()
+            HStack {
+                Spacer()
+                Button("Quit") { NSApp.terminate(nil) }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+```
+
+- [ ] **Step 7: Create `ErrorView.swift`**
+
+```swift
+// agent/installer/macos-app/Sources/BreezeInstaller/Views/ErrorView.swift
+import SwiftUI
+
+struct ErrorView: View {
+    let message: String
+    let recoverable: Bool
+    let onRetry: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 36))
+                .foregroundStyle(.orange)
+            Text("Install could not continue")
+                .font(.title3).bold()
+            Text(message)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer()
+            HStack {
+                Spacer()
+                Button("Quit") { NSApp.terminate(nil) }
+                    .keyboardShortcut(.cancelAction)
+                if recoverable {
+                    Button("Try again") { onRetry() }
+                        .keyboardShortcut(.defaultAction)
+                        .buttonStyle(.borderedProminent)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+```
+
+- [ ] **Step 8: Build**
+
+```bash
+cd agent/installer/macos-app && swift build
+```
+Expected: clean build. (May warn about `@main` + `main.swift` if the placeholder wasn't deleted — fix.)
+
+- [ ] **Step 9: Run all tests**
+
+```bash
+cd agent/installer/macos-app && swift test
+```
+Expected: 12 tests pass (8 parser + 4 arch).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add agent/installer/macos-app/
+git commit -m "installer-app: SwiftUI views + state machine"
+```
+
+---
+
+## Task 7: `Info.plist` and entitlements
+
+**Files:**
+- Create: `agent/installer/macos-app/Resources/Info.plist`
+- Create: `agent/installer/macos-app/entitlements.plist`
+
+- [ ] **Step 1: `Info.plist`**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>BreezeInstaller</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.breeze.installer</string>
+    <key>CFBundleName</key>
+    <string>Breeze Installer</string>
+    <key>CFBundleDisplayName</key>
+    <string>Breeze Installer</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>11.0</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSHumanReadableCopyright</key>
+    <string>Copyright © 2026 Olive Technologies LLC.</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+</dict>
+</plist>
+```
+
+- [ ] **Step 2: `entitlements.plist` (minimal hardened-runtime)**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <false/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <false/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <false/>
+</dict>
+</plist>
+```
+
+(No sandbox entitlement — installer needs to invoke `/usr/sbin/installer` as root via AppleScript, which the sandbox would block. Hardened runtime is required for notarization.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add agent/installer/macos-app/Resources/Info.plist agent/installer/macos-app/entitlements.plist
+git commit -m "installer-app: Info.plist + entitlements"
+```
+
+---
+
+## Task 8: Build script — assemble `.app` bundle from SPM output
+
+**Files:**
+- Create: `agent/installer/macos-app/build-app-bundle.sh`
+
+The script takes the SPM-built executable + Resources + Info.plist and assembles a proper macOS `.app` bundle that Gatekeeper recognizes. Universal binary (arm64 + x86_64) so a single app runs on all Macs.
+
+- [ ] **Step 1: Implement**
+
+```bash
+#!/usr/bin/env bash
+# agent/installer/macos-app/build-app-bundle.sh
+#
+# Assembles Breeze Installer.app from the SPM-built executable.
+# Produces a universal (arm64 + x86_64) .app bundle.
+#
+# Usage:
+#   ./build-app-bundle.sh \
+#     --pkg-amd64 /path/to/breeze-agent-darwin-amd64.pkg \
+#     --pkg-arm64 /path/to/breeze-agent-darwin-arm64.pkg \
+#     --output    /path/to/output/Breeze\ Installer.app
+#
+# Requires Swift 5.9+, macOS 11+ build host.
+set -euo pipefail
+
+PKG_AMD64=""
+PKG_ARM64=""
+OUTPUT=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pkg-amd64) PKG_AMD64="$2"; shift 2 ;;
+        --pkg-arm64) PKG_ARM64="$2"; shift 2 ;;
+        --output)    OUTPUT="$2";    shift 2 ;;
+        *) echo "Unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [[ -z "$PKG_AMD64" || -z "$PKG_ARM64" || -z "$OUTPUT" ]]; then
+    echo "Usage: $0 --pkg-amd64 PATH --pkg-arm64 PATH --output PATH" >&2
+    exit 1
+fi
+for f in "$PKG_AMD64" "$PKG_ARM64"; do
+    [[ -f "$f" ]] || { echo "Missing PKG: $f" >&2; exit 1; }
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "→ Building universal binary…"
+swift build -c release --arch arm64
+swift build -c release --arch x86_64
+ARM_BIN=".build/arm64-apple-macosx/release/BreezeInstaller"
+X86_BIN=".build/x86_64-apple-macosx/release/BreezeInstaller"
+[[ -f "$ARM_BIN" && -f "$X86_BIN" ]] || { echo "SPM build did not produce expected binaries" >&2; exit 1; }
+
+UNIVERSAL_BIN="$(mktemp -d)/BreezeInstaller"
+lipo -create "$ARM_BIN" "$X86_BIN" -output "$UNIVERSAL_BIN"
+file "$UNIVERSAL_BIN"
+
+echo "→ Assembling .app bundle at $OUTPUT…"
+rm -rf "$OUTPUT"
+mkdir -p "$OUTPUT/Contents/MacOS"
+mkdir -p "$OUTPUT/Contents/Resources"
+
+cp "$UNIVERSAL_BIN" "$OUTPUT/Contents/MacOS/BreezeInstaller"
+chmod 755 "$OUTPUT/Contents/MacOS/BreezeInstaller"
+
+cp Resources/Info.plist "$OUTPUT/Contents/Info.plist"
+if [[ -f Resources/AppIcon.icns ]]; then
+    cp Resources/AppIcon.icns "$OUTPUT/Contents/Resources/AppIcon.icns"
+fi
+
+cp "$PKG_AMD64" "$OUTPUT/Contents/Resources/breeze-agent-amd64.pkg"
+cp "$PKG_ARM64" "$OUTPUT/Contents/Resources/breeze-agent-arm64.pkg"
+
+echo "→ .app bundle assembled:"
+ls -la "$OUTPUT/Contents/"
+echo "✓ Done. Sign + notarize with the CI workflow or manually:"
+echo "    codesign --force --options runtime --entitlements entitlements.plist \\"
+echo "      --sign \"Developer ID Application: …\" --timestamp \"$OUTPUT\""
+```
+
+- [ ] **Step 2: Make executable + smoke-test locally**
+
+```bash
+chmod +x agent/installer/macos-app/build-app-bundle.sh
+
+# Create dummy PKGs for the local smoke
+mkdir -p /tmp/breeze-installer-smoke
+echo "fake" > /tmp/breeze-installer-smoke/amd64.pkg
+echo "fake" > /tmp/breeze-installer-smoke/arm64.pkg
+
+agent/installer/macos-app/build-app-bundle.sh \
+  --pkg-amd64 /tmp/breeze-installer-smoke/amd64.pkg \
+  --pkg-arm64 /tmp/breeze-installer-smoke/arm64.pkg \
+  --output /tmp/breeze-installer-smoke/Breeze\ Installer.app
+```
+Expected: bundle is created with the universal binary in `Contents/MacOS/`, both fake PKGs in `Contents/Resources/`, Info.plist in place. `file Contents/MacOS/BreezeInstaller` shows "Mach-O universal binary with 2 architectures".
+
+- [ ] **Step 3: Test launch (will fail bootstrap but should show error UI)**
+
+```bash
+mv "/tmp/breeze-installer-smoke/Breeze Installer.app" "/tmp/breeze-installer-smoke/Breeze Installer [A7K2XQ@nonexistent.example].app"
+open "/tmp/breeze-installer-smoke/Breeze Installer [A7K2XQ@nonexistent.example].app"
+```
+Expected: window opens, parser succeeds, network fetch fails, shows ErrorView with "Network error: …" and a Try again button.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add agent/installer/macos-app/build-app-bundle.sh
+git commit -m "installer-app: build script for .app bundle assembly"
+```
+
+---
+
+## Task 9: Local sign + notarize + staple test
+
+This is a manual verification step using the developer's own Apple Developer ID credentials. No CI involved yet — proves the assembled `.app` is notarizable before wiring CI.
+
+**Files:** none (manual)
+
+- [ ] **Step 1: Build a real .app with real PKGs**
+
+Use the latest signed PKGs from a recent release (download from GitHub or build locally):
+
+```bash
+agent/installer/macos-app/build-app-bundle.sh \
+  --pkg-amd64 ~/Downloads/breeze-agent-darwin-amd64.pkg \
+  --pkg-arm64 ~/Downloads/breeze-agent-darwin-arm64.pkg \
+  --output "/tmp/Breeze Installer.app"
+```
+
+- [ ] **Step 2: Sign**
+
+```bash
+SIGNING_IDENTITY="Developer ID Application: Olive Technologies LLC (TEAMID)"
+codesign --force --options runtime \
+  --entitlements agent/installer/macos-app/entitlements.plist \
+  --sign "$SIGNING_IDENTITY" --timestamp \
+  --deep "/tmp/Breeze Installer.app"
+codesign --verify --verbose=2 "/tmp/Breeze Installer.app"
+```
+Expected: `valid on disk` + `satisfies its Designated Requirement`.
+
+- [ ] **Step 3: Notarize**
+
+```bash
+ditto -c -k --keepParent "/tmp/Breeze Installer.app" "/tmp/installer-notarize.zip"
+xcrun notarytool submit "/tmp/installer-notarize.zip" \
+  --apple-id "$APPLE_ID" \
+  --password "$APPLE_APP_PASSWORD" \
+  --team-id "$APPLE_TEAM_ID" \
+  --wait --timeout 30m
+```
+Expected: status `Accepted` after 30s–3min.
+
+- [ ] **Step 4: Staple**
+
+```bash
+xcrun stapler staple "/tmp/Breeze Installer.app"
+xcrun stapler validate "/tmp/Breeze Installer.app"
+```
+Expected: `The validate action worked!`.
+
+- [ ] **Step 5: Verify Gatekeeper acceptance**
+
+```bash
+spctl -a -t exec -vv "/tmp/Breeze Installer.app"
+```
+Expected: `accepted` + `source=Notarized Developer ID`.
+
+- [ ] **Step 6: Rename + launch**
+
+```bash
+mv "/tmp/Breeze Installer.app" "/tmp/Breeze Installer [A7K2XQ@us.2breeze.app].app"
+open "/tmp/Breeze Installer [A7K2XQ@us.2breeze.app].app"
+```
+Expected: window appears, attempts to fetch bootstrap (will 404 against real API since the token is fake), shows ErrorView. **Critically:** no Gatekeeper warning, no "unidentified developer" prompt — proves the rename does not invalidate the signature/staple.
+
+If you want to test the happy path: issue a real token via the Plan A endpoints first, use that token in the rename, and run with the actual API.
+
+No commit — verification only.
+
+---
+
+## Task 10: CI workflow — `build-macos-installer-app` job
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Add the job**
+
+Insert after the existing `build-macos-agent` job (around line 770), and before `build-viewer`:
+
+```yaml
+  build-macos-installer-app:
+    name: Build macOS Installer App
+    needs: [build-macos-agent]
+    runs-on: macos-latest
+    if: vars.ENABLE_MACOS_SIGNING == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download .pkg darwin/amd64
+        uses: actions/download-artifact@v7
+        with:
+          name: breeze-agent-darwin-amd64-pkg
+          path: installer-pkgs/
+      - name: Download .pkg darwin/arm64
+        uses: actions/download-artifact@v7
+        with:
+          name: breeze-agent-darwin-arm64-pkg
+          path: installer-pkgs/
+
+      - name: Setup signing keychain
+        env:
+          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          # Reuse the existing keychain setup pattern from build-macos-agent.
+          # If that job already runs in the same job graph, the keychain may
+          # not survive across jobs — we set it up fresh here.
+          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          echo "$APPLE_CERTIFICATE_BASE64" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+      - name: Build .app bundle
+        run: |
+          chmod +x agent/installer/macos-app/build-app-bundle.sh
+          agent/installer/macos-app/build-app-bundle.sh \
+            --pkg-amd64 installer-pkgs/breeze-agent-darwin-amd64.pkg \
+            --pkg-arm64 installer-pkgs/breeze-agent-darwin-arm64.pkg \
+            --output "build/Breeze Installer.app"
+
+      - name: Sign .app
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          codesign --force --options runtime \
+            --entitlements agent/installer/macos-app/entitlements.plist \
+            --sign "$APPLE_SIGNING_IDENTITY" --timestamp \
+            --deep "build/Breeze Installer.app"
+          codesign --verify --verbose=2 "build/Breeze Installer.app"
+
+      - name: Notarize + staple
+        env:
+          APPLE_ID:       ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID:  ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          ditto -c -k --keepParent "build/Breeze Installer.app" build/installer-notarize.zip
+          xcrun notarytool submit build/installer-notarize.zip \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait --timeout 30m
+          xcrun stapler staple "build/Breeze Installer.app"
+          xcrun stapler validate "build/Breeze Installer.app"
+          spctl -a -t exec -vv "build/Breeze Installer.app"
+
+      - name: Package for release
+        run: |
+          ditto -c -k --sequesterRsrc --keepParent \
+            "build/Breeze Installer.app" \
+            "build/Breeze Installer.app.zip"
+          ls -lh build/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: breeze-installer-app
+          path: build/Breeze Installer.app.zip
+          retention-days: 30
+
+      - name: Cleanup keychain
+        if: always()
+        run: security delete-keychain "$RUNNER_TEMP/signing.keychain-db" || true
+```
+
+- [ ] **Step 2: Wire into release-asset upload**
+
+Find the existing release-asset upload step (`actions/upload-release-asset` or `softprops/action-gh-release` near the bottom of `release.yml`) and add `Breeze Installer.app.zip` to its file list. Pattern:
+
+```yaml
+      - name: Download installer-app artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: breeze-installer-app
+          path: release-assets/
+
+      # Then in the release-create step, add release-assets/Breeze Installer.app.zip to the files list.
+```
+
+(Exact wiring depends on the existing `release` job at the bottom of `release.yml` — match its convention.)
+
+- [ ] **Step 3: Validate workflow YAML**
+
+```bash
+gh workflow view release.yml 2>&1 | head -5  # smoke-checks the YAML parses
+# Or use actionlint if installed:
+actionlint .github/workflows/release.yml
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci: build, sign, notarize Breeze Installer.app"
+```
+
+- [ ] **Step 5: Test on a release tag (optional, blocking)**
+
+The CI job only runs when `vars.ENABLE_MACOS_SIGNING == 'true'`. Either:
+- (a) Push a test tag to trigger the full release pipeline and confirm `breeze-installer-app` artifact appears.
+- (b) Manually run the job via `gh workflow run release.yml -f ref=refs/heads/feature/...` if the workflow supports it.
+- (c) Defer validation to the first real release that includes this PR.
+
+Recommendation: **(c)** — minimize risk of accidentally publishing a release. The first real release after merge will validate end-to-end.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Plan B delivers Spec §"Components #1 — Swift installer app" (filename parser, bootstrap fetcher, AppleScript installer, SwiftUI views) and §"Components #4 — CI" (build, sign, notarize, staple, upload). Spec §"Components #2 — API" is Plan A. Spec §"Components #5 — installer builder service" + the route flip is Plan C.
+- **No placeholders:** all Swift code, Info.plist, entitlements, build script, and CI YAML are concrete.
+- **Type consistency:** `BootstrapClient.Payload`, `Architecture`, `Installer`, `FilenameTokenParser.Result`, `InstallController`, `InstallState` — all defined where first used and referenced consistently downstream. The state machine cases match between `InstallState` enum and `RootView` switch.
+- **One known unknown:** the existing `build-macos-agent` job's exact keychain setup pattern. Plan B's CI step recreates the keychain rather than depending on artifact-passed state — slightly more work per release but isolates failures. If during execution the existing keychain pattern is materially different, mirror it instead.
+- **One deferred polish:** `Resources/AppIcon.icns` is referenced in Info.plist + build script but not generated here. The build script already handles its absence (skips the copy). Add a real icon as a Plan B followup.
+
+---
+
+## Plan B Followups (not in this plan)
+
+- Real `AppIcon.icns` (e.g. via `iconutil` from a square PNG; one-time design work).
+- Localized strings (`en.lproj/Localizable.strings`) so non-English users see translated UI.
+- In-app update check (compare `CFBundleShortVersionString` against latest GitHub release; offer "Get latest installer").
+- Installer telemetry (HTTP POST to `/api/v1/installer/events` with `install.start`/`install.success`/`install.fail` — needs a corresponding API route).
+- Self-hoster doc: how to rebuild and re-sign the installer app with a custom Developer ID.

--- a/docs/superpowers/plans/2026-04-19-macos-installer-plan-c-route-wiring.md
+++ b/docs/superpowers/plans/2026-04-19-macos-installer-plan-c-route-wiring.md
@@ -1,0 +1,719 @@
+# macOS Installer App — Plan C: Route Wiring
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Switch the macOS branch of `GET /enrollment-keys/:id/installer/macos` to issue a bootstrap token (Plan A) and return a renamed `Breeze Installer.app.zip` (built by Plan B's CI). Old `install.sh`-based zip remains accessible behind a `?legacy=1` query param for one release cycle as a rollback escape hatch.
+
+**Architecture:** Extract the bootstrap-token issuance logic from Plan A's `POST /:id/bootstrap-token` route into a shared service helper (`issueBootstrapTokenForKey`) so both the standalone route and the installer-download path call the same code. Add a fetcher for the new `Breeze Installer.app.zip` GitHub release asset. Add a zip-rename helper that walks the entries of the installer-app zip and rewrites the `.app` directory name to embed the token + API host. Modify the installer route to use these new pieces.
+
+**Tech Stack:** Hono, Drizzle, `node-stream-zip` (read) + `archiver` (write), Vitest. No new infra.
+
+**Requires:** Plan A merged (bootstrap endpoint + token issuance). Plan B merged (`Breeze Installer.app.zip` published as a release asset). If Plan B's first release hasn't shipped yet, the installer route will gracefully fall back to the legacy zip via the env-var gate documented in Task 4.
+
+---
+
+## File Structure
+
+**Create:**
+- `apps/api/src/services/installerAppZip.ts` — `renameAppInZip` helper
+- `apps/api/src/services/installerAppZip.test.ts` — unit tests for rename helper
+- `apps/api/src/services/installerBootstrapTokenIssuance.ts` — extracted issuance helper
+
+**Modify:**
+- `apps/api/src/services/binarySource.ts` — add `getGithubInstallerAppUrl()`
+- `apps/api/src/services/installerBuilder.ts` — add `fetchMacosInstallerAppZip()` + `probeMacosInstallerApp()`
+- `apps/api/src/routes/enrollmentKeys.ts` — modify `GET /:id/installer/macos` branch; refactor `POST /:id/bootstrap-token` to call shared issuance helper
+- `apps/api/src/routes/enrollmentKeys.test.ts` — update existing macOS installer tests
+
+**Verify (no edits expected):**
+- `apps/api/src/routes/installer.test.ts` (Plan A) — should still pass.
+
+---
+
+## Task 1: Extract bootstrap-token issuance into a shared helper
+
+**Files:**
+- Create: `apps/api/src/services/installerBootstrapTokenIssuance.ts`
+- Modify: `apps/api/src/routes/enrollmentKeys.ts` — `POST /:id/bootstrap-token` route now calls the helper
+
+- [ ] **Step 1: Create the helper**
+
+```ts
+// apps/api/src/services/installerBootstrapTokenIssuance.ts
+import { db } from '../db';
+import { eq } from 'drizzle-orm';
+import { enrollmentKeys, installerBootstrapTokens } from '../db/schema/installerBootstrapTokens';
+// NB: enrollmentKeys is exported from db/schema/orgs.ts; adjust import to wherever
+// installerBootstrapTokens lives (Plan A added apps/api/src/db/schema/installerBootstrapTokens.ts).
+import {
+  generateBootstrapToken,
+  bootstrapTokenExpiresAt,
+} from './installerBootstrapToken';
+
+export interface IssueBootstrapTokenInput {
+  parentEnrollmentKeyId: string;
+  createdByUserId: string;
+  maxUsage?: number;
+}
+
+export interface IssuedBootstrapToken {
+  token: string;
+  expiresAt: Date;
+  parentKeyName: string;
+}
+
+export class BootstrapTokenIssuanceError extends Error {
+  constructor(public code: 'parent_not_found' | 'parent_expired' | 'parent_exhausted', message: string) {
+    super(message);
+    this.name = 'BootstrapTokenIssuanceError';
+  }
+}
+
+/**
+ * Issues a single-use bootstrap token tied to an existing parent enrollment
+ * key. Used by both the standalone POST /enrollment-keys/:id/bootstrap-token
+ * route AND the macOS installer download route — they were two duplicate
+ * code paths in Plan A; this helper unifies them.
+ *
+ * Caller is responsible for:
+ *  - access control (ensureOrgAccess on parentKey.orgId)
+ *  - audit logging
+ *
+ * Throws BootstrapTokenIssuanceError on parent-key validation failures so
+ * the caller can map to its own HTTP shape.
+ */
+export async function issueBootstrapTokenForKey(
+  input: IssueBootstrapTokenInput,
+): Promise<IssuedBootstrapToken> {
+  const [parent] = await db
+    .select()
+    .from(enrollmentKeys)
+    .where(eq(enrollmentKeys.id, input.parentEnrollmentKeyId))
+    .limit(1);
+  if (!parent) {
+    throw new BootstrapTokenIssuanceError('parent_not_found', 'Enrollment key not found');
+  }
+  if (parent.expiresAt && new Date(parent.expiresAt) < new Date()) {
+    throw new BootstrapTokenIssuanceError('parent_expired', 'Enrollment key has expired');
+  }
+  if (parent.maxUsage !== null && parent.usageCount >= parent.maxUsage) {
+    throw new BootstrapTokenIssuanceError('parent_exhausted', 'Enrollment key usage exhausted');
+  }
+
+  const token = generateBootstrapToken();
+  const expiresAt = bootstrapTokenExpiresAt();
+
+  await db.insert(installerBootstrapTokens).values({
+    token,
+    orgId: parent.orgId,
+    parentEnrollmentKeyId: parent.id,
+    siteId: parent.siteId,
+    maxUsage: input.maxUsage ?? 1,
+    createdBy: input.createdByUserId,
+    expiresAt,
+  });
+
+  return { token, expiresAt, parentKeyName: parent.name };
+}
+```
+
+- [ ] **Step 2: Refactor the existing `POST /:id/bootstrap-token` route to use the helper**
+
+In `apps/api/src/routes/enrollmentKeys.ts`, replace the inline body of the `/:id/bootstrap-token` POST handler (added in Plan A Task 7) with:
+
+```ts
+import {
+  issueBootstrapTokenForKey,
+  BootstrapTokenIssuanceError,
+} from '../services/installerBootstrapTokenIssuance';
+
+// ... inside the handler body, AFTER ensureOrgAccess check:
+try {
+  const { token, expiresAt } = await issueBootstrapTokenForKey({
+    parentEnrollmentKeyId: parent.id,
+    createdByUserId: auth.user.id,
+    maxUsage,
+  });
+
+  writeEnrollmentKeyAudit(c, auth, {
+    orgId: parent.orgId,
+    action: 'enrollment_key.bootstrap_token_issued',
+    keyId: parent.id,
+    keyName: parent.name,
+    details: { maxUsage },
+  });
+
+  return c.json({ token, expiresAt: expiresAt.toISOString(), maxUsage });
+} catch (err) {
+  if (err instanceof BootstrapTokenIssuanceError) {
+    if (err.code === 'parent_not_found') return c.json({ error: err.message }, 404);
+    return c.json({ error: err.message }, 410);
+  }
+  throw err;
+}
+```
+
+The `db.select` for the parent key + the `ensureOrgAccess` call before this block stay as they were — those are auth-side concerns the helper deliberately doesn't own.
+
+- [ ] **Step 3: Run existing route tests**
+
+```bash
+cd apps/api && npx vitest run src/routes/enrollmentKeys.test.ts -t "bootstrap-token"
+```
+Expected: Plan A's 4 tests still pass — the helper extraction is behaviour-preserving.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/services/installerBootstrapTokenIssuance.ts apps/api/src/routes/enrollmentKeys.ts
+git commit -m "refactor(api): extract bootstrap-token issuance to shared helper"
+```
+
+---
+
+## Task 2: GitHub release URL for the installer app
+
+**Files:**
+- Modify: `apps/api/src/services/binarySource.ts`
+
+- [ ] **Step 1: Add the URL helper**
+
+Append to `apps/api/src/services/binarySource.ts`:
+
+```ts
+/**
+ * URL of the notarized Breeze Installer.app.zip for the current release.
+ * Asset is uploaded by the build-macos-installer-app job in release.yml.
+ */
+export function getGithubInstallerAppUrl(): string {
+  return `${githubDownloadBase()}/Breeze%20Installer.app.zip`;
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd apps/api && npx tsc --noEmit 2>&1 | grep -i installerApp
+```
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/services/binarySource.ts
+git commit -m "feat(api): URL helper for installer app GitHub asset"
+```
+
+---
+
+## Task 3: Zip-rename helper (TDD)
+
+**Files:**
+- Create: `apps/api/src/services/installerAppZip.ts`
+- Create: `apps/api/src/services/installerAppZip.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// apps/api/src/services/installerAppZip.test.ts
+import { describe, it, expect } from 'vitest';
+import archiver from 'archiver';
+import StreamZip from 'node-stream-zip';
+import { writeFile, unlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { renameAppInZip } from './installerAppZip';
+
+/** Build a fixture zip containing a fake `.app` directory. */
+async function buildFixtureZip(appName: string): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const archive = archiver('zip', { zlib: { level: 0 } });
+    const chunks: Buffer[] = [];
+    archive.on('data', (c: Buffer) => chunks.push(c));
+    archive.on('end', () => resolve(Buffer.concat(chunks)));
+    archive.on('error', reject);
+
+    archive.append('fake-binary', { name: `${appName}/Contents/MacOS/BreezeInstaller`, mode: 0o755 });
+    archive.append('<plist/>', { name: `${appName}/Contents/Info.plist` });
+    archive.append('codesign-data', { name: `${appName}/Contents/_CodeSignature/CodeResources` });
+    archive.append('pkg-bytes', { name: `${appName}/Contents/Resources/breeze-agent-amd64.pkg` });
+    archive.append('pkg-bytes', { name: `${appName}/Contents/Resources/breeze-agent-arm64.pkg` });
+    archive.finalize().catch(reject);
+  });
+}
+
+async function listEntries(zipBuf: Buffer): Promise<string[]> {
+  const tmp = join(tmpdir(), `installer-zip-test-${Date.now()}.zip`);
+  await writeFile(tmp, zipBuf);
+  try {
+    const z = new StreamZip.async({ file: tmp });
+    const entries = Object.keys(await z.entries());
+    await z.close();
+    return entries.sort();
+  } finally {
+    await unlink(tmp).catch(() => {});
+  }
+}
+
+describe('renameAppInZip', () => {
+  it('renames the app directory in every entry path', async () => {
+    const input = await buildFixtureZip('Breeze Installer.app');
+    const out = await renameAppInZip(input, {
+      oldAppName: 'Breeze Installer.app',
+      newAppName: 'Breeze Installer [A7K2XQ@us.2breeze.app].app',
+    });
+    const entries = await listEntries(out);
+    expect(entries).toEqual([
+      'Breeze Installer [A7K2XQ@us.2breeze.app].app/Contents/Info.plist',
+      'Breeze Installer [A7K2XQ@us.2breeze.app].app/Contents/MacOS/BreezeInstaller',
+      'Breeze Installer [A7K2XQ@us.2breeze.app].app/Contents/Resources/breeze-agent-amd64.pkg',
+      'Breeze Installer [A7K2XQ@us.2breeze.app].app/Contents/Resources/breeze-agent-arm64.pkg',
+      'Breeze Installer [A7K2XQ@us.2breeze.app].app/Contents/_CodeSignature/CodeResources',
+    ]);
+  });
+
+  it('preserves entry contents byte-for-byte', async () => {
+    const input = await buildFixtureZip('Breeze Installer.app');
+    const out = await renameAppInZip(input, {
+      oldAppName: 'Breeze Installer.app',
+      newAppName: 'Breeze Installer [BBBBBB@host.local].app',
+    });
+    const tmp = join(tmpdir(), `installer-zip-content-${Date.now()}.zip`);
+    await writeFile(tmp, out);
+    const z = new StreamZip.async({ file: tmp });
+    const data = await z.entryData('Breeze Installer [BBBBBB@host.local].app/Contents/Info.plist');
+    await z.close();
+    await unlink(tmp);
+    expect(data.toString()).toBe('<plist/>');
+  });
+
+  it('throws if no entry matches the old app name', async () => {
+    const input = await buildFixtureZip('Different.app');
+    await expect(
+      renameAppInZip(input, {
+        oldAppName: 'Breeze Installer.app',
+        newAppName: 'Breeze Installer [A7K2XQ@x.example].app',
+      }),
+    ).rejects.toThrow(/no entries matched/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+```bash
+cd apps/api && npx vitest run src/services/installerAppZip.test.ts
+```
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// apps/api/src/services/installerAppZip.ts
+import archiver from 'archiver';
+import StreamZip from 'node-stream-zip';
+import { writeFile, mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+export interface RenameAppInZipOpts {
+  oldAppName: string;  // e.g. "Breeze Installer.app"
+  newAppName: string;  // e.g. "Breeze Installer [A7K2XQ@us.2breeze.app].app"
+}
+
+/**
+ * Walks every entry in `sourceZip` and rewrites its path so that the
+ * leading `oldAppName` directory becomes `newAppName`. Entry contents
+ * are preserved byte-for-byte — this is just a metadata rewrite.
+ *
+ * The Mac code signature lives inside `Contents/_CodeSignature/` and
+ * is hashed from `Contents/` contents, NOT the bundle's own directory
+ * name. Renaming the top-level folder leaves both `codesign --verify`
+ * and `xcrun stapler validate` passing.
+ *
+ * Throws if no entry begins with `oldAppName/` — guards against feeding
+ * in the wrong fixture (e.g. a release where the build output renamed
+ * its top-level directory).
+ */
+export async function renameAppInZip(
+  sourceZip: Buffer,
+  opts: RenameAppInZipOpts,
+): Promise<Buffer> {
+  const workDir = await mkdtemp(join(tmpdir(), 'installer-app-zip-'));
+  const inputPath = join(workDir, 'in.zip');
+  await writeFile(inputPath, sourceZip);
+  try {
+    const reader = new StreamZip.async({ file: inputPath });
+    const entries = await reader.entries();
+    let matched = 0;
+
+    const out = archiver('zip', { zlib: { level: 0 } }); // store-only; .app contents already small or pre-compressed
+    const chunks: Buffer[] = [];
+    out.on('data', (c: Buffer) => chunks.push(c));
+    const done = new Promise<void>((resolve, reject) => {
+      out.on('end', () => resolve());
+      out.on('error', reject);
+    });
+
+    for (const entry of Object.values(entries)) {
+      const oldPrefix = `${opts.oldAppName}/`;
+      let newPath = entry.name;
+      if (entry.name === opts.oldAppName) {
+        newPath = opts.newAppName;
+        matched++;
+      } else if (entry.name.startsWith(oldPrefix)) {
+        newPath = opts.newAppName + entry.name.slice(opts.oldAppName.length);
+        matched++;
+      }
+      if (entry.isDirectory) {
+        out.append('', { name: newPath, mode: entry.attr });
+      } else {
+        const data = await reader.entryData(entry.name);
+        out.append(data, { name: newPath, mode: entry.attr });
+      }
+    }
+    await reader.close();
+
+    if (matched === 0) {
+      throw new Error(
+        `installerAppZip: no entries matched old app name "${opts.oldAppName}" — wrong fixture?`,
+      );
+    }
+
+    await out.finalize();
+    await done;
+    return Buffer.concat(chunks);
+  } finally {
+    await rm(workDir, { recursive: true, force: true });
+  }
+}
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+```bash
+cd apps/api && npx vitest run src/services/installerAppZip.test.ts
+```
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/installerAppZip.ts apps/api/src/services/installerAppZip.test.ts
+git commit -m "feat(api): zip-rename helper for installer app"
+```
+
+---
+
+## Task 4: Installer-app fetcher with feature gate
+
+**Files:**
+- Modify: `apps/api/src/services/installerBuilder.ts`
+
+- [ ] **Step 1: Add fetcher + probe**
+
+Append to `apps/api/src/services/installerBuilder.ts`:
+
+```ts
+import { getGithubInstallerAppUrl } from './binarySource';
+
+/**
+ * Fetches the notarized Breeze Installer.app.zip from the GitHub release.
+ * Returns null if the asset is not available (e.g. first release after
+ * Plan B merged but before the next tag is cut). Caller falls back to
+ * the legacy install.sh zip in that case.
+ */
+export async function fetchMacosInstallerAppZip(): Promise<Buffer | null> {
+  if (getBinarySource() === 'github') {
+    const url = getGithubInstallerAppUrl();
+    const resp = await fetch(url, { redirect: 'follow' });
+    if (resp.status === 404) return null;
+    if (!resp.ok) throw new Error(`Failed to fetch installer app zip: ${resp.status}`);
+    return Buffer.from(await resp.arrayBuffer());
+  }
+  const binaryDir = resolve(process.env.AGENT_BINARY_DIR || './agent/bin');
+  const path = join(binaryDir, 'Breeze Installer.app.zip');
+  try {
+    return await readFile(path);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+/**
+ * HEAD probe for the installer app asset. Mirrors probeMacosPkg.
+ * Returns true if reachable, false if 404, throws otherwise.
+ */
+export async function probeMacosInstallerApp(): Promise<boolean> {
+  if (getBinarySource() === 'github') {
+    const url = getGithubInstallerAppUrl();
+    try {
+      const resp = await fetch(url, {
+        method: 'HEAD',
+        redirect: 'follow',
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (resp.status === 404) return false;
+      return resp.ok;
+    } catch {
+      return false;
+    }
+  }
+  const binaryDir = resolve(process.env.AGENT_BINARY_DIR || './agent/bin');
+  try {
+    await stat(join(binaryDir, 'Breeze Installer.app.zip'));
+    return true;
+  } catch {
+    return false;
+  }
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd apps/api && npx tsc --noEmit 2>&1 | grep -i installerApp
+```
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/services/installerBuilder.ts
+git commit -m "feat(api): fetch + probe installer app zip"
+```
+
+---
+
+## Task 5: Wire the installer route to use the new app
+
+**Files:**
+- Modify: `apps/api/src/routes/enrollmentKeys.ts` — `GET /:id/installer/macos` branch
+
+- [ ] **Step 1: Update the macOS branch**
+
+Find the `if (platform === 'macos')` block in the installer download handler (around line 666 of `enrollmentKeys.ts`). Replace it with the new flow that prefers the installer-app path and falls back to the legacy zip on `?legacy=1` or when the asset is missing.
+
+```ts
+import {
+  fetchMacosInstallerAppZip,
+  buildMacosInstallerZip,
+  fetchMacosPkgs,
+} from '../services/installerBuilder';
+import { renameAppInZip } from '../services/installerAppZip';
+import {
+  issueBootstrapTokenForKey,
+  BootstrapTokenIssuanceError,
+} from '../services/installerBootstrapTokenIssuance';
+
+// Inside the existing handler, replacing the macOS branch.
+// `parentKey`, `auth`, `globalSecret`, `serverUrl`, `childMaxUsage` are already in scope.
+
+if (platform === 'macos') {
+  const wantLegacy = c.req.query('legacy') === '1';
+
+  // Lazy: try the new app-bundle path unless the caller forced legacy.
+  const appZip = wantLegacy ? null : await fetchMacosInstallerAppZip();
+
+  if (appZip) {
+    // New path — bootstrap token + renamed app zip. No child enrollment key
+    // is created here; the bootstrap endpoint creates it lazily on consume.
+    let issued;
+    try {
+      issued = await issueBootstrapTokenForKey({
+        parentEnrollmentKeyId: parentKey.id,
+        createdByUserId: auth.user.id,
+        maxUsage: childMaxUsage,
+      });
+    } catch (err) {
+      if (err instanceof BootstrapTokenIssuanceError) {
+        if (err.code === 'parent_not_found') return c.json({ error: err.message }, 404);
+        return c.json({ error: err.message }, 410);
+      }
+      throw err;
+    }
+
+    const apiHost = new URL(serverUrl).host;
+    const newAppName = `Breeze Installer [${issued.token}@${apiHost}].app`;
+    const renamedZip = await renameAppInZip(appZip, {
+      oldAppName: 'Breeze Installer.app',
+      newAppName,
+    });
+
+    writeEnrollmentKeyAudit(c, auth, {
+      orgId: parentKey.orgId,
+      action: 'enrollment_key.installer_download',
+      keyId: parentKey.id,
+      keyName: parentKey.name,
+      details: { platform, mode: 'app-bundle', token: issued.token, count: childMaxUsage },
+    });
+
+    c.header('Content-Type', 'application/zip');
+    c.header('Content-Disposition', `attachment; filename="${newAppName}.zip"`);
+    c.header('Content-Length', String(renamedZip.length));
+    c.header('Cache-Control', 'no-store');
+    return c.body(renamedZip as unknown as ArrayBuffer);
+  }
+
+  // Legacy path — fall back to the install.sh zip when:
+  //  (a) caller explicitly passed ?legacy=1, OR
+  //  (b) the installer-app asset is not yet on the GitHub release for this version.
+  // The existing legacy block creates the child key inline (Plan A's lazy-creation
+  // path doesn't apply here because there's no token to lazily resolve later).
+  const macosPkgs = await fetchMacosPkgs();
+
+  // Re-create the child enrollment key inline (the original Plan A code lives here).
+  // ... existing block unchanged: rawChildKey + childKey insert + buildMacosInstallerZip + audit + response.
+}
+```
+
+(The legacy block stays identical to today's implementation. Plan C only adds the new branch above it; nothing in the existing code needs to be deleted in this plan. Removal of the legacy fallback is a Plan C followup once the new path has shipped successfully for one release.)
+
+- [ ] **Step 2: Update existing macOS installer test**
+
+In `apps/api/src/routes/enrollmentKeys.test.ts`, the existing test for `GET /:id/installer/macos` will continue to pass IF the test mocks `fetchMacosInstallerAppZip` to return `null` (the legacy path). Add a new test case for the app-bundle path:
+
+```ts
+describe('GET /:id/installer/macos with installer app', () => {
+  it('returns a renamed app zip when installer app is available', async () => {
+    // Mock fetchMacosInstallerAppZip to return a valid fixture zip
+    vi.mocked(fetchMacosInstallerAppZip).mockResolvedValue(
+      await buildFixtureAppZip('Breeze Installer.app'),  // helper from installerAppZip.test.ts
+    );
+    // ... mock parent key lookup, ensureOrgAccess, etc. (existing pattern)
+
+    const res = await app.request(
+      `/enrollment-keys/${parentKeyId}/installer/macos?count=1`,
+      { headers: { authorization: `Bearer ${jwt}` } },
+    );
+    expect(res.status).toBe(200);
+    const cd = res.headers.get('content-disposition');
+    expect(cd).toMatch(/Breeze Installer \[[A-Z0-9]{6}@[^\]]+\]\.app\.zip/);
+  });
+
+  it('falls back to legacy zip when ?legacy=1 is passed', async () => {
+    vi.mocked(fetchMacosInstallerAppZip).mockResolvedValue(/* unused */ Buffer.alloc(0));
+    // ... same parent-key mocks ...
+    const res = await app.request(
+      `/enrollment-keys/${parentKeyId}/installer/macos?count=1&legacy=1`,
+      { headers: { authorization: `Bearer ${jwt}` } },
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-disposition')).toContain('breeze-agent-macos.zip');
+  });
+
+  it('falls back to legacy zip when installer app asset is missing (404)', async () => {
+    vi.mocked(fetchMacosInstallerAppZip).mockResolvedValue(null);
+    // ... mocks ...
+    const res = await app.request(
+      `/enrollment-keys/${parentKeyId}/installer/macos?count=1`,
+      { headers: { authorization: `Bearer ${jwt}` } },
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-disposition')).toContain('breeze-agent-macos.zip');
+  });
+});
+```
+
+(Helper `buildFixtureAppZip` already exists in `installerAppZip.test.ts` — extract to a shared `__fixtures__` module or duplicate it inline.)
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd apps/api && npx vitest run src/routes/enrollmentKeys.test.ts -t "installer/macos"
+```
+Expected: original tests still pass + 3 new tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/routes/enrollmentKeys.ts apps/api/src/routes/enrollmentKeys.test.ts
+git commit -m "feat(api): macOS installer route returns renamed app zip"
+```
+
+---
+
+## Task 6: End-to-end smoke test
+
+**Files:** none (manual verification)
+
+Requires: Plan A + Plan B both deployed. Plan B's CI must have published `Breeze Installer.app.zip` as a GitHub release asset for the version your local API is configured to download.
+
+- [ ] **Step 1: Start the API + ensure it can reach the release**
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.override.yml.dev up -d
+# Verify the installer app asset is reachable for the current BINARY_VERSION:
+cd apps/api && pnpm tsx -e "
+  import { probeMacosInstallerApp } from './src/services/installerBuilder';
+  probeMacosInstallerApp().then(r => console.log('reachable:', r));
+"
+```
+Expected: `reachable: true`. If false, either the release hasn't shipped yet (set `BINARY_VERSION=latest` and re-test) or Plan B's CI didn't upload the asset (check GitHub release page).
+
+- [ ] **Step 2: Download an installer**
+
+```bash
+JWT=$(./scripts/dev-login.sh)
+PARENT_KEY_ID="REPLACE_WITH_REAL_KEY_ID"
+curl -sS -OJ \
+  -H "Authorization: Bearer $JWT" \
+  "http://localhost:3001/api/v1/enrollment-keys/$PARENT_KEY_ID/installer/macos?count=1"
+```
+Expected: a file named `Breeze Installer [TOKEN@host].app.zip` lands in the current dir, ~55 MB.
+
+- [ ] **Step 3: Extract + verify Gatekeeper acceptance**
+
+```bash
+unzip -q "Breeze Installer "*.app.zip
+APP_PATH=$(ls -d "Breeze Installer "*.app | head -1)
+spctl -a -t exec -vv "$APP_PATH"
+```
+Expected: `accepted` + `source=Notarized Developer ID` — the rename did not invalidate the staple.
+
+- [ ] **Step 4: Launch the installer**
+
+```bash
+open "$APP_PATH"
+```
+Expected: window opens, fetches bootstrap, shows ConfirmView with the org name. Clicking Install triggers the native admin password dialog. After auth + ~10s, DoneView appears. Agent appears in the web console as a new device.
+
+- [ ] **Step 5: Verify the legacy fallback still works**
+
+```bash
+curl -sS -OJ \
+  -H "Authorization: Bearer $JWT" \
+  "http://localhost:3001/api/v1/enrollment-keys/$PARENT_KEY_ID/installer/macos?count=1&legacy=1"
+```
+Expected: a file named `breeze-agent-macos.zip` (the old path), unzippable to the install.sh + 2 PKGs + enrollment.json bundle.
+
+- [ ] **Step 6: Confirm CI green**
+
+```bash
+cd apps/api && pnpm test
+```
+Expected: all green.
+
+No commit — verification only.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Plan C delivers Spec §"Components #5 — installer builder service" (zip rename helper, fetcher) and the route change (Spec §"Components #2 — Installer route"). Combined with Plan A (token + endpoint) and Plan B (Swift app + CI), the full spec ships.
+- **No placeholders:** all TypeScript, all Vitest cases, all curl commands are concrete.
+- **Type consistency:** `IssueBootstrapTokenInput`, `IssuedBootstrapToken`, `BootstrapTokenIssuanceError`, `RenameAppInZipOpts`, `fetchMacosInstallerAppZip` — defined where first used and referenced consistently.
+- **Behaviour-preserving for legacy callers:** the route change is gated on whether `fetchMacosInstallerAppZip()` returns a buffer. Until the first release that publishes `Breeze Installer.app.zip`, every download still returns the legacy zip. There is no flag day.
+- **Rollback path:** removing the new branch and reverting the import edits restores prior behaviour exactly. `?legacy=1` exists for individual-call rollback (e.g., a single customer reports the new installer broken — they can hit `?legacy=1` to get the working old path while we investigate).
+- **One known unknown:** the existing enrollmentKeys.test.ts mock harness for the macOS branch — Plan A's tests already mock the legacy-path dependencies (`fetchMacosPkgs`, `buildMacosInstallerZip`); we now need to add `fetchMacosInstallerAppZip` to that mock surface. If the mock pattern doesn't cleanly accept additions, refactor the route's macOS branch into a smaller `serveMacosInstaller` helper first and test the helper directly.
+
+---
+
+## Plan C Followups (not in this plan)
+
+- Remove the legacy `?legacy=1` fallback after one full release cycle with no rollback needed.
+- Delete `MACOS_INSTALL_SCRIPT` constant + `buildMacosInstallerZip` helper + `install.sh` references once legacy is removed.
+- Surface the bootstrap token in the audit-log UI so support can correlate "user says installer didn't work" → which token → which IP consumed it (or didn't).
+- Cron sweep for expired-but-never-consumed bootstrap tokens (Plan A followup) — moved here because Plan C makes it more visible (every install download issues one).
+- Apply the same filename-token + bootstrap-endpoint pattern to Windows MSI as a future cleanup, retiring the `sign.2breeze.app` signing VM (see macOS spec appendix for the rationale).

--- a/docs/superpowers/specs/2026-04-19-macos-installer-app-design.md
+++ b/docs/superpowers/specs/2026-04-19-macos-installer-app-design.md
@@ -1,0 +1,432 @@
+# macOS GUI Installer App — Design Spec
+
+- **Created:** 2026-04-19
+- **Status:** Proposed, not yet implemented
+- **Related:** `buildMacosInstallerZip` in `apps/api/src/services/installerBuilder.ts`, `agent/installer/macos/`, Windows `MsiSigningService` at `apps/api/src/services/msiSigning.ts`
+
+## Problem
+
+Downloading a macOS installer from the web UI today produces a zip containing two unsigned `.pkg` files, `enrollment.json`, and `install.sh`. The admin has to unzip, open Terminal, and run `sudo bash install.sh`. This is fine for technical users but wildly off-brand compared to the Windows MSI experience (double-click, click through, done). Non-technical end-users bounce off it.
+
+**Goal:** ship a macOS installer that feels exactly like the MSI flow — one file, double-click, native admin-password prompt, GUI progress, done.
+
+## Why the naive approach (server-side inject + sign + notarize per install) is too expensive
+
+MSI is an OLE2 compound file — the API can byte-patch space-padded sentinels in place and re-sign with `signtool` in ~3s. PKG is a xar archive whose TOC checksums the contents, so any modification invalidates the signature. Per-customer injection requires the full pipeline: `xar -xf` → edit → `xar -cf` → `productsign` → `xcrun notarytool submit --wait` → `xcrun stapler staple`. The `notarytool` call is a **30–180s round-trip to Apple** that can't be avoided if users browser-download the file. It also needs a macOS signing host, not just a Linux VM.
+
+For a UX improvement over a working-but-awkward flow, that infrastructure isn't worth it. The existing Windows MSI signing pipeline already teaches this lesson: it works, but the signing VM + Cloudflare Access tunnel + Azure Trusted Signing account + rotating cert + byte-patch sentinel code is a heavy stack for the value delivered. See the appendix for why we're not mirroring that stack on the Mac side.
+
+## Design — Static notarized `.app`, per-customer token encoded in filename
+
+Ship a tiny `Breeze Installer.app`, signed + notarized **once per release in CI**, identical across all customers. Per-customer data (one short token) is encoded in the bundle's filename. The code signature and stapled notarization ticket are based on the content of `Contents/` — renaming the bundle's enclosing folder has no effect on either. The app reads its own bundle path on launch, extracts the token, calls a bootstrap endpoint, prompts for admin password, installs the embedded PKG, runs `breeze-agent enroll`.
+
+### User-facing flow
+
+1. Admin clicks "Download macOS Installer" in the web UI.
+2. Browser downloads `Breeze Installer [A7K2XQ@us.2breeze.app].app.zip` (~55 MB — the app bundle embeds both arm64 and amd64 PKGs in its `Resources/`).
+3. Safari auto-extracts on download; Chrome requires a double-click. Either way the admin ends up with `Breeze Installer [A7K2XQ@us.2breeze.app].app` in `~/Downloads`.
+4. Double-click the app. Gatekeeper verifies the stapled notarization ticket — no "unidentified developer" warning.
+5. App reads its own bundle URL, regex-extracts token + API host from the filename.
+6. App fetches `GET https://us.2breeze.app/api/v1/installer/bootstrap/A7K2XQ` → returns `{ serverUrl, enrollmentKey, enrollmentSecret?, siteId?, orgName }`.
+7. App shows a one-window UI: "Install Breeze Agent for *Acme Corp*?" with an Install button.
+8. User clicks Install → native macOS admin password dialog (via AppleScript `do shell script … with administrator privileges`).
+9. App picks the right PKG for the host CPU (`uname -m`), runs `installer -pkg <path> -target /` as root with progress spinner.
+10. App runs `/usr/local/bin/breeze-agent enroll <key> --server <url> [--enrollment-secret <secret>] [--site-id <id>]`.
+11. Success screen → Quit.
+
+### Why filename-token works
+
+A `.app` bundle's code signature is based on hashes of every file under `Contents/`, recorded in `Contents/_CodeSignature/CodeResources`. The bundle's own name and path are **not** inputs to that hash. Renaming the bundle from `Breeze Installer.app` to `Breeze Installer [A7K2XQ@us.2breeze.app].app` leaves signature verification and stapled-ticket verification both passing. Gatekeeper on launch runs `codesign --verify` and `spctl -a` — both succeed regardless of the enclosing directory name.
+
+Confirm with: `codesign -v -v "Breeze Installer [A7K2XQ@us.2breeze.app].app"` after rename.
+
+### Single-file distribution — no sidecar, no DMG
+
+Everything needed to install lives inside the `.app`:
+
+```
+Breeze Installer [A7K2XQ@us.2breeze.app].app/
+└── Contents/
+    ├── Info.plist
+    ├── MacOS/
+    │   └── Breeze Installer          ← the Swift executable
+    ├── Resources/
+    │   ├── breeze-agent-arm64.pkg    ← embedded, signed, ~26 MB
+    │   ├── breeze-agent-amd64.pkg    ← embedded, signed, ~26 MB
+    │   ├── AppIcon.icns
+    │   └── en.lproj/                 ← UI strings
+    └── _CodeSignature/
+        └── CodeResources             ← hashes of everything above
+```
+
+Both PKGs live inside the signed app bundle and are notarized together with the app. The app bundle is one atomic unit — if notarization passes, every contained artifact is trusted. No sibling files, no DMG, no re-notarization per customer.
+
+Shipped wrapper: a single `.zip` containing the renamed `.app`. No README, no instructions file. The filename itself is the only per-customer payload.
+
+## Components
+
+### 1. Swift installer app — `agent/installer/macos-app/`
+
+**Language:** Swift + SwiftUI
+**Target:** macOS 11.0+ (matches agent minimum)
+**Bundle ID:** `com.breeze.installer`
+**Xcode project:** checked in, configured for Developer ID Application signing
+
+**Filename parsing (app startup, first code to run):**
+
+```swift
+// Bundle.main.bundleURL is the full path to the .app itself.
+// lastPathComponent strips to "Breeze Installer [A7K2XQ@us.2breeze.app].app"
+let bundleName = Bundle.main.bundleURL.lastPathComponent
+
+// Regex: [<token>@<host>] — token is [A-Z0-9]{6}, host is any non-] chars
+let pattern = #"\[([A-Z0-9]{6})@([^\]]+)\]"#
+guard let match = bundleName.firstMatch(of: try! Regex(pattern)) else {
+  // User renamed the bundle and stripped the token bracket.
+  showError("This installer needs its original filename. Please re-download from your Breeze web console.")
+  return
+}
+let token = String(match.1)
+let apiHost = String(match.2)
+
+// Construct bootstrap URL. apiHost is always a valid hostname because it
+// was written by our server; validate shape defensively anyway.
+guard let bootstrapURL = URL(string: "https://\(apiHost)/api/v1/installer/bootstrap/\(token)") else {
+  showError("Installer filename is malformed. Please re-download.")
+  return
+}
+```
+
+**State machine:**
+
+```
+Launch → Parse filename → Fetch bootstrap → Confirm → Install → Enroll → Done
+                                                              ↘ Error
+```
+
+Each transition displays a SwiftUI view. Errors are recoverable where possible ("Retry" button for network errors) and terminal where not ("Please re-download" for bad filenames).
+
+**Admin-privilege install:** use AppleScript, which is the officially-supported way to trigger the native admin-password dialog for a one-shot command:
+
+```swift
+let script = """
+do shell script "'/usr/sbin/installer' -pkg '\(pkgPath)' -target / && \
+'/usr/local/bin/breeze-agent' enroll '\(token)' --server '\(serverUrl)' \
+--enrollment-secret '\(secret)' --site-id '\(siteId)' --quiet" \
+with administrator privileges
+"""
+var error: NSDictionary?
+NSAppleScript(source: script)?.executeAndReturnError(&error)
+```
+
+Shell-escape the values (they come from server response — still, belt and suspenders). `NSAppleScript` with `administrator privileges` shows the familiar "Breeze Installer wants to make changes" dialog with Touch ID / password field. No SMJobBless helper tool needed for this scope.
+
+**Architecture detection:** `Process` launching `/usr/bin/uname -m`, read stdout, match `"arm64"` → `breeze-agent-arm64.pkg`, `"x86_64"` → `breeze-agent-amd64.pkg`. Same logic as today's `install.sh`, ported to Swift.
+
+**Progress display:** v1 ships with an indeterminate spinner and a "this takes about 10 seconds" label. Parsing `installer` stderr for percentage is a v2 nicety.
+
+**What happens if enrollment fails (network error, expired token after install):** PKG is installed, agent binary is on disk, but `breeze-agent enroll` returned non-zero. Show an actionable error: "Agent installed but enrollment failed: *<reason>*. Re-run the installer to retry, or enroll manually via the web console." Do **not** attempt automatic cleanup — the agent binary can be safely left installed; re-running the app re-enrolls.
+
+### 2. API — bootstrap token endpoint
+
+**New table:** `installer_bootstrap_tokens`
+
+```sql
+CREATE TABLE installer_bootstrap_tokens (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  token TEXT NOT NULL UNIQUE,              -- stored lowercase, 6-char base36
+  org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  parent_enrollment_key_id UUID NOT NULL REFERENCES enrollment_keys(id) ON DELETE CASCADE,
+  site_id UUID REFERENCES sites(id),
+  max_usage INTEGER NOT NULL DEFAULT 1,
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  consumed_at TIMESTAMPTZ,
+  consumed_from_ip TEXT
+);
+
+CREATE INDEX idx_installer_bootstrap_tokens_expires
+  ON installer_bootstrap_tokens(expires_at)
+  WHERE consumed_at IS NULL;
+```
+
+**RLS:** Shape 1 (direct `org_id`) — auto-discovered by the RLS contract test. Standard `breeze_has_org_access(org_id)` policy. Bootstrap consumption path uses `withSystemDbAccessContext` since the token IS the auth and there's no user session; admin-facing read paths use the request context as usual.
+
+**Token entropy:** 6 chars of `[A-Z0-9]` (base36) = 36⁶ ≈ 2.2 billion values. Single-use + 24h TTL + RLS-isolated lookup means brute-force is not a realistic threat (issuing 1000 guesses/sec would take 25 days per token, and expired tokens 404 identically to invalid ones). If we want to be paranoid, bump to 8 chars (2.8 trillion) — cost is two extra characters in the filename.
+
+**Store raw, not hashed:** unlike enrollment keys (which are long-lived secrets used by agents), bootstrap tokens are single-use, 24h-TTL, and only exist in the DB long enough to be consumed. Hashing adds ceremony without a meaningful security win. Store `token` as plain text and compare by equality.
+
+**Route change — `GET /:id/installer/:platform` in `apps/api/src/routes/enrollmentKeys.ts`:**
+
+When `platform === 'macos'`:
+
+1. Validate parent key as today (TTL, usage, access).
+2. Generate a 6-char base36 token.
+3. **Do NOT create a child enrollment key here.** The child is created lazily inside the bootstrap route on first token consumption. Eliminates orphan child keys from "admin downloaded installer but never ran it".
+4. Insert `installer_bootstrap_tokens` row with 24h expiry, parent key ID, site ID, desired `maxUsage`.
+5. Fetch cached `Breeze Installer.app.zip` from GitHub release (new helper `fetchMacosInstallerAppZip`, same pattern as `fetchMacosPkg`).
+6. Rewrite the zip so the inner `.app` directory is renamed from `Breeze Installer.app` to `Breeze Installer [<TOKEN>@<apiHost>].app`. See implementation note below.
+7. Return the zip with `Content-Disposition: attachment; filename="Breeze Installer [<TOKEN>@<apiHost>].app.zip"`.
+
+**Implementation note — renaming entries inside a ZIP:** `node-stream-zip` or `adm-zip` can read entry-by-entry and write a new zip with rewritten paths. No decompression needed for store-compressed entries, but deflated entries must be re-copied. `archiver` handles the write side cleanly. Pseudo:
+
+```ts
+import StreamZip from 'node-stream-zip';
+import archiver from 'archiver';
+
+export async function renameAppInZip(
+  sourceZip: Buffer,
+  oldAppName: string,  // "Breeze Installer.app"
+  newAppName: string,  // "Breeze Installer [A7K2XQ@us.2breeze.app].app"
+): Promise<Buffer> {
+  const zip = new StreamZip.async({ file: <tmp-from-buffer> });
+  const out = archiver('zip', { zlib: { level: 0 } }); // store-only; app is already compressed internally
+  const chunks: Buffer[] = [];
+  out.on('data', c => chunks.push(c));
+
+  for (const entry of Object.values(await zip.entries())) {
+    const rewrittenPath = entry.name.replace(oldAppName, newAppName);
+    const data = await zip.entryData(entry.name);
+    out.append(data, { name: rewrittenPath, mode: entry.attr });
+  }
+  await out.finalize();
+  await zip.close();
+  return Buffer.concat(chunks);
+}
+```
+
+Rewriting ZIP entry paths does NOT touch the files inside `Contents/` — signature remains valid.
+
+**New public route:** `GET /api/v1/installer/bootstrap/:token` — no auth (token IS the auth), no tenant context (resolved from token row), no rate limit for v1 (add a global 1000/min if abuse appears).
+
+```ts
+installerRoutes.get('/bootstrap/:token', async (c) => {
+  const token = c.req.param('token')?.toUpperCase() ?? '';
+  if (!/^[A-Z0-9]{6}$/.test(token)) {
+    return c.json({ error: 'invalid token' }, 400);
+  }
+
+  // Atomically consume the token + create the child enrollment key.
+  // Concurrent callers can't both succeed — PG row lock on the update serializes them.
+  const result = await withSystemDbAccessContext(async (tx) => {
+    const [row] = await tx.select().from(installerBootstrapTokens)
+      .where(eq(installerBootstrapTokens.token, token))
+      .limit(1);
+    if (!row) return null;
+    if (row.consumedAt) return null;
+    if (new Date(row.expiresAt) < new Date()) return null;
+
+    // Mark consumed
+    const [updated] = await tx.update(installerBootstrapTokens)
+      .set({
+        consumedAt: new Date(),
+        consumedFromIp: c.req.header('cf-connecting-ip') ?? null,
+      })
+      .where(and(
+        eq(installerBootstrapTokens.id, row.id),
+        isNull(installerBootstrapTokens.consumedAt),  // idempotency guard
+      ))
+      .returning();
+    if (!updated) return null;  // lost race to a concurrent request
+
+    // Lazily create the child enrollment key now, with a fresh TTL
+    const [parentKey] = await tx.select().from(enrollmentKeys)
+      .where(eq(enrollmentKeys.id, row.parentEnrollmentKeyId)).limit(1);
+    if (!parentKey) return null;  // parent deleted between issue and consume
+
+    const rawChildKey = generateEnrollmentKey();
+    const childKeyHash = hashEnrollmentKey(rawChildKey);
+    const [child] = await tx.insert(enrollmentKeys).values({
+      orgId: row.orgId,
+      siteId: row.siteId,
+      name: `${parentKey.name} (mac-installer ${token})`,
+      key: childKeyHash,
+      keySecretHash: parentKey.keySecretHash,
+      maxUsage: row.maxUsage,
+      expiresAt: freshChildExpiresAt(),
+      createdBy: row.createdBy,
+      installerPlatform: 'macos',
+    }).returning();
+
+    const [org] = await tx.select().from(organizations)
+      .where(eq(organizations.id, row.orgId)).limit(1);
+
+    return { rawChildKey, siteId: row.siteId, orgName: org?.name ?? 'your organization' };
+  });
+
+  if (!result) {
+    return c.json({ error: 'token invalid, expired, or already used' }, 404);
+  }
+
+  return c.json({
+    serverUrl: process.env.PUBLIC_API_URL,
+    enrollmentKey: result.rawChildKey,
+    enrollmentSecret: process.env.AGENT_ENROLLMENT_SECRET || null,
+    siteId: result.siteId,
+    orgName: result.orgName,
+  });
+});
+```
+
+**Security properties:**
+
+- Single-use: transaction updates `consumed_at` with an `IS NULL` guard; concurrent consumption returns 404 from the losing side.
+- 24h TTL enforced in SQL.
+- No information leak: invalid / expired / already-used tokens all return `404 {error: "token invalid, expired, or already used"}`.
+- Parent key deletion between token issue and consume: returns 404 (parent FK `ON DELETE CASCADE` removes the token row automatically, but belt-and-braces check inside the tx too).
+- No user auth needed: the token's entropy + single-use + short TTL is the security model. Same pattern as password-reset links.
+
+### 3. Web UI — no change required
+
+The existing "Download macOS Installer" button POSTs to `GET /:id/installer/macos` and saves the returned blob. The response's `Content-Type` shifts from `application/zip` (unchanged) but its filename and contents change. Browser handles the blob as an opaque download. Zero UI code changes.
+
+One small polish: on the macOS download success toast, show a one-liner: *"If your download doesn't auto-extract, double-click the zip to unzip first, then double-click Breeze Installer."* — covers Chrome users who don't auto-extract.
+
+### 4. CI — build, sign, notarize `Breeze Installer.app` once per release
+
+**New job in `.github/workflows/release.yml`:** `build-macos-installer-app`, depends on `build-macos-agent` (needs the signed darwin agent binaries to embed the PKGs).
+
+```yaml
+build-macos-installer-app:
+  needs: [build-macos-agent]
+  runs-on: macos-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4          # pkgbuild orchestration from a Node script, optional
+      with: { node-version: '20' }
+
+    - name: Import signing cert
+      uses: apple-actions/import-codesign-certs@v3
+      with:
+        p12-file-base64: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_P12 }}
+        p12-password: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
+
+    - name: Download prebuilt PKGs
+      uses: actions/download-artifact@v4
+      with:
+        name: breeze-agent-darwin-amd64-pkg
+        path: installer-pkgs/
+    - uses: actions/download-artifact@v4
+      with:
+        name: breeze-agent-darwin-arm64-pkg
+        path: installer-pkgs/
+
+    - name: Build Breeze Installer.app
+      run: |
+        cp installer-pkgs/breeze-agent-darwin-amd64.pkg \
+           agent/installer/macos-app/Breeze\ Installer/Resources/breeze-agent-amd64.pkg
+        cp installer-pkgs/breeze-agent-darwin-arm64.pkg \
+           agent/installer/macos-app/Breeze\ Installer/Resources/breeze-agent-arm64.pkg
+        cd agent/installer/macos-app
+        xcodebuild -scheme "Breeze Installer" -configuration Release \
+          -derivedDataPath build \
+          CODE_SIGN_IDENTITY="Developer ID Application: Olive Technologies LLC (TEAMID)" \
+          CODE_SIGN_STYLE=Manual \
+          DEVELOPMENT_TEAM=$TEAM_ID
+
+    - name: Notarize + staple
+      env:
+        APPLE_ID:          ${{ secrets.APPLE_ID }}
+        APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+        APPLE_TEAM_ID:     ${{ secrets.APPLE_TEAM_ID }}
+      run: |
+        APP="agent/installer/macos-app/build/Build/Products/Release/Breeze Installer.app"
+        ditto -c -k --keepParent "$APP" installer-notarize.zip
+        xcrun notarytool submit installer-notarize.zip \
+          --apple-id "$APPLE_ID" --password "$APPLE_ID_PASSWORD" --team-id "$APPLE_TEAM_ID" \
+          --wait
+        xcrun stapler staple "$APP"
+        ditto -c -k --sequesterRsrc --keepParent "$APP" "Breeze Installer.app.zip"
+
+    - name: Upload to release
+      uses: actions/upload-artifact@v4
+      with:
+        name: breeze-installer-app-zip
+        path: Breeze Installer.app.zip
+```
+
+The release's asset-upload step (already present for the other darwin artifacts) picks up `Breeze Installer.app.zip` and pushes it to the GitHub release.
+
+### 5. Installer builder service — `apps/api/src/services/installerBuilder.ts`
+
+**Add fetcher (mirrors `fetchMacosPkg`):**
+
+```ts
+export async function fetchMacosInstallerAppZip(): Promise<Buffer>
+```
+
+**Add renamer** (implementation sketch above):
+
+```ts
+export async function buildMacosInstallerAppZip(
+  templateAppZip: Buffer,
+  token: string,
+  apiHost: string,
+): Promise<Buffer>
+```
+
+**Deprecate** `buildMacosInstallerZip` (the zip-with-install.sh builder). Keep it behind a `?legacy=1` query param on the installer route for one release cycle as a rollback escape hatch, then delete in a followup.
+
+## Open questions
+
+1. **Token format exposed in filename.** Current choice: `[<6-char-token>@<api-host>]` — visible and somewhat ugly in Finder. Alternatives:
+   - `[A7K2XQ]` with API host fetched from a DNS TXT record or a hardcoded compile-time default. Cleaner but breaks self-hosters who don't compile their own app.
+   - Base64-encoded compact payload `[QTdLMlhRQHVzLjJicmVlemUuYXBw]` — shorter numerically but more opaque; users can't tell what region it is at a glance.
+   - **Recommendation:** keep `[TOKEN@HOST]` as designed. The bracket makes it visually distinct from the app name, and the host is informative ("which Breeze deployment does this install into?"). Ugly-but-honest beats pretty-but-magic.
+
+2. **PKG embedding vs remote download at install time.** Embedding both PKGs makes the `.app` ~55 MB. Downloading from GitHub CDN at install time would keep it ~5 MB but adds a network dependency mid-install. Embedding matches current behavior and makes the installer fully self-contained; that's the safer default. Download-on-demand is a followup if install bundle size becomes a real complaint.
+
+3. **Re-enrollment UX.** If the admin runs the installer on a machine already enrolled as device X, we'd currently create a duplicate device Y. Detecting this: run `/usr/local/bin/breeze-agent status` (returns device ID if enrolled, non-zero otherwise) before enrolling. If already enrolled, show a confirmation: *"This Mac is already registered as <hostname> in <org>. Replace it?"*. **Deferred to v2** — not blocking the first ship.
+
+4. **Progress parsing.** `installer` emits percentage lines to stderr, parseable but finicky. v1 ships with a spinner.
+
+5. **Telemetry.** Should the installer app phone home with `install.start` / `install.success` / `install.fail` events for support diagnosis? Low priority for v1; punted to followup.
+
+## Non-goals
+
+- Per-customer signing or notarization of the `.app`. The whole point is that it's static.
+- MDM-based silent install. MSPs with Jamf/Kandji/Intune should push the raw PKG via MDM, not this GUI installer.
+- In-app auto-update of the installer. Agent's `/enroll` command is stable; old installers keep working.
+- Progress parsing from `installer` stderr. Spinner is fine.
+- Self-hoster doc for custom-compiling the installer with their own Developer ID. Covered in a followup doc after the Apple pipeline stabilizes.
+
+## Risks
+
+- **User renames the `.app` and strips the `[...]` bracket.** App falls back to clear error message: *"This installer needs its original filename — re-download from your Breeze web console."* Can't mitigate without per-install notarization.
+- **ZIP extraction behavior differs by browser.** Safari auto-extracts; Chrome does not. Add a one-liner to the download-success toast covering Chrome users.
+- **Token leakage via browser history or corporate proxy logs.** The bootstrap URL contains the token. Mitigations already in place: single-use + 24h TTL. Moving the token to a POST body is marginal — URL-path tokens are industry-standard for this kind of short-lived bootstrap (password resets, magic login links). Good enough.
+- **Safari 17+ zip auto-extract prompts for permission the first time.** One-time OS-level nuisance, not our bug.
+- **User's Mac is fully offline after download.** Bootstrap endpoint unreachable → install fails. Show network-error view with "Retry" button. Online install only.
+- **Apple notarization service outage during release.** Blocks the CI job. Same risk as today's agent-binary notarization — existing mitigation (retry, manual kick) applies.
+- **Developer ID Application cert rotation.** One-time annual chore, same as agent binaries. Not new ops.
+
+## Build sequence
+
+1. **Token table + RLS + migrations + integration test.** Migration number, policy SQL, allowlist entry in `rls-coverage.integration.test.ts`. Drop-into-`psql` verification as `breeze_app`. No installer app yet.
+2. **Bootstrap route + unit + integration tests.** `POST`-only from `curl`, no Swift app needed. Verify single-use + TTL + race-safe concurrent consume. Verify child enrollment key is created lazily.
+3. **Installer route change.** Generate token, skip child-key creation, return the generic template app renamed with `[TOKEN@HOST]` using the existing zip-with-install.sh as a fallback behind `?legacy=1`. Deploy + smoke test with a stub `.app` (any signed Mac app will do for the plumbing).
+4. **Swift app.** Xcode project, SwiftUI views, filename parser, bootstrap fetcher, AppleScript installer, enroll invocation. Local Developer ID build + smoke test on dev machine.
+5. **CI pipeline.** `build-macos-installer-app` job, upload-artifact, attach to release. Validate notarization + stapling on a fresh tag.
+6. **Flip default.** Remove `?legacy=1` fallback after one full release cycle with no rollback needed.
+
+## Appendix — Why we're not mirroring the Windows MSI signing stack
+
+The Windows MSI flow uses server-side byte-patch sentinels + remote signing via a Cloudflare-tunneled Windows VM + Azure Trusted Signing dlib. That works, but carries a real ops tax: a Windows VM on the OliveTech LAN, CF Access service tokens, an Azure subscription with rotating signing certs, a 3-day cert lifetime, and a pile of padded-sentinel code (the v0.62.23 trim bug surfaced precisely because the padded-sentinel path was the one customers actually hit but wasn't in the smoke test). All of that solves "inject per-customer data into a signed binary without re-signing."
+
+Authenticode on MSI is actually based on the MSI's internal content hash, not the filename — meaning a generic signed MSI can be renamed `Breeze Agent [TOKEN].msi` and its signature stays valid, identical in principle to this Mac design. A future cleanup could fold the Windows MSI onto the same pattern:
+
+1. Generic signed + notarized MSI, built once in CI, no per-customer signing.
+2. A WiX custom action that reads the built-in `OriginalDatabase` property (full path to the MSI being installed), regex-extracts the token from the filename, calls the same `GET /installer/bootstrap/<token>` endpoint, invokes `breeze-agent enroll` with the returned values.
+3. API just renames the template MSI per download and serves it — no byte-patch, no Windows VM, no Azure account.
+
+Retiring the current Windows stack isn't urgent (it's paid for and working), but building the Mac installer on this simpler pattern avoids re-creating the same ops surface on another platform. If the Windows stack ever needs a material change — cert migration, Azure churn, a new signing provider — that's the moment to switch it over. Until then, treat the filename-token approach as the forward-default for any new platform (Linux `.deb`/`.rpm`, Windows app-store bundles, etc.).
+
+## Followups (not in scope)
+
+- Re-enrollment detection + "replace existing device?" confirmation.
+- Progress bar from `installer` stderr parsing.
+- Installer app telemetry (`install.start`/`install.success`/`install.fail` events).
+- Self-hoster doc: "how to build your own signed Breeze Installer.app with your own Developer ID."
+- Port Windows MSI to filename-token pattern; retire the `sign.2breeze.app` signing VM.
+- Linux installer: same pattern with a signed `.sh` or `.deb` that self-extracts a signed agent + reads token from its own filename.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       nanoid:
         specifier: ^5.1.7
         version: 5.1.7
+      node-stream-zip:
+        specifier: ^1.15.0
+        version: 1.15.0
       nodemailer:
         specifier: ^8.0.4
         version: 8.0.4
@@ -15477,7 +15480,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0)(vite@7.3.2(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -20000,8 +20003,7 @@ snapshots:
 
   node-releases@2.0.37: {}
 
-  node-stream-zip@1.15.0:
-    optional: true
+  node-stream-zip@1.15.0: {}
 
   nodemailer@8.0.4: {}
 


### PR DESCRIPTION
## Summary

End-to-end native macOS installer replacing the current Terminal-based `install.sh` flow. Admin downloads one `.zip`, double-clicks `Breeze Installer.app`, native macOS admin-password prompt appears, agent is installed + enrolled. No Terminal required.

Three self-contained plans merged into this branch:

- **Plan A** — new `installer_bootstrap_tokens` table (RLS Shape 1), `GET /api/v1/installer/bootstrap/:token` public endpoint (token IS the auth, single-use, 24h TTL), and `POST /enrollment-keys/:id/bootstrap-token` issuance route
- **Plan B** — new `agent/installer/macos-app/` Swift Package: SwiftUI app reads the token from its own bundle filename (`Breeze Installer [TOKEN@host].app`), fetches enrollment config via bootstrap endpoint, runs `installer -pkg` + `breeze-agent enroll` as root via AppleScript admin dialog. CI job `build-macos-installer-app` in `release.yml` builds → signs → notarizes → staples → uploads `Breeze Installer.app.zip` as a release asset
- **Plan C** — installer route modified to return a renamed app zip (token + API host encoded in filename); `?legacy=1` fallback to the existing `install.sh` zip for one release cycle

### Why filename-based tokens (not per-install signing)

macOS code signature is hashed from `Contents/` subtree — not the bundle's own directory name. A single signed+notarized `.app` can be renamed per customer to embed a token, without re-signing or re-notarizing. Same principle could retire the Windows MSI signing VM stack later; appendix in the design spec explains.

### Docs

- Design spec: `docs/superpowers/specs/2026-04-19-macos-installer-app-design.md`
- Per-plan implementation plans: `docs/superpowers/plans/2026-04-19-macos-installer-plan-{a,b,c}-*.md`

## Security hardening applied during review

Review found several issues; all Critical + top Important resolved in this PR:

- **Token-burn race fixed** — `INSERT` child enrollment key before `UPDATE ... consumed_at` so a failed insert doesn't permanently burn the token
- **Ops logging at 6 distinct bootstrap failure reasons** — response body stays uniformly 404 (intentional, no info leak), but internal logs distinguish replay attempts / orphaned parents / expired tokens / lost races
- **Audit log stores `tokenId` not raw token** — no replayable secrets in audit trail
- **Child enrollment key TTL bounded by parent expiry** — `min(parent.expiresAt, now + CHILD_TTL)`; rejects consume if parent already expired
- **Token entropy raised from ~31 bits (6 chars) to ~52 bits (10 chars)** — 36^10 ≈ 3.7T keyspace
- **Schema CHECK constraints added** via followup migration: `max_usage >= 1`, `expires_at > created_at`, `site_id ON DELETE SET NULL`
- **`renameAppInZip` failures fall through to legacy path** — don't 500 on release-zip packaging regressions
- **`probeMacosInstallerApp` logs swallowed network errors** instead of silently reporting "not available"

## Test plan

- [x] **API unit + integration**: 3219/3244 passing, 0 fails (25 pre-existing skips)
- [x] **Swift**: 18/18 passing (FilenameTokenParser 8, Architecture 4, Installer.shellEscape 6)
- [x] **RLS contract test**: auto-discovers `installer_bootstrap_tokens` as Shape 1, policies verified
- [x] **RLS verified as `breeze_app`**: cross-tenant insert fails with policy violation
- [x] **CHECK constraints verified**: `max_usage = 0` insert fails with expected check-constraint error
- [x] **Bootstrap endpoint is genuinely public**: no global auth middleware in `index.ts`; per-route auth; `installer.ts` has none
- [ ] **End-to-end smoke**: requires first post-merge release to upload `Breeze Installer.app.zip`; legacy `?legacy=1` path keeps working until then
- [ ] **Local sign + notarize + staple**: needs personal Apple credentials; first real release that includes this PR validates the CI path

## Open followups (not in this PR, filed for tracking)

- RFC 5987 `filename*=UTF-8''…` on `Content-Disposition` (current `[TOKEN@host]` brackets are tolerated by Safari/Chrome but can be stripped by corporate proxies / Outlook safe-link rewriting)
- Redis sliding-window rate limit on `/api/v1/installer/bootstrap/:token` (entropy widening addressed the immediate risk)
- `FOR UPDATE` lock on parent key during issuance to close TOCTOU window
- Direct unit tests for `issueBootstrapTokenForKey`
- Assert uniform-404 body across all 3 failure branches (only 1 currently asserts exact body)
- Rename `BootstrapClient.Error` status-0 sentinels to `.invalidURL` / `.invalidResponse`
- Promote `Installer.Error.userCancelled` (code -128) to a first-class case
- Remove `?legacy=1` fallback after one successful release cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)