### PR TITLE
fix(agent): correct embedded manifest trust root + recovery CLI for stuck fleets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,16 @@ jobs:
       - name: Build API
         run: pnpm build --filter=@breeze/api
 
+      - name: Verify expected dist artefacts exist
+        # tsup config defines named entries — a regression to a single
+        # entry would silently drop dist/scripts/recover-stuck-agents.cjs
+        # (the runbook target), and a typo there could move dist/index.cjs
+        # off the path the production Dockerfile CMDs at. Fail loudly.
+        run: |
+          test -f apps/api/dist/index.cjs || { echo "missing apps/api/dist/index.cjs"; exit 1; }
+          test -f apps/api/dist/scripts/recover-stuck-agents.cjs || { echo "missing apps/api/dist/scripts/recover-stuck-agents.cjs"; exit 1; }
+          echo "Both expected dist artefacts present"
+
       - name: Upload API artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -65,9 +65,18 @@ CLAUDE.md
 .claude/skills/
 .claude/settings.example.json
 
-# Internal docs (not for public repo)
+# Internal docs (not for public repo). Use /internal/* (not /internal) so
+# selective re-inclusion below works — once a directory itself is ignored,
+# git won't recurse into it and !rules don't match.
 .internal/
-/internal
+/internal/*
+# Release manifest public keys + README are checked in so the agent's
+# embedded trust-root regression test (TestEmbeddedTrustRootMatchesRepoPubKey)
+# has a tracked source of truth. Private keys stay out.
+!/internal/release-keys/
+/internal/release-keys/*
+!/internal/release-keys/*.pub
+!/internal/release-keys/README.md
 
 # Stray screenshots
 *.png

--- a/agent/internal/heartbeat/handlers_devupdate.go
+++ b/agent/internal/heartbeat/handlers_devupdate.go
@@ -42,16 +42,23 @@ func handleDevUpdate(h *Heartbeat, cmd Command) tools.CommandResult {
 
 	version := tools.GetPayloadString(cmd.Payload, "version", "dev")
 	component := tools.GetPayloadString(cmd.Payload, "component", devUpdateComponentAgent)
+	// preserveAutoUpdate=true tells handleDevUpdateAgent NOT to disable
+	// auto_update after the swap. Used by server-orchestrated recovery
+	// flows (see apps/api/scripts/recover-stuck-agents.ts) where the
+	// goal is to get back onto the auto-update path, not to pin a dev
+	// binary. Default false preserves the original dev-push behaviour.
+	preserveAutoUpdate := tools.GetPayloadBool(cmd.Payload, "preserveAutoUpdate", false)
 
 	log.Info("dev_update received",
 		"version", version,
 		"component", component,
 		"downloadUrl", downloadURL,
+		"preserveAutoUpdate", preserveAutoUpdate,
 	)
 
 	switch component {
 	case devUpdateComponentAgent, "":
-		return handleDevUpdateAgent(h, start, downloadURL, checksum, version)
+		return handleDevUpdateAgent(h, start, downloadURL, checksum, version, preserveAutoUpdate)
 	case devUpdateComponentDesktopHelper:
 		return handleDevUpdateDesktopHelper(h, start, downloadURL, checksum, version)
 	default:
@@ -59,15 +66,19 @@ func handleDevUpdate(h *Heartbeat, cmd Command) tools.CommandResult {
 	}
 }
 
-func handleDevUpdateAgent(h *Heartbeat, start time.Time, downloadURL, checksum, version string) tools.CommandResult {
-	// Disable auto-update so the heartbeat doesn't overwrite the dev binary
-	// after the agent restarts. Persisted to disk via viper so it survives
-	// the restart triggered by the update.
-	h.config.AutoUpdate = false
-	if err := config.SetAndPersist("auto_update", false); err != nil {
-		log.Warn("failed to persist auto_update=false — dev build may revert after restart", "error", err.Error())
+func handleDevUpdateAgent(h *Heartbeat, start time.Time, downloadURL, checksum, version string, preserveAutoUpdate bool) tools.CommandResult {
+	if preserveAutoUpdate {
+		log.Info("dev_update preserving auto_update — likely a server-orchestrated recovery push")
+	} else {
+		// Disable auto-update so the heartbeat doesn't overwrite the dev binary
+		// after the agent restarts. Persisted to disk via viper so it survives
+		// the restart triggered by the update.
+		h.config.AutoUpdate = false
+		if err := config.SetAndPersist("auto_update", false); err != nil {
+			log.Warn("failed to persist auto_update=false — dev build may revert after restart", "error", err.Error())
+		}
+		log.Info("auto_update disabled and persisted for dev push")
 	}
-	log.Info("auto_update disabled and persisted for dev push")
 
 	// Resolve current binary path
 	binaryPath, err := os.Executable()

--- a/agent/internal/heartbeat/handlers_devupdate.go
+++ b/agent/internal/heartbeat/handlers_devupdate.go
@@ -48,12 +48,17 @@ func handleDevUpdate(h *Heartbeat, cmd Command) tools.CommandResult {
 	// goal is to get back onto the auto-update path, not to pin a dev
 	// binary. Default false preserves the original dev-push behaviour.
 	preserveAutoUpdate := tools.GetPayloadBool(cmd.Payload, "preserveAutoUpdate", false)
+	// reason is informational — surfaces in logs so a future operator
+	// grepping for "agent_update_trust_root_recovery" can find every
+	// affected device's update timeline without parsing payloads.
+	reason := tools.GetPayloadString(cmd.Payload, "reason", "")
 
 	log.Info("dev_update received",
 		"version", version,
 		"component", component,
 		"downloadUrl", downloadURL,
 		"preserveAutoUpdate", preserveAutoUpdate,
+		"reason", reason,
 	)
 
 	switch component {
@@ -66,19 +71,35 @@ func handleDevUpdate(h *Heartbeat, cmd Command) tools.CommandResult {
 	}
 }
 
-func handleDevUpdateAgent(h *Heartbeat, start time.Time, downloadURL, checksum, version string, preserveAutoUpdate bool) tools.CommandResult {
+// applyDevUpdateAutoUpdatePolicy decides whether a dev_update should leave
+// auto_update on or pin the agent to the pushed binary.
+//
+//   - preserveAutoUpdate=false (default, classic dev push): set
+//     h.config.AutoUpdate=false and persist to disk so the next heartbeat
+//     doesn't immediately re-upgrade off the dev binary.
+//   - preserveAutoUpdate=true (server-orchestrated recovery push): leave
+//     auto_update untouched so the recovered agent rejoins the normal
+//     update path on its next heartbeat.
+//
+// The persist-fail path logs a warning rather than returning an error —
+// the binary swap proceeds and the agent restarts; if persist failed the
+// only consequence is auto_update reverts to its on-disk value at restart.
+// Extracted so handlers_devupdate_test.go can exercise both branches
+// without standing up the full updater pipeline.
+func applyDevUpdateAutoUpdatePolicy(h *Heartbeat, preserveAutoUpdate bool) {
 	if preserveAutoUpdate {
 		log.Info("dev_update preserving auto_update — likely a server-orchestrated recovery push")
-	} else {
-		// Disable auto-update so the heartbeat doesn't overwrite the dev binary
-		// after the agent restarts. Persisted to disk via viper so it survives
-		// the restart triggered by the update.
-		h.config.AutoUpdate = false
-		if err := config.SetAndPersist("auto_update", false); err != nil {
-			log.Warn("failed to persist auto_update=false — dev build may revert after restart", "error", err.Error())
-		}
-		log.Info("auto_update disabled and persisted for dev push")
+		return
 	}
+	h.config.AutoUpdate = false
+	if err := config.SetAndPersist("auto_update", false); err != nil {
+		log.Warn("failed to persist auto_update=false — dev build may revert after restart", "error", err.Error())
+	}
+	log.Info("auto_update disabled and persisted for dev push")
+}
+
+func handleDevUpdateAgent(h *Heartbeat, start time.Time, downloadURL, checksum, version string, preserveAutoUpdate bool) tools.CommandResult {
+	applyDevUpdateAutoUpdatePolicy(h, preserveAutoUpdate)
 
 	// Resolve current binary path
 	binaryPath, err := os.Executable()

--- a/agent/internal/heartbeat/handlers_devupdate_test.go
+++ b/agent/internal/heartbeat/handlers_devupdate_test.go
@@ -1,0 +1,67 @@
+package heartbeat
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/breeze-rmm/agent/internal/config"
+)
+
+// loadEphemeralConfigForPersist sets up a real (but throwaway) agent.yaml
+// + viper state so config.SetAndPersist can write without exploding. The
+// dev_update auto_update policy unconditionally calls SetAndPersist on
+// the disabling branch and we want the test to exercise that real path
+// rather than mocking it away.
+func loadEphemeralConfigForPersist(t *testing.T) *config.Config {
+	t.Helper()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`agent_id: 00000000-0000-0000-0000-000000000001
+server_url: https://api.example.test
+auth_token: brz_test_inline
+log_level: info
+auto_update: true
+`), 0o600); err != nil {
+		t.Fatalf("write agent.yaml: %v", err)
+	}
+	t.Cleanup(viper.Reset)
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	return cfg
+}
+
+func TestApplyDevUpdateAutoUpdatePolicy_DefaultDisablesAutoUpdate(t *testing.T) {
+	cfg := loadEphemeralConfigForPersist(t)
+	cfg.AutoUpdate = true
+	h := &Heartbeat{config: cfg}
+
+	applyDevUpdateAutoUpdatePolicy(h, false)
+
+	if h.config.AutoUpdate {
+		t.Fatal("expected h.config.AutoUpdate=false after default dev push")
+	}
+	if got := viper.GetBool("auto_update"); got {
+		t.Fatal("expected viper auto_update=false (persisted)")
+	}
+}
+
+func TestApplyDevUpdateAutoUpdatePolicy_PreserveLeavesAutoUpdateUntouched(t *testing.T) {
+	cfg := loadEphemeralConfigForPersist(t)
+	cfg.AutoUpdate = true
+	h := &Heartbeat{config: cfg}
+
+	applyDevUpdateAutoUpdatePolicy(h, true)
+
+	if !h.config.AutoUpdate {
+		t.Fatal("expected h.config.AutoUpdate to stay true when preserveAutoUpdate=true (recovery push)")
+	}
+	if got := viper.GetBool("auto_update"); !got {
+		t.Fatal("expected viper auto_update to stay true (no persist call)")
+	}
+}

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -61,10 +61,17 @@ var ErrTextBusy = fmt.Errorf("binary is currently executing")
 
 const maxUpdateBinaryBytes int64 = 500 * 1024 * 1024
 
+// trustedUpdateManifestPublicKeys is the embedded trust root for release
+// manifest signatures. It MUST match the raw Ed25519 public key in
+// internal/release-keys/release-manifest.ed25519.pub (the SPKI suffix); the
+// release.yml workflow signs every manifest with the corresponding private
+// key. TestEmbeddedTrustRootMatchesRepoPubKey enforces that match at build
+// time so the agent never ships with a mismatched trust root again.
+//
+// Self-hosters can append additional base64 raw Ed25519 public keys via the
+// BREEZE_UPDATE_MANIFEST_PUBLIC_KEYS env var (read in trustedManifestKeys).
 var trustedUpdateManifestPublicKeys = []string{
-	// Breeze production update manifest trust root. Self-hosters can append
-	// additional base64 raw Ed25519 public keys with BREEZE_UPDATE_MANIFEST_PUBLIC_KEYS.
-	"7eYBdr5+J5Rnwlil8FccFX/uAO8AnYxHmzVlhJnr++c=",
+	"yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=",
 }
 
 type updateManifest struct {

--- a/agent/internal/updater/updater_test.go
+++ b/agent/internal/updater/updater_test.go
@@ -3,9 +3,11 @@ package updater
 import (
 	"crypto/ed25519"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -104,6 +106,57 @@ func signedReleaseArtifactDownloadInfo(t *testing.T, version, assetName, rawURL 
 		Manifest:          string(payload),
 		ManifestSignature: base64.StdEncoding.EncodeToString(signature),
 	}
+}
+
+// TestEmbeddedTrustRootMatchesRepoPubKey guards against shipping the agent
+// with an Ed25519 trust root that doesn't match the key the release pipeline
+// actually signs manifests with. PR #568 (May 2026) baked in a wrong key,
+// silently breaking auto-update for v0.65.5 and v0.65.6 — agents downloaded
+// the manifest, failed signature verification, and parked devices in
+// "updating" state forever. This test compares the embedded key against the
+// repo-tracked public key file (whose private counterpart is the GitHub
+// secret RELEASE_MANIFEST_ED25519_PRIVATE_KEY) so the same regression
+// can't slip in again.
+func TestEmbeddedTrustRootMatchesRepoPubKey(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot resolve test file location via runtime.Caller")
+	}
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..")
+	pubPath := filepath.Join(repoRoot, "internal", "release-keys", "release-manifest.ed25519.pub")
+
+	pemBytes, err := os.ReadFile(pubPath)
+	if err != nil {
+		t.Fatalf("repo manifest pub key not readable at %s: %v", pubPath, err)
+	}
+
+	block, _ := pem.Decode(pemBytes)
+	if block == nil || block.Type != "PUBLIC KEY" {
+		t.Fatalf("expected a PEM PUBLIC KEY block in %s", pubPath)
+	}
+
+	parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse SPKI from %s: %v", pubPath, err)
+	}
+	edKey, ok := parsed.(ed25519.PublicKey)
+	if !ok {
+		t.Fatalf("expected ed25519.PublicKey in %s, got %T", pubPath, parsed)
+	}
+	expected := base64.StdEncoding.EncodeToString(edKey)
+
+	for _, k := range trustedUpdateManifestPublicKeys {
+		if k == expected {
+			return
+		}
+	}
+	t.Fatalf(
+		"trustedUpdateManifestPublicKeys does not contain the repo manifest pub key.\n"+
+			"  expected (raw base64 of %s): %s\n"+
+			"  embedded: %v\n"+
+			"If you rotated the manifest signing key, update agent/internal/updater/updater.go to match.",
+		pubPath, expected, trustedUpdateManifestPublicKeys,
+	)
 }
 
 func TestNewCreatesUpdater(t *testing.T) {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,6 +14,8 @@
     "dev": "tsx watch src/index.ts",
     "lint": "eslint --ext .ts src",
     "oauth:gen-keys": "tsx scripts/oauth-gen-keys.ts",
+    "recover:stuck-agents": "tsx scripts/recover-stuck-agents.ts",
+    "recover:stuck-agents:prod": "node dist/scripts/recover-stuck-agents.cjs",
     "secrets:reencrypt": "tsx ../../scripts/re-encrypt-secrets.ts",
     "start": "node dist/index.cjs",
     "test": "vitest",

--- a/apps/api/scripts/recover-stuck-agents.lib.ts
+++ b/apps/api/scripts/recover-stuck-agents.lib.ts
@@ -1,0 +1,87 @@
+// Pure (no I/O) helpers for the recover-stuck-agents script. Split out so
+// the unit test can import them without triggering the script's top-level
+// main() — which opens the DB pool and exits the process.
+//
+// Behavioural orchestration (DB queries, command insert, exit codes) lives
+// in recover-stuck-agents.ts.
+import { normalizeAgentArchitecture } from '../src/routes/agents/helpers';
+
+// Versions known to ship with the broken trust root. Exact-match only —
+// agent versions are bare semver per project convention (no `v` prefix,
+// no pre-release suffixes in releases), so a string equality check is
+// sufficient. If you discover another, append it here; the regression
+// test in agent/internal/updater/updater_test.go prevents new releases
+// from joining this list.
+export const BROKEN_AGENT_VERSIONS = ['0.65.5', '0.65.6'] as const;
+
+export const RECOVERY_COMMAND_MARKER = 'agent_update_trust_root_recovery';
+
+export type DeviceRow = {
+  id: string;
+  hostname: string | null;
+  agentVersion: string | null;
+  osType: string | null;
+  architecture: string | null;
+  status: string;
+};
+
+export type AgentVersionRow = {
+  version: string;
+  platform: string;
+  architecture: string;
+  downloadUrl: string;
+  checksum: string;
+};
+
+export type Plan = {
+  device: DeviceRow;
+  binary: AgentVersionRow;
+};
+
+export type Skip = {
+  device: DeviceRow;
+  reason: string;
+};
+
+export function planRecovery(devs: DeviceRow[], binaries: AgentVersionRow[]): {
+  plans: Plan[];
+  skipped: Skip[];
+} {
+  const byPlatformArch = new Map<string, AgentVersionRow>();
+  for (const b of binaries) {
+    byPlatformArch.set(`${b.platform}/${b.architecture}`, b);
+  }
+
+  const plans: Plan[] = [];
+  const skipped: Skip[] = [];
+
+  for (const d of devs) {
+    if (!d.osType) {
+      skipped.push({ device: d, reason: 'os_type is null' });
+      continue;
+    }
+    const arch = normalizeAgentArchitecture(d.architecture);
+    if (!arch) {
+      skipped.push({ device: d, reason: `unrecognised architecture: ${d.architecture}` });
+      continue;
+    }
+    const binary = byPlatformArch.get(`${d.osType}/${arch}`);
+    if (!binary) {
+      skipped.push({
+        device: d,
+        reason: `no isLatest=true agent binary registered for ${d.osType}/${arch}`,
+      });
+      continue;
+    }
+    if (BROKEN_AGENT_VERSIONS.includes(binary.version as typeof BROKEN_AGENT_VERSIONS[number])) {
+      skipped.push({
+        device: d,
+        reason: `latest binary is still ${binary.version} (broken). Bump BREEZE_VERSION on this server first.`,
+      });
+      continue;
+    }
+    plans.push({ device: d, binary });
+  }
+
+  return { plans, skipped };
+}

--- a/apps/api/scripts/recover-stuck-agents.test.ts
+++ b/apps/api/scripts/recover-stuck-agents.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AgentVersionRow,
+  BROKEN_AGENT_VERSIONS,
+  DeviceRow,
+  planRecovery,
+} from './recover-stuck-agents.lib';
+
+function makeDevice(overrides: Partial<DeviceRow> = {}): DeviceRow {
+  return {
+    id: 'dev-1',
+    hostname: 'host-1',
+    agentVersion: '0.65.5',
+    osType: 'linux',
+    architecture: 'amd64',
+    status: 'online',
+    ...overrides,
+  };
+}
+
+function makeBinary(overrides: Partial<AgentVersionRow> = {}): AgentVersionRow {
+  return {
+    version: '0.65.7',
+    platform: 'linux',
+    architecture: 'amd64',
+    downloadUrl: 'https://example/agent-linux-amd64',
+    checksum: 'sha256:deadbeef',
+    ...overrides,
+  };
+}
+
+describe('planRecovery', () => {
+  it('queues a healthy device with a registered non-broken binary', () => {
+    const { plans, skipped } = planRecovery([makeDevice()], [makeBinary()]);
+    expect(skipped).toEqual([]);
+    expect(plans).toHaveLength(1);
+    expect(plans[0].device.id).toBe('dev-1');
+    expect(plans[0].binary.version).toBe('0.65.7');
+  });
+
+  it('refuses to dispatch when the latest registered binary is itself a broken version (the safety check that prevented an outage)', () => {
+    // This is the load-bearing safety net: if the operator forgot to bump
+    // BREEZE_VERSION, agent_versions still has 0.65.6 as isLatest, and
+    // re-pushing 0.65.6 would just recreate the failed-update loop.
+    const broken = makeBinary({ version: '0.65.6' });
+    const { plans, skipped } = planRecovery([makeDevice()], [broken]);
+    expect(plans).toEqual([]);
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].reason).toContain('still 0.65.6 (broken)');
+    expect(skipped[0].reason).toContain('Bump BREEZE_VERSION');
+  });
+
+  it('skips devices with null os_type with a distinct reason', () => {
+    const { plans, skipped } = planRecovery(
+      [makeDevice({ id: 'dev-no-os', osType: null })],
+      [makeBinary()],
+    );
+    expect(plans).toEqual([]);
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].reason).toBe('os_type is null');
+  });
+
+  it('skips devices with unrecognised architecture without crashing', () => {
+    const { plans, skipped } = planRecovery(
+      [makeDevice({ id: 'dev-mips', architecture: 'mips' })],
+      [makeBinary()],
+    );
+    expect(plans).toEqual([]);
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].reason).toContain('unrecognised architecture');
+    expect(skipped[0].reason).toContain('mips');
+  });
+
+  it('matches platform/arch exactly — windows device with only linux binary registered is skipped, not coerced', () => {
+    const winDev = makeDevice({ id: 'dev-win', osType: 'windows', architecture: 'amd64' });
+    const linuxDev = makeDevice({ id: 'dev-lin', osType: 'linux', architecture: 'amd64' });
+    const { plans, skipped } = planRecovery(
+      [winDev, linuxDev],
+      [makeBinary({ platform: 'linux', architecture: 'amd64' })],
+    );
+    expect(plans).toHaveLength(1);
+    expect(plans[0].device.id).toBe('dev-lin');
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].device.id).toBe('dev-win');
+    expect(skipped[0].reason).toContain('no isLatest=true agent binary registered for windows/amd64');
+  });
+
+  it('normalises common architecture aliases (x86_64 → amd64, aarch64 → arm64)', () => {
+    const x86Dev = makeDevice({ id: 'dev-x86', osType: 'linux', architecture: 'x86_64' });
+    const aarchDev = makeDevice({ id: 'dev-aarch', osType: 'linux', architecture: 'aarch64' });
+    const { plans } = planRecovery(
+      [x86Dev, aarchDev],
+      [
+        makeBinary({ platform: 'linux', architecture: 'amd64' }),
+        makeBinary({ platform: 'linux', architecture: 'arm64' }),
+      ],
+    );
+    expect(plans).toHaveLength(2);
+    expect(plans.find((p) => p.device.id === 'dev-x86')?.binary.architecture).toBe('amd64');
+    expect(plans.find((p) => p.device.id === 'dev-aarch')?.binary.architecture).toBe('arm64');
+  });
+
+  it('treats BROKEN_AGENT_VERSIONS as exact-match — a hypothetical 0.65.5-rc.1 binary would NOT be flagged broken', () => {
+    // Documents the exact-match assumption (project releases use bare semver).
+    // If we ever ship a pre-release through the same agent_versions table,
+    // either change BROKEN_AGENT_VERSIONS to a prefix check or pin those
+    // pre-releases to non-isLatest.
+    const rc = makeBinary({ version: '0.65.5-rc.1' });
+    const { plans, skipped } = planRecovery([makeDevice()], [rc]);
+    expect(plans).toHaveLength(1);
+    expect(plans[0].binary.version).toBe('0.65.5-rc.1');
+    expect(skipped).toEqual([]);
+  });
+
+  it('exports BROKEN_AGENT_VERSIONS as a non-empty const so callers and tests share one source of truth', () => {
+    expect(BROKEN_AGENT_VERSIONS.length).toBeGreaterThan(0);
+    expect(BROKEN_AGENT_VERSIONS).toContain('0.65.5');
+    expect(BROKEN_AGENT_VERSIONS).toContain('0.65.6');
+  });
+});

--- a/apps/api/scripts/recover-stuck-agents.ts
+++ b/apps/api/scripts/recover-stuck-agents.ts
@@ -19,39 +19,32 @@
  *
  * The script is idempotent — repeated runs won't enqueue duplicate
  * dev_update commands for devices that already have a pending or
- * sent recovery command in flight.
+ * sent recovery command in flight. If the run aborts mid-loop (DB
+ * blip, network), re-running picks up where it stopped because of
+ * that same idempotency check.
+ *
+ * Exit codes:
+ *   0  every recoverable device queued (or no work to do)
+ *   1  fatal error before/after the loop, or one or more per-device
+ *      enqueues threw (operator should retry; idempotent)
+ *   2  one or more devices were skipped during --apply (e.g. latest
+ *      registered binary is still on a broken version — operator
+ *      forgot to bump BREEZE_VERSION first). Distinct from 1 so
+ *      shell scripts can decide whether re-running will help.
  */
 import { and, eq, inArray, sql } from 'drizzle-orm';
 
 import { closeDb, db, withSystemDbAccessContext } from '../src/db';
 import { agentVersions } from '../src/db/schema/agentVersions';
 import { devices, deviceCommands } from '../src/db/schema/devices';
-import { normalizeAgentArchitecture } from '../src/routes/agents/helpers';
-
-// Versions known to ship with the broken trust root. If you discover
-// another, append it here — the regression test in
-// agent/internal/updater/updater_test.go prevents new releases from
-// joining this list.
-const BROKEN_AGENT_VERSIONS = ['0.65.5', '0.65.6'] as const;
-
-const RECOVERY_COMMAND_MARKER = 'agent_update_trust_root_recovery';
-
-type DeviceRow = {
-  id: string;
-  hostname: string | null;
-  agentVersion: string | null;
-  osType: string | null;
-  architecture: string | null;
-  status: string;
-};
-
-type AgentVersionRow = {
-  version: string;
-  platform: string;
-  architecture: string;
-  downloadUrl: string;
-  checksum: string;
-};
+import {
+  AgentVersionRow,
+  BROKEN_AGENT_VERSIONS,
+  DeviceRow,
+  Plan,
+  RECOVERY_COMMAND_MARKER,
+  planRecovery,
+} from './recover-stuck-agents.lib';
 
 async function selectAffectedDevices(): Promise<DeviceRow[]> {
   return db
@@ -104,59 +97,6 @@ async function hasRecoveryAlreadyQueued(deviceId: string): Promise<boolean> {
     )
     .limit(1);
   return rows.length > 0;
-}
-
-type Plan = {
-  device: DeviceRow;
-  binary: AgentVersionRow;
-};
-
-type Skip = {
-  device: DeviceRow;
-  reason: string;
-};
-
-function planRecovery(devs: DeviceRow[], binaries: AgentVersionRow[]): {
-  plans: Plan[];
-  skipped: Skip[];
-} {
-  const byPlatformArch = new Map<string, AgentVersionRow>();
-  for (const b of binaries) {
-    byPlatformArch.set(`${b.platform}/${b.architecture}`, b);
-  }
-
-  const plans: Plan[] = [];
-  const skipped: Skip[] = [];
-
-  for (const d of devs) {
-    if (!d.osType) {
-      skipped.push({ device: d, reason: 'os_type is null' });
-      continue;
-    }
-    const arch = normalizeAgentArchitecture(d.architecture);
-    if (!arch) {
-      skipped.push({ device: d, reason: `unrecognised architecture: ${d.architecture}` });
-      continue;
-    }
-    const binary = byPlatformArch.get(`${d.osType}/${arch}`);
-    if (!binary) {
-      skipped.push({
-        device: d,
-        reason: `no isLatest=true agent binary registered for ${d.osType}/${arch}`,
-      });
-      continue;
-    }
-    if (BROKEN_AGENT_VERSIONS.includes(binary.version as typeof BROKEN_AGENT_VERSIONS[number])) {
-      skipped.push({
-        device: d,
-        reason: `latest binary is still ${binary.version} (broken). Bump BREEZE_VERSION on this server first.`,
-      });
-      continue;
-    }
-    plans.push({ device: d, binary });
-  }
-
-  return { plans, skipped };
 }
 
 async function enqueueRecovery(plan: Plan): Promise<'queued' | 'already-pending'> {
@@ -217,6 +157,12 @@ async function run(apply: boolean): Promise<void> {
 
     if (plans.length === 0) {
       console.log('\n[recover-stuck-agents] No recoverable devices.');
+      // Skips with no plans during --apply still mean the operator's intent
+      // wasn't fully satisfied (e.g. forgot to bump BREEZE_VERSION). Surface
+      // it via exit code 2 so a wrapping shell script doesn't declare victory.
+      if (apply && skipped.length > 0) {
+        process.exitCode = 2;
+      }
       return;
     }
 
@@ -224,19 +170,30 @@ async function run(apply: boolean): Promise<void> {
 
     let queued = 0;
     let alreadyPending = 0;
+    let failed = 0;
     for (const p of plans) {
       const label = `  - ${p.device.hostname ?? p.device.id} (${p.device.agentVersion} ${p.device.osType}/${p.device.architecture}) → ${p.binary.version}`;
       if (!apply) {
         console.log(label);
         continue;
       }
-      const outcome = await enqueueRecovery(p);
-      if (outcome === 'queued') {
-        queued++;
-        console.log(`${label}  [queued]`);
-      } else {
-        alreadyPending++;
-        console.log(`${label}  [skipped: recovery already pending]`);
+      try {
+        const outcome = await enqueueRecovery(p);
+        if (outcome === 'queued') {
+          queued++;
+          console.log(`${label}  [queued]`);
+        } else {
+          alreadyPending++;
+          console.log(`${label}  [skipped: recovery already pending]`);
+        }
+      } catch (err) {
+        // Don't abort the whole loop on a single device's DB blip — re-running
+        // is safe (hasRecoveryAlreadyQueued de-dupes), but if the loop dies
+        // here the operator is left without a tally and may not know which
+        // devices made it through. Keep going and report at the end.
+        failed++;
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`${label}  [FAILED: ${msg}]`);
       }
     }
 
@@ -245,7 +202,23 @@ async function run(apply: boolean): Promise<void> {
       return;
     }
 
-    console.log(`\n[recover-stuck-agents] Done. Queued ${queued}, skipped ${alreadyPending} already-pending.`);
+    console.log(
+      `\n[recover-stuck-agents] Done. Queued ${queued}, ${alreadyPending} already-pending` +
+        (failed > 0 ? `, ${failed} failed` : '') +
+        (skipped.length > 0 ? `, ${skipped.length} pre-skipped` : '') +
+        '.',
+    );
+    if (failed > 0) {
+      console.error(
+        `[recover-stuck-agents] ${failed} device(s) failed to enqueue — re-run is safe and idempotent.`,
+      );
+      process.exitCode = 1;
+    } else if (skipped.length > 0) {
+      // No per-device failures, but at least one device couldn't be reached
+      // by the safety/eligibility checks. Operator probably needs to act
+      // (e.g. bump BREEZE_VERSION) before another run will help.
+      process.exitCode = 2;
+    }
     console.log(
       '[recover-stuck-agents] Agents will pick up the command on their next heartbeat (within ~60s).',
     );

--- a/apps/api/scripts/recover-stuck-agents.ts
+++ b/apps/api/scripts/recover-stuck-agents.ts
@@ -1,0 +1,275 @@
+#!/usr/bin/env tsx
+/**
+ * One-time recovery for agents whose embedded manifest trust root was
+ * baked wrong in v0.65.5/v0.65.6 (PR #568). Those agents cannot
+ * auto-update because manifest signature verification always fails, so
+ * they will never pick up the v0.65.7 fix on their own.
+ *
+ * For each affected device we queue a dev_update command pointing at
+ * the latest binary from agent_versions. dev_update uses
+ * UpdateFromURL, which skips manifest verification and only checks a
+ * checksum the API computed after verifying the GitHub release
+ * manifest — so the trust chain becomes API → agent (already
+ * established via bearer token + TLS) instead of GitHub → agent
+ * (which is what's broken).
+ *
+ * Usage (from the API container):
+ *   pnpm recover:stuck-agents               # dry run (default)
+ *   pnpm recover:stuck-agents -- --apply    # actually queue the commands
+ *
+ * The script is idempotent — repeated runs won't enqueue duplicate
+ * dev_update commands for devices that already have a pending or
+ * sent recovery command in flight.
+ */
+import { and, eq, inArray, sql } from 'drizzle-orm';
+
+import { closeDb, db, withSystemDbAccessContext } from '../src/db';
+import { agentVersions } from '../src/db/schema/agentVersions';
+import { devices, deviceCommands } from '../src/db/schema/devices';
+import { normalizeAgentArchitecture } from '../src/routes/agents/helpers';
+
+// Versions known to ship with the broken trust root. If you discover
+// another, append it here — the regression test in
+// agent/internal/updater/updater_test.go prevents new releases from
+// joining this list.
+const BROKEN_AGENT_VERSIONS = ['0.65.5', '0.65.6'] as const;
+
+const RECOVERY_COMMAND_MARKER = 'agent_update_trust_root_recovery';
+
+type DeviceRow = {
+  id: string;
+  hostname: string | null;
+  agentVersion: string | null;
+  osType: string | null;
+  architecture: string | null;
+  status: string;
+};
+
+type AgentVersionRow = {
+  version: string;
+  platform: string;
+  architecture: string;
+  downloadUrl: string;
+  checksum: string;
+};
+
+async function selectAffectedDevices(): Promise<DeviceRow[]> {
+  return db
+    .select({
+      id: devices.id,
+      hostname: devices.hostname,
+      agentVersion: devices.agentVersion,
+      osType: devices.osType,
+      architecture: devices.architecture,
+      status: devices.status,
+    })
+    .from(devices)
+    .where(
+      and(
+        inArray(devices.agentVersion, BROKEN_AGENT_VERSIONS as unknown as string[]),
+        sql`${devices.status} != 'decommissioned'`,
+      ),
+    );
+}
+
+async function selectLatestBinaries(): Promise<AgentVersionRow[]> {
+  return db
+    .select({
+      version: agentVersions.version,
+      platform: agentVersions.platform,
+      architecture: agentVersions.architecture,
+      downloadUrl: agentVersions.downloadUrl,
+      checksum: agentVersions.checksum,
+    })
+    .from(agentVersions)
+    .where(
+      and(
+        eq(agentVersions.component, 'agent'),
+        eq(agentVersions.isLatest, true),
+      ),
+    );
+}
+
+async function hasRecoveryAlreadyQueued(deviceId: string): Promise<boolean> {
+  const rows = await db
+    .select({ id: deviceCommands.id })
+    .from(deviceCommands)
+    .where(
+      and(
+        eq(deviceCommands.deviceId, deviceId),
+        eq(deviceCommands.type, 'dev_update'),
+        inArray(deviceCommands.status, ['pending', 'sent']),
+        sql`${deviceCommands.payload}->>'reason' = ${RECOVERY_COMMAND_MARKER}`,
+      ),
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+type Plan = {
+  device: DeviceRow;
+  binary: AgentVersionRow;
+};
+
+type Skip = {
+  device: DeviceRow;
+  reason: string;
+};
+
+function planRecovery(devs: DeviceRow[], binaries: AgentVersionRow[]): {
+  plans: Plan[];
+  skipped: Skip[];
+} {
+  const byPlatformArch = new Map<string, AgentVersionRow>();
+  for (const b of binaries) {
+    byPlatformArch.set(`${b.platform}/${b.architecture}`, b);
+  }
+
+  const plans: Plan[] = [];
+  const skipped: Skip[] = [];
+
+  for (const d of devs) {
+    if (!d.osType) {
+      skipped.push({ device: d, reason: 'os_type is null' });
+      continue;
+    }
+    const arch = normalizeAgentArchitecture(d.architecture);
+    if (!arch) {
+      skipped.push({ device: d, reason: `unrecognised architecture: ${d.architecture}` });
+      continue;
+    }
+    const binary = byPlatformArch.get(`${d.osType}/${arch}`);
+    if (!binary) {
+      skipped.push({
+        device: d,
+        reason: `no isLatest=true agent binary registered for ${d.osType}/${arch}`,
+      });
+      continue;
+    }
+    if (BROKEN_AGENT_VERSIONS.includes(binary.version as typeof BROKEN_AGENT_VERSIONS[number])) {
+      skipped.push({
+        device: d,
+        reason: `latest binary is still ${binary.version} (broken). Bump BREEZE_VERSION on this server first.`,
+      });
+      continue;
+    }
+    plans.push({ device: d, binary });
+  }
+
+  return { plans, skipped };
+}
+
+async function enqueueRecovery(plan: Plan): Promise<'queued' | 'already-pending'> {
+  if (await hasRecoveryAlreadyQueued(plan.device.id)) {
+    return 'already-pending';
+  }
+  await db.insert(deviceCommands).values({
+    deviceId: plan.device.id,
+    type: 'dev_update',
+    targetRole: 'agent',
+    status: 'pending',
+    payload: {
+      version: plan.binary.version,
+      component: 'agent',
+      downloadUrl: plan.binary.downloadUrl,
+      checksum: plan.binary.checksum,
+      // preserveAutoUpdate is honoured by v0.65.7+ agents; older
+      // agents don't read it and will set auto_update=false after
+      // recovery (operator must re-enable manually until they're on
+      // a build that respects the flag).
+      preserveAutoUpdate: true,
+      reason: RECOVERY_COMMAND_MARKER,
+    },
+  });
+  return 'queued';
+}
+
+async function run(apply: boolean): Promise<void> {
+  return withSystemDbAccessContext(async () => {
+    const [devs, binaries] = await Promise.all([
+      selectAffectedDevices(),
+      selectLatestBinaries(),
+    ]);
+
+    if (devs.length === 0) {
+      console.log('[recover-stuck-agents] No devices on broken versions — nothing to do.');
+      return;
+    }
+
+    console.log(
+      `[recover-stuck-agents] Found ${devs.length} device(s) on ${BROKEN_AGENT_VERSIONS.join(' / ')}.`,
+    );
+    console.log(
+      `[recover-stuck-agents] ${binaries.length} latest agent binar${binaries.length === 1 ? 'y' : 'ies'} registered:`,
+    );
+    for (const b of binaries) {
+      console.log(`  - ${b.version} ${b.platform}/${b.architecture}`);
+    }
+
+    const { plans, skipped } = planRecovery(devs, binaries);
+
+    if (skipped.length > 0) {
+      console.log(`\n[recover-stuck-agents] Skipping ${skipped.length} device(s):`);
+      for (const s of skipped) {
+        console.log(`  - ${s.device.hostname ?? s.device.id} (${s.device.agentVersion}): ${s.reason}`);
+      }
+    }
+
+    if (plans.length === 0) {
+      console.log('\n[recover-stuck-agents] No recoverable devices.');
+      return;
+    }
+
+    console.log(`\n[recover-stuck-agents] ${apply ? 'Queueing' : 'Would queue'} dev_update for ${plans.length} device(s):`);
+
+    let queued = 0;
+    let alreadyPending = 0;
+    for (const p of plans) {
+      const label = `  - ${p.device.hostname ?? p.device.id} (${p.device.agentVersion} ${p.device.osType}/${p.device.architecture}) → ${p.binary.version}`;
+      if (!apply) {
+        console.log(label);
+        continue;
+      }
+      const outcome = await enqueueRecovery(p);
+      if (outcome === 'queued') {
+        queued++;
+        console.log(`${label}  [queued]`);
+      } else {
+        alreadyPending++;
+        console.log(`${label}  [skipped: recovery already pending]`);
+      }
+    }
+
+    if (!apply) {
+      console.log('\n[recover-stuck-agents] Dry run only. Re-run with --apply to queue commands.');
+      return;
+    }
+
+    console.log(`\n[recover-stuck-agents] Done. Queued ${queued}, skipped ${alreadyPending} already-pending.`);
+    console.log(
+      '[recover-stuck-agents] Agents will pick up the command on their next heartbeat (within ~60s).',
+    );
+    console.log(
+      '[recover-stuck-agents] Note: dev_update disables auto_update on agents that ignore preserveAutoUpdate (i.e. all currently broken versions).',
+    );
+    console.log(
+      '[recover-stuck-agents] After recovery, re-enable auto_update on those devices via your config policy or admin UI.',
+    );
+  });
+}
+
+async function main(): Promise<void> {
+  const args = new Set(process.argv.slice(2));
+  const apply = args.has('--apply');
+  await run(apply);
+}
+
+main()
+  .catch((err) => {
+    console.error('[recover-stuck-agents] FAILED');
+    console.error(err instanceof Error ? err.stack ?? err.message : err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await closeDb();
+  });

--- a/apps/api/tsup.config.ts
+++ b/apps/api/tsup.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  // src/index.ts is the API server. scripts/* are operational one-shots that
+  // must be available inside the production image (the runtime container
+  // doesn't carry source or tsx). Use named entries so index.cjs stays at
+  // dist/index.cjs (preserving the existing Dockerfile CMD path) and scripts
+  // land at dist/scripts/<name>.cjs.
+  entry: {
+    index: 'src/index.ts',
+    'scripts/recover-stuck-agents': 'scripts/recover-stuck-agents.ts',
+  },
   format: ['cjs'],
   dts: true,
   noExternal: ['@breeze/shared', 'dotenv'],

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'scripts/**/*.test.ts'],
     exclude: ['src/__tests__/integration/**'],
     setupFiles: ['src/__tests__/setup.ts'],
     coverage: {

--- a/internal/release-keys/README.md
+++ b/internal/release-keys/README.md
@@ -1,0 +1,54 @@
+# Release manifest signing keys
+
+These are the keys the GitHub release workflow uses to sign every release's
+`release-artifact-manifest.json`. Two parallel signature schemes:
+
+| Algorithm | Public key file | Private key | Verifier |
+|---|---|---|---|
+| Ed25519 (raw) | `release-manifest.ed25519.pub` | GitHub secret `RELEASE_MANIFEST_ED25519_PRIVATE_KEY` | The Breeze agent (embedded) and the API |
+| Minisign | `release-manifest.minisign.pub` | GitHub secret `RELEASE_MANIFEST_MINISIGN_PRIVATE_KEY` | Minisign verifiers (humans, CI checks) |
+
+The local `.key` files are gitignored copies of the GitHub secrets used for
+local signing experiments — never commit them.
+
+## ⚠ When you rotate `release-manifest.ed25519.pub`
+
+The agent embeds the **raw 32-byte Ed25519 public key** (the SPKI suffix of
+this `.pub` file, base64-encoded) at
+`agent/internal/updater/updater.go` in `trustedUpdateManifestPublicKeys`.
+**If you rotate the signing key, the embedded list must include the new
+public key in the same release** — otherwise auto-update breaks for every
+agent that ships from then on (this is exactly how PR #568 broke
+v0.65.5/v0.65.6, fixed by `6744d54a`).
+
+To extract the raw Ed25519 bytes from this file:
+
+```bash
+openssl pkey -pubin -in release-manifest.ed25519.pub -outform DER \
+  | tail -c 32 | base64
+# → yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=
+```
+
+Paste that base64 string into `trustedUpdateManifestPublicKeys`. Keep the
+old key in the slice for at least one release so existing agents can still
+verify the previous manifests during their upgrade window.
+
+The regression test
+`agent/internal/updater/updater_test.go::TestEmbeddedTrustRootMatchesRepoPubKey`
+runs in CI and fails the build if the embedded list doesn't include the
+current public key — so a rotation that updates one but not the other won't
+ship.
+
+## Recovering agents stuck on a wrong-key build
+
+If an agent fleet is on a version with a broken embedded key (so they can't
+auto-update past it), use the server-orchestrated recovery script:
+
+```bash
+docker compose exec -w /app/apps/api api node dist/scripts/recover-stuck-agents.cjs --apply
+```
+
+It dispatches `dev_update` commands that bypass manifest signature
+verification (using the API's own bearer-token chain of trust instead). See
+`apps/api/scripts/recover-stuck-agents.ts` for the full flow and safety
+checks.

--- a/internal/release-keys/release-manifest.ed25519.pub
+++ b/internal/release-keys/release-manifest.ed25519.pub
@@ -1,0 +1,3 @@
+-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAyzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=
+-----END PUBLIC KEY-----

--- a/internal/release-keys/release-manifest.minisign.pub
+++ b/internal/release-keys/release-manifest.minisign.pub
@@ -1,0 +1,2 @@
+untrusted comment: minisign public key 1902D68300B6B91D
+RWQdubYAg9YCGei1PjYLk0O+bxUBPvznFoUIMG1SEZmusah422rk061q


### PR DESCRIPTION
## Summary

- Replace the wrong Ed25519 public key embedded in the agent's `trustedUpdateManifestPublicKeys` slice with the actual production signing key from `internal/release-keys/release-manifest.ed25519.pub`. PR #568 (`2c3a8e10`) hardcoded a key that doesn't match what the release pipeline signs manifests with — auto-update has been broken for every release since v0.65.5 (manifest signature verification fails 100% of the time).
- Add `TestEmbeddedTrustRootMatchesRepoPubKey` so this can't regress silently again.
- Track the public-key files (`*.pub`) and a `README.md` in `internal/release-keys/`. Private `.key` files stay gitignored.
- Add a server-orchestrated recovery script (`apps/api/scripts/recover-stuck-agents.ts`, bundled into `dist/scripts/`) that dispatches `dev_update` commands to agents on broken versions. `dev_update`'s `UpdateFromURL` skips manifest signature verification and only checks a checksum the API computed after verifying the GitHub release manifest, so the trust chain becomes API → agent (already established via bearer token + TLS) instead of GitHub → agent (which is what's broken).
- Add `preserveAutoUpdate` flag to the agent's `dev_update` payload so server-orchestrated recoveries don't permanently disable auto-update like dev-pushes intentionally do.

## Background

On 2026-05-08, all 7 connected US production agents got parked in `'updating'` state. Heartbeat told them to upgrade to v0.65.6, they sent `update_status: 'updating'` to the API, then failed manifest verification once a minute and never recovered. Diagnosis trail in `project_agent_manifest_trust_root_bug.md` (memory file).

Mitigation already applied in production: `agent_versions` flipped so v0.65.5 is `is_latest=true` again, stuck `devices.status='updating'` reset to `'online'`. **That mitigation is non-durable** — it's reverted on every API container restart by `binarySync`. This PR is the durable fix.

## How a self-hoster recovers their fleet (release notes draft for v0.65.7)

```bash
# 1. Upgrade the server
ssh root@<your-droplet> "cd /opt/breeze && \\
  sed -i 's/^BREEZE_VERSION=.*/BREEZE_VERSION=0.65.7/' .env && \\
  docker compose pull api web && docker compose up -d binaries-init api web"

# 2. Dry-run the recovery (lists what would be touched)
docker compose exec -w /app/apps/api api node dist/scripts/recover-stuck-agents.cjs

# 3. Apply
docker compose exec -w /app/apps/api api node dist/scripts/recover-stuck-agents.cjs --apply
```

Agents pick up the `dev_update` command on their next heartbeat (~60s), download v0.65.7 from the customer's API endpoint (which redirects to GitHub/S3 as configured), verify checksum, swap binary, restart on the corrected trust root. Future auto-updates work normally.

The script's safety check refuses to dispatch if `is_latest=true` is still on a known-broken version, so running it before bumping `BREEZE_VERSION` is a no-op (verified end-to-end against the live US droplet).

## Caveats

- Existing v0.65.5/v0.65.6 agents (the ones being recovered) ignore the `preserveAutoUpdate` flag because their code predates it. They'll set `auto_update=false` after recovery — operator has to re-enable via config policy. The flag is forward-compatible: future recovery dispatches against v0.65.7+ agents will preserve auto-update automatically.
- No matching private key exists for the wrong-key (`7eYBdr5...`) — there's no scenario where re-signing with the broken key would have been an option. The fix has to be agent-side.
- US droplet's `BREEZE_VERSION` is currently 0.65.6 in `/opt/breeze/.env`. Either bump it to 0.65.7 after merging or roll it back to 0.65.5 manually before the next API restart, otherwise `binarySync` will re-register v0.65.6 as latest and the loop resumes.

## Test plan

- [x] `TestEmbeddedTrustRootMatchesRepoPubKey` passes locally (verifies the embedded key matches `internal/release-keys/release-manifest.ed25519.pub`).
- [x] Full updater test suite green.
- [x] Verified both v0.65.5 and v0.65.6 release manifests verify under the corrected key (Python ed25519 verify against the real GitHub-hosted manifest signatures).
- [x] Recovery script bundled via tsup and smoke-tested inside the live `breeze-api` container on the US droplet — found 11 affected devices, correctly skipped them with the safety message because the registered latest binary is still 0.65.5.
- [ ] After merge + v0.65.7 release: full end-to-end recovery on the US droplet (bump `BREEZE_VERSION`, run `--apply`, watch agents flip to v0.65.7 within ~60s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)