### PR TITLE
fix(devices): reject duplicate refresh_inventory commands with 409 (#830)

### DIFF
--- a/apps/api/src/routes/devices/commands.test.ts
+++ b/apps/api/src/routes/devices/commands.test.ts
@@ -361,12 +361,21 @@ describe('device commands routes', () => {
       expect(auditPayload).not.toContain('abc123');
     });
 
-    it('queues a refresh_inventory command as a pending row', async () => {
+    it('queues a refresh_inventory command as a pending row when none exists', async () => {
       vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce({
         id: 'device-a',
         orgId: 'org-123',
         hostname: 'host-a',
         status: 'online'
+      } as never);
+
+      // Dedup pre-check: no existing pending refresh_inventory for this device.
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
       } as never);
 
       vi.mocked(db.insert).mockReturnValueOnce({
@@ -391,6 +400,69 @@ describe('device commands routes', () => {
       const body = await res.json();
       expect(body.type).toBe('refresh_inventory');
       expect(body.status).toBe('pending');
+    });
+
+    it('rejects a duplicate refresh_inventory with 409 when one is already pending (#830)', async () => {
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce({
+        id: 'device-a',
+        orgId: 'org-123',
+        hostname: 'host-a',
+        status: 'online'
+      } as never);
+
+      // Dedup pre-check: an existing pending refresh_inventory blocks a new one.
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: 'cmd-existing' }])
+          })
+        })
+      } as never);
+
+      const res = await app.request('/devices/device-a/commands', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ type: 'refresh_inventory' })
+      });
+
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.code).toBe('ALREADY_PENDING');
+      expect(body.commandId).toBe('cmd-existing');
+      // Crucial: no new row was queued.
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('does NOT apply dedup pre-check for non-refresh commands (reboot still inserts directly)', async () => {
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce({
+        id: 'device-a',
+        orgId: 'org-123',
+        hostname: 'host-a',
+        status: 'online'
+      } as never);
+
+      vi.mocked(db.insert).mockReturnValueOnce({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{
+            id: 'cmd-reboot',
+            deviceId: 'device-a',
+            type: 'reboot',
+            status: 'pending',
+            createdAt: new Date()
+          }])
+        })
+      } as never);
+
+      const res = await app.request('/devices/device-a/commands', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ type: 'reboot' })
+      });
+
+      expect(res.status).toBe(201);
+      // Reboot/shutdown are self-limiting (device goes away), so the dedup
+      // check is intentionally scoped to refresh_inventory only.
+      expect(db.select).not.toHaveBeenCalled();
     });
 
     it('rejects an unknown command type with 400', async () => {

--- a/apps/api/src/routes/devices/commands.ts
+++ b/apps/api/src/routes/devices/commands.ts
@@ -203,6 +203,37 @@ commandsRoutes.post(
       return c.json({ error: 'Cannot send commands to a decommissioned device' }, 400);
     }
 
+    // Dedup refresh_inventory: each click fans out ~12 collectors on the
+    // agent, and the API returns 201 as soon as the row is inserted, so a
+    // fast clicker could queue an unbounded backlog. Reject when a pending
+    // refresh_inventory already exists for this device. Other commands
+    // are self-limiting (reboot/shutdown — the device goes away) or rare
+    // (containment, evidence collection) so this guard is scoped narrowly.
+    // (#830)
+    if (data.type === 'refresh_inventory') {
+      const [existingPending] = await db
+        .select({ id: deviceCommands.id })
+        .from(deviceCommands)
+        .where(
+          and(
+            eq(deviceCommands.deviceId, deviceId),
+            eq(deviceCommands.type, 'refresh_inventory'),
+            eq(deviceCommands.status, 'pending'),
+          ),
+        )
+        .limit(1);
+      if (existingPending) {
+        return c.json(
+          {
+            error: 'An inventory refresh is already pending for this device',
+            code: 'ALREADY_PENDING',
+            commandId: existingPending.id,
+          },
+          409,
+        );
+      }
+    }
+
     // Wake-on-LAN takes a separate path: the command row must be addressed to
     // an online relay agent on the target's LAN, not the offline target.
     if (data.type === 'wake') {


### PR DESCRIPTION
## Summary

Closes #830. PR #788 added the on-demand inventory refresh command, but each click queues a fresh `device_commands` row, each of which fans out ~12 collectors on the agent. The button is disabled only while a single click is in flight, and the API returns 201 immediately after the insert — so a fast clicker (or a stuck UI) can pile up unbounded backlog with no cooldown.

Unlike `reboot`/`shutdown` (self-limiting — the device goes away), inventory refresh is the most spammable command in this set.

## What changes

`apps/api/src/routes/devices/commands.ts` — server-side dedup pre-check in `POST /:id/commands`:

- For `data.type === 'refresh_inventory'`, run a single-row SELECT against `device_commands` filtered by `(device_id, type='refresh_inventory', status='pending')` before the insert.
- If a row exists → return **409** with `{ error: 'An inventory refresh is already pending for this device', code: 'ALREADY_PENDING', commandId }`.
- Otherwise → proceed to the existing insert path unchanged.

Scope choice: this guard is intentionally narrow (refresh_inventory only). Other commands are either self-limiting (reboot/shutdown make the device go away) or rare and intentional (containment, evidence collection). A blanket "one-pending-per-type-per-device" rule would block legitimate cases like queueing a follow-up `update` behind one already in flight.

Why server-side, not just client-side cooldown: a client timer doesn't compose with multi-tab or multi-user usage — two admins clicking from different sessions both think they're the first. The server is the source of truth for what's already queued. The 409 body's `error` text is already user-friendly when surfaced by `sendDeviceCommand`'s existing error path, so no web changes were needed.

## Test

`apps/api/src/routes/devices/commands.test.ts` — three new cases:

1. `'queues a refresh_inventory command as a pending row when none exists'` — happy path; asserts both the dedup pre-check SELECT and the insert happen, returns 201.
2. `'rejects a duplicate refresh_inventory with 409 when one is already pending'` — asserts body `code = 'ALREADY_PENDING'`, returns the existing `commandId`, AND `db.insert` was never called.
3. `'does NOT apply dedup pre-check for non-refresh commands'` — sends a reboot, asserts `db.select` was never called. Locks the scope guard against future scope creep.

```
Test Files  432 passed (432)
      Tests  4603 passed | 28 skipped (4631)
```

Local `tsc --noEmit` clean.

## Refs

- Closes #830
- Related: #788 (the original on-demand inventory refresh command)