### PR TITLE
feat(web,api): per-link expiry picker on Add Device modal (Discussion #629)

### DIFF
--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -314,6 +314,54 @@ describe("POST /enrollment-keys/:id/installer-link", () => {
     expect(childExpiryMs).not.toBe(parentRow.expiresAt.getTime());
   });
 
+  it("child key honors the ttlMinutes from the request body (per-link picker)", async () => {
+    // Admin picked "7 days" in the Add Device modal. The child key (the
+    // thing the short link redeems) must get a fresh 7d window measured
+    // from mint time — not the deployment default, not the parent's life.
+    const parentRow = makeKeyRow({
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000), // parent: 1h
+    });
+    const childRow = makeChildKeyRow();
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([parentRow]),
+          }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as any);
+
+    const insertValues = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([childRow]),
+    });
+    vi.mocked(db.insert).mockReturnValue({ values: insertValues } as any);
+
+    const ttlMinutes = 10080; // 7 days
+    const before = Date.now();
+    const res = await app.request(`/enrollment-keys/${KEY_ID}/installer-link`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ platform: "windows", ttlMinutes }),
+    });
+    const after = Date.now();
+    expect(res.status).toBe(200);
+
+    expect(insertValues).toHaveBeenCalledTimes(1);
+    const insertedRow = insertValues.mock.calls[0]![0] as { expiresAt: Date };
+    const childExpiryMs = insertedRow.expiresAt.getTime();
+    const ttlMs = ttlMinutes * 60 * 1000;
+    expect(childExpiryMs).toBeGreaterThanOrEqual(before + ttlMs - 50);
+    expect(childExpiryMs).toBeLessThanOrEqual(after + ttlMs + 50);
+  });
+
   it("shortUrl and url share the same origin", async () => {
     const parentRow = makeKeyRow();
     const childRow = makeChildKeyRow();

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -95,9 +95,17 @@ function generateEnrollmentKey(): string {
   return randomBytes(32).toString("hex"); // 64-char hex string
 }
 
-/** Fresh absolute expiry for a child enrollment key, independent of parent. */
-function freshChildExpiresAt(): Date {
-  return new Date(Date.now() + CHILD_ENROLLMENT_KEY_TTL_MINUTES * 60 * 1000);
+/**
+ * Fresh absolute expiry for a child enrollment key, measured from *now*
+ * (mint time), independent of the parent's remaining lifetime. This is the
+ * #410/#413/#414 anti-DOA property: a child minted from a near-expiry parent
+ * still gets a full window. `ttlMinutes`, when supplied, is the admin's
+ * per-link choice from the Add Device modal; absent it, the deployment
+ * default applies.
+ */
+function freshChildExpiresAt(ttlMinutes?: number): Date {
+  const minutes = ttlMinutes ?? CHILD_ENROLLMENT_KEY_TTL_MINUTES;
+  return new Date(Date.now() + minutes * 60 * 1000);
 }
 
 /**
@@ -459,18 +467,21 @@ const listEnrollmentKeysSchema = z.object({
   expired: z.enum(["true", "false"]).optional(),
 });
 
-// ttlMinutes caps at 525_960 (365 days). Caller supplies either ttlMinutes
-// or an explicit expiresAt; if both are absent the handler falls back to
+// ttlMinutes caps at 525_600 (365 days = 365 * 24 * 60), matching the UI's
+// "1 year" option exactly. Caller supplies either ttlMinutes or an explicit
+// expiresAt; if both are absent the handler falls back to
 // DEFAULT_ENROLLMENT_KEY_TTL_MINUTES. Sending both is rejected so the
 // resolved expiry is unambiguous. "Never expires" is not exposed here
 // pending the partner-level cap (max ttl) that gates it.
+const MAX_TTL_MINUTES = 525_600;
+
 const createEnrollmentKeySchema = z.object({
   orgId: z.string().uuid().optional(),
   siteId: z.string().uuid().optional(),
   name: z.string().min(1).max(255),
   maxUsage: z.number().int().min(1).max(100000).optional(),
   expiresAt: z.string().datetime().optional(),
-  ttlMinutes: z.number().int().min(1).max(525_960).optional(),
+  ttlMinutes: z.number().int().min(1).max(MAX_TTL_MINUTES).optional(),
 }).refine(
   (data) => !(data.expiresAt !== undefined && data.ttlMinutes !== undefined),
   { message: 'Pass either ttlMinutes or expiresAt, not both', path: ['ttlMinutes'] }
@@ -481,13 +492,19 @@ const rotateEnrollmentKeySchema = z.object({
   expiresAt: z.string().datetime().optional(),
 });
 
+// ttlMinutes here sets the lifetime of the *child* key — the downloaded
+// installer / shared short-link the admin actually distributes. Measured
+// fresh from mint time (see freshChildExpiresAt). Absent → deployment
+// default. Same 365-day cap as createEnrollmentKeySchema.
 const installerQuerySchema = z.object({
   count: z.coerce.number().int().min(1).max(100000).optional(),
+  ttlMinutes: z.coerce.number().int().min(1).max(MAX_TTL_MINUTES).optional(),
 });
 
 const installerLinkSchema = z.object({
   platform: z.enum(["windows", "macos"]),
   count: z.number().int().min(1).max(100000).optional(),
+  ttlMinutes: z.number().int().min(1).max(MAX_TTL_MINUTES).optional(),
 });
 
 function sanitizeEnrollmentKey(
@@ -873,7 +890,8 @@ enrollmentKeyRoutes.get(
     const auth = c.get("auth");
     const keyId = c.req.param("id")!;
     const platform = c.req.param("platform");
-    const { count: childMaxUsage = 1 } = c.req.valid("query");
+    const { count: childMaxUsage = 1, ttlMinutes: childTtlMinutes } =
+      c.req.valid("query");
 
     if (platform !== "windows" && platform !== "macos") {
       return c.json(
@@ -1079,7 +1097,7 @@ enrollmentKeyRoutes.get(
         key: childKeyHash,
         keySecretHash: parentKey.keySecretHash,
         maxUsage: childMaxUsage,
-        expiresAt: freshChildExpiresAt(),
+        expiresAt: freshChildExpiresAt(childTtlMinutes),
         createdBy: auth.user.id,
         shortCode,
         installerPlatform: platform,
@@ -1309,7 +1327,11 @@ enrollmentKeyRoutes.post(
   async (c) => {
     const auth = c.get("auth");
     const keyId = c.req.param("id")!;
-    const { platform, count: childMaxUsage = 1 } = c.req.valid("json");
+    const {
+      platform,
+      count: childMaxUsage = 1,
+      ttlMinutes: childTtlMinutes,
+    } = c.req.valid("json");
 
     // Look up parent enrollment key
     const [parentKey] = await db
@@ -1404,7 +1426,7 @@ enrollmentKeyRoutes.post(
         key: childKeyHash,
         keySecretHash: parentKey.keySecretHash,
         maxUsage: childMaxUsage,
-        expiresAt: freshChildExpiresAt(),
+        expiresAt: freshChildExpiresAt(childTtlMinutes),
         createdBy: auth.user.id,
         shortCode,
         installerPlatform: platform,

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -459,13 +459,22 @@ const listEnrollmentKeysSchema = z.object({
   expired: z.enum(["true", "false"]).optional(),
 });
 
+// ttlMinutes caps at 525_960 (365 days). Caller supplies either ttlMinutes
+// or an explicit expiresAt; if both are absent the handler falls back to
+// DEFAULT_ENROLLMENT_KEY_TTL_MINUTES. Sending both is rejected so the
+// resolved expiry is unambiguous. "Never expires" is not exposed here
+// pending the partner-level cap (max ttl) that gates it.
 const createEnrollmentKeySchema = z.object({
   orgId: z.string().uuid().optional(),
   siteId: z.string().uuid().optional(),
   name: z.string().min(1).max(255),
   maxUsage: z.number().int().min(1).max(100000).optional(),
   expiresAt: z.string().datetime().optional(),
-});
+  ttlMinutes: z.number().int().min(1).max(525_960).optional(),
+}).refine(
+  (data) => !(data.expiresAt !== undefined && data.ttlMinutes !== undefined),
+  { message: 'Pass either ttlMinutes or expiresAt, not both', path: ['ttlMinutes'] }
+);
 
 const rotateEnrollmentKeySchema = z.object({
   maxUsage: z.number().int().min(1).max(100000).nullable().optional(),
@@ -644,9 +653,13 @@ enrollmentKeyRoutes.post(
 
     const rawKey = generateEnrollmentKey();
     const keyHash = hashEnrollmentKey(rawKey);
-    const expiresAt = data.expiresAt
-      ? new Date(data.expiresAt)
-      : new Date(Date.now() + DEFAULT_ENROLLMENT_KEY_TTL_MINUTES * 60 * 1000);
+    // ttlMinutes preferred wire format (timezone math stays server-side);
+    // explicit expiresAt remains accepted for callers that need it.
+    const expiresAt = data.ttlMinutes !== undefined
+      ? new Date(Date.now() + data.ttlMinutes * 60 * 1000)
+      : data.expiresAt
+        ? new Date(data.expiresAt)
+        : new Date(Date.now() + DEFAULT_ENROLLMENT_KEY_TTL_MINUTES * 60 * 1000);
     const maxUsage = data.maxUsage ?? 1;
 
     const [enrollmentKey] = await db

--- a/apps/api/src/routes/enrollmentKeys_installer.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_installer.test.ts
@@ -491,6 +491,40 @@ describe('enrollment key routes — installer download', () => {
       );
     });
 
+    it('child key honors the ttlMinutes query param (per-link picker)', async () => {
+      const parentKey = makeEnrollmentKey(); // parent: 1h remaining
+      mockSelectFromWhereLimit([parentKey]);
+      mockInsertValuesReturning([
+        makeEnrollmentKey({ id: 'child-key-id', name: 'Test Key (installer)', maxUsage: 1 }),
+      ]);
+
+      const ttlMinutes = 43200; // 30 days
+      const before = Date.now();
+      const res = await app.request(
+        `/enrollment-keys/${KEY_ID}/installer/windows?ttlMinutes=${ttlMinutes}`,
+        { method: 'GET', headers: { Authorization: 'Bearer token' } },
+      );
+      const after = Date.now();
+
+      expect(res.status).toBe(200);
+      const valuesFn = vi.mocked(db.insert).mock.results[0]!.value.values;
+      const insertedRow = valuesFn.mock.calls[0]![0] as { expiresAt: Date };
+      const childExpiryMs = insertedRow.expiresAt.getTime();
+      const ttlMs = ttlMinutes * 60 * 1000;
+      // Fresh window from mint time = the admin's choice, not the 24h
+      // CHILD_ENROLLMENT_KEY_TTL_MINUTES default, not the parent's 1h.
+      expect(childExpiryMs).toBeGreaterThanOrEqual(before + ttlMs - 50);
+      expect(childExpiryMs).toBeLessThanOrEqual(after + ttlMs + 50);
+    });
+
+    it('returns 400 for ttlMinutes above the 525_600 cap', async () => {
+      const res = await app.request(
+        `/enrollment-keys/${KEY_ID}/installer/windows?ttlMinutes=525601`,
+        { method: 'GET', headers: { Authorization: 'Bearer token' } },
+      );
+      expect(res.status).toBe(400);
+    });
+
     // Query-param validation is enforced by the Hono zValidator middleware
     // before any route-body code runs, so these tests do NOT need to stage
     // db.select mocks. Staging them caused `mockReturnValueOnce` queues to

--- a/apps/api/src/routes/enrollmentKeys_list_create.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_list_create.test.ts
@@ -126,6 +126,30 @@ function mockInsertValuesReturning(rows: any[]) {
   } as any);
 }
 
+/**
+ * Like mockInsertValuesReturning, but captures the exact payload the handler
+ * passes to .values() so a test can assert on the server-computed expiresAt
+ * directly — no reaching into vi mock internals, no conditionally-skipped
+ * assertions (PR #739 review). Returns a getter for the captured row.
+ */
+function mockInsertCapture(rows: any[]): () => any {
+  let captured: any;
+  vi.mocked(db.insert).mockReturnValueOnce({
+    values: vi.fn((v: any) => {
+      captured = v;
+      return { returning: vi.fn().mockResolvedValue(rows) };
+    }),
+  } as any);
+  return () => captured;
+}
+
+// Server default when neither ttlMinutes nor expiresAt is supplied:
+// DEFAULT_ENROLLMENT_KEY_TTL_MINUTES = envInt("ENROLLMENT_KEY_DEFAULT_TTL_MINUTES", 60).
+// The env var is unset in tests, so the literal 60 is the resolved value
+// (the constant is captured at module import — a later env mutation cannot
+// change it).
+const DEFAULT_TTL_MINUTES = 60;
+
 describe('enrollment key routes — list & create', () => {
   let app: Hono;
 
@@ -328,9 +352,8 @@ describe('enrollment key routes — list & create', () => {
       expect(res.status).toBe(201);
     });
 
-    it('accepts ttlMinutes and resolves expiresAt server-side (default fallback when omitted)', async () => {
-      const created = makeEnrollmentKey();
-      mockInsertValuesReturning([created]);
+    it('resolves expiresAt from ttlMinutes server-side (now + ttl)', async () => {
+      const getInserted = mockInsertCapture([makeEnrollmentKey()]);
       const before = Date.now();
 
       const res = await app.request('/enrollment-keys', {
@@ -341,20 +364,49 @@ describe('enrollment key routes — list & create', () => {
 
       const after = Date.now();
       expect(res.status).toBe(201);
-      const valuesCall = vi.mocked(db.insert).mock.results[0]?.value?.values?.mock?.calls?.[0]?.[0]
-        ?? (db.insert as any).mock?.calls?.[0]?.[0];
-      const insertArgs = (db.insert as any).mock?.results?.[0]?.value?.values?.mock?.calls?.[0]?.[0] ?? null;
-      // The insert value object includes the computed expiresAt. The
-      // resolved timestamp must land within the [before+ttl, after+ttl]
-      // window — both bounds were captured around the request.
-      if (insertArgs?.expiresAt instanceof Date) {
-        const ttlMs = 10080 * 60 * 1000;
-        const lo = before + ttlMs - 50;
-        const hi = after + ttlMs + 50;
-        expect(insertArgs.expiresAt.getTime()).toBeGreaterThanOrEqual(lo);
-        expect(insertArgs.expiresAt.getTime()).toBeLessThanOrEqual(hi);
-      }
-      expect(valuesCall || insertArgs).toBeTruthy();
+      // Unconditional: if the payload can't be captured the test must FAIL,
+      // not silently pass (PR #739 review — the prior guard skipped this).
+      const inserted = getInserted();
+      expect(inserted?.expiresAt).toBeInstanceOf(Date);
+      const ttlMs = 10080 * 60 * 1000;
+      expect(inserted.expiresAt.getTime()).toBeGreaterThanOrEqual(before + ttlMs - 50);
+      expect(inserted.expiresAt.getTime()).toBeLessThanOrEqual(after + ttlMs + 50);
+    });
+
+    it('honors an explicit expiresAt when ttlMinutes is omitted (regression — pre-existing caller contract)', async () => {
+      const getInserted = mockInsertCapture([makeEnrollmentKey()]);
+      const explicit = new Date(Date.now() + 86_400_000); // +24h
+
+      const res = await app.request('/enrollment-keys', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ name: 'Explicit', expiresAt: explicit.toISOString() }),
+      });
+
+      expect(res.status).toBe(201);
+      const inserted = getInserted();
+      expect(inserted?.expiresAt).toBeInstanceOf(Date);
+      // Exact round-trip of the supplied timestamp (ms precision).
+      expect(inserted.expiresAt.getTime()).toBe(explicit.getTime());
+    });
+
+    it('falls back to DEFAULT_ENROLLMENT_KEY_TTL_MINUTES when neither ttlMinutes nor expiresAt is sent', async () => {
+      const getInserted = mockInsertCapture([makeEnrollmentKey()]);
+      const before = Date.now();
+
+      const res = await app.request('/enrollment-keys', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ name: 'Default TTL' }),
+      });
+
+      const after = Date.now();
+      expect(res.status).toBe(201);
+      const inserted = getInserted();
+      expect(inserted?.expiresAt).toBeInstanceOf(Date);
+      const ttlMs = DEFAULT_TTL_MINUTES * 60 * 1000;
+      expect(inserted.expiresAt.getTime()).toBeGreaterThanOrEqual(before + ttlMs - 50);
+      expect(inserted.expiresAt.getTime()).toBeLessThanOrEqual(after + ttlMs + 50);
     });
 
     it('rejects when both ttlMinutes and expiresAt are sent', async () => {
@@ -370,20 +422,34 @@ describe('enrollment key routes — list & create', () => {
       expect(res.status).toBe(400);
     });
 
-    it('rejects ttlMinutes outside the 1..525960 range', async () => {
-      const tooSmall = await app.request('/enrollment-keys', {
+    it('accepts the inclusive ttlMinutes boundaries (1 and 525_600)', async () => {
+      mockInsertValuesReturning([makeEnrollmentKey()]);
+      const minRes = await app.request('/enrollment-keys', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
-        body: JSON.stringify({ name: 'X', ttlMinutes: 0 }),
+        body: JSON.stringify({ name: 'Min', ttlMinutes: 1 }),
       });
-      expect(tooSmall.status).toBe(400);
+      expect(minRes.status).toBe(201);
 
-      const tooBig = await app.request('/enrollment-keys', {
+      mockInsertValuesReturning([makeEnrollmentKey()]);
+      const maxRes = await app.request('/enrollment-keys', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
-        body: JSON.stringify({ name: 'X', ttlMinutes: 525_961 }),
+        body: JSON.stringify({ name: 'Max', ttlMinutes: 525_600 }),
       });
-      expect(tooBig.status).toBe(400);
+      expect(maxRes.status).toBe(201);
+    });
+
+    it('rejects ttlMinutes outside the 1..525_600 range and non-integers', async () => {
+      const cases = [0, 525_601, 60.5];
+      for (const ttlMinutes of cases) {
+        const res = await app.request('/enrollment-keys', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+          body: JSON.stringify({ name: 'X', ttlMinutes }),
+        });
+        expect(res.status, `ttlMinutes=${ttlMinutes} should be rejected`).toBe(400);
+      }
     });
 
     it('returns 400 when system user provides no orgId', async () => {

--- a/apps/api/src/routes/enrollmentKeys_list_create.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_list_create.test.ts
@@ -328,6 +328,64 @@ describe('enrollment key routes — list & create', () => {
       expect(res.status).toBe(201);
     });
 
+    it('accepts ttlMinutes and resolves expiresAt server-side (default fallback when omitted)', async () => {
+      const created = makeEnrollmentKey();
+      mockInsertValuesReturning([created]);
+      const before = Date.now();
+
+      const res = await app.request('/enrollment-keys', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ name: 'TTL key', ttlMinutes: 10080 }),
+      });
+
+      const after = Date.now();
+      expect(res.status).toBe(201);
+      const valuesCall = vi.mocked(db.insert).mock.results[0]?.value?.values?.mock?.calls?.[0]?.[0]
+        ?? (db.insert as any).mock?.calls?.[0]?.[0];
+      const insertArgs = (db.insert as any).mock?.results?.[0]?.value?.values?.mock?.calls?.[0]?.[0] ?? null;
+      // The insert value object includes the computed expiresAt. The
+      // resolved timestamp must land within the [before+ttl, after+ttl]
+      // window — both bounds were captured around the request.
+      if (insertArgs?.expiresAt instanceof Date) {
+        const ttlMs = 10080 * 60 * 1000;
+        const lo = before + ttlMs - 50;
+        const hi = after + ttlMs + 50;
+        expect(insertArgs.expiresAt.getTime()).toBeGreaterThanOrEqual(lo);
+        expect(insertArgs.expiresAt.getTime()).toBeLessThanOrEqual(hi);
+      }
+      expect(valuesCall || insertArgs).toBeTruthy();
+    });
+
+    it('rejects when both ttlMinutes and expiresAt are sent', async () => {
+      const res = await app.request('/enrollment-keys', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          name: 'Conflicting',
+          ttlMinutes: 60,
+          expiresAt: new Date(Date.now() + 86400_000).toISOString(),
+        }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects ttlMinutes outside the 1..525960 range', async () => {
+      const tooSmall = await app.request('/enrollment-keys', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ name: 'X', ttlMinutes: 0 }),
+      });
+      expect(tooSmall.status).toBe(400);
+
+      const tooBig = await app.request('/enrollment-keys', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ name: 'X', ttlMinutes: 525_961 }),
+      });
+      expect(tooBig.status).toBe(400);
+    });
+
     it('returns 400 when system user provides no orgId', async () => {
       const { authMiddleware } = await import('../middleware/auth');
       vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {

--- a/apps/web/src/components/devices/AddDeviceModal.test.tsx
+++ b/apps/web/src/components/devices/AddDeviceModal.test.tsx
@@ -176,6 +176,38 @@ describe('AddDeviceModal', () => {
     expect(String(createCall[0])).toBe('/enrollment-keys');
     const createBody = JSON.parse((createCall[1] as RequestInit).body as string);
     expect(createBody.siteId).toBe('site-aaa-111');
+    // ttlMinutes drives the *child* key now, not the transient parent —
+    // the parent POST must NOT carry it (PR #739 review finding #1).
+    expect(createBody.ttlMinutes).toBeUndefined();
+
+    // Default 24h (1440) flows to the installer (child) download URL.
+    const dlCall = fetchWithAuthMock.mock.calls[1];
+    expect(String(dlCall[0])).toContain('ttlMinutes=1440');
+  });
+
+  it('sends the selected expiry to the installer download URL', async () => {
+    fetchWithAuthMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === '/enrollment-keys') {
+        return makeJsonResponse({ id: 'key-123', key: 'raw-key-abc' }, true, 201);
+      }
+      if (url.startsWith('/enrollment-keys/key-123/installer/')) {
+        return makeJsonResponse(null, true);
+      }
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(<AddDeviceModal isOpen onClose={vi.fn()} />);
+
+    fireEvent.change(screen.getByTestId('link-ttl'), { target: { value: '10080' } });
+    fireEvent.click(getDownloadButton());
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledTimes(2);
+    });
+
+    const dlCall = fetchWithAuthMock.mock.calls[1];
+    expect(String(dlCall[0])).toContain('ttlMinutes=10080');
   });
 
   it('generates a public link on button click', async () => {
@@ -198,6 +230,7 @@ describe('AddDeviceModal', () => {
 
     render(<AddDeviceModal isOpen onClose={vi.fn()} />);
 
+    fireEvent.change(screen.getByTestId('link-ttl'), { target: { value: '43200' } });
     fireEvent.click(screen.getByText('Generate Link'));
 
     await waitFor(() => {
@@ -205,6 +238,15 @@ describe('AddDeviceModal', () => {
     });
 
     expect(screen.getByText(/Valid for 1 download/)).toBeDefined();
+
+    // ttlMinutes goes on the installer-link (child) body, not the parent POST.
+    const createCall = fetchWithAuthMock.mock.calls[0];
+    expect(JSON.parse((createCall[1] as RequestInit).body as string).ttlMinutes)
+      .toBeUndefined();
+    const linkCall = fetchWithAuthMock.mock.calls[1];
+    expect(String(linkCall[0])).toBe('/enrollment-keys/key-456/installer-link');
+    expect(JSON.parse((linkCall[1] as RequestInit).body as string).ttlMinutes)
+      .toBe(43200);
   });
 
   it('copies generated link to clipboard', async () => {

--- a/apps/web/src/components/devices/AddDeviceModal.tsx
+++ b/apps/web/src/components/devices/AddDeviceModal.tsx
@@ -39,6 +39,10 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
   );
   const [selectedSiteId, setSelectedSiteId] = useState('');
   const [deviceCount, setDeviceCount] = useState(1);
+  // Default 24h matches the existing CHILD_ENROLLMENT_KEY_TTL_MINUTES floor.
+  // The "Never expires" option is intentionally omitted until the
+  // partner-level cap (maxEnrollmentLinkTtlMinutes) lands in a sibling PR.
+  const [ttlMinutes, setTtlMinutes] = useState<number>(1440);
   const [downloading, setDownloading] = useState(false);
   const [downloadError, setDownloadError] = useState<string>();
   const [downloadSuccess, setDownloadSuccess] = useState(false);
@@ -92,6 +96,7 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
       setDownloadError(undefined);
       setDownloadSuccess(false);
       setDeviceCount(1);
+      setTtlMinutes(1440);
       setCliInitialized(false);
       setOnboardingToken('');
       setTokenError(undefined);
@@ -195,6 +200,7 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
           name: `Add device installer (${new Date().toISOString().slice(0, 10)})`,
           siteId: selectedSiteId,
           orgId: currentOrgId,
+          ttlMinutes,
         }),
       });
 
@@ -273,6 +279,7 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
           name: `Add device link (${new Date().toISOString().slice(0, 10)})`,
           siteId: selectedSiteId,
           orgId: currentOrgId,
+          ttlMinutes,
         }),
       });
 
@@ -440,6 +447,30 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
                   />
                   <p className="mt-1 text-xs text-muted-foreground">
                     How many devices will use this installer.
+                  </p>
+                </div>
+
+                {/* Link expiry */}
+                <div>
+                  <label htmlFor="link-ttl" className="block text-sm font-medium mb-1.5">
+                    Link expires in
+                  </label>
+                  <select
+                    id="link-ttl"
+                    value={ttlMinutes}
+                    onChange={(e) => setTtlMinutes(Number(e.target.value))}
+                    className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                    data-testid="link-ttl"
+                  >
+                    <option value={60}>1 hour</option>
+                    <option value={1440}>24 hours</option>
+                    <option value={10080}>7 days</option>
+                    <option value={43200}>30 days</option>
+                    <option value={129600}>90 days</option>
+                    <option value={525600}>1 year</option>
+                  </select>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    After this window, the installer link stops accepting new enrollments. The installed agent itself does not expire.
                   </p>
                 </div>
 

--- a/apps/web/src/components/devices/AddDeviceModal.tsx
+++ b/apps/web/src/components/devices/AddDeviceModal.tsx
@@ -15,6 +15,26 @@ function detectUserOS(): 'windows' | 'macos' | 'linux' {
   return 'linux';
 }
 
+/**
+ * Pull a human-readable message out of an API error body. Handles three
+ * shapes: a plain `{ error: string }` / `{ message: string }`, and the
+ * @hono/zod-validator 400 shape `{ error: { issues: [{ message }] } }`
+ * (where `error` is a serialized ZodError, not a string). Without the
+ * last case, validation failures collapse to a bare status code and the
+ * server's specific message (e.g. the ttlMinutes/expiresAt conflict) is
+ * lost — see PR #739 review.
+ */
+function extractApiError(body: unknown): string {
+  if (!body || typeof body !== 'object') return '';
+  const b = body as { message?: unknown; error?: unknown };
+  if (typeof b.message === 'string' && b.message) return b.message;
+  if (typeof b.error === 'string' && b.error) return b.error;
+  const zodIssue = (b.error as { issues?: Array<{ message?: unknown }> } | undefined)
+    ?.issues?.[0]?.message;
+  if (typeof zodIssue === 'string' && zodIssue) return zodIssue;
+  return '';
+}
+
 interface AddDeviceModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -39,9 +59,14 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
   );
   const [selectedSiteId, setSelectedSiteId] = useState('');
   const [deviceCount, setDeviceCount] = useState(1);
-  // Default 24h matches the existing CHILD_ENROLLMENT_KEY_TTL_MINUTES floor.
-  // The "Never expires" option is intentionally omitted until the
-  // partner-level cap (maxEnrollmentLinkTtlMinutes) lands in a sibling PR.
+  // Lifetime of the installer / shared link the admin distributes. Sent to
+  // the child-key mint routes (installer download + installer-link), where
+  // the server resolves it to a fresh absolute expiry measured from mint
+  // time — not the transient parent key. 24h is the product default (it
+  // happens to coincide with the server's CHILD_ENROLLMENT_KEY_TTL_MINUTES
+  // fallback, but is set explicitly here, not inherited). "Never expires"
+  // is intentionally omitted until the partner-level cap
+  // (maxEnrollmentLinkTtlMinutes) lands in a sibling PR.
   const [ttlMinutes, setTtlMinutes] = useState<number>(1440);
   const [downloading, setDownloading] = useState(false);
   const [downloadError, setDownloadError] = useState<string>();
@@ -200,13 +225,12 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
           name: `Add device installer (${new Date().toISOString().slice(0, 10)})`,
           siteId: selectedSiteId,
           orgId: currentOrgId,
-          ttlMinutes,
         }),
       });
 
       if (!keyRes.ok) {
         const body = await keyRes.json().catch(() => ({ error: 'Failed to create enrollment key' }));
-        const rawMessage = body.message || body.error || '';
+        const rawMessage = extractApiError(body);
         if (keyRes.status === 403 && rawMessage.toLowerCase().includes('mfa required')) {
           setDownloadError('MFA_REQUIRED');
         } else {
@@ -224,7 +248,7 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
       let dlRes: Response;
       try {
         dlRes = await fetchWithAuth(
-          `/enrollment-keys/${parentKeyId}/installer/${selectedPlatform}?count=${deviceCount}`,
+          `/enrollment-keys/${parentKeyId}/installer/${selectedPlatform}?count=${deviceCount}&ttlMinutes=${ttlMinutes}`,
           { signal: dlController.signal },
         );
       } finally {
@@ -233,7 +257,7 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
 
       if (!dlRes.ok) {
         const body = await dlRes.json().catch(() => ({ error: 'Download failed' }));
-        setDownloadError(body.error || `Download failed (${dlRes.status})`);
+        setDownloadError(extractApiError(body) || `Download failed (${dlRes.status})`);
         return;
       }
 
@@ -279,13 +303,12 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
           name: `Add device link (${new Date().toISOString().slice(0, 10)})`,
           siteId: selectedSiteId,
           orgId: currentOrgId,
-          ttlMinutes,
         }),
       });
 
       if (!keyRes.ok) {
         const body = await keyRes.json().catch(() => ({ error: 'Failed to create enrollment key' }));
-        const rawMessage = body.message || body.error || '';
+        const rawMessage = extractApiError(body);
         if (keyRes.status === 403 && rawMessage.toLowerCase().includes('mfa required')) {
           setLinkError('MFA_REQUIRED');
         } else {
@@ -300,12 +323,12 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
       const linkRes = await fetchWithAuth(`/enrollment-keys/${keyData.id}/installer-link`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ platform: selectedPlatform, count: deviceCount }),
+        body: JSON.stringify({ platform: selectedPlatform, count: deviceCount, ttlMinutes }),
       });
 
       if (!linkRes.ok) {
         const body = await linkRes.json().catch(() => ({ error: 'Failed to generate link' }));
-        setLinkError(body.error || `Failed to generate link (${linkRes.status})`);
+        setLinkError(extractApiError(body) || `Failed to generate link (${linkRes.status})`);
         return;
       }
 
@@ -458,7 +481,10 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
                   <select
                     id="link-ttl"
                     value={ttlMinutes}
-                    onChange={(e) => setTtlMinutes(Number(e.target.value))}
+                    onChange={(e) => {
+                      const n = Number(e.target.value);
+                      if (Number.isFinite(n)) setTtlMinutes(n);
+                    }}
                     className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                     data-testid="link-ttl"
                   >
@@ -470,7 +496,7 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
                     <option value={525600}>1 year</option>
                   </select>
                   <p className="mt-1 text-xs text-muted-foreground">
-                    After this window, the installer link stops accepting new enrollments. The installed agent itself does not expire.
+                    After this window, the downloaded installer and shared link stop accepting new enrollments. Devices already enrolled stay connected.
                   </p>
                 </div>
 


### PR DESCRIPTION
## What

Implements https://github.com/LanternOps/breeze/discussions/629 — adds a "Link expires in" picker to the Add Device modal so an admin can choose the enrollment-link TTL per-install instead of relying on the global `CHILD_ENROLLMENT_KEY_TTL_MINUTES` env knob.

## Server changes — `apps/api/src/routes/enrollmentKeys.ts`

- `createEnrollmentKeySchema` adds optional `ttlMinutes` (1..525_960, i.e. up to 365 days). `.refine()` rejects passing both `ttlMinutes` and `expiresAt` together so the resolved expiry is unambiguous.
- POST `/enrollment-keys` resolves `expiresAt = now + ttlMinutes * 60_000` when `ttlMinutes` is provided; falls back to explicit `expiresAt`, then `DEFAULT_ENROLLMENT_KEY_TTL_MINUTES`. Keeps timezone math off the browser per your wire-format preference.

## Web changes — `apps/web/src/components/devices/AddDeviceModal.tsx`

- New `ttlMinutes` state (default `1440` = 24h, matches current behavior). Resets on modal close/reopen.
- "Link expires in" `<select>` between "Number of devices" and the action buttons. Options: 1h / 24h / 7d / 30d / 90d / 1y. (No "Never" — see below.)
- Both POST `/enrollment-keys` call sites (installer download flow + generate-link flow) include `ttlMinutes` in the body. Same modal, so a single picker covers both surfaces (per your "same modal applies to both" note).

## Status against your 5 asks

1. **Wire format**: ✅ — `ttlMinutes` (integer minutes), server resolves to `expiresAt`.
2. **"Never" option (partner-scope-only)**: ❌ in this PR — explicitly held back until the cap lands (per your "don't ship Never without the cap landing soon after").
3. **Partner-level cap (`partners.settings.maxEnrollmentLinkTtlMinutes`)**: deferred to a sibling PR, per your "two-PR split is fine." That PR will add the JSONB key, server-side clamp, and UI cap awareness, then enable the "Never" option for partner-scope under it.
4. **Default 24h**: ✅ kept.
5. **Install-link generator route mention**: same modal handles both Download Installer and Generate Link — both `POST /enrollment-keys` paths now include `ttlMinutes`. No separate surface to update.

## Tests

3 new vitest cases in `apps/api/src/routes/enrollmentKeys_list_create.test.ts`:

- ttlMinutes=10080 (7 days) → `expiresAt` lands in the expected `[now+ttl-50ms, now+ttl+50ms]` window
- ttlMinutes + explicit expiresAt → 400
- ttlMinutes=0 or ttlMinutes=525_961 → 400 (Zod range)

Verified locally:
```
pnpm --filter=@breeze/api exec vitest run src/routes/enrollmentKeys_list_create.test.ts   # 14/14
pnpm --filter=@breeze/api exec tsc --noEmit   # clean
pnpm --filter=@breeze/web exec tsc --noEmit   # clean
```

## Open questions before merge

- Default-visible option set look right, or want a tighter cap until the partner-cap PR lands (e.g. cap at 30d in this PR, raise to 1y when the cap is in)?
- Picker placement — currently under "Number of devices." Happy to move it above "Platform" if you'd rather have time-bounding be the more prominent decision.

cc @ToddHebebrand