### PR TITLE
fix(web): use filteredFindings and reset selection on search

### DIFF
--- a/apps/web/src/components/sensitiveData/FindingsTab.tsx
+++ b/apps/web/src/components/sensitiveData/FindingsTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Search, ChevronLeft, ChevronRight } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import {
@@ -48,6 +48,15 @@ export default function FindingsTab() {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [showRemediation, setShowRemediation] = useState(false);
 
+  const filteredFindings = useMemo(
+    () => findings.filter((f: Finding) => !search || f.filePath.toLowerCase().includes(search.toLowerCase())),
+    [findings, search]
+  );
+
+  useEffect(() => {
+    setSelectedIds(new Set());
+  }, [search]);
+
   const fetchFindings = useCallback(async (page = 1) => {
     try {
       setLoading(true);
@@ -83,10 +92,10 @@ export default function FindingsTab() {
   };
 
   const toggleAll = () => {
-    if (selectedIds.size === findings.length) {
+    if (selectedIds.size === filteredFindings.length) {
       setSelectedIds(new Set());
     } else {
-      setSelectedIds(new Set(findings.map((f) => f.id)));
+      setSelectedIds(new Set(filteredFindings.map((f: Finding) => f.id)));
     }
   };
 
@@ -157,7 +166,7 @@ export default function FindingsTab() {
               <th className="px-4 py-3">
                 <input
                   type="checkbox"
-                  checked={findings.length > 0 && selectedIds.size === findings.length}
+                  checked={filteredFindings.length > 0 && selectedIds.size === filteredFindings.length}
                   onChange={toggleAll}
                   className="rounded border-border"
                 />
@@ -188,9 +197,7 @@ export default function FindingsTab() {
                 </td>
               </tr>
             )}
-            {!loading && findings
-              .filter((f) => !search || f.filePath.toLowerCase().includes(search.toLowerCase()))
-              .map((f) => (
+            {!loading && filteredFindings.map((f: Finding) => (
                 <tr key={f.id} className="text-sm hover:bg-muted/20">
                   <td className="px-4 py-3">
                     <input


### PR DESCRIPTION
Fixed #809 

Introduce a memoized filteredFindings (useMemo) and clear selectedIds whenever the search term changes. Update toggleAll, the header checkbox checked state, and the row rendering to use filteredFindings instead of the full findings list so bulk selection and counts only apply to visible results and avoid selecting hidden items. This also provides a small performance improvement by avoiding repeated filtering in render.

## Summary

<!-- What does this PR do? Keep it brief (1-3 bullets). -->

**Filtering and Selection Improvements:**

* Introduced `useMemo` to memoize the filtered findings list based on the current search term, improving performance by avoiding unnecessary recalculations.
* Updated the "select all" (`toggleAll`) logic and checkbox state to operate on the filtered findings instead of the full findings list, ensuring correct selection behavior when a search filter is applied. [[1]](diffhunk://#diff-6066a3b7fd448c0ab298ff6438a9338841ea66525489f3382927ec8144d58dd5L86-R98) [[2]](diffhunk://#diff-6066a3b7fd448c0ab298ff6438a9338841ea66525489f3382927ec8144d58dd5L160-R169)
* Reset the set of selected findings whenever the search term changes, preventing selections from persisting across different filter results.
* Simplified the rendering of findings to use the memoized filtered list, reducing code duplication and improving clarity.

**Minor update:**

* Added `useMemo` to the import statement to support the new memoization logic.

## Type of Change

<!-- Check the one that applies: -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Other: <!-- describe -->

## Testing

<!-- How did you verify this works? -->

- [x] Existing tests pass (`pnpm test` / `make test`)
- [ ] Added new tests
- [ ] Manual testing (describe below)

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [x] I have tested on the relevant platforms
- [x] No secrets, credentials, or personal data included
