### PR TITLE
feat(api): severity-by-exit-code mapping for scripts (Feature #3)

### DIFF
--- a/apps/api/migrations/2026-05-21-scripts-exit-code-severity-mapping.sql
+++ b/apps/api/migrations/2026-05-21-scripts-exit-code-severity-mapping.sql
@@ -1,0 +1,8 @@
+-- Feature #3: severity-by-exit-code for scripts-as-monitors.
+-- Adds an opt-in mapping from script exit code to alert severity.
+-- When NULL (default), existing behavior is unchanged.
+-- When set, shape is: { "0": null, "1": "low", "2": "medium", "3": "high", "4": "critical" }
+-- where a null severity for a code means "no alert" and any AlertSeverity string
+-- triggers an alert at that severity.
+ALTER TABLE scripts
+  ADD COLUMN IF NOT EXISTS exit_code_severity_mapping jsonb;

--- a/apps/api/src/db/schema/scripts.ts
+++ b/apps/api/src/db/schema/scripts.ts
@@ -8,6 +8,12 @@ export const scriptRunAsEnum = pgEnum('script_run_as', ['system', 'user', 'eleva
 export const executionStatusEnum = pgEnum('execution_status', ['pending', 'queued', 'running', 'completed', 'failed', 'timeout', 'cancelled']);
 export const triggerTypeEnum = pgEnum('trigger_type', ['manual', 'scheduled', 'alert', 'policy']);
 
+// Feature #3: severity-by-exit-code mapping. Keys are non-negative integer
+// strings (e.g. "0", "1"), values are AlertSeverity literals or null.
+// A null value for a given exit code means "no alert"; otherwise the listed
+// severity is used when a script execution finishes with that exit code.
+export type ScriptExitCodeSeverityMapping = Record<string, 'critical' | 'high' | 'medium' | 'low' | 'info' | null>;
+
 export const scripts = pgTable('scripts', {
   id: uuid('id').primaryKey().defaultRandom(),
   orgId: uuid('org_id').references(() => organizations.id),
@@ -22,6 +28,9 @@ export const scripts = pgTable('scripts', {
   runAs: scriptRunAsEnum('run_as').notNull().default('system'),
   isSystem: boolean('is_system').notNull().default(false),
   version: integer('version').notNull().default(1),
+  // NULL = legacy behavior (non-zero exit = error). When set, see
+  // ScriptExitCodeSeverityMapping above and deriveSeverityFromScript().
+  exitCodeSeverityMapping: jsonb('exit_code_severity_mapping').$type<ScriptExitCodeSeverityMapping>(),
   createdBy: uuid('created_by').references(() => users.id),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull()

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -90,6 +90,15 @@ const listScriptsSchema = z.object({
   includeSystem: z.string().optional() // 'true' to include system scripts
 });
 
+// Feature #3 (severity-by-exit-code): exit code -> severity map.
+// Keys must be non-negative integer strings (e.g. "0", "1", "2").
+// Values are an AlertSeverity literal or null (null = no alert for that code).
+const alertSeverityValueSchema = z.enum(['critical', 'high', 'medium', 'low', 'info']);
+const exitCodeSeverityMappingSchema = z.record(
+  z.string().regex(/^\d+$/, 'Exit codes must be non-negative integer strings'),
+  alertSeverityValueSchema.nullable()
+);
+
 const createScriptSchema = z.object({
   orgId: z.string().uuid().optional(),
   name: z.string().min(1).max(255),
@@ -101,7 +110,8 @@ const createScriptSchema = z.object({
   parameters: z.any().optional(),
   timeoutSeconds: z.number().int().min(1).max(86400).default(300),
   runAs: z.enum(['system', 'user', 'elevated']).default('system'),
-  isSystem: z.boolean().optional()
+  isSystem: z.boolean().optional(),
+  exitCodeSeverityMapping: exitCodeSeverityMappingSchema.nullable().optional()
 });
 
 const updateScriptSchema = z.object({
@@ -113,7 +123,8 @@ const updateScriptSchema = z.object({
   content: z.string().min(1).optional(),
   parameters: z.any().optional(),
   timeoutSeconds: z.number().int().min(1).max(86400).optional(),
-  runAs: z.enum(['system', 'user', 'elevated']).optional()
+  runAs: z.enum(['system', 'user', 'elevated']).optional(),
+  exitCodeSeverityMapping: exitCodeSeverityMappingSchema.nullable().optional()
 });
 
 const executeScriptSchema = z.object({
@@ -460,6 +471,7 @@ scriptRoutes.post(
         runAs: data.runAs,
         isSystem,
         version: 1,
+        exitCodeSeverityMapping: data.exitCodeSeverityMapping ?? null,
         createdBy: auth.user.id
       })
       .returning();
@@ -519,6 +531,7 @@ scriptRoutes.put(
     if (data.parameters !== undefined) updates.parameters = data.parameters;
     if (data.timeoutSeconds !== undefined) updates.timeoutSeconds = data.timeoutSeconds;
     if (data.runAs !== undefined) updates.runAs = data.runAs;
+    if (data.exitCodeSeverityMapping !== undefined) updates.exitCodeSeverityMapping = data.exitCodeSeverityMapping;
 
     // Increment version if content changes
     if (data.content !== undefined && data.content !== script.content) {

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
+import { exitCodeSeverityMappingSchema } from '@breeze/shared';
 import { and, eq, sql, desc, like, inArray, or, isNull } from 'drizzle-orm';
 import { escapeLike } from '../utils/sql';
 import { db } from '../db';
@@ -90,14 +91,10 @@ const listScriptsSchema = z.object({
   includeSystem: z.string().optional() // 'true' to include system scripts
 });
 
-// Feature #3 (severity-by-exit-code): exit code -> severity map.
-// Keys must be non-negative integer strings (e.g. "0", "1", "2").
-// Values are an AlertSeverity literal or null (null = no alert for that code).
-const alertSeverityValueSchema = z.enum(['critical', 'high', 'medium', 'low', 'info']);
-const exitCodeSeverityMappingSchema = z.record(
-  z.string().regex(/^\d+$/, 'Exit codes must be non-negative integer strings'),
-  alertSeverityValueSchema.nullable()
-);
+// Feature #3 (severity-by-exit-code): the wire-format schema for the
+// exit-code → AlertSeverity map. Defined in @breeze/shared so the UI form,
+// the route handler, and tests all import the same shape. Runtime severity
+// derivation lives in services/scriptSeverity.ts.
 
 const createScriptSchema = z.object({
   orgId: z.string().uuid().optional(),

--- a/apps/api/src/services/scriptSeverity.test.ts
+++ b/apps/api/src/services/scriptSeverity.test.ts
@@ -55,8 +55,9 @@ describe('deriveSeverityFromScript', () => {
         '10': 'high',
       };
       // exit 5: no exact match. Lower defined codes: ["10","0"] filtered by < 5 -> ["0"]
-      // mapping["0"] is null -> skip, fallback to 'critical'.
-      expect(deriveSeverityFromScript(5, sparseMapping)).toBe('critical');
+      // mapping["0"] is null -> skip; no other lower codes -> fall back to 'medium'.
+      // (Was 'critical' before #798 review — see comment in scriptSeverity.ts.)
+      expect(deriveSeverityFromScript(5, sparseMapping)).toBe('medium');
       // exit 15: lower defined codes < 15: ["10","0"]. mapping["10"]='high' -> 'high'.
       expect(deriveSeverityFromScript(15, sparseMapping)).toBe('high');
     });
@@ -69,19 +70,22 @@ describe('deriveSeverityFromScript', () => {
       expect(deriveSeverityFromScript(0, mapping)).toBeNull();
     });
 
-    it('returns critical fallback when no lower codes are defined', () => {
+    it('falls back to medium (NOT critical) when no lower codes are defined', () => {
+      // #798 review fix: user explicitly mapped exit 10, so an unmapped
+      // exit 5 should not silently escalate beyond what they configured.
       const mapping: ScriptExitCodeSeverityMapping = {
         '10': 'high',
       };
-      // exit 5: no defined codes below 5 -> fallback to 'critical'
-      expect(deriveSeverityFromScript(5, mapping)).toBe('critical');
+      expect(deriveSeverityFromScript(5, mapping)).toBe('medium');
     });
 
-    it('handles an empty mapping object as legacy-not-set (silent on 0, critical otherwise)', () => {
+    it('treats an empty mapping {} as legacy-not-set (silent on 0, medium otherwise)', () => {
+      // #798 review fix: clearing all UI rows yields {} and must NOT
+      // silently escalate every non-zero to critical.
       const mapping: ScriptExitCodeSeverityMapping = {};
       expect(deriveSeverityFromScript(0, mapping)).toBeNull();
-      // exit non-zero with empty mapping: no defined codes -> fallback 'critical'
-      expect(deriveSeverityFromScript(1, mapping)).toBe('critical');
+      expect(deriveSeverityFromScript(1, mapping)).toBe('medium');
+      expect(deriveSeverityFromScript(99, mapping)).toBe('medium');
     });
 
     it('supports per-script overrides that silence certain exit codes', () => {
@@ -96,6 +100,27 @@ describe('deriveSeverityFromScript', () => {
     });
   });
 
+  describe('abnormal termination — negative exit codes', () => {
+    // #798 review fix: explicit branch for negative codes (Unix signal-kills
+    // like SIGKILL = -9). Previously these accidentally returned 'critical'
+    // via the empty-lower-code fallback; now they return 'critical' as a
+    // documented case with test coverage.
+    it('returns critical for SIGKILL (-9) regardless of mapping', () => {
+      expect(deriveSeverityFromScript(-9, null)).toBe('critical');
+      expect(deriveSeverityFromScript(-9, {})).toBe('critical');
+      expect(deriveSeverityFromScript(-9, { '0': null, '1': 'low' })).toBe('critical');
+    });
+
+    it('returns critical for SIGSEGV (-11)', () => {
+      expect(deriveSeverityFromScript(-11, null)).toBe('critical');
+    });
+
+    it('returns critical for any negative code', () => {
+      expect(deriveSeverityFromScript(-1, null)).toBe('critical');
+      expect(deriveSeverityFromScript(-128, null)).toBe('critical');
+    });
+  });
+
   describe('edge cases', () => {
     it('handles NaN exit code as 0', () => {
       expect(deriveSeverityFromScript(NaN, null)).toBeNull();
@@ -103,6 +128,12 @@ describe('deriveSeverityFromScript', () => {
 
     it('handles Infinity exit code as 0', () => {
       expect(deriveSeverityFromScript(Infinity, null)).toBeNull();
+    });
+
+    it('handles -Infinity exit code as 0 (not negative branch)', () => {
+      // -Infinity isn't finite, so the normalize-to-0 branch catches it
+      // before the negative-code check.
+      expect(deriveSeverityFromScript(-Infinity, null)).toBeNull();
     });
   });
 });

--- a/apps/api/src/services/scriptSeverity.test.ts
+++ b/apps/api/src/services/scriptSeverity.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { deriveSeverityFromScript, type ScriptExitCodeSeverityMapping } from './scriptSeverity';
+
+describe('deriveSeverityFromScript', () => {
+  describe('legacy behavior (null mapping)', () => {
+    it('returns null for exit 0 with no mapping', () => {
+      expect(deriveSeverityFromScript(0, null)).toBeNull();
+      expect(deriveSeverityFromScript(0, undefined)).toBeNull();
+    });
+
+    it('returns medium for non-zero exit with no mapping', () => {
+      expect(deriveSeverityFromScript(1, null)).toBe('medium');
+      expect(deriveSeverityFromScript(2, null)).toBe('medium');
+      expect(deriveSeverityFromScript(127, null)).toBe('medium');
+      expect(deriveSeverityFromScript(255, undefined)).toBe('medium');
+    });
+
+    it('treats null/undefined exit code as 0', () => {
+      expect(deriveSeverityFromScript(null, null)).toBeNull();
+      expect(deriveSeverityFromScript(undefined, null)).toBeNull();
+    });
+  });
+
+  describe('opt-in mapping', () => {
+    const standardMapping: ScriptExitCodeSeverityMapping = {
+      '0': null,
+      '1': 'low',
+      '2': 'medium',
+      '3': 'high',
+      '4': 'critical',
+    };
+
+    it('uses null severity for defined exit 0', () => {
+      expect(deriveSeverityFromScript(0, standardMapping)).toBeNull();
+    });
+
+    it('maps each defined exit code to its severity', () => {
+      expect(deriveSeverityFromScript(1, standardMapping)).toBe('low');
+      expect(deriveSeverityFromScript(2, standardMapping)).toBe('medium');
+      expect(deriveSeverityFromScript(3, standardMapping)).toBe('high');
+      expect(deriveSeverityFromScript(4, standardMapping)).toBe('critical');
+    });
+
+    it('falls back to the highest-defined-lower severity for unmapped non-zero codes', () => {
+      // exit 5 falls back to "4" -> 'critical'
+      expect(deriveSeverityFromScript(5, standardMapping)).toBe('critical');
+      // exit 99 also falls back to "4" -> 'critical'
+      expect(deriveSeverityFromScript(99, standardMapping)).toBe('critical');
+    });
+
+    it('skips entries that map to null when falling back', () => {
+      // Sparse mapping: only "0" -> null and "10" -> 'high'
+      const sparseMapping: ScriptExitCodeSeverityMapping = {
+        '0': null,
+        '10': 'high',
+      };
+      // exit 5: no exact match. Lower defined codes: ["10","0"] filtered by < 5 -> ["0"]
+      // mapping["0"] is null -> skip, fallback to 'critical'.
+      expect(deriveSeverityFromScript(5, sparseMapping)).toBe('critical');
+      // exit 15: lower defined codes < 15: ["10","0"]. mapping["10"]='high' -> 'high'.
+      expect(deriveSeverityFromScript(15, sparseMapping)).toBe('high');
+    });
+
+    it('returns null for exit 0 when mapping is set but lacks key "0"', () => {
+      const mapping: ScriptExitCodeSeverityMapping = {
+        '1': 'low',
+        '2': 'medium',
+      };
+      expect(deriveSeverityFromScript(0, mapping)).toBeNull();
+    });
+
+    it('returns critical fallback when no lower codes are defined', () => {
+      const mapping: ScriptExitCodeSeverityMapping = {
+        '10': 'high',
+      };
+      // exit 5: no defined codes below 5 -> fallback to 'critical'
+      expect(deriveSeverityFromScript(5, mapping)).toBe('critical');
+    });
+
+    it('handles an empty mapping object as legacy-not-set (silent on 0, critical otherwise)', () => {
+      const mapping: ScriptExitCodeSeverityMapping = {};
+      expect(deriveSeverityFromScript(0, mapping)).toBeNull();
+      // exit non-zero with empty mapping: no defined codes -> fallback 'critical'
+      expect(deriveSeverityFromScript(1, mapping)).toBe('critical');
+    });
+
+    it('supports per-script overrides that silence certain exit codes', () => {
+      // Tech wants exit 1 to be silent (e.g. "no work needed") but exit 2 to alert.
+      const mapping: ScriptExitCodeSeverityMapping = {
+        '0': null,
+        '1': null,
+        '2': 'high',
+      };
+      expect(deriveSeverityFromScript(1, mapping)).toBeNull();
+      expect(deriveSeverityFromScript(2, mapping)).toBe('high');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles NaN exit code as 0', () => {
+      expect(deriveSeverityFromScript(NaN, null)).toBeNull();
+    });
+
+    it('handles Infinity exit code as 0', () => {
+      expect(deriveSeverityFromScript(Infinity, null)).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/services/scriptSeverity.ts
+++ b/apps/api/src/services/scriptSeverity.ts
@@ -5,19 +5,28 @@
  * null = no alert) based on an opt-in per-script mapping.
  *
  * Convention documented for techs:
- *   Exit 0  -> no alert
- *   Exit 1  -> info / low
- *   Exit 2  -> medium (warning)
- *   Exit 3  -> high (alert)
- *   Exit 4  -> critical (urgent)
- *   Exit 5+ -> critical (legacy non-zero compat)
+ *   Exit 0         -> no alert
+ *   Exit 1         -> info / low
+ *   Exit 2         -> medium (warning)
+ *   Exit 3         -> high (alert)
+ *   Exit 4         -> critical (urgent)
+ *   Exit 5+        -> falls back to highest-defined-lower severity, OR
+ *                     'medium' if no lower code is defined
+ *   Negative codes -> 'critical' (abnormal termination, e.g. SIGKILL = -9
+ *                     on Unix; PowerShell/cmd return non-negative codes)
  *
- * The mapping is per-script and stored as JSONB on `scripts.exit_code_severity_mapping`.
- * Keys are non-negative integer strings; values are an AlertSeverity literal or null.
+ * The mapping is per-script and stored as JSONB on
+ * `scripts.exit_code_severity_mapping`. Keys are non-negative integer
+ * strings; values are an AlertSeverity literal or null.
  *
- * When the mapping is NULL (default), legacy behavior is preserved:
+ * When the mapping is NULL or `{}` (empty), legacy behavior is preserved:
  *   exit 0 = ok (null), any non-zero = 'medium' (matches the previous
- *   "create alert at default severity on non-zero" path).
+ *   "create alert at default severity on non-zero" path). Treating `{}`
+ *   identically to null is important for the UI clear-all-rows path —
+ *   otherwise a user clearing every row would silently escalate every
+ *   non-zero exit to critical. (See #798 review.)
+ *
+ * Wire-format validator: `exitCodeSeverityMappingSchema` in @breeze/shared.
  */
 
 import type { AlertSeverity } from '@breeze/shared';
@@ -29,44 +38,69 @@ export type { ScriptExitCodeSeverityMapping };
  * Derive the alert severity (or null = no alert) for a script execution.
  *
  * @param exitCode - The script's exit code. `null`/`undefined` is treated as 0 (success).
+ *                   Negative codes are interpreted as abnormal termination → 'critical'.
  * @param mapping  - Per-script override mapping, or null for legacy behavior.
+ *                   An empty object `{}` is treated identically to null.
  * @returns AlertSeverity to use, or null if no alert should be raised.
  */
 export function deriveSeverityFromScript(
   exitCode: number | null | undefined,
   mapping: ScriptExitCodeSeverityMapping | null | undefined
 ): AlertSeverity | null {
+  // Normalize NaN / Infinity / nullish to 0; keep finite negative codes
+  // intact so they can be handled explicitly below.
   const code = typeof exitCode === 'number' && Number.isFinite(exitCode) ? exitCode : 0;
 
-  // Legacy: no opt-in mapping. Non-zero exit creates an alert at the default
-  // 'medium' severity; exit 0 is silent.
-  if (!mapping) {
+  // Negative exit codes mean the process did not exit normally (Unix
+  // signal kill: SIGKILL = -9, SIGSEGV = -11, etc.). Treat as critical
+  // regardless of mapping — abnormal termination is always alert-worthy,
+  // and ints in the mapping cannot match a negative code anyway.
+  if (code < 0) {
+    return 'critical';
+  }
+
+  // Treat an empty mapping object identically to null. A UI that lets the
+  // user clear all rows yields `{}`, and we don't want that to silently
+  // escalate every non-zero exit to critical via the no-lower-defined-code
+  // fallback. (See #798 review.)
+  const effectiveMapping =
+    mapping && typeof mapping === 'object' && Object.keys(mapping).length > 0
+      ? mapping
+      : null;
+
+  // Legacy: no opt-in mapping. Non-zero exit creates an alert at the
+  // default 'medium' severity; exit 0 is silent.
+  if (!effectiveMapping) {
     return code === 0 ? null : 'medium';
   }
 
   const key = String(code);
-  if (key in mapping) {
-    return mapping[key] ?? null;
+  if (key in effectiveMapping) {
+    return effectiveMapping[key] ?? null;
   }
 
-  // Fallback: pick the entry for the next-lower defined exit code, so that
-  // an exit of 7 with mapping defined up to 4 still escalates to whatever
-  // 4 specified (typically 'critical'). If no lower code is defined, default
-  // to 'critical' (the highest practical severity for unmapped non-zero).
+  // Mapping is set but did not list 0: treat as silent (do not alert).
   if (code === 0) {
-    // Mapping is set but did not list 0: treat as silent (do not alert).
     return null;
   }
 
-  const definedCodes = Object.keys(mapping)
+  // Fallback: pick the entry for the next-lower defined exit code, so an
+  // exit of 7 with mapping defined up to 4 still escalates to whatever 4
+  // specified (typically 'critical').
+  const definedCodes = Object.keys(effectiveMapping)
     .map((k) => Number(k))
     .filter((n) => Number.isFinite(n) && n >= 0 && n < code)
     .sort((a, b) => b - a); // descending
 
   for (const lowerCode of definedCodes) {
-    const sev = mapping[String(lowerCode)];
+    const sev = effectiveMapping[String(lowerCode)];
     if (sev) return sev;
   }
 
-  return 'critical';
+  // No lower defined code (or all lower codes mapped to null). Fall back
+  // to 'medium' rather than 'critical' — the user explicitly mapped
+  // specific codes, so unmapped ones should not auto-escalate beyond what
+  // they configured. This matches Tactical RMM's "don't escalate unmapped
+  // codes" convention and the legacy non-zero default. (See #798 review.)
+  return 'medium';
 }

--- a/apps/api/src/services/scriptSeverity.ts
+++ b/apps/api/src/services/scriptSeverity.ts
@@ -1,0 +1,72 @@
+/**
+ * Script exit-code severity mapping (Feature #3)
+ *
+ * Translates a script execution's exit code into an alert severity (or
+ * null = no alert) based on an opt-in per-script mapping.
+ *
+ * Convention documented for techs:
+ *   Exit 0  -> no alert
+ *   Exit 1  -> info / low
+ *   Exit 2  -> medium (warning)
+ *   Exit 3  -> high (alert)
+ *   Exit 4  -> critical (urgent)
+ *   Exit 5+ -> critical (legacy non-zero compat)
+ *
+ * The mapping is per-script and stored as JSONB on `scripts.exit_code_severity_mapping`.
+ * Keys are non-negative integer strings; values are an AlertSeverity literal or null.
+ *
+ * When the mapping is NULL (default), legacy behavior is preserved:
+ *   exit 0 = ok (null), any non-zero = 'medium' (matches the previous
+ *   "create alert at default severity on non-zero" path).
+ */
+
+import type { AlertSeverity } from '@breeze/shared';
+import type { ScriptExitCodeSeverityMapping } from '../db/schema/scripts';
+
+export type { ScriptExitCodeSeverityMapping };
+
+/**
+ * Derive the alert severity (or null = no alert) for a script execution.
+ *
+ * @param exitCode - The script's exit code. `null`/`undefined` is treated as 0 (success).
+ * @param mapping  - Per-script override mapping, or null for legacy behavior.
+ * @returns AlertSeverity to use, or null if no alert should be raised.
+ */
+export function deriveSeverityFromScript(
+  exitCode: number | null | undefined,
+  mapping: ScriptExitCodeSeverityMapping | null | undefined
+): AlertSeverity | null {
+  const code = typeof exitCode === 'number' && Number.isFinite(exitCode) ? exitCode : 0;
+
+  // Legacy: no opt-in mapping. Non-zero exit creates an alert at the default
+  // 'medium' severity; exit 0 is silent.
+  if (!mapping) {
+    return code === 0 ? null : 'medium';
+  }
+
+  const key = String(code);
+  if (key in mapping) {
+    return mapping[key] ?? null;
+  }
+
+  // Fallback: pick the entry for the next-lower defined exit code, so that
+  // an exit of 7 with mapping defined up to 4 still escalates to whatever
+  // 4 specified (typically 'critical'). If no lower code is defined, default
+  // to 'critical' (the highest practical severity for unmapped non-zero).
+  if (code === 0) {
+    // Mapping is set but did not list 0: treat as silent (do not alert).
+    return null;
+  }
+
+  const definedCodes = Object.keys(mapping)
+    .map((k) => Number(k))
+    .filter((n) => Number.isFinite(n) && n >= 0 && n < code)
+    .sort((a, b) => b - a); // descending
+
+  for (const lowerCode of definedCodes) {
+    const sev = mapping[String(lowerCode)];
+    if (sev) return sev;
+  }
+
+  return 'critical';
+}

--- a/packages/shared/src/validators/index.test.ts
+++ b/packages/shared/src/validators/index.test.ts
@@ -9,6 +9,8 @@ import {
   refreshTokenSchema,
   mfaVerifySchema,
   passwordResetSchema,
+  exitCodeSeverityMappingSchema,
+  alertSeverityValueSchema,
   createOrgSchema,
   createSiteSchema,
   inviteUserSchema,
@@ -532,5 +534,50 @@ describe('validators', () => {
       });
       expect(result.success).toBe(true);
     });
+  });
+});
+
+describe('exitCodeSeverityMappingSchema', () => {
+  it('accepts a valid mapping with severities and null', () => {
+    const r = exitCodeSeverityMappingSchema.safeParse({
+      '0': null,
+      '1': 'low',
+      '2': 'medium',
+      '3': 'high',
+      '4': 'critical',
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts an empty mapping (semantics handled by deriveSeverityFromScript)', () => {
+    expect(exitCodeSeverityMappingSchema.safeParse({}).success).toBe(true);
+  });
+
+  it('rejects negative integer keys', () => {
+    const r = exitCodeSeverityMappingSchema.safeParse({ '-1': 'critical' });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects non-integer string keys', () => {
+    expect(exitCodeSeverityMappingSchema.safeParse({ '1.5': 'high' }).success).toBe(false);
+    expect(exitCodeSeverityMappingSchema.safeParse({ 'abc': 'high' }).success).toBe(false);
+  });
+
+  it('rejects an unknown severity value', () => {
+    const r = exitCodeSeverityMappingSchema.safeParse({ '1': 'urgent' });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('alertSeverityValueSchema', () => {
+  it('accepts each canonical severity', () => {
+    for (const sev of ['critical', 'high', 'medium', 'low', 'info'] as const) {
+      expect(alertSeverityValueSchema.safeParse(sev).success).toBe(true);
+    }
+  });
+
+  it('rejects null at the standalone level', () => {
+    // The mapping schema wraps with .nullable(); this base schema does not.
+    expect(alertSeverityValueSchema.safeParse(null).success).toBe(false);
   });
 });

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -144,6 +144,18 @@ export const deviceQuerySchema = paginationSchema.extend({
 // Script Validators
 // ============================================
 
+// Feature #3 (severity-by-exit-code): exit code → AlertSeverity (or null = no alert).
+// Keys must be non-negative integer strings (e.g. "0", "1", "2"). Negative or
+// fractional codes are runtime-only (SIGKILL = -9 on Unix); the schema only
+// accepts the canonical wire-format representation.
+//
+// Lives here so route handlers, UI forms, and tests all import the same shape.
+export const alertSeverityValueSchema = z.enum(['critical', 'high', 'medium', 'low', 'info']);
+export const exitCodeSeverityMappingSchema = z.record(
+  z.string().regex(/^\d+$/, 'Exit codes must be non-negative integer strings'),
+  alertSeverityValueSchema.nullable()
+);
+
 export const createScriptSchema = z.object({
   name: z.string().min(1).max(255),
   description: z.string().max(2000).optional(),


### PR DESCRIPTION
## Summary

Adopts the Tactical RMM convention of mapping script exit codes to alert severity, so techs can express graduated criticality directly from PowerShell / Bash without separate API calls.

## Changes

- **Schema:** add nullable `exit_code_severity_mapping` JSONB column on `scripts`
- **Migration:** `2026-05-21-scripts-exit-code-severity-mapping.sql`
- **Routes:** accept / persist the field on `POST` and `PUT /scripts`
- **Service:** `scriptSeverity.ts` (pure helper `deriveSeverityFromScript()`) + 13 unit tests

NULL preserves existing behavior (non-zero = error). When set, a map like:

```json
{"0": null, "1": "low", "2": "medium", "3": "high", "4": "critical"}
```

controls which exit codes alert and at what severity, with a sensible fallback for unmapped non-zero codes. Tech can `exit 3` from PowerShell to fire a high-severity alert without touching the API.

## Backward compat

Column is nullable; existing scripts are unaffected. The `deriveSeverityFromScript()` helper is exported for downstream script-as-monitor wiring (a follow-up PR will call it from the run-handler).

## Test plan

- [x] Unit tests pass (13 tests in `scriptSeverity.test.ts`)
- [ ] Manual: create a script with a severity map via API, verify persistence on `GET`
- [ ] Follow-up PR will wire the helper into the script execution / alert path