### PR TITLE
fix(mcp-bootstrap): cast jsonb_build_object args + sync integration test

### DIFF
--- a/apps/api/src/__tests__/integration/mcpBootstrap.integration.test.ts
+++ b/apps/api/src/__tests__/integration/mcpBootstrap.integration.test.ts
@@ -139,10 +139,15 @@ describe('MCP bootstrap integration', () => {
       const created = await readToolResult(res);
       expect(created).toMatchObject({ activation_status: 'pending_email' });
       expect(created.tenant_id).toMatch(/^[0-9a-f-]{36}$/);
+      expect(typeof created.bootstrap_secret).toBe('string');
       const tenantId: string = created.tenant_id;
+      const bootstrapSecret: string = created.bootstrap_secret;
 
       // Step 2: verify_tenant → pending_email -----------------------------------
-      res = await rpcCall(app, { name: 'verify_tenant', arguments: { tenant_id: tenantId } });
+      res = await rpcCall(app, {
+        name: 'verify_tenant',
+        arguments: { tenant_id: tenantId, bootstrap_secret: bootstrapSecret },
+      });
       expect(await readToolResult(res)).toEqual({ status: 'pending_email' });
 
       // Step 3: simulate email click (direct DB writes) -------------------------
@@ -158,7 +163,10 @@ describe('MCP bootstrap integration', () => {
         .where(eq(partnerActivations.partnerId, tenantId));
 
       // Step 4: verify_tenant → pending_payment (mints readonly api_key) -------
-      res = await rpcCall(app, { name: 'verify_tenant', arguments: { tenant_id: tenantId } });
+      res = await rpcCall(app, {
+        name: 'verify_tenant',
+        arguments: { tenant_id: tenantId, bootstrap_secret: bootstrapSecret },
+      });
       const afterEmail = await readToolResult(res);
       expect(afterEmail.status).toBe('pending_payment');
       expect(afterEmail.scope).toBe('readonly');
@@ -192,7 +200,10 @@ describe('MCP bootstrap integration', () => {
       }
 
       // Step 6: verify_tenant → active -----------------------------------------
-      res = await rpcCall(app, { name: 'verify_tenant', arguments: { tenant_id: tenantId } });
+      res = await rpcCall(app, {
+        name: 'verify_tenant',
+        arguments: { tenant_id: tenantId, bootstrap_secret: bootstrapSecret },
+      });
       const afterPayment = await readToolResult(res);
       expect(afterPayment.status).toBe('active');
       expect(afterPayment.scope).toBe('full');

--- a/apps/api/src/modules/mcpBootstrap/tools/createTenant.ts
+++ b/apps/api/src/modules/mcpBootstrap/tools/createTenant.ts
@@ -149,7 +149,12 @@ async function issueBootstrapSecret(partnerId: string): Promise<string> {
     updated = await db
       .update(partners)
       .set({
-        settings: sql`coalesce(${partners.settings}, '{}'::jsonb) || jsonb_build_object(${BOOTSTRAP_SECRET_SETTINGS_KEY}, ${secretHash})`,
+        // Explicit ::text casts: jsonb_build_object takes "any" arguments,
+        // so the planner can't infer the parameter types when both args are
+        // bound parameters (postgres-js `prepare` errors with "could not
+        // determine data type of parameter $1"). Both values are JS strings,
+        // so ::text is lossless.
+        settings: sql`coalesce(${partners.settings}, '{}'::jsonb) || jsonb_build_object(${BOOTSTRAP_SECRET_SETTINGS_KEY}::text, ${secretHash}::text)`,
       })
       .where(eq(partners.id, partnerId))
       .returning({ id: partners.id });


### PR DESCRIPTION
## Summary
Closes the last failing integration test in the smoke-test pipeline (`mcpBootstrap.integration.test.ts > end-to-end: create → ... → authed invite`). Two distinct bugs both surfaced once #513 / #514 stopped masking smoke-test failures.

### 1. `jsonb_build_object` parameter type inference
`issueBootstrapSecret` in `apps/api/src/modules/mcpBootstrap/tools/createTenant.ts:152` built the new settings JSON via `jsonb_build_object($1, $2)` where both arguments were bound parameters. Postgres' planner can't infer types for `jsonb_build_object` (signature is `"any"`), so postgres-js's `PREPARE` failed with `could not determine data type of parameter $1` on the first call. The existing unit tests mock Drizzle so they never exercised the SQL planner.

Fixed with explicit `::text` casts on both args — both are JS strings (sha256 hex hash and a string constant), so the cast is lossless.

Confirmed against the real test DB:
```sql
PREPARE x AS UPDATE partners SET settings = ... || jsonb_build_object($1, $2) ...
-> ERROR: could not determine data type of parameter $1

PREPARE y AS ... jsonb_build_object($1::text, $2::text) ...
-> PREPARE  (success)
```

### 2. Stale integration test
`mcpBootstrap.integration.test.ts` wasn't updated when `verify_tenant` started requiring `bootstrap_secret` (commit `7b768267`). Captures the secret from `create_tenant`'s response and passes it through all three `verify_tenant` calls.

Also asserts the `bootstrap_secret` return shape so a future schema change trips the test loudly.

## Test plan
- [x] `pnpm test:integration -t "end-to-end: create"` — passes
- [x] `pnpm test src/modules/mcpBootstrap` — 101/101 unit tests pass
- [x] `npx tsc --noEmit` — clean
- [ ] Smoke-test job goes fully green (closing the loop on #512 → #513 → #514 → this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)