### PR TITLE
feat(web): surface MCP URL on login + connected-apps

### DIFF
--- a/apps/web/src/components/auth/LoginPage.tsx
+++ b/apps/web/src/components/auth/LoginPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import LoginForm from './LoginForm';
 import MFAVerifyForm from './MFAVerifyForm';
+import McpUrlCard from '../shared/McpUrlCard';
 import { useAuthStore, apiLogin, apiVerifyMFA, apiSendSmsMfaCode, fetchAndApplyPreferences } from '../../stores/auth';
 import type { MfaMethod } from '../../stores/auth';
 import { navigateTo } from '../../lib/navigation';
@@ -145,6 +146,7 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
         errorMessage={error}
         loading={loading}
       />
+      <McpUrlCard variant="compact" className="mt-8" />
     </div>
   );
 }

--- a/apps/web/src/components/shared/McpUrlCard.tsx
+++ b/apps/web/src/components/shared/McpUrlCard.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+import { cn } from '../../lib/utils';
+
+interface McpUrlCardProps {
+  /** Full card with title + description (default) or compact one-liner */
+  variant?: 'card' | 'compact';
+  className?: string;
+}
+
+function resolveMcpUrl(): string {
+  const base = (import.meta.env.PUBLIC_API_URL as string | undefined)?.trim() || window.location.origin;
+  return `${base.replace(/\/$/, '')}/mcp/sse`;
+}
+
+export default function McpUrlCard({ variant = 'card', className }: McpUrlCardProps) {
+  const [url, setUrl] = useState<string>('');
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    setUrl(resolveMcpUrl());
+  }, []);
+
+  const onCopy = async () => {
+    if (!url) return;
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard blocked; user can still select the text manually.
+    }
+  };
+
+  if (variant === 'compact') {
+    return (
+      <div className={cn('text-xs text-muted-foreground', className)}>
+        <p className="mb-1">Connecting an AI agent?</p>
+        <div className="flex items-center gap-2 rounded-md border bg-muted/40 px-2 py-1.5">
+          <code className="flex-1 truncate font-mono text-[11px]" title={url}>
+            {url || '…'}
+          </code>
+          <button
+            type="button"
+            onClick={onCopy}
+            disabled={!url}
+            className="shrink-0 rounded border bg-background px-2 py-0.5 text-[11px] font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {copied ? 'Copied' : 'Copy'}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('rounded-md border bg-card p-4', className)}>
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h2 className="text-sm font-semibold">Direct your AI agent here</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Paste this URL into your MCP client (Claude.ai, ChatGPT, Cursor, …). You'll be sent
+            back here to authorize the connection via OAuth.
+          </p>
+        </div>
+      </div>
+      <div className="mt-3 flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-2">
+        <code className="flex-1 truncate font-mono text-xs" title={url}>
+          {url || 'Resolving…'}
+        </code>
+        <button
+          type="button"
+          onClick={onCopy}
+          disabled={!url}
+          className="shrink-0 rounded-md border bg-background px-3 py-1 text-xs font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/settings/connected-apps.astro
+++ b/apps/web/src/pages/settings/connected-apps.astro
@@ -1,6 +1,7 @@
 ---
 import DashboardLayout from '../../layouts/DashboardLayout.astro';
 import ConnectedAppsList from '../../components/settings/ConnectedAppsList';
+import McpUrlCard from '../../components/shared/McpUrlCard';
 ---
 
 <DashboardLayout title="Connected apps">
@@ -12,6 +13,7 @@ import ConnectedAppsList from '../../components/settings/ConnectedAppsList';
         Revoke access at any time — the app's token will be rejected within 10 minutes.
       </p>
     </div>
+    <McpUrlCard client:only="react" />
     <ConnectedAppsList client:only="react" />
   </div>
 </DashboardLayout>

--- a/docker/Caddyfile.prod
+++ b/docker/Caddyfile.prod
@@ -97,7 +97,7 @@
   }
 
   # --- API routes (with compression) ---
-  @api path /api/* /s/* /health /ready /metrics/* /i/* /activate/*
+  @api path /api/* /s/* /health /health/* /ready /metrics/* /i/* /activate/*
   handle @api {
     encode zstd gzip
     reverse_proxy api:3001

--- a/e2e-tests/.gitignore
+++ b/e2e-tests/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # Playwright output
 playwright-report/
 test-results/
+results/
 blob-report/
 
 # Auth state (generated at runtime by globalSetup)

--- a/security_reports/README.md
+++ b/security_reports/README.md
@@ -26,6 +26,7 @@ Files:
 - [R-198 through R-199](/Users/toddhebebrand/breeze/security_reports/security_best_practices_report_r198_r199.md)
 - [R-200](/Users/toddhebebrand/breeze/security_reports/security_best_practices_report_r200.md)
 - [R-201 through R-214](/Users/toddhebebrand/breeze/security_reports/security_best_practices_report_r201_r214.md)
+- [2026-05-02 General hardening review](/Users/toddhebebrand/breeze/security_reports/security_best_practices_report_2026-05-02_general_hardening.md)
 
 The canonical working report is still:
 - [security_best_practices_report.md](/Users/toddhebebrand/breeze/security_best_practices_report.md)

--- a/security_reports/security_best_practices_report_2026-05-02_general_hardening.md
+++ b/security_reports/security_best_practices_report_2026-05-02_general_hardening.md
@@ -1,0 +1,160 @@
+# Security Best Practices Review - General Hardening
+
+Date: 2026-05-02
+Repository: `/Users/toddhebebrand/breeze`
+Reviewer mode: `security-best-practices`
+
+## Executive Summary
+
+I reviewed the existing security documentation, prior remediation reports, CI security workflows, and selected high-risk API/web/agent surfaces. The previous canonical report shows the original tracked findings as remediated; this pass found no new critical or high-confidence tenant-isolation bypass.
+
+I did find four actionable hardening items:
+
+- One medium-risk open-redirect/phishing weakness in billing portal return URL handling.
+- One medium-risk push notification token logging issue.
+- One low-risk CI scanner gap where npm audit is currently advisory-only because the pinned pnpm version is known to use a retired advisory endpoint.
+- One low-risk OAuth DCR cleanup gap if dynamic client registration is enabled.
+
+Best next work: fix the two medium findings first because they are small, low-regression changes with clear security value. Then make npm audit blocking again by bumping pnpm and wiring DCR cleanup if MCP OAuth DCR is expected in any production-like environment.
+
+## Method
+
+1. Loaded the project instructions and security-best-practices guidance for TypeScript/React/Node-style web services and Go components.
+2. Reviewed previous security reports and the security policy to avoid re-reporting remediated findings.
+3. Reviewed app bootstrap, CORS/CSP/body-limit/rate-limit posture, CI scanning workflows, OAuth DCR notes, billing portal forwarding, browser auth helpers, and notification senders.
+4. Ran static searches for high-risk sinks: token storage, bearer injection, raw HTML, redirects, outbound fetch, command execution, path joins, secrets, unsafe TODOs, and unauthenticated public surfaces.
+
+Local scanner note: the local shell in this Codex environment does not have `pnpm`, `npm`, `corepack`, or `govulncheck` on `PATH`, so I could not execute a fresh local `pnpm audit` or `govulncheck` run. CI does contain security scanning workflows, reviewed below.
+
+## Medium Findings
+
+### G-001: Billing portal accepts arbitrary return URLs
+
+Rule ID: EXPRESS-REDIRECT-001
+Severity: Medium
+
+Location:
+- [/Users/toddhebebrand/breeze/apps/api/src/routes/externalServices.ts:82](/Users/toddhebebrand/breeze/apps/api/src/routes/externalServices.ts:82)
+- [/Users/toddhebebrand/breeze/apps/api/src/routes/externalServices.ts:110](/Users/toddhebebrand/breeze/apps/api/src/routes/externalServices.ts:110)
+- [/Users/toddhebebrand/breeze/apps/web/src/components/layout/Header.tsx:68](/Users/toddhebebrand/breeze/apps/web/src/components/layout/Header.tsx:68)
+
+Evidence:
+- The API schema accepts any syntactically valid URL: `returnUrl: z.string().url()`.
+- The validated value is forwarded as `return_url` to the billing service without same-origin or allowlist enforcement.
+- The normal web caller sends `window.location.href`, which is same-origin in the current UI flow, but the server-side endpoint does not enforce that contract.
+
+Impact:
+- Any authenticated partner user can ask the API to create a billing portal session with an attacker-controlled return URL. If the upstream billing/Stripe flow honors that value, the returned billing link can be used as a trusted Breeze-to-billing-to-attacker redirect chain for phishing or session-confusion attacks.
+
+Fix:
+- Validate `returnUrl` server-side against `PUBLIC_APP_URL`, `DASHBOARD_URL`, or `CORS_ALLOWED_ORIGINS`.
+- Prefer accepting only same-origin relative paths from the client, then build the absolute return URL server-side.
+- Add tests that reject `https://example.com/back` and accept the configured dashboard origin.
+
+Mitigation:
+- If the billing service already performs stricter allowlisting, document it and still add API-side validation so the security boundary is visible in this repo.
+
+False positive notes:
+- Exploitability depends on the upstream billing service honoring the forwarded `return_url`. The Breeze API currently does not show that protection.
+
+### G-002: APNS stub logs push notification tokens
+
+Rule ID: EXPRESS-CONFIG-001 / GO-CONFIG-001 equivalent secret logging control
+Severity: Medium
+
+Location:
+- [/Users/toddhebebrand/breeze/apps/api/src/services/notifications.ts:176](/Users/toddhebebrand/breeze/apps/api/src/services/notifications.ts:176)
+
+Evidence:
+- `sendAPNS()` logs `{ token, title: payload.title }` while returning a stubbed response.
+- Push tokens are bearer-like device identifiers. They should be treated as sensitive operational data because logs are commonly shipped to third-party aggregation and retained longer than application data.
+
+Impact:
+- APNS device tokens can leak into API logs whenever mobile notification dispatch hits the APNS path. A log-reader or compromised log sink could harvest device identifiers and correlate users/devices, and in some push systems a token leak can enable unauthorized notification attempts if paired with provider credentials.
+
+Fix:
+- Remove the token from the warning or log only a short hash/fingerprint, for example `sha256(token).slice(0, 12)`.
+- Add a regression test around `sendAPNS()` or notification dispatch logging if the project has logger test utilities.
+
+Mitigation:
+- Review current logs for accidental APNS token exposure if this code has run in a connected environment.
+
+False positive notes:
+- This path is currently a stub, but it is production code in the API service and receives real `device.apnsToken` values when called.
+
+## Low Findings
+
+### G-003: npm audit is advisory-only because CI pins pnpm 9.15.0
+
+Rule ID: EXPRESS-DEPENDENCY-001
+Severity: Low
+
+Location:
+- [/Users/toddhebebrand/breeze/package.json:24](/Users/toddhebebrand/breeze/package.json:24)
+- [/Users/toddhebebrand/breeze/.github/workflows/security.yml:15](/Users/toddhebebrand/breeze/.github/workflows/security.yml:15)
+- [/Users/toddhebebrand/breeze/.github/workflows/security.yml:47](/Users/toddhebebrand/breeze/.github/workflows/security.yml:47)
+
+Evidence:
+- The repo pins `packageManager` to `pnpm@9.15.0`.
+- The security workflow also sets `PNPM_VERSION: '9.15.0'`.
+- The workflow documents that this pnpm version calls a retired advisory endpoint and leaves `pnpm audit --audit-level=critical` as `continue-on-error: true`.
+
+Impact:
+- Critical npm dependency advisories may be visible in logs but will not fail pull requests or scheduled scans. In an RMM product with remote execution and agent update paths, dependency advisory response should be blocking for critical findings.
+
+Fix:
+- Bump pnpm to at least the workflow-commented fixed version, update `packageManager`, and remove `continue-on-error`.
+- Keep the current Trivy, CodeQL, Dependabot, and gitleaks workflows; they are useful complementary controls.
+
+Mitigation:
+- Until the pnpm bump lands, review the weekly security workflow output manually.
+
+False positive notes:
+- This is a process/control gap, not an exploitable code path. It is still worth fixing because the workflow explicitly says it is currently advisory-only.
+
+### G-004: OAuth DCR cleanup helper is not scheduled
+
+Rule ID: EXPRESS-DOS-001
+Severity: Low
+
+Location:
+- [/Users/toddhebebrand/breeze/apps/api/src/config/env.ts:23](/Users/toddhebebrand/breeze/apps/api/src/config/env.ts:23)
+- [/Users/toddhebebrand/breeze/apps/api/src/routes/oauth.ts:90](/Users/toddhebebrand/breeze/apps/api/src/routes/oauth.ts:90)
+- [/Users/toddhebebrand/breeze/apps/api/src/oauth/provider.ts:36](/Users/toddhebebrand/breeze/apps/api/src/oauth/provider.ts:36)
+- [/Users/toddhebebrand/breeze/apps/api/src/oauth/provider.ts:49](/Users/toddhebebrand/breeze/apps/api/src/oauth/provider.ts:49)
+- [/Users/toddhebebrand/breeze/apps/api/src/oauth/provider.ts:274](/Users/toddhebebrand/breeze/apps/api/src/oauth/provider.ts:274)
+
+Evidence:
+- `OAUTH_DCR_ENABLED` defaults to disabled in production, but can be enabled.
+- The route blocks registration only when DCR is disabled.
+- The provider enables dynamic registration with `initialAccessToken: false` when DCR is enabled.
+- The cleanup helper itself documents that anyone can create a client when DCR is enabled and that the cleanup is not wired into the worker registry.
+
+Impact:
+- If production or hosted environments enable DCR, unauthenticated clients can accumulate abandoned OAuth client rows until manual cleanup runs. Rate limiting reduces abuse speed, but the table still grows without a scheduled lifecycle control.
+
+Fix:
+- Wire `cleanupStaleOauthClients()` into a daily BullMQ/worker job when MCP OAuth is enabled.
+- Consider making production DCR require an initial access token once dashboard issuance exists.
+
+Mitigation:
+- Keep `OAUTH_DCR_ENABLED=false` in production until the cleanup is scheduled or externally cron-driven.
+
+False positive notes:
+- This is conditional on DCR being enabled. The default production value is safer, but the feature flag exists and the code comments already identify the missing scheduler.
+
+## Positive Controls Observed
+
+- API bootstrap applies secure headers, CSP, request body limits, CORS allowlisting, and global rate limiting.
+- Access tokens are no longer persisted in browser local storage; the persisted auth store excludes `tokens`.
+- Metrics scraping has a dedicated bearer token path and production redacts org IDs from Prometheus labels by default.
+- Security workflows exist for CodeQL, gitleaks, Trivy, npm audit, and Go `govulncheck`.
+- Prior reports show substantial remediation coverage across agent result binding, helper output redaction, route authorization, RLS, and queue dedupe issues.
+
+## Suggested Next Work Order
+
+1. Fix G-002 by removing APNS token logging. This is the smallest and lowest-risk code change.
+2. Fix G-001 by enforcing same-origin billing portal return URLs in the API and updating tests.
+3. Bump pnpm and make `pnpm audit --audit-level=critical` blocking again.
+4. Wire OAuth DCR cleanup if DCR is expected outside local development.
+5. Continue deeper manual review in these areas: public installer/download endpoints, remote desktop/tunnel ticket lifecycles, AI tool execution approvals, and file browser upload/download path handling.


### PR DESCRIPTION
## Summary

- Adds a small `McpUrlCard` component that resolves the tenant's MCP SSE endpoint and exposes it with a copy button.
- **Compact variant** sits under the login form ("Connecting an AI agent?") so users discover the URL before they even sign in.
- **Full card** sits above the list on Settings → Connected apps so users can paste it into Claude.ai, ChatGPT, Cursor, etc. before authorizing via OAuth.
- Caddyfile.prod tweak + e2e gitignore tweak + a 2026-05-02 hardening review report under `security_reports/`.

## Background

This PR was originally committed on top of #554 on the same feature branch, but it never made it onto the GitHub branch before #554 was squash-merged. Recovered from local git objects and rebased onto the post-#554 main.

## Test plan

- [ ] Visit `/login` while signed out — confirm the compact "Connecting an AI agent?" block renders with a copyable MCP URL.
- [ ] Visit `/settings/connected-apps` while signed in — confirm the full McpUrlCard renders above the apps list.
- [ ] Click copy → URL is on the clipboard.
- [ ] Caddyfile.prod change deploys cleanly to the US droplet (`docker compose up -d caddy` with no errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)