### PR TITLE
chore: bump Go to 1.25.10 + allowlist esbuild build script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ concurrency:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '9.15.7'
-  GO_VERSION: '1.25.9'
+  GO_VERSION: '1.25.10'
 
 jobs:
   lint:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.9'
+          go-version: '1.25.10'
           cache-dependency-path: agent/go.sum
 
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '9.15.7'
-  GO_VERSION: '1.25.9'
+  GO_VERSION: '1.25.10'
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '9.15.7'
-  GO_VERSION: '1.25.9'
+  GO_VERSION: '1.25.10'
 
 permissions:
   actions: read

--- a/agent/go.mod
+++ b/agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/breeze-rmm/agent
 
-go 1.25.9
+go 1.25.10
 
 require (
 	cloud.google.com/go/storage v1.62.1

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -25,5 +25,10 @@
     "playwright": "^1.58.2",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
 packages:
   - 'apps/*'
   - 'packages/*'
+
+# pnpm 11+ refuses to run install scripts unless they're in this allowlist.
+# Add packages here only after confirming what their install script does:
+#   - esbuild downloads its native binary on install (required for tsup, vitest, etc.)
+onlyBuiltDependencies:
+  - esbuild


### PR DESCRIPTION
## Summary

Two CI hygiene fixes that have been failing on every PR (caught while reviewing #612 and #613).

1. **Go 1.25.10** — `govulncheck` reports 3 reachable net/http vulns in 1.25.9, most prominently [GO-2026-4918](https://pkg.go.dev/vuln/GO-2026-4918) (HTTP/2 transport infinite loop on a bad `SETTINGS_MAX_FRAME_SIZE` from a peer). Threat model is bounded for Breeze — agents only speak HTTP/2 to their own API server, the API sits behind Caddy — but the bump is a one-line change that resolves all three. Bumped in: `agent/go.mod`, `.github/workflows/{ci,codeql,release,security}.yml`.

2. **pnpm `onlyBuiltDependencies: [esbuild]`** — pnpm 11+ refuses to run install scripts unless the package is allowlisted. `esbuild` downloads its native binary on install; without approval, the `doc-verify` job dies with `ERR_PNPM_IGNORED_BUILDS` on every PR. Added at the workspace root (for normal `pnpm install`) and in `e2e-tests/package.json` (for the doc-verify job that runs with `--ignore-workspace`).

## Test plan

- [x] `go build ./...` clean on the bumped toolchain locally.
- [x] `pnpm install --ignore-workspace` in `e2e-tests/` no longer emits `ERR_PNPM_IGNORED_BUILDS`.
- [ ] CI: verify `Go Vulnerability Check` and `doc-verify` go green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)