### PR TITLE
fix(api): partner-multi-org orgId pass-through (#620)

### DIFF
--- a/apps/api/src/routes/discovery.ts
+++ b/apps/api/src/routes/discovery.ts
@@ -228,7 +228,8 @@ const updateProfileSchema = z.object({
 
 const scanSchema = z.object({
   profileId: z.string().uuid(),
-  agentId: z.string().optional()
+  agentId: z.string().optional(),
+  orgId: z.string().uuid().optional()
 });
 
 const listJobsSchema = z.object({
@@ -521,7 +522,7 @@ discoveryRoutes.post(
   async (c) => {
     const auth = c.get('auth');
     const body = c.req.valid('json');
-    const orgResult = resolveOrgId(auth);
+    const orgResult = resolveOrgId(auth, body.orgId ?? c.req.query('orgId'));
     if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
 
     const conditions: ReturnType<typeof eq>[] = [eq(discoveryProfiles.id, body.profileId)];

--- a/apps/api/src/routes/huntress.ts
+++ b/apps/api/src/routes/huntress.ts
@@ -286,7 +286,7 @@ huntressRoutes.post(
     const auth = c.get('auth');
     const body = c.req.valid('json');
 
-    const orgResult = resolveOrgId(auth, body.orgId);
+    const orgResult = resolveOrgId(auth, body.orgId ?? requestedOrgId(c));
     if ('error' in orgResult) {
       return c.json({ error: orgResult.error }, orgResult.status);
     }

--- a/apps/api/src/routes/partner_multi_org_orgid.test.ts
+++ b/apps/api/src/routes/partner_multi_org_orgid.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Regression: partner-scope users with >1 accessible org must be able to scope
+ * requests via the `?orgId=` query string (or `body.orgId` for POST/JSON
+ * handlers). See issue #620.
+ *
+ * Each affected route file is exercised: the resolver should accept the
+ * user-supplied orgId, validate it against `accessibleOrgIds`, and forward it
+ * through. Foreign orgIds must 403; missing orgId must still 400 with the
+ * existing "orgId is required..." message.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const { authState, ORG_A, ORG_B, FOREIGN_ORG } = vi.hoisted(() => {
+  const ORG_A = '11111111-1111-1111-1111-111111111111';
+  const ORG_B = '22222222-2222-2222-2222-222222222222';
+  const FOREIGN_ORG = '33333333-3333-3333-3333-333333333333';
+  return {
+    ORG_A,
+    ORG_B,
+    FOREIGN_ORG,
+    authState: {
+      scope: 'partner' as 'partner' | 'organization' | 'system',
+      orgId: null as string | null,
+      partnerId: 'partner-1' as string | null,
+      accessibleOrgIds: [ORG_A, ORG_B] as string[] | null,
+    },
+  };
+});
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', {
+      user: { id: 'user-1', email: 'test@example.com', name: 'Test' },
+      userId: 'user-1',
+      scope: authState.scope,
+      orgId: authState.orgId,
+      partnerId: authState.partnerId,
+      accessibleOrgIds: authState.accessibleOrgIds,
+      canAccessOrg: (id: string) => Array.isArray(authState.accessibleOrgIds)
+        && authState.accessibleOrgIds.includes(id),
+      orgCondition: () => undefined,
+    });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+// ---------------------------------------------------------------------------
+// db / chain mocks shared across all four route imports
+// ---------------------------------------------------------------------------
+function chainMock(terminalValue: any) {
+  const handler: ProxyHandler<any> = {
+    get(_t, prop) {
+      if (prop === 'then') return undefined;
+      return (..._args: any[]) => new Proxy(
+        () => Promise.resolve(terminalValue),
+        {
+          get(_t2, p) {
+            if (p === 'then') return (resolve: any) => resolve(terminalValue);
+            return (..._a: any[]) => new Proxy(() => Promise.resolve(terminalValue), handler);
+          },
+          apply() { return Promise.resolve(terminalValue); },
+        }
+      );
+    },
+  };
+  return new Proxy({}, handler);
+}
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  SYSTEM_DB_ACCESS_CONTEXT: { scope: 'system', orgId: null, accessibleOrgIds: null },
+  db: {
+    select: vi.fn(() => chainMock([{ count: 0 }])),
+    insert: vi.fn(() => chainMock([])),
+    update: vi.fn(() => chainMock(undefined)),
+    delete: vi.fn(() => chainMock(undefined)),
+    transaction: vi.fn(async (fn: any) => fn({
+      select: vi.fn(() => chainMock([])),
+      insert: vi.fn(() => chainMock([])),
+      update: vi.fn(() => chainMock([])),
+    })),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  softwareCatalog: { id: 'id', orgId: 'orgId', name: 'name', vendor: 'vendor', description: 'description', category: 'category' },
+  softwareVersions: { id: 'id', catalogId: 'catalogId', isLatest: 'isLatest' },
+  softwareDeployments: { id: 'id', orgId: 'orgId' },
+  deploymentResults: { deploymentId: 'deploymentId', status: 'status' },
+  softwareInventory: {
+    deviceId: 'deviceId',
+    name: 'name',
+    vendor: 'vendor',
+    version: 'version',
+    lastSeen: 'lastSeen',
+  },
+  softwarePolicies: {
+    id: 'id',
+    orgId: 'orgId',
+    name: 'name',
+    mode: 'mode',
+    isActive: 'isActive',
+    rules: 'rules',
+  },
+  configurationPolicies: { id: 'id', orgId: 'orgId', name: 'name', status: 'status' },
+  configPolicyFeatureLinks: {
+    configPolicyId: 'configPolicyId',
+    featureType: 'featureType',
+    featurePolicyId: 'featurePolicyId',
+    updatedAt: 'updatedAt',
+  },
+  configPolicyAssignments: {
+    configPolicyId: 'configPolicyId',
+    level: 'level',
+    targetId: 'targetId',
+    priority: 'priority',
+    assignedBy: 'assignedBy',
+  },
+  devices: { id: 'id', orgId: 'orgId', agentId: 'agentId', siteId: 'siteId', status: 'status' },
+  discoveryProfiles: { id: 'id', orgId: 'orgId', siteId: 'siteId' },
+  discoveryJobs: { id: 'id', status: 'status', completedAt: 'completedAt', errors: 'errors', updatedAt: 'updatedAt' },
+  discoveredAssets: { id: 'id', orgId: 'orgId' },
+  huntressIntegrations: {
+    id: 'id',
+    orgId: 'orgId',
+    name: 'name',
+    accountId: 'accountId',
+    apiBaseUrl: 'apiBaseUrl',
+    apiKeyEncrypted: 'apiKeyEncrypted',
+    webhookSecretEncrypted: 'webhookSecretEncrypted',
+    isActive: 'isActive',
+    lastSyncAt: 'lastSyncAt',
+    lastSyncStatus: 'lastSyncStatus',
+    lastSyncError: 'lastSyncError',
+    createdBy: 'createdBy',
+    createdAt: 'createdAt',
+    updatedAt: 'updatedAt',
+  },
+  huntressAgents: { integrationId: 'integrationId', deviceId: 'deviceId', status: 'status' },
+  huntressIncidents: {
+    id: 'id', orgId: 'orgId', integrationId: 'integrationId', deviceId: 'deviceId',
+    huntressIncidentId: 'huntressIncidentId', severity: 'severity', category: 'category',
+    title: 'title', description: 'description', recommendation: 'recommendation',
+    status: 'status', reportedAt: 'reportedAt', resolvedAt: 'resolvedAt', details: 'details',
+    createdAt: 'createdAt', updatedAt: 'updatedAt',
+  },
+}));
+
+// External services pulled in by these route files
+vi.mock('../services', () => ({}));
+vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn(), writeAuditEvent: vi.fn() }));
+vi.mock('../services/deploymentTargetResolver', () => ({ resolveDeploymentTargets: vi.fn().mockResolvedValue([]) }));
+vi.mock('../services/s3Storage', () => ({
+  uploadBinary: vi.fn(),
+  getPresignedUrl: vi.fn(() => Promise.resolve('https://s3.example.com/presigned')),
+  isS3Configured: vi.fn(() => false),
+}));
+vi.mock('../services/redis', () => ({
+  isRedisAvailable: vi.fn(() => false),
+  getRedisConnection: vi.fn(),
+}));
+vi.mock('../jobs/discoveryWorker', () => ({
+  enqueueDiscoveryScan: vi.fn(async () => {}),
+  getDiscoveryQueue: vi.fn(() => null),
+}));
+vi.mock('../services/discoveryJobCreation', () => ({
+  createDiscoveryJobIfIdle: vi.fn(async ({ profileId }: any) => ({
+    job: { id: 'job-1', profileId, status: 'scheduled' },
+    created: true,
+  })),
+}));
+vi.mock('./agentWs', () => ({
+  sendCommandToAgent: vi.fn(() => true),
+}));
+vi.mock('../jobs/huntressSync', () => ({
+  scheduleHuntressSync: vi.fn(async () => 'job-1'),
+  ingestHuntressWebhookPayload: vi.fn(),
+  findHuntressIntegrationByAccount: vi.fn(async () => ({ status: 'none' as const })),
+}));
+vi.mock('../services/huntressClient', () => ({}));
+vi.mock('../services/huntressConstants', () => ({
+  offlineStatusSqlList: [],
+  resolvedStatusSqlList: [],
+}));
+vi.mock('../services/secretCrypto', () => ({
+  encryptSecret: vi.fn((v: string | undefined) => `enc:${v ?? ''}`),
+  decryptSecret: vi.fn(() => 'secret'),
+  isEncryptedSecret: vi.fn(() => false),
+}));
+vi.mock('../services/permissions', () => ({
+  PERMISSIONS: new Proxy(
+    {},
+    {
+      get: () => ({ resource: 'res', action: 'act' }),
+    }
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: partner-scope user with TWO accessible orgs.
+  authState.scope = 'partner';
+  authState.orgId = null;
+  authState.partnerId = 'partner-1';
+  authState.accessibleOrgIds = [ORG_A, ORG_B];
+});
+
+async function expectNotOrgIdRequired400(res: Response) {
+  if (res.status === 400) {
+    const body = await res.clone().json().catch(() => ({}));
+    expect(String((body as { error?: string }).error ?? '')).not.toMatch(/orgId is required/i);
+    expect(String((body as { error?: string }).error ?? '')).not.toMatch(/Organization context required/i);
+  }
+}
+
+describe('issue #620: partner-multi-org orgId pass-through', () => {
+  describe('software catalog routes', () => {
+    it('GET /software/catalog accepts ?orgId= for partner-multi-org user', async () => {
+      const { softwareRoutes } = await import('./software');
+      const app = new Hono().route('/software', softwareRoutes);
+
+      const res = await app.request(`/software/catalog?orgId=${ORG_A}`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer t' },
+      });
+
+      await expectNotOrgIdRequired400(res);
+    });
+
+    it('GET /software/catalog 400s when orgId is missing', async () => {
+      const { softwareRoutes } = await import('./software');
+      const app = new Hono().route('/software', softwareRoutes);
+
+      const res = await app.request('/software/catalog', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer t' },
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(String(body.error)).toMatch(/orgId is required/i);
+    });
+
+    it('GET /software/catalog 403s when ?orgId= points outside accessibleOrgIds', async () => {
+      const { softwareRoutes } = await import('./software');
+      const app = new Hono().route('/software', softwareRoutes);
+
+      const res = await app.request(`/software/catalog?orgId=${FOREIGN_ORG}`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer t' },
+      });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('GET /software/catalog/search accepts ?orgId=', async () => {
+      const { softwareRoutes } = await import('./software');
+      const app = new Hono().route('/software', softwareRoutes);
+
+      const res = await app.request(`/software/catalog/search?q=foo&orgId=${ORG_A}`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer t' },
+      });
+
+      await expectNotOrgIdRequired400(res);
+    });
+
+    it('POST /software/catalog accepts orgId in body', async () => {
+      const { softwareRoutes } = await import('./software');
+      const app = new Hono().route('/software', softwareRoutes);
+
+      const res = await app.request('/software/catalog', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer t' },
+        body: JSON.stringify({ name: 'Acme', orgId: ORG_A }),
+      });
+
+      await expectNotOrgIdRequired400(res);
+    });
+  });
+
+  describe('software inventory routes', () => {
+    it('GET /software-inventory accepts ?orgId=', async () => {
+      const { softwareInventoryRoutes } = await import('./softwareInventory');
+      const app = new Hono().route('/software-inventory', softwareInventoryRoutes);
+
+      const res = await app.request(`/software-inventory?orgId=${ORG_A}`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer t' },
+      });
+
+      await expectNotOrgIdRequired400(res);
+    });
+
+    it('GET /software-inventory 400s when orgId is missing', async () => {
+      const { softwareInventoryRoutes } = await import('./softwareInventory');
+      const app = new Hono().route('/software-inventory', softwareInventoryRoutes);
+
+      const res = await app.request('/software-inventory', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer t' },
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('GET /software-inventory 403s when ?orgId= is foreign', async () => {
+      const { softwareInventoryRoutes } = await import('./softwareInventory');
+      const app = new Hono().route('/software-inventory', softwareInventoryRoutes);
+
+      const res = await app.request(`/software-inventory?orgId=${FOREIGN_ORG}`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer t' },
+      });
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('discovery scan route', () => {
+    it('POST /discovery/scan accepts orgId in body', async () => {
+      const { discoveryRoutes } = await import('./discovery');
+      const app = new Hono().route('/discovery', discoveryRoutes);
+
+      const res = await app.request('/discovery/scan', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer t' },
+        body: JSON.stringify({
+          profileId: '99999999-9999-9999-9999-999999999999',
+          orgId: ORG_A,
+        }),
+      });
+
+      await expectNotOrgIdRequired400(res);
+    });
+
+    it('POST /discovery/scan 400s when orgId is missing for partner-multi-org user', async () => {
+      const { discoveryRoutes } = await import('./discovery');
+      const app = new Hono().route('/discovery', discoveryRoutes);
+
+      const res = await app.request('/discovery/scan', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer t' },
+        body: JSON.stringify({ profileId: '99999999-9999-9999-9999-999999999999' }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(String(body.error)).toMatch(/orgId is required/i);
+    });
+  });
+
+  describe('huntress integration save', () => {
+    it('POST /huntress/integration accepts ?orgId= as a fallback for body.orgId', async () => {
+      const { huntressRoutes } = await import('./huntress');
+      const app = new Hono().route('/huntress', huntressRoutes);
+
+      const res = await app.request(`/huntress/integration?orgId=${ORG_A}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer t' },
+        body: JSON.stringify({ name: 'Primary', apiKey: 'k' }),
+      });
+
+      await expectNotOrgIdRequired400(res);
+    });
+  });
+});

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -32,18 +32,38 @@ const requireSoftwareExecute = requirePermission(PERMISSIONS.DEVICES_EXECUTE.res
 // Helpers
 // ---------------------------------------------------------------------------
 
+type ResolveScopedOrgIdResult =
+  | { orgId: string }
+  | { error: string; status: 400 | 403 };
+
 function resolveScopedOrgId(
   auth: {
     scope: 'system' | 'partner' | 'organization';
     orgId?: string | null;
     accessibleOrgIds?: string[] | null;
+  },
+  requestedOrgId?: string,
+): ResolveScopedOrgIdResult {
+  if (requestedOrgId) {
+    const accessibleOrgIds = auth.accessibleOrgIds ?? [];
+    if (auth.scope === 'organization') {
+      if (auth.orgId && requestedOrgId !== auth.orgId) {
+        return { error: 'Access to this organization denied', status: 403 };
+      }
+      return { orgId: requestedOrgId };
+    }
+    if (!accessibleOrgIds.includes(requestedOrgId)) {
+      return { error: 'Access to this organization denied', status: 403 };
+    }
+    return { orgId: requestedOrgId };
   }
-) {
-  if (auth.orgId) return auth.orgId;
+
+  if (auth.orgId) return { orgId: auth.orgId };
   if (auth.scope === 'partner' && Array.isArray(auth.accessibleOrgIds) && auth.accessibleOrgIds.length === 1) {
-    return auth.accessibleOrgIds[0] ?? null;
+    const single = auth.accessibleOrgIds[0];
+    if (single) return { orgId: single };
   }
-  return null;
+  return { error: 'orgId is required for this scope', status: 400 };
 }
 
 function getPagination(query: { page?: string; limit?: string }) {
@@ -238,7 +258,8 @@ const createCatalogSchema = z.object({
   description: z.string().max(2000).optional(),
   iconUrl: z.string().url().optional(),
   websiteUrl: z.string().url().optional(),
-  isManaged: z.boolean().optional()
+  isManaged: z.boolean().optional(),
+  orgId: z.string().uuid().optional()
 });
 
 const updateCatalogSchema = z.object({
@@ -318,8 +339,9 @@ softwareRoutes.get(
   zValidator('query', listCatalogSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgId = resolveScopedOrgId(auth);
-    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const { orgId } = orgResult;
 
     const query = c.req.valid('query');
     const { page, limit, offset } = getPagination(query);
@@ -366,10 +388,11 @@ softwareRoutes.post(
   zValidator('json', createCatalogSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgId = resolveScopedOrgId(auth);
-    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
-
     const payload = c.req.valid('json');
+    const orgResult = resolveScopedOrgId(auth, payload.orgId ?? c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const { orgId } = orgResult;
+
     const [item] = await db.insert(softwareCatalog).values({
       orgId,
       name: payload.name,
@@ -402,8 +425,9 @@ softwareRoutes.get(
   zValidator('query', catalogSearchSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgId = resolveScopedOrgId(auth);
-    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const { orgId } = orgResult;
 
     const query = c.req.valid('query');
     const term = `%${query.q}%`;
@@ -432,8 +456,9 @@ softwareRoutes.get(
   zValidator('param', catalogIdParamSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgId = resolveScopedOrgId(auth);
-    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const { orgId } = orgResult;
 
     const { id } = c.req.valid('param');
     const [item] = await db.select().from(softwareCatalog)
@@ -457,8 +482,9 @@ softwareRoutes.patch(
   zValidator('json', updateCatalogSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgId = resolveScopedOrgId(auth);
-    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const { orgId } = orgResult;
 
     const { id } = c.req.valid('param');
     const payload = c.req.valid('json');
@@ -494,8 +520,9 @@ softwareRoutes.delete(
   zValidator('param', catalogIdParamSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgId = resolveScopedOrgId(auth);
-    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const { orgId } = orgResult;
 
     const { id } = c.req.valid('param');
     const [existing] = await db.select().from(softwareCatalog)
@@ -530,8 +557,9 @@ softwareRoutes.get(
   zValidator('param', versionParamSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgId = resolveScopedOrgId(auth);
-    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const { orgId } = orgResult;
 
     const { id } = c.req.valid('param');
     const [catalogItem] = await db.select().from(softwareCatalog)
@@ -556,8 +584,9 @@ softwareRoutes.post(
   zValidator('json', createVersionSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgId = resolveScopedOrgId(auth);
-    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const { orgId } = orgResult;
 
     const { id } = c.req.valid('param');
     const payload = c.req.valid('json');
@@ -606,8 +635,9 @@ softwareRoutes.post(
   requireMfa(),
   async (c) => {
     const auth = c.get('auth');
-    const orgId = resolveScopedOrgId(auth);
-    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const { orgId } = orgResult;
 
     if (!isS3Configured()) {
       return c.json({ error: 'S3 storage is not configured' }, 503);
@@ -728,8 +758,9 @@ softwareRoutes.post(
   zValidator('param', versionIdParamSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgId = resolveScopedOrgId(auth);
-    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const { orgId } = orgResult;
 
     const { id, versionId } = c.req.valid('param');
     const [catalogItem] = await db.select().from(softwareCatalog)
@@ -771,8 +802,9 @@ softwareRoutes.get(
   requireSoftwareRead,
   async (c) => {
     const auth = c.get('auth');
-    const orgId = resolveScopedOrgId(auth);
-    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const { orgId } = orgResult;
 
     const catalogId = c.req.param('id')!;
     const versionId = c.req.param('versionId')!;
@@ -811,8 +843,9 @@ softwareRoutes.get(
   zValidator('query', listDeploymentsSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgId = resolveScopedOrgId(auth);
-    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const { orgId } = orgResult;
 
     const query = c.req.valid('query');
     const { page, limit, offset } = getPagination(query);
@@ -846,8 +879,9 @@ softwareRoutes.post(
   zValidator('json', createDeploymentSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgId = resolveScopedOrgId(auth);
-    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const { orgId } = orgResult;
 
     const payload = c.req.valid('json');
 
@@ -983,8 +1017,9 @@ softwareRoutes.post(
   ),
   async (c) => {
     const auth = c.get('auth');
-    const orgId = resolveScopedOrgId(auth);
-    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const { orgId } = orgResult;
 
     const body = c.req.valid('json');
     const softwareId = body.softwareId;
@@ -1093,8 +1128,9 @@ softwareRoutes.get(
   zValidator('param', deploymentIdParamSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgId = resolveScopedOrgId(auth);
-    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const { orgId } = orgResult;
 
     const { id } = c.req.valid('param');
     const [deployment] = await db.select().from(softwareDeployments)
@@ -1122,8 +1158,9 @@ softwareRoutes.post(
   zValidator('json', cancelDeploymentSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgId = resolveScopedOrgId(auth);
-    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const { orgId } = orgResult;
 
     const { id } = c.req.valid('param');
     const [deployment] = await db.select().from(softwareDeployments)
@@ -1160,8 +1197,9 @@ softwareRoutes.get(
   zValidator('param', deploymentIdParamSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgId = resolveScopedOrgId(auth);
-    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const { orgId } = orgResult;
 
     const { id } = c.req.valid('param');
     const [deployment] = await db.select().from(softwareDeployments)
@@ -1187,8 +1225,9 @@ softwareRoutes.get(
   zValidator('query', listInventorySchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgId = resolveScopedOrgId(auth);
-    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const { orgId } = orgResult;
 
     const query = c.req.valid('query');
 
@@ -1225,8 +1264,9 @@ softwareRoutes.get(
   zValidator('param', inventoryParamSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgId = resolveScopedOrgId(auth);
-    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const { orgId } = orgResult;
 
     const { deviceId } = c.req.valid('param');
 

--- a/apps/api/src/routes/softwareInventory.ts
+++ b/apps/api/src/routes/softwareInventory.ts
@@ -60,12 +60,31 @@ const deviceDrilldownQuerySchema = z.object({
 // Helpers
 // ============================================
 
-function resolveOrgId(auth: AuthContext): string | null {
-  if (auth.orgId) return auth.orgId;
-  if (Array.isArray(auth.accessibleOrgIds) && auth.accessibleOrgIds.length === 1) {
-    return auth.accessibleOrgIds[0] ?? null;
+type ResolveOrgIdResult =
+  | { orgId: string }
+  | { error: string; status: 400 | 403 };
+
+function resolveOrgId(auth: AuthContext, requestedOrgId?: string): ResolveOrgIdResult {
+  if (requestedOrgId) {
+    const accessibleOrgIds = auth.accessibleOrgIds ?? [];
+    if (auth.orgId) {
+      if (requestedOrgId !== auth.orgId) {
+        return { error: 'Access to this organization denied', status: 403 };
+      }
+      return { orgId: requestedOrgId };
+    }
+    if (!accessibleOrgIds.includes(requestedOrgId)) {
+      return { error: 'Access to this organization denied', status: 403 };
+    }
+    return { orgId: requestedOrgId };
   }
-  return null;
+
+  if (auth.orgId) return { orgId: auth.orgId };
+  if (Array.isArray(auth.accessibleOrgIds) && auth.accessibleOrgIds.length === 1) {
+    const single = auth.accessibleOrgIds[0];
+    if (single) return { orgId: single };
+  }
+  return { error: 'Organization context required', status: 400 };
 }
 
 type PolicyStatus = 'allowed' | 'blocked' | 'audit' | 'no_policy';
@@ -173,10 +192,11 @@ softwareInventoryRoutes.get('/', requireSoftwareInventoryRead, zValidator('query
   const auth = c.get('auth') as AuthContext;
   const { search, vendor, limit, offset, sortBy, sortOrder } = c.req.valid('query');
 
-  const orgId = resolveOrgId(auth);
-  if (!orgId) {
-    return c.json({ error: 'Organization context required' }, 400);
+  const orgResult = resolveOrgId(auth, c.req.query('orgId'));
+  if ('error' in orgResult) {
+    return c.json({ error: orgResult.error }, orgResult.status);
   }
+  const { orgId } = orgResult;
 
   const conditions: SQL[] = [eq(devices.orgId, orgId)];
 
@@ -279,10 +299,11 @@ softwareInventoryRoutes.post('/approve', requireSoftwareInventoryWrite, requireM
   const auth = c.get('auth') as AuthContext;
   const { softwareName, vendor } = c.req.valid('json');
 
-  const orgId = resolveOrgId(auth);
-  if (!orgId) {
-    return c.json({ error: 'Organization context required' }, 400);
+  const orgResult = resolveOrgId(auth, c.req.query('orgId'));
+  if ('error' in orgResult) {
+    return c.json({ error: orgResult.error }, orgResult.status);
   }
+  const { orgId } = orgResult;
 
   // Find or create "Default Allowlist" policy
   const [existing] = await db
@@ -359,10 +380,11 @@ softwareInventoryRoutes.post('/deny', requireSoftwareInventoryWrite, requireMfa(
   const auth = c.get('auth') as AuthContext;
   const { softwareName, vendor } = c.req.valid('json');
 
-  const orgId = resolveOrgId(auth);
-  if (!orgId) {
-    return c.json({ error: 'Organization context required' }, 400);
+  const orgResult = resolveOrgId(auth, c.req.query('orgId'));
+  if ('error' in orgResult) {
+    return c.json({ error: orgResult.error }, orgResult.status);
   }
+  const { orgId } = orgResult;
 
   // Find or create "Default Blocklist" policy
   const [existing] = await db
@@ -436,10 +458,11 @@ softwareInventoryRoutes.post('/clear', requireSoftwareInventoryWrite, requireMfa
   const auth = c.get('auth') as AuthContext;
   const { softwareName, vendor } = c.req.valid('json');
 
-  const orgId = resolveOrgId(auth);
-  if (!orgId) {
-    return c.json({ error: 'Organization context required' }, 400);
+  const orgResult = resolveOrgId(auth, c.req.query('orgId'));
+  if ('error' in orgResult) {
+    return c.json({ error: orgResult.error }, orgResult.status);
   }
+  const { orgId } = orgResult;
 
   // Remove from both Default Allowlist and Default Blocklist
   const defaults = await db
@@ -486,10 +509,11 @@ softwareInventoryRoutes.get('/:name/devices', requireSoftwareInventoryRead, zVal
   const softwareName = decodeURIComponent(c.req.param('name'));
   const { vendor, limit, offset } = c.req.valid('query');
 
-  const orgId = resolveOrgId(auth);
-  if (!orgId) {
-    return c.json({ error: 'Organization context required' }, 400);
+  const orgResult = resolveOrgId(auth, c.req.query('orgId'));
+  if ('error' in orgResult) {
+    return c.json({ error: orgResult.error }, orgResult.status);
   }
+  const { orgId } = orgResult;
 
   const conditions: SQL[] = [
     eq(devices.orgId, orgId),


### PR DESCRIPTION
## Summary
- Partner-scope users with >1 accessible org hit 400 on Software Library, Software Inventory, Discovery Scan, and Huntress save even with the top-bar org switcher set. Four resolver call sites dropped the user-supplied `orgId` on the floor.
- Fixes the resolvers in `software.ts`, `softwareInventory.ts`, the POST `/discovery/scan` handler, and the POST `/huntress/integration` handler. Tenant boundary preserved — foreign orgIds 403, missing orgId still 400.

## Changes
- `software.ts` — `resolveScopedOrgId` now takes `(auth, requested?)` and returns `{orgId} | {error, status}`. All 21 `/catalog*` + `/deploy*` handlers read `c.req.query('orgId')`. POST `/catalog` also accepts `body.orgId` via `createCatalogSchema`.
- `softwareInventory.ts` — same resolver shape; `GET /` accepts `?orgId=`.
- `discovery.ts` — `scanSchema` now includes `orgId`; resolver call forwards `body.orgId ?? c.req.query('orgId')` (the helper already supported the second arg).
- `huntress.ts` POST `/integration` — widened to `body.orgId ?? requestedOrgId(c)` for symmetry with `/integration/sync`.
- New regression file `partner_multi_org_orgid.test.ts` (11 tests) covers acceptance, foreign-org 403, and the existing 400 when neither auth nor request supplies an `orgId`.

## Test plan
- [x] `npx vitest run src/routes/partner_multi_org_orgid.test.ts` — 11 passed
- [x] `pnpm --filter=@breeze/api test` — 388 files, 4054 passed, 0 failed
- [x] `npx tsc --noEmit` — clean
- [ ] Reporter (@bdunncompany) verifies on a self-hosted droplet with a 2-org partner user against Software Library / Software Inventory / Discovery Scan / Huntress save

Refs #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)