### PR TITLE
fix(api,agent): truncate connection inventory strings to column widths (#504)

### DIFF
--- a/agent/internal/collectors/connections.go
+++ b/agent/internal/collectors/connections.go
@@ -19,3 +19,17 @@ type ConnectionsCollector struct{}
 func NewConnectionsCollector() *ConnectionsCollector {
 	return &ConnectionsCollector{}
 }
+
+// sanitizeConnectionInfo trims and length-bounds every string field so the
+// payload never carries values that would overflow the API's column widths
+// (state varchar(20), process_name varchar(255)). The server also clamps
+// defensively (see apps/api/src/routes/agents/connections.ts), but doing
+// it here saves bandwidth on chatty Linux containers. See #504.
+func sanitizeConnectionInfo(conn ConnectionInfo) ConnectionInfo {
+	conn.Protocol = truncateCollectorString(conn.Protocol)
+	conn.LocalAddr = truncateCollectorString(conn.LocalAddr)
+	conn.RemoteAddr = truncateCollectorString(conn.RemoteAddr)
+	conn.State = truncateCollectorString(conn.State)
+	conn.ProcessName = truncateCollectorString(conn.ProcessName)
+	return conn
+}

--- a/agent/internal/collectors/connections_darwin.go
+++ b/agent/internal/collectors/connections_darwin.go
@@ -221,12 +221,3 @@ func (c *ConnectionsCollector) parseAddress(addr string) (string, int) {
 
 	return addr, 0
 }
-
-func sanitizeConnectionInfo(conn ConnectionInfo) ConnectionInfo {
-	conn.Protocol = truncateCollectorString(conn.Protocol)
-	conn.LocalAddr = truncateCollectorString(conn.LocalAddr)
-	conn.RemoteAddr = truncateCollectorString(conn.RemoteAddr)
-	conn.State = truncateCollectorString(conn.State)
-	conn.ProcessName = truncateCollectorString(conn.ProcessName)
-	return conn
-}

--- a/agent/internal/collectors/connections_linux.go
+++ b/agent/internal/collectors/connections_linux.go
@@ -37,7 +37,7 @@ func (c *ConnectionsCollector) Collect() ([]ConnectionInfo, error) {
 		}
 
 		if info := c.mapConnection(conn, processName); info != nil {
-			connections = append(connections, *info)
+			connections = append(connections, sanitizeConnectionInfo(*info))
 		}
 	}
 

--- a/agent/internal/collectors/connections_windows.go
+++ b/agent/internal/collectors/connections_windows.go
@@ -38,7 +38,7 @@ func (c *ConnectionsCollector) Collect() ([]ConnectionInfo, error) {
 			}
 		}
 
-		connections = append(connections, ConnectionInfo{
+		connections = append(connections, sanitizeConnectionInfo(ConnectionInfo{
 			Protocol:    protocol,
 			LocalAddr:   conn.Laddr.IP,
 			LocalPort:   int(conn.Laddr.Port),
@@ -47,7 +47,7 @@ func (c *ConnectionsCollector) Collect() ([]ConnectionInfo, error) {
 			State:       conn.Status,
 			Pid:         int(conn.Pid),
 			ProcessName: processName,
-		})
+		}))
 	}
 
 	return connections, nil

--- a/apps/api/src/routes/agents/connections.test.ts
+++ b/apps/api/src/routes/agents/connections.test.ts
@@ -234,6 +234,62 @@ describe('connections routes', () => {
       expect(res.status).toBe(400);
     });
 
+    it('truncates oversized state/processName/addr to column widths (#504)', async () => {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: DEVICE_ID, agentId: AGENT_ID, orgId: 'org-1' }]),
+          }),
+        }),
+      } as any);
+
+      let insertedValues: any;
+      vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
+        const tx = {
+          delete: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(undefined),
+          }),
+          insert: vi.fn().mockReturnValue({
+            values: vi.fn().mockImplementation((rows: any) => {
+              insertedValues = rows;
+              return Promise.resolve(undefined);
+            }),
+          }),
+        };
+        return fn(tx);
+      });
+
+      const longProcessName = 'x'.repeat(500);
+      const longState = 'ESTABLISHED_WITH_LINGER_AND_EXTRAS';
+      const longAddr = 'fe80::1234:5678:9abc:def0%' + 'a'.repeat(200);
+
+      const res = await app.request(`/agents/${AGENT_ID}/connections`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          connections: [
+            {
+              protocol: 'tcp',
+              localAddr: longAddr,
+              localPort: 443,
+              remoteAddr: longAddr,
+              remotePort: 54321,
+              state: longState,
+              pid: 1234,
+              processName: longProcessName,
+            },
+          ],
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(insertedValues).toHaveLength(1);
+      expect(insertedValues[0].state.length).toBeLessThanOrEqual(20);
+      expect(insertedValues[0].processName.length).toBeLessThanOrEqual(255);
+      expect(insertedValues[0].localAddr.length).toBeLessThanOrEqual(128);
+      expect(insertedValues[0].remoteAddr.length).toBeLessThanOrEqual(128);
+    });
+
     it('should accept all valid protocol types', async () => {
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn().mockReturnValue({

--- a/apps/api/src/routes/agents/connections.ts
+++ b/apps/api/src/routes/agents/connections.ts
@@ -7,6 +7,25 @@ import { devices, deviceConnections } from '../../db/schema';
 import { captureException } from '../../services/sentry';
 import { submitConnectionsSchema } from './schemas';
 
+// Hard caps that match the device_connections column widths. Agent
+// collectors emit kernel-bound values (TCP states, /proc comm names) that
+// normally fit, but older or non-darwin agents skip sanitization and can
+// occasionally egress oversized strings — see #504. Truncating here keeps
+// the insert from blowing up with 22001 "value too long for type" and
+// removes an entire class of 500s regardless of agent version.
+const STATE_MAX = 20;
+const PROCESS_NAME_MAX = 255;
+const ADDR_MAX = 128; // local_addr / remote_addr are text; cap for sanity (e.g. IPv6 zone IDs)
+
+function clampNullable(value: string | null | undefined, max: number): string | null {
+  if (value === null || value === undefined || value === '') return null;
+  return value.length > max ? value.slice(0, max) : value;
+}
+
+function clampRequired(value: string, max: number): string {
+  return value.length > max ? value.slice(0, max) : value;
+}
+
 export const connectionsRoutes = new Hono();
 
 connectionsRoutes.put(
@@ -40,13 +59,13 @@ connectionsRoutes.put(
             deviceId: device.id,
             orgId: device.orgId,
             protocol: conn.protocol,
-            localAddr: conn.localAddr,
+            localAddr: clampRequired(conn.localAddr, ADDR_MAX),
             localPort: conn.localPort,
-            remoteAddr: conn.remoteAddr || null,
+            remoteAddr: clampNullable(conn.remoteAddr, ADDR_MAX),
             remotePort: conn.remotePort || null,
-            state: conn.state || null,
+            state: clampNullable(conn.state, STATE_MAX),
             pid: conn.pid || null,
-            processName: conn.processName || null,
+            processName: clampNullable(conn.processName, PROCESS_NAME_MAX),
             updatedAt: now
           }))
         );


### PR DESCRIPTION
## Summary
- Fixes #504 — `PUT /agents/:id/connections` returned 500 on Linux agent inventory when a collected value overflowed a `device_connections` column (`state varchar(20)`, `process_name varchar(255)`), i.e. Postgres `22001 value too long for type`. The darwin collector sanitized strings; Linux/Windows did not.
- **Server**: defensively clamp `state` / `processName` / `localAddr` / `remoteAddr` to column widths before INSERT. This unblocks affected self-host users (SemoTech) immediately, with no agent fleet upgrade required, and removes the whole "value too long" class of 500s.
- **Agent**: hoisted `sanitizeConnectionInfo` to the platform-neutral collector file and wired it into the Linux and Windows collectors so oversized values aren't egressed at all (defense-in-depth + bandwidth).
- The existing pg-error diagnostic logging stays in place, so if a *different* root cause (FK race, RLS, statement timeout) surfaces post-fix it will still be captured.

## Test plan
- [x] `vitest run apps/api/src/routes/agents/connections.test.ts` — 10/10 pass, incl. new truncation test
- [x] `npx tsc --noEmit -p apps/api/tsconfig.json` clean
- [x] `GOOS=linux go build ./internal/collectors/...` and `GOOS=windows` clean
- [ ] Smoke: confirm a Linux agent with >400 connections completes the connections inventory without a 500 on a build with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)