### PR TITLE
fix(agent): harden in-place upgrade — PS error handling + temp cleanup + doc fixes (#845 follow-up)

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -3055,9 +3055,17 @@ func (h *Heartbeat) doUpgrade(targetVersion string) {
 	// fallback every ~30s, and orphaned processes accumulate during heartbeat
 	// goroutine wedges until the service dies.
 	//
-	// 404 / network / checksum errors are non-fatal: we log and proceed with
-	// an agent-only upgrade (no regression vs. pre-#816 behavior), which
-	// matters for releases that don't yet ship the user-helper artifact.
+	// ANY download failure is non-fatal — we log a WARN and proceed with an
+	// agent-only upgrade. This is intentional and covers more than just 404s
+	// (manifest signature failure, auth-token expiry, JSON decode error, FS
+	// write error, etc. all land here):
+	//   (a) pre-#816 releases legitimately lack the user-helper artifact, so
+	//       we don't want to block their upgrades, and
+	//   (b) we'd rather degrade than fail an agent upgrade on a transient
+	//       helper-fetch glitch.
+	// `currentVersion` is included in the WARN so operators can tell the
+	// "legitimately pre-#816, ignore" case apart from the "this release SHOULD
+	// have shipped the artifact, something's broken" case.
 	userHelperTempPath := ""
 	userHelperTargetPath := ""
 	if runtime.GOOS == "windows" {
@@ -3072,6 +3080,7 @@ func (h *Heartbeat) doUpgrade(targetVersion string) {
 		if tempPath, dlErr := helperUpdater.DownloadBinary(targetVersion); dlErr != nil {
 			log.Warn(
 				"user-helper download failed; proceeding with agent-only upgrade",
+				"currentVersion", h.agentVersion,
 				"targetVersion", targetVersion,
 				"error", dlErr.Error(),
 			)

--- a/agent/internal/updater/restart_windows.go
+++ b/agent/internal/updater/restart_windows.go
@@ -98,38 +98,93 @@ type restartScriptOptions struct {
 // for backward-compatible behavior when the user-helper paths are unset
 // (issue #816). Single-quote escaping doubles single quotes, matching the
 // established convention for the agent path.
+//
+// Error handling: PowerShell's Copy-Item is a non-terminating cmdlet by
+// default — a failed Copy (locked file, ACL denied, disk full) does NOT
+// stop the script, so without `$ErrorActionPreference = 'Stop'` + try/catch,
+// we'd swallow the failure and proceed to Start-Service, ending up with the
+// new agent paired with a stale or missing user-helper — exactly the
+// partial-success state #816 was filed against. The generated script:
+//   - sets `$ErrorActionPreference = 'Stop'` globally,
+//   - wraps the swap block (Stop-Service / Stop-Process / Copy-Item agent /
+//     Copy-Item user-helper) in a single try/catch,
+//   - logs Exception.Message / StackTrace / ScriptStackTrace + a named
+//     "operation" tag to `${env:TEMP}\breeze-update-failure-<unix>.log` on
+//     failure (TEMP always exists; ProgramData may not on fresh installs —
+//     see #609),
+//   - always falls through to Start-Service afterwards so the host doesn't
+//     end with the service stopped (catch path attempts start too — if the
+//     partial swap left a corrupt agent, the start may fail, but at least
+//     we've tried and the failure log captures the cause),
+//   - keeps Remove-Item cleanups outside the try/catch so they always run.
 func buildRestartScript(opts restartScriptOptions) string {
 	safeAgent := strings.ReplaceAll(opts.AgentTempPath, "'", "''")
 	safeAgentTarget := strings.ReplaceAll(opts.AgentTargetPath, "'", "''")
 
-	lines := []string{
-		"Start-Sleep -Seconds 3",
-		// Stop the agent service first
-		"Stop-Service -Name '" + serviceName + "' -Force -ErrorAction SilentlyContinue",
-		// Kill any lingering breeze processes (helper, viewer, user helpers)
-		// that might hold file locks on the binary or shared directory.
-		"Get-Process -Name 'breeze-helper','breeze-agent','breeze-user-helper','breeze-viewer' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue",
-		"Start-Sleep -Seconds 2",
-		fmt.Sprintf("Copy-Item -Path '%s' -Destination '%s' -Force", safeAgent, safeAgentTarget),
+	hasHelper := opts.UserHelperTempPath != "" && opts.UserHelperTargetPath != ""
+	var safeHelper, safeHelperTarget string
+	if hasHelper {
+		safeHelper = strings.ReplaceAll(opts.UserHelperTempPath, "'", "''")
+		safeHelperTarget = strings.ReplaceAll(opts.UserHelperTargetPath, "'", "''")
 	}
 
-	// Optionally swap in the user-helper too. Skipped when the caller didn't
-	// pre-download it (pre-#816 release, network failure, 404, etc.) — the
-	// agent-only upgrade still succeeds in that case.
-	if opts.UserHelperTempPath != "" && opts.UserHelperTargetPath != "" {
-		safeHelper := strings.ReplaceAll(opts.UserHelperTempPath, "'", "''")
-		safeHelperTarget := strings.ReplaceAll(opts.UserHelperTargetPath, "'", "''")
+	lines := []string{
+		// Make all errors in the swap block terminating so try/catch can
+		// actually catch a failed Copy-Item. Without this, Copy-Item is
+		// non-terminating and a write failure would silently regress to
+		// the pre-#816 bug (new agent + stale/missing user-helper).
+		"$ErrorActionPreference = 'Stop'",
+		"Start-Sleep -Seconds 3",
+		"try {",
+		// Stop the agent service first. We OPT OUT of -ErrorAction Stop here
+		// because the service may not exist on some test paths and that
+		// shouldn't fail the script.
+		"  Stop-Service -Name '" + serviceName + "' -Force -ErrorAction SilentlyContinue",
+		// Kill any lingering breeze processes (helper, viewer, user helpers)
+		// that might hold file locks on the binary or shared directory.
+		"  Get-Process -Name 'breeze-helper','breeze-agent','breeze-user-helper','breeze-viewer' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue",
+		"  Start-Sleep -Seconds 2",
+		fmt.Sprintf("  Copy-Item -Path '%s' -Destination '%s' -Force", safeAgent, safeAgentTarget),
+	}
+
+	// Ordering: the agent Copy MUST come before the helper Copy. A partial
+	// failure that stops between the two leaves a working (if pre-#816)
+	// install rather than the helper-installed-but-agent-stale state #816
+	// was filed against. (See restart_windows_test.go's ordering test.)
+	if hasHelper {
 		lines = append(lines,
-			fmt.Sprintf("Copy-Item -Path '%s' -Destination '%s' -Force", safeHelper, safeHelperTarget),
+			fmt.Sprintf("  Copy-Item -Path '%s' -Destination '%s' -Force", safeHelper, safeHelperTarget),
 		)
 	}
 
 	lines = append(lines,
-		"Start-Service -Name '"+serviceName+"'",
+		// Success path: start the service.
+		"  Start-Service -Name '"+serviceName+"'",
+		"} catch {",
+		// Failure path: log structured diagnostics. ${env:TEMP} always exists
+		// on Windows (unlike C:\ProgramData\Breeze, which may not exist yet
+		// on a fresh install — see #609 / HardenProgramDataAcl sequencing).
+		"  $stamp = [int][double]::Parse((Get-Date -UFormat %s))",
+		"  $logPath = Join-Path $env:TEMP (\"breeze-update-failure-$stamp.log\")",
+		"  $op = if ($_.InvocationInfo) { $_.InvocationInfo.Line } else { '<unknown>' }",
+		"  $msg = @(",
+		"    \"Breeze update-helper failure at $(Get-Date -Format o)\",",
+		"    \"operation: $op\",",
+		"    \"exception: $($_.Exception.Message)\",",
+		"    \"stackTrace: $($_.Exception.StackTrace)\",",
+		"    \"scriptStackTrace: $($_.ScriptStackTrace)\"",
+		"  ) -join \"`r`n\"",
+		"  $msg | Out-File -FilePath $logPath -Append -Encoding utf8",
+		// Always attempt Start-Service afterwards so we don't leave the host
+		// with the service stopped. If the partial Copy corrupted the agent,
+		// this start may fail too — that's OK, the log above captures why.
+		"  Start-Service -Name '"+serviceName+"' -ErrorAction SilentlyContinue",
+		"}",
+		// Cleanup OUTSIDE the try/catch — these should always run regardless
+		// of swap success or failure, and Remove-Item is best-effort anyway.
 		fmt.Sprintf("Remove-Item -Path '%s' -Force -ErrorAction SilentlyContinue", safeAgent),
 	)
-	if opts.UserHelperTempPath != "" && opts.UserHelperTargetPath != "" {
-		safeHelper := strings.ReplaceAll(opts.UserHelperTempPath, "'", "''")
+	if hasHelper {
 		lines = append(lines,
 			fmt.Sprintf("Remove-Item -Path '%s' -Force -ErrorAction SilentlyContinue", safeHelper),
 		)

--- a/agent/internal/updater/restart_windows_test.go
+++ b/agent/internal/updater/restart_windows_test.go
@@ -28,6 +28,149 @@ func TestBuildRestartScript_AgentOnly(t *testing.T) {
 	}
 }
 
+// TestBuildRestartScript_ErrorActionPreference asserts the generated script
+// makes Copy-Item failures terminating. Without this, a Copy-Item failure
+// during the swap would not propagate into the try/catch and the script
+// would silently regress to the pre-#816 partial-success state.
+func TestBuildRestartScript_ErrorActionPreference(t *testing.T) {
+	got := buildRestartScript(restartScriptOptions{
+		AgentTempPath:   `C:\tmp\agent.exe`,
+		AgentTargetPath: `C:\Program Files\Breeze\breeze-agent.exe`,
+	})
+	if !strings.Contains(got, "$ErrorActionPreference = 'Stop'") {
+		t.Fatalf("expected $ErrorActionPreference = 'Stop'; script was:\n%s", got)
+	}
+}
+
+// TestBuildRestartScript_TryCatchWrapsSwap asserts the swap block (Copy-Item
+// calls etc.) is wrapped in a single try { … } catch { … } so a failed Copy
+// produces a structured failure log instead of a silent agent-only outcome.
+func TestBuildRestartScript_TryCatchWrapsSwap(t *testing.T) {
+	got := buildRestartScript(restartScriptOptions{
+		AgentTempPath:        `C:\tmp\agent.exe`,
+		AgentTargetPath:      `C:\Program Files\Breeze\breeze-agent.exe`,
+		UserHelperTempPath:   `C:\tmp\helper.exe`,
+		UserHelperTargetPath: `C:\Program Files\Breeze\breeze-user-helper.exe`,
+	})
+
+	tryIdx := strings.Index(got, "try {")
+	catchIdx := strings.Index(got, "} catch {")
+	if tryIdx < 0 {
+		t.Fatalf("expected `try {` opener; script was:\n%s", got)
+	}
+	if catchIdx <= tryIdx {
+		t.Fatalf("expected `} catch {` after `try {`; script was:\n%s", got)
+	}
+
+	// Both Copy-Item calls must live inside the try block (i.e. between the
+	// `try {` opener and the `} catch {` line).
+	agentCopy := `Copy-Item -Path 'C:\tmp\agent.exe' -Destination 'C:\Program Files\Breeze\breeze-agent.exe' -Force`
+	helperCopy := `Copy-Item -Path 'C:\tmp\helper.exe' -Destination 'C:\Program Files\Breeze\breeze-user-helper.exe' -Force`
+	agentIdx := strings.Index(got, agentCopy)
+	helperIdx := strings.Index(got, helperCopy)
+	if agentIdx < tryIdx || agentIdx > catchIdx {
+		t.Fatalf("agent Copy-Item must be inside try { … } catch; script was:\n%s", got)
+	}
+	if helperIdx < tryIdx || helperIdx > catchIdx {
+		t.Fatalf("helper Copy-Item must be inside try { … } catch; script was:\n%s", got)
+	}
+}
+
+// TestBuildRestartScript_StartServiceInBothPaths verifies Start-Service is
+// invoked in BOTH the try-success path (inside the try { … }) AND the catch
+// path (so a partial-Copy failure still leaves the host with a service
+// start attempt — better to fail the start with a corrupt agent than to
+// leave the service stopped indefinitely).
+func TestBuildRestartScript_StartServiceInBothPaths(t *testing.T) {
+	got := buildRestartScript(restartScriptOptions{
+		AgentTempPath:   `C:\tmp\agent.exe`,
+		AgentTargetPath: `C:\Program Files\Breeze\breeze-agent.exe`,
+	})
+
+	// Count Start-Service invocations on the BreezeAgent service — must be 2
+	// (one in try-path, one in catch-path). Test by substring count.
+	const needle = "Start-Service -Name 'BreezeAgent'"
+	count := strings.Count(got, needle)
+	if count != 2 {
+		t.Fatalf("expected Start-Service to appear twice (try + catch); got %d. Script was:\n%s", count, got)
+	}
+
+	// The catch-path Start-Service must use -ErrorAction SilentlyContinue
+	// (since `$ErrorActionPreference = 'Stop'` is set globally and we DON'T
+	// want a failed start inside the catch to re-throw and skip cleanup).
+	if !strings.Contains(got, "Start-Service -Name 'BreezeAgent' -ErrorAction SilentlyContinue") {
+		t.Fatalf("expected catch-path Start-Service with -ErrorAction SilentlyContinue; script was:\n%s", got)
+	}
+}
+
+// TestBuildRestartScript_FailureLogUsesTemp verifies the structured failure
+// log goes to ${env:TEMP}, not a hardcoded drive letter or
+// C:\ProgramData\Breeze (which may not exist yet on a fresh install — see
+// #609). %TEMP% is guaranteed to exist on any Windows host.
+func TestBuildRestartScript_FailureLogUsesTemp(t *testing.T) {
+	got := buildRestartScript(restartScriptOptions{
+		AgentTempPath:   `C:\tmp\agent.exe`,
+		AgentTargetPath: `C:\Program Files\Breeze\breeze-agent.exe`,
+	})
+
+	if !strings.Contains(got, "$env:TEMP") {
+		t.Fatalf("expected failure log path to reference $env:TEMP; script was:\n%s", got)
+	}
+	if !strings.Contains(got, "breeze-update-failure-") {
+		t.Fatalf("expected failure log filename pattern breeze-update-failure-<stamp>.log; script was:\n%s", got)
+	}
+	// `Out-File -Append -Encoding utf8` is the spec'd write call.
+	if !strings.Contains(got, "Out-File") || !strings.Contains(got, "-Append") || !strings.Contains(got, "-Encoding utf8") {
+		t.Fatalf("expected Out-File -Append -Encoding utf8 for the failure log; script was:\n%s", got)
+	}
+	// Defense-in-depth: no hardcoded C:\ProgramData log path crept in.
+	if strings.Contains(got, `C:\ProgramData\Breeze\breeze-update-failure`) {
+		t.Fatalf("failure log must not be written under C:\\ProgramData\\Breeze (may not exist on fresh installs); script was:\n%s", got)
+	}
+}
+
+// TestBuildRestartScript_CleanupOutsideTryCatch asserts the Remove-Item
+// cleanup lines run regardless of swap success/failure — they must live
+// AFTER the closing `}` of the catch block, not inside try or catch.
+func TestBuildRestartScript_CleanupOutsideTryCatch(t *testing.T) {
+	got := buildRestartScript(restartScriptOptions{
+		AgentTempPath:        `C:\tmp\agent.exe`,
+		AgentTargetPath:      `C:\Program Files\Breeze\breeze-agent.exe`,
+		UserHelperTempPath:   `C:\tmp\helper.exe`,
+		UserHelperTargetPath: `C:\Program Files\Breeze\breeze-user-helper.exe`,
+	})
+
+	// Find the close of the catch block: the literal "\n}\r\n" — i.e. the
+	// catch-closing brace must be followed by the cleanup Remove-Item lines.
+	// Match the position of the catch-closing brace as the first standalone
+	// "}" that follows the `} catch {` opener.
+	catchOpenerIdx := strings.Index(got, "} catch {")
+	if catchOpenerIdx < 0 {
+		t.Fatalf("expected `} catch {`; script was:\n%s", got)
+	}
+	// The closing `}` of the catch is the next `}` AFTER `} catch {`'s `{`.
+	closeIdx := strings.Index(got[catchOpenerIdx+len("} catch {"):], "\n}")
+	if closeIdx < 0 {
+		t.Fatalf("expected catch-block closing `}`; script was:\n%s", got)
+	}
+	catchCloseIdx := catchOpenerIdx + len("} catch {") + closeIdx
+
+	// All Remove-Item lines must appear AFTER the catch close.
+	for _, needle := range []string{
+		`Remove-Item -Path 'C:\tmp\agent.exe' -Force -ErrorAction SilentlyContinue`,
+		`Remove-Item -Path 'C:\tmp\helper.exe' -Force -ErrorAction SilentlyContinue`,
+		"Remove-Item -Path $PSCommandPath -Force -ErrorAction SilentlyContinue",
+	} {
+		idx := strings.Index(got, needle)
+		if idx < 0 {
+			t.Fatalf("missing cleanup line %q; script was:\n%s", needle, got)
+		}
+		if idx < catchCloseIdx {
+			t.Fatalf("cleanup line %q must appear after catch block close; script was:\n%s", needle, got)
+		}
+	}
+}
+
 // TestBuildRestartScript_WithUserHelper verifies that when both user-helper
 // paths are provided the generated script emits a second Copy-Item AFTER the
 // agent's and includes a cleanup step for the helper temp file. The ordering

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -47,9 +47,18 @@ type Config struct {
 type Updater struct {
 	config *Config
 	client *http.Client
-	// extras is set by UpdateToWithCompanions / UpdateFromURLWithCompanions
-	// to forward companion-binary paths (e.g. breeze-user-helper.exe) into
-	// the Windows restart helper. Not user-visible. Issue #816.
+	// extras is set by UpdateToWithUserHelper to forward companion-binary
+	// paths (e.g. breeze-user-helper.exe) into the Windows restart helper.
+	// Not user-visible. Issue #816.
+	//
+	// Asymmetry note (footgun): UpdateFromURL (the dev_push path) also
+	// reads u.extras when it calls RestartWithHelper on Windows, but there
+	// is no UpdateFromURLWithUserHelper wrapper. A dev-push caller that
+	// wants a helper swap on that path has to mutate u.extras directly.
+	// Currently no dev-push caller does this — the surface is flagged here
+	// so a future addition doesn't silently no-op the helper field. The
+	// upcoming type-design refactor (PR B of the #845 follow-up series)
+	// will fold this into an explicit options struct.
 	extras updateExtras
 }
 
@@ -63,8 +72,12 @@ func New(cfg *Config) *Updater {
 
 // updateExtras carries optional companion-binary info into the Windows
 // restart helper. It is set transiently via the Updater's exported
-// UpdateToWithCompanions / UpdateFromURLWithCompanions wrappers so the
-// existing UpdateTo signature stays stable. Issue #816.
+// UpdateToWithUserHelper wrapper so the existing UpdateTo signature stays
+// stable. Issue #816.
+//
+// Note: only UpdateToWithUserHelper exists today — UpdateFromURL (dev-push)
+// has no companion-setter wrapper but still consumes u.extras when it
+// builds the Windows restart script. See the field comment on Updater.
 type updateExtras struct {
 	userHelperTempPath   string
 	userHelperTargetPath string
@@ -553,6 +566,16 @@ func (u *Updater) verifyReleaseArtifactManifest(payload []byte, info downloadInf
 // temp-file path on success after verifying the downloaded bytes against
 // the signed manifest checksum. The caller is responsible for cleanup.
 // Issue #816.
+//
+// Note on the second verifyChecksum: internal downloadBinary verifies the
+// signed MANIFEST (the JSON payload's Ed25519 signature) but does NOT
+// verify the downloaded FILE bytes against manifest.Checksum — that
+// file-checksum verification is done by callers of downloadBinary
+// (e.g. UpdateTo does its own verify post-write). DownloadBinary, as an
+// exported method, performs the file-checksum verification HERE so
+// exported callers get a verified file without having to know about the
+// manifest-vs-file distinction. The second verify is intentional and a
+// future simplifier should not delete it as "redundant".
 func (u *Updater) DownloadBinary(version string) (string, error) {
 	tempPath, manifest, err := u.downloadBinary(version)
 	if err != nil {

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -254,10 +254,21 @@ func writeUpdateMarker(version string) {
 // restart helper to copy a freshly-downloaded breeze-user-helper.exe into
 // place alongside the agent. Empty paths fall back to agent-only behavior.
 // Issue #816.
+//
+// Cleanup contract: on UpdateTo failure, the user-helper temp file is
+// removed here too. UpdateTo's own error branches only know about the agent
+// tempPath, so without this cleanup the pre-downloaded helper would orphan
+// in %TEMP% on every failed upgrade. On success (UpdateTo returns nil) we
+// intentionally leave the file in place — the spawned restart script owns
+// it and removes it after the swap.
 func (u *Updater) UpdateToWithUserHelper(version, userHelperTempPath, userHelperTargetPath string) error {
 	u.extras.userHelperTempPath = userHelperTempPath
 	u.extras.userHelperTargetPath = userHelperTargetPath
-	return u.UpdateTo(version)
+	err := u.UpdateTo(version)
+	if err != nil && userHelperTempPath != "" {
+		removeCleanup(userHelperTempPath)
+	}
+	return err
 }
 
 // UpdateTo downloads and installs a new version
@@ -304,6 +315,13 @@ func (u *Updater) UpdateTo(version string) error {
 		// agent-only swap (backward compatible). Issue #816.
 		if err := RestartWithHelper(tempPath, u.config.BinaryPath, u.extras.userHelperTempPath, u.extras.userHelperTargetPath); err != nil {
 			removeCleanup(tempPath)
+			// The user-helper temp was pre-downloaded by the caller before
+			// UpdateTo was invoked; if we never spawned the restart script,
+			// nothing will ever clean it up. Mirror the agent tempPath
+			// cleanup so failed spawns don't leak helper temps in %TEMP%.
+			if u.extras.userHelperTempPath != "" {
+				removeCleanup(u.extras.userHelperTempPath)
+			}
 			if rbErr := u.Rollback(); rbErr != nil {
 				log.Error("rollback also failed", "originalError", err, "rollbackError", rbErr)
 			}

--- a/agent/internal/updater/updater_test.go
+++ b/agent/internal/updater/updater_test.go
@@ -1000,3 +1000,76 @@ func TestExpectedReleaseAssetNames_Agent(t *testing.T) {
 		t.Fatalf("expected %q in agent asset name set, got %v", expected, got)
 	}
 }
+
+// TestUpdateToWithUserHelper_CleansHelperTempOnFailure regression-tests the
+// fix for the orphan-temp-file bug flagged in the #845 follow-up review:
+// when UpdateTo returns an error AND the caller pre-downloaded a user-helper
+// to `userHelperTempPath`, the temp file must be removed. Before the fix
+// only the agent temp was cleaned up, leaking the helper temp in %TEMP%
+// on every failed upgrade.
+//
+// We force UpdateTo to fail by giving it no AuthToken — downloadBinary
+// returns "auth token not available" immediately on every platform.
+func TestUpdateToWithUserHelper_CleansHelperTempOnFailure(t *testing.T) {
+	// Synthesize a "pre-downloaded user-helper" tempfile. The test owns the
+	// file; UpdateToWithUserHelper is expected to remove it on UpdateTo failure.
+	helperTemp, err := os.CreateTemp("", "breeze-user-helper-leak-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	helperTemp.Close()
+	helperTempPath := helperTemp.Name()
+	// Best-effort cleanup if the test fails (we expect the SUT to do this).
+	t.Cleanup(func() { _ = os.Remove(helperTempPath) })
+
+	// On non-Windows, UpdateTo's first step (checkWritable) would fail before
+	// we get to the AuthToken check. Use a path that exists and is writable
+	// so we DO reach downloadBinary and fail there with "auth token not
+	// available" — exercises the same UpdateTo error-return path on every OS.
+	binaryFile, err := os.CreateTemp("", "breeze-agent-bin-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	binaryFile.Close()
+	t.Cleanup(func() { _ = os.Remove(binaryFile.Name()) })
+
+	u := New(&Config{
+		ServerURL:  "http://localhost:0",
+		BinaryPath: binaryFile.Name(),
+		BackupPath: binaryFile.Name() + ".backup",
+		// AuthToken intentionally nil — forces downloadBinary to return early.
+	})
+
+	err = u.UpdateToWithUserHelper("9.9.9", helperTempPath, `C:\target\breeze-user-helper.exe`)
+	if err == nil {
+		t.Fatal("expected UpdateTo to fail (no auth token configured)")
+	}
+
+	if _, statErr := os.Stat(helperTempPath); !os.IsNotExist(statErr) {
+		t.Fatalf("user-helper temp file should be removed on UpdateTo failure; got stat err=%v", statErr)
+	}
+}
+
+// TestUpdateToWithUserHelper_NoHelperTempPathIsNoOp guards against a
+// regression where the new cleanup branch fires when no helper-temp was
+// ever passed (call path: agent-only upgrade on a release that doesn't
+// ship the user-helper artifact). It must not error or panic.
+func TestUpdateToWithUserHelper_NoHelperTempPathIsNoOp(t *testing.T) {
+	binaryFile, err := os.CreateTemp("", "breeze-agent-bin-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	binaryFile.Close()
+	t.Cleanup(func() { _ = os.Remove(binaryFile.Name()) })
+
+	u := New(&Config{
+		ServerURL:  "http://localhost:0",
+		BinaryPath: binaryFile.Name(),
+		BackupPath: binaryFile.Name() + ".backup",
+	})
+
+	// Empty userHelperTempPath should leave the cleanup branch dormant.
+	if err := u.UpdateToWithUserHelper("9.9.9", "", ""); err == nil {
+		t.Fatal("expected UpdateTo to fail (no auth token configured)")
+	}
+}

--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -509,7 +509,17 @@ export async function syncFromGitHub(
       fallbackChecksums,
       releaseTag: release.tag_name,
     });
-    if (!metadata) continue;
+    if (!metadata) {
+      // `!asset` above is silent (legitimate "release predates this artifact"
+      // case). `!metadata` is different: the asset IS in the release but its
+      // checksum could not be resolved from the trusted manifest or the
+      // fallback checksums file. That's an unexpected manifest/checksums
+      // inconsistency the on-call should be told about — don't skip silently.
+      console.warn(
+        `[binarySync] Missing metadata for agent asset (release=${release.tag_name}, asset=${assetName}, component=agent); skipping`,
+      );
+      continue;
+    }
     const platform = GH_PLATFORM_MAP[target.goos];
     if (!platform) continue;
 
@@ -542,7 +552,14 @@ export async function syncFromGitHub(
       fallbackChecksums,
       releaseTag: release.tag_name,
     });
-    if (!metadata) continue;
+    if (!metadata) {
+      // See agent loop above: `!metadata` after `!asset` passed indicates an
+      // unexpected manifest/checksums inconsistency, not a missing artifact.
+      console.warn(
+        `[binarySync] Missing metadata for helper asset (release=${release.tag_name}, asset=${target.assetName}, component=helper); skipping`,
+      );
+      continue;
+    }
     const platform = GH_PLATFORM_MAP[target.goos];
     if (!platform) continue;
 
@@ -578,7 +595,14 @@ export async function syncFromGitHub(
       fallbackChecksums,
       releaseTag: release.tag_name,
     });
-    if (!metadata) continue;
+    if (!metadata) {
+      // See agent loop above: `!metadata` after `!asset` passed indicates an
+      // unexpected manifest/checksums inconsistency, not a missing artifact.
+      console.warn(
+        `[binarySync] Missing metadata for user-helper asset (release=${release.tag_name}, asset=${target.assetName}, component=user-helper); skipping`,
+      );
+      continue;
+    }
     const platform = GH_PLATFORM_MAP[target.goos];
     if (!platform) continue;
 


### PR DESCRIPTION
## Summary

Follow-up to PR #845 (which fixed issue #816 — the agent's in-place upgrade now deploys `breeze-user-helper.exe`). The multi-agent review surfaced several correctness gaps; this PR addresses the **critical** ones plus three small low-risk suggestions.

Strictly in scope (per the plan). The type-design refactor (PR B) and remaining test coverage (PR C) are separate, planned follow-ups.

## Fixes mapped to review findings

### #1 — PowerShell hardening (C1, restart_windows.go)
PowerShell's `Copy-Item` is non-terminating by default; a failed Copy (locked file, ACL denied, disk full) would silently regress to the partial-success state #816 was filed against. The generated script now:
- sets `$ErrorActionPreference = 'Stop'` globally,
- wraps the swap block (`Stop-Service` / `Stop-Process` / `Copy-Item agent` / `Copy-Item user-helper` / `Start-Service`) in a single `try { … } catch { … }`,
- on failure, logs `Exception.Message`, `Exception.StackTrace`, `ScriptStackTrace`, and the failing operation to `${env:TEMP}\breeze-update-failure-<unix>.log` via `Out-File -Append -Encoding utf8` (uses `$env:TEMP` not `C:\ProgramData\Breeze` — the latter may not exist on a fresh install, cf. #609),
- always attempts `Start-Service` afterwards (catch path uses `-ErrorAction SilentlyContinue` so a failed start doesn't re-throw and skip cleanup),
- keeps `Remove-Item` cleanups outside the try/catch so they always run.

Decision recorded: **single try/catch wrapping the entire swap block**, with `Start-Service` invoked once inside the try (success path) and once inside the catch (degraded path). I considered a nested try/catch around each Copy-Item but it'd be more code for the same outcome — any Copy failure already needs to abort the swap, and a single catch keeps the failure log structure clean.

`Stop-Service` keeps its `-ErrorAction SilentlyContinue` since the service legitimately may not exist on some test paths.

### #2 — User-helper temp leak (C2, updater.go)
`UpdateTo`'s error branches called `removeCleanup(tempPath)` only for the agent temp. The pre-downloaded user-helper temp would orphan in `%TEMP%` on every failed upgrade. Fixed at two sites:
- `UpdateToWithUserHelper` now cleans up the helper temp when `UpdateTo` returns an error.
- `UpdateTo`'s `RestartWithHelper` failure branch also cleans up `u.extras.userHelperTempPath`.

On success the spawned restart script owns the file and removes it.

### #3 — Stale doc references (C3, updater.go)
Comments at the `extras` field and `updateExtras` struct cited `UpdateToWithCompanions` / `UpdateFromURLWithCompanions`, neither of which exists. The actual setter is `UpdateToWithUserHelper`. Also added an explicit "asymmetry footgun" note: `UpdateFromURL` reads `u.extras` but has no companion-setter wrapper, so a dev-push caller wanting a helper swap on that path must mutate `u.extras` directly. Will be cleaned up by PR B's refactor, but the misleading references were actively wrong now.

### I5 — User-helper download WARN context (heartbeat.go)
Added `currentVersion` to the `"user-helper download failed; proceeding with agent-only upgrade"` WARN — the single most useful field for distinguishing "release pre-dates artifact" from "release should have shipped artifact but didn't." Rewrote the preceding comment block: the original "404 / network / checksum" wording undersold the scope (the catch swallows any error from `DownloadBinary`, including auth-token expiry, manifest signature failure, JSON decode, FS write). New comment makes the scope explicit and documents the two intentional reasons we degrade.

### S1 — Ordering rationale in production code (restart_windows.go)
Mirrored the test docstring rationale ("agent Copy must come before helper Copy — partial failure leaves a working pre-#816 install, not a helper-installed-but-agent-stale state") into a comment in `buildRestartScript` so the constraint is documented at the line that enforces it.

### S2 — binarySync.ts WARN on metadata resolution failure
The agent/helper/user-helper sync loops all had a silent `if (!metadata) continue;` after the silent `if (!asset) continue;`. The `!asset` case is legitimate (release predates the artifact) and stays silent; the `!metadata` case indicates an unexpected manifest/checksums inconsistency and now emits a `console.warn` with release tag, asset name, and component. No behavior change otherwise.

### S3 — `DownloadBinary` doc explaining the second checksum verify
Added a one-paragraph note: internal `downloadBinary` verifies the signed manifest (JSON payload's Ed25519 signature) but does not verify the downloaded file bytes against `manifest.Checksum`. `DownloadBinary` does that file-checksum verification here so exported callers get a verified file without knowing the manifest-vs-file distinction. A future "simplifier" must not delete it as redundant.

## Test Plan

All existing tests pass; new tests added:

**Go (`agent/internal/updater/`):**
- `TestBuildRestartScript_ErrorActionPreference` — generated script sets `$ErrorActionPreference = 'Stop'`.
- `TestBuildRestartScript_TryCatchWrapsSwap` — both Copy-Item calls are inside `try { … } catch { … }`.
- `TestBuildRestartScript_StartServiceInBothPaths` — `Start-Service` appears twice (try + catch); catch path uses `-ErrorAction SilentlyContinue`.
- `TestBuildRestartScript_FailureLogUsesTemp` — failure log path uses `$env:TEMP`, not a hardcoded drive letter; uses `Out-File -Append -Encoding utf8`.
- `TestBuildRestartScript_CleanupOutsideTryCatch` — `Remove-Item` cleanup lines appear after the catch-block close.
- `TestUpdateToWithUserHelper_CleansHelperTempOnFailure` — synthesizes a helper temp file, forces `UpdateTo` to fail, asserts the helper temp is gone.
- `TestUpdateToWithUserHelper_NoHelperTempPathIsNoOp` — regression guard that the new cleanup is a no-op on agent-only upgrades.

**Verification commands:**
- `cd agent && go build ./...` — clean
- `cd agent && go vet ./...` — clean (m1cpu warnings are upstream)
- `cd agent && GOOS=windows GOARCH=amd64 go build ./...` — clean
- `cd agent && go test -race ./internal/updater/... ./internal/heartbeat/...` — all pass
- `cd apps/api && npx tsc --noEmit` — clean
- `cd apps/api && npx vitest run src/services/binarySync.test.ts src/routes/agentVersions.test.ts` — 27/27 pass
- `cd apps/api && npx eslint src/services/binarySync.ts` — clean

## Follow-up series

This is part 1 of 3:
- **PR B (planned)** — `updateExtras` field type-design refactor (e.g. an options struct passed into `UpdateTo` rather than a transient struct field). Will clean up the `UpdateFromURL`/`u.extras` footgun documented in this PR.
- **PR C (planned)** — Test coverage for the `doUpgrade` user-helper fallback block and the `binarySync.ts` `USER_HELPER_TARGETS` sync loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
