### PR TITLE
Raise hard-coded submitChangesSchema.max(1000) to a configurable default of 50000

### DIFF
--- a/apps/api/src/routes/agents/schemas.test.ts
+++ b/apps/api/src/routes/agents/schemas.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  submitChangesSchema,
+  CHANGE_INGEST_MAX_ITEMS,
+  __resolveChangeIngestMaxItemsForTests,
+} from './schemas';
+
+// Build a minimal valid change item the schema accepts.
+function makeChange(suffix: number) {
+  return {
+    timestamp: new Date(Date.UTC(2026, 4, 19, 1, 0, suffix % 60)).toISOString(),
+    changeType: 'software',
+    changeAction: 'added',
+    subject: `pkg-${suffix}`,
+  };
+}
+
+describe('CHANGE_INGEST_MAX_ITEMS resolver — env validation', () => {
+  const originalEnv = process.env.CHANGE_INGEST_MAX_ITEMS;
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.CHANGE_INGEST_MAX_ITEMS;
+    else process.env.CHANGE_INGEST_MAX_ITEMS = originalEnv;
+  });
+
+  it('defaults to 50000 when the env var is unset', () => {
+    delete process.env.CHANGE_INGEST_MAX_ITEMS;
+    expect(__resolveChangeIngestMaxItemsForTests()).toBe(50000);
+  });
+
+  it('parses a valid positive integer in range', () => {
+    process.env.CHANGE_INGEST_MAX_ITEMS = '75000';
+    expect(__resolveChangeIngestMaxItemsForTests()).toBe(75000);
+  });
+
+  it('falls back to default on a non-numeric value (would otherwise become NaN and reject every ingest)', () => {
+    process.env.CHANGE_INGEST_MAX_ITEMS = 'abc';
+    expect(__resolveChangeIngestMaxItemsForTests()).toBe(50000);
+  });
+
+  it('falls back to default on 0 (would otherwise reject every non-empty ingest)', () => {
+    process.env.CHANGE_INGEST_MAX_ITEMS = '0';
+    expect(__resolveChangeIngestMaxItemsForTests()).toBe(50000);
+  });
+
+  it('falls back to default on a negative integer', () => {
+    process.env.CHANGE_INGEST_MAX_ITEMS = '-5';
+    expect(__resolveChangeIngestMaxItemsForTests()).toBe(50000);
+  });
+
+  it('falls back to default on a value above the safety ceiling (200000)', () => {
+    process.env.CHANGE_INGEST_MAX_ITEMS = '99999999';
+    expect(__resolveChangeIngestMaxItemsForTests()).toBe(50000);
+  });
+
+  it('accepts the safety ceiling exactly', () => {
+    process.env.CHANGE_INGEST_MAX_ITEMS = '200000';
+    expect(__resolveChangeIngestMaxItemsForTests()).toBe(200000);
+  });
+
+  it('falls back to default on an empty string', () => {
+    process.env.CHANGE_INGEST_MAX_ITEMS = '';
+    expect(__resolveChangeIngestMaxItemsForTests()).toBe(50000);
+  });
+});
+
+describe('submitChangesSchema — array length boundary', () => {
+  it('accepts N=CHANGE_INGEST_MAX_ITEMS items', () => {
+    const changes = Array.from({ length: CHANGE_INGEST_MAX_ITEMS }, (_, i) => makeChange(i));
+    const parsed = submitChangesSchema.safeParse({ changes });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects N=CHANGE_INGEST_MAX_ITEMS + 1 items', () => {
+    const changes = Array.from({ length: CHANGE_INGEST_MAX_ITEMS + 1 }, (_, i) => makeChange(i));
+    const parsed = submitChangesSchema.safeParse({ changes });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('accepts an empty changes array (default)', () => {
+    expect(submitChangesSchema.safeParse({}).success).toBe(true);
+    expect(submitChangesSchema.safeParse({ changes: [] }).success).toBe(true);
+  });
+});

--- a/apps/api/src/routes/agents/schemas.ts
+++ b/apps/api/src/routes/agents/schemas.ts
@@ -556,7 +556,7 @@ export const submitChangesSchema = z.object({
       (value) => !value || JSON.stringify(value).length <= 65535,
       { message: 'details too large (max 64KB)' }
     ),
-  })).max(1000).default([])
+  })).max(parseInt(process.env.CHANGE_INGEST_MAX_ITEMS || '50000', 10)).default([])
 });
 
 // ============================================

--- a/apps/api/src/routes/agents/schemas.ts
+++ b/apps/api/src/routes/agents/schemas.ts
@@ -538,6 +538,35 @@ export const changeActionValues = [
   'updated'
 ] as const;
 
+/**
+ * Per-request cap on `submitChangesSchema.changes[]`. Resolved + clamped
+ * once at module-load so a misconfigured env var (NaN, 0, negative,
+ * unbounded) can never propagate into `z.array().max(...)` and either
+ * (a) reject every legitimate ingest, fleet-wide, with a generic 400,
+ * or (b) make the array length effectively unbounded.
+ *
+ * Default 50000 was chosen to fit large Linux package-inventory deltas
+ * under the existing 5 MB body / 10 MB decompressed guards in
+ * `changes.ts:66-77`. The hard ceiling of 200000 is the safety stop
+ * even if an operator sets the env var to something unreasonable —
+ * matches the rationale in #752 review (Todd, 2026-05-19).
+ */
+const CHANGE_INGEST_MAX_ITEMS_DEFAULT = 50000;
+const CHANGE_INGEST_MAX_ITEMS_CEILING = 200000;
+function resolveChangeIngestMaxItems(): number {
+  const raw = process.env.CHANGE_INGEST_MAX_ITEMS;
+  if (!raw) return CHANGE_INGEST_MAX_ITEMS_DEFAULT;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > CHANGE_INGEST_MAX_ITEMS_CEILING) {
+    return CHANGE_INGEST_MAX_ITEMS_DEFAULT;
+  }
+  return parsed;
+}
+export const CHANGE_INGEST_MAX_ITEMS = resolveChangeIngestMaxItems();
+// Re-exported for tests of the resolver. Production code reads
+// CHANGE_INGEST_MAX_ITEMS (the resolved value) directly.
+export const __resolveChangeIngestMaxItemsForTests = resolveChangeIngestMaxItems;
+
 export const submitChangesSchema = z.object({
   changes: z.array(z.object({
     timestamp: z.string().datetime({ offset: true }),
@@ -556,7 +585,7 @@ export const submitChangesSchema = z.object({
       (value) => !value || JSON.stringify(value).length <= 65535,
       { message: 'details too large (max 64KB)' }
     ),
-  })).max(parseInt(process.env.CHANGE_INGEST_MAX_ITEMS || '50000', 10)).default([])
+  })).max(CHANGE_INGEST_MAX_ITEMS).default([])
 });
 
 // ============================================


### PR DESCRIPTION
## Summary

`submitChangesSchema` caps the agent's `changes[]` array at 1000 items via
a hard-coded `.max(1000)`. On every freshly-installed Linux host the agent
correctly computes its initial inventory diff (packages, services,
scheduled tasks, startup items, user accounts, network details) and tries
to submit it in one batch. On real Ubuntu/Debian hosts this batch
routinely contains 1200-2200 items.

The entire batch is then rejected with HTTP 400 by the
`submitChangesSchema.safeParse` call in
`apps/api/src/routes/agents/changes.ts:85-94`. Because the change batch
is the only delivery path for the software / services / startup
sub-collectors, those tables (`device_software`, etc.) stay empty for the
device for the lifetime of the agent -- the collector keeps trying every
heartbeat and every batch keeps failing validation as a whole.

Observed in `agent.log` on every fresh enroll:

```
WARN inventory send failed component=heartbeat label="changes (1383)" status=400
```

Across a test fleet of 7 Linux hosts, `SELECT COUNT(*) FROM device_software
WHERE device_id = ...` returns 0 for all of them despite each having
~900-1700 packages reported via `dpkg-query`.

## Fix

Replace the hard-coded `.max(1000)` with a value parsed from
`CHANGE_INGEST_MAX_ITEMS`, defaulting to 50000. This matches the existing
pattern at `routes/agents/changes.ts:11-12` where
`CHANGE_INGEST_MAX_BODY_BYTES` and `CHANGE_INGEST_MAX_DECOMPRESSED_BYTES`
are similarly env-configurable. The body-size and decompressed-size guards
at `changes.ts:66-77` remain the hard backstop against truly oversized
payloads.

The 50000 default is well within the existing 5 MB body limit (~100
bytes/change x 50000 ~= 5 MB exactly), so this does not relax the actual
ingestion ceiling -- it just removes the spurious in-memory cap.

## Test plan

Verified with the exact zod version in the breeze-api container:

| Schema | Item count | Result |
|---|---|---|
| unpatched (cap=1000) | 5000 | rejected |
| patched, default cap (50000) | 5000 | accepted |
| patched, `CHANGE_INGEST_MAX_ITEMS=2000` | 5000 | rejected |
| patched, `CHANGE_INGEST_MAX_ITEMS=2000` | 1500 | accepted |

No schema-shape changes -- the cap value is the only thing that varies.
Existing tests in `apps/api/src/routes/agents/changes.test.ts` still pass
unchanged (no test currently exercises the 1000-item boundary).
