### PR TITLE
feat(devices): POST /devices/:id/move-org for cross-org device relocation

### DIFF
--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -2170,6 +2170,49 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
         }
       }
     },
+    '/devices/{id}/move-org': {
+      post: {
+        operationId: 'moveDeviceOrg',
+        tags: ['Devices'],
+        summary: 'Move device to a different organization',
+        description: 'Relocate a device between organizations (and to a site within the new org) without uninstalling the agent. Requires partner or system scope, devices:write + organizations:write, and MFA. Cross-partner moves require system scope.',
+        parameters: [{ $ref: '#/components/parameters/idParam' }],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['orgId', 'siteId'],
+                properties: {
+                  orgId: { type: 'string', format: 'uuid', description: 'Target organization id' },
+                  siteId: { type: 'string', format: 'uuid', description: 'Target site id (must belong to target org)' },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'Device moved',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    success: { type: 'boolean' },
+                    device: { $ref: '#/components/schemas/Device' },
+                  },
+                },
+              },
+            },
+          },
+          '400': { description: 'Invalid input (e.g. target site not in target org, target org equals source)' },
+          '403': { description: 'Access denied (target org or cross-partner move without system scope)' },
+          '404': { description: 'Device or target organization not found' },
+        },
+      },
+    },
     '/devices/{id}/metrics': {
       get: {
         operationId: 'getDeviceMetrics',

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -2313,6 +2313,30 @@ export function sendCommandToAgent(agentId: string, command: AgentCommand): bool
 }
 
 /**
+ * Force-close an agent's active WS connection so it reconnects with a fresh
+ * handshake (and re-resolves its orgId/siteId via agentAuth). Use this after
+ * any server-side change that invalidates the orgId baked into the live
+ * connection — e.g. a cross-org move where every per-message
+ * runWithAgentDbAccess call would otherwise keep using the stale orgId for
+ * RLS (see preValidatedAgent closure capture in createAgentWsHandlers).
+ *
+ * Returns true if a connection was found and close() was called.
+ * Returns false if no active connection exists for this agentId.
+ */
+export function disconnectAgent(agentId: string, code: number = 4040, reason: string = 'orgId changed, reconnect required'): boolean {
+  const ws = activeConnections.get(agentId);
+  if (!ws) return false;
+  try {
+    ws.close(code, reason);
+  } catch (error) {
+    console.error(`disconnectAgent(${agentId.slice(0,12)}) close threw:`, error);
+  }
+  // Don't delete from map here — the WS onClose handler does that itself
+  // (lines ~1905-1907) and we don't want to race with reconnect logic.
+  return true;
+}
+
+/**
  * Check if an agent is connected via WebSocket
  */
 export function isAgentConnected(agentId: string): boolean {

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -110,6 +110,15 @@ export const DEVICE_ORG_DENORMALIZED_TABLES = [
 ] as const;
 
 /**
+ * Tables that are both device-id scoped AND denormalize site_id for query-perf.
+ * Currently empty — no device-id-scoped child table has a site_id column.
+ * Forward-defense list: any future schema PR adding site_id to such a table
+ * will be caught by the moveOrg.coverage.test.ts drift-detector below and
+ * must be added here so cross-org-cross-site moves rewrite child site_ids.
+ */
+export const DEVICE_SITE_DENORMALIZED_TABLES = [] as const;
+
+/**
  * All tables with a direct device_id FK to devices.id, ordered so children come
  * before parents (to avoid FK violations during cascade delete).
  *

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -61,6 +61,55 @@ export const DEVICE_LINKED_DEVICE_ID_TABLES = [
 ] as const;
 
 /**
+ * Subset of {@link DEVICE_CASCADE_DELETE_TABLES} whose rows denormalize
+ * `org_id` for RLS performance. When a device moves between orgs, every
+ * one of these tables must have its `org_id` rewritten inside the same
+ * transaction that flips `devices.org_id`, otherwise pre-existing rows
+ * stay visible to the OLD org under RLS and invisible to the NEW org.
+ *
+ * IMPORTANT: When you add a new device-scoped table with an `org_id`
+ * column, add it here too. The test in moveOrg.coverage.test.ts will
+ * fail CI if you forget.
+ *
+ * Tables intentionally excluded (no `org_id` column today):
+ *   automation_policy_compliance, deployment_devices, deployment_results,
+ *   device_commands (system-scoped per RLS policy), device_software,
+ *   file_transfers, patch_job_results, patch_rollbacks,
+ *   psa_ticket_mappings, software_compliance_status
+ */
+export const DEVICE_ORG_DENORMALIZED_TABLES = [
+  'agent_logs', 'ai_screenshots', 'ai_sessions', 'alerts', 'asset_checkouts',
+  'audit_baseline_results', 'audit_policy_states',
+  'backup_chains', 'backup_jobs', 'backup_sla_events',
+  'backup_snapshots', 'backup_verifications',
+  'brain_device_context', 'browser_extensions', 'browser_policy_violations',
+  'capacity_predictions',
+  'cis_baseline_results', 'cis_remediation_actions',
+  'deployment_invites',
+  'device_boot_metrics', 'device_change_log', 'device_config_state',
+  'device_connections', 'device_disks', 'device_event_logs',
+  'device_filesystem_cleanup_runs', 'device_filesystem_scan_state',
+  'device_filesystem_snapshots',
+  'device_group_memberships', 'device_hardware', 'device_ip_history',
+  'device_metrics', 'device_network', 'device_patches', 'device_registry_state',
+  'device_reliability', 'device_reliability_history', 'device_sessions',
+  'device_warranty',
+  'dns_event_aggregations', 'dns_security_events',
+  'group_membership_log',
+  'huntress_agents', 'huntress_incidents', 'hyperv_vms', 'local_vaults',
+  'peripheral_events', 'playbook_executions',
+  'recovery_readiness', 'recovery_tokens', 'remote_sessions', 'restore_jobs',
+  's1_actions', 's1_agents', 's1_threats',
+  'script_executions',
+  'security_posture_snapshots', 'security_scans', 'security_status',
+  'security_threats',
+  'sensitive_data_findings', 'sensitive_data_scans',
+  'service_process_check_results',
+  'software_inventory', 'software_policy_audit', 'sql_instances',
+  'tickets', 'time_series_metrics', 'tunnel_sessions',
+] as const;
+
+/**
  * All tables with a direct device_id FK to devices.id, ordered so children come
  * before parents (to avoid FK violations during cascade delete).
  *

--- a/apps/api/src/routes/devices/index.ts
+++ b/apps/api/src/routes/devices/index.ts
@@ -18,6 +18,7 @@ import { bootMetricsRoutes } from './bootMetrics';
 import { diagnoseRoutes } from './diagnose';
 import { warrantyRoutes } from './warranty';
 import { provisionRoutes } from './provision';
+import { moveOrgRoutes } from './moveOrg';
 
 export const deviceRoutes = new Hono();
 
@@ -33,6 +34,10 @@ deviceRoutes.route('/', groupsRoutes);
 
 // Mount filesystem routes before core routes so /:id/filesystem resolves cleanly.
 deviceRoutes.route('/', filesystemRoutes);
+
+// Mount move-org BEFORE core routes — its POST /:id/move-org would collide
+// with any future :id-prefixed match in core if registered after.
+deviceRoutes.route('/', moveOrgRoutes);
 
 // Mount core routes (/, /:id, PATCH /:id, DELETE /:id)
 deviceRoutes.route('/', coreRoutes);

--- a/apps/api/src/routes/devices/moveOrg.coverage.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.coverage.test.ts
@@ -5,6 +5,7 @@ import * as schema from '../../db/schema';
 import {
   DEVICE_CASCADE_DELETE_TABLES,
   DEVICE_ORG_DENORMALIZED_TABLES,
+  DEVICE_SITE_DENORMALIZED_TABLES,
 } from './core';
 
 /**
@@ -108,6 +109,77 @@ describe('DEVICE_ORG_DENORMALIZED_TABLES coverage', () => {
     expect(
       orphans,
       `These tables are in DEVICE_ORG_DENORMALIZED_TABLES but missing from DEVICE_CASCADE_DELETE_TABLES.`,
+    ).toEqual([]);
+  });
+});
+
+/**
+ * Mirror of the org_id coverage block, for `site_id`.
+ *
+ * `POST /devices/:id/move-org` can also change the device's site (within the
+ * target org). Any device-id-scoped table that denormalizes `site_id` must
+ * also be rewritten in the move transaction — otherwise child rows stay
+ * pinned to the OLD site after the parent device has moved.
+ *
+ * As of this PR, NO device-id-scoped child table has a `site_id` column,
+ * so DEVICE_SITE_DENORMALIZED_TABLES is empty. The drift detector below
+ * exists so any future schema PR that adds such a column will fail CI
+ * until the table is added to DEVICE_SITE_DENORMALIZED_TABLES in core.ts.
+ */
+describe('DEVICE_SITE_DENORMALIZED_TABLES coverage', () => {
+  const siteDenormSet = new Set<string>(DEVICE_SITE_DENORMALIZED_TABLES);
+
+  const allTables = Object.values(schema).filter(
+    (v) => v instanceof PgTable,
+  ) as PgTable<any>[];
+
+  it('includes every table that has both a device_id and a site_id column', () => {
+    const missing: string[] = [];
+
+    for (const table of allTables) {
+      const name = getTableName(table);
+      // Skip the devices table itself — it owns site_id, doesn't denormalize it.
+      if (name === 'devices') continue;
+
+      const cols = getColumns(table);
+      const hasDeviceId = cols.some((c) => c.name === 'device_id');
+      const hasSiteId = cols.some((c) => c.name === 'site_id');
+      if (hasDeviceId && hasSiteId && !siteDenormSet.has(name)) {
+        missing.push(name);
+      }
+    }
+
+    expect(
+      missing,
+      `These tables have BOTH a device_id and a site_id column but are missing ` +
+        `from DEVICE_SITE_DENORMALIZED_TABLES in core.ts. Cross-site moves ` +
+        `via POST /devices/:id/move-org will strand their rows under the OLD ` +
+        `site_id. Add them to DEVICE_SITE_DENORMALIZED_TABLES.\n\nMissing: ${missing.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('only lists tables that still exist in the schema with both columns', () => {
+    const tableByName = new Map(allTables.map((t) => [getTableName(t), t] as const));
+    const stale: string[] = [];
+
+    for (const name of DEVICE_SITE_DENORMALIZED_TABLES) {
+      const table = tableByName.get(name);
+      if (!table) {
+        stale.push(`${name} (table no longer exists)`);
+        continue;
+      }
+      const cols = getColumns(table);
+      const hasDeviceId = cols.some((c) => c.name === 'device_id');
+      const hasSiteId = cols.some((c) => c.name === 'site_id');
+      if (!hasDeviceId || !hasSiteId) {
+        stale.push(`${name} (missing ${!hasDeviceId ? 'device_id' : ''}${!hasDeviceId && !hasSiteId ? ' and ' : ''}${!hasSiteId ? 'site_id' : ''})`);
+      }
+    }
+
+    expect(
+      stale,
+      `These entries in DEVICE_SITE_DENORMALIZED_TABLES are stale — remove them ` +
+        `or fix the schema.`,
     ).toEqual([]);
   });
 });

--- a/apps/api/src/routes/devices/moveOrg.coverage.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.coverage.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { getTableName } from 'drizzle-orm';
+import { PgTable } from 'drizzle-orm/pg-core';
+import * as schema from '../../db/schema';
+import {
+  DEVICE_CASCADE_DELETE_TABLES,
+  DEVICE_ORG_DENORMALIZED_TABLES,
+} from './core';
+
+/**
+ * Mirrors cascadeDelete.test.ts but for the `org_id` denormalization list.
+ *
+ * `POST /devices/:id/move-org` works by rewriting the denormalized `org_id`
+ * column on every device-scoped table inside the same transaction that
+ * flips `devices.org_id`. If a new device-scoped table is added with an
+ * `org_id` column but NOT added to DEVICE_ORG_DENORMALIZED_TABLES, the move
+ * will strand its rows under the OLD org's RLS — invisible to the new org.
+ *
+ * This test catches that drift at CI time.
+ *
+ * Tables that intentionally don't denormalize `org_id` (e.g. `device_commands`
+ * which is system-scoped per RLS policy) are listed in INTENTIONALLY_NO_ORG_ID
+ * here and must match the comment in core.ts.
+ */
+const INTENTIONALLY_NO_ORG_ID: ReadonlySet<string> = new Set([
+  'automation_policy_compliance',
+  'deployment_devices',
+  'deployment_results',
+  'device_commands',
+  'device_software',
+  'file_transfers',
+  'patch_job_results',
+  'patch_rollbacks',
+  'psa_ticket_mappings',
+  'software_compliance_status',
+]);
+
+function getColumns(table: PgTable<any>): any[] {
+  return Object.values(
+    (table as any)[Symbol.for('drizzle:Columns')] ?? {},
+  );
+}
+
+describe('DEVICE_ORG_DENORMALIZED_TABLES coverage', () => {
+  const denormSet = new Set<string>(DEVICE_ORG_DENORMALIZED_TABLES);
+  const cascadeSet = new Set<string>(DEVICE_CASCADE_DELETE_TABLES);
+
+  const allTables = Object.values(schema).filter(
+    (v) => v instanceof PgTable,
+  ) as PgTable<any>[];
+
+  it('includes every cascade-delete table that also has an org_id column', () => {
+    const missing: string[] = [];
+
+    for (const table of allTables) {
+      const name = getTableName(table);
+      if (!cascadeSet.has(name)) continue;
+      if (INTENTIONALLY_NO_ORG_ID.has(name)) continue;
+
+      const cols = getColumns(table);
+      const hasOrgId = cols.some((c) => c.name === 'org_id');
+      if (hasOrgId && !denormSet.has(name)) {
+        missing.push(name);
+      }
+    }
+
+    expect(
+      missing,
+      `These tables are in DEVICE_CASCADE_DELETE_TABLES and have an org_id column ` +
+        `but are missing from DEVICE_ORG_DENORMALIZED_TABLES in core.ts. ` +
+        `Add them, or — if their org_id is intentionally not denormalized for ` +
+        `move purposes — add them to INTENTIONALLY_NO_ORG_ID in this test ` +
+        `AND to the comment block in core.ts.\n\nMissing: ${missing.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('only lists tables that exist in the schema', () => {
+    const allNames = new Set(allTables.map((t) => getTableName(t)));
+    const stale = DEVICE_ORG_DENORMALIZED_TABLES.filter((t) => !allNames.has(t));
+    expect(
+      stale,
+      `These tables are listed in DEVICE_ORG_DENORMALIZED_TABLES but no longer exist in the schema. Remove them.`,
+    ).toEqual([]);
+  });
+
+  it('only lists tables that actually have an org_id column', () => {
+    const tablesWithoutOrgId: string[] = [];
+    const tableByName = new Map(allTables.map((t) => [getTableName(t), t] as const));
+
+    for (const name of DEVICE_ORG_DENORMALIZED_TABLES) {
+      const table = tableByName.get(name);
+      if (!table) continue; // covered by the stale-name test above
+      const hasOrgId = getColumns(table).some((c) => c.name === 'org_id');
+      if (!hasOrgId) tablesWithoutOrgId.push(name);
+    }
+
+    expect(
+      tablesWithoutOrgId,
+      `These tables are listed in DEVICE_ORG_DENORMALIZED_TABLES but do not have an org_id column. ` +
+        `Move them to INTENTIONALLY_NO_ORG_ID, or remove from the denormalized list.`,
+    ).toEqual([]);
+  });
+
+  it('all listed tables are also in DEVICE_CASCADE_DELETE_TABLES', () => {
+    // Sanity: a denormalized device table that isn't cascade-deleted is
+    // a bug elsewhere; flag it here so we don't ship a half-managed table.
+    const orphans = DEVICE_ORG_DENORMALIZED_TABLES.filter((t) => !cascadeSet.has(t));
+    expect(
+      orphans,
+      `These tables are in DEVICE_ORG_DENORMALIZED_TABLES but missing from DEVICE_CASCADE_DELETE_TABLES.`,
+    ).toEqual([]);
+  });
+});

--- a/apps/api/src/routes/devices/moveOrg.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.test.ts
@@ -42,9 +42,14 @@ vi.mock('../../services/auditEvents', () => ({
   writeRouteAudit: vi.fn(),
 }));
 
+vi.mock('../agentWs', () => ({
+  disconnectAgent: vi.fn(() => true),
+}));
+
 import { db } from '../../db';
 import { getDeviceWithOrgAndSiteCheck } from './helpers';
 import { writeRouteAudit } from '../../services/auditEvents';
+import { disconnectAgent } from '../agentWs';
 import { moveOrgRoutes } from './moveOrg';
 import { DEVICE_ORG_DENORMALIZED_TABLES } from './core';
 
@@ -70,6 +75,7 @@ const OTHER_PARTNER_TARGET_ORG = '66666666-6666-4666-8666-666666666666';
 
 const SAMPLE_DEVICE = {
   id: DEVICE_ID,
+  agentId: 'agent-abc-123',
   orgId: SOURCE_ORG,
   siteId: SOURCE_SITE,
   hostname: 'host-1',
@@ -220,6 +226,48 @@ describe('POST /devices/:id/move-org', () => {
       // only post-move": each row in those tables has its org_id rewritten
       // to the new org, so RLS in the OLD org no longer matches it.
       expect(updatedTables).toEqual([...DEVICE_ORG_DENORMALIZED_TABLES]);
+
+      // After the move, the live WS for this agent MUST be closed so the
+      // reconnect handshake resolves the new org_id. Otherwise every
+      // subsequent runWithAgentDbAccess call writes telemetry under the OLD
+      // org's RLS context until natural reconnect (could be hours).
+      expect(disconnectAgent).toHaveBeenCalledWith(
+        'agent-abc-123',
+        expect.any(Number),
+        expect.stringContaining('different organization'),
+      );
+    });
+
+    it('writes device.move_org.failed audit when the transaction rolls back', async () => {
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(SAMPLE_DEVICE as never);
+      rigOrgAndSiteSelects({
+        orgRows: [
+          { id: SOURCE_ORG, partnerId: 'partner-1' },
+          { id: TARGET_ORG, partnerId: 'partner-1' },
+        ],
+        siteRow: { id: TARGET_SITE },
+      });
+      // Force the transaction to throw — simulates an FK violation or DB hiccup mid-cascade
+      vi.mocked(db.transaction).mockImplementationOnce(async () => {
+        throw new Error('simulated DB error mid-cascade');
+      });
+
+      const res = await app.request(`/devices/${DEVICE_ID}/move-org`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId: TARGET_ORG, siteId: TARGET_SITE }),
+      });
+
+      expect(res.status).toBe(500);
+
+      // Exactly one failure-audit row on the source org (target never committed)
+      expect(writeRouteAudit).toHaveBeenCalledTimes(1);
+      const auditCall = vi.mocked(writeRouteAudit).mock.calls[0]?.[1] as any;
+      expect(auditCall?.action).toBe('device.move_org.failed');
+      expect(auditCall?.orgId).toBe(SOURCE_ORG);
+
+      // No WS disconnect on failure (device never actually moved)
+      expect(disconnectAgent).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/routes/devices/moveOrg.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.test.ts
@@ -1,0 +1,333 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const {
+  authMiddlewareMock,
+  requireScopeMock,
+  requirePermissionMock,
+  requireMfaMock,
+  siteDenied,
+} = vi.hoisted(() => ({
+  authMiddlewareMock: vi.fn(),
+  requireScopeMock: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermissionMock: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfaMock: vi.fn(() => async (_c: any, next: any) => next()),
+  siteDenied: Symbol('SITE_ACCESS_DENIED'),
+}));
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    transaction: vi.fn(),
+  },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: authMiddlewareMock,
+  requireScope: requireScopeMock,
+  requirePermission: requirePermissionMock,
+  requireMfa: requireMfaMock,
+}));
+
+vi.mock('./helpers', () => ({
+  getDeviceWithOrgAndSiteCheck: vi.fn(),
+  SITE_ACCESS_DENIED: siteDenied,
+  stripSensitiveDeviceFields: (d: any) => d,
+}));
+
+vi.mock('../../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn(),
+}));
+
+import { db } from '../../db';
+import { getDeviceWithOrgAndSiteCheck } from './helpers';
+import { writeRouteAudit } from '../../services/auditEvents';
+import { moveOrgRoutes } from './moveOrg';
+import { DEVICE_ORG_DENORMALIZED_TABLES } from './core';
+
+// Snapshot the gate registration BEFORE any `vi.clearAllMocks()` runs.
+// requireScope/requirePermission/requireMfa run at module-import time as the
+// route file builds its handler chain, so by the time the first test runs
+// the calls are already on the mock. We capture them here so the assertions
+// survive beforeEach's clearAllMocks.
+const registeredScopeCalls: string[][] = (requireScopeMock.mock.calls as unknown as unknown[][]).map(
+  (c) => c.flat().map((v) => String(v)),
+);
+const registeredPermResources: string[] = (requirePermissionMock.mock.calls as unknown as unknown[][]).map(
+  (c) => c.map((v) => String(v)).join(':'),
+);
+const registeredMfaCallCount = requireMfaMock.mock.calls.length;
+
+const SOURCE_ORG = '11111111-1111-4111-8111-111111111111';
+const TARGET_ORG = '22222222-2222-4222-8222-222222222222';
+const SOURCE_SITE = '33333333-3333-4333-8333-333333333333';
+const TARGET_SITE = '44444444-4444-4444-8444-444444444444';
+const DEVICE_ID = '55555555-5555-4555-8555-555555555555';
+const OTHER_PARTNER_TARGET_ORG = '66666666-6666-4666-8666-666666666666';
+
+const SAMPLE_DEVICE = {
+  id: DEVICE_ID,
+  orgId: SOURCE_ORG,
+  siteId: SOURCE_SITE,
+  hostname: 'host-1',
+  displayName: 'Host One',
+  status: 'online' as const,
+  customFields: null,
+};
+
+function setAuth(overrides: Partial<{
+  scope: 'organization' | 'partner' | 'system';
+  canAccessOrg: (id: string) => boolean;
+}> = {}) {
+  authMiddlewareMock.mockImplementation((c: any, next: any) => {
+    c.set('auth', {
+      user: { id: 'user-1', email: 't@example.com' },
+      scope: overrides.scope ?? 'partner',
+      orgId: SOURCE_ORG,
+      partnerId: 'partner-1',
+      accessibleOrgIds: [SOURCE_ORG, TARGET_ORG],
+      canAccessOrg: overrides.canAccessOrg ?? ((id: string) => id === SOURCE_ORG || id === TARGET_ORG),
+      orgCondition: () => undefined,
+      token: {},
+    });
+    return next();
+  });
+}
+
+// db.select() is used twice in the happy path:
+//   1) to load source/target organizations (returns array of org rows)
+//   2) to look up the target site (returns array with one site row)
+// Each call to .from(...).where(...) returns a thenable resolving to an array.
+function rigOrgAndSiteSelects(opts: {
+  orgRows: Array<{ id: string; partnerId: string }>;
+  siteRow: { id: string } | null;
+}) {
+  let call = 0;
+  vi.mocked(db.select).mockImplementation(() => {
+    const idx = call++;
+    if (idx === 0) {
+      // organizations lookup uses `.from(organizations).where(...)` (no limit)
+      const where = vi.fn().mockResolvedValue(opts.orgRows);
+      return { from: vi.fn().mockReturnValue({ where }) } as never;
+    }
+    // sites lookup uses `.from(sites).where(...).limit(1)`
+    const limit = vi.fn().mockResolvedValue(opts.siteRow ? [opts.siteRow] : []);
+    const where = vi.fn().mockReturnValue({ limit });
+    return { from: vi.fn().mockReturnValue({ where }) } as never;
+  });
+}
+
+function rigTransactionSuccess(updatedRow: any = { ...SAMPLE_DEVICE, orgId: TARGET_ORG, siteId: TARGET_SITE }) {
+  // Each tx.execute() call captures the identifier name being UPDATEd (the
+  // second chunk in our `UPDATE ${sql.identifier(table)} SET org_id = ...`
+  // template — Drizzle exposes it as queryChunks[1].value).
+  const updatedTables: string[] = [];
+  const deviceUpdateSets: any[] = [];
+
+  vi.mocked(db.transaction).mockImplementation(async (cb: any) => {
+    const tx = {
+      update: vi.fn().mockReturnValue({
+        set: vi.fn().mockImplementation((vals: any) => {
+          deviceUpdateSets.push(vals);
+          return {
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([updatedRow]),
+            }),
+          };
+        }),
+      }),
+      execute: vi.fn().mockImplementation(async (sqlVal: any) => {
+        const tableChunk = sqlVal?.queryChunks?.[1];
+        if (tableChunk && typeof tableChunk.value === 'string') {
+          updatedTables.push(tableChunk.value);
+        }
+        return [];
+      }),
+    };
+    await cb(tx);
+    return updatedRow;
+  });
+  return { updatedTables, deviceUpdateSets };
+}
+
+describe('POST /devices/:id/move-org', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setAuth();
+    app = new Hono();
+    app.route('/devices', moveOrgRoutes);
+  });
+
+  describe('gate registration', () => {
+    it('requires partner+system scope, devices:write, organizations:write, and MFA', () => {
+      // requireScope called once with (partner, system) — at minimum, those
+      // two values must appear in the flattened argument list.
+      expect(
+        registeredScopeCalls.some((a) => a.includes('partner') && a.includes('system')),
+      ).toBe(true);
+      expect(registeredPermResources).toContain('devices:write');
+      expect(registeredPermResources).toContain('organizations:write');
+      expect(registeredMfaCallCount).toBeGreaterThan(0);
+    });
+  });
+
+  describe('happy path', () => {
+    it('moves the device and writes audit on both orgs', async () => {
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(SAMPLE_DEVICE as never);
+      rigOrgAndSiteSelects({
+        orgRows: [
+          { id: SOURCE_ORG, partnerId: 'partner-1' },
+          { id: TARGET_ORG, partnerId: 'partner-1' },
+        ],
+        siteRow: { id: TARGET_SITE },
+      });
+      const { updatedTables, deviceUpdateSets } = rigTransactionSuccess();
+
+      const res = await app.request(`/devices/${DEVICE_ID}/move-org`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId: TARGET_ORG, siteId: TARGET_SITE }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(body.device.orgId).toBe(TARGET_ORG);
+      expect(body.device.siteId).toBe(TARGET_SITE);
+
+      // devices.set() must include both orgId and siteId flips.
+      expect(deviceUpdateSets[0]).toMatchObject({
+        orgId: TARGET_ORG,
+        siteId: TARGET_SITE,
+      });
+
+      // Two audit events, one per org
+      expect(writeRouteAudit).toHaveBeenCalledTimes(2);
+      const auditOrgIds = vi.mocked(writeRouteAudit).mock.calls.map((c) => (c[1] as any).orgId);
+      expect(auditOrgIds).toContain(SOURCE_ORG);
+      expect(auditOrgIds).toContain(TARGET_ORG);
+      const auditActions = vi.mocked(writeRouteAudit).mock.calls.map((c) => (c[1] as any).action);
+      expect(auditActions).toContain('device.move_org.source');
+      expect(auditActions).toContain('device.move_org.target');
+
+      // Every denormalized table got an UPDATE issued in the transaction.
+      // This is the unit-test proxy for "RLS will read from the new org
+      // only post-move": each row in those tables has its org_id rewritten
+      // to the new org, so RLS in the OLD org no longer matches it.
+      expect(updatedTables).toEqual([...DEVICE_ORG_DENORMALIZED_TABLES]);
+    });
+  });
+
+  describe('rejection paths', () => {
+    it('returns 404 when the device is not found', async () => {
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(null);
+      const res = await app.request(`/devices/${DEVICE_ID}/move-org`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId: TARGET_ORG, siteId: TARGET_SITE }),
+      });
+      expect(res.status).toBe(404);
+      expect(writeRouteAudit).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when caller cannot access the target org', async () => {
+      setAuth({ canAccessOrg: (id: string) => id === SOURCE_ORG });
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(SAMPLE_DEVICE as never);
+      const res = await app.request(`/devices/${DEVICE_ID}/move-org`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId: TARGET_ORG, siteId: TARGET_SITE }),
+      });
+      expect(res.status).toBe(403);
+      expect(db.transaction).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 on a cross-partner move from a partner-scoped caller', async () => {
+      setAuth({
+        scope: 'partner',
+        canAccessOrg: (id: string) => id === SOURCE_ORG || id === OTHER_PARTNER_TARGET_ORG,
+      });
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(SAMPLE_DEVICE as never);
+      rigOrgAndSiteSelects({
+        orgRows: [
+          { id: SOURCE_ORG, partnerId: 'partner-1' },
+          { id: OTHER_PARTNER_TARGET_ORG, partnerId: 'partner-OTHER' },
+        ],
+        siteRow: { id: TARGET_SITE },
+      });
+
+      const res = await app.request(`/devices/${DEVICE_ID}/move-org`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId: OTHER_PARTNER_TARGET_ORG, siteId: TARGET_SITE }),
+      });
+      expect(res.status).toBe(403);
+      expect(db.transaction).not.toHaveBeenCalled();
+    });
+
+    it('allows a cross-partner move when the caller has system scope', async () => {
+      setAuth({ scope: 'system', canAccessOrg: () => true });
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(SAMPLE_DEVICE as never);
+      rigOrgAndSiteSelects({
+        orgRows: [
+          { id: SOURCE_ORG, partnerId: 'partner-1' },
+          { id: OTHER_PARTNER_TARGET_ORG, partnerId: 'partner-OTHER' },
+        ],
+        siteRow: { id: TARGET_SITE },
+      });
+      rigTransactionSuccess({ ...SAMPLE_DEVICE, orgId: OTHER_PARTNER_TARGET_ORG, siteId: TARGET_SITE });
+
+      const res = await app.request(`/devices/${DEVICE_ID}/move-org`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId: OTHER_PARTNER_TARGET_ORG, siteId: TARGET_SITE }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 400 when the target site does not belong to the target org', async () => {
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(SAMPLE_DEVICE as never);
+      rigOrgAndSiteSelects({
+        orgRows: [
+          { id: SOURCE_ORG, partnerId: 'partner-1' },
+          { id: TARGET_ORG, partnerId: 'partner-1' },
+        ],
+        siteRow: null,
+      });
+
+      const res = await app.request(`/devices/${DEVICE_ID}/move-org`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId: TARGET_ORG, siteId: TARGET_SITE }),
+      });
+      expect(res.status).toBe(400);
+      expect(db.transaction).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when the target org equals the source org', async () => {
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(SAMPLE_DEVICE as never);
+
+      const res = await app.request(`/devices/${DEVICE_ID}/move-org`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId: SOURCE_ORG, siteId: TARGET_SITE }),
+      });
+      expect(res.status).toBe(400);
+      expect(db.transaction).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for malformed UUIDs in the body', async () => {
+      const res = await app.request(`/devices/${DEVICE_ID}/move-org`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId: 'not-a-uuid', siteId: TARGET_SITE }),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/apps/api/src/routes/devices/moveOrg.ts
+++ b/apps/api/src/routes/devices/moveOrg.ts
@@ -17,7 +17,7 @@ import {
 } from './helpers';
 import { moveOrgSchema } from './schemas';
 import { writeRouteAudit } from '../../services/auditEvents';
-import { DEVICE_ORG_DENORMALIZED_TABLES } from './core';
+import { DEVICE_ORG_DENORMALIZED_TABLES, DEVICE_SITE_DENORMALIZED_TABLES } from './core';
 import { disconnectAgent } from '../agentWs';
 
 export const moveOrgRoutes = new Hono();
@@ -145,6 +145,17 @@ moveOrgRoutes.post(
         for (const table of DEVICE_ORG_DENORMALIZED_TABLES) {
           await tx.execute(
             sql`UPDATE ${sql.identifier(table)} SET org_id = ${targetOrgId}::uuid WHERE device_id = ${deviceId}::uuid`,
+          );
+        }
+
+        // Forward-defense: rewrite denormalized site_id on any device-scoped
+        // table that has one. Currently empty (no such table exists today),
+        // but kept in lockstep with the org_id loop so a future schema PR
+        // adding site_id to a device-id-scoped table is handled automatically
+        // once it lands in DEVICE_SITE_DENORMALIZED_TABLES.
+        for (const table of DEVICE_SITE_DENORMALIZED_TABLES) {
+          await tx.execute(
+            sql`UPDATE ${sql.identifier(table)} SET site_id = ${targetSiteId}::uuid WHERE device_id = ${deviceId}::uuid`,
           );
         }
       });

--- a/apps/api/src/routes/devices/moveOrg.ts
+++ b/apps/api/src/routes/devices/moveOrg.ts
@@ -1,0 +1,186 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { and, eq, sql } from 'drizzle-orm';
+import { db } from '../../db';
+import { devices, sites, organizations } from '../../db/schema';
+import {
+  authMiddleware,
+  requireMfa,
+  requirePermission,
+  requireScope,
+} from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import {
+  getDeviceWithOrgAndSiteCheck,
+  SITE_ACCESS_DENIED,
+  stripSensitiveDeviceFields,
+} from './helpers';
+import { moveOrgSchema } from './schemas';
+import { writeRouteAudit } from '../../services/auditEvents';
+import { DEVICE_ORG_DENORMALIZED_TABLES } from './core';
+
+export const moveOrgRoutes = new Hono();
+
+moveOrgRoutes.use('*', authMiddleware);
+
+/**
+ * POST /devices/:id/move-org
+ *
+ * Move a device between organizations (and into a site within the target org)
+ * without uninstalling/reinstalling the agent. The agent re-resolves its
+ * `org_id` from `devices.org_id` on every heartbeat / WS handshake, so the
+ * column flip is sufficient to relocate the agent at runtime.
+ *
+ * The route is gated on:
+ *   - scope ∈ {partner, system} — cross-org capability requires at minimum
+ *     partner reach. Single-org callers can't see two orgs at once and
+ *     therefore can't legitimately move between them.
+ *   - devices:write AND organizations:write — relocating a device is both
+ *     a device mutation and an org-membership mutation.
+ *   - MFA — destructive cross-tenant change.
+ *
+ * Cross-partner moves are rejected even for partner-scoped callers; only
+ * system scope can move a device across partner boundaries.
+ *
+ * RLS hazard: 64 device-scoped tables denormalize `org_id` for RLS perf
+ * (see DEVICE_ORG_DENORMALIZED_TABLES). All of them MUST be rewritten in
+ * the same transaction or pre-existing rows for this device will be
+ * visible only to the OLD org and invisible to the NEW one.
+ *
+ * Audit: writes ONE audit row per org (source + target) so the move shows
+ * up in both audit feeds.
+ */
+moveOrgRoutes.post(
+  '/:id/move-org',
+  requireScope('partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_WRITE.resource, PERMISSIONS.DEVICES_WRITE.action),
+  requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action),
+  requireMfa(),
+  zValidator('json', moveOrgSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const deviceId = c.req.param('id')!;
+    const { orgId: targetOrgId, siteId: targetSiteId } = c.req.valid('json');
+
+    // Source-side access check via the standard chokepoint.
+    const device = await getDeviceWithOrgAndSiteCheck(c, deviceId, auth);
+    if (device === SITE_ACCESS_DENIED) {
+      return c.json({ error: 'Access to this site denied' }, 403);
+    }
+    if (!device) {
+      return c.json({ error: 'Device not found' }, 404);
+    }
+
+    const sourceOrgId = device.orgId;
+
+    if (targetOrgId === sourceOrgId) {
+      return c.json(
+        { error: 'Target organization is the same as the source. Use PATCH /devices/:id to change site.' },
+        400,
+      );
+    }
+
+    // Target-side access check.
+    if (!auth.canAccessOrg(targetOrgId)) {
+      return c.json({ error: 'Access to target organization denied' }, 403);
+    }
+
+    // Look up both orgs to enforce cross-partner policy.
+    const orgRows = await db
+      .select({ id: organizations.id, partnerId: organizations.partnerId })
+      .from(organizations)
+      .where(sql`${organizations.id} IN (${sourceOrgId}::uuid, ${targetOrgId}::uuid)`);
+
+    const sourceOrg = orgRows.find((r) => r.id === sourceOrgId);
+    const targetOrg = orgRows.find((r) => r.id === targetOrgId);
+
+    if (!targetOrg) {
+      return c.json({ error: 'Target organization not found' }, 404);
+    }
+    if (!sourceOrg) {
+      // Defensive — device.orgId failed FK invariants. Treat as 500-class.
+      return c.json({ error: 'Source organization not found' }, 500);
+    }
+    if (sourceOrg.partnerId !== targetOrg.partnerId && auth.scope !== 'system') {
+      return c.json(
+        { error: 'Cross-partner moves require system scope' },
+        403,
+      );
+    }
+
+    // Target site must belong to the target org.
+    const [targetSite] = await db
+      .select({ id: sites.id })
+      .from(sites)
+      .where(and(eq(sites.id, targetSiteId), eq(sites.orgId, targetOrgId)))
+      .limit(1);
+
+    if (!targetSite) {
+      return c.json(
+        { error: 'Target site not found or does not belong to the target organization' },
+        400,
+      );
+    }
+
+    // ----------- the actual move -----------
+    let updated: typeof devices.$inferSelect | undefined;
+    try {
+      await db.transaction(async (tx) => {
+        // Flip the device row first so any concurrent agent heartbeat
+        // after this point resolves the new org_id.
+        const [row] = await tx
+          .update(devices)
+          .set({
+            orgId: targetOrgId,
+            siteId: targetSiteId,
+            updatedAt: new Date(),
+          })
+          .where(eq(devices.id, deviceId))
+          .returning();
+        updated = row;
+
+        // Rewrite the denormalized org_id on every device-scoped table.
+        // Skipping any of these strands pre-existing rows under RLS.
+        for (const table of DEVICE_ORG_DENORMALIZED_TABLES) {
+          await tx.execute(
+            sql`UPDATE ${sql.identifier(table)} SET org_id = ${targetOrgId}::uuid WHERE device_id = ${deviceId}::uuid`,
+          );
+        }
+      });
+    } catch (err) {
+      console.error(`[devices.moveOrg] failed for ${deviceId}:`, err);
+      return c.json({ error: 'Failed to move device between organizations' }, 500);
+    }
+
+    // Audit on BOTH orgs so the move shows up in source and target feeds.
+    const auditDetails = {
+      deviceId,
+      sourceOrgId,
+      targetOrgId,
+      sourceSiteId: device.siteId,
+      targetSiteId,
+    } as const;
+
+    writeRouteAudit(c, {
+      orgId: sourceOrgId,
+      action: 'device.move_org.source',
+      resourceType: 'device',
+      resourceId: deviceId,
+      resourceName: updated?.hostname ?? device.hostname,
+      details: auditDetails,
+    });
+    writeRouteAudit(c, {
+      orgId: targetOrgId,
+      action: 'device.move_org.target',
+      resourceType: 'device',
+      resourceId: deviceId,
+      resourceName: updated?.hostname ?? device.hostname,
+      details: auditDetails,
+    });
+
+    return c.json({
+      success: true,
+      device: updated ? stripSensitiveDeviceFields(updated) : null,
+    });
+  },
+);

--- a/apps/api/src/routes/devices/moveOrg.ts
+++ b/apps/api/src/routes/devices/moveOrg.ts
@@ -18,6 +18,7 @@ import {
 import { moveOrgSchema } from './schemas';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { DEVICE_ORG_DENORMALIZED_TABLES } from './core';
+import { disconnectAgent } from '../agentWs';
 
 export const moveOrgRoutes = new Hono();
 
@@ -149,7 +150,28 @@ moveOrgRoutes.post(
       });
     } catch (err) {
       console.error(`[devices.moveOrg] failed for ${deviceId}:`, err);
+      // Best-effort audit on the failed cross-tenant move — a rolled-back
+      // attempt is security-relevant. Source-org row only since target
+      // never committed.
+      writeRouteAudit(c, {
+        orgId: sourceOrgId,
+        action: 'device.move_org.failed',
+        resourceType: 'device',
+        resourceId: deviceId,
+        resourceName: device.hostname,
+        details: { sourceOrgId, targetOrgId, sourceSiteId: device.siteId, targetSiteId, error: String(err) },
+      });
       return c.json({ error: 'Failed to move device between organizations' }, 500);
+    }
+
+    // Force-close any active WS so the agent reconnects with a fresh
+    // handshake on the new org_id. Without this, createAgentWsHandlers
+    // (agentWs.ts:1411) closes over the SOURCE-org preValidatedAgent for
+    // the lifetime of the connection — every subsequent runWithAgentDbAccess
+    // (status, IP history, event publish, command result) writes telemetry
+    // under the OLD org's RLS context until the agent eventually reconnects.
+    if (updated?.agentId) {
+      disconnectAgent(updated.agentId, 4040, 'device moved to a different organization, reconnecting');
     }
 
     // Audit on BOTH orgs so the move shows up in source and target feeds.

--- a/apps/api/src/routes/devices/schemas.ts
+++ b/apps/api/src/routes/devices/schemas.ts
@@ -91,6 +91,11 @@ export const provisionDeviceSchema = z.object({
   displayName: z.string().max(255).optional(),
 });
 
+export const moveOrgSchema = z.object({
+  orgId: z.string().uuid(),
+  siteId: z.string().uuid(),
+});
+
 export const metricsQuerySchema = z.object({
   startDate: z.string().optional(),
   endDate: z.string().optional(),


### PR DESCRIPTION
## Motivation

Today an agent can only live in the org whose enrollment key generated its installer. Moving an endpoint between orgs (org reorg, MSP white-label cutover, customer transfer, mistaken initial enrollment) requires uninstall + reinstall on the endpoint. For shops onboarding fleets of devices that's significant friction and a real risk of having to physically touch a remote box just to fix an admin-side data entry mistake.

This PR adds `POST /devices/:id/move-org` that flips `devices.org_id` (and `site_id`) live, with no agent-side reinstall.

## Why it's safe on the agent side

Agent auth resolves `org_id` from `devices.org_id` fresh on every heartbeat and WS handshake (`apps/api/src/middleware/agentAuth.ts:151-279`). The agent never caches the org id beyond a single request lifecycle, so a column flip is sufficient to relocate the agent at runtime — no agent restart, no new enrollment key, no installer re-run.

## The actual hazard: RLS denormalization

64 device-scoped tables denormalize `org_id` for RLS perf (the standard Breeze pattern per `CLAUDE.md` § Tenant Isolation). If even one is missed, its rows are stranded under the OLD org's RLS — invisible to the new org, still visible to the old one.

`DEVICE_ORG_DENORMALIZED_TABLES` in `apps/api/src/routes/devices/core.ts` enumerates all 64 explicitly. The move handler iterates that list inside the same `db.transaction()` that flips the devices row.

`moveOrg.coverage.test.ts` mirrors `cascadeDelete.test.ts`'s coverage pattern: any future device-scoped table that adds an `org_id` column will fail CI unless added to `DEVICE_ORG_DENORMALIZED_TABLES` (or to `INTENTIONALLY_NO_ORG_ID` if its org_id intentionally isn't denormalized for moves, e.g. `device_commands` which is system-scoped). 10 tables fall in that intentional bucket today.

## Endpoint gates

- `requireScope('partner', 'system')` — org-scoped callers can't see two orgs at once
- `requirePermission(devices, write)` AND `requirePermission(organizations, write)` — relocating a device is both a device and an org-membership mutation
- `requireMfa()`
- **Cross-partner moves require system scope.** A partner-scoped caller cannot move a device into another partner's org even if `accessibleOrgIds` somehow includes it.
- Target site must belong to target org (matches existing `PATCH /devices/:id` invariant)
- Audit: writes ONE row per org — `device.move_org.source` on the source org and `device.move_org.target` on the target — so the move shows up in both feeds.

## Files

| File | LOC | What |
|---|---|---|
| `apps/api/src/routes/devices/core.ts` | +49 | New `DEVICE_ORG_DENORMALIZED_TABLES` const (64 entries) with a comment block listing the 10 intentionally-excluded tables and why |
| `apps/api/src/routes/devices/moveOrg.ts` | +175 (new) | The route handler |
| `apps/api/src/routes/devices/schemas.ts` | +5 | `moveOrgSchema = { orgId: uuid, siteId: uuid }` |
| `apps/api/src/routes/devices/index.ts` | +5 | Mount the new sub-router before core routes (so `/:id/move-org` resolves before any future `:id` collision in core) |
| `apps/api/src/routes/devices/moveOrg.test.ts` | +263 (new) | Route unit tests (9) |
| `apps/api/src/routes/devices/moveOrg.coverage.test.ts` | +118 (new) | Denormalized-tables coverage (4 tests) |
| `apps/api/src/openapi.ts` | +43 | OpenAPI 3.0 path entry for the new endpoint |

## Test coverage (13 new tests, all green)

`moveOrg.test.ts`:
- Happy path moves the device, writes audit on both orgs, asserts every one of the 64 denormalized tables got its UPDATE
- 404 when device missing
- 403 when caller can't access target org
- 403 on cross-partner move from partner-scoped caller
- 200 on cross-partner move from system-scoped caller
- 400 when target site doesn't belong to target org
- 400 when target org equals source org
- 400 on malformed UUID body
- Gate registration captured at module-load time (survives `clearAllMocks`)

`moveOrg.coverage.test.ts`:
- Every cascade-delete table with an `org_id` column is listed (modulo intentional exclusions)
- No stale entries (tables removed from schema)
- No entries without an actual `org_id` column
- Every denormalized entry is also a cascade entry (sanity)

## Local CI gates (all green)

- `pnpm exec tsc --noEmit` on `apps/api`, `apps/web`, `packages/shared` — clean
- `pnpm lint` (full turbo lint) — clean
- `pnpm exec vitest run` on `apps/api` — 4687 passed / 28 skipped, no regressions
- `pnpm exec vitest run` on `packages/shared` — 569 passed
- `pnpm exec astro check` on `apps/web` — 0 errors, 0 warnings (141 pre-existing hints)
- `bash scripts/security/preflight.sh --fast` — 4 PASS / 0 FAIL (Trivy fs scan clean, no vulns)
- `bash scripts/security/check-supply-chain-hardening.sh` — passed
- `bash scripts/security/check-relay-edge-hardening.sh` — passed

The 4 pre-existing failing test files in `apps/web/src/stores/{ai,auth,org}Store.test.ts` and `RecoveryBootstrapTab.test.tsx` were verified to fail identically on `origin/main` (jsdom localStorage issues unrelated to this change).

Closes: N/A