### PR TITLE
fix(api): GET /orgs/sites honors explicit organizationId over ambient orgId (#723)

### DIFF
--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -890,16 +890,14 @@ orgRoutes.get('/sites', requireScope('organization', 'partner', 'system'), requi
   const auth = c.get('auth') as AuthContext;
   const { orgId, organizationId, ...pagination } = c.req.valid('query');
 
-  // Support both orgId and organizationId parameter names. The explicit
-  // `organizationId` (set by the page for the resource it is managing) MUST
-  // take precedence over `orgId`: the web client's fetchWithAuth auto-injects
-  // the ambient active-org `?orgId=` whenever the URL lacks the literal
-  // `orgId=` substring, so a Sites request for `?organizationId=<selected>`
-  // arrives as `?organizationId=<selected>&orgId=<activeOrg>`. With the old
-  // `orgId || organizationId` precedence the ambient org shadowed the
-  // explicitly-requested one (issue #723 — sites for a non-active org appeared
-  // to vanish / wrong org's sites shown). Access is still gated by
-  // ensureOrgAccess below, so this is not a tenant-isolation relaxation.
+  // Precedence: the explicit `organizationId` (the resource the page is
+  // managing) MUST win over `orgId`. `orgId` may be an *ambient* value the web
+  // client's fetchWithAuth auto-injects rather than a user-chosen scope;
+  // letting it shadow an explicit `organizationId` surfaced the wrong org's
+  // sites (issue #723). Access is still gated by ensureOrgAccess below — this
+  // is a precedence fix, not a tenant-isolation relaxation. See the orgId
+  // auto-injection in fetchWithAuth (apps/web/src/stores/auth.ts) for the
+  // mechanism that makes the ambient orgId show up here.
   const effectiveOrgId = organizationId || orgId;
 
   const { page, limit, offset } = getPagination(pagination);

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -890,8 +890,17 @@ orgRoutes.get('/sites', requireScope('organization', 'partner', 'system'), requi
   const auth = c.get('auth') as AuthContext;
   const { orgId, organizationId, ...pagination } = c.req.valid('query');
 
-  // Support both orgId and organizationId parameter names
-  const effectiveOrgId = orgId || organizationId;
+  // Support both orgId and organizationId parameter names. The explicit
+  // `organizationId` (set by the page for the resource it is managing) MUST
+  // take precedence over `orgId`: the web client's fetchWithAuth auto-injects
+  // the ambient active-org `?orgId=` whenever the URL lacks the literal
+  // `orgId=` substring, so a Sites request for `?organizationId=<selected>`
+  // arrives as `?organizationId=<selected>&orgId=<activeOrg>`. With the old
+  // `orgId || organizationId` precedence the ambient org shadowed the
+  // explicitly-requested one (issue #723 — sites for a non-active org appeared
+  // to vanish / wrong org's sites shown). Access is still gated by
+  // ensureOrgAccess below, so this is not a tenant-isolation relaxation.
+  const effectiveOrgId = organizationId || orgId;
 
   const { page, limit, offset } = getPagination(pagination);
   let conditions;

--- a/apps/api/src/routes/partner_multi_org_orgid.test.ts
+++ b/apps/api/src/routes/partner_multi_org_orgid.test.ts
@@ -1,30 +1,40 @@
 /**
- * Regression: partner-scope users with >1 accessible org must be able to scope
- * requests via the `?orgId=` query string (or `body.orgId` for POST/JSON
- * handlers). See issue #620.
+ * Regression coverage for orgId / organizationId resolution on partner-scope,
+ * multi-org users (issues #620 and #723).
  *
- * Each affected route file is exercised: the resolver should accept the
- * user-supplied orgId, validate it against `accessibleOrgIds`, and forward it
- * through. Foreign orgIds must 403; missing orgId must still 400 with the
+ * #620: partner-scope users with >1 accessible org must be able to scope
+ * requests via the `?orgId=` query string (or `body.orgId` for POST/JSON
+ * handlers). Each affected route file is exercised: the resolver should accept
+ * the user-supplied orgId, validate it against `accessibleOrgIds`, and forward
+ * it through. Foreign orgIds must 403; missing orgId must still 400 with the
  * existing "orgId is required..." message.
+ *
+ * #723: GET /orgs/sites must scope by the explicit `organizationId`, not the
+ * ambient `orgId` the web client auto-injects (see the #723 describe block).
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
-const { authState, ORG_A, ORG_B, FOREIGN_ORG } = vi.hoisted(() => {
+const { authState, canAccessOrgSpy, ORG_A, ORG_B, FOREIGN_ORG } = vi.hoisted(() => {
   const ORG_A = '11111111-1111-1111-1111-111111111111';
   const ORG_B = '22222222-2222-2222-2222-222222222222';
   const FOREIGN_ORG = '33333333-3333-3333-3333-333333333333';
+  const state = {
+    scope: 'partner' as 'partner' | 'organization' | 'system',
+    orgId: null as string | null,
+    partnerId: 'partner-1' as string | null,
+    accessibleOrgIds: [ORG_A, ORG_B] as string[] | null,
+  };
   return {
     ORG_A,
     ORG_B,
     FOREIGN_ORG,
-    authState: {
-      scope: 'partner' as 'partner' | 'organization' | 'system',
-      orgId: null as string | null,
-      partnerId: 'partner-1' as string | null,
-      accessibleOrgIds: [ORG_A, ORG_B] as string[] | null,
-    },
+    authState: state,
+    // Recording spy so a test can assert *which* org the handler resolved
+    // (the call arg is the resolved effectiveOrgId — see the #723 block).
+    // vi.clearAllMocks() in beforeEach clears call history but keeps this impl.
+    canAccessOrgSpy: vi.fn((id: string) =>
+      Array.isArray(state.accessibleOrgIds) && state.accessibleOrgIds.includes(id)),
   };
 });
 
@@ -37,8 +47,7 @@ vi.mock('../middleware/auth', () => ({
       orgId: authState.orgId,
       partnerId: authState.partnerId,
       accessibleOrgIds: authState.accessibleOrgIds,
-      canAccessOrg: (id: string) => Array.isArray(authState.accessibleOrgIds)
-        && authState.accessibleOrgIds.includes(id),
+      canAccessOrg: canAccessOrgSpy,
       orgCondition: () => undefined,
     });
     return next();
@@ -46,6 +55,9 @@ vi.mock('../middleware/auth', () => ({
   requireScope: vi.fn(() => async (_c: any, next: any) => next()),
   requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
   requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+  // orgs.ts imports requirePartner at module load and uses it as bare
+  // middleware (orgs.ts:350/367/622); without a stub here the mocked auth
+  // module yields `undefined` for it and route registration throws.
   requirePartner: async (_c: any, next: any) => next(),
 }));
 
@@ -378,21 +390,47 @@ describe('issue #620: partner-multi-org orgId pass-through', () => {
 });
 
 /**
- * Regression: issue #723. The web client's fetchWithAuth auto-injects the
- * ambient active-org `?orgId=` whenever the URL lacks the literal `orgId=`
- * substring. The Sites management page requests `/orgs/sites?organizationId=
- * <selected>`, which on the wire becomes `?organizationId=<selected>&orgId=
- * <activeOrg>`. GET /orgs/sites resolved `orgId || organizationId`, so the
- * ambient active org shadowed the explicitly-requested org — sites for a
- * non-active org appeared to vanish and the wrong org's sites were shown.
- * The explicit `organizationId` (the resource the user is acting on) must take
- * precedence; access is still gated by ensureOrgAccess so this is not a
- * tenant-isolation relaxation.
+ * Regression: issue #723 — GET /orgs/sites must scope by the explicit
+ * `organizationId` (the resource the page is managing), not the ambient
+ * `orgId` the web client's fetchWithAuth auto-injects. The old
+ * `orgId || organizationId` precedence let the ambient org shadow the
+ * explicit one, so the wrong org's sites showed / sites appeared to vanish.
+ * Access is still gated by ensureOrgAccess (not a tenant-isolation
+ * relaxation). Full mechanism: see the precedence comment in
+ * routes/orgs.ts GET /sites.
  */
 describe('issue #723: GET /orgs/sites organizationId precedence', () => {
-  // Assertions key off the ensureOrgAccess boundary, which runs BEFORE any DB
-  // query — this isolates the precedence/authz logic (the actual fix surface)
-  // and is deterministic on both the buggy and fixed implementations.
+  // Two assertion strategies, both keyed off the ensureOrgAccess boundary
+  // (which runs BEFORE any DB query, so it is deterministic regardless of the
+  // proxy db mock's shape):
+  //   1. status (403 vs not) — works only when the two orgs differ in
+  //      accessibility, so the resolution flips the authz outcome.
+  //   2. the canAccessOrgSpy call arg — for partner scope, ensureOrgAccess
+  //      calls auth.canAccessOrg(effectiveOrgId), so the arg *is* the resolved
+  //      org. This discriminates precedence even when BOTH orgs are accessible
+  //      (the real-world #723 shape), where status alone cannot.
+
+  it('scopes the query to the explicit organizationId when BOTH orgs are accessible (the real-world #723 shape)', async () => {
+    // This is the exact case the #723 reporter hit: a partner user who can see
+    // BOTH orgs. Neither precedence 403s (both pass ensureOrgAccess), so the
+    // ONLY observable difference between buggy and fixed code is *which* org
+    // the handler scopes to — status-only assertions (the tests below) cannot
+    // catch it. ensureOrgAccess calls auth.canAccessOrg(effectiveOrgId) for
+    // partner scope, so the spy's call arg is the resolved org: fixed
+    // precedence resolves the explicit ORG_A, buggy precedence the ambient
+    // ORG_B.
+    authState.accessibleOrgIds = [ORG_A, ORG_B];
+    const { orgRoutes } = await import('./orgs');
+    const app = new Hono().route('/orgs', orgRoutes);
+
+    await app.request(`/orgs/sites?organizationId=${ORG_A}&orgId=${ORG_B}`, {
+      method: 'GET',
+      headers: { Authorization: 'Bearer t' },
+    });
+
+    expect(canAccessOrgSpy).toHaveBeenCalledWith(ORG_A);
+    expect(canAccessOrgSpy).not.toHaveBeenCalledWith(ORG_B);
+  });
 
   it('does not 403 when the explicit organizationId is accessible but the auto-injected ambient orgId is not', async () => {
     authState.accessibleOrgIds = [ORG_A];

--- a/apps/api/src/routes/partner_multi_org_orgid.test.ts
+++ b/apps/api/src/routes/partner_multi_org_orgid.test.ts
@@ -46,6 +46,7 @@ vi.mock('../middleware/auth', () => ({
   requireScope: vi.fn(() => async (_c: any, next: any) => next()),
   requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
   requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePartner: async (_c: any, next: any) => next(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -373,5 +374,71 @@ describe('issue #620: partner-multi-org orgId pass-through', () => {
 
       await expectNotOrgIdRequired400(res);
     });
+  });
+});
+
+/**
+ * Regression: issue #723. The web client's fetchWithAuth auto-injects the
+ * ambient active-org `?orgId=` whenever the URL lacks the literal `orgId=`
+ * substring. The Sites management page requests `/orgs/sites?organizationId=
+ * <selected>`, which on the wire becomes `?organizationId=<selected>&orgId=
+ * <activeOrg>`. GET /orgs/sites resolved `orgId || organizationId`, so the
+ * ambient active org shadowed the explicitly-requested org — sites for a
+ * non-active org appeared to vanish and the wrong org's sites were shown.
+ * The explicit `organizationId` (the resource the user is acting on) must take
+ * precedence; access is still gated by ensureOrgAccess so this is not a
+ * tenant-isolation relaxation.
+ */
+describe('issue #723: GET /orgs/sites organizationId precedence', () => {
+  // Assertions key off the ensureOrgAccess boundary, which runs BEFORE any DB
+  // query — this isolates the precedence/authz logic (the actual fix surface)
+  // and is deterministic on both the buggy and fixed implementations.
+
+  it('does not 403 when the explicit organizationId is accessible but the auto-injected ambient orgId is not', async () => {
+    authState.accessibleOrgIds = [ORG_A];
+    const { orgRoutes } = await import('./orgs');
+    const app = new Hono().route('/orgs', orgRoutes);
+
+    // Simulates fetchWithAuth appending &orgId=<activeOrg=ORG_B> to a page
+    // request that explicitly asked for organizationId=ORG_A. Buggy precedence
+    // resolves the inaccessible ORG_B -> 403; correct precedence resolves the
+    // explicit, accessible ORG_A and proceeds (must not be denied).
+    const res = await app.request(`/orgs/sites?organizationId=${ORG_A}&orgId=${ORG_B}`, {
+      method: 'GET',
+      headers: { Authorization: 'Bearer t' },
+    });
+
+    expect(res.status).not.toBe(403);
+  });
+
+  it('honors the explicit organizationId over an accessible ambient orgId (precedence flipped, not fallthrough)', async () => {
+    authState.accessibleOrgIds = [ORG_A];
+    const { orgRoutes } = await import('./orgs');
+    const app = new Hono().route('/orgs', orgRoutes);
+
+    // Explicit organizationId points at the inaccessible ORG_B while the
+    // ambient orgId is the accessible ORG_A. The explicit value must win, so
+    // access must be denied. Buggy precedence resolves ORG_A and does NOT 403.
+    const res = await app.request(`/orgs/sites?organizationId=${ORG_B}&orgId=${ORG_A}`, {
+      method: 'GET',
+      headers: { Authorization: 'Bearer t' },
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('still scopes by orgId when no organizationId is supplied (fallback unchanged)', async () => {
+    authState.accessibleOrgIds = [ORG_A];
+    const { orgRoutes } = await import('./orgs');
+    const app = new Hono().route('/orgs', orgRoutes);
+
+    // Only the ambient orgId is present and it is foreign -> must still be
+    // denied (guards that the orgId fallback is preserved by the fix).
+    const res = await app.request(`/orgs/sites?orgId=${FOREIGN_ORG}`, {
+      method: 'GET',
+      headers: { Authorization: 'Bearer t' },
+    });
+
+    expect(res.status).toBe(403);
   });
 });


### PR DESCRIPTION
## Problem
`fetchWithAuth` auto-injects the active-org `?orgId=` whenever the URL lacks the literal `orgId=` substring. The Sites page requests `/orgs/sites?organizationId=<selected>`, which on the wire becomes `?organizationId=<selected>&orgId=<activeOrg>`. `GET /orgs/sites` resolved `orgId || organizationId`, so the ambient active org shadowed the explicitly-requested org — **sites for a non-active org appeared to vanish and the wrong org's sites were shown** (perceived data loss).

## Fix
`apps/api/src/routes/orgs.ts:894` — swap precedence to `organizationId || orgId`. The explicit `organizationId` (the resource the user is managing) now wins; the `orgId`-only fallback is preserved. Access is still gated by `ensureOrgAccess`, so this is **not** a tenant-isolation relaxation.

## Verification
TDD (red→green). Added regression tests to the existing `partner_multi_org_orgid.test.ts` (#620/#621 suite — which should have covered `/sites` originally). Full `partner_multi_org_orgid` + `orgs` suites: **78/78 pass**.

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)