### PR TITLE
fix(agent): SpawnHelperInSession passes --role system explicitly

### DIFF
--- a/agent/internal/sessionbroker/spawner_cmdline.go
+++ b/agent/internal/sessionbroker/spawner_cmdline.go
@@ -1,0 +1,12 @@
+package sessionbroker
+
+import "fmt"
+
+// buildUserHelperCmdLine constructs the command line passed to
+// CreateProcessAsUser when the broker spawns a user-helper child. The role
+// flag is always set explicitly so the child never inherits the cobra default
+// — that default has been flipped twice (PR #549) and the SYSTEM-context
+// helper crash-looped both times.
+func buildUserHelperCmdLine(exePath, role string) string {
+	return fmt.Sprintf(`"%s" user-helper --role %s`, exePath, role)
+}

--- a/agent/internal/sessionbroker/spawner_cmdline_test.go
+++ b/agent/internal/sessionbroker/spawner_cmdline_test.go
@@ -1,0 +1,45 @@
+package sessionbroker
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildUserHelperCmdLine_AlwaysExplicitRole guards against the spawn-path
+// regressions that have shipped twice now:
+//
+//   - PR #549 (v0.64.x): Scheduled Task on Windows ran user-helper without
+//     --role, inherited cobra default "system", and crash-looped because the
+//     task identity was BUILTIN\Users (not SYSTEM). Fix: cobra default
+//     flipped to "user".
+//   - v0.64.3 mirror bug: SpawnHelperInSession (SYSTEM-context capture
+//     helper) also omitted --role, so flipping the cobra default sent it the
+//     wrong role and the SYSTEM helper crash-looped with "user role requires
+//     non-SYSTEM identity".
+//
+// Both spawn paths must always pass --role explicitly so the cobra default is
+// never load-bearing again.
+func TestBuildUserHelperCmdLine_AlwaysExplicitRole(t *testing.T) {
+	cases := []struct {
+		role       string
+		wantSubstr string
+	}{
+		{"system", "--role system"},
+		{"user", "--role user"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.role, func(t *testing.T) {
+			got := buildUserHelperCmdLine(`C:\Program Files\Breeze\breeze-agent.exe`, tc.role)
+			if !strings.Contains(got, tc.wantSubstr) {
+				t.Fatalf("cmdline missing %q: got %q", tc.wantSubstr, got)
+			}
+			if !strings.Contains(got, "user-helper") {
+				t.Fatalf("cmdline missing user-helper subcommand: got %q", got)
+			}
+			// Quoting around the exe path matters — the path contains a space.
+			if !strings.HasPrefix(got, `"C:\Program Files\Breeze\breeze-agent.exe"`) {
+				t.Fatalf("exe path not quoted: got %q", got)
+			}
+		})
+	}
+}

--- a/agent/internal/sessionbroker/spawner_windows.go
+++ b/agent/internal/sessionbroker/spawner_windows.go
@@ -102,7 +102,7 @@ func SpawnHelperInSession(sessionID uint32) (*SpawnedHelper, error) {
 	if err != nil {
 		return nil, fmt.Errorf("os.Executable: %w", err)
 	}
-	cmdLine, err := windows.UTF16PtrFromString(fmt.Sprintf(`"%s" user-helper`, exePath))
+	cmdLine, err := windows.UTF16PtrFromString(buildUserHelperCmdLine(exePath, "system"))
 	if err != nil {
 		return nil, fmt.Errorf("UTF16PtrFromString: %w", err)
 	}
@@ -174,7 +174,7 @@ func SpawnUserHelperInSession(sessionID uint32) (*SpawnedHelper, error) {
 	if err != nil {
 		return nil, fmt.Errorf("os.Executable: %w", err)
 	}
-	cmdLine, err := windows.UTF16PtrFromString(fmt.Sprintf(`"%s" user-helper --role user`, exePath))
+	cmdLine, err := windows.UTF16PtrFromString(buildUserHelperCmdLine(exePath, "user"))
 	if err != nil {
 		return nil, fmt.Errorf("UTF16PtrFromString: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Mirror-bug regression introduced by #549: the SYSTEM-context capture helper spawned by `SpawnHelperInSession` in `spawner_windows.go` constructed its command line as `\"%s\" user-helper` with **no** `--role` flag. After #549 flipped the cobra default from `"system"` to `"user"`, that SYSTEM caller started receiving role `"user"` and the broker correctly rejected the IPC handshake with `\"user role requires non-SYSTEM identity\"`.
- Live impact (last 30 min on prod): 4 rejection events on 0.64.3-helper across HomeLaptop (Revenant Global) and win-build. Confirmed in `agent_logs` on the US droplet.
- Both Windows spawn paths now call a single `buildUserHelperCmdLine(exePath, role)` helper, so the cobra default is never load-bearing again.

## Root cause

| Path | Caller identity | Old cmdline | Old default reached | Result |
|---|---|---|---|---|
| `SpawnHelperInSession` (line 105) | SYSTEM | `"...exe" user-helper` | `"user"` (post-#549) | ❌ rejected |
| `SpawnUserHelperInSession` (line 177) | logged-in user | `"...exe" user-helper --role user` | n/a (explicit) | ✅ ok |
| `\Breeze\AgentUserHelper` Scheduled Task | BUILTIN\\Users | `user-helper` (XML, post-#549 made `--role user` explicit) | n/a | ✅ ok |

#549 acknowledged that `spawner_windows.go` had to keep working but only checked the second call site. The first call site had no `--role` at all — the bug.

## Fix

- New `spawner_cmdline.go`: `buildUserHelperCmdLine(exePath, role string) string` — one place to format the command line.
- `spawner_windows.go`:
  - `SpawnHelperInSession` → `buildUserHelperCmdLine(exePath, \"system\")`
  - `SpawnUserHelperInSession` → `buildUserHelperCmdLine(exePath, \"user\")`
- `spawner_cmdline_test.go`: regression test that asserts both \`--role system\` and \`--role user\` substrings appear, the exe path is properly quoted, and \`user-helper\` subcommand is present. Runs on every platform (no Windows-only build tag), so CI on Linux catches future drift.

## Test plan

- [x] `go test -race ./internal/sessionbroker/...` — passes locally including the new `TestBuildUserHelperCmdLine_AlwaysExplicitRole`.
- [x] `GOOS=windows go build ./internal/sessionbroker/...` — clean cross-compile.
- [x] `go vet ./internal/sessionbroker/...` — clean (pre-existing detector_windows.go warnings unrelated).
- [ ] After merge + 0.64.4 release: confirm `auth_rejected` events with reason \`user role requires non-SYSTEM identity\` stop appearing in `agent_logs` for 0.64.4-helper on HomeLaptop and win-build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)