### PR TITLE
feat(devices): on-demand inventory refresh command + UI button

### DIFF
--- a/agent/internal/heartbeat/handlers.go
+++ b/agent/internal/heartbeat/handlers.go
@@ -56,6 +56,9 @@ var handlerRegistry = map[string]CommandHandler{
 	tools.CmdRebootSafeMode: handleRebootSafeMode,
 	tools.CmdWakeOnLan:      handleWakeOnLan,
 
+	// On-demand inventory refresh
+	tools.CmdRefreshInventory: handleRefreshInventory,
+
 	// Software inventory
 	tools.CmdCollectSoftware:   handleCollectSoftware,
 	tools.CmdSoftwareUninstall: handleSoftwareUninstall,
@@ -228,6 +231,37 @@ func handleLock(_ *Heartbeat, cmd Command) tools.CommandResult {
 
 func handleWakeOnLan(_ *Heartbeat, cmd Command) tools.CommandResult {
 	return tools.WakeOnLan(cmd.Payload)
+}
+
+// handleRefreshInventory triggers an immediate run of the full inventory cycle
+// (hardware, software, disk, network, configuration changes, sessions,
+// connections, patches, policy state, security status, Apple warranty). Each
+// collector is dispatched to its own goroutine via h.sendInventory(); the
+// returned result acknowledges the dispatch synchronously while data flows in
+// over the next 30s–2min as each collector completes.
+func handleRefreshInventory(h *Heartbeat, _ Command) tools.CommandResult {
+	start := time.Now()
+	if h.sendInventoryFn != nil {
+		h.sendInventoryFn()
+	} else {
+		h.sendInventory()
+	}
+	return tools.NewSuccessResult(map[string]any{
+		"dispatched": []string{
+			"hardware",
+			"software",
+			"disk",
+			"network",
+			"configuration_changes",
+			"session",
+			"connections",
+			"patch",
+			"policy_registry",
+			"policy_config",
+			"security_status",
+			"apple_warranty",
+		},
+	}, time.Since(start).Milliseconds())
 }
 
 func handleRebootSafeMode(h *Heartbeat, cmd Command) tools.CommandResult {

--- a/agent/internal/heartbeat/handlers_test.go
+++ b/agent/internal/heartbeat/handlers_test.go
@@ -1,6 +1,7 @@
 package heartbeat
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/breeze-rmm/agent/internal/remote/desktop"
@@ -22,6 +23,7 @@ var allCommandTypes = []string{
 	tools.CmdRegistrySet, tools.CmdRegistryDelete,
 	tools.CmdRegistryKeyCreate, tools.CmdRegistryKeyDelete,
 	tools.CmdReboot, tools.CmdShutdown, tools.CmdLock, tools.CmdRebootSafeMode, tools.CmdWakeOnLan,
+	tools.CmdRefreshInventory,
 	tools.CmdCollectSoftware, tools.CmdSoftwareUninstall, tools.CmdSoftwareInstall,
 	tools.CmdCollectBootPerformance, tools.CmdManageStartupItem,
 	tools.CmdCollectReliabilityMetrics,
@@ -145,6 +147,34 @@ func TestDispatchUnknownCommandReturnsFalse(t *testing.T) {
 	})
 	if handled {
 		t.Fatal("dispatchCommand should return false for unknown command type")
+	}
+}
+
+func TestHandleRefreshInventoryDispatchesSendInventory(t *testing.T) {
+	var called int
+	h := &Heartbeat{
+		sendInventoryFn: func() { called++ },
+	}
+
+	result := handleRefreshInventory(h, Command{ID: "test-refresh-1", Type: tools.CmdRefreshInventory})
+
+	if called != 1 {
+		t.Fatalf("sendInventoryFn called %d times, want 1", called)
+	}
+	if result.Status != "completed" {
+		t.Errorf("result.Status = %q, want %q", result.Status, "completed")
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("result.ExitCode = %d, want 0", result.ExitCode)
+	}
+	var payload struct {
+		Dispatched []string `json:"dispatched"`
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &payload); err != nil {
+		t.Fatalf("result.Stdout not valid JSON: %v (stdout=%q)", err, result.Stdout)
+	}
+	if len(payload.Dispatched) != 12 {
+		t.Errorf("dispatched len = %d, want 12 (one per send*Inventory collector)", len(payload.Dispatched))
 	}
 }
 

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -218,6 +218,11 @@ type Heartbeat struct {
 	// real sendHeartbeat call inside sendHeartbeatWithWatchdog. nil in
 	// production — the real sendHeartbeat method is invoked.
 	sendHeartbeatFn func()
+
+	// sendInventoryFn is an optional override used by tests to replace the
+	// real sendInventory call inside handleRefreshInventory. nil in
+	// production — the real sendInventory method is invoked.
+	sendInventoryFn func()
 }
 
 func New(cfg *config.Config) *Heartbeat {

--- a/agent/internal/remote/tools/types.go
+++ b/agent/internal/remote/tools/types.go
@@ -48,6 +48,11 @@ const (
 	CmdLock           = "lock"
 	CmdRebootSafeMode = "reboot_safe_mode"
 	CmdWakeOnLan      = "wake_on_lan"
+	// On-demand re-run of all inventory collectors. Triggers the same set of
+	// send*Inventory submissions the heartbeat fires periodically, so the API
+	// sees fresh hardware/software/network/etc. without waiting for the next
+	// scheduled cycle.
+	CmdRefreshInventory = "refresh_inventory"
 
 	// Software inventory
 	CmdCollectSoftware   = "collect_software"

--- a/apps/api/src/routes/devices/commands.test.ts
+++ b/apps/api/src/routes/devices/commands.test.ts
@@ -361,6 +361,50 @@ describe('device commands routes', () => {
       expect(auditPayload).not.toContain('abc123');
     });
 
+    it('queues a refresh_inventory command as a pending row', async () => {
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce({
+        id: 'device-a',
+        orgId: 'org-123',
+        hostname: 'host-a',
+        status: 'online'
+      } as never);
+
+      vi.mocked(db.insert).mockReturnValueOnce({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{
+            id: 'cmd-refresh',
+            deviceId: 'device-a',
+            type: 'refresh_inventory',
+            status: 'pending',
+            createdAt: new Date()
+          }])
+        })
+      } as never);
+
+      const res = await app.request('/devices/device-a/commands', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ type: 'refresh_inventory' })
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.type).toBe('refresh_inventory');
+      expect(body.status).toBe('pending');
+    });
+
+    it('rejects an unknown command type with 400', async () => {
+      const res = await app.request('/devices/device-a/commands', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ type: 'definitely_not_a_command' })
+      });
+
+      expect(res.status).toBe(400);
+      expect(vi.mocked(getDeviceWithOrgCheck)).not.toHaveBeenCalled();
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
     it('rejects generic script command requests with caller-controlled content', async () => {
       const res = await app.request('/devices/device-a/commands', {
         method: 'POST',

--- a/apps/api/src/routes/devices/schemas.ts
+++ b/apps/api/src/routes/devices/schemas.ts
@@ -44,7 +44,7 @@ export const createCommandSchema = z.object({
   // 'wake' is the user-facing wake action. Internally it dispatches via the
   // wakeOnLan service and writes a deviceCommands row of type 'wake_on_lan'
   // addressed to a relay agent. See apps/api/src/services/wakeOnLan.ts.
-  type: z.enum(['script', 'reboot', 'reboot_safe_mode', 'shutdown', 'update', 'collect_evidence', 'execute_containment', 'wake']),
+  type: z.enum(['script', 'reboot', 'reboot_safe_mode', 'shutdown', 'update', 'collect_evidence', 'execute_containment', 'wake', 'refresh_inventory']),
   payload: z.any().optional()
 });
 
@@ -59,7 +59,7 @@ export const BULK_COMMAND_MAX_DEVICES = 500;
 
 export const bulkCommandSchema = z.object({
   deviceIds: z.array(z.string().uuid()).min(1).max(BULK_COMMAND_MAX_DEVICES),
-  type: z.enum(['script', 'reboot', 'reboot_safe_mode', 'shutdown', 'update', 'collect_evidence', 'execute_containment', 'wake']),
+  type: z.enum(['script', 'reboot', 'reboot_safe_mode', 'shutdown', 'update', 'collect_evidence', 'execute_containment', 'wake', 'refresh_inventory']),
   payload: z.any().optional()
 });
 

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -128,6 +128,10 @@ export const CommandTypes = {
   REBOOT_SAFE_MODE: 'reboot_safe_mode',
   // Wake-on-LAN — sent to a relay agent on the target's LAN, not the offline target itself
   WAKE_ON_LAN: 'wake_on_lan',
+  // On-demand inventory refresh — agent re-runs every send*Inventory collector,
+  // so the API sees fresh hardware/software/network/etc. without waiting for
+  // the next periodic cycle.
+  REFRESH_INVENTORY: 'refresh_inventory',
   // Self-uninstall (remote wipe)
   SELF_UNINSTALL: 'self_uninstall',
   // Backup

--- a/apps/web/src/components/devices/DeviceActions.tsx
+++ b/apps/web/src/components/devices/DeviceActions.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import {
   Play,
   RotateCcw,
+  RefreshCw,
   Monitor,
   Settings,
   Power,
@@ -98,6 +99,16 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
               >
                 <Wrench className="h-4 w-4" />
                 Remote Tools
+              </button>
+              <button
+                type="button"
+                onClick={() => handleAction('refresh')}
+                disabled={device.status === 'offline'}
+                title="Re-run agent inventory collectors so the UI sees fresh hardware/software/network data without waiting for the next heartbeat cycle"
+                className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <RefreshCw className="h-4 w-4" />
+                Refresh
               </button>
               <button
                 type="button"
@@ -211,6 +222,16 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
         >
           <Wrench className="h-4 w-4" />
           Remote Tools
+        </button>
+        <button
+          type="button"
+          onClick={() => handleAction('refresh')}
+          disabled={device.status === 'offline' || loading}
+          title="Re-run agent inventory collectors so the UI sees fresh hardware/software/network data without waiting for the next heartbeat cycle"
+          className="flex items-center gap-2 rounded-md border bg-background px-4 py-2 text-sm font-medium transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <RefreshCw className="h-4 w-4" />
+          Refresh
         </button>
         <button
           type="button"

--- a/apps/web/src/components/devices/DeviceDetailPage.tsx
+++ b/apps/web/src/components/devices/DeviceDetailPage.tsx
@@ -168,6 +168,15 @@ export default function DeviceDetailPage({ deviceId }: DeviceDetailPageProps) {
           break;
         }
 
+        case 'refresh': {
+          await sendDeviceCommand(device.id, 'refresh_inventory');
+          showToast({
+            type: 'success',
+            message: `Inventory refresh requested for ${device.hostname}. Fresh data in 1–2 minutes.`,
+          });
+          break;
+        }
+
         case 'maintenance': {
           const isCurrentlyMaintenance = device.status === 'maintenance';
           await toggleMaintenanceMode(device.id, !isCurrentlyMaintenance);

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -302,6 +302,15 @@ export default function DevicesPage() {
           break;
         }
 
+        case 'refresh': {
+          await sendDeviceCommand(device.id, 'refresh_inventory');
+          showToast({
+            type: 'success',
+            message: `Inventory refresh requested for ${device.hostname}. Fresh data in 1–2 minutes.`,
+          });
+          break;
+        }
+
         case 'maintenance':
           const isCurrentlyMaintenance = device.status === 'maintenance';
           await toggleMaintenanceMode(device.id, !isCurrentlyMaintenance);


### PR DESCRIPTION
## Summary

Adds a new agent command `refresh_inventory` plus a "Refresh" UI button so a Breeze admin can force the agent to re-run every inventory collector right now, instead of waiting for the next periodic cycle.

Real-world driver: an admin renames a Windows host, replaces a NIC, installs/uninstalls software, or changes the device role. The agent eventually picks this up at its next inventory tick, but the wait is annoying when you're verifying a change. A one-click "Refresh" is the obvious shortcut and several PSA/RMM products have it as a top-level action on the device page.

## What it does

- **Agent:** new `tools.CmdRefreshInventory = "refresh_inventory"` constant. `handleRefreshInventory` calls the existing `h.sendInventory()` fan-out (hardware, software, disk, network, configuration changes, sessions, connections, patches, policy state, security status, Apple warranty — 12 collectors), then returns a synchronous ack listing what was dispatched. Actual inventory submissions stream in over the next 30s–2min as each collector finishes, exactly like the periodic heartbeat path. No new concurrency surface.
- **API:** `createCommandSchema` accepts `'refresh_inventory'`; the generic `POST /devices/:id/commands` insert writes the type to `device_commands` as-is. No new service, no new endpoint, no migration. `CommandTypes.REFRESH_INVENTORY` added to the registry.
- **Web:** "Refresh" button next to the existing Reboot button on the device list kebab + the device detail action bar. Disabled when the device is offline. Toast: _"Inventory refresh requested — fresh data in 1–2 minutes."_

## What it doesn't do

- No bulk refresh-on-many endpoint. Easy follow-up if it's useful, but the bulk case is rare for refresh (you'd just re-run all agents every N min, which is what the heartbeat already does).
- No streaming-status toast that watches the collectors complete. The toast is fire-and-forget; the next page refresh shows the new values. Could be paired with a polling toast similar to the wake feedback, but that's a separate UX choice.

## Test plan

- [x] `go test ./internal/heartbeat/` — `TestHandlerRegistryCompleteness` confirms the new command type has a handler; `TestHandleRefreshInventoryDispatchesSendInventory` asserts `sendInventory` is called exactly once and the result lists all 12 collectors.
- [x] `pnpm test src/routes/devices/commands.test.ts` — 18 pass, including new "queues a refresh_inventory command as a pending row" and the "unknown command type → 400" guard.
- [x] `pnpm test src/services/commandQueue.test.ts` — unchanged-green.
- [x] `pnpm exec tsc --noEmit` (apps/web) — clean.
- [ ] Manual smoke once deployed: click Refresh on a live device → toast appears → within 1–2 minutes the device's hardware/software fields show fresh `last_seen_at` timestamps. (Will verify against my home fleet after build.)
