### PR TITLE
e2e: seed test fixtures for fresh-DB runs

### DIFF
--- a/e2e-tests/run.ts
+++ b/e2e-tests/run.ts
@@ -17,7 +17,7 @@ import dotenv from 'dotenv';
 import type { Config, Test, TestFile, TestResult, CLIOptions, RunnerContext, UiSession } from './src/types.js';
 import { isRecord, resolveEnvString } from './src/utils.js';
 import { closeUiSession, cleanupBrowser } from './src/browser.js';
-import { runUiStepLive, runRemoteStepLive, runApiStepLive, runUiStepSimulated, runRemoteStepSimulated, runApiStepSimulated } from './src/steps.js';
+import { runUiStepLive, runRemoteStepLive, runApiStepLive, runUiStepSimulated, runRemoteStepSimulated, runApiStepSimulated, runSeedStepLive, runSeedStepSimulated } from './src/steps.js';
 import { TestTracker } from './src/tracker.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -361,6 +361,17 @@ async function runTest(test: Test): Promise<TestResult> {
             const apiPath = step.request?.path ?? '';
             console.log(`     [API] ${apiMethod} ${apiPath}`);
             stepOutput = await runApiStepLive(step, context, config, options);
+
+            if (options.verbose) {
+              console.log(`     Result: ${JSON.stringify(stepOutput, null, 2)}`);
+            }
+          }
+        } else if (step.action === 'seed') {
+          if (options.mode === 'simulate') {
+            stepOutput = runSeedStepSimulated(step, context, options);
+          } else {
+            console.log(`     [SEED] Loading fixtures from ${step.seed?.sqlFile ?? 'seed-fixtures.sql'}`);
+            stepOutput = await runSeedStepLive(step, context, config);
 
             if (options.verbose) {
               console.log(`     Result: ${JSON.stringify(stepOutput, null, 2)}`);

--- a/e2e-tests/src/steps.ts
+++ b/e2e-tests/src/steps.ts
@@ -1,6 +1,13 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { fileURLToPath } from 'url';
 import type { Config, TestStep, RunnerContext, UiSession, CLIOptions, JsonRpcResponse } from './types.js';
 import { isRecord, resolveEnvString, resolveTemplates, interpolateTemplate, extractStructuredResult, assertExpectations, lookupVar, asNumber, normalizeUrl } from './utils.js';
 import { ensureUiSession, runUiPlaywrightAction, isLoginStep, captureSimulatedExtracts, cachedStorageState, cachedApiToken, setCachedApiToken } from './browser.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const E2E_DIR = path.resolve(path.dirname(__filename), '..');
 
 function buildNodeBaseUrl(host: string, port: number): string {
   const normalizedHost = host.startsWith('http://') || host.startsWith('https://') ? host : `http://${host}`;
@@ -380,4 +387,65 @@ export function runApiStepSimulated(step: TestStep, context: RunnerContext, opti
     console.log(`     Request: ${JSON.stringify(resolveTemplates(step.request, context.vars), null, 2)}`);
   }
   return { simulated: true };
+}
+
+// --- Seed step (idempotent SQL fixtures via docker exec psql) ---
+
+export async function runSeedStepLive(step: TestStep, _context: RunnerContext, _config: Config): Promise<Record<string, unknown>> {
+  const sqlFileRel = step.seed?.sqlFile ?? 'seed-fixtures.sql';
+  const container = step.seed?.container ?? 'breeze-postgres';
+  const database = step.seed?.database ?? process.env.POSTGRES_DB ?? 'breeze';
+  const dbUser = step.seed?.user ?? process.env.POSTGRES_USER ?? 'breeze';
+
+  const sqlPath = path.isAbsolute(sqlFileRel) ? sqlFileRel : path.join(E2E_DIR, sqlFileRel);
+  if (!fs.existsSync(sqlPath)) {
+    throw new Error(`Seed file not found: ${sqlPath}`);
+  }
+
+  const sql = fs.readFileSync(sqlPath, 'utf-8');
+
+  // docker exec -i <container> psql -U <user> -d <database> -v ON_ERROR_STOP=1 -f -
+  const args = [
+    'exec', '-i', container,
+    'psql', '-U', dbUser, '-d', database,
+    '-v', 'ON_ERROR_STOP=1',
+    '-q',
+    '-f', '-',
+  ];
+
+  try {
+    const stdout = execFileSync('docker', args, {
+      input: sql,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: step.timeout ?? 60000,
+    });
+    const output = stdout.toString().trim();
+    if (output) {
+      for (const line of output.split('\n')) {
+        console.log(`     [SEED] ${line}`);
+      }
+    }
+    return { seeded: true, file: sqlFileRel };
+  } catch (error: any) {
+    const stderr = error?.stderr?.toString?.() ?? '';
+    const stdout = error?.stdout?.toString?.() ?? '';
+    const detail = [stdout, stderr].filter(Boolean).join('\n').trim();
+
+    // Container missing or docker not running → treat as non-fatal so the
+    // bootstrap step doesn't block runs against remote/non-docker deployments.
+    // The downstream tests will fail naturally if the data really isn't there.
+    const benign = /No such container|Cannot connect to the Docker daemon|Is the docker daemon running/i.test(detail);
+    if (benign) {
+      console.log(`     [SEED] Skipping — local docker postgres not available (${detail.split('\n')[0] || 'no detail'})`);
+      return { seeded: false, skipped: true, reason: 'docker-unavailable' };
+    }
+
+    throw new Error(`Seed failed running ${sqlFileRel}: ${detail || error.message}`);
+  }
+}
+
+export function runSeedStepSimulated(step: TestStep, _context: RunnerContext, _options: CLIOptions): Record<string, unknown> {
+  const sqlFile = step.seed?.sqlFile ?? 'seed-fixtures.sql';
+  console.log(`     [SEED] Simulated psql -f ${sqlFile}`);
+  return { simulated: true, seeded: false };
 }

--- a/e2e-tests/src/types.ts
+++ b/e2e-tests/src/types.ts
@@ -1,6 +1,6 @@
 export interface TestStep {
   id: string;
-  action: 'ui' | 'remote' | 'api';
+  action: 'ui' | 'remote' | 'api' | 'seed';
   description?: string;
   node?: string;
   tool?: string;
@@ -11,6 +11,17 @@ export interface TestStep {
     path: string;
     query?: Record<string, string>;
     body?: Record<string, unknown>;
+  };
+  /**
+   * For `seed` action steps. Runs a SQL fixture file against local Postgres via
+   * `docker exec breeze-postgres psql`. Path is resolved relative to the
+   * `e2e-tests/` directory. The fixture must be idempotent.
+   */
+  seed?: {
+    sqlFile?: string;
+    container?: string;
+    database?: string;
+    user?: string;
   };
   /** Per-step auth override. Set `'none'` to skip the default Bearer token injection on `api` steps. */
   auth?: 'none' | 'bearer';

--- a/e2e-tests/tests/0000-seed-fixtures.yaml
+++ b/e2e-tests/tests/0000-seed-fixtures.yaml
@@ -1,0 +1,107 @@
+# E2E Bootstrap — seed test fixtures for fresh-DB runs
+#
+# Sorts FIRST in the run order (0000- prefix) so every other test in the
+# suite finds the data it expects. Tracks issue #518.
+#
+# What it does:
+#   1. Verifies the database has the default org/site/admin (autoMigrate seed).
+#   2. Runs e2e-tests/seed-fixtures.sql via `docker exec breeze-postgres psql`
+#      to insert the minimum fixtures the rest of the suite assumes:
+#        - 2 devices matching E2E_MACOS_DEVICE_ID and E2E_WINDOWS_DEVICE_ID
+#        - device_groups, alerts (medium + critical), audit log entry
+#        - device_software, browser_extensions
+#        - cis_baselines + results, backup_configs + jobs (success + failed)
+#        - patches + device_patches (Windows + macOS)
+#   3. Confirms via the API that devices and alerts now exist.
+#
+# Idempotent: the SQL uses `ON CONFLICT DO NOTHING` / `WHERE NOT EXISTS` /
+# `IF NOT EXISTS` everywhere, so re-running against a populated DB is a
+# no-op. Re-running against a non-docker / remote deployment also no-ops:
+# the seed step detects "docker not available" and continues.
+#
+# Why SQL instead of API: most fixture tables (devices, alerts,
+# audit_logs) have no admin POST endpoint — they are agent-write or
+# system-internal. Creating the data via psql is the only reliable path
+# without standing up a real agent fleet. RLS / business validation are
+# NOT exercised here, but that's appropriate for fixture setup.
+
+tests:
+  - id: bootstrap_seed_fixtures
+    name: "Bootstrap: seed E2E test fixtures"
+    description: >
+      Idempotent fresh-DB bootstrap. Loads seed-fixtures.sql via
+      `docker exec breeze-postgres psql` and then verifies the API
+      sees the seeded devices and alerts.
+    tags: [bootstrap, fixture, critical]
+    nodes: [linux, windows, macos]
+    timeout: 60000
+    steps:
+      # ── Step 1: Login (so subsequent API steps reuse the JWT) ──
+      - id: login
+        action: ui
+        description: "Login with admin credentials"
+        playwright:
+          - goto: "/login"
+          - waitFor: "text=Sign in"
+            timeout: 10000
+          - fill:
+              "[name='email']": "${TEST_USER_EMAIL}"
+              "[name='password']": "${TEST_USER_PASSWORD}"
+          - click: "button[type='submit']"
+          - waitFor:
+              url: "**/"
+              timeout: 15000
+          - waitFor: "h1:has-text('Welcome')"
+            timeout: 15000
+
+      # ── Step 2: Quick existence check — skip seed if already populated ──
+      # Optional: if this passes (fixture devices already there), the seed
+      # step below is still safe to run (it's a no-op), but logging the
+      # check makes diagnosis easier when fixtures are missing.
+      - id: precheck_macos_device
+        action: api
+        description: "Check whether the macOS fixture device already exists"
+        optional: true
+        request:
+          method: GET
+          path: "/api/v1/devices/{{devices.macos}}"
+
+      # ── Step 3: Run the SQL fixture loader (idempotent) ────────
+      - id: seed_fixtures
+        action: seed
+        description: "Apply seed-fixtures.sql via docker exec breeze-postgres psql"
+        seed:
+          sqlFile: "seed-fixtures.sql"
+          container: "breeze-postgres"
+          database: "breeze"
+          user: "breeze"
+
+      # ── Step 4: Verify the macOS fixture device is now visible ──
+      - id: verify_macos_device
+        action: api
+        description: "Verify macOS fixture device is reachable via API"
+        request:
+          method: GET
+          path: "/api/v1/devices/{{devices.macos}}"
+        expect:
+          osType: macos
+
+      # ── Step 5: Verify the Windows fixture device is now visible ──
+      - id: verify_windows_device
+        action: api
+        description: "Verify Windows fixture device is reachable via API"
+        request:
+          method: GET
+          path: "/api/v1/devices/{{devices.windows}}"
+        expect:
+          osType: windows
+
+      # ── Step 6: Verify alerts list has at least one row ────────
+      - id: verify_alerts_seeded
+        action: api
+        description: "Verify alerts table has fixture rows"
+        request:
+          method: GET
+          path: "/api/v1/alerts"
+          query:
+            limit: "10"


### PR DESCRIPTION
## Summary
- New `e2e-tests/tests/0000-seed-fixtures.yaml` (6-step bootstrap, tagged `[bootstrap, fixture, critical]`, `0000-` prefix sorts first): login, precheck, seed, verify-macOS, verify-Windows, verify-alerts.
- New `seed` action in the runner — `runSeedStepLive` pipes SQL into `docker exec breeze-postgres psql`; self-skips on docker unavailability so remote/CI runs don't break.
- `runSeedStepSimulated` for `--mode simulate`. `TestStep.action` union extended.

**Approach deviation worth flagging:** the issue's preferred YAML-first plan (POST partner/org/site/devices/alerts via API) isn't viable — devices, alerts, and audit_logs have no admin create endpoints (agent-write or system-internal), and orgs/sites/partners are MFA-gated. The pre-existing `e2e-tests/seed-fixtures.sql` already covers all required fixtures and is idempotent (`ON CONFLICT` / `WHERE NOT EXISTS` / `IF NOT EXISTS` everywhere). The new `seed` action wraps it cleanly.

Closes #518

## Test plan
- [x] `--mode simulate --test bootstrap_seed_fixtures` passes
- [x] `--mode live` against local docker — seed runs, fixture-table counts unchanged on second run (idempotent)
- [x] Dry-run shows `bootstrap_seed_fixtures` first in test plan (227 tests total)
- [ ] Run full suite end-to-end against a fresh DB — couldn't verify locally because the dev-DB admin password didn't match `.env`. Ideally: `docker compose down -v && docker compose up -d && sleep 30 && cd e2e-tests && npx tsx run.ts --mode live` should now complete without "Device not found" or empty-table timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)