### PR TITLE
ci: wire RLS coverage contract test into smoke-test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -618,6 +618,25 @@ jobs:
           NODE_ENV: test
         run: pnpm --filter=@breeze/api test:integration
 
+      # The rls-coverage contract test inspects pg_catalog to verify every
+      # tenant-scoped table has policies covering SELECT/INSERT/UPDATE/DELETE
+      # via the right access helper. Runs against the same test DB AFTER
+      # the integration suite (which has already triggered autoMigrate).
+      # Has its own runner because vitest.integration.config.ts excludes it:
+      # the read-only catalog inspection must not be hooked to setup.ts,
+      # which TRUNCATEs core tables on beforeEach.
+      - name: Run RLS coverage contract test
+        env:
+          DATABASE_URL: postgresql://breeze_test:breeze_test@localhost:5433/breeze_test
+          DATABASE_URL_APP: postgresql://breeze_app:breeze_test@localhost:5433/breeze_test
+          BREEZE_APP_DB_PASSWORD: breeze_test
+          POSTGRES_PASSWORD: breeze_test
+          JWT_SECRET: ci-smoke-k7x9Qm4pR2vL8nW5jT3yF6hB0cA1dE4gI7
+          APP_ENCRYPTION_KEY: ci-smoke-Xz9Lm3Kp7Wn2Qr5Tv8Yb0Hd4Fg6Jc1Ae3
+          MFA_ENCRYPTION_KEY: ci-smoke-Nm4Rp8Ws2Kv6Tq0Yh3Bd7Fg1Jc5Le9Ax2
+          NODE_ENV: test
+        run: pnpm --filter=@breeze/api test:rls-coverage
+
       - name: Show container logs on failure
         if: failure()
         run: |

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,6 +23,7 @@
     "test:docker:up": "docker compose -f ../../docker-compose.test.yml up -d --wait",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:integration:watch": "vitest --config vitest.integration.config.ts",
+    "test:rls-coverage": "vitest run --config vitest.config.rls-coverage.ts",
     "test:run": "vitest run"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Adds a \`test:rls-coverage\` script in \`apps/api/package.json\`.
- Adds a CI step that runs it after the integration suite in the smoke-test job.

## Why
\`vitest.integration.config.ts\` excludes \`rls-coverage.integration.test.ts\` because the test inspects \`pg_catalog\` read-only and must not be hooked to setup.ts (which TRUNCATEs core tables on \`beforeEach\`). It had no other runner — so the regression PR #605 fixed shipped to main without anyone noticing.

This wires it into CI so the contract test runs against the same migrated test DB the integration suite uses.

## Test plan
- [x] \`pnpm --filter=@breeze/api test:rls-coverage\` passes locally (9/9)
- [ ] CI smoke-test job picks up the new step and it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)