### PR TITLE
docs(deploy): document PUBLIC_API_URL requirement for installer link generation

### DIFF
--- a/apps/docs/src/content/docs/deploy/environment.mdx
+++ b/apps/docs/src/content/docs/deploy/environment.mdx
@@ -56,7 +56,7 @@ All configuration is done through environment variables, defined in your `.env.p
 | `API_PORT` | `3001` | | API server port |
 | `WEB_PORT` | `4321` | | Web dashboard port |
 | `PUBLIC_API_URL` | `https://${BREEZE_DOMAIN}` (bundled compose only) | | Public API URL used for generated agent installers and shareable links. The bundled `docker-compose.yml` derives this from `BREEZE_DOMAIN`. If you use a custom compose file, you must set `PUBLIC_API_URL` in `.env` **and** map it into the `api` service `environment:` block, or **Generate Link** / **Download Installer** will fail with `Server URL not configured`. |
-| `API_URL` | — | | Legacy fallback for `PUBLIC_API_URL` (same semantics). Set one or the other. |
+| `API_URL` | — | | Legacy fallback for `PUBLIC_API_URL`, honored only by enrollment, installer, and MCP-invite code paths. Auto-update, dev-push, and a few other routes read `PUBLIC_API_URL` only — prefer setting `PUBLIC_API_URL`. |
 | `BREEZE_DOMAIN` | — | Yes (prod) | Domain for Caddy TLS provisioning |
 | `ACME_EMAIL` | — | Yes (prod) | Email for Let's Encrypt certificate notifications |
 | `CORS_ALLOWED_ORIGINS` | — | | Comma-separated allowed CORS origins |

--- a/apps/docs/src/content/docs/deploy/environment.mdx
+++ b/apps/docs/src/content/docs/deploy/environment.mdx
@@ -55,7 +55,8 @@ All configuration is done through environment variables, defined in your `.env.p
 | `NODE_ENV` | `production` | | Environment mode |
 | `API_PORT` | `3001` | | API server port |
 | `WEB_PORT` | `4321` | | Web dashboard port |
-| `PUBLIC_API_URL` | — | | Full public API URL. Leave empty for Docker deployments — the web app uses relative URLs through Caddy. |
+| `PUBLIC_API_URL` | `https://${BREEZE_DOMAIN}` (bundled compose only) | | Public API URL used for generated agent installers and shareable links. The bundled `docker-compose.yml` derives this from `BREEZE_DOMAIN`. If you use a custom compose file, you must set `PUBLIC_API_URL` in `.env` **and** map it into the `api` service `environment:` block, or **Generate Link** / **Download Installer** will fail with `Server URL not configured`. |
+| `API_URL` | — | | Legacy fallback for `PUBLIC_API_URL` (same semantics). Set one or the other. |
 | `BREEZE_DOMAIN` | — | Yes (prod) | Domain for Caddy TLS provisioning |
 | `ACME_EMAIL` | — | Yes (prod) | Email for Let's Encrypt certificate notifications |
 | `CORS_ALLOWED_ORIGINS` | — | | Comma-separated allowed CORS origins |

--- a/apps/docs/src/content/docs/reference/troubleshooting.mdx
+++ b/apps/docs/src/content/docs/reference/troubleshooting.mdx
@@ -150,12 +150,11 @@ curl http://localhost:3001/health/ready
 
 ### "Generate Link" fails with `Server URL not configured (set PUBLIC_API_URL or API_URL)`
 
-The API container can't see a `PUBLIC_API_URL` or `API_URL` env var, so it has no base URL to mint the installer share link against.
+**Cause**: The API container can't see a `PUBLIC_API_URL` or `API_URL` env var, so it has no base URL to mint the installer share link against. The bundled `docker-compose.yml` derives this from `BREEZE_DOMAIN` (since [#613](https://github.com/LanternOps/breeze/pull/613) / v0.65.7+), so this only bites custom or older compose files.
 
-Fix:
-
+**Fix**:
 1. Set `PUBLIC_API_URL=https://<your-domain>` in `/opt/breeze/.env` (or wherever your compose `.env` lives).
-2. If you use a custom compose file (anything other than the bundled `docker-compose.yml` shipped in the repo), explicitly map the variable into the `api` service. Docker Compose only forwards env vars to a container when they appear in that service's `environment:` block — having the value in `.env` is necessary but not sufficient.
+2. If you use a custom compose file, explicitly map the variable into the `api` service. Docker Compose only forwards env vars to a container when they appear in that service's `environment:` block — having the value in `.env` is necessary but not sufficient.
 
    ```yaml
    api:
@@ -164,13 +163,11 @@ Fix:
    ```
 3. `docker compose up -d api` to recreate the container.
 
-The bundled `docker-compose.yml` already wires this up from `BREEZE_DOMAIN`, so this only bites custom / pre-v0.65.6 compose files.
-
 ### "Generate Link" fails with `MSI build pipeline not reachable. Retry`
 
-The release-manifest verifier is rejecting the live MSI because the manifest's `repository` field is `LanternOps/breeze` but the code default expects `lanternops/breeze` (case mismatch). Fix is on `main` ([#867](https://github.com/LanternOps/breeze/pull/867)) and will ship in the next release after v0.67.0.
+**Cause**: The release-manifest verifier is rejecting the live MSI because the manifest's `repository` field is `LanternOps/breeze` but the code default expects `lanternops/breeze` (case mismatch). Fix is on `main` ([#867](https://github.com/LanternOps/breeze/pull/867)) and will ship in the next release after v0.67.0.
 
-Workaround on v0.67.0 — add to `.env` and map into the `api` service:
+**Fix** (workaround on v0.67.0): add to `.env` and map into the `api` service.
 
 ```
 BINARY_GITHUB_REPOSITORY=LanternOps/breeze

--- a/apps/docs/src/content/docs/reference/troubleshooting.mdx
+++ b/apps/docs/src/content/docs/reference/troubleshooting.mdx
@@ -146,6 +146,44 @@ docker compose -f docker/docker-compose.prod.yml exec api \
 curl http://localhost:3001/health/ready
 ```
 
+## Installer Issues
+
+### "Generate Link" fails with `Server URL not configured (set PUBLIC_API_URL or API_URL)`
+
+The API container can't see a `PUBLIC_API_URL` or `API_URL` env var, so it has no base URL to mint the installer share link against.
+
+Fix:
+
+1. Set `PUBLIC_API_URL=https://<your-domain>` in `/opt/breeze/.env` (or wherever your compose `.env` lives).
+2. If you use a custom compose file (anything other than the bundled `docker-compose.yml` shipped in the repo), explicitly map the variable into the `api` service. Docker Compose only forwards env vars to a container when they appear in that service's `environment:` block — having the value in `.env` is necessary but not sufficient.
+
+   ```yaml
+   api:
+     environment:
+       PUBLIC_API_URL: ${PUBLIC_API_URL}
+   ```
+3. `docker compose up -d api` to recreate the container.
+
+The bundled `docker-compose.yml` already wires this up from `BREEZE_DOMAIN`, so this only bites custom / pre-v0.65.6 compose files.
+
+### "Generate Link" fails with `MSI build pipeline not reachable. Retry`
+
+The release-manifest verifier is rejecting the live MSI because the manifest's `repository` field is `LanternOps/breeze` but the code default expects `lanternops/breeze` (case mismatch). Fix is on `main` ([#867](https://github.com/LanternOps/breeze/pull/867)) and will ship in the next release after v0.67.0.
+
+Workaround on v0.67.0 — add to `.env` and map into the `api` service:
+
+```
+BINARY_GITHUB_REPOSITORY=LanternOps/breeze
+```
+
+```yaml
+api:
+  environment:
+    BINARY_GITHUB_REPOSITORY: ${BINARY_GITHUB_REPOSITORY}
+```
+
+Then `docker compose up -d api`. Same workaround unblocks **Download Installer**, which hits the same code path silently.
+
 ## Getting Help
 
 - Check the [GitHub Issues](https://github.com/LanternOps/breeze/issues)


### PR DESCRIPTION
## Summary

- Rewrite the misleading `PUBLIC_API_URL` row in `deploy/environment.mdx` — the previous "leave empty for Docker deployments" copy is only true for the bundled `docker-compose.yml` (which derives the value from `BREEZE_DOMAIN`). Custom or older compose files must map it explicitly into the `api` service `environment:` block, or **Generate Link** / **Download Installer** fail with `Server URL not configured (set PUBLIC_API_URL or API_URL)`.
- Add an **Installer Issues** section to `reference/troubleshooting.mdx` covering:
  - `Server URL not configured` — root cause and the .env-plus-compose-mapping fix.
  - `MSI build pipeline not reachable. Retry` — links to #866 / #867 with the `BINARY_GITHUB_REPOSITORY=LanternOps/breeze` workaround for v0.67.0.

## Why

Self-hosted user on v0.67.0 (SemoTech, Discord) hit both errors back-to-back: the #866 repo case-mismatch first, then `Server URL not configured` once that was unblocked. Their stack didn't map `PUBLIC_API_URL` into the `api` service, so the API container never saw the value from `.env`. The bundled root `docker-compose.yml` has wired this up since #613 (v0.65.6+), but the docs still suggested the var could be left empty.

No code change — the existing error message in [enrollmentKeys.ts:949-955](https://github.com/LanternOps/breeze/blob/main/apps/api/src/routes/enrollmentKeys.ts#L949-L955) is already informative; this is a docs gap only.

## Test plan

- [ ] Visit `/deploy/environment/` on the docs site preview and confirm the `PUBLIC_API_URL` row reads correctly.
- [ ] Visit `/reference/troubleshooting/` and confirm the new **Installer Issues** section renders between **Container Issues** and **Getting Help**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)