### PR TITLE
fix(api): capture real client IP in audit logs (#521)

### DIFF
--- a/apps/api/src/routes/tunnels.ts
+++ b/apps/api/src/routes/tunnels.ts
@@ -9,6 +9,7 @@ import { sendCommandToAgent, isAgentConnected } from './agentWs';
 import { checkRemoteAccess } from '../services/remoteAccessPolicy';
 import { createWsTicket, createVncConnectCode, consumeVncConnectCode, getViewerAccessTokenExpirySeconds } from '../services/remoteSessionAuth';
 import { createViewerAccessToken, verifyViewerAccessToken } from '../services/jwt';
+import { getTrustedClientIp } from '../services/clientIp';
 import { isViewerJtiRevoked, isViewerSessionRevoked, revokeViewerSession } from '../services/viewerTokenRevocation';
 import type { AuthContext } from '../middleware/auth';
 
@@ -147,9 +148,7 @@ async function isSourceIpAllowed(sourceIp: string, orgId: string): Promise<boole
 }
 
 function getClientIp(c: any): string {
-  return c.req.header('x-forwarded-for')?.split(',')[0]?.trim()
-    || c.req.header('x-real-ip')
-    || '127.0.0.1';
+  return getTrustedClientIp(c, '127.0.0.1');
 }
 
 async function getDeviceForTunnel(deviceId: string, auth: AuthContext) {


### PR DESCRIPTION
## Summary

Fixes #521 — every audit-log entry on prod was capturing `172.19.0.8` (cloudflared's docker IP) instead of the real client IP, breaking abuse investigation and login-anomaly review.

Two changes:

1. **Header precedence reordered** in `apps/api/src/services/clientIp.ts`: now `cf-connecting-ip → x-forwarded-for → x-real-ip` (was XFF first). Cloudflared sets a trustworthy `cf-connecting-ip` header even when XFF is poisoned by an intermediate proxy — so it's the most reliable signal in our deploy chain (cloudflared → Caddy → API).

2. **22 audit/security call sites** that were reading raw `c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip')` are now standardized on `getTrustedClientIp(c)` / `getTrustedClientIpOrUndefined(c)`. This applies the `TRUST_PROXY_HEADERS` security gate uniformly and removes the duplicated header-parsing code.

The Caddyfile-side fix (propagating CF-Connecting-IP from cloudflared through Caddy's reverse_proxy) lives on the droplets and will be applied operationally.

## Test plan

- [x] `pnpm --filter @breeze/api test` — 3688 pass, 28 skipped, 0 fail
- [x] `tsc --noEmit` clean for changed files (one pre-existing unrelated error in `installerAppZip.test.ts` already on main)
- [ ] After Caddyfile fix on droplets: verify new audit_logs rows have real client IPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)