### PR TITLE
fix(web,api): persist user role change in Settings → Users + .strict() guard (#710)

### DIFF
--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -396,6 +396,29 @@ describe('user routes', () => {
     });
   });
 
+  describe('PATCH /users/:id (admin update)', () => {
+    it('rejects unknown top-level fields including roleId (strict schema)', async () => {
+      // The Edit dialog historically sent { email, name, roleId } and roleId was
+      // silently dropped because updateUserSchema lacked .strict(). After the
+      // hardening, the extra field must surface as 400 instead of a no-op 200.
+      const res = await app.request('/users/11111111-1111-1111-1111-111111111111', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ name: 'New Name', roleId: '22222222-2222-2222-2222-222222222222' })
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects an arbitrary extra field (strict schema, defense in depth)', async () => {
+      const res = await app.request('/users/11111111-1111-1111-1111-111111111111', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ name: 'New Name', mysteryField: 'oops' })
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
   describe('POST /users/:id/role', () => {
     it('should assign a partner role', async () => {
       vi.mocked(db.select)

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -70,10 +70,12 @@ const resendInviteSchema = z.object({
   userId: z.string().uuid()
 });
 
+// .strict() so unknown keys surface as 400, not silently dropped. Role is not
+// updatable via this endpoint — POST /users/:id/role writes the join-table row.
 const updateUserSchema = z.object({
   name: z.string().min(1).max(255).optional(),
   status: z.enum(['active', 'invited', 'disabled']).optional()
-});
+}).strict();
 
 const assignRoleSchema = z.object({
   roleId: z.string().uuid()

--- a/apps/web/src/components/settings/UsersPage.test.tsx
+++ b/apps/web/src/components/settings/UsersPage.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import UsersPage from './UsersPage';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: (sel: (s: { user: { id: string } | null }) => unknown) => sel({ user: { id: 'me' } }),
+}));
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: (sel: (s: { organizations: unknown[] }) => unknown) => sel({ organizations: [] }),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const jsonResponse = (payload: unknown, status = 200): Response =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'OK',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+const ROLE_ADMIN = { id: 'role-admin-uuid', name: 'Partner Admin', scope: 'partner' };
+const ROLE_TECH = { id: 'role-tech-uuid', name: 'Partner Technician', scope: 'partner' };
+
+const TREVOR = {
+  id: 'user-trevor-uuid',
+  name: 'Trevor',
+  email: 'trevor@example.com',
+  roleName: 'Partner Admin',
+  status: 'active',
+};
+
+function seedUsersAndRoles() {
+  fetchMock.mockImplementation(async (url, opts) => {
+    const method = (opts as RequestInit | undefined)?.method ?? 'GET';
+    if (url === '/users' && method === 'GET') {
+      return jsonResponse({ data: [TREVOR] });
+    }
+    if (url === '/users/roles' && method === 'GET') {
+      return jsonResponse({ data: [ROLE_ADMIN, ROLE_TECH] });
+    }
+    if (typeof url === 'string' && url.startsWith('/users/') && method === 'PATCH') {
+      return jsonResponse({ success: true });
+    }
+    if (typeof url === 'string' && url.endsWith('/role') && method === 'POST') {
+      return jsonResponse({ success: true });
+    }
+    return jsonResponse({});
+  });
+}
+
+describe('UsersPage — handleEditSubmit role-change contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    seedUsersAndRoles();
+  });
+
+  it('POSTs /users/:id/role with the new roleId when the role is changed', async () => {
+    render(<UsersPage />);
+    await screen.findByText('Trevor');
+
+    // Click Edit for Trevor (the only user).
+    fireEvent.click(screen.getByRole('button', { name: /^edit$/i }));
+    await screen.findByLabelText(/^Role$/);
+
+    // Change role to Technician.
+    fireEvent.change(screen.getByLabelText(/^Role$/), { target: { value: ROLE_TECH.id } });
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      const roleCalls = fetchMock.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && (c[0] as string).endsWith('/role'),
+      );
+      expect(roleCalls.length).toBe(1);
+      const [url, opts] = roleCalls[0];
+      expect(url).toBe(`/users/${TREVOR.id}/role`);
+      expect((opts as RequestInit).method).toBe('POST');
+      expect((opts as RequestInit).body).toBe(JSON.stringify({ roleId: ROLE_TECH.id }));
+    });
+  });
+
+  it('does NOT POST /users/:id/role when the role is unchanged (name-only edit)', async () => {
+    render(<UsersPage />);
+    await screen.findByText('Trevor');
+
+    fireEvent.click(screen.getByRole('button', { name: /^edit$/i }));
+    await screen.findByLabelText(/^Role$/);
+
+    // Leave role at its existing value (Partner Admin, defaultValue matches).
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      // PATCH /users/:id is expected (name still sent).
+      const patchCalls = fetchMock.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && (c[0] as string) === `/users/${TREVOR.id}`,
+      );
+      expect(patchCalls.length).toBe(1);
+    });
+
+    const roleCalls = fetchMock.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && (c[0] as string).endsWith('/role'),
+    );
+    expect(roleCalls.length).toBe(0);
+  });
+});

--- a/apps/web/src/components/settings/UsersPage.tsx
+++ b/apps/web/src/components/settings/UsersPage.tsx
@@ -199,13 +199,29 @@ export default function UsersPage() {
 
     setSubmitting(true);
     try {
-      const response = await fetchWithAuth(`/users/${selectedUser.id}`, {
+      // Name/status update — schema is .strict() so only declared keys are accepted.
+      const patchRes = await fetchWithAuth(`/users/${selectedUser.id}`, {
         method: 'PATCH',
-        body: JSON.stringify(values)
+        body: JSON.stringify({ name: values.name })
       });
-
-      if (!response.ok) {
+      if (!patchRes.ok) {
         throw new Error('Failed to update user');
+      }
+
+      // Role lives on partner_users / organization_users; the dedicated
+      // POST /users/:id/role endpoint writes it. selectedUser.role is the
+      // role name (display string), not the id — resolve via the roles list.
+      // Only POST when the role actually changed to avoid an unnecessary
+      // audit-log entry on name-only edits.
+      const currentRoleId = roles.find(r => r.name === selectedUser.role)?.id;
+      if (values.roleId && values.roleId !== currentRoleId) {
+        const roleRes = await fetchWithAuth(`/users/${selectedUser.id}/role`, {
+          method: 'POST',
+          body: JSON.stringify({ roleId: values.roleId })
+        });
+        if (!roleRes.ok) {
+          throw new Error('Failed to update role');
+        }
       }
 
       await fetchUsers();


### PR DESCRIPTION
Closes/implements [Discussion #710](https://github.com/LanternOps/breeze/discussions/710). Green-lit by @ToddHebebrand with the role-id-by-name correction folded in.

## Root cause

\`updateUserSchema\` (\`apps/api/src/routes/users.ts:73-76\`) was not \`.strict()\`, so the Edit dialog's PATCH body \`{ email, name, roleId }\` silently dropped \`roleId\` before the handler ever saw it. Handler returned 200 with \`name\` as a no-op, \`fetchUsers()\` re-rendered the unchanged row, user appeared to "save" without error. Role only persists via \`POST /users/:id/role\`, which the Edit flow never called.

## Changes

1. **\`.strict()\` on \`updateUserSchema\`** — unknown keys surface as 400 instead of silently dropped. Defense in depth so the next silently-dropped field doesn't reproduce the same class of bug.

2. **\`handleEditSubmit\` in \`UsersPage.tsx\`** splits into:
   - PATCH \`/users/:id\` with \`{ name }\` only (schema-valid)
   - Conditional POST \`/users/:id/role\` with \`{ roleId }\` **only when the role actually changed**. \`selectedUser\` carries the role *name*, not the id — resolved via \`roles.find(r => r.name === selectedUser.role)?.id\` per your correction.

3. **PATCH and POST are independent** — role POST errors surface to the user; the name PATCH is not silently swallowed.

## Tests

- **\`apps/web/src/components/settings/UsersPage.test.tsx\` (new)**:
  - "POSTs \`/users/:id/role\` with the new roleId when the role is changed"
  - "does NOT POST \`/users/:id/role\` when the role is unchanged (name-only edit)"

- **\`apps/api/src/routes/users.test.ts\` (added)** under a new \`PATCH /users/:id (admin update)\` describe:
  - "rejects unknown top-level fields including roleId (strict schema)" — asserts 400
  - "rejects an arbitrary extra field (strict schema, defense in depth)" — asserts 400

## Verification

- \`apps/api\`: \`npx tsc --noEmit\` clean. \`vitest run src/routes/users.test.ts\` — **14/14 passed** (12 existing + 2 new).
- \`apps/web\`: \`npx tsc --noEmit\` clean. \`vitest run UsersPage.test.tsx\` — **2/2 passed**.
- \`pnpm audit --audit-level=critical\` — 1 moderate + 1 high pre-existing on \`main\` (same cross-PR upstream-image blocker tracked in #680/#700/#705/#712); not introduced by this branch.