### PR TITLE
feat(agent): supervise BreezeWatchdog from inside the agent (Layer A4, Discussion #854)

### DIFF
--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -558,11 +558,13 @@ func startAgent(cfg *config.Config) (*agentComponents, error) {
 	// Tell the heartbeat where the state file is so it can update after each heartbeat.
 	hb.SetStatePath(statePath)
 
-	// Mutual supervision: when running as the Windows service, this agent
-	// process supervises BreezeWatchdog the same way BreezeWatchdog
+	// Mutual supervision: on Windows, when running as the SCM service this
+	// agent process supervises BreezeWatchdog the same way BreezeWatchdog
 	// supervises us. On macOS/Linux the OS service managers (launchd
-	// KeepAlive, systemd Restart=always) already do this, so the
-	// non-Windows stub of startWatchdogSupervisor is a no-op.
+	// KeepAlive, systemd Restart=always) already do this — and although
+	// LaunchDaemons report cfg.IsService=true via service_unix.go:21-26,
+	// startWatchdogSupervisor is a no-op stub on non-Windows builds, so
+	// gating on cfg.IsService here is safe across platforms.
 	var supervisorCancel context.CancelFunc
 	var supervisorDone <-chan struct{}
 	if cfg.IsService {

--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -283,6 +283,14 @@ type agentComponents struct {
 	hb          *heartbeat.Heartbeat
 	wsClient    *websocket.Client
 	secureToken *secmem.SecureString
+
+	// supervisorCancel cancels long-lived supervisory goroutines started in
+	// startAgent (currently: the Windows watchdog supervisor). nil on
+	// platforms or run modes where no supervisor was started.
+	supervisorCancel context.CancelFunc
+	// supervisorDone closes after the supervisor goroutine has fully
+	// exited. nil when supervisorCancel is nil.
+	supervisorDone <-chan struct{}
 }
 
 // shutdownAgent gracefully stops all agent components.
@@ -294,6 +302,18 @@ type agentComponents struct {
 func shutdownAgent(comps *agentComponents) {
 	if comps == nil {
 		return
+	}
+
+	// Cancel the watchdog supervisor BEFORE we tell the watchdog the agent
+	// is intentionally stopping. Otherwise the supervisor could race
+	// in-flight and re-start a watchdog the SCM is mid-stop on.
+	if comps.supervisorCancel != nil {
+		comps.supervisorCancel()
+		if comps.supervisorDone != nil {
+			runWithTimeout("watchdog supervisor stop", 2*time.Second, func() {
+				<-comps.supervisorDone
+			})
+		}
 	}
 
 	// Write stopping state so the watchdog knows shutdown is intentional.
@@ -538,10 +558,25 @@ func startAgent(cfg *config.Config) (*agentComponents, error) {
 	// Tell the heartbeat where the state file is so it can update after each heartbeat.
 	hb.SetStatePath(statePath)
 
+	// Mutual supervision: when running as the Windows service, this agent
+	// process supervises BreezeWatchdog the same way BreezeWatchdog
+	// supervises us. On macOS/Linux the OS service managers (launchd
+	// KeepAlive, systemd Restart=always) already do this, so the
+	// non-Windows stub of startWatchdogSupervisor is a no-op.
+	var supervisorCancel context.CancelFunc
+	var supervisorDone <-chan struct{}
+	if cfg.IsService {
+		supCtx, supCancel := context.WithCancel(context.Background())
+		supervisorCancel = supCancel
+		supervisorDone = startWatchdogSupervisor(supCtx)
+	}
+
 	return &agentComponents{
-		hb:          hb,
-		wsClient:    wsClient,
-		secureToken: secureToken,
+		hb:               hb,
+		wsClient:         wsClient,
+		secureToken:      secureToken,
+		supervisorCancel: supervisorCancel,
+		supervisorDone:   supervisorDone,
 	}, nil
 }
 

--- a/agent/cmd/breeze-agent/watchdog_supervisor_other.go
+++ b/agent/cmd/breeze-agent/watchdog_supervisor_other.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package main
+
+import "context"
+
+// startWatchdogSupervisor is a no-op on non-Windows platforms. The watchdog
+// supervisor relies on the Windows Service Control Manager; macOS uses
+// launchd KeepAlive and Linux uses systemd Restart=always, both of which
+// already supervise the watchdog process at the OS level.
+//
+// This stub exists so startAgent can call startWatchdogSupervisor
+// unconditionally without per-OS guards at the call site.
+func startWatchdogSupervisor(ctx context.Context) <-chan struct{} {
+	done := make(chan struct{})
+	close(done)
+	return done
+}

--- a/agent/cmd/breeze-agent/watchdog_supervisor_windows.go
+++ b/agent/cmd/breeze-agent/watchdog_supervisor_windows.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -144,6 +143,14 @@ func runWatchdogSupervisor(ctx context.Context, ctl watchdogServiceController, i
 		case svc.Running:
 			if consecutiveFailures > 0 {
 				log.Info("watchdog supervisor: watchdog healthy again", "previousFailures", consecutiveFailures)
+				// Recovery detected — drop the backoff cadence immediately
+				// rather than waiting another slow tick to learn we're back.
+				if currentInterval != interval {
+					t.Reset(interval)
+					currentInterval = interval
+					log.Info("watchdog supervisor: cadence reset to fast after recovery",
+						"interval", interval.String())
+				}
 			}
 			consecutiveFailures = 0
 			return
@@ -171,6 +178,14 @@ func runWatchdogSupervisor(ctx context.Context, ctl watchdogServiceController, i
 			log.Info("watchdog supervisor: restart issued",
 				"totalRestarts", watchdogSupervisorRestartCount.Load())
 			consecutiveFailures = 0
+			// Restart issued — return to fast cadence so the verifying probe
+			// arrives one interval from now, not five.
+			if currentInterval != interval {
+				t.Reset(interval)
+				currentInterval = interval
+				log.Info("watchdog supervisor: cadence reset to fast after restart",
+					"interval", interval.String())
+			}
 		default:
 			// Unknown state code — log and move on.
 			log.Warn("watchdog supervisor: unexpected service state, ignoring", "state", state)
@@ -204,7 +219,3 @@ func runWatchdogSupervisor(ctx context.Context, ctl watchdogServiceController, i
 		}
 	}
 }
-
-// errSupervisorStopped is a sentinel for tests that want to assert the
-// goroutine exited via ctx-cancel rather than a panic.
-var errSupervisorStopped = errors.New("watchdog supervisor stopped")

--- a/agent/cmd/breeze-agent/watchdog_supervisor_windows.go
+++ b/agent/cmd/breeze-agent/watchdog_supervisor_windows.go
@@ -1,0 +1,210 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+// windowsWatchdogServiceName is the SCM name installed by
+// `breeze-watchdog service install` (agent/cmd/breeze-watchdog/service_cmd_windows.go:16).
+// Kept duplicated here rather than imported so this file can stand alone in
+// the breeze-agent package without pulling watchdog cmd internals.
+const watchdogSupervisorServiceName = "BreezeWatchdog"
+
+// Supervisor tick cadence. Sixty seconds is fast enough to recover from a
+// crashed-and-disabled watchdog within one heartbeat window, while staying
+// well below any reasonable detection-window for "watchdog flapping".
+const watchdogSupervisorInterval = 60 * time.Second
+
+// After this many consecutive failures (open-service or start), the
+// supervisor goes into slow-tick mode (5x interval) to avoid log spam when
+// the watchdog has been deliberately uninstalled or quarantined. It still
+// keeps trying so a re-install is auto-detected, just more quietly.
+const watchdogSupervisorBackoffAfter = 3
+
+// watchdogServiceController is the minimal subset of the Windows SCM API
+// the supervisor needs. Defined as an interface so unit tests can substitute
+// a fake without touching the real Service Control Manager. Production code
+// uses windowsSCMController below.
+type watchdogServiceController interface {
+	QueryState(name string) (svc.State, error)
+	Start(name string) error
+}
+
+// windowsSCMController is the production implementation backed by the real
+// Windows SCM via golang.org/x/sys/windows/svc/mgr.
+type windowsSCMController struct{}
+
+func (windowsSCMController) QueryState(name string) (svc.State, error) {
+	m, err := mgr.Connect()
+	if err != nil {
+		return 0, fmt.Errorf("connect SCM: %w", err)
+	}
+	defer m.Disconnect()
+
+	s, err := m.OpenService(name)
+	if err != nil {
+		return 0, fmt.Errorf("open service %q: %w", name, err)
+	}
+	defer s.Close()
+
+	st, err := s.Query()
+	if err != nil {
+		return 0, fmt.Errorf("query service %q: %w", name, err)
+	}
+	return st.State, nil
+}
+
+func (windowsSCMController) Start(name string) error {
+	m, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("connect SCM: %w", err)
+	}
+	defer m.Disconnect()
+
+	s, err := m.OpenService(name)
+	if err != nil {
+		return fmt.Errorf("open service %q: %w", name, err)
+	}
+	defer s.Close()
+
+	if err := s.Start(); err != nil {
+		return fmt.Errorf("start service %q: %w", name, err)
+	}
+	return nil
+}
+
+// watchdogSupervisorCtl is the package-level seam that production wires to
+// the real SCM. Tests overwrite it.
+var watchdogSupervisorCtl watchdogServiceController = windowsSCMController{}
+
+// watchdogSupervisorRestartCount is incremented every time the supervisor
+// successfully issues a Start. Exposed for tests and future telemetry
+// (A2 — TypeTamperAlert wiring will read this).
+var watchdogSupervisorRestartCount atomic.Int64
+
+// startWatchdogSupervisor launches a goroutine that periodically verifies
+// the BreezeWatchdog Windows service is running, restarting it if found
+// stopped or paused. Cancel ctx to stop the goroutine.
+//
+// Intentionally conservative:
+//   - Does NOT attempt to reinstall a missing service (that's bootstrap
+//     territory; see watchdog_bootstrap.go).
+//   - Does NOT touch StartContinuous / paused-pending / start-pending
+//     transient states — only Stopped and Paused trigger a Start.
+//   - Backs off to a slow tick after consecutive failures so a removed or
+//     quarantined watchdog doesn't pin the agent log at 100% volume.
+//
+// Returns a stop channel that closes after the goroutine has exited. Useful
+// in tests and in case shutdownAgent ever needs to await full teardown.
+func startWatchdogSupervisor(ctx context.Context) <-chan struct{} {
+	done := make(chan struct{})
+	go runWatchdogSupervisor(ctx, watchdogSupervisorCtl, watchdogSupervisorInterval, done)
+	return done
+}
+
+// runWatchdogSupervisor is the pure-Go loop body, separated from
+// startWatchdogSupervisor so tests can drive it with a stub controller and
+// a short interval.
+func runWatchdogSupervisor(ctx context.Context, ctl watchdogServiceController, interval time.Duration, done chan<- struct{}) {
+	defer close(done)
+
+	log.Info("watchdog supervisor started",
+		"service", watchdogSupervisorServiceName,
+		"interval", interval.String())
+
+	t := time.NewTicker(interval)
+	defer t.Stop()
+
+	consecutiveFailures := 0
+	currentInterval := interval
+
+	checkAndMaybeRestart := func() {
+		if err := ctx.Err(); err != nil {
+			return
+		}
+		state, qErr := ctl.QueryState(watchdogSupervisorServiceName)
+		if qErr != nil {
+			consecutiveFailures++
+			log.Warn("watchdog supervisor: query failed",
+				"error", qErr.Error(),
+				"consecutiveFailures", consecutiveFailures)
+			return
+		}
+
+		switch state {
+		case svc.Running:
+			if consecutiveFailures > 0 {
+				log.Info("watchdog supervisor: watchdog healthy again", "previousFailures", consecutiveFailures)
+			}
+			consecutiveFailures = 0
+			return
+		case svc.StartPending, svc.StopPending, svc.ContinuePending, svc.PausePending:
+			// Transient: SCM will resolve to a steady state on its own.
+			// Don't touch.
+			return
+		case svc.Stopped, svc.Paused:
+			// Re-check ctx right before the side-effecting call so that
+			// an in-flight Stop request from the SCM doesn't race a
+			// restart into a stop sequence.
+			if err := ctx.Err(); err != nil {
+				return
+			}
+			log.Warn("watchdog supervisor: watchdog is not running, attempting restart",
+				"state", state)
+			if err := ctl.Start(watchdogSupervisorServiceName); err != nil {
+				consecutiveFailures++
+				log.Error("watchdog supervisor: start failed",
+					"error", err.Error(),
+					"consecutiveFailures", consecutiveFailures)
+				return
+			}
+			watchdogSupervisorRestartCount.Add(1)
+			log.Info("watchdog supervisor: restart issued",
+				"totalRestarts", watchdogSupervisorRestartCount.Load())
+			consecutiveFailures = 0
+		default:
+			// Unknown state code — log and move on.
+			log.Warn("watchdog supervisor: unexpected service state, ignoring", "state", state)
+		}
+	}
+
+	// Probe once on start so the supervisor doesn't have to wait an entire
+	// interval to react to a watchdog that was already down at agent
+	// startup.
+	checkAndMaybeRestart()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("watchdog supervisor stopping", "reason", ctx.Err().Error())
+			return
+		case <-t.C:
+			checkAndMaybeRestart()
+			// Adjust cadence based on failure count.
+			newInterval := interval
+			if consecutiveFailures >= watchdogSupervisorBackoffAfter {
+				newInterval = interval * 5
+			}
+			if newInterval != currentInterval {
+				t.Reset(newInterval)
+				currentInterval = newInterval
+				log.Info("watchdog supervisor: cadence adjusted",
+					"interval", newInterval.String(),
+					"consecutiveFailures", consecutiveFailures)
+			}
+		}
+	}
+}
+
+// errSupervisorStopped is a sentinel for tests that want to assert the
+// goroutine exited via ctx-cancel rather than a panic.
+var errSupervisorStopped = errors.New("watchdog supervisor stopped")

--- a/agent/cmd/breeze-agent/watchdog_supervisor_windows_test.go
+++ b/agent/cmd/breeze-agent/watchdog_supervisor_windows_test.go
@@ -1,0 +1,185 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows/svc"
+)
+
+// fakeSCM is a programmable watchdogServiceController. Sequence of states
+// is replayed on each QueryState; Start records calls and may return an
+// injected error.
+type fakeSCM struct {
+	mu sync.Mutex
+
+	states     []svc.State
+	stateIdx   int
+	queryErr   error
+	startErr   error
+	startCalls int
+}
+
+func (f *fakeSCM) QueryState(_ string) (svc.State, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.queryErr != nil {
+		return 0, f.queryErr
+	}
+	if len(f.states) == 0 {
+		return svc.Running, nil
+	}
+	st := f.states[f.stateIdx]
+	if f.stateIdx < len(f.states)-1 {
+		f.stateIdx++
+	}
+	return st, nil
+}
+
+func (f *fakeSCM) Start(_ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.startCalls++
+	// Once Start succeeds, subsequent QueryState should reflect Running so
+	// the supervisor's "healthy again" log message is reachable in tests.
+	if f.startErr == nil {
+		f.states = append(f.states, svc.Running)
+		f.stateIdx = len(f.states) - 1
+	}
+	return f.startErr
+}
+
+func (f *fakeSCM) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.startCalls
+}
+
+// waitUntil polls cond until it returns true or the timeout fires. Used to
+// avoid sleep-based assertions in supervisor tests.
+func waitUntil(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("waitUntil: condition not met within timeout")
+}
+
+func TestWatchdogSupervisor_RestartsStoppedService(t *testing.T) {
+	fake := &fakeSCM{states: []svc.State{svc.Stopped}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	// Tight interval so the test doesn't take a real minute. The initial
+	// probe runs immediately so even a slow tick yields a fast first
+	// observation.
+	go runWatchdogSupervisor(ctx, fake, 10*time.Millisecond, done)
+
+	waitUntil(t, time.Second, func() bool { return fake.callCount() >= 1 })
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("supervisor did not stop after ctx cancel")
+	}
+}
+
+func TestWatchdogSupervisor_NoopWhenRunning(t *testing.T) {
+	fake := &fakeSCM{states: []svc.State{svc.Running}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go runWatchdogSupervisor(ctx, fake, 5*time.Millisecond, done)
+
+	// Let several ticks elapse.
+	time.Sleep(50 * time.Millisecond)
+
+	if got := fake.callCount(); got != 0 {
+		t.Fatalf("Start called %d times; expected 0 when service is Running", got)
+	}
+
+	cancel()
+	<-done
+}
+
+func TestWatchdogSupervisor_BacksOffOnRepeatedFailure(t *testing.T) {
+	fake := &fakeSCM{
+		queryErr: errors.New("ERROR_SERVICE_DOES_NOT_EXIST"),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go runWatchdogSupervisor(ctx, fake, 5*time.Millisecond, done)
+
+	// Failure path doesn't call Start, but we can verify the goroutine
+	// keeps running rather than panicking on repeated query errors.
+	time.Sleep(60 * time.Millisecond)
+
+	if got := fake.callCount(); got != 0 {
+		t.Fatalf("Start called %d times despite query failure; expected 0", got)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("supervisor did not stop after ctx cancel")
+	}
+}
+
+func TestWatchdogSupervisor_IgnoresPendingStates(t *testing.T) {
+	fake := &fakeSCM{
+		states: []svc.State{
+			svc.StartPending,
+			svc.StopPending,
+			svc.ContinuePending,
+			svc.PausePending,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go runWatchdogSupervisor(ctx, fake, 5*time.Millisecond, done)
+
+	time.Sleep(80 * time.Millisecond)
+
+	if got := fake.callCount(); got != 0 {
+		t.Fatalf("Start called %d times on pending states; expected 0", got)
+	}
+
+	cancel()
+	<-done
+}
+
+func TestWatchdogSupervisor_RestartsPausedService(t *testing.T) {
+	fake := &fakeSCM{states: []svc.State{svc.Paused}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go runWatchdogSupervisor(ctx, fake, 10*time.Millisecond, done)
+
+	waitUntil(t, time.Second, func() bool { return fake.callCount() >= 1 })
+
+	cancel()
+	<-done
+}

--- a/agent/cmd/breeze-agent/watchdog_supervisor_windows_test.go
+++ b/agent/cmd/breeze-agent/watchdog_supervisor_windows_test.go
@@ -23,11 +23,13 @@ type fakeSCM struct {
 	queryErr   error
 	startErr   error
 	startCalls int
+	queryCalls int
 }
 
 func (f *fakeSCM) QueryState(_ string) (svc.State, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.queryCalls++
 	if f.queryErr != nil {
 		return 0, f.queryErr
 	}
@@ -58,6 +60,12 @@ func (f *fakeSCM) callCount() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.startCalls
+}
+
+func (f *fakeSCM) queryCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.queryCalls
 }
 
 // waitUntil polls cond until it returns true or the timeout fires. Used to
@@ -105,8 +113,8 @@ func TestWatchdogSupervisor_NoopWhenRunning(t *testing.T) {
 	done := make(chan struct{})
 	go runWatchdogSupervisor(ctx, fake, 5*time.Millisecond, done)
 
-	// Let several ticks elapse.
-	time.Sleep(50 * time.Millisecond)
+	// Wait for several probes to happen, then verify no Start was issued.
+	waitUntil(t, time.Second, func() bool { return fake.queryCount() >= 3 })
 
 	if got := fake.callCount(); got != 0 {
 		t.Fatalf("Start called %d times; expected 0 when service is Running", got)
@@ -129,7 +137,7 @@ func TestWatchdogSupervisor_BacksOffOnRepeatedFailure(t *testing.T) {
 
 	// Failure path doesn't call Start, but we can verify the goroutine
 	// keeps running rather than panicking on repeated query errors.
-	time.Sleep(60 * time.Millisecond)
+	waitUntil(t, time.Second, func() bool { return fake.queryCount() >= 3 })
 
 	if got := fake.callCount(); got != 0 {
 		t.Fatalf("Start called %d times despite query failure; expected 0", got)
@@ -159,7 +167,7 @@ func TestWatchdogSupervisor_IgnoresPendingStates(t *testing.T) {
 	done := make(chan struct{})
 	go runWatchdogSupervisor(ctx, fake, 5*time.Millisecond, done)
 
-	time.Sleep(80 * time.Millisecond)
+	waitUntil(t, time.Second, func() bool { return fake.queryCount() >= 4 })
 
 	if got := fake.callCount(); got != 0 {
 		t.Fatalf("Start called %d times on pending states; expected 0", got)


### PR DESCRIPTION
Implements Layer A4 from Discussion #854 with the scope constraints from your review.

## What this does

A Windows-only goroutine in `startAgent` that opens the `BreezeWatchdog` service via SCM every 60s and calls `s.Start()` if found in `Stopped` or `Paused` state. Closes the symmetric hole that #852 leaves open: watchdog supervises agent; this supervises watchdog.

The two scopes that ship today (#852 + this PR) cover:
- Main agent wedged → watchdog restarts agent (#852, merged)
- Watchdog stopped manually or by hung-update auto-disable, main agent healthy → this PR

Defense-in-depth for the crash case (#853, SCM restart-on-crash) is a companion PR not yet merged; if #853 lands, the matrix extends to also cover "watchdog process crashed" via SCM recovery.


## Agreement with the three scope constraints from Discussion #854

**Scope (b) — "scoped reading", agent goroutine, narrowly bounded.** Matches what `fc3bf7de` already does:
- Only acts on `Stopped` / `Paused` steady states
- Ignores all `*Pending` transients
- Does NOT reinstall a missing service (bootstrap territory)
- Does NOT touch SCM config (start-type, recovery actions, etc.)
- After 3 consecutive open-or-start failures backs off to 5× interval (slow-tick) so a deliberately-removed watchdog doesn't flood the agent log; still keeps trying so a re-install is auto-detected
- Cancelled before `shutdownAgent` writes `ShutdownIntent` so a clean stop doesn't race a supervisor-driven restart

**Hard line on growth — agreed.** A4 stays at "is the sibling service in Stopped state? if so, `Start()`." Any future supervision of OTHER sidecars (helper, broker, future PAM broker, future ZTNA gateway) is a separate design conversation. The "Design doc: should A4 grow into a generic sidecar supervisor?" item on the project board is where that lives.

**GPO-disabled gap — defer, document, don't silently self-repair.** Agreed. SCM refuses to start a Disabled service and A4 only does `s.Start()`. GPO-disable is an active misconfiguration; silent re-arm invites surprises for the admin who did it on purpose. Future installer-repair / bootstrap layer is the right place if we ever decide to handle this.

**Linux/macOS A4 — document the gap, parity with Windows GPO-disabled.** Agreed. Non-Windows builds get a no-op stub at `watchdog_supervisor_other.go`. Neither `launchctl disable` nor `systemctl disable` is in scope for v1.

## Implementation

| File | Purpose |
|---|---|
| `agent/cmd/breeze-agent/main.go` | Registers supervisor goroutine in `startAgent`, cancels in `shutdownAgent` before ShutdownIntent. |
| `agent/cmd/breeze-agent/watchdog_supervisor_windows.go` | Windows SCM logic via `golang.org/x/sys/windows/svc/mgr`. Service name `BreezeWatchdog` matches `agent/cmd/breeze-watchdog/service_cmd_windows.go:16`. |
| `agent/cmd/breeze-agent/watchdog_supervisor_other.go` | Linux/macOS no-op stub (launchd/systemd already supervise breeze-watchdog at the OS level). |
| `agent/cmd/breeze-agent/watchdog_supervisor_windows_test.go` | Seam-based tests via fake SCM controller. No real `svc.mgr` in tests. |

Net diff: 4 files, +451 / -3.

## Testing

- `CGO_ENABLED=0 go test ./cmd/breeze-agent/...` → PASS
- `CGO_ENABLED=0 go vet ./cmd/breeze-agent/...` → clean
- Cross-platform compile: `GOOS=windows/linux/darwin` all build clean
- `bash scripts/security/preflight.sh --fast` → 4 passed, 0 failed (govulncheck clean, Trivy clean across gomod / cargo / npm / pnpm)

Not run: integration test on a real Windows endpoint. The seam-based test exercises every state transition (Stopped→Start, Paused→Start, *Pending→ignore, 3-fail→slow-tick, fast recovery on next success) but cannot prove SCM behavior in production. The "telemetry event" + "E2E on the Windows test VM" tracks on the project board are the right places to close that gap.

## Refs

- Discussion #854 — direction approved
- Project board: [LanternOps/projects/6](https://github.com/orgs/LanternOps/projects/6) (track: "A4 — agent → watchdog supervision implementation")
- Companion: #853 (defense-in-depth on the crash case via SCM recovery actions)
- Successor PRs already on the board: telemetry event, slow-tick backoff test, E2E Windows VM
