### PR TITLE
fix(ci): set BREEZE_ALLOW_UNAUTH_REDIS=true in smoke-binary-source workflows

### DIFF
--- a/.github/workflows/ci-smoke-binary-source-github.yml
+++ b/.github/workflows/ci-smoke-binary-source-github.yml
@@ -93,6 +93,13 @@ jobs:
           BREEZE_APP_DB_PASSWORD: breeze
           POSTGRES_PASSWORD: breeze
           REDIS_URL: redis://localhost:6379
+          # The CI Redis service has no password; #909 made unauthenticated
+          # Redis fail-closed in self-hosted production (IS_HOSTED=false
+          # below). This override acknowledges the CI-only sandbox posture
+          # so resolveRedisUrl() warns instead of throwing. Without it the
+          # smoke step exits 1 at boot before the binary-download path is
+          # ever exercised. See #969.
+          BREEZE_ALLOW_UNAUTH_REDIS: "true"
           NODE_ENV: production
           PUBLIC_APP_URL: http://localhost:3001
           # PUBLIC_API_URL drives the server-relative URL rewrite in

--- a/.github/workflows/ci-smoke-binary-source-local.yml
+++ b/.github/workflows/ci-smoke-binary-source-local.yml
@@ -86,6 +86,13 @@ jobs:
           BREEZE_APP_DB_PASSWORD: breeze
           POSTGRES_PASSWORD: breeze
           REDIS_URL: redis://localhost:6379
+          # The CI Redis service has no password; #909 made unauthenticated
+          # Redis fail-closed in self-hosted production (IS_HOSTED=false
+          # below). This override acknowledges the CI-only sandbox posture
+          # so resolveRedisUrl() warns instead of throwing. Without it the
+          # smoke step exits 1 at boot before the binary-download path is
+          # ever exercised. See #969.
+          BREEZE_ALLOW_UNAUTH_REDIS: "true"
           NODE_ENV: production
           PUBLIC_APP_URL: http://localhost:3001
           # Production-strict env that the API requires at boot post-#568.


### PR DESCRIPTION
## Summary
Closes #969.

Both `smoke-binary-source-local` and `smoke-binary-source-github` have been failing on main since 2026-05-27 ~07:00Z. Root cause: #909 made unauthenticated Redis fail-closed in self-hosted production. The smoke workflows bring up a Redis service container with no password and set `NODE_ENV=production` + `IS_HOSTED=false`, which now hits the fail-closed branch at boot. The API exits 1 before the binary-download path is ever exercised.

The check is documented to support a CI-only opt-out (verbatim from the runtime error):

> If your deployment intentionally runs Redis on a private network without auth, set `BREEZE_ALLOW_UNAUTH_REDIS=true` to acknowledge the risk.

Verified via the corresponding test on main (`apps/api/src/services/redis.test.ts:92`):

> `warns but does not throw in self-hosted prod when BREEZE_ALLOW_UNAUTH_REDIS=true`

Setting the env in the workflow `env:` block restores the previously-passing boot behavior without weakening the production check.

## Why this fix vs adding a Redis password to the workflow

The alternative is to start the CI Redis service with `redis-server --requirepass <ci-only>` and set `REDIS_PASSWORD` + `redis://:<ci-only>@localhost:6379` in the env. That's closer to prod posture but adds 3-4 lines per workflow with no real benefit — the smoke job doesn't exercise auth and the override is explicitly designed for this CI shape.

If you'd prefer the password approach instead, happy to swap.

## Test plan

- [ ] CI runs `smoke-binary-source-local` + `smoke-binary-source-github` to green on this PR
- [ ] Verify no behavior change in real production deploys (override only takes effect when `BREEZE_ALLOW_UNAUTH_REDIS=true` is set, which prod deploys never set)

## Timeline reference

- Last green run on main: 2026-05-26 18:45 (`b2e7308`)
- First red run on main: 2026-05-27 ~07:00 (`1e1e39e`)
- ~12 consecutive failures since