### PR TITLE
feat(dns-security): scaffold web UI — sidebar entry, /dns-security page, Integrations tab

### DIFF
--- a/apps/web/src/components/dnsSecurity/AddDnsIntegrationModal.test.tsx
+++ b/apps/web/src/components/dnsSecurity/AddDnsIntegrationModal.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AddDnsIntegrationModal from './AddDnsIntegrationModal';
+import { fetchWithAuth } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('../shared/Toast', () => ({
+  showToast: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+const showToastMock = vi.mocked(showToast);
+
+function makeJsonResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
+
+describe('AddDnsIntegrationModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('only lists the 5 supported providers (opendns + quad9 hidden)', () => {
+    render(<AddDnsIntegrationModal onClose={() => {}} onCreated={() => {}} />);
+    const select = screen.getByLabelText('Provider') as HTMLSelectElement;
+    const options = Array.from(select.options).map((o) => o.value);
+    expect(options).toEqual([
+      'umbrella',
+      'cloudflare',
+      'dnsfilter',
+      'pihole',
+      'adguard_home',
+    ]);
+    expect(options).not.toContain('opendns');
+    expect(options).not.toContain('quad9');
+  });
+
+  it('renders Cloudflare-specific fields (Account ID, no apiSecret)', () => {
+    render(<AddDnsIntegrationModal onClose={() => {}} onCreated={() => {}} />);
+    // Default selection is cloudflare
+    expect(screen.getByLabelText('API token')).toBeInTheDocument();
+    expect(screen.getByLabelText('Account ID')).toBeInTheDocument();
+    expect(screen.queryByLabelText('API secret')).toBeNull();
+    expect(screen.queryByLabelText('HTTP Basic password')).toBeNull();
+  });
+
+  it('switches to Umbrella-specific fields when provider changes', () => {
+    render(<AddDnsIntegrationModal onClose={() => {}} onCreated={() => {}} />);
+    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'umbrella' } });
+    expect(screen.getByLabelText('API key')).toBeInTheDocument();
+    expect(screen.getByLabelText('API secret')).toBeInTheDocument();
+    expect(screen.getByLabelText('Organization ID')).toBeInTheDocument();
+  });
+
+  it('switches to AdGuard Home fields (HTTP Basic username + password + endpoint)', () => {
+    render(<AddDnsIntegrationModal onClose={() => {}} onCreated={() => {}} />);
+    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'adguard_home' } });
+    expect(screen.getByLabelText('HTTP Basic username')).toBeInTheDocument();
+    expect(screen.getByLabelText('HTTP Basic password')).toBeInTheDocument();
+    expect(screen.getByLabelText('API endpoint')).toBeInTheDocument();
+  });
+
+  it('submits a Cloudflare integration via POST /dns-security/integrations with the right shape', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ data: { id: 'new-1' } }));
+    const onCreated = vi.fn();
+    const onClose = vi.fn();
+
+    render(<AddDnsIntegrationModal onClose={onClose} onCreated={onCreated} />);
+    fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Acme HQ' } });
+    fireEvent.change(screen.getByLabelText('API token'), { target: { value: 'cf-token-abc' } });
+    fireEvent.change(screen.getByLabelText('Account ID'), { target: { value: '0123456789abcdef' } });
+    fireEvent.click(screen.getByRole('button', { name: /Add integration/i }));
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        '/dns-security/integrations',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+    const init = fetchWithAuthMock.mock.calls[0]![1] as RequestInit;
+    const body = JSON.parse(String(init.body));
+    expect(body).toMatchObject({
+      provider: 'cloudflare',
+      name: 'Acme HQ',
+      apiKey: 'cf-token-abc',
+      config: { accountId: '0123456789abcdef' },
+      isActive: true,
+    });
+    expect(body.apiSecret).toBeUndefined();
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'success', message: expect.stringMatching(/Cloudflare/) }),
+      );
+    });
+    expect(onCreated).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders inline error and keeps modal open when API rejects (does NOT close on failure)', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(
+      makeJsonResponse({ error: 'organizationId is required for Cisco Umbrella' }, false, 400),
+    );
+    const onClose = vi.fn();
+    const onCreated = vi.fn();
+
+    render(<AddDnsIntegrationModal onClose={onClose} onCreated={onCreated} />);
+    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'umbrella' } });
+    fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Umbrella Prod' } });
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'k' } });
+    fireEvent.change(screen.getByLabelText('API secret'), { target: { value: 's' } });
+    // Intentionally leave Organization ID blank to trigger server-side validation
+    fireEvent.click(screen.getByRole('button', { name: /Add integration/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/organizationId is required/);
+    });
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onCreated).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/dnsSecurity/AddDnsIntegrationModal.tsx
+++ b/apps/web/src/components/dnsSecurity/AddDnsIntegrationModal.tsx
@@ -1,0 +1,321 @@
+import { useId, useState } from 'react';
+import { X } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, ActionError } from '../../lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+
+/**
+ * Supported provider IDs. Mirrors the wire-format `dns_provider` enum,
+ * but only lists providers that have working sync (umbrella, cloudflare,
+ * dnsfilter, pihole, adguard_home). opendns and quad9 exist in the enum
+ * but throw "not yet supported" server-side, so we hide them from the
+ * picker rather than showing broken options. See
+ * apps/api/src/services/dnsProviders/index.ts.
+ */
+type SupportedProvider =
+  | 'umbrella'
+  | 'cloudflare'
+  | 'dnsfilter'
+  | 'pihole'
+  | 'adguard_home';
+
+interface ProviderFieldSpec {
+  label: string;
+  helpText: string;
+  apiKey: { label: string; placeholder: string };
+  apiSecret?: { label: string; placeholder: string };
+  configFields?: Array<{
+    key: 'organizationId' | 'accountId' | 'apiEndpoint';
+    label: string;
+    placeholder: string;
+    type?: 'text' | 'url';
+  }>;
+}
+
+const PROVIDERS: Record<SupportedProvider, ProviderFieldSpec> = {
+  umbrella: {
+    label: 'Cisco Umbrella',
+    helpText: 'API key + secret from the Umbrella Reporting API; organizationId from your Umbrella dashboard URL.',
+    apiKey: { label: 'API key', placeholder: 'reporting-api-key' },
+    apiSecret: { label: 'API secret', placeholder: 'reporting-api-secret' },
+    configFields: [
+      { key: 'organizationId', label: 'Organization ID', placeholder: '1234567' },
+    ],
+  },
+  cloudflare: {
+    label: 'Cloudflare Gateway',
+    helpText: 'API token with Zero Trust → Gateway → Read scope.',
+    apiKey: { label: 'API token', placeholder: 'cf-api-token' },
+    configFields: [
+      { key: 'accountId', label: 'Account ID', placeholder: '32-char hex from the Cloudflare dashboard' },
+    ],
+  },
+  dnsfilter: {
+    label: 'DNSFilter',
+    helpText: 'API key from your DNSFilter account settings; account ID required only for multi-tenant scopes.',
+    apiKey: { label: 'API key', placeholder: 'dnsfilter-api-key' },
+    configFields: [
+      { key: 'accountId', label: 'Account ID (optional)', placeholder: 'leave blank for single-tenant' },
+    ],
+  },
+  pihole: {
+    label: 'Pi-hole',
+    helpText: 'Pi-hole API endpoint + API key. Use the LAN-routable hostname.',
+    apiKey: { label: 'API key', placeholder: 'pihole api key from /admin' },
+    configFields: [
+      { key: 'apiEndpoint', label: 'API endpoint', placeholder: 'http://pihole.local', type: 'url' },
+    ],
+  },
+  adguard_home: {
+    label: 'AdGuard Home',
+    helpText: 'API endpoint + HTTP Basic auth username (apiKey) + password (apiSecret).',
+    apiKey: { label: 'HTTP Basic username', placeholder: 'admin' },
+    apiSecret: { label: 'HTTP Basic password', placeholder: 'password' },
+    configFields: [
+      { key: 'apiEndpoint', label: 'API endpoint', placeholder: 'https://adguard.client.local', type: 'url' },
+    ],
+  },
+};
+
+type ConfigPayload = {
+  organizationId?: string;
+  accountId?: string;
+  apiEndpoint?: string;
+};
+
+interface AddDnsIntegrationModalProps {
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+export default function AddDnsIntegrationModal({ onClose, onCreated }: AddDnsIntegrationModalProps) {
+  const [provider, setProvider] = useState<SupportedProvider>('cloudflare');
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [apiSecret, setApiSecret] = useState('');
+  const [config, setConfig] = useState<ConfigPayload>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const spec = PROVIDERS[provider];
+
+  const updateConfig = (key: keyof ConfigPayload, value: string) => {
+    setConfig((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+
+    // Trim string-empty values so we don't send them — the server treats
+    // empty strings as set, which breaks the provider-specific refinements
+    // (e.g. cloudflare config.accountId empty string ≠ undefined).
+    const trimmedConfig: ConfigPayload = {};
+    if (config.organizationId?.trim()) trimmedConfig.organizationId = config.organizationId.trim();
+    if (config.accountId?.trim()) trimmedConfig.accountId = config.accountId.trim();
+    if (config.apiEndpoint?.trim()) trimmedConfig.apiEndpoint = config.apiEndpoint.trim();
+
+    try {
+      await runAction({
+        request: () => fetchWithAuth('/dns-security/integrations', {
+          method: 'POST',
+          body: JSON.stringify({
+            provider,
+            name: name.trim(),
+            description: description.trim() || undefined,
+            apiKey,
+            apiSecret: apiSecret || undefined,
+            config: Object.keys(trimmedConfig).length > 0 ? trimmedConfig : undefined,
+            isActive: true,
+          }),
+        }),
+        errorFallback: 'Failed to create integration',
+        successMessage: `${spec.label} integration "${name}" added`,
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+      onCreated();
+      onClose();
+    } catch (err) {
+      if (err instanceof ActionError) {
+        if (err.status === 401) return;
+        setError(err.message);
+      } else {
+        setError(err instanceof Error ? err.message : 'Network error');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
+      <div className="relative max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-lg border bg-card p-6 shadow-lg">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="absolute right-3 top-3 inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-muted"
+        >
+          <X className="h-4 w-4" />
+        </button>
+
+        <h2 className="text-lg font-semibold">Add DNS Integration</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Connect a DNS filtering provider to ingest query logs and threat events.
+        </p>
+
+        <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+          <Field label="Provider">
+            {(id) => (
+              <>
+                <select
+                  id={id}
+                  value={provider}
+                  onChange={(e) => {
+                    setProvider(e.target.value as SupportedProvider);
+                    setConfig({}); // clear provider-specific fields when switching
+                  }}
+                  className="h-9 w-full rounded-md border bg-background px-2 text-sm"
+                >
+                  {(Object.entries(PROVIDERS) as Array<[SupportedProvider, ProviderFieldSpec]>).map(
+                    ([key, p]) => (
+                      <option key={key} value={key}>
+                        {p.label}
+                      </option>
+                    ),
+                  )}
+                </select>
+                <p className="mt-1 text-xs text-muted-foreground">{spec.helpText}</p>
+              </>
+            )}
+          </Field>
+
+          <Field label="Display name">
+            {(id) => (
+              <input
+                id={id}
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                maxLength={200}
+                required
+                placeholder="e.g. Acme HQ Gateway"
+                className="h-9 w-full rounded-md border bg-background px-2 text-sm"
+              />
+            )}
+          </Field>
+
+          <Field label="Description (optional)">
+            {(id) => (
+              <textarea
+                id={id}
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                maxLength={2000}
+                rows={2}
+                placeholder="What this integration covers"
+                className="w-full rounded-md border bg-background px-2 py-1.5 text-sm"
+              />
+            )}
+          </Field>
+
+          <Field label={spec.apiKey.label}>
+            {(id) => (
+              <input
+                id={id}
+                type="text"
+                autoComplete="off"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                required
+                placeholder={spec.apiKey.placeholder}
+                className="h-9 w-full rounded-md border bg-background px-2 text-sm font-mono"
+              />
+            )}
+          </Field>
+
+          {spec.apiSecret && (
+            <Field label={spec.apiSecret.label}>
+              {(id) => (
+                <input
+                  id={id}
+                  type="password"
+                  autoComplete="new-password"
+                  value={apiSecret}
+                  onChange={(e) => setApiSecret(e.target.value)}
+                  required
+                  placeholder={spec.apiSecret!.placeholder}
+                  className="h-9 w-full rounded-md border bg-background px-2 text-sm font-mono"
+                />
+              )}
+            </Field>
+          )}
+
+          {spec.configFields?.map((field) => (
+            <Field key={field.key} label={field.label}>
+              {(id) => (
+                <input
+                  id={id}
+                  type={field.type ?? 'text'}
+                  value={config[field.key] ?? ''}
+                  onChange={(e) => updateConfig(field.key, e.target.value)}
+                  placeholder={field.placeholder}
+                  className="h-9 w-full rounded-md border bg-background px-2 text-sm"
+                />
+              )}
+            </Field>
+          ))}
+
+          {error && (
+            <div role="alert" className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border bg-background px-3 py-1.5 text-sm font-medium hover:bg-muted"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting || !name.trim() || !apiKey.trim()}
+              className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            >
+              {submitting ? 'Adding…' : 'Add integration'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  // Render-prop: gives the child the auto-generated `id` so the label's
+  // htmlFor binding works for assistive tech AND for testing-library's
+  // getByLabelText (which requires explicit for/id pairing or nested
+  // form-control association — render-prop avoids the latter being
+  // ambiguous when the Field also renders helper text).
+  children: (id: string) => React.ReactNode;
+}) {
+  const id = useId();
+  return (
+    <div className="block">
+      <label htmlFor={id} className="mb-1 block text-sm font-medium">
+        {label}
+      </label>
+      {children(id)}
+    </div>
+  );
+}

--- a/apps/web/src/components/dnsSecurity/AddDnsIntegrationModal.tsx
+++ b/apps/web/src/components/dnsSecurity/AddDnsIntegrationModal.tsx
@@ -1,8 +1,8 @@
 import { useId, useState } from 'react';
-import { X } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
+import { Dialog } from '../shared/Dialog';
 
 /**
  * Supported provider IDs. Mirrors the wire-format `dns_provider` enum,
@@ -151,17 +151,14 @@ export default function AddDnsIntegrationModal({ onClose, onCreated }: AddDnsInt
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
-      <div className="relative max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-lg border bg-card p-6 shadow-lg">
-        <button
-          type="button"
-          onClick={onClose}
-          aria-label="Close"
-          className="absolute right-3 top-3 inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-muted"
-        >
-          <X className="h-4 w-4" />
-        </button>
-
+    <Dialog
+      open
+      onClose={onClose}
+      title="Add DNS Integration"
+      maxWidth="lg"
+      className="p-6 max-h-[90vh] overflow-y-auto"
+    >
+      <div className="relative">
         <h2 className="text-lg font-semibold">Add DNS Integration</h2>
         <p className="mt-1 text-sm text-muted-foreground">
           Connect a DNS filtering provider to ingest query logs and threat events.
@@ -293,7 +290,7 @@ export default function AddDnsIntegrationModal({ onClose, onCreated }: AddDnsInt
           </div>
         </form>
       </div>
-    </div>
+    </Dialog>
   );
 }
 

--- a/apps/web/src/components/dnsSecurity/AddDnsPolicyModal.tsx
+++ b/apps/web/src/components/dnsSecurity/AddDnsPolicyModal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useId, useState } from 'react';
-import { X } from 'lucide-react';
+import { Dialog } from '../shared/Dialog';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
@@ -56,6 +56,11 @@ export default function AddDnsPolicyModal({ onClose, onCreated }: AddDnsPolicyMo
       if (list.length > 0 && !integrationId) {
         setIntegrationId(list[0]!.id);
       }
+    } catch (err) {
+      // Match the sibling-tab pattern: silent on AbortError, otherwise
+      // surface to the dialog's inline error UI. (Todd #847 review.)
+      if (err instanceof Error && err.name === 'AbortError') return;
+      setError(err instanceof Error ? err.message : 'Failed to load integrations');
     } finally {
       setLoadingIntegrations(false);
     }
@@ -123,17 +128,14 @@ export default function AddDnsPolicyModal({ onClose, onCreated }: AddDnsPolicyMo
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
-      <div className="relative max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-lg border bg-card p-6 shadow-lg">
-        <button
-          type="button"
-          onClick={onClose}
-          aria-label="Close"
-          className="absolute right-3 top-3 inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-muted"
-        >
-          <X className="h-4 w-4" />
-        </button>
-
+    <Dialog
+      open
+      onClose={onClose}
+      title="New DNS Policy"
+      maxWidth="lg"
+      className="p-6 max-h-[90vh] overflow-y-auto"
+    >
+      <div className="relative">
         <h2 className="text-lg font-semibold">New DNS Policy</h2>
         <p className="mt-1 text-sm text-muted-foreground">
           Blocklist or allowlist domains pushed to your DNS provider on the next sync cycle.
@@ -252,6 +254,6 @@ export default function AddDnsPolicyModal({ onClose, onCreated }: AddDnsPolicyMo
           </div>
         </form>
       </div>
-    </div>
+    </Dialog>
   );
 }

--- a/apps/web/src/components/dnsSecurity/AddDnsPolicyModal.tsx
+++ b/apps/web/src/components/dnsSecurity/AddDnsPolicyModal.tsx
@@ -1,0 +1,257 @@
+import { useCallback, useEffect, useId, useState } from 'react';
+import { X } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, ActionError } from '../../lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+
+type PolicyType = 'blocklist' | 'allowlist';
+
+interface IntegrationOption {
+  id: string;
+  name: string;
+  provider: string;
+}
+
+interface AddDnsPolicyModalProps {
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+export default function AddDnsPolicyModal({ onClose, onCreated }: AddDnsPolicyModalProps) {
+  const [integrations, setIntegrations] = useState<IntegrationOption[]>([]);
+  const [loadingIntegrations, setLoadingIntegrations] = useState(true);
+  const [integrationId, setIntegrationId] = useState('');
+  const [name, setName] = useState('');
+  const [type, setType] = useState<PolicyType>('blocklist');
+  const [description, setDescription] = useState('');
+  const [domainsText, setDomainsText] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const integrationFieldId = useId();
+  const nameFieldId = useId();
+  const typeFieldId = useId();
+  const descFieldId = useId();
+  const domainsFieldId = useId();
+
+  const fetchIntegrations = useCallback(async () => {
+    setLoadingIntegrations(true);
+    try {
+      const res = await fetchWithAuth('/dns-security/integrations');
+      if (!res.ok) {
+        if (res.status === 401) {
+          void navigateTo('/login', { replace: true });
+          return;
+        }
+        setError(`Failed to load integrations (HTTP ${res.status})`);
+        return;
+      }
+      const body = await res.json();
+      const list: IntegrationOption[] = ((body.data ?? body.integrations ?? []) as Array<{
+        id: string;
+        name: string;
+        provider: string;
+      }>).map((i) => ({ id: i.id, name: i.name, provider: i.provider }));
+      setIntegrations(list);
+      if (list.length > 0 && !integrationId) {
+        setIntegrationId(list[0]!.id);
+      }
+    } finally {
+      setLoadingIntegrations(false);
+    }
+  }, [integrationId]);
+
+  useEffect(() => {
+    void fetchIntegrations();
+  }, [fetchIntegrations]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (submitting) return;
+    if (!integrationId) {
+      setError('Pick an integration first');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+
+    // Parse the bulk-paste domains box. Same shape as the per-row table
+    // adder in the parent tab: whitespace/comma separated, de-duped,
+    // length-capped per the server schema (500 chars per entry, 500 max).
+    const seen = new Set<string>();
+    const domains = domainsText
+      .split(/[\s,]+/)
+      .map((s) => s.trim().toLowerCase())
+      .filter((s) => {
+        if (!s || s.length > 500) return false;
+        if (seen.has(s)) return false;
+        seen.add(s);
+        return true;
+      })
+      .slice(0, 500)
+      .map((domain) => ({ domain }));
+
+    try {
+      await runAction({
+        request: () => fetchWithAuth('/dns-security/policies', {
+          method: 'POST',
+          body: JSON.stringify({
+            integrationId,
+            name: name.trim(),
+            description: description.trim() || undefined,
+            type,
+            domains: domains.length > 0 ? domains : undefined,
+            isActive: true,
+          }),
+        }),
+        errorFallback: 'Failed to create policy',
+        successMessage: `Policy "${name}" created`,
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+      onCreated();
+      onClose();
+    } catch (err) {
+      if (err instanceof ActionError) {
+        if (err.status === 401) return;
+        setError(err.message);
+      } else {
+        setError(err instanceof Error ? err.message : 'Network error');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
+      <div className="relative max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-lg border bg-card p-6 shadow-lg">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="absolute right-3 top-3 inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-muted"
+        >
+          <X className="h-4 w-4" />
+        </button>
+
+        <h2 className="text-lg font-semibold">New DNS Policy</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Blocklist or allowlist domains pushed to your DNS provider on the next sync cycle.
+        </p>
+
+        <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+          <div>
+            <label htmlFor={integrationFieldId} className="mb-1 block text-sm font-medium">
+              Integration
+            </label>
+            {loadingIntegrations ? (
+              <p className="text-xs text-muted-foreground">Loading integrations…</p>
+            ) : integrations.length === 0 ? (
+              <p className="text-xs text-destructive">
+                No integrations configured. Add one on the Integrations tab first.
+              </p>
+            ) : (
+              <select
+                id={integrationFieldId}
+                value={integrationId}
+                onChange={(e) => setIntegrationId(e.target.value)}
+                className="h-9 w-full rounded-md border bg-background px-2 text-sm"
+              >
+                {integrations.map((it) => (
+                  <option key={it.id} value={it.id}>
+                    {it.name} ({it.provider})
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+
+          <div>
+            <label htmlFor={nameFieldId} className="mb-1 block text-sm font-medium">
+              Policy name
+            </label>
+            <input
+              id={nameFieldId}
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              maxLength={200}
+              required
+              placeholder="e.g. Threat blocklist"
+              className="h-9 w-full rounded-md border bg-background px-2 text-sm"
+            />
+          </div>
+
+          <div>
+            <label htmlFor={typeFieldId} className="mb-1 block text-sm font-medium">
+              Type
+            </label>
+            <select
+              id={typeFieldId}
+              value={type}
+              onChange={(e) => setType(e.target.value as PolicyType)}
+              className="h-9 w-full rounded-md border bg-background px-2 text-sm"
+            >
+              <option value="blocklist">Blocklist (deny)</option>
+              <option value="allowlist">Allowlist (permit)</option>
+            </select>
+          </div>
+
+          <div>
+            <label htmlFor={descFieldId} className="mb-1 block text-sm font-medium">
+              Description (optional)
+            </label>
+            <textarea
+              id={descFieldId}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              maxLength={2000}
+              rows={2}
+              className="w-full rounded-md border bg-background px-2 py-1.5 text-sm"
+            />
+          </div>
+
+          <div>
+            <label htmlFor={domainsFieldId} className="mb-1 block text-sm font-medium">
+              Initial domains (optional)
+              <span className="ml-1 font-normal text-muted-foreground">
+                (one per line, comma-separated, or paste a list — up to 500)
+              </span>
+            </label>
+            <textarea
+              id={domainsFieldId}
+              value={domainsText}
+              onChange={(e) => setDomainsText(e.target.value)}
+              rows={4}
+              placeholder={'malware.example.com\nphish.example.com\nc2.example.org'}
+              className="w-full rounded-md border bg-background px-2 py-1.5 font-mono text-xs"
+            />
+          </div>
+
+          {error && (
+            <div role="alert" className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border bg-background px-3 py-1.5 text-sm font-medium hover:bg-muted"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting || !name.trim() || !integrationId}
+              className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            >
+              {submitting ? 'Creating…' : 'Create policy'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/dnsSecurity/DnsSecurityEventsTab.test.tsx
+++ b/apps/web/src/components/dnsSecurity/DnsSecurityEventsTab.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DnsSecurityEventsTab from './DnsSecurityEventsTab';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+function makeJsonResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
+
+describe('DnsSecurityEventsTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('defaults to blocked-only — query string contains action=blocked', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ data: [], pagination: { total: 0 } }));
+    render(<DnsSecurityEventsTab />);
+    await waitFor(() => {
+      const url = fetchWithAuthMock.mock.calls[0]?.[0];
+      expect(String(url)).toMatch(/action=blocked/);
+    });
+  });
+
+  it('toggling "Show all" re-fetches without the action filter', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ data: [], pagination: { total: 0 } }));
+    render(<DnsSecurityEventsTab />);
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(1));
+
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ data: [], pagination: { total: 0 } }));
+    fireEvent.click(screen.getByLabelText(/Show all/));
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(2));
+    const secondUrl = String(fetchWithAuthMock.mock.calls[1]![0]);
+    expect(secondUrl).not.toMatch(/action=blocked/);
+  });
+
+  it('renders event rows with action badge + device hostname fallback chain', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(
+      makeJsonResponse({
+        data: [
+          {
+            id: 'evt-1',
+            timestamp: '2026-05-22T20:00:00.000Z',
+            domain: 'malware.example.com',
+            queryType: 'A',
+            action: 'blocked',
+            category: 'malware',
+            threatType: 'trojan',
+            sourceIp: '10.0.0.42',
+            sourceHostname: null,
+            deviceId: 'dev-1',
+            deviceHostname: 'TST-LAPTOP-01',
+            integrationId: 'int-1',
+          },
+          {
+            id: 'evt-2',
+            timestamp: '2026-05-22T20:01:00.000Z',
+            domain: 'unknown.example.com',
+            queryType: 'AAAA',
+            action: 'blocked',
+            category: null,
+            threatType: null,
+            sourceIp: '10.0.0.99',
+            sourceHostname: null,
+            deviceId: null,
+            deviceHostname: null,
+            integrationId: 'int-1',
+          },
+        ],
+        pagination: { total: 2 },
+      }),
+    );
+
+    render(<DnsSecurityEventsTab />);
+    await waitFor(() => expect(screen.getByText('malware.example.com')).toBeInTheDocument());
+    expect(screen.getByText('TST-LAPTOP-01')).toBeInTheDocument();
+    expect(screen.getByText('10.0.0.99')).toBeInTheDocument(); // sourceIp fallback for the unknown row
+    expect(screen.getAllByText('blocked').length).toBeGreaterThan(0);
+  });
+
+  it('Surfaces an inline error when the events endpoint fails', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({}, false, 500));
+    render(<DnsSecurityEventsTab />);
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/Failed to load events/);
+    });
+  });
+});

--- a/apps/web/src/components/dnsSecurity/DnsSecurityEventsTab.tsx
+++ b/apps/web/src/components/dnsSecurity/DnsSecurityEventsTab.tsx
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useState } from 'react';
+import { ScrollText, RefreshCw } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { navigateTo } from '@/lib/navigation';
+
+type Action = 'allowed' | 'blocked' | 'redirected';
+
+interface DnsEvent {
+  id: string;
+  timestamp: string;
+  domain: string;
+  queryType: string | null;
+  action: Action;
+  category: string | null;
+  threatType: string | null;
+  sourceIp: string | null;
+  sourceHostname: string | null;
+  deviceId: string | null;
+  deviceHostname: string | null;
+  integrationId: string | null;
+}
+
+const ACTION_BADGE: Record<Action, string> = {
+  allowed: 'bg-muted text-muted-foreground',
+  blocked: 'bg-destructive/15 text-destructive',
+  redirected: 'bg-warning/15 text-warning',
+};
+
+export default function DnsSecurityEventsTab() {
+  const [events, setEvents] = useState<DnsEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [total, setTotal] = useState(0);
+
+  /**
+   * Default to blocked-only — per the decision surface (Q5: "Blocked
+   * threats by default; volume of allowed queries is huge and noisy").
+   */
+  const [showAll, setShowAll] = useState(false);
+
+  const fetchEvents = useCallback(async (signal?: AbortSignal) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ limit: '100' });
+      if (!showAll) params.set('action', 'blocked');
+      const res = await fetchWithAuth(`/dns-security/events?${params.toString()}`, { signal });
+      if (!res.ok) {
+        if (res.status === 401) {
+          void navigateTo('/login', { replace: true });
+          return;
+        }
+        throw new Error(`Failed to load events (HTTP ${res.status})`);
+      }
+      const body = await res.json();
+      setEvents((body.data ?? []) as DnsEvent[]);
+      setTotal(Number(body.pagination?.total ?? 0));
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return;
+      setError(err instanceof Error ? err.message : 'Failed to load events');
+    } finally {
+      if (!signal?.aborted) setLoading(false);
+    }
+  }, [showAll]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetchEvents(controller.signal);
+    return () => controller.abort();
+  }, [fetchEvents]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h2 className="text-lg font-medium">DNS query events</h2>
+          <p className="text-xs text-muted-foreground">
+            {loading ? 'Loading…' : `${events.length} of ${total} ${showAll ? 'event' : 'blocked event'}${total === 1 ? '' : 's'} (most recent 100)`}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <label className="inline-flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={showAll}
+              onChange={(e) => setShowAll(e.target.checked)}
+              className="h-4 w-4 rounded border"
+            />
+            Show all (not just blocked)
+          </label>
+          <button
+            type="button"
+            onClick={() => void fetchEvents()}
+            disabled={loading}
+            title="Refresh"
+            className="inline-flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted disabled:opacity-50"
+          >
+            <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div role="alert" className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {loading && events.length === 0 ? (
+        <div className="flex items-center gap-2 rounded-md border bg-card px-4 py-6 text-sm text-muted-foreground">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          Loading events…
+        </div>
+      ) : events.length === 0 ? (
+        <div className="rounded-md border border-dashed bg-card px-4 py-8 text-center">
+          <ScrollText className="mx-auto h-8 w-8 text-muted-foreground" />
+          <p className="mt-2 text-sm font-medium">
+            {showAll ? 'No DNS events recorded' : 'No blocked DNS events'}
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {showAll
+              ? 'Configure an integration and wait for the first 15-minute sync to complete.'
+              : 'No threats blocked in the recent window. Try toggling "Show all" to see allowed traffic.'}
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-md border">
+          <table className="w-full text-sm">
+            <thead className="border-b bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2 text-left">When</th>
+                <th className="px-3 py-2 text-left">Device</th>
+                <th className="px-3 py-2 text-left">Domain</th>
+                <th className="px-3 py-2 text-left">Category</th>
+                <th className="px-3 py-2 text-left">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {events.map((e) => (
+                <tr key={e.id} className="border-b last:border-b-0 hover:bg-muted/20">
+                  <td className="px-3 py-1.5 whitespace-nowrap text-xs text-muted-foreground">
+                    {new Date(e.timestamp).toLocaleString()}
+                  </td>
+                  <td className="px-3 py-1.5">
+                    {e.deviceHostname ?? e.sourceHostname ?? e.sourceIp ?? <span className="text-muted-foreground italic">unknown</span>}
+                  </td>
+                  <td className="px-3 py-1.5 font-mono text-xs">{e.domain}</td>
+                  <td className="px-3 py-1.5 text-xs">
+                    {e.category ? (
+                      <>
+                        <span className="font-medium">{e.category}</span>
+                        {e.threatType && <span className="text-muted-foreground"> · {e.threatType}</span>}
+                      </>
+                    ) : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-1.5">
+                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${ACTION_BADGE[e.action]}`}>
+                      {e.action}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/dnsSecurity/DnsSecurityIntegrationsTab.test.tsx
+++ b/apps/web/src/components/dnsSecurity/DnsSecurityIntegrationsTab.test.tsx
@@ -1,0 +1,125 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DnsSecurityIntegrationsTab from './DnsSecurityIntegrationsTab';
+import { fetchWithAuth } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('../shared/Toast', () => ({
+  showToast: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+const showToastMock = vi.mocked(showToast);
+
+function makeJsonResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
+
+describe('DnsSecurityIntegrationsTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the empty state when no integrations exist', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ data: [] }));
+    render(<DnsSecurityIntegrationsTab />);
+    await waitFor(() => {
+      expect(screen.getByText('No DNS integrations configured')).toBeInTheDocument();
+    });
+  });
+
+  it('renders each integration row with its provider label and last-sync state', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(
+      makeJsonResponse({
+        data: [
+          {
+            id: 'int-1',
+            orgId: 'org-1',
+            provider: 'cloudflare',
+            name: 'Acme HQ Gateway',
+            enabled: true,
+            lastSync: '2026-05-22T19:00:00.000Z',
+            lastSyncStatus: 'success',
+            lastSyncError: null,
+            totalEventsProcessed: 4242,
+            createdAt: '2026-05-01T00:00:00.000Z',
+          },
+          {
+            id: 'int-2',
+            orgId: 'org-1',
+            provider: 'adguard_home',
+            name: 'Lab AdGuard',
+            enabled: true,
+            lastSync: null,
+            lastSyncStatus: null,
+            lastSyncError: null,
+            totalEventsProcessed: 0,
+            createdAt: '2026-05-02T00:00:00.000Z',
+          },
+        ],
+      }),
+    );
+
+    render(<DnsSecurityIntegrationsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Acme HQ Gateway')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Cloudflare Gateway')).toBeInTheDocument();
+    expect(screen.getByText('AdGuard Home')).toBeInTheDocument();
+    expect(screen.getByText('Lab AdGuard')).toBeInTheDocument();
+    expect(screen.getByText('4242')).toBeInTheDocument();
+    expect(screen.getByText('Never')).toBeInTheDocument();
+  });
+
+  it('Sync button POSTs /integrations/:id/sync via runAction and toasts on success', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(
+      makeJsonResponse({
+        data: [{
+          id: 'int-1',
+          orgId: 'org-1',
+          provider: 'umbrella',
+          name: 'Umbrella Prod',
+          enabled: true,
+          lastSync: '2026-05-22T19:00:00.000Z',
+          lastSyncStatus: 'success',
+          lastSyncError: null,
+          totalEventsProcessed: 10,
+          createdAt: '2026-05-01T00:00:00.000Z',
+        }],
+      }),
+    );
+
+    render(<DnsSecurityIntegrationsTab />);
+    await waitFor(() => expect(screen.getByText('Umbrella Prod')).toBeInTheDocument());
+
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ success: true }));
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ data: [] })); // refetch
+
+    fireEvent.click(screen.getByTitle('Sync now'));
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'success', message: 'Sync queued for Umbrella Prod' }),
+      );
+    });
+  });
+
+  it('surfaces an inline error banner when the list endpoint fails', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ error: 'boom' }, false, 500));
+    render(<DnsSecurityIntegrationsTab />);
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/Failed to load integrations/);
+    });
+  });
+});

--- a/apps/web/src/components/dnsSecurity/DnsSecurityIntegrationsTab.tsx
+++ b/apps/web/src/components/dnsSecurity/DnsSecurityIntegrationsTab.tsx
@@ -3,6 +3,7 @@ import { Plug, RefreshCw, Trash2, Plus } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
+import AddDnsIntegrationModal from './AddDnsIntegrationModal';
 
 type Provider =
   | 'umbrella'
@@ -41,6 +42,7 @@ export default function DnsSecurityIntegrationsTab() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [showAddModal, setShowAddModal] = useState(false);
 
   const fetchIntegrations = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
@@ -119,9 +121,7 @@ export default function DnsSecurityIntegrationsTab() {
         <h2 className="text-lg font-medium">Configured integrations</h2>
         <button
           type="button"
-          // Add-integration modal lands in a follow-up PR; the button is wired
-          // up so the IA is visible but tells the operator where it's headed.
-          onClick={() => alert('Add Integration modal lands in a follow-up PR. For now, POST /dns-security/integrations directly with the provider-specific config payload.')}
+          onClick={() => setShowAddModal(true)}
           className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
         >
           <Plus className="h-4 w-4" />
@@ -203,6 +203,13 @@ export default function DnsSecurityIntegrationsTab() {
             </tbody>
           </table>
         </div>
+      )}
+
+      {showAddModal && (
+        <AddDnsIntegrationModal
+          onClose={() => setShowAddModal(false)}
+          onCreated={() => void fetchIntegrations()}
+        />
       )}
     </div>
   );

--- a/apps/web/src/components/dnsSecurity/DnsSecurityIntegrationsTab.tsx
+++ b/apps/web/src/components/dnsSecurity/DnsSecurityIntegrationsTab.tsx
@@ -1,0 +1,209 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Plug, RefreshCw, Trash2, Plus } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, ActionError } from '../../lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+
+type Provider =
+  | 'umbrella'
+  | 'cloudflare'
+  | 'dnsfilter'
+  | 'pihole'
+  | 'opendns'
+  | 'quad9'
+  | 'adguard_home';
+
+const PROVIDER_LABELS: Record<Provider, string> = {
+  umbrella: 'Cisco Umbrella',
+  cloudflare: 'Cloudflare Gateway',
+  dnsfilter: 'DNSFilter',
+  pihole: 'Pi-hole',
+  opendns: 'OpenDNS',
+  quad9: 'Quad9',
+  adguard_home: 'AdGuard Home',
+};
+
+type Integration = {
+  id: string;
+  orgId: string;
+  provider: Provider;
+  name: string;
+  enabled: boolean;
+  lastSync: string | null;
+  lastSyncStatus: string | null;
+  lastSyncError: string | null;
+  totalEventsProcessed: number | null;
+  createdAt: string;
+};
+
+export default function DnsSecurityIntegrationsTab() {
+  const [integrations, setIntegrations] = useState<Integration[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const fetchIntegrations = useCallback(async (signal?: AbortSignal) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchWithAuth('/dns-security/integrations', { signal });
+      if (!res.ok) {
+        if (res.status === 401) {
+          void navigateTo('/login', { replace: true });
+          return;
+        }
+        throw new Error(`Failed to load integrations (HTTP ${res.status})`);
+      }
+      const body = await res.json();
+      setIntegrations((body.data ?? body.integrations ?? []) as Integration[]);
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return;
+      setError(err instanceof Error ? err.message : 'Failed to load integrations');
+    } finally {
+      if (!signal?.aborted) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetchIntegrations(controller.signal);
+    return () => controller.abort();
+  }, [fetchIntegrations]);
+
+  const handleSync = async (integration: Integration) => {
+    setBusyId(integration.id);
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/dns-security/integrations/${integration.id}/sync`, {
+          method: 'POST',
+        }),
+        errorFallback: `Failed to trigger sync for ${integration.name}`,
+        successMessage: `Sync queued for ${integration.name}`,
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+      // Refresh to surface updated lastSync state once the worker runs.
+      await fetchIntegrations();
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return;
+      // runAction already toasted; nothing inline to surface beyond that.
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleDelete = async (integration: Integration) => {
+    if (!window.confirm(`Delete ${integration.name}? Stored events are retained per the retention policy.`)) {
+      return;
+    }
+    setBusyId(integration.id);
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/dns-security/integrations/${integration.id}`, {
+          method: 'DELETE',
+        }),
+        errorFallback: `Failed to delete ${integration.name}`,
+        successMessage: `Deleted ${integration.name}`,
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+      await fetchIntegrations();
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return;
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-medium">Configured integrations</h2>
+        <button
+          type="button"
+          // Add-integration modal lands in a follow-up PR; the button is wired
+          // up so the IA is visible but tells the operator where it's headed.
+          onClick={() => alert('Add Integration modal lands in a follow-up PR. For now, POST /dns-security/integrations directly with the provider-specific config payload.')}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          <Plus className="h-4 w-4" />
+          Add integration
+        </button>
+      </div>
+
+      {error && (
+        <div role="alert" className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center gap-2 rounded-md border bg-card px-4 py-6 text-sm text-muted-foreground">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          Loading integrations…
+        </div>
+      ) : integrations.length === 0 ? (
+        <div className="rounded-md border border-dashed bg-card px-4 py-8 text-center">
+          <Plug className="mx-auto h-8 w-8 text-muted-foreground" />
+          <p className="mt-2 text-sm font-medium">No DNS integrations configured</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Connect one of the 7 supported providers to start ingesting DNS query logs.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-md border">
+          <table className="w-full text-sm">
+            <thead className="border-b bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th className="px-4 py-2 text-left">Name</th>
+                <th className="px-4 py-2 text-left">Provider</th>
+                <th className="px-4 py-2 text-left">Last sync</th>
+                <th className="px-4 py-2 text-left">Events</th>
+                <th className="px-4 py-2 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {integrations.map((it) => (
+                <tr key={it.id} className="border-b last:border-b-0">
+                  <td className="px-4 py-2 font-medium">{it.name}</td>
+                  <td className="px-4 py-2">{PROVIDER_LABELS[it.provider] ?? it.provider}</td>
+                  <td className="px-4 py-2">
+                    {it.lastSync ? (
+                      <span className={it.lastSyncStatus === 'error' ? 'text-destructive' : ''}>
+                        {new Date(it.lastSync).toLocaleString()}
+                        {it.lastSyncStatus === 'error' && ' — failed'}
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">Never</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2">{it.totalEventsProcessed ?? 0}</td>
+                  <td className="px-4 py-2 text-right">
+                    <div className="inline-flex items-center gap-1">
+                      <button
+                        type="button"
+                        onClick={() => handleSync(it)}
+                        disabled={busyId === it.id}
+                        title="Sync now"
+                        className="inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+                      >
+                        <RefreshCw className={`h-4 w-4 ${busyId === it.id ? 'animate-spin' : ''}`} />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(it)}
+                        disabled={busyId === it.id}
+                        title="Delete integration"
+                        className="inline-flex h-7 w-7 items-center justify-center rounded text-destructive hover:bg-destructive/10 disabled:opacity-50"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/dnsSecurity/DnsSecurityOverviewTab.test.tsx
+++ b/apps/web/src/components/dnsSecurity/DnsSecurityOverviewTab.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DnsSecurityOverviewTab from './DnsSecurityOverviewTab';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+function makeJsonResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
+
+describe('DnsSecurityOverviewTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders stat counters from /stats and top-blocked list from /top-blocked in parallel', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(
+      makeJsonResponse({
+        data: { total: 12345, blocked: 234, allowed: 12100, redirected: 7 },
+      }),
+    );
+    fetchWithAuthMock.mockResolvedValueOnce(
+      makeJsonResponse({
+        data: [
+          { domain: 'malware.example.com', count: 47, category: 'malware' },
+          { domain: 'phish.example.com', count: 22, category: 'phishing' },
+        ],
+      }),
+    );
+
+    render(<DnsSecurityOverviewTab />);
+
+    await waitFor(() => expect(screen.getByText('12,345')).toBeInTheDocument());
+    expect(screen.getByText('234')).toBeInTheDocument();
+    expect(screen.getByText('12,100')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+    expect(screen.getByText('malware.example.com')).toBeInTheDocument();
+    expect(screen.getByText('phish.example.com')).toBeInTheDocument();
+    // Counts column on the top-blocked widget
+    expect(screen.getByText('47')).toBeInTheDocument();
+    expect(screen.getByText('22')).toBeInTheDocument();
+  });
+
+  it('renders empty-state for top-blocked when API returns []', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(
+      makeJsonResponse({ data: { total: 0, blocked: 0, allowed: 0, redirected: 0 } }),
+    );
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ data: [] }));
+
+    render(<DnsSecurityOverviewTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No blocked domains in the current window.')).toBeInTheDocument();
+    });
+  });
+
+  it('Shows inline error when BOTH endpoints fail; tolerates partial failure when one succeeds', async () => {
+    // Both fail
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({}, false, 500));
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({}, false, 500));
+
+    render(<DnsSecurityOverviewTab />);
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/Failed to load overview/);
+    });
+  });
+});

--- a/apps/web/src/components/dnsSecurity/DnsSecurityOverviewTab.tsx
+++ b/apps/web/src/components/dnsSecurity/DnsSecurityOverviewTab.tsx
@@ -1,0 +1,181 @@
+import { useCallback, useEffect, useState } from 'react';
+import { ShieldAlert, ShieldCheck, Activity, AlertTriangle } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { navigateTo } from '@/lib/navigation';
+
+interface DnsStats {
+  total: number;
+  blocked: number;
+  allowed: number;
+  redirected: number;
+  /** Optional aggregations the API may include; render only when present. */
+  topCategories?: Array<{ category: string; count: number }>;
+  topDomains?: Array<{ domain: string; count: number }>;
+}
+
+interface TopBlockedEntry {
+  domain: string;
+  count: number;
+  category?: string | null;
+}
+
+export default function DnsSecurityOverviewTab() {
+  const [stats, setStats] = useState<DnsStats | null>(null);
+  const [topBlocked, setTopBlocked] = useState<TopBlockedEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchOverview = useCallback(async (signal?: AbortSignal) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [statsRes, topRes] = await Promise.all([
+        fetchWithAuth('/dns-security/stats', { signal }),
+        fetchWithAuth('/dns-security/top-blocked?limit=10', { signal }),
+      ]);
+
+      if (statsRes.status === 401 || topRes.status === 401) {
+        void navigateTo('/login', { replace: true });
+        return;
+      }
+
+      if (statsRes.ok) {
+        const body = await statsRes.json();
+        const data = body.data ?? body;
+        setStats({
+          total: Number(data.total ?? 0),
+          blocked: Number(data.blocked ?? 0),
+          allowed: Number(data.allowed ?? 0),
+          redirected: Number(data.redirected ?? 0),
+          topCategories: data.topCategories,
+          topDomains: data.topDomains,
+        });
+      }
+      if (topRes.ok) {
+        const body = await topRes.json();
+        setTopBlocked((body.data ?? []) as TopBlockedEntry[]);
+      }
+
+      if (!statsRes.ok && !topRes.ok) {
+        throw new Error('Failed to load overview');
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return;
+      setError(err instanceof Error ? err.message : 'Failed to load overview');
+    } finally {
+      if (!signal?.aborted) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetchOverview(controller.signal);
+    return () => controller.abort();
+  }, [fetchOverview]);
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div role="alert" className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          label="Total queries"
+          value={stats?.total ?? 0}
+          icon={<Activity className="h-4 w-4" />}
+          loading={loading}
+        />
+        <StatCard
+          label="Blocked"
+          value={stats?.blocked ?? 0}
+          icon={<ShieldAlert className="h-4 w-4" />}
+          tone="destructive"
+          loading={loading}
+        />
+        <StatCard
+          label="Allowed"
+          value={stats?.allowed ?? 0}
+          icon={<ShieldCheck className="h-4 w-4" />}
+          tone="success"
+          loading={loading}
+        />
+        <StatCard
+          label="Redirected"
+          value={stats?.redirected ?? 0}
+          icon={<AlertTriangle className="h-4 w-4" />}
+          tone="warning"
+          loading={loading}
+        />
+      </div>
+
+      <div className="rounded-lg border bg-card p-4">
+        <h3 className="mb-3 text-sm font-semibold">Top blocked domains</h3>
+        {loading && topBlocked.length === 0 ? (
+          <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
+            <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+            Loading…
+          </div>
+        ) : topBlocked.length === 0 ? (
+          <p className="py-4 text-center text-xs text-muted-foreground italic">
+            No blocked domains in the current window.
+          </p>
+        ) : (
+          <ol className="space-y-1 text-sm">
+            {topBlocked.map((entry, idx) => (
+              <li
+                key={entry.domain}
+                className="flex items-center justify-between rounded px-2 py-1 hover:bg-muted/30"
+              >
+                <span className="font-mono text-xs">
+                  <span className="mr-2 inline-block w-5 text-right text-muted-foreground">{idx + 1}.</span>
+                  {entry.domain}
+                  {entry.category && (
+                    <span className="ml-2 text-muted-foreground">({entry.category})</span>
+                  )}
+                </span>
+                <span className="font-mono text-xs font-medium">{entry.count}</span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  icon,
+  tone,
+  loading,
+}: {
+  label: string;
+  value: number;
+  icon: React.ReactNode;
+  tone?: 'destructive' | 'success' | 'warning';
+  loading: boolean;
+}) {
+  const toneClass =
+    tone === 'destructive'
+      ? 'text-destructive'
+      : tone === 'success'
+        ? 'text-success'
+        : tone === 'warning'
+          ? 'text-warning'
+          : 'text-foreground';
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        {icon}
+        {label}
+      </div>
+      <div className={`mt-1 text-2xl font-semibold tabular-nums ${toneClass}`}>
+        {loading ? <span className="text-muted-foreground">—</span> : value.toLocaleString()}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/dnsSecurity/DnsSecurityPage.tsx
+++ b/apps/web/src/components/dnsSecurity/DnsSecurityPage.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Network, Plug, ListChecks, ScrollText } from 'lucide-react';
+import DnsSecurityIntegrationsTab from './DnsSecurityIntegrationsTab';
+
+type Tab = 'overview' | 'integrations' | 'policies' | 'events';
+
+const VALID_TABS: readonly Tab[] = ['overview', 'integrations', 'policies', 'events'];
+
+function readTabFromHash(): Tab {
+  if (typeof window === 'undefined') return 'overview';
+  const hash = window.location.hash.replace('#', '');
+  return (VALID_TABS as readonly string[]).includes(hash) ? (hash as Tab) : 'overview';
+}
+
+export default function DnsSecurityPage() {
+  const [activeTab, setActiveTab] = useState<Tab>(readTabFromHash);
+
+  // Reflect tab into URL hash per the CLAUDE.md "URL State in Components"
+  // rule — matches DeviceDetails.tsx / OrganizationsPage.tsx.
+  const switchTab = useCallback((tab: Tab) => {
+    window.location.hash = tab;
+    setActiveTab(tab);
+  }, []);
+
+  useEffect(() => {
+    const onHashChange = () => setActiveTab(readTabFromHash());
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">DNS Security</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            DNS filtering integrations, blocklist/allowlist policies, and threat events
+            across Umbrella, Cloudflare Gateway, DNSFilter, Pi-hole, OpenDNS, Quad9, and AdGuard Home.
+          </p>
+        </div>
+      </header>
+
+      <nav className="flex gap-1 border-b">
+        <TabButton active={activeTab === 'overview'} onClick={() => switchTab('overview')} icon={<Network className="h-4 w-4" />}>
+          Overview
+        </TabButton>
+        <TabButton active={activeTab === 'integrations'} onClick={() => switchTab('integrations')} icon={<Plug className="h-4 w-4" />}>
+          Integrations
+        </TabButton>
+        <TabButton active={activeTab === 'policies'} onClick={() => switchTab('policies')} icon={<ListChecks className="h-4 w-4" />}>
+          Policies
+        </TabButton>
+        <TabButton active={activeTab === 'events'} onClick={() => switchTab('events')} icon={<ScrollText className="h-4 w-4" />}>
+          Events
+        </TabButton>
+      </nav>
+
+      <div role="tabpanel">
+        {activeTab === 'overview' && <OverviewPlaceholder />}
+        {activeTab === 'integrations' && <DnsSecurityIntegrationsTab />}
+        {activeTab === 'policies' && <PoliciesPlaceholder />}
+        {activeTab === 'events' && <EventsPlaceholder />}
+      </div>
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  icon,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={`inline-flex items-center gap-2 border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
+        active
+          ? 'border-primary text-foreground'
+          : 'border-transparent text-muted-foreground hover:text-foreground'
+      }`}
+    >
+      {icon}
+      {children}
+    </button>
+  );
+}
+
+function OverviewPlaceholder() {
+  return (
+    <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">
+      DNS threat counters + top-blocked widget land here in a follow-up PR. The data
+      endpoints (<code>/dns-security/stats</code>, <code>/dns-security/top-blocked</code>)
+      are already API-complete.
+    </div>
+  );
+}
+
+function PoliciesPlaceholder() {
+  return (
+    <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">
+      Policy editor (blocklist/allowlist domains, per-row table with add/delete + bulk paste)
+      lands in a follow-up PR. Backed by <code>GET/POST /dns-security/policies</code> and
+      <code>PATCH /dns-security/policies/:id/domains</code>.
+    </div>
+  );
+}
+
+function EventsPlaceholder() {
+  return (
+    <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">
+      Threat events list (blocked-by-default with "show all" toggle) lands in a follow-up PR.
+      Backed by <code>GET /dns-security/events</code>.
+    </div>
+  );
+}

--- a/apps/web/src/components/dnsSecurity/DnsSecurityPage.tsx
+++ b/apps/web/src/components/dnsSecurity/DnsSecurityPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Network, Plug, ListChecks, ScrollText } from 'lucide-react';
 import DnsSecurityIntegrationsTab from './DnsSecurityIntegrationsTab';
+import DnsSecurityPoliciesTab from './DnsSecurityPoliciesTab';
 
 type Tab = 'overview' | 'integrations' | 'policies' | 'events';
 
@@ -58,7 +59,7 @@ export default function DnsSecurityPage() {
       <div role="tabpanel">
         {activeTab === 'overview' && <OverviewPlaceholder />}
         {activeTab === 'integrations' && <DnsSecurityIntegrationsTab />}
-        {activeTab === 'policies' && <PoliciesPlaceholder />}
+        {activeTab === 'policies' && <DnsSecurityPoliciesTab />}
         {activeTab === 'events' && <EventsPlaceholder />}
       </div>
     </div>
@@ -100,16 +101,6 @@ function OverviewPlaceholder() {
       DNS threat counters + top-blocked widget land here in a follow-up PR. The data
       endpoints (<code>/dns-security/stats</code>, <code>/dns-security/top-blocked</code>)
       are already API-complete.
-    </div>
-  );
-}
-
-function PoliciesPlaceholder() {
-  return (
-    <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">
-      Policy editor (blocklist/allowlist domains, per-row table with add/delete + bulk paste)
-      lands in a follow-up PR. Backed by <code>GET/POST /dns-security/policies</code> and
-      <code>PATCH /dns-security/policies/:id/domains</code>.
     </div>
   );
 }

--- a/apps/web/src/components/dnsSecurity/DnsSecurityPage.tsx
+++ b/apps/web/src/components/dnsSecurity/DnsSecurityPage.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useState } from 'react';
 import { Network, Plug, ListChecks, ScrollText } from 'lucide-react';
 import DnsSecurityIntegrationsTab from './DnsSecurityIntegrationsTab';
 import DnsSecurityPoliciesTab from './DnsSecurityPoliciesTab';
+import DnsSecurityEventsTab from './DnsSecurityEventsTab';
+import DnsSecurityOverviewTab from './DnsSecurityOverviewTab';
 
 type Tab = 'overview' | 'integrations' | 'policies' | 'events';
 
@@ -57,10 +59,10 @@ export default function DnsSecurityPage() {
       </nav>
 
       <div role="tabpanel">
-        {activeTab === 'overview' && <OverviewPlaceholder />}
+        {activeTab === 'overview' && <DnsSecurityOverviewTab />}
         {activeTab === 'integrations' && <DnsSecurityIntegrationsTab />}
         {activeTab === 'policies' && <DnsSecurityPoliciesTab />}
-        {activeTab === 'events' && <EventsPlaceholder />}
+        {activeTab === 'events' && <DnsSecurityEventsTab />}
       </div>
     </div>
   );
@@ -95,21 +97,3 @@ function TabButton({
   );
 }
 
-function OverviewPlaceholder() {
-  return (
-    <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">
-      DNS threat counters + top-blocked widget land here in a follow-up PR. The data
-      endpoints (<code>/dns-security/stats</code>, <code>/dns-security/top-blocked</code>)
-      are already API-complete.
-    </div>
-  );
-}
-
-function EventsPlaceholder() {
-  return (
-    <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">
-      Threat events list (blocked-by-default with "show all" toggle) lands in a follow-up PR.
-      Backed by <code>GET /dns-security/events</code>.
-    </div>
-  );
-}

--- a/apps/web/src/components/dnsSecurity/DnsSecurityPoliciesTab.test.tsx
+++ b/apps/web/src/components/dnsSecurity/DnsSecurityPoliciesTab.test.tsx
@@ -1,0 +1,156 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DnsSecurityPoliciesTab from './DnsSecurityPoliciesTab';
+import { fetchWithAuth } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('../shared/Toast', () => ({
+  showToast: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+const showToastMock = vi.mocked(showToast);
+
+function makeJsonResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
+
+const samplePolicy = {
+  id: 'pol-1',
+  orgId: 'org-1',
+  integrationId: 'int-1',
+  integrationName: 'Acme Cloudflare',
+  provider: 'cloudflare',
+  name: 'Threat blocklist',
+  description: null,
+  type: 'blocklist' as const,
+  domains: [
+    { domain: 'malware.example.com' },
+    { domain: 'phish.example.com' },
+  ],
+  categories: null,
+  isActive: true,
+  syncStatus: 'synced',
+  lastSynced: '2026-05-22T20:00:00.000Z',
+};
+
+describe('DnsSecurityPoliciesTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the empty state when no policies exist', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ data: [] }));
+    render(<DnsSecurityPoliciesTab />);
+    await waitFor(() => {
+      expect(screen.getByText('No DNS policies configured')).toBeInTheDocument();
+    });
+  });
+
+  it('renders policy rows with type badge + domain count', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ data: [samplePolicy] }));
+    render(<DnsSecurityPoliciesTab />);
+    await waitFor(() => expect(screen.getByText('Threat blocklist')).toBeInTheDocument());
+    expect(screen.getByText('blocklist')).toBeInTheDocument();
+    expect(screen.getByText(/Acme Cloudflare/)).toBeInTheDocument();
+    expect(screen.getByText(/2 domains/)).toBeInTheDocument();
+  });
+
+  it('Expand → Add a single domain → PATCH .domains with the right add[] payload', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ data: [samplePolicy] }));
+    render(<DnsSecurityPoliciesTab />);
+    await waitFor(() => expect(screen.getByText('Threat blocklist')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Threat blocklist'));
+
+    // PATCH success then refetch
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ ok: true }));
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ data: [samplePolicy] }));
+
+    fireEvent.change(screen.getByLabelText(/Add domains/), {
+      target: { value: 'new-bad.example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Add$/ }));
+
+    await waitFor(() => {
+      const patchCall = fetchWithAuthMock.mock.calls.find(
+        ([, init]) => init?.method === 'PATCH',
+      );
+      expect(patchCall).toBeDefined();
+      const body = JSON.parse(String((patchCall as RequestInit[])?.[1]?.body));
+      expect(body).toEqual({ add: [{ domain: 'new-bad.example.com' }] });
+    });
+  });
+
+  it('Bulk paste with mixed separators de-dupes against existing + splits cleanly', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ data: [samplePolicy] }));
+    render(<DnsSecurityPoliciesTab />);
+    await waitFor(() => expect(screen.getByText('Threat blocklist')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Threat blocklist'));
+
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ ok: true }));
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ data: [samplePolicy] }));
+
+    // Mix newlines, commas, whitespace + a duplicate of an existing domain.
+    fireEvent.change(screen.getByLabelText(/Add domains/), {
+      target: {
+        value: 'a.example.com\nb.example.com, c.example.com  malware.example.com',
+      },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Add$/ }));
+
+    await waitFor(() => {
+      const patchCall = fetchWithAuthMock.mock.calls.find(
+        ([, init]) => init?.method === 'PATCH',
+      );
+      const body = JSON.parse(String((patchCall as RequestInit[])?.[1]?.body));
+      // malware.example.com is in the existing policy → filtered out.
+      expect(body).toEqual({
+        add: [
+          { domain: 'a.example.com' },
+          { domain: 'b.example.com' },
+          { domain: 'c.example.com' },
+        ],
+      });
+    });
+  });
+
+  it('Per-row trash button PATCHes remove[] with the deleted domain', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ data: [samplePolicy] }));
+    render(<DnsSecurityPoliciesTab />);
+    await waitFor(() => expect(screen.getByText('Threat blocklist')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Threat blocklist'));
+
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ ok: true }));
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ data: [samplePolicy] }));
+
+    fireEvent.click(screen.getByLabelText('Remove malware.example.com'));
+
+    await waitFor(() => {
+      const patchCall = fetchWithAuthMock.mock.calls.find(
+        ([, init]) => init?.method === 'PATCH',
+      );
+      const body = JSON.parse(String((patchCall as RequestInit[])?.[1]?.body));
+      expect(body).toEqual({ remove: ['malware.example.com'] });
+    });
+  });
+
+  it('Surfaces an inline error banner when the list endpoint fails', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({}, false, 500));
+    render(<DnsSecurityPoliciesTab />);
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/Failed to load policies/);
+    });
+    expect(showToastMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/dnsSecurity/DnsSecurityPoliciesTab.tsx
+++ b/apps/web/src/components/dnsSecurity/DnsSecurityPoliciesTab.tsx
@@ -1,0 +1,261 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Plus, Trash2, ListChecks } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, ActionError } from '../../lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+import AddDnsPolicyModal from './AddDnsPolicyModal';
+
+type PolicyType = 'blocklist' | 'allowlist';
+
+interface PolicyDomain {
+  domain: string;
+  reason?: string;
+  addedAt?: string;
+  addedBy?: string;
+}
+
+interface Policy {
+  id: string;
+  orgId: string;
+  integrationId: string;
+  integrationName: string;
+  provider: string;
+  name: string;
+  description: string | null;
+  type: PolicyType;
+  domains: PolicyDomain[];
+  categories: string[] | null;
+  isActive: boolean;
+  syncStatus: string | null;
+  lastSynced: string | null;
+}
+
+export default function DnsSecurityPoliciesTab() {
+  const [policies, setPolicies] = useState<Policy[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [domainDraft, setDomainDraft] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const fetchPolicies = useCallback(async (signal?: AbortSignal) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchWithAuth('/dns-security/policies', { signal });
+      if (!res.ok) {
+        if (res.status === 401) {
+          void navigateTo('/login', { replace: true });
+          return;
+        }
+        throw new Error(`Failed to load policies (HTTP ${res.status})`);
+      }
+      const body = await res.json();
+      setPolicies((body.data ?? []) as Policy[]);
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return;
+      setError(err instanceof Error ? err.message : 'Failed to load policies');
+    } finally {
+      if (!signal?.aborted) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetchPolicies(controller.signal);
+    return () => controller.abort();
+  }, [fetchPolicies]);
+
+  /**
+   * Apply add/remove changes to a policy's domain list. Both inputs are
+   * arrays so a single PATCH can do bulk paste + bulk delete atomically.
+   */
+  const patchDomains = async (
+    policyId: string,
+    delta: { add?: PolicyDomain[]; remove?: string[] }
+  ): Promise<void> => {
+    setBusy(true);
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/dns-security/policies/${policyId}/domains`, {
+          method: 'PATCH',
+          body: JSON.stringify(delta),
+        }),
+        errorFallback: 'Failed to update domains',
+        successMessage: 'Domains updated',
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+      await fetchPolicies();
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return;
+      // runAction already surfaced a toast; nothing else inline.
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  /**
+   * Add domains from the editor. Accepts a single domain OR a bulk paste
+   * (newline / comma / whitespace separated). Trims + filters empties +
+   * de-dupes against the existing list before sending.
+   */
+  const handleAddDomains = async (policy: Policy) => {
+    const raw = domainDraft.trim();
+    if (!raw) return;
+    const existing = new Set(policy.domains.map((d) => d.domain.toLowerCase()));
+    const incoming = raw
+      .split(/[\s,]+/)
+      .map((s) => s.trim().toLowerCase())
+      .filter((s) => s.length > 0 && s.length <= 500 && !existing.has(s));
+    if (incoming.length === 0) {
+      setDomainDraft('');
+      return;
+    }
+    await patchDomains(policy.id, {
+      add: incoming.map((domain) => ({ domain })),
+    });
+    setDomainDraft('');
+  };
+
+  const handleRemoveDomain = async (policy: Policy, domain: string) => {
+    await patchDomains(policy.id, { remove: [domain] });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-medium">Block / Allow policies</h2>
+        <button
+          type="button"
+          onClick={() => setShowAddModal(true)}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          <Plus className="h-4 w-4" />
+          New policy
+        </button>
+      </div>
+
+      {error && (
+        <div role="alert" className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center gap-2 rounded-md border bg-card px-4 py-6 text-sm text-muted-foreground">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          Loading policies…
+        </div>
+      ) : policies.length === 0 ? (
+        <div className="rounded-md border border-dashed bg-card px-4 py-8 text-center">
+          <ListChecks className="mx-auto h-8 w-8 text-muted-foreground" />
+          <p className="mt-2 text-sm font-medium">No DNS policies configured</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Create a blocklist or allowlist tied to one of your DNS integrations.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {policies.map((policy) => {
+            const isExpanded = expandedId === policy.id;
+            return (
+              <div key={policy.id} className="rounded-md border bg-card">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setDomainDraft('');
+                    setExpandedId(isExpanded ? null : policy.id);
+                  }}
+                  className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-muted/30"
+                >
+                  <div>
+                    <div className="text-sm font-medium">
+                      {policy.name}{' '}
+                      <span
+                        className={`ml-2 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                          policy.type === 'blocklist'
+                            ? 'bg-destructive/15 text-destructive'
+                            : 'bg-success/15 text-success'
+                        }`}
+                      >
+                        {policy.type}
+                      </span>
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      {policy.integrationName} · {policy.domains.length} domain
+                      {policy.domains.length === 1 ? '' : 's'}
+                    </div>
+                  </div>
+                  <span className="text-xs text-muted-foreground">
+                    {isExpanded ? 'Hide' : 'Edit domains'}
+                  </span>
+                </button>
+
+                {isExpanded && (
+                  <div className="border-t px-4 py-3 space-y-3">
+                    {policy.domains.length === 0 ? (
+                      <p className="text-xs text-muted-foreground italic">No domains yet.</p>
+                    ) : (
+                      <ul className="space-y-1 max-h-64 overflow-y-auto rounded border bg-muted/20 p-2 text-sm">
+                        {policy.domains.map((d) => (
+                          <li key={d.domain} className="flex items-center justify-between gap-2 px-2 py-1">
+                            <span className="font-mono text-xs">{d.domain}</span>
+                            <button
+                              type="button"
+                              onClick={() => handleRemoveDomain(policy, d.domain)}
+                              disabled={busy}
+                              className="inline-flex h-6 w-6 items-center justify-center rounded text-destructive hover:bg-destructive/10 disabled:opacity-50"
+                              aria-label={`Remove ${d.domain}`}
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+
+                    <div className="space-y-1">
+                      <label className="block text-xs font-medium" htmlFor={`add-domains-${policy.id}`}>
+                        Add domains
+                        <span className="ml-1 font-normal text-muted-foreground">
+                          (one per line, comma-separated, or paste a list)
+                        </span>
+                      </label>
+                      <textarea
+                        id={`add-domains-${policy.id}`}
+                        rows={3}
+                        value={domainDraft}
+                        onChange={(e) => setDomainDraft(e.target.value)}
+                        placeholder={'malware.example.com\nphish.example.com'}
+                        className="w-full rounded-md border bg-background px-2 py-1.5 font-mono text-xs"
+                      />
+                      <div className="flex justify-end">
+                        <button
+                          type="button"
+                          onClick={() => handleAddDomains(policy)}
+                          disabled={busy || !domainDraft.trim()}
+                          className="inline-flex items-center gap-1 rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                        >
+                          <Plus className="h-3.5 w-3.5" />
+                          Add
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {showAddModal && (
+        <AddDnsPolicyModal
+          onClose={() => setShowAddModal(false)}
+          onCreated={() => void fetchPolicies()}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -121,6 +121,7 @@ const navSections: NavSection[] = [
     items: [
       { name: 'Network Monitor', href: '/monitoring', icon: Activity },
       { name: 'Security', href: '/security', icon: ShieldCheck },
+      { name: 'DNS Security', href: '/dns-security', icon: Network },
       { name: 'Sensitive Data', href: '/sensitive-data', icon: ScanSearch },
       { name: 'Peripherals', href: '/peripherals', icon: Usb },
       { name: 'AI Risk Engine', href: '/ai-risk', icon: BrainCircuit },

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -33,6 +33,7 @@ const TARGET_GLOBS = [
   'src/components/patches/PatchesPage.tsx',
   'src/components/settings/RolesPage.tsx',
   'src/components/devices/DeviceInfoTab.tsx',
+  'src/components/dnsSecurity/DnsSecurityIntegrationsTab.tsx',
 ];
 
 const absoluteFiles: string[] = TARGET_GLOBS.map((rel) => resolve(WEB_ROOT, '..', rel));
@@ -224,7 +225,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(5);
+    expect(absoluteFiles.length).toBe(6);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -35,6 +35,8 @@ const TARGET_GLOBS = [
   'src/components/devices/DeviceInfoTab.tsx',
   'src/components/dnsSecurity/DnsSecurityIntegrationsTab.tsx',
   'src/components/dnsSecurity/AddDnsIntegrationModal.tsx',
+  'src/components/dnsSecurity/DnsSecurityPoliciesTab.tsx',
+  'src/components/dnsSecurity/AddDnsPolicyModal.tsx',
 ];
 
 const absoluteFiles: string[] = TARGET_GLOBS.map((rel) => resolve(WEB_ROOT, '..', rel));

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -228,7 +228,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(7);
+    expect(absoluteFiles.length).toBe(8);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -228,7 +228,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(8);
+    expect(absoluteFiles.length).toBe(9);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -34,6 +34,7 @@ const TARGET_GLOBS = [
   'src/components/settings/RolesPage.tsx',
   'src/components/devices/DeviceInfoTab.tsx',
   'src/components/dnsSecurity/DnsSecurityIntegrationsTab.tsx',
+  'src/components/dnsSecurity/AddDnsIntegrationModal.tsx',
 ];
 
 const absoluteFiles: string[] = TARGET_GLOBS.map((rel) => resolve(WEB_ROOT, '..', rel));
@@ -225,7 +226,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(6);
+    expect(absoluteFiles.length).toBe(7);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/pages/dns-security.astro
+++ b/apps/web/src/pages/dns-security.astro
@@ -1,0 +1,8 @@
+---
+import DashboardLayout from '../layouts/DashboardLayout.astro';
+import DnsSecurityPage from '../components/dnsSecurity/DnsSecurityPage';
+---
+
+<DashboardLayout title="DNS Security">
+  <DnsSecurityPage client:load />
+</DashboardLayout>


### PR DESCRIPTION
## Summary

End-to-end web UI for the DNS Security feature (#828). Sidebar entry under Security → DNS Security, dedicated `/dns-security` page with 4 hash-routed tabs that exercise every backend endpoint shipped in #797 / #846 / #843.

**Previous PR description called this a "scaffold" with stub modals — the diff actually ships fully functional tabs, both modals, and complete `runAction` adoption.** Reframing per Todd's #847 review so the file count + LOC matches the description.

## What's in this PR

| Tab | File | Lines | What works |
|---|---|---|---|
| Integrations | `DnsSecurityIntegrationsTab.tsx` | ~210 | List integrations; per-row Sync + Delete via `runAction`. |
| Add Integration | `AddDnsIntegrationModal.tsx` | ~321 | Provider-aware form for all 5 supported providers (umbrella, cloudflare, dnsfilter, pihole, adguard_home). Provider-specific config fields (e.g. Cloudflare account_id, AdGuard Home username+password+endpoint). Password fields, validation. `runAction` POST. |
| Policies | `DnsSecurityPoliciesTab.tsx` | ~261 | Expandable rows. Per-domain trash via `PATCH /policies/:id/domains { remove: [...] }`. Bulk-paste add via `{ add: [...] }`. De-dupes against existing domains in the dialog. |
| Add Policy | `AddDnsPolicyModal.tsx` | ~257 | Integration picker fetching `/integrations`. Bulk-paste initial domain list with split + dedup + 500-row cap. `runAction` POST. |
| Events | `DnsSecurityEventsTab.tsx` | ~171 | Full table render. Defaults to `action=blocked` filter. "Show all" toggle re-fetches without the filter. AbortController wired through. |
| Overview | `DnsSecurityOverviewTab.tsx` | ~181 | 4 stat cards from `/stats` + Top Blocked widget from `/top-blocked`. Parallel fetch, partial-failure tolerance. |

Plus:
- `DnsSecurityPage.tsx` — 4-tab shell with hash routing (matches `DeviceDetails.tsx` convention)
- `Sidebar.tsx` — new "DNS Security" entry under the Security section
- `apps/web/src/pages/dns-security.astro` — page mount
- `no-silent-mutations.test.ts` — TARGET_GLOBS bumped 4→8 (the 4 new mutation-using DNS files + `RolesPage.tsx` from #840 which landed in main between #847 v1 and now)

## What changed since Todd's review

- **Both modals now route through `apps/web/src/components/shared/Dialog.tsx`** instead of the hand-rolled wrappers. Restores focus trap, Escape-to-close, body scroll-lock, portal rendering, `aria-modal`/`role="dialog"` semantics — matches every other modal in the codebase (DeviceSettingsModal, MonitorDetailModal, RemediationModal, CreateScanModal, PatchApprovalModal, BaselineFormModal, all 3 DR modals).
- **`AddDnsPolicyModal.fetchIntegrations` wrapped in try/catch** — matches the sibling-tab pattern (silent on `AbortError`, surfaces other errors to the inline error UI).

## Test

```
Test Files  5 passed (5)
      Tests  23 passed (23)
```

All dnsSecurity vitest cases pass after the Dialog refactor (testing-library queries still resolve through the portal — verified by re-running AddDnsIntegrationModal tests). `tsc --noEmit` clean. `no-silent-mutations` guard still green with the new entries.

## Refs

- Closes #828 (UI side)
- Depends on no other PRs (backend endpoints from #797 / #846 / #833 are already in main)