### PR TITLE
fix(web,api): v0.65.7 strict-CSP regressions + agent_versions ON CONFLICT

### DIFF
--- a/apps/api/src/services/binarySync.test.ts
+++ b/apps/api/src/services/binarySync.test.ts
@@ -27,7 +27,27 @@ vi.mock("../db", () => ({
   },
 }));
 
-import { syncFromGitHub } from "./binarySync";
+const fsMocks = vi.hoisted(() => ({
+  readdir: vi.fn(),
+  readFile: vi.fn(),
+  stat: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => fsMocks);
+
+vi.mock("node:fs", () => ({
+  createReadStream: () => {
+    const { Readable } = require("node:stream");
+    return Readable.from(Buffer.from("local agent bytes"));
+  },
+}));
+
+vi.mock("./s3Storage", () => ({
+  isS3Configured: () => false,
+  syncDirectory: vi.fn(),
+}));
+
+import { syncBinaries, syncFromGitHub } from "./binarySync";
 
 function makeSignedReleaseManifest(assetName: string, assetBuffer: Buffer) {
   const { publicKey, privateKey } = generateKeyPairSync("ed25519");
@@ -143,5 +163,32 @@ describe("binarySync", () => {
         }),
       }),
     );
+  });
+
+  it("upserts local agent binaries with the full 4-column conflict target (regression: #617)", async () => {
+    // The agent_versions table has a UNIQUE constraint on
+    // (version, platform, architecture, component). The local-binary path used
+    // to omit `component`, so Postgres rejected the upsert with
+    // "no unique or exclusion constraint matching the ON CONFLICT
+    // specification" and the wrapping transaction rolled back, leaving
+    // agent_versions empty after every API restart.
+    process.env.BINARY_SOURCE = "local";
+    process.env.AGENT_BINARY_DIR = "/fake/agent/bin";
+    process.env.BINARY_VERSION_FILE = "/fake/version";
+    delete process.env.BREEZE_VERSION;
+
+    fsMocks.readdir.mockResolvedValue(["breeze-agent-linux-amd64"] as any);
+    fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 1234 } as any);
+    fsMocks.readFile.mockResolvedValue("0.65.7" as any);
+
+    await syncBinaries();
+
+    const targets = dbMocks.onConflictDoUpdate.mock.calls.map(
+      (call: any[]) => (call[0] as { target: unknown[] }).target,
+    );
+    expect(targets.length).toBeGreaterThan(0);
+    for (const target of targets) {
+      expect(target).toHaveLength(4);
+    }
   });
 });

--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -352,10 +352,14 @@ export async function syncBinaries(): Promise<void> {
             isLatest: true,
           })
           .onConflictDoUpdate({
+            // Match the actual unique constraint
+            // (version, platform, architecture, component). `component`
+            // defaults to 'agent' in the schema for the local-binary path.
             target: [
               agentVersions.version,
               agentVersions.platform,
               agentVersions.architecture,
+              agentVersions.component,
             ],
             set: {
               downloadUrl,

--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -48,11 +48,18 @@ export default defineConfig({
         // covered.  Add their sha256 hashes here so they pass CSP validation.
         // If a CSP script-src-elem violation appears in the browser console,
         // copy the suggested sha256 hash from the error into this array.
+        //
+        // ClientRouter swap script: this hash is for the inline script Astro's
+        // <ClientRouter> injects during view-transition swaps (issue #618).
+        // It is constant per Astro version; if you bump astro, re-verify and
+        // update.  Hash-chasing here is a known-fragile workaround --
+        // longer-term we should migrate to a nonce-based CSP.
         resources: [
           "'self'",
           'https://cdn.jsdelivr.net',
           'https://static.cloudflareinsights.com',
-          "'sha256-dr7co1YqmJP1+caEJBfXkM/oHRwOVAknT+gDygo8nD0='"
+          "'sha256-dr7co1YqmJP1+caEJBfXkM/oHRwOVAknT+gDygo8nD0='",
+          "'sha256-6wgjuQN80bYuvy8C2/v+mFX1HAEgrfvSs+beElRyx+8='"
         ]
       },
       styleDirective: {

--- a/apps/web/public/theme-bootstrap.js
+++ b/apps/web/public/theme-bootstrap.js
@@ -1,0 +1,20 @@
+(function () {
+  function applyTheme() {
+    var t = localStorage.getItem('theme');
+    var dark =
+      t === 'dark' ||
+      (t !== 'light' && matchMedia('(prefers-color-scheme: dark)').matches);
+    document.documentElement.classList.toggle('dark', dark);
+  }
+
+  applyTheme();
+
+  if (!window.__themeSwap) {
+    window.__themeSwap = true;
+    document.addEventListener('astro:after-swap', function () {
+      applyTheme();
+      var main = document.querySelector('main');
+      if (main) main.scrollTop = 0;
+    });
+  }
+})();

--- a/apps/web/src/layouts/Layout.astro
+++ b/apps/web/src/layouts/Layout.astro
@@ -19,30 +19,17 @@ const { title } = Astro.props;
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <!--
+      Theme bootstrap is an external script (not is:inline) so it's covered by
+      script-src 'self' under the strict hash-based CSP. Keeping it inline would
+      require maintaining a sha256 in astro.config.mjs that drifts every time
+      the script changes (see issue #618).
+    -->
+    <script is:inline src="/theme-bootstrap.js"></script>
     <title>{title} | Breeze RMM</title>
     <ClientRouter />
   </head>
   <body class="min-h-screen bg-background antialiased">
-    <script is:inline>
-      (function(){
-        // Apply theme immediately to prevent flash (runs on every navigation)
-        var t = localStorage.getItem('theme');
-        var dark = t === 'dark' || (t !== 'light' && matchMedia('(prefers-color-scheme: dark)').matches);
-        document.documentElement.classList.toggle('dark', dark);
-
-        // Register after-swap handler once (guard prevents re-registration on View Transitions)
-        if (!window.__themeSwap) {
-          window.__themeSwap = true;
-          document.addEventListener('astro:after-swap', function() {
-            var t = localStorage.getItem('theme');
-            var dark = t === 'dark' || (t !== 'light' && matchMedia('(prefers-color-scheme: dark)').matches);
-            document.documentElement.classList.toggle('dark', dark);
-            var main = document.querySelector('main');
-            if (main) main.scrollTop = 0;
-          });
-        }
-      })();
-    </script>
     <slot />
   </body>
 </html>


### PR DESCRIPTION
## Summary

Two v0.65.7 regressions reported by self-hosted operators after the SR-001..SR-024 security hardening (#568) shipped strict hash-based CSP and tightened other defaults. Both reproduced locally and fixed here.

### #618 — Dark mode + view-transitions broken under strict CSP
- The `<script is:inline>` theme bootstrap in `Layout.astro` opted out of Astro's hash generation, so its sha256 never landed in the served `script-src`. Browsers refused it, the `astro:after-swap` listener never registered, and dark mode dropped on every navigation.
- The `<ClientRouter>` view-transition swap injects another inline script at runtime (also CSP-refused), so React islands stayed on their SSR fallback after transition navigations.

**Fix:** moved the theme bootstrap to `apps/web/public/theme-bootstrap.js` (covered by `'self'`) and added the ClientRouter swap script's sha256 to the allowlist with a note that hash-chasing is fragile and a future nonce-based CSP is the durable answer.

### #617 — `syncBinaries` ON CONFLICT mismatch leaves `agent_versions` empty
- The local-binary upsert path used a 3-column `ON CONFLICT (version, platform, architecture)` target while the actual unique constraint is 4 columns (`+ component`). Postgres rejected the upsert; the wrapping transaction rolled back; the table stayed empty across restarts. This blocked new enrollments and the recovery path documented in #609.

**Fix:** added `component` to the conflict target (matches the schema default of `'agent'` for that path) and added a regression test exercising the local-binary code path.

## Test plan
- [x] `pnpm vitest run` (apps/api) — 2/2 binarySync tests pass, including new regression test
- [x] `pnpm vitest run` (apps/web) — 379/379 pass
- [x] `pnpm tsc --noEmit` (apps/api) — clean
- [x] `pnpm build` (apps/web) — clean; verified `dist/server/chunks/server_*.mjs` now contains the ClientRouter swap hash and no longer contains the inline theme-bootstrap hash
- [ ] Manual smoke against a prod-built web container behind the strict CSP middleware (operator-side verification — local dev mode skips CSP per `apps/web/src/middleware.ts:116`)
- [ ] Confirm `recover-stuck-agents.cjs` reports >0 latest binaries after a fresh start with the patched API

## Follow-ups (not in this PR)
- Migrate to nonce-based CSP so we stop chasing inline-script hashes for framework-injected scripts.
- Add a smoke check that runs the e2e-tests YAML runner against a prod-built web container, not the dev server (this whole class of regression is invisible in dev).

Closes #617
Closes #618

🤖 Generated with [Claude Code](https://claude.com/claude-code)