### PR TITLE
fix(event-bus): structured logging for swallowed local-handler errors + regression tests for #815

### DIFF
--- a/apps/api/src/services/eventBus.test.ts
+++ b/apps/api/src/services/eventBus.test.ts
@@ -6,6 +6,21 @@ vi.mock('./redis', () => ({
   getRedisConnection: vi.fn()
 }));
 
+// Mock the db module so we can assert `runOutsideDbContext` is invoked
+// from `publish()`. PR #815 added `runOutsideDbContext` to fix an
+// `idle in transaction` leak (2026-05-21 prod login lockout); the
+// regression test below makes a future "wrap publish in try/catch
+// for resilience" refactor visibly fail if it deletes that call.
+vi.mock('../db', () => {
+  const runOutsideDbContext = vi.fn(<T>(fn: () => T): T => fn());
+  return {
+    runOutsideDbContext,
+    // No other db exports are reached by eventBus.ts at module init,
+    // but stub the surface so a stray import doesn't blow up.
+    db: {},
+  };
+});
+
 describe('eventBus service', () => {
   let mockRedis: Partial<Redis>;
   let eventBusModule: typeof import('./eventBus');
@@ -93,6 +108,68 @@ describe('eventBus service', () => {
       'breeze-api',
       '123-0'
     );
+  });
+
+  // ---------------------------------------------------------------------
+  // Regression coverage for PR #815 + #820.
+  // ---------------------------------------------------------------------
+
+  it('publish() invokes runOutsideDbContext exactly once per publish (regression for #815)', async () => {
+    const { publishEvent, EVENT_TYPES } = eventBusModule;
+    const { runOutsideDbContext } = await import('../db');
+    vi.mocked(runOutsideDbContext).mockClear();
+
+    await publishEvent(EVENT_TYPES.DEVICE_ENROLLED, 'org-1', { deviceId: 'dev-1' }, 'unit-test');
+
+    expect(runOutsideDbContext).toHaveBeenCalledTimes(1);
+    // Redis ops must run INSIDE the wrapped block, not before / after.
+    const callOrder = (runOutsideDbContext as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0]!;
+    const xaddOrder = (mockRedis.xadd as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0]!;
+    expect(xaddOrder).toBeGreaterThan(callOrder);
+  });
+
+  it('publishEvent rejects when redis.xadd rejects (underpins caller-tx-rolls-back guarantee)', async () => {
+    const { publishEvent, EVENT_TYPES } = eventBusModule;
+    (mockRedis.xadd as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('redis down'));
+
+    await expect(
+      publishEvent(EVENT_TYPES.DEVICE_ENROLLED, 'org-1', { deviceId: 'dev-1' }, 'unit-test'),
+    ).rejects.toThrow(/redis down/);
+  });
+
+  it('local-handler failure emits structured log + does NOT stop subsequent handlers (issue #820)', async () => {
+    const { getEventBus, publishEvent, EVENT_TYPES } = eventBusModule;
+    const bus = getEventBus();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const failingHandler = vi.fn().mockRejectedValue(new Error('boom'));
+    const survivingHandler = vi.fn().mockResolvedValue(undefined);
+
+    bus.subscribe(EVENT_TYPES.DEVICE_ENROLLED, failingHandler);
+    bus.subscribe(EVENT_TYPES.DEVICE_ENROLLED, survivingHandler);
+
+    await publishEvent(EVENT_TYPES.DEVICE_ENROLLED, 'org-1', { deviceId: 'dev-1' }, 'unit-test');
+
+    // Both handlers were given a turn — one failure doesn't stop the loop.
+    expect(failingHandler).toHaveBeenCalledTimes(1);
+    expect(survivingHandler).toHaveBeenCalledTimes(1);
+
+    // The failure is logged structurally (JSON in the second console.error arg)
+    // so ops can grep / forward / aggregate.
+    const localFailLogs = errorSpy.mock.calls.filter((c) =>
+      typeof c[0] === 'string' && c[0].includes('local-handler-failed'),
+    );
+    expect(localFailLogs).toHaveLength(1);
+    const payload = JSON.parse(localFailLogs[0]![1] as string);
+    expect(payload.errorId).toBe('EVENT_BUS_LOCAL_HANDLER_FAILED');
+    expect(payload.eventType).toBe(EVENT_TYPES.DEVICE_ENROLLED);
+    expect(payload.orgId).toBe('org-1');
+    expect(payload.source).toBe('unit-test');
+    expect(payload.eventId).toEqual(expect.any(String));
+    expect(payload.handlerIndex).toBe(0);
+    expect(payload.error.message).toBe('boom');
+
+    errorSpy.mockRestore();
   });
 
   it('should unsubscribe handlers', async () => {

--- a/apps/api/src/services/eventBus.ts
+++ b/apps/api/src/services/eventBus.ts
@@ -234,7 +234,16 @@ class EventBus {
 
   /**
    * Invoke local in-process handlers for an event
-   * Called when publishing to handle local subscribers immediately
+   * Called when publishing to handle local subscribers immediately.
+   *
+   * Failures here are swallowed (not rethrown) so one buggy subscriber
+   * can't take down the publishEvent path — the BullMQ subscribers in
+   * webhookDelivery.ts and automationWorker.ts depend on this. The
+   * tradeoff is silent failure of e.g. a dropped delivery enqueue, so
+   * each failure is emitted as a structured log line (JSON-shaped via
+   * console.error) that carries enough context (event.id, event.orgId,
+   * event.source, event.type, handler index) to be searchable by an
+   * operator and pulled into ops dashboards. See issue #820.
    */
   private async invokeLocalHandlers(event: BreezeEvent): Promise<void> {
     const typeHandlers = this.handlers.get(event.type) || new Set();
@@ -243,12 +252,30 @@ class EventBus {
 
     if (allHandlers.length === 0) return;
 
+    let handlerIndex = 0;
     for (const handler of allHandlers) {
       try {
         await handler(event);
       } catch (err) {
-        console.error(`[EventBus] Local handler failed for ${event.type}:`, err);
+        // Structured shape so ops can grep / aggregate / forward to a
+        // log aggregator. Keep using console.error rather than throw so
+        // a single failing subscriber doesn't stop the publish loop.
+        console.error(
+          '[EventBus] local-handler-failed',
+          JSON.stringify({
+            errorId: 'EVENT_BUS_LOCAL_HANDLER_FAILED',
+            eventId: event.id,
+            eventType: event.type,
+            orgId: event.orgId,
+            source: event.source,
+            handlerIndex,
+            error: err instanceof Error
+              ? { name: err.name, message: err.message, stack: err.stack }
+              : String(err),
+          }),
+        );
       }
+      handlerIndex += 1;
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #820 (follow-up to PR #815).

### 1. \`invokeLocalHandlers\` now emits structured JSON for swallowed errors

Previously the catch did:
\`\`\`ts
console.error(\`[EventBus] Local handler failed for \${event.type}:\`, err);
\`\`\`
— no \`event.id\`, no \`orgId\`, no \`source\`, no handler index. A dropped webhook-delivery enqueue (the \`*\` subscribers in \`webhookDelivery.ts\` and \`automationWorker.ts\`) had no DLQ, no retry, and only a buried unstructured log line with no correlation back to the originating event.

Now each failure logs a JSON payload via \`console.error\` carrying:
\`\`\`json
{
  "errorId": "EVENT_BUS_LOCAL_HANDLER_FAILED",
  "eventId": "...",
  "eventType": "device.enrolled",
  "orgId": "...",
  "source": "unit-test",
  "handlerIndex": 0,
  "error": { "name": "Error", "message": "boom", "stack": "..." }
}
\`\`\`

Continues to **swallow rather than rethrow** so a single bad subscriber doesn't take down the publish loop — original behavior preserved, only observability improves.

### 2. Regression tests so a future refactor doesn't silently undo PR #815

The existing \`eventBus.test.ts\` would still pass if \`runOutsideDbContext\` were deleted entirely — the call is structurally invisible to the suite. A future "add a try/catch for resilience" refactor could silently re-introduce the \`idle in transaction\` leak that caused the **2026-05-21 production login lockout**.

New tests (mock \`../db\` so \`runOutsideDbContext\` is observable):

- **"publish() invokes \`runOutsideDbContext\` exactly once per publish"** — asserts the wrapping call AND that \`redis.xadd\` runs AFTER the wrapping starts (via \`invocationCallOrder\`).
- **"publishEvent rejects when redis.xadd rejects"** — underpins the caller-tx-rolls-back guarantee that motivated #815.
- **"local-handler failure emits structured log + does NOT stop subsequent handlers"** — exercises the #820 logging shape and asserts the loop continues past a failing subscriber.

## Verification

\`\`\`
$ bash scripts/security/preflight.sh --fast
All required checks passed

$ npx tsc -p apps/api
# clean

$ npx vitest run
Test Files  428 passed (428)
Tests       4546 passed | 28 skipped (4574)
\`\`\`

## Test plan

- [x] 3 existing \`eventBus\` tests still pass
- [x] 3 new regression tests pass — including the structured-log payload shape assertion
- [x] Full \`apps/api\` vitest stays green (428 files / 4546 tests)