### PR TITLE
test(api): bump time-bomb fixture dates in snapshots immutability test

### DIFF
--- a/apps/api/src/routes/backup/snapshots.test.ts
+++ b/apps/api/src/routes/backup/snapshots.test.ts
@@ -140,7 +140,7 @@ describe('snapshot routes', () => {
         legalHold: true,
         legalHoldReason: 'Regulatory matter',
         isImmutable: true,
-        immutableUntil: new Date('2026-06-01T00:00:00.000Z'),
+        immutableUntil: new Date('2030-06-01T00:00:00.000Z'),
         immutabilityEnforcement: 'application',
       }),
     ]));
@@ -238,7 +238,7 @@ describe('snapshot routes', () => {
     selectMock.mockReturnValueOnce(chainMock([
       makeSnapshot({
         isImmutable: true,
-        immutableUntil: new Date('2026-06-01T00:00:00.000Z'),
+        immutableUntil: new Date('2030-06-01T00:00:00.000Z'),
         immutabilityEnforcement: 'provider',
       }),
     ]));
@@ -305,14 +305,14 @@ describe('snapshot routes', () => {
       .mockReturnValueOnce(chainMock([
         makeSnapshot({
           isImmutable: true,
-          immutableUntil: new Date('2026-06-01T00:00:00.000Z'),
+          immutableUntil: new Date('2030-06-01T00:00:00.000Z'),
           immutabilityEnforcement: 'application',
         }),
       ]))
       .mockReturnValueOnce(chainMock([
         makeSnapshot({
           isImmutable: true,
-          immutableUntil: new Date('2026-06-01T00:00:00.000Z'),
+          immutableUntil: new Date('2030-06-01T00:00:00.000Z'),
           immutabilityEnforcement: 'application',
         }),
       ]));
@@ -320,7 +320,7 @@ describe('snapshot routes', () => {
     const res = await app.request(`/backup/snapshots/${SNAPSHOT_ID}/immutability`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
-      body: JSON.stringify({ reason: 'Try shorten', extendUntil: '2026-05-01T00:00:00.000Z', enforcement: 'application' }),
+      body: JSON.stringify({ reason: 'Try shorten', extendUntil: '2030-05-01T00:00:00.000Z', enforcement: 'application' }),
     });
 
     expect(res.status).toBe(409);


### PR DESCRIPTION
## Summary

The \`snapshot routes > rejects attempts to shorten an existing immutability window\` test in \`snapshots.test.ts\` started failing on main on 2026-05-02 once the wall clock passed the hardcoded \`extendUntil: '2026-05-01'\` fixture. The route's \"must end in the future\" guard now fires at 400 before the intended \"can only be extended forward\" 409 conflict check.

This bumps fixture dates to 2030 (matching the existing 2026-06-01 anchors, also bumped) for multi-year runway. Test-only change — no route logic touched.

## Test plan

- [x] \`vitest run src/routes/backup/snapshots.test.ts\` passes locally (7/7)
- [ ] CI Test API job goes green
- [ ] Unblocks the 12 dependabot PRs that have been red on this single shared failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)