### PR TITLE
fix(api): narrow possibly-undefined binary in installerAppZip test

### DIFF
--- a/apps/api/src/services/installerAppZip.test.ts
+++ b/apps/api/src/services/installerAppZip.test.ts
@@ -86,7 +86,7 @@ describe('renameAppInZip', () => {
       const entries = await z.entries();
       const binary = entries['Breeze Installer [PERMS01@host.local].app/Contents/MacOS/BreezeInstaller'];
       expect(binary, 'BreezeInstaller entry must exist').toBeTruthy();
-      const binaryMode = (binary.attr >>> 16) & 0o777;
+      const binaryMode = (binary!.attr >>> 16) & 0o777;
       expect(binaryMode & 0o100, 'BreezeInstaller must remain executable (owner-x bit)').not.toBe(0);
       await z.close();
     } finally {


### PR DESCRIPTION
## Summary

Pre-existing TS18048 error in `apps/api/src/services/installerAppZip.test.ts:89` has been blocking the Type Check job on every PR.

`StreamZip`'s `entries()` returns a record where indexed access yields `T | undefined` under `strictNullChecks`. The test already asserts `expect(binary, '...').toBeTruthy()` on the line above, but TS doesn't carry that narrowing forward. One-character fix: assert non-null at the use site.

## Change

```ts
- const binaryMode = (binary.attr >>> 16) & 0o777;
+ const binaryMode = (binary!.attr >>> 16) & 0o777;
```

Test logic is unchanged.

## Verification

- `cd apps/api && npx tsc --noEmit` -> 0 errors (was 1)
- `npx vitest run src/services/installerAppZip.test.ts` -> 4/4 passing