### PR TITLE
fix(web): use ReactElement instead of removed global JSX namespace

### DIFF
--- a/apps/web/src/components/auth/StatusIcon.tsx
+++ b/apps/web/src/components/auth/StatusIcon.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 type Variant = 'success' | 'error' | 'pending';
 
 interface StatusIconProps {
@@ -15,7 +17,7 @@ const VARIANT_STYLES: Record<Variant, { ring: string; text: string }> = {
   pending: { ring: 'bg-primary/10', text: 'text-primary' },
 };
 
-const PATHS: Record<Variant, JSX.Element> = {
+const PATHS: Record<Variant, ReactElement> = {
   success: (
     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
   ),


### PR DESCRIPTION
## What

`@types/react` 19 removes the global `JSX` namespace — `JSX.Element` must now be imported from `react` (as `ReactElement`, `React.JSX.Element`, or via named import).

The only repo usage was in `apps/web/src/components/auth/StatusIcon.tsx:18`:

```diff
+import type { ReactElement } from 'react';
-const PATHS: Record<Variant, JSX.Element> = {
+const PATHS: Record<Variant, ReactElement> = {
```

## Why

Unblocks the Dependabot react group bump (#762: `react` 19.2.0→19.2.6 + `@types/react` 18.3.28→19.2.14), which fails Type Check with `error ts(2503): Cannot find namespace 'JSX'`. After this lands, #762 should rebase clean.

## Verification

- `rg 'JSX\.' apps/web/src` → no remaining occurrences in our code.
- `npx tsc --noEmit -p apps/web/tsconfig.json` → no errors on `StatusIcon.tsx`.
- No runtime behavior change — `ReactElement` is the same type the removed global `JSX.Element` aliased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)