### PR TITLE
feat(api): schedule CVE enrichment job + accept osvEcosystem on catalog (#731)

### DIFF
--- a/apps/api/src/db/schema/thirdPartyCatalog.ts
+++ b/apps/api/src/db/schema/thirdPartyCatalog.ts
@@ -16,6 +16,7 @@ export const thirdPartyPackageCatalog = pgTable('third_party_package_catalog', {
   notes: text('notes'),
   homepageUrl: text('homepage_url'),
   lastCveCheckAt: timestamp('last_cve_check_at', { withTimezone: true }),
+  // Maintainers must set osv_ecosystem per package for CVE enrichment to match rows.
   osvEcosystem: varchar('osv_ecosystem', { length: 64 }),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -141,6 +141,7 @@ import { initializeReliabilityWorker, shutdownReliabilityWorker } from './jobs/r
 import { initializeUserRiskJobs, shutdownUserRiskJobs } from './jobs/userRiskJobs';
 import { initializeUserRiskRetention, shutdownUserRiskRetention } from './jobs/userRiskRetention';
 import { initializePatchComplianceReportWorker, shutdownPatchComplianceReportWorker } from './jobs/patchComplianceReportWorker';
+import { initializeCveEnrichmentWorker, shutdownCveEnrichmentWorker } from './jobs/cveEnrichmentWorker';
 import { initializeSoftwareComplianceWorker, shutdownSoftwareComplianceWorker } from './jobs/softwareComplianceWorker';
 import { initializeSoftwareRemediationWorker, shutdownSoftwareRemediationWorker } from './jobs/softwareRemediationWorker';
 import { initializeAuditBaselineJobs, shutdownAuditBaselineJobs } from './jobs/auditBaselineJobs';
@@ -996,6 +997,7 @@ async function initializeWorkers(): Promise<void> {
     ['monitorWorker', initializeMonitorWorker],
     ['snmpRetention', initializeSnmpRetention],
     ['patchComplianceReportWorker', initializePatchComplianceReportWorker],
+    ['cveEnrichmentWorker', initializeCveEnrichmentWorker],
     ['dnsSyncWorker', initializeDnsSyncJob],
     ['s1SyncWorker', initializeS1SyncJob],
     ['huntressSyncWorker', initializeHuntressSyncJob],
@@ -1121,6 +1123,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownIncidentTimelineEnricher,
     shutdownIncidentCorrelationWorker,
     shutdownPatchComplianceReportWorker,
+    shutdownCveEnrichmentWorker,
     shutdownDnsSyncJob,
     shutdownS1SyncJob,
     shutdownHuntressSyncJob,

--- a/apps/api/src/jobs/cveEnrichmentWorker.test.ts
+++ b/apps/api/src/jobs/cveEnrichmentWorker.test.ts
@@ -7,7 +7,7 @@ const { queryOsvForPackage, mockRows, updateSet } = vi.hoisted(() => ({
       patchId: 'p1',
       packageId: 'Mozilla.Firefox',
       currentSeverity: 'moderate',
-      ecosystem: 'npm',
+      ecosystem: 'test-ecosystem',
       version: '120.0',
     },
   ],
@@ -65,6 +65,18 @@ vi.mock('../db', () => ({
   },
 }));
 
+vi.mock('bullmq', () => ({
+  Queue: class {},
+  Worker: class {
+    on = vi.fn();
+    close = vi.fn();
+  },
+}));
+
+vi.mock('../services/redis', () => ({
+  getBullMQConnection: vi.fn(() => ({})),
+}));
+
 vi.mock('../services/osvClient', () => ({
   queryOsvForPackage: (...args: unknown[]) => queryOsvForPackage(...args),
   OsvRateLimitError: class OsvRateLimitError extends Error {},
@@ -88,6 +100,11 @@ describe('runCveEnrichmentBatch', () => {
     const summary = await runCveEnrichmentBatch();
 
     expect(summary).toEqual({ scanned: 1, updated: 1, errors: 0 });
+    expect(queryOsvForPackage).toHaveBeenCalledWith({
+      ecosystem: 'test-ecosystem',
+      name: 'Mozilla.Firefox',
+      version: '120.0',
+    });
     expect(updateSet).toHaveBeenCalledWith(
       expect.objectContaining({
         cveIds: ['CVE-2024-1', 'CVE-2024-2'],

--- a/apps/api/src/jobs/cveEnrichmentWorker.ts
+++ b/apps/api/src/jobs/cveEnrichmentWorker.ts
@@ -1,11 +1,41 @@
+import { Job, Queue, Worker } from 'bullmq';
 import { and, eq, isNotNull } from 'drizzle-orm';
-import { db } from '../db';
+import * as dbModule from '../db';
 import { patches, thirdPartyPackageCatalog } from '../db/schema';
 import {
   queryOsvForPackage,
   OsvRateLimitError,
   OsvServerError,
 } from '../services/osvClient';
+import { getBullMQConnection } from '../services/redis';
+
+const { db } = dbModule;
+
+const QUEUE_NAME = 'cve-enrichment';
+const JOB_NAME = 'enrich';
+const DEFAULT_BATCH_LIMIT = 100;
+const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+type CveEnrichmentJobData = {
+  limit?: number;
+};
+
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const withSystem = dbModule.withSystemDbAccessContext;
+  return typeof withSystem === 'function' ? withSystem(fn) : fn();
+};
+
+let enrichmentQueue: Queue<CveEnrichmentJobData> | null = null;
+let enrichmentWorker: Worker<CveEnrichmentJobData> | null = null;
+
+export function getCveEnrichmentQueue(): Queue<CveEnrichmentJobData> {
+  if (!enrichmentQueue) {
+    enrichmentQueue = new Queue<CveEnrichmentJobData>(QUEUE_NAME, {
+      connection: getBullMQConnection(),
+    });
+  }
+  return enrichmentQueue;
+}
 
 const SEVERITY_RANK: Record<string, number> = {
   critical: 4,
@@ -119,3 +149,76 @@ export async function runCveEnrichmentBatch(
 
   return summary;
 }
+
+export function createCveEnrichmentWorker(): Worker<CveEnrichmentJobData> {
+  return new Worker<CveEnrichmentJobData>(
+    QUEUE_NAME,
+    async (job: Job<CveEnrichmentJobData>) => {
+      if (job.name !== JOB_NAME) {
+        console.warn(`[CveEnrichment] Ignoring unknown job name: ${job.name}`);
+        return { scanned: 0, updated: 0, errors: 0, skipped: true };
+      }
+
+      return runWithSystemDbAccess(() =>
+        runCveEnrichmentBatch({ limit: job.data.limit ?? DEFAULT_BATCH_LIMIT })
+      );
+    },
+    {
+      connection: getBullMQConnection(),
+      concurrency: 1,
+    }
+  );
+}
+
+export async function initializeCveEnrichmentWorker(): Promise<void> {
+  try {
+    enrichmentWorker = createCveEnrichmentWorker();
+
+    enrichmentWorker.on('error', (error) => {
+      console.error('[CveEnrichment] Worker error:', error);
+    });
+
+    enrichmentWorker.on('failed', (job, error) => {
+      console.error(`[CveEnrichment] Job ${job?.id} failed:`, error);
+    });
+
+    const queue = getCveEnrichmentQueue();
+    const existingJobs = await queue.getRepeatableJobs();
+    for (const job of existingJobs) {
+      await queue.removeRepeatableByKey(job.key);
+    }
+
+    await queue.add(
+      JOB_NAME,
+      { limit: DEFAULT_BATCH_LIMIT },
+      {
+        repeat: { every: DEFAULT_INTERVAL_MS },
+        removeOnComplete: { count: 5 },
+        removeOnFail: { count: 10 },
+      }
+    );
+
+    console.log('[CveEnrichment] Worker initialized');
+  } catch (error) {
+    console.error('[CveEnrichment] Failed to initialize:', error);
+    throw error;
+  }
+}
+
+export async function shutdownCveEnrichmentWorker(): Promise<void> {
+  if (enrichmentWorker) {
+    await enrichmentWorker.close();
+    enrichmentWorker = null;
+  }
+  if (enrichmentQueue) {
+    await enrichmentQueue.close();
+    enrichmentQueue = null;
+  }
+}
+
+export const __testOnly = {
+  QUEUE_NAME,
+  JOB_NAME,
+  DEFAULT_BATCH_LIMIT,
+  DEFAULT_INTERVAL_MS,
+};

--- a/apps/api/src/jobs/cveEnrichmentWorker.ts
+++ b/apps/api/src/jobs/cveEnrichmentWorker.ts
@@ -7,7 +7,7 @@ import {
   OsvRateLimitError,
   OsvServerError,
 } from '../services/osvClient';
-import { getBullMQConnection } from '../services/redis';
+import { getBullMQConnection, isRedisAvailable } from '../services/redis';
 
 const { db } = dbModule;
 
@@ -171,6 +171,11 @@ export function createCveEnrichmentWorker(): Worker<CveEnrichmentJobData> {
 }
 
 export async function initializeCveEnrichmentWorker(): Promise<void> {
+  if (!isRedisAvailable()) {
+    console.warn('[CveEnrichment] Redis unavailable; queue worker disabled (inline fallback enabled)');
+    return;
+  }
+
   try {
     enrichmentWorker = createCveEnrichmentWorker();
 
@@ -215,10 +220,3 @@ export async function shutdownCveEnrichmentWorker(): Promise<void> {
     enrichmentQueue = null;
   }
 }
-
-export const __testOnly = {
-  QUEUE_NAME,
-  JOB_NAME,
-  DEFAULT_BATCH_LIMIT,
-  DEFAULT_INTERVAL_MS,
-};

--- a/apps/api/src/routes/thirdPartyCatalog/operations.test.ts
+++ b/apps/api/src/routes/thirdPartyCatalog/operations.test.ts
@@ -15,6 +15,7 @@ const mockCatalogTable = vi.hoisted(() => ({
   breezeTested: 'thirdPartyPackageCatalog.breezeTested',
   notes: 'thirdPartyPackageCatalog.notes',
   homepageUrl: 'thirdPartyPackageCatalog.homepageUrl',
+  osvEcosystem: 'thirdPartyPackageCatalog.osvEcosystem',
   createdAt: 'thirdPartyPackageCatalog.createdAt',
   updatedAt: 'thirdPartyPackageCatalog.updatedAt',
 }));
@@ -99,6 +100,7 @@ type CatalogRow = {
   breezeTested: boolean;
   notes: string | null;
   homepageUrl: string | null;
+  osvEcosystem: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -115,17 +117,10 @@ function catalogRow(overrides: Partial<CatalogRow>): CatalogRow {
     breezeTested: false,
     notes: null,
     homepageUrl: null,
+    osvEcosystem: null,
     createdAt: new Date('2026-01-01T00:00:00.000Z'),
     updatedAt: new Date('2026-01-01T00:00:00.000Z'),
     ...overrides,
-  };
-}
-
-function insertReturning(row: CatalogRow) {
-  return {
-    values: vi.fn().mockReturnValue({
-      returning: vi.fn().mockResolvedValue([row]),
-    }),
   };
 }
 
@@ -189,8 +184,12 @@ describe('third-party catalog operations routes', () => {
       packageId: 'Google.Chrome',
       vendor: 'Google',
       friendlyName: 'Google Chrome',
+      osvEcosystem: 'test-ecosystem',
     });
-    vi.mocked(db.insert).mockReturnValueOnce(insertReturning(row) as never);
+    const values = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([row]),
+    });
+    vi.mocked(db.insert).mockReturnValueOnce({ values } as never);
 
     const res = await app.request('/third-party-catalog', {
       method: 'POST',
@@ -199,6 +198,7 @@ describe('third-party catalog operations routes', () => {
         packageId: 'Google.Chrome',
         vendor: 'Google',
         friendlyName: 'Google Chrome',
+        osvEcosystem: 'test-ecosystem',
       }),
     });
 
@@ -209,6 +209,40 @@ describe('third-party catalog operations routes', () => {
       packageId: 'Google.Chrome',
       vendor: 'Google',
       friendlyName: 'Google Chrome',
+      osvEcosystem: 'test-ecosystem',
+    }));
+    expect(values).toHaveBeenCalledWith(expect.objectContaining({
+      osvEcosystem: 'test-ecosystem',
+    }));
+  });
+
+  it('updates catalog item osvEcosystem with platform admin access', async () => {
+    const row = catalogRow({
+      osvEcosystem: 'test-ecosystem',
+    });
+    const set = vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([row]),
+      }),
+    });
+    vi.mocked(db.update).mockReturnValueOnce({ set } as never);
+
+    const res = await app.request('/third-party-catalog/22222222-2222-4222-8222-222222222222', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        osvEcosystem: 'test-ecosystem',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual(expect.objectContaining({
+      osvEcosystem: 'test-ecosystem',
+    }));
+    expect(set).toHaveBeenCalledWith(expect.objectContaining({
+      osvEcosystem: 'test-ecosystem',
+      updatedAt: expect.any(Date),
     }));
   });
 

--- a/apps/api/src/routes/thirdPartyCatalog/operations.ts
+++ b/apps/api/src/routes/thirdPartyCatalog/operations.ts
@@ -32,6 +32,7 @@ operationsRoutes.post('/', zValidator('json', upsertCatalogSchema), async (c) =>
     breezeTested: data.breezeTested ?? false,
     notes: data.notes ?? null,
     homepageUrl: data.homepageUrl ?? null,
+    osvEcosystem: data.osvEcosystem ?? null,
   }).returning();
   invalidateCatalogCache();
   return c.json(row, 201);

--- a/apps/api/src/routes/thirdPartyCatalog/schemas.test.ts
+++ b/apps/api/src/routes/thirdPartyCatalog/schemas.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { upsertCatalogSchema } from './schemas';
+
+describe('third-party catalog schemas', () => {
+  it('accepts osvEcosystem on create', () => {
+    const parsed = upsertCatalogSchema.parse({
+      packageId: 'Example.Package',
+      vendor: 'Example',
+      friendlyName: 'Example Package',
+      osvEcosystem: 'test-ecosystem',
+    });
+
+    expect(parsed.osvEcosystem).toBe('test-ecosystem');
+  });
+
+  it('accepts osvEcosystem on update', () => {
+    const parsed = upsertCatalogSchema.partial().parse({
+      osvEcosystem: 'test-ecosystem',
+    });
+
+    expect(parsed.osvEcosystem).toBe('test-ecosystem');
+  });
+});

--- a/apps/api/src/routes/thirdPartyCatalog/schemas.ts
+++ b/apps/api/src/routes/thirdPartyCatalog/schemas.ts
@@ -27,4 +27,5 @@ export const upsertCatalogSchema = z.object({
   breezeTested: z.boolean().optional(),
   notes: z.string().max(2000).nullable().optional(),
   homepageUrl: httpUrl.nullable().optional(),
+  osvEcosystem: z.string().min(1).max(64).nullable().optional(),
 });


### PR DESCRIPTION
## Problem
CVE enrichment shipped **dormant**: `runCveEnrichmentBatch` was never scheduled (no `index.ts` registration), and `osv_ecosystem` (the join gate) was not settable via the catalog schema and NULL in all seeds. `patches.cveIds` could never populate.

## Fix
- Register the worker in `apps/api/src/index.ts` following the existing `patchComplianceReportWorker` pattern (init array + shutdown list); BullMQ repeatable (24h) with dedupe of stale repeatables + clean shutdown.
- Add `osvEcosystem` to the catalog upsert schema + persist it.

**Caveat (tracked in #731):** maintainers must still populate `osv_ecosystem` per package for enrichment to match rows — intentionally not guessed here. Code comment added.

## Verification
`cveEnrichmentWorker.test.ts` + catalog `schemas`/`operations` tests extended; **17/17 pass**. (Codex-generated, `index.ts` wiring + worker timer impl diff-reviewed and tests run by Claude.)

Closes #731

🤖 Generated with [Claude Code](https://claude.com/claude-code)