### PR TITLE
fix(devices): add elevation_requests to denorm tables list

### DIFF
--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -95,6 +95,7 @@ export const DEVICE_ORG_DENORMALIZED_TABLES = [
   'device_reliability', 'device_reliability_history', 'device_sessions',
   'device_warranty',
   'dns_event_aggregations', 'dns_security_events',
+  'elevation_requests',
   'group_membership_log',
   'huntress_agents', 'huntress_incidents', 'hyperv_vms', 'local_vaults',
   'peripheral_events', 'playbook_executions',
@@ -111,12 +112,14 @@ export const DEVICE_ORG_DENORMALIZED_TABLES = [
 
 /**
  * Tables that are both device-id scoped AND denormalize site_id for query-perf.
- * Currently empty — no device-id-scoped child table has a site_id column.
- * Forward-defense list: any future schema PR adding site_id to such a table
- * will be caught by the moveOrg.coverage.test.ts drift-detector below and
- * must be added here so cross-org-cross-site moves rewrite child site_ids.
+ * Cross-org-cross-site moves via POST /devices/:id/move-org must rewrite each
+ * row's site_id alongside org_id, or those rows strand under the OLD site_id.
+ * The moveOrg.coverage.test.ts drift-detector enforces that any future
+ * schema PR adding site_id to a device-id-scoped table populates this list.
  */
-export const DEVICE_SITE_DENORMALIZED_TABLES = [] as const;
+export const DEVICE_SITE_DENORMALIZED_TABLES = [
+  'elevation_requests',
+] as const;
 
 /**
  * All tables with a direct device_id FK to devices.id, ordered so children come

--- a/apps/api/src/routes/devices/moveOrg.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.test.ts
@@ -51,7 +51,7 @@ import { getDeviceWithOrgAndSiteCheck } from './helpers';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { disconnectAgent } from '../agentWs';
 import { moveOrgRoutes } from './moveOrg';
-import { DEVICE_ORG_DENORMALIZED_TABLES } from './core';
+import { DEVICE_ORG_DENORMALIZED_TABLES, DEVICE_SITE_DENORMALIZED_TABLES } from './core';
 
 // Snapshot the gate registration BEFORE any `vi.clearAllMocks()` runs.
 // requireScope/requirePermission/requireMfa run at module-import time as the
@@ -224,8 +224,13 @@ describe('POST /devices/:id/move-org', () => {
       // Every denormalized table got an UPDATE issued in the transaction.
       // This is the unit-test proxy for "RLS will read from the new org
       // only post-move": each row in those tables has its org_id rewritten
-      // to the new org, so RLS in the OLD org no longer matches it.
-      expect(updatedTables).toEqual([...DEVICE_ORG_DENORMALIZED_TABLES]);
+      // to the new org, so RLS in the OLD org no longer matches it. The
+      // SITE loop runs second and any table in DEVICE_SITE_DENORMALIZED_TABLES
+      // appears in updatedTables a second time for the site_id rewrite.
+      expect(updatedTables).toEqual([
+        ...DEVICE_ORG_DENORMALIZED_TABLES,
+        ...DEVICE_SITE_DENORMALIZED_TABLES,
+      ]);
 
       // After the move, the live WS for this agent MUST be closed so the
       // reconnect handshake resolves the new org_id. Otherwise every


### PR DESCRIPTION
Closes the bookkeeping gap left over from #905 (PAM elevation_requests schema). The drift-detector tests added in #875 caught it on main:

```
FAIL src/routes/devices/moveOrg.coverage.test.ts > DEVICE_ORG_DENORMALIZED_TABLES coverage
  Missing: elevation_requests

FAIL src/routes/devices/moveOrg.coverage.test.ts > DEVICE_SITE_DENORMALIZED_TABLES coverage
  Missing: elevation_requests
```

`elevation_requests` has both `org_id` and `site_id` columns (Track 1 Shape-1 tenancy with denormalized lookups). Without this fix, moving a device with active PAM elevation requests via `POST /devices/:id/move-org` would strand them under the OLD org/site_id — invisible to the new tenant via RLS.

## What changes

- `apps/api/src/routes/devices/core.ts` — add `'elevation_requests'` to both `DEVICE_ORG_DENORMALIZED_TABLES` and `DEVICE_SITE_DENORMALIZED_TABLES`. Update `DEVICE_SITE_DENORMALIZED_TABLES`'s comment now that the list is no longer empty.
- `apps/api/src/routes/devices/moveOrg.test.ts` — the happy-path assertion only expected `DEVICE_ORG_DENORMALIZED_TABLES` entries in the captured `updatedTables` list. The site-loop was added in #875 but was a no-op when `DEVICE_SITE_DENORMALIZED_TABLES` was empty. Now that the site list has an entry, the test correctly asserts both org-loop + site-loop UPDATEs.

## Verification

```
pnpm exec tsc --noEmit                                  clean
pnpm exec vitest run moveOrg.coverage.test.ts           6/6 pass
pnpm exec vitest run moveOrg.test.ts                    10/10 pass
pnpm exec vitest run cascadeDelete.test.ts              3/3 pass
pnpm exec vitest run (full apps/api)                    5051 pass | 2 fail | 28 skipped
```

The 2 remaining failures are in `admin/abuse.test.ts` (`suppresses raw tokenRevocationFailures...` and `still returns 200 when createAuditLog itself throws`). These are pre-existing on main, not touched here, and look like cascading effects from one of the recent security PRs (#909/#918/#923). Flagging for separate triage.

## Why a separate PR

This is unblocking work for upcoming PAM Track 3 (which I'm holding locally until main is green). Keeping it surgical and self-merge-fast so the next bigger PR can rebase on a green base.