### PR TITLE
fix(security): bump supply-chain guard's pinned node version from 22 to 26

### DIFF
--- a/scripts/security/check-supply-chain-hardening.sh
+++ b/scripts/security/check-supply-chain-hardening.sh
@@ -232,13 +232,13 @@ require_grep 'AUTH %s' scripts/prod/deploy.sh \
   "production deploy script must feed Redis AUTH through stdin"
 
 for dockerfile in apps/api/Dockerfile apps/web/Dockerfile docker/Dockerfile.api docker/Dockerfile.web; do
-  require_grep '^FROM[[:space:]]+node:22-alpine@sha256:[0-9a-f]{64}[[:space:]]+AS[[:space:]]+base' "$dockerfile" \
+  require_grep '^FROM[[:space:]]+node:26-alpine@sha256:[0-9a-f]{64}[[:space:]]+AS[[:space:]]+base' "$dockerfile" \
     "$dockerfile must digest-pin the Node base image while retaining the tag for Dependabot refreshes"
   reject_grep '^FROM[[:space:]]+node:[^[:space:]@]+([[:space:]]|$)' "$dockerfile" \
     "$dockerfile must not use tag-only Node base image references"
 done
 for dockerfile in apps/api/Dockerfile apps/web/Dockerfile; do
-  require_grep '^FROM[[:space:]]+node:22-alpine@sha256:[0-9a-f]{64}[[:space:]]+AS[[:space:]]+runner' "$dockerfile" \
+  require_grep '^FROM[[:space:]]+node:26-alpine@sha256:[0-9a-f]{64}[[:space:]]+AS[[:space:]]+runner' "$dockerfile" \
     "$dockerfile must digest-pin the production Node runner image while retaining the tag for Dependabot refreshes"
 done
 


### PR DESCRIPTION
## Summary

`scripts/security/check-supply-chain-hardening.sh` lines 235 and 241 require `node:22-alpine` in the four production Dockerfiles, but those files were bumped to `node:26-alpine` in #667 (Dependabot) and #675 (corepack → npm-install). The guard never caught up, so the **Security Audit** job currently fails on every PR that touches code under the CI workflow's path filters.

## Why this hasn't been noticed on main

The guard's path is `Run supply-chain hardening guard` inside the `security-audit` job in `.github/workflows/ci.yml`. CI triggers on `pull_request: [main]` and `push: [main]`, but the node-26 bump merge commits (`103ba8c3`, `e2e5b3ec`) don't list a `Security Audit` check-run on `gh api repos/.../commits/.../check-runs` — so the guard never fired on the merges that introduced the mismatch. It only surfaces on subsequent PRs.

## Reproduction

On a freshly checked out main:
```bash
$ bash scripts/security/check-supply-chain-hardening.sh
ERROR: apps/api/Dockerfile must digest-pin the Node base image while retaining the tag for Dependabot refreshes
```

## Fix

Change the two `require_grep` lines from `node:22-alpine` to `node:26-alpine`. The digest already in repo (`sha256:e71ac5e9...`) is correct for `node:26-alpine`; no Dockerfile changes needed.

## Verification

```bash
$ bash scripts/security/check-supply-chain-hardening.sh
Supply-chain hardening checks passed.
```

## Test plan

- [ ] CI's `Security Audit` job goes green on this PR
- [ ] No other check-run regresses