### PR TITLE
fix(oauth): consent route handles login-prompt with empty prompt.details

### DIFF
--- a/apps/api/src/routes/oauthInteraction.test.ts
+++ b/apps/api/src/routes/oauthInteraction.test.ts
@@ -621,6 +621,54 @@ describe('oauthInteractionRoutes', () => {
     expect(await res.json()).toEqual({ message: 'invalid_scope' });
   });
 
+  it('H3: login-prompt fallback grants params.scope when prompt.details is empty', async () => {
+    // First-visit single-step flow: oidc-provider has issued a `login`
+    // prompt but not yet a `consent` prompt, so `prompt.details` is empty.
+    // The consent UI in this state is rendered from `details.params.scope`,
+    // so the H3 displayed-scope check must fall back to the request param.
+    // Without this fallback the consent POST would 400 on every fresh
+    // login+consent cycle (regression caught by the OAuth integration test
+    // in CI smoke).
+    const d = details({
+      session: undefined,
+      prompt: { name: 'login', details: {} },
+    } as any);
+    mocks.interactionDetails.mockResolvedValue(d);
+    queueSelect([{ partnerId: PARTNER_ID, userId: 'u1' }], 'limit');
+    queueSelect([{ partnerId: PARTNER_ID, orgId: 'org-1' }], 'limit');
+    queueUpdate(); // setGrantBreezeMeta on oauth_grants
+    queueInsertGrantReturning({ firstConsented: true });
+
+    const res = await request(await loadApp(), '/api/v1/oauth/interaction/uid-1/consent', {
+      method: 'POST',
+      body: JSON.stringify({ partner_id: PARTNER_ID, approve: true }),
+    });
+    expect(res.status).toBe(200);
+    expect(mocks.Grant.instances[0]?.addOIDCScope)
+      .toHaveBeenCalledWith('openid offline_access mcp:read mcp:write');
+    expect(mocks.Grant.instances[0]?.addResourceScope)
+      .toHaveBeenCalledWith('https://api.example/mcp/server', 'mcp:read mcp:write');
+  });
+
+  it('GET /interaction/:uid: login-prompt fallback returns scopes from params', async () => {
+    // Mirror of the POST fallback: the GET endpoint serving the consent UI
+    // must surface the requested scopes when prompt.details is empty,
+    // otherwise the user sees a blank consent screen.
+    const d = details({
+      session: { accountId: 'u1' },
+      lastSubmission: { accountId: 'u1' },
+      prompt: { name: 'login', details: {} },
+    } as any);
+    mocks.interactionDetails.mockResolvedValue(d);
+    queueSelect([{ partnerId: PARTNER_ID, partnerName: 'Acme' }]);
+    queueSelect([{ metadata: { client_name: 'Claude Desktop' } }], 'limit');
+
+    const res = await request(await loadApp(), '/api/v1/oauth/interaction/uid-1');
+    expect(res.status).toBe(200);
+    const body = await res.json() as { scopes: string[] };
+    expect(body.scopes).toEqual(['openid', 'offline_access', 'mcp:read', 'mcp:write']);
+  });
+
   it('does not mount routes when MCP_OAUTH_ENABLED is false', async () => {
     const res = await request(await loadApp(false), '/api/v1/oauth/interaction/uid-1');
     expect(res.status).toBe(404);

--- a/apps/api/src/routes/oauthInteraction.ts
+++ b/apps/api/src/routes/oauthInteraction.ts
@@ -147,13 +147,24 @@ if (MCP_OAUTH_ENABLED) {
       (typeof (details.params as any).client_name === 'string' && (details.params as any).client_name) ||
       clientId;
 
+    // On a first-visit single-step flow the prompt is `login`, and
+    // `prompt.details.scopes.new` doesn't exist yet — fall back to the
+    // request's scope param so the consent UI still renders the scopes
+    // the user is being asked to approve. Same rationale as the
+    // `displayedScopeSet` fallback in POST /consent below.
+    const promptScopesNew = ((details.prompt.details as any)?.scopes?.new ?? []) as string[];
+    const requestScopes =
+      (details.params.scope as string | undefined)?.split(' ').filter(Boolean) ?? [];
+    const displayScopes =
+      promptScopesNew.length > 0 ? promptScopesNew : requestScopes;
+
     return c.json({
       uid: details.uid,
       client: {
         client_id: clientId,
         client_name: clientName,
       },
-      scopes: ((details.prompt.details as any)?.scopes?.new ?? []) as string[],
+      scopes: displayScopes,
       resource: resource ?? null,
       partners: memberships,
     });
@@ -234,6 +245,22 @@ if (MCP_OAUTH_ENABLED) {
       ...((promptDetails.missingOIDCScope as string[] | undefined) ?? []),
       ...Object.values(missingResourceScopes).flat(),
     ]);
+    // When the interaction is in the `login` prompt (the single-step
+    // login+consent flow this route handles, where the user has no prior
+    // OIDC session), oidc-provider hasn't generated consent metadata yet —
+    // `prompt.details` is empty. The consent UI in that state is rendered
+    // from `details.params.scope` itself (see the GET `/interaction/:uid`
+    // handler above, and `apps/web/src/components/oauth/ConsentForm.tsx`),
+    // so falling back to the request's scope param here matches what the
+    // user actually saw on screen. The H3 invariant — "don't grant a scope
+    // the consent UI didn't display" — still holds because the request
+    // scope passed through oidc-provider's `scopes` whitelist before this
+    // point. Without this fallback, the security check 400s on every
+    // first-visit consent (regression caught by the OAuth integration
+    // test in CI smoke).
+    if (displayedScopeSet.size === 0 && (details.prompt as any)?.name === 'login') {
+      for (const s of requestedScopes) displayedScopeSet.add(s);
+    }
     const grantedScopes = requestedScopes.filter((s) => displayedScopeSet.has(s));
     if (requestedScopes.length > 0 && grantedScopes.length === 0) {
       throw new HTTPException(400, { message: 'invalid_scope' });


### PR DESCRIPTION
## Summary
- Fixes the OAuth code-flow integration test that PR #513 exposed in CI smoke (`completes register → authorize → consent → token → MCP call → refresh → revoke` returning 400 instead of 200).
- Root cause: the H3 displayed-scope check (added in #509/#510) reads scope metadata exclusively from `prompt.details`. On a first-visit single-step flow, oidc-provider only issues the `login` prompt — `prompt.details` is empty — so the displayed-scope set is `[]`, the intersection with the requested scopes is empty, and the route 400s with `invalid_scope` on every fresh consent.
- Same issue surfaced in the GET `/interaction/:uid` handler: it returns `scopes` from `prompt.details.scopes.new`, so the consent UI was rendering blank for first-visit consents.

## Fix
When `prompt.details` is empty AND `prompt.name === 'login'`, fall back to `details.params.scope` for the displayed-scope set. The H3 invariant still holds — `params.scope` is exactly what the consent UI renders, and oidc-provider's `scopes` whitelist already filters out anything the provider doesn't advertise.

## Why the unit tests didn't catch it
Every existing unit test mocks `prompt.details.scopes.new` populated. None exercised a login-prompt interaction. This PR adds two regression tests that do.

## Test plan
- [x] `pnpm test src/routes/oauthInteraction.test.ts` — 23/23 pass (was 21, +2 new)
- [x] `pnpm test:integration src/__tests__/integration/oauth-code-flow.integration.test.ts` — 3/3 pass
- [x] `npx tsc --noEmit` — clean
- [ ] CI smoke-test job goes green for the first time in a while

🤖 Generated with [Claude Code](https://claude.com/claude-code)