### PR TITLE
fix(enrollment-keys): reject unknown fields on POST/PATCH (closes #945)

### DIFF
--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -475,6 +475,12 @@ const listEnrollmentKeysSchema = z.object({
 // pending the partner-level cap (max ttl) that gates it.
 const MAX_TTL_MINUTES = 525_600;
 
+// `.strict()` on every write schema: unknown keys surface as a Zod
+// `unrecognized_keys` issue (HTTP 400 via zValidator) instead of being
+// silently dropped. A common foot-gun is a caller sending `maxUses` when
+// the canonical field is `maxUsage` — without strict mode the request
+// returned 201 with `maxUsage: 1` (the default), masking the typo.
+// Closes #945.
 const createEnrollmentKeySchema = z.object({
   orgId: z.string().uuid().optional(),
   siteId: z.string().uuid().optional(),
@@ -482,7 +488,7 @@ const createEnrollmentKeySchema = z.object({
   maxUsage: z.number().int().min(1).max(100000).optional(),
   expiresAt: z.string().datetime().optional(),
   ttlMinutes: z.number().int().min(1).max(MAX_TTL_MINUTES).optional(),
-}).refine(
+}).strict().refine(
   (data) => !(data.expiresAt !== undefined && data.ttlMinutes !== undefined),
   { message: 'Pass either ttlMinutes or expiresAt, not both', path: ['ttlMinutes'] }
 );
@@ -490,7 +496,7 @@ const createEnrollmentKeySchema = z.object({
 const rotateEnrollmentKeySchema = z.object({
   maxUsage: z.number().int().min(1).max(100000).nullable().optional(),
   expiresAt: z.string().datetime().optional(),
-});
+}).strict();
 
 // ttlMinutes here sets the lifetime of the *child* key — the downloaded
 // installer / shared short-link the admin actually distributes. Measured
@@ -505,7 +511,7 @@ const installerLinkSchema = z.object({
   platform: z.enum(["windows", "macos"]),
   count: z.number().int().min(1).max(100000).optional(),
   ttlMinutes: z.number().int().min(1).max(MAX_TTL_MINUTES).optional(),
-});
+}).strict();
 
 function sanitizeEnrollmentKey(
   enrollmentKey: typeof enrollmentKeys.$inferSelect,
@@ -1246,7 +1252,7 @@ enrollmentKeyRoutes.get(
 
 const bootstrapTokenBodySchema = z.object({
   maxUsage: z.number().int().min(1).max(1000).default(1),
-});
+}).strict();
 
 enrollmentKeyRoutes.post(
   "/:id/bootstrap-token",

--- a/apps/api/src/routes/enrollmentKeys_strict.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_strict.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Strict-mode regression tests for enrollment-key write schemas.
+ *
+ * Closes #945 — a misspelled `maxUses` (canonical: `maxUsage`) used to be
+ * silently dropped by Zod's permissive default, and the request returned
+ * 201 with the server default for maxUsage. After `.strict()` was added to
+ * each write schema, unknown fields surface as a 400 with the offending
+ * key name in the response body.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  enrollmentKeys: {
+    id: 'enrollmentKeys.id',
+    orgId: 'enrollmentKeys.orgId',
+    siteId: 'enrollmentKeys.siteId',
+    name: 'enrollmentKeys.name',
+    key: 'enrollmentKeys.key',
+    maxUsage: 'enrollmentKeys.maxUsage',
+    usageCount: 'enrollmentKeys.usageCount',
+    expiresAt: 'enrollmentKeys.expiresAt',
+    createdAt: 'enrollmentKeys.createdAt',
+    createdBy: 'enrollmentKeys.createdBy',
+  },
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', {
+      user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+      scope: 'organization',
+      partnerId: null,
+      orgId: 'org-111',
+      accessibleOrgIds: ['org-111'],
+      orgCondition: () => undefined,
+      canAccessOrg: (id: string) => id === 'org-111',
+    });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+vi.mock('../services/auditService', () => ({
+  createAuditLogAsync: vi.fn(),
+}));
+
+vi.mock('../services/permissions', () => ({
+  PERMISSIONS: {
+    ORGS_READ: { resource: 'orgs', action: 'read' },
+    ORGS_WRITE: { resource: 'orgs', action: 'write' },
+  },
+}));
+
+vi.mock('../services/enrollmentKeySecurity', () => ({
+  hashEnrollmentKey: vi.fn((key: string) => `hashed_${key}`),
+  hashEnrollmentKeyCandidates: vi.fn((key: string) => [`hashed_${key}`]),
+}));
+
+vi.mock('../services/redis', () => ({
+  getRedis: vi.fn(() => ({})),
+}));
+
+vi.mock('../services/rate-limit', () => ({
+  rateLimiter: vi.fn(async () => ({ allowed: true, remaining: 10, resetAt: new Date() })),
+}));
+
+import { enrollmentKeyRoutes } from './enrollmentKeys';
+
+const KEY_ID = '11111111-1111-1111-1111-111111111111';
+
+const HEADERS = {
+  'Content-Type': 'application/json',
+  Authorization: 'Bearer token',
+} as const;
+
+/**
+ * The Hono zValidator default error hook returns `c.json({ success: false,
+ * error }, 400)` where `error` is the serialized ZodError. The exact JSON
+ * shape isn't part of our public contract, so this helper just stringifies
+ * the body and asserts the offending key name appears somewhere in it —
+ * enough to confirm the unknown-key was surfaced to the caller.
+ */
+async function bodyContains(res: Response, needle: string): Promise<boolean> {
+  const text = await res.text();
+  return text.includes(needle);
+}
+
+describe('enrollment key routes — strict mode (closes #945)', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/enrollment-keys', enrollmentKeyRoutes);
+  });
+
+  describe('POST /enrollment-keys', () => {
+    it('rejects misspelled maxUses with 400 and surfaces the unknown key', async () => {
+      const res = await app.request('/enrollment-keys', {
+        method: 'POST',
+        headers: HEADERS,
+        body: JSON.stringify({ name: 'Typo key', maxUses: 5 }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(await bodyContains(res, 'maxUses')).toBe(true);
+    });
+
+    it('rejects an arbitrary unknown field with 400', async () => {
+      const res = await app.request('/enrollment-keys', {
+        method: 'POST',
+        headers: HEADERS,
+        body: JSON.stringify({ name: 'Key', somethingRandom: 'value' }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(await bodyContains(res, 'somethingRandom')).toBe(true);
+    });
+  });
+
+  describe('POST /enrollment-keys/:id/rotate', () => {
+    it('rejects misspelled maxUses with 400', async () => {
+      const res = await app.request(`/enrollment-keys/${KEY_ID}/rotate`, {
+        method: 'POST',
+        headers: HEADERS,
+        body: JSON.stringify({ maxUses: 5 }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(await bodyContains(res, 'maxUses')).toBe(true);
+    });
+  });
+
+  describe('POST /enrollment-keys/:id/installer-link', () => {
+    it('rejects unknown field with 400', async () => {
+      const res = await app.request(`/enrollment-keys/${KEY_ID}/installer-link`, {
+        method: 'POST',
+        headers: HEADERS,
+        body: JSON.stringify({ platform: 'windows', maxUses: 5 }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(await bodyContains(res, 'maxUses')).toBe(true);
+    });
+  });
+
+  describe('POST /enrollment-keys/:id/bootstrap-token', () => {
+    it('rejects unknown field with 400', async () => {
+      const res = await app.request(`/enrollment-keys/${KEY_ID}/bootstrap-token`, {
+        method: 'POST',
+        headers: HEADERS,
+        body: JSON.stringify({ maxUses: 5 }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(await bodyContains(res, 'maxUses')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `apps/api/src/routes/enrollmentKeys.ts`: add `.strict()` to every Zod schema gating a write op so unknown fields return 400 instead of being silently dropped
- A misspelled `maxUses` (canonical: `maxUsage`) on `POST /enrollment-keys` used to land 201 with `maxUsage: 1` (the server default); now it returns 400 and surfaces the unknown key name in the response body

## Schemas tightened

- `createEnrollmentKeySchema` (POST /enrollment-keys)
- `rotateEnrollmentKeySchema` (POST /:id/rotate)
- `installerLinkSchema` (POST /:id/installer-link)
- `bootstrapTokenBodySchema` (POST /:id/bootstrap-token)

## Tests

New `apps/api/src/routes/enrollmentKeys_strict.test.ts` — 5 cases exercising each route with a misspelled-field payload, asserting `400` plus the offending key name in the response body.

Existing enrollment-key test suite: 88 → 93 tests, all passing.

`npx tsc --noEmit` in `apps/api`: clean.

## Test plan
- [x] `pnpm test run src/routes/enrollmentKeys*.test.ts` — 93 passed
- [x] `npx tsc --noEmit` in `apps/api` — clean

Closes #945

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>