### PR TITLE
agent/helper: uninstall on policy disable + pgrep fallback

### DIFF
--- a/agent/internal/helper/install_darwin.go
+++ b/agent/internal/helper/install_darwin.go
@@ -21,6 +21,16 @@ func packageExtension() string { return ".dmg" }
 // destAppPath is the fixed install location — avoids fragile filepath.Dir chains.
 const destAppPath = "/Applications/Breeze Helper.app"
 
+// uninstallPackage removes the installed Breeze Helper.app bundle.
+// Idempotent: returns nil if the bundle is already gone.
+func uninstallPackage() error {
+	if err := os.RemoveAll(destAppPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove app bundle: %w", err)
+	}
+	log.Info("app bundle removed", "path", destAppPath)
+	return nil
+}
+
 // installPackage mounts the DMG, copies the .app bundle, and unmounts.
 func installPackage(dmgPath, _ string) error {
 	// Mount the DMG to a temp mount point

--- a/agent/internal/helper/install_linux.go
+++ b/agent/internal/helper/install_linux.go
@@ -18,6 +18,16 @@ const desktopEntryPath = "/etc/xdg/autostart/breeze-helper.desktop"
 
 func packageExtension() string { return ".AppImage" }
 
+// uninstallPackage removes the installed AppImage. Idempotent.
+func uninstallPackage() error {
+	binaryPath := defaultBinaryPath()
+	if err := os.Remove(binaryPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove binary: %w", err)
+	}
+	log.Info("AppImage removed", "path", binaryPath)
+	return nil
+}
+
 // installPackage copies the AppImage to the target path and makes it executable.
 // AppImages are self-contained and directly runnable.
 func installPackage(appImagePath, binaryPath string) error {

--- a/agent/internal/helper/install_windows.go
+++ b/agent/internal/helper/install_windows.go
@@ -16,6 +16,67 @@ const registryValue = "BreezeHelper"
 
 func packageExtension() string { return ".msi" }
 
+const helperDisplayName = "Breeze Helper"
+
+// uninstallPackage finds the MSI ProductCode in the registry and runs
+// msiexec /x to uninstall it. Idempotent: returns nil if not installed.
+func uninstallPackage() error {
+	productCode, err := findHelperProductCode(helperDisplayName)
+	if err != nil {
+		return fmt.Errorf("locate product code: %w", err)
+	}
+	if productCode == "" {
+		return nil // not installed
+	}
+
+	cmd := exec.Command("msiexec", "/x", productCode, "/qn", "/norestart")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 3010 {
+			log.Info("MSI uninstalled (reboot required)", "productCode", productCode)
+			return nil
+		}
+		return fmt.Errorf("msiexec /x %s: %w (output: %s)", productCode, err, strings.TrimSpace(string(out)))
+	}
+	log.Info("MSI uninstalled", "productCode", productCode)
+	return nil
+}
+
+// findHelperProductCode walks the standard 64-bit and 32-bit Uninstall keys
+// looking for a ProductCode-style subkey whose DisplayName matches displayName.
+func findHelperProductCode(displayName string) (string, error) {
+	roots := []string{
+		`SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`,
+		`SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall`,
+	}
+	for _, root := range roots {
+		key, err := registry.OpenKey(registry.LOCAL_MACHINE, root, registry.READ)
+		if err != nil {
+			continue
+		}
+		subKeys, err := key.ReadSubKeyNames(0)
+		key.Close()
+		if err != nil {
+			continue
+		}
+		for _, sk := range subKeys {
+			if !strings.HasPrefix(sk, "{") {
+				continue // only ProductCode-style entries
+			}
+			child, err := registry.OpenKey(registry.LOCAL_MACHINE, root+`\`+sk, registry.READ)
+			if err != nil {
+				continue
+			}
+			name, _, _ := child.GetStringValue("DisplayName")
+			child.Close()
+			if name == displayName {
+				return sk, nil
+			}
+		}
+	}
+	return "", nil
+}
+
 // installPackage runs the MSI installer silently.
 // Exit code 3010 means success but reboot required — treated as success.
 func installPackage(msiPath, _ string) error {

--- a/agent/internal/helper/manager.go
+++ b/agent/internal/helper/manager.go
@@ -233,7 +233,54 @@ func (m *Manager) Apply(settings *Settings) {
 
 	if settings.Enabled {
 		m.applyPendingUpdate()
+	} else {
+		m.uninstallLocked()
 	}
+}
+
+// uninstallLocked performs full cleanup when the helper policy is disabled.
+// Removes the autostart entry, the installed package, and any per-session
+// config/status files. All operations are idempotent so this is safe to call
+// every Apply tick while the policy is off.
+//
+// Must be called with m.mu held.
+func (m *Manager) uninstallLocked() {
+	if !m.isInstalled() && !m.hasResidualState() {
+		return
+	}
+
+	if err := removeAutoStartFunc(); err != nil {
+		log.Warn("uninstall: remove autostart failed", "error", err.Error())
+	}
+
+	if err := uninstallPackageFunc(); err != nil {
+		log.Warn("uninstall: remove package failed", "error", err.Error())
+	}
+
+	sessionsDir := filepath.Join(m.baseDir, "sessions")
+	if err := os.RemoveAll(sessionsDir); err != nil {
+		log.Warn("uninstall: remove sessions dir failed", "path", sessionsDir, "error", err.Error())
+	}
+
+	if err := os.Remove(m.legacyConfigPath()); err != nil && !os.IsNotExist(err) {
+		log.Debug("uninstall: legacy config removal", "error", err.Error())
+	}
+
+	m.pendingHelperVersion = ""
+	m.abandonedVersion = ""
+	m.updateFailures = 0
+
+	log.Info("breeze assist uninstalled")
+}
+
+// hasResidualState reports whether per-session helper state still exists on
+// disk. Used by uninstallLocked to know when more cleanup is needed even if
+// the binary is already gone.
+func (m *Manager) hasResidualState() bool {
+	if _, err := os.Stat(filepath.Join(m.baseDir, "sessions")); err == nil {
+		return true
+	}
+	return false
 }
 
 func settingsToConfig(s *Settings) *Config {

--- a/agent/internal/helper/migrate.go
+++ b/agent/internal/helper/migrate.go
@@ -8,6 +8,7 @@ import (
 
 var (
 	removeAutoStartFunc   = removeAutoStart
+	uninstallPackageFunc  = uninstallPackage
 	stopHelperLegacyFunc  = stopHelperLegacy
 	migrationTargetsFunc  = migrationTargets
 	prepareSessionDirFunc = prepareSessionDir

--- a/agent/internal/helper/process_check_darwin.go
+++ b/agent/internal/helper/process_check_darwin.go
@@ -26,8 +26,16 @@ func isOurProcess(pid int, binaryPath string) bool {
 	return filepath.Clean(exePath) == filepath.Clean(binaryPath)
 }
 
-// isHelperRunningInSession is a no-op on macOS (session-based spawning is
-// Windows-only). The PID-based check is sufficient on macOS/Linux.
-func isHelperRunningInSession(_ string, _ string) bool {
-	return false
+// isHelperRunningInSession scans the process table for the helper binary.
+// The PID-tracked check in the watcher fails when:
+//   - the helper was spawned via IPC (PID returned as 0)
+//   - helper_status.yaml hasn't been written yet (Tauri still booting)
+// In those windows the watcher would respawn even though a helper is alive,
+// piling up orphaned processes. Session arg is ignored — macOS is single-
+// session from the agent's perspective.
+func isHelperRunningInSession(_ string, binaryPath string) bool {
+	if binaryPath == "" {
+		return false
+	}
+	return runHelperCommand("pgrep", "-f", binaryPath) == nil
 }

--- a/agent/internal/helper/process_check_linux.go
+++ b/agent/internal/helper/process_check_linux.go
@@ -23,8 +23,16 @@ func isOurProcess(pid int, binaryPath string) bool {
 	return filepath.Clean(exePath) == filepath.Clean(binaryPath)
 }
 
-// isHelperRunningInSession is a no-op on Linux (session-based spawning is
-// Windows-only). The PID-based check is sufficient on macOS/Linux.
-func isHelperRunningInSession(_ string, _ string) bool {
-	return false
+// isHelperRunningInSession scans the process table for the helper binary.
+// The PID-tracked check in the watcher fails when:
+//   - the helper was spawned via IPC (PID returned as 0)
+//   - helper_status.yaml hasn't been written yet (helper still booting)
+// In those windows the watcher would respawn even though a helper is alive,
+// piling up orphaned processes. Session arg is ignored — Linux is single-
+// session from the agent's perspective.
+func isHelperRunningInSession(_ string, binaryPath string) bool {
+	if binaryPath == "" {
+		return false
+	}
+	return runHelperCommand("pgrep", "-f", binaryPath) == nil
 }


### PR DESCRIPTION
## Summary
- Adds platform `uninstallPackage()`: `.app` bundle removal on macOS, AppImage removal on Linux, MSI ProductCode lookup + `msiexec` on Windows.
- `Manager.Apply` now calls `uninstallLocked()` when `settings.Enabled=false`: removes autostart, uninstalls the package, clears sessions dir and legacy config. Idempotent.
- `process_check_{darwin,linux}`: `isHelperRunningInSession` now `pgrep`s the binary path as a fallback. Prevents orphaned helpers when the watcher spawned via IPC (PID=0) or `helper_status.yaml` hasn't been written yet.

## Test plan
- [ ] Go: `cd agent && go test -race ./internal/helper/...`
- [ ] Manual macOS: disable helper policy, confirm `.app` bundle and autostart are removed.
- [ ] Manual Linux: disable helper policy, confirm AppImage and autostart .desktop removed.
- [ ] Manual Windows: disable helper policy, confirm MSI uninstalls and no stale registry entry remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)