### PR TITLE
fix(api): soft-revoke OAuth client on self-reported suspicious approval (close ~15min access-token window)

### DIFF
--- a/apps/api/src/routes/approvals.test.ts
+++ b/apps/api/src/routes/approvals.test.ts
@@ -28,13 +28,15 @@ vi.mock('../db/schema/ai', () => ({
   aiToolExecutions: { id: 'id' },
 }));
 
-vi.mock('../db/schema/oauth', () => ({
-  oauthGrants: { id: 'id', accountId: 'accountId', clientId: 'clientId' },
-  oauthRefreshTokens: { id: 'id', userId: 'userId', clientId: 'clientId' },
-}));
-
 vi.mock('../db/schema/audit', () => ({
   auditLogs: {},
+}));
+
+vi.mock('./lifecycle', () => ({
+  revokeUserOauthClient: vi.fn(async () => ({ grantsRevoked: 1, refreshTokensRevoked: 1 })),
+  // Not used by approvals.ts but exported from lifecycle.ts; mocked to avoid
+  // pulling in the full lifecycle module-init chain in this test surface.
+  isOauthClientBlockedForOrg: vi.fn(async () => false),
 }));
 
 const TEST_USER = {
@@ -399,47 +401,41 @@ describe('POST /approvals/:id/report-suspicious', () => {
       }),
     } as any);
 
-    // 2) update approval_requests (status=reported)
+    // 2) update approval_requests (status=reported) — the only remaining
+    //    direct db.update in this handler now that grant/refresh-token
+    //    revocation is delegated to lifecycle.revokeUserOauthClient.
     const approvalUpdateSet = vi.fn().mockReturnValue({
       where: vi.fn().mockResolvedValue(undefined),
     });
-    // 3) update oauth_refresh_tokens
-    const tokenUpdateSet = vi.fn().mockReturnValue({
-      where: vi.fn().mockReturnValue({
-        returning: vi.fn().mockResolvedValue([{ id: 'rt-1' }]),
-      }),
-    });
-    vi.mocked(db.update)
-      .mockReturnValueOnce({ set: approvalUpdateSet } as any)
-      .mockReturnValueOnce({ set: tokenUpdateSet } as any);
-
-    // delete oauth_grants
-    vi.mocked(db.delete).mockReturnValue({
-      where: vi.fn().mockReturnValue({
-        returning: vi.fn().mockResolvedValue([{ id: 'grant-1' }]),
-      }),
-    } as any);
+    vi.mocked(db.update).mockReturnValueOnce({ set: approvalUpdateSet } as any);
 
     // insert audit log
     vi.mocked(db.insert).mockReturnValue({
       values: vi.fn().mockResolvedValue(undefined),
     } as any);
 
-    return { approvalUpdateSet, tokenUpdateSet };
+    return { approvalUpdateSet };
   }
 
-  it('happy path: 204, denies row, revokes grant + tokens, writes audit', async () => {
-    const { approvalUpdateSet, tokenUpdateSet } = wireRevocationStubs({ existing: baseRow });
+  it('happy path: 204, denies row, delegates OAuth client revocation to lifecycle helper, writes audit', async () => {
+    const { approvalUpdateSet } = wireRevocationStubs({ existing: baseRow });
 
     const res = await buildApp().request('/approvals/a1/report-suspicious', { method: 'POST' });
     expect(res.status).toBe(204);
     expect(approvalUpdateSet).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'reported' }),
     );
-    expect(tokenUpdateSet).toHaveBeenCalledWith(
-      expect.objectContaining({ revokedAt: expect.any(Date) }),
+    // Revocation is the canonical lifecycle.ts soft-revoke path: stamps
+    // oauth_grants.revoked_at + revokes refresh-token JTIs + writes the
+    // grant-revocation cache marker so any in-flight access JWT is
+    // rejected before its natural expiry.
+    const { revokeUserOauthClient } = await import('./lifecycle');
+    expect(revokeUserOauthClient).toHaveBeenCalledWith(
+      TEST_USER.id,
+      baseRow.requestingClientId,
+      TEST_USER.id,
+      'self-reported suspicious approval',
     );
-    expect(db.delete).toHaveBeenCalled();
     expect(db.insert).toHaveBeenCalled();
   });
 

--- a/apps/api/src/routes/approvals.ts
+++ b/apps/api/src/routes/approvals.ts
@@ -7,9 +7,9 @@ import { db } from '../db';
 import { authMiddleware } from '../middleware/auth';
 import { approvalRequests } from '../db/schema/approvals';
 import { aiToolExecutions } from '../db/schema/ai';
-import { oauthGrants, oauthRefreshTokens } from '../db/schema/oauth';
 import { auditLogs } from '../db/schema/audit';
 import { buildApprovalPush, getUserPushTokens, sendExpoPush } from '../services/expoPush';
+import { revokeUserOauthClient } from './lifecycle';
 
 export const approvalRoutes = new Hono();
 
@@ -187,37 +187,28 @@ approvalRoutes.post('/:id/report-suspicious', async (c) => {
   }
 
   // Revoke the requesting OAuth client (grant + refresh tokens) for this user.
-  // TODO(lifecycle): a parallel agent is adding a `revoked_at` column on
-  // `oauth_grants` for soft-revoke + audit history. Until that lands we delete
-  // the grant row outright (oidc-provider treats a missing grant as revoked)
-  // and mark refresh tokens as revoked via the existing column.
+  // Delegates to the canonical lifecycle.ts soft-revoke flow, which:
+  //   1. UPDATEs oauth_grants.revoked_at + revoked_by_user_id + revoked_reason
+  //      (was: DELETE — left audit-history empty AND skipped #2 below).
+  //   2. Stamps every active refresh token's revoked_at AND revokes the JTI
+  //      in the Redis access-token blocklist so any in-flight access JWT is
+  //      rejected by bearerTokenAuthMiddleware before its natural ~15-min
+  //      TTL expiry. The old delete-only path left a ~15-min window where
+  //      access tokens minted from the (now-revoked) grant would continue
+  //      working — a real gap for a user-initiated suspicious-report flow.
+  //   3. Writes belt-and-suspenders grant-revocation cache markers for
+  //      direct-authorize grants that don't have a refresh token row.
   const requestingClientId = existing.requestingClientId;
   let grantsRevoked = 0;
   let refreshTokensRevoked = 0;
   if (requestingClientId) {
     try {
-      const deleted = await db
-        .delete(oauthGrants)
-        .where(
-          and(
-            eq(oauthGrants.accountId, userId),
-            eq(oauthGrants.clientId, requestingClientId),
-          )
-        )
-        .returning({ id: oauthGrants.id });
-      grantsRevoked = deleted.length;
-
-      const tokenRes = await db
-        .update(oauthRefreshTokens)
-        .set({ revokedAt: new Date() })
-        .where(
-          and(
-            eq(oauthRefreshTokens.userId, userId),
-            eq(oauthRefreshTokens.clientId, requestingClientId),
-          )
-        )
-        .returning({ id: oauthRefreshTokens.id });
-      refreshTokensRevoked = tokenRes.length;
+      ({ grantsRevoked, refreshTokensRevoked } = await revokeUserOauthClient(
+        userId,
+        requestingClientId,
+        userId,
+        'self-reported suspicious approval',
+      ));
     } catch (err) {
       console.error('[approvals] report-suspicious: revocation failed:', err);
       // Non-fatal: the approval row + audit log are still authoritative; the

--- a/apps/api/src/routes/lifecycle.ts
+++ b/apps/api/src/routes/lifecycle.ts
@@ -313,7 +313,7 @@ lifecycleRoutes.get('/me/oauth-clients', async (c) => {
   });
 });
 
-async function revokeUserOauthClient(
+export async function revokeUserOauthClient(
   userId: string,
   clientId: string,
   revokedByUserId: string,


### PR DESCRIPTION
## Problem

`POST /approvals/:id/report-suspicious` revokes the OAuth client that triggered the flagged approval. The current implementation has a real security gap:

```ts
// apps/api/src/routes/approvals.ts:198-220 (current)
const deleted = await db
  .delete(oauthGrants)
  .where(and(eq(oauthGrants.accountId, userId), eq(oauthGrants.clientId, requestingClientId)))
  ...
const tokenRes = await db
  .update(oauthRefreshTokens)
  .set({ revokedAt: new Date() })
  .where(and(eq(oauthRefreshTokens.userId, userId), eq(oauthRefreshTokens.clientId, requestingClientId)))
  ...
```

This path deletes the grant row and stamps refresh tokens, but **never writes to the Redis grant-revocation cache**. `bearerTokenAuthMiddleware` (`middleware/bearerTokenAuth.ts`) gates every request on `isGrantRevoked(grant_id)`, which reads from that cache. Since nothing wrote, any access JWT already minted from the (now-deleted) grant continues to validate for **up to ACCESS_TOKEN_TTL_SECONDS (~15 min)** past the user-initiated revocation.

That's the threat: the user reports a suspicious approval, expecting *immediate* revocation. They get *eventual* revocation, with a window during which any access token previously issued from the offending client can still call MCP tools.

## TODO context

`approvals.ts:190` carries:

```
// TODO(lifecycle): a parallel agent is adding a `revoked_at` column on
// `oauth_grants` for soft-revoke + audit history. Until that lands we delete
// the grant row outright (oidc-provider treats a missing grant as revoked)
// and mark refresh tokens as revoked via the existing column.
```

That column landed in `2026-05-07-mobile-device-and-oauth-lifecycle.sql`. `routes/lifecycle.ts:316` (`revokeUserOauthClient`) is the canonical soft-revoke function — it does the UPDATE, stamps refresh-token JTIs in the Redis blocklist via `revokeJti`, and writes the grant-revocation cache marker via `revokeGrant` for any grant that didn't have a refresh token row. It powers `/me/oauth-clients/:clientId/revoke`.

## What this PR does

- Exports `revokeUserOauthClient` from `routes/lifecycle.ts` (was file-local).
- Replaces the inline DELETE+UPDATE block in `POST /approvals/:id/report-suspicious` with a single call:
  ```ts
  await revokeUserOauthClient(
    userId,
    requestingClientId,
    userId,                              // revoking actor is the user themselves
    'self-reported suspicious approval', // audit reason
  );
  ```
- Removes the now-unused `oauthGrants` / `oauthRefreshTokens` schema imports from `approvals.ts`.
- Updates `approvals.test.ts`: the per-table `db.delete` / `db.update` mocks for the revocation flow are replaced with `vi.mock('./lifecycle', () => ({ revokeUserOauthClient: vi.fn(...) }))`. The happy-path test now asserts the canonical call shape.

The audit-log entry still records `grantsRevoked` / `refreshTokensRevoked` counts; they now come from the helper's return shape instead of inline returning() arrays.

## Checks

- `pnpm --filter @breeze/api exec tsc --noEmit` clean
- `apps/api` full vitest suite: 4674 pass, 28 skip, 0 fail
- `lifecycle.test.ts` 19/19, `approvals.test.ts` 17/17

Net diff: +43, -56.