### PR TITLE
fix(software-policies): accept orgId from query string on POST (#808)

### DIFF
--- a/apps/api/src/routes/softwarePolicies.ts
+++ b/apps/api/src/routes/softwarePolicies.ts
@@ -196,7 +196,14 @@ softwarePoliciesRoutes.post(
     const auth = c.get('auth');
     const payload = c.req.valid('json');
 
-    const resolvedOrg = resolveOrgIdForWrite(auth, payload.orgId);
+    // The frontend always sends ?orgId=<currentOrgId> on partner-scope POSTs,
+    // not in the JSON body. Reading only from payload.orgId left partner-scope
+    // users with no resolvable org (#808: "orgId is required for this scope"
+    // after the underlying 500 from #807 was fixed).
+    const resolvedOrg = resolveOrgIdForWrite(
+      auth,
+      payload.orgId ?? c.req.query('orgId') ?? undefined
+    );
     if (!resolvedOrg.orgId) {
       return c.json({ error: resolvedOrg.error ?? 'Organization resolution failed' }, 400);
     }


### PR DESCRIPTION
Closes #808.

## Symptom

\`POST /api/v1/software-policies?orgId=<id>\` (with a valid blocklist payload) returns 400 with:

\`\`\`json
{"error":"orgId is required for this scope"}
\`\`\`

The frontend always sends \`?orgId=<currentOrgId>\` in the query string, never in the JSON body, so a partner-scope user with multiple accessible orgs cannot create policies.

## Root cause

At \`apps/api/src/routes/softwarePolicies.ts:199\`:

\`\`\`ts
const resolvedOrg = resolveOrgIdForWrite(auth, payload.orgId);
\`\`\`

Only \`payload.orgId\` (JSON body) is consulted. The \`resolveOrgIdForWrite\` helper falls through to the no-orgId branch and returns the error.

Other write-routes in the same area (\`software.ts\`, \`softwareInventory.ts\`) already accept orgId from the query, this one was missed.

## Fix

Mirror the canonical pattern:

\`\`\`ts
const resolvedOrg = resolveOrgIdForWrite(
  auth,
  payload.orgId ?? c.req.query('orgId') ?? undefined
);
\`\`\`

Tenant boundary unchanged: foreign orgIds still 403 via \`auth.canAccessOrg\`, missing orgId still 400.

## Files changed

| File | Change |
|---|---|
| \`apps/api/src/routes/softwarePolicies.ts\` | accept orgId from query (8 added, 1 removed) |

## Verification

- \`pnpm --filter @breeze/api exec tsc --noEmit\`: clean
- **Live-tested on a self-host instance**: Create Software Policy with payload \`{name, mode:"blocklist", rules}\` and \`?orgId=<id>\` now creates the policy successfully (confirmed end-to-end in browser)

## Note on stacking

This PR is the second half of the #808 fix. The first half is a separate PR for #807 (\`fix(migrations): backport 0040 target_type DROP NOT NULL for fresh installs\`) which is required to clear the underlying 500 from a NOT NULL violation. With both PRs merged, #808 is fully closed; with only this one, the route still 500s for any partner-scope user creating a policy on a fresh install.