### PR TITLE
fix(web): keep global search placeholder on one line

### DIFF
--- a/apps/web/src/components/layout/CommandPalette.tsx
+++ b/apps/web/src/components/layout/CommandPalette.tsx
@@ -534,10 +534,10 @@ export default function CommandPalette() {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="flex h-9 w-80 items-center gap-2 rounded-md border bg-background px-3 text-sm text-muted-foreground hover:bg-muted/40 focus:outline-none focus:ring-2 focus:ring-ring"
+        className="flex h-9 w-full items-center gap-2 rounded-md border bg-background px-3 text-sm text-muted-foreground hover:bg-muted/40 focus:outline-none focus:ring-2 focus:ring-ring"
       >
-        <Search className="h-4 w-4" />
-        <span className="flex-1 text-left">Search devices, scripts, alerts, users, settings</span>
+        <Search className="h-4 w-4 shrink-0" />
+        <span className="flex-1 truncate whitespace-nowrap text-left">Search devices, scripts, alerts, users, settings</span>
         <span className="rounded border bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase text-muted-foreground">
           {modifierLabel ? `${modifierLabel}+K` : 'K'}
         </span>

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -193,7 +193,7 @@ export default function Header() {
         </div>
 
         {/* Global Search */}
-        <div data-tour="search">
+        <div data-tour="search" className="min-w-0 flex-1 max-w-xs sm:max-w-sm md:max-w-md lg:max-w-[28rem]">
           <CommandPalette />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Widen the header global-search trigger responsively so the full placeholder text fits on one line on larger screens (per Kamlo's mockup).
- Add `whitespace-nowrap` + `truncate` so the text never wraps; it shrinks gracefully to just the search icon on small screens.

## Changes
- `Header.tsx` — search wrapper now `flex-1 max-w-xs sm:max-w-sm md:max-w-md lg:max-w-[28rem]` so the bar grows with the viewport.
- `CommandPalette.tsx` — trigger button is `w-full`; text uses `truncate whitespace-nowrap`; icon uses `shrink-0`.

## Test plan
- [x] Desktop (1440px): full text "Search devices, scripts, alerts, users, settings" + CMD+K on one line
- [x] Tablet (820px): full text still on one line
- [x] Mobile (390px): collapses to search icon, no wrap/overflow, header intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)