### PR TITLE
fix(agent/api): suppress console window for user-helper child spawns on Windows

### DIFF
--- a/agent/internal/executor/executor.go
+++ b/agent/internal/executor/executor.go
@@ -178,6 +178,12 @@ func (e *Executor) Execute(script ScriptExecution) (*ScriptResult, error) {
 	// Set process group so children are killed on timeout
 	setProcessGroup(cmd)
 
+	// Suppress console window allocation on Windows (no-op elsewhere). The
+	// user-helper is built -H windowsgui, so a console-subsystem child like
+	// powershell.exe would otherwise pop a visible "black box" on the
+	// interactive user desktop every script run.
+	hideWindow(cmd)
+
 	// When the context is cancelled (timeout), kill the entire process group
 	// rather than only the shell leader. Otherwise long-running children like
 	// `sleep` keep the stdout/stderr pipes open and Wait() blocks forever.

--- a/agent/internal/executor/limits_linux.go
+++ b/agent/internal/executor/limits_linux.go
@@ -28,3 +28,6 @@ func killProcessGroup(cmd *exec.Cmd) error {
 	}
 	return syscall.Kill(-pgid, syscall.SIGKILL)
 }
+
+// hideWindow is a no-op on Linux.
+func hideWindow(cmd *exec.Cmd) {}

--- a/agent/internal/executor/limits_unix.go
+++ b/agent/internal/executor/limits_unix.go
@@ -27,3 +27,6 @@ func killProcessGroup(cmd *exec.Cmd) error {
 	}
 	return syscall.Kill(-pgid, syscall.SIGKILL)
 }
+
+// hideWindow is a no-op on non-Windows platforms.
+func hideWindow(cmd *exec.Cmd) {}

--- a/agent/internal/executor/limits_windows.go
+++ b/agent/internal/executor/limits_windows.go
@@ -2,7 +2,12 @@
 
 package executor
 
-import "os/exec"
+import (
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
 
 // setProcessGroup is a no-op on Windows. Job Objects could be used for full
 // process tree management but are deferred to a future enhancement.
@@ -14,4 +19,19 @@ func killProcessGroup(cmd *exec.Cmd) error {
 		return nil
 	}
 	return cmd.Process.Kill()
+}
+
+// hideWindow prevents the spawned shell (powershell.exe, cmd.exe, etc.) from
+// allocating a visible console window when the user-helper (linked
+// -H windowsgui) executes a user-context script. Without CREATE_NO_WINDOW the
+// kernel attaches a fresh console to console-subsystem children.
+func hideWindow(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.HideWindow = true
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NO_WINDOW
 }

--- a/agent/internal/executor/limits_windows_test.go
+++ b/agent/internal/executor/limits_windows_test.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package executor
+
+import (
+	"os/exec"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestHideWindow_SetsCreateNoWindow(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/c", "echo", "ok")
+	hideWindow(cmd)
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr not allocated")
+	}
+	if !cmd.SysProcAttr.HideWindow {
+		t.Error("HideWindow flag not set")
+	}
+	if cmd.SysProcAttr.CreationFlags&windows.CREATE_NO_WINDOW == 0 {
+		t.Errorf("CREATE_NO_WINDOW not set; CreationFlags=0x%x", cmd.SysProcAttr.CreationFlags)
+	}
+}
+
+func TestHideWindow_NilSafe(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("hideWindow(nil) panicked: %v", r)
+		}
+	}()
+	hideWindow(nil)
+}

--- a/agent/internal/userhelper/client.go
+++ b/agent/internal/userhelper/client.go
@@ -566,6 +566,7 @@ func (c *Client) handleLaunchProcess(env *ipc.Envelope) {
 
 	cmd := osexec.Command(req.BinaryPath, req.Args...)
 	cmd.Dir = filepath.Dir(req.BinaryPath)
+	hideWindow(cmd)
 	if err := cmd.Start(); err != nil {
 		log.Warn("failed to launch process", "binary", req.BinaryPath, "args", req.Args, "error", err.Error())
 		c.conn.SendTyped(env.ID, ipc.TypeLaunchResult, ipc.LaunchProcessResult{
@@ -780,6 +781,7 @@ func (c *Client) executeProcess(cmd ipc.IPCCommand) ipc.IPCCommandResult {
 	var stdout, stderr bytes.Buffer
 	proc.Stdout = &stdout
 	proc.Stderr = &stderr
+	hideWindow(proc)
 
 	done := make(chan error, 1)
 	if err := proc.Start(); err != nil {

--- a/agent/internal/userhelper/spawn_other.go
+++ b/agent/internal/userhelper/spawn_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package userhelper
+
+import "os/exec"
+
+// hideWindow is a no-op on non-Windows platforms.
+func hideWindow(cmd *exec.Cmd) {}

--- a/agent/internal/userhelper/spawn_windows.go
+++ b/agent/internal/userhelper/spawn_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package userhelper
+
+import (
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// hideWindow prevents Windows from allocating a visible console window when the
+// user-helper (built with -H windowsgui per agent/Makefile) spawns a
+// console-subsystem child like winget.exe, powershell.exe or cmd.exe. Without
+// CREATE_NO_WINDOW, the kernel attaches a fresh console to the child because
+// the GUI-subsystem parent has none to inherit, which surfaces a "black box"
+// on the interactive user desktop. Augments any existing SysProcAttr instead
+// of replacing it.
+func hideWindow(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.HideWindow = true
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NO_WINDOW
+}

--- a/agent/internal/userhelper/spawn_windows_test.go
+++ b/agent/internal/userhelper/spawn_windows_test.go
@@ -1,0 +1,53 @@
+//go:build windows
+
+package userhelper
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestHideWindow_SetsFlagsOnNilSysProcAttr(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/c", "echo", "hello")
+	if cmd.SysProcAttr != nil {
+		t.Fatalf("precondition: SysProcAttr should be nil before hideWindow()")
+	}
+
+	hideWindow(cmd)
+
+	if cmd.SysProcAttr == nil {
+		t.Fatal("hideWindow did not allocate SysProcAttr")
+	}
+	if !cmd.SysProcAttr.HideWindow {
+		t.Error("HideWindow flag not set")
+	}
+	if cmd.SysProcAttr.CreationFlags&windows.CREATE_NO_WINDOW == 0 {
+		t.Errorf("CREATE_NO_WINDOW bit not set; CreationFlags=0x%x", cmd.SysProcAttr.CreationFlags)
+	}
+}
+
+func TestHideWindow_PreservesExistingCreationFlags(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/c", "echo", "hello")
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: 0x00000200} // CREATE_NEW_PROCESS_GROUP
+
+	hideWindow(cmd)
+
+	if cmd.SysProcAttr.CreationFlags&0x00000200 == 0 {
+		t.Error("hideWindow clobbered pre-existing CREATE_NEW_PROCESS_GROUP")
+	}
+	if cmd.SysProcAttr.CreationFlags&windows.CREATE_NO_WINDOW == 0 {
+		t.Error("CREATE_NO_WINDOW not OR'd in alongside existing flag")
+	}
+}
+
+func TestHideWindow_NilCmdDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("hideWindow(nil) panicked: %v", r)
+		}
+	}()
+	hideWindow(nil)
+}

--- a/apps/api/src/routes/devPush.ts
+++ b/apps/api/src/routes/devPush.ts
@@ -95,7 +95,7 @@ devPushRoutes.post('/push', bodyLimit({ maxSize: 150 * 1024 * 1024, onError: (c)
       : `dev-${Math.floor(Date.now() / 1000)}`;
   const file = body.binary;
 
-  const allowedComponents = ['agent', 'desktop-helper'] as const;
+  const allowedComponents = ['agent', 'desktop-helper', 'user-helper'] as const;
   type Component = (typeof allowedComponents)[number];
   const rawComponent = typeof body.component === 'string' ? body.component : 'agent';
   if (!allowedComponents.includes(rawComponent as Component)) {


### PR DESCRIPTION
## Summary

Suppress visible console window allocation when the GUI-subsystem `breeze-user-helper.exe` spawns console-subsystem children (winget.exe, powershell.exe, cmd.exe, arbitrary user-context binaries).

Fixes #754.

## What

Three Windows spawn sites in the user-helper / executor were using `osexec.Command(...).Start()` without `SysProcAttr`, so a GUI-subsystem parent + console child caused Windows to allocate a fresh console on the user's desktop on every spawn. Most visible trigger is the heartbeat-driven winget patch scan (~15-minute cycle).

Adds a per-package `hideWindow(*exec.Cmd)` helper (Windows: `HideWindow=true` + `CreationFlags |= windows.CREATE_NO_WINDOW`; no-op everywhere else) and calls it at the three spawn sites. Augments any existing `SysProcAttr` rather than replacing it.

Matches the convention already used in `sessionbroker/spawn_process_windows.go:79` and `sessionbroker/spawner_windows.go:138,209`.

The `apps/api/src/routes/devPush.ts` one-liner adds `user-helper` to `allowedComponents`. The agent already routes `component='user-helper'` correctly via `handleDevUpdateUserHelper`; the API was the gap.

## Test plan

- [x] `go vet ./internal/userhelper/... ./internal/executor/...` on darwin and `GOOS=windows GOARCH=amd64` — clean
- [x] Existing package tests pass (`CGO_ENABLED=0 go test ./internal/executor/... ./internal/userhelper/...`)
- [x] New Windows-only unit tests in this PR cover: nil-cmd safety, fresh `SysProcAttr` allocation, additive behavior when `CreationFlags` already has `CREATE_NEW_PROCESS_GROUP` set
- [x] Built `breeze-agent-windows-amd64.exe` + `breeze-user-helper-windows-amd64.exe` from this branch via `make build-windows`; `file` confirms expected PE subsystems
- [x] Deployed to a Windows 11 workstation with an interactive user session; polled `Get-Process winget` every 200ms during a `sendInventory()` cycle and captured 4 winget.exe spawns by `breeze-user-helper.exe` in session 1 — all `MainWindowHandle=0` (see issue #754 for the captured timestamps)
- [x] Rolled out to ~78 Windows endpoints in a production multi-MSP install via `dev-push` (one of the commits in this PR is the API allowlist that makes that possible); no crashes, no regressions in WebRTC remote desktop / screenshot / user-context script execution

## Notes

- `syscall.CREATE_NO_WINDOW` is not exported in Go's stdlib for Windows (`CREATE_NEW_PROCESS_GROUP` is, but not `CREATE_NO_WINDOW`); using `golang.org/x/sys/windows.CREATE_NO_WINDOW` to match the existing sessionbroker convention.
- Happy to split the API change into its own PR if preferred. The agent fix works without it (the user-helper binary can be replaced via MSI install/repair), but dev-push as the canary path needed it.
