### PR TITLE
fix(web): adopt extractApiError project-wide

### DIFF
--- a/apps/web/src/components/alerts/AlertRuleEditPage.tsx
+++ b/apps/web/src/components/alerts/AlertRuleEditPage.tsx
@@ -5,6 +5,7 @@ import type { NotificationChannel } from './NotificationChannelList';
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
 import { navigateTo } from '@/lib/navigation';
+import { extractApiError } from '@/lib/apiError';
 
 type Site = { id: string; name: string };
 type Group = { id: string; name: string };
@@ -38,7 +39,8 @@ export default function AlertRuleEditPage({ ruleId, isNew = false }: AlertRuleEd
           void navigateTo('/login', { replace: true });
           return;
         }
-        throw new Error('Failed to fetch alert rule');
+        const errData = await response.json().catch(() => null);
+        throw new Error(extractApiError(errData, 'Failed to fetch alert rule'));
       }
       const data = await response.json();
       const rule = data.rule ?? data.data ?? data;
@@ -159,8 +161,8 @@ export default function AlertRuleEditPage({ ruleId, isNew = false }: AlertRuleEd
           void navigateTo('/login', { replace: true });
           return;
         }
-        const data = await response.json();
-        throw new Error(data.error || 'Failed to save alert rule');
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to save alert rule'));
       }
 
       void navigateTo('/alerts/rules');

--- a/apps/web/src/components/alerts/AlertRulesPage.tsx
+++ b/apps/web/src/components/alerts/AlertRulesPage.tsx
@@ -5,6 +5,7 @@ import AlertsTabStrip from './AlertsTabStrip';
 import { fetchWithAuth } from '../../stores/auth';
 import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
+import { extractApiError } from '@/lib/apiError';
 
 type ModalMode = 'closed' | 'delete' | 'test';
 
@@ -27,7 +28,8 @@ export default function AlertRulesPage() {
           void navigateTo('/login', { replace: true });
           return;
         }
-        throw new Error('Failed to fetch alert rules');
+        const errData = await response.json().catch(() => null);
+        throw new Error(extractApiError(errData, 'Failed to fetch alert rules'));
       }
       const data = await response.json();
       setRules(data.rules ?? data.data ?? (Array.isArray(data) ? data : []));
@@ -67,7 +69,8 @@ export default function AlertRulesPage() {
           void navigateTo('/login', { replace: true });
           return;
         }
-        throw new Error('Failed to test rule');
+        const errData = await response.json().catch(() => null);
+        throw new Error(extractApiError(errData, 'Failed to test rule'));
       }
 
       const data = await response.json();
@@ -97,7 +100,8 @@ export default function AlertRulesPage() {
           void navigateTo('/login', { replace: true });
           return;
         }
-        throw new Error(`Failed to ${enabled ? 'enable' : 'disable'} rule`);
+        const errData = await response.json().catch(() => null);
+        throw new Error(extractApiError(errData, `Failed to ${enabled ? 'enable' : 'disable'} rule`));
       }
 
       setRules(prev =>
@@ -144,7 +148,8 @@ export default function AlertRulesPage() {
             void navigateTo('/login', { replace: true });
             return;
           }
-          throw new Error('Failed to delete rule');
+          const errData = await response.json().catch(() => null);
+          throw new Error(extractApiError(errData, 'Failed to delete rule'));
         }
 
         showToast({ type: 'success', message: `"${ruleToDelete.name}" deleted` });

--- a/apps/web/src/components/alerts/AlertTemplateEditor.tsx
+++ b/apps/web/src/components/alerts/AlertTemplateEditor.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Plus, Save, Trash2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { extractApiError } from '@/lib/apiError';
 import type { AlertSeverity } from './AlertList';
 import { fetchWithAuth } from '../../stores/auth';
 import Breadcrumbs from '../layout/Breadcrumbs';
@@ -425,7 +426,8 @@ export default function AlertTemplateEditor({ templateId }: AlertTemplateEditorP
       setError(undefined);
       const response = await fetchWithAuth(`/alert-templates/templates/${templateId}`);
       if (!response.ok) {
-        throw new Error('Failed to fetch alert template.');
+        const errData = await response.json().catch(() => null);
+        throw new Error(extractApiError(errData, 'Failed to fetch alert template.'));
       }
       const data = await response.json();
       const template = (data.data ?? data.template ?? data) as AlertTemplateResponse;
@@ -709,8 +711,8 @@ export default function AlertTemplateEditor({ templateId }: AlertTemplateEditorP
       });
 
       if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to save alert template.');
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to save alert template.'));
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred.');

--- a/apps/web/src/components/auditBaselines/BaselineApplyTab.tsx
+++ b/apps/web/src/components/auditBaselines/BaselineApplyTab.tsx
@@ -8,6 +8,7 @@ import {
   AlertTriangle,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { extractApiError } from '@/lib/apiError';
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
 import type { Baseline } from './BaselineFormModal';
@@ -76,7 +77,10 @@ export default function BaselineApplyTab({ baseline, mode }: Props) {
       if (currentOrgId) params.set('orgId', currentOrgId);
       if (baseline) params.set('baselineId', baseline.id);
       const response = await fetchWithAuth(`/audit-baselines/apply-requests?${params.toString()}`);
-      if (!response.ok) throw new Error('Failed to fetch approval requests');
+      if (!response.ok) {
+        const errBody = await response.json().catch(() => null);
+        throw new Error(extractApiError(errBody, 'Failed to fetch approval requests'));
+      }
       const data = await response.json();
       setApprovals(Array.isArray(data.data) ? data.data : []);
     } catch (err) {
@@ -93,7 +97,10 @@ export default function BaselineApplyTab({ baseline, mode }: Props) {
       const params = new URLSearchParams();
       if (currentOrgId) params.set('orgId', currentOrgId);
       const response = await fetchWithAuth(`/devices?${params.toString()}`);
-      if (!response.ok) throw new Error('Failed to fetch devices');
+      if (!response.ok) {
+        const errBody = await response.json().catch(() => null);
+        throw new Error(extractApiError(errBody, 'Failed to fetch devices'));
+      }
       const data = await response.json();
       const allDevices: Device[] = Array.isArray(data.data) ? data.data : Array.isArray(data) ? data : [];
       // Filter to matching OS type
@@ -152,8 +159,8 @@ export default function BaselineApplyTab({ baseline, mode }: Props) {
         body: JSON.stringify(body),
       });
       if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || 'Dry run failed');
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Dry run failed'));
       }
       const data = await response.json();
       setDryRunResult({ skipped: data.skipped ?? [] });
@@ -181,8 +188,8 @@ export default function BaselineApplyTab({ baseline, mode }: Props) {
         body: JSON.stringify(body),
       });
       if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to create approval request');
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to create approval request'));
       }
       setStep('requested');
       fetchApprovals();
@@ -205,8 +212,8 @@ export default function BaselineApplyTab({ baseline, mode }: Props) {
         body: JSON.stringify(body),
       });
       if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to process decision');
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to process decision'));
       }
       fetchApprovals();
     } catch (err) {
@@ -234,8 +241,8 @@ export default function BaselineApplyTab({ baseline, mode }: Props) {
         body: JSON.stringify(body),
       });
       if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to apply baseline');
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to apply baseline'));
       }
       fetchApprovals();
     } catch (err) {

--- a/apps/web/src/components/auditBaselines/BaselineFormModal.tsx
+++ b/apps/web/src/components/auditBaselines/BaselineFormModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { X, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { extractApiError } from '@/lib/apiError';
 import { Dialog } from '../shared/Dialog';
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
@@ -87,8 +88,8 @@ export default function BaselineFormModal({ baseline, onClose, onSaved }: Props)
       });
 
       if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to save baseline');
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to save baseline'));
       }
 
       onSaved();

--- a/apps/web/src/components/automations/AutomationEditPage.tsx
+++ b/apps/web/src/components/automations/AutomationEditPage.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft } from 'lucide-react';
 import AutomationForm, { type ActionFormValues, type AutomationFormValues } from './AutomationForm';
 import { fetchWithAuth } from '../../stores/auth';
 import type { DeploymentTargetConfig } from '@breeze/shared';
+import { extractApiError } from '@/lib/apiError';
 import { navigateTo } from '@/lib/navigation';
 import Breadcrumbs from '../layout/Breadcrumbs';
 
@@ -272,7 +273,7 @@ export default function AutomationEditPage({ automationId, isNew = false }: Auto
 
       if (!response.ok) {
         const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to save automation');
+        throw new Error(extractApiError(data, 'Failed to save automation'));
       }
 
       void navigateTo('/automations');

--- a/apps/web/src/components/backup/EncryptionKeyList.tsx
+++ b/apps/web/src/components/backup/EncryptionKeyList.tsx
@@ -9,6 +9,7 @@ import {
   XCircle,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { extractApiError } from '@/lib/apiError';
 import { fetchWithAuth } from '../../stores/auth';
 import { formatTime } from './backupDashboardHelpers';
 import AlphaBadge from '../shared/AlphaBadge';
@@ -57,7 +58,10 @@ export default function EncryptionKeyList() {
     try {
       setError(undefined);
       const response = await fetchWithAuth('/backup/encryption/keys');
-      if (!response.ok) throw new Error('Failed to fetch encryption keys');
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to fetch encryption keys'));
+      }
       const payload = await response.json();
       const data = payload?.data ?? payload ?? [];
       setKeys(Array.isArray(data) ? data : []);
@@ -87,8 +91,8 @@ export default function EncryptionKeyList() {
         body: JSON.stringify({ name: newName, keyType: newKeyType }),
       });
       if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to create key');
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to create key'));
       }
       const payload = await response.json();
       const created = payload?.data ?? payload ?? {};
@@ -114,7 +118,10 @@ export default function EncryptionKeyList() {
       const response = await fetchWithAuth(`/backup/encryption/keys/${rotatingKeyId}/rotate`, {
         method: 'POST',
       });
-      if (!response.ok) throw new Error('Failed to rotate key');
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to rotate key'));
+      }
       rotateDialogRef.current?.close();
       await fetchKeys();
     } catch (err) {
@@ -131,7 +138,10 @@ export default function EncryptionKeyList() {
         method: 'PATCH',
         body: JSON.stringify({ status: 'deactivated' }),
       });
-      if (!response.ok) throw new Error('Failed to deactivate key');
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to deactivate key'));
+      }
       await fetchKeys();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to deactivate key');

--- a/apps/web/src/components/backup/SLAConfigDialog.tsx
+++ b/apps/web/src/components/backup/SLAConfigDialog.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Loader2, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { extractApiError } from '@/lib/apiError';
 import { fetchWithAuth } from '../../stores/auth';
 
 // ── Types ──────────────────────────────────────────────────────────
@@ -111,8 +112,8 @@ export default function SLAConfigDialog({ config, onClose }: SLAConfigDialogProp
       });
 
       if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || `Failed to ${isEdit ? 'update' : 'create'} SLA config`);
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, `Failed to ${isEdit ? 'update' : 'create'} SLA config`));
       }
 
       onClose(true);

--- a/apps/web/src/components/backup/VMRestoreWizard.tsx
+++ b/apps/web/src/components/backup/VMRestoreWizard.tsx
@@ -10,6 +10,7 @@ import {
   Zap,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { extractApiError } from '@/lib/apiError';
 import { fetchWithAuth } from '../../stores/auth';
 import { formatBytes, formatTime } from './backupDashboardHelpers';
 import VMRestoreSpecsStep from './VMRestoreSpecsStep';
@@ -171,8 +172,8 @@ export default function VMRestoreWizard() {
       });
 
       if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to start restore');
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to start restore'));
       }
 
       setRestoreSuccess(

--- a/apps/web/src/components/backup/VaultConfigDialog.tsx
+++ b/apps/web/src/components/backup/VaultConfigDialog.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { HardDrive, Loader2, Server, Usb, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { extractApiError } from '@/lib/apiError';
 import { fetchWithAuth } from '../../stores/auth';
 
 // ── Types ──────────────────────────────────────────────────────────
@@ -99,8 +100,8 @@ export default function VaultConfigDialog({ vault, onClose }: VaultConfigDialogP
       });
 
       if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || `Failed to ${isEdit ? 'update' : 'create'} vault`);
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, `Failed to ${isEdit ? 'update' : 'create'} vault`));
       }
 
       onClose(true);

--- a/apps/web/src/components/cisHardening/CisBaselineForm.tsx
+++ b/apps/web/src/components/cisHardening/CisBaselineForm.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Loader2, X } from 'lucide-react';
 import { fetchWithAuth } from '@/stores/auth';
+import { extractApiError } from '@/lib/apiError';
 import type { Baseline } from './types';
 import HelpTooltip from '../shared/HelpTooltip';
 
@@ -57,7 +58,7 @@ export default function CisBaselineForm({ baseline, onClose, onSaved }: CisBasel
 
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || `${res.status} ${res.statusText}`);
+        throw new Error(extractApiError(data, `${res.status} ${res.statusText}`));
       }
 
       onSaved();

--- a/apps/web/src/components/cisHardening/CisBaselinesTab.tsx
+++ b/apps/web/src/components/cisHardening/CisBaselinesTab.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Loader2, Pencil, Play, Plus } from 'lucide-react';
 import { cn, friendlyFetchError } from '@/lib/utils';
+import { extractApiError } from '@/lib/apiError';
 import { fetchWithAuth } from '@/stores/auth';
 import CisBaselineForm from './CisBaselineForm';
 import type { Baseline } from './types';
@@ -62,7 +63,7 @@ export default function CisBaselinesTab({ refreshKey, onMutate }: CisBaselinesTa
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || `${res.status} ${res.statusText}`);
+        throw new Error(extractApiError(data, `${res.status} ${res.statusText}`));
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to trigger scan');

--- a/apps/web/src/components/configurationPolicies/AssignmentsTab.tsx
+++ b/apps/web/src/components/configurationPolicies/AssignmentsTab.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Plus, Trash2, Search, ChevronDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { extractApiError } from '@/lib/apiError';
 import { fetchWithAuth } from '../../stores/auth';
 import { DEVICE_ROLES, getDeviceRoleLabel } from '@/lib/deviceRoles';
 import HelpTooltip from '../shared/HelpTooltip';
@@ -66,7 +67,10 @@ export default function AssignmentsTab({ policyId, orgId }: Props) {
     try {
       setAssignmentsLoading(true);
       const response = await fetchWithAuth(`/configuration-policies/${policyId}/assignments`);
-      if (!response.ok) throw new Error('Failed to fetch assignments');
+      if (!response.ok) {
+        const errBody = await response.json().catch(() => null);
+        throw new Error(extractApiError(errBody, 'Failed to fetch assignments'));
+      }
       const data = await response.json();
       setAssignments(Array.isArray(data.data) ? data.data : []);
     } catch (err) {
@@ -95,7 +99,10 @@ export default function AssignmentsTab({ policyId, orgId }: Props) {
       const url = endpointMap[level];
       if (!url) return;
       const res = await fetchWithAuth(url);
-      if (!res.ok) throw new Error(`Failed to load targets (HTTP ${res.status})`);
+      if (!res.ok) {
+        const errBody = await res.json().catch(() => null);
+        throw new Error(extractApiError(errBody, `Failed to load targets (HTTP ${res.status})`));
+      }
       const data = await res.json();
       const items = Array.isArray(data.data) ? data.data : Array.isArray(data) ? data : [];
       const options: TargetOption[] = items.map((item: any) => ({
@@ -197,8 +204,8 @@ export default function AssignmentsTab({ policyId, orgId }: Props) {
         }),
       });
       if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to add assignment');
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to add assignment'));
       }
       setNewTargetId('');
       setNewPriority('0');
@@ -219,7 +226,10 @@ export default function AssignmentsTab({ policyId, orgId }: Props) {
         `/configuration-policies/${policyId}/assignments/${aid}`,
         { method: 'DELETE' }
       );
-      if (!response.ok) throw new Error('Failed to remove assignment');
+      if (!response.ok) {
+        const errBody = await response.json().catch(() => null);
+        throw new Error(extractApiError(errBody, 'Failed to remove assignment'));
+      }
       await fetchAssignments();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');

--- a/apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.tsx
@@ -7,6 +7,7 @@ import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
 import PolicyLinkSelector from './featureTabs/PolicyLinkSelector';
 import { navigateTo } from '@/lib/navigation';
+import { extractApiError } from '@/lib/apiError';
 import Breadcrumbs from '../layout/Breadcrumbs';
 
 const createPolicySchema = z.object({
@@ -46,8 +47,8 @@ export default function ConfigPolicyCreatePage() {
       });
 
       if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to create policy');
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to create policy'));
       }
 
       const policy = await response.json();

--- a/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
@@ -21,6 +21,7 @@ import {
 } from 'lucide-react';
 import Breadcrumbs from '../layout/Breadcrumbs';
 import { cn } from '@/lib/utils';
+import { extractApiError } from '@/lib/apiError';
 import { OverflowTabs } from '../shared/OverflowTabs';
 import { fetchWithAuth } from '../../stores/auth';
 import type { FeatureType, FeatureLink } from './featureTabs/types';
@@ -117,7 +118,10 @@ export default function ConfigPolicyDetailPage({ policyId }: ConfigPolicyDetailP
       setLoading(true);
       setError(undefined);
       const response = await fetchWithAuth(`/configuration-policies/${policyId}`);
-      if (!response.ok) throw new Error('Failed to fetch policy');
+      if (!response.ok) {
+        const errBody = await response.json().catch(() => null);
+        throw new Error(extractApiError(errBody, 'Failed to fetch policy'));
+      }
       const data = await response.json();
       setPolicy(data);
       setEditName(data.name);
@@ -135,7 +139,10 @@ export default function ConfigPolicyDetailPage({ policyId }: ConfigPolicyDetailP
     if (!policyId) return;
     try {
       const response = await fetchWithAuth(`/configuration-policies/${policyId}/features`);
-      if (!response.ok) throw new Error('Failed to fetch features');
+      if (!response.ok) {
+        const errBody = await response.json().catch(() => null);
+        throw new Error(extractApiError(errBody, 'Failed to fetch features'));
+      }
       const data = await response.json();
       setFeatureLinks(Array.isArray(data.data) ? data.data : []);
     } catch {
@@ -189,8 +196,8 @@ export default function ConfigPolicyDetailPage({ policyId }: ConfigPolicyDetailP
         }),
       });
       if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to update policy');
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to update policy'));
       }
       const updated = await response.json();
       setPolicy(updated);

--- a/apps/web/src/components/configurationPolicies/featureTabs/BackupTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/BackupTab.tsx
@@ -17,6 +17,7 @@ import { FEATURE_META } from './types';
 import { useFeatureLink } from './useFeatureLink';
 import FeatureTabShell from './FeatureTabShell';
 import { fetchWithAuth } from '../../../stores/auth';
+import { extractApiError } from '@/lib/apiError';
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -536,8 +537,8 @@ export default function BackupTab({ policyId, existingLink, onLinkChanged, linke
       });
 
       if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to create backup config');
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to create backup config'));
       }
 
       const created = await response.json();

--- a/apps/web/src/components/configurationPolicies/featureTabs/useFeatureLink.ts
+++ b/apps/web/src/components/configurationPolicies/featureTabs/useFeatureLink.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { fetchWithAuth } from '../../../stores/auth';
+import { extractApiError } from '@/lib/apiError';
 import type { FeatureType, FeatureLink } from './types';
 
 type SavePayload = {
@@ -38,8 +39,8 @@ export function useFeatureLink(policyId: string) {
         });
 
         if (!response.ok) {
-          const data = await response.json().catch(() => ({}));
-          throw new Error(data.error || `Failed to ${existingLinkId ? 'update' : 'create'} feature link`);
+          const data = await response.json().catch(() => null);
+          throw new Error(extractApiError(data, `Failed to ${existingLinkId ? 'update' : 'create'} feature link`));
         }
 
         const result = await response.json();
@@ -63,7 +64,10 @@ export function useFeatureLink(policyId: string) {
           `/configuration-policies/${policyId}/features/${linkId}`,
           { method: 'DELETE' }
         );
-        if (!response.ok) throw new Error('Failed to remove feature link');
+        if (!response.ok) {
+          const data = await response.json().catch(() => null);
+          throw new Error(extractApiError(data, 'Failed to remove feature link'));
+        }
         return true;
       } catch (err) {
         setError(err instanceof Error ? err.message : 'An error occurred');

--- a/apps/web/src/components/devices/ChangeSiteModal.tsx
+++ b/apps/web/src/components/devices/ChangeSiteModal.tsx
@@ -3,6 +3,7 @@ import { X, Loader2, MapPin } from 'lucide-react';
 import type { Device } from './DeviceList';
 import { Dialog } from '../shared/Dialog';
 import { fetchWithAuth } from '../../stores/auth';
+import { extractApiError } from '@/lib/apiError';
 
 type Site = {
   id: string;
@@ -70,7 +71,7 @@ export default function ChangeSiteModal({ device, isOpen, onClose, onSaved }: Ch
 
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to change site');
+        throw new Error(extractApiError(data, 'Failed to change site'));
       }
 
       onSaved();

--- a/apps/web/src/components/devices/DeviceSettingsModal.tsx
+++ b/apps/web/src/components/devices/DeviceSettingsModal.tsx
@@ -3,6 +3,7 @@ import { X, Loader2, Plus, Tag, Trash2 } from 'lucide-react';
 import type { Device } from './DeviceList';
 import { Dialog } from '../shared/Dialog';
 import { fetchWithAuth } from '../../stores/auth';
+import { extractApiError } from '@/lib/apiError';
 
 type Site = {
   id: string;
@@ -88,7 +89,7 @@ export default function DeviceSettingsModal({ device, isOpen, onClose, onSaved, 
 
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to save settings');
+        throw new Error(extractApiError(data, 'Failed to save settings'));
       }
 
       onSaved();

--- a/apps/web/src/components/discovery/DiscoveryJobList.tsx
+++ b/apps/web/src/components/discovery/DiscoveryJobList.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { CheckCircle, Clock, AlertTriangle, PlayCircle, X, ArrowRight, CalendarClock, Filter } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import { widthPercentClass } from '@/lib/utils';
+import { extractApiError } from '@/lib/apiError';
 
 export type DiscoveryJobStatus = 'scheduled' | 'running' | 'completed' | 'failed' | 'cancelled' | 'pending';
 
@@ -185,7 +186,7 @@ export default function DiscoveryJobList({ timezone, profileFilter, profileSubne
       const response = await fetchWithAuth(`/discovery/jobs/${jobId}/cancel`, { method: 'POST' });
       if (!response.ok) {
         const data = await response.json().catch(() => ({}));
-        throw new Error(data.error ?? 'Failed to cancel job');
+        throw new Error(extractApiError(data, 'Failed to cancel job'));
       }
       await fetchJobs(false);
     } catch (err) {

--- a/apps/web/src/components/integrations/MonitoringIntegration.tsx
+++ b/apps/web/src/components/integrations/MonitoringIntegration.tsx
@@ -13,6 +13,7 @@ import {
   Webhook
 } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { extractApiError } from '@/lib/apiError';
 
 type WebhookEndpoint = {
   id: string;
@@ -225,7 +226,8 @@ export default function MonitoringIntegration() {
       setLoadError(undefined);
       const response = await fetchWithAuth('/integrations/monitoring');
       if (!response.ok) {
-        throw new Error('Failed to load monitoring settings');
+        const errData = await response.json().catch(() => null);
+        throw new Error(extractApiError(errData, 'Failed to load monitoring settings'));
       }
       const data = await response.json();
       setSettings(normalizeSettings(data.data ?? data));
@@ -321,8 +323,8 @@ export default function MonitoringIntegration() {
       });
 
       if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.error || 'Failed to save monitoring settings');
+        const errorData = await response.json().catch(() => null);
+        throw new Error(extractApiError(errorData, 'Failed to save monitoring settings'));
       }
 
       setSaveState({ status: 'saved', message: 'Monitoring settings saved.' });
@@ -362,10 +364,10 @@ export default function MonitoringIntegration() {
         method: 'POST',
         body: JSON.stringify(payload)
       });
-      const data = await response.json().catch(() => ({}));
+      const data = (await response.json().catch(() => ({}))) as { message?: string };
 
       if (!response.ok) {
-        throw new Error(data.error || data.message || 'Connection test failed');
+        throw new Error(extractApiError(data, 'Connection test failed'));
       }
 
       updateTestResult(testKey, {

--- a/apps/web/src/components/integrations/PSAIntegration.tsx
+++ b/apps/web/src/components/integrations/PSAIntegration.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
+import { extractApiError } from '@/lib/apiError';
 
 type PsaProvider = 'connectwise' | 'autotask' | 'halo';
 type ConnectionStatus = 'connected' | 'needs-auth' | 'disconnected' | 'testing';
@@ -131,7 +132,8 @@ export default function PSAIntegration() {
           return;
         }
         if (!response.ok) {
-          throw new Error('Failed to load PSA configuration');
+          const errData = await response.json().catch(() => null);
+          throw new Error(extractApiError(errData, 'Failed to load PSA configuration'));
         }
         const payload = await response.json().catch(() => ({}));
         if (!isMounted) return;
@@ -239,7 +241,7 @@ export default function PSAIntegration() {
       const data = await response.json().catch(() => ({}));
 
       if (!response.ok) {
-        throw new Error(data.error || 'Failed to save configuration');
+        throw new Error(extractApiError(data, 'Failed to save configuration'));
       }
 
       setHasConfig(true);
@@ -279,7 +281,7 @@ export default function PSAIntegration() {
       const data = await response.json().catch(() => ({}));
 
       if (!response.ok || data.success === false) {
-        throw new Error(data.error || 'Connection test failed');
+        throw new Error(extractApiError(data, 'Connection test failed'));
       }
 
       setTestResult({

--- a/apps/web/src/components/integrations/PSAMappingEditor.tsx
+++ b/apps/web/src/components/integrations/PSAMappingEditor.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Save } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { extractApiError } from '@/lib/apiError';
 
 type MappingRow = {
   id: string;
@@ -71,7 +72,8 @@ export default function PSAMappingEditor() {
         return;
       }
       if (!response.ok) {
-        throw new Error('Failed to load PSA mappings');
+        const errData = await response.json().catch(() => null);
+        throw new Error(extractApiError(errData, 'Failed to load PSA mappings'));
       }
       const data = await response.json();
       const savedMappings = data.mappings ?? data.data ?? data ?? [];
@@ -106,8 +108,8 @@ export default function PSAMappingEditor() {
       });
 
       if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to save PSA mappings');
+        const data = await response.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to save PSA mappings'));
       }
 
       setSuccess('PSA mappings saved successfully.');

--- a/apps/web/src/components/integrations/TicketingIntegration.tsx
+++ b/apps/web/src/components/integrations/TicketingIntegration.tsx
@@ -11,6 +11,7 @@ import {
   ArrowLeftRight
 } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { extractApiError } from '@/lib/apiError';
 
 type ProviderId = 'zendesk' | 'freshdesk' | 'servicenow';
 
@@ -254,7 +255,8 @@ export default function TicketingIntegration() {
         setLoadError(undefined);
         const response = await fetchWithAuth('/integrations/ticketing');
         if (!response.ok) {
-          throw new Error('Failed to load ticketing settings');
+          const errData = await response.json().catch(() => null);
+          throw new Error(extractApiError(errData, 'Failed to load ticketing settings'));
         }
         const data = await response.json();
         const payload = data.data ?? data;
@@ -343,8 +345,8 @@ export default function TicketingIntegration() {
         body: JSON.stringify(buildPayload())
       });
       if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.error || 'Connection test failed');
+        const errorData = await response.json().catch(() => null);
+        throw new Error(extractApiError(errorData, 'Connection test failed'));
       }
       const data = await response.json().catch(() => ({}));
       setTestStatus({
@@ -370,8 +372,8 @@ export default function TicketingIntegration() {
         body: JSON.stringify(buildPayload())
       });
       if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.error || 'Failed to save ticketing settings');
+        const errorData = await response.json().catch(() => null);
+        throw new Error(extractApiError(errorData, 'Failed to save ticketing settings'));
       }
       const data = await response.json().catch(() => ({}));
       setSaveStatus({

--- a/apps/web/src/components/integrations/WebhookEditor.tsx
+++ b/apps/web/src/components/integrations/WebhookEditor.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Check, Plus, Trash2, TriangleAlert } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { extractApiError } from '@/lib/apiError';
 
 type HeaderRow = { id: string; key: string; value: string };
 
@@ -110,8 +111,8 @@ export default function WebhookEditor({ webhookId, initialValues, onSave, onTest
         });
 
         if (!response.ok) {
-          const data = await response.json().catch(() => ({}));
-          throw new Error(data.error || 'Failed to save webhook');
+          const data = await response.json().catch(() => null);
+          throw new Error(extractApiError(data, 'Failed to save webhook'));
         }
 
         setSuccess('Webhook saved successfully.');
@@ -139,7 +140,7 @@ export default function WebhookEditor({ webhookId, initialValues, onSave, onTest
 
         if (!response.ok) {
           const data = await response.json().catch(() => ({}));
-          throw new Error(data.error || 'Test failed');
+          throw new Error(extractApiError(data, 'Test failed'));
         }
 
         setSuccess('Test webhook sent successfully.');

--- a/apps/web/src/components/integrations/WebhookTestPanel.tsx
+++ b/apps/web/src/components/integrations/WebhookTestPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Send } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { extractApiError } from '@/lib/apiError';
 
 type TestHistoryItem = {
   id: string;
@@ -120,7 +121,7 @@ export default function WebhookTestPanel({ webhookId, timezone }: WebhookTestPan
       const data = await apiResponse.json().catch(() => ({}));
 
       if (!apiResponse.ok) {
-        throw new Error(data.error || 'Test failed');
+        throw new Error(extractApiError(data, 'Test failed'));
       }
 
       setResponse({

--- a/apps/web/src/components/peripherals/PeripheralPolicyForm.tsx
+++ b/apps/web/src/components/peripherals/PeripheralPolicyForm.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { X, Plus, Trash2 } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { extractApiError } from '@/lib/apiError';
 
 type ExceptionRule = {
   vendor: string;
@@ -88,7 +89,7 @@ export default function PeripheralPolicyForm({ policy, onClose }: PeripheralPoli
       });
       if (!response.ok) {
         const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to save policy');
+        throw new Error(extractApiError(data, 'Failed to save policy'));
       }
       onClose(true);
     } catch (err) {

--- a/apps/web/src/components/remote/ConnectDesktopButton.tsx
+++ b/apps/web/src/components/remote/ConnectDesktopButton.tsx
@@ -4,6 +4,7 @@ import type { DesktopAccessState, RemoteAccessPolicy } from '@breeze/shared';
 import { fetchWithAuth } from '@/stores/auth';
 import { getViewerDownloadInfo, getAllViewerDownloads } from '@/lib/viewerDownload';
 import { buildRemoteVncPageUrl } from '@/lib/remoteTunnelUrls';
+import { extractApiError } from '@/lib/apiError';
 
 interface Props {
   deviceId: string;
@@ -176,7 +177,7 @@ export default function ConnectDesktopButton({ deviceId, className = '', compact
                 return;
               }
               if (data.status === 'failed') {
-                setError(data.errorMessage || 'VNC tunnel failed to open');
+                setError(extractApiError(data, 'VNC tunnel failed to open'));
                 setStatus('idle');
                 return;
               }

--- a/apps/web/src/components/remote/ConnectVncButton.tsx
+++ b/apps/web/src/components/remote/ConnectVncButton.tsx
@@ -3,6 +3,7 @@ import { Monitor, MonitorOff, ExternalLink, X, Globe } from 'lucide-react';
 import type { RemoteAccessPolicy } from '@breeze/shared';
 import { fetchWithAuth } from '@/stores/auth';
 import { buildRemoteVncPageUrl } from '@/lib/remoteTunnelUrls';
+import { extractApiError } from '@/lib/apiError';
 
 interface Props {
   deviceId: string;
@@ -105,7 +106,7 @@ export default function ConnectVncButton({
               return;
             }
             if (data.status === 'failed') {
-              throw new Error(data.errorMessage || 'Tunnel failed to open');
+              throw new Error(extractApiError(data, 'Tunnel failed to open'));
             }
           }
         } catch (e) {

--- a/apps/web/src/components/remote/ProxyTunnelPage.tsx
+++ b/apps/web/src/components/remote/ProxyTunnelPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import { ArrowLeft, Copy, Check, X, Globe, Network } from 'lucide-react';
 import { fetchWithAuth } from '@/stores/auth';
+import { extractApiError } from '@/lib/apiError';
 
 interface Props {
   tunnelId: string;
@@ -31,7 +32,7 @@ export default function ProxyTunnelPage({ tunnelId, target }: Props) {
         const data = await res.json();
         setStatus(data.status);
         if (data.status === 'failed') {
-          setError(data.errorMessage || 'Tunnel failed');
+          setError(extractApiError(data, 'Tunnel failed'));
         }
       }
     } catch { /* ignore */ }

--- a/apps/web/src/components/scripts/ScriptExecutionsPage.tsx
+++ b/apps/web/src/components/scripts/ScriptExecutionsPage.tsx
@@ -6,6 +6,7 @@ import ScriptExecutionModal, { type Device, type Site } from './ScriptExecutionM
 import type { Script } from './ScriptList';
 import type { ScriptParameter } from './ScriptForm';
 import { fetchWithAuth } from '../../stores/auth';
+import { extractApiError } from '@/lib/apiError';
 import { navigateTo } from '@/lib/navigation';
 import Breadcrumbs from '../layout/Breadcrumbs';
 
@@ -122,7 +123,7 @@ export default function ScriptExecutionsPage({ scriptId }: ScriptExecutionsPageP
         return;
       }
       const data = await response.json();
-      throw new Error(data.error || 'Failed to execute script');
+      throw new Error(extractApiError(data, 'Failed to execute script'));
     }
 
     // Refresh executions list

--- a/apps/web/src/components/scripts/ScriptsPage.tsx
+++ b/apps/web/src/components/scripts/ScriptsPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
+import { extractApiError } from '@/lib/apiError';
 import { Plus, Download, Search, X, Loader2, Check, FileCode, ArrowRight } from 'lucide-react';
 import ScriptList, { type Script, type ScriptLanguage, type OSType } from './ScriptList';
 import ScriptExecutionModal, { type Device, type Site } from './ScriptExecutionModal';
@@ -175,7 +176,7 @@ export default function ScriptsPage() {
     };
 
     if (!response.ok) {
-      throw new Error(data.error || 'Failed to execute script');
+      throw new Error(extractApiError(data, 'Failed to execute script'));
     }
 
     const candidateTimestamps = [
@@ -280,7 +281,7 @@ export default function ScriptsPage() {
         if (response.status === 409) {
           setError(`"${systemScript.name}" is already in your library`);
         } else {
-          throw new Error(data.error || 'Failed to import script');
+          throw new Error(extractApiError(data, 'Failed to import script'));
         }
         return;
       }

--- a/apps/web/src/components/settings/EnrollmentKeyManager.tsx
+++ b/apps/web/src/components/settings/EnrollmentKeyManager.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
 import { fallbackInstallerFilename, filenameFromContentDisposition } from '@/lib/downloadFilename';
+import { extractApiError } from '@/lib/apiError';
 import { navigateTo } from '@/lib/navigation';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { showToast } from '../shared/Toast';
@@ -140,7 +141,7 @@ export default function EnrollmentKeyManager() {
 
       if (!response.ok) {
         const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to create enrollment key');
+        throw new Error(extractApiError(data, 'Failed to create enrollment key'));
       }
 
       const created = await response.json().catch(() => ({} as Record<string, unknown>));
@@ -197,7 +198,7 @@ export default function EnrollmentKeyManager() {
 
       if (!response.ok) {
         const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to rotate enrollment key');
+        throw new Error(extractApiError(data, 'Failed to rotate enrollment key'));
       }
 
       const rotated = await response.json().catch(() => ({} as Record<string, unknown>));

--- a/apps/web/src/components/settings/OrgEventLogSettings.tsx
+++ b/apps/web/src/components/settings/OrgEventLogSettings.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Database, Save, Key, Link, ScrollText, Info } from 'lucide-react';
 import { useOrgStore } from '../../stores/orgStore';
 import { fetchWithAuth } from '../../stores/auth';
+import { extractApiError } from '@/lib/apiError';
 import { navigateTo } from '@/lib/navigation';
 import { showToast } from '../shared/Toast';
 
@@ -108,7 +109,7 @@ export default function OrgEventLogSettings({ onDirty, locked }: OrgEventLogSett
 
       if (!response.ok) {
         const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to save log forwarding settings');
+        throw new Error(extractApiError(data, 'Failed to save log forwarding settings'));
       }
 
       showToast({ message: 'Log forwarding settings saved', type: 'success' });

--- a/apps/web/src/components/settings/OrganizationsPage.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.tsx
@@ -5,6 +5,7 @@ import SiteList, { type Site } from './SiteList';
 import SiteForm from './SiteForm';
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
+import { extractApiError } from '@/lib/apiError';
 import { navigateTo } from '@/lib/navigation';
 
 type ModalMode = 'closed' | 'add' | 'edit' | 'delete';
@@ -349,7 +350,7 @@ export default function OrganizationsPage() {
 
       if (!response.ok) {
         const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || `Failed to save site (${response.status})`);
+        throw new Error(extractApiError(data, `Failed to save site (${response.status})`));
       }
 
       await fetchSites(selectedOrg.id);

--- a/apps/web/src/components/setup/AccountSetupStep.tsx
+++ b/apps/web/src/components/setup/AccountSetupStep.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Eye, EyeOff, Loader2 } from 'lucide-react';
 import { fetchWithAuth, apiLogin, useAuthStore } from '../../stores/auth';
+import { extractApiError } from '@/lib/apiError';
 
 interface AccountSetupStepProps {
   onNext: () => void;
@@ -43,9 +44,8 @@ export default function AccountSetupStep({ onNext }: AccountSetupStepProps) {
           body: JSON.stringify({ email })
         });
         if (!emailRes.ok) {
-          let msg = 'Failed to update email';
-          try { const data = await emailRes.json(); msg = data.error || msg; } catch { /* ignore parse error */ }
-          setError(msg);
+          const data = await emailRes.json().catch(() => null);
+          setError(extractApiError(data, 'Failed to update email'));
           setLoading(false);
           return;
         }
@@ -60,9 +60,8 @@ export default function AccountSetupStep({ onNext }: AccountSetupStepProps) {
           body: JSON.stringify({ currentPassword, newPassword })
         });
         if (!pwRes.ok) {
-          let msg = 'Failed to change password';
-          try { const data = await pwRes.json(); msg = data.error || msg; } catch { /* ignore parse error */ }
-          setError(msg);
+          const data = await pwRes.json().catch(() => null);
+          setError(extractApiError(data, 'Failed to change password'));
           setLoading(false);
           return;
         }

--- a/apps/web/src/components/setup/EnrollDeviceStep.tsx
+++ b/apps/web/src/components/setup/EnrollDeviceStep.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { Check, Copy, Loader2, Download, Link, ArrowLeft, Info } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { extractApiError } from '@/lib/apiError';
 import { fallbackInstallerFilename, filenameFromContentDisposition } from '@/lib/downloadFilename';
 import { showToast } from '../shared/Toast';
 
@@ -66,9 +67,8 @@ export default function EnrollDeviceStep({ orgId, siteId, onBack, onFinish: _onF
     try {
       const res = await fetchWithAuth('/devices/onboarding-token', { method: 'POST' });
       if (!res.ok) {
-        let msg = 'Failed to generate installation token';
-        try { const data = await res.json(); msg = data.error || data.message || msg; } catch { /* ignore */ }
-        setTokenError(msg);
+        const data = await res.json().catch(() => null);
+        setTokenError(extractApiError(data, 'Failed to generate installation token'));
         return;
       }
       const data = await res.json();

--- a/apps/web/src/components/setup/OrganizationSetupStep.tsx
+++ b/apps/web/src/components/setup/OrganizationSetupStep.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Building2, MapPin, Loader2 } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { extractApiError } from '@/lib/apiError';
 
 interface OrgData {
   partner?: { id: string; name: string; slug: string };
@@ -113,9 +114,8 @@ export default function OrganizationSetupStep({ onNext }: OrganizationSetupStepP
             body: JSON.stringify({ name: orgName })
           });
           if (!res.ok) {
-            let msg = 'Failed to update organization name';
-            try { const data = await res.json(); msg = data.error || msg; } catch { /* ignore */ }
-            setError(msg);
+            const data = await res.json().catch(() => null);
+            setError(extractApiError(data, 'Failed to update organization name'));
             setSaving(false);
             return;
           }
@@ -128,9 +128,8 @@ export default function OrganizationSetupStep({ onNext }: OrganizationSetupStepP
           body: JSON.stringify({ name, slug: slugify(name) })
         });
         if (!res.ok) {
-          let msg = 'Failed to create organization';
-          try { const data = await res.json(); msg = data.error || msg; } catch { /* ignore */ }
-          setError(msg);
+          const data = await res.json().catch(() => null);
+          setError(extractApiError(data, 'Failed to create organization'));
           setSaving(false);
           return;
         }
@@ -146,9 +145,8 @@ export default function OrganizationSetupStep({ onNext }: OrganizationSetupStepP
             body: JSON.stringify({ name: siteName })
           });
           if (!res.ok) {
-            let msg = 'Failed to update site name';
-            try { const data = await res.json(); msg = data.error || msg; } catch { /* ignore */ }
-            setError(msg);
+            const data = await res.json().catch(() => null);
+            setError(extractApiError(data, 'Failed to update site name'));
             setSaving(false);
             return;
           }
@@ -161,9 +159,8 @@ export default function OrganizationSetupStep({ onNext }: OrganizationSetupStepP
           body: JSON.stringify({ orgId: finalOrgId, name })
         });
         if (!res.ok) {
-          let msg = 'Failed to create site';
-          try { const data = await res.json(); msg = data.error || msg; } catch { /* ignore */ }
-          setError(msg);
+          const data = await res.json().catch(() => null);
+          setError(extractApiError(data, 'Failed to create site'));
           setSaving(false);
           return;
         }

--- a/apps/web/src/components/setup/SetupSummaryStep.tsx
+++ b/apps/web/src/components/setup/SetupSummaryStep.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { CheckCircle, Loader2 } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { extractApiError } from '@/lib/apiError';
 
 interface SetupSummaryStepProps {
   stepsVisited: boolean[];
@@ -19,9 +20,8 @@ export default function SetupSummaryStep({ stepsVisited }: SetupSummaryStepProps
     try {
       const res = await fetchWithAuth('/system/setup-complete', { method: 'POST' });
       if (!res.ok) {
-        let msg = 'Failed to complete setup';
-        try { const data = await res.json(); msg = data.error || msg; } catch { /* ignore parse error */ }
-        setError(msg);
+        const data = await res.json().catch(() => null);
+        setError(extractApiError(data, 'Failed to complete setup'));
         setLoading(false);
         return;
       }

--- a/apps/web/src/components/webhooks/WebhooksPage.tsx
+++ b/apps/web/src/components/webhooks/WebhooksPage.tsx
@@ -5,6 +5,7 @@ import WebhookForm, { type WebhookFormValues, webhookEventOptions } from './Webh
 import WebhookDeliveryHistory, { type WebhookDelivery } from './WebhookDeliveryHistory';
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
+import { extractApiError } from '@/lib/apiError';
 
 type ModalMode = 'closed' | 'create' | 'edit' | 'delete';
 
@@ -252,7 +253,7 @@ export default function WebhooksPage() {
 
       if (!response.ok) {
         const data = await response.json();
-        throw new Error(data.error || 'Failed to save webhook');
+        throw new Error(extractApiError(data, 'Failed to save webhook'));
       }
 
       await fetchWebhooks();

--- a/apps/web/src/lib/apiError.test.ts
+++ b/apps/web/src/lib/apiError.test.ts
@@ -86,4 +86,12 @@ describe('extractApiError', () => {
   it('returns fallback for object with no recognized fields', () => {
     expect(extractApiError({ foo: 'bar', baz: 42 }, FALLBACK)).toBe(FALLBACK);
   });
+
+  it('handles legacy errorMessage field (remote/proxy tunnel endpoints)', () => {
+    expect(extractApiError({ errorMessage: 'Tunnel timed out' }, FALLBACK)).toBe('Tunnel timed out');
+  });
+
+  it('prefers error over errorMessage when both exist', () => {
+    expect(extractApiError({ error: 'real', errorMessage: 'legacy' }, FALLBACK)).toBe('real');
+  });
 });

--- a/apps/web/src/lib/apiError.ts
+++ b/apps/web/src/lib/apiError.ts
@@ -51,5 +51,13 @@ export function extractApiError(data: unknown, fallback: string): string {
     parts.push(body.message);
   }
 
+  // Some legacy endpoints (remote/proxy tunnel) emit `errorMessage` instead.
+  if (parts.length === 0) {
+    const errorMessage = (data as { errorMessage?: unknown }).errorMessage;
+    if (typeof errorMessage === 'string' && errorMessage.length > 0) {
+      parts.push(errorMessage);
+    }
+  }
+
   return parts.length > 0 ? parts.join(': ') : fallback;
 }

--- a/apps/web/src/stores/aiStore.ts
+++ b/apps/web/src/stores/aiStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { AiPageContext, AiStreamEvent, AiApprovalMode } from '@breeze/shared';
 import { fetchWithAuth } from './auth';
+import { extractApiError } from '@/lib/apiError';
 import {
   processStreamEvent,
   mapMessagesFromApi,
@@ -110,8 +111,8 @@ export const useAiStore = create<AiState>()(
         body: JSON.stringify({ pageContext: pageContext ?? undefined })
       });
       if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error || 'Failed to create session');
+        const data = await res.json().catch(() => null);
+        throw new Error(extractApiError(data, 'Failed to create session'));
       }
       const data = await res.json();
       set({ sessionId: data.id, messages: [], isLoading: false, isFlagged: false, flagReason: null });
@@ -212,17 +213,17 @@ export const useAiStore = create<AiState>()(
       });
 
       if (!res.ok) {
-        const data = await res.json().catch(() => ({ error: 'Failed to send message' }));
+        const data = await res.json().catch(() => null);
 
         if (res.status === 409) {
           set((s) => ({
             messages: s.messages.filter((m) => m.id !== userMsgId),
-            error: data.error || 'Another response is still in progress for this conversation.'
+            error: extractApiError(data, 'Another response is still in progress for this conversation.')
           }));
           return;
         }
 
-        throw new Error(data.error || 'Failed to send message');
+        throw new Error(extractApiError(data, 'Failed to send message'));
       }
 
       const reader = res.body?.getReader();
@@ -277,8 +278,8 @@ export const useAiStore = create<AiState>()(
         body: JSON.stringify({ approved })
       });
       if (!res.ok) {
-        const data = await res.json().catch(() => ({ error: 'Unknown error' }));
-        set({ error: data.error || 'Failed to process approval. It may have timed out.' });
+        const data = await res.json().catch(() => null);
+        set({ error: extractApiError(data, 'Failed to process approval. It may have timed out.') });
         return;
       }
       set({ pendingApproval: null });
@@ -298,8 +299,8 @@ export const useAiStore = create<AiState>()(
         body: JSON.stringify({ approved })
       });
       if (!res.ok) {
-        const data = await res.json().catch(() => ({ error: 'Unknown error' }));
-        set({ error: data.error || 'Failed to process plan approval' });
+        const data = await res.json().catch(() => null);
+        set({ error: extractApiError(data, 'Failed to process plan approval') });
         return;
       }
       if (approved) {
@@ -333,8 +334,8 @@ export const useAiStore = create<AiState>()(
         method: 'POST'
       });
       if (!res.ok) {
-        const data = await res.json().catch(() => ({ error: 'Unknown error' }));
-        set({ error: data.error || 'Failed to abort plan' });
+        const data = await res.json().catch(() => null);
+        set({ error: extractApiError(data, 'Failed to abort plan') });
         return;
       }
       set({ activePlan: null });
@@ -354,8 +355,8 @@ export const useAiStore = create<AiState>()(
         body: JSON.stringify({ paused })
       });
       if (!res.ok) {
-        const data = await res.json().catch(() => ({ error: 'Unknown error' }));
-        set({ error: data.error || 'Failed to pause AI' });
+        const data = await res.json().catch(() => null);
+        set({ error: extractApiError(data, 'Failed to pause AI') });
         return;
       }
       set({ isPaused: paused });
@@ -415,8 +416,8 @@ export const useAiStore = create<AiState>()(
         const data = await res.json();
         set({ searchResults: data.data || [], isSearching: false });
       } else {
-        const data = await res.json().catch(() => ({ error: 'Search failed' }));
-        set({ isSearching: false, error: data.error || 'Search failed' });
+        const data = await res.json().catch(() => null);
+        set({ isSearching: false, error: extractApiError(data, 'Search failed') });
       }
     } catch (err) {
       console.error('[AI] Search failed:', err);
@@ -457,8 +458,8 @@ export const useAiStore = create<AiState>()(
         body: JSON.stringify({ reason }),
       });
       if (!res.ok) {
-        const data = await res.json().catch(() => ({ error: 'Failed to flag session' }));
-        set({ error: data.error || 'Failed to flag session' });
+        const data = await res.json().catch(() => null);
+        set({ error: extractApiError(data, 'Failed to flag session') });
         return;
       }
       set({ isFlagged: true, flagReason: reason ?? null });
@@ -474,8 +475,8 @@ export const useAiStore = create<AiState>()(
     try {
       const res = await fetchWithAuth(`/ai/sessions/${sessionId}/flag`, { method: 'DELETE' });
       if (!res.ok) {
-        const data = await res.json().catch(() => ({ error: 'Failed to unflag session' }));
-        set({ error: data.error || 'Failed to unflag session' });
+        const data = await res.json().catch(() => null);
+        set({ error: extractApiError(data, 'Failed to unflag session') });
         return;
       }
       set({ isFlagged: false, flagReason: null });

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { extractApiError } from '@/lib/apiError';
 
 export interface UserPreferences {
   theme?: 'light' | 'dark' | 'system';
@@ -376,7 +377,7 @@ export async function apiLogin(email: string, password: string): Promise<{
     const data = await response.json();
 
     if (!response.ok) {
-      return { success: false, error: data.error || 'Login failed' };
+      return { success: false, error: extractApiError(data, 'Login failed') };
     }
 
     if (data.mfaRequired) {
@@ -420,7 +421,7 @@ export async function apiVerifyMFA(code: string, tempToken: string, method?: Mfa
     const data = await response.json();
 
     if (!response.ok) {
-      return { success: false, error: data.error || 'MFA verification failed' };
+      return { success: false, error: extractApiError(data, 'MFA verification failed') };
     }
 
     const user = data.user ? { ...data.user, requiresSetup: !!data.requiresSetup } : data.user;
@@ -464,7 +465,7 @@ export async function apiRegister(
     const data = await response.json();
 
     if (!response.ok) {
-      return { success: false, error: data.error || 'Registration failed' };
+      return { success: false, error: extractApiError(data, 'Registration failed') };
     }
 
     return {
@@ -502,7 +503,7 @@ export async function apiRegisterPartner(
     const data = await response.json();
 
     if (!response.ok) {
-      return { success: false, error: data.error || 'Registration failed' };
+      return { success: false, error: extractApiError(data, 'Registration failed') };
     }
 
     return {
@@ -590,10 +591,10 @@ export async function apiForgotPassword(email: string): Promise<{
       body: JSON.stringify({ email })
     });
 
-    const data = await response.json();
+    const data = await response.json().catch(() => null);
 
     if (!response.ok) {
-      return { success: false, error: data.error };
+      return { success: false, error: extractApiError(data, 'Failed to send reset email') };
     }
 
     return { success: true };
@@ -615,10 +616,10 @@ export async function apiResetPassword(token: string, password: string): Promise
       body: JSON.stringify({ token, password })
     });
 
-    const data = await response.json();
+    const data = await response.json().catch(() => null);
 
     if (!response.ok) {
-      return { success: false, error: data.error };
+      return { success: false, error: extractApiError(data, 'Failed to reset password') };
     }
 
     return { success: true };
@@ -663,9 +664,9 @@ export async function apiResendVerification(): Promise<{ success: boolean; error
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
     });
-    const data = await response.json().catch(() => ({}));
+    const data = await response.json().catch(() => null);
     if (!response.ok) {
-      return { success: false, error: data?.error ?? 'Failed to resend verification email' };
+      return { success: false, error: extractApiError(data, 'Failed to resend verification email') };
     }
     return { success: true };
   } catch {
@@ -687,7 +688,7 @@ export async function apiSendSmsMfaCode(tempToken: string): Promise<{
     const data = await response.json();
 
     if (!response.ok) {
-      return { success: false, error: data.error || 'Failed to send SMS code' };
+      return { success: false, error: extractApiError(data, 'Failed to send SMS code') };
     }
 
     return { success: true };
@@ -709,7 +710,7 @@ export async function apiVerifyPhone(phoneNumber: string, currentPassword: strin
     const data = await response.json();
 
     if (!response.ok) {
-      return { success: false, error: data.error || 'Failed to send verification code' };
+      return { success: false, error: extractApiError(data, 'Failed to send verification code') };
     }
 
     return { success: true };
@@ -731,7 +732,7 @@ export async function apiConfirmPhone(phoneNumber: string, code: string, current
     const data = await response.json();
 
     if (!response.ok) {
-      return { success: false, error: data.error || 'Failed to verify phone' };
+      return { success: false, error: extractApiError(data, 'Failed to verify phone') };
     }
 
     return { success: true };
@@ -754,7 +755,7 @@ export async function apiEnableSmsMfa(currentPassword: string): Promise<{
     const data = await response.json();
 
     if (!response.ok) {
-      return { success: false, error: data.error || 'Failed to enable SMS MFA' };
+      return { success: false, error: extractApiError(data, 'Failed to enable SMS MFA') };
     }
 
     return { success: true, recoveryCodes: data.recoveryCodes };
@@ -815,7 +816,7 @@ export async function apiAcceptInvite(token: string, password: string): Promise<
     const data = await response.json();
 
     if (!response.ok) {
-      return { success: false, error: data.error || 'Failed to accept invite' };
+      return { success: false, error: extractApiError(data, 'Failed to accept invite') };
     }
 
     return { success: true, user: data.user, tokens: data.tokens };

--- a/apps/web/src/stores/scriptAiStore.ts
+++ b/apps/web/src/stores/scriptAiStore.ts
@@ -8,6 +8,7 @@
 
 import { create } from 'zustand';
 import { fetchWithAuth } from './auth';
+import { extractApiError } from '@/lib/apiError';
 import type {
   AiStreamEvent,
   ScriptBuilderContext,
@@ -195,8 +196,8 @@ export const useScriptAiStore = create<ScriptAiState>()(
           body: JSON.stringify({ context }),
         });
         if (!res.ok) {
-          const data = await res.json().catch(() => ({ error: 'Failed to create session' }));
-          throw new Error(data.error || 'Failed to create session');
+          const data = await res.json().catch(() => null);
+          throw new Error(extractApiError(data, 'Failed to create session'));
         }
         const data = await res.json();
         set({
@@ -272,18 +273,18 @@ export const useScriptAiStore = create<ScriptAiState>()(
         );
 
         if (!res.ok) {
-          const data = await res.json().catch(() => ({ error: 'Failed to send message' }));
+          const data = await res.json().catch(() => null);
 
           // Conflict — remove optimistic message
           if (res.status === 409) {
             set((s) => ({
               messages: s.messages.filter((m) => m.id !== userMsgId),
-              error: data.error || 'Another response is still in progress.',
+              error: extractApiError(data, 'Another response is still in progress.'),
             }));
             return;
           }
 
-          throw new Error(data.error || 'Failed to send message');
+          throw new Error(extractApiError(data, 'Failed to send message'));
         }
 
         // Process SSE stream
@@ -367,8 +368,8 @@ export const useScriptAiStore = create<ScriptAiState>()(
           }
         );
         if (!res.ok) {
-          const data = await res.json().catch(() => ({ error: 'Unknown error' }));
-          set({ error: data.error || 'Failed to process approval. It may have timed out.' });
+          const data = await res.json().catch(() => null);
+          set({ error: extractApiError(data, 'Failed to process approval. It may have timed out.') });
           return;
         }
         set({ pendingApproval: null });

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { AiPageContext, AiStreamEvent, AiApprovalMode } from '@breeze/shared';
 import { fetchWithAuth } from './auth';
+import { extractApiError } from '@/lib/apiError';
 import {
   processStreamEvent,
   mapMessagesFromApi,
@@ -178,8 +179,8 @@ export const useWorkspaceStore = create<WorkspaceState>()(
                 body: JSON.stringify({ pageContext: tab.pageContext ?? undefined }),
               });
               if (!res.ok) {
-                const data = await res.json();
-                throw new Error(data.error || 'Failed to create session');
+                const data = await res.json().catch(() => null);
+                throw new Error(extractApiError(data, 'Failed to create session'));
               }
               const data = await res.json();
               sessionId = data.id;
@@ -218,18 +219,18 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             });
 
             if (!res.ok) {
-              const data = await res.json().catch(() => ({ error: 'Failed to send message' }));
+              const data = await res.json().catch(() => null);
               if (res.status === 409) {
                 set((s) => ({
                   tabs: s.tabs.map((t) =>
                     t.id === tabId
-                      ? { ...t, messages: t.messages.filter((m) => m.id !== userMsgId), error: data.error || 'Another response is still in progress.' }
+                      ? { ...t, messages: t.messages.filter((m) => m.id !== userMsgId), error: extractApiError(data, 'Another response is still in progress.') }
                       : t
                   ),
                 }));
                 return;
               }
-              throw new Error(data.error || 'Failed to send message');
+              throw new Error(extractApiError(data, 'Failed to send message'));
             }
 
             const reader = res.body?.getReader();
@@ -339,8 +340,8 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               body: JSON.stringify({ approved }),
             });
             if (!res.ok) {
-              const data = await res.json().catch(() => ({ error: 'Unknown error' }));
-              updateTab(tabId, { error: data.error || 'Failed to process approval. It may have timed out.' });
+              const data = await res.json().catch(() => null);
+              updateTab(tabId, { error: extractApiError(data, 'Failed to process approval. It may have timed out.') });
               return;
             }
             updateTab(tabId, { pendingApproval: null, hasApprovalPending: false });
@@ -360,8 +361,8 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               body: JSON.stringify({ approved }),
             });
             if (!res.ok) {
-              const data = await res.json().catch(() => ({ error: 'Unknown error' }));
-              updateTab(tabId, { error: data.error || 'Failed to process plan approval' });
+              const data = await res.json().catch(() => null);
+              updateTab(tabId, { error: extractApiError(data, 'Failed to process plan approval') });
               return;
             }
             if (approved && tab.pendingPlan) {
@@ -393,8 +394,8 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               method: 'POST',
             });
             if (!res.ok) {
-              const data = await res.json().catch(() => ({ error: 'Unknown error' }));
-              updateTab(tabId, { error: data.error || 'Failed to abort plan' });
+              const data = await res.json().catch(() => null);
+              updateTab(tabId, { error: extractApiError(data, 'Failed to abort plan') });
               return;
             }
             updateTab(tabId, { activePlan: null });
@@ -414,8 +415,8 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               body: JSON.stringify({ paused }),
             });
             if (!res.ok) {
-              const data = await res.json().catch(() => ({ error: 'Unknown error' }));
-              updateTab(tabId, { error: data.error || 'Failed to pause AI' });
+              const data = await res.json().catch(() => null);
+              updateTab(tabId, { error: extractApiError(data, 'Failed to pause AI') });
               return;
             }
             updateTab(tabId, { isPaused: paused });
@@ -454,8 +455,8 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               body: JSON.stringify({ reason }),
             });
             if (!res.ok) {
-              const data = await res.json().catch(() => ({ error: 'Failed to flag session' }));
-              updateTab(tabId, { error: data.error || 'Failed to flag session' });
+              const data = await res.json().catch(() => null);
+              updateTab(tabId, { error: extractApiError(data, 'Failed to flag session') });
               return;
             }
             updateTab(tabId, { isFlagged: true });
@@ -472,8 +473,8 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           try {
             const res = await fetchWithAuth(`/ai/sessions/${tab.sessionId}/flag`, { method: 'DELETE' });
             if (!res.ok) {
-              const data = await res.json().catch(() => ({ error: 'Failed to unflag session' }));
-              updateTab(tabId, { error: data.error || 'Failed to unflag session' });
+              const data = await res.json().catch(() => null);
+              updateTab(tabId, { error: extractApiError(data, 'Failed to unflag session') });
               return;
             }
             updateTab(tabId, { isFlagged: false });


### PR DESCRIPTION
## Summary

Follow-up to #686. That PR introduced `apps/web/src/lib/apiError.ts` (`extractApiError`) but only adopted it in one component — the silent-failure review flagged 40+ other sites in the web app still doing `throw new Error(data.error || '...')` that render `[object Object]` whenever the API returns a structured zod issues body.

This PR finishes the rollout: every fetch-error rendering site in `apps/web/src/` now goes through `extractApiError`.

## Changes

**Helper (`apps/web/src/lib/apiError.ts`):**

- Added `errorMessage` to the shape cascade (used by remote/proxy tunnel endpoints — `ConnectVncButton`, `ConnectDesktopButton`, `ProxyTunnelPage`).
- 2 new unit tests covering the legacy shape and the error/errorMessage precedence.
- Final cascade: `error` → `details` (concatenated when both present) → top-level `issues` → `message` → `errorMessage`.

**Adoption sites (~80 across 43 files):**

- alerts/integrations (9 files): AlertRuleEditPage, AlertTemplateEditor, AlertRulesPage, MonitoringIntegration, PSAIntegration, PSAMappingEditor, TicketingIntegration, WebhookEditor, WebhookTestPanel
- backup/DR (4 files): VaultConfigDialog, VMRestoreWizard, EncryptionKeyList, SLAConfigDialog
- configuration policies (5 files): ConfigPolicyCreatePage, ConfigPolicyDetailPage, AssignmentsTab, featureTabs/BackupTab, featureTabs/useFeatureLink
- audit baselines (2 files): BaselineFormModal, BaselineApplyTab
- scripts/CIS/devices/settings (8 files): ScriptsPage, ScriptExecutionsPage, CisBaselinesTab, CisBaselineForm, DeviceSettingsModal, ChangeSiteModal, EnrollmentKeyManager, OrgEventLogSettings, OrganizationsPage
- automations/webhooks/peripherals (3 files): AutomationEditPage, WebhooksPage, PeripheralPolicyForm
- remote (3 files): ConnectDesktopButton, ProxyTunnelPage, ConnectVncButton (legacy `errorMessage` field)
- discovery (1 file): DiscoveryJobList (`??` variant)
- setup (4 files): AccountSetupStep, OrganizationSetupStep, SetupSummaryStep, EnrollDeviceStep — manual try/catch JSON-parse patterns simplified to `await res.json().catch(() => null)` + helper
- stores (4 files): auth.ts (12), aiStore (9), workspaceStore (8), scriptAiStore (4) — these return error objects rather than throw; helper works the same way

**Hardening side-effect:** where the original code did `await response.json()` with no `.catch`, the catch was added so a non-JSON 5xx body can't crash the page.

**Intentionally not touched:**
- Happy-path `data.message` consumed for success toasts (TicketingIntegration, PSAIntegration, AlertRulesPage success branches)
- `interruptResponse` in workspaceStore/aiStore/scriptAiStore — uses custom `data.reason` field
- `apiVerifyEmail` in auth.ts — `error` field is a typed union (`invalid` | `expired` | `consumed`) consumed as a code, not a message
- `BackupTab.handleTestConnection` — `data?.error` is mixed with provider-capability messaging, not a pure error path

## Stacking note

This PR is stacked on #686 (the helper itself lives there). Base is `fix/alerts-channel-consolidation`; GitHub will auto-rebase to `main` when #686 merges.

## Test plan

- [x] `apps/web` `tsc --noEmit` clean
- [x] `apps/web` vitest: 396 passed (was 394 in #686; +2 new `errorMessage` tests in `apiError.test.ts`)
- [ ] Manual smoke: trigger a zod validation failure on any covered form, confirm the error region renders the readable message rather than `[object Object]`
- [ ] Manual smoke: trigger an `errorMessage`-shape failure (open a VNC tunnel against an unreachable host), confirm the message is rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>