### PR TITLE
fix(api): drop oauth tables from PARTNER_TENANT_TABLES allowlist

### DIFF
--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -58,12 +58,6 @@ const PARTNER_TENANT_TABLES: ReadonlyMap<string, string> = new Map<string, strin
   ['partner_users', 'partner_id'],
   ['oauth_clients', 'partner_id'],
   ['oauth_client_partner_grants', 'partner_id'],
-  ['oauth_refresh_tokens', 'partner_id'],
-  // oauth_grants partner_id is nullable (NULL between adapter.upsert and the
-  // setGrantBreezeMeta UPDATE during consent). The coverage check only needs
-  // the column name; the policy's `partner_id IS NULL OR ...` clause is
-  // checked by the policy's own qual, not this allowlist.
-  ['oauth_grants', 'partner_id'],
   ['email_verification_tokens', 'partner_id'],
 ]);
 


### PR DESCRIPTION
## Summary
- Removes `oauth_grants` and `oauth_refresh_tokens` from `PARTNER_TENANT_TABLES` in the RLS coverage test. PR #568's migration `2026-05-03-oauth-token-user-rls.sql` moved these to user-scoped policies, so the partner-axis assertion fails on a fresh DB.
- Both tables remain correctly listed in `USER_ID_SCOPED_TABLES`.

## Why this slipped past CI
`vitest.integration.config.ts` explicitly excludes `rls-coverage.integration.test.ts` (it's a read-only `pg_catalog` inspection), and there's no `test:rls-coverage` npm script wiring it into CI's `smoke-test` job. Found while running PR #568's test plan post-merge.

## Verification
\`\`\`
npx vitest run --config vitest.config.rls-coverage.ts
# Test Files  1 passed (1)
# Tests  9 passed (9)
\`\`\`

## Follow-up (not in this PR)
Add a `test:rls-coverage` script and wire it into the `smoke-test` job so this can't regress silently again.

## Test plan
- [x] `npx vitest run --config vitest.config.rls-coverage.ts` passes against fresh test DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)