### PR TITLE
fix(roles): RolesPage adopts runAction + clone PATCH checked + role shape validated

### DIFF
--- a/apps/web/src/components/settings/RolesPage.tsx
+++ b/apps/web/src/components/settings/RolesPage.tsx
@@ -9,6 +9,8 @@ import RoleManager, {
 } from './RoleManager';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
+import { runAction, ActionError } from '../../lib/runAction';
+import { showToast } from '../shared/Toast';
 
 type ModalMode = 'closed' | 'create' | 'edit' | 'clone' | 'delete' | 'users';
 
@@ -57,7 +59,20 @@ export default function RolesPage() {
       if (!response.ok) {
         throw new Error('Failed to fetch role details');
       }
-      return await response.json();
+      const data = await response.json();
+      // Shape validation (#822 issue #2): if the role-detail endpoint ever
+      // returns a role without a `permissions` array (renamed key, nested
+      // shape, partial response), opening the Edit modal would populate
+      // with zero checked cells. A user who saves then PATCHes
+      // `permissions: []` over a real role — data loss. Treat any shape
+      // mismatch as a load error rather than silently dropping the cells.
+      if (!data || typeof data !== 'object') {
+        throw new Error('Role detail response is not an object');
+      }
+      if (!Array.isArray(data.permissions)) {
+        throw new Error('Role detail response is missing the `permissions` array');
+      }
+      return data as Role;
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
       return null;
@@ -168,20 +183,24 @@ export default function RolesPage() {
   }) => {
     setSubmitting(true);
     try {
-      const response = await fetchWithAuth('/roles', {
-        method: 'POST',
-        body: JSON.stringify(data)
+      await runAction({
+        request: () => fetchWithAuth('/roles', {
+          method: 'POST',
+          body: JSON.stringify(data)
+        }),
+        errorFallback: 'Failed to create role',
+        successMessage: `Role "${data.name}" created`,
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
       });
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || 'Failed to create role');
-      }
-
       await fetchRoles();
       handleCloseModal();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred');
+      if (err instanceof ActionError) {
+        if (err.status === 401) return;
+        setError(err.message);
+      } else {
+        setError(err instanceof Error ? err.message : 'An error occurred');
+      }
     } finally {
       setSubmitting(false);
     }
@@ -197,20 +216,24 @@ export default function RolesPage() {
 
     setSubmitting(true);
     try {
-      const response = await fetchWithAuth(`/roles/${selectedRole.id}`, {
-        method: 'PATCH',
-        body: JSON.stringify(data)
+      await runAction({
+        request: () => fetchWithAuth(`/roles/${selectedRole.id}`, {
+          method: 'PATCH',
+          body: JSON.stringify(data)
+        }),
+        errorFallback: 'Failed to update role',
+        successMessage: `Role "${data.name}" updated`,
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
       });
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || 'Failed to update role');
-      }
-
       await fetchRoles();
       handleCloseModal();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred');
+      if (err instanceof ActionError) {
+        if (err.status === 401) return;
+        setError(err.message);
+      } else {
+        setError(err instanceof Error ? err.message : 'An error occurred');
+      }
     } finally {
       setSubmitting(false);
     }
@@ -226,18 +249,15 @@ export default function RolesPage() {
 
     setSubmitting(true);
     try {
-      const response = await fetchWithAuth(`/roles/${selectedRole.id}/clone`, {
-        method: 'POST',
-        body: JSON.stringify({ name: data.name })
+      // Step 1: clone with the new name. Server returns the new role row.
+      const clonedRole = await runAction<Role>({
+        request: () => fetchWithAuth(`/roles/${selectedRole.id}/clone`, {
+          method: 'POST',
+          body: JSON.stringify({ name: data.name })
+        }),
+        errorFallback: 'Failed to clone role',
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
       });
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || 'Failed to clone role');
-      }
-
-      // If cloning succeeded, now update with new permissions if different
-      const clonedRole = await response.json();
 
       // Check if permissions were modified from original
       const originalPermSet = new Set(
@@ -251,22 +271,38 @@ export default function RolesPage() {
 
       const parentRoleChanged = data.parentRoleId !== selectedRole.parentRoleId;
 
+      // Step 2 (#822 issue #1): if the user edited permissions / description /
+      // parent, PATCH the new role with the changes. PREVIOUSLY this PATCH's
+      // response was unchecked — if the clone succeeded but the PATCH failed,
+      // the code reported success and the user thought they had a clone with
+      // their edited permissions but silently got the original ones. Now the
+      // PATCH goes through runAction so any failure surfaces as a clear toast
+      // and the modal does NOT close on partial-success.
       if (permissionsChanged || data.description !== selectedRole.description || parentRoleChanged) {
-        // Update the cloned role with modified permissions/description/parentRoleId
-        await fetchWithAuth(`/roles/${clonedRole.id}`, {
-          method: 'PATCH',
-          body: JSON.stringify({
-            description: data.description,
-            permissions: data.permissions,
-            parentRoleId: data.parentRoleId
-          })
+        await runAction({
+          request: () => fetchWithAuth(`/roles/${clonedRole.id}`, {
+            method: 'PATCH',
+            body: JSON.stringify({
+              description: data.description,
+              permissions: data.permissions,
+              parentRoleId: data.parentRoleId
+            })
+          }),
+          errorFallback: 'Role cloned, but applying the edited permissions failed. Edit the new role to retry.',
+          onUnauthorized: () => void navigateTo('/login', { replace: true })
         });
       }
 
+      showToast({ message: `Role "${data.name}" cloned`, type: 'success' });
       await fetchRoles();
       handleCloseModal();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred');
+      if (err instanceof ActionError) {
+        if (err.status === 401) return;
+        setError(err.message);
+      } else {
+        setError(err instanceof Error ? err.message : 'An error occurred');
+      }
     } finally {
       setSubmitting(false);
     }
@@ -276,20 +312,25 @@ export default function RolesPage() {
     if (!selectedRole) return;
 
     setSubmitting(true);
+    const deletedName = selectedRole.name;
     try {
-      const response = await fetchWithAuth(`/roles/${selectedRole.id}`, {
-        method: 'DELETE'
+      await runAction({
+        request: () => fetchWithAuth(`/roles/${selectedRole.id}`, {
+          method: 'DELETE'
+        }),
+        errorFallback: 'Failed to delete role',
+        successMessage: `Role "${deletedName}" deleted`,
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
       });
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || 'Failed to delete role');
-      }
-
       await fetchRoles();
       handleCloseModal();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred');
+      if (err instanceof ActionError) {
+        if (err.status === 401) return;
+        setError(err.message);
+      } else {
+        setError(err instanceof Error ? err.message : 'An error occurred');
+      }
     } finally {
       setSubmitting(false);
     }

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -31,6 +31,7 @@ const TARGET_GLOBS = [
   'src/components/alerts/NotificationChannelsPage.tsx',
   'src/components/settings/PartnerSettingsPage.tsx',
   'src/components/patches/PatchesPage.tsx',
+  'src/components/settings/RolesPage.tsx',
 ];
 
 const absoluteFiles: string[] = TARGET_GLOBS.map((rel) => resolve(WEB_ROOT, '..', rel));
@@ -222,7 +223,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(3);
+    expect(absoluteFiles.length).toBe(4);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }


### PR DESCRIPTION
## Summary

Fixes #822 (all three findings from the multi-agent re-review of PR #802).

### 1. Clone follow-up PATCH is now checked (silent failure → loud failure)

\`handleCloneSubmit\`'s step-2 PATCH (apply edited permissions/description/parentRoleId to the newly-cloned role) previously had **no \`if (!response.ok)\` check**. If the clone succeeded but the PATCH failed, the code reported success and the user believed they had a clone with their edited permissions but silently got the original ones.

The PATCH now goes through \`runAction\` with a dedicated \`errorFallback\`:
> *"Role cloned, but applying the edited permissions failed. Edit the new role to retry."*

so failure surfaces as a clear toast AND the modal does not close on partial-success.

### 2. \`fetchRoleWithPermissions\` validates the response shape

Previously \`return await response.json()\` with no validation. A response without a \`permissions\` array (renamed key, partial response, etc.) would populate the Edit modal with zero checked cells — a subsequent save would PATCH \`permissions: []\` over a real role. **Data loss.**

Now rejects with a descriptive error if the response isn't an object or is missing the \`permissions\` array.

### 3. All four mutation handlers route through \`runAction\`

\`handleCreateSubmit\` / \`handleEditSubmit\` / \`handleCloneSubmit\` / \`handleDeleteConfirm\` all use \`runAction\` with:
- \`errorFallback\` for the generic case
- \`successMessage\` on success (create/edit/delete; clone fires a combined toast at the end)
- \`onUnauthorized\` → \`/login\` redirect for consistent session-expiry UX

Shared catch handles \`ActionError\` 401 silently (auth redirect already handled), other \`ActionError\` messages mirror into \`setError\` so the inline banner still shows the most recent failure.

### 4. Added \`RolesPage.tsx\` to \`TARGET_GLOBS\` in \`no-silent-mutations.test.ts\`

Future mutation regressions in \`RolesPage\` that bypass \`runAction\` now fail CI. Bumps the guard's expected file count from 3 → 4.

## Verification

\`\`\`
$ bash scripts/security/preflight.sh --fast
All required checks passed

$ npx tsc -p apps/api && npx tsc -p apps/web
# clean

$ npx vitest run src/components/settings/ src/lib/__tests__/no-silent-mutations.test.ts src/lib/runAction.test.ts
Test Files  10 passed (10)
Tests       83 passed (83)
\`\`\`

## Test plan

- [x] Existing 8 settings tests still pass
- [x] \`no-silent-mutations\` guard now scans \`RolesPage.tsx\` (4th file) and stays green — proves no mutation in the file bypasses \`runAction\`
- [x] \`runAction\` unit tests still pass against the updated dependency graph