### PR TITLE
feat(m365): Delegant-backed M365 helpdesk agent — tools, RBAC, approvals, audit

### DIFF
--- a/apps/api/migrations/2026-05-27-b-delegant-m365-connections.sql
+++ b/apps/api/migrations/2026-05-27-b-delegant-m365-connections.sql
@@ -1,0 +1,44 @@
+-- Per-customer M365 connection pointers for the Breeze AI agent's Delegant
+-- integration. Stores references into Delegant + display metadata only.
+-- NO secrets here: the per-customer Entra client secret lives in Delegant.
+CREATE TABLE IF NOT EXISTS delegant_m365_connections (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id                UUID NOT NULL,
+  customer_label        VARCHAR(128) NOT NULL,
+  customer_display_name VARCHAR(256) NOT NULL,
+  delegant_org_id       VARCHAR(64) NOT NULL,
+  delegant_connection_id VARCHAR(64) NOT NULL,
+  m365_tenant_id        VARCHAR(64) NOT NULL,
+  status                VARCHAR(32) NOT NULL DEFAULT 'active',
+  last_verified_at      TIMESTAMP,
+  created_at            TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at            TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS delegant_m365_org_customer_uniq
+  ON delegant_m365_connections (org_id, customer_label);
+CREATE INDEX IF NOT EXISTS delegant_m365_org_idx
+  ON delegant_m365_connections (org_id);
+
+-- Row-Level Security: this is per-org tenant data, mirroring c2c_connections.
+-- Use the canonical breeze_org_isolation_{select,insert,update,delete} pattern
+-- backed by public.breeze_has_org_access(org_id) (see migration 0008 and the
+-- 2026-04-11 RLS rewrite). ENABLE + FORCE so even the table owner is bound.
+-- Idempotent — safe to re-run.
+DROP POLICY IF EXISTS breeze_org_isolation_select ON delegant_m365_connections;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON delegant_m365_connections;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON delegant_m365_connections;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON delegant_m365_connections;
+
+ALTER TABLE delegant_m365_connections ENABLE ROW LEVEL SECURITY;
+ALTER TABLE delegant_m365_connections FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY breeze_org_isolation_select ON delegant_m365_connections
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON delegant_m365_connections
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON delegant_m365_connections
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON delegant_m365_connections
+  FOR DELETE USING (public.breeze_has_org_access(org_id));

--- a/apps/api/migrations/2026-05-27-b-delegant-m365-connections.sql
+++ b/apps/api/migrations/2026-05-27-b-delegant-m365-connections.sql
@@ -3,7 +3,7 @@
 -- NO secrets here: the per-customer Entra client secret lives in Delegant.
 CREATE TABLE IF NOT EXISTS delegant_m365_connections (
   id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  org_id                UUID NOT NULL,
+  org_id                UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
   customer_label        VARCHAR(128) NOT NULL,
   customer_display_name VARCHAR(256) NOT NULL,
   delegant_org_id       VARCHAR(64) NOT NULL,
@@ -19,6 +19,23 @@ CREATE UNIQUE INDEX IF NOT EXISTS delegant_m365_org_customer_uniq
   ON delegant_m365_connections (org_id, customer_label);
 CREATE INDEX IF NOT EXISTS delegant_m365_org_idx
   ON delegant_m365_connections (org_id);
+
+-- org_id -> organizations(id) FK with ON DELETE CASCADE so connection pointers
+-- can't orphan against deleted orgs (and org teardown auto-cleans them rather
+-- than blocking). Guarded for DBs that created the table before the FK existed;
+-- fresh creates above already carry it, so re-runs are no-ops.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'delegant_m365_connections_org_id_fkey'
+      AND conrelid = 'delegant_m365_connections'::regclass
+  ) THEN
+    ALTER TABLE delegant_m365_connections
+      ADD CONSTRAINT delegant_m365_connections_org_id_fkey
+      FOREIGN KEY (org_id) REFERENCES organizations(id) ON DELETE CASCADE;
+  END IF;
+END $$;
 
 -- Row-Level Security: this is per-org tenant data, mirroring c2c_connections.
 -- Use the canonical breeze_org_isolation_{select,insert,update,delete} pattern

--- a/apps/api/migrations/2026-05-27-c-ai-sessions-delegant-connection.sql
+++ b/apps/api/migrations/2026-05-27-c-ai-sessions-delegant-connection.sql
@@ -1,0 +1,8 @@
+-- Bind an AI session to one customer M365 connection for its lifetime, and
+-- correlate a tool execution to its Delegant audit entry.
+ALTER TABLE ai_sessions
+  ADD COLUMN IF NOT EXISTS delegant_m365_connection_id UUID
+  REFERENCES delegant_m365_connections (id);
+
+ALTER TABLE ai_tool_executions
+  ADD COLUMN IF NOT EXISTS delegant_tool_call_id VARCHAR(64);

--- a/apps/api/migrations/2026-05-27-c-ai-sessions-delegant-connection.sql
+++ b/apps/api/migrations/2026-05-27-c-ai-sessions-delegant-connection.sql
@@ -2,7 +2,28 @@
 -- correlate a tool execution to its Delegant audit entry.
 ALTER TABLE ai_sessions
   ADD COLUMN IF NOT EXISTS delegant_m365_connection_id UUID
-  REFERENCES delegant_m365_connections (id);
+  REFERENCES delegant_m365_connections (id) ON DELETE SET NULL;
+
+-- For DBs that added the column before ON DELETE SET NULL was specified, swap
+-- the default NO ACTION FK so deleting a connection nulls the binding instead
+-- of blocking. Idempotent: only acts when the current rule isn't already SET
+-- NULL ('n'); re-runs are no-ops.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'ai_sessions_delegant_m365_connection_id_fkey'
+      AND conrelid = 'ai_sessions'::regclass
+      AND confdeltype <> 'n'
+  ) THEN
+    ALTER TABLE ai_sessions
+      DROP CONSTRAINT ai_sessions_delegant_m365_connection_id_fkey;
+    ALTER TABLE ai_sessions
+      ADD CONSTRAINT ai_sessions_delegant_m365_connection_id_fkey
+      FOREIGN KEY (delegant_m365_connection_id)
+      REFERENCES delegant_m365_connections (id) ON DELETE SET NULL;
+  END IF;
+END $$;
 
 ALTER TABLE ai_tool_executions
   ADD COLUMN IF NOT EXISTS delegant_tool_call_id VARCHAR(64);

--- a/apps/api/src/config/env.delegant.test.ts
+++ b/apps/api/src/config/env.delegant.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+describe('delegant env config', () => {
+  const ORIGINAL = { ...process.env };
+  afterEach(() => {
+    process.env = { ...ORIGINAL };
+  });
+
+  it('reads DELEGANT_* vars when present', async () => {
+    process.env.DELEGANT_BASE_URL = 'https://delegant.example';
+    process.env.DELEGANT_SERVICE_TOKEN = 'svc-token';
+    process.env.DELEGANT_PRINCIPAL_SIGNING_KEY = '-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----';
+    process.env.DELEGANT_PRINCIPAL_KID = 'kid-1';
+
+    vi.resetModules();
+    const mod = await import('./env');
+
+    expect(mod.DELEGANT_BASE_URL).toBe('https://delegant.example');
+    expect(mod.DELEGANT_SERVICE_TOKEN).toBe('svc-token');
+    expect(mod.DELEGANT_PRINCIPAL_KID).toBe('kid-1');
+    expect(mod.DELEGANT_PRINCIPAL_SIGNING_KEY).toContain('BEGIN PRIVATE KEY');
+  });
+
+  it('defaults to empty strings when absent', async () => {
+    delete process.env.DELEGANT_BASE_URL;
+    delete process.env.DELEGANT_SERVICE_TOKEN;
+    delete process.env.DELEGANT_PRINCIPAL_SIGNING_KEY;
+    delete process.env.DELEGANT_PRINCIPAL_KID;
+
+    vi.resetModules();
+    const mod = await import('./env');
+
+    expect(typeof mod.DELEGANT_BASE_URL).toBe('string');
+    expect(typeof mod.DELEGANT_SERVICE_TOKEN).toBe('string');
+    expect(typeof mod.DELEGANT_PRINCIPAL_SIGNING_KEY).toBe('string');
+    expect(typeof mod.DELEGANT_PRINCIPAL_KID).toBe('string');
+    expect(mod.DELEGANT_BASE_URL).toBe('');
+    expect(mod.DELEGANT_SERVICE_TOKEN).toBe('');
+    expect(mod.DELEGANT_PRINCIPAL_SIGNING_KEY).toBe('');
+    expect(mod.DELEGANT_PRINCIPAL_KID).toBe('');
+  });
+});

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -48,3 +48,10 @@ export const OAUTH_COOKIE_SECRET = process.env.OAUTH_COOKIE_SECRET ?? '';
 export function mfaForcePartnerAdmin(): boolean {
   return envFlag('MFA_FORCE_FOR_PARTNER_ADMIN', true);
 }
+
+// Delegant service configuration for M365 helpdesk agent capability.
+// Delegant is a sibling service that manages AI-agent identity and governance.
+export const DELEGANT_BASE_URL = process.env.DELEGANT_BASE_URL ?? '';
+export const DELEGANT_SERVICE_TOKEN = process.env.DELEGANT_SERVICE_TOKEN ?? '';
+export const DELEGANT_PRINCIPAL_SIGNING_KEY = process.env.DELEGANT_PRINCIPAL_SIGNING_KEY ?? '';
+export const DELEGANT_PRINCIPAL_KID = process.env.DELEGANT_PRINCIPAL_KID ?? '';

--- a/apps/api/src/config/validate.test.ts
+++ b/apps/api/src/config/validate.test.ts
@@ -1082,6 +1082,31 @@ describe('validateConfig', () => {
       });
     });
 
+    // --- Delegant M365 (DELEGANT_BASE_URL as soft-enable indicator) ----------
+    it('refuses to boot when DELEGANT_BASE_URL is set but a companion secret is missing', () => {
+      withEnv({
+        ...prodBase,
+        DELEGANT_BASE_URL: 'https://delegant.internal',
+        DELEGANT_SERVICE_TOKEN: 'svc',
+        DELEGANT_PRINCIPAL_SIGNING_KEY: '',
+        DELEGANT_PRINCIPAL_KID: 'kid-1',
+      }, () => {
+        expect(() => validateConfig()).toThrow(/DELEGANT_PRINCIPAL_SIGNING_KEY/);
+      });
+    });
+
+    it('does not require Delegant secrets when DELEGANT_BASE_URL is unset', () => {
+      withEnv({
+        ...prodBase,
+        DELEGANT_BASE_URL: '',
+        DELEGANT_SERVICE_TOKEN: '',
+        DELEGANT_PRINCIPAL_SIGNING_KEY: '',
+        DELEGANT_PRINCIPAL_KID: '',
+      }, () => {
+        expect(() => validateConfig()).not.toThrow();
+      });
+    });
+
     // --- Dev mode never enforces ----------------------------------------------
     it('does not enforce feature-flagged secrets in development', () => {
       withEnv({

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -432,6 +432,15 @@ const envSchema = z
     MSI_SIGNING_URL: z.string().optional(),
     MSI_SIGNING_CF_ACCESS_SECRET: z.string().optional(),
 
+    // Delegant M365 helpdesk — DELEGANT_BASE_URL is the soft-enable indicator.
+    // When set, the service token + principal signing material are required;
+    // without them every M365 tool call mints an empty/invalid principal JWT
+    // and 5xxs (auth_failed) at first use instead of failing at boot.
+    DELEGANT_BASE_URL: z.string().optional(),
+    DELEGANT_SERVICE_TOKEN: z.string().optional(),
+    DELEGANT_PRINCIPAL_SIGNING_KEY: z.string().optional(),
+    DELEGANT_PRINCIPAL_KID: z.string().optional(),
+
     // -- Optional with defaults -----------------------------------------------
     API_PORT: portSchema,
     REDIS_URL: z.string().default('redis://localhost:6379'),
@@ -913,6 +922,33 @@ const envSchema = z
         'MSI_SIGNING_URL is set (Cloudflare Access service-token auth to the signing tunnel)',
         ctx,
       );
+
+      // Delegant M365 helpdesk (DELEGANT_BASE_URL as indicator). When the
+      // feature is soft-enabled, all transport + principal-signing material is
+      // required; a partial config mints an empty/invalid principal JWT and
+      // auth_fails at first M365 tool call instead of failing at boot.
+      const delegantEnabled = Boolean(data.DELEGANT_BASE_URL?.trim());
+      requireIf(
+        delegantEnabled,
+        'DELEGANT_SERVICE_TOKEN',
+        data.DELEGANT_SERVICE_TOKEN,
+        'DELEGANT_BASE_URL is set (service-to-service auth to Delegant)',
+        ctx,
+      );
+      requireIf(
+        delegantEnabled,
+        'DELEGANT_PRINCIPAL_SIGNING_KEY',
+        data.DELEGANT_PRINCIPAL_SIGNING_KEY,
+        'DELEGANT_BASE_URL is set (Ed25519 PKCS8 key that signs the principal JWT)',
+        ctx,
+      );
+      requireIf(
+        delegantEnabled,
+        'DELEGANT_PRINCIPAL_KID',
+        data.DELEGANT_PRINCIPAL_KID,
+        'DELEGANT_BASE_URL is set (key id Delegant uses to verify the principal JWT)',
+        ctx,
+      );
     }
   });
 
@@ -1056,6 +1092,10 @@ export function validateConfig(): AppConfig {
     CLOUDFLARE_ZONE_ID: env.CLOUDFLARE_ZONE_ID,
     MSI_SIGNING_URL: env.MSI_SIGNING_URL,
     MSI_SIGNING_CF_ACCESS_SECRET: env.MSI_SIGNING_CF_ACCESS_SECRET,
+    DELEGANT_BASE_URL: env.DELEGANT_BASE_URL,
+    DELEGANT_SERVICE_TOKEN: env.DELEGANT_SERVICE_TOKEN,
+    DELEGANT_PRINCIPAL_SIGNING_KEY: env.DELEGANT_PRINCIPAL_SIGNING_KEY,
+    DELEGANT_PRINCIPAL_KID: env.DELEGANT_PRINCIPAL_KID,
     API_PORT: env.API_PORT,
     REDIS_URL: env.REDIS_URL,
     REDIS_HOST: env.REDIS_HOST,

--- a/apps/api/src/db/schema/ai.ts
+++ b/apps/api/src/db/schema/ai.ts
@@ -44,6 +44,7 @@ export const aiSessions = pgTable('ai_sessions', {
   flaggedAt: timestamp('flagged_at'),
   flaggedBy: uuid('flagged_by').references(() => users.id),
   flagReason: text('flag_reason'),
+  delegantM365ConnectionId: uuid('delegant_m365_connection_id'),
 }, (table) => ({
   orgIdIdx: index('ai_sessions_org_id_idx').on(table.orgId),
   userIdIdx: index('ai_sessions_user_id_idx').on(table.userId),
@@ -90,6 +91,7 @@ export const aiToolExecutions = pgTable('ai_tool_executions', {
   commandId: uuid('command_id'),
   durationMs: integer('duration_ms'),
   errorMessage: text('error_message'),
+  delegantToolCallId: varchar('delegant_tool_call_id', { length: 64 }),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   completedAt: timestamp('completed_at')
 }, (table) => ({

--- a/apps/api/src/db/schema/delegant.test.ts
+++ b/apps/api/src/db/schema/delegant.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { getTableConfig } from 'drizzle-orm/pg-core';
+import { delegantM365Connections } from './delegant';
+
+describe('delegantM365Connections schema', () => {
+  it('has the expected columns', () => {
+    const cfg = getTableConfig(delegantM365Connections);
+    const names = cfg.columns.map((c) => c.name).sort();
+    expect(names).toEqual(
+      [
+        'id', 'org_id', 'customer_label', 'customer_display_name',
+        'delegant_org_id', 'delegant_connection_id', 'm365_tenant_id',
+        'status', 'last_verified_at', 'created_at', 'updated_at',
+      ].sort(),
+    );
+  });
+
+  it('is named delegant_m365_connections', () => {
+    expect(getTableConfig(delegantM365Connections).name).toBe('delegant_m365_connections');
+  });
+});

--- a/apps/api/src/db/schema/delegant.ts
+++ b/apps/api/src/db/schema/delegant.ts
@@ -1,0 +1,31 @@
+import {
+  pgTable,
+  uuid,
+  varchar,
+  timestamp,
+  uniqueIndex,
+  index,
+} from 'drizzle-orm/pg-core';
+
+export const delegantM365Connections = pgTable(
+  'delegant_m365_connections',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    orgId: uuid('org_id').notNull(),
+    customerLabel: varchar('customer_label', { length: 128 }).notNull(),
+    customerDisplayName: varchar('customer_display_name', { length: 256 }).notNull(),
+    delegantOrgId: varchar('delegant_org_id', { length: 64 }).notNull(),
+    delegantConnectionId: varchar('delegant_connection_id', { length: 64 }).notNull(),
+    m365TenantId: varchar('m365_tenant_id', { length: 64 }).notNull(),
+    status: varchar('status', { length: 32 }).notNull().default('active'),
+    lastVerifiedAt: timestamp('last_verified_at'),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (t) => ({
+    orgCustomerUniq: uniqueIndex('delegant_m365_org_customer_uniq').on(t.orgId, t.customerLabel),
+    orgIdx: index('delegant_m365_org_idx').on(t.orgId),
+  })
+);
+
+export type DelegantM365ConnectionRow = typeof delegantM365Connections.$inferSelect;

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -60,6 +60,7 @@ export * from './warranty';
 export * from './applicationBackup';
 export * from './hypervVms';
 export * from './c2c';
+export * from './delegant';
 export * from './sla';
 export * from './drPlans';
 export * from './localVault';

--- a/apps/api/src/routes/ai.m365session.test.ts
+++ b/apps/api/src/routes/ai.m365session.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  aiSessions: {
+    id: 'aiSessions.id',
+    orgId: 'aiSessions.orgId',
+    userId: 'aiSessions.userId',
+    delegantM365ConnectionId: 'aiSessions.delegantM365ConnectionId',
+  },
+  aiMessages: {
+    id: 'aiMessages.id',
+    sessionId: 'aiMessages.sessionId',
+  },
+  aiToolExecutions: {
+    id: 'aiToolExecutions.id',
+    sessionId: 'aiToolExecutions.sessionId',
+  },
+  auditLogs: {
+    id: 'auditLogs.id',
+    orgId: 'auditLogs.orgId',
+  },
+  aiActionPlans: {
+    id: 'aiActionPlans.id',
+  },
+  delegantM365Connections: {
+    id: 'delegantM365Connections.id',
+    orgId: 'delegantM365Connections.orgId',
+    customerLabel: 'delegantM365Connections.customerLabel',
+    customerDisplayName: 'delegantM365Connections.customerDisplayName',
+    status: 'delegantM365Connections.status',
+  },
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', {
+      user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+      scope: 'organization',
+      partnerId: null,
+      orgId: 'org-111',
+      accessibleOrgIds: ['org-111'],
+      orgCondition: () => undefined,
+      canAccessOrg: (id: string) => id === 'org-111',
+    });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+vi.mock('../services/aiAgent', () => ({
+  createSession: vi.fn(),
+  getSession: vi.fn(),
+  listSessions: vi.fn(),
+  closeSession: vi.fn(),
+  getSessionMessages: vi.fn(),
+  handleApproval: vi.fn(),
+  searchSessions: vi.fn(),
+  listM365Connections: vi.fn(),
+}));
+
+vi.mock('../services/aiCostTracker', () => ({
+  getSessionHistory: vi.fn(),
+  getUsageSummary: vi.fn(),
+  updateBudget: vi.fn(),
+}));
+
+vi.mock('../services/streamingSessionManager', () => ({
+  streamingSessionManager: {
+    getOrCreate: vi.fn(),
+    get: vi.fn(),
+    remove: vi.fn(),
+    tryTransitionToProcessing: vi.fn(),
+    interrupt: vi.fn(),
+    startTurnTimeout: vi.fn(),
+  },
+}));
+
+vi.mock('../services/aiAgentSdk', () => ({
+  runPreFlightChecks: vi.fn(),
+  abortActivePlan: vi.fn(),
+}));
+
+vi.mock('../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn(),
+}));
+
+vi.mock('../services/sentry', () => ({
+  captureException: vi.fn(),
+}));
+
+import { aiRoutes } from './ai';
+import { createSession, listM365Connections } from '../services/aiAgent';
+
+const SESSION_ID = '11111111-1111-1111-1111-111111111111';
+const CONNECTION_ID = '33333333-3333-3333-3333-333333333333';
+
+describe('AI M365 session binding', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/ai', aiRoutes);
+  });
+
+  // ============================================
+  // POST /sessions with delegantM365ConnectionId
+  // ============================================
+  describe('POST /ai/sessions with M365 connection', () => {
+    it('creates a session bound to a same-org connection', async () => {
+      vi.mocked(createSession).mockResolvedValueOnce({
+        id: SESSION_ID,
+        orgId: 'org-111',
+        delegantM365ConnectionId: CONNECTION_ID,
+      } as any);
+
+      const res = await app.request('/ai/sessions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ delegantM365ConnectionId: CONNECTION_ID }),
+      });
+
+      expect(res.status).toBe(201);
+      // service was called with the connection id in the body
+      expect(vi.mocked(createSession)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ delegantM365ConnectionId: CONNECTION_ID })
+      );
+    });
+
+    it('rejects a session bound to a cross-org / unknown connection with 400', async () => {
+      vi.mocked(createSession).mockRejectedValueOnce(new Error('Invalid M365 connection'));
+
+      const res = await app.request('/ai/sessions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ delegantM365ConnectionId: CONNECTION_ID }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid M365 connection');
+    });
+
+    it('creates a session with NO connection (back-compat)', async () => {
+      vi.mocked(createSession).mockResolvedValueOnce({
+        id: SESSION_ID,
+        orgId: 'org-111',
+      } as any);
+
+      const res = await app.request('/ai/sessions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({}),
+      });
+
+      expect(res.status).toBe(201);
+      const callArg = vi.mocked(createSession).mock.calls[0]![1] as any;
+      expect(callArg.delegantM365ConnectionId).toBeUndefined();
+    });
+
+    it('rejects a non-uuid connection id at the schema boundary with 400', async () => {
+      const res = await app.request('/ai/sessions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ delegantM365ConnectionId: 'not-a-uuid' }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(vi.mocked(createSession)).not.toHaveBeenCalled();
+    });
+  });
+
+  // ============================================
+  // GET /m365-connections
+  // ============================================
+  describe('GET /ai/m365-connections', () => {
+    it('returns only the three safe fields for active connections', async () => {
+      vi.mocked(listM365Connections).mockResolvedValueOnce([
+        { id: CONNECTION_ID, customerLabel: 'acme', customerDisplayName: 'Acme Corp' },
+      ]);
+
+      const res = await app.request('/ai/m365-connections', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toEqual([
+        { id: CONNECTION_ID, customerLabel: 'acme', customerDisplayName: 'Acme Corp' },
+      ]);
+      // never leak the delegant pointer fields
+      const json = JSON.stringify(body);
+      expect(json).not.toContain('delegantOrgId');
+      expect(json).not.toContain('delegantConnectionId');
+      expect(json).not.toContain('m365TenantId');
+    });
+  });
+});

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -17,7 +17,8 @@ import {
   closeSession,
   getSessionMessages,
   handleApproval,
-  searchSessions
+  searchSessions,
+  listM365Connections
 } from '../services/aiAgent';
 import { runPreFlightChecks, abortActivePlan } from '../services/aiAgentSdk';
 import { streamingSessionManager } from '../services/streamingSessionManager';
@@ -40,7 +41,8 @@ import { aiActionPlans } from '../db/schema';
 import { captureException } from '../services/sentry';
 
 const createAiSessionSchema = sharedCreateAiSessionSchema.extend({
-  orgId: z.string().uuid().optional()
+  orgId: z.string().uuid().optional(),
+  delegantM365ConnectionId: z.string().uuid().optional()
 });
 
 /**
@@ -92,6 +94,7 @@ aiRoutes.post(
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to create session';
       if (message === 'Organization context required') return c.json({ error: message }, 400);
+      if (message === 'Invalid M365 connection') return c.json({ error: message }, 400);
       if (message === 'Access denied to this organization') return c.json({ error: message }, 403);
       return c.json({ error: message }, 500);
     }
@@ -115,6 +118,19 @@ aiRoutes.get(
     });
 
     return c.json({ data: sessions });
+  }
+);
+
+// GET /m365-connections - List the caller's active M365 customer connections.
+// Returns ONLY id, customerLabel, customerDisplayName — never delegant pointer fields.
+aiRoutes.get(
+  '/m365-connections',
+  requireScope('organization', 'partner', 'system'),
+  requireAiRead,
+  async (c) => {
+    const auth = c.get('auth');
+    const rows = await listM365Connections(auth);
+    return c.json({ data: rows });
   }
 );
 

--- a/apps/api/src/routes/approvals.test.ts
+++ b/apps/api/src/routes/approvals.test.ts
@@ -25,7 +25,12 @@ vi.mock('../db/schema/approvals', () => ({
 }));
 
 vi.mock('../db/schema/ai', () => ({
-  aiToolExecutions: { id: 'id' },
+  aiToolExecutions: { id: 'id', sessionId: 'session_id' },
+  aiSessions: { id: 'id', delegantM365ConnectionId: 'delegant_m365_connection_id' },
+}));
+
+vi.mock('../db/schema/delegant', () => ({
+  delegantM365Connections: { id: 'id', customerDisplayName: 'customer_display_name' },
 }));
 
 vi.mock('../db/schema/audit', () => ({
@@ -90,6 +95,16 @@ function mockSelectResolves(rows: unknown[]) {
       where: vi.fn().mockResolvedValue(rows),
     }),
   } as any);
+}
+
+// Mocks the customer-tenant join chain used by lookupCustomerTenants:
+//   db.select({...}).from(...).innerJoin(...).innerJoin(...).where(...)
+function mockTenantJoinResolves(rows: unknown[]) {
+  const innerJoin2 = { where: vi.fn().mockResolvedValue(rows) };
+  const innerJoin1 = { innerJoin: vi.fn().mockReturnValue(innerJoin2) };
+  return {
+    from: vi.fn().mockReturnValue({ innerJoin: vi.fn().mockReturnValue(innerJoin1) }),
+  };
 }
 
 beforeEach(() => {
@@ -178,6 +193,67 @@ describe('GET /approvals/:id', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.approval.id).toBe('a1');
+  });
+});
+
+describe('GET /approvals/:id customer tenant (M365)', () => {
+  const m365Approval = {
+    id: 'a1',
+    userId: TEST_USER.id,
+    requestingClientLabel: 'Breeze AI',
+    requestingMachineLabel: null,
+    requestingClientId: null,
+    requestingSessionId: null,
+    actionLabel: 'Reset M365 password',
+    actionToolName: 'm365_reset_password',
+    actionArguments: { userPrincipalName: 'jane@pinnacle.dental' },
+    riskTier: 'high',
+    riskSummary: 'Reset M365 password for jane@pinnacle.dental on Pinnacle Dental.',
+    status: 'pending',
+    expiresAt: new Date(Date.now() + 60_000),
+    decidedAt: null,
+    decisionReason: null,
+    executionId: 'exec-m365',
+    isRecursive: false,
+    createdAt: new Date(),
+  };
+
+  it('serializes customerTenant from the connection for an m365 mutation approval', async () => {
+    // 1) approval row select; 2) customer-tenant join chain.
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([m365Approval]),
+        }),
+      } as any)
+      .mockReturnValueOnce(
+        mockTenantJoinResolves([
+          { executionId: 'exec-m365', customerDisplayName: 'Pinnacle Dental' },
+        ]) as any,
+      );
+
+    const res = await buildApp().request('/approvals/a1');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.approval.customerTenant).toBe('Pinnacle Dental');
+  });
+
+  it('serializes customerTenant: null for a non-m365 approval (no tenant lookup)', async () => {
+    const nonM365 = {
+      ...m365Approval,
+      actionToolName: 'breeze.devices.reboot',
+      riskSummary: 'Reboot devices.',
+    };
+    // Only the approval-row select runs; lookupCustomerTenants short-circuits
+    // (no m365 tool) and never queries the DB.
+    mockSelectResolves([nonM365]);
+
+    const res = await buildApp().request('/approvals/a1');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.approval.customerTenant).toBeNull();
+    // The join select must not have been invoked beyond the single row read.
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/api/src/routes/approvals.ts
+++ b/apps/api/src/routes/approvals.ts
@@ -1,12 +1,13 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { zValidator } from '@hono/zod-validator';
-import { and, eq, gt, desc } from 'drizzle-orm';
+import { and, eq, gt, desc, inArray } from 'drizzle-orm';
 
 import { db } from '../db';
 import { authMiddleware } from '../middleware/auth';
 import { approvalRequests } from '../db/schema/approvals';
-import { aiToolExecutions } from '../db/schema/ai';
+import { aiToolExecutions, aiSessions } from '../db/schema/ai';
+import { delegantM365Connections } from '../db/schema/delegant';
 import { auditLogs } from '../db/schema/audit';
 import { buildApprovalPush, getUserPushTokens, sendExpoPush } from '../services/expoPush';
 import { revokeUserOauthClient } from './lifecycle';
@@ -29,7 +30,14 @@ approvalRoutes.get('/pending', async (c) => {
     )
     .orderBy(desc(approvalRequests.createdAt));
 
-  return c.json({ approvals: rows.map(serialize) });
+  // Batched lookup: one query resolves the customer tenant for ALL M365
+  // mutation rows in this list (no N+1).
+  const tenants = await lookupCustomerTenants(rows);
+  return c.json({
+    approvals: rows.map((r) =>
+      serialize(r, (r.executionId && tenants.get(r.executionId)) || null),
+    ),
+  });
 });
 
 const denySchema = z.object({
@@ -130,7 +138,9 @@ approvalRoutes.get('/:id', async (c) => {
     .where(and(eq(approvalRequests.id, id), eq(approvalRequests.userId, userId)));
 
   if (!row) return c.json({ error: 'Not found' }, 404);
-  return c.json({ approval: serialize(row) });
+  const tenants = await lookupCustomerTenants([row]);
+  const customerTenant = (row.executionId && tenants.get(row.executionId)) || null;
+  return c.json({ approval: serialize(row, customerTenant) });
 });
 
 approvalRoutes.post('/:id/approve', async (c) => {
@@ -308,7 +318,56 @@ async function decideHandler(
   return c.json({ approval: serialize(updated!) });
 }
 
-function serialize(r: typeof approvalRequests.$inferSelect) {
+// The two M365 mutation tools (tier 3) that create an approval card. Read-only
+// M365 tools are tier 1 and never reach this surface. Only these get a customer
+// tenant lookup so a technician sees the blast radius at a glance.
+const M365_MUTATION_TOOLS = new Set(['m365_reset_password', 'm365_disable_user']);
+
+/**
+ * Resolve the customer tenant display name for a set of approval rows whose
+ * action is an M365 mutation. Walks executionId -> ai_tool_executions.sessionId
+ * -> ai_sessions.delegantM365ConnectionId -> delegant_m365_connections, joined
+ * in ONE query for ALL given execution ids (no per-row / N+1 lookups).
+ *
+ * Returns a Map keyed by executionId. Rows with no execution, a non-M365 tool,
+ * or a session without a Delegant M365 connection are simply absent from the
+ * map and serialize as customerTenant: null.
+ */
+async function lookupCustomerTenants(
+  rows: (typeof approvalRequests.$inferSelect)[],
+): Promise<Map<string, string>> {
+  const executionIds = rows
+    .filter((r) => r.executionId && M365_MUTATION_TOOLS.has(r.actionToolName))
+    .map((r) => r.executionId as string);
+
+  if (executionIds.length === 0) return new Map();
+
+  const joined = await db
+    .select({
+      executionId: aiToolExecutions.id,
+      customerDisplayName: delegantM365Connections.customerDisplayName,
+    })
+    .from(aiToolExecutions)
+    .innerJoin(aiSessions, eq(aiSessions.id, aiToolExecutions.sessionId))
+    .innerJoin(
+      delegantM365Connections,
+      eq(delegantM365Connections.id, aiSessions.delegantM365ConnectionId),
+    )
+    .where(inArray(aiToolExecutions.id, executionIds));
+
+  const map = new Map<string, string>();
+  for (const row of joined) {
+    if (row.executionId && row.customerDisplayName) {
+      map.set(row.executionId, row.customerDisplayName);
+    }
+  }
+  return map;
+}
+
+function serialize(
+  r: typeof approvalRequests.$inferSelect,
+  customerTenant: string | null = null,
+) {
   return {
     id: r.id,
     requestingClientLabel: r.requestingClientLabel,
@@ -318,6 +377,7 @@ function serialize(r: typeof approvalRequests.$inferSelect) {
     actionArguments: r.actionArguments,
     riskTier: r.riskTier,
     riskSummary: r.riskSummary,
+    customerTenant,
     status: r.status,
     expiresAt: r.expiresAt.toISOString(),
     decidedAt: r.decidedAt?.toISOString() ?? null,

--- a/apps/api/src/services/aiAgent.m365.test.ts
+++ b/apps/api/src/services/aiAgent.m365.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the DB and the schema so we can drive createSession / listM365Connections
+// through the real service logic without a live database.
+const selectMock = vi.fn();
+const insertMock = vi.fn();
+
+vi.mock('../db', () => ({
+  db: {
+    select: (...args: unknown[]) => selectMock(...args),
+    insert: (...args: unknown[]) => insertMock(...args),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  aiSessions: { id: 'aiSessions.id', orgId: 'aiSessions.orgId' },
+  aiMessages: { sessionId: 'aiMessages.sessionId', createdAt: 'aiMessages.createdAt' },
+  aiToolExecutions: {},
+  delegantM365Connections: {
+    id: 'delegantM365Connections.id',
+    orgId: 'delegantM365Connections.orgId',
+    customerLabel: 'delegantM365Connections.customerLabel',
+    customerDisplayName: 'delegantM365Connections.customerDisplayName',
+    status: 'delegantM365Connections.status',
+  },
+}));
+
+vi.mock('./aiAgentSystemPrompt', () => ({ AI_SYSTEM_PROMPT_BASE: 'base' }));
+vi.mock('./brainDeviceContext', () => ({
+  getActiveDeviceContext: vi.fn().mockResolvedValue(null),
+}));
+
+import { createSession, listM365Connections } from './aiAgent';
+
+const CONNECTION_ID = '33333333-3333-3333-3333-333333333333';
+
+function connSelect(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  };
+}
+
+const auth: any = {
+  user: { id: 'user-1' },
+  orgId: 'org-111',
+  accessibleOrgIds: ['org-111'],
+  canAccessOrg: (id: string) => id === 'org-111',
+  orgCondition: () => undefined,
+};
+
+describe('createSession M365 binding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects a connection belonging to a different org', async () => {
+    selectMock.mockReturnValueOnce(
+      connSelect([{ id: CONNECTION_ID, orgId: 'org-OTHER', status: 'active' }])
+    );
+
+    await expect(
+      createSession(auth, { delegantM365ConnectionId: CONNECTION_ID })
+    ).rejects.toThrow('Invalid M365 connection');
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown connection', async () => {
+    selectMock.mockReturnValueOnce(connSelect([]));
+
+    await expect(
+      createSession(auth, { delegantM365ConnectionId: CONNECTION_ID })
+    ).rejects.toThrow('Invalid M365 connection');
+  });
+
+  it('rejects a non-active connection', async () => {
+    selectMock.mockReturnValueOnce(
+      connSelect([{ id: CONNECTION_ID, orgId: 'org-111', status: 'revoked' }])
+    );
+
+    await expect(
+      createSession(auth, { delegantM365ConnectionId: CONNECTION_ID })
+    ).rejects.toThrow('Invalid M365 connection');
+  });
+
+  it('persists delegantM365ConnectionId for a valid same-org connection', async () => {
+    selectMock.mockReturnValueOnce(
+      connSelect([{ id: CONNECTION_ID, orgId: 'org-111', status: 'active' }])
+    );
+    const valuesSpy = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([{ id: 'sess-1' }]),
+    });
+    insertMock.mockReturnValueOnce({ values: valuesSpy });
+
+    const result = await createSession(auth, { delegantM365ConnectionId: CONNECTION_ID });
+
+    expect(result.delegantM365ConnectionId).toBe(CONNECTION_ID);
+    expect(valuesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ delegantM365ConnectionId: CONNECTION_ID })
+    );
+  });
+
+  it('persists a null connection id when none is supplied (back-compat)', async () => {
+    const valuesSpy = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([{ id: 'sess-1' }]),
+    });
+    insertMock.mockReturnValueOnce({ values: valuesSpy });
+
+    const result = await createSession(auth, {});
+
+    expect(result.delegantM365ConnectionId).toBeNull();
+    // no connection lookup performed
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(valuesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ delegantM365ConnectionId: null })
+    );
+  });
+});
+
+describe('listM365Connections', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('selects only the three safe columns filtered to active connections', async () => {
+    const selectArgsHolder: any = {};
+    const whereSpy = vi.fn().mockReturnValue({
+      orderBy: vi.fn().mockResolvedValue([
+        { id: CONNECTION_ID, customerLabel: 'acme', customerDisplayName: 'Acme Corp' },
+      ]),
+    });
+    selectMock.mockImplementationOnce((cols: any) => {
+      selectArgsHolder.cols = cols;
+      return { from: vi.fn().mockReturnValue({ where: whereSpy }) };
+    });
+
+    const rows = await listM365Connections(auth);
+
+    expect(rows).toEqual([
+      { id: CONNECTION_ID, customerLabel: 'acme', customerDisplayName: 'Acme Corp' },
+    ]);
+    // projection must NOT include any pointer/tenant fields
+    expect(Object.keys(selectArgsHolder.cols)).toEqual([
+      'id',
+      'customerLabel',
+      'customerDisplayName',
+    ]);
+  });
+});

--- a/apps/api/src/services/aiAgent.ts
+++ b/apps/api/src/services/aiAgent.ts
@@ -7,7 +7,7 @@
  */
 
 import { db } from '../db';
-import { aiSessions, aiMessages, aiToolExecutions } from '../db/schema';
+import { aiSessions, aiMessages, aiToolExecutions, delegantM365Connections } from '../db/schema';
 import { eq, and, desc, sql, type SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiPageContext, AiApprovalMode } from '@breeze/shared/types/ai';
@@ -24,12 +24,38 @@ const DEFAULT_MODEL = 'claude-sonnet-4-5-20250929';
 
 export async function createSession(
   auth: AuthContext,
-  options: { pageContext?: AiPageContext; model?: string; title?: string; orgId?: string }
-): Promise<{ id: string; orgId: string }> {
+  options: {
+    pageContext?: AiPageContext;
+    model?: string;
+    title?: string;
+    orgId?: string;
+    delegantM365ConnectionId?: string;
+  }
+): Promise<{ id: string; orgId: string; delegantM365ConnectionId: string | null }> {
   const orgId = options.orgId ?? auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
   if (!orgId) throw new Error('Organization context required');
   if (orgId !== auth.orgId && !auth.canAccessOrg(orgId)) {
     throw new Error('Access denied to this organization');
+  }
+
+  // Cross-org validation (SECURITY-CRITICAL): a session may only be bound to an
+  // active M365 connection that belongs to the session's org.
+  let delegantM365ConnectionId: string | null = null;
+  if (options.delegantM365ConnectionId) {
+    const [conn] = await db
+      .select({
+        id: delegantM365Connections.id,
+        orgId: delegantM365Connections.orgId,
+        status: delegantM365Connections.status
+      })
+      .from(delegantM365Connections)
+      .where(eq(delegantM365Connections.id, options.delegantM365ConnectionId))
+      .limit(1);
+
+    if (!conn || conn.orgId !== orgId || conn.status !== 'active') {
+      throw new Error('Invalid M365 connection');
+    }
+    delegantM365ConnectionId = conn.id;
   }
 
   const [session] = await db
@@ -40,12 +66,13 @@ export async function createSession(
       model: options.model ?? DEFAULT_MODEL,
       title: options.title ?? null,
       contextSnapshot: options.pageContext ?? null,
+      delegantM365ConnectionId,
       systemPrompt: await buildSystemPrompt(auth, options.pageContext)
     })
     .returning();
 
   if (!session) throw new Error('Failed to create session');
-  return { id: session.id, orgId };
+  return { id: session.id, orgId, delegantM365ConnectionId };
 }
 
 export async function getSession(sessionId: string, auth: AuthContext) {
@@ -89,6 +116,33 @@ export async function listSessions(auth: AuthContext, options: { status?: string
     .offset(offset);
 
   return sessions;
+}
+
+/**
+ * List the caller's ACTIVE M365 customer connections.
+ *
+ * Returns ONLY the browser-safe projection (id, customerLabel,
+ * customerDisplayName) — never the delegant pointer / tenant fields.
+ * RLS (breeze_has_org_access) is enabled on the table; we also apply the
+ * explicit org filter here for defense-in-depth, matching the convention
+ * used by other AI services.
+ */
+export async function listM365Connections(
+  auth: AuthContext
+): Promise<{ id: string; customerLabel: string; customerDisplayName: string }[]> {
+  const conditions: SQL[] = [eq(delegantM365Connections.status, 'active')];
+  const orgCondition = auth.orgCondition(delegantM365Connections.orgId);
+  if (orgCondition) conditions.push(orgCondition);
+
+  return db
+    .select({
+      id: delegantM365Connections.id,
+      customerLabel: delegantM365Connections.customerLabel,
+      customerDisplayName: delegantM365Connections.customerDisplayName
+    })
+    .from(delegantM365Connections)
+    .where(and(...conditions))
+    .orderBy(delegantM365Connections.customerDisplayName);
 }
 
 export async function closeSession(sessionId: string, auth: AuthContext): Promise<{ orgId: string } | null> {

--- a/apps/api/src/services/aiAgentSdk.m365risk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.m365risk.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { buildM365RiskSummary } from './aiAgentSdk';
+import { TOOL_TIERS } from './aiAgentSdkTools';
+
+describe('buildM365RiskSummary', () => {
+  it('includes customer, user, and reason for reset_password', () => {
+    const s = buildM365RiskSummary('m365_reset_password',
+      { userIdentifier: 'jane@pinnacle.dental', reason: 'forgot password' },
+      { customerDisplayName: 'Pinnacle Dental' } as any);
+    expect(s).toContain('Pinnacle Dental');
+    expect(s).toContain('jane@pinnacle.dental');
+    expect(s).toContain('forgot password');
+  });
+  it('includes customer and user for disable_user', () => {
+    const s = buildM365RiskSummary('m365_disable_user',
+      { userIdentifier: 'bob@acme.co', reason: 'offboarding' },
+      { customerDisplayName: 'Acme' } as any);
+    expect(s).toContain('Acme');
+    expect(s).toContain('bob@acme.co');
+    expect(s).toContain('offboarding');
+  });
+  it('handles the mcp__breeze__ prefixed tool name', () => {
+    const s = buildM365RiskSummary('mcp__breeze__m365_reset_password',
+      { userIdentifier: 'jane@pinnacle.dental', reason: 'forgot password' },
+      { customerDisplayName: 'Pinnacle Dental' } as any);
+    expect(s).toContain('Pinnacle Dental');
+    expect(s).toContain('jane@pinnacle.dental');
+  });
+  it('returns null for a non-m365 tool', () => {
+    expect(buildM365RiskSummary('execute_command', {}, null)).toBeNull();
+  });
+  it('returns null when no connection is available', () => {
+    expect(buildM365RiskSummary('m365_reset_password', { userIdentifier: 'x', reason: 'y' }, null)).toBeNull();
+  });
+});
+
+describe('TOOL_TIERS — M365 helpdesk tools', () => {
+  it('registers M365 tool tiers 1/1/1/3/3', () => {
+    expect(TOOL_TIERS['m365_lookup_user']).toBe(1);
+    expect(TOOL_TIERS['m365_recent_signins']).toBe(1);
+    expect(TOOL_TIERS['m365_list_group_memberships']).toBe(1);
+    expect(TOOL_TIERS['m365_disable_user']).toBe(3);
+    expect(TOOL_TIERS['m365_reset_password']).toBe(3);
+  });
+});

--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -658,6 +658,63 @@ describe('createSessionPostToolUse', () => {
     expect(JSON.stringify(insertedPayloads)).not.toContain('hunter2');
     expect(JSON.stringify(insertedPayloads)).not.toContain('raw-secret');
   });
+
+  it('persists delegantToolCallId on the inserted execution row (tier < 2)', async () => {
+    const session = makeActiveSession();
+    const values = mockInsertValues();
+    const callback = createSessionPostToolUse(session);
+
+    await callback('m365_lookup_user', { userIdentifier: 'u1' }, JSON.stringify({
+      message: 'M365 user profile: {"id":"u1"}',
+      delegantToolCallId: 'tc-123',
+    }), false, 12);
+
+    // Two inserts fire (aiMessages then aiToolExecutions); the execution row is
+    // the one carrying toolInput.
+    const execInsert = values.mock.calls
+      .map((c) => c[0])
+      .find((v) => v && typeof v === 'object' && 'toolInput' in v);
+    expect(execInsert).toBeDefined();
+    expect((execInsert as any).delegantToolCallId).toBe('tc-123');
+  });
+
+  it('omits delegantToolCallId for non-M365 tool output (no key present)', async () => {
+    const session = makeActiveSession();
+    const values = mockInsertValues();
+    const callback = createSessionPostToolUse(session);
+
+    await callback('execute_command', { deviceId: 'device-1' }, JSON.stringify({
+      status: 'completed',
+    }), false, 12);
+
+    const execInsert = values.mock.calls
+      .map((c) => c[0])
+      .find((v) => v && typeof v === 'object' && 'toolInput' in v);
+    expect(execInsert).toBeDefined();
+    expect((execInsert as any).delegantToolCallId).toBeUndefined();
+  });
+
+  it('persists delegantToolCallId on the updated execution row (tier >= 2)', async () => {
+    vi.mocked(checkGuardrails).mockReturnValue({
+      allowed: true,
+      tier: 3,
+      requiresApproval: true,
+    } as any);
+    const session = makeActiveSession();
+    const where = vi.fn().mockResolvedValue(undefined);
+    const set = vi.fn().mockReturnValue({ where });
+    vi.mocked(db.update).mockReturnValue({ set } as any);
+    const callback = createSessionPostToolUse(session);
+
+    await callback('m365_reset_password', { userIdentifier: 'u1', reason: 'forgot' }, JSON.stringify({
+      message: 'Reset the password for u1.',
+      delegantToolCallId: 'tc-456',
+    }), false, 12);
+
+    const setCall = set.mock.calls.find((c) => c[0] && 'status' in c[0]);
+    expect(setCall).toBeDefined();
+    expect((setCall![0] as any).delegantToolCallId).toBe('tc-456');
+  });
 });
 
 // ============================================

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -23,6 +23,8 @@ import { writeAuditEvent, requestLikeFromSnapshot, type RequestLike } from './au
 import type { ActiveSession, AuditSnapshot } from './streamingSessionManager';
 import { compactToolResultForChat } from './aiToolOutput';
 import { buildApprovalPush, getUserPushTokens, sendExpoPush } from './expoPush';
+import { loadSession, loadConnection } from './m365Helpers';
+import type { DelegantM365ConnectionRow } from '../db/schema/delegant';
 
 const SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 const SESSION_IDLE_TIMEOUT_MS = 2 * 60 * 60 * 1000; // 2 hours
@@ -31,6 +33,34 @@ function stripMcpPrefix(toolName: string): string {
   if (!toolName.startsWith('mcp__')) return toolName;
   const separatorIndex = toolName.indexOf('__', 'mcp__'.length);
   return separatorIndex === -1 ? toolName : toolName.slice(separatorIndex + 2);
+}
+
+/**
+ * Human-readable verbs for the two M365 mutation tools that hit per-step
+ * approval. The three read tools are tier 1 and never create an approval card,
+ * so they are intentionally absent.
+ */
+const M365_VERB: Record<string, string> = {
+  m365_reset_password: 'Reset M365 password for',
+  m365_disable_user: 'Disable M365 sign-in for',
+};
+
+/**
+ * Build an enriched approval-card risk summary for M365 mutation tools,
+ * surfacing the customer tenant, target user, and the operator's reason.
+ * Returns null for non-M365 tools or when no connection is available, so the
+ * caller can fall back to the default guardrail description.
+ */
+export function buildM365RiskSummary(
+  toolName: string,
+  input: Record<string, unknown>,
+  conn: Pick<DelegantM365ConnectionRow, 'customerDisplayName'> | null,
+): string | null {
+  const verb = M365_VERB[stripMcpPrefix(toolName)] ?? M365_VERB[toolName];
+  if (!verb || !conn) return null;
+  const user = String(input.userIdentifier ?? 'a user');
+  const reason = input.reason ? ` Reason: ${String(input.reason)}.` : '';
+  return `${verb} ${user} on ${conn.customerDisplayName}.${reason}`;
 }
 
 function isAllowedForSession(toolName: string, allowedTools: readonly string[]): boolean {
@@ -386,7 +416,18 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
       const riskTier: 'medium' | 'high' | 'critical' =
         guardrailCheck.tier >= 4 ? 'critical' : guardrailCheck.tier >= 3 ? 'high' : 'medium';
       const actionLabel = description;
-      const riskSummary = description.length > 500 ? `${description.slice(0, 497)}...` : description;
+      // For M365 mutation tools, enrich the approval card with the customer
+      // tenant + target user + reason. Non-fatal: any DB hiccup falls back to
+      // the default description rather than throwing into the approval path.
+      let m365Summary: string | null = null;
+      try {
+        const sessRow = await loadSession(session.breezeSessionId);
+        if (sessRow?.delegantM365ConnectionId) {
+          const conn = await loadConnection(sessRow.delegantM365ConnectionId);
+          m365Summary = buildM365RiskSummary(toolName, input as Record<string, unknown>, conn);
+        }
+      } catch { /* non-fatal: fall back to default description */ }
+      const riskSummary = m365Summary ?? (description.length > 500 ? `${description.slice(0, 497)}...` : description);
       const expiresAt = new Date(Date.now() + 300_000); // matches waitForApproval timeout
 
       let approvalRequestId: string | undefined;

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -631,6 +631,7 @@ export function createSessionPostToolUse(session: ActiveSession): PostToolUseCal
               toolOutput: parsedOutput,
               status: isError ? 'failed' : 'completed',
               errorMessage: isError ? (typeof parsedOutput.error === 'string' ? parsedOutput.error : safeOutput.slice(0, 1000)) : undefined,
+              delegantToolCallId: typeof parsedOutput.delegantToolCallId === 'string' ? parsedOutput.delegantToolCallId : undefined,
               durationMs,
               completedAt: new Date(),
             })
@@ -649,6 +650,7 @@ export function createSessionPostToolUse(session: ActiveSession): PostToolUseCal
                 status: isError ? 'failed' : 'completed',
                 toolOutput: parsedOutput,
                 errorMessage: isError ? (typeof parsedOutput.error === 'string' ? parsedOutput.error : safeOutput.slice(0, 1000)) : undefined,
+                delegantToolCallId: typeof parsedOutput.delegantToolCallId === 'string' ? parsedOutput.delegantToolCallId : undefined,
                 durationMs,
                 completedAt: new Date(),
               })

--- a/apps/api/src/services/aiAgentSdkTools.m365gating.test.ts
+++ b/apps/api/src/services/aiAgentSdkTools.m365gating.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { m365ToolDefinitions } from './aiAgentSdkTools';
+
+// The 5 M365 helpdesk tools are only advertised to the model when the Delegant
+// integration is configured (DELEGANT_BASE_URL set). On instances with no M365
+// wiring they must not appear in the tool manifest at all.
+const getAuth = () => ({ user: { id: 'u1' }, orgId: 'o1' }) as any;
+const getSession = () => undefined;
+
+describe('M365 tool registration gating', () => {
+  const ORIG = process.env.DELEGANT_BASE_URL;
+  afterEach(() => {
+    if (ORIG === undefined) delete process.env.DELEGANT_BASE_URL;
+    else process.env.DELEGANT_BASE_URL = ORIG;
+  });
+
+  it('registers no M365 tools when DELEGANT_BASE_URL is unset', () => {
+    delete process.env.DELEGANT_BASE_URL;
+    expect(m365ToolDefinitions(getAuth, getSession, undefined, undefined)).toEqual([]);
+  });
+
+  it('treats a blank/whitespace DELEGANT_BASE_URL as unconfigured', () => {
+    process.env.DELEGANT_BASE_URL = '   ';
+    expect(m365ToolDefinitions(getAuth, getSession, undefined, undefined)).toEqual([]);
+  });
+
+  it('registers all 5 M365 tools (correct names) when DELEGANT_BASE_URL is set', () => {
+    process.env.DELEGANT_BASE_URL = 'https://delegant.example';
+    const names = m365ToolDefinitions(getAuth, getSession, undefined, undefined).map((t) => t.name);
+    expect(names).toEqual([
+      'm365_lookup_user',
+      'm365_recent_signins',
+      'm365_list_group_memberships',
+      'm365_disable_user',
+      'm365_reset_password',
+    ]);
+  });
+});

--- a/apps/api/src/services/aiAgentSdkTools.sessionAware.test.ts
+++ b/apps/api/src/services/aiAgentSdkTools.sessionAware.test.ts
@@ -34,7 +34,6 @@ const { makeSessionAwareHandler } = __test__;
 
 type ToolResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 const fakeAuth = { scope: 'organization', orgId: 'org-1', accessibleOrgIds: ['org-1'] } as any;
 const fakeSession = { breezeSessionId: 'sess-123', auth: fakeAuth } as any;
 

--- a/apps/api/src/services/aiAgentSdkTools.sessionAware.test.ts
+++ b/apps/api/src/services/aiAgentSdkTools.sessionAware.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ============================================
+// Mocks — keep makeSessionAwareHandler isolated from DB + heavy deps.
+// runOutsideDbContext / withDbAccessContext just invoke their callback so the
+// enforcement ordering (preToolUse -> handler -> postToolUse) is observable.
+// ============================================
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  db: {},
+}));
+
+vi.mock('./aiAgent', () => ({ waitForPlanApproval: vi.fn() }));
+
+// Identity compaction so we can assert on the exact handler output text.
+vi.mock('./aiToolOutput', () => ({
+  compactToolResultForChat: vi.fn((_tool: string, raw: string) => raw),
+}));
+
+// The M365 handlers are imported by the module under test; stub them out — we
+// inject our own sessionHandler into makeSessionAwareHandler.
+vi.mock('./aiToolsM365', () => ({
+  m365LookupUserHandler: vi.fn(),
+  m365RecentSigninsHandler: vi.fn(),
+  m365ListGroupMembershipsHandler: vi.fn(),
+  m365DisableUserHandler: vi.fn(),
+  m365ResetPasswordHandler: vi.fn(),
+}));
+
+import { __test__ } from './aiAgentSdkTools';
+
+const { makeSessionAwareHandler } = __test__;
+
+type ToolResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const fakeAuth = { scope: 'organization', orgId: 'org-1', accessibleOrgIds: ['org-1'] } as any;
+const fakeSession = { breezeSessionId: 'sess-123', auth: fakeAuth } as any;
+
+const firstText = (res: ToolResult) => res.content[0]?.text ?? '';
+
+describe('makeSessionAwareHandler (M365 enforcement routing)', () => {
+  let getAuth: any;
+  let getActiveSession: any;
+  let sessionHandler: any;
+  let onPreToolUse: any;
+  let onPostToolUse: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getAuth = vi.fn(() => fakeAuth);
+    getActiveSession = vi.fn(() => fakeSession);
+    sessionHandler = vi.fn(async () => JSON.stringify({ data: { ok: true } }));
+    onPreToolUse = vi.fn(async () => ({ allowed: true }));
+    onPostToolUse = vi.fn(async () => undefined);
+  });
+
+  // (1) Approval / guardrail / RBAC gate runs BEFORE the handler.
+  // On the old inline registration the handler was called directly with no
+  // onPreToolUse, so a tier-3 approval denial / RBAC denial could never block it.
+  it('blocks execution and returns the error when onPreToolUse denies (sessionHandler never runs)', async () => {
+    onPreToolUse.mockResolvedValueOnce({ allowed: false, error: 'approval_required' });
+    const handler = makeSessionAwareHandler(
+      'm365_reset_password', getAuth, getActiveSession, sessionHandler, onPreToolUse, onPostToolUse,
+    );
+
+    const res = (await handler({ userIdentifier: 'u@x.com', reason: 'r' })) as ToolResult;
+
+    expect(onPreToolUse).toHaveBeenCalledWith('m365_reset_password', { userIdentifier: 'u@x.com', reason: 'r' });
+    expect(sessionHandler).not.toHaveBeenCalled();
+    expect(res.isError).toBe(true);
+    expect(firstText(res)).toContain('approval_required');
+    // postToolUse still records the denied attempt (isError = true).
+    expect(onPostToolUse).toHaveBeenCalledWith(
+      'm365_reset_password', expect.any(Object), expect.stringContaining('approval_required'), true, 0,
+    );
+  });
+
+  // (2) onPostToolUse runs on success — proves the audit-persistence path executes.
+  // The old inline registration had NO onPostToolUse, so ai_tool_executions rows
+  // and delegant_tool_call_id were never written.
+  it('invokes onPostToolUse with toolName/args/result on success', async () => {
+    sessionHandler.mockResolvedValueOnce(JSON.stringify({ data: { reset: true } }));
+    const handler = makeSessionAwareHandler(
+      'm365_disable_user', getAuth, getActiveSession, sessionHandler, onPreToolUse, onPostToolUse,
+    );
+
+    await handler({ userIdentifier: 'u@x.com', reason: 'r' });
+
+    expect(onPostToolUse).toHaveBeenCalledTimes(1);
+    expect(onPostToolUse).toHaveBeenCalledWith(
+      'm365_disable_user',
+      { userIdentifier: 'u@x.com', reason: 'r' },
+      JSON.stringify({ data: { reset: true } }),
+      false,
+      expect.any(Number),
+    );
+  });
+
+  // (3) preTool allowed -> handler runs once and its text is returned.
+  it('calls sessionHandler once and returns its text when onPreToolUse allows', async () => {
+    sessionHandler.mockResolvedValueOnce(JSON.stringify({ data: { display: 'Jane' } }));
+    const handler = makeSessionAwareHandler(
+      'm365_lookup_user', getAuth, getActiveSession, sessionHandler, onPreToolUse, onPostToolUse,
+    );
+
+    const res = (await handler({ userIdentifier: 'jane@x.com' })) as ToolResult;
+
+    expect(onPreToolUse).toHaveBeenCalledTimes(1);
+    expect(sessionHandler).toHaveBeenCalledTimes(1);
+    // sessionHandler receives (args, auth, sessionId) — sessionId from active session.
+    expect(sessionHandler).toHaveBeenCalledWith({ userIdentifier: 'jane@x.com' }, fakeAuth, 'sess-123');
+    expect(res.isError).toBeUndefined();
+    expect(firstText(res)).toBe(JSON.stringify({ data: { display: 'Jane' } }));
+  });
+
+  // (4) No active session -> no_active_session error, handler & enforcement skipped.
+  it('returns no_active_session and skips handler when there is no active session', async () => {
+    getActiveSession.mockReturnValueOnce(undefined);
+    const handler = makeSessionAwareHandler(
+      'm365_lookup_user', getAuth, getActiveSession, sessionHandler, onPreToolUse, onPostToolUse,
+    );
+
+    const res = (await handler({ userIdentifier: 'jane@x.com' })) as ToolResult;
+
+    expect(res.isError).toBe(true);
+    expect(firstText(res)).toContain('no_active_session');
+    expect(onPreToolUse).not.toHaveBeenCalled();
+    expect(sessionHandler).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -472,6 +472,55 @@ export const __test__ = { makeSessionAwareHandler };
 // ============================================
 
 /**
+ * The Microsoft 365 helpdesk tool definitions, gated on the Delegant
+ * integration being configured. Returns [] (so the tools are NOT advertised to
+ * the model) on instances where DELEGANT_BASE_URL is unset/blank — without a
+ * configured Delegant endpoint + a seeded customer connection the tools can
+ * only ever no-op with `no_customer_selected`, so there's no reason to surface
+ * them. Read from process.env at call time so it tracks runtime config.
+ */
+export function m365ToolDefinitions(
+  getAuth: () => AuthContext,
+  getActiveSession: (() => ActiveSession | undefined) | undefined,
+  onPreToolUse?: PreToolUseCallback,
+  onPostToolUse?: PostToolUseCallback,
+) {
+  if (!(process.env.DELEGANT_BASE_URL ?? '').trim()) return [];
+  return [
+    tool(
+      'm365_lookup_user',
+      'Look up a Microsoft 365 user (profile, account status, assigned licenses) on the customer tenant selected for this session.',
+      { userIdentifier: z.string() },
+      makeSessionAwareHandler('m365_lookup_user', getAuth, getActiveSession, m365LookupUserHandler, onPreToolUse, onPostToolUse)
+    ),
+    tool(
+      'm365_recent_signins',
+      "Read recent sign-in activity for a Microsoft 365 user on the customer tenant selected for this session. Useful for can't-log-in and lockout triage.",
+      { userIdentifier: z.string() },
+      makeSessionAwareHandler('m365_recent_signins', getAuth, getActiveSession, m365RecentSigninsHandler, onPreToolUse, onPostToolUse)
+    ),
+    tool(
+      'm365_list_group_memberships',
+      'List the groups in the customer tenant selected for this session.',
+      {},
+      makeSessionAwareHandler('m365_list_group_memberships', getAuth, getActiveSession, m365ListGroupMembershipsHandler, onPreToolUse, onPostToolUse)
+    ),
+    tool(
+      'm365_disable_user',
+      'Disable (block sign-in for) a Microsoft 365 user on the customer tenant selected for this session. Requires approval.',
+      { userIdentifier: z.string(), reason: z.string() },
+      makeSessionAwareHandler('m365_disable_user', getAuth, getActiveSession, m365DisableUserHandler, onPreToolUse, onPostToolUse)
+    ),
+    tool(
+      'm365_reset_password',
+      'Reset the password for a Microsoft 365 user on the customer tenant selected for this session. Returns a temporary password the user must change at next sign-in. Requires approval.',
+      { userIdentifier: z.string(), reason: z.string() },
+      makeSessionAwareHandler('m365_reset_password', getAuth, getActiveSession, m365ResetPasswordHandler, onPreToolUse, onPostToolUse)
+    ),
+  ];
+}
+
+/**
  * Creates an SDK MCP server instance with all Breeze tools.
  * Auth context is fetched lazily via the getAuth thunk so all tool handlers
  * see the latest org-scoped access even when the session is reused.
@@ -1568,44 +1617,13 @@ export function createBreezeMcpServer(
     ),
 
     // Microsoft 365 helpdesk tools (session-aware; the customer tenant is bound
-    // to the active AI session). Routed through makeSessionAwareHandler so they
-    // get the SAME enforcement as every other tool: onPreToolUse (TOOL_TIERS gate,
-    // guardrails, RBAC, rate limits, tier-3 approval) and onPostToolUse
-    // (ai_tool_executions persistence + delegant_tool_call_id correlation).
-    tool(
-      'm365_lookup_user',
-      'Look up a Microsoft 365 user (profile, account status, assigned licenses) on the customer tenant selected for this session.',
-      { userIdentifier: z.string() },
-      makeSessionAwareHandler('m365_lookup_user', getAuth, getActiveSession, m365LookupUserHandler, onPreToolUse, onPostToolUse)
-    ),
-
-    tool(
-      'm365_recent_signins',
-      "Read recent sign-in activity for a Microsoft 365 user on the customer tenant selected for this session. Useful for can't-log-in and lockout triage.",
-      { userIdentifier: z.string() },
-      makeSessionAwareHandler('m365_recent_signins', getAuth, getActiveSession, m365RecentSigninsHandler, onPreToolUse, onPostToolUse)
-    ),
-
-    tool(
-      'm365_list_group_memberships',
-      'List the groups in the customer tenant selected for this session.',
-      {},
-      makeSessionAwareHandler('m365_list_group_memberships', getAuth, getActiveSession, m365ListGroupMembershipsHandler, onPreToolUse, onPostToolUse)
-    ),
-
-    tool(
-      'm365_disable_user',
-      'Disable (block sign-in for) a Microsoft 365 user on the customer tenant selected for this session. Requires approval.',
-      { userIdentifier: z.string(), reason: z.string() },
-      makeSessionAwareHandler('m365_disable_user', getAuth, getActiveSession, m365DisableUserHandler, onPreToolUse, onPostToolUse)
-    ),
-
-    tool(
-      'm365_reset_password',
-      'Reset the password for a Microsoft 365 user on the customer tenant selected for this session. Returns a temporary password the user must change at next sign-in. Requires approval.',
-      { userIdentifier: z.string(), reason: z.string() },
-      makeSessionAwareHandler('m365_reset_password', getAuth, getActiveSession, m365ResetPasswordHandler, onPreToolUse, onPostToolUse)
-    ),
+    // to the active AI session). Only advertised when the Delegant integration
+    // is configured — see m365ToolDefinitions. Routed through
+    // makeSessionAwareHandler so they get the SAME enforcement as every other
+    // tool: onPreToolUse (TOOL_TIERS gate, guardrails, RBAC, rate limits, tier-3
+    // approval) and onPostToolUse (ai_tool_executions persistence +
+    // delegant_tool_call_id correlation).
+    ...m365ToolDefinitions(getAuth, getActiveSession, onPreToolUse, onPostToolUse),
   ];
 
   return createSdkMcpServer({

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -360,6 +360,113 @@ function makeHandler(
   };
 }
 
+/**
+ * Session-aware variant of makeHandler for tools whose handler signature is
+ * `(args, auth, sessionId)` and which require an active streaming session
+ * (e.g. Microsoft 365 helpdesk tools bound to a customer tenant).
+ *
+ * CRITICAL: this mirrors makeHandler EXACTLY — the full onPreToolUse enforcement
+ * chain (TOOL_TIERS gate, guardrails, RBAC checkToolPermission, rate limits, and
+ * tier-3 approval-card creation + waitForApproval blocking poll) runs before the
+ * handler, and onPostToolUse runs after for ai_tool_executions persistence +
+ * delegant_tool_call_id correlation. The ONLY difference from makeHandler is the
+ * execute line: instead of executeTool(toolName, args, auth) it resolves the
+ * active session and calls sessionHandler(args, auth, session.breezeSessionId).
+ *
+ * The no_active_session guard runs before any enforcement (nothing to enforce
+ * if there is no session/tenant to act on).
+ */
+function makeSessionAwareHandler(
+  toolName: string,
+  getAuth: () => AuthContext,
+  getActiveSession: (() => ActiveSession | undefined) | undefined,
+  sessionHandler: (args: Record<string, unknown>, auth: AuthContext, sessionId: string) => Promise<string>,
+  onPreToolUse?: PreToolUseCallback,
+  onPostToolUse?: PostToolUseCallback,
+) {
+  const toolTimeout = getToolTimeout(toolName);
+
+  return async (args: Record<string, unknown>) => {
+    // See makeHandler: escape any inherited AsyncLocalStorage DB context so all
+    // DB ops (preToolUse approval writes, the tool call, postToolUse persistence)
+    // start with a clean transaction context.
+    return runOutsideDbContext(async () => {
+    const startTime = Date.now();
+
+    // Resolve the active session up front. The no_active_session guard precedes
+    // enforcement — there is no tenant/session to gate against if it's absent.
+    const session = getActiveSession?.();
+    if (!session) {
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ error: 'no_active_session', message: 'No active session.' }) }],
+        isError: true,
+      };
+    }
+
+    // Pre-execution check (guardrails, RBAC, rate limits, approval). IDENTICAL to makeHandler.
+    if (onPreToolUse) {
+      let check: { allowed: true } | { allowed: false; error: string };
+      try {
+        check = await onPreToolUse(toolName, args);
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : 'Unknown error';
+        console.error(`[AI-SDK] PreToolUse threw for ${toolName}: ${reason}`);
+        check = { allowed: false, error: `Guardrails check failed: ${reason}` };
+      }
+      if (!check.allowed) {
+        const safeError = compactToolResultForChat(toolName, JSON.stringify({ error: check.error }));
+        await safePostToolUse(onPostToolUse, toolName, args, safeError, true, 0);
+        return {
+          content: [{ type: 'text' as const, text: safeError }],
+          isError: true,
+        };
+      }
+    }
+    try {
+      const auth = getAuth();
+      // Use the user's actual auth scope so RLS / DB-level tenant isolation is enforced.
+      const dbContext: DbAccessContext = {
+        scope: auth.scope as DbAccessContext['scope'],
+        orgId: auth.orgId ?? null,
+        accessibleOrgIds: auth.accessibleOrgIds ?? null,
+      };
+      const result = await withTimeout(
+        withDbAccessContext(dbContext, () => sessionHandler(args, auth, session.breezeSessionId)),
+        toolTimeout,
+        toolName,
+      );
+      const compactResult = compactToolResultForChat(toolName, result);
+
+      // Detect error responses returned as JSON strings by tool handlers
+      let isToolError = false;
+      try {
+        const parsed = JSON.parse(compactResult);
+        if (parsed && typeof parsed === 'object' && 'error' in parsed && !('success' in parsed) && !('data' in parsed) && !('configured' in parsed)) {
+          isToolError = true;
+        }
+      } catch { /* not JSON, treat as success */ }
+
+      const durationMs = Date.now() - startTime;
+      await safePostToolUse(onPostToolUse, toolName, args, compactResult, isToolError, durationMs);
+      return { content: [{ type: 'text' as const, text: compactResult }], ...(isToolError ? { isError: true } : {}) };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Tool execution failed';
+      const durationMs = Date.now() - startTime;
+      console.error(`[AI-SDK] Tool ${toolName} failed in ${durationMs}ms: ${message}`);
+      const safeError = compactToolResultForChat(toolName, JSON.stringify({ error: message }));
+      await safePostToolUse(onPostToolUse, toolName, args, safeError, true, durationMs);
+      return {
+        content: [{ type: 'text' as const, text: safeError }],
+        isError: true,
+      };
+    }
+    }); // end runOutsideDbContext
+  };
+}
+
+// Exported for unit tests that lock in the enforcement ordering.
+export const __test__ = { makeSessionAwareHandler };
+
 // ============================================
 // SDK MCP Server Factory
 // ============================================
@@ -1461,67 +1568,43 @@ export function createBreezeMcpServer(
     ),
 
     // Microsoft 365 helpdesk tools (session-aware; the customer tenant is bound
-    // to the active AI session). Thin glue around the testable handlers in
-    // ./aiToolsM365 — each resolves the session via getActiveSession() following
-    // the propose_action_plan precedent.
+    // to the active AI session). Routed through makeSessionAwareHandler so they
+    // get the SAME enforcement as every other tool: onPreToolUse (TOOL_TIERS gate,
+    // guardrails, RBAC, rate limits, tier-3 approval) and onPostToolUse
+    // (ai_tool_executions persistence + delegant_tool_call_id correlation).
     tool(
       'm365_lookup_user',
       'Look up a Microsoft 365 user (profile, account status, assigned licenses) on the customer tenant selected for this session.',
       { userIdentifier: z.string() },
-      async (args: Record<string, unknown>) => {
-        const session = getActiveSession?.();
-        if (!session) return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'no_active_session', message: 'No active session.' }) }], isError: true };
-        const text = await m365LookupUserHandler(args, session.auth, session.breezeSessionId);
-        return { content: [{ type: 'text' as const, text }] };
-      }
+      makeSessionAwareHandler('m365_lookup_user', getAuth, getActiveSession, m365LookupUserHandler, onPreToolUse, onPostToolUse)
     ),
 
     tool(
       'm365_recent_signins',
       "Read recent sign-in activity for a Microsoft 365 user on the customer tenant selected for this session. Useful for can't-log-in and lockout triage.",
       { userIdentifier: z.string() },
-      async (args: Record<string, unknown>) => {
-        const session = getActiveSession?.();
-        if (!session) return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'no_active_session', message: 'No active session.' }) }], isError: true };
-        const text = await m365RecentSigninsHandler(args, session.auth, session.breezeSessionId);
-        return { content: [{ type: 'text' as const, text }] };
-      }
+      makeSessionAwareHandler('m365_recent_signins', getAuth, getActiveSession, m365RecentSigninsHandler, onPreToolUse, onPostToolUse)
     ),
 
     tool(
       'm365_list_group_memberships',
       'List the groups in the customer tenant selected for this session.',
       {},
-      async (args: Record<string, unknown>) => {
-        const session = getActiveSession?.();
-        if (!session) return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'no_active_session', message: 'No active session.' }) }], isError: true };
-        const text = await m365ListGroupMembershipsHandler(args, session.auth, session.breezeSessionId);
-        return { content: [{ type: 'text' as const, text }] };
-      }
+      makeSessionAwareHandler('m365_list_group_memberships', getAuth, getActiveSession, m365ListGroupMembershipsHandler, onPreToolUse, onPostToolUse)
     ),
 
     tool(
       'm365_disable_user',
       'Disable (block sign-in for) a Microsoft 365 user on the customer tenant selected for this session. Requires approval.',
       { userIdentifier: z.string(), reason: z.string() },
-      async (args: Record<string, unknown>) => {
-        const session = getActiveSession?.();
-        if (!session) return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'no_active_session', message: 'No active session.' }) }], isError: true };
-        const text = await m365DisableUserHandler(args, session.auth, session.breezeSessionId);
-        return { content: [{ type: 'text' as const, text }] };
-      }
+      makeSessionAwareHandler('m365_disable_user', getAuth, getActiveSession, m365DisableUserHandler, onPreToolUse, onPostToolUse)
     ),
 
     tool(
       'm365_reset_password',
       'Reset the password for a Microsoft 365 user on the customer tenant selected for this session. Returns a temporary password the user must change at next sign-in. Requires approval.',
       { userIdentifier: z.string(), reason: z.string() },
-      async (args: Record<string, unknown>) => {
-        const session = getActiveSession?.();
-        if (!session) return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'no_active_session', message: 'No active session.' }) }], isError: true };
-        const text = await m365ResetPasswordHandler(args, session.auth, session.breezeSessionId);
-        return { content: [{ type: 'text' as const, text }] };
-      }
+      makeSessionAwareHandler('m365_reset_password', getAuth, getActiveSession, m365ResetPasswordHandler, onPreToolUse, onPostToolUse)
     ),
   ];
 

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -18,6 +18,10 @@ import { compactToolResultForChat } from './aiToolOutput';
 import type { ActiveSession } from './streamingSessionManager';
 import { waitForPlanApproval } from './aiAgent';
 import { aiActionPlans } from '../db/schema';
+import {
+  m365LookupUserHandler, m365RecentSigninsHandler, m365ListGroupMembershipsHandler,
+  m365DisableUserHandler, m365ResetPasswordHandler,
+} from './aiToolsM365';
 
 /**
  * Callback invoked before tool execution to enforce guardrails, RBAC,
@@ -1447,6 +1451,70 @@ export function createBreezeMcpServer(
             message: 'Plan approved. Execute the steps in order now.',
           }) }],
         };
+      }
+    ),
+
+    // Microsoft 365 helpdesk tools (session-aware; the customer tenant is bound
+    // to the active AI session). Thin glue around the testable handlers in
+    // ./aiToolsM365 — each resolves the session via getActiveSession() following
+    // the propose_action_plan precedent.
+    tool(
+      'm365_lookup_user',
+      'Look up a Microsoft 365 user (profile, account status, assigned licenses) on the customer tenant selected for this session.',
+      { userIdentifier: z.string() },
+      async (args: Record<string, unknown>) => {
+        const session = getActiveSession?.();
+        if (!session) return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'no_active_session', message: 'No active session.' }) }], isError: true };
+        const text = await m365LookupUserHandler(args, session.auth, session.breezeSessionId);
+        return { content: [{ type: 'text' as const, text }] };
+      }
+    ),
+
+    tool(
+      'm365_recent_signins',
+      "Read recent sign-in activity for a Microsoft 365 user on the customer tenant selected for this session. Useful for can't-log-in and lockout triage.",
+      { userIdentifier: z.string() },
+      async (args: Record<string, unknown>) => {
+        const session = getActiveSession?.();
+        if (!session) return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'no_active_session', message: 'No active session.' }) }], isError: true };
+        const text = await m365RecentSigninsHandler(args, session.auth, session.breezeSessionId);
+        return { content: [{ type: 'text' as const, text }] };
+      }
+    ),
+
+    tool(
+      'm365_list_group_memberships',
+      'List the groups in the customer tenant selected for this session.',
+      {},
+      async (args: Record<string, unknown>) => {
+        const session = getActiveSession?.();
+        if (!session) return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'no_active_session', message: 'No active session.' }) }], isError: true };
+        const text = await m365ListGroupMembershipsHandler(args, session.auth, session.breezeSessionId);
+        return { content: [{ type: 'text' as const, text }] };
+      }
+    ),
+
+    tool(
+      'm365_disable_user',
+      'Disable (block sign-in for) a Microsoft 365 user on the customer tenant selected for this session. Requires approval.',
+      { userIdentifier: z.string(), reason: z.string() },
+      async (args: Record<string, unknown>) => {
+        const session = getActiveSession?.();
+        if (!session) return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'no_active_session', message: 'No active session.' }) }], isError: true };
+        const text = await m365DisableUserHandler(args, session.auth, session.breezeSessionId);
+        return { content: [{ type: 'text' as const, text }] };
+      }
+    ),
+
+    tool(
+      'm365_reset_password',
+      'Reset the password for a Microsoft 365 user on the customer tenant selected for this session. Returns a temporary password the user must change at next sign-in. Requires approval.',
+      { userIdentifier: z.string(), reason: z.string() },
+      async (args: Record<string, unknown>) => {
+        const session = getActiveSession?.();
+        if (!session) return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'no_active_session', message: 'No active session.' }) }], isError: true };
+        const text = await m365ResetPasswordHandler(args, session.auth, session.breezeSessionId);
+        return { content: [{ type: 'text' as const, text }] };
       }
     ),
   ];

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -137,6 +137,12 @@ export const TOOL_TIERS = {
   query_monitors: 1,
   manage_monitors: 1,           // Action-level escalation in guardrails
   get_service_monitoring_status: 1,
+  // M365 helpdesk tools (Delegant-backed)
+  m365_lookup_user: 1,
+  m365_recent_signins: 1,
+  m365_list_group_memberships: 1,
+  m365_disable_user: 3,
+  m365_reset_password: 3,
 } as const satisfies Readonly<Record<string, AiToolTier>> as Readonly<Record<string, AiToolTier>>;
 
 // All tool names, prefixed for SDK MCP format

--- a/apps/api/src/services/aiGuardrails.m365.test.ts
+++ b/apps/api/src/services/aiGuardrails.m365.test.ts
@@ -12,7 +12,7 @@ vi.mock(import('./permissions'), async (importOriginal) => {
   };
 });
 
-import { checkToolPermission } from './aiGuardrails';
+import { checkGuardrails, checkToolPermission } from './aiGuardrails';
 import { getUserPermissions, hasPermission } from './permissions';
 
 const auth = {
@@ -79,5 +79,36 @@ describe('m365 RBAC', () => {
     );
     expect(err).toBeFalsy();
     expect(hasPermission).toHaveBeenCalledWith(expect.anything(), 'm365', 'execute');
+  });
+});
+
+// Regression guard for the tier-resolution gap: M365 tools are registered for
+// the SDK runtime (TOOL_TIERS) but live OUTSIDE the `aiTools` registry that
+// getToolTier reads, so checkGuardrails used to fail-close every M365 call as
+// tier-4 "Unknown tool" — blocking the feature entirely. These assert the real
+// guardrail tiers so the registry/SDK tier sources can't silently drift apart.
+describe('m365 guardrail tiers', () => {
+  it('treats read-only M365 tools as tier 1 (no approval)', () => {
+    for (const name of ['m365_lookup_user', 'm365_recent_signins', 'm365_list_group_memberships']) {
+      const check = checkGuardrails(name, {});
+      expect(check.allowed).toBe(true);
+      expect(check.tier).toBe(1);
+      expect(check.requiresApproval).toBe(false);
+    }
+  });
+
+  it('treats mutating M365 tools as tier 3 (per-step approval)', () => {
+    for (const name of ['m365_disable_user', 'm365_reset_password']) {
+      const check = checkGuardrails(name, { userIdentifier: 'x', reason: 'y' });
+      expect(check.allowed).toBe(true);
+      expect(check.tier).toBe(3);
+      expect(check.requiresApproval).toBe(true);
+    }
+  });
+
+  it('still fail-closes a genuinely unknown tool as tier 4', () => {
+    const check = checkGuardrails('m365_not_a_real_tool', {});
+    expect(check.allowed).toBe(false);
+    expect(check.tier).toBe(4);
   });
 });

--- a/apps/api/src/services/aiGuardrails.m365.test.ts
+++ b/apps/api/src/services/aiGuardrails.m365.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// checkToolPermission resolves the caller's permissions via getUserPermissions
+// (DB-backed) and tests them with hasPermission. Both are mocked here so the
+// RBAC mapping for the M365 tools can be exercised without a DB.
+vi.mock(import('./permissions'), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getUserPermissions: vi.fn(),
+    hasPermission: vi.fn(),
+  };
+});
+
+import { checkToolPermission } from './aiGuardrails';
+import { getUserPermissions, hasPermission } from './permissions';
+
+const auth = {
+  user: { id: 'user-1' },
+  token: { roleId: 'helpdesk', scope: 'organization' },
+  orgId: 'org-1',
+  partnerId: null,
+} as any;
+
+describe('m365 RBAC', () => {
+  beforeEach(() => {
+    vi.mocked(getUserPermissions).mockReset();
+    vi.mocked(hasPermission).mockReset();
+    vi.mocked(getUserPermissions).mockResolvedValue({ roleId: 'helpdesk' } as any);
+  });
+
+  it('blocks reset_password for a user lacking m365.execute', async () => {
+    vi.mocked(hasPermission).mockReturnValue(false);
+    const err = await checkToolPermission(
+      'm365_reset_password',
+      { userIdentifier: 'x', reason: 'y' },
+      auth,
+    );
+    expect(err).toBeTruthy();
+    expect(err).toContain('requires m365.execute');
+    expect(hasPermission).toHaveBeenCalledWith(expect.anything(), 'm365', 'execute');
+  });
+
+  it('blocks disable_user for a user lacking m365.execute', async () => {
+    vi.mocked(hasPermission).mockReturnValue(false);
+    const err = await checkToolPermission(
+      'm365_disable_user',
+      { userIdentifier: 'x', reason: 'y' },
+      auth,
+    );
+    expect(err).toBeTruthy();
+    expect(hasPermission).toHaveBeenCalledWith(expect.anything(), 'm365', 'execute');
+  });
+
+  it('allows lookup_user for a user with m365.read', async () => {
+    vi.mocked(hasPermission).mockReturnValue(true);
+    const err = await checkToolPermission(
+      'm365_lookup_user',
+      { userIdentifier: 'x' },
+      auth,
+    );
+    expect(err).toBeFalsy();
+    expect(hasPermission).toHaveBeenCalledWith(expect.anything(), 'm365', 'read');
+  });
+
+  it('allows recent_signins and list_group_memberships with m365.read', async () => {
+    vi.mocked(hasPermission).mockReturnValue(true);
+    expect(await checkToolPermission('m365_recent_signins', { userIdentifier: 'x' }, auth)).toBeFalsy();
+    expect(await checkToolPermission('m365_list_group_memberships', { userIdentifier: 'x' }, auth)).toBeFalsy();
+    expect(hasPermission).toHaveBeenCalledWith(expect.anything(), 'm365', 'read');
+  });
+
+  it('allows reset_password when m365.execute is granted', async () => {
+    vi.mocked(hasPermission).mockReturnValue(true);
+    const err = await checkToolPermission(
+      'm365_reset_password',
+      { userIdentifier: 'x', reason: 'y' },
+      auth,
+    );
+    expect(err).toBeFalsy();
+    expect(hasPermission).toHaveBeenCalledWith(expect.anything(), 'm365', 'execute');
+  });
+});

--- a/apps/api/src/services/aiGuardrails.ts
+++ b/apps/api/src/services/aiGuardrails.ts
@@ -370,6 +370,12 @@ const TOOL_PERMISSIONS: Record<string, { resource: string; action: string } | Re
   get_backup_health: { resource: 'devices', action: 'read' },
   run_backup_verification: { resource: 'devices', action: 'execute' },
   get_recovery_readiness: { resource: 'devices', action: 'read' },
+  // M365 helpdesk tools (Delegant-backed)
+  m365_lookup_user: { resource: 'm365', action: 'read' },
+  m365_recent_signins: { resource: 'm365', action: 'read' },
+  m365_list_group_memberships: { resource: 'm365', action: 'read' },
+  m365_disable_user: { resource: 'm365', action: 'execute' },
+  m365_reset_password: { resource: 'm365', action: 'execute' },
 };
 
 const TOOL_EXTRA_PERMISSIONS: Record<string, { resource: string; action: string }[]> = {

--- a/apps/api/src/services/aiTools.ts
+++ b/apps/api/src/services/aiTools.ts
@@ -55,6 +55,11 @@ import { registerDocsTools } from './aiToolsDocs';
 import { registerRemoteTools } from './aiToolsRemote';
 import { registerAgentMgmtTools } from './aiToolsAgentMgmt';
 import { registerUITools } from './aiToolsUI';
+// M365 helpdesk tools are session-aware (handler signature includes a sessionId)
+// so they are NOT registered in the `aiTools` execution registry — they run via
+// makeSessionAwareHandler in the SDK server. Their tiers still must be visible to
+// getToolTier so checkGuardrails can gate them; import the tier table for fallback.
+import { m365ToolTiers } from './aiToolsM365';
 
 // ============================================
 // Shared Types
@@ -181,7 +186,7 @@ export function getToolDefinitions(): Anthropic.Tool[] {
 }
 
 export function getToolTier(toolName: string): AiToolTier | undefined {
-  return aiTools.get(toolName)?.tier;
+  return aiTools.get(toolName)?.tier ?? m365ToolTiers[toolName];
 }
 
 export async function executeTool(

--- a/apps/api/src/services/aiToolsM365.test.ts
+++ b/apps/api/src/services/aiToolsM365.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./delegantClient', () => ({ invokeDelegantTool: vi.fn() }));
+vi.mock('./m365Helpers', async (orig) => {
+  const actual = await (orig as any)();
+  return { ...actual, loadSession: vi.fn(), loadConnection: vi.fn() };
+});
+
+import { invokeDelegantTool } from './delegantClient';
+import { loadSession, loadConnection } from './m365Helpers';
+import {
+  m365LookupUserHandler, m365RecentSigninsHandler, m365ListGroupMembershipsHandler,
+  m365DisableUserHandler, m365ResetPasswordHandler, m365ToolTiers,
+} from './aiToolsM365';
+
+const auth = { orgId: 'org-A', user: { id: 'tech-1', email: 't@x.com' } } as any;
+const activeConn = {
+  id: 'c1', orgId: 'org-A', status: 'active', delegantOrgId: 'dorg-1',
+  delegantConnectionId: 'dconn-1', customerLabel: 'pinnacle', customerDisplayName: 'Pinnacle',
+};
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe('m365_lookup_user', () => {
+  it('errors and never calls Delegant when no customer is selected', async () => {
+    (loadSession as any).mockResolvedValue({ id: 'sess-1', orgId: 'org-A', delegantM365ConnectionId: null });
+    const out = await m365LookupUserHandler({ userIdentifier: 'jane@x.com' }, auth, 'sess-1');
+    expect(JSON.parse(out).error).toBe('no_customer_selected');
+    expect(invokeDelegantTool).not.toHaveBeenCalled();
+  });
+
+  it('errors connection_not_found and never calls Delegant on a cross-org connection', async () => {
+    (loadSession as any).mockResolvedValue({ id: 'sess-1', orgId: 'org-A', delegantM365ConnectionId: 'c1' });
+    (loadConnection as any).mockResolvedValue({ ...activeConn, orgId: 'org-OTHER' });
+    const out = await m365LookupUserHandler({ userIdentifier: 'jane@x.com' }, auth, 'sess-1');
+    expect(JSON.parse(out).error).toBe('connection_not_found');
+    expect(invokeDelegantTool).not.toHaveBeenCalled();
+  });
+
+  it('calls Delegant get_user on the happy path (object id, no UPN resolve)', async () => {
+    (loadSession as any).mockResolvedValue({ id: 'sess-1', orgId: 'org-A', delegantM365ConnectionId: 'c1' });
+    (loadConnection as any).mockResolvedValue(activeConn);
+    (invokeDelegantTool as any).mockResolvedValue({ kind: 'ok', data: { id: 'u1', displayName: 'Jane', assignedLicenses: [] } });
+    const out = await m365LookupUserHandler({ userIdentifier: 'u1' }, auth, 'sess-1');
+    expect(invokeDelegantTool).toHaveBeenCalledTimes(1);
+    expect((invokeDelegantTool as any).mock.calls[0][0].toolName).toBe('get_user');
+    expect(out).toContain('Jane');
+  });
+
+  it('returns a graceful message when Delegant is unreachable', async () => {
+    (loadSession as any).mockResolvedValue({ id: 'sess-1', orgId: 'org-A', delegantM365ConnectionId: 'c1' });
+    (loadConnection as any).mockResolvedValue(activeConn);
+    (invokeDelegantTool as any).mockResolvedValue({ kind: 'error', code: 'delegant_unreachable', message: 'down' });
+    const out = await m365LookupUserHandler({ userIdentifier: 'u1' }, auth, 'sess-1');
+    expect(out.toLowerCase()).toContain('could');
+  });
+});
+
+describe('UPN resolution', () => {
+  it('resolves a UPN to an object id via get_user before the real call (signins)', async () => {
+    (loadSession as any).mockResolvedValue({ id: 'sess-1', orgId: 'org-A', delegantM365ConnectionId: 'c1' });
+    (loadConnection as any).mockResolvedValue(activeConn);
+    (invokeDelegantTool as any)
+      .mockResolvedValueOnce({ kind: 'ok', data: { id: 'resolved-id' } }) // get_user resolve
+      .mockResolvedValueOnce({ kind: 'ok', data: { value: [] } });        // signin activity
+    const out = await m365RecentSigninsHandler({ userIdentifier: 'jane@x.com' }, auth, 'sess-1');
+    const calls = (invokeDelegantTool as any).mock.calls;
+    expect(calls[0][0].toolName).toBe('get_user');
+    expect(calls[1][0].toolName).toBe('get_user_signin_activity');
+    expect(calls[1][0].parameters.userId).toBe('resolved-id');
+    expect(out).toBeTruthy();
+  });
+});
+
+describe('m365_reset_password', () => {
+  it('requires a reason argument and never calls Delegant without it', async () => {
+    (loadSession as any).mockResolvedValue({ id: 'sess-1', orgId: 'org-A', delegantM365ConnectionId: 'c1' });
+    (loadConnection as any).mockResolvedValue(activeConn);
+    const out = await m365ResetPasswordHandler({ userIdentifier: 'u1' }, auth, 'sess-1');
+    expect(JSON.parse(out).error).toBeDefined();
+    expect(invokeDelegantTool).not.toHaveBeenCalled();
+  });
+
+  it('calls reset_user_password and surfaces the temp password', async () => {
+    (loadSession as any).mockResolvedValue({ id: 'sess-1', orgId: 'org-A', delegantM365ConnectionId: 'c1' });
+    (loadConnection as any).mockResolvedValue(activeConn);
+    (invokeDelegantTool as any).mockResolvedValue({ kind: 'ok', data: { temporaryPassword: 'Temp123!' } });
+    const out = await m365ResetPasswordHandler({ userIdentifier: 'u1', reason: 'forgot' }, auth, 'sess-1');
+    expect((invokeDelegantTool as any).mock.calls.at(-1)[0].toolName).toBe('reset_user_password');
+    expect(out).toContain('Temp123!');
+  });
+});
+
+describe('m365_disable_user', () => {
+  it('requires a reason and calls disable_user when present', async () => {
+    (loadSession as any).mockResolvedValue({ id: 'sess-1', orgId: 'org-A', delegantM365ConnectionId: 'c1' });
+    (loadConnection as any).mockResolvedValue(activeConn);
+    const noReason = await m365DisableUserHandler({ userIdentifier: 'u1' }, auth, 'sess-1');
+    expect(JSON.parse(noReason).error).toBeDefined();
+    (invokeDelegantTool as any).mockResolvedValue({ kind: 'ok', data: {} });
+    const ok = await m365DisableUserHandler({ userIdentifier: 'u1', reason: 'offboarding' }, auth, 'sess-1');
+    expect((invokeDelegantTool as any).mock.calls.at(-1)[0].toolName).toBe('disable_user');
+    expect(ok).toContain('u1');
+  });
+});
+
+describe('m365_list_group_memberships', () => {
+  it('lists groups without needing a user identifier', async () => {
+    (loadSession as any).mockResolvedValue({ id: 'sess-1', orgId: 'org-A', delegantM365ConnectionId: 'c1' });
+    (loadConnection as any).mockResolvedValue(activeConn);
+    (invokeDelegantTool as any).mockResolvedValue({ kind: 'ok', data: { value: [{ id: 'g1', displayName: 'Sales' }] } });
+    const out = await m365ListGroupMembershipsHandler({}, auth, 'sess-1');
+    expect((invokeDelegantTool as any).mock.calls[0][0].toolName).toBe('list_groups');
+    expect(out).toContain('Sales');
+  });
+});
+
+describe('tool tiers', () => {
+  it('assigns tiers 1/1/1/3/3', () => {
+    expect(m365ToolTiers['m365_lookup_user']).toBe(1);
+    expect(m365ToolTiers['m365_recent_signins']).toBe(1);
+    expect(m365ToolTiers['m365_list_group_memberships']).toBe(1);
+    expect(m365ToolTiers['m365_disable_user']).toBe(3);
+    expect(m365ToolTiers['m365_reset_password']).toBe(3);
+  });
+});

--- a/apps/api/src/services/aiToolsM365.test.ts
+++ b/apps/api/src/services/aiToolsM365.test.ts
@@ -47,6 +47,26 @@ describe('m365_lookup_user', () => {
     expect(out).toContain('Jane');
   });
 
+  it('threads the Delegant toolCallId into the output JSON when present', async () => {
+    (loadSession as any).mockResolvedValue({ id: 'sess-1', orgId: 'org-A', delegantM365ConnectionId: 'c1' });
+    (loadConnection as any).mockResolvedValue(activeConn);
+    (invokeDelegantTool as any).mockResolvedValue({ kind: 'ok', data: { id: 'u1', displayName: 'Jane' }, toolCallId: 'tc-123' });
+    const out = await m365LookupUserHandler({ userIdentifier: 'u1' }, auth, 'sess-1');
+    expect(out).toContain('Jane'); // human text still present as a substring
+    const parsed = JSON.parse(out);
+    expect(parsed.delegantToolCallId).toBe('tc-123');
+    expect(parsed.message).toContain('Jane');
+  });
+
+  it('omits delegantToolCallId when Delegant does not return one', async () => {
+    (loadSession as any).mockResolvedValue({ id: 'sess-1', orgId: 'org-A', delegantM365ConnectionId: 'c1' });
+    (loadConnection as any).mockResolvedValue(activeConn);
+    (invokeDelegantTool as any).mockResolvedValue({ kind: 'ok', data: { id: 'u1', displayName: 'Jane' } });
+    const out = await m365LookupUserHandler({ userIdentifier: 'u1' }, auth, 'sess-1');
+    expect(out).toContain('Jane');
+    expect(out).not.toContain('delegantToolCallId');
+  });
+
   it('returns a graceful message when Delegant is unreachable', async () => {
     (loadSession as any).mockResolvedValue({ id: 'sess-1', orgId: 'org-A', delegantM365ConnectionId: 'c1' });
     (loadConnection as any).mockResolvedValue(activeConn);

--- a/apps/api/src/services/aiToolsM365.ts
+++ b/apps/api/src/services/aiToolsM365.ts
@@ -1,0 +1,212 @@
+/**
+ * Microsoft 365 helpdesk AI tool handlers.
+ *
+ * Each exported handler is a clean, unit-testable function with an EXPLICIT
+ * sessionId parameter: (input, auth, sessionId) => Promise<string>. They are
+ * registered inline inside createBreezeMcpServer (see aiAgentSdkTools.ts),
+ * which supplies the session id from the active AI session.
+ *
+ * Flow per call: resolve session + customer connection (with cross-org guard) ->
+ * optionally resolve a UPN to an object id -> invoke the Delegant tool ->
+ * format a concise LLM-readable string.
+ */
+
+import type { AuthContext } from '../middleware/auth';
+import { invokeDelegantTool, type DelegantToolName } from './delegantClient';
+import type { DelegantM365ConnectionRow } from '../db/schema/delegant';
+import {
+  loadSession, loadConnection, authorizeConnection, formatResultForLlm, errorString,
+} from './m365Helpers';
+import {
+  DELEGANT_BASE_URL, DELEGANT_SERVICE_TOKEN, DELEGANT_PRINCIPAL_SIGNING_KEY, DELEGANT_PRINCIPAL_KID,
+} from '../config/env';
+
+const env = {
+  DELEGANT_BASE_URL, DELEGANT_SERVICE_TOKEN, DELEGANT_PRINCIPAL_SIGNING_KEY, DELEGANT_PRINCIPAL_KID,
+};
+
+export const m365ToolTiers: Record<string, 1 | 3> = {
+  m365_lookup_user: 1,
+  m365_recent_signins: 1,
+  m365_list_group_memberships: 1,
+  m365_disable_user: 3,
+  m365_reset_password: 3,
+};
+
+function principals(auth: AuthContext) {
+  return {
+    actingUser: {
+      breezeUserId: auth.user.id,
+      delegantPrincipalId: process.env.DELEGANT_TEST_ACTING_USER_ID ?? '',
+    },
+    agent: { delegantPrincipalId: process.env.DELEGANT_TEST_AGENT_ID ?? '' },
+  };
+}
+
+type ResolvedContext =
+  | { error: string }
+  | { conn: DelegantM365ConnectionRow };
+
+async function resolveContext(auth: AuthContext, sessionId: string): Promise<ResolvedContext> {
+  const session = await loadSession(sessionId);
+  if (!session) return { error: errorString('session_not_found', 'AI session not found.') };
+  if (!session.delegantM365ConnectionId) {
+    return {
+      error: errorString(
+        'no_customer_selected',
+        'No M365 customer is selected for this session. Start a new session and pick a customer.',
+      ),
+    };
+  }
+  const conn = await loadConnection(session.delegantM365ConnectionId);
+  const authz = authorizeConnection(conn, auth.orgId ?? '');
+  if (!authz.ok) {
+    return { error: errorString('connection_not_found', 'M365 connection not found for this session.') };
+  }
+  return { conn: authz.conn };
+}
+
+async function call(
+  conn: DelegantM365ConnectionRow,
+  auth: AuthContext,
+  sessionId: string,
+  toolName: DelegantToolName,
+  parameters: Record<string, unknown>,
+) {
+  const p = principals(auth);
+  return invokeDelegantTool(
+    { connection: conn, toolName, parameters, actingUser: p.actingUser, agent: p.agent, sessionId },
+    { env },
+  );
+}
+
+/**
+ * Resolve a user identifier to a Graph object id. UPNs (containing '@') are
+ * resolved via a get_user call first; bare object ids are returned as-is.
+ * Returns null if resolution fails (so the caller can surface a graceful error).
+ */
+async function resolveUserId(
+  identifier: string,
+  conn: DelegantM365ConnectionRow,
+  auth: AuthContext,
+  sessionId: string,
+): Promise<string | null> {
+  if (!identifier.includes('@')) return identifier;
+  const res = await call(conn, auth, sessionId, 'get_user', { userId: identifier });
+  if (res.kind === 'ok') return (res.data as any)?.id ?? identifier;
+  return null;
+}
+
+const errorTemplate = (e: { code: string; message: string }): string =>
+  `Could not complete the M365 operation: ${e.message}`;
+
+const unresolvedUser = (identifier: string): string =>
+  errorString('user_not_found', `Could not find an M365 user matching "${identifier}".`);
+
+function requireString(input: Record<string, unknown>, key: string): string | null {
+  const v = input[key];
+  return typeof v === 'string' && v.length > 0 ? v : null;
+}
+
+export async function m365LookupUserHandler(
+  input: Record<string, unknown>,
+  auth: AuthContext,
+  sessionId: string,
+): Promise<string> {
+  const ctx = await resolveContext(auth, sessionId);
+  if ('error' in ctx) return ctx.error;
+  const identifier = requireString(input, 'userIdentifier');
+  if (!identifier) return errorString('missing_user', 'A user identifier (UPN or object id) is required.');
+
+  const result = await call(ctx.conn, auth, sessionId, 'get_user', { userId: identifier });
+  return formatResultForLlm(result, {
+    successTemplate: (data) => `M365 user profile: ${JSON.stringify(data)}`,
+    errorTemplate,
+  });
+}
+
+export async function m365RecentSigninsHandler(
+  input: Record<string, unknown>,
+  auth: AuthContext,
+  sessionId: string,
+): Promise<string> {
+  const ctx = await resolveContext(auth, sessionId);
+  if ('error' in ctx) return ctx.error;
+  const identifier = requireString(input, 'userIdentifier');
+  if (!identifier) return errorString('missing_user', 'A user identifier (UPN or object id) is required.');
+
+  const userId = await resolveUserId(identifier, ctx.conn, auth, sessionId);
+  if (userId === null) return unresolvedUser(identifier);
+
+  const result = await call(ctx.conn, auth, sessionId, 'get_user_signin_activity', { userId });
+  return formatResultForLlm(result, {
+    successTemplate: (data) => `Recent sign-in activity for ${identifier}: ${JSON.stringify(data)}`,
+    errorTemplate,
+  });
+}
+
+export async function m365ListGroupMembershipsHandler(
+  _input: Record<string, unknown>,
+  auth: AuthContext,
+  sessionId: string,
+): Promise<string> {
+  const ctx = await resolveContext(auth, sessionId);
+  if ('error' in ctx) return ctx.error;
+
+  const result = await call(ctx.conn, auth, sessionId, 'list_groups', {});
+  return formatResultForLlm(result, {
+    successTemplate: (data) => `Groups in the customer tenant: ${JSON.stringify(data)}`,
+    errorTemplate,
+  });
+}
+
+export async function m365DisableUserHandler(
+  input: Record<string, unknown>,
+  auth: AuthContext,
+  sessionId: string,
+): Promise<string> {
+  const reason = requireString(input, 'reason');
+  if (!reason) return errorString('missing_reason', 'A reason is required for this action.');
+
+  const ctx = await resolveContext(auth, sessionId);
+  if ('error' in ctx) return ctx.error;
+  const identifier = requireString(input, 'userIdentifier');
+  if (!identifier) return errorString('missing_user', 'A user identifier (UPN or object id) is required.');
+
+  const userId = await resolveUserId(identifier, ctx.conn, auth, sessionId);
+  if (userId === null) return unresolvedUser(identifier);
+
+  const result = await call(ctx.conn, auth, sessionId, 'disable_user', { userId, reason });
+  return formatResultForLlm(result, {
+    successTemplate: () => `Disabled (blocked sign-in for) M365 user ${identifier}.`,
+    errorTemplate,
+  });
+}
+
+export async function m365ResetPasswordHandler(
+  input: Record<string, unknown>,
+  auth: AuthContext,
+  sessionId: string,
+): Promise<string> {
+  const reason = requireString(input, 'reason');
+  if (!reason) return errorString('missing_reason', 'A reason is required for this action.');
+
+  const ctx = await resolveContext(auth, sessionId);
+  if ('error' in ctx) return ctx.error;
+  const identifier = requireString(input, 'userIdentifier');
+  if (!identifier) return errorString('missing_user', 'A user identifier (UPN or object id) is required.');
+
+  const userId = await resolveUserId(identifier, ctx.conn, auth, sessionId);
+  if (userId === null) return unresolvedUser(identifier);
+
+  const result = await call(ctx.conn, auth, sessionId, 'reset_user_password', { userId, reason });
+  return formatResultForLlm(result, {
+    successTemplate: (data) => {
+      const temp = (data as any)?.temporaryPassword;
+      return temp
+        ? `Reset the password for ${identifier}. Temporary password: ${temp} (the user must change it at next sign-in).`
+        : `Reset the password for ${identifier}. ${JSON.stringify(data)}`;
+    },
+    errorTemplate,
+  });
+}

--- a/apps/api/src/services/aiToolsM365.ts
+++ b/apps/api/src/services/aiToolsM365.ts
@@ -33,13 +33,18 @@ export const m365ToolTiers: Record<string, 1 | 3> = {
   m365_reset_password: 3,
 };
 
+// v1 single-customer seeding: every action is attributed to one static acting
+// principal + one agent principal sourced from env. This is a deliberate v1
+// shortcut (per-technician principal mapping is a known follow-up) — see the
+// operator runbook. Named DELEGANT_* (not DELEGANT_TEST_*) because these are
+// real production config, not test scaffolding.
 function principals(auth: AuthContext) {
   return {
     actingUser: {
       breezeUserId: auth.user.id,
-      delegantPrincipalId: process.env.DELEGANT_TEST_ACTING_USER_ID ?? '',
+      delegantPrincipalId: process.env.DELEGANT_ACTING_USER_ID ?? '',
     },
-    agent: { delegantPrincipalId: process.env.DELEGANT_TEST_AGENT_ID ?? '' },
+    agent: { delegantPrincipalId: process.env.DELEGANT_AGENT_ID ?? '' },
   };
 }
 

--- a/apps/api/src/services/delegantClient.test.ts
+++ b/apps/api/src/services/delegantClient.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { generateKeyPair, exportPKCS8, exportJWK, jwtVerify, importJWK } from 'jose';
+import { __mintPrincipalJwtForTest } from './delegantClient';
+
+let privatePem: string;
+let publicJwk: any;
+
+beforeAll(async () => {
+  const { publicKey, privateKey } = await generateKeyPair('EdDSA', { crv: 'Ed25519', extractable: true });
+  privatePem = await exportPKCS8(privateKey);
+  publicJwk = await exportJWK(publicKey);
+});
+
+describe('mintPrincipalJwt', () => {
+  it('mints a breeze_ai_agent token with the acting-user chain and required claims', async () => {
+    const token = await __mintPrincipalJwtForTest({
+      signingKeyPem: privatePem,
+      kid: 'kid-1',
+      agentPrincipalId: 'agent-123',
+      breezeOrgId: 'should-not-be-used',
+      delegantOrgId: 'dorg-456',
+      actingUserBreezeId: 'tech-1',
+      actingUserDelegantId: 'duser-789',
+      sessionId: 'sess-1',
+      nowSeconds: 1_000_000,
+    });
+    const pubKey = await importJWK(publicJwk, 'EdDSA');
+    const { payload, protectedHeader } = await jwtVerify(token, pubKey, {
+      issuer: 'breeze-api', audience: 'delegant',
+      // Token is minted with nowSeconds=1_000_000; verify against that same
+      // clock so jose's temporal (exp/iat) checks use the token's mint time
+      // rather than the real wall clock.
+      currentDate: new Date(1_000_000 * 1000),
+    });
+    expect(protectedHeader.kid).toBe('kid-1');
+    expect(protectedHeader.alg).toBe('EdDSA');
+    expect(payload.sub).toBe('agent-123');
+    expect(payload.principal_type).toBe('breeze_ai_agent');
+    expect(payload.breeze_org_id).toBe('dorg-456'); // delegant org, not breeze org
+    expect(payload.breeze_acting_user_id).toBe('duser-789');
+    expect(payload.breeze_user_id).toBe('tech-1');
+    expect(payload.breeze_session_id).toBe('sess-1');
+    expect(payload.exp).toBe(1_000_060); // now + 60
+    expect(typeof payload.jti).toBe('string');
+  });
+
+  it('produces a unique jti on each call', async () => {
+    const args = {
+      signingKeyPem: privatePem, kid: 'kid-1', agentPrincipalId: 'a',
+      breezeOrgId: 'b', delegantOrgId: 'd', actingUserBreezeId: 't',
+      actingUserDelegantId: 'u', sessionId: 's', nowSeconds: 1,
+    };
+    const t1 = await __mintPrincipalJwtForTest(args);
+    const t2 = await __mintPrincipalJwtForTest(args);
+    const p1 = JSON.parse(Buffer.from(t1.split('.')[1], 'base64url').toString());
+    const p2 = JSON.parse(Buffer.from(t2.split('.')[1], 'base64url').toString());
+    expect(p1.jti).not.toBe(p2.jti);
+  });
+});

--- a/apps/api/src/services/delegantClient.test.ts
+++ b/apps/api/src/services/delegantClient.test.ts
@@ -52,8 +52,8 @@ describe('mintPrincipalJwt', () => {
     };
     const t1 = await __mintPrincipalJwtForTest(args);
     const t2 = await __mintPrincipalJwtForTest(args);
-    const p1 = JSON.parse(Buffer.from(t1.split('.')[1], 'base64url').toString());
-    const p2 = JSON.parse(Buffer.from(t2.split('.')[1], 'base64url').toString());
+    const p1 = JSON.parse(Buffer.from(t1.split('.')[1]!, 'base64url').toString());
+    const p2 = JSON.parse(Buffer.from(t2.split('.')[1]!, 'base64url').toString());
     expect(p1.jti).not.toBe(p2.jti);
   });
 });
@@ -144,7 +144,7 @@ describe('invokeDelegantTool response mapping', () => {
   it('sends the service token and principal header', async () => {
     const fetchMock = mockFetchOnce(200, { isError: false, data: {} });
     await invokeDelegantTool(baseArgs(), { env, fetchImpl: fetchMock });
-    const [url, init] = fetchMock.mock.calls[0];
+    const [url, init] = fetchMock.mock.calls[0]!;
     expect(url).toBe('https://delegant.example/v1/tools/invoke');
     expect(init.headers['Authorization']).toBe('Bearer svc');
     expect(typeof init.headers['X-Delegant-Principal']).toBe('string');

--- a/apps/api/src/services/delegantClient.test.ts
+++ b/apps/api/src/services/delegantClient.test.ts
@@ -157,6 +157,13 @@ describe('invokeDelegantTool response mapping', () => {
     expect(JSON.parse(init.body)).toEqual({ toolName: 'get_user', parameters: { userId: 'u1' } });
   });
 
+  it('pins redirect:error so a 3xx cannot forward the bearer token + principal JWT off-host', async () => {
+    const fetchMock = mockFetchOnce(200, { isError: false, data: {} });
+    await invokeDelegantTool(baseArgs(), { env, fetchImpl: fetchMock });
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect(init.redirect).toBe('error');
+  });
+
   it('does not log tool parameters', async () => {
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const args = baseArgs();

--- a/apps/api/src/services/delegantClient.test.ts
+++ b/apps/api/src/services/delegantClient.test.ts
@@ -99,6 +99,12 @@ describe('invokeDelegantTool response mapping', () => {
     expect(res).toEqual({ kind: 'ok', data: { id: 'u1' } });
   });
 
+  it('maps 200 + {isError:false,data,toolCallId} to ok with toolCallId', async () => {
+    const fetchMock = mockFetchOnce(200, { isError: false, data: { id: 'u1' }, toolCallId: 'tc-123' });
+    const res = await invokeDelegantTool(baseArgs(), { env, fetchImpl: fetchMock });
+    expect(res).toEqual({ kind: 'ok', data: { id: 'u1' }, toolCallId: 'tc-123' });
+  });
+
   it('maps 200 + {isError:true,message} to error/tool_error', async () => {
     const fetchMock = mockFetchOnce(200, { isError: true, message: 'user not found' });
     const res = await invokeDelegantTool(baseArgs(), { env, fetchImpl: fetchMock });

--- a/apps/api/src/services/delegantClient.test.ts
+++ b/apps/api/src/services/delegantClient.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { generateKeyPair, exportPKCS8, exportJWK, jwtVerify, importJWK } from 'jose';
-import { __mintPrincipalJwtForTest } from './delegantClient';
+import { __mintPrincipalJwtForTest, invokeDelegantTool } from './delegantClient';
 
 let privatePem: string;
 let publicJwk: any;
@@ -55,5 +55,109 @@ describe('mintPrincipalJwt', () => {
     const p1 = JSON.parse(Buffer.from(t1.split('.')[1], 'base64url').toString());
     const p2 = JSON.parse(Buffer.from(t2.split('.')[1], 'base64url').toString());
     expect(p1.jti).not.toBe(p2.jti);
+  });
+});
+
+function mockFetchOnce(status: number, body: unknown, opts: { throwNetwork?: boolean } = {}) {
+  if (opts.throwNetwork) {
+    return vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+  }
+  return vi.fn().mockResolvedValue({
+    status,
+    ok: status >= 200 && status < 300,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response);
+}
+
+const baseArgs = () => ({
+  connection: {
+    id: 'conn-1', orgId: 'org-1', customerLabel: 'pinnacle',
+    customerDisplayName: 'Pinnacle', delegantOrgId: 'dorg-1',
+    delegantConnectionId: 'dconn-1', m365TenantId: 'tid-1',
+    status: 'active', lastVerifiedAt: null, createdAt: new Date(), updatedAt: new Date(),
+  } as any,
+  toolName: 'get_user' as const,
+  parameters: { userId: 'u1' },
+  actingUser: { breezeUserId: 'tech-1', delegantPrincipalId: 'duser-1' },
+  agent: { delegantPrincipalId: 'agent-1' },
+  sessionId: 'sess-1',
+});
+
+describe('invokeDelegantTool response mapping', () => {
+  const env = {
+    DELEGANT_BASE_URL: 'https://delegant.example',
+    DELEGANT_SERVICE_TOKEN: 'svc',
+    DELEGANT_PRINCIPAL_SIGNING_KEY: '',
+    DELEGANT_PRINCIPAL_KID: 'kid-1',
+  };
+  beforeAll(() => { env.DELEGANT_PRINCIPAL_SIGNING_KEY = privatePem; });
+
+  it('maps 200 + {isError:false,data} to ok', async () => {
+    const fetchMock = mockFetchOnce(200, { isError: false, data: { id: 'u1' } });
+    const res = await invokeDelegantTool(baseArgs(), { env, fetchImpl: fetchMock });
+    expect(res).toEqual({ kind: 'ok', data: { id: 'u1' } });
+  });
+
+  it('maps 200 + {isError:true,message} to error/tool_error', async () => {
+    const fetchMock = mockFetchOnce(200, { isError: true, message: 'user not found' });
+    const res = await invokeDelegantTool(baseArgs(), { env, fetchImpl: fetchMock });
+    expect(res).toEqual({ kind: 'error', code: 'tool_error', message: 'user not found' });
+  });
+
+  it('maps 200 + {pending:true} to error/unexpected_pending (fail loud)', async () => {
+    const fetchMock = mockFetchOnce(200, { isError: false, pending: true, approvalRequestId: 'a1' });
+    const res = await invokeDelegantTool(baseArgs(), { env, fetchImpl: fetchMock });
+    expect(res).toMatchObject({ kind: 'error', code: 'unexpected_pending' });
+  });
+
+  it('maps 401 to error/auth_failed', async () => {
+    const res = await invokeDelegantTool(baseArgs(), { env, fetchImpl: mockFetchOnce(401, { error: 'unauthorized' }) });
+    expect(res).toMatchObject({ kind: 'error', code: 'auth_failed' });
+  });
+
+  it('maps 403 to error/forbidden', async () => {
+    const res = await invokeDelegantTool(baseArgs(), { env, fetchImpl: mockFetchOnce(403, { error: 'forbidden_principal_type' }) });
+    expect(res).toMatchObject({ kind: 'error', code: 'forbidden' });
+  });
+
+  it('maps 400 to error/bad_request', async () => {
+    const res = await invokeDelegantTool(baseArgs(), { env, fetchImpl: mockFetchOnce(400, { error: 'missing toolName' }) });
+    expect(res).toMatchObject({ kind: 'error', code: 'bad_request' });
+  });
+
+  it('maps 404 to error/not_found', async () => {
+    const res = await invokeDelegantTool(baseArgs(), { env, fetchImpl: mockFetchOnce(404, { error: 'unknown tool' }) });
+    expect(res).toMatchObject({ kind: 'error', code: 'not_found' });
+  });
+
+  it('maps 500 to error/delegant_unavailable', async () => {
+    const res = await invokeDelegantTool(baseArgs(), { env, fetchImpl: mockFetchOnce(500, { isError: true, message: 'Internal error' }) });
+    expect(res).toMatchObject({ kind: 'error', code: 'delegant_unavailable' });
+  });
+
+  it('maps a network throw to error/delegant_unreachable', async () => {
+    const res = await invokeDelegantTool(baseArgs(), { env, fetchImpl: mockFetchOnce(0, null, { throwNetwork: true }) });
+    expect(res).toMatchObject({ kind: 'error', code: 'delegant_unreachable' });
+  });
+
+  it('sends the service token and principal header', async () => {
+    const fetchMock = mockFetchOnce(200, { isError: false, data: {} });
+    await invokeDelegantTool(baseArgs(), { env, fetchImpl: fetchMock });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://delegant.example/v1/tools/invoke');
+    expect(init.headers['Authorization']).toBe('Bearer svc');
+    expect(typeof init.headers['X-Delegant-Principal']).toBe('string');
+    expect(JSON.parse(init.body)).toEqual({ toolName: 'get_user', parameters: { userId: 'u1' } });
+  });
+
+  it('does not log tool parameters', async () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const args = baseArgs();
+    args.parameters = { userId: 'jane.doe@pinnacle.dental' };
+    await invokeDelegantTool(args, { env, fetchImpl: mockFetchOnce(200, { isError: false, data: {} }) });
+    const logged = spy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(logged).not.toContain('jane.doe@pinnacle.dental');
+    spy.mockRestore();
   });
 });

--- a/apps/api/src/services/delegantClient.ts
+++ b/apps/api/src/services/delegantClient.ts
@@ -108,6 +108,11 @@ export async function invokeDelegantTool(
       },
       body: JSON.stringify({ toolName: args.toolName, parameters: args.parameters }),
       signal: controller.signal,
+      // Never follow redirects: a 3xx from a misconfigured/compromised Delegant
+      // endpoint would otherwise re-send the Authorization bearer token AND the
+      // signed principal JWT to the redirect target (arbitrary host). A redirect
+      // is treated as a network error (-> delegant_unreachable).
+      redirect: 'error',
     });
     result = await mapResponse(resp);
   } catch {

--- a/apps/api/src/services/delegantClient.ts
+++ b/apps/api/src/services/delegantClient.ts
@@ -1,0 +1,35 @@
+import { SignJWT, importPKCS8 } from 'jose';
+import { randomUUID } from 'node:crypto';
+
+interface MintArgs {
+  signingKeyPem: string;
+  kid: string;
+  agentPrincipalId: string;
+  breezeOrgId: string; // accepted but not placed in token; delegantOrgId is authoritative
+  delegantOrgId: string;
+  actingUserBreezeId: string;
+  actingUserDelegantId: string;
+  sessionId: string;
+  nowSeconds: number;
+}
+
+async function mintPrincipalJwt(args: MintArgs): Promise<string> {
+  const key = await importPKCS8(args.signingKeyPem, 'EdDSA');
+  return new SignJWT({
+    breeze_org_id: args.delegantOrgId,
+    principal_type: 'breeze_ai_agent',
+    breeze_user_id: args.actingUserBreezeId,
+    breeze_acting_user_id: args.actingUserDelegantId,
+    breeze_session_id: args.sessionId,
+  })
+    .setProtectedHeader({ alg: 'EdDSA', kid: args.kid })
+    .setSubject(args.agentPrincipalId)
+    .setIssuer('breeze-api')
+    .setAudience('delegant')
+    .setIssuedAt(args.nowSeconds)
+    .setExpirationTime(args.nowSeconds + 60)
+    .setJti(randomUUID())
+    .sign(key);
+}
+
+export const __mintPrincipalJwtForTest = mintPrincipalJwt;

--- a/apps/api/src/services/delegantClient.ts
+++ b/apps/api/src/services/delegantClient.ts
@@ -54,7 +54,7 @@ export interface DelegantInvokeArgs {
 }
 
 export type DelegantInvokeResult =
-  | { kind: 'ok'; data: unknown }   // a later task may widen this with an optional toolCallId
+  | { kind: 'ok'; data: unknown; toolCallId?: string }
   | { kind: 'error'; code: DelegantErrorCode; message: string };
 
 interface InvokeDeps {
@@ -134,7 +134,11 @@ async function mapResponse(resp: Response): Promise<DelegantInvokeResult> {
     if (body && body.isError === true) {
       return { kind: 'error', code: 'tool_error', message: String(body.message ?? 'tool error') };
     }
-    return { kind: 'ok', data: body?.data ?? body };
+    return {
+      kind: 'ok',
+      data: body?.data ?? body,
+      ...(typeof body?.toolCallId === 'string' ? { toolCallId: body.toolCallId } : {}),
+    };
   }
   const message = String(body?.message ?? body?.error ?? `HTTP ${resp.status}`);
   switch (resp.status) {

--- a/apps/api/src/services/delegantClient.ts
+++ b/apps/api/src/services/delegantClient.ts
@@ -1,5 +1,6 @@
 import { SignJWT, importPKCS8 } from 'jose';
 import { randomUUID } from 'node:crypto';
+import type { DelegantM365ConnectionRow } from '../db/schema/delegant';
 
 interface MintArgs {
   signingKeyPem: string;
@@ -33,3 +34,132 @@ async function mintPrincipalJwt(args: MintArgs): Promise<string> {
 }
 
 export const __mintPrincipalJwtForTest = mintPrincipalJwt;
+
+export type DelegantToolName =
+  | 'get_user' | 'get_user_signin_activity' | 'list_groups'
+  | 'get_group_members' | 'disable_user' | 'reset_user_password';
+
+export type DelegantErrorCode =
+  | 'tool_error' | 'unexpected_pending' | 'bad_request' | 'auth_failed'
+  | 'forbidden' | 'not_found' | 'delegant_unavailable' | 'delegant_unreachable'
+  | 'unexpected';
+
+export interface DelegantInvokeArgs {
+  connection: DelegantM365ConnectionRow;
+  toolName: DelegantToolName;
+  parameters: Record<string, unknown>;
+  actingUser: { breezeUserId: string; delegantPrincipalId: string };
+  agent: { delegantPrincipalId: string };
+  sessionId: string;
+}
+
+export type DelegantInvokeResult =
+  | { kind: 'ok'; data: unknown }   // a later task may widen this with an optional toolCallId
+  | { kind: 'error'; code: DelegantErrorCode; message: string };
+
+interface InvokeDeps {
+  env: {
+    DELEGANT_BASE_URL: string; DELEGANT_SERVICE_TOKEN: string;
+    DELEGANT_PRINCIPAL_SIGNING_KEY: string; DELEGANT_PRINCIPAL_KID: string;
+  };
+  fetchImpl?: typeof fetch;
+  nowSeconds?: () => number;
+}
+
+const TIMEOUT_MS = 15_000;
+
+export async function invokeDelegantTool(
+  args: DelegantInvokeArgs,
+  deps: InvokeDeps,
+): Promise<DelegantInvokeResult> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const now = deps.nowSeconds ? deps.nowSeconds() : Math.floor(Date.now() / 1000);
+  const requestId = randomUUID();
+
+  let token: string;
+  try {
+    token = await mintPrincipalJwt({
+      signingKeyPem: deps.env.DELEGANT_PRINCIPAL_SIGNING_KEY,
+      kid: deps.env.DELEGANT_PRINCIPAL_KID,
+      agentPrincipalId: args.agent.delegantPrincipalId,
+      breezeOrgId: args.connection.orgId,
+      delegantOrgId: args.connection.delegantOrgId,
+      actingUserBreezeId: args.actingUser.breezeUserId,
+      actingUserDelegantId: args.actingUser.delegantPrincipalId,
+      sessionId: args.sessionId,
+      nowSeconds: now,
+    });
+  } catch (err) {
+    return { kind: 'error', code: 'unexpected', message: `failed to mint token: ${String(err)}` };
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  const started = Date.now();
+  let result: DelegantInvokeResult;
+  try {
+    const resp = await fetchImpl(`${deps.env.DELEGANT_BASE_URL}/v1/tools/invoke`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${deps.env.DELEGANT_SERVICE_TOKEN}`,
+        'X-Delegant-Principal': token,
+        'Content-Type': 'application/json',
+        'X-Request-Id': requestId,
+      },
+      body: JSON.stringify({ toolName: args.toolName, parameters: args.parameters }),
+      signal: controller.signal,
+    });
+    result = await mapResponse(resp);
+  } catch {
+    result = { kind: 'error', code: 'delegant_unreachable', message: 'Could not reach the M365 service.' };
+  } finally {
+    clearTimeout(timer);
+  }
+
+  logInvoke({
+    toolName: args.toolName, connectionId: args.connection.id,
+    customerLabel: args.connection.customerLabel, sessionId: args.sessionId,
+    requestId, durationMs: Date.now() - started, result,
+  });
+  return result;
+}
+
+async function mapResponse(resp: Response): Promise<DelegantInvokeResult> {
+  const body = await resp.json().catch(() => null) as any;
+  if (resp.status === 200) {
+    if (body && body.pending === true) {
+      return { kind: 'error', code: 'unexpected_pending',
+        message: 'Delegant returned a pending approval; expected allow. Check Delegant policy for this org.' };
+    }
+    if (body && body.isError === true) {
+      return { kind: 'error', code: 'tool_error', message: String(body.message ?? 'tool error') };
+    }
+    return { kind: 'ok', data: body?.data ?? body };
+  }
+  const message = String(body?.message ?? body?.error ?? `HTTP ${resp.status}`);
+  switch (resp.status) {
+    case 400: return { kind: 'error', code: 'bad_request', message };
+    case 401: return { kind: 'error', code: 'auth_failed', message };
+    case 403: return { kind: 'error', code: 'forbidden', message };
+    case 404: return { kind: 'error', code: 'not_found', message };
+    default:
+      if (resp.status >= 500) return { kind: 'error', code: 'delegant_unavailable', message };
+      return { kind: 'error', code: 'unexpected', message };
+  }
+}
+
+function logInvoke(fields: {
+  toolName: string; connectionId: string; customerLabel: string;
+  sessionId: string; requestId: string; durationMs: number; result: DelegantInvokeResult;
+}): void {
+  const base = {
+    msg: 'delegant_invoke', toolName: fields.toolName, connectionId: fields.connectionId,
+    customerLabel: fields.customerLabel, sessionId: fields.sessionId,
+    requestId: fields.requestId, durationMs: fields.durationMs, kind: fields.result.kind,
+  };
+  if (fields.result.kind === 'error') {
+    console.error(JSON.stringify({ ...base, code: fields.result.code, error: fields.result.message.slice(0, 200) }));
+  } else {
+    console.log(JSON.stringify(base));
+  }
+}

--- a/apps/api/src/services/m365.live.test.ts
+++ b/apps/api/src/services/m365.live.test.ts
@@ -9,8 +9,8 @@ const LIVE = process.env.DELEGANT_LIVE_TEST === '1'
   && !!process.env.DELEGANT_SERVICE_TOKEN
   && !!process.env.DELEGANT_PRINCIPAL_SIGNING_KEY
   && !!process.env.DELEGANT_PRINCIPAL_KID
-  && !!process.env.DELEGANT_TEST_AGENT_ID
-  && !!process.env.DELEGANT_TEST_ACTING_USER_ID;
+  && !!process.env.DELEGANT_AGENT_ID
+  && !!process.env.DELEGANT_ACTING_USER_ID;
 
 // Mutations (password reset) require an EXTRA explicit opt-in so a stray live
 // run can never reset a real account.
@@ -43,11 +43,11 @@ function liveConnection(): DelegantM365ConnectionRow {
 }
 
 function liveActingUser() {
-  return { breezeUserId: 'live-tech', delegantPrincipalId: process.env.DELEGANT_TEST_ACTING_USER_ID! };
+  return { breezeUserId: 'live-tech', delegantPrincipalId: process.env.DELEGANT_ACTING_USER_ID! };
 }
 
 function liveAgent() {
-  return { delegantPrincipalId: process.env.DELEGANT_TEST_AGENT_ID! };
+  return { delegantPrincipalId: process.env.DELEGANT_AGENT_ID! };
 }
 
 describe.skipIf(!LIVE)('m365 live (sandbox tenant)', () => {

--- a/apps/api/src/services/m365.live.test.ts
+++ b/apps/api/src/services/m365.live.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { invokeDelegantTool } from './delegantClient';
+import type { DelegantM365ConnectionRow } from '../db/schema/delegant';
+
+// Opt-in live suite. Runs ONLY when real Delegant creds + a seeded sandbox
+// connection are present. Without them, every test SKIPS so `pnpm test` is green.
+const LIVE = process.env.DELEGANT_LIVE_TEST === '1'
+  && !!process.env.DELEGANT_BASE_URL
+  && !!process.env.DELEGANT_SERVICE_TOKEN
+  && !!process.env.DELEGANT_PRINCIPAL_SIGNING_KEY
+  && !!process.env.DELEGANT_PRINCIPAL_KID
+  && !!process.env.DELEGANT_TEST_AGENT_ID
+  && !!process.env.DELEGANT_TEST_ACTING_USER_ID;
+
+// Mutations (password reset) require an EXTRA explicit opt-in so a stray live
+// run can never reset a real account.
+const ALLOW_MUTATIONS = LIVE && process.env.DELEGANT_LIVE_ALLOW_MUTATIONS === '1';
+
+function liveEnv() {
+  return {
+    DELEGANT_BASE_URL: process.env.DELEGANT_BASE_URL!,
+    DELEGANT_SERVICE_TOKEN: process.env.DELEGANT_SERVICE_TOKEN!,
+    DELEGANT_PRINCIPAL_SIGNING_KEY: process.env.DELEGANT_PRINCIPAL_SIGNING_KEY!,
+    DELEGANT_PRINCIPAL_KID: process.env.DELEGANT_PRINCIPAL_KID!,
+  };
+}
+
+// A seeded sandbox connection + a known sandbox user are provided via env.
+function liveConnection(): DelegantM365ConnectionRow {
+  return {
+    id: process.env.DELEGANT_LIVE_CONNECTION_ID ?? 'live-conn',
+    orgId: process.env.DELEGANT_LIVE_BREEZE_ORG_ID ?? 'live-org',
+    customerLabel: 'sandbox',
+    customerDisplayName: 'Sandbox Tenant',
+    delegantOrgId: process.env.DELEGANT_LIVE_DELEGANT_ORG_ID!,
+    delegantConnectionId: process.env.DELEGANT_LIVE_DELEGANT_CONNECTION_ID ?? 'live-dconn',
+    m365TenantId: process.env.DELEGANT_LIVE_M365_TENANT_ID ?? 'live-tid',
+    status: 'active',
+    lastVerifiedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function liveActingUser() {
+  return { breezeUserId: 'live-tech', delegantPrincipalId: process.env.DELEGANT_TEST_ACTING_USER_ID! };
+}
+
+function liveAgent() {
+  return { delegantPrincipalId: process.env.DELEGANT_TEST_AGENT_ID! };
+}
+
+describe.skipIf(!LIVE)('m365 live (sandbox tenant)', () => {
+  it('get_user returns a real profile for the sandbox user', async () => {
+    const sandboxUser = process.env.DELEGANT_LIVE_SANDBOX_UPN!;
+    const res = await invokeDelegantTool({
+      connection: liveConnection(),
+      toolName: 'get_user',
+      parameters: { userId: sandboxUser },
+      actingUser: liveActingUser(),
+      agent: liveAgent(),
+      sessionId: 'live-session',
+    }, { env: liveEnv() });
+    expect(res.kind).toBe('ok');
+    if (res.kind === 'ok') {
+      expect(res.data).toBeTruthy();
+      // Delegant returns the Graph user object (id/displayName/userPrincipalName).
+      expect(typeof res.toolCallId === 'string' || res.toolCallId === undefined).toBe(true);
+    }
+  });
+
+  it('audit round-trip: a live invoke returns a toolCallId that resolves in Delegant audit', async () => {
+    const sandboxUser = process.env.DELEGANT_LIVE_SANDBOX_UPN!;
+    const res = await invokeDelegantTool({
+      connection: liveConnection(),
+      toolName: 'get_user',
+      parameters: { userId: sandboxUser },
+      actingUser: liveActingUser(),
+      agent: liveAgent(),
+      sessionId: 'live-session',
+    }, { env: liveEnv() });
+    expect(res.kind).toBe('ok');
+    if (res.kind === 'ok' && res.toolCallId) {
+      // GET {BASE}/v1/audit/tool-calls/{id} with the service token + a breeze_service
+      // principal JWT should return the audit record with agent + acting-user attribution.
+      // TODO(live-harness): implement the authed GET once a breeze_service JWT minter
+      // is available to the test; for now assert we have an id to correlate.
+      expect(typeof res.toolCallId).toBe('string');
+    }
+  });
+});
+
+describe.skipIf(!ALLOW_MUTATIONS)('m365 live mutations (DISPOSABLE sandbox user ONLY)', () => {
+  it('reset_user_password returns a temporary password for a disposable sandbox user', async () => {
+    const disposableUser = process.env.DELEGANT_LIVE_DISPOSABLE_UPN!;
+    const res = await invokeDelegantTool({
+      connection: liveConnection(),
+      toolName: 'reset_user_password',
+      parameters: { userId: disposableUser },
+      actingUser: liveActingUser(),
+      agent: liveAgent(),
+      sessionId: 'live-session',
+    }, { env: liveEnv() });
+    expect(res.kind).toBe('ok');
+  });
+});

--- a/apps/api/src/services/m365Helpers.test.ts
+++ b/apps/api/src/services/m365Helpers.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { authorizeConnection, formatResultForLlm, errorString } from './m365Helpers';
+
+describe('authorizeConnection', () => {
+  it('rejects a connection from another org', () => {
+    const conn = { id: 'c1', orgId: 'org-A', status: 'active' } as any;
+    const out = authorizeConnection(conn, 'org-B');
+    expect(out.ok).toBe(false);
+  });
+  it('accepts a connection in the same org', () => {
+    const conn = { id: 'c1', orgId: 'org-A', status: 'active' } as any;
+    const out = authorizeConnection(conn, 'org-A');
+    expect(out.ok).toBe(true);
+  });
+  it('rejects a null connection', () => {
+    expect(authorizeConnection(null, 'org-A').ok).toBe(false);
+  });
+  it('rejects an inactive connection', () => {
+    const conn = { id: 'c1', orgId: 'org-A', status: 'disconnected' } as any;
+    expect(authorizeConnection(conn, 'org-A').ok).toBe(false);
+  });
+});
+
+describe('formatResultForLlm', () => {
+  it('renders ok via the success template', () => {
+    const s = formatResultForLlm(
+      { kind: 'ok', data: { temporaryPassword: 'Temp123!' } },
+      { successTemplate: (d: any) => `pw=${d.temporaryPassword}`, errorTemplate: (e) => `err=${e.message}` },
+    );
+    expect(s).toBe('pw=Temp123!');
+  });
+  it('renders error via the error template', () => {
+    const s = formatResultForLlm(
+      { kind: 'error', code: 'delegant_unreachable', message: 'down' },
+      { successTemplate: () => 'ok', errorTemplate: (e) => `err=${e.message}` },
+    );
+    expect(s).toBe('err=down');
+  });
+});
+
+describe('errorString', () => {
+  it('produces a JSON error string the LLM can read', () => {
+    const s = errorString('no_customer_selected', 'pick a customer');
+    expect(JSON.parse(s)).toEqual({ error: 'no_customer_selected', message: 'pick a customer' });
+  });
+});

--- a/apps/api/src/services/m365Helpers.ts
+++ b/apps/api/src/services/m365Helpers.ts
@@ -34,7 +34,17 @@ export function formatResultForLlm(
     errorTemplate: (err: { code: string; message: string }) => string;
   },
 ): string {
-  if (result.kind === 'ok') return templates.successTemplate(result.data);
+  if (result.kind === 'ok') {
+    const message = templates.successTemplate(result.data);
+    // When Delegant returns a toolCallId, emit a JSON envelope carrying both the
+    // human-readable message and the delegantToolCallId so the postToolUse layer
+    // can correlate this Breeze audit row to Delegant's audit ledger. The human
+    // text remains a substring of the JSON (the LLM can still read it).
+    if (typeof result.toolCallId === 'string') {
+      return JSON.stringify({ message, delegantToolCallId: result.toolCallId });
+    }
+    return message;
+  }
   return templates.errorTemplate({ code: result.code, message: result.message });
 }
 

--- a/apps/api/src/services/m365Helpers.ts
+++ b/apps/api/src/services/m365Helpers.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared helpers for the M365 helpdesk AI tool handlers.
+ *
+ * Pure functions (authorizeConnection, formatResultForLlm, errorString) plus
+ * minimal DB-backed loaders (loadSession, loadConnection). The loaders are
+ * intentionally plain selects — the calling tool handler owns access context.
+ */
+
+import { db } from '../db';
+import { eq } from 'drizzle-orm';
+import { aiSessions } from '../db/schema/ai';
+import { delegantM365Connections } from '../db/schema/delegant';
+import type { DelegantM365ConnectionRow } from '../db/schema/delegant';
+import type { DelegantInvokeResult } from './delegantClient';
+
+export function errorString(code: string, message: string): string {
+  return JSON.stringify({ error: code, message });
+}
+
+export function authorizeConnection(
+  conn: DelegantM365ConnectionRow | null,
+  authOrgId: string,
+): { ok: true; conn: DelegantM365ConnectionRow } | { ok: false } {
+  if (!conn) return { ok: false };
+  if (conn.orgId !== authOrgId) return { ok: false };
+  if (conn.status !== 'active') return { ok: false };
+  return { ok: true, conn };
+}
+
+export function formatResultForLlm(
+  result: DelegantInvokeResult,
+  templates: {
+    successTemplate: (data: any) => string;
+    errorTemplate: (err: { code: string; message: string }) => string;
+  },
+): string {
+  if (result.kind === 'ok') return templates.successTemplate(result.data);
+  return templates.errorTemplate({ code: result.code, message: result.message });
+}
+
+export async function loadSession(sessionId: string) {
+  const [row] = await db
+    .select()
+    .from(aiSessions)
+    .where(eq(aiSessions.id, sessionId))
+    .limit(1);
+  return row ?? null;
+}
+
+export async function loadConnection(connectionId: string) {
+  const [row] = await db
+    .select()
+    .from(delegantM365Connections)
+    .where(eq(delegantM365Connections.id, connectionId))
+    .limit(1);
+  return row ?? null;
+}

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -103,6 +103,7 @@ export const ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'config_policy_backup_settings',
   'configuration_policies',
   'custom_field_definitions',
+  'delegant_m365_connections',
   'deployment_invites',
   'deployments',
   'device_boot_metrics',

--- a/apps/mobile/src/screens/approvals/ApprovalScreen.tsx
+++ b/apps/mobile/src/screens/approvals/ApprovalScreen.tsx
@@ -20,6 +20,7 @@ import { RequesterRow } from './components/RequesterRow';
 import { ActionHeadline } from './components/ActionHeadline';
 import { DetailsCollapse } from './components/DetailsCollapse';
 import { RiskBand } from './components/RiskBand';
+import { CustomerTenantBadge } from './components/CustomerTenantBadge';
 import { ApprovalButtons } from './components/ApprovalButtons';
 import { decisionTarget, type CapturedRequestId } from './decisionTarget';
 import { SuspiciousReportSheet } from './components/SuspiciousReportSheet';
@@ -248,6 +249,9 @@ export function ApprovalScreen() {
             createdAt={focused.createdAt}
           />
           <ActionHeadline action={focused.actionLabel} />
+          {focused.customerTenant ? (
+            <CustomerTenantBadge tenant={focused.customerTenant} />
+          ) : null}
           <RiskBand tier={focused.riskTier} summary={focused.riskSummary} />
           <DetailsCollapse toolName={focused.actionToolName} args={focused.actionArguments} />
         </ScrollView>

--- a/apps/mobile/src/screens/approvals/components/CustomerTenantBadge.tsx
+++ b/apps/mobile/src/screens/approvals/components/CustomerTenantBadge.tsx
@@ -1,0 +1,34 @@
+import { Text, View } from 'react-native';
+import { useApprovalTheme, type, spacing, radii } from '../../../theme';
+
+interface Props {
+  tenant: string;
+}
+
+/**
+ * Prominent "Customer tenant" line for M365 mutation approvals. Rendered above
+ * the risk band so the technician sees WHICH customer org the action targets —
+ * the blast radius — before approving from a push notification.
+ *
+ * Only mounted when the server supplies a non-null customerTenant; non-M365
+ * approvals never render this.
+ */
+export function CustomerTenantBadge({ tenant }: Props) {
+  const theme = useApprovalTheme('dark');
+  return (
+    <View
+      style={{
+        marginHorizontal: spacing[6],
+        marginTop: spacing[6],
+        padding: spacing[4],
+        borderRadius: radii.md,
+        backgroundColor: theme.bg2,
+        borderLeftWidth: 3,
+        borderLeftColor: theme.brand,
+      }}
+    >
+      <Text style={[type.metaCaps, { color: theme.textMd }]}>Customer tenant</Text>
+      <Text style={[type.title, { color: theme.textHi, marginTop: spacing[1] }]}>{tenant}</Text>
+    </View>
+  );
+}

--- a/apps/mobile/src/services/approvals.ts
+++ b/apps/mobile/src/services/approvals.ts
@@ -20,6 +20,14 @@ export interface ApprovalRequest {
   actionArguments: Record<string, unknown>;
   riskTier: RiskTier;
   riskSummary: string;
+  /**
+   * Customer tenant (M365) this action targets, e.g. "Pinnacle Dental".
+   * Server-derived for M365 mutation approvals (m365_reset_password /
+   * m365_disable_user) by resolving the linked AI session's Delegant M365
+   * connection. Null for all other approvals. Surfaced prominently on the
+   * card so a technician sees the blast radius before deciding.
+   */
+  customerTenant: string | null;
   status: ApprovalStatus;
   expiresAt: string;
   decidedAt: string | null;

--- a/apps/mobile/src/store/approvalsSlice.test.ts
+++ b/apps/mobile/src/store/approvalsSlice.test.ts
@@ -32,6 +32,7 @@ function makeApproval(overrides: Partial<ApprovalRequest> = {}): ApprovalRequest
     actionArguments: {},
     riskTier: 'medium',
     riskSummary: 'Will reboot the agent service',
+    customerTenant: null,
     status: 'pending',
     expiresAt: new Date(Date.now() + 60_000).toISOString(),
     decidedAt: null,

--- a/apps/web/src/components/ai/AiChatSidebar.tsx
+++ b/apps/web/src/components/ai/AiChatSidebar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
-import { X, MessageSquare, Plus, History, Search, ArrowLeft, Loader2, Flag } from 'lucide-react';
+import { X, MessageSquare, Plus, History, Search, ArrowLeft, Loader2, Flag, Building2 } from 'lucide-react';
 import { useAiStore } from '@/stores/aiStore';
 import AiChatMessages from './AiChatMessages';
 import AiChatInput from './AiChatInput';
@@ -43,7 +43,12 @@ export default function AiChatSidebar() {
     isInterrupting,
     isFlagged,
     flagSession,
-    unflagSession
+    unflagSession,
+    m365Connections,
+    selectedM365ConnectionId,
+    boundM365ConnectionId,
+    loadM365Connections,
+    setSelectedM365Connection
   } = useAiStore();
 
   const [searchQuery, setSearchQuery] = useState('');
@@ -80,6 +85,15 @@ export default function AiChatSidebar() {
   useEffect(() => {
     if (showHistory) loadSessions();
   }, [showHistory, loadSessions]);
+
+  // Load M365 customer connections when the sidebar opens
+  useEffect(() => {
+    if (isOpen) loadM365Connections();
+  }, [isOpen, loadM365Connections]);
+
+  const boundConnection = boundM365ConnectionId
+    ? m365Connections.find((conn) => conn.id === boundM365ConnectionId)
+    : null;
 
   // Debounced search
   useEffect(() => {
@@ -220,6 +234,36 @@ export default function AiChatSidebar() {
           <>
             {/* Cost indicator */}
             <AiCostIndicator enabled={isOpen} />
+
+            {/* M365 customer selector — only when starting a new session */}
+            {!sessionId && m365Connections.length > 0 && (
+              <div className="flex items-center gap-2 border-b px-4 py-2">
+                <Building2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <select
+                  value={selectedM365ConnectionId ?? ''}
+                  onChange={(e) => setSelectedM365Connection(e.target.value || null)}
+                  className="w-full rounded-md border bg-muted px-2 py-1 text-xs text-foreground outline-none focus:border-primary"
+                  aria-label="M365 customer"
+                >
+                  <option value="">No M365 customer</option>
+                  {m365Connections.map((conn) => (
+                    <option key={conn.id} value={conn.id}>
+                      {conn.customerDisplayName}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {/* Bound M365 customer badge */}
+            {sessionId && boundConnection && (
+              <div className="flex items-center gap-1.5 border-b bg-muted/40 px-4 py-2">
+                <Building2 className="h-3.5 w-3.5 shrink-0 text-primary" />
+                <span className="truncate text-xs font-medium text-foreground">
+                  {boundConnection.customerDisplayName}
+                </span>
+              </div>
+            )}
 
             {/* Context badge */}
             {pageContext && (

--- a/apps/web/src/stores/aiStore.ts
+++ b/apps/web/src/stores/aiStore.ts
@@ -19,6 +19,12 @@ interface SearchResult {
   createdAt: string;
 }
 
+interface M365Connection {
+  id: string;
+  customerLabel: string;
+  customerDisplayName: string;
+}
+
 interface AiState {
   isOpen: boolean;
   sessionId: string | null;
@@ -39,6 +45,10 @@ interface AiState {
   isInterrupting: boolean;
   isFlagged: boolean;
   flagReason: string | null;
+  // M365 customer binding (Delegant helpdesk tools)
+  m365Connections: M365Connection[];
+  selectedM365ConnectionId: string | null;
+  boundM365ConnectionId: string | null;
 
   // Actions
   toggle: () => void;
@@ -61,6 +71,8 @@ interface AiState {
   switchSession: (sessionId: string) => Promise<void>;
   flagSession: (reason?: string) => Promise<void>;
   unflagSession: () => Promise<void>;
+  loadM365Connections: () => Promise<void>;
+  setSelectedM365Connection: (connectionId: string | null) => void;
 }
 
 export const useAiStore = create<AiState>()(
@@ -85,6 +97,9 @@ export const useAiStore = create<AiState>()(
   isInterrupting: false,
   isFlagged: false,
   flagReason: null,
+  m365Connections: [],
+  selectedM365ConnectionId: null,
+  boundM365ConnectionId: null,
 
   toggle: () => {
     const opening = !get().isOpen;
@@ -105,17 +120,27 @@ export const useAiStore = create<AiState>()(
   createSession: async () => {
     set({ isLoading: true, error: null });
     try {
-      const { pageContext } = get();
+      const { pageContext, selectedM365ConnectionId } = get();
       const res = await fetchWithAuth('/ai/sessions', {
         method: 'POST',
-        body: JSON.stringify({ pageContext: pageContext ?? undefined })
+        body: JSON.stringify({
+          pageContext: pageContext ?? undefined,
+          delegantM365ConnectionId: selectedM365ConnectionId ?? undefined
+        })
       });
       if (!res.ok) {
         const data = await res.json().catch(() => null);
         throw new Error(extractApiError(data, 'Failed to create session'));
       }
       const data = await res.json();
-      set({ sessionId: data.id, messages: [], isLoading: false, isFlagged: false, flagReason: null });
+      set({
+        sessionId: data.id,
+        messages: [],
+        isLoading: false,
+        isFlagged: false,
+        flagReason: null,
+        boundM365ConnectionId: data.delegantM365ConnectionId ?? null
+      });
     } catch (err) {
       set({
         error: err instanceof Error ? err.message : 'Failed to create session',
@@ -150,6 +175,7 @@ export const useAiStore = create<AiState>()(
         isLoading: false,
         isFlagged: !!data.session.flaggedAt,
         flagReason: data.session.flagReason ?? null,
+        boundM365ConnectionId: data.session.delegantM365ConnectionId ?? null,
       });
     } catch (err) {
       set({
@@ -376,7 +402,7 @@ export const useAiStore = create<AiState>()(
         set({ error: 'Failed to close session' });
         return;
       }
-      set({ sessionId: null, messages: [] });
+      set({ sessionId: null, messages: [], boundM365ConnectionId: null });
     } catch (err) {
       console.error('[AI] Failed to close session:', err);
       set({ error: 'Failed to close session' });
@@ -440,6 +466,7 @@ export const useAiStore = create<AiState>()(
         isLoading: false,
         isFlagged: !!data.session?.flaggedAt,
         flagReason: data.session?.flagReason ?? null,
+        boundM365ConnectionId: data.session?.delegantM365ConnectionId ?? null,
       });
     } catch (err) {
       set({
@@ -485,6 +512,23 @@ export const useAiStore = create<AiState>()(
       set({ error: 'Failed to unflag session' });
     }
   },
+
+  loadM365Connections: async () => {
+    try {
+      const res = await fetchWithAuth('/ai/m365-connections');
+      if (!res.ok) {
+        console.error('[AI] Failed to load M365 connections: HTTP', res.status);
+        return;
+      }
+      const data = await res.json();
+      set({ m365Connections: data.data || [] });
+    } catch (err) {
+      console.error('[AI] Failed to load M365 connections:', err);
+    }
+  },
+
+  setSelectedM365Connection: (connectionId: string | null) =>
+    set({ selectedM365ConnectionId: connectionId }),
     }),
     {
       name: 'breeze-ai-chat',

--- a/docs/runbooks/m365-helpdesk-agent.md
+++ b/docs/runbooks/m365-helpdesk-agent.md
@@ -1,0 +1,276 @@
+# Breeze M365 Helpdesk Agent Operator Runbook
+
+This runbook documents how to configure and seed the Breeze AI agent's Microsoft 365 helpdesk integration, which delegates identity and access operations to the Delegant service.
+
+## Overview
+
+The Breeze AI agent integrates five M365 helpdesk tools with the Delegant identity-governance service:
+- `m365_lookup_user` — read user details
+- `m365_recent_signins` — list recent sign-ins
+- `m365_list_group_memberships` — enumerate group membership
+- `m365_disable_user` — disable a user account (mutation)
+- `m365_reset_password` — reset a user password (mutation)
+
+These tools call Delegant via `POST /v1/tools/invoke`. Tier-1 reads (lookup, signins, groups) run automatically; tier-3 mutations (disable, reset) require approval via Breeze's approval UI.
+
+---
+
+## Section 1: Environment Variables
+
+Configure these in `apps/api/src/config/env.ts` before deploying:
+
+### Required Environment Variables
+
+- **`DELEGANT_BASE_URL`** — base URL of the Delegant service (e.g. `https://delegant.internal`). No trailing slash.
+
+- **`DELEGANT_SERVICE_TOKEN`** — the shared service bearer token; sent as `Authorization: Bearer <token>` to Delegant. Must match Delegant's configured `serviceToken`.
+
+- **`DELEGANT_PRINCIPAL_SIGNING_KEY`** — an Ed25519 PRIVATE key in PKCS8 PEM format. Used to sign the per-call principal JWT. Delegant must hold the matching PUBLIC key (as a JWK in its `jwtKeySet`) under the same `kid`.
+
+- **`DELEGANT_PRINCIPAL_KID`** — the key id; must match the `kid` of the public key registered in Delegant's `jwtKeySet`.
+
+- **`DELEGANT_TEST_AGENT_ID`** — (v1 single-customer seeding) the Delegant `principals` row id of the `breeze_ai_agent` principal. Used as the JWT `sub` claim.
+
+- **`DELEGANT_TEST_ACTING_USER_ID`** — (v1 single-customer seeding) the Delegant `principals` row id (a UUID) of the `breeze_user` principal representing the acting technician. Used as the JWT `breeze_acting_user_id` claim (chains the agent to the acting user).
+
+### Single-Customer Shortcut (v1)
+
+The current version uses `DELEGANT_TEST_AGENT_ID` and `DELEGANT_TEST_ACTING_USER_ID` as a **single-customer shortcut**. This is because v1 lacks a per-technician principal mapping table — a known follow-up. Bulk principal provisioning is deferred to a Delegant-side slice.
+
+Example configuration:
+```bash
+export DELEGANT_BASE_URL="https://delegant.internal"
+export DELEGANT_SERVICE_TOKEN="shared-service-token-here"
+export DELEGANT_PRINCIPAL_SIGNING_KEY="-----BEGIN PRIVATE KEY-----
+...
+-----END PRIVATE KEY-----"
+export DELEGANT_PRINCIPAL_KID="key-id-matching-public-in-delegant-jwtkeyset"
+export DELEGANT_TEST_AGENT_ID="breeze-ai-agent-principals-id"
+export DELEGANT_TEST_ACTING_USER_ID="breeze-user-principals-id-uuid"
+```
+
+---
+
+## Section 2: Delegant-Side Prerequisites
+
+Before Breeze can invoke helpdesk tools, an operator **must** set up the following in Delegant:
+
+### 1. Create the Agent Principal
+
+Create a `breeze_ai_agent` principal in Delegant. Record its `principals` row id → `DELEGANT_TEST_AGENT_ID`.
+
+### 2. Create a Technician Principal
+
+Create a `breeze_user` principal per technician in Delegant. Record its id (a UUID) → `DELEGANT_TEST_ACTING_USER_ID`. The principal **must**:
+- Belong to the **same Delegant org** as the M365 connection being onboarded.
+- Have type `breeze_user` (Delegant's wireAuth rejects mismatches with 403).
+
+### 3. Configure Policy
+
+Ensure the org's Delegant policy permits `breeze_ai_agent` to invoke the relevant tools as `allow` (NOT `require_approval`):
+
+```
+breeze_ai_agent {
+  m365_lookup_user: allow
+  m365_recent_signins: allow
+  m365_list_group_memberships: allow
+  m365_disable_user: allow
+  m365_reset_password: allow
+}
+```
+
+If a tool resolves to `require_approval` or `pending` on the Delegant side, Breeze returns a fail-loud `unexpected_pending` error — because Breeze owns the human approval step, not Delegant. (See Troubleshooting for details.)
+
+### 4. Register the JWT Public Key
+
+Register the JWT public key (matching `DELEGANT_PRINCIPAL_KID`) in Delegant's `jwtKeySet`. Delegant uses this key to verify the per-call principal JWT signed by Breeze.
+
+---
+
+## Section 3: Seed the Breeze-Side Connection (SQL)
+
+There is **no onboarding UI in v1**; seed the connection manually with a single SQL INSERT.
+
+**Note:** The `delegant_m365_connections` table has RLS enabled via `breeze_has_org_access`. Run this as a DB superuser/owner or with the appropriate role that bypasses RLS (e.g., the migration/admin role).
+
+```sql
+INSERT INTO delegant_m365_connections
+  (org_id, customer_label, customer_display_name, delegant_org_id, delegant_connection_id, m365_tenant_id, status)
+VALUES
+  ('<breeze-org-uuid>', 'sandbox', 'Sandbox Tenant',
+   '<delegant-org-id>', '<delegant-connection-id>', '<m365-tenant-id>', 'active');
+```
+
+### Placeholder Definitions
+
+- **`breeze-org-uuid`** — the Breeze organization (MSP partner) UUID.
+- **`sandbox`** — the slug a technician picks in the session switcher.
+- **`Sandbox Tenant`** — shown in the customer switcher and on approval cards.
+- **`delegant-org-id`** — the Delegant org id that owns this M365 connection.
+- **`delegant-connection-id`** — the Delegant connection id (points to the M365 credential pair onboarded in Delegant).
+- **`m365-tenant-id`** — the customer's Microsoft 365 tenant id (display only; no secrets stored Breeze-side).
+- **`active`** — status; valid values are `active`, `paused`, or `deactivated`.
+
+### Security Note
+
+**No secrets are stored Breeze-side.** The per-customer Entra client secret lives in Delegant. Breeze only stores the pointer (`delegant_connection_id`) and references it during tool invocation.
+
+---
+
+## Section 4: Technician Workflow
+
+1. **Open the Breeze AI chat** — the technician navigates to the agent in the Breeze app.
+
+2. **Pick the customer** — a new session-switcher dropdown appears. The technician selects the customer (e.g., "Sandbox Tenant").
+
+3. **Ask the agent for helpdesk work** — the technician makes a natural-language request (e.g., "Look up user john@contoso.com", "Reset password for jane@contoso.com").
+
+4. **Automatic tier-1 reads** — lookup, signins, and group-membership calls execute automatically and return results inline.
+
+5. **Approve tier-3 mutations** — if the agent needs to disable a user or reset a password, Breeze's approval UI (web or mobile) shows an approval card with:
+   - Customer tenant name
+   - Target user
+   - Requested action (disable / reset password)
+   - Reason (from the agent's context)
+   
+   The technician approves or rejects. On approval, Breeze calls Delegant's tool-invoke endpoint.
+
+---
+
+## Section 5: Database Migrations Note (Operational Gotcha)
+
+The package script `pnpm --filter @breeze/api db:migrate` runs `tsx src/db/autoMigrate.ts`, but **that file only DEFINES `autoMigrate()` without invoking it** (no main-guard). **As a result, `db:migrate` is effectively a NO-OP.**
+
+### Where Migrations Actually Run
+
+Migrations are applied by `apps/api/scripts/check-migrations.ts`, which:
+- Calls `autoMigrate()`
+- Is run during deployment or container startup
+- Requires the `breeze_app` DB role to exist
+
+The `breeze_app` role is provisioned by `ensureAppRole()` when both of these are set:
+- `POSTGRES_PASSWORD` or `BREEZE_APP_DB_PASSWORD`
+- `DATABASE_URL_APP`
+
+### M365 Migrations
+
+The two M365-specific migrations are:
+- `2026-05-27-b-delegant-m365-connections.sql` — creates the `delegant_m365_connections` table with RLS.
+- `2026-05-27-c-ai-sessions-delegant-connection.sql` — adds `delegant_connection_id` to the `ai_sessions` table.
+
+**Operators should be aware:** this is a pre-existing repo quirk. Do not assume `pnpm db:migrate` has applied all pending migrations; verify by querying the schema or checking `_migrations` table.
+
+---
+
+## Section 6: Forensic / Audit Correlation
+
+A complete audit trail spans both Breeze and Delegant:
+
+1. **Breeze side:** Locate the `ai_tool_executions` row for the execution (filtered by technician, time, tool name, etc.).
+
+2. **Extract `delegant_tool_call_id`** — this column contains the call id returned by Delegant's invoke response.
+
+3. **Query Delegant audit:**
+   ```
+   GET /v1/audit/tool-calls/{delegant_tool_call_id}
+   ```
+   
+4. **Delegant's response** shows the complete ledger entry:
+   - Agent principal (`breeze_ai_agent`) attribution
+   - Acting-user principal attribution (the technician)
+   - Tool name and parameters
+   - Result/outcome
+   - Hash-chained record integrity
+
+This cross-service correlation enables operators to reconstruct the full authorization and execution chain for any helpdesk action.
+
+---
+
+## Section 7: Prerequisites for Live / Manual Testing
+
+A **disposable Microsoft 365 SANDBOX tenant** is required for:
+- The live test suite (`test/live/m365-*.live.test.ts`)
+- Manual end-to-end verification
+
+### Why Sandbox is Mandatory
+
+Mutations like password reset and user disable **hit a real M365 tenant**. Never run mutation tests against a production customer tenant.
+
+### Setup Steps
+
+1. Provision a test M365 sandbox tenant (Microsoft provides free developer tenants).
+2. Onboard the sandbox M365 credentials in Delegant (creating a `delegant_connection_id`).
+3. Create the `breeze_user` principal in Delegant for the test technician.
+4. Seed the Breeze `delegant_m365_connections` table (Section 3) with the sandbox connection.
+5. Set all required environment variables (Section 1).
+6. Run the live test suite:
+   ```bash
+   pnpm --filter @breeze/api test:live
+   ```
+
+---
+
+## Troubleshooting
+
+### `unexpected_pending` Error
+
+**Symptom:** Tool invocation returns "Tool returned unexpected_pending."
+
+**Cause:** Delegant evaluated the policy as `require_approval` or `pending` for this tool. Breeze does not support deferred approval on the Delegant side.
+
+**Resolution:**
+1. Check the org policy in Delegant for the `breeze_ai_agent` principal.
+2. Ensure the tool is set to `allow` (not `require_approval`).
+3. Redeploy or reload Delegant's policy cache.
+
+### JWT Signature Verification Fails
+
+**Symptom:** Delegant returns 401 Unauthorized on tool invocation.
+
+**Cause:** The signing key or `kid` mismatch between Breeze and Delegant.
+
+**Resolution:**
+1. Verify `DELEGANT_PRINCIPAL_SIGNING_KEY` is the correct Ed25519 private key in PKCS8 PEM format.
+2. Extract the corresponding public key and register it in Delegant's `jwtKeySet` with the exact same `kid` as `DELEGANT_PRINCIPAL_KID`.
+3. Test signature with a tool like `openssl` or the Delegant validation endpoint.
+
+### Service Token Rejected
+
+**Symptom:** Delegant returns 403 Forbidden with "invalid service token."
+
+**Cause:** `DELEGANT_SERVICE_TOKEN` does not match Delegant's configured `serviceToken`.
+
+**Resolution:**
+1. Confirm the token value in both systems.
+2. Verify there are no leading/trailing whitespaces in the env var.
+3. Redeploy Breeze after updating the token.
+
+### Migration Table Not Found
+
+**Symptom:** Breeze API fails at startup with "table delegant_m365_connections does not exist."
+
+**Cause:** Migrations did not run during deployment.
+
+**Resolution:**
+1. Verify `DATABASE_URL_APP` and `BREEZE_APP_DB_PASSWORD` (or `POSTGRES_PASSWORD`) are set.
+2. Check `_migrations` table for the two M365 migration entries (2026-05-27-b-*, 2026-05-27-c-*).
+3. If missing, manually run `check-migrations.ts` or trigger the deployment pipeline again.
+4. See Section 5 for more context on migration execution.
+
+---
+
+## Summary Checklist
+
+Before going live:
+
+- [ ] All environment variables set (Section 1)
+- [ ] `breeze_ai_agent` principal created in Delegant (Section 2.1)
+- [ ] `breeze_user` principal created in Delegant, same org, type `breeze_user` (Section 2.2)
+- [ ] Policy configured for `allow` on all five tools (Section 2.3)
+- [ ] JWT public key registered in Delegant's `jwtKeySet` with correct `kid` (Section 2.4)
+- [ ] `delegant_m365_connections` row seeded via SQL (Section 3)
+- [ ] Migrations applied (`_migrations` table contains 2026-05-27-b-* and 2026-05-27-c-*) (Section 5)
+- [ ] Sandbox M365 tenant available for testing (Section 7)
+- [ ] Technician `breeze_user` principal linked in `DELEGANT_TEST_ACTING_USER_ID`
+
+For live troubleshooting, use the audit trail in Section 6 to correlate actions across Breeze and Delegant.

--- a/docs/runbooks/m365-helpdesk-agent.md
+++ b/docs/runbooks/m365-helpdesk-agent.md
@@ -29,13 +29,13 @@ Configure these in `apps/api/src/config/env.ts` before deploying:
 
 - **`DELEGANT_PRINCIPAL_KID`** — the key id; must match the `kid` of the public key registered in Delegant's `jwtKeySet`.
 
-- **`DELEGANT_TEST_AGENT_ID`** — (v1 single-customer seeding) the Delegant `principals` row id of the `breeze_ai_agent` principal. Used as the JWT `sub` claim.
+- **`DELEGANT_AGENT_ID`** — (v1 single-customer seeding) the Delegant `principals` row id of the `breeze_ai_agent` principal. Used as the JWT `sub` claim.
 
-- **`DELEGANT_TEST_ACTING_USER_ID`** — (v1 single-customer seeding) the Delegant `principals` row id (a UUID) of the `breeze_user` principal representing the acting technician. Used as the JWT `breeze_acting_user_id` claim (chains the agent to the acting user).
+- **`DELEGANT_ACTING_USER_ID`** — (v1 single-customer seeding) the Delegant `principals` row id (a UUID) of the `breeze_user` principal representing the acting technician. Used as the JWT `breeze_acting_user_id` claim (chains the agent to the acting user).
 
 ### Single-Customer Shortcut (v1)
 
-The current version uses `DELEGANT_TEST_AGENT_ID` and `DELEGANT_TEST_ACTING_USER_ID` as a **single-customer shortcut**. This is because v1 lacks a per-technician principal mapping table — a known follow-up. Bulk principal provisioning is deferred to a Delegant-side slice.
+The current version uses `DELEGANT_AGENT_ID` and `DELEGANT_ACTING_USER_ID` as a **single-customer shortcut**. This is because v1 lacks a per-technician principal mapping table — a known follow-up. Bulk principal provisioning is deferred to a Delegant-side slice.
 
 Example configuration:
 ```bash
@@ -45,8 +45,8 @@ export DELEGANT_PRINCIPAL_SIGNING_KEY="-----BEGIN PRIVATE KEY-----
 ...
 -----END PRIVATE KEY-----"
 export DELEGANT_PRINCIPAL_KID="key-id-matching-public-in-delegant-jwtkeyset"
-export DELEGANT_TEST_AGENT_ID="breeze-ai-agent-principals-id"
-export DELEGANT_TEST_ACTING_USER_ID="breeze-user-principals-id-uuid"
+export DELEGANT_AGENT_ID="breeze-ai-agent-principals-id"
+export DELEGANT_ACTING_USER_ID="breeze-user-principals-id-uuid"
 ```
 
 ---
@@ -57,11 +57,11 @@ Before Breeze can invoke helpdesk tools, an operator **must** set up the followi
 
 ### 1. Create the Agent Principal
 
-Create a `breeze_ai_agent` principal in Delegant. Record its `principals` row id → `DELEGANT_TEST_AGENT_ID`.
+Create a `breeze_ai_agent` principal in Delegant. Record its `principals` row id → `DELEGANT_AGENT_ID`.
 
 ### 2. Create a Technician Principal
 
-Create a `breeze_user` principal per technician in Delegant. Record its id (a UUID) → `DELEGANT_TEST_ACTING_USER_ID`. The principal **must**:
+Create a `breeze_user` principal per technician in Delegant. Record its id (a UUID) → `DELEGANT_ACTING_USER_ID`. The principal **must**:
 - Belong to the **same Delegant org** as the M365 connection being onboarded.
 - Have type `breeze_user` (Delegant's wireAuth rejects mismatches with 403).
 
@@ -271,6 +271,6 @@ Before going live:
 - [ ] `delegant_m365_connections` row seeded via SQL (Section 3)
 - [ ] Migrations applied (`_migrations` table contains 2026-05-27-b-* and 2026-05-27-c-*) (Section 5)
 - [ ] Sandbox M365 tenant available for testing (Section 7)
-- [ ] Technician `breeze_user` principal linked in `DELEGANT_TEST_ACTING_USER_ID`
+- [ ] Technician `breeze_user` principal linked in `DELEGANT_ACTING_USER_ID`
 
 For live troubleshooting, use the audit trail in Section 6 to correlate actions across Breeze and Delegant.


### PR DESCRIPTION
## Summary

Adds a Microsoft 365 helpdesk agent backed by Delegant, exposing M365 admin actions as AI-agent tools with tiered RBAC, per-action approvals, customer-tenant scoping, and audit correlation. 15 commits, ~2.6k lines across API, web, mobile, and docs.

## What's included

- **Data model:** `delegant_m365_connections` schema + migrations (connections table, session/execution columns).
- **Delegant client:** principal JWT minting, HTTP invoke + response mapping, safe logging (`delegantClient.ts`, `m365Helpers.ts`).
- **Tools:** five M365 helpdesk tools with inline session-aware registration (`aiToolsM365.ts`, `aiAgentSdkTools.ts`).
- **Enforcement:** tool tiers + RBAC permissions, approval-card risk summary, and routing of M365 tools through the approval/RBAC/audit pipeline via a session-aware wrapper (`approvals.ts`, `aiGuardrails.ts`, `aiAgent*.ts`).
- **Customer scoping:** customer switcher, session binding, header badge (web `AiChatSidebar.tsx`/`aiStore.ts`); customer-tenant badge on the mobile approval card.
- **Audit:** captures the Delegant `toolCallId` for audit correlation.
- **Docs:** operator runbook (`docs/runbooks/m365-helpdesk-agent.md`).

## Testing

Extensive unit coverage added alongside each layer (`*.test.ts` for delegant client, M365 tools, guardrails, session-aware tools, approvals, aiAgent). Includes an **opt-in live suite skeleton** (`m365.live.test.ts`) that is sandbox-only and skips without credentials.

## Notes for review

- Large feature branch developed incrementally — reviewing commit-by-commit may be easier than the squashed diff.
- Touches the AI agent enforcement path (approvals/RBAC/audit); the multi-tenant + approval surfaces are the highest-value review areas.

## Post-review hardening (commits 1a48a74d, 00050474)

Self-review surfaced one blocking bug + several hardening gaps; all fixed TDD (RED→GREEN), 599 AI-suite tests green, `tsc` 0 new errors.

- **Blocking:** the 5 M365 tools were rejected at runtime as tier-4 "Unknown tool" — `checkGuardrails`→`getToolTier` reads the `aiTools` registry, but the session-aware M365 tools live outside it (only in `TOOL_TIERS`). `getToolTier` now falls back to `m365ToolTiers`; added the tier regression tests that catch it.
- **Conditional registration:** M365 tools are now only advertised to the model when `DELEGANT_BASE_URL` is set (`m365ToolDefinitions`), so unconfigured instances don't surface inert tools.
- **Delegant client:** `redirect:'error'` so a 3xx can't forward the bearer token + principal JWT off-host.
- **Boot validation:** `DELEGANT_BASE_URL` in production now fail-closes unless its companion secrets are set.
- **Migrations:** added `org_id → organizations(id) ON DELETE CASCADE` on `delegant_m365_connections` (was unconstrained), and `ai_sessions` binding FK now `ON DELETE SET NULL`. Idempotent guarded blocks.
- **Env rename:** `DELEGANT_TEST_*` → `DELEGANT_ACTING_USER_ID`/`DELEGANT_AGENT_ID` (real v1 prod config, not test scaffolding).

**Migration note:** the two migrations (`2026-05-27-b-…`, `-c-`) were **amended after the original branch push** to add the FKs above. Verified against a fresh empty Postgres: all 211 migrations apply cleanly from scratch (self-hoster install path), drift-clean ledger, idempotent re-apply, FKs created with the correct delete rules. **If you applied the branch's earlier `-b-`/`-c-` to a local DB before this amendment, that DB needs a `down -v` re-apply** (the migration checksum changed). A fresh install is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
