### PR TITLE
feat(monitoring): anomaly alerting for failed logins, enrollments, command dispatch

### DIFF
--- a/apps/api/src/routes/agents/enrollment.ts
+++ b/apps/api/src/routes/agents/enrollment.ts
@@ -19,6 +19,7 @@ import { getRedis } from '../../services/redis';
 import { rateLimiter } from '../../services/rate-limit';
 import { enrollSchema } from './schemas';
 import { generateAgentId, generateApiKey, issueMtlsCertForDevice } from './helpers';
+import { recordAgentEnrollment } from '../../services/anomalyMetrics';
 import { queueWarrantySyncForDevice } from '../../services/warrantyWorker';
 import { dispatchHook } from '../../services/partnerHooks';
 import { matchDeploymentInviteOnEnrollment } from '../../modules/mcpInvites/matchInviteOnEnrollment';
@@ -80,6 +81,7 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
     ENROLLMENT_RATE_WINDOW_SECONDS
   );
   if (!rateCheck.allowed) {
+    recordAgentEnrollment('denied');
     c.header('Retry-After', String(Math.ceil((rateCheck.resetAt.getTime() - Date.now()) / 1000)));
     writeAuditEvent(c, {
       orgId: null,
@@ -308,6 +310,9 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
       .from(organizations)
       .where(eq(organizations.id, key.orgId))
       .limit(1);
+
+    // Captured for the success-path anomaly counter (enrollment rate by partner).
+    const enrollmentPartnerId = org?.partnerId ?? null;
 
     if (org) {
       const [partner] = await db
@@ -689,6 +694,8 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
     }
 
     const mtlsCert = await issueMtlsCertForDevice(device.id, key.orgId);
+
+    recordAgentEnrollment('success', enrollmentPartnerId);
 
     writeAuditEvent(c, {
       orgId: key.orgId,

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -12,6 +12,7 @@ import {
   verifyPassword
 } from '../../services';
 import { createAuditLogAsync } from '../../services/auditService';
+import { recordFailedLogin } from '../../services/anomalyMetrics';
 import type { RequestLike } from '../../services/auditEvents';
 import { createHash, randomBytes, timingSafeEqual } from 'crypto';
 import {
@@ -562,6 +563,8 @@ export async function auditUserLoginFailure(
   }
 ): Promise<void> {
   const orgId = await resolveUserAuditOrgId(opts.userId);
+
+  recordFailedLogin(opts.reason, orgId);
 
   writeAuthAudit(c, {
     orgId: orgId ?? undefined,

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -29,6 +29,7 @@ import { getEmailService } from '../../services/email';
 import { createHash } from 'crypto';
 import { authMiddleware } from '../../middleware/auth';
 import { createAuditLogAsync } from '../../services/auditService';
+import { recordFailedLogin } from '../../services/anomalyMetrics';
 import { TenantInactiveError } from '../../services/tenantStatus';
 import { nanoid } from 'nanoid';
 import { ENABLE_2FA, loginSchema } from './schemas';
@@ -206,6 +207,7 @@ loginRoutes.post('/login', zValidator('json', loginSchema), async (c) => {
     const ipRateKey = `login:ip:${ip}`;
     const ipRateCheck = await rateLimiter(redis, ipRateKey, 10, 5 * 60);
     if (!ipRateCheck.allowed) {
+      recordFailedLogin('rate_limited_ip');
       // Task 11: floor rate-limit responses too. Without this, the
       // attacker can detect whether they've crossed the per-IP bucket
       // (cheap rate-limit 429, ~5ms) vs the per-(IP,email) bucket
@@ -222,6 +224,7 @@ loginRoutes.post('/login', zValidator('json', loginSchema), async (c) => {
     const rateCheck = await rateLimiter(redis, rateKey, loginLimiter.limit, loginLimiter.windowSeconds);
 
     if (!rateCheck.allowed) {
+      recordFailedLogin('rate_limited_account');
       await floorPromise;
       return c.json({
         error: 'Too many login attempts. Please try again later.',

--- a/apps/api/src/routes/metrics.test.ts
+++ b/apps/api/src/routes/metrics.test.ts
@@ -274,4 +274,80 @@ describe('metrics routes', () => {
     );
     expect(body.backup_operations.low_readiness_devices).toBe(3);
   });
+
+  it('records anomaly counters with tenant attribution (non-production)', async () => {
+    // metricsRoutes is already imported in beforeEach, which registers the
+    // anomaly recorder; importing anomalyMetrics after that resolves to the
+    // same module instance under the current resetModules state.
+    const anomaly = await import('../services/anomalyMetrics');
+    anomaly.recordFailedLogin('invalid_password', 'org-1');
+    anomaly.recordFailedLogin('invalid_password', 'org-1');
+    anomaly.recordFailedLogin('rate_limited_ip');
+    anomaly.recordAgentEnrollment('success', 'partner-1');
+    anomaly.recordAgentEnrollment('denied');
+    anomaly.recordCommandDispatch('reboot', 'user', 'org-1');
+    anomaly.recordCommandDispatch('script', 'system');
+
+    const res = await app.request('/metrics', {
+      headers: { Authorization: 'Bearer token' }
+    });
+    const body = await res.text();
+
+    expect(
+      getMetricLine(body, 'breeze_failed_logins_total', { reason: 'invalid_password', tenant: 'org-1' })?.endsWith(' 2')
+    ).toBe(true);
+    // No tenant id supplied → 'unknown' (not redacted) outside production.
+    expect(
+      getMetricLine(body, 'breeze_failed_logins_total', { reason: 'rate_limited_ip', tenant: 'unknown' })?.endsWith(' 1')
+    ).toBe(true);
+    expect(
+      getMetricLine(body, 'breeze_agent_enrollments_total', { result: 'success', tenant: 'partner-1' })?.endsWith(' 1')
+    ).toBe(true);
+    expect(
+      getMetricLine(body, 'breeze_agent_enrollments_total', { result: 'denied', tenant: 'unknown' })?.endsWith(' 1')
+    ).toBe(true);
+    expect(
+      getMetricLine(body, 'breeze_commands_dispatched_total', { type: 'reboot', actor: 'user', tenant: 'org-1' })?.endsWith(' 1')
+    ).toBe(true);
+    expect(
+      getMetricLine(body, 'breeze_commands_dispatched_total', { type: 'script', actor: 'system', tenant: 'unknown' })?.endsWith(' 1')
+    ).toBe(true);
+  });
+
+  it('redacts the tenant label on anomaly counters in production', async () => {
+    const prevNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    process.env.METRICS_SCRAPE_TOKEN = 'test-scrape-token';
+    vi.resetModules();
+    try {
+      const metricsModule = await import('./metrics');
+      const anomaly = await import('../services/anomalyMetrics');
+      anomaly.recordFailedLogin('invalid_password', 'org-secret');
+      anomaly.recordAgentEnrollment('success', 'partner-secret');
+      anomaly.recordCommandDispatch('reboot', 'user', 'org-secret');
+
+      const prodApp = new Hono();
+      prodApp.route('/', metricsModule.metricsRoutes);
+      const res = await prodApp.request('/scrape', {
+        headers: { Authorization: 'Bearer test-scrape-token' }
+      });
+      const body = await res.text();
+
+      // Tenant ids must not leak into Prometheus labels in production.
+      expect(body).not.toContain('org-secret');
+      expect(body).not.toContain('partner-secret');
+      expect(
+        getMetricLine(body, 'breeze_failed_logins_total', { reason: 'invalid_password', tenant: 'redacted' })?.endsWith(' 1')
+      ).toBe(true);
+      expect(
+        getMetricLine(body, 'breeze_agent_enrollments_total', { result: 'success', tenant: 'redacted' })?.endsWith(' 1')
+      ).toBe(true);
+      expect(
+        getMetricLine(body, 'breeze_commands_dispatched_total', { type: 'reboot', actor: 'user', tenant: 'redacted' })?.endsWith(' 1')
+      ).toBe(true);
+    } finally {
+      process.env.NODE_ENV = prevNodeEnv;
+      vi.resetModules();
+    }
+  });
 });

--- a/apps/api/src/routes/metrics.ts
+++ b/apps/api/src/routes/metrics.ts
@@ -28,6 +28,7 @@ import {
   getS1MetricsSnapshot,
   setS1MetricsRecorder
 } from '../services/sentinelOne/metrics';
+import { setAnomalyMetricsRecorder } from '../services/anomalyMetrics';
 
 export {
   recordBackupCommandTimeout,
@@ -240,6 +241,32 @@ const s1ActionPollTransitionsTotal = new Counter({
   registers: [register]
 });
 
+// Anomaly-detection signals (launch-readiness CRITICAL #5). The `tenant` label
+// carries a partner identifier so a single noisy/attacked partner doesn't mask
+// the rest of the fleet, but it is redacted in production by default (same policy
+// as `org_id` on http_requests_total) so Prometheus never persists a tenant
+// identifier unless the operator opts in via METRICS_INCLUDE_ORG_ID.
+const failedLoginsTotal = new Counter({
+  name: 'breeze_failed_logins_total',
+  help: 'Failed login attempts by reason and tenant',
+  labelNames: ['reason', 'tenant'] as const,
+  registers: [register]
+});
+
+const agentEnrollmentsTotal = new Counter({
+  name: 'breeze_agent_enrollments_total',
+  help: 'Agent enrollment attempts by result and tenant (partner)',
+  labelNames: ['result', 'tenant'] as const,
+  registers: [register]
+});
+
+const commandsDispatchedTotal = new Counter({
+  name: 'breeze_commands_dispatched_total',
+  help: 'Commands dispatched to agents by type, actor kind, and tenant',
+  labelNames: ['type', 'actor', 'tenant'] as const,
+  registers: [register]
+});
+
 const processStartTimeGauge = new Gauge({
   name: 'process_start_time_seconds',
   help: 'Start time of the process since unix epoch in seconds',
@@ -274,6 +301,9 @@ softwareRemediationDecisionsTotal.labels('queued').inc(0);
 s1SyncRunsTotal.labels('sync-integration', 'success').inc(0);
 s1ActionDispatchTotal.labels('isolate', 'accepted').inc(0);
 s1ActionPollTransitionsTotal.labels('queued').inc(0);
+failedLoginsTotal.labels('invalid_password', 'redacted').inc(0);
+agentEnrollmentsTotal.labels('success', 'redacted').inc(0);
+commandsDispatchedTotal.labels('script', 'user', 'redacted').inc(0);
 nodejsVersionInfoGauge.labels(process.version).set(1);
 
 interface CounterValue {
@@ -387,6 +417,35 @@ export function updateBusinessMetrics(metrics: {
 export function recordCommand(type = 'script'): void {
   commandsTotalCounter.labels(type).inc();
   commandsTotal += 1;
+}
+
+// Resolve the `tenant` label for anomaly counters. Redacted in production by
+// default (METRICS_INCLUDE_ORG_ID) so a partner identifier never lands in
+// Prometheus unless explicitly enabled. `null`/`undefined` becomes 'unknown'
+// so an unattributable event is still counted rather than dropped.
+function tenantLabel(id: string | null | undefined): string {
+  if (!METRICS_INCLUDE_ORG_ID) return 'redacted';
+  const trimmed = id?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : 'unknown';
+}
+
+function recordFailedLoginMetric(reason: string, tenantId?: string | null): void {
+  failedLoginsTotal.labels(normalizeMetricLabel(reason, 'unknown'), tenantLabel(tenantId)).inc();
+}
+
+function recordAgentEnrollmentMetric(
+  result: 'success' | 'denied' | 'error',
+  partnerId?: string | null
+): void {
+  agentEnrollmentsTotal.labels(result, tenantLabel(partnerId)).inc();
+}
+
+function recordCommandDispatchMetric(
+  type: string,
+  actor: 'user' | 'system',
+  orgId?: string | null
+): void {
+  commandsDispatchedTotal.labels(normalizeMetricLabel(type, 'unknown'), actor, tenantLabel(orgId)).inc();
 }
 
 export function recordAlert(severity = 'info'): void {
@@ -552,6 +611,12 @@ setBackupMetricsRecorder({
   onCommandTimeout: recordBackupCommandTimeoutMetric,
   onVerificationResult: recordBackupVerificationResultMetric,
   onLowReadinessDevices: setLowReadinessDevicesMetric,
+});
+
+setAnomalyMetricsRecorder({
+  onFailedLogin: recordFailedLoginMetric,
+  onAgentEnrollment: recordAgentEnrollmentMetric,
+  onCommandDispatch: recordCommandDispatchMetric,
 });
 
 async function refreshBackupOperationalGauges(): Promise<void> {

--- a/apps/api/src/services/anomalyMetrics.ts
+++ b/apps/api/src/services/anomalyMetrics.ts
@@ -1,0 +1,47 @@
+// Thin indirection so request-path / service code can emit anomaly-detection
+// signals (launch-readiness CRITICAL #5) without importing `routes/metrics`,
+// which pulls in the whole metrics + backup-verification graph and would close
+// an import cycle (metrics → backup/verificationService → commandQueue →
+// metrics). `routes/metrics` registers the real recorder at startup via
+// `setAnomalyMetricsRecorder`; until then these are no-ops.
+
+type AnomalyMetricsRecorder = {
+  onFailedLogin: (reason: string, tenantId?: string | null) => void;
+  onAgentEnrollment: (result: 'success' | 'denied' | 'error', partnerId?: string | null) => void;
+  onCommandDispatch: (type: string, actor: 'user' | 'system', orgId?: string | null) => void;
+};
+
+const noop = () => {};
+
+let recorder: AnomalyMetricsRecorder = {
+  onFailedLogin: noop,
+  onAgentEnrollment: noop,
+  onCommandDispatch: noop,
+};
+
+export function setAnomalyMetricsRecorder(next: Partial<AnomalyMetricsRecorder> | null | undefined): void {
+  recorder = {
+    onFailedLogin: next?.onFailedLogin ?? noop,
+    onAgentEnrollment: next?.onAgentEnrollment ?? noop,
+    onCommandDispatch: next?.onCommandDispatch ?? noop,
+  };
+}
+
+export function recordFailedLogin(reason: string, tenantId?: string | null): void {
+  recorder.onFailedLogin(reason, tenantId);
+}
+
+export function recordAgentEnrollment(
+  result: 'success' | 'denied' | 'error',
+  partnerId?: string | null
+): void {
+  recorder.onAgentEnrollment(result, partnerId);
+}
+
+export function recordCommandDispatch(
+  type: string,
+  actor: 'user' | 'system',
+  orgId?: string | null
+): void {
+  recorder.onCommandDispatch(type, actor, orgId);
+}

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -9,6 +9,7 @@ import {
   releaseClaimedCommandDelivery,
 } from './commandDispatch';
 import { commandAuditDetails } from './commandAudit';
+import { recordCommandDispatch } from './anomalyMetrics';
 
 // Sentinel error string for the WS-pre-check fast-fail path. The fileBrowser
 // route (and any other interactive caller) matches on this substring to map
@@ -351,6 +352,16 @@ export async function queueCommand(
   // by RLS and the audit block would silently no-op before ever reaching
   // the insert. `runOutsideDbContext` escapes any caller tx so a failed
   // audit can't poison the caller's transaction.
+  // Anomaly signal (launch-readiness #5): count every dispatch so a command
+  // flood is visible regardless of command type. Tenant attribution happens
+  // in the audited block below (where the device's org is already loaded) to
+  // avoid adding a devices lookup to the dispatch hot path. Non-audited
+  // dispatches are still counted, just with an unattributed tenant label.
+  const dispatchActor: 'user' | 'system' = userId ? 'user' : 'system';
+  if (!AUDITED_COMMANDS.has(type)) {
+    recordCommandDispatch(type, dispatchActor);
+  }
+
   if (command && AUDITED_COMMANDS.has(type)) {
     const commandId = command.id;
     runOutsideDbContext(() =>
@@ -362,8 +373,11 @@ export async function queueCommand(
           .limit(1);
 
         if (!device) {
+          recordCommandDispatch(type, dispatchActor);
           return;
         }
+
+        recordCommandDispatch(type, dispatchActor, device.orgId);
 
         await db.insert(auditLogs).values({
           orgId: device.orgId,

--- a/monitoring/rules/breeze-rules.yml
+++ b/monitoring/rules/breeze-rules.yml
@@ -169,6 +169,47 @@ groups:
           summary: "Scheduled backup verification runs are being skipped"
           description: "{{ $value }} scheduled verification skip(s) occurred in the last hour"
 
+  # Anomaly-detection alerts (launch-readiness CRITICAL #5). Thresholds are
+  # deliberately coarse starting points — tune after observing real baselines
+  # in production. The `tenant` label is redacted unless METRICS_INCLUDE_ORG_ID
+  # is enabled, so the `by (tenant)` breakdown collapses to a single series in
+  # the default (redacted) configuration and these still fire on aggregate.
+  - name: breeze-anomaly-alerts
+    interval: 1m
+    rules:
+      - alert: FailedLoginSpike
+        expr: |
+          sum(increase(breeze_failed_logins_total{job="breeze-api"}[5m])) by (tenant) > 50
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Elevated failed-login rate (possible credential stuffing)"
+          description: "{{ $value }} failed logins in 5m for tenant {{ $labels.tenant }} — investigate for credential stuffing / brute force"
+          runbook_url: "https://docs.breeze.local/runbooks/failed-login-spike"
+
+      - alert: EnrollmentSpike
+        expr: |
+          sum(increase(breeze_agent_enrollments_total{job="breeze-api"}[10m])) by (tenant) > 100
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Unusual agent-enrollment rate"
+          description: "{{ $value }} enrollment attempts in 10m for tenant {{ $labels.tenant }} — verify this matches an expected rollout, not a leaked enrollment key"
+          runbook_url: "https://docs.breeze.local/runbooks/enrollment-spike"
+
+      - alert: CommandDispatchSpike
+        expr: |
+          sum(increase(breeze_commands_dispatched_total{job="breeze-api"}[5m])) by (tenant) > 200
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Unusual command-dispatch rate"
+          description: "{{ $value }} commands dispatched in 5m for tenant {{ $labels.tenant }} — possible compromised account fanning out commands"
+          runbook_url: "https://docs.breeze.local/runbooks/command-dispatch-spike"
+
   - name: breeze-recording-rules
     interval: 30s
     rules:
@@ -222,3 +263,12 @@ groups:
           rate(pg_stat_statements_seconds_total[5m])
           /
           rate(pg_stat_statements_calls_total[5m])
+
+      - record: breeze:failed_logins:increase5m
+        expr: sum(increase(breeze_failed_logins_total{job="breeze-api"}[5m])) by (reason, tenant)
+
+      - record: breeze:agent_enrollments:increase10m
+        expr: sum(increase(breeze_agent_enrollments_total{job="breeze-api"}[10m])) by (result, tenant)
+
+      - record: breeze:commands_dispatched:increase5m
+        expr: sum(increase(breeze_commands_dispatched_total{job="breeze-api"}[5m])) by (type, actor, tenant)


### PR DESCRIPTION
## Summary

Closes launch-readiness CRITICAL #5 (the last purely-code item before Tier 1, per `internal/2026-05-24-launch-readiness-consultant-verdict.md`). Adds three Prometheus counters with prod-redacted tenant labels plus the alert + recording rules that fire on them.

| Signal | Counter | Wired at |
|--------|---------|----------|
| Failed logins | `breeze_failed_logins_total{reason,tenant}` | `auditUserLoginFailure` (password failures) + both login rate-limit branches (credential stuffing) |
| Enrollments | `breeze_agent_enrollments_total{result,tenant}` | success path (partner-attributed) + enrollment rate-limit denial |
| Command dispatch | `breeze_commands_dispatched_total{type,actor,tenant}` | every `queueCommand`; tenant attributed for audited commands without adding a hot-path lookup |

New Prometheus rules in `monitoring/rules/breeze-rules.yml`: `FailedLoginSpike`, `EnrollmentSpike`, `CommandDispatchSpike` alerts + three matching recording rules.

## Design notes

- **Tenant labels are prod-redacted by default** — they reuse the existing `METRICS_INCLUDE_ORG_ID` policy, so no partner/org identifier lands in Prometheus unless an operator opts in. Alerts still fire on aggregate when redacted.
- **Import-cycle avoidance:** signals route through a new thin `services/anomalyMetrics.ts` recorder (mirrors the existing `backupMetrics` pattern) so request/service code never imports `routes/metrics`. A direct import closed a `metrics → backup/verificationService → commandQueue → metrics` cycle and broke `auth.test.ts`; the recorder breaks it.
- **Thresholds are coarse starting points** (50 logins/5m, 100 enrollments/10m, 200 commands/5m) per the verdict's "start coarse, tighten later." Tune against real baselines once scraping in prod.

## Test plan

- [x] `promtool check rules` — 33 rules OK (incl. new `breeze-anomaly-alerts` group)
- [x] `tsc --noEmit` clean (no new errors)
- [x] 68 metrics + auth tests pass (incl. 2 new: tenant attribution + prod-redaction)
- [x] 197 commandQueue + agents tests pass
- [ ] Confirm rules deploy to the Prometheus/Alertmanager that's already paging (ops, #3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)