### PR TITLE
fix(agents/enroll): allow re-enrollment without prior token when existing row is decommissioned

### DIFF
--- a/apps/api/src/routes/agents/enrollment.test.ts
+++ b/apps/api/src/routes/agents/enrollment.test.ts
@@ -527,6 +527,86 @@ describe('POST /agents/enroll — 401 reason disambiguation', () => {
     const body = await resp.json();
     expect(body.reason).toBe('hostname_collision_requires_existing_device_token');
   });
+
+  it('denies re-enrollment when the existing row is decommissioned AND its token was probe-suspended', async () => {
+    // Suspension trumps decommission. Task 18 added auto-suspend-on-probe
+    // (commit 2669ea43); the maintainer's explicit intent is that
+    // unsuspending be manual — "the reconnect-loop on a single device is the
+    // desired ops alarm signal." An admin DELETE of a probe-suspended device
+    // must NOT auto-restore the slot. The operator has to clear
+    // agent_token_suspended_at deliberately first, which leaves an audit
+    // trail of the "yes, I cleared a security suspension" decision.
+    //
+    // Real-world sequence A: probe-storm suspended the token at t=0, ops
+    // alarm fired (reconnect-loop), admin investigated, decided the box was
+    // compromised/abandoned, and decommissioned it. Without this gate, the
+    // hostname could silently re-enroll with fresh tokens after the
+    // suspension alarm fired — defeating the security signal.
+    mockKeyLookup({
+      id: 'key-suspended-decom',
+      orgId: 'org-suspended-decom',
+      siteId: 'site-suspended-decom',
+      keySecretHash: null,
+      expiresAt: new Date(Date.now() + 3600_000),
+      maxUsage: 10,
+      usageCount: 0,
+    });
+
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn().mockResolvedValue([{
+            id: 'key-suspended-decom',
+            orgId: 'org-suspended-decom',
+            siteId: 'site-suspended-decom',
+          }]),
+        })),
+      })),
+    } as any);
+
+    mockSelectRows([{ partnerId: 'partner-suspended-decom' }]);
+    mockSelectRows([{ maxDevices: null }]);
+    // Existing row: DECOMMISSIONED AND token-suspended.
+    mockSelectRows([{
+      id: 'device-suspended-decom',
+      status: 'decommissioned',
+      agentTokenHash: 'old-suspended-hash',
+      previousTokenHash: null,
+      previousTokenExpiresAt: null,
+      agentTokenSuspendedAt: new Date('2026-05-25T12:00:00Z'),
+    }]);
+
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody),
+    });
+
+    expect(resp.status).toBe(409);
+    const body = (await resp.json()) as Record<string, unknown>;
+    expect(body.reason).toBe('existing_decommissioned_row_has_suspended_token');
+    // Audit row was written denying the attempt — not silently allowed.
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'agent.enroll',
+        resourceId: 'device-suspended-decom',
+        result: 'denied',
+        details: expect.objectContaining({
+          reason: 'existing_decommissioned_row_has_suspended_token',
+        }),
+      })
+    );
+    // NOT the decom-bypass success audit
+    expect(writeAuditEvent).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        details: expect.objectContaining({
+          reason: 'decommissioned_row_reenrolled',
+        }),
+      })
+    );
+  });
 });
 
 describe('POST /agents/enroll — ENROLLMENT_SECRET_ENFORCEMENT_MODE', () => {

--- a/apps/api/src/routes/agents/enrollment.test.ts
+++ b/apps/api/src/routes/agents/enrollment.test.ts
@@ -465,6 +465,67 @@ describe('POST /agents/enroll — 401 reason disambiguation', () => {
         }),
       })
     );
+    // AND: an audit row was written for the admin-approved replacement bypass
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'agent.enroll',
+        resourceId: 'device-decom-existing',
+        result: 'success',
+        details: expect.objectContaining({
+          reason: 'decommissioned_row_reenrolled',
+          priorDeviceId: 'device-decom-existing',
+        }),
+      })
+    );
+  });
+
+  it('regression: status=offline (not decommissioned) still 409s without an existing-device token', async () => {
+    // Defense against future refactors that might widen the decommissioned
+    // bypass — make sure 'offline' rows continue to require the prior token.
+    mockKeyLookup({
+      id: 'key-offline',
+      orgId: 'org-offline',
+      siteId: 'site-offline',
+      keySecretHash: null,
+      expiresAt: new Date(Date.now() + 3600_000),
+      maxUsage: 10,
+      usageCount: 0,
+    });
+
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn().mockResolvedValue([{
+            id: 'key-offline',
+            orgId: 'org-offline',
+            siteId: 'site-offline',
+          }]),
+        })),
+      })),
+    } as any);
+
+    mockSelectRows([{ partnerId: 'partner-offline' }]);
+    mockSelectRows([{ maxDevices: null }]);
+    // Existing row is OFFLINE (the normal "device hasn't checked in" state),
+    // NOT decommissioned — no token attached to request.
+    mockSelectRows([{
+      id: 'device-offline-existing',
+      status: 'offline',
+      agentTokenHash: 'old-offline-hash',
+      previousTokenHash: null,
+      previousTokenExpiresAt: null,
+    }]);
+
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody),
+    });
+
+    expect(resp.status).toBe(409);
+    const body = await resp.json();
+    expect(body.reason).toBe('hostname_collision_requires_existing_device_token');
   });
 });
 

--- a/apps/api/src/routes/agents/enrollment.test.ts
+++ b/apps/api/src/routes/agents/enrollment.test.ts
@@ -362,6 +362,110 @@ describe('POST /agents/enroll — 401 reason disambiguation', () => {
     const body = await resp.json();
     expect(body.reason).toBe('hostname_collision_requires_existing_device_token');
   });
+
+  it('allows re-enrollment without the existing-device token when the existing row is decommissioned', async () => {
+    // Real-world scenario (Trevor-Legion, 2026-05-25):
+    // 1. Admin calls DELETE /api/v1/devices/<id> — soft-deletes, status=decommissioned
+    // 2. Operator uninstalls Breeze on the endpoint and re-runs the installer
+    // 3. Fresh agent has no prior token; re-enrolls
+    // Pre-fix: hostname-collision check returned 409 even for decommissioned
+    // rows, leaving the host permanently un-enrollable without a hand-rename
+    // in SQL. Post-fix: decommissioned rows are treated as authenticated for
+    // re-enrollment, and the existing row is restored/updated in-place so
+    // history (agent_logs etc.) survives.
+    mockKeyLookup({
+      id: 'key-decom',
+      orgId: 'org-decom',
+      siteId: 'site-decom',
+      keySecretHash: null,
+      expiresAt: new Date(Date.now() + 3600_000),
+      maxUsage: 10,
+      usageCount: 0,
+    });
+
+    // Claim the enrollment key
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn().mockResolvedValue([{
+            id: 'key-decom',
+            orgId: 'org-decom',
+            siteId: 'site-decom',
+          }]),
+        })),
+      })),
+    } as any);
+
+    mockSelectRows([{ partnerId: 'partner-decom' }]);
+    mockSelectRows([{ maxDevices: null }]);
+    // Existing row is DECOMMISSIONED — no token attached to the request
+    mockSelectRows([{
+      id: 'device-decom-existing',
+      status: 'decommissioned',
+      agentTokenHash: 'old-decom-hash',
+      previousTokenHash: null,
+      previousTokenExpiresAt: null,
+    }]);
+
+    // Auto-restore: db.update flipping status decommissioned -> offline
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: vi.fn(() => ({
+        where: vi.fn().mockResolvedValue(undefined),
+      })),
+    } as any);
+
+    // Transaction: device is existing, so the inner branch is tx.update().returning()
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
+      const fakeTx = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 0 }]),
+          }),
+        }),
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{
+                id: 'device-decom-existing',
+                orgId: 'org-decom',
+                siteId: 'site-decom',
+                hostname: 'host-1',
+              }]),
+            }),
+          }),
+        }),
+        insert: vi.fn().mockReturnValue({
+          values: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([]),
+            onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+          }),
+        }),
+        delete: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      };
+      return fn(fakeTx);
+    });
+
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody),
+    });
+
+    expect(resp.status).toBe(201);
+    const body = (await resp.json()) as Record<string, unknown>;
+    expect(body.deviceId).toBe('device-decom-existing');
+    // Importantly: no 409 audit event was written for hostname_collision
+    expect(writeAuditEvent).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        details: expect.objectContaining({
+          reason: 'hostname_collision_requires_existing_device_token',
+        }),
+      })
+    );
+  });
 });
 
 describe('POST /agents/enroll — ENROLLMENT_SECRET_ENFORCEMENT_MODE', () => {

--- a/apps/api/src/routes/agents/enrollment.ts
+++ b/apps/api/src/routes/agents/enrollment.ts
@@ -377,17 +377,48 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
 
     let existingDeviceAuthenticated = false;
     if (existingDevice) {
-      const now = new Date();
-      const existingDeviceToken = getProvidedExistingDeviceToken(c);
-      // Task 18: a suspended token cannot be used to re-authenticate an
-      // existing-device collision and silently rotate to a new token.
       const tokenSuspended = !!existingDevice.agentTokenSuspendedAt;
-      existingDeviceAuthenticated =
-        !tokenSuspended &&
-        (tokenHashMatches(existingDevice.agentTokenHash, existingDeviceToken, now) ||
-          tokenHashMatches(existingDevice.previousTokenHash, existingDeviceToken, now, existingDevice.previousTokenExpiresAt));
+
+      if (tokenSuspended) {
+        // Suspension trumps decommission. Task 18 added a suspend-on-probe
+        // mechanism; the maintainer's explicit intent (commit 2669ea43) is
+        // that unsuspending is manual — "the reconnect-loop on a single
+        // device is the desired ops alarm signal." An admin DELETE of a
+        // probe-suspended device must NOT silently auto-restore the slot:
+        // the operator has to clear `agent_token_suspended_at` deliberately
+        // (SQL or future admin endpoint), which leaves an audit trail of
+        // the "yes, I cleared a security suspension" decision. Without
+        // this, the decom-bypass below would let the same hostname re-
+        // enroll with fresh tokens after the suspend alarm fired.
+        existingDeviceAuthenticated = false;
+      } else if (existingDevice.status === 'decommissioned') {
+        // Decommission-bypass: admin explicitly DELETE'd the device. The
+        // prior agent's tokens are irrelevant; the slot is freed for fresh
+        // enrollment. The auto-restore block below flips status back to
+        // 'online' and the transaction below re-uses the existing device
+        // id so audit history (agent_logs etc.) survives. Without this
+        // branch, uninstall+reinstall on the same hostname is permanently
+        // broken — observed 2026-05-25 on Trevor-Legion: agent re-enroll
+        // loops on 409 until an operator hand-renames the decommissioned
+        // row in SQL to free the hostname.
+        existingDeviceAuthenticated = true;
+      } else {
+        const now = new Date();
+        const existingDeviceToken = getProvidedExistingDeviceToken(c);
+        existingDeviceAuthenticated =
+          tokenHashMatches(existingDevice.agentTokenHash, existingDeviceToken, now) ||
+          tokenHashMatches(existingDevice.previousTokenHash, existingDeviceToken, now, existingDevice.previousTokenExpiresAt);
+      }
 
       if (!existingDeviceAuthenticated) {
+        const isSuspendedDecom = tokenSuspended && existingDevice.status === 'decommissioned';
+        const reason = isSuspendedDecom
+          ? 'existing_decommissioned_row_has_suspended_token'
+          : 'hostname_collision_requires_existing_device_token';
+        const errorMessage = isSuspendedDecom
+          ? 'Re-enrollment refused: existing device is decommissioned but its agent token was suspended (cross-tenant probe alarm). Clear agent_token_suspended_at on the device row before re-enrolling.'
+          : 'Enrollment attempted to replace an existing hostname without the existing device token';
+
         writeAuditEvent(c, {
           orgId: key.orgId,
           actorType: 'system',
@@ -396,15 +427,17 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
           resourceId: existingDevice.id,
           resourceName: data.hostname,
           details: {
-            reason: 'hostname_collision_requires_existing_device_token',
+            reason,
             siteId,
           },
           result: 'denied',
-          errorMessage: 'Enrollment attempted to replace an existing hostname without the existing device token',
+          errorMessage,
         });
         return c.json({
-          error: 'A device with this hostname already exists and re-enrollment requires the existing device token or an admin-approved replacement workflow',
-          reason: 'hostname_collision_requires_existing_device_token',
+          error: isSuspendedDecom
+            ? 'Re-enrollment refused: existing device row is decommissioned and has a suspended agent token. An operator must clear the suspension flag before re-enrollment.'
+            : 'A device with this hostname already exists and re-enrollment requires the existing device token or an admin-approved replacement workflow',
+          reason,
         }, 409);
       }
     }

--- a/apps/api/src/routes/agents/enrollment.ts
+++ b/apps/api/src/routes/agents/enrollment.ts
@@ -402,6 +402,24 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
         // loops on 409 until an operator hand-renames the decommissioned
         // row in SQL to free the hostname.
         existingDeviceAuthenticated = true;
+        // Audit the admin-approved-replacement bypass for forensic
+        // traceability. Re-enrollment onto a decommissioned slot is a
+        // sensitive transition (new tokens issued, device id preserved) and
+        // must be traceable independent of the success-path audit below.
+        writeAuditEvent(c, {
+          orgId: key.orgId,
+          actorType: 'system',
+          action: 'agent.enroll',
+          resourceType: 'device',
+          resourceId: existingDevice.id,
+          resourceName: data.hostname,
+          details: {
+            reason: 'decommissioned_row_reenrolled',
+            siteId,
+            priorDeviceId: existingDevice.id,
+          },
+          result: 'success',
+        });
       } else {
         const now = new Date();
         const existingDeviceToken = getProvidedExistingDeviceToken(c);


### PR DESCRIPTION
## Real-world bug

Observed 2026-05-25 on a BDunn endpoint (`Trevor-Legion`): operator uninstalled the Breeze agent via the standard onboarding uninstall flow and re-ran the installer. The fresh agent had no prior `agentTokenHash`, so the hostname-collision check at `apps/api/src/routes/agents/enrollment.ts:385` returned `HTTP 409 hostname_collision_requires_existing_device_token` on every re-enrollment attempt — even though the prior device row had been explicitly `DELETE`'d by an admin (`status='decommissioned'`).

The only manual unblock was hand-renaming the decommissioned row's hostname via SQL to free the hostname slot:

```sql
UPDATE devices
SET hostname = 'Trevor-Legion-archived-200f2a95'
WHERE id = '200f2a95-...' AND status = 'decommissioned';
```

After that the next attempt succeeded and the existing auto-restore block (`enrollment.ts:408`) flipped status back. Without that workaround, every uninstall+reinstall on the same hostname is permanently broken.

## Fix

In the existing-device auth check, treat `status='decommissioned'` as implicitly authenticated:

```ts
if (existingDevice.status === 'decommissioned') {
  existingDeviceAuthenticated = true;
} else {
  // existing token-check path, unchanged
}
```

The reasoning:

1. An admin **explicitly** removed the device via `DELETE /api/v1/devices/<id>` (the soft-delete sets `status='decommissioned'`). That admin action **is** the "admin-approved replacement workflow" referenced in the existing 409 error message — but the current code has no path to honor it.
2. The prior agent's tokens are irrelevant: the device record was marked for replacement. Requiring the prior token defeats the entire point of the decommission action.
3. The downstream auto-restore block at `enrollment.ts:408` (untouched in this PR) flips `status` back to `'online'` and the transaction `UPDATE`s the existing row in-place — so `device.id` is preserved and all related history survives (`agent_logs`, `alerts`, `software_inventory`, `time_series_metrics`, etc.).

Devices that are `'online'` / `'offline'` still require the existing-device token. No security regression for the active-device hostname-takeover threat model the original check was designed for.

## Tests

Added one unit test under the existing `POST /agents/enroll — 401 reason disambiguation` describe block:

```
✓ allows re-enrollment without the existing-device token when the existing row is decommissioned
```

Mocks an existing decommissioned row, sends an enrollment with no `existingDeviceToken` header, asserts `201` + correct `deviceId` + that **no** `hostname_collision_requires_existing_device_token` audit event was written.

Existing 409 tests (active device + token absent, with and without matching hardware identity) are unchanged and still pass.

## Local CI

- `pnpm --filter @breeze/api test src/routes/agents/enrollment.test.ts` → **13/13 pass** (including new test)
- `pnpm --filter @breeze/api exec tsc --noEmit` → **clean**

## Live test status (honest disclosure)

Not yet deployed to a Breeze API instance — I do not have authorization for the rolling-fork build/deploy procedure on `breeze.bdunn.com`. The fix is a 10-line mirror of the SQL workaround I empirically verified works on prod earlier today (the workaround proves the storage layer correctly handles re-enrolling onto a decommissioned row; this PR just lets the API path get there instead of forcing operators to hand-edit the DB).

## Test plan
- [ ] CI green
- [ ] Reviewer: confirm the security reasoning — decommissioned-implies-admin-approved-replacement matches your intent
- [ ] After merge + deploy: decommission a test device via DELETE, attempt re-enroll, verify 201 + status flips to online + history preserved