### PR TITLE
fix(agent/mgmtdetect): fall back to registry when dsregcmd fails on DCs

### DIFF
--- a/agent/internal/mgmtdetect/deep_identity_windows.go
+++ b/agent/internal/mgmtdetect/deep_identity_windows.go
@@ -17,7 +17,7 @@ func collectIdentityStatus() IdentityStatus {
 	cmd := exec.CommandContext(ctx, "dsregcmd", "/status")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Warn("dsregcmd failed, falling back to registry", "error", err)
+		log.Warn("dsregcmd failed, falling back to registry", "error", err.Error())
 		fb := collectIdentityStatusFromRegistry()
 		// Tag the source so the UI shows the real reason, not just "dsregcmd_error"
 		if fb.JoinType == JoinTypeNone {
@@ -55,7 +55,7 @@ func collectIdentityStatusFromRegistry() IdentityStatus {
 		`SYSTEM\CurrentControlSet\Services\Tcpip\Parameters`,
 		registry.READ)
 	if err != nil {
-		log.Warn("registry identity fallback: failed to open Tcpip\\Parameters", "error", err)
+		log.Warn("registry identity fallback: failed to open Tcpip\\Parameters", "error", err.Error())
 		id.JoinType = JoinTypeNone
 		return id
 	}

--- a/agent/internal/mgmtdetect/deep_identity_windows.go
+++ b/agent/internal/mgmtdetect/deep_identity_windows.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"os/exec"
 	"time"
+
+	"golang.org/x/sys/windows/registry"
 )
 
 func collectIdentityStatus() IdentityStatus {
@@ -15,8 +17,55 @@ func collectIdentityStatus() IdentityStatus {
 	cmd := exec.CommandContext(ctx, "dsregcmd", "/status")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Warn("dsregcmd failed", "error", err)
-		return IdentityStatus{JoinType: JoinTypeNone, Source: "dsregcmd_error"}
+		log.Warn("dsregcmd failed, falling back to registry", "error", err)
+		fb := collectIdentityStatusFromRegistry()
+		// Tag the source so the UI shows the real reason, not just "dsregcmd_error"
+		if fb.JoinType == JoinTypeNone {
+			fb.Source = "dsregcmd_error_no_fallback"
+		}
+		return fb
 	}
-	return parseDsregcmdOutput(string(output))
+
+	id := parseDsregcmdOutput(string(output))
+	// dsregcmd is the source of truth when it runs. But it has been observed
+	// to mis-report on some Server 2016 DCs (return success with no JoinInfo).
+	// As a sanity check, if it reports no join at all, try the registry; if
+	// the registry knows about classic AD membership, trust that.
+	if id.JoinType == JoinTypeNone {
+		fb := collectIdentityStatusFromRegistry()
+		if fb.JoinType != JoinTypeNone {
+			fb.Source = "registry_fallback_after_dsregcmd_none"
+			return fb
+		}
+	}
+	return id
+}
+
+// collectIdentityStatusFromRegistry reads canonical Win32 registry locations
+// for classic AD domain membership. Used when dsregcmd is unavailable, errors,
+// or returns no join info.
+//
+// Detects classic on-prem AD via HKLM\SYSTEM\...\Tcpip\Parameters\Domain.
+// (Azure AD via HKLM\...\CloudDomainJoin\JoinInfo could be added later if
+// needed; the dsregcmd path remains primary for Azure AD detection.)
+func collectIdentityStatusFromRegistry() IdentityStatus {
+	id := IdentityStatus{Source: "registry"}
+
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE,
+		`SYSTEM\CurrentControlSet\Services\Tcpip\Parameters`,
+		registry.READ)
+	if err != nil {
+		log.Warn("registry identity fallback: failed to open Tcpip\\Parameters", "error", err)
+		id.JoinType = JoinTypeNone
+		return id
+	}
+	defer k.Close()
+
+	if domain, _, derr := k.GetStringValue("Domain"); derr == nil && domain != "" {
+		id.DomainJoined = true
+		id.DomainName = domain
+	}
+
+	id.JoinType = deriveJoinType(id)
+	return id
 }


### PR DESCRIPTION
## Why

Real bug observed on `ARL-DC-01` (Windows Server 2016, Domain Controller for its on-prem AD domain): the Device Management tab shows **"Not Joined"** with `Detection source: dsregcmd_error`. The machine IS the domain — it's literally the DC — so reporting workgroup is wrong.

Root cause: `agent/internal/mgmtdetect/deep_identity_windows.go` used `dsregcmd /status` as the **sole** source of join status. When `dsregcmd` returned a non-zero exit code (observed on some Server 2016 DCs), the agent returned `{JoinType: none, Source: "dsregcmd_error"}` with **no fallback**.

## What

Fall back to the canonical Win32 registry value when dsregcmd either fails OR succeeds with no join info:

```
HKLM\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Domain (REG_SZ)
```

Non-empty → `DomainJoined=true`, `DomainName=<value>`, `JoinType=on_prem_ad`.

The `Source` field is now informative about which path ran:

| Source | Meaning |
|---|---|
| `dsregcmd` | Primary, unchanged |
| `registry_fallback_after_dsregcmd_none` | dsregcmd OK but reported no join — registry found classic AD |
| `registry` | dsregcmd errored, registry fallback succeeded |
| `dsregcmd_error_no_fallback` | dsregcmd errored AND registry also showed no domain (genuinely workgroup or detection blocked) |

Currently classic on-prem AD only. Azure AD / Hybrid via the equivalent `HKLM\...\CloudDomainJoin\JoinInfo` path could be added later; dsregcmd remains the primary detector for those.

## Local CI

- `GOOS=windows GOARCH=amd64 go build ./internal/mgmtdetect/` → clean
- `GOOS=windows GOARCH=amd64 go vet ./internal/mgmtdetect/` → clean
- No new dependencies (`golang.org/x/sys/windows/registry` already in use elsewhere in this package — see `deep_policy_windows.go`)

## Test plan
- [ ] CI green
- [ ] Deploy to one Server 2016 DC (ARL-DC-01) — Management tab should show "Domain Joined" with `Source: registry` (since dsregcmd errors there)
- [ ] Deploy to a workstation that previously showed `dsregcmd` source — should still show `dsregcmd` source with no change