### PR TITLE
fix(installer): apply SCM service-recovery actions on MSI deploys

### DIFF
--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -109,7 +109,7 @@
     <CustomAction
       Id="ConfigureBreezeFailureActions"
       Property="BREEZE_SC_FAILURE_CMD"
-      ExeCommand="/c sc failure BreezeAgent reset= 86400 actions= restart/5000/restart/10000/restart/30000 &amp; sc failure BreezeWatchdog reset= 86400 actions= restart/5000/restart/10000/restart/30000 &amp; exit /b 0"
+      ExeCommand="/c &quot;sc failure BreezeAgent reset= 86400 actions= restart/5000/restart/10000/restart/30000 &amp; sc failure BreezeWatchdog reset= 86400 actions= restart/5000/restart/10000/restart/30000&quot;"
       Execute="deferred"
       Impersonate="no"
       Return="ignore" />

--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -64,6 +64,7 @@
     <Property Id="POWERSHELL_EXE" Secure="yes" />
     <Property Id="BREEZE_KILL_CMD" Secure="yes" />
     <Property Id="BREEZE_ACL_CMD" Secure="yes" />
+    <Property Id="BREEZE_SC_FAILURE_CMD" Secure="yes" />
     <CustomAction Id="SetPowerShellPath" Property="POWERSHELL_EXE" Value="[System64Folder]WindowsPowerShell\v1.0\powershell.exe" />
 
     <!-- Kill any running Breeze processes before InstallValidate so upgrades
@@ -90,6 +91,28 @@
       ExeCommand="/c (if not exist &quot;[ProgramDataBreezeDir].&quot; mkdir &quot;[ProgramDataBreezeDir].&quot;) &amp;&amp; (if not exist &quot;[ProgramDataBreezeDataDir].&quot; mkdir &quot;[ProgramDataBreezeDataDir].&quot;) &amp;&amp; (if not exist &quot;[ProgramDataBreezeLogsDir].&quot; mkdir &quot;[ProgramDataBreezeLogsDir].&quot;) &amp;&amp; icacls &quot;[ProgramDataBreezeDir].&quot; /inheritance:r /grant:r *S-1-5-18:(OI)(CI)F *S-1-5-32-544:(OI)(CI)F &amp;&amp; icacls &quot;[ProgramDataBreezeDataDir].&quot; /inheritance:r /grant:r *S-1-5-18:(OI)(CI)F *S-1-5-32-544:(OI)(CI)F &amp;&amp; icacls &quot;[ProgramDataBreezeLogsDir].&quot; /inheritance:r /grant:r *S-1-5-18:(OI)(CI)F *S-1-5-32-544:(OI)(CI)F"
       Execute="immediate"
       Return="check" />
+
+    <!-- Set SCM failure-action recovery on both services after they're
+         installed. Mirrors agent/cmd/breeze-agent/service_cmd_windows.go:72-79
+         and agent/cmd/breeze-watchdog/service_cmd_windows.go:63-67 (5s/10s/30s
+         restart escalation with 24-hour counter reset).
+
+         Without this, MSI-installed services have no SCM-driven auto-restart;
+         only `breeze-agent.exe service install` (the manual subcommand)
+         applied the recovery actions before. So every MSI deployment was
+         missing this hardening.
+
+         `sc failure` syntax: spaces after each `=` are mandatory; actions are
+         a slash-separated list of (actionType/delayMs) pairs. exit /b 0 at
+         the end so a transient sc-error doesn't roll back the install. -->
+    <SetProperty Id="BREEZE_SC_FAILURE_CMD" Value="[System64Folder]cmd.exe" Before="ConfigureBreezeFailureActions" Sequence="execute" />
+    <CustomAction
+      Id="ConfigureBreezeFailureActions"
+      Property="BREEZE_SC_FAILURE_CMD"
+      ExeCommand="/c sc failure BreezeAgent reset= 86400 actions= restart/5000/restart/10000/restart/30000 &amp; sc failure BreezeWatchdog reset= 86400 actions= restart/5000/restart/10000/restart/30000 &amp; exit /b 0"
+      Execute="deferred"
+      Impersonate="no"
+      Return="ignore" />
 
     <StandardDirectory Id="ProgramFiles64Folder">
       <Directory Id="INSTALLFOLDER" Name="Breeze">
@@ -256,6 +279,10 @@
            gate skipped repair, leaving repaired installs with stale task
            pointers. -->
       <Custom Action="RegisterUserHelperTask" After="InstallServices" Condition="NOT REMOVE" />
+      <!-- Apply SCM recovery actions immediately after the services are
+           registered. Deferred + non-impersonated so it runs as LocalSystem
+           (which sc.exe needs for SERVICE_CHANGE_CONFIG). -->
+      <Custom Action="ConfigureBreezeFailureActions" After="InstallServices" Condition="NOT REMOVE" />
       <!-- Enrollment runs after file copy but before InstallServices.
 
            Return="check" on the EnrollAgent CA means a non-zero exit

--- a/agent/installer/scripts/verify-recovery-actions.cmd
+++ b/agent/installer/scripts/verify-recovery-actions.cmd
@@ -1,0 +1,36 @@
+@echo off
+REM Verify the SCM service-recovery actions are set on a Breeze install.
+REM
+REM Run on a FRESH VM after MSI install. An upgrade over a developer-
+REM installed agent (where `breeze-agent service install` had been run)
+REM will look correct even if the MSI CustomAction never fired, so this
+REM only proves correctness on a clean-slate install.
+REM
+REM Expected output for each service:
+REM   RESET_PERIOD (in seconds)    : 86400
+REM   FAILURE_ACTIONS              : RESTART -- Delay = 5000 milliseconds.
+REM                                : RESTART -- Delay = 10000 milliseconds.
+REM                                : RESTART -- Delay = 30000 milliseconds.
+
+setlocal
+set EXIT=0
+
+echo === BreezeAgent ===
+sc qfailure BreezeAgent | findstr /C:"RESET_PERIOD" /C:"RESTART"
+if errorlevel 1 set EXIT=1
+
+echo.
+echo === BreezeWatchdog ===
+sc qfailure BreezeWatchdog | findstr /C:"RESET_PERIOD" /C:"RESTART"
+if errorlevel 1 set EXIT=1
+
+echo.
+if "%EXIT%"=="0" (
+  echo OK: recovery actions present on both services.
+) else (
+  echo FAIL: recovery actions missing on one or both services.
+  echo Check that the MSI CustomAction "ConfigureBreezeFailureActions"
+  echo fired during install. Re-run "msiexec /i breeze-agent.msi /l*v
+  echo install.log" and grep install.log for ConfigureBreezeFailureActions.
+)
+exit /b %EXIT%


### PR DESCRIPTION
## Summary

The MSI's `<ServiceInstall>` elements for `BreezeAgent` and `BreezeWatchdog` ship with no SCM recovery actions. The Go subcommand path at `agent/cmd/breeze-agent/service_cmd_windows.go:72-79` sets 5s/10s/30s restart escalation with a 24h reset window, but that subcommand only runs when a developer manually invokes `breeze-agent service install`. **Pure-MSI deployments go directly through `ServiceInstall` and end up with no auto-restart at all** — if either binary crashes hard (segfault, panic to OS, OOM kill), the SCM does nothing.

Defense in depth, complementary to #852: #852 handles the wedge case (process alive, heartbeat stalled). This handles the crash case (process gone). Together they cover both.

## What changes

`agent/installer/breeze.wxs`:
- Adds property `BREEZE_SC_FAILURE_CMD`
- Adds deferred CustomAction `ConfigureBreezeFailureActions` that shells out to `sc failure` for both services after they're created
- Sequences it `After="InstallServices"` with `NOT REMOVE` so it only runs on install/upgrade, not uninstall

Mirrors the existing `KillBreezeProcesses` / `HardenProgramDataAcl` CA pattern in this same file (CustomAction shells `[System64Folder]cmd.exe`). Does not require the WiX Util extension or any build-tool changes.

`sc failure` syntax notes: spaces after every `=` are mandatory; the `restart/5000/restart/10000/restart/30000` actions field is 5s/10s/30s restart escalation; `reset= 86400` resets the counter after 24h of stable running. `exit /b 0` at the end so a transient sc error doesn't roll back the install.

## Test

Manual verification on a Windows test box:
```cmd
msiexec /i breeze-agent.msi /qn
sc qfailure BreezeAgent
sc qfailure BreezeWatchdog
```
Both should report:
```
RESET_PERIOD: 86400 seconds
FAILURE_ACTIONS: RESTART/5000 / RESTART/10000 / RESTART/30000
```

No Go code touched — agent test suite unaffected. WiX compile validated by the existing CI MSI build job.

## Refs

Related: #799 / #852 (watchdog auto-restart, the wedge-case sibling to this crash-case fix). No code-level dependency between them — this PR is fully self-contained.