### PR TITLE
feat(web): inline edit for Display Name on device Details tab

### DIFF
--- a/apps/api/src/routes/devices/schemas.ts
+++ b/apps/api/src/routes/devices/schemas.ts
@@ -68,7 +68,9 @@ export const listDevicesSchema = z.object({
 });
 
 export const updateDeviceSchema = z.object({
-  displayName: z.string().min(1).max(255).optional(),
+  // Nullable so the inline-edit "clear" path (empty input → PATCH {displayName:null})
+  // can unset the name; the devices.display_name column is nullable. See PR #787.
+  displayName: z.string().max(255).nullable().optional(),
   siteId: z.string().uuid().optional(),
   tags: z.array(z.string()).optional(),
   customFields: z.record(

--- a/apps/web/src/components/devices/DeviceInfoTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceInfoTab.test.tsx
@@ -1,0 +1,239 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DeviceInfoTab from './DeviceInfoTab';
+import { fetchWithAuth } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+// runAction calls showToast; mock it so we can assert error surfaces without
+// rendering a real toast.
+vi.mock('../shared/Toast', () => ({
+  showToast: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+const showToastMock = vi.mocked(showToast);
+
+const deviceId = '11111111-1111-1111-1111-111111111111';
+
+function makeJsonResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
+
+function mockInitialLoad(displayName: string | null) {
+  fetchWithAuthMock.mockImplementation(async (input, init) => {
+    const url = String(input);
+    const method = init?.method ?? 'GET';
+    if (url === `/devices/${deviceId}` && method === 'GET') {
+      return makeJsonResponse({
+        hostname: 'TST-LAPTOP-01',
+        displayName,
+        osType: 'windows',
+        osVersion: '11',
+        tags: [],
+        status: 'online',
+      });
+    }
+    if (url === '/custom-fields') {
+      return makeJsonResponse({ data: [] });
+    }
+    return makeJsonResponse({}, false, 404);
+  });
+}
+
+describe('DeviceInfoTab — display name inline edit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('saves a non-empty display name via PATCH', async () => {
+    mockInitialLoad('Old Name');
+    render(<DeviceInfoTab deviceId={deviceId} />);
+    await screen.findByText('Old Name');
+
+    // Wire the PATCH response BEFORE the click.
+    fetchWithAuthMock.mockImplementationOnce(async () => makeJsonResponse({ ok: true }));
+
+    fireEvent.click(screen.getByTitle('Edit display name'));
+    const input = screen.getByPlaceholderText('Leave blank to clear') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'New Name' } });
+    fireEvent.click(screen.getByTitle('Save'));
+
+    await waitFor(() => {
+      const patchCall = fetchWithAuthMock.mock.calls.find(
+        ([, init]) => init?.method === 'PATCH',
+      );
+      expect(patchCall).toBeDefined();
+      expect(patchCall?.[0]).toBe(`/devices/${deviceId}`);
+      expect(JSON.parse(String(patchCall?.[1]?.body))).toEqual({ displayName: 'New Name' });
+    });
+
+    // After save, modal collapses and the new value renders.
+    await waitFor(() => expect(screen.getByText('New Name')).toBeInTheDocument());
+  });
+
+  it('CLEARING the display name sends PATCH {displayName: null} (the headline use case)', async () => {
+    mockInitialLoad('Existing Name');
+    render(<DeviceInfoTab deviceId={deviceId} />);
+    await screen.findByText('Existing Name');
+
+    fetchWithAuthMock.mockImplementationOnce(async () => makeJsonResponse({ ok: true }));
+
+    fireEvent.click(screen.getByTitle('Edit display name'));
+    const input = screen.getByPlaceholderText('Leave blank to clear') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.click(screen.getByTitle('Save'));
+
+    await waitFor(() => {
+      const patchCall = fetchWithAuthMock.mock.calls.find(
+        ([, init]) => init?.method === 'PATCH',
+      );
+      expect(patchCall).toBeDefined();
+      const body = JSON.parse(String(patchCall?.[1]?.body));
+      expect(body).toEqual({ displayName: null });
+    });
+
+    await waitFor(() => expect(screen.getByText('Not set')).toBeInTheDocument());
+  });
+
+  it('whitespace-only input is treated as clearing (trimmed → null)', async () => {
+    mockInitialLoad('Existing');
+    render(<DeviceInfoTab deviceId={deviceId} />);
+    await screen.findByText('Existing');
+
+    fetchWithAuthMock.mockImplementationOnce(async () => makeJsonResponse({ ok: true }));
+
+    fireEvent.click(screen.getByTitle('Edit display name'));
+    const input = screen.getByPlaceholderText('Leave blank to clear') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.click(screen.getByTitle('Save'));
+
+    await waitFor(() => {
+      const patchCall = fetchWithAuthMock.mock.calls.find(
+        ([, init]) => init?.method === 'PATCH',
+      );
+      const body = JSON.parse(String(patchCall?.[1]?.body));
+      expect(body).toEqual({ displayName: null });
+    });
+  });
+
+  it('Cancel reverts to the original value without firing a PATCH', async () => {
+    mockInitialLoad('Original');
+    render(<DeviceInfoTab deviceId={deviceId} />);
+    await screen.findByText('Original');
+
+    fireEvent.click(screen.getByTitle('Edit display name'));
+    const input = screen.getByPlaceholderText('Leave blank to clear') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Discarded edit' } });
+    fireEvent.click(screen.getByTitle('Cancel'));
+
+    expect(screen.getByText('Original')).toBeInTheDocument();
+    const patchCall = fetchWithAuthMock.mock.calls.find(
+      ([, init]) => init?.method === 'PATCH',
+    );
+    expect(patchCall).toBeUndefined();
+  });
+
+  it('surfaces an error toast when the API rejects the save (runAction integration)', async () => {
+    mockInitialLoad('Old');
+    render(<DeviceInfoTab deviceId={deviceId} />);
+    await screen.findByText('Old');
+
+    fetchWithAuthMock.mockImplementationOnce(async () =>
+      makeJsonResponse({ error: 'Invalid display name' }, false, 400),
+    );
+
+    fireEvent.click(screen.getByTitle('Edit display name'));
+    const input = screen.getByPlaceholderText('Leave blank to clear') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'New' } });
+    fireEvent.click(screen.getByTitle('Save'));
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error', message: 'Invalid display name' }),
+      );
+    });
+    // The editor should NOT collapse on error — user keeps the chance to fix the value.
+    expect(screen.getByPlaceholderText('Leave blank to clear')).toBeInTheDocument();
+  });
+
+  it('renders the inline error message at the top of the page (visible even with no custom fields)', async () => {
+    mockInitialLoad('Old');
+    render(<DeviceInfoTab deviceId={deviceId} />);
+    await screen.findByText('Old');
+
+    fetchWithAuthMock.mockImplementationOnce(async () =>
+      makeJsonResponse({ error: 'Conflict — name already used' }, false, 409),
+    );
+
+    fireEvent.click(screen.getByTitle('Edit display name'));
+    fireEvent.change(screen.getByPlaceholderText('Leave blank to clear'), {
+      target: { value: 'Dup' },
+    });
+    fireEvent.click(screen.getByTitle('Save'));
+
+    // The hoisted role="alert" container should render the message regardless
+    // of whether the Custom Fields section is present.
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Conflict — name already used');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runAction adoption on the other two mutating handlers in this file.
+// ---------------------------------------------------------------------------
+
+describe('DeviceInfoTab — role + custom-field mutations also use runAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('Device Role save fires success toast via runAction', async () => {
+    // Initial load with a windows device that supports role editing.
+    fetchWithAuthMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === `/devices/${deviceId}` && method === 'GET') {
+        return makeJsonResponse({
+          hostname: 'TST-LAPTOP-01',
+          displayName: null,
+          osType: 'windows',
+          deviceRole: 'workstation',
+          deviceRoleSource: 'auto',
+          tags: [],
+          status: 'online',
+        });
+      }
+      if (url === '/custom-fields') return makeJsonResponse({ data: [] });
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(<DeviceInfoTab deviceId={deviceId} />);
+    await screen.findByText('TST-LAPTOP-01');
+
+    // PATCH succeeds with 200.
+    fetchWithAuthMock.mockImplementationOnce(async () => makeJsonResponse({ ok: true }));
+
+    const editRoleBtn = screen.getByTitle('Change role');
+    fireEvent.click(editRoleBtn);
+    // Find the role <select> and pick a non-current value.
+    const select = screen.getByRole('combobox') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'server' } });
+    fireEvent.click(screen.getByTitle('Save'));
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'success', message: 'Device role saved' }),
+      );
+    });
+  });
+});

--- a/apps/web/src/components/devices/DeviceInfoTab.tsx
+++ b/apps/web/src/components/devices/DeviceInfoTab.tsx
@@ -174,6 +174,9 @@ export default function DeviceInfoTab({ deviceId }: DeviceInfoTabProps) {
   const [editingRole, setEditingRole] = useState(false);
   const [selectedRole, setSelectedRole] = useState<string>('unknown');
   const [savingRole, setSavingRole] = useState(false);
+  const [editingDisplayName, setEditingDisplayName] = useState(false);
+  const [displayNameDraft, setDisplayNameDraft] = useState('');
+  const [savingDisplayName, setSavingDisplayName] = useState(false);
 
   const fetchInfo = useCallback(async () => {
     setLoading(true);
@@ -242,6 +245,36 @@ export default function DeviceInfoTab({ deviceId }: DeviceInfoTabProps) {
       setSaveError('Network error. Please check your connection and try again.');
     } finally {
       setSavingRole(false);
+    }
+  };
+
+  const handleSaveDisplayName = async () => {
+    setSavingDisplayName(true);
+    setSaveError(null);
+    // Trim; an empty draft clears the display name (PATCH with null).
+    const trimmed = displayNameDraft.trim();
+    const payload: { displayName: string | null } = { displayName: trimmed === '' ? null : trimmed };
+    try {
+      const response = await fetchWithAuth(`/devices/${deviceId}`, {
+        method: 'PATCH',
+        body: JSON.stringify(payload),
+      });
+      if (response.ok) {
+        setInfo(prev => prev ? { ...prev, displayName: payload.displayName } : prev);
+        setEditingDisplayName(false);
+      } else {
+        let detail = `Failed to save (HTTP ${response.status})`;
+        try {
+          const body = await response.json();
+          if (body.error) detail = body.error;
+        } catch { /* non-JSON response */ }
+        setSaveError(detail);
+      }
+    } catch (err) {
+      console.error('Failed to save display name:', err);
+      setSaveError('Network error. Please check your connection and try again.');
+    } finally {
+      setSavingDisplayName(false);
     }
   };
 
@@ -393,7 +426,63 @@ export default function DeviceInfoTab({ deviceId }: DeviceInfoTabProps) {
     <div className="grid gap-6 lg:grid-cols-2">
       <Section title="System" icon={<Monitor className="h-4 w-4 text-muted-foreground" />}>
         <InfoRow label="Hostname" value={info?.hostname ?? '—'} />
-        <InfoRow label="Display Name" value={info?.displayName ?? 'Not set'} />
+        <div className="flex items-center justify-between py-2">
+          <dt className="text-sm text-muted-foreground">Display Name</dt>
+          <dd className="text-sm font-medium text-right flex items-center gap-2">
+            {editingDisplayName ? (
+              <>
+                <input
+                  type="text"
+                  value={displayNameDraft}
+                  onChange={e => setDisplayNameDraft(e.target.value)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter') void handleSaveDisplayName();
+                    if (e.key === 'Escape') setEditingDisplayName(false);
+                  }}
+                  maxLength={255}
+                  placeholder="Leave blank to clear"
+                  className="h-8 w-48 rounded-md border bg-background px-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                  autoFocus
+                />
+                <button
+                  type="button"
+                  onClick={handleSaveDisplayName}
+                  disabled={savingDisplayName}
+                  className="inline-flex h-7 w-7 items-center justify-center rounded text-primary hover:bg-primary/10"
+                  title="Save"
+                >
+                  <Check className="h-4 w-4" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setEditingDisplayName(false)}
+                  className="inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-muted"
+                  title="Cancel"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </>
+            ) : (
+              <>
+                <span className={info?.displayName ? '' : 'text-muted-foreground italic'}>
+                  {info?.displayName ?? 'Not set'}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setDisplayNameDraft(info?.displayName ?? '');
+                    setEditingDisplayName(true);
+                    setSaveError(null);
+                  }}
+                  className="inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+                  title="Edit display name"
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </button>
+              </>
+            )}
+          </dd>
+        </div>
         <InfoRow label="Serial Number" value={hw?.serialNumber ?? '—'} />
         <InfoRow label="Manufacturer" value={hw?.manufacturer ?? '—'} />
         <InfoRow label="Model" value={hw?.model ?? '—'} />

--- a/apps/web/src/components/devices/DeviceInfoTab.tsx
+++ b/apps/web/src/components/devices/DeviceInfoTab.tsx
@@ -4,6 +4,7 @@ import type { DesktopAccessState, TCCPermissions } from '@breeze/shared';
 import MacOSPermissionsCard from './MacOSPermissionsCard';
 import { fetchWithAuth } from '../../stores/auth';
 import { formatUptime } from '../../lib/utils';
+import { runAction, ActionError } from '../../lib/runAction';
 import {
   DEVICE_ROLES,
   getDeviceRoleLabel,
@@ -225,24 +226,24 @@ export default function DeviceInfoTab({ deviceId }: DeviceInfoTabProps) {
     setSavingRole(true);
     setSaveError(null);
     try {
-      const response = await fetchWithAuth(`/devices/${deviceId}`, {
-        method: 'PATCH',
-        body: JSON.stringify({ deviceRole: selectedRole }),
+      await runAction({
+        request: () => fetchWithAuth(`/devices/${deviceId}`, {
+          method: 'PATCH',
+          body: JSON.stringify({ deviceRole: selectedRole }),
+        }),
+        errorFallback: 'Failed to save device role',
+        successMessage: 'Device role saved',
       });
-      if (response.ok) {
-        setInfo(prev => prev ? { ...prev, deviceRole: selectedRole, deviceRoleSource: 'manual' } : prev);
-        setEditingRole(false);
-      } else {
-        let detail = `Failed to save (HTTP ${response.status})`;
-        try {
-          const body = await response.json();
-          if (body.error) detail = body.error;
-        } catch { /* non-JSON response */ }
-        setSaveError(detail);
-      }
+      setInfo(prev => prev ? { ...prev, deviceRole: selectedRole, deviceRoleSource: 'manual' } : prev);
+      setEditingRole(false);
     } catch (err) {
-      console.error('Failed to save device role:', err);
-      setSaveError('Network error. Please check your connection and try again.');
+      if (err instanceof ActionError) {
+        if (err.status === 401) return;
+        setSaveError(err.message);
+      } else {
+        console.error('Failed to save device role:', err);
+        setSaveError('Network error. Please check your connection and try again.');
+      }
     } finally {
       setSavingRole(false);
     }
@@ -255,24 +256,28 @@ export default function DeviceInfoTab({ deviceId }: DeviceInfoTabProps) {
     const trimmed = displayNameDraft.trim();
     const payload: { displayName: string | null } = { displayName: trimmed === '' ? null : trimmed };
     try {
-      const response = await fetchWithAuth(`/devices/${deviceId}`, {
-        method: 'PATCH',
-        body: JSON.stringify(payload),
+      await runAction({
+        request: () => fetchWithAuth(`/devices/${deviceId}`, {
+          method: 'PATCH',
+          body: JSON.stringify(payload),
+        }),
+        errorFallback: 'Failed to save display name',
+        successMessage: payload.displayName === null
+          ? 'Display name cleared'
+          : 'Display name saved',
       });
-      if (response.ok) {
-        setInfo(prev => prev ? { ...prev, displayName: payload.displayName } : prev);
-        setEditingDisplayName(false);
-      } else {
-        let detail = `Failed to save (HTTP ${response.status})`;
-        try {
-          const body = await response.json();
-          if (body.error) detail = body.error;
-        } catch { /* non-JSON response */ }
-        setSaveError(detail);
-      }
+      setInfo(prev => prev ? { ...prev, displayName: payload.displayName } : prev);
+      setEditingDisplayName(false);
     } catch (err) {
-      console.error('Failed to save display name:', err);
-      setSaveError('Network error. Please check your connection and try again.');
+      if (err instanceof ActionError) {
+        if (err.status === 401) return; // auth redirect handles UX
+        // runAction already surfaced a toast; mirror the message inline for
+        // the form so the user sees it next to the input.
+        setSaveError(err.message);
+      } else {
+        console.error('Failed to save display name:', err);
+        setSaveError('Network error. Please check your connection and try again.');
+      }
     } finally {
       setSavingDisplayName(false);
     }
@@ -288,27 +293,27 @@ export default function DeviceInfoTab({ deviceId }: DeviceInfoTabProps) {
     setSaving(true);
     setSaveError(null);
     try {
-      const response = await fetchWithAuth(`/devices/${deviceId}`, {
-        method: 'PATCH',
-        body: JSON.stringify({ customFields: { [fieldKey]: editValue } }),
+      await runAction({
+        request: () => fetchWithAuth(`/devices/${deviceId}`, {
+          method: 'PATCH',
+          body: JSON.stringify({ customFields: { [fieldKey]: editValue } }),
+        }),
+        errorFallback: `Failed to save "${fieldKey}"`,
+        successMessage: 'Custom field saved',
       });
-      if (response.ok) {
-        setInfo(prev => prev ? {
-          ...prev,
-          customFields: { ...(prev.customFields ?? {}), [fieldKey]: editValue }
-        } : prev);
-        setEditingField(null);
-      } else {
-        let detail = `Failed to save (HTTP ${response.status})`;
-        try {
-          const body = await response.json();
-          if (body.error) detail = body.error;
-        } catch { /* non-JSON response */ }
-        setSaveError(detail);
-      }
+      setInfo(prev => prev ? {
+        ...prev,
+        customFields: { ...(prev.customFields ?? {}), [fieldKey]: editValue }
+      } : prev);
+      setEditingField(null);
     } catch (err) {
-      console.error(`Failed to save custom field "${fieldKey}":`, err);
-      setSaveError('Network error. Please check your connection and try again.');
+      if (err instanceof ActionError) {
+        if (err.status === 401) return;
+        setSaveError(err.message);
+      } else {
+        console.error(`Failed to save custom field "${fieldKey}":`, err);
+        setSaveError('Network error. Please check your connection and try again.');
+      }
     } finally {
       setSaving(false);
     }
@@ -424,6 +429,17 @@ export default function DeviceInfoTab({ deviceId }: DeviceInfoTabProps) {
 
   return (
     <div className="grid gap-6 lg:grid-cols-2">
+      {/* Page-level save error. Hoisted out of the Custom Fields section
+          (which only renders when applicableFields.length > 0) so the
+          display-name / role / field error states are always visible. */}
+      {saveError && (
+        <div
+          role="alert"
+          className="lg:col-span-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        >
+          {saveError}
+        </div>
+      )}
       <Section title="System" icon={<Monitor className="h-4 w-4 text-muted-foreground" />}>
         <InfoRow label="Hostname" value={info?.hostname ?? '—'} />
         <div className="flex items-center justify-between py-2">
@@ -671,11 +687,6 @@ export default function DeviceInfoTab({ deviceId }: DeviceInfoTabProps) {
             <ListChecks className="h-4 w-4 text-muted-foreground" />
             <h3 className="text-sm font-semibold">Custom Fields</h3>
           </div>
-          {saveError && (
-            <div className="mb-4 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-              {saveError}
-            </div>
-          )}
           <dl className="divide-y">
             {applicableFields.map(def => {
               const currentValue = info?.customFields?.[def.fieldKey] ?? def.defaultValue ?? null;

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -32,6 +32,7 @@ const TARGET_GLOBS = [
   'src/components/settings/PartnerSettingsPage.tsx',
   'src/components/patches/PatchesPage.tsx',
   'src/components/settings/RolesPage.tsx',
+  'src/components/devices/DeviceInfoTab.tsx',
 ];
 
 const absoluteFiles: string[] = TARGET_GLOBS.map((rel) => resolve(WEB_ROOT, '..', rel));
@@ -223,7 +224,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(4);
+    expect(absoluteFiles.length).toBe(5);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/runActionAllowlist.ts
+++ b/apps/web/src/lib/runActionAllowlist.ts
@@ -16,7 +16,6 @@ export const RUN_ACTION_MIGRATION_BACKLOG: ReadonlyArray<string> = [
   'apps/web/src/components/devices/DeviceBootPerformanceTab.tsx',
   'apps/web/src/components/devices/DeviceFilesystemTab.tsx',
   'apps/web/src/components/devices/DeviceGroupsPage.tsx',
-  'apps/web/src/components/devices/DeviceInfoTab.tsx',
   'apps/web/src/components/devices/DeviceList.tsx',
   'apps/web/src/components/devices/DevicePatchStatusTab.tsx',
   'apps/web/src/components/devices/DeviceSecurityTab.tsx',

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -119,7 +119,10 @@ export const createRoleSchema = z.object({
 // ============================================
 
 export const updateDeviceSchema = z.object({
-  displayName: z.string().max(255).optional(),
+  // Nullable so callers can explicitly clear the display name; the
+  // devices.display_name column is nullable. Keep in sync with the route
+  // schema in apps/api/src/routes/devices/schemas.ts.
+  displayName: z.string().max(255).nullable().optional(),
   siteId: z.string().uuid().optional(),
   tags: z.array(z.string().max(50)).max(20).optional()
 });


### PR DESCRIPTION
## Summary

The Display Name field on a device's Details tab was static text — the only way to edit it was via the kebab menu → Settings modal on the device list. Discoverability hole.

This adds the inline pencil-edit pattern already used by Role a few rows below: click pencil → input appears → Save (Enter or ✓) PATCHes `/devices/:id` with `{displayName}`, Cancel (Esc or ✗) reverts.

- Empty input clears the field (PATCH `{displayName: null}`).
- `maxLength` matches the API-side `updateDeviceSchema.max(255)`.
- Mirrors `handleSaveRole` exactly — same `fetchWithAuth` wrapper, same error-detail extraction, same `saveError` surface. No new modal, no new state machine.

Driven by [Discussion #736 follow-up] feedback that Display Name had no obvious editing path from the device detail page.

## Test plan

- [x] Click pencil → input pre-populates with current value
- [x] Empty + Save → field reads "Not set", server-side `display_name` cleared
- [x] Non-empty + Save → field reads new value, server-side row updated
- [x] Esc / ✗ → reverts to last saved value without PATCH
- [x] 401 → existing auth redirect handles it
- [x] Server error → `saveError` toast surfaces extractApiError message
- [x] Verified in prod (deployed via `breeze-web:multifix-v2-2026-05-20`)
