### PR TITLE
fix(release): close 6 release-verify silent-failure modes pre-tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,9 @@ jobs:
       - name: Run supply-chain hardening guard
         run: bash scripts/security/check-supply-chain-hardening.sh
 
+      - name: Run relay/edge hardening guard
+        run: bash scripts/security/check-relay-edge-hardening.sh
+
   build-api:
     name: Build API
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -615,18 +615,13 @@ jobs:
         run: |
           for bin in staging/breeze-agent-darwin-* staging/breeze-backup-darwin-* staging/breeze-desktop-helper-darwin-* staging/breeze-watchdog-darwin-*; do
             [ -f "$bin" ] || continue
+            case "$bin" in *.pkg|*.zip) continue ;; esac
             ZIP_PATH="${bin}.zip"
             ditto -c -k --keepParent "$bin" "$ZIP_PATH"
 
-            echo "Submitting $(basename "$bin") for notarization..."
-            xcrun notarytool submit "$ZIP_PATH" \
-              --apple-id "$APPLE_ID" \
-              --password "$APPLE_PASSWORD" \
-              --team-id "$APPLE_TEAM_ID" \
-              --wait --timeout 30m
+            scripts/release/notarize-submit.sh "$ZIP_PATH"
 
             rm -f "$ZIP_PATH"
-            echo "Notarized: $(basename "$bin")"
           done
 
       - name: Upload signed darwin/amd64
@@ -747,14 +742,9 @@ jobs:
             exit 0
           fi
           for pkg in staging/*.pkg; do
-            echo "Submitting $(basename "$pkg") for notarization..."
-            xcrun notarytool submit "$pkg" \
-              --apple-id "$APPLE_ID" \
-              --password "$APPLE_PASSWORD" \
-              --team-id "$APPLE_TEAM_ID" \
-              --wait --timeout 30m
-
+            scripts/release/notarize-submit.sh "$pkg"
             xcrun stapler staple "$pkg"
+            xcrun stapler validate "$pkg"
             echo "Notarized and stapled: $(basename "$pkg")"
           done
 
@@ -886,25 +876,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           ditto -c -k --keepParent "build/Breeze Installer.app" build/installer-notarize.zip
-          submit_output=$(xcrun notarytool submit build/installer-notarize.zip \
-            --apple-id "$APPLE_ID" \
-            --password "$APPLE_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID" \
-            --wait --timeout 30m)
-          echo "$submit_output"
-          submission_id=$(echo "$submit_output" | awk '/^[[:space:]]*id:/ {print $2; exit}')
-          status=$(echo "$submit_output" | awk '/^[[:space:]]*status:/ {print $2; exit}')
-          if [ "$status" != "Accepted" ]; then
-            echo "::error::Notarization failed with status '$status' (submission $submission_id)"
-            if [ -n "$submission_id" ]; then
-              echo "--- xcrun notarytool log $submission_id ---"
-              xcrun notarytool log "$submission_id" \
-                --apple-id "$APPLE_ID" \
-                --password "$APPLE_PASSWORD" \
-                --team-id "$APPLE_TEAM_ID" || true
-            fi
-            exit 1
-          fi
+          scripts/release/notarize-submit.sh build/installer-notarize.zip
           xcrun stapler staple "build/Breeze Installer.app"
           xcrun stapler validate "build/Breeze Installer.app"
           spctl -a -t exec -vv "build/Breeze Installer.app"
@@ -1269,11 +1241,7 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          xcrun notarytool submit breeze-viewer-macos.dmg \
-            --apple-id "$APPLE_ID" \
-            --password "$APPLE_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID" \
-            --wait --timeout 30m
+          "$GITHUB_WORKSPACE/scripts/release/notarize-submit.sh" breeze-viewer-macos.dmg
           xcrun stapler staple breeze-viewer-macos.dmg
           xcrun stapler validate breeze-viewer-macos.dmg
 
@@ -1394,11 +1362,7 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          xcrun notarytool submit breeze-helper-macos.dmg \
-            --apple-id "$APPLE_ID" \
-            --password "$APPLE_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID" \
-            --wait --timeout 30m
+          "$GITHUB_WORKSPACE/scripts/release/notarize-submit.sh" breeze-helper-macos.dmg
           xcrun stapler staple breeze-helper-macos.dmg
           xcrun stapler validate breeze-helper-macos.dmg
 
@@ -1857,6 +1821,7 @@ jobs:
           import hashlib
           import json
           import os
+          import re
           from pathlib import Path
 
           release_dir = Path("release-assets")
@@ -1867,10 +1832,29 @@ jobs:
               "release-artifact-manifest.json.minisig",
           }
 
+          # Raw Mach-O agent binaries get Developer ID + notarization but
+          # ship to users only inside the .pkg. spctl --assess --type execute
+          # is invalid against raw Mach-O, so the trust label is correct
+          # even though the end-user verifier differs (.pkg gatekeeper check).
+          DARWIN_BINARY_RE = re.compile(
+              r"^breeze-(agent|backup|desktop-helper|watchdog)-darwin-(amd64|arm64)$"
+          )
+
           def platform_trust(name):
+              # *-template.msi is intentionally unsigned here; per-tenant
+              # property injection happens server-side and the resulting
+              # MSI is signed there.
+              if name.endswith("-template.msi"):
+                  return "release-workflow-produced"
               if name.endswith(".msi") or name.endswith(".exe"):
                   return "windows-authenticode-required"
-              if name.endswith(".pkg") or name.endswith(".app.zip"):
+              if (
+                  name.endswith(".pkg")
+                  or name.endswith(".app.zip")
+                  or name.endswith(".dmg")
+              ):
+                  return "macos-developer-id-notarization-required"
+              if DARWIN_BINARY_RE.match(name):
                   return "macos-developer-id-notarization-required"
               return "release-workflow-produced"
 
@@ -1989,33 +1973,33 @@ jobs:
       - name: Verify release asset integrity requirements
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          required_assets=(
-            "breeze-agent-windows-amd64.exe"
-            "breeze-backup-windows-amd64.exe"
-            "breeze-watchdog-windows-amd64.exe"
-            "breeze-agent.msi"
-            "breeze-agent-darwin-amd64"
-            "breeze-agent-darwin-arm64"
-            "breeze-agent-darwin-amd64.pkg"
-            "breeze-agent-darwin-arm64.pkg"
-            "breeze-backup-darwin-amd64"
-            "breeze-backup-darwin-arm64"
-            "breeze-desktop-helper-darwin-amd64"
-            "breeze-desktop-helper-darwin-arm64"
-            "breeze-watchdog-darwin-amd64"
-            "breeze-watchdog-darwin-arm64"
-            "Breeze Installer.app.zip"
-            "breeze-viewer-windows.msi"
-            "breeze-helper-windows.msi"
-            "latest.json"
-            "release-artifact-manifest.json"
-            "release-artifact-manifest.json.ed25519"
-            "release-artifact-manifest.json.minisig"
-            "checksums.txt"
-          )
+          set -euo pipefail
+          # checksums.txt is verified for existence/non-emptiness but cannot
+          # contain a SHA entry for itself: `sha256sum * > checksums.txt`
+          # expands the glob before creating the redirection target.
+          if [ ! -s "release-assets/checksums.txt" ]; then
+            echo "::error::Required asset missing or empty: checksums.txt"
+            exit 1
+          fi
 
-          for asset in "${required_assets[@]}"; do
-            if [ ! -s "release-assets/$asset" ]; then
+          # Build the asset list dynamically from release-assets/ to catch
+          # partial-upload failures (missing AppImage, DMG, signature, etc.)
+          # that a hand-curated list silently allows.
+          # ! -name '.*' mirrors `sha256sum *`'s glob (which excludes dotfiles)
+          # so the two steps see the same file set. Materialize via a tempfile
+          # so a `find` failure propagates under set -e (process substitution
+          # exit codes don't reach the parent shell).
+          assets_list=$(mktemp)
+          trap 'rm -f "$assets_list"' EXIT
+          find release-assets -mindepth 1 -maxdepth 1 -type f ! -name '.*' -print0 \
+            > "$assets_list"
+
+          asset_count=0
+          while IFS= read -r -d '' path; do
+            asset=$(basename "$path")
+            [ "$asset" = "checksums.txt" ] && continue
+            asset_count=$((asset_count + 1))
+            if [ ! -s "$path" ]; then
               echo "::error::Required signed/notarized release asset missing or empty: $asset"
               exit 1
             fi
@@ -2030,7 +2014,13 @@ jobs:
               echo "::error::checksums.txt missing SHA-256 entry for $asset"
               exit 1
             fi
-          done
+          done < "$assets_list"
+
+          if [ "$asset_count" -eq 0 ]; then
+            echo "::error::No signable artifacts found in release-assets/ (only checksums.txt or empty)"
+            exit 1
+          fi
+          echo "Verified $asset_count release assets against checksums.txt"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0

--- a/scripts/release/notarize-submit.sh
+++ b/scripts/release/notarize-submit.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# notarize-submit.sh — submit an artifact to Apple notarytool and fail closed
+# on rejection.
+#
+# `xcrun notarytool submit … --wait` exits 0 for Accepted, Invalid, AND
+# Rejected. Trusting the exit code alone ships rejected artifacts. This helper
+# parses the status: line and prints `notarytool log <id>` on failure.
+#
+# Required env: APPLE_ID, APPLE_PASSWORD, APPLE_TEAM_ID
+# Usage: notarize-submit.sh <path-to-artifact>
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: notarize-submit.sh <path>" >&2
+  exit 2
+fi
+
+artifact="$1"
+if [ ! -s "$artifact" ]; then
+  echo "::error::notarize-submit: artifact missing or empty: $artifact" >&2
+  exit 1
+fi
+
+: "${APPLE_ID:?APPLE_ID is required}"
+: "${APPLE_PASSWORD:?APPLE_PASSWORD is required}"
+: "${APPLE_TEAM_ID:?APPLE_TEAM_ID is required}"
+
+echo "Submitting $(basename "$artifact") for notarization..."
+# Capture both streams so auth/network errors show up regardless of the
+# caller's stderr handling.
+submit_output=$(xcrun notarytool submit "$artifact" \
+  --apple-id "$APPLE_ID" \
+  --password "$APPLE_PASSWORD" \
+  --team-id "$APPLE_TEAM_ID" \
+  --wait --timeout 30m 2>&1)
+echo "$submit_output"
+
+# Parsing plain-text submit output; do NOT pass --output-format json without
+# updating both extractors below. Empty status falls through to the failure
+# branch and exits non-zero — the failure is fail-closed by construction.
+submission_id=$(echo "$submit_output" | awk '/^[[:space:]]*id:/ {print $2; exit}')
+status=$(echo "$submit_output" | awk '/^[[:space:]]*status:/ {print $2; exit}')
+
+if [ "$status" != "Accepted" ]; then
+  echo "::error::Notarization failed for $(basename "$artifact"): status='$status' submission='$submission_id'" >&2
+  if [ -n "$submission_id" ]; then
+    echo "--- xcrun notarytool log $submission_id ---" >&2
+    xcrun notarytool log "$submission_id" \
+      --apple-id "$APPLE_ID" \
+      --password "$APPLE_PASSWORD" \
+      --team-id "$APPLE_TEAM_ID" >&2 || true
+  fi
+  exit 1
+fi
+
+echo "Notarization Accepted: $(basename "$artifact") (submission $submission_id)"


### PR DESCRIPTION
## Summary

Pre-emptive audit of the release-verify path landed in #568 found six bugs that would each have triggered a separate hotfix tag. Closing all six in one PR so the next tag doesn't repeat the #598/#599 cycle.

| # | Severity | What's wrong | Fix |
|---|---|---|---|
| F1 | blocker | Integrity gate required `checksums.txt` to contain a SHA entry for itself, but `sha256sum * > checksums.txt` expands the glob before redirection — every tag would fail here. | Drop self-entry requirement; existence-only check on `checksums.txt` |
| F2 | blocker | `xcrun notarytool submit --wait` exits 0 for Accepted, Invalid, AND Rejected. Four of five sites trusted the exit code; rejected raw Mach-O (which can't be stapled) shipped silently. | New `scripts/release/notarize-submit.sh` parses `status:` and fails closed; wired into all five sites for consistency |
| F3 | high | Manifest classifier labeled the unsigned `breeze-agent-template.msi` as `windows-authenticode-required` despite template being intentionally unsigned at workflow time (re-signed server-side per `apps/api/src/services/msiSigning.ts:53`). | Classifier returns `release-workflow-produced` for `*-template.msi` |
| F4 | medium | Classifier left `*.dmg` and raw Mach-O agent binaries at `release-workflow-produced` despite full Developer ID + notarization. | Classifier returns `macos-developer-id-notarization-required` for `*.dmg` and `breeze-(agent\|backup\|desktop-helper\|watchdog)-darwin-(amd64\|arm64)` |
| F5 | medium | `scripts/security/check-relay-edge-hardening.sh` (added by #568) was never invoked. | Added step to `ci.yml` security job alongside the supply-chain sibling |
| F6 | medium | Hand-curated required-assets list omitted Linux AppImages, both DMGs, several agent binaries. Partial-upload failures shipped silently. | List built dynamically from `release-assets/` with `set -euo pipefail`, tempfile materialization (so `find` errors propagate), and `! -name '.*'` to mirror `sha256sum *` glob |

## Why all in one PR

Two consecutive hotfix tags (#598, #599) had to be cut after #568 because each fix uncovered the next bug only when the workflow re-ran. An auditor agent traced the full path end-to-end (no real-runner artifacts, but with synthetic dry-runs of each loop body), then this PR addresses all six in priority order.

## Review applied

Internal review via `pr-review-toolkit:code-reviewer`, `silent-failure-hunter`, and `comment-analyzer` agents found two important silent-failure modes in the initial fix:
- `find -print0` exit code didn't propagate through process substitution → fixed via tempfile + `set -euo pipefail`
- Dotfile glob mismatch between `sha256sum *` and `find -print0` → fixed by adding `! -name '.*'` to find

Comments cleaned up to drop `#598` issue ref and `jsign` tool mention (both flagged as drift-prone).

## Verification

- [x] `shellcheck scripts/release/notarize-submit.sh` clean
- [x] YAML parses for `release.yml` and `ci.yml`
- [x] `bash scripts/security/check-relay-edge-hardening.sh` → `relay-edge-hardening: ok`
- [x] `bash scripts/security/check-supply-chain-hardening.sh` → `Supply-chain hardening checks passed.`
- [x] API tests pass: `installerBuilder.test.ts`, `releaseArtifactManifest.test.ts`, `binarySync.test.ts` (16/16)
- [x] F1 dotfile + happy-path simulation locally (verified `.DS_Store` is correctly skipped, missing-checksum entries detected)
- [x] No API consumer enforces `windows-authenticode-required` on the template MSI (only `breeze-agent.msi` at `installerBuilder.ts:215`)

## Test plan

- [ ] CI green on this PR
- [ ] After merge, cut a test prerelease tag (e.g. `0.64.5-rc.1`) and verify:
  - [ ] All five notarization sites complete with `Notarization Accepted: …`
  - [ ] Verify-integrity step prints `Verified N release assets against checksums.txt` with N matching the published asset count
  - [ ] `release-artifact-manifest.json` has `windows-authenticode-required` only on signed Windows MSI/EXEs (not template MSI), `macos-developer-id-notarization-required` on `.pkg`/`.app.zip`/`.dmg` and Mach-O agent binaries
  - [ ] CI security job runs both `check-supply-chain-hardening.sh` and `check-relay-edge-hardening.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)