### PR TITLE
feat(audit-logs): resolve agent actor to device hostname

### DIFF
--- a/apps/api/src/routes/audit.test.ts
+++ b/apps/api/src/routes/audit.test.ts
@@ -14,22 +14,27 @@ vi.mock('../services/auditEvents', () => ({
   writeRouteAudit: vi.fn()
 }));
 
-// countRows does: db.select().from().leftJoin().where() and destructures [row]
-// queryRows does: db.select().from().leftJoin().where().orderBy().limit().offset()
+// countRows does: db.select().from().where() and destructures [row]
+// queryRows does: db.select().from().leftJoin(users).leftJoin(devices).where().orderBy().limit().offset()
 // So .where() must be both iterable (as array) AND have .orderBy()
+const createWhereChain = () =>
+  Object.assign(Promise.resolve([{ count: 0 }]), {
+    orderBy: vi.fn().mockReturnValue({
+      limit: vi.fn().mockReturnValue({
+        offset: vi.fn().mockResolvedValue([])
+      })
+    })
+  });
+const createJoinChain = () => {
+  const chain: any = {
+    leftJoin: vi.fn(() => chain),
+    where: vi.fn().mockReturnValue(createWhereChain())
+  };
+  return chain;
+};
 const createDbChain = () => ({
   from: vi.fn().mockReturnValue({
-    leftJoin: vi.fn().mockReturnValue({
-      where: vi.fn().mockReturnValue(
-        Object.assign(Promise.resolve([{ count: 0 }]), {
-          orderBy: vi.fn().mockReturnValue({
-            limit: vi.fn().mockReturnValue({
-              offset: vi.fn().mockResolvedValue([])
-            })
-          })
-        })
-      )
-    }),
+    leftJoin: vi.fn(() => createJoinChain()),
     where: vi.fn().mockResolvedValue([{ count: 0 }])
   })
 });
@@ -48,7 +53,8 @@ vi.mock('../db', () => ({
 
 vi.mock('../db/schema', () => ({
   auditLogs: { orgId: 'orgId', actorId: 'actorId', timestamp: 'timestamp', id: 'id' },
-  users: { id: 'id', name: 'name' }
+  users: { id: 'id', name: 'name' },
+  devices: { agentId: 'agentId', hostname: 'hostname', displayName: 'displayName' }
 }));
 
 vi.mock('../middleware/auth', () => ({

--- a/apps/api/src/routes/auditLogs.test.ts
+++ b/apps/api/src/routes/auditLogs.test.ts
@@ -8,24 +8,29 @@ vi.mock('../services/auditEvents', () => ({
   writeRouteAudit: vi.fn()
 }));
 
-// countRows does: db.select().from().leftJoin().where() and destructures [row]
-// queryRows does: db.select().from().leftJoin().where().orderBy().limit().offset()
-// GET /logs/:id does: db.select().from().leftJoin().where() and destructures [row]
+// countRows does: db.select().from().where() and destructures [row]
+// queryRows does: db.select().from().leftJoin(users).leftJoin(devices).where().orderBy().limit().offset()
+// GET /logs/:id does: db.select().from().leftJoin(users).leftJoin(devices).where() and destructures [row]
 // So .where() must be both iterable (as array) AND have .orderBy()
 // Returning empty array by default; countRows returns row?.count ?? 0 = 0 when empty
+const createWhereChain = () =>
+  Object.assign(Promise.resolve([]), {
+    orderBy: vi.fn().mockReturnValue({
+      limit: vi.fn().mockReturnValue({
+        offset: vi.fn().mockResolvedValue([])
+      })
+    })
+  });
+const createJoinChain = () => {
+  const chain: any = {
+    leftJoin: vi.fn(() => chain),
+    where: vi.fn().mockReturnValue(createWhereChain())
+  };
+  return chain;
+};
 const createDbChain = () => ({
   from: vi.fn().mockReturnValue({
-    leftJoin: vi.fn().mockReturnValue({
-      where: vi.fn().mockReturnValue(
-        Object.assign(Promise.resolve([]), {
-          orderBy: vi.fn().mockReturnValue({
-            limit: vi.fn().mockReturnValue({
-              offset: vi.fn().mockResolvedValue([])
-            })
-          })
-        })
-      )
-    }),
+    leftJoin: vi.fn(() => createJoinChain()),
     where: vi.fn().mockReturnValue(Object.assign(Promise.resolve([{ count: 0 }]), {
       limit: vi.fn().mockResolvedValue([])
     }))
@@ -47,7 +52,8 @@ vi.mock('../db', () => ({
 
 vi.mock('../db/schema', () => ({
   auditLogs: { orgId: 'orgId', actorId: 'actorId', timestamp: 'timestamp', id: 'id' },
-  users: { id: 'id', name: 'name' }
+  users: { id: 'id', name: 'name' },
+  devices: { agentId: 'agentId', hostname: 'hostname', displayName: 'displayName' }
 }));
 
 vi.mock('../middleware/auth', () => ({
@@ -195,10 +201,12 @@ describe('audit log routes', () => {
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           leftJoin: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              orderBy: vi.fn().mockReturnValue({
-                limit: vi.fn().mockReturnValue({
-                  offset: vi.fn().mockResolvedValue([formulaRow])
+            leftJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    offset: vi.fn().mockResolvedValue([formulaRow])
+                  })
                 })
               })
             })
@@ -245,10 +253,12 @@ describe('audit log routes', () => {
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           leftJoin: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              orderBy: vi.fn().mockReturnValue({
-                limit: vi.fn().mockReturnValue({
-                  offset: vi.fn().mockResolvedValue([row])
+            leftJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    offset: vi.fn().mockResolvedValue([row])
+                  })
                 })
               })
             })
@@ -270,10 +280,12 @@ describe('audit log routes', () => {
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           leftJoin: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              orderBy: vi.fn().mockReturnValue({
-                limit: vi.fn().mockReturnValue({
-                  offset: vi.fn().mockResolvedValue([row])
+            leftJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    offset: vi.fn().mockResolvedValue([row])
+                  })
                 })
               })
             })
@@ -318,10 +330,12 @@ describe('audit log routes', () => {
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           leftJoin: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              orderBy: vi.fn().mockReturnValue({
-                limit: vi.fn().mockReturnValue({
-                  offset: vi.fn().mockResolvedValue([row])
+            leftJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    offset: vi.fn().mockResolvedValue([row])
+                  })
                 })
               })
             })

--- a/apps/api/src/routes/auditLogs.ts
+++ b/apps/api/src/routes/auditLogs.ts
@@ -3,7 +3,7 @@ import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { and, desc, eq, gte, lte, ilike, or, sql, SQL } from 'drizzle-orm';
 import { db } from '../db';
-import { auditLogs as auditLogsTable, users } from '../db/schema';
+import { auditLogs as auditLogsTable, users, devices } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
 import { PERMISSIONS } from '../services/permissions';
@@ -155,11 +155,18 @@ function deriveCategory(action: string): string {
 type DbRow = {
   log: typeof auditLogsTable.$inferSelect;
   userName: string | null;
+  deviceHostname: string | null;
+  deviceDisplayName: string | null;
 };
 
 function resolveActorName(row: DbRow, details?: Record<string, unknown> | null): string {
   if (row.userName) {
     return row.userName;
+  }
+
+  if (row.log.actorType === 'agent') {
+    const deviceName = row.deviceDisplayName || row.deviceHostname;
+    if (deviceName) return deviceName;
   }
 
   if (row.log.actorEmail) {
@@ -298,9 +305,18 @@ function buildSearchCondition(q: string): SQL {
 
 async function queryRows(where: SQL | undefined, limit: number, offset: number): Promise<DbRow[]> {
   return db
-    .select({ log: auditLogsTable, userName: users.name })
+    .select({
+      log: auditLogsTable,
+      userName: users.name,
+      deviceHostname: devices.hostname,
+      deviceDisplayName: devices.displayName,
+    })
     .from(auditLogsTable)
     .leftJoin(users, eq(auditLogsTable.actorId, users.id))
+    .leftJoin(
+      devices,
+      sql`${devices.agentId} = ${auditLogsTable.details}->>'rawActorId' AND ${auditLogsTable.actorType} = 'agent'`
+    )
     .where(where)
     .orderBy(desc(auditLogsTable.timestamp))
     .limit(limit)
@@ -331,6 +347,8 @@ interface LateralAuditRow extends Record<string, unknown> {
   checksum: string | null;
   initiated_by: string | null;
   user_name: string | null;
+  device_hostname: string | null;
+  device_display_name: string | null;
 }
 
 async function queryLatestPerOrg(orgIds: string[], limit: number): Promise<DbRow[]> {
@@ -341,7 +359,9 @@ async function queryLatestPerOrg(orgIds: string[], limit: number): Promise<DbRow
       al.actor_email, al.action, al.resource_type, al.resource_id,
       al.resource_name, al.details, al.ip_address, al.user_agent,
       al.result, al.error_message, al.checksum, al.initiated_by,
-      u.name AS user_name
+      u.name AS user_name,
+      d.hostname AS device_hostname,
+      d.display_name AS device_display_name
     FROM unnest(ARRAY[${orgIdsSql}]::uuid[]) AS o(org_id)
     CROSS JOIN LATERAL (
       SELECT * FROM audit_logs
@@ -350,6 +370,9 @@ async function queryLatestPerOrg(orgIds: string[], limit: number): Promise<DbRow
       LIMIT ${limit}
     ) al
     LEFT JOIN users u ON al.actor_id = u.id
+    LEFT JOIN devices d
+      ON al.actor_type = 'agent'
+      AND d.agent_id = al.details->>'rawActorId'
     ORDER BY al.timestamp DESC
     LIMIT ${limit}
   `);
@@ -374,6 +397,8 @@ async function queryLatestPerOrg(orgIds: string[], limit: number): Promise<DbRow
       initiatedBy: r.initiated_by,
     } as DbRow['log'],
     userName: r.user_name ?? null,
+    deviceHostname: r.device_hostname ?? null,
+    deviceDisplayName: r.device_display_name ?? null,
   }));
 }
 
@@ -381,7 +406,6 @@ async function countRows(where: SQL | undefined): Promise<number> {
   const [row] = await db
     .select({ count: sql<number>`count(*)::int` })
     .from(auditLogsTable)
-    .leftJoin(users, eq(auditLogsTable.actorId, users.id))
     .where(where);
   return row?.count ?? 0;
 }
@@ -561,9 +585,18 @@ auditLogRoutes.get(
     if (orgCond) conditions.push(orgCond);
 
     const [row] = await db
-      .select({ log: auditLogsTable, userName: users.name })
+      .select({
+        log: auditLogsTable,
+        userName: users.name,
+        deviceHostname: devices.hostname,
+        deviceDisplayName: devices.displayName,
+      })
       .from(auditLogsTable)
       .leftJoin(users, eq(auditLogsTable.actorId, users.id))
+      .leftJoin(
+        devices,
+        sql`${devices.agentId} = ${auditLogsTable.details}->>'rawActorId' AND ${auditLogsTable.actorType} = 'agent'`
+      )
       .where(and(...conditions));
 
     if (!row) {


### PR DESCRIPTION
Rebased version of #793 onto post-#792 main. Closes #793.

#793 went DIRTY after #792 squash-merged its embedded LATERAL commit. Maintainer-push to the contributor fork was blocked by a token-auth edge case (same as the #795/#792 dance earlier), so re-published from LanternOps — commit author preserved as @bdunncompany.

Original review thread: https://github.com/LanternOps/breeze/pull/793

---

Resolves agent actor entries in audit logs to the device hostname (LEFT JOIN devices ON devices.agent_id = audit_logs.details->>'rawActorId'). RLS-safe: deleted/cross-tenant devices return NULL via the policy and fall back to the existing `Agent <prefix>` display. `actorName` response field unchanged — no API shape break.

Closes #793