### PR TITLE
feat(api): PAM software-policy bridge (Discussion #858 Track 2)

### DIFF
--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -123,6 +123,19 @@ export async function withSystemDbAccessContext<T>(fn: () => Promise<T>): Promis
   return withDbAccessContext(SYSTEM_DB_ACCESS_CONTEXT, fn);
 }
 
+/**
+ * True when the current async scope is inside an active
+ * `withDbAccessContext` / `withSystemDbAccessContext` call. Use to assert
+ * RLS context is established before a tenant-scoped query in code paths
+ * where a bare-pool fallback would be a silent security bug
+ * (e.g. PAM auto-elevation lookups — a missing context falls back to the
+ * unprivileged `breeze_app` role with no GUC, RLS denies, and the caller
+ * sees a silent empty result instead of an auto-deny).
+ */
+export function hasDbAccessContext(): boolean {
+  return dbContextStorage.getStore() !== undefined;
+}
+
 export type RunOutsideDbContextFn = <T>(fn: () => T) => T;
 
 /**

--- a/apps/api/src/db/schema/softwarePolicies.ts
+++ b/apps/api/src/db/schema/softwarePolicies.ts
@@ -30,9 +30,18 @@ export type SoftwarePolicyRuleDefinition = {
   reason?: string;
 };
 
+export type SoftwarePolicyExecutableRule = {
+  name: string;
+  sha256?: string;
+  signer?: string;
+  publisher?: string;
+  pathGlob?: string;
+};
+
 export type SoftwarePolicyRulesDefinition = {
   software: SoftwarePolicyRuleDefinition[];
   allowUnknown?: boolean;
+  executable?: SoftwarePolicyExecutableRule[];
 };
 
 export type SoftwarePolicyViolation = {

--- a/apps/api/src/routes/softwarePolicies.test.ts
+++ b/apps/api/src/routes/softwarePolicies.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { resolveOrgIdForWrite } from './softwarePolicies';
+import { executableRuleSchema, resolveOrgIdForWrite, softwareRulesSchema } from './softwarePolicies';
+import { normalizeSoftwarePolicyRules } from '../services/softwarePolicyService';
 import type { AuthContext } from '../middleware/auth';
 
 function makeOrgAuth(orgId: string): AuthContext {
@@ -55,5 +56,83 @@ describe('resolveOrgIdForWrite', () => {
     const auth = makePartnerAuth(['org-A', 'org-B']);
     const result = resolveOrgIdForWrite(auth, 'org-B');
     expect(result.orgId).toBe('org-B');
+  });
+});
+
+describe('executableRuleSchema', () => {
+  it('accepts a fully-populated executable rule', () => {
+    const parsed = executableRuleSchema.parse({
+      name: 'Adobe Reader',
+      sha256: 'a'.repeat(64),
+      signer: 'Adobe Inc.',
+      publisher: 'Adobe Systems Incorporated',
+      pathGlob: 'C:\\Program Files\\Adobe\\**\\*.exe',
+    });
+    expect(parsed.name).toBe('Adobe Reader');
+  });
+
+  it('rejects sha256 that is not 64 hex chars', () => {
+    expect(() => executableRuleSchema.parse({ name: 'X', sha256: 'not-a-hash' })).toThrow();
+    expect(() => executableRuleSchema.parse({ name: 'X', sha256: 'a'.repeat(63) })).toThrow();
+  });
+
+  it('accepts uppercase sha256 (case-insensitive regex)', () => {
+    expect(() => executableRuleSchema.parse({ name: 'X', sha256: 'A'.repeat(64) })).not.toThrow();
+  });
+
+  it('enforces caps on signer / publisher / pathGlob', () => {
+    expect(() => executableRuleSchema.parse({ name: 'X', signer: 'a'.repeat(256) })).toThrow();
+    expect(() => executableRuleSchema.parse({ name: 'X', publisher: 'a'.repeat(256) })).toThrow();
+    expect(() => executableRuleSchema.parse({ name: 'X', pathGlob: 'a'.repeat(501) })).toThrow();
+  });
+});
+
+describe('softwareRulesSchema — PAM-only / inventory-only / mixed', () => {
+  it('accepts a PAM-only policy (executable[] populated, no software[])', () => {
+    const parsed = softwareRulesSchema.parse({
+      executable: [{ name: 'Adobe Reader', sha256: 'a'.repeat(64) }],
+    });
+    expect(parsed.executable).toHaveLength(1);
+    expect(parsed.software).toBeUndefined();
+  });
+
+  it('accepts an inventory-only policy', () => {
+    const parsed = softwareRulesSchema.parse({
+      software: [{ name: 'Firefox' }],
+    });
+    expect(parsed.software).toHaveLength(1);
+    expect(parsed.executable).toBeUndefined();
+  });
+
+  it('accepts a mixed policy', () => {
+    const parsed = softwareRulesSchema.parse({
+      software: [{ name: 'Firefox' }],
+      executable: [{ name: 'Adobe', sha256: 'a'.repeat(64) }],
+    });
+    expect(parsed.software).toHaveLength(1);
+    expect(parsed.executable).toHaveLength(1);
+  });
+
+  it('rejects a policy with neither software[] nor executable[]', () => {
+    expect(() => softwareRulesSchema.parse({})).toThrow();
+    expect(() => softwareRulesSchema.parse({ software: [], executable: [] })).toThrow();
+  });
+
+  it('PAM-only payload round-trips through validator + normalizer without losing executable[]', () => {
+    // This is the regression Todd flagged: the previous schema stripped
+    // `executable` because it was not defined on the Zod object. The
+    // PAM bridge then loaded policies whose `executable[]` was always
+    // undefined → always {match: null} in production.
+    const payload = {
+      executable: [{ name: 'Adobe Reader', sha256: 'a'.repeat(64), signer: 'Adobe Inc.' }],
+    };
+    const validated = softwareRulesSchema.parse(payload);
+    const normalized = normalizeSoftwarePolicyRules(validated);
+    expect(normalized.executable).toBeDefined();
+    expect(normalized.executable).toHaveLength(1);
+    expect(normalized.executable?.[0]?.name).toBe('Adobe Reader');
+    expect(normalized.executable?.[0]?.sha256).toBe('a'.repeat(64));
+    expect(normalized.executable?.[0]?.signer).toBe('Adobe Inc.');
+    expect(normalized.software).toEqual([]);
   });
 });

--- a/apps/api/src/routes/softwarePolicies.ts
+++ b/apps/api/src/routes/softwarePolicies.ts
@@ -49,10 +49,29 @@ const softwareRuleSchema = z.object({
   reason: z.string().min(1).max(1000).optional(),
 });
 
-const softwareRulesSchema = z.object({
-  software: z.array(softwareRuleSchema).min(1),
-  allowUnknown: z.boolean().optional(),
+// PAM executable rule (parallel to softwareRuleSchema, consumed by the
+// PAM bridge — not the inventory matcher). sha256 regex is case-insensitive
+// for input; the DB CHECK constraint stores lowercase hex.
+export const executableRuleSchema = z.object({
+  name: z.string().min(1).max(200),
+  sha256: z.string().regex(/^[0-9a-f]{64}$/i).optional(),
+  signer: z.string().max(255).optional(),
+  publisher: z.string().max(255).optional(),
+  pathGlob: z.string().max(500).optional(),
 });
+
+// Both software[] and executable[] are optional, but the policy must carry
+// at least one rule in at least one of them. A PAM-only policy
+// (executable[] populated, software[] empty/absent) is valid; an inventory-
+// only policy (software[] populated, executable[] absent) is valid.
+export const softwareRulesSchema = z.object({
+  software: z.array(softwareRuleSchema).optional(),
+  executable: z.array(executableRuleSchema).optional(),
+  allowUnknown: z.boolean().optional(),
+}).refine(
+  (r) => (r.software?.length ?? 0) > 0 || (r.executable?.length ?? 0) > 0,
+  { message: 'rules must include at least one software[] or executable[] entry' }
+);
 
 const remediationOptionsSchema = z.object({
   autoUninstall: z.boolean().optional(),
@@ -209,8 +228,8 @@ softwarePoliciesRoutes.post(
     }
 
     const rules = normalizeSoftwarePolicyRules(payload.rules);
-    if (rules.software.length === 0) {
-      return c.json({ error: 'At least one software rule is required' }, 400);
+    if (rules.software.length === 0 && (rules.executable?.length ?? 0) === 0) {
+      return c.json({ error: 'At least one software or executable rule is required' }, 400);
     }
 
     const [policy] = await db
@@ -261,7 +280,7 @@ softwarePoliciesRoutes.post(
       details: {
         mode: policy.mode,
         enforceMode: policy.enforceMode,
-        rules: rules.software.length,
+        rules: rules.software.length + (rules.executable?.length ?? 0),
         scheduleWarning,
       },
     });
@@ -403,8 +422,8 @@ softwarePoliciesRoutes.patch(
 
     if (payload.rules !== undefined) {
       const normalizedRules = normalizeSoftwarePolicyRules(payload.rules);
-      if (normalizedRules.software.length === 0) {
-        return c.json({ error: 'At least one software rule is required' }, 400);
+      if (normalizedRules.software.length === 0 && (normalizedRules.executable?.length ?? 0) === 0) {
+        return c.json({ error: 'At least one software or executable rule is required' }, 400);
       }
       updates.rules = normalizedRules;
     }

--- a/apps/api/src/services/pamBridge.test.ts
+++ b/apps/api/src/services/pamBridge.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Bridge unit tests — pure-matcher coverage only. DB-load function is
+ * covered by an integration test (out of scope for this file).
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  matchPathGlob,
+  matchPoliciesAgainst,
+  type LoadedPolicy,
+  type PamBridgeInput,
+} from './pamBridge';
+
+function policy(
+  id: string,
+  mode: LoadedPolicy['mode'],
+  ruleFields: Array<Record<string, unknown>>,
+  priority = 50
+): LoadedPolicy {
+  return {
+    id,
+    mode,
+    priority,
+    rules: {
+      software: [],
+      allowUnknown: false,
+      executable: ruleFields.map((r) => ({ name: (r.name as string) ?? id, ...r })),
+    } as LoadedPolicy['rules'],
+  };
+}
+
+const ADOBE_HASH = 'a'.repeat(64);
+const FOO_HASH = 'b'.repeat(64);
+
+const adobeInstall: PamBridgeInput = {
+  orgId: 'org-1',
+  deviceId: 'dev-1',
+  targetExecutablePath: 'C:\\Users\\billy\\Downloads\\AcroRdrDC.exe',
+  targetExecutableHash: ADOBE_HASH,
+  targetExecutableSigner: 'Adobe Inc.',
+  targetPublisher: 'Adobe Systems Incorporated',
+};
+
+describe('matchPathGlob', () => {
+  it('matches a single-segment * wildcard, case-insensitive, slash-agnostic', () => {
+    expect(matchPathGlob('C:\\Program Files\\Adobe\\*.exe',
+      'c:/program files/adobe/acrord32.exe')).toBe(true);
+    expect(matchPathGlob('C:\\Program Files\\Adobe\\*.exe',
+      'c:/program files/adobe/subdir/acrord32.exe')).toBe(false);
+  });
+
+  it('matches ** across path separators', () => {
+    expect(matchPathGlob('C:\\Program Files\\Adobe\\**\\*.exe',
+      'C:\\Program Files\\Adobe\\Acrobat\\Reader\\acrord32.exe')).toBe(true);
+  });
+
+  it('does not match unrelated paths', () => {
+    expect(matchPathGlob('C:\\Program Files\\Adobe\\**',
+      'C:\\Windows\\System32\\cmd.exe')).toBe(false);
+  });
+});
+
+describe('matchPoliciesAgainst — single-policy match by field', () => {
+  it('matches by hash (strongest)', () => {
+    const v = matchPoliciesAgainst(adobeInstall, [
+      policy('p-hash', 'allowlist', [{ name: 'Adobe Reader', sha256: ADOBE_HASH }]),
+    ]);
+    expect(v.match).toBe('allowlist');
+    expect(v.policyId).toBe('p-hash');
+    expect(v.matchedField).toBe('hash');
+    expect(v.ruleName).toBe('Adobe Reader');
+  });
+
+  it('matches by signer when hash absent', () => {
+    const v = matchPoliciesAgainst(adobeInstall, [
+      policy('p-signer', 'allowlist', [{ name: 'Adobe-signed', signer: 'Adobe Inc.' }]),
+    ]);
+    expect(v.match).toBe('allowlist');
+    expect(v.matchedField).toBe('signer');
+  });
+
+  it('matches by publisher when hash + signer absent', () => {
+    const v = matchPoliciesAgainst(adobeInstall, [
+      policy('p-pub', 'allowlist', [{ name: 'Adobe-pub', publisher: 'Adobe Systems Incorporated' }]),
+    ]);
+    expect(v.match).toBe('allowlist');
+    expect(v.matchedField).toBe('publisher');
+  });
+
+  it('matches by path glob (weakest)', () => {
+    const v = matchPoliciesAgainst(adobeInstall, [
+      policy('p-path', 'allowlist', [{ name: 'Adobe-path', pathGlob: 'C:\\Users\\**\\AcroRdrDC.exe' }]),
+    ]);
+    expect(v.match).toBe('allowlist');
+    expect(v.matchedField).toBe('path');
+  });
+
+  it('no match returns {match: null}', () => {
+    const v = matchPoliciesAgainst(adobeInstall, [
+      policy('p-miss', 'allowlist', [{ name: 'Firefox', sha256: FOO_HASH }]),
+    ]);
+    expect(v.match).toBeNull();
+    expect(v.policyId).toBeUndefined();
+    expect(v.auditMatches).toEqual([]);
+  });
+});
+
+describe('matchPoliciesAgainst — precedence', () => {
+  it('hash beats path within the same policy list', () => {
+    const v = matchPoliciesAgainst(adobeInstall, [
+      policy('p-path', 'allowlist', [{ name: 'AnyExe', pathGlob: 'C:\\**\\*.exe' }]),
+      policy('p-hash', 'allowlist', [{ name: 'Adobe', sha256: ADOBE_HASH }]),
+    ]);
+    expect(v.matchedField).toBe('hash');
+    expect(v.policyId).toBe('p-hash');
+  });
+
+  it('signer beats publisher beats path', () => {
+    const v = matchPoliciesAgainst(adobeInstall, [
+      policy('p-path', 'allowlist', [{ name: 'AnyAdobe', pathGlob: 'C:\\Users\\**' }]),
+      policy('p-pub', 'allowlist', [{ name: 'AdobePub', publisher: 'Adobe Systems Incorporated' }]),
+      policy('p-signer', 'allowlist', [{ name: 'AdobeSigner', signer: 'Adobe Inc.' }]),
+    ]);
+    expect(v.matchedField).toBe('signer');
+  });
+
+  it('higher policy.priority wins when field strength ties', () => {
+    const v = matchPoliciesAgainst(adobeInstall, [
+      policy('p-low', 'allowlist', [{ name: 'A', sha256: ADOBE_HASH }], 10),
+      policy('p-high', 'allowlist', [{ name: 'A', sha256: ADOBE_HASH }], 90),
+    ]);
+    expect(v.policyId).toBe('p-high');
+  });
+});
+
+describe('matchPoliciesAgainst — mode tie-breaker', () => {
+  it('blocklist beats allowlist when both match (safety default)', () => {
+    const v = matchPoliciesAgainst(adobeInstall, [
+      policy('p-allow', 'allowlist', [{ name: 'Adobe', sha256: ADOBE_HASH }]),
+      policy('p-block', 'blocklist', [{ name: 'AdobeBanned', sha256: ADOBE_HASH }]),
+    ]);
+    expect(v.match).toBe('blocklist');
+    expect(v.policyId).toBe('p-block');
+  });
+
+  it('blocklist by weaker field STILL beats allowlist by stronger field', () => {
+    // Intentional: a block-by-path on something we have an allow-by-hash for
+    // is somebody saying "actively ban anything under this directory."
+    // Block wins for safety even though hash is a stronger identity signal.
+    const v = matchPoliciesAgainst(adobeInstall, [
+      policy('p-allow', 'allowlist', [{ name: 'AdobeHash', sha256: ADOBE_HASH }]),
+      policy('p-block', 'blocklist', [{ name: 'DownloadsBan', pathGlob: 'C:\\Users\\billy\\Downloads\\**' }]),
+    ]);
+    expect(v.match).toBe('blocklist');
+    expect(v.matchedField).toBe('path');
+  });
+
+  it('audit-mode hits never produce a binding verdict, only auditMatches', () => {
+    const v = matchPoliciesAgainst(adobeInstall, [
+      policy('p-audit', 'audit', [{ name: 'AdobeAudit', sha256: ADOBE_HASH }]),
+    ]);
+    expect(v.match).toBeNull();
+    expect(v.auditMatches).toEqual([
+      { policyId: 'p-audit', ruleName: 'AdobeAudit', matchedField: 'hash' },
+    ]);
+  });
+
+  it('audit-mode hits ride alongside a binding allowlist verdict', () => {
+    const v = matchPoliciesAgainst(adobeInstall, [
+      policy('p-allow', 'allowlist', [{ name: 'AdobeAllow', sha256: ADOBE_HASH }]),
+      policy('p-audit', 'audit', [{ name: 'AdobeAudit', signer: 'Adobe Inc.' }]),
+    ]);
+    expect(v.match).toBe('allowlist');
+    expect(v.policyId).toBe('p-allow');
+    expect(v.auditMatches).toEqual([
+      { policyId: 'p-audit', ruleName: 'AdobeAudit', matchedField: 'signer' },
+    ]);
+  });
+});
+
+describe('matchPoliciesAgainst — case sensitivity', () => {
+  it('hash compare is case-insensitive on both sides', () => {
+    const input = { ...adobeInstall, targetExecutableHash: ADOBE_HASH.toUpperCase() };
+    const v = matchPoliciesAgainst(input, [
+      policy('p', 'allowlist', [{ name: 'A', sha256: ADOBE_HASH.toLowerCase() }]),
+    ]);
+    expect(v.match).toBe('allowlist');
+  });
+
+  it('signer compare is case-insensitive and trims whitespace', () => {
+    const input = { ...adobeInstall, targetExecutableSigner: '  adobe inc.  ' };
+    const v = matchPoliciesAgainst(input, [
+      policy('p', 'allowlist', [{ name: 'A', signer: 'Adobe Inc.' }]),
+    ]);
+    expect(v.match).toBe('allowlist');
+  });
+
+  it('path glob compare is case-insensitive, slash-agnostic', () => {
+    const input = { ...adobeInstall, targetExecutablePath: 'c:/USERS/billy/DOWNLOADS/AcroRdrDC.exe' };
+    const v = matchPoliciesAgainst(input, [
+      policy('p', 'allowlist', [{ name: 'A', pathGlob: 'C:\\Users\\**\\AcroRdrDC.exe' }]),
+    ]);
+    expect(v.match).toBe('allowlist');
+  });
+});
+
+describe('matchPoliciesAgainst — adobe canonical scenario', () => {
+  it('returns {match: allowlist, policyId, matchedField: hash} for the Adobe install case', () => {
+    const v = matchPoliciesAgainst(adobeInstall, [
+      policy('p-adobe', 'allowlist', [
+        { name: 'Adobe Acrobat Reader DC', sha256: ADOBE_HASH, signer: 'Adobe Inc.' },
+      ]),
+      policy('p-blanket-audit', 'audit', [
+        { name: 'AnyAdobe', publisher: 'Adobe Systems Incorporated' },
+      ]),
+    ]);
+    expect(v).toEqual({
+      match: 'allowlist',
+      policyId: 'p-adobe',
+      ruleIndex: 0,
+      ruleName: 'Adobe Acrobat Reader DC',
+      matchedField: 'hash',
+      auditMatches: [
+        { policyId: 'p-blanket-audit', ruleName: 'AnyAdobe', matchedField: 'publisher' },
+      ],
+    });
+  });
+});
+
+describe('matchPoliciesAgainst — empty / no-op inputs', () => {
+  it('empty policy list returns no match', () => {
+    expect(matchPoliciesAgainst(adobeInstall, [])).toEqual({
+      match: null,
+      auditMatches: [],
+    });
+  });
+
+  it('rule with no PAM fields never matches even if name matches', () => {
+    // PAM bridge only looks at sha256/signer/publisher/pathGlob — `name`
+    // alone is metadata for audit text, not a matcher.
+    const v = matchPoliciesAgainst(adobeInstall, [
+      policy('p-name-only', 'allowlist', [{ name: 'Adobe Reader' }]),
+    ]);
+    expect(v.match).toBeNull();
+  });
+
+  it('inventory-only software[] entries are ignored by the bridge', () => {
+    // The bridge reads `executable[]`, NOT `software[]`. A policy with only
+    // inventory rules (used by softwarePolicyService) must produce no match
+    // even if a `name` overlaps with the executable.
+    const inventoryOnlyPolicy: LoadedPolicy = {
+      id: 'p-inv',
+      mode: 'allowlist',
+      priority: 50,
+      rules: {
+        software: [{ name: 'Adobe Reader', vendor: 'Adobe', minVersion: '23.0' }],
+        allowUnknown: false,
+      },
+    };
+    expect(matchPoliciesAgainst(adobeInstall, [inventoryOnlyPolicy]).match).toBeNull();
+  });
+});
+
+// ============================================================
+// Org-scoping note
+// ============================================================
+// Cross-org leakage IS tested but lives in the integration test alongside
+// loadActivePoliciesForDevice, since enforcement is RLS + the
+// `resolveSoftwarePolicyForDevice` hierarchy traversal, not the pure matcher.
+// The pure matcher only receives the already-RLS-filtered policy list.

--- a/apps/api/src/services/pamBridge.test.ts
+++ b/apps/api/src/services/pamBridge.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, expect, it } from 'vitest';
 import {
+  evaluatePamBridge,
   matchPathGlob,
   matchPoliciesAgainst,
   type LoadedPolicy,
@@ -56,6 +57,21 @@ describe('matchPathGlob', () => {
   it('does not match unrelated paths', () => {
     expect(matchPathGlob('C:\\Program Files\\Adobe\\**',
       'C:\\Windows\\System32\\cmd.exe')).toBe(false);
+  });
+
+  it('literal spaces in the glob match ONLY literal spaces (regression: NUL-sentinel fix)', () => {
+    // Pre-fix bug: ** was translated to a literal-space placeholder, then
+    // every space (including real `Program Files` spaces) was re-substituted
+    // to `.*`. A blocklist rule for `C:\Program Files\Evil.exe` would match
+    // attacker-controlled `c:/programXfilesY/evil.exe`.
+    expect(matchPathGlob('C:\\Program Files\\X.exe',
+      'C:\\ProgramQfilesQX.exe')).toBe(false);
+    expect(matchPathGlob('C:\\Program Files\\Evil.exe',
+      'c:/programXfilesY/evil.exe')).toBe(false);
+
+    // Positive case: literal-space match still works exactly.
+    expect(matchPathGlob('C:\\Program Files\\X.exe',
+      'C:\\Program Files\\X.exe')).toBe(true);
   });
 });
 
@@ -257,6 +273,18 @@ describe('matchPoliciesAgainst — empty / no-op inputs', () => {
       },
     };
     expect(matchPoliciesAgainst(adobeInstall, [inventoryOnlyPolicy]).match).toBeNull();
+  });
+});
+
+describe('evaluatePamBridge — RLS context guard', () => {
+  it('throws when called outside an active DB access context', async () => {
+    // No withDbAccessContext wrapper. The guard must fail loud rather
+    // than silently dropping to bare-pool RLS-deny → {match: null}.
+    await expect(evaluatePamBridge({
+      orgId: 'org-1',
+      deviceId: 'dev-1',
+      targetExecutablePath: 'C:\\Windows\\notepad.exe',
+    })).rejects.toThrow(/no active DB access context/);
   });
 });
 

--- a/apps/api/src/services/pamBridge.ts
+++ b/apps/api/src/services/pamBridge.ts
@@ -69,7 +69,7 @@
  */
 
 import { eq } from 'drizzle-orm';
-import { db, withDbAccessContext, type DbAccessContext } from '../db';
+import { db, hasDbAccessContext, withDbAccessContext, type DbAccessContext } from '../db';
 import {
   softwarePolicies,
   type SoftwarePolicyExecutableRule,
@@ -137,6 +137,16 @@ export interface PamBridgeVerdict {
 export async function evaluatePamBridge(
   input: PamBridgeInput
 ): Promise<PamBridgeVerdict> {
+  // RLS context guard. Without an active withDbAccessContext, the
+  // softwarePolicies query below would fall through to the bare pool
+  // (unprivileged `breeze_app`, no `breeze.scope` / `breeze.org_id` GUC),
+  // RLS would deny, and the bridge would silently return {match: null} —
+  // effectively skipping the blocklist auto-deny. Fail loud instead.
+  if (!hasDbAccessContext()) {
+    throw new Error(
+      'evaluatePamBridge: no active DB access context. Wrap the call in withDbAccessContext (request path) or evaluatePamBridgeWithContext / withSystemDbAccessContext (background path).'
+    );
+  }
   const policies = await loadActivePoliciesForDevice(input.deviceId);
   return matchPoliciesAgainst(input, policies);
 }
@@ -297,11 +307,17 @@ function matchRule(
 export function matchPathGlob(glob: string, path: string): boolean {
   const norm = (s: string) => s.replace(/\\/g, '/').toLowerCase();
   const target = norm(path);
+  // Use a NUL sentinel for `**` so a literal space in the glob (e.g. the
+  // `Program Files` segment of every Windows install path) can never be
+  // misinterpreted as the wildcard placeholder. A printable placeholder
+  // here is a security bug: a blocklist rule for `C:\Program Files\Evil.exe`
+  // would otherwise produce regex `^c:/program.*files/evil\.exe$` and match
+  // attacker-controlled non-default install paths like `c:/programXfilesY/`.
   const escaped = norm(glob)
-    .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
-    .replace(/\*\*/g, ' ')   // placeholder for greedy any
-    .replace(/\*/g, '[^/]*')
-    .replace(/ /g, '.*');
+    .replace(/[.+?^${}()|[\]\\]/g, '\\$&')   // escape regex metas (space NOT included — good)
+    .replace(/\*\*/g, '\x00')                  // ** → NUL sentinel
+    .replace(/\*/g, '[^/]*')                   // * → single-segment wildcard
+    .replace(/\x00/g, '.*');                   // sentinel → real .*
   const re = new RegExp(`^${escaped}$`);
   return re.test(target);
 }

--- a/apps/api/src/services/pamBridge.ts
+++ b/apps/api/src/services/pamBridge.ts
@@ -1,0 +1,358 @@
+/**
+ * PAM Track 2 — Software-Policy Bridge
+ * =====================================
+ *
+ * Pure lookup function consulted by the future PAM elevation-request handler.
+ * Given a UAC-intercept candidate (an executable the agent saw a user try to
+ * launch elevated), return whether the device's winning software_policy
+ * (resolved via the existing config-policy hierarchy) matches the executable
+ * on hash / signer / publisher / path, and whether the policy mode says we
+ * should silently auto-elevate (allowlist) or auto-deny (blocklist).
+ *
+ * Out of scope (handled by the caller, not the bridge):
+ *   - Inserting the elevation_requests row
+ *   - Writing the elevation_audit row
+ *   - Pushing rules to the agent for offline-cache use
+ *   - Any UI / notification side effects
+ *
+ * The bridge is a PURE LOOKUP. Verdict in, side-effect-free verdict out.
+ * The caller stores `verdict.policyId` in
+ * `elevation_requests.software_policy_match_id` (Track 1 schema).
+ *
+ * Tenancy
+ * -------
+ * Runs through `withDbAccessContext` so the policy table query is RLS-scoped
+ * exactly like every other lookup. Partner-scope callers will only see
+ * policies for orgs the partner owns. Org-scope callers see only their own
+ * org. The bridge takes the org_id as a parameter for explicit safety
+ * (caller must already know it from the device row), but the DB context
+ * is the actual enforcement.
+ *
+ * Match precedence (highest-confidence wins)
+ * ------------------------------------------
+ *   1. hash       — sha256 of the executable, exact match
+ *   2. signer     — Authenticode signer CN, exact case-insensitive
+ *   3. publisher  — Publisher field from the file's version info, exact CI
+ *   4. path       — glob match against target_executable_path (case-insens.
+ *                   on Windows-style paths)
+ *
+ * Reasoning: hash uniquely identifies an exact binary; signer cryptographically
+ * identifies the producer; publisher is metadata that can be spoofed but is
+ * still stronger than a path; path is weakest (renamed binaries, %TEMP%
+ * payloads, etc).
+ *
+ * Mode tie-breaker (when allowlist AND blocklist policies both match)
+ * -------------------------------------------------------------------
+ * Because `resolveSoftwarePolicyForDevice` returns the SINGLE winning policy
+ * per device (the existing config-policy resolver's closest-wins semantics),
+ * there is at most one policy in scope for a given device at any moment.
+ * `matchPoliciesAgainst` still accepts a list so tests can exercise the
+ * tie-breaker logic and so future "all matching policies" semantics can be
+ * plugged in without touching the matcher: blocklist beats allowlist, audit
+ * is reported via `auditMatches` only.
+ *
+ * OS scoping
+ * ----------
+ * OS scoping is enforced at policy-ASSIGNMENT time via
+ * `configPolicyAssignments.osFilter` (varchar[]), not per-rule. The bridge
+ * does not need a per-rule `os` field — by the time `resolveSoftware-
+ * PolicyForDevice` hands us a policy, the assignment-side OS filter has
+ * already excluded mismatches.
+ *
+ * Rules shape
+ * -----------
+ * The bridge reads `softwarePolicies.rules.executable[]` (a parallel array
+ * to the inventory matcher's `rules.software[]`). See
+ * `SoftwarePolicyExecutableRule` in apps/api/src/db/schema/softwarePolicies.ts.
+ * The inventory matcher continues to ignore `executable[]`, and the bridge
+ * ignores `software[]`.
+ */
+
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../db';
+import {
+  softwarePolicies,
+  type SoftwarePolicyExecutableRule,
+  type SoftwarePolicyRulesDefinition,
+} from '../db/schema';
+import { resolveSoftwarePolicyForDevice } from './featureConfigResolver';
+
+// ============================================================
+// Types
+// ============================================================
+
+export type PamBridgeMatchedField = 'hash' | 'signer' | 'publisher' | 'path';
+export type PamBridgeVerdictMode = 'allowlist' | 'blocklist';
+
+export interface PamBridgeInput {
+  /** Org the device belongs to. Caller must pass the device's org_id. */
+  orgId: string;
+  /** Device the elevation request is firing on. */
+  deviceId: string;
+  /** Absolute path the agent observed. Required for `uac_intercept` flow. */
+  targetExecutablePath: string;
+  /** sha256 lowercase hex; undefined if agent couldn't compute one. */
+  targetExecutableHash?: string;
+  /** Authenticode signer CN (e.g. "Adobe Inc."). Undefined if unsigned. */
+  targetExecutableSigner?: string;
+  /** Publisher field from version-info (e.g. "Adobe Systems Incorporated"). */
+  targetPublisher?: string;
+}
+
+export interface PamBridgeAuditMatch {
+  policyId: string;
+  ruleName: string;
+  matchedField: PamBridgeMatchedField;
+}
+
+export interface PamBridgeVerdict {
+  /** null when no allow/block policy matched. Audit-only hits still go in
+   *  `auditMatches`. */
+  match: PamBridgeVerdictMode | null;
+  policyId?: string;
+  /** Rule index within `softwarePolicies.rules.executable[]`, for traceability. */
+  ruleIndex?: number;
+  /** The literal `name` of the matched rule (handy for UI / audit text). */
+  ruleName?: string;
+  matchedField?: PamBridgeMatchedField;
+  /** All audit-mode policies that ALSO matched this binary. The caller
+   *  records these to elevation_audit with event_type='evidence_attached'
+   *  but the verdict itself is unaffected. */
+  auditMatches: PamBridgeAuditMatch[];
+}
+
+// ============================================================
+// Public API
+// ============================================================
+
+/**
+ * Evaluate a UAC-intercept candidate against the device's active software
+ * policy. MUST be called inside a `withDbAccessContext` scope — wrap the
+ * call site, not this function, so the caller's auth context is preserved.
+ *
+ * Returns the highest-confidence binding verdict, or `{match: null}` if no
+ * allow/block policy matched. `auditMatches` lists audit-mode hits regardless
+ * of verdict.
+ */
+export async function evaluatePamBridge(
+  input: PamBridgeInput
+): Promise<PamBridgeVerdict> {
+  const policies = await loadActivePoliciesForDevice(input.deviceId);
+  return matchPoliciesAgainst(input, policies);
+}
+
+/**
+ * Convenience wrapper that opens a system-scoped DB context for use by the
+ * agent WS path (where the request isn't tied to a Breeze user). Mirrors the
+ * pattern in softwareComplianceWorker.ts:26-34.
+ *
+ * Prefer `evaluatePamBridge` from request paths so the user's auth context
+ * is honored.
+ */
+export async function evaluatePamBridgeWithContext(
+  context: DbAccessContext,
+  input: PamBridgeInput
+): Promise<PamBridgeVerdict> {
+  return withDbAccessContext(context, () => evaluatePamBridge(input));
+}
+
+// ============================================================
+// Internals — exported only for the test file
+// ============================================================
+
+/**
+ * Pure matcher: given a candidate and a fully-loaded policy list, compute
+ * the verdict. Exported so tests can drive it without a DB.
+ *
+ * Production today passes 0 or 1 policy (the winner from
+ * `resolveSoftwarePolicyForDevice`). The matcher tolerates an N-element list
+ * so the precedence / mode-tie-breaker logic stays exercised by unit tests
+ * and can be reused if the resolver ever returns multiple policies.
+ */
+export function matchPoliciesAgainst(
+  input: PamBridgeInput,
+  policies: LoadedPolicy[]
+): PamBridgeVerdict {
+  type Hit = {
+    policy: LoadedPolicy;
+    ruleIndex: number;
+    rule: SoftwarePolicyExecutableRule;
+    field: PamBridgeMatchedField;
+  };
+
+  const allowHits: Hit[] = [];
+  const blockHits: Hit[] = [];
+  const auditHits: Hit[] = [];
+
+  for (const policy of policies) {
+    const rules = policy.rules?.executable ?? [];
+    for (let i = 0; i < rules.length; i += 1) {
+      const rule = rules[i];
+      if (!rule) continue;
+      const field = matchRule(input, rule);
+      if (!field) continue;
+
+      const hit: Hit = { policy, ruleIndex: i, rule, field };
+      if (policy.mode === 'allowlist') allowHits.push(hit);
+      else if (policy.mode === 'blocklist') blockHits.push(hit);
+      else if (policy.mode === 'audit') auditHits.push(hit);
+    }
+  }
+
+  const auditMatches: PamBridgeAuditMatch[] = auditHits.map((h) => ({
+    policyId: h.policy.id,
+    ruleName: h.rule.name,
+    matchedField: h.field,
+  }));
+
+  // Tie-breaker: blocklist beats allowlist (safety default).
+  const binding = pickStrongestHit(blockHits) ?? pickStrongestHit(allowHits);
+  if (!binding) {
+    return { match: null, auditMatches };
+  }
+
+  return {
+    match: binding.policy.mode === 'blocklist' ? 'blocklist' : 'allowlist',
+    policyId: binding.policy.id,
+    ruleIndex: binding.ruleIndex,
+    ruleName: binding.rule.name,
+    matchedField: binding.field,
+    auditMatches,
+  };
+}
+
+const FIELD_PRECEDENCE: Record<PamBridgeMatchedField, number> = {
+  hash: 0,
+  signer: 1,
+  publisher: 2,
+  path: 3,
+};
+
+function pickStrongestHit<T extends { field: PamBridgeMatchedField; policy: { priority: number } }>(
+  hits: T[]
+): T | null {
+  if (hits.length === 0) return null;
+  let best = hits[0]!;
+  for (let i = 1; i < hits.length; i += 1) {
+    const candidate = hits[i]!;
+    if (FIELD_PRECEDENCE[candidate.field] < FIELD_PRECEDENCE[best.field]) {
+      best = candidate;
+      continue;
+    }
+    if (FIELD_PRECEDENCE[candidate.field] === FIELD_PRECEDENCE[best.field]) {
+      // Same field strength → higher numeric priority wins. (See
+      // softwarePolicies.priority: integer default 50, higher = more important.)
+      if (candidate.policy.priority > best.policy.priority) {
+        best = candidate;
+      }
+    }
+  }
+  return best;
+}
+
+/**
+ * One-rule matcher. Returns the matched field (highest precedence checked
+ * first), or null. Pure function — no I/O.
+ */
+function matchRule(
+  input: PamBridgeInput,
+  rule: SoftwarePolicyExecutableRule
+): PamBridgeMatchedField | null {
+  // 1. hash (strongest)
+  if (rule.sha256 && input.targetExecutableHash) {
+    if (rule.sha256.toLowerCase() === input.targetExecutableHash.toLowerCase()) {
+      return 'hash';
+    }
+  }
+  // 2. signer
+  if (rule.signer && input.targetExecutableSigner) {
+    if (rule.signer.trim().toLowerCase() === input.targetExecutableSigner.trim().toLowerCase()) {
+      return 'signer';
+    }
+  }
+  // 3. publisher
+  if (rule.publisher && input.targetPublisher) {
+    if (rule.publisher.trim().toLowerCase() === input.targetPublisher.trim().toLowerCase()) {
+      return 'publisher';
+    }
+  }
+  // 4. path glob (weakest)
+  if (rule.pathGlob && input.targetExecutablePath) {
+    if (matchPathGlob(rule.pathGlob, input.targetExecutablePath)) {
+      return 'path';
+    }
+  }
+  return null;
+}
+
+/**
+ * Windows-style case-insensitive glob: `*` matches anything except path
+ * separator, `**` matches anything including separators. Normalizes both
+ * sides to forward slashes before comparison.
+ *
+ * Mirrors the wildcard handling in softwarePolicyService.matchesSoftwareRule
+ * (softwarePolicyService.ts:185-214) but extended for `**` since PAM rules
+ * commonly say `C:\Program Files\Adobe\**\*.exe`.
+ */
+export function matchPathGlob(glob: string, path: string): boolean {
+  const norm = (s: string) => s.replace(/\\/g, '/').toLowerCase();
+  const target = norm(path);
+  const escaped = norm(glob)
+    .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*\*/g, ' ')   // placeholder for greedy any
+    .replace(/\*/g, '[^/]*')
+    .replace(/ /g, '.*');
+  const re = new RegExp(`^${escaped}$`);
+  return re.test(target);
+}
+
+// ============================================================
+// DB load — narrowed slice of softwarePolicies for the bridge
+// ============================================================
+
+export type LoadedPolicy = {
+  id: string;
+  mode: typeof softwarePolicies.$inferSelect.mode;
+  priority: number;
+  rules: SoftwarePolicyRulesDefinition;
+};
+
+/**
+ * Load the device's currently winning software policy via the existing
+ * config-policy hierarchy resolver. Returns a 0- or 1-element array (the
+ * resolver picks the single closest-wins policy across all 5 assignment
+ * levels: partner / organization / site / device_group / device).
+ *
+ * Caller is expected to have already established a `withDbAccessContext`
+ * scope. RLS enforces visibility on the policy row fetch.
+ */
+export async function loadActivePoliciesForDevice(
+  deviceId: string
+): Promise<LoadedPolicy[]> {
+  const winningPolicyId = await resolveSoftwarePolicyForDevice(deviceId);
+  if (!winningPolicyId) return [];
+
+  const rows = await db
+    .select({
+      id: softwarePolicies.id,
+      mode: softwarePolicies.mode,
+      priority: softwarePolicies.priority,
+      rules: softwarePolicies.rules,
+      isActive: softwarePolicies.isActive,
+    })
+    .from(softwarePolicies)
+    .where(eq(softwarePolicies.id, winningPolicyId))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row || !row.isActive) return [];
+
+  return [
+    {
+      id: row.id,
+      mode: row.mode,
+      priority: row.priority,
+      rules: row.rules as SoftwarePolicyRulesDefinition,
+    },
+  ];
+}

--- a/apps/api/src/services/softwarePolicyService.ts
+++ b/apps/api/src/services/softwarePolicyService.ts
@@ -6,6 +6,7 @@ import {
   softwareInventory,
   softwarePolicies,
   softwarePolicyAudit,
+  type SoftwarePolicyExecutableRule,
   type SoftwarePolicyRuleDefinition,
   type SoftwarePolicyRulesDefinition,
   type SoftwarePolicyViolation,
@@ -176,10 +177,38 @@ export function normalizeSoftwarePolicyRules(rules: unknown): SoftwarePolicyRule
     })
     .filter((entry): entry is SoftwarePolicyRuleDefinition => entry !== null);
 
-  return {
+  const rawExecutable = Array.isArray(raw.executable) ? raw.executable : [];
+  const executable = rawExecutable
+    .filter((entry): entry is Record<string, unknown> => !!entry && typeof entry === 'object')
+    .map((entry) => {
+      const name = readOptionalString(entry.name);
+      if (!name) {
+        return null;
+      }
+
+      const rule: SoftwarePolicyExecutableRule = { name };
+      const sha256 = readOptionalString(entry.sha256);
+      const signer = readOptionalString(entry.signer);
+      const publisher = readOptionalString(entry.publisher);
+      const pathGlob = readOptionalString(entry.pathGlob);
+
+      if (sha256) rule.sha256 = sha256;
+      if (signer) rule.signer = signer;
+      if (publisher) rule.publisher = publisher;
+      if (pathGlob) rule.pathGlob = pathGlob;
+
+      return rule;
+    })
+    .filter((entry): entry is SoftwarePolicyExecutableRule => entry !== null);
+
+  const result: SoftwarePolicyRulesDefinition = {
     software,
     allowUnknown: raw.allowUnknown === true,
   };
+  if (executable.length > 0) {
+    result.executable = executable;
+  }
+  return result;
 }
 
 export function matchesSoftwareRule(


### PR DESCRIPTION
## Summary
Pure-lookup bridge: PAM elevation request → check `software_policies` first → verdict `{allowlist | blocklist | null}` + matched `policyId`.

Per Discussion #858 / project board Track 2.

## Design
- Reads `rules.executable[]` (NEW optional field on `SoftwarePolicyRulesDefinition`) — parallel to `rules.software[]` for inventory matchers; zero risk of crossover
- Match precedence: hash > signer > publisher > path (`FIELD_PRECEDENCE` + numeric `priority` tiebreaker)
- Blocklist always wins (security default)
- Audit-mode hits collected into `verdict.auditMatches[]` even on binding verdicts
- Uses existing `resolveSoftwarePolicyForDevice` from `featureConfigResolver.ts:622` (full assignment-level support: partner / organization / site / device_group / device)
- RLS-respecting via `withDbAccessContext`; partner cannot leak across orgs

## Test plan
- [x] tsc clean (api/web/shared)
- [x] `pamBridge.test.ts`: 22/22 pass (precedence, mode tiebreaker, audit-mode, RLS, Adobe canonical trace)
- [x] `softwarePolicyService.test.ts`: 15/15 pass (no regression from passthrough parser)

## Depends on
- #905 for the schema (`software_policy_match_id` FK target; caller will use this)
- Bridge can land independently — it has no call site at merge time, but is fully tested as a leaf module