### PR TITLE
e2e: selector drift + post-login race fixes

### DIFF
--- a/e2e-tests/tests/agent_log_shipping.yaml
+++ b/e2e-tests/tests/agent_log_shipping.yaml
@@ -31,6 +31,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       # ── Step 2: Query all diagnostic logs for the device ───────
       - id: query_all_logs

--- a/e2e-tests/tests/alert_lifecycle.yaml
+++ b/e2e-tests/tests/alert_lifecycle.yaml
@@ -30,6 +30,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_alerts
         action: ui
@@ -120,6 +122,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_alerts
         action: ui
@@ -194,6 +198,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       # NOTE: The trigger_test_alert_via_api step was removed because
       # POST /api/v1/alerts/test does not exist.
@@ -321,6 +327,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: verify_rules_index_redirect
         action: ui
@@ -364,6 +372,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_channels
         action: ui
@@ -471,6 +481,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: verify_agent_online
         action: ui

--- a/e2e-tests/tests/audit_and_logs.yaml
+++ b/e2e-tests/tests/audit_and_logs.yaml
@@ -32,7 +32,7 @@ tests:
         description: "Navigate to Audit Log page and verify heading"
         playwright:
           - goto: "/audit"
-          - waitFor: "text=Audit Log"
+          - waitFor: "text=Audit Trail"
             timeout: 15000
           - waitFor: "text=Track user actions, sensitive operations, and system changes."
 
@@ -82,7 +82,7 @@ tests:
         description: "Navigate to Audit Log page and wait for loading to complete"
         playwright:
           - goto: "/audit"
-          - waitFor: "text=Audit Log"
+          - waitFor: "text=Audit Trail"
             timeout: 15000
           - waitFor: "button:has-text('Filters')"
             timeout: 20000
@@ -123,7 +123,7 @@ tests:
         description: "Click Apply Filters to submit the filter selection"
         playwright:
           - click: "button:has-text('Apply Filters')"
-          - waitFor: "text=Audit Log"
+          - waitFor: "text=Audit Trail"
             timeout: 10000
 
       - id: verify_clear_button_appears
@@ -137,7 +137,7 @@ tests:
         description: "Click the Clear button to remove all active filters"
         playwright:
           - click: "button:has-text('Clear')"
-          - waitFor: "text=Audit Log"
+          - waitFor: "text=Audit Trail"
             timeout: 5000
 
   - id: audit_log_sorting
@@ -167,7 +167,7 @@ tests:
         description: "Navigate to Audit Log page and wait for table to load"
         playwright:
           - goto: "/audit"
-          - waitFor: "text=Audit Log"
+          - waitFor: "text=Audit Trail"
             timeout: 15000
           - waitFor: "table"
             timeout: 20000
@@ -223,7 +223,7 @@ tests:
         description: "Navigate to Audit Log page and wait for entries"
         playwright:
           - goto: "/audit"
-          - waitFor: "text=Audit Log"
+          - waitFor: "text=Audit Trail"
             timeout: 15000
           - waitFor: "tbody tr"
             timeout: 20000

--- a/e2e-tests/tests/audit_and_logs.yaml
+++ b/e2e-tests/tests/audit_and_logs.yaml
@@ -26,6 +26,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_audit
         action: ui
@@ -76,6 +78,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_audit
         action: ui
@@ -161,6 +165,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_audit
         action: ui
@@ -217,6 +223,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_audit
         action: ui
@@ -280,6 +288,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_logs
         action: ui
@@ -351,6 +361,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_logs
         action: ui

--- a/e2e-tests/tests/authentication.yaml
+++ b/e2e-tests/tests/authentication.yaml
@@ -28,6 +28,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: verify_dashboard
         action: ui
@@ -208,6 +210,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_devices
         action: ui

--- a/e2e-tests/tests/automations.yaml
+++ b/e2e-tests/tests/automations.yaml
@@ -25,6 +25,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_automations
         action: ui
@@ -103,6 +105,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_new_automation
         action: ui
@@ -211,6 +215,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_new_automation
         action: ui
@@ -298,6 +304,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_automations
         action: ui
@@ -380,6 +388,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_automations
         action: ui
@@ -461,6 +471,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_automations
         action: ui
@@ -521,6 +533,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_automations
         action: ui

--- a/e2e-tests/tests/backup_lifecycle.yaml
+++ b/e2e-tests/tests/backup_lifecycle.yaml
@@ -26,6 +26,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_backup
         action: ui
@@ -64,6 +66,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_backup
         action: ui
@@ -124,6 +128,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_backup
         action: ui
@@ -186,6 +192,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_backup
         action: ui
@@ -229,6 +237,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_backup
         action: ui

--- a/e2e-tests/tests/browser_security.yaml
+++ b/e2e-tests/tests/browser_security.yaml
@@ -23,6 +23,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_security
         action: ui
@@ -90,6 +92,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_security_score
         action: ui
@@ -168,6 +172,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_recommendations
         action: ui
@@ -256,6 +262,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: scan_linux_extensions
         action: api
@@ -327,6 +335,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_trends
         action: ui

--- a/e2e-tests/tests/cis_hardening.yaml
+++ b/e2e-tests/tests/cis_hardening.yaml
@@ -23,6 +23,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_cis
         action: ui
@@ -40,10 +42,10 @@ tests:
               selector: "h2"
               contains: "CIS Hardening"
           - assert:
-              # Bare `p` matched the sidebar version banner ("Web 0.x · API 0.x")
-              # because that hydrates above the page subtitle. Pin to the p
-              # adjacent to the page heading.
-              selector: "h2 + p"
+              # Bare `p` and even `h2 + p` get hijacked by the AiChatSidebar
+              # SSR shell (which has its own h2 + "Cmd+Enter to send" p that
+              # renders earlier in DOM order). Pin to the actual content.
+              selector: "p:has-text('Configuration baselines')"
               contains: "Configuration baselines, compliance scoring, and remediation tracking."
 
       - id: verify_summary_cards
@@ -89,6 +91,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_cis
         action: ui
@@ -188,6 +192,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_cis
         action: ui
@@ -266,6 +272,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_cis
         action: ui
@@ -359,6 +367,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_baselines
         action: ui
@@ -441,6 +451,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_baselines
         action: ui
@@ -512,6 +524,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       # Step 1: Create a Windows L1 baseline targeting Kit
       - id: navigate_baselines
@@ -642,6 +656,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       # Step 1: Request remediation via API for a known CIS check on Kit
       - id: request_remediation
@@ -731,6 +747,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_baselines
         action: ui

--- a/e2e-tests/tests/cis_hardening.yaml
+++ b/e2e-tests/tests/cis_hardening.yaml
@@ -40,7 +40,10 @@ tests:
               selector: "h2"
               contains: "CIS Hardening"
           - assert:
-              selector: "p"
+              # Bare `p` matched the sidebar version banner ("Web 0.x · API 0.x")
+              # because that hydrates above the page subtitle. Pin to the p
+              # adjacent to the page heading.
+              selector: "h2 + p"
               contains: "Configuration baselines, compliance scoring, and remediation tracking."
 
       - id: verify_summary_cards

--- a/e2e-tests/tests/configuration_policies.yaml
+++ b/e2e-tests/tests/configuration_policies.yaml
@@ -23,6 +23,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_config_policies
         action: ui
@@ -71,6 +73,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_new_policy
         action: ui
@@ -121,6 +125,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_new_policy
         action: ui
@@ -205,6 +211,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_new_policy
         action: ui
@@ -261,6 +269,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_config_policies
         action: ui
@@ -317,6 +327,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_config_policies
         action: ui

--- a/e2e-tests/tests/dashboard.yaml
+++ b/e2e-tests/tests/dashboard.yaml
@@ -29,13 +29,16 @@ tests:
 
       - id: verify_dashboard_heading
         action: ui
-        description: "Verify main Dashboard heading renders"
+        description: "Verify main dashboard heading renders"
         playwright:
-          - waitFor: "text=Dashboard"
+          # h1 was renamed from "Dashboard" → "Welcome" — match the
+          # current copy. The other "text=Dashboard" waitFors below
+          # still match the sidebar nav link, which kept its label.
+          - waitFor: "h1:has-text('Welcome')"
             timeout: 10000
           - assert:
               selector: "h1"
-              contains: "Dashboard"
+              contains: "Welcome"
 
       - id: verify_stat_cards
         action: ui

--- a/e2e-tests/tests/dashboard.yaml
+++ b/e2e-tests/tests/dashboard.yaml
@@ -26,6 +26,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: verify_dashboard_heading
         action: ui
@@ -59,14 +61,6 @@ tests:
               selector: "text=Critical"
               exists: true
 
-      - id: verify_subheading
-        action: ui
-        description: "Verify dashboard subheading text is visible"
-        playwright:
-          - assert:
-              selector: "text=Overview of your managed devices and alerts"
-              exists: true
-
   - id: dashboard_device_status_chart
     name: "Dashboard Device Status Chart"
     description: "Verify the Device Status pie chart section renders"
@@ -86,6 +80,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: verify_device_status_chart
         action: ui
@@ -116,6 +112,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: verify_recent_alerts_heading
         action: ui
@@ -149,6 +147,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: verify_recent_activity_heading
         action: ui
@@ -182,6 +182,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: verify_sidebar_links
         action: ui
@@ -240,6 +242,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: verify_search_button_visible
         action: ui
@@ -291,6 +295,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: open_user_menu
         action: ui
@@ -335,6 +341,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: verify_and_toggle_dark_mode
         action: ui
@@ -366,6 +374,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: verify_devices_api
         action: api

--- a/e2e-tests/tests/dashboard_comprehensive.yaml
+++ b/e2e-tests/tests/dashboard_comprehensive.yaml
@@ -29,20 +29,20 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       # ── Step 2: Dashboard heading and subheading ───────────────
       - id: verify_heading
         action: ui
-        description: "Verify Dashboard heading and subheading render"
+        description: "Verify Dashboard heading renders"
         playwright:
-          - waitFor: "text=Dashboard"
+          # h1 was renamed to "Welcome" and the subtitle was removed.
+          - waitFor: "h1:has-text('Welcome')"
             timeout: 10000
           - assert:
               selector: "h1"
-              contains: "Dashboard"
-          - assert:
-              selector: "text=Overview of your managed devices and alerts"
-              exists: true
+              contains: "Welcome"
 
       # ── Step 3: Stat cards (Total Devices, Online, Warnings, Critical)
       - id: verify_stat_cards

--- a/e2e-tests/tests/device_detail_tabs.yaml
+++ b/e2e-tests/tests/device_detail_tabs.yaml
@@ -41,6 +41,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_device
         action: ui
@@ -99,6 +101,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_device
         action: ui
@@ -133,6 +137,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_device
         action: ui
@@ -179,6 +185,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_device
         action: ui
@@ -230,6 +238,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_device
         action: ui
@@ -277,6 +287,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_windows_device
         action: ui
@@ -324,6 +336,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_device
         action: ui
@@ -371,6 +385,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_device
         action: ui
@@ -454,6 +470,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_device
         action: ui
@@ -500,6 +518,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_device
         action: ui
@@ -534,6 +554,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_device
         action: ui
@@ -580,6 +602,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_device
         action: ui
@@ -614,6 +638,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_device
         action: ui
@@ -648,6 +674,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_device
         action: ui
@@ -682,6 +710,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_windows_device
         action: ui
@@ -716,6 +746,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_windows_device
         action: ui
@@ -750,6 +782,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_device
         action: ui
@@ -786,6 +820,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_nonexistent_device
         action: ui
@@ -820,6 +856,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_device
         action: ui
@@ -854,6 +892,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_device
         action: ui
@@ -888,6 +928,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_device
         action: ui
@@ -922,6 +964,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_device
         action: ui
@@ -956,6 +1000,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_linux_device
         action: ui

--- a/e2e-tests/tests/device_management.yaml
+++ b/e2e-tests/tests/device_management.yaml
@@ -30,6 +30,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_devices
         action: ui
@@ -117,6 +119,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_devices
         action: ui
@@ -166,6 +170,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_devices
         action: ui
@@ -212,6 +218,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_devices
         action: ui
@@ -256,6 +264,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_devices
         action: ui
@@ -300,6 +310,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_devices
         action: ui
@@ -355,6 +367,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_devices
         action: ui
@@ -424,6 +438,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_device_detail
         action: ui
@@ -524,6 +540,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_device_detail
         action: ui
@@ -614,6 +632,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_devices
         action: ui
@@ -667,6 +687,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_devices
         action: ui
@@ -750,6 +772,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_compare_page
         action: ui
@@ -803,6 +827,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_groups_page
         action: ui
@@ -869,6 +895,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: check_heartbeat
         action: api
@@ -913,6 +941,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: check_system_info
         action: api
@@ -957,6 +987,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: check_windows_status
         action: api

--- a/e2e-tests/tests/discovery_network.yaml
+++ b/e2e-tests/tests/discovery_network.yaml
@@ -23,6 +23,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_discovery
         action: ui
@@ -75,6 +77,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_profiles_tab
         action: ui
@@ -104,7 +108,10 @@ tests:
           - fill:
               "input[placeholder='Headquarters scan']": "E2E Test Profile"
           - fill:
-              "textarea[placeholder='10.0.0.0/24\n10.0.1.0/24']": "192.168.1.0/24"
+              # Substring match — the literal placeholder contains a newline,
+              # which YAML preserves and the CSS parser then chokes on
+              # ("Unsupported token BADSTRING").
+              "textarea[placeholder*='10.0.0.0/24']": "192.168.1.0/24"
           - click: "label:has-text('ICMP Ping') input[type='checkbox']"
           - click: "label:has-text('TCP Port Scan') input[type='checkbox']"
 
@@ -145,6 +152,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_profiles_tab
         action: ui
@@ -204,6 +213,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_assets_tab
         action: ui
@@ -243,6 +254,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_changes_tab
         action: ui

--- a/e2e-tests/tests/fleet_management.yaml
+++ b/e2e-tests/tests/fleet_management.yaml
@@ -23,6 +23,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_fleet
         action: ui
@@ -81,6 +83,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_fleet
         action: ui
@@ -130,6 +134,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_fleet
         action: ui
@@ -184,6 +190,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_fleet
         action: ui

--- a/e2e-tests/tests/integrations.yaml
+++ b/e2e-tests/tests/integrations.yaml
@@ -24,6 +24,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_webhooks
         action: ui
@@ -72,6 +74,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_webhooks
         action: ui
@@ -179,6 +183,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_webhooks
         action: ui
@@ -225,6 +231,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_psa
         action: ui
@@ -273,6 +281,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_psa
         action: ui
@@ -323,6 +333,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_psa
         action: ui

--- a/e2e-tests/tests/monitoring_dashboard.yaml
+++ b/e2e-tests/tests/monitoring_dashboard.yaml
@@ -23,6 +23,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_monitoring
         action: ui
@@ -60,6 +62,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_monitoring
         action: ui
@@ -132,6 +136,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_monitoring
         action: ui
@@ -184,6 +190,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_monitoring_checks
         action: ui
@@ -214,6 +222,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_monitoring_templates
         action: ui

--- a/e2e-tests/tests/monitoring_security.yaml
+++ b/e2e-tests/tests/monitoring_security.yaml
@@ -23,6 +23,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_security
         action: ui
@@ -222,6 +224,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_score
         action: ui
@@ -301,6 +305,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_antivirus
         action: ui
@@ -402,6 +408,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_firewall
         action: ui
@@ -475,6 +483,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_encryption
         action: ui
@@ -551,6 +561,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_password_policy
         action: ui
@@ -627,6 +639,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_vulnerabilities
         action: ui
@@ -728,6 +742,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_trends
         action: ui
@@ -824,6 +840,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_recommendations
         action: ui
@@ -910,6 +928,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_admin_audit
         action: ui
@@ -927,7 +947,8 @@ tests:
               selector: "h2"
               contains: "Admin Account Audit"
           - assert:
-              selector: "p"
+              # Bare `p` matches AiChatSidebar's SSR shell first; pin by content.
+              selector: "p:has-text('Privileged account review')"
               contains: "Privileged account review across all devices"
 
       - id: verify_stat_cards
@@ -1010,6 +1031,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_monitoring
         action: ui
@@ -1055,6 +1078,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_peripherals
         action: ui
@@ -1099,6 +1124,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_sensitive_data
         action: ui
@@ -1127,6 +1154,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_audit
         action: ui
@@ -1162,6 +1191,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_score
         action: ui

--- a/e2e-tests/tests/patch_management.yaml
+++ b/e2e-tests/tests/patch_management.yaml
@@ -24,6 +24,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_patches
         action: ui
@@ -75,6 +77,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_patches
         action: ui
@@ -139,6 +143,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_patches_tab
         action: ui
@@ -217,6 +223,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_compliance_tab
         action: ui
@@ -285,6 +293,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_patches
         action: ui
@@ -346,6 +356,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_patches_tab
         action: ui

--- a/e2e-tests/tests/peripherals_and_data.yaml
+++ b/e2e-tests/tests/peripherals_and_data.yaml
@@ -26,6 +26,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_peripherals
         action: ui
@@ -61,6 +63,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_peripherals_policies
         action: ui
@@ -134,6 +138,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_peripherals
         action: ui
@@ -170,6 +176,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_peripherals_activity
         action: ui
@@ -241,6 +249,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_sensitive_data
         action: ui
@@ -278,6 +288,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_sensitive_data_dashboard
         action: ui
@@ -332,6 +344,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_sensitive_data_findings
         action: ui
@@ -404,6 +418,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_sensitive_data_scans
         action: ui

--- a/e2e-tests/tests/policies.yaml
+++ b/e2e-tests/tests/policies.yaml
@@ -23,6 +23,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_policies
         action: ui
@@ -130,6 +132,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_new_policy
         action: ui
@@ -147,7 +151,9 @@ tests:
               selector: "h1"
               contains: "Create Policy"
           - assert:
-              selector: "p"
+              # Bare `p` was hijacked by AiChatSidebar's SSR shell ("Loading...")
+              # which renders earlier in DOM order. Pin to the heading sibling.
+              selector: "h1 + p"
               contains: "Define compliance rules and enforcement behavior."
 
       - id: fill_policy_name_and_description
@@ -275,6 +281,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_policies
         action: ui
@@ -361,6 +369,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_compliance_dashboard
         action: ui
@@ -464,6 +474,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_new_policy
         action: ui
@@ -552,6 +564,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_policies
         action: ui

--- a/e2e-tests/tests/remote_access.yaml
+++ b/e2e-tests/tests/remote_access.yaml
@@ -23,6 +23,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_remote
         action: ui
@@ -81,6 +83,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_terminal_launcher
         action: ui
@@ -154,6 +158,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_files_launcher
         action: ui
@@ -198,6 +204,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_sessions
         action: ui
@@ -288,6 +296,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_sessions
         action: ui

--- a/e2e-tests/tests/reports_analytics.yaml
+++ b/e2e-tests/tests/reports_analytics.yaml
@@ -24,6 +24,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_reports
         action: ui
@@ -87,6 +89,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_reports
         action: ui
@@ -130,6 +134,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_reports
         action: ui
@@ -179,6 +185,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_new_report
         action: ui
@@ -228,6 +236,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_report_builder
         action: ui
@@ -269,6 +279,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_analytics
         action: ui
@@ -341,6 +353,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_analytics
         action: ui
@@ -389,6 +403,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_analytics
         action: ui

--- a/e2e-tests/tests/script_execution.yaml
+++ b/e2e-tests/tests/script_execution.yaml
@@ -22,6 +22,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_scripts
         action: ui
@@ -101,6 +103,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: open_new_script_page
         action: ui
@@ -232,6 +236,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_scripts
         action: ui
@@ -344,6 +350,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: create_failing_script
         action: ui
@@ -456,6 +464,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_scripts
         action: ui
@@ -528,6 +538,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: open_library_modal
         action: ui

--- a/e2e-tests/tests/settings_admin.yaml
+++ b/e2e-tests/tests/settings_admin.yaml
@@ -24,6 +24,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_settings
         action: ui
@@ -65,6 +67,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_users
         action: ui
@@ -151,6 +155,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_roles
         action: ui
@@ -208,6 +214,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_api_keys
         action: ui
@@ -284,6 +292,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_enrollment_keys
         action: ui
@@ -351,6 +361,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_sso
         action: ui
@@ -403,6 +415,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_profile
         action: ui
@@ -462,6 +476,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_ai_usage
         action: ui
@@ -525,6 +541,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_access_reviews
         action: ui
@@ -591,6 +609,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_sites
         action: ui
@@ -630,6 +650,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_custom_fields
         action: ui

--- a/e2e-tests/tests/snmp_and_admin.yaml
+++ b/e2e-tests/tests/snmp_and_admin.yaml
@@ -23,6 +23,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_snmp_via_redirect
         action: ui
@@ -124,6 +126,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_snmp_tab
         action: ui
@@ -179,6 +183,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_snmp_templates
         action: ui
@@ -235,6 +241,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_partner
         action: ui
@@ -394,6 +402,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_partner
         action: ui
@@ -488,6 +498,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_quarantined
         action: ui
@@ -555,6 +567,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_quarantined
         action: ui
@@ -600,6 +614,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_quarantined
         action: ui

--- a/e2e-tests/tests/software_management.yaml
+++ b/e2e-tests/tests/software_management.yaml
@@ -22,6 +22,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_software_catalog
         action: ui
@@ -63,6 +65,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_catalog
         action: ui
@@ -122,6 +126,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_software_inventory
         action: ui
@@ -175,6 +181,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_software_policies
         action: ui
@@ -222,6 +230,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_catalog
         action: ui
@@ -274,6 +284,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: verify_windows_software_in_logs
         action: api

--- a/e2e-tests/tests/user_profile.yaml
+++ b/e2e-tests/tests/user_profile.yaml
@@ -25,6 +25,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_profile_short_url
         action: ui
@@ -56,6 +58,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_profile
         action: ui
@@ -136,6 +140,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_profile
         action: ui
@@ -177,6 +183,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_profile
         action: ui
@@ -217,6 +225,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_profile
         action: ui
@@ -257,6 +267,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_to_profile
         action: ui

--- a/e2e-tests/tests/user_risk.yaml
+++ b/e2e-tests/tests/user_risk.yaml
@@ -23,6 +23,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_risk
         action: ui
@@ -82,6 +84,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_risk
         action: ui
@@ -155,6 +159,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_risk
         action: ui
@@ -232,6 +238,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_risk
         action: ui
@@ -303,6 +311,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_risk
         action: ui
@@ -348,6 +358,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_risk
         action: ui
@@ -405,6 +417,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_audit_baselines
         action: ui
@@ -466,6 +480,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_audit_baselines
         action: ui
@@ -515,6 +531,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_audit_baselines
         action: ui
@@ -598,6 +616,8 @@ tests:
           - waitFor:
               url: "**/"
               timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
 
       - id: navigate_audit_baselines_list
         action: ui


### PR DESCRIPTION
## Summary
Follow-up to PR #517 (which shipped the runner-level rate-limit + session-trust + seed-fixtures fixes). This PR is the YAML-level cleanup needed to actually make tests pass against the current `https://2breeze.app` UI.

## What's in here

**1. `waitFor h1:has-text('Welcome')` after every post-login `waitFor: { url: "**/" }`** — applied programmatically across all 29 yaml files (211 occurrences). The URL change races the React auth-store rehydrate; under load Playwright sees the URL flip momentarily and times out before content settles. Adding a real-DOM wait gives the page time to render.

**2. Six targeted selector fixes for AiChatSidebar SSR-shell hijack:**
- `cis_hardening.yaml` — bare `p` (and `h2 + p`) was matching AiChatInput's "Cmd+Enter to send" SSR shell. Pin to `p:has-text('Configuration baselines')`.
- `dashboard.yaml` — h1 → "Welcome", subtitle was deleted in UI; drop the assertion.
- `dashboard_comprehensive.yaml` — same h1 + subtitle update.
- `policies.yaml` — bare `p` → `h1 + p` for the create-policy subtitle.
- `monitoring_security.yaml` — bare `p` → `p:has-text('Privileged account review')` for the admin audit page.
- `discovery_network.yaml` — literal newline in YAML key crashed the CSS parser ("Unsupported token BADSTRING"); use `placeholder*='10.0.0.0/24'` substring match.

**3. `audit_and_logs.yaml` — page heading drift** — `Audit Log` → `Audit Trail` (3 occurrences).

## Pass-rate progression

Run-to-run improvement during this session:

| Run | Tests | Pass | Rate |
|---|---|---|---|
| Baseline (no fixes) | 45 | 2 | 4% |
| + #517 runner+seed fixes | 52 | 10 | 19% |
| + #517 session-trust | 26 | 8 | 31% |
| **+ this PR** | **46** | **12** | **26%** |

The 26% number understates the impact — the session-trust fix from #517 did the heavy lifting. This PR's main contribution is unblocking a chunk of pages that had stale selectors.

## Out of scope (tracked for later)
~25 remaining `locator.waitFor: Timeout 15s` failures are **per-test selector drift** — each test waits for a different page element that's been renamed or restructured. Each fix is mechanical (~5 min: fetch page, find current selector, update YAML) but slow at volume. Not blocking — just leaves headroom for a future cleanup sprint.

A handful of failures are real-data-dependent (CIS Scan needing an online agent, Agent Diagnostic Logs needing logs to ship, MCP -32602 schema validation). Those need backend work, not test edits.

## Test plan
- [x] `dashboard_loads_with_stats` passes against fresh DB + seed-fixtures (verified locally, 5.3s)
- [x] Critical-tag suite goes 12/46 (vs 8/26 in the prior session-trust-only run)
- [x] No new regressions vs prior runs (every previously-passing test still passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)