### PR TITLE
fix(agent/backup): close mtime race in TestRunBackup_WithRetention

### DIFF
--- a/agent/internal/backup/backup_test.go
+++ b/agent/internal/backup/backup_test.go
@@ -480,10 +480,22 @@ func TestRunBackup_WithRetention(t *testing.T) {
 	// Run backup twice, modifying the file between runs to ensure the
 	// incremental cutoff doesn't skip it.
 	for i := 0; i < 2; i++ {
+		// Sleep BEFORE the second write so the file's mtime is strictly after
+		// the prior snapshot.Timestamp. The 10ms post-write sleep below is not
+		// enough on its own: snapshot.Timestamp is set inside
+		// CreateSnapshotContext (snapshot.go) before the mock provider upload,
+		// so on a fast runner iter 2's WriteFile can land within the same
+		// filesystem-mtime tick as iter 1's snapshot timestamp, causing the
+		// incremental cutoff to skip the file (observed on GitHub Actions
+		// Linux runners, e.g. https://github.com/LanternOps/breeze/pull/890).
+		if i > 0 {
+			time.Sleep(100 * time.Millisecond)
+		}
 		if err := os.WriteFile(filePath, []byte(fmt.Sprintf("retention test run %d", i)), 0644); err != nil {
 			t.Fatalf("failed to write file for run %d: %v", i+1, err)
 		}
-		// Ensure modTime is after lastSnapshotTime
+		// Belt-and-suspenders: also wait after the write so the cutoff (set
+		// during this RunBackup) is comfortably after the file mtime.
 		time.Sleep(10 * time.Millisecond)
 
 		job, err := mgr.RunBackup()


### PR DESCRIPTION
## Why

`TestRunBackup_WithRetention` is flaky on CI runners. Most recent hit:
[Test Agent run 26416137750 on PR #890](https://github.com/LanternOps/breeze/actions/runs/26416137750/job/77760906193) —

```
backup_test.go:494: RunBackup #2 status = "skipped", want "completed"
```

The 2nd backup decides there are no eligible files because the file's mtime is not strictly after the prior `snapshot.Timestamp`. The cutoff filter is `modTime.After(cutoff)` in `shouldIncludeFile` (`backup.go:461`).

`snapshot.Timestamp` is set as `time.Now().UTC()` inside `CreateSnapshotContext` (`snapshot.go:65`) BEFORE the mock provider upload. On a fast runner, iter 1's snapshot timestamp + mock upload + return + iter 2's `WriteFile` can all land within the same filesystem-mtime tick, so the file's mtime equals (or rounds equal to) the cutoff and gets filtered out.

The pre-existing `time.Sleep(10ms)` is BETWEEN `WriteFile` and `RunBackup` — that doesn't change the mtime of the file already written, so it didn't address the actual race.

## What

- Sleep 100ms BEFORE iter 2's `WriteFile` so the new mtime is strictly after the prior `snapshot.Timestamp`.
- Keep the original 10ms post-write sleep as belt-and-suspenders.
- Comment explains the race and links to the failing CI run.

No production code changes. Adds ~100ms wall-clock per test run.

## Local CI

- `go test ./internal/backup/ -count=100 -race` → 100/100 pass, 46s
- `go vet ./internal/backup/` → clean
- `govulncheck ./internal/backup/...` → 0 vulnerabilities affecting code

## Test plan
- [ ] CI green on this PR
- [ ] Re-run #890's Test Agent (or wait for next Dependabot PR) — should no longer flake on this test