### PR TITLE
fix(api): tolerate canonical-case repo in release manifest verifier (#866)

### DIFF
--- a/apps/api/src/services/releaseArtifactManifest.test.ts
+++ b/apps/api/src/services/releaseArtifactManifest.test.ts
@@ -83,6 +83,56 @@ describe("releaseArtifactManifest", () => {
     );
   });
 
+  it("accepts a repository mismatch that differs only in case", async () => {
+    // GitHub repo names are case-insensitive for routing, and the manifest's
+    // repository field reflects whatever case the org had at repo-create time
+    // (GITHUB_REPOSITORY env var in release.yml). A strict comparison against
+    // a lowercased default like "lanternops/breeze" rejects manifests written
+    // as "LanternOps/breeze", which is exactly the bug self-hosters hit when
+    // generating an MSI installer link.
+    const asset = Buffer.from("trusted-msi");
+    const signed = makeSignedManifest({
+      assetName: "breeze-agent.msi",
+      assetBuffer: asset,
+      repository: "LanternOps/breeze",
+    });
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+    await expect(
+      verifyReleaseArtifactBuffer({
+        assetName: "breeze-agent.msi",
+        assetBuffer: asset,
+        manifestBytes: signed.manifest,
+        signatureBytes: signed.signature,
+        expectedRepository: "lanternops/breeze",
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        repository: "LanternOps/breeze",
+      }),
+    );
+  });
+
+  it("still rejects a repository mismatch beyond case differences", async () => {
+    const asset = Buffer.from("trusted-msi");
+    const signed = makeSignedManifest({
+      assetName: "breeze-agent.msi",
+      assetBuffer: asset,
+      repository: "evilorg/breeze",
+    });
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+    await expect(
+      verifyReleaseArtifactBuffer({
+        assetName: "breeze-agent.msi",
+        assetBuffer: asset,
+        manifestBytes: signed.manifest,
+        signatureBytes: signed.signature,
+        expectedRepository: "lanternops/breeze",
+      }),
+    ).rejects.toThrow("repository mismatch");
+  });
+
   it("rejects a tampered manifest signature", async () => {
     const asset = Buffer.from("trusted-pkg");
     const signed = makeSignedManifest({

--- a/apps/api/src/services/releaseArtifactManifest.ts
+++ b/apps/api/src/services/releaseArtifactManifest.ts
@@ -236,11 +236,19 @@ function selectManifestAsset(args: {
 }): SelectedReleaseArtifactManifestAsset {
   const { manifest } = args;
   if (args.expectedRepository) {
-    assertStringEqual(
-      manifest.repository,
-      args.expectedRepository,
-      "repository",
-    );
+    // GitHub repository names are case-insensitive for routing; the manifest
+    // case reflects whatever GITHUB_REPOSITORY was set to at release time
+    // (canonical org case, e.g. "LanternOps/breeze") while callers may pass a
+    // lowercased default. Lock identity but tolerate case to avoid the
+    // self-hoster footgun in fetchRegularMsi/fetchMacosPkg pre-flight.
+    if (
+      typeof manifest.repository !== "string" ||
+      manifest.repository.toLowerCase() !== args.expectedRepository.toLowerCase()
+    ) {
+      throw new Error(
+        `Release artifact manifest repository mismatch: expected ${args.expectedRepository}, got ${String(manifest.repository)}`,
+      );
+    }
   }
   if (args.expectedRelease) {
     assertStringEqual(manifest.release, args.expectedRelease, "release");


### PR DESCRIPTION
Closes #866.

## Summary

- `selectManifestAsset` now compares `manifest.repository` case-insensitively against `expectedRepository`. The Ed25519 signature already binds identity; case sensitivity here only created a footgun.
- Self-hosters on default `BINARY_SOURCE=github` without `MSI_SIGNING_URL` were hitting "MSI build pipeline not reachable" because the manifest writes `LanternOps/breeze` (from `GITHUB_REPOSITORY` in `release.yml:1952`) while `getGithubReleaseRepository()` defaults to `lanternops/breeze` (`binarySource.ts:4`), and the verifier used strict `!==` (`releaseArtifactManifest.ts:166`).
- Reproduced live against the v0.67.0 GitHub manifest before the fix (`VERIFY FAILED: repository mismatch`) and after the fix (`VERIFY OK`).

Hosted SaaS never hit this because it uses `MsiSigningService.probe()` and skips the GitHub fallback. The latent bug landed in #568 (v0.65.0); existing tests mocked `fetchRegularMsi` end-to-end so live-manifest verification was never exercised.

## Test plan

- [x] New: `accepts a repository mismatch that differs only in case` — exact bug repro
- [x] New: `still rejects a repository mismatch beyond case differences` — guards against weakening the check
- [x] `apps/api/src/services/releaseArtifactManifest.test.ts` — 9/9 passing
- [x] `apps/api/src/routes/enrollmentKeys.test.ts` — 32/32 passing
- [x] Live: `verifyGithubReleaseArtifactBuffer` against `https://github.com/lanternops/breeze/releases/download/v0.67.0/release-artifact-manifest.json` now succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)