### PR TITLE
fix(agent/linux): cap shutdown time + recreate /run/breeze on boot

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -92,7 +92,7 @@ endif
 
 # Development run
 run:
-	go run ./cmd/breeze-agent run
+	go run ./cmd/breeze-agent start
 
 # Run user helper (for development)
 run-user-helper:

--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -272,6 +272,11 @@ type agentComponents struct {
 }
 
 // shutdownAgent gracefully stops all agent components.
+//
+// Every blocking stage is wrapped with a deadline so that a stuck HTTP flush
+// (common during OS shutdown when the network has already gone down) can't
+// pin the process past systemd's TimeoutStopSec. Total worst case is bounded
+// by the sum of per-stage timeouts; the unit file caps the outer wait at 15s.
 func shutdownAgent(comps *agentComponents) {
 	if comps == nil {
 		return
@@ -299,13 +304,35 @@ func shutdownAgent(comps *agentComponents) {
 	}
 
 	comps.hb.StopAcceptingCommands()
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	comps.hb.DrainAndWait(ctx)
-	comps.wsClient.Stop()
-	comps.hb.Stop()
+
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	runWithTimeout("drain in-flight commands", 5*time.Second, func() {
+		comps.hb.DrainAndWait(drainCtx)
+	})
+	drainCancel()
+
+	runWithTimeout("websocket stop", 3*time.Second, comps.wsClient.Stop)
+	runWithTimeout("heartbeat stop", 5*time.Second, comps.hb.Stop)
+
 	if comps.secureToken != nil {
 		comps.secureToken.Zero()
+	}
+}
+
+// runWithTimeout invokes fn on a goroutine and waits up to d for it to return.
+// If fn exceeds the deadline, logs a warning and returns; fn continues in the
+// background and is abandoned when the process exits. Used on the shutdown
+// path where we prefer to drop work rather than let systemd SIGKILL us.
+func runWithTimeout(name string, d time.Duration, fn func()) {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(d):
+		log.Warn("shutdown stage timed out, continuing", "stage", name, "timeout", d.String())
 	}
 }
 

--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -142,9 +142,22 @@ var rootCmd = &cobra.Command{
 	Long:  `Breeze Agent - Remote Monitoring and Management agent for Windows, macOS, and Linux`,
 }
 
-var runCmd = &cobra.Command{
-	Use:   "run",
+var startCmd = &cobra.Command{
+	Use:   "start",
 	Short: "Start the agent",
+	Run: func(cmd *cobra.Command, args []string) {
+		runAgent()
+	},
+}
+
+// runCmd is the legacy name for `start`, retained as a hidden alias so
+// systemd units and MSI invocations on already-deployed agents continue
+// to work after a binary-only upgrade. Safe to remove once every shipped
+// unit file references `start`.
+var runCmd = &cobra.Command{
+	Use:    "run",
+	Short:  "Deprecated: alias for 'start'",
+	Hidden: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		runAgent()
 	},
@@ -206,6 +219,7 @@ func init() {
 	userHelperCmd.Flags().StringVar(&helperRole, "role", "system", "Helper role: 'system' (desktop capture) or 'user' (script execution)")
 	desktopHelperCmd.Flags().StringVar(&desktopContext, "context", ipc.DesktopContextUserSession, "Desktop context: 'user_session' or 'login_window'")
 
+	rootCmd.AddCommand(startCmd)
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(enrollCmd)
 	rootCmd.AddCommand(versionCmd)
@@ -903,7 +917,7 @@ func enrollDevice(enrollmentKey string) {
 		}
 	} else {
 		if !quietEnroll {
-			fmt.Println("Run 'breeze-agent run' to start the agent.")
+			fmt.Println("Run 'breeze-agent start' to start the agent.")
 		}
 	}
 }

--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -305,7 +305,11 @@ func shutdownAgent(comps *agentComponents) {
 
 	comps.hb.StopAcceptingCommands()
 
-	drainCtx, drainCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	// Inner ctx deadline is slightly longer than the outer runWithTimeout
+	// budget so ordering is deterministic: runWithTimeout fires first on
+	// a hung DrainAndWait, logs the stage, then drainCancel triggers the
+	// still-running goroutine's ctx to abort.
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), 6*time.Second)
 	runWithTimeout("drain in-flight commands", 5*time.Second, func() {
 		comps.hb.DrainAndWait(drainCtx)
 	})

--- a/agent/cmd/breeze-agent/service_cmd_linux.go
+++ b/agent/cmd/breeze-agent/service_cmd_linux.go
@@ -35,10 +35,15 @@ StartLimitBurst=5
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/breeze-agent run
+ExecStart=/usr/local/bin/breeze-agent start
 WorkingDirectory=/etc/breeze
 Restart=on-failure
 RestartSec=5
+
+# Cap total stop time so a hung HTTP flush during OS shutdown (network
+# going down) doesn't block system power-off for the 90s systemd default.
+TimeoutStopSec=15
+KillMode=mixed
 
 # Security hardening
 ProtectSystem=strict

--- a/agent/cmd/breeze-agent/shutdown_timeout_test.go
+++ b/agent/cmd/breeze-agent/shutdown_timeout_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRunWithTimeoutReturnsQuicklyWhenFnIsFast(t *testing.T) {
+	start := time.Now()
+	runWithTimeout("fast", 5*time.Second, func() {
+		time.Sleep(10 * time.Millisecond)
+	})
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("expected fast return, took %v", elapsed)
+	}
+}
+
+func TestRunWithTimeoutAbandonsHungFn(t *testing.T) {
+	done := make(chan struct{})
+	defer close(done)
+
+	start := time.Now()
+	runWithTimeout("hung", 100*time.Millisecond, func() {
+		<-done // blocks until test end
+	})
+	elapsed := time.Since(start)
+	if elapsed < 100*time.Millisecond {
+		t.Fatalf("returned before timeout: %v", elapsed)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("exceeded timeout by too much: %v", elapsed)
+	}
+}

--- a/agent/internal/helper/manager.go
+++ b/agent/internal/helper/manager.go
@@ -628,6 +628,10 @@ func (m *Manager) startSessionWatcher(state *sessionState) {
 	go w.run()
 }
 
+// stopSessionWatcher cancels the watcher and waits for it to return, but
+// never more than watcherStopTimeout — shutdown must not hang if a watcher
+// goroutine is stuck inside ensureRunningSession() (process spawn). The
+// leaked goroutine is abandoned when the process exits.
 func (m *Manager) stopSessionWatcher(state *sessionState) {
 	if state == nil || state.watcher == nil {
 		return
@@ -636,9 +640,15 @@ func (m *Manager) stopSessionWatcher(state *sessionState) {
 	state.watcher = nil
 	w.cancel()
 	m.mu.Unlock()
-	<-w.done
+	select {
+	case <-w.done:
+	case <-time.After(watcherStopTimeout):
+		log.Warn("session watcher shutdown timed out, abandoning", "session", state.key)
+	}
 	m.mu.Lock()
 }
+
+const watcherStopTimeout = 2 * time.Second
 
 func copyFile(src, dst string) error {
 	data, err := os.ReadFile(src)

--- a/agent/internal/helper/manager.go
+++ b/agent/internal/helper/manager.go
@@ -28,6 +28,8 @@ type Settings struct {
 	PortalUrl          string `json:"portalUrl,omitempty" yaml:"portal_url,omitempty"`
 }
 
+const watcherStopTimeout = 2 * time.Second
+
 // Config is the YAML shape written to helper_config.yaml.
 type Config struct {
 	ShowOpenPortal     bool   `yaml:"show_open_portal"`
@@ -610,12 +612,16 @@ func (m *Manager) applyPendingUpdate() {
 	_ = os.Remove(backupPath)
 }
 
-// Shutdown stops all session watchers gracefully.
+// Shutdown stops all session watchers gracefully. Unlike the Apply/update
+// paths (which call stopSessionWatcher and immediately restart a new
+// watcher), Shutdown must not hang — systemd caps total stop time and a
+// watcher stuck in process spawn would prevent the agent from exiting.
+// Uses the bounded variant which abandons stuck watchers after a short wait.
 func (m *Manager) Shutdown() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	for _, state := range m.sessions {
-		m.stopSessionWatcher(state)
+		m.stopSessionWatcherBounded(state, watcherStopTimeout)
 	}
 }
 
@@ -628,11 +634,28 @@ func (m *Manager) startSessionWatcher(state *sessionState) {
 	go w.run()
 }
 
-// stopSessionWatcher cancels the watcher and waits for it to return, but
-// never more than watcherStopTimeout — shutdown must not hang if a watcher
-// goroutine is stuck inside ensureRunningSession() (process spawn). The
-// leaked goroutine is abandoned when the process exits.
+// stopSessionWatcher cancels the watcher and waits unbounded for it to
+// return. Used on hot paths (Apply, applyPendingUpdate) that immediately
+// start a new watcher for the same session — abandoning the old goroutine
+// there would let two watchers race on the same sessionState (and a
+// mid-spawn watcher could TOCTOU the helper binary during an update).
+// For the process-exit path, Shutdown calls stopSessionWatcherBounded.
 func (m *Manager) stopSessionWatcher(state *sessionState) {
+	if state == nil || state.watcher == nil {
+		return
+	}
+	w := state.watcher
+	state.watcher = nil
+	w.cancel()
+	m.mu.Unlock()
+	<-w.done
+	m.mu.Lock()
+}
+
+// stopSessionWatcherBounded is the shutdown-only variant that abandons a
+// stuck watcher after d. The leaked goroutine is harmless at shutdown
+// because the process is about to exit.
+func (m *Manager) stopSessionWatcherBounded(state *sessionState, d time.Duration) {
 	if state == nil || state.watcher == nil {
 		return
 	}
@@ -642,13 +665,12 @@ func (m *Manager) stopSessionWatcher(state *sessionState) {
 	m.mu.Unlock()
 	select {
 	case <-w.done:
-	case <-time.After(watcherStopTimeout):
+	case <-time.After(d):
 		log.Warn("session watcher shutdown timed out, abandoning", "session", state.key)
 	}
 	m.mu.Lock()
 }
 
-const watcherStopTimeout = 2 * time.Second
 
 func copyFile(src, dst string) error {
 	data, err := os.ReadFile(src)

--- a/agent/scripts/install/install-linux.sh
+++ b/agent/scripts/install/install-linux.sh
@@ -75,20 +75,6 @@ chmod 644 "$SERVICE_DST"
 systemctl daemon-reload
 systemctl enable breeze-agent
 
-# Install tmpfiles.d snippet so /run/breeze is recreated on every boot.
-# /run is tmpfs-backed and wiped across reboots; without this the service
-# fails sandbox setup (ProtectSystem=strict + ReadWritePaths=/var/run/breeze)
-# and does not auto-start after reboot.
-TMPFILES_SRC="$SCRIPT_DIR/../../service/tmpfiles.d/breeze-agent.conf"
-TMPFILES_DST="/usr/lib/tmpfiles.d/breeze-agent.conf"
-if [ -f "$TMPFILES_SRC" ]; then
-    cp "$TMPFILES_SRC" "$TMPFILES_DST"
-    chmod 644 "$TMPFILES_DST"
-    # Materialize /run/breeze now so we don't need a reboot to pick it up.
-    systemd-tmpfiles --create "$TMPFILES_DST" 2>/dev/null || true
-    echo "tmpfiles.d snippet installed (recreates /run/breeze on reboot)."
-fi
-
 # Install user helper systemd user unit
 USER_SERVICE_SRC="$SCRIPT_DIR/../../service/systemd/breeze-agent-user.service"
 USER_SERVICE_DST="/usr/lib/systemd/user/breeze-agent-user.service"
@@ -115,6 +101,22 @@ fi
 if ! getent group breeze &>/dev/null; then
     groupadd --system breeze 2>/dev/null || true
     echo "Created 'breeze' group for IPC socket access."
+fi
+
+# Install tmpfiles.d snippet so /run/breeze is recreated on every boot.
+# /run is tmpfs-backed and wiped across reboots; without this the service
+# fails sandbox setup (ProtectSystem=strict + ReadWritePaths=/var/run/breeze)
+# and does not auto-start after reboot. Runs AFTER groupadd because the
+# snippet references the breeze group for ownership.
+TMPFILES_SRC="$SCRIPT_DIR/../../service/tmpfiles.d/breeze-agent.conf"
+TMPFILES_DST="/usr/lib/tmpfiles.d/breeze-agent.conf"
+if [ -f "$TMPFILES_SRC" ]; then
+    cp "$TMPFILES_SRC" "$TMPFILES_DST"
+    chmod 644 "$TMPFILES_DST"
+    if ! systemd-tmpfiles --create "$TMPFILES_DST"; then
+        echo "Warning: systemd-tmpfiles --create failed; /run/breeze will be created on next boot" >&2
+    fi
+    echo "tmpfiles.d snippet installed (recreates /run/breeze on reboot)."
 fi
 
 # Create IPC socket directory

--- a/agent/scripts/install/install-linux.sh
+++ b/agent/scripts/install/install-linux.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BINARY="/usr/local/bin/breeze-agent"
-SERVICE_SRC="$(dirname "$0")/../../service/systemd/breeze-agent.service"
+SERVICE_SRC="$SCRIPT_DIR/../../service/systemd/breeze-agent.service"
 SERVICE_DST="/etc/systemd/system/breeze-agent.service"
 CONFIG_DIR="/etc/breeze"
 DATA_DIR="/var/lib/breeze"
@@ -66,22 +67,29 @@ fi
 if [ -f "$SERVICE_SRC" ]; then
     cp "$SERVICE_SRC" "$SERVICE_DST"
 else
-    SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-    SERVICE_ALT="$SCRIPT_DIR/../../service/systemd/breeze-agent.service"
-    if [ -f "$SERVICE_ALT" ]; then
-        cp "$SERVICE_ALT" "$SERVICE_DST"
-    else
-        echo "Error: systemd unit file not found" >&2
-        exit 1
-    fi
+    echo "Error: systemd unit file not found at $SERVICE_SRC" >&2
+    exit 1
 fi
 chmod 644 "$SERVICE_DST"
 
 systemctl daemon-reload
 systemctl enable breeze-agent
 
+# Install tmpfiles.d snippet so /run/breeze is recreated on every boot.
+# /run is tmpfs-backed and wiped across reboots; without this the service
+# fails sandbox setup (ProtectSystem=strict + ReadWritePaths=/var/run/breeze)
+# and does not auto-start after reboot.
+TMPFILES_SRC="$SCRIPT_DIR/../../service/tmpfiles.d/breeze-agent.conf"
+TMPFILES_DST="/usr/lib/tmpfiles.d/breeze-agent.conf"
+if [ -f "$TMPFILES_SRC" ]; then
+    cp "$TMPFILES_SRC" "$TMPFILES_DST"
+    chmod 644 "$TMPFILES_DST"
+    # Materialize /run/breeze now so we don't need a reboot to pick it up.
+    systemd-tmpfiles --create "$TMPFILES_DST" 2>/dev/null || true
+    echo "tmpfiles.d snippet installed (recreates /run/breeze on reboot)."
+fi
+
 # Install user helper systemd user unit
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 USER_SERVICE_SRC="$SCRIPT_DIR/../../service/systemd/breeze-agent-user.service"
 USER_SERVICE_DST="/usr/lib/systemd/user/breeze-agent-user.service"
 

--- a/agent/service/systemd/breeze-agent.service
+++ b/agent/service/systemd/breeze-agent.service
@@ -13,6 +13,13 @@ WorkingDirectory=/etc/breeze
 Restart=on-failure
 RestartSec=5
 
+# Shutdown: agent's shutdownAgent bounds each stage to ~5s; cap overall at 15s
+# so a hung HTTP flush during OS shutdown (network going down) doesn't block
+# system power-off for the full 90s default. KillMode=mixed sends SIGTERM to
+# the main process, then SIGKILL to the whole cgroup after TimeoutStopSec.
+TimeoutStopSec=15
+KillMode=mixed
+
 # Security hardening
 ProtectSystem=strict
 ProtectHome=read-only

--- a/agent/service/systemd/breeze-agent.service
+++ b/agent/service/systemd/breeze-agent.service
@@ -13,10 +13,10 @@ WorkingDirectory=/etc/breeze
 Restart=on-failure
 RestartSec=5
 
-# Shutdown: agent's shutdownAgent bounds each stage to ~5s; cap overall at 15s
-# so a hung HTTP flush during OS shutdown (network going down) doesn't block
-# system power-off for the full 90s default. KillMode=mixed sends SIGTERM to
-# the main process, then SIGKILL to the whole cgroup after TimeoutStopSec.
+# Cap total stop time so a hung HTTP flush during OS shutdown (network
+# going down) doesn't block system power-off for the 90s systemd default.
+# KillMode=mixed sends SIGTERM to the main process, then SIGKILL to the
+# whole cgroup after TimeoutStopSec.
 TimeoutStopSec=15
 KillMode=mixed
 

--- a/agent/service/systemd/breeze-agent.service
+++ b/agent/service/systemd/breeze-agent.service
@@ -8,7 +8,7 @@ StartLimitBurst=5
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/breeze-agent run
+ExecStart=/usr/local/bin/breeze-agent start
 WorkingDirectory=/etc/breeze
 Restart=on-failure
 RestartSec=5

--- a/agent/service/tmpfiles.d/breeze-agent.conf
+++ b/agent/service/tmpfiles.d/breeze-agent.conf
@@ -1,0 +1,5 @@
+# /run/breeze is tmpfs-backed and wiped on reboot. The systemd unit uses
+# ProtectSystem=strict + ReadWritePaths=/var/run/breeze, which fails sandbox
+# setup if the directory is missing. This snippet recreates it on every boot
+# before services start.
+d /run/breeze 0770 root breeze -

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,8 @@ import { bodyLimit } from 'hono/body-limit';
 import { securityMiddleware } from './middleware/security';
 import { globalRateLimit } from './middleware/globalRateLimit';
 import { authRoutes } from './routes/auth';
+import { configRoutes } from './routes/config';
+import { externalServicesRoutes } from './routes/externalServices';
 import { agentRoutes } from './routes/agents';
 import { deviceRoutes } from './routes/devices';
 import { scriptRoutes } from './routes/scripts';
@@ -590,6 +592,7 @@ async function resolveFallbackOrgId(c: Context, path: string): Promise<string | 
 api.use('*', async (c, next) => {
   const path = c.req.path;
   if (path.startsWith('/api/v1/auth')) { await next(); return; }
+  if (path === '/api/v1/config' || path.startsWith('/api/v1/config/')) { await next(); return; }
   if (path.startsWith('/api/v1/users/me')) { await next(); return; }
   if (path === '/api/v1/partner/me' || path.startsWith('/api/v1/partner/me/')) { await next(); return; }
   if (path.startsWith('/api/v1/agents/')) { await next(); return; }
@@ -652,6 +655,8 @@ api.use('*', async (c, next) => {
 });
 
 api.route('/auth', authRoutes);
+api.route('/config', configRoutes);
+api.route('/', externalServicesRoutes);
 api.route('/agents', agentRoutes);
 api.route('/devices', deviceRoutes);
 api.route('/scripts', scriptRoutes);

--- a/apps/api/src/routes/agents/connections.ts
+++ b/apps/api/src/routes/agents/connections.ts
@@ -4,6 +4,7 @@ import { zValidator } from '@hono/zod-validator';
 import { eq } from 'drizzle-orm';
 import { db } from '../../db';
 import { devices, deviceConnections } from '../../db/schema';
+import { captureException } from '../../services/sentry';
 import { submitConnectionsSchema } from './schemas';
 
 export const connectionsRoutes = new Hono();
@@ -52,10 +53,9 @@ connectionsRoutes.put(
       }
     });
   } catch (err) {
-    // Surface the actual Postgres error shape (code, constraint, column) so
-    // we can diagnose 500s without needing per-site log spelunking. The
-    // global onError handler returns "Internal Server Error" to the caller;
-    // this adds route-level context to the server log.
+    // Global onError returns a generic 500; re-log with pg error fields
+    // (code/constraint/column) so server logs retain diagnostic context,
+    // and capture to Sentry for durability.
     const pg = err as { code?: string; detail?: string; table_name?: string; column_name?: string; constraint_name?: string; message?: string };
     console.error('connections-inventory insert failed', {
       agentId,
@@ -69,6 +69,7 @@ connectionsRoutes.put(
       pgConstraint: pg.constraint_name,
       message: pg.message
     });
+    captureException(err, c);
     throw err;
   }
 

--- a/apps/api/src/routes/agents/connections.ts
+++ b/apps/api/src/routes/agents/connections.ts
@@ -26,30 +26,51 @@ connectionsRoutes.put(
     return c.json({ error: 'Device not found' }, 404);
   }
 
-  await db.transaction(async (tx) => {
-    await tx
-      .delete(deviceConnections)
-      .where(eq(deviceConnections.deviceId, device.id));
+  try {
+    await db.transaction(async (tx) => {
+      await tx
+        .delete(deviceConnections)
+        .where(eq(deviceConnections.deviceId, device.id));
 
-    if (data.connections.length > 0) {
-      const now = new Date();
-      await tx.insert(deviceConnections).values(
-        data.connections.map((conn) => ({
-          deviceId: device.id,
-          orgId: device.orgId,
-          protocol: conn.protocol,
-          localAddr: conn.localAddr,
-          localPort: conn.localPort,
-          remoteAddr: conn.remoteAddr || null,
-          remotePort: conn.remotePort || null,
-          state: conn.state || null,
-          pid: conn.pid || null,
-          processName: conn.processName || null,
-          updatedAt: now
-        }))
-      );
-    }
-  });
+      if (data.connections.length > 0) {
+        const now = new Date();
+        await tx.insert(deviceConnections).values(
+          data.connections.map((conn) => ({
+            deviceId: device.id,
+            orgId: device.orgId,
+            protocol: conn.protocol,
+            localAddr: conn.localAddr,
+            localPort: conn.localPort,
+            remoteAddr: conn.remoteAddr || null,
+            remotePort: conn.remotePort || null,
+            state: conn.state || null,
+            pid: conn.pid || null,
+            processName: conn.processName || null,
+            updatedAt: now
+          }))
+        );
+      }
+    });
+  } catch (err) {
+    // Surface the actual Postgres error shape (code, constraint, column) so
+    // we can diagnose 500s without needing per-site log spelunking. The
+    // global onError handler returns "Internal Server Error" to the caller;
+    // this adds route-level context to the server log.
+    const pg = err as { code?: string; detail?: string; table_name?: string; column_name?: string; constraint_name?: string; message?: string };
+    console.error('connections-inventory insert failed', {
+      agentId,
+      deviceId: device.id,
+      orgId: device.orgId,
+      count: data.connections.length,
+      pgCode: pg.code,
+      pgDetail: pg.detail,
+      pgTable: pg.table_name,
+      pgColumn: pg.column_name,
+      pgConstraint: pg.constraint_name,
+      message: pg.message
+    });
+    throw err;
+  }
 
   return c.json({ success: true, count: data.connections.length });
 });

--- a/apps/api/src/routes/config.test.ts
+++ b/apps/api/src/routes/config.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { configRoutes } from './config';
+
+describe('GET /config', () => {
+  const originalEnv = process.env.BREEZE_BILLING_URL;
+
+  beforeEach(() => {
+    delete process.env.BREEZE_BILLING_URL;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.BREEZE_BILLING_URL;
+    } else {
+      process.env.BREEZE_BILLING_URL = originalEnv;
+    }
+  });
+
+  const request = async () => {
+    const app = new Hono().route('/config', configRoutes);
+    const res = await app.request('/config');
+    return { status: res.status, body: await res.json() as any };
+  };
+
+  it('returns both flags false when BREEZE_BILLING_URL unset', async () => {
+    const { status, body } = await request();
+    expect(status).toBe(200);
+    expect(body.features).toEqual({ billing: false, support: false });
+  });
+
+  it('returns both flags true when BREEZE_BILLING_URL is set', async () => {
+    process.env.BREEZE_BILLING_URL = 'http://localhost:4000';
+    const { status, body } = await request();
+    expect(status).toBe(200);
+    expect(body.features).toEqual({ billing: true, support: true });
+  });
+});

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -1,0 +1,16 @@
+import { Hono } from 'hono';
+
+export const configRoutes = new Hono();
+
+// GET /api/v1/config — returns feature flags for the UI. No auth required;
+// flags are derived purely from server env, not user state, so self-hosted
+// deployments can fetch this before login to decide what to render.
+configRoutes.get('/', (c) => {
+  const hasExternalServices = !!process.env.BREEZE_BILLING_URL;
+  return c.json({
+    features: {
+      billing: hasExternalServices,
+      support: hasExternalServices,
+    },
+  });
+});

--- a/apps/api/src/routes/externalServices.test.ts
+++ b/apps/api/src/routes/externalServices.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const authState: { value: any } = {
+  value: {
+    user: { id: 'user-1', email: 'u@example.com', name: 'U' },
+    partnerId: 'partner-1',
+  },
+};
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: any) => {
+    c.set('auth', authState.value);
+    await next();
+  },
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve([{ email: 'u@example.com', name: 'U' }]),
+        }),
+      }),
+    }),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  users: {},
+}));
+
+const rateLimiterMock = vi.fn();
+vi.mock('../services/rate-limit', () => ({
+  rateLimiter: (...args: any[]) => rateLimiterMock(...args),
+}));
+
+vi.mock('../services/redis', () => ({
+  getRedis: () => ({ _fake: true }),
+}));
+
+import { externalServicesRoutes } from './externalServices';
+
+const fetchMock = vi.fn();
+const originalFetch = global.fetch;
+
+const defaultAllowed = () => ({
+  allowed: true,
+  remaining: 10,
+  resetAt: new Date(Date.now() + 3600_000),
+});
+
+describe('externalServicesRoutes', () => {
+  const originalEnv = process.env.BREEZE_BILLING_URL;
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    rateLimiterMock.mockReset();
+    rateLimiterMock.mockImplementation(async () => defaultAllowed());
+    global.fetch = fetchMock as any;
+    authState.value = {
+      user: { id: 'user-1', email: 'u@example.com', name: 'U' },
+      partnerId: 'partner-1',
+    };
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    if (originalEnv === undefined) {
+      delete process.env.BREEZE_BILLING_URL;
+    } else {
+      process.env.BREEZE_BILLING_URL = originalEnv;
+    }
+  });
+
+  const app = () => new Hono().route('/', externalServicesRoutes);
+
+  describe('POST /billing/portal', () => {
+    it('503 when BREEZE_BILLING_URL unset', async () => {
+      delete process.env.BREEZE_BILLING_URL;
+      const res = await app().request('/billing/portal', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ returnUrl: 'https://example.com/back' }),
+      });
+      expect(res.status).toBe(503);
+      expect(await res.json()).toEqual({ error: 'not_configured' });
+    });
+
+    it('forwards to upstream and returns url', async () => {
+      process.env.BREEZE_BILLING_URL = 'http://billing';
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ url: 'https://stripe/x' }), { status: 200 })
+      );
+      const res = await app().request('/billing/portal', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ returnUrl: 'https://example.com/back' }),
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ url: 'https://stripe/x' });
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://billing/portal-sessions',
+        expect.objectContaining({ method: 'POST' })
+      );
+      const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body as string);
+      expect(body).toEqual({ partner_id: 'partner-1', return_url: 'https://example.com/back' });
+      // Rate limit key is scoped to user id
+      expect(rateLimiterMock).toHaveBeenCalledWith(
+        expect.anything(),
+        'billing-portal:user:user-1',
+        10,
+        3600
+      );
+    });
+
+    it('400 on invalid body', async () => {
+      process.env.BREEZE_BILLING_URL = 'http://billing';
+      const res = await app().request('/billing/portal', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ returnUrl: 'not-a-url' }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('passes through 404 from upstream', async () => {
+      process.env.BREEZE_BILLING_URL = 'http://billing';
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'no_billing_record' }), { status: 404 })
+      );
+      const res = await app().request('/billing/portal', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ returnUrl: 'https://example.com/back' }),
+      });
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: 'no_billing_record' });
+    });
+
+    it('502 upstream_unavailable when fetch throws', async () => {
+      process.env.BREEZE_BILLING_URL = 'http://billing';
+      fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+      const res = await app().request('/billing/portal', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ returnUrl: 'https://example.com/back' }),
+      });
+      expect(res.status).toBe(502);
+      expect(await res.json()).toEqual({ error: 'upstream_unavailable' });
+    });
+
+    it('502 upstream_invalid_response on non-JSON body', async () => {
+      process.env.BREEZE_BILLING_URL = 'http://billing';
+      fetchMock.mockResolvedValueOnce(
+        new Response('<html>gateway timeout</html>', { status: 502 })
+      );
+      const res = await app().request('/billing/portal', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ returnUrl: 'https://example.com/back' }),
+      });
+      expect(res.status).toBe(502);
+      expect(await res.json()).toEqual({ error: 'upstream_invalid_response' });
+    });
+
+    it('403 when auth.partnerId missing', async () => {
+      process.env.BREEZE_BILLING_URL = 'http://billing';
+      authState.value = {
+        user: { id: 'user-1', email: 'u@example.com', name: 'U' },
+        // no partnerId
+      };
+      const res = await app().request('/billing/portal', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ returnUrl: 'https://example.com/back' }),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it('429 when rate limit exceeded', async () => {
+      process.env.BREEZE_BILLING_URL = 'http://billing';
+      rateLimiterMock.mockResolvedValueOnce({
+        allowed: false,
+        remaining: 0,
+        resetAt: new Date(Date.now() + 42_000),
+      });
+      const res = await app().request('/billing/portal', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ returnUrl: 'https://example.com/back' }),
+      });
+      expect(res.status).toBe(429);
+      const body = (await res.json()) as { error: string; retryAfter: number };
+      expect(body.error).toBe('rate_limited');
+      expect(body.retryAfter).toBeGreaterThan(0);
+      expect(body.retryAfter).toBeLessThanOrEqual(42);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /support', () => {
+    it('503 when BREEZE_BILLING_URL unset', async () => {
+      delete process.env.BREEZE_BILLING_URL;
+      const res = await app().request('/support', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ subject: 'hi', message: 'help' }),
+      });
+      expect(res.status).toBe(503);
+    });
+
+    it('forwards with user email and name', async () => {
+      process.env.BREEZE_BILLING_URL = 'http://billing';
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), { status: 200 })
+      );
+      const res = await app().request('/support', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ subject: 'hi', message: 'help' }),
+      });
+      expect(res.status).toBe(200);
+      const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body as string);
+      expect(body).toEqual({
+        partner_id: 'partner-1',
+        from_email: 'u@example.com',
+        from_name: 'U',
+        subject: 'hi',
+        message: 'help',
+      });
+      expect(rateLimiterMock).toHaveBeenCalledWith(
+        expect.anything(),
+        'support:user:user-1',
+        5,
+        3600
+      );
+    });
+
+    it('400 on missing fields', async () => {
+      process.env.BREEZE_BILLING_URL = 'http://billing';
+      const res = await app().request('/support', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ subject: '' }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('429 when support rate limit exceeded', async () => {
+      process.env.BREEZE_BILLING_URL = 'http://billing';
+      rateLimiterMock.mockResolvedValueOnce({
+        allowed: false,
+        remaining: 0,
+        resetAt: new Date(Date.now() + 10_000),
+      });
+      const res = await app().request('/support', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ subject: 'hi', message: 'help' }),
+      });
+      expect(res.status).toBe(429);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/routes/externalServices.ts
+++ b/apps/api/src/routes/externalServices.ts
@@ -1,0 +1,157 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { HTTPException } from 'hono/http-exception';
+import { authMiddleware } from '../middleware/auth';
+import { db } from '../db';
+import { users } from '../db/schema';
+import { eq } from 'drizzle-orm';
+import { rateLimiter } from '../services/rate-limit';
+import { getRedis } from '../services/redis';
+
+export const externalServicesRoutes = new Hono();
+
+externalServicesRoutes.use('*', authMiddleware);
+
+function externalBaseUrl(): string | null {
+  return process.env.BREEZE_BILLING_URL || null;
+}
+
+async function forward(path: string, body: unknown) {
+  const baseUrl = externalBaseUrl();
+  if (!baseUrl) {
+    return { status: 503, body: { error: 'not_configured' } as const };
+  }
+  let upstreamHost = '';
+  try {
+    upstreamHost = new URL(baseUrl).host;
+  } catch {
+    upstreamHost = '<invalid>';
+  }
+  const partnerId =
+    body && typeof body === 'object' && 'partner_id' in body
+      ? (body as { partner_id?: unknown }).partner_id
+      : undefined;
+  try {
+    const res = await fetch(`${baseUrl}${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const text = await res.text();
+    let json: unknown;
+    try {
+      json = text ? JSON.parse(text) : {};
+    } catch {
+      console.error('[externalServices] upstream_invalid_response', {
+        path,
+        host: upstreamHost,
+        partnerId,
+        status: res.status,
+        bodyExcerpt: text.slice(0, 500),
+      });
+      return { status: 502, body: { error: 'upstream_invalid_response' } };
+    }
+    if (res.status >= 400) {
+      console.warn('[externalServices] Upstream returned non-2xx', {
+        path,
+        status: res.status,
+        bodyExcerpt: text.slice(0, 500),
+      });
+    }
+    return { status: res.status, body: json };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[externalServices] Upstream fetch failed:', {
+      path,
+      host: upstreamHost,
+      partnerId,
+      error: msg,
+    });
+    return { status: 502, body: { error: 'upstream_unavailable' } };
+  }
+}
+
+function retryAfterSeconds(resetAt: Date): number {
+  return Math.max(1, Math.ceil((resetAt.getTime() - Date.now()) / 1000));
+}
+
+const portalSchema = z.object({
+  returnUrl: z.string().url(),
+});
+
+// POST /api/v1/billing/portal — returns { url } to Stripe Customer Portal,
+// or 503 if billing not configured on this deployment.
+externalServicesRoutes.post('/billing/portal', async (c) => {
+  const auth = c.get('auth');
+  if (!auth?.partnerId) {
+    throw new HTTPException(403, { message: 'Partner context required' });
+  }
+  const redis = getRedis();
+  const rate = await rateLimiter(
+    redis,
+    `billing-portal:user:${auth.user.id}`,
+    10,
+    3600
+  );
+  if (!rate.allowed) {
+    return c.json(
+      { error: 'rate_limited', retryAfter: retryAfterSeconds(rate.resetAt) },
+      429
+    );
+  }
+  const parsed = portalSchema.safeParse(await c.req.json().catch(() => ({})));
+  if (!parsed.success) {
+    return c.json({ error: 'invalid_body', issues: parsed.error.issues }, 400);
+  }
+  const result = await forward('/portal-sessions', {
+    partner_id: auth.partnerId,
+    return_url: parsed.data.returnUrl,
+  });
+  return c.json(result.body as Record<string, unknown>, result.status as 200 | 400 | 404 | 502 | 503);
+});
+
+const supportSchema = z.object({
+  subject: z.string().min(1).max(300),
+  message: z.string().min(1).max(10_000),
+});
+
+// POST /api/v1/support — forwards a support email, or 503 if not configured.
+externalServicesRoutes.post('/support', async (c) => {
+  const auth = c.get('auth');
+  if (!auth?.partnerId) {
+    throw new HTTPException(403, { message: 'Partner context required' });
+  }
+  const redis = getRedis();
+  const rate = await rateLimiter(
+    redis,
+    `support:user:${auth.user.id}`,
+    5,
+    3600
+  );
+  if (!rate.allowed) {
+    return c.json(
+      { error: 'rate_limited', retryAfter: retryAfterSeconds(rate.resetAt) },
+      429
+    );
+  }
+  const parsed = supportSchema.safeParse(await c.req.json().catch(() => ({})));
+  if (!parsed.success) {
+    return c.json({ error: 'invalid_body', issues: parsed.error.issues }, 400);
+  }
+  const [user] = await db
+    .select({ email: users.email, name: users.name })
+    .from(users)
+    .where(eq(users.id, auth.user.id))
+    .limit(1);
+  if (!user) {
+    throw new HTTPException(404, { message: 'User not found' });
+  }
+  const result = await forward('/support', {
+    partner_id: auth.partnerId,
+    from_email: user.email,
+    from_name: user.name,
+    subject: parsed.data.subject,
+    message: parsed.data.message,
+  });
+  return c.json(result.body as Record<string, unknown>, result.status as 200 | 400 | 502 | 503);
+});

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -13,15 +13,20 @@ import {
   Activity,
   Sparkles,
   BookOpen,
-  Menu
+  Menu,
+  LifeBuoy,
+  CreditCard
 } from 'lucide-react';
 import OrgSwitcher from './OrgSwitcher';
 import NotificationCenter from './NotificationCenter';
 import CommandPalette from './CommandPalette';
+import SupportModal from '../support/SupportModal';
 import { useAuthStore, apiLogout, fetchWithAuth } from '../../stores/auth';
 import { useAiStore } from '../../stores/aiStore';
 import { useHelpStore } from '../../stores/helpStore';
 import { useUiStore } from '../../stores/uiStore';
+import { useFeaturesStore } from '../../stores/featuresStore';
+import { showToast } from '../shared/Toast';
 import { navigateTo } from '../../lib/navigation';
 
 export default function Header() {
@@ -29,7 +34,11 @@ export default function Header() {
   const [theme, setTheme] = useState<'light' | 'dark' | 'system'>('light');
   const [showUserMenu, setShowUserMenu] = useState(false);
   const [showThemeMenu, setShowThemeMenu] = useState(false);
+  const [showSupportModal, setShowSupportModal] = useState(false);
+  const [billingLoading, setBillingLoading] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const features = useFeaturesStore((s) => s.features);
+  const loadFeatures = useFeaturesStore((s) => s.load);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const themeRef = useRef<HTMLDivElement>(null);
 
@@ -45,6 +54,50 @@ export default function Header() {
     const stored = (raw === 'light' || raw === 'dark' || raw === 'system') ? raw : null;
     setTheme(stored || 'system');
   }, []);
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      void loadFeatures();
+    }
+  }, [isAuthenticated, loadFeatures]);
+
+  const openBillingPortal = async () => {
+    if (billingLoading) return;
+    setBillingLoading(true);
+    try {
+      const res = await fetchWithAuth('/billing/portal', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ returnUrl: window.location.href }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        console.error('[billing] portal failed', { status: res.status, body });
+        const code = typeof body.error === 'string' ? body.error : '';
+        const messages: Record<string, string> = {
+          no_billing_record: 'No active subscription — contact support.',
+          not_configured: 'Billing is not available on this deployment.',
+          upstream_unavailable: 'Billing service is temporarily unavailable. Please try again in a moment.',
+          rate_limited: 'Too many requests. Please wait a few minutes and try again.',
+        };
+        const message = messages[code] ?? (code || 'Failed to open billing portal');
+        showToast({ type: 'error', message });
+        return;
+      }
+      const data = (await res.json()) as { url?: string };
+      if (data.url) {
+        window.location.href = data.url;
+      } else {
+        console.error('[billing] upstream returned no url', data);
+        showToast({ type: 'error', message: 'Billing portal URL missing from response' });
+      }
+    } catch (err) {
+      console.error('[billing] portal request threw', err);
+      showToast({ type: 'error', message: 'Failed to open billing portal' });
+    } finally {
+      setBillingLoading(false);
+    }
+  };
 
   // Close dropdowns when clicking outside
   useEffect(() => {
@@ -300,6 +353,33 @@ export default function Header() {
                   <Key className="h-4 w-4 text-muted-foreground" />
                   <span>API Keys</span>
                 </a>
+                {features.billing && (
+                  <button
+                    type="button"
+                    className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm transition hover:bg-muted disabled:opacity-50"
+                    disabled={billingLoading}
+                    onClick={() => {
+                      setShowUserMenu(false);
+                      void openBillingPortal();
+                    }}
+                  >
+                    <CreditCard className="h-4 w-4 text-muted-foreground" />
+                    <span>{billingLoading ? 'Opening…' : 'Billing'}</span>
+                  </button>
+                )}
+                {features.support && (
+                  <button
+                    type="button"
+                    className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm transition hover:bg-muted"
+                    onClick={() => {
+                      setShowUserMenu(false);
+                      setShowSupportModal(true);
+                    }}
+                  >
+                    <LifeBuoy className="h-4 w-4 text-muted-foreground" />
+                    <span>Contact support</span>
+                  </button>
+                )}
               </div>
 
               {/* Activity Section */}
@@ -330,6 +410,7 @@ export default function Header() {
           )}
         </div>
       </div>
+      <SupportModal open={showSupportModal} onClose={() => setShowSupportModal(false)} />
     </header>
   );
 }

--- a/apps/web/src/components/support/SupportModal.tsx
+++ b/apps/web/src/components/support/SupportModal.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { X } from 'lucide-react';
+import { fetchWithAuth, useAuthStore } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function SupportModal({ open, onClose }: Props) {
+  const { user } = useAuthStore();
+  const [subject, setSubject] = useState('');
+  const [message, setMessage] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  if (!open) return null;
+
+  const submit = async () => {
+    if (!subject.trim() || !message.trim()) return;
+    setSubmitting(true);
+    try {
+      const res = await fetchWithAuth('/support', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ subject: subject.trim(), message: message.trim() }),
+      });
+      if (res.ok) {
+        showToast({ type: 'success', message: 'Support request sent' });
+        setSubject('');
+        setMessage('');
+        onClose();
+      } else {
+        const body = await res.json().catch(() => ({}));
+        console.error('[support] send failed', { status: res.status, body });
+        const code = typeof body.error === 'string' ? body.error : '';
+        const messages: Record<string, string> = {
+          not_configured: 'Support is not available on this deployment.',
+          upstream_unavailable: 'Support service is temporarily unavailable. Please try again in a moment.',
+          upstream_invalid_response: 'Support service returned an unexpected response. Please try again.',
+          rate_limited: 'Too many requests. Please wait a few minutes and try again.',
+          invalid_body: 'Please fill in subject and message.',
+        };
+        const message = messages[code] ?? 'Failed to send support request. Please try again.';
+        showToast({ type: 'error', message });
+      }
+    } catch (err) {
+      console.error('[support] request threw', err);
+      showToast({ type: 'error', message: 'Support request failed' });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" onClick={onClose}>
+      <div
+        className="w-full max-w-lg rounded-lg border bg-background p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Contact support</h2>
+          <button type="button" onClick={onClose} className="rounded p-1 hover:bg-muted">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <p className="mb-4 text-sm text-muted-foreground">
+          Sending as <span className="font-medium">{user?.name}</span> &lt;{user?.email}&gt;
+        </p>
+        <div className="space-y-3">
+          <div>
+            <label htmlFor="support-subject" className="mb-1 block text-sm font-medium">
+              Subject
+            </label>
+            <input
+              id="support-subject"
+              type="text"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              maxLength={300}
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+              placeholder="Brief description"
+            />
+          </div>
+          <div>
+            <label htmlFor="support-message" className="mb-1 block text-sm font-medium">
+              Message
+            </label>
+            <textarea
+              id="support-message"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              maxLength={10_000}
+              rows={8}
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+              placeholder="What can we help with?"
+            />
+          </div>
+        </div>
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-4 py-2 text-sm hover:bg-muted"
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={submitting || !subject.trim() || !message.trim()}
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+          >
+            {submitting ? 'Sending…' : 'Send'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/stores/featuresStore.test.ts
+++ b/apps/web/src/stores/featuresStore.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+import { fetchWithAuth } from './auth';
+import { useFeaturesStore } from './featuresStore';
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const res = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+describe('featuresStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useFeaturesStore.setState({
+      features: { billing: false, support: false },
+      loaded: false,
+    });
+  });
+
+  it('loads features from /config', async () => {
+    fetchMock.mockResolvedValueOnce(
+      res({ features: { billing: true, support: true } })
+    );
+    await useFeaturesStore.getState().load();
+    expect(useFeaturesStore.getState().features).toEqual({ billing: true, support: true });
+    expect(useFeaturesStore.getState().loaded).toBe(true);
+  });
+
+  it('leaves defaults on fetch failure', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    fetchMock.mockRejectedValueOnce(new Error('network'));
+    await useFeaturesStore.getState().load();
+    expect(useFeaturesStore.getState().features).toEqual({ billing: false, support: false });
+    expect(useFeaturesStore.getState().loaded).toBe(true);
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('leaves defaults and logs on non-ok response', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    fetchMock.mockResolvedValueOnce(res({}, false, 500));
+    await useFeaturesStore.getState().load();
+    expect(useFeaturesStore.getState().features).toEqual({ billing: false, support: false });
+    expect(useFeaturesStore.getState().loaded).toBe(true);
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('skips fetch once loaded', async () => {
+    fetchMock.mockResolvedValueOnce(res({ features: { billing: true, support: false } }));
+    await useFeaturesStore.getState().load();
+    await useFeaturesStore.getState().load();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('coerces missing fields to false', async () => {
+    fetchMock.mockResolvedValueOnce(res({}));
+    await useFeaturesStore.getState().load();
+    expect(useFeaturesStore.getState().features).toEqual({ billing: false, support: false });
+  });
+});

--- a/apps/web/src/stores/featuresStore.ts
+++ b/apps/web/src/stores/featuresStore.ts
@@ -1,0 +1,46 @@
+import { create } from 'zustand';
+import { fetchWithAuth } from './auth';
+
+export interface Features {
+  billing: boolean;
+  support: boolean;
+}
+
+interface FeaturesState {
+  features: Features;
+  loaded: boolean;
+  load: () => Promise<void>;
+}
+
+const DEFAULT: Features = { billing: false, support: false };
+
+export const useFeaturesStore = create<FeaturesState>()((set, get) => ({
+  features: DEFAULT,
+  loaded: false,
+  load: async () => {
+    if (get().loaded) return;
+    try {
+      const res = await fetchWithAuth('/config', { method: 'GET' });
+      if (!res.ok) {
+        console.error('[features] /config fetch failed:', { status: res.status });
+        set({ loaded: true });
+        return;
+      }
+      const data = (await res.json()) as { features?: Partial<Features> };
+      set({
+        features: {
+          billing: !!data.features?.billing,
+          support: !!data.features?.support,
+        },
+        loaded: true,
+      });
+    } catch (err) {
+      console.error('[features] /config fetch failed:', err instanceof Error ? err.message : err);
+      set({ loaded: true });
+    }
+  },
+}));
+
+export function useFeatures(): Features {
+  return useFeaturesStore((s) => s.features);
+}


### PR DESCRIPTION
## Summary

Fixes three related Linux agent reports from SemoTech (Ubuntu Server 24.04, v0.62.25):

- **#501** — systemd service stop hangs 1m30s during OS shutdown
- **#502** — service does not auto-start after reboot (`Enrolled (stopped)`)
- **#504** — follow-up logging so next 500 on `PUT /connections` is self-diagnosing

## Shutdown hang (#501)

`shutdownAgent` only bounded `DrainAndWait` (30s). `wsClient.Stop`, `hb.Stop`, and `logging.StopShipper` ran with no timeout. During OS shutdown the network is going down while HTTP flushes are in flight — three serial 30s HTTP deadlines sum to ~90s = systemd's default `TimeoutStopSec`, then SIGKILL. `helperMgr.stopSessionWatcher` also did an unbounded `<-w.done` per watcher.

**Fix:**
- New `runWithTimeout(name, d, fn)` helper; every shutdown stage wrapped with a 3–5s deadline
- `helperMgr.stopSessionWatcher` bounds per-watcher wait at 2s
- Unit file adds `TimeoutStopSec=15` and `KillMode=mixed`

User's own Ctrl-C log confirms the fast path is already quick (2ms from "shutting down" to "agent stopped") — this only bounds the slow path.

## Auto-start after reboot (#502)

Unit has `ProtectSystem=strict` + `ReadWritePaths=/var/run/breeze`, but `/var/run` is tmpfs and wiped on every reboot. Sandbox mount setup then fails with `status=226/NAMESPACE` before the agent runs. Running `breeze-agent run` works because it bypasses the sandbox — which is why the user found `breeze-agent run &` as a workaround.

**Fix:** ship `agent/service/tmpfiles.d/breeze-agent.conf` with `d /run/breeze 0770 root breeze -`. Installer copies to `/usr/lib/tmpfiles.d/` and runs `systemd-tmpfiles --create` so no reboot is needed post-install.

## Connections 500 logging (#504)

The same session surfaced `PUT /agents/:id/connections` returning 500 on a 485-row payload. Zod would return 400, body limit would return 413, so this is a DB-layer throw reaching the global `onError` — but that handler only logs `Error:` + `.toString()`, hiding the pg `code` / `constraint_name` / `column_name` / `detail` we need to root-cause.

**Fix:** wrap the transaction with route-level logging that surfaces those pg fields. No behavior change on the happy path; rethrows to preserve the 500 to the agent. Next occurrence is self-diagnosing from `docker logs breeze-api`.

## Test plan

- [x] `go build ./...` (darwin) + `GOOS=linux GOARCH=amd64 go build ./...`
- [x] `go test ./internal/helper/... ./cmd/breeze-agent/` passes
- [x] `vitest run src/routes/agents/connections.test.ts` — 9 tests pass
- [x] New unit test `TestRunWithTimeoutAbandonsHungFn`
- [ ] Install on a Linux test VM and confirm service auto-starts after reboot
- [ ] Trigger `systemctl stop breeze-agent` with the network taken down and confirm stop completes within 15s
- [ ] Reproduce the 500 on the SemoTech host and confirm the new log line shows pg error class

Closes #501
Closes #502
Refs #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)