### PR TITLE
fix(web): action-toast accessibility + flush-on-mount so wake feedback is visible (#720)

### DIFF
--- a/apps/web/src/components/shared/Toast.test.tsx
+++ b/apps/web/src/components/shared/Toast.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ToastContainer, { showToast, _resetToastQueueForTests } from './Toast';
@@ -91,6 +91,40 @@ describe('ToastContainer', () => {
       expect(screen.getByText('between-mounts-message')).toBeInTheDocument();
     });
     expect(screen.getByTestId('toast')).toHaveAttribute('role', 'alert');
+  });
+
+  it('with two mounted containers, a pre-mount queued toast lands in exactly one and the survivor keeps its registration after the other unmounts', async () => {
+    // Model the Astro island duplication / view-transition overlap case:
+    // a toast is queued before any container exists, then two containers
+    // mount, then the older one unmounts. The newer container's
+    // registration must survive.
+    showToast({ type: 'error', message: 'pre-mount-queued' });
+
+    const first = render(<ToastContainer />);
+    const second = render(<ToastContainer />);
+
+    // The pre-mount queued toast lands in exactly one container (the first
+    // to mount drains the shared queue via splice).
+    await waitFor(() => {
+      const allToasts = screen.getAllByTestId('toast');
+      expect(allToasts).toHaveLength(1);
+      expect(allToasts[0]).toHaveTextContent('pre-mount-queued');
+    });
+
+    // Unmount the older container. Under the old cleanup (unconditional
+    // null), this would clobber the second container's registration and
+    // subsequent showToast calls would silently queue instead of render.
+    first.unmount();
+
+    act(() => {
+      showToast({ type: 'success', message: 'after-first-unmount' });
+    });
+
+    await waitFor(() => {
+      expect(
+        within(second.container).getByText('after-first-unmount')
+      ).toBeInTheDocument();
+    });
   });
 
   it('auto-dismisses after the default 5000ms', async () => {

--- a/apps/web/src/components/shared/Toast.test.tsx
+++ b/apps/web/src/components/shared/Toast.test.tsx
@@ -1,0 +1,116 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ToastContainer, { showToast, _resetToastQueueForTests } from './Toast';
+
+describe('ToastContainer', () => {
+  beforeEach(() => {
+    _resetToastQueueForTests();
+  });
+
+  afterEach(() => {
+    _resetToastQueueForTests();
+  });
+
+  it('renders an error toast with role=alert and aria-live=assertive so screen readers and Playwright role-selectors find it', () => {
+    render(<ToastContainer />);
+
+    act(() => {
+      showToast({ type: 'error', message: 'NO_MACS: no MAC on file' });
+    });
+
+    const toast = screen.getByTestId('toast');
+    expect(toast).toHaveAttribute('role', 'alert');
+    expect(toast).toHaveAttribute('aria-live', 'assertive');
+    expect(toast).toHaveAttribute('data-toast-type', 'error');
+    expect(toast).toHaveTextContent('NO_MACS: no MAC on file');
+
+    expect(screen.getByRole('alert')).toBe(toast);
+  });
+
+  it('renders a success toast with role=status and aria-live=polite', () => {
+    render(<ToastContainer />);
+
+    act(() => {
+      showToast({ type: 'success', message: 'Wake packet sent' });
+    });
+
+    const toast = screen.getByTestId('toast');
+    expect(toast).toHaveAttribute('role', 'status');
+    expect(toast).toHaveAttribute('aria-live', 'polite');
+    expect(toast).toHaveAttribute('data-toast-type', 'success');
+    expect(toast).toHaveTextContent('Wake packet sent');
+  });
+
+  it('renders an undo toast with role=status and exposes the Undo button', () => {
+    render(<ToastContainer />);
+    const onUndo = vi.fn();
+
+    act(() => {
+      showToast({ type: 'undo', message: 'Decommissioning...', onUndo });
+    });
+
+    const toast = screen.getByTestId('toast');
+    expect(toast).toHaveAttribute('role', 'status');
+    expect(toast).toHaveAttribute('data-toast-type', 'undo');
+
+    const undoBtn = screen.getByRole('button', { name: /undo/i });
+    expect(undoBtn).toBeInTheDocument();
+  });
+
+  it('flushes toasts queued before the container mounts (avoids silent-drop on early showToast calls)', async () => {
+    // showToast called before any ToastContainer is mounted — the existing
+    // production failure mode was that this silently no-op'd. The queue
+    // change must surface the toast as soon as the container appears.
+    showToast({ type: 'error', message: 'queued-error-message' });
+    showToast({ type: 'success', message: 'queued-success-message' });
+
+    render(<ToastContainer />);
+
+    await waitFor(() => {
+      const toasts = screen.getAllByTestId('toast');
+      expect(toasts).toHaveLength(2);
+    });
+
+    expect(screen.getByText('queued-error-message')).toBeInTheDocument();
+    expect(screen.getByText('queued-success-message')).toBeInTheDocument();
+  });
+
+  it('survives an unmount/remount cycle without losing toasts emitted in the gap', async () => {
+    const { unmount } = render(<ToastContainer />);
+
+    unmount();
+
+    // Emit a toast while no container is mounted (e.g., between Astro view
+    // transitions). It must land when the next container mounts.
+    showToast({ type: 'error', message: 'between-mounts-message' });
+
+    render(<ToastContainer />);
+
+    await waitFor(() => {
+      expect(screen.getByText('between-mounts-message')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('toast')).toHaveAttribute('role', 'alert');
+  });
+
+  it('auto-dismisses after the default 5000ms', async () => {
+    vi.useFakeTimers();
+    try {
+      render(<ToastContainer />);
+
+      act(() => {
+        showToast({ type: 'success', message: 'self-dismissing' });
+      });
+
+      expect(screen.getByTestId('toast')).toBeInTheDocument();
+
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(screen.queryByTestId('toast')).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/web/src/components/shared/Toast.tsx
+++ b/apps/web/src/components/shared/Toast.tsx
@@ -39,13 +39,9 @@ export default function ToastContainer() {
 
   useEffect(() => {
     addToastFn = addToast;
-    // Flush any toasts queued before the container mounted (or between
-    // unmount/remount across an Astro view-transition).
-    while (pendingToasts.length > 0) {
-      const queued = pendingToasts.shift();
-      if (queued) addToast(queued);
-    }
-    return () => { addToastFn = null; };
+    const queued = pendingToasts.splice(0, pendingToasts.length); // snapshot+clear, no destructive drain mid-loop
+    queued.forEach(addToast);
+    return () => { if (addToastFn === addToast) addToastFn = null; }; // don't clobber a newer registration
   }, [addToast]);
 
   const dismiss = (id: string) => {

--- a/apps/web/src/components/shared/Toast.tsx
+++ b/apps/web/src/components/shared/Toast.tsx
@@ -10,16 +10,27 @@ interface ToastData {
 }
 
 let addToastFn: ((toast: Omit<ToastData, 'id'>) => void) | null = null;
+const pendingToasts: Array<Omit<ToastData, 'id'>> = [];
 
 export function showToast(toast: Omit<ToastData, 'id'>) {
-  addToastFn?.(toast);
+  if (addToastFn) {
+    addToastFn(toast);
+  } else {
+    pendingToasts.push(toast);
+  }
+}
+
+// Visible for tests so each case starts with no carried-over queue state.
+export function _resetToastQueueForTests() {
+  pendingToasts.length = 0;
+  addToastFn = null;
 }
 
 export default function ToastContainer() {
   const [toasts, setToasts] = useState<ToastData[]>([]);
 
   const addToast = useCallback((toast: Omit<ToastData, 'id'>) => {
-    const id = Date.now().toString();
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     setToasts(prev => [...prev, { ...toast, id }]);
     setTimeout(() => {
       setToasts(prev => prev.filter(t => t.id !== id));
@@ -28,6 +39,12 @@ export default function ToastContainer() {
 
   useEffect(() => {
     addToastFn = addToast;
+    // Flush any toasts queued before the container mounted (or between
+    // unmount/remount across an Astro view-transition).
+    while (pendingToasts.length > 0) {
+      const queued = pendingToasts.shift();
+      if (queued) addToast(queued);
+    }
     return () => { addToastFn = null; };
   }, [addToast]);
 
@@ -38,44 +55,53 @@ export default function ToastContainer() {
   if (toasts.length === 0) return null;
 
   return (
-    <div className="fixed bottom-6 right-6 z-50 flex flex-col gap-2" role="status" aria-live="polite" aria-atomic="false">
-      {toasts.map(toast => (
-        <div
-          key={toast.id}
-          className={`flex items-center gap-3 rounded-lg border px-4 py-3 shadow-lg animate-in ${
-            toast.type === 'error'
-              ? 'bg-destructive text-destructive-foreground border-destructive/40'
-              : 'bg-card'
-          }`}
-          style={{ minWidth: 280, maxWidth: 400 }}
-        >
-          {toast.type === 'error' ? (
-            <XCircle className="h-4 w-4 shrink-0" />
-          ) : (
-            <CheckCircle className="h-4 w-4 shrink-0 text-success" />
-          )}
-          <span className={`flex-1 text-sm ${toast.type === 'error' ? '' : 'text-foreground'}`}>{toast.message}</span>
-          {toast.type === 'undo' && toast.onUndo && (
-            <button
-              onClick={() => { toast.onUndo?.(); dismiss(toast.id); }}
-              className="flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-primary hover:bg-muted transition-colors"
-            >
-              <Undo2 className="h-3 w-3" />
-              Undo
-            </button>
-          )}
-          <button
-            onClick={() => dismiss(toast.id)}
-            className={`rounded p-0.5 transition-colors ${
-              toast.type === 'error'
-                ? 'text-destructive-foreground/70 hover:text-destructive-foreground'
-                : 'text-muted-foreground hover:text-foreground'
+    <div className="fixed bottom-6 right-6 z-50 flex flex-col gap-2" data-testid="toast-container">
+      {toasts.map(toast => {
+        const isError = toast.type === 'error';
+        return (
+          <div
+            key={toast.id}
+            role={isError ? 'alert' : 'status'}
+            aria-live={isError ? 'assertive' : 'polite'}
+            aria-atomic="true"
+            data-testid="toast"
+            data-toast-type={toast.type}
+            className={`flex items-center gap-3 rounded-lg border px-4 py-3 shadow-lg animate-in ${
+              isError
+                ? 'bg-destructive text-destructive-foreground border-destructive/40'
+                : 'bg-card'
             }`}
+            style={{ minWidth: 280, maxWidth: 400 }}
           >
-            <X className="h-3.5 w-3.5" />
-          </button>
-        </div>
-      ))}
+            {isError ? (
+              <XCircle className="h-4 w-4 shrink-0" />
+            ) : (
+              <CheckCircle className="h-4 w-4 shrink-0 text-success" />
+            )}
+            <span className={`flex-1 text-sm ${isError ? '' : 'text-foreground'}`}>{toast.message}</span>
+            {toast.type === 'undo' && toast.onUndo && (
+              <button
+                onClick={() => { toast.onUndo?.(); dismiss(toast.id); }}
+                className="flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-primary hover:bg-muted transition-colors"
+              >
+                <Undo2 className="h-3 w-3" />
+                Undo
+              </button>
+            )}
+            <button
+              onClick={() => dismiss(toast.id)}
+              aria-label="Dismiss"
+              className={`rounded p-0.5 transition-colors ${
+                isError
+                  ? 'text-destructive-foreground/70 hover:text-destructive-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/src/services/__tests__/deviceActions.test.ts
+++ b/apps/web/src/services/__tests__/deviceActions.test.ts
@@ -6,7 +6,10 @@ import {
   executeScript,
   sendBulkCommand,
   sendDeviceCommand,
-  toggleMaintenanceMode
+  sendWakeCommand,
+  toggleMaintenanceMode,
+  WakeCommandError,
+  wakeFriendlyErrorMessage
 } from '../deviceActions';
 
 vi.mock('@/stores/auth', () => ({
@@ -216,6 +219,93 @@ describe('deviceActions service', () => {
       fetchWithAuthMock.mockResolvedValue(makeResponse({ message: 'Delete rejected' }, false, 403));
 
       await expect(decommissionDevice('dev-1')).rejects.toThrow('Delete rejected');
+    });
+  });
+
+  describe('sendWakeCommand', () => {
+    it('returns the wake response body on a successful dispatch', async () => {
+      const wakeResponse = {
+        deviceId: 'dev-1',
+        type: 'wake_on_lan',
+        status: 'dispatched',
+        wakeAttemptId: 'wake-1',
+        relay: { deviceId: 'relay-1', hostname: 'PEER-01' },
+        network: '10.0.1.0/24',
+        broadcast: '10.0.1.255',
+        macs: ['aa:bb:cc:dd:ee:ff']
+      };
+      fetchWithAuthMock.mockResolvedValue(makeResponse(wakeResponse));
+
+      const result = await sendWakeCommand('dev-1');
+
+      expect(fetchWithAuthMock).toHaveBeenCalledWith('/devices/dev-1/commands', {
+        method: 'POST',
+        body: JSON.stringify({ type: 'wake' })
+      });
+      expect(result).toEqual(wakeResponse);
+    });
+
+    it('throws WakeCommandError carrying server-side code and message on 412', async () => {
+      // 412 NO_MACS is the most common pre-flight rejection: agent hasn't checked
+      // in yet, so we have no MAC to wake. UI relies on .code + .message both
+      // being preserved through the throw.
+      fetchWithAuthMock.mockResolvedValue(
+        makeResponse(
+          {
+            error:
+              'Target has no recorded MAC address. The agent must check in at least once before Wake-on-LAN is available.',
+            code: 'NO_MACS'
+          },
+          false,
+          412
+        )
+      );
+
+      const err = await sendWakeCommand('dev-1').catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(WakeCommandError);
+      const wakeErr = err as WakeCommandError;
+      expect(wakeErr.code).toBe('NO_MACS');
+      expect(wakeErr.message).toBe(
+        'Target has no recorded MAC address. The agent must check in at least once before Wake-on-LAN is available.'
+      );
+    });
+
+    it('falls back to a default message when the error body has no error/message fields', async () => {
+      fetchWithAuthMock.mockResolvedValue(makeResponse({ code: 'NO_RELAY' }, false, 503));
+
+      const err = await sendWakeCommand('dev-1').catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(WakeCommandError);
+      expect((err as WakeCommandError).code).toBe('NO_RELAY');
+      expect((err as Error).message).toBe('Failed to send wake command');
+    });
+
+    it('still throws WakeCommandError when the error body is unparseable JSON', async () => {
+      fetchWithAuthMock.mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: vi.fn().mockRejectedValue(new Error('invalid json'))
+      } as unknown as Response);
+
+      const err = await sendWakeCommand('dev-1').catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(WakeCommandError);
+      expect((err as WakeCommandError).code).toBeUndefined();
+    });
+  });
+
+  describe('wakeFriendlyErrorMessage', () => {
+    it('maps every documented failure code to a user-readable string', () => {
+      expect(wakeFriendlyErrorMessage('NO_MACS')).toContain('No MAC address');
+      expect(wakeFriendlyErrorMessage('NO_SUBNET')).toContain('subnet mask');
+      expect(wakeFriendlyErrorMessage('IPV6_ONLY')).toContain('IPv4');
+      expect(wakeFriendlyErrorMessage('NO_RELAY')).toContain('online peer agent');
+      expect(wakeFriendlyErrorMessage('RELAY_OVERRIDE_INVALID')).toContain('relay');
+      expect(wakeFriendlyErrorMessage('WS_SEND_FAILED')).toContain('Try again');
+      expect(wakeFriendlyErrorMessage('TARGET_NOT_FOUND')).toContain('Device not found');
+    });
+
+    it('returns null for unknown / undefined codes so callers fall back to the raw server message', () => {
+      expect(wakeFriendlyErrorMessage(undefined)).toBeNull();
+      expect(wakeFriendlyErrorMessage('UNKNOWN_CODE_FROM_FUTURE')).toBeNull();
     });
   });
 


### PR DESCRIPTION
## What

Fixes the Wake-on-LAN half of https://github.com/LanternOps/breeze/issues/720 (silent action-button feedback). Pushover/channel-Test half left for a sibling PR — different surface (NotificationChannelsPage, ties into #678).

## Root causes (both real, both in `apps/web/src/components/shared/Toast.tsx`)

1. **Wrong ARIA role on errors.** Every toast used `role=status` + `aria-live=polite`. Error toasts that *did* render were invisible to:
   - Playwright `[role=alert]` selectors (exactly the QA scan in the issue evidence)
   - Screen readers expecting an assertive announcement on a failed action

2. **Silent-drop window in the module-level singleton.** `showToast()` writes to a module-level `addToastFn`. Until `ToastContainer`'s `useEffect` runs (initial JS load) — and again briefly during Astro view-transition unmount/remount — `addToastFn` is `null` and the call is a no-op. The Wake handler in `DevicesPage.tsx` / `DeviceDetailPage.tsx` is fully wired (`sendWakeCommand` → `WakeCommandError` → `wakeFriendlyErrorMessage` → `showToast`); the toasts were being created and lost.

## Fix

- Errors → `role=alert` + `aria-live=assertive`. Success/undo stay `role=status` + `aria-live=polite`.
- Add a `pendingToasts` queue. `showToast()` called while `addToastFn === null` lands in the queue; the container flushes it on the next mount. Survives both initial-load races and view-transition gaps.
- Add `data-testid="toast"` + `data-toast-type` for stable test selectors.
- Switch toast id from bare `Date.now()` to `Date.now()-<random>` so two toasts firing in the same tick don't collide.

No changes to the Wake handler call sites — they were already correct.

## Tests (all new, 25 total in the two touched suites)

- **`apps/web/src/components/shared/Toast.test.tsx`** (new, 6 cases):
  - error renders `role=alert` + `aria-live=assertive`
  - success renders `role=status` + `aria-live=polite`
  - undo renders with the Undo button
  - pre-mount `showToast` calls flush on mount (the silent-drop fix)
  - unmount/remount gap toasts land on next mount
  - auto-dismiss at 5000ms

- **`apps/web/src/services/__tests__/deviceActions.test.ts`** (extended, 6 new cases):
  - `sendWakeCommand` 202 returns parsed body
  - `sendWakeCommand` 412 with `{error, code: 'NO_MACS'}` throws `WakeCommandError` preserving both fields (the exact server shape from the issue)
  - falls back to `'Failed to send wake command'` when the error body has no `error`/`message`
  - throws `WakeCommandError` (code `undefined`) when the error body is unparseable JSON
  - `wakeFriendlyErrorMessage` covers every documented code
  - returns `null` for unknown/undefined codes so callers fall through to the raw server message

Verified locally:

```
pnpm --filter=@breeze/web exec vitest run \
  src/components/shared/Toast.test.tsx \
  src/services/__tests__/deviceActions.test.ts
# Test Files  2 passed (2)
#      Tests  25 passed (25)
```

`pnpm --filter=@breeze/web exec tsc --noEmit` clean.

## Scope intentionally limited

- Wake-on-LAN only. Pushover/channel-Test silence has a different root cause (channel-card state not populated from the test response) — sibling PR.
- Did **not** touch the Wake handler call sites. They were correct; the toasts were just being lost.
- Did **not** audit other action buttons (Reboot, Run Script, Decommission). The Toast.tsx fix is the shared root cause for any of them that were affected; if specific call sites are still silent after this lands, those can be follow-ups with a tight repro.