### PR TITLE
cleanup(web): drop dead microtask yield in OrgSwitcher refresh-race guard

### DIFF
--- a/apps/web/src/components/layout/OrgSwitcher.tsx
+++ b/apps/web/src/components/layout/OrgSwitcher.tsx
@@ -254,12 +254,10 @@ export default function OrgSwitcher() {
                   onSelect={async () => {
                     if (org.id !== currentOrgId) {
                       setOrganization(org.id);
-                      // Yield a microtask so setOrganization's downstream
-                      // fetchSites/etc has a chance to register itself with
-                      // tokenRefreshInFlight before we check. Then wait for
-                      // any pending refresh to settle so the post-reload
-                      // page doesn't race the same cookie jti. See #950.
-                      await Promise.resolve();
+                      // Wait for any refresh that was already in flight at
+                      // click time (e.g. AdminSessionManager's 5-min
+                      // heartbeat) to settle so the post-reload page
+                      // doesn't reuse the same cookie jti. See #950.
                       await waitForPendingRefresh();
                       const redirect = getOrgSwitchRedirect(window.location.pathname);
                       if (redirect) {
@@ -278,7 +276,6 @@ export default function OrgSwitcher() {
                     if (changed) {
                       // Same refresh-race avoidance as the org-switch path
                       // above — see #950.
-                      await Promise.resolve();
                       await waitForPendingRefresh();
                       window.location.reload();
                     }


### PR DESCRIPTION
## Summary
- Removes `await Promise.resolve()` from both handlers in `OrgSwitcher.tsx` — the microtask yield can't enable the registration the comment claimed (a 401 refresh requires a network round-trip, not a microtask).
- Rewrites the comment to describe the actual race the guard catches: refreshes that were already in flight at click time (e.g. AdminSessionManager's 5-min heartbeat).
- No behavior change — existing `OrgSwitcher.test.tsx` (7 tests) pass unchanged.

Closes #956.

## Test plan
- [x] `pnpm vitest run src/components/layout/OrgSwitcher.test.tsx` → 7/7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)