### PR TITLE
fix: add spam protection for refresh_inventory command

### DIFF
--- a/apps/api/src/routes/devices/commands.test.ts
+++ b/apps/api/src/routes/devices/commands.test.ts
@@ -369,6 +369,15 @@ describe('device commands routes', () => {
         status: 'online'
       } as never);
 
+      // Mock the pending check to return no existing command
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
+      } as never);
+
       vi.mocked(db.insert).mockReturnValueOnce({
         values: vi.fn().mockReturnValue({
           returning: vi.fn().mockResolvedValue([{
@@ -391,6 +400,40 @@ describe('device commands routes', () => {
       const body = await res.json();
       expect(body.type).toBe('refresh_inventory');
       expect(body.status).toBe('pending');
+    });
+
+    it('rejects refresh_inventory when one is already pending (spam protection)', async () => {
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce({
+        id: 'device-a',
+        orgId: 'org-123',
+        hostname: 'host-a',
+        status: 'online'
+      } as never);
+
+      // Mock the pending check to return an existing command
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: 'cmd-existing',
+              deviceId: 'device-a',
+              type: 'refresh_inventory',
+              status: 'pending'
+            }])
+          })
+        })
+      } as never);
+
+      const res = await app.request('/devices/device-a/commands', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ type: 'refresh_inventory' })
+      });
+
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toContain('already pending');
+      expect(db.insert).not.toHaveBeenCalled();
     });
 
     it('rejects an unknown command type with 400', async () => {

--- a/apps/api/src/routes/devices/commands.ts
+++ b/apps/api/src/routes/devices/commands.ts
@@ -135,6 +135,26 @@ commandsRoutes.post(
         continue;
       }
 
+      // Prevent spam: skip refresh_inventory if one is already pending for this device
+      if (data.type === 'refresh_inventory') {
+        const [existingPending] = await db
+          .select()
+          .from(deviceCommands)
+          .where(
+            and(
+              eq(deviceCommands.deviceId, deviceId),
+              eq(deviceCommands.type, 'refresh_inventory'),
+              eq(deviceCommands.status, 'pending')
+            )
+          )
+          .limit(1);
+
+        if (existingPending) {
+          failed.push(deviceId);
+          continue;
+        }
+      }
+
       const [command] = await db
         .insert(deviceCommands)
         .values({
@@ -201,6 +221,25 @@ commandsRoutes.post(
     // Don't allow commands to decommissioned devices
     if (device.status === 'decommissioned') {
       return c.json({ error: 'Cannot send commands to a decommissioned device' }, 400);
+    }
+
+    // Prevent spam: reject refresh_inventory if one is already pending for this device
+    if (data.type === 'refresh_inventory') {
+      const [existingPending] = await db
+        .select()
+        .from(deviceCommands)
+        .where(
+          and(
+            eq(deviceCommands.deviceId, deviceId),
+            eq(deviceCommands.type, 'refresh_inventory'),
+            eq(deviceCommands.status, 'pending')
+          )
+        )
+        .limit(1);
+
+      if (existingPending) {
+        return c.json({ error: 'A refresh_inventory command is already pending for this device' }, 409);
+      }
     }
 
     // Wake-on-LAN takes a separate path: the command row must be addressed to


### PR DESCRIPTION
## Summary

Fixes #830

Adds server-side spam protection for refresh_inventory commands by rejecting new requests when one is already pending for the device.

## Problem

The Refresh inventory button has no spam protection. Users can click repeatedly and queue unbounded refresh_inventory rows, each of which fans out approximately 12 inventory collectors on the agent.

## Solution

Server-side dedup check: Before inserting a refresh_inventory command, check if one is already pending for that device.

Single-device endpoint: Return 409 Conflict with clear error message.
Bulk endpoint: Skip the device and add to failed array.

## Testing

All 23 existing tests pass.
Added new test for spam protection scenario.
Updated existing test to mock the pending check.

## Behavior Change

Before: Multiple clicks queue multiple pending commands.
After: Only one pending command allowed per device at a time.