### PR TITLE
fix(api): restore approval reaper + account-deletion admin queue (RLS system-scope bypass)

### DIFF
--- a/apps/api/migrations/2026-05-16-approval-shape6-system-bypass.sql
+++ b/apps/api/migrations/2026-05-16-approval-shape6-system-bypass.sql
@@ -1,0 +1,47 @@
+-- 2026-05-16: approval_requests + account_deletion_requests — add a
+-- system-scope bypass to the Shape-6 user-scoped RLS policies.
+--
+-- PR #696 Critical #1 / #2. The policies created by
+-- 2026-05-06-approval-requests.sql and 2026-05-07-account-deletion-requests.sql
+-- were:
+--
+--   USING (user_id = breeze_current_user_id())
+--   WITH CHECK (user_id = breeze_current_user_id())
+--
+-- with NO system-scope OR branch. Two non-request code paths run under
+-- SYSTEM DB scope, where breeze.user_id is unset so breeze_current_user_id()
+-- is NULL and `user_id = NULL` matches zero rows under FORCE RLS for the
+-- unprivileged breeze_app role:
+--
+--   * approvalExpiryReaper (BullMQ worker via withSystemDbAccessContext) —
+--     the bounded UPDATE...FROM transitioned 0 rows every run, so expired
+--     approvals were never reaped and mobile-only approvals always burned
+--     the full waitForApproval ceiling.
+--   * the account-deletion admin queue (routes/auth/accountDeletion.ts via
+--     runWithSystemDbAccess) — list/get/process all returned empty/404, so
+--     admins could never see or action a deletion request.
+--
+-- Fix: mirror the oauth_authorization_codes (2026-04-24) / sessions policy
+-- shape by adding `OR breeze_current_scope() = 'system'` to both USING and
+-- WITH CHECK. user_id remains the canonical tenancy axis under any user
+-- scope; only genuine system-scope contexts (background workers, the admin
+-- queue) gain access. No cross-user exposure: a request-scoped caller always
+-- has breeze.scope != 'system', so the user_id predicate still governs.
+--
+-- Idempotent: DROP POLICY IF EXISTS then recreate with a deterministic body.
+-- Re-applying is a true no-op. autoMigrate wraps each file in a transaction,
+-- so no inner BEGIN/COMMIT.
+
+DROP POLICY IF EXISTS approval_requests_user_scope ON approval_requests;
+DO $$ BEGIN
+  CREATE POLICY approval_requests_user_scope ON approval_requests
+    USING     (user_id = breeze_current_user_id() OR breeze_current_scope() = 'system')
+    WITH CHECK (user_id = breeze_current_user_id() OR breeze_current_scope() = 'system');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DROP POLICY IF EXISTS account_deletion_requests_user_scope ON account_deletion_requests;
+DO $$ BEGIN
+  CREATE POLICY account_deletion_requests_user_scope ON account_deletion_requests
+    USING     (user_id = breeze_current_user_id() OR breeze_current_scope() = 'system')
+    WITH CHECK (user_id = breeze_current_user_id() OR breeze_current_scope() = 'system');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;

--- a/apps/api/src/__tests__/integration/approval-system-scope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/approval-system-scope.integration.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Integration test for PR #696 Critical #1 + #2.
+ *
+ * Both the approval-expiry reaper and the account-deletion admin queue run
+ * under SYSTEM DB scope, but the Shape-6 policies on `approval_requests` and
+ * `account_deletion_requests` were `user_id = breeze_current_user_id()` with
+ * NO system-scope OR branch. Under system scope `breeze_current_user_id()` is
+ * NULL, so FORCE RLS hid every row from `breeze_app`:
+ *
+ *   - #2: `reapExpiredApprovals()` transitioned 0 rows — expiry never ran.
+ *   - #1: the account-deletion admin endpoints (which use
+ *     `runWithSystemDbAccess`) saw an empty queue. #1 also had a second
+ *     defect: `accountDeletion.ts`'s `runWithSystemDbAccess` lacked the
+ *     `runOutsideDbContext` wrap, so inside an authenticated request it was
+ *     a no-op that inherited the caller's (admin's) request scope.
+ *
+ * These tests assert the composed production behavior against a real DB as
+ * the unprivileged `breeze_app` role. They fail (RED) until the fix-forward
+ * migration adds `OR breeze_current_scope() = 'system'` to both policies AND
+ * `runWithSystemDbAccess` is corrected to escape the ambient request context.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { eq } from 'drizzle-orm';
+import './setup';
+import { getTestDb } from './setup';
+import { withDbAccessContext, withSystemDbAccessContext } from '../../db';
+import { approvalRequests } from '../../db/schema/approvals';
+import { accountDeletionRequests, partners, users } from '../../db/schema';
+import { reapExpiredApprovals } from '../../jobs/approvalExpiryReaper';
+import { runWithSystemDbAccess } from '../../routes/auth/accountDeletion';
+
+function userContext(userId: string) {
+  return {
+    scope: 'organization' as const,
+    orgId: null,
+    accessibleOrgIds: [],
+    accessiblePartnerIds: [],
+    userId,
+  };
+}
+
+let partnerId: string;
+let adminId: string;
+let requesterId: string;
+
+beforeEach(async () => {
+  // Seed as the superuser test connection (bypasses RLS) — setup.ts's
+  // cleanupDatabase() TRUNCATEs users CASCADE on beforeEach, so the
+  // approval/deletion rows are cleared transitively each test.
+  const tdb = getTestDb();
+  const [p] = await tdb
+    .insert(partners)
+    .values({ name: 'PR696 System Scope', slug: `pr696-sysscope-${Date.now()}`, type: 'msp', plan: 'pro', status: 'active' })
+    .returning({ id: partners.id });
+  partnerId = p!.id;
+  const [admin, requester] = await tdb
+    .insert(users)
+    .values([
+      { partnerId, email: `admin-${Date.now()}@pr696.test`, name: 'PR696 Admin', status: 'active' },
+      { partnerId, email: `req-${Date.now()}@pr696.test`, name: 'PR696 Requester', status: 'active' },
+    ])
+    .returning({ id: users.id });
+  adminId = admin!.id;
+  requesterId = requester!.id;
+});
+
+describe('PR#696 #2 — approvalExpiryReaper transitions overdue rows under system scope', () => {
+  it('expires a pending, overdue approval and reports the count', async () => {
+    const tdb = getTestDb();
+    const [row] = await tdb
+      .insert(approvalRequests)
+      .values({
+        userId: requesterId,
+        requestingClientLabel: 'pr696-reaper-client',
+        actionLabel: 'pr696.reaper.overdue',
+        actionToolName: 'pr696.reaper',
+        riskTier: 'low',
+        riskSummary: 'overdue approval should be reaped',
+        expiresAt: new Date(Date.now() - 60_000), // already expired
+      })
+      .returning({ id: approvalRequests.id });
+
+    // Mirror the production BullMQ worker: it wraps reapExpiredApprovals in
+    // withSystemDbAccessContext (no ambient request context, so this genuinely
+    // enters system scope). Calling it bare would run at scope='none'.
+    const reaped = await withSystemDbAccessContext(() => reapExpiredApprovals());
+
+    expect(reaped).toBe(1);
+
+    const [after] = await tdb
+      .select({ status: approvalRequests.status })
+      .from(approvalRequests)
+      .where(eq(approvalRequests.id, row!.id));
+    expect(after!.status).toBe('expired');
+  });
+
+  it('does not touch an approval that has not yet expired', async () => {
+    const tdb = getTestDb();
+    const [row] = await tdb
+      .insert(approvalRequests)
+      .values({
+        userId: requesterId,
+        requestingClientLabel: 'pr696-reaper-client',
+        actionLabel: 'pr696.reaper.fresh',
+        actionToolName: 'pr696.reaper',
+        riskTier: 'low',
+        riskSummary: 'fresh approval must survive the reaper',
+        expiresAt: new Date(Date.now() + 5 * 60_000),
+      })
+      .returning({ id: approvalRequests.id });
+
+    const reaped = await withSystemDbAccessContext(() => reapExpiredApprovals());
+
+    expect(reaped).toBe(0);
+    const [after] = await tdb
+      .select({ status: approvalRequests.status })
+      .from(approvalRequests)
+      .where(eq(approvalRequests.id, row!.id));
+    expect(after!.status).toBe('pending');
+  });
+});
+
+describe('PR#696 #1 — account-deletion admin reads the queue under true system scope', () => {
+  it('runWithSystemDbAccess reaches another user\'s row even from within an ambient request scope', async () => {
+    const tdb = getTestDb();
+    await tdb.insert(accountDeletionRequests).values({
+      userId: requesterId,
+      processBy: new Date(Date.now() + 7 * 24 * 60 * 60_000),
+      reason: 'pr696 admin-queue visibility',
+    });
+
+    // Simulate the authenticated admin request: authMiddleware establishes a
+    // request-scoped DB context for the admin BEFORE the handler runs. The
+    // handler then calls runWithSystemDbAccess(...) — which must escape this
+    // ambient context to reach system scope.
+    const rows = await withDbAccessContext(userContext(adminId), async () =>
+      runWithSystemDbAccess(async () =>
+        getSystemScopedDeletionRequests(),
+      ),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.userId).toBe(requesterId);
+  });
+});
+
+// Helper kept outside the assertion so the query runs through the app `db`
+// proxy (breeze_app, RLS enforced) under whatever scope is active.
+async function getSystemScopedDeletionRequests() {
+  const { db } = await import('../../db');
+  return db
+    .select({ id: accountDeletionRequests.id, userId: accountDeletionRequests.userId })
+    .from(accountDeletionRequests);
+}

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -133,10 +133,15 @@ const USER_ID_SCOPED_TABLES: ReadonlySet<string> = new Set<string>([
   // System-scope bypass covers the adapter writes (runOutsideDbContext).
   'oauth_interactions',
   // approval_requests: MCP step-up approval records, scoped to the requesting
-  // user via breeze_current_user_id(). Shape 6 policy.
+  // user via breeze_current_user_id(). Shape 6 policy, plus an
+  // `OR breeze_current_scope() = 'system'` branch (migration
+  // 2026-05-16-approval-shape6-system-bypass.sql) so the BullMQ expiry
+  // reaper can transition rows under system scope.
   'approval_requests',
   // account_deletion_requests: user-initiated deletion queue records, scoped
-  // to the requesting user via breeze_current_user_id(). Shape 6 policy.
+  // to the requesting user via breeze_current_user_id(). Shape 6 policy with
+  // the same system-scope OR branch so the account-deletion admin queue
+  // (runWithSystemDbAccess) can read/process the queue.
   'account_deletion_requests',
 ]);
 
@@ -681,16 +686,13 @@ describe('approval_requests RLS — cross-user forge enforcement (Shape 6)', () 
   }
 
   afterAll(async () => {
-    // approval_requests policy has no system-scope OR branch, so system
-    // context cannot delete the row directly. Delete it as user A (the
-    // row's owner). Users/partners are dual-axis / partner-axis and DO
-    // accept system scope, so we tear those down via system context.
-    if (approvalAId && userAId) {
-      await withDbAccessContext(userContext(userAId), async () =>
-        db.delete(approvalRequests).where(eq(approvalRequests.id, approvalAId!))
-      );
-    }
+    // approval_requests now has a system-scope OR branch (migration
+    // 2026-05-16-approval-shape6-system-bypass.sql), so system context can
+    // tear the row down directly alongside the users/partners fixtures.
     await withSystemDbAccessContext(async () => {
+      if (approvalAId) {
+        await db.delete(approvalRequests).where(eq(approvalRequests.id, approvalAId!));
+      }
       if (userAId) await db.delete(users).where(eq(users.id, userAId));
       if (userBId) await db.delete(users).where(eq(users.id, userBId));
       if (partnerId) await db.delete(partners).where(eq(partners.id, partnerId));
@@ -771,9 +773,10 @@ describe('approval_requests RLS — cross-user forge enforcement (Shape 6)', () 
     expect(updated).toEqual([]);
 
     // Read back as user A (the row's owner) to confirm it is genuinely
-    // untouched. We can't use system scope here: the approval_requests
-    // policy is `user_id = breeze_current_user_id()` with no system-scope
-    // OR branch, so system context has no read access either.
+    // untouched. Reading as the owner is a deliberately stronger assertion
+    // than a system-scope read: it proves the row is intact from the user
+    // whose tenancy axis governs it, not merely visible to the privileged
+    // system context (which the policy now also permits).
     const actual = await withDbAccessContext(userContext(userAId), async () =>
       db
         .select({ id: approvalRequests.id, status: approvalRequests.status })

--- a/apps/api/src/routes/auth/accountDeletion.ts
+++ b/apps/api/src/routes/auth/accountDeletion.ts
@@ -26,9 +26,20 @@ import {
 } from './helpers';
 
 const { db } = dbModule;
-const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+export const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
   const withSystem = dbModule.withSystemDbAccessContext;
-  return typeof withSystem === 'function' ? withSystem(fn) : fn();
+  if (typeof withSystem !== 'function') return fn();
+  // Escape any ambient request-scoped DB context BEFORE entering system
+  // scope. authMiddleware wraps the admin handler in withDbAccessContext
+  // (the admin's own partner/org scope); withSystemDbAccessContext
+  // short-circuits when a context already exists, so without
+  // runOutsideDbContext these "system" queries silently ran as the admin's
+  // own user and the deletion-request queue always came back empty. Mirror
+  // lifecycle.ts's asSystem. See PR #696 Critical #1.
+  const runOutside = dbModule.runOutsideDbContext;
+  return typeof runOutside === 'function'
+    ? runOutside(() => withSystem(fn))
+    : withSystem(fn);
 };
 
 export const accountDeletionRoutes = new Hono();


### PR DESCRIPTION
**Production hotfix.** PR #611 (merged to `main` 2026-05-14) shipped the approval backend with Shape-6 RLS policies that have **no system-scope OR branch**. Two non-request paths run under SYSTEM DB scope (`breeze_current_user_id()` = NULL), so FORCE RLS hides every row from `breeze_app`:

- **Approval-expiry reaper** (BullMQ worker): transitions **0 rows** every run — expired approvals never expire; mobile/AI approvals always burn the full `waitForApproval` ceiling.
- **Account-deletion admin queue** (`runWithSystemDbAccess`): list/get/process return **empty/404** — staff can't see or action deletion requests. This is the **Apple App Store account-deletion compliance** mechanism; user requests pile up invisibly.

Second defect: `accountDeletion.ts`'s `runWithSystemDbAccess` lacked `runOutsideDbContext`, so inside an admin request it inherited the admin's own scope (no-op).

Severity: **fail-closed** (too little access, not cross-tenant leakage) — functional/compliance bug, not a security incident. Live ~2 days.

## Fix
- `2026-05-16-approval-shape6-system-bypass.sql` adds `OR breeze_current_scope() = 'system'` to both policies (mirrors `oauth_authorization_codes` 2026-04-24 / `sessions`). Request-scoped callers never have `scope='system'`, so `user_id` still governs — **no cross-user exposure** (unchanged cross-user forge tests prove this). Idempotent.
- `accountDeletion.ts`: `runWithSystemDbAccess` now wraps `runOutsideDbContext` (mirrors `lifecycle.ts`'s `asSystem`).
- Corrected now-false comments + forge-test teardown in `rls-coverage`.

## Verification
Against a real DB from `main`'s **exact buggy baseline** (policies reverted, migration record cleared): **RED** (reaper 0 rows / admin queue empty) → **GREEN** after `autoMigrate` applies the migration. New `approval-system-scope.integration.test.ts`; `rls-coverage` contract + forge **16/16**; `accountDeletion` units **38/38**; tsc clean.

Same fix as #741 (which targets the unmerged `feat/mobile-approval-mode` / #696); this lands it directly on `main` since #611 already shipped the bug there. Refs #611, #696, #741, #698.

🤖 Generated with [Claude Code](https://claude.com/claude-code)