### PR TITLE
security: SSRF allowlists + MFA-gate admin/suspend + provision auth fail-closed

### DIFF
--- a/apps/api/src/routes/admin/abuse.test.ts
+++ b/apps/api/src/routes/admin/abuse.test.ts
@@ -237,7 +237,7 @@ describe('admin/abuse — auth gate', () => {
     const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ reason: 'long enough reason here' }),
+      body: JSON.stringify({ confirmEmail: 'admin@breeze.test', reason: 'long enough reason here' }),
     });
     expect(res.status).toBe(403);
     expect(createAuditLog).not.toHaveBeenCalled();
@@ -249,7 +249,7 @@ describe('admin/abuse — auth gate', () => {
     const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ reason: 'long enough reason here' }),
+      body: JSON.stringify({ confirmEmail: 'admin@breeze.test', reason: 'long enough reason here' }),
     });
     expect(res.status).toBe(403);
   });
@@ -259,9 +259,36 @@ describe('admin/abuse — auth gate', () => {
     const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ reason: 'short' }),
+      body: JSON.stringify({ confirmEmail: 'admin@breeze.test', reason: 'short' }),
     });
     expect(res.status).toBe(400);
+  });
+
+  it('400s when confirmEmail is missing (anti-typo gate)', async () => {
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'cross-region account farming detected' }),
+    });
+    expect(res.status).toBe(400);
+    expect(revokeAllUserTokens).not.toHaveBeenCalled();
+  });
+
+  it('400s when confirmEmail does not match the caller account', async () => {
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        confirmEmail: 'someone-else@breeze.test',
+        reason: 'cross-region account farming detected',
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('confirmEmail');
+    expect(revokeAllUserTokens).not.toHaveBeenCalled();
   });
 
   it('platform admin gate is enforced on /unsuspend as well', async () => {
@@ -281,7 +308,7 @@ describe('admin/abuse — auth gate', () => {
     const res = await app.request('/admin/partners/missing/suspend-for-abuse', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ reason: 'this is a long enough reason' }),
+      body: JSON.stringify({ confirmEmail: 'admin@breeze.test', reason: 'this is a long enough reason' }),
     });
     expect(res.status).toBe(404);
     const body = (await res.json()) as { error: string };
@@ -313,7 +340,7 @@ describe('admin/abuse — suspend mutation behavior', () => {
     const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ reason: 'cross-region account farming detected' }),
+      body: JSON.stringify({ confirmEmail: 'admin@breeze.test', reason: 'cross-region account farming detected' }),
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -381,7 +408,7 @@ describe('admin/abuse — suspend mutation behavior', () => {
     const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ reason: 'self-suspend prevention test case' }),
+      body: JSON.stringify({ confirmEmail: 'admin@breeze.test', reason: 'self-suspend prevention test case' }),
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as { userCount: number };
@@ -400,7 +427,7 @@ describe('admin/abuse — suspend mutation behavior', () => {
     const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ reason: 'redis-down silent failure regression' }),
+      body: JSON.stringify({ confirmEmail: 'admin@breeze.test', reason: 'redis-down silent failure regression' }),
     });
     expect(res.status).toBe(500);
     const body = (await res.json()) as {
@@ -426,7 +453,7 @@ describe('admin/abuse — suspend mutation behavior', () => {
     const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ reason: 'audit failure must not undo suspend' }),
+      body: JSON.stringify({ confirmEmail: 'admin@breeze.test', reason: 'audit failure must not undo suspend' }),
     });
     // Suspend committed, JWTs revoked — losing the audit row is recoverable.
     // We still report success so the operator UI doesn't go red on something
@@ -449,7 +476,7 @@ describe('admin/abuse — suspend mutation behavior', () => {
     const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ reason: 'oauth revocation regression coverage' }),
+      body: JSON.stringify({ confirmEmail: 'admin@breeze.test', reason: 'oauth revocation regression coverage' }),
     });
     expect(res.status).toBe(200);
 
@@ -478,7 +505,7 @@ describe('admin/abuse — suspend mutation behavior', () => {
     const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ reason: 'redis-down oauth revocation regression' }),
+      body: JSON.stringify({ confirmEmail: 'admin@breeze.test', reason: 'redis-down oauth revocation regression' }),
     });
     expect(res.status).toBe(500);
     const body = (await res.json()) as {
@@ -506,7 +533,7 @@ describe('admin/abuse — suspend mutation behavior', () => {
     const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ reason: 'oauth-only revocation path coverage' }),
+      body: JSON.stringify({ confirmEmail: 'admin@breeze.test', reason: 'oauth-only revocation path coverage' }),
     });
     expect(res.status).toBe(200);
 

--- a/apps/api/src/routes/admin/abuse.ts
+++ b/apps/api/src/routes/admin/abuse.ts
@@ -17,8 +17,19 @@ import { revokeAllUserTokens } from '../../services/tokenRevocation';
 import { revokeAllPartnerOauthArtifacts } from '../../oauth/grantRevocation';
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
 import { captureException } from '../../services/sentry';
+import { requireMfa } from '../../middleware/auth';
 
 export const abuseRoutes = new Hono();
+
+// confirmEmail must match the caller's account email on suspend — same
+// anti-typo gate as POST /admin/tenant-erasure. Suspend queues
+// self_uninstall on every device under the partner; re-enrollment from
+// scratch is the only recovery path, so a fat-finger on /partners/:id
+// is catastrophic. Unsuspend is reversible — only the reason matters.
+const suspendSchema = z.object({
+  confirmEmail: z.string().email(),
+  reason: z.string().trim().min(10, 'reason must be at least 10 characters'),
+});
 
 const reasonSchema = z.object({
   reason: z.string().trim().min(10, 'reason must be at least 10 characters'),
@@ -26,11 +37,18 @@ const reasonSchema = z.object({
 
 abuseRoutes.post(
   '/partners/:id/suspend-for-abuse',
-  zValidator('json', reasonSchema),
+  requireMfa(),
+  zValidator('json', suspendSchema),
   async (c) => {
-    const partnerId = c.req.param('id');
-    const { reason } = c.req.valid('json');
     const auth = c.get('auth');
+    const { reason, confirmEmail } = c.req.valid('json');
+    if (confirmEmail.trim().toLowerCase() !== auth.user.email.trim().toLowerCase()) {
+      return c.json(
+        { error: 'confirmEmail must match your account email' },
+        400,
+      );
+    }
+    const partnerId = c.req.param('id');
     const callerId = auth.user.id;
 
     const result = await withSystemDbAccessContext(async () => {

--- a/apps/api/src/routes/devices/provision.ts
+++ b/apps/api/src/routes/devices/provision.ts
@@ -59,7 +59,10 @@ provisionRoutes.post(
     const data = c.req.valid('json');
 
     // ----------- auth: caller must be able to see the target org -----------
-    if (typeof auth.canAccessOrg === 'function' && !auth.canAccessOrg(data.orgId)) {
+    // canAccessOrg is always populated by authMiddleware; the prior `typeof
+    // === 'function'` guard silently fell open if it were ever missing. We
+    // require it to be present and use it directly — fail-closed instead.
+    if (!auth.canAccessOrg(data.orgId)) {
       return c.json({ error: 'Caller does not have access to target organization' }, 403);
     }
 

--- a/apps/api/src/routes/dnsSecurity.test.ts
+++ b/apps/api/src/routes/dnsSecurity.test.ts
@@ -138,4 +138,70 @@ describe('dns security routes', () => {
 
     expect(res.status).toBe(403);
   });
+
+  it('rejects pihole apiEndpoint pointing at cloud-metadata (SSRF)', async () => {
+    const res = await app.request('/dns-security/integrations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        provider: 'pihole',
+        name: 'Pi-hole',
+        apiKey: 'api-key-123',
+        config: { apiEndpoint: 'http://169.254.169.254/admin' }
+      })
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects adguard_home apiEndpoint pointing at loopback (SSRF)', async () => {
+    const res = await app.request('/dns-security/integrations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        provider: 'adguard_home',
+        name: 'AdGuard Home',
+        apiKey: 'admin',
+        apiSecret: 'pw',
+        config: { apiEndpoint: 'http://127.0.0.1:3000' }
+      })
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects cloudflare apiEndpoint pointing off the cloudflare.com allowlist (SSRF)', async () => {
+    const res = await app.request('/dns-security/integrations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        provider: 'cloudflare',
+        name: 'Cloudflare DNS',
+        apiKey: 'api-key-123',
+        config: { accountId: 'acct-123', apiEndpoint: 'https://internal-vault.cluster.local/' }
+      })
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts pihole apiEndpoint on RFC1918 (legitimate on-prem)', async () => {
+    // We don't expect this to succeed end-to-end (the DB insert isn't mocked
+    // here) — just that validation doesn't reject the URL as SSRF.
+    const res = await app.request('/dns-security/integrations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        provider: 'pihole',
+        name: 'Pi-hole',
+        apiKey: 'api-key-123',
+        config: { apiEndpoint: 'http://192.168.1.50' }
+      })
+    });
+
+    // Anything other than 400 means the URL passed validation. The downstream
+    // DB layer isn't mocked, so a 500 is also acceptable here — the assertion
+    // is that we didn't reject at validation time.
+    expect(res.status).not.toBe(400);
+  });
 });

--- a/apps/api/src/routes/dnsSecurity.ts
+++ b/apps/api/src/routes/dnsSecurity.ts
@@ -21,6 +21,23 @@ import { scheduleDnsEventSync, schedulePolicySync } from '../jobs/dnsSyncJob';
 import { writeRouteAudit } from '../services/auditEvents';
 import { encryptSecret } from '../services/secretCrypto';
 import { PERMISSIONS } from '../services/permissions';
+import { checkSsrfSafe, type SsrfMode } from '../services/ssrfGuard';
+
+// Per-provider URL guard mode.
+//
+// - umbrella / cloudflare / dnsfilter accept apiEndpoint mostly as a no-op
+//   (they default to a known vendor URL) but a malicious override should
+//   still be vendor-shaped + HTTPS-only.
+// - pihole / adguard_home are on-prem appliances and tenants legitimately
+//   point them at RFC1918 addresses. We still block loopback/link-local/
+//   metadata to prevent self-targeting the API container.
+const SSRF_MODE_BY_PROVIDER: Record<string, { mode: SsrfMode; allowlist?: readonly string[] }> = {
+  umbrella: { mode: 'strict-https', allowlist: ['.umbrella.com', '.opendns.com', '.cisco.com'] },
+  cloudflare: { mode: 'strict-https', allowlist: ['.cloudflare.com'] },
+  dnsfilter: { mode: 'strict-https', allowlist: ['.dnsfilter.com'] },
+  pihole: { mode: 'on-prem-http' },
+  adguard_home: { mode: 'on-prem-http' },
+};
 
 const dnsSecurityRoutes = new Hono();
 
@@ -174,6 +191,26 @@ const createIntegrationSchema = z.object({
         path: ['apiSecret'],
         message: 'apiSecret (HTTP Basic auth password) is required for AdGuard Home'
       });
+    }
+  }
+
+  // SSRF guard — block tenant-supplied URLs that point at loopback,
+  // link-local (cloud metadata), or in strict-mode at private/RFC1918
+  // ranges. Per-provider mode is configured in SSRF_MODE_BY_PROVIDER.
+  if (data.config?.apiEndpoint) {
+    const guard = SSRF_MODE_BY_PROVIDER[data.provider];
+    if (guard) {
+      const result = checkSsrfSafe(data.config.apiEndpoint, {
+        mode: guard.mode,
+        hostnameAllowlist: guard.allowlist,
+      });
+      if (!result.ok) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['config', 'apiEndpoint'],
+          message: `apiEndpoint rejected: ${result.reason}`,
+        });
+      }
     }
   }
 });

--- a/apps/api/src/routes/sentinelOne.test.ts
+++ b/apps/api/src/routes/sentinelOne.test.ts
@@ -184,6 +184,34 @@ describe('sentinel one routes', () => {
     expect(res.status).toBe(400);
   });
 
+  it('rejects management URLs not on the sentinelone.net allowlist (SSRF)', async () => {
+    const res = await app.request('/s1/integration', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'SentinelOne Prod',
+        managementUrl: 'https://internal-vault.cluster.local/',
+        apiToken: 'token'
+      })
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects management URLs pointing at cloud-metadata (SSRF)', async () => {
+    const res = await app.request('/s1/integration', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'SentinelOne Prod',
+        managementUrl: 'https://169.254.169.254/latest/meta-data/',
+        apiToken: 'token'
+      })
+    });
+
+    expect(res.status).toBe(400);
+  });
+
   it('requires token re-entry when changing the SentinelOne management host', async () => {
     vi.mocked(db.select).mockReturnValueOnce({
       from: vi.fn(() => ({

--- a/apps/api/src/routes/sentinelOne.ts
+++ b/apps/api/src/routes/sentinelOne.ts
@@ -19,6 +19,12 @@ import {
   getActiveS1IntegrationForOrg
 } from '../services/sentinelOne/actions';
 import { escapeLike } from '../utils/sql';
+import { checkSsrfSafe } from '../services/ssrfGuard';
+
+// SentinelOne deploys as managed SaaS only. Per-tenant management consoles
+// use the .sentinelone.net suffix (e.g. usea1-partners.sentinelone.net).
+// Any tenant-supplied URL pointing elsewhere is treated as SSRF.
+const S1_HOSTNAME_ALLOWLIST = ['.sentinelone.net'] as const;
 
 export const sentinelOneRoutes = new Hono();
 sentinelOneRoutes.use('*', authMiddleware);
@@ -103,13 +109,18 @@ function resolveOrgId(
 const integrationUpsertSchema = z.object({
   orgId: z.string().uuid().optional(),
   name: z.string().min(1).max(200),
-  managementUrl: z.string().url().max(2_000).refine((value) => {
-    try {
-      return new URL(value).protocol === 'https:';
-    } catch {
-      return false;
+  managementUrl: z.string().url().max(2_000).superRefine((value, ctx) => {
+    const result = checkSsrfSafe(value, {
+      mode: 'strict-https',
+      hostnameAllowlist: S1_HOSTNAME_ALLOWLIST,
+    });
+    if (!result.ok) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `managementUrl rejected: ${result.reason}`,
+      });
     }
-  }, { message: 'managementUrl must use HTTPS' }),
+  }),
   apiToken: z.string().max(10_000).optional(),
   isActive: z.boolean().optional()
 });

--- a/apps/api/src/services/ssrfGuard.test.ts
+++ b/apps/api/src/services/ssrfGuard.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import { checkSsrfSafe, isSsrfSafe } from './ssrfGuard';
+
+describe('ssrfGuard', () => {
+  describe('strict-https mode', () => {
+    const opts = { mode: 'strict-https' as const };
+
+    it('accepts a normal public HTTPS URL', () => {
+      expect(checkSsrfSafe('https://api.example.com/v1/things', opts)).toEqual({ ok: true });
+    });
+
+    it('rejects HTTP', () => {
+      expect(isSsrfSafe('http://api.example.com', opts)).toBe(false);
+    });
+
+    it('rejects cloud-metadata IPv4 (AWS / OpenStack)', () => {
+      expect(isSsrfSafe('https://169.254.169.254/latest/meta-data/', opts)).toBe(false);
+    });
+
+    it('rejects cloud-metadata hostname (GCP)', () => {
+      expect(isSsrfSafe('https://metadata.google.internal/computeMetadata/', opts)).toBe(false);
+    });
+
+    it('rejects loopback hostname alias', () => {
+      expect(isSsrfSafe('https://localhost/', opts)).toBe(false);
+    });
+
+    it('rejects 127.0.0.1', () => {
+      expect(isSsrfSafe('https://127.0.0.1/', opts)).toBe(false);
+    });
+
+    it('rejects ::1', () => {
+      expect(isSsrfSafe('https://[::1]/', opts)).toBe(false);
+    });
+
+    it('rejects RFC1918 in strict-https mode', () => {
+      expect(isSsrfSafe('https://10.0.0.5/', opts)).toBe(false);
+      expect(isSsrfSafe('https://192.168.1.1/', opts)).toBe(false);
+      expect(isSsrfSafe('https://172.20.0.1/', opts)).toBe(false);
+    });
+
+    it('rejects CGNAT 100.64.0.0/10', () => {
+      expect(isSsrfSafe('https://100.64.0.5/', opts)).toBe(false);
+    });
+
+    it('rejects IPv6 unique-local fc00::/7', () => {
+      expect(isSsrfSafe('https://[fd00::1]/', opts)).toBe(false);
+    });
+
+    it('rejects IPv4-mapped IPv6 loopback', () => {
+      expect(isSsrfSafe('https://[::ffff:127.0.0.1]/', opts)).toBe(false);
+    });
+
+    it('rejects unparseable URL', () => {
+      expect(isSsrfSafe('not a url', opts)).toBe(false);
+    });
+
+    it('rejects URL with empty hostname (file:// style — caught by scheme check)', () => {
+      expect(isSsrfSafe('https://', opts)).toBe(false);
+    });
+
+    it('rejects non-http(s) schemes', () => {
+      expect(isSsrfSafe('file:///etc/passwd', opts)).toBe(false);
+      expect(isSsrfSafe('gopher://example.com/', opts)).toBe(false);
+    });
+
+    it('rejects ftp scheme', () => {
+      expect(isSsrfSafe('ftp://example.com/', opts)).toBe(false);
+    });
+
+    it('accepts 172.15 (below private range)', () => {
+      expect(isSsrfSafe('https://172.15.0.1/', opts)).toBe(true);
+    });
+
+    it('accepts 172.32 (above private range)', () => {
+      expect(isSsrfSafe('https://172.32.0.1/', opts)).toBe(true);
+    });
+  });
+
+  describe('on-prem-http mode', () => {
+    const opts = { mode: 'on-prem-http' as const };
+
+    it('accepts HTTP', () => {
+      expect(isSsrfSafe('http://pi-hole.lan/admin/', opts)).toBe(true);
+    });
+
+    it('accepts HTTPS', () => {
+      expect(isSsrfSafe('https://adguard.example.com/', opts)).toBe(true);
+    });
+
+    it('accepts RFC1918 (on-prem appliances live there)', () => {
+      expect(isSsrfSafe('http://192.168.1.50/', opts)).toBe(true);
+      expect(isSsrfSafe('http://10.0.0.5/', opts)).toBe(true);
+      expect(isSsrfSafe('http://172.20.0.1/', opts)).toBe(true);
+    });
+
+    it('still rejects loopback', () => {
+      expect(isSsrfSafe('http://127.0.0.1/', opts)).toBe(false);
+      expect(isSsrfSafe('http://localhost/', opts)).toBe(false);
+    });
+
+    it('still rejects link-local / metadata', () => {
+      expect(isSsrfSafe('http://169.254.169.254/', opts)).toBe(false);
+    });
+  });
+
+  describe('on-prem-strict mode', () => {
+    const opts = { mode: 'on-prem-strict' as const };
+
+    it('accepts a public HTTP host (on-prem appliance reachable over WAN)', () => {
+      expect(isSsrfSafe('http://adguard.public.example.com/', opts)).toBe(true);
+    });
+
+    it('rejects RFC1918 (hosted-saas can\'t reach customer LAN)', () => {
+      expect(isSsrfSafe('http://192.168.1.50/', opts)).toBe(false);
+    });
+
+    it('rejects loopback / link-local same as the other modes', () => {
+      expect(isSsrfSafe('http://127.0.0.1/', opts)).toBe(false);
+      expect(isSsrfSafe('http://169.254.169.254/', opts)).toBe(false);
+    });
+  });
+
+  describe('hostnameAllowlist', () => {
+    it('accepts hostname ending with allowed suffix', () => {
+      expect(
+        isSsrfSafe('https://usea1-partners.sentinelone.net/web/api', {
+          mode: 'strict-https',
+          hostnameAllowlist: ['.sentinelone.net'],
+        })
+      ).toBe(true);
+    });
+
+    it('rejects hostname not on allowlist even if public + HTTPS', () => {
+      expect(
+        isSsrfSafe('https://internal-vault.cluster.example.com/', {
+          mode: 'strict-https',
+          hostnameAllowlist: ['.sentinelone.net'],
+        })
+      ).toBe(false);
+    });
+
+    it('rejects subdomain match without the leading dot guard (no .sentinel.one match)', () => {
+      expect(
+        isSsrfSafe('https://attacker-sentinelone.net.evil.com/', {
+          mode: 'strict-https',
+          hostnameAllowlist: ['.sentinelone.net'],
+        })
+      ).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/services/ssrfGuard.ts
+++ b/apps/api/src/services/ssrfGuard.ts
@@ -1,0 +1,174 @@
+// Block tenant-controlled URLs from reaching internal/metadata addresses.
+//
+// Tenants can configure external integrations (DNS providers, SentinelOne)
+// with their own API endpoints. Without validation, a partner-scope user
+// could point an integration at http://169.254.169.254/ (cloud metadata)
+// or other internal services and exfiltrate via stored response bodies.
+//
+// Three modes:
+//   - 'strict-https'  — require HTTPS; reject loopback/link-local/private/
+//                       metadata hosts. For cloud-only vendors like
+//                       SentinelOne and DNSFilter.
+//   - 'on-prem-http'  — allow HTTP (some on-prem appliances ship http-only
+//                       admin interfaces); still reject loopback/link-local/
+//                       metadata. RFC1918 allowed by default; can be locked
+//                       down further in hosted-saas mode.
+//   - 'on-prem-strict'— same as on-prem-http but reject RFC1918 too. Used
+//                       when the API host is hosted SaaS and an on-prem
+//                       address can't possibly be reachable from us anyway.
+
+import { isIP } from 'node:net';
+
+export type SsrfMode = 'strict-https' | 'on-prem-http' | 'on-prem-strict';
+
+export interface SsrfGuardOptions {
+  mode: SsrfMode;
+  /** Optional hostname allowlist suffix (e.g. ['.sentinelone.net']). When set, hostname must end with one of these. */
+  hostnameAllowlist?: readonly string[];
+}
+
+const METADATA_HOSTS = new Set([
+  // AWS / OpenStack / DigitalOcean (alternate)
+  '169.254.169.254',
+  '169.254.170.2',
+  // Alibaba / Oracle Cloud
+  '100.100.100.200',
+  // GCP / Azure (resolve to 169.254 but tenants may try direct names)
+  'metadata.google.internal',
+  'metadata.azure.com',
+]);
+
+const LOOPBACK_HOSTNAMES = new Set([
+  'localhost',
+  'ip6-localhost',
+  'ip6-loopback',
+]);
+
+function isLoopbackIp(addr: string): boolean {
+  // IPv4 loopback: 127.0.0.0/8
+  if (addr.startsWith('127.')) return true;
+  // IPv6 loopback ::1 and various textual forms
+  if (addr === '::1' || addr === '0:0:0:0:0:0:0:1') return true;
+  // IPv4-mapped IPv6 loopback ::ffff:127.0.0.1 (and Node-normalized ::ffff:7f00:0/24)
+  if (/^::ffff:127\./i.test(addr)) return true;
+  if (/^::ffff:7f[0-9a-f]{2}:/i.test(addr)) return true;
+  return false;
+}
+
+function isLinkLocalIp(addr: string): boolean {
+  // IPv4 link-local 169.254.0.0/16
+  if (addr.startsWith('169.254.')) return true;
+  // IPv6 link-local fe80::/10
+  if (/^fe[89ab][0-9a-f]?:/i.test(addr)) return true;
+  return false;
+}
+
+function isPrivateIp(addr: string): boolean {
+  // IPv4 private: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 100.64.0.0/10 (CGNAT)
+  if (addr.startsWith('10.')) return true;
+  if (addr.startsWith('192.168.')) return true;
+  const m172 = addr.match(/^172\.(\d+)\./);
+  if (m172) {
+    const o = Number(m172[1]);
+    if (o >= 16 && o <= 31) return true;
+  }
+  const m100 = addr.match(/^100\.(\d+)\./);
+  if (m100) {
+    const o = Number(m100[1]);
+    if (o >= 64 && o <= 127) return true;
+  }
+  // IPv6 unique-local fc00::/7
+  if (/^f[cd][0-9a-f]{2}:/i.test(addr)) return true;
+  // IPv4-mapped IPv6 private (textual form)
+  if (/^::ffff:(10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[01])\.)/i.test(addr)) return true;
+  // IPv4-mapped IPv6 private (Node-normalized hex form)
+  if (/^::ffff:0a[0-9a-f]{2}:/i.test(addr)) return true; // 10.0.0.0/8 -> ::ffff:0a__:__
+  if (/^::ffff:c0a8:/i.test(addr)) return true; // 192.168.0.0/16 -> ::ffff:c0a8:____
+  if (/^::ffff:ac1[0-9a-f]:/i.test(addr)) return true; // 172.16.0.0/12 -> ::ffff:ac10-ac1f:__
+  return false;
+}
+
+function isUnspecifiedIp(addr: string): boolean {
+  if (addr === '0.0.0.0') return true;
+  if (addr === '::' || addr === '0:0:0:0:0:0:0:0') return true;
+  return false;
+}
+
+export interface SsrfGuardResult {
+  ok: boolean;
+  reason?: string;
+}
+
+/**
+ * Validate that a tenant-supplied URL is safe to reach from inside the API.
+ *
+ * This is a STATIC check on the URL string. It does NOT resolve DNS — a
+ * sufficiently motivated attacker can still bind a public hostname to an
+ * internal IP (DNS rebinding) or use an HTTP redirect to bounce to one.
+ * We accept that limitation here: a future hardening pass should add
+ * pre-fetch DNS resolution + same-host re-validation in the HTTP client.
+ */
+export function checkSsrfSafe(rawUrl: string, opts: SsrfGuardOptions): SsrfGuardResult {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return { ok: false, reason: 'URL is malformed' };
+  }
+
+  if (opts.mode === 'strict-https' && parsed.protocol !== 'https:') {
+    return { ok: false, reason: 'URL must use https://' };
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { ok: false, reason: `URL protocol ${parsed.protocol} is not allowed (must be http or https)` };
+  }
+
+  // Strip IPv6 brackets if present.
+  const hostnameLower = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (!hostnameLower) {
+    return { ok: false, reason: 'URL has no hostname' };
+  }
+
+  if (LOOPBACK_HOSTNAMES.has(hostnameLower)) {
+    return { ok: false, reason: `hostname ${hostnameLower} is a loopback alias` };
+  }
+
+  if (METADATA_HOSTS.has(hostnameLower)) {
+    return { ok: false, reason: `hostname ${hostnameLower} is a cloud-metadata address` };
+  }
+
+  if (isIP(hostnameLower) > 0) {
+    if (isLoopbackIp(hostnameLower)) {
+      return { ok: false, reason: `hostname ${hostnameLower} is a loopback IP` };
+    }
+    if (isLinkLocalIp(hostnameLower)) {
+      return { ok: false, reason: `hostname ${hostnameLower} is a link-local IP (cloud metadata range)` };
+    }
+    if (isUnspecifiedIp(hostnameLower)) {
+      return { ok: false, reason: `hostname ${hostnameLower} is the unspecified address` };
+    }
+    if (opts.mode === 'strict-https' || opts.mode === 'on-prem-strict') {
+      if (isPrivateIp(hostnameLower)) {
+        return { ok: false, reason: `hostname ${hostnameLower} is a private/RFC1918 IP` };
+      }
+    }
+  }
+
+  if (opts.hostnameAllowlist && opts.hostnameAllowlist.length > 0) {
+    const ok = opts.hostnameAllowlist.some((suffix) => hostnameLower.endsWith(suffix.toLowerCase()));
+    if (!ok) {
+      return { ok: false, reason: `hostname must end with one of: ${opts.hostnameAllowlist.join(', ')}` };
+    }
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Zod `.refine` compatible predicate that throws nothing; returns boolean.
+ * Use checkSsrfSafe() directly if you need the rejection reason.
+ */
+export function isSsrfSafe(rawUrl: string, opts: SsrfGuardOptions): boolean {
+  return checkSsrfSafe(rawUrl, opts).ok;
+}


### PR DESCRIPTION
Closes #910 #911 #913 #917.

## Summary

- **SSRF guard helper** (`apps/api/src/services/ssrfGuard.ts`) — rejects tenant-supplied URLs at cloud-metadata, loopback, link-local, unspecified, and (in strict mode) RFC1918/CGNAT addresses. Optional hostname-suffix allowlist for SaaS-only vendors.
- **DNS Security integrations** (#910 / H-1): per-provider SSRF mode — `umbrella`/`cloudflare`/`dnsfilter` get strict-HTTPS + vendor-suffix allowlist; `pihole`/`adguard_home` get on-prem-HTTP (RFC1918 allowed) with loopback/link-local still blocked.
- **SentinelOne managementUrl** (#911 / H-3): now constrained to `.sentinelone.net` via strict-HTTPS + hostname allowlist (mirrors the existing huntressClient pattern).
- **Admin suspend-for-abuse** (#913 / M-1): adds `requireMfa()` and a `confirmEmail` anti-typo gate that must match the caller's account email (mirrors `/admin/tenant-erasure`). Splits the shared `reasonSchema` so the reversible `/unsuspend` route is unaffected.
- **`/devices/provision` canAccessOrg** (#917 / L-4): drops the defensive `typeof === 'function'` guard that silently fell open if the method were missing. Calls `auth.canAccessOrg()` unconditionally so a missing field would fail closed.

## Test plan

- [x] `npx vitest run` in `apps/api` — **4994 pass, 28 skipped, 0 failed**
- [x] `npx tsc --noEmit` in `apps/api` — clean
- [x] 28 new tests in `services/ssrfGuard.test.ts` (every reject path + on-prem allow)
- [x] 4 new tests in `routes/dnsSecurity.test.ts` (3 SSRF rejects + 1 legitimate on-prem accept)
- [x] 2 new tests in `routes/sentinelOne.test.ts` (off-allowlist host, cloud-metadata)
- [x] 2 new tests + 11 updated tests in `routes/admin/abuse.test.ts` (missing confirmEmail, mismatched confirmEmail)

## Notes

- Static URL-string check only — DNS-rebinding remains a documented future-hardening item.
- Does NOT address #912 / H-2 (Redis fail-closed self-hosted) — that stacks on top of the still-open #909.
- Does NOT address #914 #915 #916 — those are larger design changes filed for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)