### PR TITLE
fix(mobile): surface interrupted/thrown biometric auth on the approval consent action (#746)

### DIFF
--- a/apps/mobile/src/screens/approvals/authOutcome.test.ts
+++ b/apps/mobile/src/screens/approvals/authOutcome.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { classifyAuthFailure } from './authOutcome';
+
+describe('classifyAuthFailure', () => {
+  it('treats an explicit user cancel as a silent no-op', () => {
+    expect(classifyAuthFailure('user_cancel')).toEqual({
+      kind: 'silent',
+      message: null,
+    });
+  });
+
+  it('surfaces system_cancel as an actionable retry (interrupted, not silent)', () => {
+    const r = classifyAuthFailure('system_cancel');
+    expect(r.kind).toBe('interrupted');
+    expect(r.message).toBe('Confirmation was interrupted. Tap Approve to try again.');
+  });
+
+  it('surfaces app_cancel as an actionable retry (interrupted, not silent)', () => {
+    const r = classifyAuthFailure('app_cancel');
+    expect(r.kind).toBe('interrupted');
+    expect(r.message).toMatch(/try again/i);
+  });
+
+  it('reports biometric lockout with a passcode hint', () => {
+    for (const code of ['lockout', 'lockout_permanent']) {
+      const r = classifyAuthFailure(code);
+      expect(r.kind).toBe('lockout');
+      expect(r.message).toMatch(/locked/i);
+    }
+  });
+
+  it('falls back to a generic failure for unknown codes', () => {
+    const r = classifyAuthFailure('authentication_failed');
+    expect(r.kind).toBe('failed');
+    expect(r.message).toBe('Authentication failed. Try again.');
+  });
+
+  it('falls back to a generic failure when the code is undefined (thrown/native error)', () => {
+    const r = classifyAuthFailure(undefined);
+    expect(r.kind).toBe('failed');
+    expect(r.message).toBe('Authentication failed. Try again.');
+  });
+
+  it('never returns a null message except for the silent user_cancel case', () => {
+    const codes = ['system_cancel', 'app_cancel', 'lockout', 'lockout_permanent', 'weird', undefined];
+    for (const code of codes) {
+      expect(classifyAuthFailure(code).message).not.toBeNull();
+    }
+  });
+});

--- a/apps/mobile/src/screens/approvals/authOutcome.ts
+++ b/apps/mobile/src/screens/approvals/authOutcome.ts
@@ -1,0 +1,55 @@
+/**
+ * Classification of a failed biometric/passcode confirmation on the
+ * approval consent action (PR #696 / issue #746).
+ *
+ * Extracted as pure logic (no RN/Expo imports) so the mobile Vitest
+ * harness (node env, .test.ts files only) can cover it, same pattern as
+ * decisionTarget.ts. The component owns flow (passcode fallback, success);
+ * this module owns "what, if anything, do we tell the user when auth did
+ * not succeed".
+ */
+
+export type AuthFailureKind = 'silent' | 'interrupted' | 'lockout' | 'failed';
+
+export interface AuthFailureClassification {
+  kind: AuthFailureKind;
+  /** User-facing message. `null` means show nothing (justified no-op). */
+  message: string | null;
+}
+
+// Only an explicit user-initiated cancel (tapped Cancel / dismissed the
+// sheet) is a justified silent no-op — the user chose not to proceed.
+const SILENT_CANCEL_CODE = 'user_cancel';
+
+// system_cancel / app_cancel fire when the OS or app interrupts the
+// prompt — backgrounding, or a SECOND push notification arriving
+// mid-confirmation (exactly the race class PR #745 addresses). The
+// consent attempt was silently dropped; the user may believe they
+// approved. This MUST surface with an actionable retry, not be swallowed.
+const INTERRUPTED_CODES = new Set(['system_cancel', 'app_cancel']);
+
+const LOCKOUT_CODES = new Set(['lockout', 'lockout_permanent']);
+
+/**
+ * Map an `expo-local-authentication` failure `error` code to what the
+ * user should see. `code` is `result.error` from a non-success
+ * LocalAuthenticationResult (may be undefined).
+ */
+export function classifyAuthFailure(code: string | undefined): AuthFailureClassification {
+  if (code === SILENT_CANCEL_CODE) {
+    return { kind: 'silent', message: null };
+  }
+  if (code && INTERRUPTED_CODES.has(code)) {
+    return {
+      kind: 'interrupted',
+      message: 'Confirmation was interrupted. Tap Approve to try again.',
+    };
+  }
+  if (code && LOCKOUT_CODES.has(code)) {
+    return {
+      kind: 'lockout',
+      message: 'Biometrics locked. Use device passcode in Settings to unlock.',
+    };
+  }
+  return { kind: 'failed', message: 'Authentication failed. Try again.' };
+}

--- a/apps/mobile/src/screens/approvals/components/ApprovalButtons.tsx
+++ b/apps/mobile/src/screens/approvals/components/ApprovalButtons.tsx
@@ -6,6 +6,7 @@ import { haptic } from '../../../lib/motion';
 import { HoldToConfirm } from './HoldToConfirm';
 import { DenyReasonSheet } from './DenyReasonSheet';
 import { captureRequestId, type CapturedRequestId } from '../decisionTarget';
+import { classifyAuthFailure } from '../authOutcome';
 
 interface Props {
   // The approval the user is looking at right now (live prop). We snapshot
@@ -21,8 +22,6 @@ interface Props {
   onDeny: (requestId: CapturedRequestId, reason?: string) => void;
 }
 
-const SILENT_CANCEL_CODES = new Set(['user_cancel', 'system_cancel', 'app_cancel']);
-const LOCKOUT_CODES = new Set(['lockout', 'lockout_permanent']);
 const PASSCODE_FALLBACK_CODES = new Set(['not_enrolled', 'passcode_not_set']);
 
 export function ApprovalButtons({ requestId, isRecursive, inFlight, onApprove, onDeny }: Props) {
@@ -59,41 +58,49 @@ export function ApprovalButtons({ requestId, isRecursive, inFlight, onApprove, o
       enrolled = false;
     }
 
-    if (!hasHw || !enrolled) {
-      const r = await authenticateWithPasscode();
+    // authenticateAsync / authenticateWithPasscode can REJECT (another
+    // auth already in progress, Android activity-not-found, native module
+    // error) — not just resolve {success:false}. Unguarded, that rejection
+    // escapes as an unhandled promise rejection: no onApprove, no message.
+    // The user taps Approve on a consent action and nothing happens with
+    // zero feedback (#746 Issue 1). Catch it and surface a failure.
+    try {
+      if (!hasHw || !enrolled) {
+        const r = await authenticateWithPasscode();
+        if (r.success) { onApprove(target); return; }
+        handleAuthFailure(r);
+        return;
+      }
+
+      const r = await LocalAuthentication.authenticateAsync({
+        promptMessage: 'Approve this request',
+        cancelLabel: 'Cancel',
+        disableDeviceFallback: false,
+      });
       if (r.success) { onApprove(target); return; }
+
+      const code = (r as { error?: string }).error;
+      if (code && PASSCODE_FALLBACK_CODES.has(code)) {
+        const fallback = await authenticateWithPasscode();
+        if (fallback.success) { onApprove(target); return; }
+        handleAuthFailure(fallback);
+        return;
+      }
       handleAuthFailure(r);
-      return;
+    } catch (err) {
+      console.warn('[ApprovalButtons] biometric auth threw', err);
+      setAuthMessage('Authentication failed. Try again.');
     }
-
-    const r = await LocalAuthentication.authenticateAsync({
-      promptMessage: 'Approve this request',
-      cancelLabel: 'Cancel',
-      disableDeviceFallback: false,
-    });
-    if (r.success) { onApprove(target); return; }
-
-    const code = (r as { error?: string }).error;
-    if (code && PASSCODE_FALLBACK_CODES.has(code)) {
-      const fallback = await authenticateWithPasscode();
-      if (fallback.success) { onApprove(target); return; }
-      handleAuthFailure(fallback);
-      return;
-    }
-    handleAuthFailure(r);
   }
 
   function handleAuthFailure(result: LocalAuthentication.LocalAuthenticationResult) {
-    const code = (result as { error?: string }).error;
-    if (code && SILENT_CANCEL_CODES.has(code)) {
-      setAuthMessage(null);
-      return;
-    }
-    if (code && LOCKOUT_CODES.has(code)) {
-      setAuthMessage('Biometrics locked. Use device passcode in Settings to unlock.');
-      return;
-    }
-    setAuthMessage('Authentication failed. Try again.');
+    // Only user_cancel is a justified silent no-op. system_cancel /
+    // app_cancel (OS/app interrupted the prompt — e.g. a second push
+    // mid-confirmation) now surface an actionable retry instead of being
+    // swallowed (#746 Issue 2). Classification is unit-tested in
+    // authOutcome.test.ts.
+    const { message } = classifyAuthFailure((result as { error?: string }).error);
+    setAuthMessage(message);
   }
 
   return (


### PR DESCRIPTION
## Summary

Fixes the two pre-existing silent failures in `apps/mobile/src/screens/approvals/components/ApprovalButtons.tsx` reported in #746. Both were introduced with the mobile approval surface in #611 and surfaced by the #745 silent-failure-hunter review. They sit on a **security-critical consent action** — the user can tap Approve and have nothing happen with zero feedback.

### Issue 1 (HIGH) — unguarded `authenticateAsync`
Only the hardware probe (`hasHardwareAsync`/`isEnrolledAsync`) was wrapped in try/catch. The actual auth calls can **reject** (another auth in progress, Android activity-not-found, native module error), not just resolve `{success:false}`. The rejection escaped as an unhandled promise rejection — no `onApprove`, no `handleAuthFailure`, no message. The whole auth flow is now wrapped; the catch routes through `setAuthMessage('Authentication failed. Try again.')` + `console.warn`.

### Issue 2 (MEDIUM) — `system_cancel`/`app_cancel` swallowed
`SILENT_CANCEL_CODES` silenced `system_cancel`/`app_cancel` alongside `user_cancel`. The former fire when the OS/app interrupts the prompt (e.g. a second push arriving mid-confirmation — the race class #745 addresses); the attempt was dropped silently and the user may believe they approved. Now only `user_cancel` is a silent no-op; `system_cancel`/`app_cancel` surface an actionable retry ("Confirmation was interrupted. Tap Approve to try again.").

## Design

Cancel-code classification extracted to `authOutcome.ts` — pure logic, no RN/Expo imports, same pattern as `decisionTarget.ts` — so the mobile Vitest harness (node env, `.test.ts` only) can cover it.

## Test

`authOutcome.test.ts`: 7 cases incl. the silent-vs-interrupted distinction, lockout, and the undefined-code (thrown/native) path. **11/11** approvals tests green (7 new + 4 existing `decisionTarget`).

Leaving #746 open for reporter/owner verification on-device.

Refs #745 #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)