### PR TITLE
fix(heartbeat): accept pseudo-interface MAC addresses up to 64 chars

### DIFF
--- a/apps/api/src/routes/agents/schemas.ts
+++ b/apps/api/src/routes/agents/schemas.ts
@@ -101,7 +101,11 @@ export const heartbeatSchema = z.object({
       ),
       ipType: z.enum(['ipv4', 'ipv6']).optional(),
       assignmentType: z.enum(['dhcp', 'static', 'vpn', 'link-local', 'unknown']).optional(),
-      macAddress: z.string().max(17).optional(),
+      // Standard MAC is 17 chars (XX:XX:XX:XX:XX:XX), but Windows pseudo-
+      // interfaces (ISATAP, Teredo, etc.) report longer EUI-64 / tunnel forms
+      // up to ~53 chars. Accept anything reasonable to avoid rejecting the
+      // whole heartbeat over an informational field.
+      macAddress: z.string().max(64).optional(),
       subnetMask: z.string().max(45).optional(),
       gateway: z.string().max(45).optional(),
       dnsServers: z.array(z.string().max(45)).max(8).optional()
@@ -117,7 +121,11 @@ export const heartbeatSchema = z.object({
       ),
       ipType: z.enum(['ipv4', 'ipv6']).optional(),
       assignmentType: z.enum(['dhcp', 'static', 'vpn', 'link-local', 'unknown']).optional(),
-      macAddress: z.string().max(17).optional(),
+      // Standard MAC is 17 chars (XX:XX:XX:XX:XX:XX), but Windows pseudo-
+      // interfaces (ISATAP, Teredo, etc.) report longer EUI-64 / tunnel forms
+      // up to ~53 chars. Accept anything reasonable to avoid rejecting the
+      // whole heartbeat over an informational field.
+      macAddress: z.string().max(64).optional(),
       subnetMask: z.string().max(45).optional(),
       gateway: z.string().max(45).optional(),
       dnsServers: z.array(z.string().max(45)).max(8).optional()
@@ -133,7 +141,11 @@ export const heartbeatSchema = z.object({
       ),
       ipType: z.enum(['ipv4', 'ipv6']).optional(),
       assignmentType: z.enum(['dhcp', 'static', 'vpn', 'link-local', 'unknown']).optional(),
-      macAddress: z.string().max(17).optional(),
+      // Standard MAC is 17 chars (XX:XX:XX:XX:XX:XX), but Windows pseudo-
+      // interfaces (ISATAP, Teredo, etc.) report longer EUI-64 / tunnel forms
+      // up to ~53 chars. Accept anything reasonable to avoid rejecting the
+      // whole heartbeat over an informational field.
+      macAddress: z.string().max(64).optional(),
       subnetMask: z.string().max(45).optional(),
       gateway: z.string().max(45).optional(),
       dnsServers: z.array(z.string().max(45)).max(8).optional()


### PR DESCRIPTION
The `macAddress` field on `ipHistoryUpdate.currentIPs|changedIPs|removedIPs`
in the heartbeat schema enforces `max(17)`, which fits a standard MAC
(`XX:XX:XX:XX:XX:XX`) but rejects Windows pseudo-interface MACs.

ISATAP, Teredo, and 6to4 interfaces report longer EUI-64 / tunnel forms,
e.g. `00-00-00-00-00-00-00-E0-00-00-00-00` (35 chars). When the agent
includes one of these in `ipHistoryUpdate`, Zod rejects the entire
heartbeat with a 400 — the device falls offline in the UI even though
the agent is healthy, watchdog is reporting, and the host is reachable
everywhere else.

Affected hosts in our fleet: Domain Controllers and any workstation
where IPv6 transition tunnels are enabled (Win10/11 default). Repro:
run an agent on a host with active ISATAP/Teredo, watch every
heartbeat 400 and the device drop offline within the inactivity window.

Fix: widen `macAddress` cap from 17 to 64 across all three IP arrays.
The downstream `device_ip_history.mac_address` column is `varchar(17)`
so `normalizeOptionalString(..., 17)` already clamps before insert;
widening the schema only changes what gets accepted at the boundary.

No behaviour change for hosts with only standard MAC addresses.