### PR TITLE
fix(web): surface remote-access launcher skip-reason instead of silently falling back to WebRTC

### DIFF
--- a/apps/web/src/components/remote/ConnectDesktopButton.test.tsx
+++ b/apps/web/src/components/remote/ConnectDesktopButton.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ConnectDesktopButton from './ConnectDesktopButton';
+import { fetchWithAuth } from '../../stores/auth';
+import { showToast, _resetToastQueueForTests } from '../shared/Toast';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('../shared/Toast', async () => {
+  const actual = await vi.importActual<typeof import('../shared/Toast')>('../shared/Toast');
+  return {
+    ...actual,
+    showToast: vi.fn(),
+  };
+});
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const toastMock = vi.mocked(showToast);
+
+const jsonRes = (body: unknown, ok = true): Response =>
+  ({
+    ok,
+    status: ok ? 200 : 500,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(body),
+  }) as unknown as Response;
+
+describe('ConnectDesktopButton — launcher skip-reason toast', () => {
+  beforeEach(() => {
+    _resetToastQueueForTests();
+    fetchMock.mockReset();
+    toastMock.mockReset();
+  });
+
+  it('toasts an explanation when partner has a launcher but THIS device is missing the identifier', async () => {
+    // GET /devices/:id returns hasRemoteAccessLauncher=false WITH a skip reason
+    // — the partner config exists but this device can't use it. Without the
+    // toast the user would silently get WebRTC instead of their RustDesk
+    // default and wonder why.
+    fetchMock.mockResolvedValueOnce(jsonRes({
+      desktopAccess: null,
+      hasRemoteAccessLauncher: false,
+      remoteAccessLaunchSkipReason: 'missing_device_identifier',
+    }));
+    // Subsequent calls (sessions/stale, sessions POST, connect-code POST) — we
+    // don't care about their detail for this test; just make them succeed
+    // enough that handleConnect doesn't error before the toast is checked.
+    fetchMock.mockResolvedValue(jsonRes({ id: 'sess-1', code: 'code-1' }));
+
+    render(<ConnectDesktopButton deviceId="dev-1" />);
+    fireEvent.click(screen.getByRole('button', { name: /connect desktop/i }));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          message: expect.stringContaining('per-device identifier'),
+        }),
+      );
+    });
+  });
+
+  it('does NOT toast when the partner has no launcher configured at all (no_provider_configured)', async () => {
+    // The "expected empty" case — no partner config means nothing surprising
+    // is happening, so we proceed silently to WebRTC.
+    fetchMock.mockResolvedValueOnce(jsonRes({
+      desktopAccess: null,
+      hasRemoteAccessLauncher: false,
+      remoteAccessLaunchSkipReason: 'no_provider_configured',
+    }));
+    fetchMock.mockResolvedValue(jsonRes({ id: 'sess-1', code: 'code-1' }));
+
+    render(<ConnectDesktopButton deviceId="dev-2" />);
+    fireEvent.click(screen.getByRole('button', { name: /connect desktop/i }));
+
+    // Give the click handler time to run; if a toast was going to fire, it
+    // would have by this point.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it('toasts a different message for provider_disabled', async () => {
+    fetchMock.mockResolvedValueOnce(jsonRes({
+      desktopAccess: null,
+      hasRemoteAccessLauncher: false,
+      remoteAccessLaunchSkipReason: 'provider_disabled',
+    }));
+    fetchMock.mockResolvedValue(jsonRes({ id: 'sess-1', code: 'code-1' }));
+
+    render(<ConnectDesktopButton deviceId="dev-3" />);
+    fireEvent.click(screen.getByRole('button', { name: /connect desktop/i }));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          message: expect.stringContaining('disabled'),
+        }),
+      );
+    });
+  });
+
+  it('does NOT toast when the launcher fires normally (hasRemoteAccessLauncher=true)', async () => {
+    // Normal launcher path — no toast.
+    fetchMock.mockResolvedValueOnce(jsonRes({
+      desktopAccess: null,
+      hasRemoteAccessLauncher: true,
+      remoteAccessLaunchSkipReason: null,
+    }));
+    fetchMock.mockResolvedValueOnce(jsonRes({
+      launchUrl: 'rustdesk://12345?password=x',
+      scheme: 'rustdesk',
+    }));
+
+    render(<ConnectDesktopButton deviceId="dev-4" />);
+    fireEvent.click(screen.getByRole('button', { name: /connect desktop/i }));
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/remote/ConnectDesktopButton.tsx
+++ b/apps/web/src/components/remote/ConnectDesktopButton.tsx
@@ -116,18 +116,53 @@ export default function ConnectDesktopButton({ deviceId, className = '', compact
       // deciding so the click always uses fresh state.
       let liveDesktopAccess: DesktopAccessState | null = desktopAccess ?? null;
       let hasRemoteAccessLauncher = false;
+      // Populated when the partner HAS a launcher configured but it can't fire
+      // for THIS device (most often `missing_device_identifier`). We toast and
+      // continue to WebRTC so the user understands why the third-party tool
+      // didn't launch, rather than wondering why their RustDesk/ScreenConnect
+      // default was silently ignored.
+      let launcherSkipReason: string | null = null;
       try {
         const devRes = await fetchWithAuth(`/devices/${deviceId}`);
         if (devRes.ok) {
           const devBody = await devRes.json() as {
             desktopAccess?: DesktopAccessState | null;
             hasRemoteAccessLauncher?: boolean;
+            remoteAccessLaunchSkipReason?: string | null;
           };
           liveDesktopAccess = devBody.desktopAccess ?? null;
           hasRemoteAccessLauncher = devBody.hasRemoteAccessLauncher === true;
+          launcherSkipReason = devBody.remoteAccessLaunchSkipReason ?? null;
         }
       } catch {
         // Network blip — fall back to the prop so the connect flow still runs.
+      }
+
+      // The partner has a launcher configured but this specific device can't
+      // use it. Toast the reason and fall through to WebRTC so the user
+      // doesn't silently get the wrong remote tool. `no_provider_configured`
+      // is intentionally NOT toasted — that's the expected-empty case.
+      // `scheme_not_allowed` would be a 422 on the launch POST, so it's
+      // surfaced loudly there rather than here.
+      if (!hasRemoteAccessLauncher && launcherSkipReason && launcherSkipReason !== 'no_provider_configured') {
+        const friendly =
+          launcherSkipReason === 'missing_device_identifier'
+            ? 'This device is missing the per-device identifier the partner-configured remote tool needs (e.g. the RustDesk peer ID). Falling back to built-in remote desktop. Set the identifier in Device Settings → Custom Fields.'
+            : launcherSkipReason === 'provider_disabled'
+              ? 'The partner-configured remote tool for this device is currently disabled. Falling back to built-in remote desktop.'
+              : launcherSkipReason === 'empty_url_template'
+                ? 'The partner-configured remote tool has no URL template set. Falling back to built-in remote desktop.'
+                : launcherSkipReason === 'config_error'
+                  ? 'Could not resolve the partner-configured remote tool (config error). Falling back to built-in remote desktop.'
+                  : null;
+        if (friendly) {
+          // 'error' type matches the loud-failure styling the other launcher
+          // paths in this component use (422 / 500). The Toast component
+          // currently only supports success | error | undo (Toast.tsx:7);
+          // 'error' is the closest match for "your preferred remote tool
+          // didn't fire — here's why" without being a hard blocker.
+          showToast({ type: 'error', message: friendly });
+        }
       }
 
       // If the partner has configured a third-party remote-tool provider

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -5,6 +5,12 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
+      // Mirrors the `@breeze/shared` path in apps/web/tsconfig.json so vitest
+      // can resolve workspace imports without a build step. Required for
+      // testing any component that imports from `@breeze/shared`.
+      '@breeze/shared': fileURLToPath(
+        new URL('../../packages/shared/src/index.ts', import.meta.url)
+      ),
       'astro:transitions/client': fileURLToPath(
         new URL('./src/__mocks__/astro-transitions-client.ts', import.meta.url)
       ),


### PR DESCRIPTION
## Problem

When a partner has a third-party remote-tool launcher configured (RustDesk, ScreenConnect, TeamViewer, etc.) and the user clicks Connect Desktop on a device that **can't** use it (typically because the device is missing the per-device identifier like `customFields.rustdesk_id`), the click silently falls through to the built-in WebRTC desktop viewer. The user expected their default tool, got something else, no toast, no tooltip, no log line they would notice.

Real-incident bait: I sat for ~10 minutes trying to figure out why my partner-default RustDesk wasn't launching on `ARL-DC-01` even though Partner settings clearly showed RustDesk as the default. The answer (the device's `customFields.rustdesk_id` was empty) was already known to the server and exposed on the API response as `remoteAccessLaunchSkipReason: 'missing_device_identifier'` — but the UI never read it.

## What this change does

`apps/api/src/routes/devices/core.ts:640-655` already computes a structured `remoteAccessLaunchSkipReason` on `GET /devices/:id` whenever `hasRemoteAccessLauncher` resolves false but a launcher provider exists. This PR makes the UI use it.

`ConnectDesktopButton.tsx` already re-fetches `/devices/:id` at click time (so the freshly-resolved state is used, not the stale prop). This change just adds `remoteAccessLaunchSkipReason` to the response shape it reads, and toasts a per-reason message when:

- `missing_device_identifier` → "This device is missing the per-device identifier the partner-configured remote tool needs (e.g. the RustDesk peer ID). Falling back to built-in remote desktop. Set the identifier in Device Settings → Custom Fields."
- `provider_disabled` → "The partner-configured remote tool for this device is currently disabled. Falling back to built-in remote desktop."
- `empty_url_template` → "The partner-configured remote tool has no URL template set. Falling back to built-in remote desktop."
- `config_error` → "Could not resolve the partner-configured remote tool (config error). Falling back to built-in remote desktop."

The toast uses `type: 'error'` because that's the only "loud" style the existing `Toast.tsx` ships (`'success' | 'error' | 'undo'` — no `'info'` or `'warning'` yet) and it matches the styling the same component already uses for the 422/500 launcher failure paths.

Intentionally NOT toasted:
- `no_provider_configured` — the expected-empty case (no partner config) where WebRTC is just the default and nothing surprising is happening.
- `scheme_not_allowed` — surfaced loudly on the launch POST path already (existing 422 handler).

The fallback to WebRTC continues regardless, so this strictly adds visibility; it does not break any working flow.

## Test coverage

`apps/web/src/components/remote/ConnectDesktopButton.test.tsx` (new file, 4 cases):

- `missing_device_identifier` → toast fires with the per-device-identifier message
- `no_provider_configured` → silent (no toast)
- `provider_disabled` → toast fires with the disabled-tool message
- normal launcher fires (`hasRemoteAccessLauncher: true`) → silent

## Why the vitest.config change is bundled

The new test couldn't be added without it. `apps/web/tsconfig.json:7` declares `"@breeze/shared": ["../../packages/shared/src"]` but `apps/web/vitest.config.ts` had no matching resolve.alias. tsc resolved imports fine; vitest blew up at static import-analysis on any component test that pulled `@breeze/shared`. This is the first such test in the repo (existing component tests like `ThirdPartyCatalog.test.tsx` test components that don't import shared). The one-line alias mirrors the tsconfig path and unlocks testing any future component that imports from shared.

## Checks

- tsc clean (`pnpm --filter @breeze/web exec tsc --noEmit`)
- New test 4/4 passing
- Pre-existing 23 failed tests in `auth.test.ts`, `aiStore.test.ts`, `orgStore.test.ts`, `RecoveryBootstrapTab.test.tsx` exist on clean `main` as well (verified via `git stash` + rerun) — all `localStorage`/jsdom-init issues unrelated to this change.