### PR TITLE
perf(audit-logs): LATERAL per-org index scan when skipCount + no filters

### DIFF
--- a/apps/api/src/routes/auditLogs.ts
+++ b/apps/api/src/routes/auditLogs.ts
@@ -307,6 +307,76 @@ async function queryRows(where: SQL | undefined, limit: number, offset: number):
     .offset(offset);
 }
 
+// Fast path for the dashboard widget (RecentActivity): the RLS CASE in
+// breeze_has_org_access() cannot be pushed into audit_logs_org_timestamp_idx,
+// so a plain ORDER BY timestamp DESC LIMIT N degrades to a Parallel Seq Scan
+// over the whole table (~28s in prod). LATERAL per-org index scans gather N
+// rows per accessible org, then top-N sort. ~9ms under RLS.
+interface LateralAuditRow extends Record<string, unknown> {
+  id: string;
+  org_id: string | null;
+  timestamp: Date | string;
+  actor_type: 'user' | 'api_key' | 'agent' | 'system';
+  actor_id: string;
+  actor_email: string | null;
+  action: string;
+  resource_type: string;
+  resource_id: string | null;
+  resource_name: string | null;
+  details: unknown;
+  ip_address: string | null;
+  user_agent: string | null;
+  result: 'success' | 'failure' | 'denied';
+  error_message: string | null;
+  checksum: string | null;
+  initiated_by: string | null;
+  user_name: string | null;
+}
+
+async function queryLatestPerOrg(orgIds: string[], limit: number): Promise<DbRow[]> {
+  const orgIdsSql = sql.join(orgIds.map((id) => sql`${id}::uuid`), sql`, `);
+  const rows = await db.execute<LateralAuditRow>(sql`
+    SELECT
+      al.id, al.org_id, al.timestamp, al.actor_type, al.actor_id,
+      al.actor_email, al.action, al.resource_type, al.resource_id,
+      al.resource_name, al.details, al.ip_address, al.user_agent,
+      al.result, al.error_message, al.checksum, al.initiated_by,
+      u.name AS user_name
+    FROM unnest(ARRAY[${orgIdsSql}]::uuid[]) AS o(org_id)
+    CROSS JOIN LATERAL (
+      SELECT * FROM audit_logs
+      WHERE audit_logs.org_id = o.org_id
+      ORDER BY timestamp DESC
+      LIMIT ${limit}
+    ) al
+    LEFT JOIN users u ON al.actor_id = u.id
+    ORDER BY al.timestamp DESC
+    LIMIT ${limit}
+  `);
+  return rows.map((r) => ({
+    log: {
+      id: r.id,
+      orgId: r.org_id,
+      timestamp: r.timestamp instanceof Date ? r.timestamp : new Date(r.timestamp),
+      actorType: r.actor_type,
+      actorId: r.actor_id,
+      actorEmail: r.actor_email,
+      action: r.action,
+      resourceType: r.resource_type,
+      resourceId: r.resource_id,
+      resourceName: r.resource_name,
+      details: r.details,
+      ipAddress: r.ip_address,
+      userAgent: r.user_agent,
+      result: r.result,
+      errorMessage: r.error_message,
+      checksum: r.checksum,
+      initiatedBy: r.initiated_by,
+    } as DbRow['log'],
+    userName: r.user_name ?? null,
+  }));
+}
+
 async function countRows(where: SQL | undefined): Promise<number> {
   const [row] = await db
     .select({ count: sql<number>`count(*)::int` })
@@ -435,9 +505,18 @@ function paginatedListHandler(
     // index. The dashboard widget that calls /logs?limit=5 doesn't need the
     // count — it never displays "X of Y total". Pass skipCount=true there.
     const skipCount = query.skipCount === 'true';
+    const hasFilters = !!(query.user || query.action || query.resource || query.from || query.to);
+    const canUseFastPath =
+      skipCount &&
+      offset === 0 &&
+      !hasFilters &&
+      Array.isArray(auth.accessibleOrgIds) &&
+      auth.accessibleOrgIds.length > 0;
     const [total, rows] = await Promise.all([
       skipCount ? Promise.resolve(-1) : countRows(where),
-      queryRows(where, limit, offset)
+      canUseFastPath
+        ? queryLatestPerOrg(auth.accessibleOrgIds as string[], limit)
+        : queryRows(where, limit, offset)
     ]);
 
     return c.json({


### PR DESCRIPTION
Even after skipping `count(*)`, the row fetch itself is slow under RLS.
The policy's `CASE WHEN breeze_current_scope() = 'system' THEN TRUE
WHEN org_id IS NULL THEN FALSE ELSE org_id = ANY(breeze_accessible_org_ids()) END`
prevents the planner from pushing the predicate into
`audit_logs_org_timestamp_idx`. `ORDER BY timestamp DESC LIMIT N`
degrades to a Parallel Seq Scan over the whole table (~28s in prod on
~600k rows).

LATERAL pattern: `unnest(accessible_org_ids)` then index-scan top-N
per org via `audit_logs_org_timestamp_idx`, merge and re-sort to the
outer limit. EXPLAIN ANALYZE under `breeze_app`: 9ms (vs 6486ms).
End-to-end through the API: ~80-100ms (vs 28-30s).

The fast path triggers when:
- `skipCount=true`
- `offset === 0`
- no filters (user/action/resource/from/to)
- `auth.accessibleOrgIds` is a finite non-empty list

Everything else falls back to the existing query.

Depends on #791.