### PR TITLE
chore(security): codify Watchtower app-image policy (#603)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,4 +219,6 @@ Then `curl -sf https://<region>.2breeze.app/health` to verify (200 = healthy).
 
 When introducing a new required env var: add it to `/opt/breeze/.env` AND map it explicitly in the `api`/`web` service `environment:` block of `/opt/breeze/docker-compose.yml`. Compose interpolation only happens for vars listed there — having a value in `.env` is necessary but not sufficient.
 
-**Known drift:** the deployed `/opt/breeze/docker-compose.yml` uses Watchtower + mutable tags, while `deploy/docker-compose.prod.yml` in the repo uses digest-pinning + no Watchtower. The `check-supply-chain-hardening.sh` rule scans repo files only, so the droplet drift isn't enforced. Reconciling this is tracked separately.
+**Watchtower policy (#603):** repo-tracked compose files never include Watchtower (enforced by `check-supply-chain-hardening.sh`). On droplets, Watchtower is acceptable for sidecars (caddy, redis, postgres-exporter, cloudflared) but **must not** auto-update `breeze-api` or `breeze-web`. Concretely, the `com.centurylinklabs.watchtower.enable: "true"` label is forbidden on those two services. The hardening check additionally rejects that label string in any tracked compose file as defense-in-depth.
+
+**Known drift:** the deployed `/opt/breeze/docker-compose.yml` uses Watchtower + mutable tags, while `deploy/docker-compose.prod.yml` in the repo uses digest-pinning + no Watchtower. The `check-supply-chain-hardening.sh` rule scans repo files only, so the droplet drift isn't fully enforced. Reconciling this is tracked separately.

--- a/scripts/security/check-supply-chain-hardening.sh
+++ b/scripts/security/check-supply-chain-hardening.sh
@@ -166,6 +166,11 @@ for compose in docker-compose.yml deploy/docker-compose.prod.yml; do
     "$compose must not mount the raw Docker socket"
   reject_grep 'watchtower' "$compose" \
     "$compose must not include Watchtower by default"
+  # Defense-in-depth: even without the Watchtower service present, an
+  # auto-update opt-in label on a tracked compose file would re-introduce
+  # the supply-chain risk the broader rule above forbids (#603).
+  reject_grep 'com\.centurylinklabs\.watchtower\.enable[[:space:]]*[:=][[:space:]]*"?(true|1|yes)"?' "$compose" \
+    "$compose must not declare Watchtower auto-update opt-in labels (com.centurylinklabs.watchtower.enable=true) on any service"
   reject_grep '--requirepass[[:space:]]+\$\{?REDIS_PASSWORD' "$compose" \
     "$compose must not expose REDIS_PASSWORD in redis-server command args"
   reject_grep 'REDISCLI_AUTH' "$compose" \


### PR DESCRIPTION
## Summary

Codifies the Option B reconciliation path from #603 in the repo. Operational drop-the-labels work on US/EU droplets is still required (separate, out of this PR).

- `scripts/security/check-supply-chain-hardening.sh`: defense-in-depth rule rejecting `com.centurylinklabs.watchtower.enable=true` labels in any tracked compose file. The existing broad `watchtower` reject already catches this as a substring; the additional rule expresses intent explicitly so future readers see the policy without having to infer it.
- `CLAUDE.md`: explicit Watchtower policy paragraph in the production deploy section. Repo compose stays Watchtower-free; droplet compose may use Watchtower for sidecars only (caddy/redis/postgres-exporter/cloudflared), and must never auto-update `breeze-api` or `breeze-web`.

## Operational follow-ups (not in this PR)

Drop the `com.centurylinklabs.watchtower.enable: "true"` labels from the `breeze-api` and `breeze-web` service blocks in `/opt/breeze/docker-compose.yml` on both US and EU droplets, then `docker compose up -d` to re-create the containers without the label. Verify with `docker inspect breeze-api --format '{{ index .Config.Labels \"com.centurylinklabs.watchtower.enable\" }}'` returning empty.

## Test plan

- [x] `scripts/security/check-supply-chain-hardening.sh` passes locally with the new rule
- [ ] CI security checks green
- [ ] Manual: confirm a deliberately-malformed branch with the bad label added to `docker-compose.yml` fails the new rule (will spot-check in CI on a throwaway test branch if reviewers want)

Refs #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)