### PR TITLE
fix(agents/enroll): mint fresh device.id on decom-bypass (closes #914)

### DIFF
--- a/apps/api/src/routes/agents/enrollment.test.ts
+++ b/apps/api/src/routes/agents/enrollment.test.ts
@@ -363,16 +363,21 @@ describe('POST /agents/enroll — 401 reason disambiguation', () => {
     expect(body.reason).toBe('hostname_collision_requires_existing_device_token');
   });
 
-  it('allows re-enrollment without the existing-device token when the existing row is decommissioned', async () => {
+  it('allows re-enrollment without the existing-device token when the existing row is decommissioned (mints a fresh device.id — #914)', async () => {
     // Real-world scenario (Trevor-Legion, 2026-05-25):
     // 1. Admin calls DELETE /api/v1/devices/<id> — soft-deletes, status=decommissioned
     // 2. Operator uninstalls Breeze on the endpoint and re-runs the installer
     // 3. Fresh agent has no prior token; re-enrolls
     // Pre-fix: hostname-collision check returned 409 even for decommissioned
     // rows, leaving the host permanently un-enrollable without a hand-rename
-    // in SQL. Post-fix: decommissioned rows are treated as authenticated for
-    // re-enrollment, and the existing row is restored/updated in-place so
-    // history (agent_logs etc.) survives.
+    // in SQL.
+    // Post-#896: re-enrollment succeeds but the new agent silently inherits
+    // the prior row's device.id and audit history (issue #914 — anyone with
+    // org enrollment key + secret + a known-decommissioned hostname could
+    // adopt the prior identity).
+    // Post-#914: re-enrollment succeeds with a FRESH device.id; the prior
+    // row is renamed (hostname suffixed with `.decom-<id8>`) inside the
+    // transaction and retains its FK-attached audit history.
     mockKeyLookup({
       id: 'key-decom',
       orgId: 'org-decom',
@@ -407,14 +412,14 @@ describe('POST /agents/enroll — 401 reason disambiguation', () => {
       previousTokenExpiresAt: null,
     }]);
 
-    // Auto-restore: db.update flipping status decommissioned -> offline
-    vi.mocked(db.update).mockReturnValueOnce({
-      set: vi.fn(() => ({
-        where: vi.fn().mockResolvedValue(undefined),
-      })),
-    } as any);
+    // Note: post-#914 the unconditional auto-restore UPDATE (status->offline)
+    // is SKIPPED on the decom-bypass-fresh-id path. The old row stays
+    // decommissioned and only its hostname is rewritten inside the
+    // transaction. So we no longer queue a top-level db.update() here.
 
-    // Transaction: device is existing, so the inner branch is tx.update().returning()
+    // Transaction: rename + INSERT-new. The decom-bypass-fresh-id path
+    // executes tx.update() once (to rename the old row's hostname) THEN
+    // tx.insert().returning() to create a fresh row with a new id.
     vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
       const fakeTx = {
         select: vi.fn().mockReturnValue({
@@ -424,19 +429,17 @@ describe('POST /agents/enroll — 401 reason disambiguation', () => {
         }),
         update: vi.fn().mockReturnValue({
           set: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              returning: vi.fn().mockResolvedValue([{
-                id: 'device-decom-existing',
-                orgId: 'org-decom',
-                siteId: 'site-decom',
-                hostname: 'host-1',
-              }]),
-            }),
+            where: vi.fn().mockResolvedValue(undefined),
           }),
         }),
         insert: vi.fn().mockReturnValue({
           values: vi.fn().mockReturnValue({
-            returning: vi.fn().mockResolvedValue([]),
+            returning: vi.fn().mockResolvedValue([{
+              id: 'device-decom-fresh-id',
+              orgId: 'org-decom',
+              siteId: 'site-decom',
+              hostname: 'host-1',
+            }]),
             onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
           }),
         }),
@@ -455,7 +458,9 @@ describe('POST /agents/enroll — 401 reason disambiguation', () => {
 
     expect(resp.status).toBe(201);
     const body = (await resp.json()) as Record<string, unknown>;
-    expect(body.deviceId).toBe('device-decom-existing');
+    // #914: response carries the FRESH device.id, NOT the prior one.
+    expect(body.deviceId).toBe('device-decom-fresh-id');
+    expect(body.deviceId).not.toBe('device-decom-existing');
     // Importantly: no 409 audit event was written for hostname_collision
     expect(writeAuditEvent).not.toHaveBeenCalledWith(
       expect.anything(),
@@ -465,7 +470,8 @@ describe('POST /agents/enroll — 401 reason disambiguation', () => {
         }),
       })
     );
-    // AND: an audit row was written for the admin-approved replacement bypass
+    // Bypass-audit row records the fresh-id reason + priorDeviceId for
+    // forensic linkage. resourceId on THIS audit row is the prior id.
     expect(writeAuditEvent).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -473,9 +479,40 @@ describe('POST /agents/enroll — 401 reason disambiguation', () => {
         resourceId: 'device-decom-existing',
         result: 'success',
         details: expect.objectContaining({
-          reason: 'decommissioned_row_reenrolled',
+          reason: 'decommissioned_row_reenrolled_fresh_id',
           priorDeviceId: 'device-decom-existing',
         }),
+      })
+    );
+    // Success-audit row references the NEW id and back-links to the prior.
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        actorType: 'agent',
+        action: 'agent.enroll',
+        resourceId: 'device-decom-fresh-id',
+        details: expect.objectContaining({
+          reenrollment: true,
+          decomBypassPriorDeviceId: 'device-decom-existing',
+        }),
+      })
+    );
+    // Defense against the pre-#914 behavior re-emerging: assert the legacy
+    // reason string is NOT used and that the success audit does NOT use the
+    // prior id as resourceId.
+    expect(writeAuditEvent).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        details: expect.objectContaining({
+          reason: 'decommissioned_row_reenrolled',
+        }),
+      })
+    );
+    expect(writeAuditEvent).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        actorType: 'agent',
+        resourceId: 'device-decom-existing',
       })
     );
   });
@@ -597,12 +634,12 @@ describe('POST /agents/enroll — 401 reason disambiguation', () => {
         }),
       })
     );
-    // NOT the decom-bypass success audit
+    // NOT the decom-bypass success audit (post-#914 reason string)
     expect(writeAuditEvent).not.toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         details: expect.objectContaining({
-          reason: 'decommissioned_row_reenrolled',
+          reason: 'decommissioned_row_reenrolled_fresh_id',
         }),
       })
     );

--- a/apps/api/src/routes/agents/enrollment.ts
+++ b/apps/api/src/routes/agents/enrollment.ts
@@ -376,6 +376,13 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
       .limit(1);
 
     let existingDeviceAuthenticated = false;
+    // Set true on the decom-bypass path so the transaction below renames
+    // the old row's hostname (freeing the slot) and INSERTs a fresh device
+    // row with a new id, instead of UPDATE-in-place on the prior id. See
+    // issue #914 — without a fresh id, any holder of the org enrollment
+    // key + secret + a known-decommissioned hostname could silently adopt
+    // the prior device's audit history (agent_logs, alerts, etc.).
+    let decomBypassFreshRow = false;
     if (existingDevice) {
       const tokenSuspended = !!existingDevice.agentTokenSuspendedAt;
 
@@ -394,18 +401,21 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
       } else if (existingDevice.status === 'decommissioned') {
         // Decommission-bypass: admin explicitly DELETE'd the device. The
         // prior agent's tokens are irrelevant; the slot is freed for fresh
-        // enrollment. The auto-restore block below flips status back to
-        // 'online' and the transaction below re-uses the existing device
-        // id so audit history (agent_logs etc.) survives. Without this
-        // branch, uninstall+reinstall on the same hostname is permanently
-        // broken — observed 2026-05-25 on Trevor-Legion: agent re-enroll
-        // loops on 409 until an operator hand-renames the decommissioned
-        // row in SQL to free the hostname.
+        // enrollment. Per issue #914 we mint a NEW device.id rather than
+        // re-using existingDevice.id — the old row keeps its FK-attached
+        // audit history (agent_logs, alerts, deviceHardware/Network) and
+        // is renamed below in-transaction to free the hostname for the
+        // fresh INSERT. Re-enrollment still works (the case that #896
+        // originally fixed), but the new agent does not silently inherit
+        // the prior row's historical attribution.
         existingDeviceAuthenticated = true;
+        decomBypassFreshRow = true;
         // Audit the admin-approved-replacement bypass for forensic
         // traceability. Re-enrollment onto a decommissioned slot is a
-        // sensitive transition (new tokens issued, device id preserved) and
-        // must be traceable independent of the success-path audit below.
+        // sensitive transition (new tokens issued) and must be traceable
+        // independent of the success-path audit below. resourceId here is
+        // the PRIOR device id; the success audit below will record the new
+        // fresh id.
         writeAuditEvent(c, {
           orgId: key.orgId,
           actorType: 'system',
@@ -414,7 +424,7 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
           resourceId: existingDevice.id,
           resourceName: data.hostname,
           details: {
-            reason: 'decommissioned_row_reenrolled',
+            reason: 'decommissioned_row_reenrolled_fresh_id',
             siteId,
             priorDeviceId: existingDevice.id,
           },
@@ -460,16 +470,19 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
       }
     }
 
-    // Auto-restore decommissioned devices on re-enrollment
-    if (existingDevice && existingDevice.status === 'decommissioned') {
-      await db.update(devices)
-        .set({ status: 'offline', updatedAt: new Date() })
-        .where(eq(devices.id, existingDevice.id));
-    }
-
+    // Pre-#914 a top-level auto-restore UPDATE flipped a decommissioned
+    // existingDevice back to status='offline' before the in-transaction
+    // re-enroll UPDATE. With #914 the decom path INSERTs a fresh row
+    // (the old row stays decommissioned), and the non-decom branches
+    // never reach this point with status='decommissioned' — so that
+    // top-level UPDATE is now unreachable and has been removed.
     const device = await db.transaction(async (tx) => {
-      // Device limit check inside transaction to prevent TOCTOU race
-      if (maxDevices != null && deviceLimitPartnerId && !existingDevice) {
+      // Device limit check inside transaction to prevent TOCTOU race.
+      // Runs when no existing row OR when the decom-bypass-fresh-id path
+      // (#914) is going to INSERT a new active row — both grow net active
+      // count by 1. Skipped on the normal UPDATE-in-place re-enroll path,
+      // which is count-neutral.
+      if (maxDevices != null && deviceLimitPartnerId && (!existingDevice || decomBypassFreshRow)) {
         const partnerOrgIds = tx
           .select({ id: organizations.id })
           .from(organizations)
@@ -505,8 +518,27 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
         }
       }
 
+      // #914 decom-bypass: rename the prior decommissioned row's hostname
+      // so the new INSERT can claim the original. There is no DB-level
+      // unique constraint on hostname today (only the cursor-keyset index
+      // devices_hostname_id_idx), but the application's existingDevice
+      // lookup at the top of this handler filters by exact hostname — if
+      // both rows kept the same hostname, the next re-enroll would race
+      // on which row .limit(1) returns. The `.decom-<id8>` suffix is
+      // collision-free in practice (8 hex chars = ~4B namespace) and
+      // mirrors the SQL workaround documented in the #896 incident notes.
+      if (decomBypassFreshRow && existingDevice) {
+        await tx
+          .update(devices)
+          .set({
+            hostname: `${data.hostname}.decom-${existingDevice.id.slice(0, 8)}`,
+            updatedAt: new Date(),
+          })
+          .where(eq(devices.id, existingDevice.id));
+      }
+
       let dev;
-      if (existingDevice) {
+      if (existingDevice && !decomBypassFreshRow) {
         [dev] = await tx
           .update(devices)
           .set({
@@ -635,6 +667,12 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
         siteId: key.siteId,
         reenrollment: Boolean(existingDevice),
         mtlsCertIssued: mtlsCert !== null,
+        // #914: when decom-bypass minted a fresh id, link the new row's
+        // audit trail back to the decommissioned row it replaced so the
+        // forensic chain is queryable in one step.
+        ...(decomBypassFreshRow && existingDevice
+          ? { decomBypassPriorDeviceId: existingDevice.id }
+          : {}),
       },
     });
 


### PR DESCRIPTION
Closes #914.

## Problem

PR #896 fixed the legitimate uninstall+reinstall case (decommissioned-row re-enrollment returning 409 forever — observed in production on Trevor-Legion 2026-05-25) by treating decommissioned rows as auth-bypassed. But it preserved `existingDevice.id`, which Todd surfaced in #914 as silent identity adoption:

> Anyone with the org's enrollment key + secret + a known-decommissioned hostname can adopt the prior identity — inheriting agent_logs, alerts, audit history, etc.

Cross-org hijack remained impossible (lookup is org+site-scoped), but within an org the bypass collapsed to enrollment-key-only auth for any historically-decommissioned hostname.

## Fix (Option A from #914)

Mint a **new** `device.id` on the decom-bypass path. The prior decommissioned row is renamed in-transaction (`hostname → "${hostname}.decom-${id8}"`) so the application's existingDevice lookup — which filters by exact hostname — no longer finds it. The renamed row keeps every FK-attached row intact (agent_logs, alerts, deviceHardware, deviceNetwork) under its decommissioned id. The fresh INSERT claims the original hostname with a new id, fresh tokens, and no inherited attribution.

Re-enrollment after admin DELETE still works (the #896 case) — only the identity inheritance is removed.

### Key design choices

| Decision | Rationale |
|---|---|
| Rename, not delete the old row | `agent_logs.device_id` FK blocks hard DELETE; rename frees the hostname slot without losing history. |
| Suffix is `.decom-<id8>` | 8 hex chars = ~4B namespace = collision-free in practice. Mirrors the SQL workaround already documented in #896 incident notes. |
| Audit reason renamed to `decommissioned_row_reenrolled_fresh_id` | Distinguishes from the pre-#914 string so a future regression is detectable from audit data. |
| Success audit gains `decomBypassPriorDeviceId` | Lets the new row's audit trail back-link to the renamed decommissioned row in one query. |
| Device-limit check now runs on this path | Net active count grows by 1; without this, a tenant could decom+re-enroll endlessly to exceed cap. |
| Removed the top-level auto-restore UPDATE | Unreachable after the change — decom always takes the fresh-id INSERT path. |

## Forensic trail (post-fix)

For a single decom-bypass enrollment, the audit log now contains two linked rows:

1. **bypass row** — `actorType=system`, `resourceId=<priorId>`, `details.reason='decommissioned_row_reenrolled_fresh_id'`, `details.priorDeviceId=<priorId>`
2. **success row** — `actorType=agent`, `resourceId=<newId>`, `details.reenrollment=true`, `details.decomBypassPriorDeviceId=<priorId>`

Either row's `priorDeviceId` / `decomBypassPriorDeviceId` field lets an investigator pivot to the other in one query.

## Verification

```
tsc --noEmit                                                clean (exit 0)
vitest run src/routes/agents/enrollment.test.ts             15/15 pass
vitest run (full apps/api)                                  4958 pass | 28 skipped | 0 fail
```

The existing decom test was updated to assert:
- Response carries the fresh id (not the prior id)
- Bypass audit uses the new reason string and links via `priorDeviceId`
- Success audit uses the new id as `resourceId` and back-links via `decomBypassPriorDeviceId`
- Two negative assertions against the pre-#914 behavior re-emerging

The suspended-decom test's no-bypass-audit assertion was bumped to the new reason string so it stays effective.

## What's not in scope

- No new migration. The DB schema already has no unique constraint on `hostname` (only the `devices_hostname_id_idx` cursor-keyset index), so the rename works without DDL.
- Existing decommissioned rows in production retain their original hostnames; only NEW decom-bypass re-enrollments take the fresh-id path. If a historical re-enrollment had already inherited identity, this PR doesn't retroactively unwind it.
- No public API contract change beyond the response `deviceId` now being different on the decom-bypass path (previously: same as prior; now: a fresh UUID). Agents don't care — they treat `deviceId` as opaque server-issued state.