### PR TITLE
fix(api): cascade devices.org_id to device-child tables on org move (#750)

### DIFF
--- a/apps/api/migrations/2026-05-18-device-child-orgid-cascade.sql
+++ b/apps/api/migrations/2026-05-18-device-child-orgid-cascade.sql
@@ -1,0 +1,109 @@
+-- Issue #750: device-child tables denormalize devices.org_id for the RLS
+-- hot path. Nothing kept that copy in sync when a device moved orgs, so
+-- child rows kept a stale org_id. On the agent inventory upserts
+-- (device_hardware, device_patches, device_registry_state,
+-- device_config_state, security_status — their ON CONFLICT ... DO UPDATE
+-- set-blocks don't refresh org_id) the UPDATE policy's USING expression
+-- (breeze_has_org_access(org_id)) is evaluated against the *existing*
+-- stale row under the agent's now-current-org scope, returns FALSE, and
+-- the write fails: "new row violates row-level security policy (USING
+-- expression)" — ~144/hr on a live fleet, silently dropping inventory.
+--
+-- The drift had no single app entrypoint (there is no first-class
+-- "move device to org" handler; it came from ops/direct SQL), so an
+-- app-layer cascade alone could be bypassed. Fix it at the DB layer so
+-- it holds regardless of which path mutates devices.org_id:
+--
+--   1. A SECURITY DEFINER trigger on devices (AFTER UPDATE OF org_id)
+--      that cascades the new org_id to every device-child table,
+--      discovered dynamically so a newly-added denormalized table can't
+--      silently reintroduce the drift.
+--   2. A one-time backfill realigning all existing drift across every
+--      device-child table (the prod hotfix only repaired the 2 hot
+--      tables; the other ~9 were latent read-time RLS bombs).
+--
+-- Idempotent: CREATE OR REPLACE / DROP TRIGGER IF EXISTS; the backfill
+-- only touches mismatched rows, so re-applying is a no-op.
+
+-- Shared discovery: ordinary public tables (not devices itself) that
+-- carry BOTH a uuid device_id and a uuid org_id column. uuid-typed guard
+-- avoids touching any unrelated column that happens to share a name.
+CREATE OR REPLACE FUNCTION public.breeze_device_child_orgid_tables()
+  RETURNS SETOF text
+  LANGUAGE sql
+  STABLE
+  AS $$
+  SELECT t.relname::text
+  FROM pg_class t
+  JOIN pg_namespace n ON n.oid = t.relnamespace
+  WHERE n.nspname = 'public'
+    AND t.relkind = 'r'
+    AND t.relname <> 'devices'
+    AND EXISTS (
+      SELECT 1 FROM pg_attribute a
+      WHERE a.attrelid = t.oid AND a.attname = 'device_id'
+        AND NOT a.attisdropped AND a.atttypid = 'uuid'::regtype
+    )
+    AND EXISTS (
+      SELECT 1 FROM pg_attribute a
+      WHERE a.attrelid = t.oid AND a.attname = 'org_id'
+        AND NOT a.attisdropped AND a.atttypid = 'uuid'::regtype
+    );
+$$;
+
+-- Trigger function. SECURITY DEFINER so the cascade runs with the
+-- migration/owner role's privileges and is not itself blocked by the
+-- child tables' org RLS (the same privilege the one-time backfill below
+-- relies on). search_path pinned for SECURITY DEFINER safety; every
+-- table reference is schema-qualified regardless.
+CREATE OR REPLACE FUNCTION public.breeze_cascade_device_org_id()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public, pg_catalog
+  AS $$
+DECLARE
+  child_table text;
+BEGIN
+  FOR child_table IN SELECT public.breeze_device_child_orgid_tables() LOOP
+    EXECUTE format(
+      'UPDATE public.%I SET org_id = $1 WHERE device_id = $2 AND org_id IS DISTINCT FROM $1',
+      child_table
+    ) USING NEW.org_id, NEW.id;
+  END LOOP;
+  RETURN NULL; -- AFTER trigger; return value ignored
+END;
+$$;
+
+DROP TRIGGER IF EXISTS breeze_cascade_device_org_id ON public.devices;
+CREATE TRIGGER breeze_cascade_device_org_id
+  AFTER UPDATE OF org_id ON public.devices
+  FOR EACH ROW
+  WHEN (NEW.org_id IS DISTINCT FROM OLD.org_id)
+  EXECUTE FUNCTION public.breeze_cascade_device_org_id();
+
+-- One-time backfill: realign every existing drifted device-child row to
+-- its device's current org. Runs as the migration role (RLS-exempt),
+-- covering ALL device-child tables, not just the two that error at
+-- ingest. Idempotent (only mismatched rows are touched).
+DO $$
+DECLARE
+  child_table text;
+  fixed bigint;
+  total bigint := 0;
+BEGIN
+  FOR child_table IN SELECT public.breeze_device_child_orgid_tables() LOOP
+    EXECUTE format(
+      'UPDATE public.%I AS c SET org_id = d.org_id FROM public.devices d '
+      'WHERE c.device_id = d.id AND c.org_id IS DISTINCT FROM d.org_id',
+      child_table
+    );
+    GET DIAGNOSTICS fixed = ROW_COUNT;
+    IF fixed > 0 THEN
+      RAISE NOTICE 'device-child org_id backfill: % rows realigned in %', fixed, child_table;
+      total := total + fixed;
+    END IF;
+  END LOOP;
+  RAISE NOTICE 'device-child org_id backfill complete: % rows realigned total', total;
+END;
+$$;

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -328,6 +328,83 @@ describe('RLS coverage contract', () => {
     expect(rows[0]?.definition).toContain('REFERENCES organizations(id, partner_id)');
   });
 
+  // Issue #750: device-child tables denormalize devices.org_id for the
+  // RLS hot path. If that copy is not kept in sync on an org move, the
+  // stale child row fails the UPDATE policy's USING expression on the
+  // agent inventory upserts. The 2026-05-18 migration installs a
+  // SECURITY DEFINER cascade trigger on devices + a backfill. Guard both
+  // the structural invariant (trigger present, definer-rights, covers
+  // every device-child table) and the data invariant (zero drift).
+  it('device.org_id changes cascade to every device-child table (no stale org_id drift) [#750]', async () => {
+    const trigger = (await db.execute(sql`
+      SELECT
+        t.tgname,
+        t.tgenabled,
+        p.prosecdef,
+        pg_get_triggerdef(t.oid) AS def
+      FROM pg_trigger t
+      JOIN pg_class c ON c.oid = t.tgrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      JOIN pg_proc p ON p.oid = t.tgfoid
+      WHERE n.nspname = 'public'
+        AND c.relname = 'devices'
+        AND t.tgname = 'breeze_cascade_device_org_id'
+        AND NOT t.tgisinternal;
+    `)) as unknown as Array<{
+      tgname: string;
+      tgenabled: string;
+      prosecdef: boolean;
+      def: string;
+    }>;
+
+    expect(
+      trigger,
+      'Missing breeze_cascade_device_org_id trigger on devices — org moves will leave stale org_id on device-child tables and break agent inventory upserts (#750). Re-apply migration 2026-05-18-device-child-orgid-cascade.sql.'
+    ).toHaveLength(1);
+    // SECURITY DEFINER: the cascade must run RLS-exempt or it cannot
+    // rewrite the stale child rows it exists to fix.
+    expect(trigger[0]?.prosecdef).toBe(true);
+    // Enabled in "origin/local" mode (fires on normal writes), not disabled.
+    expect(trigger[0]?.tgenabled).toBe('O');
+    expect(trigger[0]?.def).toContain('UPDATE OF org_id');
+    expect(trigger[0]?.def).toContain('FOR EACH ROW');
+
+    // The discovery helper must resolve every table that denormalizes a
+    // uuid org_id alongside a uuid device_id — that is exactly the set
+    // the cascade and backfill iterate. A new such table is auto-covered.
+    const discovered = (await db.execute(sql`
+      SELECT count(*)::int AS n FROM public.breeze_device_child_orgid_tables();
+    `)) as unknown as Array<{ n: number }>;
+    expect(discovered[0]?.n ?? 0).toBeGreaterThan(0);
+
+    // Data invariant: no device-child row may carry an org_id that
+    // disagrees with its device. Read under system scope so RLS doesn't
+    // hide cross-org rows from the audit.
+    const drift = await withSystemDbAccessContext(async () => {
+      const tables = (await db.execute(sql`
+        SELECT public.breeze_device_child_orgid_tables() AS t;
+      `)) as unknown as Array<{ t: string }>;
+
+      const offenders: Array<{ table_name: string; n: number }> = [];
+      for (const { t } of tables) {
+        const [row] = (await db.execute(sql`
+          SELECT count(*)::int AS n
+          FROM ${sql.identifier(t)} c
+          JOIN public.devices d ON d.id = c.device_id
+          WHERE c.org_id IS DISTINCT FROM d.org_id;
+        `)) as unknown as Array<{ n: number }>;
+        const n = row?.n ?? 0;
+        if (n > 0) offenders.push({ table_name: t, n });
+      }
+      return offenders;
+    });
+
+    expect(
+      drift,
+      `device-child tables with org_id drift vs devices.org_id (#750 regression — cascade trigger not keeping these in sync):\n${JSON.stringify(drift, null, 2)}`
+    ).toEqual([]);
+  });
+
   it('every org-tenant public table has RLS on and all four DML commands covered by breeze_has_org_access', async () => {
     const idKeyedList = Array.from(ORG_ID_KEYED_TENANT_TABLES);
 


### PR DESCRIPTION
## Summary

Fixes #750. device-child tables denormalize `devices.org_id` for the RLS hot path; nothing kept that copy in sync on an org move. On the agent inventory upserts (`device_hardware`, `device_patches`, `device_registry_state`, `device_config_state`, `security_status` — their `ON CONFLICT DO UPDATE` set-blocks don't refresh `org_id`), the UPDATE policy's `USING breeze_has_org_access(org_id)` is evaluated against the **existing stale row** under the agent's now-current-org scope, returns FALSE, and the write fails — ~144/hr on a live fleet, silently dropping inventory.

Root cause per @bdunncompany's **amended** analysis on the issue (the original "agent path not wrapped in `withDbAccessContext`" reading was a dead end — the agent path *is* org-scoped). The empirical sweep found drift in 11 device-child tables; the 2 upsert-on-conflict tables actively error, the other ~9 are latent read-time RLS bombs.

## Approach — DB-layer cascade (chosen option 1, made bypass-proof)

There is no first-class "move device to org" handler — the drift originated from ops/direct SQL, which an app-layer cascade can't intercept. Fixing it at the DB layer holds regardless of mutation path:

- **`breeze_device_child_orgid_tables()`** — dynamic discovery of public tables carrying **both** a uuid `device_id` and uuid `org_id` (70 today). New denormalized tables are auto-covered, so the drift can't silently come back (the contributor's explicit ask).
- **`breeze_cascade_device_org_id()`** — `SECURITY DEFINER` trigger, `AFTER UPDATE OF org_id ON devices`, `WHEN (NEW.org_id IS DISTINCT FROM OLD.org_id)`, cascading the new `org_id` to every discovered child table. DEFINER rights so the cascade itself isn't blocked by the child org RLS.
- **One-time idempotent backfill** realigning **all** existing drift across every device-child table (the prod hotfix only repaired the 2 hot tables; this clears the ~9 latent ones too).

Option 2 (softening the UPDATE USING) was *not* taken — it changes the security model and belongs in a Discussion, per the issue.

## Idempotency / safety

`CREATE OR REPLACE` / `DROP TRIGGER IF EXISTS`; backfill only touches mismatched rows — re-apply is a no-op. No inner `BEGIN`/`COMMIT` (autoMigrate wraps each file). Migration filename sorts after the latest 2026-05-16 migration; no same-day dependency.

## Verification

- Local: trigger cascades `device_hardware` correctly on a simulated org move (rolled-back txn); re-applying the migration is a clean no-op; 70 tables discovered.
- New **rls-coverage contract invariant** (`#750`): trigger exists on `devices`, is SECURITY DEFINER, fires on `UPDATE OF org_id`, discovery helper resolves >0 tables, and **zero** device-child `org_id` drift. Confirmed the test **fails with the trigger dropped** (real regression guard).
- `pnpm test:rls-coverage` 17/17 green; `autoMigrate.test.ts` 27/27 green (ordering).

## Production note

The contributor already hotfixed prod by realigning `device_hardware`/`device_patches` under system scope (error rate → 0). This migration's backfill is a superset (all ~11 drifted tables) and is idempotent, so it safely re-converges any remaining drift on deploy. The 5 inventory upsert `set`-blocks still omit `org_id` (a separate write-site inconsistency) — moot for correctness now the trigger keeps child rows aligned, noted on the issue as optional defense-in-depth.

Leaving #750 open for reporter verification on the live fleet after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)