### PR TITLE
feat(dns-security): emit dns.threat.blocked from sync so event-bus consumers can subscribe

### DIFF
--- a/apps/api/src/jobs/dnsSyncJob.ts
+++ b/apps/api/src/jobs/dnsSyncJob.ts
@@ -21,6 +21,7 @@ import { getBullMQConnection } from '../services/redis';
 import { isReusableState } from '../services/bullmqUtils';
 import { decryptSecret } from '../services/secretCrypto';
 import { captureException } from '../services/sentry';
+import { publishEvent, EVENT_TYPES } from '../services/eventBus';
 
 const { db } = dbModule;
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -505,6 +506,40 @@ async function processSyncIntegration(data: SyncIntegrationJobData): Promise<{
         if (row.action === 'blocked') current.blockedQueries += 1;
         if (row.action === 'allowed') current.allowedQueries += 1;
         aggregationMap.set(key, current);
+
+        // #829 — emit dns.threat.blocked so the existing event-bus
+        // subscribers (webhookDelivery, automationWorker, alert rules) can
+        // consume the signal. Only fire for actually-blocked threat events
+        // (action=blocked AND category present) so an "allowed" DNS query
+        // doesn't pollute the bus. Best-effort: failure to publish here
+        // must not abort sync — the event-bus internals already swallow
+        // local-handler errors with structured logging (#820), but we
+        // still wrap the call to suppress a hypothetical xadd reject.
+        if (row.action === 'blocked' && category) {
+          publishEvent(
+            EVENT_TYPES.DNS_THREAT_BLOCKED,
+            row.orgId,
+            {
+              deviceId: row.deviceId,
+              domain: row.domain,
+              category,
+              integrationId: row.integrationId,
+              timestamp: row.timestamp.toISOString(),
+            },
+            'dns-sync-job',
+            { priority: 'high' }
+          ).catch((err) => {
+            console.error(
+              '[DnsSyncJob] dns.threat.blocked publish failed',
+              JSON.stringify({
+                orgId: row.orgId,
+                domain: row.domain,
+                category,
+                error: err instanceof Error ? err.message : String(err),
+              }),
+            );
+          });
+        }
       }
     }
 

--- a/apps/api/src/services/eventBus.test.ts
+++ b/apps/api/src/services/eventBus.test.ts
@@ -172,6 +172,36 @@ describe('eventBus service', () => {
     errorSpy.mockRestore();
   });
 
+  it('exports DNS_THREAT_BLOCKED = "dns.threat.blocked" so dnsSyncJob can emit and consumers can subscribe (#829)', async () => {
+    const { EVENT_TYPES, publishEvent } = eventBusModule;
+    expect(EVENT_TYPES.DNS_THREAT_BLOCKED).toBe('dns.threat.blocked');
+
+    // Smoke-check the new event type is wired into the EventType union too
+    // (publishEvent's signature would reject a string not in the union).
+    const eventId = await publishEvent(
+      EVENT_TYPES.DNS_THREAT_BLOCKED,
+      'org-1',
+      {
+        deviceId: 'dev-1',
+        domain: 'malware.example.com',
+        category: 'malware',
+        integrationId: 'int-1',
+        timestamp: new Date().toISOString(),
+      },
+      'dns-sync-job',
+      { priority: 'high' }
+    );
+    expect(eventId).toEqual(expect.any(String));
+
+    const xaddMock = mockRedis.xadd as ReturnType<typeof vi.fn>;
+    const lastCall = xaddMock.mock.calls[xaddMock.mock.calls.length - 1]!;
+    const eventJson = lastCall[lastCall.length - 1] as string;
+    const event = JSON.parse(eventJson);
+    expect(event.type).toBe('dns.threat.blocked');
+    expect(event.priority).toBe('high');
+    expect(event.payload.domain).toBe('malware.example.com');
+  });
+
   it('should unsubscribe handlers', async () => {
     const { getEventBus, EVENT_TYPES } = eventBusModule;
     const bus = getEventBus();


### PR DESCRIPTION
## Summary

Partially addresses #829.

The DNS Security feature ingests query-log events but **nothing consumes them** — confirmed in the issue. This PR wires the threat events into the event-bus pipeline so the existing \`webhookDelivery\` / \`automationWorker\` machinery (which already wildcard-subscribe to all events) gets the signal, and so future alert rules can subscribe via the standard \`subscribe(EVENT_TYPES.DNS_THREAT_BLOCKED, ...)\` path.

**Scope intentionally limited.** This PR does NOT change alert rule definitions or notification configs. The remaining "raise an alert when a blocked-threat event fires" piece is a follow-up that needs a quick design discussion on:
- alert template defaults
- severity floor (this PR emits at \`priority: 'high'\`)
- cooldown (one blocked domain per device per hour? per day?)
- threat_score (issue calls out the unpopulated column; that's also a follow-up)

## Changes

### 1. New event type \`dns.threat.blocked\` in \`eventBus.ts\`

- Added to the \`EventType\` union under a DNS Security comment block.
- Added \`DNS_THREAT_BLOCKED: 'dns.threat.blocked'\` to \`EVENT_TYPES\` export so consumers do \`subscribe(EVENT_TYPES.DNS_THREAT_BLOCKED, ...)\`.

### 2. Emission from \`processSyncIntegration\` in \`dnsSyncJob.ts\`

After the bulk insert into \`dns_security_events\`, iterate the \`.returning()\` rows and for every row where \`action === 'blocked'\` AND \`category != null\`, fire:

\`\`\`ts
publishEvent(
  EVENT_TYPES.DNS_THREAT_BLOCKED,
  row.orgId,
  { deviceId, domain, category, integrationId, timestamp },
  'dns-sync-job',
  { priority: 'high' }
);
\`\`\`

- Filter \`action === 'blocked'\` means \`allowed\`/\`redirected\` queries don't pollute the bus.
- \`category != null\` means generic-DNS noise without a threat category is filtered out.
- Priority \`'high'\` matches the severity of "device hit a malware/C2 domain". Not \`'critical'\` — that escalation belongs in a deliberate alert-rule decision, not the default.
- Best-effort: a thrown publish (Redis down etc.) is caught and logged as structured JSON without aborting the sync.

### 3. Tests

New test in \`eventBus.test.ts\` asserts:
- \`EVENT_TYPES.DNS_THREAT_BLOCKED === 'dns.threat.blocked'\`
- \`publishEvent\` accepts the new type (compile-time + runtime EventType-union proof)
- Serialized event carries \`priority: 'high'\` and a representative threat payload

## Verification

\`\`\`
$ bash scripts/security/preflight.sh --fast
All required checks passed

$ npx tsc -p apps/api
# clean

$ npx vitest run
Test Files  428 passed (428)
Tests       4544 passed | 28 skipped (4572)
\`\`\`

## Test plan

- [x] All 4 existing eventBus tests still pass
- [x] New "DNS_THREAT_BLOCKED" smoke test passes
- [x] Full apps/api vitest stays green