### PR TITLE
fix(api): resolve orgId from query string on update-ring create

### DIFF
--- a/apps/api/src/routes/updateRings.ts
+++ b/apps/api/src/routes/updateRings.ts
@@ -226,7 +226,9 @@ updateRingRoutes.post(
     const auth = c.get('auth');
     const data = c.req.valid('json');
 
-    const orgResult = resolveOrgId(auth, data.orgId);
+    // fetchWithAuth injects the selected org as a query param for partner/system
+    // users, so fall back to it when the body omits orgId (matches the GET handler).
+    const orgResult = resolveOrgId(auth, data.orgId ?? c.req.query('orgId'));
     if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
     const { orgId } = orgResult;
 

--- a/apps/api/src/routes/updateRings_list_create.test.ts
+++ b/apps/api/src/routes/updateRings_list_create.test.ts
@@ -278,6 +278,35 @@ describe('updateRings routes', () => {
       expect(body.name).toBe('Test Ring');
     });
 
+    it('should resolve orgId from the query string for partner users (fetchWithAuth injects it there)', async () => {
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-123', email: 'partner@example.com', name: 'Partner' },
+          scope: 'partner',
+          orgId: null,
+          partnerId: PARTNER_ID,
+          accessibleOrgIds: [ORG_ID, ORG_ID_2],
+          canAccessOrg: () => true
+        });
+        return next();
+      });
+
+      const created = makeRing();
+      vi.mocked(db.insert).mockReturnValueOnce({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([created])
+        })
+      } as any);
+
+      const res = await app.request(`/update-rings?orgId=${ORG_ID}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ name: 'Test Ring', deferralDays: 7, ringOrder: 1 })
+      });
+
+      expect(res.status).toBe(201);
+    });
+
     it('should validate required fields (missing name)', async () => {
       const res = await app.request('/update-rings', {
         method: 'POST',


### PR DESCRIPTION
## Problem

Partner/MSP users got **400 "orgId is required"** when creating a custom update ring, while listing rings worked fine for the same user.

Reported by jubsy0:
> seems there is a bug with the creating custom update rings
> `POST /api/v1/update-rings?orgId=… 400 (Bad Request)`

## Root cause

An orgId-source mismatch between the web client and the `POST /update-rings` handler:

- `fetchWithAuth` injects the selected org as a **query parameter** (`?orgId=…`) for partner/system users — `apps/web/src/stores/auth.ts:294-300`.
- The create payload never includes `orgId` in the body — `apps/web/src/components/patches/PatchesPage.tsx:341-349`.
- The POST handler resolved the org **only from the JSON body** (`resolveOrgId(auth, data.orgId)`), so `data.orgId` was `undefined`.

Why it only bit some users:
- **Org-scoped users** passed via the `auth.orgId` fallback in `resolveOrgId`.
- **Partner/MSP users** (`auth.orgId === null`, multiple `accessibleOrgIds`) had no fallback → 400.

`GET /update-rings` worked for the same user because the list handler already reads orgId from the query (`zValidator('query', listRingsSchema)`). Only `POST` ignored it. PATCH/DELETE are unaffected — they derive org from the existing row.

## Fix

Fall back to the query-string orgId on create, matching the client contract and the GET handler:

```ts
const orgResult = resolveOrgId(auth, data.orgId ?? c.req.query('orgId'));
```

No tenant-isolation change: both the body and query paths flow through the same `auth.canAccessOrg()` check in `resolveOrgId`, which returns 403 on a non-accessible org.

## Tests

- Added a regression test in `updateRings_list_create.test.ts`: a partner user (`orgId: null`, two accessible orgs) POSTing with `?orgId=…` and no body orgId. Reproduced the 400 before the fix; passes after.
- The existing POST tests only ran as org-scoped users, which is the coverage gap that let this ship — now closed.

## Verification

- `tsc --noEmit` — clean
- Full API suite — 458 files, 5092 passed / 28 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)