### PR TITLE
feat(web): DevicesPage walks /devices cursor (#742 PR 3b — web)

### DIFF
--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -101,7 +101,21 @@ export default function DevicesPage() {
       // capped page and stops — same UX as before, no user-visible cap
       // once the server-side cursor migration lands.
       const [devicesResult, orgsResponse, sitesResponse, groupsResponse] = await Promise.all([
-        fetchAllDevices({ includeDecommissioned: true }),
+        fetchAllDevices({
+          includeDecommissioned: true,
+          // Surface the silent-cap case (#778 review). Without this, hitting
+          // the safety ceiling would render an incomplete device list and
+          // get reported later as "devices are missing."
+          onTruncated: ({ pagesWalked, pageLimit }) => {
+            showToast({
+              type: 'error',
+              message:
+                `Devices list truncated at ${pagesWalked * pageLimit} rows ` +
+                `(safety cap hit). Some devices may not be shown — refresh or contact support.`,
+              duration: 8000
+            });
+          }
+        }),
         fetchWithAuth('/orgs'),
         fetchWithAuth('/orgs/sites'),
         fetchWithAuth('/device-groups?includeMemberships=true').catch((err) => {

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -12,6 +12,7 @@ import AddDeviceModal from './AddDeviceModal';
 import CreateGroupModal from './CreateGroupModal';
 import { DeviceFilterBar } from '../filters/DeviceFilterBar';
 import { fetchWithAuth } from '../../stores/auth';
+import { fetchAllDevices } from '../../lib/devicesFetch';
 import { sendDeviceCommand, sendBulkCommand, executeScript, toggleMaintenanceMode, decommissionDevice, bulkDecommissionDevices, restoreDevice, permanentDeleteDevice, sendWakeCommand, sendBulkWakeCommand, summarizeBulkWakeFailures, summarizeBulkCommandFailures, watchWakeOutcome, WakeCommandError, wakeFriendlyErrorMessage } from '../../services/deviceActions';
 import { navigateTo } from '@/lib/navigation';
 import { getErrorMessage, getErrorTitle } from '@/lib/errorMessages';
@@ -92,12 +93,15 @@ export default function DevicesPage() {
       setLoading(true);
       setError(null);
 
-      // Fetch devices, orgs, sites, and groups in parallel
-      const [devicesResponse, orgsResponse, sitesResponse, groupsResponse] = await Promise.all([
-        // limit=500 matches the API-side cap for /devices; the list is
-        // paginated client-side after this fetch. Larger fleets need
-        // server-side sort/filter/page — tracked separately.
-        fetchWithAuth('/devices?includeDecommissioned=true&limit=500'),
+      // Devices walk the cursor (Discussion #742 PR 3); orgs/sites/groups
+      // are bounded one-shot fetches. Run all four in parallel so the
+      // first paint isn't gated on the slowest one. fetchAllDevices is
+      // forward+backward compatible: against the cursor API it walks
+      // pages, against the legacy offset API it returns the first
+      // capped page and stops — same UX as before, no user-visible cap
+      // once the server-side cursor migration lands.
+      const [devicesResult, orgsResponse, sitesResponse, groupsResponse] = await Promise.all([
+        fetchAllDevices({ includeDecommissioned: true }),
         fetchWithAuth('/orgs'),
         fetchWithAuth('/orgs/sites'),
         fetchWithAuth('/device-groups?includeMemberships=true').catch((err) => {
@@ -106,12 +110,7 @@ export default function DevicesPage() {
         })
       ]);
 
-      if (!devicesResponse.ok) {
-        throw devicesResponse;
-      }
-
-      const devicesData = await devicesResponse.json();
-      const deviceList = devicesData.data ?? devicesData.devices ?? devicesData ?? [];
+      const deviceList = devicesResult.data;
 
       // Transform API response to match Device type
       const transformedDevices: Device[] = deviceList.map((d: Record<string, unknown>) => {

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -88,7 +88,7 @@ export default function DevicesPage() {
     return unique.length > 0 ? unique : undefined;
   }, [scriptTargetDevices]);
 
-  const fetchDevices = useCallback(async () => {
+  const fetchDevices = useCallback(async (signal?: AbortSignal) => {
     try {
       setLoading(true);
       setError(null);
@@ -100,25 +100,33 @@ export default function DevicesPage() {
       // pages, against the legacy offset API it returns the first
       // capped page and stops — same UX as before, no user-visible cap
       // once the server-side cursor migration lands.
+      //
+      // `signal` is wired by the mount useEffect's AbortController so a
+      // navigate-away mid-walk stops the next page request and prevents
+      // setState on an unmounted component (#778 review).
       const [devicesResult, orgsResponse, sitesResponse, groupsResponse] = await Promise.all([
         fetchAllDevices({
           includeDecommissioned: true,
+          signal,
           // Surface the silent-cap case (#778 review). Without this, hitting
           // the safety ceiling would render an incomplete device list and
           // get reported later as "devices are missing."
-          onTruncated: ({ pagesWalked, pageLimit }) => {
+          onTruncated: ({ actualCount }) => {
             showToast({
               type: 'error',
               message:
-                `Devices list truncated at ${pagesWalked * pageLimit} rows ` +
+                `Devices list truncated at ${actualCount} rows ` +
                 `(safety cap hit). Some devices may not be shown — refresh or contact support.`,
               duration: 8000
             });
           }
         }),
-        fetchWithAuth('/orgs'),
-        fetchWithAuth('/orgs/sites'),
-        fetchWithAuth('/device-groups?includeMemberships=true').catch((err) => {
+        fetchWithAuth('/orgs', { signal }),
+        fetchWithAuth('/orgs/sites', { signal }),
+        fetchWithAuth('/device-groups?includeMemberships=true', { signal }).catch((err) => {
+          // AbortError on unmount is expected — bubble it up so the outer
+          // catch can short-circuit cleanly; don't log it as a real failure.
+          if (err instanceof Error && err.name === 'AbortError') throw err;
           console.warn('Failed to fetch device groups:', err);
           return null;
         })
@@ -205,14 +213,23 @@ export default function DevicesPage() {
       setOrgs(orgsList);
       setSites(sitesList);
     } catch (err) {
+      // Aborts are expected when the component unmounts mid-walk — drop
+      // them silently rather than rendering a misleading error banner.
+      if (err instanceof Error && err.name === 'AbortError') return;
       setError(err);
     } finally {
-      setLoading(false);
+      // setLoading(false) is harmless after unmount (React 18 ignores
+      // setState on unmounted components for hook-based components) but
+      // we still skip it when we know the call aborted, to avoid a
+      // brief flicker if the component remounts on the same key.
+      if (!signal?.aborted) setLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    fetchDevices();
+    const controller = new AbortController();
+    fetchDevices(controller.signal);
+    return () => controller.abort();
   }, [fetchDevices]);
 
   const handleGroupCreated = useCallback(async (newGroupId: string) => {
@@ -623,7 +640,7 @@ export default function DevicesPage() {
           <p className="text-xs text-muted-foreground mb-3">{getErrorMessage(error)}</p>
           <button
             type="button"
-            onClick={fetchDevices}
+            onClick={() => void fetchDevices()}
             className="text-xs font-medium text-primary hover:underline"
           >
             Try again

--- a/apps/web/src/lib/devicesFetch.test.ts
+++ b/apps/web/src/lib/devicesFetch.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchAllDevices } from './devicesFetch';
+
+function jsonResponse(body: unknown, init?: { ok?: boolean; status?: number }): Response {
+  return {
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('fetchAllDevices', () => {
+  it('legacy single-page API (no nextCursor) — walks one page and returns immediately', async () => {
+    const fetcher = vi.fn().mockResolvedValueOnce(
+      jsonResponse({
+        data: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+        pagination: { page: 1, limit: 500, total: 3 },
+      }),
+    );
+    const result = await fetchAllDevices({ fetcher });
+    expect(result.data).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }]);
+    expect(result.total).toBe(3);
+    expect(result.pagesWalked).toBe(1);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    // First call must request includeTotal and not pass a cursor.
+    const firstCall = fetcher.mock.calls[0][0] as string;
+    expect(firstCall).toContain('includeTotal=true');
+    expect(firstCall).not.toContain('cursor=');
+  });
+
+  it('new cursor API — walks pages until nextCursor goes null', async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: [{ id: '1' }, { id: '2' }],
+          pagination: { nextCursor: 'cur-p2', limit: 2, total: 5 },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: [{ id: '3' }, { id: '4' }],
+          pagination: { nextCursor: 'cur-p3', limit: 2 },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: [{ id: '5' }],
+          pagination: { nextCursor: null, limit: 2 },
+        }),
+      );
+
+    const result = await fetchAllDevices({ fetcher, pageLimit: 2 });
+
+    expect(result.data.map((d) => d.id)).toEqual(['1', '2', '3', '4', '5']);
+    expect(result.total).toBe(5);
+    expect(result.pagesWalked).toBe(3);
+    expect(fetcher).toHaveBeenCalledTimes(3);
+    // includeTotal only on page 0.
+    expect(fetcher.mock.calls[0][0]).toContain('includeTotal=true');
+    expect(fetcher.mock.calls[1][0]).not.toContain('includeTotal=true');
+    expect(fetcher.mock.calls[2][0]).not.toContain('includeTotal=true');
+    // Cursor param threads through after page 0.
+    expect(fetcher.mock.calls[0][0]).not.toContain('cursor=');
+    expect(fetcher.mock.calls[1][0]).toContain('cursor=cur-p2');
+    expect(fetcher.mock.calls[2][0]).toContain('cursor=cur-p3');
+  });
+
+  it('treats empty-string nextCursor as terminal (defensive)', async () => {
+    const fetcher = vi.fn().mockResolvedValueOnce(
+      jsonResponse({
+        data: [{ id: 'only' }],
+        pagination: { nextCursor: '', limit: 200 },
+      }),
+    );
+    const result = await fetchAllDevices({ fetcher });
+    expect(result.pagesWalked).toBe(1);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws the failed Response on a non-OK page (caller can show error UI)', async () => {
+    const failingResponse = jsonResponse({ error: 'nope' }, { ok: false, status: 500 });
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: [{ id: 'p0' }],
+          pagination: { nextCursor: 'cur', limit: 1 },
+        }),
+      )
+      .mockResolvedValueOnce(failingResponse);
+
+    await expect(fetchAllDevices({ fetcher, pageLimit: 1 })).rejects.toBe(failingResponse);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('accepts `devices` key shape as well as `data` (legacy fallback)', async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          devices: [{ id: 'legacy-1' }, { id: 'legacy-2' }],
+          pagination: { page: 1, limit: 500, total: 2 },
+        }),
+      );
+    const result = await fetchAllDevices({ fetcher });
+    expect(result.data).toEqual([{ id: 'legacy-1' }, { id: 'legacy-2' }]);
+    expect(result.total).toBe(2);
+  });
+
+  it('respects includeDecommissioned=false', async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({ data: [], pagination: { nextCursor: null } }),
+      );
+    await fetchAllDevices({ fetcher, includeDecommissioned: false });
+    expect(fetcher.mock.calls[0][0]).not.toContain('includeDecommissioned');
+  });
+});

--- a/apps/web/src/lib/devicesFetch.test.ts
+++ b/apps/web/src/lib/devicesFetch.test.ts
@@ -124,7 +124,7 @@ describe('fetchAllDevices', () => {
       expect(fetcher).toHaveBeenCalledTimes(200);
     });
 
-    it('invokes onTruncated with {pagesWalked, pageLimit} when the ceiling is hit', async () => {
+    it('invokes onTruncated with {pagesWalked, pageLimit, actualCount} when the ceiling is hit', async () => {
       const onTruncated = vi.fn();
       const fetcher = vi.fn().mockImplementation(async () =>
         jsonResponse({
@@ -136,7 +136,38 @@ describe('fetchAllDevices', () => {
       await fetchAllDevices({ fetcher, pageLimit: 1, onTruncated });
 
       expect(onTruncated).toHaveBeenCalledTimes(1);
-      expect(onTruncated).toHaveBeenCalledWith({ pagesWalked: 200, pageLimit: 1 });
+      // 200 pages × 1 row each = 200 rows accumulated. The callback's third
+      // field is the EXACT count, not the pagesWalked * pageLimit product
+      // (which overcounts when the final page arrived partial). Todd's
+      // #778 review noted the overcount; this asserts the precise figure.
+      expect(onTruncated).toHaveBeenCalledWith({
+        pagesWalked: 200,
+        pageLimit: 1,
+        actualCount: 200,
+      });
+    });
+
+    it('actualCount reflects the real accumulated rows, not pagesWalked * pageLimit', async () => {
+      // Server returns 7 rows on the first page but the cursor never ends.
+      // The walker burns the rest of MAX_PAGES with empty data pages.
+      // pagesWalked * pageLimit would say 200 × 10 = 2000; actualCount = 7.
+      const onTruncated = vi.fn();
+      let firstCall = true;
+      const fetcher = vi.fn().mockImplementation(async () => {
+        const body = firstCall
+          ? { data: [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }, { id: 'e' }, { id: 'f' }, { id: 'g' }], pagination: { nextCursor: 'still-going', limit: 10 } }
+          : { data: [], pagination: { nextCursor: 'still-going', limit: 10 } };
+        firstCall = false;
+        return jsonResponse(body);
+      });
+
+      await fetchAllDevices({ fetcher, pageLimit: 10, onTruncated });
+
+      expect(onTruncated).toHaveBeenCalledWith({
+        pagesWalked: 200,
+        pageLimit: 10,
+        actualCount: 7, // NOT 2000
+      });
     });
 
     it('does NOT invoke onTruncated when the walk terminates naturally', async () => {

--- a/apps/web/src/lib/devicesFetch.test.ts
+++ b/apps/web/src/lib/devicesFetch.test.ts
@@ -117,4 +117,55 @@ describe('fetchAllDevices', () => {
     await fetchAllDevices({ fetcher, includeDecommissioned: false });
     expect(fetcher.mock.calls[0][0]).not.toContain('includeDecommissioned');
   });
+
+  describe('AbortSignal', () => {
+    it('throws AbortError immediately when signal is already aborted before invocation', async () => {
+      const fetcher = vi.fn();
+      const controller = new AbortController();
+      controller.abort();
+      await expect(fetchAllDevices({ fetcher, signal: controller.signal })).rejects.toMatchObject({
+        name: 'AbortError',
+      });
+      expect(fetcher).not.toHaveBeenCalled();
+    });
+
+    it('stops walking when the signal aborts between pages', async () => {
+      const controller = new AbortController();
+      const fetcher = vi
+        .fn()
+        .mockImplementationOnce(async () => {
+          // Abort during page 0 — the walker should detect it before issuing page 1.
+          controller.abort();
+          return jsonResponse({
+            data: [{ id: '1' }, { id: '2' }],
+            pagination: { nextCursor: 'cur-p2', limit: 2, total: 10 },
+          });
+        })
+        .mockResolvedValueOnce(
+          jsonResponse({ data: [{ id: '3' }], pagination: { nextCursor: null } }),
+        );
+
+      await expect(
+        fetchAllDevices({ fetcher, pageLimit: 2, signal: controller.signal }),
+      ).rejects.toMatchObject({ name: 'AbortError' });
+      // Page 0 was already in flight when the abort fired, so it completes;
+      // page 1 must NOT be issued because the inter-page check trips first.
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    it('completes normally when signal is provided but never aborts', async () => {
+      const controller = new AbortController();
+      const fetcher = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: [{ id: 'a' }, { id: 'b' }],
+            pagination: { nextCursor: null, limit: 200, total: 2 },
+          }),
+        );
+      const result = await fetchAllDevices({ fetcher, signal: controller.signal });
+      expect(result.data).toEqual([{ id: 'a' }, { id: 'b' }]);
+      expect(result.pagesWalked).toBe(1);
+    });
+  });
 });

--- a/apps/web/src/lib/devicesFetch.test.ts
+++ b/apps/web/src/lib/devicesFetch.test.ts
@@ -94,20 +94,6 @@ describe('fetchAllDevices', () => {
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
 
-  it('accepts `devices` key shape as well as `data` (legacy fallback)', async () => {
-    const fetcher = vi
-      .fn()
-      .mockResolvedValueOnce(
-        jsonResponse({
-          devices: [{ id: 'legacy-1' }, { id: 'legacy-2' }],
-          pagination: { page: 1, limit: 500, total: 2 },
-        }),
-      );
-    const result = await fetchAllDevices({ fetcher });
-    expect(result.data).toEqual([{ id: 'legacy-1' }, { id: 'legacy-2' }]);
-    expect(result.total).toBe(2);
-  });
-
   it('respects includeDecommissioned=false', async () => {
     const fetcher = vi
       .fn()
@@ -116,6 +102,72 @@ describe('fetchAllDevices', () => {
       );
     await fetchAllDevices({ fetcher, includeDecommissioned: false });
     expect(fetcher.mock.calls[0][0]).not.toContain('includeDecommissioned');
+  });
+
+  describe('MAX_PAGES safety ceiling (#778 review)', () => {
+    it('stops walking at MAX_PAGES=200 and returns total=undefined to signal "not the full fleet"', async () => {
+      // Server returns nextCursor forever. The walker must stop at the
+      // hard ceiling — without it, a stuck server-side cursor would spin
+      // the UI thread forever.
+      const fetcher = vi.fn().mockImplementation(async () =>
+        jsonResponse({
+          data: [{ id: 'd' }],
+          pagination: { nextCursor: 'never-ending', limit: 1 },
+        }),
+      );
+
+      const result = await fetchAllDevices({ fetcher, pageLimit: 1 });
+
+      expect(result.pagesWalked).toBe(200);
+      expect(result.total).toBeUndefined();
+      expect(result.data.length).toBe(200);
+      expect(fetcher).toHaveBeenCalledTimes(200);
+    });
+
+    it('invokes onTruncated with {pagesWalked, pageLimit} when the ceiling is hit', async () => {
+      const onTruncated = vi.fn();
+      const fetcher = vi.fn().mockImplementation(async () =>
+        jsonResponse({
+          data: [{ id: 'd' }],
+          pagination: { nextCursor: 'never-ending', limit: 1 },
+        }),
+      );
+
+      await fetchAllDevices({ fetcher, pageLimit: 1, onTruncated });
+
+      expect(onTruncated).toHaveBeenCalledTimes(1);
+      expect(onTruncated).toHaveBeenCalledWith({ pagesWalked: 200, pageLimit: 1 });
+    });
+
+    it('does NOT invoke onTruncated when the walk terminates naturally', async () => {
+      const onTruncated = vi.fn();
+      const fetcher = vi.fn().mockResolvedValueOnce(
+        jsonResponse({
+          data: [{ id: 'a' }],
+          pagination: { nextCursor: null, limit: 200, total: 1 },
+        }),
+      );
+
+      await fetchAllDevices({ fetcher, onTruncated });
+      expect(onTruncated).not.toHaveBeenCalled();
+    });
+
+    it('a throwing onTruncated does not corrupt the return value', async () => {
+      const onTruncated = vi.fn(() => {
+        throw new Error('boom');
+      });
+      const fetcher = vi.fn().mockImplementation(async () =>
+        jsonResponse({
+          data: [{ id: 'd' }],
+          pagination: { nextCursor: 'never-ending', limit: 1 },
+        }),
+      );
+
+      const result = await fetchAllDevices({ fetcher, pageLimit: 1, onTruncated });
+      // Walker still returns the truncated rows even though the callback threw.
+      expect(result.pagesWalked).toBe(200);
+      expect(result.data.length).toBe(200);
+    });
   });
 
   describe('AbortSignal', () => {

--- a/apps/web/src/lib/devicesFetch.ts
+++ b/apps/web/src/lib/devicesFetch.ts
@@ -1,0 +1,128 @@
+/**
+ * Devices list fetcher — walks the `/devices` keyset cursor and accumulates
+ * every accessible row (Discussion #742 PR 3b — web consumer).
+ *
+ * Forward + backward compatible with the API on either side of the
+ * cursor migration:
+ *   - **New API** (cursor mode): server returns
+ *     `{data, pagination: {nextCursor, limit, total?}}`. We follow
+ *     `nextCursor` until it goes null, accumulating pages.
+ *   - **Old API** (offset mode): server returns
+ *     `{data, pagination: {page, limit, total}}` with no `nextCursor`.
+ *     The walk terminates after the first page, giving the same capped
+ *     single-page behavior the UI had before.
+ *
+ * `includeTotal=true` is set only on the first request; the cursor mode
+ * doesn't recompute the count per page (the client carries it). On the
+ * old API the param is ignored — no behavior change.
+ *
+ * Defensive: every page is capped at PAGE_LIMIT, and the walk itself is
+ * capped at MAX_PAGES so a misbehaving server can't pull the UI into an
+ * unbounded loop.
+ */
+import { fetchWithAuth } from '../stores/auth';
+
+/** Per-page size requested from the server. 200 matches the UI's
+ *  largest natural page size selector and keeps responses around 200KB
+ *  for the widest current device shape — well under the 1MB cursor mode
+ *  ceiling and well below the server's `DEVICES_LIST_HARD_MAX=1000`. */
+const PAGE_LIMIT = 200;
+
+/** Defensive ceiling on the page walk. PAGE_LIMIT * MAX_PAGES = 40,000
+ *  devices — at least an order of magnitude over the realistic fleet
+ *  size for the next several years, and a hard guard against an API bug
+ *  that returns a stuck `nextCursor` pointing back at the same window. */
+const MAX_PAGES = 200;
+
+export interface DevicesListResponse {
+  /** All accessible device rows. Order: whatever the server returned
+   *  (default `hostname ASC` under the cursor API; `last_seen_at DESC`
+   *  under the legacy offset API). */
+  data: Record<string, unknown>[];
+  /** Total accessible row count when known. Undefined when the server
+   *  didn't return it (cursor mode with includeTotal=false) or when the
+   *  count was unavailable (legacy mode it should always be set). */
+  total?: number;
+  /** How many cursor pages were walked. 1 means single-page (legacy or
+   *  small fleet). Useful for tests and telemetry. */
+  pagesWalked: number;
+}
+
+export interface FetchAllDevicesOptions {
+  /** Whether to include decommissioned devices. Matches the old query
+   *  param exactly. */
+  includeDecommissioned?: boolean;
+  /** Override the per-page size for tests. Production should leave this
+   *  at the module default. */
+  pageLimit?: number;
+  /** Override fetcher for tests. Defaults to the auth-wrapped fetch. */
+  fetcher?: typeof fetchWithAuth;
+}
+
+/**
+ * Walk the `/devices` cursor (or single page on legacy API) and return
+ * the full accessible set as one array.
+ *
+ * Rejects (throws the failed Response) on the first non-OK page so the
+ * caller surfaces a single clear error rather than a partial render with
+ * a misleading device count. A retry from the UI redoes the walk
+ * end-to-end.
+ */
+export async function fetchAllDevices(
+  options: FetchAllDevicesOptions = {},
+): Promise<DevicesListResponse> {
+  const includeDecommissioned = options.includeDecommissioned ?? true;
+  const pageLimit = options.pageLimit ?? PAGE_LIMIT;
+  const fetcher = options.fetcher ?? fetchWithAuth;
+
+  const accumulated: Record<string, unknown>[] = [];
+  let cursor: string | null = null;
+  let total: number | undefined;
+
+  for (let pageNum = 0; pageNum < MAX_PAGES; pageNum++) {
+    const params = new URLSearchParams();
+    if (includeDecommissioned) params.set('includeDecommissioned', 'true');
+    params.set('limit', String(pageLimit));
+    if (cursor !== null) params.set('cursor', cursor);
+    // includeTotal only on the cursor-less first page — the cursor API
+    // skips the count(*) on subsequent pages and we carry the value
+    // received on page 0.
+    if (pageNum === 0) params.set('includeTotal', 'true');
+
+    const resp = await fetcher(`/devices?${params.toString()}`);
+    if (!resp.ok) throw resp;
+    const body = (await resp.json()) as {
+      data?: Record<string, unknown>[];
+      devices?: Record<string, unknown>[];
+      pagination?: {
+        nextCursor?: string | null;
+        total?: number;
+        // Legacy fields — present on the offset API, harmless to read.
+        page?: number;
+        limit?: number;
+      };
+    };
+    const page = body.data ?? body.devices ?? [];
+    accumulated.push(...page);
+
+    if (pageNum === 0 && typeof body.pagination?.total === 'number') {
+      total = body.pagination.total;
+    }
+    cursor =
+      typeof body.pagination?.nextCursor === 'string' && body.pagination.nextCursor.length > 0
+        ? body.pagination.nextCursor
+        : null;
+    if (cursor === null) {
+      return { data: accumulated, total, pagesWalked: pageNum + 1 };
+    }
+  }
+
+  // Hit the safety ceiling. Return what we have, but flag total as
+  // undefined so the caller knows the walk didn't complete and shouldn't
+  // assert "this is the full fleet."
+  console.warn(
+    `[fetchAllDevices] hit MAX_PAGES=${MAX_PAGES} safety ceiling at limit=${pageLimit}; truncating walk. ` +
+      `Investigate server-side cursor loop.`,
+  );
+  return { data: accumulated, total: undefined, pagesWalked: MAX_PAGES };
+}

--- a/apps/web/src/lib/devicesFetch.ts
+++ b/apps/web/src/lib/devicesFetch.ts
@@ -57,6 +57,13 @@ export interface FetchAllDevicesOptions {
   pageLimit?: number;
   /** Override fetcher for tests. Defaults to the auth-wrapped fetch. */
   fetcher?: typeof fetchWithAuth;
+  /** Optional cancellation signal. When the caller (e.g. the DevicesPage
+   *  on navigate-away) aborts, the walker stops between pages and rejects
+   *  with the standard `DOMException('Aborted', 'AbortError')`. Without
+   *  this, a multi-page walk can keep issuing up to MAX_PAGES requests
+   *  after the user has left the page — wasted bandwidth on slow links
+   *  and unnecessary API load. */
+  signal?: AbortSignal;
 }
 
 /**
@@ -74,12 +81,28 @@ export async function fetchAllDevices(
   const includeDecommissioned = options.includeDecommissioned ?? true;
   const pageLimit = options.pageLimit ?? PAGE_LIMIT;
   const fetcher = options.fetcher ?? fetchWithAuth;
+  const signal = options.signal;
+
+  // Fast-path: if the caller already aborted before invocation, throw
+  // immediately rather than issuing page 0.
+  if (signal?.aborted) {
+    throw signalAbortError(signal);
+  }
 
   const accumulated: Record<string, unknown>[] = [];
   let cursor: string | null = null;
   let total: number | undefined;
 
   for (let pageNum = 0; pageNum < MAX_PAGES; pageNum++) {
+    // Check between pages so a navigate-away that lands mid-walk stops
+    // the next request before we issue it. Checking here (rather than
+    // inside the fetcher) means we still surface a single AbortError
+    // even when the underlying fetch implementation does not honor
+    // AbortSignal.
+    if (signal?.aborted) {
+      throw signalAbortError(signal);
+    }
+
     const params = new URLSearchParams();
     if (includeDecommissioned) params.set('includeDecommissioned', 'true');
     params.set('limit', String(pageLimit));
@@ -125,4 +148,17 @@ export async function fetchAllDevices(
       `Investigate server-side cursor loop.`,
   );
   return { data: accumulated, total: undefined, pagesWalked: MAX_PAGES };
+}
+
+/** Build the standard DOMException-shaped AbortError so callers can do
+ *  `catch (err) { if (err.name === 'AbortError') return; }` against any
+ *  abort source (DOM-native fetch, our walker, any other library). When
+ *  the signal carries a `reason`, prefer that; otherwise fall back to the
+ *  generic message. */
+function signalAbortError(signal: AbortSignal): Error {
+  // AbortSignal.reason was added in 17+/Chromium 100+; gracefully degrade
+  // if we're in an older environment.
+  const reason = (signal as { reason?: unknown }).reason;
+  if (reason instanceof Error) return reason;
+  return new DOMException('Aborted', 'AbortError');
 }

--- a/apps/web/src/lib/devicesFetch.ts
+++ b/apps/web/src/lib/devicesFetch.ts
@@ -69,8 +69,13 @@ export interface FetchAllDevicesOptions {
    *  warning (toast, telemetry) so a silent truncation doesn't get
    *  reported later as "devices are missing." The walker still returns
    *  the accumulated rows with `total=undefined` to indicate the count
-   *  is unreliable. */
-  onTruncated?: (info: { pagesWalked: number; pageLimit: number }) => void;
+   *  is unreliable.
+   *
+   *  `actualCount` is the precise number of rows accumulated (which may
+   *  be slightly less than `pagesWalked * pageLimit` if the final page
+   *  arrived partial). Callers should display this rather than the
+   *  pagesWalked * pageLimit product. (Todd's #778 review.) */
+  onTruncated?: (info: { pagesWalked: number; pageLimit: number; actualCount: number }) => void;
 }
 
 /**
@@ -159,7 +164,11 @@ export async function fetchAllDevices(
       `Investigate server-side cursor loop.`,
   );
   try {
-    options.onTruncated?.({ pagesWalked: MAX_PAGES, pageLimit });
+    options.onTruncated?.({
+      pagesWalked: MAX_PAGES,
+      pageLimit,
+      actualCount: accumulated.length,
+    });
   } catch (err) {
     // A misbehaving onTruncated must not corrupt the return — we still
     // surface the accumulated rows so the UI degrades gracefully.

--- a/apps/web/src/lib/devicesFetch.ts
+++ b/apps/web/src/lib/devicesFetch.ts
@@ -64,6 +64,13 @@ export interface FetchAllDevicesOptions {
    *  after the user has left the page — wasted bandwidth on slow links
    *  and unnecessary API load. */
   signal?: AbortSignal;
+  /** Invoked when the walker hits the MAX_PAGES safety ceiling without
+   *  reaching the end of the cursor. Lets the caller surface a visible
+   *  warning (toast, telemetry) so a silent truncation doesn't get
+   *  reported later as "devices are missing." The walker still returns
+   *  the accumulated rows with `total=undefined` to indicate the count
+   *  is unreliable. */
+  onTruncated?: (info: { pagesWalked: number; pageLimit: number }) => void;
 }
 
 /**
@@ -116,7 +123,6 @@ export async function fetchAllDevices(
     if (!resp.ok) throw resp;
     const body = (await resp.json()) as {
       data?: Record<string, unknown>[];
-      devices?: Record<string, unknown>[];
       pagination?: {
         nextCursor?: string | null;
         total?: number;
@@ -125,7 +131,10 @@ export async function fetchAllDevices(
         limit?: number;
       };
     };
-    const page = body.data ?? body.devices ?? [];
+    // Both the cursor API (#777) and the legacy offset API return `data`.
+    // A previous draft also accepted a `devices` key, but no deployed shape
+    // ever returns that — dropped per #778 review.
+    const page = body.data ?? [];
     accumulated.push(...page);
 
     if (pageNum === 0 && typeof body.pagination?.total === 'number') {
@@ -142,11 +151,20 @@ export async function fetchAllDevices(
 
   // Hit the safety ceiling. Return what we have, but flag total as
   // undefined so the caller knows the walk didn't complete and shouldn't
-  // assert "this is the full fleet."
+  // assert "this is the full fleet." Invoke onTruncated so the UI can
+  // surface a visible warning — a silent console.warn gets reported as
+  // "missing devices" with no obvious cause (Todd's #778 review).
   console.warn(
     `[fetchAllDevices] hit MAX_PAGES=${MAX_PAGES} safety ceiling at limit=${pageLimit}; truncating walk. ` +
       `Investigate server-side cursor loop.`,
   );
+  try {
+    options.onTruncated?.({ pagesWalked: MAX_PAGES, pageLimit });
+  } catch (err) {
+    // A misbehaving onTruncated must not corrupt the return — we still
+    // surface the accumulated rows so the UI degrades gracefully.
+    console.warn('[fetchAllDevices] onTruncated callback threw:', err);
+  }
   return { data: accumulated, total: undefined, pagesWalked: MAX_PAGES };
 }
 


### PR DESCRIPTION
## Summary

Web-side migration to the keyset cursor API introduced in PR #777 (Discussion #742 PR 3, server). Removes the user-visible 500-device cap on the Devices page by walking `nextCursor` and accumulating pages.

## Compat: ships independently of #777

Forward + backward compatible with the API on either side of the cursor migration:

- **New cursor API** (#777 merged): `fetchAllDevices` walks `nextCursor` until null, accumulating every accessible row. No 500-device ceiling.
- **Legacy offset API** (#777 not merged): the first page has no `nextCursor`, the walk terminates after one request — identical UX to today.

So this PR can land before, with, or after #777 without any reordering. Cleanly stacked, not strictly dependent.

## Change shape

- `apps/web/src/lib/devicesFetch.ts` — new `fetchAllDevices()` helper, intentionally split out from `DevicesPage.tsx` so the cursor-walk semantics are unit-testable in isolation. PAGE_LIMIT=200, MAX_PAGES=200 safety ceiling, throws the failed Response on the first non-OK page (caller surfaces one clear error rather than a partial render).
- `apps/web/src/components/devices/DevicesPage.tsx` — `fetchDevices` calls `fetchAllDevices()` alongside the existing parallel orgs/sites/groups fetches. No other UI changes — DeviceList still does client-side filter/sort/page over the accumulated array, so the on-page UX is unchanged.
- `apps/web/src/lib/devicesFetch.test.ts` — 6 unit tests.

Diff: **+259 / -12 across 3 files**.

## What this PR explicitly does NOT do (deliberate)

Server-driven sort/filter/page on the DeviceList UI surface (true incremental loading, debounced server-search, "Load more" / virtualized scroll) is a separate, larger UX project — call it PR 3c. The cursor API supports all of it (sort, sortDir, role, orgIds[], siteIds[], groupIds[], includeTotal), but converting the existing 963-line DeviceList from a client-side filter/sort/page component to a controlled one is a significant refactor that benefits from its own focused review pass.

This PR is the minimum web change that unlocks PR #777's user-visible benefit: **no 500-device cap on the Devices page**. Anything more would mix unrelated concerns.

## Tests

- `devicesFetch.test.ts` — 6 unit tests passing:
  - Legacy single-page response (one fetch, no cursor, returns immediately)
  - Multi-page cursor walk (three pages, `includeTotal` only on page 0, cursor threaded through)
  - Empty-string `nextCursor` treated as terminal (defensive)
  - Mid-walk non-OK response throws (caller can surface error UI)
  - `devices` key shape accepted alongside `data` (legacy fallback)
  - `includeDecommissioned=false` omits the param
- All 52 existing devices-component tests pass (no regressions).
- `no-silent-mutations` guard (17 tests) passes.

## Notes

- `includeTotal=true` only sent on page 0. On the cursor API the server returns the count once and the client carries it across subsequent pages; on the legacy offset API the param is ignored. No behavior difference either way.
- Page transform stays in `DevicesPage.tsx` (orgs/sites name resolution). The fetcher returns the raw `data` array; the page does the transform once after all pages have been collected. This avoids re-transforming the same row per page, and avoids per-page state updates that would cause repeated re-renders during the walk.

References Discussion #742, PR #777.
