### PR TITLE
perf(api,agent): tighten log batch limits + slow systemd restart cooldown

### DIFF
--- a/agent/cmd/breeze-agent/service_cmd_linux.go
+++ b/agent/cmd/breeze-agent/service_cmd_linux.go
@@ -38,7 +38,11 @@ Type=simple
 ExecStart=/usr/local/bin/breeze-agent start
 WorkingDirectory=/etc/breeze
 Restart=on-failure
-RestartSec=5
+# 30s cooldown spreads respawn across a fleet that crashes simultaneously
+# (e.g. correlated network blip). Combined with StartLimitBurst=5 over
+# StartLimitIntervalSec=60, a misbehaving host backs off entirely instead
+# of stampeding the API.
+RestartSec=30
 
 # Cap total stop time so a hung HTTP flush during OS shutdown (network
 # going down) doesn't block system power-off for the 90s systemd default.

--- a/agent/cmd/breeze-watchdog/service_cmd_linux.go
+++ b/agent/cmd/breeze-watchdog/service_cmd_linux.go
@@ -31,7 +31,9 @@ Type=simple
 ExecStart=/usr/local/bin/breeze-watchdog run
 WorkingDirectory=/etc/breeze
 Restart=always
-RestartSec=5
+# Watchdog should come back faster than the agent (RestartSec=30) so it can
+# cover an agent crash, but 5s was unnecessarily aggressive.
+RestartSec=15
 
 # Security hardening
 ProtectSystem=strict

--- a/agent/service/systemd/breeze-agent.service
+++ b/agent/service/systemd/breeze-agent.service
@@ -11,7 +11,11 @@ Type=simple
 ExecStart=/usr/local/bin/breeze-agent start
 WorkingDirectory=/etc/breeze
 Restart=on-failure
-RestartSec=5
+# 30s cooldown spreads respawn across a fleet that crashes simultaneously
+# (e.g. correlated network blip). Combined with StartLimitBurst=5 over
+# StartLimitIntervalSec=60, a misbehaving host backs off entirely instead
+# of stampeding the API.
+RestartSec=30
 
 # Cap total stop time so a hung HTTP flush during OS shutdown (network
 # going down) doesn't block system power-off for the 90s systemd default.

--- a/apps/api/src/routes/agents/logs.test.ts
+++ b/apps/api/src/routes/agents/logs.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const AGENT_ID = 'agent-001';
+const DEVICE_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const ORG_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+  },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../../db/schema', () => ({
+  devices: {
+    id: 'id',
+    agentId: 'agent_id',
+    orgId: 'org_id',
+  },
+  agentLogs: {
+    deviceId: 'device_id',
+    orgId: 'org_id',
+    timestamp: 'timestamp',
+    level: 'level',
+    component: 'component',
+    message: 'message',
+    fields: 'fields',
+    agentVersion: 'agent_version',
+  },
+}));
+
+import { db } from '../../db';
+import { logsRoutes } from './logs';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockDeviceLookup(found: boolean) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi
+          .fn()
+          .mockResolvedValue(
+            found ? [{ id: DEVICE_ID, agentId: AGENT_ID, orgId: ORG_ID }] : []
+          ),
+      }),
+    }),
+  } as any);
+}
+
+function mockInsertSuccess() {
+  vi.mocked(db.insert).mockReturnValue({
+    values: vi.fn().mockResolvedValue(undefined),
+  } as any);
+}
+
+function makeLogEntry(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    timestamp: '2026-05-01T00:00:00.000Z',
+    level: 'info',
+    component: 'test',
+    message: 'hello',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('agent logs routes', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/agents', logsRoutes);
+  });
+
+  describe('POST /agents/:id/logs — batch size limit', () => {
+    it('accepts a batch with exactly 200 entries (at the cap)', async () => {
+      mockDeviceLookup(true);
+      mockInsertSuccess();
+
+      const logs = Array.from({ length: 200 }, () => makeLogEntry());
+      const res = await app.request(`/agents/${AGENT_ID}/logs`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ logs }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.received).toBe(200);
+    });
+
+    it('rejects a batch with 250 entries (over the 200 cap)', async () => {
+      // No device lookup — request should be rejected by Zod before DB.
+      const logs = Array.from({ length: 250 }, () => makeLogEntry());
+      const res = await app.request(`/agents/${AGENT_ID}/logs`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ logs }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/invalid request body/i);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /agents/:id/logs — body size limit', () => {
+    it('rejects payloads larger than 256 KB with 413', async () => {
+      // Build a payload that's >256KB on the wire. Three entries × ~100KB
+      // message each = ~300KB JSON total.
+      const bigMessage = 'x'.repeat(100 * 1024);
+      const logs = Array.from({ length: 3 }, () =>
+        makeLogEntry({ message: bigMessage })
+      );
+
+      const res = await app.request(`/agents/${AGENT_ID}/logs`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ logs }),
+      });
+
+      expect(res.status).toBe(413);
+      const body = await res.json();
+      expect(body.error).toMatch(/too large/i);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it('accepts payloads under 256 KB', async () => {
+      mockDeviceLookup(true);
+      mockInsertSuccess();
+
+      // ~45KB total — well under the 256KB cap. Each message stays under
+      // the per-entry 10000-char Zod limit.
+      const logs = Array.from({ length: 5 }, () =>
+        makeLogEntry({ message: 'a'.repeat(9 * 1024) })
+      );
+
+      const res = await app.request(`/agents/${AGENT_ID}/logs`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ logs }),
+      });
+
+      expect(res.status).toBe(201);
+    });
+  });
+});

--- a/apps/api/src/routes/agents/logs.ts
+++ b/apps/api/src/routes/agents/logs.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
 import { z } from 'zod';
 import { eq } from 'drizzle-orm';
 import { gunzipSync } from 'node:zlib';
@@ -8,6 +9,16 @@ import { devices, agentLogs } from '../../db/schema';
 export const logsRoutes = new Hono();
 
 // Agent Diagnostic Log Shipping
+//
+// Limits are layered to bound the worst-case impact of a single request:
+//   - bodyLimit (256KB pre-gunzip): cap the on-the-wire payload from a single
+//     misbehaving agent so it can't dump megabytes per call.
+//   - gunzip maxOutputLength (10MB): defense-in-depth against zip-bomb-style
+//     decompressed inflation; legitimate batches of 200 small entries stay
+//     well under this ceiling.
+//   - max(logs)=200: cap rows per request. Combined with the agent's ~60s
+//     ship interval and a 1-2s typical processing budget, this still scales
+//     to ~200 logs/min/agent, which is 5-10x the realistic steady-state rate.
 const agentLogEntrySchema = z.object({
   timestamp: z.string().datetime({ offset: true }),
   level: z.enum(['debug', 'info', 'warn', 'error']),
@@ -21,10 +32,16 @@ const agentLogEntrySchema = z.object({
 });
 
 const agentLogIngestSchema = z.object({
-  logs: z.array(agentLogEntrySchema).max(500),
+  logs: z.array(agentLogEntrySchema).max(200),
 });
 
-logsRoutes.post('/:id/logs', async (c) => {
+logsRoutes.post(
+  '/:id/logs',
+  bodyLimit({
+    maxSize: 256 * 1024,
+    onError: (c) => c.json({ error: 'Log batch too large (max 256KB gzipped)' }, 413),
+  }),
+  async (c) => {
   const agentId = c.req.param('id');
   let body: unknown;
 
@@ -32,11 +49,17 @@ logsRoutes.post('/:id/logs', async (c) => {
     const raw = Buffer.from(await c.req.arrayBuffer());
     const encoding = c.req.header('content-encoding')?.toLowerCase() ?? '';
     const decoded = encoding.includes('gzip')
-      ? gunzipSync(raw, { maxOutputLength: 10 * 1024 * 1024 }) // 10MB limit
+      ? gunzipSync(raw, { maxOutputLength: 10 * 1024 * 1024 }) // 10MB decompressed cap (defense-in-depth)
       : raw;
     body = JSON.parse(decoded.toString('utf-8'));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    // Hono's bodyLimit middleware throws a BodyLimitError when the request
+    // body exceeds the configured maxSize (no Content-Length header) — surface
+    // it as 413 instead of the generic 400.
+    if (err instanceof Error && err.name === 'BodyLimitError') {
+      return c.json({ error: 'Log batch too large (max 256KB gzipped)' }, 413);
+    }
     console.error(`[AgentLogs] Failed to decode request body for agent ${agentId}:`, message);
     return c.json({ error: 'Failed to decode request body', detail: message }, 400);
   }


### PR DESCRIPTION
## Summary

Hardens the agent log ingest path and Linux systemd respawn cadence against DoS-style storms from a single misbehaving agent or fleet-wide correlated crashes. **Part of a 3-PR DoS-resilience bundle slated for 0.64.3** (sibling PRs: agent Retry-After respect, per-org agent rate limit).

### Gap

- `POST /agents/:id/logs` accepted up to **500 entries** per batch and the global **1 MB** pre-decompression `bodyLimit`. With agents shipping every ~60s, a misbehaving agent could dump ~5 MB/min of decompressed logs into `agent_logs` at the per-agent rate cap (120 r/min).
- Linux systemd `RestartSec=5` on both `breeze-agent` and `breeze-watchdog` let any correlated crash (network blip, bad config push) trigger a thundering herd of reconnect/respawn attempts at 5s intervals across the fleet.

### Fix

| Knob | Before | After |
|---|---|---|
| `agentLogIngestSchema.max()` | 500 | **200** |
| Per-route `bodyLimit` on `/agents/:id/logs` | (none — global 1 MB) | **256 KB** |
| Gunzip `maxOutputLength` (defense-in-depth) | 10 MB | 10 MB (kept) |
| `breeze-agent.service` `RestartSec` | 5 | **30** |
| `breeze-watchdog.service` `RestartSec` | 5 | **15** |

A 200-entry × ~60s shipper interval still scales to ~200 logs/min/agent — 5-10× the realistic steady-state rate. The 30s agent restart combined with `StartLimitBurst=5` / `StartLimitIntervalSec=60` means a misbehaving host backs off entirely instead of stampeding the API. Watchdog at 15s still recovers faster than the agent.

### Files

- `apps/api/src/routes/agents/logs.ts` — bodyLimit middleware, max 200 entries, 413 on body overflow, refreshed comments.
- `apps/api/src/routes/agents/logs.test.ts` — new tests (200/250 entry cap, 256KB body cap).
- `agent/service/systemd/breeze-agent.service` — `RestartSec=30`.
- `agent/cmd/breeze-agent/service_cmd_linux.go` — embedded unit `RestartSec=30` (kept in sync).
- `agent/cmd/breeze-watchdog/service_cmd_linux.go` — embedded unit `RestartSec=15`.

## Test plan

- [x] New Vitest suite `apps/api/src/routes/agents/logs.test.ts` (4 tests, all passing) covering:
  - 200 entries accepted (201)
  - 250 entries rejected (400 from Zod, before any DB call)
  - >256 KB payload rejected (413)
  - <256 KB payload accepted (201)
- [x] Existing `apps/api/src/routes/logs.test.ts` tests still pass (15 tests, untouched).
- [x] `cd apps/api && npx tsc --noEmit` — clean.
- [x] `cd agent && go build ./...` — clean (only third-party `m1cpu` `-Wgnu-folding-constant` warnings, unrelated).
- [x] `cd agent && go build ./cmd/breeze-watchdog/...` — clean.
- [ ] Soak in staging once merged to confirm a deliberately misbehaving agent now hits 413 instead of slow-bleed-ingesting megabytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)