### PR TITLE
fix(enrollment): only consume key after successful device insert (closes #946)

### DIFF
--- a/apps/api/src/routes/agents.test.ts
+++ b/apps/api/src/routes/agents.test.ts
@@ -319,7 +319,10 @@ describe('agent routes', () => {
         update: vi.fn().mockReturnValue({
           set: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
-              returning: vi.fn().mockResolvedValue([])
+              // #946: in-tx consume-key UPDATE must return one row to indicate
+              // a successful claim. An empty array triggers the race-lost
+              // sentinel and rolls back the device INSERT.
+              returning: vi.fn().mockResolvedValue([{ id: 'key-123' }])
             })
           })
         })
@@ -442,7 +445,10 @@ describe('agent routes', () => {
         update: vi.fn().mockReturnValue({
           set: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
-              returning: vi.fn().mockResolvedValue([])
+              // #946: in-tx consume-key UPDATE must return one row to indicate
+              // a successful claim. An empty array triggers the race-lost
+              // sentinel and rolls back the device INSERT.
+              returning: vi.fn().mockResolvedValue([{ id: 'key-123' }])
             })
           })
         })
@@ -542,7 +548,10 @@ describe('agent routes', () => {
         update: vi.fn().mockReturnValue({
           set: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
-              returning: vi.fn().mockResolvedValue([])
+              // #946: in-tx consume-key UPDATE must return one row to indicate
+              // a successful claim. An empty array triggers the race-lost
+              // sentinel and rolls back the device INSERT.
+              returning: vi.fn().mockResolvedValue([{ id: 'key-123' }])
             })
           })
         })

--- a/apps/api/src/routes/agents/enrollment.test.ts
+++ b/apps/api/src/routes/agents/enrollment.test.ts
@@ -226,8 +226,10 @@ describe('POST /agents/enroll — 401 reason disambiguation', () => {
   });
 
   it('accepts a valid (unexpired, non-exhausted) row and does not return 401 at the lookup stage', async () => {
-    // Valid lookup → then downstream update fetch returns no row → race-lost branch.
-    // We just want to assert the 401 reason is NOT one of the three above.
+    // Valid lookup → the in-transaction claim UPDATE affects 0 rows → race-lost branch.
+    // #946: the increment used to live outside the transaction; it is now the
+    // last statement inside it, so we simulate the race by having the
+    // transaction's tx.update().returning() return [].
     mockKeyLookup({
       id: 'key-3',
       orgId: 'org-3',
@@ -238,14 +240,44 @@ describe('POST /agents/enroll — 401 reason disambiguation', () => {
       usageCount: 0,
     });
 
-    // Downstream update: return empty (race condition path) so we stop there
-    vi.mocked(db.update).mockReturnValueOnce({
-      set: vi.fn(() => ({
-        where: vi.fn(() => ({
-          returning: vi.fn().mockResolvedValue([]),
-        })),
-      })),
-    } as any);
+    mockSelectRows([{ partnerId: 'partner-3' }]);
+    mockSelectRows([{ maxDevices: null }]);
+    mockSelectRows([]); // no existing device
+
+    // Inside the transaction: device INSERT succeeds, then the consume-key
+    // UPDATE returns [] (race-lost). The route throws the sentinel and the
+    // transaction rolls back; outer catch surfaces the 401.
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
+      const fakeTx = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 0 }]),
+          }),
+        }),
+        insert: vi.fn().mockReturnValue({
+          values: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{
+              id: 'device-race-lost',
+              orgId: 'org-3',
+              siteId: 'site-3',
+              hostname: 'host-1',
+            }]),
+            onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+          }),
+        }),
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([]),
+            }),
+          }),
+        }),
+        delete: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      };
+      return fn(fakeTx);
+    });
 
     const resp = await buildApp().request('/agents/enroll', {
       method: 'POST',
@@ -417,9 +449,11 @@ describe('POST /agents/enroll — 401 reason disambiguation', () => {
     // decommissioned and only its hostname is rewritten inside the
     // transaction. So we no longer queue a top-level db.update() here.
 
-    // Transaction: rename + INSERT-new. The decom-bypass-fresh-id path
-    // executes tx.update() once (to rename the old row's hostname) THEN
-    // tx.insert().returning() to create a fresh row with a new id.
+    // Transaction: rename + INSERT-new + consume-key. The decom-bypass-fresh-id
+    // path executes tx.update() to rename the old row's hostname, then
+    // tx.insert().returning() to create a fresh row with a new id, then
+    // tx.update(enrollmentKeys).set().where().returning() to consume the key
+    // (#946 — increment moved into the transaction, last statement).
     vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
       const fakeTx = {
         select: vi.fn().mockReturnValue({
@@ -429,7 +463,10 @@ describe('POST /agents/enroll — 401 reason disambiguation', () => {
         }),
         update: vi.fn().mockReturnValue({
           set: vi.fn().mockReturnValue({
-            where: vi.fn().mockResolvedValue(undefined),
+            where: vi.fn(() => Object.assign(
+              Promise.resolve(undefined) as any,
+              { returning: vi.fn().mockResolvedValue([{ id: 'key-decom' }]) }
+            )),
           }),
         }),
         insert: vi.fn().mockReturnValue({
@@ -872,7 +909,10 @@ describe('POST /agents/enroll — manifestTrustKeys delivery (#639)', () => {
     // Step 5: existing-device lookup → empty (fresh enrollment)
     mockSelectRows([]);
 
-    // Step 6: db.transaction returns the inserted device row directly.
+    // Step 6: db.transaction runs device INSERT then the in-tx key-consume
+    // UPDATE (#946). The fake tx supports both chains:
+    //   - tx.insert(devices).values(...).returning() → new device row
+    //   - tx.update(enrollmentKeys).set(...).where(...).returning() → [{id}]
     vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
       const fakeTx = {
         select: vi.fn().mockReturnValue({
@@ -895,6 +935,13 @@ describe('POST /agents/enroll — manifestTrustKeys delivery (#639)', () => {
             onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
           }),
         }),
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: 'key-happy' }]),
+            }),
+          }),
+        }),
         delete: vi.fn().mockReturnValue({
           where: vi.fn().mockResolvedValue(undefined),
         }),
@@ -914,5 +961,269 @@ describe('POST /agents/enroll — manifestTrustKeys delivery (#639)', () => {
     expect(Array.isArray(body.manifestTrustKeys)).toBe(true);
     expect(body.manifestTrustKeys).toEqual(trustKeys);
     expect(manifestSigning.getActiveTrustKeyset).toHaveBeenCalled();
+  });
+});
+
+describe('POST /agents/enroll — enrollment key not consumed on failed device insert (#946)', () => {
+  // Issue #946: pre-fix, `enrollment_keys.usage_count` was incremented during
+  // key validation, before the device INSERT. Any post-validation failure
+  // (hostname collision, device-limit, suspended-decom-token, etc.) would
+  // silently burn a single-use key without ever creating a device — leaving
+  // the customer with an exhausted key and no enrolled host.
+  //
+  // Post-fix: the increment is the last statement inside the device
+  // transaction. Failures roll back the device INSERT *and* the increment
+  // atomically; a successful enrollment is the only path that bumps the
+  // counter.
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.AGENT_ENROLLMENT_SECRET;
+    process.env.NODE_ENV = 'test';
+  });
+
+  it('does NOT call db.update(enrollment_keys) on the hostname-collision 409 path', async () => {
+    // maxUsage: 1, usageCount: 0 — a single-use key. The hostname-collision
+    // path returns 409 BEFORE the transaction opens. The buggy code path
+    // would have bumped usage_count to 1 here (now permanently exhausted).
+    // The fix never touches the row.
+    mockKeyLookup({
+      id: 'key-once',
+      orgId: 'org-once',
+      siteId: 'site-once',
+      keySecretHash: null,
+      expiresAt: new Date(Date.now() + 3600_000),
+      maxUsage: 1,
+      usageCount: 0,
+    });
+
+    mockSelectRows([{ partnerId: 'partner-once' }]);
+    mockSelectRows([{ maxDevices: null }]);
+    // Existing device row in a status that triggers a hostname-collision 409
+    mockSelectRows([{
+      id: 'device-collision',
+      status: 'online',
+      agentTokenHash: 'someone-elses-token',
+      previousTokenHash: null,
+      previousTokenExpiresAt: null,
+    }]);
+
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody),
+    });
+
+    expect(resp.status).toBe(409);
+    const body = await resp.json();
+    expect(body.reason).toBe('hostname_collision_requires_existing_device_token');
+
+    // The fix: db.update was never invoked (no standalone pre-insert
+    // increment, no transaction opened). Pre-fix, db.update would have
+    // been called exactly once to bump usage_count.
+    expect(db.update).not.toHaveBeenCalled();
+    // And no transaction was opened, so the in-tx consume never ran either.
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call db.update(enrollment_keys) on the suspended-decom-token 409 path', async () => {
+    // Another failure path that previously consumed the key — a decommissioned
+    // row whose token was probe-suspended. The route returns 409 before any
+    // device write, and the fix means the counter is untouched.
+    mockKeyLookup({
+      id: 'key-suspended',
+      orgId: 'org-suspended',
+      siteId: 'site-suspended',
+      keySecretHash: null,
+      expiresAt: new Date(Date.now() + 3600_000),
+      maxUsage: 1,
+      usageCount: 0,
+    });
+
+    mockSelectRows([{ partnerId: 'partner-suspended' }]);
+    mockSelectRows([{ maxDevices: null }]);
+    mockSelectRows([{
+      id: 'device-suspended',
+      status: 'decommissioned',
+      agentTokenHash: 'old-hash',
+      previousTokenHash: null,
+      previousTokenExpiresAt: null,
+      agentTokenSuspendedAt: new Date('2026-05-25T12:00:00Z'),
+    }]);
+
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody),
+    });
+
+    expect(resp.status).toBe(409);
+    expect(db.update).not.toHaveBeenCalled();
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+
+  it('consumes the key ONLY inside the device transaction on the success path', async () => {
+    // Happy path: lookup → org/partner → no existing device → transaction
+    // opens → INSERT new device → consume key inside the same tx → 201.
+    // Asserts that the standalone pre-insert db.update is gone (it would
+    // have been called exactly once before the device write), and that the
+    // tx-internal update of enrollment_keys WAS called (the new location).
+    mockKeyLookup({
+      id: 'key-success',
+      orgId: 'org-success',
+      siteId: 'site-success',
+      keySecretHash: null,
+      expiresAt: new Date(Date.now() + 3600_000),
+      maxUsage: 1,
+      usageCount: 0,
+    });
+
+    mockSelectRows([{ partnerId: 'partner-success' }]);
+    mockSelectRows([{ maxDevices: null }]);
+    mockSelectRows([]); // no existing device
+
+    let txUpdateCalls = 0;
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
+      const fakeTx = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 0 }]),
+          }),
+        }),
+        insert: vi.fn().mockReturnValue({
+          values: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{
+              id: 'device-success',
+              orgId: 'org-success',
+              siteId: 'site-success',
+              hostname: 'host-1',
+            }]),
+            onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+          }),
+        }),
+        update: vi.fn(() => {
+          txUpdateCalls += 1;
+          return {
+            set: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                returning: vi.fn().mockResolvedValue([{ id: 'key-success' }]),
+              }),
+            }),
+          };
+        }),
+        delete: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      };
+      return fn(fakeTx);
+    });
+
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody),
+    });
+
+    expect(resp.status).toBe(201);
+    // The standalone pre-insert UPDATE is gone — db.update (the top-level
+    // mock) is never called.
+    expect(db.update).not.toHaveBeenCalled();
+    // The transaction's tx.update WAS called exactly once: to consume the key.
+    expect(txUpdateCalls).toBe(1);
+  });
+
+  it('rolls back the key consume when the in-transaction claim loses the TOCTOU race', async () => {
+    // Race scenario: lookup observed maxUsage > usageCount, device INSERT
+    // succeeded, but a concurrent enrollment drained the last slot before
+    // we got to the consume step. The in-tx UPDATE returns 0 rows; the
+    // route throws the sentinel and the transaction rolls back. Device
+    // INSERT is undone; counter unchanged. Response is 401
+    // enrollment_key_race_lost (same wire-format as before the move).
+    mockKeyLookup({
+      id: 'key-race',
+      orgId: 'org-race',
+      siteId: 'site-race',
+      keySecretHash: null,
+      expiresAt: new Date(Date.now() + 3600_000),
+      maxUsage: 1,
+      usageCount: 0,
+    });
+
+    mockSelectRows([{ partnerId: 'partner-race' }]);
+    mockSelectRows([{ maxDevices: null }]);
+    mockSelectRows([]); // no existing device
+
+    let txUpdateReturnedZero = false;
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
+      const fakeTx = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 0 }]),
+          }),
+        }),
+        insert: vi.fn().mockReturnValue({
+          values: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{
+              id: 'device-race',
+              orgId: 'org-race',
+              siteId: 'site-race',
+              hostname: 'host-1',
+            }]),
+            onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+          }),
+        }),
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn(() => {
+                txUpdateReturnedZero = true;
+                return Promise.resolve([]);
+              }),
+            }),
+          }),
+        }),
+        delete: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      };
+      // The real Postgres transaction would re-throw the sentinel and
+      // rollback. We propagate the throw so the outer route handler
+      // catches it and surfaces the 401.
+      return fn(fakeTx);
+    });
+
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody),
+    });
+
+    expect(resp.status).toBe(401);
+    const body = await resp.json();
+    expect(body.reason).toBe('enrollment_key_race_lost');
+    expect(txUpdateReturnedZero).toBe(true);
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        details: expect.objectContaining({ reason: 'enrollment_key_race_lost' }),
+        result: 'denied',
+      })
+    );
+  });
+
+  it('does not increment for bogus keys — 401 enrollment_key_not_found writes nothing', async () => {
+    // Anti-goal guard: the validation itself must remain eager. A bogus
+    // key 401s without any DB write (no lookup-row, no update, no txn).
+    mockKeyLookup(undefined);
+
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody),
+    });
+
+    expect(resp.status).toBe(401);
+    expect(db.update).not.toHaveBeenCalled();
+    expect(db.transaction).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/agents/enrollment.ts
+++ b/apps/api/src/routes/agents/enrollment.ts
@@ -286,39 +286,19 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
       throw new HTTPException(400, { message: 'Enrollment key must be associated with a site' });
     }
 
-    const [key] = await db
-      .update(enrollmentKeys)
-      .set({ usageCount: sql`${enrollmentKeys.usageCount} + 1` })
-      .where(
-        and(
-          eq(enrollmentKeys.id, matchingKey.id),
-          ...validEnrollmentKeyConditions
-        )
-      )
-      .returning();
+    // The enrollment key is NOT consumed here — only validated. The actual
+    // usage_count bump happens inside the transaction below, *after* the
+    // device INSERT/UPDATE succeeds. Issue #946: previously, the increment
+    // ran before the device write, so any post-validation failure
+    // (hostname collision, device limit, etc.) silently burned a single-
+    // use key without ever creating a device.
+    const key = {
+      id: matchingKey.id,
+      orgId: matchingKey.orgId,
+      siteId: matchingKey.siteId,
+    };
 
-    if (!key) {
-      // The row existed at step 1 but the re-validated UPDATE affected 0
-      // rows — the key expired or was exhausted between the initial lookup
-      // and the claim. Distinct reason so this specific race is visible in
-      // the audit log and the client can retry with a fresh installer.
-      writeAuditEvent(c, {
-        orgId: matchingKey.orgId,
-        actorType: 'system',
-        action: 'agent.enroll',
-        resourceType: 'device',
-        resourceName: data.hostname,
-        details: { reason: 'enrollment_key_race_lost', keyId: matchingKey.id },
-        result: 'denied',
-        errorMessage: 'Enrollment key was claimed by another enrollment in the same moment',
-      });
-      return c.json({
-        error: 'Enrollment key was just exhausted or expired — regenerate a fresh key or installer link',
-        reason: 'enrollment_key_race_lost',
-      }, 401);
-    }
-
-    const siteId = key.siteId!; // non-null asserted: matchingKey.siteId guard at line 180
+    const siteId = key.siteId!; // non-null asserted: matchingKey.siteId guard above
 
     // Fetch partner device limit (used inside transaction below)
     let deviceLimitPartnerId: string | null = null;
@@ -476,7 +456,16 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
     // (the old row stays decommissioned), and the non-decom branches
     // never reach this point with status='decommissioned' — so that
     // top-level UPDATE is now unreachable and has been removed.
-    const device = await db.transaction(async (tx) => {
+    //
+    // #946: in-transaction sentinel used to translate "enrollment-key
+    // claim lost the TOCTOU race" into the 401 enrollment_key_race_lost
+    // response after rolling back the device INSERT. Any other throw in
+    // the transaction propagates normally (HTTPException for device-limit,
+    // generic 500 for unexpected failures).
+    const ENROLLMENT_KEY_RACE_LOST = Symbol('enrollment_key_race_lost');
+    let device;
+    try {
+      device = await db.transaction(async (tx) => {
       // Device limit check inside transaction to prevent TOCTOU race.
       // Runs when no existing row OR when the decom-bypass-fresh-id path
       // (#914) is going to INSERT a new active row — both grow net active
@@ -650,8 +639,54 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
         }
       }
 
+      // #946: consume the enrollment key ONLY after the device row has
+      // been successfully written. We re-apply the validity conditions
+      // (`expiresAt`/`maxUsage`) to preserve the TOCTOU protection that
+      // the standalone pre-insert UPDATE used to provide. If a concurrent
+      // claim drained the last slot between our initial lookup and this
+      // point, the UPDATE affects 0 rows; we throw the sentinel and the
+      // transaction rolls back — the device INSERT is undone and the
+      // caller receives 401 enrollment_key_race_lost.
+      const claimed = await tx
+        .update(enrollmentKeys)
+        .set({ usageCount: sql`${enrollmentKeys.usageCount} + 1` })
+        .where(
+          and(
+            eq(enrollmentKeys.id, matchingKey.id),
+            ...validEnrollmentKeyConditions
+          )
+        )
+        .returning({ id: enrollmentKeys.id });
+
+      if (claimed.length === 0) {
+        throw ENROLLMENT_KEY_RACE_LOST;
+      }
+
       return dev;
     });
+    } catch (err) {
+      if (err === ENROLLMENT_KEY_RACE_LOST) {
+        // The device INSERT was rolled back along with the failed key
+        // claim. Surface the same `enrollment_key_race_lost` reason the
+        // standalone pre-insert UPDATE used to emit, so clients and audit
+        // logs stay backwards-compatible.
+        writeAuditEvent(c, {
+          orgId: matchingKey.orgId,
+          actorType: 'system',
+          action: 'agent.enroll',
+          resourceType: 'device',
+          resourceName: data.hostname,
+          details: { reason: 'enrollment_key_race_lost', keyId: matchingKey.id },
+          result: 'denied',
+          errorMessage: 'Enrollment key was claimed by another enrollment in the same moment',
+        });
+        return c.json({
+          error: 'Enrollment key was just exhausted or expired — regenerate a fresh key or installer link',
+          reason: 'enrollment_key_race_lost',
+        }, 401);
+      }
+      throw err;
+    }
 
     const mtlsCert = await issueMtlsCertForDevice(device.id, key.orgId);
 


### PR DESCRIPTION
## Summary

- Move the `enrollment_keys.usage_count` increment from key validation into the device transaction, executed as the last statement before commit. Failures between validation and the device write (hostname collision, suspended decom, device limit, etc.) no longer burn single-use keys.
- Preserve the public API contract: same `enrollment_key_race_lost` 401 shape via a sentinel that rolls back the transaction. Validation itself remains eager — bogus / expired / exhausted keys still 401 with zero DB writes.
- Re-apply the validity conditions (`expiresAt` / `usage_count < max_usage`) inside the in-tx UPDATE so concurrent claims still race correctly — the losing transaction rolls back the device INSERT.

## Approach

**Option A** (single transaction wrapping device write + key consume) from the issue. Cleanest fit for the existing route style (already uses `db.transaction(...)` for the device write) and naturally handles rollback.

## Test plan

Regression coverage in `apps/api/src/routes/agents/enrollment.test.ts`:

- [x] `does NOT call db.update(enrollment_keys) on the hostname-collision 409 path` — single-use key stays at `usage_count=0` after collision (the core bug guard).
- [x] `does NOT call db.update(enrollment_keys) on the suspended-decom-token 409 path` — second pre-insert failure path also leaves counter intact.
- [x] `consumes the key ONLY inside the device transaction on the success path` — proves standalone pre-insert update is gone and the in-tx update fires exactly once.
- [x] `rolls back the key consume when the in-transaction claim loses the TOCTOU race` — TOCTOU semantics preserved; 401 `enrollment_key_race_lost` wire format unchanged.
- [x] `does not increment for bogus keys — 401 enrollment_key_not_found writes nothing` — validation still eager, anti-goal honored.

Local test runs:
- [x] `pnpm vitest run src/routes/agents/enrollment.test.ts` — 20/20 passing (was 15; added 5).
- [x] `pnpm vitest run src/routes/agents.test.ts` — 24/24 passing (3 tx mocks updated to return a row from the in-tx consume).
- [x] `pnpm vitest run src/routes/agents` — 167/167 passing across 19 files.
- [x] `pnpm vitest run src/routes/enrollmentKeys*.test.ts` — 88/88 passing.
- [x] `npx tsc --noEmit` in `apps/api` — zero errors.

## Concurrency notes

- The TOCTOU re-check inside the transaction (`WHERE id = :id AND usage_count < max_usage AND (expires_at IS NULL OR expires_at > NOW())`) is the same condition the standalone UPDATE used. Two concurrent enrollments racing the last slot of a `maxUsage=1` key: one's UPDATE returns 1 row and commits; the other's returns 0 rows and rolls back its device INSERT with a `401 enrollment_key_race_lost`. Net effect: at most one device per slot.
- Decom-bypass path (#914) still works: rename → fresh INSERT → in-tx consume. Verified by existing test `allows re-enrollment without the existing-device token when the existing row is decommissioned`.
- The device-limit check inside the transaction also still rolls the consume back correctly because it throws `HTTPException` before reaching the consume statement.

Closes #946.

🤖 Generated with [Claude Code](https://claude.com/claude-code)