### PR TITLE
fix(api,audit): hash audit chain via convert_to, not text::bytea (unblocks v0.67.x EU upgrade)

### DIFF
--- a/apps/api/migrations/2026-05-25-b-audit-log-checksum-chain.sql
+++ b/apps/api/migrations/2026-05-25-b-audit-log-checksum-chain.sql
@@ -42,7 +42,11 @@ BEGIN
           || NEW.timestamp::text;
 
   NEW.prev_checksum := prev;
-  NEW.checksum := encode(sha256(payload::bytea), 'hex');
+  -- convert_to(... ,'UTF8'), not payload::bytea: the text->bytea cast runs the
+  -- string through bytea's input parser, which interprets backslash escapes and
+  -- throws `invalid input syntax for type bytea` on the \n / \" / \\ that
+  -- jsonb details::text emits. convert_to encodes the bytes faithfully.
+  NEW.checksum := encode(sha256(convert_to(payload, 'UTF8')), 'hex');
   RETURN NEW;
 END;
 $$;
@@ -81,12 +85,12 @@ BEGIN
 
     UPDATE audit_logs SET
       prev_checksum = prev,
-      checksum = encode(sha256((
+      checksum = encode(sha256(convert_to(
         COALESCE(prev, '') || '|' || rec.id::text || '|' || rec.actor_type::text || '|' ||
         COALESCE(rec.actor_id::text, '') || '|' || rec.action || '|' || rec.resource_type || '|' ||
         COALESCE(rec.resource_id::text, '') || '|' || rec.result::text || '|' ||
         COALESCE(rec.details::text, '') || '|' || rec.timestamp::text
-      )::bytea), 'hex')
+      , 'UTF8')), 'hex')
     WHERE id = rec.id
     RETURNING checksum INTO prev;
 

--- a/apps/api/migrations/2026-05-25-c-audit-log-checksum-canonical-fix.sql
+++ b/apps/api/migrations/2026-05-25-c-audit-log-checksum-canonical-fix.sql
@@ -39,7 +39,9 @@ BEGIN
   LIMIT 1;
 
   NEW.prev_checksum := prev;
-  NEW.checksum := encode(sha256(audit_log_canonical_payload(NEW, prev)::bytea), 'hex');
+  -- convert_to(... ,'UTF8'), not ::bytea — see note in -b-: the text->bytea cast
+  -- throws on the backslash escapes jsonb details::text emits.
+  NEW.checksum := encode(sha256(convert_to(audit_log_canonical_payload(NEW, prev), 'UTF8')), 'hex');
   RETURN NEW;
 END;
 $$;
@@ -62,7 +64,7 @@ BEGIN
     WHERE org_id IS NOT DISTINCT FROM p_org_id
     ORDER BY timestamp, id
   LOOP
-    expected_hash := encode(sha256(audit_log_canonical_payload(rec, prev)::bytea), 'hex');
+    expected_hash := encode(sha256(convert_to(audit_log_canonical_payload(rec, prev), 'UTF8')), 'hex');
     IF rec.checksum IS DISTINCT FROM expected_hash
        OR rec.prev_checksum IS DISTINCT FROM prev THEN
       broken_id := rec.id;
@@ -108,7 +110,7 @@ BEGIN
 
     UPDATE audit_logs SET
       prev_checksum = prev,
-      checksum = encode(sha256(audit_log_canonical_payload(rec, prev)::bytea), 'hex')
+      checksum = encode(sha256(convert_to(audit_log_canonical_payload(rec, prev), 'UTF8')), 'hex')
     WHERE id = rec.id
     RETURNING checksum INTO prev;
 

--- a/apps/api/src/__tests__/integration/audit-checksum.integration.test.ts
+++ b/apps/api/src/__tests__/integration/audit-checksum.integration.test.ts
@@ -127,6 +127,56 @@ describe('audit_logs checksum chain', () => {
     });
   });
 
+  // Regression for the `text::bytea` cast bug (EU upgrade blocked by
+  // `invalid input syntax for type bytea`). The canonical payload includes
+  // `details::text`, and jsonb renders control chars / quotes / backslashes
+  // in string values as backslash escapes (\n, \", \\, \uXXXX). The original
+  // trigger/verifier/backfill hashed via `payload::bytea`, which runs the
+  // string through bytea's *input parser* — it interprets those escapes and
+  // throws on any that aren't a valid bytea escape. Real audit history
+  // (Windows paths, multi-line messages, user-agents with quotes) trips it,
+  // so the insert itself fails. The fix hashes via convert_to(payload,'UTF8'),
+  // which faithfully encodes the bytes. These payloads are backslash-free in
+  // every other test, which is why the bug hid until real data hit it.
+  it('hashes audit rows whose details contain backslash escapes', async () => {
+    const details = {
+      path: 'C:\\Users\\admin\\AppData',
+      msg: 'line1\nline2\ttabbed',
+      quote: 'he said "hi"',
+      unicode: 'café',
+    };
+    await withSystemDbAccessContext(async () => {
+      // Without the fix this INSERT throws `invalid input syntax for type bytea`.
+      const inserted = (await db.execute(sql`
+        INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result, details)
+        VALUES (${orgId}, 'system', gen_random_uuid(), 'escape.test', 'test', 'success', ${JSON.stringify(details)}::jsonb)
+        RETURNING id, prev_checksum, checksum
+      `)) as unknown as Array<{ id: string; prev_checksum: string | null; checksum: string }>;
+      const row = inserted[0]!;
+      expect(row.checksum).toMatch(/^[0-9a-f]{64}$/);
+
+      // The checksum must be sha256 over the UTF-8 bytes of the canonical
+      // payload (what convert_to produces), matching the Node-side hash.
+      const canonicalRows = (await db.execute(sql`
+        SELECT public.audit_log_canonical_payload(
+          (SELECT audit_logs FROM audit_logs WHERE id = ${row.id}),
+          ${row.prev_checksum}::varchar
+        ) AS payload
+      `)) as unknown as Array<{ payload: string }>;
+      const expected = createHash('sha256').update(canonicalRows[0]!.payload, 'utf8').digest('hex');
+      expect(row.checksum).toEqual(expected);
+    });
+
+    // The verifier walks the same convert_to path — it must not throw and must
+    // report the chain intact for the backslash-laden row.
+    await withSystemDbAccessContext(async () => {
+      const breaks = (await db.execute(sql`
+        SELECT * FROM public.audit_log_verify_chain(${orgId}::uuid)
+      `)) as unknown as Array<{ broken_id: string }>;
+      expect(breaks).toEqual([]);
+    });
+  });
+
   it('audit_log_verify_chain detects tampering via direct SQL UPDATE', async () => {
     // Seed three rows each in their own transaction so the chain is
     // unambiguously ordered (see same-tx note above). Each insert returns the

--- a/apps/api/src/jobs/auditRetention.ts
+++ b/apps/api/src/jobs/auditRetention.ts
@@ -149,7 +149,11 @@ export async function pruneExpiredAuditLogs(): Promise<RetentionStats> {
             UPDATE audit_logs
             SET prev_checksum = NULL,
                 checksum = encode(
-                  sha256(audit_log_canonical_payload(head, NULL)::bytea),
+                  -- convert_to(... ,'UTF8'), not ::bytea: the text->bytea cast
+                  -- throws on the backslash escapes jsonb details::text emits.
+                  -- Must match the trigger/verifier hash exactly or this
+                  -- re-anchor would itself break the chain.
+                  sha256(convert_to(audit_log_canonical_payload(head, NULL), 'UTF8')),
                   'hex'
                 )
             FROM head


### PR DESCRIPTION
## Problem

Upgrading EU to v0.67.x fails during migration `2026-05-25-b-audit-log-checksum-chain.sql` with:

```
ERROR: invalid input syntax for type bytea   (routine: byteain, in audit_log_compute_checksum())
```

The audit_logs hash-chain migrations (`-b-`/`-c-`, #900) hash the canonical payload with `sha256(<text>::bytea)`. **`text::bytea` is not a UTF-8 encoder** — it runs the string through bytea's input parser (`byteain`), which interprets backslash escapes. The payload embeds `details::text`, and `jsonb::text` renders control chars / quotes / backslashes in string values as `\n \t \" \\ \uXXXX`. Any real audit row (Windows paths, multi-line messages, user-agents with quotes) trips the parser, aborting the `-b-` backfill on existing data. Fresh/CI DBs have no such rows, so it shipped green and only broke on real data.

Reproduction:
```sql
SELECT (('{"msg":"line1\nline2"}'::jsonb)::text)::bytea;  -- ERROR: invalid input syntax for type bytea
```

## Fix

`::bytea` → `convert_to(payload, 'UTF8')` at every hashing site:

- `2026-05-25-b-…`: trigger fn + backfill loop
- `2026-05-25-c-…`: trigger fn + `audit_log_verify_chain` + backfill loop
- `src/jobs/auditRetention.ts`: retention re-anchor UPDATE

For backslash-free payloads `::bytea` and `convert_to(.,'UTF8')` are **byte-identical** (verified), and the live trigger also used `::bytea`, so no backslash row could ever have been written — **every existing checksum stays valid; no chain divergence.**

## Why edit the shipped migrations instead of appending

`-b-`'s backfill `DO $$` throws and aborts the batch transaction **before** any later-dated migration is reached, so a forward-only fix cannot unblock EU. EU/US never *recorded* `-b-`/`-c-` (the failed attempt rolled back), and CI `check-migrations` / smoke / integration all use fresh DBs — so autoMigrate's checksum guard is not tripped in any of those paths.

⚠️ **Reviewer note:** persistent local dev/test DBs that already applied `-b-`/`-c-` will trip the checksum guard on next boot. Re-apply with `docker compose -f docker-compose.test.yml down -v && up -d` (test stack), or update the two `breeze_migrations.checksum` rows (dev DB, non-destructive).

## Tests

- `audit-checksum.integration.test.ts` — new test inserts a row whose `details` contain backslash escapes; asserts insert + `verify_chain` survive and match the Node-side UTF-8 hash.
- Verified on a fresh DB: audit-checksum 6/6, audit-retention 6/6, autoMigrate ordering 42/42.
- Directly exercised the backfill loop over pre-existing backslash rows → no throw, `verify_chain` = 0 breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)