### PR TITLE
fix(api): PR #696 review follow-up — security, transactions, silent failures

### DIFF
--- a/apps/api/migrations/2026-05-07-c-mobile-device-and-oauth-lifecycle.sql
+++ b/apps/api/migrations/2026-05-07-c-mobile-device-and-oauth-lifecycle.sql
@@ -1,4 +1,4 @@
--- 2026-05-07-mobile-device-and-oauth-lifecycle.sql
+-- 2026-05-07-c-mobile-device-and-oauth-lifecycle.sql
 -- Device + OAuth client lifecycle management. Adds:
 --   1. Block columns on `mobile_devices` (status, blocked_at, blocked_by_user_id, blocked_reason)
 --   2. Revocation columns on `oauth_grants` (revoked_at, revoked_by_user_id, revoked_reason)

--- a/apps/api/src/db/schema/mobile.ts
+++ b/apps/api/src/db/schema/mobile.ts
@@ -22,7 +22,7 @@ export const mobileDevices = pgTable('mobile_devices', {
   lastActiveAt: timestamp('last_active_at'),
   // Lifecycle: a device can be soft-blocked (lost-phone revocation, admin
   // takeover). Blocked rows stay for audit; re-pairing creates a fresh row
-  // with a new deviceId. See migration 2026-05-07-mobile-device-and-oauth-
+  // with a new deviceId. See migration 2026-05-07-c-mobile-device-and-oauth-
   // lifecycle.sql for the schema rationale.
   status: mobileDeviceStatusEnum('status').notNull().default('active'),
   blockedAt: timestamp('blocked_at', { withTimezone: true }),

--- a/apps/api/src/db/schema/oauth.ts
+++ b/apps/api/src/db/schema/oauth.ts
@@ -138,7 +138,7 @@ export const oauthGrants = pgTable('oauth_grants', {
 // oauth_client_blocks: org-wide block of an OAuth client (e.g. "no Cursor
 // over MCP for the next 30 days for everyone in Acme Corp"). Token
 // validation consults this table after the user-level oauthGrants check.
-// Shape 1 (org-tenant) RLS — see migration 2026-05-07-mobile-device-and-
+// Shape 1 (org-tenant) RLS — see migration 2026-05-07-c-mobile-device-and-
 // oauth-lifecycle.sql for policies.
 export const oauthClientBlocks = pgTable('oauth_client_blocks', {
   id: uuid('id').primaryKey().defaultRandom(),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -53,7 +53,6 @@ import { updateRingRoutes } from './routes/updateRings';
 import { mobileRoutes } from './routes/mobile';
 import { approvalRoutes } from './routes/approvals';
 import { lifecycleRoutes, lifecycleAdminRoutes } from './routes/lifecycle';
-import { mobileDeviceBlockedMiddleware } from './middleware/mobileDeviceBlocked';
 import { analyticsRoutes } from './routes/analytics';
 import { discoveryRoutes } from './routes/discovery';
 import { networkBaselineRoutes } from './routes/networkBaselines';
@@ -723,12 +722,10 @@ api.route('/psa', psaRoutes);
 api.route('/patches', patchRoutes);
 api.route('/patch-policies', patchPolicyRoutes);
 api.route('/update-rings', updateRingRoutes);
-// Device-blocked check sits in front of mobile + approvals routes so a
-// blocked phone gets a structured 403 from EVERY mobile-app API call,
-// not just approval endpoints. The middleware only acts when the
-// X-Breeze-Mobile-Device-Id header is present, so non-mobile clients
-// (web dashboard, MCP) sail through unchanged.
-api.use('/mobile/*', mobileDeviceBlockedMiddleware);
+// The device-blocked check is mounted inside mobileRoutes / approvalRoutes
+// AFTER authMiddleware so the lookup can be scoped to the authenticated
+// user. Mounting it at this layer (in front of /mobile/*) would let an
+// unauthenticated caller probe the mobile_devices table by deviceId.
 api.route('/mobile', mobileRoutes);
 api.route('/mobile/approvals', approvalRoutes);
 api.route('/', lifecycleRoutes);

--- a/apps/api/src/jobs/approvalExpiryReaper.ts
+++ b/apps/api/src/jobs/approvalExpiryReaper.ts
@@ -175,7 +175,9 @@ export async function reapExpiredApprovals(): Promise<number> {
       });
     } catch (err) {
       // Audit is best-effort — never block a transition on the audit write.
+      // Capture to Sentry so a sustained audit failure (compliance gap) pages.
       console.error('[ApprovalExpiryReaper] Failed to write audit event:', err);
+      captureException(err instanceof Error ? err : new Error(String(err)));
     }
   }
 
@@ -269,6 +271,7 @@ export async function shutdownApprovalExpiryReaper(): Promise<void> {
       await worker.close();
     } catch (err) {
       console.error('[ApprovalExpiryReaper] Error closing worker:', err);
+      captureException(err instanceof Error ? err : new Error(String(err)));
     }
   }
   if (queue) {
@@ -276,6 +279,7 @@ export async function shutdownApprovalExpiryReaper(): Promise<void> {
       await queue.close();
     } catch (err) {
       console.error('[ApprovalExpiryReaper] Error closing queue:', err);
+      captureException(err instanceof Error ? err : new Error(String(err)));
     }
   }
 }

--- a/apps/api/src/middleware/mobileDeviceBlocked.test.ts
+++ b/apps/api/src/middleware/mobileDeviceBlocked.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const selectChain = {
+  from: vi.fn().mockReturnThis(),
+  where: vi.fn().mockReturnThis(),
+  limit: vi.fn(),
+};
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => selectChain),
+  },
+  runOutsideDbContext: <T>(fn: () => Promise<T>) => fn(),
+  withSystemDbAccessContext: <T>(fn: () => Promise<T>) => fn(),
+}));
+
+import { Hono } from 'hono';
+import { mobileDeviceBlockedMiddleware } from './mobileDeviceBlocked';
+
+const MOBILE_DEVICE_ID_HEADER = 'x-breeze-mobile-device-id';
+
+type AuthShape = { user: { id: string } } | null;
+
+function makeApp(auth: AuthShape) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    if (auth) c.set('auth', auth as never);
+    await next();
+  });
+  app.use('*', mobileDeviceBlockedMiddleware);
+  app.get('/anything', (c) => c.json({ ok: true }));
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  selectChain.limit.mockResolvedValue([]);
+});
+
+describe('mobileDeviceBlockedMiddleware', () => {
+  it('passes through when no device-id header is present', async () => {
+    const app = makeApp({ user: { id: 'u1' } });
+    const res = await app.request('/anything');
+    expect(res.status).toBe(200);
+    expect(selectChain.limit).not.toHaveBeenCalled();
+  });
+
+  it('passes through when device-id header is empty or oversized', async () => {
+    const app = makeApp({ user: { id: 'u1' } });
+    const a = await app.request('/anything', { headers: { [MOBILE_DEVICE_ID_HEADER]: '   ' } });
+    const b = await app.request('/anything', { headers: { [MOBILE_DEVICE_ID_HEADER]: 'x'.repeat(256) } });
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+    expect(selectChain.limit).not.toHaveBeenCalled();
+  });
+
+  it('passes through when there is no auth context (defense in depth)', async () => {
+    const app = makeApp(null);
+    const res = await app.request('/anything', { headers: { [MOBILE_DEVICE_ID_HEADER]: 'dev-1' } });
+    expect(res.status).toBe(200);
+    expect(selectChain.limit).not.toHaveBeenCalled();
+  });
+
+  it('passes through when no row matches (deviceId, userId)', async () => {
+    selectChain.limit.mockResolvedValueOnce([]);
+    const app = makeApp({ user: { id: 'u1' } });
+    const res = await app.request('/anything', { headers: { [MOBILE_DEVICE_ID_HEADER]: 'dev-foreign' } });
+    expect(res.status).toBe(200);
+    expect(selectChain.limit).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes through when the matched row is active', async () => {
+    selectChain.limit.mockResolvedValueOnce([{ status: 'active' }]);
+    const app = makeApp({ user: { id: 'u1' } });
+    const res = await app.request('/anything', { headers: { [MOBILE_DEVICE_ID_HEADER]: 'dev-1' } });
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 403 with code device_blocked when the row is blocked, never echoes the admin reason', async () => {
+    selectChain.limit.mockResolvedValueOnce([{ status: 'blocked' }]);
+    const app = makeApp({ user: { id: 'u1' } });
+    const res = await app.request('/anything', { headers: { [MOBILE_DEVICE_ID_HEADER]: 'dev-1' } });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.code).toBe('device_blocked');
+    expect(body.reason).toBeUndefined();
+    expect(body.blockedReason).toBeUndefined();
+  });
+});

--- a/apps/api/src/middleware/mobileDeviceBlocked.ts
+++ b/apps/api/src/middleware/mobileDeviceBlocked.ts
@@ -2,22 +2,30 @@ import type { Context, Next } from 'hono';
 import { and, eq } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { mobileDevices } from '../db/schema';
-import { MOBILE_DEVICE_ID_HEADER } from '../routes/lifecycle';
+import type { AuthContext } from './auth';
+
+// Kept in sync with MOBILE_DEVICE_ID_HEADER in routes/lifecycle.ts.
+// Inlined to avoid an import chain into lifecycle.ts (which pulls in
+// services/configurationPolicy via services/index) just for a string.
+const MOBILE_DEVICE_ID_HEADER = 'x-breeze-mobile-device-id';
 
 /**
  * Reject API calls from a blocked mobile device with a structured
  * `device_blocked` error. The mobile app renders this as a full-screen
  * lockout state instructing the user to re-pair.
  *
+ * MUST be mounted after `authMiddleware`. Without an auth context the
+ * deviceId header would let an unauthenticated probe enumerate the
+ * mobile_devices table and read admin block reasons; we therefore
+ * scope every lookup to the authenticated user.
+ *
  * Behaviour:
  *   - No `X-Breeze-Mobile-Device-Id` header → noop (web dashboard, MCP).
- *   - Header present but no matching row → noop (first call before
- *     /devices register lands).
- *   - Header present + row's status='blocked' → 403 with code.
- *
- * The lookup runs under system DB context: this middleware fires before
- * the per-request RLS scope is set up, and we want it to see the row
- * even if the user is otherwise locked out.
+ *   - Header present + row exists for this user with status='blocked'
+ *     → 403 with code. The 403 body never echoes `blocked_reason` —
+ *     it's admin free-text and not meant for the client surface.
+ *   - Header present but no matching row for this user → noop. The
+ *     header from a foreign device id is treated as if absent.
  */
 export async function mobileDeviceBlockedMiddleware(c: Context, next: Next): Promise<Response | void> {
   const deviceId = c.req.header(MOBILE_DEVICE_ID_HEADER) ?? c.req.header(MOBILE_DEVICE_ID_HEADER.toUpperCase());
@@ -25,22 +33,22 @@ export async function mobileDeviceBlockedMiddleware(c: Context, next: Next): Pro
     return next();
   }
 
-  // We need the auth context to scope the lookup to the calling user;
-  // /mobile/* paths run authMiddleware via the route file itself, but
-  // this middleware fires earlier. Look up by device_id only — the
-  // device_id space is global and the caller proves identity via the
-  // bearer token; we don't need to gate further here.
   const trimmed = deviceId.trim();
   if (trimmed.length === 0 || trimmed.length > 255) {
+    return next();
+  }
+
+  const auth = c.get('auth') as AuthContext | undefined;
+  if (!auth?.user?.id) {
     return next();
   }
 
   const [row] = await runOutsideDbContext(() =>
     withSystemDbAccessContext(() =>
       db
-        .select({ status: mobileDevices.status, blockedReason: mobileDevices.blockedReason })
+        .select({ status: mobileDevices.status })
         .from(mobileDevices)
-        .where(eq(mobileDevices.deviceId, trimmed))
+        .where(and(eq(mobileDevices.deviceId, trimmed), eq(mobileDevices.userId, auth.user.id)))
         .limit(1)
     )
   );
@@ -54,7 +62,6 @@ export async function mobileDeviceBlockedMiddleware(c: Context, next: Next): Pro
       {
         error: 'This device has been deactivated. Please re-pair to continue.',
         code: 'device_blocked',
-        reason: row.blockedReason ?? null,
       },
       403
     );
@@ -62,6 +69,3 @@ export async function mobileDeviceBlockedMiddleware(c: Context, next: Next): Pro
 
   return next();
 }
-
-// Suppress lint about unused import when consuming `and`.
-void and;

--- a/apps/api/src/routes/approvals.test.ts
+++ b/apps/api/src/routes/approvals.test.ts
@@ -16,6 +16,17 @@ vi.mock('../middleware/mobileDeviceBlocked', () => ({
   mobileDeviceBlockedMiddleware: vi.fn((_c: any, next: any) => next()),
 }));
 
+const { revokeUserOauthClientMock } = vi.hoisted(() => ({
+  revokeUserOauthClientMock: vi.fn(),
+}));
+vi.mock('../services/oauthRevocation', () => ({
+  revokeUserOauthClient: revokeUserOauthClientMock,
+}));
+
+vi.mock('../services/sentry', () => ({
+  captureException: vi.fn(),
+}));
+
 vi.mock('../services/expoPush', () => ({
   sendExpoPush: vi.fn(async () => [{ status: 'ok', id: 'tk' }]),
   getUserPushTokens: vi.fn(async () => ['ExponentPushToken[abc]']),
@@ -397,7 +408,11 @@ describe('POST /approvals/:id/report-suspicious', () => {
     createdAt: new Date(),
   };
 
-  function wireRevocationStubs(opts: { existing: typeof baseRow | null }) {
+  function wireRevocationStubs(opts: {
+    existing: typeof baseRow | null;
+    revokeResult?: { grantsRevoked: number; refreshTokensRevoked: number; cacheFailures: number };
+    revokeThrows?: Error;
+  }) {
     // 1) initial select to find approval
     vi.mocked(db.select).mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
@@ -409,44 +424,65 @@ describe('POST /approvals/:id/report-suspicious', () => {
     const approvalUpdateSet = vi.fn().mockReturnValue({
       where: vi.fn().mockResolvedValue(undefined),
     });
-    // 3) update oauth_refresh_tokens
-    const tokenUpdateSet = vi.fn().mockReturnValue({
-      where: vi.fn().mockReturnValue({
-        returning: vi.fn().mockResolvedValue([{ id: 'rt-1' }]),
-      }),
-    });
-    vi.mocked(db.update)
-      .mockReturnValueOnce({ set: approvalUpdateSet } as any)
-      .mockReturnValueOnce({ set: tokenUpdateSet } as any);
-
-    // delete oauth_grants
-    vi.mocked(db.delete).mockReturnValue({
-      where: vi.fn().mockReturnValue({
-        returning: vi.fn().mockResolvedValue([{ id: 'grant-1' }]),
-      }),
-    } as any);
+    vi.mocked(db.update).mockReturnValueOnce({ set: approvalUpdateSet } as any);
 
     // insert audit log
     vi.mocked(db.insert).mockReturnValue({
       values: vi.fn().mockResolvedValue(undefined),
     } as any);
 
-    return { approvalUpdateSet, tokenUpdateSet };
+    revokeUserOauthClientMock.mockReset();
+    if (opts.revokeThrows) {
+      revokeUserOauthClientMock.mockRejectedValueOnce(opts.revokeThrows);
+    } else {
+      revokeUserOauthClientMock.mockResolvedValueOnce(
+        opts.revokeResult ?? { grantsRevoked: 1, refreshTokensRevoked: 1, cacheFailures: 0 },
+      );
+    }
+
+    return { approvalUpdateSet };
   }
 
-  it('happy path: 204, denies row, revokes grant + tokens, writes audit', async () => {
-    const { approvalUpdateSet, tokenUpdateSet } = wireRevocationStubs({ existing: baseRow });
+  it('happy path: 204, marks row reported, calls revokeUserOauthClient, writes audit', async () => {
+    const { approvalUpdateSet } = wireRevocationStubs({ existing: baseRow });
 
     const res = await buildApp().request('/approvals/a1/report-suspicious', { method: 'POST' });
     expect(res.status).toBe(204);
     expect(approvalUpdateSet).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'reported' }),
     );
-    expect(tokenUpdateSet).toHaveBeenCalledWith(
-      expect.objectContaining({ revokedAt: expect.any(Date) }),
+    expect(revokeUserOauthClientMock).toHaveBeenCalledWith(
+      TEST_USER.id,
+      baseRow.requestingClientId,
+      TEST_USER.id,
+      expect.any(String),
     );
-    expect(db.delete).toHaveBeenCalled();
     expect(db.insert).toHaveBeenCalled();
+  });
+
+  it('returns 200 + warning when revocation throws (session not revoked)', async () => {
+    wireRevocationStubs({ existing: baseRow, revokeThrows: new Error('db down') });
+
+    const res = await buildApp().request('/approvals/a1/report-suspicious', { method: 'POST' });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.reported).toBe(true);
+    expect(body.revoked).toBe(false);
+    expect(body.warning).toMatch(/revoke this app manually/i);
+  });
+
+  it('returns 200 + warning when revocation succeeds but cacheFailures > 0', async () => {
+    wireRevocationStubs({
+      existing: baseRow,
+      revokeResult: { grantsRevoked: 1, refreshTokensRevoked: 1, cacheFailures: 2 },
+    });
+
+    const res = await buildApp().request('/approvals/a1/report-suspicious', { method: 'POST' });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.reported).toBe(true);
+    expect(body.revoked).toBe(true);
+    expect(body.cacheFailures).toBe(2);
   });
 
   it('returns 404 when the approval does not exist for this user', async () => {

--- a/apps/api/src/routes/approvals.test.ts
+++ b/apps/api/src/routes/approvals.test.ts
@@ -8,6 +8,12 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     delete: vi.fn(),
   },
+  runOutsideDbContext: <T>(fn: () => Promise<T>) => fn(),
+  withSystemDbAccessContext: <T>(fn: () => Promise<T>) => fn(),
+}));
+
+vi.mock('../middleware/mobileDeviceBlocked', () => ({
+  mobileDeviceBlockedMiddleware: vi.fn((_c: any, next: any) => next()),
 }));
 
 vi.mock('../services/expoPush', () => ({

--- a/apps/api/src/routes/approvals.ts
+++ b/apps/api/src/routes/approvals.ts
@@ -5,6 +5,7 @@ import { and, eq, gt, desc } from 'drizzle-orm';
 
 import { db } from '../db';
 import { authMiddleware } from '../middleware/auth';
+import { mobileDeviceBlockedMiddleware } from '../middleware/mobileDeviceBlocked';
 import { approvalRequests } from '../db/schema/approvals';
 import { aiToolExecutions } from '../db/schema/ai';
 import { oauthGrants, oauthRefreshTokens } from '../db/schema/oauth';
@@ -14,6 +15,7 @@ import { buildApprovalPush, getUserPushTokens, sendExpoPush } from '../services/
 export const approvalRoutes = new Hono();
 
 approvalRoutes.use('*', authMiddleware);
+approvalRoutes.use('*', mobileDeviceBlockedMiddleware);
 
 approvalRoutes.get('/pending', async (c) => {
   const userId = c.get('auth').user.id;

--- a/apps/api/src/routes/approvals.ts
+++ b/apps/api/src/routes/approvals.ts
@@ -8,9 +8,10 @@ import { authMiddleware } from '../middleware/auth';
 import { mobileDeviceBlockedMiddleware } from '../middleware/mobileDeviceBlocked';
 import { approvalRequests } from '../db/schema/approvals';
 import { aiToolExecutions } from '../db/schema/ai';
-import { oauthGrants, oauthRefreshTokens } from '../db/schema/oauth';
 import { auditLogs } from '../db/schema/audit';
 import { buildApprovalPush, getUserPushTokens, sendExpoPush } from '../services/expoPush';
+import { revokeUserOauthClient } from '../services/oauthRevocation';
+import { captureException } from '../services/sentry';
 
 export const approvalRoutes = new Hono();
 
@@ -183,47 +184,36 @@ approvalRoutes.post('/:id/report-suspicious', async (c) => {
           .set({ status: 'rejected', approvedBy: userId, approvedAt: new Date() })
           .where(eq(aiToolExecutions.id, existing.executionId));
       } catch (err) {
+        captureException(err);
         console.error('[approvals] report-suspicious: failed to mirror to ai_tool_executions:', err);
       }
     }
   }
 
-  // Revoke the requesting OAuth client (grant + refresh tokens) for this user.
-  // TODO(lifecycle): a parallel agent is adding a `revoked_at` column on
-  // `oauth_grants` for soft-revoke + audit history. Until that lands we delete
-  // the grant row outright (oidc-provider treats a missing grant as revoked)
-  // and mark refresh tokens as revoked via the existing column.
+  // Revoke the requesting OAuth client (grant + refresh tokens) for this
+  // user via the shared revokeUserOauthClient helper — same code path the
+  // self-revoke and admin-block routes use. Soft-revokes via
+  // oauth_grants.revoked_at + jti/grant Redis cache writes.
   const requestingClientId = existing.requestingClientId;
   let grantsRevoked = 0;
   let refreshTokensRevoked = 0;
+  let cacheFailures = 0;
+  let revocationFailed = false;
   if (requestingClientId) {
     try {
-      const deleted = await db
-        .delete(oauthGrants)
-        .where(
-          and(
-            eq(oauthGrants.accountId, userId),
-            eq(oauthGrants.clientId, requestingClientId),
-          )
-        )
-        .returning({ id: oauthGrants.id });
-      grantsRevoked = deleted.length;
-
-      const tokenRes = await db
-        .update(oauthRefreshTokens)
-        .set({ revokedAt: new Date() })
-        .where(
-          and(
-            eq(oauthRefreshTokens.userId, userId),
-            eq(oauthRefreshTokens.clientId, requestingClientId),
-          )
-        )
-        .returning({ id: oauthRefreshTokens.id });
-      refreshTokensRevoked = tokenRes.length;
+      const r = await revokeUserOauthClient(
+        userId,
+        requestingClientId,
+        userId,
+        'reported as suspicious by user',
+      );
+      grantsRevoked = r.grantsRevoked;
+      refreshTokensRevoked = r.refreshTokensRevoked;
+      cacheFailures = r.cacheFailures;
     } catch (err) {
+      revocationFailed = true;
+      captureException(err);
       console.error('[approvals] report-suspicious: revocation failed:', err);
-      // Non-fatal: the approval row + audit log are still authoritative; the
-      // user can revoke from the connected-apps UI as a fallback.
     }
   }
 
@@ -246,11 +236,31 @@ approvalRoutes.post('/:id/report-suspicious', async (c) => {
         priorStatus: existing.status,
         grantsRevoked,
         refreshTokensRevoked,
+        cacheFailures,
+        revocationFailed,
       },
-      result: 'success',
+      result: revocationFailed ? 'failure' : 'success',
     });
   } catch (err) {
+    captureException(err);
     console.error('[approvals] report-suspicious: audit insert failed:', err);
+  }
+
+  // Tell the mobile UI whether revocation actually succeeded so it can
+  // render "session revoked" vs "report recorded — revoke manually from
+  // connected-apps" accurately.
+  if (revocationFailed || cacheFailures > 0) {
+    return c.json(
+      {
+        reported: true,
+        revoked: !revocationFailed,
+        cacheFailures,
+        warning: revocationFailed
+          ? 'session revocation failed; revoke this app manually from connected-apps'
+          : 'session-cache invalidation partially failed; active tokens may survive up to access-token TTL',
+      },
+      200
+    );
   }
 
   return c.body(null, 204);

--- a/apps/api/src/routes/approvals.ts
+++ b/apps/api/src/routes/approvals.ts
@@ -319,10 +319,12 @@ async function decideHandler(
         .set({ status: aiStatus, approvedBy: userId, approvedAt: new Date() })
         .where(eq(aiToolExecutions.id, updated.executionId));
     } catch (err) {
+      captureException(err);
       console.error('[approvals] Failed to mirror status to ai_tool_executions:', err);
       // Non-fatal: the approval_request row is the source of truth for the
       // mobile UI. The SDK poll will time out at the 5-min ceiling if the
       // mirror fails — better than failing the user-facing decide call.
+      // Captured to Sentry so a sustained mirror failure pages ops.
     }
   }
 

--- a/apps/api/src/routes/auth/accountDeletion.ts
+++ b/apps/api/src/routes/auth/accountDeletion.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { and, desc, eq, ne } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, ne } from 'drizzle-orm';
 import * as dbModule from '../../db';
 import {
   accountDeletionRequests,
@@ -454,15 +454,11 @@ async function resolveReachableUserIds(auth: AdminAuth): Promise<string[] | null
 
     const orgIds = (auth.accessibleOrgIds ?? []).filter((id): id is string => !!id);
     if (orgIds.length > 0) {
-      // Drizzle `inArray` on org_id — but to keep imports small we run a single
-      // query per org id only when necessary. For typical admin scopes this
-      // is at most a handful of ids; we filter with a single SQL `IN` instead.
       const orgRows = await db
-        .select({ userId: organizationUsers.userId, orgId: organizationUsers.orgId })
-        .from(organizationUsers);
-      for (const r of orgRows) {
-        if (r.orgId && orgIds.includes(r.orgId)) ids.add(r.userId);
-      }
+        .select({ userId: organizationUsers.userId })
+        .from(organizationUsers)
+        .where(inArray(organizationUsers.orgId, orgIds));
+      for (const r of orgRows) ids.add(r.userId);
     }
 
     return Array.from(ids);
@@ -523,8 +519,24 @@ accountDeletionAdminRoutes.get(
 
     const reachable = await resolveReachableUserIds(auth);
 
-    const rows = await runWithSystemDbAccess(async () => {
-      const query = db
+    // Non-system admins outside any tenant get an empty page without
+    // round-tripping to the DB.
+    if (auth.scope !== 'system' && (!reachable || reachable.length === 0)) {
+      return c.json({ requests: [], limit, offset });
+    }
+
+    // Push tenant scoping into the SQL WHERE. Previously the limit/offset
+    // ran first and then JS filtered out unreachable rows — which produced
+    // partial pages for non-system admins.
+    const reachabilityFilter = reachable
+      ? inArray(accountDeletionRequests.userId, reachable)
+      : undefined;
+    const whereClause = reachabilityFilter
+      ? and(eq(accountDeletionRequests.status, status), reachabilityFilter)
+      : eq(accountDeletionRequests.status, status);
+
+    const rows = await runWithSystemDbAccess(async () =>
+      db
         .select({
           request: accountDeletionRequests,
           user: {
@@ -536,16 +548,14 @@ accountDeletionAdminRoutes.get(
         })
         .from(accountDeletionRequests)
         .leftJoin(users, eq(users.id, accountDeletionRequests.userId))
-        .where(eq(accountDeletionRequests.status, status))
+        .where(whereClause)
         .orderBy(desc(accountDeletionRequests.requestedAt))
         .limit(limit)
-        .offset(offset);
-      return query;
-    });
+        .offset(offset)
+    );
 
-    const filtered = rows.filter((r) => adminCanReach(auth, reachable, r.request.userId));
     return c.json({
-      requests: filtered.map(serializeAdminRow),
+      requests: rows.map(serializeAdminRow),
       limit,
       offset,
     });
@@ -565,15 +575,21 @@ accountDeletionAdminRoutes.get(
       return c.json({ count: 0 });
     }
 
-    const rows = await runWithSystemDbAccess(async () =>
+    const reachabilityFilter = reachable
+      ? inArray(accountDeletionRequests.userId, reachable)
+      : undefined;
+    const whereClause = reachabilityFilter
+      ? and(eq(accountDeletionRequests.status, 'pending'), reachabilityFilter)
+      : eq(accountDeletionRequests.status, 'pending');
+
+    const [row] = await runWithSystemDbAccess(async () =>
       db
-        .select({ userId: accountDeletionRequests.userId })
+        .select({ total: count() })
         .from(accountDeletionRequests)
-        .where(eq(accountDeletionRequests.status, 'pending'))
+        .where(whereClause)
     );
 
-    const total = rows.filter((r) => adminCanReach(auth, reachable, r.userId)).length;
-    return c.json({ count: total });
+    return c.json({ count: row?.total ?? 0 });
   }
 );
 

--- a/apps/api/src/routes/lifecycle.test.ts
+++ b/apps/api/src/routes/lifecycle.test.ts
@@ -468,7 +468,7 @@ describe('POST /me/oauth-clients/:clientId/revoke (transactional revoke)', () =>
     const { db } = await import('../db');
     vi.mocked(db.select).mockImplementation(() => {
       selectCallCount++;
-      return buildSelectChain(() =>
+      return buildSelectChain<any>(() =>
         selectCallCount === 1
           ? [{ id: 'grant-1', revokedAt: null }]
           : [
@@ -505,7 +505,7 @@ describe('POST /me/oauth-clients/:clientId/revoke (transactional revoke)', () =>
     const { db } = await import('../db');
     vi.mocked(db.select).mockImplementation(() => {
       selectCallCount++;
-      return buildSelectChain(() =>
+      return buildSelectChain<any>(() =>
         selectCallCount === 1 ? [{ id: 'grant-1', revokedAt: null }] : []
       ) as any;
     });
@@ -527,7 +527,7 @@ describe('POST /me/oauth-clients/:clientId/revoke (transactional revoke)', () =>
     const { db } = await import('../db');
     vi.mocked(db.select).mockImplementation(() => {
       selectCallCount++;
-      return buildSelectChain(() =>
+      return buildSelectChain<any>(() =>
         selectCallCount === 1 ? [{ id: 'grant-1', revokedAt: null }] : []
       ) as any;
     });

--- a/apps/api/src/routes/lifecycle.test.ts
+++ b/apps/api/src/routes/lifecycle.test.ts
@@ -48,8 +48,8 @@ let nextSelectRows: any[] = [];
 let nextUpdateReturning: any[] = [];
 let nextInsertReturning: any[] = [];
 
-vi.mock('../db', () => ({
-  db: {
+vi.mock('../db', () => {
+  const mockDb: any = {
     select: vi.fn(() => buildSelectChain(() => nextSelectRows)),
     update: vi.fn(() => ({
       set: vi.fn(function (this: any) { return this; }),
@@ -63,11 +63,20 @@ vi.mock('../db', () => ({
     delete: vi.fn(() => ({
       where: vi.fn(async () => undefined),
     })),
-    transaction: vi.fn(async (fn: any) => fn({})),
-  },
-  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
-  withDbAccessContext: vi.fn(async (_c: unknown, fn: () => Promise<unknown>) => fn()),
-  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+    // Pass mockDb itself as the tx so chained tx.update / tx.select reuse
+    // the same chain mocks as the bare db.
+    transaction: vi.fn(async (fn: any) => fn(mockDb)),
+  };
+  return {
+    db: mockDb,
+    withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+    withDbAccessContext: vi.fn(async (_c: unknown, fn: () => Promise<unknown>) => fn()),
+    runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  };
+});
+
+vi.mock('../services/sentry', () => ({
+  captureException: vi.fn(),
 }));
 
 vi.mock('../db/schema', () => {
@@ -426,5 +435,109 @@ describe('POST /admin/orgs/:orgId/oauth-clients/:clientId/unblock-globally', () 
     );
     // adminCanReachUser is not invoked; canAccessOrg uses 'o-1' so this org is out of scope
     expect([403, 404]).toContain(res.status);
+  });
+});
+
+// ============================================================
+// POST /me/oauth-clients/:clientId/revoke
+// ============================================================
+
+describe('POST /me/oauth-clients/:clientId/revoke (transactional revoke)', () => {
+  // The route looks up an existing grant first via .select().from().where().limit(),
+  // then calls revokeUserOauthClient which does:
+  //   - update grants .returning() — drives nextUpdateReturning
+  //   - select refresh tokens — drives nextSelectRows (second call)
+  //   - update refresh tokens (no returning, only matters for completion)
+  // Because the buildSelectChain mock returns nextSelectRows for every .from()
+  // chain, we drive both reads with the same array and order calls carefully.
+
+  it('returns 200 + cacheFailures + warning when Redis revokeJti throws', async () => {
+    const { revokeJti } = await import('../oauth/revocationCache');
+    vi.mocked(revokeJti).mockRejectedValueOnce(new Error('redis down'));
+
+    // First select: presence check returns one row so we proceed.
+    // Second select (inside transaction): refresh tokens to revoke.
+    // Drizzle's .limit() returns the array; we'll simulate with multiple
+    // select-chain invocations producing the same rows.
+    nextSelectRows = [{ id: 'grant-1', revokedAt: null }];
+    nextUpdateReturning = [{ id: 'grant-1' }];
+
+    // Patch the chain so the second .from() returns a refresh-token list
+    // and the first returns the grant presence row.
+    let selectCallCount = 0;
+    const { db } = await import('../db');
+    vi.mocked(db.select).mockImplementation(() => {
+      selectCallCount++;
+      return buildSelectChain(() =>
+        selectCallCount === 1
+          ? [{ id: 'grant-1', revokedAt: null }]
+          : [
+              {
+                id: 'rt-1',
+                payload: { jti: 'jti-1', grantId: 'g-1' },
+                expiresAt: new Date(Date.now() + 60_000).toISOString(),
+              },
+            ]
+      ) as any;
+    });
+
+    const res = await lifecycleRoutes.request('/me/oauth-clients/cid-1/revoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'test' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.revoked).toBe(true);
+    expect(body.cacheFailures).toBeGreaterThanOrEqual(1);
+    expect(body.warning).toMatch(/cache/i);
+
+    const { captureException } = await import('../services/sentry');
+    expect(captureException).toHaveBeenCalled();
+  });
+
+  it('returns 204 with no body when revoke + cache writes all succeed', async () => {
+    nextSelectRows = [{ id: 'grant-1', revokedAt: null }];
+    nextUpdateReturning = [{ id: 'grant-1' }];
+
+    let selectCallCount = 0;
+    const { db } = await import('../db');
+    vi.mocked(db.select).mockImplementation(() => {
+      selectCallCount++;
+      return buildSelectChain(() =>
+        selectCallCount === 1 ? [{ id: 'grant-1', revokedAt: null }] : []
+      ) as any;
+    });
+
+    const res = await lifecycleRoutes.request('/me/oauth-clients/cid-1/revoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'test' }),
+    });
+
+    expect(res.status).toBe(204);
+  });
+
+  it('returns 409 when no grants remain to revoke', async () => {
+    nextSelectRows = [{ id: 'grant-1', revokedAt: null }];
+    nextUpdateReturning = []; // already-revoked: update affects 0 rows
+
+    let selectCallCount = 0;
+    const { db } = await import('../db');
+    vi.mocked(db.select).mockImplementation(() => {
+      selectCallCount++;
+      return buildSelectChain(() =>
+        selectCallCount === 1 ? [{ id: 'grant-1', revokedAt: null }] : []
+      ) as any;
+    });
+
+    const res = await lifecycleRoutes.request('/me/oauth-clients/cid-1/revoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'test' }),
+    });
+
+    expect(res.status).toBe(409);
   });
 });

--- a/apps/api/src/routes/lifecycle.test.ts
+++ b/apps/api/src/routes/lifecycle.test.ts
@@ -47,12 +47,16 @@ function buildSelectChain<T>(rows: () => T[]) {
 let nextSelectRows: any[] = [];
 let nextUpdateReturning: any[] = [];
 let nextInsertReturning: any[] = [];
+let lastUpdateSet: Record<string, unknown> | undefined;
 
 vi.mock('../db', () => {
   const mockDb: any = {
     select: vi.fn(() => buildSelectChain(() => nextSelectRows)),
     update: vi.fn(() => ({
-      set: vi.fn(function (this: any) { return this; }),
+      set: vi.fn(function (this: any, payload: Record<string, unknown>) {
+        lastUpdateSet = payload;
+        return this;
+      }),
       where: vi.fn(function (this: any) { return this; }),
       returning: vi.fn(async () => nextUpdateReturning),
     })),
@@ -147,6 +151,7 @@ beforeEach(() => {
   nextSelectRows = [];
   nextUpdateReturning = [];
   nextInsertReturning = [];
+  lastUpdateSet = undefined;
   mockAuth = {
     scope: 'organization',
     partnerId: 'p-1',
@@ -242,6 +247,13 @@ describe('POST /me/mobile-devices/:id/block', () => {
     );
 
     expect(res.status).toBe(204);
+    // Push tokens MUST be cleared so a stolen phone can't keep receiving
+    // approval pushes after the block. (Issue #696 review finding.)
+    expect(lastUpdateSet).toMatchObject({
+      status: 'blocked',
+      fcmToken: null,
+      apnsToken: null,
+    });
   });
 
   it('refuses to block the current device with 409 + self_revoke_blocked', async () => {

--- a/apps/api/src/routes/lifecycle.ts
+++ b/apps/api/src/routes/lifecycle.ts
@@ -18,10 +18,9 @@ import { approvalRequests } from '../db/schema/approvals';
 import { authMiddleware, requirePermission } from '../middleware/auth';
 import { rateLimiter, getRedis } from '../services';
 import { writeRouteAudit } from '../services/auditEvents';
-import { revokeGrant, revokeJti } from '../oauth/revocationCache';
 import { ERROR_IDS, logOauthError } from '../oauth/log';
-import { ACCESS_TOKEN_TTL_SECONDS } from '../oauth/provider';
 import { captureException } from '../services/sentry';
+import { revokeUserOauthClient } from '../services/oauthRevocation';
 import { resolveUserAuditOrgId } from './auth/helpers';
 import { PERMISSIONS } from '../services/permissions';
 
@@ -308,138 +307,6 @@ lifecycleRoutes.get('/me/oauth-clients', async (c) => {
     })),
   });
 });
-
-interface RevokeUserOauthClientResult {
-  grantsRevoked: number;
-  refreshTokensRevoked: number;
-  /**
-   * Number of Redis revocation-cache writes that failed after the DB
-   * transaction committed. >0 means the DB state is fully correct but
-   * some active JWTs may survive until natural TTL (≤ ACCESS_TOKEN_TTL).
-   * Callers that need to alert on this should propagate to the response
-   * and audit details.
-   */
-  cacheFailures: number;
-}
-
-async function revokeUserOauthClient(
-  userId: string,
-  clientId: string,
-  revokedByUserId: string,
-  reason: string | null
-): Promise<RevokeUserOauthClientResult> {
-  return asSystem(async () => {
-    const now = new Date();
-
-    // Atomic DB phase. Grants UPDATE + refresh-tokens SELECT/UPDATE must
-    // succeed or fail together; a Redis failure during cache invalidation
-    // (handled after commit) must not be able to leave grants revoked
-    // while refresh tokens stay active in the DB.
-    const { updatedGrants, tokens } = await db.transaction(async (tx) => {
-      const updatedGrants = await tx
-        .update(oauthGrants)
-        .set({ revokedAt: now, revokedByUserId, revokedReason: reason })
-        .where(
-          and(
-            eq(oauthGrants.accountId, userId),
-            eq(oauthGrants.clientId, clientId),
-            isNull(oauthGrants.revokedAt)
-          )
-        )
-        .returning({ id: oauthGrants.id });
-
-      const tokens = await tx
-        .select({
-          id: oauthRefreshTokens.id,
-          payload: oauthRefreshTokens.payload,
-          expiresAt: oauthRefreshTokens.expiresAt,
-        })
-        .from(oauthRefreshTokens)
-        .where(
-          and(
-            eq(oauthRefreshTokens.userId, userId),
-            eq(oauthRefreshTokens.clientId, clientId),
-            isNull(oauthRefreshTokens.revokedAt)
-          )
-        );
-
-      if (tokens.length > 0) {
-        await tx
-          .update(oauthRefreshTokens)
-          .set({ revokedAt: now })
-          .where(inArray(oauthRefreshTokens.id, tokens.map((t) => t.id)));
-      }
-
-      return { updatedGrants, tokens };
-    });
-
-    // Cache-revoke every active jti + grant so sibling JWTs are killed
-    // before natural expiry. Best-effort: failures here are logged + sent
-    // to Sentry, surfaced via cacheFailures, and DO NOT throw. The DB
-    // state above is already correct; throwing here would tell the caller
-    // "revoke failed" when in fact only the cache write failed.
-    let cacheFailures = 0;
-    const onCacheFailure = (
-      err: unknown,
-      message: string,
-      context: Record<string, unknown>
-    ): void => {
-      cacheFailures++;
-      logOauthError({
-        errorId: ERROR_IDS.OAUTH_REVOCATION_CACHE_WRITE_FAILED,
-        message,
-        err,
-        context: { ...context, clientId, userId },
-      });
-      captureException(err);
-    };
-
-    const seenGrants = new Set<string>();
-    for (const tok of tokens) {
-      const payload = tok.payload as { jti?: string; grantId?: string } | null;
-      if (payload?.jti) {
-        const ttl = Math.ceil((new Date(tok.expiresAt).getTime() - Date.now()) / 1000);
-        try {
-          await revokeJti(payload.jti, Math.max(ttl, 1));
-        } catch (err) {
-          onCacheFailure(err, 'self-service jti revocation cache write failed', {
-            jti: payload.jti,
-          });
-        }
-      }
-      if (payload?.grantId && !seenGrants.has(payload.grantId)) {
-        seenGrants.add(payload.grantId);
-        try {
-          await revokeGrant(payload.grantId, ACCESS_TOKEN_TTL_SECONDS);
-        } catch (err) {
-          onCacheFailure(err, 'self-service grant revocation cache write failed', {
-            grantId: payload.grantId,
-          });
-        }
-      }
-    }
-
-    // Belt-and-suspenders: also write a grant marker for any grant rows
-    // that didn't have a refresh token (direct authorize flows).
-    for (const grant of updatedGrants) {
-      if (seenGrants.has(grant.id)) continue;
-      seenGrants.add(grant.id);
-      try {
-        await revokeGrant(grant.id, ACCESS_TOKEN_TTL_SECONDS);
-      } catch (err) {
-        onCacheFailure(err, 'self-service grant-only revocation cache write failed', {
-          grantId: grant.id,
-        });
-      }
-    }
-
-    return {
-      grantsRevoked: updatedGrants.length,
-      refreshTokensRevoked: tokens.length,
-      cacheFailures,
-    };
-  });
-}
 
 lifecycleRoutes.post(
   '/me/oauth-clients/:clientId/revoke',

--- a/apps/api/src/routes/lifecycle.ts
+++ b/apps/api/src/routes/lifecycle.ts
@@ -21,6 +21,7 @@ import { writeRouteAudit } from '../services/auditEvents';
 import { revokeGrant, revokeJti } from '../oauth/revocationCache';
 import { ERROR_IDS, logOauthError } from '../oauth/log';
 import { ACCESS_TOKEN_TTL_SECONDS } from '../oauth/provider';
+import { captureException } from '../services/sentry';
 import { resolveUserAuditOrgId } from './auth/helpers';
 import { PERMISSIONS } from '../services/permissions';
 
@@ -308,44 +309,90 @@ lifecycleRoutes.get('/me/oauth-clients', async (c) => {
   });
 });
 
+interface RevokeUserOauthClientResult {
+  grantsRevoked: number;
+  refreshTokensRevoked: number;
+  /**
+   * Number of Redis revocation-cache writes that failed after the DB
+   * transaction committed. >0 means the DB state is fully correct but
+   * some active JWTs may survive until natural TTL (≤ ACCESS_TOKEN_TTL).
+   * Callers that need to alert on this should propagate to the response
+   * and audit details.
+   */
+  cacheFailures: number;
+}
+
 async function revokeUserOauthClient(
   userId: string,
   clientId: string,
   revokedByUserId: string,
   reason: string | null
-): Promise<{ grantsRevoked: number; refreshTokensRevoked: number }> {
+): Promise<RevokeUserOauthClientResult> {
   return asSystem(async () => {
     const now = new Date();
 
-    // Mark grants revoked (per-user-per-client lifecycle).
-    const updatedGrants = await db
-      .update(oauthGrants)
-      .set({ revokedAt: now, revokedByUserId, revokedReason: reason })
-      .where(
-        and(
-          eq(oauthGrants.accountId, userId),
-          eq(oauthGrants.clientId, clientId),
-          isNull(oauthGrants.revokedAt)
+    // Atomic DB phase. Grants UPDATE + refresh-tokens SELECT/UPDATE must
+    // succeed or fail together; a Redis failure during cache invalidation
+    // (handled after commit) must not be able to leave grants revoked
+    // while refresh tokens stay active in the DB.
+    const { updatedGrants, tokens } = await db.transaction(async (tx) => {
+      const updatedGrants = await tx
+        .update(oauthGrants)
+        .set({ revokedAt: now, revokedByUserId, revokedReason: reason })
+        .where(
+          and(
+            eq(oauthGrants.accountId, userId),
+            eq(oauthGrants.clientId, clientId),
+            isNull(oauthGrants.revokedAt)
+          )
         )
-      )
-      .returning({ id: oauthGrants.id });
+        .returning({ id: oauthGrants.id });
 
-    // Stamp + cache-revoke every active refresh token for the (user, client)
-    // pair so sibling JWTs are killed before natural expiry.
-    const tokens = await db
-      .select({
-        id: oauthRefreshTokens.id,
-        payload: oauthRefreshTokens.payload,
-        expiresAt: oauthRefreshTokens.expiresAt,
-      })
-      .from(oauthRefreshTokens)
-      .where(
-        and(
-          eq(oauthRefreshTokens.userId, userId),
-          eq(oauthRefreshTokens.clientId, clientId),
-          isNull(oauthRefreshTokens.revokedAt)
-        )
-      );
+      const tokens = await tx
+        .select({
+          id: oauthRefreshTokens.id,
+          payload: oauthRefreshTokens.payload,
+          expiresAt: oauthRefreshTokens.expiresAt,
+        })
+        .from(oauthRefreshTokens)
+        .where(
+          and(
+            eq(oauthRefreshTokens.userId, userId),
+            eq(oauthRefreshTokens.clientId, clientId),
+            isNull(oauthRefreshTokens.revokedAt)
+          )
+        );
+
+      if (tokens.length > 0) {
+        await tx
+          .update(oauthRefreshTokens)
+          .set({ revokedAt: now })
+          .where(inArray(oauthRefreshTokens.id, tokens.map((t) => t.id)));
+      }
+
+      return { updatedGrants, tokens };
+    });
+
+    // Cache-revoke every active jti + grant so sibling JWTs are killed
+    // before natural expiry. Best-effort: failures here are logged + sent
+    // to Sentry, surfaced via cacheFailures, and DO NOT throw. The DB
+    // state above is already correct; throwing here would tell the caller
+    // "revoke failed" when in fact only the cache write failed.
+    let cacheFailures = 0;
+    const onCacheFailure = (
+      err: unknown,
+      message: string,
+      context: Record<string, unknown>
+    ): void => {
+      cacheFailures++;
+      logOauthError({
+        errorId: ERROR_IDS.OAUTH_REVOCATION_CACHE_WRITE_FAILED,
+        message,
+        err,
+        context: { ...context, clientId, userId },
+      });
+      captureException(err);
+    };
 
     const seenGrants = new Set<string>();
     for (const tok of tokens) {
@@ -355,13 +402,9 @@ async function revokeUserOauthClient(
         try {
           await revokeJti(payload.jti, Math.max(ttl, 1));
         } catch (err) {
-          logOauthError({
-            errorId: ERROR_IDS.OAUTH_REVOCATION_CACHE_WRITE_FAILED,
-            message: 'self-service jti revocation cache write failed',
-            err,
-            context: { jti: payload.jti, clientId, userId },
+          onCacheFailure(err, 'self-service jti revocation cache write failed', {
+            jti: payload.jti,
           });
-          throw err;
         }
       }
       if (payload?.grantId && !seenGrants.has(payload.grantId)) {
@@ -369,13 +412,9 @@ async function revokeUserOauthClient(
         try {
           await revokeGrant(payload.grantId, ACCESS_TOKEN_TTL_SECONDS);
         } catch (err) {
-          logOauthError({
-            errorId: ERROR_IDS.OAUTH_REVOCATION_CACHE_WRITE_FAILED,
-            message: 'self-service grant revocation cache write failed',
-            err,
-            context: { grantId: payload.grantId, clientId, userId },
+          onCacheFailure(err, 'self-service grant revocation cache write failed', {
+            grantId: payload.grantId,
           });
-          throw err;
         }
       }
     }
@@ -388,26 +427,16 @@ async function revokeUserOauthClient(
       try {
         await revokeGrant(grant.id, ACCESS_TOKEN_TTL_SECONDS);
       } catch (err) {
-        logOauthError({
-          errorId: ERROR_IDS.OAUTH_REVOCATION_CACHE_WRITE_FAILED,
-          message: 'self-service grant-only revocation cache write failed',
-          err,
-          context: { grantId: grant.id, clientId, userId },
+        onCacheFailure(err, 'self-service grant-only revocation cache write failed', {
+          grantId: grant.id,
         });
-        throw err;
       }
-    }
-
-    if (tokens.length > 0) {
-      await db
-        .update(oauthRefreshTokens)
-        .set({ revokedAt: now })
-        .where(inArray(oauthRefreshTokens.id, tokens.map((t) => t.id)));
     }
 
     return {
       grantsRevoked: updatedGrants.length,
       refreshTokensRevoked: tokens.length,
+      cacheFailures,
     };
   });
 }
@@ -452,8 +481,23 @@ lifecycleRoutes.post(
         reason: body.reason ?? null,
         grantsRevoked: result.grantsRevoked,
         refreshTokensRevoked: result.refreshTokensRevoked,
+        cacheFailures: result.cacheFailures,
       },
     });
+
+    // DB state is committed regardless. Cache miss means active JWTs may
+    // survive up to ACCESS_TOKEN_TTL; signal that to the client so its UI
+    // can warn rather than show "session ended" prematurely.
+    if (result.cacheFailures > 0) {
+      return c.json(
+        {
+          revoked: true,
+          cacheFailures: result.cacheFailures,
+          warning: 'session-cache invalidation partially failed; active tokens may survive up to access-token TTL',
+        },
+        200
+      );
+    }
 
     return c.body(null, 204);
   }
@@ -681,13 +725,25 @@ lifecycleAdminRoutes.post(
         .where(eq(organizationUsers.orgId, orgId))
     );
     let tokensRevoked = 0;
+    let cacheFailures = 0;
+    const failedUserIds: string[] = [];
     for (const { userId } of userIdsInOrg) {
       try {
         const r = await revokeUserOauthClient(userId, clientId, auth.user.id, body.reason);
         tokensRevoked += r.refreshTokensRevoked;
+        cacheFailures += r.cacheFailures;
       } catch (err) {
-        // Surface but don't block — org-wide block row is already in place.
-        console.error('[lifecycle] org-block revoke failed for user', userId, err);
+        // Org-wide block row is already in place; DB state for this user
+        // was rolled back by the transaction. Track the user so callers
+        // can decide whether to retry, and surface to Sentry.
+        failedUserIds.push(userId);
+        logOauthError({
+          errorId: ERROR_IDS.OAUTH_REVOCATION_CACHE_WRITE_FAILED,
+          message: 'org-block per-user revoke failed; user keeps active tokens until natural expiry',
+          err,
+          context: { userId, clientId, orgId },
+        });
+        captureException(err);
       }
     }
 
@@ -700,6 +756,8 @@ lifecycleAdminRoutes.post(
         reason: body.reason,
         blockedUntil: blockedUntil?.toISOString() ?? null,
         tokensRevoked,
+        cacheFailures,
+        failedUserIds,
       },
     });
 
@@ -710,6 +768,8 @@ lifecycleAdminRoutes.post(
         blockedAt: row.blockedAt.toISOString(),
         blockedUntil: row.blockedUntil?.toISOString() ?? null,
         tokensRevoked,
+        cacheFailures,
+        failedUserIds,
       },
       201
     );

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -17,6 +17,7 @@ import {
   sites
 } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
+import { mobileDeviceBlockedMiddleware } from '../middleware/mobileDeviceBlocked';
 import { userRateLimit } from '../middleware/userRateLimit';
 import { setCooldown, markConfigPolicyRuleCooldown } from '../services/alertCooldown';
 import { writeRouteAudit } from '../services/auditEvents';
@@ -212,8 +213,10 @@ const summaryQuerySchema = z.object({
   orgId: z.string().uuid().optional()
 });
 
-// Apply auth middleware to all routes
+// Apply auth middleware to all routes. mobileDeviceBlockedMiddleware
+// must run after auth so the lookup is scoped to the authenticated user.
 mobileRoutes.use('*', authMiddleware);
+mobileRoutes.use('*', mobileDeviceBlockedMiddleware);
 
 // POST /notifications/register - Compatibility push token registration endpoint
 mobileRoutes.post(

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -23,6 +23,7 @@ import { writeAuditEvent, requestLikeFromSnapshot, type RequestLike } from './au
 import type { ActiveSession, AuditSnapshot } from './streamingSessionManager';
 import { compactToolResultForChat } from './aiToolOutput';
 import { buildApprovalPush, getUserPushTokens, sendExpoPush } from './expoPush';
+import { captureException } from './sentry';
 
 const SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 const SESSION_IDLE_TIMEOUT_MS = 2 * 60 * 60 * 1000; // 2 hours
@@ -424,10 +425,13 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
         );
         approvalRequestId = approvalRow?.id;
       } catch (err) {
+        captureException(err);
         console.error('[AI-SDK] Failed to create mobile approval_request row:', err);
         // Non-fatal: SSE approval flow still works for in-app web UI even
         // without the mobile-readable row. The approve/deny handler simply
-        // won't have an executionId to resolve back to.
+        // won't have an executionId to resolve back to. Captured to Sentry
+        // so a sustained insert failure pages ops — when this fails the
+        // mobile-only approval flow silently hangs for 5 min.
       }
 
       // Best-effort push notification to the user's mobile device(s).
@@ -455,7 +459,10 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
             );
           }
         } catch (err) {
+          captureException(err);
           console.error('[AI-SDK] Failed to dispatch approval push notification:', err);
+          // Push is best-effort; the in-app UI still works. But a sustained
+          // push failure means mobile-only approvals time out silently.
         }
       }
 

--- a/apps/api/src/services/expoPush.test.ts
+++ b/apps/api/src/services/expoPush.test.ts
@@ -30,6 +30,13 @@ vi.mock('../db/schema/mobile', () => ({
   },
 }));
 
+const { captureExceptionMock } = vi.hoisted(() => ({
+  captureExceptionMock: vi.fn(),
+}));
+vi.mock('./sentry', () => ({
+  captureException: captureExceptionMock,
+}));
+
 import { sendExpoPush, buildApprovalPush } from './expoPush';
 import { db } from '../db';
 
@@ -144,7 +151,7 @@ describe('sendExpoPush', () => {
     expect(nullSets.length).toBeGreaterThanOrEqual(2);
   });
 
-  it('logs but does not mark inactive on non-DeviceNotRegistered ticket errors', async () => {
+  it('logs but does not mark inactive on non-terminal ticket errors (rate-limit retry)', async () => {
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
@@ -165,6 +172,63 @@ describe('sendExpoPush', () => {
 
     expect(tickets).toHaveLength(1);
     expect(errSpy).toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it.each([
+    ['InvalidCredentials', 'rotated APNs cert / Expo creds'],
+    ['MismatchSenderId', 'FCM project mismatch'],
+  ])(
+    'marks tokens inactive AND captures Sentry on terminal error %s',
+    async (code, _label) => {
+      captureExceptionMock.mockClear();
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              status: 'error',
+              message: code,
+              details: { error: code },
+            },
+          ],
+        }),
+      } as unknown as Response);
+
+      await sendExpoPush([
+        { to: 'ExponentPushToken[abc]', title: 't', body: 'b' },
+      ]);
+
+      expect(captureExceptionMock).toHaveBeenCalled();
+      expect(vi.mocked(db.update).mock.calls.length).toBeGreaterThanOrEqual(2);
+      errSpy.mockRestore();
+    },
+  );
+
+  it('captures Sentry alarm on MessageTooBig (config bug, no token clear)', async () => {
+    captureExceptionMock.mockClear();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            status: 'error',
+            message: 'too big',
+            details: { error: 'MessageTooBig' },
+          },
+        ],
+      }),
+    } as unknown as Response);
+
+    await sendExpoPush([
+      { to: 'ExponentPushToken[abc]', title: 't', body: 'b' },
+    ]);
+
+    expect(captureExceptionMock).toHaveBeenCalled();
+    // MessageTooBig is alarmable but not a token-death signal; token stays.
     expect(db.update).not.toHaveBeenCalled();
     errSpy.mockRestore();
   });

--- a/apps/api/src/services/expoPush.ts
+++ b/apps/api/src/services/expoPush.ts
@@ -1,6 +1,7 @@
 import { db } from '../db';
 import { mobileDevices } from '../db/schema/mobile';
 import { and, eq } from 'drizzle-orm';
+import { captureException } from './sentry';
 
 const EXPO_PUSH_URL = 'https://exp.host/--/api/v2/push/send';
 const MAX_LABEL_LEN = 60;
@@ -45,6 +46,25 @@ export async function sendExpoPush(
   return tickets;
 }
 
+// Codes that mean "this push token will never deliver again." Per Expo
+// docs these are all terminal: the token is bad, the cert/credentials
+// are wrong, or the device unregistered. In all cases we clear the
+// token row so subsequent pushes don't keep hitting the same dead end.
+const TERMINAL_TOKEN_ERROR_CODES = new Set([
+  'DeviceNotRegistered',
+  'InvalidCredentials',
+  'MismatchSenderId',
+]);
+
+// Codes that signal a config bug — not user-recoverable but worth paging
+// ops because every approval push will silently fail until the cert/key
+// is rotated.
+const ALARMABLE_ERROR_CODES = new Set([
+  'InvalidCredentials',
+  'MismatchSenderId',
+  'MessageTooBig',
+]);
+
 async function handleTicketErrors(
   messages: ExpoPushMessage[],
   tickets: ExpoPushTicket[]
@@ -63,13 +83,20 @@ async function handleTicketErrors(
       message: ticket.message,
       code,
     });
-    if (code === 'DeviceNotRegistered' && token) {
+    if (ALARMABLE_ERROR_CODES.has(code ?? '')) {
+      captureException(
+        new Error(`Expo push terminal error: ${code ?? 'unknown'} — ${ticket.message ?? ''}`),
+      );
+    }
+    if (code && TERMINAL_TOKEN_ERROR_CODES.has(code) && token) {
       deadTokens.push(token);
     }
   }
   if (deadTokens.length === 0) return;
-  try {
-    for (const token of deadTokens) {
+  // Clear each token in its own try block so one DB failure doesn't
+  // abandon the rest.
+  for (const token of deadTokens) {
+    try {
       await db
         .update(mobileDevices)
         .set({ apnsToken: null })
@@ -78,9 +105,10 @@ async function handleTicketErrors(
         .update(mobileDevices)
         .set({ fcmToken: null })
         .where(eq(mobileDevices.fcmToken, token));
+    } catch (err) {
+      captureException(err);
+      console.error('[expoPush] failed to clear dead token', { token, err });
     }
-  } catch (err) {
-    console.error('[expoPush] failed to clear dead tokens', err);
   }
 }
 

--- a/apps/api/src/services/oauthRevocation.ts
+++ b/apps/api/src/services/oauthRevocation.ts
@@ -1,0 +1,142 @@
+import { and, eq, inArray, isNull } from 'drizzle-orm';
+
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { oauthGrants, oauthRefreshTokens } from '../db/schema/oauth';
+import { revokeGrant, revokeJti } from '../oauth/revocationCache';
+import { ERROR_IDS, logOauthError } from '../oauth/log';
+import { ACCESS_TOKEN_TTL_SECONDS } from '../oauth/provider';
+import { captureException } from './sentry';
+
+export interface RevokeUserOauthClientResult {
+  grantsRevoked: number;
+  refreshTokensRevoked: number;
+  /**
+   * Number of Redis revocation-cache writes that failed after the DB
+   * transaction committed. >0 means the DB state is fully correct but
+   * some active JWTs may survive until natural TTL (≤ ACCESS_TOKEN_TTL).
+   * Callers that need to alert on this should propagate to the response
+   * and audit details.
+   */
+  cacheFailures: number;
+}
+
+/**
+ * Revoke every active grant + refresh token a user holds for a single
+ * OAuth client. Used by:
+ *   - lifecycle: self-revoke + admin org-block + admin per-user block
+ *   - approvals: "this wasn't me" suspicious-report path
+ *
+ * Atomic DB phase (grants UPDATE + refresh-tokens SELECT/UPDATE) under
+ * db.transaction. Redis cache writes are best-effort after commit; cache
+ * failures are logged + Sentry'd and surfaced via `cacheFailures` rather
+ * than throwing.
+ */
+export async function revokeUserOauthClient(
+  userId: string,
+  clientId: string,
+  revokedByUserId: string,
+  reason: string | null
+): Promise<RevokeUserOauthClientResult> {
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const now = new Date();
+
+      const { updatedGrants, tokens } = await db.transaction(async (tx) => {
+        const updatedGrants = await tx
+          .update(oauthGrants)
+          .set({ revokedAt: now, revokedByUserId, revokedReason: reason })
+          .where(
+            and(
+              eq(oauthGrants.accountId, userId),
+              eq(oauthGrants.clientId, clientId),
+              isNull(oauthGrants.revokedAt)
+            )
+          )
+          .returning({ id: oauthGrants.id });
+
+        const tokens = await tx
+          .select({
+            id: oauthRefreshTokens.id,
+            payload: oauthRefreshTokens.payload,
+            expiresAt: oauthRefreshTokens.expiresAt,
+          })
+          .from(oauthRefreshTokens)
+          .where(
+            and(
+              eq(oauthRefreshTokens.userId, userId),
+              eq(oauthRefreshTokens.clientId, clientId),
+              isNull(oauthRefreshTokens.revokedAt)
+            )
+          );
+
+        if (tokens.length > 0) {
+          await tx
+            .update(oauthRefreshTokens)
+            .set({ revokedAt: now })
+            .where(inArray(oauthRefreshTokens.id, tokens.map((t) => t.id)));
+        }
+
+        return { updatedGrants, tokens };
+      });
+
+      let cacheFailures = 0;
+      const onCacheFailure = (
+        err: unknown,
+        message: string,
+        context: Record<string, unknown>
+      ): void => {
+        cacheFailures++;
+        logOauthError({
+          errorId: ERROR_IDS.OAUTH_REVOCATION_CACHE_WRITE_FAILED,
+          message,
+          err,
+          context: { ...context, clientId, userId },
+        });
+        captureException(err);
+      };
+
+      const seenGrants = new Set<string>();
+      for (const tok of tokens) {
+        const payload = tok.payload as { jti?: string; grantId?: string } | null;
+        if (payload?.jti) {
+          const ttl = Math.ceil((new Date(tok.expiresAt).getTime() - Date.now()) / 1000);
+          try {
+            await revokeJti(payload.jti, Math.max(ttl, 1));
+          } catch (err) {
+            onCacheFailure(err, 'oauth jti revocation cache write failed', {
+              jti: payload.jti,
+            });
+          }
+        }
+        if (payload?.grantId && !seenGrants.has(payload.grantId)) {
+          seenGrants.add(payload.grantId);
+          try {
+            await revokeGrant(payload.grantId, ACCESS_TOKEN_TTL_SECONDS);
+          } catch (err) {
+            onCacheFailure(err, 'oauth grant revocation cache write failed', {
+              grantId: payload.grantId,
+            });
+          }
+        }
+      }
+
+      for (const grant of updatedGrants) {
+        if (seenGrants.has(grant.id)) continue;
+        seenGrants.add(grant.id);
+        try {
+          await revokeGrant(grant.id, ACCESS_TOKEN_TTL_SECONDS);
+        } catch (err) {
+          onCacheFailure(err, 'oauth grant-only revocation cache write failed', {
+            grantId: grant.id,
+          });
+        }
+      }
+
+      return {
+        grantsRevoked: updatedGrants.length,
+        refreshTokensRevoked: tokens.length,
+        cacheFailures,
+      };
+    })
+  );
+}


### PR DESCRIPTION
## Summary

Address verified findings from the multi-agent review of PR #696. Commits stack on top of `feat/mobile-approval-mode` — merge this first, then the parent PR rebases.

Two critical findings, one important pagination fix, the silent-failure cluster, a unification refactor, and a defensive migration rename.

## Verified (and acted on)

- **Critical**: mobile-blocked middleware ran before auth, scoped lookups by header value alone, and echoed admin `blocked_reason` to the client. Now mounted after `authMiddleware`, scoped by `userId`, reason dropped from response. (`e795fe7d`)
- **Critical**: `revokeUserOauthClient` was non-transactional — UPDATE grants committed before Redis writes that threw on failure, leaving partial state. Now wrapped in `db.transaction`; Redis writes are best-effort after commit and surface `cacheFailures` to caller + audit. (`ec607241`)
- **Important**: admin account-deletion list/count full-scanned `organization_users` and applied SQL `limit/offset` then JS-filtered, breaking pagination for non-system admins. Now `inArray(reachable)` in WHERE before limit/offset; pending-count uses `count()`. (`311ed7fa`)
- **Unification**: `report-suspicious` did its own DELETE on `oauth_grants`, ignoring the new soft-delete `revoked_at` column shipped in the same PR. Extracted `revokeUserOauthClient` to a shared `services/oauthRevocation.ts` and made `report-suspicious` use it. Returns 200+warning when revocation fails so the mobile UI can show accurate state instead of always claiming "session revoked." (`b90ef956`)
- **Silent failures**: added `captureException` at decideHandler `ai_tool_executions` mirror, expiry reaper audit/shutdown, `aiAgentSdk` approval-row insert + push dispatch. `expoPush` now treats `InvalidCredentials` / `MismatchSenderId` as terminal (clears token) and `MessageTooBig` as alarmable. Per-token try/catch in the dead-token cleanup loop. (`8c02db3f`)
- **Test gap**: assert mobile block clears `fcmToken` / `apnsToken`. (`a8c19f39`)
- **Migration rename**: `2026-05-07-mobile-…` → `2026-05-07-c-mobile-…` so the file sorts intentionally after the `-b-` files instead of accidentally-because-'m'-comes-after-'b'. Safe per CLAUDE.md: file is fully idempotent and prod hasn't seen it yet. (`070db55b`)

## Findings dismissed

- ~~Critical: missing `client_id` JWT claim~~ — verified false positive; `oidc-provider@9.8.3` always emits `client_id` in jwt format (`jwt.js:122`).
- ~~Important: block doesn't clear push tokens~~ — verified false positive at the code level; both block paths null the tokens. The test gap was real and is now closed (`a8c19f39`).

## Test plan

- [x] `pnpm test --filter=@breeze/api` — 4172 passed, 28 skipped, 0 failed
- [x] `npx tsc --noEmit` clean across api
- [ ] Manual: hit `/api/v1/mobile/devices` without auth + with `X-Breeze-Mobile-Device-Id` set; confirm 401 (no blocked-row leak)
- [ ] Manual: trigger Redis outage during self-revoke; confirm 200 + `cacheFailures > 0 ` + grants still revoked in DB
- [ ] Manual: log in as partner admin, paginate `/admin/account-deletion-requests`; confirm full pages not partial

🤖 Generated with [Claude Code](https://claude.com/claude-code)