### PR TITLE
feat(agent): offline PAM rule cache (Discussion #858 Track 7)

### DIFF
--- a/agent/internal/pam/cache.go
+++ b/agent/internal/pam/cache.go
@@ -1,0 +1,326 @@
+// Package pam provides the agent-side rule cache for the PAM (Privileged Access
+// Management) rule engine. The cache lets the agent enforce PAM rules while
+// offline from the Breeze API.
+//
+// File layout (uses config.GetDataDir under the hood):
+//
+//	Windows:  %ProgramData%\Breeze\data\pam-rules.json
+//	Linux:    /var/lib/breeze/pam-rules.json
+//	macOS:    /Library/Application Support/Breeze/data/pam-rules.json
+//
+// The file is an HMAC-SHA256-authenticated JSON envelope. The rule body itself
+// is opaque to this package (json.RawMessage) — the actual rule schema is
+// defined by the rule engine (separate PR, not in this track).
+//
+// Tampering with the file on disk is detected via the HMAC. Read-only-to-SYSTEM
+// NTFS ACLs on Windows raise the bar further, but the HMAC is the
+// authoritative trust boundary.
+package pam
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/config"
+)
+
+// FormatVersion is the on-disk envelope schema version. Bump on any breaking
+// envelope change. The rule body (Rules) is versioned independently by the
+// rule engine.
+const FormatVersion = 1
+
+// StaleAfter is the duration after which a cached ruleset is considered stale
+// for alerting purposes. Load returns ErrStale once SyncedAt + StaleAfter is in
+// the past; callers may keep using the rules anyway (fail-closed) but should
+// raise an alert.
+const StaleAfter = 24 * time.Hour
+
+// RefuseAfter is the hard upper bound. Once a cached ruleset is older than
+// RefuseAfter, Load returns (nil, ErrRefuseStale) and refuses to hand back the
+// envelope at all. The cache is too far out of sync with the server to be
+// safely enforceable; the caller must either re-sync or fail-closed at the
+// policy layer (block everything) rather than enforce ancient rules.
+const RefuseAfter = 7 * 24 * time.Hour
+
+// ErrCacheMissing is returned by Load when the cache file does not exist.
+var ErrCacheMissing = errors.New("pam: cache file missing")
+
+// ErrCorrupt is returned by Load when the JSON envelope cannot be parsed or
+// required fields are missing/zero. Callers should treat this the same as
+// ErrCacheMissing and request a full re-sync from the server.
+var ErrCorrupt = errors.New("pam: cache envelope corrupt")
+
+// ErrHMACMismatch is returned by Verify (and Load on error path) when the
+// stored MAC does not match the recomputed MAC. Indicates tampering or HMAC-key
+// drift; callers MUST NOT trust the rule body.
+var ErrHMACMismatch = errors.New("pam: HMAC mismatch")
+
+// ErrStale is returned by Load when the cache is older than StaleAfter but
+// still within RefuseAfter. The returned *Envelope is still valid (HMAC was
+// checked) — this is a signal to alert the user, not to discard the rules.
+var ErrStale = errors.New("pam: cache stale")
+
+// ErrRefuseStale is returned by Load when the cache is older than RefuseAfter.
+// The returned envelope is nil — the cache is too old to be trusted for
+// enforcement and callers must re-sync or fail-closed.
+var ErrRefuseStale = errors.New("pam: cache exceeds RefuseAfter, refusing to enforce")
+
+// Envelope is the on-disk format. Field order is significant only for human
+// readability — the HMAC is computed over the canonical JSON of the inner
+// SignedFields, NOT over the whole envelope serialization, so field reordering
+// during round-trip cannot break verification.
+type Envelope struct {
+	// Version is the envelope schema version (currently 1). A loader sees a
+	// version it doesn't understand → returns ErrCorrupt.
+	Version int `json:"version"`
+
+	// SignedFields holds everything covered by the MAC. Kept as a nested
+	// struct (not flattened) so the MAC computation has one well-defined
+	// JSON shape independent of envelope-level fields added later.
+	SignedFields SignedFields `json:"signed"`
+
+	// MAC is hex(HMAC-SHA256(key, canonical-json(SignedFields))).
+	MAC string `json:"mac"`
+}
+
+// SignedFields is the portion of the envelope covered by the HMAC.
+type SignedFields struct {
+	// RulesetID identifies the server-side ruleset revision this cache
+	// represents. Opaque string; server-assigned (e.g. ULID or short hash).
+	// Empty string is invalid → ErrCorrupt.
+	RulesetID string `json:"ruleset_id"`
+
+	// SyncedAt is when the agent last received this ruleset from the server.
+	// Used for staleness alerting. UTC, RFC3339 in JSON.
+	SyncedAt time.Time `json:"synced_at"`
+
+	// Rules is the opaque rule body. The rule engine (separate PR) is the
+	// only consumer that understands its shape. Keeping it as RawMessage
+	// here means this package never has to change when the rule schema does.
+	Rules json.RawMessage `json:"rules"`
+}
+
+// Save writes env to path atomically and applies tight ACLs on Windows.
+// It computes (or overwrites) env.MAC using key.
+//
+// Atomicity follows the same pattern as agent.yaml SaveTo
+// (agent/internal/config/config.go:519 `atomicWriteFile`):
+// write to "<path>.partial" → fsync → rename. On power loss the destination
+// either holds the previous good copy or nothing — never a torn write.
+func Save(path string, env *Envelope, key []byte) error {
+	if env == nil {
+		return errors.New("pam: nil envelope")
+	}
+	if env.SignedFields.RulesetID == "" {
+		return errors.New("pam: empty ruleset_id")
+	}
+	if env.SignedFields.SyncedAt.IsZero() {
+		return errors.New("pam: zero SyncedAt")
+	}
+	if len(key) == 0 {
+		return errors.New("pam: empty HMAC key")
+	}
+	if env.Version == 0 {
+		env.Version = FormatVersion
+	}
+
+	mac, err := computeMAC(&env.SignedFields, key)
+	if err != nil {
+		return fmt.Errorf("pam: compute MAC: %w", err)
+	}
+	env.MAC = mac
+
+	// Compact marshal (no MarshalIndent): keeps the on-disk byte form stable
+	// across round-trips and matches the compact form used when computing the
+	// MAC over SignedFields. A pretty-printed file would still verify
+	// correctly (the MAC is over the inner signed struct, not the file bytes)
+	// but it makes diffing the file by hand harder for no real benefit — the
+	// cache is machine-only.
+	data, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("pam: marshal envelope: %w", err)
+	}
+
+	// Make sure the parent dir exists with restrictive perms before writing.
+	// On Windows, applyCacheACL (cache_windows.go) tightens to SYSTEM+Admins
+	// only after the file lands.
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return fmt.Errorf("pam: mkdir %s: %w", dir, err)
+	}
+
+	if err := atomicWriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("pam: atomic write: %w", err)
+	}
+
+	// ACL hardening is best-effort: on Windows we tighten the DACL; on other
+	// platforms applyCacheACL is a no-op (Chmod already happened via perm bits).
+	if err := applyCacheACL(path); err != nil {
+		// Don't fail the Save — file is written, MAC protects integrity.
+		// Caller can log the warning.
+		return fmt.Errorf("pam: apply ACL (file written): %w", err)
+	}
+	return nil
+}
+
+// Load reads the cache from path and verifies its HMAC against key.
+//
+// Returns:
+//   - (nil, ErrCacheMissing)   — file does not exist
+//   - (nil, ErrCorrupt)        — JSON parse failure or missing required fields
+//   - (nil, ErrHMACMismatch)   — MAC verification failed
+//   - (nil, ErrRefuseStale)    — verified but older than RefuseAfter (7d)
+//   - (env, ErrStale)          — verified but older than StaleAfter (24h)
+//   - (env, nil)               — verified and fresh
+//
+// On ErrStale the returned envelope is still usable; the caller decides
+// whether to enforce stale rules or refuse. The PAM design (per Billy) is to
+// keep enforcing while raising an alert — up to RefuseAfter. Past RefuseAfter
+// the cache is withheld entirely (Load returns nil envelope) and the policy
+// layer must fail-closed.
+func Load(path string, key []byte) (*Envelope, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrCacheMissing
+		}
+		return nil, fmt.Errorf("pam: read cache: %w", err)
+	}
+
+	var env Envelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrCorrupt, err)
+	}
+	if env.Version != FormatVersion {
+		return nil, fmt.Errorf("%w: unknown version %d", ErrCorrupt, env.Version)
+	}
+	if env.SignedFields.RulesetID == "" {
+		return nil, fmt.Errorf("%w: empty ruleset_id", ErrCorrupt)
+	}
+	if env.SignedFields.SyncedAt.IsZero() {
+		return nil, fmt.Errorf("%w: zero SyncedAt", ErrCorrupt)
+	}
+	if env.MAC == "" {
+		return nil, fmt.Errorf("%w: empty MAC", ErrCorrupt)
+	}
+
+	if err := verifyMAC(&env, key); err != nil {
+		return nil, err
+	}
+
+	age := time.Since(env.SignedFields.SyncedAt)
+	if age > RefuseAfter {
+		return nil, ErrRefuseStale
+	}
+	if age > StaleAfter {
+		return &env, ErrStale
+	}
+	return &env, nil
+}
+
+// Verify re-checks the MAC on an already-loaded envelope using key. Useful for
+// the staleness alerter or any caller that wants to revalidate without
+// re-reading the file.
+func Verify(env *Envelope, key []byte) error {
+	if env == nil {
+		return errors.New("pam: nil envelope")
+	}
+	return verifyMAC(env, key)
+}
+
+// verifyMAC recomputes the MAC and compares constant-time.
+func verifyMAC(env *Envelope, key []byte) error {
+	if len(key) == 0 {
+		return errors.New("pam: empty HMAC key")
+	}
+	want, err := computeMAC(&env.SignedFields, key)
+	if err != nil {
+		return fmt.Errorf("pam: compute MAC: %w", err)
+	}
+	wantBytes, err := hex.DecodeString(want)
+	if err != nil {
+		return fmt.Errorf("pam: decode computed MAC: %w", err)
+	}
+	gotBytes, err := hex.DecodeString(env.MAC)
+	if err != nil {
+		return fmt.Errorf("%w: invalid hex", ErrHMACMismatch)
+	}
+	if !hmac.Equal(wantBytes, gotBytes) {
+		return ErrHMACMismatch
+	}
+	return nil
+}
+
+// computeMAC computes hex(HMAC-SHA256(key, canonical-json(signed))).
+//
+// "Canonical" here means: encoding/json's default Marshal output for
+// SignedFields with no indentation. Because SignedFields is a struct (not a
+// map), Go's encoder emits fields in struct declaration order deterministically.
+// json.RawMessage is written verbatim — which means the server MUST produce the
+// rules body in a stable byte form, OR the agent must canonicalize it on
+// receive (recommended path: server emits compact JSON, agent stores verbatim,
+// MAC covers exactly what was received).
+//
+// This mirrors the IPC HMAC pattern (agent/internal/ipc/protocol.go:196
+// `computeHMAC`) but uses encoded JSON as the MAC input rather than
+// concatenating fields, because the rule body is variable-shape.
+func computeMAC(signed *SignedFields, key []byte) (string, error) {
+	buf, err := json.Marshal(signed)
+	if err != nil {
+		return "", err
+	}
+	mac := hmac.New(sha256.New, key)
+	mac.Write(buf)
+	return hex.EncodeToString(mac.Sum(nil)), nil
+}
+
+// DefaultPath returns the platform default cache file path. Routes through
+// config.GetDataDir so all platforms land under the same data root the rest
+// of the agent uses (Windows: %ProgramData%\Breeze\data,
+// macOS: /Library/Application Support/Breeze/data, Linux: /var/lib/breeze).
+func DefaultPath() string {
+	return filepath.Join(config.GetDataDir(), "pam-rules.json")
+}
+
+// atomicWriteFile mirrors the pattern at
+// agent/internal/config/config.go:519. Duplicated locally (rather than
+// imported) because the upstream helper is unexported.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	tmp := path + ".partial"
+	_ = os.Remove(tmp)
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	// Best-effort dir fsync; Windows no-ops are expected.
+	if d, derr := os.Open(filepath.Dir(path)); derr == nil {
+		_ = d.Sync()
+		d.Close()
+	}
+	return nil
+}

--- a/agent/internal/pam/cache.go
+++ b/agent/internal/pam/cache.go
@@ -8,6 +8,11 @@
 //	Linux:    /var/lib/breeze/pam-rules.json
 //	macOS:    /Library/Application Support/Breeze/data/pam-rules.json
 //
+// The HMAC key lives in a sibling `keys/` subdir under the same data root
+// (see DefaultKeyPath). Co-locating the key with the cache file would mean a
+// single ACL regression on the data dir exposes both; the separation buys
+// defense in depth.
+//
 // The file is an HMAC-SHA256-authenticated JSON envelope. The rule body itself
 // is opaque to this package (json.RawMessage) — the actual rule schema is
 // defined by the rule engine (separate PR, not in this track).
@@ -15,6 +20,33 @@
 // Tampering with the file on disk is detected via the HMAC. Read-only-to-SYSTEM
 // NTFS ACLs on Windows raise the bar further, but the HMAC is the
 // authoritative trust boundary.
+//
+// # Threat model — cache file vs key co-location
+//
+// The cache envelope and its HMAC key are stored in sibling directories
+// (data/pam-rules.json vs data/keys/pam-rules.key) rather than alongside each
+// other in the same dir. Both paths inherit hardened parent-dir perms today,
+// but if a future change ever loosens the data dir's ACL/perms (e.g. to let
+// the Breeze Helper running as the logged-in user read agent.yaml), the key
+// still sits behind a separately ACL'd subdir (0700 on Unix, SYSTEM+Admins-
+// only DACL on Windows). An attacker who can read the envelope still can't
+// forge a new MAC without also breaching the keys dir.
+//
+// # Threat model — staleness
+//
+// The 7-day refuse-stale gate (RefuseAfter) uses wall-clock time via
+// time.Since(SignedFields.SyncedAt). A local-admin attacker with the ability
+// to roll the system clock back can defeat this gate and keep a stale
+// envelope "fresh" indefinitely. This is acceptable for the threat the gate
+// is designed to catch — "agent forgotten / VPN broken for >7d, rules need
+// to fail closed" — but is NOT a defense against an active local-admin
+// attacker.
+//
+// Defense in depth for the air-gapped-endpoint threat model would require a
+// monotonic "last-seen-fresh" watermark file that only ever moves forward
+// (max(previous, time.Now()) on every successful sync), so that rolling the
+// clock back cannot make the watermark younger. That is out of scope for
+// this PR and tracked as a follow-up.
 package pam
 
 import (

--- a/agent/internal/pam/cache_key.go
+++ b/agent/internal/pam/cache_key.go
@@ -22,10 +22,18 @@ const keyLen = 32
 // without any operator visibility.
 var ErrKeyCorrupt = errors.New("pam: key file corrupt (wrong length)")
 
-// DefaultKeyPath returns the platform default HMAC-key file path. Sits
-// alongside DefaultPath under the agent data dir.
+// DefaultKeyPath returns the platform default HMAC-key file path.
+//
+// Threat model: the key lives under a sibling `keys/` subdir rather than
+// alongside the cache file under GetDataDir() directly. This is defense in
+// depth — if a future regression on the data dir's ACL ever loosens read
+// access to local Users, the key still sits behind a separately ACL'd
+// `keys/` directory (mode 0700 on Unix, SYSTEM+Administrators-only DACL on
+// Windows applied by LoadOrCreateKey via applyCacheACL). An attacker who
+// can read the cache envelope still can't recompute or forge its HMAC
+// without also breaching the keys dir.
 func DefaultKeyPath() string {
-	return filepath.Join(config.GetDataDir(), "pam-rules.key")
+	return filepath.Join(config.GetDataDir(), "keys", "pam-rules.key")
 }
 
 // LoadOrCreateKey returns the HMAC key bytes used to sign the PAM cache
@@ -62,18 +70,29 @@ func LoadOrCreateKey(keyPath string) ([]byte, error) {
 		return nil, fmt.Errorf("pam: generate key: %w", err)
 	}
 
+	// Parent dir gets mode 0700 (Unix) — stricter than the 0750 used for the
+	// data dir itself, because nothing other than the agent process (running
+	// as root) should ever traverse the keys/ subdir.
 	dir := filepath.Dir(keyPath)
-	if err := os.MkdirAll(dir, 0750); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("pam: mkdir %s: %w", dir, err)
+	}
+	// On Windows, also pin the parent dir's DACL to SYSTEM+Administrators
+	// only. SDDL flags are identical to the file-level ACL (no inheritance,
+	// no Users). File-level ACL alone would be sufficient for read
+	// confidentiality of the key bytes, but pinning the dir too means an
+	// attacker can't replace the file via a same-dir rename either.
+	if err := applyCacheACL(dir); err != nil {
+		return nil, fmt.Errorf("pam: apply key dir ACL: %w", err)
 	}
 	if err := atomicWriteFile(keyPath, buf, 0600); err != nil {
 		return nil, fmt.Errorf("pam: write key file: %w", err)
 	}
 	if err := applyCacheACL(keyPath); err != nil {
 		// Key bytes are already on disk; ACL failure on Windows leaves the
-		// file at the parent dir's inherited ACL (typically SYSTEM+Admins
-		// already via the data dir's DACL — see config/permissions_windows.go).
-		// Surface the error so the caller can log it.
+		// file at the parent dir's inherited ACL (which we just tightened
+		// above to SYSTEM+Admins only). Surface the error so the caller can
+		// log it.
 		return nil, fmt.Errorf("pam: apply key ACL (file written): %w", err)
 	}
 	return buf, nil

--- a/agent/internal/pam/cache_key.go
+++ b/agent/internal/pam/cache_key.go
@@ -1,0 +1,80 @@
+package pam
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/breeze-rmm/agent/internal/config"
+)
+
+// keyLen is the HMAC-SHA256 key length. We always generate exactly 32 bytes;
+// loading a file of any other length is an error (treated as corruption).
+const keyLen = 32
+
+// ErrKeyCorrupt is returned by LoadOrCreateKey when the on-disk key file
+// exists but is the wrong length. The caller should treat the cache as
+// unusable (no valid key → MAC always mismatches) and either delete the key
+// file + cache to re-create both, or alert. We do NOT auto-rotate, because
+// silently rotating the key invalidates every existing cached envelope
+// without any operator visibility.
+var ErrKeyCorrupt = errors.New("pam: key file corrupt (wrong length)")
+
+// DefaultKeyPath returns the platform default HMAC-key file path. Sits
+// alongside DefaultPath under the agent data dir.
+func DefaultKeyPath() string {
+	return filepath.Join(config.GetDataDir(), "pam-rules.key")
+}
+
+// LoadOrCreateKey returns the HMAC key bytes used to sign the PAM cache
+// envelope.
+//
+// On first call (file does not exist) it generates 32 bytes from crypto/rand,
+// writes them atomically with 0600 perms (Unix) and SYSTEM+Administrators-only
+// DACL (Windows, via applyCacheACL), and returns the bytes.
+//
+// On subsequent calls it reads the file and returns its contents. A file of
+// any length other than keyLen (32) returns ErrKeyCorrupt — the caller must
+// resolve operator-visibly (delete file → next call regenerates → existing
+// cache envelope becomes ErrHMACMismatch and gets re-synced).
+//
+// The key never leaves the agent host. The server has no copy. That's the
+// whole point: a per-host key means a leaked cache envelope from one machine
+// can't be replayed onto another, and there's no key-distribution channel for
+// an attacker to compromise.
+func LoadOrCreateKey(keyPath string) ([]byte, error) {
+	data, err := os.ReadFile(keyPath)
+	if err == nil {
+		if len(data) != keyLen {
+			return nil, fmt.Errorf("%w: got %d bytes, want %d", ErrKeyCorrupt, len(data), keyLen)
+		}
+		return data, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("pam: read key file: %w", err)
+	}
+
+	// First-run path: generate + persist.
+	buf := make([]byte, keyLen)
+	if _, err := rand.Read(buf); err != nil {
+		return nil, fmt.Errorf("pam: generate key: %w", err)
+	}
+
+	dir := filepath.Dir(keyPath)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return nil, fmt.Errorf("pam: mkdir %s: %w", dir, err)
+	}
+	if err := atomicWriteFile(keyPath, buf, 0600); err != nil {
+		return nil, fmt.Errorf("pam: write key file: %w", err)
+	}
+	if err := applyCacheACL(keyPath); err != nil {
+		// Key bytes are already on disk; ACL failure on Windows leaves the
+		// file at the parent dir's inherited ACL (typically SYSTEM+Admins
+		// already via the data dir's DACL — see config/permissions_windows.go).
+		// Surface the error so the caller can log it.
+		return nil, fmt.Errorf("pam: apply key ACL (file written): %w", err)
+	}
+	return buf, nil
+}

--- a/agent/internal/pam/cache_other.go
+++ b/agent/internal/pam/cache_other.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package pam
+
+// applyCacheACL is a no-op on non-Windows platforms. The 0600 perm bits passed
+// to atomicWriteFile already restrict to the file owner (root, since the agent
+// runs as root via systemd/launchd). Mirrors the pattern at
+// agent/internal/config/permissions_unix.go:1.
+func applyCacheACL(path string) error {
+	return nil
+}

--- a/agent/internal/pam/cache_test.go
+++ b/agent/internal/pam/cache_test.go
@@ -14,6 +14,14 @@ import (
 // MAC is reproducible across runs.
 var testKey = []byte("0123456789abcdef0123456789abcdef")
 
+// testKeyPath mirrors the production layout: cache file under the temp root,
+// HMAC key under a sibling keys/ subdir (matching DefaultKeyPath). Returns
+// the key path; the parent dir is created by LoadOrCreateKey on first use.
+func testKeyPath(t *testing.T, dir string) string {
+	t.Helper()
+	return filepath.Join(dir, "keys", "pam-rules.key")
+}
+
 // newGoodEnvelope returns a fresh, valid envelope (SyncedAt = now).
 func newGoodEnvelope() *Envelope {
 	return &Envelope{
@@ -304,9 +312,10 @@ func TestStaleAfterBoundary(t *testing.T) {
 func TestLoadOrCreateKey(t *testing.T) {
 	t.Run("create then read round-trip", func(t *testing.T) {
 		dir := t.TempDir()
-		keyPath := filepath.Join(dir, "pam-rules.key")
+		keyPath := testKeyPath(t, dir)
 
-		// First call: file does not exist → generate.
+		// First call: file does not exist → generate. Parent dir does not
+		// exist either — LoadOrCreateKey is expected to MkdirAll it.
 		k1, err := LoadOrCreateKey(keyPath)
 		if err != nil {
 			t.Fatalf("LoadOrCreateKey (create): %v", err)
@@ -334,7 +343,11 @@ func TestLoadOrCreateKey(t *testing.T) {
 
 	t.Run("wrong length returns ErrKeyCorrupt", func(t *testing.T) {
 		dir := t.TempDir()
-		keyPath := filepath.Join(dir, "pam-rules.key")
+		keyPath := testKeyPath(t, dir)
+		// Pre-create the parent dir since we're seeding the file directly.
+		if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+			t.Fatalf("seed parent dir: %v", err)
+		}
 		if err := os.WriteFile(keyPath, []byte("too-short"), 0600); err != nil {
 			t.Fatalf("seed short key: %v", err)
 		}
@@ -346,7 +359,7 @@ func TestLoadOrCreateKey(t *testing.T) {
 
 	t.Run("end-to-end with Save/Load", func(t *testing.T) {
 		dir := t.TempDir()
-		keyPath := filepath.Join(dir, "pam-rules.key")
+		keyPath := testKeyPath(t, dir)
 		cachePath := filepath.Join(dir, "pam-rules.json")
 
 		key, err := LoadOrCreateKey(keyPath)

--- a/agent/internal/pam/cache_test.go
+++ b/agent/internal/pam/cache_test.go
@@ -1,0 +1,382 @@
+package pam
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// testKey is a fixed 32-byte HMAC key. Tests must use a constant key so the
+// MAC is reproducible across runs.
+var testKey = []byte("0123456789abcdef0123456789abcdef")
+
+// newGoodEnvelope returns a fresh, valid envelope (SyncedAt = now).
+func newGoodEnvelope() *Envelope {
+	return &Envelope{
+		Version: FormatVersion,
+		SignedFields: SignedFields{
+			RulesetID: "ruleset-abc123",
+			SyncedAt:  time.Now().UTC(),
+			Rules:     json.RawMessage(`{"allow":["powershell.exe"]}`),
+		},
+	}
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pam-rules.json")
+	env := newGoodEnvelope()
+
+	if err := Save(path, env, testKey); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if env.MAC == "" {
+		t.Fatalf("Save did not populate envelope.MAC")
+	}
+
+	got, err := Load(path, testKey)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.SignedFields.RulesetID != env.SignedFields.RulesetID {
+		t.Errorf("RulesetID = %q, want %q",
+			got.SignedFields.RulesetID, env.SignedFields.RulesetID)
+	}
+	if string(got.SignedFields.Rules) != string(env.SignedFields.Rules) {
+		t.Errorf("Rules = %s, want %s",
+			string(got.SignedFields.Rules), string(env.SignedFields.Rules))
+	}
+	if got.MAC != env.MAC {
+		t.Errorf("MAC = %q, want %q", got.MAC, env.MAC)
+	}
+}
+
+func TestLoadErrors(t *testing.T) {
+	// Pre-build a tampered cache file: write a valid one then flip a byte in
+	// the rules body — should still parse as JSON but fail the MAC check.
+	tamperedDir := t.TempDir()
+	tamperedPath := filepath.Join(tamperedDir, "pam-rules.json")
+	{
+		env := newGoodEnvelope()
+		if err := Save(tamperedPath, env, testKey); err != nil {
+			t.Fatalf("setup tampered: Save: %v", err)
+		}
+		raw, err := os.ReadFile(tamperedPath)
+		if err != nil {
+			t.Fatalf("setup tampered: read: %v", err)
+		}
+		// Replace "allow" → "block" inside the Rules body. This re-shapes the
+		// signed bytes without breaking JSON validity.
+		flipped := []byte(strings.Replace(string(raw), `"allow"`, `"block"`, 1))
+		if string(flipped) == string(raw) {
+			t.Fatalf("setup tampered: replacement did not change file")
+		}
+		if err := os.WriteFile(tamperedPath, flipped, 0600); err != nil {
+			t.Fatalf("setup tampered: write: %v", err)
+		}
+	}
+
+	// Stale cache: SyncedAt set 48h ago (past StaleAfter, well within RefuseAfter).
+	staleDir := t.TempDir()
+	stalePath := filepath.Join(staleDir, "pam-rules.json")
+	{
+		env := newGoodEnvelope()
+		env.SignedFields.SyncedAt = time.Now().Add(-48 * time.Hour).UTC()
+		if err := Save(stalePath, env, testKey); err != nil {
+			t.Fatalf("setup stale: Save: %v", err)
+		}
+	}
+
+	// Refuse-stale cache: SyncedAt set 8 days ago (past RefuseAfter).
+	refuseStaleDir := t.TempDir()
+	refuseStalePath := filepath.Join(refuseStaleDir, "pam-rules.json")
+	{
+		env := newGoodEnvelope()
+		env.SignedFields.SyncedAt = time.Now().Add(-8 * 24 * time.Hour).UTC()
+		if err := Save(refuseStalePath, env, testKey); err != nil {
+			t.Fatalf("setup refuse-stale: Save: %v", err)
+		}
+	}
+
+	// Corrupt JSON file.
+	corruptDir := t.TempDir()
+	corruptPath := filepath.Join(corruptDir, "pam-rules.json")
+	if err := os.WriteFile(corruptPath, []byte(`{not json`), 0600); err != nil {
+		t.Fatalf("setup corrupt: %v", err)
+	}
+
+	// Wrong version.
+	wrongVerDir := t.TempDir()
+	wrongVerPath := filepath.Join(wrongVerDir, "pam-rules.json")
+	{
+		env := newGoodEnvelope()
+		env.Version = 999
+		// Compute MAC manually so it passes MAC check and we hit version check
+		// instead. (Save would overwrite Version=999 only if it were 0.)
+		mac, _ := computeMAC(&env.SignedFields, testKey)
+		env.MAC = mac
+		data, _ := json.Marshal(env)
+		if err := os.WriteFile(wrongVerPath, data, 0600); err != nil {
+			t.Fatalf("setup wrong-version: %v", err)
+		}
+	}
+
+	// Empty ruleset_id (corrupt-ish).
+	emptyIDDir := t.TempDir()
+	emptyIDPath := filepath.Join(emptyIDDir, "pam-rules.json")
+	{
+		env := newGoodEnvelope()
+		env.SignedFields.RulesetID = ""
+		mac, _ := computeMAC(&env.SignedFields, testKey)
+		env.Version = FormatVersion
+		env.MAC = mac
+		data, _ := json.Marshal(env)
+		if err := os.WriteFile(emptyIDPath, data, 0600); err != nil {
+			t.Fatalf("setup empty-id: %v", err)
+		}
+	}
+
+	tests := []struct {
+		name      string
+		path      string
+		key       []byte
+		wantErr   error
+		wantEnv   bool // whether Load should return a non-nil envelope
+	}{
+		{
+			name:    "missing file",
+			path:    filepath.Join(t.TempDir(), "nope.json"),
+			key:     testKey,
+			wantErr: ErrCacheMissing,
+		},
+		{
+			name:    "corrupt json",
+			path:    corruptPath,
+			key:     testKey,
+			wantErr: ErrCorrupt,
+		},
+		{
+			name:    "wrong version",
+			path:    wrongVerPath,
+			key:     testKey,
+			wantErr: ErrCorrupt,
+		},
+		{
+			name:    "empty ruleset_id",
+			path:    emptyIDPath,
+			key:     testKey,
+			wantErr: ErrCorrupt,
+		},
+		{
+			name:    "hmac mismatch (tampered rules)",
+			path:    tamperedPath,
+			key:     testKey,
+			wantErr: ErrHMACMismatch,
+		},
+		{
+			name:    "hmac mismatch (wrong key)",
+			path:    stalePath, // a valid file
+			key:     []byte("wrong-key-wrong-key-wrong-key-wr"),
+			wantErr: ErrHMACMismatch,
+		},
+		{
+			name:    "stale returns envelope plus ErrStale",
+			path:    stalePath,
+			key:     testKey,
+			wantErr: ErrStale,
+			wantEnv: true,
+		},
+		{
+			name:    "refuse-stale returns nil plus ErrRefuseStale",
+			path:    refuseStalePath,
+			key:     testKey,
+			wantErr: ErrRefuseStale,
+			wantEnv: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Load(tt.path, tt.key)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Load err = %v, want errors.Is(.., %v)", err, tt.wantErr)
+			}
+			if tt.wantEnv && got == nil {
+				t.Errorf("Load returned nil envelope; expected non-nil for %s", tt.name)
+			}
+			if !tt.wantEnv && got != nil {
+				t.Errorf("Load returned non-nil envelope; expected nil for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestSaveValidation(t *testing.T) {
+	dir := t.TempDir()
+	tests := []struct {
+		name string
+		env  *Envelope
+		key  []byte
+		want string // substring expected in error
+	}{
+		{"nil envelope", nil, testKey, "nil envelope"},
+		{"empty ruleset_id", &Envelope{SignedFields: SignedFields{SyncedAt: time.Now()}}, testKey, "empty ruleset_id"},
+		{"zero SyncedAt", &Envelope{SignedFields: SignedFields{RulesetID: "x"}}, testKey, "zero SyncedAt"},
+		{"empty key", newGoodEnvelope(), nil, "empty HMAC key"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Save(filepath.Join(dir, "x.json"), tt.env, tt.key)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("Save err = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestVerifyStandalone(t *testing.T) {
+	env := newGoodEnvelope()
+	mac, err := computeMAC(&env.SignedFields, testKey)
+	if err != nil {
+		t.Fatalf("computeMAC: %v", err)
+	}
+	env.MAC = mac
+
+	if err := Verify(env, testKey); err != nil {
+		t.Errorf("Verify with correct key: %v", err)
+	}
+	if err := Verify(env, []byte("nope-nope-nope-nope-nope-nope-no")); !errors.Is(err, ErrHMACMismatch) {
+		t.Errorf("Verify with wrong key: err = %v, want ErrHMACMismatch", err)
+	}
+	if err := Verify(nil, testKey); err == nil {
+		t.Errorf("Verify(nil): want error, got nil")
+	}
+}
+
+func TestStaleAfterBoundary(t *testing.T) {
+	// Just under StaleAfter → no ErrStale.
+	// Just over StaleAfter, within RefuseAfter → ErrStale, envelope returned.
+	// Just over RefuseAfter → ErrRefuseStale, nil envelope.
+	dir := t.TempDir()
+	freshPath := filepath.Join(dir, "fresh.json")
+	stalePath := filepath.Join(dir, "stale.json")
+	refusePath := filepath.Join(dir, "refuse.json")
+
+	fresh := newGoodEnvelope()
+	fresh.SignedFields.SyncedAt = time.Now().Add(-StaleAfter + 1*time.Minute).UTC()
+	if err := Save(freshPath, fresh, testKey); err != nil {
+		t.Fatalf("Save fresh: %v", err)
+	}
+	if _, err := Load(freshPath, testKey); err != nil {
+		t.Errorf("Load fresh: err = %v, want nil", err)
+	}
+
+	stale := newGoodEnvelope()
+	stale.SignedFields.SyncedAt = time.Now().Add(-StaleAfter - 1*time.Minute).UTC()
+	if err := Save(stalePath, stale, testKey); err != nil {
+		t.Fatalf("Save stale: %v", err)
+	}
+	got, err := Load(stalePath, testKey)
+	if !errors.Is(err, ErrStale) {
+		t.Errorf("Load stale: err = %v, want ErrStale", err)
+	}
+	if got == nil {
+		t.Errorf("Load stale: envelope = nil, want non-nil (stale-but-usable)")
+	}
+
+	refuse := newGoodEnvelope()
+	refuse.SignedFields.SyncedAt = time.Now().Add(-RefuseAfter - 1*time.Minute).UTC()
+	if err := Save(refusePath, refuse, testKey); err != nil {
+		t.Fatalf("Save refuse: %v", err)
+	}
+	gotRefuse, errRefuse := Load(refusePath, testKey)
+	if !errors.Is(errRefuse, ErrRefuseStale) {
+		t.Errorf("Load refuse: err = %v, want ErrRefuseStale", errRefuse)
+	}
+	if gotRefuse != nil {
+		t.Errorf("Load refuse: envelope = %+v, want nil (refused)", gotRefuse)
+	}
+}
+
+func TestLoadOrCreateKey(t *testing.T) {
+	t.Run("create then read round-trip", func(t *testing.T) {
+		dir := t.TempDir()
+		keyPath := filepath.Join(dir, "pam-rules.key")
+
+		// First call: file does not exist → generate.
+		k1, err := LoadOrCreateKey(keyPath)
+		if err != nil {
+			t.Fatalf("LoadOrCreateKey (create): %v", err)
+		}
+		if len(k1) != 32 {
+			t.Fatalf("created key len = %d, want 32", len(k1))
+		}
+		info, err := os.Stat(keyPath)
+		if err != nil {
+			t.Fatalf("stat key file: %v", err)
+		}
+		if info.Size() != 32 {
+			t.Errorf("key file size = %d, want 32", info.Size())
+		}
+
+		// Second call: file exists → read back identical bytes.
+		k2, err := LoadOrCreateKey(keyPath)
+		if err != nil {
+			t.Fatalf("LoadOrCreateKey (read): %v", err)
+		}
+		if string(k1) != string(k2) {
+			t.Errorf("read-back key differs from created key")
+		}
+	})
+
+	t.Run("wrong length returns ErrKeyCorrupt", func(t *testing.T) {
+		dir := t.TempDir()
+		keyPath := filepath.Join(dir, "pam-rules.key")
+		if err := os.WriteFile(keyPath, []byte("too-short"), 0600); err != nil {
+			t.Fatalf("seed short key: %v", err)
+		}
+		_, err := LoadOrCreateKey(keyPath)
+		if !errors.Is(err, ErrKeyCorrupt) {
+			t.Errorf("err = %v, want ErrKeyCorrupt", err)
+		}
+	})
+
+	t.Run("end-to-end with Save/Load", func(t *testing.T) {
+		dir := t.TempDir()
+		keyPath := filepath.Join(dir, "pam-rules.key")
+		cachePath := filepath.Join(dir, "pam-rules.json")
+
+		key, err := LoadOrCreateKey(keyPath)
+		if err != nil {
+			t.Fatalf("LoadOrCreateKey: %v", err)
+		}
+		env := newGoodEnvelope()
+		if err := Save(cachePath, env, key); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+		if _, err := Load(cachePath, key); err != nil {
+			t.Errorf("Load with managed key: %v", err)
+		}
+	})
+}
+
+func TestAtomicWriteLeavesNoPartialFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pam-rules.json")
+	env := newGoodEnvelope()
+	if err := Save(path, env, testKey); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".partial") {
+			t.Errorf("leftover partial file: %s", e.Name())
+		}
+	}
+}

--- a/agent/internal/pam/cache_windows.go
+++ b/agent/internal/pam/cache_windows.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+package pam
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+// cacheFileSDDL: SYSTEM and BUILTIN\Administrators get full access; no
+// inheritance, no other principals. Matches the windowsConfigFileSDDL pattern
+// at agent/internal/config/permissions_windows.go:13.
+//
+// Format: D:P(A;;FA;;;SY)(A;;FA;;;BA)
+//   D:P        — discretionary ACL, protected (no inheritance from parent)
+//   (A;;FA;;;SY) — Allow / no flags / Full Access / SYSTEM
+//   (A;;FA;;;BA) — Allow / no flags / Full Access / BUILTIN\Administrators
+//
+// Deliberately omits BUILTIN\Users (BU) because the IPC helper and the rule
+// engine both run as SYSTEM. A logged-in user has no business reading PAM rules
+// on disk — those would leak the enforcement policy.
+const cacheFileSDDL = `D:P(A;;FA;;;SY)(A;;FA;;;BA)`
+
+// applyCacheACL pins the file's DACL to SYSTEM+Admins only. Same call shape as
+// applyWindowsDACL at agent/internal/config/permissions_windows.go:28.
+func applyCacheACL(path string) error {
+	sd, err := windows.SecurityDescriptorFromString(cacheFileSDDL)
+	if err != nil {
+		return fmt.Errorf("pam: parse cache DACL: %w", err)
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil {
+		return fmt.Errorf("pam: extract cache DACL: %w", err)
+	}
+	if err := windows.SetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		dacl,
+		nil,
+	); err != nil {
+		return fmt.Errorf("pam: set DACL on %s: %w", path, err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
Agent-side offline rule cache for PAM. HMAC-SHA256-signed JSON envelope, 24h staleness alert + 7-day enforcement refusal.

Per Discussion #858 / project board Track 7. Smallest standalone unit — no call site yet, agent leaf package.

## Design
- File: `config.GetDataDir() + "/pam-rules.json"` (matches `change_tracker_snapshot.json` pattern at `heartbeat.go:277`)
- Key: 32-byte random key managed by package (`LoadOrCreateKey(DefaultKeyPath())`). No external crypto deps beyond stdlib + existing `golang.org/x/sys/windows`.
- MAC scope covers `json.Marshal(signed)` not literal bytes (pretty-print + envelope-additions friendly; Go json determinism since 1.12 makes this safe)
- Two-tier staleness: `StaleAfter = 24h` → returns envelope + `ErrStale` (alert); `RefuseAfter = 7d` → returns nil + `ErrRefuseStale` (refuse to enforce)
- Windows DACL via `SetNamedSecurityInfo` (SYSTEM + Administrators only, no Users) — mirrors `permissions_windows.go:28`
- Atomic write reuses `agent/internal/config/config.go:519` pattern

## Test plan
- [x] `go vet ./internal/pam/` clean
- [x] `GOOS=linux go build` clean
- [x] `GOOS=windows go build` clean
- [x] `go test -race -count=1`: 8 top-level tests + 16 subtests, all PASS

## Related
- Schema (Track 1): #905
- Bridge (Track 2): #906
- Wire-up surface (heartbeat extension, agent boot-time Load, staleness alerter) is OUT OF SCOPE for this PR — needs follow-up.