### PR TITLE
fix(agent): emit UTF-8 from PowerShell event-log queries

### DIFF
--- a/agent/internal/collectors/command_limits.go
+++ b/agent/internal/collectors/command_limits.go
@@ -21,6 +21,14 @@ const (
 	collectorResultLimit         = 5000
 )
 
+// utf8PowerShellCommand wraps a PowerShell command so its stdout is emitted as
+// UTF-8. Without this, PowerShell renders output using the console OEM codepage
+// (e.g. CP852 on Polish Windows), which Go then decodes as UTF-8 and corrupts
+// non-Latin characters into U+FFFD. See issue #979.
+func utf8PowerShellCommand(command string) string {
+	return "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;" + command
+}
+
 func runCollectorOutput(timeout time.Duration, name string, args ...string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()

--- a/agent/internal/collectors/eventlogs_windows.go
+++ b/agent/internal/collectors/eventlogs_windows.go
@@ -190,7 +190,7 @@ func (c *EventLogCollector) collectPowerEvents(since time.Time) ([]EventLogEntry
 		sinceStr,
 	)
 
-	output, err := runCollectorOutput(collectorLongCommandTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", psCmd)
+	output, err := runCollectorOutput(collectorLongCommandTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", utf8PowerShellCommand(psCmd))
 	if err != nil {
 		// No events found is not an error
 		return nil, nil
@@ -247,7 +247,7 @@ func (c *EventLogCollector) queryWinEvents(logName string, maxLevel int, since t
 		logName, levelFilter, sinceStr,
 	)
 
-	output, err := runCollectorOutput(collectorLongCommandTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", psCmd)
+	output, err := runCollectorOutput(collectorLongCommandTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", utf8PowerShellCommand(psCmd))
 	if err != nil {
 		// No events found is not an error
 		return nil, nil

--- a/agent/internal/collectors/powershell_encoding_test.go
+++ b/agent/internal/collectors/powershell_encoding_test.go
@@ -1,0 +1,20 @@
+package collectors
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUTF8PowerShellCommand(t *testing.T) {
+	t.Parallel()
+
+	inner := `Get-WinEvent -FilterHashtable @{LogName='System'} | ConvertTo-Json`
+	got := utf8PowerShellCommand(inner)
+
+	if !strings.HasPrefix(got, "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;") {
+		t.Fatalf("expected UTF-8 output-encoding prefix, got %q", got)
+	}
+	if !strings.HasSuffix(got, inner) {
+		t.Fatalf("expected original command preserved as suffix, got %q", got)
+	}
+}

--- a/agent/internal/remote/tools/eventlogs_windows.go
+++ b/agent/internal/remote/tools/eventlogs_windows.go
@@ -13,7 +13,7 @@ import (
 func listEventLogsOS(startTime time.Time) CommandResult {
 	// Use PowerShell to get event log names
 	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command",
-		`Get-WinEvent -ListLog * -ErrorAction SilentlyContinue | Select-Object LogName, RecordCount, MaximumSizeInBytes | ConvertTo-Json`)
+		utf8PowerShellCommand(`Get-WinEvent -ListLog * -ErrorAction SilentlyContinue | Select-Object LogName, RecordCount, MaximumSizeInBytes | ConvertTo-Json`))
 	output, err := cmd.Output()
 	if err != nil {
 		return NewErrorResult(fmt.Errorf("failed to list event logs: %w", err), time.Since(startTime).Milliseconds())
@@ -61,9 +61,9 @@ func queryEventLogsOS(logName, level, source string, eventID, page, limit int, s
 	// Query events using PowerShell
 	maxEvents := page * limit
 	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command",
-		fmt.Sprintf(`Get-WinEvent -FilterHashtable @{%s} -MaxEvents %d -ErrorAction SilentlyContinue | `+
+		utf8PowerShellCommand(fmt.Sprintf(`Get-WinEvent -FilterHashtable @{%s} -MaxEvents %d -ErrorAction SilentlyContinue | `+
 			`Select-Object RecordId, LogName, LevelDisplayName, TimeCreated, ProviderName, Id, Message | `+
-			`ConvertTo-Json -Depth 2`, filter, maxEvents))
+			`ConvertTo-Json -Depth 2`, filter, maxEvents)))
 
 	output, err := cmd.Output()
 	if err != nil {
@@ -107,10 +107,10 @@ func queryEventLogsOS(logName, level, source string, eventID, page, limit int, s
 
 func getEventLogEntryOS(logName string, recordID int64, startTime time.Time) CommandResult {
 	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command",
-		fmt.Sprintf(`Get-WinEvent -FilterHashtable @{LogName='%s'} -ErrorAction SilentlyContinue | `+
+		utf8PowerShellCommand(fmt.Sprintf(`Get-WinEvent -FilterHashtable @{LogName='%s'} -ErrorAction SilentlyContinue | `+
 			`Where-Object { $_.RecordId -eq %d } | Select-Object -First 1 | `+
 			`Select-Object RecordId, LogName, LevelDisplayName, TimeCreated, ProviderName, Id, Message, UserId, MachineName | `+
-			`ConvertTo-Json -Depth 2`, escapePowerShellSingleQuoted(logName), recordID))
+			`ConvertTo-Json -Depth 2`, escapePowerShellSingleQuoted(logName), recordID)))
 
 	output, err := cmd.Output()
 	if err != nil {

--- a/agent/internal/remote/tools/powershell_encoding.go
+++ b/agent/internal/remote/tools/powershell_encoding.go
@@ -1,0 +1,9 @@
+package tools
+
+// utf8PowerShellCommand wraps a PowerShell command so its stdout is emitted as
+// UTF-8. Without this, PowerShell renders output using the console OEM codepage
+// (e.g. CP852 on Polish Windows), which Go then decodes as UTF-8 and corrupts
+// non-Latin characters into U+FFFD. See issue #979.
+func utf8PowerShellCommand(command string) string {
+	return "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;" + command
+}

--- a/agent/internal/remote/tools/powershell_encoding_test.go
+++ b/agent/internal/remote/tools/powershell_encoding_test.go
@@ -1,0 +1,20 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUTF8PowerShellCommand(t *testing.T) {
+	t.Parallel()
+
+	inner := `Get-WinEvent -ListLog * | ConvertTo-Json`
+	got := utf8PowerShellCommand(inner)
+
+	if !strings.HasPrefix(got, "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;") {
+		t.Fatalf("expected UTF-8 output-encoding prefix, got %q", got)
+	}
+	if !strings.HasSuffix(got, inner) {
+		t.Fatalf("expected original command preserved as suffix, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Polish (and any non-Latin-locale) Windows machines showed Device Logs with every diacritic corrupted to `�` (U+FFFD) — e.g. `przesta� korzysta� ... zosta� zamkni�ty`.
- **Root cause:** the agent reads Windows Event Log messages via `Get-WinEvent ... | ConvertTo-Json`. PowerShell writes stdout using the console OEM codepage (CP852 on Polish Windows); Go then decodes those bytes as UTF-8, substituting `�` for every invalid sequence. The original characters are lost before storage.
- **Fix:** prepend `[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;` to the Get-WinEvent commands via a small `utf8PowerShellCommand` helper so PowerShell emits UTF-8 and Go reads it losslessly.

Applied to both event-log surfaces:
- `internal/collectors/eventlogs_windows.go` (the collector that produced the reported screenshot)
- `internal/remote/tools/eventlogs_windows.go` (interactive event-log viewer, 3 commands)

Closes #979

## Test plan
- [x] `go test ./internal/collectors/ ./internal/remote/tools/ -run TestUTF8PowerShellCommand` — passes (asserts prefix + preserved command)
- [x] `GOOS=windows go vet ./internal/collectors/ ./internal/remote/tools/` — clean (Windows-tagged files compile)
- [ ] Manual: confirm on a Polish-locale Windows VM that event-log messages render diacritics correctly (Windows-only, can't repro on macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)