### PR TITLE
fix(event-bus): publish runs outside any active DB transaction context

### DIFF
--- a/apps/api/src/services/eventBus.ts
+++ b/apps/api/src/services/eventBus.ts
@@ -1,6 +1,7 @@
 import Redis from 'ioredis';
 import { getRedisConnection } from './redis';
 import { randomUUID } from 'crypto';
+import { runOutsideDbContext } from '../db';
 
 // Event types for type safety
 export type EventType =
@@ -173,7 +174,6 @@ class EventBus {
     source: string,
     options: PublishOptions = {}
   ): Promise<string> {
-    const redis = this.getOrCreateRedis();
     const eventId = randomUUID();
     const streamKey = `${STREAM_PREFIX}:${orgId}`;
 
@@ -192,32 +192,44 @@ class EventBus {
       }
     };
 
-    // Add to Redis Stream
-    await redis.xadd(
-      streamKey,
-      'MAXLEN',
-      '~',
-      MAX_STREAM_LENGTH.toString(),
-      '*',
-      'event',
-      JSON.stringify(event)
-    );
+    // Escape any active AsyncLocalStorage DB transaction context before doing
+    // Redis-bound work. Otherwise a publishEvent call made from inside a
+    // transaction (e.g. alertWorker, createAlert, publishEvent) holds the
+    // Postgres connection in `idle in transaction` for as long as Redis takes.
+    // Any local handler (e.g. webhookDelivery / automationWorker `*`
+    // subscribers that queue BullMQ deliveries) compounds that wait. Under a
+    // Redis stall this manifested as Postgres pool exhaustion and login
+    // lockout on 2026-05-21.
+    return runOutsideDbContext(async () => {
+      const redis = this.getOrCreateRedis();
 
-    // Also publish to pub/sub for real-time subscribers
-    await redis.publish(`${STREAM_PREFIX}:live:${orgId}`, JSON.stringify(event));
+      // Add to Redis Stream
+      await redis.xadd(
+        streamKey,
+        'MAXLEN',
+        '~',
+        MAX_STREAM_LENGTH.toString(),
+        '*',
+        'event',
+        JSON.stringify(event)
+      );
 
-    // Publish to global channel for cross-org subscribers (webhooks, etc.)
-    await redis.publish(`${STREAM_PREFIX}:global`, JSON.stringify(event));
+      // Also publish to pub/sub for real-time subscribers
+      await redis.publish(`${STREAM_PREFIX}:live:${orgId}`, JSON.stringify(event));
 
-    if (type !== 'monitoring.check_failed' && type !== 'monitoring.check_recovered') {
-      console.log(`[EventBus] Published ${type} for org ${orgId}: ${eventId}`);
-    }
+      // Publish to global channel for cross-org subscribers (webhooks, etc.)
+      await redis.publish(`${STREAM_PREFIX}:global`, JSON.stringify(event));
 
-    // Invoke local in-process handlers immediately
-    // This handles the case where startConsuming() hasn't been called
-    await this.invokeLocalHandlers(event as BreezeEvent);
+      if (type !== 'monitoring.check_failed' && type !== 'monitoring.check_recovered') {
+        console.log(`[EventBus] Published ${type} for org ${orgId}: ${eventId}`);
+      }
 
-    return eventId;
+      // Invoke local in-process handlers immediately
+      // This handles the case where startConsuming() hasn't been called
+      await this.invokeLocalHandlers(event as BreezeEvent);
+
+      return eventId;
+    });
   }
 
   /**


### PR DESCRIPTION
## Problem

\`EventBus.publish()\` does serial Redis ops (\`xadd\`, \`publish\` x2) then awaits \`invokeLocalHandlers\` which fans out to subscribed handlers. When a caller is inside an AsyncLocalStorage DB transaction context (e.g. \`alertWorker.ts:81\` wraps every job in \`runWithSystemDbAccess\` which calls \`baseDb.transaction(...)\`), every awaited Redis op holds the Postgres connection in \`idle in transaction\` for the duration.

Worse: the \`*\` subscribers in \`webhookDelivery.ts:407-427\` and \`automationWorker.ts:864-876\` each call \`runWithSystemDbAccess\`, which short-circuits at \`db/index.ts:103\` when an outer context exists, sharing the parent's transaction. They then do their own BullMQ \`queue.add\` (more Redis) inside that transaction.

Under any Redis stall (BullMQ slow path, connection churn, ioredis reconnect delay), the awaits never resolve and the parent's Postgres connection sits idle in transaction indefinitely. The \`alertWorker\` has \`concurrency: 10\` and the \`evaluate-all\` job runs on a schedule, so the pool drains fast under adverse Redis conditions.

## Real-world manifestation

Production login lockout on 2026-05-21 where login appeared to hang despite the api healthcheck returning 200. \`pg_stat_activity\` showed 6+ connections from \`postgres.js\` in \`idle in transaction\` with \`wait_event=ClientRead\` and \`now()-query_start\` over 37 minutes, all holding the same SELECT against the \`devices\` table (which \`featureConfigResolver.ts:88\` runs from inside the worker's transaction).

\`\`\`sql
SELECT pid, now()-query_start AS dur, state, wait_event, LEFT(query, 80)
FROM pg_stat_activity
WHERE application_name = 'postgres.js' AND state = 'idle in transaction'
ORDER BY query_start;
\`\`\`

\`\`\`
   pid   |       dur       |        state        | wait_event | LEFT(query,80)
---------+-----------------+---------------------+------------+-------------------
 1340691 | 00:37:02.429056 | idle in transaction | ClientRead | select "id", "org_id", ... from "devices" where ...
 1340689 | 00:37:02.429042 | idle in transaction | ClientRead | (same)
 ... (4 more, all >36 min)
\`\`\`

Remaining pool slots were consumed by hot agent traffic, so anything that needed a fresh connection (auth/login) waited indefinitely.

## Fix

Single-point fix in \`publish()\`: wrap the Redis ops + \`invokeLocalHandlers\` block in \`runOutsideDbContext(...)\` so the Postgres connection is released the moment its actual SQL completes, regardless of what the publish path is doing.

The \`*\` subscribers now open their own transactions (since \`dbContextStorage.getStore()\` returns undefined inside \`runOutsideDbContext\`), which is the correct behavior anyway. They were always supposed to be independent. Failure semantics preserved: if Redis is hard-down, \`publishEvent\` still throws and the caller's transaction still rolls back via the awaited throw.

## Verification

- \`pnpm --filter @breeze/api exec tsc --noEmit\`: clean
- **Live deployed and verified in production**: stuck-in-transaction count dropped from double-digit accumulation pre-fix (the original lockout pattern) to bouncing 0-2 with max idle age under 13 seconds post-fix, across multiple multi-minute observation windows.
- Independent code-review investigation by a second pass identified the same root cause and architectural pattern.

## Files changed

| File | Change |
|---|---|
| \`apps/api/src/services/eventBus.ts\` | Wrap Redis xadd + 2x publish + invokeLocalHandlers in \`runOutsideDbContext(...)\` |

37 insertions, 25 deletions.

## Defense-in-depth recommendation

I also applied \`ALTER DATABASE breeze SET idle_in_transaction_session_timeout = 60000\` on my self-host (plus \`ALTER ROLE breeze\` and \`breeze_app\`) as a belt-and-suspenders safeguard. This caps the duration of any future leaked transaction at 60s. Worth considering as a default in the deploy template or as a migration.