### PR TITLE
feat(devices): expose mainAgentSilentSince + watchdogStatus on list endpoint (#800 web-UI gap)

### DIFF
--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -368,6 +368,8 @@ coreRoutes.get(
         architecture: devices.architecture,
         agentVersion: devices.agentVersion,
         status: devices.status,
+        watchdogStatus: devices.watchdogStatus,
+        mainAgentSilentSince: devices.mainAgentSilentSince,
         lastSeenAt: devices.lastSeenAt,
         enrolledAt: devices.enrolledAt,
         tags: devices.tags,


### PR DESCRIPTION
Closes the API-side of the web-UI gap Todd called out on Discussion #854: *"`mainAgentSilentSince` and `watchdogStatus` are in the schema and event bus but no UI surfaces them yet."*

## What

Two-line addition to the `GET /devices` list-endpoint SELECT projection.

## Why

The fields are already populated by the agent heartbeat path (`apps/api/src/routes/agents/heartbeat.ts:95,120`, set by #851) and live on the `devices` table (`apps/api/src/db/schema/devices.ts:11,57,66`). The detail endpoint (`GET /devices/:id`) already returns them — `getDeviceWithOrgCheck` does `db.select()` without a projection, so it picks them up automatically. Only the list endpoint's explicit projection was missing them.

This is the smallest possible foundation for the seeded follow-ups on the A4 project board:
- Amber "agent silent (watchdog OK)" badge on Device row
- Watchdog-status block on Device Detail

Both UI items need the data in the list response so they can render without a per-row N+1 fetch.

## Risk

- **Contract:** purely additive, no client breakage.
- **Performance:** two extra columns from the same row, no new joins. LATERAL/per-org scan plan from #792 is unchanged.
- **Drizzle types:** response type updates automatically from the SELECT projection.
- **Tests:** no list-endpoint response-shape test exists today to catch regressions either way; not adding one in this PR. Happy to add if you want — would mock `db.select` and assert both fields appear in the row shape.

## Preflight

- `tsc --noEmit` clean
- `pnpm --filter @breeze/api test -- --run devices/core` → 432 test files / 4605 pass
- `bash scripts/security/preflight.sh --fast` → 4 passed, 0 failed (govulncheck + Trivy gomod/cargo/npm/pnpm clean)

## Refs

- Discussion #854 — direction
- Project board: [LanternOps/projects/6](https://github.com/orgs/LanternOps/projects/6) — "Web UI gap" track
- Source of the data: #851 (Layer C, server-side asymmetry detection) — merged