### PR TITLE
fix(release): drop spctl exec check on raw Mach-O agent binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -766,10 +766,26 @@ jobs:
             exit 1
           fi
 
+          # Raw Mach-O binaries: verify signature + hardened runtime + Developer ID.
+          # Do NOT run `spctl -a -t exec` against raw command-line binaries — Gatekeeper's
+          # exec assessment is bundle-aware and rejects raw Mach-O with "the code is valid
+          # but does not seem to be an app", even when signing/notarization are correct.
+          # The user-facing assessment happens at the .pkg layer below (binaries are
+          # delivered to end users only inside notarized .pkgs).
           for bin in staging/breeze-agent-darwin-* staging/breeze-backup-darwin-* staging/breeze-desktop-helper-darwin-* staging/breeze-watchdog-darwin-*; do
             [ -f "$bin" ] || continue
             codesign --verify --strict --verbose=2 "$bin"
-            spctl -a -vv -t exec "$bin"
+            DETAILS=$(codesign -dvvv "$bin" 2>&1)
+            if ! grep -q 'flags=.*runtime' <<<"$DETAILS"; then
+              echo "::error::$bin missing hardened runtime flag"
+              echo "$DETAILS"
+              exit 1
+            fi
+            if ! grep -q 'Authority=Developer ID Application' <<<"$DETAILS"; then
+              echo "::error::$bin not signed by Developer ID Application"
+              echo "$DETAILS"
+              exit 1
+            fi
           done
 
           for pkg in staging/*.pkg; do


### PR DESCRIPTION
## Summary
- v0.65.0's release workflow failed at the new "Verify macOS signatures and notarization" step (added by #568) — `spctl -a -t exec` against the raw `breeze-agent-darwin-amd64` Mach-O binary returned `rejected (the code is valid but does not seem to be an app)`. Cascading effect: `Build macOS Installer App` and `Build Binaries Init Image` were skipped and `Release Integrity Gate` failed. Prod Docker push succeeded so the API/Web deploy is unblocked, but macOS agents won't get OTA updates to 0.65.0 until a v0.65.1 tag re-runs the workflow.
- Root cause: `spctl -a -t exec` performs a Gatekeeper *bundle* assessment and is not a valid check for raw command-line Mach-O binaries — it always rejects them with that message regardless of signature/notarization correctness. This step never ran on a real tag release before v0.65.0 (added in #568, merged 2026-05-05; v0.64.4 was the last tag before that).
- Fix: drop the `spctl -a -t exec` line for raw binaries; replace with checks that actually mean something for command-line tools — hardened runtime flag presence and `Authority=Developer ID Application`. `codesign --verify --strict` is preserved. The .pkg-level checks (`pkgutil --check-signature`, `stapler validate`, `spctl -a -t install`) are unchanged and remain the user-facing Gatekeeper assurance, since binaries reach end users only inside notarized .pkgs.

## Evidence
Failing job log (run `25412615958`, job `74537579525`):
```
staging/breeze-agent-darwin-amd64: valid on disk
staging/breeze-agent-darwin-amd64: satisfies its Designated Requirement
staging/breeze-agent-darwin-amd64: rejected (the code is valid but does not seem to be an app)
##[error]Process completed with exit code 3.
```
All four prior steps in the same job (productsign + notarytool submit + stapler) succeeded — Apple Notary Service returned `Accepted` for both amd64 and arm64 .pkgs.

## Test plan
- [ ] Tag a `v0.65.1-rc.1` (or `v0.65.1` directly) once merged; confirm the `Sign macOS Agent Binary` job now passes through to `Build macOS Installer App` and `Build Binaries Init Image`.
- [ ] After tag completes, sanity-check on a Mac: download `breeze-agent-darwin-arm64.pkg` from the GH release, run `spctl -a -t install -vv`, verify `accepted ... source=Notarized Developer ID`.
- [ ] Verify a fresh macOS install + auto-update path bumps to 0.65.1.

## Notes for reviewer
- No secrets touched; cert + Apple API keys are healthy (notarization succeeded for both .pkgs in the failing run).
- Two binaries that the verify loop globs for don't exist in the agent staging dir today (`breeze-backup-darwin-*`, `breeze-watchdog-darwin-*`); the `[ -f "$bin" ] || continue` guard keeps the loop a no-op for those, and the same conservative globbing is preserved here.
- I considered adding `--entitlements` checks but those don't show up in `codesign -dvvv` output by default and would require `--xml` parsing; the two checks added (hardened runtime + Developer ID) are the high-value ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)