### PR TITLE
test(agent,api): close coverage gaps from #845 review (#845 follow-up)

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -223,6 +223,18 @@ type Heartbeat struct {
 	// real sendInventory call inside handleRefreshInventory. nil in
 	// production — the real sendInventory method is invoked.
 	sendInventoryFn func()
+
+	// userHelperDownloader is an optional test seam: when non-nil,
+	// prefetchUserHelper calls this instead of constructing a real
+	// updater.Updater and invoking DownloadBinary. nil in production.
+	// Signature mirrors updater.Updater.DownloadBinary so the production
+	// default can be a one-line shim.
+	userHelperDownloader func(targetVersion string) (string, error)
+
+	// userHelperGOOS is an optional test seam: when non-empty, replaces
+	// runtime.GOOS in prefetchUserHelper. nil/"" in production — the real
+	// runtime.GOOS value is used so the prefetch only runs on Windows.
+	userHelperGOOS string
 }
 
 func New(cfg *config.Config) *Heartbeat {
@@ -3008,6 +3020,73 @@ func (h *Heartbeat) handleUpgrade(targetVersion string) {
 	}
 }
 
+// prefetchUserHelper pre-downloads breeze-user-helper.exe so the upgrade-restart
+// script can drop it alongside the new agent binary. Returns nil when the
+// helper is not applicable (non-Windows) or could not be fetched (404 for
+// pre-#816 releases, network errors, checksum mismatches, manifest signature
+// failure, etc.). Callers proceed with an agent-only upgrade in that case —
+// non-fatal by design (issue #816).
+//
+// Without this prefetch, in-place upgrades produce an agent install missing
+// the user-helper (only the MSI installer ever placed it on disk before #816),
+// the HelperLifecycleManager falls through to a `breeze-agent.exe user-helper`
+// fallback every ~30s, and orphaned processes accumulate during heartbeat
+// goroutine wedges until the service dies.
+//
+// ANY download failure is non-fatal — we log a WARN and return nil. This is
+// intentional and covers more than just 404s:
+//   (a) pre-#816 releases legitimately lack the user-helper artifact, so we
+//       don't want to block their upgrades, and
+//   (b) we'd rather degrade than fail an agent upgrade on a transient
+//       helper-fetch glitch.
+// `currentVersion` is included in the WARN so operators can tell the
+// "legitimately pre-#816, ignore" case apart from the "this release SHOULD
+// have shipped the artifact, something's broken" case.
+func (h *Heartbeat) prefetchUserHelper(targetVersion, binaryPath string) *updater.BinaryPair {
+	goos := h.userHelperGOOS
+	if goos == "" {
+		goos = runtime.GOOS
+	}
+	if goos != "windows" {
+		return nil
+	}
+
+	download := h.userHelperDownloader
+	if download == nil {
+		helperCfg := &updater.Config{
+			ServerURL:             h.config.ServerURL,
+			AuthToken:             h.secureToken,
+			CurrentVersion:        h.agentVersion,
+			Component:             "user-helper",
+			PinnedManifestPubKeys: h.config.PinnedManifestPubKeys,
+		}
+		helperUpdater := updater.New(helperCfg)
+		download = helperUpdater.DownloadBinary
+	}
+
+	tempPath, dlErr := download(targetVersion)
+	if dlErr != nil {
+		log.Warn(
+			"user-helper download failed; proceeding with agent-only upgrade",
+			"currentVersion", h.agentVersion,
+			"targetVersion", targetVersion,
+			"error", dlErr.Error(),
+		)
+		return nil
+	}
+
+	pair := &updater.BinaryPair{
+		Temp:   tempPath,
+		Target: filepath.Join(filepath.Dir(binaryPath), "breeze-user-helper.exe"),
+	}
+	log.Info(
+		"pre-downloaded user-helper for restart-helper swap",
+		"temp", pair.Temp,
+		"target", pair.Target,
+	)
+	return pair
+}
+
 // doUpgrade contains the actual upgrade logic, called by handleUpgrade.
 func (h *Heartbeat) doUpgrade(targetVersion string) {
 	log.Info("upgrade requested", "targetVersion", targetVersion)
@@ -3047,54 +3126,12 @@ func (h *Heartbeat) doUpgrade(targetVersion string) {
 		PinnedManifestPubKeys: h.config.PinnedManifestPubKeys,
 	}
 
-	// On Windows, also pre-download breeze-user-helper.exe so the restart
-	// helper script can drop it alongside the new agent binary. Without this,
-	// in-place upgrades produce an agent install missing the user-helper
-	// (only the MSI installer ever placed it on disk before #816), the
-	// HelperLifecycleManager falls through to a `breeze-agent.exe user-helper`
-	// fallback every ~30s, and orphaned processes accumulate during heartbeat
-	// goroutine wedges until the service dies.
-	//
-	// ANY download failure is non-fatal — we log a WARN and proceed with an
-	// agent-only upgrade. This is intentional and covers more than just 404s
-	// (manifest signature failure, auth-token expiry, JSON decode error, FS
-	// write error, etc. all land here):
-	//   (a) pre-#816 releases legitimately lack the user-helper artifact, so
-	//       we don't want to block their upgrades, and
-	//   (b) we'd rather degrade than fail an agent upgrade on a transient
-	//       helper-fetch glitch.
-	// `currentVersion` is included in the WARN so operators can tell the
-	// "legitimately pre-#816, ignore" case apart from the "this release SHOULD
-	// have shipped the artifact, something's broken" case.
-	var userHelperPair *updater.BinaryPair
-	if runtime.GOOS == "windows" {
-		helperCfg := &updater.Config{
-			ServerURL:             h.config.ServerURL,
-			AuthToken:             h.secureToken,
-			CurrentVersion:        h.agentVersion,
-			Component:             "user-helper",
-			PinnedManifestPubKeys: h.config.PinnedManifestPubKeys,
-		}
-		helperUpdater := updater.New(helperCfg)
-		if tempPath, dlErr := helperUpdater.DownloadBinary(targetVersion); dlErr != nil {
-			log.Warn(
-				"user-helper download failed; proceeding with agent-only upgrade",
-				"currentVersion", h.agentVersion,
-				"targetVersion", targetVersion,
-				"error", dlErr.Error(),
-			)
-		} else {
-			userHelperPair = &updater.BinaryPair{
-				Temp:   tempPath,
-				Target: filepath.Join(filepath.Dir(binaryPath), "breeze-user-helper.exe"),
-			}
-			log.Info(
-				"pre-downloaded user-helper for restart-helper swap",
-				"temp", userHelperPair.Temp,
-				"target", userHelperPair.Target,
-			)
-		}
-	}
+	// Pre-download breeze-user-helper.exe on Windows so the restart-helper
+	// script can drop it alongside the new agent binary. See prefetchUserHelper
+	// for the full rationale (issue #816 / PR #845). All failure modes are
+	// non-fatal — a nil return value is the normal "agent-only upgrade"
+	// outcome.
+	userHelperPair := h.prefetchUserHelper(targetVersion, binaryPath)
 
 	u := updater.New(updaterCfg)
 	if err := u.UpdateToWithOptions(targetVersion, updater.UpdateOptions{UserHelper: userHelperPair}); err != nil {

--- a/agent/internal/heartbeat/heartbeat_userhelper_test.go
+++ b/agent/internal/heartbeat/heartbeat_userhelper_test.go
@@ -1,0 +1,122 @@
+package heartbeat
+
+import (
+	"errors"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/config"
+)
+
+// TestPrefetchUserHelper_HappyPath covers the success branch: the injected
+// downloader returns a temp path with no error, and prefetchUserHelper builds
+// a *BinaryPair pointing the helper-restart script at
+// <agent-dir>/breeze-user-helper.exe.
+func TestPrefetchUserHelper_HappyPath(t *testing.T) {
+	tempPath := filepath.Join(t.TempDir(), "breeze-user-helper-dl-12345")
+	var calls atomic.Int32
+	h := &Heartbeat{
+		config:         &config.Config{},
+		agentVersion:   "1.2.3",
+		userHelperGOOS: "windows",
+		userHelperDownloader: func(targetVersion string) (string, error) {
+			calls.Add(1)
+			if targetVersion != "1.2.4" {
+				t.Fatalf("expected targetVersion=1.2.4, got %q", targetVersion)
+			}
+			return tempPath, nil
+		},
+	}
+
+	binaryPath := "/opt/breeze/breeze-agent"
+	pair := h.prefetchUserHelper("1.2.4", binaryPath)
+	if pair == nil {
+		t.Fatal("expected non-nil BinaryPair on happy path")
+	}
+	if pair.Temp != tempPath {
+		t.Fatalf("Temp: expected %q, got %q", tempPath, pair.Temp)
+	}
+	wantTarget := filepath.Join(filepath.Dir(binaryPath), "breeze-user-helper.exe")
+	if pair.Target != wantTarget {
+		t.Fatalf("Target: expected %q, got %q", wantTarget, pair.Target)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("downloader call count: expected 1, got %d", got)
+	}
+}
+
+// TestPrefetchUserHelper_DownloadFails covers the non-fatal failure branch:
+// downloader returns an error (404 from pre-#816 release, transient network
+// error, checksum mismatch, etc.). prefetchUserHelper must return nil so the
+// caller proceeds with an agent-only upgrade — the entire reason PR #845
+// exists.
+func TestPrefetchUserHelper_DownloadFails(t *testing.T) {
+	var calls atomic.Int32
+	h := &Heartbeat{
+		config:         &config.Config{},
+		agentVersion:   "1.2.3",
+		userHelperGOOS: "windows",
+		userHelperDownloader: func(targetVersion string) (string, error) {
+			calls.Add(1)
+			return "", errors.New("404 status: not found")
+		},
+	}
+
+	pair := h.prefetchUserHelper("1.2.4", "/opt/breeze/breeze-agent")
+	if pair != nil {
+		t.Fatalf("expected nil BinaryPair on download failure, got %+v", pair)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("downloader should be called exactly once even on failure, got %d", got)
+	}
+}
+
+// TestPrefetchUserHelper_NonWindows verifies the prefetch is a no-op on
+// non-Windows runtimes. Non-Windows agents never spawn user-helper sessions,
+// so the download would be pointless work + needless server load.
+func TestPrefetchUserHelper_NonWindows(t *testing.T) {
+	var calls atomic.Int32
+	for _, goos := range []string{"linux", "darwin"} {
+		t.Run(goos, func(t *testing.T) {
+			h := &Heartbeat{
+				config:         &config.Config{},
+				agentVersion:   "1.2.3",
+				userHelperGOOS: goos,
+				userHelperDownloader: func(targetVersion string) (string, error) {
+					calls.Add(1)
+					return "/tmp/should-not-be-called", nil
+				},
+			}
+			pair := h.prefetchUserHelper("1.2.4", "/opt/breeze/breeze-agent")
+			if pair != nil {
+				t.Fatalf("expected nil BinaryPair on non-Windows runtime %s, got %+v", goos, pair)
+			}
+		})
+	}
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("downloader must not be invoked on non-Windows runtimes, got %d calls", got)
+	}
+}
+
+// TestPrefetchUserHelper_DefaultGOOSMatchesRuntime is a smoke test: when no
+// override is set, the function falls back to runtime.GOOS. On non-Windows
+// CI hosts this means a nil return without ever touching the network — which
+// is exactly the safety property we want.
+func TestPrefetchUserHelper_DefaultGOOSMatchesRuntime(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test asserts non-Windows runtime safety; would need network on Windows")
+	}
+	h := &Heartbeat{
+		config:       &config.Config{},
+		agentVersion: "1.2.3",
+		// No userHelperGOOS override, no userHelperDownloader injection.
+		// On a non-Windows host this must short-circuit before constructing
+		// the real updater (which would otherwise try to hit ServerURL).
+	}
+	pair := h.prefetchUserHelper("1.2.4", "/opt/breeze/breeze-agent")
+	if pair != nil {
+		t.Fatalf("expected nil BinaryPair on non-Windows runtime, got %+v", pair)
+	}
+}

--- a/agent/internal/updater/updater_test.go
+++ b/agent/internal/updater/updater_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -671,6 +672,80 @@ func TestDownloadBinaryServerError(t *testing.T) {
 	_, _, err := u.downloadBinary("1.0.0")
 	if err == nil {
 		t.Fatal("should fail on server error")
+	}
+}
+
+// TestDownloadBinary_ChecksumMismatchCleansUpTempFile pins the cleanup-on-checksum-
+// failure contract in the exported DownloadBinary path. heartbeat.doUpgrade's
+// user-helper fallback (issue #816, PR #845) relies on DownloadBinary returning
+// "" and leaving no temp file behind on checksum failure — otherwise repeated
+// upgrade retries leak temp files into the OS temp dir.
+func TestDownloadBinary_ChecksumMismatchCleansUpTempFile(t *testing.T) {
+	// Redirect os.CreateTemp("", ...) into the test's TempDir so we can
+	// detect any leftover binary fragments.
+	tempRoot := t.TempDir()
+	t.Setenv("TMPDIR", tempRoot)
+
+	// Intended content (what the signed manifest declares).
+	intendedContent := []byte("INTENDED-binary-bytes")
+	// Tampered content actually served by the binary URL. Same length as
+	// intendedContent so the manifest.Size check passes and we reach the
+	// post-download verifyChecksum.
+	tamperedContent := []byte("TAMPERED-binary-bytes")
+	if len(intendedContent) != len(tamperedContent) {
+		t.Fatalf("test setup invariant: intended and tampered must be same length (%d vs %d)",
+			len(intendedContent), len(tamperedContent))
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/agent-versions/1.0.0/download":
+			w.Header().Set("Content-Type", "application/json")
+			// Manifest is signed against the *intended* bytes' SHA256.
+			json.NewEncoder(w).Encode(signedDownloadInfo(
+				t, "1.0.0", "agent",
+				"http://"+r.Host+"/binary/breeze-agent",
+				intendedContent,
+			))
+		case r.URL.Path == "/binary/breeze-agent":
+			// Serve the tampered bytes so the post-write verifyChecksum
+			// inside DownloadBinary fails.
+			w.Write(tamperedContent)
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	u := New(&Config{
+		ServerURL: server.URL,
+		AuthToken: secmem.NewSecureString("test-token"),
+	})
+	u.client = server.Client()
+
+	gotPath, err := u.DownloadBinary("1.0.0")
+	if err == nil {
+		t.Fatalf("expected checksum mismatch error, got nil (path=%q)", gotPath)
+	}
+	if gotPath != "" {
+		t.Fatalf("expected empty returned path on checksum failure, got %q", gotPath)
+	}
+
+	// Confirm no temp file was leaked: walk the redirected temp dir.
+	// The only entries should be ones t.TempDir created internally; the
+	// breeze-agent-dev-* file from downloadFromURL must not be present.
+	entries, err := os.ReadDir(tempRoot)
+	if err != nil {
+		t.Fatalf("failed to read temp dir %s: %v", tempRoot, err)
+	}
+	for _, entry := range entries {
+		// t.TempDir() places per-test subdirs under TMPDIR; allow those,
+		// but no breeze-agent-dev-* leftovers.
+		name := entry.Name()
+		if strings.HasPrefix(name, "breeze-agent-dev-") {
+			t.Fatalf("temp file leaked after checksum failure: %s", filepath.Join(tempRoot, name))
+		}
 	}
 }
 

--- a/agent/internal/updater/updater_test.go
+++ b/agent/internal/updater/updater_test.go
@@ -758,100 +758,10 @@ func TestNormalizePreflightErr_PreservesTextBusy(t *testing.T) {
 	}
 }
 
-func TestRollback_UnlinksBeforeWrite(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("unlink behavior is Unix-only")
-	}
-
-	tmpDir := t.TempDir()
-	binaryPath := filepath.Join(tmpDir, "breeze-agent")
-	backupPath := filepath.Join(tmpDir, "breeze-agent.backup")
-
-	// Create "current" binary and hold it open (simulates running executable)
-	os.WriteFile(binaryPath, []byte("corrupted"), 0755)
-	holder, err := os.Open(binaryPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer holder.Close()
-
-	origInfo, _ := os.Stat(binaryPath)
-	origSys := origInfo.Sys().(*syscall.Stat_t)
-	origIno := origSys.Ino
-
-	// Create backup
-	os.WriteFile(backupPath, []byte("good v0.1.0"), 0755)
-
-	u := New(&Config{BinaryPath: binaryPath, BackupPath: backupPath})
-	if err := u.Rollback(); err != nil {
-		t.Fatalf("rollback failed: %v", err)
-	}
-
-	// Verify rollback content
-	content, _ := os.ReadFile(binaryPath)
-	if string(content) != "good v0.1.0" {
-		t.Fatalf("rollback content mismatch: %s", string(content))
-	}
-
-	// Verify new inode (unlink happened)
-	newInfo, _ := os.Stat(binaryPath)
-	newSys := newInfo.Sys().(*syscall.Stat_t)
-	if newSys.Ino == origIno {
-		t.Fatal("expected new inode after unlink+create in rollback")
-	}
-}
-
-func TestReplaceBinary_UnlinksBeforeWrite(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("unlink behavior is Unix-only")
-	}
-
-	tmpDir := t.TempDir()
-	binaryPath := filepath.Join(tmpDir, "breeze-agent")
-	newBinaryPath := filepath.Join(tmpDir, "new-binary")
-
-	// Create current binary and hold it open (simulates running executable holding inode)
-	os.WriteFile(binaryPath, []byte("old binary"), 0755)
-	holder, err := os.Open(binaryPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer holder.Close()
-
-	// Record original inode
-	origInfo, _ := os.Stat(binaryPath)
-	origSys := origInfo.Sys().(*syscall.Stat_t)
-	origIno := origSys.Ino
-
-	// Create new binary
-	os.WriteFile(newBinaryPath, []byte("new binary v2"), 0644)
-
-	u := New(&Config{BinaryPath: binaryPath})
-	if err := u.replaceBinary(newBinaryPath); err != nil {
-		t.Fatalf("replace failed: %v", err)
-	}
-
-	// Verify new content at path
-	content, _ := os.ReadFile(binaryPath)
-	if string(content) != "new binary v2" {
-		t.Fatalf("expected new content, got: %s", string(content))
-	}
-
-	// Verify it's a NEW inode (unlink created a new file, not truncated old one)
-	newInfo, _ := os.Stat(binaryPath)
-	newSys := newInfo.Sys().(*syscall.Stat_t)
-	if newSys.Ino == origIno {
-		t.Fatal("expected new inode after unlink+create, but got same inode")
-	}
-
-	// Verify the held-open file descriptor still reads old content (kernel kept old inode)
-	holder.Seek(0, 0)
-	oldContent := make([]byte, 100)
-	n, _ := holder.Read(oldContent)
-	if string(oldContent[:n]) != "old binary" {
-		t.Fatalf("held FD should still read old content, got: %s", string(oldContent[:n]))
-	}
-}
+// TestRollback_UnlinksBeforeWrite and TestReplaceBinary_UnlinksBeforeWrite
+// live in updater_unix_test.go (build-tag !windows) because they use
+// syscall.Stat_t to inspect inodes, which doesn't exist on Windows. The
+// previous runtime-skip pattern still broke `go test -c` cross-compile.
 
 // TestTrustedManifestKeys_IncludesPinnedKeys verifies that per-deployment
 // pinned pubkeys delivered via heartbeat/enrollment (#625) are included in

--- a/agent/internal/updater/updater_unix_test.go
+++ b/agent/internal/updater/updater_unix_test.go
@@ -1,0 +1,100 @@
+//go:build !windows
+
+// Tests in this file rely on syscall.Stat_t / inode semantics that don't
+// exist on Windows. Splitting them out with a build tag keeps the rest of
+// updater_test.go cross-compilable for GOOS=windows.
+package updater
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestRollback_UnlinksBeforeWrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	binaryPath := filepath.Join(tmpDir, "breeze-agent")
+	backupPath := filepath.Join(tmpDir, "breeze-agent.backup")
+
+	// Create "current" binary and hold it open (simulates running executable)
+	os.WriteFile(binaryPath, []byte("corrupted"), 0755)
+	holder, err := os.Open(binaryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer holder.Close()
+
+	origInfo, _ := os.Stat(binaryPath)
+	origSys := origInfo.Sys().(*syscall.Stat_t)
+	origIno := origSys.Ino
+
+	// Create backup
+	os.WriteFile(backupPath, []byte("good v0.1.0"), 0755)
+
+	u := New(&Config{BinaryPath: binaryPath, BackupPath: backupPath})
+	if err := u.Rollback(); err != nil {
+		t.Fatalf("rollback failed: %v", err)
+	}
+
+	// Verify rollback content
+	content, _ := os.ReadFile(binaryPath)
+	if string(content) != "good v0.1.0" {
+		t.Fatalf("rollback content mismatch: %s", string(content))
+	}
+
+	// Verify new inode (unlink happened)
+	newInfo, _ := os.Stat(binaryPath)
+	newSys := newInfo.Sys().(*syscall.Stat_t)
+	if newSys.Ino == origIno {
+		t.Fatal("expected new inode after unlink+create in rollback")
+	}
+}
+
+func TestReplaceBinary_UnlinksBeforeWrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	binaryPath := filepath.Join(tmpDir, "breeze-agent")
+	newBinaryPath := filepath.Join(tmpDir, "new-binary")
+
+	// Create current binary and hold it open (simulates running executable holding inode)
+	os.WriteFile(binaryPath, []byte("old binary"), 0755)
+	holder, err := os.Open(binaryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer holder.Close()
+
+	// Record original inode
+	origInfo, _ := os.Stat(binaryPath)
+	origSys := origInfo.Sys().(*syscall.Stat_t)
+	origIno := origSys.Ino
+
+	// Create new binary
+	os.WriteFile(newBinaryPath, []byte("new binary v2"), 0644)
+
+	u := New(&Config{BinaryPath: binaryPath})
+	if err := u.replaceBinary(newBinaryPath); err != nil {
+		t.Fatalf("replace failed: %v", err)
+	}
+
+	// Verify new content at path
+	content, _ := os.ReadFile(binaryPath)
+	if string(content) != "new binary v2" {
+		t.Fatalf("expected new content, got: %s", string(content))
+	}
+
+	// Verify it's a NEW inode (unlink created a new file, not truncated old one)
+	newInfo, _ := os.Stat(binaryPath)
+	newSys := newInfo.Sys().(*syscall.Stat_t)
+	if newSys.Ino == origIno {
+		t.Fatal("expected new inode after unlink+create, but got same inode")
+	}
+
+	// Verify the held-open file descriptor still reads old content (kernel kept old inode)
+	holder.Seek(0, 0)
+	oldContent := make([]byte, 100)
+	n, _ := holder.Read(oldContent)
+	if string(oldContent[:n]) != "old binary" {
+		t.Fatalf("held FD should still read old content, got: %s", string(oldContent[:n]))
+	}
+}

--- a/apps/api/src/routes/agentVersions.test.ts
+++ b/apps/api/src/routes/agentVersions.test.ts
@@ -565,6 +565,36 @@ describe("agentVersions routes", () => {
 
       expect(res.status).toBe(404);
     });
+
+    // Issue #816 / PR #845: heartbeat.doUpgrade pre-downloads the user-helper
+    // for in-place Windows upgrades and treats a 404 from this route as a
+    // non-fatal "release predates #816, fall back to agent-only upgrade"
+    // signal. This test pins the 404 contract for the (version, platform,
+    // arch, component=user-helper) tuple that the agent's prefetchUserHelper
+    // depends on. If the route ever started returning 200/400/500 here,
+    // doUpgrade's fallback would break and we'd silently re-create the
+    // #816 production failure.
+    it("returns 404 when component=user-helper has no row (pins #845 agent fallback contract)", async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as any);
+
+      const res = await app.request(
+        "/agent-versions/1.0.0/download?platform=windows&arch=amd64&component=user-helper",
+      );
+
+      expect(res.status).toBe(404);
+      const body = (await res.json()) as { error?: string };
+      // Body MUST include some error message — the agent treats this as
+      // non-fatal, but droplet operators reading API logs need a human-
+      // readable reason. Empty bodies make the failure invisible.
+      expect(typeof body.error).toBe("string");
+      expect(body.error?.length ?? 0).toBeGreaterThan(0);
+    });
   });
 
   describe("POST /agent-versions", () => {

--- a/apps/api/src/services/binarySync.test.ts
+++ b/apps/api/src/services/binarySync.test.ts
@@ -90,6 +90,43 @@ function makeSignedReleaseManifest(assetName: string, assetBuffer: Buffer) {
   };
 }
 
+// Multi-asset variant for tests that need the same signed manifest to cover
+// both the agent and the user-helper sync loops (issue #816 / PR #845).
+function makeSignedReleaseManifestMulti(
+  assets: { name: string; buffer: Buffer }[],
+  release = "v1.2.3",
+) {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const publicDer = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+  const rawPublicKey = publicDer
+    .subarray(publicDer.length - 32)
+    .toString("base64");
+  const checksums = new Map<string, string>();
+  for (const a of assets) {
+    checksums.set(a.name, createHash("sha256").update(a.buffer).digest("hex"));
+  }
+  const manifest = Buffer.from(
+    JSON.stringify({
+      schemaVersion: 1,
+      repository: "LanternOps/breeze",
+      release,
+      assets: assets.map((a) => ({
+        name: a.name,
+        sha256: checksums.get(a.name)!,
+        size: a.buffer.length,
+        platformTrust: "release-workflow-produced",
+      })),
+    }),
+  );
+  return {
+    checksums,
+    manifest,
+    signature: Buffer.from(sign(null, manifest, privateKey).toString("base64")),
+    publicKey: rawPublicKey,
+    release,
+  };
+}
+
 describe("binarySync", () => {
   const originalEnv = process.env;
 
@@ -269,6 +306,211 @@ describe("binarySync", () => {
 
     errorSpy.mockRestore();
     warnSpy.mockRestore();
+  });
+
+  // Issue #816 / PR #845: syncFromGitHub gained a USER_HELPER_TARGETS loop
+  // that registers the windows/amd64 breeze-user-helper.exe asset as its own
+  // component=user-helper row. heartbeat.doUpgrade's prefetch then fetches
+  // it via GET /agent-versions/:v/download. The three tests below cover the
+  // load-bearing behaviors of that loop.
+  describe("syncFromGitHub user-helper loop (#816)", () => {
+    function stubGitHubReleaseFetch(
+      signed: ReturnType<typeof makeSignedReleaseManifestMulti>,
+      assetBytes: Map<string, Buffer>,
+    ) {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string) => {
+          if (url.includes("/releases/latest")) {
+            return new Response(
+              JSON.stringify({
+                tag_name: signed.release,
+                body: "release notes",
+                assets: [
+                  ...Array.from(assetBytes.entries()).map(([name, buf]) => ({
+                    name,
+                    browser_download_url: `https://github.com/LanternOps/breeze/releases/download/${signed.release}/${name}`,
+                    size: buf.length,
+                  })),
+                  {
+                    name: "release-artifact-manifest.json",
+                    browser_download_url: `https://github.com/LanternOps/breeze/releases/download/${signed.release}/release-artifact-manifest.json`,
+                    size: signed.manifest.length,
+                  },
+                  {
+                    name: "release-artifact-manifest.json.ed25519",
+                    browser_download_url: `https://github.com/LanternOps/breeze/releases/download/${signed.release}/release-artifact-manifest.json.ed25519`,
+                    size: signed.signature.length,
+                  },
+                ],
+              }),
+            );
+          }
+          if (url.endsWith("/release-artifact-manifest.json"))
+            return new Response(signed.manifest);
+          if (url.endsWith("/release-artifact-manifest.json.ed25519"))
+            return new Response(signed.signature);
+          return new Response("not found", { status: 404 });
+        }),
+      );
+    }
+
+    it("registers component=user-helper when both agent and user-helper assets are present", async () => {
+      const agentAsset = {
+        name: "breeze-agent-windows-amd64.exe",
+        buffer: Buffer.from("trusted windows agent bytes"),
+      };
+      const userHelperAsset = {
+        name: "breeze-user-helper-windows-amd64.exe",
+        buffer: Buffer.from("trusted user-helper bytes"),
+      };
+      const signed = makeSignedReleaseManifestMulti([
+        agentAsset,
+        userHelperAsset,
+      ]);
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      stubGitHubReleaseFetch(
+        signed,
+        new Map([
+          [agentAsset.name, agentAsset.buffer],
+          [userHelperAsset.name, userHelperAsset.buffer],
+        ]),
+      );
+
+      const result = await syncFromGitHub();
+
+      expect(result.version).toBe("1.2.3");
+      expect(result.synced).toEqual(
+        expect.arrayContaining([
+          "agent:windows/amd64",
+          "user-helper:windows/amd64",
+        ]),
+      );
+
+      // Assert the user-helper upsert specifically — same checksum + canonical
+      // browser_download_url the agent will resolve via the download route.
+      const userHelperInsert = (
+        dbMocks.insertValues.mock.calls as any[][]
+      ).find(
+        (call) =>
+          (call[0] as { component: string }).component === "user-helper",
+      );
+      expect(userHelperInsert).toBeDefined();
+      expect(userHelperInsert![0]).toMatchObject({
+        version: "1.2.3",
+        platform: "windows",
+        architecture: "amd64",
+        component: "user-helper",
+        checksum: signed.checksums.get(userHelperAsset.name),
+        downloadUrl: `https://github.com/LanternOps/breeze/releases/download/v1.2.3/${userHelperAsset.name}`,
+      });
+    });
+
+    it("succeeds without user-helper row when the asset is missing (pre-#816 release backward-compat)", async () => {
+      // Pre-#816 GitHub releases ship the agent asset but not the user-helper.
+      // The loop MUST short-circuit silently — anything else would block all
+      // historical releases from syncing.
+      const agentAsset = {
+        name: "breeze-agent-windows-amd64.exe",
+        buffer: Buffer.from("pre-816 agent bytes"),
+      };
+      const signed = makeSignedReleaseManifestMulti([agentAsset]);
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      stubGitHubReleaseFetch(
+        signed,
+        new Map([[agentAsset.name, agentAsset.buffer]]),
+      );
+
+      const result = await syncFromGitHub();
+
+      // Agent sync still succeeded.
+      expect(result.synced).toContain("agent:windows/amd64");
+      // No user-helper row registered.
+      expect(result.synced).not.toContain("user-helper:windows/amd64");
+      const userHelperInserts = dbMocks.insertValues.mock.calls.filter(
+        (call: any[]) => (call[0] as { component: string }).component === "user-helper",
+      );
+      expect(userHelperInserts).toHaveLength(0);
+    });
+
+    it("isolates user-helper upsert failures from the agent insert (logs error, agent still synced)", async () => {
+      // Mirror the existing error-handling pattern: per-target try/catch
+      // logs to console.error and continues with the next target. A
+      // user-helper insert failure MUST NOT abort the agent insert.
+      const agentAsset = {
+        name: "breeze-agent-windows-amd64.exe",
+        buffer: Buffer.from("agent bytes"),
+      };
+      const userHelperAsset = {
+        name: "breeze-user-helper-windows-amd64.exe",
+        buffer: Buffer.from("user-helper bytes"),
+      };
+      const signed = makeSignedReleaseManifestMulti([
+        agentAsset,
+        userHelperAsset,
+      ]);
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      stubGitHubReleaseFetch(
+        signed,
+        new Map([
+          [agentAsset.name, agentAsset.buffer],
+          [userHelperAsset.name, userHelperAsset.buffer],
+        ]),
+      );
+
+      // Make the transaction throw ONLY for the user-helper insert. Both
+      // agent and user-helper paths run through db.transaction(); detect
+      // which is which by peeking at the captured insertValues args.
+      const defaultTxImpl = async (fn: (tx: any) => Promise<void>) =>
+        fn(dbMocks.tx);
+      dbMocks.transaction.mockImplementation(
+        async (fn: (tx: any) => Promise<void>) => {
+          // Wrap the inner insert to inspect its values before deciding
+          // whether to throw.
+          const insertWrap = vi.fn((row: Record<string, unknown>) => {
+            if (row.component === "user-helper") {
+              // Record the captured row so the assertion below can still
+              // inspect what would have been inserted.
+              (dbMocks.insertValues as any)(row);
+              throw new Error("simulated user-helper upsert failure");
+            }
+            return (dbMocks.insertValues as any)(row);
+          });
+          const tx = {
+            update: dbMocks.tx.update,
+            insert: vi.fn(() => ({ values: insertWrap })),
+          };
+          return fn(tx);
+        },
+      );
+
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      try {
+        const result = await syncFromGitHub();
+
+        // Agent insert succeeded.
+        expect(result.synced).toContain("agent:windows/amd64");
+        // User-helper insert did NOT make it into the synced list.
+        expect(result.synced).not.toContain("user-helper:windows/amd64");
+
+        // Error was logged via console.error (don't pin the exact string;
+        // the file's existing pattern is `[binarySync] Failed to upsert
+        // user-helper version for ...`).
+        const userHelperErrCalls = errorSpy.mock.calls.filter((args) =>
+          String(args[0] ?? "").includes("user-helper"),
+        );
+        expect(userHelperErrCalls.length).toBeGreaterThan(0);
+      } finally {
+        errorSpy.mockRestore();
+        // Restore the hoisted default so later tests don't recurse through
+        // the wrapper above.
+        dbMocks.transaction.mockImplementation(defaultTxImpl);
+      }
+    });
   });
 
   it("upserts local agent binaries with the full 4-column conflict target (regression: #617)", async () => {


### PR DESCRIPTION
This is **part 3 of 3** in the #845 follow-up series. Part 1 (correctness, #848) and Part 2 (refactor, #849) already merged. This PR closes the test-coverage gaps surfaced by the multi-agent review of #845.

## Gaps addressed (mapped to the review)

### T1 — `binarySync.ts` USER_HELPER_TARGETS sync loop (review rating 8/10, "critical")
File: `apps/api/src/services/binarySync.test.ts`

New `describe("syncFromGitHub user-helper loop (#816)")` block with three cases mirroring the existing AGENT_TARGETS test model:

1. **Happy path:** release with both `breeze-agent-windows-amd64.exe` and `breeze-user-helper-windows-amd64.exe` assets — asserts `result.synced` includes `"user-helper:windows/amd64"` AND `upsertVersion` is called with `component: "user-helper"` and the canonical `browser_download_url`.
2. **Missing asset (backward-compat):** release with only the agent asset — asserts `result.synced` does NOT include `user-helper`, no exception thrown, agent sync still succeeded. Load-bearing for pre-#816 releases.
3. **Upsert failure isolation:** `db.transaction` rigged to throw on the user-helper insert — asserts the agent insert still ran, error logged via `console.error`, mirroring the per-target try/catch pattern already in the file.

Adds a multi-asset variant of `makeSignedReleaseManifest` so a single signed release-artifact-manifest.json can cover both assets (required by the GH manifest verifier).

### T2 — `doUpgrade` user-helper fallback path (review rating 8/10, "critical")
Files: `agent/internal/heartbeat/heartbeat.go`, `agent/internal/heartbeat/heartbeat_userhelper_test.go`

Used **Option A (function-pointer injection)**.

**Refactor (byte-equivalent to inline code post-PR-A/B):** factored the user-helper pre-download block out of `doUpgrade` into a new method:

```go
func (h *Heartbeat) prefetchUserHelper(targetVersion, binaryPath string) *updater.BinaryPair
```

Two test seams added to the `Heartbeat` struct:

- `userHelperDownloader func(string) (string, error)` — replaces `updater.Updater.DownloadBinary` (mirrors its signature so the prod default is a one-line shim).
- `userHelperGOOS string` — replaces `runtime.GOOS` so the Windows-only short-circuit can be exercised on Linux/macOS CI hosts.

Both default to zero values in production; the real updater and `runtime.GOOS` are used.

**`doUpgrade` diff is strictly behavior-preserving** — the block is replaced with a single line:

```go
userHelperPair := h.prefetchUserHelper(targetVersion, binaryPath)
```

passed unchanged into the existing `UpdateToWithOptions` call. Same Windows-only check, same `updater.Config`, same `updater.New(...).DownloadBinary` call, same WARN/INFO log args, same `BinaryPair{Temp, Target=filepath.Join(filepath.Dir(binaryPath), "breeze-user-helper.exe")}`.

New `heartbeat_userhelper_test.go` covers four cases:

1. **Happy path:** stub returns `(tempPath, nil)` → non-nil `*BinaryPair` with `Temp == tempPath` and `Target == <agent-dir>/breeze-user-helper.exe`.
2. **Download failure:** stub returns `("", err)` → `nil`; downloader still called exactly once.
3. **Non-Windows runtime** (linux, darwin): `nil`; downloader **never** invoked (verified via atomic counter — non-Windows agents shouldn't waste server load on the helper artifact).
4. **Default `runtime.GOOS` fallback** on non-Windows CI hosts: `nil` without touching the network — smoke test for the production short-circuit.

### T3 — Negative case for `component=user-helper` download route
File: `apps/api/src/routes/agentVersions.test.ts`

One new test: GET `/agent-versions/1.0.0/download?platform=windows&arch=amd64&component=user-helper` with no row returns 404 with a non-empty `error` field. Pins the contract that `prefetchUserHelper`'s 404-graceful fallback depends on.

### T4 — `DownloadBinary` checksum-failure cleanup
File: `agent/internal/updater/updater_test.go`

`TestDownloadBinary_ChecksumMismatchCleansUpTempFile` — uses the existing `httptest.Server` pattern, serves bytes that don't match the manifest checksum, asserts:

- `err != nil`
- returned path is `""`
- no `breeze-agent-dev-*` temp file leaked in `TMPDIR` (verified the test catches a sabotaged build that drops the `removeCleanup` call).

### T5 — Pre-existing Windows cross-compile breakage in `updater_test.go`
Files: `agent/internal/updater/updater_test.go`, `agent/internal/updater/updater_unix_test.go` (new)

The two `syscall.Stat_t`-using tests (`TestRollback_UnlinksBeforeWrite`, `TestReplaceBinary_UnlinksBeforeWrite`) had a runtime `t.Skip` on Windows, but the `Stat_t` reference outside the skip broke `GOOS=windows go test -c ./internal/updater/...`. Moved both tests into a new `updater_unix_test.go` with `//go:build !windows`. Behavior unchanged — these tests never ran on Windows.

## Test plan

```
# API
cd apps/api
npx tsc --noEmit                                                     # clean
npx vitest run src/services/binarySync.test.ts \
               src/routes/agentVersions.test.ts                       # 31 tests pass
npx eslint src/services/binarySync.test.ts \
           src/routes/agentVersions.test.ts                           # clean

# Agent
cd agent
go build ./...                                                        # clean
go vet ./...                                                          # clean
GOOS=windows GOARCH=amd64 go build ./...                              # clean
GOOS=windows GOARCH=amd64 go test -c -o /dev/null ./internal/updater/... # clean (broken pre-T5)
go test -race ./internal/updater/... ./internal/heartbeat/...         # all pass (race clean)
```

## Test counts (new tests landed)

| Surface | File | New tests |
|---|---|---|
| API | `apps/api/src/services/binarySync.test.ts` | 3 |
| API | `apps/api/src/routes/agentVersions.test.ts` | 1 |
| Agent | `agent/internal/updater/updater_test.go` | 1 |
| Agent | `agent/internal/heartbeat/heartbeat_userhelper_test.go` (new file) | 4 |

T5 is a build-fix, no new test logic.

## Closing note

This is the final part of the #845 follow-up series. With this merged:

- #848 (correctness fixes) ✓
- #849 (UpdateOptions refactor) ✓
- This PR (test coverage gaps + T5 cross-compile fix) ← merge to complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)
