### PR TITLE
perf(api): /devices latest-metrics — LATERAL+LIMIT 1 over GROUP BY MAX

### DIFF
--- a/apps/api/src/__tests__/integration/devicesLatestMetricsLateral.integration.test.ts
+++ b/apps/api/src/__tests__/integration/devicesLatestMetricsLateral.integration.test.ts
@@ -1,0 +1,229 @@
+/**
+ * LATERAL latest-metrics query — integration test
+ *
+ * `GET /devices` enriches each row with its newest `device_metrics` sample.
+ * The query lives in `routes/devices/core.ts` and uses
+ * `(VALUES ($1::uuid), ($2::uuid), ...) AS d(device_id) INNER JOIN LATERAL
+ *  (SELECT ... FROM device_metrics WHERE device_id = d.device_id
+ *   ORDER BY timestamp DESC LIMIT 1) AS m ON true`.
+ *
+ * Two things this test pins that a mocked unit test cannot:
+ *
+ *   1. The Drizzle `sql` template's array-spread behavior — passing a JS
+ *      array of UUIDs as `${ids}::uuid[]` actually emits N positional
+ *      parameters, not a single array. That bug bit production on this
+ *      exact code path during deploy iteration; the `sql.join` + VALUES
+ *      form below is the verified fix. A regression to the array-spread
+ *      shape would fail this test at runtime against real Postgres.
+ *
+ *   2. The query plan still uses the (device_id, timestamp) PK with
+ *      backward index scan + LIMIT 1 — i.e. the per-device cost stays
+ *      O(log n) and doesn't fall back to a full per-device scan.
+ *
+ * Prerequisites:
+ *   docker compose -f docker-compose.test.yml up -d
+ *
+ * Run:
+ *   pnpm test:integration -- src/__tests__/integration/devicesLatestMetricsLateral.integration.test.ts
+ */
+import './setup';
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { getTestDb } from './setup';
+import { devices, deviceMetrics } from '../../db/schema';
+import { createPartner, createOrganization, createSite } from './db-utils';
+
+interface LateralRow {
+  device_id: string;
+  cpu_percent: number;
+  ram_percent: number;
+  timestamp: Date;
+}
+
+// devices.agent_id is NOT NULL — generate per row so the FK-less insert
+// satisfies the constraint without bringing in the enrollment service.
+let agentIdCounter = 0;
+async function insertDevice(opts: {
+  orgId: string;
+  siteId: string;
+  hostname: string;
+}): Promise<string> {
+  const db = getTestDb();
+  agentIdCounter++;
+  const [row] = await db
+    .insert(devices)
+    .values({
+      orgId: opts.orgId,
+      siteId: opts.siteId,
+      agentId: `agent-test-${agentIdCounter}-${Date.now()}`,
+      hostname: opts.hostname,
+      displayName: opts.hostname,
+      osType: 'windows',
+      osVersion: '11',
+      osBuild: '22000',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'online',
+      enrolledAt: new Date(),
+    })
+    .returning({ id: devices.id });
+  return row.id;
+}
+
+async function insertMetric(opts: {
+  deviceId: string;
+  orgId: string;
+  timestamp: Date;
+  cpuPercent: number;
+  ramPercent: number;
+}) {
+  const db = getTestDb();
+  await db.insert(deviceMetrics).values({
+    deviceId: opts.deviceId,
+    orgId: opts.orgId,
+    timestamp: opts.timestamp,
+    cpuPercent: opts.cpuPercent,
+    ramPercent: opts.ramPercent,
+    ramUsedMb: 1000,
+    diskPercent: 50,
+    diskUsedGb: 100,
+  });
+}
+
+describe('GET /devices latest-metrics LATERAL query (integration)', () => {
+  let orgId: string;
+  let siteId: string;
+
+  beforeEach(async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    orgId = org.id;
+    const site = await createSite({ orgId });
+    siteId = site.id;
+  });
+
+  it('returns the newest metric row per device, never a stale one', async () => {
+    const deviceA = await insertDevice({ orgId, siteId, hostname: 'host-a' });
+    const deviceB = await insertDevice({ orgId, siteId, hostname: 'host-b' });
+    const deviceC = await insertDevice({ orgId, siteId, hostname: 'host-c' });
+
+    // Each device gets multiple metric rows. The LATERAL must pick the
+    // last (timestamp DESC LIMIT 1) — not the first, not the average.
+    await insertMetric({ deviceId: deviceA, orgId, timestamp: new Date('2026-05-16T10:00:00Z'), cpuPercent: 5, ramPercent: 10 });
+    await insertMetric({ deviceId: deviceA, orgId, timestamp: new Date('2026-05-16T11:00:00Z'), cpuPercent: 25, ramPercent: 40 });
+    await insertMetric({ deviceId: deviceA, orgId, timestamp: new Date('2026-05-16T12:00:00Z'), cpuPercent: 50, ramPercent: 75 }); // newest
+
+    await insertMetric({ deviceId: deviceB, orgId, timestamp: new Date('2026-05-16T09:00:00Z'), cpuPercent: 99, ramPercent: 99 });
+    await insertMetric({ deviceId: deviceB, orgId, timestamp: new Date('2026-05-16T13:00:00Z'), cpuPercent: 3, ramPercent: 8 }); // newest
+
+    await insertMetric({ deviceId: deviceC, orgId, timestamp: new Date('2026-05-16T08:00:00Z'), cpuPercent: 17, ramPercent: 22 }); // only one, also newest
+
+    const deviceIds = [deviceA, deviceB, deviceC];
+
+    // Mirror the exact construction used by routes/devices/core.ts.
+    // If a future Drizzle change reverts to array-spread semantics, the
+    // parameter binding will fail at this call against real Postgres.
+    const idTuples = sql.join(
+      deviceIds.map((id) => sql`(${id}::uuid)`),
+      sql`, `
+    );
+
+    const rows = await getTestDb().execute<LateralRow>(sql`
+      SELECT d.device_id, m.cpu_percent, m.ram_percent, m.timestamp
+      FROM (VALUES ${idTuples}) AS d(device_id)
+      INNER JOIN LATERAL (
+        SELECT cpu_percent, ram_percent, timestamp
+        FROM ${deviceMetrics}
+        WHERE device_id = d.device_id
+        ORDER BY timestamp DESC
+        LIMIT 1
+      ) AS m ON true
+    `);
+
+    expect(rows).toHaveLength(3);
+
+    const byId = new Map(rows.map((r: LateralRow) => [r.device_id, r]));
+    // cpu/ram values uniquely identify which metric row was picked,
+    // so they double as a "newest-row" assertion. (Asserting the raw
+    // timestamp round-trip is a separate concern — `timestamp without
+    // time zone` + JS Date involves TZ semantics that aren't the subject
+    // of this query test.)
+    expect(byId.get(deviceA)?.cpu_percent).toBe(50);
+    expect(byId.get(deviceA)?.ram_percent).toBe(75);
+    expect(byId.get(deviceB)?.cpu_percent).toBe(3);
+    expect(byId.get(deviceB)?.ram_percent).toBe(8);
+    expect(byId.get(deviceC)?.cpu_percent).toBe(17);
+    expect(byId.get(deviceC)?.ram_percent).toBe(22);
+  });
+
+  it('returns no row for a device with zero metrics (INNER JOIN drops it)', async () => {
+    const deviceWithMetrics = await insertDevice({ orgId, siteId, hostname: 'host-with' });
+    const deviceWithout = await insertDevice({ orgId, siteId, hostname: 'host-without' });
+    await insertMetric({
+      deviceId: deviceWithMetrics, orgId,
+      timestamp: new Date('2026-05-16T12:00:00Z'),
+      cpuPercent: 42, ramPercent: 50,
+    });
+
+    const deviceIds = [deviceWithMetrics, deviceWithout];
+    const idTuples = sql.join(
+      deviceIds.map((id) => sql`(${id}::uuid)`),
+      sql`, `
+    );
+
+    const rows = await getTestDb().execute<LateralRow>(sql`
+      SELECT d.device_id, m.cpu_percent, m.ram_percent, m.timestamp
+      FROM (VALUES ${idTuples}) AS d(device_id)
+      INNER JOIN LATERAL (
+        SELECT cpu_percent, ram_percent, timestamp
+        FROM ${deviceMetrics}
+        WHERE device_id = d.device_id
+        ORDER BY timestamp DESC
+        LIMIT 1
+      ) AS m ON true
+    `);
+
+    // Caller (core.ts) uses a Map keyed by device_id and falls back to
+    // 0 / null when a device isn't in the map, so missing rows are
+    // expected and benign — but the query itself must return ONLY the
+    // device that has metrics.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].device_id).toBe(deviceWithMetrics);
+    expect(rows[0].cpu_percent).toBe(42);
+  });
+
+  it('uses the (device_id, timestamp) PK with backward index scan + LIMIT 1', async () => {
+    // Plan-shape guard. The point of LATERAL is that the inner subquery
+    // does a backward index scan with LIMIT 1 — depth 1, not a full
+    // per-device scan. EXPLAIN should show that. If a future refactor
+    // accidentally regresses to a sort-on-disk or full-history shape,
+    // this fails loudly with the plan that broke it.
+    const device = await insertDevice({ orgId, siteId, hostname: 'host-plan' });
+    for (let i = 0; i < 200; i++) {
+      await insertMetric({
+        deviceId: device, orgId,
+        timestamp: new Date(Date.now() - i * 60_000),
+        cpuPercent: i, ramPercent: i,
+      });
+    }
+
+    const idTuples = sql.join([sql`(${device}::uuid)`], sql`, `);
+    const plan = await getTestDb().execute<{ 'QUERY PLAN': string }>(sql`
+      EXPLAIN
+      SELECT d.device_id, m.cpu_percent, m.ram_percent, m.timestamp
+      FROM (VALUES ${idTuples}) AS d(device_id)
+      INNER JOIN LATERAL (
+        SELECT cpu_percent, ram_percent, timestamp
+        FROM ${deviceMetrics}
+        WHERE device_id = d.device_id
+        ORDER BY timestamp DESC
+        LIMIT 1
+      ) AS m ON true
+    `);
+
+    const planText = plan.map((r: { 'QUERY PLAN': string }) => r['QUERY PLAN']).join('\n');
+    expect(planText).toMatch(/Index Scan Backward using device_metrics_device_id_timestamp_pk/);
+    expect(planText).toMatch(/Limit/);
+  });
+});

--- a/apps/api/src/__tests__/integration/devicesLatestMetricsLateral.integration.test.ts
+++ b/apps/api/src/__tests__/integration/devicesLatestMetricsLateral.integration.test.ts
@@ -34,7 +34,8 @@ import { getTestDb } from './setup';
 import { devices, deviceMetrics } from '../../db/schema';
 import { createPartner, createOrganization, createSite } from './db-utils';
 
-interface LateralRow {
+// Index signature required so `db.execute<T>` accepts T as a Record<string, unknown>.
+interface LateralRow extends Record<string, unknown> {
   device_id: string;
   cpu_percent: number;
   ram_percent: number;
@@ -68,6 +69,7 @@ async function insertDevice(opts: {
       enrolledAt: new Date(),
     })
     .returning({ id: devices.id });
+  if (!row) throw new Error('insertDevice: insert returned no row');
   return row.id;
 }
 
@@ -189,8 +191,10 @@ describe('GET /devices latest-metrics LATERAL query (integration)', () => {
     // expected and benign — but the query itself must return ONLY the
     // device that has metrics.
     expect(rows).toHaveLength(1);
-    expect(rows[0].device_id).toBe(deviceWithMetrics);
-    expect(rows[0].cpu_percent).toBe(42);
+    const [onlyRow] = rows;
+    if (!onlyRow) throw new Error('expected exactly one row');
+    expect(onlyRow.device_id).toBe(deviceWithMetrics);
+    expect(onlyRow.cpu_percent).toBe(42);
   });
 
   it('uses the (device_id, timestamp) PK with backward index scan + LIMIT 1', async () => {

--- a/apps/api/src/routes/devices.test.ts
+++ b/apps/api/src/routes/devices.test.ts
@@ -25,16 +25,24 @@ vi.mock('../services/permissions', () => ({
   })
 }));
 
-vi.mock('drizzle-orm', () => ({
-  eq: vi.fn((...args: unknown[]) => ({ eq: args })),
-  and: vi.fn((...args: unknown[]) => ({ and: args })),
-  gte: vi.fn((...args: unknown[]) => ({ gte: args })),
-  like: vi.fn((...args: unknown[]) => ({ like: args })),
-  sql: vi.fn(() => ({ as: vi.fn(() => 'latestTimestamp') })),
-  desc: vi.fn((col: unknown) => ({ desc: col })),
-  inArray: vi.fn((...args: unknown[]) => ({ inArray: args })),
-  count: vi.fn()
-}));
+vi.mock('drizzle-orm', () => {
+  // drizzle-orm's `sql` is a callable tag with attached statics (sql.join,
+  // sql.raw, etc.). The /devices LATERAL query uses sql.join() to build a
+  // VALUES tuple list, so the mock has to expose that as a function.
+  const sqlTag: any = vi.fn(() => ({ as: vi.fn(() => 'latestTimestamp') }));
+  sqlTag.join = vi.fn((parts: unknown[]) => ({ join: parts }));
+  sqlTag.raw = vi.fn((s: unknown) => ({ raw: s }));
+  return {
+    eq: vi.fn((...args: unknown[]) => ({ eq: args })),
+    and: vi.fn((...args: unknown[]) => ({ and: args })),
+    gte: vi.fn((...args: unknown[]) => ({ gte: args })),
+    like: vi.fn((...args: unknown[]) => ({ like: args })),
+    sql: sqlTag,
+    desc: vi.fn((col: unknown) => ({ desc: col })),
+    inArray: vi.fn((...args: unknown[]) => ({ inArray: args })),
+    count: vi.fn()
+  };
+});
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
@@ -62,7 +70,11 @@ vi.mock('../db', () => ({
     })),
     delete: vi.fn(() => ({
       where: vi.fn(() => Promise.resolve())
-    }))
+    })),
+    // db.execute() is used for the latest-metrics LATERAL query in
+    // /devices and for any raw sql template. Returns an empty array
+    // by default; tests override via vi.mocked(db.execute).mockResolvedValueOnce.
+    execute: vi.fn(() => Promise.resolve([]))
   }
 }));
 
@@ -159,6 +171,7 @@ describe('device routes', () => {
     vi.mocked(db.delete).mockImplementation(() => ({
       where: vi.fn(() => Promise.resolve())
     }) as any);
+    vi.mocked(db.execute).mockImplementation(() => Promise.resolve([]) as any);
     app = new Hono();
     app.route('/devices', deviceRoutes);
   });
@@ -334,23 +347,17 @@ describe('device routes', () => {
               })
             })
           })
-        } as any)
-        // 3rd: subquery for latest metric timestamps (not awaited, builds subquery ref)
-        .mockReturnValueOnce({
-          from: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              groupBy: vi.fn().mockReturnValue({
-                as: vi.fn().mockReturnValue({ deviceId: 'deviceId', latestTimestamp: 'latestTimestamp' })
-              })
-            })
-          })
-        } as any)
-        // 4th: metrics query with innerJoin (awaited)
-        .mockReturnValueOnce({
-          from: vi.fn().mockReturnValue({
-            innerJoin: vi.fn().mockResolvedValue([])
-          })
         } as any);
+
+      // Latest-metrics LATERAL query goes through db.execute() with a
+      // raw sql template — return one row per device so the response
+      // mapping (cpuPercent / ramPercent / metrics.timestamp) exercises
+      // the per-device latest lookup path.
+      const metricsTimestamp = new Date('2026-05-16T17:00:00Z');
+      vi.mocked(db.execute).mockResolvedValueOnce([
+        { device_id: 'device-1', cpu_percent: 12.5, ram_percent: 33, timestamp: metricsTimestamp },
+        { device_id: 'device-2', cpu_percent: 4.2, ram_percent: 18, timestamp: metricsTimestamp },
+      ] as any);
 
       const res = await app.request('/devices?status=online&osType=linux&search=host&page=1&limit=2', {
         method: 'GET',
@@ -362,6 +369,25 @@ describe('device routes', () => {
       expect(body.data).toHaveLength(2);
       expect(body.pagination.total).toBe(2);
       expect(body.data[0].hardware).toBeDefined();
+      // LATERAL metrics row → response: snake_case columns map to
+      // camelCase metrics.cpuPercent / ramPercent. Each device matches
+      // by uuid, so device-1's metrics row sticks to device-1.
+      expect(body.data[0].cpuPercent).toBe(12.5);
+      expect(body.data[0].ramPercent).toBe(33);
+      expect(body.data[1].cpuPercent).toBe(4.2);
+      expect(body.data[1].ramPercent).toBe(18);
+      expect(body.data[0].metrics).toEqual({
+        cpuPercent: 12.5,
+        ramPercent: 33,
+        timestamp: metricsTimestamp.toISOString(),
+      });
+
+      // Regression guard: the LATERAL replaces what used to be two
+      // db.select() chains (a GROUP BY MAX subquery + an innerJoin on
+      // the max timestamp). If a future refactor reverts to those, the
+      // db.select call count here will jump from 2 to 4.
+      expect(vi.mocked(db.select).mock.calls.length).toBe(2);
+      expect(vi.mocked(db.execute).mock.calls.length).toBe(1);
     });
   });
 

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { and, eq, gte, like, sql, desc, inArray } from 'drizzle-orm';
+import { and, eq, gte, like, sql, desc } from 'drizzle-orm';
 import { db, withSystemDbAccessContext } from '../../db';
 import { createHash, randomBytes } from 'crypto';
 import {
@@ -289,40 +289,47 @@ coreRoutes.get(
     }>();
 
     if (deviceIds.length > 0) {
-      const latestMetricTimestamps = db
-        .select({
-          deviceId: deviceMetrics.deviceId,
-          latestTimestamp: sql<Date>`max(${deviceMetrics.timestamp})`.as('latest_timestamp')
-        })
-        .from(deviceMetrics)
-        .where(inArray(deviceMetrics.deviceId, deviceIds))
-        .groupBy(deviceMetrics.deviceId)
-        .as('latest_metric_timestamps');
+      // Per-device latest-row lookup via LATERAL + LIMIT 1 against the
+      // (device_id, timestamp) primary key. Index-scan-backward returns
+      // one row per device in O(log n) per device. Replaces a
+      // GROUP BY MAX + self-join shape that scanned every metric row
+      // per device to compute the max timestamp — quadratic in metric
+      // history depth, observed at ~1 s on a 70-device fleet with
+      // ~8.8k rows/device.
+      //
+      // Build a VALUES tuple list so each id is bound as its own $N::uuid
+      // parameter. Drizzle's sql template spreads a JS array into N
+      // positional params (not a single uuid[]), which breaks the
+      // natural-looking `unnest(${ids}::uuid[])` form at runtime —
+      // PostgresError: cannot cast type record to uuid[]. The VALUES
+      // form sidesteps that.
+      const idTuples = sql.join(
+        deviceIds.map((id) => sql`(${id}::uuid)`),
+        sql`, `
+      );
+      const rows = await db.execute<{
+        device_id: string;
+        cpu_percent: number;
+        ram_percent: number;
+        timestamp: Date;
+      }>(sql`
+        SELECT d.device_id, m.cpu_percent, m.ram_percent, m.timestamp
+        FROM (VALUES ${idTuples}) AS d(device_id)
+        INNER JOIN LATERAL (
+          SELECT cpu_percent, ram_percent, timestamp
+          FROM ${deviceMetrics}
+          WHERE device_id = d.device_id
+          ORDER BY timestamp DESC
+          LIMIT 1
+        ) AS m ON true
+      `);
 
-      const latestMetrics = await db
-        .select({
-          deviceId: deviceMetrics.deviceId,
-          cpuPercent: deviceMetrics.cpuPercent,
-          ramPercent: deviceMetrics.ramPercent,
-          timestamp: deviceMetrics.timestamp
-        })
-        .from(deviceMetrics)
-        .innerJoin(
-          latestMetricTimestamps,
-          and(
-            eq(deviceMetrics.deviceId, latestMetricTimestamps.deviceId),
-            eq(deviceMetrics.timestamp, latestMetricTimestamps.latestTimestamp)
-          )
-        );
-
-      for (const metric of latestMetrics) {
-        if (!latestMetricsByDevice.has(metric.deviceId)) {
-          latestMetricsByDevice.set(metric.deviceId, {
-            cpuPercent: metric.cpuPercent,
-            ramPercent: metric.ramPercent,
-            timestamp: metric.timestamp
-          });
-        }
+      for (const row of rows) {
+        latestMetricsByDevice.set(row.device_id, {
+          cpuPercent: row.cpu_percent,
+          ramPercent: row.ram_percent,
+          timestamp: row.timestamp,
+        });
       }
     }
 


### PR DESCRIPTION
## Description

### What

`GET /devices` enriches each row with its most recent `device_metrics` sample. The current query computes the latest timestamp per device with `GROUP BY MAX(timestamp)` and self-joins back to `device_metrics` to fetch the row at that timestamp:

```sql
SELECT m.device_id, m.cpu_percent, m.ram_percent, m.timestamp
FROM device_metrics m
INNER JOIN (
  SELECT device_id, MAX(timestamp) AS max_ts
  FROM device_metrics
  WHERE device_id IN (...)
  GROUP BY device_id
) latest
  ON m.device_id = latest.device_id AND m.timestamp = latest.max_ts;
```

The aggregate subquery scans every metric row for every device in the page to compute the max. With per-device metric history at typical retention depths (thousands of rows), that's a lot of work for "give me 70 latest samples."

This PR replaces it with `LATERAL + LIMIT 1` against the `(device_id, timestamp)` primary key:

```sql
SELECT d.device_id, m.cpu_percent, m.ram_percent, m.timestamp
FROM (VALUES ($1::uuid), ($2::uuid), ...) AS d(device_id)
INNER JOIN LATERAL (
  SELECT cpu_percent, ram_percent, timestamp
  FROM device_metrics
  WHERE device_id = d.device_id
  ORDER BY timestamp DESC
  LIMIT 1
) AS m ON true;
```

The planner switches to a per-device **backward index scan** on the PK, returns one row per device, and stops. Constant work per device, regardless of how much metric history each one has.

### Why a VALUES tuple list, not `unnest($1::uuid[])`

Drizzle's `sql` tagged template spreads a JS array into N positional parameters rather than binding it as a single `uuid[]`, so the natural-looking `unnest(${deviceIds}::uuid[])` form fails at runtime with `PostgresError: cannot cast type record to uuid[]`. Building the id list as `sql.join(deviceIds.map(id => sql\`(${id}::uuid)\`), sql\`, \`)` emits one `$N::uuid` per id and feeds them through `(VALUES ...) AS d(device_id)`, which the LATERAL join then iterates.

### Benchmark (live production data)

EXPLAIN ANALYZE on a 70-device set with ~8.8k metric rows per device (~617k rows total):

| Shape | Plan | Time |
|---|---|---|
| `GROUP BY MAX` + self-join (before) | seq/index scan of full history then aggregate | ~1,007 ms |
| `DISTINCT ON (device_id) ... ORDER BY` (tried) | sort-on-disk on full set | ~2,267 ms |
| `LATERAL + LIMIT 1` (this PR) | Nested Loop over 70 backward index scans of depth 1 | **2.487 ms** |

That's roughly **400× faster** on this dataset and grows favorably with metric retention depth (the old shape is quadratic in retention, the new shape is constant per device).

### Functional behavior

Zero change. The output payload is identical — same `metrics.cpuPercent`, `metrics.ramPercent`, `metrics.timestamp` per device. Only the query plan differs.

### Test plan

- [x] `EXPLAIN ANALYZE` on live data confirms plan + timing (table above)
- [x] Output shape matches the existing query — verified by spot-checking against the previous query for the same device set
- [x] Manual end-to-end test against a live deploy
- [x] Unit test update (`apps/api/src/routes/devices.test.ts`):
  - Swapped the stale `db.select` mock chains (GROUP BY subquery + innerJoin metrics fetch) for a `db.execute` mock returning canned `{device_id, cpu_percent, ram_percent, timestamp}` rows
  - Asserts response mapping: `metrics.cpuPercent` / `ramPercent` / `timestamp` correctly come through from the snake_case query output
  - Added a `db.select` call-count assertion (must be 2 after this change, was 4 before) — fails fast if anyone reverts the LATERAL change
  - Added `sql.join` and `sql.raw` to the drizzle-orm mock since the query uses them
- [x] **New integration test** (`apps/api/src/__tests__/integration/devicesLatestMetricsLateral.integration.test.ts`) covering three regression risks a mocked test can't:
  - **Parameter binding**: runs the exact `sql.join` + VALUES construction against real Postgres. If a future Drizzle change reverts to array-spread semantics, this fails with the runtime error I hit during deploy iteration.
  - **Newest-row correctness**: inserts multiple metric rows per device with varying timestamps; asserts the returned row is the newest (verified by unique cpu/ram values keyed to each timestamp).
  - **Empty-metrics device**: confirms `INNER JOIN LATERAL ... ON true` drops a device with zero metric rows from the result (the caller's `latestMetricsByDevice` map then naturally falls back to zeroes — same behavior as before).
  - **Plan-shape guard**: runs `EXPLAIN` after inserting 200 rows for one device; asserts the plan contains `Index Scan Backward using device_metrics_device_id_timestamp_pk` + `Limit`. Future refactors that accidentally regress to a full-scan plan fail this loudly with the bad plan in the error message.
- [x] Full `pnpm --filter @breeze/api test` passes locally on the rebased branch (all files green, 28 pre-existing skips)
- [x] Integration suite passes: `pnpm test:integration -- src/__tests__/integration/devicesLatestMetricsLateral.integration.test.ts` (3/3)

### Risk

Low. Self-contained query change with no schema, contract, or behavior change. The query path is on the request hot path for the Devices page, so a regression here would be visible immediately — but the plan is strictly better (backward index seeks vs full history scans).

---

