### PR TITLE
feat(devices): raise /devices limit cap to 500 for small-MSP fleets

### DIFF
--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -190,7 +190,14 @@ coreRoutes.get(
   async (c) => {
     const auth = c.get('auth');
     const query = c.req.valid('query');
-    const { page, limit, offset } = getPagination(query);
+    // Devices list intentionally allows a higher cap than the default
+    // 100 — the web client paginates client-side over the returned set,
+    // so the cap is what gates how many devices a partner-scope user
+    // can see at once. 500 covers small MSP fleets in a single round
+    // trip while staying well under the ~1 MB JSON-payload mark.
+    // Longer-term, server-side sort/filter/page is needed for fleets
+    // beyond this range; tracked separately.
+    const { page, limit, offset } = getPagination(query, 500);
 
     // Build conditions array
     const conditions: ReturnType<typeof eq>[] = [];

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -79,7 +79,10 @@ export default function DevicesPage() {
 
       // Fetch devices, orgs, sites, and groups in parallel
       const [devicesResponse, orgsResponse, sitesResponse, groupsResponse] = await Promise.all([
-        fetchWithAuth('/devices?includeDecommissioned=true'),
+        // limit=500 matches the API-side cap for /devices; the list is
+        // paginated client-side after this fetch. Larger fleets need
+        // server-side sort/filter/page — tracked separately.
+        fetchWithAuth('/devices?includeDecommissioned=true&limit=500'),
         fetchWithAuth('/orgs'),
         fetchWithAuth('/orgs/sites'),
         fetchWithAuth('/device-groups?includeMemberships=true').catch((err) => {


### PR DESCRIPTION
## Description

### What

The default `getPagination` cap is `maxLimit = 100`. `GET /devices` uses it as-is, so a partner-scope user sees at most 100 devices regardless of how many are enrolled. The web `DevicesPage` fetches once with no explicit `limit` and paginates client-side over the returned set — once a partner manages more than 100 endpoints, the list silently truncates because there's no "next page" mechanism on the client side.

This PR raises the cap to 500 specifically for `/devices` (other routes keep the default 100) and has the web fetch ask for it. 500 devices is roughly 1 MB of JSON, well within what the page renders fast.

### Why

Most early-adopter fleets sit comfortably under 500 endpoints. Path A (this PR) gives them a working list immediately. Above 500 the architecture itself needs to change — full server-side pagination, sort, filter, total count, etc. That's Path B and lives in Discussion #742, where I've laid out a concrete design proposal for your read.

This PR is intentionally surgical so it can land independently of the larger refactor.

### Diff

Two lines + comment:

```ts
// apps/api/src/routes/devices/core.ts
- const { page, limit, offset } = getPagination(query);
+ const { page, limit, offset } = getPagination(query, 500);
```

```ts
// apps/web/src/components/devices/DevicesPage.tsx
- fetchWithAuth('/devices?includeDecommissioned=true'),
+ fetchWithAuth('/devices?includeDecommissioned=true&limit=500'),
```

Plus a short rationale comment on each side pointing at the longer-term plan.

### Open question — hardcoded vs env-var

I went with hardcoded `500` because:
- It's a defensible default with a payload-size rationale (~1 MB cap)
- The vast majority of early-adopter fleets fit comfortably under it
- An env-var alternative (`BREEZE_DEVICES_LIST_MAX=500`) just moves the cliff from 100 to whatever-you-set, doesn't fix the underlying architecture

If you'd prefer the env-var path — happy to switch in this PR. Either way the cap is a band-aid; the architectural fix is in Discussion #742.

### Test plan

- [x] `pnpm --filter @breeze/api test` `devices.test.ts` passes locally on the rebased branch (13/13)
- [x] Lived on a 70-device install for testing (see Discussion #742 for the related perf work). Response time stays in the same fast range after the cap lift; the LATERAL fix carries that.
- [ ] No new test added — the change is a single literal-value parameter (`getPagination(query, 500)` vs `getPagination(query)`). The 50-device default behavior is exercised by the existing `should list devices with filters and pagination` test (which uses `limit=2`). A new "honors `limit` up to 500" test wouldn't add meaningful coverage over what the existing pagination logic already covers — but happy to add one if you'd prefer.

### Risk

Trivial. Two-line change. No schema change, no contract change. The only behavioral difference is that `limit=200`, `limit=300`, etc. are now honored where they were previously clamped to 100.

The one place to be careful: if any caller was relying on the silent-truncation-at-100 as a safety net, that net is gone. I've grepped the codebase — `apps/mobile/src/services/api.ts:436` is the only other API client that hits `/devices`, and it doesn't pass `limit`, so it stays on the default 50 and is unaffected.

---

