### PR TITLE
fix(web): software inventory Actions dropdown clipped on single-result lists (#632)

### DIFF
--- a/apps/web/src/components/software/SoftwareInventory.tsx
+++ b/apps/web/src/components/software/SoftwareInventory.tsx
@@ -324,7 +324,11 @@ export default function SoftwareInventory({ onSwitchToPolicies }: SoftwareInvent
                           </button>
                           {actionMenu?.name === row.name && (
                             <div
-                              className="absolute right-0 top-9 z-10 w-44 rounded-md border bg-card shadow-lg"
+                              className="fixed z-50 w-44 rounded-md border bg-card shadow-lg"
+                              style={{
+                                left: `${Math.min(actionMenu.x - 160, window.innerWidth - 192)}px`,
+                                top: `${actionMenu.y + 8}px`,
+                              }}
                               onClick={(e) => e.stopPropagation()}
                             >
                               <button


### PR DESCRIPTION
Closes #632.

## Repro

1. Software → Software Policies → Inventory tab.
2. Search for a software name that returns exactly one row.
3. Click that row's Actions button.
4. **Expected**: Approve / Deny / Create Policy menu appears.
5. **Actual**: button toggles its open state but the dropdown is invisible (clipped by the table's overflow container).

Workaround users discover: type a partial term so multiple rows return.

## Cause

`apps/web/src/components/software/SoftwareInventory.tsx:325-377` rendered the dropdown with `position: absolute` inside the table's `overflow-x-auto` wrapper. With a single-row tbody, the wrapper is short enough that the absolutely-positioned popup extends past its bottom edge and gets clipped. Multi-row searches happen to look fine because the table grows tall enough to contain the popup before it hits the wrapper bottom.

The component already records the click coordinates with `setActionMenu({ x: e.clientX, y: e.clientY })` at line 317 — but those values were never read by the render. Per your #632 comment: "looks like the original author started down the fixed-positioning path and didn't finish."

## Fix

Switch the dropdown from `absolute right-0 top-9` to `position: fixed` using the existing `actionMenu.x/y`. With `fixed`, the popup escapes the table's overflow container and renders relative to the viewport.

```diff
   {actionMenu?.name === row.name && (
     <div
-      className="absolute right-0 top-9 z-10 w-44 rounded-md border bg-card shadow-lg"
+      className="fixed z-50 w-44 rounded-md border bg-card shadow-lg"
+      style={{
+        left: `${Math.min(actionMenu.x - 160, window.innerWidth - 192)}px`,
+        top: `${actionMenu.y + 8}px`,
+      }}
       onClick={(e) => e.stopPropagation()}
     >
```

The `Math.min` clamp keeps the popup on-screen for clicks near the right edge of the viewport. `192` matches the popup width (`w-44` = 11rem = 176px) plus a small margin.

The portal alternative (`ReactDOM.createPortal(..., document.body)`) is also valid but, as you noted, "isn't worth the extra surface area for a single dropdown."

## Verified

Applied against v0.65.8 and tested with the same single-row repro — dropdown now visible and clickable on single-row searches. Multi-row case continues to work.