### PR TITLE
fix(web): wait for in-flight refresh before OrgSwitcher reload (closes #950)

### DIFF
--- a/apps/web/src/components/layout/OrgSwitcher.test.tsx
+++ b/apps/web/src/components/layout/OrgSwitcher.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import OrgSwitcher, { getOrgSwitchRedirect } from './OrgSwitcher';
@@ -7,6 +7,11 @@ const setOrganizationMock = vi.fn();
 const setSiteMock = vi.fn();
 const fetchOrganizationsMock = vi.fn();
 const fetchSitesMock = vi.fn();
+// vi.mock factories are hoisted; declare with vi.hoisted so the mock
+// factory below can close over the same reference.
+const { waitForPendingRefreshMock } = vi.hoisted(() => ({
+  waitForPendingRefreshMock: vi.fn().mockResolvedValue(undefined)
+}));
 
 let mockStoreState: {
   currentOrgId: string | null;
@@ -24,6 +29,13 @@ vi.mock('@/stores/orgStore', () => ({
     fetchOrganizations: fetchOrganizationsMock,
     fetchSites: fetchSitesMock
   })
+}));
+
+// Mock the auth store so the OrgSwitcher's #950 refresh-race guard
+// (waitForPendingRefresh) resolves immediately in unit tests without
+// pulling in the real zustand store + module-level state.
+vi.mock('@/stores/auth', () => ({
+  waitForPendingRefresh: waitForPendingRefreshMock
 }));
 
 describe('getOrgSwitchRedirect', () => {
@@ -58,6 +70,7 @@ describe('OrgSwitcher org change navigation', () => {
     setSiteMock.mockReset();
     fetchOrganizationsMock.mockReset();
     fetchSitesMock.mockReset();
+    waitForPendingRefreshMock.mockClear();
 
     mockStoreState = {
       currentOrgId: 'org-a',
@@ -114,19 +127,24 @@ describe('OrgSwitcher org change navigation', () => {
     fireEvent.click(orgButtons[0]);
   }
 
-  it('redirects to /devices when switching orgs from a device-detail page', () => {
+  it('redirects to /devices when switching orgs from a device-detail page', async () => {
     const { reloadMock, hrefSetter } = stubLocation('/devices/abc123');
 
     render(<OrgSwitcher />);
 
     openDropdownAndClickOrg('Org B');
 
+    // setOrganization is called synchronously inside the click handler.
     expect(setOrganizationMock).toHaveBeenCalledWith('org-b');
-    expect(hrefSetter).toHaveBeenCalledWith('/devices');
+    // The navigation step is gated behind await waitForPendingRefresh()
+    // (#950 fix) so it lands on a later microtask. waitFor handles the
+    // settle cycle.
+    await waitFor(() => expect(hrefSetter).toHaveBeenCalledWith('/devices'));
     expect(reloadMock).not.toHaveBeenCalled();
+    expect(waitForPendingRefreshMock).toHaveBeenCalled();
   });
 
-  it('reloads in place when switching orgs from a non-detail page', () => {
+  it('reloads in place when switching orgs from a non-detail page', async () => {
     const { reloadMock, hrefSetter } = stubLocation('/devices');
 
     render(<OrgSwitcher />);
@@ -134,8 +152,9 @@ describe('OrgSwitcher org change navigation', () => {
     openDropdownAndClickOrg('Org B');
 
     expect(setOrganizationMock).toHaveBeenCalledWith('org-b');
-    expect(reloadMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(reloadMock).toHaveBeenCalledTimes(1));
     expect(hrefSetter).not.toHaveBeenCalled();
+    expect(waitForPendingRefreshMock).toHaveBeenCalled();
   });
 
   it('does nothing when clicking the already-selected organization', () => {

--- a/apps/web/src/components/layout/OrgSwitcher.tsx
+++ b/apps/web/src/components/layout/OrgSwitcher.tsx
@@ -9,6 +9,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useOrgStore, type Organization, type Site } from '@/stores/orgStore';
+import { waitForPendingRefresh } from '@/stores/auth';
 
 /**
  * When switching organizations, certain detail-view routes show data scoped to
@@ -250,9 +251,16 @@ export default function OrgSwitcher() {
                   key={org.id}
                   org={org}
                   isSelected={org.id === currentOrgId}
-                  onSelect={() => {
+                  onSelect={async () => {
                     if (org.id !== currentOrgId) {
                       setOrganization(org.id);
+                      // Yield a microtask so setOrganization's downstream
+                      // fetchSites/etc has a chance to register itself with
+                      // tokenRefreshInFlight before we check. Then wait for
+                      // any pending refresh to settle so the post-reload
+                      // page doesn't race the same cookie jti. See #950.
+                      await Promise.resolve();
+                      await waitForPendingRefresh();
                       const redirect = getOrgSwitchRedirect(window.location.pathname);
                       if (redirect) {
                         window.location.href = redirect;
@@ -263,11 +271,15 @@ export default function OrgSwitcher() {
                   }}
                   sites={sites}
                   currentSiteId={currentSiteId}
-                  onSelectSite={(siteId) => {
+                  onSelectSite={async (siteId) => {
                     const changed = siteId !== currentSiteId;
                     setSite(siteId);
                     setIsOpen(false);
                     if (changed) {
+                      // Same refresh-race avoidance as the org-switch path
+                      // above — see #950.
+                      await Promise.resolve();
+                      await waitForPendingRefresh();
                       window.location.reload();
                     }
                   }}

--- a/apps/web/src/stores/auth.test.ts
+++ b/apps/web/src/stores/auth.test.ts
@@ -8,7 +8,9 @@ import {
   apiResetPassword,
   apiVerifyMFA,
   fetchWithAuth,
-  useAuthStore
+  restoreAccessTokenFromCookie,
+  useAuthStore,
+  waitForPendingRefresh
 } from './auth';
 
 const makeResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
@@ -301,5 +303,71 @@ describe('auth API helpers', () => {
 
     expect((fetchMock.mock.calls[0][1] as RequestInit).referrerPolicy).toBe('no-referrer');
     expect((fetchMock.mock.calls[1][1] as RequestInit).referrerPolicy).toBe('no-referrer');
+  });
+});
+
+describe('waitForPendingRefresh (#950)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves immediately when no refresh is in flight', async () => {
+    const before = Date.now();
+    await waitForPendingRefresh();
+    expect(Date.now() - before).toBeLessThan(50);
+  });
+
+  it('serializes behind an in-flight refresh', async () => {
+    // Block the underlying /auth/refresh call so the in-flight promise stays
+    // pending; resolve it later and assert waitForPendingRefresh resolves
+    // only AFTER the in-flight one settles. This is the core anti-race
+    // semantic — without it, the post-reload page beats the pre-reload page
+    // to its own cookie consumption.
+    let resolveRefresh!: (value: unknown) => void;
+    const refreshGate = new Promise((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      await refreshGate;
+      return makeResponse({ user: baseUser, tokens: baseTokens });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Kick off a refresh (don't await). restoreAccessTokenFromCookie uses
+    // the same shared in-flight gate that waitForPendingRefresh observes.
+    const inflight = restoreAccessTokenFromCookie();
+
+    // Microtask yield so the underlying requestTokenRefresh call has been
+    // dispatched and the module's tokenRefreshInFlight is populated.
+    await Promise.resolve();
+
+    let waitResolved = false;
+    const waitPromise = waitForPendingRefresh().then(() => {
+      waitResolved = true;
+    });
+
+    // Confirm we have NOT resolved yet — refresh is still pending.
+    await Promise.resolve();
+    expect(waitResolved).toBe(false);
+
+    // Unblock the refresh; waitForPendingRefresh should now resolve.
+    resolveRefresh(undefined);
+    await inflight;
+    await waitPromise;
+    expect(waitResolved).toBe(true);
+  });
+
+  it('does not propagate refresh failures', async () => {
+    // The whole point is serialization-without-coupling; if the pre-reload
+    // refresh threw, the caller (OrgSwitcher) still needs to proceed to its
+    // reload step so the post-reload page gets its own clean attempt.
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network down'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const inflight = restoreAccessTokenFromCookie();
+    await Promise.resolve();
+
+    await expect(waitForPendingRefresh()).resolves.toBeUndefined();
+    await inflight;
   });
 });

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -254,6 +254,32 @@ async function requestTokenRefreshShared(): Promise<Tokens | null> {
   return tokenRefreshInFlight;
 }
 
+/**
+ * Resolve when any in-flight token refresh has settled. Used by reload-class
+ * code paths (OrgSwitcher, SiteSwitcher) to avoid the post-reload page racing
+ * the pre-reload page on the same refresh cookie jti — see #950.
+ *
+ * The v0.67.0 launch-readiness security sweep (#900) introduced NX-claim
+ * refresh-token reuse-detection: only ONE concurrent /auth/refresh wins;
+ * the loser gets 401 AND has its refresh cookie cleared. If OrgSwitcher
+ * fires window.location.reload() while a refresh is mid-flight, the
+ * post-reload page hydrates fresh, its Astro islands fire /auth/refresh,
+ * lose the race, get the cookie cleared, and the user is bounced to /login.
+ *
+ * Returns immediately if no refresh is in flight. Swallows refresh errors —
+ * we only care about serialization; if the pre-reload refresh failed, the
+ * post-reload page will get its own fresh attempt with no race.
+ */
+export async function waitForPendingRefresh(): Promise<void> {
+  if (tokenRefreshInFlight) {
+    try {
+      await tokenRefreshInFlight;
+    } catch {
+      // Intentionally swallowed — see comment above.
+    }
+  }
+}
+
 export async function restoreAccessTokenFromCookie(): Promise<boolean> {
   try {
     const tokens = await requestTokenRefreshShared();


### PR DESCRIPTION
Closes #950 (P1 customer-facing).

## Approach

Option (a) from the issue: web hotfix that awaits any in-flight `tokenRefreshInFlight` before `window.location.reload()`. Keeps the API-side reuse-detection semantics intact (the whole point of #900) and unblocks both code paths Todd called out: org-switch AND site-switch (`OrgSwitcher.tsx:270`).

## Changes

| File | Δ | What |
|---|---|---|
| `apps/web/src/stores/auth.ts` | +24 LOC | Export `waitForPendingRefresh()`. Resolves immediately if no refresh is in flight; awaits the existing in-flight promise otherwise. Swallows refresh errors (caller only needs serialization, not the result — if the pre-reload refresh failed, the post-reload page will get its own clean attempt with no race). |
| `apps/web/src/components/layout/OrgSwitcher.tsx` | +14 LOC | Both `onSelect` handlers now `await Promise.resolve(); await waitForPendingRefresh();` before navigation. The microtask yield lets `setOrganization`'s downstream `fetchSites` kick off so it has a chance to register itself with `tokenRefreshInFlight` before we check. |
| `apps/web/src/stores/auth.test.ts` | +66 LOC | 3 new tests in a `waitForPendingRefresh (#950)` describe block: resolves-immediately, serializes-behind-in-flight (with controlled gate), does-not-propagate refresh-failures. |
| `apps/web/src/components/layout/OrgSwitcher.test.tsx` | +21 LOC, -8 LOC | Existing 2 navigation tests converted to `async` + `waitFor` (handlers are now async). New `vi.mock` for `@/stores/auth` using `vi.hoisted` so the mock factory can close over the same reference. |

## Verification

```
pnpm exec tsc --noEmit (apps/web)          clean (exit 0)
pnpm exec vitest run OrgSwitcher.test.tsx  7/7 pass
pnpm exec vitest run auth.test.ts          3/3 new pass (pre-existing
                                             failures unchanged)
pnpm exec vitest run (full apps/web)       600 passed (vs 597 on
                                             origin/main pre-fix);
                                             zero new regressions
```

Delta vs. `origin/main` (verified by stash + checkout): **+3 tests passing, 0 regressions.** The 23 pre-existing failures on main remain (environmental — `localStorage` undefined in some setup paths; same set fails on a clean `origin/main` checkout). Not introduced by this PR; left for separate triage.

## What's not in scope

- **Option (b)** from #950 (API-side raced-loser differentiation: distinguish race from replay, return 401 without clearing cookie or return winner's already-minted pair). Todd recommended that as a follow-up because the same race will eventually bite any other code path that triggers a reload during background refresh. Not in this PR.
- **The 23 pre-existing web-test failures.** Separate triage item.

## Edge cases considered

- **No refresh in flight when click fires:** `waitForPendingRefresh()` resolves immediately; no perceptible delay.
- **Refresh in flight + completes successfully:** post-reload page hydrates after the cookie has rotated; its own islands get a fresh access token without racing.
- **Refresh in flight + fails:** `waitForPendingRefresh` swallows; reload proceeds; post-reload page gets its own clean refresh attempt (no race since the failed one already cleared its in-flight slot).
- **User clicks the SAME org:** existing guard `if (org.id !== currentOrgId)` short-circuits before the await chain (unchanged behavior).
- **Concurrent click on a second org while first is still awaiting:** `setOrganization` writes immediately on the new click; the second await chain replaces the first's intent. Worst case is a benign extra wait, never a missed reload.

## Workaround for users still on v0.67.0 / v0.67.1

Per #950: open the new org in a new tab via Cmd/Ctrl+click — bypasses the refresh-cookie race entirely.