### PR TITLE
fix(release): skip .pkg/.zip in macOS binary verify loop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -774,6 +774,10 @@ jobs:
           # delivered to end users only inside notarized .pkgs).
           for bin in staging/breeze-agent-darwin-* staging/breeze-backup-darwin-* staging/breeze-desktop-helper-darwin-* staging/breeze-watchdog-darwin-*; do
             [ -f "$bin" ] || continue
+            # The prefix glob also matches .pkg / .zip files in staging at this
+            # point in the workflow — skip them (.pkg uses productsign, .zip is
+            # the notarytool upload artifact). The .pkg loop below verifies them.
+            case "$bin" in *.pkg|*.zip) continue ;; esac
             codesign --verify --strict --verbose=2 "$bin"
             DETAILS=$(codesign -dvvv "$bin" 2>&1)
             if ! grep -q 'flags=.*runtime' <<<"$DETAILS"; then


### PR DESCRIPTION
## Summary

Follow-up to #598. The verify loop's prefix glob `staging/breeze-agent-darwin-*` (and the analogous `breeze-backup-darwin-*`, `breeze-desktop-helper-darwin-*`, `breeze-watchdog-darwin-*`) matches both raw Mach-O binaries AND the `.pkg` installer (which shares the prefix). When the loop iterates over `breeze-agent-darwin-amd64.pkg`, `codesign --verify` returns "code object is not signed at all" — `.pkg`s are productsigned, not codesigned.

Observed in v0.65.1 release run 25416464564 (job 74549030654):
```
staging/breeze-agent-darwin-amd64: valid on disk
staging/breeze-agent-darwin-amd64: satisfies its Designated Requirement
staging/breeze-agent-darwin-amd64.pkg: code object is not signed at all
```

The signing pipeline succeeded — both .pkgs were signed by productsign and notarized + stapled by Apple's Notary Service. Only the verify step is broken.

## Fix

Add `case "$bin" in *.pkg|*.zip) continue ;; esac` inside the binary loop. The dedicated `.pkg` loop directly below already verifies installer signatures via `pkgutil --check-signature` + `stapler validate` + `spctl -a -t install`.

## Test plan
- [ ] Tag v0.65.2 once merged; confirm `Sign macOS Agent Binary` job passes through to `Build Binaries Init Image`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)