### PR TITLE
docs: sync apps/docs/ to v0.66.0..HEAD + docs-review tracker

### DIFF
--- a/apps/docs/src/content/docs/agents/commands.mdx
+++ b/apps/docs/src/content/docs/agents/commands.mdx
@@ -283,6 +283,12 @@ Enable or disable automatic agent self-updates for the device. When disabled, th
 
 This command is also exposed directly as `POST /devices/:id/auto-update` with body `{ "enabled": <bool> }` — useful for re-enabling auto-update on agents that were left with it turned off (for example after a manual or recovery update).
 
+### `refresh_inventory`
+
+Ask the agent to collect a fresh hardware/software inventory snapshot immediately instead of waiting for its scheduled run. The dashboard exposes this as the **Refresh Inventory** button on the device detail page; the API surface is `POST /devices/:id/commands` with `{ "type": "refresh_inventory" }`.
+
+Duplicates are rejected: while an inventory refresh is already queued or running for a device, a second request returns `409 Conflict` with `code: "ALREADY_PENDING"`. The bulk variant (`POST /devices/bulk/commands`) applies the same check per device and partitions its response into `commands` (newly issued), `skipped` (already-pending refreshes, each with the existing `commandId`), and `failed`.
+
 ---
 
 ## File Operations

--- a/apps/docs/src/content/docs/agents/enrollment-keys.mdx
+++ b/apps/docs/src/content/docs/agents/enrollment-keys.mdx
@@ -125,6 +125,8 @@ curl -X POST https://breeze.yourdomain.com/api/v1/enrollment-keys \
 
 When neither `expiresAt` nor `ttlMinutes` is supplied, the key expires after `ENROLLMENT_KEY_DEFAULT_TTL_MINUTES` (default 60). Supplying both is rejected so the resolved expiry is unambiguous.
 
+POST and PATCH on `/enrollment-keys` reject any field that isn't in the table above. A typo like `maxUses` (instead of `maxUsage`) now returns `400 Bad Request` with a precise field-name error rather than silently dropping the value — useful when scripting key creation against earlier API examples that used different field names.
+
 <Aside>
   The default TTL is configurable via the `ENROLLMENT_KEY_DEFAULT_TTL_MINUTES` environment variable. If unset, keys expire 60 minutes after creation.
 </Aside>

--- a/apps/docs/src/content/docs/agents/enrollment.mdx
+++ b/apps/docs/src/content/docs/agents/enrollment.mdx
@@ -85,3 +85,9 @@ If an agent's token is compromised or the device needs to be reassigned:
    - macOS: `sudo rm "/Library/Application Support/Breeze/agent.yaml" "/Library/Application Support/Breeze/secrets.yaml"`
    - Windows: `Remove-Item C:\ProgramData\Breeze\agent.yaml, C:\ProgramData\Breeze\secrets.yaml`
 3. **Re-enroll**: `sudo breeze-agent enroll YOUR_ENROLLMENT_KEY --server ... --enrollment-secret ...`
+
+### Reusing a hostname for a decommissioned device
+
+When a device row is **decommissioned** in the dashboard, the original device id is retired but the hostname is free to be claimed again. Running `breeze-agent enroll` from a new install on the same hostname creates a fresh device record (new id, new token) rather than failing with a hostname collision. The decommissioned row stays in audit history for compliance — the new device is treated as a distinct asset from day one.
+
+The only exception is if the decommissioned device's token was suspended for a security reason (for example, a cross-tenant access probe). In that case re-enrollment is blocked with a `409 Conflict` until an administrator reviews the previous incident. The response includes the reason so the technician on-site knows to escalate rather than retry.

--- a/apps/docs/src/content/docs/agents/installation.mdx
+++ b/apps/docs/src/content/docs/agents/installation.mdx
@@ -116,6 +116,14 @@ The GUI installer uses bootstrap tokens generated server-side from an enrollment
 
 ---
 
+## Pre-Provisioning Devices
+
+For deployments where you want a device row to exist in the dashboard before the agent has ever talked to the server — for example, building out an asset list ahead of a hardware shipment — admins can pre-create the row with `POST /devices/provision`. The endpoint accepts the device's hostname, target organization, and site, and returns a single-use enrollment payload that can be baked into the installer.
+
+Pre-provisioned devices land in `status: 'pending'` and stay there until the agent's first heartbeat arrives. They show up in the device list with a "Pending enrollment" indicator so it's clear which rows are placeholders versus active devices.
+
+---
+
 ## What Gets Installed
 
 All platform installers (MSI, PKG, and manual service install) include two components:

--- a/apps/docs/src/content/docs/deploy/binaries.mdx
+++ b/apps/docs/src/content/docs/deploy/binaries.mdx
@@ -32,6 +32,12 @@ The release version is determined by `BINARY_VERSION` or `BREEZE_VERSION`. If ne
 
 On startup, the API calls GitHub's Releases API to register the current version's checksums in the `agent_versions` table, so agents know when a new version is available.
 
+#### Manifest trust root
+
+In production, GitHub mode requires the `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` env var. This is the base64 SPKI of the Ed25519 public key that signs our release manifests. The API verifies every fetched manifest against this key before trusting its checksums, so a compromised GitHub release alone can't deliver tampered binaries.
+
+The published default works for the official Breeze releases; only override it if you build and sign your own binaries. The API refuses to start in production without it.
+
 ### Local Mode
 
 Binaries are served from disk. The API reads from these directories:

--- a/apps/docs/src/content/docs/deploy/environment.mdx
+++ b/apps/docs/src/content/docs/deploy/environment.mdx
@@ -28,9 +28,10 @@ All configuration is done through environment variables, defined in your `.env.p
 
 | Variable | Default | Required | Description |
 |---|---|---|---|
-| `REDIS_URL` | `redis://localhost:6379` | | Redis connection URL. Include the password when `REDIS_PASSWORD` is set (e.g., `redis://:password@localhost:6379`) |
+| `REDIS_URL` | `redis://localhost:6379` | Yes (prod) | Redis connection URL. **Must carry a password in production** (e.g., `redis://:password@localhost:6379`) — the API refuses to boot if it doesn't. |
 | `REDIS_PORT` | `6379` | | Redis port |
-| `REDIS_PASSWORD` | — | Yes (prod) | Password for Redis authentication. Set in docker-compose and include in `REDIS_URL` |
+| `REDIS_PASSWORD` | — | Yes (prod) | Password for Redis authentication. Set in docker-compose and include in `REDIS_URL`. |
+| `REDIS_PASSWORD_FILE` | — | | Path to a file containing the Redis password (Docker secret style). Used in place of `REDIS_PASSWORD` when secrets are mounted as files. |
 
 ## Authentication & Security
 
@@ -60,7 +61,9 @@ All configuration is done through environment variables, defined in your `.env.p
 | `BREEZE_DOMAIN` | — | Yes (prod) | Domain for Caddy TLS provisioning |
 | `ACME_EMAIL` | — | Yes (prod) | Email for Let's Encrypt certificate notifications |
 | `CORS_ALLOWED_ORIGINS` | — | | Comma-separated allowed CORS origins |
-| `TRUST_PROXY_HEADERS` | `false` | | Set `true` when behind a reverse proxy |
+| `IS_HOSTED` | — | Yes (prod) | `true` for hosted SaaS edition, `false` for self-hosted. Must be set explicitly — the API refuses to boot otherwise. Controls signup gating, billing, and email-verification policy. |
+| `TRUST_PROXY_HEADERS` | — | Yes (prod) | `true` when behind a reverse proxy (Caddy, Cloudflare). Must be set explicitly in production. |
+| `TRUSTED_PROXY_CIDRS` | — | When `TRUST_PROXY_HEADERS=true` | Comma-separated CIDRs of trusted reverse proxies (e.g., `10.0.0.0/8,172.16.0.0/12`). Required when proxy headers are trusted. |
 | `DASHBOARD_URL` | — | | URL for links in emails |
 | `PUBLIC_APP_URL` | — | | Public-facing app URL |
 
@@ -94,14 +97,15 @@ All configuration is done through environment variables, defined in your `.env.p
 
 ## Binary Distribution
 
-| Variable | Default | Description |
-|---|---|---|
-| `BINARY_SOURCE` | `local` | Download source: `local` (serve from disk, optional S3) or `github` (redirect to GitHub Releases) |
-| `AGENT_BINARY_DIR` | `./agent/bin` | Local directory containing agent binaries |
-| `VIEWER_BINARY_DIR` | `./viewer/bin` | Local directory containing viewer installers |
-| `HELPER_BINARY_DIR` | `/data/binaries/helper` | Local directory containing helper binaries |
-| `BINARY_VERSION_FILE` | — | Path to `VERSION` file for local mode DB registration (set automatically in Docker Compose) |
-| `BINARY_VERSION` | — | Release tag for GitHub redirect mode (falls back to `BREEZE_VERSION`, then `latest`) |
+| Variable | Default | Required | Description |
+|---|---|---|---|
+| `BINARY_SOURCE` | `local` | | Download source: `local` (serve from disk, optional S3) or `github` (redirect to GitHub Releases) |
+| `AGENT_BINARY_DIR` | `./agent/bin` | | Local directory containing agent binaries |
+| `VIEWER_BINARY_DIR` | `./viewer/bin` | | Local directory containing viewer installers |
+| `HELPER_BINARY_DIR` | `/data/binaries/helper` | | Local directory containing helper binaries |
+| `BINARY_VERSION_FILE` | — | | Path to `VERSION` file for local mode DB registration (set automatically in Docker Compose) |
+| `BINARY_VERSION` | — | | Release tag for GitHub redirect mode (falls back to `BREEZE_VERSION`, then `latest`) |
+| `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` | — | Yes (prod) | Comma-separated base64 SPKI of the Ed25519 keys that sign release manifests. The API refuses to start in production without it. `BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` is accepted as an alias. |
 
 See [Binary Distribution](/deploy/binaries/) for details on local vs GitHub mode and S3 offloading.
 

--- a/apps/docs/src/content/docs/deploy/production.mdx
+++ b/apps/docs/src/content/docs/deploy/production.mdx
@@ -67,6 +67,20 @@ An optional monitoring stack (Prometheus, Grafana, Alertmanager, Loki, Promtail,
 
    Paste the output into `.env`.
 
+   Then set these required deployment-mode flags. Without them the API refuses to boot in production:
+
+   ```bash
+   # Self-hosted by default. Set to "true" only if you're running the hosted SaaS edition.
+   IS_HOSTED=false
+
+   # Base64 SPKI of the Ed25519 key used to sign release manifests. The hosted releases
+   # we publish on GitHub are anchored to this key — leave the published default unless
+   # you build and sign your own binaries.
+   RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=<base64-spki>
+   ```
+
+   If Breeze is behind a reverse proxy, also set `TRUST_PROXY_HEADERS=true` and list the proxy's CIDRs in `TRUSTED_PROXY_CIDRS`. See [Environment Variables](/deploy/environment/) for details.
+
 4. **Configure TURN server**
 
    The TURN server enables remote desktop connectivity across NATs and firewalls. Set the server's public IP address:
@@ -143,7 +157,7 @@ By default, images pull the `latest` tag. To pin to a specific release:
 
 ```bash
 # In .env
-BREEZE_VERSION=0.3.0
+BREEZE_VERSION=0.67.1
 ```
 
 Then pull and restart:
@@ -163,7 +177,7 @@ REDIS_MAXMEMORY=512mb
 
 ### Redis Authentication
 
-Redis requires password authentication in production. Generate a password and add it to `.env`:
+Redis password authentication is **required in production**. The API will refuse to start if `REDIS_URL` doesn't carry a password. The secret-generation loop above already produces `REDIS_PASSWORD`; pair it with a `REDIS_URL` that uses it:
 
 ```bash
 REDIS_PASSWORD=$(openssl rand -hex 32)

--- a/apps/docs/src/content/docs/features/dns-security.mdx
+++ b/apps/docs/src/content/docs/features/dns-security.mdx
@@ -7,7 +7,9 @@ import { Steps, Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
 DNS Security provides DNS-level threat prevention for your managed fleet by integrating with third-party DNS filtering providers and enforcing allowlist/blocklist policies. The system ingests DNS security events from connected providers, categorizes threats, logs blocked queries, and gives you aggregated statistics to understand threat exposure across your organization.
 
-Integrations connect Breeze to your existing DNS filtering infrastructure. Each integration is scoped to an organization and stores encrypted API credentials for the target provider. Once connected, Breeze periodically syncs DNS security events from the provider and stores them in the `dns_security_events` table, where they can be queried, filtered, and analyzed. Policies define domain-level allowlists and blocklists that are pushed back to the provider through a BullMQ sync pipeline.
+You manage DNS Security from the **DNS Security** page in the dashboard sidebar. The page has tabs for an overview, blocked-event feed, policy management, and provider integrations. The API endpoints below back the same workflows for scripts and automations.
+
+Integrations connect Breeze to your existing DNS filtering infrastructure. Each integration is scoped to an organization and stores encrypted API credentials for the target provider. Once connected, Breeze periodically syncs DNS security events from the provider and stores them in the `dns_security_events` table, where they can be queried, filtered, and analyzed. Policies define domain-level allowlists and blocklists that are pushed back to the provider through a sync pipeline.
 
 ---
 
@@ -64,8 +66,11 @@ Breeze supports the following DNS filter providers:
 | Cloudflare Gateway | `cloudflare` | `apiKey`, `config.accountId` |
 | DNSFilter | `dnsfilter` | `apiKey` |
 | Pi-hole | `pihole` | `apiKey`, `config.apiEndpoint` |
+| AdGuard Home | `adguard_home` | `apiKey`, `apiSecret`, `config.apiEndpoint` |
 | OpenDNS | `opendns` | `apiKey` |
 | Quad9 | `quad9` | `apiKey` |
+
+For AdGuard Home, `apiKey` is the admin username and `apiSecret` is the admin password (the provider uses HTTP Basic Auth). `config.apiEndpoint` is the base URL of your AdGuard Home instance (e.g., `https://adguard.example.com`).
 
 <Aside>
   Breeze also detects DNS filtering tools during management posture assessment. If Cisco Umbrella, DNSFilter, or Netskope agents are installed on a device, they appear in the device's posture report regardless of whether an API integration is configured.
@@ -104,7 +109,7 @@ Authorization: Bearer <token>
 | Field | Type | Description |
 |-------|------|-------------|
 | `orgId` | UUID | Organization ID. Auto-resolved for org-scoped tokens |
-| `provider` | string | DNS provider: `umbrella`, `cloudflare`, `dnsfilter`, `pihole`, `opendns`, `quad9` |
+| `provider` | string | DNS provider: `umbrella`, `cloudflare`, `dnsfilter`, `pihole`, `adguard_home`, `opendns`, `quad9` |
 | `name` | string | Human-readable name (max 200 chars) |
 | `description` | string | Optional description (max 2,000 chars) |
 | `apiKey` | string | Provider API key (required, max 5,000 chars) |
@@ -263,6 +268,14 @@ Each event in the response includes:
 | `sourceHostname` | string | Hostname of the querying device (from provider) |
 | `providerEventId` | string | Unique event ID from the DNS provider |
 | `metadata` | object | Additional provider-specific data |
+
+### Automatic Threat Alerts
+
+When a blocked event arrives with a known threat category (malware, phishing, botnet, ransomware, cryptomining), Breeze automatically raises a high-severity alert for the affected device. You don't need a rule for this — the alert fires from the DNS Security pipeline itself.
+
+To avoid alert storms when the same device hits the same threat category repeatedly, alerts are deduplicated per `(device, category)` for a 60-minute cooldown window. A second malware block on the same device within the window updates the existing alert's "last seen" timestamp rather than raising a new one.
+
+Threat events are also published on the internal event bus so other consumers (custom webhooks, future integrations) can subscribe to `dns.threat.blocked` without polling the events endpoint.
 
 ---
 

--- a/apps/docs/src/content/docs/features/notifications.mdx
+++ b/apps/docs/src/content/docs/features/notifications.mdx
@@ -409,7 +409,33 @@ All endpoints require authentication via `authMiddleware`.
 | DELETE | `/alerts/channels/:id` | Delete a notification channel |
 | POST | `/alerts/channels/:id/test` | Send a test notification through the channel |
 
-Channel endpoints require `organization`, `partner`, or `system` scope.
+Channel endpoints require `organization`, `partner`, or `system` scope. Create, update, delete, and test all require MFA verification.
+
+### Per-channel throttle
+
+Each channel can cap how many notifications it dispatches per device (or per rule, depending on the alert source) inside a sliding window. Use this when a noisy device might otherwise pager-bomb on-call.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `throttleMaxPerWindow` | integer or null | null | Maximum notifications per window. `null` or `0` means unlimited. |
+| `throttleWindowSeconds` | integer | `3600` | Length of the sliding window in seconds. |
+
+The throttle is applied at dispatch time. When the cap is reached, the dispatcher skips the send and records a "throttled" outcome on the delivery — throttled deliveries are not retried. If the throttle backend (Redis) is unavailable, the dispatcher fails open and delivers the notification rather than dropping it.
+
+Add these fields to any channel POST/PUT body:
+
+```bash
+curl -X POST /alerts/channels \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "On-Call SMS",
+    "type": "sms",
+    "config": { "phoneNumbers": ["+15551234567"], "from": "+15550001111" },
+    "throttleMaxPerWindow": 5,
+    "throttleWindowSeconds": 3600,
+    "enabled": true
+  }'
+```
 
 ### Creating a channel
 

--- a/apps/docs/src/content/docs/features/patch-management.mdx
+++ b/apps/docs/src/content/docs/features/patch-management.mdx
@@ -144,12 +144,15 @@ Scanning is asynchronous. The scan command is sent to the agent on each target d
 
 ## Reviewing and Approving Patches
 
+For all approval endpoints below, `orgId` is accepted either in the JSON body (as shown) or as the `?orgId=` query parameter. Organization-scoped tokens auto-resolve `orgId`. An optional `ringId` field (UUID) ties the approval to a specific deployment ring; if you don't pass it, approvals are not ring-scoped and the response returns `ringId: null`.
+
 ### Approving
 
 ```bash
 POST /patches/:id/approve
 {
   "orgId": "uuid",
+  "ringId": "ring-uuid",
   "note": "Reviewed — approved for production fleet"
 }
 ```

--- a/apps/docs/src/content/docs/features/remote-access.mdx
+++ b/apps/docs/src/content/docs/features/remote-access.mdx
@@ -181,8 +181,8 @@ Wake-on-LAN powers on an offline device from the Breeze dashboard without visiti
 **Requirements:**
 
 - The target device must have Wake-on-LAN enabled in its BIOS/UEFI (often labelled "Power on by LAN" or "Wake on Magic Packet").
-- The target must have checked in at least once so Breeze has its MAC address and last-known IPv4 subnet.
-- At least one other agent must be online at the same site and on the same subnet to relay the magic packet.
+- The target must have checked in at least once so Breeze has its MAC address(es) and one or more recorded non-APIPA IPv4 subnets. APIPA addresses (`169.254.0.0/16`) are skipped — they're a sign of a broken DHCP lease and don't represent the real LAN.
+- At least one other agent must be online at the same site and on a matching subnet to relay the magic packet. Breeze tries every plausible candidate subnet recorded for the target, in priority order, until one succeeds.
 
 **Sending a wake:**
 
@@ -221,7 +221,7 @@ By default, **Connect → Desktop** opens the built-in Breeze WebRTC desktop ses
 
 </Steps>
 
-Each device then needs that custom field populated with its identifier for the tool. When a user clicks **Connect → Desktop**, Breeze substitutes the values and either opens the URL in a new browser tab (`http`/`https`) or hands it to the operating system's protocol handler (any other scheme, e.g. `rustdesk://`). If a device is missing the required custom field, the launcher is unavailable for that device and the built-in WebRTC session remains the fallback.
+Each device then needs that custom field populated with its identifier for the tool. When a user clicks **Connect → Desktop**, Breeze substitutes the values and either opens the URL in a new browser tab (`http`/`https`) or hands it to the operating system's protocol handler (any other scheme, e.g. `rustdesk://`). If the launcher can't issue a URL — provider disabled, no provider configured, device is missing the required custom field, or the resolved URL fails the scheme check — the UI surfaces the specific reason instead of silently falling back to WebRTC, so you can fix the configuration rather than guess why a click did nothing.
 
 **Security:**
 

--- a/apps/docs/src/content/docs/features/scripts.mdx
+++ b/apps/docs/src/content/docs/features/scripts.mdx
@@ -146,6 +146,34 @@ Navigate to **Scripts** and click a script name to open the editor, then click *
 | `alert` | An alert-triggered automation runs the script as a remediation action |
 | `policy` | A configuration policy triggers the script as part of enforcement |
 
+### Severity by Exit Code
+
+When a script finishes, Breeze decides whether to raise an alert and at what severity based on the exit code. The mapping is configurable per script.
+
+The defaults are conservative: exit code `0` raises no alert at all, and any non-zero exit raises a `medium`-severity alert unless you override it. To customize, set the `exitCodeSeverityMapping` field on the script — a JSON object mapping exit-code strings to severity levels.
+
+| Exit code | Default behavior | Override via `exitCodeSeverityMapping` |
+|---|---|---|
+| `0` | No alert. | Always no alert (cannot be overridden). |
+| `1`, `2`, `3`, … | Single `medium`-severity alert. | Map any specific code to `low`, `medium`, `high`, or `critical`. |
+| Negative values | `critical` (abnormal termination, e.g., killed by signal). | Always `critical` (cannot be overridden). |
+| Unmapped non-zero | Falls back to the next-lower defined entry, else `medium`. | — |
+
+Example mapping:
+
+```json
+{
+  "exitCodeSeverityMapping": {
+    "1": "low",
+    "2": "medium",
+    "3": "high",
+    "4": "critical"
+  }
+}
+```
+
+An empty mapping `{}` is treated the same as omitting the field (default behavior). Pass the field on both POST `/scripts` and PUT `/scripts/:id`.
+
 ---
 
 ## Creating Scripts via API
@@ -173,11 +201,12 @@ Authorization: Bearer <token>
     }
   },
   "timeoutSeconds": 120,
-  "runAs": "system"
+  "runAs": "system",
+  "exitCodeSeverityMapping": { "1": "low", "2": "medium", "3": "high" }
 }
 ```
 
-The response includes the full script object with an auto-generated `id` and `version: 1`.
+The response includes the full script object with an auto-generated `id` and `version: 1`. The `exitCodeSeverityMapping` field is optional — see [Severity by Exit Code](#severity-by-exit-code) above.
 
 ---
 

--- a/apps/docs/src/content/docs/features/snmp.mdx
+++ b/apps/docs/src/content/docs/features/snmp.mdx
@@ -43,8 +43,15 @@ Templates are named collections of OIDs that define what to poll on a device. Th
 
 | Type | Description |
 |------|-------------|
-| **Builtin** | Ship with the platform. Cannot be modified or deleted. Cover common device types. |
+| **Builtin** | Ship with the platform. Cannot be modified or deleted. Cover common device types and major vendors. |
 | **Custom** | Created by users. Fully editable. Scoped globally (not per-org). |
+
+Built-in templates now cover a broad range of common network gear so you can monitor most devices without writing your own template. Browse the full list with `GET /snmp/templates?source=builtin`. The library includes:
+
+- Generic baselines (Common, Router, Switch, Printer per RFC 1213 and RFC 3805)
+- Cisco IOS switches
+- Ubiquiti UniFi switches, access points, and security gateways
+- Additional multi-vendor templates added with each release
 
 Each OID entry in a template includes:
 

--- a/apps/docs/src/content/docs/features/watchdog.mdx
+++ b/apps/docs/src/content/docs/features/watchdog.mdx
@@ -103,6 +103,16 @@ Failover keeps the device manageable even when the agent process is completely d
 
 ---
 
+## Agent-Silent Detection
+
+The watchdog reports its own health to the server through its own connection. That means the watchdog can be perfectly healthy while the main agent has gone quiet — a "silent agent" condition that earlier versions of Breeze couldn't distinguish from a fully-offline device.
+
+The server now watches for this asymmetry on every device. When the main agent stops checking in but the watchdog stays online, the device row shows an amber **Agent silent (watchdog OK)** badge in the dashboard. The badge tells you the device is still reachable through the watchdog and a remote **Restart Agent** action will work — versus a fully-offline device where neither component is responding.
+
+The agent also supervises itself. If its main loop stops making forward progress for an extended period, the agent self-restarts before the watchdog needs to step in, keeping recovery fast for the common transient-stuck case.
+
+---
+
 ## Health Journal
 
 The watchdog maintains a local rotating log file called the **health journal**. Each entry records a timestamped event (state transition, health check result, recovery action, IPC message) in structured JSON format.

--- a/apps/docs/src/content/docs/reference/api.mdx
+++ b/apps/docs/src/content/docs/reference/api.mdx
@@ -55,10 +55,15 @@ curl -X POST https://breeze.yourdomain.com/api/v1/auth/refresh \
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/devices` | List devices (paginated, filterable) |
+| `GET` | `/devices` | List devices (paginated, filterable; supports keyset cursor) |
 | `GET` | `/devices/:id` | Get device details |
-| `POST` | `/devices/:id/commands` | Send command to device |
+| `POST` | `/devices/provision` | Pre-create a device row before any agent has enrolled. Returns a single-use enrollment payload. |
+| `POST` | `/devices/:id/move-org` | Relocate a device to a different organization within the same partner. |
+| `POST` | `/devices/:id/commands` | Send command to device. Rejects a duplicate `refresh_inventory` with `409 ALREADY_PENDING`. |
+| `POST` | `/devices/bulk/commands` | Send the same command to many devices. Returns `commands`, `skipped`, and `failed` arrays. |
 | `DELETE` | `/devices/:id` | Decommission device |
+
+`GET /devices` supports a cursor-based paging mode in addition to the legacy `page`/`limit` shape. Pass `cursor`, `sort` (`hostname` / `lastSeen` / `enrolled`), `sortDir`, `limit` (max 1000), and optional filters like `orgIds`, `siteIds`, `groupIds`, `includeDecommissioned`, and `includeTotal`. The response carries `{ devices, nextCursor, limit, total? }`; pass `nextCursor` back as `cursor` to fetch the next page. The list payload also exposes `mainAgentSilentSince` and `watchdogStatus` per device so callers can render the **Agent silent (watchdog OK)** badge described in [Agent Watchdog](/features/watchdog/).
 
 ## Partners & Organizations
 

--- a/apps/docs/src/content/docs/reference/audit-logs.mdx
+++ b/apps/docs/src/content/docs/reference/audit-logs.mdx
@@ -45,7 +45,8 @@ Each audit log entry contains the following fields:
 | `userAgent` | Text | Client user-agent string |
 | `result` | Enum | Outcome of the action: `success`, `failure`, or `denied` |
 | `errorMessage` | Text | Error details when the result is `failure` or `denied` |
-| `checksum` | String (128) | Integrity checksum for tamper detection |
+| `checksum` | String (128) | SHA-256 of this row's canonical payload |
+| `prevChecksum` | String (128) | Checksum of the previous audit row in this organization's hash chain |
 
 ### Actor Types
 
@@ -86,6 +87,15 @@ The following actions are flagged as security events and appear in the security 
 - `policy.create`
 - `policy.evaluate`
 - `automation.policy.evaluate`
+- `agent.source.ip.changed` — emitted when an agent's source IP changes between heartbeats; can indicate NAT changes, mobility, or stolen tokens.
+
+### Tamper Evidence
+
+Audit log rows are append-only at the database layer. Postgres triggers refuse `UPDATE`, `DELETE`, and `TRUNCATE` against the table — even a superuser cannot rewrite history without explicit administrative privileges.
+
+In addition to row-level immutability, each row carries `prevChecksum` linking to the previous audit row in the same organization. Together with `checksum`, this produces a per-org SHA-256 hash chain. Verifying the chain end-to-end detects insertion, deletion, or alteration of any row between two timestamps.
+
+Retention pruning is the one supported path that removes audit rows. It requires both the `breeze_audit_admin` Postgres role and the `breeze.allow_audit_retention='1'` session GUC, and re-anchors the chain on the surviving rows so the integrity check continues to pass after old data ages out. The platform's audit retention worker handles this — operators do not prune by hand.
 
 ### Compliance Actions
 
@@ -120,8 +130,11 @@ The audit log list endpoints support the following query parameters for filterin
 | `resource` | String | Filter by resource type or resource name (ILIKE match) |
 | `from` | ISO 8601 datetime | Start of date range |
 | `to` | ISO 8601 datetime | End of date range |
+| `skipCount` | Boolean | When `true`, the list endpoint skips the `count(*)` over the filtered set and returns only the page itself. Use it on high-frequency dashboard widgets where the total isn't displayed. |
 
 The search endpoint (`GET /search`) adds a `q` parameter that performs a full-text ILIKE search across action, actor email, resource type, resource name, and the JSON-cast details field. Search conditions are combined with any active filters using AND logic.
+
+The dashboard's audit-log viewer humanizes raw action codes (e.g. `device.create` renders as "Created device") and, for `actorType=agent` rows, qualifies the actor column with the device hostname instead of showing only the agent identifier.
 
 ### Retention Policies
 

--- a/apps/docs/src/content/docs/reference/schema.mdx
+++ b/apps/docs/src/content/docs/reference/schema.mdx
@@ -22,16 +22,25 @@ The central table for managed endpoints:
 | `orgId` | UUID | FK → organizations |
 | `siteId` | UUID | FK → sites |
 | `agentId` | varchar(64) | Unique agent identifier |
-| `agentTokenHash` | varchar(64) | SHA-256 hash of the agent bearer token (nullable for pre-migration devices) |
+| `agentTokenHash` | varchar(64) | SHA-256 hash of the main agent bearer token (nullable for pre-migration devices) |
+| `watchdogTokenHash` | varchar(64) | SHA-256 hash of the companion watchdog token |
+| `helperTokenHash` | varchar(64) | SHA-256 hash of the user-helper token |
+| `agentTokenSuspendedAt` | timestamp | Set when the agent token is auto-suspended (e.g. cross-tenant access attempt). Re-enrollment is blocked until cleared. |
+| `agentTokenSuspendedReason` | varchar(255) | Reason recorded alongside `agentTokenSuspendedAt`. |
 | `hostname` | varchar(255) | Device hostname |
-| `displayName` | varchar(255) | Optional display name |
+| `displayName` | varchar(255) | Optional display name (editable inline from the device detail page) |
 | `osType` | enum | `windows`, `macos`, `linux` |
 | `osVersion` | varchar(100) | OS version string |
 | `osBuild` | varchar(100) | OS build identifier (optional) |
 | `architecture` | varchar(20) | CPU architecture (e.g. `amd64`, `arm64`) |
 | `agentVersion` | varchar(20) | Installed agent version |
-| `status` | enum | `online`, `offline`, `maintenance`, `decommissioned`, `quarantined` |
+| `status` | enum | `online`, `offline`, `maintenance`, `updating`, `pending`, `decommissioned`, `quarantined` |
 | `lastSeenAt` | timestamp | Last telemetry received |
+| `lastSeenIp` | inet | Source IP recorded on the most recent heartbeat; changes raise an `agent.source.ip.changed` audit event. |
+| `mainAgentSilentSince` | timestamp | Set by the server when the main agent stops heartbeating but the watchdog is still online. Cleared when the agent resumes. |
+| `watchdogStatus` | enum | `connected`, `failover`, `offline` — last reported watchdog state. |
+| `watchdogLastSeenAt` | timestamp | Last watchdog check-in. |
+| `watchdogVersion` | varchar(20) | Installed watchdog binary version. |
 | `enrolledAt` | timestamp | When the device was enrolled |
 | `enrolledBy` | UUID | FK → users (who initiated enrollment) |
 | `tags` | text[] | Array of string tags |
@@ -59,6 +68,9 @@ The central table for managed endpoints:
 | `deviceGroups` | Static and dynamic device groups with filter rules |
 | `deviceGroupMemberships` | Many-to-many device ↔ group mapping |
 | `deviceCommands` | Command queue (pending, completed, failed) |
+| `elevationRequests` | Privileged-action mode (PAM) elevation requests awaiting approval |
+| `elevationAudit` | Immutable audit trail of elevation approve/deny/expire decisions |
+| `refreshTokenFamilies` | Refresh-token lineage for reuse-detection (RFC 9700 §4.13.2) |
 
 ### Organizations
 

--- a/apps/docs/src/content/docs/reference/users-and-roles.mdx
+++ b/apps/docs/src/content/docs/reference/users-and-roles.mdx
@@ -274,6 +274,8 @@ Every user-to-scope association includes a `roleId`. The role determines what th
 
 Roles can be **system** (built-in, immutable) or **custom** (created by administrators).
 
+Roles also carry a **Force MFA** flag. When the flag is on, any user assigned to that role gets a `428 Precondition Required` response on protected endpoints until they enroll a TOTP authenticator. The dashboard intercepts the 428 and walks the user through a forced enrollment screen before letting them reach any other workflow. Partner Admin is seeded with Force MFA on. Switch it on for any role whose privilege level warrants mandatory MFA — admin-equivalent roles, billing operators, and similar.
+
 ### Permission Model
 
 Permissions are stored as `resource:action` pairs in the `permissions` table. Roles are linked to permissions through the `role_permissions` join table.
@@ -287,11 +289,15 @@ Permissions are stored as `resource:action` pairs in the `permissions` table. Ro
 | `alerts` | Alert rules and acknowledgement |
 | `automations` | Automation workflows |
 | `reports` | Reporting and analytics |
+| `backup` | Backup jobs, vaults, and restore operations |
+| `billing` | Subscriptions, invoicing, and payment methods |
 | `users` | User and role management |
 | `settings` | Organisation and system settings |
 | `organizations` | Organisation CRUD |
 | `sites` | Site management |
 | `remote` | Remote access sessions |
+
+The authoritative list of assignable permissions is also available at runtime via `GET /permissions/catalog`. The dashboard's role builder consumes this endpoint so the matrix of resources and actions stays in sync with the server whenever new permissions are added.
 
 **Available actions:**
 

--- a/apps/docs/src/content/docs/security/hardening.mdx
+++ b/apps/docs/src/content/docs/security/hardening.mdx
@@ -48,10 +48,12 @@ Before going live, verify every item:
 ### Authentication
 
 - [ ] MFA (TOTP) enabled for all admin accounts
+- [ ] Roles that should require MFA have **Force MFA** turned on. Users in a force-MFA role get a `428 Precondition Required` response until they enroll a TOTP device; the dashboard then redirects them through a forced-enrollment page before any other workflow becomes available.
 - [ ] Registration disabled in production (`ENABLE_REGISTRATION=false`) after initial setup
 - [ ] Rate limiting active on login endpoints
 - [ ] Session timeout configured (`SESSION_MAX_AGE`)
 - [ ] Session revocation is fail-closed — revoked sessions stay revoked even if Redis is unavailable
+- [ ] Refresh tokens use family-based reuse detection — replaying a previously rotated refresh token immediately revokes every other token in that family, log out included.
 
 ### Agent Security
 
@@ -60,7 +62,14 @@ Before going live, verify every item:
 - [ ] Config file permissions: `0750` for `/etc/breeze/`, `0640` for `agent.yaml`, `0600` for `secrets.yaml`
 - [ ] Agent rate limiting enabled (120 req/60s per agent via Redis)
 - [ ] Enrollment keys set with expiry and usage limits
+- [ ] Cross-tenant probe detection enabled — if an agent token is used to access a device in another tenant, the token is automatically suspended and re-enrollment is blocked until an admin reviews the device.
+- [ ] Source-IP tracking active — every heartbeat records the agent's source IP, and an `agent.source.ip.changed` audit event fires when it shifts, surfacing token theft or NAT changes.
 - [ ] Consider enabling [Cloudflare mTLS](/security/mtls/) for zero-trust agent auth
+
+### Outbound Request Safety (SSRF)
+
+- [ ] Outbound integrations (webhooks, DNS providers, SSO discovery) flow through the platform's SSRF guard, which blocks private/loopback ranges and cloud metadata hostnames unless an explicit allowlist entry permits them.
+- [ ] `partners.settings` and `sites.settings` columns are AES-256-GCM encrypted at rest — secrets stored here (provider credentials, integration tokens) never leave the database in plaintext.
 
 ### Monitoring
 
@@ -98,6 +107,14 @@ All mutating operations are automatically logged with:
 | `details` | JSON payload of changes |
 | `ipAddress` | Client IP address |
 | `timestamp` | ISO 8601 timestamp |
+| `checksum` | SHA-256 of the canonical row payload |
+| `prev_checksum` | Checksum of the previous row in this organization's chain |
+
+### Tamper evidence
+
+The `audit_log` table is **append-only at the database level**. Database triggers refuse `UPDATE`, `DELETE`, and `TRUNCATE` operations against audit rows — not even a superuser can quietly edit history. Each row also carries a `prev_checksum` that links to the previous audit row in the same organization, producing a per-org SHA-256 hash chain. Verifying the chain end-to-end detects any insertion, deletion, or alteration between two timestamps.
+
+Retention pruning is the one legitimate path that removes audit rows. It requires both the `breeze_audit_admin` Postgres role and the `breeze.allow_audit_retention='1'` session GUC; pruning re-anchors the chain on the surviving rows so the integrity check still passes after old data ages out. Both controls are managed by the platform's audit retention worker — operators do not run pruning by hand.
 
 Query audit logs via the API:
 

--- a/apps/docs/src/content/docs/security/overview.mdx
+++ b/apps/docs/src/content/docs/security/overview.mdx
@@ -295,7 +295,7 @@ The AI system has access to powerful tools. Every AI-initiated action passes thr
 
 | Control | Implementation |
 |---------|----------------|
-| **Base image** | `node:20-alpine` (minimal attack surface) |
+| **Base image** | `node:24-alpine` (current LTS, minimal attack surface) |
 | **Multi-stage build** | `deps → builder → runner` (no build tools in production) |
 | **Non-root execution** | Dedicated `hono` user (UID 1001), `nodejs` group (GID 1001) |
 | **File ownership** | `--chown=hono:nodejs` on all copied assets |
@@ -345,6 +345,9 @@ All scanners run in CI and **block merges** on failure.
 | `APP_ENCRYPTION_KEY` | AES-256-GCM encryption | 32-byte hex |
 | `MFA_ENCRYPTION_KEY` | MFA secret encryption | 32-byte hex |
 | `AGENT_ENROLLMENT_SECRET` | Agent enrollment | 32-byte hex |
+| `REDIS_PASSWORD` | Redis authentication (must appear in `REDIS_URL`) | 32-byte hex |
+| `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` | Verifies signed release manifests in GitHub-mode binary distribution | Base64 SPKI |
+| `IS_HOSTED` | Deployment mode flag (`true`/`false`); gates signup, billing, and email-verification policy | Explicit boolean |
 
 ### Production Enforcement
 

--- a/apps/docs/src/content/docs/security/secrets.mdx
+++ b/apps/docs/src/content/docs/security/secrets.mdx
@@ -43,7 +43,7 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 
 3. Restart the API:
    ```bash
-   docker compose -f docker/docker-compose.prod.yml restart api
+   docker compose -f deploy/docker-compose.prod.yml restart api
    ```
 
 4. All existing JWTs become invalid — users will need to log in again
@@ -82,7 +82,7 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 
 6. Restart the API:
    ```bash
-   docker compose -f docker/docker-compose.prod.yml restart api
+   docker compose -f deploy/docker-compose.prod.yml restart api
    ```
 
 </Steps>
@@ -106,7 +106,7 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 
 4. Restart the API:
    ```bash
-   docker compose -f docker/docker-compose.prod.yml restart api
+   docker compose -f deploy/docker-compose.prod.yml restart api
    ```
 
 </Steps>
@@ -128,7 +128,7 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 
 3. Restart the API:
    ```bash
-   docker compose -f docker/docker-compose.prod.yml restart api
+   docker compose -f deploy/docker-compose.prod.yml restart api
    ```
 
 4. Regenerate enrollment keys and redistribute to anyone deploying new agents
@@ -152,7 +152,7 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 
 3. Restart the API:
    ```bash
-   docker compose -f docker/docker-compose.prod.yml restart api
+   docker compose -f deploy/docker-compose.prod.yml restart api
    ```
 
 4. Notify users to regenerate their MFA recovery codes via Settings, or trigger a bulk regeneration as an admin
@@ -193,7 +193,7 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 
 3. Restart the API:
    ```bash
-   docker compose -f docker/docker-compose.prod.yml restart api
+   docker compose -f deploy/docker-compose.prod.yml restart api
    ```
 
 4. All active sessions are invalidated — users must log in again
@@ -211,7 +211,7 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 
 2. Update the password in PostgreSQL:
    ```bash
-   docker compose -f docker/docker-compose.prod.yml exec postgres \
+   docker compose -f deploy/docker-compose.prod.yml exec postgres \
      psql -U breeze -c "ALTER USER breeze PASSWORD 'new-password';"
    ```
 
@@ -219,7 +219,7 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 
 4. Restart the API:
    ```bash
-   docker compose -f docker/docker-compose.prod.yml restart api
+   docker compose -f deploy/docker-compose.prod.yml restart api
    ```
 
 </Steps>
@@ -245,7 +245,7 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 
 3. Restart the API and worker processes:
    ```bash
-   docker compose -f docker/docker-compose.prod.yml restart api worker
+   docker compose -f deploy/docker-compose.prod.yml restart api worker
    ```
 
 </Steps>
@@ -264,7 +264,7 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 
 3. Restart the API:
    ```bash
-   docker compose -f docker/docker-compose.prod.yml restart api
+   docker compose -f deploy/docker-compose.prod.yml restart api
    ```
 
 4. Verify by uploading and downloading a test file
@@ -293,7 +293,7 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 
 4. Restart the API:
    ```bash
-   docker compose -f docker/docker-compose.prod.yml restart api
+   docker compose -f deploy/docker-compose.prod.yml restart api
    ```
 
 5. Verify by triggering a certificate enrollment or renewal
@@ -319,7 +319,7 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 
 3. Restart the TURN server and the API:
    ```bash
-   docker compose -f docker/docker-compose.prod.yml restart api turn
+   docker compose -f deploy/docker-compose.prod.yml restart api turn
    ```
 
 </Steps>
@@ -347,7 +347,7 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 
 4. Restart API and Prometheus:
    ```bash
-   docker compose -f docker/docker-compose.prod.yml restart api prometheus
+   docker compose -f deploy/docker-compose.prod.yml restart api prometheus
    ```
 
 </Steps>
@@ -368,7 +368,7 @@ Covers `RESEND_API_KEY`, `SMTP_USER` / `SMTP_PASS`, and `MAILGUN_API_KEY`.
 
 3. Restart the API:
    ```bash
-   docker compose -f docker/docker-compose.prod.yml restart api
+   docker compose -f deploy/docker-compose.prod.yml restart api
    ```
 
 4. Verify by triggering a test notification (e.g., password reset email)
@@ -391,7 +391,7 @@ Covers `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN`.
 
 3. Restart the API:
    ```bash
-   docker compose -f docker/docker-compose.prod.yml restart api
+   docker compose -f deploy/docker-compose.prod.yml restart api
    ```
 
 4. Verify by triggering a test SMS alert
@@ -414,7 +414,7 @@ Covers `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN`.
 
 3. Restart the API:
    ```bash
-   docker compose -f docker/docker-compose.prod.yml restart api
+   docker compose -f deploy/docker-compose.prod.yml restart api
    ```
 
 4. Revoke the old key in the Anthropic console

--- a/scripts/docs-review/last-reviewed.json
+++ b/scripts/docs-review/last-reviewed.json
@@ -1,0 +1,5 @@
+{
+  "lastReviewedRef": "623514b6",
+  "reviewedAt": "2026-05-27",
+  "notes": "Bumped after v0.66.0..HEAD sweep on 2026-05-26. The /update-breeze-docs skill writes this back after each sweep; read with `jq -r .lastReviewedRef scripts/docs-review/last-reviewed.json` and use it as the lower bound for `git log $REF..HEAD` when running a docs sweep."
+}

--- a/scripts/docs-review/mapping.json
+++ b/scripts/docs-review/mapping.json
@@ -527,6 +527,224 @@
         "agents/commands.mdx",
         "reference/api.mdx"
       ]
+    },
+    {
+      "pattern": "apps/api/src/routes/devices/moveOrg.ts",
+      "docs": [
+        "reference/api.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/routes/devices/provision.ts",
+      "docs": [
+        "reference/api.mdx",
+        "agents/installation.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/routes/devices/cursor.ts",
+      "docs": [
+        "reference/api.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/routes/devices/core.ts",
+      "docs": [
+        "reference/api.mdx",
+        "features/watchdog.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/routes/devices/watchdogLogs.ts",
+      "docs": [
+        "features/watchdog.mdx",
+        "reference/api.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/routes/dnsSecurity.ts",
+      "docs": [
+        "features/dns-security.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/jobs/dnsSyncJob.ts",
+      "docs": [
+        "features/dns-security.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/services/dnsThreatAlerts.ts",
+      "docs": [
+        "features/dns-security.mdx",
+        "features/alerts.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/services/dnsProviders/**",
+      "docs": [
+        "features/dns-security.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/web/src/components/dnsSecurity/**",
+      "docs": [
+        "features/dns-security.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/web/src/pages/dns-security.astro",
+      "docs": [
+        "features/dns-security.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/services/notificationThrottle.ts",
+      "docs": [
+        "features/notifications.mdx",
+        "features/alerts.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/services/notificationDispatcher.ts",
+      "docs": [
+        "features/notifications.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/services/scriptSeverity.ts",
+      "docs": [
+        "features/scripts.mdx",
+        "features/alerts.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/services/ssrfGuard.ts",
+      "docs": [
+        "security/hardening.mdx",
+        "security/overview.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/services/logRedaction.ts",
+      "docs": [
+        "security/error-tracking.mdx",
+        "reference/audit-logs.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/services/auditService.ts",
+      "docs": [
+        "reference/audit-logs.mdx",
+        "security/hardening.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/routes/auditLogs.ts",
+      "docs": [
+        "reference/audit-logs.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/web/src/lib/auditFormat.ts",
+      "docs": [
+        "reference/audit-logs.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/web/src/components/audit/**",
+      "docs": [
+        "reference/audit-logs.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/web/src/components/auth/ForcedMfaSetupPage.tsx",
+      "docs": [
+        "reference/users-and-roles.mdx",
+        "security/hardening.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/config/validate.ts",
+      "docs": [
+        "deploy/environment.mdx",
+        "deploy/production.mdx",
+        "security/hardening.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/services/redis.ts",
+      "docs": [
+        "deploy/environment.mdx",
+        "deploy/production.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/middleware/auth.ts",
+      "docs": [
+        "reference/users-and-roles.mdx",
+        "security/hardening.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/middleware/bearerTokenAuth.ts",
+      "docs": [
+        "features/mcp-server.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/routes/permissionsCatalog.ts",
+      "docs": [
+        "reference/users-and-roles.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/services/releaseArtifactManifest.ts",
+      "docs": [
+        "deploy/binaries.mdx",
+        "deploy/upgrades.mdx",
+        "security/hardening.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/oauth/provider.ts",
+      "docs": [
+        "features/mcp-server.mdx",
+        "reference/users-and-roles.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/routes/snmp*.ts",
+      "docs": [
+        "features/snmp.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/migrations/**",
+      "docs": [
+        "reference/schema.mdx"
+      ]
+    },
+    {
+      "pattern": "docker/Dockerfile.*",
+      "docs": [
+        "deploy/production.mdx",
+        "security/overview.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/Dockerfile",
+      "docs": [
+        "deploy/production.mdx",
+        "security/overview.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/web/Dockerfile",
+      "docs": [
+        "deploy/production.mdx",
+        "security/overview.mdx"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Audience-filtered sweep of `apps/docs/` (the Astro docs site) against code shipped between v0.66.0 and HEAD. 23 files, +458/-45. Pure docs + tooling scope, no behavior change.

**Deploy:** new prod-required env vars (`RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS`, `IS_HOSTED`, authenticated Redis), Node 24 LTS base bump, `security/secrets.mdx` compose paths corrected to `deploy/`.

**Features:** AdGuard Home DNS provider, DNS threat auto-alerts + UI, per-channel notification throttle, script exit-code severity mapping, `refresh_inventory` + 409 dedup, expanded SNMP templates, WoL multi-subnet + APIPA skip, launcher skip-reason surfaced, watchdog "Agent silent" badge + self-restart.

**Security:** role `force_mfa` + 428 forced-enrollment flow, audit-log append-only triggers + per-org checksum chain + retention role, agent-token auto-suspend + source-IP audit, refresh-token family reuse detection, SSRF allowlist, encrypted partner/site settings.

**Agents:** decommissioned-row re-enrollment with fresh device id, suspended-token 409 path, admin `POST /devices/provision` with pending status, enrollment-keys strict-validation.

**Reference:** `api.mdx` adds move-org, provision, cursor pagination, `mainAgentSilentSince`/`watchdogStatus` on list. `schema.mdx` adds new device columns, status enum entries (`updating`, `pending`), and `elevation_requests` / `elevation_audit` / `refresh_token_families`. `audit-logs.mdx` adds `prev_checksum` + tamper-evidence + `skipCount` + `agent.source.ip.changed`. `users-and-roles.mdx` adds Force MFA and `GET /permissions/catalog` plus backup/billing/reports resources.

**Tooling:** new `scripts/docs-review/last-reviewed.json` so future "since last release" sweeps know the window. Expanded `mapping.json` (~30 entries) covering the previously-unmapped DNS UI, notification services, audit pipeline, validator, Dockerfiles, and migrations glob.

## Test plan

- [x] `apps/docs/` builds locally
- [x] No `apps/api/` or `apps/web/` source touched — verified with `git diff --stat origin/main..HEAD`
- [x] Rebased onto current main (was parked since round 7's #957 merge)