### PR TITLE
fix(docker): use npm-install for pnpm on node:26-alpine (corepack removed)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -4,7 +4,7 @@
 
 # Stage 1: Base image with pnpm
 FROM node:26-alpine@sha256:e71ac5e964b9201072425d59d2e876359efa25dc96bb1768cb73295728d6e4ea AS base
-RUN corepack enable && corepack prepare pnpm@9.15.7 --activate
+RUN npm install -g pnpm@9.15.7
 RUN apk add --no-cache libc6-compat python3 make g++
 WORKDIR /app
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -4,7 +4,7 @@
 
 # Stage 1: Base image with pnpm
 FROM node:26-alpine@sha256:e71ac5e964b9201072425d59d2e876359efa25dc96bb1768cb73295728d6e4ea AS base
-RUN corepack enable && corepack prepare pnpm@9.15.7 --activate
+RUN npm install -g pnpm@9.15.7
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

After the Wave 5 bump to node:26-alpine (#666, #667), the prod Docker builds for apps/api and apps/web failed CI with `exit code: 127  corepack: not found` because Node 25+ removed bundled corepack from the official Docker images.

The Wave 5 local validation didn't catch this because the dev Dockerfiles (`docker/Dockerfile.{api,web}.dev`) already use `npm install -g pnpm` — they were always different from prod.

This switches the prod Dockerfiles to the same approach. Pinning pnpm@9.15.7 to match the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)