### PR TITLE
fix(web): render permission-aware empty state on platform-admin 403 (#721)

### DIFF
--- a/apps/web/src/components/admin/ThirdPartyCatalog.test.tsx
+++ b/apps/web/src/components/admin/ThirdPartyCatalog.test.tsx
@@ -10,13 +10,16 @@ vi.mock('../../stores/auth', () => ({
 
 const fetchMock = vi.mocked(fetchWithAuth);
 
-const makeJsonResponse = (payload: unknown, ok = true): Response =>
-  ({
+const makeJsonResponse = (payload: unknown, ok = true, status?: number): Response => {
+  const finalStatus = status ?? (ok ? 200 : 500);
+  return {
     ok,
-    status: ok ? 200 : 500,
+    status: finalStatus,
     statusText: ok ? 'OK' : 'ERROR',
     json: vi.fn().mockResolvedValue(payload),
-  }) as unknown as Response;
+    clone: vi.fn().mockImplementation(function (this: Response) { return this; }),
+  } as unknown as Response;
+};
 
 const sampleItems = [
   {
@@ -252,5 +255,36 @@ describe('ThirdPartyCatalog', () => {
     });
 
     confirmSpy.mockRestore();
+  });
+
+  it('renders a platform-admin permission state when the API returns 403 (#721 Case 1)', async () => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValueOnce(
+      makeJsonResponse({ error: 'platform admin access required' }, false, 403),
+    );
+
+    render(<ThirdPartyCatalog />);
+
+    const state = await screen.findByTestId('catalog-requires-platform-admin');
+    expect(state.textContent).toMatch(/Platform-admin access required/i);
+
+    // Generic "Failed to load catalog" red banner must NOT appear in this state
+    // — that's the whole point of the issue.
+    expect(screen.queryByText(/Failed to load catalog/i)).toBeNull();
+    // And we should NOT have rendered the data-testid="catalog-total" counter
+    // at "0", which was the second tell from the QA walkthrough.
+    expect(screen.queryByTestId('catalog-total')).toBeNull();
+  });
+
+  it('still surfaces a generic error banner for non-permission 403s and 500s', async () => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValueOnce(
+      makeJsonResponse({ error: 'internal' }, false, 500),
+    );
+
+    render(<ThirdPartyCatalog />);
+
+    await screen.findByText(/Failed to load catalog/i);
+    expect(screen.queryByTestId('catalog-requires-platform-admin')).toBeNull();
   });
 });

--- a/apps/web/src/components/admin/ThirdPartyCatalog.test.tsx
+++ b/apps/web/src/components/admin/ThirdPartyCatalog.test.tsx
@@ -257,7 +257,7 @@ describe('ThirdPartyCatalog', () => {
     confirmSpy.mockRestore();
   });
 
-  it('renders a platform-admin permission state when the API returns 403 (#721 Case 1)', async () => {
+  it('renders a platform-admin permission state on any 403 (#721 Case 1)', async () => {
     fetchMock.mockReset();
     fetchMock.mockResolvedValueOnce(
       makeJsonResponse({ error: 'platform admin access required' }, false, 403),
@@ -276,7 +276,26 @@ describe('ThirdPartyCatalog', () => {
     expect(screen.queryByTestId('catalog-total')).toBeNull();
   });
 
-  it('still surfaces a generic error banner for non-permission 403s and 500s', async () => {
+  it('renders the permission state for a 403 regardless of body wording', async () => {
+    // The endpoint is platform-admin-gated end-to-end, so any 403 is a
+    // platform-admin denial. A backend rewording of the error string
+    // (e.g. "platform_admin_required" or "forbidden") must NOT cause the
+    // page to fall back to the generic "Failed to load" banner — that
+    // would be a silent regression invisible to the previous body-sniff
+    // test design. (Todd review on #857.)
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValueOnce(
+      makeJsonResponse({ error: 'forbidden' }, false, 403),
+    );
+
+    render(<ThirdPartyCatalog />);
+
+    const state = await screen.findByTestId('catalog-requires-platform-admin');
+    expect(state.textContent).toMatch(/Platform-admin access required/i);
+    expect(screen.queryByText(/Failed to load catalog/i)).toBeNull();
+  });
+
+  it('surfaces a generic error banner for non-403 failures (500)', async () => {
     fetchMock.mockReset();
     fetchMock.mockResolvedValueOnce(
       makeJsonResponse({ error: 'internal' }, false, 500),

--- a/apps/web/src/components/admin/ThirdPartyCatalog.tsx
+++ b/apps/web/src/components/admin/ThirdPartyCatalog.tsx
@@ -69,20 +69,18 @@ export default function ThirdPartyCatalog() {
       if (showOnlyTested) params.set('breezeTested', 'true');
       const response = await fetchWithAuth(`/third-party-catalog?${params.toString()}`);
       if (!response.ok) {
-        // The third-party catalog endpoint is platform-admin only. A non-
-        // platform-admin admin (org/partner admin, the prod default since
-        // there's no platform-admin in prod) gets a 403 with
-        // {"error":"platform admin access required"}. Render a clear
-        // authorization-boundary state instead of a generic red "Failed to
-        // load catalog" banner that looks like an outage. (#721 Case 1)
+        // The third-party catalog endpoint is platform-admin-gated end-to-
+        // end (`apps/api/src/routes/thirdPartyCatalog/list.ts` uses
+        // platformAdminMiddleware), so any 403 here is platform-admin
+        // denial. Match the sibling pattern in
+        // AccountDeletionRequestsList.tsx:42-45 — status-only check, no
+        // body sniff (a backend rewording of the error string would
+        // silently break the UI without test coverage). (#721 Case 1)
         if (response.status === 403) {
-          const body = await response.clone().json().catch(() => ({})) as { error?: string };
-          if (typeof body.error === 'string' && body.error.toLowerCase().includes('platform admin')) {
-            setRequiresPlatformAdmin(true);
-            setItems([]);
-            setTotal(0);
-            return;
-          }
+          setRequiresPlatformAdmin(true);
+          setItems([]);
+          setTotal(0);
+          return;
         }
         throw new Error('Failed to load catalog');
       }

--- a/apps/web/src/components/admin/ThirdPartyCatalog.tsx
+++ b/apps/web/src/components/admin/ThirdPartyCatalog.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Package, Search, ShieldCheck, AlertTriangle, RefreshCw, Plus, Pencil, Trash2, Play } from 'lucide-react';
+import { Package, Search, ShieldCheck, AlertTriangle, RefreshCw, Plus, Pencil, Trash2, Play, Lock } from 'lucide-react';
 import { fetchWithAuth } from '@/stores/auth';
 import ThirdPartyCatalogEditor, { type CatalogEditorInitial } from './ThirdPartyCatalogEditor';
 
@@ -50,6 +50,7 @@ export default function ThirdPartyCatalog() {
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
+  const [requiresPlatformAdmin, setRequiresPlatformAdmin] = useState(false);
   const [notice, setNotice] = useState<string>();
   const [search, setSearch] = useState('');
   const [showOnlyTested, setShowOnlyTested] = useState(false);
@@ -67,7 +68,25 @@ export default function ThirdPartyCatalog() {
       if (search.trim()) params.set('search', search.trim());
       if (showOnlyTested) params.set('breezeTested', 'true');
       const response = await fetchWithAuth(`/third-party-catalog?${params.toString()}`);
-      if (!response.ok) throw new Error('Failed to load catalog');
+      if (!response.ok) {
+        // The third-party catalog endpoint is platform-admin only. A non-
+        // platform-admin admin (org/partner admin, the prod default since
+        // there's no platform-admin in prod) gets a 403 with
+        // {"error":"platform admin access required"}. Render a clear
+        // authorization-boundary state instead of a generic red "Failed to
+        // load catalog" banner that looks like an outage. (#721 Case 1)
+        if (response.status === 403) {
+          const body = await response.clone().json().catch(() => ({})) as { error?: string };
+          if (typeof body.error === 'string' && body.error.toLowerCase().includes('platform admin')) {
+            setRequiresPlatformAdmin(true);
+            setItems([]);
+            setTotal(0);
+            return;
+          }
+        }
+        throw new Error('Failed to load catalog');
+      }
+      setRequiresPlatformAdmin(false);
       const data = await response.json();
       setItems(data.items ?? []);
       setTotal(data.total ?? 0);
@@ -189,6 +208,31 @@ export default function ThirdPartyCatalog() {
           homepageUrl: editor.entry.homepageUrl,
         }
       : undefined;
+
+  if (requiresPlatformAdmin) {
+    return (
+      <div className="p-6">
+        <h1 className="text-2xl font-semibold flex items-center gap-2 mb-6">
+          <Package className="w-6 h-6" /> Third-Party Package Catalog
+        </h1>
+        <div
+          data-testid="catalog-requires-platform-admin"
+          className="bg-blue-50 border border-blue-200 text-blue-900 px-6 py-8 rounded flex items-start gap-4"
+        >
+          <Lock className="w-6 h-6 flex-shrink-0 mt-0.5" />
+          <div>
+            <div className="font-semibold mb-1">Platform-admin access required</div>
+            <div className="text-sm">
+              The third-party catalog is managed by Breeze platform admins. Your account
+              ({/* role-aware text intentionally not surfaced — server-side identity is the source of truth */}
+              an org/partner admin) can view the curated catalog through normal patch flows but
+              cannot edit it directly.
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="p-6">


### PR DESCRIPTION
## Summary

Closes #721. PR #690 added the Third-Party Catalog admin page, which calls `GET /api/v1/third-party-catalog`. The route is platform-admin only — a non-platform-admin user (org/partner admin, the default in prod since no platform-admin role is provisioned there) gets a 403 with `{\"error\":\"platform admin access required\"}`. The page caught that as a generic Error and rendered a red **'Failed to load catalog'** banner plus **'Total entries: 0'**, which reads as an outage or empty database when in fact the seed data is present and the user just lacks the scope.

## What changes

`apps/web/src/components/admin/ThirdPartyCatalog.tsx`:

- On a 403 whose body's `error` field includes `'platform admin'` (case-insensitive), set a new `requiresPlatformAdmin` state instead of the generic error.
- When `requiresPlatformAdmin` is true, return a dedicated empty state with a Lock icon and 'Platform-admin access required' messaging. This short-circuits the page body so the misleading 'Total entries: 0' counter and the editor controls don't render at all.
- Non-permission 403s and non-403 failures (500, etc) still fall through to the original 'Failed to load catalog' banner — scope guard.

## Case 2 — already mitigated, no change needed

The issue's Case 2 (dashboard deletion-requests count widget firing 403 on every dashboard load) is already silently swallowed at `apps/web/src/components/layout/Sidebar.tsx:236`:

```ts
fetchWithAuth('/admin/account-deletion-requests/pending-count')
  .then(async (r) => {
    if (cancelled) return;
    if (!r.ok) return; // 401/403 quietly suppresses the badge
```

And `fetchWithAuth` does not console.error on 403 either (verified — only `PARTNER_INACTIVE` triggers any console activity). So no widget console-spam survives for non-platform-admin users. This PR therefore scopes to Case 1 only and notes Case 2 as already fixed in the changelog. Worth re-running the original Playwright walkthrough on `main` to confirm.

## Test

`apps/web/src/components/admin/ThirdPartyCatalog.test.tsx`:

- Existing `makeJsonResponse` helper extended to accept an explicit status code and to provide a `.clone()` (used by the new 403 detection).
- **New test**: 403 with `'platform admin access required'` renders the permission state AND does NOT render the generic 'Failed to load' banner or the `catalog-total` counter (the two QA tells from the walkthrough — asserting their *absence* prevents the bug from coming back disguised).
- **New test**: 500 still renders the generic error banner AND does NOT render the permission state. Locks the scope so the new branch can't accidentally swallow real outages.

```
Test Files  1 passed (1)
      Tests  16 passed (16)
```

Local `tsc --noEmit` clean.

## Follow-up (out of scope)

The issue suggested centralizing the 'platform-admin required' detection. That's worth doing once a second page hits the same case — premature to extract a shared helper from one call site. Filed in my head for next time it comes up.

## Refs

- Closes #721
- Related: #690 (the Third-Party Catalog page this fix lives on)