### PR TITLE
fix(api,agent): persist software_install result to deployment_results (#631)

### DIFF
--- a/agent/internal/remote/tools/software_install.go
+++ b/agent/internal/remote/tools/software_install.go
@@ -27,8 +27,13 @@ var checksumHexPattern = regexp.MustCompile(`^[a-fA-F0-9]{64}$`)
 
 // InstallSoftware downloads a package from a presigned URL, verifies its checksum,
 // and executes it with the provided silent install arguments.
-func InstallSoftware(payload map[string]any) CommandResult {
+func InstallSoftware(payload map[string]any) (result CommandResult) {
 	startTime := time.Now()
+	// Stamp StartedAt on every return path so the server can record the
+	// real start instead of reconstructing it from durationMs.
+	defer func() {
+		result.StartedAt = startTime.UTC().Format(time.RFC3339Nano)
+	}()
 
 	downloadUrl, errResult := RequirePayloadString(payload, "downloadUrl")
 	if errResult != nil {
@@ -94,7 +99,7 @@ func InstallSoftware(payload map[string]any) CommandResult {
 		return result
 	}
 
-	result := map[string]any{
+	successPayload := map[string]any{
 		"softwareName": softwareName,
 		"version":      version,
 		"fileType":     fileType,
@@ -104,9 +109,9 @@ func InstallSoftware(payload map[string]any) CommandResult {
 		"success":      true,
 	}
 	if outputTruncated {
-		result["outputTruncated"] = true
+		successPayload["outputTruncated"] = true
 	}
-	return NewSuccessResult(result, time.Since(startTime).Milliseconds())
+	return NewSuccessResult(successPayload, time.Since(startTime).Milliseconds())
 }
 
 func validateInstallInputs(fileName, fileType, checksum, silentInstallArgs, softwareName, version string) (string, string, string, string, string, string, error) {

--- a/agent/internal/remote/tools/types.go
+++ b/agent/internal/remote/tools/types.go
@@ -214,6 +214,10 @@ type CommandResult struct {
 	Stderr     string `json:"stderr,omitempty"`
 	Error      string `json:"error,omitempty"`
 	DurationMs int64  `json:"durationMs,omitempty"`
+	// RFC3339Nano timestamp captured by the agent at the moment the command's
+	// primary work began. Set by command handlers that care about the server-
+	// side reconstruction (e.g. software_install). Empty when not applicable.
+	StartedAt string `json:"startedAt,omitempty"`
 }
 
 // NewSuccessResult creates a successful command result with data

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -553,6 +553,10 @@ const commandResultSchema = z.object({
   stdout: z.string().max(5_000_000).optional(),
   stderr: z.string().max(5_000_000).optional(),
   durationMs: z.number().int().optional(),
+  // RFC3339 timestamp captured by the agent at the moment the command's
+  // primary work began. Optional for back-compat with pre-startedAt agents,
+  // which the server falls back to reconstructing from durationMs.
+  startedAt: z.string().datetime().optional(),
   error: z.string().max(10_000).optional(),
   result: z.any().optional().refine(
     (val) => {

--- a/apps/api/src/routes/agents/commands.ts
+++ b/apps/api/src/routes/agents/commands.ts
@@ -3,7 +3,7 @@ import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { and, eq, inArray } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
-import { deviceCommands } from '../../db/schema';
+import { deviceCommands, deploymentResults } from '../../db/schema';
 import type { AgentAuthContext } from '../../middleware/agentAuth';
 import { writeAuditEvent } from '../../services/auditEvents';
 import {
@@ -150,6 +150,46 @@ commandsRoutes.post(
     // Commands dispatched directly over WebSocket can use non-UUID IDs and
     // intentionally have no device_commands row.
     if (!uuidRegex.test(commandId)) {
+      // Software install commands carry their tracking IDs in the commandId
+      // itself: `sw-install-<deploymentUuid>-<deviceUuid>`. Persist the
+      // outcome to deployment_results so the dashboard reflects reality.
+      const swInstallMatch = commandId.match(
+        /^sw-install-([0-9a-f-]{36})-([0-9a-f-]{36})$/i,
+      );
+      if (swInstallMatch) {
+        const [, deploymentIdFromCmd, deviceIdFromCmd] = swInstallMatch;
+        if (deploymentIdFromCmd && deviceIdFromCmd && deviceIdFromCmd === deviceId) {
+          const drStatus =
+            data.status === 'completed'
+              ? data.exitCode && data.exitCode !== 0
+                ? 'failed'
+                : 'completed'
+              : 'failed';
+          const completedAt = new Date();
+          // Prefer agent-reported startedAt (post-#631); fall back to
+          // reconstructing from durationMs for older agents that don't carry it.
+          const startedAt = data.startedAt
+            ? new Date(data.startedAt)
+            : data.durationMs
+              ? new Date(completedAt.getTime() - data.durationMs)
+              : completedAt;
+          await db
+            .update(deploymentResults)
+            .set({
+              status: drStatus,
+              startedAt,
+              completedAt,
+              exitCode: data.exitCode ?? null,
+              output: data.stdout ?? null,
+              errorMessage: data.error ?? data.stderr ?? null,
+            })
+            .where(and(
+              eq(deploymentResults.deploymentId, deploymentIdFromCmd),
+              eq(deploymentResults.deviceId, deviceId),
+              eq(deploymentResults.status, 'pending'),
+            ));
+        }
+      }
       return c.json({ success: true });
     }
 

--- a/apps/api/src/routes/agents/schemas.ts
+++ b/apps/api/src/routes/agents/schemas.ts
@@ -178,6 +178,10 @@ export const commandResultSchema = z.object({
   stdout: z.string().max(5_000_000).optional(),
   stderr: z.string().max(5_000_000).optional(),
   durationMs: z.number().int().optional(),
+  // RFC3339 timestamp captured by the agent at the moment the command's
+  // primary work began. Optional for back-compat with pre-startedAt agents,
+  // which the server falls back to reconstructing from durationMs.
+  startedAt: z.string().datetime().optional(),
   error: z.string().max(10_000).optional(),
   result: z.any().optional().refine(
     (val) => {


### PR DESCRIPTION
Closes #631.

## What

Software install commands are issued in `routes/software.ts` with a custom non-UUID command id of the form `sw-install-<deploymentUuid>-<deviceUuid>`. These don't go through `queueCommandForExecution` and have no `device_commands` row, so the agent result handler at `routes/agents/commands.ts:152` short-circuits at the `uuidRegex` check and returns `200 OK` without doing anything. `deployment_results` stays `status='pending'` indefinitely even though the install succeeded on the device, so the dashboard's deployment list shows every install in-progress forever.

## Fix (Option A from the issue)

Add a `software_install` branch **before** the `uuidRegex` short-circuit in `routes/agents/commands.ts:152`:

- Parse `deploymentId` and `deviceId` out of the command id with `/^sw-install-([0-9a-f-]{36})-([0-9a-f-]{36})$/i`
- Validate `deviceIdFromCmd === deviceId` (the requesting agent)
- `UPDATE deployment_results SET status, startedAt, completedAt, exitCode, output, errorMessage WHERE deploymentId = ? AND deviceId = ? AND status = 'pending'`
- The `status = 'pending'` predicate makes a duplicate result a no-op

## startedAt design (per your note)

Rather than reconstructing `startedAt` from `durationMs`, this PR adds `startedAt: string` to the agent's `CommandResult` schema, as you suggested. Backwards-compatible: the server prefers `data.startedAt` and falls back to `completedAt - durationMs` reconstruction for older agents that don't carry it.

- `packages/shared`-style schema additions: both `agentWs.ts:548` and `agents/schemas.ts:175` accept `startedAt: z.string().datetime().optional()`
- `agent/internal/remote/tools/types.go:210` — `CommandResult` struct gets `StartedAt string \`json:\"startedAt,omitempty\"\``
- `agent/internal/remote/tools/software_install.go:30` — `InstallSoftware` switches to a named return + `defer` so every return path stamps `StartedAt = startTime.UTC().Format(time.RFC3339Nano)` once, no per-branch boilerplate
- `routes/agents/commands.ts:168-174` — `data.startedAt ? new Date(data.startedAt) : (data.durationMs ? new Date(completedAt.getTime() - data.durationMs) : completedAt)`

This PR ships **Option A only** (immediate-feedback synchronous result handler). Option B (the inventory-driven reconciliation backstop for the agent-crashed-mid-install case) is a clean follow-up — happy to file as a separate PR if interest.

## Verification

Verified empirically against v0.65.8: prior to this patch, two successful WinDirStat installs (WTstSrv01 and Trevor-NUC) showed `deployment_results.status='pending'` indefinitely. With this patch applied, status flips to `'completed'` and exitCode/output/startedAt land within seconds. Local `tsc --noEmit` and `go build ./...` both clean.