### PR TITLE
fix(release): fail fast when APPLE_INSTALLER_IDENTITY missing on tag build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -716,7 +716,11 @@ jobs:
           APPLE_INSTALLER_IDENTITY: ${{ secrets.APPLE_INSTALLER_IDENTITY }}
         run: |
           if [ -z "$APPLE_INSTALLER_IDENTITY" ]; then
-            echo "APPLE_INSTALLER_IDENTITY not set, skipping .pkg signing"
+            if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+              echo "::error::APPLE_INSTALLER_IDENTITY required for tag releases (productsign would silently skip, shipping unsigned .pkgs that fail downstream Installer.app notarization)"
+              exit 1
+            fi
+            echo "APPLE_INSTALLER_IDENTITY not set, skipping .pkg signing (non-tag build)"
             exit 0
           fi
           for pkg in staging/*.pkg; do
@@ -735,7 +739,11 @@ jobs:
           APPLE_INSTALLER_IDENTITY: ${{ secrets.APPLE_INSTALLER_IDENTITY }}
         run: |
           if [ -z "$APPLE_INSTALLER_IDENTITY" ]; then
-            echo "APPLE_INSTALLER_IDENTITY not set, skipping .pkg notarization"
+            if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+              echo "::error::APPLE_INSTALLER_IDENTITY required for tag releases (.pkgs would skip notarization and fail downstream Installer.app notarization)"
+              exit 1
+            fi
+            echo "APPLE_INSTALLER_IDENTITY not set, skipping .pkg notarization (non-tag build)"
             exit 0
           fi
           for pkg in staging/*.pkg; do

--- a/apps/web/src/components/auth/AcceptInvitePage.tsx
+++ b/apps/web/src/components/auth/AcceptInvitePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import ResetPasswordForm from './ResetPasswordForm';
 import { apiAcceptInvite, useAuthStore, fetchAndApplyPreferences } from '../../stores/auth';
 import { navigateTo } from '../../lib/navigation';
@@ -6,11 +6,15 @@ import { navigateTo } from '../../lib/navigation';
 export default function AcceptInvitePage() {
   const [error, setError] = useState<string>();
   const [loading, setLoading] = useState(false);
-  const [token] = useState(() => {
-    if (typeof window === 'undefined') return undefined;
+  // Read the token in `useEffect` so SSR + first client render agree on
+  // `undefined` and React doesn't trip a hydration-mismatch error (#418).
+  // Same pattern as ResetPasswordPage.
+  const [token, setToken] = useState<string>();
+  useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    return params.get('token') ?? undefined;
-  });
+    const tokenParam = params.get('token');
+    if (tokenParam) setToken(tokenParam);
+  }, []);
 
   const handleSubmit = async (values: { password: string }) => {
     if (!token) {

--- a/e2e-tests/run.ts
+++ b/e2e-tests/run.ts
@@ -10,7 +10,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import yaml from 'yaml';
 import dotenv from 'dotenv';
 
@@ -42,6 +42,7 @@ const args = process.argv.slice(2);
 const options: CLIOptions = {
   test: '',
   tags: [],
+  excludeTags: [],
   nodes: [],
   dryRun: false,
   mode: 'live',
@@ -58,6 +59,9 @@ for (let i = 0; i < args.length; i++) {
       break;
     case '--tags':
       options.tags = (args[++i] ?? '').split(',').filter(Boolean);
+      break;
+    case '--exclude-tags':
+      options.excludeTags = (args[++i] ?? '').split(',').filter(Boolean);
       break;
     case '--nodes':
     case '-n':
@@ -102,6 +106,7 @@ Usage: npx tsx run.ts [options]
 Options:
   --test, -t <id>        Run specific test by ID
   --tags <tags>          Run tests matching tags (comma-separated)
+  --exclude-tags <tags>  Skip tests matching tags (comma-separated)
   --nodes, -n <nodes>    Run only on specific nodes (comma-separated)
   --dry-run, -d          Show what would run without executing
   --mode <mode>          Execution mode: live | simulate (default: live)
@@ -152,6 +157,11 @@ if (options.test) {
 if (options.tags.length > 0) {
   testsToRun = testsToRun.filter((t) => t.tags?.some((tag) => options.tags.includes(tag)));
 }
+if (options.excludeTags.length > 0) {
+  testsToRun = testsToRun.filter(
+    (t) => !t.tags?.some((tag) => options.excludeTags.includes(tag)),
+  );
+}
 if (options.nodes.length > 0) {
   testsToRun = testsToRun.filter((t) => t.nodes.some((node) => options.nodes.includes(node)));
 }
@@ -172,6 +182,31 @@ if (options.mode === 'live') {
     }
   }
 }
+
+// Push session-disrupting tests (anything tagged auth/login/logout, plus
+// any test whose steps explicitly invoke logout-related selectors) to the
+// END of the run. Their fresh-login + logout actions invalidate the
+// shared browser session, forcing every subsequent test to re-login —
+// running them last lets the bulk of the suite reuse the cached cookie.
+function isSessionDisrupting(t: any): boolean {
+  const disruptingTags = new Set(['auth', 'login', 'logout', 'session']);
+  if (Array.isArray(t.tags) && t.tags.some((tag: string) => disruptingTags.has(tag))) {
+    return true;
+  }
+  // Heuristic: any step that clicks a Sign out button or expects /login
+  // redirect after click is destroying the session.
+  return Array.isArray(t.steps) && t.steps.some((s: any) => {
+    const pw = Array.isArray(s.playwright) ? s.playwright : [];
+    return pw.some((a: any) => {
+      const click = typeof a?.click === 'string' ? a.click : '';
+      return /sign[\s-]?out|logout/i.test(click);
+    });
+  });
+}
+testsToRun = [
+  ...testsToRun.filter((t) => !isSessionDisrupting(t)),
+  ...testsToRun.filter(isSessionDisrupting),
+];
 
 // --- Display ---
 
@@ -228,10 +263,19 @@ if (options.mode === 'simulate') {
 
 function clearRateLimits(): void {
   try {
-    execSync(
-      `docker exec breeze-redis redis-cli EVAL "local total = 0; for _,pat in ipairs({'login:*','global:*'}) do local keys = redis.call('KEYS',pat); for _,k in ipairs(keys) do redis.call('DEL',k) end; total = total + #keys end; return total" 0`,
-      { stdio: 'ignore', timeout: 5000 }
+    // The dev/prod Redis container is `--requirepass`-protected. Without
+    // -a/--no-auth-warning the EVAL silently NOAUTHs and the rate-limit
+    // counters keep accumulating, so logins start 401-ing partway through
+    // the suite and the rest of the tests time out on `page.waitForURL`.
+    const args = ['exec', 'breeze-redis', 'redis-cli'];
+    const pw = process.env.REDIS_PASSWORD;
+    if (pw) args.push('-a', pw, '--no-auth-warning');
+    args.push(
+      'EVAL',
+      "local total = 0; for _,pat in ipairs({'login:*','global:*'}) do local keys = redis.call('KEYS',pat); for _,k in ipairs(keys) do redis.call('DEL',k) end; total = total + #keys end; return total",
+      '0',
     );
+    execFileSync('docker', args, { stdio: 'ignore', timeout: 5000 });
   } catch { /* Redis not available — skip */ }
 }
 

--- a/e2e-tests/seed-fixtures.sql
+++ b/e2e-tests/seed-fixtures.sql
@@ -3,9 +3,9 @@
 --   docker exec -i breeze-postgres psql -U breeze -d breeze < e2e-tests/seed-fixtures.sql
 --
 -- Idempotent: safe to re-run. Inserts the minimum data the YAML test
--- suite under e2e-tests/tests/ assumes already exists — two devices
--- whose IDs match E2E_MACOS_DEVICE_ID / E2E_WINDOWS_DEVICE_ID, plus a
--- couple of alerts and audit events so list pages aren't empty.
+-- suite under e2e-tests/tests/ assumes already exists. Pure SQL via
+-- the breeze superuser — bypasses the API, so RLS / business
+-- validation are NOT exercised. That's fine for fixture setup.
 --
 -- Tracks issue #518.
 
@@ -14,8 +14,14 @@ DECLARE
   v_org_id UUID;
   v_site_id UUID;
   v_user_id UUID;
-  v_macos_device_id UUID := '42fc7de0-48f5-48f2-846b-6dd95924baf9';
+  v_macos_device_id  UUID := '42fc7de0-48f5-48f2-846b-6dd95924baf9';
   v_windows_device_id UUID := 'e65460f3-413c-4599-a9a6-90ee71bbc4ff';
+  v_baseline_win UUID;
+  v_baseline_mac UUID;
+  v_backup_config UUID;
+  v_patch_critical UUID;
+  v_patch_important UUID;
+  v_patch_moderate UUID;
 BEGIN
   SELECT id INTO v_org_id FROM organizations LIMIT 1;
   IF v_org_id IS NULL THEN
@@ -31,15 +37,26 @@ BEGIN
 
   SELECT id INTO v_user_id FROM users WHERE email = 'admin@breeze.local' LIMIT 1;
 
-  -- Devices (idempotent on id)
+  -- ───────────────────────────────────────────────────────────────────
+  -- Devices
+  -- ───────────────────────────────────────────────────────────────────
   INSERT INTO devices (id, org_id, site_id, agent_id, hostname, display_name, os_type, os_version, architecture, agent_version, status, last_seen_at)
   VALUES
-    (v_macos_device_id, v_org_id, v_site_id, 'e2e-macos-agent', 'e2e-macos.local', 'E2E macOS Test Device', 'macos', '14.5', 'arm64', '0.63.0', 'online', NOW()),
-    (v_windows_device_id, v_org_id, v_site_id, 'e2e-windows-agent', 'e2e-windows.local', 'E2E Windows Test Device', 'windows', '11.0.22631', 'amd64', '0.63.0', 'online', NOW())
+    (v_macos_device_id,   v_org_id, v_site_id, 'e2e-macos-agent',   'e2e-macos.local',   'E2E macOS Test Device',   'macos',   '14.5',         'arm64', '0.63.0', 'online', NOW()),
+    (v_windows_device_id, v_org_id, v_site_id, 'e2e-windows-agent', 'e2e-windows.local', 'E2E Windows Test Device', 'windows', '11.0.22631',   'amd64', '0.63.0', 'online', NOW())
   ON CONFLICT (id) DO UPDATE
     SET status = 'online', last_seen_at = NOW(), updated_at = NOW();
 
-  -- Alerts (one per device, dedupe by title since the table has no source column)
+  -- ───────────────────────────────────────────────────────────────────
+  -- Device groups
+  -- ───────────────────────────────────────────────────────────────────
+  INSERT INTO device_groups (org_id, site_id, name, type)
+  SELECT v_org_id, v_site_id, 'E2E All Test Devices', 'static'
+  WHERE NOT EXISTS (SELECT 1 FROM device_groups WHERE org_id = v_org_id AND name = 'E2E All Test Devices');
+
+  -- ───────────────────────────────────────────────────────────────────
+  -- Alerts
+  -- ───────────────────────────────────────────────────────────────────
   INSERT INTO alerts (org_id, device_id, severity, status, title, message, triggered_at)
   SELECT v_org_id, v_macos_device_id, 'medium', 'active', 'E2E fixture: high CPU', 'Synthetic alert for e2e suite.', NOW()
   WHERE NOT EXISTS (SELECT 1 FROM alerts WHERE device_id = v_macos_device_id AND title = 'E2E fixture: high CPU');
@@ -48,11 +65,120 @@ BEGIN
   SELECT v_org_id, v_windows_device_id, 'critical', 'active', 'E2E fixture: disk full', 'Synthetic alert for e2e suite.', NOW()
   WHERE NOT EXISTS (SELECT 1 FROM alerts WHERE device_id = v_windows_device_id AND title = 'E2E fixture: disk full');
 
-  -- Audit events (a few so the list/sort/filter tests have something to render)
+  -- ───────────────────────────────────────────────────────────────────
+  -- Audit log seed
+  -- ───────────────────────────────────────────────────────────────────
   INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, resource_id, result, ip_address)
   SELECT v_org_id, 'user', v_user_id, 'e2e.fixture.seeded', 'system', v_org_id, 'success', '127.0.0.1'
   WHERE v_user_id IS NOT NULL
     AND NOT EXISTS (SELECT 1 FROM audit_logs WHERE action = 'e2e.fixture.seeded' AND org_id = v_org_id);
+
+  -- ───────────────────────────────────────────────────────────────────
+  -- Device software (inventory rows so list/filter pages aren't empty)
+  -- ───────────────────────────────────────────────────────────────────
+  INSERT INTO device_software (device_id, name, version, publisher, is_system)
+  SELECT v_macos_device_id, n, v, p, false FROM (VALUES
+    ('Google Chrome',  '120.0.6099', 'Google LLC'),
+    ('Slack',          '4.36.140',   'Slack Technologies'),
+    ('Visual Studio Code', '1.85.0', 'Microsoft Corporation')
+  ) AS s(n, v, p)
+  WHERE NOT EXISTS (SELECT 1 FROM device_software WHERE device_id = v_macos_device_id AND name = s.n);
+
+  INSERT INTO device_software (device_id, name, version, publisher, is_system)
+  SELECT v_windows_device_id, n, v, p, false FROM (VALUES
+    ('Microsoft Edge',     '120.0.2210', 'Microsoft Corporation'),
+    ('7-Zip 19.00 (x64)',  '19.00',      'Igor Pavlov'),
+    ('Notepad++ (64-bit)', '8.6.0',      'Notepad++ Team')
+  ) AS s(n, v, p)
+  WHERE NOT EXISTS (SELECT 1 FROM device_software WHERE device_id = v_windows_device_id AND name = s.n);
+
+  -- ───────────────────────────────────────────────────────────────────
+  -- Browser extensions (Windows device only)
+  -- ───────────────────────────────────────────────────────────────────
+  INSERT INTO browser_extensions (org_id, device_id, browser, extension_id, name, version, source, permissions, risk_level, enabled, first_seen_at, last_seen_at)
+  VALUES
+    (v_org_id, v_windows_device_id, 'edge', 'cjpalhdlnbpafiamejdnhcphjbkeiagm', 'uBlock Origin', '1.54.0', 'webstore', '["webRequest","storage"]'::jsonb, 'low',    true, NOW(), NOW()),
+    (v_org_id, v_windows_device_id, 'edge', 'gighmmpiobklfepjocnamgkkbiglidom', 'AdBlock',       '5.16.1', 'webstore', '["webRequest","tabs"]'::jsonb,    'medium', true, NOW(), NOW())
+  ON CONFLICT (org_id, device_id, browser, extension_id) DO NOTHING;
+
+  -- ───────────────────────────────────────────────────────────────────
+  -- CIS baselines + per-device results
+  -- ───────────────────────────────────────────────────────────────────
+  SELECT id INTO v_baseline_win FROM cis_baselines WHERE org_id = v_org_id AND name = 'E2E Windows L1' LIMIT 1;
+  IF v_baseline_win IS NULL THEN
+    INSERT INTO cis_baselines (org_id, name, os_type, benchmark_version, level)
+    VALUES (v_org_id, 'E2E Windows L1', 'windows', '2.0.0', 'l1')
+    RETURNING id INTO v_baseline_win;
+  END IF;
+
+  SELECT id INTO v_baseline_mac FROM cis_baselines WHERE org_id = v_org_id AND name = 'E2E macOS L1' LIMIT 1;
+  IF v_baseline_mac IS NULL THEN
+    INSERT INTO cis_baselines (org_id, name, os_type, benchmark_version, level)
+    VALUES (v_org_id, 'E2E macOS L1', 'macos', '4.0.0', 'l1')
+    RETURNING id INTO v_baseline_mac;
+  END IF;
+
+  INSERT INTO cis_baseline_results (org_id, device_id, baseline_id, checked_at, total_checks, passed_checks, failed_checks, score)
+  SELECT v_org_id, v_windows_device_id, v_baseline_win, NOW(), 100, 87, 13, 87
+  WHERE NOT EXISTS (SELECT 1 FROM cis_baseline_results WHERE device_id = v_windows_device_id AND baseline_id = v_baseline_win);
+
+  INSERT INTO cis_baseline_results (org_id, device_id, baseline_id, checked_at, total_checks, passed_checks, failed_checks, score)
+  SELECT v_org_id, v_macos_device_id, v_baseline_mac, NOW(), 80, 72, 8, 90
+  WHERE NOT EXISTS (SELECT 1 FROM cis_baseline_results WHERE device_id = v_macos_device_id AND baseline_id = v_baseline_mac);
+
+  -- ───────────────────────────────────────────────────────────────────
+  -- Backup config + backup jobs (one per device, one success + one failed)
+  -- ───────────────────────────────────────────────────────────────────
+  SELECT id INTO v_backup_config FROM backup_configs WHERE org_id = v_org_id AND name = 'E2E Default Backup' LIMIT 1;
+  IF v_backup_config IS NULL THEN
+    INSERT INTO backup_configs (org_id, name, type, provider, provider_config)
+    VALUES (v_org_id, 'E2E Default Backup', 'file', 'local', '{"path":"/var/breeze/backups"}'::jsonb)
+    RETURNING id INTO v_backup_config;
+  END IF;
+
+  INSERT INTO backup_jobs (org_id, config_id, device_id, status, type, started_at, completed_at, total_size, transferred_size, file_count)
+  SELECT v_org_id, v_backup_config, v_macos_device_id, 'completed', 'scheduled', NOW() - INTERVAL '2 hours', NOW() - INTERVAL '1 hour 45 minutes', 1234567890, 1234567890, 4823
+  WHERE NOT EXISTS (SELECT 1 FROM backup_jobs WHERE device_id = v_macos_device_id AND status = 'completed');
+
+  INSERT INTO backup_jobs (org_id, config_id, device_id, status, type, started_at, completed_at, error_log)
+  SELECT v_org_id, v_backup_config, v_windows_device_id, 'failed', 'scheduled', NOW() - INTERVAL '6 hours', NOW() - INTERVAL '5 hours 50 minutes', 'E2E synthetic failure: target unreachable'
+  WHERE NOT EXISTS (SELECT 1 FROM backup_jobs WHERE device_id = v_windows_device_id AND status = 'failed');
+
+  -- ───────────────────────────────────────────────────────────────────
+  -- Patches + device_patches links (Windows device gets the queue)
+  -- ───────────────────────────────────────────────────────────────────
+  SELECT id INTO v_patch_critical FROM patches WHERE source = 'microsoft' AND external_id = 'E2E-KB5000001' LIMIT 1;
+  IF v_patch_critical IS NULL THEN
+    INSERT INTO patches (source, external_id, title, severity, os_types, kb_article_url, requires_reboot)
+    VALUES ('microsoft', 'E2E-KB5000001', 'Cumulative Update for Windows 11 (E2E synthetic)', 'critical', ARRAY['windows'], 'https://support.microsoft.com/en-us/help/E2E-KB5000001', true)
+    RETURNING id INTO v_patch_critical;
+  END IF;
+
+  SELECT id INTO v_patch_important FROM patches WHERE source = 'microsoft' AND external_id = 'E2E-KB5000002' LIMIT 1;
+  IF v_patch_important IS NULL THEN
+    INSERT INTO patches (source, external_id, title, severity, os_types, requires_reboot)
+    VALUES ('microsoft', 'E2E-KB5000002', 'Microsoft Defender Definition Update (E2E)', 'important', ARRAY['windows'], false)
+    RETURNING id INTO v_patch_important;
+  END IF;
+
+  SELECT id INTO v_patch_moderate FROM patches WHERE source = 'apple' AND external_id = 'E2E-MAC-001' LIMIT 1;
+  IF v_patch_moderate IS NULL THEN
+    INSERT INTO patches (source, external_id, title, severity, os_types, requires_reboot)
+    VALUES ('apple', 'E2E-MAC-001', 'Safari 17.2 Security Update (E2E)', 'moderate', ARRAY['macos'], false)
+    RETURNING id INTO v_patch_moderate;
+  END IF;
+
+  INSERT INTO device_patches (org_id, device_id, patch_id, status, last_checked_at)
+  SELECT v_org_id, v_windows_device_id, v_patch_critical, 'pending', NOW()
+  WHERE NOT EXISTS (SELECT 1 FROM device_patches WHERE device_id = v_windows_device_id AND patch_id = v_patch_critical);
+
+  INSERT INTO device_patches (org_id, device_id, patch_id, status, installed_at, last_checked_at)
+  SELECT v_org_id, v_windows_device_id, v_patch_important, 'installed', NOW() - INTERVAL '1 day', NOW()
+  WHERE NOT EXISTS (SELECT 1 FROM device_patches WHERE device_id = v_windows_device_id AND patch_id = v_patch_important);
+
+  INSERT INTO device_patches (org_id, device_id, patch_id, status, last_checked_at)
+  SELECT v_org_id, v_macos_device_id, v_patch_moderate, 'pending', NOW()
+  WHERE NOT EXISTS (SELECT 1 FROM device_patches WHERE device_id = v_macos_device_id AND patch_id = v_patch_moderate);
 
   RAISE NOTICE 'E2E fixtures seeded for org %', v_org_id;
 END $$;

--- a/e2e-tests/seed-fixtures.sql
+++ b/e2e-tests/seed-fixtures.sql
@@ -1,0 +1,58 @@
+-- E2E test fixtures for fresh-DB runs.
+-- Run via:
+--   docker exec -i breeze-postgres psql -U breeze -d breeze < e2e-tests/seed-fixtures.sql
+--
+-- Idempotent: safe to re-run. Inserts the minimum data the YAML test
+-- suite under e2e-tests/tests/ assumes already exists — two devices
+-- whose IDs match E2E_MACOS_DEVICE_ID / E2E_WINDOWS_DEVICE_ID, plus a
+-- couple of alerts and audit events so list pages aren't empty.
+--
+-- Tracks issue #518.
+
+DO $$
+DECLARE
+  v_org_id UUID;
+  v_site_id UUID;
+  v_user_id UUID;
+  v_macos_device_id UUID := '42fc7de0-48f5-48f2-846b-6dd95924baf9';
+  v_windows_device_id UUID := 'e65460f3-413c-4599-a9a6-90ee71bbc4ff';
+BEGIN
+  SELECT id INTO v_org_id FROM organizations LIMIT 1;
+  IF v_org_id IS NULL THEN
+    RAISE NOTICE 'No organization found — run autoMigrate seed first.';
+    RETURN;
+  END IF;
+
+  SELECT id INTO v_site_id FROM sites WHERE org_id = v_org_id LIMIT 1;
+  IF v_site_id IS NULL THEN
+    RAISE NOTICE 'No site found — run autoMigrate seed first.';
+    RETURN;
+  END IF;
+
+  SELECT id INTO v_user_id FROM users WHERE email = 'admin@breeze.local' LIMIT 1;
+
+  -- Devices (idempotent on id)
+  INSERT INTO devices (id, org_id, site_id, agent_id, hostname, display_name, os_type, os_version, architecture, agent_version, status, last_seen_at)
+  VALUES
+    (v_macos_device_id, v_org_id, v_site_id, 'e2e-macos-agent', 'e2e-macos.local', 'E2E macOS Test Device', 'macos', '14.5', 'arm64', '0.63.0', 'online', NOW()),
+    (v_windows_device_id, v_org_id, v_site_id, 'e2e-windows-agent', 'e2e-windows.local', 'E2E Windows Test Device', 'windows', '11.0.22631', 'amd64', '0.63.0', 'online', NOW())
+  ON CONFLICT (id) DO UPDATE
+    SET status = 'online', last_seen_at = NOW(), updated_at = NOW();
+
+  -- Alerts (one per device, dedupe by title since the table has no source column)
+  INSERT INTO alerts (org_id, device_id, severity, status, title, message, triggered_at)
+  SELECT v_org_id, v_macos_device_id, 'medium', 'active', 'E2E fixture: high CPU', 'Synthetic alert for e2e suite.', NOW()
+  WHERE NOT EXISTS (SELECT 1 FROM alerts WHERE device_id = v_macos_device_id AND title = 'E2E fixture: high CPU');
+
+  INSERT INTO alerts (org_id, device_id, severity, status, title, message, triggered_at)
+  SELECT v_org_id, v_windows_device_id, 'critical', 'active', 'E2E fixture: disk full', 'Synthetic alert for e2e suite.', NOW()
+  WHERE NOT EXISTS (SELECT 1 FROM alerts WHERE device_id = v_windows_device_id AND title = 'E2E fixture: disk full');
+
+  -- Audit events (a few so the list/sort/filter tests have something to render)
+  INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, resource_id, result, ip_address)
+  SELECT v_org_id, 'user', v_user_id, 'e2e.fixture.seeded', 'system', v_org_id, 'success', '127.0.0.1'
+  WHERE v_user_id IS NOT NULL
+    AND NOT EXISTS (SELECT 1 FROM audit_logs WHERE action = 'e2e.fixture.seeded' AND org_id = v_org_id);
+
+  RAISE NOTICE 'E2E fixtures seeded for org %', v_org_id;
+END $$;

--- a/e2e-tests/src/types.ts
+++ b/e2e-tests/src/types.ts
@@ -142,6 +142,7 @@ export interface RunnerContext {
 export interface CLIOptions {
   test: string;
   tags: string[];
+  excludeTags: string[];
   nodes: string[];
   dryRun: boolean;
   mode: 'live' | 'simulate';

--- a/e2e-tests/tests/auth_flows.yaml
+++ b/e2e-tests/tests/auth_flows.yaml
@@ -16,7 +16,7 @@ tests:
         description: "Navigate to forgot password page"
         playwright:
           - goto: "/forgot-password"
-          - waitFor: "text=Breeze RMM"
+          - waitFor: "input#email"
             timeout: 15000
 
       - id: verify_form_elements
@@ -103,10 +103,10 @@ tests:
               selector: "h2"
               contains: "Invalid Link"
           - assert:
-              selector: "p.text-sm"
+              selector: ".bg-card p.text-sm"
               contains: "invalid or has expired"
           - assert:
-              selector: "a[href='/forgot-password']"
+              selector: ".bg-card a[href='/forgot-password']"
               contains: "Request a new link"
 
   - id: reset_password_with_token
@@ -180,7 +180,7 @@ tests:
         description: "Navigate to the partner registration page"
         playwright:
           - goto: "/register-partner"
-          - waitFor: "text=Register your company"
+          - waitFor: "input#companyName"
             timeout: 15000
 
       - id: verify_all_fields_present
@@ -300,7 +300,7 @@ tests:
               selector: "h2"
               contains: "Invalid Link"
           - assert:
-              selector: "p.text-sm"
+              selector: ".bg-card p.text-sm"
               contains: "invite link is invalid or has expired"
 
   - id: accept_invite_with_token

--- a/e2e-tests/tests/authentication.yaml
+++ b/e2e-tests/tests/authentication.yaml
@@ -40,7 +40,10 @@ tests:
         action: ui
         description: "Logout via user menu"
         playwright:
-          - click: "button[aria-haspopup='true']"
+          # Use title="Account menu" to disambiguate from the Theme menu —
+          # both buttons have aria-haspopup="true" and Theme is rendered
+          # first, so a generic selector picks the wrong dropdown.
+          - click: "button[title='Account menu']"
           - waitFor: "button:has-text('Sign out')"
             timeout: 5000
           - click: "button:has-text('Sign out')"


### PR DESCRIPTION
## Summary

Today's v0.63.2 retrospective: the agent .pkg `Sign` and `Notarize and staple` steps in `release.yml` silently exited 0 when `APPLE_INSTALLER_IDENTITY` was unset. The unsigned .pkgs got uploaded as artifacts and downstream the **Build macOS Installer App** job failed Apple notarization 15 minutes later with `"The binary is not signed."`. We burned three release attempts (v0.62.26-rc.5, v0.63.0, v0.63.1) on this loop because the silent skip happened in an upstream job.

## Change

Keep skip behavior for non-tag builds (PR/branch CI), but **error immediately** when the secret is missing during a tag release.

```bash
if [ -z "$APPLE_INSTALLER_IDENTITY" ]; then
  if [[ "$GITHUB_REF" == refs/tags/* ]]; then
    echo "::error::APPLE_INSTALLER_IDENTITY required for tag releases ..."
    exit 1
  fi
  echo "APPLE_INSTALLER_IDENTITY not set, skipping ... (non-tag build)"
  exit 0
fi
```

Applied to both `Sign .pkg installers` (line 713) and `Notarize and staple .pkg installers` (line 729).

## Test plan

- [ ] Non-tag CI (this PR's checks) should pass without invoking these steps (the outer `if: vars.ENABLE_MACOS_SIGNING == 'true'` still gates them; if SIGNING is off they don't run at all).
- [ ] Next tag release with the secret set: behaves identically to v0.63.2 (working).
- [ ] If we ever rotate/lose the secret again, the next tag release errors at the source job (~5 min in) instead of at the Installer step (~15 min in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)