### PR TITLE
perf(audit-logs): skipCount query param to bypass count(*) on dashboard widget

### DIFF
--- a/apps/api/src/routes/auditLogs.ts
+++ b/apps/api/src/routes/auditLogs.ts
@@ -33,7 +33,10 @@ const listLogsSchema = z.object({
   action: z.string().min(1).optional(),
   resource: z.string().min(1).optional(),
   from: z.string().datetime().optional(),
-  to: z.string().datetime().optional()
+  to: z.string().datetime().optional(),
+  // RecentActivity widget doesn't display "X of Y total"; the count(*) is a
+  // 2-3s RLS-bound scan even with an index. Pass skipCount=true to skip it.
+  skipCount: z.enum(['true', 'false']).optional()
 });
 
 const searchSchema = listLogsSchema.extend({
@@ -428,8 +431,12 @@ function paginatedListHandler(
 
     const orgCond = auth.orgCondition(auditLogsTable.orgId);
     const where = buildFilterConditions(orgCond, query);
+    // count(*) on audit_logs is 2-3s under RLS even with the org_timestamp
+    // index. The dashboard widget that calls /logs?limit=5 doesn't need the
+    // count — it never displays "X of Y total". Pass skipCount=true there.
+    const skipCount = query.skipCount === 'true';
     const [total, rows] = await Promise.all([
-      countRows(where),
+      skipCount ? Promise.resolve(-1) : countRows(where),
       queryRows(where, limit, offset)
     ]);
 
@@ -439,7 +446,7 @@ function paginatedListHandler(
         page,
         limit,
         total,
-        totalPages: Math.ceil(total / limit)
+        totalPages: total < 0 ? -1 : Math.ceil(total / limit)
       }
     });
   };

--- a/apps/web/src/components/dashboard/RecentActivity.tsx
+++ b/apps/web/src/components/dashboard/RecentActivity.tsx
@@ -47,7 +47,7 @@ export default function RecentActivity() {
         setIsLoading(true);
         setError(null);
 
-        const response = await fetchWithAuth('/audit-logs/logs?limit=5');
+        const response = await fetchWithAuth('/audit-logs/logs?limit=5&skipCount=true');
 
         if (!response.ok) {
           throw response;


### PR DESCRIPTION
The dashboard `RecentActivity` widget calls
`GET /audit-logs/logs?limit=5` to render the most recent 5 audit
events. The `paginatedListHandler` always runs `count(*)` to populate
pagination metadata — but the widget never displays "X of Y total".

Under RLS (`breeze_app` role with `breeze_has_org_access(org_id)` SELECT
policy), `count(*)` on `audit_logs` takes ~2.8s on a 600k-row table
because the CASE wrapper in the policy can't be combined with the
`(org_id, timestamp DESC)` index — the planner falls back to a
Parallel Seq Scan.

Add an optional `skipCount=true` query param. When set, the handler
skips `countRows()` and returns `pagination.total = -1`. The widget
opts in; full audit-log viewer keeps exact pagination.