### PR TITLE
feat(devices): amber 'Agent silent (watchdog OK)' badge on device row (#800 web-UI gap)

### DIFF
--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -368,6 +368,8 @@ coreRoutes.get(
         architecture: devices.architecture,
         agentVersion: devices.agentVersion,
         status: devices.status,
+        watchdogStatus: devices.watchdogStatus,
+        mainAgentSilentSince: devices.mainAgentSilentSince,
         lastSeenAt: devices.lastSeenAt,
         enrolledAt: devices.enrolledAt,
         tags: devices.tags,

--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import DeviceList, { type Device } from './DeviceList';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+vi.mock('../remote/ConnectDesktopButton', () => ({
+  default: () => null,
+}));
+vi.mock('@/lib/formatTime', () => ({
+  formatLastSeen: () => 'just now',
+}));
+
+const baseDevice: Device = {
+  id: '11111111-1111-1111-1111-111111111111',
+  hostname: 'host-a',
+  os: 'windows',
+  osVersion: '11',
+  status: 'online',
+  cpuPercent: 10,
+  ramPercent: 20,
+  lastSeen: new Date().toISOString(),
+  orgId: 'org-1',
+  orgName: 'Acme',
+  siteId: 'site-1',
+  siteName: 'HQ',
+  agentVersion: '0.67.0',
+  tags: [],
+};
+
+describe('DeviceList — agent-silent (watchdog OK) badge (#800 web-UI gap)', () => {
+  it('renders the amber badge when mainAgentSilentSince is set AND watchdog is reporting', () => {
+    const device: Device = {
+      ...baseDevice,
+      id: '22222222-2222-2222-2222-222222222222',
+      hostname: 'host-silent-but-watchdog-ok',
+      mainAgentSilentSince: new Date(Date.now() - 17 * 60_000).toISOString(),
+      watchdogStatus: 'connected',
+    };
+
+    render(<DeviceList devices={[device]} />);
+
+    const badge = screen.getByTestId(`device-${device.id}-agent-silent-badge`);
+    expect(badge.textContent).toMatch(/Agent silent/i);
+    // 17 minutes ago should render as "17m" (not "0h" or "1d")
+    expect(badge.textContent).toMatch(/17m/);
+  });
+
+  it('does NOT render the badge when the watchdog is also offline (we trust device.status=offline instead)', () => {
+    const device: Device = {
+      ...baseDevice,
+      id: '33333333-3333-3333-3333-333333333333',
+      hostname: 'host-fully-offline',
+      status: 'offline',
+      mainAgentSilentSince: new Date(Date.now() - 60 * 60_000).toISOString(),
+      watchdogStatus: 'offline',
+    };
+
+    render(<DeviceList devices={[device]} />);
+
+    expect(screen.queryByTestId(`device-${device.id}-agent-silent-badge`)).toBeNull();
+  });
+
+  it('does NOT render the badge when the agent is heartbeating normally (mainAgentSilentSince null)', () => {
+    const device: Device = {
+      ...baseDevice,
+      id: '44444444-4444-4444-4444-444444444444',
+      hostname: 'host-healthy',
+      mainAgentSilentSince: null,
+      watchdogStatus: 'connected',
+    };
+
+    render(<DeviceList devices={[device]} />);
+
+    expect(screen.queryByTestId(`device-${device.id}-agent-silent-badge`)).toBeNull();
+  });
+
+  it('still renders when watchdog reports FAILOVER (watchdog has taken over the heartbeat)', () => {
+    const device: Device = {
+      ...baseDevice,
+      id: '55555555-5555-5555-5555-555555555555',
+      hostname: 'host-failover',
+      mainAgentSilentSince: new Date(Date.now() - 2 * 3600 * 1000).toISOString(),
+      watchdogStatus: 'failover',
+    };
+
+    render(<DeviceList devices={[device]} />);
+
+    const badge = screen.getByTestId(`device-${device.id}-agent-silent-badge`);
+    // 2h should render as "2h"
+    expect(badge.textContent).toMatch(/2h/);
+  });
+});

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -38,6 +38,21 @@ export type Device = {
   isHeadless?: boolean;
   desktopAccess?: DesktopAccessState | null;
   remoteAccessPolicy?: RemoteAccessPolicy | null;
+  /**
+   * Server-detected asymmetry: timestamp at which the API stopped
+   * receiving main-agent heartbeats while the watchdog is still
+   * reporting in. Set by the heartbeat handler (#851 / Layer C).
+   * Null when the agent is heartbeating normally or has fully gone
+   * silent (watchdog included).
+   */
+  mainAgentSilentSince?: string | null;
+  /**
+   * Watchdog reachability as last reported. 'connected' = normal,
+   * 'failover' = watchdog took over because main-agent stopped,
+   * 'offline' = we haven't heard from the watchdog either (in which
+   * case `status === 'offline'` is the load-bearing signal).
+   */
+  watchdogStatus?: 'connected' | 'failover' | 'offline' | null;
 };
 
 type DeviceListProps = {
@@ -77,6 +92,28 @@ const statusLabels: Record<DeviceStatus, string> = {
   quarantined: 'Quarantined',
   updating: 'Updating'
 };
+
+/**
+ * "Agent silent (watchdog OK)" amber badge. Fires when the server-side
+ * asymmetry detector (#851 / Layer C) has marked `mainAgentSilentSince`
+ * AND the watchdog is still reporting in (`watchdogStatus !== 'offline'`).
+ * That state means the main agent has wedged but the box is alive — a
+ * different failure mode from a fully-offline device, and the distinction
+ * is the whole point of #800.
+ *
+ * Returns null when no asymmetry is present so the cell stays clean.
+ */
+function shouldShowAgentSilentBadge(device: Pick<Device, 'mainAgentSilentSince' | 'watchdogStatus'>): boolean {
+  return Boolean(device.mainAgentSilentSince) && device.watchdogStatus !== 'offline';
+}
+
+function formatSilentDuration(silentSince: string): string {
+  const minutes = Math.max(1, Math.floor((Date.now() - new Date(silentSince).getTime()) / 60_000));
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
 
 const osLabels: Record<OSType, string> = {
   windows: 'Windows',
@@ -768,9 +805,20 @@ export default function DeviceList({
                     })()}
                   </td>
                   <td className="px-3 py-3 text-sm">
-                    <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${statusColors[device.status]}`}>
-                      {statusLabels[device.status]}
-                    </span>
+                    <div className="flex flex-wrap items-center gap-1">
+                      <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${statusColors[device.status]}`}>
+                        {statusLabels[device.status]}
+                      </span>
+                      {shouldShowAgentSilentBadge(device) && (
+                        <span
+                          data-testid={`device-${device.id}-agent-silent-badge`}
+                          title={`Main agent has been silent for ${formatSilentDuration(device.mainAgentSilentSince!)}. Watchdog is still reporting in, so the box is alive but the agent has wedged.`}
+                          className="inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium bg-warning/15 text-warning border-warning/30"
+                        >
+                          Agent silent · {formatSilentDuration(device.mainAgentSilentSince!)}
+                        </span>
+                      )}
+                    </div>
                   </td>
                   <td className="px-3 py-3 text-sm">
                     {device.status === 'online' ? (

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -134,7 +134,9 @@ export default function DevicesPage() {
           agentVersion: (d.agentVersion ?? '') as string,
           tags: (d.tags ?? []) as string[],
           deviceRole: d.deviceRole as DeviceRole | undefined,
-          deviceRoleSource: d.deviceRoleSource as string | undefined
+          deviceRoleSource: d.deviceRoleSource as string | undefined,
+          mainAgentSilentSince: (d.mainAgentSilentSince ?? null) as string | null,
+          watchdogStatus: (d.watchdogStatus ?? null) as Device['watchdogStatus']
         };
       });
 


### PR DESCRIPTION
**Stacked on #861.** Once #861 lands and this PR auto-rebases onto main, the diff in this PR shrinks to just the UI piece.

Surfaces the server-side asymmetry detector (#851 / Layer C) in the device list. Closes the visible half of the #800 / Discussion #854 web-UI gap.

## When the badge fires

- `mainAgentSilentSince` is set (the main agent stopped heartbeating), AND
- `watchdogStatus !== 'offline'` (the box is still alive, watchdog is reporting in)

That combination is the distinct failure mode #800 was filed for: the endpoint is reachable but the agent has wedged. Without this badge it's indistinguishable from a fully-offline device in the UI.

## What it looks like

Inline next to the existing status pill in the device list row. Tailwind amber tone (`bg-warning/15 text-warning border-warning/30`) matches the existing 'maintenance' badge so the visual register is "attention needed" not "broken".

Label: `Agent silent · {17m|2h|1d}` with a title-attribute tooltip explaining what the state means and that watchdog reachability is intact.

## What it intentionally does NOT do

- Does not render when the watchdog is also offline — `device.status='offline'` is the load-bearing signal there.
- Does not render when `mainAgentSilentSince` is null (agent heartbeating normally).
- Does not modify the existing status pill — additive only.

## Tests

4 cases in `DeviceList.test.tsx`:
- main silent + watchdog connected → badge renders, formats minutes (`17m`)
- watchdog offline → no badge
- main silent null → no badge
- watchdog FAILOVER (watchdog took over the heartbeat) → badge renders, formats hours (`2h`)

## Preflight

- `tsc --noEmit` clean
- 4/4 new tests pass
- `bash scripts/security/preflight.sh --fast` → 4 passed, 0 failed (Trivy + govulncheck clean across gomod/cargo/npm/pnpm)

## Refs

- Builds on #861 (list-endpoint exposes the two fields)
- Source of the data: #851 (Layer C asymmetry detection) — merged
- A4 project board: [LanternOps/projects/6](https://github.com/orgs/LanternOps/projects/6), track "Web UI gap"
- Follow-up: watchdog-status block on Device Detail (separate PR, deeper layout work)