### PR TITLE
fix(web): Run Scan reports failure instead of "queued for 0 devices" (#727)

### DIFF
--- a/apps/web/src/components/patches/PatchesPage.test.tsx
+++ b/apps/web/src/components/patches/PatchesPage.test.tsx
@@ -161,4 +161,68 @@ describe('PatchesPage', () => {
 
     expect(await screen.findByText('Patch scan queued for 3 devices, 1 dispatched immediately.')).toBeTruthy();
   });
+
+  it('surfaces a scan error when /patches/scan responds 200 with success:false', async () => {
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === '/update-rings') return makeJsonResponse({ data: [] });
+      if (url === '/patches') return makeJsonResponse({ data: [] });
+      if (url === '/devices?limit=100&page=1') {
+        return makeJsonResponse({
+          data: [{ id: 'device-1', hostname: 'PC-1' }],
+          pagination: { page: 1, limit: 100, total: 1 },
+        });
+      }
+      if (url === '/patches/scan') {
+        return makeJsonResponse({
+          success: false,
+          error: 'No devices are licensed for patching.',
+          queuedCommandIds: [],
+          dispatchedCommandIds: [],
+        });
+      }
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(<PatchesPage />);
+
+    await screen.findByText('No patches found. Try adjusting your search or filters.');
+    fireEvent.click(screen.getByRole('button', { name: 'Run Scan' }));
+
+    expect(
+      await screen.findByText('No devices are licensed for patching.')
+    ).toBeTruthy();
+    expect(screen.queryByText(/Patch scan queued for 0 devices/)).toBeNull();
+  });
+
+  it('surfaces a scan error when 200 response queued zero devices with no explicit error string', async () => {
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === '/update-rings') return makeJsonResponse({ data: [] });
+      if (url === '/patches') return makeJsonResponse({ data: [] });
+      if (url === '/devices?limit=100&page=1') {
+        return makeJsonResponse({
+          data: [{ id: 'device-1', hostname: 'PC-1' }],
+          pagination: { page: 1, limit: 100, total: 1 },
+        });
+      }
+      if (url === '/patches/scan') {
+        return makeJsonResponse({
+          queuedCommandIds: [],
+          dispatchedCommandIds: [],
+        });
+      }
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(<PatchesPage />);
+
+    await screen.findByText('No patches found. Try adjusting your search or filters.');
+    fireEvent.click(screen.getByRole('button', { name: 'Run Scan' }));
+
+    expect(
+      await screen.findByText(/No scan commands were queued/)
+    ).toBeTruthy();
+    expect(screen.queryByText(/Patch scan queued for 0 devices/)).toBeNull();
+  });
 });

--- a/apps/web/src/components/patches/PatchesPage.tsx
+++ b/apps/web/src/components/patches/PatchesPage.tsx
@@ -259,7 +259,21 @@ export default function PatchesPage() {
       }
       const body = await response.json().catch(() => ({}));
       const dispatched = Array.isArray(body?.dispatchedCommandIds) ? body.dispatchedCommandIds.length : 0;
-      const queued = Array.isArray(body?.queuedCommandIds) ? body.queuedCommandIds.length : deviceIds.length;
+      // Treat the absent `queuedCommandIds` field as 0, not as
+      // deviceIds.length — the fallback was masking the "scan didn't
+      // actually queue" path as a benign success. The server only owns
+      // the truth of what got queued; the request count is irrelevant
+      // once the response is in.
+      const queued = Array.isArray(body?.queuedCommandIds) ? body.queuedCommandIds.length : 0;
+      const succeeded = body?.success !== false && (queued > 0 || dispatched > 0);
+      if (!succeeded) {
+        const reason = (typeof body?.error === 'string' && body.error)
+          || (typeof body?.message === 'string' && body.message)
+          || (queued === 0 && dispatched === 0
+            ? 'No scan commands were queued. Verify the target devices are online and licensed for patching.'
+            : 'Patch scan did not start.');
+        throw new Error(reason);
+      }
       setScanSuccess(
         `Patch scan queued for ${queued} devices${dispatched > 0 ? `, ${dispatched} dispatched immediately` : ''}.`
       );


### PR DESCRIPTION
## What

Fixes https://github.com/LanternOps/breeze/issues/727 — the Run Scan button on `/patches` rendered "Patch scan queued for 0 devices." even when the server signaled failure (`success:false` or `queuedCommandIds:[]`). Same under-communication family as #720, distinct surface.

## Root causes (both in `apps/web/src/components/patches/PatchesPage.tsx`)

1. The handler only checked `response.ok`; a 200 with `{success:false, error:"..."}` slipped past.
2. `queued` fell back to `deviceIds.length` when `queuedCommandIds` was absent. The server is the only source of truth for what actually landed — the request count is irrelevant once the response is in.

## Fix

After parsing the body:
- `queued = body.queuedCommandIds?.length ?? 0` (no more request-count fallback)
- `succeeded = body.success !== false && (queued > 0 || dispatched > 0)`
- If not succeeded, throw with reason = `body.error || body.message || "No scan commands were queued. Verify the target devices are online and licensed for patching."` — caught by the existing try/catch and shown in `scanError`.

The happy path is unchanged in behavior (still renders the same banner with actual counts).

## Tests

Two new cases in `apps/web/src/components/patches/PatchesPage.test.tsx`:

1. `surfaces a scan error when /patches/scan responds 200 with success:false` — asserts the explicit `error` string appears and the "queued for 0 devices" banner does NOT.
2. `surfaces a scan error when 200 response queued zero devices with no explicit error string` — asserts the default fallback message appears and the "queued for 0 devices" banner does NOT.

Verified locally:
```
pnpm --filter=@breeze/web exec vitest run src/components/patches/PatchesPage.test.tsx
# Test Files  1 passed (1)
#      Tests  4 passed (4)
```
`pnpm --filter=@breeze/web exec tsc --noEmit` clean.

## Scope

Patches Run Scan only. The other UI-silence issues from your 2026-05-15 QA sweep have their own PRs / issues (#722 Wake toast accessibility, #728 channel-test persistence, #725 Alerts resolution silence still open).