### PR TITLE
fix(security): resolve SR-001/002/004/005/007/008/009 from security report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ env:
   PNPM_VERSION: '10.33.4'
   GO_VERSION: '1.25.10'
 
+# SR-007: least-privilege default. CI runs on every PR (including forks) and
+# only needs to read the repo. Any job needing more must opt in per-job.
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,13 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+# SR-007: least-privilege default for every job. Build jobs only need to read
+# the repo + exchange artifacts. Jobs that publish override this with their
+# own per-job `permissions:` (create-release → contents: write; GHCR pushes →
+# packages: write; Tauri/MSI signing → id-token: write).
+permissions:
+  contents: read
+
 jobs:
   build-api:
     name: Build API

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -617,15 +617,19 @@ async function resolveFallbackOrgId(c: Context, path: string): Promise<string | 
   return null;
 }
 
-// Generic partner status guard — blocks non-active partners
+// Generic partner status guard — blocks non-active partners.
+// IMPORTANT: every branch MUST `return` the next()/partnerGuard() promise so
+// any Response (403 PARTNER_INACTIVE, 403 PARTNER_NOT_FOUND, 503 PARTNER_LOOKUP_UNAVAILABLE)
+// propagates back through Hono's compose chain. Discarding the return causes
+// Hono to throw "Context is not finalized" and the request collapses to 500.
 api.use('*', async (c, next) => {
   const path = c.req.path;
-  if (path.startsWith('/api/v1/auth')) { await next(); return; }
-  if (path === '/api/v1/config' || path.startsWith('/api/v1/config/')) { await next(); return; }
-  if (path.startsWith('/api/v1/users/me')) { await next(); return; }
-  if (path === '/api/v1/partner/me' || path.startsWith('/api/v1/partner/me/')) { await next(); return; }
-  if (path.startsWith('/api/v1/agents/')) { await next(); return; }
-  await partnerGuard(c, next);
+  if (path.startsWith('/api/v1/auth')) return next();
+  if (path === '/api/v1/config' || path.startsWith('/api/v1/config/')) return next();
+  if (path.startsWith('/api/v1/users/me')) return next();
+  if (path === '/api/v1/partner/me' || path.startsWith('/api/v1/partner/me/')) return next();
+  if (path.startsWith('/api/v1/agents/')) return next();
+  return partnerGuard(c, next);
 });
 
 api.use('*', async (c, next) => {

--- a/apps/api/src/middleware/mobileDeviceBlocked.test.ts
+++ b/apps/api/src/middleware/mobileDeviceBlocked.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../services/jwt', () => ({
+  verifyToken: vi.fn(),
+}));
+
+const limitMock = vi.fn();
+const whereMock = vi.fn(() => ({ limit: limitMock }));
+vi.mock('../db', () => ({
+  db: {
+    select: () => ({ from: () => ({ where: whereMock }) }),
+  },
+  runOutsideDbContext: (fn: () => unknown) => fn(),
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+}));
+
+vi.mock('../db/schema', () => ({
+  mobileDevices: {
+    status: { name: 'status' },
+    blockedReason: { name: 'blocked_reason' },
+    deviceId: { name: 'device_id' },
+    userId: { name: 'user_id' },
+  },
+}));
+
+import { Hono } from 'hono';
+import { mobileDeviceBlockedMiddleware } from './mobileDeviceBlocked';
+import { verifyToken } from '../services/jwt';
+import { MOBILE_DEVICE_ID_HEADER } from '../services/mobileDeviceBinding';
+
+function makeApp() {
+  const app = new Hono();
+  app.use('/mobile/*', mobileDeviceBlockedMiddleware);
+  app.get('/mobile/ping', (c) => c.json({ ok: true }));
+  return app;
+}
+
+const VICTIM = 'user-victim-1';
+const DEVICE = 'install-uuid-victim';
+
+describe('mobileDeviceBlockedMiddleware — signed device binding (SR-001)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    limitMock.mockResolvedValue([]);
+  });
+
+  it('blocks a request whose SIGNED token is bound to a blocked device, even with NO header (the bypass)', async () => {
+    vi.mocked(verifyToken).mockResolvedValue({ sub: VICTIM, mdid: DEVICE, type: 'access' } as never);
+    limitMock.mockResolvedValueOnce([{ status: 'blocked', blockedReason: 'lost phone' }]);
+
+    const res = await makeApp().request('/mobile/ping', {
+      headers: { Authorization: 'Bearer stolen-bound-token' }, // note: NO X-Breeze-Mobile-Device-Id
+    });
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code?: string; reason?: string };
+    expect(body.code).toBe('device_blocked');
+    expect(body.reason).toBe('lost phone');
+  });
+
+  it('blocks even when the attacker spoofs a DIFFERENT device-id header (signed claim wins)', async () => {
+    vi.mocked(verifyToken).mockResolvedValue({ sub: VICTIM, mdid: DEVICE, type: 'access' } as never);
+    limitMock.mockResolvedValueOnce([{ status: 'blocked', blockedReason: null }]);
+
+    const res = await makeApp().request('/mobile/ping', {
+      headers: {
+        Authorization: 'Bearer stolen-bound-token',
+        [MOBILE_DEVICE_ID_HEADER]: 'some-other-unblocked-id',
+      },
+    });
+
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { code?: string }).code).toBe('device_blocked');
+  });
+
+  it('scopes the blocked lookup to device_id AND the token user (report guidance)', async () => {
+    vi.mocked(verifyToken).mockResolvedValue({ sub: VICTIM, mdid: DEVICE, type: 'access' } as never);
+    limitMock.mockResolvedValueOnce([]); // no row for (device, user) → not blocked
+
+    const res = await makeApp().request('/mobile/ping', {
+      headers: { Authorization: 'Bearer bound-token' },
+    });
+
+    expect(res.status).toBe(200);
+    // Two predicates anded together: device_id and user_id (not a global device_id-only lookup).
+    expect(whereMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes a bound token whose device row is still active', async () => {
+    vi.mocked(verifyToken).mockResolvedValue({ sub: VICTIM, mdid: DEVICE, type: 'access' } as never);
+    limitMock.mockResolvedValueOnce([{ status: 'active', blockedReason: null }]);
+
+    const res = await makeApp().request('/mobile/ping', {
+      headers: { Authorization: 'Bearer bound-token' },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('passes a bound token with no device row yet (pre-registration onboarding)', async () => {
+    vi.mocked(verifyToken).mockResolvedValue({ sub: VICTIM, mdid: DEVICE, type: 'access' } as never);
+    limitMock.mockResolvedValueOnce([]);
+
+    const res = await makeApp().request('/mobile/ping', {
+      headers: { Authorization: 'Bearer bound-token' },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('falls back to the header for legacy tokens minted before binding (migration)', async () => {
+    vi.mocked(verifyToken).mockResolvedValue({ sub: VICTIM, type: 'access' } as never); // no mdid
+    limitMock.mockResolvedValueOnce([{ status: 'blocked', blockedReason: 'admin block' }]);
+
+    const res = await makeApp().request('/mobile/ping', {
+      headers: {
+        Authorization: 'Bearer legacy-token',
+        [MOBILE_DEVICE_ID_HEADER]: DEVICE,
+      },
+    });
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { code?: string }).code).toBe('device_blocked');
+  });
+
+  it('is a noop for non-mobile callers (no token, no header) — web/MCP unaffected', async () => {
+    const res = await makeApp().request('/mobile/ping');
+    expect(res.status).toBe(200);
+    expect(whereMock).not.toHaveBeenCalled();
+  });
+
+  it('is a noop for a legacy token with no header (web dashboard reaching a /mobile/* path)', async () => {
+    vi.mocked(verifyToken).mockResolvedValue({ sub: 'web-user', type: 'access' } as never);
+    const res = await makeApp().request('/mobile/ping', {
+      headers: { Authorization: 'Bearer web-token' },
+    });
+    expect(res.status).toBe(200);
+    expect(whereMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/middleware/mobileDeviceBlocked.ts
+++ b/apps/api/src/middleware/mobileDeviceBlocked.ts
@@ -2,45 +2,64 @@ import type { Context, Next } from 'hono';
 import { and, eq } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { mobileDevices } from '../db/schema';
-import { MOBILE_DEVICE_ID_HEADER } from '../routes/lifecycle';
+import { verifyToken } from '../services/jwt';
+import { MOBILE_DEVICE_ID_HEADER, readMobileDeviceId } from '../services/mobileDeviceBinding';
 
 /**
  * Reject API calls from a blocked mobile device with a structured
  * `device_blocked` error. The mobile app renders this as a full-screen
  * lockout state instructing the user to re-pair.
  *
- * Behaviour:
- *   - No `X-Breeze-Mobile-Device-Id` header → noop (web dashboard, MCP).
- *   - Header present but no matching row → noop (first call before
- *     /devices register lands).
- *   - Header present + row's status='blocked' → 403 with code.
+ * SR-001: the authoritative device identity is the SIGNED `mdid` JWT claim,
+ * not the `X-Breeze-Mobile-Device-Id` header. The header is spoofable and
+ * omittable, so a stolen-phone bearer token could previously bypass the
+ * lockout entirely by simply not sending it. We now:
  *
- * The lookup runs under system DB context: this middleware fires before
- * the per-request RLS scope is set up, and we want it to see the row
- * even if the user is otherwise locked out.
+ *   1. Prefer the signed `mdid` claim. When present, the lookup is scoped to
+ *      BOTH the bound device id and the token's user — an attacker cannot
+ *      strip or alter it without re-authenticating (login/refresh re-mint).
+ *   2. Fall back to the header ONLY for legacy tokens minted before binding
+ *      (migration window) and for non-mobile callers that never carry the
+ *      claim — preserving the original behaviour for them.
+ *   3. No matching row → noop (the very first calls land before the device
+ *      registers; we must not break onboarding).
+ *
+ * Runs under system DB context: this fires before the per-request RLS scope
+ * is set up, and must see the row even when the user is otherwise locked out.
  */
 export async function mobileDeviceBlockedMiddleware(c: Context, next: Next): Promise<Response | void> {
-  const deviceId = c.req.header(MOBILE_DEVICE_ID_HEADER) ?? c.req.header(MOBILE_DEVICE_ID_HEADER.toUpperCase());
+  // Derive the device identity from the signed bearer token when possible.
+  let signedDeviceId: string | null = null;
+  let tokenUserId: string | null = null;
+  const authHeader = c.req.header('Authorization');
+  if (authHeader?.startsWith('Bearer ')) {
+    const payload = await verifyToken(authHeader.slice(7)).catch(() => null);
+    if (payload && payload.type === 'access') {
+      tokenUserId = payload.sub ?? null;
+      if (typeof payload.mdid === 'string' && payload.mdid.length > 0) {
+        signedDeviceId = payload.mdid;
+      }
+    }
+  }
+
+  // Bound token → trust the signed id and scope by user. Otherwise fall back
+  // to the (legacy, spoofable) header with device-id-only scoping.
+  const deviceId = signedDeviceId ?? readMobileDeviceId(c);
   if (!deviceId) {
     return next();
   }
+  const scopeByUser = signedDeviceId !== null && tokenUserId !== null;
 
-  // We need the auth context to scope the lookup to the calling user;
-  // /mobile/* paths run authMiddleware via the route file itself, but
-  // this middleware fires earlier. Look up by device_id only — the
-  // device_id space is global and the caller proves identity via the
-  // bearer token; we don't need to gate further here.
-  const trimmed = deviceId.trim();
-  if (trimmed.length === 0 || trimmed.length > 255) {
-    return next();
-  }
+  const whereClause = scopeByUser
+    ? and(eq(mobileDevices.deviceId, deviceId), eq(mobileDevices.userId, tokenUserId as string))
+    : eq(mobileDevices.deviceId, deviceId);
 
   const [row] = await runOutsideDbContext(() =>
     withSystemDbAccessContext(() =>
       db
         .select({ status: mobileDevices.status, blockedReason: mobileDevices.blockedReason })
         .from(mobileDevices)
-        .where(eq(mobileDevices.deviceId, trimmed))
+        .where(whereClause)
         .limit(1)
     )
   );
@@ -63,5 +82,6 @@ export async function mobileDeviceBlockedMiddleware(c: Context, next: Next): Pro
   return next();
 }
 
-// Suppress lint about unused import when consuming `and`.
-void and;
+// Re-exported for callers that previously imported the header constant from
+// here (and the lifecycle route module).
+export { MOBILE_DEVICE_ID_HEADER };

--- a/apps/api/src/middleware/partnerGuard.test.ts
+++ b/apps/api/src/middleware/partnerGuard.test.ts
@@ -15,6 +15,10 @@ vi.mock('../db', () => ({
       }),
     }),
   },
+  // Passthrough — production wraps the partner lookup so that RLS doesn't
+  // shadow the row under `breeze_app` (the guard fires before authMiddleware
+  // sets a request-scoped context). The test exercises the same call shape.
+  withSystemDbAccessContext: <T>(fn: () => Promise<T>) => fn(),
 }));
 
 vi.mock('../db/schema', () => ({
@@ -98,5 +102,67 @@ describe('partnerGuard — fail closed (SR-005)', () => {
       headers: { Authorization: 'Bearer partner-token' },
     });
     expect(res.status).toBe(200);
+  });
+});
+
+// Regression: the production wrapper in `index.ts` previously did
+// `await partnerGuard(c, next);` without returning, which silently discarded
+// any Response the guard produced — Hono then threw "Context is not
+// finalized" and the request collapsed to 500. This suite exercises the same
+// wrapper shape used in `index.ts` to ensure that pattern can't sneak back in.
+describe('partnerGuard — wrapper shape (regression for #781 wrapper-discards-Response)', () => {
+  function makeWrapperApp() {
+    const app = new Hono();
+    // Mirrors `api.use('*', async (c, next) => { ...exempt paths...; return partnerGuard(c, next); })`
+    // from `apps/api/src/index.ts`. The `return` is the bit under test.
+    app.use('*', (c, next) => partnerGuard(c, next));
+    app.get('/protected', (c) => c.json({ ok: true }));
+    return app;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('propagates 403 PARTNER_NOT_FOUND through the wrapper instead of collapsing to 500', async () => {
+    vi.mocked(verifyToken).mockResolvedValueOnce({ partnerId: 'p-missing' } as never);
+    limitMock.mockResolvedValueOnce([]);
+    const res = await makeWrapperApp().request('/protected', {
+      headers: { Authorization: 'Bearer partner-token' },
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe('PARTNER_NOT_FOUND');
+  });
+
+  it('propagates 503 PARTNER_LOOKUP_UNAVAILABLE through the wrapper', async () => {
+    vi.mocked(verifyToken).mockResolvedValueOnce({ partnerId: 'p-1' } as never);
+    limitMock.mockRejectedValueOnce(new Error('db down'));
+    const res = await makeWrapperApp().request('/protected', {
+      headers: { Authorization: 'Bearer partner-token' },
+    });
+    expect(res.status).toBe(503);
+  });
+
+  it('propagates 403 PARTNER_INACTIVE through the wrapper', async () => {
+    vi.mocked(verifyToken).mockResolvedValueOnce({ partnerId: 'p-1' } as never);
+    limitMock.mockResolvedValueOnce([{ status: 'suspended', settings: {} }]);
+    const res = await makeWrapperApp().request('/protected', {
+      headers: { Authorization: 'Bearer partner-token' },
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe('PARTNER_INACTIVE');
+  });
+
+  it('lets through valid active-partner traffic and returns 200 from the downstream handler', async () => {
+    vi.mocked(verifyToken).mockResolvedValueOnce({ partnerId: 'p-1' } as never);
+    limitMock.mockResolvedValueOnce([{ status: 'active', settings: {} }]);
+    const res = await makeWrapperApp().request('/protected', {
+      headers: { Authorization: 'Bearer partner-token' },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok?: boolean };
+    expect(body.ok).toBe(true);
   });
 });

--- a/apps/api/src/middleware/partnerGuard.test.ts
+++ b/apps/api/src/middleware/partnerGuard.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../services/jwt', () => ({
+  verifyToken: vi.fn(),
+}));
+
+const limitMock = vi.fn();
+vi.mock('../db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: limitMock,
+        }),
+      }),
+    }),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  partners: { id: { name: 'id' }, status: { name: 'status' }, settings: { name: 'settings' } },
+}));
+
+import { Hono } from 'hono';
+import { partnerGuard } from './partnerGuard';
+import { verifyToken } from '../services/jwt';
+
+function makeApp() {
+  const app = new Hono();
+  app.use('*', partnerGuard);
+  app.get('/protected', (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe('partnerGuard — fail closed (SR-005)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes through when there is no Authorization header', async () => {
+    const res = await makeApp().request('/protected');
+    expect(res.status).toBe(200);
+  });
+
+  it('passes through when the token cannot be verified (non-first-party / OAuth token)', async () => {
+    vi.mocked(verifyToken).mockRejectedValueOnce(new Error('not a breeze jwt'));
+    const res = await makeApp().request('/protected', {
+      headers: { Authorization: 'Bearer oauth-token' },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('passes through when the verified token carries no partnerId', async () => {
+    vi.mocked(verifyToken).mockResolvedValueOnce({ partnerId: null } as never);
+    const res = await makeApp().request('/protected', {
+      headers: { Authorization: 'Bearer org-token' },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 503 when the partner DB lookup throws (was failing open)', async () => {
+    vi.mocked(verifyToken).mockResolvedValueOnce({ partnerId: 'p-1' } as never);
+    limitMock.mockRejectedValueOnce(new Error('connection terminated'));
+    const res = await makeApp().request('/protected', {
+      headers: { Authorization: 'Bearer partner-token' },
+    });
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe('PARTNER_LOOKUP_UNAVAILABLE');
+  });
+
+  it('returns 403 when the verified token references a partner that does not exist (was failing open)', async () => {
+    vi.mocked(verifyToken).mockResolvedValueOnce({ partnerId: 'p-missing' } as never);
+    limitMock.mockResolvedValueOnce([]);
+    const res = await makeApp().request('/protected', {
+      headers: { Authorization: 'Bearer partner-token' },
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe('PARTNER_NOT_FOUND');
+  });
+
+  it('returns 403 when the partner exists but is not active', async () => {
+    vi.mocked(verifyToken).mockResolvedValueOnce({ partnerId: 'p-1' } as never);
+    limitMock.mockResolvedValueOnce([{ status: 'suspended', settings: {} }]);
+    const res = await makeApp().request('/protected', {
+      headers: { Authorization: 'Bearer partner-token' },
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe('PARTNER_INACTIVE');
+  });
+
+  it('passes through when the partner exists and is active', async () => {
+    vi.mocked(verifyToken).mockResolvedValueOnce({ partnerId: 'p-1' } as never);
+    limitMock.mockResolvedValueOnce([{ status: 'active', settings: {} }]);
+    const res = await makeApp().request('/protected', {
+      headers: { Authorization: 'Bearer partner-token' },
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/api/src/middleware/partnerGuard.ts
+++ b/apps/api/src/middleware/partnerGuard.ts
@@ -39,14 +39,23 @@ export async function partnerGuard(c: Context, next: Next) {
       .where(eq(partners.id, partnerId))
       .limit(1);
   } catch (err) {
+    // Fail closed: this guard is a security + billing-control boundary. A
+    // verified token already proved a partnerId; if we cannot resolve that
+    // partner's status we must not let the request through. SR-005.
     console.error(`[PartnerGuard] DB lookup failed for partner ${partnerId}:`, err instanceof Error ? err.message : String(err));
-    await next();
-    return;
+    return c.json({
+      error: 'Account status temporarily unavailable',
+      code: 'PARTNER_LOOKUP_UNAVAILABLE',
+    }, 503);
   }
 
   if (!partner) {
-    await next();
-    return;
+    // A signature-verified token references a partner that no longer exists
+    // (deleted/purged). Fail closed rather than treating it as anonymous. SR-005.
+    return c.json({
+      error: 'Account not found',
+      code: 'PARTNER_NOT_FOUND',
+    }, 403);
   }
 
   if (partner.status !== 'active') {

--- a/apps/api/src/middleware/partnerGuard.ts
+++ b/apps/api/src/middleware/partnerGuard.ts
@@ -1,14 +1,13 @@
 import { Context, Next } from 'hono';
 import { eq } from 'drizzle-orm';
-import { db } from '../db';
+import { db, withSystemDbAccessContext } from '../db';
 import { partners } from '../db/schema';
 import { verifyToken } from '../services/jwt';
 
 export async function partnerGuard(c: Context, next: Next) {
   const authHeader = c.req.header('Authorization');
   if (!authHeader?.startsWith('Bearer ')) {
-    await next();
-    return;
+    return next();
   }
 
   const token = authHeader.slice(7);
@@ -19,25 +18,29 @@ export async function partnerGuard(c: Context, next: Next) {
     const payload = await verifyToken(token);
     partnerId = payload?.partnerId ?? null;
   } catch {
-    await next();
-    return;
+    return next();
   }
 
   if (!partnerId) {
-    await next();
-    return;
+    return next();
   }
 
   let partner;
   try {
-    [partner] = await db
-      .select({
-        status: partners.status,
-        settings: partners.settings,
-      })
-      .from(partners)
-      .where(eq(partners.id, partnerId))
-      .limit(1);
+    // Run under the system RLS context. This guard fires before authMiddleware
+    // has set a request-scoped context, so a bare `db` read of `partners`
+    // (which has partner-axis RLS) would return 0 rows under `breeze_app`
+    // and trigger PARTNER_NOT_FOUND for every authenticated request. SR-005.
+    [partner] = await withSystemDbAccessContext(() =>
+      db
+        .select({
+          status: partners.status,
+          settings: partners.settings,
+        })
+        .from(partners)
+        .where(eq(partners.id, partnerId!))
+        .limit(1),
+    );
   } catch (err) {
     // Fail closed: this guard is a security + billing-control boundary. A
     // verified token already proved a partnerId; if we cannot resolve that
@@ -70,5 +73,5 @@ export async function partnerGuard(c: Context, next: Next) {
     }, 403);
   }
 
-  await next();
+  return next();
 }

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -37,6 +37,7 @@ import {
   userRequiresSetup
 } from './helpers';
 import { assertPasswordAuthAllowedBySso, SsoPasswordAuthRequiredError } from './ssoPolicy';
+import { readMobileDeviceId, carryForwardBinding } from '../../services/mobileDeviceBinding';
 
 const { db, withSystemDbAccessContext } = dbModule;
 
@@ -207,7 +208,11 @@ loginRoutes.post('/login', zValidator('json', loginSchema), async (c) => {
     orgId,
     partnerId,
     scope,
-    mfa: mfaSatisfied
+    mfa: mfaSatisfied,
+    // SR-001: bind the token to the mobile install id when the client sends
+    // it. Web/SSO clients don't send the header → mdid stays absent → no
+    // behaviour change for them.
+    mdid: readMobileDeviceId(c) ?? undefined
   });
 
   // Update last login
@@ -344,7 +349,11 @@ loginRoutes.post('/refresh', async (c) => {
     orgId: context.orgId,
     partnerId: context.partnerId,
     scope: context.scope,
-    mfa: ENABLE_2FA ? payload.mfa : false
+    mfa: ENABLE_2FA ? payload.mfa : false,
+    // SR-001: preserve the device binding from the prior (signed) refresh
+    // token. Deliberately NOT re-read from the header — a refresh must not be
+    // able to drop the binding by omitting it.
+    mdid: carryForwardBinding(payload)
   });
 
   try {

--- a/apps/api/src/routes/auth/mfa.ts
+++ b/apps/api/src/routes/auth/mfa.ts
@@ -16,6 +16,7 @@ import {
   getRedis
 } from '../../services';
 import { getTwilioService } from '../../services/twilio';
+import { readMobileDeviceId } from '../../services/mobileDeviceBinding';
 import { authMiddleware } from '../../middleware/auth';
 import { ENABLE_2FA, mfaVerifySchema, mfaEnableSchema } from './schemas';
 import {
@@ -217,7 +218,9 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
       orgId: mfaOrgId,
       partnerId: mfaPartnerId,
       scope: mfaScope,
-      mfa: true
+      mfa: true,
+      // SR-001: bind to the mobile install id when present (MFA login path).
+      mdid: readMobileDeviceId(c) ?? undefined
     });
 
     // Update last login

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -17,7 +17,7 @@ import {
 } from '../../db/schema';
 import { authMiddleware, requireMfa, requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
-import { getPagination, getDeviceWithOrgCheck } from './helpers';
+import { getPagination, getDeviceWithOrgCheck, stripSensitiveDeviceFields } from './helpers';
 import { listDevicesSchema, updateDeviceSchema } from './schemas';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { resolveRemoteAccessForDevice } from '../../services/remoteAccessPolicy';
@@ -524,7 +524,7 @@ coreRoutes.get(
     }
 
     return c.json({
-      ...device,
+      ...stripSensitiveDeviceFields(device),
       hardware: hardware || null,
       networkInterfaces,
       recentMetrics,

--- a/apps/api/src/routes/devices/helpers.test.ts
+++ b/apps/api/src/routes/devices/helpers.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { stripSensitiveDeviceFields } from './helpers';
+
+// SR-008 (systemic twin): GET /devices/:id spreads the full device row to the
+// client. Credential verifiers + mTLS material must never reach any client,
+// even an authenticated same-tenant dashboard user.
+
+describe('stripSensitiveDeviceFields (SR-008)', () => {
+  const sensitive = {
+    agentTokenHash: 'a'.repeat(64),
+    previousTokenHash: 'b'.repeat(64),
+    watchdogTokenHash: 'c'.repeat(64),
+    previousWatchdogTokenHash: 'd'.repeat(64),
+    helperTokenHash: 'e'.repeat(64),
+    previousHelperTokenHash: 'f'.repeat(64),
+    tokenIssuedAt: new Date(),
+    watchdogTokenIssuedAt: new Date(),
+    helperTokenIssuedAt: new Date(),
+    previousTokenExpiresAt: new Date(),
+    previousWatchdogTokenExpiresAt: new Date(),
+    previousHelperTokenExpiresAt: new Date(),
+    mtlsCertSerialNumber: 'SERIAL123',
+    mtlsCertCfId: 'cf-cert-id',
+    mtlsCertExpiresAt: new Date(),
+    mtlsCertIssuedAt: new Date(),
+  };
+  const safe = {
+    id: 'dev-1',
+    orgId: 'org-1',
+    hostname: 'host-1',
+    status: 'online',
+    osType: 'linux',
+    customFields: { k: 'v' },
+  };
+
+  it('removes every credential verifier and mTLS field', () => {
+    const out = stripSensitiveDeviceFields({ ...safe, ...sensitive }) as Record<string, unknown>;
+    for (const key of Object.keys(sensitive)) {
+      expect(out).not.toHaveProperty(key);
+    }
+  });
+
+  it('preserves all non-sensitive operational fields', () => {
+    const out = stripSensitiveDeviceFields({ ...safe, ...sensitive }) as Record<string, unknown>;
+    expect(out).toEqual(safe);
+  });
+
+  it('does not mutate the input object (internal logic still needs the full row)', () => {
+    const input = { ...safe, ...sensitive };
+    stripSensitiveDeviceFields(input);
+    expect(input.agentTokenHash).toBe('a'.repeat(64));
+  });
+});

--- a/apps/api/src/routes/devices/helpers.ts
+++ b/apps/api/src/routes/devices/helpers.ts
@@ -5,6 +5,33 @@ import type { AuthContext } from '../../middleware/auth';
 
 export { getPagination } from '../../utils/pagination';
 
+/**
+ * SR-008 (systemic twin of the MCP breeze://devices/{id} leak): device-detail
+ * endpoints spread the full `devices` row to the client. These columns are
+ * credential verifiers / mTLS material and must never be serialized to any
+ * client. `getDeviceWithOrgCheck` still returns the full row so internal
+ * handler logic keeps working; strip only at the response boundary.
+ */
+const SENSITIVE_DEVICE_FIELDS = [
+  'agentTokenHash', 'tokenIssuedAt',
+  'previousTokenHash', 'previousTokenExpiresAt',
+  'watchdogTokenHash', 'watchdogTokenIssuedAt',
+  'previousWatchdogTokenHash', 'previousWatchdogTokenExpiresAt',
+  'helperTokenHash', 'helperTokenIssuedAt',
+  'previousHelperTokenHash', 'previousHelperTokenExpiresAt',
+  'mtlsCertSerialNumber', 'mtlsCertExpiresAt', 'mtlsCertIssuedAt', 'mtlsCertCfId',
+] as const;
+
+export function stripSensitiveDeviceFields<T extends Record<string, unknown>>(
+  device: T
+): Omit<T, (typeof SENSITIVE_DEVICE_FIELDS)[number]> {
+  const clone = { ...device };
+  for (const field of SENSITIVE_DEVICE_FIELDS) {
+    delete clone[field];
+  }
+  return clone;
+}
+
 export async function ensureOrgAccess(
   orgId: string,
   auth: Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds' | 'canAccessOrg'>

--- a/apps/api/src/routes/lifecycle.ts
+++ b/apps/api/src/routes/lifecycle.ts
@@ -53,10 +53,12 @@ const REVOKE_RATE_LIMIT = 10;
 const REVOKE_RATE_WINDOW_SECONDS = 60;
 
 // Header sent by the mobile app on every API call so we can identify which
-// paired device is making the call (and therefore detect "this device tried
-// to block itself" → 409 self-lockout protection, and "this device has been
-// blocked → 403 device_blocked").
-export const MOBILE_DEVICE_ID_HEADER = 'x-breeze-mobile-device-id';
+// paired device is making the call (used here only for self-lockout UX and
+// "is this the current device" hints — NOT a security boundary; see
+// services/mobileDeviceBinding.ts and SR-001). Re-exported from the canonical
+// low-dependency module so there is a single source of truth.
+import { MOBILE_DEVICE_ID_HEADER } from '../services/mobileDeviceBinding';
+export { MOBILE_DEVICE_ID_HEADER };
 
 const blockReasonSchema = z.object({
   reason: z.string().trim().max(500).optional(),

--- a/apps/api/src/routes/mcpServer.deviceProjection.test.ts
+++ b/apps/api/src/routes/mcpServer.deviceProjection.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { getTableColumns } from 'drizzle-orm';
+import { devices } from '../db/schema/devices';
+import {
+  SAFE_DEVICE_RESOURCE_FIELDS,
+  buildSafeDeviceProjection,
+} from './mcpServer';
+
+// SR-008: breeze://devices/{id} must never serialize credential verifiers or
+// mTLS material to an MCP/AI client. The projection is an explicit ALLOW-LIST
+// so any future column is excluded by default (fail-safe), not opt-out.
+
+const KNOWN_SENSITIVE_COLUMNS = [
+  'agentTokenHash',
+  'previousTokenHash',
+  'watchdogTokenHash',
+  'previousWatchdogTokenHash',
+  'helperTokenHash',
+  'previousHelperTokenHash',
+  'mtlsCertSerialNumber',
+  'mtlsCertCfId',
+  'mtlsCertExpiresAt',
+  'mtlsCertIssuedAt',
+  'agentId',
+];
+
+describe('SR-008 — safe device resource projection', () => {
+  const allColumns = Object.keys(getTableColumns(devices));
+
+  it('never includes any known sensitive/credential column', () => {
+    for (const sensitive of KNOWN_SENSITIVE_COLUMNS) {
+      expect(allColumns).toContain(sensitive); // guards against schema renames
+      expect(SAFE_DEVICE_RESOURCE_FIELDS).not.toContain(sensitive);
+    }
+  });
+
+  it('is an allow-list of real device columns only (no typos, fail-safe)', () => {
+    for (const field of SAFE_DEVICE_RESOURCE_FIELDS) {
+      expect(allColumns).toContain(field);
+    }
+  });
+
+  it('still exposes the operationally useful fields an AI client needs', () => {
+    for (const safe of ['id', 'hostname', 'status', 'osType', 'osVersion', 'lastSeenAt']) {
+      expect(SAFE_DEVICE_RESOURCE_FIELDS).toContain(safe);
+    }
+  });
+
+  it('buildSafeDeviceProjection returns only allow-listed columns', () => {
+    const projection = buildSafeDeviceProjection();
+    const keys = Object.keys(projection);
+    expect(new Set(keys)).toEqual(new Set(SAFE_DEVICE_RESOURCE_FIELDS));
+    for (const sensitive of KNOWN_SENSITIVE_COLUMNS) {
+      expect(keys).not.toContain(sensitive);
+    }
+  });
+});

--- a/apps/api/src/routes/mcpServer.ts
+++ b/apps/api/src/routes/mcpServer.ts
@@ -25,7 +25,7 @@ import { getToolDefinitions, executeTool, getToolTier } from '../services/aiTool
 import { checkGuardrails, checkToolPermission, checkToolRateLimit } from '../services/aiGuardrails';
 import { db, withSystemDbAccessContext } from '../db';
 import { devices, alerts, scripts, automations, partners, organizations, partnerUsers } from '../db/schema';
-import { eq, and, asc, desc, inArray, type SQL } from 'drizzle-orm';
+import { eq, and, asc, desc, inArray, getTableColumns, type SQL } from 'drizzle-orm';
 import type { PgColumn } from 'drizzle-orm/pg-core';
 import type { AuthContext } from '../middleware/auth';
 import { writeAuditEvent } from '../services/auditEvents';
@@ -1125,6 +1125,32 @@ function handleResourcesList(id: string | number): JsonRpcResponse {
 // ============================================
 
 /**
+ * SR-008: explicit ALLOW-LIST of `devices` columns safe to serialize into the
+ * `breeze://devices/{id}` MCP resource. An allow-list (not a deny-list) is
+ * deliberate — any column added to the schema in future is excluded by
+ * default, so a newly-introduced credential/secret column cannot silently
+ * leak to an AI/MCP client. Excludes: agent/watchdog/helper token hashes and
+ * their issued/expiry timestamps, mTLS certificate material/metadata, and the
+ * internal agentId.
+ */
+export const SAFE_DEVICE_RESOURCE_FIELDS = [
+  'id', 'orgId', 'siteId', 'hostname', 'displayName',
+  'osType', 'deviceRole', 'deviceRoleSource', 'osVersion', 'osBuild',
+  'architecture', 'agentVersion', 'status', 'lastSeenAt', 'enrolledAt',
+  'enrolledBy', 'tags', 'customFields', 'managementPosture', 'tccPermissions',
+  'desktopAccess', 'lastUser', 'uptimeSeconds', 'isHeadless', 'watchdogStatus',
+  'watchdogLastSeen', 'watchdogVersion', 'quarantinedAt', 'quarantinedReason',
+  'createdAt', 'updatedAt',
+] as const;
+
+export function buildSafeDeviceProjection() {
+  const cols = getTableColumns(devices);
+  return Object.fromEntries(
+    SAFE_DEVICE_RESOURCE_FIELDS.map((field) => [field, cols[field]])
+  ) as Pick<typeof cols, (typeof SAFE_DEVICE_RESOURCE_FIELDS)[number]>;
+}
+
+/**
  * Query a table with org-scoping and return a JSON-RPC resource result.
  */
 async function readOrgScopedResource(
@@ -1218,7 +1244,7 @@ async function handleResourcesRead(
       if (orgFilter) conditions.push(orgFilter);
 
       const [device] = await db
-        .select()
+        .select(buildSafeDeviceProjection())
         .from(devices)
         .where(and(...conditions))
         .limit(1);

--- a/apps/api/src/routes/mobile.test.ts
+++ b/apps/api/src/routes/mobile.test.ts
@@ -238,6 +238,81 @@ describe('mobile routes', () => {
 
       expect(res.status).toBe(400);
     });
+
+    it('returns 409 and does not upsert when deviceId belongs to another user (SR-002)', async () => {
+      // The auth mock authenticates user-123. An attacker in the same tenant
+      // POSTs the victim's deviceId. RLS lets the pre-check SELECT see the
+      // victim row; the handler must refuse rather than reassigning user_id.
+      vi.mocked(db.select).mockReturnValue(
+        mockSelectLimitChain([{ status: 'active', userId: 'victim-user-999' }]) as any
+      );
+      vi.mocked(db.insert).mockReturnValue(
+        mockInsertOnConflictReturning([{ id: 'stolen', deviceId: 'victim-device', platform: 'android' }]) as any
+      );
+
+      const res = await app.request('/mobile/devices', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          deviceId: 'victim-device',
+          platform: 'android',
+          fcmToken: 'attacker-fcm'
+        })
+      });
+
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.code).toBe('device_owned_by_other');
+      // Critically: no insert/upsert was attempted against the victim row.
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('still allows the owner to re-register their own existing device (SR-002 regression)', async () => {
+      vi.mocked(db.select).mockReturnValue(
+        mockSelectLimitChain([{ status: 'active', userId: 'user-123' }]) as any
+      );
+      vi.mocked(db.insert).mockReturnValue(
+        mockInsertOnConflictReturning([
+          { id: 'mobile-1', deviceId: 'device-123', platform: 'android', fcmToken: 'fcm-1' }
+        ]) as any
+      );
+
+      const res = await app.request('/mobile/devices', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          deviceId: 'device-123',
+          platform: 'android',
+          fcmToken: 'fcm-1'
+        })
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.deviceId).toBe('device-123');
+    });
+
+    it('returns 409 when the conflict upsert matches no owned row (race defense, SR-002)', async () => {
+      // No row visible at pre-check time, but the conflicting row turns out
+      // not to be owned by the caller → setWhere matches 0 rows → empty
+      // returning(). Must surface as 409, never a silent 201 with null body.
+      vi.mocked(db.select).mockReturnValue(mockSelectLimitChain([]) as any);
+      vi.mocked(db.insert).mockReturnValue(mockInsertOnConflictReturning([]) as any);
+
+      const res = await app.request('/mobile/devices', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          deviceId: 'raced-device',
+          platform: 'android',
+          fcmToken: 'fcm-1'
+        })
+      });
+
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.code).toBe('device_owned_by_other');
+    });
   });
 
   describe('PATCH /mobile/devices/:id/settings', () => {

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -336,14 +336,28 @@ mobileRoutes.post(
     if (data.osVersion !== undefined) updateSet.osVersion = data.osVersion;
     if (data.appVersion !== undefined) updateSet.appVersion = data.appVersion;
 
-    // Same blocked-row protection as /notifications/register: if a row
-    // exists for this deviceId in `blocked` state, salt the id so the
-    // re-pair lands in a fresh row.
+    // `device_id` is globally unique. Without an ownership guard the conflict
+    // path below would happily reassign another user's row to the caller
+    // (and RLS permits it for same-tenant callers). Refuse up front if the
+    // id is registered to anyone else — never touch a row we don't own. SR-002.
     const [existing] = await db
-      .select({ status: mobileDevices.status })
+      .select({ status: mobileDevices.status, userId: mobileDevices.userId })
       .from(mobileDevices)
       .where(eq(mobileDevices.deviceId, data.deviceId))
       .limit(1);
+    if (existing && existing.userId !== auth.user.id) {
+      return c.json(
+        {
+          error: 'This device is already registered to another account.',
+          code: 'device_owned_by_other',
+        },
+        409
+      );
+    }
+
+    // Same blocked-row protection as /notifications/register: if our own row
+    // for this deviceId is `blocked`, salt the id so the re-pair lands in a
+    // fresh row instead of reactivating the blocked one.
     const insertDeviceId = existing?.status === 'blocked'
       ? `${data.deviceId}-${now.getTime()}`
       : data.deviceId;
@@ -365,9 +379,25 @@ mobileRoutes.post(
       .onConflictDoUpdate({
         target: mobileDevices.deviceId,
         set: updateSet,
-        setWhere: sql`${mobileDevices.status} = 'active'`
+        // Defense-in-depth against a race between the ownership check above
+        // and this upsert: the update can only ever touch an active row the
+        // caller already owns. A foreign/blocked row yields 0 updated rows.
+        setWhere: sql`${mobileDevices.status} = 'active' AND ${mobileDevices.userId} = ${auth.user.id}`
       })
       .returning();
+
+    if (!device) {
+      // Conflict fired but the owned-and-active guard matched no row — the id
+      // was taken by another user between the check and the upsert. Never
+      // fall through to a 201 with a null body.
+      return c.json(
+        {
+          error: 'This device is already registered to another account.',
+          code: 'device_owned_by_other',
+        },
+        409
+      );
+    }
 
     writeRouteAudit(c, {
       orgId: auth.orgId,

--- a/apps/api/src/services/expoPush.test.ts
+++ b/apps/api/src/services/expoPush.test.ts
@@ -144,6 +144,61 @@ describe('sendExpoPush', () => {
     expect(nullSets.length).toBeGreaterThanOrEqual(2);
   });
 
+  it('does not log the full Expo push token on ticket error (SR-004)', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const secretToken = 'ExponentPushToken[SUPERSECRETPUSHADDRESS12345]';
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            status: 'error',
+            message: 'too many',
+            details: { error: 'MessageRateExceeded' },
+          },
+        ],
+      }),
+    } as unknown as Response);
+
+    await sendExpoPush([{ to: secretToken, title: 't', body: 'b' }]);
+
+    expect(errSpy).toHaveBeenCalled();
+    const logged = JSON.stringify(errSpy.mock.calls);
+    // The raw, reusable push address must never appear in logs.
+    expect(logged).not.toContain(secretToken);
+    expect(logged).not.toContain('SUPERSECRETPUSHADDRESS12345');
+    // A redacted reference (last-4 suffix) is still useful for correlation.
+    expect(logged).toContain('345]');
+    errSpy.mockRestore();
+  });
+
+  it('still clears DeviceNotRegistered tokens using the full token despite redacted logging (SR-004)', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const deadToken = 'ExponentPushToken[DEADTOKENFULLVALUE99999]';
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            status: 'error',
+            message: 'gone',
+            details: { error: 'DeviceNotRegistered' },
+          },
+        ],
+      }),
+    } as unknown as Response);
+
+    await sendExpoPush([{ to: deadToken, title: 't', body: 'b' }]);
+
+    // DB cleanup must still receive the FULL token (matching the stored column).
+    const fullTokenUsed = updateWhereCalls.length > 0;
+    expect(fullTokenUsed).toBe(true);
+    // But the log must not contain it.
+    const logged = JSON.stringify(errSpy.mock.calls);
+    expect(logged).not.toContain(deadToken);
+    errSpy.mockRestore();
+  });
+
   it('logs but does not mark inactive on non-DeviceNotRegistered ticket errors', async () => {
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({

--- a/apps/api/src/services/expoPush.ts
+++ b/apps/api/src/services/expoPush.ts
@@ -5,6 +5,19 @@ import { and, eq } from 'drizzle-orm';
 const EXPO_PUSH_URL = 'https://exp.host/--/api/v2/push/send';
 const MAX_LABEL_LEN = 60;
 
+/**
+ * Expo push tokens are bearer-like device addresses: anyone holding one can
+ * POST unsolicited notifications to that device via the unauthenticated Expo
+ * push API. Never log them in full. We keep only a short trailing suffix so a
+ * leaked log line still allows correlation with the DB row but is not a usable
+ * push address on its own. SR-004.
+ */
+export function redactPushToken(token: string | undefined): string {
+  if (!token) return '<none>';
+  if (token.length <= 4) return '****';
+  return `…${token.slice(-4)}`;
+}
+
 export interface ExpoPushMessage {
   to: string;
   title: string;
@@ -59,7 +72,7 @@ async function handleTicketErrors(
         ? (ticket.details as { error?: string }).error
         : undefined;
     console.error('[expoPush] ticket error', {
-      token,
+      token: redactPushToken(token),
       message: ticket.message,
       code,
     });

--- a/apps/api/src/services/jwt.test.ts
+++ b/apps/api/src/services/jwt.test.ts
@@ -88,6 +88,25 @@ describe('jwt service', () => {
     });
   });
 
+  describe('mobile device binding claim (mdid) — SR-001', () => {
+    it('round-trips an mdid claim through an access token', async () => {
+      const token = await createAccessToken({ ...testPayload, mdid: 'install-abc-123' });
+      const decoded = await verifyToken(token);
+      expect(decoded?.mdid).toBe('install-abc-123');
+    });
+
+    it('round-trips an mdid claim through a refresh token', async () => {
+      const token = await createRefreshToken({ ...testPayload, mdid: 'install-abc-123' });
+      const decoded = await verifyToken(token);
+      expect(decoded?.mdid).toBe('install-abc-123');
+    });
+
+    it('leaves mdid undefined when not bound (web / MCP / OAuth tokens)', async () => {
+      const decoded = await verifyToken(await createAccessToken(testPayload));
+      expect(decoded?.mdid).toBeUndefined();
+    });
+  });
+
   describe('createTokenPair', () => {
     it('should create both access and refresh tokens', async () => {
       const result = await createTokenPair(testPayload);

--- a/apps/api/src/services/jwt.ts
+++ b/apps/api/src/services/jwt.ts
@@ -32,6 +32,11 @@ export interface TokenPayload {
   // Indicates whether this token was issued after completing MFA.
   // For legacy tokens that predate this claim, verification defaults this to false.
   mfa: boolean;
+  // Mobile device binding (SR-001). Set only on tokens minted for the mobile
+  // app, to the per-install device id. Absent on web/MCP/OAuth/agent tokens.
+  // The lost-phone block is enforced against this SIGNED value, never a
+  // client-supplied header (which is spoofable / omittable).
+  mdid?: string;
   iat?: number;
   jti?: string;
 }
@@ -88,6 +93,7 @@ export async function verifyToken(token: string): Promise<TokenPayload | null> {
       scope: payload.scope as 'system' | 'partner' | 'organization',
       type: payload.type as 'access' | 'refresh',
       mfa: payload.mfa === true,
+      mdid: typeof payload.mdid === 'string' && payload.mdid.length > 0 ? payload.mdid : undefined,
       iat: typeof payload.iat === 'number' ? payload.iat : undefined,
       jti: typeof payload.jti === 'string' ? payload.jti : undefined
     };

--- a/apps/api/src/services/mobileDeviceBinding.test.ts
+++ b/apps/api/src/services/mobileDeviceBinding.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MOBILE_DEVICE_ID_HEADER,
+  normalizeDeviceId,
+  readMobileDeviceId,
+  carryForwardBinding,
+} from './mobileDeviceBinding';
+
+describe('mobileDeviceBinding helpers (SR-001)', () => {
+  describe('normalizeDeviceId', () => {
+    it('returns null for empty / whitespace / missing', () => {
+      expect(normalizeDeviceId(undefined)).toBeNull();
+      expect(normalizeDeviceId(null)).toBeNull();
+      expect(normalizeDeviceId('')).toBeNull();
+      expect(normalizeDeviceId('   ')).toBeNull();
+    });
+    it('trims and returns a valid id', () => {
+      expect(normalizeDeviceId('  install-123  ')).toBe('install-123');
+    });
+    it('rejects ids longer than 255 chars', () => {
+      expect(normalizeDeviceId('a'.repeat(256))).toBeNull();
+      expect(normalizeDeviceId('a'.repeat(255))).toBe('a'.repeat(255));
+    });
+  });
+
+  describe('readMobileDeviceId', () => {
+    const ctx = (headers: Record<string, string>) =>
+      ({ req: { header: (k: string) => headers[k] ?? headers[k.toUpperCase()] } }) as never;
+
+    it('reads the lowercase header', () => {
+      expect(readMobileDeviceId(ctx({ [MOBILE_DEVICE_ID_HEADER]: 'dev-1' }))).toBe('dev-1');
+    });
+    it('returns null when header absent', () => {
+      expect(readMobileDeviceId(ctx({}))).toBeNull();
+    });
+  });
+
+  describe('carryForwardBinding', () => {
+    it('preserves a prior token binding (refresh keeps the device bound)', () => {
+      expect(carryForwardBinding({ mdid: 'install-123' })).toBe('install-123');
+    });
+    it('returns undefined when the prior token was not bound', () => {
+      expect(carryForwardBinding({})).toBeUndefined();
+      expect(carryForwardBinding({ mdid: '' })).toBeUndefined();
+    });
+    it('ignores everything except the prior mdid — a refresh cannot introduce a new binding', () => {
+      // Only the previously-signed value matters; there is no header input here
+      // by design, so an attacker cannot un-bind by omitting a header on refresh.
+      expect(carryForwardBinding({ mdid: 'bound-old' })).toBe('bound-old');
+    });
+  });
+});

--- a/apps/api/src/services/mobileDeviceBinding.ts
+++ b/apps/api/src/services/mobileDeviceBinding.ts
@@ -1,0 +1,41 @@
+import type { Context } from 'hono';
+
+/**
+ * Header the mobile app sends on every request carrying its per-install id.
+ *
+ * SECURITY NOTE (SR-001): this header is client-controlled — it can be
+ * omitted or forged. It must NEVER be the sole basis for a server-side
+ * revocation/lockout decision. The authoritative device identity is the
+ * signed `mdid` JWT claim (see services/jwt.ts). The header is retained only
+ * as a migration fallback for tokens minted before binding existed, and for
+ * pre-auth UX hints.
+ */
+export const MOBILE_DEVICE_ID_HEADER = 'x-breeze-mobile-device-id';
+
+const MAX_DEVICE_ID_LEN = 255;
+
+/** Trim + length-validate a candidate device id. Returns null when unusable. */
+export function normalizeDeviceId(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0 || trimmed.length > MAX_DEVICE_ID_LEN) return null;
+  return trimmed;
+}
+
+/** Read + normalize the per-install device id from the request header. */
+export function readMobileDeviceId(c: Context): string | null {
+  const raw =
+    c.req.header(MOBILE_DEVICE_ID_HEADER) ??
+    c.req.header(MOBILE_DEVICE_ID_HEADER.toUpperCase());
+  return normalizeDeviceId(raw);
+}
+
+/**
+ * The `mdid` value to carry into a re-minted token on refresh. It is ALWAYS
+ * derived from the previously-signed token, never the request header — so a
+ * bound mobile session cannot be silently un-bound by omitting the header on
+ * a refresh call (which would otherwise re-open the SR-001 bypass).
+ */
+export function carryForwardBinding(previous: { mdid?: string | null }): string | undefined {
+  return previous.mdid && previous.mdid.length > 0 ? previous.mdid : undefined;
+}

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -275,7 +275,7 @@ services:
       --min-port=49152
       --max-port=65535
       --no-cli
-      --static-auth-secret=${TURN_SECRET:-}
+      --static-auth-secret=${TURN_SECRET:?TURN_SECRET must be set (openssl rand -hex 32) when the turn profile is enabled}
       --realm=${TURN_REALM:-breeze.local}
       --external-ip=${TURN_HOST:-}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -282,7 +282,7 @@ services:
       --min-port=49152
       --max-port=65535
       --no-cli
-      --static-auth-secret=${TURN_SECRET:-}
+      --static-auth-secret=${TURN_SECRET:?TURN_SECRET must be set (openssl rand -hex 32) when the turn profile is enabled}
       --realm=${TURN_REALM:-breeze.local}
       --external-ip=${TURN_HOST:-}
 

--- a/scripts/security/check-relay-edge-hardening.sh
+++ b/scripts/security/check-relay-edge-hardening.sh
@@ -35,6 +35,19 @@ for file in docker/turnserver.conf docker-compose.yml deploy/docker-compose.prod
   require_grep 'no-multicast-peers|--no-multicast-peers' "$file" "$file must deny multicast TURN peers"
 done
 
+# SR-009: coturn must fail closed if TURN_SECRET is unset/empty. An empty
+# REST shared secret makes TURN credentials trivially forgeable (open relay).
+# Require the fail-closed `${TURN_SECRET:?...}` form and reject the silent
+# empty-default `${TURN_SECRET:-}` / bare `${TURN_SECRET}` forms.
+for file in docker-compose.yml deploy/docker-compose.prod.yml; do
+  reject_grep 'static-auth-secret=\$\{TURN_SECRET:-' "$file" \
+    "$file: TURN static-auth-secret must fail closed (\${TURN_SECRET:?...}), not default to empty (\${TURN_SECRET:-})"
+  reject_grep 'static-auth-secret=\$\{TURN_SECRET\}' "$file" \
+    "$file: TURN static-auth-secret must fail closed (\${TURN_SECRET:?...}), not use a bare \${TURN_SECRET}"
+  require_grep 'static-auth-secret=\$\{TURN_SECRET:\?' "$file" \
+    "$file: TURN static-auth-secret must use the fail-closed \${TURN_SECRET:?...} form"
+done
+
 reject_grep 'trusted_proxies[[:space:]]+static[[:space:]]+private_ranges' docker/Caddyfile.prod \
   "Caddy must not trust all private ranges as proxy hops"
 require_grep 'CADDY_TRUSTED_PROXIES' docker/Caddyfile.prod \

--- a/scripts/security/check-supply-chain-hardening.sh
+++ b/scripts/security/check-supply-chain-hardening.sh
@@ -31,6 +31,16 @@ if [[ -e docker-compose.override.yml ]]; then
   fail "docker-compose.override.yml must not exist; Docker Compose auto-loads it and can weaken production defaults"
 fi
 
+# SR-007: workflows that build/publish artifacts must declare a top-level
+# (workflow-global) least-privilege `permissions:` block so build jobs don't
+# inherit the repo/org default GITHUB_TOKEN scopes. Jobs needing more (release
+# publish, GHCR push, OIDC signing) override per-job. A column-0 `permissions:`
+# is the workflow-global one; per-job blocks are indented.
+require_grep '^permissions:' .github/workflows/release.yml \
+  "release workflow must declare a top-level least-privilege permissions: block (SR-007)"
+require_grep '^permissions:' .github/workflows/ci.yml \
+  "CI workflow must declare a top-level least-privilege permissions: block (SR-007)"
+
 require_grep '^  release-integrity-gate:' .github/workflows/release.yml \
   "release workflow must include release-integrity-gate"
 require_grep 'needs: .*release-integrity-gate' .github/workflows/release.yml \


### PR DESCRIPTION
## Summary

Verification + fixes for the findings in `security_best_practices_report.md`. Each finding was **verified against real code before fixing** (parallel subagents); several of the report's severities were adjusted. All fixes are test-driven.

- **SR-001 (High)** — Mobile lost-phone lockout was bypassable by omitting/spoofing the `X-Breeze-Mobile-Device-Id` header (mobile reused standard JWTs with no device binding). Added a signed `mdid` JWT claim + `services/mobileDeviceBinding.ts`. Enforcement now keys off the **signed claim scoped by device_id + user_id**; the header is a legacy-migration fallback only. Bound at login/MFA mint; carried forward (never header-re-read) on refresh so a refresh can't drop the binding.
- **SR-002 (Med)** — `POST /api/v1/mobile/devices` upsert could reassign another same-tenant user's device row. Added ownership guard (→ `409 device_owned_by_other`) + tightened conflict `setWhere` to `status='active' AND user_id=<caller>` (race defense).
- **SR-004 (Low)** — Expo push token redacted in ticket-error logs (last-4 suffix); full token still used for the DB dead-token cleanup.
- **SR-005 (Low)** — `partnerGuard` now fails **closed**: `503` on DB lookup error, `403` on missing partner for a verified token. Pass-through preserved for no-token / unverifiable (OAuth) / no-partnerId.
- **SR-007 (Med)** — Added top-level least-privilege `permissions: contents: read` to `release.yml` and `ci.yml` (per-job overrides for the 6 privileged release jobs already existed). Codified via `check-supply-chain-hardening.sh`.
- **SR-008 (Med)** — MCP `breeze://devices/{id}` now serializes a **fail-safe column allow-list** instead of the full row (was leaking agent/watchdog/helper token hashes + mTLS metadata). REST `GET /devices/:id` strips the same columns (systemic twin). Note: the leaked hashes are one-way verifiers, not auth-usable.
- **SR-009 (Med)** — coturn `--static-auth-secret` fails closed (`${TURN_SECRET:?...}`) in both compose files (was `${TURN_SECRET:-}`, silently empty). Codified via `check-relay-edge-hardening.sh`.

### Intentionally not in this PR
- **SR-003** — Verification showed it's by-design/unreachable (`active→pending` regression doesn't exist in code; consent-time gate + refresh re-check already block it). No change.
- **SR-006** — Deferred; needs a design decision (the real gap is the dashboard/docs Linux one-liner being TLS-only, distinct from the `install.sh` path).

## Test plan
- TDD throughout (RED → GREEN per fix). New tests: `jwt`, `mobileDeviceBinding`, `mobileDeviceBlocked`, `partnerGuard`, `mobile` (SR-002), `expoPush` (SR-004), `mcpServer.deviceProjection`, `devices/helpers`.
- ~230 affected + regression tests pass (services, middleware, mobile, MCP, devices routes, auth routes, lifecycle).
- `tsc --noEmit` clean. `check-supply-chain-hardening.sh` and `check-relay-edge-hardening.sh` pass (both gained regression rules for SR-007/SR-009).

🤖 Generated with [Claude Code](https://claude.com/claude-code)