### PR TITLE
fix(api): scripts.is_system rows visible to partner-scope and org-scope readers (#633)

### DIFF
--- a/apps/api/migrations/2026-05-15-scripts-is-system-rls-select.sql
+++ b/apps/api/migrations/2026-05-15-scripts-is-system-rls-select.sql
@@ -1,0 +1,25 @@
+-- 2026-05-15: Allow is_system=true scripts to be visible to partner-scope
+-- and org-scope readers.
+--
+-- Background: the SELECT policy at apps/api/migrations/0001-baseline.sql:17710
+-- is breeze_org_isolation_select USING (breeze_has_org_access(org_id)).
+-- System scripts are stored with is_system=true, org_id=NULL, and
+-- breeze_has_org_access(NULL) returns FALSE for every non-system scope
+-- (function body at 0001-baseline.sql, definition near line 1663). System
+-- scripts were therefore invisible to partner-scope and org-scope readers —
+-- they could only be SELECTed under system DB context.
+--
+-- INSERT/UPDATE/DELETE policies are unchanged; system-row writes continue
+-- via withSystemDbAccessContext from system-scope handlers (the existing
+-- pattern that scripts.is_system writes already use today).
+--
+-- Idempotent: same-name drop-and-recreate of a deterministic policy.
+-- Re-running converges to the same final state. autoMigrate wraps each
+-- migration file in a transaction, so no inner BEGIN/COMMIT.
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON scripts;
+CREATE POLICY breeze_org_isolation_select ON scripts
+  FOR SELECT USING (
+    is_system = true
+    OR breeze_has_org_access(org_id)
+  );

--- a/apps/api/src/__tests__/integration/scripts-system-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/scripts-system-rls.integration.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Integration test for Discussion #633 — scripts.is_system RLS hole.
+ *
+ * The original SELECT policy on `scripts` was:
+ *   USING (breeze_has_org_access(org_id))
+ * System scripts are stored with is_system=true, org_id=NULL.
+ * breeze_has_org_access(NULL) returns FALSE for every non-system scope
+ * (function body in 0001-baseline.sql). So system scripts were invisible
+ * to partner-scope and org-scope readers — they could only be SELECTed
+ * under system DB context.
+ *
+ * The migration `2026-05-15-scripts-is-system-rls-select.sql` replaces
+ * the SELECT policy with:
+ *   USING (is_system = true OR breeze_has_org_access(org_id))
+ *
+ * INSERT/UPDATE/DELETE policies are unchanged. System-row writes still
+ * require system DB context.
+ *
+ * These tests run as the unprivileged `breeze_app` role so RLS is
+ * actually enforced. They prove:
+ *
+ *   1. After the migration, a partner-scope reader sees an is_system row.
+ *      (Without the migration, this read returns 0 rows — the bug.)
+ *   2. After the migration, an org-scope reader sees the same is_system row.
+ *   3. Partner-scope INSERT of {is_system: true, org_id: null} is still
+ *      rejected by RLS — locks that the migration didn't relax writes.
+ */
+import './setup';
+import { describe, it, expect } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext } from '../../db';
+import { scripts } from '../../db/schema';
+import { createPartner, createOrganization } from './db-utils';
+import { getTestDb } from './setup';
+
+describe('scripts.is_system RLS — Discussion #633', () => {
+  it('partner-scope reader sees an is_system=true script (org_id=NULL)', async () => {
+    const partner = await createPartner();
+    const name = `sys-script-partner-${Date.now()}`;
+
+    // Insert the system row under system DB context (existing pattern).
+    await withSystemDbAccessContext(async () => {
+      await db.insert(scripts).values({
+        orgId: null,
+        name,
+        osTypes: ['windows'],
+        language: 'powershell',
+        content: 'Write-Host "noop"',
+        isSystem: true
+      });
+    });
+
+    // Read under partner scope as breeze_app — pre-fix this returned 0 rows.
+    const rows = await withDbAccessContext(
+      {
+        scope: 'partner',
+        orgId: null,
+        accessibleOrgIds: null,
+        accessiblePartnerIds: [partner.id]
+      },
+      async () => db.select().from(scripts).where(eq(scripts.name, name))
+    );
+
+    expect(rows).toHaveLength(1);
+    const row = rows[0]!;
+    expect(row.isSystem).toBe(true);
+    expect(row.orgId).toBeNull();
+  });
+
+  it('org-scope reader sees an is_system=true script (org_id=NULL)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const name = `sys-script-org-${Date.now()}`;
+
+    await withSystemDbAccessContext(async () => {
+      await db.insert(scripts).values({
+        orgId: null,
+        name,
+        osTypes: ['linux'],
+        language: 'bash',
+        content: 'echo noop',
+        isSystem: true
+      });
+    });
+
+    const rows = await withDbAccessContext(
+      {
+        scope: 'organization',
+        orgId: org.id,
+        accessibleOrgIds: [org.id]
+      },
+      async () => db.select().from(scripts).where(eq(scripts.name, name))
+    );
+
+    expect(rows).toHaveLength(1);
+    const row = rows[0]!;
+    expect(row.isSystem).toBe(true);
+  });
+
+  it('partner-scope INSERT of {is_system:true, org_id:null} is still rejected by RLS', async () => {
+    const partner = await createPartner();
+    const attemptedName = `sys-insert-attempt-${Date.now()}`;
+
+    let caught: unknown;
+    try {
+      await withDbAccessContext(
+        {
+          scope: 'partner',
+          orgId: null,
+          accessibleOrgIds: null,
+          accessiblePartnerIds: [partner.id]
+        },
+        async () => {
+          await db.insert(scripts).values({
+            orgId: null,
+            name: attemptedName,
+            osTypes: ['windows'],
+            language: 'powershell',
+            content: 'Write-Host "noop"',
+            isSystem: true
+          });
+        }
+      );
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeDefined();
+    const cause = (caught as { cause?: { message?: string } } | undefined)?.cause;
+    expect(cause?.message).toMatch(
+      /new row violates row-level security policy for table "scripts"/
+    );
+
+    // And confirm via superuser read that no row landed.
+    const rows = await getTestDb()
+      .select()
+      .from(scripts)
+      .where(eq(scripts.name, attemptedName));
+    expect(rows).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes/implements [Discussion #633](https://github.com/LanternOps/breeze/discussions/633). Green-lit by @ToddHebebrand including the idempotency confirmation and inner-BEGIN caveat.

## Root cause

\`scripts\` SELECT policy at \`apps/api/migrations/0001-baseline.sql:17710\`:

\`\`\`sql
CREATE POLICY breeze_org_isolation_select ON public.scripts
  FOR SELECT USING (public.breeze_has_org_access(org_id));
\`\`\`

System scripts are stored with \`is_system=true, org_id=NULL\`. \`breeze_has_org_access(NULL)\` returns FALSE for every non-system scope — verified against the function body in \`0001-baseline.sql\`:

\`\`\`sql
CREATE OR REPLACE FUNCTION public.breeze_has_org_access(target_org_id uuid) RETURNS boolean ...
  SELECT CASE
    WHEN public.breeze_current_scope() = 'system' THEN TRUE
    WHEN target_org_id IS NULL THEN FALSE
    ELSE COALESCE(target_org_id = ANY(public.breeze_accessible_org_ids()), FALSE)
  END;
\`\`\`

System scripts were therefore invisible to partner-scope and org-scope readers — only system DB context could SELECT them. \`grep\` confirmed no later migration replaces the policy.

## Fix

New migration \`apps/api/migrations/2026-05-15-scripts-is-system-rls-select.sql\` replaces the SELECT policy:

\`\`\`sql
DROP POLICY IF EXISTS breeze_org_isolation_select ON scripts;
CREATE POLICY breeze_org_isolation_select ON scripts
  FOR SELECT USING (
    is_system = true
    OR breeze_has_org_access(org_id)
  );
\`\`\`

- **INSERT/UPDATE/DELETE policies unchanged** — system-row writes continue via \`withSystemDbAccessContext\` from system-scope handlers (the existing pattern).
- **Idempotent** — same-name drop-and-recreate of a deterministic policy.
- **No inner \`BEGIN;\`/\`COMMIT;\`** per your caveat; \`autoMigrate\` already wraps each file in a transaction.

## Tests

\`apps/api/src/__tests__/integration/scripts-system-rls.integration.test.ts\` — three cases against the real DB via the existing \`breeze_app\` harness used by \`audit-logs-rls.integration.test.ts\`:

1. **Partner-scope reader sees an \`is_system=true\` script (\`org_id=NULL\`).** Inserts the row under \`withSystemDbAccessContext\`, then SELECTs under partner scope. Without the migration this returns 0 rows — the bug. With the migration it returns the row.
2. **Org-scope reader sees the same row.** Same setup, org scope.
3. **Partner-scope INSERT of \`{is_system:true, org_id:null}\` is still rejected by RLS.** Locks that the migration didn't relax INSERT/UPDATE/DELETE; expects the production RLS error message.

## rls-coverage allowlist

No change required. \`scripts\` is auto-discovered as Shape 1 (direct \`org_id\` column) and the new SELECT policy still references \`breeze_has_org_access\` in the OR branch, so the contract test's semantic check still passes.

## Verification

- \`npx tsc --noEmit -p apps/api/tsconfig.json\` clean.
- **Integration test NOT run locally** — test postgres container (\`docker-compose.test.yml\`) was not up on the build host. Test pattern mirrors \`apps/api/src/__tests__/integration/audit-logs-rls.integration.test.ts\` (same \`getTestDb()\` + \`withDbAccessContext\` + \`withSystemDbAccessContext\` shape). CI's smoke-test job will exercise it.