### PR TITLE
fix(viewer): supply explicit undefined to useRef for React 19

### DIFF
--- a/apps/viewer/src/components/DesktopViewer.tsx
+++ b/apps/viewer/src/components/DesktopViewer.tsx
@@ -180,7 +180,8 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
 
   // Frame rate tracking
   const frameCountRef = useRef(0);
-  const fpsIntervalRef = useRef<ReturnType<typeof setInterval>>();
+  // React 19 removed the no-arg useRef overload; explicit `undefined` init.
+  const fpsIntervalRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
 
   // Remote screen size (actual pixels from agent)
   const remoteScreenRef = useRef({ width: 1920, height: 1080 });


### PR DESCRIPTION
## What

React 19 removed the no-arg `useRef` overload — `useRef<T>()` must now be `useRef<T>(initial)`. Single remaining call in the viewer:

```diff
-const fpsIntervalRef = useRef<ReturnType<typeof setInterval>>();
+const fpsIntervalRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
```

## Why

Broke all three Build Viewer jobs in the **v0.66.0** release workflow:

```
src/components/DesktopViewer.tsx(183,26): error TS2554: Expected 1 arguments, but got 0.
```

This is the same React 19 breakage class as #783 (JSX namespace removal) — both surfaced after #762 bumped `@types/react` to 19.

## Why `undefined` and not `null`

`clearInterval(fpsIntervalRef.current)` at line 815 requires `number | undefined` per the DOM lib types — `null` fails the same TS check (`error TS2345: Type 'null' is not assignable to type 'number | undefined'`).

## Verification

- `grep -rE 'useRef<[^>]*>\(\)'` repo-wide → only this one call.
- `cd apps/viewer && npx tsc --noEmit` → clean.
- `cd apps/helper && npx tsc --noEmit` → clean.
- `cd apps/web && npx tsc --noEmit` → clean.

## Follow-up

After this merges, tag **v0.66.1** to ship the v0.66.0 release content + this viewer fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)