### PR TITLE
fix: ensure UTF-8 in terminal and process output

### DIFF
--- a/agent/internal/executor/executor.go
+++ b/agent/internal/executor/executor.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/breeze-rmm/agent/internal/config"
 	"github.com/breeze-rmm/agent/internal/logging"
+	"github.com/breeze-rmm/agent/internal/procoutput"
 	"github.com/breeze-rmm/agent/internal/privilege"
 )
 
@@ -161,7 +162,12 @@ func (e *Executor) Execute(script ScriptExecution) (*ScriptResult, error) {
 		return result, err
 	}
 
-	args := append(shellArgs, scriptPath)
+	var args []string
+	if runtime.GOOS == "windows" {
+		shellCmd, args = procoutput.WindowsScriptCommand(shellCmd, shellArgs, scriptPath)
+	} else {
+		args = append(shellArgs, scriptPath)
+	}
 	cmd := exec.CommandContext(ctx, shellCmd, args...)
 
 	// Set working directory
@@ -173,7 +179,7 @@ func (e *Executor) Execute(script ScriptExecution) (*ScriptResult, error) {
 	cmd.Stderr = &limitedWriter{buf: &stderr, limit: MaxOutputSize}
 
 	// Configure environment
-	cmd.Env = e.buildEnvironment(script)
+	cmd.Env = procoutput.ApplyEnv(e.buildEnvironment(script))
 
 	// Set process group so children are killed on timeout
 	setProcessGroup(cmd)
@@ -225,8 +231,8 @@ func (e *Executor) Execute(script ScriptExecution) (*ScriptResult, error) {
 	e.mu.Unlock()
 
 	// Process results
-	result.Stdout = stdout.String()
-	result.Stderr = stderr.String()
+	result.Stdout = procoutput.BytesToUTF8(stdout.Bytes())
+	result.Stderr = procoutput.BytesToUTF8(stderr.Bytes())
 	result.CompletedAt = time.Now().UTC().Format(time.RFC3339)
 
 	// Record truncation in both a structured field and human-readable notice

--- a/agent/internal/executor/executor_test.go
+++ b/agent/internal/executor/executor_test.go
@@ -132,6 +132,26 @@ func TestBuildEnvironmentIncludesBreezeMetadataAndParameters(t *testing.T) {
 	}
 }
 
+func TestExecuteCapturesAccentedUTF8Output(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash accent test runs on Unix")
+	}
+
+	e := newTestExecutor()
+	result, err := e.Execute(ScriptExecution{
+		ID:         "exec-accent",
+		ScriptID:   "script-accent",
+		ScriptType: ScriptTypeBash,
+		Script:     "printf 'café\\n'",
+	})
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if result.Stdout != "café\n" {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, "café\n")
+	}
+}
+
 func TestConfigureRunAsSystemNoOp(t *testing.T) {
 	e := newTestExecutor()
 	cmd := exec.Command("echo", "hello")

--- a/agent/internal/procoutput/codepage.go
+++ b/agent/internal/procoutput/codepage.go
@@ -1,0 +1,82 @@
+package procoutput
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/text/encoding/charmap"
+)
+
+// charmapForCodePage maps a Windows code page identifier to a charmap decoder.
+// Unmapped code pages return nil; callers must fall back to ToValidUTF8 rather
+// than guessing a Western European encoding.
+func charmapForCodePage(cp uint32) *charmap.Charmap {
+	switch cp {
+	case 437:
+		return charmap.CodePage437
+	case 850:
+		return charmap.CodePage850
+	case 852:
+		return charmap.CodePage852
+	case 855:
+		return charmap.CodePage855
+	case 858:
+		return charmap.CodePage858
+	case 860:
+		return charmap.CodePage860
+	case 862:
+		return charmap.CodePage862
+	case 863:
+		return charmap.CodePage863
+	case 865:
+		return charmap.CodePage865
+	case 866:
+		return charmap.CodePage866
+	case 874:
+		return charmap.Windows874
+	case 1250:
+		return charmap.Windows1250
+	case 1251:
+		return charmap.Windows1251
+	case 1252:
+		return charmap.Windows1252
+	case 1253:
+		return charmap.Windows1253
+	case 1254:
+		return charmap.Windows1254
+	case 1255:
+		return charmap.Windows1255
+	case 1256:
+		return charmap.Windows1256
+	case 1257:
+		return charmap.Windows1257
+	case 1258:
+		return charmap.Windows1258
+	default:
+		return nil
+	}
+}
+
+// decodeFromWindowsCodePage transcodes bytes using an explicit Windows code page.
+// Used by the Windows runtime path and by unit tests on all platforms.
+func decodeFromWindowsCodePage(b []byte, cp uint32) (string, bool) {
+	if cp == 65001 {
+		return "", false
+	}
+	enc := charmapForCodePage(cp)
+	if enc == nil {
+		return "", false
+	}
+	return transcode(b, enc)
+}
+
+func transcode(b []byte, enc *charmap.Charmap) (string, bool) {
+	if enc == nil {
+		return "", false
+	}
+	decoded, err := enc.NewDecoder().Bytes(b)
+	if err != nil || !utf8.Valid(decoded) {
+		return "", false
+	}
+	return strings.TrimRight(string(decoded), "\x00"), true
+}

--- a/agent/internal/procoutput/encoding.go
+++ b/agent/internal/procoutput/encoding.go
@@ -13,6 +13,10 @@ func BytesToUTF8(b []byte) string {
 	if len(b) == 0 {
 		return ""
 	}
+	// When bytes are already valid UTF-8, passthrough even though some Windows
+	// code pages (e.g. CP1252) can produce byte sequences that happen to decode
+	// as valid UTF-8. Transcoding speculatively without a reliable locale hint
+	// would corrupt genuinely UTF-8 output, so passthrough is the safer trade-off.
 	if utf8.Valid(b) {
 		return string(b)
 	}

--- a/agent/internal/procoutput/encoding.go
+++ b/agent/internal/procoutput/encoding.go
@@ -1,0 +1,23 @@
+package procoutput
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// BytesToUTF8 converts captured process stdout/stderr bytes into a valid UTF-8
+// string suitable for JSON marshaling and web UI display. Valid UTF-8 input is
+// returned unchanged; on Windows, non-UTF-8 bytes are transcoded from the
+// active console code page when possible.
+func BytesToUTF8(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	if utf8.Valid(b) {
+		return string(b)
+	}
+	if decoded, ok := decodeWindowsConsoleBytes(b); ok {
+		return decoded
+	}
+	return strings.ToValidUTF8(string(b), "\uFFFD")
+}

--- a/agent/internal/procoutput/encoding_other.go
+++ b/agent/internal/procoutput/encoding_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package procoutput
+
+func decodeWindowsConsoleBytes(_ []byte) (string, bool) {
+	return "", false
+}

--- a/agent/internal/procoutput/encoding_test.go
+++ b/agent/internal/procoutput/encoding_test.go
@@ -1,0 +1,132 @@
+package procoutput
+
+import (
+	"encoding/json"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestBytesToUTF8Empty(t *testing.T) {
+	if got := BytesToUTF8(nil); got != "" {
+		t.Fatalf("expected empty string, got %q", got)
+	}
+	if got := BytesToUTF8([]byte{}); got != "" {
+		t.Fatalf("expected empty string, got %q", got)
+	}
+}
+
+func TestBytesToUTF8ValidUTF8Passthrough(t *testing.T) {
+	input := []byte("café résumé naïve 日本語 привет")
+	got := BytesToUTF8(input)
+	if got != string(input) {
+		t.Fatalf("expected passthrough, got %q want %q", got, string(input))
+	}
+
+	payload, err := json.Marshal(map[string]string{"stdout": got})
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	if string(payload) == "" {
+		t.Fatal("expected non-empty JSON payload")
+	}
+}
+
+func TestDecodeFromWindowsCodePageCP850(t *testing.T) {
+	raw := []byte{0x63, 0x61, 0x66, 0x82} // "caf" + é
+	got, ok := decodeFromWindowsCodePage(raw, 850)
+	if !ok {
+		t.Fatal("expected CP850 decode to succeed")
+	}
+	if got != "café" {
+		t.Fatalf("got %q, want %q", got, "café")
+	}
+}
+
+func TestDecodeFromWindowsCodePageCP1252(t *testing.T) {
+	raw := []byte{0x63, 0x61, 0x66, 0xE9}
+	got, ok := decodeFromWindowsCodePage(raw, 1252)
+	if !ok {
+		t.Fatal("expected CP1252 decode to succeed")
+	}
+	if got != "café" {
+		t.Fatalf("got %q, want %q", got, "café")
+	}
+}
+
+func TestDecodeFromWindowsCodePageCP866(t *testing.T) {
+	raw := []byte{0xE2, 0xA5, 0xE1, 0xE2} // "тест" in CP866
+	got, ok := decodeFromWindowsCodePage(raw, 866)
+	if !ok {
+		t.Fatal("expected CP866 decode to succeed")
+	}
+	if got != "тест" {
+		t.Fatalf("got %q, want %q", got, "тест")
+	}
+}
+
+func TestDecodeFromWindowsCodePageUnmapped(t *testing.T) {
+	raw := []byte{0x63, 0x61, 0x66, 0x82}
+	if _, ok := decodeFromWindowsCodePage(raw, 999); ok {
+		t.Fatal("expected unmapped code page to fail decoding")
+	}
+	if enc := charmapForCodePage(999); enc != nil {
+		t.Fatal("expected unmapped code page to return nil encoder")
+	}
+}
+
+func TestBytesToUTF8UnmappedCodePageFallsBackGracefully(t *testing.T) {
+	raw := []byte{0x63, 0x61, 0x66, 0x82}
+	got, ok := decodeFromWindowsCodePage(raw, 999)
+	if ok {
+		t.Fatalf("expected decode failure for unmapped CP, got %q", got)
+	}
+
+	fallback := BytesToUTF8(raw)
+	if fallback == string(raw) {
+		t.Fatal("expected invalid bytes to be sanitized on non-Windows")
+	}
+	if !strings.Contains(fallback, "\uFFFD") {
+		t.Fatalf("expected replacement character in fallback, got %q", fallback)
+	}
+}
+
+func TestBytesToUTF8InvalidBytesUseReplacementOnNonWindows(t *testing.T) {
+	raw := []byte{0xFF, 0xFE, 0xFD}
+	got := BytesToUTF8(raw)
+	if got == string(raw) {
+		t.Fatal("expected invalid bytes to be sanitized")
+	}
+}
+
+func TestWindowsScriptCommandPowerShell(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows script bootstrap is platform-specific")
+	}
+	shellCmd, args := WindowsScriptCommand("powershell.exe", []string{"-NoProfile", "-File"}, `C:\scripts\test.ps1`)
+	if shellCmd != "powershell.exe" {
+		t.Fatalf("shellCmd = %q", shellCmd)
+	}
+	if len(args) < 4 || args[0] != "-NoProfile" || args[2] != "-Command" {
+		t.Fatalf("unexpected args: %#v", args)
+	}
+	if args[len(args)-1] == "" {
+		t.Fatal("expected bootstrap command")
+	}
+}
+
+func TestWindowsScriptCommandCmd(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows script bootstrap is platform-specific")
+	}
+	shellCmd, args := WindowsScriptCommand("cmd.exe", []string{"/C"}, `C:\scripts\test.bat`)
+	if shellCmd != "cmd.exe" {
+		t.Fatalf("shellCmd = %q", shellCmd)
+	}
+	if len(args) != 2 || args[0] != "/C" {
+		t.Fatalf("unexpected args: %#v", args)
+	}
+	if args[1] != "chcp 65001 >nul & C:\\scripts\\test.bat" {
+		t.Fatalf("unexpected cmd bootstrap: %q", args[1])
+	}
+}

--- a/agent/internal/procoutput/encoding_windows.go
+++ b/agent/internal/procoutput/encoding_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package procoutput
+
+import "golang.org/x/sys/windows"
+
+func decodeWindowsConsoleBytes(b []byte) (string, bool) {
+	cp, ok := activeConsoleCodePage()
+	if !ok {
+		return "", false
+	}
+	return decodeFromWindowsCodePage(b, cp)
+}
+
+// activeConsoleCodePage returns the code page used for captured console/process
+// output. GetConsoleOutputCP reflects the active console; when unavailable (e.g.
+// piped capture with no console), GetOEMCP is used as a fallback.
+func activeConsoleCodePage() (uint32, bool) {
+	if cp, err := windows.GetConsoleOutputCP(); err == nil && cp != 0 && cp != 65001 {
+		return cp, true
+	}
+	if cp, err := windows.GetOEMCP(); err == nil && cp != 0 && cp != 65001 {
+		return cp, true
+	}
+	return 0, false
+}

--- a/agent/internal/procoutput/env.go
+++ b/agent/internal/procoutput/env.go
@@ -1,0 +1,44 @@
+package procoutput
+
+import "strings"
+
+// ApplyEnv returns a copy of base with UTF-8 locale variables appended when the
+// environment lacks them. Subprocesses spawned by the agent often inherit
+// LANG=C from systemd/LaunchDaemon and emit non-UTF-8 bytes on Windows.
+func ApplyEnv(base []string) []string {
+	if hasUTF8Locale(base) {
+		out := make([]string, len(base))
+		copy(out, base)
+		return out
+	}
+	out := append([]string{}, base...)
+	return append(out,
+		"LANG=C.UTF-8",
+		"LC_ALL=C.UTF-8",
+		"LC_CTYPE=C.UTF-8",
+	)
+}
+
+func hasUTF8Locale(env []string) bool {
+	for _, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		switch key {
+		case "LANG", "LC_ALL", "LC_CTYPE":
+			if isUTF8LocaleValue(value) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isUTF8LocaleValue(value string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	if normalized == "" || normalized == "c" || normalized == "posix" {
+		return false
+	}
+	return strings.Contains(normalized, "utf-8") || strings.Contains(normalized, "utf8")
+}

--- a/agent/internal/procoutput/env_test.go
+++ b/agent/internal/procoutput/env_test.go
@@ -1,0 +1,34 @@
+package procoutput
+
+import "testing"
+
+func TestApplyEnvAddsUTF8WhenMissing(t *testing.T) {
+	env := ApplyEnv([]string{"PATH=/bin"})
+	if !envContains(env, "LANG=C.UTF-8") {
+		t.Fatalf("expected LANG=C.UTF-8, got %v", env)
+	}
+}
+
+func TestApplyEnvPreservesExistingUTF8(t *testing.T) {
+	original := []string{"LANG=fr_FR.UTF-8", "PATH=/bin"}
+	env := ApplyEnv(original)
+	if len(env) != len(original) {
+		t.Fatalf("expected no extra vars, got %v", env)
+	}
+}
+
+func TestApplyEnvIgnoresNonUTF8Locale(t *testing.T) {
+	env := ApplyEnv([]string{"LANG=C", "LC_ALL=POSIX"})
+	if !envContains(env, "LANG=C.UTF-8") {
+		t.Fatalf("expected UTF-8 locale vars to be appended, got %v", env)
+	}
+}
+
+func envContains(env []string, want string) bool {
+	for _, entry := range env {
+		if entry == want {
+			return true
+		}
+	}
+	return false
+}

--- a/agent/internal/procoutput/shell_other.go
+++ b/agent/internal/procoutput/shell_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package procoutput
+
+// WindowsScriptCommand is a no-op on non-Windows platforms.
+func WindowsScriptCommand(shellCmd string, shellArgs []string, scriptPath string) (string, []string) {
+	return shellCmd, append(append([]string{}, shellArgs...), scriptPath)
+}

--- a/agent/internal/procoutput/shell_windows.go
+++ b/agent/internal/procoutput/shell_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package procoutput
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+const powershellUTF8Bootstrap = "[Console]::InputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; "
+
+// WindowsScriptCommand adjusts shell argv so script invocations emit UTF-8 on
+// Windows consoles before output is captured.
+func WindowsScriptCommand(shellCmd string, shellArgs []string, scriptPath string) (string, []string) {
+	switch strings.ToLower(filepath.Base(shellCmd)) {
+	case "powershell.exe", "pwsh.exe":
+		quoted := escapePowerShellSingleQuotedPath(scriptPath)
+		return shellCmd, []string{
+			"-NoProfile", "-ExecutionPolicy", "Bypass", "-Command",
+			powershellUTF8Bootstrap + "& '" + quoted + "'",
+		}
+	case "cmd.exe":
+		// GetShellCommand returns ["/C"]; run chcp before the script/batch file.
+		args := append(append([]string{}, shellArgs...), "chcp 65001 >nul & "+scriptPath)
+		return shellCmd, args
+	default:
+		return shellCmd, append(append([]string{}, shellArgs...), scriptPath)
+	}
+}
+
+func escapePowerShellSingleQuotedPath(path string) string {
+	return strings.ReplaceAll(path, "'", "''")
+}

--- a/agent/internal/remote/tools/software_install.go
+++ b/agent/internal/remote/tools/software_install.go
@@ -15,6 +15,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/breeze-rmm/agent/internal/procoutput"
 )
 
 const (
@@ -321,26 +323,28 @@ func executeInstaller(localPath, fileType, silentInstallArgs string) (int, strin
 		return 1, "", fmt.Errorf("unsupported file type %q on %s", fileType, runtime.GOOS)
 	}
 
+	cmd.Env = procoutput.ApplyEnv(os.Environ())
+
 	output, err := cmd.CombinedOutput()
 	exitCode := 0
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			exitCode = exitErr.ExitCode()
 		} else {
-			return 1, string(output), err
+			return 1, procoutput.BytesToUTF8(output), err
 		}
 	}
 
 	// MSI exit codes: 0 = success, 3010 = success pending reboot
 	if fileType == "msi" && (exitCode == 0 || exitCode == 3010) {
-		return exitCode, string(output), nil
+		return exitCode, procoutput.BytesToUTF8(output), nil
 	}
 
 	if exitCode != 0 {
-		return exitCode, string(output), fmt.Errorf("installer exited with code %d", exitCode)
+		return exitCode, procoutput.BytesToUTF8(output), fmt.Errorf("installer exited with code %d", exitCode)
 	}
 
-	return 0, string(output), nil
+	return 0, procoutput.BytesToUTF8(output), nil
 }
 
 func buildMSIExecArgs(localPath, silentInstallArgs string) []string {
@@ -377,7 +381,7 @@ func installDMG(ctx context.Context, dmgPath string) (int, string, error) {
 
 	mountCmd := exec.CommandContext(ctx, "hdiutil", "attach", dmgPath, "-mountpoint", mountPoint, "-nobrowse", "-quiet")
 	if out, err := mountCmd.CombinedOutput(); err != nil {
-		return 1, string(out), fmt.Errorf("failed to mount DMG: %w", err)
+		return 1, procoutput.BytesToUTF8(out), fmt.Errorf("failed to mount DMG: %w", err)
 	}
 	defer exec.Command("hdiutil", "detach", mountPoint, "-quiet").Run()
 
@@ -394,11 +398,11 @@ func installDMG(ctx context.Context, dmgPath string) (int, string, error) {
 					exitCode = exitErr.ExitCode()
 				}
 				if exitCode != 0 {
-					return exitCode, string(out), fmt.Errorf("pkg installer exited with code %d", exitCode)
+					return exitCode, procoutput.BytesToUTF8(out), fmt.Errorf("pkg installer exited with code %d", exitCode)
 				}
-				return 1, string(out), err
+				return 1, procoutput.BytesToUTF8(out), err
 			}
-			return 0, string(out), nil
+			return 0, procoutput.BytesToUTF8(out), nil
 		}
 	}
 
@@ -410,9 +414,9 @@ func installDMG(ctx context.Context, dmgPath string) (int, string, error) {
 			cmd := exec.CommandContext(ctx, "cp", "-R", src, dst)
 			out, err := cmd.CombinedOutput()
 			if err != nil {
-				return 1, string(out), fmt.Errorf("failed to copy app: %w", err)
+				return 1, procoutput.BytesToUTF8(out), fmt.Errorf("failed to copy app: %w", err)
 			}
-			return 0, string(out), nil
+			return 0, procoutput.BytesToUTF8(out), nil
 		}
 	}
 

--- a/agent/internal/scripts/runner.go
+++ b/agent/internal/scripts/runner.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"time"
+
+	"github.com/breeze-rmm/agent/internal/procoutput"
 )
 
 type ScriptResult struct {
@@ -56,6 +58,7 @@ func (r *ScriptRunner) Run(language, content string, timeout time.Duration) *Scr
 	defer cancel()
 
 	cmd := r.buildCommandContext(ctx, language, scriptFile)
+	cmd.Env = procoutput.ApplyEnv(os.Environ())
 
 	// Set up output capture
 	var stdout, stderr bytes.Buffer
@@ -82,8 +85,8 @@ func (r *ScriptRunner) Run(language, content string, timeout time.Duration) *Scr
 		result.ExitCode = 0
 	}
 
-	result.Stdout = stdout.String()
-	result.Stderr = stderr.String()
+	result.Stdout = procoutput.BytesToUTF8(stdout.Bytes())
+	result.Stderr = procoutput.BytesToUTF8(stderr.Bytes())
 	result.DurationMs = time.Since(start).Milliseconds()
 
 	return result
@@ -115,7 +118,8 @@ func (r *ScriptRunner) buildCommandContext(ctx context.Context, language, script
 	switch language {
 	case "powershell":
 		if runtime.GOOS == "windows" {
-			return exec.CommandContext(ctx, "powershell", "-ExecutionPolicy", "Bypass", "-File", scriptFile)
+			shellCmd, args := procoutput.WindowsScriptCommand("powershell", []string{"-ExecutionPolicy", "Bypass", "-File"}, scriptFile)
+			return exec.CommandContext(ctx, shellCmd, args...)
 		}
 		return exec.CommandContext(ctx, "pwsh", "-File", scriptFile)
 	case "bash":
@@ -123,6 +127,10 @@ func (r *ScriptRunner) buildCommandContext(ctx context.Context, language, script
 	case "python":
 		return exec.CommandContext(ctx, "python3", scriptFile)
 	case "cmd":
+		if runtime.GOOS == "windows" {
+			shellCmd, args := procoutput.WindowsScriptCommand("cmd", []string{"/c"}, scriptFile)
+			return exec.CommandContext(ctx, shellCmd, args...)
+		}
 		return exec.CommandContext(ctx, "cmd", "/c", scriptFile)
 	default:
 		return exec.CommandContext(ctx, "sh", scriptFile)

--- a/agent/internal/scripts/runner_test.go
+++ b/agent/internal/scripts/runner_test.go
@@ -386,3 +386,18 @@ func TestRunScriptWithSpecialCharacters(t *testing.T) {
 		t.Fatalf("exitCode = %d, want 0", result.ExitCode)
 	}
 }
+
+func TestRunCapturesAccentedUTF8Output(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping bash accent test on Windows")
+	}
+
+	r := NewRunner()
+	result := r.Run("bash", "printf 'résumé\\n'", 10*time.Second)
+	if result.Status != "completed" {
+		t.Fatalf("status = %q, want completed (error: %s)", result.Status, result.ErrorMsg)
+	}
+	if result.Stdout != "résumé\n" {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, "résumé\n")
+	}
+}

--- a/agent/internal/terminal/pty_darwin.go
+++ b/agent/internal/terminal/pty_darwin.go
@@ -85,8 +85,7 @@ func (s *Session) start() error {
 	if os.Getenv("SHELL") == "" {
 		env = append(env, "SHELL="+s.Shell)
 	}
-	env = append(env,
-		"TERM=xterm-256color",
+	env = applyShellEnv(env,
 		fmt.Sprintf("COLUMNS=%d", s.Cols),
 		fmt.Sprintf("LINES=%d", s.Rows),
 	)

--- a/agent/internal/terminal/pty_darwin_nocgo.go
+++ b/agent/internal/terminal/pty_darwin_nocgo.go
@@ -69,8 +69,7 @@ func (s *Session) start() error {
 	if os.Getenv("SHELL") == "" {
 		env = append(env, "SHELL="+s.Shell)
 	}
-	env = append(env,
-		"TERM=xterm-256color",
+	env = applyShellEnv(env,
 		fmt.Sprintf("COLUMNS=%d", s.Cols),
 		fmt.Sprintf("LINES=%d", s.Rows),
 	)

--- a/agent/internal/terminal/pty_test.go
+++ b/agent/internal/terminal/pty_test.go
@@ -84,6 +84,7 @@ func TestSessionStartSetsTermEnv(t *testing.T) {
 	foundTerm := false
 	foundCols := false
 	foundLines := false
+	foundLang := false
 	for _, env := range s.cmd.Env {
 		if env == "TERM=xterm-256color" {
 			foundTerm = true
@@ -94,6 +95,9 @@ func TestSessionStartSetsTermEnv(t *testing.T) {
 		if env == "LINES=50" {
 			foundLines = true
 		}
+		if env == "LANG=C.UTF-8" {
+			foundLang = true
+		}
 	}
 	if !foundTerm {
 		t.Fatal("expected TERM=xterm-256color in env")
@@ -103,6 +107,9 @@ func TestSessionStartSetsTermEnv(t *testing.T) {
 	}
 	if !foundLines {
 		t.Fatal("expected LINES=50 in env")
+	}
+	if !foundLang {
+		t.Fatal("expected LANG=C.UTF-8 in env")
 	}
 }
 

--- a/agent/internal/terminal/pty_unix.go
+++ b/agent/internal/terminal/pty_unix.go
@@ -61,8 +61,7 @@ func (s *Session) start() error {
 	if os.Getenv("SHELL") == "" {
 		env = append(env, "SHELL="+s.Shell)
 	}
-	env = append(env,
-		"TERM=xterm-256color",
+	env = applyShellEnv(env,
 		fmt.Sprintf("COLUMNS=%d", s.Cols),
 		fmt.Sprintf("LINES=%d", s.Rows),
 	)

--- a/agent/internal/terminal/pty_windows.go
+++ b/agent/internal/terminal/pty_windows.go
@@ -96,13 +96,13 @@ func (s *Session) startPipes() error {
 	var cmd *exec.Cmd
 	shellBase := strings.ToLower(filepath.Base(s.Shell))
 	if shellBase == "powershell.exe" || shellBase == "pwsh.exe" {
-		cmd = exec.Command(s.Shell, "-NoExit", "-Command",
-			"[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; "+
-				"$Host.UI.RawUI.ForegroundColor = 'Gray'")
+		cmd = exec.Command(s.Shell, "-NoExit", "-Command", powershellBootstrapCommand())
+	} else if shellBase == "cmd.exe" {
+		cmd = exec.Command(s.Shell, "/K", "chcp 65001 >nul")
 	} else {
 		cmd = exec.Command(s.Shell)
 	}
-	cmd.Env = append(os.Environ(), "TERM=xterm-256color")
+	cmd.Env = applyShellEnv(os.Environ())
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
@@ -190,8 +190,19 @@ func (s *Session) resize(cols, rows uint16) error {
 // buildCommandLine constructs the shell command line string.
 func buildCommandLine(shell string) string {
 	shellBase := strings.ToLower(filepath.Base(shell))
-	if shellBase == "powershell.exe" || shellBase == "pwsh.exe" {
-		return shell + ` -NoExit -Command "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8"`
+	switch shellBase {
+	case "powershell.exe", "pwsh.exe":
+		return shell + ` -NoExit -Command "` + powershellBootstrapCommand() + `"`
+	case "cmd.exe":
+		return shell + ` /K chcp 65001 >nul`
+	default:
+		return shell
 	}
-	return shell
+}
+
+// powershellBootstrapCommand configures UTF-8 console I/O and readable colors
+// on dark web-terminal backgrounds.
+func powershellBootstrapCommand() string {
+	return "[Console]::InputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; " +
+		"$Host.UI.RawUI.ForegroundColor = 'Gray'"
 }

--- a/agent/internal/terminal/pty_windows_test.go
+++ b/agent/internal/terminal/pty_windows_test.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package terminal
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildCommandLinePowerShellSetsUTF8(t *testing.T) {
+	got := buildCommandLine(`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`)
+	if got == `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe` {
+		t.Fatalf("expected UTF-8 bootstrap command, got bare shell: %q", got)
+	}
+	for _, part := range []string{"InputEncoding", "OutputEncoding", "UTF8"} {
+		if !strings.Contains(got, part) {
+			t.Fatalf("expected %q in command line, got %q", part, got)
+		}
+	}
+}
+
+func TestBuildCommandLineCmdSetsUTF8CodePage(t *testing.T) {
+	got := buildCommandLine(`C:\Windows\System32\cmd.exe`)
+	want := `C:\Windows\System32\cmd.exe /K chcp 65001 >nul`
+	if got != want {
+		t.Fatalf("buildCommandLine(cmd.exe) = %q, want %q", got, want)
+	}
+}

--- a/agent/internal/terminal/terminal_env.go
+++ b/agent/internal/terminal/terminal_env.go
@@ -1,0 +1,14 @@
+package terminal
+
+import (
+	"github.com/breeze-rmm/agent/internal/procoutput"
+)
+
+// applyShellEnv returns a shell environment with UTF-8 locale (when missing),
+// TERM, and any extra variables appended last.
+func applyShellEnv(base []string, extra ...string) []string {
+	env := procoutput.ApplyEnv(append([]string{}, base...))
+	env = append(env, "TERM=xterm-256color")
+	env = append(env, extra...)
+	return env
+}

--- a/agent/internal/terminal/terminal_env_test.go
+++ b/agent/internal/terminal/terminal_env_test.go
@@ -1,0 +1,50 @@
+package terminal
+
+import (
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/procoutput"
+)
+
+func TestApplyShellEnvAddsUTF8LocaleWhenMissing(t *testing.T) {
+	env := applyShellEnv([]string{"PATH=/bin", "HOME=/root"})
+	if !containsEnv(env, "LANG=C.UTF-8") {
+		t.Fatalf("expected LANG=C.UTF-8, got %v", env)
+	}
+	if !containsEnv(env, "LC_ALL=C.UTF-8") {
+		t.Fatalf("expected LC_ALL=C.UTF-8, got %v", env)
+	}
+	if !containsEnv(env, "LC_CTYPE=C.UTF-8") {
+		t.Fatalf("expected LC_CTYPE=C.UTF-8, got %v", env)
+	}
+	if !containsEnv(env, "TERM=xterm-256color") {
+		t.Fatalf("expected TERM=xterm-256color, got %v", env)
+	}
+}
+
+func TestApplyShellEnvPreservesExistingUTF8(t *testing.T) {
+	original := []string{"LANG=fr_FR.UTF-8", "LC_ALL=fr_FR.UTF-8"}
+	env := applyShellEnv(original)
+	if !containsEnv(env, "LANG=fr_FR.UTF-8") {
+		t.Fatalf("expected existing UTF-8 locale to be preserved, got %v", env)
+	}
+	if containsEnv(env, "LANG=C.UTF-8") {
+		t.Fatalf("expected LANG=C.UTF-8 not to be appended when UTF-8 locale exists, got %v", env)
+	}
+}
+
+func TestApplyEnvReplacesNonUTF8Locale(t *testing.T) {
+	env := procoutput.ApplyEnv([]string{"LANG=C", "LC_ALL=C"})
+	if !containsEnv(env, "LANG=C.UTF-8") {
+		t.Fatalf("expected LANG=C.UTF-8 to be appended, got %v", env)
+	}
+}
+
+func containsEnv(env []string, want string) bool {
+	for _, entry := range env {
+		if entry == want {
+			return true
+		}
+	}
+	return false
+}

--- a/agent/internal/userhelper/client.go
+++ b/agent/internal/userhelper/client.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/breeze-rmm/agent/internal/executor"
 	"github.com/breeze-rmm/agent/internal/helper"
+	"github.com/breeze-rmm/agent/internal/procoutput"
 	"github.com/breeze-rmm/agent/internal/ipc"
 	"github.com/breeze-rmm/agent/internal/logging"
 	"github.com/breeze-rmm/agent/internal/remote/clipboard"
@@ -777,6 +778,7 @@ func (c *Client) executeProcess(cmd ipc.IPCCommand) ipc.IPCCommandResult {
 
 	timeoutSec := getIntOrDefault(payload, "timeoutSeconds", 300)
 	proc := osexec.Command(name, args...)
+	proc.Env = procoutput.ApplyEnv(os.Environ())
 
 	var stdout, stderr bytes.Buffer
 	proc.Stdout = &stdout
@@ -801,8 +803,8 @@ func (c *Client) executeProcess(cmd ipc.IPCCommand) ipc.IPCCommandResult {
 		}
 		resultJSON, err := json.Marshal(map[string]any{
 			"exitCode": exitCode,
-			"stdout":   executor.SanitizeOutput(stdout.String()),
-			"stderr":   executor.SanitizeOutput(stderr.String()),
+			"stdout":   executor.SanitizeOutput(procoutput.BytesToUTF8(stdout.Bytes())),
+			"stderr":   executor.SanitizeOutput(procoutput.BytesToUTF8(stderr.Bytes())),
 		})
 		if err != nil {
 			return ipc.IPCCommandResult{CommandID: cmd.CommandID, Status: "failed", Error: fmt.Sprintf("marshal result: %v", err)}

--- a/agent/internal/userhelper/client_test.go
+++ b/agent/internal/userhelper/client_test.go
@@ -94,6 +94,36 @@ func TestExecuteScriptListRunningUsesSharedExecutor(t *testing.T) {
 	})
 }
 
+func TestExecuteProcessCapturesAccentedUTF8Output(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("accent capture test uses /bin/sh")
+	}
+
+	c := New("/tmp/test.sock", ipc.HelperRoleUser)
+	result := c.executeProcess(ipc.IPCCommand{
+		CommandID: "proc-accent",
+		Type:      "exec",
+		Payload: marshalPayload(t, map[string]any{
+			"command":        "/bin/sh",
+			"args":           []any{"-c", "printf 'café\\n'"},
+			"timeoutSeconds": 10,
+		}),
+	})
+	if result.Status != "completed" {
+		t.Fatalf("expected completed status, got %s (%s)", result.Status, result.Error)
+	}
+
+	var payload struct {
+		Stdout string `json:"stdout"`
+	}
+	if err := json.Unmarshal(result.Result, &payload); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if payload.Stdout != "café\n" {
+		t.Fatalf("stdout = %q, want %q", payload.Stdout, "café\n")
+	}
+}
+
 func TestAuthorizeCommandUsesHelperScopes(t *testing.T) {
 	c := New("/tmp/test.sock", ipc.HelperRoleUser)
 	c.scopes = []string{"run_as_user"}

--- a/agent/internal/websocket/client.go
+++ b/agent/internal/websocket/client.go
@@ -2,6 +2,7 @@ package websocket
 
 import (
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"math/rand/v2"
@@ -29,6 +30,8 @@ const (
 	backoffFactor  = 2.0
 	jitterFactor   = 0.3
 )
+
+const capabilityTerminalOutputBase64 = "terminal_output_base64"
 
 var terminalOutputEnqueueTimeout = 5 * time.Second
 
@@ -65,6 +68,8 @@ type Client struct {
 	tlsConfigMu     sync.RWMutex
 	conn            *websocket.Conn
 	connMu          sync.RWMutex
+	capabilitiesMu  sync.RWMutex
+	terminalOutputBase64 bool
 	cmdHandler      CommandHandler
 	done            chan struct{}
 	sendChan        chan []byte
@@ -129,6 +134,7 @@ func (c *Client) closeCurrentConn(sendClose bool) {
 	}
 	_ = c.conn.Close()
 	c.conn = nil
+	c.resetConnectionCapabilities()
 }
 
 func (c *Client) currentTLSConfig() *tls.Config {
@@ -150,6 +156,8 @@ func (c *Client) ForceReconnect() {
 }
 
 func (c *Client) connect() error {
+	c.resetConnectionCapabilities()
+
 	wsURL, err := c.buildWSURL()
 	if err != nil {
 		return fmt.Errorf("failed to build WebSocket URL: %w", err)
@@ -305,7 +313,12 @@ func (c *Client) readPump() {
 			continue
 		}
 
-		// Skip non-command messages (connected, ack, heartbeat_ack, error, etc.)
+		if msg.Type == "connected" {
+			c.handleConnectedMessage(message)
+			continue
+		}
+
+		// Skip non-command messages (ack, heartbeat_ack, error, etc.)
 		// Commands have both an ID and a type like "run_script", "list_processes", etc.
 		if msg.ID == "" {
 			// Server acknowledgments, errors, etc. - not commands
@@ -320,6 +333,42 @@ func (c *Client) readPump() {
 
 		go c.processCommand(cmd)
 	}
+}
+
+func (c *Client) handleConnectedMessage(raw []byte) {
+	var msg struct {
+		Type         string   `json:"type"`
+		Capabilities []string `json:"capabilities"`
+	}
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		log.Warn("failed to parse connected message", "error", err.Error())
+		return
+	}
+
+	enabled := false
+	for _, capability := range msg.Capabilities {
+		if capability == capabilityTerminalOutputBase64 {
+			enabled = true
+			break
+		}
+	}
+	c.setTerminalOutputBase64(enabled)
+}
+
+func (c *Client) resetConnectionCapabilities() {
+	c.setTerminalOutputBase64(false)
+}
+
+func (c *Client) setTerminalOutputBase64(enabled bool) {
+	c.capabilitiesMu.Lock()
+	c.terminalOutputBase64 = enabled
+	c.capabilitiesMu.Unlock()
+}
+
+func (c *Client) terminalOutputBase64Enabled() bool {
+	c.capabilitiesMu.RLock()
+	defer c.capabilitiesMu.RUnlock()
+	return c.terminalOutputBase64
 }
 
 func (c *Client) writePump(done <-chan struct{}, exited chan<- struct{}) {
@@ -552,12 +601,19 @@ func (c *Client) SendBackupProgress(commandID string, event any) error {
 	}
 }
 
-// SendTerminalOutput sends terminal output data to the server
+// SendTerminalOutput sends terminal output data to the server.
+// When the server advertises terminal_output_base64 in its connected handshake,
+// output is base64-encoded so non-UTF-8 console bytes are not corrupted by JSON.
 func (c *Client) SendTerminalOutput(sessionId string, data []byte) error {
 	msg := map[string]any{
 		"type":      "terminal_output",
 		"sessionId": sessionId,
-		"data":      string(data),
+	}
+	if c.terminalOutputBase64Enabled() {
+		msg["data"] = base64.StdEncoding.EncodeToString(data)
+		msg["encoding"] = "base64"
+	} else {
+		msg["data"] = string(data)
 	}
 	msgBytes, err := json.Marshal(msg)
 	if err != nil {

--- a/agent/internal/websocket/client_pump_test.go
+++ b/agent/internal/websocket/client_pump_test.go
@@ -181,6 +181,66 @@ func TestReadPump_IgnoresNonCommandMessages(t *testing.T) {
 	if handlerCalled.Load() {
 		t.Fatal("handler should not be called for non-command messages")
 	}
+	if c.terminalOutputBase64Enabled() {
+		t.Fatal("connected without capabilities should not enable terminal base64")
+	}
+}
+
+func TestReadPump_ConnectedMessageEnablesTerminalOutputBase64(t *testing.T) {
+	srv := newTestServer(t, func(conn *websocket.Conn) {
+		conn.WriteJSON(map[string]any{
+			"type":         "connected",
+			"capabilities": []string{"terminal_output_base64"},
+		})
+		time.Sleep(100 * time.Millisecond)
+		conn.Close()
+	})
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, noopHandler)
+	if err := c.connect(); err != nil {
+		t.Fatalf("connect error: %v", err)
+	}
+
+	c.readPump()
+
+	if !c.terminalOutputBase64Enabled() {
+		t.Fatal("expected terminal_output_base64 capability to be enabled")
+	}
+}
+
+func TestConnectResetsTerminalOutputBase64Capability(t *testing.T) {
+	srv := newTestServer(t, func(conn *websocket.Conn) {
+		conn.WriteJSON(map[string]any{
+			"type":         "connected",
+			"capabilities": []string{"terminal_output_base64"},
+		})
+		time.Sleep(100 * time.Millisecond)
+		conn.Close()
+	})
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, noopHandler)
+	if err := c.connect(); err != nil {
+		t.Fatalf("connect error: %v", err)
+	}
+	c.readPump()
+
+	if !c.terminalOutputBase64Enabled() {
+		t.Fatal("expected capability enabled after connected message")
+	}
+
+	c.closeCurrentConn(false)
+	if c.terminalOutputBase64Enabled() {
+		t.Fatal("expected capability reset after disconnect")
+	}
+
+	if err := c.connect(); err != nil {
+		t.Fatalf("reconnect error: %v", err)
+	}
+	if c.terminalOutputBase64Enabled() {
+		t.Fatal("expected capability reset on reconnect before connected message")
+	}
 }
 
 func TestReadPump_RespondsToServerPing(t *testing.T) {

--- a/agent/internal/websocket/client_send_test.go
+++ b/agent/internal/websocket/client_send_test.go
@@ -299,7 +299,7 @@ func TestSendBackupProgress_ChannelFull(t *testing.T) {
 
 // ---------- SendTerminalOutput ----------
 
-func TestSendTerminalOutput_Success(t *testing.T) {
+func TestSendTerminalOutput_PlainTextWhenCapabilityAbsent(t *testing.T) {
 	c := newTestClient("http://localhost", noopHandler)
 
 	err := c.SendTerminalOutput("sess-term-1", []byte("$ whoami\nroot\n"))
@@ -319,8 +319,37 @@ func TestSendTerminalOutput_Success(t *testing.T) {
 		if parsed["sessionId"] != "sess-term-1" {
 			t.Fatalf("sessionId = %v, want sess-term-1", parsed["sessionId"])
 		}
+		if _, ok := parsed["encoding"]; ok {
+			t.Fatalf("encoding = %v, want field omitted", parsed["encoding"])
+		}
 		if parsed["data"] != "$ whoami\nroot\n" {
-			t.Fatalf("data = %v, want terminal output", parsed["data"])
+			t.Fatalf("data = %v, want plain terminal output", parsed["data"])
+		}
+	default:
+		t.Fatal("expected data in sendChan")
+	}
+}
+
+func TestSendTerminalOutput_Base64WhenCapabilityEnabled(t *testing.T) {
+	c := newTestClient("http://localhost", noopHandler)
+	c.setTerminalOutputBase64(true)
+
+	err := c.SendTerminalOutput("sess-term-1", []byte("$ whoami\nroot\n"))
+	if err != nil {
+		t.Fatalf("SendTerminalOutput error: %v", err)
+	}
+
+	select {
+	case data := <-c.sendChan:
+		var parsed map[string]any
+		if err := json.Unmarshal(data, &parsed); err != nil {
+			t.Fatalf("unmarshal error: %v", err)
+		}
+		if parsed["encoding"] != "base64" {
+			t.Fatalf("encoding = %v, want base64", parsed["encoding"])
+		}
+		if parsed["data"] != "JCB3aG9hbWkKcm9vdAo=" {
+			t.Fatalf("data = %v, want base64 terminal output", parsed["data"])
 		}
 	default:
 		t.Fatal("expected data in sendChan")

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -154,6 +154,7 @@ import {
   createAgentWsHandlers,
   createAgentWsRoutes,
   __resetCrossTenantDropsForTest,
+  AGENT_WS_CAPABILITIES,
 } from './agentWs';
 import { enqueueDiscoveryResults } from '../jobs/discoveryWorker';
 import { enqueueSnmpPollResults } from '../jobs/snmpWorker';
@@ -213,6 +214,29 @@ function updateResult(rows: unknown[] = []) {
     })
   };
 }
+
+describe('agent websocket handshake', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('advertises terminal_output_base64 in the connected message', async () => {
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+
+    vi.mocked(db.update).mockReturnValue(updateResult() as any);
+    vi.mocked(db.select).mockReturnValue(selectAgentDevice([]) as any);
+
+    const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
+    const ws = wsMock();
+
+    await handlers.onOpen({}, ws as any);
+
+    expect(ws.send).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(vi.mocked(ws.send).mock.calls[0][0] as string);
+    expect(payload.type).toBe('connected');
+    expect(payload.capabilities).toEqual([...AGENT_WS_CAPABILITIES]);
+  });
+});
 
 describe('agent websocket command results', () => {
   beforeEach(() => {

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -236,6 +236,35 @@ describe('agent websocket handshake', () => {
     expect(payload.type).toBe('connected');
     expect(payload.capabilities).toEqual([...AGENT_WS_CAPABILITIES]);
   });
+
+  it('decodes base64 terminal_output and relays UTF-8 to the terminal consumer', async () => {
+    const sessionId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+
+    vi.mocked(getActiveTerminalSession).mockReturnValue({
+      agentId: 'agent-123',
+      userId: 'user-1',
+      deviceId: 'device-123',
+      startedAt: new Date(),
+      lastPongAt: Date.now(),
+      userWs: wsMock() as any,
+    } as any);
+
+    const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
+    const ws = wsMock();
+    const base64Payload = Buffer.from('café\n', 'utf8').toString('base64');
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'terminal_output',
+        sessionId,
+        data: base64Payload,
+        encoding: 'base64',
+      }),
+    } as any, ws as any);
+
+    expect(vi.mocked(handleTerminalOutput)).toHaveBeenCalledWith(sessionId, 'café\n');
+  });
 });
 
 describe('agent websocket command results', () => {

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -30,6 +30,9 @@ import { publishEvent } from '../services/eventBus';
 import { revokeViewerSession } from '../services/viewerTokenRevocation';
 import { getActiveTrustKeyset } from '../services/manifestSigning';
 
+/** Capabilities advertised to agents in the post-connect `connected` message. */
+export const AGENT_WS_CAPABILITIES = ['terminal_output_base64'] as const;
+
 declare module 'hono' {
   interface ContextVariableMap {
     agentDb: AgentDbContext;
@@ -689,8 +692,16 @@ const heartbeatMessageSchema = z.object({
 const terminalOutputSchema = z.object({
   type: z.literal('terminal_output'),
   sessionId: z.string(),
-  data: z.string()
+  data: z.string(),
+  encoding: z.enum(['base64']).optional(),
 });
+
+function decodeTerminalOutput(data: string, encoding?: 'base64'): string {
+  if (encoding === 'base64') {
+    return Buffer.from(data, 'base64').toString('utf8');
+  }
+  return data;
+}
 
 const agentMessageSchema = z.discriminatedUnion('type', [
   commandResultSchema,
@@ -1474,7 +1485,8 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
         type: 'connected',
         agentId,
         timestamp: Date.now(),
-        pendingCommands
+        pendingCommands,
+        capabilities: [...AGENT_WS_CAPABILITIES],
       }));
 
       // Start server-side ping/pong for stale connection detection
@@ -1573,14 +1585,17 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
             console.warn(`[AgentWs] Dropping malformed terminal_output from agent ${agentId}: ${parsed.error.errors[0]?.message}`);
             return;
           }
-          const { sessionId, data: termData } = parsed.data;
+          const { sessionId, data: termData, encoding } = parsed.data;
           const termSession = getActiveTerminalSession(sessionId);
           if (!termSession || termSession.agentId !== agentId) {
             console.warn(`[AgentWs] Dropping terminal_output for unowned session ${sessionId} from agent ${agentId}`);
             recordCrossTenantDrop(agentId, authenticatedAgent?.deviceId, 'terminal_output');
             return;
           }
-          handleTerminalOutput(sessionId, termData);
+          handleTerminalOutput(
+            sessionId,
+            decodeTerminalOutput(termData, encoding),
+          );
           return;
         }
 

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -696,11 +696,17 @@ const terminalOutputSchema = z.object({
   encoding: z.enum(['base64']).optional(),
 });
 
-function decodeTerminalOutput(data: string, encoding?: 'base64'): string {
-  if (encoding === 'base64') {
-    return Buffer.from(data, 'base64').toString('utf8');
+function decodeTerminalOutput(data: string, encoding?: 'base64'): string | null {
+  if (encoding !== 'base64') {
+    return data;
   }
-  return data;
+  const decoded = Buffer.from(data, 'base64');
+  const roundTrip = decoded.toString('base64');
+  const normalizeBase64 = (value: string) => value.replace(/\s/g, '').replace(/=+$/, '');
+  if (normalizeBase64(roundTrip) !== normalizeBase64(data)) {
+    return null;
+  }
+  return decoded.toString('utf8');
 }
 
 const agentMessageSchema = z.discriminatedUnion('type', [
@@ -1592,9 +1598,14 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
             recordCrossTenantDrop(agentId, authenticatedAgent?.deviceId, 'terminal_output');
             return;
           }
+          const decodedOutput = decodeTerminalOutput(termData, encoding);
+          if (decodedOutput === null) {
+            console.warn(`[AgentWs] Dropping terminal_output with invalid base64 from agent ${agentId} session ${sessionId}`);
+            return;
+          }
           handleTerminalOutput(
             sessionId,
-            decodeTerminalOutput(termData, encoding),
+            decodedOutput,
           );
           return;
         }
@@ -2101,6 +2112,7 @@ const terminalOutputFastPathSchema = z.object({
   type: z.literal('terminal_output'),
   sessionId: z.string().min(SESSION_ID_MIN).max(SESSION_ID_MAX),
   data: z.string().max(TERMINAL_OUTPUT_MAX_BYTES),
+  encoding: z.enum(['base64']).optional(),
 });
 
 const terminalCommandResultSchema = z.object({


### PR DESCRIPTION
## Fix mojibake (`�`) in terminal and process output

### Problem

Accented characters (`é è à ç …`) and other non-ASCII bytes render as `�`
in the web UI — in the remote terminal (xterm.js), and also in script
execution history and user-context command results. Most visible on
French/Windows hosts and on Linux services running with `LANG=C`.

### Root cause

Two independent failures stack on every process-output path:

1. **Source not UTF-8.** Spawned processes inherit a non-UTF-8 locale:
   `LANG=C` on minimal/systemd environments, an OEM code page (CP850/CP1252,
   etc.) on Windows — e.g. `é` = `0x82`.
2. **JSON transport corruption.** Raw bytes were converted via `string(...)`
   before `json.Marshal`. Go's JSON encoder replaces every invalid-UTF-8
   byte with `U+FFFD`, so even a later locale fix can't recover bytes already
   mangled in transit.

Both layers are needed: UTF-8 at the source for correct text, byte-safe
handling so JSON never corrupts non-UTF-8 sequences.

### Fix

A shared `agent/internal/procoutput` package centralizes both layers and is
reused everywhere a process is spawned and its output captured:

- **`ApplyEnv`** — forces `LANG/LC_ALL/LC_CTYPE=C.UTF-8` when the locale is
  not already UTF-8 (no-op for `*.UTF-8` locales).
- **`BytesToUTF8`** — passthrough when bytes are already valid UTF-8;
  otherwise, on Windows, transcodes from the **actual active code page**
  (queried at runtime via `GetConsoleOutputCP`, falling back to `GetOEMCP`)
  mapped to the matching `charmap` decoder. Unmapped pages fall back
  gracefully. Unix path is a pure passthrough.
- **`WindowsScriptCommand`** — UTF-8 console bootstrap (`chcp 65001` /
  PowerShell encoding) for shell-wrapped commands.

**Terminal flow (PTY → xterm).** Because xterm consumes raw bytes (ANSI,
binary), terminal output is sent base64-encoded — but **negotiated**, not
unconditional, to avoid any deploy-order regression. The API advertises a
`capabilities` array in the existing `connected` handshake
(`terminal_output_base64`); the agent only emits base64 if that capability
was advertised, otherwise falls back to plain text. The flag resets on
(re)connect.

**Non-terminal flows (script history, winget / user-context exec, software
install).** These are plain text displayed in the UI, so no base64 and no
negotiation: the agent simply guarantees valid UTF-8 via `procoutput` before
JSON. No API schema change, no deploy-order coupling.

### Compatibility

Terminal base64 negotiation:

| Scenario              | Behavior                                          |
|-----------------------|---------------------------------------------------|
| old agent + new API   | no base64 sent → passthrough (unchanged)          |
| new agent + old API   | no capability advertised → plain text, no garbage |
| new agent + new API   | base64 round-trip                                 |
| reconnect             | flag reset until next `connected`                 |

Deployment order between agent and API no longer matters. The non-terminal
paths carry no compatibility concern (plain UTF-8 strings throughout).

### Note for reviewers

Previously the agent silently dropped the `connected` message in `readPump`
(no `id` field). It now parses it to read `capabilities`. Behavioral change,
but no risk — nothing relied on the message being discarded.

### Files

| File | Change |
|------|--------|
| `agent/internal/procoutput/*` | New package: `ApplyEnv`, `BytesToUTF8` (runtime code-page detection), `WindowsScriptCommand` |
| `agent/internal/terminal/terminal_env.go` | Delegates to `procoutput.ApplyEnv` (terminal behavior unchanged) |
| `agent/internal/terminal/pty_{unix,darwin,darwin_nocgo,windows}.go` | env + shell bootstrap |
| `agent/internal/websocket/client.go` | base64 transport + capability gating + reset |
| `agent/internal/executor/executor.go` | env + Windows bootstrap + safe capture |
| `agent/internal/userhelper/client.go` | exec/winget: env + safe capture |
| `agent/internal/scripts/runner.go` | env + Windows bootstrap + safe capture |
| `agent/internal/remote/tools/software_install.go` | env + safe capture on installer output |
| `apps/api/src/routes/agentWs.ts` | advertise capability, decode base64 |

### Tests

- `procoutput`: valid-UTF-8 passthrough; CP850/CP1252/CP866 → correct UTF-8
  (proves it's not hardcoded to Western pages); unmapped code page falls back
  gracefully; `ApplyEnv`.
- Per-site accented-output capture tests (`executor`, `scripts`,
  `userhelper`).
- Terminal: capability parsed → base64; capability absent → plain text;
  handshake parsing; capability reset on reconnect.
- API: `connected` advertises `terminal_output_base64`; base64 decode path.
- `go test ./internal/...`, `vitest agentWs.test.ts`, API lint — all green.

---

*Draft:* opening for early feedback on the capability/handshake approach
before finalizing.
