### PR TITLE
test(db): guard legacy migrations stay consistent with the baseline (#817)

### DIFF
--- a/apps/api/src/db/autoMigrate.ts
+++ b/apps/api/src/db/autoMigrate.ts
@@ -239,7 +239,7 @@ async function recordMigration(
 }
 
 /** The highest legacy migration number that should be marked as applied for legacy DBs. */
-const LEGACY_CUTOFF = 65;
+export const LEGACY_CUTOFF = 65;
 
 /**
  * Single-track migration runner for Breeze.

--- a/apps/api/src/db/baselineConsistency.test.ts
+++ b/apps/api/src/db/baselineConsistency.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import {
+  parseMigrationNumber,
+  isLegacyRangeMigration,
+  extractTrackedAlters,
+  parseBaselineTables,
+  checkAlterAgainstBaseline,
+  REMEDIATED_LEGACY_GAPS,
+  type BaselineSchema,
+  type BaselineColumn,
+} from './baselineConsistency';
+
+describe('baselineConsistency', () => {
+  describe('parseMigrationNumber', () => {
+    it('extracts the numeric prefix of a legacy migration', () => {
+      expect(parseMigrationNumber('0040-software-policy-scope-deprecation.sql')).toBe(40);
+    });
+
+    it('extracts 1 from the baseline filename', () => {
+      expect(parseMigrationNumber('0001-baseline.sql')).toBe(1);
+    });
+
+    it('parses a date-prefixed migration as its leading year', () => {
+      expect(parseMigrationNumber('2026-05-21-software-policies-target-type-nullable.sql')).toBe(2026);
+    });
+
+    it('returns null when there is no numeric prefix', () => {
+      expect(parseMigrationNumber('optional-timescale.sql')).toBeNull();
+    });
+  });
+
+  describe('isLegacyRangeMigration', () => {
+    it('is true for a migration inside the 2-65 legacy range', () => {
+      expect(isLegacyRangeMigration('0040-software-policy-scope-deprecation.sql')).toBe(true);
+    });
+
+    it('is false for the baseline itself (number 1)', () => {
+      expect(isLegacyRangeMigration('0001-baseline.sql')).toBe(false);
+    });
+
+    it('is false for a post-cutoff numbered migration', () => {
+      expect(isLegacyRangeMigration('0066-fix-search-vector-fresh-install.sql')).toBe(false);
+    });
+
+    it('is false for a date-prefixed migration', () => {
+      expect(isLegacyRangeMigration('2026-05-21-software-policies-target-type-nullable.sql')).toBe(false);
+    });
+  });
+
+  describe('extractTrackedAlters', () => {
+    it('extracts a DROP NOT NULL', () => {
+      expect(extractTrackedAlters('ALTER TABLE software_policies ALTER COLUMN target_type DROP NOT NULL;')).toEqual([
+        { kind: 'drop-not-null', table: 'software_policies', column: 'target_type' },
+      ]);
+    });
+
+    it('extracts a SET NOT NULL', () => {
+      expect(extractTrackedAlters('ALTER TABLE backups ALTER COLUMN device_id SET NOT NULL;')).toEqual([
+        { kind: 'set-not-null', table: 'backups', column: 'device_id' },
+      ]);
+    });
+
+    it('extracts a TYPE change with its new type', () => {
+      expect(extractTrackedAlters('ALTER TABLE foo ALTER COLUMN bar TYPE text;')).toEqual([
+        { kind: 'type', table: 'foo', column: 'bar', newType: 'text' },
+      ]);
+    });
+
+    it('captures a parameterized new type', () => {
+      expect(extractTrackedAlters('ALTER TABLE foo ALTER COLUMN bar SET DATA TYPE character varying(100);')).toEqual([
+        { kind: 'type', table: 'foo', column: 'bar', newType: 'character varying(100)' },
+      ]);
+    });
+
+    it('extracts a DROP COLUMN, tolerating IF EXISTS', () => {
+      expect(extractTrackedAlters('ALTER TABLE foo DROP COLUMN IF EXISTS legacy_col;')).toEqual([
+        { kind: 'drop-column', table: 'foo', column: 'legacy_col' },
+      ]);
+    });
+
+    it('extracts a RENAME COLUMN with the new name', () => {
+      expect(extractTrackedAlters('ALTER TABLE foo RENAME COLUMN old_name TO new_name;')).toEqual([
+        { kind: 'rename-column', table: 'foo', column: 'old_name', newColumn: 'new_name' },
+      ]);
+    });
+
+    it('handles the ALTER TABLE ONLY and public. qualifiers', () => {
+      expect(extractTrackedAlters('ALTER TABLE ONLY public.devices ALTER COLUMN org_id DROP NOT NULL;')).toEqual([
+        { kind: 'drop-not-null', table: 'devices', column: 'org_id' },
+      ]);
+    });
+
+    it('ignores ADD COLUMN (caught by drift detection, out of scope)', () => {
+      expect(extractTrackedAlters('ALTER TABLE foo ADD COLUMN IF NOT EXISTS bar text;')).toEqual([]);
+    });
+
+    it('ignores tracked statements that appear only inside a SQL comment', () => {
+      expect(extractTrackedAlters('-- ALTER TABLE foo ALTER COLUMN bar DROP NOT NULL;\nSELECT 1;')).toEqual([]);
+    });
+
+    it('is case-insensitive on keywords', () => {
+      expect(extractTrackedAlters('alter table foo alter column bar drop not null;')).toEqual([
+        { kind: 'drop-not-null', table: 'foo', column: 'bar' },
+      ]);
+    });
+
+    it('extracts multiple statements from one migration', () => {
+      const sql = `
+        ALTER TABLE a ALTER COLUMN x DROP NOT NULL;
+        ALTER TABLE b DROP COLUMN y;
+      `;
+      expect(extractTrackedAlters(sql)).toEqual([
+        { kind: 'drop-not-null', table: 'a', column: 'x' },
+        { kind: 'drop-column', table: 'b', column: 'y' },
+      ]);
+    });
+
+    it('parses the real 0040 migration to exactly one drop-not-null', () => {
+      const sql = [
+        '-- Software policies are now pure templates (rules + enforcement only).',
+        '-- Device targeting is handled exclusively through Configuration Policy assignments.',
+        '-- Make target_type nullable since new policies no longer set it.',
+        'ALTER TABLE software_policies ALTER COLUMN target_type DROP NOT NULL;',
+      ].join('\n');
+      expect(extractTrackedAlters(sql)).toEqual([
+        { kind: 'drop-not-null', table: 'software_policies', column: 'target_type' },
+      ]);
+    });
+  });
+
+  describe('parseBaselineTables', () => {
+    const sample = `
+CREATE TABLE IF NOT EXISTS public.widgets (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    name character varying(50) NOT NULL,
+    note text,
+    count integer DEFAULT 0 NOT NULL,
+    CONSTRAINT widgets_count_check CHECK ((count >= 0))
+);
+
+CREATE TABLE public.gadgets (
+    id uuid NOT NULL,
+    label text
+);
+`;
+
+    it('parses every table in the baseline', () => {
+      const schema = parseBaselineTables(sample);
+      expect([...schema.keys()].sort()).toEqual(['gadgets', 'widgets']);
+    });
+
+    it('records each column type without the DEFAULT clause', () => {
+      const widgets = parseBaselineTables(sample).get('widgets');
+      expect(widgets?.get('id')?.type).toBe('uuid');
+      expect(widgets?.get('name')?.type).toBe('character varying(50)');
+      expect(widgets?.get('count')?.type).toBe('integer');
+    });
+
+    it('records the NOT NULL flag per column', () => {
+      const widgets = parseBaselineTables(sample).get('widgets');
+      expect(widgets?.get('id')?.notNull).toBe(true);
+      expect(widgets?.get('name')?.notNull).toBe(true);
+      expect(widgets?.get('note')?.notNull).toBe(false);
+      expect(widgets?.get('count')?.notNull).toBe(true);
+    });
+
+    it('skips table-level constraint lines', () => {
+      const widgets = parseBaselineTables(sample).get('widgets');
+      expect(widgets?.has('CONSTRAINT')).toBe(false);
+      expect([...(widgets?.keys() ?? [])].sort()).toEqual(['count', 'id', 'name', 'note']);
+    });
+  });
+
+  describe('checkAlterAgainstBaseline', () => {
+    const baseline: BaselineSchema = new Map<string, Map<string, BaselineColumn>>([
+      [
+        'software_policies',
+        new Map<string, BaselineColumn>([
+          ['target_type', { type: 'character varying(50)', notNull: true }],
+          ['name', { type: 'text', notNull: true }],
+        ]),
+      ],
+      ['audit_logs', new Map<string, BaselineColumn>([['org_id', { type: 'uuid', notNull: false }]])],
+    ]);
+
+    it('reports a DROP NOT NULL as unsatisfied when the baseline still has NOT NULL', () => {
+      const result = checkAlterAgainstBaseline(
+        { kind: 'drop-not-null', table: 'software_policies', column: 'target_type' },
+        baseline,
+      );
+      expect(result.satisfied).toBe(false);
+    });
+
+    it('reports a DROP NOT NULL as satisfied when the baseline column is already nullable', () => {
+      const result = checkAlterAgainstBaseline(
+        { kind: 'drop-not-null', table: 'audit_logs', column: 'org_id' },
+        baseline,
+      );
+      expect(result.satisfied).toBe(true);
+    });
+
+    it('reports a SET NOT NULL as satisfied when the baseline column is NOT NULL', () => {
+      const result = checkAlterAgainstBaseline(
+        { kind: 'set-not-null', table: 'software_policies', column: 'name' },
+        baseline,
+      );
+      expect(result.satisfied).toBe(true);
+    });
+
+    it('reports a SET NOT NULL as unsatisfied when the baseline column is nullable', () => {
+      const result = checkAlterAgainstBaseline(
+        { kind: 'set-not-null', table: 'audit_logs', column: 'org_id' },
+        baseline,
+      );
+      expect(result.satisfied).toBe(false);
+    });
+
+    it('reports a TYPE change as satisfied when the baseline type matches', () => {
+      const result = checkAlterAgainstBaseline(
+        { kind: 'type', table: 'software_policies', column: 'name', newType: 'text' },
+        baseline,
+      );
+      expect(result.satisfied).toBe(true);
+    });
+
+    it('reports a TYPE change as unsatisfied when the baseline type differs', () => {
+      const result = checkAlterAgainstBaseline(
+        { kind: 'type', table: 'software_policies', column: 'name', newType: 'jsonb' },
+        baseline,
+      );
+      expect(result.satisfied).toBe(false);
+    });
+
+    it('reports a DROP COLUMN as unsatisfied when the column still exists in the baseline', () => {
+      const result = checkAlterAgainstBaseline(
+        { kind: 'drop-column', table: 'software_policies', column: 'name' },
+        baseline,
+      );
+      expect(result.satisfied).toBe(false);
+    });
+
+    it('reports a DROP COLUMN as satisfied when the column is absent from the baseline', () => {
+      const result = checkAlterAgainstBaseline(
+        { kind: 'drop-column', table: 'software_policies', column: 'removed_col' },
+        baseline,
+      );
+      expect(result.satisfied).toBe(true);
+    });
+
+    it('reports a RENAME COLUMN as satisfied when only the new name is present', () => {
+      const result = checkAlterAgainstBaseline(
+        { kind: 'rename-column', table: 'software_policies', column: 'old_name', newColumn: 'name' },
+        baseline,
+      );
+      expect(result.satisfied).toBe(true);
+    });
+
+    it('reports a RENAME COLUMN as unsatisfied when the old name is still present', () => {
+      const result = checkAlterAgainstBaseline(
+        { kind: 'rename-column', table: 'software_policies', column: 'name', newColumn: 'name_v2' },
+        baseline,
+      );
+      expect(result.satisfied).toBe(false);
+    });
+  });
+
+  // ── The guard itself ──────────────────────────────────────────────────────
+  // Every schema-shape mutation made by a legacy-range migration (2-65) must be
+  // reflected in 0001-baseline.sql, because autoMigrate marks 2-65 as applied
+  // WITHOUT running their SQL on fresh installs. A gap here means the schema
+  // silently diverges. See issue #817.
+  describe('legacy migrations are consistent with the consolidated baseline', () => {
+    const migrationsDir = path.resolve(__dirname, '../../migrations');
+    const baseline = parseBaselineTables(
+      readFileSync(path.join(migrationsDir, '0001-baseline.sql'), 'utf8'),
+    );
+
+    const legacyFiles = readdirSync(migrationsDir)
+      .filter((f) => f.endsWith('.sql') && isLegacyRangeMigration(f))
+      .sort();
+
+    it('finds the full legacy migration range', () => {
+      expect(legacyFiles.length).toBeGreaterThan(50);
+    });
+
+    it('every legacy schema mutation is reflected in the baseline (or explicitly remediated)', () => {
+      const gaps: string[] = [];
+
+      for (const file of legacyFiles) {
+        const sql = readFileSync(path.join(migrationsDir, file), 'utf8');
+        for (const alter of extractTrackedAlters(sql)) {
+          const result = checkAlterAgainstBaseline(alter, baseline);
+          if (result.satisfied) continue;
+          if (REMEDIATED_LEGACY_GAPS[file]) continue;
+          gaps.push(`  ${file}: ${alter.kind} ${alter.table}.${alter.column} — ${result.detail}`);
+        }
+      }
+
+      expect(
+        gaps,
+        gaps.length === 0
+          ? ''
+          : `Legacy migration(s) mutate the schema in a way 0001-baseline.sql does not reflect.\n` +
+              `On fresh installs these are marked applied but never run, so the effect is lost.\n` +
+              `Fix: re-run the effect in a new dated migration and add the file to REMEDIATED_LEGACY_GAPS,\n` +
+              `or correct 0001-baseline.sql if it can be regenerated.\n\n${gaps.join('\n')}`,
+      ).toEqual([]);
+    });
+
+    it('every REMEDIATED_LEGACY_GAPS entry names a real legacy migration file', () => {
+      for (const file of Object.keys(REMEDIATED_LEGACY_GAPS)) {
+        expect(legacyFiles, `${file} is allowlisted but not a legacy-range migration`).toContain(file);
+      }
+    });
+  });
+});

--- a/apps/api/src/db/baselineConsistency.ts
+++ b/apps/api/src/db/baselineConsistency.ts
@@ -1,0 +1,219 @@
+/**
+ * Baseline-consistency guard (issue #817).
+ *
+ * On a fresh install, `autoMigrate` applies `0001-baseline.sql` and then marks
+ * every migration in the legacy range (2 .. LEGACY_CUTOFF) as applied WITHOUT
+ * running its SQL — on the assumption that the consolidated baseline already
+ * reflects them. If a legacy migration mutates the schema (drops a NOT NULL,
+ * changes a type, drops/renames a column) and that change was never folded into
+ * `0001-baseline.sql`, the effect is silently lost on every fresh install.
+ *
+ * This module parses the schema-shape mutations out of each legacy migration
+ * and the column definitions out of the baseline so a test can assert the two
+ * agree. ADD COLUMN is intentionally out of scope: a column missing from the
+ * baseline is caught by `db:check-drift` (Drizzle declares the column, the DB
+ * does not). The mutations below are the ones drift detection cannot catch,
+ * because Drizzle and the migration agree while the baseline silently differs.
+ */
+import { LEGACY_CUTOFF } from './autoMigrate';
+
+export type TrackedAlterKind = 'drop-not-null' | 'set-not-null' | 'type' | 'drop-column' | 'rename-column';
+
+export interface TrackedAlter {
+  kind: TrackedAlterKind;
+  table: string;
+  column: string;
+  /** Present for `type`. */
+  newType?: string;
+  /** Present for `rename-column`. */
+  newColumn?: string;
+}
+
+export interface BaselineColumn {
+  type: string;
+  notNull: boolean;
+}
+
+/** table name → (column name → column definition), parsed from `0001-baseline.sql`. */
+export type BaselineSchema = Map<string, Map<string, BaselineColumn>>;
+
+export interface BaselineCheckResult {
+  satisfied: boolean;
+  detail: string;
+}
+
+/**
+ * Legacy migrations whose effect is genuinely absent from `0001-baseline.sql`
+ * but is re-applied by a post-cutoff dated migration (which DOES run on fresh
+ * installs). Key = legacy migration filename, value = justification.
+ */
+export const REMEDIATED_LEGACY_GAPS: Record<string, string> = {
+  '0040-software-policy-scope-deprecation.sql':
+    '0001-baseline.sql declares software_policies.target_type NOT NULL; the DROP NOT NULL is ' +
+    're-applied post-cutoff by 2026-05-21-software-policies-target-type-nullable.sql (PR #812, issue #807/#808).',
+};
+
+/** Required regex capture group — throws if the group did not participate in the match. */
+function group(match: RegExpMatchArray, index: number): string {
+  const value = match[index];
+  if (value === undefined) {
+    throw new Error(`missing capture group ${index} in "${match[0] ?? ''}"`);
+  }
+  return value;
+}
+
+/** Leading numeric prefix of a migration filename, or null if it has none. */
+export function parseMigrationNumber(filename: string): number | null {
+  const match = filename.match(/^(\d+)-/);
+  return match ? Number.parseInt(group(match, 1), 10) : null;
+}
+
+/** True when the file is a legacy-range migration (2 .. LEGACY_CUTOFF) that fresh installs skip. */
+export function isLegacyRangeMigration(filename: string): boolean {
+  const num = parseMigrationNumber(filename);
+  return num !== null && num >= 2 && num <= LEGACY_CUTOFF;
+}
+
+/** Strip `-- line` and block SQL comments so they cannot false-match. */
+function stripSqlComments(sql: string): string {
+  return sql.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/--[^\n]*/g, ' ');
+}
+
+// `ALTER TABLE [ONLY] [public.]<table>` — the shared prefix of every tracked statement.
+const TABLE = String.raw`ALTER\s+TABLE\s+(?:ONLY\s+)?(?:"?public"?\.)?"?(\w+)"?`;
+const COLUMN = String.raw`"?(\w+)"?`;
+// A type expression: one or more word tokens (none of them `USING`), plus an optional `(...)`.
+const TYPE_EXPR = String.raw`((?:(?!USING\b)[a-zA-Z]\w*)(?:\s+(?!USING\b)[a-zA-Z]\w*)*(?:\s*\([^)]*\))?)`;
+
+interface AlterPattern {
+  regex: RegExp;
+  build: (m: RegExpMatchArray) => TrackedAlter;
+}
+
+const ALTER_PATTERNS: AlterPattern[] = [
+  {
+    regex: new RegExp(`${TABLE}\\s+ALTER\\s+COLUMN\\s+${COLUMN}\\s+DROP\\s+NOT\\s+NULL`, 'gi'),
+    build: (m) => ({ kind: 'drop-not-null', table: group(m, 1), column: group(m, 2) }),
+  },
+  {
+    regex: new RegExp(`${TABLE}\\s+ALTER\\s+COLUMN\\s+${COLUMN}\\s+SET\\s+NOT\\s+NULL`, 'gi'),
+    build: (m) => ({ kind: 'set-not-null', table: group(m, 1), column: group(m, 2) }),
+  },
+  {
+    regex: new RegExp(`${TABLE}\\s+ALTER\\s+COLUMN\\s+${COLUMN}\\s+(?:SET\\s+DATA\\s+)?TYPE\\s+${TYPE_EXPR}`, 'gi'),
+    build: (m) => ({ kind: 'type', table: group(m, 1), column: group(m, 2), newType: group(m, 3).trim() }),
+  },
+  {
+    regex: new RegExp(`${TABLE}\\s+DROP\\s+COLUMN\\s+(?:IF\\s+EXISTS\\s+)?${COLUMN}`, 'gi'),
+    build: (m) => ({ kind: 'drop-column', table: group(m, 1), column: group(m, 2) }),
+  },
+  {
+    regex: new RegExp(`${TABLE}\\s+RENAME\\s+COLUMN\\s+${COLUMN}\\s+TO\\s+${COLUMN}`, 'gi'),
+    build: (m) => ({ kind: 'rename-column', table: group(m, 1), column: group(m, 2), newColumn: group(m, 3) }),
+  },
+];
+
+/** Extract every tracked schema-shape mutation from a migration's SQL, in source order. */
+export function extractTrackedAlters(sql: string): TrackedAlter[] {
+  const clean = stripSqlComments(sql);
+  const found: Array<{ index: number; alter: TrackedAlter }> = [];
+
+  for (const { regex, build } of ALTER_PATTERNS) {
+    for (const match of clean.matchAll(regex)) {
+      found.push({ index: match.index ?? 0, alter: build(match) });
+    }
+  }
+
+  return found.sort((a, b) => a.index - b.index).map((f) => f.alter);
+}
+
+/** Type expressions normalized for comparison (lowercased, whitespace collapsed). */
+function normalizeType(type: string): string {
+  return type.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+const CONSTRAINT_LINE = /^\s*(CONSTRAINT|PRIMARY\s+KEY|FOREIGN\s+KEY|UNIQUE|CHECK|EXCLUDE)\b/i;
+
+/** Parse every `CREATE TABLE` block of `0001-baseline.sql` into a column map. */
+export function parseBaselineTables(baselineSql: string): BaselineSchema {
+  const schema: BaselineSchema = new Map();
+  const tableRegex = /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:"?public"?\.)?"?(\w+)"?\s*\(([\s\S]*?)\n\);/gi;
+
+  for (const tableMatch of baselineSql.matchAll(tableRegex)) {
+    const tableName = group(tableMatch, 1);
+    const body = group(tableMatch, 2);
+    const columns = new Map<string, BaselineColumn>();
+
+    for (const rawLine of body.split('\n')) {
+      const line = rawLine.trim().replace(/,\s*$/, '');
+      if (!line || CONSTRAINT_LINE.test(line)) continue;
+
+      const colMatch = line.match(/^"?(\w+)"?\s+(.+)$/);
+      if (!colMatch) continue;
+      const columnName = group(colMatch, 1);
+      const rest = group(colMatch, 2);
+
+      const notNull = /\bNOT\s+NULL\b/i.test(rest);
+      // The type is everything up to the first DEFAULT / NOT NULL / GENERATED / COLLATE clause.
+      const cutPoints = [/\bDEFAULT\b/i, /\bNOT\s+NULL\b/i, /\bGENERATED\b/i, /\bCOLLATE\b/i]
+        .map((re) => rest.match(re)?.index ?? -1)
+        .filter((i) => i >= 0);
+      const type = (cutPoints.length ? rest.slice(0, Math.min(...cutPoints)) : rest).trim();
+
+      columns.set(columnName, { type, notNull });
+    }
+
+    schema.set(tableName, columns);
+  }
+
+  return schema;
+}
+
+/** Verify a legacy migration's schema mutation is reflected in the parsed baseline. */
+export function checkAlterAgainstBaseline(alter: TrackedAlter, baseline: BaselineSchema): BaselineCheckResult {
+  const table = baseline.get(alter.table);
+  const column = table?.get(alter.column);
+
+  switch (alter.kind) {
+    case 'drop-not-null':
+      if (!table) return { satisfied: false, detail: `table "${alter.table}" is absent from the baseline` };
+      if (!column) return { satisfied: false, detail: `column "${alter.column}" is absent from the baseline` };
+      return column.notNull
+        ? { satisfied: false, detail: 'baseline still declares this column NOT NULL' }
+        : { satisfied: true, detail: 'baseline column is nullable' };
+
+    case 'set-not-null':
+      if (!table) return { satisfied: false, detail: `table "${alter.table}" is absent from the baseline` };
+      if (!column) return { satisfied: false, detail: `column "${alter.column}" is absent from the baseline` };
+      return column.notNull
+        ? { satisfied: true, detail: 'baseline column is NOT NULL' }
+        : { satisfied: false, detail: 'baseline declares this column nullable' };
+
+    case 'type': {
+      if (!table) return { satisfied: false, detail: `table "${alter.table}" is absent from the baseline` };
+      if (!column) return { satisfied: false, detail: `column "${alter.column}" is absent from the baseline` };
+      const expected = normalizeType(alter.newType ?? '');
+      const actual = normalizeType(column.type);
+      return actual === expected
+        ? { satisfied: true, detail: `baseline type is "${column.type}"` }
+        : { satisfied: false, detail: `baseline type is "${column.type}", migration sets "${alter.newType}"` };
+    }
+
+    case 'drop-column':
+      // A table entirely absent from the baseline has nothing to mismatch.
+      if (!table) return { satisfied: true, detail: `table "${alter.table}" is absent from the baseline` };
+      return table.has(alter.column)
+        ? { satisfied: false, detail: 'column is still present in the baseline' }
+        : { satisfied: true, detail: 'column is absent from the baseline' };
+
+    case 'rename-column': {
+      if (!table) return { satisfied: true, detail: `table "${alter.table}" is absent from the baseline` };
+      if (table.has(alter.column)) {
+        return { satisfied: false, detail: `old column name "${alter.column}" is still present in the baseline` };
+      }
+      return table.has(alter.newColumn ?? '')
+        ? { satisfied: true, detail: `baseline has the renamed column "${alter.newColumn}"` }
+        : { satisfied: false, detail: `renamed column "${alter.newColumn}" is absent from the baseline` };
+    }
+  }
+}


### PR DESCRIPTION
## Summary

`autoMigrate` marks legacy-range migrations (2..`LEGACY_CUTOFF`) as applied **without running their SQL** on fresh installs, assuming `0001-baseline.sql` already reflects them. When it doesn't, the schema silently diverges — this is the root cause behind #807/#808, where `software_policies.target_type` stayed `NOT NULL` on every install after 2026-03-16 and 500'd the software-inventory approve endpoint.

Nothing caught that class of bug: `breeze_migrations` shows the migration as applied, and `db:check-drift` misses it (Drizzle and the migration agree the column is nullable; only the baseline silently differs).

This adds the guard #817 asks for:

- **`baselineConsistency.ts`** — parses the schema-shape mutations a fresh install would skip (`DROP`/`SET NOT NULL`, `TYPE` change, `DROP`/`RENAME COLUMN`) out of every legacy migration, and parses the column definitions out of `0001-baseline.sql`.
- **`baselineConsistency.test.ts`** — asserts every legacy mutation is reflected in the baseline. `ADD COLUMN` is intentionally out of scope (`db:check-drift` already catches that class).
- **`REMEDIATED_LEGACY_GAPS`** — an allowlist (pattern: `rls-coverage.integration.test.ts`) for gaps genuinely re-applied by a post-cutoff dated migration. Currently one entry: `0040`, fixed by PR #812.
- `LEGACY_CUTOFF` is now exported from `autoMigrate.ts` so the guard's range can't drift from the runner's.

It's a Vitest test auto-discovered by the existing `test-api` CI job — no workflow change — so it guards every future PR that touches `apps/api/migrations/`.

## Test Plan

- [x] 37 unit + guard tests pass (parsing, baseline check, the real-files guard)
- [x] **Verified the guard catches the real gap**: emptied `REMEDIATED_LEGACY_GAPS` → the test fails flagging exactly `0040 ... software_policies.target_type — baseline still declares this column NOT NULL`, with **no false positives** across all 64 legacy migrations
- [x] `autoMigrate.test.ts` still green after the `export` change (79/79 total)
- [x] `tsc --noEmit` clean, `eslint` clean

Refs #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)