### PR TITLE
refactor(agent/updater): thread companion binaries via UpdateOptions parameter (#845 follow-up)

### DIFF
--- a/agent/internal/heartbeat/handlers_devupdate.go
+++ b/agent/internal/heartbeat/handlers_devupdate.go
@@ -243,7 +243,10 @@ func handleDevUpdateAgent(h *Heartbeat, start time.Time, downloadURL, checksum, 
 	// Run the update in a goroutine since UpdateFromURL triggers a restart
 	go func() {
 		h.sendUpdateStatus(version)
-		if err := u.UpdateFromURL(downloadURL, checksum); err != nil {
+		// dev_push is agent-only — no user-helper swap on this path. If a
+		// future dev-push surface needs to swap a companion binary too, pass
+		// updater.UpdateOptions{UserHelper: ...} here.
+		if err := u.UpdateFromURL(downloadURL, checksum, updater.UpdateOptions{}); err != nil {
 			log.Error("dev_update failed", "version", version, "error", err.Error())
 		}
 	}()

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -3066,8 +3066,7 @@ func (h *Heartbeat) doUpgrade(targetVersion string) {
 	// `currentVersion` is included in the WARN so operators can tell the
 	// "legitimately pre-#816, ignore" case apart from the "this release SHOULD
 	// have shipped the artifact, something's broken" case.
-	userHelperTempPath := ""
-	userHelperTargetPath := ""
+	var userHelperPair *updater.BinaryPair
 	if runtime.GOOS == "windows" {
 		helperCfg := &updater.Config{
 			ServerURL:             h.config.ServerURL,
@@ -3085,18 +3084,20 @@ func (h *Heartbeat) doUpgrade(targetVersion string) {
 				"error", dlErr.Error(),
 			)
 		} else {
-			userHelperTempPath = tempPath
-			userHelperTargetPath = filepath.Join(filepath.Dir(binaryPath), "breeze-user-helper.exe")
+			userHelperPair = &updater.BinaryPair{
+				Temp:   tempPath,
+				Target: filepath.Join(filepath.Dir(binaryPath), "breeze-user-helper.exe"),
+			}
 			log.Info(
 				"pre-downloaded user-helper for restart-helper swap",
-				"temp", userHelperTempPath,
-				"target", userHelperTargetPath,
+				"temp", userHelperPair.Temp,
+				"target", userHelperPair.Target,
 			)
 		}
 	}
 
 	u := updater.New(updaterCfg)
-	if err := u.UpdateToWithUserHelper(targetVersion, userHelperTempPath, userHelperTargetPath); err != nil {
+	if err := u.UpdateToWithOptions(targetVersion, updater.UpdateOptions{UserHelper: userHelperPair}); err != nil {
 		// If the filesystem is read-only, stop retrying — this is permanent
 		// until the service unit is fixed or the filesystem is remounted.
 		// Intentionally NOT persisted to disk (unlike dev_push in handlers_devupdate.go)

--- a/agent/internal/updater/restart_unix.go
+++ b/agent/internal/updater/restart_unix.go
@@ -48,10 +48,10 @@ func restartLaunchd() error {
 }
 
 // RestartWithHelper is Windows-only; on Unix it's never called because
-// updater.go gates on runtime.GOOS == "windows". The userHelperTempPath /
-// userHelperTargetPath arguments are accepted to keep the signature aligned
-// with the Windows build but are unused here (issue #816).
-func RestartWithHelper(_, _, _, _ string) error {
+// updater.go gates on runtime.GOOS == "windows". The arguments are accepted
+// to keep the signature aligned with the Windows build but are unused here
+// (issue #816).
+func RestartWithHelper(_ BinaryPair, _ *BinaryPair) error {
 	return fmt.Errorf("RestartWithHelper is only supported on Windows")
 }
 

--- a/agent/internal/updater/restart_windows.go
+++ b/agent/internal/updater/restart_windows.go
@@ -78,19 +78,22 @@ func Restart() error {
 // performs the in-place agent binary swap on Windows. Built by RestartWithHelper
 // and consumed by buildRestartScript so the script text can be unit-tested
 // without spawning PowerShell.
+//
+// The half-set invariant from the pre-PR-B shape (four parallel string fields
+// where "both UserHelper paths are set OR both empty" was only enforced by a
+// defensive runtime check) is now expressed in the type system: UserHelper is
+// a *BinaryPair, nil means "no helper to swap", and a non-nil value carries
+// both paths together. Issue #816, #845 follow-up.
 type restartScriptOptions struct {
-	// AgentTempPath is the freshly-downloaded breeze-agent.exe in a temp dir.
-	AgentTempPath string
-	// AgentTargetPath is the final install location of breeze-agent.exe.
-	AgentTargetPath string
-	// UserHelperTempPath is the freshly-downloaded breeze-user-helper.exe
-	// in a temp dir. Empty string means "no user-helper to swap" — the
-	// generated script omits the helper Copy-Item entirely (backward-compat
-	// with releases that lack the user-helper artifact). Issue #816.
-	UserHelperTempPath string
-	// UserHelperTargetPath is the final install location of
-	// breeze-user-helper.exe (typically the same directory as the agent).
-	UserHelperTargetPath string
+	// Agent is the freshly-downloaded breeze-agent.exe temp file plus its
+	// final install location. Required.
+	Agent BinaryPair
+	// UserHelper, when non-nil, is the freshly-downloaded breeze-user-helper.exe
+	// temp file plus its final install location (typically the same directory
+	// as the agent). nil means "no user-helper to swap" — the generated script
+	// omits the helper Copy-Item entirely (backward-compat with releases that
+	// lack the user-helper artifact). Issue #816.
+	UserHelper *BinaryPair
 }
 
 // buildRestartScript renders the PowerShell helper script. Extracted from
@@ -118,14 +121,17 @@ type restartScriptOptions struct {
 //     we've tried and the failure log captures the cause),
 //   - keeps Remove-Item cleanups outside the try/catch so they always run.
 func buildRestartScript(opts restartScriptOptions) string {
-	safeAgent := strings.ReplaceAll(opts.AgentTempPath, "'", "''")
-	safeAgentTarget := strings.ReplaceAll(opts.AgentTargetPath, "'", "''")
+	safeAgent := strings.ReplaceAll(opts.Agent.Temp, "'", "''")
+	safeAgentTarget := strings.ReplaceAll(opts.Agent.Target, "'", "''")
 
-	hasHelper := opts.UserHelperTempPath != "" && opts.UserHelperTargetPath != ""
+	// nil-as-absent: the type system now guarantees both helper paths come as
+	// a single unit, so we cannot land in the half-set state the pre-PR-B
+	// defensive check guarded against.
+	hasHelper := opts.UserHelper != nil
 	var safeHelper, safeHelperTarget string
 	if hasHelper {
-		safeHelper = strings.ReplaceAll(opts.UserHelperTempPath, "'", "''")
-		safeHelperTarget = strings.ReplaceAll(opts.UserHelperTargetPath, "'", "''")
+		safeHelper = strings.ReplaceAll(opts.UserHelper.Temp, "'", "''")
+		safeHelperTarget = strings.ReplaceAll(opts.UserHelper.Target, "'", "''")
 	}
 
 	lines := []string{
@@ -205,17 +211,15 @@ func buildRestartScript(opts restartScriptOptions) string {
 // This avoids the race where the agent tries to SCM-stop itself
 // (killing the goroutine before it can call Start).
 //
-// userHelperTempPath / userHelperTargetPath are optional. Pass empty strings
-// to perform an agent-only upgrade (the pre-#816 behavior). When both are
-// non-empty, the generated script also copies the user-helper into place
-// so the post-upgrade HelperLifecycleManager finds it on disk and does not
-// fall back to spawning breeze-agent.exe in a loop (issue #816).
-func RestartWithHelper(newBinaryPath, targetPath string, userHelperTempPath, userHelperTargetPath string) error {
+// userHelper is optional. Pass nil to perform an agent-only upgrade (the
+// pre-#816 behavior). When non-nil, the generated script also copies the
+// user-helper into place so the post-upgrade HelperLifecycleManager finds
+// it on disk and does not fall back to spawning breeze-agent.exe in a loop
+// (issue #816).
+func RestartWithHelper(agent BinaryPair, userHelper *BinaryPair) error {
 	script := buildRestartScript(restartScriptOptions{
-		AgentTempPath:        newBinaryPath,
-		AgentTargetPath:      targetPath,
-		UserHelperTempPath:   userHelperTempPath,
-		UserHelperTargetPath: userHelperTargetPath,
+		Agent:      agent,
+		UserHelper: userHelper,
 	})
 
 	scriptFile, err := os.CreateTemp("", "breeze-update-*.ps1")
@@ -229,12 +233,18 @@ func RestartWithHelper(newBinaryPath, targetPath string, userHelperTempPath, use
 	}
 	scriptFile.Close()
 
+	userHelperTemp := ""
+	userHelperTarget := ""
+	if userHelper != nil {
+		userHelperTemp = userHelper.Temp
+		userHelperTarget = userHelper.Target
+	}
 	log.Info("spawning update helper script",
 		"script", scriptFile.Name(),
-		"newBinary", newBinaryPath,
-		"target", targetPath,
-		"userHelperTemp", userHelperTempPath,
-		"userHelperTarget", userHelperTargetPath,
+		"newBinary", agent.Temp,
+		"target", agent.Target,
+		"userHelperTemp", userHelperTemp,
+		"userHelperTarget", userHelperTarget,
 	)
 
 	cmd := exec.Command("powershell.exe",

--- a/agent/internal/updater/restart_windows_test.go
+++ b/agent/internal/updater/restart_windows_test.go
@@ -8,13 +8,15 @@ import (
 )
 
 // TestBuildRestartScript_AgentOnly is the pre-#816 baseline: when the caller
-// passes empty user-helper paths the generated script must not reference the
+// passes a nil UserHelper the generated script must not reference the
 // user-helper at all (backward-compatible with releases that don't yet ship
 // the breeze-user-helper artifact and with non-Windows release histories).
 func TestBuildRestartScript_AgentOnly(t *testing.T) {
 	got := buildRestartScript(restartScriptOptions{
-		AgentTempPath:   `C:\Windows\Temp\breeze-agent-1234.exe`,
-		AgentTargetPath: `C:\Program Files\Breeze\breeze-agent.exe`,
+		Agent: BinaryPair{
+			Temp:   `C:\Windows\Temp\breeze-agent-1234.exe`,
+			Target: `C:\Program Files\Breeze\breeze-agent.exe`,
+		},
 	})
 
 	if !strings.Contains(got, `Copy-Item -Path 'C:\Windows\Temp\breeze-agent-1234.exe' -Destination 'C:\Program Files\Breeze\breeze-agent.exe' -Force`) {
@@ -28,14 +30,42 @@ func TestBuildRestartScript_AgentOnly(t *testing.T) {
 	}
 }
 
+// TestBuildRestartScript_NilUserHelperIsAbsent verifies the new contract from
+// PR B (#845 follow-up): UserHelper == nil means "no helper to swap" and the
+// generated script must omit any helper Copy-Item / Remove-Item lines. This
+// replaces the pre-PR-B TestBuildRestartScript_HelperOnlyPathsAreIgnoredIfEmpty
+// test that verified defensive runtime behavior — the half-set state is now
+// impossible to construct at the type level (the four parallel string fields
+// were collapsed into a single *BinaryPair).
+func TestBuildRestartScript_NilUserHelperIsAbsent(t *testing.T) {
+	got := buildRestartScript(restartScriptOptions{
+		Agent: BinaryPair{
+			Temp:   `C:\tmp\agent.exe`,
+			Target: `C:\Program Files\Breeze\breeze-agent.exe`,
+		},
+		UserHelper: nil,
+	})
+
+	if strings.Contains(got, "breeze-user-helper") {
+		t.Fatalf("nil UserHelper script must not mention breeze-user-helper; script was:\n%s", got)
+	}
+	// Defense in depth: also verify no second Copy-Item snuck in. The agent
+	// Copy-Item is the only Copy-Item line we expect.
+	if c := strings.Count(got, "Copy-Item -Path"); c != 1 {
+		t.Fatalf("expected exactly one Copy-Item line with nil UserHelper; got %d. Script was:\n%s", c, got)
+	}
+}
+
 // TestBuildRestartScript_ErrorActionPreference asserts the generated script
 // makes Copy-Item failures terminating. Without this, a Copy-Item failure
 // during the swap would not propagate into the try/catch and the script
 // would silently regress to the pre-#816 partial-success state.
 func TestBuildRestartScript_ErrorActionPreference(t *testing.T) {
 	got := buildRestartScript(restartScriptOptions{
-		AgentTempPath:   `C:\tmp\agent.exe`,
-		AgentTargetPath: `C:\Program Files\Breeze\breeze-agent.exe`,
+		Agent: BinaryPair{
+			Temp:   `C:\tmp\agent.exe`,
+			Target: `C:\Program Files\Breeze\breeze-agent.exe`,
+		},
 	})
 	if !strings.Contains(got, "$ErrorActionPreference = 'Stop'") {
 		t.Fatalf("expected $ErrorActionPreference = 'Stop'; script was:\n%s", got)
@@ -47,10 +77,14 @@ func TestBuildRestartScript_ErrorActionPreference(t *testing.T) {
 // produces a structured failure log instead of a silent agent-only outcome.
 func TestBuildRestartScript_TryCatchWrapsSwap(t *testing.T) {
 	got := buildRestartScript(restartScriptOptions{
-		AgentTempPath:        `C:\tmp\agent.exe`,
-		AgentTargetPath:      `C:\Program Files\Breeze\breeze-agent.exe`,
-		UserHelperTempPath:   `C:\tmp\helper.exe`,
-		UserHelperTargetPath: `C:\Program Files\Breeze\breeze-user-helper.exe`,
+		Agent: BinaryPair{
+			Temp:   `C:\tmp\agent.exe`,
+			Target: `C:\Program Files\Breeze\breeze-agent.exe`,
+		},
+		UserHelper: &BinaryPair{
+			Temp:   `C:\tmp\helper.exe`,
+			Target: `C:\Program Files\Breeze\breeze-user-helper.exe`,
+		},
 	})
 
 	tryIdx := strings.Index(got, "try {")
@@ -83,8 +117,10 @@ func TestBuildRestartScript_TryCatchWrapsSwap(t *testing.T) {
 // leave the service stopped indefinitely).
 func TestBuildRestartScript_StartServiceInBothPaths(t *testing.T) {
 	got := buildRestartScript(restartScriptOptions{
-		AgentTempPath:   `C:\tmp\agent.exe`,
-		AgentTargetPath: `C:\Program Files\Breeze\breeze-agent.exe`,
+		Agent: BinaryPair{
+			Temp:   `C:\tmp\agent.exe`,
+			Target: `C:\Program Files\Breeze\breeze-agent.exe`,
+		},
 	})
 
 	// Count Start-Service invocations on the BreezeAgent service — must be 2
@@ -109,8 +145,10 @@ func TestBuildRestartScript_StartServiceInBothPaths(t *testing.T) {
 // #609). %TEMP% is guaranteed to exist on any Windows host.
 func TestBuildRestartScript_FailureLogUsesTemp(t *testing.T) {
 	got := buildRestartScript(restartScriptOptions{
-		AgentTempPath:   `C:\tmp\agent.exe`,
-		AgentTargetPath: `C:\Program Files\Breeze\breeze-agent.exe`,
+		Agent: BinaryPair{
+			Temp:   `C:\tmp\agent.exe`,
+			Target: `C:\Program Files\Breeze\breeze-agent.exe`,
+		},
 	})
 
 	if !strings.Contains(got, "$env:TEMP") {
@@ -134,10 +172,14 @@ func TestBuildRestartScript_FailureLogUsesTemp(t *testing.T) {
 // AFTER the closing `}` of the catch block, not inside try or catch.
 func TestBuildRestartScript_CleanupOutsideTryCatch(t *testing.T) {
 	got := buildRestartScript(restartScriptOptions{
-		AgentTempPath:        `C:\tmp\agent.exe`,
-		AgentTargetPath:      `C:\Program Files\Breeze\breeze-agent.exe`,
-		UserHelperTempPath:   `C:\tmp\helper.exe`,
-		UserHelperTargetPath: `C:\Program Files\Breeze\breeze-user-helper.exe`,
+		Agent: BinaryPair{
+			Temp:   `C:\tmp\agent.exe`,
+			Target: `C:\Program Files\Breeze\breeze-agent.exe`,
+		},
+		UserHelper: &BinaryPair{
+			Temp:   `C:\tmp\helper.exe`,
+			Target: `C:\Program Files\Breeze\breeze-user-helper.exe`,
+		},
 	})
 
 	// Find the close of the catch block: the literal "\n}\r\n" — i.e. the
@@ -171,18 +213,22 @@ func TestBuildRestartScript_CleanupOutsideTryCatch(t *testing.T) {
 	}
 }
 
-// TestBuildRestartScript_WithUserHelper verifies that when both user-helper
-// paths are provided the generated script emits a second Copy-Item AFTER the
-// agent's and includes a cleanup step for the helper temp file. The ordering
-// matters: the agent Copy-Item must come first so a partial failure still
-// leaves a working (if pre-#816) install rather than an installed user-helper
-// with a stale agent.
+// TestBuildRestartScript_WithUserHelper verifies that when a non-nil
+// UserHelper is provided the generated script emits a second Copy-Item AFTER
+// the agent's and includes a cleanup step for the helper temp file. The
+// ordering matters: the agent Copy-Item must come first so a partial failure
+// still leaves a working (if pre-#816) install rather than an installed
+// user-helper with a stale agent.
 func TestBuildRestartScript_WithUserHelper(t *testing.T) {
 	got := buildRestartScript(restartScriptOptions{
-		AgentTempPath:        `C:\Windows\Temp\breeze-agent-1234.exe`,
-		AgentTargetPath:      `C:\Program Files\Breeze\breeze-agent.exe`,
-		UserHelperTempPath:   `C:\Windows\Temp\breeze-user-helper-5678.exe`,
-		UserHelperTargetPath: `C:\Program Files\Breeze\breeze-user-helper.exe`,
+		Agent: BinaryPair{
+			Temp:   `C:\Windows\Temp\breeze-agent-1234.exe`,
+			Target: `C:\Program Files\Breeze\breeze-agent.exe`,
+		},
+		UserHelper: &BinaryPair{
+			Temp:   `C:\Windows\Temp\breeze-user-helper-5678.exe`,
+			Target: `C:\Program Files\Breeze\breeze-user-helper.exe`,
+		},
 	})
 
 	agentCopy := `Copy-Item -Path 'C:\Windows\Temp\breeze-agent-1234.exe' -Destination 'C:\Program Files\Breeze\breeze-agent.exe' -Force`
@@ -214,10 +260,14 @@ func TestBuildRestartScript_WithUserHelper(t *testing.T) {
 // user-helper path must follow the same rule (issue #816).
 func TestBuildRestartScript_EscapesSingleQuotes(t *testing.T) {
 	got := buildRestartScript(restartScriptOptions{
-		AgentTempPath:        `C:\tmp\agent'evil.exe`,
-		AgentTargetPath:      `C:\Program Files\Breeze\breeze-agent.exe`,
-		UserHelperTempPath:   `C:\tmp\helper'evil.exe`,
-		UserHelperTargetPath: `C:\Program Files\Breeze\breeze-user-helper.exe`,
+		Agent: BinaryPair{
+			Temp:   `C:\tmp\agent'evil.exe`,
+			Target: `C:\Program Files\Breeze\breeze-agent.exe`,
+		},
+		UserHelper: &BinaryPair{
+			Temp:   `C:\tmp\helper'evil.exe`,
+			Target: `C:\Program Files\Breeze\breeze-user-helper.exe`,
+		},
 	})
 
 	if !strings.Contains(got, `'C:\tmp\agent''evil.exe'`) {
@@ -231,41 +281,5 @@ func TestBuildRestartScript_EscapesSingleQuotes(t *testing.T) {
 	// inject commands via a crafted temp path.
 	if strings.Contains(got, `'C:\tmp\agent'evil.exe'`) {
 		t.Fatalf("agent path single quote was not escaped; script was:\n%s", got)
-	}
-}
-
-// TestBuildRestartScript_HelperOnlyPathsAreIgnoredIfEmpty exercises the
-// defensive code path where only one of the two helper paths is provided.
-// We treat this as "no user-helper to install" rather than partially
-// generating a broken script.
-func TestBuildRestartScript_HelperOnlyPathsAreIgnoredIfEmpty(t *testing.T) {
-	cases := []struct {
-		name string
-		opts restartScriptOptions
-	}{
-		{
-			name: "temp set, target empty",
-			opts: restartScriptOptions{
-				AgentTempPath:      `C:\tmp\agent.exe`,
-				AgentTargetPath:    `C:\Program Files\Breeze\breeze-agent.exe`,
-				UserHelperTempPath: `C:\tmp\helper.exe`,
-			},
-		},
-		{
-			name: "target set, temp empty",
-			opts: restartScriptOptions{
-				AgentTempPath:        `C:\tmp\agent.exe`,
-				AgentTargetPath:      `C:\Program Files\Breeze\breeze-agent.exe`,
-				UserHelperTargetPath: `C:\Program Files\Breeze\breeze-user-helper.exe`,
-			},
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := buildRestartScript(tc.opts)
-			if strings.Contains(got, `breeze-user-helper.exe' -Force`) {
-				t.Fatalf("expected no user-helper Copy-Item when one path is empty; script was:\n%s", got)
-			}
-		})
 	}
 }

--- a/agent/internal/updater/types.go
+++ b/agent/internal/updater/types.go
@@ -1,0 +1,27 @@
+package updater
+
+// BinaryPair is a freshly-downloaded binary in a temp location plus its final
+// install path. Used to pipe optional companion binaries (e.g. breeze-user-helper.exe)
+// through the Windows in-place upgrade swap.
+type BinaryPair struct {
+	Temp   string
+	Target string
+}
+
+// IsZero reports whether both fields are the empty string. Useful for treating
+// an accidentally zero-valued BinaryPair as "no companion to swap" instead of
+// generating a broken script — though the preferred API is to pass a *BinaryPair
+// and use nil to express absence (see restartScriptOptions.UserHelper).
+func (p BinaryPair) IsZero() bool { return p.Temp == "" && p.Target == "" }
+
+// UpdateOptions carries optional companion behavior for an update operation.
+// Passed by value into UpdateToWithOptions / UpdateFromURL so the call site is
+// self-describing: there is no Updater-level state for callers to mutate, and
+// the helper-swap path is visible from a single function body. Issue #816 /
+// #845 follow-up (PR B): replaces the prior u.extras action-at-a-distance.
+type UpdateOptions struct {
+	// UserHelper, when non-nil, is also swapped alongside the main binary
+	// on Windows. Ignored on other platforms (the agent-only path is the
+	// only path on non-Windows).
+	UserHelper *BinaryPair
+}

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -326,7 +326,14 @@ func (u *Updater) UpdateTo(version string) error {
 		// component-agnostic, and downloading a second component requires
 		// the caller's AuthToken/server context. Pass empty strings for an
 		// agent-only swap (backward compatible). Issue #816.
-		if err := RestartWithHelper(tempPath, u.config.BinaryPath, u.extras.userHelperTempPath, u.extras.userHelperTargetPath); err != nil {
+		var userHelperOpt *BinaryPair
+		if u.extras.userHelperTempPath != "" || u.extras.userHelperTargetPath != "" {
+			userHelperOpt = &BinaryPair{
+				Temp:   u.extras.userHelperTempPath,
+				Target: u.extras.userHelperTargetPath,
+			}
+		}
+		if err := RestartWithHelper(BinaryPair{Temp: tempPath, Target: u.config.BinaryPath}, userHelperOpt); err != nil {
 			removeCleanup(tempPath)
 			// The user-helper temp was pre-downloaded by the caller before
 			// UpdateTo was invoked; if we never spawned the restart script,
@@ -805,7 +812,14 @@ func (u *Updater) UpdateFromURL(url, expectedChecksum string) error {
 
 	// 4. Windows: spawn helper script for binary swap
 	if runtime.GOOS == "windows" {
-		if err := RestartWithHelper(tempPath, u.config.BinaryPath, u.extras.userHelperTempPath, u.extras.userHelperTargetPath); err != nil {
+		var userHelperOpt *BinaryPair
+		if u.extras.userHelperTempPath != "" || u.extras.userHelperTargetPath != "" {
+			userHelperOpt = &BinaryPair{
+				Temp:   u.extras.userHelperTempPath,
+				Target: u.extras.userHelperTargetPath,
+			}
+		}
+		if err := RestartWithHelper(BinaryPair{Temp: tempPath, Target: u.config.BinaryPath}, userHelperOpt); err != nil {
 			removeCleanup(tempPath)
 			if rbErr := u.Rollback(); rbErr != nil {
 				log.Error("rollback also failed", "originalError", err, "rollbackError", rbErr)

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -47,19 +47,6 @@ type Config struct {
 type Updater struct {
 	config *Config
 	client *http.Client
-	// extras is set by UpdateToWithUserHelper to forward companion-binary
-	// paths (e.g. breeze-user-helper.exe) into the Windows restart helper.
-	// Not user-visible. Issue #816.
-	//
-	// Asymmetry note (footgun): UpdateFromURL (the dev_push path) also
-	// reads u.extras when it calls RestartWithHelper on Windows, but there
-	// is no UpdateFromURLWithUserHelper wrapper. A dev-push caller that
-	// wants a helper swap on that path has to mutate u.extras directly.
-	// Currently no dev-push caller does this — the surface is flagged here
-	// so a future addition doesn't silently no-op the helper field. The
-	// upcoming type-design refactor (PR B of the #845 follow-up series)
-	// will fold this into an explicit options struct.
-	extras updateExtras
 }
 
 // New creates a new Updater
@@ -68,19 +55,6 @@ func New(cfg *Config) *Updater {
 		config: cfg,
 		client: &http.Client{Timeout: 5 * time.Minute},
 	}
-}
-
-// updateExtras carries optional companion-binary info into the Windows
-// restart helper. It is set transiently via the Updater's exported
-// UpdateToWithUserHelper wrapper so the existing UpdateTo signature stays
-// stable. Issue #816.
-//
-// Note: only UpdateToWithUserHelper exists today — UpdateFromURL (dev-push)
-// has no companion-setter wrapper but still consumes u.extras when it
-// builds the Windows restart script. See the field comment on Updater.
-type updateExtras struct {
-	userHelperTempPath   string
-	userHelperTargetPath string
 }
 
 // ErrReadOnlyFS is returned when the binary path is on a read-only filesystem.
@@ -263,29 +237,41 @@ func writeUpdateMarker(version string) {
 	}
 }
 
-// UpdateToWithUserHelper behaves like UpdateTo but also instructs the Windows
-// restart helper to copy a freshly-downloaded breeze-user-helper.exe into
-// place alongside the agent. Empty paths fall back to agent-only behavior.
-// Issue #816.
+// UpdateTo is a thin shim around UpdateToWithOptions for the common case of
+// an agent-only upgrade. New code (and any caller that needs to thread a
+// companion binary like breeze-user-helper.exe through the Windows restart
+// helper) should call UpdateToWithOptions directly.
+func (u *Updater) UpdateTo(version string) error {
+	return u.UpdateToWithOptions(version, UpdateOptions{})
+}
+
+// UpdateToWithOptions downloads and installs a new version. When
+// opts.UserHelper is non-nil and the host is Windows, the Windows restart
+// helper script also swaps the user-helper binary alongside the agent.
 //
-// Cleanup contract: on UpdateTo failure, the user-helper temp file is
-// removed here too. UpdateTo's own error branches only know about the agent
-// tempPath, so without this cleanup the pre-downloaded helper would orphan
-// in %TEMP% on every failed upgrade. On success (UpdateTo returns nil) we
-// intentionally leave the file in place — the spawned restart script owns
-// it and removes it after the swap.
-func (u *Updater) UpdateToWithUserHelper(version, userHelperTempPath, userHelperTargetPath string) error {
-	u.extras.userHelperTempPath = userHelperTempPath
-	u.extras.userHelperTargetPath = userHelperTargetPath
-	err := u.UpdateTo(version)
-	if err != nil && userHelperTempPath != "" {
-		removeCleanup(userHelperTempPath)
+// Cleanup contract: on update failure (any error returned from this method),
+// if opts.UserHelper != nil the user-helper temp file is removed. The agent
+// caller pre-downloaded the helper to a temp file before invoking this method;
+// if we never spawn the restart script, nothing else will ever clean it up.
+// On success (this method returns nil) the helper temp is intentionally left
+// in place — the spawned restart script owns it and removes it after the swap.
+//
+// Issue #816 / #845 follow-up (PR B): replaces UpdateToWithUserHelper and the
+// u.extras action-at-a-distance state with an explicit options parameter.
+func (u *Updater) UpdateToWithOptions(version string, opts UpdateOptions) error {
+	err := u.updateTo(version, opts)
+	if err != nil && opts.UserHelper != nil && opts.UserHelper.Temp != "" {
+		// Cleanup contract: see method doc. Preserved verbatim from
+		// PR A's UpdateToWithUserHelper error-path cleanup.
+		removeCleanup(opts.UserHelper.Temp)
 	}
 	return err
 }
 
-// UpdateTo downloads and installs a new version
-func (u *Updater) UpdateTo(version string) error {
+// updateTo is the unexported implementation shared by UpdateTo and
+// UpdateToWithOptions. opts.UserHelper, when non-nil, is threaded through to
+// RestartWithHelper on Windows.
+func (u *Updater) updateTo(version string, opts UpdateOptions) error {
 	log.Info("starting update", "targetVersion", version)
 
 	// Pre-flight: verify we can write to the binary's directory.
@@ -324,23 +310,17 @@ func (u *Updater) UpdateTo(version string) error {
 		// User-helper swap is wired in by the heartbeat-layer caller
 		// (heartbeat.doUpgrade), not here — the updater package is
 		// component-agnostic, and downloading a second component requires
-		// the caller's AuthToken/server context. Pass empty strings for an
-		// agent-only swap (backward compatible). Issue #816.
-		var userHelperOpt *BinaryPair
-		if u.extras.userHelperTempPath != "" || u.extras.userHelperTargetPath != "" {
-			userHelperOpt = &BinaryPair{
-				Temp:   u.extras.userHelperTempPath,
-				Target: u.extras.userHelperTargetPath,
-			}
-		}
-		if err := RestartWithHelper(BinaryPair{Temp: tempPath, Target: u.config.BinaryPath}, userHelperOpt); err != nil {
+		// the caller's AuthToken/server context. Pass nil for an agent-only
+		// swap (backward compatible). Issue #816.
+		if err := RestartWithHelper(BinaryPair{Temp: tempPath, Target: u.config.BinaryPath}, opts.UserHelper); err != nil {
 			removeCleanup(tempPath)
-			// The user-helper temp was pre-downloaded by the caller before
-			// UpdateTo was invoked; if we never spawned the restart script,
-			// nothing will ever clean it up. Mirror the agent tempPath
-			// cleanup so failed spawns don't leak helper temps in %TEMP%.
-			if u.extras.userHelperTempPath != "" {
-				removeCleanup(u.extras.userHelperTempPath)
+			// Defense in depth: UpdateToWithOptions also cleans the helper
+			// temp on any returned error, but we mirror the agent tempPath
+			// removal here too so the cleanup happens in the same branch as
+			// the agent's, keeping the spawn-failure flow tidy. The
+			// outer-layer cleanup is then a no-op for this case.
+			if opts.UserHelper != nil && opts.UserHelper.Temp != "" {
+				removeCleanup(opts.UserHelper.Temp)
 			}
 			if rbErr := u.Rollback(); rbErr != nil {
 				log.Error("rollback also failed", "originalError", err, "rollbackError", rbErr)
@@ -779,7 +759,16 @@ func (u *Updater) DownloadAndVerify(url, expectedChecksum string) (string, error
 
 // UpdateFromURL downloads a binary directly from a URL (skipping the version-lookup
 // API call used by UpdateTo). Used by dev_push for fast iteration.
-func (u *Updater) UpdateFromURL(url, expectedChecksum string) error {
+//
+// opts.UserHelper, when non-nil and on Windows, is threaded through to the
+// restart helper script so a dev-push can swap the user-helper alongside the
+// agent. Existing dev_push callers (handlers_devupdate.go) pass UpdateOptions{}
+// for agent-only behavior. Issue #816 / #845 follow-up (PR B): replaces the
+// prior u.extras action-at-a-distance read inside UpdateFromURL — that read
+// silently inherited whatever UpdateToWithUserHelper had last stuffed into
+// u.extras, which was a real footgun for any future dev-push surface that
+// shared an Updater instance with the heartbeat upgrade path.
+func (u *Updater) UpdateFromURL(url, expectedChecksum string, opts UpdateOptions) error {
 	log.Info("starting dev update from URL", "url", url)
 
 	// Pre-flight: verify we can write to the binary's directory.
@@ -812,14 +801,7 @@ func (u *Updater) UpdateFromURL(url, expectedChecksum string) error {
 
 	// 4. Windows: spawn helper script for binary swap
 	if runtime.GOOS == "windows" {
-		var userHelperOpt *BinaryPair
-		if u.extras.userHelperTempPath != "" || u.extras.userHelperTargetPath != "" {
-			userHelperOpt = &BinaryPair{
-				Temp:   u.extras.userHelperTempPath,
-				Target: u.extras.userHelperTargetPath,
-			}
-		}
-		if err := RestartWithHelper(BinaryPair{Temp: tempPath, Target: u.config.BinaryPath}, userHelperOpt); err != nil {
+		if err := RestartWithHelper(BinaryPair{Temp: tempPath, Target: u.config.BinaryPath}, opts.UserHelper); err != nil {
 			removeCleanup(tempPath)
 			if rbErr := u.Rollback(); rbErr != nil {
 				log.Error("rollback also failed", "originalError", err, "rollbackError", rbErr)

--- a/agent/internal/updater/updater_test.go
+++ b/agent/internal/updater/updater_test.go
@@ -1001,18 +1001,21 @@ func TestExpectedReleaseAssetNames_Agent(t *testing.T) {
 	}
 }
 
-// TestUpdateToWithUserHelper_CleansHelperTempOnFailure regression-tests the
+// TestUpdateToWithOptions_CleansHelperTempOnFailure regression-tests the
 // fix for the orphan-temp-file bug flagged in the #845 follow-up review:
 // when UpdateTo returns an error AND the caller pre-downloaded a user-helper
-// to `userHelperTempPath`, the temp file must be removed. Before the fix
-// only the agent temp was cleaned up, leaking the helper temp in %TEMP%
-// on every failed upgrade.
+// via opts.UserHelper, the temp file must be removed. Before the fix only
+// the agent temp was cleaned up, leaking the helper temp in %TEMP% on every
+// failed upgrade.
+//
+// Ported from the pre-PR-B TestUpdateToWithUserHelper_CleansHelperTempOnFailure
+// — same intent, new API surface (UpdateToWithOptions + UpdateOptions).
 //
 // We force UpdateTo to fail by giving it no AuthToken — downloadBinary
 // returns "auth token not available" immediately on every platform.
-func TestUpdateToWithUserHelper_CleansHelperTempOnFailure(t *testing.T) {
+func TestUpdateToWithOptions_CleansHelperTempOnFailure(t *testing.T) {
 	// Synthesize a "pre-downloaded user-helper" tempfile. The test owns the
-	// file; UpdateToWithUserHelper is expected to remove it on UpdateTo failure.
+	// file; UpdateToWithOptions is expected to remove it on update failure.
 	helperTemp, err := os.CreateTemp("", "breeze-user-helper-leak-test-*")
 	if err != nil {
 		t.Fatal(err)
@@ -1040,7 +1043,12 @@ func TestUpdateToWithUserHelper_CleansHelperTempOnFailure(t *testing.T) {
 		// AuthToken intentionally nil — forces downloadBinary to return early.
 	})
 
-	err = u.UpdateToWithUserHelper("9.9.9", helperTempPath, `C:\target\breeze-user-helper.exe`)
+	err = u.UpdateToWithOptions("9.9.9", UpdateOptions{
+		UserHelper: &BinaryPair{
+			Temp:   helperTempPath,
+			Target: `C:\target\breeze-user-helper.exe`,
+		},
+	})
 	if err == nil {
 		t.Fatal("expected UpdateTo to fail (no auth token configured)")
 	}
@@ -1050,11 +1058,13 @@ func TestUpdateToWithUserHelper_CleansHelperTempOnFailure(t *testing.T) {
 	}
 }
 
-// TestUpdateToWithUserHelper_NoHelperTempPathIsNoOp guards against a
-// regression where the new cleanup branch fires when no helper-temp was
-// ever passed (call path: agent-only upgrade on a release that doesn't
-// ship the user-helper artifact). It must not error or panic.
-func TestUpdateToWithUserHelper_NoHelperTempPathIsNoOp(t *testing.T) {
+// TestUpdateToWithOptions_NoUserHelperIsNoOp guards against a regression
+// where the helper-temp cleanup branch fires when opts.UserHelper is nil
+// (call path: agent-only upgrade on a release that doesn't ship the
+// user-helper artifact, or a non-Windows host). It must not error or panic.
+//
+// Ported from the pre-PR-B TestUpdateToWithUserHelper_NoHelperTempPathIsNoOp.
+func TestUpdateToWithOptions_NoUserHelperIsNoOp(t *testing.T) {
 	binaryFile, err := os.CreateTemp("", "breeze-agent-bin-test-*")
 	if err != nil {
 		t.Fatal(err)
@@ -1068,8 +1078,48 @@ func TestUpdateToWithUserHelper_NoHelperTempPathIsNoOp(t *testing.T) {
 		BackupPath: binaryFile.Name() + ".backup",
 	})
 
-	// Empty userHelperTempPath should leave the cleanup branch dormant.
-	if err := u.UpdateToWithUserHelper("9.9.9", "", ""); err == nil {
+	// nil UserHelper should leave the cleanup branch dormant.
+	if err := u.UpdateToWithOptions("9.9.9", UpdateOptions{}); err == nil {
 		t.Fatal("expected UpdateTo to fail (no auth token configured)")
+	}
+}
+
+// TestUpdateTo_DelegatesToUpdateToWithOptions verifies the thin-shim wiring
+// added by PR B: UpdateTo must forward to UpdateToWithOptions with a
+// zero-valued UpdateOptions, i.e. the agent-only path. We can't observe the
+// internal call directly, but we can prove equivalence by asserting both
+// invocations produce the same observable error (no auth token), confirming
+// the shim doesn't drop arguments or short-circuit.
+func TestUpdateTo_DelegatesToUpdateToWithOptions(t *testing.T) {
+	binaryFile, err := os.CreateTemp("", "breeze-agent-bin-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	binaryFile.Close()
+	t.Cleanup(func() { _ = os.Remove(binaryFile.Name()) })
+
+	mkUpdater := func() *Updater {
+		return New(&Config{
+			ServerURL:  "http://localhost:0",
+			BinaryPath: binaryFile.Name(),
+			BackupPath: binaryFile.Name() + ".backup",
+		})
+	}
+
+	shimErr := mkUpdater().UpdateTo("9.9.9")
+	if shimErr == nil {
+		t.Fatal("expected shim UpdateTo to fail (no auth token)")
+	}
+
+	explicitErr := mkUpdater().UpdateToWithOptions("9.9.9", UpdateOptions{})
+	if explicitErr == nil {
+		t.Fatal("expected explicit UpdateToWithOptions to fail (no auth token)")
+	}
+
+	// Errors must be structurally identical — same wrapped message text — to
+	// prove the shim isn't munging args. Use Error() string equality; both
+	// flows reach the same downloadBinary "auth token not available" branch.
+	if shimErr.Error() != explicitErr.Error() {
+		t.Fatalf("shim and explicit calls produced different errors:\n  shim:     %v\n  explicit: %v", shimErr, explicitErr)
 	}
 }


### PR DESCRIPTION
## Why

Part 2 of 3 of the #845 follow-up series. Part 1 (correctness — PS error handling, helper-temp cleanup) merged in #848. Part 3 (added test coverage for the doUpgrade fallback + binarySync USER_HELPER_TARGETS) is next.

The multi-agent type-design review of #845 flagged two action-at-a-distance / footgun shapes in the updater:

1. **`updateExtras` struct on `Updater` is stateful mutation.** `UpdateToWithUserHelper` set `u.extras` as a side effect, then `UpdateTo` read `u.extras` when calling `RestartWithHelper`. New contributors reading `UpdateTo` alone didn't see the helper-swap path. Worse, **`UpdateFromURL` (dev-push path) also read `u.extras` with no corresponding setter on its surface** — a real footgun for any future dev-push caller sharing an `Updater` instance with the heartbeat upgrade path. Latent only because heartbeat constructs a fresh `Updater` per upgrade.

2. **Four parallel string fields** in `restartScriptOptions` and the `RestartWithHelper(newBinaryPath, targetPath, userHelperTempPath, userHelperTargetPath string)` signature encoded the "either both UserHelper paths are set or both empty" invariant nowhere in the type system — only by convention plus a defensive compound predicate (`opts.UserHelperTempPath != "" && opts.UserHelperTargetPath != ""`) and a defensive test asserting half-set inputs were silently ignored.

## Before → after

```go
// Before
type Updater struct {
    config *Config
    client *http.Client
    extras updateExtras   // stateful side-channel, mutated by UpdateToWithUserHelper, read by UpdateTo + UpdateFromURL
}
type updateExtras struct {
    userHelperTempPath   string
    userHelperTargetPath string
}

func (u *Updater) UpdateTo(version string) error { /* reads u.extras */ }
func (u *Updater) UpdateToWithUserHelper(version, userHelperTempPath, userHelperTargetPath string) error
func (u *Updater) UpdateFromURL(url, expectedChecksum string) error  // silently reads u.extras

type restartScriptOptions struct {
    AgentTempPath        string
    AgentTargetPath      string
    UserHelperTempPath   string
    UserHelperTargetPath string
}
func RestartWithHelper(newBinaryPath, targetPath, userHelperTempPath, userHelperTargetPath string) error
```

```go
// After
type Updater struct {
    config *Config
    client *http.Client
    // no more extras
}

type BinaryPair struct {
    Temp   string
    Target string
}
func (p BinaryPair) IsZero() bool

type UpdateOptions struct {
    UserHelper *BinaryPair  // nil = no helper swap
}

func (u *Updater) UpdateTo(version string) error                                // thin shim
func (u *Updater) UpdateToWithOptions(version string, opts UpdateOptions) error  // implementation
// UpdateToWithUserHelper deleted
func (u *Updater) UpdateFromURL(url, expectedChecksum string, opts UpdateOptions) error  // explicit param

type restartScriptOptions struct {
    Agent      BinaryPair
    UserHelper *BinaryPair  // nil = no helper swap
}
func RestartWithHelper(agent BinaryPair, userHelper *BinaryPair) error
```

The half-set invariant is now expressed in the type system: `UserHelper` is either nil (omit the helper Copy-Item entirely) or a fully-specified `*BinaryPair`. The defensive runtime check is gone because the half-set state is unrepresentable.

## Semantic equivalence

The PowerShell script generated by `buildRestartScript` is **byte-identical** to the pre-PR shape across three representative cases:

```
[OK]  agent-only            — byte-identical (len=1220)
[OK]  with-helper           — byte-identical (len=1404)
[OK]  single-quote injection — byte-identical (len=1428)
```

(Verified by diffing the pre-PR `buildRestartScript` implementation against the new one with matched inputs — script removed after verification.) The heartbeat upgrade path (`doUpgrade`) and dev-push path (`handleDevUpdate`) both produce the same agent-only behavior they did before, and the user-helper swap path takes the same code path it did pre-refactor with the helper-pair carried as a single value instead of two parallel strings.

## Cleanup contract preserved

PR A's error-path cleanup (`removeCleanup(userHelperTempPath)` when `UpdateTo` fails with a pre-downloaded helper in flight) is preserved verbatim. It now lives in `UpdateToWithOptions` (outer wrapper around the implementation) and is also mirrored at the inner Windows-branch spawn-failure site for defense in depth. The inner branch already handles the spawn-failure cleanup; the outer wrapper covers all other failure paths (download / checksum / backup / etc.).

## Test plan

Run locally:
- `cd agent && go build ./...` — passes
- `cd agent && GOOS=windows GOARCH=amd64 go build ./...` — passes
- `cd agent && go vet ./...` — passes
- `cd agent && go test -race ./internal/updater/... ./internal/heartbeat/...` — passes
- `cd apps/api && npx tsc --noEmit` — passes (no API changes)
- `grep -rn 'updateExtras\|UpdateToWithUserHelper\|\.extras\b' agent/internal/` — only comments referencing the prior PR

Tests:
- All PR A try/catch / `$ErrorActionPreference` / catch-path Start-Service / `$env:TEMP` log / single-quote escaping / agent-helper ordering tests are preserved unchanged in intent; only the `restartScriptOptions` literal construction was ported to the new field names.
- The pre-PR `TestBuildRestartScript_HelperOnlyPathsAreIgnoredIfEmpty` test (which asserted defensive runtime behavior on half-set inputs) is replaced by `TestBuildRestartScript_NilUserHelperIsAbsent` — same intent (no helper Copy-Item when there's nothing to swap), now verifying the new nil-as-absent type-level contract.
- `TestUpdateToWithUserHelper_CleansHelperTempOnFailure` ported to `TestUpdateToWithOptions_CleansHelperTempOnFailure` (new API, same intent).
- `TestUpdateToWithUserHelper_NoHelperTempPathIsNoOp` ported to `TestUpdateToWithOptions_NoUserHelperIsNoOp`.
- New `TestUpdateTo_DelegatesToUpdateToWithOptions` proves the thin shim's wiring: `UpdateTo(v)` and `UpdateToWithOptions(v, UpdateOptions{})` produce byte-identical error output, confirming the shim doesn't drop args.

## Notes for reviewers

- One nit-worth-flagging: the inner Windows branch in `updateTo` and the outer wrapper in `UpdateToWithOptions` both clean up `opts.UserHelper.Temp` on error. The inner one happens first (before `Rollback`), the outer one fires for any other error path. This is intentional defense-in-depth rather than redundant cleanup — `removeCleanup` already tolerates `ENOENT` so the second call is a no-op. Documented in a code comment.
- Backward compatibility is intra-module only — this is internal to the agent. No external Go consumers of the `updater` package.
- Followup PR C will add: doUpgrade user-helper-fallback test, binarySync USER_HELPER_TARGETS test. Explicitly out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
