### PR TITLE
feat(web): smart wake toast — active status polling instead of "wait 5 min"

### DIFF
--- a/apps/web/src/components/devices/DeviceDetailPage.tsx
+++ b/apps/web/src/components/devices/DeviceDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useEventStream } from '../../hooks/useEventStream';
 import { ArrowLeft } from 'lucide-react';
 import { showToast } from '../shared/Toast';
@@ -25,6 +25,22 @@ export default function DeviceDetailPage({ deviceId }: DeviceDetailPageProps) {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [changeSiteOpen, setChangeSiteOpen] = useState(false);
   const [scriptPickerOpen, setScriptPickerOpen] = useState(false);
+
+  // Track every in-flight wake watcher so that navigating away aborts the
+  // long-running poll loop. Without this, watchWakeOutcome keeps polling
+  // /devices/:id for up to 4 minutes after unmount and tries to render a
+  // toast / setDevice on a dead component. (Todd's #789 review.) A Set is
+  // used because a single device-detail page can only have one wake at a
+  // time, but the abstraction matches the multi-target DevicesPage path
+  // and is cheap.
+  const wakeWatchersRef = useRef<Set<AbortController>>(new Set());
+  useEffect(() => {
+    const watchers = wakeWatchersRef.current;
+    return () => {
+      for (const ctrl of watchers) ctrl.abort();
+      watchers.clear();
+    };
+  }, []);
 
   const fetchDevice = useCallback(async () => {
     try {
@@ -158,18 +174,24 @@ export default function DeviceDetailPage({ deviceId }: DeviceDetailPageProps) {
               type: 'success',
               message: `Wake packet sent to ${hostname} via ${wake.relay.hostname} (${wake.broadcast}). Watching for it to come online…`,
             });
-            void watchWakeOutcome(device.id).then(async (outcome) => {
-              if (outcome === 'online') {
-                showToast({ type: 'success', message: `${hostname} is now online.` });
-                await fetchDevice();
-              } else if (outcome === 'timeout') {
-                showToast({
-                  type: 'error',
-                  message: `${hostname} did not come online within 4 minutes. Check ethernet + BIOS WoL.`,
-                });
-              }
-              // 'aborted' is silent — user navigated away or page reloaded.
-            });
+            const wakeController = new AbortController();
+            wakeWatchersRef.current.add(wakeController);
+            void watchWakeOutcome(device.id, { signal: wakeController.signal })
+              .then(async (outcome) => {
+                if (outcome === 'online') {
+                  showToast({ type: 'success', message: `${hostname} is now online.` });
+                  await fetchDevice();
+                } else if (outcome === 'timeout') {
+                  showToast({
+                    type: 'error',
+                    message: `${hostname} did not come online within 4 minutes. Check ethernet + BIOS WoL.`,
+                  });
+                }
+                // 'aborted' is silent — user navigated away or page reloaded.
+              })
+              .finally(() => {
+                wakeWatchersRef.current.delete(wakeController);
+              });
           } catch (err) {
             if (err instanceof WakeCommandError) {
               const friendly = wakeFriendlyErrorMessage(err.code) ?? err.message;

--- a/apps/web/src/components/devices/DeviceDetailPage.tsx
+++ b/apps/web/src/components/devices/DeviceDetailPage.tsx
@@ -8,7 +8,7 @@ import ChangeSiteModal from './ChangeSiteModal';
 import ScriptPickerModal, { type Script, type ScriptRunAsSelection } from './ScriptPickerModal';
 import type { Device, DeviceStatus, OSType } from './DeviceList';
 import { fetchWithAuth } from '../../stores/auth';
-import { sendDeviceCommand, executeScript, toggleMaintenanceMode, decommissionDevice, clearDeviceSessions, restoreDevice, permanentDeleteDevice, sendWakeCommand, WakeCommandError, wakeFriendlyErrorMessage } from '../../services/deviceActions';
+import { sendDeviceCommand, executeScript, toggleMaintenanceMode, decommissionDevice, clearDeviceSessions, restoreDevice, permanentDeleteDevice, sendWakeCommand, watchWakeOutcome, WakeCommandError, wakeFriendlyErrorMessage } from '../../services/deviceActions';
 import { useAiStore } from '@/stores/aiStore';
 import { navigateTo } from '@/lib/navigation';
 import Breadcrumbs from '../layout/Breadcrumbs';
@@ -153,9 +153,22 @@ export default function DeviceDetailPage({ deviceId }: DeviceDetailPageProps) {
         case 'wake': {
           try {
             const wake = await sendWakeCommand(device.id);
+            const hostname = device.hostname;
             showToast({
               type: 'success',
-              message: `Wake packet sent to ${device.hostname} via ${wake.relay.hostname} (${wake.broadcast}). Wait up to 5 min for it to come online.`,
+              message: `Wake packet sent to ${hostname} via ${wake.relay.hostname} (${wake.broadcast}). Watching for it to come online…`,
+            });
+            void watchWakeOutcome(device.id).then(async (outcome) => {
+              if (outcome === 'online') {
+                showToast({ type: 'success', message: `${hostname} is now online.` });
+                await fetchDevice();
+              } else if (outcome === 'timeout') {
+                showToast({
+                  type: 'error',
+                  message: `${hostname} did not come online within 4 minutes. Check ethernet + BIOS WoL.`,
+                });
+              }
+              // 'aborted' is silent — user navigated away or page reloaded.
             });
           } catch (err) {
             if (err instanceof WakeCommandError) {

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -12,7 +12,7 @@ import AddDeviceModal from './AddDeviceModal';
 import CreateGroupModal from './CreateGroupModal';
 import { DeviceFilterBar } from '../filters/DeviceFilterBar';
 import { fetchWithAuth } from '../../stores/auth';
-import { sendDeviceCommand, sendBulkCommand, executeScript, toggleMaintenanceMode, decommissionDevice, bulkDecommissionDevices, restoreDevice, permanentDeleteDevice, sendWakeCommand, sendBulkWakeCommand, summarizeBulkWakeFailures, WakeCommandError, wakeFriendlyErrorMessage } from '../../services/deviceActions';
+import { sendDeviceCommand, sendBulkCommand, executeScript, toggleMaintenanceMode, decommissionDevice, bulkDecommissionDevices, restoreDevice, permanentDeleteDevice, sendWakeCommand, sendBulkWakeCommand, summarizeBulkWakeFailures, watchWakeOutcome, WakeCommandError, wakeFriendlyErrorMessage } from '../../services/deviceActions';
 import { navigateTo } from '@/lib/navigation';
 import { getErrorMessage, getErrorTitle } from '@/lib/errorMessages';
 import { asRecord, toPercent } from '@/lib/deviceUtils';
@@ -287,9 +287,21 @@ export default function DevicesPage() {
         case 'wake': {
           try {
             const wake = await sendWakeCommand(device.id);
+            const hostname = device.hostname;
             showToast({
               type: 'success',
-              message: `Wake packet sent to ${device.hostname} via ${wake.relay.hostname} (${wake.broadcast}). Wait up to 5 min for it to come online.`,
+              message: `Wake packet sent to ${hostname} via ${wake.relay.hostname} (${wake.broadcast}). Watching for it to come online…`,
+            });
+            void watchWakeOutcome(device.id).then(async (outcome) => {
+              if (outcome === 'online') {
+                showToast({ type: 'success', message: `${hostname} is now online.` });
+                await fetchDevices();
+              } else if (outcome === 'timeout') {
+                showToast({
+                  type: 'error',
+                  message: `${hostname} did not come online within 4 minutes. Check ethernet + BIOS WoL.`,
+                });
+              }
             });
           } catch (err) {
             if (err instanceof WakeCommandError) {

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useEventStream } from '../../hooks/useEventStream';
 import { List, Grid, Plus, AlertCircle } from 'lucide-react';
 import { showToast } from '../shared/Toast';
@@ -59,6 +59,21 @@ export default function DevicesPage() {
   const [advancedFilter, setAdvancedFilter] = useState<FilterConditionGroup | null>(null);
   const [showCreateGroup, setShowCreateGroup] = useState(false);
   const [autoSelectGroupId, setAutoSelectGroupId] = useState<string | null>(null);
+
+  // Track every in-flight wake watcher so navigating away aborts the
+  // long-running poll loop. Without this, each wake fired on this page
+  // keeps polling /devices/:id for up to 4 minutes after unmount and
+  // attempts setState (via showToast + fetchDevices) on a dead component.
+  // (Todd's #789 review.) A user can wake several rows in quick
+  // succession, hence a Set rather than a single controller.
+  const wakeWatchersRef = useRef<Set<AbortController>>(new Set());
+  useEffect(() => {
+    const watchers = wakeWatchersRef.current;
+    return () => {
+      for (const ctrl of watchers) ctrl.abort();
+      watchers.clear();
+    };
+  }, []);
 
   const scriptTargetLabel =
     scriptTargetDevices.length === 1
@@ -292,17 +307,24 @@ export default function DevicesPage() {
               type: 'success',
               message: `Wake packet sent to ${hostname} via ${wake.relay.hostname} (${wake.broadcast}). Watching for it to come online…`,
             });
-            void watchWakeOutcome(device.id).then(async (outcome) => {
-              if (outcome === 'online') {
-                showToast({ type: 'success', message: `${hostname} is now online.` });
-                await fetchDevices();
-              } else if (outcome === 'timeout') {
-                showToast({
-                  type: 'error',
-                  message: `${hostname} did not come online within 4 minutes. Check ethernet + BIOS WoL.`,
-                });
-              }
-            });
+            const wakeController = new AbortController();
+            wakeWatchersRef.current.add(wakeController);
+            void watchWakeOutcome(device.id, { signal: wakeController.signal })
+              .then(async (outcome) => {
+                if (outcome === 'online') {
+                  showToast({ type: 'success', message: `${hostname} is now online.` });
+                  await fetchDevices();
+                } else if (outcome === 'timeout') {
+                  showToast({
+                    type: 'error',
+                    message: `${hostname} did not come online within 4 minutes. Check ethernet + BIOS WoL.`,
+                  });
+                }
+                // 'aborted' is silent — user navigated away or page reloaded.
+              })
+              .finally(() => {
+                wakeWatchersRef.current.delete(wakeController);
+              });
           } catch (err) {
             if (err instanceof WakeCommandError) {
               const friendly = wakeFriendlyErrorMessage(err.code) ?? err.message;

--- a/apps/web/src/services/__tests__/deviceActions.test.ts
+++ b/apps/web/src/services/__tests__/deviceActions.test.ts
@@ -10,6 +10,7 @@ import {
   sendWakeCommand,
   summarizeBulkWakeFailures,
   toggleMaintenanceMode,
+  watchWakeOutcome,
   WakeCommandError,
   wakeFriendlyErrorMessage,
   type BulkWakeFailed
@@ -292,6 +293,66 @@ describe('deviceActions service', () => {
       const err = await sendWakeCommand('dev-1').catch((e: unknown) => e);
       expect(err).toBeInstanceOf(WakeCommandError);
       expect((err as WakeCommandError).code).toBeUndefined();
+    });
+  });
+
+  describe('watchWakeOutcome', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    it('resolves "online" when the device transitions to online', async () => {
+      fetchWithAuthMock
+        .mockResolvedValueOnce(makeResponse({ device: { status: 'offline' } }))
+        .mockResolvedValueOnce(makeResponse({ device: { status: 'offline' } }))
+        .mockResolvedValueOnce(makeResponse({ device: { status: 'online' } }));
+
+      const promise = watchWakeOutcome('dev-1', { pollIntervalMs: 100, timeoutMs: 60_000 });
+      await vi.advanceTimersByTimeAsync(350);
+      await expect(promise).resolves.toBe('online');
+      expect(fetchWithAuthMock).toHaveBeenCalledTimes(3);
+      expect(fetchWithAuthMock).toHaveBeenCalledWith('/devices/dev-1');
+    });
+
+    it('resolves "timeout" if the device never transitions before timeoutMs', async () => {
+      fetchWithAuthMock.mockResolvedValue(makeResponse({ device: { status: 'offline' } }));
+
+      const promise = watchWakeOutcome('dev-1', { pollIntervalMs: 100, timeoutMs: 300 });
+      await vi.advanceTimersByTimeAsync(400);
+      await expect(promise).resolves.toBe('timeout');
+    });
+
+    it('resolves "aborted" when the signal is aborted mid-poll', async () => {
+      fetchWithAuthMock.mockResolvedValue(makeResponse({ device: { status: 'offline' } }));
+      const ctrl = new AbortController();
+
+      const promise = watchWakeOutcome('dev-1', {
+        pollIntervalMs: 1000,
+        timeoutMs: 60_000,
+        signal: ctrl.signal,
+      });
+      ctrl.abort();
+      await vi.advanceTimersByTimeAsync(50);
+      await expect(promise).resolves.toBe('aborted');
+    });
+
+    it('keeps polling through transient HTTP errors', async () => {
+      fetchWithAuthMock
+        .mockRejectedValueOnce(new Error('network down'))
+        .mockResolvedValueOnce(makeResponse({ device: { status: 'offline' } }, false, 503))
+        .mockResolvedValueOnce(makeResponse({ device: { status: 'online' } }));
+
+      const promise = watchWakeOutcome('dev-1', { pollIntervalMs: 50, timeoutMs: 60_000 });
+      await vi.advanceTimersByTimeAsync(200);
+      await expect(promise).resolves.toBe('online');
+    });
+
+    it('accepts `data` or `device` payload shapes from /devices/:id', async () => {
+      fetchWithAuthMock.mockResolvedValueOnce(makeResponse({ data: { status: 'online' } }));
+
+      const promise = watchWakeOutcome('dev-1', { pollIntervalMs: 10, timeoutMs: 60_000 });
+      await vi.advanceTimersByTimeAsync(50);
+      await expect(promise).resolves.toBe('online');
     });
   });
 

--- a/apps/web/src/services/deviceActions.ts
+++ b/apps/web/src/services/deviceActions.ts
@@ -93,6 +93,73 @@ export function wakeFriendlyErrorMessage(code: string | undefined): string | nul
   }
 }
 
+export type WakeOutcome = 'online' | 'timeout' | 'aborted' | 'still-offline';
+
+export interface WatchWakeOutcomeOptions {
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+// Polls /devices/:id after a successful wake dispatch and resolves when the
+// device transitions to 'online' or the timeout elapses. Best-effort: a
+// transient HTTP error doesn't abort, it just skips one poll. Caller fires
+// the user-visible follow-up toast based on the resolved outcome.
+//
+// Defaults: 8s poll interval, 4-minute total timeout. The existing
+// 5-min wake guidance covers the worst-case BIOS POST + Windows boot;
+// 4 min on the watcher prevents the toast from outlasting the user's
+// attention while still catching most successful wakes.
+export async function watchWakeOutcome(
+  deviceId: string,
+  opts: WatchWakeOutcomeOptions = {}
+): Promise<WakeOutcome> {
+  const interval = opts.pollIntervalMs ?? 8000;
+  const totalTimeout = opts.timeoutMs ?? 4 * 60 * 1000;
+  const deadline = Date.now() + totalTimeout;
+
+  while (Date.now() < deadline) {
+    if (opts.signal?.aborted) return 'aborted';
+
+    const remaining = deadline - Date.now();
+    const sleepFor = Math.min(interval, remaining);
+    if (sleepFor <= 0) break;
+    await waitOrAbort(sleepFor, opts.signal);
+    if (opts.signal?.aborted) return 'aborted';
+
+    try {
+      const resp = await fetchWithAuth(`/devices/${deviceId}`);
+      if (!resp.ok) continue;
+      const body = await resp.json();
+      const device = body.device ?? body.data ?? body;
+      if (device?.status === 'online') return 'online';
+    } catch {
+      // Network blip during polling is not an error condition for the
+      // wake outcome — just try again on the next tick.
+    }
+  }
+
+  return 'timeout';
+}
+
+function waitOrAbort(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    function onAbort() {
+      clearTimeout(timer);
+      resolve();
+    }
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
 export async function sendWakeCommand(deviceId: string): Promise<WakeResponse> {
   const response = await fetchWithAuth(`/devices/${deviceId}/commands`, {
     method: 'POST',


### PR DESCRIPTION
## Summary

The current wake toast says _"Wait up to 5 min for it to come online"_ and then disappears in 5 seconds. The user has to manually refresh the device list or detail page to find out whether the wake actually worked.

This replaces the static guidance with active polling. After a successful wake dispatch:

1. Initial toast: _"Wake packet sent via PEER-01 (10.0.1.255). Watching for it to come online…"_
2. Poll `GET /devices/:id` every 8 seconds for up to 4 minutes.
3. On `status === 'online'` → follow-up toast _"<host> is now online."_ and trigger `fetchDevices()`/`fetchDevice()` so the UI reflects the new state immediately.
4. On 4-minute timeout → error toast _"<host> did not come online within 4 minutes. Check ethernet + BIOS WoL."_
5. `AbortSignal`-aware: caller can cancel the watcher (route change, etc.). Resolves silently on `aborted`.

## Why a watcher helper, not a toast-update API

The existing toast API is fire-and-forget — no stable id, no `updateToast`. A proper toast-update API would be invasive enough to warrant its own PR and design discussion. The two-toast pattern (dispatch + outcome) is the minimal change that gives users the feedback they actually want, with no new global state.

Best-effort polling: a transient HTTP error or network blip during the watch skips that poll and tries again on the next tick. Only a hard 4-minute deadline transitions to `timeout`.

## What it doesn't do

- **Single-device wake only.** Bulk wake's per-device outcome would need a different summary surface (you don't want 50 toasts for a 50-device bulk). That's a separate UX problem.
- **No toast deduplication.** If the user fires another wake while a previous watcher is still running, you get two simultaneous watchers and two follow-up toasts. Rare in practice; not worth the complexity to dedup right now.

## Test plan

- [x] `pnpm test src/services/__tests__/deviceActions.test.ts` — 30 pass (25 prior + 5 new):
  - online-after-N-polls
  - timeout when never online
  - aborted via AbortSignal
  - HTTP-error / rejection resilience (keeps polling)
  - payload shape `{device:...}` or `{data:...}`
- [x] `pnpm exec tsc --noEmit` (apps/web) — clean.
- [ ] Manual smoke once deployed: wake an offline LAN device → initial toast → ~30s later "now online" toast + the device row flips status. (Will verify against home fleet after build.)
