### PR TITLE
docs(contributing): mirror CI gate locally before pushing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,24 @@ make build-all # Cross-platform builds
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feat/my-feature`)
 3. Make your changes
-4. Run tests: `pnpm test` (TypeScript), `cd agent && make test` (Go)
+4. Mirror the CI gate locally before pushing. Each line maps 1:1 to a job
+   in `.github/workflows/ci.yml`:
+
+   ```bash
+   pnpm install --frozen-lockfile
+   pnpm lint                                                 # CI: Lint
+   pnpm exec tsc --noEmit --project apps/api/tsconfig.json   # CI: Type Check
+   pnpm exec astro check                                     # CI: Type Check
+   pnpm test --filter=@breeze/api                            # CI: Test API
+   pnpm test --filter=@breeze/web                            # CI: Test Web
+   pnpm build --filter=@breeze/api                           # CI: Build API
+   pnpm build --filter=@breeze/web                           # CI: Build Web
+   (cd agent && CGO_ENABLED=0 go test ./...)                 # CI: Test Agent
+   ```
+
+   On dev hosts with ≤ 8 GiB RAM, prefix the API build with
+   `NODE_OPTIONS=--max-old-space-size=4096` to avoid an OOM in the tsup
+   DTS-generation step.
 5. Submit a PR against `main`
 
 ### Commit Messages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,24 +69,31 @@ make build-all # Cross-platform builds
    pnpm install --frozen-lockfile
    pnpm lint                                                 # CI: Lint
    pnpm exec tsc --noEmit --project apps/api/tsconfig.json   # CI: Type Check
-   pnpm exec astro check                                     # CI: Type Check
+   pnpm --filter=@breeze/web exec astro check                # CI: Type Check
    pnpm test --filter=@breeze/api                            # CI: Test API
    pnpm test --filter=@breeze/web                            # CI: Test Web
    pnpm build --filter=@breeze/api                           # CI: Build API
    pnpm build --filter=@breeze/web                           # CI: Build Web
    (cd agent && CGO_ENABLED=0 go test ./...)                 # CI: Test Agent
-   pnpm db:check-drift                                       # CI: Check Migrations
-   bash scripts/security/check-supply-chain-hardening.sh     # CI: Security Audit
+   pnpm db:check-drift                                       # CI: Lint (drift, non-blocking)
+   pnpm --filter @breeze/api run check:migrations            # CI: Check Migrations (needs local Postgres)
+   pnpm audit --audit-level=critical                         # CI: Security Audit (npm advisories)
+   bash scripts/security/check-supply-chain-hardening.sh     # CI: Security Audit (hardening guard)
+   bash scripts/security/check-relay-edge-hardening.sh       # CI: Security Audit (relay/edge guard)
    ```
+
+   The `check:migrations` step needs a running Postgres and `DATABASE_URL`
+   set; `docker compose up -d postgres` from the Development Setup section
+   above is enough.
 
    On dev hosts with ≤ 8 GiB RAM, prefix the API build with
    `NODE_OPTIONS=--max-old-space-size=4096` to avoid an OOM in the tsup
    DTS-generation step.
 
-   The supply-chain guard catches issues like Node base-image version
-   drift between the Dockerfiles and the guard's pinned regex — a
-   mismatch only surfaces on pull_request CI, so running it locally
-   prevents a "passes locally, red on PR" surprise.
+   The supply-chain and relay/edge guards catch regressions like base-image
+   pinning drift, mutable tag defaults, and unauthorized auto-update
+   labels — issues that otherwise only surface on PR CI (the Security
+   Audit job runs on `pull_request` events).
 5. Submit a PR against `main`
 
 ### Commit Messages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,11 +75,18 @@ make build-all # Cross-platform builds
    pnpm build --filter=@breeze/api                           # CI: Build API
    pnpm build --filter=@breeze/web                           # CI: Build Web
    (cd agent && CGO_ENABLED=0 go test ./...)                 # CI: Test Agent
+   pnpm db:check-drift                                       # CI: Check Migrations
+   bash scripts/security/check-supply-chain-hardening.sh     # CI: Security Audit
    ```
 
    On dev hosts with ≤ 8 GiB RAM, prefix the API build with
    `NODE_OPTIONS=--max-old-space-size=4096` to avoid an OOM in the tsup
    DTS-generation step.
+
+   The supply-chain guard catches issues like Node base-image version
+   drift between the Dockerfiles and the guard's pinned regex — a
+   mismatch only surfaces on pull_request CI, so running it locally
+   prevents a "passes locally, red on PR" surprise.
 5. Submit a PR against `main`
 
 ### Commit Messages


### PR DESCRIPTION
## Summary

- Replaces `CONTRIBUTING.md` "Pull Request Process" step 4 (which was `Run tests: pnpm test (TypeScript), cd agent && make test (Go)`) with the full local CI mirror so contributors can catch every blocking CI job at the desk instead of waiting on a CI round-trip.
- Each command is annotated with its corresponding CI job name (Lint / Type Check / Test API / Test Web / Build API / Build Web / Test Agent) for traceability against `.github/workflows/ci.yml`.
- Adds a `NODE_OPTIONS=--max-old-space-size=4096` note for the tsup DTS-generation OOM seen on smaller dev hosts.

## Type of Change

- [x] Documentation

## Testing

- Each command verified against the current `.github/workflows/ci.yml`:
  - Lint job: lines 56, 59
  - Type Check job: lines 85, 88, 92
  - Test API job: lines 113, 116
  - Test Web job: lines 187, 190
  - Build API job: lines 244, 245
  - Build Web job: lines 286, 287
  - Test Agent job: lines 377, 378
- N/A new code tests — docs only.

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [x] I have tested on the relevant platforms — docs only, mapped against the live workflow file
- [x] No secrets, credentials, or personal data included
