### PR TITLE
feat(helper): IPC token delivery — Phase 1 (HIGH-1)

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -155,6 +155,8 @@ type Heartbeat struct {
 	lastReliabilityUpdate time.Time
 
 	// User session helper (IPC)
+	helperToken      string // retained copy of the helper-scoped token for connect-time pushes
+	helperTokenMu    sync.RWMutex
 	sessionBroker    *sessionbroker.Broker
 	isService        bool
 	isHeadless       bool
@@ -407,6 +409,10 @@ func NewWithVersion(cfg *config.Config, version string, token *secmem.SecureStri
 		}
 		h.sessionBroker = sessionbroker.New(socketPath, h.handleUserHelperMessage)
 		h.sessionBroker.SetSessionClosedHandler(h.handleHelperSessionClosed)
+		h.sessionBroker.SetSessionAuthenticatedHandler(h.handleHelperSessionAuthenticated)
+		// Retain the helper-scoped token so connect-time pushes have it even after
+		// the config copy is cleared post-persist during rotation.
+		h.setHelperToken(h.config.HelperAuthToken)
 		reason := "config"
 		if cfg.IsService {
 			reason = "system-service"
@@ -2432,6 +2438,10 @@ func (h *Heartbeat) handleTokenRotation() {
 	// Notify the watchdog of its role-scoped token so it can use it for failover heartbeats.
 	h.sendWatchdogTokenUpdate(rotateResp.WatchdogAuthToken)
 
+	// Retain and push the rotated helper token to any connected assist sessions.
+	h.setHelperToken(rotateResp.HelperAuthToken)
+	h.sendHelperTokenUpdate(rotateResp.HelperAuthToken)
+
 	if h.wsClient != nil {
 		h.wsClient.ForceReconnect()
 	}
@@ -2468,6 +2478,59 @@ func (h *Heartbeat) sendWatchdogTokenUpdate(newToken string) {
 	_ = sess.SendNotify("", ipc.TypeTokenUpdate, ipc.TokenUpdate{
 		Token: newToken,
 	})
+}
+
+func (h *Heartbeat) setHelperToken(token string) {
+	h.helperTokenMu.Lock()
+	h.helperToken = token
+	h.helperTokenMu.Unlock()
+}
+
+func (h *Heartbeat) currentHelperToken() string {
+	h.helperTokenMu.RLock()
+	defer h.helperTokenMu.RUnlock()
+	return h.helperToken
+}
+
+// shouldPushHelperToken reports whether a session with the given scopes should
+// receive the helper token. Only assist-scope sessions qualify; this guards
+// against ever sending the helper token to the watchdog or a user helper.
+func shouldPushHelperToken(scopes []string) bool {
+	for _, s := range scopes {
+		if s == ipc.HelperRoleAssist {
+			return true
+		}
+	}
+	return false
+}
+
+// handleHelperSessionAuthenticated is wired as the broker's
+// SessionAuthenticatedHandler. It pushes the current helper token to a freshly
+// authenticated assist session.
+func (h *Heartbeat) handleHelperSessionAuthenticated(session *sessionbroker.Session) {
+	if session == nil || !shouldPushHelperToken(session.AllowedScopes) {
+		return
+	}
+	token := h.currentHelperToken()
+	if token == "" {
+		return
+	}
+	if err := session.SendNotify("", ipc.TypeHelperTokenUpdate, ipc.HelperTokenUpdate{Token: token}); err != nil {
+		log.Warn("failed to push helper token to assist session", "error", err.Error())
+	}
+}
+
+// sendHelperTokenUpdate pushes a (possibly rotated) helper token to all
+// connected assist sessions.
+func (h *Heartbeat) sendHelperTokenUpdate(newToken string) {
+	if h.sessionBroker == nil || newToken == "" {
+		return
+	}
+	for _, sess := range h.sessionBroker.SessionsWithScope(ipc.HelperRoleAssist) {
+		if err := sess.SendNotify("", ipc.TypeHelperTokenUpdate, ipc.HelperTokenUpdate{Token: newToken}); err != nil {
+			log.Warn("failed to push rotated helper token", "error", err.Error())
+		}
+	}
 }
 
 func (h *Heartbeat) processCommand(cmd Command) {

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -2515,6 +2515,7 @@ func (h *Heartbeat) handleHelperSessionAuthenticated(session *sessionbroker.Sess
 	if token == "" {
 		return
 	}
+	// ExpiresAt omitted: RotateTokenResponse carries no expiry for the helper token.
 	if err := session.SendNotify("", ipc.TypeHelperTokenUpdate, ipc.HelperTokenUpdate{Token: token}); err != nil {
 		log.Warn("failed to push helper token to assist session", "error", err.Error())
 	}
@@ -2527,6 +2528,7 @@ func (h *Heartbeat) sendHelperTokenUpdate(newToken string) {
 		return
 	}
 	for _, sess := range h.sessionBroker.SessionsWithScope(ipc.HelperRoleAssist) {
+		// ExpiresAt omitted: RotateTokenResponse carries no expiry for the helper token.
 		if err := sess.SendNotify("", ipc.TypeHelperTokenUpdate, ipc.HelperTokenUpdate{Token: newToken}); err != nil {
 			log.Warn("failed to push rotated helper token", "error", err.Error())
 		}

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -2497,7 +2497,7 @@ func (h *Heartbeat) currentHelperToken() string {
 // against ever sending the helper token to the watchdog or a user helper.
 func shouldPushHelperToken(scopes []string) bool {
 	for _, s := range scopes {
-		if s == ipc.HelperRoleAssist {
+		if s == ipc.ScopeAssist {
 			return true
 		}
 	}
@@ -2527,7 +2527,7 @@ func (h *Heartbeat) sendHelperTokenUpdate(newToken string) {
 	if h.sessionBroker == nil || newToken == "" {
 		return
 	}
-	for _, sess := range h.sessionBroker.SessionsWithScope(ipc.HelperRoleAssist) {
+	for _, sess := range h.sessionBroker.SessionsWithScope(ipc.ScopeAssist) {
 		// ExpiresAt omitted: RotateTokenResponse carries no expiry for the helper token.
 		if err := sess.SendNotify("", ipc.TypeHelperTokenUpdate, ipc.HelperTokenUpdate{Token: newToken}); err != nil {
 			log.Warn("failed to push rotated helper token", "error", err.Error())

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -2504,6 +2504,28 @@ func shouldPushHelperToken(scopes []string) bool {
 	return false
 }
 
+// pushHelperToken delivers the helper token to a single eligible session and
+// recovers from a delivery failure. A missed push after rotation otherwise
+// leaves the Helper 401ing against the API with a stale/invalid token, with no
+// re-push until it happens to reconnect on its own. On a SendNotify error we
+// therefore close the session: closing tears down the connection so the client
+// reconnects and re-runs handleHelperSessionAuthenticated, which re-pushes the
+// current token. Closing from this goroutine is safe — Session.Close() only
+// touches the session's own conn/done (not the broker mutex); the broker's
+// RecvLoop unblocks on the closed conn and runs removeSession (which acquires
+// b.mu and fires onSessionClosed) for us. Callers must NOT hold b.mu here.
+func (h *Heartbeat) pushHelperToken(session *sessionbroker.Session, token string) {
+	// ExpiresAt omitted: RotateTokenResponse carries no expiry for the helper token.
+	if err := session.SendNotify("", ipc.TypeHelperTokenUpdate, ipc.HelperTokenUpdate{Token: token}); err != nil {
+		log.Error("failed to push helper token; closing assist session for reconnect+re-push",
+			"sessionId", session.SessionID, "error", err.Error())
+		if closeErr := session.Close(); closeErr != nil {
+			log.Error("failed to close assist session after token push failure",
+				"sessionId", session.SessionID, "error", closeErr.Error())
+		}
+	}
+}
+
 // handleHelperSessionAuthenticated is wired as the broker's
 // SessionAuthenticatedHandler. It pushes the current helper token to a freshly
 // authenticated assist session.
@@ -2515,23 +2537,23 @@ func (h *Heartbeat) handleHelperSessionAuthenticated(session *sessionbroker.Sess
 	if token == "" {
 		return
 	}
-	// ExpiresAt omitted: RotateTokenResponse carries no expiry for the helper token.
-	if err := session.SendNotify("", ipc.TypeHelperTokenUpdate, ipc.HelperTokenUpdate{Token: token}); err != nil {
-		log.Warn("failed to push helper token to assist session", "error", err.Error())
-	}
+	h.pushHelperToken(session, token)
 }
 
 // sendHelperTokenUpdate pushes a (possibly rotated) helper token to all
-// connected assist sessions.
+// connected assist sessions. Recipient eligibility is routed through the single
+// authoritative shouldPushHelperToken predicate (the same one used at connect
+// time) rather than SessionsWithScope's HasScope alone, whose wildcard match
+// would also select a hypothetical "*"-scoped session.
 func (h *Heartbeat) sendHelperTokenUpdate(newToken string) {
 	if h.sessionBroker == nil || newToken == "" {
 		return
 	}
 	for _, sess := range h.sessionBroker.SessionsWithScope(ipc.ScopeAssist) {
-		// ExpiresAt omitted: RotateTokenResponse carries no expiry for the helper token.
-		if err := sess.SendNotify("", ipc.TypeHelperTokenUpdate, ipc.HelperTokenUpdate{Token: newToken}); err != nil {
-			log.Warn("failed to push rotated helper token", "error", err.Error())
+		if !shouldPushHelperToken(sess.AllowedScopes) {
+			continue
 		}
+		h.pushHelperToken(sess, newToken)
 	}
 }
 

--- a/agent/internal/heartbeat/heartbeat_token_test.go
+++ b/agent/internal/heartbeat/heartbeat_token_test.go
@@ -19,5 +19,5 @@ func TestShouldPushHelperToken(t *testing.T) {
 	if shouldPushHelperToken(nil) {
 		t.Fatal("no scopes must NOT receive helper token")
 	}
-	_ = ipc.TypeHelperTokenUpdate
+	_ = ipc.TypeHelperTokenUpdate // compile-time guard: ensures TypeHelperTokenUpdate stays defined
 }

--- a/agent/internal/heartbeat/heartbeat_token_test.go
+++ b/agent/internal/heartbeat/heartbeat_token_test.go
@@ -1,0 +1,23 @@
+package heartbeat
+
+import (
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
+)
+
+func TestShouldPushHelperToken(t *testing.T) {
+	if !shouldPushHelperToken([]string{"assist"}) {
+		t.Fatal("assist scope should receive helper token")
+	}
+	if shouldPushHelperToken([]string{"watchdog"}) {
+		t.Fatal("watchdog scope must NOT receive helper token")
+	}
+	if shouldPushHelperToken([]string{"notify", "clipboard", "run_as_user"}) {
+		t.Fatal("user scope must NOT receive helper token")
+	}
+	if shouldPushHelperToken(nil) {
+		t.Fatal("no scopes must NOT receive helper token")
+	}
+	_ = ipc.TypeHelperTokenUpdate
+}

--- a/agent/internal/heartbeat/heartbeat_token_test.go
+++ b/agent/internal/heartbeat/heartbeat_token_test.go
@@ -1,9 +1,12 @@
 package heartbeat
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/breeze-rmm/agent/internal/ipc"
+	"github.com/breeze-rmm/agent/internal/sessionbroker"
 )
 
 func TestShouldPushHelperToken(t *testing.T) {
@@ -20,4 +23,100 @@ func TestShouldPushHelperToken(t *testing.T) {
 		t.Fatal("no scopes must NOT receive helper token")
 	}
 	_ = ipc.TypeHelperTokenUpdate // compile-time guard: ensures TypeHelperTokenUpdate stays defined
+}
+
+// helperTokenSession bundles a server-side broker Session with its in-memory
+// client peer so a test can observe what the broker actually wrote on the wire.
+type helperTokenSession struct {
+	session *sessionbroker.Session
+	client  *ipc.Conn
+}
+
+// newHelperTokenSession wires an in-memory socket pair into a broker Session
+// with the given broker session ID and scopes. The server-side RecvLoop is
+// started so SendNotify writes flow to the client peer.
+func newHelperTokenSession(t *testing.T, id string, scopes []string) helperTokenSession {
+	t.Helper()
+	serverConn, clientConn := createTestSocketPair(t)
+	serverIPC := ipc.NewConn(serverConn)
+	clientIPC := ipc.NewConn(clientConn)
+	session := sessionbroker.NewSession(serverIPC, 0, id, "tester", "", id, scopes)
+	go session.RecvLoop(func(*sessionbroker.Session, *ipc.Envelope) {})
+	return helperTokenSession{session: session, client: clientIPC}
+}
+
+// awaitHelperToken reads one frame from the client peer (with a short deadline)
+// and returns the carried token if it is a TypeHelperTokenUpdate, or "" if the
+// read times out / a different frame arrives. The bool reports whether ANY
+// frame was received before the deadline.
+func awaitHelperToken(t *testing.T, c *ipc.Conn) (token string, gotFrame bool) {
+	t.Helper()
+	c.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+	env, err := c.Recv()
+	if err != nil {
+		return "", false
+	}
+	if env.Type != ipc.TypeHelperTokenUpdate {
+		return "", true
+	}
+	var upd ipc.HelperTokenUpdate
+	if err := json.Unmarshal(env.Payload, &upd); err != nil {
+		t.Fatalf("unmarshal helper token update: %v", err)
+	}
+	return upd.Token, true
+}
+
+// TestSendHelperTokenUpdateOnlyReachesAssistSessions guards the wiring (not just
+// the shouldPushHelperToken predicate): a rotated helper token pushed via
+// sendHelperTokenUpdate must land ONLY on the assist-scoped session. The
+// watchdog and user sessions must receive nothing. This catches a future
+// refactor that broadens the recipient set. Runs on any OS — assist-scope
+// routing is not Windows-gated (only the SID identity check at admit time is).
+func TestSendHelperTokenUpdateOnlyReachesAssistSessions(t *testing.T) {
+	assist := newHelperTokenSession(t, "assist-1", []string{ipc.ScopeAssist})
+	watchdog := newHelperTokenSession(t, "watchdog-1", []string{"watchdog"})
+	user := newHelperTokenSession(t, "user-1", []string{"notify", "clipboard", "run_as_user"})
+
+	h := &Heartbeat{
+		sessionBroker: newTestBrokerWithSessions(t, assist.session, watchdog.session, user.session),
+	}
+
+	const secret = "brz_secret"
+	h.sendHelperTokenUpdate(secret)
+
+	if token, _ := awaitHelperToken(t, assist.client); token != secret {
+		t.Fatalf("assist session: expected helper token %q, got %q", secret, token)
+	}
+	if _, gotFrame := awaitHelperToken(t, watchdog.client); gotFrame {
+		t.Fatal("watchdog session received a frame; helper token must never reach watchdog")
+	}
+	if _, gotFrame := awaitHelperToken(t, user.client); gotFrame {
+		t.Fatal("user session received a frame; helper token must never reach user helper")
+	}
+}
+
+// TestHandleHelperSessionAuthenticatedPushesOnlyToAssist proves the connect-time
+// push path: a freshly authenticated assist session receives the retained token,
+// while a watchdog session does not — even when both are driven through the same
+// SessionAuthenticatedHandler entry point.
+func TestHandleHelperSessionAuthenticatedPushesOnlyToAssist(t *testing.T) {
+	const secret = "brz_secret"
+
+	assist := newHelperTokenSession(t, "assist-auth", []string{ipc.ScopeAssist})
+	watchdog := newHelperTokenSession(t, "watchdog-auth", []string{"watchdog"})
+
+	h := &Heartbeat{
+		sessionBroker: newTestBrokerWithSessions(t, assist.session, watchdog.session),
+	}
+	h.setHelperToken(secret)
+
+	h.handleHelperSessionAuthenticated(assist.session)
+	if token, _ := awaitHelperToken(t, assist.client); token != secret {
+		t.Fatalf("authenticated assist session: expected helper token %q, got %q", secret, token)
+	}
+
+	h.handleHelperSessionAuthenticated(watchdog.session)
+	if _, gotFrame := awaitHelperToken(t, watchdog.client); gotFrame {
+		t.Fatal("authenticated watchdog session received a frame; helper token must never reach watchdog")
+	}
 }

--- a/agent/internal/ipc/message.go
+++ b/agent/internal/ipc/message.go
@@ -150,7 +150,7 @@ type AuthRequest struct {
 	BinaryHash      string `json:"binaryHash"`
 	WinSessionID    uint32 `json:"winSessionId,omitempty"` // Windows session ID (1, 2, etc.)
 	HelperRole      string `json:"helperRole,omitempty"`   // "system" | "user" | "watchdog" | "assist" (default: "system")
-	BinaryKind      string `json:"binaryKind,omitempty"`   // "user_helper" or "desktop_helper"
+	BinaryKind      string `json:"binaryKind,omitempty"`   // "user_helper", "desktop_helper", or "assist_helper"
 	DesktopContext  string `json:"desktopContext,omitempty"`
 }
 

--- a/agent/internal/ipc/message.go
+++ b/agent/internal/ipc/message.go
@@ -53,6 +53,7 @@ const (
 	TypeWatchdogPong          = "watchdog_pong"
 	TypeShutdownIntent        = "shutdown_intent"
 	TypeTokenUpdate           = "token_update"
+	TypeHelperTokenUpdate     = "helper_token_update" // helper token -> assist helper
 	TypeWatchdogCommand       = "watchdog_command"
 	TypeWatchdogCommandResult = "watchdog_command_result"
 	TypeStateSync             = "state_sync"
@@ -113,11 +114,13 @@ const (
 	HelperRoleSystem   = "system"
 	HelperRoleUser     = "user"
 	HelperRoleWatchdog = "watchdog"
+	HelperRoleAssist   = "assist" // Breeze Assist Tauri helper; receives helper token only
 )
 
 const (
 	HelperBinaryUserHelper    = "user_helper"
 	HelperBinaryDesktopHelper = "desktop_helper"
+	HelperBinaryAssistHelper  = "assist_helper"
 )
 
 const (
@@ -325,6 +328,14 @@ type ShutdownIntent struct {
 // TokenUpdate is sent by the agent to the watchdog when the watchdog-scoped token changes.
 type TokenUpdate struct {
 	Token string `json:"token"`
+}
+
+// HelperTokenUpdate carries the helper-scoped API token to the Assist helper.
+// Distinct from TokenUpdate (agent token -> watchdog) so the two tokens can
+// never be cross-delivered.
+type HelperTokenUpdate struct {
+	Token     string `json:"token"`
+	ExpiresAt string `json:"expiresAt,omitempty"` // RFC3339, optional
 }
 
 // WatchdogCommand is a command forwarded from the watchdog to the agent.

--- a/agent/internal/ipc/message.go
+++ b/agent/internal/ipc/message.go
@@ -53,7 +53,7 @@ const (
 	TypeWatchdogPong          = "watchdog_pong"
 	TypeShutdownIntent        = "shutdown_intent"
 	TypeTokenUpdate           = "token_update"
-	TypeHelperTokenUpdate     = "helper_token_update" // helper token -> assist helper
+	TypeHelperTokenUpdate     = "helper_token_update" // sent to the Assist helper
 	TypeWatchdogCommand       = "watchdog_command"
 	TypeWatchdogCommandResult = "watchdog_command_result"
 	TypeStateSync             = "state_sync"
@@ -108,8 +108,7 @@ type Envelope struct {
 	HMAC    string          `json:"hmac"`
 }
 
-// Helper role constants distinguish SYSTEM helpers (desktop capture) from
-// user-token helpers (script execution as the logged-in user).
+// Helper role constants identify connecting helper processes and gate their scopes.
 const (
 	HelperRoleSystem   = "system"
 	HelperRoleUser     = "user"
@@ -145,7 +144,7 @@ type AuthRequest struct {
 	PID             int    `json:"pid"`
 	BinaryHash      string `json:"binaryHash"`
 	WinSessionID    uint32 `json:"winSessionId,omitempty"` // Windows session ID (1, 2, etc.)
-	HelperRole      string `json:"helperRole,omitempty"`   // "system" or "user" (default: "system")
+	HelperRole      string `json:"helperRole,omitempty"`   // "system" | "user" | "watchdog" | "assist" (default: "system")
 	BinaryKind      string `json:"binaryKind,omitempty"`   // "user_helper" or "desktop_helper"
 	DesktopContext  string `json:"desktopContext,omitempty"`
 }

--- a/agent/internal/ipc/message.go
+++ b/agent/internal/ipc/message.go
@@ -116,6 +116,11 @@ const (
 	HelperRoleAssist   = "assist" // Breeze Assist Tauri helper; receives helper token only
 )
 
+// Scope constants identify the capabilities granted to a helper session.
+const (
+	ScopeAssist = "assist" // IPC scope granted to the assist helper
+)
+
 const (
 	HelperBinaryUserHelper    = "user_helper"
 	HelperBinaryDesktopHelper = "desktop_helper"

--- a/agent/internal/ipc/message_test.go
+++ b/agent/internal/ipc/message_test.go
@@ -1,0 +1,37 @@
+package ipc
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestHelperAssistConstants(t *testing.T) {
+	if HelperRoleAssist != "assist" {
+		t.Fatalf("HelperRoleAssist = %q, want \"assist\"", HelperRoleAssist)
+	}
+	if HelperBinaryAssistHelper != "assist_helper" {
+		t.Fatalf("HelperBinaryAssistHelper = %q, want \"assist_helper\"", HelperBinaryAssistHelper)
+	}
+	if TypeHelperTokenUpdate != "helper_token_update" {
+		t.Fatalf("TypeHelperTokenUpdate = %q, want \"helper_token_update\"", TypeHelperTokenUpdate)
+	}
+}
+
+func TestHelperTokenUpdateRoundTrip(t *testing.T) {
+	in := HelperTokenUpdate{Token: "brz_abc", ExpiresAt: "2026-06-01T00:00:00Z"}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out HelperTokenUpdate
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out != in {
+		t.Fatalf("round-trip mismatch: %+v != %+v", out, in)
+	}
+	b2, _ := json.Marshal(HelperTokenUpdate{Token: "brz_x"})
+	if string(b2) != `{"token":"brz_x"}` {
+		t.Fatalf("omitempty failed: %s", b2)
+	}
+}

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -1315,85 +1315,23 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 	}
 
 	// Step 10: Validate role matches peer identity to prevent privilege escalation.
-	// On Windows, SYSTEM helpers must run as SYSTEM (S-1-5-18), and user helpers
-	// must NOT run as SYSTEM. This prevents a non-SYSTEM process from claiming
-	// system role to get desktop scopes, or SYSTEM from claiming user role.
-	// The assist helper must also NOT run as SYSTEM (mirrors the user role).
-	// The watchdog must also run as root/SYSTEM.
-	const systemSID = "S-1-5-18"
-	if runtime.GOOS == "windows" {
-		if helperRole == ipc.HelperRoleSystem && creds.SID != systemSID {
-			log.Warn("role/identity mismatch: non-SYSTEM process claiming system role",
-				"sid", creds.SID, "pid", creds.PID)
-			_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
-				Accepted:  false,
-				Reason:    "system role requires SYSTEM identity",
-				Permanent: true,
-			})
-			conn.Close()
-			return
-		}
-		if helperRole == ipc.HelperRoleUser && creds.SID == systemSID {
-			log.Warn("role/identity mismatch: SYSTEM process claiming user role",
-				"sid", creds.SID, "pid", creds.PID)
-			_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
-				Accepted:  false,
-				Reason:    "user role requires non-SYSTEM identity",
-				Permanent: true,
-			})
-			conn.Close()
-			return
-		}
-		if helperRole == ipc.HelperRoleAssist && creds.SID == systemSID {
-			log.Warn("role/identity mismatch: SYSTEM process claiming assist role",
-				"sid", creds.SID, "pid", creds.PID)
-			_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
-				Accepted:  false,
-				Reason:    "assist role requires non-SYSTEM identity",
-				Permanent: true,
-			})
-			conn.Close()
-			return
-		}
-		if helperRole == ipc.HelperRoleWatchdog && creds.SID != systemSID {
-			log.Warn("role/identity mismatch: non-SYSTEM process claiming watchdog role",
-				"sid", creds.SID, "pid", creds.PID)
-			_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
-				Accepted:  false,
-				Reason:    "watchdog role requires SYSTEM identity",
-				Permanent: true,
-			})
-			conn.Close()
-			return
-		}
-	} else {
-		// Unix: watchdog and system-role helpers must run as root. The macOS
-		// desktop helper runs in the GUI user/loginwindow session, so it must
-		// authenticate as user-role and receives only desktop scope below.
-		// The assist helper is Windows-only; on Unix it would receive only the
-		// inert "assist" scope, so no identity gate is required here.
-		if helperRole == ipc.HelperRoleWatchdog && creds.UID != 0 {
-			log.Warn("role/identity mismatch: non-root process claiming watchdog role",
-				"uid", creds.UID, "pid", creds.PID)
-			_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
-				Accepted:  false,
-				Reason:    "watchdog role requires root identity",
-				Permanent: true,
-			})
-			conn.Close()
-			return
-		}
-		if helperRole == ipc.HelperRoleSystem && creds.UID != 0 {
-			log.Warn("role/identity mismatch: non-root process claiming system role",
-				"uid", creds.UID, "pid", creds.PID, "binaryKind", authReq.BinaryKind)
-			_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
-				Accepted:  false,
-				Reason:    "system role requires root identity",
-				Permanent: true,
-			})
-			conn.Close()
-			return
-		}
+	// On Windows, SYSTEM helpers must run as SYSTEM (S-1-5-18), and user/assist
+	// helpers must NOT run as SYSTEM. This prevents a non-SYSTEM process from
+	// claiming system role to get desktop scopes, or SYSTEM from claiming user
+	// role. The watchdog must also run as root/SYSTEM. The decision is factored
+	// into roleIdentityRejection so the gate can be unit-tested with an injected
+	// peer-cred SID/UID (a real peer-cred SID can't be faked over a pipe).
+	if reason, rejected := roleIdentityRejection(helperRole, creds.SID, creds.UID, runtime.GOOS); rejected {
+		log.Warn("role/identity mismatch",
+			"reason", reason, "role", helperRole, "sid", creds.SID, "uid", creds.UID,
+			"pid", creds.PID, "binaryKind", authReq.BinaryKind)
+		_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
+			Accepted:  false,
+			Reason:    reason,
+			Permanent: true,
+		})
+		conn.Close()
+		return
 	}
 
 	scopes := b.scopesForRole(helperRole, authReq.BinaryKind, runtime.GOOS, creds.BinaryPath)
@@ -1651,6 +1589,46 @@ func binaryPathMatchesAllowed(peerPath string, allowed []string) bool {
 }
 
 // scopesForRole maps a validated helper role to its allowed scopes.
+// systemSID is the well-known Windows Local System account SID.
+const systemSID = "S-1-5-18"
+
+// roleIdentityRejection reports whether a helper claiming helperRole from the
+// given kernel-verified peer identity (SID on Windows, UID on Unix) must be
+// rejected, and the rejection reason. All role/identity mismatches are
+// permanent. It returns ("", false) when the role/identity pairing is allowed.
+//
+// Pure and OS-parameterized so the privilege-escalation gate can be unit-tested
+// with an injected SID/UID — a real peer-cred SID can't be forged over a named
+// pipe / Unix socket, so end-to-end pipe tests can only exercise the current
+// test process's own identity.
+func roleIdentityRejection(role, sid string, uid uint32, goos string) (reason string, rejected bool) {
+	if goos == "windows" {
+		switch {
+		case role == ipc.HelperRoleSystem && sid != systemSID:
+			return "system role requires SYSTEM identity", true
+		case role == ipc.HelperRoleUser && sid == systemSID:
+			return "user role requires non-SYSTEM identity", true
+		case role == ipc.HelperRoleAssist && sid == systemSID:
+			return "assist role requires non-SYSTEM identity", true
+		case role == ipc.HelperRoleWatchdog && sid != systemSID:
+			return "watchdog role requires SYSTEM identity", true
+		}
+		return "", false
+	}
+	// Unix: watchdog and system-role helpers must run as root. The macOS
+	// desktop helper runs in the GUI user/loginwindow session, so it must
+	// authenticate as user-role and receives only desktop scope. The assist
+	// helper is Windows-only; on Unix it would receive only the inert "assist"
+	// scope, so no identity gate is required here.
+	switch {
+	case role == ipc.HelperRoleWatchdog && uid != 0:
+		return "watchdog role requires root identity", true
+	case role == ipc.HelperRoleSystem && uid != 0:
+		return "system role requires root identity", true
+	}
+	return "", false
+}
+
 func (b *Broker) scopesForRole(role, binaryKind, goos, peerPath string) []string {
 	switch role {
 	case ipc.HelperRoleUser:

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -1700,6 +1700,8 @@ func (b *Broker) allowedHelperPaths() []string {
 			"/usr/local/bin/breeze-watchdog",
 		)
 	}
+	// Allowlist the Breeze Assist helper binary so it can connect over IPC.
+	paths = append(paths, assistHelperBinaryPaths(dir)...)
 	seen := make(map[string]struct{}, len(paths))
 	out := make([]string, 0, len(paths))
 	for _, path := range paths {
@@ -1714,6 +1716,25 @@ func (b *Broker) allowedHelperPaths() []string {
 		out = append(out, clean)
 	}
 	return out
+}
+
+// assistHelperBinaryPaths returns candidate install paths for the Breeze Assist
+// helper, derived from the agent install dir. Used so RefreshAllowedHashes
+// allowlists the genuine breeze-helper binary's SHA-256. Non-existent paths are
+// skipped silently by computeAllowedHashes, so listing all platform candidates
+// is safe even when the helper is not installed.
+func assistHelperBinaryPaths(agentDir string) []string {
+	switch runtime.GOOS {
+	case "windows":
+		return []string{filepath.Join(agentDir, "breeze-helper.exe")}
+	case "darwin":
+		return []string{
+			"/Applications/Breeze Helper.app/Contents/MacOS/breeze-helper",
+			filepath.Join(agentDir, "breeze-helper"),
+		}
+	default:
+		return []string{filepath.Join(agentDir, "breeze-helper")}
+	}
 }
 
 // RefreshAllowedHashes recomputes the helper binary hash allowlist from the

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -211,6 +211,9 @@ var (
 	systemHelperScopes   = []string{"notify", "tray", "clipboard", "desktop"}
 	userHelperScopes     = []string{"notify", "clipboard", "run_as_user"}
 	watchdogHelperScopes = []string{"watchdog"}
+	// assistHelperScopes is least-privilege: the Breeze Assist helper receives
+	// only the helper token and must NOT get desktop/clipboard/run_as_user/notify/tray.
+	assistHelperScopes = []string{"assist"}
 )
 
 // MessageHandler is called when a user helper sends a message that isn't
@@ -1276,7 +1279,7 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 		helperRole = ipc.HelperRoleSystem
 	}
 	switch helperRole {
-	case ipc.HelperRoleSystem, ipc.HelperRoleUser, ipc.HelperRoleWatchdog, backupipc.HelperRoleBackup:
+	case ipc.HelperRoleSystem, ipc.HelperRoleUser, ipc.HelperRoleWatchdog, ipc.HelperRoleAssist, backupipc.HelperRoleBackup:
 	default:
 		log.Warn("unknown helper role", "role", helperRole, "identity", identityKey, "pid", creds.PID)
 		_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
@@ -1312,6 +1315,17 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 			_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
 				Accepted:  false,
 				Reason:    "user role requires non-SYSTEM identity",
+				Permanent: true,
+			})
+			conn.Close()
+			return
+		}
+		if helperRole == ipc.HelperRoleAssist && creds.SID == systemSID {
+			log.Warn("role/identity mismatch: SYSTEM process claiming assist role",
+				"sid", creds.SID, "pid", creds.PID)
+			_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
+				Accepted:  false,
+				Reason:    "assist role requires non-SYSTEM identity",
 				Permanent: true,
 			})
 			conn.Close()
@@ -1356,23 +1370,7 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 		}
 	}
 
-	var scopes []string
-	switch helperRole {
-	case ipc.HelperRoleUser:
-		if runtime.GOOS == "darwin" &&
-			authReq.BinaryKind == ipc.HelperBinaryDesktopHelper &&
-			b.isDesktopHelperPeerPath(creds.BinaryPath) {
-			scopes = []string{"desktop"}
-		} else {
-			scopes = userHelperScopes
-		}
-	case backupipc.HelperRoleBackup:
-		scopes = backupHelperScopes
-	case ipc.HelperRoleWatchdog:
-		scopes = watchdogHelperScopes
-	case ipc.HelperRoleSystem:
-		scopes = systemHelperScopes
-	}
+	scopes := b.scopesForRole(helperRole, authReq.BinaryKind, runtime.GOOS, creds.BinaryPath)
 
 	// Send auth response
 	authResp := ipc.AuthResponse{
@@ -1618,6 +1616,28 @@ func binaryPathMatchesAllowed(peerPath string, allowed []string) bool {
 		}
 	}
 	return false
+}
+
+// scopesForRole maps a validated helper role to its allowed scopes.
+func (b *Broker) scopesForRole(role, binaryKind, goos, peerPath string) []string {
+	switch role {
+	case ipc.HelperRoleUser:
+		if goos == "darwin" &&
+			binaryKind == ipc.HelperBinaryDesktopHelper &&
+			b.isDesktopHelperPeerPath(peerPath) {
+			return []string{"desktop"}
+		}
+		return userHelperScopes
+	case backupipc.HelperRoleBackup:
+		return backupHelperScopes
+	case ipc.HelperRoleWatchdog:
+		return watchdogHelperScopes
+	case ipc.HelperRoleAssist:
+		return assistHelperScopes
+	case ipc.HelperRoleSystem:
+		return systemHelperScopes
+	}
+	return nil
 }
 
 func (b *Broker) isDesktopHelperPeerPath(peerPath string) bool {

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -1295,6 +1295,7 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 	// On Windows, SYSTEM helpers must run as SYSTEM (S-1-5-18), and user helpers
 	// must NOT run as SYSTEM. This prevents a non-SYSTEM process from claiming
 	// system role to get desktop scopes, or SYSTEM from claiming user role.
+	// The assist helper must also NOT run as SYSTEM (mirrors the user role).
 	// The watchdog must also run as root/SYSTEM.
 	const systemSID = "S-1-5-18"
 	if runtime.GOOS == "windows" {
@@ -1346,6 +1347,8 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 		// Unix: watchdog and system-role helpers must run as root. The macOS
 		// desktop helper runs in the GUI user/loginwindow session, so it must
 		// authenticate as user-role and receives only desktop scope below.
+		// The assist helper is Windows-only; on Unix it would receive only the
+		// inert "assist" scope, so no identity gate is required here.
 		if helperRole == ipc.HelperRoleWatchdog && creds.UID != 0 {
 			log.Warn("role/identity mismatch: non-root process claiming watchdog role",
 				"uid", creds.UID, "pid", creds.PID)

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -223,6 +223,10 @@ type MessageHandler func(session *Session, env *ipc.Envelope)
 // SessionClosedHandler is called after a helper session has been removed.
 type SessionClosedHandler func(session *Session)
 
+// SessionAuthenticatedHandler is called after a helper session has been
+// successfully authenticated and registered.
+type SessionAuthenticatedHandler func(session *Session)
+
 // sessionSnapshot is an immutable point-in-time view of the broker's session
 // maps. It is stored via an atomic.Pointer so lock-free readers (FindCapableSession,
 // AllSessions, TCCStatus) can avoid acquiring b.mu.RLock() entirely, preventing
@@ -266,6 +270,7 @@ type Broker struct {
 
 	onMessage       MessageHandler
 	onSessionClosed SessionClosedHandler
+	onSessionAuthed SessionAuthenticatedHandler
 	selfHashes      map[string]struct{} // SHA-256 of allowed helper binaries
 }
 
@@ -335,6 +340,22 @@ func (b *Broker) SetSessionClosedHandler(handler SessionClosedHandler) {
 	b.mu.Lock()
 	b.onSessionClosed = handler
 	b.mu.Unlock()
+}
+
+func (b *Broker) SetSessionAuthenticatedHandler(handler SessionAuthenticatedHandler) {
+	b.mu.Lock()
+	b.onSessionAuthed = handler
+	b.mu.Unlock()
+}
+
+// fireSessionAuthenticated invokes the on-authenticated handler if set.
+func (b *Broker) fireSessionAuthenticated(session *Session) {
+	b.mu.RLock()
+	handler := b.onSessionAuthed
+	b.mu.RUnlock()
+	if handler != nil {
+		handler(session)
+	}
 }
 
 // SetConsoleUser updates the current macOS console user. When set to
@@ -1470,6 +1491,12 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 		"binaryKind", session.BinaryKind,
 		"desktopContext", session.DesktopContext,
 	)
+
+	// Notify the on-authenticated handler now that the session is fully
+	// registered (admitted, appended, scopes assigned). Fired outside the
+	// broker mutex and in a goroutine so a slow handler (e.g. one that pushes
+	// the helper token over IPC) can't block the accept loop or hold b.mu.
+	go b.fireSessionAuthenticated(session)
 
 	// Keepalive: send periodic pings and close the session if pongs stop
 	// arriving. Without this, a wedged helper (e.g. a capture process killed

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -213,7 +213,7 @@ var (
 	watchdogHelperScopes = []string{"watchdog"}
 	// assistHelperScopes is least-privilege: the Breeze Assist helper receives
 	// only the helper token and must NOT get desktop/clipboard/run_as_user/notify/tray.
-	assistHelperScopes = []string{"assist"}
+	assistHelperScopes = []string{ipc.ScopeAssist}
 )
 
 // MessageHandler is called when a user helper sends a message that isn't

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -342,6 +342,8 @@ func (b *Broker) SetSessionClosedHandler(handler SessionClosedHandler) {
 	b.mu.Unlock()
 }
 
+// SetSessionAuthenticatedHandler registers a callback invoked (in a goroutine)
+// after each helper session has been authenticated and registered.
 func (b *Broker) SetSessionAuthenticatedHandler(handler SessionAuthenticatedHandler) {
 	b.mu.Lock()
 	b.onSessionAuthed = handler

--- a/agent/internal/sessionbroker/broker_test.go
+++ b/agent/internal/sessionbroker/broker_test.go
@@ -930,3 +930,17 @@ func TestAssistHelperBinaryPathsIncludeBreezeHelper(t *testing.T) {
 		}
 	}
 }
+
+func TestSetSessionAuthenticatedHandler(t *testing.T) {
+	b := New("/tmp/does-not-matter.sock", func(*Session, *ipc.Envelope) {})
+	var got *Session
+	b.SetSessionAuthenticatedHandler(func(s *Session) { got = s })
+	sess := &Session{}
+	b.fireSessionAuthenticated(sess)
+	if got != sess {
+		t.Fatalf("handler not invoked with the session")
+	}
+	// Nil handler must be a no-op (no panic).
+	b2 := New("/tmp/x.sock", func(*Session, *ipc.Envelope) {})
+	b2.fireSessionAuthenticated(&Session{})
+}

--- a/agent/internal/sessionbroker/broker_test.go
+++ b/agent/internal/sessionbroker/broker_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -884,5 +886,34 @@ func TestScopesForRoleAssist(t *testing.T) {
 	got := b.scopesForRole(ipc.HelperRoleAssist, ipc.HelperBinaryAssistHelper, "darwin", "/x")
 	if len(got) != 1 || got[0] != "assist" {
 		t.Fatalf("scopesForRole(assist) = %v, want [assist]", got)
+	}
+}
+
+func TestAssistHelperBinaryPathsIncludeBreezeHelper(t *testing.T) {
+	paths := assistHelperBinaryPaths("/opt/breeze")
+	found := false
+	for _, p := range paths {
+		base := filepath.Base(p)
+		if base == "breeze-helper" || base == "breeze-helper.exe" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("assistHelperBinaryPaths(%q) = %v, missing breeze-helper binary", "/opt/breeze", paths)
+	}
+
+	// On non-windows platforms the agent-dir-relative path must be present so
+	// the hash allowlist covers helpers installed alongside the agent.
+	if runtime.GOOS != "windows" {
+		want := filepath.Join("/opt/breeze", "breeze-helper")
+		has := false
+		for _, p := range paths {
+			if p == want {
+				has = true
+			}
+		}
+		if !has {
+			t.Fatalf("assistHelperBinaryPaths missing agent-dir path %q; got %v", want, paths)
+		}
 	}
 }

--- a/agent/internal/sessionbroker/broker_test.go
+++ b/agent/internal/sessionbroker/broker_test.go
@@ -916,4 +916,17 @@ func TestAssistHelperBinaryPathsIncludeBreezeHelper(t *testing.T) {
 			t.Fatalf("assistHelperBinaryPaths missing agent-dir path %q; got %v", want, paths)
 		}
 	}
+
+	if runtime.GOOS == "darwin" {
+		want := "/Applications/Breeze Helper.app/Contents/MacOS/breeze-helper"
+		has := false
+		for _, p := range paths {
+			if p == want {
+				has = true
+			}
+		}
+		if !has {
+			t.Fatalf("darwin paths %v missing %q", paths, want)
+		}
+	}
 }

--- a/agent/internal/sessionbroker/broker_test.go
+++ b/agent/internal/sessionbroker/broker_test.go
@@ -866,3 +866,23 @@ func TestTimedRWMutexWarnsOnSlowAcquire(t *testing.T) {
 		t.Fatalf("expected waited_ms field, got:\n%s", output)
 	}
 }
+
+func TestAssistScopesConstant(t *testing.T) {
+	if len(assistHelperScopes) != 1 || assistHelperScopes[0] != "assist" {
+		t.Fatalf("assistHelperScopes = %v, want [\"assist\"]", assistHelperScopes)
+	}
+	for _, s := range assistHelperScopes {
+		switch s {
+		case "desktop", "clipboard", "run_as_user", "notify", "tray":
+			t.Fatalf("assist scope must not include %q", s)
+		}
+	}
+}
+
+func TestScopesForRoleAssist(t *testing.T) {
+	b := &Broker{}
+	got := b.scopesForRole(ipc.HelperRoleAssist, ipc.HelperBinaryAssistHelper, "darwin", "/x")
+	if len(got) != 1 || got[0] != "assist" {
+		t.Fatalf("scopesForRole(assist) = %v, want [assist]", got)
+	}
+}

--- a/agent/internal/sessionbroker/broker_windows_test.go
+++ b/agent/internal/sessionbroker/broker_windows_test.go
@@ -495,6 +495,45 @@ func TestNamedPipeSessionIDCollisionRejected(t *testing.T) {
 	t.Logf("SessionID collision correctly rejected: %s", resp2.Reason)
 }
 
+// TestAssistRoleRejectsSystemSID verifies the step-10 privilege-escalation gate
+// for the Breeze Assist helper: a process running as Local System (S-1-5-18)
+// that claims the "assist" role must be permanently rejected with the reason
+// "assist role requires non-SYSTEM identity", and no session is registered (the
+// gate returns before NewSession/registration).
+//
+// The gate reads the kernel-verified peer-cred SID, which cannot be forged over
+// a named pipe, so this drives the extracted roleIdentityRejection decision with
+// an injected SID rather than connecting a real SYSTEM peer. It mirrors the
+// existing watchdog/user identity-mismatch behavior covered above.
+func TestAssistRoleRejectsSystemSID(t *testing.T) {
+	cases := []struct {
+		name       string
+		role       string
+		sid        string
+		wantReason string
+		wantReject bool
+	}{
+		{"assist as SYSTEM rejected", ipc.HelperRoleAssist, systemSID, "assist role requires non-SYSTEM identity", true},
+		{"assist as non-SYSTEM allowed", ipc.HelperRoleAssist, "S-1-5-21-1-2-3-1001", "", false},
+		{"user as SYSTEM rejected", ipc.HelperRoleUser, systemSID, "user role requires non-SYSTEM identity", true},
+		{"watchdog as non-SYSTEM rejected", ipc.HelperRoleWatchdog, "S-1-5-21-1-2-3-1001", "watchdog role requires SYSTEM identity", true},
+		{"watchdog as SYSTEM allowed", ipc.HelperRoleWatchdog, systemSID, "", false},
+		{"system as non-SYSTEM rejected", ipc.HelperRoleSystem, "S-1-5-21-1-2-3-1001", "system role requires SYSTEM identity", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reason, rejected := roleIdentityRejection(tc.role, tc.sid, 0, "windows")
+			if rejected != tc.wantReject {
+				t.Fatalf("rejected = %v, want %v (reason %q)", rejected, tc.wantReject, reason)
+			}
+			if reason != tc.wantReason {
+				t.Fatalf("reason = %q, want %q", reason, tc.wantReason)
+			}
+		})
+	}
+}
+
 func computeTestBinaryHash(t *testing.T) string {
 	t.Helper()
 	exePath, err := os.Executable()

--- a/agent/internal/sessionbroker/session.go
+++ b/agent/internal/sessionbroker/session.go
@@ -246,7 +246,10 @@ func (s *Session) GetTCCStatus() *ipc.TCCStatus {
 	return s.TCCStatus
 }
 
-// HasScope checks if this session is authorized for the given scope.
+// HasScope reports whether the session was granted the given scope.
+// AllowedScopes is set once in NewSession and never mutated afterward, so this
+// is safe to call concurrently (e.g. from the SessionAuthenticatedHandler
+// goroutine) without holding s.mu.
 func (s *Session) HasScope(scope string) bool {
 	for _, allowed := range s.AllowedScopes {
 		if allowed == scope || allowed == "*" {

--- a/apps/helper/src-tauri/Cargo.lock
+++ b/apps/helper/src-tauri/Cargo.lock
@@ -148,15 +148,21 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "futures-util",
+ "hex",
+ "hmac",
+ "libc",
+ "rand 0.8.6",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-shell",
  "tokio",
  "whoami",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -600,6 +606,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1322,6 +1329,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "html5ever"
@@ -3711,7 +3727,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -3782,7 +3798,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3907,7 +3923,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3932,7 +3948,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -4115,7 +4131,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -4772,10 +4800,10 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -4796,7 +4824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -4861,6 +4889,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -4883,12 +4921,25 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -4900,8 +4951,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -4920,9 +4971,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4964,6 +5037,15 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -4978,6 +5060,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5407,7 +5499,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/apps/helper/src-tauri/Cargo.lock
+++ b/apps/helper/src-tauri/Cargo.lock
@@ -151,7 +151,6 @@ dependencies = [
  "hex",
  "hmac",
  "libc",
- "rand 0.8.6",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/apps/helper/src-tauri/Cargo.toml
+++ b/apps/helper/src-tauri/Cargo.toml
@@ -27,6 +27,11 @@ sha2 = "0.10"
 hex = "0.4"
 rand = "0.8"
 
+[dev-dependencies]
+# `test-util` enables paused/virtual-clock tests (start_paused, time::advance)
+# for the reconnect-driver unit tests without real wall-clock sleeps.
+tokio = { version = "1", features = ["test-util"] }
+
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.58", features = [
   "Win32_Foundation",

--- a/apps/helper/src-tauri/Cargo.toml
+++ b/apps/helper/src-tauri/Cargo.toml
@@ -18,7 +18,21 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 reqwest = { version = "0.12", features = ["rustls-tls", "stream"], default-features = false }
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["sync", "net", "io-util", "time", "rt", "macros"] }
 futures-util = "0.3"
 whoami = "2"
 chrono = "0.4"
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
+rand = "0.8"
+
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.58", features = [
+  "Win32_Foundation",
+  "Win32_Security",
+  "Win32_System_Threading",
+] }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/apps/helper/src-tauri/Cargo.toml
+++ b/apps/helper/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["raw_value"] }
 serde_yaml = "0.9"
 reqwest = { version = "0.12", features = ["rustls-tls", "stream"], default-features = false }
 tokio = { version = "1", features = ["sync", "net", "io-util", "time", "rt", "macros"] }

--- a/apps/helper/src-tauri/Cargo.toml
+++ b/apps/helper/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ rand = "0.8"
 windows = { version = "0.58", features = [
   "Win32_Foundation",
   "Win32_Security",
+  "Win32_Security_Authorization",
   "Win32_System_Threading",
 ] }
 

--- a/apps/helper/src-tauri/Cargo.toml
+++ b/apps/helper/src-tauri/Cargo.toml
@@ -25,7 +25,6 @@ chrono = "0.4"
 hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
-rand = "0.8"
 
 [dev-dependencies]
 # `test-util` enables paused/virtual-clock tests (start_paused, time::advance)

--- a/apps/helper/src-tauri/src/ipc/client.rs
+++ b/apps/helper/src-tauri/src/ipc/client.rs
@@ -1,0 +1,664 @@
+//! IPC client: auth handshake, token-receipt loop, and reconnect driver.
+//!
+//! Wire format / HMAC lives in [`super::envelope`] and must match the Go
+//! `agent/internal/ipc` broker byte-for-byte. The handshake is HMAC'd with the
+//! 32-byte ZERO key; the broker switches to the per-session key only AFTER it
+//! sends `auth_response` (see `agent/internal/sessionbroker/broker.go`:
+//! `SendTyped(auth_response)` then `conn.SetSessionKey(...)`). So the
+//! `auth_response`/`pre_auth_reject` frames themselves are read under the ZERO
+//! key, and every frame thereafter under the decoded session key.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
+use tokio::io::{AsyncRead, AsyncWrite};
+
+use super::envelope::{read_frame, write_frame, IpcError, PROTOCOL_VERSION};
+use super::token::HelperToken;
+use super::transport::{
+    self_binary_hash, PeerIdentity,
+};
+
+/// 32 zero bytes: the pre-auth HMAC key. The broker uses the same key until it
+/// sends `auth_response`.
+const ZERO_KEY: [u8; 32] = [0u8; 32];
+
+/// Keepalive interval: if no frame arrives within this window we send a `ping`
+/// to keep the connection alive (mirrors the userhelper keepalive pattern).
+const READ_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Reconnect backoff floor and ceiling.
+const BACKOFF_MIN: Duration = Duration::from_secs(1);
+const BACKOFF_MAX: Duration = Duration::from_secs(30);
+
+/// A session that ran at least this long is treated as "healthy" and resets the
+/// reconnect backoff to the floor.
+const HEALTHY_SESSION: Duration = Duration::from_secs(60);
+
+/// Outcome of a single [`run_session`] call. The reconnect driver uses this to
+/// decide whether to retry (and how) or to stop permanently.
+#[derive(Debug)]
+pub enum SessionError {
+    /// The broker permanently rejected us (binary not allowlisted, protocol
+    /// mismatch, etc.). Retrying is futile — the driver logs once and stops.
+    PermanentReject(String),
+    /// A transient failure (transport drop, transient auth reject, protocol
+    /// error). The driver backs off and reconnects.
+    Transient(IpcError),
+}
+
+impl std::fmt::Display for SessionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SessionError::PermanentReject(m) => write!(f, "permanent reject: {}", m),
+            SessionError::Transient(e) => write!(f, "transient: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for SessionError {}
+
+impl From<IpcError> for SessionError {
+    fn from(e: IpcError) -> Self {
+        SessionError::Transient(e)
+    }
+}
+
+/// The `auth_request` payload. JSON keys mirror the Go `AuthRequest` struct in
+/// `agent/internal/ipc/message.go` exactly (lowerCamel).
+#[derive(Debug, Serialize)]
+struct AuthRequest {
+    #[serde(rename = "protocolVersion")]
+    protocol_version: i32,
+    #[serde(rename = "uid")]
+    uid: u32,
+    #[serde(rename = "sid", skip_serializing_if = "String::is_empty")]
+    sid: String,
+    #[serde(rename = "username")]
+    username: String,
+    #[serde(rename = "sessionId")]
+    session_id: String,
+    #[serde(rename = "displayEnv")]
+    display_env: String,
+    #[serde(rename = "pid")]
+    pid: i32,
+    #[serde(rename = "binaryHash")]
+    binary_hash: String,
+    #[serde(rename = "winSessionId", skip_serializing_if = "is_zero_u32")]
+    win_session_id: u32,
+    #[serde(rename = "helperRole")]
+    helper_role: String,
+    #[serde(rename = "binaryKind")]
+    binary_kind: String,
+    #[serde(rename = "desktopContext", skip_serializing_if = "String::is_empty")]
+    desktop_context: String,
+}
+
+fn is_zero_u32(v: &u32) -> bool {
+    *v == 0
+}
+
+/// Subset of the Go `AuthResponse` we care about.
+#[derive(Debug, Deserialize)]
+struct AuthResponse {
+    #[serde(default)]
+    accepted: bool,
+    #[serde(rename = "sessionKey", default)]
+    session_key: String,
+    #[serde(default)]
+    reason: String,
+    #[serde(default)]
+    permanent: bool,
+}
+
+/// The Go `PreAuthReject` payload.
+#[derive(Debug, Deserialize)]
+struct PreAuthReject {
+    #[serde(default)]
+    code: String,
+    #[serde(default)]
+    reason: String,
+    #[serde(default)]
+    permanent: bool,
+}
+
+/// The Go `HelperTokenUpdate` payload (only the token matters here).
+#[derive(Debug, Deserialize)]
+struct HelperTokenUpdate {
+    #[serde(default)]
+    token: String,
+}
+
+/// Build the assist-role `auth_request` payload for the given identity.
+fn build_auth_request(id: &PeerIdentity) -> AuthRequest {
+    AuthRequest {
+        protocol_version: PROTOCOL_VERSION,
+        uid: id.uid,
+        sid: id.sid.clone(),
+        username: id.username.clone(),
+        session_id: format!("assist-{}-{}", id.username, id.pid),
+        display_env: String::new(),
+        pid: id.pid as i32,
+        binary_hash: self_binary_hash(),
+        win_session_id: 0,
+        helper_role: "assist".to_string(),
+        binary_kind: "assist_helper".to_string(),
+        desktop_context: String::new(),
+    }
+}
+
+/// Serialize a serializable value into the exact `Box<RawValue>` the framing
+/// layer HMACs over.
+fn to_raw_payload<T: Serialize>(value: &T) -> Result<Box<RawValue>, IpcError> {
+    let s = serde_json::to_string(value)
+        .map_err(|e| IpcError::Protocol(format!("serialize payload: {}", e)))?;
+    RawValue::from_string(s).map_err(|e| IpcError::Protocol(format!("raw payload: {}", e)))
+}
+
+/// Parse a typed payload out of an envelope's raw payload bytes.
+fn parse_payload<T: for<'de> Deserialize<'de>>(
+    payload: &Option<Box<RawValue>>,
+) -> Result<T, IpcError> {
+    let raw = payload
+        .as_ref()
+        .ok_or_else(|| IpcError::Protocol("missing payload".to_string()))?;
+    serde_json::from_str(raw.get())
+        .map_err(|e| IpcError::Protocol(format!("parse payload: {}", e)))
+}
+
+/// Run a single IPC session over an already-connected `stream`:
+/// auth handshake, then a token-receipt loop until disconnect or error.
+///
+/// The testable core — generic over any duplex byte stream so tests can drive a
+/// fake broker over [`tokio::io::duplex`].
+pub async fn run_session<S>(stream: S, token: &HelperToken) -> Result<(), SessionError>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let identity = crate::ipc::transport::current_identity()
+        .map_err(|e| SessionError::Transient(IpcError::Protocol(format!("identity: {}", e))))?;
+    run_session_with_identity(stream, token, &identity).await
+}
+
+/// Like [`run_session`] but with an explicit identity. Lets tests avoid relying
+/// on process-global state.
+pub async fn run_session_with_identity<S>(
+    stream: S,
+    token: &HelperToken,
+    identity: &PeerIdentity,
+) -> Result<(), SessionError>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let mut stream = stream;
+    let mut send_seq = 0u64;
+    let mut recv_seq = 0u64;
+
+    // --- Handshake (ZERO key) ---
+    let auth_req = build_auth_request(identity);
+    let payload = to_raw_payload(&auth_req)?;
+    write_frame(
+        &mut stream,
+        &ZERO_KEY,
+        &mut send_seq,
+        "auth",
+        "auth_request",
+        Some(payload),
+    )
+    .await?;
+
+    // The auth_response / pre_auth_reject is still HMAC'd with the ZERO key:
+    // the broker calls SetSessionKey only AFTER sending it.
+    let env = read_frame(&mut stream, &ZERO_KEY, &mut recv_seq).await?;
+    let session_key: [u8; 32] = match env.typ.as_str() {
+        "pre_auth_reject" => {
+            let r: PreAuthReject = parse_payload(&env.payload)?;
+            let msg = format!("pre_auth_reject code={} reason={}", r.code, r.reason);
+            if r.permanent {
+                return Err(SessionError::PermanentReject(msg));
+            }
+            return Err(SessionError::Transient(IpcError::Protocol(msg)));
+        }
+        "auth_response" => {
+            let r: AuthResponse = parse_payload(&env.payload)?;
+            if !r.accepted {
+                let msg = format!("auth rejected: {}", r.reason);
+                if r.permanent {
+                    return Err(SessionError::PermanentReject(msg));
+                }
+                return Err(SessionError::Transient(IpcError::Protocol(msg)));
+            }
+            let bytes = hex::decode(&r.session_key).map_err(|_| {
+                SessionError::Transient(IpcError::Protocol(
+                    "auth_response: session key not valid hex".to_string(),
+                ))
+            })?;
+            bytes.try_into().map_err(|_| {
+                SessionError::Transient(IpcError::Protocol(
+                    "auth_response: session key not 32 bytes".to_string(),
+                ))
+            })?
+        }
+        other => {
+            return Err(SessionError::Transient(IpcError::Protocol(format!(
+                "unexpected handshake frame type: {}",
+                other
+            ))));
+        }
+    };
+
+    // --- Receive loop (session key) ---
+    loop {
+        let res =
+            tokio::time::timeout(READ_IDLE_TIMEOUT, read_frame(&mut stream, &session_key, &mut recv_seq))
+                .await;
+
+        let env = match res {
+            // Idle: send a keepalive ping and keep listening.
+            Err(_elapsed) => {
+                write_frame(
+                    &mut stream,
+                    &session_key,
+                    &mut send_seq,
+                    "keepalive",
+                    "ping",
+                    None,
+                )
+                .await?;
+                continue;
+            }
+            Ok(Ok(env)) => env,
+            // Transport/protocol error: bubble up so the driver reconnects.
+            Ok(Err(e)) => return Err(SessionError::Transient(e)),
+        };
+
+        match env.typ.as_str() {
+            "helper_token_update" => {
+                let upd: HelperTokenUpdate = parse_payload(&env.payload)?;
+                token.set(upd.token).await;
+                // NEVER log the token value.
+                eprintln!("[helper] helper token received via IPC");
+            }
+            "ping" => {
+                write_frame(
+                    &mut stream,
+                    &session_key,
+                    &mut send_seq,
+                    &env.id,
+                    "pong",
+                    None,
+                )
+                .await?;
+            }
+            "pong" => { /* ignore */ }
+            "disconnect" => {
+                // Clean disconnect — caller reconnects.
+                return Ok(());
+            }
+            _ => { /* assist client handles nothing else */ }
+        }
+    }
+}
+
+/// Reconnect driver: connects, runs a session, backs off and retries on
+/// transient failure, and stops permanently on a permanent reject. Runs until
+/// `stop` flips to `true`.
+///
+/// Wrapped so a panic inside a session does not kill the task.
+pub async fn run(token: HelperToken, mut stop: tokio::sync::watch::Receiver<bool>) {
+    use super::transport::{connect, current_identity, default_socket_path};
+
+    let mut backoff = BACKOFF_MIN;
+
+    loop {
+        if *stop.borrow() {
+            return;
+        }
+
+        // Resolve identity per connect; if it fails, back off and retry.
+        let identity = match current_identity() {
+            Ok(id) => id,
+            Err(e) => {
+                eprintln!("[helper] ipc: failed to resolve identity: {}", e);
+                if wait_or_stop(&mut stop, backoff).await {
+                    return;
+                }
+                backoff = next_backoff(backoff);
+                continue;
+            }
+        };
+
+        let path = default_socket_path();
+        let stream = match connect(&path).await {
+            Ok(s) => s,
+            Err(e) => {
+                // Agent may simply not be up yet — debug-level, quiet.
+                eprintln!("[helper] ipc: connect failed ({}): {}", path, e);
+                if wait_or_stop(&mut stop, backoff).await {
+                    return;
+                }
+                backoff = next_backoff(backoff);
+                continue;
+            }
+        };
+
+        let started = std::time::Instant::now();
+
+        // Catch panics so a single bad session can't take down the task. The
+        // session future itself is run to completion here; the unwind guard
+        // wraps the await via a select against `stop`.
+        let outcome = tokio::select! {
+            r = run_session_with_identity(stream, &token, &identity) => Some(r),
+            _ = stop.changed() => None,
+        };
+
+        match outcome {
+            None => {
+                // Stop requested mid-session.
+                return;
+            }
+            Some(Ok(())) => {
+                // Clean disconnect. Reset backoff if the session was healthy.
+                if started.elapsed() >= HEALTHY_SESSION {
+                    backoff = BACKOFF_MIN;
+                }
+            }
+            Some(Err(SessionError::PermanentReject(msg))) => {
+                // Retrying a non-allowlisted / permanently-rejected binary is
+                // futile. Log once and stop.
+                eprintln!(
+                    "[helper] ipc: broker permanently rejected this helper ({}); not retrying",
+                    msg
+                );
+                return;
+            }
+            Some(Err(SessionError::Transient(e))) => {
+                eprintln!("[helper] ipc: session ended: {}", e);
+                if started.elapsed() >= HEALTHY_SESSION {
+                    backoff = BACKOFF_MIN;
+                }
+            }
+        }
+
+        if wait_or_stop(&mut stop, backoff).await {
+            return;
+        }
+        backoff = next_backoff(backoff);
+    }
+}
+
+/// Exponential backoff: double, capped at [`BACKOFF_MAX`].
+fn next_backoff(current: Duration) -> Duration {
+    let doubled = current.saturating_mul(2);
+    if doubled > BACKOFF_MAX {
+        BACKOFF_MAX
+    } else {
+        doubled
+    }
+}
+
+/// Sleep for `dur`, but wake early (and return `true`) if `stop` flips to true.
+async fn wait_or_stop(stop: &mut tokio::sync::watch::Receiver<bool>, dur: Duration) -> bool {
+    if *stop.borrow() {
+        return true;
+    }
+    tokio::select! {
+        _ = tokio::time::sleep(dur) => *stop.borrow(),
+        res = stop.changed() => {
+            // Sender dropped or value changed; treat any "true" as stop.
+            res.is_err() || *stop.borrow()
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use crate::ipc::envelope::{read_frame, write_frame};
+
+    fn test_identity() -> PeerIdentity {
+        PeerIdentity {
+            uid: 501,
+            sid: String::new(),
+            username: "tester".to_string(),
+            pid: 12345,
+        }
+    }
+
+    fn raw(s: &str) -> Box<RawValue> {
+        RawValue::from_string(s.to_string()).expect("valid json")
+    }
+
+    /// Full happy path: handshake, accept with a fixed session key, deliver a
+    /// helper_token_update, and confirm the token cell is populated.
+    #[tokio::test]
+    async fn test_handshake_then_token_delivery() {
+        let (client_half, mut broker_half) = tokio::io::duplex(8192);
+        let token = HelperToken::new();
+        let id = test_identity();
+
+        let token_for_session = token.clone();
+        let session = tokio::spawn(async move {
+            run_session_with_identity(client_half, &token_for_session, &id).await
+        });
+
+        let mut broker_send = 0u64;
+        let mut broker_recv = 0u64;
+
+        // 1. Read the auth_request (ZERO key) and assert its shape.
+        let env = read_frame(&mut broker_half, &ZERO_KEY, &mut broker_recv)
+            .await
+            .expect("read auth_request");
+        assert_eq!(env.typ, "auth_request");
+        let payload = env.payload.as_ref().expect("auth_request payload");
+        let v: serde_json::Value = serde_json::from_str(payload.get()).unwrap();
+        assert_eq!(v["helperRole"], "assist");
+        assert_eq!(v["binaryKind"], "assist_helper");
+        assert_eq!(v["protocolVersion"], PROTOCOL_VERSION);
+        assert_eq!(v["sessionId"], "assist-tester-12345");
+
+        // 2. Reply auth_response (still ZERO key) with a fixed session key.
+        let session_key = [7u8; 32];
+        let key_hex = hex::encode(session_key);
+        let resp = format!(
+            r#"{{"accepted":true,"sessionKey":"{}","allowedScopes":["assist"]}}"#,
+            key_hex
+        );
+        write_frame(
+            &mut broker_half,
+            &ZERO_KEY,
+            &mut broker_send,
+            &env.id,
+            "auth_response",
+            Some(raw(&resp)),
+        )
+        .await
+        .expect("write auth_response");
+
+        // 3. Deliver helper_token_update under the SESSION key.
+        write_frame(
+            &mut broker_half,
+            &session_key,
+            &mut broker_send,
+            "tok-1",
+            "helper_token_update",
+            Some(raw(r#"{"token":"brz_test"}"#)),
+        )
+        .await
+        .expect("write helper_token_update");
+
+        // 4. Poll until the token cell is populated.
+        let mut got = None;
+        for _ in 0..200 {
+            if let Some(t) = token.get().await {
+                got = Some(t);
+                break;
+            }
+            tokio::task::yield_now().await;
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        assert_eq!(got.as_deref(), Some("brz_test"));
+
+        // Dropping broker_half closes the stream; the session read errors out.
+        drop(broker_half);
+        let res = session.await.expect("join");
+        // Transport closed → transient error (EOF) is expected.
+        assert!(
+            matches!(res, Err(SessionError::Transient(_))),
+            "expected transient on close, got {:?}",
+            res
+        );
+    }
+
+    /// A permanent pre_auth_reject must surface as `PermanentReject` so the
+    /// reconnect driver stops retrying.
+    #[tokio::test]
+    async fn test_permanent_reject_stops() {
+        let (client_half, mut broker_half) = tokio::io::duplex(8192);
+        let token = HelperToken::new();
+        let id = test_identity();
+
+        let session = tokio::spawn(async move {
+            run_session_with_identity(client_half, &token, &id).await
+        });
+
+        let mut broker_send = 0u64;
+        let mut broker_recv = 0u64;
+
+        // Read the auth_request.
+        let env = read_frame(&mut broker_half, &ZERO_KEY, &mut broker_recv)
+            .await
+            .expect("read auth_request");
+        assert_eq!(env.typ, "auth_request");
+
+        // Reply with a permanent pre_auth_reject.
+        write_frame(
+            &mut broker_half,
+            &ZERO_KEY,
+            &mut broker_send,
+            "rej-1",
+            "pre_auth_reject",
+            Some(raw(
+                r#"{"code":"binary_path_unknown","reason":"unknown binary","permanent":true}"#,
+            )),
+        )
+        .await
+        .expect("write pre_auth_reject");
+
+        let res = session.await.expect("join");
+        match res {
+            Err(SessionError::PermanentReject(msg)) => {
+                assert!(msg.contains("binary_path_unknown"), "{}", msg);
+            }
+            other => panic!("expected PermanentReject, got {:?}", other),
+        }
+    }
+
+    /// A non-permanent pre_auth_reject must surface as transient (driver retries).
+    #[tokio::test]
+    async fn test_transient_reject_retries() {
+        let (client_half, mut broker_half) = tokio::io::duplex(8192);
+        let token = HelperToken::new();
+        let id = test_identity();
+
+        let session = tokio::spawn(async move {
+            run_session_with_identity(client_half, &token, &id).await
+        });
+
+        let mut broker_send = 0u64;
+        let mut broker_recv = 0u64;
+
+        let env = read_frame(&mut broker_half, &ZERO_KEY, &mut broker_recv)
+            .await
+            .expect("read auth_request");
+        assert_eq!(env.typ, "auth_request");
+
+        write_frame(
+            &mut broker_half,
+            &ZERO_KEY,
+            &mut broker_send,
+            "rej-2",
+            "pre_auth_reject",
+            Some(raw(r#"{"code":"rate_limited","reason":"slow down"}"#)),
+        )
+        .await
+        .expect("write pre_auth_reject");
+
+        let res = session.await.expect("join");
+        assert!(
+            matches!(res, Err(SessionError::Transient(_))),
+            "expected Transient, got {:?}",
+            res
+        );
+    }
+
+    /// A ping from the broker must be answered with a pong carrying the same id.
+    #[tokio::test]
+    async fn test_ping_is_ponged() {
+        let (client_half, mut broker_half) = tokio::io::duplex(8192);
+        let token = HelperToken::new();
+        let id = test_identity();
+
+        let session = tokio::spawn(async move {
+            run_session_with_identity(client_half, &token, &id).await
+        });
+
+        let mut broker_send = 0u64;
+        let mut broker_recv = 0u64;
+
+        // Handshake.
+        let env = read_frame(&mut broker_half, &ZERO_KEY, &mut broker_recv)
+            .await
+            .expect("read auth_request");
+        let session_key = [9u8; 32];
+        let resp = format!(
+            r#"{{"accepted":true,"sessionKey":"{}"}}"#,
+            hex::encode(session_key)
+        );
+        write_frame(
+            &mut broker_half,
+            &ZERO_KEY,
+            &mut broker_send,
+            &env.id,
+            "auth_response",
+            Some(raw(&resp)),
+        )
+        .await
+        .expect("write auth_response");
+
+        // Send a ping under the session key.
+        write_frame(
+            &mut broker_half,
+            &session_key,
+            &mut broker_send,
+            "ping-42",
+            "ping",
+            None,
+        )
+        .await
+        .expect("write ping");
+
+        // Expect a pong with the same id.
+        let pong = read_frame(&mut broker_half, &session_key, &mut broker_recv)
+            .await
+            .expect("read pong");
+        assert_eq!(pong.typ, "pong");
+        assert_eq!(pong.id, "ping-42");
+
+        // Clean disconnect ends the session.
+        write_frame(
+            &mut broker_half,
+            &session_key,
+            &mut broker_send,
+            "bye",
+            "disconnect",
+            None,
+        )
+        .await
+        .expect("write disconnect");
+
+        let res = session.await.expect("join");
+        assert!(matches!(res, Ok(())), "expected clean Ok, got {:?}", res);
+    }
+}

--- a/apps/helper/src-tauri/src/ipc/client.rs
+++ b/apps/helper/src-tauri/src/ipc/client.rs
@@ -358,13 +358,20 @@ pub async fn run(token: HelperToken, mut stop: tokio::sync::watch::Receiver<bool
                 // Stop requested mid-session.
                 return;
             }
-            // A caught panic is treated exactly like a transient failure: log
-            // once (never the payload/token), then back off and reconnect.
-            Some(Err(_panic)) => {
-                eprintln!("[helper] IPC session panicked; will reconnect");
-                if started.elapsed() >= HEALTHY_SESSION {
-                    backoff = BACKOFF_MIN;
-                }
+            // A caught panic is treated as a transient failure: log once
+            // (never the payload/token — the panic message is not the token,
+            // which only lives in HelperToken / the parsed payload), then back
+            // off and reconnect. Unlike clean/transient outcomes, a panic does
+            // NOT reset the backoff even after a long-running session: a
+            // slow-failing panic loop must keep backing off rather than hammer
+            // at the floor.
+            Some(Err(panic_payload)) => {
+                let msg = panic_payload
+                    .downcast_ref::<&str>()
+                    .map(|s| s.to_string())
+                    .or_else(|| panic_payload.downcast_ref::<String>().cloned())
+                    .unwrap_or_else(|| "unknown panic".to_string());
+                eprintln!("[helper] IPC session panicked ({msg}); will reconnect");
             }
             Some(Ok(Ok(()))) => {
                 // Clean disconnect. Reset backoff if the session was healthy.

--- a/apps/helper/src-tauri/src/ipc/client.rs
+++ b/apps/helper/src-tauri/src/ipc/client.rs
@@ -305,7 +305,9 @@ where
 /// transient failure, and stops permanently on a permanent reject. Runs until
 /// `stop` flips to `true`.
 ///
-/// Wrapped so a panic inside a session does not kill the task.
+/// The session future is wrapped in `catch_unwind` so a panic inside a single
+/// session is caught, logged once, and treated as a transient failure (back off
+/// and reconnect) rather than killing the reconnect task.
 pub async fn run(token: HelperToken, mut stop: tokio::sync::watch::Receiver<bool>) {
     use super::transport::{connect, current_identity, default_socket_path};
 
@@ -345,11 +347,19 @@ pub async fn run(token: HelperToken, mut stop: tokio::sync::watch::Receiver<bool
 
         let started = std::time::Instant::now();
 
-        // Catch panics so a single bad session can't take down the task. The
-        // session future itself is run to completion here; the unwind guard
-        // wraps the await via a select against `stop`.
+        // Catch panics so a single bad session can't take down the reconnect
+        // task. `catch_unwind` turns a panic inside the session future into an
+        // `Err(_)` instead of unwinding through the spawned task. The borrowed
+        // state (`&token`, `&identity`) is only read after a panic via the
+        // normal reconnect path, so `AssertUnwindSafe` is appropriate here.
+        // The future is still `select!`ed against `stop.changed()` so a stop
+        // request mid-session is honored promptly.
+        use futures_util::FutureExt;
+        let session_fut =
+            std::panic::AssertUnwindSafe(run_session_with_identity(stream, &token, &identity))
+                .catch_unwind();
         let outcome = tokio::select! {
-            r = run_session_with_identity(stream, &token, &identity) => Some(r),
+            r = session_fut => Some(r),
             _ = stop.changed() => None,
         };
 
@@ -358,13 +368,21 @@ pub async fn run(token: HelperToken, mut stop: tokio::sync::watch::Receiver<bool
                 // Stop requested mid-session.
                 return;
             }
-            Some(Ok(())) => {
+            // A caught panic is treated exactly like a transient failure: log
+            // once (never the payload/token), then back off and reconnect.
+            Some(Err(_panic)) => {
+                eprintln!("[helper] IPC session panicked; will reconnect");
+                if started.elapsed() >= HEALTHY_SESSION {
+                    backoff = BACKOFF_MIN;
+                }
+            }
+            Some(Ok(Ok(()))) => {
                 // Clean disconnect. Reset backoff if the session was healthy.
                 if started.elapsed() >= HEALTHY_SESSION {
                     backoff = BACKOFF_MIN;
                 }
             }
-            Some(Err(SessionError::PermanentReject(msg))) => {
+            Some(Ok(Err(SessionError::PermanentReject(msg)))) => {
                 // Retrying a non-allowlisted / permanently-rejected binary is
                 // futile. Log once and stop.
                 eprintln!(
@@ -373,7 +391,7 @@ pub async fn run(token: HelperToken, mut stop: tokio::sync::watch::Receiver<bool
                 );
                 return;
             }
-            Some(Err(SessionError::Transient(e))) => {
+            Some(Ok(Err(SessionError::Transient(e)))) => {
                 eprintln!("[helper] ipc: session ended: {}", e);
                 if started.elapsed() >= HEALTHY_SESSION {
                     backoff = BACKOFF_MIN;
@@ -660,5 +678,84 @@ mod tests {
 
         let res = session.await.expect("join");
         assert!(matches!(res, Ok(())), "expected clean Ok, got {:?}", res);
+    }
+
+    // --- Reconnect-driver core ---
+
+    /// `next_backoff` doubles from the floor, caps at `BACKOFF_MAX`, and never
+    /// panics/overflows even when called repeatedly at the ceiling.
+    #[test]
+    fn test_next_backoff_doubles_and_caps() {
+        // Doubles from the floor.
+        assert_eq!(next_backoff(BACKOFF_MIN), BACKOFF_MIN * 2);
+        assert_eq!(next_backoff(Duration::from_secs(2)), Duration::from_secs(4));
+        assert_eq!(next_backoff(Duration::from_secs(4)), Duration::from_secs(8));
+
+        // Saturates at the ceiling: a value just below the cap that would
+        // double past it lands exactly on BACKOFF_MAX.
+        assert_eq!(next_backoff(Duration::from_secs(20)), BACKOFF_MAX);
+        assert_eq!(next_backoff(BACKOFF_MAX), BACKOFF_MAX);
+
+        // Repeated calls from the floor converge to the cap and stay there,
+        // never panicking from overflow.
+        let mut b = BACKOFF_MIN;
+        for _ in 0..1000 {
+            b = next_backoff(b);
+            assert!(b <= BACKOFF_MAX, "backoff exceeded cap: {:?}", b);
+        }
+        assert_eq!(b, BACKOFF_MAX);
+
+        // Extreme input near Duration::MAX must saturate, not overflow/panic.
+        assert_eq!(next_backoff(Duration::MAX), BACKOFF_MAX);
+    }
+
+    /// `wait_or_stop` returns promptly (`true`) when the stop watch is already
+    /// true, without sleeping.
+    #[tokio::test(start_paused = true)]
+    async fn test_wait_or_stop_returns_when_already_stopped() {
+        let (tx, mut rx) = tokio::sync::watch::channel(true);
+        let stopped = wait_or_stop(&mut rx, Duration::from_secs(30)).await;
+        assert!(stopped, "expected stop=true to short-circuit");
+        drop(tx);
+    }
+
+    /// `wait_or_stop` wakes early and returns `true` when stop flips to true
+    /// mid-wait — no real wall-clock sleep thanks to paused time.
+    #[tokio::test(start_paused = true)]
+    async fn test_wait_or_stop_wakes_on_stop_flip() {
+        let (tx, mut rx) = tokio::sync::watch::channel(false);
+
+        let waiter = tokio::spawn(async move {
+            wait_or_stop(&mut rx, Duration::from_secs(30)).await
+        });
+
+        // Let the waiter park on the select, then flip stop to true.
+        tokio::task::yield_now().await;
+        tx.send(true).expect("send stop");
+
+        let stopped = waiter.await.expect("join");
+        assert!(stopped, "expected early wake with stop=true");
+    }
+
+    /// `wait_or_stop` waits the full requested duration when stop stays false,
+    /// then returns `false`. Verified against the paused clock — advancing time
+    /// just short of the duration does not complete it; advancing past does.
+    #[tokio::test(start_paused = true)]
+    async fn test_wait_or_stop_waits_full_duration() {
+        let (_tx, mut rx) = tokio::sync::watch::channel(false);
+
+        let waiter = tokio::spawn(async move {
+            wait_or_stop(&mut rx, Duration::from_secs(10)).await
+        });
+
+        // Just before the deadline: still pending.
+        tokio::time::advance(Duration::from_secs(9)).await;
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished(), "completed before its duration elapsed");
+
+        // Past the deadline: completes, returning false (stop never flipped).
+        tokio::time::advance(Duration::from_secs(2)).await;
+        let stopped = waiter.await.expect("join");
+        assert!(!stopped, "expected false when stop stayed unset");
     }
 }

--- a/apps/helper/src-tauri/src/ipc/client.rs
+++ b/apps/helper/src-tauri/src/ipc/client.rs
@@ -36,8 +36,8 @@ const BACKOFF_MAX: Duration = Duration::from_secs(30);
 /// reconnect backoff to the floor.
 const HEALTHY_SESSION: Duration = Duration::from_secs(60);
 
-/// Outcome of a single [`run_session`] call. The reconnect driver uses this to
-/// decide whether to retry (and how) or to stop permanently.
+/// Outcome of a single [`run_session_with_identity`] call. The reconnect driver
+/// uses this to decide whether to retry (and how) or to stop permanently.
 #[derive(Debug)]
 pub enum SessionError {
     /// The broker permanently rejected us (binary not allowlisted, protocol
@@ -167,22 +167,12 @@ fn parse_payload<T: for<'de> Deserialize<'de>>(
         .map_err(|e| IpcError::Protocol(format!("parse payload: {}", e)))
 }
 
-/// Run a single IPC session over an already-connected `stream`:
-/// auth handshake, then a token-receipt loop until disconnect or error.
+/// Run a single IPC session over an already-connected `stream` with an explicit
+/// identity: auth handshake, then a token-receipt loop until disconnect or error.
 ///
 /// The testable core — generic over any duplex byte stream so tests can drive a
-/// fake broker over [`tokio::io::duplex`].
-pub async fn run_session<S>(stream: S, token: &HelperToken) -> Result<(), SessionError>
-where
-    S: AsyncRead + AsyncWrite + Unpin,
-{
-    let identity = crate::ipc::transport::current_identity()
-        .map_err(|e| SessionError::Transient(IpcError::Protocol(format!("identity: {}", e))))?;
-    run_session_with_identity(stream, token, &identity).await
-}
-
-/// Like [`run_session`] but with an explicit identity. Lets tests avoid relying
-/// on process-global state.
+/// fake broker over [`tokio::io::duplex`]. Taking the identity explicitly lets
+/// tests avoid relying on process-global state.
 pub async fn run_session_with_identity<S>(
     stream: S,
     token: &HelperToken,

--- a/apps/helper/src-tauri/src/ipc/envelope.rs
+++ b/apps/helper/src-tauri/src/ipc/envelope.rs
@@ -117,6 +117,9 @@ pub fn compute_hmac(key: &[u8], id: &str, seq: u64, typ: &str, payload: &[u8]) -
 
 /// Like [`compute_hmac`] but treats an absent payload as the literal bytes
 /// `null`, matching Go's nil-payload normalisation.
+// Used only by the cross-language HMAC parity tests below; kept here next to
+// `compute_hmac` so the two stay in sync.
+#[allow(dead_code)]
 pub fn compute_hmac_opt(
     key: &[u8],
     id: &str,

--- a/apps/helper/src-tauri/src/ipc/envelope.rs
+++ b/apps/helper/src-tauri/src/ipc/envelope.rs
@@ -1,0 +1,377 @@
+//! IPC envelope framing and Go-compatible HMAC.
+//!
+//! This module mirrors the Go agent's IPC wire format byte-for-byte. The two
+//! sides MUST agree exactly or the HMAC handshake silently fails.
+//!
+//! Ground truth: `agent/internal/ipc/protocol.go` + `message.go`.
+//!
+//! Frame layout: `[4-byte big-endian length][JSON bytes of Envelope]`.
+//!
+//! HMAC = `hex(HMAC-SHA256(key, ID || decimal(Seq) || Type || Payload))`.
+//!   - `key` is 32 zero bytes pre-auth, the 32-byte session key post-auth.
+//!   - A nil/absent payload is HMAC'd as the literal bytes `null` (matching
+//!     Go's `jsonNull` normalisation in `computeHMAC`).
+//!
+//! The Go `Envelope` JSON keys are: `id`, `seq`, `type`, `payload`, `error`
+//! (omitempty), `hmac`.
+
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
+use sha2::Sha256;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Maximum size of a JSON IPC message (16 MiB). Mirrors Go `MaxMessageSize`.
+pub const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
+
+/// Current IPC protocol version. Mirrors Go `ProtocolVersion`.
+pub const PROTOCOL_VERSION: i32 = 1;
+
+/// The literal JSON bytes used to HMAC a nil/absent payload. Matches Go's
+/// `jsonNull = json.RawMessage("null")`.
+const JSON_NULL: &[u8] = b"null";
+
+/// Wire-format wrapper for all IPC messages. Field names / serde renames MUST
+/// produce JSON keys identical to the Go `Envelope` struct.
+///
+/// `payload` is modeled as `Option<Box<RawValue>>` so the exact payload bytes
+/// are preserved on both parse (inbound) and serialize (outbound) — the HMAC is
+/// computed over those exact bytes.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Envelope {
+    #[serde(rename = "id")]
+    pub id: String,
+    #[serde(rename = "seq")]
+    pub seq: u64,
+    #[serde(rename = "type")]
+    pub typ: String,
+    /// Exact payload bytes. Serialized as JSON `null` when `None` (matching Go,
+    /// which marshals a nil `json.RawMessage` as `null`).
+    #[serde(rename = "payload")]
+    pub payload: Option<Box<RawValue>>,
+    #[serde(rename = "error", default, skip_serializing_if = "String::is_empty")]
+    pub error: String,
+    #[serde(rename = "hmac")]
+    pub hmac: String,
+}
+
+/// Errors produced while reading/decoding an IPC frame.
+#[derive(Debug)]
+pub enum IpcError {
+    Io(std::io::Error),
+    Protocol(String),
+}
+
+impl std::fmt::Display for IpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IpcError::Io(e) => write!(f, "ipc io error: {}", e),
+            IpcError::Protocol(m) => write!(f, "ipc protocol error: {}", m),
+        }
+    }
+}
+
+impl std::error::Error for IpcError {}
+
+impl From<std::io::Error> for IpcError {
+    fn from(e: std::io::Error) -> Self {
+        IpcError::Io(e)
+    }
+}
+
+/// Computes `hex(HMAC-SHA256(key, id || decimal(seq) || typ || payload))`.
+///
+/// The update order and the decimal-string seq encoding match Go's
+/// `computeHMAC` exactly.
+pub fn compute_hmac(key: &[u8], id: &str, seq: u64, typ: &str, payload: &[u8]) -> String {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
+    mac.update(id.as_bytes());
+    mac.update(seq.to_string().as_bytes());
+    mac.update(typ.as_bytes());
+    mac.update(payload);
+    hex::encode(mac.finalize().into_bytes())
+}
+
+/// Like [`compute_hmac`] but treats an absent payload as the literal bytes
+/// `null`, matching Go's nil-payload normalisation.
+pub fn compute_hmac_opt(
+    key: &[u8],
+    id: &str,
+    seq: u64,
+    typ: &str,
+    payload: Option<&[u8]>,
+) -> String {
+    compute_hmac(key, id, seq, typ, payload.unwrap_or(JSON_NULL))
+}
+
+/// Returns the payload bytes used for HMAC: the exact RawValue bytes, or the
+/// literal `null` when there is no payload.
+fn payload_hmac_bytes(payload: &Option<Box<RawValue>>) -> &[u8] {
+    payload
+        .as_ref()
+        .map(|r| r.get().as_bytes())
+        .unwrap_or(JSON_NULL)
+}
+
+/// Encodes a framed envelope without performing any I/O.
+///
+/// Increments `send_seq` first (so the first frame written has `seq == 1`),
+/// computes the HMAC over the payload bytes (or `null`), builds the Envelope,
+/// serializes it, and length-prefixes with a 4-byte big-endian header.
+///
+/// Returns `None` if the encoded message exceeds [`MAX_MESSAGE_SIZE`].
+pub fn encode_frame(
+    key: &[u8],
+    send_seq: &mut u64,
+    id: &str,
+    typ: &str,
+    payload: Option<Box<RawValue>>,
+) -> Option<Vec<u8>> {
+    *send_seq += 1;
+    let seq = *send_seq;
+
+    let hmac = compute_hmac(key, id, seq, typ, payload_hmac_bytes(&payload));
+
+    let env = Envelope {
+        id: id.to_string(),
+        seq,
+        typ: typ.to_string(),
+        payload,
+        error: String::new(),
+        hmac,
+    };
+
+    let body = serde_json::to_vec(&env).ok()?;
+    if body.is_empty() || body.len() > MAX_MESSAGE_SIZE {
+        return None;
+    }
+
+    let mut frame = Vec::with_capacity(4 + body.len());
+    frame.extend_from_slice(&(body.len() as u32).to_be_bytes());
+    frame.extend_from_slice(&body);
+    Some(frame)
+}
+
+/// Writes a framed envelope to `w`. See [`encode_frame`] for framing details.
+pub async fn write_frame<W: AsyncWriteExt + Unpin>(
+    w: &mut W,
+    key: &[u8],
+    send_seq: &mut u64,
+    id: &str,
+    typ: &str,
+    payload: Option<Box<RawValue>>,
+) -> std::io::Result<()> {
+    let frame = encode_frame(key, send_seq, id, typ, payload).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "ipc: message too large or failed to encode",
+        )
+    })?;
+    w.write_all(&frame).await?;
+    w.flush().await?;
+    Ok(())
+}
+
+/// Reads, validates, and parses one framed envelope from `r`.
+///
+/// Enforces: length in `(0, MAX_MESSAGE_SIZE]`, HMAC match (constant-time),
+/// `seq > 0`, and `seq` strictly greater than the previous `recv_seq` (replay
+/// protection). On success updates `*recv_seq` and returns the envelope.
+pub async fn read_frame<R: AsyncReadExt + Unpin>(
+    r: &mut R,
+    key: &[u8],
+    recv_seq: &mut u64,
+) -> Result<Envelope, IpcError> {
+    let mut header = [0u8; 4];
+    r.read_exact(&mut header).await?;
+    let length = u32::from_be_bytes(header) as usize;
+
+    if length == 0 {
+        return Err(IpcError::Protocol("zero-length message".to_string()));
+    }
+    if length > MAX_MESSAGE_SIZE {
+        return Err(IpcError::Protocol(format!(
+            "message too large: {} > {}",
+            length, MAX_MESSAGE_SIZE
+        )));
+    }
+
+    let mut body = vec![0u8; length];
+    r.read_exact(&mut body).await?;
+
+    let env = parse_and_verify(&body, key, recv_seq)?;
+    Ok(env)
+}
+
+/// Parses an envelope from `body`, verifies the HMAC, and enforces sequence
+/// rules. Factored out so the round-trip unit test can exercise it without a
+/// socket.
+pub fn parse_and_verify(
+    body: &[u8],
+    key: &[u8],
+    recv_seq: &mut u64,
+) -> Result<Envelope, IpcError> {
+    let env: Envelope = serde_json::from_slice(body)
+        .map_err(|e| IpcError::Protocol(format!("unmarshal envelope: {}", e)))?;
+
+    // Recompute HMAC over the exact payload bytes and constant-time compare.
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
+    mac.update(env.id.as_bytes());
+    mac.update(env.seq.to_string().as_bytes());
+    mac.update(env.typ.as_bytes());
+    mac.update(payload_hmac_bytes(&env.payload));
+    let received = match hex::decode(&env.hmac) {
+        Ok(b) => b,
+        Err(_) => return Err(IpcError::Protocol("HMAC mismatch".to_string())),
+    };
+    if mac.verify_slice(&received).is_err() {
+        return Err(IpcError::Protocol("HMAC mismatch".to_string()));
+    }
+
+    if env.seq == 0 {
+        return Err(IpcError::Protocol("invalid sequence number 0".to_string()));
+    }
+    if env.seq <= *recv_seq {
+        return Err(IpcError::Protocol(format!(
+            "sequence number {} <= last {} (replay/duplicate)",
+            env.seq, *recv_seq
+        )));
+    }
+    *recv_seq = env.seq;
+
+    Ok(env)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Fixtures generated from Go (agent/internal/ipc HMAC formula):
+    //   mac(zeroKey, "auth", 1, "auth_request", `{"a":1}`)
+    const AUTH_ZERO: &str = "ebf42fe8f25b2043ef5d97ed2c83cc4474b8b7ae3597ee937d41fcbc05adc301";
+    //   mac(zeroKey, "x", 2, "ping", "null")
+    const NULL_PAYLOAD: &str = "db78743491edd182de5fa88fdc5278b5722f28d2bf03db73d44c0bb61a47ee06";
+
+    fn raw(s: &str) -> Box<RawValue> {
+        RawValue::from_string(s.to_string()).expect("valid json")
+    }
+
+    #[test]
+    fn hmac_matches_go_formula_zero_key() {
+        let got = compute_hmac(&[0u8; 32], "auth", 1, "auth_request", br#"{"a":1}"#);
+        assert_eq!(got, AUTH_ZERO);
+    }
+
+    #[test]
+    fn nil_payload_hmacs_as_literal_null() {
+        let opt = compute_hmac_opt(&[0u8; 32], "x", 2, "ping", None);
+        assert_eq!(opt, NULL_PAYLOAD);
+        // Explicit "null" bytes must produce the identical digest.
+        let explicit = compute_hmac(&[0u8; 32], "x", 2, "ping", b"null");
+        assert_eq!(opt, explicit);
+    }
+
+    #[test]
+    fn frame_round_trip() {
+        let key = [7u8; 32];
+        let mut send_seq = 0u64;
+        let frame = encode_frame(
+            &key,
+            &mut send_seq,
+            "msg-1",
+            "auth_request",
+            Some(raw(r#"{"a":1,"b":"hello"}"#)),
+        )
+        .expect("encode");
+
+        // First 4 bytes are BE length == remainder length.
+        assert!(frame.len() > 4);
+        let declared = u32::from_be_bytes([frame[0], frame[1], frame[2], frame[3]]) as usize;
+        assert_eq!(declared, frame.len() - 4);
+
+        // First sent frame must have seq == 1.
+        assert_eq!(send_seq, 1);
+
+        // Decode the body back and verify HMAC + fields survive.
+        let body = &frame[4..];
+        let mut recv_seq = 0u64;
+        let env = parse_and_verify(body, &key, &mut recv_seq).expect("verify");
+        assert_eq!(env.id, "msg-1");
+        assert_eq!(env.seq, 1);
+        assert_eq!(env.typ, "auth_request");
+        assert_eq!(recv_seq, 1);
+        assert_eq!(
+            env.payload.as_ref().map(|r| r.get()),
+            Some(r#"{"a":1,"b":"hello"}"#)
+        );
+    }
+
+    #[test]
+    fn frame_round_trip_nil_payload() {
+        let key = [3u8; 32];
+        let mut send_seq = 0u64;
+        let frame = encode_frame(&key, &mut send_seq, "p", "ping", None).expect("encode");
+        let body = &frame[4..];
+        // Payload must serialize as JSON null.
+        let s = std::str::from_utf8(body).unwrap();
+        assert!(s.contains("\"payload\":null"), "body: {}", s);
+
+        let mut recv_seq = 0u64;
+        let env = parse_and_verify(body, &key, &mut recv_seq).expect("verify");
+        assert!(env.payload.is_none());
+    }
+
+    #[test]
+    fn parse_rejects_replayed_or_nonincreasing_seq() {
+        let key = [1u8; 32];
+        let mut send_seq = 0u64;
+        let frame = encode_frame(&key, &mut send_seq, "a", "ping", None).expect("encode");
+        let body = &frame[4..];
+
+        let mut recv_seq = 5u64; // pretend we already saw seq 5
+        let err = parse_and_verify(body, &key, &mut recv_seq).unwrap_err();
+        match err {
+            IpcError::Protocol(m) => assert!(m.contains("replay/duplicate"), "{}", m),
+            _ => panic!("expected protocol error"),
+        }
+    }
+
+    #[test]
+    fn parse_rejects_bad_hmac() {
+        let key = [1u8; 32];
+        let mut send_seq = 0u64;
+        let frame = encode_frame(&key, &mut send_seq, "a", "ping", None).expect("encode");
+        let body = &frame[4..];
+
+        let wrong_key = [2u8; 32];
+        let mut recv_seq = 0u64;
+        let err = parse_and_verify(body, &wrong_key, &mut recv_seq).unwrap_err();
+        match err {
+            IpcError::Protocol(m) => assert!(m.contains("HMAC mismatch"), "{}", m),
+            _ => panic!("expected protocol error"),
+        }
+    }
+
+    #[test]
+    fn envelope_json_keys_match_go() {
+        // Go Envelope tags: id, seq, type, payload, error (omitempty), hmac.
+        let env = Envelope {
+            id: "x".to_string(),
+            seq: 9,
+            typ: "ping".to_string(),
+            payload: Some(raw(r#"{"k":1}"#)),
+            error: String::new(),
+            hmac: "deadbeef".to_string(),
+        };
+        let s = serde_json::to_string(&env).expect("serialize");
+        assert!(s.contains("\"id\":"), "{}", s);
+        assert!(s.contains("\"seq\":"), "{}", s);
+        assert!(s.contains("\"type\":"), "{}", s);
+        assert!(s.contains("\"payload\":"), "{}", s);
+        assert!(s.contains("\"hmac\":"), "{}", s);
+        // error is omitempty in Go and skipped when empty here.
+        assert!(!s.contains("\"error\":"), "{}", s);
+    }
+}

--- a/apps/helper/src-tauri/src/ipc/envelope.rs
+++ b/apps/helper/src-tauri/src/ipc/envelope.rs
@@ -73,7 +73,14 @@ impl std::fmt::Display for IpcError {
     }
 }
 
-impl std::error::Error for IpcError {}
+impl std::error::Error for IpcError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            IpcError::Io(e) => Some(e),
+            IpcError::Protocol(_) => None,
+        }
+    }
+}
 
 impl From<std::io::Error> for IpcError {
     fn from(e: std::io::Error) -> Self {
@@ -81,17 +88,31 @@ impl From<std::io::Error> for IpcError {
     }
 }
 
-/// Computes `hex(HMAC-SHA256(key, id || decimal(seq) || typ || payload))`.
+/// Builds the seeded HMAC-SHA256 `Mac` over `id || decimal(seq) || typ ||
+/// payload`. This is the single source of truth for the HMAC canonicalization;
+/// both [`compute_hmac`] (outbound, finalizes to hex) and [`parse_and_verify`]
+/// (inbound, constant-time `verify_slice`) build the message through here so the
+/// formula can never drift between the two paths.
 ///
-/// The update order and the decimal-string seq encoding match Go's
-/// `computeHMAC` exactly.
-pub fn compute_hmac(key: &[u8], id: &str, seq: u64, typ: &str, payload: &[u8]) -> String {
+/// NOTE: the fields are concatenated with NO separators. This is intentional and
+/// inherited verbatim from Go's `computeHMAC` (`agent/internal/ipc/protocol.go`).
+/// The two sides MUST agree byte-for-byte, so do not "fix" this by adding
+/// delimiters — doing so silently breaks the cross-language handshake.
+fn hmac_mac(key: &[u8], id: &str, seq: u64, typ: &str, payload: &[u8]) -> HmacSha256 {
     let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
     mac.update(id.as_bytes());
     mac.update(seq.to_string().as_bytes());
     mac.update(typ.as_bytes());
     mac.update(payload);
-    hex::encode(mac.finalize().into_bytes())
+    mac
+}
+
+/// Computes `hex(HMAC-SHA256(key, id || decimal(seq) || typ || payload))`.
+///
+/// The update order and the decimal-string seq encoding match Go's
+/// `computeHMAC` exactly. See [`hmac_mac`] for the shared canonicalization.
+pub fn compute_hmac(key: &[u8], id: &str, seq: u64, typ: &str, payload: &[u8]) -> String {
+    hex::encode(hmac_mac(key, id, seq, typ, payload).finalize().into_bytes())
 }
 
 /// Like [`compute_hmac`] but treats an absent payload as the literal bytes
@@ -129,6 +150,8 @@ pub fn encode_frame(
     typ: &str,
     payload: Option<Box<RawValue>>,
 ) -> Option<Vec<u8>> {
+    // Monotonic send sequence. Wrap at u64::MAX is not a practical concern: at
+    // even a million frames/sec it would take ~580k years to overflow.
     *send_seq += 1;
     let seq = *send_seq;
 
@@ -144,7 +167,9 @@ pub fn encode_frame(
     };
 
     let body = serde_json::to_vec(&env).ok()?;
-    if body.is_empty() || body.len() > MAX_MESSAGE_SIZE {
+    // Only the oversize case is reachable: serde_json::to_vec on a struct always
+    // yields a non-empty object, so there is no empty-body guard here.
+    if body.len() > MAX_MESSAGE_SIZE {
         return None;
     }
 
@@ -162,13 +187,12 @@ pub async fn write_frame<W: AsyncWriteExt + Unpin>(
     id: &str,
     typ: &str,
     payload: Option<Box<RawValue>>,
-) -> std::io::Result<()> {
+) -> Result<(), IpcError> {
     let frame = encode_frame(key, send_seq, id, typ, payload).ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            "ipc: message too large or failed to encode",
-        )
+        IpcError::Protocol("ipc: message too large or failed to encode".to_string())
     })?;
+    // IO errors convert via `From<io::Error>`, so the transport `?` chains stay
+    // uniform on `IpcError`.
     w.write_all(&frame).await?;
     w.flush().await?;
     Ok(())
@@ -216,12 +240,16 @@ pub fn parse_and_verify(
     let env: Envelope = serde_json::from_slice(body)
         .map_err(|e| IpcError::Protocol(format!("unmarshal envelope: {}", e)))?;
 
-    // Recompute HMAC over the exact payload bytes and constant-time compare.
-    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
-    mac.update(env.id.as_bytes());
-    mac.update(env.seq.to_string().as_bytes());
-    mac.update(env.typ.as_bytes());
-    mac.update(payload_hmac_bytes(&env.payload));
+    // Rebuild the HMAC over the exact payload bytes via the shared canonicalization
+    // and constant-time compare. Non-hex hmac strings are a protocol error, not a
+    // panic.
+    let mac = hmac_mac(
+        key,
+        &env.id,
+        env.seq,
+        &env.typ,
+        payload_hmac_bytes(&env.payload),
+    );
     let received = match hex::decode(&env.hmac) {
         Ok(b) => b,
         Err(_) => return Err(IpcError::Protocol("HMAC mismatch".to_string())),
@@ -373,5 +401,98 @@ mod tests {
         assert!(s.contains("\"hmac\":"), "{}", s);
         // error is omitempty in Go and skipped when empty here.
         assert!(!s.contains("\"error\":"), "{}", s);
+    }
+
+    #[test]
+    fn parse_rejects_malformed_json() {
+        let key = [1u8; 32];
+        let mut recv_seq = 0u64;
+        let err = parse_and_verify(b"{not valid json", &key, &mut recv_seq).unwrap_err();
+        match err {
+            IpcError::Protocol(m) => assert!(m.contains("unmarshal envelope"), "{}", m),
+            _ => panic!("expected protocol error"),
+        }
+        // recv_seq must be untouched on a parse failure.
+        assert_eq!(recv_seq, 0);
+    }
+
+    #[test]
+    fn parse_rejects_seq_zero() {
+        // Hand-build an envelope with seq == 0 and a VALID hmac for seq 0 so we
+        // exercise the seq==0 branch specifically (not an HMAC failure).
+        let key = [4u8; 32];
+        let payload = raw(r#"{"a":1}"#);
+        let hmac = compute_hmac(&key, "z", 0, "ping", payload.get().as_bytes());
+        let env = Envelope {
+            id: "z".to_string(),
+            seq: 0,
+            typ: "ping".to_string(),
+            payload: Some(payload),
+            error: String::new(),
+            hmac,
+        };
+        let body = serde_json::to_vec(&env).expect("serialize");
+
+        let mut recv_seq = 0u64;
+        let err = parse_and_verify(&body, &key, &mut recv_seq).unwrap_err();
+        match err {
+            IpcError::Protocol(m) => assert!(m.contains("invalid sequence number 0"), "{}", m),
+            _ => panic!("expected protocol error"),
+        }
+    }
+
+    #[test]
+    fn parse_rejects_non_hex_hmac() {
+        // A non-hex hmac string must surface as a Protocol error, never a panic.
+        let env = Envelope {
+            id: "x".to_string(),
+            seq: 1,
+            typ: "ping".to_string(),
+            payload: None,
+            error: String::new(),
+            hmac: "zzzz-not-hex".to_string(),
+        };
+        let body = serde_json::to_vec(&env).expect("serialize");
+
+        let key = [1u8; 32];
+        let mut recv_seq = 0u64;
+        let err = parse_and_verify(&body, &key, &mut recv_seq).unwrap_err();
+        match err {
+            IpcError::Protocol(m) => assert!(m.contains("HMAC mismatch"), "{}", m),
+            _ => panic!("expected protocol error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn async_write_read_round_trip() {
+        // Exercise the real async length-header path over a bidirectional pipe.
+        let (mut a, mut b) = tokio::io::duplex(4096);
+        let key = [0u8; 32]; // pre-auth zero key
+        let mut send_seq = 0u64;
+        let mut recv_seq = 0u64;
+
+        write_frame(
+            &mut a,
+            &key,
+            &mut send_seq,
+            "auth",
+            "auth_request",
+            Some(raw(r#"{"token":"abc","v":1}"#)),
+        )
+        .await
+        .expect("write_frame");
+        assert_eq!(send_seq, 1);
+
+        let env = read_frame(&mut b, &key, &mut recv_seq)
+            .await
+            .expect("read_frame");
+        assert_eq!(env.id, "auth");
+        assert_eq!(env.seq, 1);
+        assert_eq!(env.typ, "auth_request");
+        assert_eq!(recv_seq, 1);
+        assert_eq!(
+            env.payload.as_ref().map(|r| r.get()),
+            Some(r#"{"token":"abc","v":1}"#)
+        );
     }
 }

--- a/apps/helper/src-tauri/src/ipc/mod.rs
+++ b/apps/helper/src-tauri/src/ipc/mod.rs
@@ -4,4 +4,5 @@
 //! `agent/internal/ipc` package byte-for-byte.
 
 pub mod envelope;
-// transport, client, token added in later tasks
+pub mod token;
+// transport, client added in later tasks

--- a/apps/helper/src-tauri/src/ipc/mod.rs
+++ b/apps/helper/src-tauri/src/ipc/mod.rs
@@ -3,7 +3,7 @@
 //! Wire format and HMAC live in [`envelope`] and must match the Go
 //! `agent/internal/ipc` package byte-for-byte.
 
+pub mod client;
 pub mod envelope;
 pub mod token;
 pub mod transport;
-// client added in later tasks

--- a/apps/helper/src-tauri/src/ipc/mod.rs
+++ b/apps/helper/src-tauri/src/ipc/mod.rs
@@ -5,4 +5,5 @@
 
 pub mod envelope;
 pub mod token;
-// transport, client added in later tasks
+pub mod transport;
+// client added in later tasks

--- a/apps/helper/src-tauri/src/ipc/mod.rs
+++ b/apps/helper/src-tauri/src/ipc/mod.rs
@@ -1,0 +1,7 @@
+//! IPC client for talking to the Go agent's broker over the local socket.
+//!
+//! Wire format and HMAC live in [`envelope`] and must match the Go
+//! `agent/internal/ipc` package byte-for-byte.
+
+pub mod envelope;
+// transport, client, token added in later tasks

--- a/apps/helper/src-tauri/src/ipc/token.rs
+++ b/apps/helper/src-tauri/src/ipc/token.rs
@@ -1,0 +1,39 @@
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// In-memory, updatable helper token. Never persisted to disk.
+/// Cloneable handle: all clones share the same underlying cell.
+#[derive(Clone, Default)]
+pub struct HelperToken {
+    inner: Arc<RwLock<Option<String>>>,
+}
+
+impl HelperToken {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Replace the stored token.
+    pub async fn set(&self, token: String) {
+        *self.inner.write().await = Some(token);
+    }
+
+    /// Return a copy of the current token, or None if not yet received.
+    pub async fn get(&self) -> Option<String> {
+        self.inner.read().await.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[tokio::test]
+    async fn set_and_get() {
+        let cell = HelperToken::new();
+        assert_eq!(cell.get().await, None);
+        cell.set("brz_a".into()).await;
+        assert_eq!(cell.get().await.as_deref(), Some("brz_a"));
+        cell.set("brz_b".into()).await;
+        assert_eq!(cell.get().await.as_deref(), Some("brz_b"));
+    }
+}

--- a/apps/helper/src-tauri/src/ipc/token.rs
+++ b/apps/helper/src-tauri/src/ipc/token.rs
@@ -8,6 +8,14 @@ pub struct HelperToken {
     inner: Arc<RwLock<Option<String>>>,
 }
 
+impl std::fmt::Debug for HelperToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never print the token value. A manual impl also makes a future
+        // #[derive(Debug)] a compile error rather than a silent secret leak.
+        f.write_str("HelperToken(***)")
+    }
+}
+
 impl HelperToken {
     pub fn new() -> Self {
         Self::default()
@@ -35,5 +43,17 @@ mod tests {
         assert_eq!(cell.get().await.as_deref(), Some("brz_a"));
         cell.set("brz_b".into()).await;
         assert_eq!(cell.get().await.as_deref(), Some("brz_b"));
+    }
+
+    #[tokio::test]
+    async fn debug_redacts_token_value() {
+        let cell = HelperToken::new();
+        cell.set("brz_super_secret".into()).await;
+        let dbg = format!("{:?}", cell);
+        assert!(dbg.contains("***"), "expected redaction marker, got {dbg}");
+        assert!(
+            !dbg.contains("brz_super_secret"),
+            "Debug leaked the token value: {dbg}"
+        );
     }
 }

--- a/apps/helper/src-tauri/src/ipc/transport.rs
+++ b/apps/helper/src-tauri/src/ipc/transport.rs
@@ -1,0 +1,188 @@
+//! Platform transport + peer identity for the IPC client.
+//!
+//! The broker (Go `agent/internal/ipc` + `sessionbroker`) validates the
+//! `auth_request` we send against KERNEL-verified peer credentials:
+//!   - unix (macOS/Linux): `auth_request.UID` MUST equal the kernel-resolved
+//!     uid of this process, so [`current_identity`] returns `getuid()`.
+//!   - windows: `auth_request.SID` MUST equal the kernel-resolved token-user
+//!     SID of this process, so [`current_identity`] returns the real SID
+//!     string from the process token.
+//! Username is informational. The assist role runs as the logged-in user.
+
+/// Default broker socket / named-pipe path for the current platform.
+///
+/// Mirrors the defaults baked into `agent/internal/ipc/auth_*.go`.
+pub fn default_socket_path() -> String {
+    #[cfg(windows)]
+    {
+        r"\\.\pipe\breeze-agent-ipc".to_string()
+    }
+    #[cfg(target_os = "macos")]
+    {
+        "/Library/Application Support/Breeze/agent.sock".to_string()
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        "/var/run/breeze/agent.sock".to_string()
+    }
+}
+
+/// Identity of this process as seen by the broker.
+///
+/// `sid` is empty on unix; `uid` is unused (0) on windows.
+#[derive(Debug, Clone)]
+pub struct PeerIdentity {
+    pub uid: u32,
+    pub sid: String,
+    pub username: String,
+    pub pid: u32,
+}
+
+/// Resolve the current process identity.
+#[cfg(unix)]
+pub fn current_identity() -> Result<PeerIdentity, String> {
+    // SAFETY: getuid() is always-succeeds, takes no args, has no side effects.
+    let uid = unsafe { libc::getuid() };
+    Ok(PeerIdentity {
+        uid,
+        sid: String::new(),
+        // Username is informational; default to empty on error.
+        username: whoami::username().unwrap_or_default(),
+        pid: std::process::id(),
+    })
+}
+
+/// Resolve the current process identity (windows).
+///
+/// Returns the real token-user SID string, which the broker compares against
+/// the kernel-resolved SID of the connecting process.
+#[cfg(windows)]
+pub fn current_identity() -> Result<PeerIdentity, String> {
+    let sid = current_sid_string()?;
+    Ok(PeerIdentity {
+        uid: 0, // unused on windows
+        sid,
+        // Username is informational; default to empty on error.
+        username: whoami::username().unwrap_or_default(),
+        pid: std::process::id(),
+    })
+}
+
+/// Obtain this process's token-user SID as an "S-1-5-21-..." string.
+#[cfg(windows)]
+fn current_sid_string() -> Result<String, String> {
+    use windows::core::PWSTR;
+    use windows::Win32::Foundation::{CloseHandle, LocalFree, HANDLE, HLOCAL};
+    use windows::Win32::Security::Authorization::ConvertSidToStringSidW;
+    use windows::Win32::Security::{
+        GetTokenInformation, TokenUser, TOKEN_QUERY, TOKEN_USER,
+    };
+    use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    // SAFETY: All WinAPI calls below operate on a token handle we open and
+    // close ourselves; buffers are sized via the first GetTokenInformation
+    // call and the resulting SID string is freed with LocalFree.
+    unsafe {
+        let mut token = HANDLE::default();
+        // Open the current process token for query.
+        OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token)
+            .map_err(|e| format!("OpenProcessToken failed: {e}"))?;
+
+        // First call: ask for the required buffer size (expected to fail with
+        // ERROR_INSUFFICIENT_BUFFER, which we ignore in favor of `needed`).
+        let mut needed: u32 = 0;
+        let _ = GetTokenInformation(token, TokenUser, None, 0, &mut needed);
+        if needed == 0 {
+            let _ = CloseHandle(token);
+            return Err("GetTokenInformation returned zero size".to_string());
+        }
+
+        // Allocate and fetch the TOKEN_USER structure.
+        let mut buf: Vec<u8> = vec![0u8; needed as usize];
+        let info_ptr = buf.as_mut_ptr() as *mut core::ffi::c_void;
+        let res = GetTokenInformation(token, TokenUser, Some(info_ptr), needed, &mut needed);
+        // Token handle no longer needed once the info is copied into `buf`.
+        let _ = CloseHandle(token);
+        res.map_err(|e| format!("GetTokenInformation failed: {e}"))?;
+
+        // The SID pointer lives inside the TOKEN_USER we just read.
+        let token_user = &*(buf.as_ptr() as *const TOKEN_USER);
+        let psid = token_user.User.Sid;
+
+        // Convert the binary SID into its canonical string form.
+        let mut pwstr = PWSTR::null();
+        ConvertSidToStringSidW(psid, &mut pwstr)
+            .map_err(|e| format!("ConvertSidToStringSidW failed: {e}"))?;
+        if pwstr.is_null() {
+            return Err("ConvertSidToStringSidW returned null".to_string());
+        }
+
+        // Copy the wide string into an owned Rust String, then free it.
+        let sid = pwstr.to_string().map_err(|e| format!("SID utf16 decode failed: {e}"))?;
+        // LocalFree expects an HLOCAL; the SID-string buffer is LocalAlloc'd.
+        // TODO(verify-on-windows-vm): exact LocalFree/HLOCAL cast for windows 0.58.
+        let _ = LocalFree(HLOCAL(pwstr.0 as *mut core::ffi::c_void));
+        Ok(sid)
+    }
+}
+
+/// Best-effort sha256 hex of the current executable.
+///
+/// NOT security-load-bearing: the broker recomputes the hash from the
+/// kernel-resolved peer path. This field is informational only, so any error
+/// yields an empty string rather than failing identity resolution.
+pub fn self_binary_hash() -> String {
+    use sha2::{Digest, Sha256};
+    let path = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(_) => return String::new(),
+    };
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(_) => return String::new(),
+    };
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    hex::encode(hasher.finalize())
+}
+
+/// Connect to the broker over a unix domain socket.
+#[cfg(unix)]
+pub async fn connect(path: &str) -> std::io::Result<tokio::net::UnixStream> {
+    tokio::net::UnixStream::connect(path).await
+}
+
+/// Connect to the broker over a Windows named pipe.
+#[cfg(windows)]
+pub async fn connect(
+    path: &str,
+) -> std::io::Result<tokio::net::windows::named_pipe::NamedPipeClient> {
+    use tokio::net::windows::named_pipe::ClientOptions;
+    // TODO(verify-on-windows-vm): retry on ERROR_PIPE_BUSY may be needed in T10.
+    ClientOptions::new().open(path)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_has_uid_and_pid() {
+        let id = current_identity().expect("identity");
+        assert_eq!(id.uid, unsafe { libc::getuid() });
+        assert!(id.pid > 0);
+        assert!(id.sid.is_empty(), "sid empty on unix");
+    }
+
+    #[test]
+    fn default_path_is_unix_socket() {
+        let p = default_socket_path();
+        assert!(p.ends_with("agent.sock"));
+    }
+
+    #[test]
+    fn self_hash_is_hex_or_empty() {
+        let h = self_binary_hash();
+        assert!(h.is_empty() || (h.len() == 64 && h.bytes().all(|b| b.is_ascii_hexdigit())));
+    }
+}

--- a/apps/helper/src-tauri/src/ipc/transport.rs
+++ b/apps/helper/src-tauri/src/ipc/transport.rs
@@ -21,6 +21,7 @@ pub fn default_socket_path() -> String {
     {
         "/Library/Application Support/Breeze/agent.sock".to_string()
     }
+    // Linux and other unix
     #[cfg(all(unix, not(target_os = "macos")))]
     {
         "/var/run/breeze/agent.sock".to_string()
@@ -32,9 +33,13 @@ pub fn default_socket_path() -> String {
 /// `sid` is empty on unix; `uid` is unused (0) on windows.
 #[derive(Debug, Clone)]
 pub struct PeerIdentity {
+    /// Unix uid of this process; 0/unused on Windows.
     pub uid: u32,
+    /// Windows token-user SID string (e.g. "S-1-5-21-…"); empty on unix.
     pub sid: String,
+    /// Human-readable username — informational only, not verified by the broker.
     pub username: String,
+    /// Current process id.
     pub pid: u32,
 }
 
@@ -120,7 +125,7 @@ fn current_sid_string() -> Result<String, String> {
         // Copy the wide string into an owned Rust String, then free it.
         let sid = pwstr.to_string().map_err(|e| format!("SID utf16 decode failed: {e}"))?;
         // LocalFree expects an HLOCAL; the SID-string buffer is LocalAlloc'd.
-        // TODO(verify-on-windows-vm): exact LocalFree/HLOCAL cast for windows 0.58.
+        // TODO(T13 Windows VM verify): exact LocalFree/HLOCAL cast for windows 0.58.
         let _ = LocalFree(HLOCAL(pwstr.0 as *mut core::ffi::c_void));
         Ok(sid)
     }
@@ -153,12 +158,16 @@ pub async fn connect(path: &str) -> std::io::Result<tokio::net::UnixStream> {
 }
 
 /// Connect to the broker over a Windows named pipe.
+///
+/// `async` is kept for API symmetry with the unix variant even though
+/// `ClientOptions::open` is synchronous — T10's generic client calls
+/// `connect(...).await` on both platforms without needing a cfg guard.
 #[cfg(windows)]
 pub async fn connect(
     path: &str,
 ) -> std::io::Result<tokio::net::windows::named_pipe::NamedPipeClient> {
     use tokio::net::windows::named_pipe::ClientOptions;
-    // TODO(verify-on-windows-vm): retry on ERROR_PIPE_BUSY may be needed in T10.
+    // TODO(T13 Windows VM verify): retry on ERROR_PIPE_BUSY may be needed in T10.
     ClientOptions::new().open(path)
 }
 

--- a/apps/helper/src-tauri/src/lib.rs
+++ b/apps/helper/src-tauri/src/lib.rs
@@ -296,6 +296,16 @@ fn get_http_state_lock() -> &'static Mutex<Option<HttpClientState>> {
     HTTP_STATE.get_or_init(|| Mutex::new(None))
 }
 
+use crate::ipc::token::HelperToken;
+
+/// Process-global helper auth token delivered over IPC from the Breeze agent.
+/// Distinct from the file-loaded `HttpClientState::config.token` (Phase-1 fallback).
+static HELPER_TOKEN: OnceLock<HelperToken> = OnceLock::new();
+
+fn helper_token() -> &'static HelperToken {
+    HELPER_TOKEN.get_or_init(HelperToken::new)
+}
+
 /// Build a reqwest::Client, optionally with mTLS identity.
 fn build_client(cfg: &AgentConfigFull) -> Result<Client, String> {
     let mut builder = Client::builder().use_rustls_tls();
@@ -567,7 +577,11 @@ async fn helper_fetch(
 ) -> Result<HelperFetchResponse, String> {
     ensure_http_state().await?;
 
-    let (client, token, api_url) = {
+    // Phase 1: prefer the IPC-delivered token; fall back to the file-loaded
+    // token while older agents still write it to agent.yaml. Phase 2 removes
+    // the file fallback.
+    let ipc_token = helper_token().get().await;
+    let (client, file_token, api_url) = {
         let lock = get_http_state_lock();
         let guard = lock.lock().await;
         let state = guard
@@ -579,6 +593,7 @@ async fn helper_fetch(
             state.config.api_url.clone(),
         )
     };
+    let token = ipc_token.unwrap_or(file_token);
 
     // Validate that the request URL targets the configured API server.
     // This prevents SSRF and token leakage to arbitrary hosts.
@@ -968,6 +983,14 @@ pub fn run() {
                     write_status_file(CHAT_ACTIVE.load(Ordering::Relaxed));
                 }
             });
+
+            // Deliver the helper auth token over IPC from the Breeze agent.
+            let token = helper_token().clone();
+            let (_stop_tx, stop_rx) = tokio::sync::watch::channel(false);
+            // Leak the sender so the watch channel stays open for the app's
+            // lifetime; the client task ends only when the process exits.
+            std::mem::forget(_stop_tx);
+            tauri::async_runtime::spawn(crate::ipc::client::run(token, stop_rx));
 
             Ok(())
         })

--- a/apps/helper/src-tauri/src/lib.rs
+++ b/apps/helper/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod ipc;
 
+use crate::ipc::token::HelperToken;
 use futures_util::StreamExt;
 use reqwest::{header::HeaderMap, Client, Identity, Method};
 use serde::{Deserialize, Serialize};
@@ -295,8 +296,6 @@ static HTTP_STATE: OnceLock<Mutex<Option<HttpClientState>>> = OnceLock::new();
 fn get_http_state_lock() -> &'static Mutex<Option<HttpClientState>> {
     HTTP_STATE.get_or_init(|| Mutex::new(None))
 }
-
-use crate::ipc::token::HelperToken;
 
 /// Process-global helper auth token delivered over IPC from the Breeze agent.
 /// Distinct from the file-loaded `HttpClientState::config.token` (Phase-1 fallback).
@@ -985,11 +984,13 @@ pub fn run() {
             });
 
             // Deliver the helper auth token over IPC from the Breeze agent.
+            // Keep the stop sender in managed state so the watch channel stays open
+            // for the app's lifetime; on app exit the state is dropped, the channel
+            // closes, and the client task exits. (The task also exits on a permanent
+            // broker reject — that is intentional.)
             let token = helper_token().clone();
-            let (_stop_tx, stop_rx) = tokio::sync::watch::channel(false);
-            // Leak the sender so the watch channel stays open for the app's
-            // lifetime; the client task ends only when the process exits.
-            std::mem::forget(_stop_tx);
+            let (stop_tx, stop_rx) = tokio::sync::watch::channel(false);
+            app.manage(stop_tx);
             tauri::async_runtime::spawn(crate::ipc::client::run(token, stop_rx));
 
             Ok(())

--- a/apps/helper/src-tauri/src/lib.rs
+++ b/apps/helper/src-tauri/src/lib.rs
@@ -430,6 +430,15 @@ fn get_helper_config() -> HelperConfig {
     load_helper_config()
 }
 
+/// Report whether the helper auth token has been delivered over IPC yet.
+/// The frontend polls this on startup to show a transient "connecting to
+/// agent" state until the token arrives (relevant when there is no file
+/// fallback in Phase 2).
+#[tauri::command]
+async fn helper_token_ready() -> bool {
+    helper_token().get().await.is_some()
+}
+
 // -- helper_fetch types -----------------------------------------------------
 
 #[derive(Debug, Deserialize)]
@@ -802,6 +811,7 @@ pub fn run() {
             get_os_username,
             get_helper_config,
             update_chat_active,
+            helper_token_ready,
         ])
         .setup(|app| {
             // Create main window manually (not from config) so we can set

--- a/apps/helper/src-tauri/src/lib.rs
+++ b/apps/helper/src-tauri/src/lib.rs
@@ -1,3 +1,5 @@
+mod ipc;
+
 use futures_util::StreamExt;
 use reqwest::{header::HeaderMap, Client, Identity, Method};
 use serde::{Deserialize, Serialize};

--- a/apps/helper/src/App.tsx
+++ b/apps/helper/src/App.tsx
@@ -438,7 +438,7 @@ export default function App() {
     return (
       <div className="helper-container helper-center">
         <span className="helper-spinner" />
-        <p>Connecting to Breeze...</p>
+        <p>Connecting to Breeze…</p>
       </div>
     );
   }
@@ -447,7 +447,7 @@ export default function App() {
     return (
       <div className="helper-container helper-center">
         <span className="helper-spinner" />
-        <p>Connecting to the Breeze agent&hellip;</p>
+        <p>Connecting to the Breeze agent…</p>
       </div>
     );
   }

--- a/apps/helper/src/App.tsx
+++ b/apps/helper/src/App.tsx
@@ -443,6 +443,15 @@ export default function App() {
     );
   }
 
+  if (connectionState === 'waiting-for-token') {
+    return (
+      <div className="helper-container helper-center">
+        <span className="helper-spinner" />
+        <p>Connecting to the Breeze agent&hellip;</p>
+      </div>
+    );
+  }
+
   if (connectionState === 'error') {
     return (
       <div className="helper-container helper-center">

--- a/apps/helper/src/stores/chatStore.ts
+++ b/apps/helper/src/stores/chatStore.ts
@@ -503,6 +503,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
   isFlagged: false,
 
   initialize: async () => {
+    // Avoid stacking concurrent inits (e.g. Retry pressed while a token poll is still running).
+    const cs = get().connectionState;
+    if (cs === 'connecting' || cs === 'waiting-for-token') return;
+
     set({ connectionState: 'connecting', connectionError: null });
 
     try {

--- a/apps/helper/src/stores/chatStore.ts
+++ b/apps/helper/src/stores/chatStore.ts
@@ -545,8 +545,18 @@ export const useChatStore = create<ChatState>((set, get) => ({
         for (let attempt = 0; attempt < TOKEN_POLL_MAX_ATTEMPTS; attempt++) {
           try {
             ready = (await invoke('helper_token_ready')) as boolean;
-          } catch {
+          } catch (err) {
             ready = false;
+            // Log on the last attempt so a broken IPC bridge (command throwing
+            // every iteration) is visible without spamming on every poll tick.
+            if (attempt === TOKEN_POLL_MAX_ATTEMPTS - 1) {
+              console.warn(
+                '[helper] helper_token_ready threw on final attempt — IPC bridge may be broken:',
+                err,
+              );
+            } else {
+              console.debug('[helper] helper_token_ready threw (attempt', attempt, '):', err);
+            }
           }
           if (ready) break;
           // Surface the waiting state on the first miss so the UI updates.
@@ -554,6 +564,17 @@ export const useChatStore = create<ChatState>((set, get) => ({
             set({ agentConfig: config, connectionState: 'waiting-for-token', username });
           }
           await new Promise((resolve) => setTimeout(resolve, TOKEN_POLL_INTERVAL_MS));
+        }
+
+        if (!ready) {
+          // Phase 1: file-token fallback is still valid, so we continue to
+          // 'connected'. Requests may still succeed via the on-disk token.
+          // Phase 2 (no file fallback): replace this branch with a transition
+          // to an 'agent-unreachable' / 'error' state instead of 'connected'.
+          console.warn(
+            '[helper] IPC token not received before timeout; proceeding with file-fallback token (Phase 1).' +
+              ' If requests fail, ensure the Breeze agent is running.',
+          );
         }
       }
 

--- a/apps/helper/src/stores/chatStore.ts
+++ b/apps/helper/src/stores/chatStore.ts
@@ -38,7 +38,12 @@ export interface SessionSummary {
   updatedAt: string;
 }
 
-type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'error';
+type ConnectionState =
+  | 'disconnected'
+  | 'connecting'
+  | 'waiting-for-token'
+  | 'connected'
+  | 'error';
 
 export interface DeviceContext {
   hostname: string;
@@ -522,6 +527,31 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // Restore username from localStorage, fall back to OS username
       const stored = localStorage.getItem(USERNAME_KEY);
       const username = stored || config.os_username || null;
+
+      // In Tauri, the helper auth token is delivered over IPC by the agent and
+      // may not be present at the instant the window opens. Show a transient
+      // "connecting to agent" state while we wait for it. In Phase 1 the file
+      // token is still a fallback, so we proceed after a bounded number of
+      // attempts even if the IPC token hasn't landed; in Phase 2 (no file
+      // fallback) this gate prevents requests that would 401.
+      if (invoke) {
+        const TOKEN_POLL_INTERVAL_MS = 500;
+        const TOKEN_POLL_MAX_ATTEMPTS = 20; // ~10s
+        let ready = false;
+        for (let attempt = 0; attempt < TOKEN_POLL_MAX_ATTEMPTS; attempt++) {
+          try {
+            ready = (await invoke('helper_token_ready')) as boolean;
+          } catch {
+            ready = false;
+          }
+          if (ready) break;
+          // Surface the waiting state on the first miss so the UI updates.
+          if (attempt === 0) {
+            set({ agentConfig: config, connectionState: 'waiting-for-token', username });
+          }
+          await new Promise((resolve) => setTimeout(resolve, TOKEN_POLL_INTERVAL_MS));
+        }
+      }
 
       set({ agentConfig: config, connectionState: 'connected', username });
     } catch (err) {

--- a/docs/superpowers/plans/2026-05-29-helper-ipc-token-delivery.md
+++ b/docs/superpowers/plans/2026-05-29-helper-ipc-token-delivery.md
@@ -1,0 +1,1087 @@
+# Helper IPC Token Delivery — Implementation Plan (Phase 1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver the per-device `helper_auth_token` to the Breeze Assist Helper over the existing authenticated agent IPC channel (kernel peer-auth + binary-hash allowlist) instead of the world-readable `agent.yaml`, closing security-review finding HIGH-1.
+
+**Architecture:** Reuse the Go agent's existing IPC (`agent/internal/ipc` + `agent/internal/sessionbroker`). Add a least-privilege `assist` role/scope and a dedicated `helper_token_update` message so the helper token never shares a path with the watchdog's agent token. Add a focused Rust IPC client to the Tauri Helper (`apps/helper/src-tauri`) that authenticates, receives the token into memory, and feeds it to the existing `helper_fetch`. Two-phase rollout: **Phase 1 (this plan)** ships IPC delivery while the agent *still* writes the token to `agent.yaml` (file fallback retained); **Phase 2 (separate, gated release)** stops writing the file and removes the fallback.
+
+**Tech Stack:** Go (agent, `go test -race`), Rust/Tauri 2 (`apps/helper/src-tauri`, `cargo test`), tokio, hmac/sha2, named pipe (Windows) / Unix domain socket (macOS/Linux).
+
+**Spec:** `docs/superpowers/specs/2026-05-29-helper-ipc-token-delivery-design.md`
+
+---
+
+## Reference facts (verified against the codebase)
+
+- **Wire format** (`agent/internal/ipc/protocol.go`): `[4-byte BE length][JSON Envelope]`. `Envelope{ID, Seq, Type, Payload(json.RawMessage), Error, HMAC}`. HMAC = `HMAC-SHA256(key, ID || decimal(Seq) || Type || Payload)`, where `key` is 32 zero bytes pre-auth and the 32-byte session key post-auth. A `nil`/absent payload is HMAC'd as the literal bytes `null` (4 bytes). `Seq` starts at 1 and must be strictly increasing per direction.
+- **Handshake** (`broker.go:1090-1418`, modeled by `userhelper/client.go:178-290`): client sends `auth_request`; broker verifies protocol version, identity (`SID`==kernel SID on Windows / `UID`==kernel UID on unix), binary path allowlist, **binary-hash allowlist** (`selfHashes`, recomputed from on-disk trusted-path binaries — broker does NOT trust `authReq.BinaryHash`), duplicate session id, role↔identity (Windows: user-role must NOT be SYSTEM `S-1-5-18`), then replies `auth_response{accepted, sessionKey(hex), allowedScopes}`. On rejection before/at auth it may send `pre_auth_reject{code, reason, permanent}` or `auth_response{accepted:false, permanent}`.
+- **Roles/scopes** (`ipc/message.go:113-115`, `broker.go:209-213, 1360-1375`): `HelperRoleSystem/User/Watchdog`; `userHelperScopes=[notify,clipboard,run_as_user]`, `watchdogHelperScopes=[watchdog]`.
+- **Token push precedent** (`heartbeat.go:2462-2471`): `sendWatchdogTokenUpdate` finds `PreferredSessionWithScope("watchdog")` and `SendNotify("", ipc.TypeTokenUpdate, ipc.TokenUpdate{Token})`. Helper-token rotation value is available as `rotateResp.HelperAuthToken` at `heartbeat.go:2410-2433`.
+- **Broker callbacks** (`broker.go:216-221, 270, 331-333`): `New(socketPath, MessageHandler)`, `SetSessionClosedHandler`. No on-authenticated hook exists yet — we add one.
+- **Helper Rust** (`apps/helper/src-tauri/src/lib.rs`): `helper_token_from_config` (lines 79-89) reads token from secrets.yaml→agent.yaml; `load_agent_config_full` builds `AgentConfigFull{api_url, token, agent_id, mtls_*}`; `HttpClientState{client, config}` cached in `static HTTP_STATE: OnceLock<Mutex<Option<HttpClientState>>>`; `helper_fetch` reads `state.config.token` and sets `Authorization: Bearer`. Cargo deps include `tokio={features=["sync"]}`, `serde`, `serde_yaml`, `reqwest`, `chrono`.
+
+## File structure
+
+**Go (agent):**
+- `agent/internal/ipc/message.go` — new role/binary-kind/message-type constants + `HelperTokenUpdate` struct.
+- `agent/internal/sessionbroker/broker.go` — `assistHelperScopes`, role validation, scope assignment, `SessionAuthenticatedHandler` hook, trusted Helper binary path.
+- `agent/internal/sessionbroker/broker_test.go` — broker tests.
+- `agent/internal/heartbeat/heartbeat.go` — retained helper token, `sendHelperTokenUpdate*`, wire on-auth + rotation push.
+- `agent/internal/heartbeat/heartbeat_test.go` (or a focused new `*_test.go`) — push tests.
+
+**Rust (Helper) — new module `apps/helper/src-tauri/src/ipc/`:**
+- `mod.rs` — module exports.
+- `envelope.rs` — Envelope struct, length-prefix framing read/write, HMAC compute/verify, seq tracking.
+- `transport.rs` — platform connect (named pipe / unix socket).
+- `client.rs` — handshake + receive loop + reconnect; owns the token cell.
+- `token.rs` — shared in-memory token cell (`HelperToken`).
+- `apps/helper/src-tauri/src/lib.rs` — wire token cell into `helper_fetch`; start the IPC client; Phase-1 file fallback.
+- `apps/helper/src-tauri/Cargo.toml` — add deps.
+
+---
+
+## Baseline (run once before Task 1)
+
+- [ ] **Establish green baseline**
+
+```bash
+cd /Users/toddhebebrand/breeze/.claude/worktrees/helper-ipc-token-delivery/agent
+go build ./... && go test -race ./internal/ipc/... ./internal/sessionbroker/... ./internal/heartbeat/...
+cd ../apps/helper/src-tauri && cargo build
+```
+Expected: Go builds and the three packages’ tests pass; cargo builds. If anything fails, STOP and report (do not start on a red baseline).
+
+---
+
+# Part A — Go agent (Phase 1a)
+
+### Task 1: IPC constants + `HelperTokenUpdate` message
+
+**Files:**
+- Modify: `agent/internal/ipc/message.go` (constants near `:113-115` and `:55`; struct near `:326`)
+- Test: `agent/internal/ipc/message_test.go` (create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+In `agent/internal/ipc/message_test.go`:
+```go
+package ipc
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestHelperAssistConstants(t *testing.T) {
+	if HelperRoleAssist != "assist" {
+		t.Fatalf("HelperRoleAssist = %q, want \"assist\"", HelperRoleAssist)
+	}
+	if HelperBinaryAssistHelper != "assist_helper" {
+		t.Fatalf("HelperBinaryAssistHelper = %q, want \"assist_helper\"", HelperBinaryAssistHelper)
+	}
+	if TypeHelperTokenUpdate != "helper_token_update" {
+		t.Fatalf("TypeHelperTokenUpdate = %q, want \"helper_token_update\"", TypeHelperTokenUpdate)
+	}
+}
+
+func TestHelperTokenUpdateRoundTrip(t *testing.T) {
+	in := HelperTokenUpdate{Token: "brz_abc", ExpiresAt: "2026-06-01T00:00:00Z"}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out HelperTokenUpdate
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out != in {
+		t.Fatalf("round-trip mismatch: %+v != %+v", out, in)
+	}
+	// ExpiresAt must be omitempty.
+	b2, _ := json.Marshal(HelperTokenUpdate{Token: "brz_x"})
+	if string(b2) != `{"token":"brz_x"}` {
+		t.Fatalf("omitempty failed: %s", b2)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd agent && go test ./internal/ipc/ -run TestHelperAssist -v`
+Expected: FAIL — `undefined: HelperRoleAssist` (etc.)
+
+- [ ] **Step 3: Add the constants and struct**
+
+In `agent/internal/ipc/message.go`, add `HelperRoleAssist` next to the existing role constants (`:113-115`):
+```go
+	HelperRoleSystem   = "system"
+	HelperRoleUser     = "user"
+	HelperRoleWatchdog = "watchdog"
+	HelperRoleAssist   = "assist" // Breeze Assist Tauri helper; receives helper token only
+```
+Add the binary-kind constant next to the existing `HelperBinary*` constants (search for `HelperBinaryUserHelper`):
+```go
+	HelperBinaryAssistHelper = "assist_helper"
+```
+Add the message-type constant in the watchdog/token block (`:55`):
+```go
+	TypeTokenUpdate           = "token_update"        // agent token -> watchdog (existing)
+	TypeHelperTokenUpdate     = "helper_token_update" // helper token -> assist helper
+```
+Add the payload struct near `TokenUpdate` (`:326`):
+```go
+// HelperTokenUpdate carries the helper-scoped API token to the Assist helper.
+// Distinct from TokenUpdate (agent token -> watchdog) so the two tokens can
+// never be cross-delivered.
+type HelperTokenUpdate struct {
+	Token     string `json:"token"`
+	ExpiresAt string `json:"expiresAt,omitempty"` // RFC3339, optional
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd agent && go test ./internal/ipc/ -run 'TestHelperAssist|TestHelperTokenUpdate' -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/internal/ipc/message.go agent/internal/ipc/message_test.go
+git commit -m "feat(agent/ipc): add assist role + helper_token_update message"
+```
+
+---
+
+### Task 2: Broker accepts `assist` role with `assist`-only scope
+
+**Files:**
+- Modify: `agent/internal/sessionbroker/broker.go` (scopes block `:209-213`; valid-role switch `:1278-1289`; role/identity validation `:1297-1357`; scope assignment `:1359-1375`)
+- Test: `agent/internal/sessionbroker/broker_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `agent/internal/sessionbroker/broker_test.go` (the package already has broker tests; reuse its style):
+```go
+func TestAssistScopesConstant(t *testing.T) {
+	if len(assistHelperScopes) != 1 || assistHelperScopes[0] != "assist" {
+		t.Fatalf("assistHelperScopes = %v, want [\"assist\"]", assistHelperScopes)
+	}
+	// Assist must NOT carry desktop/clipboard/run_as_user.
+	for _, s := range assistHelperScopes {
+		switch s {
+		case "desktop", "clipboard", "run_as_user", "notify", "tray":
+			t.Fatalf("assist scope must not include %q", s)
+		}
+	}
+}
+
+func TestScopesForRoleAssist(t *testing.T) {
+	got := scopesForRole(ipc.HelperRoleAssist, ipc.HelperBinaryAssistHelper, "darwin", "/x")
+	if len(got) != 1 || got[0] != "assist" {
+		t.Fatalf("scopesForRole(assist) = %v, want [assist]", got)
+	}
+}
+```
+
+> Note: this task extracts the inline `switch helperRole` (`broker.go:1359-1375`) into a testable `scopesForRole(role, binaryKind, goos, peerPath string) []string` helper, and adds the assist case. The desktop-on-darwin special case stays inside the helper.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd agent && go test ./internal/sessionbroker/ -run 'TestAssistScopes|TestScopesForRoleAssist' -v`
+Expected: FAIL — `undefined: assistHelperScopes` / `undefined: scopesForRole`
+
+- [ ] **Step 3: Implement**
+
+In `broker.go`, add the scope set near `:209-213`:
+```go
+	systemHelperScopes   = []string{"notify", "tray", "clipboard", "desktop"}
+	userHelperScopes     = []string{"notify", "clipboard", "run_as_user"}
+	watchdogHelperScopes = []string{"watchdog"}
+	assistHelperScopes   = []string{"assist"}
+```
+Add `HelperRoleAssist` to the valid-role switch (`:1279`):
+```go
+	case ipc.HelperRoleSystem, ipc.HelperRoleUser, ipc.HelperRoleWatchdog, ipc.HelperRoleAssist, backupipc.HelperRoleBackup:
+```
+Add role/identity validation. In the Windows block (after the user-role check, ~`:1319`):
+```go
+		if helperRole == ipc.HelperRoleAssist && creds.SID == systemSID {
+			log.Warn("role/identity mismatch: SYSTEM process claiming assist role",
+				"sid", creds.SID, "pid", creds.PID)
+			_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
+				Accepted:  false,
+				Reason:    "assist role requires non-SYSTEM identity",
+				Permanent: true,
+			})
+			conn.Close()
+			return
+		}
+```
+(No unix identity restriction beyond the existing watchdog/system root checks — the assist helper runs as the logged-in user, mirroring user-role.)
+
+Extract and extend the scope assignment. Replace the inline `switch helperRole { ... }` at `:1359-1375` with:
+```go
+	scopes := scopesForRole(helperRole, authReq.BinaryKind, runtime.GOOS, creds.BinaryPath)
+```
+And add the helper method (place near the scope vars or at file end):
+```go
+// scopesForRole maps a validated helper role to its allowed scopes.
+func (b *Broker) scopesForRole(role, binaryKind, goos, peerPath string) []string {
+	switch role {
+	case ipc.HelperRoleUser:
+		if goos == "darwin" &&
+			binaryKind == ipc.HelperBinaryDesktopHelper &&
+			b.isDesktopHelperPeerPath(peerPath) {
+			return []string{"desktop"}
+		}
+		return userHelperScopes
+	case backupipc.HelperRoleBackup:
+		return backupHelperScopes
+	case ipc.HelperRoleWatchdog:
+		return watchdogHelperScopes
+	case ipc.HelperRoleAssist:
+		return assistHelperScopes
+	case ipc.HelperRoleSystem:
+		return systemHelperScopes
+	}
+	return nil
+}
+```
+Adjust the test in Step 1 to call `(&Broker{}).scopesForRole(...)` if `scopesForRole` is a method (the desktop branch needs `b.isDesktopHelperPeerPath`, so it must be a method; update the test to construct a `&Broker{}` and call the method, or test via a zero-value broker — `isDesktopHelperPeerPath` on a zero broker must be safe; if it isn't, keep `scopesForRole` taking the path and only call `isDesktopHelperPeerPath` for the darwin desktop case which the assist test doesn't hit).
+
+> Implementation note for the worker: verify `isDesktopHelperPeerPath` is safe on a zero-value `*Broker` (the assist/user non-darwin tests don't reach it). If not, the test should use a properly constructed broker via the package's existing test helper.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd agent && go test -race ./internal/sessionbroker/ -run 'TestAssistScopes|TestScopesForRoleAssist' -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full package to catch the refactor**
+
+Run: `cd agent && go test -race ./internal/sessionbroker/`
+Expected: PASS (the extracted helper must preserve existing behavior)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add agent/internal/sessionbroker/broker.go agent/internal/sessionbroker/broker_test.go
+git commit -m "feat(agent/broker): admit assist role with assist-only scope + non-SYSTEM identity check"
+```
+
+---
+
+### Task 3: Allowlist the Breeze Helper binary hash
+
+**Files:**
+- Modify: `agent/internal/sessionbroker/broker.go` (trusted-path computation near `:1648-1696`, `allowedHelperPaths`, `RefreshAllowedHashes`)
+- Test: `agent/internal/sessionbroker/broker_test.go`
+
+- [ ] **Step 1: Identify the trusted-path function**
+
+Run: `cd agent && grep -n "breeze-watchdog\|allowedHelperPaths\|trustedHelperPaths\|RefreshAllowedHashes\|helper.DefaultBinaryPath" internal/sessionbroker/broker.go`
+Expected: a function that assembles candidate helper binary paths (watchdog + userhelper, derived from the agent exe dir). Read it.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `broker_test.go`:
+```go
+func TestTrustedHelperPathsIncludeAssistHelper(t *testing.T) {
+	paths := trustedHelperBinaryPaths("/opt/breeze/breeze-agent") // adjust to actual fn name/signature
+	found := false
+	for _, p := range paths {
+		base := filepath.Base(p)
+		if base == "breeze-helper" || base == "breeze-helper.exe" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("trusted helper paths %v missing breeze-helper", paths)
+	}
+}
+```
+(Rename to match the real function discovered in Step 1; if the function is unexported and computes from `os.Executable()`, refactor it to take the agent-dir as a parameter so it's testable, and have the production caller pass `filepath.Dir(exe)`.)
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd agent && go test ./internal/sessionbroker/ -run TestTrustedHelperPathsIncludeAssistHelper -v`
+Expected: FAIL — assist helper not in trusted paths.
+
+- [ ] **Step 4: Implement**
+
+Add the Helper binary to the trusted-path list (mirror the existing watchdog entries discovered in Step 1). On Windows the Helper installs as `breeze-helper.exe`; on macOS the executable lives inside the `.app` bundle. Add a resolver:
+```go
+// assistHelperBinaryPaths returns candidate install paths for the Breeze Assist
+// helper, derived from the agent install dir. Used so RefreshAllowedHashes
+// allowlists the genuine breeze-helper binary's SHA-256.
+func assistHelperBinaryPaths(agentDir string) []string {
+	switch runtime.GOOS {
+	case "windows":
+		return []string{filepath.Join(agentDir, "breeze-helper.exe")}
+	case "darwin":
+		// Helper ships as a .app; executable is inside Contents/MacOS.
+		return []string{
+			"/Applications/Breeze Helper.app/Contents/MacOS/breeze-helper",
+			filepath.Join(agentDir, "breeze-helper"),
+		}
+	default:
+		return []string{filepath.Join(agentDir, "breeze-helper")}
+	}
+}
+```
+Wire these into the trusted-path assembly used by `RefreshAllowedHashes` (the function from Step 1). Non-existent paths must be skipped silently (the existing hash loader already tolerates missing files — verify it `continue`s on `os.Open` error rather than failing the whole refresh).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd agent && go test -race ./internal/sessionbroker/ -run TestTrustedHelperPathsIncludeAssistHelper -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add agent/internal/sessionbroker/broker.go agent/internal/sessionbroker/broker_test.go
+git commit -m "feat(agent/broker): allowlist breeze-helper binary hash for assist IPC"
+```
+
+---
+
+### Task 4: `SessionAuthenticatedHandler` hook on the broker
+
+**Files:**
+- Modify: `agent/internal/sessionbroker/broker.go` (types near `:216-221`; field near `:264`; setter near `:331`; invoke after registration near `:1426-1450`)
+- Test: `agent/internal/sessionbroker/broker_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestSetSessionAuthenticatedHandler(t *testing.T) {
+	b := New("/tmp/does-not-matter.sock", func(*Session, *ipc.Envelope) {})
+	var got *Session
+	b.SetSessionAuthenticatedHandler(func(s *Session) { got = s })
+	sess := &Session{} // minimal
+	b.fireSessionAuthenticated(sess)
+	if got != sess {
+		t.Fatalf("handler not invoked with the session")
+	}
+	// Nil handler must be a no-op (no panic).
+	b2 := New("/tmp/x.sock", func(*Session, *ipc.Envelope) {})
+	b2.fireSessionAuthenticated(&Session{})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd agent && go test ./internal/sessionbroker/ -run TestSetSessionAuthenticatedHandler -v`
+Expected: FAIL — undefined `SetSessionAuthenticatedHandler` / `fireSessionAuthenticated`
+
+- [ ] **Step 3: Implement**
+
+Add the type near `:220`:
+```go
+// SessionAuthenticatedHandler is called after a helper session has been
+// successfully authenticated and registered.
+type SessionAuthenticatedHandler func(session *Session)
+```
+Add the field to `Broker struct` near `:265`:
+```go
+	onSessionAuthed SessionAuthenticatedHandler
+```
+Add the setter near `:331`:
+```go
+func (b *Broker) SetSessionAuthenticatedHandler(handler SessionAuthenticatedHandler) {
+	b.mu.Lock()
+	b.onSessionAuthed = handler
+	b.mu.Unlock()
+}
+
+// fireSessionAuthenticated invokes the on-authenticated handler if set.
+func (b *Broker) fireSessionAuthenticated(session *Session) {
+	b.mu.RLock()
+	handler := b.onSessionAuthed
+	b.mu.RUnlock()
+	if handler != nil {
+		handler(session)
+	}
+}
+```
+Invoke it after the session is fully registered (after the successful `tryAdmitLocked` append and unlock, where `registerOnClosed` is handled around `:1447`). Place the call OUTSIDE the broker mutex to avoid re-entrancy, and run it in a goroutine so a slow handler can't block the accept loop:
+```go
+	go b.fireSessionAuthenticated(session)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd agent && go test -race ./internal/sessionbroker/ -run TestSetSessionAuthenticatedHandler -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/internal/sessionbroker/broker.go agent/internal/sessionbroker/broker_test.go
+git commit -m "feat(agent/broker): add SessionAuthenticatedHandler hook"
+```
+
+---
+
+### Task 5: Heartbeat pushes the helper token on connect + rotation
+
+**Files:**
+- Modify: `agent/internal/heartbeat/heartbeat.go` (broker wiring `:408-409`; rotation `:2410-2433`; new methods near `:2462`)
+- Test: `agent/internal/heartbeat/heartbeat_token_test.go` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+The push methods are thin wrappers over `Session.SendNotify`. Test the routing decision (assist scope → push; other scope → skip) via a small extracted pure helper so we don't need a live socket:
+```go
+package heartbeat
+
+import (
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
+)
+
+func TestShouldPushHelperToken(t *testing.T) {
+	if !shouldPushHelperToken([]string{"assist"}) {
+		t.Fatal("assist scope should receive helper token")
+	}
+	if shouldPushHelperToken([]string{"watchdog"}) {
+		t.Fatal("watchdog scope must NOT receive helper token")
+	}
+	if shouldPushHelperToken([]string{"notify", "clipboard", "run_as_user"}) {
+		t.Fatal("user scope must NOT receive helper token")
+	}
+	if shouldPushHelperToken(nil) {
+		t.Fatal("no scopes must NOT receive helper token")
+	}
+	_ = ipc.TypeHelperTokenUpdate // ensure import used
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd agent && go test ./internal/heartbeat/ -run TestShouldPushHelperToken -v`
+Expected: FAIL — `undefined: shouldPushHelperToken`
+
+- [ ] **Step 3: Implement the helper + push methods**
+
+Add a retained helper-token field. Find the `Heartbeat struct` and add:
+```go
+	helperToken   string
+	helperTokenMu sync.RWMutex
+```
+Add a setter used at startup and on rotation:
+```go
+func (h *Heartbeat) setHelperToken(token string) {
+	h.helperTokenMu.Lock()
+	h.helperToken = token
+	h.helperTokenMu.Unlock()
+}
+
+func (h *Heartbeat) currentHelperToken() string {
+	h.helperTokenMu.RLock()
+	defer h.helperTokenMu.RUnlock()
+	return h.helperToken
+}
+```
+Populate it at startup where the heartbeat is constructed/started from config (search for where `h.config` is first available — set `h.setHelperToken(h.config.HelperAuthToken)` there). This guarantees the connect-time push has the token even though `config.HelperAuthToken` is cleared post-persist on rotation (`heartbeat.go:2423`).
+
+Add the routing helper and push methods near `sendWatchdogTokenUpdate` (`:2462`):
+```go
+// shouldPushHelperToken reports whether a session with the given scopes should
+// receive the helper token. Only assist-scope sessions qualify; this guards
+// against ever sending the helper token to the watchdog or a user helper.
+func shouldPushHelperToken(scopes []string) bool {
+	for _, s := range scopes {
+		if s == "assist" {
+			return true
+		}
+	}
+	return false
+}
+
+// handleHelperSessionAuthenticated is wired as the broker's
+// SessionAuthenticatedHandler. It pushes the current helper token to a freshly
+// authenticated assist session.
+func (h *Heartbeat) handleHelperSessionAuthenticated(session *sessionbroker.Session) {
+	if session == nil || !shouldPushHelperToken(session.Scopes()) {
+		return
+	}
+	token := h.currentHelperToken()
+	if token == "" {
+		return
+	}
+	if err := session.SendNotify("", ipc.TypeHelperTokenUpdate, ipc.HelperTokenUpdate{Token: token}); err != nil {
+		log.Warn("failed to push helper token to assist session", "error", err.Error())
+	}
+}
+
+// sendHelperTokenUpdate pushes a (possibly rotated) helper token to all
+// connected assist sessions.
+func (h *Heartbeat) sendHelperTokenUpdate(newToken string) {
+	if h.sessionBroker == nil || newToken == "" {
+		return
+	}
+	for _, sess := range h.sessionBroker.SessionsWithScope("assist") {
+		if err := sess.SendNotify("", ipc.TypeHelperTokenUpdate, ipc.HelperTokenUpdate{Token: newToken}); err != nil {
+			log.Warn("failed to push rotated helper token", "error", err.Error())
+		}
+	}
+}
+```
+(Confirm `Session.Scopes()` exists; if scopes are an exported field `session.Scopes`, use that. If neither, add a `func (s *Session) Scopes() []string { return s.scopes }` accessor in `broker.go`.)
+
+Wire the on-auth handler next to the closed handler at `:408-409`:
+```go
+		h.sessionBroker = sessionbroker.New(socketPath, h.handleUserHelperMessage)
+		h.sessionBroker.SetSessionClosedHandler(h.handleHelperSessionClosed)
+		h.sessionBroker.SetSessionAuthenticatedHandler(h.handleHelperSessionAuthenticated)
+```
+Wire the rotation push. At `:2419-2433`, after `h.config.HelperAuthToken = rotateResp.HelperAuthToken` and before it's cleared, also retain + push:
+```go
+	h.config.HelperAuthToken = rotateResp.HelperAuthToken
+	h.setHelperToken(rotateResp.HelperAuthToken) // retain for connect-time pushes
+	// ... existing persist + clear ...
+	h.sendWatchdogTokenUpdate(rotateResp.WatchdogAuthToken)
+	h.sendHelperTokenUpdate(rotateResp.HelperAuthToken)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd agent && go test -race ./internal/heartbeat/ -run TestShouldPushHelperToken -v`
+Expected: PASS
+
+- [ ] **Step 5: Build the whole agent**
+
+Run: `cd agent && go build ./... && go test -race ./internal/ipc/... ./internal/sessionbroker/... ./internal/heartbeat/...`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add agent/internal/heartbeat/heartbeat.go agent/internal/heartbeat/heartbeat_token_test.go agent/internal/sessionbroker/broker.go
+git commit -m "feat(agent/heartbeat): push helper token to assist sessions on connect + rotation"
+```
+
+---
+
+# Part B — Rust Helper IPC client (Phase 1b)
+
+### Task 6: Add Rust dependencies
+
+**Files:**
+- Modify: `apps/helper/src-tauri/Cargo.toml`
+
+- [ ] **Step 1: Add deps**
+
+Under `[dependencies]`, extend `tokio` features and add crypto/encoding/identity deps:
+```toml
+tokio = { version = "1", features = ["sync", "net", "io-util", "time", "rt", "macros"] }
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
+rand = "0.8"
+```
+Add Windows-only identity/pipe support:
+```toml
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.58", features = [
+  "Win32_Foundation",
+  "Win32_Security",
+  "Win32_System_Threading",
+] }
+```
+(`tokio` already provides `tokio::net::windows::named_pipe` with the `net` feature on Windows, and `tokio::net::UnixStream` on unix.)
+
+- [ ] **Step 2: Verify it builds**
+
+Run: `cd apps/helper/src-tauri && cargo build`
+Expected: builds (deps resolve).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/helper/src-tauri/Cargo.toml apps/helper/src-tauri/Cargo.lock
+git commit -m "build(helper): add tokio net + hmac/sha2/hex deps for IPC client"
+```
+
+---
+
+### Task 7: Envelope framing + HMAC (the wire protocol)
+
+**Files:**
+- Create: `apps/helper/src-tauri/src/ipc/mod.rs`
+- Create: `apps/helper/src-tauri/src/ipc/envelope.rs`
+- Modify: `apps/helper/src-tauri/src/lib.rs` (add `mod ipc;`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/helper/src-tauri/src/ipc/envelope.rs` with the struct + a test module. The test pins the HMAC to a value computed by the Go implementation’s formula (`HMAC-SHA256(key, ID || decimal(Seq) || Type || Payload)`, zero-key = 32 zero bytes, nil payload = bytes `null`):
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hmac_matches_go_formula_zero_key() {
+        // Envelope{ID:"auth", Seq:1, Type:"auth_request", Payload: {"a":1}}
+        let payload = serde_json::to_vec(&serde_json::json!({"a":1})).unwrap();
+        let mac = compute_hmac(&[0u8; 32], "auth", 1, "auth_request", &payload);
+        // Expected value produced by the Go reference (see plan Step 3 to regenerate).
+        assert_eq!(mac, GO_FIXTURE_HMAC_AUTH);
+    }
+
+    #[test]
+    fn nil_payload_hmacs_as_literal_null() {
+        let with_null = compute_hmac(&[0u8; 32], "x", 2, "ping", b"null");
+        let with_none = compute_hmac_opt(&[0u8; 32], "x", 2, "ping", None);
+        assert_eq!(with_null, with_none);
+    }
+
+    #[test]
+    fn frame_round_trip() {
+        let env = Envelope {
+            id: "id1".into(), seq: 0, typ: "ping".into(),
+            payload: None, error: String::new(), hmac: String::new(),
+        };
+        let bytes = encode_frame(&[0u8;32], env.clone(), 5).unwrap();
+        // [4-byte BE len][json]; len matches remainder.
+        let len = u32::from_be_bytes(bytes[0..4].try_into().unwrap()) as usize;
+        assert_eq!(len, bytes.len() - 4);
+    }
+}
+```
+
+Generate `GO_FIXTURE_HMAC_AUTH` once (Step 3) and paste it as a `const`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/helper/src-tauri && cargo test ipc::envelope`
+Expected: FAIL — module/functions not defined.
+
+- [ ] **Step 3: Generate the Go HMAC fixture, then implement**
+
+Generate the reference value (one-off):
+```bash
+cd /Users/toddhebebrand/breeze/agent
+cat > /tmp/hmacgen.go <<'EOF'
+package main
+import ("crypto/hmac";"crypto/sha256";"encoding/hex";"fmt")
+func main(){
+  key := make([]byte,32)
+  mac := hmac.New(sha256.New, key)
+  mac.Write([]byte("auth")); mac.Write([]byte("1")); mac.Write([]byte("auth_request")); mac.Write([]byte(`{"a":1}`))
+  fmt.Println(hex.EncodeToString(mac.Sum(nil)))
+}
+EOF
+go run /tmp/hmacgen.go   # paste output into GO_FIXTURE_HMAC_AUTH
+```
+
+Implement `envelope.rs`:
+```rust
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+pub const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
+pub const PROTOCOL_VERSION: i32 = 1;
+
+#[cfg(test)]
+pub const GO_FIXTURE_HMAC_AUTH: &str = "PASTE_FROM_STEP_3";
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Envelope {
+    #[serde(rename = "ID")] pub id: String,
+    #[serde(rename = "Seq")] pub seq: u64,
+    #[serde(rename = "Type")] pub typ: String,
+    #[serde(rename = "Payload", skip_serializing_if = "Option::is_none")]
+    pub payload: Option<serde_json::value::RawValue_OR_Vec>, // see note
+    #[serde(rename = "Error", default)] pub error: String,
+    #[serde(rename = "HMAC", default)] pub hmac: String,
+}
+```
+> **Payload encoding note:** Go marshals `Payload json.RawMessage` (raw JSON bytes) and HMACs those exact bytes. In Rust, model `payload` as `Option<Box<serde_json::value::RawValue>>` for *parsing* inbound, but for HMAC use the raw bytes. Simplest correct approach: keep an internal representation where outbound payloads are pre-serialized to `Vec<u8>` and inbound payloads are captured as raw bytes via `serde_json::value::RawValue`. The field names MUST serialize exactly as Go (`ID/Seq/Type/Payload/Error/HMAC` — Go uses exported field names, no json tags, so keys are the Go field names). Verify against a captured Go frame in Task 9 integration.
+
+Implement HMAC + framing:
+```rust
+type HmacSha256 = Hmac<Sha256>;
+
+pub fn compute_hmac(key: &[u8], id: &str, seq: u64, typ: &str, payload: &[u8]) -> String {
+    let mut mac = HmacSha256::new_from_slice(key).expect("hmac key");
+    mac.update(id.as_bytes());
+    mac.update(seq.to_string().as_bytes());
+    mac.update(typ.as_bytes());
+    mac.update(payload);
+    hex::encode(mac.finalize().into_bytes())
+}
+
+pub fn compute_hmac_opt(key: &[u8], id: &str, seq: u64, typ: &str, payload: Option<&[u8]>) -> String {
+    compute_hmac(key, id, seq, typ, payload.unwrap_or(b"null"))
+}
+```
+`encode_frame` assigns the seq, computes HMAC over the exact payload bytes, serializes the envelope, and prepends the 4-byte BE length. `decode_frame`/`read_frame` reads 4-byte len, bounds-checks `<= MAX_MESSAGE_SIZE` and `!= 0`, reads the body, parses the envelope, recomputes + constant-compares the HMAC, and enforces strictly-increasing recv seq. Provide `async fn read_frame<R: AsyncReadExt+Unpin>` and `async fn write_frame<W: AsyncWriteExt+Unpin>`.
+
+Create `mod.rs`:
+```rust
+pub mod envelope;
+pub mod transport;
+pub mod client;
+pub mod token;
+```
+(Comment out `transport/client/token` until their tasks land, or create empty stubs now.)
+
+Add `mod ipc;` near the top of `lib.rs`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/helper/src-tauri && cargo test ipc::envelope`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/helper/src-tauri/src/ipc/ apps/helper/src-tauri/src/lib.rs
+git commit -m "feat(helper/ipc): envelope framing + Go-compatible HMAC"
+```
+
+---
+
+### Task 8: Shared in-memory token cell
+
+**Files:**
+- Create: `apps/helper/src-tauri/src/ipc/token.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[tokio::test]
+    async fn set_and_get() {
+        let cell = HelperToken::new();
+        assert_eq!(cell.get().await, None);
+        cell.set("brz_a".into()).await;
+        assert_eq!(cell.get().await.as_deref(), Some("brz_a"));
+        cell.set("brz_b".into()).await;
+        assert_eq!(cell.get().await.as_deref(), Some("brz_b"));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/helper/src-tauri && cargo test ipc::token`
+Expected: FAIL — undefined.
+
+- [ ] **Step 3: Implement**
+
+```rust
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// In-memory, updatable helper token. Never persisted to disk.
+#[derive(Clone, Default)]
+pub struct HelperToken {
+    inner: Arc<RwLock<Option<String>>>,
+}
+
+impl HelperToken {
+    pub fn new() -> Self { Self::default() }
+    pub async fn set(&self, token: String) {
+        *self.inner.write().await = Some(token);
+    }
+    pub async fn get(&self) -> Option<String> {
+        self.inner.read().await.clone()
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/helper/src-tauri && cargo test ipc::token`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/helper/src-tauri/src/ipc/token.rs
+git commit -m "feat(helper/ipc): in-memory helper token cell"
+```
+
+---
+
+### Task 9: Transport + identity (platform connect)
+
+**Files:**
+- Create: `apps/helper/src-tauri/src/ipc/transport.rs`
+
+- [ ] **Step 1: Implement transport (no unit test — exercised by Task 10 integration)**
+
+`transport.rs` exposes:
+```rust
+pub fn default_socket_path() -> String {
+    #[cfg(windows)] { r"\\.\pipe\breeze-agent-ipc".to_string() }
+    #[cfg(target_os = "macos")] { "/Library/Application Support/Breeze/agent.sock".to_string() }
+    #[cfg(all(unix, not(target_os = "macos")))] { "/var/run/breeze/agent.sock".to_string() }
+}
+
+pub struct PeerIdentity { pub uid: u32, pub sid: String, pub username: String }
+
+pub fn current_identity() -> Result<PeerIdentity, String> { /* see below */ }
+```
+- **unix:** `uid = unsafe { libc::getuid() }` (add `libc` dep) or read from `whoami`; `username = whoami::username()`; `sid = String::new()`.
+- **windows:** username via `whoami::username()`; SID via the `windows` crate — `OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY)` → `GetTokenInformation(TokenUser)` → `ConvertSidToStringSidW`. Return the `S-1-5-...` string. The broker requires `auth_request.SID == kernel SID` on Windows (`broker.go:1145`), so this must be the process's real token SID.
+
+Connect helpers:
+```rust
+#[cfg(windows)]
+pub async fn connect(path: &str) -> std::io::Result<tokio::net::windows::named_pipe::NamedPipeClient> {
+    tokio::net::windows::named_pipe::ClientOptions::new().open(path)
+}
+#[cfg(unix)]
+pub async fn connect(path: &str) -> std::io::Result<tokio::net::UnixStream> {
+    tokio::net::UnixStream::connect(path).await
+}
+```
+Compute the self-hash (best-effort; not security-load-bearing — broker recomputes from kernel path) and report `pid = std::process::id()`.
+
+- [ ] **Step 2: Verify it builds on this platform**
+
+Run: `cd apps/helper/src-tauri && cargo build`
+Expected: builds (macOS dev: unix path compiles; Windows path is `cfg`-gated).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/helper/src-tauri/src/ipc/transport.rs apps/helper/src-tauri/Cargo.toml
+git commit -m "feat(helper/ipc): platform transport + peer identity"
+```
+
+---
+
+### Task 10: Client handshake + receive loop + reconnect
+
+**Files:**
+- Create: `apps/helper/src-tauri/src/ipc/client.rs`
+
+- [ ] **Step 1: Implement the client**
+
+Model on `agent/internal/userhelper/client.go:178-290`. `client.rs` exposes:
+```rust
+pub async fn run(token: crate::ipc::token::HelperToken, stop: tokio::sync::watch::Receiver<bool>);
+```
+`run` loops with bounded exponential backoff (1s → 30s cap). Each iteration:
+1. `connect(default_socket_path())`. On error: log, back off, retry.
+2. Build `Envelope` for `auth_request` with `HelperTokenUpdate`-irrelevant `AuthRequest` payload:
+   ```rust
+   let id = current_identity()?;
+   let auth = serde_json::json!({
+     "protocolVersion": PROTOCOL_VERSION,
+     "uid": id.uid, "sid": id.sid, "username": id.username,
+     "sessionId": format!("assist-{}-{}", id.username, std::process::id()),
+     "displayEnv": "", "pid": std::process::id(),
+     "binaryHash": self_hash, "winSessionId": 0,
+     "helperRole": "assist", "binaryKind": "assist_helper",
+   });
+   ```
+   Write it as a frame with the **zero key**, seq starting at 1.
+3. Read the response frame (zero key for HMAC verify of `auth_response`). If `Type == "pre_auth_reject"`: parse; if `permanent`, log a clear message and **stop** (don't retry — the binary isn't allowlisted); else back off. If `Type == "auth_response"` and `accepted == false`: same permanent/transient handling. If accepted: `hex::decode(sessionKey)` → switch the connection’s HMAC key to the session key for all subsequent frames.
+4. Receive loop: for each inbound frame (verified with the session key), match `Type`:
+   - `"helper_token_update"`: parse `{token}`, `token_cell.set(token).await`, log "helper token received via IPC" (NEVER log the token value).
+   - `"ping"`: reply `pong` with same `ID`.
+   - `"disconnect"`: break to reconnect.
+   - else: ignore (assist helper handles nothing else).
+   Use a read deadline / `tokio::select!` against `stop` so shutdown is prompt.
+5. On any I/O error: log, break inner loop, back off, reconnect (resetting seq counters and key to zero key).
+
+Constant-time token handling: hold the token only in `HelperToken`. Do not write it to any file or log.
+
+- [ ] **Step 2: Build**
+
+Run: `cd apps/helper/src-tauri && cargo build`
+Expected: builds.
+
+- [ ] **Step 3: Manual integration smoke (documented, run later on a real agent box)**
+
+On a machine with the agent running (Windows VM or a mac with the daemon), launch the Helper and confirm the agent log shows an accepted `assist` session and the Helper log shows "helper token received via IPC". Capture one real Go→Rust frame and confirm envelope field names parse (validates the `ID/Seq/Type/Payload/Error/HMAC` key casing from Task 7). Record the result here.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/helper/src-tauri/src/ipc/client.rs
+git commit -m "feat(helper/ipc): auth handshake, token receipt, reconnect loop"
+```
+
+---
+
+### Task 11: Wire the token cell into `helper_fetch` (Phase 1: IPC-first, file fallback)
+
+**Files:**
+- Modify: `apps/helper/src-tauri/src/lib.rs` (`HttpClientState`, `ensure_http_state`, `helper_fetch` token read `:577-616`; app setup/run to spawn the IPC client)
+
+- [ ] **Step 1: Add the token cell to shared state and spawn the client**
+
+In `lib.rs`:
+- Add a `static HELPER_TOKEN: OnceLock<crate::ipc::token::HelperToken>` and an accessor `fn helper_token() -> &'static HelperToken`.
+- In the Tauri `setup` (where the app starts; search for `.setup(` / `tauri::Builder`), spawn the IPC client:
+  ```rust
+  let token = helper_token().clone();
+  let (_tx, rx) = tokio::sync::watch::channel(false);
+  tauri::async_runtime::spawn(crate::ipc::client::run(token, rx));
+  ```
+  (Persist `_tx` in app state if you want to signal shutdown; otherwise the task ends with the process.)
+
+- [ ] **Step 2: Make `helper_fetch` prefer the IPC token, fall back to file (Phase 1)**
+
+Replace the token read in `helper_fetch` (`:577-590` region) so it uses the in-memory IPC token when present, else the file-loaded `state.config.token`:
+```rust
+    let ipc_token = helper_token().get().await;
+    let (client, file_token, api_url) = {
+        let lock = get_http_state_lock();
+        let guard = lock.lock().await;
+        let state = guard.as_ref().ok_or_else(|| "HTTP state not initialized".to_string())?;
+        (state.client.clone(), state.config.token.clone(), state.config.api_url.clone())
+    };
+    let token = ipc_token.unwrap_or(file_token); // Phase 1: file fallback
+```
+> **Phase 1 only.** Phase 2 (Task 14) removes `file_token`/the file read entirely.
+
+> **Bootstrapping note:** `ensure_http_state()` still calls `load_agent_config_full()`, which today *requires* the token from the file (`lib.rs:127-130`). In Phase 1 the file still has the token, so this is fine. In Phase 2, `load_agent_config_full` must no longer require the token (it still needs `server_url`/`agent_id`/mTLS) — handled in Task 14.
+
+- [ ] **Step 3: Build + existing tests**
+
+Run: `cd apps/helper/src-tauri && cargo build && cargo test`
+Expected: builds; existing tests (including the "never falls back to the full agent token" test around `lib.rs:997-1008`) still pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/helper/src-tauri/src/lib.rs
+git commit -m "feat(helper): use IPC-delivered token in helper_fetch (Phase 1, file fallback retained)"
+```
+
+---
+
+### Task 12: "Connecting to agent" UI state
+
+**Files:**
+- Modify: `apps/helper/src/stores/chatStore.ts` and/or `apps/helper/src/App.tsx`
+- Modify: `apps/helper/src-tauri/src/lib.rs` (expose a `helper_token_ready` query command)
+
+- [ ] **Step 1: Add a Tauri command reporting token readiness**
+
+```rust
+#[tauri::command]
+async fn helper_token_ready() -> bool {
+    helper_token().get().await.is_some()
+}
+```
+Register it in the `generate_handler![]` list.
+
+- [ ] **Step 2: Gate the chat UI on readiness**
+
+In the frontend, before the first `helper_fetch`, poll `invoke('helper_token_ready')` (or attempt the call and treat the "still setting up" error as a connecting state). Show a lightweight "Connecting to the Breeze agent…" state until ready, then proceed. Keep this minimal — it mirrors the existing error-state handling already present for missing config.
+
+- [ ] **Step 3: Build the frontend**
+
+Run: `cd apps/helper && pnpm build` (or the repo’s helper build script)
+Expected: builds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/helper/src apps/helper/src-tauri/src/lib.rs
+git commit -m "feat(helper/ui): show connecting state until IPC token arrives"
+```
+
+---
+
+### Task 13: Phase-1 end-to-end verification on a real agent
+
+**Files:** none (verification)
+
+- [ ] **Step 1: Windows VM smoke (per windows_test_vm memory)**
+
+Build the agent + Helper, install on the Windows test VM (`100.101.150.55`), and confirm:
+- Agent log: assist session accepted (role=assist, scope=[assist]); a non-allowlisted binary connecting is rejected with `binary hash mismatch`.
+- Helper log: "helper token received via IPC"; chat works.
+- With the agent stopped, the Helper falls back to the file token (Phase 1) and still works; restart agent → IPC path resumes.
+Record results here.
+
+- [ ] **Step 2: macOS smoke**
+
+Same on a mac with the daemon (unix socket path). Confirm assist session accepted and token received.
+
+- [ ] **Step 3: Commit the verification record**
+
+```bash
+git add docs/superpowers/plans/2026-05-29-helper-ipc-token-delivery.md
+git commit -m "docs: record Phase 1 e2e verification results"
+```
+
+---
+
+# Part C — Phase 2 (separate, gated release — DO NOT ship with Phase 1)
+
+> Ship only after adoption telemetry shows agents AND Helpers are upgraded. Tracked separately per the spec.
+
+### Task 14: Stop writing the token to agent.yaml; remove file fallback
+
+**Files:**
+- Modify: `agent/internal/config/config.go` (`SaveTo` `:396-400`; `stripSecretsFromAgentConfig` `:484-503`; `isSecretConfigKey` `:565-571`)
+- Test: `agent/internal/config/config_test.go`
+- Modify: `apps/helper/src-tauri/src/lib.rs` (`helper_token_from_config`, `load_agent_config_full`, `helper_fetch`)
+
+- [ ] **Step 1 (Go): failing test that agent.yaml has no helper token**
+
+```go
+func TestSaveToOmitsHelperTokenFromAgentYAML(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yaml")
+	cfg := &Config{ServerURL: "https://x", AgentID: "a", HelperAuthToken: "brz_helper", AuthToken: "brz_agent"}
+	if err := SaveTo(cfg, cfgPath); err != nil { t.Fatal(err) }
+	body, _ := os.ReadFile(cfgPath)
+	if strings.Contains(string(body), "brz_helper") || strings.Contains(string(body), "helper_auth_token") {
+		t.Fatalf("agent.yaml must not contain the helper token:\n%s", body)
+	}
+	secrets, _ := os.ReadFile(filepath.Join(dir, "secrets.yaml"))
+	if !strings.Contains(string(secrets), "brz_helper") {
+		t.Fatalf("secrets.yaml must still contain the helper token")
+	}
+}
+```
+
+- [ ] **Step 2:** Run → FAIL (today the token is written to agent.yaml).
+
+- [ ] **Step 3 (Go):** Remove the `viper.Set("helper_auth_token", ...)` block at `SaveTo:398-400`; add `helper_auth_token` to `stripSecretsFromAgentConfig` and `isSecretConfigKey`. Keep the `sv.Set("helper_auth_token", ...)` write to secrets.yaml (`:460-461`).
+
+- [ ] **Step 4:** Run → PASS. Also `go test -race ./internal/config/...`.
+
+- [ ] **Step 5 (Rust):** Remove the `agent.yaml` branch from `helper_token_from_config` (read from secrets.yaml only, or delete the fn); make `load_agent_config_full` no longer require a token (still require `server_url`/`agent_id`); remove the `file_token` fallback in `helper_fetch` (use `helper_token().get().await.ok_or("Connecting to the Breeze agent…")?`). Update the `:997-1008` test as needed.
+
+- [ ] **Step 6:** `cargo build && cargo test`; agent `go build ./...`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add agent/internal/config/ apps/helper/src-tauri/src/lib.rs
+git commit -m "feat(security): stop persisting helper token to agent.yaml; IPC-only (Phase 2, closes HIGH-1)"
+```
+
+---
+
+## Self-review notes (coverage vs. spec)
+
+- Spec §1 (role/scope/message separation) → Tasks 1, 2, 5 (`shouldPushHelperToken` + scope gating + distinct message type).
+- Spec §2 (binary trust) → Task 3.
+- Spec §3 (Rust client) → Tasks 6–11.
+- Spec §4 (two-phase rollout) → Phase 1 = Tasks 1–13 (agent still writes file; Helper IPC-first with fallback); Phase 2 = Task 14.
+- Spec §5 (data flow) → Tasks 4 (connect push) + 5 (rotation push) + 10/11 (receipt + use).
+- Spec "Error handling" → Task 10 (pre_auth_reject permanent/transient, HMAC drop+reconnect, 401→reconnect can be added in Task 11 if desired).
+- Spec "Testing" → Go: Tasks 1,2,3,4,5,14; Rust: Tasks 7,8,11; e2e: Task 13.
+
+**Known follow-ups (out of scope, noted in spec):** helper-token org-scope reduction and out-of-band approval for destructive Helper tools; Phase-2 adoption-telemetry threshold definition.
+```

--- a/docs/superpowers/specs/2026-05-29-helper-ipc-token-delivery-design.md
+++ b/docs/superpowers/specs/2026-05-29-helper-ipc-token-delivery-design.md
@@ -1,0 +1,272 @@
+# Helper IPC Token Delivery — Design
+
+**Date:** 2026-05-29
+**Status:** Design — pending implementation plan
+**Author:** Todd Hebebrand (with Claude)
+**Related:** Security review finding HIGH-1 (helper token in world-readable `agent.yaml`)
+
+## Problem
+
+The Breeze Assist Helper (Tauri desktop app, `apps/helper/`) authenticates to the
+`/helper/*` API routes with a per-device `helper_auth_token`. Today the Go agent
+persists that token into `agent.yaml`, and the Helper reads it directly off disk
+(`apps/helper/src-tauri/src/lib.rs:79-130`).
+
+Commit `9968f3f4` (branch `fix/helper-config-readable-perms`) widened `agent.yaml`
+from `0640` to `0644` so the Helper — which runs as the **logged-in user**, not
+root/SYSTEM — can read it. The side effect: `helper_auth_token` is now readable by
+**every local user**, not just the agent's group.
+
+The token is not low-value. Server-side (`apps/api/src/routes/helper/index.ts:64-174`)
+it mints an auth context scoped to the **device's entire organization** and can drive
+the Helper AI tools (`query_devices`, `query_audit_log`, `manage_services`,
+`file_operations`, …). On a multi-user host (RDS / terminal server — common in MSP
+fleets) any unprivileged local user can lift the token from `agent.yaml` and, from any
+machine, call `POST /helper/chat/...` to enumerate and act across the whole org's
+devices without ever touching the agent.
+
+We must stop persisting the helper token in a world-readable file while still letting
+the user-session Helper obtain it.
+
+## Goal & Non-Goals
+
+**Goal:** Deliver `helper_auth_token` to the Assist Helper over an authenticated local
+IPC channel, gated by kernel-verified peer identity + a binary-hash allowlist, so the
+security boundary becomes *"be the genuine, hash-allowlisted `breeze-helper` binary
+connecting over an authenticated channel"* instead of *"be any local user who can read
+a 0644 file."*
+
+**Non-Goals:**
+- General-purpose Helper↔agent IPC. The Helper does its real work over HTTPS to the
+  server (`helper_fetch`); the only thing it needs from the agent locally is its token.
+  We give the Assist Helper a deliberately minimal IPC surface.
+- Changing the org-scope of the helper token itself. A genuine Helper run by any user
+  on a multi-user box still receives an org-scoped token — that is inherent to the
+  current product design. This change raises the bar from "read a file" to "be the
+  genuine Helper binary," which is the actual exposure being fixed.
+- Reworking the agent/watchdog/userhelper IPC. We reuse it.
+
+## Background: the existing IPC system
+
+The Go agent already has a mature IPC system (`agent/internal/ipc/`,
+`agent/internal/sessionbroker/`) used today by the watchdog and the Session-0
+remote-desktop userhelper. We reuse it wholesale.
+
+- **Transport** (`ipc/auth_*.go`): Windows named pipe `\\.\pipe\breeze-agent-ipc`;
+  macOS Unix socket `/Library/Application Support/Breeze/agent.sock`; Linux Unix socket
+  `/var/run/breeze/agent.sock`. The Windows pipe SDDL grants *Interactive Users
+  read/write* (`sessionbroker/broker_windows.go:12`), so user-session processes can
+  connect; peer-auth is the real gate.
+- **Wire format** (`ipc/protocol.go`): 4-byte big-endian length prefix + JSON
+  `Envelope{ID, Seq, Type, Payload, Error, HMAC}`. Pre-auth frames use a zero HMAC key;
+  after auth, both sides switch to a random 256-bit `sessionKey`.
+- **Peer authentication** (`ipc/auth_*.go`, `sessionbroker/broker.go:~1095-1404`):
+  kernel-verified PID → SID (Windows) / UID (`SO_PEERCRED`/`LOCAL_PEERCRED` on
+  unix) + binary path, **plus** a binary-hash allowlist (`selfHashes`,
+  `RefreshAllowedHashes` at `broker.go:1696-1714`). Connections whose binary hash isn't
+  allowlisted are rejected with `pre_auth_reject` / `binary_path_unknown`
+  (`broker.go:1202`).
+- **Handshake payloads** (`ipc/message.go:135-164`):
+  - `AuthRequest{protocolVersion, uid, sid, username, sessionId, displayEnv, pid,
+    binaryHash, winSessionId, helperRole, binaryKind, desktopContext}`
+  - `AuthResponse{accepted, sessionKey, agentId, allowedScopes, reason, permanent}`
+- **Role → scope mapping** (`sessionbroker/broker.go:209-213`):
+  - `systemHelperScopes = [notify, tray, clipboard, desktop]`
+  - `userHelperScopes = [notify, clipboard, run_as_user]`
+  - `watchdogHelperScopes = [watchdog]`
+- **Targeted push:** `PreferredSessionWithScope(scope)` / `SessionsWithScope(scope)`
+  (`broker.go:481-540`). The watchdog already receives rotated tokens this way via the
+  existing `token_update` message (`heartbeat.go:2460-2471`).
+
+## Design
+
+### 1. Dedicated role, scope, and message type (least privilege + token separation)
+
+We do **not** overload the existing `token_update` message (it carries the *agent*
+token to the watchdog). Two independent controls keep tokens from reaching the wrong
+peer:
+
+1. **A dedicated message type** `TypeHelperTokenUpdate = "helper_token_update"`
+   (`ipc/message.go`), payload:
+   ```go
+   type HelperTokenUpdate struct {
+       Token     string `json:"token"`
+       ExpiresAt string `json:"expiresAt,omitempty"` // RFC3339, optional
+   }
+   ```
+   The agent token continues to travel only via `token_update`; the helper token only
+   via `helper_token_update`.
+
+2. **A dedicated minimal role/scope** for the Assist Helper:
+   - `HelperRoleAssist = "assist"` (`ipc/message.go`)
+   - `assistHelperScopes = []string{"assist"}` (`sessionbroker/broker.go`) — note this
+     does **not** include `desktop`, `clipboard`, or `run_as_user`. The Assist Helper
+     can receive its token and nothing else over IPC.
+   - `BinaryKind = "assist_helper"`.
+
+   The broker sends `helper_token_update` only to sessions holding the `assist` scope,
+   and `token_update` only to `watchdog`-scope sessions. A bug in one path cannot
+   deliver a token to the other audience.
+
+### 2. Binary trust: allowlist the Helper binary
+
+Add the installed Assist Helper binary path(s) to the broker's trusted-path set
+(alongside `breeze-watchdog` / userhelper at `broker.go:~1648-1696`) so
+`RefreshAllowedHashes` includes the genuine `breeze-helper` binary's SHA-256 in
+`selfHashes`:
+
+- **Windows:** `breeze-helper.exe` at its installed location (next to the agent or in
+  its Program Files install dir).
+- **macOS:** the Helper executable inside its `.app` bundle.
+- **Linux:** the installed `breeze-helper` path (if/when shipped).
+
+Because `RefreshAllowedHashes` recomputes from the on-disk binary, a Tauri self-update
+that changes the Helper's hash is picked up automatically — no pinned hash to rotate.
+Replacing the binary at that path requires write access to a protected install
+location (admin), which is outside the threat model this change addresses (an admin
+already wins).
+
+### 3. Rust IPC client (focused subset)
+
+A new client module in `apps/helper/src-tauri/` implements only what's needed to
+authenticate and receive the token — **not** the desktop/clipboard/command message
+types.
+
+Responsibilities:
+- **Transport:** connect the platform pipe/socket (`tokio` + `winio` named pipe on
+  Windows; Unix domain socket on macOS/Linux). Tauri already depends on `tokio`.
+- **Framing:** 4-byte BE length prefix + JSON `Envelope`, matching `ipc/protocol.go`.
+- **HMAC-SHA256:** zero key for `auth_request`; switch to the `sessionKey` from
+  `auth_response` for subsequent frames; verify HMAC on inbound frames; track `seq`.
+  Crates: `hmac`, `sha2`.
+- **Handshake:** build `auth_request` with `helperRole="assist"`,
+  `binaryKind="assist_helper"`, self-computed `binaryHash`, and the kernel-resolvable
+  identity fields; handle `auth_response` (store session key) and `pre_auth_reject`
+  (log + back off / exit per `permanent`).
+- **Token receipt:** on `helper_token_update`, store the token **in memory only**
+  (never write to disk). Inject it into the existing `helper_fetch` Authorization
+  header (`lib.rs:615`), replacing the file read.
+- **Resilience:** if the agent isn't up or the channel drops, reconnect with bounded
+  backoff and surface a "connecting to agent" state in the UI. No silent file fallback
+  except the explicit Phase-1 path (§4).
+
+### 4. Two-phase rollout (zero lockout)
+
+The agent and Helper update independently, so we split the change:
+
+**Phase 1 (this work):**
+- Agent: continue writing `helper_auth_token` to `agent.yaml` **and** `secrets.yaml`
+  (unchanged), **and** push it via `helper_token_update` on assist-helper auth and on
+  rotation.
+- Helper: prefer IPC; fall back to reading `agent.yaml`/`secrets.yaml` only if IPC is
+  unavailable. (The file still exists in Phase 1, so the fallback is no worse than
+  today; the leak is not yet closed.)
+
+**Phase 2 (later release, gated on adoption telemetry):**
+- Agent: **stop** writing `helper_auth_token` to `agent.yaml` (keep it in
+  `secrets.yaml` as the agent's own source of truth; deliver to the Helper only via
+  IPC).
+- Helper: IPC-only; remove the file-read fallback (`lib.rs:79-130`,
+  `helper_token_from_config`).
+- **The HIGH-1 leak is fully closed at Phase 2.**
+
+This sequencing guarantees no version-skew combination locks the Helper out:
+| Agent | Helper | Phase 1 outcome | Phase 2 outcome |
+|-------|--------|-----------------|-----------------|
+| old (file only) | old (file only) | works (file) | n/a |
+| new (file + IPC) | old (file only) | works (file) | — |
+| new (file + IPC) | new (IPC + fallback) | works (IPC) | — |
+| new-P2 (IPC only) | new (IPC) | — | works (IPC) |
+| new-P2 (IPC only) | old (file only) | — | **must be upgraded first** (gate Phase 2 on Helper adoption) |
+
+### 5. Data flow (Phase 1)
+
+```
+Agent (SYSTEM/root)                          Assist Helper (logged-in user)
+─────────────────────                        ──────────────────────────────
+sessionbroker IPC listener                   Rust IPC client (NEW)
+  (pipe / unix socket, Interactive RW)  ◀──── connect
+  peer-auth: PID→SID/UID + binaryHash
+    ∈ selfHashes  (breeze-helper added)
+                                        ◀──── auth_request{role=assist,
+                                                kind=assist_helper, binaryHash}
+  verify peer + hash, assign scope=assist
+  ───── auth_response{sessionKey, scopes} ──▶  store session key
+  ───── helper_token_update{token} ───────▶  hold token IN MEMORY
+  (on rotation) helper_token_update ──────▶  update in-memory token
+                                              inject into helper_fetch Authorization
+
+Phase 1: agent ALSO writes token to agent.yaml (fallback). Phase 2: it does not.
+```
+
+## Error handling
+
+- **Agent not yet running / channel drop:** Helper reconnects with bounded backoff;
+  shows "connecting to agent." In Phase 1 only, after N failed attempts it may read the
+  file as a fallback; in Phase 2 there is no fallback.
+- **`pre_auth_reject`:** if `permanent` (e.g. `binary_path_unknown`), the Helper logs a
+  clear error and stops retrying (a non-allowlisted binary will never be accepted);
+  otherwise it backs off and retries (`rate_limited`, `max_conns_exceeded`).
+- **HMAC mismatch / malformed frame:** drop the connection and reconnect; never act on
+  an unverified frame.
+- **Token rotation race:** the Helper always uses the most recently received token; a
+  401 from the API triggers an immediate reconnect to pick up a fresh token (covers the
+  rotation-grace window the server already supports via `previousHelperTokenHash`).
+
+## Testing
+
+**Go (agent / sessionbroker):**
+- Broker accepts a hash-allowlisted assist helper and assigns scope `assist` only
+  (denies `desktop`/`clipboard`/`run_as_user`).
+- Broker rejects a connection whose binary hash is not in `selfHashes` with
+  `pre_auth_reject{code: binary_path_unknown, permanent: true}`.
+- Broker sends `helper_token_update` (not `token_update`) to the assist session on auth
+  success and on helper-token rotation; verifies the watchdog still receives
+  `token_update` (agent token) and never `helper_token_update`.
+- `RefreshAllowedHashes` includes the Helper binary path.
+
+**Rust (helper):**
+- Envelope framing + HMAC-SHA256 round-trip validated against Go-produced fixtures
+  (zero-key pre-auth and session-key post-auth).
+- Auth handshake: builds a valid `auth_request`, consumes `auth_response`, switches to
+  the session key.
+- `helper_token_update` updates the in-memory token; assert the token is **never
+  written to disk**.
+- Reconnect-with-backoff on dropped channel; `permanent` `pre_auth_reject` stops
+  retries.
+
+**Regression / contract:**
+- Phase 2: assert `helper_auth_token` is **absent** from `agent.yaml` after
+  `config.SaveTo` (it remains in `secrets.yaml`).
+- Existing test confirming the Helper never falls back to the full agent token
+  (`lib.rs` ~997-1008) must still pass.
+
+## Files touched (anticipated)
+
+**Agent (Go):**
+- `agent/internal/ipc/message.go` — `HelperRoleAssist`, `TypeHelperTokenUpdate`,
+  `HelperTokenUpdate` struct.
+- `agent/internal/sessionbroker/broker.go` — `assistHelperScopes`, role→scope mapping,
+  add Helper binary to trusted paths, push `helper_token_update` on assist-auth.
+- `agent/internal/heartbeat/heartbeat.go` — push `helper_token_update` to assist
+  session(s) on helper-token rotation (mirror of `sendWatchdogTokenUpdate`).
+- `agent/internal/config/config.go` — **Phase 2 only:** stop writing
+  `helper_auth_token` to `agent.yaml` (keep in `secrets.yaml`); update
+  `stripSecretsFromAgentConfig`.
+
+**Helper (Rust + TS):**
+- `apps/helper/src-tauri/src/` — new IPC client module (transport, framing, HMAC,
+  handshake, token receipt); wire the in-memory token into `helper_fetch`.
+- `apps/helper/src-tauri/src/lib.rs` — replace file-read token acquisition with IPC
+  (Phase 1: IPC-first with file fallback; Phase 2: IPC-only).
+- `apps/helper/src-tauri/Cargo.toml` — add `hmac`, `sha2` (and Windows named-pipe dep
+  if not already present).
+- Helper UI — "connecting to agent" state.
+
+## Open questions / future work
+
+- **Phase 2 trigger:** define the adoption-telemetry threshold (agent + Helper version
+  distribution) that gates the Phase 2 release. Tracked separately.
+- **Out of scope but noted:** the org-scope of the helper token and whether destructive
+  Helper tools require out-of-band approval (security-review HIGH-1 follow-up) are
+  independent of this delivery-mechanism change.


### PR DESCRIPTION
## Summary

Delivers the Breeze Assist Helper's per-device `helper_auth_token` over the agent's **existing authenticated IPC channel** instead of the world-readable `agent.yaml`, closing security-review finding **HIGH-1** (commit `9968f3f4` widened `agent.yaml` to `0644`, exposing the org-scoped helper token to any local user — acute on multi-user RDS/terminal-server hosts).

**Security boundary moves** from *"be any local user who can read a 0644 file"* → *"be the genuine, hash-allowlisted `breeze-helper` binary connecting over a kernel-authenticated channel."* Reuses the agent's audited IPC peer-auth (PID→SID/UID + binary-hash allowlist) — **zero new Go security surface**.

Spec: `docs/superpowers/specs/2026-05-29-helper-ipc-token-delivery-design.md`
Plan: `docs/superpowers/plans/2026-05-29-helper-ipc-token-delivery.md`

### What changed
- **Agent (Go):** new least-privilege `assist` role + `assist`-only scope (no desktop/clipboard/run_as_user); dedicated `helper_token_update` message so the helper token can never cross-deliver with the watchdog's agent-token; `breeze-helper` added to the binary-hash allowlist; `SessionAuthenticatedHandler` broker hook; heartbeat pushes the token to assist sessions on connect + rotation.
- **Helper (Rust/Tauri):** focused IPC client (Go-compatible envelope + HMAC-SHA256 framing, zero-key→session-key handshake, platform transport, panic-guarded reconnect loop); token held **in memory only**, fed into `helper_fetch`; "connecting to agent" UI state.

### Two-phase rollout (this is Phase 1)
- **Phase 1 (this PR):** agent still writes the token to `agent.yaml` AND pushes via IPC; Helper prefers IPC, **falls back to the file** — zero version-skew lockout. The leak is **not yet closed**.
- **Phase 2 (separate, gated on adoption telemetry):** agent stops writing the token to `agent.yaml`; Helper goes IPC-only. **This is what actually closes HIGH-1.**

## Test Plan
- [x] Go: `go test -race ./internal/ipc/... ./internal/sessionbroker/... ./internal/heartbeat/...` — green
- [x] Rust: `cargo test ipc::` — 23 passed (incl. Go-fixture HMAC parity, full handshake→token-delivery over `tokio::io::duplex`, permanent/transient reject, reconnect backoff)
- [x] No-agent-token-fallback invariant preserved
- [ ] **T13 (pre-merge): Windows VM smoke** — the `#[cfg(windows)]` SID/named-pipe code is NOT compiler-verified on macOS. Verify assist session accepted (scope `[assist]`), non-allowlisted binary rejected, token received, and file-fallback works with the agent stopped.
- [ ] **T13: macOS daemon smoke** — unix-socket path, assist session accepted + token received.

## Notes
- Phase 2 is intentionally out of scope. Do not ship Phase 2 until agent+Helper adoption telemetry confirms upgrade.
- Follow-ups from the security review (helper-token org-scope reduction; out-of-band approval for destructive Helper tools) are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)