### PR TITLE
chore(preflight): mirror the Gitleaks secret-scan CI gate locally (#714)

### DIFF
--- a/scripts/security/preflight.sh
+++ b/scripts/security/preflight.sh
@@ -15,7 +15,8 @@
 #   - pnpm (matches packageManager field in package.json)
 #   - go install golang.org/x/vuln/cmd/govulncheck@latest
 #   - cargo install cargo-audit --locked
-#   - docker (or OrbStack/Colima) for the Trivy scans, OR `brew install trivy`
+#   - docker (or OrbStack/Colima) for the Trivy + Gitleaks scans, OR
+#     `brew install trivy gitleaks`
 #
 # Exit code: 0 if every required check passes, non-zero on any FAIL. Skipped
 # checks (missing tooling) are non-fatal unless --strict is passed.
@@ -107,6 +108,23 @@ fi
 # 4) Supply-chain + relay/edge hardening — CI: ci.yml job security-audit steps 2 & 3
 step "supply-chain hardening guard" bash scripts/security/check-supply-chain-hardening.sh
 step "relay/edge hardening guard" bash scripts/security/check-relay-edge-hardening.sh
+
+# 4b) Gitleaks secret scan — CI: secret-scan.yml job gitleaks (separate
+# required PR check). Prefer the native binary if installed; fall back to
+# the official Docker image. The CI workflow runs:
+#   `gitleaks detect --source . --verbose`
+# We mirror those exact flags here so a clean local run gives the same
+# verdict as the CI check.
+if command -v gitleaks >/dev/null 2>&1; then
+  step "gitleaks detect (secret-scan.yml mirror)" \
+    gitleaks detect --source . --verbose
+elif command -v docker >/dev/null 2>&1; then
+  step "gitleaks detect via Docker (secret-scan.yml mirror)" \
+    docker run --rm -v "$ROOT_DIR":/scan:ro ghcr.io/gitleaks/gitleaks:latest \
+      detect --source /scan --verbose
+else
+  skip "gitleaks detect" "install: brew install gitleaks  OR start Docker/OrbStack"
+fi
 
 # 5) Trivy filesystem scan — CI: security.yml job trivy-fs-scan, blocking step
 # Prefer the native trivy binary if installed; fall back to the official Docker


### PR DESCRIPTION
Closes the third remaining checkbox on #714 — the local `scripts/security/preflight.sh` was skipping Gitleaks even though `secret-scan.yml` is a separate required PR check, so a clean local run could still fail CI on Gitleaks, defeating the script's "what passes here passes there" promise.

## What changes

New \"4b) Gitleaks\" gate matching the CI shape:

```
if command -v gitleaks >/dev/null 2>&1; then
  step "gitleaks detect (secret-scan.yml mirror)" \
    gitleaks detect --source . --verbose
elif command -v docker >/dev/null 2>&1; then
  step "gitleaks detect via Docker (secret-scan.yml mirror)" \
    docker run --rm -v "\$ROOT_DIR":/scan:ro ghcr.io/gitleaks/gitleaks:latest \
      detect --source /scan --verbose
else
  skip "gitleaks detect" "install: brew install gitleaks  OR start Docker/OrbStack"
fi
```

The invocation mirrors `secret-scan.yml:40` (`gitleaks detect --source . --verbose`) exactly.

Also updated the first-time-setup header to list gitleaks alongside trivy under the "docker OR brew install" choice.

## Checks

- `bash -n scripts/security/preflight.sh` clean.
- Manually exercised the Docker fallback against the live repo:
  ```
  docker run --rm -v "\$ROOT_DIR":/scan:ro ghcr.io/gitleaks/gitleaks:latest detect --source /scan --verbose
  ```
  → 2098 commits scanned, no leaks, exit 0.

Net diff: +19, -1.

#714 remaining: scheme guard denylist→allowlist conversion and client-side inline template validator mirroring. Both bigger / coordination-heavy; staying open on the tracking issue.