### PR TITLE
fix(api): coerce retention cutoff Date to ISO string for postgres-js

### DIFF
--- a/apps/api/src/jobs/ipHistoryRetention.ts
+++ b/apps/api/src/jobs/ipHistoryRetention.ts
@@ -44,7 +44,8 @@ export function createIPHistoryRetentionWorker(): Worker<RetentionJobData> {
       return runWithSystemDbAccess(async () => {
         const startTime = Date.now();
         const retentionDays = Math.max(1, job.data.retentionDays ?? DEFAULT_RETENTION_DAYS);
-        const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+        // postgres-js does not coerce JS Date in template-literal params; pass an ISO string.
+        const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000).toISOString();
 
         const result = await db.execute(sql`
           DELETE FROM device_ip_history

--- a/apps/api/src/jobs/userRiskRetention.ts
+++ b/apps/api/src/jobs/userRiskRetention.ts
@@ -55,7 +55,8 @@ export function createUserRiskRetentionWorker(): Worker<RetentionJobData> {
     async (job: Job<RetentionJobData>) => {
       return runWithSystemDbAccess(async () => {
         const retentionDays = Math.max(30, job.data.retentionDays ?? DEFAULT_RETENTION_DAYS);
-        const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+        // postgres-js does not coerce JS Date in template-literal params; pass an ISO string.
+        const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000).toISOString();
         const start = Date.now();
 
         const result = await db.execute(sql`


### PR DESCRIPTION
## Summary
- Both `UserRiskRetention` and `IPHistoryRetention` BullMQ workers have been failing on every scheduled run in prod (US and EU) with `TypeError: The "string" argument must be of type string or an instance of Buffer or ArrayBuffer. Received an instance of Date`.
- Root cause: a JS `Date` interpolated into a `drizzle-orm` `sql` template is sent as a bind parameter through `postgres-js`, which does not implicitly stringify `Date` in that path.
- Fix: pass `cutoff.toISOString()` instead of the `Date` object. Postgres accepts ISO 8601 for both `timestamp` and `timestamptz`, and `cutoff` is computed in UTC so no timezone ambiguity.
- Other retention jobs in `apps/api/src/jobs/` (`changeLogRetention`, `snmpRetention`, `reliabilityRetention`, `agentLogRetention`, `eventLogRetention`, `playbookRetention`) use the Drizzle query builder (`lt(col, cutoff)`) which routes through the column type mapper and coerces `Date` correctly — they are unaffected.

## Impact
- Retention has not been running successfully in prod, so `user_risk_scores` and `device_ip_history` (inactive rows) have been growing unbounded since these workers shipped.
- After this lands, the next scheduled run will compact / prune the backlog.

## Test plan
- [ ] CI: API unit + integration tests green
- [ ] After deploy, confirm next scheduled run logs `[UserRiskRetention] Compacted user risk snapshots…` and `[IPHistoryRetention] Pruned N inactive rows…` instead of the `TypeError`
- [ ] Spot-check `user_risk_scores` row count drops on US (was the noisier of the two)

🤖 Generated with [Claude Code](https://claude.com/claude-code)