### PR TITLE
fix(security): align supply-chain guard with Node 24 LTS Dockerfile pin

### DIFF
--- a/scripts/security/check-supply-chain-hardening.sh
+++ b/scripts/security/check-supply-chain-hardening.sh
@@ -252,13 +252,13 @@ require_grep 'AUTH %s' scripts/prod/deploy.sh \
   "production deploy script must feed Redis AUTH through stdin"
 
 for dockerfile in apps/api/Dockerfile apps/web/Dockerfile docker/Dockerfile.api docker/Dockerfile.web; do
-  require_grep '^FROM[[:space:]]+node:26-alpine@sha256:[0-9a-f]{64}[[:space:]]+AS[[:space:]]+base' "$dockerfile" \
+  require_grep '^FROM[[:space:]]+node:24-alpine@sha256:[0-9a-f]{64}[[:space:]]+AS[[:space:]]+base' "$dockerfile" \
     "$dockerfile must digest-pin the Node base image while retaining the tag for Dependabot refreshes"
   reject_grep '^FROM[[:space:]]+node:[^[:space:]@]+([[:space:]]|$)' "$dockerfile" \
     "$dockerfile must not use tag-only Node base image references"
 done
 for dockerfile in apps/api/Dockerfile apps/web/Dockerfile; do
-  require_grep '^FROM[[:space:]]+node:26-alpine@sha256:[0-9a-f]{64}[[:space:]]+AS[[:space:]]+runner' "$dockerfile" \
+  require_grep '^FROM[[:space:]]+node:24-alpine@sha256:[0-9a-f]{64}[[:space:]]+AS[[:space:]]+runner' "$dockerfile" \
     "$dockerfile must digest-pin the production Node runner image while retaining the tag for Dependabot refreshes"
 done
 


### PR DESCRIPTION
## Summary

Every PR's **Security Audit** check has been failing since #908 with:

```
ERROR: apps/api/Dockerfile must digest-pin the Node base image while
retaining the tag for Dependabot refreshes
```

This blocks the `CI Success` aggregate check and makes every PR show as BLOCKED until merged with \`--admin\`.

## Root cause

Two intentional but uncoordinated decisions drifted apart:

| PR | What it did |
|---|---|
| #693 (`6372ba82`) | Bumped supply-chain guard from `node:22-alpine` → `node:26-alpine` to catch up with Dependabot bumps (#667, #675) |
| #908 (`2719f10d`) | Explicitly rolled the four production Dockerfiles back from `node:26` → `node:24` LTS (\"pin api/web images to Node 24 LTS\") |

Nobody updated the guard to follow #908's rollback. The Dockerfiles are correctly on `node:24-alpine` LTS; only the guard's required version string was stale.

## Fix

Change the guard's `require_grep` lines from `node:26-alpine` to `node:24-alpine`. No Dockerfile changes — the digest already in repo (`sha256:2bdb65ed1...`) is the correct one for `node:24-alpine`.

The digest regex (`@sha256:[0-9a-f]{64}`) is unchanged, so Dependabot can still refresh the digest without touching this guard.

## Test plan

- [ ] Security Audit job goes green on this PR
- [ ] No other supply-chain checks regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)