### PR TITLE
feat(ops): off-region backup upload + automated restore verification

### DIFF
--- a/docs/DISASTER_RECOVERY.md
+++ b/docs/DISASTER_RECOVERY.md
@@ -131,6 +131,49 @@ Test your backups at least monthly:
 3. Decrypt and inspect your configuration backup.
 4. Confirm object storage sync by comparing file counts and checksums.
 
+### Off-Region Backup + Automated Restore Test (DigitalOcean)
+
+The local `pg_dump` written by `scripts/backup.sh` lives on the droplet and does
+**not** survive a region/droplet loss. Two ops scripts close that gap:
+
+- `scripts/ops/offsite-backup.sh` — runs `backup.sh --db`, then uploads the dump
+  to an **off-region** S3-compatible bucket. On DO, create a **Spaces bucket in a
+  different region than the droplet** (droplet FRA1 → Spaces AMS3/NYC3). Enable
+  **bucket versioning** + a lifecycle rule to expire noncurrent versions, so a
+  corrupt or attacker-encrypted dump can't overwrite good history. It also writes
+  a stable `db/latest.dump` pointer.
+- `scripts/ops/restore-test.sh` — pulls `db/latest.dump` from that off-region
+  bucket, restores it into a throwaway dockerized Postgres via `restore.sh`,
+  asserts a sane `devices` row count, then tears the scratch DB down. POSTs to
+  `RESTORE_TEST_ALERT_URL` (Slack/Alertmanager) on failure. This is the *proof*
+  that the backup is restorable — run it on a schedule, not by hand.
+
+**One-time Spaces setup** (off-region bucket, e.g. via `s3cmd`/`aws` against the
+Spaces endpoint or the DO control panel): create the bucket in a foreign region,
+enable versioning, add a Spaces access key. Put the credentials in the droplet's
+backup environment:
+
+```bash
+OFFSITE_S3_ENDPOINT=https://nyc3.digitaloceanspaces.com
+OFFSITE_S3_BUCKET=breeze-dr-offsite
+OFFSITE_S3_ACCESS_KEY=...
+OFFSITE_S3_SECRET_KEY=...
+RESTORE_TEST_ALERT_URL=https://hooks.slack.com/services/...   # optional
+```
+
+**Cron (on the droplet):**
+
+```cron
+# Daily off-region DB backup at 02:15
+15 2 * * *  cd /opt/breeze && /opt/breeze/scripts/ops/offsite-backup.sh >> /var/log/breeze-offsite.log 2>&1
+# Weekly restore verification, Sundays 03:30 — pages on failure
+30 3 * * 0  cd /opt/breeze && /opt/breeze/scripts/ops/restore-test.sh >> /var/log/breeze-restore-test.log 2>&1
+```
+
+The restore test needs `docker`, `aws`, `pg_restore`, and `psql` on the droplet.
+A green weekly run is the artifact underwriters and the launch-readiness checklist
+ask for ("backup tested ≤ 90 days").
+
 ---
 
 ## 4. Scenario 1: Single Service Crash

--- a/scripts/ops/offsite-backup.sh
+++ b/scripts/ops/offsite-backup.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Breeze RMM — Off-Region Backup
+#
+# Runs the local backup (scripts/backup.sh) then pushes the resulting Postgres
+# dump (and optionally the encrypted config bundle) to an off-region,
+# S3-compatible bucket — on DigitalOcean, a Spaces bucket created in a DIFFERENT
+# region than the droplet. That foreign-region copy is what survives a full
+# region/droplet loss; the local BACKUP_DIR copy does not.
+#
+# Recommended bucket setup (one-time, in the DO control panel or via s3api):
+#   - Create the Spaces bucket in a region other than your droplet's region.
+#   - Enable Bucket Versioning so a corrupt/encrypted dump can't clobber good
+#     history, and a lifecycle rule to expire noncurrent versions after N days.
+#
+# Usage:
+#   ./scripts/ops/offsite-backup.sh            # db dump -> offsite
+#   ./scripts/ops/offsite-backup.sh --config   # also push encrypted config bundle
+#
+# Environment variables:
+#   DATABASE_URL              Postgres connection string (passed to backup.sh)
+#   BACKUP_DIR                Local backup dir (default: /var/backups/breeze)
+#   BACKUP_ENCRYPTION_KEY     Required only with --config
+#
+#   OFFSITE_S3_ENDPOINT       Off-region Spaces endpoint, e.g.
+#                             https://nyc3.digitaloceanspaces.com   (required)
+#   OFFSITE_S3_BUCKET         Off-region bucket name                 (required)
+#   OFFSITE_S3_ACCESS_KEY     Spaces access key                      (required)
+#   OFFSITE_S3_SECRET_KEY     Spaces secret key                      (required)
+#   OFFSITE_S3_PREFIX         Key prefix in the bucket (default: db)
+#
+# Exit codes:
+#   0 — backup created and uploaded
+#   1 — backup created but upload failed
+#   2 — backup step failed (nothing to upload)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BACKUP_DIR="${BACKUP_DIR:-/var/backups/breeze}"
+OFFSITE_S3_PREFIX="${OFFSITE_S3_PREFIX:-db}"
+PUSH_CONFIG=false
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [offsite] $*"; }
+die() { log "FATAL: $*" >&2; exit "${2:-2}"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --config) PUSH_CONFIG=true ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) die "Unknown option: $1" ;;
+  esac
+  shift
+done
+
+for var in OFFSITE_S3_ENDPOINT OFFSITE_S3_BUCKET OFFSITE_S3_ACCESS_KEY OFFSITE_S3_SECRET_KEY; do
+  if [ -z "${!var:-}" ]; then die "${var} is required"; fi
+done
+command -v aws >/dev/null 2>&1 || die "aws CLI is required (install awscli)"
+
+# 1) Produce the local backups via the existing, tested script.
+backup_flags=(--db)
+$PUSH_CONFIG && backup_flags+=(--config)
+log "Running local backup: backup.sh ${backup_flags[*]}"
+if ! "${REPO_ROOT}/scripts/backup.sh" "${backup_flags[@]}"; then
+  # backup.sh exit 1 = partial; still try to upload whatever db dump exists.
+  log "WARNING: backup.sh reported a non-zero exit; will upload any dump produced"
+fi
+
+# 2) Find the newest dump just written.
+latest_dump="$(find "${BACKUP_DIR}" -maxdepth 1 -name 'db_*.dump' -type f -print0 \
+  | xargs -0 ls -t 2>/dev/null | head -1 || true)"
+[ -n "${latest_dump}" ] || die "No db_*.dump found in ${BACKUP_DIR} to upload"
+
+export AWS_ACCESS_KEY_ID="${OFFSITE_S3_ACCESS_KEY}"
+export AWS_SECRET_ACCESS_KEY="${OFFSITE_S3_SECRET_KEY}"
+s3() { aws --endpoint-url "${OFFSITE_S3_ENDPOINT}" s3 "$@"; }
+
+upload() {
+  local src="$1" key="$2"
+  log "Uploading $(basename "${src}") -> s3://${OFFSITE_S3_BUCKET}/${key}"
+  s3 cp "${src}" "s3://${OFFSITE_S3_BUCKET}/${key}" --only-show-errors
+}
+
+rc=0
+dump_key="${OFFSITE_S3_PREFIX}/$(basename "${latest_dump}")"
+upload "${latest_dump}" "${dump_key}" || rc=1
+# A stable pointer to the most recent dump so the restore test doesn't have to
+# list+sort the bucket. Versioning keeps prior 'latest.dump' contents.
+upload "${latest_dump}" "${OFFSITE_S3_PREFIX}/latest.dump" || rc=1
+
+if $PUSH_CONFIG; then
+  latest_cfg="$(find "${BACKUP_DIR}" -maxdepth 1 -name 'config_*.tar.gz.enc' -type f -print0 \
+    | xargs -0 ls -t 2>/dev/null | head -1 || true)"
+  if [ -n "${latest_cfg}" ]; then
+    upload "${latest_cfg}" "config/$(basename "${latest_cfg}")" || rc=1
+  else
+    log "WARNING: --config requested but no config bundle found to upload"
+    rc=1
+  fi
+fi
+
+if [ $rc -eq 0 ]; then
+  log "Off-region backup complete"
+  exit 0
+fi
+log "ERROR: one or more uploads failed"
+exit 1

--- a/scripts/ops/restore-test.sh
+++ b/scripts/ops/restore-test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# Breeze RMM — Automated Restore Verification (DR gap #6)
+#
+# Proves the off-region backup is actually restorable, on a schedule. Pulls the
+# latest Postgres dump from the off-region Spaces bucket, restores it into a
+# throwaway dockerized Postgres, asserts the data looks sane, then tears the
+# scratch DB down. Designed to run weekly via cron and page on failure.
+#
+# This closes the "no proven backup restore" finding: backup.sh + restore.sh
+# already work, but nothing exercised the restore path automatically.
+#
+# Usage:
+#   ./scripts/ops/restore-test.sh
+#
+# Environment variables (off-region source — same bucket offsite-backup.sh writes):
+#   OFFSITE_S3_ENDPOINT       e.g. https://nyc3.digitaloceanspaces.com  (required)
+#   OFFSITE_S3_BUCKET         bucket name                               (required)
+#   OFFSITE_S3_ACCESS_KEY     Spaces access key                         (required)
+#   OFFSITE_S3_SECRET_KEY     Spaces secret key                         (required)
+#   OFFSITE_S3_PREFIX         key prefix (default: db)
+#   OFFSITE_S3_KEY            dump key to test (default: <prefix>/latest.dump)
+#
+#   RESTORE_TEST_PG_IMAGE     postgres image (default: postgres:16)
+#   RESTORE_TEST_MIN_DEVICES  minimum device rows to consider the restore sane
+#                             (default: 1)
+#   RESTORE_TEST_ALERT_URL    optional webhook (Slack/Alertmanager) POSTed on
+#                             failure; if unset, failures only log + exit non-zero
+#
+# Exit codes:
+#   0 — restore verified
+#   1 — restore ran but verification failed (data missing/short)
+#   2 — could not run the test (missing dump, docker, env, etc.)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+OFFSITE_S3_PREFIX="${OFFSITE_S3_PREFIX:-db}"
+OFFSITE_S3_KEY="${OFFSITE_S3_KEY:-${OFFSITE_S3_PREFIX}/latest.dump}"
+PG_IMAGE="${RESTORE_TEST_PG_IMAGE:-postgres:16}"
+MIN_DEVICES="${RESTORE_TEST_MIN_DEVICES:-1}"
+
+CONTAINER="breeze-restore-test-$$"
+WORKDIR="$(mktemp -d)"
+PG_PASSWORD="restore-test-$$"
+PG_PORT="55432"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [restore-test] $*"; }
+
+alert() {
+  local msg="$1"
+  log "ALERT: ${msg}"
+  if [ -n "${RESTORE_TEST_ALERT_URL:-}" ]; then
+    curl -fsS -m 10 -X POST -H 'Content-Type: application/json' \
+      -d "{\"text\":\"[Breeze restore-test FAILED] ${msg}\"}" \
+      "${RESTORE_TEST_ALERT_URL}" >/dev/null 2>&1 || log "WARNING: alert webhook POST failed"
+  fi
+}
+
+cleanup() {
+  docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+  rm -rf "${WORKDIR}" || true
+}
+trap cleanup EXIT
+
+fail() { alert "$1"; exit "${2:-1}"; }
+
+# --- preflight ---
+for var in OFFSITE_S3_ENDPOINT OFFSITE_S3_BUCKET OFFSITE_S3_ACCESS_KEY OFFSITE_S3_SECRET_KEY; do
+  [ -n "${!var:-}" ] || fail "${var} is required" 2
+done
+command -v docker >/dev/null 2>&1 || fail "docker is required" 2
+command -v aws >/dev/null 2>&1 || fail "aws CLI is required" 2
+
+# --- 1) pull the latest off-region dump ---
+export AWS_ACCESS_KEY_ID="${OFFSITE_S3_ACCESS_KEY}"
+export AWS_SECRET_ACCESS_KEY="${OFFSITE_S3_SECRET_KEY}"
+DUMP_FILE="${WORKDIR}/latest.dump"
+log "Fetching s3://${OFFSITE_S3_BUCKET}/${OFFSITE_S3_KEY}"
+if ! aws --endpoint-url "${OFFSITE_S3_ENDPOINT}" s3 cp \
+     "s3://${OFFSITE_S3_BUCKET}/${OFFSITE_S3_KEY}" "${DUMP_FILE}" --only-show-errors; then
+  fail "could not download dump ${OFFSITE_S3_KEY} from off-region bucket" 2
+fi
+dump_size="$(du -h "${DUMP_FILE}" | cut -f1)"
+log "Downloaded dump (${dump_size})"
+
+# Guard against a truncated/empty object passing as a "backup".
+dump_bytes="$(wc -c < "${DUMP_FILE}" | tr -d ' ')"
+[ "${dump_bytes}" -gt 1024 ] || fail "downloaded dump is suspiciously small (${dump_bytes} bytes)" 1
+
+# --- 2) spin up scratch postgres ---
+log "Starting scratch ${PG_IMAGE} (container ${CONTAINER})"
+docker run -d --name "${CONTAINER}" \
+  -e POSTGRES_PASSWORD="${PG_PASSWORD}" \
+  -e POSTGRES_DB=breeze \
+  -p "127.0.0.1:${PG_PORT}:5432" \
+  "${PG_IMAGE}" >/dev/null || fail "failed to start scratch postgres" 2
+
+SCRATCH_URL="postgresql://postgres:${PG_PASSWORD}@127.0.0.1:${PG_PORT}/breeze"
+
+log "Waiting for scratch postgres to accept connections..."
+ready=false
+for _ in $(seq 1 30); do
+  if docker exec "${CONTAINER}" pg_isready -U postgres -d breeze >/dev/null 2>&1; then
+    ready=true; break
+  fi
+  sleep 1
+done
+$ready || fail "scratch postgres never became ready" 2
+
+# --- 3) restore via the existing, tested restore.sh ---
+# restore.sh runs pg_restore + a device-count sanity check; we point it at the
+# scratch DB and auto-confirm. pg_restore/psql must be present on the host.
+log "Restoring dump into scratch DB via restore.sh"
+if ! DATABASE_URL="${SCRATCH_URL}" RESTORE_SKIP_CONFIRM=yes \
+     "${REPO_ROOT}/scripts/restore.sh" --db "${DUMP_FILE}"; then
+  fail "restore.sh failed against scratch DB — backup is NOT restorable" 1
+fi
+
+# --- 4) independent assertion (don't just trust restore.sh's own check) ---
+device_count="$(docker exec -e PGPASSWORD="${PG_PASSWORD}" "${CONTAINER}" \
+  psql -U postgres -d breeze -t -A -c 'SELECT count(*) FROM devices;' 2>/dev/null | tr -d '[:space:]' || echo ERR)"
+
+case "${device_count}" in
+  ''|*[!0-9]*) fail "post-restore device count query failed (got '${device_count}')" 1 ;;
+esac
+if [ "${device_count}" -lt "${MIN_DEVICES}" ]; then
+  fail "restored DB has ${device_count} devices (< ${MIN_DEVICES} expected) — possible empty/partial backup" 1
+fi
+
+log "SUCCESS: restore verified — ${device_count} devices, dump ${dump_size}"
+exit 0


### PR DESCRIPTION
## Summary

Closes launch-readiness **DR gap #6** ("no proven backup restore"). `backup.sh` and `restore.sh` already worked, but the Postgres dump never left the droplet (a region/droplet loss took it with), and nothing exercised the restore path automatically — so "is the backup restorable?" was unproven.

Two thin ops scripts (they reuse the existing tested `backup.sh`/`restore.sh` rather than reimplementing dump/restore logic):

- **`scripts/ops/offsite-backup.sh`** — runs `backup.sh --db`, then uploads the dump (plus a stable `db/latest.dump` pointer, and optionally the encrypted config bundle) to an off-region S3-compatible bucket. On DigitalOcean, that's a **Spaces bucket in a different region than the droplet**; enable versioning + noncurrent-version expiry so a corrupt/encrypted dump can't clobber good history.
- **`scripts/ops/restore-test.sh`** — pulls `latest.dump` from the off-region bucket, restores it into a throwaway dockerized Postgres via `restore.sh`, asserts a sane `devices` row count, tears the scratch DB down, and POSTs to `RESTORE_TEST_ALERT_URL` (Slack/Alertmanager) on failure. A green weekly run is the proof-of-restorability artifact the checklist (and underwriters) ask for.
- **`DISASTER_RECOVERY.md`** — documents the one-time Spaces setup, env vars, and the daily-backup + weekly-restore-test cron.

## Why scripts, not app code

This gap is operational. The restore test deliberately runs against a disposable container so it can't touch prod, and routes through `restore.sh` so it tests the *real* recovery path operators would use by hand.

## Test plan

- [x] Verified end-to-end locally: dumped the running `breeze` DB (1.7M, `-Fc`), spun up `postgres:16`, restored via `pg_restore --clean --if-exists`, asserted **8 devices**, torn down.
- [x] `bash -n` clean on both scripts.
- [x] `shellcheck` clean (one SC2329 false positive — `cleanup` is invoked via `trap ... EXIT`).
- [ ] Deploy: create off-region Spaces bucket (versioning on), set `OFFSITE_S3_*` env on the droplet, install the two cron entries, confirm first weekly run goes green.

## Deploy notes

Requires `docker`, `aws`, `pg_restore`, `psql` on the droplet. Cron + env are in the DR doc. Independent of PR #975 (anomaly alerting) — no shared files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)