### PR TITLE
security: audit-sanitizer + global Sentry capture + sync-job redaction + CI hygiene

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -89,6 +89,26 @@ updates:
     reviewers:
       - "toddhebebrand"
 
+  # E2E test harness has its own package.json (Playwright + tsx + dotenv).
+  # Without explicit coverage these never get bumped and land in CI runner
+  # context where a vulnerable transitive could exfiltrate runner secrets.
+  - package-ecosystem: "npm"
+    directory: "/e2e-tests"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "npm"
+      - "e2e-tests"
+    commit-message:
+      prefix: "chore(deps):"
+    reviewers:
+      - "toddhebebrand"
+
   # Go dependencies for the agent
   - package-ecosystem: "gomod"
     directory: "/agent"

--- a/.github/workflows/ci-smoke-binary-source-github.yml
+++ b/.github/workflows/ci-smoke-binary-source-github.yml
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v6

--- a/.github/workflows/ci-smoke-binary-source-local.yml
+++ b/.github/workflows/ci-smoke-binary-source-local.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v6

--- a/.github/workflows/dev-build-agent.yml
+++ b/.github/workflows/dev-build-agent.yml
@@ -20,6 +20,12 @@ on:
         required: true
         default: 'dev'
 
+# Default least-privilege: this workflow only reads the repo. Per-job
+# permissions can opt into write scopes (e.g. id-token: write for
+# signing) when they actually need them.
+permissions:
+  contents: read
+
 env:
   GO_VERSION: '1.25.8'
 

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -16,6 +16,9 @@ on:
       - '**/*.md'
       - '**/*.mdx'
 
+permissions:
+  contents: read
+
 jobs:
   ci-success:
     name: CI Success

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
 

--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -103,8 +103,10 @@
          missing this hardening.
 
          `sc failure` syntax: spaces after each `=` are mandatory; actions are
-         a slash-separated list of (actionType/delayMs) pairs. exit /b 0 at
-         the end so a transient sc-error doesn't roll back the install. -->
+         a slash-separated list of (actionType/delayMs) pairs. `Return="ignore"`
+         (below) is what prevents a transient sc-error from rolling back the
+         install — keep both the static ExeCommand and Return="ignore" in
+         sync if either is ever edited. -->
     <SetProperty Id="BREEZE_SC_FAILURE_CMD" Value="[System64Folder]cmd.exe" Before="ConfigureBreezeFailureActions" Sequence="execute" />
     <CustomAction
       Id="ConfigureBreezeFailureActions"

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -820,7 +820,11 @@ app.onError((err, c) => {
     );
   }
 
+  // Route unhandled errors to Sentry. Per-route `captureException(err, c)`
+  // calls only cover routes with explicit try/catch — anything that throws
+  // and falls through to onError was previously invisible to Sentry.
   console.error('Error:', err);
+  captureException(err, c);
   return c.json(
     {
       error: 'Internal Server Error',

--- a/apps/api/src/jobs/dnsSyncJob.ts
+++ b/apps/api/src/jobs/dnsSyncJob.ts
@@ -21,6 +21,7 @@ import { getBullMQConnection } from '../services/redis';
 import { isReusableState } from '../services/bullmqUtils';
 import { decryptForColumn } from '../services/secretCrypto';
 import { captureException } from '../services/sentry';
+import { redactLogMessage } from '../services/logRedaction';
 import { publishEvent, EVENT_TYPES } from '../services/eventBus';
 
 const { db } = dbModule;
@@ -576,11 +577,14 @@ async function processSyncIntegration(data: SyncIntegrationJobData): Promise<{
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    // Redact before persisting. Pi-hole puts the API key in the URL query
+    // string (?auth=<key>); a Node fetch error whose .cause echoes the URL
+    // would otherwise land in dnsFilterIntegrations.lastSyncError verbatim.
     await db
       .update(dnsFilterIntegrations)
       .set({
         lastSyncStatus: 'error',
-        lastSyncError: message.slice(0, 2000),
+        lastSyncError: redactLogMessage(message).slice(0, 2000),
         updatedAt: new Date()
       })
       .where(eq(dnsFilterIntegrations.id, integration.id));
@@ -655,7 +659,7 @@ async function processPolicySync(data: SyncPolicyJobData): Promise<{
       .update(dnsPolicies)
       .set({
         syncStatus: 'error',
-        syncError: message.slice(0, 2000),
+        syncError: redactLogMessage(message).slice(0, 2000),
         updatedAt: new Date()
       })
       .where(eq(dnsPolicies.id, row.policy.id));

--- a/apps/api/src/jobs/s1Sync.test.ts
+++ b/apps/api/src/jobs/s1Sync.test.ts
@@ -8,7 +8,8 @@ import {
   resolveAgentSyncTarget,
   resolveOrgIdForAgentSite,
   resolveThreatSyncTarget,
-  resolveDeviceIdForAgent
+  resolveDeviceIdForAgent,
+  truncateError
 } from './s1Sync';
 
 describe('s1Sync helpers', () => {
@@ -28,6 +29,16 @@ describe('s1Sync helpers', () => {
     expect(normalizeThreatStatus('quarantine_pending')).toBe('quarantined');
     expect(normalizeThreatStatus('in_progress')).toBe('in_progress');
     expect(normalizeThreatStatus('new')).toBe('active');
+  });
+
+  it('truncateError strips Authorization-bearer patterns before persisting to DB', () => {
+    // S1 puts the bearer token in a header; HTTP error messages can echo
+    // headers back. lastSyncError is read by operators in plain text — the
+    // redaction guards against any future error message that includes the
+    // header verbatim.
+    const out = truncateError(new Error('s1 fetch failed: Authorization: Bearer s1_token_secret at /web/api'));
+    expect(out).not.toContain('s1_token_secret');
+    expect(out).toContain('[REDACTED]');
   });
 
   it('transitions action polling failures to terminal failure at threshold', () => {

--- a/apps/api/src/jobs/s1Sync.ts
+++ b/apps/api/src/jobs/s1Sync.ts
@@ -15,6 +15,7 @@ import { isReusableState } from '../services/bullmqUtils';
 import { decryptForColumn } from '../services/secretCrypto';
 import { S1_THREAT_ACTIONS, SentinelOneClient, type S1ThreatAction, type S1ActionStatus } from '../services/sentinelOne/client';
 import { captureException } from '../services/sentry';
+import { redactLogMessage } from '../services/logRedaction';
 import { publishEvent } from '../services/eventBus';
 import {
   recordS1ActionDispatch,
@@ -125,9 +126,12 @@ function isThreatAction(value: string): value is S1ThreatAction {
   return (S1_THREAT_ACTIONS as readonly string[]).includes(value);
 }
 
-function truncateError(err: unknown): string {
+export function truncateError(err: unknown): string {
   const message = err instanceof Error ? err.message : String(err);
-  return message.slice(0, 2_000);
+  // Redact before truncating. S1 bearer tokens go in headers (not URL), but
+  // an HTTP error message can still echo back a Cookie or Authorization
+  // header — strip those before persisting to DB.
+  return redactLogMessage(message).slice(0, 2_000);
 }
 
 export function dedupeThreatDetections<T extends { s1ThreatId: string }>(rows: T[]): T[] {

--- a/apps/api/src/routes/admin/abuse.test.ts
+++ b/apps/api/src/routes/admin/abuse.test.ts
@@ -419,6 +419,34 @@ describe('admin/abuse — suspend mutation behavior', () => {
     expect((auditCall.details as Record<string, unknown>).tokenRevocationFailures).toBeDefined();
   });
 
+  it('suppresses raw tokenRevocationFailures and oauthRevocationError in production', async () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    try {
+      vi.mocked(revokeAllUserTokens).mockRejectedValueOnce(new Error('Redis unavailable: internal-path-xyz'));
+      vi.mocked(revokeAllPartnerOauthArtifacts).mockRejectedValueOnce(new Error('oauth revocation cache write failed: postgres constraint xyz'));
+
+      const app = buildApp(platformAdminAuth);
+      const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ reason: 'prod-mode-redaction-regression' }),
+      });
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as Record<string, unknown>;
+      // Flags + counts still surface for triage.
+      expect(body.tokenRevocationFailed).toBe(true);
+      expect(body.tokenRevocationFailureCount).toBe(1);
+      expect(body.oauthRevocationFailed).toBe(true);
+      // Raw err.message strings are NOT in the response body.
+      expect(body.tokenRevocationFailures).toBeUndefined();
+      expect(body.oauthRevocationError).toBeUndefined();
+    } finally {
+      if (originalEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = originalEnv;
+    }
+  });
+
   it('still returns 200 (and writes audit) when createAuditLog itself throws', async () => {
     vi.mocked(createAuditLog).mockRejectedValueOnce(new Error('audit DB down'));
 

--- a/apps/api/src/routes/admin/abuse.ts
+++ b/apps/api/src/routes/admin/abuse.ts
@@ -239,16 +239,28 @@ abuseRoutes.post(
     }
 
     if (tokenRevocationFailures.length > 0 || oauthRevocationError !== null) {
+      // Raw err.message strings suppressed in production. Counts + a
+      // generic flag still surface so operators can triage; full detail
+      // is in Sentry + the audit trail. Anywhere other than prod (dev,
+      // test, staging-style) keeps the richer view for debugging.
+      const exposeRaw = process.env.NODE_ENV !== 'production';
       return c.json(
         {
           error: 'partial_suspend',
           partnerId,
           status: 'suspended' as const,
           ...(tokenRevocationFailures.length > 0
-            ? { tokenRevocationFailed: true, tokenRevocationFailures }
+            ? {
+                tokenRevocationFailed: true,
+                tokenRevocationFailureCount: tokenRevocationFailures.length,
+                ...(exposeRaw ? { tokenRevocationFailures } : {}),
+              }
             : {}),
           ...(oauthRevocationError !== null
-            ? { oauthRevocationFailed: true, oauthRevocationError }
+            ? {
+                oauthRevocationFailed: true,
+                ...(exposeRaw ? { oauthRevocationError } : {}),
+              }
             : {}),
           deviceCount: result.deviceCount,
           userCount: result.userCount,

--- a/apps/api/src/routes/admin/tenantExport.ts
+++ b/apps/api/src/routes/admin/tenantExport.ts
@@ -69,7 +69,12 @@ tenantExportRoutes.get('/:orgId', requireMfa(), async (c) => {
     return c.body(zipBuffer as unknown as ArrayBuffer);
   } catch (err) {
     captureException(err, c);
-    const detail = err instanceof Error ? err.message : 'export failed';
+    // Raw err.message suppressed in production — even admin-gated endpoints
+    // can leak DB constraint names or internal paths via err.message. Sentry
+    // + audit trail keep the full diagnostic context.
+    const detail = process.env.NODE_ENV !== 'production' && err instanceof Error
+      ? err.message
+      : undefined;
     return c.json({ error: 'export failed', detail }, 500);
   }
 });

--- a/apps/api/src/services/auditEvents.test.ts
+++ b/apps/api/src/services/auditEvents.test.ts
@@ -64,6 +64,68 @@ describe('writeAuditEvent', () => {
     );
   });
 
+  it('runs details through sanitizeAuditPayload — redacts secrets and caps depth', () => {
+    const c = buildRequestLike({ 'user-agent': 'vitest' });
+
+    writeAuditEvent(c, {
+      orgId: '123e4567-e89b-42d3-a456-426614174000',
+      actorType: 'user',
+      actorId: '123e4567-e89b-42d3-a456-426614174001',
+      action: 'oauth.grant.revoke',
+      resourceType: 'oauth_grant',
+      resourceId: '123e4567-e89b-42d3-a456-426614174002',
+      details: {
+        // These are the field names sanitizeAuditPayload's SECRET_FIELD_PATTERN
+        // matches; the caller no longer has to remember to filter them.
+        password: 'hunter2',
+        token: 'brz_should_be_redacted',
+        apiKey: 'brz_api_key_secret',
+        clientSecret: 'oauth-client-secret',
+        // Safe fields pass through.
+        grantId: 'grant-123',
+        revokedCount: 3,
+      },
+    });
+
+    expect(createAuditLogAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          password: '[REDACTED]',
+          token: '[REDACTED]',
+          apiKey: '[REDACTED]',
+          clientSecret: '[REDACTED]',
+          grantId: 'grant-123',
+          revokedCount: 3,
+        }),
+      })
+    );
+  });
+
+  it('redacts Authorization-bearer patterns embedded inside arbitrary string fields', () => {
+    const c = buildRequestLike({ 'user-agent': 'vitest' });
+
+    // admin/abuse.ts persists raw err.message strings into details. If an
+    // upstream error message ever echoes back an Authorization header, this
+    // test documents that the sanitizer's per-string redaction strips it
+    // before persistence.
+    writeAuditEvent(c, {
+      orgId: '123e4567-e89b-42d3-a456-426614174000',
+      actorType: 'user',
+      actorId: '123e4567-e89b-42d3-a456-426614174001',
+      action: 'partner.suspended_for_abuse',
+      resourceType: 'partner',
+      resourceId: '123e4567-e89b-42d3-a456-426614174002',
+      details: {
+        upstreamError: 'fetch failed: Authorization: Bearer brz_leaked_token at /api',
+      },
+    });
+
+    const call = vi.mocked(createAuditLogAsync).mock.calls.at(-1)?.[0];
+    const persistedError = String(call?.details?.upstreamError ?? '');
+    expect(persistedError).not.toContain('brz_leaked_token');
+    expect(persistedError).toContain('[REDACTED]');
+  });
+
   it('normalizes non-UUID resource IDs and preserves raw resource ID in details', () => {
     const c = buildRequestLike({ 'user-agent': 'vitest' });
 

--- a/apps/api/src/services/auditEvents.ts
+++ b/apps/api/src/services/auditEvents.ts
@@ -1,5 +1,6 @@
 import { createAuditLogAsync, type InitiatedByType } from './auditService';
 import { getTrustedClientIpOrUndefined } from './clientIp';
+import { sanitizeAuditPayload } from './auditPayloadSanitizer';
 
 export const ANONYMOUS_ACTOR_ID = '00000000-0000-0000-0000-000000000000';
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -77,6 +78,14 @@ export function writeAuditEvent(c: RequestLike, event: AuditEventInput): void {
     }
   }
 
+  // Run details through the shared sanitizer before persisting. ~499
+  // audit call sites previously had to filter secrets at the call point;
+  // applying sanitizeAuditPayload here closes the systemic gap (e.g.
+  // admin/abuse.ts persisting raw err.message strings into details).
+  const sanitizedDetails = Object.keys(details).length > 0
+    ? (sanitizeAuditPayload(details) as Record<string, unknown>)
+    : undefined;
+
   createAuditLogAsync({
     orgId: event.orgId ?? undefined,
     actorType: resolvedActorType,
@@ -86,7 +95,7 @@ export function writeAuditEvent(c: RequestLike, event: AuditEventInput): void {
     resourceType: event.resourceType,
     resourceId,
     resourceName: event.resourceName ?? undefined,
-    details: Object.keys(details).length > 0 ? details : undefined,
+    details: sanitizedDetails,
     ipAddress: getTrustedClientIpOrUndefined(c),
     userAgent: c.req.header('user-agent'),
     result: event.result ?? 'success',

--- a/apps/api/src/services/logRedaction.test.ts
+++ b/apps/api/src/services/logRedaction.test.ts
@@ -26,6 +26,16 @@ describe('log redaction', () => {
     });
   });
 
+  it('redacts Pi-hole-style ?auth= URL query params (catches a real leak vector)', () => {
+    // Pi-hole puts the API key in the URL query string. If a Node fetch
+    // error echoes the URL, the API key ends up in dnsFilterIntegrations.
+    // lastSyncError verbatim. The `auth` alternative in the assignment
+    // pattern strips it before persistence.
+    expect(redactLogMessage('fetch failed for http://pi.hole/admin/api.php?auth=brz_pihole_secret&getAllQueries=true')).toBe(
+      'fetch failed for http://pi.hole/admin/api.php?auth=[REDACTED]&getAllQueries=true'
+    );
+  });
+
   it('redacts row messages and fields defensively before returning logs', () => {
     expect(redactAgentLogRow({
       id: 'log-1',

--- a/apps/api/src/services/logRedaction.ts
+++ b/apps/api/src/services/logRedaction.ts
@@ -4,7 +4,10 @@ const SECRET_KEY_PATTERN = /password|passwd|pwd|token|secret|api.*key|access.*ke
 
 const SECRET_ASSIGNMENT_PATTERNS: RegExp[] = [
   /\b(authorization\s*:\s*bearer\s+)[^\s,;]+/gi,
-  /\b((?:password|passwd|pwd|token|secret|api[_-]?key|access[_-]?key|private[_-]?key|client[_-]?secret|community|authpassphrase|privacypassphrase)\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s,;&]+)/gi,
+  // Includes `auth=` to catch Pi-hole's URL pattern `?auth=<apiKey>` —
+  // these can leak into Node fetch error messages whose .cause echoes
+  // the URL verbatim.
+  /\b((?:password|passwd|pwd|token|secret|api[_-]?key|access[_-]?key|private[_-]?key|client[_-]?secret|community|authpassphrase|privacypassphrase|auth)\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s,;&]+)/gi,
   /\b(Cookie\s*:\s*)[^\r\n]+/g,
 ];
 


### PR DESCRIPTION
Closes #919 #920 #921 #922.

## Summary

- **D-1 / #919 — audit-payload sanitizer at the source.** `writeAuditEvent` now routes `details` through the existing `sanitizeAuditPayload`. ~499 audit call sites previously depended on each one filtering secrets manually. One-line change closes the systemic gap.
- **D-2 / #920 — global `onError` captures to Sentry.** Unhandled errors falling through `app.onError` were previously invisible to Sentry; only routes with explicit `captureException` were observed.
- **D-3 / #921 — sync-job error redaction.** `dnsSyncJob` and `s1Sync` now wrap `err.message` in `redactLogMessage` before persisting to `lastSyncError`. The redaction regex was extended with `auth` to catch Pi-hole's URL pattern `?auth=<apiKey>` which can leak into Node `fetch` error messages.
- **D-4..D-6 / #922 — CI hygiene cluster.** `dtolnay/rust-toolchain` + `pnpm/action-setup` SHA-pinned in the workflows that were drift; `permissions: contents: read` added to `dev-build-agent.yml` + `docs-ci.yml`; `/e2e-tests` added to dependabot.
- **D-8 — admin error message redaction.** `admin/abuse.ts` partial-suspend + `admin/tenantExport.ts` 500 now suppress raw `err.message` in production. Counts + flags still surface for triage; full detail in Sentry + audit trail.
- **D-11 — WiX comment fix.** `breeze.wxs`: comment referenced `exit /b 0` semantics the actual `ExeCommand` doesn't include. Reworded to describe the real `Return="ignore"` behaviour.

## Test plan

- [x] `npx vitest run` against the 4 touched test files: **41/41 pass**.
- [x] `npx tsc --noEmit` in `apps/api`: clean.
- [x] Full `apps/api` suite passes when test files are run in isolation. A handful of pre-existing timing-flaky tests fail under the 5000-test load (5s default timeout, 50+ test files importing); none are touched by this PR — verified by re-running the failing files standalone, all pass.

## New tests

- `services/auditEvents.test.ts`: sanitizer redacts secret fields; Authorization-bearer patterns embedded inside arbitrary string fields are stripped.
- `services/logRedaction.test.ts`: Pi-hole `?auth=<key>` URL query param scrubbed.
- `jobs/s1Sync.test.ts`: `truncateError` strips Authorization-bearer patterns before persistence.
- `routes/admin/abuse.test.ts`: production-mode response suppresses raw `err.message` fields, keeps counts/flags.

## Notes

This PR does NOT address #914 #915 #916 (re-enrollment auth, audit retention privilege separation, external anchor) — those remain open as larger design changes filed earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)