### PR TITLE
fix(web): flip Devices row kebab dropdown direction when near viewport bottom

### DIFF
--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -126,6 +126,11 @@ export default function DeviceList({
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkMenuOpen, setBulkMenuOpen] = useState(false);
   const [rowMenuOpenId, setRowMenuOpenId] = useState<string | null>(null);
+  // Flip the row dropdown direction when the click happens close to the
+  // viewport bottom — the menu has ~7 items × ~36px, so any row whose
+  // kebab sits <300px from the viewport bottom would otherwise render
+  // its dropdown into the area below the table and get clipped.
+  const [rowMenuFlipUp, setRowMenuFlipUp] = useState(false);
   const rowMenuRef = useRef<HTMLDivElement>(null);
   const [serverFilterIds, setServerFilterIds] = useState<Set<string> | null>(null);
   const [serverFilterLoading, setServerFilterLoading] = useState(false);
@@ -811,13 +816,21 @@ export default function DeviceList({
                       <div className="relative" ref={rowMenuOpenId === device.id ? rowMenuRef : undefined}>
                         <button
                           type="button"
-                          onClick={() => setRowMenuOpenId(rowMenuOpenId === device.id ? null : device.id)}
+                          onClick={(e) => {
+                            if (rowMenuOpenId !== device.id) {
+                              const rect = e.currentTarget.getBoundingClientRect();
+                              // ~280px dropdown height (7 items × ~36px + padding/divider).
+                              // Flip up when the space below the button is less than that.
+                              setRowMenuFlipUp(window.innerHeight - rect.bottom < 300);
+                            }
+                            setRowMenuOpenId(rowMenuOpenId === device.id ? null : device.id);
+                          }}
                           className="flex h-8 w-8 items-center justify-center rounded-md transition hover:bg-muted"
                         >
                           <MoreVertical className="h-4 w-4" />
                         </button>
                         {rowMenuOpenId === device.id && (
-                          <div className="absolute right-0 top-full z-50 mt-1 w-48 rounded-md border bg-card shadow-lg">
+                          <div className={`absolute right-0 z-50 w-48 rounded-md border bg-card shadow-lg ${rowMenuFlipUp ? 'bottom-full mb-1' : 'top-full mt-1'}`}>
                             <button
                               type="button"
                               disabled={device.status !== 'online'}


### PR DESCRIPTION
## Bug

On the Devices list, the row-action kebab (three-dots, right-most column) always opens its dropdown DOWNWARD via `absolute right-0 top-full mt-1`. For any row whose kebab button sits within ~280px of the viewport bottom — typically the last row(s) when the table fills the page — the dropdown extends below the table boundary and is clipped, making **Wake**, **Settings**, **Decommission**, etc. invisible without scrolling the entire page.

Caught live during 2026-05-20 testing on a 12-device fleet view — the bottom row's kebab dropdown was structurally unreachable.

## Fix

`apps/web/src/components/devices/DeviceList.tsx`:

1. New `rowMenuFlipUp` state.
2. When the kebab is clicked, measure `e.currentTarget.getBoundingClientRect().bottom` vs `window.innerHeight`. If the remaining space is less than 300px, set `rowMenuFlipUp=true` and the dropdown renders with `bottom-full mb-1` (opens upward) instead of `top-full mt-1`.
3. Decision is made at click time (not on render) so direction reflects the live scroll/viewport state, not stale state from when the row mounted.
4. The ~300px threshold = menu's max height (7 items × 36px + padding + divider) + small margin.

```diff
- <div className=\"absolute right-0 top-full z-50 mt-1 w-48 ...\">
+ <div className={\`absolute right-0 z-50 w-48 ... \${rowMenuFlipUp ? 'bottom-full mb-1' : 'top-full mt-1'}\`}>
```

## What it deliberately doesn't do

- No new dependencies (no Popper / Floating-UI).
- No portal — the dropdown stays inside the same `relative` parent regardless of flip direction, so the existing click-outside handler continues to work without changes.
- No fix for the bulk-action menu (`MoreHorizontal` at line 551) — that menu is short enough not to hit the same issue today; can be retrofitted later with the same pattern if needed.

## Tests

- `tsc --noEmit` clean.
- 46/46 existing web devices tests pass.
- No new unit tests — the behavior is dependent on real viewport geometry (window.innerHeight + getBoundingClientRect), which vitest's jsdom doesn't reliably simulate. This is a UX fix verified by manual click on a last-row kebab in the production-style fleet view.