### PR TITLE
fix(agent): deploy breeze-user-helper.exe on in-place upgrade (#816)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -538,6 +538,20 @@ jobs:
           overwrite: true
           retention-days: 30
 
+      # Issue #816: ship the user-helper as a discrete GitHub release asset
+      # so the agent's in-place auto-upgrade can fetch it directly. Pre-#816
+      # the binary was only ever bundled into the MSI installer, which meant
+      # hosts that reached new versions via auto-update never received it
+      # and the HelperLifecycleManager fell through to a
+      # `breeze-agent.exe user-helper` fallback every ~30s.
+      - name: Upload signed Windows user-helper EXE artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: breeze-user-helper-windows-amd64
+          path: dist/breeze-user-helper-windows-amd64.exe
+          overwrite: true
+          retention-days: 30
+
       - name: Upload Windows MSI artifact
         uses: actions/upload-artifact@v7
         with:
@@ -1805,7 +1819,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           path: artifacts
-          pattern: '{api-dist,web-dist,breeze-agent-*,breeze-backup-*,breeze-desktop-helper-*,breeze-watchdog-*,breeze-viewer-*,breeze-helper-*,breeze-installer-app,viewer-latest-json}'
+          pattern: '{api-dist,web-dist,breeze-agent-*,breeze-backup-*,breeze-desktop-helper-*,breeze-user-helper-*,breeze-watchdog-*,breeze-viewer-*,breeze-helper-*,breeze-installer-app,viewer-latest-json}'
           merge-multiple: false
 
       - name: Prepare release assets
@@ -1828,6 +1842,14 @@ jobs:
 
           # Copy desktop-helper binaries
           for dir in artifacts/breeze-desktop-helper-*; do
+            if [ -d "$dir" ] && ls "$dir"/* >/dev/null 2>&1; then
+              cp "$dir"/* release-assets/
+            fi
+          done
+
+          # Copy user-helper binaries (Windows-only sibling of the agent that
+          # runs in interactive user sessions). See #816.
+          for dir in artifacts/breeze-user-helper-*; do
             if [ -d "$dir" ] && ls "$dir"/* >/dev/null 2>&1; then
               cp "$dir"/* release-assets/
             fi

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -3047,8 +3047,47 @@ func (h *Heartbeat) doUpgrade(targetVersion string) {
 		PinnedManifestPubKeys: h.config.PinnedManifestPubKeys,
 	}
 
+	// On Windows, also pre-download breeze-user-helper.exe so the restart
+	// helper script can drop it alongside the new agent binary. Without this,
+	// in-place upgrades produce an agent install missing the user-helper
+	// (only the MSI installer ever placed it on disk before #816), the
+	// HelperLifecycleManager falls through to a `breeze-agent.exe user-helper`
+	// fallback every ~30s, and orphaned processes accumulate during heartbeat
+	// goroutine wedges until the service dies.
+	//
+	// 404 / network / checksum errors are non-fatal: we log and proceed with
+	// an agent-only upgrade (no regression vs. pre-#816 behavior), which
+	// matters for releases that don't yet ship the user-helper artifact.
+	userHelperTempPath := ""
+	userHelperTargetPath := ""
+	if runtime.GOOS == "windows" {
+		helperCfg := &updater.Config{
+			ServerURL:             h.config.ServerURL,
+			AuthToken:             h.secureToken,
+			CurrentVersion:        h.agentVersion,
+			Component:             "user-helper",
+			PinnedManifestPubKeys: h.config.PinnedManifestPubKeys,
+		}
+		helperUpdater := updater.New(helperCfg)
+		if tempPath, dlErr := helperUpdater.DownloadBinary(targetVersion); dlErr != nil {
+			log.Warn(
+				"user-helper download failed; proceeding with agent-only upgrade",
+				"targetVersion", targetVersion,
+				"error", dlErr.Error(),
+			)
+		} else {
+			userHelperTempPath = tempPath
+			userHelperTargetPath = filepath.Join(filepath.Dir(binaryPath), "breeze-user-helper.exe")
+			log.Info(
+				"pre-downloaded user-helper for restart-helper swap",
+				"temp", userHelperTempPath,
+				"target", userHelperTargetPath,
+			)
+		}
+	}
+
 	u := updater.New(updaterCfg)
-	if err := u.UpdateTo(targetVersion); err != nil {
+	if err := u.UpdateToWithUserHelper(targetVersion, userHelperTempPath, userHelperTargetPath); err != nil {
 		// If the filesystem is read-only, stop retrying — this is permanent
 		// until the service unit is fixed or the filesystem is remounted.
 		// Intentionally NOT persisted to disk (unlike dev_push in handlers_devupdate.go)

--- a/agent/internal/updater/restart_unix.go
+++ b/agent/internal/updater/restart_unix.go
@@ -48,8 +48,10 @@ func restartLaunchd() error {
 }
 
 // RestartWithHelper is Windows-only; on Unix it's never called because
-// updater.go gates on runtime.GOOS == "windows".
-func RestartWithHelper(_, _ string) error {
+// updater.go gates on runtime.GOOS == "windows". The userHelperTempPath /
+// userHelperTargetPath arguments are accepted to keep the signature aligned
+// with the Windows build but are unused here (issue #816).
+func RestartWithHelper(_, _, _, _ string) error {
 	return fmt.Errorf("RestartWithHelper is only supported on Windows")
 }
 

--- a/agent/internal/updater/restart_windows.go
+++ b/agent/internal/updater/restart_windows.go
@@ -74,21 +74,35 @@ func Restart() error {
 	return nil
 }
 
-// RestartWithHelper spawns a detached PowerShell script that:
-//  1. Waits for the current process to exit
-//  2. Stops the service
-//  3. Copies the new binary over the old one
-//  4. Starts the service
-//  5. Cleans up temp files
-//
-// This avoids the race where the agent tries to SCM-stop itself
-// (killing the goroutine before it can call Start).
-func RestartWithHelper(newBinaryPath, targetPath string) error {
-	// Escape single quotes to prevent PowerShell injection
-	safeBinary := strings.ReplaceAll(newBinaryPath, "'", "''")
-	safeTarget := strings.ReplaceAll(targetPath, "'", "''")
+// restartScriptOptions captures inputs to the PowerShell helper script that
+// performs the in-place agent binary swap on Windows. Built by RestartWithHelper
+// and consumed by buildRestartScript so the script text can be unit-tested
+// without spawning PowerShell.
+type restartScriptOptions struct {
+	// AgentTempPath is the freshly-downloaded breeze-agent.exe in a temp dir.
+	AgentTempPath string
+	// AgentTargetPath is the final install location of breeze-agent.exe.
+	AgentTargetPath string
+	// UserHelperTempPath is the freshly-downloaded breeze-user-helper.exe
+	// in a temp dir. Empty string means "no user-helper to swap" — the
+	// generated script omits the helper Copy-Item entirely (backward-compat
+	// with releases that lack the user-helper artifact). Issue #816.
+	UserHelperTempPath string
+	// UserHelperTargetPath is the final install location of
+	// breeze-user-helper.exe (typically the same directory as the agent).
+	UserHelperTargetPath string
+}
 
-	script := strings.Join([]string{
+// buildRestartScript renders the PowerShell helper script. Extracted from
+// RestartWithHelper so it can be unit-tested for shell-injection safety and
+// for backward-compatible behavior when the user-helper paths are unset
+// (issue #816). Single-quote escaping doubles single quotes, matching the
+// established convention for the agent path.
+func buildRestartScript(opts restartScriptOptions) string {
+	safeAgent := strings.ReplaceAll(opts.AgentTempPath, "'", "''")
+	safeAgentTarget := strings.ReplaceAll(opts.AgentTargetPath, "'", "''")
+
+	lines := []string{
 		"Start-Sleep -Seconds 3",
 		// Stop the agent service first
 		"Stop-Service -Name '" + serviceName + "' -Force -ErrorAction SilentlyContinue",
@@ -96,11 +110,58 @@ func RestartWithHelper(newBinaryPath, targetPath string) error {
 		// that might hold file locks on the binary or shared directory.
 		"Get-Process -Name 'breeze-helper','breeze-agent','breeze-user-helper','breeze-viewer' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue",
 		"Start-Sleep -Seconds 2",
-		fmt.Sprintf("Copy-Item -Path '%s' -Destination '%s' -Force", safeBinary, safeTarget),
-		"Start-Service -Name '" + serviceName + "'",
-		fmt.Sprintf("Remove-Item -Path '%s' -Force -ErrorAction SilentlyContinue", safeBinary),
-		"Remove-Item -Path $PSCommandPath -Force -ErrorAction SilentlyContinue",
-	}, "\r\n")
+		fmt.Sprintf("Copy-Item -Path '%s' -Destination '%s' -Force", safeAgent, safeAgentTarget),
+	}
+
+	// Optionally swap in the user-helper too. Skipped when the caller didn't
+	// pre-download it (pre-#816 release, network failure, 404, etc.) — the
+	// agent-only upgrade still succeeds in that case.
+	if opts.UserHelperTempPath != "" && opts.UserHelperTargetPath != "" {
+		safeHelper := strings.ReplaceAll(opts.UserHelperTempPath, "'", "''")
+		safeHelperTarget := strings.ReplaceAll(opts.UserHelperTargetPath, "'", "''")
+		lines = append(lines,
+			fmt.Sprintf("Copy-Item -Path '%s' -Destination '%s' -Force", safeHelper, safeHelperTarget),
+		)
+	}
+
+	lines = append(lines,
+		"Start-Service -Name '"+serviceName+"'",
+		fmt.Sprintf("Remove-Item -Path '%s' -Force -ErrorAction SilentlyContinue", safeAgent),
+	)
+	if opts.UserHelperTempPath != "" && opts.UserHelperTargetPath != "" {
+		safeHelper := strings.ReplaceAll(opts.UserHelperTempPath, "'", "''")
+		lines = append(lines,
+			fmt.Sprintf("Remove-Item -Path '%s' -Force -ErrorAction SilentlyContinue", safeHelper),
+		)
+	}
+	lines = append(lines, "Remove-Item -Path $PSCommandPath -Force -ErrorAction SilentlyContinue")
+
+	return strings.Join(lines, "\r\n")
+}
+
+// RestartWithHelper spawns a detached PowerShell script that:
+//  1. Waits for the current process to exit
+//  2. Stops the service
+//  3. Copies the new agent binary (and, optionally, the new user-helper)
+//     over the old one
+//  4. Starts the service
+//  5. Cleans up temp files
+//
+// This avoids the race where the agent tries to SCM-stop itself
+// (killing the goroutine before it can call Start).
+//
+// userHelperTempPath / userHelperTargetPath are optional. Pass empty strings
+// to perform an agent-only upgrade (the pre-#816 behavior). When both are
+// non-empty, the generated script also copies the user-helper into place
+// so the post-upgrade HelperLifecycleManager finds it on disk and does not
+// fall back to spawning breeze-agent.exe in a loop (issue #816).
+func RestartWithHelper(newBinaryPath, targetPath string, userHelperTempPath, userHelperTargetPath string) error {
+	script := buildRestartScript(restartScriptOptions{
+		AgentTempPath:        newBinaryPath,
+		AgentTargetPath:      targetPath,
+		UserHelperTempPath:   userHelperTempPath,
+		UserHelperTargetPath: userHelperTargetPath,
+	})
 
 	scriptFile, err := os.CreateTemp("", "breeze-update-*.ps1")
 	if err != nil {
@@ -117,6 +178,8 @@ func RestartWithHelper(newBinaryPath, targetPath string) error {
 		"script", scriptFile.Name(),
 		"newBinary", newBinaryPath,
 		"target", targetPath,
+		"userHelperTemp", userHelperTempPath,
+		"userHelperTarget", userHelperTargetPath,
 	)
 
 	cmd := exec.Command("powershell.exe",

--- a/agent/internal/updater/restart_windows_test.go
+++ b/agent/internal/updater/restart_windows_test.go
@@ -1,0 +1,128 @@
+//go:build windows
+
+package updater
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildRestartScript_AgentOnly is the pre-#816 baseline: when the caller
+// passes empty user-helper paths the generated script must not reference the
+// user-helper at all (backward-compatible with releases that don't yet ship
+// the breeze-user-helper artifact and with non-Windows release histories).
+func TestBuildRestartScript_AgentOnly(t *testing.T) {
+	got := buildRestartScript(restartScriptOptions{
+		AgentTempPath:   `C:\Windows\Temp\breeze-agent-1234.exe`,
+		AgentTargetPath: `C:\Program Files\Breeze\breeze-agent.exe`,
+	})
+
+	if !strings.Contains(got, `Copy-Item -Path 'C:\Windows\Temp\breeze-agent-1234.exe' -Destination 'C:\Program Files\Breeze\breeze-agent.exe' -Force`) {
+		t.Fatalf("expected agent Copy-Item line; script was:\n%s", got)
+	}
+	if strings.Contains(got, "breeze-user-helper") {
+		t.Fatalf("agent-only script should not mention user-helper; script was:\n%s", got)
+	}
+	if !strings.Contains(got, "Start-Service -Name 'BreezeAgent'") {
+		t.Fatalf("expected Start-Service line; script was:\n%s", got)
+	}
+}
+
+// TestBuildRestartScript_WithUserHelper verifies that when both user-helper
+// paths are provided the generated script emits a second Copy-Item AFTER the
+// agent's and includes a cleanup step for the helper temp file. The ordering
+// matters: the agent Copy-Item must come first so a partial failure still
+// leaves a working (if pre-#816) install rather than an installed user-helper
+// with a stale agent.
+func TestBuildRestartScript_WithUserHelper(t *testing.T) {
+	got := buildRestartScript(restartScriptOptions{
+		AgentTempPath:        `C:\Windows\Temp\breeze-agent-1234.exe`,
+		AgentTargetPath:      `C:\Program Files\Breeze\breeze-agent.exe`,
+		UserHelperTempPath:   `C:\Windows\Temp\breeze-user-helper-5678.exe`,
+		UserHelperTargetPath: `C:\Program Files\Breeze\breeze-user-helper.exe`,
+	})
+
+	agentCopy := `Copy-Item -Path 'C:\Windows\Temp\breeze-agent-1234.exe' -Destination 'C:\Program Files\Breeze\breeze-agent.exe' -Force`
+	helperCopy := `Copy-Item -Path 'C:\Windows\Temp\breeze-user-helper-5678.exe' -Destination 'C:\Program Files\Breeze\breeze-user-helper.exe' -Force`
+
+	agentIdx := strings.Index(got, agentCopy)
+	helperIdx := strings.Index(got, helperCopy)
+	if agentIdx < 0 {
+		t.Fatalf("expected agent Copy-Item line; script was:\n%s", got)
+	}
+	if helperIdx < 0 {
+		t.Fatalf("expected user-helper Copy-Item line; script was:\n%s", got)
+	}
+	if helperIdx <= agentIdx {
+		t.Fatalf("user-helper Copy-Item must come AFTER agent Copy-Item; script was:\n%s", got)
+	}
+
+	// Helper temp file cleanup line.
+	if !strings.Contains(got, `Remove-Item -Path 'C:\Windows\Temp\breeze-user-helper-5678.exe' -Force -ErrorAction SilentlyContinue`) {
+		t.Fatalf("expected Remove-Item cleanup for helper temp; script was:\n%s", got)
+	}
+}
+
+// TestBuildRestartScript_EscapesSingleQuotes guards the single-quote escaping
+// pattern (PowerShell-injection safety): a path containing a literal single
+// quote must be doubled inside the script so PowerShell parses it as a
+// literal rather than a string-delimiter. This mirrors the agent-path
+// escaping that's been in place since the helper was introduced — the
+// user-helper path must follow the same rule (issue #816).
+func TestBuildRestartScript_EscapesSingleQuotes(t *testing.T) {
+	got := buildRestartScript(restartScriptOptions{
+		AgentTempPath:        `C:\tmp\agent'evil.exe`,
+		AgentTargetPath:      `C:\Program Files\Breeze\breeze-agent.exe`,
+		UserHelperTempPath:   `C:\tmp\helper'evil.exe`,
+		UserHelperTargetPath: `C:\Program Files\Breeze\breeze-user-helper.exe`,
+	})
+
+	if !strings.Contains(got, `'C:\tmp\agent''evil.exe'`) {
+		t.Fatalf("expected agent path single quotes to be doubled; script was:\n%s", got)
+	}
+	if !strings.Contains(got, `'C:\tmp\helper''evil.exe'`) {
+		t.Fatalf("expected user-helper path single quotes to be doubled; script was:\n%s", got)
+	}
+	// And the un-escaped form must NOT appear — that would mean we're shipping
+	// a script PowerShell would terminate the string on, letting an attacker
+	// inject commands via a crafted temp path.
+	if strings.Contains(got, `'C:\tmp\agent'evil.exe'`) {
+		t.Fatalf("agent path single quote was not escaped; script was:\n%s", got)
+	}
+}
+
+// TestBuildRestartScript_HelperOnlyPathsAreIgnoredIfEmpty exercises the
+// defensive code path where only one of the two helper paths is provided.
+// We treat this as "no user-helper to install" rather than partially
+// generating a broken script.
+func TestBuildRestartScript_HelperOnlyPathsAreIgnoredIfEmpty(t *testing.T) {
+	cases := []struct {
+		name string
+		opts restartScriptOptions
+	}{
+		{
+			name: "temp set, target empty",
+			opts: restartScriptOptions{
+				AgentTempPath:      `C:\tmp\agent.exe`,
+				AgentTargetPath:    `C:\Program Files\Breeze\breeze-agent.exe`,
+				UserHelperTempPath: `C:\tmp\helper.exe`,
+			},
+		},
+		{
+			name: "target set, temp empty",
+			opts: restartScriptOptions{
+				AgentTempPath:        `C:\tmp\agent.exe`,
+				AgentTargetPath:      `C:\Program Files\Breeze\breeze-agent.exe`,
+				UserHelperTargetPath: `C:\Program Files\Breeze\breeze-user-helper.exe`,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildRestartScript(tc.opts)
+			if strings.Contains(got, `breeze-user-helper.exe' -Force`) {
+				t.Fatalf("expected no user-helper Copy-Item when one path is empty; script was:\n%s", got)
+			}
+		})
+	}
+}

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -47,6 +47,10 @@ type Config struct {
 type Updater struct {
 	config *Config
 	client *http.Client
+	// extras is set by UpdateToWithCompanions / UpdateFromURLWithCompanions
+	// to forward companion-binary paths (e.g. breeze-user-helper.exe) into
+	// the Windows restart helper. Not user-visible. Issue #816.
+	extras updateExtras
 }
 
 // New creates a new Updater
@@ -55,6 +59,15 @@ func New(cfg *Config) *Updater {
 		config: cfg,
 		client: &http.Client{Timeout: 5 * time.Minute},
 	}
+}
+
+// updateExtras carries optional companion-binary info into the Windows
+// restart helper. It is set transiently via the Updater's exported
+// UpdateToWithCompanions / UpdateFromURLWithCompanions wrappers so the
+// existing UpdateTo signature stays stable. Issue #816.
+type updateExtras struct {
+	userHelperTempPath   string
+	userHelperTargetPath string
 }
 
 // ErrReadOnlyFS is returned when the binary path is on a read-only filesystem.
@@ -165,6 +178,18 @@ func (u *Updater) expectedReleaseAssetNames() map[string]struct{} {
 		case "linux":
 			return map[string]struct{}{"breeze-viewer-linux.AppImage": {}}
 		}
+	case "user-helper":
+		// breeze-user-helper is the GUI-subsystem sibling of breeze-agent
+		// that runs in interactive user sessions (sessionbroker spawn path).
+		// It only exists on Windows — Linux/macOS user-session work is
+		// handled by other surfaces. See agent/installer/build-msi.ps1
+		// for how it's bundled into the installer; the in-place
+		// auto-upgrade path (#816) downloads it as a separate artifact.
+		if runtime.GOOS == "windows" {
+			return map[string]struct{}{
+				fmt.Sprintf("breeze-user-helper-%s-%s.exe", runtime.GOOS, runtime.GOARCH): {},
+			}
+		}
 	}
 	return map[string]struct{}{}
 }
@@ -225,6 +250,16 @@ func writeUpdateMarker(version string) {
 	}
 }
 
+// UpdateToWithUserHelper behaves like UpdateTo but also instructs the Windows
+// restart helper to copy a freshly-downloaded breeze-user-helper.exe into
+// place alongside the agent. Empty paths fall back to agent-only behavior.
+// Issue #816.
+func (u *Updater) UpdateToWithUserHelper(version, userHelperTempPath, userHelperTargetPath string) error {
+	u.extras.userHelperTempPath = userHelperTempPath
+	u.extras.userHelperTargetPath = userHelperTargetPath
+	return u.UpdateTo(version)
+}
+
 // UpdateTo downloads and installs a new version
 func (u *Updater) UpdateTo(version string) error {
 	log.Info("starting update", "targetVersion", version)
@@ -262,7 +297,12 @@ func (u *Updater) UpdateTo(version string) error {
 	//    The agent exits normally after spawning the script.
 	if runtime.GOOS == "windows" {
 		writeUpdateMarker(version)
-		if err := RestartWithHelper(tempPath, u.config.BinaryPath); err != nil {
+		// User-helper swap is wired in by the heartbeat-layer caller
+		// (heartbeat.doUpgrade), not here — the updater package is
+		// component-agnostic, and downloading a second component requires
+		// the caller's AuthToken/server context. Pass empty strings for an
+		// agent-only swap (backward compatible). Issue #816.
+		if err := RestartWithHelper(tempPath, u.config.BinaryPath, u.extras.userHelperTempPath, u.extras.userHelperTargetPath); err != nil {
 			removeCleanup(tempPath)
 			if rbErr := u.Rollback(); rbErr != nil {
 				log.Error("rollback also failed", "originalError", err, "rollbackError", rbErr)
@@ -489,6 +529,24 @@ func (u *Updater) verifyReleaseArtifactManifest(payload []byte, info downloadInf
 	}, nil
 }
 
+// DownloadBinary is the exported wrapper around downloadBinary used by
+// callers that need to pre-download a companion artifact (e.g. the
+// breeze-user-helper.exe) outside the full UpdateTo flow. Returns the
+// temp-file path on success after verifying the downloaded bytes against
+// the signed manifest checksum. The caller is responsible for cleanup.
+// Issue #816.
+func (u *Updater) DownloadBinary(version string) (string, error) {
+	tempPath, manifest, err := u.downloadBinary(version)
+	if err != nil {
+		return "", err
+	}
+	if err := u.verifyChecksum(tempPath, manifest.Checksum); err != nil {
+		removeCleanup(tempPath)
+		return "", fmt.Errorf("checksum verification failed: %w", err)
+	}
+	return tempPath, nil
+}
+
 // downloadBinary fetches download info from the API and then downloads the binary.
 // Supports both legacy redirect responses and JSON info responses.
 func (u *Updater) downloadBinary(version string) (string, updateManifest, error) {
@@ -706,7 +764,7 @@ func (u *Updater) UpdateFromURL(url, expectedChecksum string) error {
 
 	// 4. Windows: spawn helper script for binary swap
 	if runtime.GOOS == "windows" {
-		if err := RestartWithHelper(tempPath, u.config.BinaryPath); err != nil {
+		if err := RestartWithHelper(tempPath, u.config.BinaryPath, u.extras.userHelperTempPath, u.extras.userHelperTargetPath); err != nil {
 			removeCleanup(tempPath)
 			if rbErr := u.Rollback(); rbErr != nil {
 				log.Error("rollback also failed", "originalError", err, "rollbackError", rbErr)

--- a/agent/internal/updater/updater_test.go
+++ b/agent/internal/updater/updater_test.go
@@ -959,3 +959,44 @@ func TestTrustedManifestKeys_SkipsMalformedPinnedEntries(t *testing.T) {
 		t.Fatalf("expected at least 1 (embedded) key, got %d", len(keys))
 	}
 }
+
+// TestExpectedReleaseAssetNames_UserHelper covers the component=user-helper
+// branch added by #816. The breeze-user-helper exists only on Windows; other
+// platforms must return an empty allowlist so verifyReleaseArtifactManifest
+// surfaces a clear "no expected asset names" error instead of accidentally
+// accepting an unrelated artifact.
+func TestExpectedReleaseAssetNames_UserHelper(t *testing.T) {
+	u := &Updater{config: &Config{Component: "user-helper"}}
+	got := u.expectedReleaseAssetNames()
+
+	if runtime.GOOS == "windows" {
+		expected := "breeze-user-helper-windows-" + runtime.GOARCH + ".exe"
+		if len(got) != 1 {
+			t.Fatalf("expected exactly 1 asset name on windows, got %d (%v)", len(got), got)
+		}
+		if _, ok := got[expected]; !ok {
+			t.Fatalf("expected %q in asset name set, got %v", expected, got)
+		}
+		return
+	}
+
+	// Non-Windows: user-helper isn't shipped, so the set is empty.
+	if len(got) != 0 {
+		t.Fatalf("expected empty asset name set on %s, got %v", runtime.GOOS, got)
+	}
+}
+
+// TestExpectedReleaseAssetNames_Agent guards against regressions in the
+// existing agent branch when refactoring the user-helper case.
+func TestExpectedReleaseAssetNames_Agent(t *testing.T) {
+	u := &Updater{config: &Config{Component: "agent"}}
+	got := u.expectedReleaseAssetNames()
+	suffix := ""
+	if runtime.GOOS == "windows" {
+		suffix = ".exe"
+	}
+	expected := "breeze-agent-" + runtime.GOOS + "-" + runtime.GOARCH + suffix
+	if _, ok := got[expected]; !ok {
+		t.Fatalf("expected %q in agent asset name set, got %v", expected, got)
+	}
+}

--- a/apps/api/src/routes/agentVersions.test.ts
+++ b/apps/api/src/routes/agentVersions.test.ts
@@ -498,6 +498,58 @@ describe("agentVersions routes", () => {
       }
     });
 
+    // Issue #816: the download route must serve a row for the new
+    // component=user-helper value. Pre-fix the zod schema rejected this with
+    // a 400 (component not in enum), which forced the agent to abort the
+    // upgrade entirely instead of falling back to an agent-only swap.
+    it("serves component=user-helper rows (#816)", async () => {
+      const canonical =
+        "https://github.com/LanternOps/breeze/releases/download/v1.0.0/breeze-user-helper-windows-amd64.exe";
+      const checksum = "f".repeat(64);
+      const signed = makeSignedReleaseArtifactManifest({
+        assetName: "breeze-user-helper-windows-amd64.exe",
+        checksum,
+        size: 2048,
+      });
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              {
+                version: "1.0.0",
+                platform: "windows",
+                architecture: "amd64",
+                component: "user-helper",
+                downloadUrl: canonical,
+                checksum,
+                fileSize: BigInt(2048),
+                releaseManifest: signed.manifest,
+                manifestSignature: signed.signature,
+                signingKeyId: "release-artifact-manifest-ed25519",
+              },
+            ]),
+          }),
+        }),
+      } as any);
+
+      try {
+        const res = await app.request(
+          "/agent-versions/1.0.0/download?platform=windows&arch=amd64&component=user-helper",
+        );
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        // user-helper is NOT routed through the server-relative proxy today
+        // (the /agents/download/:os/:arch route is agent-only); the canonical
+        // GitHub URL is returned as-is. See buildServerRelativeAgentDownloadUrl.
+        expect(body.url).toBe(canonical);
+        expect(body.checksum).toBe(checksum);
+      } finally {
+        delete process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS;
+      }
+    });
+
     it("should return 404 for unknown version", async () => {
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -37,7 +37,10 @@ const architectureEnum = z.enum(["amd64", "arm64"]);
 const latestQuerySchema = z.object({
   platform: platformEnum,
   arch: architectureEnum,
-  component: z.enum(["agent", "helper", "viewer"]).optional().default("agent"),
+  component: z
+    .enum(["agent", "helper", "viewer", "user-helper"])
+    .optional()
+    .default("agent"),
 });
 
 const downloadParamsSchema = z.object({
@@ -47,7 +50,10 @@ const downloadParamsSchema = z.object({
 const downloadQuerySchema = z.object({
   platform: platformEnum,
   arch: architectureEnum,
-  component: z.enum(["agent", "helper", "viewer"]).optional().default("agent"),
+  component: z
+    .enum(["agent", "helper", "viewer", "user-helper"])
+    .optional()
+    .default("agent"),
 });
 
 const createVersionSchema = z.object({
@@ -62,7 +68,10 @@ const createVersionSchema = z.object({
   fileSize: z.number().int().positive().optional(),
   releaseNotes: z.string().optional(),
   isLatest: z.boolean().optional().default(false),
-  component: z.enum(["agent", "helper", "viewer"]).optional().default("agent"),
+  component: z
+    .enum(["agent", "helper", "viewer", "user-helper"])
+    .optional()
+    .default("agent"),
 });
 
 type ReleaseManifest = {

--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -36,6 +36,19 @@ const HELPER_TARGETS = [
   { goos: "linux", goarch: "amd64", assetName: "breeze-helper-linux.AppImage" },
 ] as const;
 
+// Issue #816: breeze-user-helper is the GUI-subsystem Windows sibling of
+// breeze-agent that the sessionbroker spawns into interactive user sessions.
+// It's signed by the same Azure Trusted Signing pipeline as the agent and
+// shipped as its own GitHub release asset so the agent's in-place auto-upgrade
+// (heartbeat.doUpgrade) can fetch it as a separate component. Windows-only.
+const USER_HELPER_TARGETS = [
+  {
+    goos: "windows",
+    goarch: "amd64",
+    assetName: "breeze-user-helper-windows-amd64.exe",
+  },
+] as const;
+
 interface BinaryInfo {
   filename: string;
   filePath: string;
@@ -547,6 +560,42 @@ export async function syncFromGitHub(
     } catch (err) {
       console.error(
         `[binarySync] Failed to upsert helper version for ${platform}/${target.goarch}:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  // Sync user-helper binaries (Windows-only; issue #816). Missing for any
+  // pre-#816 release — `release.assets.find` returns undefined and the loop
+  // body short-circuits. The agent treats a 404 here as non-fatal and falls
+  // back to an agent-only upgrade.
+  for (const target of USER_HELPER_TARGETS) {
+    const asset = release.assets.find((a) => a.name === target.assetName);
+    if (!asset) continue;
+    const metadata = await getReleaseAssetMetadata({
+      asset,
+      trustedManifest,
+      fallbackChecksums,
+      releaseTag: release.tag_name,
+    });
+    if (!metadata) continue;
+    const platform = GH_PLATFORM_MAP[target.goos];
+    if (!platform) continue;
+
+    try {
+      await upsertVersion(
+        version,
+        platform,
+        target.goarch,
+        "user-helper",
+        asset.browser_download_url,
+        metadata,
+        release.body,
+      );
+      synced.push(`user-helper:${platform}/${target.goarch}`);
+    } catch (err) {
+      console.error(
+        `[binarySync] Failed to upsert user-helper version for ${platform}/${target.goarch}:`,
         err instanceof Error ? err.message : err,
       );
     }


### PR DESCRIPTION
## Summary

Fixes #816. On Windows hosts the agent's in-place auto-upgrade lost `breeze-user-helper.exe`: the MSI installer was the only path that ever placed it on disk, and the upgrade restart-helper script only copied `breeze-agent.exe`. The downstream symptom -- HelperLifecycleManager falling through to a `breeze-agent.exe user-helper` fallback every ~30s and orphaned processes accumulating during heartbeat goroutine wedges until the service died -- is documented in the issue.

Two layers of fix, separated into two commits.

### Layer B - agent (`1531a195`)

- `expectedReleaseAssetNames()` learns a `case "user-helper":` branch returning `breeze-user-helper-windows-amd64.exe` on Windows and empty elsewhere (the user-helper is Windows-only).
- `restart_windows.go` extracts the PowerShell script generation into a pure `buildRestartScript()` so it's unit-testable without spawning a process. `RestartWithHelper` gets two additional string params (`userHelperTempPath`, `userHelperTargetPath`); empty strings preserve the pre-#816 agent-only behavior. Single-quote escaping for the helper path mirrors the agent path's existing pattern.
- `updater.go` exposes `UpdateToWithUserHelper()` plus an exported `DownloadBinary()` for callers that need to pre-fetch a companion artifact through the same signed-manifest pipeline.
- `heartbeat.doUpgrade` on Windows constructs a second `Updater` with `Component: "user-helper"`, downloads the helper to a temp file, and threads the temp path + the install-dir helper path through `UpdateToWithUserHelper`.

**Call chain after this PR (Windows in-place upgrade):**
```
heartbeat.doUpgrade
  -> updater.New(Component="user-helper").DownloadBinary(target)   # NEW
  -> updater.New(Component="agent").UpdateToWithUserHelper(target, helperTmp, helperTarget)
       -> RestartWithHelper(agentTmp, agentTarget, helperTmp, helperTarget)
            -> PowerShell: Stop-Service; Copy-Item agent; Copy-Item helper; Start-Service
```

### Layer A - release pipeline + API (`17a019fe`)

- `release.yml` uploads `breeze-user-helper-windows-amd64.exe` as a separate artifact post-signing, extends the assemble-release download pattern, and stages it into `release-assets/` so it lands in the GitHub Release alongside the agent. The signed release-artifact manifest's existing `platform_trust` labeller already classifies `.exe` as `windows-authenticode-required`, which is correct here.
- `binarySync.ts` gets a `USER_HELPER_TARGETS` constant and a sync loop mirroring the agent/helper loops. `upsertVersion` was already component-agnostic.
- `agentVersions.ts` extends the component zod enum on all three schemas (latest, download, create) to accept `"user-helper"`. The `agent_versions.component` column is `varchar(20)` -- no DB migration needed.

### 404-graceful for pre-fix releases

Any `breeze_versions` row missing for `component=user-helper` produces a 404 from `/agent-versions/:version/download`. `heartbeat.doUpgrade` treats this (along with network errors, checksum mismatches, and signature failures) as non-fatal: it logs a warning and proceeds with an agent-only upgrade. **This PR introduces no regression for releases that don't yet ship the user-helper artifact.** Auto-upgraded hosts will pick up the helper as soon as a release tagged after this PR ships.

## Test Plan

### Agent
```
cd agent && go build ./...                                 # ok
cd agent && go vet ./...                                   # ok
cd agent && go test -race ./internal/updater/...           # ok (3 new tests)
cd agent && go test -race ./internal/heartbeat/...         # ok
cd agent && GOOS=windows GOARCH=amd64 go build ./...       # ok
```

New tests:
- `TestExpectedReleaseAssetNames_UserHelper` (covers both Windows and non-Windows paths)
- `TestExpectedReleaseAssetNames_Agent` (regression guard for the existing branch)
- `TestBuildRestartScript_AgentOnly` (script omits user-helper when paths empty)
- `TestBuildRestartScript_WithUserHelper` (helper Copy-Item emitted AFTER agent's, plus cleanup)
- `TestBuildRestartScript_EscapesSingleQuotes` (PowerShell-injection guard for both paths)
- `TestBuildRestartScript_HelperOnlyPathsAreIgnoredIfEmpty` (defensive partial-input handling)

### API
```
cd apps/api && npx tsc --noEmit            # clean
cd apps/api && npx eslint <touched files>  # clean
cd apps/api && npx vitest run              # 4544 passed | 28 skipped (1 new test added)
```

New test: `agentVersions.test.ts > "serves component=user-helper rows (#816)"` verifies the download route returns the canonical GitHub URL + checksum end-to-end against a signed release-artifact manifest.

## Hosted-SaaS caveat (out of scope, deferred)

For self-hosted (`BINARY_SOURCE=local`) deployments this PR works end-to-end. For hosted SaaS (`BINARY_SOURCE=github`) the download route returns the canonical github.com URL, which the agent's `downloadFromURL` rejects on host-match. Same class as #646. The agent gracefully falls back to an agent-only upgrade in that case -- no regression, but hosted-SaaS hosts won't actually receive the user-helper until we extend `buildServerRelativeAgentDownloadUrl` (and the `/agents/download/:os/:arch` route) to also proxy `component=user-helper`. Tracking separately so this PR stays focused on the root-cause fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)