### PR TITLE
chore: knock three #714 nits — provider-id UUID, dead TRIVY_FS_RAN var, dead EffectiveOrgSettings field

### DIFF
--- a/apps/web/src/components/settings/PartnerRemoteAccessTab.tsx
+++ b/apps/web/src/components/settings/PartnerRemoteAccessTab.tsx
@@ -9,7 +9,10 @@ type Props = {
 };
 
 function makeProviderId(): string {
-  return `provider-${Math.random().toString(36).slice(2, 10)}`;
+  // crypto.randomUUID is widely supported in the browsers Breeze targets and
+  // gives a 122-bit-entropy id; Math.random().toString(36).slice(2,10) gave
+  // ~48 bits and is collidable on large provider lists (issue #714).
+  return `provider-${crypto.randomUUID()}`;
 }
 
 function emptyProvider(): RemoteAccessProvider {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -583,7 +583,6 @@ export interface EffectiveOrgSettings {
   defaults?: InheritableDefaultSettings;
   branding?: InheritableBrandingSettings;
   aiBudgets?: InheritableAiBudgetSettings;
-  remoteAccessProviders?: InheritableRemoteAccessSettings;
   locked: string[];
 }
 

--- a/scripts/security/preflight.sh
+++ b/scripts/security/preflight.sh
@@ -113,11 +113,9 @@ step "relay/edge hardening guard" bash scripts/security/check-relay-edge-hardeni
 # image. The CI workflow uses the aquasecurity/trivy-action GH Action, which
 # under the hood runs the same scan against the same severities — we mirror the
 # blocking step's flags here (HIGH,CRITICAL, exit-code 1).
-TRIVY_FS_RAN="0"
 if command -v trivy >/dev/null 2>&1; then
   step "trivy fs scan (HIGH,CRITICAL, blocking)" \
     trivy fs --severity HIGH,CRITICAL --exit-code 1 .
-  TRIVY_FS_RAN="1"
 elif command -v docker >/dev/null 2>&1; then
   # --ignorefile: container CWD is /, not /scan, so Trivy's default
   # .trivyignore auto-load doesn't fire. Pointing at the in-container
@@ -127,7 +125,6 @@ elif command -v docker >/dev/null 2>&1; then
     docker run --rm -v "$ROOT_DIR":/scan:ro aquasec/trivy:latest \
       fs --severity HIGH,CRITICAL --exit-code 1 \
       --ignorefile /scan/.trivyignore /scan
-  TRIVY_FS_RAN="1"
 else
   skip "trivy fs scan" "install: brew install trivy  OR start Docker/OrbStack"
 fi


### PR DESCRIPTION
Three of the cleanest checkboxes from #714. All pure cleanups, no behavior change for any live code path.

## What ships

### 1. `makeProviderId()` → `crypto.randomUUID()` (web)

`apps/web/src/components/settings/PartnerRemoteAccessTab.tsx:11-13` used `Math.random().toString(36).slice(2, 10)` — 8 base36 chars ≈ 48 bits of entropy and collidable on a large provider list. Swapped to `crypto.randomUUID()` (122-bit entropy, widely supported in the browsers Breeze targets). Comment cites #714.

### 2. Drop dead `TRIVY_FS_RAN` shell var

`scripts/security/preflight.sh:116, 120, 130` set the variable in two branches but no one reads it (ShellCheck SC2034). Removed all three lines.

### 3. Remove dead `EffectiveOrgSettings.remoteAccessProviders` type field

`packages/shared/src/types/index.ts:586` declared the field but `apps/api/src/services/effectiveSettings.ts` never populates it (verified by grep: the only writers and readers of `remoteAccessProviders` are on `PartnerSettings` at line 624, which is untouched). Removed from EffectiveOrgSettings; PartnerSettings declaration kept as the live source of truth. If org-level RemoteAccess overrides become a feature later, the field can be re-added with the matching merge in `effectiveSettings.ts` then.

## What stays open on #714

- Allowlist scheme guard in `remoteAccessLauncherScheme.ts` (needs validator rewrite + test updates)
- Client-side inline template validator mirroring the server denylist (UX + validator coordination)
- Gitleaks gate documentation in `preflight.sh` header (small but stylistic choice; left for whoever owns the header text)

## Checks

- `pnpm --filter @breeze/web exec tsc --noEmit` clean
- `pnpm --filter @breeze/api exec tsc --noEmit` clean
- `bash -n scripts/security/preflight.sh` clean

Net diff: +4, -5.