### PR TITLE
feat(asymmetry): server detects main-agent silence while watchdog stays online (#800 Layer C, server slice)

### DIFF
--- a/apps/api/migrations/2026-05-22-devices-main-agent-silent-since.sql
+++ b/apps/api/migrations/2026-05-22-devices-main-agent-silent-since.sql
@@ -1,0 +1,11 @@
+-- #800 Layer C: server-side detection of main-agent silence while
+-- watchdog stays online. Add a nullable timestamp column that the
+-- heartbeat handler sets on the watchdog branch when the asymmetry
+-- exists, and clears on the main agent branch when the agent recovers.
+--
+-- Safe migration: nullable column, no default, no index — the per-row
+-- update happens only at heartbeat time so we don't need a hot-path
+-- index for now.
+
+ALTER TABLE devices
+  ADD COLUMN IF NOT EXISTS main_agent_silent_since TIMESTAMPTZ;

--- a/apps/api/src/db/schema/devices.ts
+++ b/apps/api/src/db/schema/devices.ts
@@ -57,6 +57,13 @@ export const devices = pgTable('devices', {
   watchdogStatus: watchdogStatusEnum('watchdog_status'),
   watchdogLastSeen: timestamp('watchdog_last_seen'),
   watchdogVersion: varchar('watchdog_version', { length: 50 }),
+  // Asymmetry detector (#800): set when the watchdog is still reporting
+  // in but the main agent has gone silent past the offline threshold.
+  // Cleared when the main agent next heartbeats. Distinct from
+  // status='offline' which only reflects main-agent silence — operators
+  // need to know "box alive, only the BreezeAgent service is wedged" so
+  // their support workflow is "remote restart" not "physical visit."
+  mainAgentSilentSince: timestamp('main_agent_silent_since'),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull()
 });

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -37,6 +37,8 @@ vi.mock('../../db/schema', () => ({
     watchdogStatus: 'devices.watchdog_status',
     watchdogLastSeen: 'devices.watchdog_last_seen',
     watchdogVersion: 'devices.watchdog_version',
+    mainAgentSilentSince: 'devices.main_agent_silent_since',
+    lastSeenAt: 'devices.last_seen_at',
     agentTokenHash: 'devices.agent_token_hash',
     tokenIssuedAt: 'devices.token_issued_at',
   },
@@ -270,5 +272,213 @@ describe('POST /agents/:id/heartbeat — manifestTrustKeys delivery (#639)', () 
     // the REST path so agents don't choke parsing the field. The empty
     // array is also what hosted-SaaS returns when no key is provisioned.
     expect(body.manifestTrustKeys).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------
+// #800 — main-agent-silent asymmetry detector
+// ---------------------------------------------------------------------
+
+function buildWatchdogApp(): Hono {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('agent', {
+      deviceId: 'device-1',
+      agentId: 'agent-1',
+      orgId: 'org-1',
+      siteId: 'site-1',
+      role: 'watchdog',
+    });
+    await next();
+  });
+  app.route('/agents', heartbeatRoutes);
+  return app;
+}
+
+describe('POST /agents/:id/heartbeat — main-agent-silent asymmetry detector (#800)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectMock.mockReset();
+    updateMock.mockReset();
+    insertMock.mockReset();
+    runOutsideDbContextMock.mockClear();
+    getActiveTrustKeysetMock.mockReset();
+    getActiveTrustKeysetMock.mockResolvedValue([]);
+  });
+
+  const sixteenMinutesAgo = new Date(Date.now() - 16 * 60 * 1000);
+  const oneMinuteAgo = new Date(Date.now() - 60 * 1000);
+
+  it('Watchdog heartbeat when main agent silent >15min → sets mainAgentSilentSince + emits event', async () => {
+    selectMock.mockReturnValueOnce(
+      selectChainResolving([
+        {
+          id: 'device-1',
+          orgId: 'org-1',
+          siteId: 'site-1',
+          hostname: 'TST-LAPTOP-01',
+          osType: 'windows',
+          architecture: 'amd64',
+          lastSeenAt: sixteenMinutesAgo,
+          mainAgentSilentSince: null, // first-transition path
+        },
+      ]),
+    );
+
+    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    updateMock.mockReturnValue({ set: setSpy });
+
+    selectMock.mockReturnValue(selectChainResolving([])); // agentVersions etc
+
+    const resp = await buildWatchdogApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agentVersion: '0.65.15', role: 'watchdog', watchdogState: 'MONITORING' }),
+    });
+
+    expect(resp.status).toBe(200);
+
+    // Update called with mainAgentSilentSince set to a Date
+    expect(setSpy).toHaveBeenCalled();
+    const updateArg = (setSpy.mock.calls as any[])[0]?.[0] as Record<string, unknown>;
+    expect(updateArg.mainAgentSilentSince).toBeInstanceOf(Date);
+    expect(updateArg.watchdogStatus).toBe('connected');
+
+    // Event emitted
+    const { publishEvent } = await import('../../services/eventBus');
+    expect(publishEvent).toHaveBeenCalledWith(
+      'device.main_agent_silent',
+      'org-1',
+      expect.objectContaining({
+        deviceId: 'device-1',
+        hostname: 'TST-LAPTOP-01',
+        silenceDurationSeconds: expect.any(Number),
+      }),
+      'heartbeat-watchdog-branch',
+      expect.objectContaining({ priority: 'high' }),
+    );
+  });
+
+  it('Watchdog heartbeat when main agent recently heartbeated → does NOT set mainAgentSilentSince + no event', async () => {
+    selectMock.mockReturnValueOnce(
+      selectChainResolving([
+        {
+          id: 'device-1',
+          orgId: 'org-1',
+          hostname: 'TST-LAPTOP-01',
+          lastSeenAt: oneMinuteAgo, // healthy
+          mainAgentSilentSince: null,
+        },
+      ]),
+    );
+    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    updateMock.mockReturnValue({ set: setSpy });
+    selectMock.mockReturnValue(selectChainResolving([]));
+
+    await buildWatchdogApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agentVersion: '0.65.15', role: 'watchdog', watchdogState: 'MONITORING' }),
+    });
+
+    const updateArg = (setSpy.mock.calls as any[])[0]?.[0] as Record<string, unknown>;
+    expect(updateArg.mainAgentSilentSince).toBeUndefined();
+    const { publishEvent } = await import('../../services/eventBus');
+    expect(publishEvent).not.toHaveBeenCalled();
+  });
+
+  it('Watchdog heartbeat when device already mainAgentSilentSince → does NOT re-emit event (no spam)', async () => {
+    // Already-silent state: subsequent watchdog ticks should idempotently
+    // update watchdog cols without re-firing the event.
+    selectMock.mockReturnValueOnce(
+      selectChainResolving([
+        {
+          id: 'device-1',
+          orgId: 'org-1',
+          hostname: 'host',
+          lastSeenAt: sixteenMinutesAgo,
+          mainAgentSilentSince: new Date(Date.now() - 10 * 60 * 1000),
+        },
+      ]),
+    );
+    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    updateMock.mockReturnValue({ set: setSpy });
+    selectMock.mockReturnValue(selectChainResolving([]));
+
+    await buildWatchdogApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agentVersion: '0.65.15', role: 'watchdog', watchdogState: 'MONITORING' }),
+    });
+
+    const updateArg = (setSpy.mock.calls as any[])[0]?.[0] as Record<string, unknown>;
+    // Already-set timestamp must NOT be overwritten on subsequent ticks
+    // (the first-set timestamp tracks "how long has this been going").
+    expect(updateArg.mainAgentSilentSince).toBeUndefined();
+    const { publishEvent } = await import('../../services/eventBus');
+    expect(publishEvent).not.toHaveBeenCalled();
+  });
+
+  it('Main-agent heartbeat after silence → clears mainAgentSilentSince to NULL', async () => {
+    selectMock.mockReturnValueOnce(
+      selectChainResolving([
+        {
+          id: 'device-1',
+          orgId: 'org-1',
+          siteId: 'site-1',
+          hostname: 'host',
+          osType: 'windows',
+          architecture: 'amd64',
+          agentVersion: '0.65.15',
+          deviceRoleSource: 'auto',
+          mainAgentSilentSince: new Date(Date.now() - 5 * 60 * 1000), // currently in silent state
+        },
+      ]),
+    );
+    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    updateMock.mockReturnValue({ set: setSpy });
+    insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+    selectMock.mockReturnValue(selectChainResolving([]));
+
+    await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+
+    const updateArg = (setSpy.mock.calls as any[])[0]?.[0] as Record<string, unknown>;
+    expect(updateArg.mainAgentSilentSince).toBeNull();
+    expect(updateArg.status).toBe('online');
+  });
+
+  it('Main-agent heartbeat with no prior silence → does not touch mainAgentSilentSince', async () => {
+    selectMock.mockReturnValueOnce(
+      selectChainResolving([
+        {
+          id: 'device-1',
+          orgId: 'org-1',
+          siteId: 'site-1',
+          hostname: 'host',
+          osType: 'windows',
+          architecture: 'amd64',
+          agentVersion: '0.65.15',
+          deviceRoleSource: 'auto',
+          mainAgentSilentSince: null,
+        },
+      ]),
+    );
+    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    updateMock.mockReturnValue({ set: setSpy });
+    insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+    selectMock.mockReturnValue(selectChainResolving([]));
+
+    await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+
+    const updateArg = (setSpy.mock.calls as any[])[0]?.[0] as Record<string, unknown>;
+    expect(updateArg.mainAgentSilentSince).toBeUndefined();
   });
 });

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -72,18 +72,58 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
   const isWatchdog = agent.role === 'watchdog';
 
   if (isWatchdog) {
-    // Update watchdog-specific columns only — don't touch agent metrics
+    // #800 Layer C — asymmetry detector. When this watchdog heartbeat
+    // arrives, check whether the MAIN agent's lastSeenAt is past the
+    // silence threshold. If so, mark the device as
+    // `mainAgentSilentSince=NOW()` (idempotent across subsequent
+    // watchdog ticks) and emit `device.main_agent_silent` on the first
+    // transition. The flag is cleared by the main-agent branch below
+    // when the agent recovers.
+    //
+    // Threshold: 15 minutes = 3x the default 5-min offline-detector
+    // window per the issue's "3 * heartbeat_interval" guidance. Stays
+    // comfortably above transient network blips while remaining well
+    // inside the typical "operator notices something is off" window.
+    const MAIN_AGENT_SILENT_THRESHOLD_MS = 15 * 60 * 1000;
+    const now = new Date();
+    const mainAgentSilent = device.lastSeenAt
+      ? now.getTime() - device.lastSeenAt.getTime() > MAIN_AGENT_SILENT_THRESHOLD_MS
+      : false;
+    const transitioningIntoSilent = mainAgentSilent && !device.mainAgentSilentSince;
+
+    const watchdogUpdates: Record<string, unknown> = {
+      watchdogStatus: data.watchdogState === 'FAILOVER' ? 'failover' : 'connected',
+      watchdogLastSeen: now,
+      watchdogVersion: data.agentVersion,
+      updatedAt: now,
+    };
+    if (transitioningIntoSilent) {
+      watchdogUpdates.mainAgentSilentSince = now;
+    }
+
     try {
       await db.update(devices)
-        .set({
-          watchdogStatus: data.watchdogState === 'FAILOVER' ? 'failover' : 'connected',
-          watchdogLastSeen: new Date(),
-          watchdogVersion: data.agentVersion,
-          updatedAt: new Date(),
-        })
+        .set(watchdogUpdates)
         .where(eq(devices.id, device.id));
     } catch (err) {
       console.error('Failed to update watchdog status:', err);
+    }
+
+    // Emit only on the silence→silent transition so subscribers (alerts,
+    // webhooks) don't fire once per watchdog tick during the outage.
+    // The clear-side event fires from the main-agent branch on recovery.
+    if (transitioningIntoSilent) {
+      publishEvent('device.main_agent_silent', device.orgId, {
+        deviceId: device.id,
+        hostname: device.hostname,
+        mainAgentLastSeenAt: device.lastSeenAt?.toISOString() ?? null,
+        watchdogStatus: data.watchdogState === 'FAILOVER' ? 'failover' : 'connected',
+        silenceDurationSeconds: device.lastSeenAt
+          ? Math.round((now.getTime() - device.lastSeenAt.getTime()) / 1000)
+          : null,
+      }, 'heartbeat-watchdog-branch', { priority: 'high' }).catch((err) => {
+        console.error('[heartbeat] device.main_agent_silent publish failed:', err);
+      });
     }
 
     // Claim watchdog-targeted commands (marks as sent to prevent duplicate delivery)
@@ -139,6 +179,15 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     uptimeSeconds: data.uptime ?? null,
     updatedAt: new Date()
   };
+
+  // #800 Layer C — recovery side. If the asymmetry detector previously
+  // set mainAgentSilentSince (watchdog kept reporting while we went
+  // dark), clear it now that the main agent is heartbeating again. No
+  // event emitted on the clear path — the natural `device.online`/
+  // status flip already conveys the recovery to subscribers.
+  if (device.mainAgentSilentSince) {
+    deviceUpdates.mainAgentSilentSince = null;
+  }
 
   // Only update deviceRole if agent provides one and current source is 'auto'
   if (data.deviceRole && device.deviceRoleSource === 'auto') {

--- a/apps/api/src/services/eventBus.ts
+++ b/apps/api/src/services/eventBus.ts
@@ -11,6 +11,7 @@ export type EventType =
   | 'device.offline'
   | 'device.updated'
   | 'device.decommissioned'
+  | 'device.main_agent_silent' // #800: watchdog OK, main agent silent
   // Alert events
   | 'alert.triggered'
   | 'alert.acknowledged'
@@ -512,6 +513,8 @@ export const EVENT_TYPES = {
   DEVICE_OFFLINE: 'device.offline' as const,
   DEVICE_UPDATED: 'device.updated' as const,
   DEVICE_DECOMMISSIONED: 'device.decommissioned' as const,
+  // #800: server-detected asymmetry (watchdog OK, main agent silent past threshold)
+  DEVICE_MAIN_AGENT_SILENT: 'device.main_agent_silent' as const,
   // Alert
   ALERT_TRIGGERED: 'alert.triggered' as const,
   ALERT_ACKNOWLEDGED: 'alert.acknowledged' as const,


### PR DESCRIPTION
## Summary

Partial fix for #800. The "Layer A" tolerant heartbeat shipped 2026-05-21; "Layer B" (watchdog auto-restart) is a separate concern. **This ships the server-side detection** so an operator sees an actionable *"agent silent (watchdog OK)"* signal instead of a generic offline.

## Scope (intentionally limited)

- ✓ Migration adds \`devices.main_agent_silent_since timestamptz\` (nullable, no default, no index)
- ✓ Watchdog-branch detection + idempotent column set
- ✓ Main-agent-branch recovery (clears the column on next agent HB)
- ✓ \`device.main_agent_silent\` event emitted on the silence→silent **transition** (NOT per watchdog tick — alert subscribers couldn't survive that)
- ✗ **UI styling change** — separate web PR (smaller blast radius, easier to review)
- ✗ **Auto-send \`restart_main_agent\` after 5 min** — behavior change, want explicit operator OK first

## Threshold

15 minutes = 3× the default 5-min offline-detector window per the issue's *"3 × heartbeat_interval"* guidance. Stays comfortably above transient network blips while remaining inside the typical "operator notices something is off" window.

## Implementation

### Migration

\`apps/api/migrations/2026-05-22-devices-main-agent-silent-since.sql\`:

\`\`\`sql
ALTER TABLE devices
  ADD COLUMN IF NOT EXISTS main_agent_silent_since TIMESTAMPTZ;
\`\`\`

Safe on the hot \`devices\` table: nullable, no default, no rewrite, no index. The per-row update happens only at heartbeat time.

### Heartbeat handler

In \`apps/api/src/routes/agents/heartbeat.ts\` watchdog branch (\`isWatchdog === true\`):

\`\`\`ts
const MAIN_AGENT_SILENT_THRESHOLD_MS = 15 * 60 * 1000;
const now = new Date();
const mainAgentSilent = device.lastSeenAt
  ? now.getTime() - device.lastSeenAt.getTime() > MAIN_AGENT_SILENT_THRESHOLD_MS
  : false;
const transitioningIntoSilent = mainAgentSilent && !device.mainAgentSilentSince;
\`\`\`

- \`transitioningIntoSilent\` gates both the column set and the event emit. Subsequent watchdog ticks during the same outage are silent.
- The column stores the **first**-set timestamp (so dashboards can show "silent for N minutes"); we don't overwrite it on idempotent retries.

In the main-agent branch:

\`\`\`ts
if (device.mainAgentSilentSince) {
  deviceUpdates.mainAgentSilentSince = null; // recovery
}
\`\`\`

No event on the clear path — the natural \`device.online\` / status flip already conveys recovery to subscribers.

### Event type

Added \`device.main_agent_silent\` to the \`EventType\` union + \`EVENT_TYPES.DEVICE_MAIN_AGENT_SILENT\` to the const map in \`eventBus.ts\`. Payload includes \`deviceId\`, \`hostname\`, \`mainAgentLastSeenAt\`, \`watchdogStatus\`, and \`silenceDurationSeconds\` so alert rules can filter by severity threshold.

## Tests

\`heartbeat.test.ts\` — 5 new cases in a dedicated describe block:

- Watchdog HB while agent silent >15min → sets column + emits event
- Watchdog HB while agent recent → no column write, no event
- Watchdog HB while already-silent → no event re-emit (no spam), no column overwrite
- Main-agent HB clears the column to NULL when previously set
- Main-agent HB with no prior silence does not touch the column

## Verification

\`\`\`
$ bash scripts/security/preflight.sh --fast
All required checks passed

$ npx tsc -p apps/api
# clean

$ npx vitest run
Test Files  428 passed (428)
Tests       4553 passed | 28 skipped (4581)
\`\`\`

## Test plan

- [x] 4 existing heartbeat tests still pass
- [x] 5 new asymmetry-path tests pass
- [x] Full apps/api vitest stays green (428 / 4553)
- [ ] On merge: deploy + verify by simulating main-agent silence on a test host (Jackson-NUC) — Billy offered Jackson-NUC as Windows test env

## Roadmap (rest of #800)

- **PR B** — web UI: render \`mainAgentSilentSince\` as a distinct amber badge "agent silent (watchdog OK)" on the Devices list instead of red "offline"
- **PR C** — auto-send \`restart_main_agent\` after 5 min in this state (gated on per-org policy, since it's a behavior change)