### PR TITLE
fix(api): require IS_HOSTED explicit in production (#570)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -400,7 +400,11 @@ MCP_OAUTH_ENABLED=false
 # Hosted SaaS (leave unset / false for self-hosted Breeze)
 # --------------------------------------------
 # Set to true on hosted deployments. Bypasses self-host gates (e.g. setup-admin
-# requirement on /auth/register) and enables billing redirect flows.
+# requirement on /auth/register) and enables billing redirect flows. Also gates
+# the email-verification → status='active' path in /auth/register-partner.
+# Required in production: must be explicitly set to true or false. The API
+# refuses to start if NODE_ENV=production and IS_HOSTED is unset, so a
+# misconfigured deploy can't silently bypass the verification gate (#570).
 IS_HOSTED=false
 # Hosted SaaS only — URL to breeze-billing's payment-setup landing page.
 # Empty on self-host (no billing service running).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,7 @@ Then `curl -sf https://<region>.2breeze.app/health` to verify (200 = healthy).
 **Required env vars added by v0.65+ — droplets without these refuse to start:**
 
 - `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` — base64 SPKI of the Ed25519 release manifest signing key. Source: `internal/release-keys/release-manifest.ed25519.pub` (the base64 between `-----BEGIN PUBLIC KEY-----` and `-----END PUBLIC KEY-----`, single line). The API config validator refuses to boot in production without it when `BINARY_SOURCE=github`.
+- `IS_HOSTED` — must be explicitly set to `true` (hosted SaaS) or `false` (self-hosted) in production. Without this, a misconfigured deploy (e.g. `.env` value not mapped through compose) silently drops new partners straight to `status='active'`, bypassing the email-verification gate in `/auth/register-partner` (issue #570).
 
 When introducing a new required env var: add it to `/opt/breeze/.env` AND map it explicitly in the `api`/`web` service `environment:` block of `/opt/breeze/docker-compose.yml`. Compose interpolation only happens for vars listed there — having a value in `.env` is necessary but not sufficient.
 

--- a/apps/api/src/config/validate.test.ts
+++ b/apps/api/src/config/validate.test.ts
@@ -35,6 +35,10 @@ const validEnv = {
   ENROLLMENT_KEY_PEPPER: 'prod-test-enrollment-pepper-32-chars-min-strong-random',
   MFA_RECOVERY_CODE_PEPPER: 'prod-test-mfa-recovery-pepper-32-chars-min-strong-random',
   RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: 'prod-test-release-manifest-public-key',
+  // Production-required (#570 defense-in-depth): explicit boolean keeps the
+  // many "production happy-path" tests below from tripping the new check.
+  // Tests that assert the missing/invalid IS_HOSTED throw override this.
+  IS_HOSTED: 'true',
 };
 
 describe('validateConfig', () => {
@@ -390,6 +394,57 @@ describe('validateConfig', () => {
     }, () => {
       const config = validateConfig();
       expect(config.TRUST_PROXY_HEADERS).toBe('false');
+    });
+  });
+
+  // #570 defense-in-depth: IS_HOSTED gates the email-verification path in
+  // register.ts. A misconfigured deploy (env not mapped through compose)
+  // would silently drop new partners to status='active' and skip the
+  // verify gate. Fail loud at startup instead.
+  it('throws when IS_HOSTED is missing in production', () => {
+    // Empty string ↔ unset for this check (`(data.IS_HOSTED ?? '').trim()`),
+    // so this also covers the unset case without depending on shell state.
+    withEnv({
+      ...validEnv,
+      NODE_ENV: 'production',
+      CORS_ALLOWED_ORIGINS: 'https://app.breeze.io',
+      TRUST_PROXY_HEADERS: 'true',
+      IS_HOSTED: '',
+    }, () => {
+      expect(() => validateConfig()).toThrow('IS_HOSTED');
+    });
+  });
+
+  it('throws when IS_HOSTED is set to a non-boolean string in production', () => {
+    withEnv({
+      ...validEnv,
+      NODE_ENV: 'production',
+      CORS_ALLOWED_ORIGINS: 'https://app.breeze.io',
+      TRUST_PROXY_HEADERS: 'true',
+      IS_HOSTED: 'maybe',
+    }, () => {
+      expect(() => validateConfig()).toThrow('IS_HOSTED');
+    });
+  });
+
+  it.each(['true', 'false', '1', '0', 'yes', 'no', 'on', 'off'])(
+    'accepts IS_HOSTED=%j in production',
+    (value) => {
+      withEnv({
+        ...validEnv,
+        NODE_ENV: 'production',
+        CORS_ALLOWED_ORIGINS: 'https://app.breeze.io',
+        TRUST_PROXY_HEADERS: 'true',
+        IS_HOSTED: value,
+      }, () => {
+        expect(() => validateConfig()).not.toThrow();
+      });
+    },
+  );
+
+  it('does not require IS_HOSTED outside production', () => {
+    withEnv({ ...validEnv, IS_HOSTED: '' }, () => {
+      expect(() => validateConfig()).not.toThrow();
     });
   });
 

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -340,6 +340,7 @@ const envSchema = z
     BINARY_SOURCE: z.string().optional(),
     RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: z.string().optional(),
     BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: z.string().optional(),
+    IS_HOSTED: z.string().optional(),
 
     // -- Optional with defaults -----------------------------------------------
     API_PORT: portSchema,
@@ -532,8 +533,8 @@ PARTNER_HOOKS_SECRET: z.string().min(16).optional(),
       }
 
       const trustProxyHeaders = (data.TRUST_PROXY_HEADERS ?? '').trim().toLowerCase();
-      const validTrustProxyValues = new Set(['true', 'false', '1', '0', 'yes', 'no', 'on', 'off']);
-      if (!validTrustProxyValues.has(trustProxyHeaders)) {
+      const validBoolValues = new Set(['true', 'false', '1', '0', 'yes', 'no', 'on', 'off']);
+      if (!validBoolValues.has(trustProxyHeaders)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['TRUST_PROXY_HEADERS'],
@@ -542,6 +543,20 @@ PARTNER_HOOKS_SECRET: z.string().min(16).optional(),
         });
       } else if (['true', '1', 'yes', 'on'].includes(trustProxyHeaders)) {
         validateTrustedProxyCidrsForProduction(data.TRUSTED_PROXY_CIDRS, ctx);
+      }
+
+      // IS_HOSTED gates the email-verification → status='active' path in
+      // register.ts. Unset/unmapped on a hosted droplet would silently
+      // drop new partners straight to 'active', bypassing the verify gate
+      // (issue #570). Self-hosted deploys must opt out explicitly.
+      const isHostedRaw = (data.IS_HOSTED ?? '').trim().toLowerCase();
+      if (!validBoolValues.has(isHostedRaw)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['IS_HOSTED'],
+          message:
+            'IS_HOSTED must be explicitly set in production to true/false (or 1/0, yes/no, on/off). Hosted SaaS deployments set true; self-hosted deployments set false.',
+        });
       }
     }
   });
@@ -661,6 +676,7 @@ export function validateConfig(): AppConfig {
     BINARY_SOURCE: env.BINARY_SOURCE,
     RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS,
     BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: env.BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS,
+    IS_HOSTED: env.IS_HOSTED,
     API_PORT: env.API_PORT,
     REDIS_URL: env.REDIS_URL,
     REDIS_HOST: env.REDIS_HOST,

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -113,6 +113,11 @@ services:
       BREEZE_VERSION: ${BREEZE_VERSION:?Set BREEZE_VERSION in .env}
       BINARY_SOURCE: github
       RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: ${RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS:?Set RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS in .env}
+      # Hosted SaaS gate (#570). This template is for hosted deploys, so
+      # IS_HOSTED is required-explicit — operators must set it in .env.
+      # Misconfiguration here silently drops new partners to status='active'
+      # and bypasses the email-verification flow.
+      IS_HOSTED: ${IS_HOSTED:?Set IS_HOSTED in .env (true for hosted SaaS, false for self-hosted)}
       AGENT_BINARY_DIR: /data/binaries/agent
       VIEWER_BINARY_DIR: /data/binaries/viewer
       HELPER_BINARY_DIR: /data/binaries/helper

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,6 +116,13 @@ services:
       BREEZE_VERSION: ${BREEZE_VERSION:?Set BREEZE_VERSION in .env}
       BINARY_SOURCE: ${BINARY_SOURCE:-github}
       RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: ${RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS:-}
+      # Hosted SaaS gate. Compose defaults to false so self-hosters upgrade
+      # without touching their .env. Hosted operators must set IS_HOSTED=true
+      # in .env so this interpolates to true. The API config validator (#570)
+      # refuses to start in production if the container env value is missing
+      # or non-boolean, so a hand-edited compose that drops this line still
+      # fails loud rather than silently bypassing the email-verification gate.
+      IS_HOSTED: ${IS_HOSTED:-false}
       AGENT_BINARY_DIR: /data/binaries/agent
       VIEWER_BINARY_DIR: /data/binaries/viewer
       HELPER_BINARY_DIR: /data/binaries/helper


### PR DESCRIPTION
## Summary

Defense-in-depth fix for the hosted-droplet misconfiguration that caused #570 — a paying partner reached `status='active'` with `email_verified_at = NULL` because `IS_HOSTED` wasn't mapped through compose's `environment:` block on the US droplet, so `register.ts:195` silently fell through to `status='active'` and bypassed the email-verification gate added in #567.

The verification flow itself is correct (consumeVerificationToken stamps `partners.email_verified_at` and auto-flips `pending → active` if payment is attached; breeze-billing also refuses to flip while `email_verified_at IS NULL`). The leak is exclusively the hosted-mode partner ever being created `status='active'` to begin with.

## What changed

- **`apps/api/src/config/validate.ts`** — when `NODE_ENV=production`, refuse to start unless `IS_HOSTED` is explicitly set to a recognized boolean (`true`/`false`/`1`/`0`/`yes`/`no`/`on`/`off`). Mirrors the existing `TRUST_PROXY_HEADERS` pattern; renamed local `validTrustProxyValues` → `validBoolValues` since both checks share it.
- **`docker-compose.yml`** — added `IS_HOSTED: ${IS_HOSTED:-false}` to the api service. Self-hosters upgrade with **zero action**; hosted operators who already set `IS_HOSTED=true` in `.env` still work via compose interpolation.
- **`deploy/docker-compose.prod.yml`** — required-explicit (`:?`) so a hosted operator cloning this template can't accidentally end up with `false`. Matches how the file treats `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS`.
- **`apps/api/src/config/validate.test.ts`** — added 4 tests (missing throws, non-boolean throws, table-driven happy-path for all 8 valid forms, dev-mode skip). Existing 54 tests still pass — added `IS_HOSTED: 'true'` to shared `validEnv`.
- **`.env.example` + `CLAUDE.md`** — documented the production-required behavior and the underlying failure mode.

## Self-hoster impact

**No upgrade action required.** Compose defaults `IS_HOSTED` to `false`, which is the correct value for self-hosters, so existing self-host deploys continue working without touching `.env`. The validator only fires if someone hand-edits compose to drop the `IS_HOSTED` line entirely — i.e. exactly the hosted-droplet drift that caused #570.

## Operational follow-ups (not in this PR)

- [ ] Audit `IS_HOSTED` is actually mapped through the api service's `environment:` block in `/opt/breeze/docker-compose.yml` on US and EU droplets.
- [ ] Spot-check production `partners` for other recent `(status=active, email_verified_at=NULL)` rows on hosted to size the bug.
- [ ] For the affected partner `8b5d7ff2-…`, decide between backfill (`email_verified_at = payment_method_attached_at`) and re-verify (send fresh link).

## Test plan

- [x] `npx vitest run src/config/validate.test.ts` — 58/58 pass
- [x] `npx vitest run src/routes/auth/register.test.ts src/config/env.test.ts` — 26/26 pass
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [ ] CI smoke + RLS-coverage jobs green
- [ ] Self-host deploy of this branch boots with no `IS_HOSTED` set in `.env` (compose default applies)
- [ ] Hosted deploy of this branch with `IS_HOSTED=true` in `.env` boots; with `IS_HOSTED` unmapped from compose, refuses to start with the new error message

Refs #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)