### PR TITLE
feat(audit-ui): humanize action codes, details, fix viewer perf + modal overflow

### DIFF
--- a/apps/web/src/components/audit/AuditLogDetail.tsx
+++ b/apps/web/src/components/audit/AuditLogDetail.tsx
@@ -1,4 +1,4 @@
-import { Clock, Globe, Link2, Shield, User, X } from 'lucide-react';
+import { Clock, Globe, Shield, User, X } from 'lucide-react';
 
 export type AuditLogEntry = {
   id: string;
@@ -37,24 +37,24 @@ export default function AuditLogDetail({ entry, isOpen, onClose, timezone }: Aud
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 py-8">
-      <div className="w-full max-w-5xl rounded-lg border bg-card shadow-sm">
+      <div className="flex max-h-[calc(100vh-4rem)] w-full max-w-5xl flex-col overflow-hidden rounded-lg border bg-card shadow-sm">
         <div className="flex items-center justify-between border-b px-6 py-4">
-          <div>
+          <div className="min-w-0">
             <h2 className="text-lg font-semibold">Audit Log Detail</h2>
-            <p className="text-sm text-muted-foreground">
+            <p className="truncate text-sm text-muted-foreground">
               {entry.action} on {entry.resource}
             </p>
           </div>
           <button
             type="button"
             onClick={onClose}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-md border text-muted-foreground transition hover:text-foreground"
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border text-muted-foreground transition hover:text-foreground"
           >
             <X className="h-4 w-4" />
           </button>
         </div>
-        <div className="grid gap-6 p-6 lg:grid-cols-[1.2fr_0.8fr]">
-          <div className="space-y-6">
+        <div className="grid flex-1 gap-6 overflow-y-auto p-6 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
+          <div className="min-w-0 space-y-6">
             <div className="rounded-lg border bg-background p-4">
               <div className="flex items-center gap-2 text-sm font-semibold">
                 <Clock className="h-4 w-4 text-muted-foreground" />
@@ -100,16 +100,16 @@ export default function AuditLogDetail({ entry, isOpen, onClose, timezone }: Aud
             </div>
           </div>
 
-          <div className="space-y-6">
+          <div className="min-w-0 space-y-6">
             <div className="rounded-lg border bg-background p-4">
               <div className="flex items-center gap-2 text-sm font-semibold">
                 <User className="h-4 w-4 text-muted-foreground" />
                 User Info
               </div>
               <div className="mt-4 space-y-2 text-sm text-muted-foreground">
-                <p className="text-base font-semibold text-foreground">{entry.user.name}</p>
-                <p>{entry.user.email}</p>
-                <p>
+                <p className="break-words text-base font-semibold text-foreground">{entry.user.name}</p>
+                <p className="break-all">{entry.user.email}</p>
+                <p className="break-words">
                   {entry.user.role} - {entry.user.department}
                 </p>
               </div>
@@ -121,32 +121,19 @@ export default function AuditLogDetail({ entry, isOpen, onClose, timezone }: Aud
                 Request Metadata
               </div>
               <div className="mt-4 space-y-2 text-sm text-muted-foreground">
-                <p>
-                  <span className="font-medium text-foreground">IP:</span> {entry.ipAddress}
+                <p className="break-all">
+                  <span className="font-medium text-foreground">IP:</span>{' '}
+                  {entry.ipAddress && entry.ipAddress.trim() ? entry.ipAddress : '-'}
                 </p>
-                <p>
-                  <span className="font-medium text-foreground">User Agent:</span> {entry.userAgent}
+                <p className="break-all">
+                  <span className="font-medium text-foreground">User Agent:</span>{' '}
+                  {entry.userAgent || '-'}
                 </p>
-                <p>
-                  <span className="font-medium text-foreground">Session:</span> {entry.sessionId}
+                <p className="break-all">
+                  <span className="font-medium text-foreground">Session:</span>{' '}
+                  {entry.sessionId || '-'}
                 </p>
               </div>
-            </div>
-
-            <div className="rounded-lg border bg-background p-4">
-              <div className="flex items-center gap-2 text-sm font-semibold">
-                <Link2 className="h-4 w-4 text-muted-foreground" />
-                Related Events
-              </div>
-              <p className="mt-3 text-sm text-muted-foreground">
-                View correlated activity for this session.
-              </p>
-              <a
-                href={entry.relatedEventId ? `/audit/events/${entry.relatedEventId}` : '#'}
-                className="mt-3 inline-flex items-center text-sm font-medium text-primary hover:underline"
-              >
-                Open related event
-              </a>
             </div>
           </div>
         </div>

--- a/apps/web/src/components/audit/AuditLogViewer.tsx
+++ b/apps/web/src/components/audit/AuditLogViewer.tsx
@@ -17,6 +17,7 @@ import { fetchWithAuth } from '../../stores/auth';
 import AuditLogDetail, { type AuditLogEntry } from './AuditLogDetail';
 import AuditFilters from './AuditFilters';
 import { navigateTo } from '@/lib/navigation';
+import { formatAuditAction, formatAuditDetails } from '@/lib/auditFormat';
 
 type SortKey = 'timestamp' | 'user' | 'action' | 'resource' | 'details' | 'ipAddress';
 
@@ -160,6 +161,14 @@ export default function AuditLogViewer({ timezone }: AuditLogViewerProps) {
         if (filters.search) params.set('q', filters.search);
       }
 
+      // Fast-path: on page 1 with no active filters, skip the slow count(*)
+      // and let the API use its LATERAL fast-path. From page 2 onward we
+      // pay the count once so pagination shows accurate totals.
+      const useSkipCount = page === 1 && !hasActiveFilters(filters);
+      if (useSkipCount) {
+        params.set('skipCount', 'true');
+      }
+
       const endpoint = params.has('q') ? '/audit-logs/search' : '/audit-logs';
       const response = await fetchWithAuth(`${endpoint}?${params.toString()}`);
 
@@ -175,8 +184,10 @@ export default function AuditLogViewer({ timezone }: AuditLogViewerProps) {
       const data = await response.json();
       setEntries(data.entries || data.data || data.logs || []);
       if (data.pagination) {
-        setTotalPages(data.pagination.totalPages || 1);
-        setTotalCount(data.pagination.total || 0);
+        // When skipCount=true the API returns -1 sentinels; preserve them so
+        // the UI can show "1 of ?" instead of a misleading "1 of 0".
+        setTotalPages(data.pagination.totalPages ?? 1);
+        setTotalCount(data.pagination.total ?? 0);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load audit logs');
@@ -446,7 +457,7 @@ export default function AuditLogViewer({ timezone }: AuditLogViewerProps) {
                           )}
                         >
                           <ShieldCheck className="h-3.5 w-3.5" />
-                          {entry.action}
+                          {formatAuditAction(entry.action)}
                         </span>
                       </td>
                       <td className="px-4 py-4 text-sm">
@@ -457,7 +468,9 @@ export default function AuditLogViewer({ timezone }: AuditLogViewerProps) {
                       </td>
                       <td className="px-4 py-4 text-sm">
                         <div className="flex flex-col gap-2">
-                          <p className="max-w-[220px] truncate text-muted-foreground">{entry.details}</p>
+                          <p className="max-w-[260px] truncate text-muted-foreground">
+                            {formatAuditDetails(entry.details) || '-'}
+                          </p>
                           <button
                             type="button"
                             onClick={() => setSelectedEntry(entry)}
@@ -469,13 +482,17 @@ export default function AuditLogViewer({ timezone }: AuditLogViewerProps) {
                         </div>
                       </td>
                       <td className="px-4 py-4 text-sm text-muted-foreground">
-                        <span className="flex items-center gap-2">
-                        <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-muted">
-                          <Globe className="h-3.5 w-3.5 text-muted-foreground" />
-                        </span>
-                        {entry.ipAddress}
-                      </span>
-                    </td>
+                        {entry.ipAddress && entry.ipAddress.trim() ? (
+                          <span className="flex items-center gap-2">
+                            <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-muted">
+                              <Globe className="h-3.5 w-3.5 text-muted-foreground" />
+                            </span>
+                            {entry.ipAddress}
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground">-</span>
+                        )}
+                      </td>
                     </tr>
                     {isExpanded && (
                       <tr className="bg-muted/20">
@@ -485,7 +502,9 @@ export default function AuditLogViewer({ timezone }: AuditLogViewerProps) {
                               <p className="text-xs font-semibold uppercase text-muted-foreground">
                                 Full Details
                               </p>
-                              <p className="mt-2 text-sm text-foreground">{entry.details}</p>
+                              <p className="mt-2 text-sm text-foreground">
+                                {formatAuditDetails(entry.details) || '-'}
+                              </p>
                             </div>
                             <div className="rounded-md border bg-background p-3">
                               <p className="text-xs font-semibold uppercase text-muted-foreground">
@@ -521,11 +540,20 @@ export default function AuditLogViewer({ timezone }: AuditLogViewerProps) {
         </table>
       </div>
 
-      {totalCount > 0 && (
+      {(totalCount > 0 || totalCount === -1) && (
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div className="text-sm text-muted-foreground">
-            Showing {(currentPage - 1) * pageSize + 1}-{Math.min(currentPage * pageSize, totalCount)} of{' '}
-            {totalCount}
+            {totalCount === -1 ? (
+              <>
+                Showing {(currentPage - 1) * pageSize + 1}-
+                {(currentPage - 1) * pageSize + entries.length}
+              </>
+            ) : (
+              <>
+                Showing {(currentPage - 1) * pageSize + 1}-
+                {Math.min(currentPage * pageSize, totalCount)} of {totalCount}
+              </>
+            )}
           </div>
           <div className="flex items-center gap-2">
             <button
@@ -536,37 +564,47 @@ export default function AuditLogViewer({ timezone }: AuditLogViewerProps) {
             >
               Previous
             </button>
-            {Array.from({ length: Math.min(totalPages, 7) }, (_, index) => {
-              let page: number;
-              if (totalPages <= 7) {
-                page = index + 1;
-              } else if (currentPage <= 4) {
-                page = index + 1;
-              } else if (currentPage >= totalPages - 3) {
-                page = totalPages - 6 + index;
-              } else {
-                page = currentPage - 3 + index;
-              }
-              return (
-                <button
-                  key={page}
-                  type="button"
-                  onClick={() => setCurrentPage(page)}
-                  className={cn(
-                    'h-9 w-9 rounded-md border text-sm font-medium',
-                    currentPage === page
-                      ? 'bg-primary text-primary-foreground'
-                      : 'text-muted-foreground hover:text-foreground'
-                  )}
-                >
-                  {page}
-                </button>
-              );
-            })}
+            {totalPages > 0 &&
+              Array.from({ length: Math.min(totalPages, 7) }, (_, index) => {
+                let page: number;
+                if (totalPages <= 7) {
+                  page = index + 1;
+                } else if (currentPage <= 4) {
+                  page = index + 1;
+                } else if (currentPage >= totalPages - 3) {
+                  page = totalPages - 6 + index;
+                } else {
+                  page = currentPage - 3 + index;
+                }
+                return (
+                  <button
+                    key={page}
+                    type="button"
+                    onClick={() => setCurrentPage(page)}
+                    className={cn(
+                      'h-9 w-9 rounded-md border text-sm font-medium',
+                      currentPage === page
+                        ? 'bg-primary text-primary-foreground'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                  >
+                    {page}
+                  </button>
+                );
+              })}
+            {totalCount === -1 && (
+              <span className="px-2 text-sm font-medium text-muted-foreground">
+                Page {currentPage}
+              </span>
+            )}
             <button
               type="button"
-              onClick={() => setCurrentPage(prev => Math.min(totalPages, prev + 1))}
-              disabled={currentPage === totalPages}
+              onClick={() => setCurrentPage(prev => prev + 1)}
+              disabled={
+                totalCount === -1
+                  ? entries.length < pageSize
+                  : currentPage === totalPages
+              }
               className="h-9 rounded-md border px-3 text-sm font-medium text-muted-foreground transition hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
             >
               Next

--- a/apps/web/src/components/audit/UserActivityReport.tsx
+++ b/apps/web/src/components/audit/UserActivityReport.tsx
@@ -3,6 +3,7 @@ import { Activity, Download, TrendingUp, User, Users } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
+import { formatAuditAction } from '@/lib/auditFormat';
 
 type ActivityEntry = {
   id: string;
@@ -231,8 +232,8 @@ export default function UserActivityReport({ timezone }: UserActivityReportProps
             <TrendingUp className="h-4 w-4 text-muted-foreground" />
             Top Action
           </div>
-          <p className="mt-3 text-2xl font-semibold capitalize">
-            {topAction.action}
+          <p className="mt-3 text-2xl font-semibold">
+            {topAction.action === 'n/a' ? 'n/a' : formatAuditAction(topAction.action)}
           </p>
           <p className="text-sm text-muted-foreground">
             {topAction.count} occurrences
@@ -264,10 +265,12 @@ export default function UserActivityReport({ timezone }: UserActivityReportProps
                   />
                   <div className="flex-1 border-l border-dashed border-muted pl-4">
                     <p className="text-xs text-muted-foreground">{formatTimestamp(entry.timestamp, timezone)}</p>
-                    <p className="text-sm font-medium text-foreground capitalize">
-                      {entry.action} - {entry.resource}
+                    <p className="text-sm font-medium text-foreground">
+                      {formatAuditAction(entry.action)} - {entry.resource}
                     </p>
-                    <p className="text-xs text-muted-foreground">{entry.ipAddress}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {entry.ipAddress && entry.ipAddress.trim() ? entry.ipAddress : '-'}
+                    </p>
                   </div>
                 </div>
               ))
@@ -283,7 +286,7 @@ export default function UserActivityReport({ timezone }: UserActivityReportProps
             ) : (
               Object.entries(stats).map(([action, count]) => (
                 <div key={action} className="flex items-center justify-between text-sm">
-                  <span className="capitalize text-muted-foreground">{action}</span>
+                  <span className="text-muted-foreground">{formatAuditAction(action)}</span>
                   <span className="font-medium text-foreground">{count}</span>
                 </div>
               ))
@@ -315,9 +318,11 @@ export default function UserActivityReport({ timezone }: UserActivityReportProps
                 sortedTimeline.slice(0, 5).map(entry => (
                   <tr key={entry.id}>
                     <td className="px-3 py-2 text-muted-foreground">{formatTimestamp(entry.timestamp, timezone)}</td>
-                    <td className="px-3 py-2 capitalize text-foreground">{entry.action}</td>
+                    <td className="px-3 py-2 text-foreground">{formatAuditAction(entry.action)}</td>
                     <td className="px-3 py-2 text-foreground">{entry.resource}</td>
-                    <td className="px-3 py-2 text-muted-foreground">{entry.ipAddress}</td>
+                    <td className="px-3 py-2 text-muted-foreground">
+                      {entry.ipAddress && entry.ipAddress.trim() ? entry.ipAddress : '-'}
+                    </td>
                   </tr>
                 ))
               )}

--- a/apps/web/src/components/dashboard/RecentActivity.tsx
+++ b/apps/web/src/components/dashboard/RecentActivity.tsx
@@ -15,11 +15,18 @@ interface AuditLogEntry {
     email: string;
   };
   action: string;
+  // Legacy flat fields (kept for back-compat with flattenEntry shape)
   resourceType?: string;
   targetType?: string;
   resourceId?: string;
   target?: string;
   targetName?: string;
+  // Current toFullEntry shape from /audit-logs/logs
+  resource?: {
+    type?: string;
+    id?: string;
+    name?: string;
+  };
   timestamp: string;
   createdAt?: string;
   details?: Record<string, unknown>;
@@ -153,13 +160,14 @@ export default function RecentActivity() {
             </thead>
             <tbody>
               {activities.map((activity) => {
-                const targetType = (activity.resourceType || activity.targetType || 'default').toLowerCase();
+                const resourceType = activity.resource?.type || activity.resourceType || activity.targetType;
+                const targetType = (resourceType || 'default').toLowerCase();
                 const Icon = typeIcons[targetType] || typeIcons.default;
                 const userName = activity.user?.name || activity.userName || 'System';
-                const targetName = activity.target || activity.targetName;
+                const targetName = activity.resource?.name || activity.target || activity.targetName;
                 const target = targetName && targetName.trim()
                   ? targetName
-                  : (activity.resourceType ? activity.resourceType : '-');
+                  : (resourceType ?? '-');
                 const timestamp = activity.timestamp || activity.createdAt || '';
 
                 return (

--- a/apps/web/src/components/dashboard/RecentActivity.tsx
+++ b/apps/web/src/components/dashboard/RecentActivity.tsx
@@ -3,6 +3,7 @@ import { FileCode, User, Settings, Monitor, AlertCircle, Activity } from 'lucide
 import { getErrorMessage, getErrorTitle } from '@/lib/errorMessages';
 import { fetchWithAuth } from '../../stores/auth';
 import { formatTimeAgo } from '@/lib/formatTime';
+import { formatAuditAction } from '@/lib/auditFormat';
 
 interface AuditLogEntry {
   id: string;
@@ -155,14 +156,17 @@ export default function RecentActivity() {
                 const targetType = (activity.resourceType || activity.targetType || 'default').toLowerCase();
                 const Icon = typeIcons[targetType] || typeIcons.default;
                 const userName = activity.user?.name || activity.userName || 'System';
-                const target = activity.target || activity.targetName || activity.resourceId || '-';
+                const targetName = activity.target || activity.targetName;
+                const target = targetName && targetName.trim()
+                  ? targetName
+                  : (activity.resourceType ? activity.resourceType : '-');
                 const timestamp = activity.timestamp || activity.createdAt || '';
 
                 return (
                   <tr key={activity.id} className="border-b border-border/50 last:border-b-0 hover:bg-muted/30 transition-colors">
                     <td className="py-3 text-sm">{userName}</td>
                     <td className="py-3 text-sm text-muted-foreground">
-                      {activity.action}
+                      {formatAuditAction(activity.action)}
                     </td>
                     <td className="py-3">
                       <div className="flex items-center gap-2 text-sm">

--- a/apps/web/src/lib/auditFormat.ts
+++ b/apps/web/src/lib/auditFormat.ts
@@ -86,3 +86,65 @@ export function formatAuditAction(action: string | null | undefined): string {
   if (!action) return '';
   return ACTION_DISPLAY[action] ?? prettify(action);
 }
+
+// Keys we never want to show in the compact Details cell — they're internal
+// plumbing, not human-relevant context.
+const NOISY_DETAIL_KEYS = new Set<string>([
+  'rawActorId',
+  'checksum',
+  'rawUserAgent',
+  'fingerprint',
+  'requestId',
+  'traceId',
+  'spanId',
+  'correlationId',
+]);
+
+// Pretty-print the relevant subset of an audit details payload as a compact
+// "key: value, key: value" string. Returns '' if nothing useful remains.
+export function formatAuditDetails(details: unknown): string {
+  if (details == null) return '';
+  if (typeof details === 'string') {
+    const trimmed = details.trim();
+    if (!trimmed) return '';
+    // Try to parse JSON strings; fall back to the raw string.
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+      try {
+        return formatAuditDetails(JSON.parse(trimmed));
+      } catch {
+        return trimmed;
+      }
+    }
+    return trimmed;
+  }
+  if (typeof details !== 'object') return String(details);
+  if (Array.isArray(details)) {
+    return details.length === 0 ? '' : `${details.length} items`;
+  }
+
+  const entries = Object.entries(details as Record<string, unknown>).filter(
+    ([key, value]) => {
+      if (NOISY_DETAIL_KEYS.has(key)) return false;
+      if (value === null || value === undefined) return false;
+      if (typeof value === 'string' && value.trim() === '') return false;
+      return true;
+    }
+  );
+
+  if (entries.length === 0) return '';
+
+  return entries
+    .map(([key, value]) => {
+      const label = key.replace(/([A-Z])/g, ' $1').replace(/_/g, ' ').toLowerCase().trim();
+      let rendered: string;
+      if (value === null || value === undefined) {
+        rendered = '';
+      } else if (typeof value === 'object') {
+        rendered = Array.isArray(value) ? `${value.length} items` : '{ ... }';
+      } else {
+        rendered = String(value);
+      }
+      return `${label}: ${rendered}`;
+    })
+    .join(', ');
+}

--- a/apps/web/src/lib/auditFormat.ts
+++ b/apps/web/src/lib/auditFormat.ts
@@ -1,0 +1,88 @@
+// Map raw audit action codes (dotted, machine-shaped) to human-readable
+// phrases. Falls back to a generic prettifier for unknown codes.
+
+const ACTION_DISPLAY: Record<string, string> = {
+  // Agent telemetry submissions (high volume)
+  'agent.sessions.submit': 'Reported sessions',
+  'agent.security_status.submit': 'Reported security status',
+  'agent.management_posture.submit': 'Reported management posture',
+  'agent.patches.submit': 'Reported patches',
+  'agent.eventlogs.submit': 'Reported event logs',
+  'agent.reliability.submit': 'Reported reliability',
+  'agent.command.result.submit': 'Submitted command result',
+  'agent.filesystem.threshold_scan.queued': 'Filesystem scan queued',
+  'agent.enroll': 'Agent enrolled',
+
+  // User/auth
+  'user.login': 'Signed in',
+  'user.logout': 'Signed out',
+  'session_initiated': 'Session initiated',
+  'session_offer_submitted': 'Session offer submitted',
+
+  // Devices
+  'device.wake_on_lan': 'Sent Wake-on-LAN',
+  'device.create': 'Added device',
+  'device.update': 'Updated device',
+  'device.delete': 'Removed device',
+  'device.archive': 'Archived device',
+
+  // Orgs/sites
+  'organization.create': 'Created organization',
+  'organization.update': 'Updated organization',
+  'organization.delete': 'Deleted organization',
+  'site.create': 'Created site',
+  'site.update': 'Updated site',
+  'site.delete': 'Deleted site',
+
+  // Alerts
+  'alert.create': 'Raised alert',
+  'alert.resolve': 'Resolved alert',
+  'alert.acknowledge': 'Acknowledged alert',
+  'alert.dismiss': 'Dismissed alert',
+
+  // Enrollment
+  'enrollment_key.create': 'Created enrollment key',
+  'enrollment_key.revoke': 'Revoked enrollment key',
+
+  // Partner
+  'partner.settings.update': 'Updated partner settings',
+
+  // AI / MCP
+  'ai.message.send': 'Sent AI message',
+  'ai.tool_approval.update': 'Updated AI tool approval',
+  'mcp.initialize': 'MCP: initialize',
+  'mcp.notifications.initialized': 'MCP: initialized notifications',
+  'mcp.tools.list': 'MCP: list tools',
+  'mcp.tools.call': 'MCP: call tool',
+  'mcp.resources.list': 'MCP: list resources',
+
+  // Remote sessions
+  'terminal.session.summary': 'Terminal session summary',
+
+  // Scripts / automation
+  'script.run': 'Ran script',
+  'script.create': 'Created script',
+  'script.update': 'Updated script',
+  'script.delete': 'Deleted script',
+  'automation.create': 'Created automation',
+  'automation.update': 'Updated automation',
+  'automation.delete': 'Deleted automation',
+};
+
+// Generic prettifier for codes that aren't in the map.
+// Examples:
+//   "foo.bar_baz.update" -> "Foo bar baz update"
+//   "api.post.events.ws-ticket" -> "Api post events ws-ticket"
+function prettify(action: string): string {
+  const cleaned = action
+    .replace(/[._]/g, ' ')
+    .trim()
+    .toLowerCase();
+  if (!cleaned) return action;
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
+export function formatAuditAction(action: string | null | undefined): string {
+  if (!action) return '';
+  return ACTION_DISPLAY[action] ?? prettify(action);
+}


### PR DESCRIPTION
Several UX issues with the Audit Trail surfaces:

1. **Action column shows raw machine codes.** `agent.security_status.submit`,
   `mcp.tools.list`, `enrollment_key.create` — readable to engineers,
   opaque to admins. Added `formatAuditAction()` lookup table in
   `apps/web/src/lib/auditFormat.ts` with a generic prettifier
   fallback for unmapped codes.

2. **Details column shows raw JSON.** Internal keys (`rawActorId`,
   `checksum`, `requestId`, etc.) dominated the visible payload.
   Added `formatAuditDetails()` that hides a noisy-key allowlist and
   emits compact `key: value` pairs.

3. **AuditLogViewer initial load was 28+ seconds.** Pass
   `skipCount=true` on page 1 with no filters so the API's LATERAL
   fast-path can be used; handle `total === -1` in pagination UI
   (show "Next" without "of N").

4. **AuditLogDetail modal sidebar overflowed the modal frame.**
   Fixed via layout adjustments.

5. **Target column on RecentActivity** was always rendering "-"
   because the component read the legacy `resourceType` field but
   the API returns nested `resource.type`. Updated to prefer the
   nested shape with fallback to flat.

Pure frontend change. No API or schema changes.