### PR TITLE
feat: Wake-on-LAN — relay-aware dispatch, audit trail, agent magic-packet handler

### DIFF
--- a/agent/internal/heartbeat/handlers.go
+++ b/agent/internal/heartbeat/handlers.go
@@ -54,6 +54,7 @@ var handlerRegistry = map[string]CommandHandler{
 	tools.CmdShutdown:       handleShutdown,
 	tools.CmdLock:           handleLock,
 	tools.CmdRebootSafeMode: handleRebootSafeMode,
+	tools.CmdWakeOnLan:      handleWakeOnLan,
 
 	// Software inventory
 	tools.CmdCollectSoftware:   handleCollectSoftware,
@@ -223,6 +224,10 @@ func handleShutdown(_ *Heartbeat, cmd Command) tools.CommandResult {
 
 func handleLock(_ *Heartbeat, cmd Command) tools.CommandResult {
 	return tools.Lock(cmd.Payload)
+}
+
+func handleWakeOnLan(_ *Heartbeat, cmd Command) tools.CommandResult {
+	return tools.WakeOnLan(cmd.Payload)
 }
 
 func handleRebootSafeMode(h *Heartbeat, cmd Command) tools.CommandResult {

--- a/agent/internal/heartbeat/handlers_test.go
+++ b/agent/internal/heartbeat/handlers_test.go
@@ -21,7 +21,7 @@ var allCommandTypes = []string{
 	tools.CmdRegistryKeys, tools.CmdRegistryValues, tools.CmdRegistryGet,
 	tools.CmdRegistrySet, tools.CmdRegistryDelete,
 	tools.CmdRegistryKeyCreate, tools.CmdRegistryKeyDelete,
-	tools.CmdReboot, tools.CmdShutdown, tools.CmdLock, tools.CmdRebootSafeMode,
+	tools.CmdReboot, tools.CmdShutdown, tools.CmdLock, tools.CmdRebootSafeMode, tools.CmdWakeOnLan,
 	tools.CmdCollectSoftware, tools.CmdSoftwareUninstall, tools.CmdSoftwareInstall,
 	tools.CmdCollectBootPerformance, tools.CmdManageStartupItem,
 	tools.CmdCollectReliabilityMetrics,

--- a/agent/internal/remote/tools/types.go
+++ b/agent/internal/remote/tools/types.go
@@ -47,6 +47,7 @@ const (
 	CmdShutdown       = "shutdown"
 	CmdLock           = "lock"
 	CmdRebootSafeMode = "reboot_safe_mode"
+	CmdWakeOnLan      = "wake_on_lan"
 
 	// Software inventory
 	CmdCollectSoftware   = "collect_software"

--- a/agent/internal/remote/tools/wake_on_lan.go
+++ b/agent/internal/remote/tools/wake_on_lan.go
@@ -1,0 +1,222 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+const (
+	wolMagicPacketLen = 102
+	wolPacketRounds   = 3
+	wolPacketGap      = 500 * time.Millisecond
+)
+
+// MagicPacket returns the 102-byte Wake-on-LAN magic packet for the given MAC:
+// six 0xFF bytes followed by sixteen back-to-back copies of the MAC.
+func MagicPacket(mac net.HardwareAddr) ([]byte, error) {
+	if len(mac) != 6 {
+		return nil, fmt.Errorf("MAC must be 6 bytes, got %d", len(mac))
+	}
+	pkt := make([]byte, wolMagicPacketLen)
+	for i := 0; i < 6; i++ {
+		pkt[i] = 0xFF
+	}
+	for i := 0; i < 16; i++ {
+		copy(pkt[6+i*6:6+(i+1)*6], mac)
+	}
+	return pkt, nil
+}
+
+// parseMAC accepts the common formats: aa:bb:cc:dd:ee:ff, aa-bb-cc-dd-ee-ff,
+// AABB.CCDD.EEFF. Returns the canonical net.HardwareAddr.
+func parseMAC(s string) (net.HardwareAddr, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, errors.New("empty MAC")
+	}
+	mac, err := net.ParseMAC(s)
+	if err != nil {
+		return nil, fmt.Errorf("invalid MAC %q: %w", s, err)
+	}
+	if len(mac) != 6 {
+		return nil, fmt.Errorf("MAC %q is not 6 bytes (got %d) — EUI-64 not supported", s, len(mac))
+	}
+	return mac, nil
+}
+
+// sendMagicPacket fires one magic-packet UDP write to broadcast:port.
+// Directed subnet broadcast (computed from target's IP + mask, e.g.
+// 192.168.1.255) is accepted by the kernel without SO_BROADCAST on Linux,
+// macOS, and Windows. If a future field test shows otherwise, add a
+// platform-split helper for SO_BROADCAST.
+func sendMagicPacket(pkt []byte, broadcast net.IP, port int) error {
+	conn, err := net.DialUDP("udp4", nil, &net.UDPAddr{IP: broadcast, Port: port})
+	if err != nil {
+		return fmt.Errorf("dial udp4 %s:%d: %w", broadcast, port, err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Write(pkt); err != nil {
+		return fmt.Errorf("write udp4 %s:%d: %w", broadcast, port, err)
+	}
+	return nil
+}
+
+func stringField(payload map[string]any, key string) (string, bool) {
+	if payload == nil {
+		return "", false
+	}
+	v, ok := payload[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+func stringSliceField(payload map[string]any, key string) []string {
+	if payload == nil {
+		return nil
+	}
+	raw, ok := payload[key]
+	if !ok {
+		return nil
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(arr))
+	for _, item := range arr {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func intSliceField(payload map[string]any, key string, defaults []int) []int {
+	if payload == nil {
+		return defaults
+	}
+	raw, ok := payload[key]
+	if !ok {
+		return defaults
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		return defaults
+	}
+	out := make([]int, 0, len(arr))
+	for _, item := range arr {
+		switch n := item.(type) {
+		case float64:
+			out = append(out, int(n))
+		case int:
+			out = append(out, n)
+		case int64:
+			out = append(out, int(n))
+		}
+	}
+	if len(out) == 0 {
+		return defaults
+	}
+	return out
+}
+
+// WakeOnLan sends magic packets to broadcast for each provided MAC across the
+// requested UDP ports, repeating in 3 rounds spaced 500 ms apart. The command
+// is considered successful if at least one packet was written without error.
+func WakeOnLan(payload map[string]any) CommandResult {
+	start := time.Now()
+
+	broadcastStr, ok := stringField(payload, "broadcast")
+	if !ok || broadcastStr == "" {
+		return NewErrorResult(errors.New("payload.broadcast is required"), time.Since(start).Milliseconds())
+	}
+	broadcast := net.ParseIP(broadcastStr).To4()
+	if broadcast == nil {
+		return NewErrorResult(fmt.Errorf("payload.broadcast %q is not a valid IPv4 address", broadcastStr), time.Since(start).Milliseconds())
+	}
+
+	macStrings := stringSliceField(payload, "macs")
+	if len(macStrings) == 0 {
+		return NewErrorResult(errors.New("payload.macs must contain at least one MAC address"), time.Since(start).Milliseconds())
+	}
+	macs := make([]net.HardwareAddr, 0, len(macStrings))
+	for _, s := range macStrings {
+		mac, err := parseMAC(s)
+		if err != nil {
+			return NewErrorResult(err, time.Since(start).Milliseconds())
+		}
+		macs = append(macs, mac)
+	}
+
+	ports := intSliceField(payload, "ports", []int{7, 9})
+	for _, p := range ports {
+		if p < 1 || p > 65535 {
+			return NewErrorResult(fmt.Errorf("invalid UDP port %d in payload.ports", p), time.Since(start).Milliseconds())
+		}
+	}
+
+	type sendErr struct {
+		mac  string
+		port int
+		err  string
+	}
+	var errs []sendErr
+	sentOK := 0
+	totalWrites := wolPacketRounds * len(macs) * len(ports)
+
+	for round := 0; round < wolPacketRounds; round++ {
+		for _, mac := range macs {
+			pkt, err := MagicPacket(mac)
+			if err != nil {
+				errs = append(errs, sendErr{mac: mac.String(), err: err.Error()})
+				continue
+			}
+			for _, port := range ports {
+				if err := sendMagicPacket(pkt, broadcast, port); err != nil {
+					errs = append(errs, sendErr{mac: mac.String(), port: port, err: err.Error()})
+					continue
+				}
+				sentOK++
+			}
+		}
+		if round < wolPacketRounds-1 {
+			time.Sleep(wolPacketGap)
+		}
+	}
+
+	wakeAttemptId, _ := stringField(payload, "wakeAttemptId")
+	targetDeviceId, _ := stringField(payload, "targetDeviceId")
+
+	if sentOK == 0 {
+		err := errors.New("no magic packets could be sent")
+		if len(errs) > 0 {
+			err = fmt.Errorf("no magic packets could be sent; first failure: %s", errs[0].err)
+		}
+		return NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+
+	result := map[string]any{
+		"wakeAttemptId":  wakeAttemptId,
+		"targetDeviceId": targetDeviceId,
+		"broadcast":      broadcast.String(),
+		"ports":          ports,
+		"macsAttempted":  macStrings,
+		"packetsSent":    sentOK,
+		"packetsTotal":   totalWrites,
+	}
+	if len(errs) > 0 {
+		details := make([]map[string]any, 0, len(errs))
+		for _, e := range errs {
+			details = append(details, map[string]any{"mac": e.mac, "port": e.port, "error": e.err})
+		}
+		result["sendErrors"] = details
+	}
+	return NewSuccessResult(result, time.Since(start).Milliseconds())
+}

--- a/agent/internal/remote/tools/wake_on_lan_test.go
+++ b/agent/internal/remote/tools/wake_on_lan_test.go
@@ -1,0 +1,193 @@
+package tools
+
+import (
+	"bytes"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestMagicPacket_Length(t *testing.T) {
+	mac, err := net.ParseMAC("aa:bb:cc:dd:ee:ff")
+	if err != nil {
+		t.Fatalf("ParseMAC: %v", err)
+	}
+	pkt, err := MagicPacket(mac)
+	if err != nil {
+		t.Fatalf("MagicPacket: %v", err)
+	}
+	if len(pkt) != 102 {
+		t.Fatalf("expected 102-byte packet, got %d", len(pkt))
+	}
+}
+
+func TestMagicPacket_Layout(t *testing.T) {
+	mac, _ := net.ParseMAC("aa:bb:cc:dd:ee:ff")
+	pkt, err := MagicPacket(mac)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantHeader := []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}
+	if !bytes.Equal(pkt[:6], wantHeader) {
+		t.Errorf("first 6 bytes: got %x, want %x", pkt[:6], wantHeader)
+	}
+
+	for i := 0; i < 16; i++ {
+		offset := 6 + i*6
+		got := pkt[offset : offset+6]
+		if !bytes.Equal(got, mac) {
+			t.Errorf("repetition #%d at offset %d: got %x, want %x", i, offset, got, mac)
+		}
+	}
+}
+
+func TestMagicPacket_WrongLength(t *testing.T) {
+	tooShort := net.HardwareAddr{0xaa, 0xbb}
+	if _, err := MagicPacket(tooShort); err == nil {
+		t.Error("expected error for 2-byte MAC, got nil")
+	}
+	eui64 := net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11}
+	if _, err := MagicPacket(eui64); err == nil {
+		t.Error("expected error for 8-byte EUI-64, got nil")
+	}
+}
+
+func TestParseMAC_Formats(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"colon", "aa:bb:cc:dd:ee:ff", "aa:bb:cc:dd:ee:ff"},
+		{"hyphen", "AA-BB-CC-DD-EE-FF", "aa:bb:cc:dd:ee:ff"},
+		{"cisco-dot", "AABB.CCDD.EEFF", "aa:bb:cc:dd:ee:ff"},
+		{"with-spaces", "  aa:bb:cc:dd:ee:ff  ", "aa:bb:cc:dd:ee:ff"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := parseMAC(c.in)
+			if err != nil {
+				t.Fatalf("parseMAC(%q): %v", c.in, err)
+			}
+			if got.String() != c.want {
+				t.Errorf("parseMAC(%q) = %q, want %q", c.in, got.String(), c.want)
+			}
+		})
+	}
+}
+
+func TestParseMAC_Invalid(t *testing.T) {
+	cases := []string{
+		"",
+		"not-a-mac",
+		"aa:bb:cc:dd:ee",                // 5 octets
+		"00:11:22:33:44:55:66:77",       // EUI-64
+		"zz:bb:cc:dd:ee:ff",             // invalid hex
+	}
+	for _, c := range cases {
+		if _, err := parseMAC(c); err == nil {
+			t.Errorf("parseMAC(%q) succeeded, expected error", c)
+		}
+	}
+}
+
+func TestWakeOnLan_RequiresBroadcast(t *testing.T) {
+	r := WakeOnLan(map[string]any{
+		"macs": []any{"aa:bb:cc:dd:ee:ff"},
+	})
+	if r.Status != "failed" {
+		t.Errorf("missing broadcast should fail, got %q", r.Status)
+	}
+}
+
+func TestWakeOnLan_RejectsIPv6Broadcast(t *testing.T) {
+	r := WakeOnLan(map[string]any{
+		"broadcast": "fe80::1",
+		"macs":      []any{"aa:bb:cc:dd:ee:ff"},
+	})
+	if r.Status != "failed" {
+		t.Errorf("IPv6 broadcast should fail, got %q", r.Status)
+	}
+}
+
+func TestWakeOnLan_RequiresMacs(t *testing.T) {
+	r := WakeOnLan(map[string]any{
+		"broadcast": "192.168.1.255",
+		"macs":      []any{},
+	})
+	if r.Status != "failed" {
+		t.Errorf("empty macs should fail, got %q", r.Status)
+	}
+}
+
+func TestWakeOnLan_RejectsInvalidMac(t *testing.T) {
+	r := WakeOnLan(map[string]any{
+		"broadcast": "192.168.1.255",
+		"macs":      []any{"not-a-mac"},
+	})
+	if r.Status != "failed" {
+		t.Errorf("invalid MAC should fail, got %q", r.Status)
+	}
+}
+
+func TestWakeOnLan_RejectsInvalidPort(t *testing.T) {
+	r := WakeOnLan(map[string]any{
+		"broadcast": "192.168.1.255",
+		"macs":      []any{"aa:bb:cc:dd:ee:ff"},
+		"ports":     []any{float64(70000)},
+	})
+	if r.Status != "failed" {
+		t.Errorf("out-of-range port should fail, got %q", r.Status)
+	}
+}
+
+// TestWakeOnLan_Loopback exercises the full send path against a UDP listener
+// on loopback. Sending to 127.0.0.1 verifies the packet bytes traverse the
+// UDP socket correctly; the kernel doesn't care that this isn't a real
+// broadcast destination for the test.
+func TestWakeOnLan_Loopback(t *testing.T) {
+	// Listen on 127.0.0.1:0 on a single port so each round/port write hits a
+	// known target. We only verify at least one packet arrives — the function
+	// fans out across ports 7 & 9 by default; we override to a single port we
+	// can bind.
+	listener, err := net.ListenPacket("udp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("ListenPacket: %v", err)
+	}
+	defer listener.Close()
+	port := listener.LocalAddr().(*net.UDPAddr).Port
+
+	result := WakeOnLan(map[string]any{
+		"broadcast":     "127.0.0.1",
+		"macs":          []any{"aa:bb:cc:dd:ee:ff"},
+		"ports":         []any{float64(port)},
+		"wakeAttemptId": "test-attempt",
+	})
+
+	if result.Status != "completed" {
+		t.Fatalf("WakeOnLan status = %q, want completed; stderr=%q error=%q", result.Status, result.Stderr, result.Error)
+	}
+
+	// Expect at least one packet to have arrived; drain whatever is queued.
+	buf := make([]byte, 200)
+	for i := 0; i < wolPacketRounds; i++ {
+		if err := listener.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+			t.Fatalf("SetReadDeadline: %v", err)
+		}
+		n, _, err := listener.ReadFrom(buf)
+		if err != nil {
+			if i == 0 {
+				t.Fatalf("no magic packet received: %v", err)
+			}
+			return // first packet sufficient
+		}
+		if n != wolMagicPacketLen {
+			t.Errorf("received %d bytes, want %d", n, wolMagicPacketLen)
+		}
+		want := []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}
+		if !bytes.Equal(buf[:6], want) {
+			t.Errorf("packet header = %x, want %x", buf[:6], want)
+		}
+	}
+}

--- a/apps/api/src/routes/devices/commands.test.ts
+++ b/apps/api/src/routes/devices/commands.test.ts
@@ -12,17 +12,18 @@ vi.mock('../../db', () => ({
   }
 }));
 
-vi.mock('../../db/schema', () => ({
-  deviceCommands: {
-    id: 'id',
-    deviceId: 'deviceId',
-    type: 'type',
-    payload: 'payload',
-    result: 'result',
-    createdAt: 'createdAt'
-  },
-  devices: { id: 'id' }
-}));
+// Wake-on-LAN brings a long transitive import chain through the API surface
+// (commands.ts -> wakeOnLan.ts -> agentWs.ts -> remoteAccessPolicy.ts ->
+// configurationPolicy.ts -> the full config-policy schema set; and
+// agentWs.ts -> discoveryWorker.ts -> networkBaseline.ts -> the enum surface).
+// Stubbing every table by name turns into a moving target — partial-mock via
+// importOriginal so the real schema satisfies the transitive imports, while
+// the assertions in this file continue to use the in-test mock infrastructure
+// that doesn't read these tables at all.
+vi.mock('../../db/schema', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../db/schema')>();
+  return { ...actual };
+});
 
 vi.mock('../../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => {

--- a/apps/api/src/routes/devices/commands.ts
+++ b/apps/api/src/routes/devices/commands.ts
@@ -10,6 +10,8 @@ import { getPagination, getDeviceWithOrgCheck } from './helpers';
 import { createCommandSchema, bulkCommandSchema, maintenanceModeSchema } from './schemas';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { commandAuditDetails, sanitizeCommandForHistory } from '../../services/commandAudit';
+import { dispatchWake } from '../../services/wakeOnLan';
+import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
 
 export const commandsRoutes = new Hono();
 
@@ -120,6 +122,29 @@ commandsRoutes.post(
     // Don't allow commands to decommissioned devices
     if (device.status === 'decommissioned') {
       return c.json({ error: 'Cannot send commands to a decommissioned device' }, 400);
+    }
+
+    // Wake-on-LAN takes a separate path: the command row must be addressed to
+    // an online relay agent on the target's LAN, not the offline target.
+    if (data.type === 'wake') {
+      const wake = await dispatchWake(deviceId, auth.user.id, {
+        ipAddress: getTrustedClientIpOrUndefined(c),
+        userAgent: c.req.header('user-agent'),
+      });
+      if (!wake.ok) {
+        return c.json({ error: wake.message, code: wake.code }, 412);
+      }
+      return c.json({
+        id: wake.commandId,
+        deviceId,
+        type: 'wake_on_lan',
+        status: 'sent',
+        wakeAttemptId: wake.wakeAttemptId,
+        relay: { deviceId: wake.relayDeviceId, hostname: wake.relayHostname },
+        network: wake.network,
+        broadcast: wake.broadcast,
+        macs: wake.macs,
+      }, 202);
     }
 
     const [command] = await db

--- a/apps/api/src/routes/devices/schemas.ts
+++ b/apps/api/src/routes/devices/schemas.ts
@@ -41,7 +41,10 @@ export const softwareQuerySchema = z.object({
 });
 
 export const createCommandSchema = z.object({
-  type: z.enum(['script', 'reboot', 'reboot_safe_mode', 'shutdown', 'update', 'collect_evidence', 'execute_containment']),
+  // 'wake' is the user-facing wake action. Internally it dispatches via the
+  // wakeOnLan service and writes a deviceCommands row of type 'wake_on_lan'
+  // addressed to a relay agent. See apps/api/src/services/wakeOnLan.ts.
+  type: z.enum(['script', 'reboot', 'reboot_safe_mode', 'shutdown', 'update', 'collect_evidence', 'execute_containment', 'wake']),
   payload: z.any().optional()
 });
 

--- a/apps/api/src/routes/mobile.test.ts
+++ b/apps/api/src/routes/mobile.test.ts
@@ -19,19 +19,18 @@ vi.mock('../db', () => ({
   withSystemDbAccessContext: vi.fn(async (fn: () => any) => fn())
 }));
 
-vi.mock('../db/schema', () => ({
-  aiSessions: {},
-  alerts: {},
-  alertRules: {},
-  alertTemplates: {},
-  deviceCommands: {},
-  devices: {},
-  mobileDevices: {},
-  organizations: {},
-  scriptExecutions: {},
-  scripts: {},
-  sites: {}
-}));
+// Wake-on-LAN brings a long transitive import chain through the API surface
+// (mobile.ts -> wakeOnLan.ts -> agentWs.ts -> remoteAccessPolicy.ts ->
+// configurationPolicy.ts -> the full config-policy schema set; and
+// agentWs.ts -> discoveryWorker.ts -> networkBaseline.ts -> the enum surface).
+// Stubbing every table by name turns into a moving target — partial-mock via
+// importOriginal so the real schema satisfies the transitive imports, while
+// the assertions in this file continue to use the in-test mock infrastructure
+// that doesn't read these tables at all.
+vi.mock('../db/schema', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db/schema')>();
+  return { ...actual };
+});
 
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => {

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -22,6 +22,8 @@ import { setCooldown, markConfigPolicyRuleCooldown } from '../services/alertCool
 import { writeRouteAudit } from '../services/auditEvents';
 import { publishEvent } from '../services/eventBus';
 import { PERMISSIONS } from '../services/permissions';
+import { dispatchWake } from '../services/wakeOnLan';
+import { getTrustedClientIpOrUndefined } from '../services/clientIp';
 
 export const mobileRoutes = new Hono();
 const requireMobileAlertRead = requirePermission(PERMISSIONS.ALERTS_READ.resource, PERMISSIONS.ALERTS_READ.action);
@@ -875,6 +877,28 @@ mobileRoutes.post(
         executionId: execution.id,
         commandId: command.id
       }, 201);
+    }
+
+    // Wake-on-LAN: dispatch via the relay-aware service. Audit row is written
+    // by the service against the target device; no route-level audit here to
+    // avoid duplication.
+    if (data.action === 'wake') {
+      const wake = await dispatchWake(device.id, auth.user.id, {
+        ipAddress: getTrustedClientIpOrUndefined(c),
+        userAgent: c.req.header('user-agent'),
+      });
+      if (!wake.ok) {
+        return c.json({ error: wake.message, code: wake.code }, 412);
+      }
+      return c.json({
+        action: 'wake',
+        commandId: wake.commandId,
+        wakeAttemptId: wake.wakeAttemptId,
+        relay: { deviceId: wake.relayDeviceId, hostname: wake.relayHostname },
+        network: wake.network,
+        broadcast: wake.broadcast,
+        macs: wake.macs,
+      }, 202);
     }
 
     const cmdResult = await db

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -126,6 +126,8 @@ export const CommandTypes = {
 
   // Safe mode reboot (Windows only)
   REBOOT_SAFE_MODE: 'reboot_safe_mode',
+  // Wake-on-LAN — sent to a relay agent on the target's LAN, not the offline target itself
+  WAKE_ON_LAN: 'wake_on_lan',
   // Self-uninstall (remote wipe)
   SELF_UNINSTALL: 'self_uninstall',
   // Backup
@@ -258,6 +260,10 @@ const AUDITED_COMMANDS: Set<string> = new Set([
   CommandTypes.PERIPHERAL_POLICY_SYNC,
   // Safe mode reboot
   CommandTypes.REBOOT_SAFE_MODE,
+  // (Wake-on-LAN audit is written by the wakeOnLan service against the target device,
+  // not by the auto-audit path. The deviceCommands row is addressed to the relay agent
+  // so the result handler in agentWs matches, but the user-visible action belongs to
+  // the target. See apps/api/src/services/wakeOnLan.ts.)
   // Self-uninstall (remote wipe)
   CommandTypes.SELF_UNINSTALL,
   CommandTypes.BACKUP_RUN,

--- a/apps/api/src/services/wakeOnLan.test.ts
+++ b/apps/api/src/services/wakeOnLan.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { computeBroadcast, intToIpv4, ipv4ToInt } from './wakeOnLan';
+
+describe('ipv4ToInt', () => {
+  it('converts dotted-quad to 32-bit int', () => {
+    expect(ipv4ToInt('0.0.0.0')).toBe(0);
+    expect(ipv4ToInt('255.255.255.255')).toBe(0xffffffff);
+    expect(ipv4ToInt('192.168.1.42')).toBe(0xc0a8012a);
+    expect(ipv4ToInt('10.0.0.1')).toBe(0x0a000001);
+  });
+
+  it('rejects malformed input', () => {
+    expect(ipv4ToInt('192.168.1')).toBeNull();
+    expect(ipv4ToInt('192.168.1.256')).toBeNull();
+    expect(ipv4ToInt('192.168.1.-1')).toBeNull();
+    expect(ipv4ToInt('not-an-ip')).toBeNull();
+    expect(ipv4ToInt('192.168.1.42.5')).toBeNull();
+    expect(ipv4ToInt('::1')).toBeNull();
+  });
+});
+
+describe('intToIpv4', () => {
+  it('round-trips with ipv4ToInt', () => {
+    const samples = ['0.0.0.0', '255.255.255.255', '192.168.1.42', '10.0.0.1'];
+    for (const ip of samples) {
+      const n = ipv4ToInt(ip);
+      expect(n).not.toBeNull();
+      expect(intToIpv4(n!)).toBe(ip);
+    }
+  });
+});
+
+describe('computeBroadcast', () => {
+  it('computes /24', () => {
+    expect(computeBroadcast('192.168.1.42', '255.255.255.0')).toEqual({
+      network: '192.168.1.0',
+      broadcast: '192.168.1.255',
+    });
+  });
+
+  it('computes /16', () => {
+    expect(computeBroadcast('10.5.7.42', '255.255.0.0')).toEqual({
+      network: '10.5.0.0',
+      broadcast: '10.5.255.255',
+    });
+  });
+
+  it('computes /23', () => {
+    expect(computeBroadcast('192.168.0.42', '255.255.254.0')).toEqual({
+      network: '192.168.0.0',
+      broadcast: '192.168.1.255',
+    });
+  });
+
+  it('computes /32 (host route)', () => {
+    expect(computeBroadcast('192.168.1.42', '255.255.255.255')).toEqual({
+      network: '192.168.1.42',
+      broadcast: '192.168.1.42',
+    });
+  });
+
+  it('computes /8', () => {
+    expect(computeBroadcast('10.5.7.42', '255.0.0.0')).toEqual({
+      network: '10.0.0.0',
+      broadcast: '10.255.255.255',
+    });
+  });
+
+  it('returns null when ip or mask is invalid', () => {
+    expect(computeBroadcast('not-an-ip', '255.255.255.0')).toBeNull();
+    expect(computeBroadcast('192.168.1.42', 'not-a-mask')).toBeNull();
+    expect(computeBroadcast('192.168.1.42', '')).toBeNull();
+  });
+
+  it('handles a non-contiguous mask (network is still ip & mask)', () => {
+    // Real networks never use this, but the function should still produce
+    // a deterministic result rather than crashing.
+    const out = computeBroadcast('192.168.1.42', '255.0.255.0');
+    expect(out).not.toBeNull();
+    expect(out!.network).toBe('192.0.1.0');
+  });
+});

--- a/apps/api/src/services/wakeOnLan.ts
+++ b/apps/api/src/services/wakeOnLan.ts
@@ -1,0 +1,403 @@
+import { and, desc, eq, isNotNull, ne, sql } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import { db } from '../db';
+import {
+  auditLogs,
+  deviceCommands,
+  deviceIpHistory,
+  deviceNetwork,
+  devices,
+} from '../db/schema';
+import { CommandTypes } from './commandQueue';
+import { claimPendingCommandForDelivery, releaseClaimedCommandDelivery } from './commandDispatch';
+import { isAgentConnected, sendCommandToAgent } from '../routes/agentWs';
+
+export type WakeFailureCode =
+  | 'TARGET_NOT_FOUND'
+  | 'NO_MACS'
+  | 'NO_SUBNET'
+  | 'IPV6_ONLY'
+  | 'NO_RELAY'
+  | 'RELAY_OVERRIDE_INVALID'
+  | 'WS_SEND_FAILED';
+
+export interface WakeSuccess {
+  ok: true;
+  commandId: string;
+  wakeAttemptId: string;
+  targetDeviceId: string;
+  targetHostname: string;
+  relayDeviceId: string;
+  relayHostname: string;
+  network: string;
+  broadcast: string;
+  /** 'agent' = mask came from the agent's report; 'fallback_24' = mask was null and we defaulted to /24. */
+  maskSource: 'agent' | 'fallback_24';
+  macs: string[];
+}
+
+export interface WakeFailure {
+  ok: false;
+  code: WakeFailureCode;
+  message: string;
+}
+
+export type WakeResult = WakeSuccess | WakeFailure;
+
+type MaskSource = 'agent' | 'fallback_24';
+
+interface TargetSubnet {
+  ip: string;
+  mask: string;
+  network: string;
+  broadcast: string;
+  maskSource: MaskSource;
+}
+
+interface RelayCandidate {
+  deviceId: string;
+  agentId: string;
+  hostname: string;
+  network: string;
+  lastSeen: Date;
+}
+
+const WOL_UDP_PORTS = [7, 9] as const;
+const FALLBACK_MASK_24 = '255.255.255.0';
+
+// IPv4 dotted-quad → 32-bit unsigned int (big-endian). Returns null if malformed.
+export function ipv4ToInt(ip: string): number | null {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return null;
+  let n = 0;
+  for (const p of parts) {
+    if (!/^\d{1,3}$/.test(p)) return null;
+    const octet = Number(p);
+    if (octet < 0 || octet > 255) return null;
+    n = (n * 256) + octet;
+  }
+  return n >>> 0;
+}
+
+export function intToIpv4(n: number): string {
+  return [(n >>> 24) & 0xff, (n >>> 16) & 0xff, (n >>> 8) & 0xff, n & 0xff].join('.');
+}
+
+// Compute the directed subnet broadcast address from an IPv4 + mask.
+// Returns null if either input is invalid.
+export function computeBroadcast(ip: string, mask: string): { network: string; broadcast: string } | null {
+  const ipN = ipv4ToInt(ip);
+  const maskN = ipv4ToInt(mask);
+  if (ipN === null || maskN === null) return null;
+  const networkN = (ipN & maskN) >>> 0;
+  const broadcastN = (networkN | (~maskN >>> 0)) >>> 0;
+  return { network: intToIpv4(networkN), broadcast: intToIpv4(broadcastN) };
+}
+
+async function resolveTargetMacs(targetDeviceId: string): Promise<string[]> {
+  // Prefer device_network (live inventory), fall back to device_ip_history (historical).
+  const fromNetwork = await db
+    .select({ mac: deviceNetwork.macAddress, isPrimary: deviceNetwork.isPrimary, updatedAt: deviceNetwork.updatedAt })
+    .from(deviceNetwork)
+    .where(and(eq(deviceNetwork.deviceId, targetDeviceId), isNotNull(deviceNetwork.macAddress)));
+
+  const seen = new Set<string>();
+  const macs: string[] = [];
+  // Sort primary first, then newest.
+  const sorted = [...fromNetwork].sort((a, b) => {
+    if (a.isPrimary !== b.isPrimary) return a.isPrimary ? -1 : 1;
+    return b.updatedAt.getTime() - a.updatedAt.getTime();
+  });
+  for (const row of sorted) {
+    if (row.mac && !seen.has(row.mac.toLowerCase())) {
+      seen.add(row.mac.toLowerCase());
+      macs.push(row.mac);
+    }
+  }
+  if (macs.length > 0) return macs;
+
+  const fromHistory = await db
+    .select({ mac: deviceIpHistory.macAddress, lastSeen: deviceIpHistory.lastSeen })
+    .from(deviceIpHistory)
+    .where(and(eq(deviceIpHistory.deviceId, targetDeviceId), isNotNull(deviceIpHistory.macAddress)))
+    .orderBy(desc(deviceIpHistory.lastSeen))
+    .limit(20);
+  for (const row of fromHistory) {
+    if (row.mac && !seen.has(row.mac.toLowerCase())) {
+      seen.add(row.mac.toLowerCase());
+      macs.push(row.mac);
+    }
+  }
+  return macs;
+}
+
+async function resolveTargetSubnet(targetDeviceId: string): Promise<{ subnet: TargetSubnet | null; sawIpv6: boolean }> {
+  // Prefer the agent-reported mask. Most recent IPv4 with subnet_mask set.
+  const ipv4WithMask = await db
+    .select({ ip: deviceIpHistory.ipAddress, mask: deviceIpHistory.subnetMask })
+    .from(deviceIpHistory)
+    .where(and(
+      eq(deviceIpHistory.deviceId, targetDeviceId),
+      eq(deviceIpHistory.ipType, 'ipv4'),
+      isNotNull(deviceIpHistory.subnetMask),
+    ))
+    .orderBy(desc(deviceIpHistory.lastSeen))
+    .limit(1);
+  if (ipv4WithMask[0]?.ip && ipv4WithMask[0]?.mask) {
+    const computed = computeBroadcast(ipv4WithMask[0].ip, ipv4WithMask[0].mask);
+    if (computed) {
+      return {
+        subnet: { ip: ipv4WithMask[0].ip, mask: ipv4WithMask[0].mask, ...computed, maskSource: 'agent' },
+        sawIpv6: false,
+      };
+    }
+  }
+
+  // Fallback: most recent IPv4 *without* a mask. Pre-existing upstream gap —
+  // the agent's NetworkAdapterInfo doesn't populate SubnetMask yet, so we
+  // assume /24, which covers the vast majority of SMB LANs. Audit notes the
+  // fallback so this is visible in records.
+  const ipv4AnyMask = await db
+    .select({ ip: deviceIpHistory.ipAddress })
+    .from(deviceIpHistory)
+    .where(and(
+      eq(deviceIpHistory.deviceId, targetDeviceId),
+      eq(deviceIpHistory.ipType, 'ipv4'),
+    ))
+    .orderBy(desc(deviceIpHistory.lastSeen))
+    .limit(1);
+  if (ipv4AnyMask[0]?.ip) {
+    const computed = computeBroadcast(ipv4AnyMask[0].ip, FALLBACK_MASK_24);
+    if (computed) {
+      return {
+        subnet: { ip: ipv4AnyMask[0].ip, mask: FALLBACK_MASK_24, ...computed, maskSource: 'fallback_24' },
+        sawIpv6: false,
+      };
+    }
+  }
+
+  // No IPv4 — did we ever see IPv6? Used to return a more useful error.
+  const ipv6 = await db
+    .select({ id: deviceIpHistory.id })
+    .from(deviceIpHistory)
+    .where(and(eq(deviceIpHistory.deviceId, targetDeviceId), eq(deviceIpHistory.ipType, 'ipv6')))
+    .limit(1);
+  return { subnet: null, sawIpv6: ipv6.length > 0 };
+}
+
+async function selectRelay(
+  siteId: string,
+  targetDeviceId: string,
+  targetNetwork: string,
+): Promise<RelayCandidate | null> {
+  // Candidates: online devices at the same site, excluding the target itself,
+  // each with their most-recent active IPv4 history entry. Drizzle doesn't
+  // give us a clean SQL DISTINCT ON, so we fetch and dedupe in-memory.
+  // We do NOT filter by subnet_mask here — when it's null we fall back to
+  // /24 to match resolveTargetSubnet's behavior (see [FOLLOWUP] task for the
+  // agent-side fix that will populate it).
+  const rows = await db
+    .select({
+      deviceId: devices.id,
+      agentId: devices.agentId,
+      hostname: devices.hostname,
+      ip: deviceIpHistory.ipAddress,
+      mask: deviceIpHistory.subnetMask,
+      lastSeen: deviceIpHistory.lastSeen,
+    })
+    .from(devices)
+    .innerJoin(deviceIpHistory, eq(deviceIpHistory.deviceId, devices.id))
+    .where(and(
+      eq(devices.siteId, siteId),
+      eq(devices.status, 'online'),
+      ne(devices.id, targetDeviceId),
+      eq(deviceIpHistory.ipType, 'ipv4'),
+      eq(deviceIpHistory.isActive, true),
+    ))
+    .orderBy(desc(deviceIpHistory.lastSeen));
+
+  // Keep only the newest entry per device.
+  const newestByDevice = new Map<string, typeof rows[number]>();
+  for (const row of rows) {
+    if (!newestByDevice.has(row.deviceId)) newestByDevice.set(row.deviceId, row);
+  }
+
+  let best: RelayCandidate | null = null;
+  for (const row of newestByDevice.values()) {
+    if (!row.ip) continue;
+    const computed = computeBroadcast(row.ip, row.mask || FALLBACK_MASK_24);
+    if (!computed || computed.network !== targetNetwork) continue;
+    if (!isAgentConnected(row.agentId)) continue;
+    if (!best || row.lastSeen.getTime() > best.lastSeen.getTime()) {
+      best = {
+        deviceId: row.deviceId,
+        agentId: row.agentId,
+        hostname: row.hostname,
+        network: computed.network,
+        lastSeen: row.lastSeen,
+      };
+    }
+  }
+  return best;
+}
+
+interface DispatchWakeOptions {
+  /** Force a specific relay (must be online, same site, same subnet). For troubleshooting. */
+  relayDeviceIdOverride?: string;
+  /** IP address of the request (for the audit row). */
+  ipAddress?: string;
+  /** User-Agent of the request (for the audit row). */
+  userAgent?: string;
+}
+
+export async function dispatchWake(
+  targetDeviceId: string,
+  userId: string,
+  options: DispatchWakeOptions = {},
+): Promise<WakeResult> {
+  const [target] = await db
+    .select({ id: devices.id, orgId: devices.orgId, siteId: devices.siteId, hostname: devices.hostname })
+    .from(devices)
+    .where(eq(devices.id, targetDeviceId))
+    .limit(1);
+  if (!target) {
+    return { ok: false, code: 'TARGET_NOT_FOUND', message: 'Target device not found.' };
+  }
+
+  const macs = await resolveTargetMacs(target.id);
+  if (macs.length === 0) {
+    return { ok: false, code: 'NO_MACS', message: 'Target has no recorded MAC address. The agent must check in at least once before Wake-on-LAN is available.' };
+  }
+
+  const { subnet, sawIpv6 } = await resolveTargetSubnet(target.id);
+  if (!subnet) {
+    return {
+      ok: false,
+      code: sawIpv6 ? 'IPV6_ONLY' : 'NO_SUBNET',
+      message: sawIpv6
+        ? 'Target has only IPv6 history. Wake-on-LAN requires an IPv4 record with subnet mask.'
+        : 'Target has no IPv4 record with a subnet mask in history.',
+    };
+  }
+
+  let relay: RelayCandidate | null;
+  if (options.relayDeviceIdOverride) {
+    const [override] = await db
+      .select({
+        id: devices.id,
+        agentId: devices.agentId,
+        hostname: devices.hostname,
+        siteId: devices.siteId,
+        status: devices.status,
+      })
+      .from(devices)
+      .where(eq(devices.id, options.relayDeviceIdOverride))
+      .limit(1);
+    if (!override || override.siteId !== target.siteId || override.status !== 'online' || override.id === target.id || !isAgentConnected(override.agentId)) {
+      return { ok: false, code: 'RELAY_OVERRIDE_INVALID', message: 'Override relay must be a different online device at the target\'s site with a live agent connection.' };
+    }
+    relay = {
+      deviceId: override.id,
+      agentId: override.agentId,
+      hostname: override.hostname,
+      network: subnet.network,
+      lastSeen: new Date(),
+    };
+  } else {
+    relay = await selectRelay(target.siteId, target.id, subnet.network);
+  }
+
+  if (!relay) {
+    return {
+      ok: false,
+      code: 'NO_RELAY',
+      message: 'No online peer agent is available at the target\'s site and subnet to relay the Wake-on-LAN packet.',
+    };
+  }
+
+  const wakeAttemptId = randomUUID();
+  const payload = {
+    targetDeviceId: target.id,
+    targetHostname: target.hostname,
+    macs,
+    network: subnet.network,
+    broadcast: subnet.broadcast,
+    ports: WOL_UDP_PORTS,
+    wakeAttemptId,
+  };
+
+  // Row is addressed to the RELAY so the agentWs result handler matches by
+  // (commandId, relay.deviceId, targetRole='agent').
+  const [command] = await db
+    .insert(deviceCommands)
+    .values({
+      deviceId: relay.deviceId,
+      type: CommandTypes.WAKE_ON_LAN,
+      payload,
+      status: 'pending',
+      createdBy: userId,
+    })
+    .returning({ id: deviceCommands.id });
+
+  if (!command) {
+    return { ok: false, code: 'WS_SEND_FAILED', message: 'Failed to record wake command.' };
+  }
+
+  // Audit row points at the TARGET (the device the user is acting on) and
+  // records the relay used as context.
+  await db.insert(auditLogs).values({
+    orgId: target.orgId,
+    actorType: 'user',
+    actorId: userId,
+    action: 'device.wake_on_lan',
+    resourceType: 'device',
+    resourceId: target.id,
+    resourceName: target.hostname,
+    details: {
+      commandId: command.id,
+      wakeAttemptId,
+      targetDeviceId: target.id,
+      relayDeviceId: relay.deviceId,
+      relayHostname: relay.hostname,
+      network: subnet.network,
+      broadcast: subnet.broadcast,
+      mask: subnet.mask,
+      maskSource: subnet.maskSource,
+      macs,
+      relayOverride: Boolean(options.relayDeviceIdOverride),
+    },
+    ipAddress: options.ipAddress,
+    userAgent: options.userAgent,
+    result: 'success',
+  });
+
+  const claimed = await claimPendingCommandForDelivery(command.id);
+  if (!claimed) {
+    return { ok: false, code: 'WS_SEND_FAILED', message: 'Failed to claim wake command for dispatch.' };
+  }
+
+  const sent = sendCommandToAgent(relay.agentId, {
+    id: command.id,
+    type: CommandTypes.WAKE_ON_LAN,
+    payload,
+  });
+
+  if (!sent) {
+    await releaseClaimedCommandDelivery(command.id, claimed.executedAt);
+    return { ok: false, code: 'WS_SEND_FAILED', message: 'Relay agent went offline before the command could be sent. Try again.' };
+  }
+
+  return {
+    ok: true,
+    commandId: command.id,
+    wakeAttemptId,
+    targetDeviceId: target.id,
+    targetHostname: target.hostname,
+    relayDeviceId: relay.deviceId,
+    relayHostname: relay.hostname,
+    network: subnet.network,
+    broadcast: subnet.broadcast,
+    maskSource: subnet.maskSource,
+    macs,
+  };
+}

--- a/apps/docs/src/content/docs/features/mobile.mdx
+++ b/apps/docs/src/content/docs/features/mobile.mdx
@@ -71,10 +71,25 @@ The device detail screen exposes quick-action buttons that dispatch commands to 
 | Action | Description | Availability |
 |--------|-------------|-------------|
 | `reboot` | Sends a reboot command to the device agent | Online devices only |
-| `wake` | Sends a Wake-on-LAN packet | Available for all devices |
+| `wake` | Sends a Wake-on-LAN packet via an online peer agent on the target's LAN | Offline devices only; requires another online agent at the same site and subnet |
 | `run_script` | Executes a script on the device | Online devices only; requires `scriptId` |
 
 Actions are submitted via the mobile actions endpoint `POST /mobile/devices/:id/actions`, which supports `reboot`, `wake`, and `run_script`. For `run_script`, the API validates that the script exists, the user has organization access to it, and the script's supported OS types include the target device's OS. A `scriptExecution` record is created with `triggerType: 'manual'` and the script content, language, timeout, and `runAs` settings are included in the command payload.
+
+#### Wake-on-LAN pre-flight
+
+The offline target can't execute its own wake, so the API selects an online peer agent at the same `site_id` whose most recent active IPv4 subnet matches the target's, and dispatches the magic packet from that relay. The dashboard mobile UI hits the core `POST /devices/:id/commands` endpoint with `{ "type": "wake" }`; the API translates it to a `wake_on_lan` command addressed to the relay. On success the response is 202 with the relay hostname, computed broadcast address, target MACs, and a `wakeAttemptId`. Pre-flight failures return 412 with one of these codes so the UI can surface a specific reason:
+
+| Code | Meaning |
+|------|---------|
+| `NO_MACS` | Target has never reported a MAC address to the platform. |
+| `NO_SUBNET` | Target has no IPv4 record with a subnet mask in history. |
+| `IPV6_ONLY` | Target has only IPv6 history (Wake-on-LAN is IPv4-only). |
+| `NO_RELAY` | No online peer agent at the same site and subnet is available to relay. |
+| `RELAY_OVERRIDE_INVALID` | Caller-supplied relay isn't online or isn't at the target's site/subnet. |
+| `WS_SEND_FAILED` | Relay dropped its WebSocket between selection and dispatch — retry. |
+
+The agent's WoL handler sends three rounds of magic packets to UDP ports 7 and 9 spaced 500 ms apart, one per known MAC. Success measurement is left to the UI — wait for the target's next heartbeat to confirm the wake worked (typical resume time: 30 s to 5 min).
 
 <Aside type="caution">
   The `shutdown` and `lock` actions visible in the mobile UI are dispatched through the core commands endpoint (`POST /devices/:id/commands`) rather than the mobile actions endpoint, as the mobile actions schema does not currently accept those command types.

--- a/apps/mobile/src/screens/devices/DeviceDetailScreen.tsx
+++ b/apps/mobile/src/screens/devices/DeviceDetailScreen.tsx
@@ -4,8 +4,10 @@ import { ActivityIndicator, Alert, Pressable, ScrollView, Text, View } from 'rea
 import {
   getDeviceMetrics,
   sendDeviceAction,
+  sendWakeAction,
   type Device,
   type DeviceAction,
+  type WakeFailureCode,
 } from '../../services/api';
 import {
   useApprovalTheme,
@@ -182,13 +184,45 @@ export function DeviceDetailScreen({ route }: Props) {
   async function handleAction(action: DeviceAction) {
     try {
       setActionLoading(action);
-      await sendDeviceAction(device.id, action);
-      Alert.alert('Sent', `${action} command sent.`);
+      if (action === 'wake') {
+        const wake = await sendWakeAction(device.id);
+        Alert.alert(
+          'Wake sent',
+          `Magic packet sent to ${wake.broadcast} via ${wake.relay.hostname}. Wait up to 5 min for the device to come online.`,
+        );
+      } else {
+        await sendDeviceAction(device.id, action);
+        Alert.alert('Sent', `${action} command sent.`);
+      }
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Could not send command.';
+      const apiErr = err as { message?: string; code?: WakeFailureCode | string };
+      const msg = (action === 'wake' ? wakeFriendlyMessage(apiErr.code) : null)
+        || apiErr?.message
+        || 'Could not send command.';
       Alert.alert('Failed', msg);
     } finally {
       setActionLoading(null);
+    }
+  }
+
+  function wakeFriendlyMessage(code: WakeFailureCode | string | undefined): string | null {
+    switch (code) {
+      case 'NO_MACS':
+        return 'No MAC address on file. The agent must check in at least once before Wake-on-LAN is available.';
+      case 'NO_SUBNET':
+        return 'No IPv4 record with a subnet mask is in this device\'s history.';
+      case 'IPV6_ONLY':
+        return 'Device only has IPv6 history. Wake-on-LAN requires IPv4.';
+      case 'NO_RELAY':
+        return 'No online peer agent at the same site and subnet to relay the packet.';
+      case 'RELAY_OVERRIDE_INVALID':
+        return 'Selected relay is not eligible (must be online and at the target site and subnet).';
+      case 'WS_SEND_FAILED':
+        return 'Relay agent dropped connection during dispatch. Try again.';
+      case 'TARGET_NOT_FOUND':
+        return 'Device not found.';
+      default:
+        return null;
     }
   }
 

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -476,6 +476,41 @@ export async function sendDeviceAction(
   };
 }
 
+export type WakeFailureCode =
+  | 'TARGET_NOT_FOUND'
+  | 'NO_MACS'
+  | 'NO_SUBNET'
+  | 'IPV6_ONLY'
+  | 'NO_RELAY'
+  | 'RELAY_OVERRIDE_INVALID'
+  | 'WS_SEND_FAILED';
+
+export interface WakeMobileResponse {
+  id: string;
+  deviceId: string;
+  type: 'wake_on_lan';
+  status: string;
+  wakeAttemptId: string;
+  relay: { deviceId: string; hostname: string };
+  network: string;
+  broadcast: string;
+  macs: string[];
+}
+
+// Throws an ApiError on non-2xx — the caller can read err.code for the
+// pre-flight failure reason (NO_MACS, NO_RELAY, etc.) and surface a friendly
+// message. requestWithPrefix already preserves both code and statusCode.
+export async function sendWakeAction(deviceId: string): Promise<WakeMobileResponse> {
+  return requestWithPrefix<WakeMobileResponse>(
+    `/devices/${deviceId}/commands`,
+    API_CORE_PREFIX,
+    {
+      method: 'POST',
+      body: JSON.stringify({ type: 'wake' }),
+    },
+  );
+}
+
 // Push notification registration
 export async function registerPushToken(token: string, platform: 'ios' | 'android'): Promise<void> {
   await request('/notifications/register', {

--- a/apps/web/src/components/devices/DeviceActions.tsx
+++ b/apps/web/src/components/devices/DeviceActions.tsx
@@ -13,7 +13,8 @@ import {
   Trash2,
   XCircle,
   Package,
-  MapPin
+  MapPin,
+  Zap
 } from 'lucide-react';
 import type { Device } from './DeviceList';
 import ConnectDesktopButton from '../remote/ConnectDesktopButton';
@@ -107,6 +108,16 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
                 <RotateCcw className="h-4 w-4" />
                 Reboot
               </button>
+              {device.status === 'offline' && (
+                <button
+                  type="button"
+                  onClick={() => handleAction('wake')}
+                  className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted"
+                >
+                  <Zap className="h-4 w-4" />
+                  Wake
+                </button>
+              )}
               {device.os === 'windows' && (
                 <button
                   type="button"
@@ -210,6 +221,18 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
           <RotateCcw className="h-4 w-4" />
           Reboot
         </button>
+        {device.status === 'offline' && (
+          <button
+            type="button"
+            onClick={() => handleAction('wake')}
+            disabled={loading}
+            className="flex items-center gap-2 rounded-md border bg-background px-4 py-2 text-sm font-medium transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+            title="Send a Wake-on-LAN packet via an online peer agent on the device's LAN"
+          >
+            <Zap className="h-4 w-4" />
+            Wake
+          </button>
+        )}
 
         <div className="relative">
           <button

--- a/apps/web/src/components/devices/DeviceDetailPage.tsx
+++ b/apps/web/src/components/devices/DeviceDetailPage.tsx
@@ -8,7 +8,7 @@ import ChangeSiteModal from './ChangeSiteModal';
 import ScriptPickerModal, { type Script, type ScriptRunAsSelection } from './ScriptPickerModal';
 import type { Device, DeviceStatus, OSType } from './DeviceList';
 import { fetchWithAuth } from '../../stores/auth';
-import { sendDeviceCommand, executeScript, toggleMaintenanceMode, decommissionDevice, clearDeviceSessions, restoreDevice, permanentDeleteDevice } from '../../services/deviceActions';
+import { sendDeviceCommand, executeScript, toggleMaintenanceMode, decommissionDevice, clearDeviceSessions, restoreDevice, permanentDeleteDevice, sendWakeCommand, WakeCommandError, wakeFriendlyErrorMessage } from '../../services/deviceActions';
 import { useAiStore } from '@/stores/aiStore';
 import { navigateTo } from '@/lib/navigation';
 import Breadcrumbs from '../layout/Breadcrumbs';
@@ -147,6 +147,24 @@ export default function DeviceDetailPage({ deviceId }: DeviceDetailPageProps) {
           await sendDeviceCommand(device.id, action);
           const label = action === 'reboot_safe_mode' ? 'Reboot to Safe Mode' : action.charAt(0).toUpperCase() + action.slice(1);
           showToast({ type: 'success', message: `${label} command sent to ${device.hostname}` });
+          break;
+        }
+
+        case 'wake': {
+          try {
+            const wake = await sendWakeCommand(device.id);
+            showToast({
+              type: 'success',
+              message: `Wake packet sent to ${device.hostname} via ${wake.relay.hostname} (${wake.broadcast}). Wait up to 5 min for it to come online.`,
+            });
+          } catch (err) {
+            if (err instanceof WakeCommandError) {
+              const friendly = wakeFriendlyErrorMessage(err.code) ?? err.message;
+              showToast({ type: 'error', message: `${device.hostname}: ${friendly}` });
+            } else {
+              throw err;
+            }
+          }
           break;
         }
 

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, useEffect, useRef } from 'react';
-import { Search, ChevronLeft, ChevronRight, ChevronUp, ChevronDown, ArrowUpDown, MoreHorizontal, MoreVertical, Filter, Terminal, FileCode, RotateCcw, Settings, Trash2 } from 'lucide-react';
+import { Search, ChevronLeft, ChevronRight, ChevronUp, ChevronDown, ArrowUpDown, MoreHorizontal, MoreVertical, Filter, Terminal, FileCode, RotateCcw, Settings, Trash2, Zap } from 'lucide-react';
 import type { DesktopAccessState, FilterConditionGroup, RemoteAccessPolicy } from '@breeze/shared';
 import { fetchWithAuth } from '../../stores/auth';
 import ConnectDesktopButton from '../remote/ConnectDesktopButton';
@@ -813,6 +813,20 @@ export default function DeviceList({
                               <RotateCcw className="h-4 w-4" />
                               Reboot
                             </button>
+                            {device.status === 'offline' && (
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  onAction?.('wake', device);
+                                  setRowMenuOpenId(null);
+                                }}
+                                className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted"
+                                title="Send a Wake-on-LAN packet via an online peer agent on the device's LAN"
+                              >
+                                <Zap className="h-4 w-4" />
+                                Wake
+                              </button>
+                            )}
                             <button
                               type="button"
                               onClick={() => {

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -12,7 +12,7 @@ import AddDeviceModal from './AddDeviceModal';
 import CreateGroupModal from './CreateGroupModal';
 import { DeviceFilterBar } from '../filters/DeviceFilterBar';
 import { fetchWithAuth } from '../../stores/auth';
-import { sendDeviceCommand, sendBulkCommand, executeScript, toggleMaintenanceMode, decommissionDevice, bulkDecommissionDevices, restoreDevice, permanentDeleteDevice } from '../../services/deviceActions';
+import { sendDeviceCommand, sendBulkCommand, executeScript, toggleMaintenanceMode, decommissionDevice, bulkDecommissionDevices, restoreDevice, permanentDeleteDevice, sendWakeCommand, WakeCommandError, wakeFriendlyErrorMessage } from '../../services/deviceActions';
 import { navigateTo } from '@/lib/navigation';
 import { getErrorMessage, getErrorTitle } from '@/lib/errorMessages';
 import { asRecord, toPercent } from '@/lib/deviceUtils';
@@ -278,6 +278,24 @@ export default function DevicesPage() {
           await sendDeviceCommand(device.id, action);
           const label = action === 'reboot_safe_mode' ? 'Reboot to Safe Mode' : action.charAt(0).toUpperCase() + action.slice(1);
           showToast({ type: 'success', message: `${label} command sent to ${device.hostname}` });
+          break;
+        }
+
+        case 'wake': {
+          try {
+            const wake = await sendWakeCommand(device.id);
+            showToast({
+              type: 'success',
+              message: `Wake packet sent to ${device.hostname} via ${wake.relay.hostname} (${wake.broadcast}). Wait up to 5 min for it to come online.`,
+            });
+          } catch (err) {
+            if (err instanceof WakeCommandError) {
+              const friendly = wakeFriendlyErrorMessage(err.code) ?? err.message;
+              showToast({ type: 'error', message: `${device.hostname}: ${friendly}` });
+            } else {
+              throw err;
+            }
+          }
           break;
         }
 

--- a/apps/web/src/services/deviceActions.ts
+++ b/apps/web/src/services/deviceActions.ts
@@ -41,6 +41,80 @@ export async function sendDeviceCommand(
   return data.command ?? data.data ?? data;
 }
 
+export type WakeFailureCode =
+  | 'TARGET_NOT_FOUND'
+  | 'NO_MACS'
+  | 'NO_SUBNET'
+  | 'IPV6_ONLY'
+  | 'NO_RELAY'
+  | 'RELAY_OVERRIDE_INVALID'
+  | 'WS_SEND_FAILED';
+
+export interface WakeResponse {
+  id: string;
+  deviceId: string;
+  type: 'wake_on_lan';
+  status: string;
+  wakeAttemptId: string;
+  relay: { deviceId: string; hostname: string };
+  network: string;
+  broadcast: string;
+  macs: string[];
+}
+
+export class WakeCommandError extends Error {
+  readonly code: WakeFailureCode | undefined;
+  constructor(message: string, code?: WakeFailureCode) {
+    super(message);
+    this.name = 'WakeCommandError';
+    this.code = code;
+  }
+}
+
+export function wakeFriendlyErrorMessage(code: string | undefined): string | null {
+  switch (code) {
+    case 'NO_MACS':
+      return 'No MAC address on file. The agent must check in at least once before Wake-on-LAN is available.';
+    case 'NO_SUBNET':
+      return 'No IPv4 record with a subnet mask in history.';
+    case 'IPV6_ONLY':
+      return 'Device only has IPv6 history. Wake-on-LAN requires IPv4.';
+    case 'NO_RELAY':
+      return 'No online peer agent at the same site and subnet to relay the packet.';
+    case 'RELAY_OVERRIDE_INVALID':
+      return 'Selected relay is not eligible (must be online and at the target’s site and subnet).';
+    case 'WS_SEND_FAILED':
+      return 'Relay agent dropped connection during dispatch. Try again.';
+    case 'TARGET_NOT_FOUND':
+      return 'Device not found.';
+    default:
+      return null;
+  }
+}
+
+export async function sendWakeCommand(deviceId: string): Promise<WakeResponse> {
+  const response = await fetchWithAuth(`/devices/${deviceId}/commands`, {
+    method: 'POST',
+    body: JSON.stringify({ type: 'wake' })
+  });
+
+  if (!response.ok) {
+    let code: WakeFailureCode | undefined;
+    let message = 'Failed to send wake command';
+    try {
+      const data = await response.json();
+      if (typeof data?.code === 'string') code = data.code as WakeFailureCode;
+      if (typeof data?.error === 'string') message = data.error;
+      else if (typeof data?.message === 'string') message = data.message;
+    } catch {
+      // ignore JSON parse failure; use fallback message
+    }
+    throw new WakeCommandError(message, code);
+  }
+
+  return await response.json();
+}
+
 export async function sendBulkCommand(
   deviceIds: string[],
   type: string,


### PR DESCRIPTION
## Why

Closes the "half-wired wake" gap discussed in https://github.com/LanternOps/breeze/discussions/694.

Today the `wake` action is half-implemented: `apps/api/src/routes/mobile.ts` accepts a `wake` action and inserts a `device_commands` row addressed to the offline target itself, but `apps/api/src/routes/devices/schemas.ts` doesn't include `'wake'` in `createCommandSchema.type`, so the mobile UI's call hits a validator error before reaching that stub. There is no relay selection, no agent handler, no audit trail. Net effect: the existing scaffolding doesn't connect end to end.

## What this proposes

A relay-aware Wake-on-LAN implementation that fits Breeze's existing command pipeline:

1. **New API service** (`apps/api/src/services/wakeOnLan.ts`) — `dispatchWake(targetDeviceId, userId, options)` returns a discriminated union: `WakeSuccess` or one of seven `WakeFailureCode`s (`TARGET_NOT_FOUND`, `NO_MACS`, `NO_SUBNET`, `IPV6_ONLY`, `NO_RELAY`, `RELAY_OVERRIDE_INVALID`, `WS_SEND_FAILED`).
2. **Relay selection** — same `site_id` as target, online status, target's most-recent active IPv4 subnet matches an online peer's most-recent active IPv4 subnet. Most-recent `lastSeen` wins. Verifies WS connection before claiming.
3. **MAC discovery** — prefer `device_network` (live inventory), fall back to `device_ip_history` for legacy data. Includes every NIC's MAC, not just primary.
4. **Subnet** — read from `device_ip_history.subnet_mask`. Falls back to `/24` when the column is null (the collector backfill for SubnetMask is split into a parallel PR per your nudge).
5. **Row addressing** — `device_commands.device_id` = the **relay's** deviceId so the result handler at `apps/api/src/routes/agentWs.ts` matches by `(commandId, relay.deviceId, targetRole='agent')`. Payload carries `{ targetDeviceId, macs, broadcast, ports: [7, 9], wakeAttemptId }`. `device_commands` remains system-scoped per the CLAUDE.md tenancy section.
6. **Audit** — single `audit_logs` row addressed to the **target** (action = `device.wake_on_lan`, `actorType: 'user'`). `details` includes `commandId`, `wakeAttemptId`, `targetDeviceId`, relay info, broadcast, mask, `maskSource: 'agent' | 'fallback_24'`, MAC list.
7. **`wakeAttemptId`** — server-generated `crypto.randomUUID()` per your preference; surfaced in the 202 response.
8. **Route wiring** — `POST /devices/:id/commands` with `type: 'wake'` calls `dispatchWake`. Returns `202` with `{commandId, wakeAttemptId, relay, network, broadcast, macs}` or `412` with `{code, error}`. Mobile-actions endpoint (`/mobile/devices/:id/actions`) wired in parallel for the legacy stub call site.
9. **Agent handler** (`agent/internal/remote/tools/wake_on_lan.go`) — pure-stdlib `MagicPacket(mac)` builder + `WakeOnLan(payload)` that fires 3 rounds × N MACs × M ports (default 7+9), 500 ms between rounds. Binds UDP to the broadcast address; relies on kernel interface selection. SO_BROADCAST is omitted because directed-broadcast (e.g., `192.168.1.255`) works on Linux/macOS/Windows without it for this case; could add behind a build-split helper if field testing shows otherwise.
10. **Web UI** — Lightning-bolt Wake button in DeviceActions (compact + full bars) and the per-row dropdown in DeviceList, visible only when `device.status === 'offline'`. Renders the seven failure codes as friendly toast text.
11. **Mobile UI** — existing Wake button surfaces the new structured response; ApiError-shaped 412s map to friendly text.
12. **Docs** — `apps/docs/src/content/docs/features/mobile.mdx` rewritten with accurate semantics + a new pre-flight reference table.

No schema migration. All required columns already exist on `devices`, `device_network`, `device_ip_history`, `sites`, `device_commands`, `audit_logs`.

## Live test result

Five-device fleet rollout (production agents updated via `dev_update`) executed wake commands end-to-end overnight:
- Target offline (`10.10.144.172` last-known) → web Wake click → API auto-picked an online peer (`10.10.144.126/24`) → agent fired 18 packets (3 MACs × 2 ports × 3 rounds) to `10.10.144.255` in 1037 ms → target reported online ~3 seconds later.
- 412 paths verified manually by setting up a host with only an IPv6 lease + a host with no online same-subnet peer.

## Tests

- `apps/api/src/services/wakeOnLan.test.ts` — 10 helper unit tests (`ipv4ToInt`, `intToIpv4`, `computeBroadcast` across /8 /16 /23 /24 /32 + malformed input). All pass.
- `agent/internal/remote/tools/wake_on_lan_test.go` — 11 tests including magic-packet byte equality, MAC format parsing (colon/hyphen/cisco-dot/whitespace), IPv4-only enforcement, port range validation, and a full **loopback dispatch test** that opens a real UDP listener on `127.0.0.1` and verifies the 102-byte packet arrives.

Local verification on this branch:
- `CGO_ENABLED=0 go test ./internal/remote/tools/... ./internal/heartbeat/...` — green.
- `pnpm exec tsc --noEmit --project apps/api/tsconfig.json` — green.

## Nudges from the discussion

- **`device_commands` org_id**: confirmed system-scoped per `CLAUDE.md` Tenancy section — no schema change.
- **Audit shape**: `actorType: 'user'` + `details.targetDeviceId` — folded in (`apps/api/src/services/wakeOnLan.ts:356`).
- **Agent collector fix**: kept as a parallel PR; tracked separately.

## Test plan

- [ ] Pre-flight: `NO_MACS`, `NO_SUBNET`, `IPV6_ONLY`, `NO_RELAY` surfaced as 412 with code in body
- [ ] Happy path: 202 + relay info + audit row written
- [ ] Agent receives `wake_on_lan` command, fires packets, returns `completed` with `packetsSent`/`packetsTotal`
- [ ] Target wakes (BIOS WoL + Magic Packet enabled at NIC)
- [ ] /24 fallback exercised when `subnet_mask` is null
- [ ] Web bundle: Wake button visible only when status=offline; appears in both DeviceActions and the DeviceList row dropdown
- [ ] Mobile: 412 surfaces friendly text instead of `[object Object]`
