### PR TITLE
fix(web,api): relax Site form validation (Discussion #628)

### DIFF
--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -721,12 +721,6 @@ describe('org routes', () => {
       expect(res.status).toBe(403);
     });
 
-    // Discussion #628 — over-validation relaxations.
-    // The schema previously required ten fields on the form side and accepted
-    // anything for `contact` on the API side. Below: name-only POST succeeds
-    // (zod's `timezone.default('UTC')` fills in the omission), invalid IANA
-    // strings are rejected, and an invalid contact email is rejected while a
-    // phone-only contact is accepted.
     it('accepts a name-only POST (no address, no contact, no timezone)', async () => {
       setAuthContext({ scope: 'organization', orgId: '11111111-1111-1111-1111-111111111111' });
       vi.mocked(db.insert).mockReturnValue({
@@ -957,6 +951,16 @@ describe('org routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.name).toBe('Updated');
+    });
+
+    it('rejects an invalid IANA timezone on update', async () => {
+      const res = await app.request('/orgs/sites/site-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ timezone: 'Mars/Olympus_Mons' })
+      });
+
+      expect(res.status).toBe(400);
     });
   });
 

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -720,6 +720,106 @@ describe('org routes', () => {
 
       expect(res.status).toBe(403);
     });
+
+    // Discussion #628 — over-validation relaxations.
+    // The schema previously required ten fields on the form side and accepted
+    // anything for `contact` on the API side. Below: name-only POST succeeds
+    // (zod's `timezone.default('UTC')` fills in the omission), invalid IANA
+    // strings are rejected, and an invalid contact email is rejected while a
+    // phone-only contact is accepted.
+    it('accepts a name-only POST (no address, no contact, no timezone)', async () => {
+      setAuthContext({ scope: 'organization', orgId: '11111111-1111-1111-1111-111111111111' });
+      vi.mocked(db.insert).mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: 'site-2', name: 'Remote-LA' }])
+        })
+      } as any);
+
+      const res = await app.request('/orgs/sites', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          orgId: '11111111-1111-1111-1111-111111111111',
+          name: 'Remote-LA'
+        })
+      });
+
+      expect(res.status).toBe(201);
+    });
+
+    it('rejects an invalid IANA timezone', async () => {
+      setAuthContext({ scope: 'organization', orgId: '11111111-1111-1111-1111-111111111111' });
+
+      const res = await app.request('/orgs/sites', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          orgId: '11111111-1111-1111-1111-111111111111',
+          name: 'Mars-HQ',
+          timezone: 'Mars/Olympus_Mons'
+        })
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects an invalid contact email format', async () => {
+      setAuthContext({ scope: 'organization', orgId: '11111111-1111-1111-1111-111111111111' });
+
+      const res = await app.request('/orgs/sites', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          orgId: '11111111-1111-1111-1111-111111111111',
+          name: 'HQ',
+          contact: { email: 'not-an-email' }
+        })
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('accepts a phone-only contact (no email)', async () => {
+      setAuthContext({ scope: 'organization', orgId: '11111111-1111-1111-1111-111111111111' });
+      vi.mocked(db.insert).mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: 'site-3', name: 'Site C' }])
+        })
+      } as any);
+
+      const res = await app.request('/orgs/sites', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          orgId: '11111111-1111-1111-1111-111111111111',
+          name: 'Site C',
+          contact: { phone: '555-1212' }
+        })
+      });
+
+      expect(res.status).toBe(201);
+    });
+
+    it('accepts a contact with empty-string email (form sends empty for absent)', async () => {
+      setAuthContext({ scope: 'organization', orgId: '11111111-1111-1111-1111-111111111111' });
+      vi.mocked(db.insert).mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: 'site-4', name: 'Site D' }])
+        })
+      } as any);
+
+      const res = await app.request('/orgs/sites', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          orgId: '11111111-1111-1111-1111-111111111111',
+          name: 'Site D',
+          contact: { name: 'Ops', email: '', phone: '+1 555 1212' }
+        })
+      });
+
+      expect(res.status).toBe(201);
+    });
   });
 
   describe('GET /orgs/sites/:id', () => {

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -63,17 +63,47 @@ const listSitesSchema = z.object({
   limit: z.string().optional()
 });
 
+// Timezone validation defers to the JS engine: a string is a valid timezone
+// iff Intl.DateTimeFormat accepts it as a `timeZone` option. This covers
+// every named IANA zone (e.g. America/Los_Angeles), the special aliases UTC
+// and GMT, and the Etc/* synthetic zones — all of which Intl.supportedValuesOf
+// notably omits, so a Set-membership check against that list incorrectly
+// rejects 'UTC' (the form's default). Constructor cost is negligible on
+// invalid input; the engine throws RangeError fast. Centralized inline
+// rather than extracted to a shared validator until a second use-site
+// materializes (likely org settings); see Discussion #628.
+function isValidIanaTimezone(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Contact JSONB is stored as-is for forward compatibility, but the recognized
+// fields are validated. Email format is policed when present so that
+// `mailto:` consumers downstream don't render garbage. Extra fields beyond
+// name/email/phone pass through. Discussion #628.
+const siteContactSchema = z
+  .object({
+    name: z.string().optional(),
+    email: z.union([z.string().email(), z.literal('')]).optional(),
+    phone: z.string().optional(),
+  })
+  .passthrough();
+
 const siteBaseSchema = z.object({
   orgId: z.string().uuid(),
   name: z.string().min(1),
   address: z.any().optional(),
-  timezone: z.string().optional(),
-  contact: z.any().optional(),
+  timezone: z.string().refine(isValidIanaTimezone, 'Invalid IANA timezone').optional(),
+  contact: siteContactSchema.optional(),
   settings: z.any().optional()
 });
 
 const createSiteSchema = siteBaseSchema.extend({
-  timezone: z.string().default('UTC')
+  timezone: z.string().refine(isValidIanaTimezone, 'Invalid IANA timezone').default('UTC')
 });
 
 const updateSiteSchema = siteBaseSchema.partial().omit({ orgId: true });

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -63,15 +63,10 @@ const listSitesSchema = z.object({
   limit: z.string().optional()
 });
 
-// Timezone validation defers to the JS engine: a string is a valid timezone
-// iff Intl.DateTimeFormat accepts it as a `timeZone` option. This covers
-// every named IANA zone (e.g. America/Los_Angeles), the special aliases UTC
-// and GMT, and the Etc/* synthetic zones — all of which Intl.supportedValuesOf
-// notably omits, so a Set-membership check against that list incorrectly
-// rejects 'UTC' (the form's default). Constructor cost is negligible on
-// invalid input; the engine throws RangeError fast. Centralized inline
-// rather than extracted to a shared validator until a second use-site
-// materializes (likely org settings); see Discussion #628.
+// Intl.supportedValuesOf('timeZone') omits UTC, GMT, and the Etc/* zones, so
+// a Set-membership check against that list rejects 'UTC' (the default).
+// Constructing Intl.DateTimeFormat throws RangeError on unknown zones and
+// accepts everything Intl recognizes, including those omissions.
 function isValidIanaTimezone(tz: string): boolean {
   try {
     new Intl.DateTimeFormat('en-US', { timeZone: tz });
@@ -81,10 +76,10 @@ function isValidIanaTimezone(tz: string): boolean {
   }
 }
 
-// Contact JSONB is stored as-is for forward compatibility, but the recognized
-// fields are validated. Email format is policed when present so that
-// `mailto:` consumers downstream don't render garbage. Extra fields beyond
-// name/email/phone pass through. Discussion #628.
+// Stored as-is into a JSONB column; `.passthrough()` keeps unknown keys for
+// forward compatibility. Email format is policed when present so downstream
+// `mailto:` consumers don't render garbage; empty string is accepted because
+// the form sends `''` for an absent value.
 const siteContactSchema = z
   .object({
     name: z.string().optional(),

--- a/apps/web/src/components/settings/SiteForm.tsx
+++ b/apps/web/src/components/settings/SiteForm.tsx
@@ -3,15 +3,10 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 
-// Only `name` is required by the API and the database (timezone defaults to
-// 'UTC' server-side). The form previously over-validated by marking 10 fields
-// as required, blocking legitimate cases like cloud-only sites, remote
-// employee home offices, and day-one onboarding where the operator wants to
-// fill in address/contact later. Discussion #628.
-//
-// Contact email is allowed to be empty; if the user enters something, it must
-// be a valid email format. Contact phone has no length floor — phones are
-// stored as-is and not format-validated elsewhere in the codebase.
+// Only `name` is required server-side (timezone defaults to 'UTC' in the API).
+// The empty-string branch on contactEmail is load-bearing: react-hook-form
+// sends `''` for unfilled inputs, so `z.string().email().optional()` alone
+// would block submit on a name-only form.
 const siteSchema = z.object({
   name: z.string().min(1, 'Site name is required'),
   timezone: z.string().optional(),

--- a/apps/web/src/components/settings/SiteForm.tsx
+++ b/apps/web/src/components/settings/SiteForm.tsx
@@ -3,18 +3,27 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 
+// Only `name` is required by the API and the database (timezone defaults to
+// 'UTC' server-side). The form previously over-validated by marking 10 fields
+// as required, blocking legitimate cases like cloud-only sites, remote
+// employee home offices, and day-one onboarding where the operator wants to
+// fill in address/contact later. Discussion #628.
+//
+// Contact email is allowed to be empty; if the user enters something, it must
+// be a valid email format. Contact phone has no length floor — phones are
+// stored as-is and not format-validated elsewhere in the codebase.
 const siteSchema = z.object({
   name: z.string().min(1, 'Site name is required'),
-  timezone: z.string().min(1, 'Timezone is required'),
-  addressLine1: z.string().min(1, 'Address line 1 is required'),
+  timezone: z.string().optional(),
+  addressLine1: z.string().optional(),
   addressLine2: z.string().optional(),
-  city: z.string().min(1, 'City is required'),
-  state: z.string().min(1, 'State/Region is required'),
-  postalCode: z.string().min(1, 'Postal code is required'),
-  country: z.string().min(1, 'Country is required'),
-  contactName: z.string().min(1, 'Contact name is required'),
-  contactEmail: z.string().email('Enter a valid email address'),
-  contactPhone: z.string().min(7, 'Enter a phone number')
+  city: z.string().optional(),
+  state: z.string().optional(),
+  postalCode: z.string().optional(),
+  country: z.string().optional(),
+  contactName: z.string().optional(),
+  contactEmail: z.union([z.string().email('Enter a valid email address'), z.literal('')]).optional(),
+  contactPhone: z.string().optional()
 });
 
 type SiteFormValues = z.infer<typeof siteSchema>;
@@ -78,6 +87,9 @@ export default function SiteForm({
       })}
       className="space-y-6 rounded-lg border bg-card p-6 shadow-sm"
     >
+      <p className="text-sm text-muted-foreground">
+        Only the site name is required. Address and contact are optional — you can fill these in later.
+      </p>
       <div className="grid gap-6 md:grid-cols-2">
         <div className="space-y-2">
           <label htmlFor="site-name" className="text-sm font-medium">


### PR DESCRIPTION
Implements the relaxations from [Discussion #628](https://github.com/LanternOps/breeze/discussions/628) (@ToddHebebrand green-lit 2026-05-14T18:55:26Z).

## What changed

### Web: `SiteForm.tsx` — drop over-validation

The form previously required **ten** fields: name, timezone, address line 1, city, state, postal code, country, contact name, contact email (format-validated), and contact phone (min 7 chars). The API + DB only need `name`; everything else is nullable or has a server-side default.

Relaxed the form schema so only `name` is required. Contact email is allowed to be empty; if present, format is still validated. Contact phone has no length floor — phones are stored as-is and not format-validated anywhere else in the codebase.

Added a single hint line at the top of the form:
> Only the site name is required. Address and contact are optional — you can fill these in later.

### API: `orgs.ts` — tighten timezone + contact, defense in depth

`siteBaseSchema.timezone` previously accepted any string. Now refines through a JS-engine check (`new Intl.DateTimeFormat('en-US', { timeZone })` throws `RangeError` on invalid IANA names). This intentionally accepts UTC and `Etc/*` zones that `Intl.supportedValuesOf('timeZone')` notably omits — verified empirically: `Intl.supportedValuesOf('timeZone')` returns 418 entries with **no** UTC variant, so a Set-membership check would incorrectly reject the form's default `'UTC'`.

`contact` was previously `z.any().optional()` — anything went. Now a `z.object({ name?, email?, phone? }).passthrough().optional()` with email format policed when present, empty string accepted (form sends `''` for absent), extra fields passed through to keep the JSONB column forward-compatible. Defense in depth so non-form callers can't poison `mailto:` consumers with malformed email values.

### Tests

Added 5 cases to `apps/api/src/routes/orgs.test.ts`:
- name-only POST → 201
- timezone `'Mars/Olympus_Mons'` → 400
- contact `{ email: 'not-an-email' }` → 400
- contact `{ phone: '555-1212' }` (phone-only) → 201
- contact `{ name, email: '', phone }` (empty email) → 201

No `SiteForm.test.tsx` added — Discussion #628 review path is API contract; form-only schema test would be redundant.

## Per Todd's review

- **name**: required ✓
- **timezone**: optional in zod, IANA-validated when present (via JS-engine acceptance check, see comment block for why I avoided `Intl.supportedValuesOf`)
- **Contact email**: format-validated when present, empty allowed
- **Contact phone**: `min(7)` dropped entirely, no format validation
- **Address fields**: all optional
- **Hint copy**: added at top of form

## Scope decisions

- IANA validator kept inline in `orgs.ts` (not extracted to `packages/shared`). Only one use-site needs it today; YAGNI. Extract when org-settings timezone validation lands in a follow-up.
- Contact JSONB shape uses `.passthrough()` so unknown keys still flow through to storage.
- No DB migration — `sites.address` and `sites.contact` are already nullable JSONB.

## Verification

- `apps/api`: `npx tsc --noEmit` 0 errors. `npx vitest run` (unit, excluding integration/rls) **4266/4266 pass**, 28 skipped. `eslint` clean on changed files.
- `apps/web`: `npx tsc --noEmit` 0 errors. `npx astro check` 0 errors / 0 warnings. `eslint` clean on `SiteForm.tsx`.
- Empirical Intl check: `Intl.supportedValuesOf('timeZone').filter(z => /UTC|Etc/i.test(z))` returned `[]` on local Node 22; switched to the `new Intl.DateTimeFormat` accept-check pattern after that.
- Mobile audit: `grep -rn '/orgs/sites' apps/mobile/src` empty — no mobile callers to break.

## Test plan

- [ ] Open Add Site modal → verify hint copy at top.
- [ ] Submit with just a name → 201, site created, defaults to UTC.
- [ ] Try invalid timezone via curl → 400.
- [ ] Contact `{ email: 'bad' }` via curl → 400.
- [ ] Contact `{ phone: '555' }` via curl → 201.