### PR TITLE
fix(web): scripts orgId pass-through for partner multi-org users (#620)

### DIFF
--- a/apps/web/src/components/devices/ScriptPickerModal.tsx
+++ b/apps/web/src/components/devices/ScriptPickerModal.tsx
@@ -72,7 +72,7 @@ export default function ScriptPickerModal({
       setLoading(true);
       setError(undefined);
 
-      const response = await fetchWithAuth('/scripts');
+      const response = await fetchWithAuth('/scripts?includeSystem=true');
       if (!response.ok) {
         throw new Error('Failed to fetch scripts');
       }

--- a/apps/web/src/components/scripts/ScriptEditPage.tsx
+++ b/apps/web/src/components/scripts/ScriptEditPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { ArrowLeft, History } from 'lucide-react';
 import ScriptForm, { type ScriptFormValues } from './ScriptForm';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
 import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
 import Breadcrumbs from '../layout/Breadcrumbs';
@@ -64,9 +65,12 @@ export default function ScriptEditPage({ scriptId }: ScriptEditPageProps) {
       const url = isNew ? '/scripts' : `/scripts/${scriptId}`;
       const method = isNew ? 'POST' : 'PUT';
 
+      const currentOrgId = useOrgStore.getState().currentOrgId;
+      const payload = isNew && currentOrgId ? { ...values, orgId: currentOrgId } : values;
+
       const response = await fetchWithAuth(url, {
         method,
-        body: JSON.stringify(values)
+        body: JSON.stringify(payload)
       });
 
       if (!response.ok) {

--- a/apps/web/src/components/scripts/ScriptsPage.test.tsx
+++ b/apps/web/src/components/scripts/ScriptsPage.test.tsx
@@ -8,6 +8,12 @@ vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn()
 }));
 
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: Object.assign(() => ({ currentOrgId: null }), {
+    getState: () => ({ currentOrgId: null })
+  })
+}));
+
 vi.mock('./ScriptList', () => ({
   default: ({ scripts, onRun }: { scripts: Array<{ id: string; name: string; lastRun?: string }>; onRun?: (script: { id: string; name: string; lastRun?: string }) => void }) => (
     <div>

--- a/apps/web/src/components/scripts/ScriptsPage.tsx
+++ b/apps/web/src/components/scripts/ScriptsPage.tsx
@@ -6,6 +6,7 @@ import ExecutionDetails from './ExecutionDetails';
 import type { ScriptExecution } from './ExecutionHistory';
 import type { ScriptParameter } from './ScriptForm';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
 import { showToast } from '../shared/Toast';
 import { cn } from '@/lib/utils';
 import { navigateTo } from '@/lib/navigation';
@@ -268,9 +269,10 @@ export default function ScriptsPage() {
   const handleImport = async (systemScript: SystemScript) => {
     setImportingId(systemScript.id);
     try {
+      const currentOrgId = useOrgStore.getState().currentOrgId;
       const response = await fetchWithAuth(`/scripts/import/${systemScript.id}`, {
         method: 'POST',
-        body: JSON.stringify({})
+        body: JSON.stringify(currentOrgId ? { orgId: currentOrgId } : {})
       });
 
       if (!response.ok) {


### PR DESCRIPTION
Closes the three frontend gaps from the follow-up comment on #620 (the backend was fixed in #621). For partner-scope users with ≥2 accessible orgs:

- Scripts → **Import from Library** button (`ScriptsPage.tsx`) — `POST /scripts/import/:id` reads `body.orgId` via zod, so `fetchWithAuth`'s `?orgId=` auto-inject was ignored. Read `currentOrgId` from `useOrgStore` and send it in the body.
- Scripts → **New Script** form (`ScriptEditPage.tsx`) — same pattern for `POST /scripts`. Inject the active org as the owner when creating.
- Device → **Run Script picker** (`ScriptPickerModal.tsx`) — `GET /scripts` filters out `is_system=true` unless `?includeSystem=true` is on the query. Append it so system-library scripts surface for device runs.

Backend handlers already do the right thing; this is one-line-each on the frontend.

`ScriptsPage.test.tsx` gains a small mock for the `orgStore` module so the new import doesn't trigger the real store's `registerOrgIdProvider` call against the already-mocked auth module.

**Verified live on top of v0.65.8** with a 6-org partner-scope user — import from library, new script creation, and device-side script picker all succeed against the active org.