### PR TITLE
fix(patches): accept orgId from query + serialize Dates as ISO in approval upsert (#805)

### DIFF
--- a/apps/api/src/routes/patches/approvals.ts
+++ b/apps/api/src/routes/patches/approvals.ts
@@ -71,7 +71,13 @@ approvalsRoutes.post(
     const auth = c.get('auth');
     const data = c.req.valid('json');
 
-    const orgResolution = resolvePatchApprovalOrgId(auth, data.orgId);
+    // The frontend always sends ?orgId=<currentOrgId> in the query for
+    // partner-scope POSTs, not in the JSON body. Reading only from data.orgId
+    // left partner-scope users with no resolvable org (#805 and class).
+    const orgResolution = resolvePatchApprovalOrgId(
+      auth,
+      data.orgId ?? c.req.query('orgId') ?? undefined
+    );
     if ('error' in orgResolution) {
       return c.json({ error: orgResolution.error }, orgResolution.status);
     }
@@ -124,7 +130,13 @@ approvalsRoutes.post(
     const { id } = c.req.valid('param');
     const data = c.req.valid('json');
 
-    const orgResolution = resolvePatchApprovalOrgId(auth, data.orgId);
+    // The frontend always sends ?orgId=<currentOrgId> in the query for
+    // partner-scope POSTs, not in the JSON body. Reading only from data.orgId
+    // left partner-scope users with no resolvable org (#805 and class).
+    const orgResolution = resolvePatchApprovalOrgId(
+      auth,
+      data.orgId ?? c.req.query('orgId') ?? undefined
+    );
     if ('error' in orgResolution) {
       return c.json({ error: orgResolution.error }, orgResolution.status);
     }
@@ -177,7 +189,13 @@ approvalsRoutes.post(
     const { id } = c.req.valid('param');
     const data = c.req.valid('json');
 
-    const orgResolution = resolvePatchApprovalOrgId(auth, data.orgId);
+    // The frontend always sends ?orgId=<currentOrgId> in the query for
+    // partner-scope POSTs, not in the JSON body. Reading only from data.orgId
+    // left partner-scope users with no resolvable org (#805 and class).
+    const orgResolution = resolvePatchApprovalOrgId(
+      auth,
+      data.orgId ?? c.req.query('orgId') ?? undefined
+    );
     if ('error' in orgResolution) {
       return c.json({ error: orgResolution.error }, orgResolution.status);
     }
@@ -227,7 +245,13 @@ approvalsRoutes.post(
     const { id } = c.req.valid('param');
     const data = c.req.valid('json');
 
-    const orgResolution = resolvePatchApprovalOrgId(auth, data.orgId);
+    // The frontend always sends ?orgId=<currentOrgId> in the query for
+    // partner-scope POSTs, not in the JSON body. Reading only from data.orgId
+    // left partner-scope users with no resolvable org (#805 and class).
+    const orgResolution = resolvePatchApprovalOrgId(
+      auth,
+      data.orgId ?? c.req.query('orgId') ?? undefined
+    );
     if ('error' in orgResolution) {
       return c.json({ error: orgResolution.error }, orgResolution.status);
     }

--- a/apps/api/src/routes/patches/helpers.ts
+++ b/apps/api/src/routes/patches/helpers.ts
@@ -74,7 +74,13 @@ export async function upsertPatchApproval(values: {
   deferUntil?: Date | null;
   notes?: string | null;
 }) {
-  // Use raw SQL for upsert because the unique index uses COALESCE expression
+  // Use raw SQL for upsert because the unique index uses COALESCE expression.
+  // Dates must be serialized to ISO strings before binding. postgres-js's
+  // template-literal driver path (db.execute(sql`...`)) doesn't auto-coerce
+  // Date instances and throws `TypeError: ... Received an instance of Date`
+  // at the Bind step (#805 root cause).
+  const approvedAtIso = values.approvedAt ? values.approvedAt.toISOString() : null;
+  const deferUntilIso = values.deferUntil ? values.deferUntil.toISOString() : null;
   await db.execute(sql`
     INSERT INTO patch_approvals (id, org_id, patch_id, ring_id, status, approved_by, approved_at, defer_until, notes, created_at, updated_at)
     VALUES (
@@ -84,8 +90,8 @@ export async function upsertPatchApproval(values: {
       ${values.ringId},
       ${values.status},
       ${values.approvedBy ?? null},
-      ${values.approvedAt ?? null},
-      ${values.deferUntil ?? null},
+      ${approvedAtIso},
+      ${deferUntilIso},
       ${values.notes ?? null},
       NOW(),
       NOW()


### PR DESCRIPTION
Closes #805.

## Symptom

\`POST /api/v1/patches/bulk-approve?orgId=<id>\` fails for partner-scope users. UI shows "Failed to approve patches" toast.

Live api log:
\`\`\`
<-- POST /api/v1/patches/bulk-approve?orgId=<id>
Error: TypeError [ERR_INVALID_ARG_TYPE]: The "string" argument must be of type string or an instance of Buffer or ArrayBuffer. Received an instance of Date
    at Bind (postgres@3.4.9/connection.js:954:16)
--> POST /api/v1/patches/bulk-approve 500 30ms
\`\`\`

## Root cause

Two stacked bugs prevented the route from working for partner-scope users:

### Bug 1: orgId not read from query

\`apps/api/src/routes/patches/approvals.ts\` resolves the target org via \`resolvePatchApprovalOrgId(auth, data.orgId)\`, which only consults the JSON body. The web client sends \`?orgId=<currentOrgId>\` in the query string. Partner-scope users with multiple accessible orgs fell through to \"orgId is required for partner/system scope\" 400 before the SQL ever ran.

This affected the bulk-approve, single approve, decline, and defer routes (all use the same resolver pattern).

### Bug 2: Date serialization at the SQL bind step

Once Bug 1 was fixed and the request reached \`upsertPatchApproval\` in \`apps/api/src/routes/patches/helpers.ts\`, the raw-SQL template literal threw the TypeError above. \`approvedAt: new Date()\` and \`deferUntil: new Date(...)\` were passed directly to \`sql\\\`...\${date}...\\\``; the postgres-js template-literal driver path doesn't auto-coerce Date instances and throws at parameter Bind.

## Fix

1. Read \`orgId\` from query string as a fallback in all four routes:
   \`\`\`ts
   resolvePatchApprovalOrgId(auth, data.orgId ?? c.req.query('orgId') ?? undefined)
   \`\`\`
   Mirrors the canonical pattern used in \`software.ts\` and \`softwareInventory.ts\`.

2. Coerce Date values to ISO strings before binding in \`upsertPatchApproval\`:
   \`\`\`ts
   const approvedAtIso = values.approvedAt ? values.approvedAt.toISOString() : null;
   const deferUntilIso = values.deferUntil ? values.deferUntil.toISOString() : null;
   \`\`\`

Tenant boundary unchanged: foreign orgIds still 403 via \`auth.canAccessOrg\`, missing orgId still 400 in the no-resolvable-org branch.

## Files changed

| File | Change |
|---|---|
| \`apps/api/src/routes/patches/approvals.ts\` | orgId from query in bulk-approve, approve, decline, defer (4 sites) |
| \`apps/api/src/routes/patches/helpers.ts\` | Coerce Date to ISO string in \`upsertPatchApproval\` |

37 insertions, 7 deletions.

## Verification

- \`pnpm --filter @breeze/api exec tsc --noEmit\`: clean
- **Live-tested on a self-host instance**: Patches → select 2 → "Approve 2" now succeeds (verified end-to-end in browser, both fixes are required for end-to-end success)