### PR TITLE
feat: anti-abuse — platform-admin gate, suspend, email verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -374,3 +374,12 @@ IS_HOSTED=false
 BILLING_URL=
 # PUBLIC_ACTIVATION_BASE_URL=https://us.2breeze.app
 # BUSINESS_EMAIL_ALLOW_OVERRIDES=/etc/breeze/email-overrides.json
+
+# --------------------------------------------
+# Platform admins (cross-tenant /admin/* gate)
+# --------------------------------------------
+# Comma-separated list of user emails to promote to platform admin at API
+# startup. Idempotent (already-promoted users are skipped) and never demotes —
+# removing an email from this list does NOT revoke the flag, demote via DB.
+# Leave unset to opt out (no platform admins, /admin/* endpoints will 403).
+BREEZE_PLATFORM_ADMINS=

--- a/apps/api/migrations/2026-05-04-a-users-email-verified-at.sql
+++ b/apps/api/migrations/2026-05-04-a-users-email-verified-at.sql
@@ -1,0 +1,11 @@
+-- Track which user clicked the verification link.
+-- partners.email_verified_at already records "this tenant has verified an
+-- email address". Adding the same stamp on users lets us re-verify or
+-- block re-resend on a per-user basis when a partner has multiple users
+-- (the foreseeable case once we surface a "send another verification
+-- email" affordance from the user's profile page).
+--
+-- Idempotent: column add is gated on IF NOT EXISTS.
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS email_verified_at timestamp;

--- a/apps/api/migrations/2026-05-04-anti-abuse-foundation.sql
+++ b/apps/api/migrations/2026-05-04-anti-abuse-foundation.sql
@@ -1,0 +1,73 @@
+-- Anti-abuse foundation:
+--   1. users.is_platform_admin flag (env-bootstrapped at API startup)
+--   2. email_verification_tokens table for the signup-email-verify flow
+--      (gate post-payment partner activation on email_verified_at)
+--
+-- All operations idempotent; this migration must be a no-op on re-apply.
+
+-- 1. Platform admin flag on users -------------------------------------------
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS is_platform_admin boolean NOT NULL DEFAULT false;
+
+-- Partial index: scanning the (very small) set of platform admins is the
+-- only access pattern; keeps the index tiny.
+CREATE INDEX IF NOT EXISTS users_is_platform_admin_idx
+  ON users (id) WHERE is_platform_admin = true;
+
+-- 2. email_verification_tokens table ----------------------------------------
+
+CREATE TABLE IF NOT EXISTS email_verification_tokens (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  token_hash  varchar(64) NOT NULL UNIQUE,
+  partner_id  uuid NOT NULL REFERENCES partners(id) ON DELETE CASCADE,
+  user_id     uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  email       varchar(255) NOT NULL,
+  expires_at  timestamp NOT NULL,
+  consumed_at timestamp,
+  created_at  timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS email_verification_tokens_partner_idx
+  ON email_verification_tokens (partner_id);
+
+CREATE INDEX IF NOT EXISTS email_verification_tokens_user_idx
+  ON email_verification_tokens (user_id);
+
+-- Reaper-friendly: only tracks live (unconsumed) tokens for expiry sweeps.
+CREATE INDEX IF NOT EXISTS email_verification_tokens_unconsumed_expires_idx
+  ON email_verification_tokens (expires_at) WHERE consumed_at IS NULL;
+
+-- RLS: partner-axis (shape #3). Token lookup during /auth/verify-email runs
+-- in system scope (no auth context yet) — the partner predicate accepts
+-- 'system' scope by design, so verification works pre-login.
+ALTER TABLE email_verification_tokens ENABLE ROW LEVEL SECURITY;
+ALTER TABLE email_verification_tokens FORCE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies
+                 WHERE tablename = 'email_verification_tokens'
+                   AND policyname = 'breeze_evt_isolation_select') THEN
+    CREATE POLICY breeze_evt_isolation_select ON email_verification_tokens
+      FOR SELECT USING (breeze_has_partner_access(partner_id));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies
+                 WHERE tablename = 'email_verification_tokens'
+                   AND policyname = 'breeze_evt_isolation_insert') THEN
+    CREATE POLICY breeze_evt_isolation_insert ON email_verification_tokens
+      FOR INSERT WITH CHECK (breeze_has_partner_access(partner_id));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies
+                 WHERE tablename = 'email_verification_tokens'
+                   AND policyname = 'breeze_evt_isolation_update') THEN
+    CREATE POLICY breeze_evt_isolation_update ON email_verification_tokens
+      FOR UPDATE USING (breeze_has_partner_access(partner_id))
+                 WITH CHECK (breeze_has_partner_access(partner_id));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies
+                 WHERE tablename = 'email_verification_tokens'
+                   AND policyname = 'breeze_evt_isolation_delete') THEN
+    CREATE POLICY breeze_evt_isolation_delete ON email_verification_tokens
+      FOR DELETE USING (breeze_has_partner_access(partner_id));
+  END IF;
+END $$;

--- a/apps/api/migrations/2026-05-04-b-evt-superseded-at.sql
+++ b/apps/api/migrations/2026-05-04-b-evt-superseded-at.sql
@@ -1,0 +1,9 @@
+-- email_verification_tokens.superseded_at — distinguishes "live token claimed
+-- by user" (consumed_at) from "live token invalidated by a later resend"
+-- (superseded_at). Without this distinction, the verify endpoint can't tell
+-- the user "a newer link was sent" vs. "you already verified."
+--
+-- Idempotent.
+
+ALTER TABLE email_verification_tokens
+  ADD COLUMN IF NOT EXISTS superseded_at timestamp;

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -54,6 +54,7 @@ const PARTNER_TENANT_TABLES: ReadonlyMap<string, string> = new Map<string, strin
   // the column name; the policy's `partner_id IS NULL OR ...` clause is
   // checked by the policy's own qual, not this allowlist.
   ['oauth_grants', 'partner_id'],
+  ['email_verification_tokens', 'partner_id'],
 ]);
 
 // Tables whose policies reference both helpers (org OR partner). `users`

--- a/apps/api/src/db/schema/emailVerificationTokens.ts
+++ b/apps/api/src/db/schema/emailVerificationTokens.ts
@@ -1,0 +1,32 @@
+import { pgTable, uuid, varchar, timestamp, index } from 'drizzle-orm/pg-core';
+import { partners } from './orgs';
+import { users } from './users';
+
+// Single-use, partner-scoped tokens emitted on signup. The verification
+// endpoint runs in system scope (pre-login) and looks up the row by
+// hashed token, then stamps `consumed_at` and `partners.email_verified_at`.
+export const emailVerificationTokens = pgTable(
+  'email_verification_tokens',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tokenHash: varchar('token_hash', { length: 64 }).notNull().unique(),
+    partnerId: uuid('partner_id')
+      .notNull()
+      .references(() => partners.id, { onDelete: 'cascade' }),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    email: varchar('email', { length: 255 }).notNull(),
+    expiresAt: timestamp('expires_at').notNull(),
+    consumedAt: timestamp('consumed_at'),
+    // Stamped when a later resend invalidates this still-live token, so
+    // the verify endpoint can return 'superseded' (a newer link was sent)
+    // distinct from 'consumed' (the user already used this link).
+    supersededAt: timestamp('superseded_at'),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (t) => ({
+    partnerIdx: index('email_verification_tokens_partner_idx').on(t.partnerId),
+    userIdx: index('email_verification_tokens_user_idx').on(t.userId),
+  })
+);

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -64,3 +64,4 @@ export * from './incidentResponse';
 export * from './tunnels';
 export * from './installerBootstrapTokens';
 export * from './deploymentInvites';
+export * from './emailVerificationTokens';

--- a/apps/api/src/db/schema/users.ts
+++ b/apps/api/src/db/schema/users.ts
@@ -30,6 +30,11 @@ export const users = pgTable('users', {
   passwordChangedAt: timestamp('password_changed_at'),
   setupCompletedAt: timestamp('setup_completed_at'),
   preferences: jsonb('preferences'),
+  emailVerifiedAt: timestamp('email_verified_at'),
+  // Platform-level admin flag — bootstrapped from BREEZE_PLATFORM_ADMINS env
+  // var at API startup, gates the cross-tenant /admin/* endpoints (e.g.
+  // suspend-for-abuse). Intentionally lives outside the partner role system.
+  isPlatformAdmin: boolean('is_platform_admin').notNull().default(false),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull()
 });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -106,6 +106,8 @@ import { peripheralControlRoutes } from './routes/peripheralControl';
 import { browserSecurityRoutes } from './routes/browserSecurity';
 import { c2cRoutes, m365CallbackRoute } from './routes/c2c';
 import { drRoutes } from './routes/dr';
+import { adminRoutes } from './routes/admin';
+import { bootstrapPlatformAdmins } from './services/platformAdminBootstrap';
 import { captureException } from './services/sentry';
 import { partnerGuard } from './middleware/partnerGuard';
 import { API_VERSION } from './version';
@@ -768,6 +770,7 @@ api.route('/browser-security', browserSecurityRoutes);
 api.route('/', m365CallbackRoute); // Public callback (no auth) — must precede c2c group
 api.route('/c2c', c2cRoutes);
 api.route('/dr', drRoutes);
+api.route('/admin', adminRoutes);
 
 app.route('/api/v1', api);
 
@@ -1205,6 +1208,12 @@ async function bootstrap(): Promise<void> {
   // `db`) would fail first.
   if (process.env.AUTO_MIGRATE !== 'false') {
     await autoMigrate();
+  }
+
+  try {
+    await bootstrapPlatformAdmins();
+  } catch (err) {
+    console.error('[startup] Platform admin bootstrap failed (non-fatal):', err);
   }
 
   await runStartupChecks();

--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -36,7 +36,8 @@ vi.mock('../db/schema', () => ({
     id: 'id',
     email: 'email',
     name: 'name',
-    status: 'status'
+    status: 'status',
+    isPlatformAdmin: 'isPlatformAdmin'
   },
   partnerUsers: {
     userId: 'partnerUsers.userId',
@@ -73,14 +74,16 @@ const activeUser = {
   id: 'user-123',
   email: 'test@example.com',
   name: 'Test User',
-  status: 'active'
+  status: 'active',
+  isPlatformAdmin: false
 };
 
 const baseAuth = {
   user: {
     id: 'user-123',
     email: 'test@example.com',
-    name: 'Test User'
+    name: 'Test User',
+    isPlatformAdmin: false
   },
   token: basePayload,
   partnerId: basePayload.partnerId,

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -14,6 +14,7 @@ export interface AuthContext {
     id: string;
     email: string;
     name: string;
+    isPlatformAdmin: boolean;
   };
   token: TokenPayload;
   partnerId: string | null;
@@ -91,7 +92,8 @@ export async function optionalAuthMiddleware(c: Context, next: Next) {
         id: users.id,
         email: users.email,
         name: users.name,
-        status: users.status
+        status: users.status,
+        isPlatformAdmin: users.isPlatformAdmin
       })
       .from(users)
       .where(eq(users.id, payload.sub))
@@ -139,7 +141,8 @@ export async function optionalAuthMiddleware(c: Context, next: Next) {
           user: {
             id: user.id,
             email: user.email,
-            name: user.name
+            name: user.name,
+            isPlatformAdmin: user.isPlatformAdmin
           },
           token: payload,
           partnerId: payload.partnerId,
@@ -300,7 +303,8 @@ export async function authMiddleware(c: Context, next: Next) {
         id: users.id,
         email: users.email,
         name: users.name,
-        status: users.status
+        status: users.status,
+        isPlatformAdmin: users.isPlatformAdmin
       })
       .from(users)
       .where(eq(users.id, payload.sub))
@@ -360,7 +364,8 @@ export async function authMiddleware(c: Context, next: Next) {
         user: {
           id: user.id,
           email: user.email,
-          name: user.name
+          name: user.name,
+          isPlatformAdmin: user.isPlatformAdmin
         },
         token: payload,
         partnerId: payload.partnerId,

--- a/apps/api/src/middleware/platformAdmin.test.ts
+++ b/apps/api/src/middleware/platformAdmin.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./auth', () => ({
+  authMiddleware: vi.fn(),
+}));
+
+vi.mock('../services/auditService', () => ({
+  createAuditLogAsync: vi.fn(),
+}));
+
+vi.mock('../services/clientIp', () => ({
+  getTrustedClientIpOrUndefined: vi.fn(() => '127.0.0.1'),
+}));
+
+import { Hono } from 'hono';
+import { platformAdminMiddleware } from './platformAdmin';
+import { authMiddleware } from './auth';
+import { createAuditLogAsync } from '../services/auditService';
+
+type AuthShape = {
+  user: { id: string; email: string; name: string; isPlatformAdmin: boolean };
+};
+
+function makeApp(authToInject: AuthShape | null) {
+  const app = new Hono();
+
+  vi.mocked(authMiddleware).mockImplementation(async (c, next) => {
+    if (authToInject) {
+      c.set('auth', authToInject as never);
+    }
+    await next();
+  });
+
+  app.use('*', platformAdminMiddleware);
+  app.get('/admin/partners/:id/anything', (c) => c.json({ ok: true, partnerId: c.req.param('id') }));
+  return app;
+}
+
+describe('platformAdminMiddleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 403 when not authenticated (no auth context after auth middleware)', async () => {
+    const app = makeApp(null);
+    const res = await app.request('/admin/partners/p-1/anything');
+    expect(res.status).toBe(403);
+    expect(createAuditLogAsync).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when authenticated but not a platform admin', async () => {
+    const app = makeApp({
+      user: { id: 'u1', email: 'u@x.com', name: 'U', isPlatformAdmin: false },
+    });
+    const res = await app.request('/admin/partners/p-1/anything');
+    expect(res.status).toBe(403);
+    expect(createAuditLogAsync).not.toHaveBeenCalled();
+  });
+
+  it('passes through and audit-logs when caller is platform admin', async () => {
+    const app = makeApp({
+      user: { id: 'u1', email: 'pa@x.com', name: 'PA', isPlatformAdmin: true },
+    });
+    const res = await app.request('/admin/partners/p-1/anything');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean };
+    expect(body.ok).toBe(true);
+    expect(createAuditLogAsync).toHaveBeenCalledTimes(1);
+    const audit = vi.mocked(createAuditLogAsync).mock.calls[0]![0];
+    expect(audit.action).toMatch(/^platform_admin\./);
+    expect(audit.actorId).toBe('u1');
+    expect(audit.resourceType).toBe('platform_admin');
+  });
+});

--- a/apps/api/src/middleware/platformAdmin.ts
+++ b/apps/api/src/middleware/platformAdmin.ts
@@ -1,0 +1,61 @@
+import { Context, Next } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+import { authMiddleware } from './auth';
+import { createAuditLogAsync } from '../services/auditService';
+import { getTrustedClientIpOrUndefined } from '../services/clientIp';
+
+/**
+ * Gates cross-tenant /admin/* endpoints to platform admins only. Runs the
+ * standard authMiddleware first, then enforces `isPlatformAdmin === true`.
+ * Every request that reaches a protected handler is audit-logged with
+ * action `platform_admin.<route>` so we can spot misuse after the fact.
+ */
+export async function platformAdminMiddleware(c: Context, next: Next) {
+  let authorized = false;
+
+  await authMiddleware(c, async () => {
+    const auth = c.get('auth');
+    if (auth?.user?.isPlatformAdmin !== true) {
+      throw new HTTPException(403, { message: 'platform admin access required' });
+    }
+
+    authorized = true;
+    const route = buildRouteAction(c.req.path);
+    createAuditLogAsync({
+      orgId: null,
+      actorType: 'user',
+      actorId: auth.user.id,
+      actorEmail: auth.user.email,
+      action: `platform_admin.${route}`,
+      resourceType: 'platform_admin',
+      details: {
+        method: c.req.method,
+        path: c.req.path,
+      },
+      ipAddress: getTrustedClientIpOrUndefined(c),
+      userAgent: c.req.header('user-agent'),
+      result: 'success',
+    });
+
+    await next();
+  });
+
+  // If authMiddleware threw HTTPException, we never reach here. If it ran
+  // without auth being set (e.g. mocked-out in tests), enforce 403 here too.
+  if (!authorized) {
+    throw new HTTPException(403, { message: 'platform admin access required' });
+  }
+}
+
+function buildRouteAction(path: string): string {
+  const cleaned = path.replace(/^\/api\/v1\/admin\//, '').replace(/^\/admin\//, '');
+  const segments = cleaned
+    .split('/')
+    .filter(Boolean)
+    .map((seg) =>
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(seg) ? ':id' : seg
+    )
+    .slice(0, 4);
+  const action = segments.join('.') || 'unknown';
+  return action.length > 80 ? action.slice(0, 80) : action;
+}

--- a/apps/api/src/routes/admin/abuse.test.ts
+++ b/apps/api/src/routes/admin/abuse.test.ts
@@ -1,0 +1,423 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// We test the platform-admin gate, Zod validation, audit-log shape, and
+// not-found path. The full suspend transaction (multi-statement Drizzle calls
+// against a chain of tables) is exercised by integration tests with a real
+// Postgres; mocking every chain accurately here would be brittle.
+
+const txMockState = vi.hoisted(() => ({
+  partner: null as null | {
+    id: string;
+    status: string;
+    paymentMethodAttachedAt: Date | null;
+  },
+  partnerDevices: [] as Array<{ id: string }>,
+  partnerOrgs: [] as Array<{ id: string }>,
+  partnerUserRows: [] as Array<{ id: string; isPlatformAdmin: boolean }>,
+  disabledUsers: [] as Array<{ id: string }>,
+  revokedKeys: [] as Array<{ id: string }>,
+  reEnabledUsers: [] as Array<{ id: string }>,
+  insertedCommands: 0,
+  insertedCommandRows: [] as Array<Record<string, unknown>>,
+  updates: [] as Array<{ table: string; values: Record<string, unknown> }>,
+  deletes: [] as Array<{ table: string }>,
+}));
+
+function makeTx() {
+  // The suspend route's call sequence (from abuse.ts):
+  //   1. select(partner).from(partners).where(...).limit(1)        → partner row
+  //   2. update(partners).set(...).where(...)                       → status flip
+  //   3. select(devices.id).from(devices).innerJoin(orgs).where(...) → device list
+  //   4. insert(deviceCommands).values([...])                       → uninstall queue
+  //   5. update(deviceCommands).set(...).where(...)                 → cancel others
+  //   6. select(users).from(users).where(partnerId)                 → user list
+  //   7. delete(sessions).where(...)                                → session purge
+  //   8. update(users).set({status:'disabled'}).where(...).returning → disable
+  //   9. select(orgs).from(orgs).where(partnerId)                   → orgs
+  //  10. update(apiKeys).set({status:'revoked'}).where(...).returning → revoke
+  //
+  // Unsuspend is much simpler:
+  //   1. select(partner).from(partners).where(...).limit(1)
+  //   2. update(partners).set(...).where(...)
+  //   3. update(users).set({status:'active'}).where(...).returning
+  //
+  // We route by select-call-index so each test can seed state and inspect the
+  // captured `updates` / `insertedCommandRows` / `deletes` after the request.
+  let selectCalls = 0;
+  return {
+    select: vi.fn(() => {
+      const call = ++selectCalls;
+      return {
+        from: () => ({
+          where: () => {
+            // partner-by-id select on calls 1 (suspend) and 1 (unsuspend); also
+            // user list on call 3 of suspend, orgs on call 4. Differentiate
+            // with thenable+limit so the right call gets the right shape.
+            const thenable: any = Promise.resolve(
+              call === 3
+                ? txMockState.partnerUserRows
+                : call === 4
+                ? txMockState.partnerOrgs
+                : txMockState.partner
+                ? [txMockState.partner]
+                : [],
+            );
+            thenable.limit = () =>
+              Promise.resolve(txMockState.partner ? [txMockState.partner] : []);
+            return thenable;
+          },
+          innerJoin: () => ({
+            where: () => Promise.resolve(txMockState.partnerDevices),
+          }),
+        }),
+      };
+    }),
+    update: vi.fn((tableRef: any) => ({
+      set: (values: any) => ({
+        where: () => {
+          txMockState.updates.push({
+            table: tableRef === 'partners.id' || tableRef?._t === 'partners' ? 'partners' : 'unknown',
+            values,
+          });
+          // returning() is called on user disable + api key revoke.
+          const ret: any = Promise.resolve(undefined);
+          ret.returning = () => {
+            // Heuristic: route by which set() shape we're seeing.
+            if (values?.status === 'disabled') {
+              return Promise.resolve(txMockState.disabledUsers);
+            }
+            if (values?.status === 'revoked') {
+              return Promise.resolve(txMockState.revokedKeys);
+            }
+            if (values?.status === 'active') {
+              return Promise.resolve(txMockState.reEnabledUsers);
+            }
+            return Promise.resolve([]);
+          };
+          return ret;
+        },
+      }),
+    })),
+    insert: vi.fn(() => ({
+      values: (rows: unknown) => {
+        if (Array.isArray(rows)) {
+          txMockState.insertedCommands += rows.length;
+          txMockState.insertedCommandRows.push(...(rows as Array<Record<string, unknown>>));
+        }
+        return Promise.resolve();
+      },
+    })),
+    delete: vi.fn(() => ({
+      where: () => {
+        txMockState.deletes.push({ table: 'sessions' });
+        return Promise.resolve();
+      },
+    })),
+    execute: vi.fn(() => Promise.resolve([])),
+  };
+}
+
+vi.mock('../../db', () => ({
+  db: {
+    transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+      return fn(makeTx());
+    }),
+  },
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../../db/schema', () => ({
+  partners: { id: 'partners.id', status: 'partners.status', paymentMethodAttachedAt: 'partners.pma' },
+  organizations: { id: 'organizations.id', partnerId: 'organizations.partnerId' },
+  devices: { id: 'devices.id', orgId: 'devices.orgId' },
+  deviceCommands: {
+    id: 'device_commands.id',
+    deviceId: 'device_commands.deviceId',
+    type: 'device_commands.type',
+    status: 'device_commands.status',
+  },
+  users: {
+    id: 'users.id',
+    partnerId: 'users.partnerId',
+    isPlatformAdmin: 'users.isPlatformAdmin',
+    status: 'users.status',
+  },
+  sessions: { userId: 'sessions.userId' },
+  apiKeys: { orgId: 'apiKeys.orgId', status: 'apiKeys.status' },
+}));
+
+vi.mock('../../services/auditService', () => ({
+  createAuditLog: vi.fn(async () => undefined),
+  createAuditLogAsync: vi.fn(),
+}));
+
+vi.mock('../../services/tokenRevocation', () => ({
+  revokeAllUserTokens: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../services/clientIp', () => ({
+  getTrustedClientIpOrUndefined: vi.fn(() => '127.0.0.1'),
+}));
+
+// Stub authMiddleware to short-circuit; the test injects its own auth context.
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (_c: unknown, next: () => Promise<void>) => next()),
+}));
+
+import { Hono } from 'hono';
+import { adminRoutes } from './index';
+import { createAuditLog } from '../../services/auditService';
+import { revokeAllUserTokens } from '../../services/tokenRevocation';
+
+type FakeAuth = {
+  user: { id: string; email: string; name: string; isPlatformAdmin: boolean };
+};
+
+function buildApp(authToInject: FakeAuth | null) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    if (authToInject) {
+      c.set('auth', authToInject as never);
+    }
+    await next();
+  });
+  app.route('/admin', adminRoutes);
+  return app;
+}
+
+const platformAdminAuth: FakeAuth = {
+  user: { id: 'admin-1', email: 'admin@breeze.test', name: 'PA', isPlatformAdmin: true },
+};
+
+const partnerAdminAuth: FakeAuth = {
+  user: { id: 'pa-1', email: 'partner@x.com', name: 'PartnerAdmin', isPlatformAdmin: false },
+};
+
+function resetState() {
+  Object.assign(txMockState, {
+    partner: { id: 'partner-1', status: 'active', paymentMethodAttachedAt: new Date() },
+    partnerDevices: [{ id: 'd-1' }, { id: 'd-2' }, { id: 'd-3' }],
+    partnerOrgs: [{ id: 'org-1' }, { id: 'org-2' }],
+    partnerUserRows: [
+      { id: 'u-1', isPlatformAdmin: false },
+      { id: 'u-2', isPlatformAdmin: false },
+    ],
+    disabledUsers: [{ id: 'u-1' }, { id: 'u-2' }],
+    revokedKeys: [{ id: 'k-1' }, { id: 'k-2' }, { id: 'k-3' }],
+    reEnabledUsers: [{ id: 'u-1' }],
+    insertedCommands: 0,
+    insertedCommandRows: [],
+    updates: [],
+    deletes: [],
+  });
+}
+
+describe('admin/abuse — auth gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetState();
+    process.env.NODE_ENV = 'test';
+  });
+
+  it('rejects callers without a platform admin flag (403) on suspend', async () => {
+    const app = buildApp(partnerAdminAuth);
+    const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'long enough reason here' }),
+    });
+    expect(res.status).toBe(403);
+    expect(createAuditLog).not.toHaveBeenCalled();
+    expect(revokeAllUserTokens).not.toHaveBeenCalled();
+  });
+
+  it('rejects unauthenticated callers (403)', async () => {
+    const app = buildApp(null);
+    const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'long enough reason here' }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('400s when reason is too short', async () => {
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'short' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('platform admin gate is enforced on /unsuspend as well', async () => {
+    const app = buildApp(partnerAdminAuth);
+    const res = await app.request('/admin/partners/partner-1/unsuspend', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'restoring legit customer' }),
+    });
+    expect(res.status).toBe(403);
+    expect(createAuditLog).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for missing partner on suspend', async () => {
+    txMockState.partner = null;
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/partners/missing/suspend-for-abuse', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'this is a long enough reason' }),
+    });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('partner not found');
+    expect(revokeAllUserTokens).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for missing partner on unsuspend', async () => {
+    txMockState.partner = null;
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/partners/missing/unsuspend', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'this is a long enough reason' }),
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('admin/abuse — suspend mutation behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetState();
+    process.env.NODE_ENV = 'test';
+  });
+
+  it('queues self_uninstall for every device, revokes JWTs for users, audits success', async () => {
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'cross-region account farming detected' }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      partnerId: string;
+      status: string;
+      deviceCount: number;
+      userCount: number;
+      apiKeyCount: number;
+      queuedUninstalls: number;
+    };
+    expect(body).toMatchObject({
+      partnerId: 'partner-1',
+      status: 'suspended',
+      deviceCount: 3,
+      userCount: 2,
+      apiKeyCount: 3,
+      queuedUninstalls: 3,
+    });
+
+    // self_uninstall queued one row per device.
+    expect(txMockState.insertedCommands).toBe(3);
+    expect(txMockState.insertedCommandRows).toHaveLength(3);
+    txMockState.insertedCommandRows.forEach((row) => {
+      expect(row.type).toBe('self_uninstall');
+      expect(row.status).toBe('pending');
+      expect(row.targetRole).toBe('agent');
+      expect(row.payload).toEqual({ removeConfig: true });
+    });
+
+    // Sessions deleted (caller is not a member of partner here, so all users targeted).
+    expect(txMockState.deletes).toContainEqual({ table: 'sessions' });
+
+    // Captured updates include partner→suspended, users→disabled, apiKeys→revoked.
+    const setStatusValues = txMockState.updates.map((u) => u.values?.status);
+    expect(setStatusValues).toEqual(expect.arrayContaining(['suspended', 'disabled', 'revoked']));
+
+    // JWT revocation called for each affected user.
+    expect(revokeAllUserTokens).toHaveBeenCalledTimes(2);
+    expect(revokeAllUserTokens).toHaveBeenCalledWith('u-1');
+    expect(revokeAllUserTokens).toHaveBeenCalledWith('u-2');
+
+    // Audit log written with the right action + details.
+    expect(createAuditLog).toHaveBeenCalledTimes(1);
+    const auditCall = vi.mocked(createAuditLog).mock.calls[0]![0]!;
+    expect(auditCall.action).toBe('partner.suspended_for_abuse');
+    expect(auditCall.resourceId).toBe('partner-1');
+    expect(auditCall.result).toBe('success');
+    expect(auditCall.details).toMatchObject({
+      reason: 'cross-region account farming detected',
+      deviceCount: 3,
+      userCount: 2,
+      apiKeyCount: 3,
+    });
+  });
+
+  it('does NOT disable, log out, or revoke tokens for the calling platform admin if they are a member of the partner', async () => {
+    // Caller is admin-1, also a member of the partner being suspended.
+    txMockState.partnerUserRows = [
+      { id: 'admin-1', isPlatformAdmin: true },
+      { id: 'u-2', isPlatformAdmin: false },
+    ];
+    txMockState.disabledUsers = [{ id: 'u-2' }]; // the SQL filter excludes the admin
+
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'self-suspend prevention test case' }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { userCount: number };
+    expect(body.userCount).toBe(1); // only u-2
+
+    // JWT revocation must NOT be called for admin-1.
+    const revokedIds = vi.mocked(revokeAllUserTokens).mock.calls.map((call) => call[0]);
+    expect(revokedIds).not.toContain('admin-1');
+    expect(revokedIds).toContain('u-2');
+  });
+
+  it('returns 500 with tokenRevocationFailed when Redis revocation throws (does NOT silently 200)', async () => {
+    vi.mocked(revokeAllUserTokens).mockRejectedValueOnce(new Error('Redis unavailable'));
+
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'redis-down silent failure regression' }),
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as {
+      error: string;
+      tokenRevocationFailed: boolean;
+      tokenRevocationFailures: Array<{ userId: string; error: string }>;
+    };
+    expect(body.error).toBe('partial_suspend');
+    expect(body.tokenRevocationFailed).toBe(true);
+    expect(body.tokenRevocationFailures).toHaveLength(1);
+    expect(body.tokenRevocationFailures[0]!.error).toContain('Redis unavailable');
+
+    // Audit log is still written, but with result='failure'.
+    const auditCall = vi.mocked(createAuditLog).mock.calls[0]![0]!;
+    expect(auditCall.result).toBe('failure');
+    expect((auditCall.details as Record<string, unknown>).tokenRevocationFailures).toBeDefined();
+  });
+
+  it('still returns 200 (and writes audit) when createAuditLog itself throws', async () => {
+    vi.mocked(createAuditLog).mockRejectedValueOnce(new Error('audit DB down'));
+
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'audit failure must not undo suspend' }),
+    });
+    // Suspend committed, JWTs revoked — losing the audit row is recoverable.
+    // We still report success so the operator UI doesn't go red on something
+    // that already happened.
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/api/src/routes/admin/abuse.ts
+++ b/apps/api/src/routes/admin/abuse.ts
@@ -1,0 +1,323 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
+import { and, eq, inArray, ne } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import {
+  partners,
+  organizations,
+  devices,
+  deviceCommands,
+  users,
+  sessions,
+  apiKeys,
+} from '../../db/schema';
+import { createAuditLog } from '../../services/auditService';
+import { revokeAllUserTokens } from '../../services/tokenRevocation';
+import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
+import { captureException } from '../../services/sentry';
+
+export const abuseRoutes = new Hono();
+
+const reasonSchema = z.object({
+  reason: z.string().trim().min(10, 'reason must be at least 10 characters'),
+});
+
+abuseRoutes.post(
+  '/partners/:id/suspend-for-abuse',
+  zValidator('json', reasonSchema),
+  async (c) => {
+    const partnerId = c.req.param('id');
+    const { reason } = c.req.valid('json');
+    const auth = c.get('auth');
+    const callerId = auth.user.id;
+
+    const result = await withSystemDbAccessContext(async () => {
+      return db.transaction(async (tx) => {
+        const [partner] = await tx
+          .select({ id: partners.id, status: partners.status })
+          .from(partners)
+          .where(eq(partners.id, partnerId))
+          .limit(1);
+
+        if (!partner) {
+          return { notFound: true as const };
+        }
+
+        await tx
+          .update(partners)
+          .set({ status: 'suspended', updatedAt: new Date() })
+          .where(eq(partners.id, partnerId));
+
+        // Collect device IDs under this partner (one query, used for both queueing
+        // uninstalls and cancelling other pending commands).
+        const partnerDevices = await tx
+          .select({ id: devices.id })
+          .from(devices)
+          .innerJoin(organizations, eq(devices.orgId, organizations.id))
+          .where(eq(organizations.partnerId, partnerId));
+        const deviceIds = partnerDevices.map((d) => d.id);
+        const deviceCount = deviceIds.length;
+
+        if (deviceCount > 0) {
+          // Queue a self_uninstall for every device in one INSERT (multi-row VALUES).
+          await tx.insert(deviceCommands).values(
+            deviceIds.map((id) => ({
+              deviceId: id,
+              type: 'self_uninstall',
+              payload: { removeConfig: true },
+              status: 'pending',
+              targetRole: 'agent',
+              createdBy: callerId,
+            }))
+          );
+
+          // Cancel any other pending/sent commands for those devices.
+          await tx
+            .update(deviceCommands)
+            .set({
+              status: 'cancelled',
+              completedAt: new Date(),
+              result: { reason: 'partner_suspended_for_abuse' },
+            })
+            .where(
+              and(
+                inArray(deviceCommands.deviceId, deviceIds),
+                ne(deviceCommands.type, 'self_uninstall'),
+                inArray(deviceCommands.status, ['pending', 'sent'])
+              )
+            );
+        }
+
+        // Collect users for revocation BEFORE deleting sessions.
+        const partnerUserRows = await tx
+          .select({ id: users.id, isPlatformAdmin: users.isPlatformAdmin })
+          .from(users)
+          .where(eq(users.partnerId, partnerId));
+        const partnerUserIds = partnerUserRows.map((u) => u.id);
+
+        // Delete sessions for all partner users EXCEPT the calling platform
+        // admin if they happen to be a member. We also skip them in the JWT
+        // revocation step below — keeps the responder logged in mid-incident.
+        const sessionTargets = partnerUserIds.filter((id) => id !== callerId);
+        if (sessionTargets.length > 0) {
+          await tx.delete(sessions).where(inArray(sessions.userId, sessionTargets));
+        }
+
+        // Disable users — but never disable the calling platform admin if
+        // they happen to be a member of the partner being suspended.
+        const disableResult = await tx
+          .update(users)
+          .set({ status: 'disabled', updatedAt: new Date() })
+          .where(
+            and(
+              eq(users.partnerId, partnerId),
+              eq(users.isPlatformAdmin, false)
+            )
+          )
+          .returning({ id: users.id });
+        const userCount = disableResult.length;
+
+        // Revoke API keys for orgs under this partner.
+        const partnerOrgs = await tx
+          .select({ id: organizations.id })
+          .from(organizations)
+          .where(eq(organizations.partnerId, partnerId));
+        const orgIds = partnerOrgs.map((o) => o.id);
+
+        let apiKeyCount = 0;
+        if (orgIds.length > 0) {
+          const apiKeyResult = await tx
+            .update(apiKeys)
+            .set({ status: 'revoked', updatedAt: new Date() })
+            .where(and(inArray(apiKeys.orgId, orgIds), ne(apiKeys.status, 'revoked')))
+            .returning({ id: apiKeys.id });
+          apiKeyCount = apiKeyResult.length;
+        }
+
+        return {
+          notFound: false as const,
+          deviceCount,
+          userCount,
+          apiKeyCount,
+          affectedUserIds: partnerUserRows
+            .filter((u) => !(u.isPlatformAdmin && u.id === callerId))
+            .map((u) => u.id),
+        };
+      });
+    });
+
+    if (result.notFound) {
+      return c.json({ error: 'partner not found' }, 404);
+    }
+
+    // Outside the transaction: revoke each affected user's JWTs in Redis.
+    // If Redis is degraded, the DB suspend has already committed but the
+    // existing JWTs would still be honoured until natural expiry — that is
+    // a partial-suspend that the operator MUST know about. We surface the
+    // failure as 500 + audit with result='failure' so they can fail-close
+    // (e.g. flush Redis manually, then re-run the suspend).
+    const tokenRevocationFailures: Array<{ userId: string; error: string }> = [];
+    const revokeResults = await Promise.allSettled(
+      result.affectedUserIds.map((id) => revokeAllUserTokens(id)),
+    );
+    revokeResults.forEach((settled, idx) => {
+      if (settled.status === 'rejected') {
+        const userId = result.affectedUserIds[idx]!;
+        const err = settled.reason;
+        tokenRevocationFailures.push({
+          userId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        captureException(err, c);
+      }
+    });
+
+    const auditResult: 'success' | 'failure' =
+      tokenRevocationFailures.length === 0 ? 'success' : 'failure';
+
+    try {
+      await createAuditLog({
+        orgId: null,
+        actorType: 'user',
+        actorId: callerId,
+        actorEmail: auth.user.email,
+        action: 'partner.suspended_for_abuse',
+        resourceType: 'partner',
+        resourceId: partnerId,
+        details: {
+          reason,
+          deviceCount: result.deviceCount,
+          userCount: result.userCount,
+          apiKeyCount: result.apiKeyCount,
+          requestedBy: callerId,
+          ...(tokenRevocationFailures.length > 0
+            ? { tokenRevocationFailures }
+            : {}),
+        },
+        ipAddress: getTrustedClientIpOrUndefined(c),
+        userAgent: c.req.header('user-agent'),
+        result: auditResult,
+      });
+    } catch (auditErr) {
+      // The DB suspend + Redis revocation already happened. Losing the audit
+      // row is recoverable (operator can reconstruct from session+command
+      // tables) but we must surface it loudly so triage isn't blind.
+      console.error('[admin/suspend-for-abuse] audit log write failed', {
+        partnerId,
+        callerId,
+        error: auditErr instanceof Error ? auditErr.message : String(auditErr),
+      });
+      captureException(auditErr, c);
+    }
+
+    if (tokenRevocationFailures.length > 0) {
+      return c.json(
+        {
+          error: 'partial_suspend',
+          partnerId,
+          status: 'suspended' as const,
+          tokenRevocationFailed: true,
+          tokenRevocationFailures,
+          deviceCount: result.deviceCount,
+          userCount: result.userCount,
+          apiKeyCount: result.apiKeyCount,
+          queuedUninstalls: result.deviceCount,
+        },
+        500,
+      );
+    }
+
+    return c.json({
+      partnerId,
+      status: 'suspended' as const,
+      deviceCount: result.deviceCount,
+      userCount: result.userCount,
+      apiKeyCount: result.apiKeyCount,
+      queuedUninstalls: result.deviceCount,
+    });
+  }
+);
+
+abuseRoutes.post(
+  '/partners/:id/unsuspend',
+  zValidator('json', reasonSchema),
+  async (c) => {
+    const partnerId = c.req.param('id');
+    const { reason } = c.req.valid('json');
+    const auth = c.get('auth');
+
+    const result = await withSystemDbAccessContext(async () => {
+      return db.transaction(async (tx) => {
+        const [partner] = await tx
+          .select({
+            id: partners.id,
+            paymentMethodAttachedAt: partners.paymentMethodAttachedAt,
+          })
+          .from(partners)
+          .where(eq(partners.id, partnerId))
+          .limit(1);
+
+        if (!partner) {
+          return { notFound: true as const };
+        }
+
+        // Preserve the activation gate: only flip to 'active' if the partner
+        // has a payment method attached. Otherwise, route them back through
+        // the pending-activation flow.
+        const newStatus: 'active' | 'pending' = partner.paymentMethodAttachedAt
+          ? 'active'
+          : 'pending';
+
+        await tx
+          .update(partners)
+          .set({ status: newStatus, updatedAt: new Date() })
+          .where(eq(partners.id, partnerId));
+
+        const reEnabled = await tx
+          .update(users)
+          .set({ status: 'active', updatedAt: new Date() })
+          .where(
+            and(
+              eq(users.partnerId, partnerId),
+              eq(users.status, 'disabled')
+            )
+          )
+          .returning({ id: users.id });
+
+        return { notFound: false as const, status: newStatus, userCount: reEnabled.length };
+      });
+    });
+
+    if (result.notFound) {
+      return c.json({ error: 'partner not found' }, 404);
+    }
+
+    await createAuditLog({
+      orgId: null,
+      actorType: 'user',
+      actorId: auth.user.id,
+      actorEmail: auth.user.email,
+      action: 'partner.unsuspended',
+      resourceType: 'partner',
+      resourceId: partnerId,
+      details: {
+        reason,
+        newStatus: result.status,
+        userCount: result.userCount,
+      },
+      ipAddress: getTrustedClientIpOrUndefined(c),
+      userAgent: c.req.header('user-agent'),
+      result: 'success',
+    });
+
+    return c.json({
+      partnerId,
+      status: result.status,
+      userCount: result.userCount,
+      note:
+        'Devices that received uninstall commands cannot be auto-restored. Re-enrollment required.',
+    });
+  }
+);
+

--- a/apps/api/src/routes/admin/index.ts
+++ b/apps/api/src/routes/admin/index.ts
@@ -1,0 +1,8 @@
+import { Hono } from 'hono';
+import { platformAdminMiddleware } from '../../middleware/platformAdmin';
+import { abuseRoutes } from './abuse';
+
+export const adminRoutes = new Hono();
+
+adminRoutes.use('*', platformAdminMiddleware);
+adminRoutes.route('/', abuseRoutes);

--- a/apps/api/src/routes/auth/index.ts
+++ b/apps/api/src/routes/auth/index.ts
@@ -5,6 +5,7 @@ import { mfaRoutes } from './mfa';
 import { phoneRoutes } from './phone';
 import { passwordRoutes } from './password';
 import { inviteRoutes } from './invite';
+import { verifyEmailRoutes } from './verifyEmail';
 
 export const authRoutes = new Hono();
 
@@ -17,4 +18,5 @@ authRoutes.route('/', mfaRoutes);
 authRoutes.route('/', phoneRoutes);
 authRoutes.route('/', passwordRoutes);
 authRoutes.route('/', inviteRoutes);
+authRoutes.route('/', verifyEmailRoutes);
 

--- a/apps/api/src/routes/auth/register.test.ts
+++ b/apps/api/src/routes/auth/register.test.ts
@@ -46,6 +46,16 @@ vi.mock('../../services/clientIp', () => ({
   getTrustedClientIpOrUndefined: vi.fn(() => '127.0.0.1'),
 }));
 
+vi.mock('../../services/emailVerification', () => ({
+  generateVerificationToken: vi.fn(async () => 'verify-token'),
+}));
+
+vi.mock('../../services/email', () => ({
+  getEmailService: vi.fn(() => ({
+    sendVerificationEmail: vi.fn(async () => undefined),
+  })),
+}));
+
 vi.mock('./helpers', async () => {
   const actual = await vi.importActual<typeof import('./helpers')>('./helpers');
   return {

--- a/apps/api/src/routes/auth/register.ts
+++ b/apps/api/src/routes/auth/register.ts
@@ -18,6 +18,8 @@ import { createPartner } from '../../services/partnerCreate';
 import { writeAuditEvent, ANONYMOUS_ACTOR_ID } from '../../services/auditEvents';
 import { createAuditLog } from '../../services/auditService';
 import { captureException } from '../../services/sentry';
+import { generateVerificationToken } from '../../services/emailVerification';
+import { getEmailService } from '../../services/email';
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
 import {
   runWithSystemDbAccess,
@@ -243,6 +245,50 @@ registerRoutes.post('/register-partner', zValidator('json', registerPartnerSchem
 
       setRefreshTokenCookie(c, tokens.refreshToken);
 
+      // Email verification — best-effort send. Failures must not fail the
+      // signup, but the result needs to be surfaced to the client so the
+      // UI can show a "we couldn't send the verification email — click to
+      // resend" banner instead of leaving the user waiting silently.
+      let verificationEmailSent = false;
+      try {
+        const rawToken = await generateVerificationToken({
+          partnerId: newPartner.id,
+          userId: newUser.id,
+          email: newUser.email,
+        });
+        const appBaseUrl = (
+          process.env.DASHBOARD_URL ||
+          process.env.PUBLIC_APP_URL ||
+          'http://localhost:4321'
+        ).replace(/\/$/, '');
+        const verificationUrl = `${appBaseUrl}/auth/verify-email?token=${encodeURIComponent(rawToken)}`;
+        const emailService = getEmailService();
+        if (emailService) {
+          await emailService.sendVerificationEmail({
+            to: newUser.email,
+            name: newUser.name,
+            verificationUrl,
+          });
+          verificationEmailSent = true;
+        } else {
+          // No email provider in production is a misconfiguration, not
+          // graceful degradation — capture so it's observable.
+          const err = new Error(
+            '[register-partner] Email service not configured; verification email skipped',
+          );
+          console.warn(err.message);
+          captureException(err, c);
+        }
+      } catch (verifyErr) {
+        console.error('[register-partner] verification email send failed', {
+          partnerId: newPartner.id,
+          userId: newUser.id,
+          error: verifyErr instanceof Error ? verifyErr.message : String(verifyErr),
+        });
+        captureException(verifyErr, c);
+      }
+
+
       phase = 'hook-dispatch';
 
       // Dispatch post-registration hook (external services can override status/redirect)
@@ -329,6 +375,7 @@ registerRoutes.post('/register-partner', zValidator('json', registerPartnerSchem
         },
         tokens: toPublicTokens(tokens),
         mfaRequired: false,
+        verificationEmailSent,
         ...(redirectUrl ? { redirectUrl } : {}),
       });
     } catch (err) {

--- a/apps/api/src/routes/auth/verifyEmail.test.ts
+++ b/apps/api/src/routes/auth/verifyEmail.test.ts
@@ -1,0 +1,299 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sendVerificationEmailMock = vi.fn(async () => undefined);
+
+vi.mock('../../db', () => ({
+  db: { select: vi.fn() },
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../../db/schema', () => ({
+  users: {
+    id: 'users.id',
+    email: 'users.email',
+    name: 'users.name',
+    partnerId: 'users.partnerId',
+    emailVerifiedAt: 'users.emailVerifiedAt',
+  },
+  partners: { id: 'partners.id' },
+}));
+
+vi.mock('../../services', () => ({
+  rateLimiter: vi.fn(async () => ({ allowed: true })),
+  getRedis: vi.fn(() => ({})),
+}));
+
+vi.mock('../../services/email', () => ({
+  getEmailService: vi.fn(() => ({
+    sendVerificationEmail: sendVerificationEmailMock,
+  })),
+}));
+
+vi.mock('../../services/emailVerification', () => ({
+  consumeVerificationToken: vi.fn(),
+  generateVerificationToken: vi.fn(async () => 'fresh-token'),
+  invalidateOpenTokens: vi.fn(async () => 0),
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', {
+      scope: 'partner',
+      partnerId: 'p-1',
+      orgId: null,
+      user: { id: 'u-1', email: 'admin@acme.test', name: 'Admin' },
+    });
+    return next();
+  }),
+}));
+
+vi.mock('./helpers', async () => {
+  const actual = await vi.importActual<typeof import('./helpers')>('./helpers');
+  return {
+    ...actual,
+    getClientRateLimitKey: vi.fn(() => 'test-client'),
+    writeAuthAudit: vi.fn(),
+  };
+});
+
+import { verifyEmailRoutes } from './verifyEmail';
+import { db } from '../../db';
+import { rateLimiter, getRedis } from '../../services';
+import {
+  consumeVerificationToken,
+  generateVerificationToken,
+  invalidateOpenTokens,
+} from '../../services/emailVerification';
+import { writeAuthAudit } from './helpers';
+import { getEmailService } from '../../services/email';
+
+function selectChain(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  };
+}
+
+async function postJson(path: string, body: unknown) {
+  return verifyEmailRoutes.request(path, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /verify-email', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(rateLimiter).mockResolvedValue({ allowed: true } as any);
+    vi.mocked(getRedis).mockReturnValue({} as any);
+  });
+
+  it('returns 503 when redis is unavailable', async () => {
+    vi.mocked(getRedis).mockReturnValueOnce(null as any);
+    const res = await postJson('/verify-email', { token: 'x' });
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 429 and audits a denied event when rate-limited', async () => {
+    vi.mocked(rateLimiter).mockResolvedValueOnce({ allowed: false } as any);
+    const res = await postJson('/verify-email', { token: 'x' });
+    expect(res.status).toBe(429);
+    expect(consumeVerificationToken).not.toHaveBeenCalled();
+    expect(writeAuthAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'auth.email_verify_failed', reason: 'rate_limited' })
+    );
+  });
+
+  it('returns 400 with the token error code when consume fails', async () => {
+    vi.mocked(consumeVerificationToken).mockResolvedValueOnce({ ok: false, error: 'expired' });
+    const res = await postJson('/verify-email', { token: 'x' });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'expired' });
+    expect(writeAuthAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'auth.email_verify_failed', reason: 'expired' })
+    );
+  });
+
+  it('returns 200 with verified payload on success', async () => {
+    vi.mocked(consumeVerificationToken).mockResolvedValueOnce({
+      ok: true,
+      partnerId: 'p-1',
+      userId: 'u-1',
+      email: 'a@b.com',
+      autoActivated: true,
+    });
+
+    const res = await postJson('/verify-email', { token: 'good' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      verified: true,
+      partnerId: 'p-1',
+      email: 'a@b.com',
+      autoActivated: true,
+    });
+    expect(writeAuthAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'auth.email_verified', result: 'success', userId: 'u-1' })
+    );
+  });
+
+  it('rejects an empty token via Zod', async () => {
+    const res = await postJson('/verify-email', { token: '' });
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBeLessThan(500);
+  });
+});
+
+describe('POST /resend-verification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(rateLimiter).mockResolvedValue({ allowed: true } as any);
+    vi.mocked(getRedis).mockReturnValue({} as any);
+    sendVerificationEmailMock.mockClear();
+  });
+
+  it('returns 400 already_verified when emailVerifiedAt is already set', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(
+      selectChain([
+        {
+          id: 'u-1',
+          email: 'a@b.com',
+          name: 'Admin',
+          partnerId: 'p-1',
+          emailVerifiedAt: new Date(),
+        },
+      ]) as any
+    );
+
+    const res = await postJson('/resend-verification', {});
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'already_verified' });
+    expect(generateVerificationToken).not.toHaveBeenCalled();
+    expect(sendVerificationEmailMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 429 with retryAfterSeconds when the per-minute limit is hit', async () => {
+    const resetAt = new Date(Date.now() + 30_000);
+    vi.mocked(rateLimiter).mockResolvedValueOnce({
+      allowed: false,
+      remaining: 0,
+      resetAt,
+    } as any);
+    const res = await postJson('/resend-verification', {});
+    expect(res.status).toBe(429);
+    expect(res.headers.get('retry-after')).toBeTruthy();
+    const body = await res.json();
+    expect(body.window).toBe('minute');
+    expect(typeof body.retryAfterSeconds).toBe('number');
+    expect(body.retryAfterSeconds).toBeGreaterThan(0);
+    expect(generateVerificationToken).not.toHaveBeenCalled();
+  });
+
+  it('returns 429 with hour-window retryAfter when the per-hour limit is hit', async () => {
+    const minuteResetAt = new Date(Date.now() + 30_000);
+    const hourResetAt = new Date(Date.now() + 30 * 60_000);
+    vi.mocked(rateLimiter)
+      .mockResolvedValueOnce({ allowed: true, remaining: 0, resetAt: minuteResetAt } as any)
+      .mockResolvedValueOnce({ allowed: false, remaining: 0, resetAt: hourResetAt } as any);
+    const res = await postJson('/resend-verification', {});
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.window).toBe('hour');
+    expect(body.retryAfterSeconds).toBeGreaterThan(60);
+    expect(generateVerificationToken).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the user row is missing', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(selectChain([]) as any);
+    const res = await postJson('/resend-verification', {});
+    expect(res.status).toBe(404);
+  });
+
+  it('invalidates open tokens, issues a new one, sends the email, and audits success', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(
+      selectChain([
+        {
+          id: 'u-1',
+          email: 'a@b.com',
+          name: 'Admin',
+          partnerId: 'p-1',
+          emailVerifiedAt: null,
+        },
+      ]) as any
+    );
+
+    const res = await postJson('/resend-verification', {});
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ sent: true });
+
+    expect(invalidateOpenTokens).toHaveBeenCalledWith('u-1');
+    expect(generateVerificationToken).toHaveBeenCalledWith({
+      partnerId: 'p-1',
+      userId: 'u-1',
+      email: 'a@b.com',
+    });
+    expect(sendVerificationEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'a@b.com',
+        name: 'Admin',
+        verificationUrl: expect.stringContaining('/auth/verify-email?token=fresh-token'),
+      })
+    );
+    expect(writeAuthAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'auth.verification_resent', result: 'success' })
+    );
+  });
+
+  it('returns 503 when the email service is unconfigured', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(
+      selectChain([
+        {
+          id: 'u-1',
+          email: 'a@b.com',
+          name: 'Admin',
+          partnerId: 'p-1',
+          emailVerifiedAt: null,
+        },
+      ]) as any
+    );
+    vi.mocked(getEmailService).mockReturnValueOnce(null as any);
+
+    const res = await postJson('/resend-verification', {});
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 500 when sendVerificationEmail throws', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(
+      selectChain([
+        {
+          id: 'u-1',
+          email: 'a@b.com',
+          name: 'Admin',
+          partnerId: 'p-1',
+          emailVerifiedAt: null,
+        },
+      ]) as any
+    );
+    sendVerificationEmailMock.mockRejectedValueOnce(new Error('Resend down'));
+
+    const res = await postJson('/resend-verification', {});
+    expect(res.status).toBe(500);
+    expect(writeAuthAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'auth.verification_resent', result: 'failure' })
+    );
+  });
+});

--- a/apps/api/src/routes/auth/verifyEmail.ts
+++ b/apps/api/src/routes/auth/verifyEmail.ts
@@ -1,0 +1,202 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import * as dbModule from '../../db';
+import { users } from '../../db/schema';
+import { rateLimiter, getRedis } from '../../services';
+import { getEmailService } from '../../services/email';
+import {
+  consumeVerificationToken,
+  generateVerificationToken,
+  invalidateOpenTokens,
+} from '../../services/emailVerification';
+import { authMiddleware } from '../../middleware/auth';
+import { getClientRateLimitKey, writeAuthAudit } from './helpers';
+
+const { db, withSystemDbAccessContext } = dbModule;
+
+export const verifyEmailRoutes = new Hono();
+
+const verifyEmailSchema = z.object({
+  token: z.string().min(1, 'token required'),
+});
+
+verifyEmailRoutes.post(
+  '/verify-email',
+  zValidator('json', verifyEmailSchema),
+  async (c) => {
+    const { token } = c.req.valid('json');
+    const rateLimitClient = getClientRateLimitKey(c);
+
+    const redis = getRedis();
+    if (!redis) {
+      return c.json({ error: 'Service temporarily unavailable' }, 503);
+    }
+
+    const rateCheck = await rateLimiter(redis, `verify-email:${rateLimitClient}`, 10, 300);
+    if (!rateCheck.allowed) {
+      writeAuthAudit(c, {
+        action: 'auth.email_verify_failed',
+        result: 'denied',
+        reason: 'rate_limited',
+      });
+      return c.json({ error: 'Too many verification attempts. Try again later.' }, 429);
+    }
+
+    const result = await consumeVerificationToken(token);
+
+    if (!result.ok) {
+      writeAuthAudit(c, {
+        action: 'auth.email_verify_failed',
+        result: 'failure',
+        reason: result.error,
+      });
+      return c.json({ error: result.error }, 400);
+    }
+
+    writeAuthAudit(c, {
+      action: 'auth.email_verified',
+      result: 'success',
+      userId: result.userId,
+      email: result.email,
+      details: {
+        partnerId: result.partnerId,
+        autoActivated: result.autoActivated,
+      },
+    });
+
+    return c.json({
+      verified: true,
+      partnerId: result.partnerId,
+      email: result.email,
+      autoActivated: result.autoActivated,
+    });
+  }
+);
+
+verifyEmailRoutes.post('/resend-verification', authMiddleware, async (c) => {
+  const auth = c.get('auth');
+  const userId = auth.user.id;
+  const rateLimitClient = getClientRateLimitKey(c);
+
+  const redis = getRedis();
+  if (!redis) {
+    return c.json({ error: 'Service temporarily unavailable' }, 503);
+  }
+
+  // Two windows: 1 per minute (debounce form spam) + 5 per hour (abuse cap).
+  const minuteCheck = await rateLimiter(redis, `resend-verify:min:${userId}:${rateLimitClient}`, 1, 60);
+  if (!minuteCheck.allowed) {
+    const retryAfterSeconds = Math.max(
+      1,
+      Math.ceil((minuteCheck.resetAt.getTime() - Date.now()) / 1000),
+    );
+    c.header('Retry-After', String(retryAfterSeconds));
+    return c.json(
+      {
+        error: `Please wait ${retryAfterSeconds} second${retryAfterSeconds === 1 ? '' : 's'} before requesting another verification email.`,
+        retryAfterSeconds,
+        window: 'minute' as const,
+      },
+      429,
+    );
+  }
+  const hourCheck = await rateLimiter(redis, `resend-verify:hour:${userId}`, 5, 3600);
+  if (!hourCheck.allowed) {
+    const retryAfterSeconds = Math.max(
+      1,
+      Math.ceil((hourCheck.resetAt.getTime() - Date.now()) / 1000),
+    );
+    const retryAfterMinutes = Math.ceil(retryAfterSeconds / 60);
+    c.header('Retry-After', String(retryAfterSeconds));
+    return c.json(
+      {
+        error: `Verification email limit reached. Try again in ${retryAfterMinutes} minute${retryAfterMinutes === 1 ? '' : 's'}.`,
+        retryAfterSeconds,
+        window: 'hour' as const,
+      },
+      429,
+    );
+  }
+
+  const [user] = await withSystemDbAccessContext(() =>
+    db
+      .select({
+        id: users.id,
+        email: users.email,
+        name: users.name,
+        partnerId: users.partnerId,
+        emailVerifiedAt: users.emailVerifiedAt,
+      })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1)
+  );
+
+  if (!user) {
+    return c.json({ error: 'User not found' }, 404);
+  }
+
+  if (user.emailVerifiedAt) {
+    return c.json({ error: 'already_verified' }, 400);
+  }
+
+  await invalidateOpenTokens(user.id);
+
+  const rawToken = await generateVerificationToken({
+    partnerId: user.partnerId,
+    userId: user.id,
+    email: user.email,
+  });
+
+  const appBaseUrl = (
+    process.env.DASHBOARD_URL ||
+    process.env.PUBLIC_APP_URL ||
+    'http://localhost:4321'
+  ).replace(/\/$/, '');
+  const verificationUrl = `${appBaseUrl}/auth/verify-email?token=${encodeURIComponent(rawToken)}`;
+
+  const emailService = getEmailService();
+  if (!emailService) {
+    console.warn('[resend-verification] Email service not configured');
+    writeAuthAudit(c, {
+      action: 'auth.verification_resent',
+      result: 'failure',
+      reason: 'email_service_unavailable',
+      userId: user.id,
+      email: user.email,
+    });
+    return c.json({ error: 'Email service unavailable' }, 503);
+  }
+
+  try {
+    await emailService.sendVerificationEmail({
+      to: user.email,
+      name: user.name,
+      verificationUrl,
+    });
+  } catch (err) {
+    console.error('[resend-verification] failed to send email', {
+      userId: user.id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    writeAuthAudit(c, {
+      action: 'auth.verification_resent',
+      result: 'failure',
+      reason: 'send_failed',
+      userId: user.id,
+      email: user.email,
+    });
+    return c.json({ error: 'Failed to send verification email' }, 500);
+  }
+
+  writeAuthAudit(c, {
+    action: 'auth.verification_resent',
+    result: 'success',
+    userId: user.id,
+    email: user.email,
+  });
+
+  return c.json({ sent: true });
+});

--- a/apps/api/src/routes/backup/jobs.test.ts
+++ b/apps/api/src/routes/backup/jobs.test.ts
@@ -125,7 +125,7 @@ describe('backup jobs routes', () => {
     app = new Hono();
     app.use('*', async (c, next) => {
       c.set('auth', {
-        user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+        user: { id: 'user-1', email: 'test@example.com', name: 'Test User', isPlatformAdmin: false },
         scope: 'organization',
         orgId: 'org-a',
         partnerId: null,

--- a/apps/api/src/routes/backup/restore.test.ts
+++ b/apps/api/src/routes/backup/restore.test.ts
@@ -103,7 +103,7 @@ describe('restore routes', () => {
     app = new Hono();
     app.use('*', async (c, next) => {
       c.set('auth', {
-        user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+        user: { id: 'user-1', email: 'test@example.com', name: 'Test User', isPlatformAdmin: false },
         scope: 'organization',
         orgId: 'org-1',
         partnerId: null,

--- a/apps/api/src/routes/helper/index.ts
+++ b/apps/api/src/routes/helper/index.ts
@@ -136,6 +136,7 @@ async function helperAuth(c: import('hono').Context, next: import('hono').Next) 
       id: device.id, // Use device ID as the "user" ID for helper sessions
       email: `helper@${device.hostname}`,
       name: device.hostname,
+      isPlatformAdmin: false,
     },
     token: {
       sub: device.id,

--- a/apps/api/src/routes/mcpServer.ts
+++ b/apps/api/src/routes/mcpServer.ts
@@ -1125,7 +1125,8 @@ async function buildAuthFromApiKey(apiKey: {
   const user = {
     id: apiKey.createdBy,
     email: `apikey-${apiKey.name}@breeze.local`,
-    name: `API Key: ${apiKey.name}`
+    name: `API Key: ${apiKey.name}`,
+    isPlatformAdmin: false
   };
 
   if (apiKey.orgId) {

--- a/apps/api/src/services/aiTools.queryAuditLog.test.ts
+++ b/apps/api/src/services/aiTools.queryAuditLog.test.ts
@@ -15,7 +15,7 @@ import type { AuthContext } from '../middleware/auth';
 
 function makeAuth(): AuthContext {
   return {
-    user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+    user: { id: 'user-1', email: 'test@example.com', name: 'Test User', isPlatformAdmin: false },
     token: {} as any,
     partnerId: null,
     orgId: 'org-123',

--- a/apps/api/src/services/aiTools.queryChangeLog.test.ts
+++ b/apps/api/src/services/aiTools.queryChangeLog.test.ts
@@ -15,7 +15,7 @@ import type { AuthContext } from '../middleware/auth';
 
 function makeAuth(): AuthContext {
   return {
-    user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+    user: { id: 'user-1', email: 'test@example.com', name: 'Test User', isPlatformAdmin: false },
     token: {} as any,
     partnerId: null,
     orgId: 'org-123',

--- a/apps/api/src/services/aiTools.sentinelOneActions.test.ts
+++ b/apps/api/src/services/aiTools.sentinelOneActions.test.ts
@@ -28,7 +28,7 @@ import {
 
 function makeAuth(): AuthContext {
   return {
-    user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+    user: { id: 'user-1', email: 'test@example.com', name: 'Test User', isPlatformAdmin: false },
     token: { mfa: true } as any,
     partnerId: null,
     orgId: 'org-123',

--- a/apps/api/src/services/deleteTenant.test.ts
+++ b/apps/api/src/services/deleteTenant.test.ts
@@ -35,7 +35,7 @@ const ORG_ID = '44444444-4444-4444-4444-444444444444';
 
 function makeAuth(overrides: Partial<AuthContext> = {}): AuthContext {
   return {
-    user: { id: USER_ID, email: 'apikey@breeze.local', name: 'API Key: test' },
+    user: { id: USER_ID, email: 'apikey@breeze.local', name: 'API Key: test', isPlatformAdmin: false },
     token: {} as AuthContext['token'],
     partnerId: PARTNER_ID,
     orgId: ORG_ID,

--- a/apps/api/src/services/email.ts
+++ b/apps/api/src/services/email.ts
@@ -23,6 +23,13 @@ export interface PasswordResetEmailParams {
   supportEmail?: string;
 }
 
+export interface VerificationEmailParams {
+  to: string | string[];
+  name?: string;
+  verificationUrl: string;
+  supportEmail?: string;
+}
+
 export interface InviteEmailParams {
   to: string | string[];
   name?: string;
@@ -170,6 +177,16 @@ export class EmailService {
 
   async sendPasswordReset(params: PasswordResetEmailParams): Promise<void> {
     const template = buildPasswordResetTemplate(params);
+    await this.sendEmail({
+      to: params.to,
+      subject: template.subject,
+      html: template.html,
+      text: template.text
+    });
+  }
+
+  async sendVerificationEmail(params: VerificationEmailParams): Promise<void> {
+    const template = buildVerificationTemplate(params);
     await this.sendEmail({
       to: params.to,
       subject: template.subject,
@@ -472,6 +489,38 @@ function buildPasswordResetTemplate(params: PasswordResetEmailParams): EmailTemp
     'A password reset was requested for your Breeze account.',
     `Reset your password: ${params.resetUrl}`,
     'If you did not request this, you can safely ignore this email.',
+    support ? `Need help? Contact ${support}.` : null,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  return { subject, html, text };
+}
+
+function buildVerificationTemplate(params: VerificationEmailParams): EmailTemplate {
+  const name = params.name?.trim() || 'there';
+  const subject = 'Verify your email for Breeze RMM';
+  const preheader = 'Confirm your email address to finish setting up Breeze.';
+  const body = `
+      <p style="${BODY_PARA}">Hi ${escapeHtml(name)},</p>
+      <p style="${BODY_PARA}">Welcome to Breeze. Please confirm your email address so we can finish setting up your account.</p>
+      ${renderButton('Verify email', params.verificationUrl)}
+      <p style="${MUTED_PARA}">This link expires in 24 hours. If you did not sign up for Breeze, you can safely ignore this email.</p>
+  `;
+  const html = renderLayout({
+    title: subject,
+    preheader,
+    heading: 'Verify your email',
+    body,
+    footer: supportFooter(params.supportEmail, 'Need help? Contact'),
+  });
+
+  const support = getSupportEmail(params.supportEmail);
+  const text = [
+    `Hi ${name},`,
+    'Welcome to Breeze. Please confirm your email address so we can finish setting up your account.',
+    `Verify your email: ${params.verificationUrl}`,
+    'This link expires in 24 hours. If you did not sign up for Breeze, you can safely ignore this email.',
     support ? `Need help? Contact ${support}.` : null,
   ]
     .filter(Boolean)

--- a/apps/api/src/services/emailVerification.test.ts
+++ b/apps/api/src/services/emailVerification.test.ts
@@ -1,0 +1,338 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../db', () => {
+  // Drizzle's `db.transaction(fn)` calls fn with a `tx` that has the same
+  // CRUD surface as `db`. We pass `db` itself so existing chain mocks work.
+  const dbInner = {
+    insert: vi.fn(),
+    select: vi.fn(),
+    update: vi.fn(),
+    transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(dbInner)),
+  };
+  return {
+    db: dbInner,
+    withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+    withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+    runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  };
+});
+
+vi.mock('../db/schema', () => ({
+  emailVerificationTokens: {
+    id: 'evt.id',
+    tokenHash: 'evt.tokenHash',
+    partnerId: 'evt.partnerId',
+    userId: 'evt.userId',
+    email: 'evt.email',
+    expiresAt: 'evt.expiresAt',
+    consumedAt: 'evt.consumedAt',
+    supersededAt: 'evt.supersededAt',
+  },
+  partners: {
+    id: 'partners.id',
+    status: 'partners.status',
+    paymentMethodAttachedAt: 'partners.paymentMethodAttachedAt',
+    emailVerifiedAt: 'partners.emailVerifiedAt',
+    settings: 'partners.settings',
+    updatedAt: 'partners.updatedAt',
+  },
+  users: {
+    id: 'users.id',
+    emailVerifiedAt: 'users.emailVerifiedAt',
+  },
+}));
+
+import { db } from '../db';
+import {
+  consumeVerificationToken,
+  generateVerificationToken,
+  invalidateOpenTokens,
+} from './emailVerification';
+
+function chainSelect(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  };
+}
+
+function chainUpdateReturning(rows: unknown[]) {
+  return {
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  };
+}
+
+function chainUpdateNoReturning() {
+  return {
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    }),
+  };
+}
+
+describe('generateVerificationToken', () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it('inserts a SHA-256 hashed token row and returns the raw nanoid', async () => {
+    const valuesSpy = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(db.insert).mockReturnValue({ values: valuesSpy } as any);
+
+    const raw = await generateVerificationToken({
+      partnerId: 'p-1',
+      userId: 'u-1',
+      email: 'TEST@example.com',
+    });
+
+    expect(typeof raw).toBe('string');
+    expect(raw.length).toBeGreaterThanOrEqual(48);
+    expect(valuesSpy).toHaveBeenCalledOnce();
+
+    const inserted = valuesSpy.mock.calls[0]![0]!;
+    expect(inserted.partnerId).toBe('p-1');
+    expect(inserted.userId).toBe('u-1');
+    expect(inserted.email).toBe('test@example.com');
+    expect(inserted.tokenHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(inserted.tokenHash).not.toBe(raw);
+    expect(inserted.expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+});
+
+describe('consumeVerificationToken', () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it('returns invalid when token row is not found', async () => {
+    vi.mocked(db.select).mockReturnValue(chainSelect([]) as any);
+    const result = await consumeVerificationToken('does-not-exist');
+    expect(result).toEqual({ ok: false, error: 'invalid' });
+  });
+
+  it('returns consumed when consumed_at is already set', async () => {
+    vi.mocked(db.select).mockReturnValue(
+      chainSelect([
+        {
+          id: 'evt-1',
+          partnerId: 'p-1',
+          userId: 'u-1',
+          email: 'a@b.com',
+          expiresAt: new Date(Date.now() + 60_000),
+          consumedAt: new Date(),
+        },
+      ]) as any
+    );
+
+    const result = await consumeVerificationToken('rawtoken');
+    expect(result).toEqual({ ok: false, error: 'consumed' });
+  });
+
+  it('returns expired when expires_at is in the past', async () => {
+    vi.mocked(db.select).mockReturnValue(
+      chainSelect([
+        {
+          id: 'evt-1',
+          partnerId: 'p-1',
+          userId: 'u-1',
+          email: 'a@b.com',
+          expiresAt: new Date(Date.now() - 1000),
+          consumedAt: null,
+        },
+      ]) as any
+    );
+
+    const result = await consumeVerificationToken('rawtoken');
+    expect(result).toEqual({ ok: false, error: 'expired' });
+  });
+
+  it('marks token consumed, stamps users + partners email_verified_at on success without auto-activating', async () => {
+    const future = new Date(Date.now() + 60_000);
+    const tokenSelect = chainSelect([
+      {
+        id: 'evt-1',
+        partnerId: 'p-1',
+        userId: 'u-1',
+        email: 'a@b.com',
+        expiresAt: future,
+        consumedAt: null,
+      },
+    ]);
+    const partnerSelect = chainSelect([
+      { id: 'p-1', status: 'pending', paymentMethodAttachedAt: null },
+    ]);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(tokenSelect as any)
+      .mockReturnValueOnce(partnerSelect as any);
+
+    const tokenUpdate = chainUpdateReturning([{ id: 'evt-1' }]);
+    const userUpdate = chainUpdateNoReturning();
+    const partnerUpdate = chainUpdateNoReturning();
+
+    vi.mocked(db.update)
+      .mockReturnValueOnce(tokenUpdate as any)
+      .mockReturnValueOnce(userUpdate as any)
+      .mockReturnValueOnce(partnerUpdate as any);
+
+    const result = await consumeVerificationToken('rawtoken');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.partnerId).toBe('p-1');
+      expect(result.userId).toBe('u-1');
+      expect(result.email).toBe('a@b.com');
+      expect(result.autoActivated).toBe(false);
+    }
+
+    const partnerSetCall = (partnerUpdate.set as any).mock.calls[0][0];
+    expect(partnerSetCall).toHaveProperty('emailVerifiedAt');
+    expect(partnerSetCall).not.toHaveProperty('status');
+  });
+
+  it('auto-activates partner when status=pending and payment method attached', async () => {
+    const future = new Date(Date.now() + 60_000);
+    const tokenSelect = chainSelect([
+      {
+        id: 'evt-1',
+        partnerId: 'p-1',
+        userId: 'u-1',
+        email: 'a@b.com',
+        expiresAt: future,
+        consumedAt: null,
+      },
+    ]);
+    const partnerSelect = chainSelect([
+      { id: 'p-1', status: 'pending', paymentMethodAttachedAt: new Date() },
+    ]);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(tokenSelect as any)
+      .mockReturnValueOnce(partnerSelect as any);
+
+    const tokenUpdate = chainUpdateReturning([{ id: 'evt-1' }]);
+    const userUpdate = chainUpdateNoReturning();
+    const partnerUpdate = chainUpdateNoReturning();
+
+    vi.mocked(db.update)
+      .mockReturnValueOnce(tokenUpdate as any)
+      .mockReturnValueOnce(userUpdate as any)
+      .mockReturnValueOnce(partnerUpdate as any);
+
+    const result = await consumeVerificationToken('rawtoken');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.autoActivated).toBe(true);
+    }
+
+    const partnerSetCall = (partnerUpdate.set as any).mock.calls[0][0];
+    expect(partnerSetCall.status).toBe('active');
+    expect(partnerSetCall).toHaveProperty('emailVerifiedAt');
+  });
+
+  it('returns superseded when supersededAt is set on the row (resend invalidated this link)', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(
+      chainSelect([
+        {
+          id: 'evt-1',
+          partnerId: 'p-1',
+          userId: 'u-1',
+          email: 'a@b.com',
+          expiresAt: new Date(Date.now() + 60_000),
+          consumedAt: null,
+          supersededAt: new Date(Date.now() - 1000),
+        },
+      ]) as any
+    );
+
+    const result = await consumeVerificationToken('rawtoken');
+    expect(result).toEqual({ ok: false, error: 'superseded' });
+  });
+
+  it('does NOT auto-activate a suspended partner even if payment is attached', async () => {
+    const future = new Date(Date.now() + 60_000);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(
+        chainSelect([
+          {
+            id: 'evt-1',
+            partnerId: 'p-1',
+            userId: 'u-1',
+            email: 'a@b.com',
+            expiresAt: future,
+            consumedAt: null,
+            supersededAt: null,
+          },
+        ]) as any
+      )
+      .mockReturnValueOnce(
+        chainSelect([
+          { id: 'p-1', status: 'suspended', paymentMethodAttachedAt: new Date() },
+        ]) as any
+      );
+
+    const tokenUpdate = chainUpdateReturning([{ id: 'evt-1' }]);
+    const userUpdate = chainUpdateNoReturning();
+    const partnerUpdate = chainUpdateNoReturning();
+    vi.mocked(db.update)
+      .mockReturnValueOnce(tokenUpdate as any)
+      .mockReturnValueOnce(userUpdate as any)
+      .mockReturnValueOnce(partnerUpdate as any);
+
+    const result = await consumeVerificationToken('rawtoken');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.autoActivated).toBe(false);
+    }
+
+    // The partner update must NOT include status=active. A suspended-then-
+    // verify should leave status=suspended (the abuse path is enforced by
+    // not the active-flip predicate, by design — a future broadening of the
+    // predicate to "not active" would re-activate suspended partners).
+    const partnerSetCall = (partnerUpdate.set as any).mock.calls[0][0];
+    expect(partnerSetCall.status).toBeUndefined();
+  });
+
+  it('returns consumed if a concurrent request claimed the token first', async () => {
+    const future = new Date(Date.now() + 60_000);
+    vi.mocked(db.select).mockReturnValueOnce(
+      chainSelect([
+        {
+          id: 'evt-1',
+          partnerId: 'p-1',
+          userId: 'u-1',
+          email: 'a@b.com',
+          expiresAt: future,
+          consumedAt: null,
+        },
+      ]) as any
+    );
+
+    // Conditional UPDATE returns no rows — another request claimed it.
+    vi.mocked(db.update).mockReturnValueOnce(chainUpdateReturning([]) as any);
+
+    const result = await consumeVerificationToken('rawtoken');
+    expect(result).toEqual({ ok: false, error: 'consumed' });
+  });
+});
+
+describe('invalidateOpenTokens', () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it('updates all unconsumed tokens for the user and returns the count', async () => {
+    vi.mocked(db.update).mockReturnValue(
+      chainUpdateReturning([{ id: 'evt-1' }, { id: 'evt-2' }]) as any
+    );
+
+    const count = await invalidateOpenTokens('u-1');
+    expect(count).toBe(2);
+  });
+
+  it('returns 0 when no live tokens exist', async () => {
+    vi.mocked(db.update).mockReturnValue(chainUpdateReturning([]) as any);
+    const count = await invalidateOpenTokens('u-1');
+    expect(count).toBe(0);
+  });
+});

--- a/apps/api/src/services/emailVerification.ts
+++ b/apps/api/src/services/emailVerification.ts
@@ -1,0 +1,201 @@
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import { createHash } from 'crypto';
+import { nanoid } from 'nanoid';
+import { db, withSystemDbAccessContext } from '../db';
+import { emailVerificationTokens, partners, users } from '../db/schema';
+
+const TOKEN_TTL_MS = 24 * 60 * 60 * 1000;
+
+function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+export interface GenerateTokenInput {
+  partnerId: string;
+  userId: string;
+  email: string;
+}
+
+/**
+ * Issue a fresh verification token. Returns the raw token (only shown
+ * once — the DB stores the SHA-256 hash). Caller is responsible for
+ * sending it via email.
+ */
+export async function generateVerificationToken(input: GenerateTokenInput): Promise<string> {
+  const rawToken = nanoid(48);
+  const tokenHash = hashToken(rawToken);
+  const expiresAt = new Date(Date.now() + TOKEN_TTL_MS);
+
+  await withSystemDbAccessContext(() =>
+    db.insert(emailVerificationTokens).values({
+      tokenHash,
+      partnerId: input.partnerId,
+      userId: input.userId,
+      email: input.email.toLowerCase(),
+      expiresAt,
+    })
+  );
+
+  return rawToken;
+}
+
+export type ConsumeFailureReason = 'invalid' | 'expired' | 'consumed' | 'superseded';
+
+export type ConsumeResult =
+  | { ok: true; partnerId: string; userId: string; email: string; autoActivated: boolean }
+  | { ok: false; error: ConsumeFailureReason };
+
+/**
+ * Atomically consume a verification token. On success, marks the token
+ * row consumed and stamps `partners.email_verified_at` and
+ * `users.email_verified_at`. If the partner already has a payment method
+ * attached and is still in `pending`, also flips it to `active` and
+ * clears the "Awaiting email verification" status banner so the
+ * verify-after-pay path doesn't strand the tenant with stale UI.
+ *
+ * Atomicity is bound to this function via an explicit `db.transaction`
+ * so the single-claim guarantee holds regardless of caller scope.
+ */
+export async function consumeVerificationToken(rawToken: string): Promise<ConsumeResult> {
+  const tokenHash = hashToken(rawToken);
+
+  return withSystemDbAccessContext(() =>
+    db.transaction(async (tx) => {
+      const [row] = await tx
+        .select({
+          id: emailVerificationTokens.id,
+          partnerId: emailVerificationTokens.partnerId,
+          userId: emailVerificationTokens.userId,
+          email: emailVerificationTokens.email,
+          expiresAt: emailVerificationTokens.expiresAt,
+          consumedAt: emailVerificationTokens.consumedAt,
+          supersededAt: emailVerificationTokens.supersededAt,
+        })
+        .from(emailVerificationTokens)
+        .where(eq(emailVerificationTokens.tokenHash, tokenHash))
+        .limit(1);
+
+      if (!row) {
+        return { ok: false, error: 'invalid' as const };
+      }
+      // Order matters: a superseded token can also be expired, but the
+      // user-facing copy ("a newer link was sent") is more useful than
+      // "expired" since the newer link probably is not.
+      if (row.supersededAt) {
+        return { ok: false, error: 'superseded' as const };
+      }
+      if (row.consumedAt) {
+        return { ok: false, error: 'consumed' as const };
+      }
+      if (row.expiresAt.getTime() <= Date.now()) {
+        return { ok: false, error: 'expired' as const };
+      }
+
+      const now = new Date();
+
+      // Single-claim guarantee: only one concurrent caller will see
+      // returning() come back non-empty. The `superseded_at IS NULL`
+      // clause closes the SELECT/UPDATE race window where invalidate-
+      // by-resend might land between our SELECT above and this UPDATE.
+      const claimed = await tx
+        .update(emailVerificationTokens)
+        .set({ consumedAt: now })
+        .where(
+          and(
+            eq(emailVerificationTokens.id, row.id),
+            isNull(emailVerificationTokens.consumedAt),
+            isNull(emailVerificationTokens.supersededAt)
+          )
+        )
+        .returning({ id: emailVerificationTokens.id });
+
+      if (claimed.length === 0) {
+        return { ok: false, error: 'consumed' as const };
+      }
+
+      await tx
+        .update(users)
+        .set({ emailVerifiedAt: now })
+        .where(eq(users.id, row.userId));
+
+      const [partnerBefore] = await tx
+        .select({
+          id: partners.id,
+          status: partners.status,
+          paymentMethodAttachedAt: partners.paymentMethodAttachedAt,
+        })
+        .from(partners)
+        .where(eq(partners.id, row.partnerId))
+        .limit(1);
+
+      const shouldAutoActivate =
+        !!partnerBefore &&
+        partnerBefore.status === 'pending' &&
+        !!partnerBefore.paymentMethodAttachedAt;
+
+      if (shouldAutoActivate) {
+        // Auto-activate AND clear the "Awaiting email verification" banner
+        // settings keys that breeze-billing wrote when payment landed
+        // before verification. Mirrors the JSONB-null pattern in
+        // breeze-billing/src/services/partnerSync.ts:activatePartner.
+        await tx
+          .update(partners)
+          .set({
+            emailVerifiedAt: now,
+            status: 'active' as const,
+            settings: sql`jsonb_set(
+              jsonb_set(
+                jsonb_set(
+                  COALESCE(${partners.settings}, '{}'::jsonb),
+                  '{statusMessage}', 'null'::jsonb
+                ),
+                '{statusActionUrl}', 'null'::jsonb
+              ),
+              '{statusActionLabel}', 'null'::jsonb
+            )`,
+            updatedAt: now,
+          })
+          .where(eq(partners.id, row.partnerId));
+      } else {
+        await tx
+          .update(partners)
+          .set({ emailVerifiedAt: now, updatedAt: now })
+          .where(eq(partners.id, row.partnerId));
+      }
+
+      return {
+        ok: true as const,
+        partnerId: row.partnerId,
+        userId: row.userId,
+        email: row.email,
+        autoActivated: shouldAutoActivate,
+      };
+    })
+  );
+}
+
+/**
+ * Marks all unconsumed tokens for a user as superseded. Old links stop
+ * working immediately and the verify endpoint reports 'superseded' so
+ * the user gets accurate copy ("a newer link was sent") rather than
+ * the misleading "you already verified".
+ *
+ * Returns the number of rows marked.
+ */
+export async function invalidateOpenTokens(userId: string): Promise<number> {
+  const now = new Date();
+  return withSystemDbAccessContext(async () => {
+    const result = await db
+      .update(emailVerificationTokens)
+      .set({ supersededAt: now })
+      .where(
+        and(
+          eq(emailVerificationTokens.userId, userId),
+          isNull(emailVerificationTokens.consumedAt),
+          isNull(emailVerificationTokens.supersededAt)
+        )
+      )
+      .returning({ id: emailVerificationTokens.id });
+    return result.length;
+  });
+}

--- a/apps/api/src/services/featureConfigResolver.ts
+++ b/apps/api/src/services/featureConfigResolver.ts
@@ -59,6 +59,7 @@ export function createSystemAuthContext(): AuthContext {
       id: '00000000-0000-0000-0000-000000000000',
       email: 'system@breeze.internal',
       name: 'System',
+      isPlatformAdmin: false,
     },
     token,
     partnerId: null,

--- a/apps/api/src/services/platformAdminBootstrap.test.ts
+++ b/apps/api/src/services/platformAdminBootstrap.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const updateMocks = vi.hoisted(() => {
+  return {
+    returningResult: [] as Array<{ id: string; email: string }>,
+    setSpy: vi.fn(),
+    whereSpy: vi.fn(),
+    returningSpy: vi.fn(),
+  };
+});
+
+vi.mock('../db', () => ({
+  db: {
+    update: vi.fn(() => ({
+      set: (values: unknown) => {
+        updateMocks.setSpy(values);
+        return {
+          where: (cond: unknown) => {
+            updateMocks.whereSpy(cond);
+            return {
+              returning: (cols: unknown) => {
+                updateMocks.returningSpy(cols);
+                return Promise.resolve(updateMocks.returningResult);
+              },
+            };
+          },
+        };
+      },
+    })),
+  },
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  users: {
+    id: 'users.id',
+    email: 'users.email',
+    isPlatformAdmin: 'users.isPlatformAdmin',
+  },
+}));
+
+import { bootstrapPlatformAdmins, parseAdminEmails } from './platformAdminBootstrap';
+import { db } from '../db';
+
+describe('parseAdminEmails', () => {
+  it('returns [] for empty input', () => {
+    expect(parseAdminEmails('')).toEqual([]);
+    expect(parseAdminEmails('   ')).toEqual([]);
+    expect(parseAdminEmails(',,, ,,')).toEqual([]);
+  });
+
+  it('splits, trims, and lowercases', () => {
+    expect(parseAdminEmails('Alice@Example.com')).toEqual(['alice@example.com']);
+    expect(parseAdminEmails('  Bob@X.com  ,Carol@y.com')).toEqual([
+      'bob@x.com',
+      'carol@y.com',
+    ]);
+  });
+
+  it('drops blank entries from messy CSV', () => {
+    expect(parseAdminEmails('a@x.com,, ,b@x.com,')).toEqual(['a@x.com', 'b@x.com']);
+  });
+});
+
+describe('bootstrapPlatformAdmins', () => {
+  const ORIGINAL_ENV = process.env.BREEZE_PLATFORM_ADMINS;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateMocks.returningResult = [];
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.BREEZE_PLATFORM_ADMINS;
+    } else {
+      process.env.BREEZE_PLATFORM_ADMINS = ORIGINAL_ENV;
+    }
+  });
+
+  it('warns and no-ops when env var is unset', async () => {
+    delete process.env.BREEZE_PLATFORM_ADMINS;
+    await bootstrapPlatformAdmins();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('No platform admins configured')
+    );
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('warns and no-ops when env var is empty', async () => {
+    process.env.BREEZE_PLATFORM_ADMINS = '   ';
+    await bootstrapPlatformAdmins();
+    expect(warnSpy).toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('promotes a single email', async () => {
+    process.env.BREEZE_PLATFORM_ADMINS = 'admin@example.com';
+    updateMocks.returningResult = [{ id: 'u1', email: 'admin@example.com' }];
+
+    await bootstrapPlatformAdmins();
+
+    expect(db.update).toHaveBeenCalledTimes(1);
+    expect(updateMocks.setSpy).toHaveBeenCalledWith({ isPlatformAdmin: true });
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('promoted 1 user')
+    );
+  });
+
+  it('promotes multiple comma-separated emails', async () => {
+    process.env.BREEZE_PLATFORM_ADMINS = 'a@x.com,B@x.com, c@x.com';
+    updateMocks.returningResult = [
+      { id: 'u1', email: 'a@x.com' },
+      { id: 'u2', email: 'b@x.com' },
+    ];
+
+    await bootstrapPlatformAdmins();
+
+    expect(db.update).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Configured 3 email(s); promoted 2 user(s)')
+    );
+  });
+
+  it('is idempotent (already-promoted users not re-promoted)', async () => {
+    process.env.BREEZE_PLATFORM_ADMINS = 'admin@example.com';
+    updateMocks.returningResult = []; // SQL filter excludes already-promoted users
+
+    await bootstrapPlatformAdmins();
+
+    expect(db.update).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('promoted 0 user')
+    );
+  });
+
+  it('normalizes whitespace and case in emails', async () => {
+    process.env.BREEZE_PLATFORM_ADMINS = '  Admin@EXAMPLE.com  ';
+    updateMocks.returningResult = [{ id: 'u1', email: 'admin@example.com' }];
+
+    await bootstrapPlatformAdmins();
+
+    // The where clause receives the lowercased+trimmed list — verify via the
+    // serialized SQL fragment passed to whereSpy. In the mock we capture the
+    // raw value; assert it stringifies to a parameterized form. The simpler
+    // observable assertion: bootstrap was invoked and produced a single update
+    // (parsing handled normalization or it would skip the call).
+    expect(db.update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/services/platformAdminBootstrap.ts
+++ b/apps/api/src/services/platformAdminBootstrap.ts
@@ -1,0 +1,43 @@
+import { sql } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../db';
+import { users } from '../db/schema';
+
+/**
+ * Idempotent bootstrap that promotes users listed in BREEZE_PLATFORM_ADMINS
+ * (comma-separated emails) to platform admin. Runs at API startup. Never
+ * demotes — removing an email from the env var is intentionally not a revoke;
+ * a platform admin must demote via DB or a future admin tool.
+ */
+export async function bootstrapPlatformAdmins(): Promise<void> {
+  const raw = process.env.BREEZE_PLATFORM_ADMINS ?? '';
+  const emails = parseAdminEmails(raw);
+
+  if (emails.length === 0) {
+    console.warn(
+      '[platform-admin-bootstrap] No platform admins configured (BREEZE_PLATFORM_ADMINS unset or empty)'
+    );
+    return;
+  }
+
+  const promoted = await withSystemDbAccessContext(async () => {
+    const result = await db
+      .update(users)
+      .set({ isPlatformAdmin: true })
+      .where(
+        sql`lower(${users.email}) = ANY(${emails}::text[]) AND ${users.isPlatformAdmin} = false`
+      )
+      .returning({ id: users.id, email: users.email });
+    return result;
+  });
+
+  console.log(
+    `[platform-admin-bootstrap] Configured ${emails.length} email(s); promoted ${promoted.length} user(s)`
+  );
+}
+
+export function parseAdminEmails(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => s.length > 0);
+}

--- a/apps/api/src/services/remoteAccessPolicy.ts
+++ b/apps/api/src/services/remoteAccessPolicy.ts
@@ -90,7 +90,7 @@ export function invalidateRemoteAccessCache(deviceId?: string): void {
 // ---------------------------------------------------------------------------
 
 const systemAuth: AuthContext = {
-  user: { id: 'system', email: 'system', name: 'System' },
+  user: { id: 'system', email: 'system', name: 'System', isPlatformAdmin: false },
   token: {} as any,
   partnerId: null,
   orgId: null,

--- a/apps/web/src/components/auth/VerifyEmailPage.tsx
+++ b/apps/web/src/components/auth/VerifyEmailPage.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useRef, useState } from 'react';
+import StatusIcon from './StatusIcon';
+import { apiVerifyEmail } from '../../stores/auth';
+
+type State =
+  | { phase: 'loading' }
+  | { phase: 'no-token' }
+  | { phase: 'success'; autoActivated: boolean }
+  | { phase: 'error'; reason: 'invalid' | 'expired' | 'consumed' | 'superseded' | 'network' | 'unknown' };
+
+const ERROR_COPY: Record<
+  Extract<State, { phase: 'error' }>['reason'],
+  { title: string; body: string }
+> = {
+  invalid: {
+    title: 'This link is invalid',
+    body: 'The verification link is not recognized. Sign in and request a new one from your account settings.',
+  },
+  expired: {
+    title: 'This link has expired',
+    body: 'Verification links expire after 24 hours. Sign in and request a new one from your account settings.',
+  },
+  consumed: {
+    title: 'This link has already been used',
+    body: 'Your email is already verified, or the link was used on another device.',
+  },
+  superseded: {
+    title: 'A newer verification link was sent',
+    body: 'Please use the most recent verification email — the older link is no longer valid.',
+  },
+  network: {
+    title: 'We couldn’t reach Breeze',
+    body: 'Check your connection and try the link again.',
+  },
+  unknown: {
+    title: 'Verification failed',
+    body: 'Something went wrong. Please try again or contact support.',
+  },
+};
+
+export default function VerifyEmailPage() {
+  const [state, setState] = useState<State>({ phase: 'loading' });
+  // Strict-mode in dev mounts components twice — block the duplicate POST so we
+  // don't burn the single-use token before the user sees a result.
+  const submittedRef = useRef(false);
+
+  useEffect(() => {
+    if (submittedRef.current) return;
+    submittedRef.current = true;
+
+    const params = new URLSearchParams(window.location.search);
+    const token = params.get('token');
+    if (!token) {
+      setState({ phase: 'no-token' });
+      return;
+    }
+
+    (async () => {
+      const result = await apiVerifyEmail(token);
+      if (result.success) {
+        setState({ phase: 'success', autoActivated: !!result.autoActivated });
+        return;
+      }
+      const err = result.error;
+      if (err === 'invalid' || err === 'expired' || err === 'consumed' || err === 'superseded') {
+        setState({ phase: 'error', reason: err });
+        return;
+      }
+      if (err === 'Network error') {
+        setState({ phase: 'error', reason: 'network' });
+        return;
+      }
+      setState({ phase: 'error', reason: 'unknown' });
+    })();
+  }, []);
+
+  if (state.phase === 'loading') {
+    return (
+      <div className="space-y-6 rounded-lg border bg-card p-6 shadow-sm" aria-busy="true">
+        <div className="space-y-2 text-center">
+          <StatusIcon variant="pending" label="Verifying" />
+          <h2 className="text-lg font-semibold">Verifying your email…</h2>
+        </div>
+      </div>
+    );
+  }
+
+  if (state.phase === 'no-token') {
+    return (
+      <div className="space-y-6 rounded-lg border bg-card p-6 shadow-sm">
+        <div className="space-y-2 text-center">
+          <StatusIcon variant="error" />
+          <h2 className="text-lg font-semibold">No verification token</h2>
+          <p className="text-sm text-muted-foreground">
+            This link is missing its token. Open the verification email and click the button again.
+          </p>
+        </div>
+        <a
+          href="/login"
+          className="flex h-11 w-full items-center justify-center rounded-md bg-primary text-sm font-medium text-primary-foreground transition hover:opacity-90"
+        >
+          Go to sign in
+        </a>
+      </div>
+    );
+  }
+
+  if (state.phase === 'success') {
+    return (
+      <div className="space-y-6 rounded-lg border bg-card p-6 shadow-sm">
+        <div className="space-y-2 text-center">
+          <StatusIcon variant="success" />
+          <h2 className="text-lg font-semibold">Email verified</h2>
+          <p className="text-sm text-muted-foreground">
+            {state.autoActivated
+              ? 'Your account is now active. You can sign in to start using Breeze.'
+              : 'Thanks for confirming your email. You can close this tab and return to Breeze.'}
+          </p>
+        </div>
+        <a
+          href="/login"
+          className="flex h-11 w-full items-center justify-center rounded-md bg-primary text-sm font-medium text-primary-foreground transition hover:opacity-90"
+        >
+          Sign in
+        </a>
+      </div>
+    );
+  }
+
+  const copy = ERROR_COPY[state.reason];
+  const showResendLink = state.reason === 'invalid' || state.reason === 'expired';
+
+  return (
+    <div className="space-y-6 rounded-lg border bg-card p-6 shadow-sm">
+      <div className="space-y-2 text-center">
+        <StatusIcon variant="error" />
+        <h2 className="text-lg font-semibold">{copy.title}</h2>
+        <p className="text-sm text-muted-foreground">{copy.body}</p>
+      </div>
+      <a
+        href="/login"
+        className="flex h-11 w-full items-center justify-center rounded-md bg-primary text-sm font-medium text-primary-foreground transition hover:opacity-90"
+      >
+        {showResendLink ? 'Sign in to request a new link' : 'Go to sign in'}
+      </a>
+    </div>
+  );
+}

--- a/apps/web/src/pages/auth/verify-email.astro
+++ b/apps/web/src/pages/auth/verify-email.astro
@@ -1,0 +1,8 @@
+---
+import AuthLayout from '../../layouts/AuthLayout.astro';
+import VerifyEmailPage from '../../components/auth/VerifyEmailPage';
+---
+
+<AuthLayout title="Verify Email">
+  <VerifyEmailPage client:load />
+</AuthLayout>

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -626,6 +626,52 @@ export async function apiResetPassword(token: string, password: string): Promise
   }
 }
 
+export async function apiVerifyEmail(token: string): Promise<{
+  success: boolean;
+  error?: 'invalid' | 'expired' | 'consumed' | string;
+  partnerId?: string;
+  email?: string;
+  autoActivated?: boolean;
+}> {
+  try {
+    const response = await fetch(buildApiUrl('/auth/verify-email'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token })
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+      return { success: false, error: data.error };
+    }
+
+    return {
+      success: true,
+      partnerId: data.partnerId,
+      email: data.email,
+      autoActivated: data.autoActivated,
+    };
+  } catch {
+    return { success: false, error: 'Network error' };
+  }
+}
+
+export async function apiResendVerification(): Promise<{ success: boolean; error?: string }> {
+  try {
+    const response = await fetchWithAuth(buildApiUrl('/auth/resend-verification'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      return { success: false, error: data?.error ?? 'Failed to resend verification email' };
+    }
+    return { success: true };
+  } catch {
+    return { success: false, error: 'Network error' };
+  }
+}
+
 export async function apiSendSmsMfaCode(tempToken: string): Promise<{
   success: boolean;
   error?: string;


### PR DESCRIPTION
## Summary

- Adds a cross-tenant `/admin/*` gate (`POST suspend-for-abuse` + `unsuspend`) behind a `users.is_platform_admin` flag bootstrapped from `BREEZE_PLATFORM_ADMINS` env var. Suspend queues `self_uninstall` on every device, deletes sessions, disables non-admin users, revokes API keys, blanket-revokes JWTs in Redis, audits — and **fails to 500 with `tokenRevocationFailed=true` if Redis revocation fails** so the operator never gets a misleading 200.
- Adds the email verification flow: tokens table with RLS, send on signup, verify + resend endpoints. Distinguishes `superseded` (a newer link was sent) from `consumed` (already used) so users get accurate copy. Auto-activates on verify when payment is already attached, clearing the "Awaiting email verification" status banner.
- Tightens `AuthContext.user.isPlatformAdmin` to a required `boolean` (was optional shortcut to dodge cascading test edits — fixed properly in this PR).

## What got us here

A pair of paid signups on hosted cloud had multiple failed CC attempts before passing — one (`VLDK`) using `rupert@rupertsmithsurveys.com` (real UK chartered surveyor) but logging in from an Egyptian Telecom IP, and a community-tier abuser (`geneshomes`) rotating across **58 distinct proxy/VPN IPs** in a few days. Both were suspended manually via raw SQL during the investigation. This PR ships the API endpoint + the email-verification gate so the next abuser can be removed in one POST instead of a SQL transaction.

## Companion PR

Activation gate lives in the `breeze-billing` repo: https://github.com/LanternOps/breeze-billing/pull/new/feat/email-verification-gate (must merge before this is fully effective for unverified-but-paid signups).

## Test plan

- [ ] `pnpm test --filter=@breeze/api` — 39 new tests pass (platformAdmin/abuse/emailVerification/verifyEmail/bootstrap)
- [ ] `npx tsc --noEmit -p apps/api/tsconfig.json` — clean
- [ ] `pnpm test -- autoMigrate` — migration ordering verified (`-a-` < `-anti-`)
- [ ] On a staging droplet, set `BREEZE_PLATFORM_ADMINS=todd@olivetech.co`; restart API; confirm bootstrap log line; `POST /admin/partners/$ID/suspend-for-abuse` succeeds with 200 and the agent self-uninstalls; flip Redis off and re-run on a second partner — confirm 500 with `tokenRevocationFailed=true`
- [ ] Sign up a new tenant; confirm verification email lands and the link works; click resend; confirm the older link returns `superseded` (not `consumed`)
- [ ] Pay → verify path: confirm partner auto-flips to `active` and the `statusMessage` banner clears

## Migrations

Three migrations, all idempotent:
1. `2026-05-04-anti-abuse-foundation.sql` — `users.is_platform_admin` + `email_verification_tokens` table + RLS
2. `2026-05-04-a-users-email-verified-at.sql` — `users.email_verified_at`
3. `2026-05-04-b-evt-superseded-at.sql` — `email_verification_tokens.superseded_at`

🤖 Generated with [Claude Code](https://claude.com/claude-code)