### PR TITLE
perf(agent): honor Retry-After header on 429/503 in httputil and log shipper

### DIFF
--- a/agent/internal/httputil/retry.go
+++ b/agent/internal/httputil/retry.go
@@ -45,25 +45,47 @@ func isRetryableStatus(code int) bool {
 // Do executes an HTTP request with retry logic. The request body must be
 // provided separately as a byte slice so it can be replayed on retries.
 // Returns the response from the first successful (or last) attempt.
+//
+// When the server returns a retryable status (especially 429 or 503) with a
+// Retry-After header, the parsed value (clamped to ≤300s) is honored for the
+// next sleep instead of the internal exponential delay. This prevents fleets
+// of agents from steamrolling server-side rate limits.
 func Do(ctx context.Context, client *http.Client, method, url string, body []byte, headers http.Header, cfg RetryConfig) (*http.Response, error) {
 	var lastErr error
 	delay := cfg.InitialDelay
+	// nextSleepOverride, if non-zero, replaces the exponential delay for the
+	// next attempt's pre-sleep. It's set when the server sends Retry-After.
+	var nextSleepOverride time.Duration
 
 	for attempt := 0; attempt <= cfg.MaxRetries; attempt++ {
 		if attempt > 0 {
-			jittered := applyJitter(delay, cfg.JitterFrac)
-			log.Debug("retrying request",
-				"attempt", attempt,
-				"delay", jittered,
-				"url", url,
-			)
+			var sleepFor time.Duration
+			if nextSleepOverride > 0 {
+				// Honor server-provided Retry-After. ParseRetryAfter already
+				// caps at 300s defensively.
+				sleepFor = nextSleepOverride
+				log.Debug("honoring Retry-After from server",
+					"attempt", attempt,
+					"delay", sleepFor,
+					"url", url,
+				)
+				nextSleepOverride = 0
+			} else {
+				sleepFor = applyJitter(delay, cfg.JitterFrac)
+				log.Debug("retrying request",
+					"attempt", attempt,
+					"delay", sleepFor,
+					"url", url,
+				)
+			}
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()
-			case <-time.After(jittered):
+			case <-time.After(sleepFor):
 			}
 
-			// Exponential backoff for next attempt
+			// Exponential backoff for next attempt (used if server doesn't
+			// send Retry-After next time around).
 			delay = time.Duration(float64(delay) * cfg.BackoffFactor)
 			if delay > cfg.MaxDelay {
 				delay = cfg.MaxDelay
@@ -95,7 +117,10 @@ func Do(ctx context.Context, client *http.Client, method, url string, body []byt
 			return resp, nil // success or non-retryable error
 		}
 
-		// Retryable status — close body and retry
+		// Retryable status — check for Retry-After before discarding response.
+		if ra := ParseRetryAfter(resp.Header, time.Now()); ra > 0 {
+			nextSleepOverride = ra
+		}
 		resp.Body.Close()
 		lastErr = &RetryableStatusError{StatusCode: resp.StatusCode, URL: url}
 	}

--- a/agent/internal/httputil/retryafter.go
+++ b/agent/internal/httputil/retryafter.go
@@ -1,0 +1,57 @@
+package httputil
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// retryAfterMaxCap is the defensive maximum we will honor from a server-provided
+// Retry-After header. Without this cap, a hostile or misconfigured server could
+// park agents for hours by sending Retry-After: 99999.
+const retryAfterMaxCap = 300 * time.Second
+
+// ParseRetryAfter returns the duration to wait per RFC 7231 §7.1.3.
+//
+// The Retry-After header may be either:
+//   - An integer number of seconds (e.g. "30")
+//   - An HTTP-date (RFC1123, RFC1123Z, or asctime — see http.ParseTime)
+//
+// The returned duration is always clamped to [0, retryAfterMaxCap]. The function
+// returns 0 if the header is missing, malformed, zero, or in the past.
+func ParseRetryAfter(h http.Header, now time.Time) time.Duration {
+	if h == nil {
+		return 0
+	}
+	raw := h.Get("Retry-After")
+	if raw == "" {
+		return 0
+	}
+
+	// Try integer seconds first (the common case).
+	if secs, err := strconv.Atoi(raw); err == nil {
+		if secs <= 0 {
+			return 0
+		}
+		d := time.Duration(secs) * time.Second
+		if d > retryAfterMaxCap {
+			return retryAfterMaxCap
+		}
+		return d
+	}
+
+	// Fall back to HTTP-date parsing (RFC 7231 allows three formats).
+	if t, err := http.ParseTime(raw); err == nil {
+		d := t.Sub(now)
+		if d <= 0 {
+			return 0
+		}
+		if d > retryAfterMaxCap {
+			return retryAfterMaxCap
+		}
+		return d
+	}
+
+	// Malformed value — caller falls back to its own delay logic.
+	return 0
+}

--- a/agent/internal/httputil/retryafter_test.go
+++ b/agent/internal/httputil/retryafter_test.go
@@ -1,0 +1,312 @@
+package httputil
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// ---------- ParseRetryAfter — integer seconds ----------
+
+func TestParseRetryAfterIntegerSeconds(t *testing.T) {
+	h := http.Header{}
+	h.Set("Retry-After", "30")
+
+	got := ParseRetryAfter(h, time.Now())
+	want := 30 * time.Second
+	if got != want {
+		t.Fatalf("ParseRetryAfter(\"30\") = %v, want %v", got, want)
+	}
+}
+
+func TestParseRetryAfterZero(t *testing.T) {
+	h := http.Header{}
+	h.Set("Retry-After", "0")
+
+	got := ParseRetryAfter(h, time.Now())
+	if got != 0 {
+		t.Fatalf("ParseRetryAfter(\"0\") = %v, want 0", got)
+	}
+}
+
+func TestParseRetryAfterNegative(t *testing.T) {
+	h := http.Header{}
+	h.Set("Retry-After", "-5")
+
+	got := ParseRetryAfter(h, time.Now())
+	if got != 0 {
+		t.Fatalf("ParseRetryAfter(\"-5\") = %v, want 0", got)
+	}
+}
+
+func TestParseRetryAfterMalformed(t *testing.T) {
+	h := http.Header{}
+	h.Set("Retry-After", "abc")
+
+	got := ParseRetryAfter(h, time.Now())
+	if got != 0 {
+		t.Fatalf("ParseRetryAfter(\"abc\") = %v, want 0", got)
+	}
+}
+
+func TestParseRetryAfterEmptyString(t *testing.T) {
+	h := http.Header{}
+	h.Set("Retry-After", "")
+
+	got := ParseRetryAfter(h, time.Now())
+	if got != 0 {
+		t.Fatalf("ParseRetryAfter(\"\") = %v, want 0", got)
+	}
+}
+
+func TestParseRetryAfterMissingHeader(t *testing.T) {
+	h := http.Header{}
+
+	got := ParseRetryAfter(h, time.Now())
+	if got != 0 {
+		t.Fatalf("ParseRetryAfter(missing) = %v, want 0", got)
+	}
+}
+
+func TestParseRetryAfterNilHeader(t *testing.T) {
+	got := ParseRetryAfter(nil, time.Now())
+	if got != 0 {
+		t.Fatalf("ParseRetryAfter(nil) = %v, want 0", got)
+	}
+}
+
+// ---------- ParseRetryAfter — HTTP-date ----------
+
+func TestParseRetryAfterHTTPDateFuture(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	future := now.Add(60 * time.Second)
+	h := http.Header{}
+	h.Set("Retry-After", future.Format(http.TimeFormat))
+
+	got := ParseRetryAfter(h, now)
+	want := 60 * time.Second
+	// Allow ±2s tolerance for any rounding in formatting/parsing.
+	diff := got - want
+	if diff < -2*time.Second || diff > 2*time.Second {
+		t.Fatalf("ParseRetryAfter(future RFC1123) = %v, want ~%v (±2s)", got, want)
+	}
+}
+
+func TestParseRetryAfterHTTPDatePast(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	past := now.Add(-60 * time.Second)
+	h := http.Header{}
+	h.Set("Retry-After", past.Format(http.TimeFormat))
+
+	got := ParseRetryAfter(h, now)
+	if got != 0 {
+		t.Fatalf("ParseRetryAfter(past date) = %v, want 0", got)
+	}
+}
+
+func TestParseRetryAfterHTTPDateRFC1123(t *testing.T) {
+	// Spec example from RFC 7231: "Tue, 15 Nov 1994 08:12:31 GMT"
+	// Use a "now" that is 60s before that fixed date so the duration is deterministic.
+	target, err := time.Parse(time.RFC1123, "Tue, 15 Nov 1994 08:12:31 GMT")
+	if err != nil {
+		t.Fatalf("setup parse: %v", err)
+	}
+	now := target.Add(-60 * time.Second)
+
+	h := http.Header{}
+	h.Set("Retry-After", "Tue, 15 Nov 1994 08:12:31 GMT")
+
+	got := ParseRetryAfter(h, now)
+	want := 60 * time.Second
+	if got != want {
+		t.Fatalf("ParseRetryAfter(RFC1123 spec example) = %v, want %v", got, want)
+	}
+}
+
+// ---------- ParseRetryAfter — cap enforcement ----------
+
+func TestParseRetryAfterAboveCap(t *testing.T) {
+	h := http.Header{}
+	h.Set("Retry-After", "99999")
+
+	got := ParseRetryAfter(h, time.Now())
+	want := 300 * time.Second
+	if got != want {
+		t.Fatalf("ParseRetryAfter(\"99999\") = %v, want %v (cap)", got, want)
+	}
+}
+
+func TestParseRetryAfterAtCap(t *testing.T) {
+	h := http.Header{}
+	h.Set("Retry-After", strconv.Itoa(int((300 * time.Second).Seconds())))
+
+	got := ParseRetryAfter(h, time.Now())
+	want := 300 * time.Second
+	if got != want {
+		t.Fatalf("ParseRetryAfter(at cap) = %v, want %v", got, want)
+	}
+}
+
+func TestParseRetryAfterHTTPDateAboveCap(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	veryFuture := now.Add(2 * time.Hour)
+	h := http.Header{}
+	h.Set("Retry-After", veryFuture.Format(http.TimeFormat))
+
+	got := ParseRetryAfter(h, now)
+	want := 300 * time.Second
+	if got != want {
+		t.Fatalf("ParseRetryAfter(2h future) = %v, want %v (cap)", got, want)
+	}
+}
+
+// ---------- Do — Retry-After is honored on 429 ----------
+
+func TestDoHonorsRetryAfterOn429(t *testing.T) {
+	var attempts atomic.Int32
+	var attemptTimes []time.Time
+	mu := make(chan struct{}, 1)
+	mu <- struct{}{}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-mu
+		attemptTimes = append(attemptTimes, time.Now())
+		mu <- struct{}{}
+
+		n := attempts.Add(1)
+		if n == 1 {
+			// First attempt: rate-limited, ask for 1s wait.
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	cfg := RetryConfig{
+		MaxRetries: 2,
+		// Internal exponential schedule would be 5ms; if Retry-After were
+		// ignored, the second attempt would happen ~5ms after the first.
+		// We want to confirm we instead wait ≥1s.
+		InitialDelay:  5 * time.Millisecond,
+		MaxDelay:      10 * time.Millisecond,
+		BackoffFactor: 2.0,
+		JitterFrac:    0,
+	}
+
+	resp, err := Do(t.Context(), ts.Client(), "GET", ts.URL, nil, nil, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if attempts.Load() != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts.Load())
+	}
+	if len(attemptTimes) < 2 {
+		t.Fatalf("expected ≥2 recorded attempt times, got %d", len(attemptTimes))
+	}
+
+	gap := attemptTimes[1].Sub(attemptTimes[0])
+	if gap < 1*time.Second {
+		t.Fatalf("expected ≥1s gap honoring Retry-After, got %v", gap)
+	}
+	// Sanity ceiling — should not be much more than 1s + scheduling slop.
+	if gap > 3*time.Second {
+		t.Fatalf("gap %v unreasonably long; expected ~1s", gap)
+	}
+}
+
+func TestDoHonorsRetryAfterOn503(t *testing.T) {
+	var attempts atomic.Int32
+	var attemptTimes []time.Time
+	mu := make(chan struct{}, 1)
+	mu <- struct{}{}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-mu
+		attemptTimes = append(attemptTimes, time.Now())
+		mu <- struct{}{}
+
+		n := attempts.Add(1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	cfg := RetryConfig{
+		MaxRetries:    2,
+		InitialDelay:  5 * time.Millisecond,
+		MaxDelay:      10 * time.Millisecond,
+		BackoffFactor: 2.0,
+		JitterFrac:    0,
+	}
+
+	resp, err := Do(t.Context(), ts.Client(), "GET", ts.URL, nil, nil, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if len(attemptTimes) < 2 {
+		t.Fatalf("expected ≥2 attempts, got %d", len(attemptTimes))
+	}
+	gap := attemptTimes[1].Sub(attemptTimes[0])
+	if gap < 1*time.Second {
+		t.Fatalf("expected ≥1s gap honoring Retry-After on 503, got %v", gap)
+	}
+}
+
+// Verify that without Retry-After, exponential delay is still small (regression
+// guard: we shouldn't accidentally start sleeping forever when no header sent).
+func TestDoNoRetryAfterUsesExponentialDelay(t *testing.T) {
+	var attempts atomic.Int32
+	var attemptTimes []time.Time
+	mu := make(chan struct{}, 1)
+	mu <- struct{}{}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-mu
+		attemptTimes = append(attemptTimes, time.Now())
+		mu <- struct{}{}
+
+		n := attempts.Add(1)
+		if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	cfg := RetryConfig{
+		MaxRetries:    2,
+		InitialDelay:  10 * time.Millisecond,
+		MaxDelay:      50 * time.Millisecond,
+		BackoffFactor: 2.0,
+		JitterFrac:    0,
+	}
+
+	resp, err := Do(t.Context(), ts.Client(), "GET", ts.URL, nil, nil, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	gap := attemptTimes[1].Sub(attemptTimes[0])
+	// Should be ~10ms, definitely <500ms (no Retry-After to trigger the long sleep).
+	if gap > 500*time.Millisecond {
+		t.Fatalf("expected ≪500ms gap without Retry-After, got %v", gap)
+	}
+}

--- a/agent/internal/logging/retryafter.go
+++ b/agent/internal/logging/retryafter.go
@@ -1,0 +1,58 @@
+package logging
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// retryAfterMaxCap is the defensive maximum we will honor from a server-provided
+// Retry-After header. Mirrors httputil.retryAfterMaxCap; duplicated here to
+// avoid a circular import (httputil already imports logging).
+const retryAfterMaxCap = 300 * time.Second
+
+// parseRetryAfter returns the duration to wait per RFC 7231 §7.1.3.
+//
+// The Retry-After header may be either:
+//   - An integer number of seconds (e.g. "30")
+//   - An HTTP-date (RFC1123, RFC1123Z, or asctime — see http.ParseTime)
+//
+// The returned duration is always clamped to [0, retryAfterMaxCap]. The function
+// returns 0 if the header is missing, malformed, zero, or in the past.
+//
+// Unexported because callers outside this package should use
+// httputil.ParseRetryAfter — this is a duplicate kept private to avoid the
+// import cycle (httputil → logging).
+func parseRetryAfter(h http.Header, now time.Time) time.Duration {
+	if h == nil {
+		return 0
+	}
+	raw := h.Get("Retry-After")
+	if raw == "" {
+		return 0
+	}
+
+	if secs, err := strconv.Atoi(raw); err == nil {
+		if secs <= 0 {
+			return 0
+		}
+		d := time.Duration(secs) * time.Second
+		if d > retryAfterMaxCap {
+			return retryAfterMaxCap
+		}
+		return d
+	}
+
+	if t, err := http.ParseTime(raw); err == nil {
+		d := t.Sub(now)
+		if d <= 0 {
+			return 0
+		}
+		if d > retryAfterMaxCap {
+			return retryAfterMaxCap
+		}
+		return d
+	}
+
+	return 0
+}

--- a/agent/internal/logging/retryafter_test.go
+++ b/agent/internal/logging/retryafter_test.go
@@ -1,0 +1,222 @@
+package logging
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// ---------- parseRetryAfter — integer seconds ----------
+
+func TestParseRetryAfterIntegerSeconds(t *testing.T) {
+	h := http.Header{}
+	h.Set("Retry-After", "30")
+
+	got := parseRetryAfter(h, time.Now())
+	want := 30 * time.Second
+	if got != want {
+		t.Fatalf("parseRetryAfter(\"30\") = %v, want %v", got, want)
+	}
+}
+
+func TestParseRetryAfterZero(t *testing.T) {
+	h := http.Header{}
+	h.Set("Retry-After", "0")
+
+	if got := parseRetryAfter(h, time.Now()); got != 0 {
+		t.Fatalf("parseRetryAfter(\"0\") = %v, want 0", got)
+	}
+}
+
+func TestParseRetryAfterNegative(t *testing.T) {
+	h := http.Header{}
+	h.Set("Retry-After", "-5")
+
+	if got := parseRetryAfter(h, time.Now()); got != 0 {
+		t.Fatalf("parseRetryAfter(\"-5\") = %v, want 0", got)
+	}
+}
+
+func TestParseRetryAfterMalformed(t *testing.T) {
+	h := http.Header{}
+	h.Set("Retry-After", "abc")
+
+	if got := parseRetryAfter(h, time.Now()); got != 0 {
+		t.Fatalf("parseRetryAfter(\"abc\") = %v, want 0", got)
+	}
+}
+
+func TestParseRetryAfterMissingHeader(t *testing.T) {
+	h := http.Header{}
+	if got := parseRetryAfter(h, time.Now()); got != 0 {
+		t.Fatalf("parseRetryAfter(missing) = %v, want 0", got)
+	}
+}
+
+func TestParseRetryAfterNilHeader(t *testing.T) {
+	if got := parseRetryAfter(nil, time.Now()); got != 0 {
+		t.Fatalf("parseRetryAfter(nil) = %v, want 0", got)
+	}
+}
+
+// ---------- parseRetryAfter — HTTP-date ----------
+
+func TestParseRetryAfterHTTPDateFuture(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	future := now.Add(60 * time.Second)
+	h := http.Header{}
+	h.Set("Retry-After", future.Format(http.TimeFormat))
+
+	got := parseRetryAfter(h, now)
+	want := 60 * time.Second
+	diff := got - want
+	if diff < -2*time.Second || diff > 2*time.Second {
+		t.Fatalf("parseRetryAfter(future RFC1123) = %v, want ~%v (±2s)", got, want)
+	}
+}
+
+func TestParseRetryAfterHTTPDatePast(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	past := now.Add(-60 * time.Second)
+	h := http.Header{}
+	h.Set("Retry-After", past.Format(http.TimeFormat))
+
+	if got := parseRetryAfter(h, now); got != 0 {
+		t.Fatalf("parseRetryAfter(past date) = %v, want 0", got)
+	}
+}
+
+func TestParseRetryAfterAboveCap(t *testing.T) {
+	h := http.Header{}
+	h.Set("Retry-After", "99999")
+
+	got := parseRetryAfter(h, time.Now())
+	want := 300 * time.Second
+	if got != want {
+		t.Fatalf("parseRetryAfter(\"99999\") = %v, want %v (cap)", got, want)
+	}
+}
+
+func TestParseRetryAfterAtCap(t *testing.T) {
+	h := http.Header{}
+	h.Set("Retry-After", strconv.Itoa(int((300 * time.Second).Seconds())))
+
+	got := parseRetryAfter(h, time.Now())
+	want := 300 * time.Second
+	if got != want {
+		t.Fatalf("parseRetryAfter(at cap) = %v, want %v", got, want)
+	}
+}
+
+// ---------- shipBatch honors Retry-After on 429 ----------
+
+func TestShipBatchHonorsRetryAfterOn429(t *testing.T) {
+	var attempts atomic.Int32
+	var attemptTimes []time.Time
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		attemptTimes = append(attemptTimes, time.Now())
+		mu.Unlock()
+
+		n := attempts.Add(1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	s := NewShipper(ShipperConfig{
+		ServerURL:    server.URL,
+		AgentID:      "test-agent",
+		AuthToken:    testToken("brz_secret"),
+		AgentVersion: "1.0.0",
+		MinLevel:     "debug",
+		HTTPClient:   server.Client(),
+	})
+
+	entries := []LogEntry{{
+		Timestamp: time.Now(),
+		Level:     "INFO",
+		Component: "test",
+		Message:   "rate-limited test",
+	}}
+
+	s.shipBatch(entries)
+
+	if attempts.Load() != 2 {
+		t.Fatalf("expected 2 attempts (1 retry), got %d", attempts.Load())
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(attemptTimes) < 2 {
+		t.Fatalf("expected ≥2 attempt times, got %d", len(attemptTimes))
+	}
+	gap := attemptTimes[1].Sub(attemptTimes[0])
+	if gap < 1*time.Second {
+		t.Fatalf("expected ≥1s gap honoring Retry-After, got %v", gap)
+	}
+	if gap > 3*time.Second {
+		t.Fatalf("gap %v unreasonably long; expected ~1s", gap)
+	}
+}
+
+// ---------- shipBatch honors Retry-After on 503 ----------
+
+func TestShipBatchHonorsRetryAfterOn503(t *testing.T) {
+	var attempts atomic.Int32
+	var attemptTimes []time.Time
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		attemptTimes = append(attemptTimes, time.Now())
+		mu.Unlock()
+
+		n := attempts.Add(1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	s := NewShipper(ShipperConfig{
+		ServerURL:    server.URL,
+		AgentID:      "test-agent",
+		AuthToken:    testToken("brz_secret"),
+		AgentVersion: "1.0.0",
+		MinLevel:     "debug",
+		HTTPClient:   server.Client(),
+	})
+
+	entries := []LogEntry{{
+		Timestamp: time.Now(),
+		Level:     "INFO",
+		Component: "test",
+		Message:   "503 test",
+	}}
+
+	s.shipBatch(entries)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(attemptTimes) < 2 {
+		t.Fatalf("expected ≥2 attempts, got %d", len(attemptTimes))
+	}
+	gap := attemptTimes[1].Sub(attemptTimes[0])
+	if gap < 1*time.Second {
+		t.Fatalf("expected ≥1s gap honoring Retry-After on 503, got %v", gap)
+	}
+}

--- a/agent/internal/logging/shipper.go
+++ b/agent/internal/logging/shipper.go
@@ -243,10 +243,19 @@ func (s *Shipper) shipBatch(entries []LogEntry) {
 
 	url := fmt.Sprintf("%s/api/v1/agents/%s/logs", s.serverURL, s.agentID)
 
+	// nextSleepOverride, if non-zero, replaces the default fixed-jitter sleep
+	// for the next retry. Set when the server sends Retry-After on 429/503.
+	var nextSleepOverride time.Duration
+
 	for attempt := 0; attempt <= shipRetryCount; attempt++ {
 		if attempt > 0 {
-			jitter := time.Duration(rand.Intn(int(shipRetryBackoff / 2)))
-			time.Sleep(shipRetryBackoff + jitter)
+			if nextSleepOverride > 0 {
+				time.Sleep(nextSleepOverride)
+				nextSleepOverride = 0
+			} else {
+				jitter := time.Duration(rand.Intn(int(shipRetryBackoff / 2)))
+				time.Sleep(shipRetryBackoff + jitter)
+			}
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -275,8 +284,27 @@ func (s *Shipper) shipBatch(entries []LogEntry) {
 			return
 		}
 
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable {
+			// 429/503: retryable, and may carry Retry-After.
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+			if ra := parseRetryAfter(resp.Header, time.Now()); ra > 0 {
+				nextSleepOverride = ra
+			}
+			resp.Body.Close()
+			cancel()
+			if attempt < shipRetryCount {
+				fmt.Fprintf(os.Stderr, "[log-shipper] server returned %d (attempt %d/%d, next sleep %v): %s\n",
+					resp.StatusCode, attempt+1, shipRetryCount+1, nextSleepOverride, string(body))
+				continue
+			}
+			fmt.Fprintf(os.Stderr, "[log-shipper] server returned %d (giving up after %d attempts): %s\n",
+				resp.StatusCode, shipRetryCount+1, string(body))
+			s.droppedCount.Add(int64(len(entries)))
+			return
+		}
+
 		if resp.StatusCode >= 500 {
-			// Server error: retry if we have attempts left
+			// Other 5xx: retry without Retry-After awareness.
 			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 			resp.Body.Close()
 			cancel()


### PR DESCRIPTION
## Summary

Part of the 0.64.3 DoS-resilience bundle (siblings: per-org rate limit, log batch tightening).

The agent's HTTP retry path ignored server-issued `Retry-After` headers, running its own 1-2-4-8-16s exponential schedule regardless of what the server requested. With a fleet of 1000 agents and `Retry-After: 30` on a 429, that meant ~5000 retried hits in 30s — defeating the rate limit the server was trying to enforce.

### Fix

- Add a stdlib-only RFC 7231 §7.1.3 parser that handles both integer seconds and HTTP-dates (RFC1123 / RFC1123Z / asctime via `http.ParseTime`).
- Cap the honored duration at **300s** so a hostile or misconfigured server can't park agents for hours.
- On a retryable response (429 or 503 specifically), the parsed value overrides the next exponential / fixed delay; if absent or malformed, fall back to the existing schedule.
- Wired into both `httputil.Do`'s retry loop and the log shipper's internal `shipBatch` retry. The log shipper also now treats 429 as retryable (was previously lumped with 4xx no-retry).

### Why duplicate the parser?

The parser lives in two places — `agent/internal/httputil/retryafter.go` (exported `ParseRetryAfter`) and `agent/internal/logging/retryafter.go` (unexported `parseRetryAfter`) — because `httputil` already imports `logging` for its logger, so `logging` cannot import `httputil` without a cycle. Tiny function, low duplication cost; flagged with a comment in both files.

## Test plan

- [x] Unit tests for parser cover integer seconds, zero, negative, malformed, empty, missing, nil header, HTTP-date future / past / RFC 7231 spec example, and the 300s cap (both integer and HTTP-date paths).
- [x] `httptest`-driven integration tests assert that a 429 (and a 503) with `Retry-After: 1` cause the second attempt to fire ≥1s after the first.
- [x] Regression test confirms that without `Retry-After`, the retry still happens within the small exponential delay (no accidental long sleep when the header is absent).
- [x] `go build ./...` clean.
- [x] `go test -race ./internal/httputil/... ./internal/logging/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)