### PR TITLE
fix(api): use getTrustedClientIp for remote session/transfer audit logs

### DIFF
--- a/apps/api/src/routes/remote/sessions.ts
+++ b/apps/api/src/routes/remote/sessions.ts
@@ -13,6 +13,7 @@ import { requireScope } from '../../middleware/auth';
 import { sendCommandToAgent } from '../agentWs';
 import { checkRemoteAccess } from '../../services/remoteAccessPolicy';
 import { createDesktopConnectCode, createWsTicket } from '../../services/remoteSessionAuth';
+import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
 import {
   createSessionSchema,
   listSessionsSchema,
@@ -199,7 +200,7 @@ sessionRoutes.post(
         deviceHostname: device.hostname,
         type: data.type
       },
-      c.req.header('X-Forwarded-For') || c.req.header('X-Real-IP')
+      getTrustedClientIpOrUndefined(c)
     );
 
     return c.json({
@@ -680,7 +681,7 @@ sessionRoutes.post(
       auth.user.id,
       device.orgId,
       { sessionId, type: session.type },
-      c.req.header('X-Forwarded-For') || c.req.header('X-Real-IP')
+      getTrustedClientIpOrUndefined(c)
     );
 
     // Send start_desktop command to agent with the offer and ICE servers
@@ -777,7 +778,7 @@ sessionRoutes.post(
       auth.user.id,
       device.orgId,
       { sessionId, type: session.type },
-      c.req.header('X-Forwarded-For') || c.req.header('X-Real-IP')
+      getTrustedClientIpOrUndefined(c)
     );
 
     return c.json({
@@ -904,7 +905,7 @@ sessionRoutes.post(
         type: session.type,
         durationSeconds
       },
-      c.req.header('X-Forwarded-For') || c.req.header('X-Real-IP')
+      getTrustedClientIpOrUndefined(c)
     );
 
     return c.json({

--- a/apps/api/src/routes/remote/transfers.ts
+++ b/apps/api/src/routes/remote/transfers.ts
@@ -10,6 +10,7 @@ import {
 } from '../../db/schema';
 import { requireScope } from '../../middleware/auth';
 import { saveChunk, assembleChunks, getFileStream, getFileSize, hasAssembledFile, getTotalBytesReceived, MAX_TRANSFER_SIZE_BYTES } from '../../services/fileStorage';
+import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
 import { Readable } from 'stream';
 import { createTransferSchema, listTransfersSchema } from './schemas';
 import {
@@ -136,7 +137,7 @@ transferRoutes.post(
         localFilename: data.localFilename,
         sizeBytes: data.sizeBytes
       },
-      c.req.header('X-Forwarded-For') || c.req.header('X-Real-IP')
+      getTrustedClientIpOrUndefined(c)
     );
 
     return c.json({
@@ -367,7 +368,7 @@ transferRoutes.post(
         direction: transfer.direction,
         remotePath: transfer.remotePath
       },
-      c.req.header('X-Forwarded-For') || c.req.header('X-Real-IP')
+      getTrustedClientIpOrUndefined(c)
     );
 
     return c.json({


### PR DESCRIPTION
## Summary

Migrates the 6 remaining audit-log call sites in `apps/api/src/routes/remote/sessions.ts` and `apps/api/src/routes/remote/transfers.ts` from raw `X-Forwarded-For` reads to `getTrustedClientIpOrUndefined()`.

Behind Cloudflare + Caddy, the raw header is a comma-separated list that overflows the `audit_logs.ip_address varchar(45)` column and triggers \"value too long\" errors on insert. Using the trusted-IP helper yields the single canonical client IP, matching the migration in #524.

## Test plan
- [ ] `pnpm test --filter=@breeze/api` passes
- [ ] Trigger a remote session start and a file transfer; confirm new `audit_logs` rows have a single sane IP (not a comma list)