### PR TITLE
fix(mobile): bind biometric consent to the request the user saw (#696 Critical #3)

### DIFF
--- a/apps/mobile/src/screens/approvals/ApprovalScreen.tsx
+++ b/apps/mobile/src/screens/approvals/ApprovalScreen.tsx
@@ -21,7 +21,7 @@ import { ActionHeadline } from './components/ActionHeadline';
 import { DetailsCollapse } from './components/DetailsCollapse';
 import { RiskBand } from './components/RiskBand';
 import { ApprovalButtons } from './components/ApprovalButtons';
-import { decisionTarget } from './decisionTarget';
+import { decisionTarget, type CapturedRequestId } from './decisionTarget';
 import { SuspiciousReportSheet } from './components/SuspiciousReportSheet';
 import { Toast } from '../../components/Toast';
 
@@ -106,7 +106,7 @@ export function ApprovalScreen() {
     transform: [{ translateX: denyShake.value }],
   }));
 
-  function handleApprove(id: string) {
+  function handleApprove(id: CapturedRequestId) {
     // Consent is bound to the request the user saw at press time. If focus
     // swapped during the biometric prompt, abort instead of approving a
     // different action. See PR #696 Critical #3 / decisionTarget.ts.
@@ -138,7 +138,7 @@ export function ApprovalScreen() {
       });
   }
 
-  function handleDeny(id: string, reason?: string) {
+  function handleDeny(id: CapturedRequestId, reason?: string) {
     const target = decisionTarget(id, focused);
     if (!target) {
       setToast({ kind: 'error', text: 'This request changed before you confirmed — review it again.' });

--- a/apps/mobile/src/screens/approvals/ApprovalScreen.tsx
+++ b/apps/mobile/src/screens/approvals/ApprovalScreen.tsx
@@ -21,6 +21,7 @@ import { ActionHeadline } from './components/ActionHeadline';
 import { DetailsCollapse } from './components/DetailsCollapse';
 import { RiskBand } from './components/RiskBand';
 import { ApprovalButtons } from './components/ApprovalButtons';
+import { decisionTarget } from './decisionTarget';
 import { SuspiciousReportSheet } from './components/SuspiciousReportSheet';
 import { Toast } from '../../components/Toast';
 
@@ -105,14 +106,21 @@ export function ApprovalScreen() {
     transform: [{ translateX: denyShake.value }],
   }));
 
-  function handleApprove() {
-    if (!focused) return;
+  function handleApprove(id: string) {
+    // Consent is bound to the request the user saw at press time. If focus
+    // swapped during the biometric prompt, abort instead of approving a
+    // different action. See PR #696 Critical #3 / decisionTarget.ts.
+    const target = decisionTarget(id, focused);
+    if (!target) {
+      setToast({ kind: 'error', text: 'This request changed before you confirmed — review it again.' });
+      return;
+    }
     successWash.value = withSequence(
       withTiming(1, { duration: 200, easing: ease }),
       withTiming(0, { duration: 600, easing: ease })
     );
     haptic.approve();
-    const approvalSnap = focused;
+    const approvalSnap = target;
     const decideSeconds = secondsToDecide(approvalSnap.id);
     dispatch(approve(approvalSnap.id))
       .unwrap()
@@ -130,15 +138,19 @@ export function ApprovalScreen() {
       });
   }
 
-  function handleDeny(reason?: string) {
-    if (!focused) return;
+  function handleDeny(id: string, reason?: string) {
+    const target = decisionTarget(id, focused);
+    if (!target) {
+      setToast({ kind: 'error', text: 'This request changed before you confirmed — review it again.' });
+      return;
+    }
     denyShake.value = withSequence(
       withTiming(-4, { duration: 40 }),
       withTiming(4, { duration: 40 }),
       withTiming(0, { duration: 40 })
     );
     haptic.deny();
-    const approvalSnap = focused;
+    const approvalSnap = target;
     const decideSeconds = secondsToDecide(approvalSnap.id);
     dispatch(deny({ id: approvalSnap.id, reason }))
       .unwrap()
@@ -242,6 +254,7 @@ export function ApprovalScreen() {
 
         <View style={{ paddingBottom: insets.bottom + spacing[5] }}>
           <ApprovalButtons
+            requestId={focused.id}
             isRecursive={isRecursive}
             inFlight={inFlight}
             onApprove={handleApprove}

--- a/apps/mobile/src/screens/approvals/components/ApprovalButtons.tsx
+++ b/apps/mobile/src/screens/approvals/components/ApprovalButtons.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Pressable, Text, View } from 'react-native';
 import * as LocalAuthentication from 'expo-local-authentication';
 import { useApprovalTheme, type, spacing, radii, palette } from '../../../theme';
@@ -7,20 +7,29 @@ import { HoldToConfirm } from './HoldToConfirm';
 import { DenyReasonSheet } from './DenyReasonSheet';
 
 interface Props {
+  // The approval the user is looking at right now. Captured at press time
+  // and threaded back through onApprove/onDeny so a focus swap during the
+  // (multi-second) biometric prompt can't rebind consent to a different
+  // request. See PR #696 Critical #3 / decisionTarget.ts.
+  requestId: string;
   isRecursive: boolean;
   inFlight: 'approve' | 'deny' | null;
-  onApprove: () => void;
-  onDeny: (reason?: string) => void;
+  onApprove: (requestId: string) => void;
+  onDeny: (requestId: string, reason?: string) => void;
 }
 
 const SILENT_CANCEL_CODES = new Set(['user_cancel', 'system_cancel', 'app_cancel']);
 const LOCKOUT_CODES = new Set(['lockout', 'lockout_permanent']);
 const PASSCODE_FALLBACK_CODES = new Set(['not_enrolled', 'passcode_not_set']);
 
-export function ApprovalButtons({ isRecursive, inFlight, onApprove, onDeny }: Props) {
+export function ApprovalButtons({ requestId, isRecursive, inFlight, onApprove, onDeny }: Props) {
   const theme = useApprovalTheme('dark');
   const [denyOpen, setDenyOpen] = useState(false);
   const [authMessage, setAuthMessage] = useState<string | null>(null);
+  // Snapshot of the request id at the moment Deny was tapped — the deny
+  // reason sheet stays open across re-renders, so reading the live prop in
+  // its onSubmit would have the same focus-swap hazard as approve.
+  const denyTargetRef = useRef<string>(requestId);
 
   async function authenticateWithPasscode(): Promise<LocalAuthentication.LocalAuthenticationResult> {
     return await LocalAuthentication.authenticateAsync({
@@ -30,6 +39,9 @@ export function ApprovalButtons({ isRecursive, inFlight, onApprove, onDeny }: Pr
   }
 
   async function handleApprovePress() {
+    // Bind consent BEFORE the biometric modal. This local survives any
+    // re-render/focus swap that happens while the OS prompt is up.
+    const target = requestId;
     haptic.tap();
     setAuthMessage(null);
 
@@ -46,7 +58,7 @@ export function ApprovalButtons({ isRecursive, inFlight, onApprove, onDeny }: Pr
 
     if (!hasHw || !enrolled) {
       const r = await authenticateWithPasscode();
-      if (r.success) { onApprove(); return; }
+      if (r.success) { onApprove(target); return; }
       handleAuthFailure(r);
       return;
     }
@@ -56,12 +68,12 @@ export function ApprovalButtons({ isRecursive, inFlight, onApprove, onDeny }: Pr
       cancelLabel: 'Cancel',
       disableDeviceFallback: false,
     });
-    if (r.success) { onApprove(); return; }
+    if (r.success) { onApprove(target); return; }
 
     const code = (r as { error?: string }).error;
     if (code && PASSCODE_FALLBACK_CODES.has(code)) {
       const fallback = await authenticateWithPasscode();
-      if (fallback.success) { onApprove(); return; }
+      if (fallback.success) { onApprove(target); return; }
       handleAuthFailure(fallback);
       return;
     }
@@ -95,7 +107,7 @@ export function ApprovalButtons({ isRecursive, inFlight, onApprove, onDeny }: Pr
       ) : null}
       <View style={{ flexDirection: 'row', paddingHorizontal: spacing[6], gap: spacing[3] }}>
         <Pressable
-          onPress={() => { haptic.tap(); setDenyOpen(true); }}
+          onPress={() => { denyTargetRef.current = requestId; haptic.tap(); setDenyOpen(true); }}
           disabled={inFlight !== null}
           style={({ pressed }) => ({
             flex: 1,
@@ -134,7 +146,7 @@ export function ApprovalButtons({ isRecursive, inFlight, onApprove, onDeny }: Pr
       <DenyReasonSheet
         visible={denyOpen}
         onCancel={() => setDenyOpen(false)}
-        onSubmit={(reason) => { setDenyOpen(false); onDeny(reason); }}
+        onSubmit={(reason) => { setDenyOpen(false); onDeny(denyTargetRef.current, reason); }}
       />
     </View>
   );

--- a/apps/mobile/src/screens/approvals/components/ApprovalButtons.tsx
+++ b/apps/mobile/src/screens/approvals/components/ApprovalButtons.tsx
@@ -5,17 +5,20 @@ import { useApprovalTheme, type, spacing, radii, palette } from '../../../theme'
 import { haptic } from '../../../lib/motion';
 import { HoldToConfirm } from './HoldToConfirm';
 import { DenyReasonSheet } from './DenyReasonSheet';
+import { captureRequestId, type CapturedRequestId } from '../decisionTarget';
 
 interface Props {
-  // The approval the user is looking at right now. Captured at press time
-  // and threaded back through onApprove/onDeny so a focus swap during the
-  // (multi-second) biometric prompt can't rebind consent to a different
-  // request. See PR #696 Critical #3 / decisionTarget.ts.
+  // The approval the user is looking at right now (live prop). We snapshot
+  // it via captureRequestId() at press time and thread the branded value
+  // back through onApprove/onDeny so a focus swap during the (multi-second)
+  // biometric prompt can't rebind consent to a different request. The brand
+  // makes passing the live id straight through a compile error. See PR #696
+  // Critical #3 / decisionTarget.ts.
   requestId: string;
   isRecursive: boolean;
   inFlight: 'approve' | 'deny' | null;
-  onApprove: (requestId: string) => void;
-  onDeny: (requestId: string, reason?: string) => void;
+  onApprove: (requestId: CapturedRequestId) => void;
+  onDeny: (requestId: CapturedRequestId, reason?: string) => void;
 }
 
 const SILENT_CANCEL_CODES = new Set(['user_cancel', 'system_cancel', 'app_cancel']);
@@ -29,7 +32,7 @@ export function ApprovalButtons({ requestId, isRecursive, inFlight, onApprove, o
   // Snapshot of the request id at the moment Deny was tapped — the deny
   // reason sheet stays open across re-renders, so reading the live prop in
   // its onSubmit would have the same focus-swap hazard as approve.
-  const denyTargetRef = useRef<string>(requestId);
+  const denyTargetRef = useRef<CapturedRequestId>(captureRequestId(requestId));
 
   async function authenticateWithPasscode(): Promise<LocalAuthentication.LocalAuthenticationResult> {
     return await LocalAuthentication.authenticateAsync({
@@ -39,9 +42,9 @@ export function ApprovalButtons({ requestId, isRecursive, inFlight, onApprove, o
   }
 
   async function handleApprovePress() {
-    // Bind consent BEFORE the biometric modal. This local survives any
-    // re-render/focus swap that happens while the OS prompt is up.
-    const target = requestId;
+    // Bind consent BEFORE the biometric modal. This branded local survives
+    // any re-render/focus swap that happens while the OS prompt is up.
+    const target = captureRequestId(requestId);
     haptic.tap();
     setAuthMessage(null);
 
@@ -107,7 +110,7 @@ export function ApprovalButtons({ requestId, isRecursive, inFlight, onApprove, o
       ) : null}
       <View style={{ flexDirection: 'row', paddingHorizontal: spacing[6], gap: spacing[3] }}>
         <Pressable
-          onPress={() => { denyTargetRef.current = requestId; haptic.tap(); setDenyOpen(true); }}
+          onPress={() => { denyTargetRef.current = captureRequestId(requestId); haptic.tap(); setDenyOpen(true); }}
           disabled={inFlight !== null}
           style={({ pressed }) => ({
             flex: 1,

--- a/apps/mobile/src/screens/approvals/decisionTarget.test.ts
+++ b/apps/mobile/src/screens/approvals/decisionTarget.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { decisionTarget } from './decisionTarget';
+
+type Approval = { id: string; status: string; riskTier: string };
+
+const pendingA: Approval = { id: 'A', status: 'pending', riskTier: 'low' };
+const pendingB: Approval = { id: 'B', status: 'pending', riskTier: 'high' };
+
+describe('decisionTarget — binds biometric consent to the request the user saw', () => {
+  it('returns the focused approval when the captured id still matches a pending request', () => {
+    expect(decisionTarget('A', pendingA)).toBe(pendingA);
+  });
+
+  it('returns null when nothing is focused anymore', () => {
+    expect(decisionTarget('A', undefined)).toBeNull();
+  });
+
+  it('returns null when focus swapped to a different request during the biometric prompt', () => {
+    // User authenticated for A; a second push moved focus to B mid-prompt.
+    // Must NOT silently approve B.
+    expect(decisionTarget('A', pendingB)).toBeNull();
+  });
+
+  it('returns null when the captured request is no longer pending (decided/expired during the prompt)', () => {
+    expect(decisionTarget('A', { id: 'A', status: 'expired', riskTier: 'low' })).toBeNull();
+    expect(decisionTarget('A', { id: 'A', status: 'approved', riskTier: 'low' })).toBeNull();
+  });
+});

--- a/apps/mobile/src/screens/approvals/decisionTarget.test.ts
+++ b/apps/mobile/src/screens/approvals/decisionTarget.test.ts
@@ -1,29 +1,34 @@
 import { describe, expect, it } from 'vitest';
 
-import { decisionTarget } from './decisionTarget';
+import { captureRequestId, decisionTarget } from './decisionTarget';
+import type { ApprovalStatus } from '../../services/approvals';
 
-type Approval = { id: string; status: string; riskTier: string };
+type Approval = { id: string; status: ApprovalStatus; riskTier: string };
 
 const pendingA: Approval = { id: 'A', status: 'pending', riskTier: 'low' };
 const pendingB: Approval = { id: 'B', status: 'pending', riskTier: 'high' };
 
 describe('decisionTarget — binds biometric consent to the request the user saw', () => {
   it('returns the focused approval when the captured id still matches a pending request', () => {
-    expect(decisionTarget('A', pendingA)).toBe(pendingA);
+    expect(decisionTarget(captureRequestId('A'), pendingA)).toBe(pendingA);
   });
 
   it('returns null when nothing is focused anymore', () => {
-    expect(decisionTarget('A', undefined)).toBeNull();
+    expect(decisionTarget(captureRequestId('A'), undefined)).toBeNull();
   });
 
   it('returns null when focus swapped to a different request during the biometric prompt', () => {
     // User authenticated for A; a second push moved focus to B mid-prompt.
     // Must NOT silently approve B.
-    expect(decisionTarget('A', pendingB)).toBeNull();
+    expect(decisionTarget(captureRequestId('A'), pendingB)).toBeNull();
   });
 
   it('returns null when the captured request is no longer pending (decided/expired during the prompt)', () => {
-    expect(decisionTarget('A', { id: 'A', status: 'expired', riskTier: 'low' })).toBeNull();
-    expect(decisionTarget('A', { id: 'A', status: 'approved', riskTier: 'low' })).toBeNull();
+    // Covers every non-pending ApprovalStatus the request could have raced
+    // into while the biometric modal was up.
+    expect(decisionTarget(captureRequestId('A'), { id: 'A', status: 'expired', riskTier: 'low' })).toBeNull();
+    expect(decisionTarget(captureRequestId('A'), { id: 'A', status: 'approved', riskTier: 'low' })).toBeNull();
+    expect(decisionTarget(captureRequestId('A'), { id: 'A', status: 'denied', riskTier: 'low' })).toBeNull();
+    expect(decisionTarget(captureRequestId('A'), { id: 'A', status: 'reported', riskTier: 'low' })).toBeNull();
   });
 });

--- a/apps/mobile/src/screens/approvals/decisionTarget.ts
+++ b/apps/mobile/src/screens/approvals/decisionTarget.ts
@@ -1,0 +1,25 @@
+/**
+ * Consent-binding guard for approval decisions (PR #696 Critical #3).
+ *
+ * The biometric prompt (LocalAuthentication.authenticateAsync) is a
+ * multi-second OS modal. While it is up, a second push, a tapped
+ * notification, or a list refresh can change which approval is focused.
+ * The user authenticated to decide the request they SAW; we must submit
+ * exactly that request — never whatever happens to be focused when the
+ * modal resolves.
+ *
+ * Capture the request id at press time (before biometric), then pass it
+ * here with the currently-focused approval at decision time. Returns the
+ * approval to act on only if the captured id still matches a focused,
+ * still-pending request; otherwise null — the caller MUST abort and ask
+ * the user to review again rather than silently deciding the wrong action.
+ */
+export function decisionTarget<T extends { id: string; status: string }>(
+  capturedId: string,
+  focused: T | undefined,
+): T | null {
+  if (!focused) return null;
+  if (focused.id !== capturedId) return null;
+  if (focused.status !== 'pending') return null;
+  return focused;
+}

--- a/apps/mobile/src/screens/approvals/decisionTarget.ts
+++ b/apps/mobile/src/screens/approvals/decisionTarget.ts
@@ -1,3 +1,20 @@
+import type { ApprovalStatus } from '../../services/approvals';
+
+/**
+ * A request id snapshotted at the moment the user pressed Approve/Deny,
+ * BEFORE the biometric modal opened. The brand makes it a compile error to
+ * pass a freshly-read `focused.id` as the captured id — that misuse would
+ * silently defeat the entire consent guard (a live id always "matches"
+ * itself). The only way to obtain one is `captureRequestId()`, which names
+ * the press-time intent at the single correct call site.
+ */
+export type CapturedRequestId = string & { readonly __capturedAtPress: unique symbol };
+
+/** Brand a request id at press time. Call this BEFORE the biometric prompt. */
+export function captureRequestId(id: string): CapturedRequestId {
+  return id as CapturedRequestId;
+}
+
 /**
  * Consent-binding guard for approval decisions (PR #696 Critical #3).
  *
@@ -8,14 +25,21 @@
  * exactly that request — never whatever happens to be focused when the
  * modal resolves.
  *
- * Capture the request id at press time (before biometric), then pass it
- * here with the currently-focused approval at decision time. Returns the
- * approval to act on only if the captured id still matches a focused,
- * still-pending request; otherwise null — the caller MUST abort and ask
- * the user to review again rather than silently deciding the wrong action.
+ * Capture the request id at press time via captureRequestId() (before
+ * biometric), then pass it here with the currently-focused approval at
+ * decision time. Returns the approval to act on only if the captured id
+ * still matches a focused, still-pending request; otherwise null — the
+ * caller MUST abort and ask the user to review again rather than silently
+ * deciding the wrong action.
+ *
+ * Safety relies on an API invariant enforced outside this module: an
+ * approval id is immutable and a request never returns to `pending` after
+ * leaving it (the approvals reaper / approvalRecursion — PR #743). If an id
+ * could be re-pended with different action content, an id+status match
+ * would no longer prove the user saw that exact action.
  */
-export function decisionTarget<T extends { id: string; status: string }>(
-  capturedId: string,
+export function decisionTarget<T extends { id: string; status: ApprovalStatus }>(
+  capturedId: CapturedRequestId,
   focused: T | undefined,
 ): T | null {
   if (!focused) return null;


### PR DESCRIPTION
## What

Carries **PR #696 Critical #3** (mobile approval consent-race guard) to `main`. The fix shipped to `feat/mobile-approval-mode` via #741 but **never reached `main`** — main's mobile approval flow (from #611 phase-1) still has the bug.

## The bug

`LocalAuthentication.authenticateAsync` is a multi-second OS modal. While it's up, a second push / tapped notification / list refresh can swap which approval is `focused`. The decision handlers read the live `focused` approval at resolve time, so a focus swap during the prompt would submit approve/deny against a **different request than the user authenticated for** — a silent wrong-consent.

## The fix

- New `decisionTarget()` pure helper: returns the approval to act on **only** if the id captured at press time still matches a focused, still-pending request; otherwise `null`.
- `ApprovalButtons` captures `requestId` before the biometric modal and threads it through `onApprove`/`onDeny`. Deny path snapshots the id in a `useRef` because the deny-reason sheet survives re-renders.
- `ApprovalScreen` handlers abort + toast "review again" instead of silently deciding when `decisionTarget` returns `null`.

## Scope discipline

Reconstructed as a **focused 4-file change off current `main`**, not a mechanical extraction from the stale branch. `feat/mobile-approval-mode` is ~7.7k lines behind main; its `DeviceDetailScreen.tsx` / `services/api.ts` deltas would **regress the #703 Wake-on-LAN mobile support** already in main. Those are deliberately excluded. `git diff main` here is exactly the consent-race change and nothing else.

(Per #744 investigation: the rest of the "~129-file mobile app" was already shipped to `main` by #611 — this 4-file consent guard is the only genuinely-unmerged mobile work.)

## Files

- `decisionTarget.ts` (new, pure logic)
- `decisionTarget.test.ts` (new)
- `ApprovalScreen.tsx` (wire guard into approve/deny)
- `components/ApprovalButtons.tsx` (capture id at press time)

## Verification

- Mobile vitest: **137 passed** / 3 skipped (includes new `decisionTarget` suite: match, no-focus, focus-swapped, no-longer-pending).
- Targeted `tsc`: no new TS2322/2345/2554; only pre-existing repo-wide TS2786 JSX noise.
- Confirmed `setToast` exists in main's `ApprovalScreen.tsx` (no missing dependency); confirmed #703 WoL still intact in main's `DeviceDetailScreen.tsx`/`api.ts`.

Refs #696 #741 #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)