### PR TITLE
feat(scripts): exit-code severity mapping editor in script form

### DIFF
--- a/apps/web/src/components/scripts/ScriptEditPage.tsx
+++ b/apps/web/src/components/scripts/ScriptEditPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { ArrowLeft, History } from 'lucide-react';
-import ScriptForm, { type ScriptFormValues } from './ScriptForm';
+import ScriptForm, { type ScriptFormValues, type ScriptSubmitValues } from './ScriptForm';
+import { mappingToRows } from './ScriptFormSchema';
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
 import { showToast } from '../shared/Toast';
@@ -44,7 +45,8 @@ export default function ScriptEditPage({ scriptId }: ScriptEditPageProps) {
         content: scriptData.content || '',
         parameters: scriptData.parameters || [],
         timeoutSeconds: scriptData.timeoutSeconds || 300,
-        runAs: scriptData.runAs || 'system'
+        runAs: scriptData.runAs || 'system',
+        exitCodeSeverityMapping: mappingToRows(scriptData.exitCodeSeverityMapping),
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
@@ -57,7 +59,7 @@ export default function ScriptEditPage({ scriptId }: ScriptEditPageProps) {
     fetchScript();
   }, [fetchScript]);
 
-  const handleSubmit = async (values: ScriptFormValues) => {
+  const handleSubmit = async (values: ScriptSubmitValues) => {
     setSubmitting(true);
     setError(undefined);
 

--- a/apps/web/src/components/scripts/ScriptForm.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.tsx
@@ -508,7 +508,8 @@ export default function ScriptForm({
           {severityFields.length === 0 && (
             <p className="text-sm text-muted-foreground">
               Map specific exit codes to alert severities. When the script returns one of these codes,
-              an alert is raised at the configured severity. Exit codes you don&apos;t list here use the
+              an alert is raised at the configured severity. Choose <em>Suppress alert</em> to mark a
+              code as informational (no incident raised). Exit codes you don&apos;t list here use the
               default outcome handling.
             </p>
           )}
@@ -541,6 +542,9 @@ export default function ScriptForm({
                       <option key={opt.value} value={opt.value}>{opt.label}</option>
                     ))}
                   </select>
+                  <p className="text-xs text-muted-foreground">
+                    Suppress alert &mdash; exit code is treated as informational, no incident raised.
+                  </p>
                 </div>
               </div>
               <button

--- a/apps/web/src/components/scripts/ScriptForm.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.tsx
@@ -12,14 +12,15 @@ import type { ScriptFormBridge } from '@/stores/scriptAiStore';
 import type { OSType } from './ScriptList';
 import {
   scriptSchema, languageOptions, categoryOptions,
-  runAsOptions, parameterTypeOptions,
-  type ScriptFormValues,
+  runAsOptions, parameterTypeOptions, severityOptions,
+  rowsToMapping,
+  type ScriptFormValues, type ScriptSubmitValues,
 } from './ScriptFormSchema';
 
-export type { ScriptFormValues, ScriptParameter } from './ScriptFormSchema';
+export type { ScriptFormValues, ScriptParameter, ScriptSubmitValues } from './ScriptFormSchema';
 
 type ScriptFormProps = {
-  onSubmit?: (values: ScriptFormValues) => void | Promise<void>;
+  onSubmit?: (values: ScriptSubmitValues) => void | Promise<void>;
   onCancel?: () => void;
   defaultValues?: Partial<ScriptFormValues>;
   submitLabel?: string;
@@ -98,6 +99,7 @@ export default function ScriptForm({
       parameters: [],
       timeoutSeconds: 300,
       runAs: 'system',
+      exitCodeSeverityMapping: [],
       ...defaultValues
     }
   });
@@ -107,11 +109,20 @@ export default function ScriptForm({
     name: 'parameters'
   });
 
+  const {
+    fields: severityFields,
+    append: appendSeverity,
+    remove: removeSeverity,
+  } = useFieldArray({ control, name: 'exitCodeSeverityMapping' });
+
+  const [severityOpen, setSeverityOpen] = useState(false);
+
   // Auto-expand sections when editing a script that has existing data
   useEffect(() => {
     if (defaultValues?.parameters && defaultValues.parameters.length > 0) setParamsOpen(true);
     if (defaultValues?.timeoutSeconds !== undefined && defaultValues.timeoutSeconds !== 300) setSettingsOpen(true);
     if (defaultValues?.runAs !== undefined && defaultValues.runAs !== 'system') setSettingsOpen(true);
+    if (defaultValues?.exitCodeSeverityMapping && defaultValues.exitCodeSeverityMapping.length > 0) setSeverityOpen(true);
   }, [defaultValues]);
 
   const { panelOpen, togglePanel } = useScriptAiStore();
@@ -217,7 +228,12 @@ export default function ScriptForm({
         // onSubmit so it's true before navigateTo dispatches the event.
         skipGuardRef.current = true;
         try {
-          await onSubmit?.(values);
+          const { exitCodeSeverityMapping, ...rest } = values;
+          const submitValues: ScriptSubmitValues = {
+            ...rest,
+            exitCodeSeverityMapping: rowsToMapping(exitCodeSeverityMapping),
+          };
+          await onSubmit?.(submitValues);
         } catch {
           // Save failed — re-arm the nav guard so user doesn't lose work
           skipGuardRef.current = false;
@@ -476,6 +492,75 @@ export default function ScriptForm({
               {watch('runAs') === 'elevated' && ' Uses sudo on macOS/Linux, runas on Windows.'}
             </p>
           </div>
+        </div>
+      </CollapsibleSection>
+
+      {/* Exit-code severity mapping */}
+      <CollapsibleSection
+        title="Exit Code Severity"
+        open={severityOpen}
+        onToggle={() => setSeverityOpen(prev => !prev)}
+        badge={severityFields.length > 0 ? (
+          <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">{severityFields.length}</span>
+        ) : undefined}
+      >
+        <div className="space-y-3">
+          {severityFields.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              Map specific exit codes to alert severities. When the script returns one of these codes,
+              an alert is raised at the configured severity. Exit codes you don&apos;t list here use the
+              default outcome handling.
+            </p>
+          )}
+          {severityFields.map((field, index) => (
+            <div key={field.id} className="flex items-start gap-3 rounded-md border bg-muted/20 p-3">
+              <div className="grid flex-1 gap-3 sm:grid-cols-2">
+                <div className="space-y-1">
+                  <label className="text-xs font-medium text-muted-foreground">Exit code</label>
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    pattern="[0-9]*"
+                    placeholder="e.g. 1"
+                    className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                    {...register(`exitCodeSeverityMapping.${index}.exitCode`)}
+                  />
+                  {errors.exitCodeSeverityMapping?.[index]?.exitCode && (
+                    <p className="text-xs text-destructive">
+                      {errors.exitCodeSeverityMapping[index]?.exitCode?.message}
+                    </p>
+                  )}
+                </div>
+                <div className="space-y-1">
+                  <label className="text-xs font-medium text-muted-foreground">Severity</label>
+                  <select
+                    className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                    {...register(`exitCodeSeverityMapping.${index}.severity`)}
+                  >
+                    {severityOptions.map(opt => (
+                      <option key={opt.value} value={opt.value}>{opt.label}</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => removeSeverity(index)}
+                className="flex h-9 w-9 items-center justify-center rounded-md hover:bg-muted text-destructive"
+                title="Remove mapping"
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={() => appendSeverity({ exitCode: '', severity: 'medium' })}
+            className="inline-flex items-center gap-1.5 rounded-md border border-dashed px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition"
+          >
+            <Plus className="h-4 w-4" />
+            Add exit code
+          </button>
         </div>
       </CollapsibleSection>
 

--- a/apps/web/src/components/scripts/ScriptFormSchema.test.ts
+++ b/apps/web/src/components/scripts/ScriptFormSchema.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mappingToRows,
+  rowsToMapping,
+  SUPPRESS_SEVERITY,
+  type ExitCodeSeverityMapping,
+  type ExitCodeSeverityRow,
+} from './ScriptFormSchema';
+
+describe('rowsToMapping / mappingToRows', () => {
+  it('round-trips a suppress entry through both helpers', () => {
+    const rows: ExitCodeSeverityRow[] = [
+      { exitCode: '0', severity: SUPPRESS_SEVERITY },
+      { exitCode: '1', severity: 'high' },
+    ];
+    const wire = rowsToMapping(rows);
+    expect(wire).toEqual({ '0': null, '1': 'high' });
+    expect(mappingToRows(wire)).toEqual(rows);
+  });
+
+  it('emits null on the wire for suppress entries', () => {
+    const wire = rowsToMapping([{ exitCode: '0', severity: SUPPRESS_SEVERITY }]);
+    expect(wire).toEqual({ '0': null });
+  });
+
+  it('preserves null entries when loading from the wire', () => {
+    const wire: ExitCodeSeverityMapping = { '0': null, '2': 'critical' };
+    const rows = mappingToRows(wire);
+    expect(rows).toEqual([
+      { exitCode: '0', severity: SUPPRESS_SEVERITY },
+      { exitCode: '2', severity: 'critical' },
+    ]);
+  });
+
+  it('returns undefined when given no rows', () => {
+    expect(rowsToMapping(undefined)).toBeUndefined();
+    expect(rowsToMapping([])).toBeUndefined();
+  });
+
+  it('returns an empty array when given no mapping', () => {
+    expect(mappingToRows(undefined)).toEqual([]);
+    expect(mappingToRows(null)).toEqual([]);
+  });
+});

--- a/apps/web/src/components/scripts/ScriptFormSchema.ts
+++ b/apps/web/src/components/scripts/ScriptFormSchema.ts
@@ -12,12 +12,19 @@ export const parameterSchema = z.object({
 export const severityValues = ['critical', 'high', 'medium', 'low', 'info'] as const;
 export type Severity = (typeof severityValues)[number];
 
+// Sentinel used in form-row state to represent the wire-shape `null`
+// (explicitly suppress the alert for this exit code). Kept as a string so
+// `<select>` values and `register()` round-trip cleanly; converted to/from
+// `null` at the form boundary by rowsToMapping / mappingToRows.
+export const SUPPRESS_SEVERITY = '__suppress__' as const;
+export type SeverityRowValue = Severity | typeof SUPPRESS_SEVERITY;
+
 // Form-side representation of one exit-code → severity mapping row. Stored as
 // a list during editing so order is stable and each row owns its own state;
-// converted to/from the wire `Record<string, severity>` at form boundaries.
+// converted to/from the wire `Record<string, severity | null>` at form boundaries.
 export const exitCodeSeverityRowSchema = z.object({
   exitCode: z.string().regex(/^\d+$/, 'Exit code must be a non-negative integer'),
-  severity: z.enum(severityValues),
+  severity: z.enum([...severityValues, SUPPRESS_SEVERITY]),
 });
 
 export const scriptSchema = z.object({
@@ -59,8 +66,10 @@ export type ExitCodeSeverityRow = z.infer<typeof exitCodeSeverityRowSchema>;
 
 // Wire shape sent to / received from the API. Form-side editing keeps an
 // ordered list of rows for stable React keys + per-row error display; we
-// convert at the form boundary.
-export type ExitCodeSeverityMapping = Record<string, Severity>;
+// convert at the form boundary. `null` = explicitly suppress the alert for
+// that exit code (distinct from omitting the key, which falls back to
+// script-level default handling).
+export type ExitCodeSeverityMapping = Record<string, Severity | null>;
 
 export type ScriptSubmitValues = Omit<ScriptFormValues, 'exitCodeSeverityMapping'> & {
   exitCodeSeverityMapping?: ExitCodeSeverityMapping;
@@ -69,7 +78,7 @@ export type ScriptSubmitValues = Omit<ScriptFormValues, 'exitCodeSeverityMapping
 export function rowsToMapping(rows: ExitCodeSeverityRow[] | undefined): ExitCodeSeverityMapping | undefined {
   if (!rows || rows.length === 0) return undefined;
   return rows.reduce<ExitCodeSeverityMapping>((acc, { exitCode, severity }) => {
-    acc[exitCode] = severity;
+    acc[exitCode] = severity === SUPPRESS_SEVERITY ? null : severity;
     return acc;
   }, {});
 }
@@ -77,17 +86,20 @@ export function rowsToMapping(rows: ExitCodeSeverityRow[] | undefined): ExitCode
 export function mappingToRows(mapping: ExitCodeSeverityMapping | null | undefined): ExitCodeSeverityRow[] {
   if (!mapping) return [];
   return Object.entries(mapping)
-    .filter((entry): entry is [string, Severity] => entry[1] !== null)
-    .map(([exitCode, severity]) => ({ exitCode, severity }))
+    .map<ExitCodeSeverityRow>(([exitCode, severity]) => ({
+      exitCode,
+      severity: severity === null ? SUPPRESS_SEVERITY : severity,
+    }))
     .sort((a, b) => Number(a.exitCode) - Number(b.exitCode));
 }
 
-export const severityOptions: { value: Severity; label: string }[] = [
+export const severityOptions: { value: SeverityRowValue; label: string }[] = [
   { value: 'critical', label: 'Critical' },
   { value: 'high', label: 'High' },
   { value: 'medium', label: 'Medium' },
   { value: 'low', label: 'Low' },
   { value: 'info', label: 'Info' },
+  { value: SUPPRESS_SEVERITY, label: 'Suppress alert' },
 ];
 
 export const languageOptions: { value: ScriptLanguage; label: string; monacoLang: string }[] = [

--- a/apps/web/src/components/scripts/ScriptFormSchema.ts
+++ b/apps/web/src/components/scripts/ScriptFormSchema.ts
@@ -9,6 +9,17 @@ export const parameterSchema = z.object({
   options: z.string().optional() // comma-separated for select type
 });
 
+export const severityValues = ['critical', 'high', 'medium', 'low', 'info'] as const;
+export type Severity = (typeof severityValues)[number];
+
+// Form-side representation of one exit-code → severity mapping row. Stored as
+// a list during editing so order is stable and each row owns its own state;
+// converted to/from the wire `Record<string, severity>` at form boundaries.
+export const exitCodeSeverityRowSchema = z.object({
+  exitCode: z.string().regex(/^\d+$/, 'Exit code must be a non-negative integer'),
+  severity: z.enum(severityValues),
+});
+
 export const scriptSchema = z.object({
   name: z.string().min(1, 'Script name is required'),
   description: z.string().optional(),
@@ -22,11 +33,62 @@ export const scriptSchema = z.object({
     .int('Timeout must be a whole number')
     .min(1, 'Timeout must be at least 1 second')
     .max(86400, 'Timeout cannot exceed 24 hours'),
-  runAs: z.enum(['system', 'user', 'elevated'])
+  runAs: z.enum(['system', 'user', 'elevated']),
+  exitCodeSeverityMapping: z
+    .array(exitCodeSeverityRowSchema)
+    .optional()
+    .superRefine((rows, ctx) => {
+      if (!rows) return;
+      const seen = new Set<string>();
+      rows.forEach((row, i) => {
+        if (seen.has(row.exitCode)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [i, 'exitCode'],
+            message: `Duplicate exit code ${row.exitCode}`,
+          });
+        }
+        seen.add(row.exitCode);
+      });
+    }),
 });
 
 export type ScriptFormValues = z.infer<typeof scriptSchema>;
 export type ScriptParameter = z.infer<typeof parameterSchema>;
+export type ExitCodeSeverityRow = z.infer<typeof exitCodeSeverityRowSchema>;
+
+// Wire shape sent to / received from the API. Form-side editing keeps an
+// ordered list of rows for stable React keys + per-row error display; we
+// convert at the form boundary.
+export type ExitCodeSeverityMapping = Record<string, Severity>;
+
+export type ScriptSubmitValues = Omit<ScriptFormValues, 'exitCodeSeverityMapping'> & {
+  exitCodeSeverityMapping?: ExitCodeSeverityMapping;
+};
+
+export function rowsToMapping(rows: ExitCodeSeverityRow[] | undefined): ExitCodeSeverityMapping | undefined {
+  if (!rows || rows.length === 0) return undefined;
+  return rows.reduce<ExitCodeSeverityMapping>((acc, { exitCode, severity }) => {
+    acc[exitCode] = severity;
+    return acc;
+  }, {});
+}
+
+export function mappingToRows(mapping: ExitCodeSeverityMapping | null | undefined): ExitCodeSeverityRow[] {
+  if (!mapping) return [];
+  return Object.entries(mapping)
+    .filter((entry): entry is [string, Severity] => entry[1] !== null)
+    .map(([exitCode, severity]) => ({ exitCode, severity }))
+    .sort((a, b) => Number(a.exitCode) - Number(b.exitCode));
+}
+
+export const severityOptions: { value: Severity; label: string }[] = [
+  { value: 'critical', label: 'Critical' },
+  { value: 'high', label: 'High' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'low', label: 'Low' },
+  { value: 'info', label: 'Info' },
+];
 
 export const languageOptions: { value: ScriptLanguage; label: string; monacoLang: string }[] = [
   { value: 'powershell', label: 'PowerShell', monacoLang: 'powershell' },


### PR DESCRIPTION
## Summary

Closes the UI gap for #798 — the exit-code → severity mapping that #798 added on the server side was reachable only via curl because the new-script / edit-script web form didn't expose it. This adds a CollapsibleSection editor below "Execution Settings".

## What changed

- **`ScriptFormSchema.ts`** — new `exitCodeSeverityMapping` field on the form schema (array of `{exitCode, severity}` rows with per-row + duplicate-code validation). Form-side representation is a list for stable React keys + per-row error display; wire shape stays the canonical `Record<string, Severity>`. New helpers `rowsToMapping` / `mappingToRows` convert at the form boundary.
- **`ScriptForm.tsx`** — new "Exit Code Severity" CollapsibleSection with `useFieldArray`-driven rows (exit-code input + severity select + remove button). Submit handler converts rows → record before calling parent `onSubmit`. Auto-expands the section when editing a script with existing mappings.
- **`ScriptEditPage.tsx`** — converts incoming `exitCodeSeverityMapping` record from the API into form rows via `mappingToRows`. The `handleSubmit` signature now takes the wire-shape `ScriptSubmitValues` since the form does the row → record conversion.

## Verification

Tested locally against `http://localhost`:

**Create path** — `/scripts/new` → expand section → add 2 rows `{1: high, 2: critical}` → submit → DB row contains `exit_code_severity_mapping = {"1": "high", "2": "critical"}`.

**Edit path** — `/scripts/:id` for that script → section auto-expanded with badge "2", both rows pre-populated (exit codes `["1","2"]`, severities `["high","critical"]`) in numeric exit-code order.

**Validation** — Schema's `superRefine` catches duplicate exit codes inline; the regex `^\d+$` matches the server-side `exitCodeSeverityMappingSchema` in `packages/shared`.

## Test plan

- [x] `npx tsc --noEmit` on apps/web — clean
- [x] Manual create + edit round-trip locally
- [ ] Adjust the existing 65 shared validator tests if any drift from the new form-side schema (none expected; the shared `exitCodeSeverityMappingSchema` is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)