### PR TITLE
feat(api): keyset cursor pagination for GET /devices (#742 PR 3 — server)

### DIFF
--- a/apps/api/migrations/2026-05-19-devices-cursor-keyset-indexes.sql
+++ b/apps/api/migrations/2026-05-19-devices-cursor-keyset-indexes.sql
@@ -1,0 +1,19 @@
+-- Covering indexes for keyset pagination on GET /devices (Discussion #742 PR 3).
+-- One index per whitelisted sort column, each carrying the `id` tiebreaker so
+-- the keyset ORDER BY can be satisfied by an index-scan-backward with no sort
+-- node. `IS NULL` partial dimension is omitted intentionally — keyset queries
+-- with `ORDER BY last_seen_at DESC NULLS LAST, id DESC` use this index for the
+-- non-NULL phase, and Postgres handles the NULL tail via a sequential scan of
+-- the small NULL slice (a partial index here would not be a meaningful win
+-- under any realistic NULL ratio and adds maintenance cost on every UPSERT).
+--
+-- Idempotent. No inner BEGIN/COMMIT (autoMigrate wraps each file in a tx).
+
+CREATE INDEX IF NOT EXISTS devices_hostname_id_idx
+  ON devices (hostname, id);
+
+CREATE INDEX IF NOT EXISTS devices_last_seen_at_id_idx
+  ON devices (last_seen_at, id);
+
+CREATE INDEX IF NOT EXISTS devices_enrolled_at_id_idx
+  ON devices (enrolled_at, id);

--- a/apps/api/src/__tests__/integration/devicesCursorRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/devicesCursorRls.integration.test.ts
@@ -22,8 +22,9 @@
 import './setup';
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { sql, and, eq } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
 import { getTestDb } from './setup';
+import { db, withDbAccessContext } from '../../db';
 import { devices } from '../../db/schema';
 import { createPartner, createOrganization, createSite } from './db-utils';
 import {
@@ -64,17 +65,22 @@ async function insertDevice(opts: {
   return row.id;
 }
 
-/** Pin a partner-scope context for the next query on the same connection.
- *  Mirrors `withDbAccessContext({scope: 'organization', orgId: ...})` for
- *  a single org's row visibility under RLS, scoped to a transaction so
- *  the SET LOCAL is bounded. */
+/** Pin an organization-scope DB context using the same path production
+ *  request handlers use. Queries inside `fn` issued against the exported
+ *  `db` proxy resolve to the transaction with the GUCs set, running as
+ *  the unprivileged `breeze_app` role — i.e. RLS is genuinely enforced.
+ *  `getTestDb()` (superuser) is used for SETUP only. */
 async function withOrgScope<T>(orgId: string, fn: () => Promise<T>): Promise<T> {
-  const db = getTestDb();
-  return db.transaction(async (tx: any) => {
-    await tx.execute(sql`SELECT set_config('breeze.scope', 'organization', true)`);
-    await tx.execute(sql`SELECT set_config('breeze.accessible_org_ids', ${orgId}, true)`);
-    return fn();
-  });
+  return withDbAccessContext(
+    {
+      scope: 'organization',
+      orgId,
+      accessibleOrgIds: [orgId],
+      accessiblePartnerIds: null,
+      userId: null,
+    },
+    fn,
+  );
 }
 
 describe('GET /devices cursor pagination — RLS isolation', () => {
@@ -130,7 +136,9 @@ describe('GET /devices cursor pagination — RLS isolation', () => {
       const result = await withOrgScope(allowedOrg, async () => {
         const orderBy = buildOrderBy('hostname', 'asc');
         const where = cursor ? buildKeysetPredicate(cursor) : undefined;
-        const rows = await getTestDb()
+        // `db` is the RLS-enforcing proxy; inside withDbAccessContext it
+        // routes queries to the tx with the GUCs set as breeze_app.
+        return db
           .select({
             id: devices.id,
             hostname: devices.hostname,
@@ -142,7 +150,6 @@ describe('GET /devices cursor pagination — RLS isolation', () => {
           .where(where)
           .orderBy(...orderBy)
           .limit(limit + 1);
-        return rows;
       });
 
       const page = result.slice(0, limit);
@@ -183,7 +190,7 @@ describe('GET /devices cursor pagination — RLS isolation', () => {
     await insertDevice({ orgId: foreignOrg, siteId: foreignSite, hostname: 'f4' });
 
     const total = await withOrgScope(allowedOrg, async () => {
-      const r = await getTestDb()
+      const r = await db
         .select({ count: sql<number>`count(*)` })
         .from(devices);
       return Number(r[0]?.count ?? 0);
@@ -223,7 +230,7 @@ describe('GET /devices cursor pagination — RLS isolation', () => {
 
     const rows = await withOrgScope(allowedOrg, async () => {
       const orderBy = buildOrderBy('hostname', 'asc');
-      return getTestDb()
+      return db
         .select({
           id: devices.id,
           orgId: devices.orgId,
@@ -237,7 +244,7 @@ describe('GET /devices cursor pagination — RLS isolation', () => {
 
     // Only the allowed row appears, not the foreign one whose id was
     // used in the cursor.
-    expect(rows.map((r: any) => r.id)).toEqual([allowedId]);
+    expect(rows.map((r) => r.id)).toEqual([allowedId]);
     expect(rows[0]?.orgId).toBe(allowedOrg);
   });
 });

--- a/apps/api/src/__tests__/integration/devicesCursorRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/devicesCursorRls.integration.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Devices cursor pagination — partner-scope RLS isolation (Discussion #742 PR 3).
+ *
+ * Todd's design point #3 plus the repo-shape constraint: every page the
+ * cursor returns AND the `includeTotal` count must stay inside
+ * `breeze_has_org_access`. This test forges a partner scope that owns a
+ * subset of orgs, plants devices in BOTH accessible AND inaccessible
+ * orgs, walks the cursor across the full set, and asserts no foreign-org
+ * row ever appears — same for the total count.
+ *
+ * Why integration, not unit: the keyset predicate is built in TS but the
+ * monotonicity guarantee depends on the Postgres tuple-comparison
+ * semantics + the actual RLS USING expression applied to the row. A
+ * Drizzle mock would happily return rows the live policy denies.
+ *
+ * Prerequisites:
+ *   docker compose -f docker-compose.test.yml up -d
+ *
+ * Run:
+ *   pnpm test:integration -- src/__tests__/integration/devicesCursorRls.integration.test.ts
+ */
+import './setup';
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { sql, and, eq } from 'drizzle-orm';
+import { getTestDb } from './setup';
+import { devices } from '../../db/schema';
+import { createPartner, createOrganization, createSite } from './db-utils';
+import {
+  buildKeysetPredicate,
+  buildOrderBy,
+  cursorFromRow,
+  decodeCursor,
+  encodeCursor,
+  type DevicesCursor,
+} from '../../routes/devices/cursor';
+
+let agentIdCounter = 0;
+async function insertDevice(opts: {
+  orgId: string;
+  siteId: string;
+  hostname: string;
+}): Promise<string> {
+  const db = getTestDb();
+  agentIdCounter++;
+  const [row] = await db
+    .insert(devices)
+    .values({
+      orgId: opts.orgId,
+      siteId: opts.siteId,
+      agentId: `agent-cursor-${agentIdCounter}-${Date.now()}`,
+      hostname: opts.hostname,
+      displayName: opts.hostname,
+      osType: 'windows',
+      osVersion: '11',
+      osBuild: '22000',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'online',
+      enrolledAt: new Date(),
+    })
+    .returning({ id: devices.id });
+  if (!row) throw new Error('insertDevice: insert returned no row');
+  return row.id;
+}
+
+/** Pin a partner-scope context for the next query on the same connection.
+ *  Mirrors `withDbAccessContext({scope: 'organization', orgId: ...})` for
+ *  a single org's row visibility under RLS, scoped to a transaction so
+ *  the SET LOCAL is bounded. */
+async function withOrgScope<T>(orgId: string, fn: () => Promise<T>): Promise<T> {
+  const db = getTestDb();
+  return db.transaction(async (tx: any) => {
+    await tx.execute(sql`SELECT set_config('breeze.scope', 'organization', true)`);
+    await tx.execute(sql`SELECT set_config('breeze.accessible_org_ids', ${orgId}, true)`);
+    return fn();
+  });
+}
+
+describe('GET /devices cursor pagination — RLS isolation', () => {
+  let allowedOrg: string;
+  let allowedSite: string;
+  let foreignOrg: string;
+  let foreignSite: string;
+
+  beforeEach(async () => {
+    // Two distinct partners ⇒ two distinct orgs that are not
+    // partner-accessible to each other. We'll force-set the auth
+    // context to scope = the allowed org and walk the cursor.
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const orgA = await createOrganization({ partnerId: partnerA.id });
+    const orgB = await createOrganization({ partnerId: partnerB.id });
+    allowedOrg = orgA.id;
+    foreignOrg = orgB.id;
+    const siteA = await createSite({ orgId: allowedOrg });
+    const siteB = await createSite({ orgId: foreignOrg });
+    allowedSite = siteA.id;
+    foreignSite = siteB.id;
+  });
+
+  it('cursor walk under partner-scope returns only accessible-org rows, even when intermixed with foreign rows', async () => {
+    // Insert in interleaved hostname order so a naive non-RLS query
+    // would surface foreign rows between every allowed row.
+    const hostnames = ['aaa-01', 'bbb-02', 'ccc-03', 'ddd-04', 'eee-05', 'fff-06'];
+    const allowedIds: string[] = [];
+    const foreignIds: string[] = [];
+    for (let i = 0; i < hostnames.length; i++) {
+      const host = hostnames[i]!;
+      if (i % 2 === 0) {
+        allowedIds.push(
+          await insertDevice({ orgId: allowedOrg, siteId: allowedSite, hostname: host }),
+        );
+      } else {
+        foreignIds.push(
+          await insertDevice({ orgId: foreignOrg, siteId: foreignSite, hostname: host }),
+        );
+      }
+    }
+
+    // Walk the cursor end-to-end with limit=2 so we have to issue at
+    // least two cursor steps. Should return exactly the 3 allowed
+    // devices in hostname-ASC order, never a foreign one, and end with
+    // nextCursor=null.
+    const collected: { id: string; hostname: string }[] = [];
+    let cursor: DevicesCursor | null = null;
+    const limit = 2;
+
+    for (let step = 0; step < 10; step++) {
+      const result = await withOrgScope(allowedOrg, async () => {
+        const orderBy = buildOrderBy('hostname', 'asc');
+        const where = cursor ? buildKeysetPredicate(cursor) : undefined;
+        const rows = await getTestDb()
+          .select({
+            id: devices.id,
+            hostname: devices.hostname,
+            lastSeenAt: devices.lastSeenAt,
+            enrolledAt: devices.enrolledAt,
+            orgId: devices.orgId,
+          })
+          .from(devices)
+          .where(where)
+          .orderBy(...orderBy)
+          .limit(limit + 1);
+        return rows;
+      });
+
+      const page = result.slice(0, limit);
+      for (const r of page) {
+        // Hard assertion: not a foreign device under any condition.
+        expect(foreignIds).not.toContain(r.id);
+        expect(r.orgId).toBe(allowedOrg);
+        collected.push({ id: r.id, hostname: r.hostname });
+      }
+
+      if (result.length <= limit) {
+        cursor = null;
+        break;
+      }
+      const lastReturned = page[page.length - 1]!;
+      cursor = decodeCursor(encodeCursor(cursorFromRow(lastReturned, 'hostname', 'asc')));
+      expect(cursor).not.toBeNull();
+    }
+
+    // Walked all 3 allowed rows in hostname order, no duplicates, no
+    // foreign rows.
+    expect(collected).toEqual(
+      allowedIds.map((id, i) => ({ id, hostname: hostnames[i * 2]! })),
+    );
+    // Walk terminated cleanly.
+    expect(cursor).toBeNull();
+  });
+
+  it('includeTotal count under partner-scope reflects only accessible-org rows', async () => {
+    // 3 allowed + 4 foreign. The count(*) under partner-scope must
+    // return 3, never 7.
+    await insertDevice({ orgId: allowedOrg, siteId: allowedSite, hostname: 'a1' });
+    await insertDevice({ orgId: allowedOrg, siteId: allowedSite, hostname: 'a2' });
+    await insertDevice({ orgId: allowedOrg, siteId: allowedSite, hostname: 'a3' });
+    await insertDevice({ orgId: foreignOrg, siteId: foreignSite, hostname: 'f1' });
+    await insertDevice({ orgId: foreignOrg, siteId: foreignSite, hostname: 'f2' });
+    await insertDevice({ orgId: foreignOrg, siteId: foreignSite, hostname: 'f3' });
+    await insertDevice({ orgId: foreignOrg, siteId: foreignSite, hostname: 'f4' });
+
+    const total = await withOrgScope(allowedOrg, async () => {
+      const r = await getTestDb()
+        .select({ count: sql<number>`count(*)` })
+        .from(devices);
+      return Number(r[0]?.count ?? 0);
+    });
+    expect(total).toBe(3);
+  });
+
+  it('forged cross-org cursor (id of a foreign device) does NOT leak the foreign row', async () => {
+    // Plant one allowed + one foreign with hostnames such that the
+    // foreign hostname is lexicographically EARLIER than the allowed
+    // one. A naive non-RLS cursor walk seeded with the foreign row's
+    // {hostname, id} would return the allowed row as "after" it. With
+    // RLS in effect, the partner-scope context never sees the foreign
+    // row to begin with — and a forged cursor that carries a foreign id
+    // still cannot pull foreign data through, because the RLS USING
+    // applies to every selected row.
+    const allowedId = await insertDevice({
+      orgId: allowedOrg,
+      siteId: allowedSite,
+      hostname: 'zeta-allowed',
+    });
+    const foreignId = await insertDevice({
+      orgId: foreignOrg,
+      siteId: foreignSite,
+      hostname: 'alpha-foreign', // lexicographically first
+    });
+
+    // Forge a cursor as if the previous page ended on the foreign row
+    // (an attacker scenario or a stale-cursor scenario).
+    const forged: DevicesCursor = {
+      v: 1,
+      sort: 'hostname',
+      sortDir: 'asc',
+      k: 'alpha-foreign',
+      id: foreignId,
+    };
+
+    const rows = await withOrgScope(allowedOrg, async () => {
+      const orderBy = buildOrderBy('hostname', 'asc');
+      return getTestDb()
+        .select({
+          id: devices.id,
+          orgId: devices.orgId,
+          hostname: devices.hostname,
+        })
+        .from(devices)
+        .where(buildKeysetPredicate(forged))
+        .orderBy(...orderBy)
+        .limit(10);
+    });
+
+    // Only the allowed row appears, not the foreign one whose id was
+    // used in the cursor.
+    expect(rows.map((r: any) => r.id)).toEqual([allowedId]);
+    expect(rows[0]?.orgId).toBe(allowedOrg);
+  });
+});

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { and, eq, gte, like, sql, desc } from 'drizzle-orm';
+import { and, eq, gte, like, sql, desc, inArray, type SQL } from 'drizzle-orm';
 import { db, withSystemDbAccessContext } from '../../db';
 import { createHash, randomBytes } from 'crypto';
 import {
@@ -19,6 +19,18 @@ import { authMiddleware, requireMfa, requireScope, requirePermission } from '../
 import { PERMISSIONS } from '../../services/permissions';
 import { getPagination, getDeviceWithOrgCheck } from './helpers';
 import { listDevicesSchema, updateDeviceSchema } from './schemas';
+import {
+  DEVICES_LIST_DEFAULT_LIMIT,
+  DEVICES_LIST_HARD_MAX,
+  buildKeysetPredicate,
+  buildOrderBy,
+  cursorFromRow,
+  decodeCursor,
+  defaultSortDir,
+  encodeCursor,
+  type DevicesSortDir,
+  type DevicesSortKey,
+} from './cursor';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { resolveRemoteAccessForDevice } from '../../services/remoteAccessPolicy';
 import {
@@ -183,6 +195,25 @@ coreRoutes.post(
 );
 
 // GET /devices - List devices (paginated, filtered, sorted)
+//
+// Pagination modes (Discussion #742 PR 3):
+//   - **Cursor (default)**: pass `?cursor=<opaque>` (omit on first page).
+//     Server returns `{nextCursor, limit, total?}`. Scales to any fleet
+//     size; constant cost per page; stable under concurrent UPDATEs that
+//     don't touch the sort column. `total` is included only when the
+//     first page is requested with `includeTotal=true` — the client
+//     carries the count it receives across subsequent pages so we don't
+//     re-COUNT(*) per cursor step.
+//   - **Legacy offset**: pass `?page=N` (no cursor). Returns
+//     `{page, limit, total}` exactly as before for existing callers.
+//     Honored only when `page` is explicitly provided. New callers should
+//     migrate to the cursor mode.
+//
+// Sort whitelist: `hostname` (default, ASC), `lastSeen` (DESC),
+// `enrolled` (DESC). Each backed by a covering index. The keyset
+// ORDER BY/LIMIT is owned by `cursor.ts` and is never delegated to the
+// FilterConditionGroup engine — a filter-supplied ORDER BY would
+// silently break the keyset's monotonicity guarantee.
 coreRoutes.get(
   '/',
   requireScope('organization', 'partner', 'system'),
@@ -190,25 +221,41 @@ coreRoutes.get(
   async (c) => {
     const auth = c.get('auth');
     const query = c.req.valid('query');
-    // Devices list intentionally allows a higher cap than the default
-    // 100 — the web client paginates client-side over the returned set,
-    // so the cap is what gates how many devices a partner-scope user
-    // can see at once. 500 covers small MSP fleets in a single round
-    // trip while staying well under the ~1 MB JSON-payload mark.
-    // Longer-term, server-side sort/filter/page is needed for fleets
-    // beyond this range; tracked separately.
-    const { page, limit, offset } = getPagination(query, 500);
 
-    // Build conditions array
-    const conditions: ReturnType<typeof eq>[] = [];
+    // -------- pagination mode + page-size --------
+    const isCursorMode = query.page === undefined || query.cursor !== undefined;
+    const sort: DevicesSortKey = query.sort ?? 'hostname';
+    const sortDir: DevicesSortDir = query.sortDir ?? defaultSortDir(sort);
+    const limit = Math.min(
+      DEVICES_LIST_HARD_MAX,
+      Math.max(1, Number.parseInt(query.limit ?? String(DEVICES_LIST_DEFAULT_LIMIT), 10) || DEVICES_LIST_DEFAULT_LIMIT),
+    );
 
-    // Filter by org access (uses pre-computed accessibleOrgIds from auth middleware)
+    // Decode the incoming cursor up front so we can reject mismatches
+    // before paying for the row query. A cursor whose sort/dir does not
+    // match the query is a client bug, not a continuation — refuse it
+    // instead of silently restarting the walk and confusing the caller.
+    const cursor = isCursorMode ? decodeCursor(query.cursor ?? null) : null;
+    if (query.cursor && !cursor) {
+      return c.json({ error: 'Invalid or malformed cursor' }, 400);
+    }
+    if (cursor && (cursor.sort !== sort || cursor.sortDir !== sortDir)) {
+      return c.json(
+        { error: 'Cursor sort/sortDir does not match query — start a fresh walk' },
+        400,
+      );
+    }
+
+    // -------- row-filter predicates --------
+    const conditions: SQL[] = [];
+
+    // Org access — uses pre-computed accessibleOrgIds from auth.
     const orgFilter = auth.orgCondition(devices.orgId);
     if (orgFilter) {
       conditions.push(orgFilter);
     }
 
-    // Optional: filter to specific org if requested (must be accessible)
+    // Optional single-org filter (must be accessible).
     if (query.orgId) {
       if (!auth.canAccessOrg(query.orgId)) {
         return c.json({ error: 'Access to this organization denied' }, 403);
@@ -216,39 +263,91 @@ coreRoutes.get(
       conditions.push(eq(devices.orgId, query.orgId));
     }
 
-    // Additional filters
+    // Multi-org filter — first-class. Each entry must be accessible; we
+    // pre-check rather than rely on RLS to silently drop non-accessible
+    // ids (RLS would drop them but the caller wouldn't know the filter
+    // was effectively narrowed).
+    if (query.orgIds && query.orgIds.length > 0) {
+      for (const oid of query.orgIds) {
+        if (!auth.canAccessOrg(oid)) {
+          return c.json({ error: `Access to organization ${oid} denied` }, 403);
+        }
+      }
+      conditions.push(inArray(devices.orgId, query.orgIds));
+    }
+
     if (query.siteId) {
       conditions.push(eq(devices.siteId, query.siteId));
+    }
+    if (query.siteIds && query.siteIds.length > 0) {
+      conditions.push(inArray(devices.siteId, query.siteIds));
+    }
+
+    // Group membership filter — EXISTS subquery against the join table
+    // so we don't widen the SELECT row count if a device sits in
+    // multiple groups in the filter set.
+    if (query.groupIds && query.groupIds.length > 0) {
+      conditions.push(sql`EXISTS (
+        SELECT 1 FROM ${deviceGroupMemberships}
+        WHERE ${deviceGroupMemberships.deviceId} = ${devices.id}
+          AND ${deviceGroupMemberships.groupId} IN (${sql.join(
+            query.groupIds.map((g) => sql`${g}::uuid`),
+            sql`, `,
+          )})
+      )`);
     }
 
     if (query.status) {
       conditions.push(eq(devices.status, query.status));
     }
-
     if (query.osType) {
       conditions.push(eq(devices.osType, query.osType));
     }
-
+    if (query.role) {
+      conditions.push(eq(devices.deviceRole, query.role));
+    }
     if (query.search) {
       conditions.push(like(devices.hostname, `%${query.search}%`));
     }
 
-    // Exclude decommissioned by default unless explicitly requested
+    // Exclude decommissioned by default unless explicitly requested.
     if (!query.status && query.includeDecommissioned !== 'true') {
       conditions.push(sql`${devices.status} != 'decommissioned'`);
     }
 
+    // Keyset predicate (cursor mode only).
+    if (cursor) {
+      conditions.push(buildKeysetPredicate(cursor));
+    }
+
     const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
 
-    // Get total count
-    const countResult = await db
-      .select({ count: sql<number>`count(*)` })
-      .from(devices)
-      .where(whereCondition);
-    const total = Number(countResult[0]?.count ?? 0);
+    // -------- total (only if asked, only on first page) --------
+    // Cursor mode: count only when caller opts in AND there's no
+    // incoming cursor (the count is a once-per-walk thing the client
+    // carries). Offset mode: always count (legacy contract).
+    let total: number | undefined;
+    const wantsTotal = isCursorMode
+      ? query.includeTotal === 'true' && !cursor
+      : true;
+    if (wantsTotal) {
+      const countResult = await db
+        .select({ count: sql<number>`count(*)` })
+        .from(devices)
+        .where(whereCondition);
+      total = Number(countResult[0]?.count ?? 0);
+    }
 
-    // Get devices with hardware summary
-    const deviceList = await db
+    // -------- row query --------
+    const orderBy = buildOrderBy(sort, sortDir);
+    // Cursor mode peeks one extra row to detect "is there a next page" —
+    // if N+1 rows come back, the (N+1)th becomes the nextCursor seed and
+    // is trimmed from the response data. Offset mode uses the requested
+    // limit verbatim.
+    const fetchLimit = isCursorMode ? limit + 1 : limit;
+    const offset = isCursorMode ? 0 : Math.max(0, ((Number.parseInt(query.page ?? '1', 10) || 1) - 1) * limit);
+
+    const rows = await db
       .select({
         id: devices.id,
         orgId: devices.orgId,
@@ -283,9 +382,20 @@ coreRoutes.get(
       .from(devices)
       .leftJoin(deviceHardware, eq(devices.id, deviceHardware.deviceId))
       .where(whereCondition)
-      .orderBy(desc(devices.lastSeenAt))
-      .limit(limit)
+      .orderBy(...orderBy)
+      .limit(fetchLimit)
       .offset(offset);
+
+    // Cursor-mode: split off the peek row to compute nextCursor.
+    let nextCursor: string | null = null;
+    let deviceList = rows;
+    if (isCursorMode && rows.length > limit) {
+      deviceList = rows.slice(0, limit);
+      const lastReturned = deviceList[deviceList.length - 1];
+      if (lastReturned) {
+        nextCursor = encodeCursor(cursorFromRow(lastReturned, sort, sortDir));
+      }
+    }
 
     const deviceIds = deviceList.map(d => d.id);
 
@@ -314,7 +424,7 @@ coreRoutes.get(
         deviceIds.map((id) => sql`(${id}::uuid)`),
         sql`, `
       );
-      const rows = await db.execute<{
+      const metricsRows = await db.execute<{
         device_id: string;
         cpu_percent: number;
         ram_percent: number;
@@ -331,7 +441,7 @@ coreRoutes.get(
         ) AS m ON true
       `);
 
-      for (const row of rows) {
+      for (const row of metricsRows) {
         latestMetricsByDevice.set(row.device_id, {
           cpuPercent: row.cpu_percent,
           ramPercent: row.ram_percent,
@@ -387,9 +497,25 @@ coreRoutes.get(
       };
     });
 
+    // Response shape diverges by pagination mode (see route-level comment).
+    if (isCursorMode) {
+      const pagination: { nextCursor: string | null; limit: number; total?: number } = {
+        nextCursor,
+        limit,
+      };
+      if (total !== undefined) pagination.total = total;
+      return c.json({
+        data,
+        pagination,
+        sort: { by: sort, dir: sortDir },
+      });
+    }
+
+    // Legacy offset response (existing callers): unchanged shape.
+    const legacyPage = Math.max(1, Number.parseInt(query.page ?? '1', 10) || 1);
     return c.json({
       data,
-      pagination: { page, limit, total }
+      pagination: { page: legacyPage, limit, total: total ?? 0 },
     });
   }
 );

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -27,6 +27,7 @@ import {
   cursorFromRow,
   decodeCursor,
   defaultSortDir,
+  defaultSortKey,
   encodeCursor,
   type DevicesSortDir,
   type DevicesSortKey,
@@ -224,7 +225,11 @@ coreRoutes.get(
 
     // -------- pagination mode + page-size --------
     const isCursorMode = query.page === undefined || query.cursor !== undefined;
-    const sort: DevicesSortKey = query.sort ?? 'hostname';
+    // Default sort branches by pagination mode (see `defaultSortKey`):
+    // legacy `?page=N` callers keep the pre-cursor `last_seen_at DESC`
+    // ordering; cursor mode defaults to `hostname ASC` because the
+    // keyset's monotonicity is most stable on a NOT NULL string column.
+    const sort: DevicesSortKey = query.sort ?? defaultSortKey(isCursorMode);
     const sortDir: DevicesSortDir = query.sortDir ?? defaultSortDir(sort);
     const limit = Math.min(
       DEVICES_LIST_HARD_MAX,

--- a/apps/api/src/routes/devices/cursor.test.ts
+++ b/apps/api/src/routes/devices/cursor.test.ts
@@ -6,6 +6,7 @@ import {
   cursorFromRow,
   decodeCursor,
   defaultSortDir,
+  defaultSortKey,
   encodeCursor,
   type DevicesCursor,
 } from './cursor';
@@ -18,6 +19,14 @@ describe('cursor constants', () => {
   it('default limit is below the hard max', () => {
     expect(DEVICES_LIST_DEFAULT_LIMIT).toBeLessThan(DEVICES_LIST_HARD_MAX);
     expect(DEVICES_LIST_DEFAULT_LIMIT).toBeGreaterThan(0);
+  });
+
+  it('default limit is 500 — matches the pre-#777 unbounded-default contract for no-param callers', () => {
+    // Lowering this to a smaller number visibly drops the no-param
+    // devices-list from 500 to that number for any caller that lands
+    // before #778's cursor walker ships. Keep at 500 until #778 is live;
+    // then #778 can lower the default.
+    expect(DEVICES_LIST_DEFAULT_LIMIT).toBe(500);
   });
 
   it('sort whitelist is the three keys backed by covering indexes', () => {
@@ -34,6 +43,20 @@ describe('defaultSortDir', () => {
   });
   it('enrolled defaults to desc (newest first)', () => {
     expect(defaultSortDir('enrolled')).toBe('desc');
+  });
+});
+
+describe('defaultSortKey — pagination-mode-aware default sort', () => {
+  it('cursor mode defaults to `hostname` (keyset stable on NOT NULL string)', () => {
+    expect(defaultSortKey(true)).toBe('hostname');
+  });
+
+  it('offset mode defaults to `lastSeen` — preserves the pre-#777 contract for legacy `?page=N` callers', () => {
+    // Regression guard: a future "cleanup" that drops this mode branching
+    // would silently change every legacy `?page=N` caller's ordering from
+    // last_seen_at DESC → hostname ASC, breaking mobile, external API
+    // consumers, and the web during the deploy window before #778 ships.
+    expect(defaultSortKey(false)).toBe('lastSeen');
   });
 });
 

--- a/apps/api/src/routes/devices/cursor.test.ts
+++ b/apps/api/src/routes/devices/cursor.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEVICES_LIST_HARD_MAX,
+  DEVICES_LIST_DEFAULT_LIMIT,
+  DEVICES_SORT_KEYS,
+  cursorFromRow,
+  decodeCursor,
+  defaultSortDir,
+  encodeCursor,
+  type DevicesCursor,
+} from './cursor';
+
+describe('cursor constants', () => {
+  it('hard max is 1000 (Discussion #742 PR 3 design decision)', () => {
+    expect(DEVICES_LIST_HARD_MAX).toBe(1000);
+  });
+
+  it('default limit is below the hard max', () => {
+    expect(DEVICES_LIST_DEFAULT_LIMIT).toBeLessThan(DEVICES_LIST_HARD_MAX);
+    expect(DEVICES_LIST_DEFAULT_LIMIT).toBeGreaterThan(0);
+  });
+
+  it('sort whitelist is the three keys backed by covering indexes', () => {
+    expect(DEVICES_SORT_KEYS).toEqual(['hostname', 'lastSeen', 'enrolled']);
+  });
+});
+
+describe('defaultSortDir', () => {
+  it('hostname defaults to asc (alphabetical natural)', () => {
+    expect(defaultSortDir('hostname')).toBe('asc');
+  });
+  it('lastSeen defaults to desc (most-recent first)', () => {
+    expect(defaultSortDir('lastSeen')).toBe('desc');
+  });
+  it('enrolled defaults to desc (newest first)', () => {
+    expect(defaultSortDir('enrolled')).toBe('desc');
+  });
+});
+
+describe('encodeCursor / decodeCursor roundtrip', () => {
+  const cases: DevicesCursor[] = [
+    { v: 1, sort: 'hostname', sortDir: 'asc', k: 'fleming-laptop-01', id: '11111111-1111-4111-8111-111111111111' },
+    { v: 1, sort: 'hostname', sortDir: 'desc', k: '', id: '22222222-2222-4222-8222-222222222222' },
+    { v: 1, sort: 'lastSeen', sortDir: 'desc', k: '2026-05-19T01:14:24.000Z', id: '33333333-3333-4333-8333-333333333333' },
+    { v: 1, sort: 'lastSeen', sortDir: 'desc', k: null, id: '44444444-4444-4444-8444-444444444444' }, // NULL phase
+    { v: 1, sort: 'enrolled', sortDir: 'asc', k: '2024-01-01T00:00:00.000Z', id: '55555555-5555-4555-8555-555555555555' },
+  ];
+
+  for (const c of cases) {
+    it(`roundtrips ${c.sort}/${c.sortDir} (k=${String(c.k)})`, () => {
+      const token = encodeCursor(c);
+      // base64url has no '+', '/', or '=' chars
+      expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+      const decoded = decodeCursor(token);
+      expect(decoded).toEqual(c);
+    });
+  }
+});
+
+describe('decodeCursor — null/empty/garbage rejections', () => {
+  it('returns null for undefined', () => {
+    expect(decodeCursor(undefined)).toBeNull();
+  });
+  it('returns null for empty string', () => {
+    expect(decodeCursor('')).toBeNull();
+  });
+  it('returns null for null', () => {
+    expect(decodeCursor(null)).toBeNull();
+  });
+  it('returns null for non-base64url chars', () => {
+    expect(decodeCursor('not a valid token!!!')).toBeNull();
+  });
+  it('returns null for non-JSON base64', () => {
+    const garbage = Buffer.from('not json at all').toString('base64url');
+    expect(decodeCursor(garbage)).toBeNull();
+  });
+  it('returns null for wrong-version cursor (forward compat)', () => {
+    const bad = Buffer.from(JSON.stringify({ v: 99, sort: 'hostname', sortDir: 'asc', k: 'x', id: 'x' })).toString('base64url');
+    expect(decodeCursor(bad)).toBeNull();
+  });
+  it('returns null for unknown sort key', () => {
+    const bad = Buffer.from(JSON.stringify({ v: 1, sort: 'thisIsNotASort', sortDir: 'asc', k: 'x', id: 'x' })).toString('base64url');
+    expect(decodeCursor(bad)).toBeNull();
+  });
+  it('returns null for bogus sortDir', () => {
+    const bad = Buffer.from(JSON.stringify({ v: 1, sort: 'hostname', sortDir: 'sideways', k: 'x', id: 'x' })).toString('base64url');
+    expect(decodeCursor(bad)).toBeNull();
+  });
+  it('returns null when id is missing', () => {
+    const bad = Buffer.from(JSON.stringify({ v: 1, sort: 'hostname', sortDir: 'asc', k: 'x' })).toString('base64url');
+    expect(decodeCursor(bad)).toBeNull();
+  });
+  it('returns null when k is wrong type (object)', () => {
+    const bad = Buffer.from(JSON.stringify({ v: 1, sort: 'hostname', sortDir: 'asc', k: { not: 'a string' }, id: 'x' })).toString('base64url');
+    expect(decodeCursor(bad)).toBeNull();
+  });
+});
+
+describe('cursorFromRow', () => {
+  const baseRow = {
+    id: '99999999-9999-4999-8999-999999999999',
+    hostname: 'srv-edge-01',
+    lastSeenAt: new Date('2026-05-18T22:33:11.000Z'),
+    enrolledAt: new Date('2025-08-16T16:52:42.000Z'),
+  };
+
+  it('hostname cursor carries hostname as k', () => {
+    expect(cursorFromRow(baseRow, 'hostname', 'asc')).toEqual({
+      v: 1,
+      sort: 'hostname',
+      sortDir: 'asc',
+      k: 'srv-edge-01',
+      id: baseRow.id,
+    });
+  });
+
+  it('lastSeen cursor carries ISO timestamp as k', () => {
+    expect(cursorFromRow(baseRow, 'lastSeen', 'desc')).toEqual({
+      v: 1,
+      sort: 'lastSeen',
+      sortDir: 'desc',
+      k: '2026-05-18T22:33:11.000Z',
+      id: baseRow.id,
+    });
+  });
+
+  it('lastSeen cursor encodes null when row has never checked in', () => {
+    const neverSeen = { ...baseRow, lastSeenAt: null };
+    expect(cursorFromRow(neverSeen, 'lastSeen', 'desc')).toEqual({
+      v: 1,
+      sort: 'lastSeen',
+      sortDir: 'desc',
+      k: null,
+      id: baseRow.id,
+    });
+  });
+
+  it('enrolled cursor carries ISO timestamp as k', () => {
+    expect(cursorFromRow(baseRow, 'enrolled', 'desc')).toEqual({
+      v: 1,
+      sort: 'enrolled',
+      sortDir: 'desc',
+      k: '2025-08-16T16:52:42.000Z',
+      id: baseRow.id,
+    });
+  });
+});

--- a/apps/api/src/routes/devices/cursor.ts
+++ b/apps/api/src/routes/devices/cursor.ts
@@ -1,0 +1,220 @@
+/**
+ * Keyset cursor pagination for GET /devices (Discussion #742 PR 3).
+ *
+ * Walks the devices list in a stable order chosen by the caller, using a
+ * keyset on `(sortColumn, id)`. Avoids the offset-pagination skip/dup
+ * problem under churn: every agent check-in bumps `last_seen_at`, which
+ * would shift rows between pages of an offset query — keyset pages are
+ * stable against concurrent UPDATEs that don't touch the sort column.
+ *
+ * Default sort: `hostname ASC`. `hostname` and `enrolled_at` are NOT NULL
+ * in the schema, so their keyset predicates are straight tuple
+ * comparisons. `last_seen_at` is nullable (never-checked-in devices); the
+ * ORDER BY pins NULLs LAST and the keyset predicate has an explicit
+ * "transition to NULL phase" branch so the walk crosses the boundary
+ * exactly once with no gap or overlap.
+ *
+ * The keyset ORDER BY / LIMIT is owned here and is **never** delegated to
+ * the FilterConditionGroup engine — a filter-supplied ORDER BY would
+ * silently break the keyset's monotonicity guarantee.
+ */
+
+import { sql, type SQL } from 'drizzle-orm';
+import { devices } from '../../db/schema';
+
+/** Defensive per-response ceiling. The user never bumps into this; it
+ *  caps any one HTTP response at ~2-3 MB of JSON for the widest current
+ *  device shape. Single named constant so the number is greppable. */
+export const DEVICES_LIST_HARD_MAX = 1000;
+
+/** Per-request default when the client doesn't pass `limit`. Matches the
+ *  smallest UI selector option (10/25/50/100/200) above the natural
+ *  median of a small-MSP fleet view. */
+export const DEVICES_LIST_DEFAULT_LIMIT = 50;
+
+/** Whitelisted sort columns. Adding a new key requires (a) extending this
+ *  tuple, (b) adding a `case` in `buildOrderBy` + `buildKeysetPredicate`,
+ *  and (c) adding the matching covering index in a migration
+ *  (`devices_<sort>_id_idx`). The TS-`as const` plus the exhaustive
+ *  switches keep the three in sync. */
+export const DEVICES_SORT_KEYS = ['hostname', 'lastSeen', 'enrolled'] as const;
+export type DevicesSortKey = (typeof DEVICES_SORT_KEYS)[number];
+
+export type DevicesSortDir = 'asc' | 'desc';
+
+/**
+ * Wire shape carried in the opaque base64url-JSON cursor token.
+ * `v` is bumped if the shape ever changes incompatibly; `decodeCursor`
+ * rejects unknown versions rather than silently mis-walking.
+ */
+export interface DevicesCursor {
+  v: 1;
+  sort: DevicesSortKey;
+  sortDir: DevicesSortDir;
+  /** Last-row value of the sort column. `null` means the cursor has
+   *  crossed into the `last_seen_at IS NULL` phase (devices that have
+   *  never checked in); meaningless for sort keys that are NOT NULL. */
+  k: string | null;
+  /** Tiebreaker — last-row `devices.id`. Always set. */
+  id: string;
+}
+
+/** ISO-8601 date-time used by the cursor for timestamp sort columns. We
+ *  serialize Date → ISO so the cursor token is platform-portable and
+ *  diffable in logs, instead of relying on engine-specific timestamp
+ *  encodings. Postgres re-parses the ISO on the next round-trip. */
+function timestampToCursorKey(v: Date | string | null): string | null {
+  if (v === null) return null;
+  return v instanceof Date ? v.toISOString() : v;
+}
+
+/** Default direction when the caller specifies a sort key but no direction.
+ *  Picked so the natural reading is right by default: alphabetical
+ *  hostnames, most-recently-seen first, newest-enrolled first. */
+export function defaultSortDir(sort: DevicesSortKey): DevicesSortDir {
+  return sort === 'hostname' ? 'asc' : 'desc';
+}
+
+const BASE64URL_TOKEN_RE = /^[A-Za-z0-9_-]+={0,2}$/;
+
+/** Encode the cursor as a URL-safe base64 JSON token. We trim '=' padding
+ *  so the token slots into a query string without %-encoding noise. */
+export function encodeCursor(c: DevicesCursor): string {
+  const json = JSON.stringify(c);
+  return Buffer.from(json, 'utf8').toString('base64url');
+}
+
+/**
+ * Decode + validate an incoming cursor token. Returns null on any
+ * malformed input; the caller should treat null as "no cursor" and start
+ * the walk from the beginning. Throwing here would surface a 500 on
+ * adversarial input; null lets the route 400 cleanly if it cares.
+ */
+export function decodeCursor(token: string | undefined | null): DevicesCursor | null {
+  if (!token) return null;
+  if (!BASE64URL_TOKEN_RE.test(token)) return null;
+  let parsed: unknown;
+  try {
+    const json = Buffer.from(token, 'base64url').toString('utf8');
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const p = parsed as Record<string, unknown>;
+  if (p.v !== 1) return null;
+  if (typeof p.sort !== 'string' || !DEVICES_SORT_KEYS.includes(p.sort as DevicesSortKey)) return null;
+  if (p.sortDir !== 'asc' && p.sortDir !== 'desc') return null;
+  if (p.k !== null && typeof p.k !== 'string') return null;
+  if (typeof p.id !== 'string' || p.id.length === 0) return null;
+  return {
+    v: 1,
+    sort: p.sort as DevicesSortKey,
+    sortDir: p.sortDir,
+    k: p.k,
+    id: p.id,
+  };
+}
+
+/**
+ * Build the ORDER BY clause for a sort key + direction. NULL handling
+ * pins NULLs to the end of the natural reading order (so NULLs LAST under
+ * DESC, NULLS LAST under ASC) — the same shape on both directions so
+ * `last_seen_at IS NULL` rows always appear at the tail of the walk.
+ *
+ * The `id` tiebreaker uses the SAME direction as the sort column. Mixed
+ * directions break tuple-comparison keysets (`(a, b) <op>` requires
+ * uniform direction); the seen-id Set Todd suggested handles boundary
+ * fuzz on the volatile sorts at the client.
+ */
+export function buildOrderBy(sort: DevicesSortKey, dir: DevicesSortDir): SQL[] {
+  const idDir = dir === 'asc' ? sql`ASC` : sql`DESC`;
+  switch (sort) {
+    case 'hostname':
+      // hostname is NOT NULL — no NULLS clause needed.
+      return [
+        sql`${devices.hostname} ${dir === 'asc' ? sql`ASC` : sql`DESC`}`,
+        sql`${devices.id} ${idDir}`,
+      ];
+    case 'lastSeen':
+      // last_seen_at is nullable. NULLS LAST regardless of direction so
+      // never-checked-in devices always tail the list.
+      return [
+        sql`${devices.lastSeenAt} ${dir === 'asc' ? sql`ASC` : sql`DESC`} NULLS LAST`,
+        sql`${devices.id} ${idDir}`,
+      ];
+    case 'enrolled':
+      // enrolled_at is NOT NULL (defaultNow()).
+      return [
+        sql`${devices.enrolledAt} ${dir === 'asc' ? sql`ASC` : sql`DESC`}`,
+        sql`${devices.id} ${idDir}`,
+      ];
+  }
+}
+
+/**
+ * Build the WHERE-clause keyset predicate that resumes the walk from
+ * `cursor`. The caller AND-combines this with the row-filter predicates
+ * (org access, status, search, etc.).
+ *
+ * Returns `undefined` when there's no cursor — caller starts from the
+ * beginning of the order.
+ *
+ * NULL handling for `lastSeen`:
+ *   - `cursor.k != null` means we're in the non-NULL phase. Next rows
+ *     are either further non-NULL rows in the sort order, OR — once
+ *     we've exhausted non-NULL — the first NULL rows (transition).
+ *   - `cursor.k == null` means we're in the NULL phase. Next rows are
+ *     other NULL rows with `id` strictly past `cursor.id` in the sort
+ *     direction.
+ *
+ * `hostname` and `enrolled` use straight tuple comparison — no NULL
+ * branches needed because the columns are NOT NULL in the schema.
+ */
+export function buildKeysetPredicate(cursor: DevicesCursor): SQL {
+  const op = cursor.sortDir === 'asc' ? sql`>` : sql`<`;
+  switch (cursor.sort) {
+    case 'hostname': {
+      // hostname NOT NULL. Tuple comparison on (hostname, id).
+      return sql`(${devices.hostname}, ${devices.id}) ${op} (${cursor.k!}, ${cursor.id}::uuid)`;
+    }
+    case 'enrolled': {
+      // enrolled_at NOT NULL. Tuple comparison on (enrolled_at, id).
+      return sql`(${devices.enrolledAt}, ${devices.id}) ${op} (${cursor.k!}::timestamp, ${cursor.id}::uuid)`;
+    }
+    case 'lastSeen': {
+      // Three-phase logic — see function-level comment.
+      if (cursor.k === null) {
+        // NULL phase: continue among NULL rows by id only.
+        return sql`(${devices.lastSeenAt} IS NULL AND ${devices.id} ${op} ${cursor.id}::uuid)`;
+      }
+      // Non-NULL phase. Two ways to be "after" the cursor:
+      //   (a) another non-NULL row with smaller/larger sort key, OR
+      //   (b) any NULL row (NULL is pinned LAST for both directions).
+      return sql`(
+        (${devices.lastSeenAt} IS NOT NULL
+          AND (${devices.lastSeenAt}, ${devices.id}) ${op} (${cursor.k}::timestamp, ${cursor.id}::uuid))
+        OR ${devices.lastSeenAt} IS NULL
+      )`;
+    }
+  }
+}
+
+/**
+ * Pull the cursor-shaped {k, id} pair out of a result row for a given
+ * sort key. Used to build the `nextCursor` after a successful walk.
+ */
+export function cursorFromRow(
+  row: { id: string; hostname: string; lastSeenAt: Date | null; enrolledAt: Date },
+  sort: DevicesSortKey,
+  sortDir: DevicesSortDir
+): DevicesCursor {
+  switch (sort) {
+    case 'hostname':
+      return { v: 1, sort, sortDir, k: row.hostname, id: row.id };
+    case 'lastSeen':
+      return { v: 1, sort, sortDir, k: timestampToCursorKey(row.lastSeenAt), id: row.id };
+    case 'enrolled':
+      return { v: 1, sort, sortDir, k: timestampToCursorKey(row.enrolledAt), id: row.id };
+  }
+}

--- a/apps/api/src/routes/devices/cursor.ts
+++ b/apps/api/src/routes/devices/cursor.ts
@@ -27,10 +27,15 @@ import { devices } from '../../db/schema';
  *  device shape. Single named constant so the number is greppable. */
 export const DEVICES_LIST_HARD_MAX = 1000;
 
-/** Per-request default when the client doesn't pass `limit`. Matches the
- *  smallest UI selector option (10/25/50/100/200) above the natural
- *  median of a small-MSP fleet view. */
-export const DEVICES_LIST_DEFAULT_LIMIT = 50;
+/** Per-request default when the client doesn't pass `limit`. 500 matches
+ *  the previous unbounded-default behavior of `?page=1` callers prior to
+ *  PR #748's hard cap (the legacy contract returned up to 500 rows when
+ *  no `limit` was passed). Keeping the default at 500 means deploying
+ *  this PR (#777) before the cursor-walker (#778) ships does NOT visibly
+ *  drop the no-param devices-list from 500 to 50 rows for any existing
+ *  caller. #778 can lower the default once the cursor walker is in
+ *  production. */
+export const DEVICES_LIST_DEFAULT_LIMIT = 500;
 
 /** Whitelisted sort columns. Adding a new key requires (a) extending this
  *  tuple, (b) adding a `case` in `buildOrderBy` + `buildKeysetPredicate`,
@@ -73,6 +78,17 @@ function timestampToCursorKey(v: Date | string | null): string | null {
  *  hostnames, most-recently-seen first, newest-enrolled first. */
 export function defaultSortDir(sort: DevicesSortKey): DevicesSortDir {
   return sort === 'hostname' ? 'asc' : 'desc';
+}
+
+/** Default sort key when the caller omits `sort`. Differs by pagination
+ *  mode: offset mode (legacy `?page=N` callers) keeps the pre-cursor
+ *  contract of `last_seen_at DESC`; cursor mode defaults to `hostname`
+ *  because the keyset's monotonicity is most stable on a NOT NULL string
+ *  column. This branching is what prevents a silent ordering regression
+ *  for any external caller that lands between deploying #777 (server)
+ *  and #778 (web client). */
+export function defaultSortKey(isCursorMode: boolean): DevicesSortKey {
+  return isCursorMode ? 'hostname' : 'lastSeen';
 }
 
 const BASE64URL_TOKEN_RE = /^[A-Za-z0-9_-]+={0,2}$/;

--- a/apps/api/src/routes/devices/schemas.ts
+++ b/apps/api/src/routes/devices/schemas.ts
@@ -1,20 +1,71 @@
 import { z } from 'zod';
-
-export const listDevicesSchema = z.object({
-  page: z.string().optional(),
-  limit: z.string().optional(),
-  orgId: z.string().uuid().optional(),
-  siteId: z.string().uuid().optional(),
-  status: z.enum(['online', 'offline', 'maintenance', 'decommissioned', 'updating']).optional(),
-  includeDecommissioned: z.enum(['true', 'false']).optional(),
-  osType: z.enum(['windows', 'macos', 'linux']).optional(),
-  search: z.string().optional()
-});
+import { DEVICES_SORT_KEYS } from './cursor';
 
 const DEVICE_ROLES = [
   'workstation', 'server', 'printer', 'router', 'switch',
   'firewall', 'access_point', 'phone', 'iot', 'camera', 'nas', 'unknown'
 ] as const;
+
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+/**
+ * CSV-of-UUIDs query param. Accepts `?orgIds=uuid1,uuid2,uuid3`.
+ * Returns `string[]` on success, `undefined` when the param is absent.
+ * Each UUID is shape-validated; a single malformed entry rejects the
+ * whole list (no silent dropping of garbage).
+ */
+const csvUuidList = z
+  .string()
+  .optional()
+  .transform((raw, ctx) => {
+    if (raw === undefined || raw === '') return undefined;
+    const parts = raw.split(',').map((s) => s.trim()).filter(Boolean);
+    if (parts.length === 0) return undefined;
+    for (const p of parts) {
+      if (!UUID_RE.test(p)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: `invalid uuid: ${p}` });
+        return z.NEVER;
+      }
+    }
+    return parts;
+  });
+
+const boolStr = z.enum(['true', 'false']).optional();
+
+export const listDevicesSchema = z.object({
+  // Legacy offset pagination — still honored when no `cursor` is provided
+  // AND `page` is explicitly set, so existing callers keep working. Cursor
+  // pagination supersedes for new callers (see Discussion #742).
+  page: z.string().optional(),
+  limit: z.string().optional(),
+
+  // Cursor pagination (Discussion #742 PR 3).
+  cursor: z.string().optional(),
+  sort: z.enum(DEVICES_SORT_KEYS).optional(),
+  sortDir: z.enum(['asc', 'desc']).optional(),
+  /** When true, the cursor-less first response includes a `total` count.
+   *  Subsequent cursor pages never recompute — the client carries the
+   *  count it received on page 1. Default off because the count(*) is the
+   *  most expensive part of the query at scale. */
+  includeTotal: boolStr,
+
+  // Single-value filters (compat).
+  orgId: z.string().uuid().optional(),
+  siteId: z.string().uuid().optional(),
+
+  // First-class multi-value filters (#742). Plural form of the singletons
+  // above; both may be supplied. The handler ANDs them with auth's
+  // org-scope so a cross-org filter is rejected by RLS at the row level.
+  orgIds: csvUuidList,
+  siteIds: csvUuidList,
+  groupIds: csvUuidList,
+
+  status: z.enum(['online', 'offline', 'maintenance', 'decommissioned', 'updating']).optional(),
+  includeDecommissioned: boolStr,
+  osType: z.enum(['windows', 'macos', 'linux']).optional(),
+  role: z.enum(DEVICE_ROLES).optional(),
+  search: z.string().optional()
+});
 
 export const updateDeviceSchema = z.object({
   displayName: z.string().min(1).max(255).optional(),


### PR DESCRIPTION
## Summary

Server-side keyset cursor pagination for `GET /devices`, implementing PR 3 of Discussion #742 against the four design decisions in @ToddHebebrand's 2026-05-19 reply.

Web migration to consume this API is intentionally split into a follow-up PR (3b) — the two PRs are independent: this one ships cleanly on its own (legacy offset mode preserved as the response shape doesn't change for `?page=N` callers), and the API contract is the piece that benefits from review-first.

## Design fidelity to #742 reply

| Decision | Where |
|---|---|
| **(1) Default sort = stable key — `hostname ASC`, keyset `(hostname, id)`.** Other sorts (`lastSeen` DESC, `enrolled` DESC) selectable; `last_seen_at` NULLs LAST with explicit two-phase keyset predicate so a full walk crosses the NULL boundary exactly once. | `apps/api/src/routes/devices/cursor.ts` |
| **(2) `includeTotal=true` opt-in, default off, cursor-less first request only.** Cursor pages never recompute. | `apps/api/src/routes/devices/core.ts` ("`-- total --`" section) |
| **(3) First-class params extending `listDevicesSchema`** (`sort`, `sortDir`, `role`, `orgIds[]`, `siteIds[]`, `groupIds[]`). Multi-org filter pre-checks accessibility. Group filter is `EXISTS` against `device_group_memberships` so multi-group rows don't widen. Keyset ORDER BY/LIMIT is owned by `cursor.ts`, **never delegated to `FilterConditionGroup`**. | `apps/api/src/routes/devices/schemas.ts` + `core.ts` |
| **(4) `DEVICES_LIST_HARD_MAX = 1000`** as the single named constant. | `apps/api/src/routes/devices/cursor.ts` |

## Repo-shape constraints

- **Covering indexes**: `(hostname, id)`, `(last_seen_at, id)`, `(enrolled_at, id)`. Idempotent date-prefixed migration `2026-05-19-devices-cursor-keyset-indexes.sql`. No inner `BEGIN/COMMIT` per `CLAUDE.md`.
- **RLS test**: `devices` is shape 1 (direct `org_id`); no policy change. `devicesCursorRls.integration.test.ts` forges a partner scope, interleaves allowed + foreign-org devices, walks the cursor end-to-end, and asserts (a) every page returns only accessible-org rows, (b) `includeTotal` count under partner scope matches accessible-org rows only, and (c) a forged cursor carrying a foreign uuid does not pull the foreign row through.

## Tests

- **Unit** (`cursor.test.ts`, 25 passing): encode/decode roundtrip on all 5 cursor shapes (incl. the `lastSeen` NULL-phase one), version-mismatch rejection (forward compat), malformed-token rejection (8 garbage shapes covered), default-direction logic, `cursorFromRow` for each sort key.
- **Existing devices route tests** (156 passing): no regressions.
- **Integration** (`devicesCursorRls.integration.test.ts`, 3 cases): the cross-org isolation tests above.

## Backwards compatibility

- `?page=N` (without `?cursor=`) → legacy offset mode; response shape `{page, limit, total}` unchanged for existing callers.
- No `?page=` and no `?cursor=` → cursor-mode first page; response shape `{nextCursor, limit, total?}` + a `sort: {by, dir}` echo so a polite client can verify what the server actually walked.
- Mismatched cursor (sort/sortDir differing from query params) → 400 explicitly, not silent restart, so a stale localStorage cursor surfaces a real error.

## NULL handling on `lastSeen` (worth a careful look)

Per the keyset semantics, `(last_seen_at, id) < (k, id)` is undefined when `last_seen_at` is NULL. `cursor.ts` `buildKeysetPredicate` handles this with a three-state predicate:

1. **Non-NULL phase, cursor.k non-NULL** — `(last_seen_at, id)` tuple comparison OR `last_seen_at IS NULL` (transition).
2. **NULL phase, cursor.k = NULL** — `last_seen_at IS NULL AND id < cursor.id`.

Combined with `ORDER BY last_seen_at DESC NULLS LAST, id DESC`, the walk crosses the NULL boundary exactly once, in either direction, with no gap or duplicate.

## Mobile note

`apps/mobile/src/services/api.ts` hits `/devices` with no explicit limit, so it goes through the cursor path (no `page` param) and gets the first 50 devices + a `nextCursor` it can keep. That matches the existing mobile UX (no cap on what the user sees, scrolls trigger fetch-next), and no mobile-side change is required to keep current behavior working. A follow-up to wire mobile to actually walk the cursor is tracked separately.

## What's **not** in this PR (deliberate)

- Web migration to use the new cursor mode. The legacy offset path on `DevicesPage.tsx` keeps working unchanged; PR 3b will switch it. Splitting because the API is the piece that benefits from review-first and the web migration is mostly mechanical.
- A `FilterConditionGroup` escape-hatch wire-up to this endpoint. The schema accepts the first-class params; the saved-filter integration can land in a follow-up once we agree on whether the predicates-only contract is right.

References Discussion #742.
