### PR TITLE
fix(api): rollback uses queueCommandForExecution for offline-consistent results (#730)

### DIFF
--- a/apps/api/src/routes/patches/helpers.ts
+++ b/apps/api/src/routes/patches/helpers.ts
@@ -47,6 +47,7 @@ export function writePatchAuditForOrgIds(
     resourceType: string;
     resourceId?: string;
     resourceName?: string;
+    result?: 'success' | 'failure' | 'denied';
     details?: Record<string, unknown>;
   }
 ): void {

--- a/apps/api/src/routes/patches/index.test.ts
+++ b/apps/api/src/routes/patches/index.test.ts
@@ -114,6 +114,11 @@ vi.mock('../../services/commandQueue', () => ({
   queueCommandForExecution: vi.fn()
 }));
 
+vi.mock('../../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn(),
+  writeAuditEvent: vi.fn()
+}));
+
 vi.mock('../../jobs/patchComplianceReportWorker', () => ({
   enqueuePatchComplianceReport: vi.fn(async () => ({ enqueued: true, jobId: 'patch-compliance-report:test' }))
 }));
@@ -154,8 +159,9 @@ vi.mock('../../middleware/auth', () => ({
 }));
 
 import { db } from '../../db';
-import { queueCommand, queueCommandForExecution } from '../../services/commandQueue';
+import { queueCommandForExecution } from '../../services/commandQueue';
 import { enqueuePatchComplianceReport } from '../../jobs/patchComplianceReportWorker';
+import { writeRouteAudit } from '../../services/auditEvents';
 
 function selectWhereResult(rows: unknown[]) {
   return {
@@ -535,6 +541,7 @@ describe('patch routes', () => {
   });
 
   it('queues rollback commands for accessible devices', async () => {
+    const insertValues = vi.fn().mockResolvedValue(undefined);
     vi.mocked(db.select)
       .mockReturnValueOnce(selectWhereLimitResult([
         {
@@ -549,9 +556,14 @@ describe('patch routes', () => {
         { id: DEVICE_B, orgId: BLOCKED_ORG_ID }
       ]) as any);
 
-    vi.mocked(queueCommand).mockResolvedValue({ id: 'cmd-rollback-1' } as any);
+    vi.mocked(queueCommandForExecution).mockResolvedValue({
+      command: {
+        id: 'cmd-rollback-1',
+        status: 'sent'
+      }
+    } as any);
     vi.mocked(db.insert).mockReturnValue({
-      values: vi.fn().mockResolvedValue(undefined)
+      values: insertValues
     } as any);
 
     const res = await app.request(`/patches/${PATCH_ID}/rollback`, {
@@ -571,10 +583,13 @@ describe('patch routes', () => {
     expect(body.patchId).toBe(PATCH_ID);
     expect(body.deviceCount).toBe(1);
     expect(body.queuedCommandIds).toEqual(['cmd-rollback-1']);
+    expect(body.dispatchedCommandIds).toEqual(['cmd-rollback-1']);
+    expect(body.pendingCommandIds).toEqual([]);
+    expect(body.failedDeviceIds).toEqual([]);
     expect(body.skipped.inaccessibleDeviceIds).toEqual([DEVICE_B]);
     expect(body.skipped.missingDeviceIds).toEqual([DEVICE_D]);
 
-    expect(queueCommand).toHaveBeenCalledWith(
+    expect(queueCommandForExecution).toHaveBeenCalledWith(
       DEVICE_A,
       'rollback_patches',
       {
@@ -589,7 +604,178 @@ describe('patch routes', () => {
         ],
         reason: 'Rollback validation'
       },
-      USER_ID
+      { userId: USER_ID, preferHeartbeat: false }
+    );
+    expect(insertValues).toHaveBeenCalledWith([
+      {
+        deviceId: DEVICE_A,
+        patchId: PATCH_ID,
+        reason: 'Rollback validation',
+        status: 'pending',
+        initiatedBy: USER_ID
+      }
+    ]);
+  });
+
+  it('reports offline rollback devices as failed without persisting rollback rows', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectWhereLimitResult([
+        {
+          id: PATCH_ID,
+          source: 'apple',
+          externalId: 'apple:example-patch',
+          title: 'Example Patch'
+        }
+      ]) as any)
+      .mockReturnValueOnce(selectWhereResult([
+        { id: DEVICE_A, orgId: ACCESSIBLE_ORG_ID }
+      ]) as any);
+
+    vi.mocked(queueCommandForExecution).mockResolvedValue({
+      error: 'Device is offline, cannot execute command'
+    } as any);
+
+    const res = await app.request(`/patches/${PATCH_ID}/rollback`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        reason: 'Offline rollback',
+        scheduleType: 'immediate',
+        deviceIds: [DEVICE_A]
+      })
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.success).toBe(false);
+    expect(body.queuedCommandIds).toEqual([]);
+    expect(body.dispatchedCommandIds).toEqual([]);
+    expect(body.pendingCommandIds).toEqual([]);
+    expect(body.failedDeviceIds).toEqual([DEVICE_A]);
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('reports mixed rollback dispatch results and persists only queued commands', async () => {
+    const insertValues = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectWhereLimitResult([
+        {
+          id: PATCH_ID,
+          source: 'apple',
+          externalId: 'apple:example-patch',
+          title: 'Example Patch'
+        }
+      ]) as any)
+      .mockReturnValueOnce(selectWhereResult([
+        { id: DEVICE_A, orgId: ACCESSIBLE_ORG_ID },
+        { id: DEVICE_C, orgId: ACCESSIBLE_ORG_ID },
+        { id: DEVICE_D, orgId: ACCESSIBLE_ORG_ID }
+      ]) as any);
+
+    vi.mocked(queueCommandForExecution).mockImplementation(async (deviceId: string) => {
+      if (deviceId === DEVICE_A) {
+        return { command: { id: 'cmd-sent', status: 'sent' } } as any;
+      }
+      if (deviceId === DEVICE_C) {
+        return { command: { id: 'cmd-pending', status: 'pending' } } as any;
+      }
+      throw new Error('queue failed');
+    });
+    vi.mocked(db.insert).mockReturnValue({
+      values: insertValues
+    } as any);
+
+    const res = await app.request(`/patches/${PATCH_ID}/rollback`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        reason: 'Mixed rollback',
+        scheduleType: 'immediate',
+        deviceIds: [DEVICE_A, DEVICE_C, DEVICE_D]
+      })
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.success).toBe(false);
+    expect(body.queuedCommandIds).toEqual(['cmd-sent', 'cmd-pending']);
+    expect(body.dispatchedCommandIds).toEqual(['cmd-sent']);
+    expect(body.pendingCommandIds).toEqual(['cmd-pending']);
+    expect(body.failedDeviceIds).toEqual([DEVICE_D]);
+    expect(insertValues).toHaveBeenCalledWith([
+      {
+        deviceId: DEVICE_A,
+        patchId: PATCH_ID,
+        reason: 'Mixed rollback',
+        status: 'pending',
+        initiatedBy: USER_ID
+      },
+      {
+        deviceId: DEVICE_C,
+        patchId: PATCH_ID,
+        reason: 'Mixed rollback',
+        status: 'pending',
+        initiatedBy: USER_ID
+      }
+    ]);
+  });
+
+  it('marks rollback audit failure when all rollback queue attempts fail', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectWhereLimitResult([
+        {
+          id: PATCH_ID,
+          source: 'apple',
+          externalId: 'apple:example-patch',
+          title: 'Example Patch'
+        }
+      ]) as any)
+      .mockReturnValueOnce(selectWhereResult([
+        { id: DEVICE_A, orgId: ACCESSIBLE_ORG_ID },
+        { id: DEVICE_C, orgId: ACCESSIBLE_ORG_ID }
+      ]) as any);
+
+    vi.mocked(queueCommandForExecution).mockResolvedValue({
+      error: 'Device is offline, cannot execute command'
+    } as any);
+
+    const res = await app.request(`/patches/${PATCH_ID}/rollback`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        reason: 'All failed rollback',
+        scheduleType: 'immediate',
+        deviceIds: [DEVICE_A, DEVICE_C]
+      })
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.success).toBe(false);
+    expect(body.queuedCommandIds).toEqual([]);
+    expect(body.dispatchedCommandIds).toEqual([]);
+    expect(body.pendingCommandIds).toEqual([]);
+    expect(body.failedDeviceIds).toEqual([DEVICE_A, DEVICE_C]);
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(writeRouteAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        orgId: ACCESSIBLE_ORG_ID,
+        action: 'patch.rollback',
+        resourceType: 'patch',
+        resourceId: PATCH_ID,
+        resourceName: 'Example Patch',
+        result: 'failure',
+        details: expect.objectContaining({
+          queuedCommandIds: [],
+          dispatchedCommandIds: [],
+          pendingCommandIds: [],
+          failedDeviceIds: [DEVICE_A, DEVICE_C]
+        })
+      })
     );
   });
 

--- a/apps/api/src/routes/patches/operations.ts
+++ b/apps/api/src/routes/patches/operations.ts
@@ -3,7 +3,7 @@ import { zValidator } from '@hono/zod-validator';
 import { and, eq, sql, inArray, desc } from 'drizzle-orm';
 import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { db } from '../../db';
-import { queueCommand, queueCommandForExecution } from '../../services/commandQueue';
+import { queueCommandForExecution } from '../../services/commandQueue';
 import { PERMISSIONS } from '../../services/permissions';
 import {
   patches,
@@ -235,7 +235,7 @@ operationsRoutes.post(
     const queueResults = await Promise.all(
       accessibleDevices.map(async (device) => {
         try {
-          const command = await queueCommand(
+          const queued = await queueCommandForExecution(
             device.id,
             'rollback_patches',
             {
@@ -243,17 +243,37 @@ operationsRoutes.post(
               patches: [patch],
               reason: data.reason ?? null
             },
-            auth.user.id
+            {
+              userId: auth.user.id,
+              preferHeartbeat: false
+            }
           );
 
-          return { ok: true as const, deviceId: device.id, commandId: command.id };
+          if (!queued.command) {
+            return { ok: false as const, deviceId: device.id };
+          }
+
+          return {
+            ok: true as const,
+            deviceId: device.id,
+            commandId: queued.command.id,
+            commandStatus: queued.command.status
+          };
         } catch {
           return { ok: false as const, deviceId: device.id };
         }
       })
     );
 
-    const queued = queueResults.filter((result): result is { ok: true; deviceId: string; commandId: string } => result.ok);
+    const queued = queueResults
+      .filter((result): result is { ok: true; deviceId: string; commandId: string; commandStatus: string } => result.ok);
+    const queuedCommandIds = queued.map((entry) => entry.commandId);
+    const dispatchedCommandIds = queueResults
+      .filter((result): result is { ok: true; deviceId: string; commandId: string; commandStatus: string } => result.ok && result.commandStatus === 'sent')
+      .map((result) => result.commandId);
+    const pendingCommandIds = queueResults
+      .filter((result): result is { ok: true; deviceId: string; commandId: string; commandStatus: string } => result.ok && result.commandStatus !== 'sent')
+      .map((result) => result.commandId);
     const failedDeviceIds = queueResults
       .filter((result): result is { ok: false; deviceId: string } => !result.ok)
       .map((result) => result.deviceId);
@@ -280,8 +300,11 @@ operationsRoutes.post(
         resourceType: 'patch',
         resourceId: id,
         resourceName: patch.title,
+        result: queued.length === 0 ? 'failure' : 'success',
         details: {
-          queuedCommandIds: queued.map((entry) => entry.commandId),
+          queuedCommandIds,
+          dispatchedCommandIds,
+          pendingCommandIds,
           deviceCount: accessibleDevices.length,
           failedDeviceIds,
           reason: data.reason ?? null
@@ -292,7 +315,9 @@ operationsRoutes.post(
     return c.json({
       success: failedDeviceIds.length === 0,
       patchId: id,
-      queuedCommandIds: queued.map((entry) => entry.commandId),
+      queuedCommandIds,
+      dispatchedCommandIds,
+      pendingCommandIds,
       deviceCount: accessibleDevices.length,
       failedDeviceIds,
       skipped: {


### PR DESCRIPTION
## Problem
`POST /patches/:id/rollback` used bare `queueCommand`, reporting **success for offline devices**, inconsistent with `POST /patches/scan` (same offline device: scan → `success:false`, rollback → success).

## Fix
Use `queueCommandForExecution` and mirror scan's classification (`dispatchedCommandIds`/`pendingCommandIds`/`failedDeviceIds`, `success = failedDeviceIds.length === 0`). Also sets the persisted audit `result` to `failure` when nothing queued (addresses the #727-family audit concern for rollback). Rollback-specifics preserved (scheduled-type 400, `patch_rollbacks` insert only for queued devices, `patch.rollback` audit action).

## Verification
`patches/index.test.ts` extended with offline/mixed/all-failed rollback cases; **18/18 pass**. (Codex-generated, diff-reviewed and tests run by Claude.)

Closes #730
Related: #727

🤖 Generated with [Claude Code](https://claude.com/claude-code)