### PR TITLE
fix(api,web): oauth Date binding, heartbeat re-enroll, readiness UUID guard, org refresh

### DIFF
--- a/apps/api/src/__tests__/integration/oauth-cleanup.integration.test.ts
+++ b/apps/api/src/__tests__/integration/oauth-cleanup.integration.test.ts
@@ -1,0 +1,137 @@
+/**
+ * OAuth cleanup integration test — guards against postgres-js raw-sql Date
+ * binding regressions.
+ *
+ * `cleanupStaleOauthClients` and `cleanupExpiredOauthLifecycleRows` interpolate
+ * Date values inside raw `sql\`\`` template fragments. postgres-js can't infer
+ * the column type for such bindings and throws ERR_INVALID_ARG_TYPE at runtime
+ * — a failure mode that mocked unit tests cannot catch. This test exercises
+ * both functions against the real driver so any future regression (dropping
+ * the .toISOString() conversion, or introducing a new ${someDate} in a raw
+ * sql chunk) blows up here.
+ */
+import './setup';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { eq } from 'drizzle-orm';
+import {
+  oauthAuthorizationCodes,
+  oauthClients,
+  oauthGrants,
+  oauthInteractions,
+  oauthRefreshTokens,
+  oauthSessions,
+} from '../../db/schema';
+import { withSystemDbAccessContext } from '../../db';
+import { cleanupStaleOauthClients, cleanupExpiredOauthLifecycleRows, DCR_STALE_CLIENT_TTL_MS } from '../../oauth/provider';
+import { createOrganization, createPartner, createUser } from './db-utils';
+import { getTestDb } from './setup';
+
+describe('OAuth cleanup raw-sql Date binding', () => {
+  beforeEach(async () => {
+    // setup.ts truncates core tables on beforeEach, but not all oauth_* tables.
+    // Clear them defensively so this file's seeded rows aren't affected by
+    // unrelated tests bleeding through.
+    await getTestDb().delete(oauthRefreshTokens);
+    await getTestDb().delete(oauthAuthorizationCodes);
+    await getTestDb().delete(oauthGrants);
+    await getTestDb().delete(oauthSessions);
+    await getTestDb().delete(oauthInteractions);
+    await getTestDb().delete(oauthClients);
+  });
+
+  it('cleanupStaleOauthClients runs without ERR_INVALID_ARG_TYPE on real postgres-js', async () => {
+    // Seed a stale (created long ago, no last_used, no partner) client that
+    // qualifies for deletion, plus an active client with a current grant so
+    // the NOT EXISTS subqueries with `>= ${nowIso}` bindings have real rows
+    // to evaluate.
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const user = await createUser({
+      partnerId: partner.id,
+      orgId: org.id,
+      email: `oauth-cleanup-stale-${Date.now()}@example.test`,
+    });
+
+    const veryOld = new Date(Date.now() - DCR_STALE_CLIENT_TTL_MS - 24 * 60 * 60 * 1000);
+    const future = new Date(Date.now() + 60 * 60 * 1000);
+
+    await getTestDb().insert(oauthClients).values([
+      {
+        id: 'stale-client-no-grants',
+        partnerId: null,
+        metadata: { client_name: 'stale DCR client' },
+        createdAt: veryOld,
+      },
+      {
+        id: 'active-client-with-grant',
+        partnerId: null,
+        metadata: { client_name: 'active DCR client' },
+        createdAt: veryOld,
+      },
+    ]);
+
+    await getTestDb().insert(oauthGrants).values({
+      id: 'grant-keeps-active-client-alive',
+      accountId: user.id,
+      clientId: 'active-client-with-grant',
+      partnerId: partner.id,
+      orgId: org.id,
+      payload: { accountId: user.id },
+      expiresAt: future,
+    });
+
+    const deleted = await withSystemDbAccessContext(() => cleanupStaleOauthClients());
+
+    // The stale client (no grants) is gone; the active one stays.
+    expect(deleted).toBeGreaterThanOrEqual(1);
+    const remaining = await getTestDb()
+      .select({ id: oauthClients.id })
+      .from(oauthClients)
+      .where(eq(oauthClients.id, 'active-client-with-grant'));
+    expect(remaining).toHaveLength(1);
+    const stale = await getTestDb()
+      .select({ id: oauthClients.id })
+      .from(oauthClients)
+      .where(eq(oauthClients.id, 'stale-client-no-grants'));
+    expect(stale).toHaveLength(0);
+  });
+
+  it('cleanupExpiredOauthLifecycleRows runs without ERR_INVALID_ARG_TYPE on real postgres-js', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const user = await createUser({
+      partnerId: partner.id,
+      orgId: org.id,
+      email: `oauth-cleanup-lifecycle-${Date.now()}@example.test`,
+    });
+
+    await getTestDb().insert(oauthClients).values({
+      id: 'lifecycle-client',
+      partnerId: partner.id,
+      metadata: { client_name: 'lifecycle test client' },
+    });
+
+    const longAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const future = new Date(Date.now() + 60 * 60 * 1000);
+
+    // One expired refresh token (should be deleted) and one live grant
+    // protected by an unrevoked refresh token (should stay) — exercises both
+    // the `< ${cutoffIso}` and `>= ${nowIso}` raw-sql bindings.
+    await getTestDb().insert(oauthGrants).values([
+      { id: 'expired-grant', accountId: user.id, clientId: 'lifecycle-client', partnerId: partner.id, orgId: org.id, payload: { accountId: user.id }, expiresAt: longAgo },
+      { id: 'live-grant',    accountId: user.id, clientId: 'lifecycle-client', partnerId: partner.id, orgId: org.id, payload: { accountId: user.id }, expiresAt: future },
+    ]);
+    await getTestDb().insert(oauthRefreshTokens).values([
+      { id: 'expired-refresh', userId: user.id, clientId: 'lifecycle-client', partnerId: partner.id, orgId: org.id, payload: { sub: user.id, jti: 'jti-expired', grantId: 'expired-grant' }, expiresAt: longAgo },
+      { id: 'live-refresh',    userId: user.id, clientId: 'lifecycle-client', partnerId: partner.id, orgId: org.id, payload: { sub: user.id, jti: 'jti-live',    grantId: 'live-grant'    }, expiresAt: future },
+    ]);
+
+    const counts = await withSystemDbAccessContext(() => cleanupExpiredOauthLifecycleRows());
+
+    expect(counts.refreshTokens).toBeGreaterThanOrEqual(1);
+    const remainingRefresh = await getTestDb().select({ id: oauthRefreshTokens.id }).from(oauthRefreshTokens);
+    expect(remainingRefresh.map((r) => r.id).sort()).toEqual(['live-refresh']);
+    const remainingGrants = await getTestDb().select({ id: oauthGrants.id }).from(oauthGrants);
+    expect(remainingGrants.map((g) => g.id).sort()).toEqual(['live-grant']);
+  });
+});

--- a/apps/api/src/oauth/provider.ts
+++ b/apps/api/src/oauth/provider.ts
@@ -70,6 +70,10 @@ export async function cleanupStaleOauthClients(
   now: Date = new Date(),
 ): Promise<number> {
   const cutoff = new Date(now.getTime() - DCR_STALE_CLIENT_TTL_MS);
+  // Date objects bound inside raw `sql` template fragments have no column-type
+  // context, so postgres-js cannot serialize them and throws ERR_INVALID_ARG_TYPE.
+  // Drizzle helpers like lt() above are fine because they know the column type.
+  const nowIso = now.toISOString();
   const deleted = await db
     .delete(oauthClients)
     .where(
@@ -84,18 +88,18 @@ export async function cleanupStaleOauthClients(
         sql`NOT EXISTS (
           SELECT 1 FROM ${oauthGrants}
           WHERE ${oauthGrants.clientId} = ${oauthClients.id}
-          AND ${oauthGrants.expiresAt} >= ${now}
+          AND ${oauthGrants.expiresAt} >= ${nowIso}
         )`,
         sql`NOT EXISTS (
           SELECT 1 FROM ${oauthAuthorizationCodes}
           WHERE ${oauthAuthorizationCodes.clientId} = ${oauthClients.id}
-          AND ${oauthAuthorizationCodes.expiresAt} >= ${now}
+          AND ${oauthAuthorizationCodes.expiresAt} >= ${nowIso}
         )`,
         sql`NOT EXISTS (
           SELECT 1 FROM ${oauthRefreshTokens}
           WHERE ${oauthRefreshTokens.clientId} = ${oauthClients.id}
           AND ${oauthRefreshTokens.revokedAt} IS NULL
-          AND ${oauthRefreshTokens.expiresAt} >= ${now}
+          AND ${oauthRefreshTokens.expiresAt} >= ${nowIso}
         )`,
       ),
     )
@@ -116,6 +120,10 @@ export async function cleanupExpiredOauthLifecycleRows(
   retentionMs: number = OAUTH_LIFECYCLE_ROW_RETENTION_MS,
 ): Promise<OauthLifecycleCleanupCounts> {
   const cutoff = new Date(now.getTime() - retentionMs);
+  // See note in cleanupStaleOauthClients: Dates bound inside raw `sql` need
+  // explicit ISO string conversion since postgres-js has no column-type hint.
+  const nowIso = now.toISOString();
+  const cutoffIso = cutoff.toISOString();
 
   const [authCodes, interactions, sessions, grants, refreshTokens] = await Promise.all([
     db.delete(oauthAuthorizationCodes)
@@ -134,16 +142,16 @@ export async function cleanupExpiredOauthLifecycleRows(
           SELECT 1 FROM ${oauthRefreshTokens}
           WHERE ${oauthRefreshTokens.payload}->>'grantId' = ${oauthGrants.id}
           AND ${oauthRefreshTokens.revokedAt} IS NULL
-          AND ${oauthRefreshTokens.expiresAt} >= ${now}
+          AND ${oauthRefreshTokens.expiresAt} >= ${nowIso}
         )`,
       ))
       .returning({ id: oauthGrants.id }),
     db.delete(oauthRefreshTokens)
       .where(sql`(
-        ${oauthRefreshTokens.expiresAt} < ${cutoff}
+        ${oauthRefreshTokens.expiresAt} < ${cutoffIso}
         OR (
           ${oauthRefreshTokens.revokedAt} IS NOT NULL
-          AND ${oauthRefreshTokens.revokedAt} < ${cutoff}
+          AND ${oauthRefreshTokens.revokedAt} < ${cutoffIso}
         )
       )`)
       .returning({ id: oauthRefreshTokens.id }),

--- a/apps/api/src/routes/agents.test.ts
+++ b/apps/api/src/routes/agents.test.ts
@@ -678,7 +678,11 @@ describe('agent routes', () => {
         })
       });
 
-      expect(res.status).toBe(403);
+      expect(res.status).toBe(401);
+      const body = await res.json() as { code?: string; expected?: string; declared?: string };
+      expect(body.code).toBe('re_enrollment_required');
+      expect(body.expected).toBe('agent');
+      expect(body.declared).toBe('watchdog');
       expect(claimPendingCommandsForDevice).not.toHaveBeenCalled();
     });
 

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -51,7 +51,22 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
   }
 
   if (data.role && data.role !== agent.role) {
-    return c.json({ error: 'Agent credential role mismatch' }, 403);
+    // Return 401 with re_enrollment_required so the watchdog/agent can drop its
+    // stale token and re-provision via IPC or /rotate-token. A 403 here causes
+    // a stale pre-#568 watchdog binary (using the main agent token but declaring
+    // role=watchdog) to retry forever; the agent's authstate.Monitor only backs
+    // off on 401, so this is what breaks the loop.
+    console.warn('[heartbeat] Agent credential role mismatch', {
+      deviceId: agent.deviceId,
+      expected: agent.role,
+      declared: data.role,
+    });
+    return c.json({
+      error: 'Agent credential role mismatch',
+      code: 're_enrollment_required',
+      expected: agent.role,
+      declared: data.role,
+    }, 401);
   }
 
   const isWatchdog = agent.role === 'watchdog';

--- a/apps/api/src/routes/backup/verificationScheduled.test.ts
+++ b/apps/api/src/routes/backup/verificationScheduled.test.ts
@@ -87,8 +87,8 @@ vi.mock('./verificationService', () => ({
   safePublish: (...args: unknown[]) => safePublishMock(...(args as [])),
 }));
 
-import { processBackupVerificationResult, timeoutStaleVerifications } from './verificationScheduled';
-import { backupVerifications, verificationOrgById } from './store';
+import { processBackupVerificationResult, recalculateReadinessScores, timeoutStaleVerifications } from './verificationScheduled';
+import { backupJobs, backupVerifications, jobOrgById, verificationOrgById } from './store';
 
 describe('verification timeout handling', () => {
   beforeEach(() => {
@@ -160,6 +160,41 @@ describe('verification timeout handling', () => {
         backupVerifications.splice(index, 1);
       }
       verificationOrgById.delete(verificationId);
+    }
+  });
+
+  it('skips non-UUID orgIds during readiness recompute fallback', async () => {
+    const validOrgId = '22222222-2222-4222-8222-222222222222';
+    const validDeviceId = 'dev-valid-uuid';
+    const invalidDeviceId = 'dev-bad-orgid';
+
+    backupJobs.push(
+      { id: 'job-bad-orgid', type: 'scheduled', deviceId: invalidDeviceId, configId: 'cfg', policyId: 'pol', snapshotId: 'snap', status: 'completed', startedAt: new Date().toISOString(), completedAt: new Date().toISOString(), createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), totalSize: 0 },
+      { id: 'job-good-orgid', type: 'scheduled', deviceId: validDeviceId, configId: 'cfg', policyId: 'pol', snapshotId: 'snap', status: 'completed', startedAt: new Date().toISOString(), completedAt: new Date().toISOString(), createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), totalSize: 0 },
+    );
+    jobOrgById.set('job-bad-orgid', 'org-123');
+    jobOrgById.set('job-good-orgid', validOrgId);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    try {
+      const count = await recalculateReadinessScores();
+
+      expect(recomputeRecoveryReadinessForDeviceMock).toHaveBeenCalledWith(validOrgId, validDeviceId);
+      expect(recomputeRecoveryReadinessForDeviceMock).not.toHaveBeenCalledWith('org-123', invalidDeviceId);
+      expect(count).toBeGreaterThanOrEqual(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[backupVerification] Skipping job with non-UUID orgId during readiness recompute',
+        expect.objectContaining({ jobId: 'job-bad-orgid', targetOrg: 'org-123' }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+      const idxBad = backupJobs.findIndex((j) => j.id === 'job-bad-orgid');
+      if (idxBad >= 0) backupJobs.splice(idxBad, 1);
+      const idxGood = backupJobs.findIndex((j) => j.id === 'job-good-orgid');
+      if (idxGood >= 0) backupJobs.splice(idxGood, 1);
+      jobOrgById.delete('job-bad-orgid');
+      jobOrgById.delete('job-good-orgid');
     }
   });
 

--- a/apps/api/src/routes/backup/verificationScheduled.ts
+++ b/apps/api/src/routes/backup/verificationScheduled.ts
@@ -588,14 +588,32 @@ export async function recalculateReadinessScores(orgId?: string): Promise<number
   if (devicesToOrg.size === 0) {
     for (const job of backupJobs) {
       const targetOrg = jobOrgById.get(job.id);
-      if (!targetOrg) continue;
+      if (!targetOrg || !UUID_RE.test(targetOrg)) {
+        if (targetOrg) {
+          console.warn('[backupVerification] Skipping job with non-UUID orgId during readiness recompute', {
+            jobId: job.id,
+            deviceId: job.deviceId,
+            targetOrg,
+          });
+        }
+        continue;
+      }
       if (orgId && targetOrg !== orgId) continue;
       if (!devicesToOrg.has(job.deviceId)) devicesToOrg.set(job.deviceId, targetOrg);
     }
 
     for (const verification of backupVerifications) {
       const targetOrg = verificationOrgById.get(verification.id) ?? verification.orgId;
-      if (!targetOrg) continue;
+      if (!targetOrg || !UUID_RE.test(targetOrg)) {
+        if (targetOrg) {
+          console.warn('[backupVerification] Skipping verification with non-UUID orgId during readiness recompute', {
+            verificationId: verification.id,
+            deviceId: verification.deviceId,
+            targetOrg,
+          });
+        }
+        continue;
+      }
       if (orgId && targetOrg !== orgId) continue;
       if (!devicesToOrg.has(verification.deviceId)) devicesToOrg.set(verification.deviceId, targetOrg);
     }

--- a/apps/web/src/components/settings/OrganizationsPage.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.tsx
@@ -4,6 +4,7 @@ import OrganizationForm from './OrganizationForm';
 import SiteList, { type Site } from './SiteList';
 import SiteForm from './SiteForm';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
 import { navigateTo } from '@/lib/navigation';
 
 type ModalMode = 'closed' | 'add' | 'edit' | 'delete';
@@ -90,6 +91,20 @@ export default function OrganizationsPage() {
     }
   }, []);
 
+  // Refresh both the local list and the global org store (consumed by the
+  // side nav). Using allSettled so a sidebar-refresh hiccup doesn't undo the
+  // user-visible success of the create/delete that already committed.
+  const refreshOrgs = useCallback(async () => {
+    const results = await Promise.allSettled([
+      fetchOrganizations(),
+      useOrgStore.getState().fetchOrganizations(),
+    ]);
+    const rejected = results.find((r) => r.status === 'rejected');
+    if (rejected && rejected.status === 'rejected') {
+      console.warn('[OrganizationsPage] org refresh partially failed', rejected.reason);
+    }
+  }, [fetchOrganizations]);
+
   const fetchSites = useCallback(async (orgId: string) => {
     setSitesLoading(true);
     try {
@@ -164,7 +179,7 @@ export default function OrganizationsPage() {
 
       const createdOrg = await response.json().catch(() => null) as { id?: string } | null;
 
-      await fetchOrganizations();
+      await refreshOrgs();
       handleCloseModal();
 
       // Guide the user straight into adding their first site for the new org.
@@ -203,7 +218,7 @@ export default function OrganizationsPage() {
       }
 
       const deletedId = selectedOrg.id;
-      await fetchOrganizations();
+      await refreshOrgs();
       handleCloseModal();
 
       if (selectedOrg?.id === deletedId) {


### PR DESCRIPTION
## Summary

Four small fixes plus follow-up logging and tests, surfaced by a multi-agent PR review.

- **oauth/provider** — `cleanupStaleOauthClients` / `cleanupExpiredOauthLifecycleRows` converted Date values to ISO strings inside raw `` sql`` `` template fragments. postgres-js can't infer the column type for raw bindings and throws `ERR_INVALID_ARG_TYPE`; Drizzle helpers like `lt()` are unaffected. A mocked unit test can't catch this regression class.
- **agents/heartbeat** — role mismatch now returns **401 + `re_enrollment_required`** (was 403). The agent's `authstate.Monitor` only backs off on 401, so a stale pre-#568 watchdog binary using the main agent token but declaring `role=watchdog` would retry forever. Also logs `{deviceId, expected, declared}` so re-enrollment churn (and credential probes) are observable.
- **backup/verificationScheduled** — guard `recalculateReadinessScores` fallback against non-UUID `targetOrg` values. Root cause: `DEFAULT_BACKUP_ORG_ID` seed is the literal string `'org-123'`, which was being treated as an orgId. Logs the skipped value (`jobId`, `deviceId`, `targetOrg`) so the upstream source stays traceable instead of silently corrupting readiness scores.
- **web/OrganizationsPage** — extract `refreshOrgs` helper using `Promise.allSettled` so a sidebar org-store refresh hiccup doesn't undo the user-visible success of a committed create/delete.

## Test plan

- [x] `pnpm test --filter=@breeze/api` — affected unit tests pass (`verificationScheduled.test.ts`, `agents.test.ts`, `provider.cleanup.test.ts` — 29 tests).
- [x] New unit test in `verificationScheduled.test.ts` exercises the fallback branch with both a non-UUID `'org-123'` and a valid UUID; asserts `recomputeRecoveryReadinessForDevice` is called only with the valid one and the warning fires.
- [x] New `oauth-cleanup.integration.test.ts` runs against real Postgres (`docker compose -f docker-compose.test.yml`) and exercises the raw-sql `>= \${nowIso}` and `< \${cutoffIso}` bindings end-to-end — 2 tests pass.
- [x] `npx tsc --noEmit` clean for `apps/api`.
- [ ] Smoke test: create/delete an org in the dashboard, confirm sidebar nav stays in sync.
- [ ] Smoke test: enroll a stale pre-#568 watchdog binary, confirm it gets a 401 + `re_enrollment_required` and stops retrying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)