### PR TITLE
perf: scale-readiness pack — Phase 1 jobs + Phase 2 indexes + RLS bug fix

### DIFF
--- a/apps/api/migrations/2026-05-17-a-devices-scale-indexes.sql
+++ b/apps/api/migrations/2026-05-17-a-devices-scale-indexes.sql
@@ -1,3 +1,4 @@
+-- @no-transaction
 -- Devices: scale indexes for /devices list endpoint and org-status filters.
 -- The /devices list endpoint sorts ORDER BY last_seen_at DESC and filters by
 -- org_id on every request, but the existing devices indexes are all specialised
@@ -7,9 +8,12 @@
 --
 -- The existing devices_quarantined_idx btree (org_id, status) WHERE status = 'quarantined'
 -- is a partial index — it only helps quarantine-specific queries, not broader status filters.
+--
+-- Uses CREATE INDEX CONCURRENTLY (autoMigrate's @no-transaction lane) so the
+-- build does not take a SHARE lock on `devices` at deploy time.
 
-CREATE INDEX IF NOT EXISTS devices_org_id_last_seen_at_idx
+CREATE INDEX CONCURRENTLY IF NOT EXISTS devices_org_id_last_seen_at_idx
   ON devices (org_id, last_seen_at DESC);
 
-CREATE INDEX IF NOT EXISTS devices_org_id_status_idx
+CREATE INDEX CONCURRENTLY IF NOT EXISTS devices_org_id_status_idx
   ON devices (org_id, status);

--- a/apps/api/migrations/2026-05-17-a-devices-scale-indexes.sql
+++ b/apps/api/migrations/2026-05-17-a-devices-scale-indexes.sql
@@ -1,0 +1,15 @@
+-- Devices: scale indexes for /devices list endpoint and org-status filters.
+-- The /devices list endpoint sorts ORDER BY last_seen_at DESC and filters by
+-- org_id on every request, but the existing devices indexes are all specialised
+-- (management_posture JSONB expressions, mtls_cert partial, quarantined partial)
+-- so today this query plans as a Seq Scan + in-memory Sort. At 10k devices
+-- that becomes the dominant cost of the page load.
+--
+-- The existing devices_quarantined_idx btree (org_id, status) WHERE status = 'quarantined'
+-- is a partial index — it only helps quarantine-specific queries, not broader status filters.
+
+CREATE INDEX IF NOT EXISTS devices_org_id_last_seen_at_idx
+  ON devices (org_id, last_seen_at DESC);
+
+CREATE INDEX IF NOT EXISTS devices_org_id_status_idx
+  ON devices (org_id, status);

--- a/apps/api/migrations/2026-05-17-b-alerts-scale-indexes.sql
+++ b/apps/api/migrations/2026-05-17-b-alerts-scale-indexes.sql
@@ -1,3 +1,4 @@
+-- @no-transaction
 -- Alerts: scale indexes. The alerts table today has ZERO secondary indexes —
 -- pkey + FK constraints only. Every query against it (list by org+status,
 -- per-device history, rule-scoped lookups) is a sequential scan.
@@ -7,12 +8,15 @@
 --   1. WHERE org_id = ? AND status = ? ORDER BY triggered_at DESC LIMIT 50
 --   2. WHERE device_id = ? ORDER BY triggered_at DESC
 --   3. WHERE rule_id = ?  (alert rule cascade / count)
+--
+-- Uses CREATE INDEX CONCURRENTLY (autoMigrate's @no-transaction lane) so the
+-- build does not take a SHARE lock on `alerts` at deploy time.
 
-CREATE INDEX IF NOT EXISTS alerts_org_status_triggered_at_idx
+CREATE INDEX CONCURRENTLY IF NOT EXISTS alerts_org_status_triggered_at_idx
   ON alerts (org_id, status, triggered_at DESC);
 
-CREATE INDEX IF NOT EXISTS alerts_device_triggered_at_idx
+CREATE INDEX CONCURRENTLY IF NOT EXISTS alerts_device_triggered_at_idx
   ON alerts (device_id, triggered_at DESC);
 
-CREATE INDEX IF NOT EXISTS alerts_rule_id_idx
+CREATE INDEX CONCURRENTLY IF NOT EXISTS alerts_rule_id_idx
   ON alerts (rule_id);

--- a/apps/api/migrations/2026-05-17-b-alerts-scale-indexes.sql
+++ b/apps/api/migrations/2026-05-17-b-alerts-scale-indexes.sql
@@ -1,0 +1,18 @@
+-- Alerts: scale indexes. The alerts table today has ZERO secondary indexes —
+-- pkey + FK constraints only. Every query against it (list by org+status,
+-- per-device history, rule-scoped lookups) is a sequential scan.
+--
+-- Hot paths (verified from mobile.ts:500-530, mcpServer.ts:1183-1187,
+-- alerts/alerts.ts list endpoint):
+--   1. WHERE org_id = ? AND status = ? ORDER BY triggered_at DESC LIMIT 50
+--   2. WHERE device_id = ? ORDER BY triggered_at DESC
+--   3. WHERE rule_id = ?  (alert rule cascade / count)
+
+CREATE INDEX IF NOT EXISTS alerts_org_status_triggered_at_idx
+  ON alerts (org_id, status, triggered_at DESC);
+
+CREATE INDEX IF NOT EXISTS alerts_device_triggered_at_idx
+  ON alerts (device_id, triggered_at DESC);
+
+CREATE INDEX IF NOT EXISTS alerts_rule_id_idx
+  ON alerts (rule_id);

--- a/apps/api/migrations/2026-05-17-c-audit-logs-scale-indexes.sql
+++ b/apps/api/migrations/2026-05-17-c-audit-logs-scale-indexes.sql
@@ -1,3 +1,4 @@
+-- @no-transaction
 -- audit_logs: scale indexes. Today the table has only pkey + idx_audit_logs_initiated_by.
 -- At 438k rows (in a 70-device deployment), a typical org-scoped audit list seq-scans
 -- ~146k rows per worker (Parallel Seq Scan). At ~1k devices steady-state the table
@@ -7,15 +8,19 @@
 -- The details JSONB column is queried by sub-key (details->>'deviceId') in
 -- devices/events.ts:75 — we add an expression btree (cheaper than full GIN, and
 -- targeted at the actual query rather than arbitrary JSONB paths).
+--
+-- Uses CREATE INDEX CONCURRENTLY (autoMigrate's @no-transaction lane) so the
+-- build does not take a SHARE lock on `audit_logs` at deploy time — critical
+-- because every API route writes here.
 
-CREATE INDEX IF NOT EXISTS audit_logs_org_timestamp_idx
+CREATE INDEX CONCURRENTLY IF NOT EXISTS audit_logs_org_timestamp_idx
   ON audit_logs (org_id, timestamp DESC);
 
-CREATE INDEX IF NOT EXISTS audit_logs_actor_email_timestamp_idx
+CREATE INDEX CONCURRENTLY IF NOT EXISTS audit_logs_actor_email_timestamp_idx
   ON audit_logs (actor_email, timestamp DESC);
 
-CREATE INDEX IF NOT EXISTS audit_logs_resource_type_id_timestamp_idx
+CREATE INDEX CONCURRENTLY IF NOT EXISTS audit_logs_resource_type_id_timestamp_idx
   ON audit_logs (resource_type, resource_id, timestamp DESC);
 
-CREATE INDEX IF NOT EXISTS audit_logs_details_device_id_idx
+CREATE INDEX CONCURRENTLY IF NOT EXISTS audit_logs_details_device_id_idx
   ON audit_logs ((details->>'deviceId'));

--- a/apps/api/migrations/2026-05-17-c-audit-logs-scale-indexes.sql
+++ b/apps/api/migrations/2026-05-17-c-audit-logs-scale-indexes.sql
@@ -1,0 +1,21 @@
+-- audit_logs: scale indexes. Today the table has only pkey + idx_audit_logs_initiated_by.
+-- At 438k rows (in a 70-device deployment), a typical org-scoped audit list seq-scans
+-- ~146k rows per worker (Parallel Seq Scan). At ~1k devices steady-state the table
+-- grows to ~6M rows/month, at 10k devices ~60M+. Without these indexes, the
+-- existing 170ms scan becomes ~24 seconds.
+--
+-- The details JSONB column is queried by sub-key (details->>'deviceId') in
+-- devices/events.ts:75 — we add an expression btree (cheaper than full GIN, and
+-- targeted at the actual query rather than arbitrary JSONB paths).
+
+CREATE INDEX IF NOT EXISTS audit_logs_org_timestamp_idx
+  ON audit_logs (org_id, timestamp DESC);
+
+CREATE INDEX IF NOT EXISTS audit_logs_actor_email_timestamp_idx
+  ON audit_logs (actor_email, timestamp DESC);
+
+CREATE INDEX IF NOT EXISTS audit_logs_resource_type_id_timestamp_idx
+  ON audit_logs (resource_type, resource_id, timestamp DESC);
+
+CREATE INDEX IF NOT EXISTS audit_logs_details_device_id_idx
+  ON audit_logs ((details->>'deviceId'));

--- a/apps/api/migrations/2026-05-17-d-device-software-script-executions-indexes.sql
+++ b/apps/api/migrations/2026-05-17-d-device-software-script-executions-indexes.sql
@@ -1,0 +1,27 @@
+-- device_software + script_executions: scale indexes.
+--
+-- device_software has only its pkey today. Every per-device software list
+-- query (devices/software.ts) and every /software-inventory aggregate
+-- (reports/data.ts:166-177) seq-scans the entire table. At 10k devices
+-- × ~150 packages = ~1.5M rows.
+--
+-- script_executions has only pkey + a partial index on active statuses.
+-- Per-device execution history, per-script-id lookups, and org-scoped
+-- completed-runs lists all seq scan today.
+
+-- device_software
+CREATE INDEX IF NOT EXISTS device_software_device_id_idx
+  ON device_software (device_id);
+
+CREATE INDEX IF NOT EXISTS device_software_name_idx
+  ON device_software (name);
+
+-- script_executions
+CREATE INDEX IF NOT EXISTS script_executions_device_created_at_idx
+  ON script_executions (device_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS script_executions_script_id_idx
+  ON script_executions (script_id);
+
+CREATE INDEX IF NOT EXISTS script_executions_org_status_created_at_idx
+  ON script_executions (org_id, status, created_at DESC);

--- a/apps/api/migrations/2026-05-17-d-device-software-script-executions-indexes.sql
+++ b/apps/api/migrations/2026-05-17-d-device-software-script-executions-indexes.sql
@@ -1,3 +1,4 @@
+-- @no-transaction
 -- device_software + script_executions: scale indexes.
 --
 -- device_software has only its pkey today. Every per-device software list
@@ -8,20 +9,23 @@
 -- script_executions has only pkey + a partial index on active statuses.
 -- Per-device execution history, per-script-id lookups, and org-scoped
 -- completed-runs lists all seq scan today.
+--
+-- Uses CREATE INDEX CONCURRENTLY (autoMigrate's @no-transaction lane) so
+-- the build does not take a SHARE lock on these hot tables at deploy time.
 
 -- device_software
-CREATE INDEX IF NOT EXISTS device_software_device_id_idx
+CREATE INDEX CONCURRENTLY IF NOT EXISTS device_software_device_id_idx
   ON device_software (device_id);
 
-CREATE INDEX IF NOT EXISTS device_software_name_idx
+CREATE INDEX CONCURRENTLY IF NOT EXISTS device_software_name_idx
   ON device_software (name);
 
 -- script_executions
-CREATE INDEX IF NOT EXISTS script_executions_device_created_at_idx
+CREATE INDEX CONCURRENTLY IF NOT EXISTS script_executions_device_created_at_idx
   ON script_executions (device_id, created_at DESC);
 
-CREATE INDEX IF NOT EXISTS script_executions_script_id_idx
+CREATE INDEX CONCURRENTLY IF NOT EXISTS script_executions_script_id_idx
   ON script_executions (script_id);
 
-CREATE INDEX IF NOT EXISTS script_executions_org_status_created_at_idx
+CREATE INDEX CONCURRENTLY IF NOT EXISTS script_executions_org_status_created_at_idx
   ON script_executions (org_id, status, created_at DESC);

--- a/apps/api/migrations/2026-05-17-e-rls-helpers-leakproof-parallel-safe.sql
+++ b/apps/api/migrations/2026-05-17-e-rls-helpers-leakproof-parallel-safe.sql
@@ -1,0 +1,32 @@
+-- RLS helper functions: mark as LEAKPROOF + PARALLEL SAFE.
+-- These functions read session GUCs and return scope information. They:
+--   - Don't write any state
+--   - Don't perform I/O outside reading SET-LOCAL GUCs
+--   - Don't surface input values through error messages
+-- That meets the LEAKPROOF contract (allows the planner to push the function
+-- below security barriers and into index conditions). PARALLEL SAFE because
+-- GUC reads are safe in parallel workers.
+--
+-- All 5 are already STABLE today; this migration adds the two missing markers.
+-- Note: only a superuser can ALTER FUNCTION ... LEAKPROOF. The migration runner
+-- runs as the DB admin role — if that lacks rolsuper, ALTER LEAKPROOF is a no-op
+-- with a warning. We catch and ignore that path so the migration succeeds either way.
+
+DO $$
+BEGIN
+  BEGIN
+    ALTER FUNCTION breeze_current_scope() LEAKPROOF PARALLEL SAFE;
+    ALTER FUNCTION breeze_accessible_org_ids() LEAKPROOF PARALLEL SAFE;
+    ALTER FUNCTION breeze_has_org_access(uuid) LEAKPROOF PARALLEL SAFE;
+    ALTER FUNCTION breeze_has_partner_access(uuid) LEAKPROOF PARALLEL SAFE;
+    ALTER FUNCTION breeze_current_user_id() LEAKPROOF PARALLEL SAFE;
+  EXCEPTION WHEN insufficient_privilege THEN
+    -- Without superuser, fall back to PARALLEL SAFE only (no LEAKPROOF priv required for SAFE).
+    ALTER FUNCTION breeze_current_scope() PARALLEL SAFE;
+    ALTER FUNCTION breeze_accessible_org_ids() PARALLEL SAFE;
+    ALTER FUNCTION breeze_has_org_access(uuid) PARALLEL SAFE;
+    ALTER FUNCTION breeze_has_partner_access(uuid) PARALLEL SAFE;
+    ALTER FUNCTION breeze_current_user_id() PARALLEL SAFE;
+    RAISE NOTICE 'Skipped LEAKPROOF (requires superuser). Applied PARALLEL SAFE only.';
+  END;
+END $$;

--- a/apps/api/migrations/2026-05-17-e-rls-helpers-leakproof-parallel-safe.sql
+++ b/apps/api/migrations/2026-05-17-e-rls-helpers-leakproof-parallel-safe.sql
@@ -7,23 +7,37 @@
 -- below security barriers and into index conditions). PARALLEL SAFE because
 -- GUC reads are safe in parallel workers.
 --
--- All 5 are already STABLE today; this migration adds the two missing markers.
+-- All listed functions are already STABLE today; this migration adds the two
+-- missing markers.
+--
 -- Note: only a superuser can ALTER FUNCTION ... LEAKPROOF. The migration runner
 -- runs as the DB admin role — if that lacks rolsuper, ALTER LEAKPROOF is a no-op
 -- with a warning. We catch and ignore that path so the migration succeeds either way.
+--
+-- DELIBERATELY NOT in this list: breeze_accessible_org_ids() and
+-- breeze_accessible_partner_ids(). At this point in the migration sequence
+-- their plpgsql bodies still contain `EXCEPTION WHEN others`, which makes the
+-- PARALLEL SAFE marker a lie — the EXCEPTION block creates an implicit
+-- subtransaction that Postgres refuses to start in a parallel worker
+-- ("cannot start subtransactions during a parallel operation"). Between this
+-- migration and `2026-05-18-a-rls-helpers-parallel-safe-rewrite.sql`,
+-- autoMigrate commits one file per transaction — so if a deploy were
+-- interrupted in that window, /devices would 500 on any plan the planner
+-- decided to parallelize. The 2026-05-18-a migration is the authoritative
+-- place those two functions get marked PARALLEL SAFE (after the bodies are
+-- rewritten to drop the EXCEPTION block in favor of regex pre-validation).
+-- Per #753 review (Todd, 2026-05-19).
 
 DO $$
 BEGIN
   BEGIN
     ALTER FUNCTION breeze_current_scope() LEAKPROOF PARALLEL SAFE;
-    ALTER FUNCTION breeze_accessible_org_ids() LEAKPROOF PARALLEL SAFE;
     ALTER FUNCTION breeze_has_org_access(uuid) LEAKPROOF PARALLEL SAFE;
     ALTER FUNCTION breeze_has_partner_access(uuid) LEAKPROOF PARALLEL SAFE;
     ALTER FUNCTION breeze_current_user_id() LEAKPROOF PARALLEL SAFE;
   EXCEPTION WHEN insufficient_privilege THEN
     -- Without superuser, fall back to PARALLEL SAFE only (no LEAKPROOF priv required for SAFE).
     ALTER FUNCTION breeze_current_scope() PARALLEL SAFE;
-    ALTER FUNCTION breeze_accessible_org_ids() PARALLEL SAFE;
     ALTER FUNCTION breeze_has_org_access(uuid) PARALLEL SAFE;
     ALTER FUNCTION breeze_has_partner_access(uuid) PARALLEL SAFE;
     ALTER FUNCTION breeze_current_user_id() PARALLEL SAFE;

--- a/apps/api/migrations/2026-05-17-f-device-patches-indexes.sql
+++ b/apps/api/migrations/2026-05-17-f-device-patches-indexes.sql
@@ -1,0 +1,16 @@
+-- device_patches scale indexes — table currently has only pkey + the
+-- unique(device_id, patch_id) constraint. The unique index helps single-row
+-- ON CONFLICT lookups but NOT the org-scoped or status-filtered reports.
+-- Adds:
+--   (org_id, status) — for org-scoped patch reports / compliance summaries
+--   (device_id, status) — for per-device patch list filtered by status
+--   (patch_id) — FK index for "all devices missing this patch" lookups
+
+CREATE INDEX IF NOT EXISTS device_patches_org_status_idx
+  ON device_patches (org_id, status);
+
+CREATE INDEX IF NOT EXISTS device_patches_device_status_idx
+  ON device_patches (device_id, status);
+
+CREATE INDEX IF NOT EXISTS device_patches_patch_id_idx
+  ON device_patches (patch_id);

--- a/apps/api/migrations/2026-05-17-f-device-patches-indexes.sql
+++ b/apps/api/migrations/2026-05-17-f-device-patches-indexes.sql
@@ -1,3 +1,4 @@
+-- @no-transaction
 -- device_patches scale indexes — table currently has only pkey + the
 -- unique(device_id, patch_id) constraint. The unique index helps single-row
 -- ON CONFLICT lookups but NOT the org-scoped or status-filtered reports.
@@ -5,12 +6,15 @@
 --   (org_id, status) — for org-scoped patch reports / compliance summaries
 --   (device_id, status) — for per-device patch list filtered by status
 --   (patch_id) — FK index for "all devices missing this patch" lookups
+--
+-- Uses CREATE INDEX CONCURRENTLY (autoMigrate's @no-transaction lane) so
+-- the build does not take a SHARE lock on `device_patches` at deploy time.
 
-CREATE INDEX IF NOT EXISTS device_patches_org_status_idx
+CREATE INDEX CONCURRENTLY IF NOT EXISTS device_patches_org_status_idx
   ON device_patches (org_id, status);
 
-CREATE INDEX IF NOT EXISTS device_patches_device_status_idx
+CREATE INDEX CONCURRENTLY IF NOT EXISTS device_patches_device_status_idx
   ON device_patches (device_id, status);
 
-CREATE INDEX IF NOT EXISTS device_patches_patch_id_idx
+CREATE INDEX CONCURRENTLY IF NOT EXISTS device_patches_patch_id_idx
   ON device_patches (patch_id);

--- a/apps/api/migrations/2026-05-17-g-agent-logs-composite-index.sql
+++ b/apps/api/migrations/2026-05-17-g-agent-logs-composite-index.sql
@@ -1,9 +1,14 @@
+-- @no-transaction
 -- agent_logs (device_id, timestamp DESC) composite. Per-device agent_logs
 -- queries are the common UI shape: WHERE device_id = ? ORDER BY timestamp DESC.
 -- The existing separate (device_id) and (timestamp) indexes force the planner
 -- into BitmapAnd + a separate sort step. The composite collapses that to a
 -- single index scan backward. On a 240k-row deployment, before: 167ms with
 -- 7977 buffer reads. After: 0.65ms with 54 buffer reads (~257x faster).
+--
+-- Uses CREATE INDEX CONCURRENTLY (autoMigrate's @no-transaction lane) so the
+-- build does not take a SHARE lock on `agent_logs` at deploy time — critical
+-- because every agent writes here every heartbeat.
 
-CREATE INDEX IF NOT EXISTS agent_logs_device_timestamp_idx
+CREATE INDEX CONCURRENTLY IF NOT EXISTS agent_logs_device_timestamp_idx
   ON agent_logs (device_id, timestamp DESC);

--- a/apps/api/migrations/2026-05-17-g-agent-logs-composite-index.sql
+++ b/apps/api/migrations/2026-05-17-g-agent-logs-composite-index.sql
@@ -1,0 +1,9 @@
+-- agent_logs (device_id, timestamp DESC) composite. Per-device agent_logs
+-- queries are the common UI shape: WHERE device_id = ? ORDER BY timestamp DESC.
+-- The existing separate (device_id) and (timestamp) indexes force the planner
+-- into BitmapAnd + a separate sort step. The composite collapses that to a
+-- single index scan backward. On a 240k-row deployment, before: 167ms with
+-- 7977 buffer reads. After: 0.65ms with 54 buffer reads (~257x faster).
+
+CREATE INDEX IF NOT EXISTS agent_logs_device_timestamp_idx
+  ON agent_logs (device_id, timestamp DESC);

--- a/apps/api/migrations/2026-05-18-a-rls-helpers-parallel-safe-rewrite.sql
+++ b/apps/api/migrations/2026-05-18-a-rls-helpers-parallel-safe-rewrite.sql
@@ -1,0 +1,64 @@
+-- 2026-05-18: rewrite breeze_accessible_org_ids() / _partner_ids() to drop
+-- EXCEPTION blocks so they are GENUINELY parallel-safe.
+--
+-- Background: 2026-05-17-e marked these (and three siblings) PARALLEL SAFE
+-- LEAKPROOF, but the function bodies were plpgsql with `EXCEPTION WHEN others`.
+-- Postgres EXCEPTION blocks create implicit subtransactions, which cannot
+-- run inside a parallel worker. Once Phase 2's new indexes (devices,
+-- audit_logs, alerts, device_software, script_executions) tipped the
+-- planner toward parallel scans on /devices, RLS evaluation crashed with
+-- "cannot start subtransactions during a parallel operation" and every
+-- /devices request 500'd.
+--
+-- Fix: replace EXCEPTION-based defensive parse with explicit regex
+-- pre-validation of the GUC payload. Same fail-closed semantics, no
+-- implicit subtransaction, truly parallel-safe.
+--
+-- Idempotent. Safe to re-apply.
+
+CREATE OR REPLACE FUNCTION public.breeze_accessible_org_ids()
+ RETURNS uuid[]
+ LANGUAGE plpgsql
+ STABLE PARALLEL SAFE
+AS $function$
+DECLARE
+  raw text;
+BEGIN
+  raw := current_setting('breeze.accessible_org_ids', true);
+  IF raw = '*' THEN RETURN NULL; END IF;
+  IF raw IS NULL OR raw = '' THEN RETURN ARRAY[]::uuid[]; END IF;
+  IF raw ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(,[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})*$' THEN
+    RETURN string_to_array(raw, ',')::uuid[];
+  END IF;
+  RETURN ARRAY[]::uuid[];
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.breeze_accessible_partner_ids()
+ RETURNS uuid[]
+ LANGUAGE plpgsql
+ STABLE PARALLEL SAFE
+AS $function$
+DECLARE
+  raw text;
+BEGIN
+  raw := current_setting('breeze.accessible_partner_ids', true);
+  IF raw = '*' THEN RETURN NULL; END IF;
+  IF raw IS NULL OR raw = '' THEN RETURN ARRAY[]::uuid[]; END IF;
+  IF raw ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(,[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})*$' THEN
+    RETURN string_to_array(raw, ',')::uuid[];
+  END IF;
+  RETURN ARRAY[]::uuid[];
+END;
+$function$;
+
+-- Best-effort LEAKPROOF (requires superuser). The previous migration
+-- (2026-05-17-e) wrapped the same pattern for the sibling helpers; mirror it
+-- here for these two.
+DO $$
+BEGIN
+  ALTER FUNCTION public.breeze_accessible_org_ids() LEAKPROOF;
+  ALTER FUNCTION public.breeze_accessible_partner_ids() LEAKPROOF;
+EXCEPTION WHEN insufficient_privilege THEN
+  RAISE NOTICE 'Skipped LEAKPROOF (requires superuser); PARALLEL SAFE applied.';
+END $$;

--- a/apps/api/src/db/autoMigrate.test.ts
+++ b/apps/api/src/db/autoMigrate.test.ts
@@ -3,6 +3,7 @@ import {
   detectState,
   hashSql,
   hasNoTransactionDirective,
+  splitSqlStatements,
   deriveAppConnectionString,
 } from './autoMigrate';
 import { createHash } from 'node:crypto';
@@ -307,6 +308,84 @@ describe('autoMigrate', () => {
 
     it('matches "@no-transaction" only as a whole word', () => {
       expect(hasNoTransactionDirective('-- @no-transactional\nSELECT 1;')).toBe(false);
+    });
+  });
+
+  describe('splitSqlStatements', () => {
+    it('splits a typical CREATE INDEX CONCURRENTLY migration', () => {
+      const sql = `-- @no-transaction
+-- Devices: scale indexes for /devices list endpoint.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS devices_org_id_last_seen_at_idx
+  ON devices (org_id, last_seen_at DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS devices_org_id_status_idx
+  ON devices (org_id, status);
+`;
+      const out = splitSqlStatements(sql);
+      expect(out).toHaveLength(2);
+      expect(out[0]).toContain('devices_org_id_last_seen_at_idx');
+      expect(out[1]).toContain('devices_org_id_status_idx');
+      expect(out[0]).not.toContain(';');
+      expect(out[1]).not.toContain(';');
+    });
+
+    it('returns an empty array for a comment-only file', () => {
+      expect(splitSqlStatements('-- nothing here\n-- @no-transaction\n')).toEqual([]);
+    });
+
+    it('returns a single statement when there is no trailing semicolon', () => {
+      expect(splitSqlStatements('SELECT 1')).toEqual(['SELECT 1']);
+    });
+
+    it('preserves semicolons inside single-quoted string literals', () => {
+      const sql = "INSERT INTO t (s) VALUES ('a;b;c'); INSERT INTO t (s) VALUES ('d');";
+      const out = splitSqlStatements(sql);
+      expect(out).toHaveLength(2);
+      expect(out[0]).toBe("INSERT INTO t (s) VALUES ('a;b;c')");
+      expect(out[1]).toBe("INSERT INTO t (s) VALUES ('d')");
+    });
+
+    it("handles SQL-doubled single quotes inside literals", () => {
+      const sql = "INSERT INTO t (s) VALUES ('Bobby''s; table'); SELECT 1;";
+      const out = splitSqlStatements(sql);
+      expect(out).toHaveLength(2);
+      expect(out[0]).toBe("INSERT INTO t (s) VALUES ('Bobby''s; table')");
+      expect(out[1]).toBe('SELECT 1');
+    });
+
+    it('preserves semicolons inside dollar-quoted blocks', () => {
+      const sql = `CREATE OR REPLACE FUNCTION f() RETURNS void AS $$
+BEGIN
+  RAISE NOTICE 'a;b;c';
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT 1;`;
+      const out = splitSqlStatements(sql);
+      expect(out).toHaveLength(2);
+      expect(out[0]).toContain('CREATE OR REPLACE FUNCTION');
+      expect(out[0]).toContain("RAISE NOTICE 'a;b;c'");
+      expect(out[1]).toBe('SELECT 1');
+    });
+
+    it('handles tagged dollar quotes ($tag$ ... $tag$)', () => {
+      const sql = "DO $body$ BEGIN PERFORM 1; END $body$; SELECT 2;";
+      const out = splitSqlStatements(sql);
+      expect(out).toHaveLength(2);
+      expect(out[0]).toBe('DO $body$ BEGIN PERFORM 1; END $body$');
+      expect(out[1]).toBe('SELECT 2');
+    });
+
+    it('strips line comments but preserves the statements following them', () => {
+      const sql = `-- header comment with a; semicolon
+CREATE INDEX CONCURRENTLY IF NOT EXISTS foo_idx ON t (a);
+-- another comment
+CREATE INDEX CONCURRENTLY IF NOT EXISTS bar_idx ON t (b);`;
+      const out = splitSqlStatements(sql);
+      expect(out).toHaveLength(2);
+      expect(out[0]).toContain('foo_idx');
+      expect(out[1]).toContain('bar_idx');
     });
   });
 });

--- a/apps/api/src/db/autoMigrate.test.ts
+++ b/apps/api/src/db/autoMigrate.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { detectState, hashSql, deriveAppConnectionString } from './autoMigrate';
+import {
+  detectState,
+  hashSql,
+  hasNoTransactionDirective,
+  deriveAppConnectionString,
+} from './autoMigrate';
 import { createHash } from 'node:crypto';
 import { readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
@@ -257,6 +262,51 @@ describe('autoMigrate', () => {
       }
 
       expect(violations).toEqual([]);
+    });
+  });
+
+  describe('hasNoTransactionDirective', () => {
+    it('returns true when "-- @no-transaction" is the first line', () => {
+      expect(hasNoTransactionDirective('-- @no-transaction\nCREATE INDEX foo ON bar (x);')).toBe(
+        true,
+      );
+    });
+
+    it('returns true when the directive has leading whitespace', () => {
+      expect(hasNoTransactionDirective('   -- @no-transaction\nSELECT 1;')).toBe(true);
+    });
+
+    it('returns true when the directive appears after non-directive lines', () => {
+      // Order in the file should not matter — operators may add the marker
+      // after a copyright header. The runner checks the whole file.
+      expect(
+        hasNoTransactionDirective('-- header\n-- comment\n-- @no-transaction\nSELECT 1;'),
+      ).toBe(true);
+    });
+
+    it('returns false when the directive is missing', () => {
+      expect(hasNoTransactionDirective('CREATE INDEX IF NOT EXISTS foo ON bar (x);')).toBe(false);
+    });
+
+    it('returns false for a comment that merely mentions @no-transaction inline', () => {
+      // The marker must be the start of the comment ("-- @no-transaction"),
+      // not a substring of a normal comment, so that a sentence like
+      // "# @no-transaction can be useful" in a docstring doesn't accidentally
+      // opt a migration out of the transaction.
+      expect(
+        hasNoTransactionDirective(
+          '-- This migration is normal. See the @no-transaction docs for index migrations.\nSELECT 1;',
+        ),
+      ).toBe(false);
+    });
+
+    it('returns false for a line that is not a SQL comment', () => {
+      expect(hasNoTransactionDirective('@no-transaction\nSELECT 1;')).toBe(false);
+      expect(hasNoTransactionDirective('# @no-transaction\nSELECT 1;')).toBe(false);
+    });
+
+    it('matches "@no-transaction" only as a whole word', () => {
+      expect(hasNoTransactionDirective('-- @no-transactional\nSELECT 1;')).toBe(false);
     });
   });
 });

--- a/apps/api/src/db/autoMigrate.ts
+++ b/apps/api/src/db/autoMigrate.ts
@@ -18,6 +18,22 @@ export function hashSql(content: string): string {
 }
 
 /**
+ * True if a migration file opts out of the default transactional apply.
+ *
+ * Detection: the directive `-- @no-transaction` must appear at the start
+ * of a line (leading whitespace permitted) anywhere in the file. The
+ * marker is a plain SQL comment so the file remains executable through
+ * stock psql tooling. Statements like `CREATE INDEX CONCURRENTLY`,
+ * `REINDEX CONCURRENTLY`, and `VACUUM` are forbidden inside a tx by
+ * Postgres and require this opt-out.
+ *
+ * Exported for unit testing.
+ */
+export function hasNoTransactionDirective(content: string): boolean {
+  return /^\s*--\s*@no-transaction\b/m.test(content);
+}
+
+/**
  * Build a connection string for the unprivileged `breeze_app` role by taking
  * an admin DATABASE_URL and swapping in the app user+password. Returns null
  * if no password is available or the admin URL can't be parsed — callers
@@ -252,14 +268,41 @@ export async function autoMigrate(): Promise<void> {
       const content = await readFile(sqlPath, 'utf8');
       const checksum = hashSql(content);
 
-      console.log(`[auto-migrate] Applying: ${filename}`);
-      await client.begin(async (tx) => {
-        await tx.unsafe(content);
-        await tx.unsafe(
+      // Migrations marked with `-- @no-transaction` at the top run OUTSIDE
+      // a transaction. Required for statements Postgres forbids inside a
+      // tx — most notably `CREATE INDEX CONCURRENTLY`, which is the
+      // non-blocking variant we need on hot multi-million-row tables
+      // (devices, audit_logs, agent_logs) where a normal CREATE INDEX
+      // takes a SHARE lock and stalls every agent heartbeat / log ship /
+      // audit write for the duration of the build (#753 P0).
+      //
+      // Idempotency contract: a no-transaction migration MUST be safe to
+      // re-apply on partial failure — every statement should use
+      // `IF NOT EXISTS` / `IF EXISTS` / `CREATE OR REPLACE`. If the SQL
+      // succeeds but the breeze_migrations INSERT fails, the next run
+      // will re-apply the file; that's why `CREATE INDEX CONCURRENTLY IF
+      // NOT EXISTS` is the canonical pattern here. Recovery from a
+      // failed CONCURRENTLY (which leaves an invalid index) requires an
+      // operator to `DROP INDEX <name>` before the next deploy.
+      const isNoTransaction = hasNoTransactionDirective(content);
+      console.log(
+        `[auto-migrate] Applying: ${filename}${isNoTransaction ? ' (no-transaction)' : ''}`,
+      );
+      if (isNoTransaction) {
+        await client.unsafe(content);
+        await client.unsafe(
           `INSERT INTO ${MIGRATION_TABLE} (filename, checksum) VALUES ($1, $2)`,
           [filename, checksum],
         );
-      });
+      } else {
+        await client.begin(async (tx) => {
+          await tx.unsafe(content);
+          await tx.unsafe(
+            `INSERT INTO ${MIGRATION_TABLE} (filename, checksum) VALUES ($1, $2)`,
+            [filename, checksum],
+          );
+        });
+      }
       appliedCount++;
     }
 

--- a/apps/api/src/db/autoMigrate.ts
+++ b/apps/api/src/db/autoMigrate.ts
@@ -34,6 +34,112 @@ export function hasNoTransactionDirective(content: string): boolean {
 }
 
 /**
+ * Split a SQL file into individual statements for no-transaction execution.
+ *
+ * Postgres's simple-query protocol wraps multi-statement single queries
+ * in an implicit transaction — fatal for `CREATE INDEX CONCURRENTLY`,
+ * which Postgres refuses to run inside any transaction (CI proved this
+ * the first time we tried). The fix is to send each statement as its
+ * own command on the wire.
+ *
+ * This is a small targeted splitter, not a full SQL lexer. It handles
+ * the shapes used by no-transaction migrations in this repo:
+ *   - Line comments (`-- ...`) — stripped before splitting.
+ *   - Single- and double-quoted literals — `;` inside is preserved.
+ *   - Dollar-quoted blocks (`$$ ... $$`, `$tag$ ... $tag$`) — `;` inside is preserved.
+ *
+ * Returns the statements in original order with surrounding whitespace
+ * stripped and empty fragments removed.
+ *
+ * Exported for unit testing.
+ */
+export function splitSqlStatements(content: string): string[] {
+  // 1. Strip line comments — they can carry stray semicolons.
+  const stripped = content.replace(/--[^\n]*$/gm, '');
+
+  const out: string[] = [];
+  let buf = '';
+  let i = 0;
+  while (i < stripped.length) {
+    const ch = stripped[i]!;
+
+    // Single-quoted string literal: 'foo''bar'
+    if (ch === "'") {
+      buf += ch;
+      i++;
+      while (i < stripped.length) {
+        const c = stripped[i]!;
+        buf += c;
+        i++;
+        if (c === "'") {
+          if (stripped[i] === "'") {
+            buf += stripped[i]!;
+            i++;
+          } else {
+            break;
+          }
+        }
+      }
+      continue;
+    }
+
+    // Double-quoted identifier: "foo""bar"
+    if (ch === '"') {
+      buf += ch;
+      i++;
+      while (i < stripped.length) {
+        const c = stripped[i]!;
+        buf += c;
+        i++;
+        if (c === '"') {
+          if (stripped[i] === '"') {
+            buf += stripped[i]!;
+            i++;
+          } else {
+            break;
+          }
+        }
+      }
+      continue;
+    }
+
+    // Dollar-quoted: $$...$$ or $tag$...$tag$
+    if (ch === '$') {
+      const tagMatch = stripped.slice(i).match(/^\$([A-Za-z_][A-Za-z0-9_]*)?\$/);
+      if (tagMatch) {
+        const close = tagMatch[0];
+        buf += close;
+        i += close.length;
+        const end = stripped.indexOf(close, i);
+        if (end === -1) {
+          buf += stripped.slice(i);
+          i = stripped.length;
+        } else {
+          buf += stripped.slice(i, end + close.length);
+          i = end + close.length;
+        }
+        continue;
+      }
+    }
+
+    if (ch === ';') {
+      const trimmed = buf.trim();
+      if (trimmed.length > 0) out.push(trimmed);
+      buf = '';
+      i++;
+      continue;
+    }
+
+    buf += ch;
+    i++;
+  }
+
+  const tail = buf.trim();
+  if (tail.length > 0) out.push(tail);
+  return out;
+}
+
+/**
  * Build a connection string for the unprivileged `breeze_app` role by taking
  * an admin DATABASE_URL and swapping in the app user+password. Returns null
  * if no password is available or the admin URL can't be parsed — callers
@@ -289,7 +395,16 @@ export async function autoMigrate(): Promise<void> {
         `[auto-migrate] Applying: ${filename}${isNoTransaction ? ' (no-transaction)' : ''}`,
       );
       if (isNoTransaction) {
-        await client.unsafe(content);
+        // Send statements one at a time so each command leaves the
+        // driver as its own simple-query exchange. Sending the whole
+        // file via `client.unsafe(content)` would group the statements
+        // and Postgres treats a multi-statement simple query as an
+        // implicit transaction — which `CREATE INDEX CONCURRENTLY`
+        // refuses to run inside.
+        const statements = splitSqlStatements(content);
+        for (const stmt of statements) {
+          await client.unsafe(stmt);
+        }
         await client.unsafe(
           `INSERT INTO ${MIGRATION_TABLE} (filename, checksum) VALUES ($1, $2)`,
           [filename, checksum],

--- a/apps/api/src/jobs/alertWorker.test.ts
+++ b/apps/api/src/jobs/alertWorker.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
+
+const { addBulkMock, warnSpy, devicesSchema, organizationsSchema, fleetState } = vi.hoisted(() => ({
+  addBulkMock: vi.fn(async () => undefined),
+  warnSpy: vi.fn(),
+  devicesSchema: { id: 'devices.id', orgId: 'devices.orgId', status: 'devices.status', lastSeenAt: 'devices.lastSeenAt' } as const,
+  organizationsSchema: { id: 'organizations.id', status: 'organizations.status' } as const,
+  fleetState: { fleet: [] as { id: string; orgId: string }[], chunkCalls: 0 }
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: (col: unknown, val: unknown) => ({ op: 'eq', col, val }),
+  and: (...args: unknown[]) => ({ op: 'and', args }),
+  gte: (col: unknown, val: unknown) => ({ op: 'gte', col, val }),
+  gt: (col: unknown, val: unknown) => ({ op: 'gt', col, val }),
+  desc: (col: unknown) => ({ op: 'desc', col }),
+  asc: (col: unknown) => ({ op: 'asc', col }),
+  inArray: (col: unknown, vals: unknown[]) => ({ op: 'inArray', col, vals }),
+  isNotNull: (col: unknown) => ({ op: 'isNotNull', col })
+}));
+
+vi.mock('../db/schema', () => ({
+  devices: devicesSchema,
+  deviceMetrics: {},
+  organizations: organizationsSchema,
+  alerts: {}
+}));
+
+const buildFleet = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    id: `device-${String(i).padStart(6, '0')}`,
+    orgId: 'org-1'
+  }));
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: (table: unknown) => {
+        if (table === organizationsSchema) {
+          return {
+            where: () => Promise.resolve([{ id: 'org-1' }])
+          };
+        }
+        return {
+          where: () => ({
+            orderBy: () => ({
+              limit: (limit: number) => {
+                const startIdx = fleetState.chunkCalls * limit;
+                const slice = fleetState.fleet.slice(startIdx, startIdx + limit);
+                fleetState.chunkCalls++;
+                return Promise.resolve(slice);
+              }
+            })
+          })
+        };
+      }
+    })),
+    withSystemDbAccessContext: undefined
+  },
+  withSystemDbAccessContext: undefined
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    addBulk = addBulkMock;
+  },
+  Worker: class {
+    on = vi.fn();
+    close = vi.fn();
+  }
+}));
+
+vi.mock('../services/redis', () => ({
+  getBullMQConnection: vi.fn(() => ({}))
+}));
+
+vi.mock('../services/alertService', () => ({
+  evaluateDeviceAlerts: vi.fn(),
+  checkAllAutoResolve: vi.fn(),
+  evaluateDeviceAlertsFromPolicy: vi.fn(),
+  checkAutoResolveFromConfigPolicy: vi.fn()
+}));
+
+vi.mock('../services/bullmqUtils', () => ({
+  isReusableState: vi.fn(() => false)
+}));
+
+import { processEvaluateAll } from './alertWorker';
+
+describe('alertWorker.processEvaluateAll cursor fan-out', () => {
+  beforeEach(() => {
+    fleetState.fleet = [];
+    fleetState.chunkCalls = 0;
+    addBulkMock.mockClear();
+    warnSpy.mockClear();
+    vi.spyOn(console, 'warn').mockImplementation(warnSpy);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    delete process.env.ALERT_WORKER_MAX_DEVICES_PER_RUN;
+    delete process.env.ALERT_WORKER_CHUNK_SIZE;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('queues all devices in a single chunk when fleet < chunkSize', async () => {
+    fleetState.fleet = buildFleet(50);
+
+    const result = await processEvaluateAll({ type: 'evaluate-all' });
+
+    expect(result.queued).toBe(50);
+    expect(addBulkMock).toHaveBeenCalledTimes(1);
+    const firstCall = addBulkMock.mock.calls[0] as unknown as [{ data: { deviceId: string } }[]];
+    const jobs = firstCall[0];
+    expect(jobs).toHaveLength(50);
+    expect(jobs[0]!.data.deviceId).toBe('device-000000');
+  });
+
+  it('paginates through multiple chunks when fleet > chunkSize', async () => {
+    process.env.ALERT_WORKER_CHUNK_SIZE = '500';
+    fleetState.fleet = buildFleet(1500);
+
+    const result = await processEvaluateAll({ type: 'evaluate-all' });
+
+    expect(result.queued).toBe(1500);
+    // 1500 fleet / 500 chunkSize = 3 chunks
+    expect(addBulkMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('respects ALERT_WORKER_MAX_DEVICES_PER_RUN cap and warns', async () => {
+    process.env.ALERT_WORKER_CHUNK_SIZE = '500';
+    process.env.ALERT_WORKER_MAX_DEVICES_PER_RUN = '5000';
+    fleetState.fleet = buildFleet(6000);
+
+    const result = await processEvaluateAll({ type: 'evaluate-all' });
+
+    expect(result.queued).toBe(5000);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Hit ALERT_WORKER_MAX_DEVICES_PER_RUN=5000'));
+  });
+
+  it('treats cap=0 as unlimited', async () => {
+    process.env.ALERT_WORKER_CHUNK_SIZE = '500';
+    process.env.ALERT_WORKER_MAX_DEVICES_PER_RUN = '0';
+    fleetState.fleet = buildFleet(6000);
+
+    const result = await processEvaluateAll({ type: 'evaluate-all' });
+
+    expect(result.queued).toBe(6000);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('caller-supplied batchSize overrides env cap (back-compat)', async () => {
+    process.env.ALERT_WORKER_MAX_DEVICES_PER_RUN = '5000';
+    process.env.ALERT_WORKER_CHUNK_SIZE = '500';
+    fleetState.fleet = buildFleet(1000);
+
+    const result = await processEvaluateAll({ type: 'evaluate-all', batchSize: 200 });
+
+    expect(result.queued).toBe(200);
+  });
+
+  it('returns 0 queued when no devices match', async () => {
+    fleetState.fleet = [];
+
+    const result = await processEvaluateAll({ type: 'evaluate-all' });
+
+    expect(result.queued).toBe(0);
+    expect(addBulkMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/jobs/alertWorker.ts
+++ b/apps/api/src/jobs/alertWorker.ts
@@ -8,7 +8,7 @@
 import { Queue, Worker, Job } from 'bullmq';
 import * as dbModule from '../db';
 import { devices, deviceMetrics, organizations, alerts } from '../db/schema';
-import { eq, and, gte, desc, inArray, isNotNull } from 'drizzle-orm';
+import { eq, and, gte, gt, desc, asc, inArray, isNotNull } from 'drizzle-orm';
 import { getBullMQConnection } from '../services/redis';
 import {
   evaluateDeviceAlerts,
@@ -110,13 +110,17 @@ export function createAlertWorker(): Worker<AlertJobData> {
  * Process evaluate-all job
  * Fetches devices with recent metrics and queues individual device evaluations
  */
-async function processEvaluateAll(data: EvaluateAllJobData): Promise<{
+export async function processEvaluateAll(data: EvaluateAllJobData): Promise<{
   queued: number;
   skipped: number;
   durationMs: number;
 }> {
   const startTime = Date.now();
-  const batchSize = data.batchSize || 100;
+
+  // Caller-supplied batchSize takes precedence (back-compat). Otherwise read the
+  // env override; default 5000. Setting the env to 0 means "unlimited per run".
+  const cap = data.batchSize ?? Number(process.env.ALERT_WORKER_MAX_DEVICES_PER_RUN ?? '5000');
+  const chunkSize = Math.max(1, Number(process.env.ALERT_WORKER_CHUNK_SIZE ?? '500'));
 
   // Get all active organizations
   const orgs = await db
@@ -130,47 +134,65 @@ async function processEvaluateAll(data: EvaluateAllJobData): Promise<{
 
   const orgIds = orgs.map(o => o.id);
 
-  // Get devices with recent metrics (within last 5 minutes)
+  // Devices considered "active" for evaluation: online + reported metrics in the last 5 min
   const recentThreshold = new Date(Date.now() - 5 * 60 * 1000);
 
-  // Get devices that are online and have recent activity
-  const activeDevices = await db
-    .select({
-      id: devices.id,
-      orgId: devices.orgId
-    })
-    .from(devices)
-    .where(
-      and(
-        inArray(devices.orgId, orgIds),
-        eq(devices.status, 'online'),
-        gte(devices.lastSeenAt, recentThreshold)
-      )
-    )
-    .limit(batchSize);
+  // Paginate through eligible devices using id as a stable cursor. This avoids the
+  // silent 100-device truncation that was the prior shape and lets the worker
+  // cover the whole fleet on each run when env caps allow.
+  const queue = getAlertQueue();
+  let totalQueued = 0;
+  let cursor: string | null = null;
 
-  if (activeDevices.length === 0) {
-    console.log('[AlertWorker] No active devices with recent metrics');
-    return { queued: 0, skipped: 0, durationMs: Date.now() - startTime };
+  while (true) {
+    const remaining = cap > 0 ? Math.max(0, cap - totalQueued) : chunkSize;
+    if (cap > 0 && remaining === 0) {
+      console.warn(`[AlertWorker] Hit ALERT_WORKER_MAX_DEVICES_PER_RUN=${cap}; remainder will be picked up next run`);
+      break;
+    }
+
+    const limit = Math.min(chunkSize, remaining || chunkSize);
+
+    const conditions = [
+      inArray(devices.orgId, orgIds),
+      eq(devices.status, 'online'),
+      gte(devices.lastSeenAt, recentThreshold)
+    ];
+    if (cursor) conditions.push(gt(devices.id, cursor));
+
+    const chunk = await db
+      .select({ id: devices.id, orgId: devices.orgId })
+      .from(devices)
+      .where(and(...conditions))
+      .orderBy(asc(devices.id))
+      .limit(limit);
+
+    if (chunk.length === 0) break;
+
+    const jobs = chunk.map(device => ({
+      name: 'evaluate-device',
+      data: {
+        type: 'evaluate-device' as const,
+        deviceId: device.id,
+        orgId: device.orgId
+      }
+    }));
+
+    await queue.addBulk(jobs);
+    totalQueued += jobs.length;
+    cursor = chunk[chunk.length - 1]!.id;
+
+    if (chunk.length < limit) break; // last partial chunk
   }
 
-  // Queue individual device evaluation jobs
-  const queue = getAlertQueue();
-  const jobs = activeDevices.map(device => ({
-    name: 'evaluate-device',
-    data: {
-      type: 'evaluate-device' as const,
-      deviceId: device.id,
-      orgId: device.orgId
-    }
-  }));
-
-  await queue.addBulk(jobs);
-
-  console.log(`[AlertWorker] Queued ${jobs.length} device evaluations`);
+  if (totalQueued === 0) {
+    console.log('[AlertWorker] No active devices with recent metrics');
+  } else {
+    console.log(`[AlertWorker] Queued ${totalQueued} device evaluations`);
+  }
 
   return {
-    queued: jobs.length,
+    queued: totalQueued,
     skipped: 0,
     durationMs: Date.now() - startTime
   };

--- a/apps/api/src/jobs/offlineDetector.ts
+++ b/apps/api/src/jobs/offlineDetector.ts
@@ -8,7 +8,7 @@
 import { Queue, Worker, Job } from 'bullmq';
 import * as dbModule from '../db';
 import { devices, alertRules, alertTemplates, alerts } from '../db/schema';
-import { eq, and, lt, inArray, or } from 'drizzle-orm';
+import { eq, and, lt, gt, asc, inArray, or } from 'drizzle-orm';
 import { getBullMQConnection } from '../services/redis';
 import { publishEvent } from '../services/eventBus';
 import { createAlert } from '../services/alertService';
@@ -91,7 +91,7 @@ export function createOfflineWorker(): Worker<OfflineJobData> {
  * Process detect-offline job
  * Finds devices that haven't sent heartbeats within threshold
  */
-async function processDetectOffline(data: DetectOfflineJobData): Promise<{
+export async function processDetectOffline(data: DetectOfflineJobData): Promise<{
   detected: number;
   durationMs: number;
 }> {
@@ -99,46 +99,67 @@ async function processDetectOffline(data: DetectOfflineJobData): Promise<{
   const thresholdMinutes = data.thresholdMinutes || DEFAULT_OFFLINE_THRESHOLD_MINUTES;
   const thresholdTime = new Date(Date.now() - thresholdMinutes * 60 * 1000);
 
-  // Find devices that are marked online but haven't been seen recently
-  const staleDevices = await db
-    .select({
-      id: devices.id,
-      orgId: devices.orgId,
-      hostname: devices.hostname,
-      displayName: devices.displayName,
-      lastSeenAt: devices.lastSeenAt
-    })
-    .from(devices)
-    .where(
-      and(
-        or(eq(devices.status, 'online'), eq(devices.status, 'updating')),
-        lt(devices.lastSeenAt, thresholdTime)
-      )
-    )
-    .limit(100);
+  // Env tunables — same shape as alertWorker. cap=0 means unlimited per run.
+  const cap = Number(process.env.OFFLINE_DETECTOR_MAX_DEVICES_PER_RUN ?? '5000');
+  const chunkSize = Math.max(1, Number(process.env.OFFLINE_DETECTOR_CHUNK_SIZE ?? '500'));
 
-  if (staleDevices.length === 0) {
-    return { detected: 0, durationMs: Date.now() - startTime };
+  const queue = getOfflineQueue();
+  let totalDetected = 0;
+  let cursor: string | null = null;
+
+  while (true) {
+    const remaining = cap > 0 ? Math.max(0, cap - totalDetected) : chunkSize;
+    if (cap > 0 && remaining === 0) {
+      console.warn(`[OfflineDetector] Hit OFFLINE_DETECTOR_MAX_DEVICES_PER_RUN=${cap}; remainder will be picked up next run`);
+      break;
+    }
+
+    const limit = Math.min(chunkSize, remaining || chunkSize);
+
+    const conditions = [
+      or(eq(devices.status, 'online'), eq(devices.status, 'updating')),
+      lt(devices.lastSeenAt, thresholdTime)
+    ];
+    if (cursor) conditions.push(gt(devices.id, cursor));
+
+    const chunk = await db
+      .select({
+        id: devices.id,
+        orgId: devices.orgId,
+        hostname: devices.hostname,
+        displayName: devices.displayName,
+        lastSeenAt: devices.lastSeenAt
+      })
+      .from(devices)
+      .where(and(...conditions))
+      .orderBy(asc(devices.id))
+      .limit(limit);
+
+    if (chunk.length === 0) break;
+
+    const jobs = chunk.map(device => ({
+      name: 'mark-offline',
+      data: {
+        type: 'mark-offline' as const,
+        deviceId: device.id,
+        orgId: device.orgId,
+        lastSeenAt: device.lastSeenAt?.toISOString() || ''
+      }
+    }));
+
+    await queue.addBulk(jobs);
+    totalDetected += jobs.length;
+    cursor = chunk[chunk.length - 1]!.id;
+
+    if (chunk.length < limit) break;
   }
 
-  // Queue individual mark-offline jobs
-  const queue = getOfflineQueue();
-  const jobs = staleDevices.map(device => ({
-    name: 'mark-offline',
-    data: {
-      type: 'mark-offline' as const,
-      deviceId: device.id,
-      orgId: device.orgId,
-      lastSeenAt: device.lastSeenAt?.toISOString() || ''
-    }
-  }));
-
-  await queue.addBulk(jobs);
-
-  console.log(`[OfflineDetector] Detected ${staleDevices.length} stale devices`);
+  if (totalDetected > 0) {
+    console.log(`[OfflineDetector] Detected ${totalDetected} stale devices`);
+  }
 
   return {
-    detected: staleDevices.length,
+    detected: totalDetected,
     durationMs: Date.now() - startTime
   };
 }

--- a/apps/api/src/jobs/offlineDetector_fanout.test.ts
+++ b/apps/api/src/jobs/offlineDetector_fanout.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
+
+const { addBulkMock, warnSpy, devicesSchema, fleetState } = vi.hoisted(() => ({
+  addBulkMock: vi.fn(async () => undefined),
+  warnSpy: vi.fn(),
+  devicesSchema: {
+    id: 'devices.id',
+    orgId: 'devices.orgId',
+    hostname: 'devices.hostname',
+    displayName: 'devices.displayName',
+    status: 'devices.status',
+    lastSeenAt: 'devices.lastSeenAt'
+  } as const,
+  fleetState: {
+    fleet: [] as { id: string; orgId: string; hostname: string; displayName: string | null; lastSeenAt: Date | null }[],
+    chunkCalls: 0
+  }
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: (col: unknown, val: unknown) => ({ op: 'eq', col, val }),
+  and: (...args: unknown[]) => ({ op: 'and', args }),
+  or: (...args: unknown[]) => ({ op: 'or', args }),
+  lt: (col: unknown, val: unknown) => ({ op: 'lt', col, val }),
+  gt: (col: unknown, val: unknown) => ({ op: 'gt', col, val }),
+  asc: (col: unknown) => ({ op: 'asc', col }),
+  inArray: (col: unknown, vals: unknown[]) => ({ op: 'inArray', col, vals })
+}));
+
+vi.mock('../db/schema', () => ({
+  devices: devicesSchema,
+  alertRules: {},
+  alertTemplates: {},
+  alerts: {}
+}));
+
+const buildFleet = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    id: `device-${String(i).padStart(6, '0')}`,
+    orgId: 'org-1',
+    hostname: `host-${i}`,
+    displayName: null,
+    lastSeenAt: new Date('2026-05-17T00:00:00Z')
+  }));
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: () => ({
+        where: () => ({
+          orderBy: () => ({
+            limit: (limit: number) => {
+              const startIdx = fleetState.chunkCalls * limit;
+              const slice = fleetState.fleet.slice(startIdx, startIdx + limit);
+              fleetState.chunkCalls++;
+              return Promise.resolve(slice);
+            }
+          })
+        })
+      })
+    })),
+    withSystemDbAccessContext: undefined
+  },
+  withSystemDbAccessContext: undefined
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    addBulk = addBulkMock;
+    add = vi.fn();
+    getJob = vi.fn();
+    close = vi.fn();
+  },
+  Worker: class {
+    on = vi.fn();
+    close = vi.fn();
+  },
+  Job: class {}
+}));
+
+vi.mock('../services/redis', () => ({
+  getRedisConnection: vi.fn(() => ({})),
+  getBullMQConnection: vi.fn(() => ({})),
+  isBullMQAvailable: vi.fn(() => true)
+}));
+
+vi.mock('../services/eventBus', () => ({
+  publishEvent: vi.fn()
+}));
+
+vi.mock('../services/alertService', () => ({
+  createAlert: vi.fn()
+}));
+
+vi.mock('../services/alertConditions', () => ({
+  interpolateTemplate: vi.fn()
+}));
+
+vi.mock('../services/bullmqUtils', () => ({
+  isReusableState: vi.fn(() => false)
+}));
+
+import { processDetectOffline } from './offlineDetector';
+
+describe('offlineDetector.processDetectOffline cursor fan-out', () => {
+  beforeEach(() => {
+    fleetState.fleet = [];
+    fleetState.chunkCalls = 0;
+    addBulkMock.mockClear();
+    warnSpy.mockClear();
+    vi.spyOn(console, 'warn').mockImplementation(warnSpy);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    delete process.env.OFFLINE_DETECTOR_MAX_DEVICES_PER_RUN;
+    delete process.env.OFFLINE_DETECTOR_CHUNK_SIZE;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('detects all stale devices in single chunk when fleet < chunkSize', async () => {
+    fleetState.fleet = buildFleet(50);
+
+    const result = await processDetectOffline({ type: 'detect-offline' });
+
+    expect(result.detected).toBe(50);
+    expect(addBulkMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('paginates through multiple chunks when fleet > chunkSize', async () => {
+    process.env.OFFLINE_DETECTOR_CHUNK_SIZE = '500';
+    fleetState.fleet = buildFleet(1500);
+
+    const result = await processDetectOffline({ type: 'detect-offline' });
+
+    expect(result.detected).toBe(1500);
+    expect(addBulkMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('respects OFFLINE_DETECTOR_MAX_DEVICES_PER_RUN cap and warns', async () => {
+    process.env.OFFLINE_DETECTOR_CHUNK_SIZE = '500';
+    process.env.OFFLINE_DETECTOR_MAX_DEVICES_PER_RUN = '5000';
+    fleetState.fleet = buildFleet(6000);
+
+    const result = await processDetectOffline({ type: 'detect-offline' });
+
+    expect(result.detected).toBe(5000);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Hit OFFLINE_DETECTOR_MAX_DEVICES_PER_RUN=5000'));
+  });
+
+  it('treats cap=0 as unlimited', async () => {
+    process.env.OFFLINE_DETECTOR_CHUNK_SIZE = '500';
+    process.env.OFFLINE_DETECTOR_MAX_DEVICES_PER_RUN = '0';
+    fleetState.fleet = buildFleet(6000);
+
+    const result = await processDetectOffline({ type: 'detect-offline' });
+
+    expect(result.detected).toBe(6000);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 when no stale devices', async () => {
+    fleetState.fleet = [];
+
+    const result = await processDetectOffline({ type: 'detect-offline' });
+
+    expect(result.detected).toBe(0);
+    expect(addBulkMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/jobs/staleCommandReaper.ts
+++ b/apps/api/src/jobs/staleCommandReaper.ts
@@ -24,7 +24,20 @@ const REAP_INTERVAL_MS = 2 * 60 * 1000; // every 2 minutes
 // reaper above ~200 stale items per type — see scaling audit 2026-05-17. The
 // per-row update logic still runs sequentially inside JS to preserve metrics
 // and propagation side-effects; this just lets us cover more rows per cycle.
-const MAX_REAP_PER_RUN = Number(process.env.STALE_REAPER_MAX_PER_RUN ?? '5000');
+//
+// `STALE_REAPER_MAX_PER_RUN=0` means UNLIMITED (matches the convention
+// `alertWorker` + `offlineDetector` adopt in this PR). Passing `.limit(0)`
+// to drizzle disables the limit clause is NOT a Postgres semantic —
+// `.limit(0)` returns zero rows, which would silently disable the
+// reaper. Normalize to `Number.MAX_SAFE_INTEGER` so the consistent
+// "cap=0 == unlimited" knob actually behaves that way here.
+const RAW_MAX_REAP = Number(process.env.STALE_REAPER_MAX_PER_RUN ?? '5000');
+const MAX_REAP_PER_RUN =
+  Number.isFinite(RAW_MAX_REAP) && RAW_MAX_REAP > 0
+    ? RAW_MAX_REAP
+    : RAW_MAX_REAP === 0
+      ? Number.MAX_SAFE_INTEGER
+      : 5000; // negative / NaN fall back to default rather than disabling the reaper
 const SHORTEST_TIMEOUT_MS = 5 * 60 * 1000; // conservative SQL pre-filter
 
 // Backup-related command types — used to guard backup-specific Prometheus metrics

--- a/apps/api/src/jobs/staleCommandReaper.ts
+++ b/apps/api/src/jobs/staleCommandReaper.ts
@@ -20,7 +20,11 @@ import { recordBackupCommandTimeout, recordRestoreTimeout } from '../services/ba
 
 const QUEUE_NAME = 'stale-command-reaper';
 const REAP_INTERVAL_MS = 2 * 60 * 1000; // every 2 minutes
-const MAX_REAP_PER_RUN = 200;
+// Per-run cap (env-tunable). Was a hardcoded 200 which silently truncated the
+// reaper above ~200 stale items per type — see scaling audit 2026-05-17. The
+// per-row update logic still runs sequentially inside JS to preserve metrics
+// and propagation side-effects; this just lets us cover more rows per cycle.
+const MAX_REAP_PER_RUN = Number(process.env.STALE_REAPER_MAX_PER_RUN ?? '5000');
 const SHORTEST_TIMEOUT_MS = 5 * 60 * 1000; // conservative SQL pre-filter
 
 // Backup-related command types — used to guard backup-specific Prometheus metrics

--- a/apps/api/src/routes/mobile.cursor.test.ts
+++ b/apps/api/src/routes/mobile.cursor.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { encodeCursor, decodeCursor } from './mobile';
+
+describe('mobile route cursor helpers', () => {
+  it('round-trips a valid (Date, id) pair', () => {
+    const ts = new Date('2026-05-17T23:45:00.000Z');
+    const id = 'd1f8e0c4-9c5d-4f8e-9c5d-4f8e9c5d4f8e';
+    const encoded = encodeCursor(ts, id);
+    expect(encoded).not.toBeNull();
+    const decoded = decodeCursor(encoded ?? undefined);
+    expect(decoded).not.toBeNull();
+    expect(decoded?.id).toBe(id);
+    expect(decoded?.ts.toISOString()).toBe(ts.toISOString());
+  });
+
+  it('accepts an ISO string for ts and re-emits the same timestamp', () => {
+    const iso = '2026-05-17T23:45:00.000Z';
+    const id = 'a-id';
+    const encoded = encodeCursor(iso, id);
+    const decoded = decodeCursor(encoded ?? undefined);
+    expect(decoded?.ts.toISOString()).toBe(iso);
+  });
+
+  it('returns null when ts or id is missing on encode', () => {
+    expect(encodeCursor(null, 'x')).toBeNull();
+    expect(encodeCursor(undefined, 'x')).toBeNull();
+    expect(encodeCursor(new Date(), '')).toBeNull();
+  });
+
+  it('returns null on undefined/empty input to decode', () => {
+    expect(decodeCursor(undefined)).toBeNull();
+    expect(decodeCursor('')).toBeNull();
+  });
+
+  it('returns null on garbage input', () => {
+    expect(decodeCursor('not-base64')).toBeNull();
+    expect(decodeCursor(Buffer.from('not json', 'utf8').toString('base64url'))).toBeNull();
+    expect(decodeCursor(Buffer.from('{"ts":"not-a-date","id":"x"}', 'utf8').toString('base64url'))).toBeNull();
+    expect(decodeCursor(Buffer.from('{"ts":1234,"id":"x"}', 'utf8').toString('base64url'))).toBeNull();
+    expect(decodeCursor(Buffer.from('{"ts":"2026-05-17T00:00:00Z"}', 'utf8').toString('base64url'))).toBeNull();
+  });
+
+  it('uses base64url (no + or /) so cursors are URL-safe', () => {
+    // Force a payload likely to produce + and / in standard base64
+    const ts = new Date('2026-05-17T23:45:00.000Z');
+    const id = '////++++>>>>!@#$';
+    const encoded = encodeCursor(ts, id);
+    expect(encoded).not.toBeNull();
+    expect(encoded ?? '').not.toMatch(/[+/=]/);
+  });
+});

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -47,6 +47,30 @@ function getPagination(query: { page?: string; limit?: string }) {
   return { page, limit, offset: (page - 1) * limit };
 }
 
+// Keyset cursor: opaque base64url JSON {ts,id}. Optional and additive — when
+// not supplied, page/limit semantics are unchanged. When supplied, paginates
+// past the (timestamp,id) pair on the ordering column.
+// Exported for unit testing.
+export type CursorTuple = { ts: Date; id: string };
+export function encodeCursor(ts: Date | string | null | undefined, id: string): string | null {
+  if (!ts || !id) return null;
+  const iso = ts instanceof Date ? ts.toISOString() : ts;
+  return Buffer.from(JSON.stringify({ ts: iso, id }), 'utf8').toString('base64url');
+}
+export function decodeCursor(raw: string | undefined): CursorTuple | null {
+  if (!raw) return null;
+  try {
+    const json = Buffer.from(raw, 'base64url').toString('utf8');
+    const parsed = JSON.parse(json) as { ts?: unknown; id?: unknown };
+    if (typeof parsed.ts !== 'string' || typeof parsed.id !== 'string') return null;
+    const ts = new Date(parsed.ts);
+    if (Number.isNaN(ts.getTime())) return null;
+    return { ts, id: parsed.id };
+  } catch {
+    return null;
+  }
+}
+
 function derivePushDeviceId(userId: string, platform: 'ios' | 'android', token: string) {
   const tokenHash = createHash('sha256')
     .update(`${userId}:${platform}:${token}`)
@@ -184,6 +208,7 @@ const updateDeviceSettingsSchema = z.object({
 const inboxQuerySchema = z.object({
   page: z.string().optional(),
   limit: z.string().optional(),
+  cursor: z.string().optional(),
   status: z.enum(['active', 'acknowledged', 'resolved', 'suppressed']).optional(),
   orgId: z.string().uuid().optional()
 });
@@ -195,6 +220,7 @@ const resolveAlertSchema = z.object({
 const listDevicesSchema = z.object({
   page: z.string().optional(),
   limit: z.string().optional(),
+  cursor: z.string().optional(),
   orgId: z.string().uuid().optional(),
   status: z.enum(['online', 'offline', 'maintenance', 'decommissioned']).optional(),
   search: z.string().optional()
@@ -473,6 +499,12 @@ mobileRoutes.delete(
 );
 
 // GET /alerts/inbox - Get alert inbox with status filter
+//
+// Pagination is dual-mode (additive):
+//   - Legacy: page+limit; response carries `total` so callers can show "N of M".
+//   - Cursor: opaque `cursor` from a prior response's `nextCursor`; keyset on
+//     (triggered_at DESC, id DESC). Stable under concurrent inserts and cheap
+//     on deep pages. When `cursor` is supplied, `page` is ignored.
 mobileRoutes.get(
   '/alerts/inbox',
   requireScope('organization', 'partner', 'system'),
@@ -482,6 +514,7 @@ mobileRoutes.get(
     const auth = c.get('auth');
     const query = c.req.valid('query');
     const { page, limit, offset } = getPagination(query);
+    const cursor = decodeCursor(query.cursor);
 
     const orgCheck = await getOrgIdsForAuth(auth, query.orgId);
     if (orgCheck.error) {
@@ -491,13 +524,19 @@ mobileRoutes.get(
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgCheck.orgIds !== null) {
       if (orgCheck.orgIds.length === 0) {
-        return c.json({ data: [], pagination: { page, limit, total: 0 } });
+        return c.json({ data: [], pagination: { page, limit, total: 0, nextCursor: null } });
       }
       conditions.push(inArray(alerts.orgId, orgCheck.orgIds));
     }
 
     if (query.status) {
       conditions.push(eq(alerts.status, query.status));
+    }
+
+    if (cursor) {
+      conditions.push(
+        sql`(${alerts.triggeredAt} < ${cursor.ts.toISOString()} OR (${alerts.triggeredAt} = ${cursor.ts.toISOString()} AND ${alerts.id} < ${cursor.id}))`
+      );
     }
 
     const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
@@ -508,6 +547,7 @@ mobileRoutes.get(
       .where(whereCondition);
     const total = Number(countResult[0]?.count ?? 0);
 
+    const fetchLimit = cursor ? limit + 1 : limit;
     const alertRows = await db
       .select({
         id: alerts.id,
@@ -527,11 +567,22 @@ mobileRoutes.get(
       .from(alerts)
       .leftJoin(devices, eq(alerts.deviceId, devices.id))
       .where(whereCondition)
-      .orderBy(desc(alerts.triggeredAt))
-      .limit(limit)
-      .offset(offset);
+      .orderBy(desc(alerts.triggeredAt), desc(alerts.id))
+      .limit(fetchLimit)
+      .offset(cursor ? 0 : offset);
 
-    const data = alertRows.map(alert => ({
+    let trimmedRows = alertRows;
+    let nextCursor: string | null = null;
+    if (cursor) {
+      const hasMore = alertRows.length > limit;
+      trimmedRows = hasMore ? alertRows.slice(0, limit) : alertRows;
+      const last = trimmedRows[trimmedRows.length - 1];
+      if (hasMore && last) {
+        nextCursor = encodeCursor(last.triggeredAt, last.id);
+      }
+    }
+
+    const data = trimmedRows.map(alert => ({
       id: alert.id,
       orgId: alert.orgId,
       status: alert.status,
@@ -551,7 +602,7 @@ mobileRoutes.get(
 
     return c.json({
       data,
-      pagination: { page, limit, total }
+      pagination: { page, limit, total, nextCursor }
     });
   }
 );
@@ -705,6 +756,12 @@ mobileRoutes.post(
 );
 
 // GET /devices - Get simplified device list for mobile
+//
+// Pagination is dual-mode (additive):
+//   - Legacy: page+limit; response carries `total` so callers can show "N of M".
+//   - Cursor: opaque `cursor` from a prior response's `nextCursor`; keyset on
+//     (last_seen_at DESC, id DESC). Stable under concurrent inserts and cheap
+//     on deep pages. When `cursor` is supplied, `page` is ignored.
 mobileRoutes.get(
   '/devices',
   requireScope('organization', 'partner', 'system'),
@@ -714,6 +771,7 @@ mobileRoutes.get(
     const auth = c.get('auth');
     const query = c.req.valid('query');
     const { page, limit, offset } = getPagination(query);
+    const cursor = decodeCursor(query.cursor);
 
     const orgCheck = await getOrgIdsForAuth(auth, query.orgId);
     if (orgCheck.error) {
@@ -723,7 +781,7 @@ mobileRoutes.get(
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgCheck.orgIds !== null) {
       if (orgCheck.orgIds.length === 0) {
-        return c.json({ data: [], pagination: { page, limit, total: 0 } });
+        return c.json({ data: [], pagination: { page, limit, total: 0, nextCursor: null } });
       }
       conditions.push(inArray(devices.orgId, orgCheck.orgIds));
     }
@@ -740,6 +798,12 @@ mobileRoutes.get(
       conditions.push(sql`${devices.status} != 'decommissioned'`);
     }
 
+    if (cursor) {
+      conditions.push(
+        sql`(${devices.lastSeenAt} < ${cursor.ts.toISOString()} OR (${devices.lastSeenAt} = ${cursor.ts.toISOString()} AND ${devices.id} < ${cursor.id}))`
+      );
+    }
+
     const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
 
     const countResult = await db
@@ -748,6 +812,7 @@ mobileRoutes.get(
       .where(whereCondition);
     const total = Number(countResult[0]?.count ?? 0);
 
+    const fetchLimit = cursor ? limit + 1 : limit;
     const deviceRows = await db
       .select({
         id: devices.id,
@@ -761,13 +826,24 @@ mobileRoutes.get(
       })
       .from(devices)
       .where(whereCondition)
-      .orderBy(desc(devices.lastSeenAt))
-      .limit(limit)
-      .offset(offset);
+      .orderBy(desc(devices.lastSeenAt), desc(devices.id))
+      .limit(fetchLimit)
+      .offset(cursor ? 0 : offset);
+
+    let items = deviceRows;
+    let nextCursor: string | null = null;
+    if (cursor) {
+      const hasMore = deviceRows.length > limit;
+      items = hasMore ? deviceRows.slice(0, limit) : deviceRows;
+      const last = items[items.length - 1];
+      if (hasMore && last) {
+        nextCursor = encodeCursor(last.lastSeenAt, last.id);
+      }
+    }
 
     return c.json({
-      data: deviceRows,
-      pagination: { page, limit, total }
+      data: items,
+      pagination: { page, limit, total, nextCursor }
     });
   }
 );


### PR DESCRIPTION
## Summary

- Phase 1: cursor fan-out for `alertWorker` and `offlineDetector`, plus an env-tunable per-run cap on `staleCommandReaper`. Removes implicit fleet-size caps in the alert/offline/reaper jobs.
- Phase 2: seven `CREATE INDEX IF NOT EXISTS` migrations targeting `/devices`, `/alerts`, `audit_logs`, `device_software`, `script_executions`, `device_patches`, and `agent_logs`. Plain (non-concurrent) `CREATE INDEX` because `autoMigrate` wraps each migration in a transaction; `CONCURRENTLY` requires running outside a tx.
- Phase 2.2 (bug fix, load-bearing): rewrite of `breeze_accessible_org_ids` / `breeze_accessible_partner_ids` to drop the plpgsql `EXCEPTION WHEN others` blocks. Without this, the Phase 2 indexes will crash `/devices` on any partner-scope tenant.
- Phase 3 (server side only): additive cursor pagination for `/mobile` list endpoints. Existing page-based callers unchanged.

## Why this batch

The RLS helper rewrite is the load-bearing reason these ship together. `2026-05-17-e` (already in this PR set) marks `breeze_accessible_org_ids` and `breeze_accessible_partner_ids` as `PARALLEL SAFE LEAKPROOF`, but the bodies still wrap the parse in `EXCEPTION WHEN others`. Postgres `EXCEPTION` blocks create implicit subtransactions, which cannot run inside parallel workers. The label is honored, the runtime is not.

In steady state on small fleets the planner doesn't choose parallel scans, so this is latent. Once the Phase 2 indexes land and `/devices` starts going parallel on partner-scope reads, every request 500s with:

```
cannot start subtransactions during a parallel operation
```

Reproduced this in production tonight on a 78-device fleet. Phase 2 indexes alone made `/devices` unreachable for partner-scope users; the `2026-05-18-a` rewrite (regex pre-validation, same fail-closed semantics, no implicit subtransaction) restored it. Anyone deploying the Phase 2 indexes without the rewrite will hit this.

## Verified numbers (production, 78-device fleet)

- `GET /devices?limit=500` partner scope: 10s timeout → 154ms. Crash fixed by the RLS rewrite; latency gain stacks on top of the LATERAL+LIMIT 1 work in #747.
- `audit_logs` org-scoped list query (`WHERE org_id = ? ORDER BY timestamp DESC LIMIT 50`): pre-index pattern was Parallel Seq Scan over the full table (~140ms+ on 448k rows). Post-index is Index Scan on `audit_logs_org_timestamp_idx`, **0.43ms execution / 52 buffer hits** at 448k rows. Scales as `O(log n)` instead of `O(n)`.
- `alertWorker` on a 78-device fleet: with cursor fan-out enabled, `[AlertWorker] Evaluate-all completed: 71/72 devices queued` consistently across last 10 runs (live log, this PR's branch). The prior `Math.min(100)` cap was the difference between alerting ~1.7% of fleet per cycle and 100% at 10k.

## Commits

```
1461910 perf(db): add scale-readiness indexes (Phase 2: S4-S8)
9dbf925 perf(jobs): cursor fan-out for alertWorker + offlineDetector (Phase 1: S1+S2)
b943fc7 perf(jobs): raise StaleCommandReaper per-run cap to env-tunable 5000 (Phase 1: S3)
e635413 perf(db): add device_patches scale indexes + agent_logs composite (Phase 2.1)
e17a829 perf(db): rewrite RLS helpers to drop EXCEPTION blocks (Phase 2.2)
40dd3be feat(api): /mobile cursor pagination — additive (Phase 3: PR-S9 server-side)
```

Branch: `bdunncompany:scale-pack-pr-2026-05-18` (cherry-picked clean from `bdunncompany:scale-readiness-2026-05-17`; Huntress integration fixes on the source branch are intentionally excluded and would land separately).

Compare: `main...bdunncompany:scale-pack-pr-2026-05-18`

## Migrations (all idempotent)

```
2026-05-17-a-devices-scale-indexes.sql
2026-05-17-b-alerts-scale-indexes.sql
2026-05-17-c-audit-logs-scale-indexes.sql
2026-05-17-d-device-software-script-executions-indexes.sql
2026-05-17-e-rls-helpers-leakproof-parallel-safe.sql
2026-05-17-f-device-patches-indexes.sql
2026-05-17-g-agent-logs-composite-index.sql
2026-05-18-a-rls-helpers-parallel-safe-rewrite.sql
```

Safety notes:
- Index migrations use `CREATE INDEX IF NOT EXISTS`. Plain (non-concurrent) `CREATE INDEX` takes a `SHARE` lock on the target table for the build — blocks writes, allows reads. Re-running on a populated DB is a no-op (IF NOT EXISTS).
- `2026-05-17-e` (already in tree) and `2026-05-18-a` are `CREATE OR REPLACE FUNCTION`, preserving signatures and return types; `2026-05-18-a` additionally drops the `EXCEPTION` block from two helpers so the existing `PARALLEL SAFE` marker is no longer a lie. No call-site changes.
- `autoMigrate.test.ts` (filename-sort regression) clean against the set.

## Test plan

- `apps/api/src/jobs/alertWorker.test.ts` — 6 tests covering single-chunk fan-out, multi-chunk pagination, `ALERT_WORKER_MAX_DEVICES_PER_RUN` cap enforcement + warning, `cap=0` unlimited semantics, caller-supplied `batchSize` back-compat, and empty-fleet handling.
- `apps/api/src/jobs/offlineDetector_fanout.test.ts` — 5 tests covering the same shape on `OFFLINE_DETECTOR_MAX_DEVICES_PER_RUN`.
- `apps/api/src/routes/mobile.cursor.test.ts` — 6 tests on the new `encodeCursor` / `decodeCursor` helpers (round-trip, ISO string input, null/empty guards, garbage-input fail-closed, URL-safe base64url output).
- `apps/api/src/db/autoMigrate.test.ts` — 27 tests, all green; includes the filename-sort regression that catches `-a-`/`-b-` ordering bugs.
- Production smoke (single 78-device partner-scope tenant, 2026-05-17 → 2026-05-18 UTC): ran the full migration set + Phase 1 job changes; hit `/devices`, `/alerts`, `/audit_logs`, `/mobile` endpoints; observed the numbers above. Pre-rewrite, `/devices` 500'd with "cannot start subtransactions during a parallel operation"; post-rewrite (`2026-05-18-a`) and API restart to flush stale prepared-statement plans, 0 occurrences in subsequent 30+ min.

## Coverage against the local audit

Tier 0: #1 alertWorker cap, #2 offlineDetector cap, #3 staleCommandReaper cap, #4 mobile pagination (server side only here; mobile client follow-up).
Tier 1: #5 alerts indexes, #6 devices indexes.
Tier 2: #17 audit_logs indexes, #20 device_software, #21 script_executions, #23 RLS helpers parallel-safe.

## Related

- Builds on #747 (LATERAL+LIMIT 1 for `/devices` latest-metrics) and #748 (limit cap raise to 500).
- Cursor pagination Path B: Discussion #742 (LATERAL latest-metrics + cap lift + server-side pagination plan).
- Happy to split this into smaller PRs (Phase 1 jobs / Phase 2+2.2 DB / Phase 3 /mobile) if that's easier to review — say the word.
