### PR TITLE
fix(api,mobile): PR #696 criticals — RLS system-bypass, system-ctx wrapper, consent race, schema drift

### DIFF
--- a/apps/api/migrations/2026-05-16-approval-shape6-system-bypass.sql
+++ b/apps/api/migrations/2026-05-16-approval-shape6-system-bypass.sql
@@ -1,0 +1,47 @@
+-- 2026-05-16: approval_requests + account_deletion_requests — add a
+-- system-scope bypass to the Shape-6 user-scoped RLS policies.
+--
+-- PR #696 Critical #1 / #2. The policies created by
+-- 2026-05-06-approval-requests.sql and 2026-05-07-account-deletion-requests.sql
+-- were:
+--
+--   USING (user_id = breeze_current_user_id())
+--   WITH CHECK (user_id = breeze_current_user_id())
+--
+-- with NO system-scope OR branch. Two non-request code paths run under
+-- SYSTEM DB scope, where breeze.user_id is unset so breeze_current_user_id()
+-- is NULL and `user_id = NULL` matches zero rows under FORCE RLS for the
+-- unprivileged breeze_app role:
+--
+--   * approvalExpiryReaper (BullMQ worker via withSystemDbAccessContext) —
+--     the bounded UPDATE...FROM transitioned 0 rows every run, so expired
+--     approvals were never reaped and mobile-only approvals always burned
+--     the full waitForApproval ceiling.
+--   * the account-deletion admin queue (routes/auth/accountDeletion.ts via
+--     runWithSystemDbAccess) — list/get/process all returned empty/404, so
+--     admins could never see or action a deletion request.
+--
+-- Fix: mirror the oauth_authorization_codes (2026-04-24) / sessions policy
+-- shape by adding `OR breeze_current_scope() = 'system'` to both USING and
+-- WITH CHECK. user_id remains the canonical tenancy axis under any user
+-- scope; only genuine system-scope contexts (background workers, the admin
+-- queue) gain access. No cross-user exposure: a request-scoped caller always
+-- has breeze.scope != 'system', so the user_id predicate still governs.
+--
+-- Idempotent: DROP POLICY IF EXISTS then recreate with a deterministic body.
+-- Re-applying is a true no-op. autoMigrate wraps each file in a transaction,
+-- so no inner BEGIN/COMMIT.
+
+DROP POLICY IF EXISTS approval_requests_user_scope ON approval_requests;
+DO $$ BEGIN
+  CREATE POLICY approval_requests_user_scope ON approval_requests
+    USING     (user_id = breeze_current_user_id() OR breeze_current_scope() = 'system')
+    WITH CHECK (user_id = breeze_current_user_id() OR breeze_current_scope() = 'system');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DROP POLICY IF EXISTS account_deletion_requests_user_scope ON account_deletion_requests;
+DO $$ BEGIN
+  CREATE POLICY account_deletion_requests_user_scope ON account_deletion_requests
+    USING     (user_id = breeze_current_user_id() OR breeze_current_scope() = 'system')
+    WITH CHECK (user_id = breeze_current_user_id() OR breeze_current_scope() = 'system');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;

--- a/apps/api/src/__tests__/integration/approval-system-scope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/approval-system-scope.integration.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Integration test for PR #696 Critical #1 + #2.
+ *
+ * Both the approval-expiry reaper and the account-deletion admin queue run
+ * under SYSTEM DB scope, but the Shape-6 policies on `approval_requests` and
+ * `account_deletion_requests` were `user_id = breeze_current_user_id()` with
+ * NO system-scope OR branch. Under system scope `breeze_current_user_id()` is
+ * NULL, so FORCE RLS hid every row from `breeze_app`:
+ *
+ *   - #2: `reapExpiredApprovals()` transitioned 0 rows — expiry never ran.
+ *   - #1: the account-deletion admin endpoints (which use
+ *     `runWithSystemDbAccess`) saw an empty queue. #1 also had a second
+ *     defect: `accountDeletion.ts`'s `runWithSystemDbAccess` lacked the
+ *     `runOutsideDbContext` wrap, so inside an authenticated request it was
+ *     a no-op that inherited the caller's (admin's) request scope.
+ *
+ * These tests assert the composed production behavior against a real DB as
+ * the unprivileged `breeze_app` role. They fail (RED) until the fix-forward
+ * migration adds `OR breeze_current_scope() = 'system'` to both policies AND
+ * `runWithSystemDbAccess` is corrected to escape the ambient request context.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { eq } from 'drizzle-orm';
+import './setup';
+import { getTestDb } from './setup';
+import { withDbAccessContext, withSystemDbAccessContext } from '../../db';
+import { approvalRequests } from '../../db/schema/approvals';
+import { accountDeletionRequests, partners, users } from '../../db/schema';
+import { reapExpiredApprovals } from '../../jobs/approvalExpiryReaper';
+import { runWithSystemDbAccess } from '../../routes/auth/accountDeletion';
+
+function userContext(userId: string) {
+  return {
+    scope: 'organization' as const,
+    orgId: null,
+    accessibleOrgIds: [],
+    accessiblePartnerIds: [],
+    userId,
+  };
+}
+
+let partnerId: string;
+let adminId: string;
+let requesterId: string;
+
+beforeEach(async () => {
+  // Seed as the superuser test connection (bypasses RLS) — setup.ts's
+  // cleanupDatabase() TRUNCATEs users CASCADE on beforeEach, so the
+  // approval/deletion rows are cleared transitively each test.
+  const tdb = getTestDb();
+  const [p] = await tdb
+    .insert(partners)
+    .values({ name: 'PR696 System Scope', slug: `pr696-sysscope-${Date.now()}`, type: 'msp', plan: 'pro', status: 'active' })
+    .returning({ id: partners.id });
+  partnerId = p!.id;
+  const [admin, requester] = await tdb
+    .insert(users)
+    .values([
+      { partnerId, email: `admin-${Date.now()}@pr696.test`, name: 'PR696 Admin', status: 'active' },
+      { partnerId, email: `req-${Date.now()}@pr696.test`, name: 'PR696 Requester', status: 'active' },
+    ])
+    .returning({ id: users.id });
+  adminId = admin!.id;
+  requesterId = requester!.id;
+});
+
+describe('PR#696 #2 — approvalExpiryReaper transitions overdue rows under system scope', () => {
+  it('expires a pending, overdue approval and reports the count', async () => {
+    const tdb = getTestDb();
+    const [row] = await tdb
+      .insert(approvalRequests)
+      .values({
+        userId: requesterId,
+        requestingClientLabel: 'pr696-reaper-client',
+        actionLabel: 'pr696.reaper.overdue',
+        actionToolName: 'pr696.reaper',
+        riskTier: 'low',
+        riskSummary: 'overdue approval should be reaped',
+        expiresAt: new Date(Date.now() - 60_000), // already expired
+      })
+      .returning({ id: approvalRequests.id });
+
+    // Mirror the production BullMQ worker: it wraps reapExpiredApprovals in
+    // withSystemDbAccessContext (no ambient request context, so this genuinely
+    // enters system scope). Calling it bare would run at scope='none'.
+    const reaped = await withSystemDbAccessContext(() => reapExpiredApprovals());
+
+    expect(reaped).toBe(1);
+
+    const [after] = await tdb
+      .select({ status: approvalRequests.status })
+      .from(approvalRequests)
+      .where(eq(approvalRequests.id, row!.id));
+    expect(after!.status).toBe('expired');
+  });
+
+  it('does not touch an approval that has not yet expired', async () => {
+    const tdb = getTestDb();
+    const [row] = await tdb
+      .insert(approvalRequests)
+      .values({
+        userId: requesterId,
+        requestingClientLabel: 'pr696-reaper-client',
+        actionLabel: 'pr696.reaper.fresh',
+        actionToolName: 'pr696.reaper',
+        riskTier: 'low',
+        riskSummary: 'fresh approval must survive the reaper',
+        expiresAt: new Date(Date.now() + 5 * 60_000),
+      })
+      .returning({ id: approvalRequests.id });
+
+    const reaped = await withSystemDbAccessContext(() => reapExpiredApprovals());
+
+    expect(reaped).toBe(0);
+    const [after] = await tdb
+      .select({ status: approvalRequests.status })
+      .from(approvalRequests)
+      .where(eq(approvalRequests.id, row!.id));
+    expect(after!.status).toBe('pending');
+  });
+});
+
+describe('PR#696 #1 — account-deletion admin reads the queue under true system scope', () => {
+  it('runWithSystemDbAccess reaches another user\'s row even from within an ambient request scope', async () => {
+    const tdb = getTestDb();
+    await tdb.insert(accountDeletionRequests).values({
+      userId: requesterId,
+      processBy: new Date(Date.now() + 7 * 24 * 60 * 60_000),
+      reason: 'pr696 admin-queue visibility',
+    });
+
+    // Simulate the authenticated admin request: authMiddleware establishes a
+    // request-scoped DB context for the admin BEFORE the handler runs. The
+    // handler then calls runWithSystemDbAccess(...) — which must escape this
+    // ambient context to reach system scope.
+    const rows = await withDbAccessContext(userContext(adminId), async () =>
+      runWithSystemDbAccess(async () =>
+        getSystemScopedDeletionRequests(),
+      ),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.userId).toBe(requesterId);
+  });
+});
+
+// Helper kept outside the assertion so the query runs through the app `db`
+// proxy (breeze_app, RLS enforced) under whatever scope is active.
+async function getSystemScopedDeletionRequests() {
+  const { db } = await import('../../db');
+  return db
+    .select({ id: accountDeletionRequests.id, userId: accountDeletionRequests.userId })
+    .from(accountDeletionRequests);
+}

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -130,10 +130,15 @@ const USER_ID_SCOPED_TABLES: ReadonlySet<string> = new Set<string>([
   // System-scope bypass covers the adapter writes (runOutsideDbContext).
   'oauth_interactions',
   // approval_requests: MCP step-up approval records, scoped to the requesting
-  // user via breeze_current_user_id(). Shape 6 policy.
+  // user via breeze_current_user_id(). Shape 6 policy, plus an
+  // `OR breeze_current_scope() = 'system'` branch (migration
+  // 2026-05-16-approval-shape6-system-bypass.sql) so the BullMQ expiry
+  // reaper can transition rows under system scope.
   'approval_requests',
   // account_deletion_requests: user-initiated deletion queue records, scoped
-  // to the requesting user via breeze_current_user_id(). Shape 6 policy.
+  // to the requesting user via breeze_current_user_id(). Shape 6 policy with
+  // the same system-scope OR branch so the account-deletion admin queue
+  // (runWithSystemDbAccess) can read/process the queue.
   'account_deletion_requests',
 ]);
 
@@ -678,16 +683,13 @@ describe('approval_requests RLS — cross-user forge enforcement (Shape 6)', () 
   }
 
   afterAll(async () => {
-    // approval_requests policy has no system-scope OR branch, so system
-    // context cannot delete the row directly. Delete it as user A (the
-    // row's owner). Users/partners are dual-axis / partner-axis and DO
-    // accept system scope, so we tear those down via system context.
-    if (approvalAId && userAId) {
-      await withDbAccessContext(userContext(userAId), async () =>
-        db.delete(approvalRequests).where(eq(approvalRequests.id, approvalAId!))
-      );
-    }
+    // approval_requests now has a system-scope OR branch (migration
+    // 2026-05-16-approval-shape6-system-bypass.sql), so system context can
+    // tear the row down directly alongside the users/partners fixtures.
     await withSystemDbAccessContext(async () => {
+      if (approvalAId) {
+        await db.delete(approvalRequests).where(eq(approvalRequests.id, approvalAId!));
+      }
       if (userAId) await db.delete(users).where(eq(users.id, userAId));
       if (userBId) await db.delete(users).where(eq(users.id, userBId));
       if (partnerId) await db.delete(partners).where(eq(partners.id, partnerId));
@@ -768,9 +770,10 @@ describe('approval_requests RLS — cross-user forge enforcement (Shape 6)', () 
     expect(updated).toEqual([]);
 
     // Read back as user A (the row's owner) to confirm it is genuinely
-    // untouched. We can't use system scope here: the approval_requests
-    // policy is `user_id = breeze_current_user_id()` with no system-scope
-    // OR branch, so system context has no read access either.
+    // untouched. Reading as the owner is a deliberately stronger assertion
+    // than a system-scope read: it proves the row is intact from the user
+    // whose tenancy axis governs it, not merely visible to the privileged
+    // system context (which the policy now also permits).
     const actual = await withDbAccessContext(userContext(userAId), async () =>
       db
         .select({ id: approvalRequests.id, status: approvalRequests.status })

--- a/apps/api/src/db/schema/oauth.ts
+++ b/apps/api/src/db/schema/oauth.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm';
-import { pgTable, text, uuid, jsonb, timestamp, index, primaryKey } from 'drizzle-orm/pg-core';
+import { pgTable, text, uuid, jsonb, timestamp, index, uniqueIndex, primaryKey } from 'drizzle-orm/pg-core';
 import { partners, organizations } from './orgs';
 import { users } from './users';
 
@@ -150,5 +150,9 @@ export const oauthClientBlocks = pgTable('oauth_client_blocks', {
   blockedUntil: timestamp('blocked_until', { withTimezone: true }),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
 }, (table) => ({
-  orgClientIdx: index('oauth_client_blocks_client_idx').on(table.clientId),
+  // Mirrors migration 2026-05-07-c-mobile-device-and-oauth-lifecycle.sql:
+  // one org-wide block per (org, client) — the lifecycle "refresh-or-insert"
+  // upsert relies on this uniqueness — plus a client_id lookup index.
+  orgClientUniq: uniqueIndex('oauth_client_blocks_org_client_uniq').on(table.orgId, table.clientId),
+  clientIdx: index('oauth_client_blocks_client_idx').on(table.clientId),
 }));

--- a/apps/api/src/routes/auth/accountDeletion.ts
+++ b/apps/api/src/routes/auth/accountDeletion.ts
@@ -26,9 +26,20 @@ import {
 } from './helpers';
 
 const { db } = dbModule;
-const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+export const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
   const withSystem = dbModule.withSystemDbAccessContext;
-  return typeof withSystem === 'function' ? withSystem(fn) : fn();
+  if (typeof withSystem !== 'function') return fn();
+  // Escape any ambient request-scoped DB context BEFORE entering system
+  // scope. authMiddleware wraps the admin handler in withDbAccessContext
+  // (the admin's own partner/org scope); withSystemDbAccessContext
+  // short-circuits when a context already exists, so without
+  // runOutsideDbContext these "system" queries silently ran as the admin's
+  // own user and the deletion-request queue always came back empty. Mirror
+  // lifecycle.ts's asSystem. See PR #696 Critical #1.
+  const runOutside = dbModule.runOutsideDbContext;
+  return typeof runOutside === 'function'
+    ? runOutside(() => withSystem(fn))
+    : withSystem(fn);
 };
 
 export const accountDeletionRoutes = new Hono();

--- a/apps/mobile/src/screens/approvals/ApprovalScreen.tsx
+++ b/apps/mobile/src/screens/approvals/ApprovalScreen.tsx
@@ -21,6 +21,7 @@ import { ActionHeadline } from './components/ActionHeadline';
 import { DetailsCollapse } from './components/DetailsCollapse';
 import { RiskBand } from './components/RiskBand';
 import { ApprovalButtons } from './components/ApprovalButtons';
+import { decisionTarget } from './decisionTarget';
 import { SuspiciousReportSheet } from './components/SuspiciousReportSheet';
 import { Toast } from '../../components/Toast';
 
@@ -105,14 +106,21 @@ export function ApprovalScreen() {
     transform: [{ translateX: denyShake.value }],
   }));
 
-  function handleApprove() {
-    if (!focused) return;
+  function handleApprove(id: string) {
+    // Consent is bound to the request the user saw at press time. If focus
+    // swapped during the biometric prompt, abort instead of approving a
+    // different action. See PR #696 Critical #3 / decisionTarget.ts.
+    const target = decisionTarget(id, focused);
+    if (!target) {
+      setToast({ kind: 'error', text: 'This request changed before you confirmed — review it again.' });
+      return;
+    }
     successWash.value = withSequence(
       withTiming(1, { duration: 200, easing: ease }),
       withTiming(0, { duration: 600, easing: ease })
     );
     haptic.approve();
-    const approvalSnap = focused;
+    const approvalSnap = target;
     const decideSeconds = secondsToDecide(approvalSnap.id);
     dispatch(approve(approvalSnap.id))
       .unwrap()
@@ -130,15 +138,19 @@ export function ApprovalScreen() {
       });
   }
 
-  function handleDeny(reason?: string) {
-    if (!focused) return;
+  function handleDeny(id: string, reason?: string) {
+    const target = decisionTarget(id, focused);
+    if (!target) {
+      setToast({ kind: 'error', text: 'This request changed before you confirmed — review it again.' });
+      return;
+    }
     denyShake.value = withSequence(
       withTiming(-4, { duration: 40 }),
       withTiming(4, { duration: 40 }),
       withTiming(0, { duration: 40 })
     );
     haptic.deny();
-    const approvalSnap = focused;
+    const approvalSnap = target;
     const decideSeconds = secondsToDecide(approvalSnap.id);
     dispatch(deny({ id: approvalSnap.id, reason }))
       .unwrap()
@@ -242,6 +254,7 @@ export function ApprovalScreen() {
 
         <View style={{ paddingBottom: insets.bottom + spacing[5] }}>
           <ApprovalButtons
+            requestId={focused.id}
             isRecursive={isRecursive}
             inFlight={inFlight}
             onApprove={handleApprove}

--- a/apps/mobile/src/screens/approvals/components/ApprovalButtons.tsx
+++ b/apps/mobile/src/screens/approvals/components/ApprovalButtons.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Pressable, Text, View } from 'react-native';
 import * as LocalAuthentication from 'expo-local-authentication';
 import { useApprovalTheme, type, spacing, radii, palette } from '../../../theme';
@@ -7,20 +7,29 @@ import { HoldToConfirm } from './HoldToConfirm';
 import { DenyReasonSheet } from './DenyReasonSheet';
 
 interface Props {
+  // The approval the user is looking at right now. Captured at press time
+  // and threaded back through onApprove/onDeny so a focus swap during the
+  // (multi-second) biometric prompt can't rebind consent to a different
+  // request. See PR #696 Critical #3 / decisionTarget.ts.
+  requestId: string;
   isRecursive: boolean;
   inFlight: 'approve' | 'deny' | null;
-  onApprove: () => void;
-  onDeny: (reason?: string) => void;
+  onApprove: (requestId: string) => void;
+  onDeny: (requestId: string, reason?: string) => void;
 }
 
 const SILENT_CANCEL_CODES = new Set(['user_cancel', 'system_cancel', 'app_cancel']);
 const LOCKOUT_CODES = new Set(['lockout', 'lockout_permanent']);
 const PASSCODE_FALLBACK_CODES = new Set(['not_enrolled', 'passcode_not_set']);
 
-export function ApprovalButtons({ isRecursive, inFlight, onApprove, onDeny }: Props) {
+export function ApprovalButtons({ requestId, isRecursive, inFlight, onApprove, onDeny }: Props) {
   const theme = useApprovalTheme('dark');
   const [denyOpen, setDenyOpen] = useState(false);
   const [authMessage, setAuthMessage] = useState<string | null>(null);
+  // Snapshot of the request id at the moment Deny was tapped — the deny
+  // reason sheet stays open across re-renders, so reading the live prop in
+  // its onSubmit would have the same focus-swap hazard as approve.
+  const denyTargetRef = useRef<string>(requestId);
 
   async function authenticateWithPasscode(): Promise<LocalAuthentication.LocalAuthenticationResult> {
     return await LocalAuthentication.authenticateAsync({
@@ -30,6 +39,9 @@ export function ApprovalButtons({ isRecursive, inFlight, onApprove, onDeny }: Pr
   }
 
   async function handleApprovePress() {
+    // Bind consent BEFORE the biometric modal. This local survives any
+    // re-render/focus swap that happens while the OS prompt is up.
+    const target = requestId;
     haptic.tap();
     setAuthMessage(null);
 
@@ -46,7 +58,7 @@ export function ApprovalButtons({ isRecursive, inFlight, onApprove, onDeny }: Pr
 
     if (!hasHw || !enrolled) {
       const r = await authenticateWithPasscode();
-      if (r.success) { onApprove(); return; }
+      if (r.success) { onApprove(target); return; }
       handleAuthFailure(r);
       return;
     }
@@ -56,12 +68,12 @@ export function ApprovalButtons({ isRecursive, inFlight, onApprove, onDeny }: Pr
       cancelLabel: 'Cancel',
       disableDeviceFallback: false,
     });
-    if (r.success) { onApprove(); return; }
+    if (r.success) { onApprove(target); return; }
 
     const code = (r as { error?: string }).error;
     if (code && PASSCODE_FALLBACK_CODES.has(code)) {
       const fallback = await authenticateWithPasscode();
-      if (fallback.success) { onApprove(); return; }
+      if (fallback.success) { onApprove(target); return; }
       handleAuthFailure(fallback);
       return;
     }
@@ -95,7 +107,7 @@ export function ApprovalButtons({ isRecursive, inFlight, onApprove, onDeny }: Pr
       ) : null}
       <View style={{ flexDirection: 'row', paddingHorizontal: spacing[6], gap: spacing[3] }}>
         <Pressable
-          onPress={() => { haptic.tap(); setDenyOpen(true); }}
+          onPress={() => { denyTargetRef.current = requestId; haptic.tap(); setDenyOpen(true); }}
           disabled={inFlight !== null}
           style={({ pressed }) => ({
             flex: 1,
@@ -134,7 +146,7 @@ export function ApprovalButtons({ isRecursive, inFlight, onApprove, onDeny }: Pr
       <DenyReasonSheet
         visible={denyOpen}
         onCancel={() => setDenyOpen(false)}
-        onSubmit={(reason) => { setDenyOpen(false); onDeny(reason); }}
+        onSubmit={(reason) => { setDenyOpen(false); onDeny(denyTargetRef.current, reason); }}
       />
     </View>
   );

--- a/apps/mobile/src/screens/approvals/decisionTarget.test.ts
+++ b/apps/mobile/src/screens/approvals/decisionTarget.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { decisionTarget } from './decisionTarget';
+
+type Approval = { id: string; status: string; riskTier: string };
+
+const pendingA: Approval = { id: 'A', status: 'pending', riskTier: 'low' };
+const pendingB: Approval = { id: 'B', status: 'pending', riskTier: 'high' };
+
+describe('decisionTarget — binds biometric consent to the request the user saw', () => {
+  it('returns the focused approval when the captured id still matches a pending request', () => {
+    expect(decisionTarget('A', pendingA)).toBe(pendingA);
+  });
+
+  it('returns null when nothing is focused anymore', () => {
+    expect(decisionTarget('A', undefined)).toBeNull();
+  });
+
+  it('returns null when focus swapped to a different request during the biometric prompt', () => {
+    // User authenticated for A; a second push moved focus to B mid-prompt.
+    // Must NOT silently approve B.
+    expect(decisionTarget('A', pendingB)).toBeNull();
+  });
+
+  it('returns null when the captured request is no longer pending (decided/expired during the prompt)', () => {
+    expect(decisionTarget('A', { id: 'A', status: 'expired', riskTier: 'low' })).toBeNull();
+    expect(decisionTarget('A', { id: 'A', status: 'approved', riskTier: 'low' })).toBeNull();
+  });
+});

--- a/apps/mobile/src/screens/approvals/decisionTarget.ts
+++ b/apps/mobile/src/screens/approvals/decisionTarget.ts
@@ -1,0 +1,25 @@
+/**
+ * Consent-binding guard for approval decisions (PR #696 Critical #3).
+ *
+ * The biometric prompt (LocalAuthentication.authenticateAsync) is a
+ * multi-second OS modal. While it is up, a second push, a tapped
+ * notification, or a list refresh can change which approval is focused.
+ * The user authenticated to decide the request they SAW; we must submit
+ * exactly that request — never whatever happens to be focused when the
+ * modal resolves.
+ *
+ * Capture the request id at press time (before biometric), then pass it
+ * here with the currently-focused approval at decision time. Returns the
+ * approval to act on only if the captured id still matches a focused,
+ * still-pending request; otherwise null — the caller MUST abort and ask
+ * the user to review again rather than silently deciding the wrong action.
+ */
+export function decisionTarget<T extends { id: string; status: string }>(
+  capturedId: string,
+  focused: T | undefined,
+): T | null {
+  if (!focused) return null;
+  if (focused.id !== capturedId) return null;
+  if (focused.status !== 'pending') return null;
+  return focused;
+}


### PR DESCRIPTION
Stacked on `feat/mobile-approval-mode` (base = PR #696's branch, same pattern as #698). Branched off `ecc5350d` so #698's fixes are preserved. Fixes the four Critical/scoped items from the #696 review that made the feature **non-functional in production** despite green (mocked) unit tests.

## Fixes

- **#1 — account-deletion admin queue returned empty.** Two layered defects: (a) the `account_deletion_requests` Shape-6 RLS policy had no system-scope OR branch, and (b) `accountDeletion.ts`'s `runWithSystemDbAccess` lacked `runOutsideDbContext`, so inside an admin request it inherited the admin's own scope. Both fixed (migration + wrapper now mirrors `lifecycle.ts`'s `asSystem`).
- **#2 — expiry reaper never expired anything.** `approval_requests` Shape-6 policy had no system-scope OR branch → under SYSTEM scope `breeze_current_user_id()` is NULL → FORCE RLS hid every row from `breeze_app`. Same migration adds the branch (the reaper's own wrapper was already correct — BullMQ worker, no ambient context).
- **#3 — mobile biometric consent race.** A focus swap during the OS biometric prompt could rebind consent to a different approval. Request id is now captured at press time, threaded `ApprovalButtons → ApprovalScreen`, and gated by a pure `decisionTarget()` — aborts with a re-review prompt instead of deciding the wrong action.
- **#7 — schema drift.** `oauth.ts` now declares the `oauth_client_blocks_org_client_uniq UNIQUE(org_id, client_id)` index the migration creates (the lifecycle upsert relies on it). *Note: not a CI blocker — `ci.yml`'s drift step is `continue-on-error`.*

The migration mirrors the `oauth_authorization_codes`/`sessions` `OR breeze_current_scope() = 'system'` pattern. Request-scoped callers never have `scope='system'`, so the `user_id` predicate still governs — no cross-user exposure (the unchanged cross-user forge tests prove this).

## Verification (test-driven, RED→GREEN)

- New `approval-system-scope.integration.test.ts` — #1 + #2 against a real DB (watched fail with the policy reverted).
- New `decisionTarget.test.ts` — pure consent-binding guard, 4/4.
- RLS contract + cross-user forge **13/13**; accountDeletion/admin/autoMigrate units **38/38**; full mobile suite 137 pass; no new type errors.
- Stale "no system-scope OR branch" comments in `rls-coverage` corrected (comment rot this migration introduced).

## Scope

Criticals + #7 only. The review's Important items (report-suspicious non-atomic flip, Expo-push silent auto-deny, receipts, `oauthRevocation` coverage, cross-user denial tests, `azp` block bypass, biometric-on-deny) are intentionally **out of scope** — for the #696 split.

Refs #696, #698.

🤖 Generated with [Claude Code](https://claude.com/claude-code)