### PR TITLE
feat(web): per-page-size selector on Devices list (Discussion #684)

### DIFF
--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -53,6 +53,9 @@ type DeviceListProps = {
   onSelect?: (device: Device) => void;
   onAction?: (action: string, device: Device) => void;
   onBulkAction?: (action: string, devices: Device[]) => void;
+  // Initial page size if the user has no stored preference for this browser.
+  // Once the component mounts, the live page size comes from localStorage
+  // (see pageSizePreference.ts); subsequent changes to this prop are ignored.
   pageSize?: number;
   serverFilter?: FilterConditionGroup | null;
 };
@@ -277,6 +280,15 @@ export default function DeviceList({
   const moreFiltersCount = [roleFilter, orgFilter, siteFilter].filter(f => f !== 'all').length + (groupFilter.length > 0 ? 1 : 0);
 
   const totalPages = Math.ceil(sortedDevices.length / effectivePageSize);
+
+  // Adjust currentPage during render when filters/search shrink the result
+  // set below it. Setting state during render is React's documented way to
+  // correct derived state without a flash of stale UI — React discards the
+  // in-progress render and re-runs with the corrected value.
+  if (totalPages > 0 && currentPage > totalPages) {
+    setCurrentPage(1);
+  }
+
   const startIndex = (currentPage - 1) * effectivePageSize;
   const paginatedDevices = sortedDevices.slice(startIndex, startIndex + effectivePageSize);
 

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -6,6 +6,11 @@ import ConnectDesktopButton from '../remote/ConnectDesktopButton';
 import { widthPercentClass } from '@/lib/utils';
 import { formatLastSeen } from '@/lib/formatTime';
 import { DEVICE_ROLES, getDeviceRoleLabel, getDeviceRoleIcon, type DeviceRole } from '@/lib/deviceRoles';
+import {
+  PAGE_SIZE_OPTIONS,
+  readPageSizePreference,
+  writePageSizePreference,
+} from './pageSizePreference';
 
 export type DeviceStatus = 'online' | 'offline' | 'maintenance' | 'decommissioned' | 'quarantined' | 'updating';
 export type OSType = 'windows' | 'macos' | 'linux';
@@ -108,6 +113,13 @@ export default function DeviceList({
   const [groupDropdownOpen, setGroupDropdownOpen] = useState(false);
   const groupDropdownRef = useRef<HTMLDivElement>(null);
   const [currentPage, setCurrentPage] = useState(1);
+  // effectivePageSize is the live, user-controllable page size. Initialized
+  // from localStorage (per-user, this-browser persistence) and falls back
+  // to the pageSize prop default for callers that supply one. See
+  // pageSizePreference.ts for the storage contract and allowed-set guard.
+  const [effectivePageSize, setEffectivePageSize] = useState<number>(() =>
+    readPageSizePreference(pageSize),
+  );
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkMenuOpen, setBulkMenuOpen] = useState(false);
   const [rowMenuOpenId, setRowMenuOpenId] = useState<string | null>(null);
@@ -264,9 +276,17 @@ export default function DeviceList({
 
   const moreFiltersCount = [roleFilter, orgFilter, siteFilter].filter(f => f !== 'all').length + (groupFilter.length > 0 ? 1 : 0);
 
-  const totalPages = Math.ceil(sortedDevices.length / pageSize);
-  const startIndex = (currentPage - 1) * pageSize;
-  const paginatedDevices = sortedDevices.slice(startIndex, startIndex + pageSize);
+  const totalPages = Math.ceil(sortedDevices.length / effectivePageSize);
+  const startIndex = (currentPage - 1) * effectivePageSize;
+  const paginatedDevices = sortedDevices.slice(startIndex, startIndex + effectivePageSize);
+
+  const handlePageSizeChange = (newSize: number) => {
+    setEffectivePageSize(newSize);
+    writePageSizePreference(newSize);
+    // Reset to page 1 so the user doesn't land out-of-range when shrinking
+    // the page (and gets a coherent first-page view when growing it).
+    setCurrentPage(1);
+  };
 
   const handleSelectAll = (checked: boolean) => {
     if (checked) {
@@ -862,32 +882,54 @@ export default function DeviceList({
         </table>
       </div>
 
-      {totalPages > 1 && (
-        <div className="mt-4 flex items-center justify-between">
-          <p className="text-sm text-muted-foreground">
-            Showing {startIndex + 1} to {Math.min(startIndex + pageSize, sortedDevices.length)} of {sortedDevices.length}
-          </p>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
-              disabled={currentPage === 1}
-              className="flex h-9 w-9 items-center justify-center rounded-md border hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </button>
-            <span className="text-sm">
-              Page {currentPage} of {totalPages}
-            </span>
-            <button
-              type="button"
-              onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
-              disabled={currentPage === totalPages}
-              className="flex h-9 w-9 items-center justify-center rounded-md border hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <ChevronRight className="h-4 w-4" />
-            </button>
+      {sortedDevices.length > 0 && (
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-2">
+          <div className="flex items-center gap-3">
+            <p className="text-sm text-muted-foreground">
+              Showing {startIndex + 1} to {Math.min(startIndex + effectivePageSize, sortedDevices.length)} of {sortedDevices.length}
+            </p>
+            <div className="flex items-center gap-2">
+              <label htmlFor="device-page-size" className="text-sm text-muted-foreground">
+                Per page
+              </label>
+              <select
+                id="device-page-size"
+                value={effectivePageSize}
+                aria-label="Devices per page"
+                onChange={event => handlePageSizeChange(Number(event.target.value))}
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring sm:w-32"
+              >
+                {PAGE_SIZE_OPTIONS.map(opt => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+              </select>
+            </div>
           </div>
+          {totalPages > 1 && (
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+                disabled={currentPage === 1}
+                className="flex h-9 w-9 items-center justify-center rounded-md border hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </button>
+              <span className="text-sm">
+                Page {currentPage} of {totalPages}
+              </span>
+              <button
+                type="button"
+                onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
+                disabled={currentPage === totalPages}
+                className="flex h-9 w-9 items-center justify-center rounded-md border hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <ChevronRight className="h-4 w-4" />
+              </button>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/apps/web/src/components/devices/pageSizePreference.test.ts
+++ b/apps/web/src/components/devices/pageSizePreference.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_PAGE_SIZE,
+  PAGE_SIZE_OPTIONS,
+  PAGE_SIZE_STORAGE_KEY,
+  isValidPageSize,
+  readPageSizePreference,
+  writePageSizePreference,
+} from './pageSizePreference';
+
+// Tiny in-memory localStorage that we install onto `window` before each
+// test. This is intentional rather than relying on jsdom's bundled
+// implementation: as of vitest 4 / jsdom 27 on this project, the test
+// environment runs under Node 22+ which intercepts the `localStorage`
+// global before jsdom can attach its own, so `window.localStorage` reads
+// as `undefined`. The unit under test reads `window.localStorage`
+// defensively (typeof guards) and the production app always runs in a
+// browser where the real Storage API is present, so we substitute a
+// behaviourally-equivalent stub here.
+function makeMemoryStorage(): Storage {
+  const data = new Map<string, string>();
+  return {
+    get length() {
+      return data.size;
+    },
+    clear() {
+      data.clear();
+    },
+    getItem(key: string) {
+      return data.has(key) ? (data.get(key) as string) : null;
+    },
+    setItem(key: string, value: string) {
+      data.set(key, String(value));
+    },
+    removeItem(key: string) {
+      data.delete(key);
+    },
+    key(i: number) {
+      return Array.from(data.keys())[i] ?? null;
+    },
+  };
+}
+
+describe('pageSizePreference', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'localStorage', {
+      value: makeMemoryStorage(),
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('isValidPageSize', () => {
+    it('accepts every option in PAGE_SIZE_OPTIONS', () => {
+      for (const opt of PAGE_SIZE_OPTIONS) {
+        expect(isValidPageSize(opt)).toBe(true);
+      }
+    });
+
+    it('rejects values not in PAGE_SIZE_OPTIONS', () => {
+      expect(isValidPageSize(7)).toBe(false);
+      expect(isValidPageSize(0)).toBe(false);
+      expect(isValidPageSize(-10)).toBe(false);
+      expect(isValidPageSize(500)).toBe(false);
+      expect(isValidPageSize(NaN)).toBe(false);
+    });
+  });
+
+  describe('readPageSizePreference', () => {
+    it('returns the fallback when localStorage has no entry', () => {
+      expect(readPageSizePreference(25)).toBe(25);
+    });
+
+    it('returns the stored value when valid', () => {
+      window.localStorage.setItem(PAGE_SIZE_STORAGE_KEY, '50');
+      expect(readPageSizePreference()).toBe(50);
+    });
+
+    it('falls back when stored value is malformed', () => {
+      window.localStorage.setItem(PAGE_SIZE_STORAGE_KEY, 'banana');
+      expect(readPageSizePreference(25)).toBe(25);
+    });
+
+    it('falls back when stored value parses but is not in the allowed set', () => {
+      window.localStorage.setItem(PAGE_SIZE_STORAGE_KEY, '7');
+      expect(readPageSizePreference(100)).toBe(100);
+    });
+
+    it('uses DEFAULT_PAGE_SIZE when the fallback itself is not in the allowed set', () => {
+      expect(readPageSizePreference(7)).toBe(DEFAULT_PAGE_SIZE);
+    });
+
+    it('returns the fallback when localStorage.getItem throws (Safari private mode)', () => {
+      vi.spyOn(window.localStorage, 'getItem').mockImplementation(() => {
+        throw new DOMException('SecurityError', 'SecurityError');
+      });
+      expect(readPageSizePreference(25)).toBe(25);
+    });
+
+    it('defaults the fallback to DEFAULT_PAGE_SIZE when not supplied', () => {
+      expect(readPageSizePreference()).toBe(DEFAULT_PAGE_SIZE);
+    });
+  });
+
+  describe('writePageSizePreference', () => {
+    it('persists a valid size as a string', () => {
+      writePageSizePreference(50);
+      expect(window.localStorage.getItem(PAGE_SIZE_STORAGE_KEY)).toBe('50');
+    });
+
+    it('ignores a write of an invalid size (does not clobber existing valid value)', () => {
+      window.localStorage.setItem(PAGE_SIZE_STORAGE_KEY, '25');
+      writePageSizePreference(7);
+      expect(window.localStorage.getItem(PAGE_SIZE_STORAGE_KEY)).toBe('25');
+    });
+
+    it('swallows setItem exceptions (quota / private mode)', () => {
+      vi.spyOn(window.localStorage, 'setItem').mockImplementation(() => {
+        throw new DOMException('QuotaExceededError', 'QuotaExceededError');
+      });
+      expect(() => writePageSizePreference(100)).not.toThrow();
+    });
+  });
+});

--- a/apps/web/src/components/devices/pageSizePreference.ts
+++ b/apps/web/src/components/devices/pageSizePreference.ts
@@ -1,0 +1,49 @@
+// Per-user page-size preference for the Devices list. Persisted in
+// localStorage under a single key so the choice survives navigation and
+// reloads on the same browser. localStorage is the v1 storage decision;
+// a future enhancement may lift it to users.settings.devicesPageSize so
+// the preference follows the user across browsers (see Discussion #684).
+
+export const PAGE_SIZE_OPTIONS = [10, 25, 50, 100, 200] as const;
+export type PageSize = (typeof PAGE_SIZE_OPTIONS)[number];
+
+export const DEFAULT_PAGE_SIZE: PageSize = 10;
+export const PAGE_SIZE_STORAGE_KEY = 'breeze.devices.pageSize';
+
+export function isValidPageSize(value: number): value is PageSize {
+  return (PAGE_SIZE_OPTIONS as readonly number[]).includes(value);
+}
+
+// readPageSizePreference returns the stored preference if present and in
+// PAGE_SIZE_OPTIONS, otherwise the supplied fallback (also validated, so
+// an out-of-set caller default still resolves to a safe option). Returns
+// DEFAULT_PAGE_SIZE during SSR or if localStorage access throws (Safari
+// private mode raises SecurityError on getItem).
+export function readPageSizePreference(fallback: number = DEFAULT_PAGE_SIZE): PageSize {
+  const safeFallback: PageSize = isValidPageSize(fallback) ? fallback : DEFAULT_PAGE_SIZE;
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return safeFallback;
+  }
+  try {
+    const raw = window.localStorage.getItem(PAGE_SIZE_STORAGE_KEY);
+    if (raw === null) return safeFallback;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || !isValidPageSize(parsed)) return safeFallback;
+    return parsed;
+  } catch {
+    return safeFallback;
+  }
+}
+
+// writePageSizePreference persists the chosen size. Silently swallows
+// errors (quota exceeded, Safari private mode) — the chosen size is still
+// applied in component state, only persistence across reload is lost.
+export function writePageSizePreference(size: number): void {
+  if (!isValidPageSize(size)) return;
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') return;
+  try {
+    window.localStorage.setItem(PAGE_SIZE_STORAGE_KEY, String(size));
+  } catch {
+    // Quota / SecurityError — ignore.
+  }
+}


### PR DESCRIPTION
Closes/implements [Discussion #684](https://github.com/LanternOps/breeze/discussions/684). Green-lit by @ToddHebebrand on 2026-05-14.

## What changed

Lets the user pick how many device rows the `/devices` list renders per page. Default stays at 10 so existing users see no surprise on first render. The chosen size persists to `localStorage` per browser, so the next visit remembers it.

Options: **10 / 25 / 50 / 100 / 200**.

The selector lives in the pagination bar at the bottom of the table, next to "Showing X to Y of Z". It is visible whenever there's at least one device — even when only one page is needed — so users can pick 25/page even when 10 fit on screen.

Switching size resets `currentPage` to 1 so the user doesn't land on an out-of-range page.

## Files

- **`apps/web/src/components/devices/pageSizePreference.ts` (new, ~50 lines)**: `PAGE_SIZE_OPTIONS`, `isValidPageSize()`, `readPageSizePreference(fallback?)`, `writePageSizePreference(size)`. SSR-safe (`typeof window` guard). Throw-safe (Safari private-mode and quota errors swallowed). Allowed-set guard: stored values not in `PAGE_SIZE_OPTIONS` resolve to the supplied fallback, which is itself validated and falls back to `DEFAULT_PAGE_SIZE` (10) if invalid.
- **`apps/web/src/components/devices/pageSizePreference.test.ts` (new, 12 cases)**: every allowed option accepted; out-of-set rejected; missing localStorage entry → fallback; malformed stored value → fallback; out-of-set stored → fallback; out-of-set caller fallback → DEFAULT_PAGE_SIZE; `getItem` throws (Safari private mode) → fallback; default fallback when not supplied; `setItem` persists string; invalid write does not clobber existing valid value; `setItem` throws (quota) → swallowed.
- **`apps/web/src/components/devices/DeviceList.tsx` (modified)**: adds `effectivePageSize` state initialized via `readPageSizePreference(pageSize)`, replaces the three uses of `pageSize` in pagination math, adds a `handlePageSizeChange` that writes through to localStorage and resets the page. The pagination bar now renders whenever `sortedDevices.length > 0` (previously only when `totalPages > 1`) so the selector is reachable even on lists that fit on one page.

## Scope (matches @ToddHebebrand's review of #684)

- **Default stays 10.** Per Todd: "Don't want to surprise existing users on first render."
- **localStorage for v1.** Lifting to `users.settings.devicesPageSize` for cross-browser persistence is a follow-up, not in this PR.
- **Other list pages out of scope** (Sites / Users / Alerts / Scripts). Per Todd: open a follow-up discussion after this lands.
- **Server-side pagination and virtualization out of scope.** The endpoint already returns the full device list in one shot; the real ceiling is a separate conversation.

## Selector styling

Matches the existing filter selects above the table: `h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring sm:w-32` — same border, focus ring, height, and responsive width.

## Verification

- `npx tsc --noEmit` (apps/web) — 0 errors.
- `npx astro check` — 0 errors, 0 warnings.
- `npx vitest run apps/web/src/components/devices/pageSizePreference.test.ts` — 12 passed.
- Locally deployed to a private staging instance (`breeze.bdunn.com`) on top of `0.65.15`. Verified: selector renders next to the pagination bar at the matching half-width on lg+, switching size re-paginates and persists across reload, picking a value that no longer divides cleanly into the list count resets to page 1, default-10 behavior preserved for users with no stored value.

## Test plan

- [ ] Open `/devices` on a fresh browser (no localStorage entry) → 10 rows/page, default unchanged.
- [ ] Pick "25" → table re-paginates immediately, page resets to 1.
- [ ] Reload → still 25 rows/page.
- [ ] Pick "200" → table shows all rows up to 200, pagination chevrons hidden when only one page.
- [ ] Open in a different browser → still default 10 (localStorage is per-browser).
- [ ] Manually set `localStorage['breeze.devices.pageSize']` to `'7'` (out of allowed set) → falls back to 10 silently, no console errors.