### PR TITLE
fix(web): drop dead microtask yield + clarify refresh-race comment (#956)

### DIFF
--- a/apps/web/src/components/layout/OrgSwitcher.tsx
+++ b/apps/web/src/components/layout/OrgSwitcher.tsx
@@ -254,12 +254,9 @@ export default function OrgSwitcher() {
                   onSelect={async () => {
                     if (org.id !== currentOrgId) {
                       setOrganization(org.id);
-                      // Yield a microtask so setOrganization's downstream
-                      // fetchSites/etc has a chance to register itself with
-                      // tokenRefreshInFlight before we check. Then wait for
-                      // any pending refresh to settle so the post-reload
-                      // page doesn't race the same cookie jti. See #950.
-                      await Promise.resolve();
+                      // Wait for any refresh that was already in flight at click time
+                      // (e.g. AdminSessionManager's 5-min heartbeat) to settle so the
+                      // post-reload page doesn't reuse the same cookie jti. See #950.
                       await waitForPendingRefresh();
                       const redirect = getOrgSwitchRedirect(window.location.pathname);
                       if (redirect) {
@@ -278,7 +275,6 @@ export default function OrgSwitcher() {
                     if (changed) {
                       // Same refresh-race avoidance as the org-switch path
                       // above — see #950.
-                      await Promise.resolve();
                       await waitForPendingRefresh();
                       window.location.reload();
                     }


### PR DESCRIPTION
## Summary
Cleans up the dead `await Promise.resolve()` microtask yield + misleading JSDoc in `OrgSwitcher` that Todd flagged in #956 (Tier-2 follow-up to #953 / #950).

The old comment claimed the microtask yield gave `setOrganization → fetchSites → fetchWithAuth → 401 → requestTokenRefreshShared` a chance to register an in-flight refresh inside one microtask. A 401 needs a full network round-trip, so that can't happen. `waitForPendingRefresh()` actually catches refreshes already in flight from `AdminSessionManager`'s 5-min heartbeat (and `AuthGuard` / `DashboardWrapper` rehydrate paths), which is what saves the #950 race.

Applied to both org-switch (~L256) and site-switch (~L276) handlers:
- Delete `await Promise.resolve();`
- Rewrite comment to point at `AdminSessionManager`'s heartbeat as the real in-flight source

No behavior change.

## Test plan
- [x] `pnpm exec tsc --noEmit` (apps/web) — clean
- [x] `pnpm exec vitest run src/components/layout/OrgSwitcher.test.tsx` — 7/7 pass (assertions on `waitForPendingRefreshMock` called, not ordering)
- [x] Manual diff review against #956 proposal — comment text matches Todd's verbatim wording

## CI note
Inheriting Smoke Test + admin/abuse test failures from main (in flight via #957). Failures on this PR match main exactly — not regressions introduced here.

Closes #956