### PR TITLE
feat(audit-logs): resolve agent actor to device hostname

### DIFF
--- a/apps/api/src/routes/audit.test.ts
+++ b/apps/api/src/routes/audit.test.ts
@@ -14,22 +14,27 @@ vi.mock('../services/auditEvents', () => ({
   writeRouteAudit: vi.fn()
 }));
 
-// countRows does: db.select().from().leftJoin().where() and destructures [row]
-// queryRows does: db.select().from().leftJoin().where().orderBy().limit().offset()
+// countRows does: db.select().from().where() and destructures [row]
+// queryRows does: db.select().from().leftJoin(users).leftJoin(devices).where().orderBy().limit().offset()
 // So .where() must be both iterable (as array) AND have .orderBy()
+const createWhereChain = () =>
+  Object.assign(Promise.resolve([{ count: 0 }]), {
+    orderBy: vi.fn().mockReturnValue({
+      limit: vi.fn().mockReturnValue({
+        offset: vi.fn().mockResolvedValue([])
+      })
+    })
+  });
+const createJoinChain = () => {
+  const chain: any = {
+    leftJoin: vi.fn(() => chain),
+    where: vi.fn().mockReturnValue(createWhereChain())
+  };
+  return chain;
+};
 const createDbChain = () => ({
   from: vi.fn().mockReturnValue({
-    leftJoin: vi.fn().mockReturnValue({
-      where: vi.fn().mockReturnValue(
-        Object.assign(Promise.resolve([{ count: 0 }]), {
-          orderBy: vi.fn().mockReturnValue({
-            limit: vi.fn().mockReturnValue({
-              offset: vi.fn().mockResolvedValue([])
-            })
-          })
-        })
-      )
-    }),
+    leftJoin: vi.fn(() => createJoinChain()),
     where: vi.fn().mockResolvedValue([{ count: 0 }])
   })
 });
@@ -48,7 +53,8 @@ vi.mock('../db', () => ({
 
 vi.mock('../db/schema', () => ({
   auditLogs: { orgId: 'orgId', actorId: 'actorId', timestamp: 'timestamp', id: 'id' },
-  users: { id: 'id', name: 'name' }
+  users: { id: 'id', name: 'name' },
+  devices: { agentId: 'agentId', hostname: 'hostname', displayName: 'displayName' }
 }));
 
 vi.mock('../middleware/auth', () => ({

--- a/apps/api/src/routes/auditLogs.test.ts
+++ b/apps/api/src/routes/auditLogs.test.ts
@@ -8,24 +8,29 @@ vi.mock('../services/auditEvents', () => ({
   writeRouteAudit: vi.fn()
 }));
 
-// countRows does: db.select().from().leftJoin().where() and destructures [row]
-// queryRows does: db.select().from().leftJoin().where().orderBy().limit().offset()
-// GET /logs/:id does: db.select().from().leftJoin().where() and destructures [row]
+// countRows does: db.select().from().where() and destructures [row]
+// queryRows does: db.select().from().leftJoin(users).leftJoin(devices).where().orderBy().limit().offset()
+// GET /logs/:id does: db.select().from().leftJoin(users).leftJoin(devices).where() and destructures [row]
 // So .where() must be both iterable (as array) AND have .orderBy()
 // Returning empty array by default; countRows returns row?.count ?? 0 = 0 when empty
+const createWhereChain = () =>
+  Object.assign(Promise.resolve([]), {
+    orderBy: vi.fn().mockReturnValue({
+      limit: vi.fn().mockReturnValue({
+        offset: vi.fn().mockResolvedValue([])
+      })
+    })
+  });
+const createJoinChain = () => {
+  const chain: any = {
+    leftJoin: vi.fn(() => chain),
+    where: vi.fn().mockReturnValue(createWhereChain())
+  };
+  return chain;
+};
 const createDbChain = () => ({
   from: vi.fn().mockReturnValue({
-    leftJoin: vi.fn().mockReturnValue({
-      where: vi.fn().mockReturnValue(
-        Object.assign(Promise.resolve([]), {
-          orderBy: vi.fn().mockReturnValue({
-            limit: vi.fn().mockReturnValue({
-              offset: vi.fn().mockResolvedValue([])
-            })
-          })
-        })
-      )
-    }),
+    leftJoin: vi.fn(() => createJoinChain()),
     where: vi.fn().mockReturnValue(Object.assign(Promise.resolve([{ count: 0 }]), {
       limit: vi.fn().mockResolvedValue([])
     }))
@@ -47,7 +52,8 @@ vi.mock('../db', () => ({
 
 vi.mock('../db/schema', () => ({
   auditLogs: { orgId: 'orgId', actorId: 'actorId', timestamp: 'timestamp', id: 'id' },
-  users: { id: 'id', name: 'name' }
+  users: { id: 'id', name: 'name' },
+  devices: { agentId: 'agentId', hostname: 'hostname', displayName: 'displayName' }
 }));
 
 vi.mock('../middleware/auth', () => ({
@@ -195,10 +201,12 @@ describe('audit log routes', () => {
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           leftJoin: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              orderBy: vi.fn().mockReturnValue({
-                limit: vi.fn().mockReturnValue({
-                  offset: vi.fn().mockResolvedValue([formulaRow])
+            leftJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    offset: vi.fn().mockResolvedValue([formulaRow])
+                  })
                 })
               })
             })
@@ -245,10 +253,12 @@ describe('audit log routes', () => {
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           leftJoin: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              orderBy: vi.fn().mockReturnValue({
-                limit: vi.fn().mockReturnValue({
-                  offset: vi.fn().mockResolvedValue([row])
+            leftJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    offset: vi.fn().mockResolvedValue([row])
+                  })
                 })
               })
             })
@@ -270,10 +280,12 @@ describe('audit log routes', () => {
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           leftJoin: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              orderBy: vi.fn().mockReturnValue({
-                limit: vi.fn().mockReturnValue({
-                  offset: vi.fn().mockResolvedValue([row])
+            leftJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    offset: vi.fn().mockResolvedValue([row])
+                  })
                 })
               })
             })
@@ -318,10 +330,12 @@ describe('audit log routes', () => {
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           leftJoin: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              orderBy: vi.fn().mockReturnValue({
-                limit: vi.fn().mockReturnValue({
-                  offset: vi.fn().mockResolvedValue([row])
+            leftJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    offset: vi.fn().mockResolvedValue([row])
+                  })
                 })
               })
             })

--- a/apps/api/src/routes/auditLogs.ts
+++ b/apps/api/src/routes/auditLogs.ts
@@ -307,6 +307,76 @@ async function queryRows(where: SQL | undefined, limit: number, offset: number):
     .offset(offset);
 }
 
+// Fast path for the dashboard widget (RecentActivity): the RLS CASE in
+// breeze_has_org_access() cannot be pushed into audit_logs_org_timestamp_idx,
+// so a plain ORDER BY timestamp DESC LIMIT N degrades to a Parallel Seq Scan
+// over the whole table (~28s in prod). LATERAL per-org index scans gather N
+// rows per accessible org, then top-N sort. ~9ms under RLS.
+interface LateralAuditRow extends Record<string, unknown> {
+  id: string;
+  org_id: string | null;
+  timestamp: Date | string;
+  actor_type: 'user' | 'api_key' | 'agent' | 'system';
+  actor_id: string;
+  actor_email: string | null;
+  action: string;
+  resource_type: string;
+  resource_id: string | null;
+  resource_name: string | null;
+  details: unknown;
+  ip_address: string | null;
+  user_agent: string | null;
+  result: 'success' | 'failure' | 'denied';
+  error_message: string | null;
+  checksum: string | null;
+  initiated_by: string | null;
+  user_name: string | null;
+}
+
+async function queryLatestPerOrg(orgIds: string[], limit: number): Promise<DbRow[]> {
+  const orgIdsSql = sql.join(orgIds.map((id) => sql`${id}::uuid`), sql`, `);
+  const rows = await db.execute<LateralAuditRow>(sql`
+    SELECT
+      al.id, al.org_id, al.timestamp, al.actor_type, al.actor_id,
+      al.actor_email, al.action, al.resource_type, al.resource_id,
+      al.resource_name, al.details, al.ip_address, al.user_agent,
+      al.result, al.error_message, al.checksum, al.initiated_by,
+      u.name AS user_name
+    FROM unnest(ARRAY[${orgIdsSql}]::uuid[]) AS o(org_id)
+    CROSS JOIN LATERAL (
+      SELECT * FROM audit_logs
+      WHERE audit_logs.org_id = o.org_id
+      ORDER BY timestamp DESC
+      LIMIT ${limit}
+    ) al
+    LEFT JOIN users u ON al.actor_id = u.id
+    ORDER BY al.timestamp DESC
+    LIMIT ${limit}
+  `);
+  return rows.map((r) => ({
+    log: {
+      id: r.id,
+      orgId: r.org_id,
+      timestamp: r.timestamp instanceof Date ? r.timestamp : new Date(r.timestamp),
+      actorType: r.actor_type,
+      actorId: r.actor_id,
+      actorEmail: r.actor_email,
+      action: r.action,
+      resourceType: r.resource_type,
+      resourceId: r.resource_id,
+      resourceName: r.resource_name,
+      details: r.details,
+      ipAddress: r.ip_address,
+      userAgent: r.user_agent,
+      result: r.result,
+      errorMessage: r.error_message,
+      checksum: r.checksum,
+      initiatedBy: r.initiated_by,
+    } as DbRow['log'],
+    userName: r.user_name ?? null,
+  }));
+}
+
 async function countRows(where: SQL | undefined): Promise<number> {
   const [row] = await db
     .select({ count: sql<number>`count(*)::int` })
@@ -435,9 +505,18 @@ function paginatedListHandler(
     // index. The dashboard widget that calls /logs?limit=5 doesn't need the
     // count — it never displays "X of Y total". Pass skipCount=true there.
     const skipCount = query.skipCount === 'true';
+    const hasFilters = !!(query.user || query.action || query.resource || query.from || query.to);
+    const canUseFastPath =
+      skipCount &&
+      offset === 0 &&
+      !hasFilters &&
+      Array.isArray(auth.accessibleOrgIds) &&
+      auth.accessibleOrgIds.length > 0;
     const [total, rows] = await Promise.all([
       skipCount ? Promise.resolve(-1) : countRows(where),
-      queryRows(where, limit, offset)
+      canUseFastPath
+        ? queryLatestPerOrg(auth.accessibleOrgIds as string[], limit)
+        : queryRows(where, limit, offset)
     ]);
 
     return c.json({

--- a/apps/api/src/routes/auditLogs.ts
+++ b/apps/api/src/routes/auditLogs.ts
@@ -3,7 +3,7 @@ import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { and, desc, eq, gte, lte, ilike, or, sql, SQL } from 'drizzle-orm';
 import { db } from '../db';
-import { auditLogs as auditLogsTable, users } from '../db/schema';
+import { auditLogs as auditLogsTable, users, devices } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
 import { PERMISSIONS } from '../services/permissions';
@@ -155,11 +155,18 @@ function deriveCategory(action: string): string {
 type DbRow = {
   log: typeof auditLogsTable.$inferSelect;
   userName: string | null;
+  deviceHostname: string | null;
+  deviceDisplayName: string | null;
 };
 
 function resolveActorName(row: DbRow, details?: Record<string, unknown> | null): string {
   if (row.userName) {
     return row.userName;
+  }
+
+  if (row.log.actorType === 'agent') {
+    const deviceName = row.deviceDisplayName || row.deviceHostname;
+    if (deviceName) return deviceName;
   }
 
   if (row.log.actorEmail) {
@@ -298,9 +305,18 @@ function buildSearchCondition(q: string): SQL {
 
 async function queryRows(where: SQL | undefined, limit: number, offset: number): Promise<DbRow[]> {
   return db
-    .select({ log: auditLogsTable, userName: users.name })
+    .select({
+      log: auditLogsTable,
+      userName: users.name,
+      deviceHostname: devices.hostname,
+      deviceDisplayName: devices.displayName,
+    })
     .from(auditLogsTable)
     .leftJoin(users, eq(auditLogsTable.actorId, users.id))
+    .leftJoin(
+      devices,
+      sql`${devices.agentId} = ${auditLogsTable.details}->>'rawActorId' AND ${auditLogsTable.actorType} = 'agent'`
+    )
     .where(where)
     .orderBy(desc(auditLogsTable.timestamp))
     .limit(limit)
@@ -331,6 +347,8 @@ interface LateralAuditRow extends Record<string, unknown> {
   checksum: string | null;
   initiated_by: string | null;
   user_name: string | null;
+  device_hostname: string | null;
+  device_display_name: string | null;
 }
 
 async function queryLatestPerOrg(orgIds: string[], limit: number): Promise<DbRow[]> {
@@ -341,7 +359,9 @@ async function queryLatestPerOrg(orgIds: string[], limit: number): Promise<DbRow
       al.actor_email, al.action, al.resource_type, al.resource_id,
       al.resource_name, al.details, al.ip_address, al.user_agent,
       al.result, al.error_message, al.checksum, al.initiated_by,
-      u.name AS user_name
+      u.name AS user_name,
+      d.hostname AS device_hostname,
+      d.display_name AS device_display_name
     FROM unnest(ARRAY[${orgIdsSql}]::uuid[]) AS o(org_id)
     CROSS JOIN LATERAL (
       SELECT * FROM audit_logs
@@ -350,6 +370,9 @@ async function queryLatestPerOrg(orgIds: string[], limit: number): Promise<DbRow
       LIMIT ${limit}
     ) al
     LEFT JOIN users u ON al.actor_id = u.id
+    LEFT JOIN devices d
+      ON al.actor_type = 'agent'
+      AND d.agent_id = al.details->>'rawActorId'
     ORDER BY al.timestamp DESC
     LIMIT ${limit}
   `);
@@ -374,6 +397,8 @@ async function queryLatestPerOrg(orgIds: string[], limit: number): Promise<DbRow
       initiatedBy: r.initiated_by,
     } as DbRow['log'],
     userName: r.user_name ?? null,
+    deviceHostname: r.device_hostname ?? null,
+    deviceDisplayName: r.device_display_name ?? null,
   }));
 }
 
@@ -381,7 +406,6 @@ async function countRows(where: SQL | undefined): Promise<number> {
   const [row] = await db
     .select({ count: sql<number>`count(*)::int` })
     .from(auditLogsTable)
-    .leftJoin(users, eq(auditLogsTable.actorId, users.id))
     .where(where);
   return row?.count ?? 0;
 }
@@ -561,9 +585,18 @@ auditLogRoutes.get(
     if (orgCond) conditions.push(orgCond);
 
     const [row] = await db
-      .select({ log: auditLogsTable, userName: users.name })
+      .select({
+        log: auditLogsTable,
+        userName: users.name,
+        deviceHostname: devices.hostname,
+        deviceDisplayName: devices.displayName,
+      })
       .from(auditLogsTable)
       .leftJoin(users, eq(auditLogsTable.actorId, users.id))
+      .leftJoin(
+        devices,
+        sql`${devices.agentId} = ${auditLogsTable.details}->>'rawActorId' AND ${auditLogsTable.actorType} = 'agent'`
+      )
       .where(and(...conditions));
 
     if (!row) {


### PR DESCRIPTION
For audit events with `actor_type='agent'`, the API's `resolveActorName`
returned `Agent <first-8-chars-of-uuid>` because the `actor_id` is the
zero UUID and the human-readable agent identifier lives in
`details->>'rawActorId'`. This makes the dashboard widget and audit
log viewer unreadable on partner accounts (every row says "Agent
af404989").

Resolve the agent UUID to the owning device's hostname (or
display_name) via a LEFT JOIN against `devices` on
`devices.agent_id = audit_logs.details->>'rawActorId' AND
audit_logs.actor_type = 'agent'`.

Falls back to the existing prefix display when the device row isn't
present (e.g. deleted device, mid-rotation agent_id). The join is
cheap because `devices.agent_id` is unique-indexed.

Depends on #792 (also touches the LATERAL fast-path query).