### PR TITLE
fix(agent): isolate TestRunCleansUpTempFile workDir — kill the intermittent Test Agent CI red

### DIFF
--- a/agent/internal/scripts/runner_test.go
+++ b/agent/internal/scripts/runner_test.go
@@ -213,7 +213,14 @@ func TestRunCleansUpTempFile(t *testing.T) {
 		t.Skip("skipping bash test on Windows")
 	}
 
-	r := NewRunner()
+	// Isolate workDir to a per-test temp dir. NewRunner() uses a shared
+	// `os.TempDir()/breeze-scripts` path which any sibling test/process can
+	// write to. With the shared path the file-count assertion below
+	// occasionally trips with `before=0, after=1 files` on CI even though
+	// `defer os.Remove(scriptFile)` in Run() is fine — the "after" file came
+	// from a sibling, not from r.Run. Per-test t.TempDir makes the check
+	// observe only this test's effect.
+	r := &ScriptRunner{workDir: t.TempDir()}
 
 	// List files before
 	beforeFiles, _ := os.ReadDir(r.workDir)


### PR DESCRIPTION
## Symptom

CI \`Test Agent\` job intermittently red on \`main\` with:

\`\`\`
runner_test.go:229: temp file not cleaned up: before=0, after=1 files
--- FAIL: TestRunCleansUpTempFile (0.00s)
\`\`\`

Today's example: scheduled run on commit \`0de38817\` 2026-05-25 10:31Z. The other 14 Test Agent / Build Agent jobs all green; just \`Test Agent\` red because of this single test.

## Root cause

\`NewRunner()\` (\`agent/internal/scripts/runner.go:30-34\`) hard-codes its workDir to \`os.TempDir() + "/breeze-scripts"\` — shared across every process and test binary on the host. The production \`defer os.Remove(scriptFile)\` inside \`Run()\` works correctly: each call cleans up its own file. But the assertion observes the **whole** directory:

\`\`\`go
r := NewRunner()
beforeFiles, _ := os.ReadDir(r.workDir)   // <-- /tmp/breeze-scripts, shared
beforeCount := len(beforeFiles)
r.Run(...)
afterFiles, _ := os.ReadDir(r.workDir)
afterCount := len(afterFiles)
if afterCount > beforeCount { t.Fatalf(...) }
\`\`\`

If any sibling test (or unrelated process) drops a file into \`/tmp/breeze-scripts\` between the before/after snapshots, the count goes up and the assertion trips even though \`r.Run\`'s own cleanup ran fine. **Production code is fine; this is a test-isolation defect.**

## Fix

Switch only \`TestRunCleansUpTempFile\` to a per-call \`&ScriptRunner{workDir: t.TempDir()}\`. \`t.TempDir()\` gives the test an isolated dir that Go's testing framework owns + cleans up automatically. The directory-level assertion now observes only this test's effect.

Scope is intentionally minimal:
- The other \`TestRun*\` cases don't read workDir contents; they keep using \`NewRunner()\` and continue to exercise the production default workDir path.
- \`TestNewRunnerCreatesWorkDir\` and \`TestNewRunnerWorkDirInTempDir\` specifically assert the prod default — also kept as-is.
- The \`ScriptRunner\` struct's \`workDir\` field is package-private; the test is in the same package, so direct struct literal works without exposing anything.

## Verified

\`\`\`
cd agent && go test -race -count=3 -run TestRunCleansUpTempFile ./internal/scripts/   # ok
cd agent && go test -race -count=1 ./internal/scripts/                                 # ok
CGO_ENABLED=0 go vet ./internal/scripts/                                               # clean
\`\`\`

Net diff: +8, -1.