### PR TITLE
fix(api,agent): hosted-SaaS auto-update host-mismatch (closes #646)

### DIFF
--- a/.github/workflows/ci-smoke-binary-source-github.yml
+++ b/.github/workflows/ci-smoke-binary-source-github.yml
@@ -75,6 +75,9 @@ jobs:
 
       - name: Boot API in BINARY_SOURCE=github mode
         env:
+          # Authenticate binarySync's github API call so we don't hit the
+          # 60/hour unauthenticated rate limit on the shared CI runner IP.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BINARY_SOURCE: github
           # Use the most recent published release whose manifest format is
           # known to be compatible with the current API code. Bump this when

--- a/.github/workflows/ci-smoke-binary-source-github.yml
+++ b/.github/workflows/ci-smoke-binary-source-github.yml
@@ -169,8 +169,12 @@ jobs:
           LOCATION=$(curl -s -o /dev/null -w '%{redirect_url}' \
             'http://localhost:3001/api/v1/agents/download/linux/amd64')
           echo "Redirect target: ${LOCATION}"
+          # GitHub returns the org slug lowercased in 302 Location headers
+          # even though the canonical case is "LanternOps". Compare case-
+          # insensitively to be robust against either form.
+          shopt -s nocasematch
           case "$LOCATION" in
-            https://github.com/LanternOps/breeze/releases/download/*)
+            https://github.com/lanternops/breeze/releases/download/*)
               echo "OK — redirect points at github releases"
               ;;
             *)
@@ -178,6 +182,7 @@ jobs:
               exit 1
               ;;
           esac
+          shopt -u nocasematch
 
       - name: Stop API
         if: always()

--- a/.github/workflows/ci-smoke-binary-source-github.yml
+++ b/.github/workflows/ci-smoke-binary-source-github.yml
@@ -1,0 +1,187 @@
+name: smoke-binary-source-github
+
+# Verifies that the BINARY_SOURCE=github auto-update path stays end-to-end
+# functional. #646 (v0.65.9 → v0.65.10) shipped without this CI smoke job in
+# place and the hosted-SaaS deploy of v0.65.9 surfaced an agent-rejected
+# download URL only after the prod rollout. This job exercises the same
+# path on every PR that touches the relevant code so the regression class
+# fails CI instead of the fleet.
+#
+# What it asserts:
+#   - API boots cleanly in BINARY_SOURCE=github mode with a published
+#     release tag.
+#   - GET /agent-versions/<version>/download returns 200 with a
+#     SERVER-RELATIVE url (matching PUBLIC_API_URL host), NOT the
+#     canonical github.com URL. That's the #646 fix and the regression
+#     would re-introduce auto-update breakage on hosted SaaS.
+
+on:
+  pull_request:
+    paths:
+      - "apps/api/src/services/binarySync.ts"
+      - "apps/api/src/services/releaseArtifactManifest.ts"
+      - "apps/api/src/routes/agentVersions.ts"
+      - "apps/api/src/routes/agents/download.ts"
+      - "apps/api/src/services/binarySource.ts"
+      - "apps/api/migrations/**"
+      - ".github/workflows/ci-smoke-binary-source-github.yml"
+  push:
+    branches: [main]
+
+jobs:
+  smoke:
+    name: BINARY_SOURCE=github download path
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: breeze
+          POSTGRES_PASSWORD: breeze
+          POSTGRES_DB: breeze
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U breeze"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build API
+        run: pnpm --filter=@breeze/api build
+
+      - name: Boot API in BINARY_SOURCE=github mode
+        env:
+          BINARY_SOURCE: github
+          # Use the most recent published release whose manifest format is
+          # known to be compatible with the current API code. Bump this when
+          # cutting a new release if the manifest schema changes.
+          BREEZE_VERSION: "0.65.8"
+          DATABASE_URL: postgres://breeze:breeze@localhost:5432/breeze
+          DATABASE_URL_APP: postgres://breeze_app:breeze@localhost:5432/breeze
+          BREEZE_APP_DB_PASSWORD: breeze
+          POSTGRES_PASSWORD: breeze
+          REDIS_URL: redis://localhost:6379
+          NODE_ENV: production
+          PUBLIC_APP_URL: http://localhost:3001
+          # PUBLIC_API_URL drives the server-relative URL rewrite in
+          # getServerOriginForDownloadResponse — the actual thing #646 fixes.
+          PUBLIC_API_URL: http://localhost:3001
+          # Production-strict env that the API requires at boot post-#568.
+          JWT_SECRET: ci-smoke-bsg-k7x9Qm4pR2vL8nW5jT3yF6hB0cA1dE4gI7
+          APP_ENCRYPTION_KEY: e9367714341ea19491ff7cd095d1a97e15ae3f7962416723ecfb29a89ed71eb9
+          MFA_ENCRYPTION_KEY: e86f8b88f2c058d428de55c4abec1b50a3cd960a7205dffdb65be8130abbb777
+          ENROLLMENT_KEY_PEPPER: ci-smoke-bsg-enrollment-pepper-Hy4Bz9Mp2Wq6Tv0Lk3
+          MFA_RECOVERY_CODE_PEPPER: ci-smoke-bsg-mfa-recovery-pepper-Nq8Zx2Vm5Tr9Lp1
+          AGENT_ENROLLMENT_SECRET: ci-smoke-bsg-agent-enrollment-Hy4Bz9Mp2Wq6Tv0Lk3
+          ENROLLMENT_SECRET_ENFORCEMENT_MODE: warn
+          IS_HOSTED: "false"
+          TRUSTED_PROXY_CIDRS: 127.0.0.1/32
+          CORS_ALLOWED_ORIGINS: http://localhost:3001
+          TRUST_PROXY_HEADERS: "false"
+          BREEZE_BOOTSTRAP_ADMIN_EMAIL: smoke-admin@example.test
+          BREEZE_BOOTSTRAP_ADMIN_PASSWORD: ci-smoke-bsg-bootstrap-admin-Hy4Bz9Mp2Wq6Tv0Lk3
+          # Production LanternOps trust root for release manifest signatures.
+          # This is the public half of the keypair the release workflow signs
+          # with; it's safe to commit (public keys are not secret).
+          RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: "yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso="
+        run: |
+          pnpm --filter=@breeze/api start &
+          API_PID=$!
+          echo "Waiting for /health/ready..."
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:3001/health/ready >/dev/null 2>&1; then
+              echo "API healthy after ${i} polls."
+              break
+            fi
+            if ! kill -0 "$API_PID" 2>/dev/null; then
+              echo "API process exited before becoming healthy."
+              exit 1
+            fi
+            sleep 2
+          done
+          curl -sf http://localhost:3001/health/ready || { echo "API never became healthy"; kill "$API_PID" 2>/dev/null; exit 1; }
+          echo "API_PID=$API_PID" >> "$GITHUB_ENV"
+
+      - name: Verify download endpoint returns 200 with server-relative URL (#646 regression check)
+        run: |
+          STATUS=$(curl -s -o /tmp/dl.json -w '%{http_code}' \
+            'http://localhost:3001/api/v1/agent-versions/0.65.8/download?platform=linux&arch=amd64&component=agent')
+          echo "Download endpoint returned: ${STATUS}"
+          cat /tmp/dl.json | jq . || cat /tmp/dl.json
+          if [ "$STATUS" != "200" ]; then
+            echo "Expected 200 — github-mode download endpoint should serve published manifests."
+            exit 1
+          fi
+
+          # The whole point of #646: the URL handed to the agent must be on
+          # our own origin, NOT github.com. Without this, the agent's
+          # downloadFromURL host check rejects with "download URL host
+          # \"github.com\" does not match server".
+          url=$(jq -er '.url' /tmp/dl.json)
+          echo "downloadUrl returned: ${url}"
+          case "$url" in
+            http://localhost:3001/api/v1/agents/download/*)
+              echo "OK — server-relative download URL"
+              ;;
+            *)
+              echo "REGRESSION (#646): expected a server-relative URL under http://localhost:3001/api/v1/agents/download/, got: ${url}"
+              exit 1
+              ;;
+          esac
+
+          # Manifest + signature should still be present (signed by the
+          # LanternOps trust root via GitHub release artifacts).
+          jq -e '.manifest != null and (.manifest | length) > 0' /tmp/dl.json
+          jq -e '.manifestSignature != null and (.manifestSignature | length) > 0' /tmp/dl.json
+
+      - name: Verify /agents/download proxy route 302s to github
+        run: |
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
+            'http://localhost:3001/api/v1/agents/download/linux/amd64')
+          if [ "$STATUS" != "302" ]; then
+            echo "Expected 302 redirect from /agents/download/:os/:arch in github mode; got ${STATUS}"
+            exit 1
+          fi
+          LOCATION=$(curl -s -o /dev/null -w '%{redirect_url}' \
+            'http://localhost:3001/api/v1/agents/download/linux/amd64')
+          echo "Redirect target: ${LOCATION}"
+          case "$LOCATION" in
+            https://github.com/LanternOps/breeze/releases/download/*)
+              echo "OK — redirect points at github releases"
+              ;;
+            *)
+              echo "Expected redirect to github.com/LanternOps/breeze/releases/...; got ${LOCATION}"
+              exit 1
+              ;;
+          esac
+
+      - name: Stop API
+        if: always()
+        run: |
+          if [ -n "${API_PID:-}" ]; then
+            kill "$API_PID" 2>/dev/null || true
+          fi

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -400,7 +400,13 @@ func (u *Updater) verifyUpdateManifest(info downloadInfo, version string) (updat
 	if manifest.Arch != runtime.GOARCH {
 		return updateManifest{}, fmt.Errorf("update manifest architecture mismatch: expected %s, got %s", runtime.GOARCH, manifest.Arch)
 	}
-	if manifest.URL != info.URL || manifest.Checksum != info.Checksum {
+	// The checksum equality below is the trust binding — it ties the
+	// signed manifest to the bytes the server is offering. We deliberately
+	// do NOT require manifest.URL == info.URL: the signed URL is canonical
+	// (e.g. github.com release artifact) while info.URL may be a server-
+	// relative proxy URL the API uses to keep the download flow inside the
+	// agent's trusted origin (see downloadFromURL host check). Issue #646.
+	if manifest.Checksum != info.Checksum {
 		return updateManifest{}, fmt.Errorf("update manifest does not match download metadata")
 	}
 	if len(manifest.Checksum) != 64 {
@@ -428,14 +434,25 @@ func (u *Updater) verifyReleaseArtifactManifest(payload []byte, info downloadInf
 		return updateManifest{}, fmt.Errorf("release artifact manifest version mismatch: expected %s, got %s", version, manifest.Release)
 	}
 
-	assetName, err := assetNameFromURL(info.URL)
-	if err != nil {
-		return updateManifest{}, fmt.Errorf("invalid release artifact download URL: %w", err)
+	// Asset name is derived from the agent's own platform/arch/component
+	// rather than parsed from info.URL — the URL may be a server-relative
+	// proxy (e.g. https://breeze.example.com/api/v1/agents/download/...)
+	// whose last segment is not the asset filename. The signed manifest's
+	// asset list still uses canonical names like "breeze-agent-windows-amd64.exe".
+	// Issue #646.
+	expected := u.expectedReleaseAssetNames()
+	if len(expected) == 0 {
+		return updateManifest{}, fmt.Errorf("no expected release asset names configured for component %q", u.component())
 	}
-	if expected := u.expectedReleaseAssetNames(); len(expected) > 0 {
-		if _, ok := expected[assetName]; !ok {
-			return updateManifest{}, fmt.Errorf("release artifact manifest asset mismatch: expected %v, got %s", expected, assetName)
-		}
+	if len(expected) != 1 {
+		// Defensive: expectedReleaseAssetNames always returns exactly one
+		// entry per (platform, arch, component) tuple. Surface this clearly
+		// if a future change adds ambiguity rather than silently picking one.
+		return updateManifest{}, fmt.Errorf("ambiguous expected asset names for component %q: %v", u.component(), expected)
+	}
+	var assetName string
+	for name := range expected {
+		assetName = name
 	}
 
 	var selected *releaseArtifactAsset

--- a/agent/internal/updater/updater_test.go
+++ b/agent/internal/updater/updater_test.go
@@ -517,6 +517,65 @@ func TestDownloadBinaryAcceptsSignedReleaseArtifactManifest(t *testing.T) {
 	}
 }
 
+// Regression for #646: the agent must accept a server-relative info.URL even
+// when the signed manifest references the canonical github.com asset URL.
+// Binary trust is bound by checksum (verified against the signed assets list),
+// not by URL string equality.
+func TestDownloadBinaryAcceptsServerRelativeUrlWithMatchingChecksum(t *testing.T) {
+	binaryContent := []byte("fake binary v1.0.0 served via server-relative proxy")
+	suffix := ""
+	if runtime.GOOS == "windows" {
+		suffix = ".exe"
+	}
+	assetName := "breeze-agent-" + runtime.GOOS + "-" + runtime.GOARCH + suffix
+
+	// Signed manifest references the canonical github URL; the API hands back
+	// a server-relative URL pointing at its own proxy route.
+	canonicalAssetURL := "https://github.com/LanternOps/breeze/releases/download/v1.0.0/" + assetName
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/agent-versions/1.0.0/download":
+			signed := signedReleaseArtifactDownloadInfo(t, "1.0.0", assetName, canonicalAssetURL, binaryContent)
+			// Override the URL handed to the agent: server-relative proxy
+			// path, NOT the canonical (cross-origin) URL signed into the
+			// manifest. Manifest signature stays intact; manifest's Assets[]
+			// list still names the asset canonically.
+			signed.URL = "http://" + r.Host + "/api/v1/agents/download/" + runtime.GOOS + "/" + runtime.GOARCH
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(signed)
+		case r.URL.Path == "/api/v1/agents/download/"+runtime.GOOS+"/"+runtime.GOARCH:
+			// Stand-in for the existing /agents/download route which 302s to
+			// github in BINARY_SOURCE=github mode. For the test we just stream
+			// the bytes directly.
+			w.Write(binaryContent)
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	u := New(&Config{
+		ServerURL: server.URL,
+		AuthToken: secmem.NewSecureString("test-token"),
+	})
+	u.client = server.Client()
+
+	tempPath, manifest, err := u.downloadBinary("1.0.0")
+	if err != nil {
+		t.Fatalf("server-relative URL with matching checksum should be accepted: %v", err)
+	}
+	defer os.Remove(tempPath)
+	if manifest.Checksum == "" {
+		t.Fatal("expected manifest checksum to be returned")
+	}
+	downloaded, _ := os.ReadFile(tempPath)
+	if string(downloaded) != string(binaryContent) {
+		t.Fatalf("downloaded content mismatch")
+	}
+}
+
 func TestDownloadBinaryRejectsWrongSignedReleaseArtifact(t *testing.T) {
 	binaryContent := []byte("fake helper artifact")
 

--- a/apps/api/scripts/recover-stuck-agents.lib.ts
+++ b/apps/api/scripts/recover-stuck-agents.lib.ts
@@ -20,6 +20,13 @@ import { normalizeAgentArchitecture } from '../src/routes/agents/helpers';
 //   build-time key. v0.65.9 agents pin the per-deployment pubkey via
 //   heartbeat/enrollment and recover from there.
 //
+//   0.65.9: enforces manifest.URL == info.URL in updater.go (the older
+//   check relaxed by #646 in v0.65.10). On hosted-SaaS BINARY_SOURCE=github
+//   servers, the API now hands out a server-relative download URL so the
+//   agent's host check passes — but the signed manifest still carries the
+//   canonical github.com URL, so the equality check fails on 0.65.9 agents.
+//   v0.65.10 agents accept the mismatch and rely on the checksum binding.
+//
 // Exact-match only — agent versions are bare semver per project convention
 // (no `v` prefix, no pre-release suffixes in releases). The regression test
 // in agent/internal/updater/updater_test.go prevents new releases from
@@ -29,9 +36,9 @@ import { normalizeAgentArchitecture } from '../src/routes/agents/helpers';
 //
 // REMOVAL: this list can be deleted once `SELECT count(*) FROM devices
 // WHERE agent_version IN (...)` returns 0 across hosted + known self-host
-// fleets. As of 2026-05-10 there are still active 0.65.7 / 0.65.8 agents
-// on at least one self-host deployment; revisit after 90 days.
-export const BROKEN_AGENT_VERSIONS = ['0.65.5', '0.65.6', '0.65.7', '0.65.8'] as const;
+// fleets. As of 2026-05-11 there are still active 0.65.7 / 0.65.8 / 0.65.9
+// agents on at least one deployment; revisit after 90 days.
+export const BROKEN_AGENT_VERSIONS = ['0.65.5', '0.65.6', '0.65.7', '0.65.8', '0.65.9'] as const;
 
 export const RECOVERY_COMMAND_MARKER = 'agent_update_trust_root_recovery';
 

--- a/apps/api/scripts/recover-stuck-agents.test.ts
+++ b/apps/api/scripts/recover-stuck-agents.test.ts
@@ -24,7 +24,7 @@ function makeBinary(overrides: Partial<AgentVersionRow> = {}): AgentVersionRow {
     // Use a version outside BROKEN_AGENT_VERSIONS as the default target — the
     // recovery safety check refuses to dispatch a broken target back at the
     // fleet (the load-bearing assertion below).
-    version: '0.65.9',
+    version: '0.65.10',
     platform: 'linux',
     architecture: 'amd64',
     downloadUrl: 'https://example/agent-linux-amd64',
@@ -39,7 +39,7 @@ describe('planRecovery', () => {
     expect(skipped).toEqual([]);
     expect(plans).toHaveLength(1);
     expect(plans[0].device.id).toBe('dev-1');
-    expect(plans[0].binary.version).toBe('0.65.9');
+    expect(plans[0].binary.version).toBe('0.65.10');
   });
 
   it('refuses to dispatch when the latest registered binary is itself a broken version (the safety check that prevented an outage)', () => {
@@ -122,12 +122,16 @@ describe('planRecovery', () => {
     expect(BROKEN_AGENT_VERSIONS).toContain('0.65.6');
   });
 
-  it('flags all known stuck-version agents (#612 + #625)', () => {
+  it('flags all known stuck-version agents (#612 + #625 + #646)', () => {
     // 0.65.5 / 0.65.6: wrong embedded manifest trust root (#568, PR #612).
     // 0.65.7 / 0.65.8: predate per-deployment manifest pinning (#625);
     //   on BINARY_SOURCE=local these agents reject locally-signed manifests.
+    // 0.65.9: enforces manifest.URL == info.URL strictly (#646);
+    //   on BINARY_SOURCE=github the server now hands out a server-relative
+    //   download URL that doesn't match the github.com URL signed into the
+    //   manifest, so 0.65.9 agents reject.
     expect(BROKEN_AGENT_VERSIONS).toEqual(
-      expect.arrayContaining(['0.65.5', '0.65.6', '0.65.7', '0.65.8']),
+      expect.arrayContaining(['0.65.5', '0.65.6', '0.65.7', '0.65.8', '0.65.9']),
     );
   });
 });

--- a/apps/api/src/routes/agentVersions.test.ts
+++ b/apps/api/src/routes/agentVersions.test.ts
@@ -299,6 +299,155 @@ describe("agentVersions routes", () => {
       expect(body.manifestSignature).toBe(signed.signature);
     });
 
+    it("rewrites downloadUrl to server-relative when PUBLIC_API_URL is set (#646 — hosted SaaS auto-update fix)", async () => {
+      const checksum = "b".repeat(64);
+      const signed = makeSignedReleaseManifest({
+        platform: "windows",
+        arch: "amd64",
+        url: "https://github.com/LanternOps/breeze/releases/download/v1.0.0/breeze-agent-windows-amd64.exe",
+        checksum,
+        size: 1234,
+      });
+
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              {
+                version: "1.0.0",
+                platform: "windows",
+                architecture: "amd64",
+                component: "agent",
+                downloadUrl:
+                  "https://github.com/LanternOps/breeze/releases/download/v1.0.0/breeze-agent-windows-amd64.exe",
+                checksum,
+                fileSize: BigInt(1234),
+                releaseManifest: signed.manifest,
+                manifestSignature: signed.signature,
+                signingKeyId: "test-key",
+              },
+            ]),
+          }),
+        }),
+      } as any);
+
+      process.env.PUBLIC_API_URL = "https://us.example.com";
+      try {
+        const res = await app.request(
+          "/agent-versions/1.0.0/download?platform=windows&arch=amd64",
+        );
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        // Server-relative URL so the agent's downloadFromURL host check
+        // passes. The actual binary is served via /agents/download/:os/:arch
+        // (which 302s to github in BINARY_SOURCE=github mode).
+        expect(body.url).toBe(
+          "https://us.example.com/api/v1/agents/download/windows/amd64",
+        );
+        expect(body.checksum).toBe(checksum);
+        // Manifest stays unmodified — its url field still references the
+        // canonical github URL. The agent (v0.65.10+) accepts the mismatch
+        // because checksum is the trust binding.
+        expect(body.manifest).toBe(signed.manifest);
+      } finally {
+        delete process.env.PUBLIC_API_URL;
+      }
+    });
+
+    it("maps platform=macos to /darwin in the server-relative URL", async () => {
+      const checksum = "b".repeat(64);
+      const signed = makeSignedReleaseManifest({
+        platform: "macos",
+        arch: "arm64",
+        url: "https://github.com/LanternOps/breeze/releases/download/v1.0.0/breeze-agent-darwin-arm64",
+        checksum,
+        size: 1234,
+      });
+
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              {
+                version: "1.0.0",
+                platform: "macos",
+                architecture: "arm64",
+                component: "agent",
+                downloadUrl:
+                  "https://github.com/LanternOps/breeze/releases/download/v1.0.0/breeze-agent-darwin-arm64",
+                checksum,
+                fileSize: BigInt(1234),
+                releaseManifest: signed.manifest,
+                manifestSignature: signed.signature,
+                signingKeyId: "test-key",
+              },
+            ]),
+          }),
+        }),
+      } as any);
+
+      process.env.PUBLIC_API_URL = "https://us.example.com";
+      try {
+        const res = await app.request(
+          "/agent-versions/1.0.0/download?platform=darwin&arch=arm64",
+        );
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.url).toBe(
+          "https://us.example.com/api/v1/agents/download/darwin/arm64",
+        );
+      } finally {
+        delete process.env.PUBLIC_API_URL;
+      }
+    });
+
+    it("keeps canonical github URL for component=helper (download route is agent-only)", async () => {
+      const canonical =
+        "https://github.com/LanternOps/breeze/releases/download/v1.0.0/breeze-helper-windows.msi";
+      const checksum = "b".repeat(64);
+      const signed = makeSignedReleaseManifest({
+        component: "helper",
+        platform: "windows",
+        arch: "amd64",
+        url: canonical,
+        checksum,
+        size: 1234,
+      });
+
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              {
+                version: "1.0.0",
+                platform: "windows",
+                architecture: "amd64",
+                component: "helper",
+                downloadUrl: canonical,
+                checksum,
+                fileSize: BigInt(1234),
+                releaseManifest: signed.manifest,
+                manifestSignature: signed.signature,
+                signingKeyId: "test-key",
+              },
+            ]),
+          }),
+        }),
+      } as any);
+
+      process.env.PUBLIC_API_URL = "https://us.example.com";
+      try {
+        const res = await app.request(
+          "/agent-versions/1.0.0/download?platform=windows&arch=amd64&component=helper",
+        );
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.url).toBe(canonical);
+      } finally {
+        delete process.env.PUBLIC_API_URL;
+      }
+    });
+
     it("should return 404 for unknown version", async () => {
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -187,6 +187,50 @@ function assetNameFromDownloadUrl(downloadUrl: string): string | null {
   }
 }
 
+// Server-origin discovery for handing agents a download URL that matches
+// their configured control-plane host. The agent's downloadFromURL enforces
+// host equality with its ServerURL to prevent leaking the bearer token to a
+// third-party origin (e.g. github.com). When PUBLIC_API_URL is set, the
+// API rewrites the response's downloadUrl to a server-relative path; the
+// existing /api/v1/agents/download/:os/:arch route then 302s to github (or
+// streams locally) — credentials stay on the trusted origin. Issue #646.
+function getServerOriginForDownloadResponse(): string | null {
+  const candidate =
+    process.env.PUBLIC_API_URL?.trim() ||
+    process.env.PUBLIC_APP_URL?.trim() ||
+    process.env.BREEZE_SERVER?.trim();
+  if (!candidate) {
+    return null;
+  }
+  return candidate.replace(/\/+$/, "");
+}
+
+// Maps the DB platform value (which uses "macos") to the Go GOOS value that
+// the /api/v1/agents/download/:os/:arch route expects (which uses "darwin").
+function dbPlatformToRouteOs(dbPlatform: string): string {
+  return dbPlatform === "macos" ? "darwin" : dbPlatform;
+}
+
+// Construct the server-relative download URL the agent should use. Only
+// applies to component=agent today — helper/viewer auto-update flows have
+// their own update mechanisms and aren't served through the agent download
+// route. Returns null to signal "fall back to the canonical (github) URL".
+function buildServerRelativeAgentDownloadUrl(
+  dbPlatform: string,
+  architecture: string,
+  component: string,
+): string | null {
+  if (component !== "agent") {
+    return null;
+  }
+  const origin = getServerOriginForDownloadResponse();
+  if (!origin) {
+    return null;
+  }
+  const os = dbPlatformToRouteOs(dbPlatform);
+  return `${origin}/api/v1/agents/download/${os}/${architecture}`;
+}
+
 export async function validateReleaseManifest(args: {
   manifest: string | null | undefined;
   signature: string | null | undefined;
@@ -299,9 +343,19 @@ agentVersionRoutes.get(
       );
     }
 
+    const serverRelativeUrl = buildServerRelativeAgentDownloadUrl(
+      platform,
+      arch,
+      component,
+    );
+
     return c.json({
       version: latestVersion.version,
-      downloadUrl: latestVersion.downloadUrl,
+      // Server-relative URL when PUBLIC_API_URL is set (hosted SaaS); the
+      // existing /api/v1/agents/download/:os/:arch route redirects to github
+      // or serves locally. Otherwise fall back to the canonical URL stored
+      // in agent_versions. Issue #646.
+      downloadUrl: serverRelativeUrl ?? latestVersion.downloadUrl,
       checksum: latestVersion.checksum,
       releaseManifest: latestVersion.releaseManifest,
       manifestSignature: latestVersion.manifestSignature,
@@ -378,9 +432,19 @@ agentVersionRoutes.get(
       );
     }
 
+    const serverRelativeUrl = buildServerRelativeAgentDownloadUrl(
+      versionInfo.platform,
+      versionInfo.architecture,
+      versionInfo.component,
+    );
+
     // Return JSON with download URL, checksum, and signed release manifest.
+    // url is server-relative when PUBLIC_API_URL is set so the agent's
+    // host check passes; the binary itself is served via the existing
+    // /api/v1/agents/download/:os/:arch route (302 to github in
+    // BINARY_SOURCE=github mode, local stream otherwise). Issue #646.
     return c.json({
-      url: versionInfo.downloadUrl,
+      url: serverRelativeUrl ?? versionInfo.downloadUrl,
       checksum: versionInfo.checksum,
       manifest: versionInfo.releaseManifest,
       manifestSignature: versionInfo.manifestSignature,

--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -445,12 +445,24 @@ export async function syncFromGitHub(
     ? `https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${requestedVersion}`
     : `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
 
-  const ghResp = await fetch(ghUrl, {
-    headers: {
-      Accept: "application/vnd.github.v3+json",
-      "User-Agent": "breeze-api",
-    },
-  });
+  // Authenticate the API call when a token is available. Unauthenticated
+  // requests are capped at 60/hour per IP — fine for prod droplets where
+  // binarySync runs once at boot, but breaks shared-IP environments like
+  // CI runners. Operators behind NAT with multiple deployments may also
+  // benefit. Token is opt-in via env; no breaking change for existing
+  // deployments. Accepts both GITHUB_TOKEN (used by GitHub Actions) and
+  // GH_TOKEN (used by the gh CLI).
+  const ghToken =
+    process.env.GITHUB_TOKEN?.trim() || process.env.GH_TOKEN?.trim();
+  const ghHeaders: Record<string, string> = {
+    Accept: "application/vnd.github.v3+json",
+    "User-Agent": "breeze-api",
+  };
+  if (ghToken) {
+    ghHeaders.Authorization = `Bearer ${ghToken}`;
+  }
+
+  const ghResp = await fetch(ghUrl, { headers: ghHeaders });
   if (!ghResp.ok) {
     throw new Error(`GitHub API error: ${ghResp.status}`);
   }


### PR DESCRIPTION
## Summary

Restores agent auto-update on hosted-SaaS deployments (`BINARY_SOURCE=github`) by returning a server-relative download URL from `/agent-versions/:v/download` and `/agent-versions/latest`, and relaxing the redundant URL-match check in the agent updater. Trust binding stays on the signed checksum.

Surfaced during the v0.65.9 US prod deploy on 2026-05-11: agents on v0.65.7 received the canonical github.com URL in the download response, rejected it via `downloadFromURL`'s host-equality check (correctly — that check prevents leaking the Bearer token to a third-party origin), and went into a retry loop. Rolled back to v0.65.7 within 30 min.

## Closes

#646

## Design

The signed release manifest already binds binary identity via SHA-256 checksum. The duplicate `manifest.URL == info.URL` equality at `updater.go:403` was theatrical defense-in-depth on top of that — it prevented us from using the existing `/api/v1/agents/download/:os/:arch` proxy route that 302s to github (which preserves credential isolation because Go's HTTP client strips `Authorization` headers across cross-host redirects).

Two paired changes:

- **Agent:** relax the URL-equality check in both `verifyUpdateManifest` and `verifyReleaseArtifactManifest`. Derive asset name from `expectedReleaseAssetNames()` (platform/arch/component the agent already knows) rather than parsing it from `info.URL`. The download host check at `updater.go:746` stays — that's the real credential leak prevention.
- **API:** add `getServerOriginForDownloadResponse()` and `buildServerRelativeAgentDownloadUrl()`. When `PUBLIC_API_URL` (or `PUBLIC_APP_URL` / `BREEZE_SERVER`) is set, the response `downloadUrl`/`url` is `${origin}/api/v1/agents/download/${os}/${arch}` (with `macos → darwin`). `agent_versions.download_url` in the DB stays canonical.

## Fleet recovery for existing v0.65.7-v0.65.9 agents

Existing agents on the broken versions lack the relaxed check, so they still can't self-upgrade. The recover-stuck-agents path covers them — `dev_update` uses checksum verification and bypasses both URL checks. After deploying v0.65.10 API:

```
pnpm recover:stuck-agents               # dry run
pnpm recover:stuck-agents -- --apply    # queue dev_update commands
```

This PR adds `0.65.9` to `BROKEN_AGENT_VERSIONS` so the script covers existing v0.65.9 fleets too.

## Tests

- **Agent:** `TestDownloadBinaryAcceptsServerRelativeUrlWithMatchingChecksum` — server-relative `info.URL` + canonical signed `manifest.URL` + matching checksum is accepted.
- **API:** three new tests in `agentVersions.test.ts`:
  - rewrites to server-relative when `PUBLIC_API_URL` is set
  - `platform=macos` maps to `/darwin/` route segment
  - `component=helper` keeps canonical github URL (helper download route is agent-only)
- **API:** `recover-stuck-agents.test.ts` updated to assert v0.65.9 is in `BROKEN_AGENT_VERSIONS`.
- **CI smoke:** `smoke-binary-source-github` boots the API in `BINARY_SOURCE=github` mode with the production LanternOps trust root and asserts:
  - download endpoint returns server-relative URL (the #646 regression check)
  - `/agents/download/:os/:arch` 302s to `github.com/LanternOps/breeze/releases/...`

This is the github-mode equivalent of the existing `smoke-binary-source-local` job. Either smoke job would have caught the #646 regression at PR time.

## Test plan

- [ ] CI smoke jobs (local + github) go green
- [ ] Deploy v0.65.10 to US droplet, verify health stays 200
- [ ] Run `pnpm recover:stuck-agents -- --apply` from API container
- [ ] Watch agents transition v0.65.7 → v0.65.10 via dev_update
- [ ] Verify subsequent (post-recovery) normal heartbeat-triggered auto-update would work — register a hypothetical v0.65.11 and confirm `/agent-versions/0.65.11/download` returns a server-relative URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>