### PR TITLE
fix(docker): pin api/web images to Node 24 LTS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -188,11 +188,16 @@ updates:
       - "toddhebebrand"
 
   # Docker base images for workspace Dockerfiles
+  # Node base is pinned to an LTS major (oidc-provider rejects non-LTS); allow
+  # minor/patch + digest updates only.
   - package-ecosystem: "docker"
     directory: "/apps/api"
     schedule:
       interval: "weekly"
       day: "monday"
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
       - "docker"
@@ -204,6 +209,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
       - "docker"
@@ -216,6 +224,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
       - "docker"

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================
 
 # Stage 1: Base image with pnpm
-FROM node:26-alpine@sha256:7c6af15abe4e3de859690e7db171d0d711bf37d27528eddfe625b2fe89e097f8 AS base
+FROM node:24-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS base
 RUN npm install -g pnpm@10.33.4
 RUN apk add --no-cache libc6-compat python3 make g++
 WORKDIR /app
@@ -42,7 +42,7 @@ WORKDIR /app/apps/api
 RUN pnpm build
 
 # Stage 4: Production runner
-FROM node:26-alpine@sha256:7c6af15abe4e3de859690e7db171d0d711bf37d27528eddfe625b2fe89e097f8 AS runner
+FROM node:24-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS runner
 WORKDIR /app
 
 # Install wget for healthcheck

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================
 
 # Stage 1: Base image with pnpm
-FROM node:26-alpine@sha256:7c6af15abe4e3de859690e7db171d0d711bf37d27528eddfe625b2fe89e097f8 AS base
+FROM node:24-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS base
 RUN npm install -g pnpm@10.33.4
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
@@ -48,7 +48,7 @@ WORKDIR /app/apps/web
 RUN pnpm build
 
 # Stage 4: Production runner
-FROM node:26-alpine@sha256:7c6af15abe4e3de859690e7db171d0d711bf37d27528eddfe625b2fe89e097f8 AS runner
+FROM node:24-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS runner
 WORKDIR /app
 
 # Install wget for healthcheck

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM node:26-alpine@sha256:7c6af15abe4e3de859690e7db171d0d711bf37d27528eddfe625b2fe89e097f8 AS base
+FROM node:24-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS base
 RUN npm install -g pnpm@10.33.4
 
 FROM base AS deps

--- a/docker/Dockerfile.api.dev
+++ b/docker/Dockerfile.api.dev
@@ -1,5 +1,5 @@
 # Development Dockerfile for API with hot-reloading
-FROM node:26-alpine
+FROM node:24-alpine
 
 # Install pnpm (pinned to match prod / packageManager field)
 RUN npm install -g pnpm@10.33.4

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -1,4 +1,4 @@
-FROM node:26-alpine@sha256:7c6af15abe4e3de859690e7db171d0d711bf37d27528eddfe625b2fe89e097f8 AS base
+FROM node:24-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS base
 RUN npm install -g pnpm@10.33.4
 
 FROM base AS deps

--- a/docker/Dockerfile.web.dev
+++ b/docker/Dockerfile.web.dev
@@ -1,5 +1,5 @@
 # Development Dockerfile for Web with hot-reloading
-FROM node:26-alpine
+FROM node:24-alpine
 
 # Install pnpm (pinned to match prod / packageManager field)
 RUN npm install -g pnpm@10.33.4


### PR DESCRIPTION
## Summary

Reported by **@SemoTech** in Discord against the self-hosted `:latest` image:

> `oidc-provider WARNING: Unsupported runtime. Use Node.js v22.x LTS, or a later LTS release.`

**Root cause:** Dependabot PRs #666, #667, #668 bumped the base image from `node:22-alpine` → `node:26-alpine`. Node 26.x is the **Current** release line, not LTS. `oidc-provider@9.8.3` checks `process.release.lts` against `Jod` (Node 22) — `process.release.lts` is `undefined` on Current builds, so the warning fires every boot. See [`oidc-provider/lib/index.js`](https://github.com/panva/node-oidc-provider/blob/v9.8.3/lib/index.js#L7-L11).

**Fix:**
- Pin all 4 Dockerfiles (api, web, plus the two `.dev` variants) to `node:24-alpine` — current Active LTS (Krypton).
- Multi-arch digest: `sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14` (linux/amd64 + linux/arm64).
- Add `ignore: ["version-update:semver-major"]` for `dependency-name: node` on each Docker Dependabot block so future bumps stay within an LTS major (still allows digest + minor/patch updates).
- `npm install -g pnpm@10.33.4` continues to work on Node 24 (no need to revert to corepack — keeps diff minimal vs. #675).

CI already runs on Node 22 (also LTS), so no workflow changes needed.

## Test plan

- [ ] `docker compose -f docker-compose.yml -f docker-compose.override.yml.local-build up --build -d` succeeds and API container starts without the `oidc-provider WARNING: Unsupported runtime` line.
- [ ] `docker exec breeze-api node -p "process.release.lts"` prints `Krypton`.
- [ ] CI (api/web image builds) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)