### PR TITLE
fix(web): scope pill refreshes all list pages on flip (#989)

### DIFF
--- a/apps/web/src/components/layout/OrgSwitcher.test.tsx
+++ b/apps/web/src/components/layout/OrgSwitcher.test.tsx
@@ -186,4 +186,30 @@ describe('OrgSwitcher org change navigation', () => {
     expect(reloadMock).not.toHaveBeenCalled();
     expect(hrefSetter).not.toHaveBeenCalled();
   });
+
+  // #989: flipping the scope pill must refresh every list page, not just the
+  // ones that happen to key on orgScope. The pill reloads after the flip,
+  // mirroring the org-switch path.
+  it('reloads after waitForPendingRefresh when flipping the scope pill to All orgs', async () => {
+    const { reloadMock } = stubLocation('/devices');
+
+    render(<OrgSwitcher />);
+
+    fireEvent.click(screen.getByTestId('org-scope-all'));
+
+    expect(setOrgScopeMock).toHaveBeenCalledWith('all');
+    await waitFor(() => expect(reloadMock).toHaveBeenCalledTimes(1));
+    expect(waitForPendingRefreshMock).toHaveBeenCalled();
+  });
+
+  it('does nothing when re-clicking the already-active scope', () => {
+    const { reloadMock } = stubLocation('/devices'); // store starts at orgScope 'current'
+
+    render(<OrgSwitcher />);
+
+    fireEvent.click(screen.getByTestId('org-scope-current'));
+
+    expect(setOrgScopeMock).not.toHaveBeenCalled();
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/components/layout/OrgSwitcher.tsx
+++ b/apps/web/src/components/layout/OrgSwitcher.tsx
@@ -162,6 +162,18 @@ function OrgScopePill() {
   const setOrgScope = useOrgStore((s) => s.setOrgScope);
   const organizationsCount = useOrgStore((s) => s.organizations.length);
 
+  // Flipping the scope changes the orgId-injection chokepoint in orgStore, but
+  // only pages with `orgScope` in their fetch deps refetch live. Rather than
+  // rely on every list page opting in (easy to miss one), reload after the flip
+  // so the new scope takes effect everywhere immediately — mirroring the
+  // org-switch path. Skip the reload when the active scope is re-clicked (#989).
+  const applyScope = async (next: 'current' | 'all') => {
+    if (next === orgScope) return;
+    setOrgScope(next);
+    await waitForPendingRefresh();
+    window.location.reload();
+  };
+
   if (organizationsCount <= 1) return null;
 
   return (
@@ -174,7 +186,7 @@ function OrgScopePill() {
       <button
         type="button"
         data-testid="org-scope-current"
-        onClick={() => setOrgScope('current')}
+        onClick={() => void applyScope('current')}
         aria-pressed={orgScope === 'current'}
         className={cn(
           'flex items-center gap-1 px-2 py-1.5 transition-colors',
@@ -190,7 +202,7 @@ function OrgScopePill() {
       <button
         type="button"
         data-testid="org-scope-all"
-        onClick={() => setOrgScope('all')}
+        onClick={() => void applyScope('all')}
         aria-pressed={orgScope === 'all'}
         className={cn(
           'flex items-center gap-1 px-2 py-1.5 transition-colors',


### PR DESCRIPTION
Closes #989.

PR #985's scope pill only triggered a live refetch on pages that include `orgScope` in their fetch deps — which was just `SNMPTemplateList`. Every other list page keyed on `[currentOrgId]` stayed on the old scope until the next navigation/reload, so an MSP clicking "All orgs" on the devices dashboard saw nothing change.

Going with your option 1 (the simplest, consistent one): the pill flips the scope and then reloads, awaiting `waitForPendingRefresh()` first so it can't interrupt an in-flight `/auth/refresh` (the same #950 guard the org-switch path uses). Re-clicking the already-active scope is a no-op (no reload).

- `apps/web/src/components/layout/OrgSwitcher.tsx` — `OrgScopePill` gains an `applyScope` handler; both buttons use it.
- `OrgSwitcher.test.tsx` — two new tests: flipping to All orgs reloads after `waitForPendingRefresh`; re-clicking the active scope does nothing.

Verified locally: web tsc clean, `OrgSwitcher.test.tsx` 9/9.
