### PR TITLE
fix(roles): RoleManager toggleExpand surfaces /roles/:id errors instead of blank matrix

### DIFF
--- a/apps/web/src/components/settings/RoleManager.test.tsx
+++ b/apps/web/src/components/settings/RoleManager.test.tsx
@@ -155,7 +155,103 @@ describe('RoleManager — catalog fetch failure handling (Todd review on #802)',
     expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull();
   });
 
-  it('expansion row in the table shows the error UI when catalog fetch fails', async () => {
+  it('expansion row shows the role-permissions error UI when /roles/:id fetch fails (issue #832)', async () => {
+    // Catalog loads fine; the role-detail fetch fails. Previously the
+    // expansion row would render a misleading zero-permissions matrix.
+    // Now it should render the inline error block with a Retry button.
+    fetchWithAuthMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === '/permissions/catalog') {
+        return makeJsonResponse({
+          permissions: [{ resource: 'devices', action: 'read' }],
+          resourceLabels: { devices: 'Devices' },
+          actionLabels: { read: 'Read' },
+        });
+      }
+      if (url.startsWith('/roles/')) {
+        return makeJsonResponse({}, false, 500);
+      }
+      return makeJsonResponse({});
+    });
+
+    const systemRole: Role = {
+      id: 'sys-1',
+      name: 'Administrator',
+      description: null,
+      scope: 'system',
+      isSystem: true,
+      userCount: 1,
+      createdAt: '2026-05-21T00:00:00Z',
+      updatedAt: '2026-05-21T00:00:00Z'
+    };
+
+    render(<RoleManager roles={[systemRole]} />);
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith('/permissions/catalog');
+    });
+
+    const adminRow = screen.getByText('Administrator').closest('tr');
+    expect(adminRow).toBeTruthy();
+    fireEvent.click(adminRow!);
+
+    // Inline error block + Retry — NOT a blank PermissionMatrix.
+    await screen.findByText((t) => t.startsWith('Failed to load permissions'));
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeTruthy();
+  });
+
+  it('expansion-row Retry refetches /roles/:id and renders the matrix on the second attempt (issue #832)', async () => {
+    // First call to /roles/:id fails 500; second call (after Retry) succeeds.
+    let roleCallCount = 0;
+    fetchWithAuthMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === '/permissions/catalog') {
+        return makeJsonResponse({
+          permissions: [{ resource: 'devices', action: 'read' }],
+          resourceLabels: { devices: 'Devices' },
+          actionLabels: { read: 'Read' },
+        });
+      }
+      if (url.startsWith('/roles/')) {
+        roleCallCount += 1;
+        if (roleCallCount === 1) return makeJsonResponse({}, false, 500);
+        return makeJsonResponse({ permissions: [{ resource: 'devices', action: 'read' }] });
+      }
+      return makeJsonResponse({});
+    });
+
+    const systemRole: Role = {
+      id: 'sys-1',
+      name: 'Administrator',
+      description: null,
+      scope: 'system',
+      isSystem: true,
+      userCount: 1,
+      createdAt: '2026-05-21T00:00:00Z',
+      updatedAt: '2026-05-21T00:00:00Z'
+    };
+
+    render(<RoleManager roles={[systemRole]} />);
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith('/permissions/catalog');
+    });
+
+    const adminRow = screen.getByText('Administrator').closest('tr');
+    fireEvent.click(adminRow!);
+    await screen.findByText((t) => t.startsWith('Failed to load permissions'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    // After successful retry, the matrix renders. The error block is gone.
+    await waitFor(() => {
+      expect(roleCallCount).toBe(2);
+    });
+    await waitFor(() => {
+      expect(screen.queryByText((t) => t.startsWith('Failed to load permissions'))).toBeNull();
+    });
+  });
+
+  it('expansion row in the table shows the error UI when catalog fetch fails (and /roles/:id succeeds)', async () => {
     fetchWithAuthMock.mockImplementation(async (input) => {
       const url = String(input);
       if (url === '/permissions/catalog') {

--- a/apps/web/src/components/settings/RoleManager.tsx
+++ b/apps/web/src/components/settings/RoleManager.tsx
@@ -61,6 +61,11 @@ export default function RoleManager({
   const [typeFilter, setTypeFilter] = useState<'all' | 'system' | 'custom'>('all');
   const [expandedRoleId, setExpandedRoleId] = useState<string | null>(null);
   const [rolePermissions, setRolePermissions] = useState<Record<string, Permission[]>>({});
+  // Per-role error state for the expansion-row fetch. Distinct from
+  // catalogError so a transient /roles/:id failure doesn't get blamed on
+  // the catalog (which may still be perfectly loaded) and doesn't render
+  // a misleading zero-permissions matrix (issue #832).
+  const [rolePermissionsError, setRolePermissionsError] = useState<Record<string, string>>({});
   const [catalog, setCatalog] = useState<PermissionCatalog | null>(null);
   const [catalogError, setCatalogError] = useState<string | null>(null);
   const [catalogReloadKey, setCatalogReloadKey] = useState(0);
@@ -128,28 +133,50 @@ export default function RoleManager({
     [catalog]
   );
 
+  const loadRolePermissions = useCallback(async (role: Role) => {
+    // Clear any prior error from a previous failed attempt before retry.
+    setRolePermissionsError(prev => {
+      if (!(role.id in prev)) return prev;
+      const next = { ...prev };
+      delete next[role.id];
+      return next;
+    });
+    try {
+      const res = await fetchWithAuth(`/roles/${role.id}`);
+      if (res.ok) {
+        const data = await res.json();
+        setRolePermissions(prev => ({ ...prev, [role.id]: normalizePermissions(data.permissions || []) }));
+        return;
+      }
+      // Match the catalog-fetch pattern: 401 → login redirect, other errors
+      // surface as an inline error block with a Retry button instead of
+      // rendering a misleading zero-permissions matrix (#832).
+      if (res.status === 401) {
+        void navigateTo('/login', { replace: true });
+        return;
+      }
+      const message = `Failed to load permissions (${res.status} ${res.statusText || 'error'})`;
+      console.error(`Role ${role.id}: ${message}`);
+      setRolePermissionsError(prev => ({ ...prev, [role.id]: message }));
+    } catch (err) {
+      console.error(`Error fetching permissions for role ${role.id}:`, err);
+      const message = err instanceof Error ? err.message : 'Network error while loading permissions';
+      setRolePermissionsError(prev => ({ ...prev, [role.id]: message }));
+    }
+  }, [normalizePermissions]);
+
   const toggleExpand = useCallback(async (role: Role) => {
     if (expandedRoleId === role.id) {
       setExpandedRoleId(null);
       return;
     }
     setExpandedRoleId(role.id);
-    if (!rolePermissions[role.id]) {
-      try {
-        const res = await fetchWithAuth(`/roles/${role.id}`);
-        if (res.ok) {
-          const data = await res.json();
-          setRolePermissions(prev => ({ ...prev, [role.id]: normalizePermissions(data.permissions || []) }));
-        } else {
-          console.error(`Failed to fetch permissions for role ${role.id}: ${res.status} ${res.statusText}`);
-          setRolePermissions(prev => ({ ...prev, [role.id]: [] }));
-        }
-      } catch (err) {
-        console.error(`Error fetching permissions for role ${role.id}:`, err);
-        setRolePermissions(prev => ({ ...prev, [role.id]: [] }));
-      }
+    // Re-fetch when no prior result exists OR a prior attempt errored — so
+    // expanding-after-a-failure naturally retries without an extra click.
+    if (!rolePermissions[role.id] || rolePermissionsError[role.id]) {
+      await loadRolePermissions(role);
     }
-  }, [expandedRoleId, rolePermissions, normalizePermissions]);
+  }, [expandedRoleId, rolePermissions, rolePermissionsError, loadRolePermissions]);
 
   const filteredRoles = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
@@ -362,8 +389,22 @@ export default function RoleManager({
                       <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                         Permissions for {role.name}
                       </div>
-                      {catalogError ? (
-                        <CatalogLoadError message={catalogError} onRetry={reloadCatalog} />
+                      {/* Render precedence (intentional ordering):
+                            1. Role-specific fetch error (with Retry) — must beat
+                               the matrix render so a failed /roles/:id never
+                                shows a misleading zero-permissions matrix (#832).
+                            2. Matrix when both role-perms AND catalog are present.
+                                If `catalog` is still cached from an earlier load,
+                                a later catalogError shouldn't blank out an
+                                already-rendered expansion (nit #1 on issue #832).
+                            3. catalogError (only when catalog is also missing)
+                                so the user has SOMETHING to retry from.
+                            4. Loading spinner. */}
+                      {rolePermissionsError[role.id] ? (
+                        <CatalogLoadError
+                          message={rolePermissionsError[role.id]}
+                          onRetry={() => void loadRolePermissions(role)}
+                        />
                       ) : rolePermissions[role.id] && catalog ? (
                         <PermissionMatrix
                           catalog={catalog}
@@ -371,6 +412,8 @@ export default function RoleManager({
                           onChange={() => {}}
                           disabled
                         />
+                      ) : catalogError ? (
+                        <CatalogLoadError message={catalogError} onRetry={reloadCatalog} />
                       ) : (
                         <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
                           <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />


### PR DESCRIPTION
## Summary

Fixes #832 (a follow-up from the #802 re-review).

Before this PR, expanding a system role's permissions row triggered a \`GET /roles/:id\`. On any non-2xx response (transient 500, network blip, 401, etc.) the catch did only \`console.error\` and set \`rolePermissions[role.id] = []\`. Because the expansion-row render condition was \`rolePermissions[role.id] && catalog\` and an empty array is truthy, the \`PermissionMatrix\` rendered showing the role as having **zero permissions** — the exact silent-failure anti-pattern PR #802 had just fixed for the catalog fetch one fetch over.

After: a new \`rolePermissionsError\` state tracks per-role fetch failures. The expansion row now renders an inline error block with a Retry button on failure, and 401 redirects to \`/login\` (was falling through to the generic error branch).

## Changes

- **\`RoleManager.tsx\`**
  - New state: \`rolePermissionsError: Record<string, string>\`.
  - Refactored \`toggleExpand\` → extracted the fetch into a \`loadRolePermissions\` helper that clears prior error → does the fetch → on 401 redirects, on other errors sets \`rolePermissionsError[role.id]\`, on success sets \`rolePermissions[role.id]\`. \`toggleExpand\` calls it both on first expansion AND on re-expansion when a prior error exists (so re-clicking the row after a failure naturally retries).
  - Render precedence in the expansion row: role-error block (with Retry) → matrix → catalog-error block → loading spinner. The catalog-error branch is now last so an already-rendered matrix isn't blanked by a later refetch failure (issue nit #1).
  - Reuses the existing \`CatalogLoadError\` component for the role-error block.

- **\`RoleManager.test.tsx\`**
  - New: "expansion row shows the role-permissions error UI when \`/roles/:id\` fetch fails" — covers the headline bug.
  - New: "expansion-row Retry refetches \`/roles/:id\` and renders the matrix on the second attempt" — covers recovery.
  - Existing "catalog fetch failure" expansion test reworked so \`/roles/:id\` succeeds, exercising the catalog-error branch specifically.

## Verification

\`\`\`
$ bash scripts/security/preflight.sh --fast
All required checks passed (4 skipped — --fast / no Trivy image)

$ npx tsc -p apps/api && npx tsc -p apps/web
# clean

$ npx vitest run src/components/settings/ src/lib/__tests__/no-silent-mutations.test.ts
Test Files  9 passed (9)
Tests  70 passed (70)
\`\`\`

## Test plan

- [x] Existing RoleManager + PermissionMatrix + RoleFormModal tests pass
- [x] New \`role-permissions error UI\` test asserts the error block + Retry button render instead of a blank matrix
- [x] New \`Retry refetches\` test asserts the recovery path
- [x] \`no-silent-mutations\` guard still passes (no new \`fetchWithAuth\` mutation outside \`runAction\` introduced)