### PR TITLE
fix(recovery): construct server-relative download URL for dev_update

### DIFF
--- a/apps/api/scripts/recover-stuck-agents.ts
+++ b/apps/api/scripts/recover-stuck-agents.ts
@@ -99,10 +99,37 @@ async function hasRecoveryAlreadyQueued(deviceId: string): Promise<boolean> {
   return rows.length > 0;
 }
 
-async function enqueueRecovery(plan: Plan): Promise<'queued' | 'already-pending'> {
+function getServerOrigin(): string {
+  const candidate =
+    process.env.PUBLIC_API_URL?.trim() ||
+    process.env.PUBLIC_APP_URL?.trim() ||
+    process.env.BREEZE_SERVER?.trim();
+  if (!candidate) {
+    throw new Error(
+      'Cannot determine server origin: set PUBLIC_API_URL (or PUBLIC_APP_URL / BREEZE_SERVER) so dev_update download URLs match the agent\'s expected server host.',
+    );
+  }
+  return candidate.replace(/\/+$/, '');
+}
+
+// The agent's downloader (updater.go:downloadFromURL) rejects download URLs
+// whose host doesn't match its configured server origin — so we cannot pass
+// the github.com URL stored in agent_versions.downloadUrl when the server is
+// running BINARY_SOURCE=github. Build a server-relative URL instead; the
+// API's /api/v1/agents/download/:os/:arch route will 302 to GitHub from
+// there (or serve from disk/S3 in non-github mode), and Go's HTTP client
+// follows the redirect transparently because the host check has already
+// passed on the originating URL.
+function buildAgentDownloadUrl(serverOrigin: string, platform: string, architecture: string): string {
+  const osParam = platform === 'macos' ? 'darwin' : platform;
+  return `${serverOrigin}/api/v1/agents/download/${osParam}/${architecture}`;
+}
+
+async function enqueueRecovery(plan: Plan, serverOrigin: string): Promise<'queued' | 'already-pending'> {
   if (await hasRecoveryAlreadyQueued(plan.device.id)) {
     return 'already-pending';
   }
+  const downloadUrl = buildAgentDownloadUrl(serverOrigin, plan.binary.platform, plan.binary.architecture);
   await db.insert(deviceCommands).values({
     deviceId: plan.device.id,
     type: 'dev_update',
@@ -111,7 +138,7 @@ async function enqueueRecovery(plan: Plan): Promise<'queued' | 'already-pending'
     payload: {
       version: plan.binary.version,
       component: 'agent',
-      downloadUrl: plan.binary.downloadUrl,
+      downloadUrl,
       checksum: plan.binary.checksum,
       // preserveAutoUpdate is honoured by v0.65.7+ agents; older
       // agents don't read it and will set auto_update=false after
@@ -126,6 +153,7 @@ async function enqueueRecovery(plan: Plan): Promise<'queued' | 'already-pending'
 
 async function run(apply: boolean): Promise<void> {
   return withSystemDbAccessContext(async () => {
+    const serverOrigin = getServerOrigin();
     const [devs, binaries] = await Promise.all([
       selectAffectedDevices(),
       selectLatestBinaries(),
@@ -135,6 +163,8 @@ async function run(apply: boolean): Promise<void> {
       console.log('[recover-stuck-agents] No devices on broken versions — nothing to do.');
       return;
     }
+
+    console.log(`[recover-stuck-agents] Server origin (for dev_update download URLs): ${serverOrigin}`);
 
     console.log(
       `[recover-stuck-agents] Found ${devs.length} device(s) on ${BROKEN_AGENT_VERSIONS.join(' / ')}.`,
@@ -178,7 +208,7 @@ async function run(apply: boolean): Promise<void> {
         continue;
       }
       try {
-        const outcome = await enqueueRecovery(p);
+        const outcome = await enqueueRecovery(p, serverOrigin);
         if (outcome === 'queued') {
           queued++;
           console.log(`${label}  [queued]`);


### PR DESCRIPTION
## Summary

The recovery script shipped in PR #612 (v0.65.7) doesn't actually work on servers running `BINARY_SOURCE=github` — which is the configuration this script was *specifically designed to recover from*. Caught during the live v0.65.7 production deploy, hotfixed in place by rebuilding the bundled cjs and `docker cp`-ing it into both running api containers. This PR is the source-tree fix.

## What was broken

The script put `agent_versions.download_url` straight into the `dev_update` payload. On `BINARY_SOURCE=github` servers, that column points to `https://github.com/LanternOps/breeze/releases/download/...`. The agent's downloader (`agent/internal/updater/updater.go:downloadFromURL`) rejects that URL up front:

```go
if parsed.Host != serverParsed.Host {
    return "", fmt.Errorf("download URL host %q does not match server %q",
        parsed.Host, serverParsed.Host)
}
```

So every dispatched `dev_update` failed with `download URL host \"github.com\" does not match server \"us.2breeze.app\"` (and the equivalent on EU). The agent's command-receipt ACK is synchronous *before* the goroutine hits the host check, so commands looked `completed` in `device_commands` but devices stayed on the broken version.

## The fix

Construct `${PUBLIC_API_URL}/api/v1/agents/download/<os>/<arch>` and use that in the payload. Falls back to `PUBLIC_APP_URL` then `BREEZE_SERVER`. The API's download route 302s to GitHub from there in github mode, or serves from disk/S3 in local mode. The agent's host check passes on the originating server URL, and Go's HTTP client follows the redirect transparently — `client.Do` follows redirects to any host without re-running the host check, so the github redirect works fine.

Also: prints the resolved server origin in the dry-run output so the operator can sanity-check before applying.

## Verified

End-to-end on both droplets after the in-container hotfix:
- US: 11 dev_updates queued, 7 online agents self-updated to 0.65.7 within ~2 min
- EU: 1 dev_update queued, agent is offline (will recover on next reconnection)
- MacBook-Pro-3 (the team's dogfood Mac): self-updated successfully, no more `failed to update` errors

## Test plan

- [x] Lint passes.
- [x] Hotfix bundle (same source) verified working on US + EU production.
- [ ] Whoever ships v0.65.8 should rebuild and retest in CI before publishing — the script is bundled via tsup into `dist/scripts/recover-stuck-agents.cjs` per #612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)