### PR TITLE
fix(auth): let pending partners authenticate so billing redirect works (#718)

### DIFF
--- a/apps/api/src/__tests__/integration/tenantStatus.integration.test.ts
+++ b/apps/api/src/__tests__/integration/tenantStatus.integration.test.ts
@@ -151,6 +151,41 @@ describe('TenantInactive gate (assertActiveTenantContext)', () => {
       const body = await res.json();
       expect(body.ok).toBe(true);
     });
+
+    // Regression: PR #568 added assertActiveTenantContext to the partner
+    // session path, which started rejecting `pending` partners. That broke
+    // self-service signup — a pending partner (verified email, awaiting
+    // payment) could no longer authenticate, so they never reached the
+    // partnerGuard 403 PARTNER_INACTIVE → /account/inactive billing page.
+    // `pending` is a legitimate, session-allowed status; feature gating is
+    // done downstream by partnerGuard, NOT by the auth/token gate.
+    it('returns 200 when partner.status = pending (session-allowed; feature gating is downstream via partnerGuard)', async () => {
+      const partner = await createPartner({ status: 'pending' });
+      const token = await mintPartnerScopedToken(partner.id);
+      const app = buildAuthGatedApp();
+
+      const res = await app.request('/protected', {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+    });
+
+    // Guard: relaxing the gate to admit `pending` must NOT admit `churned`.
+    // churned/suspended/soft-deleted remain security-dead — the #568 win.
+    it('returns 403 when partner.status = churned', async () => {
+      const partner = await createPartner({ status: 'churned' });
+      const token = await mintPartnerScopedToken(partner.id);
+      const app = buildAuthGatedApp();
+
+      const res = await app.request('/protected', {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+
+      expect(res.status).toBe(403);
+    });
   });
 
   describe('org-scoped tokens', () => {

--- a/apps/api/src/services/tenantStatus.ts
+++ b/apps/api/src/services/tenantStatus.ts
@@ -26,6 +26,31 @@ export async function getActivePartner(partnerId: string): Promise<{ id: string 
   });
 }
 
+// Partner statuses allowed to hold an authenticated session. `pending`
+// is legitimate — a self-service signup that has verified email but not
+// yet completed payment. It MUST be able to authenticate so the
+// downstream partnerGuard (status !== 'active' → 403 PARTNER_INACTIVE)
+// can redirect it to the billing page. Feature gating is partnerGuard's
+// job, not the auth/token gate's. `suspended`/`churned`/soft-deleted
+// stay rejected — that is the SR-001..SR-024 (PR #568) mid-session
+// cutoff we keep. Deliberately distinct from getActivePartner (strictly
+// 'active'), which the org-cascade / API-key path relies on — do not
+// merge them.
+const PARTNER_SESSION_ALLOWED_STATUSES = new Set(['active', 'pending']);
+
+export async function getSessionAllowedPartner(partnerId: string): Promise<{ id: string } | null> {
+  return withSystemDbAccessContext(async () => {
+    const [partner] = await db
+      .select({ id: partners.id, status: partners.status, deletedAt: partners.deletedAt })
+      .from(partners)
+      .where(and(eq(partners.id, partnerId), isNull(partners.deletedAt)))
+      .limit(1);
+
+    if (!partner || !PARTNER_SESSION_ALLOWED_STATUSES.has(partner.status)) return null;
+    return { id: partner.id };
+  });
+}
+
 export async function getActiveOrgTenant(orgId: string): Promise<{ orgId: string; partnerId: string } | null> {
   return withSystemDbAccessContext(async () => {
     const [org] = await db
@@ -56,7 +81,9 @@ export async function assertActiveTenantContext(context: {
   if (context.scope === 'system') return;
 
   if (context.scope === 'partner') {
-    if (!context.partnerId || !(await getActivePartner(context.partnerId))) {
+    // Session gate, not feature gate: admit `pending` (partnerGuard
+    // handles the billing redirect). Strictly-dead tenants still rejected.
+    if (!context.partnerId || !(await getSessionAllowedPartner(context.partnerId))) {
       throw new TenantInactiveError('Partner is not active');
     }
     return;


### PR DESCRIPTION
## Summary

Production regression from PR #568 (SR-001..SR-024 hardening): `assertActiveTenantContext` was wired into the partner session path, and `getActivePartner` only admits `status='active'`. A `pending` partner — a self-service signup that verified email but hasn't completed payment — could no longer authenticate. `login.ts` caught `TenantInactiveError` and returned a generic 401, so the user never reached the `partnerGuard` 403 `PARTNER_INACTIVE` → `/account/inactive` billing page, and couldn't password-reset either.

**Net effect:** verified, would-be-paying signups silently trapped in a "wrong username/password" loop. Observed on EU prod — 3 partners (e.g. SSG Mozambique, MTV IT).

## Fix

Add `getSessionAllowedPartner` (status ∈ {active, pending}, not soft-deleted) and use it only for the partner-scope branch of `assertActiveTenantContext`. `getActivePartner` stays strictly `active` and untouched — the org-cascade / API-key path (`getActiveOrgTenant`, `apiKeyAuth`) is unchanged. `suspended`/`churned`/soft-deleted remain rejected everywhere, preserving the #568 mid-session cutoff. Password is verified before this gate, so the email-enumeration side channel #568 closed is **not** reintroduced.

## Test

TDD: failing integration test (pending → 200) + a churned → 403 guard added to `tenantStatus.integration.test.ts`. Verified locally: **11/11** `tenantStatus` integration tests green; API typecheck clean.

## Scope note

This is the isolated regression fix (commit cherry-picked from `fix/pending-partner-login-regression`, separated from unrelated #727/docs commits). The broader "surface payment-incomplete state + retry path" UX work remains tracked in #718; #719 (password-reset for inactive tenants) is largely resolved as a side effect and will be re-scoped after this deploys.

Closes nothing — leaving #718 open for the follow-up UX work and reporter verification.

Fixes the auth regression in #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)