### PR TITLE
fix(web): Sites pane on Organizations & Sites follows in-page org (#709)

### DIFF
--- a/apps/web/src/components/settings/OrganizationsPage.test.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import OrganizationsPage from './OrganizationsPage';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: {
+    getState: () => ({ fetchOrganizations: vi.fn() }),
+  },
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('@/lib/apiError', () => ({
+  extractApiError: (err: unknown) => (err instanceof Error ? err.message : 'error'),
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const jsonResponse = (payload: unknown, status = 200): Response =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'OK',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+const ORG_A = { id: 'org-a-uuid', name: 'Org A', status: 'active', slug: 'org-a', deviceCount: 0 };
+const ORG_B = { id: 'org-b-uuid', name: 'Org B', status: 'active', slug: 'org-b', deviceCount: 0 };
+
+describe('OrganizationsPage — fetchSites URL contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockImplementation(async (url) => {
+      if (url === '/orgs/organizations') {
+        return jsonResponse({ data: [ORG_A, ORG_B] });
+      }
+      if (typeof url === 'string' && url.startsWith('/orgs/sites?')) {
+        return jsonResponse({ data: [] });
+      }
+      return jsonResponse({});
+    });
+  });
+
+  it('passes orgId= (not organizationId=) so fetchWithAuth auto-injection cannot double-set it', async () => {
+    render(<OrganizationsPage />);
+    await screen.findByTestId(`org-row-${ORG_B.id}`);
+    fireEvent.click(screen.getByTestId(`org-row-${ORG_B.id}`));
+
+    await waitFor(() => {
+      const sitesCalls = fetchMock.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && (c[0] as string).startsWith('/orgs/sites?'),
+      );
+      expect(sitesCalls.length).toBeGreaterThan(0);
+      const url = sitesCalls[sitesCalls.length - 1][0] as string;
+      expect(url).toContain(`orgId=${ORG_B.id}`);
+      expect(url).not.toContain(`organizationId=`);
+    });
+  });
+});

--- a/apps/web/src/components/settings/OrganizationsPage.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.tsx
@@ -111,7 +111,8 @@ export default function OrganizationsPage() {
   const fetchSites = useCallback(async (orgId: string) => {
     setSitesLoading(true);
     try {
-      const response = await fetchWithAuth(`/orgs/sites?organizationId=${orgId}`);
+      // organizationId= alias slips past fetchWithAuth's orgId= auto-injection guard.
+      const response = await fetchWithAuth(`/orgs/sites?orgId=${orgId}`);
       if (!response.ok) throw new Error('Failed to fetch sites');
       const data = await response.json();
       const siteList = Array.isArray(data?.data) ? data.data : Array.isArray(data) ? data : [];

--- a/apps/web/src/stores/orgStore.test.ts
+++ b/apps/web/src/stores/orgStore.test.ts
@@ -65,7 +65,7 @@ describe('org store', () => {
     await flushAsync();
 
     expect(fetchWithAuthMock).toHaveBeenCalledWith('/orgs/organizations?partnerId=partner-1');
-    expect(fetchWithAuthMock).toHaveBeenCalledWith('/orgs/sites?organizationId=org-1');
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/orgs/sites?orgId=org-1');
     expect(useOrgStore.getState().currentOrgId).toBe('org-1');
     expect(useOrgStore.getState().sites).toHaveLength(1);
     expect(getCurrentOrganization()?.id).toBe('org-1');
@@ -113,7 +113,7 @@ describe('org store', () => {
 
     await useOrgStore.getState().fetchSites();
 
-    expect(fetchWithAuthMock).toHaveBeenCalledWith('/orgs/sites?organizationId=org-1');
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/orgs/sites?orgId=org-1');
     expect(getCurrentSite()?.id).toBe('site-1');
   });
 

--- a/apps/web/src/stores/orgStore.ts
+++ b/apps/web/src/stores/orgStore.ts
@@ -169,7 +169,7 @@ export const useOrgStore = create<OrgState>()(
 
         set({ isLoading: true, error: null });
         try {
-          const response = await fetchWithAuth(`/orgs/sites?organizationId=${currentOrgId}`);
+          const response = await fetchWithAuth(`/orgs/sites?orgId=${currentOrgId}`);
           if (!response.ok) {
             throw new Error('Failed to fetch sites');
           }


### PR DESCRIPTION
Closes/implements [Discussion #709](https://github.com/LanternOps/breeze/discussions/709). Green-lit by @ToddHebebrand.

## Root cause

`fetchWithAuth` (`apps/web/src/stores/auth.ts:268-275`) auto-injects \`orgId=<currentOrgId>\` whenever the URL does not already contain the literal substring \`orgId=\`. Two call sites (`OrganizationsPage.fetchSites`, `orgStore.fetchSites`) used the alias \`organizationId=\`. The injector did not see it and appended \`&orgId=<top-bar-org>\` to every request.

The API at \`apps/api/src/routes/orgs.ts:921-924\` then resolved:

\`\`\`ts
const effectiveOrgId = orgId || organizationId; // top-bar wins
\`\`\`

Page heading is local React state and stays correct — divergence is invisible in code review.

## Fix

Rename both call sites to \`orgId=\` so the injector sees them and skips re-adding the top-bar context.

## Tests

Both call sites covered per the review request:

- **\`orgStore.test.ts\`** — existing \`fetchSites\` assertions updated to expect \`/orgs/sites?orgId=org-1\`.
- **\`OrganizationsPage.test.tsx\` (new)** — renders the page, clicks a non-default org in the left list, asserts the captured Sites request URL contains \`orgId=<in-page-org-uuid>\` and does NOT contain \`organizationId=\`.

## Verification

- \`npx tsc --noEmit\` clean.
- \`npx vitest run src/components/settings/OrganizationsPage.test.tsx\` — 1 passed.
- \`pnpm audit --audit-level=critical\` — 1 moderate + 1 high on main (same cross-PR upstream-image blocker tracked in #680/#700/#705); not introduced by this branch.