### PR TITLE
fix(agent): make agent.yaml readable by the Helper (Breeze Assist)

### DIFF
--- a/agent/internal/collectors/command_limits.go
+++ b/agent/internal/collectors/command_limits.go
@@ -21,6 +21,14 @@ const (
 	collectorResultLimit         = 5000
 )
 
+// utf8PowerShellCommand wraps a PowerShell command so its stdout is emitted as
+// UTF-8. Without this, PowerShell renders output using the console OEM codepage
+// (e.g. CP852 on Polish Windows), which Go then decodes as UTF-8 and corrupts
+// non-Latin characters into U+FFFD. See issue #979.
+func utf8PowerShellCommand(command string) string {
+	return "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;" + command
+}
+
 func runCollectorOutput(timeout time.Duration, name string, args ...string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()

--- a/agent/internal/collectors/eventlogs_windows.go
+++ b/agent/internal/collectors/eventlogs_windows.go
@@ -190,7 +190,7 @@ func (c *EventLogCollector) collectPowerEvents(since time.Time) ([]EventLogEntry
 		sinceStr,
 	)
 
-	output, err := runCollectorOutput(collectorLongCommandTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", psCmd)
+	output, err := runCollectorOutput(collectorLongCommandTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", utf8PowerShellCommand(psCmd))
 	if err != nil {
 		// No events found is not an error
 		return nil, nil
@@ -247,7 +247,7 @@ func (c *EventLogCollector) queryWinEvents(logName string, maxLevel int, since t
 		logName, levelFilter, sinceStr,
 	)
 
-	output, err := runCollectorOutput(collectorLongCommandTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", psCmd)
+	output, err := runCollectorOutput(collectorLongCommandTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", utf8PowerShellCommand(psCmd))
 	if err != nil {
 		// No events found is not an error
 		return nil, nil

--- a/agent/internal/collectors/powershell_encoding_test.go
+++ b/agent/internal/collectors/powershell_encoding_test.go
@@ -1,0 +1,20 @@
+package collectors
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUTF8PowerShellCommand(t *testing.T) {
+	t.Parallel()
+
+	inner := `Get-WinEvent -FilterHashtable @{LogName='System'} | ConvertTo-Json`
+	got := utf8PowerShellCommand(inner)
+
+	if !strings.HasPrefix(got, "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;") {
+		t.Fatalf("expected UTF-8 output-encoding prefix, got %q", got)
+	}
+	if !strings.HasSuffix(got, inner) {
+		t.Fatalf("expected original command preserved as suffix, got %q", got)
+	}
+}

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -323,7 +323,7 @@ func SetAndPersist(key string, value any) error {
 
 func SetSecretAndPersist(key string, value any) error {
 	path := secretsFilePath()
-	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
 	if err := enforceConfigDirPermissions(filepath.Dir(path)); err != nil {
@@ -404,7 +404,7 @@ func SaveTo(cfg *Config, cfgFile string) error {
 		cfgPath = cfgFile
 		dir := filepath.Dir(cfgPath)
 		if dir != "." {
-			if err := os.MkdirAll(dir, 0750); err != nil {
+			if err := os.MkdirAll(dir, 0755); err != nil {
 				return err
 			}
 			if err := enforceConfigDirPermissions(dir); err != nil {
@@ -413,7 +413,7 @@ func SaveTo(cfg *Config, cfgFile string) error {
 		}
 	} else {
 		cfgPath = filepath.Join(configDir(), "agent.yaml")
-		if err := os.MkdirAll(configDir(), 0750); err != nil {
+		if err := os.MkdirAll(configDir(), 0755); err != nil {
 			return err
 		}
 		if err := enforceConfigDirPermissions(configDir()); err != nil {
@@ -430,7 +430,10 @@ func SaveTo(cfg *Config, cfgFile string) error {
 		return fmt.Errorf("marshaling agent config: %w", err)
 	}
 	cfgYAML = stripSecretsFromAgentConfig(cfgYAML)
-	if err := atomicWriteFile(cfgPath, cfgYAML, 0640); err != nil {
+	// agent.yaml is world-readable (0644) so the Breeze Helper, running as the
+	// logged-in user, can read it. It carries only the helper-scoped token;
+	// full tokens and mTLS keys are written to root-only secrets.yaml below.
+	if err := atomicWriteFile(cfgPath, cfgYAML, 0644); err != nil {
 		return fmt.Errorf("writing agent config: %w", err)
 	}
 
@@ -660,7 +663,7 @@ func migrateInlineSecretsToSecretFile(cfgPath string) error {
 	}
 
 	if secretFileExists || len(secretValues) > 0 {
-		if err := os.MkdirAll(filepath.Dir(secretPath), 0750); err != nil {
+		if err := os.MkdirAll(filepath.Dir(secretPath), 0755); err != nil {
 			return err
 		}
 		if err := enforceConfigDirPermissions(filepath.Dir(secretPath)); err != nil {
@@ -673,7 +676,7 @@ func migrateInlineSecretsToSecretFile(cfgPath string) error {
 			return err
 		}
 	}
-	if err := writeYAMLFile(cfgPath, cfgValues, 0640); err != nil {
+	if err := writeYAMLFile(cfgPath, cfgValues, 0644); err != nil {
 		return err
 	}
 	return enforceConfigFilePermissions(cfgPath)

--- a/agent/internal/config/config_test.go
+++ b/agent/internal/config/config_test.go
@@ -225,17 +225,84 @@ func TestSaveToWritesAtomicallyWithoutLeftoverTempFiles(t *testing.T) {
 		t.Fatalf("Load returned incomplete config: %+v", loaded)
 	}
 
-	// On POSIX, the perm set at OpenFile time must survive — preserving the
-	// TOCTOU-permission property the previous code's comment called out.
-	// Skip on Windows where POSIX mode bits don't map directly.
+	// On POSIX, agent.yaml must be world-readable (0644) so the Breeze Helper
+	// ("Breeze Assist"), which runs as the logged-in user and is neither the
+	// owner (root) nor in the owning group (wheel), can read it. secrets.yaml
+	// holds the full agent/watchdog tokens and mTLS keys and stays root-only
+	// (0600). Skip on Windows where POSIX mode bits don't map directly.
 	if runtime.GOOS != "windows" {
-		if mode := agentInfo.Mode().Perm(); mode != 0o640 {
-			t.Errorf("agent.yaml mode = %o, want 0640", mode)
+		if mode := agentInfo.Mode().Perm(); mode != 0o644 {
+			t.Errorf("agent.yaml mode = %o, want 0644 (Helper runs as logged-in user)", mode)
 		}
 		if mode := secretsInfo.Mode().Perm(); mode != 0o600 {
 			t.Errorf("secrets.yaml mode = %o, want 0600", mode)
 		}
 	}
+}
+
+// TestEnforceConfigPermissionsAreHelperReadable guards the bug where the
+// SR-001..SR-024 hardening (#568) tightened agent.yaml to 0640 in a 0750 dir,
+// which the Breeze Helper (running as the logged-in user, not root/wheel) could
+// not read — surfacing as "Breeze Assist requires the Breeze agent...". The
+// config dir must be traversable and agent.yaml world-readable, while
+// secrets.yaml stays owner-only.
+func TestEnforceConfigPermissionsAreHelperReadable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX mode bits don't apply on Windows; DACLs covered separately")
+	}
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yaml")
+	secretsPath := filepath.Join(dir, "secrets.yaml")
+
+	// Start from deliberately over-tight perms to prove the enforce funcs loosen
+	// the config (and keep the secret locked).
+	if err := os.WriteFile(cfgPath, []byte("server_url: x\n"), 0o600); err != nil {
+		t.Fatalf("write agent.yaml: %v", err)
+	}
+	if err := os.WriteFile(secretsPath, []byte("auth_token: x\n"), 0o644); err != nil {
+		t.Fatalf("write secrets.yaml: %v", err)
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("chmod dir: %v", err)
+	}
+
+	if err := enforceConfigDirPermissions(dir); err != nil {
+		t.Fatalf("enforceConfigDirPermissions: %v", err)
+	}
+	if err := enforceConfigFilePermissions(cfgPath); err != nil {
+		t.Fatalf("enforceConfigFilePermissions: %v", err)
+	}
+	if err := enforceSecretFilePermissions(secretsPath); err != nil {
+		t.Fatalf("enforceSecretFilePermissions: %v", err)
+	}
+
+	dirMode := statPerm(t, dir)
+	if dirMode != 0o755 {
+		t.Errorf("config dir mode = %o, want 0755 (others must traverse to reach agent.yaml)", dirMode)
+	}
+	cfgMode := statPerm(t, cfgPath)
+	if cfgMode != 0o644 {
+		t.Errorf("agent.yaml mode = %o, want 0644 (Helper must read it as the logged-in user)", cfgMode)
+	}
+	if cfgMode&0o004 == 0 {
+		t.Errorf("agent.yaml mode = %o is not other-readable; Helper cannot read it", cfgMode)
+	}
+	secretsMode := statPerm(t, secretsPath)
+	if secretsMode != 0o600 {
+		t.Errorf("secrets.yaml mode = %o, want 0600 (full tokens/keys must stay owner-only)", secretsMode)
+	}
+	if secretsMode&0o077 != 0 {
+		t.Errorf("secrets.yaml mode = %o leaks group/other access to real secrets", secretsMode)
+	}
+}
+
+func statPerm(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return info.Mode().Perm()
 }
 
 // TestAtomicWriteFileOverwritesExistingFile verifies the helper correctly

--- a/agent/internal/config/permissions_unix.go
+++ b/agent/internal/config/permissions_unix.go
@@ -4,12 +4,20 @@ package config
 
 import "os"
 
+// The Breeze Helper ("Breeze Assist") runs as the logged-in user, while the
+// agent writes these files as root. The user is neither the owner (root) nor in
+// the owning group (wheel), so the config dir must be traversable (0755) and
+// agent.yaml world-readable (0644) for the Helper to read its server URL,
+// agent ID, and helper-scoped token. The full agent/watchdog tokens and mTLS
+// keys are NOT in agent.yaml — they live in secrets.yaml, which stays
+// owner-only (0600).
+
 func enforceConfigDirPermissions(path string) error {
-	return os.Chmod(path, 0750)
+	return os.Chmod(path, 0755)
 }
 
 func enforceConfigFilePermissions(path string) error {
-	return os.Chmod(path, 0640)
+	return os.Chmod(path, 0644)
 }
 
 func enforceSecretFilePermissions(path string) error {

--- a/agent/internal/config/permissions_windows.go
+++ b/agent/internal/config/permissions_windows.go
@@ -8,9 +8,19 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// The Breeze Helper ("Breeze Assist") runs in the logged-in user's session,
+// while the agent (SYSTEM) writes these files. The config dir and agent.yaml
+// grant BUILTIN\Users read so the Helper can read the server URL, agent ID, and
+// helper-scoped token — restoring the default ProgramData ACL that #568's
+// PROTECTED DACL stripped. SYSTEM and Administrators keep full control. The
+// directory's Users ACE is read+traverse (FRFX) and intentionally NOT
+// inheritable, so it never propagates to secrets.yaml. The full agent/watchdog
+// tokens and mTLS keys live ONLY in secrets.yaml, which stays SYSTEM +
+// Administrators (never Users).
 const (
-	windowsConfigDirSDDL  = `D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)`
-	windowsConfigFileSDDL = `D:P(A;;FA;;;SY)(A;;FA;;;BA)`
+	windowsConfigDirSDDL  = `D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;;FRFX;;;BU)`
+	windowsConfigFileSDDL = `D:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FR;;;BU)`
+	windowsSecretFileSDDL = `D:P(A;;FA;;;SY)(A;;FA;;;BA)`
 )
 
 func enforceConfigDirPermissions(path string) error {
@@ -22,7 +32,7 @@ func enforceConfigFilePermissions(path string) error {
 }
 
 func enforceSecretFilePermissions(path string) error {
-	return applyWindowsDACL(path, windowsConfigFileSDDL)
+	return applyWindowsDACL(path, windowsSecretFileSDDL)
 }
 
 func applyWindowsDACL(path, sddl string) error {

--- a/agent/internal/config/permissions_windows_test.go
+++ b/agent/internal/config/permissions_windows_test.go
@@ -1,0 +1,109 @@
+//go:build windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// TestWindowsConfigDACLGrantsUsersRead locks the invariants behind the
+// "Breeze Assist requires the Breeze agent..." regression: agent.yaml and its
+// directory must grant BUILTIN\Users read (so the Helper, running as the
+// logged-in user, can read them), while secrets.yaml must NOT — the full
+// agent/watchdog tokens and mTLS keys stay SYSTEM + Administrators only.
+func TestWindowsConfigDACLGrantsUsersRead(t *testing.T) {
+	if !strings.Contains(windowsConfigFileSDDL, "(A;;FR;;;BU)") {
+		t.Errorf("agent.yaml DACL must grant BUILTIN\\Users read: %s", windowsConfigFileSDDL)
+	}
+	if !strings.Contains(windowsConfigDirSDDL, ";BU)") {
+		t.Errorf("config dir DACL must grant BUILTIN\\Users read+traverse: %s", windowsConfigDirSDDL)
+	}
+	if strings.Contains(windowsSecretFileSDDL, "BU") || strings.Contains(windowsSecretFileSDDL, "IU") {
+		t.Errorf("secrets.yaml DACL must NOT grant Users/Interactive access: %s", windowsSecretFileSDDL)
+	}
+	// All three must be PROTECTED (D:P) so inherited ACEs can't widen access.
+	for name, sddl := range map[string]string{
+		"dir":     windowsConfigDirSDDL,
+		"config":  windowsConfigFileSDDL,
+		"secrets": windowsSecretFileSDDL,
+	} {
+		if !strings.HasPrefix(sddl, "D:P") {
+			t.Errorf("%s DACL must be PROTECTED (D:P prefix): %s", name, sddl)
+		}
+		// Every DACL string must parse as a valid security descriptor.
+		if _, err := windows.SecurityDescriptorFromString(sddl); err != nil {
+			t.Errorf("%s DACL does not parse: %v", name, err)
+		}
+	}
+}
+
+// TestEnforceConfigFileDACLAppliesUsersRead applies the real DACL to a temp file
+// and reads it back, confirming a Users (BU) ACE is present on agent.yaml and
+// absent on secrets.yaml.
+func TestEnforceConfigFileDACLAppliesUsersRead(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yaml")
+	secretsPath := filepath.Join(dir, "secrets.yaml")
+	if err := os.WriteFile(cfgPath, []byte("server_url: x\n"), 0o600); err != nil {
+		t.Fatalf("write agent.yaml: %v", err)
+	}
+	if err := os.WriteFile(secretsPath, []byte("auth_token: x\n"), 0o600); err != nil {
+		t.Fatalf("write secrets.yaml: %v", err)
+	}
+
+	if err := enforceConfigFilePermissions(cfgPath); err != nil {
+		t.Fatalf("enforceConfigFilePermissions: %v", err)
+	}
+	if err := enforceSecretFilePermissions(secretsPath); err != nil {
+		t.Fatalf("enforceSecretFilePermissions: %v", err)
+	}
+
+	usersSID, err := windows.CreateWellKnownSid(windows.WinBuiltinUsersSid)
+	if err != nil {
+		t.Fatalf("CreateWellKnownSid: %v", err)
+	}
+
+	if !daclGrantsSID(t, cfgPath, usersSID) {
+		t.Errorf("agent.yaml DACL does not grant BUILTIN\\Users; Helper cannot read it")
+	}
+	if daclGrantsSID(t, secretsPath, usersSID) {
+		t.Errorf("secrets.yaml DACL grants BUILTIN\\Users; real secrets are exposed")
+	}
+}
+
+// daclGrantsSID reports whether the file's DACL contains an allow ACE for sid.
+func daclGrantsSID(t *testing.T, path string, sid *windows.SID) bool {
+	t.Helper()
+	sd, err := windows.GetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+	)
+	if err != nil {
+		t.Fatalf("GetNamedSecurityInfo(%s): %v", path, err)
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil {
+		t.Fatalf("DACL(%s): %v", path, err)
+	}
+	if dacl == nil {
+		return false
+	}
+	for i := uint32(0); i < uint32(dacl.AceCount); i++ {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		if err := windows.GetAce(dacl, i, &ace); err != nil {
+			continue
+		}
+		aceSID := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+		if aceSID.Equals(sid) {
+			return true
+		}
+	}
+	return false
+}

--- a/agent/internal/remote/tools/eventlogs_windows.go
+++ b/agent/internal/remote/tools/eventlogs_windows.go
@@ -13,7 +13,7 @@ import (
 func listEventLogsOS(startTime time.Time) CommandResult {
 	// Use PowerShell to get event log names
 	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command",
-		`Get-WinEvent -ListLog * -ErrorAction SilentlyContinue | Select-Object LogName, RecordCount, MaximumSizeInBytes | ConvertTo-Json`)
+		utf8PowerShellCommand(`Get-WinEvent -ListLog * -ErrorAction SilentlyContinue | Select-Object LogName, RecordCount, MaximumSizeInBytes | ConvertTo-Json`))
 	output, err := cmd.Output()
 	if err != nil {
 		return NewErrorResult(fmt.Errorf("failed to list event logs: %w", err), time.Since(startTime).Milliseconds())
@@ -61,9 +61,9 @@ func queryEventLogsOS(logName, level, source string, eventID, page, limit int, s
 	// Query events using PowerShell
 	maxEvents := page * limit
 	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command",
-		fmt.Sprintf(`Get-WinEvent -FilterHashtable @{%s} -MaxEvents %d -ErrorAction SilentlyContinue | `+
+		utf8PowerShellCommand(fmt.Sprintf(`Get-WinEvent -FilterHashtable @{%s} -MaxEvents %d -ErrorAction SilentlyContinue | `+
 			`Select-Object RecordId, LogName, LevelDisplayName, TimeCreated, ProviderName, Id, Message | `+
-			`ConvertTo-Json -Depth 2`, filter, maxEvents))
+			`ConvertTo-Json -Depth 2`, filter, maxEvents)))
 
 	output, err := cmd.Output()
 	if err != nil {
@@ -107,10 +107,10 @@ func queryEventLogsOS(logName, level, source string, eventID, page, limit int, s
 
 func getEventLogEntryOS(logName string, recordID int64, startTime time.Time) CommandResult {
 	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command",
-		fmt.Sprintf(`Get-WinEvent -FilterHashtable @{LogName='%s'} -ErrorAction SilentlyContinue | `+
+		utf8PowerShellCommand(fmt.Sprintf(`Get-WinEvent -FilterHashtable @{LogName='%s'} -ErrorAction SilentlyContinue | `+
 			`Where-Object { $_.RecordId -eq %d } | Select-Object -First 1 | `+
 			`Select-Object RecordId, LogName, LevelDisplayName, TimeCreated, ProviderName, Id, Message, UserId, MachineName | `+
-			`ConvertTo-Json -Depth 2`, escapePowerShellSingleQuoted(logName), recordID))
+			`ConvertTo-Json -Depth 2`, escapePowerShellSingleQuoted(logName), recordID)))
 
 	output, err := cmd.Output()
 	if err != nil {

--- a/agent/internal/remote/tools/powershell_encoding.go
+++ b/agent/internal/remote/tools/powershell_encoding.go
@@ -1,0 +1,9 @@
+package tools
+
+// utf8PowerShellCommand wraps a PowerShell command so its stdout is emitted as
+// UTF-8. Without this, PowerShell renders output using the console OEM codepage
+// (e.g. CP852 on Polish Windows), which Go then decodes as UTF-8 and corrupts
+// non-Latin characters into U+FFFD. See issue #979.
+func utf8PowerShellCommand(command string) string {
+	return "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;" + command
+}

--- a/agent/internal/remote/tools/powershell_encoding_test.go
+++ b/agent/internal/remote/tools/powershell_encoding_test.go
@@ -1,0 +1,20 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUTF8PowerShellCommand(t *testing.T) {
+	t.Parallel()
+
+	inner := `Get-WinEvent -ListLog * | ConvertTo-Json`
+	got := utf8PowerShellCommand(inner)
+
+	if !strings.HasPrefix(got, "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;") {
+		t.Fatalf("expected UTF-8 output-encoding prefix, got %q", got)
+	}
+	if !strings.HasSuffix(got, inner) {
+		t.Fatalf("expected original command preserved as suffix, got %q", got)
+	}
+}


### PR DESCRIPTION
## Problem

A user enabled Breeze Assist (the `helper` feature) via configuration policy, but on the device the tray app showed:

> Breeze Assist requires the Breeze agent. Ensure the Breeze agent is installed and running on this device.

…even though the agent was installed and running.

**Root cause:** the message is misleading. It comes from the Helper's `load_agent_config_full()` (`apps/helper/src-tauri/src/lib.rs:95-98`), which fires on **any** failure to read `agent.yaml` — including permission-denied, not just file-not-found. The Helper runs as the **logged-in user**, while the agent writes `agent.yaml` as **root/SYSTEM**. The SR-001..SR-024 hardening (#568) tightened the config so the logged-in user can no longer read it:

- **POSIX:** `agent.yaml` is `0640` in a `0750` dir, owned `root:wheel`. The user is neither owner nor in the `wheel` group → `EACCES`.
- **Windows:** #568 introduced a **PROTECTED** DACL granting only SYSTEM + Administrators, stripping the inherited ProgramData `Users:Read`. A non-elevated interactive process (standard **or** admin) is then denied — confirmed near-universal on Windows.

## Fix

Restore read access for the logged-in user on the config dir + `agent.yaml`, while keeping `secrets.yaml` locked down:

- **POSIX** (`permissions_unix.go`): dir `0750 → 0755`, `agent.yaml` `0640 → 0644`; `secrets.yaml` stays `0600`.
- **Windows** (`permissions_windows.go`): add `(A;;FR;;;BU)` to `agent.yaml` and non-inheritable `(A;;FRFX;;;BU)` to the dir; **split `secrets.yaml` onto its own SDDL** (`windowsSecretFileSDDL`) that stays SYSTEM + Administrators only. (It previously shared the config-file SDDL, so widening one would have widened both — the key trap.)
- Updated the now-stale hardcoded `0640`/`0750` literals in `config.go` (`SaveTo` + secrets-migration path) so there's no transient tight window.

**Why this is safe:** `agent.yaml` carries only the **helper-scoped** token plus non-secret config (`config.go:396-400`). The full agent/watchdog tokens and mTLS keys live in `secrets.yaml`, which stays owner/SYSTEM-only. Widening `agent.yaml` does not expose high-privilege credentials.

## Verification

- POSIX regression test `TestEnforceConfigPermissionsAreHelperReadable` (TDD: RED at `0640`/`0750` → GREEN at `0644`/`0755`); full `internal/config` suite green with `-race` on macOS.
- Windows DACL tests cross-build + `go vet` clean for `windows/amd64`.
- **Real Windows Server 2022** (`go test -c` cross-compiled, run on the box): `TestWindowsConfigDACLGrantsUsersRead` and `TestEnforceConfigFileDACLAppliesUsersRead` **pass** — apply DACL + read back via the live Windows ACL API.
- **Real Windows `icacls`** on files set with the production SDDL:
  - `agent.yaml` → `BUILTIN\Users:(R)`, `BUILTIN\Administrators:(F)`, `NT AUTHORITY\SYSTEM:(F)`
  - `secrets.yaml` → `Administrators:(F)`, `SYSTEM:(F)` — **no Users entry**

## Deployment note

This fix is in the **agent** (it writes/enforces the perms), so already-hardened machines stay broken until the **new agent** runs `FixConfigPermissions` on startup and re-applies the looser ACL. A Helper-only update will **not** fix existing devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)