### PR TITLE
chore: move root-level docs into docs/ + refresh security pages

### DIFF
--- a/docs/SECRET_ROTATION.md
+++ b/docs/SECRET_ROTATION.md
@@ -93,9 +93,9 @@ Schedule hard rotations during a maintenance window and notify users in advance.
 
 **What it protects:** Encrypts sensitive data at rest in the database (SSO client secrets, integration tokens, etc.). Uses AES-256-GCM with versioned prefixes (`enc:v1:` legacy ciphertexts and `enc:v2:<keyId>:` key-id ciphertexts).
 
-**Current implementation:** `apps/api/src/services/secretCrypto.ts` derives 256-bit AES keys via SHA-256 from configured secret strings. Legacy `enc:v1:` values use `APP_ENCRYPTION_KEY` (or the existing fallback chain). When `APP_ENCRYPTION_KEY_ID` or `SECRET_ENCRYPTION_KEY_ID` is configured, new writes use `enc:v2:<keyId>:` and decrypt by key ID from the active key or keyring.
+**Current implementation:** `apps/api/src/services/secretCrypto.ts` derives 256-bit AES keys via SHA-256 from configured secret strings. Legacy `enc:v1:` values use `APP_ENCRYPTION_KEY` (or `SSO_ENCRYPTION_KEY` / `SECRET_ENCRYPTION_KEY` aliases). When `APP_ENCRYPTION_KEY_ID` or `SECRET_ENCRYPTION_KEY_ID` is configured, new writes use `enc:v2:<keyId>:` and decrypt by key ID from the active key or keyring.
 
-> **WARNING:** Rotating this key without re-encrypting existing data will make all previously encrypted values unreadable. This causes permanent data loss if you do not follow the re-encryption procedure.
+> **WARNING:** Rotating this key without re-encrypting existing data will make all previously encrypted values unreadable -- unless those rows are still decryptable via the legacy fallback chain (see below). Always run the re-encrypt script before retiring any old key material.
 
 ### Rotation Status
 
@@ -103,6 +103,33 @@ Breeze can read both legacy `enc:v1:` values and key-id based
 `enc:v2:<keyId>:` values. New encryption remains `enc:v1:` unless an active key
 ID is configured, which preserves compatibility for deployments that have not
 started a key-id migration.
+
+### Read-Side Legacy Fallback Chain (v0.65.0+)
+
+When the primary `APP_ENCRYPTION_KEY` (or `SSO_ENCRYPTION_KEY` /
+`SECRET_ENCRYPTION_KEY` alias) fails to decrypt an `enc:v1:` row,
+`decryptSecret()` retries with a fixed legacy chain:
+
+1. `JWT_SECRET`
+2. `SESSION_SECRET`
+
+This lets operators upgrade to a dedicated `APP_ENCRYPTION_KEY` without first
+re-encrypting every row -- rows written by older builds (when the encryption
+key was derived from `JWT_SECRET` / `SESSION_SECRET`) still decrypt
+transparently. New writes always use the active key. The fallback only applies
+to `enc:v1:`; unknown `enc:v2:` key IDs fail closed.
+
+When a fallback decrypt succeeds, the API logs the following warning **once
+per process per row** (suppressed in tests):
+
+```
+[secretCrypto] Decrypted enc:v1: row with legacy fallback key. Run scripts/re-encrypt-secrets.ts to re-encrypt under APP_ENCRYPTION_KEY.
+```
+
+This warning is your migration indicator. Tail the API logs after deploying a
+new `APP_ENCRYPTION_KEY` -- if no warnings appear over a representative
+window, the legacy fallback path is no longer reachable and you can safely
+rotate `JWT_SECRET` / `SESSION_SECRET` independently.
 
 Supported key-id environment variables:
 
@@ -124,33 +151,72 @@ script at `scripts/re-encrypt-secrets.ts`. Do not perform manual SQL rewrites;
 the registry covers text, text-array, and JSON secret locations used by
 `encryptSecret()`.
 
-### Rotation Procedure
+### Rotation Procedure (v0.65.0+)
 
-1. Keep the old `APP_ENCRYPTION_KEY` configured so legacy `enc:v1` values remain readable.
+This procedure assumes you are rotating the dedicated `APP_ENCRYPTION_KEY`
+itself. For keyring-driven `enc:v2` key-ID rotations, see the next subsection.
+
+1. **Generate the new key:** `openssl rand -hex 32`.
+2. **Set the new `APP_ENCRYPTION_KEY` in your environment.** Leave
+   `JWT_SECRET` and `SESSION_SECRET` in place -- the read-side legacy
+   fallback chain uses them to decrypt any `enc:v1:` rows that were written
+   by older builds. **Do not** rotate `JWT_SECRET` or `SESSION_SECRET` in the
+   same change; their unchanged values are what keep legacy ciphertext
+   readable while the re-encrypt script runs.
+3. **Deploy the API.** New writes use the new `APP_ENCRYPTION_KEY`. Existing
+   rows decrypt either under the new key (no-op for rows already on the new
+   key) or under the legacy fallback (`JWT_SECRET` / `SESSION_SECRET`).
+4. **Dry-run the re-encrypt script:**
+
+   ```bash
+   pnpm --filter @breeze/api secrets:reencrypt
+   ```
+
+   Review the JSON summary. `errors` must be empty. `changed` is the number of
+   rows that would be re-encrypted under the new key.
+5. **Apply the migration:**
+
+   ```bash
+   pnpm --filter @breeze/api secrets:reencrypt -- --apply
+   ```
+
+6. **Re-run the dry run.** `changed` should now be `0`.
+7. **Confirm the legacy fallback is no longer reached.** Tail the API logs
+   for at least one full request cycle through every encrypted-column code
+   path (SSO logins, integration syncs, webhook deliveries, MFA reads). You
+   should see **zero** occurrences of:
+
+   ```
+   [secretCrypto] Decrypted enc:v1: row with legacy fallback key
+   ```
+
+   If the warning still fires, identify the table/column from the call site
+   and re-run the script. Common causes: a row added to the registry after
+   the previous rotation, or a column type (`json` / `text-array`) whose
+   transform missed an entry.
+8. **Optional -- rotate `JWT_SECRET` / `SESSION_SECRET`.** Once the warning
+   has stayed silent over a representative window (typically 24-48h covering
+   all background jobs and weekly schedules), the legacy fallback is dead
+   code. You can now rotate `JWT_SECRET` and `SESSION_SECRET` independently
+   following their own procedures (sections 2 and 7) without risk of
+   stranding ciphertext.
+
+### Keyring-Driven `enc:v2` Rotation (advanced)
+
+For deployments already using `APP_ENCRYPTION_KEY_ID` + `APP_ENCRYPTION_KEYRING`:
+
+1. Keep the old keyring entry available so prior `enc:v2:<oldId>:` values remain readable.
 2. Generate the new key: `openssl rand -hex 32`.
 3. Configure a new active key ID and keyring entry:
 
 ```bash
 APP_ENCRYPTION_KEY=<old-key-that-can-read-enc-v1>
 APP_ENCRYPTION_KEY_ID=app-2026-05
-APP_ENCRYPTION_KEYRING='{"app-2026-05":"<new-key>"}'
+APP_ENCRYPTION_KEYRING='{"app-2026-05":"<new-key>","app-2025-11":"<previous-key>"}'
 ```
 
-4. Run a dry run:
-
-```bash
-pnpm --filter @breeze/api secrets:reencrypt
-```
-
-5. Review the JSON summary. `errors` must be empty.
-6. Apply the migration:
-
-```bash
-pnpm --filter @breeze/api secrets:reencrypt -- --apply
-```
-
-7. Run the dry run again. `changed` should be `0`.
-8. After backups and application checks pass, remove the old key material from
+4. Run the dry run, apply, re-verify with `changed=0` (steps 4-6 above).
+5. After backups and application checks pass, remove the old key material from
    the keyring/vault when no `enc:v1` or old-key `enc:v2` values remain.
 
 Emergency compromise response should prefer restoring from a known-good backup
@@ -183,41 +249,77 @@ cd apps/api
 
 ## 4. MFA_ENCRYPTION_KEY
 
-**What it protects:** Encrypts MFA TOTP secrets stored in the `users` table. Without the correct key, users cannot complete MFA verification.
+**What it protects:** Encrypts MFA TOTP secrets stored on the `users` table. Without a working key, users cannot complete MFA verification.
+
+**Current implementation (v0.65.0+):** `apps/api/src/services/mfaSecretCrypto.ts` writes new TOTP secrets as `mfa:v1:` rows under `MFA_ENCRYPTION_KEY` (AES-256-GCM, SHA-256-derived 256-bit key). Reads accept both formats:
+
+- `mfa:v1:` rows are decrypted with `MFA_ENCRYPTION_KEY`.
+- Legacy `enc:v1:` rows fall through to `decryptSecret()`, which uses the standard `APP_ENCRYPTION_KEY` chain and its legacy fallback (see §3).
+
+The decryption path returns a `migratedSecret` value alongside the plaintext so callers can persist the rewrap on the next successful MFA verification (transparent online migration). New enrollments always write `mfa:v1:`.
 
 ### Rotation Procedure
 
-The same re-encryption approach as `APP_ENCRYPTION_KEY` applies:
+The dual-format read path means rotation does NOT instantly lock users out, but you must run the re-encrypt step before retiring the old key.
 
-1. Generate new key: `openssl rand -hex 32`
-2. Run a re-encryption migration targeting MFA secret columns.
-3. Update `MFA_ENCRYPTION_KEY` in your environment.
-4. Deploy.
+1. **Generate the new key:** `openssl rand -hex 32`.
+2. **Update `MFA_ENCRYPTION_KEY` in your environment.** Keep the old `APP_ENCRYPTION_KEY` / `JWT_SECRET` / `SESSION_SECRET` in place so any remaining `enc:v1:` MFA rows still decrypt via the legacy fallback.
+3. **Deploy the API.** New MFA enrollments write `mfa:v1:` under the new key.
+4. **Dry-run the re-encrypt script** (`scripts/re-encrypt-secrets.ts` covers MFA columns through the encrypted-column registry):
 
-> **WARNING:** If you rotate this key without re-encryption, all users with MFA enabled will be locked out of their accounts. They would need to disable and re-enable MFA, which requires admin intervention.
+   ```bash
+   pnpm --filter @breeze/api secrets:reencrypt
+   pnpm --filter @breeze/api secrets:reencrypt -- --apply
+   ```
+
+5. **Verify** by tailing the API logs while users sign in -- you should not see legacy-fallback warnings (§3) attributable to MFA reads. The transparent migration path also rewrites old rows on first successful login, so steady-state attrition is expected.
+
+> **WARNING:** Do **not** rotate `MFA_ENCRYPTION_KEY` simultaneously with `APP_ENCRYPTION_KEY` and the legacy `JWT_SECRET` / `SESSION_SECRET` fallbacks. Doing so removes every read path for both `mfa:v1:` and `enc:v1:` MFA rows, locking out every MFA-enabled user. Rotate one, run the re-encrypt script, verify, then move to the next.
 
 ---
 
 ## 5. ENROLLMENT_KEY_PEPPER / MFA_RECOVERY_CODE_PEPPER
 
-**What they protect:** These peppers are mixed into SHA-256 hashes for enrollment keys and MFA recovery codes, respectively. See `apps/api/src/services/enrollmentKeySecurity.ts`.
+**What they protect:** These peppers are mixed into SHA-256 hashes for enrollment keys and MFA recovery codes, respectively. Used for one-way hashing, not encryption. See `apps/api/src/services/enrollmentKeySecurity.ts` and `apps/api/src/routes/auth/helpers.ts`.
 
-### Rotation Procedure
+### ENROLLMENT_KEY_PEPPER (rotation-safe via fallback chain, v0.65.0+)
 
-These peppers are used for one-way hashing, not encryption. Rotating them means **all existing hashes become invalid:**
+`enrollmentKeySecurity.ts` exposes two functions:
 
-- **ENROLLMENT_KEY_PEPPER:** All unexpired enrollment keys become unusable. You must regenerate enrollment keys after rotation.
-- **MFA_RECOVERY_CODE_PEPPER:** All existing MFA recovery codes become invalid. Users must generate new recovery codes.
+- `hashEnrollmentKey(rawKey)` -- always uses the **primary** `ENROLLMENT_KEY_PEPPER`. All new writes hash here.
+- `hashEnrollmentKeyCandidates(rawKey)` -- returns every hash a stored row could match: primary first, then one hash per legacy pepper. Lookup paths (e.g. `inArray(enrollmentKeys.key, candidates)`) accept any match.
 
-**Steps:**
+The legacy fallback list is, in order, every non-empty value of:
 
-1. Generate new pepper: `openssl rand -hex 32`
-2. Update the env var.
+1. `APP_ENCRYPTION_KEY`
+2. `SSO_ENCRYPTION_KEY`
+3. `SECRET_ENCRYPTION_KEY`
+4. `JWT_SECRET`
+5. `SESSION_SECRET`
+
+(De-duped, and the primary `ENROLLMENT_KEY_PEPPER` value itself is excluded if any of the above happens to share its value.) This list matches the historical "pre-dedicated-pepper" hash sources used before `ENROLLMENT_KEY_PEPPER` was a required env var.
+
+**Rotation Procedure:**
+
+1. Generate the new pepper: `openssl rand -hex 32`.
+2. Set `ENROLLMENT_KEY_PEPPER` to the new value. **Leave** `APP_ENCRYPTION_KEY`, `JWT_SECRET`, and `SESSION_SECRET` in place -- existing enrollment-key hashes match through the legacy fallback list.
+3. Deploy. New enrollment keys are hashed under the new pepper; existing keys remain matchable via the candidate lookup.
+4. **Drain the legacy list.** Existing enrollment keys are short-lived (24h TTL by default) and self-rotate as devices enroll, so the fallback list naturally goes idle within a TTL cycle. Audit the `enrollment_keys` table: once no rows remain whose hash is reachable only through legacy peppers (typically after one TTL window plus margin), drop the legacy values from the env in a follow-up rotation.
+
+There is no re-hash migration script for enrollment keys -- the fallback path plus natural TTL turnover is the expected migration mechanism. Forced rotation of all peppers without waiting for TTL drain will invalidate every unexpired enrollment key (devices in flight will need a fresh key).
+
+### MFA_RECOVERY_CODE_PEPPER (no fallback chain)
+
+`MFA_RECOVERY_CODE_PEPPER` is read directly by `getRecoveryCodePepper()` in `apps/api/src/routes/auth/helpers.ts` with **no** legacy fallback -- this is intentional, because recovery codes are a high-value last-resort credential and the operational risk of rotating them is bounded (users regenerate via the UI). Rotation invalidates every existing recovery code.
+
+**Rotation Procedure:**
+
+1. Generate the new pepper: `openssl rand -hex 32`.
+2. Update `MFA_RECOVERY_CODE_PEPPER`.
 3. Deploy.
-4. For enrollment keys: regenerate and redistribute to anyone who needs to enroll new devices.
-5. For recovery codes: notify users to regenerate their MFA recovery codes via the UI. Alternatively, an admin can trigger bulk regeneration.
+4. Notify all MFA-enabled users to regenerate their recovery codes via the UI. Admins can trigger bulk regeneration if available, or force-revoke unused codes.
 
-Schedule this during a maintenance window and communicate the impact.
+Schedule during a maintenance window and communicate the impact.
 
 ---
 
@@ -457,3 +559,52 @@ If you suspect any secret has been compromised:
 3. **Rotate related secrets.** If `JWT_SECRET` was compromised, also rotate `SESSION_SECRET`. If database credentials leaked, also rotate `APP_ENCRYPTION_KEY` in case encrypted data was exfiltrated.
 4. **Notify affected users** if their data may have been accessed.
 5. **File a post-incident report** documenting the timeline, impact, and remediation.
+
+### Emergency Rotation Quick Reference (v0.65.0+ fallback chains)
+
+The read-side fallback chains added in v0.65.0 change the emergency-rotation
+ordering in two important ways:
+
+- **Rotating `APP_ENCRYPTION_KEY` alone no longer locks out existing rows.**
+  `enc:v1:` ciphertext written under older builds (or under a previous
+  `APP_ENCRYPTION_KEY`) will continue to decrypt via the `JWT_SECRET` /
+  `SESSION_SECRET` legacy fallback. This is *good* for routine rotation but
+  *bad* in a confirmed-compromise scenario: if the attacker had access to
+  any of `JWT_SECRET`, `SESSION_SECRET`, or the old `APP_ENCRYPTION_KEY`,
+  they can still decrypt exfiltrated `enc:v1:` ciphertext until those
+  legacy values are also rotated and every row has been re-encrypted.
+- **`ENROLLMENT_KEY_PEPPER` rotation is similarly soft.** The pepper
+  fallback list keeps existing enrollment-key hashes matchable across all
+  candidate peppers, so an attacker who lifted any one of the historical
+  pepper sources can still match stored hashes until those values are
+  rotated.
+
+Recommended order for a **confirmed compromise of secrets at rest** (assume
+the database and the full env both leaked):
+
+1. **Rotate `JWT_SECRET` and `SESSION_SECRET` first** (sections 2 and 7).
+   This invalidates active sessions and removes the legacy decrypt fallback
+   for both `secretCrypto` and `enrollmentKeySecurity`.
+2. **Rotate `APP_ENCRYPTION_KEY`** (section 3) to a fresh value the attacker
+   has never seen. Run `pnpm --filter @breeze/api secrets:reencrypt --
+   --apply` immediately so new ciphertext is written under the new key. Tail
+   logs for the `legacy fallback key` warning -- with `JWT_SECRET` /
+   `SESSION_SECRET` already rotated, any warning indicates a row that the
+   re-encrypt registry missed and must be investigated before proceeding.
+3. **Rotate `MFA_ENCRYPTION_KEY`** (section 4) and re-run the script. The
+   `mfa:v1:` -> new-key transition relies on the same registry path.
+4. **Rotate `ENROLLMENT_KEY_PEPPER`** (section 5). Because step 1 already
+   rotated `JWT_SECRET` / `SESSION_SECRET`, the fallback pepper list is now
+   constrained to (rotated) `APP_ENCRYPTION_KEY` only. If you also want to
+   cut the `APP_ENCRYPTION_KEY`-derived pepper, stage a follow-up rotation
+   after the enrollment-key TTL window has fully drained (default 24h).
+5. **Rotate `MFA_RECOVERY_CODE_PEPPER`** (section 5) -- this has no
+   fallback, so recovery codes are immediately invalidated. Notify users
+   to regenerate.
+6. **Revoke all user-facing API keys** and force a global session reset.
+7. **Reissue integration credentials** that were stored encrypted at rest
+   (SSO client secrets, PSA tokens, Huntress / S1 / DNS-filter API keys,
+   webhook secrets, SNMP credentials, etc.) -- attacker-decrypted
+   ciphertext means the upstream credential itself is compromised.
+8. Restore from a known-good backup if integrity of any encrypted column is
+   in doubt; do not rely on ad-hoc database rewrites.

--- a/docs/SECURITY_PRACTICES.md
+++ b/docs/SECURITY_PRACTICES.md
@@ -110,6 +110,21 @@ breeze.accessible_org_ids = comma-separated list or '*'
 
 These variables are set via `set_config()` within the request transaction context using Node.js `AsyncLocalStorage`. Queries that don't have proper context set will fail — there is no default permissive state.
 
+As of v0.65.0, every tenant-scoped table is configured with `FORCE ROW LEVEL SECURITY` in addition to having policies enabled. PostgreSQL evaluates RLS policies for *all* roles — including the table owner — eliminating the residual risk that an operator-mode connection (migrations, maintenance, or a custom deployment running the API as a privileged role) could accidentally bypass tenant isolation. The application connects as the unprivileged `breeze_app` role for all request-path queries, and FORCE RLS now enforces the same policy evaluation even when administrative roles touch the data. The migration that applies FORCE RLS to all currently-discovered tenant tables is `apps/api/migrations/2026-05-03-tenant-rls-force-and-invites.sql`; the contract test `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` keeps coverage from regressing as new tables are added.
+
+### Platform Admin
+
+Platform admin is a separate authorization axis from the partner/organization RBAC system. The `users.is_platform_admin` boolean flag gates the cross-tenant `/admin/*` endpoints (audit forensic queries, abuse response, partner suspension) which need to operate above any single tenant's scope.
+
+| Property | Implementation |
+|---|---|
+| **Schema** | `users.is_platform_admin` boolean column (defaults to `false`) |
+| **Bootstrap** | `BREEZE_PLATFORM_ADMINS` env var — comma-separated email allowlist, applied on API startup |
+| **Middleware** | `platformAdminMiddleware` (`apps/api/src/middleware/platformAdmin.ts`) — runs `authMiddleware` then enforces `isPlatformAdmin === true`, fails closed with 403 |
+| **Audit** | Every authorized request is recorded as `platform_admin.<route>` in `audit_logs`, including method, path, actor, and trusted client IP |
+
+Platform admin is intentionally orthogonal to roles: a platform admin must still hold the appropriate organization or partner role to act on tenant-scoped data via normal endpoints. The flag only unlocks the cross-tenant administrative surface.
+
 ### Role-Based Access Control
 
 | Component | Description |
@@ -142,6 +157,8 @@ The agent runs on customer endpoints with elevated privileges. Its security is p
 - **Hashing**: SHA-256 hash stored in `devices.agentTokenHash` — plaintext never persisted server-side
 - **Validation**: Every agent REST request and WebSocket connection validates the bearer token against the stored hash
 - **Status checks**: Decommissioned and quarantined devices are rejected with 403
+
+When a device record exists in the database but has no token hash — the case for legacy devices enrolled before the v0.62 token-hash migration — the API returns a structured `{ code: "re_enrollment_required" }` signal on both the WebSocket auth path and HTTP 401 responses (`apps/api/src/middleware/agentAuth.ts`, `apps/api/src/routes/agentWs.ts`). The agent treats this as a non-fault terminal state: it stops retrying with the orphaned credential and prompts the operator to re-enroll the device, rather than silently failing in a reconnect loop or appearing healthy while unable to receive commands. This makes upgrade behavior explicit and auditable.
 
 ### Config File Permissions
 
@@ -239,15 +256,44 @@ Breeze includes policy-driven USB/peripheral controls for data-exfiltration resi
 
 ### Secret Encryption Details
 
-Secrets encrypted at rest use versioned formats:
+Breeze uses versioned, prefixed ciphertext formats so that the storage format is self-describing and rotation is a per-row operation, never a global re-encrypt-or-fail event.
 
-- Legacy: `enc:v1:{base64url(iv)}.{base64url(authTag)}.{base64url(ciphertext)}`
-- Keyring: `enc:v2:{keyId}:{base64url(iv)}.{base64url(authTag)}.{base64url(ciphertext)}`
+#### Application secrets — `enc:v1:` / `enc:v2:`
 
-- 12-byte random IV generated per encryption (never reused)
-- GCM authentication tag prevents tampering
-- `isEncryptedSecret()` check prevents double-encryption
-- Key hierarchy: dedicated `APP_ENCRYPTION_KEY` in production, optional `APP_ENCRYPTION_KEY_ID`/`APP_ENCRYPTION_KEYRING` for rotation, with fallback chain for development
+| Format | Purpose |
+|---|---|
+| `enc:v1:{base64url(iv)}.{base64url(authTag)}.{base64url(ciphertext)}` | Single-key AES-256-GCM under `APP_ENCRYPTION_KEY` |
+| `enc:v2:{keyId}:{base64url(iv)}.{base64url(authTag)}.{base64url(ciphertext)}` | Keyring-aware AES-256-GCM, key resolved from `APP_ENCRYPTION_KEYRING` JSON or the active `APP_ENCRYPTION_KEY_ID` |
+
+- AES-256-GCM with a fresh 12-byte random IV per operation (never reused)
+- GCM authentication tag rejects any tampered ciphertext on decrypt
+- `isEncryptedSecret()` guard prevents double-encryption when the same value is rewritten
+- Active key may carry an `APP_ENCRYPTION_KEY_ID` so future writes are tagged with `enc:v2:`; the keyring lets multiple key versions coexist while migration runs
+
+**Dual-decrypt fallback chain (v0.65.0).** Earlier versions of Breeze derived the secret-encryption key from `JWT_SECRET` (and at one point `SESSION_SECRET`). v0.65.0 made `APP_ENCRYPTION_KEY` mandatory in production but adds a read-only fallback chain so existing rows decrypt transparently after upgrade: a primary-key decrypt failure on an `enc:v1:` row triggers a retry against any `JWT_SECRET` / `SESSION_SECRET` values present in the environment. Successful fallback decryption emits a one-time `[secretCrypto] Decrypted enc:v1: row with legacy fallback key` warning so operators can run `scripts/re-encrypt-secrets.ts` to re-encrypt the row under the dedicated key. New writes always use the active `APP_ENCRYPTION_KEY` — the legacy keys are never used for encryption.
+
+#### MFA secrets — `mfa:v1:`
+
+TOTP shared secrets are encrypted under a dedicated key, isolated from the general application-secrets key:
+
+- Format: `mfa:v1:{base64url(iv)}.{base64url(authTag)}.{base64url(ciphertext)}`
+- Algorithm: AES-256-GCM with `MFA_ENCRYPTION_KEY` (SHA-256 derived)
+- Backwards-compatible read: rows still in the legacy `enc:v1:` format are decrypted via `decryptSecret()` and surfaced for in-place migration to `mfa:v1:` (`decryptMfaTotpSecretForMigration` returns both plaintext and a re-encrypted blob), so existing TOTP setups survive the upgrade without forcing every user to re-enroll MFA
+
+Isolating the MFA key means an exposure of `APP_ENCRYPTION_KEY` does not also expose every TOTP shared secret, and rotating one key does not require touching the other.
+
+#### Pepper system — enrollment keys & MFA recovery codes
+
+Enrollment keys and MFA recovery codes are SHA-256 hashed with a server-side pepper before storage, so a database snapshot alone cannot be brute-forced:
+
+- **Enrollment keys**: peppered with `ENROLLMENT_KEY_PEPPER` (`apps/api/src/services/enrollmentKeySecurity.ts`)
+- **MFA recovery codes**: peppered with `MFA_RECOVERY_CODE_PEPPER`
+
+Each pepper has a **primary + legacy fallback list**: new writes use the primary value, but lookups also try every legacy pepper in the candidate list (e.g. older deployments that derived the pepper from `APP_ENCRYPTION_KEY` / `JWT_SECRET` before dedicated peppers were required). This lets operators promote a fresh dedicated pepper to primary without invalidating any existing enrollment keys or recovery codes already in the database.
+
+#### Rotation
+
+Encryption-at-rest rotation procedures (key generation, keyring rollout, re-encryption batch jobs, and verification) are documented in [SECRET_ROTATION.md](SECRET_ROTATION.md).
 
 ---
 
@@ -273,6 +319,37 @@ Breeze uses Redis-backed sliding window rate limiting. The implementation is **f
 - **Atomicity**: `MULTI` pipeline for race-condition-free counting
 - **Auto-cleanup**: Keys expire after the window elapses
 - **Response**: Standard `X-RateLimit-*` headers and `429` with `Retry-After`
+
+### Abuse Controls
+
+Beyond per-endpoint rate limiting, v0.65.0 introduces platform-admin-only abuse controls and a hardened email-verification flow. The supporting schema lives in `apps/api/migrations/2026-05-04-anti-abuse-foundation.sql`.
+
+#### Partner suspension for abuse
+
+`POST /admin/partners/:id/suspend-for-abuse` — gated by `platformAdminMiddleware`, requires a written reason (≥10 chars) — performs a single transactional sweep that:
+
+1. Sets the partner's status to `suspended`
+2. Queues a `self_uninstall` command for every device under the partner (multi-row INSERT)
+3. Cancels any other pending or in-flight commands for those devices
+4. Deletes all sessions for users in the partner (excluding the calling platform admin if they happen to be a member, so the responder stays signed in)
+5. Disables every non-platform-admin user belonging to the partner
+6. Revokes every API key belonging to organizations under the partner
+7. Outside the transaction, blanket-revokes JWTs for every affected user via Redis (`revokeAllUserTokens`)
+
+Step 7 is **fail-closed**: if any Redis revocation rejects, the endpoint returns HTTP 500 with `tokenRevocationFailed: true` and a list of the failures, and the audit log is written with `result: 'failure'`. The DB-level suspend has already committed at that point, so the partner is suspended and devices are queued for uninstall — but the operator is loudly told that some existing JWTs may continue to authenticate until natural expiry, so they can flush Redis manually and re-run the call. An unsuspend endpoint (`POST /admin/partners/:id/unsuspend`) is provided for reversible cases; it preserves the activation gate (only flips to `active` if a payment method was attached, otherwise returns the partner to `pending`) and re-enables disabled users. Uninstalled devices are not auto-restored — re-enrollment is required.
+
+#### Email verification on signup
+
+New partner signups must verify their email address before the account is fully activated. Verification tokens have explicit terminal states beyond a binary used/unused flag:
+
+| State | Meaning | Returned to user |
+|---|---|---|
+| `consumed` | Token was previously redeemed successfully | `400 consumed` |
+| `superseded` | A newer verification email was issued; this token is dead-on-arrival | `400 superseded` |
+| `expired` | TTL elapsed before the user clicked | `400 expired` |
+| `invalid` | Token does not exist or fails structural validation | `400 invalid` |
+
+Distinguishing `superseded` from `consumed` matters: when a user clicks **Resend verification**, every still-open token for that user is marked `superseded` (`invalidateOpenTokens`) and a fresh one is issued. Old links stop working immediately, and clicking a stale email reports `superseded` rather than the misleading `consumed` — which would suggest the user (or someone else) had already verified via that link. The resend endpoint enforces a 1-per-minute debounce plus a 5-per-hour abuse cap per user.
 
 ---
 
@@ -348,6 +425,8 @@ Every security-relevant operation is recorded in the `audit_logs` table:
 | `userAgent` | Client identifier |
 | `details` | JSONB metadata (command type, exit codes, etc.) |
 | `errorMessage` | Failure reason (if applicable) |
+
+Client IPs in audit logs are derived via `getTrustedClientIp()`, which only honors `CF-Connecting-IP` / `X-Forwarded-For` / `X-Real-IP` headers when the immediate TCP peer matches a CIDR in `TRUSTED_PROXY_CIDRS`. Forwarded headers from untrusted hops are ignored entirely, and in production with proxy-header trust enabled but no CIDRs configured, the trust list defaults to loopback only — never silently honoring arbitrary upstreams. This makes audit IP attribution accurate even behind multi-layer proxies (Cloudflare → Caddy → API) and prevents a malicious client from spoofing forwarded headers to forge the recorded source IP.
 
 ### Retention
 
@@ -466,10 +545,15 @@ All scanners run in CI and **block merges** on failure.
 
 | Secret | Purpose | Minimum Strength |
 |---|---|---|
-| `JWT_SECRET` | Token signing | 32+ characters |
-| `APP_ENCRYPTION_KEY` | AES-256-GCM encryption | 32-byte hex |
-| `MFA_ENCRYPTION_KEY` | MFA secret encryption | 32-byte hex |
-| `AGENT_ENROLLMENT_SECRET` | Agent enrollment | 32-byte hex |
+| `JWT_SECRET` | Access/refresh token signing (HS256) | 32+ characters |
+| `SESSION_SECRET` | Session token signing | 32+ characters |
+| `APP_ENCRYPTION_KEY` | AES-256-GCM encryption for application secrets (`enc:v1:`/`enc:v2:`) | 32-byte hex |
+| `MFA_ENCRYPTION_KEY` | AES-256-GCM encryption for TOTP shared secrets (`mfa:v1:`) | 32-byte hex |
+| `ENROLLMENT_KEY_PEPPER` | Server-side pepper for SHA-256 enrollment-key hashes | 32+ characters |
+| `MFA_RECOVERY_CODE_PEPPER` | Server-side pepper for SHA-256 recovery-code hashes | 32+ characters |
+| `AGENT_ENROLLMENT_SECRET` | Shared secret presented at agent enrollment | 32-byte hex |
+| `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` | Base64 SPKI Ed25519 key(s) used to verify signed agent release manifests; **required when `BINARY_SOURCE=github` in production** — the API config validator refuses to boot without it | base64 SPKI |
+| `BREEZE_PLATFORM_ADMINS` | Optional. Comma-separated email allowlist applied on startup to bootstrap `users.is_platform_admin`. Without it, no user has cross-tenant admin access. | n/a |
 
 ### Production Enforcement
 
@@ -479,6 +563,16 @@ Breeze validates environment configuration on startup:
 - Requires explicit `CORS_ALLOWED_ORIGINS` (no wildcards)
 - Enforces minimum secret strength
 - Logs warnings for non-critical misconfigurations
+
+#### Migration / deprecation gates
+
+A small set of environment flags exist as one-release migration aids during cross-cutting hardening waves. Each flag has a forward-looking default; operators are expected to retire them within one release of upgrading.
+
+| Flag | Behavior | Status |
+|---|---|---|
+| `ENROLLMENT_SECRET_ENFORCEMENT_MODE` | When set to `warn`, the enrollment endpoint logs a warning instead of rejecting requests that lack a configured `AGENT_ENROLLMENT_SECRET` (or per-key secret). Default is `enforce`. Use only for the single release immediately following the upgrade, then remove. | Deprecation aid — to be removed after operators migrate |
+| `AUTOMATION_WEBHOOK_ALLOW_LEGACY_SECRET` | When `true` (current default), inbound automation webhooks may authenticate with the legacy shared-secret header instead of the new HMAC `x-breeze-signature` + `x-breeze-timestamp` scheme. Will default to `false` in the next release. | Senders must migrate to HMAC |
+| `SSO_EXCHANGE_RETURN_REFRESH_TOKEN` | When `true` (current default for one release), the SSO exchange endpoint returns a refresh token alongside the access token to keep existing integrations working. Set to `false` to opt out early. | Will be removed in a future release |
 
 ### Secret Rotation
 
@@ -503,8 +597,10 @@ The following are always hashed or encrypted before persistence:
 - Session tokens (SHA-256)
 - API keys (SHA-256)
 - Agent auth tokens (SHA-256)
-- Enrollment keys (SHA-256 with pepper)
-- MFA secrets (AES-256-GCM)
+- Enrollment keys (SHA-256 with `ENROLLMENT_KEY_PEPPER`)
+- MFA recovery codes (SHA-256 with `MFA_RECOVERY_CODE_PEPPER`)
+- MFA TOTP secrets (AES-256-GCM under `MFA_ENCRYPTION_KEY`, `mfa:v1:` format)
+- Application secrets — SSO client secrets, webhook signing keys, integration credentials (AES-256-GCM under `APP_ENCRYPTION_KEY`, `enc:v1:`/`enc:v2:` format)
 
 ---
 
@@ -630,6 +726,6 @@ Breeze's security controls align with SOC 2 Trust Service Criteria:
 
 ---
 
-*Last updated: February 2026*
+*Last updated: May 2026 (v0.65.0 cross-cutting hardening release)*
 
 *For questions about Breeze security practices, contact [security@lanternops.io](mailto:security@lanternops.io).*


### PR DESCRIPTION
## Summary

Follow-up to the prior root-cleanup PR. The original stash that got carried over from that work contained more than just the three doc edits — it also had a full set of file moves that hadn't been committed. This PR completes that pass.

- Moves root-level register, threat-model, and security-report markdown files into `docs/registers/`, `docs/threat-models/`, and `docs/security-reports/` (37 renames, all 100% similarity).
- Drops three orphaned scratch files at the root: `test-crud-buttons.py`, `test-crud-click.py`, `tmp_codex_test`.
- Refreshes `README.md` (Live Demos link, expanded feature lists, abuse-controls row), `docs/SECRET_ROTATION.md` (read-side legacy fallback chain doc for v0.65.0+), and `docs/SECURITY_PRACTICES.md` (forced-RLS notes, platform-admin section).
- Updates the one stale path reference in `docs/release-notes/security-hardening-template.md` (`security_reports/...` → `docs/security-reports/...`).

No code changes — markdown and file moves only. The previous PR's `Live Demos` README addition merged cleanly; the broader README content here is additive on top of it.

## Test plan

- [x] `git status` shows only renames + 3 modified docs + 1 template path update + 3 deletions of scratch files
- [x] Spot-checked rename targets vs. main HEAD content — all `MATCH` (pure renames)
- [x] `grep` for old paths across the repo returned only the one template reference, which is updated
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)