### PR TITLE
ci: add test-MSI workflow + extract reusable build-msi

### DIFF
--- a/.github/workflows/build-msi-reusable.yml
+++ b/.github/workflows/build-msi-reusable.yml
@@ -1,0 +1,365 @@
+name: Build + Sign Windows MSI (reusable)
+
+# Reusable workflow that builds the three Windows Go binaries
+# (breeze-agent, breeze-backup, breeze-watchdog), runs installer/build-msi.ps1,
+# and (optionally) signs the binaries + MSI via Azure Trusted Signing.
+#
+# Called by:
+#   - .github/workflows/release.yml (production: signs based on tag prerelease suffix)
+#   - .github/workflows/test-msi.yml (workflow_dispatch: builds an MSI from any branch
+#     for smoke testing without cutting a real release)
+#
+# Inputs:
+#   ref            - git ref to check out (branch / SHA / tag)
+#   version        - full version string to stamp into binaries + MSI
+#                    (e.g. "0.62.23" for a real tag, "0.62.23-test.12345" for a test build)
+#   signing_env    - GitHub Environment to attach to the job:
+#                      "signing-production"  - Azure Trusted Signing prod profile
+#                      "signing-prerelease"  - Azure Trusted Signing prerelease profile
+#                      "none"                - skip signing entirely (build unsigned MSI)
+#   go_version     - Go toolchain version to use (defaults to release.yml's pin)
+#
+# Output:
+#   msi_artifact_name - artifact name for the (signed or unsigned) MSI
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref (branch, SHA, or tag) to build from'
+        required: true
+        type: string
+      version:
+        description: 'Version string to stamp into binaries and MSI (no leading v)'
+        required: true
+        type: string
+      signing_env:
+        description: 'Signing environment: signing-production, signing-prerelease, or none'
+        required: true
+        type: string
+      go_version:
+        description: 'Go toolchain version'
+        required: false
+        type: string
+        default: '1.25.9'
+    outputs:
+      msi_artifact_name:
+        description: 'Name of the uploaded MSI artifact'
+        value: ${{ jobs.build-windows-msi.outputs.msi_artifact_name }}
+
+jobs:
+  build-windows-msi:
+    name: Build + Sign Windows Artifacts
+    if: vars.ENABLE_WINDOWS_SIGNING == 'true' || inputs.signing_env == 'none'
+    runs-on: windows-latest
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: ${{ inputs.signing_env }}
+    outputs:
+      msi_artifact_name: ${{ steps.expose.outputs.name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ inputs.go_version }}
+          cache-dependency-path: agent/go.sum
+
+      - name: Download Go dependencies
+        working-directory: agent
+        shell: pwsh
+        run: go mod download
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Install WiX CLI
+        shell: pwsh
+        run: |
+          dotnet tool update --global wix | Out-Null
+          if ($LASTEXITCODE -ne 0) {
+            dotnet tool install --global wix | Out-Null
+          }
+          "$env:USERPROFILE\.dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          wix eula accept wix7
+
+      - name: Resolve version
+        id: version
+        shell: pwsh
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          $version = $env:INPUT_VERSION
+          if ([string]::IsNullOrWhiteSpace($version)) {
+            throw "inputs.version is required"
+          }
+          # Strip a leading 'v' if a caller passed a tag-like string
+          if ($version.StartsWith("v")) { $version = $version.Substring(1) }
+          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          Write-Host "Building MSI for version: $version"
+
+      - name: Build Windows resources and binary
+        shell: pwsh
+        env:
+          BUILD_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          New-Item -Path dist -ItemType Directory -Force | Out-Null
+          go install github.com/tc-hib/go-winres@v0.3.3
+          Push-Location agent\resources
+          & "$env:USERPROFILE\go\bin\go-winres.exe" make --in winres.json --out ..\cmd\breeze-agent\rsrc_windows_amd64.syso
+          Pop-Location
+          Push-Location agent
+          $env:GOOS = "windows"
+          $env:GOARCH = "amd64"
+          $env:CGO_ENABLED = "0"
+          go build -ldflags="-s -w -X main.version=$env:BUILD_VERSION" -o ..\dist\breeze-agent-windows-amd64.exe .\cmd\breeze-agent
+          Pop-Location
+          # Build breeze-backup
+          Push-Location agent
+          $env:GOOS = "windows"
+          $env:GOARCH = "amd64"
+          $env:CGO_ENABLED = "0"
+          go build -ldflags="-s -w -X main.version=$env:BUILD_VERSION" -o ..\dist\breeze-backup-windows-amd64.exe .\cmd\breeze-backup
+          Pop-Location
+          # Build breeze-watchdog
+          Push-Location agent
+          $env:GOOS = "windows"
+          $env:GOARCH = "amd64"
+          $env:CGO_ENABLED = "0"
+          go build -ldflags="-s -w -X main.version=$env:BUILD_VERSION" -o ..\dist\breeze-watchdog-windows-amd64.exe .\cmd\breeze-watchdog
+          Pop-Location
+
+      - name: Validate signing configuration
+        if: inputs.signing_env != 'none'
+        shell: pwsh
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SIGNING_ENDPOINT: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          AZURE_SIGNING_ACCOUNT_NAME: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
+          AZURE_CERT_PROFILE_PROD: ${{ secrets.AZURE_CERT_PROFILE_PROD }}
+          AZURE_CERT_PROFILE_PRERELEASE: ${{ secrets.AZURE_CERT_PROFILE_PRERELEASE }}
+          SIGNING_ENV: ${{ inputs.signing_env }}
+        run: |
+          $required = @("AZURE_CLIENT_ID", "AZURE_TENANT_ID", "AZURE_SIGNING_ENDPOINT", "AZURE_SIGNING_ACCOUNT_NAME")
+          foreach ($name in $required) {
+            if ([string]::IsNullOrWhiteSpace((Get-Item "env:$name").Value)) {
+              throw "Missing required signing secret: $name"
+            }
+          }
+
+          $isPrerelease = $env:SIGNING_ENV -eq "signing-prerelease"
+          if ($isPrerelease) {
+            if ([string]::IsNullOrWhiteSpace($env:AZURE_CERT_PROFILE_PRERELEASE)) {
+              throw "Missing required signing secret: AZURE_CERT_PROFILE_PRERELEASE"
+            }
+          } else {
+            if ([string]::IsNullOrWhiteSpace($env:AZURE_CERT_PROFILE_PROD)) {
+              throw "Missing required signing secret: AZURE_CERT_PROFILE_PROD"
+            }
+          }
+
+      - name: Azure Login (OIDC)
+        if: inputs.signing_env != 'none'
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Sign Windows EXE (stable profile)
+        if: inputs.signing_env == 'signing-production'
+        uses: azure/artifact-signing-action@db7a3a6bd3912025c705162fb7475389f5b69ec6 # v1
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PROD }}
+          files: ${{ github.workspace }}\dist\breeze-agent-windows-amd64.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Sign Windows EXE (prerelease profile)
+        if: inputs.signing_env == 'signing-prerelease'
+        uses: azure/artifact-signing-action@db7a3a6bd3912025c705162fb7475389f5b69ec6 # v1
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PRERELEASE }}
+          files: ${{ github.workspace }}\dist\breeze-agent-windows-amd64.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Sign backup EXE (stable profile)
+        if: inputs.signing_env == 'signing-production'
+        uses: azure/artifact-signing-action@db7a3a6bd3912025c705162fb7475389f5b69ec6 # v1
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PROD }}
+          files: ${{ github.workspace }}\dist\breeze-backup-windows-amd64.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Sign backup EXE (prerelease profile)
+        if: inputs.signing_env == 'signing-prerelease'
+        uses: azure/artifact-signing-action@db7a3a6bd3912025c705162fb7475389f5b69ec6 # v1
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PRERELEASE }}
+          files: ${{ github.workspace }}\dist\breeze-backup-windows-amd64.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Sign watchdog executable (stable profile)
+        if: inputs.signing_env == 'signing-production'
+        uses: azure/artifact-signing-action@db7a3a6bd3912025c705162fb7475389f5b69ec6 # v1
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PROD }}
+          files: ${{ github.workspace }}\dist\breeze-watchdog-windows-amd64.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Sign watchdog executable (prerelease profile)
+        if: inputs.signing_env == 'signing-prerelease'
+        uses: azure/artifact-signing-action@db7a3a6bd3912025c705162fb7475389f5b69ec6 # v1
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PRERELEASE }}
+          files: ${{ github.workspace }}\dist\breeze-watchdog-windows-amd64.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Build MSI
+        shell: pwsh
+        env:
+          BUILD_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          $root = $env:GITHUB_WORKSPACE
+          $version = $env:BUILD_VERSION
+          $agentExe = Join-Path $root "dist\breeze-agent-windows-amd64.exe"
+          $backupExe = Join-Path $root "dist\breeze-backup-windows-amd64.exe"
+          $watchdogExe = Join-Path $root "dist\breeze-watchdog-windows-amd64.exe"
+          $msiPath = Join-Path $root "dist\breeze-agent.msi"
+          & (Join-Path $root "agent\installer\build-msi.ps1") -Version $version -AgentExePath $agentExe -BackupExePath $backupExe -WatchdogExePath $watchdogExe -OutputPath $msiPath
+
+      - name: Build Template MSI
+        shell: pwsh
+        env:
+          BUILD_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          $root = $env:GITHUB_WORKSPACE
+          $version = $env:BUILD_VERSION
+          $agentExe = Join-Path $root "dist\breeze-agent-windows-amd64.exe"
+          $backupExe = Join-Path $root "dist\breeze-backup-windows-amd64.exe"
+          $watchdogExe = Join-Path $root "dist\breeze-watchdog-windows-amd64.exe"
+          $msiPath = Join-Path $root "dist\breeze-agent-template.msi"
+          & (Join-Path $root "agent\installer\build-msi.ps1") -Version $version -AgentExePath $agentExe -BackupExePath $backupExe -WatchdogExePath $watchdogExe -OutputPath $msiPath -Template
+
+      # Only sign the regular MSI — template MSI is re-signed server-side by jsign after patching
+      - name: Sign MSI (stable profile)
+        if: inputs.signing_env == 'signing-production'
+        uses: azure/artifact-signing-action@db7a3a6bd3912025c705162fb7475389f5b69ec6 # v1
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PROD }}
+          files: ${{ github.workspace }}\dist\breeze-agent.msi
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Sign MSI (prerelease profile)
+        if: inputs.signing_env == 'signing-prerelease'
+        uses: azure/artifact-signing-action@db7a3a6bd3912025c705162fb7475389f5b69ec6 # v1
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PRERELEASE }}
+          files: ${{ github.workspace }}\dist\breeze-agent.msi
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Verify signatures
+        if: inputs.signing_env != 'none'
+        shell: pwsh
+        run: |
+          $targets = @(
+            (Join-Path $env:GITHUB_WORKSPACE "dist\breeze-agent-windows-amd64.exe"),
+            (Join-Path $env:GITHUB_WORKSPACE "dist\breeze-backup-windows-amd64.exe"),
+            (Join-Path $env:GITHUB_WORKSPACE "dist\breeze-watchdog-windows-amd64.exe"),
+            (Join-Path $env:GITHUB_WORKSPACE "dist\breeze-agent.msi")
+          )
+          foreach ($target in $targets) {
+            $sig = Get-AuthenticodeSignature -FilePath $target
+            # Valid = fully trusted chain; UnknownError = signed but Azure Trusted
+            # Signing root cert not yet in local trust store (normal for new accounts)
+            if ($sig.Status -ne "Valid" -and $sig.Status -ne "UnknownError") {
+              throw "Signature validation failed for $target. Status: $($sig.Status)"
+            }
+            if ($sig.Status -eq "UnknownError") {
+              Write-Host "::warning::$target signed but root cert not yet trusted locally (Status: UnknownError). This is normal for new Azure Trusted Signing accounts."
+            }
+            Write-Host "Verified: $target - Status: $($sig.Status) - Signer: $($sig.SignerCertificate.Subject)"
+          }
+
+      - name: Upload signed Windows EXE artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: breeze-agent-windows-amd64
+          path: dist/breeze-agent-windows-amd64.exe
+          overwrite: true
+          retention-days: 30
+
+      - name: Upload Windows MSI artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: breeze-agent-windows-msi
+          path: dist/breeze-agent.msi
+          retention-days: 30
+
+      - name: Upload Template MSI artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: breeze-agent-template-msi
+          path: dist/breeze-agent-template.msi
+          retention-days: 30
+
+      - name: Upload signed backup EXE artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: breeze-backup-windows-amd64
+          path: dist/breeze-backup-windows-amd64.exe
+          overwrite: true
+          retention-days: 30
+
+      - name: Upload signed watchdog EXE artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: breeze-watchdog-windows-amd64
+          path: dist/breeze-watchdog-windows-amd64.exe
+          overwrite: true
+          retention-days: 30
+
+      - name: Expose artifact name
+        id: expose
+        shell: bash
+        run: echo "name=breeze-agent-windows-msi" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,299 +218,37 @@ jobs:
           path: agent/breeze-desktop-helper-${{ matrix.goos }}-${{ matrix.goarch }}
           retention-days: 30
 
-  build-windows-msi:
-    name: Build + Sign Windows Artifacts
-    if: vars.ENABLE_WINDOWS_SIGNING == 'true'
-    runs-on: windows-latest
-    needs: [build-agent]
-    permissions:
-      contents: read
-      id-token: write
-    environment:
-      name: ${{ contains(github.ref_name, '-') && 'signing-prerelease' || 'signing-production' }}
+  resolve-msi-inputs:
+    name: Resolve MSI Build Inputs
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.compute.outputs.version }}
+      signing_env: ${{ steps.compute.outputs.signing_env }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: agent/go.sum
-
-      - name: Download Go dependencies
-        working-directory: agent
-        shell: pwsh
-        run: go mod download
-
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '8.0.x'
-
-      - name: Install WiX CLI
-        shell: pwsh
-        run: |
-          dotnet tool update --global wix | Out-Null
-          if ($LASTEXITCODE -ne 0) {
-            dotnet tool install --global wix | Out-Null
-          }
-          "$env:USERPROFILE\.dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          wix eula accept wix7
-
-      - name: Get version from tag
-        id: version
-        shell: pwsh
+      - name: Compute version + signing_env from tag
+        id: compute
         env:
           REF_NAME: ${{ github.ref_name }}
         run: |
-          $version = $env:REF_NAME.Substring(1)
-          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          # Strip leading 'v' from tag (release.yml is triggered by tags 'v*')
+          version="${REF_NAME#v}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          if [[ "$version" == *-* ]]; then
+            echo "signing_env=signing-prerelease" >> "$GITHUB_OUTPUT"
+          else
+            echo "signing_env=signing-production" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Build Windows resources and binary
-        shell: pwsh
-        env:
-          BUILD_VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          New-Item -Path dist -ItemType Directory -Force | Out-Null
-          go install github.com/tc-hib/go-winres@v0.3.3
-          Push-Location agent\resources
-          & "$env:USERPROFILE\go\bin\go-winres.exe" make --in winres.json --out ..\cmd\breeze-agent\rsrc_windows_amd64.syso
-          Pop-Location
-          Push-Location agent
-          $env:GOOS = "windows"
-          $env:GOARCH = "amd64"
-          $env:CGO_ENABLED = "0"
-          go build -ldflags="-s -w -X main.version=$env:BUILD_VERSION" -o ..\dist\breeze-agent-windows-amd64.exe .\cmd\breeze-agent
-          Pop-Location
-          # Build breeze-backup
-          Push-Location agent
-          $env:GOOS = "windows"
-          $env:GOARCH = "amd64"
-          $env:CGO_ENABLED = "0"
-          go build -ldflags="-s -w -X main.version=$env:BUILD_VERSION" -o ..\dist\breeze-backup-windows-amd64.exe .\cmd\breeze-backup
-          Pop-Location
-          # Build breeze-watchdog
-          Push-Location agent
-          $env:GOOS = "windows"
-          $env:GOARCH = "amd64"
-          $env:CGO_ENABLED = "0"
-          go build -ldflags="-s -w -X main.version=$env:BUILD_VERSION" -o ..\dist\breeze-watchdog-windows-amd64.exe .\cmd\breeze-watchdog
-          Pop-Location
-
-      - name: Validate signing configuration
-        shell: pwsh
-        env:
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_SIGNING_ENDPOINT: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          AZURE_SIGNING_ACCOUNT_NAME: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          AZURE_CERT_PROFILE_PROD: ${{ secrets.AZURE_CERT_PROFILE_PROD }}
-          AZURE_CERT_PROFILE_PRERELEASE: ${{ secrets.AZURE_CERT_PROFILE_PRERELEASE }}
-        run: |
-          $required = @("AZURE_CLIENT_ID", "AZURE_TENANT_ID", "AZURE_SIGNING_ENDPOINT", "AZURE_SIGNING_ACCOUNT_NAME")
-          foreach ($name in $required) {
-            if ([string]::IsNullOrWhiteSpace((Get-Item "env:$name").Value)) {
-              throw "Missing required signing secret: $name"
-            }
-          }
-
-          $isPrerelease = "${{ contains(github.ref_name, '-') }}" -eq "true"
-          if ($isPrerelease) {
-            if ([string]::IsNullOrWhiteSpace($env:AZURE_CERT_PROFILE_PRERELEASE)) {
-              throw "Missing required signing secret: AZURE_CERT_PROFILE_PRERELEASE"
-            }
-          } else {
-            if ([string]::IsNullOrWhiteSpace($env:AZURE_CERT_PROFILE_PROD)) {
-              throw "Missing required signing secret: AZURE_CERT_PROFILE_PROD"
-            }
-          }
-
-      - name: Azure Login (OIDC)
-        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          allow-no-subscriptions: true
-
-      - name: Sign Windows EXE (stable profile)
-        if: ${{ !contains(github.ref_name, '-') }}
-        uses: azure/artifact-signing-action@db7a3a6bd3912025c705162fb7475389f5b69ec6 # v1
-        with:
-          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PROD }}
-          files: ${{ github.workspace }}\dist\breeze-agent-windows-amd64.exe
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-
-      - name: Sign Windows EXE (prerelease profile)
-        if: ${{ contains(github.ref_name, '-') }}
-        uses: azure/artifact-signing-action@db7a3a6bd3912025c705162fb7475389f5b69ec6 # v1
-        with:
-          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PRERELEASE }}
-          files: ${{ github.workspace }}\dist\breeze-agent-windows-amd64.exe
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-
-      - name: Sign backup EXE (stable profile)
-        if: ${{ !contains(github.ref_name, '-') }}
-        uses: azure/artifact-signing-action@db7a3a6bd3912025c705162fb7475389f5b69ec6 # v1
-        with:
-          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PROD }}
-          files: ${{ github.workspace }}\dist\breeze-backup-windows-amd64.exe
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-
-      - name: Sign backup EXE (prerelease profile)
-        if: ${{ contains(github.ref_name, '-') }}
-        uses: azure/artifact-signing-action@db7a3a6bd3912025c705162fb7475389f5b69ec6 # v1
-        with:
-          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PRERELEASE }}
-          files: ${{ github.workspace }}\dist\breeze-backup-windows-amd64.exe
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-
-      - name: Sign watchdog executable (stable profile)
-        if: ${{ !contains(github.ref_name, '-') }}
-        uses: azure/artifact-signing-action@db7a3a6bd3912025c705162fb7475389f5b69ec6 # v1
-        with:
-          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PROD }}
-          files: ${{ github.workspace }}\dist\breeze-watchdog-windows-amd64.exe
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-
-      - name: Sign watchdog executable (prerelease profile)
-        if: ${{ contains(github.ref_name, '-') }}
-        uses: azure/artifact-signing-action@db7a3a6bd3912025c705162fb7475389f5b69ec6 # v1
-        with:
-          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PRERELEASE }}
-          files: ${{ github.workspace }}\dist\breeze-watchdog-windows-amd64.exe
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-
-      - name: Build MSI
-        shell: pwsh
-        run: |
-          $root = $env:GITHUB_WORKSPACE
-          $version = "${{ steps.version.outputs.version }}"
-          $agentExe = Join-Path $root "dist\breeze-agent-windows-amd64.exe"
-          $backupExe = Join-Path $root "dist\breeze-backup-windows-amd64.exe"
-          $watchdogExe = Join-Path $root "dist\breeze-watchdog-windows-amd64.exe"
-          $msiPath = Join-Path $root "dist\breeze-agent.msi"
-          & (Join-Path $root "agent\installer\build-msi.ps1") -Version $version -AgentExePath $agentExe -BackupExePath $backupExe -WatchdogExePath $watchdogExe -OutputPath $msiPath
-
-      - name: Build Template MSI
-        shell: pwsh
-        run: |
-          $root = $env:GITHUB_WORKSPACE
-          $version = "${{ steps.version.outputs.version }}"
-          $agentExe = Join-Path $root "dist\breeze-agent-windows-amd64.exe"
-          $backupExe = Join-Path $root "dist\breeze-backup-windows-amd64.exe"
-          $watchdogExe = Join-Path $root "dist\breeze-watchdog-windows-amd64.exe"
-          $msiPath = Join-Path $root "dist\breeze-agent-template.msi"
-          & (Join-Path $root "agent\installer\build-msi.ps1") -Version $version -AgentExePath $agentExe -BackupExePath $backupExe -WatchdogExePath $watchdogExe -OutputPath $msiPath -Template
-
-      # Only sign the regular MSI — template MSI is re-signed server-side by jsign after patching
-      - name: Sign MSI (stable profile)
-        if: ${{ !contains(github.ref_name, '-') }}
-        uses: azure/artifact-signing-action@db7a3a6bd3912025c705162fb7475389f5b69ec6 # v1
-        with:
-          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PROD }}
-          files: ${{ github.workspace }}\dist\breeze-agent.msi
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-
-      - name: Sign MSI (prerelease profile)
-        if: ${{ contains(github.ref_name, '-') }}
-        uses: azure/artifact-signing-action@db7a3a6bd3912025c705162fb7475389f5b69ec6 # v1
-        with:
-          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PRERELEASE }}
-          files: ${{ github.workspace }}\dist\breeze-agent.msi
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-
-      - name: Verify signatures
-        shell: pwsh
-        run: |
-          $targets = @(
-            (Join-Path $env:GITHUB_WORKSPACE "dist\breeze-agent-windows-amd64.exe"),
-            (Join-Path $env:GITHUB_WORKSPACE "dist\breeze-backup-windows-amd64.exe"),
-            (Join-Path $env:GITHUB_WORKSPACE "dist\breeze-watchdog-windows-amd64.exe"),
-            (Join-Path $env:GITHUB_WORKSPACE "dist\breeze-agent.msi")
-          )
-          foreach ($target in $targets) {
-            $sig = Get-AuthenticodeSignature -FilePath $target
-            # Valid = fully trusted chain; UnknownError = signed but Azure Trusted
-            # Signing root cert not yet in local trust store (normal for new accounts)
-            if ($sig.Status -ne "Valid" -and $sig.Status -ne "UnknownError") {
-              throw "Signature validation failed for $target. Status: $($sig.Status)"
-            }
-            if ($sig.Status -eq "UnknownError") {
-              Write-Host "::warning::$target signed but root cert not yet trusted locally (Status: UnknownError). This is normal for new Azure Trusted Signing accounts."
-            }
-            Write-Host "Verified: $target - Status: $($sig.Status) - Signer: $($sig.SignerCertificate.Subject)"
-          }
-
-      - name: Upload signed Windows EXE artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: breeze-agent-windows-amd64
-          path: dist/breeze-agent-windows-amd64.exe
-          overwrite: true
-          retention-days: 30
-
-      - name: Upload Windows MSI artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: breeze-agent-windows-msi
-          path: dist/breeze-agent.msi
-          retention-days: 30
-
-      - name: Upload Template MSI artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: breeze-agent-template-msi
-          path: dist/breeze-agent-template.msi
-          retention-days: 30
-
-      - name: Upload signed backup EXE artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: breeze-backup-windows-amd64
-          path: dist/breeze-backup-windows-amd64.exe
-          overwrite: true
-          retention-days: 30
-
-      - name: Upload signed watchdog EXE artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: breeze-watchdog-windows-amd64
-          path: dist/breeze-watchdog-windows-amd64.exe
-          overwrite: true
-          retention-days: 30
+  build-windows-msi:
+    name: Build + Sign Windows Artifacts
+    needs: [build-agent, resolve-msi-inputs]
+    uses: ./.github/workflows/build-msi-reusable.yml
+    with:
+      ref: ${{ github.ref }}
+      version: ${{ needs.resolve-msi-inputs.outputs.version }}
+      signing_env: ${{ needs.resolve-msi-inputs.outputs.signing_env }}
+      go_version: '1.25.9'
+    secrets: inherit
 
   build-macos-agent:
     name: Sign macOS Agent Binary

--- a/.github/workflows/test-msi.yml
+++ b/.github/workflows/test-msi.yml
@@ -1,0 +1,113 @@
+name: Test MSI (manual build)
+
+# Manually-dispatched workflow that builds an optionally-signed Windows MSI from
+# any branch or commit, without cutting a real release. Useful for smoke-testing
+# installer changes (e.g. PR-#410-class agent enrollment changes) on a Windows
+# VM before tagging.
+#
+# The version is stamped as "{base}-test.{run_id}" so it can never collide with
+# a tagged release. The MSI is uploaded as a workflow artifact (90-day retention),
+# not as a GitHub Release.
+#
+# See: https://github.com/LanternOps/breeze/issues/412
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref (branch, SHA, or tag) to build from'
+        required: true
+        type: string
+        default: 'main'
+      signing_env:
+        description: 'Signing environment (gates Azure Trusted Signing creds via GitHub Environment approval)'
+        required: true
+        type: choice
+        options:
+          - signing-prerelease
+          - signing-production
+          - none
+        default: signing-prerelease
+
+jobs:
+  resolve-version:
+    name: Resolve test version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.compute.outputs.version }}
+    steps:
+      - name: Checkout (for git describe)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Compute "{base}-test.{run_id}" version
+        id: compute
+        env:
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          # Find the most recent vN.N.N tag reachable from the chosen ref;
+          # fall back to 0.0.0 if the repo has no tags yet.
+          base=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "v0.0.0")
+          base="${base#v}"
+          # Strip any prerelease suffix on the base tag — we want a clean
+          # core version to attach our own "-test.<run>" suffix to.
+          base="${base%%-*}"
+          version="${base}-test.${RUN_ID}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Computed test version: ${version}"
+
+  build:
+    name: Build + (optionally) sign MSI
+    needs: [resolve-version]
+    uses: ./.github/workflows/build-msi-reusable.yml
+    with:
+      ref: ${{ inputs.ref }}
+      version: ${{ needs.resolve-version.outputs.version }}
+      signing_env: ${{ inputs.signing_env }}
+    secrets: inherit
+
+  publish-artifact:
+    name: Re-upload MSI with 90-day retention
+    needs: [build, resolve-version]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download MSI from reusable build
+        uses: actions/download-artifact@v8
+        with:
+          name: breeze-agent-windows-msi
+          path: msi/
+
+      - name: Rename MSI with version stamp
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p out
+          mv "msi/breeze-agent.msi" "out/breeze-agent-${VERSION}.msi"
+          ls -la out/
+
+      - name: Upload versioned MSI (90-day retention)
+        uses: actions/upload-artifact@v7
+        with:
+          name: breeze-agent-test-msi
+          path: out/*.msi
+          retention-days: 90
+
+      - name: Summary
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+          REF: ${{ inputs.ref }}
+          SIGNING_ENV: ${{ inputs.signing_env }}
+        run: |
+          {
+            echo "## Test MSI built"
+            echo ""
+            echo "- ref: \`${REF}\`"
+            echo "- version: \`${VERSION}\`"
+            echo "- signing: \`${SIGNING_ENV}\`"
+            echo ""
+            echo "Download from the **breeze-agent-test-msi** artifact on this run."
+            echo "This run did **not** create a GitHub Release."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- New `.github/workflows/build-msi-reusable.yml` (`workflow_call`): builds breeze-agent / breeze-backup / breeze-watchdog (windows/amd64), runs `installer/build-msi.ps1`, optionally signs each EXE + the MSI via Azure Trusted Signing. Inputs: `ref`, `version`, `signing_env`, `go_version`. Output: `msi_artifact_name`.
- New `.github/workflows/test-msi.yml` (`workflow_dispatch`): inputs `ref` + `signing_env` (`signing-prerelease | signing-production | none`). Computes `{base}-test.{run_id}` from `git describe --tags` so it can never collide with a real release. Uploads `breeze-agent-test-msi` with 90-day retention. No GH release.
- `release.yml` — replaced ~280 lines of inline `build-windows-msi` with a small `resolve-msi-inputs` helper job + a `uses:` call to the reusable workflow. Behavior preserved verbatim: same runner, same Azure OIDC + pinned signing-action SHA, same prerelease-vs-production cert-profile branching (now keyed off `inputs.signing_env`), same `vars.ENABLE_WINDOWS_SIGNING` gate, same artifact names + retention, same downstream `needs:` references.

Closes #412

## Test plan
- [ ] Dispatch `test-msi.yml` from this branch with `signing_env: none` — verify MSI artifact is produced and labelled `{base}-test.{run_id}`
- [ ] Dispatch `test-msi.yml` with `signing_env: signing-prerelease` — verify environment-protection-rule reviewer prompt fires before signing creds load
- [ ] Cut a no-op release (or dry-run via `act`) to confirm `release.yml` still produces identical artifacts to current main
- [ ] Confirm `signing-prerelease` and `signing-production` GitHub Environments exist with appropriate reviewers (couldn't verify from source — see issue body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)