### PR TITLE
feat(dns): add AdGuard Home as a supported DNS filtering provider

### DIFF
--- a/apps/api/migrations/2026-05-21-dns-provider-adguard-home.sql
+++ b/apps/api/migrations/2026-05-21-dns-provider-adguard-home.sql
@@ -1,0 +1,3 @@
+-- Add AdGuard Home as a supported DNS filtering provider.
+-- Self-hosted DNS sinkhole common with MSP clients (RFC 1918 / SOHO networks).
+ALTER TYPE dns_provider ADD VALUE IF NOT EXISTS 'adguard_home';

--- a/apps/api/src/db/schema/dnsSecurity.ts
+++ b/apps/api/src/db/schema/dnsSecurity.ts
@@ -22,7 +22,8 @@ export const dnsProviderEnum = pgEnum('dns_provider', [
   'dnsfilter',
   'pihole',
   'opendns',
-  'quad9'
+  'quad9',
+  'adguard_home'
 ]);
 
 export const dnsActionEnum = pgEnum('dns_action', [

--- a/apps/api/src/routes/dnsSecurity.test.ts
+++ b/apps/api/src/routes/dnsSecurity.test.ts
@@ -41,7 +41,7 @@ vi.mock('../db/schema', () => ({
     createdBy: 'createdBy'
   },
   dnsPolicies: {},
-  dnsProviderEnum: { enumValues: ['umbrella', 'cloudflare', 'pihole'] },
+  dnsProviderEnum: { enumValues: ['umbrella', 'cloudflare', 'pihole', 'adguard_home'] },
   dnsSecurityEvents: {},
   dnsThreatCategoryEnum: { enumValues: ['malware', 'phishing'] }
 }));

--- a/apps/api/src/routes/dnsSecurity.ts
+++ b/apps/api/src/routes/dnsSecurity.ts
@@ -159,6 +159,23 @@ const createIntegrationSchema = z.object({
       message: 'apiEndpoint is required for Pi-hole'
     });
   }
+
+  if (data.provider === 'adguard_home') {
+    if (!data.config?.apiEndpoint) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['config', 'apiEndpoint'],
+        message: 'apiEndpoint is required for AdGuard Home (e.g. https://adguard.client.local)'
+      });
+    }
+    if (!data.apiSecret) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['apiSecret'],
+        message: 'apiSecret (HTTP Basic auth password) is required for AdGuard Home'
+      });
+    }
+  }
 });
 
 const listEventsQuerySchema = z.object({

--- a/apps/api/src/services/dnsProviders/adguardHome.test.ts
+++ b/apps/api/src/services/dnsProviders/adguardHome.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AdGuardHomeProvider } from './adguardHome';
+
+interface MockResponse {
+  ok: boolean;
+  status?: number;
+  statusText?: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+}
+
+function makeFetchMock(responses: MockResponse[]): ReturnType<typeof vi.fn> {
+  const queue = [...responses];
+  return vi.fn(async () => {
+    const next = queue.shift();
+    if (!next) throw new Error('fetch mock exhausted');
+    const headers = new Map(Object.entries(next.headers ?? {}));
+    return {
+      ok: next.ok,
+      status: next.status ?? (next.ok ? 200 : 500),
+      statusText: next.statusText ?? '',
+      text: async () => JSON.stringify(next.body ?? {}),
+      headers: { get: (k: string) => headers.get(k.toLowerCase()) ?? null }
+    } as unknown as Response;
+  });
+}
+
+describe('AdGuardHomeProvider', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function newProvider(): AdGuardHomeProvider {
+    return new AdGuardHomeProvider('admin', 'hunter2', { apiEndpoint: 'https://adguard.example/' });
+  }
+
+  it('throws when apiEndpoint is missing', async () => {
+    const provider = new AdGuardHomeProvider('admin', 'hunter2', {});
+    await expect(provider.syncEvents(new Date(0), new Date())).rejects.toThrow(/apiEndpoint/);
+  });
+
+  it('sends HTTP Basic auth header on requests', async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: { data: [] } }]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await newProvider().syncEvents(new Date(0), new Date());
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const call = fetchMock.mock.calls[0]!;
+    const [url, init] = call as [string | URL, RequestInit];
+    expect(String(url)).toContain('https://adguard.example/control/querylog');
+    const auth = init.headers as Record<string, string>;
+    // Basic admin:hunter2 → base64(YWRtaW46aHVudGVyMg==)
+    expect(auth.Authorization).toBe('Basic YWRtaW46aHVudGVyMg==');
+  });
+
+  it('maps blocked reasons to action=blocked and parses domain/timestamp', async () => {
+    const fetchMock = makeFetchMock([{
+      ok: true,
+      body: {
+        data: [{
+          time: '2026-05-21T10:00:00Z',
+          question: { name: 'tracker.bad.example', type: 'A' },
+          reason: 'FilteredBlackList',
+          client: '10.0.0.5',
+          client_info: { name: 'workstation-3' },
+          elapsedMs: '0.42',
+          cached: false,
+          upstream: 'tls://1.1.1.1'
+        }]
+      }
+    }]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const events = await newProvider().syncEvents(
+      new Date('2026-05-21T00:00:00Z'),
+      new Date('2026-05-22T00:00:00Z')
+    );
+
+    expect(events).toHaveLength(1);
+    const ev = events[0]!;
+    expect(ev.domain).toBe('tracker.bad.example');
+    expect(ev.action).toBe('blocked');
+    expect(ev.sourceIp).toBe('10.0.0.5');
+    expect(ev.sourceHostname).toBe('workstation-3');
+    expect(ev.queryType).toBe('A');
+    expect(ev.metadata?.reason).toBe('FilteredBlackList');
+    expect(ev.providerEventId).toContain('tracker.bad.example');
+  });
+
+  it('maps Rewrite reasons to action=redirected and unfiltered to allowed', async () => {
+    const fetchMock = makeFetchMock([{
+      ok: true,
+      body: {
+        data: [
+          {
+            time: '2026-05-21T10:00:00Z',
+            question: { name: 'ok.example', type: 'A' },
+            reason: 'NotFilteredNotFound',
+            client: '10.0.0.5'
+          },
+          {
+            time: '2026-05-21T10:00:01Z',
+            question: { name: 'internal.example', type: 'A' },
+            reason: 'RewriteEtcHosts',
+            client: '10.0.0.5'
+          }
+        ]
+      }
+    }]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const events = await newProvider().syncEvents(
+      new Date('2026-05-21T00:00:00Z'),
+      new Date('2026-05-22T00:00:00Z')
+    );
+
+    expect(events.map((e) => e.action)).toEqual(['allowed', 'redirected']);
+  });
+
+  it('stops paging once a timestamp falls before `since`', async () => {
+    const fetchMock = makeFetchMock([{
+      ok: true,
+      body: {
+        data: [
+          { time: '2026-05-21T11:00:00Z', question: { name: 'a.example', type: 'A' }, reason: 'NotFilteredNotFound' },
+          { time: '2026-05-21T09:00:00Z', question: { name: 'b.example', type: 'A' }, reason: 'NotFilteredNotFound' },
+          { time: '2026-05-20T10:00:00Z', question: { name: 'c.example', type: 'A' }, reason: 'NotFilteredNotFound' }
+        ]
+      }
+    }]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const events = await newProvider().syncEvents(
+      new Date('2026-05-21T10:00:00Z'),
+      new Date('2026-05-21T23:59:59Z')
+    );
+
+    expect(events.map((e) => e.domain)).toEqual(['a.example']);
+    // Only the first page is fetched because the third entry crossed `since`.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('addBlocklistDomain appends an Adblock-style rule preserving existing rules', async () => {
+    const fetchMock = makeFetchMock([
+      { ok: true, body: { user_rules: ['||existing.bad^', '@@||allowed.good^'] } },
+      { ok: true, body: {} }
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await newProvider().addBlocklistDomain('new.bad.example');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const init = fetchMock.mock.calls[1]![1] as RequestInit;
+    const body = JSON.parse(init.body as string) as { rules: string[] };
+    expect(body.rules).toEqual(['||existing.bad^', '@@||allowed.good^', '||new.bad.example^']);
+  });
+
+  it('addBlocklistDomain is a no-op when rule already exists', async () => {
+    const fetchMock = makeFetchMock([
+      { ok: true, body: { user_rules: ['||already.bad^'] } }
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await newProvider().addBlocklistDomain('already.bad');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1); // only the GET, no POST
+  });
+
+  it('removeBlocklistDomain removes the matching rule and POSTs the new set', async () => {
+    const fetchMock = makeFetchMock([
+      { ok: true, body: { user_rules: ['||one.bad^', '||two.bad^', '@@||three.good^'] } },
+      { ok: true, body: {} }
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await newProvider().removeBlocklistDomain('two.bad');
+
+    const init = fetchMock.mock.calls[1]![1] as RequestInit;
+    const body = JSON.parse(init.body as string) as { rules: string[] };
+    expect(body.rules).toEqual(['||one.bad^', '@@||three.good^']);
+  });
+
+  it('addAllowlistDomain appends @@-prefixed rule', async () => {
+    const fetchMock = makeFetchMock([
+      { ok: true, body: { user_rules: [] } },
+      { ok: true, body: {} }
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await newProvider().addAllowlistDomain('safe.example');
+
+    const init = fetchMock.mock.calls[1]![1] as RequestInit;
+    const body = JSON.parse(init.body as string) as { rules: string[] };
+    expect(body.rules).toEqual(['@@||safe.example^']);
+  });
+});

--- a/apps/api/src/services/dnsProviders/adguardHome.ts
+++ b/apps/api/src/services/dnsProviders/adguardHome.ts
@@ -1,0 +1,191 @@
+import type { DnsAction } from '../../db/schema';
+import type { DnsEvent, DnsProvider } from './index';
+import { requestJson } from './http';
+import { asArray, asNumber, asRecord, asString, asStringArray } from './helpers';
+
+export interface AdGuardHomeConfig {
+  apiEndpoint?: string;
+}
+
+// AdGuard Home filtering reason enum (see openapi/openapi.yaml in AdguardTeam/AdGuardHome).
+// We treat all "Filtered*" reasons except FilteredInvalid/NotFilteredError as blocked.
+const BLOCKED_REASONS = new Set([
+  'FilteredBlackList',
+  'FilteredSafeBrowsing',
+  'FilteredParental',
+  'FilteredSafeSearch',
+  'FilteredBlockedService'
+]);
+
+const REDIRECTED_REASONS = new Set([
+  'Rewrite',
+  'RewriteEtcHosts',
+  'RewriteRule'
+]);
+
+// Map AdGuard filter list rule prefix → blocklist domain syntax for set_rules.
+// We use Adblock Plus-style rules: `||example.com^` blocks, `@@||example.com^` allows.
+function toBlockRule(domain: string): string {
+  return `||${domain}^`;
+}
+
+function toAllowRule(domain: string): string {
+  return `@@||${domain}^`;
+}
+
+export class AdGuardHomeProvider implements DnsProvider {
+  constructor(
+    private readonly username: string,
+    private readonly password: string | null,
+    private readonly config: AdGuardHomeConfig
+  ) {}
+
+  private baseUrl(): string {
+    const endpoint = this.config.apiEndpoint;
+    if (!endpoint) {
+      throw new Error('AdGuard Home integration requires config.apiEndpoint (e.g. https://adguard.client.local)');
+    }
+    return endpoint.replace(/\/+$/, '');
+  }
+
+  private authHeader(): string {
+    const pw = this.password ?? '';
+    return `Basic ${Buffer.from(`${this.username}:${pw}`).toString('base64')}`;
+  }
+
+  private async call<T>(path: string, init: RequestInit = {}): Promise<T> {
+    return requestJson<T>(`${this.baseUrl()}${path}`, {
+      ...init,
+      headers: {
+        Authorization: this.authHeader(),
+        ...(init.headers ?? {})
+      }
+    });
+  }
+
+  // Read current filtering rules so we can splice in additions/removals without
+  // clobbering the user's existing rule set. AdGuard's API replaces the full
+  // rules array on each set_rules call.
+  private async getFilteringRules(): Promise<string[]> {
+    const status = await this.call<Record<string, unknown>>('/control/filtering/status');
+    return asStringArray(status.user_rules);
+  }
+
+  private async setFilteringRules(rules: string[]): Promise<void> {
+    await this.call<unknown>('/control/filtering/set_rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rules })
+    });
+  }
+
+  async syncEvents(since: Date, until: Date): Promise<DnsEvent[]> {
+    // AdGuard's querylog is paginated reverse-chronologically. We page back
+    // using `older_than` until we cross `since`. Cap pages to keep one sync
+    // bounded even on a busy resolver.
+    const perPage = 500;
+    const maxPages = 50;
+    const events: DnsEvent[] = [];
+    let olderThan: string | undefined;
+
+    for (let page = 0; page < maxPages; page++) {
+      const params = new URLSearchParams({ limit: String(perPage) });
+      if (olderThan) params.set('older_than', olderThan);
+
+      const payload = await this.call<Record<string, unknown>>(
+        `/control/querylog?${params.toString()}`
+      );
+      const data = asArray(payload.data);
+      if (data.length === 0) break;
+
+      let crossedSince = false;
+      let oldestTimestamp: string | undefined;
+
+      for (const entry of data) {
+        const record = asRecord(entry);
+        if (!record) continue;
+
+        const timestampRaw = asString(record.time);
+        const question = asRecord(record.question);
+        const domain = asString(question?.name);
+        if (!timestampRaw || !domain) continue;
+
+        const timestamp = new Date(timestampRaw);
+        if (Number.isNaN(timestamp.getTime())) continue;
+
+        oldestTimestamp = timestampRaw;
+
+        if (timestamp < since) {
+          crossedSince = true;
+          continue;
+        }
+        if (timestamp > until) continue;
+
+        const reason = asString(record.reason) ?? '';
+        let action: DnsAction = 'allowed';
+        if (BLOCKED_REASONS.has(reason)) action = 'blocked';
+        else if (REDIRECTED_REASONS.has(reason)) action = 'redirected';
+
+        const clientIp = asString(record.client);
+        const clientInfo = asRecord(record.client_info);
+        const clientName = asString(clientInfo?.name);
+
+        // Provider event id: AdGuard doesn't expose one, so synthesize from
+        // (timestamp, domain, client, reason). Elapsed-ms helps distinguish
+        // back-to-back queries from the same client.
+        const elapsedMs = asString(record.elapsedMs) ?? asNumber(record.elapsedMs)?.toString() ?? '';
+        const eventId = `${timestampRaw}|${domain}|${clientIp ?? ''}|${reason}|${elapsedMs}`;
+
+        events.push({
+          timestamp,
+          domain,
+          queryType: asString(question?.type) ?? 'A',
+          action,
+          sourceIp: clientIp,
+          sourceHostname: clientName,
+          providerEventId: eventId,
+          metadata: { reason, cached: record.cached === true, upstream: asString(record.upstream) }
+        });
+      }
+
+      if (crossedSince) break;
+      if (data.length < perPage) break;
+      if (!oldestTimestamp) break;
+      olderThan = oldestTimestamp;
+    }
+
+    return events;
+  }
+
+  async addBlocklistDomain(domain: string): Promise<void> {
+    const rules = await this.getFilteringRules();
+    const blockRule = toBlockRule(domain);
+    if (rules.includes(blockRule)) return;
+    rules.push(blockRule);
+    await this.setFilteringRules(rules);
+  }
+
+  async removeBlocklistDomain(domain: string): Promise<void> {
+    const rules = await this.getFilteringRules();
+    const blockRule = toBlockRule(domain);
+    const filtered = rules.filter((r) => r !== blockRule);
+    if (filtered.length === rules.length) return;
+    await this.setFilteringRules(filtered);
+  }
+
+  async addAllowlistDomain(domain: string): Promise<void> {
+    const rules = await this.getFilteringRules();
+    const allowRule = toAllowRule(domain);
+    if (rules.includes(allowRule)) return;
+    rules.push(allowRule);
+    await this.setFilteringRules(rules);
+  }
+
+  async removeAllowlistDomain(domain: string): Promise<void> {
+    const rules = await this.getFilteringRules();
+    const allowRule = toAllowRule(domain);
+    const filtered = rules.filter((r) => r !== allowRule);
+    if (filtered.length === rules.length) return;
+    await this.setFilteringRules(filtered);
+  }
+}

--- a/apps/api/src/services/dnsProviders/index.ts
+++ b/apps/api/src/services/dnsProviders/index.ts
@@ -3,6 +3,7 @@ import { UmbrellaProvider } from './umbrella';
 import { CloudflareGatewayProvider } from './cloudflare';
 import { DnsFilterProvider } from './dnsfilter';
 import { PiHoleProvider } from './pihole';
+import { AdGuardHomeProvider } from './adguardHome';
 
 export interface DnsEvent {
   timestamp: Date;
@@ -46,6 +47,8 @@ export function createDnsProvider(input: DnsProviderFactoryInput): DnsProvider {
       return new DnsFilterProvider(input.apiKey, input.config);
     case 'pihole':
       return new PiHoleProvider(input.apiKey, input.config);
+    case 'adguard_home':
+      return new AdGuardHomeProvider(input.apiKey, input.apiSecret, input.config);
     case 'opendns':
     case 'quad9':
       throw new Error(`Provider ${input.provider} is not yet supported for API sync`);
@@ -58,5 +61,6 @@ export {
   UmbrellaProvider,
   CloudflareGatewayProvider,
   DnsFilterProvider,
-  PiHoleProvider
+  PiHoleProvider,
+  AdGuardHomeProvider
 };


### PR DESCRIPTION
## Summary

AdGuard Home is one of the most common self-hosted DNS filtering servers in the field (open-source, deployed on small SoHo/MSP networks). Adding it to the existing `dns_provider` enum extends Breeze's multi-provider DNS management without changing the route shape, purely additive.

## Changes

- Extend `dnsProviderEnum` with `'adguard_home'` (schema + idempotent `ALTER TYPE ... ADD VALUE IF NOT EXISTS` migration)
- New `AdGuardHomeProvider` that talks to `/control/{querylog,filtering/*}` using HTTP Basic auth (`apiKey` = username, `apiSecret` = password, `config.apiEndpoint` = base URL)
- Wire it up in `createDnsProvider` factory
- Add route-level zod validation requiring `apiEndpoint` + `apiSecret` when `provider === 'adguard_home'`
- Map AdGuard filtering reasons (`FilteredBlackList` / `SafeBrowsing` / ..., `Rewrite` / `RewriteEtcHosts` / ...) to the existing `DnsAction` enum
- Use Adblock Plus rule syntax (`||domain^` / `@@||domain^`) for blocklist/allowlist sync, preserving existing `user_rules` on each `set_rules` call
- Unit tests for auth header, reason mapping, paging termination, and rule add/remove semantics

## Backward compat

Purely additive: enum extension, new provider class, new factory branch. No changes to existing provider behavior.

## Test plan

- [x] Unit tests pass (197 LOC of new tests in `adguardHome.test.ts`)
- [ ] Manual: connect a real AdGuard Home instance, sync a small blocklist, verify rules appear in AGH UI
- [ ] Manual: ingest querylog and confirm reason mapping produces correct `DnsAction` values