### PR TITLE
fix(api): security/compliance + patches endpoints honor orgId narrowing

### DIFF
--- a/apps/api/src/__tests__/integration/org-scope-narrowing.integration.test.ts
+++ b/apps/api/src/__tests__/integration/org-scope-narrowing.integration.test.ts
@@ -16,10 +16,17 @@ import { securityRoutes } from '../../routes/security';
 import { devices, devicePatches, patches, securityStatus } from '../../db/schema';
 
 // Regression coverage for PR #973 — server-side orgId narrowing on the
-// /patches and /security/status routes. Asserts real data isolation against
-// a live test DB (not mocked): a partner-scope caller narrowing to one of
-// its own orgs sees only that org's rows, and a caller asking for an org it
+// /patches and /security/* routes. Asserts real data isolation against a
+// live test DB (not mocked): a partner-scope caller narrowing to one of its
+// own orgs sees only that org's rows, and a caller asking for an org it
 // cannot access is denied (403 for patches, empty set for security).
+//
+// /security/firewall is one of the four compliance routes this PR actually
+// repaired (their query schema stripped orgId and their handler dropped the
+// second listStatusRows arg). /security/status was never broken; it is
+// asserted too, but firewall is the route that locks the fix against the
+// exact regression that reopens the hole — a refactor dropping orgId from a
+// compliance schema or call site.
 
 function buildApp(): Hono {
   const app = new Hono();
@@ -57,7 +64,7 @@ async function seedPatch(externalId: string, title: string) {
   return row.id;
 }
 
-describe('org-scope narrowing (PR #973) — /patches and /security/status', () => {
+describe('org-scope narrowing (PR #973) — /patches and /security', () => {
   // `patches` is a global catalog (no tenant FK) so cleanupDatabase does not
   // truncate it between tests or across runs; random external_ids keep each
   // seeded patch unique regardless of leftover catalog rows.
@@ -69,6 +76,8 @@ describe('org-scope narrowing (PR #973) — /patches and /security/status', () =
   let token: string;
   let patchA: string;
   let patchB: string;
+  let deviceAId: string;
+  let deviceBId: string;
 
   beforeEach(async () => {
     // Partner P1 with org A + a partner-scope user/token that can access all of P1's orgs.
@@ -89,6 +98,8 @@ describe('org-scope narrowing (PR #973) — /patches and /security/status', () =
     // Devices: one in A, one in B, one in the foreign org.
     const deviceA = await seedDevice(orgAId, siteA.id, 'agent-a', 'dev-a');
     const deviceB = await seedDevice(orgBId, siteB.id, 'agent-b', 'dev-b');
+    deviceAId = deviceA;
+    deviceBId = deviceB;
     const deviceForeign = await seedDevice(
       foreignOrgId,
       foreignEnv.site.id,
@@ -147,6 +158,27 @@ describe('org-scope narrowing (PR #973) — /patches and /security/status', () =
     const res = await app.request(`/security/status?orgId=${foreignOrgId}`, auth());
     expect(res.status).toBe(200);
     expect((await res.json()).data).toEqual([]);
+  });
+
+  // ── The fix's real target: a repaired compliance route (/security/firewall).
+  // Locks both the schema (orgId must survive validation) and the call site
+  // (handler must forward query.orgId to listStatusRows).
+  it('security/firewall (repaired route): ?orgId=A narrows to org A devices, excluding B', async () => {
+    const res = await app.request(`/security/firewall?orgId=${orgAId}`, auth());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const deviceIds = body.data.map((d: { deviceId: string }) => d.deviceId);
+    expect(deviceIds).toContain(deviceAId);
+    expect(deviceIds).not.toContain(deviceBId); // org B's device is excluded
+    expect(body.summary.total).toBe(1); // only A's single device is in scope
+  });
+
+  it('security/firewall (repaired route): ?orgId=<foreign> returns empty (200) — IDOR pin', async () => {
+    const res = await app.request(`/security/firewall?orgId=${foreignOrgId}`, auth());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual([]);
+    expect(body.summary.total).toBe(0);
   });
 
   // ── Test 3: the patches device-join filter actually excludes the other org ─

--- a/apps/api/src/__tests__/integration/org-scope-narrowing.integration.test.ts
+++ b/apps/api/src/__tests__/integration/org-scope-narrowing.integration.test.ts
@@ -1,0 +1,160 @@
+import { randomUUID } from 'node:crypto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+
+import './setup';
+import { getTestDb } from './setup';
+import {
+  createOrganization,
+  createSite,
+  setupTestEnvironment,
+  type TestEnvironment
+} from './db-utils';
+import { authMiddleware } from '../../middleware/auth';
+import { patchRoutes } from '../../routes/patches';
+import { securityRoutes } from '../../routes/security';
+import { devices, devicePatches, patches, securityStatus } from '../../db/schema';
+
+// Regression coverage for PR #973 — server-side orgId narrowing on the
+// /patches and /security/status routes. Asserts real data isolation against
+// a live test DB (not mocked): a partner-scope caller narrowing to one of
+// its own orgs sees only that org's rows, and a caller asking for an org it
+// cannot access is denied (403 for patches, empty set for security).
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.use(authMiddleware);
+  app.route('/patches', patchRoutes);
+  app.route('/security', securityRoutes);
+  return app;
+}
+
+async function seedDevice(orgId: string, siteId: string, agentId: string, hostname: string) {
+  const [row] = await getTestDb()
+    .insert(devices)
+    .values({
+      orgId,
+      siteId,
+      agentId,
+      hostname,
+      osType: 'windows',
+      osVersion: '11',
+      architecture: 'x64',
+      agentVersion: '0.66.1',
+      status: 'online'
+    })
+    .returning({ id: devices.id });
+  if (!row) throw new Error('seedDevice: insert returned no row');
+  return row.id;
+}
+
+async function seedPatch(externalId: string, title: string) {
+  const [row] = await getTestDb()
+    .insert(patches)
+    .values({ source: 'microsoft', externalId, title, requiresReboot: false })
+    .returning({ id: patches.id });
+  if (!row) throw new Error('seedPatch: insert returned no row');
+  return row.id;
+}
+
+describe('org-scope narrowing (PR #973) — /patches and /security/status', () => {
+  // `patches` is a global catalog (no tenant FK) so cleanupDatabase does not
+  // truncate it between tests or across runs; random external_ids keep each
+  // seeded patch unique regardless of leftover catalog rows.
+  let app: Hono;
+  let partnerEnv: TestEnvironment; // partner P1, owns orgA (partnerEnv.organization)
+  let orgAId: string;
+  let orgBId: string;
+  let foreignOrgId: string; // belongs to a different partner — P1 cannot access it
+  let token: string;
+  let patchA: string;
+  let patchB: string;
+
+  beforeEach(async () => {
+    // Partner P1 with org A + a partner-scope user/token that can access all of P1's orgs.
+    partnerEnv = await setupTestEnvironment({ scope: 'partner' });
+    token = partnerEnv.token;
+    orgAId = partnerEnv.organization.id;
+
+    // Second org B under the SAME partner P1.
+    const orgB = await createOrganization({ partnerId: partnerEnv.partner.id });
+    orgBId = orgB.id;
+    const siteB = await createSite({ orgId: orgBId });
+    const siteA = await createSite({ orgId: orgAId });
+
+    // A foreign org under a DIFFERENT partner — P1's token must not reach it.
+    const foreignEnv = await setupTestEnvironment({ scope: 'partner' });
+    foreignOrgId = foreignEnv.organization.id;
+
+    // Devices: one in A, one in B, one in the foreign org.
+    const deviceA = await seedDevice(orgAId, siteA.id, 'agent-a', 'dev-a');
+    const deviceB = await seedDevice(orgBId, siteB.id, 'agent-b', 'dev-b');
+    const deviceForeign = await seedDevice(
+      foreignOrgId,
+      foreignEnv.site.id,
+      'agent-f',
+      'dev-f'
+    );
+
+    // Distinct patches present on A's device vs B's device.
+    patchA = await seedPatch(`KB-A-${randomUUID()}`, 'Patch only on org A device');
+    patchB = await seedPatch(`KB-B-${randomUUID()}`, 'Patch only on org B device');
+    await getTestDb()
+      .insert(devicePatches)
+      .values([
+        { deviceId: deviceA, orgId: orgAId, patchId: patchA, status: 'missing' },
+        { deviceId: deviceB, orgId: orgBId, patchId: patchB, status: 'missing' }
+      ]);
+
+    // Security status rows for every device.
+    await getTestDb()
+      .insert(securityStatus)
+      .values([
+        { deviceId: deviceA, orgId: orgAId, provider: 'windows_defender' },
+        { deviceId: deviceB, orgId: orgBId, provider: 'windows_defender' },
+        { deviceId: deviceForeign, orgId: foreignOrgId, provider: 'windows_defender' }
+      ]);
+
+    app = buildApp();
+  });
+
+  const auth = () => ({ headers: { Authorization: `Bearer ${token}` } });
+
+  // ── Test 1: narrowing returns a strict subset ──────────────────────────────
+  it('patches: ?orgId=A returns only patches present on org A devices', async () => {
+    const res = await app.request(`/patches?orgId=${orgAId}`, auth());
+    expect(res.status).toBe(200);
+    const ids = (await res.json()).data.map((p: { id: string }) => p.id);
+    expect(ids).toContain(patchA);
+    expect(ids).not.toContain(patchB); // org B's patch is excluded
+  });
+
+  it('security/status: ?orgId=A returns only org A device statuses', async () => {
+    const res = await app.request(`/security/status?orgId=${orgAId}`, auth());
+    expect(res.status).toBe(200);
+    const orgIds = (await res.json()).data.map((s: { orgId: string }) => s.orgId);
+    expect(orgIds.length).toBeGreaterThan(0);
+    expect(new Set(orgIds)).toEqual(new Set([orgAId])); // nothing from B or foreign
+  });
+
+  // ── Test 2: IDOR pin — a foreign org the caller cannot access ──────────────
+  it('patches: ?orgId=<foreign> is rejected with 403', async () => {
+    const res = await app.request(`/patches?orgId=${foreignOrgId}`, auth());
+    expect(res.status).toBe(403);
+  });
+
+  it('security/status: ?orgId=<foreign> returns an empty set (200)', async () => {
+    const res = await app.request(`/security/status?orgId=${foreignOrgId}`, auth());
+    expect(res.status).toBe(200);
+    expect((await res.json()).data).toEqual([]);
+  });
+
+  // ── Test 3: the patches device-join filter actually excludes the other org ─
+  it('patches: ?orgId=B returns B-only patches, excluding A', async () => {
+    const res = await app.request(`/patches?orgId=${orgBId}`, auth());
+    expect(res.status).toBe(200);
+    const ids = (await res.json()).data.map((p: { id: string }) => p.id);
+    expect(ids).toContain(patchB);
+    expect(ids).not.toContain(patchA);
+  });
+});

--- a/apps/api/src/routes/patches/list.ts
+++ b/apps/api/src/routes/patches/list.ts
@@ -3,7 +3,7 @@ import { zValidator } from '@hono/zod-validator';
 import { and, eq, sql, desc, type SQL } from 'drizzle-orm';
 import { requireScope } from '../../middleware/auth';
 import { db } from '../../db';
-import { patches, patchApprovals } from '../../db/schema';
+import { patches, patchApprovals, devices, devicePatches } from '../../db/schema';
 import { listPatchesSchema, listSourcesSchema, patchIdParamSchema } from './schemas';
 import { getPagination, inferPatchOs } from './helpers';
 
@@ -37,6 +37,22 @@ listRoutes.get(
     }
     if (query.os) {
       conditions.push(sql`${sql.param(query.os)} = ANY(${patches.osTypes})`);
+    }
+
+    // Org scoping. The `patches` table is a global vendor-published catalog
+    // with no `org_id` column — the only way "patches for org X" is meaningful
+    // is via the device_patches join showing which patches are present on
+    // devices in that org. When the caller passes `?orgId=<uuid>`, narrow to
+    // patches present on devices in that org via EXISTS. Without an explicit
+    // orgId we preserve the prior behavior (full catalog for partner/system
+    // scope) to keep this change minimum-risk; a follow-up can decide whether
+    // partner-no-orgId callers should also auto-narrow.
+    if (query.orgId) {
+      conditions.push(sql`EXISTS (
+        SELECT 1 FROM ${devicePatches} dp
+        INNER JOIN ${devices} d ON d.id = dp.device_id
+        WHERE dp.patch_id = ${patches.id} AND d.org_id = ${query.orgId}
+      )`);
     }
 
     const whereClause = conditions.length > 0 ? and(...conditions) : undefined;

--- a/apps/api/src/routes/security/compliance.ts
+++ b/apps/api/src/routes/security/compliance.ts
@@ -69,7 +69,7 @@ complianceRoutes.get(
     const query = c.req.valid('query');
     const { page, limit } = getPagination(query);
 
-    const statuses = (await listStatusRows(auth)).map(toStatusResponse);
+    const statuses = (await listStatusRows(auth, query.orgId)).map(toStatusResponse);
 
     let devicesData = statuses.map((status) => ({
       deviceId: status.deviceId,
@@ -124,7 +124,7 @@ complianceRoutes.get(
     const query = c.req.valid('query');
     const { page, limit } = getPagination(query);
 
-    const statuses = (await listStatusRows(auth)).map(toStatusResponse);
+    const statuses = (await listStatusRows(auth, query.orgId)).map(toStatusResponse);
 
     const methodByOs: Record<'windows' | 'macos' | 'linux', string> = {
       windows: 'bitlocker',
@@ -198,7 +198,7 @@ complianceRoutes.get(
     const auth = c.get('auth');
     const query = c.req.valid('query');
     const { page, limit } = getPagination(query);
-    const statusRows = await listStatusRows(auth);
+    const statusRows = await listStatusRows(auth, query.orgId);
 
     let devicesData = statusRows.map((row) => {
       const policy = parsePasswordPolicySummary(row.passwordPolicySummary);
@@ -266,7 +266,7 @@ complianceRoutes.get(
     const auth = c.get('auth');
     const query = c.req.valid('query');
     const { page, limit } = getPagination(query);
-    const statusRows = await listStatusRows(auth);
+    const statusRows = await listStatusRows(auth, query.orgId);
 
     let rows = statusRows.map((row) => {
       const parsed = parseLocalAdminSummary(row.localAdminSummary);

--- a/apps/api/src/routes/security/schemas.ts
+++ b/apps/api/src/routes/security/schemas.ts
@@ -217,7 +217,12 @@ export const firewallQuerySchema = z.object({
   limit: z.string().optional(),
   status: z.enum(['enabled', 'disabled']).optional(),
   os: z.enum(['windows', 'macos', 'linux']).optional(),
-  search: z.string().optional()
+  search: z.string().optional(),
+  // Optional org narrowing — partner-scope callers can pass orgId to narrow
+  // an otherwise-cross-org view to a single org. listStatusRows() already
+  // supports this; the schema previously stripped it before the handler
+  // could read it, so the matrix saw 201 always regardless of orgId.
+  orgId: z.string().uuid().optional()
 });
 
 export const encryptionQuerySchema = z.object({
@@ -225,7 +230,8 @@ export const encryptionQuerySchema = z.object({
   limit: z.string().optional(),
   status: z.enum(['encrypted', 'partial', 'unencrypted']).optional(),
   os: z.enum(['windows', 'macos', 'linux']).optional(),
-  search: z.string().optional()
+  search: z.string().optional(),
+  orgId: z.string().uuid().optional()
 });
 
 export const passwordPolicyQuerySchema = z.object({
@@ -233,7 +239,8 @@ export const passwordPolicyQuerySchema = z.object({
   limit: z.string().optional(),
   compliance: z.enum(['compliant', 'non_compliant']).optional(),
   os: z.enum(['windows', 'macos', 'linux']).optional(),
-  search: z.string().optional()
+  search: z.string().optional(),
+  orgId: z.string().uuid().optional()
 });
 
 export const adminAuditQuerySchema = z.object({
@@ -241,7 +248,8 @@ export const adminAuditQuerySchema = z.object({
   limit: z.string().optional(),
   issue: z.enum(['default_account', 'weak_password', 'stale_account', 'no_issues']).optional(),
   os: z.enum(['windows', 'macos', 'linux']).optional(),
-  search: z.string().optional()
+  search: z.string().optional(),
+  orgId: z.string().uuid().optional()
 });
 
 export const recommendationsQuerySchema = z.object({


### PR DESCRIPTION
## What

Five trivial server-side fixes that make `/security/firewall`, `/security/encryption`, `/security/password-policy`, `/security/admin-audit`, and `/patches` honor the `?orgId=<uuid>` query parameter that they appear to accept but today silently ignore. ~33 LOC across 3 files.

## Why

Live verification matrix against `breeze.bdunn.com` showed these endpoints return identical totals regardless of whether `?orgId=` is supplied:

| Endpoint | partner-no-orgId | partner-with-orgId=Tucker | Verdict |
|---|---|---|---|
| `/security/firewall` | 201 | 201 | ignored |
| `/security/encryption` | 201 | 201 | ignored |
| `/security/password-policy` | 201 | 201 | ignored |
| `/security/admin-audit` | 201 | 201 | ignored |
| `/patches` | 8321 | 8321 | ignored |

For an MSP managing multiple orgs, this means the Security pages and Patches list silently show partner-wide data even when the user clearly intended to narrow to one org. This becomes visible to users now that the global org-scope toggle (#972) gives them a clean way to choose Current-org or All-orgs — Current mode appears broken on these endpoints because the server ignores the narrowing.

## How

**Security compliance (8 LOC).** `listStatusRows(auth, orgId?)` in `security/helpers.ts` already supports orgId narrowing. The bug was two trivial gaps:

1. The four Zod query schemas (`firewallQuerySchema`, `encryptionQuerySchema`, `passwordPolicyQuerySchema`, `adminAuditQuerySchema`) did not declare `orgId`, so the validator stripped it before the handler could read it.
2. The four handlers called `listStatusRows(auth)` with no second arg.

Fix: one-line schema addition + one-arg call edit per endpoint.

**Patches (~12 LOC).** The `patches` table is a global vendor-published catalog with no `org_id` column — narrowing by org only makes sense via the `device_patches → devices.org_id` join. The handler already accepted `?orgId=` for the per-org approval-status enrichment but never used it to scope the catalog list itself.

Fix: when `query.orgId` is provided, AND an EXISTS clause into the patches WHERE that requires at least one `device_patches` row in that org. When no `orgId` is provided, preserve prior full-catalog behavior to keep this change minimum-risk.

## What this PR does NOT do

Several endpoints in the verification matrix that returned suspicious totals (`/security/threats`, `/cis/baselines`, `/peripherals/policies`, `/reports`, `/automations`, `/incidents`) were INVESTIGATED but found correct — they correctly honor orgId in code; the matrix saw 0/0 because the tables are empty in the verification environment, not because the filter was ignored.

`/security/recommendations` correctly honors orgId but always returns 7 because the helper iterates a hard-coded 7-category catalog and any meaningful fleet triggers all 7. No code change appropriate.

## Test plan

- [x] `pnpm test --filter=@breeze/api` — 18 existing security + patches tests pass.
- [x] `tsc --noEmit` clean for the touched files (filters.ts has 2 pre-existing unrelated errors).
- [ ] Live re-run of the matrix after deploy to confirm partner-no-orgId vs partner-with-orgId now differ for these 5 endpoints.

## Notes for reviewers

- Pairs with PR #972 (global org-scope toggle) — that PR gives users a way to choose scope; this PR makes the server actually honor it for these endpoints.
- Branches independently off `main` and is mergeable on its own.
- For `/patches`: chose the safer "narrow only when explicit `?orgId=` is supplied" semantic over "auto-narrow for any partner-scope caller without orgId" to keep the change minimum-risk. Happy to switch to the broader fix if you prefer; the design doc considers both.
