### PR TITLE
fix(agent): bump golang.org/x/net to v0.55.0 for GO-2026-5026

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -22,8 +22,8 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/y9o/go-openh264 v0.2.0
-	golang.org/x/net v0.54.0
-	golang.org/x/sys v0.44.0
+	golang.org/x/net v0.55.0
+	golang.org/x/sys v0.45.0
 	google.golang.org/api v0.279.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/agent/go.sum
+++ b/agent/go.sum
@@ -265,8 +265,8 @@ golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPI
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
-golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -278,8 +278,8 @@ golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
 golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=


### PR DESCRIPTION
## Summary

CI's **Go Vulnerability Check** job (`CGO_ENABLED=0 govulncheck ./...`) fails on **GO-2026-5026**, a *called* vulnerability in `golang.org/x/net@v0.54.0`: "Invoking failure to reject ASCII-only Punycode-encoded labels in `golang.org/x/net/idna`."

The vulnerable symbol is reached via:
`api.Client.RotateToken` → `http.Client.Do` → `idna.ToASCII` (`agent/pkg/api/client.go:241`).

This PR bumps `golang.org/x/net` **v0.54.0 → v0.55.0** (the fixed release) in `agent/go.mod`, the only Go module in the repo. `go mod tidy` also transitively bumps `golang.org/x/sys` **v0.44.0 → v0.45.0**, which `x/net v0.55.0` requires. No other dependencies were changed.

The 13 vulnerabilities govulncheck still reports in *required-but-not-called* modules are unchanged behavior — they do not fail the check.

### Files changed
- `agent/go.mod`
- `agent/go.sum`

## Test Plan

All run in the `agent/` module:

- `CGO_ENABLED=0 go build ./...` — passes (exit 0)
- `go vet ./...` — clean (exit 0; only pre-existing third-party cgo C-compiler warnings from `go-m1cpu`)
- `go test -race ./...` — all packages pass; no failures (pre-existing macOS `LC_DYSYMTAB` linker warnings are unrelated toolchain noise)
- `govulncheck ./...` — **Symbol Results: "No vulnerabilities found"**. GO-2026-5026 no longer appears in the called-vulnerabilities section. Exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)