### PR TITLE
feat(web): switch device list view when changing organizations from device detail

### DIFF
--- a/apps/web/src/components/layout/OrgSwitcher.test.tsx
+++ b/apps/web/src/components/layout/OrgSwitcher.test.tsx
@@ -1,0 +1,152 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import OrgSwitcher, { getOrgSwitchRedirect } from './OrgSwitcher';
+
+const setOrganizationMock = vi.fn();
+const setSiteMock = vi.fn();
+const fetchOrganizationsMock = vi.fn();
+const fetchSitesMock = vi.fn();
+
+let mockStoreState: {
+  currentOrgId: string | null;
+  currentSiteId: string | null;
+  organizations: Array<{ id: string; partnerId: string; name: string; status: string; createdAt: string }>;
+  sites: Array<{ id: string; orgId: string; name: string; deviceCount: number; createdAt: string }>;
+  isLoading: boolean;
+};
+
+vi.mock('@/stores/orgStore', () => ({
+  useOrgStore: () => ({
+    ...mockStoreState,
+    setOrganization: setOrganizationMock,
+    setSite: setSiteMock,
+    fetchOrganizations: fetchOrganizationsMock,
+    fetchSites: fetchSitesMock
+  })
+}));
+
+describe('getOrgSwitchRedirect', () => {
+  it('redirects /devices/:id to /devices', () => {
+    expect(getOrgSwitchRedirect('/devices/abc123')).toBe('/devices');
+    expect(getOrgSwitchRedirect('/devices/abc123/')).toBe('/devices');
+  });
+
+  it('does not redirect from the device list itself', () => {
+    expect(getOrgSwitchRedirect('/devices')).toBeNull();
+    expect(getOrgSwitchRedirect('/devices/')).toBeNull();
+  });
+
+  it('does not redirect sibling device routes that share the prefix', () => {
+    expect(getOrgSwitchRedirect('/devices/compare')).toBeNull();
+    expect(getOrgSwitchRedirect('/devices/groups')).toBeNull();
+  });
+
+  it('does not redirect unrelated routes', () => {
+    expect(getOrgSwitchRedirect('/')).toBeNull();
+    expect(getOrgSwitchRedirect('/alerts/abc123')).toBeNull();
+    expect(getOrgSwitchRedirect('/scripts/abc123')).toBeNull();
+    expect(getOrgSwitchRedirect('/settings/organizations/abc123')).toBeNull();
+  });
+});
+
+describe('OrgSwitcher org change navigation', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    setOrganizationMock.mockReset();
+    setSiteMock.mockReset();
+    fetchOrganizationsMock.mockReset();
+    fetchSitesMock.mockReset();
+
+    mockStoreState = {
+      currentOrgId: 'org-a',
+      currentSiteId: null,
+      organizations: [
+        { id: 'org-a', partnerId: 'p1', name: 'Org A', status: 'active', createdAt: '2024-01-01' },
+        { id: 'org-b', partnerId: 'p1', name: 'Org B', status: 'active', createdAt: '2024-01-01' }
+      ],
+      sites: [],
+      isLoading: false
+    };
+  });
+
+  function stubLocation(pathname: string) {
+    const reloadMock = vi.fn();
+    const hrefSetter = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: {
+        ...originalLocation,
+        pathname,
+        reload: reloadMock,
+        set href(value: string) {
+          hrefSetter(value);
+        },
+        get href() {
+          return `http://localhost${pathname}`;
+        }
+      }
+    });
+    return { reloadMock, hrefSetter };
+  }
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: originalLocation
+    });
+  });
+
+  function openDropdownAndClickOrg(orgName: string) {
+    // Toggle the trigger button (first button on the page) to open the dropdown,
+    // then click the menu item that matches the org name.
+    const triggerButton = screen.getAllByRole('button')[0];
+    fireEvent.click(triggerButton);
+    const orgButtons = screen
+      .getAllByRole('button')
+      .filter((b) => b !== triggerButton && b.textContent?.includes(orgName));
+    if (orgButtons.length === 0) {
+      throw new Error(`No menu item for ${orgName} found`);
+    }
+    fireEvent.click(orgButtons[0]);
+  }
+
+  it('redirects to /devices when switching orgs from a device-detail page', () => {
+    const { reloadMock, hrefSetter } = stubLocation('/devices/abc123');
+
+    render(<OrgSwitcher />);
+
+    openDropdownAndClickOrg('Org B');
+
+    expect(setOrganizationMock).toHaveBeenCalledWith('org-b');
+    expect(hrefSetter).toHaveBeenCalledWith('/devices');
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
+  it('reloads in place when switching orgs from a non-detail page', () => {
+    const { reloadMock, hrefSetter } = stubLocation('/devices');
+
+    render(<OrgSwitcher />);
+
+    openDropdownAndClickOrg('Org B');
+
+    expect(setOrganizationMock).toHaveBeenCalledWith('org-b');
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+    expect(hrefSetter).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when clicking the already-selected organization', () => {
+    const { reloadMock, hrefSetter } = stubLocation('/devices/abc123');
+
+    render(<OrgSwitcher />);
+
+    openDropdownAndClickOrg('Org A');
+
+    expect(setOrganizationMock).not.toHaveBeenCalled();
+    expect(reloadMock).not.toHaveBeenCalled();
+    expect(hrefSetter).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/layout/OrgSwitcher.tsx
+++ b/apps/web/src/components/layout/OrgSwitcher.tsx
@@ -10,6 +10,28 @@ import {
 import { cn } from '@/lib/utils';
 import { useOrgStore, type Organization, type Site } from '@/stores/orgStore';
 
+/**
+ * When switching organizations, certain detail-view routes show data scoped to
+ * the previous org and would render blank or 404 under the new org. For those
+ * routes we navigate up to the list view in the destination org instead of
+ * reloading the now-inaccessible URL.
+ *
+ * Returns the destination URL when redirection is needed, otherwise null
+ * (meaning the caller should keep the current path and just reload).
+ */
+export function getOrgSwitchRedirect(pathname: string): string | null {
+  // /devices/:id -> /devices (but not /devices, /devices/compare, /devices/groups, etc.)
+  const deviceDetail = pathname.match(/^\/devices\/([^/]+)\/?$/);
+  if (deviceDetail) {
+    const segment = deviceDetail[1];
+    // Preserve sibling routes that share the prefix.
+    if (segment !== 'compare' && segment !== 'groups') {
+      return '/devices';
+    }
+  }
+  return null;
+}
+
 const statusColors: Record<string, string> = {
   active: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300',
   trial: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300',
@@ -231,7 +253,12 @@ export default function OrgSwitcher() {
                   onSelect={() => {
                     if (org.id !== currentOrgId) {
                       setOrganization(org.id);
-                      window.location.reload();
+                      const redirect = getOrgSwitchRedirect(window.location.pathname);
+                      if (redirect) {
+                        window.location.href = redirect;
+                      } else {
+                        window.location.reload();
+                      }
                     }
                   }}
                   sites={sites}


### PR DESCRIPTION
## Summary

- Switching organizations from the org switcher while viewing `/devices/:id` now navigates to `/devices` in the destination org, instead of reloading the now-inaccessible URL (which rendered blank or 404).
- Non-detail routes still reload in place, preserving existing behavior.
- Sibling routes `/devices/compare` and `/devices/groups` are intentionally excluded from the redirect since they share the path prefix but are not device-scoped detail views.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Other:

## Background

`OrgSwitcher` previously called `window.location.reload()` after `setOrganization`. If the user was on `/devices/:id`, the reload re-requested the same URL under the new org. The device does not belong to the new org, so the page either errored, rendered blank, or 404'd depending on how the detail component handles a missing record.

## Implementation

Added a small pure helper `getOrgSwitchRedirect(pathname)` co-located with `OrgSwitcher.tsx`. It returns `/devices` when the pathname matches `/devices/:id` (anything that is not `compare` or `groups`) and `null` otherwise. The org-switch handler uses the return value to decide between `window.location.href = redirect` and `window.location.reload()`.

This keeps the device-detail page itself unchanged, which avoids subscribing the detail page to org-store changes just to handle a navigation case.

## Testing

- [x] Existing tests pass (no regressions; pre-existing localStorage-related failures in `orgStore.test.ts`, `RecoveryBootstrapTab.test.tsx`, and others are present on `main` and unaffected by this change)
- [x] Added new tests: 7 cases covering the pathname helper plus full component-level coverage of the redirect and non-redirect paths
- [x] Manual testing: `pnpm build` for `apps/web` succeeds

Run just the new tests:

```
pnpm --filter @breeze/web test -- --run src/components/layout/OrgSwitcher.test.tsx
```

## Follow-ups

The same pattern affects other detail routes whose IDs are org-scoped. Worth a follow-up PR for at least these, all of which currently rely on `OrgSwitcher`'s plain reload:

- `/scripts/:id`, `/scripts/:id/executions`
- `/alerts/:id`, `/alerts/rules/:id`
- `/incidents/:id`
- `/automations/:id`
- `/policies/:id`, `/configuration-policies/:id`
- `/audit-baselines/:id`
- `/settings/organizations/:id`, `/settings/sites/:id`, `/settings/alert-templates/:id`
- `/remote/proxy/:tunnelId`, `/remote/vnc/:tunnelId`, `/remote/terminal/:deviceId`, `/remote/files/:deviceId`

If the team is happy with this approach, the helper can be extended into a small route-mapping table and reused.

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [x] I have tested on the relevant platforms
- [x] No secrets, credentials, or personal data included
