### PR TITLE
fix(api,config): correct misleading TRUSTED_PROXY_CIDRS error hint

### DIFF
--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -260,7 +260,8 @@ function validateTrustedProxyCidrsForProduction(value: string | undefined, ctx: 
       path: ['TRUSTED_PROXY_CIDRS'],
       message:
         'TRUSTED_PROXY_CIDRS must be a non-empty CIDR list when TRUST_PROXY_HEADERS is enabled in production '
-        + '(e.g. "172.30.0.11/32" for a local Caddy hop, or "10.0.0.0/8,172.16.0.0/12" for a wider trusted range). '
+        + '(e.g. "172.30.0.11/32" for a local Caddy hop). Private-range proxies MUST be pinned to exact hosts '
+        + '(/32 for IPv4, /128 for IPv6) — broad private CIDRs like 172.16.0.0/12 or 10.0.0.0/8 are rejected. '
         + 'Without it, every upstream proxy is rejected and per-IP rate limits collapse onto a spoofable fingerprint. '
         + 'If the API is NOT behind a reverse proxy, set TRUST_PROXY_HEADERS=false instead.',
     });


### PR DESCRIPTION
## Problem

The empty-list error hint for `TRUSTED_PROXY_CIDRS` suggests `"10.0.0.0/8,172.16.0.0/12"` as a valid *"wider trusted range"*:

```ts
+ '(e.g. "172.30.0.11/32" for a local Caddy hop, or "10.0.0.0/8,172.16.0.0/12" for a wider trusted range). '
```

But both are **private-range CIDRs that the validator rejects** two checks later — private proxies must be pinned to exact hosts (`/32` for IPv4, `/128` for IPv6, see `isPrivateOrLocalProxyNetwork` + the `prefix !== maxPrefix` guard). So the hint invites operators to set exactly the value that boot-refuses.

This is not hypothetical: a production droplet was found with `TRUSTED_PROXY_CIDRS=172.16.0.0/12` in its `.env`, latent (containers predated the edit) until the next recreate would have crashed the api on config validation.

## Fix

Reword the hint to state the `/32` pinning rule and explicitly call out that broad private CIDRs like `172.16.0.0/12` / `10.0.0.0/8` are rejected — so the example no longer contradicts the validator.

No behavior change. `validate.test.ts` unchanged — 97/97 pass (no test asserts the message text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)