### PR TITLE
fix(devices): dedup refresh_inventory on the bulk endpoint too (#830 follow-up)

### DIFF
--- a/apps/api/src/routes/devices/commands.test.ts
+++ b/apps/api/src/routes/devices/commands.test.ts
@@ -122,6 +122,68 @@ describe('device commands routes', () => {
       expect(body.failed).toEqual(['22222222-2222-2222-2222-222222222222']);
     });
 
+    it('bulk refresh_inventory dedups already-pending devices, skips silently (caught by @xxiaoxiong on #831)', async () => {
+      // Two devices: A has a pending refresh_inventory already, B does not.
+      // Expected: A is silently skipped (not added to `failed`), B gets a
+      // new pending row. The single-device endpoint (#856) returns 409
+      // on duplicate; the bulk path can't 409 per-device, so silent skip
+      // is the right behavior — already-queued isn't an error.
+      const deviceA = '11111111-1111-1111-1111-111111111111';
+      const deviceB = '22222222-2222-2222-2222-222222222222';
+
+      vi.mocked(getDeviceWithOrgCheck)
+        .mockResolvedValueOnce({ id: deviceA, orgId: 'org-123', hostname: 'a', status: 'online' } as never)
+        .mockResolvedValueOnce({ id: deviceB, orgId: 'org-123', hostname: 'b', status: 'online' } as never);
+
+      // Dedup pre-check: A returns an existing pending row, B returns empty.
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ id: 'cmd-existing-a' }])
+            })
+          })
+        } as never)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([])
+            })
+          })
+        } as never);
+
+      // Insert only fires for B.
+      vi.mocked(db.insert).mockReturnValueOnce({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{
+            id: 'cmd-new-b',
+            deviceId: deviceB,
+            type: 'refresh_inventory',
+            status: 'pending',
+            createdAt: new Date()
+          }])
+        })
+      } as never);
+
+      const res = await app.request('/devices/bulk/commands', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          deviceIds: [deviceA, deviceB],
+          type: 'refresh_inventory'
+        })
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.commands).toHaveLength(1);
+      expect(body.commands[0].deviceId).toBe(deviceB);
+      // A was skipped silently — NOT in failed (already-pending isn't a failure).
+      expect(body.failed).not.toContain(deviceA);
+      // Insert was called exactly once (for B), not twice.
+      expect(vi.mocked(db.insert)).toHaveBeenCalledTimes(1);
+    });
+
     it('rejects generic script command requests before device lookup', async () => {
       const res = await app.request('/devices/bulk/commands', {
         method: 'POST',

--- a/apps/api/src/routes/devices/commands.ts
+++ b/apps/api/src/routes/devices/commands.ts
@@ -135,6 +135,26 @@ commandsRoutes.post(
         continue;
       }
 
+      // Same dedup #856 added to /:id/commands. The bulk path was
+      // missed — caught by @xxiaoxiong on #831. Skip the device
+      // silently when one is already pending (already-queued isn't an
+      // error in bulk context; nothing actionable for the caller to
+      // retry, and adding to `failed` would falsely imply a problem).
+      if (data.type === 'refresh_inventory') {
+        const [existingPending] = await db
+          .select({ id: deviceCommands.id })
+          .from(deviceCommands)
+          .where(
+            and(
+              eq(deviceCommands.deviceId, deviceId),
+              eq(deviceCommands.type, 'refresh_inventory'),
+              eq(deviceCommands.status, 'pending'),
+            ),
+          )
+          .limit(1);
+        if (existingPending) continue;
+      }
+
       const [command] = await db
         .insert(deviceCommands)
         .values({


### PR DESCRIPTION
Follow-up to #856. Closes the bulk-path half of #830 that #856 missed — caught by @xxiaoxiong in #831.

## The gap

#856 added the dedup pre-check to `POST /:id/commands` (single device) but the bulk loop at `POST /devices/bulk/commands` was not touched. Result: the spam vector #830 was filed for was only half-closed. A bulk-spam request against the same fleet of devices could still queue duplicate pending `refresh_inventory` rows, each fanning out the ~12 collectors per device on the agent.

## The fix

Same SELECT-before-INSERT pattern as #856, applied per-iteration in the existing `for (const deviceId of deviceIds)` loop in `apps/api/src/routes/devices/commands.ts`.

**Behavior on already-pending:** silently `continue` (skip the device, do not insert). NOT added to the response `failed` array. The single-device endpoint can `409` because there's exactly one caller intent; in the bulk context "already queued" is a no-op, not an error, and surfacing it as `failed` would falsely imply something for the caller to retry.

Scope guard: only applies to `data.type === 'refresh_inventory'`. Reboots, evidence collection, etc. still flow through unchanged.

## Test

New test in `apps/api/src/routes/devices/commands.test.ts`: bulk request with `deviceA` (already-pending) + `deviceB` (clean) — asserts `commands` has exactly one row for `deviceB`, `deviceA` is NOT in `failed`, `db.insert` is called exactly once.

## Preflight

- `tsc --noEmit` clean
- 432 test files / 4606 pass
- `bash scripts/security/preflight.sh --fast` → 4 passed, 0 failed (Trivy + govulncheck clean across gomod/cargo/npm/pnpm)

## Refs

- Closes the bulk-path half of #830
- Credit: @xxiaoxiong for catching this on #831
- #856 covered the per-device endpoint