### PR TITLE
fix(api,huntress): Basic auth + /incident_reports path + numeric-id normalization + persist failure status

### DIFF
--- a/apps/api/src/jobs/huntressSync.ts
+++ b/apps/api/src/jobs/huntressSync.ts
@@ -17,7 +17,7 @@ import { publishEvent } from '../services/eventBus';
 import { getBullMQConnection } from '../services/redis';
 import { isReusableState } from '../services/bullmqUtils';
 import { captureException } from '../services/sentry';
-import { decryptForColumn } from '../services/secretCrypto';
+import { decryptSecret } from '../services/secretCrypto';
 import { HUNTRESS_OFFLINE_STATUSES, HUNTRESS_RESOLVED_STATUSES } from '../services/huntressConstants';
 
 const { db } = dbModule;
@@ -597,7 +597,7 @@ async function syncIntegrationById(
     } else {
       let apiKey: string | null;
       try {
-        apiKey = decryptForColumn('huntress_integrations', 'api_key_encrypted', integration.apiKeyEncrypted);
+        apiKey = decryptSecret(integration.apiKeyEncrypted);
       } catch (err) {
         throw new Error(`Failed to decrypt API key for Huntress integration ${integrationId}: ${err instanceof Error ? err.message : String(err)}`);
       }
@@ -662,14 +662,24 @@ async function syncIntegrationById(
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     try {
-      await db
-        .update(huntressIntegrations)
-        .set({
-          lastSyncStatus: 'error',
-          lastSyncError: `${source}: ${message}`.slice(0, 2000),
-          updatedAt: new Date(),
-        })
-        .where(eq(huntressIntegrations.id, integrationId));
+      // The whole sync job runs inside one withSystemDbAccessContext transaction.
+      // Re-throwing below rolls that transaction back, so recording the failure on
+      // the job's own connection would be undone and the row would keep its stale
+      // status. Escape the current context (runOutsideDbContext) and open a fresh
+      // transaction (runWithSystemDbAccess) so the 'error' status commits and
+      // survives the rollback.
+      await dbModule.runOutsideDbContext(() =>
+        runWithSystemDbAccess(() =>
+          db
+            .update(huntressIntegrations)
+            .set({
+              lastSyncStatus: 'error',
+              lastSyncError: `${source}: ${message}`.slice(0, 2000),
+              updatedAt: new Date(),
+            })
+            .where(eq(huntressIntegrations.id, integrationId))
+        )
+      );
     } catch (dbErr) {
       console.error(`[HuntressSync] Failed to record sync error for integration ${integrationId}:`, dbErr);
       captureException(dbErr instanceof Error ? dbErr : new Error(String(dbErr)));

--- a/apps/api/src/services/huntressClient.test.ts
+++ b/apps/api/src/services/huntressClient.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { HuntressClient } from './huntressClient';
+
+// Regression coverage for the Huntress sync fixes:
+//  1. HTTP Basic auth (not Bearer/X-API-Key).
+//  2. Incidents come from /incident_reports (not /incidents).
+//  3. Numeric ids (Huntress returns id/agent_id as numbers) survive normalization
+//     instead of being dropped as "missing required fields".
+
+type Captured = { url: URL; init: RequestInit };
+
+function mockFetch(bodyFor: (pathname: string) => unknown) {
+  const calls: Captured[] = [];
+  const fn = vi.fn(async (url: URL, init: RequestInit) => {
+    calls.push({ url, init });
+    const body = bodyFor(url.pathname);
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => JSON.stringify(body),
+      headers: { get: () => null },
+    } as unknown as Response;
+  });
+  vi.stubGlobal('fetch', fn);
+  return calls;
+}
+
+// A single page with no next-page markers so pagination terminates after one request.
+const onePage = (key: string, rows: unknown[]) => ({
+  [key]: rows,
+  pagination: { current_page: 1, current_page_count: rows.length, limit: 100, total_count: rows.length, next_page: null },
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('HuntressClient', () => {
+  it('authenticates with HTTP Basic (base64 of the key:secret pair), not Bearer/X-API-Key', async () => {
+    const calls = mockFetch((p) => (p.endsWith('/agents') ? onePage('agents', []) : onePage('incident_reports', [])));
+    const client = new HuntressClient({ apiKey: 'mykey:mysecret' });
+    await client.listAgents();
+
+    const headers = calls[0].init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe(`Basic ${Buffer.from('mykey:mysecret').toString('base64')}`);
+    expect(headers.Authorization).not.toContain('Bearer');
+    expect(headers['X-API-Key']).toBeUndefined();
+  });
+
+  it('reads incidents from /incident_reports, not /incidents', async () => {
+    const calls = mockFetch(() => onePage('incident_reports', []));
+    const client = new HuntressClient({ apiKey: 'k:s' });
+    await client.listIncidents();
+
+    expect(calls.some((c) => c.url.pathname.endsWith('/incident_reports'))).toBe(true);
+    expect(calls.some((c) => c.url.pathname.endsWith('/incidents'))).toBe(false);
+  });
+
+  it('keeps agent records whose id is a number (numeric ids are coerced, not dropped)', async () => {
+    mockFetch(() =>
+      onePage('agents', [{ id: 12345, hostname: 'HOST-1', platform: 'windows', status: 'active' }])
+    );
+    const client = new HuntressClient({ apiKey: 'k:s' });
+    const agents = await client.listAgents();
+
+    expect(agents).toHaveLength(1);
+    expect(agents[0].huntressAgentId).toBe('12345');
+    expect(agents[0].hostname).toBe('HOST-1');
+  });
+
+  it('keeps incident records with a numeric id and maps the real fields (subject/body/sent_at)', async () => {
+    mockFetch(() =>
+      onePage('incident_reports', [
+        { id: 678, agent_id: 99, subject: 'Suspicious login', body: 'Details here', severity: 'high', status: 'sent', sent_at: '2026-05-01T00:00:00Z' },
+      ])
+    );
+    const client = new HuntressClient({ apiKey: 'k:s' });
+    const incidents = await client.listIncidents();
+
+    expect(incidents).toHaveLength(1);
+    expect(incidents[0].huntressIncidentId).toBe('678');
+    expect(incidents[0].title).toBe('Suspicious login'); // from `subject`
+    expect(incidents[0].description).toBe('Details here'); // from `body`
+    expect(incidents[0].reportedAt?.toISOString()).toBe('2026-05-01T00:00:00.000Z'); // from `sent_at`
+  });
+});

--- a/apps/api/src/services/huntressClient.test.ts
+++ b/apps/api/src/services/huntressClient.test.ts
@@ -43,7 +43,7 @@ describe('HuntressClient', () => {
     const client = new HuntressClient({ apiKey: 'mykey:mysecret' });
     await client.listAgents();
 
-    const headers = calls[0].init.headers as Record<string, string>;
+    const headers = calls[0]!.init.headers as Record<string, string>;
     expect(headers.Authorization).toBe(`Basic ${Buffer.from('mykey:mysecret').toString('base64')}`);
     expect(headers.Authorization).not.toContain('Bearer');
     expect(headers['X-API-Key']).toBeUndefined();
@@ -66,8 +66,8 @@ describe('HuntressClient', () => {
     const agents = await client.listAgents();
 
     expect(agents).toHaveLength(1);
-    expect(agents[0].huntressAgentId).toBe('12345');
-    expect(agents[0].hostname).toBe('HOST-1');
+    expect(agents[0]!.huntressAgentId).toBe('12345');
+    expect(agents[0]!.hostname).toBe('HOST-1');
   });
 
   it('keeps incident records with a numeric id and maps the real fields (subject/body/sent_at)', async () => {
@@ -80,9 +80,9 @@ describe('HuntressClient', () => {
     const incidents = await client.listIncidents();
 
     expect(incidents).toHaveLength(1);
-    expect(incidents[0].huntressIncidentId).toBe('678');
-    expect(incidents[0].title).toBe('Suspicious login'); // from `subject`
-    expect(incidents[0].description).toBe('Details here'); // from `body`
-    expect(incidents[0].reportedAt?.toISOString()).toBe('2026-05-01T00:00:00.000Z'); // from `sent_at`
+    expect(incidents[0]!.huntressIncidentId).toBe('678');
+    expect(incidents[0]!.title).toBe('Suspicious login'); // from `subject`
+    expect(incidents[0]!.description).toBe('Details here'); // from `body`
+    expect(incidents[0]!.reportedAt?.toISOString()).toBe('2026-05-01T00:00:00.000Z'); // from `sent_at`
   });
 });

--- a/apps/api/src/services/huntressClient.ts
+++ b/apps/api/src/services/huntressClient.ts
@@ -39,6 +39,10 @@ function firstString(record: JsonRecord, keys: string[]): string | null {
   for (const key of keys) {
     const value = record[key];
     if (typeof value === 'string' && value.trim()) return value.trim();
+    // Huntress returns identifiers (id, account_id, agent_id) as numbers, not
+    // strings. Coerce finite numbers so id-based fields don't resolve to null
+    // (which would drop the whole record during normalization).
+    if (typeof value === 'number' && Number.isFinite(value)) return String(value);
   }
   return null;
 }
@@ -239,11 +243,11 @@ function normalizeIncident(input: unknown): HuntressIncidentRecord | null {
     huntressIncidentId,
     severity: normalizeSeverity(firstString(row, ['severity', 'priority', 'level'])),
     category: firstString(row, ['category', 'type', 'threatType', 'incidentType']),
-    title: firstString(row, ['title', 'name', 'summary']) ?? fallbackTitle,
-    description: firstString(row, ['description', 'details', 'message', 'summary']),
+    title: firstString(row, ['subject', 'title', 'name', 'summary']) ?? fallbackTitle,
+    description: firstString(row, ['body', 'description', 'details', 'message', 'summary']),
     recommendation: firstString(row, ['recommendation', 'recommendedAction', 'remediation', 'nextSteps']),
     status: normalizeStatus(firstString(row, ['status', 'state', 'resolutionStatus', 'incidentStatus'])),
-    reportedAt: firstDate(row, ['reportedAt', 'reported_at', 'createdAt', 'created_at', 'detectedAt', 'timestamp']),
+    reportedAt: firstDate(row, ['sent_at', 'reportedAt', 'reported_at', 'createdAt', 'created_at', 'detectedAt', 'timestamp']),
     resolvedAt: firstDate(row, ['resolvedAt', 'resolved_at', 'closedAt', 'closed_at']),
     huntressAgentId: firstString(row, ['agentId', 'agent_id', 'hostAgentId', 'host_agent_id']),
     hostname: firstString(row, ['hostname', 'hostName', 'computerName', 'host']),
@@ -375,11 +379,13 @@ export class HuntressClient {
     for (const [key, value] of Object.entries(query ?? {})) {
       url.searchParams.set(key, value);
     }
-    // Send both Bearer token and X-API-Key header for compatibility with different Huntress API auth modes
+    // Huntress API only accepts HTTP Basic auth (verified live 2026-05-29: Bearer and
+    // X-API-Key both return 401 "Missing or incorrect authorization scheme"). The
+    // integration's apiKey field stores the literal "<key>:<secret>" pair from the
+    // Huntress portal; base64-encode it for the Basic auth header.
     const headers: Record<string, string> = {
       Accept: 'application/json',
-      Authorization: `Bearer ${this.apiKey}`,
-      'X-API-Key': this.apiKey,
+      Authorization: `Basic ${Buffer.from(this.apiKey).toString('base64')}`,
     };
     if (this.accountId) {
       headers['X-Account-Id'] = this.accountId;
@@ -449,7 +455,7 @@ export class HuntressClient {
   }
 
   async listIncidents(since?: Date): Promise<HuntressIncidentRecord[]> {
-    const rows = await this.requestPaginated('/incidents', since, ['incidents', 'alerts', 'findings', 'data', 'items', 'results']);
+    const rows = await this.requestPaginated('/incident_reports', since, ['incident_reports', 'incidents', 'alerts', 'findings', 'data', 'items', 'results']);
     const incidents = rows
       .map((row) => normalizeIncident(row))
       .filter((row): row is HuntressIncidentRecord => row !== null);


### PR DESCRIPTION
## What

Fixes the Huntress integration sync, which was silently broken: it imported no data and the integration status falsely read `success`. Four distinct bugs:

1. **Auth → 401.** The client sent `Authorization: Bearer <key>` + `X-API-Key`. The Huntress REST API requires **HTTP Basic** (`base64(KEY:SECRET)`); Bearer/X-API-Key return `401 "Missing or incorrect authorization scheme"`. The `apiKey` field already stores the literal `key:secret` pair, so no schema or form change is needed — just `Authorization: Basic ${base64(apiKey)}`.
2. **Path → 404.** `listIncidents` called `/incidents`; the real endpoint is **`/incident_reports`** (`/incidents` returns `404 "Invalid path specified"`).
3. **Normalization dropped 100% of records.** Huntress returns `id`/`account_id`/`agent_id` as **numbers**, but `firstString` only accepted strings, so every agent + incident resolved to a null id and was discarded (`Dropped 165/165 agent records … missing required fields`) despite a `200`. Coerce finite numbers in `firstString`, and map the real `incident_reports` field names: `subject` (title), `body` (description), `sent_at` (reportedAt).
4. **Failure status never persisted.** The sync job runs inside a single `withSystemDbAccessContext` transaction. On failure the catch wrote `lastSyncStatus='error'` and then re-threw (so BullMQ marks the job failed) — but the re-throw **rolled the transaction back**, discarding the `error` write. So a broken integration kept its stale `success` status indefinitely, masking the outage. Fix: record the failure via `runOutsideDbContext` + a fresh `withSystemDbAccessContext` so it commits in a separate transaction that survives the rollback.

Bugs 1–3 stop data flowing; bug 4 hides that fact. They share the same subsystem, hence one PR.

## Verification (against a live deployment with real credentials)

- **Auth + path + agents endpoint:** direct calls returned `BASIC /account 200`, `BASIC /agents 200`, `BASIC /incident_reports 200`; the prior `Bearer /account` returned `401` and `/incidents` returned `404`.
- **Normalization:** after deploy, a real sync imported **165 agents (fresh) + incidents** where previously `0` landed (all dropped). Integration rows flipped from a 9-day-stale `success` to fresh syncs.
- **Failure status (bug 4):** with a throwaway integration seeded `status='success'` and an undecryptable key, a failed sync left the row at `success` **before** the fix and correctly flipped it to `error` + message **after** the fix.

## Notes for reviewers

- `firstString` numeric coercion is safe for all callers: it only changes behavior when a field is numeric (ids), and string fields are unaffected.
- The transaction-rollback fix is the general "record-then-rethrow inside a transaction loses the record" trap; the failure write must commit outside the job transaction.
- Happy to add unit tests (e.g. a `HuntressClient` `fetch`-mock asserting Basic auth, the `/incident_reports` path, and numeric-id records surviving normalization) if you'd like them in this PR.
