### PR TITLE
feat(devices): bulk Wake-on-LAN (Discussion #694 follow-up)

### DIFF
--- a/apps/api/src/routes/devices/commands.test.ts
+++ b/apps/api/src/routes/devices/commands.test.ts
@@ -66,10 +66,19 @@ vi.mock('../../services/auditEvents', () => ({
   writeRouteAudit: vi.fn()
 }));
 
+vi.mock('../../services/wakeOnLan', () => ({
+  dispatchWake: vi.fn(),
+}));
+
+vi.mock('../../services/clientIp', () => ({
+  getTrustedClientIpOrUndefined: vi.fn(() => '127.0.0.1'),
+}));
+
 import { commandsRoutes } from './commands';
 import { db } from '../../db';
 import { getDeviceWithOrgCheck } from './helpers';
 import { writeRouteAudit } from '../../services/auditEvents';
+import { dispatchWake } from '../../services/wakeOnLan';
 
 describe('device commands routes', () => {
   let app: Hono;
@@ -132,6 +141,172 @@ describe('device commands routes', () => {
       const body = await res.json();
       expect(body.error).toContain('scripts endpoint');
       expect(vi.mocked(getDeviceWithOrgCheck)).not.toHaveBeenCalled();
+    });
+
+    describe('bulk-wake (type=wake)', () => {
+      const onlineDevice = (id: string) =>
+        ({ id, orgId: 'org-123', status: 'online', hostname: `host-${id.slice(0, 4)}` } as never);
+
+      it('iterates dispatchWake per device and returns per-device outcomes with a shared bulkId', async () => {
+        // 3 devices: 2 wake-able, 1 with no relay
+        vi.mocked(getDeviceWithOrgCheck)
+          .mockResolvedValueOnce(onlineDevice('11111111-1111-1111-1111-111111111111'))
+          .mockResolvedValueOnce(onlineDevice('22222222-2222-2222-2222-222222222222'))
+          .mockResolvedValueOnce(onlineDevice('33333333-3333-3333-3333-333333333333'));
+
+        vi.mocked(dispatchWake)
+          .mockResolvedValueOnce({
+            ok: true,
+            commandId: 'cmd-1',
+            wakeAttemptId: 'wake-1',
+            targetDeviceId: '11111111-1111-1111-1111-111111111111',
+            targetHostname: 'host-1111',
+            relayDeviceId: 'relay-1',
+            relayHostname: 'relay-host-1',
+            network: '10.10.10.0',
+            broadcast: '10.10.10.255',
+            maskSource: 'agent',
+            macs: ['aa:bb:cc:dd:ee:01'],
+          })
+          .mockResolvedValueOnce({
+            ok: false,
+            code: 'NO_RELAY',
+            message: 'No online peer agent is available at the target\'s site and subnet to relay the Wake-on-LAN packet.',
+          })
+          .mockResolvedValueOnce({
+            ok: true,
+            commandId: 'cmd-3',
+            wakeAttemptId: 'wake-3',
+            targetDeviceId: '33333333-3333-3333-3333-333333333333',
+            targetHostname: 'host-3333',
+            relayDeviceId: 'relay-2',
+            relayHostname: 'relay-host-2',
+            network: '10.10.20.0',
+            broadcast: '10.10.20.255',
+            maskSource: 'agent',
+            macs: ['aa:bb:cc:dd:ee:03'],
+          });
+
+        const res = await app.request('/devices/bulk/commands', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+          body: JSON.stringify({
+            deviceIds: [
+              '11111111-1111-1111-1111-111111111111',
+              '22222222-2222-2222-2222-222222222222',
+              '33333333-3333-3333-3333-333333333333',
+            ],
+            type: 'wake',
+          }),
+        });
+
+        expect(res.status).toBe(202);
+        const body = await res.json();
+        expect(body.bulkId).toMatch(/^[0-9a-f-]{36}$/);
+        expect(body.succeeded).toHaveLength(2);
+        expect(body.failed).toHaveLength(1);
+        expect(body.failed[0]).toMatchObject({
+          deviceId: '22222222-2222-2222-2222-222222222222',
+          code: 'NO_RELAY',
+        });
+
+        // Every dispatchWake call received the same bulkId so audit
+        // rows can be correlated to one user click.
+        const calls = vi.mocked(dispatchWake).mock.calls;
+        expect(calls).toHaveLength(3);
+        const bulkIds = new Set(calls.map(([, , opts]) => (opts as any).bulkId));
+        expect(bulkIds.size).toBe(1);
+        expect(bulkIds.has(body.bulkId)).toBe(true);
+      });
+
+      it('returns DECOMMISSIONED for decommissioned devices without calling dispatchWake', async () => {
+        vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce(
+          { id: '11111111-1111-1111-1111-111111111111', orgId: 'org-123', status: 'decommissioned', hostname: 'host-1111' } as never,
+        );
+
+        const res = await app.request('/devices/bulk/commands', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+          body: JSON.stringify({
+            deviceIds: ['11111111-1111-1111-1111-111111111111'],
+            type: 'wake',
+          }),
+        });
+
+        expect(res.status).toBe(202);
+        const body = await res.json();
+        expect(body.succeeded).toHaveLength(0);
+        expect(body.failed).toEqual([
+          {
+            deviceId: '11111111-1111-1111-1111-111111111111',
+            code: 'DECOMMISSIONED',
+            message: 'Cannot wake a decommissioned device.',
+          },
+        ]);
+        expect(vi.mocked(dispatchWake)).not.toHaveBeenCalled();
+      });
+
+      it('returns TARGET_NOT_FOUND when getDeviceWithOrgCheck filters out a cross-org device', async () => {
+        // null = either not found OR partner-scope access denied. Either way,
+        // partner-scope safety: dispatchWake is never invoked.
+        vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce(null as never);
+
+        const res = await app.request('/devices/bulk/commands', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+          body: JSON.stringify({
+            deviceIds: ['11111111-1111-1111-1111-111111111111'],
+            type: 'wake',
+          }),
+        });
+
+        expect(res.status).toBe(202);
+        const body = await res.json();
+        expect(body.failed[0]).toMatchObject({
+          deviceId: '11111111-1111-1111-1111-111111111111',
+          code: 'TARGET_NOT_FOUND',
+        });
+        expect(vi.mocked(dispatchWake)).not.toHaveBeenCalled();
+      });
+
+      it('schema rejects deviceIds.length > 500 (BULK_COMMAND_MAX_DEVICES cap)', async () => {
+        const tooManyIds = Array.from({ length: 501 }, (_, i) => {
+          const hex = i.toString(16).padStart(12, '0');
+          return `00000000-0000-0000-0000-${hex}`;
+        });
+        const res = await app.request('/devices/bulk/commands', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+          body: JSON.stringify({ deviceIds: tooManyIds, type: 'wake' }),
+        });
+        expect(res.status).toBe(400);
+        expect(vi.mocked(getDeviceWithOrgCheck)).not.toHaveBeenCalled();
+        expect(vi.mocked(dispatchWake)).not.toHaveBeenCalled();
+      });
+
+      it('schema accepts type=wake', async () => {
+        // Sanity check that the enum is in fact extended; the dispatchWake
+        // path is mocked to a single failure to avoid setting up successful
+        // returns — we only care that validation passes.
+        vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce(
+          onlineDevice('11111111-1111-1111-1111-111111111111'),
+        );
+        vi.mocked(dispatchWake).mockResolvedValueOnce({
+          ok: false,
+          code: 'NO_MACS',
+          message: 'no mac',
+        });
+
+        const res = await app.request('/devices/bulk/commands', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+          body: JSON.stringify({
+            deviceIds: ['11111111-1111-1111-1111-111111111111'],
+            type: 'wake',
+          }),
+        });
+        expect(res.status).toBe(202);
+      });
     });
   });
 

--- a/apps/api/src/routes/devices/commands.ts
+++ b/apps/api/src/routes/devices/commands.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { eq, sql, desc, and } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
 import { db } from '../../db';
 import { deviceCommands, devices } from '../../db/schema';
 import { authMiddleware, requireMfa, requireScope, requirePermission } from '../../middleware/auth';
@@ -10,7 +11,7 @@ import { getPagination, getDeviceWithOrgCheck } from './helpers';
 import { createCommandSchema, bulkCommandSchema, maintenanceModeSchema } from './schemas';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { commandAuditDetails, sanitizeCommandForHistory } from '../../services/commandAudit';
-import { dispatchWake } from '../../services/wakeOnLan';
+import { dispatchWake, type WakeFailureCode } from '../../services/wakeOnLan';
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
 
 export const commandsRoutes = new Hono();
@@ -39,6 +40,85 @@ commandsRoutes.post(
       return c.json({ error: 'Script commands must be executed through the scripts endpoint' }, 400);
     }
 
+    const deviceIds = [...new Set(data.deviceIds)];
+
+    // Wake-on-LAN takes a separate path from the generic device_commands
+    // insertion: each device needs a relay picked on its LAN, the command
+    // row is addressed to that relay (not the offline target), and the
+    // dispatch result includes per-device failure codes (NO_RELAY,
+    // NO_MACS, etc.) that the UI surfaces in a grouped summary. See
+    // services/wakeOnLan.ts + Discussion #694.
+    if (data.type === 'wake') {
+      const bulkId = randomUUID();
+      const succeeded: Array<{
+        deviceId: string;
+        commandId: string;
+        wakeAttemptId: string;
+        relayDeviceId: string;
+        relayHostname: string;
+        broadcast: string;
+      }> = [];
+      const failed: Array<{
+        deviceId: string;
+        code: WakeFailureCode | 'DECOMMISSIONED' | 'TARGET_NOT_FOUND';
+        message: string;
+      }> = [];
+      const ipAddress = getTrustedClientIpOrUndefined(c);
+      const userAgent = c.req.header('user-agent');
+
+      // Inline worker pool. dispatchWake does 5-7 DB selects + 2 inserts +
+      // 1 update + 1 WS write per device (no locks/transactions per
+      // services/wakeOnLan.ts). Concurrency 8 caps overlap on the
+      // breeze_app pool (~10-20 conns) and keeps wall time on a 500-device
+      // bulk well under Cloudflare's ~100s proxy timeout. Avoided a
+      // p-limit dependency by inlining — the loop is trivial.
+      const CONCURRENCY = 8;
+      const queue = [...deviceIds];
+      async function worker(): Promise<void> {
+        for (;;) {
+          const deviceId = queue.shift();
+          if (!deviceId) return;
+          // Per-device authorization — partner-scope filtering happens in
+          // getDeviceWithOrgCheck (helpers.ts). dispatchWake itself does
+          // NOT independently authorize the caller, so this gate must run
+          // before the wake dispatches.
+          const device = await getDeviceWithOrgCheck(deviceId, auth);
+          if (!device) {
+            failed.push({ deviceId, code: 'TARGET_NOT_FOUND', message: 'Device not found or access denied.' });
+            continue;
+          }
+          if (device.status === 'decommissioned') {
+            failed.push({ deviceId, code: 'DECOMMISSIONED', message: 'Cannot wake a decommissioned device.' });
+            continue;
+          }
+          const result = await dispatchWake(deviceId, auth.user.id, {
+            ipAddress,
+            userAgent,
+            bulkId,
+          });
+          if (result.ok) {
+            succeeded.push({
+              deviceId,
+              commandId: result.commandId,
+              wakeAttemptId: result.wakeAttemptId,
+              relayDeviceId: result.relayDeviceId,
+              relayHostname: result.relayHostname,
+              broadcast: result.broadcast,
+            });
+          } else {
+            failed.push({ deviceId, code: result.code, message: result.message });
+          }
+        }
+      }
+      const workers = Array.from(
+        { length: Math.min(CONCURRENCY, deviceIds.length) },
+        () => worker(),
+      );
+      await Promise.all(workers);
+
+      return c.json({ bulkId, succeeded, failed }, 202);
+    }
+
     const commandList: Array<{
       id: string;
       deviceId: string;
@@ -47,7 +127,6 @@ commandsRoutes.post(
       createdAt: Date;
     }> = [];
     const failed: string[] = [];
-    const deviceIds = [...new Set(data.deviceIds)];
 
     for (const deviceId of deviceIds) {
       const device = await getDeviceWithOrgCheck(deviceId, auth);

--- a/apps/api/src/routes/devices/schemas.ts
+++ b/apps/api/src/routes/devices/schemas.ts
@@ -48,9 +48,18 @@ export const createCommandSchema = z.object({
   payload: z.any().optional()
 });
 
+/**
+ * Per-request cap on bulk command operations. 500 keeps the worst-case
+ * wall time well under Cloudflare's ~100s proxy timeout (HTTP 524) even
+ * if a future bulk type ends up serial — at the inline 8-worker pool
+ * used by the bulk-wake path, 500 devices completes in single-digit
+ * seconds. Caps DoS risk from an auth'd caller passing a giant array.
+ */
+export const BULK_COMMAND_MAX_DEVICES = 500;
+
 export const bulkCommandSchema = z.object({
-  deviceIds: z.array(z.string().uuid()).min(1),
-  type: z.enum(['script', 'reboot', 'reboot_safe_mode', 'shutdown', 'update', 'collect_evidence', 'execute_containment']),
+  deviceIds: z.array(z.string().uuid()).min(1).max(BULK_COMMAND_MAX_DEVICES),
+  type: z.enum(['script', 'reboot', 'reboot_safe_mode', 'shutdown', 'update', 'collect_evidence', 'execute_containment', 'wake']),
   payload: z.any().optional()
 });
 

--- a/apps/api/src/services/wakeOnLan.ts
+++ b/apps/api/src/services/wakeOnLan.ts
@@ -248,6 +248,10 @@ interface DispatchWakeOptions {
   ipAddress?: string;
   /** User-Agent of the request (for the audit row). */
   userAgent?: string;
+  /** Correlation id when invoked from a bulk endpoint. Stamped onto the audit row's
+   *  details so ops can group N per-device wake audit entries to a single bulk click.
+   *  Undefined for single-device wake (audit row carries no bulkId field). */
+  bulkId?: string;
 }
 
 export async function dispatchWake(
@@ -365,6 +369,7 @@ export async function dispatchWake(
       maskSource: subnet.maskSource,
       macs,
       relayOverride: Boolean(options.relayDeviceIdOverride),
+      ...(options.bulkId ? { bulkId: options.bulkId } : {}),
     },
     ipAddress: options.ipAddress,
     userAgent: options.userAgent,

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -590,6 +590,14 @@ export default function DeviceList({
                 <hr className="my-1" />
                 <button
                   type="button"
+                  onClick={() => handleBulkAction('wake')}
+                  className="w-full px-4 py-2 text-left text-sm hover:bg-muted"
+                >
+                  Wake Selected
+                </button>
+                <hr className="my-1" />
+                <button
+                  type="button"
                   onClick={() => handleBulkAction('decommission')}
                   className="w-full px-4 py-2 text-left text-sm text-destructive hover:bg-destructive/10"
                 >

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -12,7 +12,7 @@ import AddDeviceModal from './AddDeviceModal';
 import CreateGroupModal from './CreateGroupModal';
 import { DeviceFilterBar } from '../filters/DeviceFilterBar';
 import { fetchWithAuth } from '../../stores/auth';
-import { sendDeviceCommand, sendBulkCommand, executeScript, toggleMaintenanceMode, decommissionDevice, bulkDecommissionDevices, restoreDevice, permanentDeleteDevice, sendWakeCommand, WakeCommandError, wakeFriendlyErrorMessage } from '../../services/deviceActions';
+import { sendDeviceCommand, sendBulkCommand, executeScript, toggleMaintenanceMode, decommissionDevice, bulkDecommissionDevices, restoreDevice, permanentDeleteDevice, sendWakeCommand, sendBulkWakeCommand, summarizeBulkWakeFailures, WakeCommandError, wakeFriendlyErrorMessage } from '../../services/deviceActions';
 import { navigateTo } from '@/lib/navigation';
 import { getErrorMessage, getErrorTitle } from '@/lib/errorMessages';
 import { asRecord, toPercent } from '@/lib/deviceUtils';
@@ -470,6 +470,32 @@ export default function DevicesPage() {
             showToast({ type: 'error', message: `${result.succeeded} decommissioned, ${result.failed} failed` });
           }
           await fetchDevices();
+          break;
+        }
+
+        case 'wake': {
+          // One round-trip; server iterates per-device with relay-pick per LAN
+          // and returns per-device outcome. We render one summary toast
+          // grouped by failure code so a 50-device bulk doesn't spam 50
+          // toasts.
+          const summary = await sendBulkWakeCommand(deviceIds);
+          const failureSummary = summarizeBulkWakeFailures(summary.failed);
+          if (summary.failed.length === 0) {
+            showToast({
+              type: 'success',
+              message: `Wake packets sent to ${summary.succeeded.length} device${summary.succeeded.length === 1 ? '' : 's'}. Allow up to 5 minutes to come online.`,
+            });
+          } else if (summary.succeeded.length === 0) {
+            showToast({
+              type: 'error',
+              message: `Could not wake any of ${summary.failed.length} device${summary.failed.length === 1 ? '' : 's'}: ${failureSummary}.`,
+            });
+          } else {
+            showToast({
+              type: 'error',
+              message: `Wake sent to ${summary.succeeded.length} of ${summary.succeeded.length + summary.failed.length} devices. ${summary.failed.length} could not be woken: ${failureSummary}.`,
+            });
+          }
           break;
         }
 

--- a/apps/web/src/services/__tests__/deviceActions.test.ts
+++ b/apps/web/src/services/__tests__/deviceActions.test.ts
@@ -5,11 +5,14 @@ import {
   decommissionDevice,
   executeScript,
   sendBulkCommand,
+  sendBulkWakeCommand,
   sendDeviceCommand,
   sendWakeCommand,
+  summarizeBulkWakeFailures,
   toggleMaintenanceMode,
   WakeCommandError,
-  wakeFriendlyErrorMessage
+  wakeFriendlyErrorMessage,
+  type BulkWakeFailed
 } from '../deviceActions';
 
 vi.mock('@/stores/auth', () => ({
@@ -320,6 +323,94 @@ describe('deviceActions service', () => {
 
       expect(result).toEqual({ succeeded: 2, failed: 1 });
       expect(fetchWithAuthMock).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('sendBulkWakeCommand', () => {
+    it('posts a single bulk request with deviceIds + type=wake', async () => {
+      fetchWithAuthMock.mockResolvedValueOnce(
+        makeResponse({
+          bulkId: 'bulk-abc',
+          succeeded: [
+            { deviceId: 'd1', commandId: 'c1', wakeAttemptId: 'w1', relayDeviceId: 'r1', relayHostname: 'r1h', broadcast: '10.0.0.255' },
+          ],
+          failed: [],
+        }, true, 202),
+      );
+
+      const result = await sendBulkWakeCommand(['d1']);
+
+      expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchWithAuthMock.mock.calls[0]!;
+      expect(url).toBe('/devices/bulk/commands');
+      expect((init as RequestInit).method).toBe('POST');
+      expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+        deviceIds: ['d1'],
+        type: 'wake',
+      });
+      expect(result.bulkId).toBe('bulk-abc');
+      expect(result.succeeded).toHaveLength(1);
+      expect(result.failed).toHaveLength(0);
+    });
+
+    it('returns parsed succeeded + failed lists with original failure codes preserved', async () => {
+      fetchWithAuthMock.mockResolvedValueOnce(
+        makeResponse({
+          bulkId: 'bulk-xyz',
+          succeeded: [
+            { deviceId: 'a', commandId: 'c-a', wakeAttemptId: 'w-a', relayDeviceId: 'r1', relayHostname: 'r1h', broadcast: '10.0.0.255' },
+          ],
+          failed: [
+            { deviceId: 'b', code: 'NO_RELAY', message: 'No online peer.' },
+            { deviceId: 'c', code: 'NO_MACS', message: 'No MAC on file.' },
+            { deviceId: 'd', code: 'DECOMMISSIONED', message: 'Cannot wake a decommissioned device.' },
+          ],
+        }, true, 202),
+      );
+
+      const result = await sendBulkWakeCommand(['a', 'b', 'c', 'd']);
+
+      expect(result.succeeded.map(s => s.deviceId)).toEqual(['a']);
+      expect(result.failed.map(f => f.code)).toEqual(['NO_RELAY', 'NO_MACS', 'DECOMMISSIONED']);
+    });
+
+    it('throws on non-OK response so the caller surfaces one error toast', async () => {
+      fetchWithAuthMock.mockResolvedValueOnce(
+        makeResponse({ error: 'deviceIds exceeds max of 500' }, false, 400),
+      );
+      await expect(sendBulkWakeCommand(Array.from({ length: 501 }, (_, i) => `d${i}`))).rejects.toThrow(
+        /deviceIds exceeds max of 500/,
+      );
+    });
+  });
+
+  describe('summarizeBulkWakeFailures', () => {
+    it('returns empty string when nothing failed', () => {
+      expect(summarizeBulkWakeFailures([])).toBe('');
+    });
+
+    it('groups failures by code with human-readable phrasing', () => {
+      const failed: BulkWakeFailed[] = [
+        { deviceId: '1', code: 'NO_RELAY', message: '' },
+        { deviceId: '2', code: 'NO_RELAY', message: '' },
+        { deviceId: '3', code: 'NO_RELAY', message: '' },
+        { deviceId: '4', code: 'NO_MACS', message: '' },
+        { deviceId: '5', code: 'DECOMMISSIONED', message: '' },
+      ];
+      const out = summarizeBulkWakeFailures(failed);
+      expect(out).toMatch(/3 with no online peer at their site/);
+      expect(out).toMatch(/1 with no MAC on file/);
+      expect(out).toMatch(/1 decommissioned/);
+    });
+
+    it('collapses IPv6_ONLY and NO_SUBNET into one bucket', () => {
+      const failed: BulkWakeFailed[] = [
+        { deviceId: '1', code: 'NO_SUBNET', message: '' },
+        { deviceId: '2', code: 'IPV6_ONLY', message: '' },
+      ];
+      const out = summarizeBulkWakeFailures(failed);
+      // Both map to the same label "with no usable IPv4 history" → one bucket of 2
+      expect(out).toBe('2 with no usable IPv4 history');
     });
   });
 });

--- a/apps/web/src/services/deviceActions.ts
+++ b/apps/web/src/services/deviceActions.ts
@@ -116,6 +116,101 @@ export async function sendWakeCommand(deviceId: string): Promise<WakeResponse> {
   return await response.json();
 }
 
+/** Bulk-wake result codes — same as WakeFailureCode plus two bulk-only
+ *  shapes the bulk handler emits before reaching dispatchWake. */
+export type BulkWakeFailureCode =
+  | WakeFailureCode
+  | 'DECOMMISSIONED'
+  // The bulk handler also emits TARGET_NOT_FOUND for "not found OR
+  // partner-scope access denied" — same as dispatchWake's own
+  // TARGET_NOT_FOUND but raised earlier (before dispatchWake is invoked).
+  ;
+
+export interface BulkWakeSucceeded {
+  deviceId: string;
+  commandId: string;
+  wakeAttemptId: string;
+  relayDeviceId: string;
+  relayHostname: string;
+  broadcast: string;
+}
+
+export interface BulkWakeFailed {
+  deviceId: string;
+  code: BulkWakeFailureCode;
+  message: string;
+}
+
+export interface BulkWakeSummary {
+  bulkId: string;
+  succeeded: BulkWakeSucceeded[];
+  failed: BulkWakeFailed[];
+}
+
+/**
+ * Bulk Wake-on-LAN — one HTTP round-trip, server iterates per-device with
+ * a relay-pick per LAN. Server response includes per-device outcome with
+ * the original WakeFailureCode preserved so the UI can group failures
+ * by reason in the summary toast.
+ *
+ * 412/422 from the server (validation, decommissioned-only selection,
+ * etc.) is surfaced as a thrown Error so the caller's catch path can
+ * show a single error toast instead of treating the entire batch as
+ * "0 succeeded."
+ */
+export async function sendBulkWakeCommand(deviceIds: string[]): Promise<BulkWakeSummary> {
+  const response = await fetchWithAuth('/devices/bulk/commands', {
+    method: 'POST',
+    body: JSON.stringify({ deviceIds, type: 'wake' })
+  });
+  if (!response.ok) {
+    throw new Error(await getErrorMessage(response, 'Failed to send bulk wake command'));
+  }
+  return await response.json();
+}
+
+/**
+ * Render a one-line failure-code summary suitable for the bulk-wake toast,
+ * grouping by code. Returns an empty string when there are no failures.
+ *
+ * Example: "3 have no online peer at their site; 1 has no MAC on file"
+ */
+export function summarizeBulkWakeFailures(failed: BulkWakeFailed[]): string {
+  if (failed.length === 0) return '';
+  const buckets: Record<string, number> = {};
+  for (const f of failed) {
+    const label = bulkWakeFailureLabel(f.code);
+    buckets[label] = (buckets[label] ?? 0) + 1;
+  }
+  return Object.entries(buckets)
+    .map(([label, count]) => `${count} ${label}`)
+    .join('; ');
+}
+
+function bulkWakeFailureLabel(code: string): string {
+  switch (code) {
+    case 'NO_RELAY':
+      return 'with no online peer at their site';
+    case 'NO_MACS':
+      return 'with no MAC on file (agent has not checked in)';
+    case 'NO_SUBNET':
+    case 'IPV6_ONLY':
+      return 'with no usable IPv4 history';
+    case 'WS_SEND_FAILED':
+      return 'had relay disconnect mid-dispatch — retry';
+    case 'TARGET_NOT_FOUND':
+      return 'not found or access denied';
+    case 'DECOMMISSIONED':
+      return 'decommissioned';
+    case 'RELAY_OVERRIDE_INVALID':
+      // Bulk path never uses override; surface generically if it ever
+      // does appear so we notice in telemetry.
+      return 'with invalid relay override';
+    default:
+      return `with error ${code}`;
+  }
+}
+
 export async function sendBulkCommand(
   deviceIds: string[],
   type: string,


### PR DESCRIPTION
## Summary

Adds a single-round-trip bulk Wake-on-LAN action on the Devices page. User selects N endpoints from the device list, picks "Wake Selected" from the bulk pulldown, server iterates per-device with per-LAN relay picking, returns one response with per-device outcomes grouped by the existing `WakeFailureCode` set. UI renders one summary toast grouped by failure code.

Follow-up to Discussion #694 / #703 (which landed single-device wake) and #720 / #722 (which landed the toast contract this builds on).

## Design constraints verified before implementation

The design contract was built against actual code reads, not guesses:

- **Rate limit** (`apps/api/src/index.ts:272`): global `300 req/min per IP` via `globalRateLimit()` — not excluded for `/devices/*`. A browser-loop bulk-wake at 100 devices would consume 1/3 of the user's per-minute global budget; one bulk request consumes 1 token.
- **Cloudflare timeout**: production runs through CF (DNS proxy on, `server: cloudflare`), ~100s proxy ceiling. At inline concurrency 8 with dispatchWake's 5-7 sequential DB round-trips per device, 500-device bulks fit with margin.
- **No DB locks in `dispatchWake`** (`services/wakeOnLan.ts:253-403`): all queries are independent point operations + a non-blocking WS write. Safe to parallelize.
- **No `p-limit` dependency in `apps/api/package.json`**: inline 8-worker pool over a shared queue avoids adding a dep.

## Change shape

**API** (4 files, +280 lines):

- `apps/api/src/routes/devices/schemas.ts`: `'wake'` added to `bulkCommandSchema.type`; `deviceIds.max(BULK_COMMAND_MAX_DEVICES = 500)` defensive cap.
- `apps/api/src/services/wakeOnLan.ts`: `DispatchWakeOptions.bulkId?: string` threaded into `audit_logs.details.bulkId` when set. Undefined for single-device wake — existing audit shape unchanged.
- `apps/api/src/routes/devices/commands.ts`: `wake` branch in `/bulk/commands` runs an inline 8-worker pool. Per worker: `getDeviceWithOrgCheck` (partner-scope safety — dispatchWake does NOT independently authorize the caller's org access), then `dispatchWake` with shared `bulkId`. Returns `{bulkId, succeeded[], failed[]}` HTTP 202.
- `apps/api/src/routes/devices/commands.test.ts`: 5 new cases covering mixed outcomes + bulkId correlation, decommissioned skip, cross-org filter, schema cap (501 → 400), and schema accepting `type=wake`.

**Web** (4 files, +214 lines):

- `apps/web/src/services/deviceActions.ts`: `sendBulkWakeCommand(deviceIds)` returns `{bulkId, succeeded, failed}`. `summarizeBulkWakeFailures(failed)` groups by code with human-readable phrases ("3 with no online peer at their site", "1 with no MAC on file"). Collapses `NO_SUBNET` + `IPV6_ONLY` into one user-facing bucket since they're indistinguishable in practice.
- `apps/web/src/services/__tests__/deviceActions.test.ts`: 6 new cases.
- `apps/web/src/components/devices/DevicesPage.tsx`: `case 'wake':` arm with three toast variants — all-success, all-fail, mixed.
- `apps/web/src/components/devices/DeviceList.tsx`: "Wake Selected" menu item between Maintenance and Decommission. Always enabled — matches `bulkDecommissionDevices` UX. Backend handles a wake to an already-online device as a harmless no-op.

## Test plan

- [x] 136 existing devices-route tests pass (no regression)
- [x] 46 existing devices web component tests pass (no regression)
- [x] 5 new bulk-wake API tests pass
- [x] 6 new bulk-wake web service tests pass
- [x] `no-silent-mutations` web mutation-contract guard (17) passes
- [x] Web build clean (`pnpm --filter @breeze/web build`)
- [x] API typecheck clean (`tsc --noEmit`)
- [x] Web typecheck clean (`tsc --noEmit`)

## Toast copy

| Outcome | Toast type | Format |
|---|---|---|
| All succeeded | success | `Wake packets sent to ${n} devices. Allow up to 5 minutes to come online.` |
| All failed | error | `Could not wake any of ${n} devices: ${grouped failures}.` |
| Mixed | error (warning if you have one) | `Wake sent to ${k} of ${n} devices. ${n-k} could not be woken: ${grouped failures}.` |

Failure groupings (per `summarizeBulkWakeFailures`):

| Code | Phrase |
|---|---|
| `NO_RELAY` | `with no online peer at their site` |
| `NO_MACS` | `with no MAC on file (agent has not checked in)` |
| `NO_SUBNET` / `IPV6_ONLY` | `with no usable IPv4 history` |
| `WS_SEND_FAILED` | `had relay disconnect mid-dispatch — retry` |
| `TARGET_NOT_FOUND` | `not found or access denied` |
| `DECOMMISSIONED` | `decommissioned` |

## Notes

- `RELAY_OVERRIDE_INVALID` is not reachable from this path (bulk-wake never sets an override) but the summarizer handles it generically so it'd surface in telemetry if it ever appeared.
- Single-device wake row menu (`DeviceList.tsx:848`) is untouched.
- Reboot/decommission/etc bulk paths are untouched — only `type=wake` takes the new branch.
- Audit log volume for a 500-device wake: 500 `device_commands` rows + 500 `auditLogs` rows. Same as a 500-device bulk reboot. No different from the existing baseline.
