### PR TITLE
fix(compose): ship working image defaults for self-host (closes #961)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -425,16 +425,28 @@ CLOUDFLARE_ZONE_ID=
 # --------------------------------------------
 # Docker Deployment
 # --------------------------------------------
-# BREEZE_VERSION is runtime metadata. Container immutability comes from the
-# digest-pinned image refs below.
-BREEZE_VERSION=0.1.3
-BREEZE_API_IMAGE_REF=ghcr.io/lanternops/breeze/api@sha256:replace-with-release-api-image-digest
-BREEZE_WEB_IMAGE_REF=ghcr.io/lanternops/breeze/web@sha256:replace-with-release-web-image-digest
-BREEZE_BINARIES_IMAGE_REF=ghcr.io/lanternops/breeze/binaries@sha256:replace-with-release-binaries-image-digest
-CADDY_IMAGE_REF=caddy@sha256:replace-with-reviewed-caddy-image-digest
-POSTGRES_IMAGE_REF=postgres@sha256:replace-with-reviewed-postgres-image-digest
-REDIS_IMAGE_REF=redis@sha256:replace-with-reviewed-redis-image-digest
-COTURN_IMAGE_REF=coturn/coturn@sha256:replace-with-reviewed-coturn-image-digest
+# BREEZE_VERSION pins the Breeze API/web/binaries images. Update this when
+# upgrading — see https://github.com/LanternOps/breeze/releases for current.
+BREEZE_VERSION=0.67.1
+
+# Breeze application images. By default these resolve to the tag matching
+# BREEZE_VERSION above. For higher supply-chain assurance, replace the tag
+# (`:${BREEZE_VERSION}`) with a `@sha256:<digest>` ref from the GHCR package
+# page (https://github.com/orgs/LanternOps/packages?repo_name=breeze) or via
+# `docker buildx imagetools inspect ghcr.io/lanternops/breeze/api:0.67.1`.
+# The strict digest-pinned production deploy path lives in deploy/.env.example
+# and is enforced by scripts/security/check-supply-chain-hardening.sh.
+BREEZE_API_IMAGE_REF=ghcr.io/lanternops/breeze/api:${BREEZE_VERSION}
+BREEZE_WEB_IMAGE_REF=ghcr.io/lanternops/breeze/web:${BREEZE_VERSION}
+BREEZE_BINARIES_IMAGE_REF=ghcr.io/lanternops/breeze/binaries:${BREEZE_VERSION}
+
+# Third-party sidecar images. Pinned to specific minor versions to match what
+# Breeze is tested against. Override to digest-pinned refs in production
+# (e.g. `caddy@sha256:<digest>` from `docker buildx imagetools inspect caddy:2-alpine`).
+CADDY_IMAGE_REF=caddy:2-alpine
+POSTGRES_IMAGE_REF=postgres:16-alpine
+REDIS_IMAGE_REF=redis:7-alpine
+COTURN_IMAGE_REF=coturn/coturn:latest
 #
 # Container platform — defaults to linux/amd64 (matches GHCR images).
 # GHCR does not publish arm64. On Apple Silicon, use
@@ -451,7 +463,7 @@ COTURN_IMAGE_REF=coturn/coturn@sha256:replace-with-reviewed-coturn-image-digest
 #   git tag v0.3.0 && git push --tags   → stable release, tagged as "latest" + "0.3.0"
 #   git tag v0.3.0-rc.1 && git push --tags → prerelease, tagged as "0.3.0-rc.1" only
 #
-# To upgrade: update BREEZE_VERSION and the digest-pinned image refs, then run
+# To upgrade: update BREEZE_VERSION (and any digest-pinned overrides) above, then run
 # docker compose pull && docker compose up -d through the normal release process.
 
 # --------------------------------------------

--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ cp .env.example .env
 #   MFA_RECOVERY_CODE_PEPPER openssl rand -base64 32
 #   BREEZE_BOOTSTRAP_ADMIN_EMAIL     your admin email, first boot only
 #   BREEZE_BOOTSTRAP_ADMIN_PASSWORD  one-time value from `openssl rand -base64 32`
+#
+# BREEZE_VERSION ships pinned to a known-good release. Bump it to upgrade
+# (see https://github.com/LanternOps/breeze/releases for the current version).
 
 # Optional — for remote desktop (WebRTC TURN relay):
 #   TURN_HOST            public IP of your TURN server
@@ -170,6 +173,8 @@ docker compose up -d
 Breeze will be running at `https://your-domain` (or `https://localhost` with a self-signed cert for local testing).
 
 On first production boot against an empty database, Breeze creates the initial Partner Admin only from operator-provided `BREEZE_BOOTSTRAP_ADMIN_EMAIL` and `BREEZE_BOOTSTRAP_ADMIN_PASSWORD` values. If those values are missing, startup refuses to seed the empty production database. The password is never printed to logs. After you sign in and finish setup, remove those bootstrap values from `.env`.
+
+For hardened production deploys (Cloudflare Tunnel, mandatory digest-pinned images, monitoring + logging), see [docs/DEPLOY_PRODUCTION.md](docs/DEPLOY_PRODUCTION.md) which uses `deploy/docker-compose.prod.yml`.
 
 ### Install the Agent
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -9,14 +9,30 @@ CORS_ALLOWED_ORIGINS=https://${BREEZE_DOMAIN}
 SENTRY_ENVIRONMENT=production
 
 # ── Release image integrity ────────────────────────────────────────
-# BREEZE_VERSION is informational/runtime metadata. Container immutability is
-# enforced by digest-pinned image refs below.
+# This is the strict, digest-pinned production deploy path
+# (deploy/docker-compose.prod.yml). Mutable tags like `:latest` are rejected
+# here intentionally — see scripts/security/check-supply-chain-hardening.sh.
+# For the simpler self-host path that allows tag-pinned images, use the
+# top-level docker-compose.yml + .env.example.
+#
+# BREEZE_VERSION is runtime metadata only. Set it to the release you intend
+# to deploy and verify it matches the digests below.
 BREEZE_VERSION=0.0.0
+#
+# Obtain Breeze release digests (replace TAG with e.g. 0.67.1):
+#   docker buildx imagetools inspect ghcr.io/lanternops/breeze/api:TAG \
+#     --format '{{json .Manifest}}' | jq -r .digest
+# Or visit https://github.com/orgs/LanternOps/packages?repo_name=breeze
+# and copy the digest of the tag you want to deploy.
 BREEZE_API_IMAGE_DIGEST=sha256:replace-with-release-api-image-digest
 BREEZE_WEB_IMAGE_DIGEST=sha256:replace-with-release-web-image-digest
 BREEZE_BINARIES_IMAGE_DIGEST=sha256:replace-with-release-binaries-image-digest
 
-# Third-party runtime images must also be digest pinned.
+# Third-party runtime images must also be digest pinned. Obtain via:
+#   docker buildx imagetools inspect caddy:2-alpine \
+#     --format '{{json .Manifest}}' | jq -r .digest
+# Re-review on every upgrade. The hardening script enforces the `@sha256:`
+# prefix and refuses to ship a release with placeholders here.
 CADDY_IMAGE_REF=caddy@sha256:replace-with-reviewed-caddy-image-digest
 CLOUDFLARED_IMAGE_REF=cloudflare/cloudflared@sha256:replace-with-reviewed-cloudflared-image-digest
 REDIS_IMAGE_REF=redis@sha256:replace-with-reviewed-redis-image-digest

--- a/docs/DEPLOY_PRODUCTION.md
+++ b/docs/DEPLOY_PRODUCTION.md
@@ -5,6 +5,17 @@ This guide deploys Breeze with TLS, hardened container settings, monitoring, and
 - `deploy/docker-compose.prod.yml`
 - `scripts/prod/deploy.sh`
 
+## Which deploy path?
+
+Breeze ships two Compose configurations:
+
+| Path | Files | When to use |
+|------|-------|-------------|
+| **Simple self-host** | `docker-compose.yml` + `.env.example` (repo root) | Single-host self-hosted deploys behind your own TLS reverse proxy. Tag-pinned images by default (override with digests for higher assurance). Uses the `*_IMAGE_REF` variable schema. |
+| **Strict production** *(this doc)* | `deploy/docker-compose.prod.yml` + `deploy/.env.example` | Production rollouts with Cloudflare Tunnel, hardened ACLs, monitoring/logging, and **mandatory** digest-pinned images. Uses the `*_IMAGE_DIGEST` variable schema (Breeze images) and `*_IMAGE_REF` (third-party). The hardening check (`scripts/security/check-supply-chain-hardening.sh`) refuses to ship a release with mutable tags in this path. |
+
+The two paths use **different variable names** intentionally — they are not interchangeable. If you copied `.env` from one path, do not point it at the other Compose file.
+
 ## Prerequisites
 
 - Linux host with Docker Engine + Docker Compose plugin
@@ -45,6 +56,29 @@ Set at least these values in `.env.prod`:
 - `METRICS_SCRAPE_TOKEN`
 - `PUBLIC_API_URL` (example: `https://app.example.com/api/v1`)
 - `GRAFANA_ADMIN_PASSWORD`
+
+### Obtaining image digests
+
+`BREEZE_*_IMAGE_DIGEST` values are `sha256:<64hex>` strings — not full image refs. The Compose file prepends `ghcr.io/lanternops/breeze/<name>@` automatically.
+
+```bash
+# Replace 0.67.1 with the release you intend to deploy.
+TAG=0.67.1
+for img in api web binaries; do
+  digest=$(docker buildx imagetools inspect "ghcr.io/lanternops/breeze/$img:$TAG" \
+    --format '{{json .Manifest}}' | jq -r .digest)
+  echo "BREEZE_${img^^}_IMAGE_DIGEST=$digest"
+done
+```
+
+Third-party `*_IMAGE_REF` values are full digest-pinned refs (`name@sha256:<64hex>`):
+
+```bash
+docker buildx imagetools inspect caddy:2-alpine \
+  --format 'caddy@{{json .Manifest | fromjson | .digest}}' | tr -d '"'
+```
+
+Browse current releases at <https://github.com/orgs/LanternOps/packages?repo_name=breeze>.
 
 The bootstrap admin password is not logged by the API. If these values are missing on first boot against an empty production database, the API refuses to seed a default admin. After the initial admin signs in and completes setup, remove `BREEZE_BOOTSTRAP_ADMIN_EMAIL` and `BREEZE_BOOTSTRAP_ADMIN_PASSWORD` from the production environment.
 


### PR DESCRIPTION
## Summary

- **Root cause:** `.env.example:431-437` ships literal `replace-with-reviewed-<name>-image-digest` placeholders for image refs. `docker-compose.yml` only validates the variable is *set* (`${VAR:?...}`), not that it's a parseable image ref, so a self-hoster following the README quickstart (`cp .env.example .env && docker compose up -d`) immediately hits `invalid reference format`. Originally reported in #961 with no doc or inline comment explaining what to substitute.
- **Fix:** `.env.example` now ships working tag-pinned defaults (Breeze refs resolve via `${BREEZE_VERSION}`, sidecars use the tags Breeze is tested against), with inline comments explaining the upgrade path to digest-pinned refs. `BREEZE_VERSION` bumped from stale `0.1.3` to `0.67.1`.
- **Docs:** Added a "Which deploy path?" table to `docs/DEPLOY_PRODUCTION.md` explaining the intentional `*_IMAGE_REF` vs `*_IMAGE_DIGEST` schema split, plus an "Obtaining image digests" section with copy-pasteable `docker buildx imagetools inspect` recipes. `deploy/.env.example` keeps its strict placeholders (still enforced by the hardening check) but now tells operators how to populate them. README quickstart notes that `BREEZE_VERSION` is load-bearing and links forward to the strict prod doc.

## Why a single PR for this

The two deploy paths are intentionally different and not interchangeable — the top-level compose targets simple self-host (mutable tags ok, that's what CI itself uses at `ci.yml:478-484` and what the droplet upgrade flow in `CLAUDE.md` uses), while `deploy/docker-compose.prod.yml` is the strict path with mandatory digest-pinning. Both needed updates and the consistency was the actual user-facing bug, so they ship together.

## Test plan

- [x] `scripts/security/check-supply-chain-hardening.sh` passes — the `^*_IMAGE_DIGEST=sha256:` and `^*_IMAGE_REF=.*@sha256:` regexes on `deploy/.env.example` are preserved.
- [x] `docker compose config` with the new top-level `.env.example` defaults resolves all six service images cleanly: `ghcr.io/lanternops/breeze/{api,web,binaries}:0.67.1`, `caddy:2-alpine`, `postgres:16-alpine`, `redis:7-alpine`.
- [x] `docker buildx imagetools inspect ghcr.io/lanternops/breeze/api:0.67.1` confirms the registry tag exists.
- [ ] CI green on this branch.
- [ ] Reporter verifies `docker compose up -d` works on a fresh self-host after this lands.

Closes #961

🤖 Generated with [Claude Code](https://claude.com/claude-code)