### PR TITLE
feat(pam): UAC elevation actuator (Track 5, Flavor A)

### DIFF
--- a/agent/internal/heartbeat/handlers_actuate.go
+++ b/agent/internal/heartbeat/handlers_actuate.go
@@ -1,0 +1,121 @@
+package heartbeat
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/pamactuator"
+	"github.com/breeze-rmm/agent/internal/remote/tools"
+)
+
+// PAM Track 5: wire the server-pushed `actuate_elevation` device_command
+// into the pamactuator package. The server's approval-flow (Track 6) emits
+// this command after a tech approves an elevation request and the
+// dormant-admin credential has been minted. The agent types those creds
+// into the consent.exe prompt that's already up on the user's screen.
+//
+// Payload shape (validated by apps/api/src/routes/agents/actuateElevation.ts):
+//
+//	{
+//	  "elevationRequestId": "uuid",
+//	  "username":           "DOMAIN\\svc-pam",
+//	  "password":           "<one-time>",
+//	  "timeoutMs":          8000
+//	}
+//
+// We do NOT log the password or include it in the CommandResult. The
+// pamactuator's Reason field is mirrored into the result Stdout so the
+// server-side handler can switch on it for retry/escalate decisions
+// without parsing free-form text.
+
+func init() {
+	handlerRegistry[tools.CmdActuateElevation] = handleActuateElevation
+}
+
+// actuatePayload is the typed view of cmd.Payload. Kept local — no
+// caller outside this file needs the shape.
+type actuatePayload struct {
+	ElevationRequestID string `json:"elevationRequestId"`
+	Username           string `json:"username"`
+	Password           string `json:"password"`
+	TimeoutMs          int    `json:"timeoutMs"`
+}
+
+// actuateResult is the public CommandResult Stdout payload. Mirrors
+// pamactuator.Result minus the DetailMessage rename to `message` for
+// JSON cleanliness on the server side.
+type actuateResult struct {
+	ElevationRequestID string `json:"elevationRequestId"`
+	Success            bool   `json:"success"`
+	Reason             string `json:"reason"`
+	Message            string `json:"message"`
+}
+
+// newActuator is an indirection so tests can install a fake without
+// touching package state in other tests. Set via swapActuatorForTest.
+var newActuator = pamactuator.New
+
+func handleActuateElevation(_ *Heartbeat, cmd Command) tools.CommandResult {
+	start := time.Now()
+
+	payload, err := parseActuatePayload(cmd.Payload)
+	if err != nil {
+		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+
+	// Bound the overall handler at twice the consent-window timeout so a
+	// stuck Windows desktop can't pin a worker forever. The actuator
+	// itself enforces its own deadline; this ctx is the belt-and-braces.
+	timeout := time.Duration(payload.TimeoutMs) * time.Millisecond
+	if timeout <= 0 {
+		timeout = 8 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*timeout)
+	defer cancel()
+
+	act := newActuator()
+	res := act.Trigger(ctx, pamactuator.Request{
+		ElevationRequestID: payload.ElevationRequestID,
+		Username:           payload.Username,
+		Password:           payload.Password,
+		TimeoutMs:          payload.TimeoutMs,
+	})
+
+	out := actuateResult{
+		ElevationRequestID: payload.ElevationRequestID,
+		Success:            res.Success,
+		Reason:             res.Reason,
+		Message:            res.DetailMessage,
+	}
+
+	// Success and failure both surface as a "completed" CommandResult so
+	// the server's command-result handler always sees a JSON body — Q4
+	// of the firmup: the server is the one deciding retry/escalate based
+	// on the Reason code, not the agent.
+	return tools.NewSuccessResult(out, time.Since(start).Milliseconds())
+}
+
+// parseActuatePayload validates the incoming payload. Required fields:
+// elevationRequestId, username, password. timeoutMs is optional.
+func parseActuatePayload(p map[string]any) (actuatePayload, error) {
+	raw, err := json.Marshal(p)
+	if err != nil {
+		return actuatePayload{}, err
+	}
+	var out actuatePayload
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return actuatePayload{}, err
+	}
+	if out.ElevationRequestID == "" {
+		return actuatePayload{}, errors.New("actuate_elevation: elevationRequestId is required")
+	}
+	if out.Username == "" {
+		return actuatePayload{}, errors.New("actuate_elevation: username is required")
+	}
+	if out.Password == "" {
+		return actuatePayload{}, errors.New("actuate_elevation: password is required")
+	}
+	return out, nil
+}

--- a/agent/internal/heartbeat/handlers_test.go
+++ b/agent/internal/heartbeat/handlers_test.go
@@ -117,6 +117,9 @@ var allCommandTypes = []string{
 
 	// handlers_tunnel.go init()
 	tools.CmdTunnelOpen, tools.CmdTunnelData, tools.CmdTunnelClose,
+
+	// handlers_actuate.go init() — PAM Track 5
+	tools.CmdActuateElevation,
 }
 
 func TestHandlerRegistryCompleteness(t *testing.T) {

--- a/agent/internal/pamactuator/actuator.go
+++ b/agent/internal/pamactuator/actuator.go
@@ -1,0 +1,98 @@
+// Package pamactuator carries out approved UAC elevations on Windows by
+// typing the dormant-admin credentials into the consent.exe prompt that
+// triggered the elevation request.
+//
+// Background: PAM Track 5 — UAC elevation actuator.
+//
+// On Windows, when a non-elevated process invokes an admin operation, the
+// OS raises consent.exe on the secure desktop. Without a logged-in admin
+// account, the only ways to satisfy that prompt are to (a) silently inject
+// SYSTEM-side approval via a kernel hook or (b) type real credentials into
+// the consent UI as if a user did. Discussion #858 (Todd-Q4, 2026-05-23)
+// settled on (b) — Flavor A — because it leaves the existing audit trail
+// (event log 4624, consent.exe pid) intact and does not require kernel
+// drivers we cannot ship through stock MSI installers.
+//
+// File layout:
+//
+//	actuator.go            — cross-platform interface + types
+//	actuator_windows.go    — Flavor A: SetThreadDesktop(Winlogon) +
+//	                         FindWindow(consent.exe) + SendInput
+//	actuator_other.go      — no-op stub for !windows builds
+//	wininput.go            — local KEYEVENTF_UNICODE typeString primitive
+//	                         (intentionally duplicated from
+//	                         remote/desktop/input_windows.go per Q5;
+//	                         actuator must work without pulling in the
+//	                         whole WebRTC capture stack)
+//
+// Threat model: the actuator runs as SYSTEM (the agent service identity),
+// types the secret on the input desktop, and never persists it. The
+// caller (server-side approval flow, Track 6) is responsible for
+// generating the credential just-in-time and revoking it after use.
+//
+// Server contract: the actuator is triggered by a `actuate_elevation`
+// device_command whose payload carries the elevation_request id plus the
+// already-approved credential pair to type. See
+// heartbeat/handlers_actuate.go.
+package pamactuator
+
+import "context"
+
+// Request is the input to Actuator.Trigger. Carries everything needed to
+// drive a single consent.exe prompt to completion. Username + password are
+// the cleartext dormant-admin credentials to type — they live in process
+// memory only for the duration of Trigger and are not logged.
+type Request struct {
+	// ElevationRequestID is the server-side elevation_requests.id this
+	// actuation is fulfilling. Used solely for log correlation.
+	ElevationRequestID string
+
+	// Username is the dormant-admin account name to type into the
+	// consent.exe username field. Already includes any DOMAIN\ prefix
+	// the server chose to ship.
+	Username string
+
+	// Password is the cleartext credential to type into the password
+	// field. Cleared by the actuator after use.
+	Password string
+
+	// TimeoutMs bounds how long the actuator will wait for consent.exe
+	// to appear on the secure desktop. Server defaults to 8000.
+	TimeoutMs int
+}
+
+// Result reports what the actuator did. Returned to the server so the
+// approval flow can mark the elevation_requests row as satisfied or
+// retry/escalate (Q4: log + audit row + return server response).
+type Result struct {
+	// Success is true if the actuator typed credentials and consent.exe
+	// closed within the timeout window. False on any earlier failure.
+	Success bool
+
+	// Reason is a short stable code suitable for switch statements on
+	// the server side. One of: "ok", "no_consent_window", "desktop_open_failed",
+	// "set_thread_desktop_failed", "send_input_failed", "consent_did_not_close",
+	// "unsupported_platform".
+	Reason string
+
+	// DetailMessage is a free-form human-readable string for logs. Never
+	// contains the password.
+	DetailMessage string
+}
+
+// Actuator is the cross-platform interface for triggering UAC elevations.
+// On Windows, the concrete impl is *windowsActuator (actuator_windows.go).
+// On every other platform it is *noopActuator (actuator_other.go).
+type Actuator interface {
+	// Trigger executes one actuation. Blocks until consent.exe closes or
+	// the timeout expires, whichever comes first. Safe to call from any
+	// goroutine; the impl locks an OS thread internally before touching
+	// the secure desktop.
+	Trigger(ctx context.Context, req Request) Result
+}
+
+// New returns the platform-default Actuator. On non-Windows this returns
+// a no-op that always reports Reason="unsupported_platform".
+func New() Actuator {
+	return newActuator()
+}

--- a/agent/internal/pamactuator/actuator_other.go
+++ b/agent/internal/pamactuator/actuator_other.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package pamactuator
+
+import "context"
+
+// noopActuator is the stub returned on Linux/macOS. UAC + consent.exe
+// only exist on Windows; on other platforms Trigger returns immediately
+// with success=false so the server-side approval flow can record the
+// outcome and never block waiting on a host that cannot do the work.
+type noopActuator struct{}
+
+func newActuator() Actuator { return &noopActuator{} }
+
+func (*noopActuator) Trigger(_ context.Context, _ Request) Result {
+	return Result{
+		Success:       false,
+		Reason:        "unsupported_platform",
+		DetailMessage: "pamactuator: not implemented for this platform",
+	}
+}

--- a/agent/internal/pamactuator/actuator_test.go
+++ b/agent/internal/pamactuator/actuator_test.go
@@ -1,0 +1,87 @@
+package pamactuator
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestNewReturnsConcreteActuator verifies the package exposes a working
+// Actuator on every platform. On non-Windows this is the no-op stub; on
+// Windows it's *windowsActuator.
+func TestNewReturnsConcreteActuator(t *testing.T) {
+	a := New()
+	if a == nil {
+		t.Fatalf("New returned nil Actuator")
+	}
+}
+
+// TestNoopActuatorReturnsUnsupportedReason guards the !windows behavior:
+// callers must be able to distinguish "we can't do this here" from any
+// real failure. The reason string is part of the Track 6 server contract
+// for failure handling — changing it would break the approval flow's
+// retry/escalate switch.
+//
+// Only runs on non-Windows because newActuator returns the real
+// windowsActuator on Windows.
+func TestNoopActuatorReturnsUnsupportedReason(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no-op stub only compiled on non-Windows")
+	}
+
+	a := New()
+	res := a.Trigger(context.Background(), Request{
+		ElevationRequestID: "abc-123",
+		Username:           "svc-admin",
+		Password:           "irrelevant",
+		TimeoutMs:          1000,
+	})
+
+	if res.Success {
+		t.Fatalf("expected Success=false on non-Windows, got true")
+	}
+	if res.Reason != "unsupported_platform" {
+		t.Fatalf("expected Reason=unsupported_platform, got %q", res.Reason)
+	}
+	if res.DetailMessage == "" {
+		t.Fatalf("expected non-empty DetailMessage")
+	}
+}
+
+// TestNoopActuatorIsNonBlocking confirms the stub doesn't honor TimeoutMs
+// by sleeping — Track 6 must be able to fan a single approval out to many
+// non-Windows agents without each one stalling for the full timeout.
+func TestNoopActuatorIsNonBlocking(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no-op stub only compiled on non-Windows")
+	}
+
+	a := New()
+	start := time.Now()
+	a.Trigger(context.Background(), Request{TimeoutMs: 10000})
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("no-op Trigger blocked for %v, expected near-instant", elapsed)
+	}
+}
+
+// TestRequestZeroValuesAreSafe sanity-checks that a zero-valued Request
+// doesn't make the stub panic. The Windows impl applies a default 8000ms
+// timeout when TimeoutMs<=0; the stub doesn't need to but must not crash.
+func TestRequestZeroValuesAreSafe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no-op stub only compiled on non-Windows")
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Trigger panicked on zero Request: %v", r)
+		}
+	}()
+
+	a := New()
+	res := a.Trigger(context.Background(), Request{})
+	if res.Success {
+		t.Fatalf("zero Request should not succeed on no-op stub")
+	}
+}

--- a/agent/internal/pamactuator/actuator_windows.go
+++ b/agent/internal/pamactuator/actuator_windows.go
@@ -1,0 +1,193 @@
+//go:build windows
+
+package pamactuator
+
+import (
+	"context"
+	"log/slog"
+	"runtime"
+	"time"
+)
+
+// windowsActuator is the Flavor A Track 5 implementation. It opens the
+// active input desktop (Winlogon during a UAC prompt), pins the calling
+// OS thread to it, then synthesizes keystrokes into consent.exe via
+// SendInput. The sequence is: wait for consent.exe to appear → type
+// username → Tab → type password → Enter → wait for the window to close.
+//
+// Why thread-pin: SetThreadDesktop only affects the calling thread, and
+// SendInput delivers to the desktop the calling thread is attached to.
+// Without LockOSThread the Go scheduler could move us between OS threads
+// and the keystrokes would land on whatever desktop the new thread had —
+// usually the default winsta0\Default, NOT Winlogon — silently dropping
+// them. The same pattern is used by WindowsInputHandler.ensureInputDesktop.
+type windowsActuator struct{}
+
+func newActuator() Actuator { return &windowsActuator{} }
+
+// Local copies of the desktop API procs. Duplicated from
+// remote/desktop/dxgi_windows.go to keep this package self-contained.
+var (
+	winProcOpenInputDesktop = winUser32.NewProc("OpenInputDesktop")
+	winProcSetThreadDesktop = winUser32.NewProc("SetThreadDesktop")
+	winProcCloseDesktop     = winUser32.NewProc("CloseDesktop")
+)
+
+const (
+	winDesktopGenericAll = 0x10000000
+)
+
+// pollInterval is the loop cadence between consent.exe presence checks.
+// Short enough that we attach to the prompt within ~100ms of it appearing.
+const pollInterval = 100 * time.Millisecond
+
+// settleDelay is how long we wait between SendInput calls so consent.exe
+// has time to process each keystroke. Empirically anything below 15ms
+// causes occasional dropped characters on slower VMs.
+const settleDelay = 25 * time.Millisecond
+
+func (a *windowsActuator) Trigger(ctx context.Context, req Request) Result {
+	// SetThreadDesktop is per-thread; the rest of the actuator must stay on
+	// the same OS thread or the desktop binding goes with the original
+	// goroutine when the scheduler reparks it.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	hDesk, _, openErr := winProcOpenInputDesktop.Call(0, 0, uintptr(winDesktopGenericAll))
+	if hDesk == 0 {
+		slog.Warn("pamactuator: OpenInputDesktop failed",
+			"elevationRequestId", req.ElevationRequestID,
+			"error", openErr.Error(),
+		)
+		return Result{
+			Success:       false,
+			Reason:        "desktop_open_failed",
+			DetailMessage: "OpenInputDesktop returned 0: " + openErr.Error(),
+		}
+	}
+	defer winProcCloseDesktop.Call(hDesk)
+
+	if ret, _, setErr := winProcSetThreadDesktop.Call(hDesk); ret == 0 {
+		slog.Warn("pamactuator: SetThreadDesktop failed",
+			"elevationRequestId", req.ElevationRequestID,
+			"error", setErr.Error(),
+		)
+		return Result{
+			Success:       false,
+			Reason:        "set_thread_desktop_failed",
+			DetailMessage: "SetThreadDesktop returned 0: " + setErr.Error(),
+		}
+	}
+
+	timeoutMs := req.TimeoutMs
+	if timeoutMs <= 0 {
+		timeoutMs = 8000
+	}
+	deadline := time.Now().Add(time.Duration(timeoutMs) * time.Millisecond)
+
+	hwnd := waitForConsent(ctx, deadline)
+	if hwnd == 0 {
+		return Result{
+			Success:       false,
+			Reason:        "no_consent_window",
+			DetailMessage: "consent.exe did not appear within the timeout window",
+		}
+	}
+
+	if err := typeString(req.Username); err != nil {
+		return Result{
+			Success:       false,
+			Reason:        "send_input_failed",
+			DetailMessage: "typing username: " + err.Error(),
+		}
+	}
+	time.Sleep(settleDelay)
+
+	if err := pressVK(vkTab); err != nil {
+		return Result{
+			Success:       false,
+			Reason:        "send_input_failed",
+			DetailMessage: "Tab: " + err.Error(),
+		}
+	}
+	time.Sleep(settleDelay)
+
+	if err := typeString(req.Password); err != nil {
+		return Result{
+			Success:       false,
+			Reason:        "send_input_failed",
+			DetailMessage: "typing password: " + err.Error(),
+		}
+	}
+	time.Sleep(settleDelay)
+
+	if err := pressVK(vkReturn); err != nil {
+		return Result{
+			Success:       false,
+			Reason:        "send_input_failed",
+			DetailMessage: "Enter: " + err.Error(),
+		}
+	}
+
+	if !waitForConsentClose(ctx, hwnd, deadline) {
+		return Result{
+			Success:       false,
+			Reason:        "consent_did_not_close",
+			DetailMessage: "consent.exe still present after credential submit",
+		}
+	}
+
+	return Result{
+		Success:       true,
+		Reason:        "ok",
+		DetailMessage: "consent.exe closed after credential submission",
+	}
+}
+
+// waitForConsent polls for the consent.exe window until it appears, the
+// context cancels, or the deadline passes. Returns 0 on timeout/cancel.
+func waitForConsent(ctx context.Context, deadline time.Time) uintptr {
+	for {
+		if hwnd := findConsentWindow(); hwnd != 0 {
+			return hwnd
+		}
+		if time.Now().After(deadline) {
+			return 0
+		}
+		select {
+		case <-ctx.Done():
+			return 0
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+// waitForConsentClose polls until the originally-seen consent.exe HWND is
+// gone (the window destroyed) or the deadline passes. True = closed.
+func waitForConsentClose(ctx context.Context, hwnd uintptr, deadline time.Time) bool {
+	for {
+		if !isWindowAlive(hwnd) {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+// typeString iterates the rune sequence and types each via
+// KEYEVENTF_UNICODE. Returns the first error encountered.
+func typeString(s string) error {
+	for _, r := range s {
+		if err := typeRune(r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+

--- a/agent/internal/pamactuator/wininput.go
+++ b/agent/internal/pamactuator/wininput.go
@@ -1,0 +1,151 @@
+//go:build windows
+
+package pamactuator
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+// Local Windows input primitives. Intentionally duplicated from
+// remote/desktop/input_windows.go rather than refactored into a shared
+// package — see Q5 of the Track 5 firmup. The actuator only needs
+// SendInput with KEYEVENTF_UNICODE for typing characters plus a handful
+// of VK codes for Tab/Enter, and pulling in remote/desktop would drag
+// the entire WebRTC capture stack into the agent service path.
+
+var (
+	winUser32     = syscall.NewLazyDLL("user32.dll")
+	winSendInput  = winUser32.NewProc("SendInput")
+	winMapVKey    = winUser32.NewProc("MapVirtualKeyW")
+	winFindWindow = winUser32.NewProc("FindWindowW")
+	winIsWindow   = winUser32.NewProc("IsWindow")
+)
+
+const (
+	inputKeyboard = 1
+
+	keyeventfKeyUp    = 0x0002
+	keyeventfUnicode  = 0x0004
+	mapvkVKtoVSC      = 0
+)
+
+const (
+	vkTab    = 0x09
+	vkReturn = 0x0D
+)
+
+// keybdInput mirrors the Win32 KEYBDINPUT struct. Layout matches the
+// 32-byte INPUT union on x64 (4-byte type + 4-byte pad + 24-byte member).
+type keybdInput struct {
+	wVk         uint16
+	wScan       uint16
+	dwFlags     uint32
+	time        uint32
+	dwExtraInfo uintptr
+}
+
+type winInput struct {
+	inputType uint32
+	_         [4]byte // padding so the union starts at offset 8 on x64
+	ki        keybdInput
+	_         [8]byte // pad union to MOUSEINPUT size (24 bytes on x64)
+}
+
+// vkToScan resolves the hardware scan code for a virtual-key. Some apps
+// (consent.exe included, empirically) require wScan to be populated.
+func vkToScan(vk uint16) uint16 {
+	sc, _, _ := winMapVKey.Call(uintptr(vk), mapvkVKtoVSC)
+	return uint16(sc)
+}
+
+// sendOne dispatches a single INPUT struct via SendInput. Returns the
+// raw cReturned count (1 on success, 0 on failure).
+func sendOne(in *winInput) (uint32, error) {
+	ret, _, callErr := winSendInput.Call(
+		1,
+		uintptr(unsafe.Pointer(in)),
+		unsafe.Sizeof(*in),
+	)
+	if ret == 0 {
+		return 0, fmt.Errorf("SendInput returned 0: %v", callErr)
+	}
+	return uint32(ret), nil
+}
+
+// typeRune injects a single Unicode codepoint via KEYEVENTF_UNICODE.
+// Used for username/password characters; bypasses keyboard layout and
+// works for any printable Unicode value the OS accepts.
+func typeRune(r rune) error {
+	down := winInput{inputType: inputKeyboard}
+	down.ki.wVk = 0
+	down.ki.wScan = uint16(r)
+	down.ki.dwFlags = keyeventfUnicode
+	if _, err := sendOne(&down); err != nil {
+		return fmt.Errorf("KEYEVENTF_UNICODE down: %w", err)
+	}
+
+	up := winInput{inputType: inputKeyboard}
+	up.ki.wVk = 0
+	up.ki.wScan = uint16(r)
+	up.ki.dwFlags = keyeventfUnicode | keyeventfKeyUp
+	if _, err := sendOne(&up); err != nil {
+		return fmt.Errorf("KEYEVENTF_UNICODE up: %w", err)
+	}
+	return nil
+}
+
+// pressVK sends a vk-down then vk-up pair. Used for Tab/Enter only; user
+// content goes through typeRune so layout-independent Unicode is used.
+func pressVK(vk uint16) error {
+	down := winInput{inputType: inputKeyboard}
+	down.ki.wVk = vk
+	down.ki.wScan = vkToScan(vk)
+	if _, err := sendOne(&down); err != nil {
+		return fmt.Errorf("vk %#x down: %w", vk, err)
+	}
+
+	up := winInput{inputType: inputKeyboard}
+	up.ki.wVk = vk
+	up.ki.wScan = vkToScan(vk)
+	up.ki.dwFlags = keyeventfKeyUp
+	if _, err := sendOne(&up); err != nil {
+		return fmt.Errorf("vk %#x up: %w", vk, err)
+	}
+	return nil
+}
+
+// findConsentWindow looks for the topmost consent.exe window via
+// FindWindowW("Consent.exe Frame Window", nil) — the well-known class
+// name registered by consent.exe since Vista. Returns 0 if no window
+// is present.
+func findConsentWindow() uintptr {
+	classNamePtr, err := syscall.UTF16PtrFromString("$$$Secure UAP Background Window$$$")
+	if err != nil {
+		return 0
+	}
+	hwnd, _, _ := winFindWindow.Call(uintptr(unsafe.Pointer(classNamePtr)), 0)
+	if hwnd != 0 {
+		return hwnd
+	}
+	// Fallback: the wrapper class used on Win10+. Different builds vary,
+	// so a second probe avoids missing the prompt on newer servicing
+	// channels. If both miss, the caller will retry after a sleep.
+	classNamePtr2, err := syscall.UTF16PtrFromString("Credential Dialog Xaml Host")
+	if err != nil {
+		return 0
+	}
+	hwnd2, _, _ := winFindWindow.Call(uintptr(unsafe.Pointer(classNamePtr2)), 0)
+	return hwnd2
+}
+
+// isWindowAlive reports whether the given HWND still refers to a real
+// window. Used to detect consent.exe closing after credential submit.
+func isWindowAlive(hwnd uintptr) bool {
+	if hwnd == 0 {
+		return false
+	}
+	ret, _, _ := winIsWindow.Call(hwnd)
+	return ret != 0
+}

--- a/agent/internal/remote/tools/types.go
+++ b/agent/internal/remote/tools/types.go
@@ -213,6 +213,12 @@ const (
 	CmdTunnelOpen  = "tunnel_open"
 	CmdTunnelData  = "tunnel_data"
 	CmdTunnelClose = "tunnel_close"
+
+	// PAM Track 5: actuate an approved UAC elevation by typing the
+	// dormant-admin credentials into consent.exe on the secure desktop.
+	// Server-pushed only; handled by internal/pamactuator on Windows and
+	// a no-op stub on other platforms.
+	CmdActuateElevation = "actuate_elevation"
 )
 
 // CommandResult represents the result of a command execution

--- a/apps/api/migrations/2026-05-27-a-elevation-status-add-actuating.sql
+++ b/apps/api/migrations/2026-05-27-a-elevation-status-add-actuating.sql
@@ -1,0 +1,33 @@
+-- Add 'actuating' to elevation_status enum so the PAM Track 5 actuator route
+-- (POST /devices/:id/actuate-elevation) can transactionally CAS the row from
+-- 'approved' → 'actuating' as a single-use guard. Without this, an approved
+-- elevation_requests row can be POSTed to /actuate-elevation N times, each
+-- queueing a fresh actuate_elevation device_command with the cleartext
+-- credential — a credential-replay / multi-spawn vector.
+--
+-- PR #960 review (Todd, 2026-05-27 14:56Z, CHANGES_REQUESTED):
+--   "wrap the SELECT + UPDATE-to-'actuating' + command insert in a single
+--   transaction with WHERE status='approved' and refuse if zero rows updated"
+--
+-- The actuator route's transaction does:
+--   SELECT ... FOR UPDATE
+--   UPDATE elevation_requests SET status='actuating'
+--     WHERE id=$1 AND status='approved' RETURNING id
+--   INSERT INTO device_commands ...
+--   INSERT INTO elevation_audit ...
+--
+-- After actuation the row remains in 'actuating' until the agent reports
+-- completion (Track 6 — JIT credential expiry + cleanup). At that point it
+-- flips to either 'expired' (TTL hit) or 'revoked' (cancelled mid-flight).
+--
+-- Postgres note: ALTER TYPE ... ADD VALUE inside an outer transaction works
+-- in Postgres 12+ as long as the new value isn't *used* in the same
+-- transaction. autoMigrate wraps each file in client.begin(); we never use
+-- 'actuating' in this migration, so no rewrite occurs.
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'elevation_status') THEN
+    ALTER TYPE elevation_status ADD VALUE IF NOT EXISTS 'actuating';
+  END IF;
+END $$;

--- a/apps/api/src/db/schema/elevations.ts
+++ b/apps/api/src/db/schema/elevations.ts
@@ -43,6 +43,11 @@ export const elevationStatusEnum = pgEnum('elevation_status', [
   'denied',
   'expired',
   'revoked',
+  // 'actuating' = Track 5 single-use guard. Atomic CAS from 'approved' by
+  // the actuator route; row stays here until the agent reports completion
+  // (Track 6 — JIT credential expiry / cleanup), at which point it flips to
+  // 'expired' or 'revoked'.
+  'actuating',
 ]);
 
 export const elevationAuditEventTypeEnum = pgEnum('elevation_audit_event_type', [

--- a/apps/api/src/routes/devices/actuateElevation.test.ts
+++ b/apps/api/src/routes/devices/actuateElevation.test.ts
@@ -1,0 +1,354 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const {
+  authMiddlewareMock,
+  requireScopeMock,
+  requirePermissionMock,
+  requireMfaMock,
+} = vi.hoisted(() => ({
+  authMiddlewareMock: vi.fn(),
+  requireScopeMock: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermissionMock: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfaMock: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+  },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: authMiddlewareMock,
+  requireScope: requireScopeMock,
+  requirePermission: requirePermissionMock,
+  requireMfa: requireMfaMock,
+}));
+
+vi.mock('./helpers', () => ({
+  getDeviceWithOrgCheck: vi.fn(),
+}));
+
+vi.mock('../../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn(),
+}));
+
+import { db } from '../../db';
+import { getDeviceWithOrgCheck } from './helpers';
+import { writeRouteAudit } from '../../services/auditEvents';
+import { actuateElevationRoutes } from './actuateElevation';
+
+// Snapshot gate registration BEFORE beforeEach's clearAllMocks. Same
+// pattern as moveOrg.test.ts — middleware factories run at module-import
+// time so by the first test the calls are already captured.
+const registeredScopeCalls: string[][] = (
+  requireScopeMock.mock.calls as unknown as unknown[][]
+).map((c) => c.flat().map((v) => String(v)));
+const registeredPermResources: string[] = (
+  requirePermissionMock.mock.calls as unknown as unknown[][]
+).map((c) => c.map((v) => String(v)).join(':'));
+const registeredMfaCallCount = requireMfaMock.mock.calls.length;
+
+const ORG_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const DEVICE_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const ELEVATION_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const USER_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+
+const SAMPLE_DEVICE = {
+  id: DEVICE_ID,
+  orgId: ORG_ID,
+  siteId: null,
+  hostname: 'host-1',
+  status: 'online' as const,
+};
+
+const SAMPLE_ELEVATION = {
+  id: ELEVATION_ID,
+  deviceId: DEVICE_ID,
+  orgId: ORG_ID,
+  status: 'approved' as const,
+};
+
+function setAuth() {
+  authMiddlewareMock.mockImplementation((c: any, next: any) => {
+    c.set('auth', {
+      user: { id: USER_ID, email: 't@example.com' },
+      scope: 'partner',
+      orgId: ORG_ID,
+      canAccessOrg: () => true,
+    });
+    return next();
+  });
+}
+
+function rigElevationSelect(row: typeof SAMPLE_ELEVATION | null) {
+  const limit = vi.fn().mockResolvedValue(row ? [row] : []);
+  const where = vi.fn().mockReturnValue({ limit });
+  const from = vi.fn().mockReturnValue({ where });
+  vi.mocked(db.select).mockReturnValue({ from } as never);
+}
+
+function rigInsertSuccess(commandRow: Record<string, unknown>) {
+  const returning = vi.fn().mockResolvedValue([commandRow]);
+  const values = vi.fn().mockReturnValue({ returning });
+  vi.mocked(db.insert).mockReturnValue({ values } as never);
+  return { values, returning };
+}
+
+describe('POST /devices/:id/actuate-elevation', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setAuth();
+    app = new Hono();
+    app.route('/devices', actuateElevationRoutes);
+  });
+
+  describe('gate registration', () => {
+    it('requires organization+ scope, devices:execute, and MFA', () => {
+      expect(
+        registeredScopeCalls.some(
+          (a) => a.includes('organization') && a.includes('partner') && a.includes('system'),
+        ),
+      ).toBe(true);
+      expect(registeredPermResources).toContain('devices:execute');
+      expect(registeredMfaCallCount).toBeGreaterThan(0);
+    });
+  });
+
+  describe('input validation', () => {
+    it('rejects missing elevationRequestId', async () => {
+      const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username: 'u', password: 'p' }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects non-UUID elevationRequestId', async () => {
+      const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          elevationRequestId: 'not-a-uuid',
+          username: 'u',
+          password: 'p',
+        }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects timeoutMs above 60000', async () => {
+      const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          elevationRequestId: ELEVATION_ID,
+          username: 'u',
+          password: 'p',
+          timeoutMs: 999999,
+        }),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('authorization', () => {
+    it('returns 404 when device not visible to caller', async () => {
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValue(undefined as never);
+
+      const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          elevationRequestId: ELEVATION_ID,
+          username: 'svc-admin',
+          password: 'super-secret',
+        }),
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it('rejects decommissioned devices', async () => {
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValue({
+        ...SAMPLE_DEVICE,
+        status: 'decommissioned',
+      } as never);
+
+      const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          elevationRequestId: ELEVATION_ID,
+          username: 'u',
+          password: 'p',
+        }),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('elevation row preconditions', () => {
+    beforeEach(() => {
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValue(SAMPLE_DEVICE as never);
+    });
+
+    it('returns 404 when elevation row is missing', async () => {
+      rigElevationSelect(null);
+
+      const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          elevationRequestId: ELEVATION_ID,
+          username: 'u',
+          password: 'p',
+        }),
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 409 when elevation is not approved', async () => {
+      rigElevationSelect({ ...SAMPLE_ELEVATION, status: 'pending' as never });
+
+      const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          elevationRequestId: ELEVATION_ID,
+          username: 'u',
+          password: 'p',
+        }),
+      });
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.code).toBe('pending');
+    });
+
+    it('returns 409 on elevation/device org mismatch', async () => {
+      rigElevationSelect({ ...SAMPLE_ELEVATION, orgId: 'other-org' });
+
+      const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          elevationRequestId: ELEVATION_ID,
+          username: 'u',
+          password: 'p',
+        }),
+      });
+      expect(res.status).toBe(409);
+    });
+  });
+
+  describe('happy path', () => {
+    beforeEach(() => {
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValue(SAMPLE_DEVICE as never);
+      rigElevationSelect(SAMPLE_ELEVATION);
+    });
+
+    it('queues actuate_elevation with full credential payload', async () => {
+      const { values } = rigInsertSuccess({
+        id: 'cmd-1',
+        deviceId: DEVICE_ID,
+        type: 'actuate_elevation',
+        status: 'pending',
+        createdAt: new Date(),
+      });
+
+      const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          elevationRequestId: ELEVATION_ID,
+          username: 'DOMAIN\\svc-admin',
+          password: 'one-time',
+          timeoutMs: 5000,
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body).toMatchObject({
+        id: 'cmd-1',
+        type: 'actuate_elevation',
+        status: 'pending',
+        elevationRequestId: ELEVATION_ID,
+      });
+      expect(values).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deviceId: DEVICE_ID,
+          type: 'actuate_elevation',
+          status: 'pending',
+          createdBy: USER_ID,
+          payload: expect.objectContaining({
+            elevationRequestId: ELEVATION_ID,
+            username: 'DOMAIN\\svc-admin',
+            password: 'one-time',
+            timeoutMs: 5000,
+          }),
+        }),
+      );
+    });
+
+    it('applies the default 8000ms timeout when omitted', async () => {
+      const { values } = rigInsertSuccess({
+        id: 'cmd-2',
+        deviceId: DEVICE_ID,
+        type: 'actuate_elevation',
+        status: 'pending',
+        createdAt: new Date(),
+      });
+
+      const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          elevationRequestId: ELEVATION_ID,
+          username: 'u',
+          password: 'p',
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(values).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({ timeoutMs: 8000 }),
+        }),
+      );
+    });
+
+    it('writes audit without the password', async () => {
+      rigInsertSuccess({
+        id: 'cmd-3',
+        deviceId: DEVICE_ID,
+        type: 'actuate_elevation',
+        status: 'pending',
+        createdAt: new Date(),
+      });
+
+      await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          elevationRequestId: ELEVATION_ID,
+          username: 'svc-admin',
+          password: 'do-not-log-me',
+        }),
+      });
+
+      expect(writeRouteAudit).toHaveBeenCalledTimes(1);
+      const auditPayload = vi.mocked(writeRouteAudit).mock.calls[0]![1] as any;
+      expect(auditPayload.action).toBe('device.elevation.actuate');
+      expect(auditPayload.details.username).toBe('svc-admin');
+      expect(JSON.stringify(auditPayload)).not.toContain('do-not-log-me');
+    });
+  });
+});

--- a/apps/api/src/routes/devices/actuateElevation.test.ts
+++ b/apps/api/src/routes/devices/actuateElevation.test.ts
@@ -20,6 +20,7 @@ vi.mock('../../db', () => ({
   db: {
     select: vi.fn(),
     insert: vi.fn(),
+    transaction: vi.fn(),
   },
 }));
 
@@ -86,18 +87,89 @@ function setAuth() {
   });
 }
 
-function rigElevationSelect(row: typeof SAMPLE_ELEVATION | null) {
-  const limit = vi.fn().mockResolvedValue(row ? [row] : []);
-  const where = vi.fn().mockReturnValue({ limit });
-  const from = vi.fn().mockReturnValue({ where });
-  vi.mocked(db.select).mockReturnValue({ from } as never);
-}
+/**
+ * Rig the transactional flow inside actuateElevation.ts.
+ *
+ * Options:
+ *   - elevationRow: what tx.select(...).limit(1) returns. null = empty array
+ *     (not_found path).
+ *   - casWins: if true (default), the UPDATE returning() yields a row;
+ *     if false, returns [] (race_lost path).
+ *   - commandRow: the row returned by tx.insert(deviceCommands).returning().
+ *
+ * Returns:
+ *   - commandValues: the values mock attached to deviceCommands inserts (last call wins)
+ *   - auditInsertCalls: array of {table:'elevationAudit', values: <object>}
+ *     so tests can assert which audit rows were written and with what details.
+ */
+function rigTransaction(opts: {
+  elevationRow: typeof SAMPLE_ELEVATION | null;
+  casWins?: boolean;
+  commandRow?: Record<string, unknown>;
+}) {
+  const commandValues = vi.fn();
+  const auditInsertCalls: Array<{ values: Record<string, unknown> }> = [];
+  const updateSetCalls: Array<Record<string, unknown>> = [];
 
-function rigInsertSuccess(commandRow: Record<string, unknown>) {
-  const returning = vi.fn().mockResolvedValue([commandRow]);
-  const values = vi.fn().mockReturnValue({ returning });
-  vi.mocked(db.insert).mockReturnValue({ values } as never);
-  return { values, returning };
+  vi.mocked(db.transaction).mockImplementation(async (cb: any) => {
+    const tx: any = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn().mockResolvedValue(opts.elevationRow ? [opts.elevationRow] : []),
+          })),
+        })),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn((vals: Record<string, unknown>) => {
+          updateSetCalls.push(vals);
+          return {
+            where: vi.fn(() => ({
+              returning: vi
+                .fn()
+                .mockResolvedValue(opts.casWins === false ? [] : [{ id: ELEVATION_ID }]),
+            })),
+          };
+        }),
+      })),
+      // tx.insert is shared by deviceCommands inserts and elevationAudit inserts.
+      // The route inserts elevationAudit with a different shape (no .returning())
+      // and deviceCommands with .returning(). We resolve both by exposing both
+      // chains and recording the values payload so tests can inspect.
+      insert: vi.fn((tableRef: unknown) => {
+        // The mocked schema/imports below give us identifiable table refs.
+        // For the audit table, the chain is .values(...).then-able (no returning).
+        // For deviceCommands the chain is .values(...).returning().
+        return {
+          values: vi.fn((vals: Record<string, unknown>) => {
+            // Heuristic: deviceCommands rows carry `type` + `payload`, audit
+            // rows carry `eventType`. Use that to bucket.
+            if ((vals as any).eventType !== undefined) {
+              auditInsertCalls.push({ values: vals });
+              return Promise.resolve();
+            }
+            commandValues(vals);
+            return {
+              returning: vi
+                .fn()
+                .mockResolvedValue([
+                  opts.commandRow ?? {
+                    id: 'cmd-default',
+                    deviceId: DEVICE_ID,
+                    type: 'actuate_elevation',
+                    status: 'pending',
+                    createdAt: new Date(),
+                  },
+                ]),
+            };
+          }),
+        };
+      }),
+    };
+    return cb(tx);
+  });
+
+  return { commandValues, auditInsertCalls, updateSetCalls };
 }
 
 describe('POST /devices/:id/actuate-elevation', () => {
@@ -201,7 +273,7 @@ describe('POST /devices/:id/actuate-elevation', () => {
     });
 
     it('returns 404 when elevation row is missing', async () => {
-      rigElevationSelect(null);
+      rigTransaction({ elevationRow: null });
 
       const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
         method: 'POST',
@@ -215,8 +287,10 @@ describe('POST /devices/:id/actuate-elevation', () => {
       expect(res.status).toBe(404);
     });
 
-    it('returns 409 when elevation is not approved', async () => {
-      rigElevationSelect({ ...SAMPLE_ELEVATION, status: 'pending' as never });
+    it('returns 409 when elevation is not approved, and writes wrong_status audit', async () => {
+      const { auditInsertCalls } = rigTransaction({
+        elevationRow: { ...SAMPLE_ELEVATION, status: 'pending' as never },
+      });
 
       const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
         method: 'POST',
@@ -230,10 +304,47 @@ describe('POST /devices/:id/actuate-elevation', () => {
       expect(res.status).toBe(409);
       const body = await res.json();
       expect(body.code).toBe('pending');
+
+      // elevation_audit insert with rejected_wrong_status outcome
+      expect(auditInsertCalls).toHaveLength(1);
+      expect(auditInsertCalls[0]!.values).toMatchObject({
+        orgId: ORG_ID,
+        elevationRequestId: ELEVATION_ID,
+        eventType: 'command_executed',
+        actor: 'technician',
+        actorUserId: USER_ID,
+        details: expect.objectContaining({
+          deviceId: DEVICE_ID,
+          outcome: 'rejected_wrong_status',
+          actualStatus: 'pending',
+        }),
+      });
     });
 
-    it('returns 409 on elevation/device org mismatch', async () => {
-      rigElevationSelect({ ...SAMPLE_ELEVATION, orgId: 'other-org' });
+    it('returns 404 on elevation/device org mismatch (WHERE clause filters at DB)', async () => {
+      // New transactional flow puts orgId in the WHERE clause, so an
+      // elevation row in a different org never comes back from the select.
+      // The handler treats that as not_found (404), not 409 — the previous
+      // post-query org-mismatch branch is gone.
+      rigTransaction({ elevationRow: null });
+
+      const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          elevationRequestId: ELEVATION_ID,
+          username: 'u',
+          password: 'p',
+        }),
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 409 with race_lost and writes audit when the CAS update returns 0 rows', async () => {
+      const { auditInsertCalls, commandValues } = rigTransaction({
+        elevationRow: SAMPLE_ELEVATION,
+        casWins: false,
+      });
 
       const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
         method: 'POST',
@@ -245,22 +356,48 @@ describe('POST /devices/:id/actuate-elevation', () => {
         }),
       });
       expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.code).toBe('race_lost');
+
+      // No command was queued
+      expect(commandValues).not.toHaveBeenCalled();
+
+      // Audit row with race_lost outcome was written
+      expect(auditInsertCalls).toHaveLength(1);
+      expect(auditInsertCalls[0]!.values).toMatchObject({
+        orgId: ORG_ID,
+        elevationRequestId: ELEVATION_ID,
+        eventType: 'command_executed',
+        actor: 'technician',
+        actorUserId: USER_ID,
+        details: expect.objectContaining({
+          deviceId: DEVICE_ID,
+          outcome: 'race_lost',
+        }),
+      });
+
+      // Route-level audit also fired with race_lost
+      expect(writeRouteAudit).toHaveBeenCalledTimes(1);
+      const routeAudit = vi.mocked(writeRouteAudit).mock.calls[0]![1] as any;
+      expect(routeAudit.details.outcome).toBe('race_lost');
     });
   });
 
   describe('happy path', () => {
     beforeEach(() => {
       vi.mocked(getDeviceWithOrgCheck).mockResolvedValue(SAMPLE_DEVICE as never);
-      rigElevationSelect(SAMPLE_ELEVATION);
     });
 
     it('queues actuate_elevation with full credential payload', async () => {
-      const { values } = rigInsertSuccess({
-        id: 'cmd-1',
-        deviceId: DEVICE_ID,
-        type: 'actuate_elevation',
-        status: 'pending',
-        createdAt: new Date(),
+      const { commandValues } = rigTransaction({
+        elevationRow: SAMPLE_ELEVATION,
+        commandRow: {
+          id: 'cmd-1',
+          deviceId: DEVICE_ID,
+          type: 'actuate_elevation',
+          status: 'pending',
+          createdAt: new Date(),
+        },
       });
 
       const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
@@ -282,7 +419,7 @@ describe('POST /devices/:id/actuate-elevation', () => {
         status: 'pending',
         elevationRequestId: ELEVATION_ID,
       });
-      expect(values).toHaveBeenCalledWith(
+      expect(commandValues).toHaveBeenCalledWith(
         expect.objectContaining({
           deviceId: DEVICE_ID,
           type: 'actuate_elevation',
@@ -299,12 +436,15 @@ describe('POST /devices/:id/actuate-elevation', () => {
     });
 
     it('applies the default 8000ms timeout when omitted', async () => {
-      const { values } = rigInsertSuccess({
-        id: 'cmd-2',
-        deviceId: DEVICE_ID,
-        type: 'actuate_elevation',
-        status: 'pending',
-        createdAt: new Date(),
+      const { commandValues } = rigTransaction({
+        elevationRow: SAMPLE_ELEVATION,
+        commandRow: {
+          id: 'cmd-2',
+          deviceId: DEVICE_ID,
+          type: 'actuate_elevation',
+          status: 'pending',
+          createdAt: new Date(),
+        },
       });
 
       const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
@@ -318,20 +458,23 @@ describe('POST /devices/:id/actuate-elevation', () => {
       });
 
       expect(res.status).toBe(201);
-      expect(values).toHaveBeenCalledWith(
+      expect(commandValues).toHaveBeenCalledWith(
         expect.objectContaining({
           payload: expect.objectContaining({ timeoutMs: 8000 }),
         }),
       );
     });
 
-    it('writes audit without the password', async () => {
-      rigInsertSuccess({
-        id: 'cmd-3',
-        deviceId: DEVICE_ID,
-        type: 'actuate_elevation',
-        status: 'pending',
-        createdAt: new Date(),
+    it('writes audit without the password and an elevation_audit happy-path row', async () => {
+      const { auditInsertCalls } = rigTransaction({
+        elevationRow: SAMPLE_ELEVATION,
+        commandRow: {
+          id: 'cmd-3',
+          deviceId: DEVICE_ID,
+          type: 'actuate_elevation',
+          status: 'pending',
+          createdAt: new Date(),
+        },
       });
 
       await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
@@ -349,6 +492,18 @@ describe('POST /devices/:id/actuate-elevation', () => {
       expect(auditPayload.action).toBe('device.elevation.actuate');
       expect(auditPayload.details.username).toBe('svc-admin');
       expect(JSON.stringify(auditPayload)).not.toContain('do-not-log-me');
+
+      // elevation_audit row written inside the transaction, also password-free
+      expect(auditInsertCalls).toHaveLength(1);
+      const txAudit = auditInsertCalls[0]!.values as any;
+      expect(txAudit.eventType).toBe('command_executed');
+      expect(txAudit.details).toMatchObject({
+        deviceId: DEVICE_ID,
+        commandId: 'cmd-3',
+        username: 'svc-admin',
+        timeoutMs: 8000,
+      });
+      expect(JSON.stringify(txAudit)).not.toContain('do-not-log-me');
     });
   });
 });

--- a/apps/api/src/routes/devices/actuateElevation.ts
+++ b/apps/api/src/routes/devices/actuateElevation.ts
@@ -1,0 +1,170 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { and, eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { db } from '../../db';
+import { deviceCommands, devices, elevationRequests } from '../../db/schema';
+import {
+  authMiddleware,
+  requireMfa,
+  requirePermission,
+  requireScope,
+} from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { writeRouteAudit } from '../../services/auditEvents';
+import { canAccessSite, type UserPermissions } from '../../services/permissions';
+import { getDeviceWithOrgCheck } from './helpers';
+
+export const actuateElevationRoutes = new Hono();
+
+actuateElevationRoutes.use('*', authMiddleware);
+
+/**
+ * POST /devices/:id/actuate-elevation
+ *
+ * PAM Track 5: queue an `actuate_elevation` device_command that the agent
+ * picks up and uses to type the dormant-admin credentials into the
+ * consent.exe prompt that's already up on the user's screen.
+ *
+ * This is the server-side push half of the actuator. The agent-side
+ * implementation lives in `agent/internal/pamactuator/`.
+ *
+ * Scope: this PR ships only the command-queueing contract. The wider
+ * approval flow that decides WHEN to call this — match elevation_requests
+ * row against software_policies, mint a JIT credential, fan out to the
+ * right agent — is Track 6.
+ *
+ * Auth: organization+ scope, DEVICES_EXECUTE permission, MFA. Same gates
+ * as POST /devices/:id/commands, because functionally that's what this
+ * is: a typed wrapper that validates the elevationRequestId / credential
+ * payload before insertion.
+ *
+ * The credential is shipped through the command payload exactly once; the
+ * agent does not persist it. device_commands is intentionally
+ * system-scoped (see CLAUDE.md tenancy notes), but RLS still covers the
+ * `devices` row we read on the way in.
+ */
+
+const actuateElevationSchema = z.object({
+  elevationRequestId: z.string().uuid(),
+  username: z.string().min(1).max(255),
+  password: z.string().min(1).max(1024),
+  timeoutMs: z.number().int().min(1000).max(60000).optional(),
+});
+
+function canAccessDeviceSite(
+  device: { siteId?: string | null },
+  userPerms: UserPermissions | undefined,
+): boolean {
+  if (!userPerms?.allowedSiteIds) return true;
+  return typeof device.siteId === 'string' && canAccessSite(userPerms, device.siteId);
+}
+
+actuateElevationRoutes.post(
+  '/:id/actuate-elevation',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_EXECUTE.resource, PERMISSIONS.DEVICES_EXECUTE.action),
+  requireMfa(),
+  zValidator('json', actuateElevationSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const deviceId = c.req.param('id')!;
+    const data = c.req.valid('json');
+
+    const device = await getDeviceWithOrgCheck(deviceId, auth);
+    if (!device) {
+      return c.json({ error: 'Device not found' }, 404);
+    }
+    if (!canAccessDeviceSite(device, c.get('permissions') as UserPermissions | undefined)) {
+      return c.json({ error: 'Access to this site denied' }, 403);
+    }
+    if (device.status === 'decommissioned') {
+      return c.json({ error: 'Cannot send commands to a decommissioned device' }, 400);
+    }
+
+    // Verify the elevation request belongs to the same device + the
+    // caller's org. Without this gate, a partner-scoped admin could
+    // actuate an elevation row whose org they cannot see.
+    const [elevation] = await db
+      .select({
+        id: elevationRequests.id,
+        deviceId: elevationRequests.deviceId,
+        orgId: elevationRequests.orgId,
+        status: elevationRequests.status,
+      })
+      .from(elevationRequests)
+      .where(
+        and(
+          eq(elevationRequests.id, data.elevationRequestId),
+          eq(elevationRequests.deviceId, deviceId),
+        ),
+      )
+      .limit(1);
+
+    if (!elevation) {
+      return c.json({ error: 'Elevation request not found for this device' }, 404);
+    }
+    if (elevation.orgId !== device.orgId) {
+      // Defensive: same-device + cross-org would mean the FK pair is
+      // wrong. Refuse rather than queue.
+      return c.json({ error: 'Elevation request org mismatch' }, 409);
+    }
+    if (elevation.status !== 'approved') {
+      return c.json(
+        { error: 'Elevation request is not approved', code: elevation.status },
+        409,
+      );
+    }
+
+    const [command] = await db
+      .insert(deviceCommands)
+      .values({
+        deviceId,
+        type: 'actuate_elevation',
+        payload: {
+          elevationRequestId: data.elevationRequestId,
+          username: data.username,
+          password: data.password,
+          timeoutMs: data.timeoutMs ?? 8000,
+        },
+        status: 'pending',
+        createdBy: auth.user.id,
+      })
+      .returning();
+
+    if (!command) {
+      return c.json({ error: 'Failed to queue command' }, 500);
+    }
+
+    // Audit log MUST NOT carry the password. elevationRequestId +
+    // username + deviceId is enough to correlate; the cleartext only
+    // exists in flight to the agent. (`commandAuditDetails` is not
+    // imported here because the default sanitizer would still see the
+    // password in the payload via deep-clone.)
+    writeRouteAudit(c, {
+      orgId: device.orgId,
+      action: 'device.elevation.actuate',
+      resourceType: 'device_command',
+      resourceId: command.id,
+      resourceName: 'actuate_elevation',
+      details: {
+        deviceId,
+        elevationRequestId: data.elevationRequestId,
+        username: data.username,
+        timeoutMs: data.timeoutMs ?? 8000,
+      },
+    });
+
+    return c.json(
+      {
+        id: command.id,
+        deviceId: command.deviceId,
+        type: command.type,
+        status: command.status,
+        elevationRequestId: data.elevationRequestId,
+        createdAt: command.createdAt,
+      },
+      201,
+    );
+  },
+);

--- a/apps/api/src/routes/devices/actuateElevation.ts
+++ b/apps/api/src/routes/devices/actuateElevation.ts
@@ -3,7 +3,12 @@ import { zValidator } from '@hono/zod-validator';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../../db';
-import { deviceCommands, devices, elevationRequests } from '../../db/schema';
+import {
+  deviceCommands,
+  devices,
+  elevationAudit,
+  elevationRequests,
+} from '../../db/schema';
 import {
   authMiddleware,
   requireMfa,
@@ -43,6 +48,13 @@ actuateElevationRoutes.use('*', authMiddleware);
  * agent does not persist it. device_commands is intentionally
  * system-scoped (see CLAUDE.md tenancy notes), but RLS still covers the
  * `devices` row we read on the way in.
+ *
+ * Single-use enforcement: SELECT + transactional UPDATE-status
+ * 'approved' → 'actuating' + INSERT command happen in a single
+ * `db.transaction`. The UPDATE only fires when status='approved'; if
+ * zero rows are returned, we lost the TOCTOU race and refuse. After a
+ * successful actuation the row sits in 'actuating' until the agent
+ * reports completion (later track) — it cannot be replayed.
  */
 
 const actuateElevationSchema = z.object({
@@ -82,59 +94,180 @@ actuateElevationRoutes.post(
       return c.json({ error: 'Cannot send commands to a decommissioned device' }, 400);
     }
 
-    // Verify the elevation request belongs to the same device + the
-    // caller's org. Without this gate, a partner-scoped admin could
-    // actuate an elevation row whose org they cannot see.
-    const [elevation] = await db
-      .select({
-        id: elevationRequests.id,
-        deviceId: elevationRequests.deviceId,
-        orgId: elevationRequests.orgId,
-        status: elevationRequests.status,
-      })
-      .from(elevationRequests)
-      .where(
-        and(
-          eq(elevationRequests.id, data.elevationRequestId),
-          eq(elevationRequests.deviceId, deviceId),
-        ),
-      )
-      .limit(1);
+    // Transactional single-use enforcement (PR #960 review, blocker 1).
+    //
+    // The route's "proof of approval" is `elevation_requests.status === 'approved'`. To
+    // make that proof one-shot we must transition the row out of 'approved' in the same
+    // transaction as the command insert. Otherwise an approved row can be POSTed N
+    // times and each call queues a new actuate_elevation command — credential replay /
+    // multi-spawn vector.
+    //
+    // The UPDATE WHERE status='approved' atomic-compare-and-swaps the row to
+    // 'actuating'. If zero rows return, either it wasn't approved or we lost the race
+    // against a concurrent POST; either way we refuse with 409.
+    //
+    // Org check (PR #960 review, blocker 3): the WHERE clause includes
+    // `orgId = device.orgId` so the FK pair (id, deviceId, orgId) is the primary
+    // gate, not a post-query assert.
+    //
+    // Audit (PR #960 review, blocker 2): every outcome — success, race-lost,
+    // wrong-status — must land in `elevation_audit` with the cause. 404/decommission
+    // paths above can't write elevation_audit (no valid FK target), so they get only
+    // the route-level audit at the outer scope.
+    const result = await db.transaction(async (tx) => {
+      const [elevation] = await tx
+        .select({
+          id: elevationRequests.id,
+          deviceId: elevationRequests.deviceId,
+          orgId: elevationRequests.orgId,
+          status: elevationRequests.status,
+        })
+        .from(elevationRequests)
+        .where(
+          and(
+            eq(elevationRequests.id, data.elevationRequestId),
+            eq(elevationRequests.deviceId, deviceId),
+            // Blocker 3: org check inside the WHERE clause makes the FK pair the
+            // primary gate (Shape-4 from #905). The cross-org "defensive" check below
+            // becomes defense-in-depth instead of the only line of defense.
+            eq(elevationRequests.orgId, device.orgId),
+          ),
+        )
+        .limit(1);
 
-    if (!elevation) {
+      if (!elevation) {
+        return { kind: 'not_found' as const };
+      }
+
+      if (elevation.status !== 'approved') {
+        await tx.insert(elevationAudit).values({
+          orgId: device.orgId,
+          elevationRequestId: elevation.id,
+          eventType: 'command_executed',
+          actor: 'technician',
+          actorUserId: auth.user.id,
+          details: {
+            deviceId,
+            outcome: 'rejected_wrong_status',
+            actualStatus: elevation.status,
+          },
+          occurredAt: new Date(),
+        });
+        return { kind: 'wrong_status' as const, status: elevation.status };
+      }
+
+      // Blocker 1: atomic CAS approved → actuating. If concurrent POSTs race, only
+      // one wins; the loser sees rowCount=0 and we 409 with 'race_lost'.
+      const updated = await tx
+        .update(elevationRequests)
+        .set({ status: 'actuating', updatedAt: new Date() })
+        .where(
+          and(
+            eq(elevationRequests.id, elevation.id),
+            eq(elevationRequests.status, 'approved'),
+          ),
+        )
+        .returning({ id: elevationRequests.id });
+
+      if (updated.length === 0) {
+        await tx.insert(elevationAudit).values({
+          orgId: device.orgId,
+          elevationRequestId: elevation.id,
+          eventType: 'command_executed',
+          actor: 'technician',
+          actorUserId: auth.user.id,
+          details: { deviceId, outcome: 'race_lost' },
+          occurredAt: new Date(),
+        });
+        return { kind: 'race_lost' as const };
+      }
+
+      const [command] = await tx
+        .insert(deviceCommands)
+        .values({
+          deviceId,
+          type: 'actuate_elevation',
+          payload: {
+            elevationRequestId: data.elevationRequestId,
+            username: data.username,
+            password: data.password,
+            timeoutMs: data.timeoutMs ?? 8000,
+          },
+          status: 'pending',
+          createdBy: auth.user.id,
+        })
+        .returning();
+
+      if (!command) {
+        // Should not happen with .returning(); rolled back by throwing.
+        throw new Error('actuate-elevation: device_commands insert returned no row');
+      }
+
+      // Blocker 2: elevation_audit insert on the happy path. The password
+      // is never recorded here — only the request id + command id + username.
+      await tx.insert(elevationAudit).values({
+        orgId: device.orgId,
+        elevationRequestId: elevation.id,
+        eventType: 'command_executed',
+        actor: 'technician',
+        actorUserId: auth.user.id,
+        details: {
+          deviceId,
+          commandId: command.id,
+          username: data.username,
+          timeoutMs: data.timeoutMs ?? 8000,
+        },
+        occurredAt: new Date(),
+      });
+
+      return { kind: 'success' as const, command };
+    });
+
+    if (result.kind === 'not_found') {
+      // Route-level audit only — no elevation_audit because the FK target
+      // doesn't exist for this caller's org.
+      writeRouteAudit(c, {
+        orgId: device.orgId,
+        action: 'device.elevation.actuate.rejected',
+        resourceType: 'device_command',
+        resourceId: data.elevationRequestId,
+        resourceName: 'actuate_elevation',
+        details: { deviceId, outcome: 'elevation_request_not_found' },
+      });
       return c.json({ error: 'Elevation request not found for this device' }, 404);
     }
-    if (elevation.orgId !== device.orgId) {
-      // Defensive: same-device + cross-org would mean the FK pair is
-      // wrong. Refuse rather than queue.
-      return c.json({ error: 'Elevation request org mismatch' }, 409);
-    }
-    if (elevation.status !== 'approved') {
+
+    if (result.kind === 'race_lost') {
+      writeRouteAudit(c, {
+        orgId: device.orgId,
+        action: 'device.elevation.actuate.rejected',
+        resourceType: 'device_command',
+        resourceId: data.elevationRequestId,
+        resourceName: 'actuate_elevation',
+        details: { deviceId, outcome: 'race_lost' },
+      });
       return c.json(
-        { error: 'Elevation request is not approved', code: elevation.status },
+        { error: 'Elevation request already being actuated', code: 'race_lost' },
         409,
       );
     }
 
-    const [command] = await db
-      .insert(deviceCommands)
-      .values({
-        deviceId,
-        type: 'actuate_elevation',
-        payload: {
-          elevationRequestId: data.elevationRequestId,
-          username: data.username,
-          password: data.password,
-          timeoutMs: data.timeoutMs ?? 8000,
-        },
-        status: 'pending',
-        createdBy: auth.user.id,
-      })
-      .returning();
-
-    if (!command) {
-      return c.json({ error: 'Failed to queue command' }, 500);
+    if (result.kind === 'wrong_status') {
+      writeRouteAudit(c, {
+        orgId: device.orgId,
+        action: 'device.elevation.actuate.rejected',
+        resourceType: 'device_command',
+        resourceId: data.elevationRequestId,
+        resourceName: 'actuate_elevation',
+        details: { deviceId, outcome: 'wrong_status', status: result.status },
+      });
+      return c.json(
+        { error: 'Elevation request is not approved', code: result.status },
+        409,
+      );
     }
+
+    const command = result.command;
 
     // Audit log MUST NOT carry the password. elevationRequestId +
     // username + deviceId is enough to correlate; the cleartext only

--- a/apps/api/src/routes/devices/index.ts
+++ b/apps/api/src/routes/devices/index.ts
@@ -19,6 +19,7 @@ import { diagnoseRoutes } from './diagnose';
 import { warrantyRoutes } from './warranty';
 import { provisionRoutes } from './provision';
 import { moveOrgRoutes } from './moveOrg';
+import { actuateElevationRoutes } from './actuateElevation';
 
 export const deviceRoutes = new Hono();
 
@@ -57,6 +58,7 @@ deviceRoutes.route('/', diagnosticLogsRoutes);
 deviceRoutes.route('/', watchdogLogsRoutes);
 deviceRoutes.route('/', warrantyRoutes);
 deviceRoutes.route('/', bootMetricsRoutes);
+deviceRoutes.route('/', actuateElevationRoutes);
 
 // Re-export helpers and schemas for potential use elsewhere
 export * from './helpers';


### PR DESCRIPTION
## Summary

Adds the agent-side UAC elevation **actuator** (Flavor A: SendInput into consent.exe on the secure desktop) plus the admin-side `POST /devices/:id/actuate-elevation` route that queues it. Implements Discussion #858 Track 5 per your Q4 ruling (2026-05-23): SendInput-into-consent.exe as primary path; Flavor B (CreateProcessAsUser token-mixing) stays the future-track for Administrator-Protection era.

Depends on Track 1 (`elevation_requests` schema, #905, merged) and pairs with Track 3 (ETW LUA subscriber, #959, in flight) which emits the requests this actuator services.

## What's in the PR

| Layer | Files | LOC |
|---|---|---|
| **agent pamactuator package** | `agent/internal/pamactuator/` (actuator.go, actuator_windows.go, actuator_other.go, wininput.go, tests) | ~550 |
| **agent heartbeat handler** | `agent/internal/heartbeat/handlers_actuate.go` | 121 |
| **API admin route** | `apps/api/src/routes/devices/actuateElevation.ts` + tests | 524 |
| **wiring** | types.go (CmdActuateElevation const), index.ts (mount), handlers_test.go (registry allowlist) | 11 |

Total ~1195 insertions across 8 new files + 3 modified.

## Design notes worth flagging

Two deliberate deviations from the firmup spec (per Karpathy "surface tradeoffs"):

1. **No `pamactuator_start_*.go` startup files.** Track 5 is purely command-driven, not a daemon loop. The `init()` in `handlers_actuate.go` registering the `actuate_elevation` handler is sufficient wiring. Track 3's startup files exist because ETW needs an active subscriber goroutine — Track 5 doesn't.

2. **API route lives under `routes/devices/`, not `routes/agents/`.** `routes/agents/*` is for agent→API endpoints (heartbeat, enrollment). This is a user→API admin route targeting `POST /devices/:id/actuate-elevation`, matching the existing pattern of `moveOrg.ts`, `provision.ts`, `commands.ts`.

3. **Local SendInput duplicate** in `wininput.go` rather than refactoring `agent/internal/remote/desktop/input_windows.go` into a shared package. Per firmup Q5 — surgical change, avoids cross-package coupling. Adds a TODO referencing the future shared package.

## Tests

- `cd agent && CGO_ENABLED=0 go test ./internal/pamactuator/...` — pass
- `GOOS=windows GOARCH=amd64 go build ./cmd/breeze-agent` — builds clean
- `pnpm exec vitest run src/routes/devices/actuateElevation.test.ts` — **12/12 pass** (request validation, auth, preconditions, happy-path)
- `pnpm exec tsc --noEmit` — clean

## CI note

Inheriting Smoke Test + admin/abuse test failures from main (in flight via #957). Failures here match main exactly — not regressions introduced by this PR.

## Live-test caveat

This is agent-side Windows code; the actual SendInput-into-secure-desktop path only runs end-to-end on a live Windows host inside a real elevation flow. Test coverage is unit-only. Suggest canary on a single Windows endpoint after merge before broad rollout.