### PR TITLE
fix(api): scope lifecycle middleware to /me/* and /admin/* (#683)

### DIFF
--- a/apps/api/src/routes/lifecycle.test.ts
+++ b/apps/api/src/routes/lifecycle.test.ts
@@ -428,3 +428,44 @@ describe('POST /admin/orgs/:orgId/oauth-clients/:clientId/unblock-globally', () 
     expect([403, 404]).toContain(res.status);
   });
 });
+
+// ============================================================
+// Regression: middleware does not leak onto sibling routes (#683)
+// ============================================================
+
+describe('lifecycle middleware scoping (#683)', () => {
+  it('does not run authMiddleware for sibling routes when mounted at /', async () => {
+    const { Hono } = await import('hono');
+    const { authMiddleware } = await import('../middleware/auth');
+    const spy = vi.mocked(authMiddleware);
+    spy.mockClear();
+
+    const sibling = new Hono();
+    sibling.get('/agent-versions/:version/download', (c) => c.json({ ok: true }));
+
+    const parent = new Hono();
+    parent.route('/', lifecycleRoutes);
+    parent.route('/', lifecycleAdminRoutes);
+    parent.route('/', sibling);
+
+    const res = await parent.request('/agent-versions/0.65.9/download?platform=linux&arch=amd64');
+    expect(res.status).toBe(200);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('still runs authMiddleware for /me/* paths', async () => {
+    const { Hono } = await import('hono');
+    const { authMiddleware } = await import('../middleware/auth');
+    const spy = vi.mocked(authMiddleware);
+    spy.mockClear();
+
+    const parent = new Hono();
+    parent.route('/', lifecycleRoutes);
+
+    nextSelectRows = [];
+    await parent.request('/me/mobile-devices', {
+      headers: { [MOBILE_DEVICE_ID_HEADER]: 'install-current' },
+    });
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/lifecycle.ts
+++ b/apps/api/src/routes/lifecycle.ts
@@ -43,8 +43,11 @@ import { PERMISSIONS } from '../services/permissions';
 export const lifecycleRoutes = new Hono();
 export const lifecycleAdminRoutes = new Hono();
 
-lifecycleRoutes.use('*', authMiddleware);
-lifecycleAdminRoutes.use('*', authMiddleware);
+// Scoped to the actual route prefixes — these sub-apps are mounted at `/`
+// (apps/api/src/index.ts), so a `'*'` wildcard would leak the middleware onto
+// sibling routes like `/agent-versions/:v/download` (see #683).
+lifecycleRoutes.use('/me/*', authMiddleware);
+lifecycleAdminRoutes.use('/admin/*', authMiddleware);
 
 const REVOKE_RATE_LIMIT = 10;
 const REVOKE_RATE_WINDOW_SECONDS = 60;


### PR DESCRIPTION
## Summary
- Fixes #683 — `/agent-versions/:v/download` returning 401 on `main`, blocking `smoke-binary-source-local`/`-github` and every open PR's CI.
- Root cause: `lifecycleRoutes` and `lifecycleAdminRoutes` (added in #611) were mounted at `/` (apps/api/src/index.ts:734-735) with `.use('*', authMiddleware)` inside each sub-app. The `'*'` wildcard matched every sibling route in the parent, including the explicitly-public download path.
- Fix: scope the middleware to the actual route prefixes each sub-app owns — `/me/*` and `/admin/*`. The route patterns inside each sub-app are unchanged.

## Test plan
- [x] `pnpm test --filter=@breeze/api -- src/routes/lifecycle.test.ts` — 19 pass (17 existing + 2 regression)
- [x] `npx tsc --noEmit` clean on `apps/api`
- [x] Regression test verified to **fail without the fix** (authMiddleware spy invoked 2x for `/agent-versions/:v/download` — once per sub-app's wildcard)
- [ ] `smoke-binary-source-local` returns 200 on this PR (CI will verify)
- [ ] `smoke-binary-source-github` returns 200 on this PR (CI will verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)