### PR TITLE
fix(agent/config): atomically fsync+rename agent.yaml and secrets.yaml (#642)

### DIFF
--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -406,35 +406,18 @@ func SaveTo(cfg *Config, cfgFile string) error {
 		}
 	}
 
-	// Write config to a temp file with correct permissions from the start,
-	// then rename to the final path. This avoids a TOCTOU window where the
-	// file exists with default permissions before Chmod is called.
-	// Temp file must keep the .yaml extension so viper can infer the type.
-	ext := filepath.Ext(cfgPath)
-	tmpPath := cfgPath[:len(cfgPath)-len(ext)] + ".tmp" + ext
-	if err := viper.WriteConfigAs(tmpPath); err != nil {
-		return err
-	}
-	// Open with correct permissions atomically (no TOCTOU gap).
-	f, err := os.OpenFile(cfgPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
+	// Serialize via viper (same encoder as WriteConfigAs), strip secrets, then
+	// write atomically: tmp file in the same directory → fsync → rename. The
+	// fsync + rename pair guards against power-loss leaving agent.yaml
+	// zero-length or partially written between O_TRUNC and the final flush.
+	cfgYAML, err := yaml.Marshal(viper.AllSettings())
 	if err != nil {
-		os.Remove(tmpPath)
 		return err
 	}
-	tmpData, err := os.ReadFile(tmpPath)
-	if err != nil {
-		f.Close()
-		os.Remove(tmpPath)
+	cfgYAML = stripSecretsFromAgentConfig(cfgYAML)
+	if err := atomicWriteFile(cfgPath, cfgYAML, 0640); err != nil {
 		return err
 	}
-	tmpData = stripSecretsFromAgentConfig(tmpData)
-	if _, err := f.Write(tmpData); err != nil {
-		f.Close()
-		os.Remove(tmpPath)
-		return err
-	}
-	f.Close()
-	os.Remove(tmpPath)
 
 	// Defense-in-depth: ensure permissions are correct even if umask interfered.
 	if err := enforceConfigDirPermissions(filepath.Dir(cfgPath)); err != nil {
@@ -463,30 +446,14 @@ func SaveTo(cfg *Config, cfgFile string) error {
 	sv.Set("mtls_key_pem", cfg.MtlsKeyPEM)
 	sv.Set("mtls_cert_expires", cfg.MtlsCertExpires)
 
-	// Write secrets via temp file, then copy to final path opened with 0600.
-	sExt := filepath.Ext(secretsPath)
-	secretsTmp := secretsPath[:len(secretsPath)-len(sExt)] + ".tmp" + sExt
-	if err := sv.WriteConfigAs(secretsTmp); err != nil {
+	// Same atomic-write pattern for the secrets file (0600).
+	secretsYAML, err := yaml.Marshal(sv.AllSettings())
+	if err != nil {
+		return fmt.Errorf("marshaling secrets file: %w", err)
+	}
+	if err := atomicWriteFile(secretsPath, secretsYAML, 0600); err != nil {
 		return fmt.Errorf("writing secrets file: %w", err)
 	}
-	sf, err := os.OpenFile(secretsPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
-	if err != nil {
-		os.Remove(secretsTmp)
-		return fmt.Errorf("creating secrets file: %w", err)
-	}
-	secretsData, err := os.ReadFile(secretsTmp)
-	if err != nil {
-		sf.Close()
-		os.Remove(secretsTmp)
-		return fmt.Errorf("reading secrets temp file: %w", err)
-	}
-	if _, err := sf.Write(secretsData); err != nil {
-		sf.Close()
-		os.Remove(secretsTmp)
-		return fmt.Errorf("writing secrets file data: %w", err)
-	}
-	sf.Close()
-	os.Remove(secretsTmp)
 
 	// Defense-in-depth: ensure secrets permissions are correct.
 	if err := enforceSecretFilePermissions(secretsPath); err != nil {
@@ -515,6 +482,51 @@ func stripSecretsFromAgentConfig(data []byte) []byte {
 		return data
 	}
 	return out
+}
+
+// atomicWriteFile writes data to path durably: it creates path+".partial" in
+// the same directory with perm set at open time, writes data, fsyncs the file
+// before close, then renames into place. Best-effort fsync on the directory
+// inode follows the rename so the rename itself survives power loss on POSIX.
+//
+// The fsync is what guards against agent.yaml ending up zero-length or
+// partially written after an unclean shutdown — kernel write-back can delay a
+// dirty page for tens of seconds on default ext4/APFS mount options. Issue #642.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	tmpPath := path + ".partial"
+	// A prior crash mid-write may have left an old tmp behind; remove it so
+	// the O_EXCL open below doesn't fail spuriously.
+	_ = os.Remove(tmpPath)
+	f, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	// Best-effort directory fsync — durable on POSIX, may no-op or error on
+	// Windows; either way the rename has already returned successfully so
+	// failures here are not fatal.
+	if d, err := os.Open(filepath.Dir(path)); err == nil {
+		_ = d.Sync()
+		d.Close()
+	}
+	return nil
 }
 
 func isSecretConfigKey(key string) bool {

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -412,11 +412,11 @@ func SaveTo(cfg *Config, cfgFile string) error {
 	// zero-length or partially written between O_TRUNC and the final flush.
 	cfgYAML, err := yaml.Marshal(viper.AllSettings())
 	if err != nil {
-		return err
+		return fmt.Errorf("marshaling agent config: %w", err)
 	}
 	cfgYAML = stripSecretsFromAgentConfig(cfgYAML)
 	if err := atomicWriteFile(cfgPath, cfgYAML, 0640); err != nil {
-		return err
+		return fmt.Errorf("writing agent config: %w", err)
 	}
 
 	// Defense-in-depth: ensure permissions are correct even if umask interfered.
@@ -485,13 +485,22 @@ func stripSecretsFromAgentConfig(data []byte) []byte {
 }
 
 // atomicWriteFile writes data to path durably: it creates path+".partial" in
-// the same directory with perm set at open time, writes data, fsyncs the file
-// before close, then renames into place. Best-effort fsync on the directory
-// inode follows the rename so the rename itself survives power loss on POSIX.
+// the same directory with perm requested at open time (still subject to umask
+// on POSIX — defense-in-depth Chmod happens at the call site), writes data,
+// fsyncs the file before close, then renames into place. Best-effort fsync
+// on the directory inode follows the rename so the rename itself survives
+// power loss on POSIX.
 //
 // The fsync is what guards against agent.yaml ending up zero-length or
-// partially written after an unclean shutdown — kernel write-back can delay a
-// dirty page for tens of seconds on default ext4/APFS mount options. Issue #642.
+// partially written after an unclean shutdown — kernel write-back can delay
+// a dirty page well past when the in-place O_TRUNC write would have returned.
+// Issue #642.
+//
+// Tradeoff vs the previous in-place write: on Windows, MoveFileEx fails with
+// ERROR_ACCESS_DENIED if another process holds the destination open without
+// FILE_SHARE_DELETE. SaveTo callers may now fail where the old O_TRUNC write
+// would have succeeded — but failing loudly is preferable to silent power-loss
+// corruption, and the next heartbeat retries.
 func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	tmpPath := path + ".partial"
 	// A prior crash mid-write may have left an old tmp behind; remove it so
@@ -519,12 +528,18 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 		os.Remove(tmpPath)
 		return err
 	}
-	// Best-effort directory fsync — durable on POSIX, may no-op or error on
-	// Windows; either way the rename has already returned successfully so
-	// failures here are not fatal.
-	if d, err := os.Open(filepath.Dir(path)); err == nil {
-		_ = d.Sync()
+	// Best-effort directory fsync — durable on POSIX, no-ops or errors on
+	// Windows. Log failures so a FS that's lost the ability to fsync metadata
+	// (e.g. went read-only, ENOSPC on the inode table) doesn't silently
+	// degrade durability across every SaveTo.
+	dir := filepath.Dir(path)
+	if d, err := os.Open(dir); err == nil {
+		if err := d.Sync(); err != nil && runtime.GOOS != "windows" {
+			log.Warn("config dir fsync failed", "dir", dir, "error", err.Error())
+		}
 		d.Close()
+	} else if runtime.GOOS != "windows" {
+		log.Warn("config dir open for fsync failed", "dir", dir, "error", err.Error())
 	}
 	return nil
 }

--- a/agent/internal/config/config_test.go
+++ b/agent/internal/config/config_test.go
@@ -170,3 +170,101 @@ log_level: info
 		}
 	}
 }
+
+// TestSaveToWritesAtomicallyWithoutLeftoverTempFiles guards #642: SaveTo must
+// not leave .partial scratch files behind on success, and the on-disk files
+// must contain the full serialized config (not zero-length or truncated).
+func TestSaveToWritesAtomicallyWithoutLeftoverTempFiles(t *testing.T) {
+	defer viper.Reset()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yaml")
+
+	const agentID = "ab3c20eddb470acffd33bbe00f25e0348e89298ab80cece542bb1fbf921e5776"
+	cfg := Default()
+	cfg.AgentID = agentID
+	cfg.ServerURL = "https://api.example.test"
+	cfg.AuthToken = "brz_agent_atomic"
+	cfg.WatchdogAuthToken = "brz_watchdog_atomic"
+
+	if err := SaveTo(cfg, cfgPath); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".partial") || strings.Contains(e.Name(), ".tmp") {
+			t.Fatalf("SaveTo left scratch file %q behind", e.Name())
+		}
+	}
+
+	agentInfo, err := os.Stat(cfgPath)
+	if err != nil {
+		t.Fatalf("stat agent.yaml: %v", err)
+	}
+	if agentInfo.Size() == 0 {
+		t.Fatalf("agent.yaml is zero-length after SaveTo")
+	}
+	secretsInfo, err := os.Stat(filepath.Join(dir, "secrets.yaml"))
+	if err != nil {
+		t.Fatalf("stat secrets.yaml: %v", err)
+	}
+	if secretsInfo.Size() == 0 {
+		t.Fatalf("secrets.yaml is zero-length after SaveTo")
+	}
+
+	loaded, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.AgentID != agentID || loaded.AuthToken != "brz_agent_atomic" || loaded.WatchdogAuthToken != "brz_watchdog_atomic" {
+		t.Fatalf("Load returned incomplete config: %+v", loaded)
+	}
+}
+
+// TestAtomicWriteFileOverwritesExistingFile verifies the helper correctly
+// replaces an existing file (the common case — every SaveTo after enrollment).
+func TestAtomicWriteFileOverwritesExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(path, []byte("old: value\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := atomicWriteFile(path, []byte("new: value\n"), 0o640); err != nil {
+		t.Fatalf("atomicWriteFile: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "new: value\n" {
+		t.Fatalf("content = %q, want %q", got, "new: value\n")
+	}
+	// No .partial leftover.
+	if _, err := os.Stat(path + ".partial"); !os.IsNotExist(err) {
+		t.Fatalf("expected .partial removed, got err=%v", err)
+	}
+}
+
+// TestAtomicWriteFileRecoversFromStaleTemp guards the case where a previous
+// crash left a .partial behind. The next write must succeed, not fail with
+// O_EXCL EEXIST.
+func TestAtomicWriteFileRecoversFromStaleTemp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(path+".partial", []byte("stale"), 0o600); err != nil {
+		t.Fatalf("seed stale: %v", err)
+	}
+	if err := atomicWriteFile(path, []byte("fresh\n"), 0o640); err != nil {
+		t.Fatalf("atomicWriteFile: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "fresh\n" {
+		t.Fatalf("content = %q, want fresh", got)
+	}
+}

--- a/agent/internal/config/config_test.go
+++ b/agent/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -222,6 +223,18 @@ func TestSaveToWritesAtomicallyWithoutLeftoverTempFiles(t *testing.T) {
 	if loaded.AgentID != agentID || loaded.AuthToken != "brz_agent_atomic" || loaded.WatchdogAuthToken != "brz_watchdog_atomic" {
 		t.Fatalf("Load returned incomplete config: %+v", loaded)
 	}
+
+	// On POSIX, the perm set at OpenFile time must survive — preserving the
+	// TOCTOU-permission property the previous code's comment called out.
+	// Skip on Windows where POSIX mode bits don't map directly.
+	if runtime.GOOS != "windows" {
+		if mode := agentInfo.Mode().Perm(); mode != 0o640 {
+			t.Errorf("agent.yaml mode = %o, want 0640", mode)
+		}
+		if mode := secretsInfo.Mode().Perm(); mode != 0o600 {
+			t.Errorf("secrets.yaml mode = %o, want 0600", mode)
+		}
+	}
 }
 
 // TestAtomicWriteFileOverwritesExistingFile verifies the helper correctly
@@ -250,11 +263,13 @@ func TestAtomicWriteFileOverwritesExistingFile(t *testing.T) {
 
 // TestAtomicWriteFileRecoversFromStaleTemp guards the case where a previous
 // crash left a .partial behind. The next write must succeed, not fail with
-// O_EXCL EEXIST.
+// O_EXCL EEXIST. Asserts both the new file is correct and the stale .partial
+// was cleaned up — together these pin the pre-Remove + O_EXCL contract.
 func TestAtomicWriteFileRecoversFromStaleTemp(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "agent.yaml")
-	if err := os.WriteFile(path+".partial", []byte("stale"), 0o600); err != nil {
+	stalePartial := path + ".partial"
+	if err := os.WriteFile(stalePartial, []byte("stale-contents-from-prior-crash"), 0o600); err != nil {
 		t.Fatalf("seed stale: %v", err)
 	}
 	if err := atomicWriteFile(path, []byte("fresh\n"), 0o640); err != nil {
@@ -266,5 +281,28 @@ func TestAtomicWriteFileRecoversFromStaleTemp(t *testing.T) {
 	}
 	if string(got) != "fresh\n" {
 		t.Fatalf("content = %q, want fresh", got)
+	}
+	// The stale .partial must be gone (consumed by the rename), not just
+	// overwritten with the fresh content — otherwise we'd be silently
+	// leaking scratch files on every crash recovery.
+	if _, err := os.Stat(stalePartial); !os.IsNotExist(err) {
+		t.Fatalf("stale .partial still present after recovery, stat err=%v", err)
+	}
+}
+
+// TestAtomicWriteFileCleansUpOnOpenFailure verifies that when the initial
+// OpenFile fails (here: parent dir does not exist), no .partial is left
+// behind. Pins the no-leftover invariant against future refactors that
+// might drop the os.Remove calls in the error paths.
+func TestAtomicWriteFileCleansUpOnOpenFailure(t *testing.T) {
+	dir := t.TempDir()
+	// path under a non-existent subdir → OpenFile fails with ENOENT.
+	path := filepath.Join(dir, "does-not-exist", "agent.yaml")
+	err := atomicWriteFile(path, []byte("data"), 0o640)
+	if err == nil {
+		t.Fatalf("expected error from atomicWriteFile, got nil")
+	}
+	if _, statErr := os.Stat(path + ".partial"); !os.IsNotExist(statErr) {
+		t.Fatalf(".partial should not exist after failed open, stat err=%v", statErr)
 	}
 }


### PR DESCRIPTION
## Summary
- Fixes #642 — `SaveTo` could leave `agent.yaml` zero-length or partially written after power loss because the final write was an in-place `O_TRUNC` with no fsync.
- Introduces `atomicWriteFile`: open `<path>.partial` with `O_EXCL` + intended perm, write, **fsync** before close, rename into place, best-effort fsync the directory inode. Used for both the stripped agent config (0640) and the secrets file (0600).
- The TOCTOU-permission guarantee from the previous code is preserved (perm is set at open time on the tmp).

## Why this matters
Under #635, a zero-length config = no pinned manifest pub keys. The next heartbeat redelivers the same set, `PinManifestKeys` is a no-op (no change → no save), and auto-update is paused for that one heartbeat cycle. The fsync + rename pair makes the on-disk state survive an unclean shutdown.

## Test plan
- [x] `go test -race -count=1 ./internal/config/...` passes
- [x] New regression tests:
  - `TestSaveToWritesAtomicallyWithoutLeftoverTempFiles` — both files non-empty + reloadable, no `.partial` leftover.
  - `TestAtomicWriteFileOverwritesExistingFile` — overwrite path is clean.
  - `TestAtomicWriteFileRecoversFromStaleTemp` — stale `.partial` from a prior crash is removed so the next write doesn't fail O_EXCL.
- [x] Existing `TestSaveToKeepsFullAgentTokensOutOfAgentYAML` still passes (token stripping preserved through the encoder change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)