### PR TITLE
fix: address self-hosted v0.65.5 install blockers (closes #609)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,11 +75,13 @@ NODE_ENV=production
 API_PORT=3001
 WEB_PORT=4321
 
-# Public URL for the API (used by web frontend in development)
-# Leave empty for Docker deployment — the web app uses relative URLs through Caddy.
-# Only set this for local dev when running outside Docker (e.g., pnpm dev).
+# Public URL for the API. Docker defaults this to https://${BREEZE_DOMAIN} for
+# generated agent installers and shareable links. Override it only when agents
+# must use a different externally reachable API URL.
 # For cookie auth with SameSite=Lax/Strict, this must use the same site as the browser page URL.
 PUBLIC_API_URL=
+# Legacy API URL fallback used by installer/share-link generation when PUBLIC_API_URL is unset.
+API_URL=
 CORS_ALLOWED_ORIGINS=https://localhost
 
 # --------------------------------------------
@@ -248,6 +250,9 @@ PUBLIC_APP_URL=https://breeze.yourdomain.com
 # --------------------------------------------
 # Set to true if running behind a reverse proxy
 TRUST_PROXY_HEADERS=false
+# Redirect HTTP requests to HTTPS at the API layer. Caddy normally handles this
+# in Docker production, but the API still receives the explicit value.
+FORCE_HTTPS=true
 # When proxy headers are trusted, restrict them to exact proxy source CIDRs.
 # Example for a local Caddy hop: TRUSTED_PROXY_CIDRS=172.30.0.11/32
 TRUSTED_PROXY_CIDRS=

--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -84,7 +84,7 @@
     <CustomAction
       Id="HardenProgramDataAcl"
       Property="BREEZE_ACL_CMD"
-      ExeCommand="/c icacls &quot;[ProgramDataBreezeDir].&quot; /inheritance:r /grant:r *S-1-5-18:(OI)(CI)F *S-1-5-32-544:(OI)(CI)F &amp;&amp; icacls &quot;[ProgramDataBreezeDataDir].&quot; /inheritance:r /grant:r *S-1-5-18:(OI)(CI)F *S-1-5-32-544:(OI)(CI)F &amp;&amp; icacls &quot;[ProgramDataBreezeLogsDir].&quot; /inheritance:r /grant:r *S-1-5-18:(OI)(CI)F *S-1-5-32-544:(OI)(CI)F"
+      ExeCommand="/c (if not exist &quot;[ProgramDataBreezeDir].&quot; mkdir &quot;[ProgramDataBreezeDir].&quot;) &amp;&amp; (if not exist &quot;[ProgramDataBreezeDataDir].&quot; mkdir &quot;[ProgramDataBreezeDataDir].&quot;) &amp;&amp; (if not exist &quot;[ProgramDataBreezeLogsDir].&quot; mkdir &quot;[ProgramDataBreezeLogsDir].&quot;) &amp;&amp; icacls &quot;[ProgramDataBreezeDir].&quot; /inheritance:r /grant:r *S-1-5-18:(OI)(CI)F *S-1-5-32-544:(OI)(CI)F &amp;&amp; icacls &quot;[ProgramDataBreezeDataDir].&quot; /inheritance:r /grant:r *S-1-5-18:(OI)(CI)F *S-1-5-32-544:(OI)(CI)F &amp;&amp; icacls &quot;[ProgramDataBreezeLogsDir].&quot; /inheritance:r /grant:r *S-1-5-18:(OI)(CI)F *S-1-5-32-544:(OI)(CI)F"
       Execute="immediate"
       Return="check" />
 

--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -84,7 +84,7 @@
     <CustomAction
       Id="HardenProgramDataAcl"
       Property="BREEZE_ACL_CMD"
-      ExeCommand="/c icacls &quot;[ProgramDataBreezeDir]&quot; /inheritance:r /grant:r *S-1-5-18:(OI)(CI)F *S-1-5-32-544:(OI)(CI)F &amp;&amp; icacls &quot;[ProgramDataBreezeDataDir]&quot; /inheritance:r /grant:r *S-1-5-18:(OI)(CI)F *S-1-5-32-544:(OI)(CI)F &amp;&amp; icacls &quot;[ProgramDataBreezeLogsDir]&quot; /inheritance:r /grant:r *S-1-5-18:(OI)(CI)F *S-1-5-32-544:(OI)(CI)F"
+      ExeCommand="/c icacls &quot;[ProgramDataBreezeDir].&quot; /inheritance:r /grant:r *S-1-5-18:(OI)(CI)F *S-1-5-32-544:(OI)(CI)F &amp;&amp; icacls &quot;[ProgramDataBreezeDataDir].&quot; /inheritance:r /grant:r *S-1-5-18:(OI)(CI)F *S-1-5-32-544:(OI)(CI)F &amp;&amp; icacls &quot;[ProgramDataBreezeLogsDir].&quot; /inheritance:r /grant:r *S-1-5-18:(OI)(CI)F *S-1-5-32-544:(OI)(CI)F"
       Execute="immediate"
       Return="check" />
 

--- a/apps/docs/src/content/docs/agents/commands.mdx
+++ b/apps/docs/src/content/docs/agents/commands.mdx
@@ -915,13 +915,13 @@ sudo log show --predicate 'process == "breeze-agent"' --last 1h
 ### Windows (Services)
 
 ```powershell
-Start-Service breeze-agent
-Stop-Service breeze-agent
-Restart-Service breeze-agent
-Get-Service breeze-agent
+Start-Service BreezeAgent
+Stop-Service BreezeAgent
+Restart-Service BreezeAgent
+Get-Service BreezeAgent
 
 # View logs
-Get-EventLog -LogName Application -Source breeze-agent -Newest 50
+Get-EventLog -LogName Application -Source BreezeAgent -Newest 50
 ```
 
 ---

--- a/apps/docs/src/content/docs/agents/installation.mdx
+++ b/apps/docs/src/content/docs/agents/installation.mdx
@@ -167,7 +167,7 @@ During enrollment, the agent:
 # Check service status
 sudo systemctl status breeze-agent  # Linux
 sudo launchctl list | grep breeze   # macOS
-Get-Service breeze-agent             # Windows
+Get-Service BreezeAgent              # Windows
 
 # Check agent version
 breeze-agent version

--- a/apps/docs/src/content/docs/deploy/turn-server.mdx
+++ b/apps/docs/src/content/docs/deploy/turn-server.mdx
@@ -89,11 +89,9 @@ use-auth-secret
 static-auth-secret=YOUR_TURN_SECRET_HERE
 realm=breeze.local
 relay-threads=2
-max-allocations-quota=100
 user-quota=4
 total-quota=1000
 max-bps=5000000
-no-loopback-peers
 no-multicast-peers
 denied-peer-ip=0.0.0.0-0.255.255.255
 denied-peer-ip=10.0.0.0-10.255.255.255

--- a/apps/docs/src/content/docs/features/watchdog.mdx
+++ b/apps/docs/src/content/docs/features/watchdog.mdx
@@ -21,7 +21,7 @@ The watchdog is installed automatically alongside the agent during normal instal
 
 ## How It Works
 
-The watchdog runs as a separate system service (`breeze-watchdog`) and monitors the agent through three independent health checks:
+The watchdog runs as a separate system service (`breeze-watchdog` on Linux, `BreezeWatchdog` on Windows) and monitors the agent through three independent health checks:
 
 1. **Process liveness** — Is the agent process still running? Detects crashes and unexpected exits.
 2. **IPC connectivity** — Can the watchdog reach the agent over its local IPC socket? Detects hangs and deadlocks.
@@ -184,7 +184,7 @@ These fields update as the watchdog reports its state through heartbeats and fai
 The agent process crashed and could not be automatically recovered after the configured number of attempts. Use the **Restart Agent** action from the device detail page, or SSH into the device and manually restart the agent service. Check the watchdog logs for recovery failure details: `GET /devices/:id/watchdog-logs?level=error`.
 
 **Watchdog status shows `offline`.**
-The watchdog service itself is not running. Check the system service manager on the device (`systemctl status breeze-watchdog` on Linux, `launchctl list | grep breeze-watchdog` on macOS, `Get-Service breeze-watchdog` on Windows).
+The watchdog service itself is not running. Check the system service manager on the device (`systemctl status breeze-watchdog` on Linux, `launchctl list | grep breeze-watchdog` on macOS, `Get-Service BreezeWatchdog` on Windows).
 
 **Agent keeps restarting in a loop.**
 The watchdog recovers the agent, but it immediately crashes again. This is usually caused by a bad configuration file or a corrupted binary. Check the agent's own diagnostic logs for startup errors. The watchdog will eventually exhaust its recovery attempts and enter failover, preventing an infinite restart loop.

--- a/apps/web/src/components/devices/AddDeviceModal.tsx
+++ b/apps/web/src/components/devices/AddDeviceModal.tsx
@@ -4,6 +4,7 @@ import { Dialog } from '../shared/Dialog';
 import { showToast } from '../shared/Toast';
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
+import { fallbackInstallerFilename, filenameFromContentDisposition } from '@/lib/downloadFilename';
 import { navigateTo } from '@/lib/navigation';
 
 function detectUserOS(): 'windows' | 'macos' | 'linux' {
@@ -232,7 +233,8 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
 
       const blob = await dlRes.blob();
       const filename =
-        selectedPlatform === 'windows' ? 'breeze-agent.msi' : 'breeze-agent-macos.zip';
+        filenameFromContentDisposition(dlRes.headers.get('Content-Disposition'))
+        ?? fallbackInstallerFilename(selectedPlatform);
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;

--- a/apps/web/src/components/settings/EnrollmentKeyManager.tsx
+++ b/apps/web/src/components/settings/EnrollmentKeyManager.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
+import { fallbackInstallerFilename, filenameFromContentDisposition } from '@/lib/downloadFilename';
 import { navigateTo } from '@/lib/navigation';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { showToast } from '../shared/Toast';
@@ -224,7 +225,9 @@ export default function EnrollmentKeyManager() {
       }
 
       const blob = await response.blob();
-      const filename = platform === 'windows' ? 'breeze-agent.msi' : 'breeze-agent-macos.zip';
+      const filename =
+        filenameFromContentDisposition(response.headers.get('Content-Disposition'))
+        ?? fallbackInstallerFilename(platform);
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;

--- a/apps/web/src/components/setup/EnrollDeviceStep.tsx
+++ b/apps/web/src/components/setup/EnrollDeviceStep.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { Check, Copy, Loader2, Download, Link, ArrowLeft, Info } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { fallbackInstallerFilename, filenameFromContentDisposition } from '@/lib/downloadFilename';
 import { showToast } from '../shared/Toast';
 
 type Platform = 'windows' | 'macos' | 'linux';
@@ -141,7 +142,9 @@ export default function EnrollDeviceStep({ orgId, siteId, onBack, onFinish: _onF
       }
 
       const blob = await dlRes.blob();
-      const filename = selectedPlatform === 'windows' ? 'breeze-agent.msi' : 'breeze-agent-macos.zip';
+      const filename =
+        filenameFromContentDisposition(dlRes.headers.get('Content-Disposition'))
+        ?? fallbackInstallerFilename(selectedPlatform);
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;

--- a/apps/web/src/lib/downloadFilename.test.ts
+++ b/apps/web/src/lib/downloadFilename.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { fallbackInstallerFilename, filenameFromContentDisposition } from './downloadFilename';
+
+describe('filenameFromContentDisposition', () => {
+  it('reads quoted filenames', () => {
+    expect(filenameFromContentDisposition('attachment; filename="breeze-agent-windows.zip"')).toBe(
+      'breeze-agent-windows.zip',
+    );
+  });
+
+  it('prefers RFC 5987 filename star values', () => {
+    expect(
+      filenameFromContentDisposition(
+        'attachment; filename="fallback.zip"; filename*=UTF-8\'\'breeze-agent%20windows.zip',
+      ),
+    ).toBe('breeze-agent windows.zip');
+  });
+
+  it('strips path separators from hostile filenames', () => {
+    expect(filenameFromContentDisposition('attachment; filename="C:\\temp\\breeze-agent.msi"')).toBe(
+      'breeze-agent.msi',
+    );
+  });
+});
+
+describe('fallbackInstallerFilename', () => {
+  it('uses zip fallback for unsigned Windows bundles', () => {
+    expect(fallbackInstallerFilename('windows')).toBe('breeze-agent-windows.zip');
+  });
+
+  it('uses macOS zip fallback', () => {
+    expect(fallbackInstallerFilename('macos')).toBe('breeze-agent-macos.zip');
+  });
+});

--- a/apps/web/src/lib/downloadFilename.test.ts
+++ b/apps/web/src/lib/downloadFilename.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fallbackInstallerFilename, filenameFromContentDisposition } from './downloadFilename';
 
 describe('filenameFromContentDisposition', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('reads quoted filenames', () => {
     expect(filenameFromContentDisposition('attachment; filename="breeze-agent-windows.zip"')).toBe(
       'breeze-agent-windows.zip',
@@ -20,6 +24,40 @@ describe('filenameFromContentDisposition', () => {
     expect(filenameFromContentDisposition('attachment; filename="C:\\temp\\breeze-agent.msi"')).toBe(
       'breeze-agent.msi',
     );
+  });
+
+  it('handles RFC 5987 values with a language tag', () => {
+    expect(
+      filenameFromContentDisposition("attachment; filename*=UTF-8'en'breeze-agent.zip"),
+    ).toBe('breeze-agent.zip');
+  });
+
+  it('strips path separators from filename* values', () => {
+    expect(
+      filenameFromContentDisposition("attachment; filename*=UTF-8''..%2Fevil.exe"),
+    ).toBe('evil.exe');
+  });
+
+  it('falls back to the un-decoded value when percent-decoding fails', () => {
+    expect(
+      filenameFromContentDisposition("attachment; filename*=UTF-8''breeze%ZZ.zip"),
+    ).toBe('breeze%ZZ.zip');
+  });
+
+  it('returns null for a null header without warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(filenameFromContentDisposition(null)).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('returns null and warns when the header has no filename param', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(filenameFromContentDisposition('attachment')).toBeNull();
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it('returns null when sanitization yields an empty filename', () => {
+    expect(filenameFromContentDisposition('attachment; filename="/"')).toBeNull();
   });
 });
 

--- a/apps/web/src/lib/downloadFilename.ts
+++ b/apps/web/src/lib/downloadFilename.ts
@@ -1,4 +1,5 @@
-const FILENAME_STAR_PREFIX = /^UTF-8''/i;
+// RFC 5987: filename*=<charset>'<lang>'<percent-encoded-value>. Lang is optional.
+const FILENAME_STAR_PREFIX = /^[\w-]+'[^']*'/i;
 
 export function filenameFromContentDisposition(header: string | null): string | null {
   if (!header) return null;
@@ -10,15 +11,19 @@ export function filenameFromContentDisposition(header: string | null): string | 
     const value = unquote(rawValue).replace(FILENAME_STAR_PREFIX, '');
     try {
       return sanitizeFilename(decodeURIComponent(value));
-    } catch {
+    } catch (err) {
+      if (!(err instanceof URIError)) throw err;
       return sanitizeFilename(value);
     }
   }
 
   const filename = parts.find((part) => part.toLowerCase().startsWith('filename='));
-  if (!filename) return null;
+  if (filename) {
+    return sanitizeFilename(unquote(filename.slice(filename.indexOf('=') + 1).trim()));
+  }
 
-  return sanitizeFilename(unquote(filename.slice(filename.indexOf('=') + 1).trim()));
+  console.warn('Content-Disposition header has no filename param; using fallback', header);
+  return null;
 }
 
 export function fallbackInstallerFilename(platform: 'windows' | 'macos'): string {

--- a/apps/web/src/lib/downloadFilename.ts
+++ b/apps/web/src/lib/downloadFilename.ts
@@ -1,0 +1,38 @@
+const FILENAME_STAR_PREFIX = /^UTF-8''/i;
+
+export function filenameFromContentDisposition(header: string | null): string | null {
+  if (!header) return null;
+
+  const parts = header.split(';').map((part) => part.trim());
+  const filenameStar = parts.find((part) => part.toLowerCase().startsWith('filename*='));
+  if (filenameStar) {
+    const rawValue = filenameStar.slice(filenameStar.indexOf('=') + 1).trim();
+    const value = unquote(rawValue).replace(FILENAME_STAR_PREFIX, '');
+    try {
+      return sanitizeFilename(decodeURIComponent(value));
+    } catch {
+      return sanitizeFilename(value);
+    }
+  }
+
+  const filename = parts.find((part) => part.toLowerCase().startsWith('filename='));
+  if (!filename) return null;
+
+  return sanitizeFilename(unquote(filename.slice(filename.indexOf('=') + 1).trim()));
+}
+
+export function fallbackInstallerFilename(platform: 'windows' | 'macos'): string {
+  return platform === 'windows' ? 'breeze-agent-windows.zip' : 'breeze-agent-macos.zip';
+}
+
+function unquote(value: string): string {
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    return value.slice(1, -1).replace(/\\"/g, '"');
+  }
+  return value;
+}
+
+function sanitizeFilename(value: string): string | null {
+  const filename = value.trim().split(/[\\/]/).pop();
+  return filename || null;
+}

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -87,6 +87,8 @@ services:
       PUBLIC_APP_URL: https://${BREEZE_DOMAIN}
       DASHBOARD_URL: https://${BREEZE_DOMAIN}
       PUBLIC_API_URL: https://${BREEZE_DOMAIN}
+      API_URL: ${API_URL:-}
+      FORCE_HTTPS: ${FORCE_HTTPS:-true}
       APP_ENCRYPTION_KEY: ${APP_ENCRYPTION_KEY:?Set APP_ENCRYPTION_KEY in .env}
       MFA_ENCRYPTION_KEY: ${MFA_ENCRYPTION_KEY:?Set MFA_ENCRYPTION_KEY in .env}
       ENROLLMENT_KEY_PEPPER: ${ENROLLMENT_KEY_PEPPER:?Set ENROLLMENT_KEY_PEPPER in .env}
@@ -244,11 +246,9 @@ services:
       --fingerprint
       --use-auth-secret
       --relay-threads=4
-      --max-allocations-quota=12
       --user-quota=4
       --total-quota=1000
       --max-bps=${TURN_MAX_BPS:-5000000}
-      --no-loopback-peers
       --no-multicast-peers
       --denied-peer-ip=0.0.0.0-0.255.255.255
       --denied-peer-ip=10.0.0.0-10.255.255.255

--- a/docker-compose.override.yml.dev
+++ b/docker-compose.override.yml.dev
@@ -116,9 +116,8 @@ services:
       --listening-port=3478
       --tls-listening-port=5349
       --fingerprint
-      --lt-cred-mech
+      --use-auth-secret
       --relay-threads=4
-      --max-allocations-quota=12
       --log-file=stdout
       --verbose
       --min-port=49152

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,11 @@ services:
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-https://${BREEZE_DOMAIN}}
       PUBLIC_APP_URL: ${PUBLIC_APP_URL:-https://${BREEZE_DOMAIN}}
       DASHBOARD_URL: ${DASHBOARD_URL:-https://${BREEZE_DOMAIN}}
+      PUBLIC_API_URL: ${PUBLIC_API_URL:-https://${BREEZE_DOMAIN}}
+      API_URL: ${API_URL:-}
+      FORCE_HTTPS: ${FORCE_HTTPS:-true}
+      TRUST_PROXY_HEADERS: ${TRUST_PROXY_HEADERS:-false}
+      TRUSTED_PROXY_CIDRS: ${TRUSTED_PROXY_CIDRS:-}
       APP_ENCRYPTION_KEY: ${APP_ENCRYPTION_KEY:?Set APP_ENCRYPTION_KEY in .env}
       MFA_ENCRYPTION_KEY: ${MFA_ENCRYPTION_KEY:?Set MFA_ENCRYPTION_KEY in .env}
       ENROLLMENT_KEY_PEPPER: ${ENROLLMENT_KEY_PEPPER:?Set ENROLLMENT_KEY_PEPPER in .env}
@@ -246,11 +251,9 @@ services:
       --fingerprint
       --use-auth-secret
       --relay-threads=4
-      --max-allocations-quota=12
       --user-quota=4
       --total-quota=1000
       --max-bps=${TURN_MAX_BPS:-5000000}
-      --no-loopback-peers
       --no-multicast-peers
       --denied-peer-ip=0.0.0.0-0.255.255.255
       --denied-peer-ip=10.0.0.0-10.255.255.255

--- a/docker/turnserver.conf
+++ b/docker/turnserver.conf
@@ -21,14 +21,12 @@ realm=breeze.local
 # Total relay threads
 relay-threads=4
 
-# Max allocations per user
-max-allocations-quota=12
+# Allocation quotas
 user-quota=4
 total-quota=1000
 
 # Bandwidth and peer abuse guardrails
 max-bps=5000000
-no-loopback-peers
 no-multicast-peers
 denied-peer-ip=0.0.0.0-0.255.255.255
 denied-peer-ip=10.0.0.0-10.255.255.255

--- a/scripts/security/check-relay-edge-hardening.sh
+++ b/scripts/security/check-relay-edge-hardening.sh
@@ -30,7 +30,8 @@ for file in docker/turnserver.conf docker-compose.yml deploy/docker-compose.prod
   require_grep 'total-quota|--total-quota' "$file" "$file must include total TURN quotas"
   require_grep 'denied-peer-ip=.*10\.0\.0\.0|--denied-peer-ip=10\.0\.0\.0' "$file" "$file must deny private TURN peers"
   require_grep 'denied-peer-ip=.*169\.254\.0\.0|--denied-peer-ip=169\.254\.0\.0' "$file" "$file must deny link-local/metadata TURN peers"
-  require_grep 'no-loopback-peers|--no-loopback-peers' "$file" "$file must deny loopback TURN peers"
+  require_grep 'denied-peer-ip=.*127\.0\.0\.0|--denied-peer-ip=127\.0\.0\.0' "$file" "$file must deny IPv4 loopback TURN peers"
+  require_grep 'denied-peer-ip=.*::1|--denied-peer-ip=::1' "$file" "$file must deny IPv6 loopback TURN peers"
   require_grep 'no-multicast-peers|--no-multicast-peers' "$file" "$file must deny multicast TURN peers"
 done
 


### PR DESCRIPTION
## Summary

Fixes the four issues reported in #609 from a self-hoster's v0.65.5 fresh install.

1. **MSI install fails: `HardenProgramDataAcl` rolls back with 1603.** Two layered bugs:
   - The `ExeCommand` passed `[ProgramDataBreezeDir]"` to `cmd.exe`. The trailing `\\\"` is interpreted as a literal `\"` by `CommandLineToArgvW`, breaking arg parsing → `icacls` returns 123 (`ERROR_INVALID_NAME`).
   - The custom action runs `Execute=\"immediate\"`, which executes during sequence walking — *before* the deferred `CreateFolders` action actually creates the directories on disk. After fixing the quoting, `icacls` then fails with error 2 (file not found) on a clean install because the dirs don't exist yet.
   - **Fix:** append `.` to each path so the closing quote isn't preceded by `\\` (path becomes `\"C:\\ProgramData\\Breeze\\.\"` — valid, parses cleanly), AND prepend `if not exist ... mkdir` for each dir in the same `cmd.exe` invocation so the dirs are guaranteed to exist before icacls touches them.

2. **`docker-compose.yml` doesn't pass production-required env to the api container.** Added `PUBLIC_API_URL`, `API_URL`, `FORCE_HTTPS`, `TRUST_PROXY_HEADERS`, `TRUSTED_PROXY_CIDRS` to the api service's environment block in both root `docker-compose.yml` and `deploy/docker-compose.prod.yml`. The validator no longer rejects boot, and the enrollment-link generator has the URL it needs.

3. **`coturn` flags don't exist in any released coturn image.** Removed `--max-allocations-quota=12` and `--no-loopback-peers` from all four configs (root compose, prod compose, dev override, `docker/turnserver.conf`). Loopback denial is preserved by the existing explicit `--denied-peer-ip=127.0.0.0-127.255.255.255` and `--denied-peer-ip=::1` ranges. Updated `scripts/security/check-relay-edge-hardening.sh` to require those explicit ranges instead of the broken flag.

4. **Docs reference `breeze-agent`/`breeze-watchdog` service names; actual Windows registration is `BreezeAgent`/`BreezeWatchdog`.** Updated `agents/installation.mdx`, `agents/commands.mdx`, `features/watchdog.mdx` to match the real names from `agent/cmd/breeze-agent/service_cmd_windows.go:17` and `agent/cmd/breeze-watchdog/service_cmd_windows.go:16`.

## Bonus — installer download UX

Issue #609 also flagged in passing that the dashboard saves `breeze-agent.zip` as `breeze-agent.msi`. Added `apps/web/src/lib/downloadFilename.ts` (with tests) that reads `Content-Disposition` (RFC 5987 support, path-separator stripping) and falls back to `breeze-agent-windows.zip` for Windows installs. Wired into `AddDeviceModal`, `EnrollmentKeyManager`, and `EnrollDeviceStep`.

## Verified end-to-end on a Windows VM

Built the MSI from this branch on the team's Windows test VM (`100.101.150.55`, Server 2022, WiX 4.0.5), then `msiexec /i ... /qn /l*vx C:\\install.log`:

- `HardenProgramDataAcl. Return value 1.` (success)
- `MainEngineThread is returning 0` (overall MSI success, no rollback)
- `BreezeAgent` service installed
- `C:\\ProgramData\\Breeze\\{,data,logs}` created with the intended ACLs (`SYSTEM:(OI)(CI)(F)` + `BUILTIN\\Administrators:(OI)(CI)(F)` only, no inheritance, no Authenticated Users)
- Clean uninstall via `msiexec /x` returned exit 0

## Test plan

- [x] Reproduced original bug (error 123 → 1603 rollback) on fresh Windows VM with the unfixed WXS.
- [x] First-pass fix (just `\\.` quoting) advanced bug from error 123 to error 2 (file not found) — confirmed the action was running before `CreateFolders` deferred script.
- [x] mkdir-then-icacls fix produces clean install + correct ACLs end-to-end.
- [x] `pnpm test` for the new `downloadFilename` helper passes.
- [x] No remaining references to `--max-allocations-quota` or `--no-loopback-peers` in the repo.
- [x] Service-name doc references corrected against `git grep -E 'service_cmd_windows.*ServiceName'`.

Closes #609.

🤖 Generated with [Claude Code](https://claude.com/claude-code)