### PR TITLE
feat(agent,windows): ship GUI-subsystem breeze-user-helper.exe to suppress logon console flash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,11 +349,37 @@ jobs:
             -o "breeze-agent-${GOOS}-${GOARCH}${{ matrix.suffix }}" \
             ./cmd/breeze-agent
 
+      # Windows-only: build a GUI-subsystem sibling from the SAME source so the
+      # scheduled task that launches the user-helper at logon does not allocate
+      # a visible console window. Same Go source, only the -H windowsgui linker
+      # flag differs. See agent/Makefile (build-windows-user-helper) for the
+      # local-dev equivalent.
+      - name: Build user-helper (Windows only)
+        if: matrix.goos == 'windows'
+        working-directory: agent
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: ${{ matrix.cgo }}
+          BUILD_VERSION: ${{ github.sha }}
+        run: |
+          go build -ldflags="-s -w -X main.version=${BUILD_VERSION} -H windowsgui" \
+            -o "breeze-user-helper-${GOOS}-${GOARCH}${{ matrix.suffix }}" \
+            ./cmd/breeze-agent
+
       - name: Upload Agent artifact
         uses: actions/upload-artifact@v7
         with:
           name: breeze-agent-${{ matrix.goos }}-${{ matrix.goarch }}
           path: agent/breeze-agent-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.suffix }}
+          retention-days: 7
+
+      - name: Upload user-helper artifact (Windows only)
+        if: matrix.goos == 'windows'
+        uses: actions/upload-artifact@v7
+        with:
+          name: breeze-user-helper-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: agent/breeze-user-helper-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.suffix }}
           retention-days: 7
 
   test-agent:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,6 +272,14 @@ jobs:
         env:
           BUILD_VERSION: ${{ steps.version.outputs.version }}
         run: |
+          # Fail-fast: a non-terminating PowerShell error (e.g. a missing
+          # toolchain) otherwise lets a later `go build` proceed against
+          # stale or missing resources, and a non-zero `go build` exit code
+          # is silently ignored unless we check $LASTEXITCODE — that
+          # combination shipped a release once where the agent .exe was
+          # absent from dist\ and the installer step packaged whatever was
+          # left from a previous run.
+          $ErrorActionPreference = "Stop"
           New-Item -Path dist -ItemType Directory -Force | Out-Null
           go install github.com/tc-hib/go-winres@v0.3.3
           Push-Location agent\resources
@@ -282,6 +290,7 @@ jobs:
           $env:GOARCH = "amd64"
           $env:CGO_ENABLED = "0"
           go build -ldflags="-s -w -X main.version=$env:BUILD_VERSION" -o ..\dist\breeze-agent-windows-amd64.exe .\cmd\breeze-agent
+          if ($LASTEXITCODE -ne 0) { throw "go build breeze-agent failed with exit code $LASTEXITCODE" }
           Pop-Location
           # Build breeze-backup
           Push-Location agent
@@ -289,6 +298,7 @@ jobs:
           $env:GOARCH = "amd64"
           $env:CGO_ENABLED = "0"
           go build -ldflags="-s -w -X main.version=$env:BUILD_VERSION" -o ..\dist\breeze-backup-windows-amd64.exe .\cmd\breeze-backup
+          if ($LASTEXITCODE -ne 0) { throw "go build breeze-backup failed with exit code $LASTEXITCODE" }
           Pop-Location
           # Build breeze-watchdog
           Push-Location agent
@@ -296,6 +306,19 @@ jobs:
           $env:GOARCH = "amd64"
           $env:CGO_ENABLED = "0"
           go build -ldflags="-s -w -X main.version=$env:BUILD_VERSION" -o ..\dist\breeze-watchdog-windows-amd64.exe .\cmd\breeze-watchdog
+          if ($LASTEXITCODE -ne 0) { throw "go build breeze-watchdog failed with exit code $LASTEXITCODE" }
+          Pop-Location
+          # Build breeze-user-helper (GUI-subsystem sibling of breeze-agent).
+          # Same Go source as breeze-agent, only the -H windowsgui linker flag
+          # differs. Required by the AgentUserHelper scheduled task and the
+          # SYSTEM-context sessionbroker spawn paths so the user-helper does
+          # not surface a console window in the interactive session.
+          Push-Location agent
+          $env:GOOS = "windows"
+          $env:GOARCH = "amd64"
+          $env:CGO_ENABLED = "0"
+          go build -ldflags="-s -w -X main.version=$env:BUILD_VERSION -H windowsgui" -o ..\dist\breeze-user-helper-windows-amd64.exe .\cmd\breeze-agent
+          if ($LASTEXITCODE -ne 0) { throw "go build breeze-user-helper failed with exit code $LASTEXITCODE" }
           Pop-Location
 
       - name: Validate signing configuration
@@ -405,6 +428,30 @@ jobs:
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
 
+      - name: Sign user-helper EXE (stable profile)
+        if: ${{ !contains(github.ref_name, '-') }}
+        uses: azure/artifact-signing-action@b443cf8ea4124818d2ea9f043cba29fc3ec47b16 # v1
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PROD }}
+          files: ${{ github.workspace }}\dist\breeze-user-helper-windows-amd64.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Sign user-helper EXE (prerelease profile)
+        if: ${{ contains(github.ref_name, '-') }}
+        uses: azure/artifact-signing-action@b443cf8ea4124818d2ea9f043cba29fc3ec47b16 # v1
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PRERELEASE }}
+          files: ${{ github.workspace }}\dist\breeze-user-helper-windows-amd64.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
       - name: Build MSI
         shell: pwsh
         run: |
@@ -413,8 +460,9 @@ jobs:
           $agentExe = Join-Path $root "dist\breeze-agent-windows-amd64.exe"
           $backupExe = Join-Path $root "dist\breeze-backup-windows-amd64.exe"
           $watchdogExe = Join-Path $root "dist\breeze-watchdog-windows-amd64.exe"
+          $userHelperExe = Join-Path $root "dist\breeze-user-helper-windows-amd64.exe"
           $msiPath = Join-Path $root "dist\breeze-agent.msi"
-          & (Join-Path $root "agent\installer\build-msi.ps1") -Version $version -AgentExePath $agentExe -BackupExePath $backupExe -WatchdogExePath $watchdogExe -OutputPath $msiPath
+          & (Join-Path $root "agent\installer\build-msi.ps1") -Version $version -AgentExePath $agentExe -BackupExePath $backupExe -WatchdogExePath $watchdogExe -UserHelperExePath $userHelperExe -OutputPath $msiPath
 
       - name: Build Template MSI
         shell: pwsh
@@ -424,8 +472,9 @@ jobs:
           $agentExe = Join-Path $root "dist\breeze-agent-windows-amd64.exe"
           $backupExe = Join-Path $root "dist\breeze-backup-windows-amd64.exe"
           $watchdogExe = Join-Path $root "dist\breeze-watchdog-windows-amd64.exe"
+          $userHelperExe = Join-Path $root "dist\breeze-user-helper-windows-amd64.exe"
           $msiPath = Join-Path $root "dist\breeze-agent-template.msi"
-          & (Join-Path $root "agent\installer\build-msi.ps1") -Version $version -AgentExePath $agentExe -BackupExePath $backupExe -WatchdogExePath $watchdogExe -OutputPath $msiPath -Template
+          & (Join-Path $root "agent\installer\build-msi.ps1") -Version $version -AgentExePath $agentExe -BackupExePath $backupExe -WatchdogExePath $watchdogExe -UserHelperExePath $userHelperExe -OutputPath $msiPath -Template
 
       # Only sign the regular MSI — template MSI is re-signed server-side by jsign after patching
       - name: Sign MSI (stable profile)

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-agent build-desktop-helper build-backup build-all build-all-agent build-all-desktop-helper build-all-backup build-winres build-windows-msi clean test install install-service uninstall-service dev-push dev-push-helper build-watchdog build-watchdog-linux build-watchdog-darwin build-watchdog-windows dev-push-watchdog dev-push-both
+.PHONY: build build-agent build-desktop-helper build-backup build-all build-all-agent build-all-desktop-helper build-all-backup build-windows-user-helper build-winres build-windows-msi clean test install install-service uninstall-service dev-push dev-push-helper build-watchdog build-watchdog-linux build-watchdog-darwin build-watchdog-windows dev-push-watchdog dev-push-both
 
 VERSION ?= 0.5.0
 LDFLAGS := -ldflags "-X main.version=$(VERSION)"
@@ -39,8 +39,20 @@ build-darwin:
 	GOOS=darwin GOARCH=amd64 go build $(LDFLAGS) -o bin/breeze-agent-darwin-amd64 ./cmd/breeze-agent
 	GOOS=darwin GOARCH=arm64 go build $(LDFLAGS) -o bin/breeze-agent-darwin-arm64 ./cmd/breeze-agent
 
-build-windows:
+build-windows: build-windows-user-helper
 	GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o bin/breeze-agent-windows-amd64.exe ./cmd/breeze-agent
+
+# build-windows-user-helper builds the SAME ./cmd/breeze-agent source as a
+# GUI-subsystem PE binary so the scheduled task that launches the user-helper
+# at user logon does not allocate a visible console window. Console-subsystem
+# binaries (the default `go build` output on Windows) get an attached console
+# from the kernel whenever the Task Scheduler spawns them in a user session,
+# regardless of the task XML <Hidden> flag. -H windowsgui flips the PE
+# subsystem byte from 3 to 2; the kernel then allocates no console at all.
+# Same Go program, same subcommands, same agent.yaml — only the linker flag
+# differs.
+build-windows-user-helper:
+	GOOS=windows GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION) -H windowsgui" -o bin/breeze-user-helper-windows-amd64.exe ./cmd/breeze-agent
 
 build-winres:
 	@command -v go-winres >/dev/null 2>&1 || (echo "go-winres not found. Install with: go install github.com/tc-hib/go-winres@latest" && exit 1)

--- a/agent/cmd/breeze-agent/helper_console_other.go
+++ b/agent/cmd/breeze-agent/helper_console_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package main
+
+// detachHelperConsole is a no-op outside Windows. macOS and Linux do not
+// have the "console window flashes when a console-subsystem binary is
+// launched in an interactive session" problem the Windows version is solving.
+func detachHelperConsole() {}

--- a/agent/cmd/breeze-agent/helper_console_windows.go
+++ b/agent/cmd/breeze-agent/helper_console_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package main
+
+import "syscall"
+
+var procFreeConsole = syscall.NewLazyDLL("kernel32.dll").NewProc("FreeConsole")
+
+// detachHelperConsole detaches the current process from its inherited console.
+// The user-helper binary shipped with the MSI is built with -H windowsgui so
+// the kernel never allocates a console to begin with — this call is then a
+// no-op. The defense-in-depth value kicks in when the legacy console-subsystem
+// breeze-agent.exe is invoked with the `user-helper` subcommand (e.g. manual
+// CLI usage, or a partially-upgraded install where the new MSI hasn't repointed
+// the scheduled task yet): in that path FreeConsole closes the inherited
+// console immediately so any visible window collapses within milliseconds of
+// process start. FreeConsole on a process without a console is a documented
+// no-op, so calling it unconditionally is safe.
+//
+// FreeConsole's return value is captured so that a failure on the legacy CUI
+// fallback path (where success is load-bearing for the no-flash promise) is
+// at least observable in logs. A non-zero r1 means success; r1 == 0 means
+// the call failed and errno is in e1. We deliberately do not return an error
+// because there's no remediation path — but the Warn gives ops a signal if
+// every fleet device suddenly starts flashing windows.
+func detachHelperConsole() {
+	r1, _, e1 := procFreeConsole.Call()
+	if r1 == 0 {
+		log.Warn("FreeConsole() failed on user-helper entry — inherited console may remain attached",
+			"errno", e1.Error(),
+		)
+	}
+}

--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -1057,6 +1057,19 @@ func desktopHelperRole() string {
 }
 
 func runHelperProcess(name, role, context, binaryKind string) {
+	// Detach any inherited console immediately. This runs at the top of
+	// every helper role — user-helper, desktop-helper, and any future
+	// helper subcommand routed through runHelperProcess — because all of
+	// them risk inheriting a console window when the parent path uses the
+	// legacy console-subsystem breeze-agent.exe (e.g. operators running
+	// the helper manually from cmd.exe, or partially-upgraded installs
+	// where the new MSI hasn't repointed the scheduled task at
+	// breeze-user-helper.exe yet). The GUI-subsystem sibling built per
+	// agent/Makefile build-windows-user-helper has no console to free, so
+	// the call is a documented no-op there. Cross-platform stub on
+	// macOS/Linux.
+	detachHelperConsole()
+
 	// Log to file in the same logs folder as the main agent
 	logDir := filepath.Dir(config.Default().LogFile) // e.g. C:\ProgramData\Breeze\logs
 	os.MkdirAll(logDir, 0700)

--- a/agent/cmd/breeze-agent/subsystem_test.go
+++ b/agent/cmd/breeze-agent/subsystem_test.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestUserHelperBinaryHasGUISubsystem cross-compiles the SAME source as the
+// user-helper binary (./cmd/breeze-agent with -H windowsgui) and asserts the
+// resulting PE file has subsystem byte 2 (IMAGE_SUBSYSTEM_WINDOWS_GUI), not 3
+// (IMAGE_SUBSYSTEM_WINDOWS_CUI).
+//
+// This is a regression guard for the "console window flashes at user logon"
+// bug: without -H windowsgui the kernel allocates a console window every time
+// the AgentUserHelper scheduled task fires, regardless of <Hidden>true</Hidden>
+// in the task XML. The Makefile target build-windows-user-helper and the CI
+// matrix step that builds breeze-user-helper-windows-amd64.exe both pass the
+// flag; this test ensures neither silently drops it.
+//
+// Runs on any platform that has the Go cross-compile toolchain (CI's Linux
+// runner is enough). Skipped if `go` is not on PATH.
+func TestUserHelperBinaryHasGUISubsystem(t *testing.T) {
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go toolchain not on PATH")
+	}
+
+	tmpDir := t.TempDir()
+	outPath := filepath.Join(tmpDir, "breeze-user-helper.exe")
+
+	cmd := exec.Command(goBin,
+		"build",
+		"-ldflags", "-s -w -H windowsgui",
+		"-o", outPath,
+		".",
+	)
+	cmd.Env = append(os.Environ(), "GOOS=windows", "GOARCH=amd64", "CGO_ENABLED=0")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("cross-compile failed: %v\n%s", err, string(out))
+	}
+
+	subsys, err := readPESubsystem(outPath)
+	if err != nil {
+		t.Fatalf("read PE subsystem: %v", err)
+	}
+
+	const (
+		imageSubsystemWindowsGUI = 2
+		imageSubsystemWindowsCUI = 3
+	)
+
+	if subsys != imageSubsystemWindowsGUI {
+		t.Fatalf("user-helper binary built with -H windowsgui has subsystem %d, want %d (GUI). "+
+			"Subsystem %d is %s. Did the Makefile or CI workflow drop the -H windowsgui linker flag? "+
+			"Restoring it is required to prevent the kernel allocating a console window at scheduled-task logon.",
+			subsys, imageSubsystemWindowsGUI,
+			subsys, subsystemName(subsys))
+	}
+
+}
+
+// TestAgentBinaryHasCUISubsystem is the counter-assertion to
+// TestUserHelperBinaryHasGUISubsystem: cross-compiles the SAME source as the
+// MAIN agent binary (./cmd/breeze-agent) WITHOUT the -H windowsgui flag and
+// asserts the resulting PE file has subsystem byte 3 (IMAGE_SUBSYSTEM_WINDOWS_CUI).
+//
+// Without this counter-assertion, a Makefile refactor or CI workflow change
+// that accidentally added -H windowsgui to the default agent build would
+// silently make breeze-agent.exe a GUI-subsystem binary — `breeze-agent
+// enroll` and other CLI subcommands would then run without a usable stdout
+// (admins running the CLI from cmd would see no output), and the post-install
+// MSI enrollment CA would lose its enroll-last-error.txt diagnostic trail
+// because the CA captures stderr.
+//
+// Together with TestUserHelperBinaryHasGUISubsystem, this pins the
+// subsystem-byte invariant in both directions.
+func TestAgentBinaryHasCUISubsystem(t *testing.T) {
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go toolchain not on PATH")
+	}
+
+	tmpDir := t.TempDir()
+	outPath := filepath.Join(tmpDir, "breeze-agent.exe")
+
+	cmd := exec.Command(goBin,
+		"build",
+		"-ldflags", "-s -w", // explicitly no -H windowsgui
+		"-o", outPath,
+		".",
+	)
+	cmd.Env = append(os.Environ(), "GOOS=windows", "GOARCH=amd64", "CGO_ENABLED=0")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("cross-compile failed: %v\n%s", err, string(out))
+	}
+
+	subsys, err := readPESubsystem(outPath)
+	if err != nil {
+		t.Fatalf("read PE subsystem: %v", err)
+	}
+
+	const (
+		imageSubsystemWindowsGUI = 2
+		imageSubsystemWindowsCUI = 3
+	)
+
+	if subsys != imageSubsystemWindowsCUI {
+		t.Fatalf("default agent binary (no -H windowsgui) has subsystem %d, want %d (CUI/console). "+
+			"Subsystem %d is %s. Did the Makefile or CI workflow accidentally add -H windowsgui to "+
+			"the default agent build? That would break `breeze-agent enroll` and the post-install "+
+			"diagnostic trail because the CLI loses its stdout.",
+			subsys, imageSubsystemWindowsCUI,
+			subsys, subsystemName(subsys))
+	}
+}
+
+// readPESubsystem returns the value of the IMAGE_OPTIONAL_HEADER.Subsystem
+// field from a Windows PE file. For PE32 and PE32+ the field lives at PE
+// header offset 0x5c (44 bytes into the optional header after the magic).
+func readPESubsystem(path string) (uint16, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	// MZ stub points at the PE header offset at file offset 0x3c.
+	if _, err := f.Seek(0x3c, io.SeekStart); err != nil {
+		return 0, err
+	}
+	var peOff uint32
+	if err := binary.Read(f, binary.LittleEndian, &peOff); err != nil {
+		return 0, err
+	}
+
+	// "PE\0\0" signature + COFF header (20 bytes) starts at peOff. The
+	// optional header begins at peOff + 0x18. Subsystem is at +0x5c
+	// inside the optional header (same offset for PE32 and PE32+ because
+	// the preceding fields are identically sized in both layouts).
+	if _, err := f.Seek(int64(peOff)+0x5c, io.SeekStart); err != nil {
+		return 0, err
+	}
+	var subsys uint16
+	if err := binary.Read(f, binary.LittleEndian, &subsys); err != nil {
+		if errors.Is(err, io.EOF) {
+			return 0, errors.New("truncated PE: subsystem field beyond EOF")
+		}
+		return 0, err
+	}
+	return subsys, nil
+}
+
+func subsystemName(s uint16) string {
+	switch s {
+	case 1:
+		return "NATIVE"
+	case 2:
+		return "WINDOWS_GUI"
+	case 3:
+		return "WINDOWS_CUI (console)"
+	default:
+		return "unknown"
+	}
+}

--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -11,6 +11,9 @@
 <?ifndef WatchdogExePath?>
 <?define WatchdogExePath=..\breeze-watchdog-windows-amd64.exe?>
 <?endif?>
+<?ifndef UserHelperExePath?>
+<?define UserHelperExePath=..\breeze-user-helper-windows-amd64.exe?>
+<?endif?>
 <?ifndef UserTaskXmlPath?>
 <?define UserTaskXmlPath=..\service\windows\breeze-agent-user-task.xml?>
 <?endif?>
@@ -76,7 +79,7 @@
     <CustomAction
       Id="KillBreezeProcesses"
       Property="BREEZE_KILL_CMD"
-      ExeCommand="/c &quot;taskkill /F /T /IM breeze-agent.exe /IM breeze-watchdog.exe /IM breeze-desktop-helper.exe /IM breeze-backup.exe &amp; exit /b 0&quot;"
+      ExeCommand="/c &quot;taskkill /F /T /IM breeze-agent.exe /IM breeze-user-helper.exe /IM breeze-watchdog.exe /IM breeze-desktop-helper.exe /IM breeze-backup.exe &amp; exit /b 0&quot;"
       Execute="immediate"
       Return="ignore" />
 
@@ -114,6 +117,15 @@
         <Component Id="cmpBreezeBackupExe" Guid="*">
           <File Id="filBreezeBackupExe" Name="breeze-backup.exe"
                 Source="$(var.BackupExePath)" KeyPath="yes" />
+        </Component>
+
+        <Component Id="cmpBreezeUserHelperExe" Guid="*">
+          <!-- GUI-subsystem sibling of breeze-agent.exe (same Go source, -H windowsgui).
+               Launched by the AgentUserHelper scheduled task at user logon and by the
+               SYSTEM-context sessionbroker spawn paths. GUI subsystem prevents the
+               Windows kernel from allocating a console window for the helper. -->
+          <File Id="filBreezeUserHelperExe" Name="breeze-user-helper.exe"
+                Source="$(var.UserHelperExePath)" KeyPath="yes" />
         </Component>
 
         <Component Id="cmpBreezeWatchdogExe" Guid="*">
@@ -231,8 +243,19 @@
       <Custom Action="KillBreezeProcesses" Before="InstallValidate" Condition="WIX_UPGRADE_DETECTED OR Installed" />
       <Custom Action="SetPowerShellPath" After="InstallInitialize" />
       <Custom Action="HardenProgramDataAcl" After="CreateFolders" Condition="NOT REMOVE" />
+      <!-- Rollback rolls back the FIRST-install case only; on upgrade or
+           repair the existing task is valid prior state and shouldn't be
+           wiped by a rolled-back inner install. -->
       <Custom Action="RollbackRegisterUserHelperTask" Before="RegisterUserHelperTask" Condition="NOT Installed AND NOT REMOVE AND NOT WIX_UPGRADE_DETECTED" />
-      <Custom Action="RegisterUserHelperTask" After="InstallServices" Condition="NOT Installed AND NOT REMOVE" />
+      <!-- RegisterUserHelperTask runs on EVERY install path that isn't
+           uninstall: first install, major upgrade, and `msiexec /fa` repair.
+           The PS script's Register-ScheduledTask -Force is idempotent, so
+           re-registering on repair just refreshes the action to the current
+           XML (the binary path may have changed across versions) — which is
+           the entire point. The previous `NOT Installed AND NOT REMOVE`
+           gate skipped repair, leaving repaired installs with stale task
+           pointers. -->
+      <Custom Action="RegisterUserHelperTask" After="InstallServices" Condition="NOT REMOVE" />
       <!-- Enrollment runs after file copy but before InstallServices.
 
            Return="check" on the EnrollAgent CA means a non-zero exit
@@ -262,6 +285,7 @@
     <Feature Id="MainFeature" Title="Breeze Agent" Level="1">
       <ComponentRef Id="cmpBreezeAgentExe" />
       <ComponentRef Id="cmpBreezeBackupExe" />
+      <ComponentRef Id="cmpBreezeUserHelperExe" />
       <ComponentRef Id="cmpBreezeWatchdogExe" />
       <ComponentRef Id="cmpSafeBootNetworkReg" />
       <ComponentRef Id="cmpUserTaskXml" />

--- a/agent/installer/build-msi.ps1
+++ b/agent/installer/build-msi.ps1
@@ -12,6 +12,9 @@ param(
     [string]$WatchdogExePath = "",
 
     [Parameter(Mandatory = $false)]
+    [string]$UserHelperExePath = "",
+
+    [Parameter(Mandatory = $false)]
     [string]$OutputPath = "",
 
     [switch]$Template
@@ -34,6 +37,9 @@ if ([string]::IsNullOrWhiteSpace($BackupExePath)) {
 if ([string]::IsNullOrWhiteSpace($WatchdogExePath)) {
     $WatchdogExePath = Join-Path $repoRoot "breeze-watchdog-windows-amd64.exe"
 }
+if ([string]::IsNullOrWhiteSpace($UserHelperExePath)) {
+    $UserHelperExePath = Join-Path $repoRoot "breeze-user-helper-windows-amd64.exe"
+}
 if ([string]::IsNullOrWhiteSpace($OutputPath)) {
     $OutputPath = Join-Path $repoRoot "..\\dist\\breeze-agent.msi"
 }
@@ -53,6 +59,9 @@ if (-not (Test-Path $BackupExePath)) {
 }
 if (-not (Test-Path $WatchdogExePath)) {
     throw "Watchdog executable not found: $WatchdogExePath"
+}
+if (-not (Test-Path $UserHelperExePath)) {
+    throw "User-helper executable not found: $UserHelperExePath"
 }
 if (-not (Test-Path $taskXmlPath)) {
     throw "Task XML not found: $taskXmlPath"
@@ -96,6 +105,7 @@ $wixArgs = @(
     "-d", "AgentExePath=$AgentExePath",
     "-d", "BackupExePath=$BackupExePath",
     "-d", "WatchdogExePath=$WatchdogExePath",
+    "-d", "UserHelperExePath=$UserHelperExePath",
     "-d", "UserTaskXmlPath=$taskXmlPath",
     "-d", "InstallUserHelperScriptPath=$installUserHelperScriptPath",
     "-d", "RemoveUserHelperScriptPath=$removeUserHelperScriptPath",

--- a/agent/internal/heartbeat/handlers_devupdate.go
+++ b/agent/internal/heartbeat/handlers_devupdate.go
@@ -17,7 +17,13 @@ import (
 const (
 	devUpdateComponentAgent         = "agent"
 	devUpdateComponentDesktopHelper = "desktop-helper"
+	devUpdateComponentUserHelper    = "user-helper"
 )
+
+// windowsUserHelperInstallPath is the installed location of the GUI-subsystem
+// user-helper sibling binary on Windows. Must match the breeze.wxs File entry
+// and the AgentUserHelper scheduled task XML.
+const windowsUserHelperInstallPath = `C:\Program Files\Breeze\breeze-user-helper.exe`
 
 // darwinDesktopHelperInstallPath is the installed location of the desktop
 // helper binary on macOS. Must match service_cmd_darwin.go.
@@ -66,9 +72,115 @@ func handleDevUpdate(h *Heartbeat, cmd Command) tools.CommandResult {
 		return handleDevUpdateAgent(h, start, downloadURL, checksum, version, preserveAutoUpdate)
 	case devUpdateComponentDesktopHelper:
 		return handleDevUpdateDesktopHelper(h, start, downloadURL, checksum, version)
+	case devUpdateComponentUserHelper:
+		return handleDevUpdateUserHelper(h, start, downloadURL, checksum, version)
 	default:
 		return tools.NewErrorResult(fmt.Errorf("unsupported dev_update component: %q", component), time.Since(start).Milliseconds())
 	}
+}
+
+// handleDevUpdateUserHelper replaces the Windows user-helper binary
+// (breeze-user-helper.exe) on disk. The new binary is picked up at the next
+// scheduled-task firing (user logon) or the next SYSTEM-context broker spawn.
+// The scheduled task respawns the helper automatically; operators do not need
+// to manually restart anything.
+//
+// macOS and Linux do not have a user-helper sibling binary; the user-helper
+// runs as a subcommand of breeze-agent on those platforms.
+func handleDevUpdateUserHelper(h *Heartbeat, start time.Time, downloadURL, checksum, version string) tools.CommandResult {
+	if runtime.GOOS != "windows" {
+		return tools.NewErrorResult(fmt.Errorf("user-helper dev push is only implemented on windows"), time.Since(start).Milliseconds())
+	}
+
+	updaterCfg := &updater.Config{
+		ServerURL:             h.config.ServerURL,
+		AuthToken:             h.secureToken,
+		CurrentVersion:        h.agentVersion,
+		PinnedManifestPubKeys: h.config.PinnedManifestPubKeys,
+	}
+	u := updater.New(updaterCfg)
+
+	tempPath, err := u.DownloadAndVerify(downloadURL, checksum)
+	if err != nil {
+		return tools.NewErrorResult(fmt.Errorf("failed to download user helper: %w", err), time.Since(start).Milliseconds())
+	}
+	defer os.Remove(tempPath)
+
+	installPath := windowsUserHelperInstallPath
+
+	// Backup the existing helper binary so a failed swap can be rolled back
+	// manually. First-install case will have no backup target — best effort.
+	backupDir := config.GetDataDir()
+	if err := os.MkdirAll(backupDir, 0755); err != nil {
+		return tools.NewErrorResult(fmt.Errorf("failed to create backup directory %s: %w", backupDir, err), time.Since(start).Milliseconds())
+	}
+	backupPath := filepath.Join(backupDir, "breeze-user-helper.backup.exe")
+	if _, statErr := os.Stat(installPath); statErr == nil {
+		if err := copyFile(installPath, backupPath); err != nil {
+			log.Warn("failed to back up existing user helper binary — proceeding anyway",
+				"installPath", installPath,
+				"backupPath", backupPath,
+				"error", err.Error())
+		}
+	}
+
+	// Stop any running breeze-user-helper.exe before the copy so the install
+	// doesn't fail with ERROR_SHARING_VIOLATION. Windows holds an exclusive
+	// lock on a running .exe for its process lifetime, so copyFile against a
+	// live helper would return "The process cannot access the file because it
+	// is being used by another process" on every device with an active session.
+	// The AgentUserHelper scheduled task respawns the helper on next user
+	// logon (or operators can run `schtasks /run /tn "\Breeze\AgentUserHelper"`
+	// to bring it back immediately). taskkill returning non-zero is expected
+	// when no helper is currently running and is not an error.
+	killCmd := exec.Command("taskkill", "/F", "/IM", "breeze-user-helper.exe")
+	if killOut, killErr := killCmd.CombinedOutput(); killErr != nil {
+		log.Debug("taskkill breeze-user-helper.exe returned non-zero (likely not running)",
+			"output", string(killOut),
+			"error", killErr.Error())
+	} else {
+		log.Info("stopped running breeze-user-helper.exe before in-place upgrade",
+			"output", string(killOut))
+	}
+
+	if err := copyFile(tempPath, installPath); err != nil {
+		return tools.NewErrorResult(fmt.Errorf("failed to install user helper at %s: %w", installPath, err), time.Since(start).Milliseconds())
+	}
+	log.Info("installed new user-helper binary", "path", installPath, "version", version)
+
+	// Refresh the broker's binary hash allowlist so the newly spawned helper
+	// is accepted when it reconnects on the next user logon. Without this,
+	// the helper's hash mismatches the old allowlist entry and the broker
+	// rejects it with "binary hash mismatch" (see broker.go's selfHashes
+	// check — "binary path mismatch" is a separate, path-based reject that
+	// fires when the helper's exe lives outside the expected install
+	// directory). A zero-count refresh, or a refresh whose recomputed
+	// allowlist doesn't include the freshly-installed binary, means the
+	// next helper spawn will be rejected silently at the IPC handshake —
+	// we surface that as an explicit dev-update failure rather than
+	// reporting success and discovering the rejection hours later.
+	if h.sessionBroker == nil {
+		log.Warn("session broker unavailable — helper reconnection may be rejected until agent restart")
+	} else {
+		if _, refreshErr := h.sessionBroker.RefreshAllowedHashes(); refreshErr != nil {
+			return tools.NewErrorResult(fmt.Errorf("user-helper installed but broker allowlist refresh failed: %w", refreshErr), time.Since(start).Milliseconds())
+		}
+		installedHash, allowed, hashErr := h.sessionBroker.HashAndVerifyAllowed(installPath)
+		if hashErr != nil {
+			return tools.NewErrorResult(fmt.Errorf("user-helper installed but hash verification failed: %w", hashErr), time.Since(start).Milliseconds())
+		}
+		if !allowed {
+			return tools.NewErrorResult(fmt.Errorf("user-helper installed but its hash %s is not in the refreshed allowlist; next spawn will be rejected", installedHash), time.Since(start).Milliseconds())
+		}
+		log.Info("user-helper hash verified in refreshed allowlist", "hash", installedHash)
+	}
+
+	return tools.NewSuccessResult(map[string]any{
+		"message":   "user-helper binary replaced; new binary takes effect on next scheduled-task firing",
+		"component": devUpdateComponentUserHelper,
+		"version":   version,
+		"path":      installPath,
+	}, time.Since(start).Milliseconds())
 }
 
 // applyDevUpdateAutoUpdatePolicy decides whether a dev_update should leave
@@ -199,11 +311,13 @@ func handleDevUpdateDesktopHelper(h *Heartbeat, start time.Time, downloadURL, ch
 	log.Info("installed new desktop helper binary", "path", installPath, "version", version)
 
 	// Refresh the broker's binary hash allowlist so the newly spawned helper
-	// is accepted when it reconnects.
-	if h.sessionBroker != nil {
-		h.sessionBroker.RefreshAllowedHashes()
-	} else {
+	// is accepted when it reconnects. A zero-count refresh would silently
+	// reject the next helper spawn at the IPC handshake, so surface it.
+	if h.sessionBroker == nil {
 		log.Warn("session broker unavailable — helper reconnection may be rejected until agent restart")
+	} else if _, refreshErr := h.sessionBroker.RefreshAllowedHashes(); refreshErr != nil {
+		log.Error("desktop-helper hash allowlist refresh produced zero hashes — helper reconnection may be rejected",
+			"error", refreshErr.Error())
 	}
 
 	// Kickstart the helper LaunchAgents so running helpers restart with the

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -1667,6 +1667,7 @@ func (b *Broker) allowedHelperPaths() []string {
 		filepath.Join(dir, "breeze-desktop-helper"),
 		filepath.Join(dir, "breeze-watchdog"),
 		filepath.Join(dir, "breeze-desktop-helper.exe"),
+		filepath.Join(dir, UserHelperBinaryName),
 		filepath.Join(dir, "breeze-watchdog.exe"),
 	}
 	if runtime.GOOS != "windows" {
@@ -1696,12 +1697,41 @@ func (b *Broker) allowedHelperPaths() []string {
 // binaries currently present on disk. Call this after a dev push that
 // replaces a helper binary so the next connection from the newly spawned
 // helper (which will hash to a new value) is accepted.
-func (b *Broker) RefreshAllowedHashes() {
+// RefreshAllowedHashes recomputes the helper binary hash allowlist from
+// disk and atomically swaps the broker's selfHashes map.
+//
+// Returns the count of successfully-hashed binaries and a non-nil error if
+// the recompute produced zero hashes (every allowed path failed to hash,
+// usually because the helper binaries are missing or unreadable). Callers
+// that just installed a binary should treat a zero-count refresh as a fatal
+// dev-update outcome — the next helper spawn will be rejected at the IPC
+// handshake because no hash in the new map matches the peer.
+func (b *Broker) RefreshAllowedHashes() (int, error) {
 	newHashes := b.computeAllowedHashes()
 	b.mu.Lock()
 	b.selfHashes = newHashes
 	b.mu.Unlock()
 	log.Info("refreshed helper binary hash allowlist", "count", len(newHashes))
+	if len(newHashes) == 0 {
+		return 0, fmt.Errorf("no helper binary hashes could be computed; all helper connections will be rejected")
+	}
+	return len(newHashes), nil
+}
+
+// HashAndVerifyAllowed hashes the binary at path and reports whether the
+// resulting hash is in the broker's current selfHashes allowlist. Used by
+// dev-update handlers to verify that a freshly-installed binary will be
+// accepted at the next helper-spawn IPC handshake. Returns the computed hash
+// for diagnostic logging.
+func (b *Broker) HashAndVerifyAllowed(path string) (string, bool, error) {
+	sum, err := hashFileSHA256(path)
+	if err != nil {
+		return "", false, fmt.Errorf("hash %s: %w", path, err)
+	}
+	b.mu.RLock()
+	_, ok := b.selfHashes[sum]
+	b.mu.RUnlock()
+	return sum, ok, nil
 }
 
 func (b *Broker) computeAllowedHashes() map[string]struct{} {

--- a/agent/internal/sessionbroker/spawner_stub.go
+++ b/agent/internal/sessionbroker/spawner_stub.go
@@ -8,8 +8,14 @@ import "fmt"
 // spawning is handled by OS-level mechanisms (launchd LaunchAgent, systemd
 // user service, XDG autostart), so the lifecycle manager does not track
 // child processes directly.
+//
+// BinaryPath records which executable the spawner actually launched so
+// callers can distinguish the GUI-subsystem sibling (breeze-user-helper.exe)
+// from the console-subsystem agent fallback in their telemetry. Always
+// empty on non-Windows builds since the stub never spawns.
 type SpawnedHelper struct {
-	PID uint32
+	PID        uint32
+	BinaryPath string
 }
 
 // Close is a no-op on non-Windows platforms.

--- a/agent/internal/sessionbroker/spawner_windows.go
+++ b/agent/internal/sessionbroker/spawner_windows.go
@@ -4,7 +4,6 @@ package sessionbroker
 
 import (
 	"fmt"
-	"os"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -14,9 +13,15 @@ import (
 // contains the PID and a duplicated process handle so callers can wait for
 // the process to exit and inspect its exit code. Close() must be called to
 // release the handle.
+//
+// BinaryPath records the executable the spawner actually launched so callers
+// can distinguish the GUI-subsystem sibling (breeze-user-helper.exe) from
+// the console-subsystem agent fallback when logging spawn outcomes — useful
+// when chasing reports of the logon console flash regression.
 type SpawnedHelper struct {
-	PID    uint32
-	Handle windows.Handle
+	PID        uint32
+	Handle     windows.Handle
+	BinaryPath string
 }
 
 // Close releases the duplicated process handle. Safe to call more than once.
@@ -97,10 +102,13 @@ func SpawnHelperInSession(sessionID uint32) (*SpawnedHelper, error) {
 		return nil, fmt.Errorf("SetTokenInformation(TokenSessionId=%d): %w", sessionID, err)
 	}
 
-	// 4. Build the command line: same binary, "user-helper" subcommand.
-	exePath, err := os.Executable()
+	// 4. Build the command line. We launch the GUI-subsystem sibling binary
+	// (breeze-user-helper.exe) so the kernel does not allocate a console
+	// window in the user session. Falls back to the agent exe if the sibling
+	// is missing — see userHelperExePath documentation.
+	exePath, err := userHelperExePath()
 	if err != nil {
-		return nil, fmt.Errorf("os.Executable: %w", err)
+		return nil, fmt.Errorf("userHelperExePath: %w", err)
 	}
 	cmdLine, err := windows.UTF16PtrFromString(buildUserHelperCmdLine(exePath, "system"))
 	if err != nil {
@@ -147,7 +155,7 @@ func SpawnHelperInSession(sessionID uint32) (*SpawnedHelper, error) {
 		"pid", pi.ProcessId,
 		"exe", exePath,
 	)
-	return &SpawnedHelper{PID: pi.ProcessId, Handle: pi.Process}, nil
+	return &SpawnedHelper{PID: pi.ProcessId, Handle: pi.Process, BinaryPath: exePath}, nil
 }
 
 // SpawnUserHelperInSession launches a user-helper process using the logged-in
@@ -169,10 +177,11 @@ func SpawnUserHelperInSession(sessionID uint32) (*SpawnedHelper, error) {
 		defer windows.DestroyEnvironmentBlock(envBlock)
 	}
 
-	// Build command line with --role user flag.
-	exePath, err := os.Executable()
+	// Build command line with --role user flag. Use the GUI-subsystem sibling
+	// binary so no console window flashes in the user session.
+	exePath, err := userHelperExePath()
 	if err != nil {
-		return nil, fmt.Errorf("os.Executable: %w", err)
+		return nil, fmt.Errorf("userHelperExePath: %w", err)
 	}
 	cmdLine, err := windows.UTF16PtrFromString(buildUserHelperCmdLine(exePath, "user"))
 	if err != nil {
@@ -215,5 +224,5 @@ func SpawnUserHelperInSession(sessionID uint32) (*SpawnedHelper, error) {
 		"exe", exePath,
 		"tokenSource", method,
 	)
-	return &SpawnedHelper{PID: pi.ProcessId, Handle: pi.Process}, nil
+	return &SpawnedHelper{PID: pi.ProcessId, Handle: pi.Process, BinaryPath: exePath}, nil
 }

--- a/agent/internal/sessionbroker/userhelper_path.go
+++ b/agent/internal/sessionbroker/userhelper_path.go
@@ -1,0 +1,56 @@
+package sessionbroker
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// UserHelperBinaryName is the on-disk filename of the GUI-subsystem user-helper
+// binary installed alongside the agent. Built from the same Go source as the
+// agent with `-H windowsgui` so the Windows kernel does not allocate a console
+// window when the scheduled task or SYSTEM-context spawn paths launch it in a
+// user session. The constant is declared in this platform-independent file so
+// resolveUserHelperPath is testable on every OS the agent builds on, even
+// though only Windows actually uses the helper binary at runtime.
+const UserHelperBinaryName = "breeze-user-helper.exe"
+
+// resolveUserHelperPath picks the right binary path for a user-helper spawn,
+// given the running agent's executable path. Pure function modulo the
+// filesystem — extracted so it can be tested without depending on Windows
+// build tags or os.Executable.
+//
+//   - sibling present → return sibling path
+//   - sibling missing with fs.ErrNotExist → log Warn + return agentExe (fallback)
+//   - any other stat error → wrap and return
+//
+// The fallback exists because some failure modes (failed build, AV
+// quarantine, partial MSI install) can leave the new scheduled task XML
+// pointing at the helper while the helper binary is missing. Returning
+// the agent path keeps run_as_user functionality alive at the cost of the
+// visible console-window flash at user logon that this whole change set
+// is meant to eliminate — so the fallback is a stop-gap, not a permanent
+// shape. Once fleet telemetry confirms that the MSI install path reliably
+// drops breeze-user-helper.exe alongside breeze-agent.exe on every
+// supported install vector (msiexec /i, /fa repair, in-place upgrade via
+// dev_update), the fs.ErrNotExist branch should be promoted to a hard
+// error so the regression surfaces loudly instead of degrading silently.
+// Without the fs.ErrNotExist branch any stat error would silently degrade —
+// the Warn provides ops telemetry for fleet-side detection in the meantime.
+func resolveUserHelperPath(agentExe string) (string, error) {
+	helper := filepath.Join(filepath.Dir(agentExe), UserHelperBinaryName)
+	_, statErr := os.Stat(helper)
+	if statErr == nil {
+		return helper, nil
+	}
+	if errors.Is(statErr, fs.ErrNotExist) {
+		log.Warn("breeze-user-helper.exe missing — falling back to agent binary; console window will flash at user logon until the install is repaired",
+			"expectedPath", helper,
+			"fallbackPath", agentExe,
+		)
+		return agentExe, nil
+	}
+	return "", fmt.Errorf("stat %s: %w", helper, statErr)
+}

--- a/agent/internal/sessionbroker/userhelper_path_other.go
+++ b/agent/internal/sessionbroker/userhelper_path_other.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package sessionbroker
+
+import "os"
+
+// userHelperExePath returns the running agent binary path on non-Windows
+// platforms. macOS and Linux launch the user-helper as a subcommand of the
+// agent binary (LaunchAgent / systemd user unit respectively), which does not
+// have the Windows console-window problem.
+func userHelperExePath() (string, error) {
+	return os.Executable()
+}

--- a/agent/internal/sessionbroker/userhelper_path_test.go
+++ b/agent/internal/sessionbroker/userhelper_path_test.go
@@ -1,0 +1,85 @@
+package sessionbroker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestResolveUserHelperPath_PicksGUIBinaryWhenAvailable verifies that when
+// breeze-user-helper.exe sits alongside the running agent binary,
+// resolveUserHelperPath returns the helper path (so spawn paths use the
+// GUI-subsystem sibling and avoid the console-window flash bug).
+//
+// This is the positive-path counterpart to the fallback test below. Together
+// they pin the two-binary contract that the AgentUserHelper scheduled task
+// XML and the SYSTEM-context broker spawn paths depend on.
+func TestResolveUserHelperPath_PicksGUIBinaryWhenAvailable(t *testing.T) {
+	tmpDir := t.TempDir()
+	agentExe := filepath.Join(tmpDir, "breeze-agent.exe")
+	helperExe := filepath.Join(tmpDir, UserHelperBinaryName)
+	if err := os.WriteFile(agentExe, []byte("agent stub"), 0o644); err != nil {
+		t.Fatalf("write agent stub: %v", err)
+	}
+	if err := os.WriteFile(helperExe, []byte("helper stub"), 0o644); err != nil {
+		t.Fatalf("write helper stub: %v", err)
+	}
+
+	got, err := resolveUserHelperPath(agentExe)
+	if err != nil {
+		t.Fatalf("resolveUserHelperPath returned unexpected error: %v", err)
+	}
+	if got != helperExe {
+		t.Fatalf("resolveUserHelperPath = %q, want %q (sibling helper)", got, helperExe)
+	}
+}
+
+// TestUserHelperExePath_FallsBackToAgentWhenSiblingMissing exercises the
+// fs.ErrNotExist branch of resolveUserHelperPath, which is the documented
+// defense-in-depth path for partially-upgraded installs where the new task
+// XML points at breeze-user-helper.exe but the binary itself is missing
+// (failed build, AV quarantine, tamper). The fallback returns the agent
+// path so run_as_user functionality keeps working at the cost of a visible
+// console window — and the log.Warn provides the ops telemetry without
+// which the silent fallback would reintroduce the bug this PR fixes.
+func TestUserHelperExePath_FallsBackToAgentWhenSiblingMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	agentExe := filepath.Join(tmpDir, "breeze-agent.exe")
+	if err := os.WriteFile(agentExe, []byte("agent stub"), 0o644); err != nil {
+		t.Fatalf("write agent stub: %v", err)
+	}
+	// Deliberately do NOT create the sibling breeze-user-helper.exe.
+
+	got, err := resolveUserHelperPath(agentExe)
+	if err != nil {
+		t.Fatalf("resolveUserHelperPath returned error on missing sibling, want nil + agent fallback: %v", err)
+	}
+	if got != agentExe {
+		t.Fatalf("resolveUserHelperPath fallback = %q, want %q (agent path)", got, agentExe)
+	}
+}
+
+// TestResolveUserHelperPath_PropagatesOtherStatErrors verifies that any
+// stat error other than fs.ErrNotExist (e.g. permission, I/O) is returned
+// to the caller so the spawn fails loud instead of silently downgrading.
+// Test simulates the "dir-instead-of-file" case via filename containing a
+// NUL byte, which os.Stat rejects with EINVAL on POSIX and ERROR_INVALID_NAME
+// on Windows. Skipped on filesystems where the synthetic invalid path
+// somehow succeeds — see error mapping note inline.
+func TestResolveUserHelperPath_PropagatesOtherStatErrors(t *testing.T) {
+	// Use a path with an embedded NUL byte to provoke an invalid-argument
+	// error from os.Stat. This is portable: every OS POSIX-syscalls go
+	// through chokes on NUL in pathnames, returning ENOENT/EINVAL/etc.,
+	// none of which are wrapped as fs.ErrNotExist.
+	agentExe := "/tmp/breeze-agent.exe\x00invalid"
+	_, err := resolveUserHelperPath(agentExe)
+	if err == nil {
+		t.Skip("filesystem unexpectedly accepted an invalid agent path; cannot exercise the error branch here")
+	}
+	// We only care that the function did NOT swallow this error as a
+	// fallback. The exact wrapping wording is intentionally not pinned.
+	if !strings.Contains(err.Error(), "stat") {
+		t.Fatalf("resolveUserHelperPath error does not mention stat: %v", err)
+	}
+}

--- a/agent/internal/sessionbroker/userhelper_path_windows.go
+++ b/agent/internal/sessionbroker/userhelper_path_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package sessionbroker
+
+import (
+	"fmt"
+	"os"
+)
+
+// userHelperExePath returns the path that the SYSTEM-context spawner should
+// use when launching a user-helper process. On Windows the convention is:
+//
+//   - C:\Program Files\Breeze\breeze-agent.exe   (this process, console subsystem)
+//   - C:\Program Files\Breeze\breeze-user-helper.exe (GUI subsystem, same source)
+//
+// Resolution logic lives in resolveUserHelperPath (userhelper_path.go) so the
+// fallback semantics are unit-testable on every platform the agent builds on,
+// not just Windows. This wrapper just supplies the agent's own executable
+// path and delegates.
+func userHelperExePath() (string, error) {
+	agentExe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("os.Executable: %w", err)
+	}
+	return resolveUserHelperPath(agentExe)
+}

--- a/agent/internal/updater/restart_windows.go
+++ b/agent/internal/updater/restart_windows.go
@@ -94,7 +94,7 @@ func RestartWithHelper(newBinaryPath, targetPath string) error {
 		"Stop-Service -Name '" + serviceName + "' -Force -ErrorAction SilentlyContinue",
 		// Kill any lingering breeze processes (helper, viewer, user helpers)
 		// that might hold file locks on the binary or shared directory.
-		"Get-Process -Name 'breeze-helper','breeze-agent','breeze-viewer' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue",
+		"Get-Process -Name 'breeze-helper','breeze-agent','breeze-user-helper','breeze-viewer' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue",
 		"Start-Sleep -Seconds 2",
 		fmt.Sprintf("Copy-Item -Path '%s' -Destination '%s' -Force", safeBinary, safeTarget),
 		"Start-Service -Name '" + serviceName + "'",

--- a/agent/scripts/install/install-windows.ps1
+++ b/agent/scripts/install/install-windows.ps1
@@ -4,19 +4,64 @@
     Install Breeze Agent user helper as a Windows Scheduled Task.
 .DESCRIPTION
     Registers the user helper scheduled task so it auto-starts for each user at login.
+
+    Failure diagnostics: when this script fails, the MSI rolls back with
+    "installer rolled back" and no actionable text in the default MSI log.
+    To preserve the cause, every error path writes a single-line timestamped
+    record to C:\ProgramData\Breeze\logs\user-helper-install-last-error.txt
+    (survives the rollback because CA-written files are opaque to MSI) and
+    emits an Event Viewer entry under Application/BreezeAgent. This mirrors
+    the enrollment CA's diagnostic trail.
 #>
 
 $ErrorActionPreference = "Stop"
 
 $BinaryPath = "C:\Program Files\Breeze\breeze-agent.exe"
+$UserHelperBinaryPath = "C:\Program Files\Breeze\breeze-user-helper.exe"
 $TaskXmlPath = Join-Path $PSScriptRoot "..\..\service\windows\breeze-agent-user-task.xml"
 $TaskName = "\Breeze\AgentUserHelper"
+$LogDir = "C:\ProgramData\Breeze\logs"
+$SentinelPath = Join-Path $LogDir "user-helper-install-last-error.txt"
+
+function Write-FailureDiagnostic {
+    param([string]$Message)
+    $ts = (Get-Date).ToUniversalTime().ToString("o")
+    $line = "$ts $Message"
+    # Sentinel file: best-effort. The MSI CA may be running before the logs
+    # directory exists, so create it first. Suppress write failures so a
+    # broken sentinel never masks the original error.
+    try {
+        if (-not (Test-Path $LogDir)) {
+            New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+        }
+        Set-Content -Path $SentinelPath -Value $line -Encoding UTF8 -Force -ErrorAction SilentlyContinue
+    } catch {
+        # Ignore — sentinel is auxiliary
+    }
+    # Event Viewer: register the BreezeAgent source on first use, then write.
+    try {
+        if (-not [System.Diagnostics.EventLog]::SourceExists("BreezeAgent")) {
+            New-EventLog -LogName Application -Source BreezeAgent -ErrorAction SilentlyContinue
+        }
+        Write-EventLog -LogName Application -Source BreezeAgent -EntryType Error -EventId 9001 -Message "user-helper task registration: $Message" -ErrorAction SilentlyContinue
+    } catch {
+        # Ignore — diagnostic is auxiliary
+    }
+    Write-Error $Message
+}
 
 Write-Host "Installing Breeze Agent User Helper..."
 
-# Verify binary exists
+# Verify binaries exist. breeze-agent.exe is the console-subsystem CLI binary
+# used by the SCM service. breeze-user-helper.exe is the GUI-subsystem sibling
+# that the scheduled task launches at user logon — same Go source, built with
+# -H windowsgui so no console window is allocated in the interactive session.
 if (-not (Test-Path $BinaryPath)) {
-    Write-Error "breeze-agent.exe not found at $BinaryPath. Install the agent first."
+    Write-FailureDiagnostic "breeze-agent.exe not found at $BinaryPath. Install the agent first."
+    exit 1
+}
+if (-not (Test-Path $UserHelperBinaryPath)) {
+    Write-FailureDiagnostic "breeze-user-helper.exe not found at $UserHelperBinaryPath. Install the agent first."
     exit 1
 }
 
@@ -25,16 +70,22 @@ if (-not (Test-Path $TaskXmlPath)) {
     $TaskXmlPath = Join-Path $PSScriptRoot "..\..\service\windows\breeze-agent-user-task.xml"
 }
 if (-not (Test-Path $TaskXmlPath)) {
-    Write-Error "Task XML template not found"
+    Write-FailureDiagnostic "Task XML template not found at $TaskXmlPath."
     exit 1
 }
 
-# Register scheduled task
+# Register scheduled task. Register-ScheduledTask -Force is idempotent —
+# safe to invoke on first install, major upgrade, and msiexec /fa repair.
 try {
-    Register-ScheduledTask -Xml (Get-Content $TaskXmlPath -Raw) -TaskName "AgentUserHelper" -TaskPath "\Breeze\" -Force
+    Register-ScheduledTask -Xml (Get-Content $TaskXmlPath -Raw) -TaskName "AgentUserHelper" -TaskPath "\Breeze\" -Force | Out-Null
     Write-Host "  Scheduled task registered: $TaskName"
+    # Clear the sentinel from any prior failed install so support staff can
+    # tell a fresh failure from a stale record.
+    if (Test-Path $SentinelPath) {
+        Remove-Item -Path $SentinelPath -Force -ErrorAction SilentlyContinue
+    }
 } catch {
-    Write-Error "Failed to register scheduled task: $_"
+    Write-FailureDiagnostic "Failed to register scheduled task: $_"
     exit 1
 }
 

--- a/agent/service/windows/breeze-agent-user-task.xml
+++ b/agent/service/windows/breeze-agent-user-task.xml
@@ -36,7 +36,7 @@
   </Settings>
   <Actions Context="Author">
     <Exec>
-      <Command>"C:\Program Files\Breeze\breeze-agent.exe"</Command>
+      <Command>"C:\Program Files\Breeze\breeze-user-helper.exe"</Command>
       <Arguments>user-helper --role user</Arguments>
     </Exec>
   </Actions>


### PR DESCRIPTION
## Why

When the `AgentUserHelper` scheduled task fires at user logon, a visible console window appears in the interactive session showing the user-helper log lines. Sometimes attached to the foreground for several seconds, sometimes minimized to the taskbar — always visible to end users, which is alarming and unprofessional.

Root cause: `agent/Makefile`'s `build-windows` produces `breeze-agent.exe` as a **CONSOLE-subsystem PE** (subsystem byte 3, `IMAGE_SUBSYSTEM_WINDOWS_CUI`). When Task Scheduler launches a console-subsystem binary in an interactive user session, the Windows kernel **always** allocates a console window. `<Hidden>true</Hidden>` in the task XML only hides the task from Task Scheduler UI, not the process's console. PowerShell `-WindowStyle Hidden` only hides PS's own window — console-subsystem children still get their own console treatment.

The only kernel-level fix is to build the user-helper binary as a **GUI-subsystem PE** (subsystem byte 2, `IMAGE_SUBSYSTEM_WINDOWS_GUI`). For GUI subsystem the kernel allocates no console at all — zero window, zero flicker, no taskbar entry, no race.

## What

Ship a second binary `breeze-user-helper.exe` built from the **same Go source** (`./cmd/breeze-agent`) with `-ldflags "-H windowsgui"`. The console-subsystem `breeze-agent.exe` is retained for CLI use (`breeze-agent enroll`, `service install`, etc.). Two binaries share the entire Go program — only the linker flag differs. Same pattern Tailscale's tray helper and many Windows service-style Go programs use.

Highlights:

- **`agent/Makefile`**: new `build-windows-user-helper` target with `-H windowsgui`, wired into `build-windows`.
- **`.github/workflows/ci.yml`**: Windows-only "Build user-helper" matrix step + separate artifact upload.
- **`.github/workflows/release.yml`**: build, sign (stable + prerelease profiles), pass through to `build-msi.ps1`.
- **`agent/installer/breeze.wxs`**: new `cmpBreezeUserHelperExe` component, added to MainFeature, added to the KillBreezeProcesses taskkill IM list.
- **`agent/installer/build-msi.ps1`**: new `-UserHelperExePath` parameter (existence check + wix arg pass-through).
- **`agent/service/windows/breeze-agent-user-task.xml`**: `<Command>` now points to `breeze-user-helper.exe`. The existing `RegisterUserHelperTask` MSI custom action re-registers on every install/upgrade with `Register-ScheduledTask -Force`, so legacy installs migrate automatically on the next MSI upgrade.
- **`agent/scripts/install/install-windows.ps1`**: verifies both binaries present before registering the task.
- **`agent/internal/sessionbroker/userhelper_path_windows.go`** (new): derives helper exe path as a sibling of `os.Executable()`. Falls back to the agent path if the sibling is missing (defense-in-depth for partial installs).
- **`agent/internal/sessionbroker/spawner_windows.go`**: both `SpawnHelperInSession` (SYSTEM-context) and `SpawnUserHelperInSession` (user-token) use `userHelperExePath()`, so the SYSTEM-spawn path also benefits.
- **`agent/internal/sessionbroker/broker.go`**: added `breeze-user-helper.exe` to the per-process binary path allowlist so the IPC handshake accepts the new helper.
- **`agent/internal/updater/restart_windows.go`**: added `breeze-user-helper` to the post-update Get-Process/Stop-Process name list.
- **`agent/internal/heartbeat/handlers_devupdate.go`**: new `devUpdateComponentUserHelper = "user-helper"` switch case and `handleDevUpdateUserHelper` function. Modeled on `handleDevUpdateDesktopHelper` — downloads, verifies, backs up, swaps the binary, then calls `RefreshAllowedHashes()` so the broker accepts the new helper on next logon.
- **`agent/cmd/breeze-agent/main.go` + `helper_console_{windows,other}.go`** (new): defense-in-depth `FreeConsole()` at the top of `runHelperProcess`. For the GUI-subsystem helper this is a no-op (no console was ever allocated). The value covers the case where the legacy console-subsystem `breeze-agent.exe` is invoked with the `user-helper` subcommand (manual CLI, or partial-upgrade transient state): FreeConsole collapses the inherited console within milliseconds.
- **`agent/cmd/breeze-agent/subsystem_test.go`** (new): cross-compiles `./cmd/breeze-agent` with `-H windowsgui`, reads the PE subsystem byte from the resulting binary, and asserts it equals 2. Regression guard for the Makefile + CI workflow.

No source-tree duplication: there is no new `agent/cmd/breeze-user-helper/main.go`. Both binaries are built from the same `./cmd/breeze-agent` package, only the linker flag and output name differ.

## Test plan

- [ ] `cd agent && CGO_ENABLED=0 go test ./...` passes (verified locally — sessionbroker + heartbeat + cmd/breeze-agent all green)
- [ ] `cd agent && go vet ./...` clean (verified locally)
- [ ] `GOOS=windows GOARCH=amd64 go build -ldflags "-H windowsgui" -o /tmp/user-helper.exe ./cmd/breeze-agent`; PE subsystem byte == 2 (verified locally via the new TestUserHelperBinaryHasGUISubsystem)
- [ ] `GOOS=windows GOARCH=amd64 go build -o /tmp/agent.exe ./cmd/breeze-agent`; PE subsystem byte == 3 (CLI mode preserved — verified locally)
- [ ] Clean install on a Windows VM via the new MSI: both exes present, scheduled task points at user-helper.exe, no console window at logon
- [ ] Upgrade from current-main MSI: existing scheduled task gets re-registered, running breeze-agent.exe in user session gets taskkilled before the new install
- [ ] Run `breeze-agent.exe user-helper --role user` manually from cmd: helper starts, FreeConsole closes the console within ms (the defense-in-depth path)
- [ ] macOS + Linux: no behavioural change (the non-Windows stubs return early), existing user-helper LaunchAgent / systemd user unit unaffected

## Verified empirically

Same fix tested on two Windows 11 endpoints over the last hour:
- Scheduled-task logon path: zero flash (verified after a real reboot)
- SYSTEM-context broker spawn path: would also use the GUI binary via the updated `spawner_windows.go`

Single binary remained an option (build `breeze-agent.exe` as GUI and call `AllocConsole()` when a CLI subcommand is detected), but adds non-trivial behaviour for `breeze-agent enroll` and friends. Two binaries is what every comparable Go project I checked does (Tailscale's `tailscaled` / `tailscale-ipn`). Happy to go single-binary if you'd prefer — let me know.