### PR TITLE
feat(devices): software update + uninstall actions from device-detail

### DIFF
--- a/agent/internal/heartbeat/handlers.go
+++ b/agent/internal/heartbeat/handlers.go
@@ -62,6 +62,7 @@ var handlerRegistry = map[string]CommandHandler{
 	// Software inventory
 	tools.CmdCollectSoftware:   handleCollectSoftware,
 	tools.CmdSoftwareUninstall: handleSoftwareUninstall,
+	tools.CmdSoftwareUpdate:    handleSoftwareUpdate,
 
 	// Boot performance
 	tools.CmdCollectBootPerformance:    handleCollectBootPerformance,
@@ -290,6 +291,10 @@ func handleCollectSoftware(_ *Heartbeat, cmd Command) tools.CommandResult {
 
 func handleSoftwareUninstall(_ *Heartbeat, cmd Command) tools.CommandResult {
 	return tools.UninstallSoftware(cmd.Payload)
+}
+
+func handleSoftwareUpdate(_ *Heartbeat, cmd Command) tools.CommandResult {
+	return tools.UpdateSoftware(cmd.Payload)
 }
 
 func handleFileList(_ *Heartbeat, cmd Command) tools.CommandResult {

--- a/agent/internal/heartbeat/handlers_test.go
+++ b/agent/internal/heartbeat/handlers_test.go
@@ -24,7 +24,7 @@ var allCommandTypes = []string{
 	tools.CmdRegistryKeyCreate, tools.CmdRegistryKeyDelete,
 	tools.CmdReboot, tools.CmdShutdown, tools.CmdLock, tools.CmdRebootSafeMode, tools.CmdWakeOnLan,
 	tools.CmdRefreshInventory,
-	tools.CmdCollectSoftware, tools.CmdSoftwareUninstall, tools.CmdSoftwareInstall,
+	tools.CmdCollectSoftware, tools.CmdSoftwareUninstall, tools.CmdSoftwareInstall, tools.CmdSoftwareUpdate,
 	tools.CmdCollectBootPerformance, tools.CmdManageStartupItem,
 	tools.CmdCollectReliabilityMetrics,
 	tools.CmdCollectAuditPolicy, tools.CmdApplyAuditPolicyBaseline,

--- a/agent/internal/remote/tools/software_update.go
+++ b/agent/internal/remote/tools/software_update.go
@@ -1,0 +1,207 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// updateAttempt mirrors uninstallAttempt — each is a single package-manager
+// command to try in order; the first one whose binary is on PATH and whose
+// invocation succeeds wins. Reused intentionally instead of introducing a
+// parallel type so the runner code can stay shared.
+type updateAttempt = uninstallAttempt
+
+// UpdateSoftware upgrades a named package to the latest version available via
+// the platform's native package manager. Like UninstallSoftware it accepts
+// {name, version?} payload; version is currently only used by winget on
+// Windows (passes through as --version target). On macOS and Linux version
+// is ignored — package managers always upgrade to the newest available.
+//
+// This is intentionally NOT a download-arbitrary-payload path. Anything that
+// can't be expressed as a package-manager upgrade (e.g. an app installed by
+// dragging a .app into /Applications outside of brew) returns
+// "no supported update command found".
+func UpdateSoftware(payload map[string]any) CommandResult {
+	startTime := time.Now()
+
+	name := strings.TrimSpace(GetPayloadString(payload, "name", ""))
+	version := strings.TrimSpace(GetPayloadString(payload, "version", ""))
+
+	if err := validateSoftwareName(name); err != nil {
+		return NewErrorResult(err, time.Since(startTime).Milliseconds())
+	}
+	if err := validateSoftwareVersion(version); err != nil {
+		return NewErrorResult(err, time.Since(startTime).Milliseconds())
+	}
+
+	if err := updateSoftwareOS(name, version); err != nil {
+		return NewErrorResult(err, time.Since(startTime).Milliseconds())
+	}
+
+	result := map[string]any{
+		"name":    name,
+		"version": version,
+		"action":  "update",
+		"success": true,
+	}
+
+	return NewSuccessResult(result, time.Since(startTime).Milliseconds())
+}
+
+func updateSoftwareOS(name, version string) error {
+	switch runtime.GOOS {
+	case "windows":
+		return updateSoftwareWindows(name, version)
+	case "darwin":
+		return updateSoftwareMacOS(name)
+	case "linux":
+		return updateSoftwareLinux(name)
+	default:
+		return fmt.Errorf("software update unsupported on %s", runtime.GOOS)
+	}
+}
+
+func updateSoftwareWindows(name, version string) error {
+	// Two-tier match strategy mirrors uninstallSoftwareWindows: try
+	// --name first (matches the human-readable name the user sees in
+	// the Software tab), then --id as a fallback (winget's stable
+	// identifier, used when the display name is ambiguous).
+	attempts := []updateAttempt{
+		{
+			command: "winget",
+			args: []string{
+				"upgrade",
+				"--name", name,
+				"--silent",
+				"--accept-source-agreements",
+				"--accept-package-agreements",
+				"--disable-interactivity",
+			},
+		},
+		{
+			command: "winget",
+			args: []string{
+				"upgrade",
+				"--id", name,
+				"--silent",
+				"--accept-source-agreements",
+				"--accept-package-agreements",
+				"--disable-interactivity",
+			},
+		},
+	}
+
+	if version != "" {
+		// When a target version is supplied, prepend version-pinned
+		// variants. winget treats --version as "upgrade to this exact
+		// version" — useful for compliance pinning.
+		attempts = append([]updateAttempt{
+			{
+				command: "winget",
+				args: []string{
+					"upgrade",
+					"--name", name,
+					"--version", version,
+					"--silent",
+					"--accept-source-agreements",
+					"--accept-package-agreements",
+					"--disable-interactivity",
+				},
+			},
+		}, attempts...)
+	}
+
+	return runUpdateAttempts(name, attempts)
+}
+
+func updateSoftwareMacOS(name string) error {
+	// brew upgrade on a cask name fails with "No available formula" before
+	// it tries the cask form, so try cask first. Plain formula second.
+	attempts := []updateAttempt{
+		{command: "brew", args: []string{"upgrade", "--cask", name}},
+		{command: "brew", args: []string{"upgrade", name}},
+	}
+
+	return runUpdateAttempts(name, attempts)
+}
+
+func updateSoftwareLinux(name string) error {
+	// Reuse the protected-package guard from uninstall: upgrading
+	// systemd/glibc/kernel through this path is just as risky as
+	// removing them, and the typical breakage (interrupted boot,
+	// broken libc) requires physical hands.
+	if isProtectedLinuxPackage(name) {
+		return fmt.Errorf("refusing to update protected package %q", name)
+	}
+
+	attempts := []updateAttempt{
+		// apt-get install --only-upgrade is the documented way to bump
+		// a single package; plain `upgrade` is whole-system.
+		{command: "apt-get", args: []string{"install", "--only-upgrade", "-y", name}},
+		{command: "dnf", args: []string{"upgrade", "-y", name}},
+		{command: "yum", args: []string{"update", "-y", name}},
+		{command: "zypper", args: []string{"update", "-y", name}},
+		// pacman -S is the upgrade-or-install verb on Arch.
+		{command: "pacman", args: []string{"-S", "--noconfirm", name}},
+	}
+
+	return runUpdateAttempts(name, attempts)
+}
+
+func runUpdateAttempts(softwareName string, attempts []updateAttempt) error {
+	errors := make([]string, 0, len(attempts))
+	attempted := 0
+
+	for _, attempt := range attempts {
+		if _, err := exec.LookPath(attempt.command); err != nil {
+			continue
+		}
+
+		attempted++
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+		cmd := exec.CommandContext(ctx, attempt.command, attempt.args...)
+		output, err := cmd.CombinedOutput()
+		cancel()
+		sanitizedOutput, outputTruncated := sanitizeUninstallOutput(string(output))
+		lowerOutput := strings.ToLower(sanitizedOutput)
+
+		if err == nil {
+			return nil
+		}
+
+		// "no updates available" / "already up to date" / "no upgrade
+		// candidate" are all success-equivalents — the package is at
+		// the requested version. Map to nil so callers see the same
+		// path as an actual upgrade.
+		if strings.Contains(lowerOutput, "no available upgrade") ||
+			strings.Contains(lowerOutput, "no applicable update") ||
+			strings.Contains(lowerOutput, "no updates available") ||
+			strings.Contains(lowerOutput, "already up to date") ||
+			strings.Contains(lowerOutput, "already up-to-date") ||
+			strings.Contains(lowerOutput, "is already the newest version") ||
+			strings.Contains(lowerOutput, "nothing to do") ||
+			strings.Contains(lowerOutput, "no packages marked for update") {
+			return nil
+		}
+
+		errLine := fmt.Sprintf("%s %v: %v (%s)", attempt.command, attempt.args, err, strings.TrimSpace(sanitizedOutput))
+		if outputTruncated {
+			errLine += " [output truncated]"
+		}
+		errors = append(errors, errLine)
+	}
+
+	if attempted == 0 {
+		return fmt.Errorf("no supported update command found on this endpoint for %q", softwareName)
+	}
+
+	joined, truncated := truncateStringBytes(strings.Join(errors, "; "), maxUninstallErrorBytes)
+	if truncated {
+		joined += " [error summary truncated]"
+	}
+	return fmt.Errorf("failed to update %q after %d attempt(s): %s", softwareName, attempted, joined)
+}

--- a/agent/internal/remote/tools/software_update_test.go
+++ b/agent/internal/remote/tools/software_update_test.go
@@ -1,0 +1,63 @@
+package tools
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// UpdateSoftware shares the same name/version validators as UninstallSoftware,
+// so we lean on the existing validator tests and only assert the public entry
+// point's error mapping here.
+
+func TestUpdateSoftwareRejectsBlankName(t *testing.T) {
+	t.Parallel()
+	result := UpdateSoftware(map[string]any{"name": "", "version": ""})
+	if result.Status != "failed" {
+		t.Fatalf("expected failed status for blank name, got %s", result.Status)
+	}
+	if !strings.Contains(result.Error, "software name is required") {
+		t.Fatalf("expected validation error, got %q", result.Error)
+	}
+}
+
+func TestUpdateSoftwareRejectsShellMetaInName(t *testing.T) {
+	t.Parallel()
+	result := UpdateSoftware(map[string]any{"name": "Chrome;rm -rf /"})
+	if result.Status != "failed" {
+		t.Fatalf("expected failed status for shell meta, got %s", result.Status)
+	}
+	if !strings.Contains(result.Error, "unsafe characters") {
+		t.Fatalf("expected unsafe-chars validation error, got %q", result.Error)
+	}
+}
+
+func TestUpdateSoftwareRejectsLeadingDashName(t *testing.T) {
+	t.Parallel()
+	result := UpdateSoftware(map[string]any{"name": "-rf"})
+	if result.Status != "failed" {
+		t.Fatalf("expected failed status for leading dash, got %s", result.Status)
+	}
+}
+
+func TestUpdateSoftwareLinuxProtectedPackage(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS != "linux" {
+		t.Skipf("linux-only guard test, current %s", runtime.GOOS)
+	}
+	result := UpdateSoftware(map[string]any{"name": "systemd"})
+	if result.Status != "failed" {
+		t.Fatalf("expected refusal for protected package, got %s", result.Status)
+	}
+	if !strings.Contains(result.Error, "protected package") {
+		t.Fatalf("expected protected-package error, got %q", result.Error)
+	}
+}
+
+func TestUpdateSoftwareUnsupportedVersionFormat(t *testing.T) {
+	t.Parallel()
+	result := UpdateSoftware(map[string]any{"name": "Chrome", "version": "1.0;rm"})
+	if result.Status != "failed" {
+		t.Fatalf("expected failed status for unsafe version, got %s", result.Status)
+	}
+}

--- a/agent/internal/remote/tools/types.go
+++ b/agent/internal/remote/tools/types.go
@@ -58,6 +58,7 @@ const (
 	CmdCollectSoftware   = "collect_software"
 	CmdSoftwareUninstall = "software_uninstall"
 	CmdSoftwareInstall   = "software_install"
+	CmdSoftwareUpdate    = "software_update"
 
 	// Boot performance
 	CmdCollectBootPerformance    = "collect_boot_performance"

--- a/apps/api/src/routes/devices/index.ts
+++ b/apps/api/src/routes/devices/index.ts
@@ -20,6 +20,7 @@ import { warrantyRoutes } from './warranty';
 import { provisionRoutes } from './provision';
 import { moveOrgRoutes } from './moveOrg';
 import { actuateElevationRoutes } from './actuateElevation';
+import { softwareActionsRoutes } from './softwareActions';
 
 export const deviceRoutes = new Hono();
 
@@ -45,6 +46,12 @@ deviceRoutes.route('/', coreRoutes);
 
 // Mount sub-resource routes
 deviceRoutes.route('/', metricsRoutes);
+// Mount softwareActionsRoutes BEFORE softwareRoutes so the POST /:id/software/update
+// + /:id/software/uninstall handlers are registered ahead of any future
+// software.ts handlers that might shadow them. Different verbs today (POST vs
+// the existing GET /:id/software) means there's no actual conflict, but ordering
+// the more-specific paths first matches the existing static-before-:id convention.
+deviceRoutes.route('/', softwareActionsRoutes);
 deviceRoutes.route('/', softwareRoutes);
 deviceRoutes.route('/', commandsRoutes);
 deviceRoutes.route('/', hardwareRoutes);

--- a/apps/api/src/routes/devices/softwareActions.test.ts
+++ b/apps/api/src/routes/devices/softwareActions.test.ts
@@ -1,0 +1,319 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+  },
+}));
+
+vi.mock('../../db/schema', () => ({
+  deviceCommands: { id: 'id', deviceId: 'deviceId', type: 'type', status: 'status' },
+  devices: { id: 'id' },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', {
+      user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+      scope: 'organization',
+      orgId: 'org-123',
+      partnerId: null,
+      accessibleOrgIds: ['org-123'],
+      canAccessOrg: (orgId: string) => orgId === 'org-123',
+      token: { mfa: true },
+    });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(
+    (resource: string, action: string) => async (c: any, next: any) => {
+      if (c.req.header('x-deny-devices-execute') === 'true' && resource === 'devices' && action === 'execute') {
+        return c.json({ error: 'Permission denied' }, 403);
+      }
+      if (c.req.header('x-site-restricted') === 'true') {
+        c.set('permissions', {
+          permissions: [{ resource, action }],
+          partnerId: null,
+          orgId: 'org-123',
+          roleId: 'role-123',
+          scope: 'organization',
+          allowedSiteIds: ['site-allowed'],
+        });
+      }
+      return next();
+    }
+  ),
+  requireMfa: vi.fn(() => async (c: any, next: any) => {
+    if (c.req.header('x-deny-mfa') === 'true') {
+      return c.json({ error: 'MFA required' }, 403);
+    }
+    return next();
+  }),
+}));
+
+vi.mock('./helpers', () => ({
+  getDeviceWithOrgCheck: vi.fn(),
+}));
+
+const queueCommandForExecutionMock = vi.fn();
+
+vi.mock('../../services/commandQueue', () => ({
+  CommandTypes: {
+    SOFTWARE_UPDATE: 'software_update',
+    SOFTWARE_UNINSTALL: 'software_uninstall',
+  },
+  queueCommandForExecution: (...args: unknown[]) => queueCommandForExecutionMock(...args),
+}));
+
+vi.mock('../../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn(),
+}));
+
+vi.mock('../../services/commandAudit', () => ({
+  commandAuditDetails: vi.fn((id: string, type: string) => ({ commandId: id, commandType: type })),
+}));
+
+import { softwareActionsRoutes } from './softwareActions';
+import { getDeviceWithOrgCheck } from './helpers';
+
+describe('device software actions routes', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queueCommandForExecutionMock.mockReset();
+    app = new Hono();
+    app.route('/devices', softwareActionsRoutes);
+  });
+
+  describe('POST /devices/:id/software/update', () => {
+    it('queues a software_update command for a valid device + payload', async () => {
+      (getDeviceWithOrgCheck as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'device-1',
+        orgId: 'org-123',
+        siteId: null,
+        hostname: 'host-1',
+        status: 'online',
+      });
+      queueCommandForExecutionMock.mockResolvedValue({
+        command: { id: 'cmd-1', status: 'sent' },
+      });
+
+      const res = await app.request('/devices/device-1/software/update', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Google Chrome' }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toMatchObject({
+        success: true,
+        commandId: 'cmd-1',
+        commandStatus: 'sent',
+        action: 'update',
+        name: 'Google Chrome',
+      });
+      expect(queueCommandForExecutionMock).toHaveBeenCalledWith(
+        'device-1',
+        'software_update',
+        { name: 'Google Chrome', source: 'device_software_tab' },
+        expect.objectContaining({ userId: 'user-123' })
+      );
+    });
+
+    it('passes version through to the agent payload when provided', async () => {
+      (getDeviceWithOrgCheck as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'device-1',
+        orgId: 'org-123',
+        siteId: null,
+        hostname: 'host-1',
+        status: 'online',
+      });
+      queueCommandForExecutionMock.mockResolvedValue({
+        command: { id: 'cmd-2', status: 'pending' },
+      });
+
+      const res = await app.request('/devices/device-1/software/update', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Google Chrome', version: '125.0.6422.142' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(queueCommandForExecutionMock).toHaveBeenCalledWith(
+        'device-1',
+        'software_update',
+        { name: 'Google Chrome', version: '125.0.6422.142', source: 'device_software_tab' },
+        expect.objectContaining({ userId: 'user-123' })
+      );
+    });
+
+    it('returns 404 when the device cannot be found by org', async () => {
+      (getDeviceWithOrgCheck as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      const res = await app.request('/devices/missing/software/update', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Slack' }),
+      });
+
+      expect(res.status).toBe(404);
+      expect(queueCommandForExecutionMock).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for decommissioned devices', async () => {
+      (getDeviceWithOrgCheck as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'device-1',
+        orgId: 'org-123',
+        siteId: null,
+        hostname: 'host-1',
+        status: 'decommissioned',
+      });
+
+      const res = await app.request('/devices/device-1/software/update', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Slack' }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(queueCommandForExecutionMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects payload with shell metacharacters in name', async () => {
+      const res = await app.request('/devices/device-1/software/update', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Chrome;rm -rf /' }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(queueCommandForExecutionMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects payload with leading dash in name', async () => {
+      const res = await app.request('/devices/device-1/software/update', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: '-rf /' }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(queueCommandForExecutionMock).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when MFA gate denies the request', async () => {
+      (getDeviceWithOrgCheck as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'device-1',
+        orgId: 'org-123',
+        siteId: null,
+        hostname: 'host-1',
+        status: 'online',
+      });
+
+      const res = await app.request('/devices/device-1/software/update', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-deny-mfa': 'true' },
+        body: JSON.stringify({ name: 'Chrome' }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(queueCommandForExecutionMock).not.toHaveBeenCalled();
+    });
+
+    it('returns 503 when the command could not be queued', async () => {
+      (getDeviceWithOrgCheck as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'device-1',
+        orgId: 'org-123',
+        siteId: null,
+        hostname: 'host-1',
+        status: 'online',
+      });
+      queueCommandForExecutionMock.mockResolvedValue({
+        error: 'Device is offline, cannot execute command',
+      });
+
+      const res = await app.request('/devices/device-1/software/update', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Chrome' }),
+      });
+
+      expect(res.status).toBe(503);
+      const body = await res.json();
+      expect(body.error).toContain('offline');
+    });
+
+    it('returns 403 when permission check denies devices.execute', async () => {
+      const res = await app.request('/devices/device-1/software/update', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-deny-devices-execute': 'true' },
+        body: JSON.stringify({ name: 'Chrome' }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(queueCommandForExecutionMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /devices/:id/software/uninstall', () => {
+    it('queues a software_uninstall command for a valid device + payload', async () => {
+      (getDeviceWithOrgCheck as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'device-1',
+        orgId: 'org-123',
+        siteId: null,
+        hostname: 'host-1',
+        status: 'online',
+      });
+      queueCommandForExecutionMock.mockResolvedValue({
+        command: { id: 'cmd-3', status: 'sent' },
+      });
+
+      const res = await app.request('/devices/device-1/software/uninstall', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Slack' }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toMatchObject({
+        success: true,
+        commandId: 'cmd-3',
+        action: 'uninstall',
+        name: 'Slack',
+      });
+      expect(queueCommandForExecutionMock).toHaveBeenCalledWith(
+        'device-1',
+        'software_uninstall',
+        { name: 'Slack', source: 'device_software_tab' },
+        expect.objectContaining({ userId: 'user-123' })
+      );
+    });
+
+    it('returns 403 when site permission denies the device', async () => {
+      (getDeviceWithOrgCheck as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'device-1',
+        orgId: 'org-123',
+        siteId: 'site-other',
+        hostname: 'host-1',
+        status: 'online',
+      });
+
+      const res = await app.request('/devices/device-1/software/uninstall', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-site-restricted': 'true' },
+        body: JSON.stringify({ name: 'Slack' }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(queueCommandForExecutionMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/routes/devices/softwareActions.ts
+++ b/apps/api/src/routes/devices/softwareActions.ts
@@ -1,0 +1,173 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
+import { authMiddleware, requireMfa, requireScope, requirePermission } from '../../middleware/auth';
+import { canAccessSite, PERMISSIONS, type UserPermissions } from '../../services/permissions';
+import { getDeviceWithOrgCheck } from './helpers';
+import { CommandTypes, queueCommandForExecution } from '../../services/commandQueue';
+import { writeRouteAudit } from '../../services/auditEvents';
+import { commandAuditDetails } from '../../services/commandAudit';
+
+export const softwareActionsRoutes = new Hono();
+
+softwareActionsRoutes.use('*', authMiddleware);
+
+function canAccessDeviceSite(
+  device: { siteId?: string | null },
+  userPerms: UserPermissions | undefined
+): boolean {
+  if (!userPerms?.allowedSiteIds) return true;
+  return typeof device.siteId === 'string' && canAccessSite(userPerms, device.siteId);
+}
+
+// Same name/version constraints as the agent's validateSoftwareName /
+// validateSoftwareVersion. Keeping these synchronized prevents a request
+// that the API would accept from coming back as a generic validator error
+// from the agent.
+const SOFTWARE_NAME_UNSAFE = /[\\/\x00\r\n']/;
+const SHELL_META = /[;&|><`$'"]/;
+
+const softwareActionPayloadSchema = z
+  .object({
+    name: z
+      .string()
+      .min(1, 'name is required')
+      .max(200, 'name exceeds 200 characters')
+      .refine((v) => !v.startsWith('-'), { message: 'name must not start with "-"' })
+      .refine((v) => !v.includes('..'), { message: 'name contains invalid traversal sequence' })
+      .refine(
+        (v) => !SOFTWARE_NAME_UNSAFE.test(v) && !SHELL_META.test(v),
+        { message: 'name contains unsafe characters' }
+      ),
+    version: z
+      .string()
+      .max(100, 'version exceeds 100 characters')
+      .refine((v) => v === '' || !v.startsWith('-'), { message: 'version must not start with "-"' })
+      .refine((v) => !v.includes('..'), { message: 'version contains invalid traversal sequence' })
+      .refine(
+        (v) => !SOFTWARE_NAME_UNSAFE.test(v) && !SHELL_META.test(v),
+        { message: 'version contains unsafe characters' }
+      )
+      .optional(),
+  })
+  .strict();
+
+// POST /devices/:id/software/update — queue a software upgrade for the named package
+softwareActionsRoutes.post(
+  '/:id/software/update',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_EXECUTE.resource, PERMISSIONS.DEVICES_EXECUTE.action),
+  requireMfa(),
+  zValidator('json', softwareActionPayloadSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const deviceId = c.req.param('id')!;
+    const data = c.req.valid('json');
+
+    const device = await getDeviceWithOrgCheck(deviceId, auth);
+    if (!device) {
+      return c.json({ error: 'Device not found' }, 404);
+    }
+    if (!canAccessDeviceSite(device, c.get('permissions') as UserPermissions | undefined)) {
+      return c.json({ error: 'Access to this site denied' }, 403);
+    }
+    if (device.status === 'decommissioned') {
+      return c.json({ error: 'Cannot send commands to a decommissioned device' }, 400);
+    }
+
+    const payload: Record<string, unknown> = { name: data.name, source: 'device_software_tab' };
+    if (data.version) payload.version = data.version;
+
+    const queued = await queueCommandForExecution(deviceId, CommandTypes.SOFTWARE_UPDATE, payload, {
+      userId: auth.user.id,
+      preferHeartbeat: false,
+    });
+
+    if (!queued.command) {
+      return c.json({ error: queued.error || 'Failed to queue software_update command' }, 503);
+    }
+
+    const command = queued.command;
+    writeRouteAudit(c, {
+      orgId: device.orgId,
+      action: 'device.software.update.queue',
+      resourceType: 'device',
+      resourceId: deviceId,
+      resourceName: device.hostname,
+      details: {
+        ...commandAuditDetails(command.id, CommandTypes.SOFTWARE_UPDATE, payload),
+        softwareName: data.name,
+        softwareVersion: data.version ?? null,
+      },
+    });
+
+    return c.json({
+      success: true,
+      commandId: command.id,
+      commandStatus: command.status,
+      name: data.name,
+      version: data.version ?? null,
+      action: 'update',
+    });
+  }
+);
+
+// POST /devices/:id/software/uninstall — queue a software uninstall for the named package
+softwareActionsRoutes.post(
+  '/:id/software/uninstall',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_EXECUTE.resource, PERMISSIONS.DEVICES_EXECUTE.action),
+  requireMfa(),
+  zValidator('json', softwareActionPayloadSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const deviceId = c.req.param('id')!;
+    const data = c.req.valid('json');
+
+    const device = await getDeviceWithOrgCheck(deviceId, auth);
+    if (!device) {
+      return c.json({ error: 'Device not found' }, 404);
+    }
+    if (!canAccessDeviceSite(device, c.get('permissions') as UserPermissions | undefined)) {
+      return c.json({ error: 'Access to this site denied' }, 403);
+    }
+    if (device.status === 'decommissioned') {
+      return c.json({ error: 'Cannot send commands to a decommissioned device' }, 400);
+    }
+
+    const payload: Record<string, unknown> = { name: data.name, source: 'device_software_tab' };
+    if (data.version) payload.version = data.version;
+
+    const queued = await queueCommandForExecution(deviceId, CommandTypes.SOFTWARE_UNINSTALL, payload, {
+      userId: auth.user.id,
+      preferHeartbeat: false,
+    });
+
+    if (!queued.command) {
+      return c.json({ error: queued.error || 'Failed to queue software_uninstall command' }, 503);
+    }
+
+    const command = queued.command;
+    writeRouteAudit(c, {
+      orgId: device.orgId,
+      action: 'device.software.uninstall.queue',
+      resourceType: 'device',
+      resourceId: deviceId,
+      resourceName: device.hostname,
+      details: {
+        ...commandAuditDetails(command.id, CommandTypes.SOFTWARE_UNINSTALL, payload),
+        softwareName: data.name,
+        softwareVersion: data.version ?? null,
+      },
+    });
+
+    return c.json({
+      success: true,
+      commandId: command.id,
+      commandStatus: command.status,
+      name: data.name,
+      version: data.version ?? null,
+      action: 'uninstall',
+    });
+  }
+);

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -85,6 +85,7 @@ export const CommandTypes = {
 
   // Software management
   SOFTWARE_UNINSTALL: 'software_uninstall',
+  SOFTWARE_UPDATE: 'software_update',
   CIS_BENCHMARK: 'cis_benchmark',
   APPLY_CIS_REMEDIATION: 'apply_cis_remediation',
 
@@ -247,6 +248,7 @@ const AUDITED_COMMANDS: Set<string> = new Set([
   CommandTypes.INSTALL_PATCHES,
   CommandTypes.ROLLBACK_PATCHES,
   CommandTypes.SOFTWARE_UNINSTALL,
+  CommandTypes.SOFTWARE_UPDATE,
   CommandTypes.CIS_BENCHMARK,
   CommandTypes.APPLY_CIS_REMEDIATION,
   CommandTypes.SECURITY_SCAN,

--- a/apps/web/src/components/devices/DeviceSoftwareInventory.test.tsx
+++ b/apps/web/src/components/devices/DeviceSoftwareInventory.test.tsx
@@ -1,0 +1,172 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DeviceSoftwareInventory from './DeviceSoftwareInventory';
+import { fetchWithAuth } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('../shared/Toast', () => ({
+  showToast: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+const showToastMock = vi.mocked(showToast);
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+const deviceId = '11111111-1111-1111-1111-111111111111';
+
+const SOFTWARE_FIXTURE = {
+  data: [
+    {
+      id: 'sw-chrome',
+      name: 'Google Chrome',
+      version: '125.0.6422.142',
+      publisher: 'Google LLC',
+      installDate: '2026-02-01',
+    },
+    {
+      id: 'sw-safari',
+      name: 'Safari',
+      version: '17.5',
+      publisher: 'Apple Inc.',
+      installDate: '2026-01-01',
+    },
+  ],
+};
+
+describe('DeviceSoftwareInventory action buttons', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders Update and Uninstall buttons enabled on Windows', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse(SOFTWARE_FIXTURE));
+
+    render(<DeviceSoftwareInventory deviceId={deviceId} osType="windows" />);
+
+    const updateBtn = await screen.findByTestId('software-update-sw-chrome');
+    const uninstallBtn = await screen.findByTestId('software-uninstall-sw-chrome');
+    expect(updateBtn).not.toBeDisabled();
+    expect(uninstallBtn).not.toBeDisabled();
+  });
+
+  it('disables Update + Uninstall for Apple-published rows on macOS', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse(SOFTWARE_FIXTURE));
+
+    render(<DeviceSoftwareInventory deviceId={deviceId} osType="macos" />);
+
+    const updateBtn = await screen.findByTestId('software-update-sw-safari');
+    const uninstallBtn = await screen.findByTestId('software-uninstall-sw-safari');
+    expect(updateBtn).toBeDisabled();
+    expect(uninstallBtn).toBeDisabled();
+    expect(updateBtn.getAttribute('title')).toContain('Apple-signed');
+  });
+
+  it('queues an update via POST /devices/:id/software/update and shows success toast', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(makeJsonResponse(SOFTWARE_FIXTURE))
+      .mockResolvedValueOnce(makeJsonResponse({ success: true, commandId: 'cmd-1', action: 'update' }));
+
+    render(<DeviceSoftwareInventory deviceId={deviceId} osType="windows" />);
+
+    const updateBtn = await screen.findByTestId('software-update-sw-chrome');
+    fireEvent.click(updateBtn);
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        `/devices/${deviceId}/software/update`,
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ name: 'Google Chrome', version: '125.0.6422.142' }),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'success', message: expect.stringContaining('Update queued') })
+      );
+    });
+  });
+
+  it('shows confirmation dialog for Uninstall and only POSTs after confirm', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(makeJsonResponse(SOFTWARE_FIXTURE))
+      .mockResolvedValueOnce(makeJsonResponse({ success: true, commandId: 'cmd-2', action: 'uninstall' }));
+
+    render(<DeviceSoftwareInventory deviceId={deviceId} osType="windows" />);
+
+    const uninstallBtn = await screen.findByTestId('software-uninstall-sw-chrome');
+    fireEvent.click(uninstallBtn);
+
+    // Dialog appears
+    expect(await screen.findByText('Uninstall Google Chrome?')).toBeTruthy();
+    // Still no second fetch yet
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId('confirm-uninstall'));
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        `/devices/${deviceId}/software/uninstall`,
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ name: 'Google Chrome', version: '125.0.6422.142' }),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'success', message: expect.stringContaining('Uninstall queued') })
+      );
+    });
+  });
+
+  it('shows an error toast when the API returns a failure for update', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(makeJsonResponse(SOFTWARE_FIXTURE))
+      .mockResolvedValueOnce(makeJsonResponse({ error: 'Device offline' }, false, 503));
+
+    render(<DeviceSoftwareInventory deviceId={deviceId} osType="windows" />);
+
+    const updateBtn = await screen.findByTestId('software-update-sw-chrome');
+    fireEvent.click(updateBtn);
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error', message: expect.stringContaining('Device offline') })
+      );
+    });
+  });
+
+  it('Cancel closes the confirmation dialog without POSTing', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse(SOFTWARE_FIXTURE));
+
+    render(<DeviceSoftwareInventory deviceId={deviceId} osType="windows" />);
+
+    const uninstallBtn = await screen.findByTestId('software-uninstall-sw-chrome');
+    fireEvent.click(uninstallBtn);
+
+    expect(await screen.findByText('Uninstall Google Chrome?')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Cancel'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Uninstall Google Chrome?')).toBeNull();
+    });
+    // No second fetch
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/devices/DeviceSoftwareInventory.tsx
+++ b/apps/web/src/components/devices/DeviceSoftwareInventory.tsx
@@ -1,6 +1,20 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Package, Search, ChevronLeft, ChevronRight, RefreshCw, X, Box } from 'lucide-react';
+import {
+  Package,
+  Search,
+  ChevronLeft,
+  ChevronRight,
+  RefreshCw,
+  X,
+  Box,
+  ArrowUpCircle,
+  Trash2,
+  Loader2,
+  AlertTriangle
+} from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { runAction, ActionError } from '../../lib/runAction';
+import { showToast } from '../shared/Toast';
 
 function isApplePublisher(publisher: string): boolean {
   const p = publisher.toLowerCase();
@@ -33,11 +47,43 @@ type DeviceSoftwareInventoryProps = {
   osType?: string;
 };
 
+type SoftwareAction = 'update' | 'uninstall';
+
+// We block update/uninstall for Apple-published macOS apps because their
+// package-manager identity (Apple-signed App Store / OS components) is not
+// expressible to `brew upgrade`/`brew uninstall`. The agent would just
+// return "no supported update command" — better to disable upfront and
+// explain why than to queue a guaranteed-to-fail command.
+function actionsAreSupported(osType: string | undefined, isApple: boolean): {
+  update: { allowed: boolean; reason?: string };
+  uninstall: { allowed: boolean; reason?: string };
+} {
+  const os = (osType || '').toLowerCase();
+  if (os === 'macos' || os === 'darwin') {
+    if (isApple) {
+      const reason = 'Apple-signed apps are managed by macOS — uninstall via Settings, update via Software Update.';
+      return { update: { allowed: false, reason }, uninstall: { allowed: false, reason } };
+    }
+    return { update: { allowed: true }, uninstall: { allowed: true } };
+  }
+  if (os === 'windows' || os === 'linux') {
+    return { update: { allowed: true }, uninstall: { allowed: true } };
+  }
+  const reason = `Software actions are not supported on ${osType || 'this OS'}.`;
+  return { update: { allowed: false, reason }, uninstall: { allowed: false, reason } };
+}
+
 function formatDate(value?: string, timezone?: string) {
   if (!value) return '-';
   const date = new Date(value);
   return Number.isNaN(date.getTime()) ? value : date.toLocaleDateString([], timezone ? { timeZone: timezone } : undefined);
 }
+
+type ConfirmState = {
+  action: SoftwareAction;
+  name: string;
+  version: string;
+};
 
 export default function DeviceSoftwareInventory({ deviceId, timezone, osType }: DeviceSoftwareInventoryProps) {
   const [software, setSoftware] = useState<SoftwareItem[]>([]);
@@ -47,9 +93,17 @@ export default function DeviceSoftwareInventory({ deviceId, timezone, osType }: 
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
-  const [total, setTotal] = useState(0);
+  const [, setTotal] = useState(0);
   const [publisherFilter, setPublisherFilter] = useState<string>('all');
   const [typeFilter, setTypeFilter] = useState<'all' | 'apple' | 'third-party'>('all');
+  // Rows currently in-flight (keyed by row id) so the table can show a
+  // per-row spinner and disable other actions on that row without disabling
+  // the entire grid.
+  const [pendingActions, setPendingActions] = useState<Record<string, SoftwareAction | undefined>>({});
+  // null when no confirm dialog is open. Only Uninstall opens one — Update
+  // queues directly, since the worst case is a silent no-op when the package
+  // is already current.
+  const [confirmState, setConfirmState] = useState<ConfirmState | null>(null);
   const pageSize = 25;
 
   // Use provided timezone, fetched siteTimezone, or browser default
@@ -89,6 +143,38 @@ export default function DeviceSoftwareInventory({ deviceId, timezone, osType }: 
     fetchSoftware();
   }, [fetchSoftware]);
 
+  const queueSoftwareAction = useCallback(
+    async (rowId: string, action: SoftwareAction, name: string, version: string) => {
+      setPendingActions((prev) => ({ ...prev, [rowId]: action }));
+      const verb = action === 'update' ? 'Update' : 'Uninstall';
+      try {
+        await runAction({
+          request: () =>
+            fetchWithAuth(`/devices/${deviceId}/software/${action}`, {
+              method: 'POST',
+              body: JSON.stringify(version ? { name, version } : { name }),
+            }),
+          errorFallback: `${verb} could not be queued`,
+          successMessage: `${verb} queued for "${name}"`,
+        });
+      } catch (err) {
+        if (err instanceof ActionError && err.status === 401) {
+          return;
+        }
+        if (!(err instanceof ActionError)) {
+          showToast({ message: `${verb} could not be queued`, type: 'error' });
+        }
+      } finally {
+        setPendingActions((prev) => {
+          const next = { ...prev };
+          delete next[rowId];
+          return next;
+        });
+      }
+    },
+    [deviceId]
+  );
+
   // Get unique publishers for filter dropdown
   const publishers = useMemo(() => {
     const publisherSet = new Set<string>();
@@ -102,16 +188,19 @@ export default function DeviceSoftwareInventory({ deviceId, timezone, osType }: 
   const rows = useMemo(() => {
     return software.map((item, index) => {
       const publisher = item.publisher ?? item.vendor ?? '-';
+      const isApple = isApplePublisher(publisher);
       return {
         id: item.id ?? `${item.name ?? item.title ?? 'software'}-${index}`,
         name: item.name ?? item.title ?? 'Unknown software',
         version: item.version || '-',
+        rawVersion: item.version || '',
         publisher,
-        isApple: isApplePublisher(publisher),
-        installDate: formatDate(item.installDate ?? item.installedAt ?? item.install_date, effectiveTimezone)
+        isApple,
+        installDate: formatDate(item.installDate ?? item.installedAt ?? item.install_date, effectiveTimezone),
+        capabilities: actionsAreSupported(osType, isApple),
       };
     });
-  }, [software, effectiveTimezone]);
+  }, [software, effectiveTimezone, osType]);
 
   const filteredRows = useMemo(() => {
     return rows.filter(item => {
@@ -275,35 +364,78 @@ export default function DeviceSoftwareInventory({ deviceId, timezone, osType }: 
                 <th className="px-4 py-3">Version</th>
                 <th className="px-4 py-3">Publisher</th>
                 <th className="px-4 py-3">Installed</th>
+                <th className="px-4 py-3 text-right">Actions</th>
               </tr>
             </thead>
             <tbody className="divide-y">
               {paginatedRows.length === 0 ? (
                 <tr>
-                  <td colSpan={4} className="px-4 py-6 text-center text-sm text-muted-foreground">
+                  <td colSpan={5} className="px-4 py-6 text-center text-sm text-muted-foreground">
                     {hasActiveFilters
                       ? 'No software matches your filters.'
                       : 'No software inventory reported.'}
                   </td>
                 </tr>
               ) : (
-                paginatedRows.map(item => (
-                  <tr key={item.id} className="text-sm hover:bg-muted/30">
-                    <td className="px-4 py-3 font-medium">
-                      <span className="flex items-center gap-2">
-                        {item.isApple ? (
-                          <AppleIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
-                        ) : (
-                          <Box className="h-4 w-4 shrink-0 text-muted-foreground" />
-                        )}
-                        {item.name}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 font-mono text-xs text-muted-foreground">{item.version}</td>
-                    <td className="px-4 py-3 text-muted-foreground">{item.publisher}</td>
-                    <td className="px-4 py-3 text-muted-foreground">{item.installDate}</td>
-                  </tr>
-                ))
+                paginatedRows.map(item => {
+                  const pendingAction = pendingActions[item.id];
+                  const isUpdatePending = pendingAction === 'update';
+                  const isUninstallPending = pendingAction === 'uninstall';
+                  const anyPending = pendingAction !== undefined;
+                  return (
+                    <tr key={item.id} className="text-sm hover:bg-muted/30">
+                      <td className="px-4 py-3 font-medium">
+                        <span className="flex items-center gap-2">
+                          {item.isApple ? (
+                            <AppleIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                          ) : (
+                            <Box className="h-4 w-4 shrink-0 text-muted-foreground" />
+                          )}
+                          {item.name}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 font-mono text-xs text-muted-foreground">{item.version}</td>
+                      <td className="px-4 py-3 text-muted-foreground">{item.publisher}</td>
+                      <td className="px-4 py-3 text-muted-foreground">{item.installDate}</td>
+                      <td className="px-4 py-3 text-right">
+                        <div className="inline-flex items-center gap-1.5">
+                          <button
+                            type="button"
+                            data-testid={`software-update-${item.id}`}
+                            disabled={!item.capabilities.update.allowed || anyPending}
+                            title={item.capabilities.update.reason ?? 'Queue an update for this package'}
+                            onClick={() => queueSoftwareAction(item.id, 'update', item.name, item.rawVersion)}
+                            className="inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                          >
+                            {isUpdatePending ? (
+                              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                            ) : (
+                              <ArrowUpCircle className="h-3.5 w-3.5" />
+                            )}
+                            Update
+                          </button>
+                          <button
+                            type="button"
+                            data-testid={`software-uninstall-${item.id}`}
+                            disabled={!item.capabilities.uninstall.allowed || anyPending}
+                            title={item.capabilities.uninstall.reason ?? 'Uninstall this package'}
+                            onClick={() =>
+                              setConfirmState({ action: 'uninstall', name: item.name, version: item.rawVersion })
+                            }
+                            className="inline-flex items-center gap-1 rounded-md border border-destructive/40 px-2 py-1 text-xs text-destructive hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-50"
+                          >
+                            {isUninstallPending ? (
+                              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                            ) : (
+                              <Trash2 className="h-3.5 w-3.5" />
+                            )}
+                            Uninstall
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })
               )}
             </tbody>
           </table>
@@ -353,6 +485,63 @@ export default function DeviceSoftwareInventory({ deviceId, timezone, osType }: 
             >
               Last
             </button>
+          </div>
+        </div>
+      )}
+
+      {confirmState && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="software-uninstall-title"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setConfirmState(null);
+          }}
+        >
+          <div className="w-full max-w-md rounded-lg border bg-card p-6 shadow-lg">
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="h-5 w-5 shrink-0 text-destructive" />
+              <div className="flex-1">
+                <h4 id="software-uninstall-title" className="text-base font-semibold">
+                  Uninstall {confirmState.name}?
+                </h4>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  This will queue an uninstall command for "{confirmState.name}" on this device.
+                  Uninstalling user data or dependencies may impact other software on the device.
+                </p>
+              </div>
+            </div>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setConfirmState(null)}
+                className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                data-testid="confirm-uninstall"
+                onClick={() => {
+                  // Resolve the row id from current rows so the spinner key
+                  // matches the row the user is looking at. We re-derive id
+                  // by name+version because pagination/filters could have
+                  // shuffled the visible set since the user clicked.
+                  const row = rows.find(
+                    (r) => r.name === confirmState.name && r.rawVersion === confirmState.version
+                  );
+                  const rowId = row?.id ?? `${confirmState.name}-${confirmState.version}`;
+                  const name = confirmState.name;
+                  const version = confirmState.version;
+                  setConfirmState(null);
+                  void queueSoftwareAction(rowId, 'uninstall', name, version);
+                }}
+                className="rounded-md bg-destructive px-3 py-1.5 text-sm font-medium text-destructive-foreground hover:opacity-90"
+              >
+                Uninstall
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -37,6 +37,7 @@ const TARGET_GLOBS = [
   'src/components/dnsSecurity/AddDnsIntegrationModal.tsx',
   'src/components/dnsSecurity/DnsSecurityPoliciesTab.tsx',
   'src/components/dnsSecurity/AddDnsPolicyModal.tsx',
+  'src/components/devices/DeviceSoftwareInventory.tsx',
 ];
 
 const absoluteFiles: string[] = TARGET_GLOBS.map((rel) => resolve(WEB_ROOT, '..', rel));
@@ -228,7 +229,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(9);
+    expect(absoluteFiles.length).toBe(10);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }


### PR DESCRIPTION
## Summary

Adds per-row **Update** and **Uninstall** action buttons to the device-detail Software tab. Both queue real commands to the agent via the existing `device_commands` pipeline; no new transport, no new schema.

### What the user sees

Each row in the Software tab now has two new buttons in an Actions column on the right:

- **Update** — a small button with an upward-arrow icon. Click queues a `software_update` command. An inline spinner replaces the icon while the request is in flight, then a green success toast: *Update queued for "Google Chrome"*.
- **Uninstall** — a small button with a trash icon, styled in the destructive color. Click opens a centered modal: *Uninstall Google Chrome? This will queue an uninstall command for this device. Uninstalling user data or dependencies may impact other software on the device.* with Cancel and red Uninstall buttons. Confirming sends a `software_uninstall` command and shows *Uninstall queued for "Google Chrome"*.

When a button is disabled, its tooltip explains why (see OS coverage matrix below).

## OS coverage matrix

| Platform | Update path | Uninstall path | Notes |
| --- | --- | --- | --- |
| Windows | `winget upgrade --name <n>` then `--id <n>` fallback. Optional `--version` pin if supplied. Falls back through silently if winget is absent. | `winget uninstall --name <n>` then `wmic product ... call uninstall /nointeractive` fallback. Optional `--version` pin if supplied. | Implementation already present for uninstall; update is new. |
| macOS (third-party) | `brew upgrade --cask <n>` then `brew upgrade <n>` (formula). | `brew uninstall --cask <n>` then `brew uninstall <n>`; falls back to `RemoveAll(/Applications/<n>.app)` when the app was installed outside brew. | Path validation refuses traversal / symlinks. |
| macOS (Apple-published) | Buttons disabled. Tooltip: *Apple-signed apps are managed by macOS — uninstall via Settings, update via Software Update.* | Same. | The agent has no clean way to address App Store / OS components; we'd just queue a guaranteed no-op. |
| Linux | `apt-get install --only-upgrade -y <n>`, `dnf upgrade -y <n>`, `yum update -y <n>`, `zypper update -y <n>`, `pacman -S --noconfirm <n>` in order. | `apt-get remove -y <n>`, `dnf remove -y <n>`, etc. | Both paths refuse to act on a protected-package allowlist (`systemd`, `glibc`, `kernel-*`, `linux-image-*`, `grub*`, `openssl`, `openssh-*`, etc.) via `isProtectedLinuxPackage`. |
| Unknown / other | Buttons disabled. | Same. | Tooltip names the OS. |

The agent gracefully maps *"no available upgrade" / "already up to date" / "is already the newest version" / "nothing to do" / "no packages marked for update"* to success — the package is at the requested version, which is what the user asked for.

## Server side

- New file `apps/api/src/routes/devices/softwareActions.ts` with two routes:
  - `POST /devices/:id/software/update`
  - `POST /devices/:id/software/uninstall`
- Both require `scope=organization|partner|system`, `devices.execute` permission, satisfied MFA, and run through `getDeviceWithOrgCheck` for tenant isolation. Decommissioned devices are rejected with 400.
- Payload schema mirrors the agent's `validateSoftwareName` / `validateSoftwareVersion` (name max 200, version max 100, no leading dash, no traversal sequence, no shell metachars). This keeps requests the API accepts from bouncing back from the agent with a generic validator error.
- `SOFTWARE_UPDATE` added to `services/commandQueue.ts` `CommandTypes` and `AUDITED_COMMANDS`. `SOFTWARE_UNINSTALL` was already there.
- Routes mounted in `routes/devices/index.ts` ahead of `softwareRoutes` (same convention as `queryRoutes` / `softwareDistinctRoutes` for static-path-before-`/:id` ordering, even though HTTP verbs differ).

## Agent side

- New constant `tools.CmdSoftwareUpdate = "software_update"` in `internal/remote/tools/types.go`.
- New `tools.UpdateSoftware` in `internal/remote/tools/software_update.go` with per-OS package-manager shims (Windows winget, macOS brew, Linux apt-get/dnf/yum/zypper/pacman).
- Linux update reuses the existing `isProtectedLinuxPackage` guard from `software.go` — same allowlist that protects kernel/glibc/systemd/grub/openssl/etc. against uninstall.
- Handler registered in `internal/heartbeat/handlers.go`, alongside `handleSoftwareUninstall`. `software_uninstall` was already wired end-to-end; this PR adds the symmetric update path.

## Web side

- `DeviceSoftwareInventory.tsx` gains an Actions column with per-row Update + Uninstall buttons. Update queues directly via `runAction` (success/error toast always surfaced). Uninstall opens a confirm dialog before queueing.
- Apple-published rows on macOS have both buttons disabled with an explanatory tooltip.
- Per-row pending state shows an inline spinner on the active button and disables the other action on the same row, so the user can't double-fire on one row but can still act on other rows.
- Added to `TARGET_GLOBS` in `no-silent-mutations.test.ts` to guard against future silent-failure regressions (count bumped from 3 to 4).

## Security considerations

- Uninstall is destructive: it requires an explicit modal confirmation. Update queues directly.
- Both routes require `requireMfa()`, in line with the other destructive `devices.execute` actions (patch install, script execution).
- Linux protected-package guard refuses to touch `systemd`, `glibc`, `kernel-*`, `linux-image-*`, `grub*`, `openssl`, `openssh-*`, package managers themselves, etc. Same allowlist that protected uninstall already.
- Payload validation runs on both API (Zod) and agent (Go) sides with identical rules so the more-restrictive layer is the floor, not a gap.
- All actions write a `device.software.{update,uninstall}.queue` audit row via `writeRouteAudit`, plus the agent-side audit emitted by `queueCommand`'s `AUDITED_COMMANDS` path.

## Test plan

- [x] **API**: 11 vitest cases in `softwareActions.test.ts` covering happy path for both verbs, 404 for missing device, 400 for decommissioned, 403 for MFA gate failure, 403 for `devices.execute` permission deny, 403 for site-restricted access, 503 when queue fails, payload validation rejection of shell metachars / leading dash in name, version pass-through, and audit-call invocation.
- [x] **Web**: 6 vitest cases in `DeviceSoftwareInventory.test.tsx` covering button render-state per OS, Apple-row disabled on macOS, update success path with correct POST body, uninstall confirm-dialog flow, error toast on 503, and Cancel-closes-dialog-without-POST.
- [x] **Agent**: 5 Go test cases in `software_update_test.go` covering blank-name rejection, shell-meta rejection, leading-dash rejection, Linux protected-package guard, and unsafe-version rejection.
- [x] **Existing tests still pass**: the agent `TestHandlerRegistryCompleteness` and `TestHandlerRegistryNoExtraEntries` guard tests both pass with the new command type added.
- [x] **TypeScript**: `pnpm exec tsc --noEmit` clean for both `apps/api` and `apps/web` (pre-existing `filters.ts` errors unchanged).
- [ ] Smoke test against a live agent (deferred to maintainer's environment): queue Update for a known third-party app on a Windows endpoint, confirm `winget upgrade` runs and the command result returns "completed".
- [ ] Smoke test on macOS: queue Uninstall for a brew cask, confirm `brew uninstall --cask` runs.
- [ ] Smoke test on Linux: queue Update for a non-protected package, confirm `apt-get install --only-upgrade` runs.