### PR TITLE
fix(release): unblock helper build under vite 7 + capture notarytool log on failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -837,11 +837,25 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           ditto -c -k --keepParent "build/Breeze Installer.app" build/installer-notarize.zip
-          xcrun notarytool submit build/installer-notarize.zip \
+          submit_output=$(xcrun notarytool submit build/installer-notarize.zip \
             --apple-id "$APPLE_ID" \
             --password "$APPLE_PASSWORD" \
             --team-id "$APPLE_TEAM_ID" \
-            --wait --timeout 30m
+            --wait --timeout 30m)
+          echo "$submit_output"
+          submission_id=$(echo "$submit_output" | awk '/^[[:space:]]*id:/ {print $2; exit}')
+          status=$(echo "$submit_output" | awk '/^[[:space:]]*status:/ {print $2; exit}')
+          if [ "$status" != "Accepted" ]; then
+            echo "::error::Notarization failed with status '$status' (submission $submission_id)"
+            if [ -n "$submission_id" ]; then
+              echo "--- xcrun notarytool log $submission_id ---"
+              xcrun notarytool log "$submission_id" \
+                --apple-id "$APPLE_ID" \
+                --password "$APPLE_PASSWORD" \
+                --team-id "$APPLE_TEAM_ID" || true
+            fi
+            exit 1
+          fi
           xcrun stapler staple "build/Breeze Installer.app"
           xcrun stapler validate "build/Breeze Installer.app"
           spctl -a -t exec -vv "build/Breeze Installer.app"

--- a/apps/helper/vite.config.ts
+++ b/apps/helper/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   },
   envPrefix: ['VITE_', 'TAURI_'],
   build: {
-    target: ['es2021', 'chrome100', 'safari13'],
+    target: 'esnext',
     minify: !process.env.TAURI_DEBUG ? 'esbuild' : false,
     sourcemap: !!process.env.TAURI_DEBUG,
     outDir: 'dist',


### PR DESCRIPTION
## Summary

- **Helper builds (3 platforms)**: PR #509 added pnpm override `vite@<6.4.2: '>=6.4.2'`, which force-bumped `apps/helper` from vite 5.4.21 → 7.3.2 despite its `^5.4.0` pin. Vite 7's bundled esbuild 0.27.7 refuses to transform array destructuring against the helper's broad target list, failing v0.63.0 release on macOS, Linux, and Windows. Switched helper to `target: 'esnext'` since it's a Tauri WebView app — the legacy target list was never load-bearing.
- **macOS Installer notarization**: was already failing in v0.62.26-rc.5 with `status: Invalid` but the workflow never called `xcrun notarytool log <id>`, leaving us blind on the actual reason. Now capture the submission ID, parse status, and dump Apple's diagnostic log before failing the step.

## Verification

- `pnpm --filter breeze-helper build` succeeds locally with vite **7.3.2** (the failing CI version) after the fix.
- Notarization log fetch is best-effort (`|| true`) so it never masks the original failure exit code.

## Out of scope

- Underlying installer notarization cause — needs the next CI run to surface Apple's reason via the new log fetch.
- Same `notarytool log` pattern is missing from the agent .pkg, viewer, and helper notarize steps. Can propagate later if useful.

## Test plan

- [ ] Re-run release workflow on a new tag (e.g. `v0.63.1`) and confirm Helper builds pass on all 3 platforms.
- [ ] Confirm the macOS Installer step either succeeds or, if it still fails, the workflow log now contains Apple's detailed reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)