### PR TITLE
fix(dns): serialize policy-sync domain mutations to prevent rule clobbering (#827)

### DIFF
--- a/apps/api/src/jobs/dnsSyncJob.test.ts
+++ b/apps/api/src/jobs/dnsSyncJob.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { runSequentialDomainMutations } from './dnsSyncJob';
+
+describe('runSequentialDomainMutations (issue #827 — policy-sync rule clobbering)', () => {
+  it('runs domain mutations one at a time, never concurrently', async () => {
+    const domains = ['a.com', 'b.com', 'c.com', 'd.com', 'e.com'];
+    let inFlight = 0;
+    let maxConcurrent = 0;
+    const completionOrder: string[] = [];
+
+    await runSequentialDomainMutations(domains, async (domain) => {
+      inFlight += 1;
+      maxConcurrent = Math.max(maxConcurrent, inFlight);
+      // Yield to the event loop — a concurrent caller would interleave here.
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      completionOrder.push(domain);
+      inFlight -= 1;
+    });
+
+    // The whole point of the fix: only one provider call is ever in flight.
+    expect(maxConcurrent).toBe(1);
+    expect(completionOrder).toEqual(domains);
+  });
+
+  it('does not invoke the operation for an empty domain list', async () => {
+    let callCount = 0;
+    await runSequentialDomainMutations([], async () => {
+      callCount += 1;
+    });
+    expect(callCount).toBe(0);
+  });
+
+  it('preserves every change against a full-array (set_rules-style) provider', async () => {
+    // Simulate a provider whose only mutation API replaces the ENTIRE rule
+    // array per call (AdGuard Home's set_rules). Each addDomain does a
+    // read-modify-write: GET current rules -> mutate -> POST full array.
+    // Under the old concurrency-10 batching, ten calls would all read the
+    // same baseline and the last POST would win, dropping the other nine.
+    let serverRules: string[] = [];
+
+    const addDomainViaSetRules = async (domain: string): Promise<void> => {
+      // READ current rules from the "server".
+      const current = [...serverRules];
+      // Yield — gives any concurrent caller a chance to read the same stale
+      // baseline. With sequential execution this is harmless.
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      // MODIFY + WRITE the full array back.
+      serverRules = [...current, domain];
+    };
+
+    const domains = Array.from({ length: 25 }, (_, i) => `domain-${i}.example.com`);
+    await runSequentialDomainMutations(domains, addDomainViaSetRules);
+
+    // No silent data loss: every domain made it into the final rule array.
+    expect(serverRules).toHaveLength(domains.length);
+    expect(new Set(serverRules)).toEqual(new Set(domains));
+  });
+
+  it('propagates the first error and stops processing remaining domains', async () => {
+    const processed: string[] = [];
+    const operation = async (domain: string): Promise<void> => {
+      if (domain === 'bad.com') {
+        throw new Error('provider rejected domain');
+      }
+      processed.push(domain);
+    };
+
+    await expect(
+      runSequentialDomainMutations(['ok1.com', 'bad.com', 'ok2.com'], operation)
+    ).rejects.toThrow('provider rejected domain');
+
+    // Sequential execution means the failure halts before later domains run.
+    expect(processed).toEqual(['ok1.com']);
+  });
+});

--- a/apps/api/src/jobs/dnsSyncJob.ts
+++ b/apps/api/src/jobs/dnsSyncJob.ts
@@ -213,6 +213,34 @@ function chunk<T>(items: T[], size: number): T[][] {
   return chunks;
 }
 
+/**
+ * Apply a per-domain provider mutation strictly sequentially — one provider
+ * API call at a time, never concurrently.
+ *
+ * The DNS provider add/remove domain methods are NOT safe to run in parallel:
+ * several providers expose only a "replace the entire rule array" API (e.g.
+ * AdGuard Home's `set_rules`), so each method performs a read-modify-write
+ * (GET current rules -> mutate -> POST full array). Running N of these
+ * concurrently means all N read the same baseline and each POSTs its own
+ * array — last write wins and silently drops the other N-1 domains' changes,
+ * while the policy-sync job still records `sync_status='synced'`. That is
+ * silent tenant data loss (issue #827).
+ *
+ * Sequential execution guarantees every call observes the previous call's
+ * write. Domain counts per policy are small and these are cheap HTTP calls,
+ * so serialization has negligible cost. Do NOT reintroduce concurrency here
+ * without a per-provider guarantee that the mutation API is incremental
+ * rather than full-array.
+ */
+export async function runSequentialDomainMutations(
+  domains: string[],
+  operation: (domain: string) => Promise<void>
+): Promise<void> {
+  for (const domain of domains) {
+    await operation(domain);
+  }
+}
+
 function syncIntervalMinutesFromConfig(config: DnsIntegrationConfig): number {
   const configured = Number(config.syncInterval);
   if (!Number.isFinite(configured)) return DEFAULT_SYNC_INTERVAL_MINUTES;
@@ -561,24 +589,14 @@ async function processPolicySync(data: SyncPolicyJobData): Promise<{
       ? normalizeDomainList(data.operations.remove)
       : [];
 
-    const runBatched = async (
-      domains: string[],
-      operation: (domain: string) => Promise<void>,
-      concurrency = 10
-    ): Promise<void> => {
-      if (domains.length === 0) return;
-      for (let i = 0; i < domains.length; i += concurrency) {
-        const block = domains.slice(i, i + concurrency);
-        await Promise.all(block.map(operation));
-      }
-    };
-
+    // Mutations MUST run sequentially — see runSequentialDomainMutations for
+    // why concurrency here causes silent rule clobbering (issue #827).
     if (row.policy.type === 'blocklist') {
-      await runBatched(addDomains, (domain) => provider.addBlocklistDomain(domain), 10);
-      await runBatched(removeDomains, (domain) => provider.removeBlocklistDomain(domain), 10);
+      await runSequentialDomainMutations(addDomains, (domain) => provider.addBlocklistDomain(domain));
+      await runSequentialDomainMutations(removeDomains, (domain) => provider.removeBlocklistDomain(domain));
     } else {
-      await runBatched(addDomains, (domain) => provider.addAllowlistDomain(domain), 10);
-      await runBatched(removeDomains, (domain) => provider.removeAllowlistDomain(domain), 10);
+      await runSequentialDomainMutations(addDomains, (domain) => provider.addAllowlistDomain(domain));
+      await runSequentialDomainMutations(removeDomains, (domain) => provider.removeAllowlistDomain(domain));
     }
 
     await db


### PR DESCRIPTION
## Root cause

`processPolicySync` in `apps/api/src/jobs/dnsSyncJob.ts` ran the provider `add*/remove*Domain` mutations in batches of **10 concurrent calls** via an inline `runBatched` helper.

Some DNS providers expose only a *full-array replacement* mutation API — notably AdGuard Home's `set_rules` — so each `add*/remove*Domain` method performs a read-modify-write:

```
GET current rules -> mutate in memory -> POST the full array
```

When ten of these run concurrently, all ten read the **same baseline** array, each mutates its own copy, and each POSTs its full array back. Last write wins — the other nine domains' changes are silently dropped. Meanwhile the job still records `sync_status='synced'`, so the data loss is invisible to the user.

## Fix

Replaced the concurrency-10 `runBatched` helper with a module-scoped, exported `runSequentialDomainMutations` helper that applies the per-domain mutations **strictly one at a time**. Sequential execution guarantees every call observes the previous call's write, eliminating the read-modify-write race entirely.

This is intentionally scoped — no `DnsProvider` interface redesign. Domain counts per policy are small and these are cheap HTTP calls, so the cost of serialization is negligible. A code comment warns against reintroducing concurrency without a per-provider guarantee that the mutation API is incremental rather than full-array.

## Test

New `apps/api/src/jobs/dnsSyncJob.test.ts` (Vitest, alongside source) covers:

- **No concurrency** — tracks max in-flight calls and asserts it never exceeds 1; completion order matches input order.
- **Empty list** — operation is never invoked.
- **Full-array provider** — simulates a `set_rules`-style read-modify-write provider with 25 domains and asserts every domain survives in the final rule array (this test would fail under the old concurrent batching).
- **Error propagation** — a mid-list failure halts before later domains run.

## Verification

- `pnpm --filter @breeze/api exec tsc --noEmit` — passes
- `vitest run src/jobs/dnsSyncJob.test.ts` — 4/4 passing

Closes #827

🤖 Generated with [Claude Code](https://claude.com/claude-code)