### PR TITLE
fix(ci): bump doc-verify + docs-review workflows to Node 22

### DIFF
--- a/.github/workflows/doc-verify.yml
+++ b/.github/workflows/doc-verify.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: "22"
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/docs-review.yml
+++ b/.github/workflows/docs-review.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Get PR diff
         run: gh pr diff "$PR_NUMBER" > /tmp/pr.diff


### PR DESCRIPTION
## Summary

Two workflows still pin Node 20 even though `apps/api/package.json` requires `>=22.19.0` — same engine constraint that broke Cloudflare Pages in #952.

- [.github/workflows/doc-verify.yml:28](https://github.com/LanternOps/breeze/blob/main/.github/workflows/doc-verify.yml#L28)
- [.github/workflows/docs-review.yml:22](https://github.com/LanternOps/breeze/blob/main/.github/workflows/docs-review.yml#L22)

**Caught while reviewing #963's red `doc-verify` status.** The job fails with `ERR_PNPM_UNSUPPORTED_ENGINE` during `pnpm install` before any actual verify work runs:

```
Your Node version is incompatible with "/home/runner/work/breeze/breeze".
Expected version: >=22.19.0
Got: v20.20.2
```

So the doc-verify gate has been effectively dead on docs PRs since the engines.node bump landed. Once this merges, #963 (and any future docs PR) will get real doc-verify coverage.

## Diff

Two-line change, version literal only — `node-version: 20` → `node-version: "22"` in each workflow. Other CI workflows already use Node 22 via `env.NODE_VERSION` (release.yml, security.yml) or literal `"22"` (ci-smoke-binary-source-*). These were the last stragglers.

## Test plan

- [x] `git grep 'node-version' .github/workflows/` — no remaining Node 20 references
- [ ] CI runs on this PR — doc-verify should now pass `pnpm install` and reach the actual verify steps