### PR TITLE
fix(audit-logs): qualify agent-actor user column instead of showing bare hostname

### DIFF
--- a/apps/api/src/routes/auditLogs.ts
+++ b/apps/api/src/routes/auditLogs.ts
@@ -152,31 +152,32 @@ function deriveCategory(action: string): string {
   return 'system';
 }
 
-type DbRow = {
+export type DbRow = {
   log: typeof auditLogsTable.$inferSelect;
   userName: string | null;
   deviceHostname: string | null;
   deviceDisplayName: string | null;
 };
 
-function resolveActorName(row: DbRow, details?: Record<string, unknown> | null): string {
+export function resolveActorName(row: DbRow, details?: Record<string, unknown> | null): string {
   if (row.userName) {
     return row.userName;
-  }
-
-  if (row.log.actorType === 'agent') {
-    const deviceName = row.deviceDisplayName || row.deviceHostname;
-    if (deviceName) return deviceName;
-  }
-
-  if (row.log.actorEmail) {
-    return row.log.actorEmail;
   }
 
   const rawActorId = typeof details?.rawActorId === 'string' ? details.rawActorId : null;
 
   if (row.log.actorType === 'agent') {
+    // Agent actions: never display the bare device hostname in the user
+    // column, because that makes the device look like it's masquerading
+    // as a user. Prefer "Agent (<hostname>)" when we can resolve a device,
+    // falling back to a short agent-id slug, then a generic "Agent".
+    const deviceName = row.deviceDisplayName || row.deviceHostname;
+    if (deviceName) return `Agent (${deviceName})`;
     return rawActorId ? `Agent ${rawActorId.slice(0, 8)}` : 'Agent';
+  }
+
+  if (row.log.actorEmail) {
+    return row.log.actorEmail;
   }
 
   if (row.log.actorType === 'api_key') {

--- a/apps/api/src/routes/auditLogs_resolveActorName.test.ts
+++ b/apps/api/src/routes/auditLogs_resolveActorName.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { resolveActorName, type DbRow } from './auditLogs';
+
+// Minimal row factory — only the fields resolveActorName actually reads.
+// resolveActorName reads row.userName, row.deviceHostname, row.deviceDisplayName,
+// row.log.actorType, row.log.actorEmail, plus details.rawActorId.
+function row(opts: {
+  userName?: string | null;
+  deviceHostname?: string | null;
+  deviceDisplayName?: string | null;
+  actorType: 'user' | 'api_key' | 'agent' | 'system';
+  actorEmail?: string | null;
+}): DbRow {
+  return {
+    log: {
+      actorType: opts.actorType,
+      actorEmail: opts.actorEmail ?? null,
+    } as DbRow['log'],
+    userName: opts.userName ?? null,
+    deviceHostname: opts.deviceHostname ?? null,
+    deviceDisplayName: opts.deviceDisplayName ?? null,
+  };
+}
+
+describe('resolveActorName', () => {
+  it('uses joined user name when present', () => {
+    expect(
+      resolveActorName(row({ userName: 'Alice', actorType: 'user', actorEmail: 'a@b.com' }))
+    ).toBe('Alice');
+  });
+
+  it('returns "Agent (<hostname>)" for an agent action with a hostname (display name preferred)', () => {
+    expect(
+      resolveActorName(
+        row({
+          actorType: 'agent',
+          deviceHostname: 'TS-Kim-XPS',
+          deviceDisplayName: null,
+        })
+      )
+    ).toBe('Agent (TS-Kim-XPS)');
+
+    expect(
+      resolveActorName(
+        row({
+          actorType: 'agent',
+          deviceHostname: 'TS-Kim-XPS',
+          deviceDisplayName: 'Kim Laptop',
+        })
+      )
+    ).toBe('Agent (Kim Laptop)');
+  });
+
+  it('does NOT return the bare hostname for an agent action', () => {
+    const result = resolveActorName(
+      row({ actorType: 'agent', deviceHostname: 'TS-Kim-XPS' })
+    );
+    expect(result).not.toBe('TS-Kim-XPS');
+  });
+
+  it('falls back to "Agent <rawActorId-slice>" when no device joined', () => {
+    expect(
+      resolveActorName(row({ actorType: 'agent' }), {
+        rawActorId: 'abcdef1234567890',
+      })
+    ).toBe('Agent abcdef12');
+  });
+
+  it('falls back to "Agent" when no device and no rawActorId', () => {
+    expect(resolveActorName(row({ actorType: 'agent' }))).toBe('Agent');
+  });
+
+  it('returns "System" for system actor with no user join', () => {
+    expect(resolveActorName(row({ actorType: 'system' }))).toBe('System');
+  });
+
+  it('returns actorEmail for api_key/user when present and no userName', () => {
+    expect(
+      resolveActorName(
+        row({ actorType: 'api_key', actorEmail: 'svc@example.com' })
+      )
+    ).toBe('svc@example.com');
+  });
+
+  it('returns "API Key <slice>" for api_key with no email', () => {
+    expect(
+      resolveActorName(row({ actorType: 'api_key' }), {
+        rawActorId: 'deadbeef1234',
+      })
+    ).toBe('API Key deadbeef');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #818.

On the dashboard Recent Activity widget and the full Audit Log page, the USER column was rendering a device hostname (e.g. \`DESKTOP-A7B3F1\`) for any row whose actor is an agent. Visually indistinguishable from a real user — looks like a device is impersonating a user. \`system\` and \`api_key\` actors already have qualifiers; \`agent\` was the odd one out.

## Change

\`resolveActorName(row, details)\` in \`apps/api/src/routes/auditLogs.ts\` — the \`actorType === 'agent'\` branch now returns:

- \`Agent (\${deviceName})\` when a device can be joined for the row,
- \`Agent \${rawActorId.slice(0, 8)}\` when only the actor id is available,
- \`Agent\` as a last resort.

Render-only fix. No migration, no schema change. Existing audit rows display correctly on next page load.

## Tests

New file \`apps/api/src/routes/auditLogs_resolveActorName.test.ts\` covers:

- Agent + device joined → \`Agent (HOSTNAME)\`
- Agent + display-name preferred over hostname
- Agent + no device → \`Agent <short id>\`
- Agent + no device + no id → \`Agent\`
- Existing \`system\` / \`api_key\` / \`user\` branches still return unchanged labels

## Verification

\`\`\`
$ bash scripts/security/preflight.sh --fast
All required checks passed

$ npx tsc -p apps/api
# clean

$ npx vitest run src/routes/auditLogs
Test Files  2 passed (2)
Tests       20 passed (20)
\`\`\`

## Test plan

- [x] Existing \`auditLogs\` integration tests still pass
- [x] New unit tests on \`resolveActorName\` cover all four agent-row shapes