### PR TITLE
fix(alerts): consolidate channel types + readable errors (#677, #678, #679)

### DIFF
--- a/apps/api/src/db/schema/alerts.ts
+++ b/apps/api/src/db/schema/alerts.ts
@@ -11,13 +11,14 @@ import {
   index,
   numeric
 } from 'drizzle-orm/pg-core';
+import { NOTIFICATION_CHANNEL_TYPES } from '@breeze/shared';
 import { organizations } from './orgs';
 import { devices } from './devices';
 import { users } from './users';
 
 export const alertSeverityEnum = pgEnum('alert_severity', ['critical', 'high', 'medium', 'low', 'info']);
 export const alertStatusEnum = pgEnum('alert_status', ['active', 'acknowledged', 'resolved', 'suppressed']);
-export const notificationChannelTypeEnum = pgEnum('notification_channel_type', ['email', 'slack', 'teams', 'webhook', 'pagerduty', 'sms']);
+export const notificationChannelTypeEnum = pgEnum('notification_channel_type', NOTIFICATION_CHANNEL_TYPES);
 
 export const alertTemplates = pgTable('alert_templates', {
   id: uuid('id').primaryKey().defaultRandom(),

--- a/apps/api/src/routes/alerts.test.ts
+++ b/apps/api/src/routes/alerts.test.ts
@@ -636,4 +636,36 @@ describe('alert routes', () => {
       expect(body.testResult.message).toContain('Test SMS sent');
     });
   });
+
+  describe('notification channel test endpoint — unsupported types', () => {
+    it('returns 501 with a renderable error when channel.type has no handler', async () => {
+      const unsupportedChannelId = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+      // Simulate deploy drift: DB row has a `type` value the switch does not handle.
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: unsupportedChannelId,
+              orgId: '11111111-1111-1111-1111-111111111111',
+              name: 'Future channel type',
+              // Cast through unknown: this value isn't in the TS enum on purpose.
+              type: 'pushover' as unknown as 'email',
+              config: {}
+            }])
+          })
+        })
+      } as any);
+
+      const res = await app.request(`/alerts/channels/${unsupportedChannelId}/test`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(501);
+      const body = await res.json();
+      expect(body.success).toBe(false);
+      expect(typeof body.error).toBe('string');
+      expect(body.error).toContain('pushover');
+    });
+  });
 });

--- a/apps/api/src/routes/alerts/channels.ts
+++ b/apps/api/src/routes/alerts/channels.ts
@@ -450,18 +450,38 @@ channelsRoutes.post(
           }
           break;
 
-        default:
-          // Channel type is in the DB enum but the test endpoint has no
-          // handler for it. This is a server-side gap, not a user error —
-          // surface it as 501 so the UI's error handler fires (200 with
-          // success:false was silently swallowed by the dashboard).
+        default: {
+          // Compile-time exhaustiveness: if a new enum value is added without
+          // a case above, TS errors here. Runtime 501 covers the deploy-drift
+          // case where the DB enum has a value the code does not handle yet.
+          const _exhaustiveCheck: never = channel.type;
+          void _exhaustiveCheck;
+          const unsupportedType = (channel as { type: string }).type;
+          console.error(
+            '[Channels] Test endpoint missing handler for channel type',
+            { channelId: channel.id, type: unsupportedType }
+          );
+          writeRouteAudit(c, {
+            orgId: channel.orgId,
+            action: 'notification_channel.test',
+            resourceType: 'notification_channel',
+            resourceId: channel.id,
+            resourceName: channel.name,
+            details: {
+              success: false,
+              reason: 'unsupported_channel_type',
+              type: unsupportedType,
+            },
+            result: 'failure',
+          });
           return c.json(
             {
               success: false,
-              error: `Test endpoint does not support channel type: ${channel.type}`
+              error: `Test endpoint does not support channel type: ${unsupportedType}`
             },
             501
           );
+        }
       }
     } catch (error) {
       testResult = {

--- a/apps/api/src/routes/alerts/channels.ts
+++ b/apps/api/src/routes/alerts/channels.ts
@@ -451,10 +451,17 @@ channelsRoutes.post(
           break;
 
         default:
-          testResult = {
-            success: false,
-            message: `Unknown channel type: ${channel.type}`
-          };
+          // Channel type is in the DB enum but the test endpoint has no
+          // handler for it. This is a server-side gap, not a user error —
+          // surface it as 501 so the UI's error handler fires (200 with
+          // success:false was silently swallowed by the dashboard).
+          return c.json(
+            {
+              success: false,
+              error: `Test endpoint does not support channel type: ${channel.type}`
+            },
+            501
+          );
       }
     } catch (error) {
       testResult = {

--- a/apps/api/src/routes/alerts/helpers.ts
+++ b/apps/api/src/routes/alerts/helpers.ts
@@ -1,4 +1,5 @@
 import { and, eq, inArray } from 'drizzle-orm';
+import type { NotificationChannelType } from '@breeze/shared';
 import { db } from '../../db';
 import {
   alertRules,
@@ -170,7 +171,7 @@ export function containsNotificationBindingOverride(value: unknown) {
 }
 
 export function validateNotificationChannelConfig(
-  type: 'email' | 'slack' | 'teams' | 'webhook' | 'pagerduty' | 'sms',
+  type: NotificationChannelType,
   config: unknown
 ): string[] {
   if (!isRecord(config)) {

--- a/apps/api/src/routes/alerts/schemas.ts
+++ b/apps/api/src/routes/alerts/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { NOTIFICATION_CHANNEL_TYPES } from '@breeze/shared';
 
 // Alert Rules schemas
 export const listAlertRulesSchema = z.object({
@@ -116,14 +117,14 @@ export const listChannelsSchema = z.object({
   page: z.string().optional(),
   limit: z.string().optional(),
   orgId: z.string().uuid().optional(),
-  type: z.enum(['email', 'slack', 'teams', 'webhook', 'pagerduty', 'sms']).optional(),
+  type: z.enum(NOTIFICATION_CHANNEL_TYPES).optional(),
   enabled: z.enum(['true', 'false']).optional()
 });
 
 export const createChannelSchema = z.object({
   orgId: z.string().uuid().optional(),
   name: z.string().min(1).max(255),
-  type: z.enum(['email', 'slack', 'teams', 'webhook', 'pagerduty', 'sms']),
+  type: z.enum(NOTIFICATION_CHANNEL_TYPES),
   config: z.record(z.unknown()), // JSONB for type-specific config
   enabled: z.boolean().default(true)
 });

--- a/apps/web/src/components/alerts/NotificationChannelForm.tsx
+++ b/apps/web/src/components/alerts/NotificationChannelForm.tsx
@@ -3,6 +3,7 @@ import { useForm, useFieldArray, Controller } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Plus, Trash2, Mail, MessageSquare, Bell, Webhook, Phone } from 'lucide-react';
+import { NOTIFICATION_CHANNEL_TYPES } from '@breeze/shared';
 import { cn } from '@/lib/utils';
 import type { NotificationChannelType } from './NotificationChannelList';
 
@@ -45,7 +46,7 @@ const smsConfigSchema = z.object({
 
 const notificationChannelSchema = z.object({
   name: z.string().min(1, 'Channel name is required'),
-  type: z.enum(['email', 'slack', 'teams', 'pagerduty', 'webhook', 'sms']),
+  type: z.enum(NOTIFICATION_CHANNEL_TYPES),
   enabled: z.boolean(),
   // Config fields (validated conditionally based on type)
   emailRecipients: z.array(z.object({ value: z.string() })).optional(),

--- a/apps/web/src/components/alerts/NotificationChannelList.tsx
+++ b/apps/web/src/components/alerts/NotificationChannelList.tsx
@@ -15,8 +15,9 @@ import {
   XCircle
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import type { NotificationChannelType } from '@breeze/shared';
 
-export type NotificationChannelType = 'email' | 'slack' | 'teams' | 'pagerduty' | 'webhook' | 'sms';
+export type { NotificationChannelType };
 
 export type NotificationChannel = {
   id: string;

--- a/apps/web/src/components/alerts/NotificationChannelsPage.tsx
+++ b/apps/web/src/components/alerts/NotificationChannelsPage.tsx
@@ -5,25 +5,9 @@ import NotificationChannelForm, { type NotificationChannelFormValues } from './N
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
 import { navigateTo } from '@/lib/navigation';
+import { extractApiError } from '@/lib/apiError';
 
 type ModalMode = 'closed' | 'create' | 'edit' | 'delete';
-
-// API errors can arrive as plain strings, zod issue objects from zValidator,
-// or a {details} field. Extract a renderable message rather than letting
-// `new Error(obj)` produce `[object Object]`.
-function extractApiError(data: unknown, fallback: string): string {
-  if (!data || typeof data !== 'object') return fallback;
-  const body = data as { error?: unknown; details?: unknown };
-  if (typeof body.error === 'string') return body.error;
-  if (body.error && typeof body.error === 'object') {
-    const zodIssues = (body.error as { issues?: Array<{ message?: string }> }).issues;
-    if (Array.isArray(zodIssues) && zodIssues.length > 0) {
-      return zodIssues.map((i) => i.message).filter(Boolean).join('; ') || fallback;
-    }
-  }
-  if (typeof body.details === 'string') return body.details;
-  return fallback;
-}
 
 type RoutingRule = {
   id: string;
@@ -55,10 +39,18 @@ export default function NotificationChannelsPage() {
   const fetchRoutingRules = useCallback(async () => {
     try {
       const response = await fetchWithAuth('/alerts/routing-rules');
-      if (!response.ok) return;
+      if (!response.ok) {
+        // Routing rules are a secondary panel; don't block the page. Log
+        // to console so failures are still debuggable.
+        const data = await response.json().catch(() => null);
+        console.warn('[NotificationChannelsPage]', extractApiError(data, `Failed to fetch routing rules (HTTP ${response.status})`));
+        return;
+      }
       const data = await response.json();
       setRoutingRules(data.rules ?? data.data ?? (Array.isArray(data) ? data : []));
-    } catch { /* non-critical */ }
+    } catch (err) {
+      console.warn('[NotificationChannelsPage] fetchRoutingRules', err);
+    }
   }, []);
 
   const fetchChannels = useCallback(async () => {
@@ -71,7 +63,8 @@ export default function NotificationChannelsPage() {
           void navigateTo('/login', { replace: true });
           return;
         }
-        throw new Error('Failed to fetch notification channels');
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to fetch notification channels'));
       }
       const data = await response.json();
       setChannels(data.channels ?? data.data ?? (Array.isArray(data) ? data : []));
@@ -308,7 +301,8 @@ export default function NotificationChannelsPage() {
           void navigateTo('/login', { replace: true });
           return;
         }
-        throw new Error('Failed to delete channel');
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to delete channel'));
       }
 
       await fetchChannels();
@@ -350,7 +344,10 @@ export default function NotificationChannelsPage() {
   const handleDeleteRoutingRule = async (ruleId: string) => {
     try {
       const response = await fetchWithAuth(`/alerts/routing-rules/${ruleId}`, { method: 'DELETE' });
-      if (!response.ok) throw new Error('Failed to delete routing rule');
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to delete routing rule'));
+      }
       await fetchRoutingRules();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to delete routing rule');

--- a/apps/web/src/components/alerts/NotificationChannelsPage.tsx
+++ b/apps/web/src/components/alerts/NotificationChannelsPage.tsx
@@ -8,6 +8,23 @@ import { navigateTo } from '@/lib/navigation';
 
 type ModalMode = 'closed' | 'create' | 'edit' | 'delete';
 
+// API errors can arrive as plain strings, zod issue objects from zValidator,
+// or a {details} field. Extract a renderable message rather than letting
+// `new Error(obj)` produce `[object Object]`.
+function extractApiError(data: unknown, fallback: string): string {
+  if (!data || typeof data !== 'object') return fallback;
+  const body = data as { error?: unknown; details?: unknown };
+  if (typeof body.error === 'string') return body.error;
+  if (body.error && typeof body.error === 'object') {
+    const zodIssues = (body.error as { issues?: Array<{ message?: string }> }).issues;
+    if (Array.isArray(zodIssues) && zodIssues.length > 0) {
+      return zodIssues.map((i) => i.message).filter(Boolean).join('; ') || fallback;
+    }
+  }
+  if (typeof body.details === 'string') return body.details;
+  return fallback;
+}
+
 type RoutingRule = {
   id: string;
   name: string;
@@ -96,7 +113,8 @@ export default function NotificationChannelsPage() {
           void navigateTo('/login', { replace: true });
           return;
         }
-        throw new Error('Test failed');
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Test failed'));
       }
 
       // Refresh to update test status
@@ -263,8 +281,8 @@ export default function NotificationChannelsPage() {
           void navigateTo('/login', { replace: true });
           return;
         }
-        const data = await response.json();
-        throw new Error(data.error || 'Failed to save channel');
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to save channel'));
       }
 
       await fetchChannels();
@@ -318,8 +336,8 @@ export default function NotificationChannelsPage() {
         }),
       });
       if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || 'Failed to save routing rule');
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to save routing rule'));
       }
       await fetchRoutingRules();
       setShowRuleForm(false);

--- a/apps/web/src/lib/apiError.test.ts
+++ b/apps/web/src/lib/apiError.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { extractApiError } from './apiError';
+
+describe('extractApiError', () => {
+  const FALLBACK = 'Operation failed';
+
+  it('returns fallback for null/undefined', () => {
+    expect(extractApiError(null, FALLBACK)).toBe(FALLBACK);
+    expect(extractApiError(undefined, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('returns fallback for non-object primitives', () => {
+    expect(extractApiError('plain string', FALLBACK)).toBe(FALLBACK);
+    expect(extractApiError(42, FALLBACK)).toBe(FALLBACK);
+    expect(extractApiError(true, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('returns body.error when it is a non-empty string', () => {
+    expect(extractApiError({ error: 'Channel not found' }, FALLBACK)).toBe('Channel not found');
+  });
+
+  it('falls back when body.error is an empty string', () => {
+    expect(extractApiError({ error: '' }, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('concatenates zod issues from body.error.issues', () => {
+    const zodBody = {
+      error: {
+        issues: [
+          { message: 'name is required', path: ['name'] },
+          { message: 'type must be one of email, slack', path: ['type'] }
+        ]
+      }
+    };
+    expect(extractApiError(zodBody, FALLBACK)).toBe('name is required; type must be one of email, slack');
+  });
+
+  it('handles zod issues array with missing/empty messages', () => {
+    const body = {
+      error: {
+        issues: [{ message: 'valid' }, { message: '' }, { path: ['x'] }, null]
+      }
+    };
+    expect(extractApiError(body, FALLBACK)).toBe('valid');
+  });
+
+  it('falls back when zod issues array is empty', () => {
+    expect(extractApiError({ error: { issues: [] } }, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('returns body.details when only details is set', () => {
+    expect(extractApiError({ details: 'phone numbers required' }, FALLBACK)).toBe('phone numbers required');
+  });
+
+  it('concatenates error + details when both are strings', () => {
+    const body = { error: 'Validation failed', details: 'name must be at least 1 character' };
+    expect(extractApiError(body, FALLBACK)).toBe('Validation failed: name must be at least 1 character');
+  });
+
+  it('concatenates error string + zod issues in details array', () => {
+    const body = {
+      error: 'Validation failed',
+      details: [{ message: 'name is required' }, { message: 'config invalid' }]
+    };
+    expect(extractApiError(body, FALLBACK)).toBe('Validation failed: name is required; config invalid');
+  });
+
+  it('does not duplicate when error and details produce the same string', () => {
+    const body = { error: 'oops', details: 'oops' };
+    expect(extractApiError(body, FALLBACK)).toBe('oops');
+  });
+
+  it('falls back to body.message (Hono default error shape)', () => {
+    expect(extractApiError({ message: 'Internal Server Error' }, FALLBACK)).toBe('Internal Server Error');
+  });
+
+  it('prefers error over message when both exist', () => {
+    expect(extractApiError({ error: 'specific', message: 'generic' }, FALLBACK)).toBe('specific');
+  });
+
+  it('handles top-level issues array (raw zValidator result)', () => {
+    const body = { issues: [{ message: 'top-level issue' }] };
+    expect(extractApiError(body, FALLBACK)).toBe('top-level issue');
+  });
+
+  it('returns fallback for object with no recognized fields', () => {
+    expect(extractApiError({ foo: 'bar', baz: 42 }, FALLBACK)).toBe(FALLBACK);
+  });
+});

--- a/apps/web/src/lib/apiError.ts
+++ b/apps/web/src/lib/apiError.ts
@@ -1,0 +1,55 @@
+// Parses error response bodies returned by the API. The API emits at least
+// four shapes today: a plain `{error: string}`, a zod-validator
+// `{error: {issues: [...]}}`, a `{error: string, details: object|array}`
+// pair from route validators, and Hono's default `{message: string}`.
+// Falling back to `new Error(obj)` produces `[object Object]` in the UI;
+// this function picks the most readable rendering of whatever we got.
+
+type ZodIssue = { message?: string; path?: Array<string | number> };
+
+function joinZodIssues(issues: unknown): string | null {
+  if (!Array.isArray(issues) || issues.length === 0) return null;
+  const messages = issues
+    .map((issue) => {
+      if (!issue || typeof issue !== 'object') return null;
+      const m = (issue as ZodIssue).message;
+      return typeof m === 'string' && m.length > 0 ? m : null;
+    })
+    .filter((m): m is string => m !== null);
+  return messages.length > 0 ? messages.join('; ') : null;
+}
+
+function detailsToString(details: unknown): string | null {
+  if (typeof details === 'string' && details.length > 0) return details;
+  const fromIssues = joinZodIssues(details);
+  if (fromIssues) return fromIssues;
+  return null;
+}
+
+export function extractApiError(data: unknown, fallback: string): string {
+  if (!data || typeof data !== 'object') return fallback;
+  const body = data as { error?: unknown; details?: unknown; message?: unknown };
+
+  // Top-level zod issues from raw zValidator result (rare but possible).
+  const topLevelIssues = joinZodIssues((data as { issues?: unknown }).issues);
+
+  const parts: string[] = [];
+
+  if (typeof body.error === 'string' && body.error.length > 0) {
+    parts.push(body.error);
+  } else if (body.error && typeof body.error === 'object') {
+    const fromError = joinZodIssues((body.error as { issues?: unknown }).issues);
+    if (fromError) parts.push(fromError);
+  }
+
+  const fromDetails = detailsToString(body.details);
+  if (fromDetails && !parts.includes(fromDetails)) parts.push(fromDetails);
+
+  if (parts.length === 0 && topLevelIssues) parts.push(topLevelIssues);
+
+  if (parts.length === 0 && typeof body.message === 'string' && body.message.length > 0) {
+    parts.push(body.message);
+  }
+
+  return parts.length > 0 ? parts.join(': ') : fallback;
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -371,9 +371,11 @@ export interface Policy {
 // Alert Types
 // ============================================
 
+import { NOTIFICATION_CHANNEL_TYPES } from '../constants';
+
 export type AlertSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
 export type AlertStatus = 'active' | 'acknowledged' | 'resolved' | 'suppressed';
-export type NotificationChannelType = 'email' | 'slack' | 'teams' | 'webhook' | 'pagerduty' | 'sms';
+export type NotificationChannelType = (typeof NOTIFICATION_CHANNEL_TYPES)[number];
 
 export interface AlertRule {
   id: string;


### PR DESCRIPTION
## Summary

Fixes three related issues reported by @bdunncompany, all surfaced from one debugging session while adding a `pushover` channel type (#676).

- **#677** — The notification channel type list was duplicated in 4 places (Drizzle `pgEnum`, two route zod schemas, a TS union in `helpers.ts`, the frontend form schema). Adding a new type required touching all four, with each missing site producing a different confusing failure mode. Turns out `NOTIFICATION_CHANNEL_TYPES` already existed in `packages/shared/src/constants/index.ts` — the four duplicates just weren't importing it. Point them at the existing constant; derive `NotificationChannelType` in `shared/types` from the same tuple. Adding a new type now touches one line.
- **#678** — `NotificationChannelsPage.tsx` did `throw new Error(data.error || ...)`, which becomes the literal string `[object Object]` when `data.error` is a structured zod issue body. Added an `extractApiError` helper that pulls a readable message out of the three shapes the API emits today (plain string, zod issues array, `details` field), applied to channel save, routing rule save, and test.
- **#679** — `/alerts/channels/:id/test`'s `default:` branch returned HTTP 200 with `success: false` in the body. The UI checks `response.ok` and treated 200 as success, so the user saw no feedback at all. Return 501 with a structured error body so the UI's error path fires. Combined with #678, the user now sees `Test endpoint does not support channel type: <type>`.

## Commits

- `37276850` chore(alerts): consolidate notification channel type list to single source (#677)
- `c7b560d0` fix(web): render readable message for structured API errors (#678)
- `033c7c84` fix(api): return 501 from /alerts/channels/:id/test for unhandled types (#679)

## Test plan

- [x] `apps/api` `tsc --noEmit` clean
- [x] `apps/web` `tsc --noEmit` clean
- [x] `packages/shared` `tsc --noEmit` clean
- [x] API vitest suite: 4158 passed
- [x] Web vitest suite: 379 passed
- [x] Shared vitest suite: 551 passed
- [ ] Manual repro of #678: trigger a zValidator failure on `/alerts/channels` and confirm the error region renders a readable message (not `[object Object]`)
- [ ] Manual repro of #679: register an unhandled channel type in the dispatcher but not the test switch, click Test, confirm UI surfaces the 501 message

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>