### PR TITLE
perf(api): per-org rate limit on agent endpoints + tune postgres pool to 30

### DIFF
--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -18,7 +18,19 @@ const connectionString =
   || process.env.DATABASE_URL
   || 'postgresql://breeze:breeze@localhost:5432/breeze';
 
+// Pool sizing: postgres-js defaults to max=10, which causes cascading 504s
+// under heartbeat storms (e.g. a 1000-agent fleet reconnecting at once).
+// Default to 30 and allow tuning via DB_POOL_MAX.
+function getDbPoolMax(): number {
+  const raw = Number.parseInt(process.env.DB_POOL_MAX ?? '', 10);
+  if (!Number.isFinite(raw) || raw <= 0) {
+    return 30;
+  }
+  return raw;
+}
+
 const client = postgres(connectionString, {
+  max: getDbPoolMax(),
   idle_timeout: 20,
   max_lifetime: 60 * 30,
   connect_timeout: 10,

--- a/apps/api/src/middleware/agentAuth.test.ts
+++ b/apps/api/src/middleware/agentAuth.test.ts
@@ -1,7 +1,41 @@
-import { describe, expect, it, vi, afterEach } from 'vitest';
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
 
-import { isAgentTokenRotationDue, matchAgentTokenHash } from './agentAuth';
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(),
+  },
+  withDbAccessContext: vi.fn(async (_context: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  devices: {
+    id: 'id',
+    agentId: 'agentId',
+    orgId: 'orgId',
+    siteId: 'siteId',
+    agentTokenHash: 'agentTokenHash',
+    previousTokenHash: 'previousTokenHash',
+    previousTokenExpiresAt: 'previousTokenExpiresAt',
+    status: 'status',
+  },
+}));
+
+vi.mock('../services', () => ({
+  getRedis: vi.fn(),
+  rateLimiter: vi.fn(),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((left, right) => ({ left, right })),
+}));
+
+import type { Context } from 'hono';
 import { createHash } from 'crypto';
+
+import { db } from '../db';
+import { getRedis, rateLimiter } from '../services';
+import { agentAuthMiddleware, isAgentTokenRotationDue, matchAgentTokenHash } from './agentAuth';
 
 function sha(token: string): string {
   return createHash('sha256').update(token).digest('hex');
@@ -69,5 +103,164 @@ describe('isAgentTokenRotationDue', () => {
         new Date('2026-03-31T18:00:00Z')
       )
     ).toBe(false);
+  });
+});
+
+type TestContext = Context & {
+  _getResponseHeaders: () => Record<string, string>;
+  _getResponse: () => { status: number; body: unknown } | null;
+};
+
+const VALID_TOKEN = 'brz_test_token';
+const VALID_HASH = sha(VALID_TOKEN);
+
+function buildSelectMock(result: unknown[]) {
+  vi.mocked(db.select).mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(result),
+      }),
+    }),
+  } as any);
+}
+
+function makeDevice(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'device-1',
+    agentId: 'agent-1',
+    orgId: 'org-1',
+    siteId: 'site-1',
+    agentTokenHash: VALID_HASH,
+    previousTokenHash: null,
+    previousTokenExpiresAt: null,
+    status: 'active',
+    ...overrides,
+  };
+}
+
+function createContext(opts: { agentId?: string; token?: string } = {}): TestContext {
+  const headers: Record<string, string> = {};
+  const store = new Map<string, unknown>();
+  const reqHeaders: Record<string, string> = {};
+  if (opts.token) {
+    reqHeaders['authorization'] = `Bearer ${opts.token}`;
+  }
+
+  let response: { status: number; body: unknown } | null = null;
+
+  return {
+    req: {
+      header: (name: string) => reqHeaders[name.toLowerCase()],
+      param: (_name: string) => opts.agentId ?? 'agent-1',
+    },
+    header: (name: string, value: string) => {
+      headers[name] = value;
+    },
+    set: (key: string, value: unknown) => {
+      store.set(key, value);
+    },
+    get: (key: string) => store.get(key),
+    json: (body: unknown, status?: number) => {
+      response = { status: status ?? 200, body };
+      return response;
+    },
+    _getResponseHeaders: () => headers,
+    _getResponse: () => response,
+  } as unknown as TestContext;
+}
+
+describe('agentAuthMiddleware - per-org rate limit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    vi.mocked(getRedis).mockReturnValue({} as any);
+  });
+
+  it('returns 429 with org_rate_limit_exceeded body and Retry-After:60 when org limit is exceeded', async () => {
+    buildSelectMock([makeDevice()]);
+
+    // Per-agent passes, per-org fails
+    vi.mocked(rateLimiter)
+      .mockResolvedValueOnce({ allowed: true, remaining: 119, resetAt: new Date(Date.now() + 60_000) })
+      .mockResolvedValueOnce({ allowed: false, remaining: 0, resetAt: new Date(Date.now() + 60_000) });
+
+    const c = createContext({ token: VALID_TOKEN, agentId: 'agent-1' });
+    const next = vi.fn();
+
+    const result = await agentAuthMiddleware(c, next);
+
+    // Middleware returned a Response (json call) without invoking next
+    expect(next).not.toHaveBeenCalled();
+    expect((result as any).status).toBe(429);
+    expect((result as any).body).toEqual({ error: 'org_rate_limit_exceeded' });
+
+    const headers = c._getResponseHeaders();
+    expect(headers['Retry-After']).toBe('60');
+
+    // Verify the org rate limiter was called with the expected key + default 600/60
+    expect(rateLimiter).toHaveBeenNthCalledWith(2, expect.anything(), 'agent_org_rate:org-1', 600, 60);
+  });
+
+  it('honors AGENT_ORG_RATE_LIMIT_PER_MIN env override', async () => {
+    vi.stubEnv('AGENT_ORG_RATE_LIMIT_PER_MIN', '900');
+    buildSelectMock([makeDevice()]);
+
+    vi.mocked(rateLimiter)
+      .mockResolvedValueOnce({ allowed: true, remaining: 100, resetAt: new Date(Date.now() + 60_000) })
+      .mockResolvedValueOnce({ allowed: true, remaining: 800, resetAt: new Date(Date.now() + 60_000) });
+
+    const c = createContext({ token: VALID_TOKEN });
+    const next = vi.fn();
+
+    await agentAuthMiddleware(c, next);
+
+    expect(rateLimiter).toHaveBeenNthCalledWith(2, expect.anything(), 'agent_org_rate:org-1', 900, 60);
+  });
+
+  it('triggers per-agent limit independently of per-org (does not increment org bucket)', async () => {
+    buildSelectMock([makeDevice()]);
+
+    // Per-agent limit fails — per-org limiter must NOT be called
+    vi.mocked(rateLimiter).mockResolvedValueOnce({
+      allowed: false,
+      remaining: 0,
+      resetAt: new Date(Date.now() + 30_000),
+    });
+
+    const c = createContext({ token: VALID_TOKEN });
+    const next = vi.fn();
+
+    await expect(agentAuthMiddleware(c, next)).rejects.toMatchObject({
+      status: 429,
+      message: 'Agent rate limit exceeded',
+    });
+
+    // Only the per-agent limiter should have been called
+    expect(rateLimiter).toHaveBeenCalledTimes(1);
+    expect(rateLimiter).toHaveBeenCalledWith(expect.anything(), 'agent_rate:agent-1', 120, 60);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('passes both limits and proceeds to next() when under both budgets', async () => {
+    buildSelectMock([makeDevice()]);
+
+    vi.mocked(rateLimiter)
+      .mockResolvedValueOnce({ allowed: true, remaining: 119, resetAt: new Date(Date.now() + 60_000) })
+      .mockResolvedValueOnce({ allowed: true, remaining: 599, resetAt: new Date(Date.now() + 60_000) });
+
+    const c = createContext({ token: VALID_TOKEN });
+    const next = vi.fn().mockResolvedValue(undefined);
+
+    await agentAuthMiddleware(c, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(c._getResponse()).toBeNull();
+    expect(rateLimiter).toHaveBeenCalledTimes(2);
+    expect(c.get('agent')).toMatchObject({
+      deviceId: 'device-1',
+      agentId: 'agent-1',
+      orgId: 'org-1',
+      siteId: 'site-1',
+    });
   });
 });

--- a/apps/api/src/middleware/agentAuth.ts
+++ b/apps/api/src/middleware/agentAuth.ts
@@ -23,7 +23,19 @@ declare module 'hono' {
 // 120 requests per 60-second window per agent
 const AGENT_RATE_LIMIT = 120;
 const AGENT_RATE_WINDOW_SECONDS = 60;
+// Default per-org budget: 5x the per-agent budget — supports up to ~5 active
+// agents per org without rate-limiting. Configurable via env var.
+const DEFAULT_AGENT_ORG_RATE_LIMIT = 600;
+const AGENT_ORG_RATE_WINDOW_SECONDS = 60;
 const DEFAULT_AGENT_TOKEN_ROTATION_MAX_AGE_DAYS = 30;
+
+function getAgentOrgRateLimit(): number {
+  const raw = Number.parseInt(process.env.AGENT_ORG_RATE_LIMIT_PER_MIN ?? '', 10);
+  if (!Number.isFinite(raw) || raw <= 0) {
+    return DEFAULT_AGENT_ORG_RATE_LIMIT;
+  }
+  return raw;
+}
 
 function tokenHashMatches(storedHash: string, tokenHash: string): boolean {
   const storedBuf = Buffer.from(storedHash, 'hex');
@@ -158,6 +170,26 @@ export async function agentAuthMiddleware(c: Context, next: Next) {
   if (!rateCheck.allowed) {
     c.header('Retry-After', String(Math.ceil((rateCheck.resetAt.getTime() - Date.now()) / 1000)));
     throw new HTTPException(429, { message: 'Agent rate limit exceeded' });
+  }
+
+  // Rate limiting per org (applied AFTER per-agent so we don't bill the org bucket
+  // for requests that already failed the per-agent check). Protects against a
+  // large fleet on one MSP saturating shared resources via the per-agent budget.
+  const orgRateKey = `agent_org_rate:${device.orgId}`;
+  const orgRateCheck = await rateLimiter(
+    redis,
+    orgRateKey,
+    getAgentOrgRateLimit(),
+    AGENT_ORG_RATE_WINDOW_SECONDS,
+  );
+
+  if (!orgRateCheck.allowed) {
+    console.warn('[agentAuth] org rate limit exceeded', {
+      orgId: device.orgId,
+      deviceId: device.id,
+    });
+    c.header('Retry-After', '60');
+    return c.json({ error: 'org_rate_limit_exceeded' }, 429);
   }
 
   if (match.tokenRotationRequired) {


### PR DESCRIPTION
## Summary

- Adds a per-org sliding-window rate limit on agent-authenticated endpoints (default 600 req/min, configurable via `AGENT_ORG_RATE_LIMIT_PER_MIN`). Returns 429 with body `{ error: 'org_rate_limit_exceeded' }` and `Retry-After: 60` so well-behaved agents back off.
- Tunes the postgres-js connection pool from the implicit default `max: 10` to `max: 30` (configurable via `DB_POOL_MAX`) to prevent cascading 504s under heartbeat storms.

## Why

The existing per-agent limit (120/60s) had no per-tenant ceiling, meaning a single MSP with 1,000 agents could sustain 120,000 req/min by spec without tripping anything. Combined with the small DB pool, reconnect storms cascaded into 504s.

The per-org budget is sized at 5x the per-agent budget (sufficient for ~5 active agents per org without rate-limiting); MSP-specific tuning is env-controlled so a single noisy customer can be raised without redeploy. Order is per-agent first, then per-org — failed per-agent requests don't bill the org bucket (cheap path).

This is part of a 3-PR DoS-resilience bundle for 0.64.3:
- This PR: per-org limit + postgres pool
- Sibling: agent Retry-After parser
- Sibling: log batch tightening

## Test plan

- [x] `pnpm vitest run src/middleware/agentAuth.test.ts` — 9 tests pass (existing 5 pure-fn tests + 4 new middleware tests)
- [x] All 109 middleware unit tests pass
- [x] All 27 db tests pass
- [x] `npx tsc --noEmit` clean (no new errors)
- [ ] Smoke test on staging: simulate org-level burst (>600 req/min) and confirm 429 with `Retry-After: 60`

## Compatibility

- Default 600/min is non-disruptive for any sane fleet (would only bite an MSP burst-storming all agents simultaneously); raise via env if a real customer hits it.
- DB pool change is monotonic safer (more headroom). Confirm pg `max_connections` has room (default 100 is fine for a single API replica).

🤖 Generated with [Claude Code](https://claude.com/claude-code)