### PR TITLE
fix(api): suppress JWT log noise when bearer isn't a JWT

### DIFF
--- a/apps/api/src/services/jwt.test.ts
+++ b/apps/api/src/services/jwt.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SignJWT } from 'jose';
 import {
   createAccessToken,
@@ -90,6 +90,34 @@ describe('jwt service', () => {
 
       const decoded = await verifyToken(hs384Token);
       expect(decoded).toBeNull();
+    });
+
+    // Non-JWT bearer tokens (API keys, agent tokens, enrollment tokens) routinely
+    // hit verifyToken when a route accepts multiple credential formats. Logging
+    // "Token verification failed" for those is misleading — stderr aggregators
+    // surface it as a warning right next to a successful 200 from the fallback.
+    it('does not log when the input is structurally not a JWT', async () => {
+      const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+      try {
+        expect(await verifyToken('brz_some_api_key_not_a_jwt')).toBeNull();
+        expect(await verifyToken('not-a-jwt-at-all')).toBeNull();
+        expect(await verifyToken('')).toBeNull();
+        expect(debugSpy).not.toHaveBeenCalled();
+      } finally {
+        debugSpy.mockRestore();
+      }
+    });
+
+    it('still logs when a real JWT fails verification (tampered signature)', async () => {
+      const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+      try {
+        const token = await createAccessToken(testPayload);
+        const tamperedToken = token.slice(0, -5) + 'xxxxx';
+        expect(await verifyToken(tamperedToken)).toBeNull();
+        expect(debugSpy).toHaveBeenCalled();
+      } finally {
+        debugSpy.mockRestore();
+      }
     });
   });
 

--- a/apps/api/src/services/jwt.ts
+++ b/apps/api/src/services/jwt.ts
@@ -1,4 +1,4 @@
-import { SignJWT, jwtVerify, type JWTHeaderParameters } from 'jose';
+import { SignJWT, jwtVerify, errors as joseErrors, type JWTHeaderParameters } from 'jose';
 import { randomUUID } from 'crypto';
 
 const e2eMode = process.env.E2E_MODE === '1' || process.env.E2E_MODE === 'true';
@@ -262,6 +262,14 @@ export async function verifyToken(token: string): Promise<TokenPayload | null> {
       jti: typeof payload.jti === 'string' ? payload.jti : undefined
     };
   } catch (error) {
+    // Routes that accept multiple bearer formats (JWT, API key, agent token,
+    // enrollment token, …) call verifyToken first. A non-JWT input lands here
+    // as JWSInvalid / JWTInvalid — expected, not a failure. Logging it sends
+    // misleading "Token verification failed" noise to stderr right next to a
+    // 200 from the fallback auth path.
+    if (error instanceof joseErrors.JWSInvalid || error instanceof joseErrors.JWTInvalid) {
+      return null;
+    }
     console.debug('[jwt] Token verification failed:', error instanceof Error ? error.message : error);
     return null;
   }


### PR DESCRIPTION
## Summary

Reported by Todd (v0.67.1 self-hosted): `[jwt] Token verification failed: Invalid Compact JWS` shows up in API logs as warning-level noise immediately followed by a successful 200 from a different auth path. Reads like a hard failure when it isn't.

**Root cause:** Several routes accept multiple bearer formats (JWT, API key, agent token, enrollment token, viewer token, …) and call `verifyToken` first, falling through on null. Non-JWT inputs raise `jose`'s `JWSInvalid` / `JWTInvalid` errors — structurally not a JWT, not an auth failure. We were logging those at `console.debug`, which Node sends to stderr, which most aggregators classify as a warning.

**Fix:** Swallow only the structural-failure errors. Genuine signature / expiry / claim-validation failures still log at debug for diagnostics. 4-line change in [apps/api/src/services/jwt.ts](apps/api/src/services/jwt.ts).

## Test plan

- [x] New unit tests in [jwt.test.ts](apps/api/src/services/jwt.test.ts):
  - `does not log when the input is structurally not a JWT` — covers `brz_*` API key shape, plain garbage, empty string
  - `still logs when a real JWT fails verification (tampered signature)` — guards against over-suppression
- [x] Full `jwt.test.ts` suite: 19/19 green
- [x] Type-check clean on touched files
- [ ] On droplets after merge: tail API logs and confirm the `Invalid Compact JWS` line is gone while real verification failures still surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)