### PR TITLE
fix(agent): user-helper defaults to --role user (not system)

### DIFF
--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -216,7 +216,7 @@ func init() {
 	enrollCmd.Flags().StringVar(&enrollDeviceRole, "device-role", "", "Device role override (e.g. workstation, server)")
 	enrollCmd.Flags().BoolVar(&forceEnroll, "force", false, "Re-enroll even if already enrolled; replaces AgentID/AuthToken on success (no-op on failure)")
 	enrollCmd.Flags().BoolVar(&quietEnroll, "quiet", false, "Suppress stdout progress output (errors still go to stderr). Intended for unattended installs.")
-	userHelperCmd.Flags().StringVar(&helperRole, "role", "system", "Helper role: 'system' (desktop capture) or 'user' (script execution)")
+	userHelperCmd.Flags().StringVar(&helperRole, "role", "user", "Helper role: 'system' (desktop capture) or 'user' (script execution)")
 	desktopHelperCmd.Flags().StringVar(&desktopContext, "context", ipc.DesktopContextUserSession, "Desktop context: 'user_session' or 'login_window'")
 
 	rootCmd.AddCommand(startCmd)

--- a/agent/cmd/breeze-agent/main_test.go
+++ b/agent/cmd/breeze-agent/main_test.go
@@ -531,6 +531,25 @@ func TestWaitForEnrollment_IgnoresTornWrite(t *testing.T) {
 	}
 }
 
+// TestUserHelperRoleDefault locks in the cobra default for `breeze-agent
+// user-helper --role`. The Windows AgentUserHelper Scheduled Task invokes
+// `breeze-agent user-helper` (historically with no flags) under
+// BUILTIN\Users at LeastPrivilege, so the default must be "user". The
+// previous "system" default caused the helper to claim HelperRoleSystem,
+// which the sessionbroker correctly rejected with "system role requires
+// SYSTEM identity", crash-looping every Windows customer on 0.63.x/0.64.x.
+// The legitimate desktop-capture path uses the separate `desktop-helper`
+// cobra command and hardcodes ipc.HelperRoleSystem in runDesktopHelper().
+func TestUserHelperRoleDefault(t *testing.T) {
+	roleFlag := userHelperCmd.Flags().Lookup("role")
+	if roleFlag == nil {
+		t.Fatal("role flag not registered on userHelperCmd")
+	}
+	if roleFlag.DefValue != "user" {
+		t.Errorf("user-helper --role default = %q, want %q (system role requires SYSTEM identity; user-mode helpers must default to user)", roleFlag.DefValue, "user")
+	}
+}
+
 // TestAssertHostnameNonEmpty guards the #439 contract at the enroll
 // boundary: enrollment must refuse to proceed with an empty or
 // whitespace-only hostname. This is the last line of defense against a

--- a/agent/service/windows/breeze-agent-user-task.xml
+++ b/agent/service/windows/breeze-agent-user-task.xml
@@ -37,7 +37,7 @@
   <Actions Context="Author">
     <Exec>
       <Command>"C:\Program Files\Breeze\breeze-agent.exe"</Command>
-      <Arguments>user-helper</Arguments>
+      <Arguments>user-helper --role user</Arguments>
     </Exec>
   </Actions>
 </Task>


### PR DESCRIPTION
## Summary

- Fixes a live customer-impacting bug on agent versions 0.63.5 and 0.64.1: Windows agents on tenants like nexusitsys and Revenant Global are crash-looping with `auth_rejected` and reason `system role requires SYSTEM identity`.
- The Windows `\Breeze\AgentUserHelper` Scheduled Task runs `breeze-agent user-helper` under `BUILTIN\Users` (S-1-5-32-545) at `LeastPrivilege`. The cobra `--role` flag on `userHelperCmd` defaulted to `"system"`, so the helper claimed `HelperRoleSystem`. The broker correctly rejected the IPC handshake because the caller is not running as SYSTEM.
- The legitimate desktop-capture path is unaffected: it uses the separate `desktop-helper` cobra command, which hardcodes `ipc.HelperRoleSystem` in `runDesktopHelper()`. The other in-process caller of `user-helper` is `agent/internal/sessionbroker/spawner_windows.go`, which already passes `--role user` explicitly.

## Root cause

Two flag-default issues:
1. `agent/cmd/breeze-agent/main.go` line 219: `userHelperCmd.Flags().StringVar(&helperRole, "role", "system", ...)` — wrong default.
2. `agent/service/windows/breeze-agent-user-task.xml`: `<Arguments>user-helper</Arguments>` — relied on the (broken) cobra default rather than passing the role explicitly.

## Fix

- `main.go`: cobra default for `--role` is now `"user"` so any caller that omits the flag gets the correct role.
- `breeze-agent-user-task.xml`: pass `--role user` explicitly as defense-in-depth so the Scheduled Task can never silently regress to whatever the binary's default happens to be.
- `main_test.go`: new `TestUserHelperRoleDefault` regression test that asserts `userHelperCmd.Flags().Lookup("role").DefValue == "user"` so a future careless edit can't reintroduce the crash-loop.

## Test plan

- [x] `cd agent && go test -run TestUserHelperRoleDefault ./cmd/breeze-agent/...` passes locally (`PASS: TestUserHelperRoleDefault`).
- [ ] After merge + release, manual smoke test on a Windows VM:
  - [ ] Re-deploy the new MSI.
  - [ ] Log in as a non-admin user; confirm `\Breeze\AgentUserHelper` Scheduled Task starts cleanly (no crash-loop).
  - [ ] Query `agent_logs` for the affected device and confirm `auth_rejected` / `system role requires SYSTEM identity` events stop appearing.
  - [ ] Verify desktop capture (`desktop-helper`) still works — that path uses the separate cobra command and is unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)