### PR TITLE
fix(api): createCustomFieldSchema accepts null options + deviceTypes

### DIFF
--- a/apps/api/src/routes/customFields.ts
+++ b/apps/api/src/routes/customFields.ts
@@ -24,10 +24,14 @@ const createCustomFieldSchema = z.object({
     .max(100)
     .regex(/^[a-z][a-z0-9_]*$/, 'Field key must be lowercase alphanumeric with underscores'),
   type: customFieldTypeSchema,
-  options: customFieldOptionsSchema.optional(),
+  // .nullable().optional() so the create form can send explicit null
+  // for unused fields. The web form serializes unused fields as null
+  // rather than omitting them — without .nullable() the validator
+  // rejects every non-Dropdown create (Text, Number, Boolean, Date).
+  options: customFieldOptionsSchema.nullable().optional(),
   required: z.boolean().default(false),
   defaultValue: z.unknown().optional(),
-  deviceTypes: z.array(z.enum(['windows', 'macos', 'linux'])).optional()
+  deviceTypes: z.array(z.enum(['windows', 'macos', 'linux'])).nullable().optional()
 });
 
 const updateCustomFieldSchema = z.object({

--- a/apps/api/src/routes/customFields_create_update_delete.test.ts
+++ b/apps/api/src/routes/customFields_create_update_delete.test.ts
@@ -132,6 +132,34 @@ describe('customFields routes', () => {
       expect(body.data.name).toBe('Serial Number');
     });
 
+    it('should accept explicit null for options and deviceTypes (#724 regression guard)', async () => {
+      // The web Custom Fields form serializes unused fields as JSON null
+      // rather than omitting them. createCustomFieldSchema must accept
+      // null for options + deviceTypes so non-Dropdown creates (Text,
+      // Number, Boolean, Date) succeed instead of 400'ing with an opaque
+      // Zod error. Regression test for issue #724.
+      const created = makeField();
+      vi.mocked(db.insert).mockReturnValueOnce({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([created])
+        })
+      } as any);
+
+      const res = await app.request('/custom-fields', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          name: 'Department',
+          fieldKey: 'department',
+          type: 'text',
+          options: null,
+          deviceTypes: null
+        })
+      });
+
+      expect(res.status).toBe(201);
+    });
+
     it('should reject when both orgId and partnerId provided', async () => {
       const res = await app.request('/custom-fields', {
         method: 'POST',

--- a/packages/shared/src/validators/filters.ts
+++ b/packages/shared/src/validators/filters.ts
@@ -159,10 +159,15 @@ export const createCustomFieldSchema = z.object({
     .max(100)
     .regex(/^[a-z][a-z0-9_]*$/, 'Field key must be lowercase alphanumeric with underscores'),
   type: customFieldTypeSchema,
-  options: customFieldOptionsSchema.optional(),
+  // .nullable().optional() so the create form can send explicit null
+  // for unused fields. Non-Dropdown types omit options; field types
+  // without a deviceTypes scope send null rather than leaving the key
+  // out. The update schema already accepts null for deviceTypes; this
+  // brings the create schema to the same shape.
+  options: customFieldOptionsSchema.nullable().optional(),
   required: z.boolean().default(false),
   defaultValue: z.unknown().optional(),
-  deviceTypes: z.array(z.enum(['windows', 'macos', 'linux'])).optional()
+  deviceTypes: z.array(z.enum(['windows', 'macos', 'linux'])).nullable().optional()
 });
 
 export const updateCustomFieldSchema = z.object({

--- a/packages/shared/src/validators/filters_customfields.test.ts
+++ b/packages/shared/src/validators/filters_customfields.test.ts
@@ -129,6 +129,21 @@ describe('createCustomFieldSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('should accept null options and null deviceTypes (web form sends explicit nulls for non-Dropdown types)', () => {
+    // Regression guard for #724: the web Custom Fields form serializes
+    // unused fields as JSON null rather than omitting them. The schema
+    // must accept null + undefined + omission for both options and
+    // deviceTypes; .nullable().optional() satisfies all three.
+    const result = createCustomFieldSchema.safeParse({
+      name: 'Department',
+      fieldKey: 'department',
+      type: 'text',
+      options: null,
+      deviceTypes: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
   it('should reject empty name', () => {
     const result = createCustomFieldSchema.safeParse({
       name: '',


### PR DESCRIPTION
## Description

Fixes #724.

### Root cause

The web Custom Fields form serializes unused fields as explicit JSON `null` rather than omitting them. `createCustomFieldSchema` in `packages/shared/src/validators/filters.ts` declared `options` and `deviceTypes` as `.optional()`. In Zod, `.optional()` allows `undefined` only — it rejects `null`. So every non-Dropdown field create (Text, Number, Boolean, Date) round-tripped a `null`, got bounced with a 400 + Zod error object, and the UI rendered that object as `[object Object]` (separate issue, #678).

The sibling `updateCustomFieldSchema` already uses `.nullable().optional()` for `deviceTypes`, which is why edits worked and creates didn't.

### Fix

```diff
- options: customFieldOptionsSchema.optional(),
+ options: customFieldOptionsSchema.nullable().optional(),
- deviceTypes: z.array(z.enum(['windows', 'macos', 'linux'])).optional()
+ deviceTypes: z.array(z.enum(['windows', 'macos', 'linux'])).nullable().optional()
```

`.nullable().optional()` accepts `null`, `undefined`, and key-omission — same shape as `updateCustomFieldSchema.deviceTypes` already uses.

### Tests

New regression test in `filters_customfields.test.ts` that calls `createCustomFieldSchema.safeParse(...)` with explicit `null` for both `options` and `deviceTypes`. Fails on `main`, passes after this change.

### Test plan

- [x] `pnpm --filter @breeze/shared test` — 16 files, 556 tests pass (including new case)
- [x] `pnpm --filter @breeze/shared exec tsc --noEmit` — clean
- [x] `pnpm --filter @breeze/api test` — 414 files, 4327 tests pass
- [x] `pnpm --filter @breeze/api exec tsc --noEmit` — clean

### Risk

Trivial. Schema gets *more* permissive on input; no existing valid payload becomes invalid. The `.nullable()` addition only changes what the schema accepts, not what it requires. No DB schema change, no contract change to existing API consumers.

### Out of scope

- `updateCustomFieldSchema.options` (line 170) has the same `.optional()` pattern. If the update form ever sends `options: null` for a non-Dropdown field, edits will silently break too — but Todd's issue scopes the fix to create. Happy to file a sibling PR if you want it harden together.
- The `[object Object]` UI rendering of Zod errors is the separately-tracked #678.
