### PR TITLE
security: batch-2 review fixes (#2 flag-off, #3, #5, #6, #7, #8, #9, #10)

### DIFF
--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -493,9 +493,11 @@ func SaveTo(cfg *Config, cfgFile string) error {
 		return fmt.Errorf("writing secrets file: %w", err)
 	}
 
-	// Defense-in-depth: ensure secrets permissions are correct.
+	// Enforce secrets permissions — this is fatal, not just a warning, because
+	// leaving secrets.yaml world-readable after a failed chmod is a security
+	// breach. agent.yaml/dir chmod failures remain warn-only (see :441-446).
 	if err := enforceSecretFilePermissions(secretsPath); err != nil {
-		log.Warn("failed to enforce secrets file permissions", "error", err.Error())
+		return fmt.Errorf("enforcing secrets file permissions on %s: %w", secretsPath, err)
 	}
 
 	return nil

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/spf13/viper"
@@ -280,6 +281,15 @@ func Load(cfgFile string) (*Config, error) {
 		if v := sv.GetString("mtls_cert_expires"); v != "" {
 			cfg.MtlsCertExpires = v
 		}
+		// Companion: backup S3 credentials migrate to secrets.yaml via
+		// isSecretYAMLKey; read them back so BackupS3AccessKey/BackupS3SecretKey
+		// are populated after Load (otherwise backup config silently breaks).
+		if v := sv.GetString("backup_s3_access_key"); v != "" {
+			cfg.BackupS3AccessKey = v
+		}
+		if v := sv.GetString("backup_s3_secret_key"); v != "" {
+			cfg.BackupS3SecretKey = v
+		}
 	}
 
 	// Validate config: fatals block startup, warnings are logged and continue.
@@ -463,6 +473,16 @@ func SaveTo(cfg *Config, cfgFile string) error {
 	sv.Set("mtls_cert_pem", cfg.MtlsCertPEM)
 	sv.Set("mtls_key_pem", cfg.MtlsKeyPEM)
 	sv.Set("mtls_cert_expires", cfg.MtlsCertExpires)
+	// Backup S3 credentials are caught by isSecretYAMLKey (suffix _access_key /
+	// _secret_key) and stripped from agent.yaml; persist them here so they
+	// survive a round-trip through SaveTo → Load. Only write non-empty values
+	// for the same reason as auth_token above.
+	if cfg.BackupS3AccessKey != "" {
+		sv.Set("backup_s3_access_key", cfg.BackupS3AccessKey)
+	}
+	if cfg.BackupS3SecretKey != "" {
+		sv.Set("backup_s3_secret_key", cfg.BackupS3SecretKey)
+	}
 
 	// Same atomic-write pattern for the secrets file (0600).
 	secretsYAML, err := yaml.Marshal(sv.AllSettings())
@@ -486,14 +506,10 @@ func stripSecretsFromAgentConfig(data []byte) []byte {
 	if err := yaml.Unmarshal(data, &values); err != nil {
 		return data
 	}
-	for _, key := range []string{
-		"auth_token",
-		"watchdog_auth_token",
-		"mtls_cert_pem",
-		"mtls_key_pem",
-		"mtls_cert_expires",
-	} {
-		delete(values, key)
+	for key := range values {
+		if isSecretYAMLKey(key) {
+			delete(values, key)
+		}
 	}
 	out, err := yaml.Marshal(values)
 	if err != nil {
@@ -562,13 +578,36 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	return nil
 }
 
-func isSecretConfigKey(key string) bool {
-	switch key {
-	case "auth_token", "watchdog_auth_token", "mtls_cert_pem", "mtls_key_pem", "mtls_cert_expires":
-		return true
-	default:
+// secretKeyAllowedInAgentYAML lists keys that look secret by suffix rules but
+// must remain in agent.yaml. The Breeze Helper ("Breeze Assist") runs as the
+// logged-in user and reads agent.yaml directly; it needs helper_auth_token.
+var secretKeyAllowedInAgentYAML = map[string]bool{
+	"helper_auth_token": true,
+}
+
+// isSecretYAMLKey reports whether key should be kept out of agent.yaml (i.e.
+// written only to secrets.yaml). It uses a suffix-based predicate so future
+// secret keys like backup_s3_access_key are caught automatically without
+// requiring an explicit list update. Keys in secretKeyAllowedInAgentYAML are
+// explicitly exempted regardless of suffix.
+func isSecretYAMLKey(key string) bool {
+	if secretKeyAllowedInAgentYAML[key] {
 		return false
 	}
+	switch key {
+	case "auth_token", "watchdog_auth_token",
+		"mtls_cert_pem", "mtls_key_pem", "mtls_cert_expires":
+		return true
+	}
+	return strings.HasSuffix(key, "_token") ||
+		strings.HasSuffix(key, "_secret_key") ||
+		strings.HasSuffix(key, "_access_key") ||
+		strings.HasSuffix(key, "_secret") ||
+		strings.HasSuffix(key, "_password")
+}
+
+func isSecretConfigKey(key string) bool {
+	return isSecretYAMLKey(key)
 }
 
 // GetDataDir returns the platform-specific data directory for the agent
@@ -624,17 +663,9 @@ func migrateInlineSecretsToSecretFile(cfgPath string) error {
 		return err
 	}
 
-	secretKeys := []string{
-		"auth_token",
-		"watchdog_auth_token",
-		"mtls_cert_pem",
-		"mtls_key_pem",
-		"mtls_cert_expires",
-	}
-
 	hasInlineSecretKeys := false
-	for _, key := range secretKeys {
-		if _, ok := cfgValues[key]; ok {
+	for key := range cfgValues {
+		if isSecretYAMLKey(key) {
 			hasInlineSecretKeys = true
 			break
 		}
@@ -655,11 +686,13 @@ func migrateInlineSecretsToSecretFile(cfgPath string) error {
 		return err
 	}
 
-	for _, key := range secretKeys {
-		if isEmptyYAMLValue(secretValues[key]) && !isEmptyYAMLValue(cfgValues[key]) {
-			secretValues[key] = cfgValues[key]
+	for key := range cfgValues {
+		if isSecretYAMLKey(key) {
+			if isEmptyYAMLValue(secretValues[key]) && !isEmptyYAMLValue(cfgValues[key]) {
+				secretValues[key] = cfgValues[key]
+			}
+			delete(cfgValues, key)
 		}
-		delete(cfgValues, key)
 	}
 
 	if secretFileExists || len(secretValues) > 0 {

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -263,6 +263,11 @@ func Load(cfgFile string) (*Config, error) {
 		if err := sv.ReadInConfig(); err != nil {
 			return nil, fmt.Errorf("reading secrets file: %w", err)
 		}
+		// IMPORTANT: this read-back is a hardcoded list and CANNOT be driven by
+		// isSecretYAMLKey (there's no generic config-key -> struct-field mapping
+		// at this layer). When you add a new secret field, update BOTH
+		// isSecretYAMLKey (so it gets stripped to secrets.yaml) AND this block
+		// (so it gets read back) — otherwise the field is silently lost on load.
 		if v := sv.GetString("auth_token"); v != "" {
 			cfg.AuthToken = v
 		}

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -444,7 +444,12 @@ func SaveTo(cfg *Config, cfgFile string) error {
 	if err != nil {
 		return fmt.Errorf("marshaling agent config: %w", err)
 	}
-	cfgYAML = stripSecretsFromAgentConfig(cfgYAML)
+	// Fail closed: if stripping secrets errors, abort BEFORE writing the
+	// world-readable agent.yaml so the unstripped buffer can never leak to it.
+	cfgYAML, err = stripSecretsFromAgentConfig(cfgYAML)
+	if err != nil {
+		return fmt.Errorf("writing agent config: %w", err)
+	}
 	// agent.yaml is world-readable (0644) so the Breeze Helper, running as the
 	// logged-in user, can read it. It carries only the helper-scoped token;
 	// full tokens and mTLS keys are written to root-only secrets.yaml below.
@@ -500,7 +505,8 @@ func SaveTo(cfg *Config, cfgFile string) error {
 
 	// Enforce secrets permissions — this is fatal, not just a warning, because
 	// leaving secrets.yaml world-readable after a failed chmod is a security
-	// breach. agent.yaml/dir chmod failures remain warn-only (see :441-446).
+	// breach. agent.yaml/dir chmod failures remain warn-only (see the log.Warn
+	// calls right after the agent.yaml write above).
 	if err := enforceSecretFilePermissions(secretsPath); err != nil {
 		return fmt.Errorf("enforcing secrets file permissions on %s: %w", secretsPath, err)
 	}
@@ -508,21 +514,35 @@ func SaveTo(cfg *Config, cfgFile string) error {
 	return nil
 }
 
-func stripSecretsFromAgentConfig(data []byte) []byte {
+// stripSecretsFromAgentConfig removes secret-bearing keys (see isSecretYAMLKey)
+// from a serialized agent.yaml buffer. It MUST fail closed: on any
+// unmarshal/marshal error it returns a wrapped error and NO data, never the
+// original unstripped buffer. The caller (SaveTo) aborts before writing the
+// world-readable (0644) agent.yaml, so secrets can never leak to that file.
+// stripMarshalForTests lets tests force the post-delete marshal step to fail so
+// the fail-closed SaveTo abort path (secrets never written to agent.yaml) can be
+// exercised. nil in production => real yaml.Marshal.
+var stripMarshalForTests func(any) ([]byte, error)
+
+func stripSecretsFromAgentConfig(data []byte) ([]byte, error) {
 	var values map[string]any
 	if err := yaml.Unmarshal(data, &values); err != nil {
-		return data
+		return nil, fmt.Errorf("stripping secrets from agent config (unmarshal): %w", err)
 	}
 	for key := range values {
 		if isSecretYAMLKey(key) {
 			delete(values, key)
 		}
 	}
-	out, err := yaml.Marshal(values)
-	if err != nil {
-		return data
+	marshal := yaml.Marshal
+	if stripMarshalForTests != nil {
+		marshal = stripMarshalForTests
 	}
-	return out
+	out, err := marshal(values)
+	if err != nil {
+		return nil, fmt.Errorf("stripping secrets from agent config (marshal): %w", err)
+	}
+	return out, nil
 }
 
 // atomicWriteFile writes data to path durably: it creates path+".partial" in

--- a/agent/internal/config/config_test.go
+++ b/agent/internal/config/config_test.go
@@ -415,3 +415,165 @@ func TestWatchdogDefaults(t *testing.T) {
 		t.Errorf("MaxRestartsPer24h default: want 5, got %d", cfg.Watchdog.MaxRestartsPer24h)
 	}
 }
+
+// TestIsSecretYAMLKey verifies the drift-proof predicate that decides which
+// config keys belong in secrets.yaml vs agent.yaml. Finding #6.
+func TestIsSecretYAMLKey(t *testing.T) {
+	cases := map[string]bool{
+		// Explicit secret keys (named in the switch).
+		"auth_token":         true,
+		"watchdog_auth_token": true,
+		"mtls_cert_pem":      true,
+		"mtls_key_pem":       true,
+		"mtls_cert_expires":  true,
+		// Caught by suffix rules (_access_key, _secret_key).
+		"backup_s3_access_key": true,
+		"backup_s3_secret_key": true,
+		// Caught by suffix rules (_password, _secret, _token).
+		"smtp_password": true,
+		"some_token":    true,
+		// Explicitly exempted: helper token MUST stay in agent.yaml for Helper.
+		"helper_auth_token": false,
+		// Non-secret keys that happen to contain "key" or "token" substrings
+		// but don't match any suffix rule.
+		"server_url":        false,
+		"agent_id":          false,
+		"backup_s3_bucket":  false,
+		"backup_s3_region":  false,
+	}
+	for key, want := range cases {
+		if got := isSecretYAMLKey(key); got != want {
+			t.Errorf("isSecretYAMLKey(%q) = %v, want %v", key, got, want)
+		}
+	}
+}
+
+// TestSaveToStripsBackupS3SecretsFromAgentYAML is the regression test for
+// Finding #6: backup_s3_access_key and backup_s3_secret_key must not appear in
+// agent.yaml (world-readable) after migration. This mirrors
+// TestMigrateInlineSecretsToSecretFileScrubsAgentYAML but exercises the
+// backup_s3_* keys that were absent from the original 5-key allowlist.
+// helper_auth_token must still be present in agent.yaml.
+func TestSaveToStripsBackupS3SecretsFromAgentYAML(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yaml")
+
+	// Write agent.yaml with inline backup_s3 secrets (old/misconfigured format).
+	if err := os.WriteFile(cfgPath, []byte(`
+agent_id: agent-backup-1
+server_url: https://api.example.test
+helper_auth_token: brz_helper
+backup_s3_bucket: my-bucket
+backup_s3_region: us-east-1
+backup_s3_access_key: AKIAIOSFODNN7EXAMPLE
+backup_s3_secret_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+`), 0o640); err != nil {
+		t.Fatalf("write agent.yaml: %v", err)
+	}
+
+	if err := migrateInlineSecretsToSecretFile(cfgPath); err != nil {
+		t.Fatalf("migrateInlineSecretsToSecretFile returned error: %v", err)
+	}
+
+	agentYAML, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read scrubbed agent.yaml: %v", err)
+	}
+	text := string(agentYAML)
+
+	// backup_s3_access_key and backup_s3_secret_key must NOT appear in agent.yaml.
+	for _, forbidden := range []string{
+		"backup_s3_access_key",
+		"backup_s3_secret_key",
+		"AKIAIOSFODNN7EXAMPLE",
+		"wJalrXUtnFEMI",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("scrubbed agent.yaml contains forbidden secret %q:\n%s", forbidden, text)
+		}
+	}
+
+	// Non-secret backup fields must remain in agent.yaml.
+	for _, required := range []string{"backup_s3_bucket: my-bucket", "backup_s3_region: us-east-1"} {
+		if !strings.Contains(text, required) {
+			t.Fatalf("scrubbed agent.yaml missing non-secret key %q:\n%s", required, text)
+		}
+	}
+
+	// helper_auth_token must remain in agent.yaml (Helper reads it).
+	if !strings.Contains(text, "helper_auth_token: brz_helper") {
+		t.Fatalf("scrubbed agent.yaml lost helper token:\n%s", text)
+	}
+
+	// secrets.yaml must contain the S3 credentials.
+	secretsYAML, err := os.ReadFile(filepath.Join(dir, "secrets.yaml"))
+	if err != nil {
+		t.Fatalf("read secrets.yaml: %v", err)
+	}
+	secretsText := string(secretsYAML)
+	for _, required := range []string{
+		"backup_s3_access_key: AKIAIOSFODNN7EXAMPLE",
+	} {
+		if !strings.Contains(secretsText, required) {
+			t.Fatalf("secrets.yaml missing %q:\n%s", required, secretsText)
+		}
+	}
+	if !strings.Contains(secretsText, "backup_s3_secret_key:") {
+		t.Fatalf("secrets.yaml missing backup_s3_secret_key:\n%s", secretsText)
+	}
+}
+
+// TestLoadReadsBackupS3FromSecrets is the companion to the strip test: verifies
+// that after backup_s3_* migrate to secrets.yaml, Load reads them back correctly
+// so that BackupS3AccessKey / BackupS3SecretKey are populated. Without this,
+// backup config silently breaks after the first migration. (Decision 3 companion.)
+//
+// This test writes agent.yaml + secrets.yaml by hand to mirror the on-disk state
+// produced by migrateInlineSecretsToSecretFile, then calls Load and asserts
+// that the credentials round-trip via the secrets read-back at config.go:265-282.
+func TestLoadReadsBackupS3FromSecrets(t *testing.T) {
+	defer viper.Reset()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yaml")
+	secretsPath := filepath.Join(dir, "secrets.yaml")
+
+	// agent.yaml after migration: no backup_s3 secrets, has non-secret backup fields.
+	agentYAML := `
+agent_id: ab3c20eddb470acffd33bbe00f25e0348e89298ab80cece542bb1fbf921e5776
+server_url: https://api.example.test
+backup_s3_bucket: my-bucket
+backup_s3_region: eu-west-1
+`
+	if err := os.WriteFile(cfgPath, []byte(agentYAML), 0o644); err != nil {
+		t.Fatalf("write agent.yaml: %v", err)
+	}
+
+	// secrets.yaml contains the migrated S3 credentials.
+	secretsYAML := `
+auth_token: brz_agent_s3
+backup_s3_access_key: AKIAIOSFODNN7EXAMPLE
+backup_s3_secret_key: wJalrXUtnFEMI/K7MDENG
+`
+	if err := os.WriteFile(secretsPath, []byte(secretsYAML), 0o600); err != nil {
+		t.Fatalf("write secrets.yaml: %v", err)
+	}
+
+	loaded, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.BackupS3AccessKey != "AKIAIOSFODNN7EXAMPLE" {
+		t.Fatalf("BackupS3AccessKey = %q, want AKIAIOSFODNN7EXAMPLE", loaded.BackupS3AccessKey)
+	}
+	if loaded.BackupS3SecretKey != "wJalrXUtnFEMI/K7MDENG" {
+		t.Fatalf("BackupS3SecretKey = %q, want wJalrXUtnFEMI/K7MDENG", loaded.BackupS3SecretKey)
+	}
+	// Non-secret fields must also be populated from agent.yaml.
+	if loaded.BackupS3Bucket != "my-bucket" {
+		t.Fatalf("BackupS3Bucket = %q, want my-bucket", loaded.BackupS3Bucket)
+	}
+	if loaded.BackupS3Region != "eu-west-1" {
+		t.Fatalf("BackupS3Region = %q, want eu-west-1", loaded.BackupS3Region)
+	}
+}
+

--- a/agent/internal/config/config_test.go
+++ b/agent/internal/config/config_test.go
@@ -614,3 +614,59 @@ func TestSaveToFailsWhenSecretsChmodFails(t *testing.T) {
 	}
 }
 
+// TestStripSecretsFromAgentConfigFailsClosed verifies the strip helper fails
+// closed: on a YAML error it returns a wrapped error and NIL data, never the
+// original (unstripped) buffer. Previously it silently returned the original
+// secret-bearing buffer, which SaveTo then wrote to the 0644 agent.yaml.
+func TestStripSecretsFromAgentConfigFailsClosed(t *testing.T) {
+	// Malformed YAML (unterminated flow mapping) forces an unmarshal error.
+	malformed := []byte("auth_token: brz_super_secret\n{ this: is, not: valid")
+
+	out, err := stripSecretsFromAgentConfig(malformed)
+	if err == nil {
+		t.Fatal("stripSecretsFromAgentConfig returned nil error on malformed YAML; expected fail-closed error")
+	}
+	if out != nil {
+		t.Fatalf("stripSecretsFromAgentConfig returned non-nil data on error: %q (must never return the unstripped buffer)", out)
+	}
+	if strings.Contains(string(out), "brz_super_secret") {
+		t.Fatal("stripSecretsFromAgentConfig leaked the original secret-bearing buffer on error")
+	}
+}
+
+// TestSaveToAbortsWhenStripFails verifies the SaveTo fail-closed path: if
+// stripping secrets errors (here via the injected marshal hook), SaveTo returns
+// an error and does NOT write secrets to the world-readable agent.yaml.
+func TestSaveToAbortsWhenStripFails(t *testing.T) {
+	defer viper.Reset()
+
+	orig := stripMarshalForTests
+	defer func() { stripMarshalForTests = orig }()
+	stripMarshalForTests = func(any) ([]byte, error) {
+		return nil, errors.New("boom: simulated strip marshal failure")
+	}
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yaml")
+
+	cfg := Default()
+	cfg.AgentID = "ab3c20eddb470acffd33bbe00f25e0348e89298ab80cece542bb1fbf921e5776"
+	cfg.ServerURL = "https://api.example.test"
+	cfg.AuthToken = "brz_agent_strip_secret"
+
+	err := SaveTo(cfg, cfgPath)
+	if err == nil {
+		t.Fatal("SaveTo returned nil; expected an error when secret stripping fails")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("error message does not include the underlying cause: %v", err)
+	}
+
+	// agent.yaml must NOT contain the secret. It may not exist at all (write
+	// aborted), which is fine — if it does exist, it must not carry the token.
+	data, readErr := os.ReadFile(cfgPath)
+	if readErr == nil && strings.Contains(string(data), "brz_agent_strip_secret") {
+		t.Fatalf("agent.yaml leaked the auth token after a failed strip: %q", data)
+	}
+}
+

--- a/agent/internal/config/config_test.go
+++ b/agent/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -574,6 +575,42 @@ backup_s3_secret_key: wJalrXUtnFEMI/K7MDENG
 	}
 	if loaded.BackupS3Region != "eu-west-1" {
 		t.Fatalf("BackupS3Region = %q, want eu-west-1", loaded.BackupS3Region)
+	}
+}
+
+// TestSaveToFailsWhenSecretsChmodFails verifies Finding #8: SaveTo must return
+// an error (not silently log a warning) when the secrets.yaml chmod enforcement
+// fails. This prevents a race window where secrets.yaml is world-readable.
+func TestSaveToFailsWhenSecretsChmodFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod injection is Unix-only; Windows DACLs covered by permissions_windows_test.go")
+	}
+	defer viper.Reset()
+
+	// Inject a failing chmod via the package-level var.
+	orig := enforceSecretFilePermissions
+	defer func() { enforceSecretFilePermissions = orig }()
+	enforceSecretFilePermissions = func(path string) error {
+		return errors.New("boom: simulated chmod failure")
+	}
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yaml")
+
+	cfg := Default()
+	cfg.AgentID = "ab3c20eddb470acffd33bbe00f25e0348e89298ab80cece542bb1fbf921e5776"
+	cfg.ServerURL = "https://api.example.test"
+	cfg.AuthToken = "brz_agent_chmod"
+
+	err := SaveTo(cfg, cfgPath)
+	if err == nil {
+		t.Fatal("SaveTo returned nil; expected an error when secrets chmod fails")
+	}
+	if !strings.Contains(err.Error(), "secrets") {
+		t.Fatalf("error message does not reference secrets path: %v", err)
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("error message does not include the underlying cause: %v", err)
 	}
 }
 

--- a/agent/internal/config/permissions_unix.go
+++ b/agent/internal/config/permissions_unix.go
@@ -20,6 +20,11 @@ func enforceConfigFilePermissions(path string) error {
 	return os.Chmod(path, 0644)
 }
 
-func enforceSecretFilePermissions(path string) error {
+func enforceSecretFilePermissionsImpl(path string) error {
 	return os.Chmod(path, 0600)
 }
+
+// enforceSecretFilePermissions is a package-level var so tests can inject a
+// failure to verify that SaveTo propagates it as a fatal error. Production
+// code always routes through enforceSecretFilePermissionsImpl.
+var enforceSecretFilePermissions = enforceSecretFilePermissionsImpl

--- a/agent/internal/config/permissions_windows.go
+++ b/agent/internal/config/permissions_windows.go
@@ -31,9 +31,14 @@ func enforceConfigFilePermissions(path string) error {
 	return applyWindowsDACL(path, windowsConfigFileSDDL)
 }
 
-func enforceSecretFilePermissions(path string) error {
+func enforceSecretFilePermissionsImpl(path string) error {
 	return applyWindowsDACL(path, windowsSecretFileSDDL)
 }
+
+// enforceSecretFilePermissions is a package-level var so tests can inject a
+// failure to verify that SaveTo propagates it as a fatal error. Production
+// code always routes through enforceSecretFilePermissionsImpl.
+var enforceSecretFilePermissions = enforceSecretFilePermissionsImpl
 
 func applyWindowsDACL(path, sddl string) error {
 	sd, err := windows.SecurityDescriptorFromString(sddl)

--- a/apps/api/migrations/2026-05-29-access-reviews-dual-axis-rls.sql
+++ b/apps/api/migrations/2026-05-29-access-reviews-dual-axis-rls.sql
@@ -1,0 +1,25 @@
+-- 2026-05-29-access-reviews-dual-axis-rls.sql
+-- Finding #7: access_reviews carries org_id (org-axis) AND partner_id
+-- (partner-axis) rows but shipped org-only Shape-1 policies, so partner-axis
+-- rows (org_id=NULL) fell back to an app-layer-only filter (fail-closed, no
+-- leak) — violating the no-app-layer-only-RLS invariant. Convert to Shape-4
+-- dual-axis (org OR partner). Mirrors deployment_invites (2026-04-20-b) /
+-- users. Axes are mutually exclusive, so no composite FK applies.
+-- Idempotent: DROP POLICY IF EXISTS then recreate. No inner BEGIN/COMMIT.
+DROP POLICY IF EXISTS breeze_org_isolation_select ON public.access_reviews;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON public.access_reviews;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON public.access_reviews;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON public.access_reviews;
+DROP POLICY IF EXISTS breeze_dual_axis_select ON public.access_reviews;
+DROP POLICY IF EXISTS breeze_dual_axis_insert ON public.access_reviews;
+DROP POLICY IF EXISTS breeze_dual_axis_update ON public.access_reviews;
+DROP POLICY IF EXISTS breeze_dual_axis_delete ON public.access_reviews;
+CREATE POLICY breeze_dual_axis_select ON public.access_reviews FOR SELECT
+  USING (public.breeze_has_org_access(org_id) OR public.breeze_has_partner_access(partner_id));
+CREATE POLICY breeze_dual_axis_insert ON public.access_reviews FOR INSERT
+  WITH CHECK (public.breeze_has_org_access(org_id) OR public.breeze_has_partner_access(partner_id));
+CREATE POLICY breeze_dual_axis_update ON public.access_reviews FOR UPDATE
+  USING (public.breeze_has_org_access(org_id) OR public.breeze_has_partner_access(partner_id))
+  WITH CHECK (public.breeze_has_org_access(org_id) OR public.breeze_has_partner_access(partner_id));
+CREATE POLICY breeze_dual_axis_delete ON public.access_reviews FOR DELETE
+  USING (public.breeze_has_org_access(org_id) OR public.breeze_has_partner_access(partner_id));

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -95,6 +95,7 @@ const PARTNER_TENANT_TABLES: ReadonlyMap<string, string> = new Map<string, strin
 const DUAL_AXIS_TENANT_TABLES: ReadonlySet<string> = new Set<string>([
   'users',
   'deployment_invites',
+  'access_reviews',
 ]);
 
 // Tables that carry a `device_id` FK but no denormalized `org_id`. Their

--- a/apps/api/src/config/validate.test.ts
+++ b/apps/api/src/config/validate.test.ts
@@ -1147,6 +1147,22 @@ describe('validateConfig', () => {
       warnSpy.mockRestore();
     });
 
+    it('emits ENABLE_2FA warning for a non-standard falsy value (envFlag disables on any non-truthy value)', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      withEnv({
+        ...validEnv,
+        NODE_ENV: 'production',
+        CORS_ALLOWED_ORIGINS: 'https://app.breeze.io',
+        TRUST_PROXY_HEADERS: 'true',
+        ENABLE_2FA: 'disabled',
+      }, () => {
+        expect(() => validateConfig()).not.toThrow();
+        const calls = warnSpy.mock.calls.map(args => args[0] as string);
+        expect(calls.some(msg => msg.includes('ENABLE_2FA'))).toBe(true);
+      });
+      warnSpy.mockRestore();
+    });
+
     it('does NOT emit ENABLE_2FA warning when ENABLE_2FA=true', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       withEnv({

--- a/apps/api/src/config/validate.test.ts
+++ b/apps/api/src/config/validate.test.ts
@@ -1105,4 +1105,84 @@ describe('validateConfig', () => {
       });
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // ENABLE_2FA=false warning (Finding #3)
+  // ---------------------------------------------------------------------------
+  describe('ENABLE_2FA=false warning', () => {
+    it('emits ENABLE_2FA warning in production when ENABLE_2FA=false', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      withEnv({
+        ...validEnv,
+        NODE_ENV: 'production',
+        CORS_ALLOWED_ORIGINS: 'https://app.breeze.io',
+        TRUST_PROXY_HEADERS: 'true',
+        ENABLE_2FA: 'false',
+      }, () => {
+        // Must NOT throw — this is warn-only
+        expect(() => validateConfig()).not.toThrow();
+        // Must emit a warning mentioning ENABLE_2FA, requireMfa, and clarify it's not just /auth/mfa
+        const calls = warnSpy.mock.calls.map(args => args[0] as string);
+        const enable2faWarning = calls.find(msg => msg.includes('ENABLE_2FA'));
+        expect(enable2faWarning).toBeDefined();
+        expect(enable2faWarning).toContain('requireMfa');
+        expect(enable2faWarning).not.toMatch(/only.*\/auth\/mfa/i);
+      });
+      warnSpy.mockRestore();
+    });
+
+    it('emits ENABLE_2FA warning with "0" value', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      withEnv({
+        ...validEnv,
+        NODE_ENV: 'production',
+        CORS_ALLOWED_ORIGINS: 'https://app.breeze.io',
+        TRUST_PROXY_HEADERS: 'true',
+        ENABLE_2FA: '0',
+      }, () => {
+        expect(() => validateConfig()).not.toThrow();
+        const calls = warnSpy.mock.calls.map(args => args[0] as string);
+        expect(calls.some(msg => msg.includes('ENABLE_2FA'))).toBe(true);
+      });
+      warnSpy.mockRestore();
+    });
+
+    it('does NOT emit ENABLE_2FA warning when ENABLE_2FA=true', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      withEnv({
+        ...validEnv,
+        NODE_ENV: 'production',
+        CORS_ALLOWED_ORIGINS: 'https://app.breeze.io',
+        TRUST_PROXY_HEADERS: 'true',
+        ENABLE_2FA: 'true',
+      }, () => {
+        expect(() => validateConfig()).not.toThrow();
+        const calls = warnSpy.mock.calls.map(args => args[0] as string);
+        expect(calls.some(msg => msg.includes('ENABLE_2FA'))).toBe(false);
+      });
+      warnSpy.mockRestore();
+    });
+
+    it('does NOT emit ENABLE_2FA warning when ENABLE_2FA is unset', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      withEnv({
+        ...validEnv,
+        NODE_ENV: 'production',
+        CORS_ALLOWED_ORIGINS: 'https://app.breeze.io',
+        TRUST_PROXY_HEADERS: 'true',
+      }, () => {
+        // Ensure ENABLE_2FA is not set
+        const orig = process.env.ENABLE_2FA;
+        delete process.env.ENABLE_2FA;
+        try {
+          expect(() => validateConfig()).not.toThrow();
+          const calls = warnSpy.mock.calls.map(args => args[0] as string);
+          expect(calls.some(msg => msg.includes('ENABLE_2FA'))).toBe(false);
+        } finally {
+          if (orig !== undefined) process.env.ENABLE_2FA = orig;
+        }
+      });
+      warnSpy.mockRestore();
+    });
+  });
 });

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -970,11 +970,19 @@ function collectWarnings(env: Record<string, string | undefined>): ConfigWarning
     // it's missing or weak.)
   }
 
-  // Warn when ENABLE_2FA=false: this neuters ALL requireMfa() step-up gates
-  // across the entire API, not just /auth/mfa endpoints. Non-fatal — a
+  // Warn when 2FA is globally disabled: this neuters ALL requireMfa() step-up
+  // gates across the entire API, not just /auth/mfa endpoints. Non-fatal — a
   // self-hosted operator may deliberately run 2FA-off; we must not lock them
   // out. See: Finding #3 (security review May 2026).
-  if (['false', '0', 'no', 'off'].includes((env.ENABLE_2FA ?? '').trim().toLowerCase())) {
+  //
+  // Mirror envFlag('ENABLE_2FA', true) exactly: it disables on ANY value that
+  // isn't in the truthy set (so ENABLE_2FA=disabled / nope also disable 2FA).
+  // Match that here so the warning fires for every disabling value, not just
+  // the obvious false/0/no/off ones.
+  const enable2faRaw = (env.ENABLE_2FA ?? '').trim().toLowerCase();
+  const enable2faSetButFalsy =
+    enable2faRaw !== '' && !['1', 'true', 'yes', 'on'].includes(enable2faRaw);
+  if (enable2faSetButFalsy) {
     warnings.push({
       key: 'ENABLE_2FA',
       message:

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -384,6 +384,11 @@ const envSchema = z
     BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: z.string().optional(),
     IS_HOSTED: z.string().optional(),
 
+    // MFA feature flag. When false, ALL requireMfa() gates become no-ops.
+    // Warning is emitted in collectWarnings; we do NOT refuse boot (a
+    // self-hosted operator may deliberately run 2FA-off).
+    ENABLE_2FA: z.string().optional(),
+
     // OAuth Dynamic Client Registration (DCR) hardening. Both default OFF.
     // See env.ts and provider.ts for the runtime read-paths; the
     // production-only validation in superRefine refuses boot when
@@ -965,6 +970,20 @@ function collectWarnings(env: Record<string, string | undefined>): ConfigWarning
     // it's missing or weak.)
   }
 
+  // Warn when ENABLE_2FA=false: this neuters ALL requireMfa() step-up gates
+  // across the entire API, not just /auth/mfa endpoints. Non-fatal — a
+  // self-hosted operator may deliberately run 2FA-off; we must not lock them
+  // out. See: Finding #3 (security review May 2026).
+  if (['false', '0', 'no', 'off'].includes((env.ENABLE_2FA ?? '').trim().toLowerCase())) {
+    warnings.push({
+      key: 'ENABLE_2FA',
+      message:
+        'ENABLE_2FA=false disables ALL requireMfa() step-up gates (admin/abuse, ' +
+        'tenant export/erasure, remote access, API keys, SSO, backups) — not just ' +
+        'the /auth/mfa endpoints. Strongly discouraged in production.',
+    });
+  }
+
   // Warn about optional secrets that look insecure
   const optionalSecrets = [
     'AGENT_ENROLLMENT_SECRET',
@@ -1034,6 +1053,7 @@ export function validateConfig(): AppConfig {
     RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS,
     BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: env.BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS,
     IS_HOSTED: env.IS_HOSTED,
+    ENABLE_2FA: env.ENABLE_2FA,
     OAUTH_DCR_ENABLED: env.OAUTH_DCR_ENABLED,
     OAUTH_DCR_REQUIRE_IAT: env.OAUTH_DCR_REQUIRE_IAT,
     // Task 26 (H-3): feature-flagged production secrets.

--- a/apps/api/src/middleware/apiKeyAuth.test.ts
+++ b/apps/api/src/middleware/apiKeyAuth.test.ts
@@ -47,7 +47,7 @@ import { getRedis, rateLimiter } from '../services';
 import { getActiveOrgTenant } from '../services/tenantStatus';
 import * as apiKeyAuthModule from './apiKeyAuth';
 
-const { apiKeyAuthMiddleware, requireApiKeyScope, eitherAuthMiddleware } = apiKeyAuthModule;
+const { apiKeyAuthMiddleware, requireApiKeyScope } = apiKeyAuthModule;
 
 type TestContext = Context & {
   _getResponseHeaders: () => Record<string, string>;
@@ -524,45 +524,6 @@ describe('requireApiKeyScope middleware', () => {
       status: 403,
       message: 'API key does not have required permissions'
     });
-  });
-});
-
-describe('eitherAuth middleware', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('rejects when neither Authorization nor X-API-Key headers are present', async () => {
-    const c = createContext();
-    const next = vi.fn();
-
-    await expect(eitherAuthMiddleware(c, next)).rejects.toMatchObject({
-      status: 401,
-      message: 'Authentication required. Provide either Authorization header or X-API-Key header.'
-    });
-  });
-
-  it.skip('prefers API key auth when X-API-Key is provided', async () => {
-    // Skipped: Complex spy mock required
-    const c = createContext({ 'X-API-Key': 'brz_key', Authorization: 'Bearer token' });
-    const next = vi.fn();
-    const apiKeySpy = vi
-      .spyOn(apiKeyAuthModule, 'apiKeyAuthMiddleware')
-      .mockResolvedValue(undefined as unknown as void);
-
-    await eitherAuthMiddleware(c, next);
-
-    expect(apiKeySpy).toHaveBeenCalledWith(c, next);
-    expect(next).not.toHaveBeenCalled();
-  });
-
-  it('falls through to next middleware when only Authorization header is provided', async () => {
-    const c = createContext({ Authorization: 'Bearer token' });
-    const next = vi.fn();
-
-    await eitherAuthMiddleware(c, next);
-
-    expect(next).toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/middleware/apiKeyAuth.ts
+++ b/apps/api/src/middleware/apiKeyAuth.ts
@@ -269,28 +269,3 @@ export function requireApiKeyScope(...requiredScopes: string[]) {
   };
 }
 
-/**
- * Middleware that accepts either JWT auth or API key auth.
- * Useful for endpoints that can be accessed by both users and automated systems.
- *
- * Usage: Use with authMiddleware for combined auth:
- *   app.use('*', eitherAuth)
- *
- * After this middleware, check c.get('auth') for user auth or c.get('apiKey') for API key auth.
- */
-export async function eitherAuthMiddleware(c: Context, next: Next) {
-  const authHeader = c.req.header('Authorization');
-  const apiKeyHeader = c.req.header('X-API-Key');
-
-  if (!authHeader && !apiKeyHeader) {
-    throw new HTTPException(401, { message: 'Authentication required. Provide either Authorization header or X-API-Key header.' });
-  }
-
-  // Prefer API key if both are provided (API keys are more specific)
-  if (apiKeyHeader) {
-    return apiKeyAuthMiddleware(c, next);
-  }
-
-  // Fall through to the next middleware (should be authMiddleware for JWT)
-  await next();
-}

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -54,130 +54,6 @@ declare module 'hono' {
   }
 }
 
-// Optional auth - doesn't throw if not authenticated, just sets auth to null
-export async function optionalAuthMiddleware(c: Context, next: Next) {
-  // If another middleware already authenticated this request, don't re-verify.
-  const existing = c.get('auth') as AuthContext | undefined;
-  if (existing) {
-    await next();
-    return;
-  }
-
-  const authHeader = c.req.header('Authorization');
-
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    // Not authenticated - continue without auth context
-    await next();
-    return;
-  }
-
-  const token = authHeader.slice(7);
-  const payload = await verifyToken(token);
-
-  if (!payload || payload.type !== 'access') {
-    // Invalid token - continue without auth context
-    await next();
-    return;
-  }
-
-  if (await isUserTokenRevoked(payload.sub, payload.iat)) {
-    // Token has been explicitly revoked - continue without auth context
-    await next();
-    return;
-  }
-
-  // Fetch user. Runs BEFORE withDbAccessContext is set (the outer purpose
-  // of this middleware), so under breeze_app without a scope the RLS policy
-  // on `users` denies everything. Wrap in system scope for the lookup only —
-  // the real request-scoped context is applied further down.
-  const [user] = await withSystemDbAccessContext(async () =>
-    db
-      .select({
-        id: users.id,
-        email: users.email,
-        name: users.name,
-        status: users.status,
-        isPlatformAdmin: users.isPlatformAdmin
-      })
-      .from(users)
-      .where(eq(users.id, payload.sub))
-      .limit(1)
-  );
-
-  if (user && user.status === 'active') {
-    try {
-      await assertActiveTenantContext({
-        scope: payload.scope,
-        partnerId: payload.partnerId,
-        orgId: payload.orgId,
-      });
-    } catch (err) {
-      if (!(err instanceof TenantInactiveError)) throw err;
-      await next();
-      return;
-    }
-
-    const accessibleOrgIds = await computeAccessibleOrgIds(
-      payload.scope,
-      payload.partnerId,
-      payload.orgId,
-      user.id
-    );
-    const accessiblePartnerIds = computeAccessiblePartnerIds(
-      payload.scope,
-      payload.partnerId
-    );
-
-    const orgCondition = (orgIdColumn: PgColumn): SQL | undefined => {
-      if (accessibleOrgIds === null) return undefined;
-      if (accessibleOrgIds.length === 0) {
-        return eq(orgIdColumn, '00000000-0000-0000-0000-000000000000');
-      }
-      if (accessibleOrgIds.length === 1) {
-        return eq(orgIdColumn, accessibleOrgIds[0]);
-      }
-      return inArray(orgIdColumn, accessibleOrgIds);
-    };
-
-    const canAccessOrg = (orgId: string): boolean => {
-      if (accessibleOrgIds === null) return true;
-      return accessibleOrgIds.includes(orgId);
-    };
-
-    await withDbAccessContext(
-      {
-        scope: payload.scope,
-        orgId: payload.orgId,
-        accessibleOrgIds,
-        accessiblePartnerIds,
-        userId: user.id
-      },
-      async () => {
-        c.set('auth', {
-          user: {
-            id: user.id,
-            email: user.email,
-            name: user.name,
-            isPlatformAdmin: user.isPlatformAdmin
-          },
-          token: payload,
-          partnerId: payload.partnerId,
-          orgId: payload.orgId,
-          scope: payload.scope,
-          accessibleOrgIds,
-          orgCondition,
-          canAccessOrg
-        });
-
-        await next();
-      }
-    );
-    return;
-  }
-
-  await next();
-}
-
 /**
  * Resolve whether the user's effective role for the current request has
  * `force_mfa=true`. Returns false for system scope (platform admin is a
@@ -393,7 +269,7 @@ export async function authMiddleware(c: Context, next: Next): Promise<void | Res
 
   // Fetch user to ensure they still exist and are active. Pre-auth lookup —
   // must run under system scope because the request's real scope isn't
-  // applied until further down (see optionalAuthMiddleware note).
+  // applied until further down (see the withDbAccessContext call below).
   const [user] = await withSystemDbAccessContext(async () =>
     db
       .select({

--- a/apps/api/src/routes/agents/agentAuthSkip.test.ts
+++ b/apps/api/src/routes/agents/agentAuthSkip.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { shouldSkipAgentAuth } from './index';
+
+const SKIPPED: Array<[string, string]> = [
+  ['/agents/enroll', 'enroll'],
+  ['/agents/renew-cert', 'renew-cert'],
+  ['/agents/quarantined', 'quarantined'],
+  ['/agents/org/123/settings', 'org'],
+  ['/agents/download/agent.msi', 'download'],
+  ['/agents/dev-123/approve', 'dev-123'],
+  ['/agents/dev-123/deny', 'dev-123'],
+];
+const ENFORCED: Array<[string, string]> = [
+  ['/agents/dev-123/heartbeat', 'dev-123'],
+  ['/agents/dev-123/inventory', 'dev-123'],
+  ['/agents/dev-123/commands', 'dev-123'],
+  ['/agents/dev-123/logs', 'dev-123'],
+  // Regression guards: nested paths ending in approve/deny MUST still enforce.
+  ['/agents/dev-123/scripts/s-1/approve', 'dev-123'],
+  ['/agents/dev-123/scripts/s-1/deny', 'dev-123'],
+  // Substring foot-guns must enforce.
+  ['/agents/dev-123/approveX', 'dev-123'],
+  ['/agents/dev-123/predeny', 'dev-123'],
+];
+
+describe('agent-auth skip carve-out', () => {
+  it.each(SKIPPED)('SKIPS for %s', (path, id) => {
+    expect(shouldSkipAgentAuth(path, id)).toBe(true);
+  });
+  it.each(ENFORCED)('ENFORCES for %s', (path, id) => {
+    expect(shouldSkipAgentAuth(path, id)).toBe(false);
+  });
+});

--- a/apps/api/src/routes/agents/index.ts
+++ b/apps/api/src/routes/agents/index.ts
@@ -32,14 +32,14 @@ export const AGENT_AUTH_SKIP_ACTIONS = new Set(['approve', 'deny']);
 export function shouldSkipAgentAuth(path: string, id: string): boolean {
   if (AGENT_AUTH_SKIP_ID_SEGMENTS.has(id)) return true;
   const segments = path.split('/').filter(Boolean);
-  const last = segments[segments.length - 1];
-  const secondLast = segments[segments.length - 2];
+  const last = segments[segments.length - 1] ?? '';
+  const secondLast = segments[segments.length - 2] ?? '';
   // Only the EXACT shape .../<id>/<action> skips — never a deeper nested path.
   return secondLast === id && AGENT_AUTH_SKIP_ACTIONS.has(last);
 }
 
 agentRoutes.use('/:id/*', async (c, next) => {
-  if (shouldSkipAgentAuth(c.req.path, c.req.param('id'))) return next();
+  if (shouldSkipAgentAuth(c.req.path, c.req.param('id') ?? '')) return next();
   return agentAuthMiddleware(c, next);
 });
 

--- a/apps/api/src/routes/agents/index.ts
+++ b/apps/api/src/routes/agents/index.ts
@@ -22,23 +22,24 @@ import { elevationRequestsRoutes } from './elevationRequests';
 
 export const agentRoutes = new Hono();
 
-// Apply agent auth to all parameterized routes.
-// Skip for endpoints that handle their own authentication:
-// - /enroll, /renew-cert, /quarantined (special endpoints matched as /:id)
-// - /org/* (org settings, uses user JWT auth)
-// - /:id/approve, /:id/deny (admin endpoints, use user JWT auth)
+// Sub-paths under /:id/* that handle their own (user-JWT) auth and skip agent-token auth.
+export const AGENT_AUTH_SKIP_ID_SEGMENTS = new Set([
+  'enroll', 'renew-cert', 'quarantined', 'org', 'download',
+]);
+// Routes of the exact shape /:id/<action> that use user JWT auth.
+export const AGENT_AUTH_SKIP_ACTIONS = new Set(['approve', 'deny']);
+
+export function shouldSkipAgentAuth(path: string, id: string): boolean {
+  if (AGENT_AUTH_SKIP_ID_SEGMENTS.has(id)) return true;
+  const segments = path.split('/').filter(Boolean);
+  const last = segments[segments.length - 1];
+  const secondLast = segments[segments.length - 2];
+  // Only the EXACT shape .../<id>/<action> skips — never a deeper nested path.
+  return secondLast === id && AGENT_AUTH_SKIP_ACTIONS.has(last);
+}
+
 agentRoutes.use('/:id/*', async (c, next) => {
-  const id = c.req.param('id');
-  if (id === 'enroll' || id === 'renew-cert' || id === 'quarantined' || id === 'org' || id === 'download') {
-    return next();
-  }
-  // Check if the sub-path is an admin endpoint that uses user JWT auth.
-  // Use a precise regex to only match /:id/approve or /:id/deny at the end
-  // of the path, avoiding false positives from substrings.
-  const path = c.req.path;
-  if (/\/[^/]+\/(approve|deny)$/.test(path)) {
-    return next();
-  }
+  if (shouldSkipAgentAuth(c.req.path, c.req.param('id'))) return next();
   return agentAuthMiddleware(c, next);
 });
 

--- a/apps/api/src/routes/auth/schemas.ts
+++ b/apps/api/src/routes/auth/schemas.ts
@@ -9,7 +9,12 @@ export const ENABLE_REGISTRATION = envFlag('ENABLE_REGISTRATION', false);
 export const ENABLE_2FA = envFlag('ENABLE_2FA', true);
 
 if (!ENABLE_2FA && process.env.NODE_ENV !== 'test') {
-  console.warn('[auth] WARNING: MFA is disabled (ENABLE_2FA=false). All MFA endpoints return 404.');
+  console.warn(
+    '[auth] WARNING: ENABLE_2FA=false. This disables ALL requireMfa() step-up ' +
+    'gates across the API (admin/abuse, tenant export/erasure, remote device ' +
+    'control, sensitive-data, API keys, SSO, backups/DR) — not just the ' +
+    '/auth/mfa endpoints. Do not use this configuration in production.',
+  );
 }
 
 // ============================================

--- a/apps/api/src/routes/devices/actuateElevation.test.ts
+++ b/apps/api/src/routes/devices/actuateElevation.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
 const {
@@ -174,12 +174,80 @@ function rigTransaction(opts: {
 
 describe('POST /devices/:id/actuate-elevation', () => {
   let app: Hono;
+  let savedPamEnv: string | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: enable the PAM actuator so existing tests continue to pass.
+    savedPamEnv = process.env.PAM_ACTUATOR_ENABLED;
+    process.env.PAM_ACTUATOR_ENABLED = 'true';
     setAuth();
     app = new Hono();
     app.route('/devices', actuateElevationRoutes);
+  });
+
+  afterEach(() => {
+    if (savedPamEnv === undefined) {
+      delete process.env.PAM_ACTUATOR_ENABLED;
+    } else {
+      process.env.PAM_ACTUATOR_ENABLED = savedPamEnv;
+    }
+  });
+
+  describe('env guard (PAM_ACTUATOR_ENABLED)', () => {
+    it('returns 403 and does NOT call db.transaction when PAM_ACTUATOR_ENABLED is unset', async () => {
+      delete process.env.PAM_ACTUATOR_ENABLED;
+
+      const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          elevationRequestId: ELEVATION_ID,
+          username: 'u',
+          password: 'p',
+        }),
+      });
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe('PAM actuator is disabled');
+      expect(vi.mocked(db.transaction)).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 and does NOT call db.transaction when PAM_ACTUATOR_ENABLED is "false"', async () => {
+      process.env.PAM_ACTUATOR_ENABLED = 'false';
+
+      const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          elevationRequestId: ELEVATION_ID,
+          username: 'u',
+          password: 'p',
+        }),
+      });
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe('PAM actuator is disabled');
+      expect(vi.mocked(db.transaction)).not.toHaveBeenCalled();
+    });
+
+    it('passes through to route logic when PAM_ACTUATOR_ENABLED is "true"', async () => {
+      process.env.PAM_ACTUATOR_ENABLED = 'true';
+      // Device lookup returns nothing → 404, but crucially the guard did NOT block (403).
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValue(undefined as never);
+
+      const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          elevationRequestId: ELEVATION_ID,
+          username: 'u',
+          password: 'p',
+        }),
+      });
+      // 404 means the guard passed and route logic ran (device not found).
+      expect(res.status).toBe(404);
+    });
   });
 
   describe('gate registration', () => {

--- a/apps/api/src/routes/devices/actuateElevation.ts
+++ b/apps/api/src/routes/devices/actuateElevation.ts
@@ -24,6 +24,15 @@ export const actuateElevationRoutes = new Hono();
 
 actuateElevationRoutes.use('*', authMiddleware);
 
+// Guard: PAM actuator is DISABLED by default. Enable only when JIT credentials
+// + agent-side target re-validation (Track 6) are deployed. Mirrors devPush.ts.
+actuateElevationRoutes.use('*', async (c, next) => {
+  if (process.env.PAM_ACTUATOR_ENABLED !== 'true') {
+    return c.json({ error: 'PAM actuator is disabled' }, 403);
+  }
+  return next();
+});
+
 /**
  * POST /devices/:id/actuate-elevation
  *

--- a/apps/api/src/routes/devices/actuateElevation.ts
+++ b/apps/api/src/routes/devices/actuateElevation.ts
@@ -25,7 +25,9 @@ export const actuateElevationRoutes = new Hono();
 actuateElevationRoutes.use('*', authMiddleware);
 
 // Guard: PAM actuator is DISABLED by default. Enable only when JIT credentials
-// + agent-side target re-validation (Track 6) are deployed. Mirrors devPush.ts.
+// + agent-side target re-validation (Track 6) are deployed. Same env-flag guard
+// STYLE as devPush.ts, but disabled by default in ALL environments (devPush only
+// gates production; it is on-by-default in dev).
 actuateElevationRoutes.use('*', async (c, next) => {
   if (process.env.PAM_ACTUATOR_ENABLED !== 'true') {
     return c.json({ error: 'PAM actuator is disabled' }, 403);

--- a/apps/api/src/services/dnsProviders/adguardHome.test.ts
+++ b/apps/api/src/services/dnsProviders/adguardHome.test.ts
@@ -1,31 +1,38 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AdGuardHomeProvider } from './adguardHome';
+import { requestJson } from './http';
+
+// requestJson now routes through safeFetch (SSRF-safe). The provider unit tests
+// don't exercise transport — they mock requestJson and assert the provider's
+// request shaping (URL, auth header, body) and response handling.
+vi.mock('./http', () => ({
+  requestJson: vi.fn()
+}));
 
 interface MockResponse {
-  ok: boolean;
-  status?: number;
-  statusText?: string;
+  ok?: boolean;
   body?: unknown;
-  headers?: Record<string, string>;
 }
 
-function makeFetchMock(responses: MockResponse[]): ReturnType<typeof vi.fn> {
+const requestJsonMock = vi.mocked(requestJson);
+
+// Queue parsed JSON bodies in call order. requestJson returns the parsed body
+// directly (unlike the old fetch mock which returned a Response).
+function makeFetchMock(responses: MockResponse[]): typeof requestJsonMock {
   const queue = [...responses];
-  return vi.fn(async () => {
+  requestJsonMock.mockImplementation(async () => {
     const next = queue.shift();
-    if (!next) throw new Error('fetch mock exhausted');
-    const headers = new Map(Object.entries(next.headers ?? {}));
-    return {
-      ok: next.ok,
-      status: next.status ?? (next.ok ? 200 : 500),
-      statusText: next.statusText ?? '',
-      text: async () => JSON.stringify(next.body ?? {}),
-      headers: { get: (k: string) => headers.get(k.toLowerCase()) ?? null }
-    } as unknown as Response;
+    if (!next) throw new Error('requestJson mock exhausted');
+    return (next.body ?? {}) as never;
   });
+  return requestJsonMock;
 }
 
 describe('AdGuardHomeProvider', () => {
+  beforeEach(() => {
+    requestJsonMock.mockReset();
+  });
+
   afterEach(() => {
     vi.unstubAllGlobals();
   });
@@ -41,7 +48,6 @@ describe('AdGuardHomeProvider', () => {
 
   it('sends HTTP Basic auth header on requests', async () => {
     const fetchMock = makeFetchMock([{ ok: true, body: { data: [] } }]);
-    vi.stubGlobal('fetch', fetchMock);
 
     await newProvider().syncEvents(new Date(0), new Date());
 
@@ -70,7 +76,6 @@ describe('AdGuardHomeProvider', () => {
         }]
       }
     }]);
-    vi.stubGlobal('fetch', fetchMock);
 
     const events = await newProvider().syncEvents(
       new Date('2026-05-21T00:00:00Z'),
@@ -108,7 +113,6 @@ describe('AdGuardHomeProvider', () => {
         ]
       }
     }]);
-    vi.stubGlobal('fetch', fetchMock);
 
     const events = await newProvider().syncEvents(
       new Date('2026-05-21T00:00:00Z'),
@@ -129,7 +133,6 @@ describe('AdGuardHomeProvider', () => {
         ]
       }
     }]);
-    vi.stubGlobal('fetch', fetchMock);
 
     const events = await newProvider().syncEvents(
       new Date('2026-05-21T10:00:00Z'),
@@ -146,7 +149,6 @@ describe('AdGuardHomeProvider', () => {
       { ok: true, body: { user_rules: ['||existing.bad^', '@@||allowed.good^'] } },
       { ok: true, body: {} }
     ]);
-    vi.stubGlobal('fetch', fetchMock);
 
     await newProvider().addBlocklistDomain('new.bad.example');
 
@@ -160,7 +162,6 @@ describe('AdGuardHomeProvider', () => {
     const fetchMock = makeFetchMock([
       { ok: true, body: { user_rules: ['||already.bad^'] } }
     ]);
-    vi.stubGlobal('fetch', fetchMock);
 
     await newProvider().addBlocklistDomain('already.bad');
 
@@ -172,7 +173,6 @@ describe('AdGuardHomeProvider', () => {
       { ok: true, body: { user_rules: ['||one.bad^', '||two.bad^', '@@||three.good^'] } },
       { ok: true, body: {} }
     ]);
-    vi.stubGlobal('fetch', fetchMock);
 
     await newProvider().removeBlocklistDomain('two.bad');
 
@@ -186,7 +186,6 @@ describe('AdGuardHomeProvider', () => {
       { ok: true, body: { user_rules: [] } },
       { ok: true, body: {} }
     ]);
-    vi.stubGlobal('fetch', fetchMock);
 
     await newProvider().addAllowlistDomain('safe.example');
 

--- a/apps/api/src/services/dnsProviders/adguardHome.ts
+++ b/apps/api/src/services/dnsProviders/adguardHome.ts
@@ -37,7 +37,8 @@ export class AdGuardHomeProvider implements DnsProvider {
   constructor(
     private readonly username: string,
     private readonly password: string | null,
-    private readonly config: AdGuardHomeConfig
+    private readonly config: AdGuardHomeConfig,
+    private readonly allowPrivateNetwork = false
   ) {}
 
   private baseUrl(): string {
@@ -56,6 +57,7 @@ export class AdGuardHomeProvider implements DnsProvider {
   private async call<T>(path: string, init: RequestInit = {}): Promise<T> {
     return requestJson<T>(`${this.baseUrl()}${path}`, {
       ...init,
+      allowPrivateNetwork: this.allowPrivateNetwork,
       headers: {
         Authorization: this.authHeader(),
         ...(init.headers ?? {})

--- a/apps/api/src/services/dnsProviders/http.test.ts
+++ b/apps/api/src/services/dnsProviders/http.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import https from 'https';
+import { EventEmitter } from 'events';
+import { requestJson } from './http';
+import { SsrfBlockedError, __setLookupForTests } from '../urlSafety';
+
+describe('requestJson — SSRF safety via safeFetch', () => {
+  afterEach(() => {
+    __setLookupForTests(null);
+    vi.restoreAllMocks();
+  });
+
+  describe('strict mode (allowPrivateNetwork unset)', () => {
+    it('rejects a hostname that resolves to cloud metadata (169.254.169.254)', async () => {
+      __setLookupForTests(async () => [{ address: '169.254.169.254', family: 4 }]);
+      await expect(requestJson('https://attacker.example/x')).rejects.toBeInstanceOf(
+        SsrfBlockedError
+      );
+    });
+
+    it('rejects a hostname that resolves to an RFC1918 address', async () => {
+      __setLookupForTests(async () => [{ address: '10.0.0.5', family: 4 }]);
+      await expect(requestJson('https://attacker.example/x')).rejects.toBeInstanceOf(
+        SsrfBlockedError
+      );
+    });
+
+    it('rejects a literal metadata URL without performing DNS', async () => {
+      let dnsCalled = false;
+      __setLookupForTests(async () => {
+        dnsCalled = true;
+        return [{ address: '8.8.8.8', family: 4 }];
+      });
+      await expect(
+        requestJson('http://169.254.169.254/latest/meta-data')
+      ).rejects.toBeInstanceOf(SsrfBlockedError);
+      expect(dnsCalled).toBe(false);
+    });
+  });
+
+  describe('on-prem opt-in (allowPrivateNetwork: true)', () => {
+    it('proceeds for an RFC1918 target and returns the parsed body', async () => {
+      // Hostname resolves to a 10.x address (permitted under opt-in). We stub
+      // https.request so the pinned connect "lands" and returns an empty body,
+      // proving the request got past the SSRF gate and parses successfully.
+      __setLookupForTests(async () => [{ address: '10.0.0.5', family: 4 }]);
+      const requestSpy = vi
+        .spyOn(https, 'request')
+        .mockImplementation((_options: any, callback?: any) => {
+          const req = new EventEmitter() as any;
+          req.write = vi.fn();
+          req.destroy = vi.fn();
+          req.setTimeout = vi.fn();
+          req.end = vi.fn(() => {
+            const res = new EventEmitter() as any;
+            res.statusCode = 200;
+            res.statusMessage = 'OK';
+            res.headers = { 'content-type': 'application/json' };
+            callback?.(res);
+            res.emit('data', Buffer.from('{}'));
+            res.emit('end');
+          });
+          return req;
+        });
+
+      const result = await requestJson('https://appliance.local/x', {
+        allowPrivateNetwork: true,
+        maxRetries: 0
+      });
+      expect(result).toEqual({});
+      expect(requestSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('STILL rejects cloud metadata (169.254.169.254) even with opt-in', async () => {
+      __setLookupForTests(async () => [{ address: '169.254.169.254', family: 4 }]);
+      await expect(
+        requestJson('https://attacker.example/x', {
+          allowPrivateNetwork: true,
+          maxRetries: 0
+        })
+      ).rejects.toBeInstanceOf(SsrfBlockedError);
+    });
+
+    it('STILL rejects loopback (127.0.0.1) even with opt-in', async () => {
+      __setLookupForTests(async () => [{ address: '127.0.0.1', family: 4 }]);
+      await expect(
+        requestJson('https://attacker.example/x', {
+          allowPrivateNetwork: true,
+          maxRetries: 0
+        })
+      ).rejects.toBeInstanceOf(SsrfBlockedError);
+    });
+
+    it('STILL rejects CGNAT (100.64.0.1) even with opt-in', async () => {
+      __setLookupForTests(async () => [{ address: '100.64.0.1', family: 4 }]);
+      await expect(
+        requestJson('https://attacker.example/x', {
+          allowPrivateNetwork: true,
+          maxRetries: 0
+        })
+      ).rejects.toBeInstanceOf(SsrfBlockedError);
+    });
+  });
+});

--- a/apps/api/src/services/dnsProviders/http.test.ts
+++ b/apps/api/src/services/dnsProviders/http.test.ts
@@ -36,6 +36,23 @@ describe('requestJson — SSRF safety via safeFetch', () => {
       ).rejects.toBeInstanceOf(SsrfBlockedError);
       expect(dnsCalled).toBe(false);
     });
+
+    it('rejects a literal IPv4-mapped IPv6 hex-form metadata URL (::ffff:a9fe:a9fe)', async () => {
+      let dnsCalled = false;
+      __setLookupForTests(async () => {
+        dnsCalled = true;
+        return [{ address: '8.8.8.8', family: 4 }];
+      });
+      // [::ffff:a9fe:a9fe] == 169.254.169.254
+      await expect(
+        requestJson('http://[::ffff:a9fe:a9fe]/latest/meta-data')
+      ).rejects.toBeInstanceOf(SsrfBlockedError);
+      expect(dnsCalled).toBe(false);
+    });
+
+    it('rejects a literal RFC1918 URL (10.0.0.5) in strict mode', async () => {
+      await expect(requestJson('http://10.0.0.5/x')).rejects.toBeInstanceOf(SsrfBlockedError);
+    });
   });
 
   describe('on-prem opt-in (allowPrivateNetwork: true)', () => {
@@ -71,6 +88,36 @@ describe('requestJson — SSRF safety via safeFetch', () => {
       expect(requestSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('proceeds for a LITERAL RFC1918 IP target (10.0.0.5) and returns the parsed body', async () => {
+      // No DNS hook needed — literal IPs are treated as pre-resolved. Verifies
+      // the literal-IP allow path past the SSRF gate (was previously untested).
+      const requestSpy = vi
+        .spyOn(https, 'request')
+        .mockImplementation((_options: any, callback?: any) => {
+          const req = new EventEmitter() as any;
+          req.write = vi.fn();
+          req.destroy = vi.fn();
+          req.setTimeout = vi.fn();
+          req.end = vi.fn(() => {
+            const res = new EventEmitter() as any;
+            res.statusCode = 200;
+            res.statusMessage = 'OK';
+            res.headers = { 'content-type': 'application/json' };
+            callback?.(res);
+            res.emit('data', Buffer.from('{}'));
+            res.emit('end');
+          });
+          return req;
+        });
+
+      const result = await requestJson('https://10.0.0.5/x', {
+        allowPrivateNetwork: true,
+        maxRetries: 0
+      });
+      expect(result).toEqual({});
+      expect(requestSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('STILL rejects cloud metadata (169.254.169.254) even with opt-in', async () => {
       __setLookupForTests(async () => [{ address: '169.254.169.254', family: 4 }]);
       await expect(
@@ -93,6 +140,16 @@ describe('requestJson — SSRF safety via safeFetch', () => {
 
     it('STILL rejects CGNAT (100.64.0.1) even with opt-in', async () => {
       __setLookupForTests(async () => [{ address: '100.64.0.1', family: 4 }]);
+      await expect(
+        requestJson('https://attacker.example/x', {
+          allowPrivateNetwork: true,
+          maxRetries: 0
+        })
+      ).rejects.toBeInstanceOf(SsrfBlockedError);
+    });
+
+    it('STILL rejects hex-form mapped metadata (::ffff:a9fe:a9fe) even with opt-in', async () => {
+      __setLookupForTests(async () => [{ address: '::ffff:a9fe:a9fe', family: 6 }]);
       await expect(
         requestJson('https://attacker.example/x', {
           allowPrivateNetwork: true,

--- a/apps/api/src/services/dnsProviders/http.test.ts
+++ b/apps/api/src/services/dnsProviders/http.test.ts
@@ -158,4 +158,64 @@ describe('requestJson — SSRF safety via safeFetch', () => {
       ).rejects.toBeInstanceOf(SsrfBlockedError);
     });
   });
+
+  describe('SSRF-blocked requests are NOT retried', () => {
+    it('fails fast on a blocked host even with maxRetries:3 (DNS lookup invoked exactly once)', async () => {
+      // Regression guard: the `!isSsrfBlocked` short-circuit in http.ts must
+      // prevent retrying an SSRF policy violation. If SsrfBlockedError were
+      // ever reclassified as retriable, the lookup would run maxRetries+1 times.
+      let lookupCalls = 0;
+      __setLookupForTests(async () => {
+        lookupCalls += 1;
+        return [{ address: '169.254.169.254', family: 4 }];
+      });
+
+      await expect(
+        requestJson('https://attacker.example/x', {
+          allowPrivateNetwork: true,
+          maxRetries: 3
+        })
+      ).rejects.toBeInstanceOf(SsrfBlockedError);
+
+      expect(lookupCalls).toBe(1);
+    });
+  });
+
+  describe('transient failures ARE retried (positive branch)', () => {
+    it('retries a transient 5xx and eventually succeeds (multiple transport attempts)', async () => {
+      // Literal allowed IP so there is no DNS hop; count transport invocations
+      // to confirm the retry loop runs more than once for a retriable 5xx.
+      let attempts = 0;
+      const requestSpy = vi
+        .spyOn(https, 'request')
+        .mockImplementation((_options: any, callback?: any) => {
+          const req = new EventEmitter() as any;
+          req.write = vi.fn();
+          req.destroy = vi.fn();
+          req.setTimeout = vi.fn();
+          req.end = vi.fn(() => {
+            attempts += 1;
+            const res = new EventEmitter() as any;
+            const firstAttempt = attempts === 1;
+            res.statusCode = firstAttempt ? 503 : 200;
+            res.statusMessage = firstAttempt ? 'Service Unavailable' : 'OK';
+            res.headers = firstAttempt
+              ? { 'content-type': 'application/json', 'retry-after': '0' }
+              : { 'content-type': 'application/json' };
+            callback?.(res);
+            res.emit('data', Buffer.from('{}'));
+            res.emit('end');
+          });
+          return req;
+        });
+
+      const result = await requestJson('https://10.0.0.5/x', {
+        allowPrivateNetwork: true,
+        maxRetries: 3
+      });
+
+      expect(result).toEqual({});
+      expect(requestSpy.mock.calls.length).toBeGreaterThan(1);
+    });
+  });
 });

--- a/apps/api/src/services/dnsProviders/http.ts
+++ b/apps/api/src/services/dnsProviders/http.ts
@@ -1,9 +1,17 @@
+import { safeFetch } from '../urlSafety';
+
 const DEFAULT_TIMEOUT_MS = 20_000;
 const DEFAULT_MAX_RETRIES = 3;
 
 interface RequestJsonInit extends RequestInit {
   timeoutMs?: number;
   maxRetries?: number;
+  /**
+   * Opt-in for on-prem appliance providers (Pi-hole / AdGuard Home on
+   * self-hosted deployments). Allows RFC1918/ULA targets while still blocking
+   * metadata/loopback/link-local/CGNAT. Hosted SaaS leaves this unset (strict).
+   */
+  allowPrivateNetwork?: boolean;
 }
 
 function toErrorMessage(status: number, statusText: string, body: string): string {
@@ -16,7 +24,12 @@ export async function requestJson<T>(
   input: string | URL,
   init: RequestJsonInit = {}
 ): Promise<T> {
-  const { timeoutMs = DEFAULT_TIMEOUT_MS, maxRetries = DEFAULT_MAX_RETRIES, ...fetchInit } = init;
+  const {
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    maxRetries = DEFAULT_MAX_RETRIES,
+    allowPrivateNetwork,
+    ...fetchInit
+  } = init;
 
   const parseRetryAfterMs = (header: string | null): number | null => {
     if (!header) return null;
@@ -52,8 +65,10 @@ export async function requestJson<T>(
     const timer = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
-      const response = await fetch(input, {
+      const response = await safeFetch(String(input), {
         ...fetchInit,
+        timeoutMs,
+        allowPrivateNetwork,
         signal: controller.signal,
         headers: {
           Accept: 'application/json',
@@ -80,9 +95,23 @@ export async function requestJson<T>(
         throw new Error(`Provider returned invalid JSON payload: ${text.slice(0, 300)}`);
       }
     } catch (error) {
+      // An SSRF policy violation must NOT be retried — fail fast. SsrfBlockedError
+      // is a plain Error subclass (not a TypeError), so the network checks below
+      // never match it; we additionally guard by name for clarity.
+      const isSsrfBlocked = error instanceof Error && error.name === 'SsrfBlockedError';
       const isAbort = error instanceof Error && error.name === 'AbortError';
-      const isNetwork = error instanceof TypeError;
-      if (attempt < maxRetries && (isAbort || isNetwork)) {
+      // safeFetch surfaces transport/TLS failures as plain Error (with `cause`)
+      // and timeouts/aborts as Error('request timed out…')/Error('aborted'). Treat
+      // those — plus the legacy fetch TypeError — as retriable transient failures.
+      const isNetwork =
+        error instanceof TypeError ||
+        (error instanceof Error &&
+          !isSsrfBlocked &&
+          (/timed out/i.test(error.message) ||
+            error.message === 'aborted' ||
+            error.message === 'socket hang up' ||
+            'cause' in error));
+      if (attempt < maxRetries && !isSsrfBlocked && (isAbort || isNetwork)) {
         await sleep(computeBackoffMs(attempt, null));
         continue;
       }

--- a/apps/api/src/services/dnsProviders/index.test.ts
+++ b/apps/api/src/services/dnsProviders/index.test.ts
@@ -30,7 +30,63 @@ describe('createDnsProvider — on-prem allowPrivateNetwork gating', () => {
     else process.env.IS_HOSTED = originalIsHosted;
   });
 
-  describe('self-hosted (IS_HOSTED unset/false)', () => {
+  describe('IS_HOSTED unset → STRICT (fail closed)', () => {
+    // An unmapped/unset IS_HOSTED must never silently weaken security
+    // (the #570 hardening lesson). On-prem providers stay strict unless
+    // self-host is affirmatively declared.
+    beforeEach(() => {
+      delete process.env.IS_HOSTED;
+    });
+
+    it('pihole stays strict (allowPrivateNetwork false)', async () => {
+      const provider = createDnsProvider({
+        provider: 'pihole',
+        apiKey: 'key',
+        apiSecret: null,
+        config: { apiEndpoint: 'https://pi.hole.local' } as never
+      });
+      await provider.addBlocklistDomain('bad.example');
+      expect(lastInit().allowPrivateNetwork).toBe(false);
+    });
+
+    it('adguard_home stays strict (allowPrivateNetwork false)', async () => {
+      const provider = createDnsProvider({
+        provider: 'adguard_home',
+        apiKey: 'admin',
+        apiSecret: 'pw',
+        config: { apiEndpoint: 'https://adguard.local' } as never
+      });
+      requestJsonMock.mockImplementation(async () => ({ data: [] }) as never);
+      await provider.syncEvents(new Date(0), new Date());
+      expect(lastInit().allowPrivateNetwork).toBe(false);
+    });
+
+    it('IS_HOSTED empty string stays strict (allowPrivateNetwork false)', async () => {
+      process.env.IS_HOSTED = '';
+      const provider = createDnsProvider({
+        provider: 'pihole',
+        apiKey: 'key',
+        apiSecret: null,
+        config: { apiEndpoint: 'https://pi.hole.local' } as never
+      });
+      await provider.addBlocklistDomain('bad.example');
+      expect(lastInit().allowPrivateNetwork).toBe(false);
+    });
+
+    it('IS_HOSTED garbage value stays strict (allowPrivateNetwork false)', async () => {
+      process.env.IS_HOSTED = 'garbage';
+      const provider = createDnsProvider({
+        provider: 'pihole',
+        apiKey: 'key',
+        apiSecret: null,
+        config: { apiEndpoint: 'https://pi.hole.local' } as never
+      });
+      await provider.addBlocklistDomain('bad.example');
+      expect(lastInit().allowPrivateNetwork).toBe(false);
+    });
+  });
+
+  describe('self-hosted (IS_HOSTED explicitly non-truthy)', () => {
     beforeEach(() => {
       process.env.IS_HOSTED = 'false';
     });

--- a/apps/api/src/services/dnsProviders/index.test.ts
+++ b/apps/api/src/services/dnsProviders/index.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createDnsProvider } from './index';
+import { requestJson } from './http';
+
+// Provider transport is mocked — we only assert that the factory threads the
+// on-prem `allowPrivateNetwork` opt-in into the right providers based on
+// IS_HOSTED, and leaves cloud providers strict.
+vi.mock('./http', () => ({
+  requestJson: vi.fn(async () => ({}))
+}));
+
+const requestJsonMock = vi.mocked(requestJson);
+
+function lastInit(): { allowPrivateNetwork?: boolean } {
+  const call = requestJsonMock.mock.calls.at(-1);
+  if (!call) throw new Error('requestJson was not called');
+  return (call[1] ?? {}) as { allowPrivateNetwork?: boolean };
+}
+
+describe('createDnsProvider — on-prem allowPrivateNetwork gating', () => {
+  const originalIsHosted = process.env.IS_HOSTED;
+
+  beforeEach(() => {
+    requestJsonMock.mockClear();
+    requestJsonMock.mockImplementation(async () => ({}) as never);
+  });
+
+  afterEach(() => {
+    if (originalIsHosted === undefined) delete process.env.IS_HOSTED;
+    else process.env.IS_HOSTED = originalIsHosted;
+  });
+
+  describe('self-hosted (IS_HOSTED unset/false)', () => {
+    beforeEach(() => {
+      process.env.IS_HOSTED = 'false';
+    });
+
+    it('pihole opts INTO private networking', async () => {
+      const provider = createDnsProvider({
+        provider: 'pihole',
+        apiKey: 'key',
+        apiSecret: null,
+        config: { apiEndpoint: 'https://pi.hole.local' } as never
+      });
+      await provider.addBlocklistDomain('bad.example');
+      expect(lastInit().allowPrivateNetwork).toBe(true);
+    });
+
+    it('adguard_home opts INTO private networking', async () => {
+      const provider = createDnsProvider({
+        provider: 'adguard_home',
+        apiKey: 'admin',
+        apiSecret: 'pw',
+        config: { apiEndpoint: 'https://adguard.local' } as never
+      });
+      requestJsonMock.mockImplementation(async () => ({ data: [] }) as never);
+      await provider.syncEvents(new Date(0), new Date());
+      expect(lastInit().allowPrivateNetwork).toBe(true);
+    });
+  });
+
+  describe('hosted SaaS (IS_HOSTED=true)', () => {
+    beforeEach(() => {
+      process.env.IS_HOSTED = 'true';
+    });
+
+    it('pihole stays strict (allowPrivateNetwork false)', async () => {
+      const provider = createDnsProvider({
+        provider: 'pihole',
+        apiKey: 'key',
+        apiSecret: null,
+        config: { apiEndpoint: 'https://pi.hole.local' } as never
+      });
+      await provider.addBlocklistDomain('bad.example');
+      expect(lastInit().allowPrivateNetwork).toBe(false);
+    });
+
+    it('adguard_home stays strict (allowPrivateNetwork false)', async () => {
+      const provider = createDnsProvider({
+        provider: 'adguard_home',
+        apiKey: 'admin',
+        apiSecret: 'pw',
+        config: { apiEndpoint: 'https://adguard.local' } as never
+      });
+      requestJsonMock.mockImplementation(async () => ({ data: [] }) as never);
+      await provider.syncEvents(new Date(0), new Date());
+      expect(lastInit().allowPrivateNetwork).toBe(false);
+    });
+  });
+
+  describe('cloud providers never set allowPrivateNetwork (strict regardless of IS_HOSTED)', () => {
+    beforeEach(() => {
+      process.env.IS_HOSTED = 'false'; // even self-hosted, cloud providers stay strict
+    });
+
+    it('cloudflare leaves allowPrivateNetwork unset', async () => {
+      const provider = createDnsProvider({
+        provider: 'cloudflare',
+        apiKey: 'token',
+        apiSecret: null,
+        config: { accountId: 'acct', blocklistId: 'bl' } as never
+      });
+      requestJsonMock.mockImplementation(async () => ({ success: true, result: {} }) as never);
+      await provider.addBlocklistDomain('bad.example');
+      expect(lastInit().allowPrivateNetwork).toBeUndefined();
+    });
+  });
+});

--- a/apps/api/src/services/dnsProviders/index.ts
+++ b/apps/api/src/services/dnsProviders/index.ts
@@ -1,4 +1,5 @@
 import type { DnsAction, DnsIntegrationConfig, DnsProvider as DnsProviderType } from '../../db/schema';
+import { isHosted } from '../../config/env';
 import { UmbrellaProvider } from './umbrella';
 import { CloudflareGatewayProvider } from './cloudflare';
 import { DnsFilterProvider } from './dnsfilter';
@@ -38,6 +39,13 @@ export function createDnsProvider(input: DnsProviderFactoryInput): DnsProvider {
     throw new Error(`Missing apiKey for DNS provider ${input.provider}`);
   }
 
+  // On-prem appliance providers (Pi-hole / AdGuard Home) legitimately live on
+  // the customer LAN, so on SELF-HOSTED deployments they may reach RFC1918/ULA
+  // targets. Hosted SaaS stays strict (no private networking). Metadata,
+  // loopback, link-local, and CGNAT remain blocked in both modes (see
+  // urlSafety.isAlwaysBlockedIp). Cloud providers leave it unset (strict).
+  const allowPrivateNetwork = !isHosted();
+
   switch (input.provider) {
     case 'umbrella':
       return new UmbrellaProvider(input.apiKey, input.apiSecret, input.config);
@@ -46,9 +54,9 @@ export function createDnsProvider(input: DnsProviderFactoryInput): DnsProvider {
     case 'dnsfilter':
       return new DnsFilterProvider(input.apiKey, input.config);
     case 'pihole':
-      return new PiHoleProvider(input.apiKey, input.config);
+      return new PiHoleProvider(input.apiKey, input.config, allowPrivateNetwork);
     case 'adguard_home':
-      return new AdGuardHomeProvider(input.apiKey, input.apiSecret, input.config);
+      return new AdGuardHomeProvider(input.apiKey, input.apiSecret, input.config, allowPrivateNetwork);
     case 'opendns':
     case 'quad9':
       throw new Error(`Provider ${input.provider} is not yet supported for API sync`);

--- a/apps/api/src/services/dnsProviders/index.ts
+++ b/apps/api/src/services/dnsProviders/index.ts
@@ -44,7 +44,19 @@ export function createDnsProvider(input: DnsProviderFactoryInput): DnsProvider {
   // targets. Hosted SaaS stays strict (no private networking). Metadata,
   // loopback, link-local, and CGNAT remain blocked in both modes (see
   // urlSafety.isAlwaysBlockedIp). Cloud providers leave it unset (strict).
-  const allowPrivateNetwork = !isHosted();
+  //
+  // Fail closed: only open RFC1918/ULA for on-prem providers when self-host is
+  // AFFIRMATIVELY declared (IS_HOSTED explicitly set to a recognized non-truthy
+  // value: 'false'/'0'/'no'/'off'). Unset/empty/garbage IS_HOSTED => strict,
+  // mirroring the #570 hardening lesson (an unmapped IS_HOSTED must never
+  // silently weaken security). We mirror envFlag's truthy set so that any value
+  // it would treat as truthy keeps us hosted (strict), and only an explicit
+  // recognized falsey signal opens private networking.
+  const isHostedRaw = (process.env.IS_HOSTED ?? '').trim().toLowerCase();
+  const recognizedSelfHostSignal = new Set(['0', 'false', 'no', 'off']).has(isHostedRaw);
+  // `!isHosted()` is implied by the falsey-set membership but kept explicit so
+  // the truthy/falsey vocabularies can never drift apart silently.
+  const allowPrivateNetwork = recognizedSelfHostSignal && !isHosted();
 
   switch (input.provider) {
     case 'umbrella':

--- a/apps/api/src/services/dnsProviders/pihole.ts
+++ b/apps/api/src/services/dnsProviders/pihole.ts
@@ -9,7 +9,8 @@ export interface PiHoleProviderConfig {
 export class PiHoleProvider implements DnsProvider {
   constructor(
     private readonly apiKey: string,
-    private readonly config: PiHoleProviderConfig
+    private readonly config: PiHoleProviderConfig,
+    private readonly allowPrivateNetwork = false
   ) {}
 
   private baseUrl(): string {
@@ -26,7 +27,9 @@ export class PiHoleProvider implements DnsProvider {
       url.searchParams.set(key, value);
     }
     url.searchParams.set('auth', this.apiKey);
-    return requestJson<Record<string, unknown>>(url);
+    return requestJson<Record<string, unknown>>(url, {
+      allowPrivateNetwork: this.allowPrivateNetwork
+    });
   }
 
   async syncEvents(since: Date, until: Date): Promise<DnsEvent[]> {

--- a/apps/api/src/services/urlSafety.test.ts
+++ b/apps/api/src/services/urlSafety.test.ts
@@ -2,7 +2,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import http from 'http';
 import { EventEmitter } from 'events';
 import type { AddressInfo } from 'net';
-import { safeFetch, isPrivateIp, SsrfBlockedError, __setLookupForTests } from './urlSafety';
+import {
+  safeFetch,
+  isPrivateIp,
+  isRfc1918OrUla,
+  isAlwaysBlockedIp,
+  SsrfBlockedError,
+  __setLookupForTests
+} from './urlSafety';
 
 describe('isPrivateIp', () => {
   it('classifies IPv4 loopback/private/link-local as private', () => {
@@ -43,6 +50,55 @@ describe('isPrivateIp', () => {
   it('classifies public IPv6 as not private', () => {
     expect(isPrivateIp('2001:4860:4860::8888')).toBe(false);
     expect(isPrivateIp('2606:4700:4700::1111')).toBe(false);
+  });
+});
+
+describe('isRfc1918OrUla', () => {
+  it('is true only for RFC1918 IPv4 + ULA IPv6', () => {
+    expect(isRfc1918OrUla('10.0.0.5')).toBe(true);
+    expect(isRfc1918OrUla('192.168.1.1')).toBe(true);
+    expect(isRfc1918OrUla('172.16.0.1')).toBe(true);
+    expect(isRfc1918OrUla('172.31.255.254')).toBe(true);
+    expect(isRfc1918OrUla('fd12::1')).toBe(true);
+    expect(isRfc1918OrUla('fc00::1')).toBe(true);
+    expect(isRfc1918OrUla('::ffff:10.0.0.1')).toBe(true);
+  });
+
+  it('is false for loopback/link-local/metadata/CGNAT/multicast/public', () => {
+    expect(isRfc1918OrUla('127.0.0.1')).toBe(false);
+    expect(isRfc1918OrUla('169.254.169.254')).toBe(false); // cloud metadata
+    expect(isRfc1918OrUla('100.64.0.1')).toBe(false); // CGNAT
+    expect(isRfc1918OrUla('0.0.0.0')).toBe(false);
+    expect(isRfc1918OrUla('224.0.0.1')).toBe(false); // multicast
+    expect(isRfc1918OrUla('fe80::1')).toBe(false); // link-local
+    expect(isRfc1918OrUla('::1')).toBe(false); // loopback
+    expect(isRfc1918OrUla('8.8.8.8')).toBe(false); // public
+    expect(isRfc1918OrUla('172.15.0.1')).toBe(false); // just outside 172.16/12
+    expect(isRfc1918OrUla('172.32.0.1')).toBe(false);
+  });
+});
+
+describe('isAlwaysBlockedIp', () => {
+  it('blocks metadata/loopback/link-local/CGNAT even though they are private', () => {
+    expect(isAlwaysBlockedIp('169.254.169.254')).toBe(true); // cloud metadata
+    expect(isAlwaysBlockedIp('127.0.0.1')).toBe(true);
+    expect(isAlwaysBlockedIp('100.64.0.1')).toBe(true); // CGNAT
+    expect(isAlwaysBlockedIp('fe80::1')).toBe(true); // link-local
+    expect(isAlwaysBlockedIp('::1')).toBe(true);
+    expect(isAlwaysBlockedIp('0.0.0.0')).toBe(true);
+    expect(isAlwaysBlockedIp('224.0.0.1')).toBe(true);
+  });
+
+  it('allows RFC1918/ULA appliance addresses (these are opt-in reachable)', () => {
+    expect(isAlwaysBlockedIp('10.0.0.5')).toBe(false);
+    expect(isAlwaysBlockedIp('192.168.1.1')).toBe(false);
+    expect(isAlwaysBlockedIp('172.16.0.1')).toBe(false);
+    expect(isAlwaysBlockedIp('fd12::1')).toBe(false);
+  });
+
+  it('allows public IPs', () => {
+    expect(isAlwaysBlockedIp('8.8.8.8')).toBe(false);
+    expect(isAlwaysBlockedIp('1.1.1.1')).toBe(false);
   });
 });
 

--- a/apps/api/src/services/urlSafety.test.ts
+++ b/apps/api/src/services/urlSafety.test.ts
@@ -41,10 +41,21 @@ describe('isPrivateIp', () => {
     expect(isPrivateIp('ff02::1')).toBe(true);
   });
 
-  it('unwraps IPv4-mapped IPv6', () => {
+  it('unwraps IPv4-mapped IPv6 (dotted-decimal form)', () => {
     expect(isPrivateIp('::ffff:127.0.0.1')).toBe(true);
     expect(isPrivateIp('::ffff:10.0.0.1')).toBe(true);
     expect(isPrivateIp('::ffff:8.8.8.8')).toBe(false);
+  });
+
+  it('unwraps IPv4-mapped IPv6 (hex-pair form) — metadata bypass guard', () => {
+    // ::ffff:a9fe:a9fe == 169.254.169.254 (cloud metadata)
+    expect(isPrivateIp('::ffff:a9fe:a9fe')).toBe(true);
+    expect(isPrivateIp('::FFFF:A9FE:A9FE')).toBe(true); // uppercase
+    // ::ffff:a00:1 == 10.0.0.1 (RFC1918)
+    expect(isPrivateIp('::ffff:a00:1')).toBe(true);
+    // ::ffff:0808:0808 == 8.8.8.8 (public) — must NOT be flagged private
+    expect(isPrivateIp('::ffff:0808:0808')).toBe(false);
+    expect(isPrivateIp('::ffff:808:808')).toBe(false);
   });
 
   it('classifies public IPv6 as not private', () => {
@@ -62,6 +73,16 @@ describe('isRfc1918OrUla', () => {
     expect(isRfc1918OrUla('fd12::1')).toBe(true);
     expect(isRfc1918OrUla('fc00::1')).toBe(true);
     expect(isRfc1918OrUla('::ffff:10.0.0.1')).toBe(true);
+    // hex-pair mapped form of 10.0.0.1
+    expect(isRfc1918OrUla('::ffff:a00:1')).toBe(true);
+    // uppercase mapped form (Bug 2: case-sensitivity)
+    expect(isRfc1918OrUla('::FFFF:10.0.0.1')).toBe(true);
+  });
+
+  it('is false for embedded metadata in a mapped IPv6 (always-blocked even though "mapped")', () => {
+    // ::ffff:a9fe:a9fe == 169.254.169.254 (metadata) — not RFC1918, stays blocked
+    expect(isRfc1918OrUla('::ffff:a9fe:a9fe')).toBe(false);
+    expect(isRfc1918OrUla('::ffff:169.254.169.254')).toBe(false);
   });
 
   it('is false for loopback/link-local/metadata/CGNAT/multicast/public', () => {
@@ -124,6 +145,26 @@ describe('safeFetch — SSRF policy', () => {
       SsrfBlockedError
     );
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('rejects literal IPv4-mapped IPv6 hex-form metadata without DNS (strict)', async () => {
+    const spy = vi.fn();
+    __setLookupForTests(async (...args) => {
+      spy(...args);
+      return [{ address: '8.8.8.8', family: 4 }];
+    });
+    // [::ffff:a9fe:a9fe] == 169.254.169.254 cloud metadata
+    await expect(safeFetch('http://[::ffff:a9fe:a9fe]/latest/meta-data')).rejects.toBeInstanceOf(
+      SsrfBlockedError
+    );
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('rejects literal IPv4-mapped IPv6 hex-form metadata even with allowPrivateNetwork', async () => {
+    // metadata is always blocked, even under the on-prem opt-in
+    await expect(
+      safeFetch('http://[::ffff:a9fe:a9fe]/latest/meta-data', { allowPrivateNetwork: true })
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
   });
 
   it('rejects unsupported schemes', async () => {

--- a/apps/api/src/services/urlSafety.ts
+++ b/apps/api/src/services/urlSafety.ts
@@ -64,13 +64,41 @@ function isPrivateV4(ip: string): boolean {
   return PRIVATE_V4_MATCHERS.some((m) => m(octets));
 }
 
+/**
+ * If `ip` is an IPv4-mapped IPv6 literal (`::ffff:…`), return the embedded IPv4
+ * address as a dotted-decimal string; otherwise return null. Handles BOTH the
+ * dotted-decimal form (`::ffff:169.254.169.254`) AND the hex-pair form
+ * (`::ffff:a9fe:a9fe`), case-insensitively.
+ *
+ * The hex-pair form is the dangerous one: `parseInt('a9fe',16)`/`parseInt('a9fe',16)`
+ * decode to 169.254.169.254 (cloud metadata) yet `::ffff:a9fe:a9fe` still
+ * contains a `:` after stripping the prefix, so a naive check routes it to the
+ * IPv6 fc/fd path and never matches — an SSRF filter bypass.
+ */
+function mappedV4(ip: string): string | null {
+  const lower = ip.toLowerCase();
+  if (!lower.startsWith('::ffff:')) return null;
+  const rest = lower.slice('::ffff:'.length);
+  // Dotted-decimal embedded form: ::ffff:a.b.c.d
+  if (rest.includes('.')) {
+    return parseV4(rest) ? rest : null;
+  }
+  // Hex-pair embedded form: ::ffff:HHHH:HHHH
+  const groups = rest.split(':');
+  if (groups.length !== 2) return null;
+  if (!groups.every((g) => /^[0-9a-f]{1,4}$/.test(g))) return null;
+  const hi = parseInt(groups[0]!, 16);
+  const lo = parseInt(groups[1]!, 16);
+  return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+}
+
 function isPrivateV6(ip: string): boolean {
   const lower = ip.toLowerCase();
   if (lower === '::' || lower === '::1') return true;
-  // IPv4-mapped IPv6 (::ffff:a.b.c.d)
-  if (lower.startsWith('::ffff:')) {
-    const v4 = lower.slice('::ffff:'.length);
-    if (isPrivateV4(v4)) return true;
+  // IPv4-mapped IPv6 (::ffff:a.b.c.d AND ::ffff:HHHH:HHHH hex-pair forms)
+  const mapped = mappedV4(lower);
+  if (mapped !== null) {
+    return isPrivateV4(mapped);
   }
   // Unique Local Addresses (fc00::/7) — first byte 0xfc or 0xfd
   if (lower.startsWith('fc') || lower.startsWith('fd')) return true;
@@ -88,9 +116,12 @@ function isPrivateV6(ip: string): boolean {
  */
 export function isPrivateIp(ip: string): boolean {
   if (!ip) return true;
-  const stripped = ip.startsWith('::ffff:') ? ip.slice('::ffff:'.length) : ip;
-  if (stripped.includes(':')) return isPrivateV6(stripped);
-  return isPrivateV4(stripped);
+  // Normalize any IPv4-mapped IPv6 literal (dotted OR hex-pair) to its embedded
+  // IPv4 first, so both forms route through the IPv4 matchers.
+  const mapped = mappedV4(ip);
+  if (mapped !== null) return isPrivateV4(mapped);
+  if (ip.includes(':')) return isPrivateV6(ip);
+  return isPrivateV4(ip);
 }
 
 // RFC1918 (IPv4 private) + ULA (IPv6 fc00::/7) only. This is the strict subset
@@ -117,13 +148,17 @@ function isRfc1918V4(ip: string): boolean {
  */
 export function isRfc1918OrUla(ip: string): boolean {
   if (!ip) return false;
-  const stripped = ip.startsWith('::ffff:') ? ip.slice('::ffff:'.length) : ip;
-  if (stripped.includes(':')) {
-    const lower = stripped.toLowerCase();
+  const lower = ip.toLowerCase();
+  // Normalize any IPv4-mapped IPv6 literal (dotted OR hex-pair, case-insensitive)
+  // to its embedded IPv4, so embedded RFC1918 is recognized as RFC1918 and
+  // embedded metadata is treated as non-RFC1918 (stays always-blocked).
+  const mapped = mappedV4(lower);
+  if (mapped !== null) return isRfc1918V4(mapped);
+  if (lower.includes(':')) {
     // ULA fc00::/7 — first byte 0xfc or 0xfd.
     return lower.startsWith('fc') || lower.startsWith('fd');
   }
-  return isRfc1918V4(stripped);
+  return isRfc1918V4(lower);
 }
 
 /**

--- a/apps/api/src/services/urlSafety.ts
+++ b/apps/api/src/services/urlSafety.ts
@@ -93,6 +93,48 @@ export function isPrivateIp(ip: string): boolean {
   return isPrivateV4(stripped);
 }
 
+// RFC1918 (IPv4 private) + ULA (IPv6 fc00::/7) only. This is the strict subset
+// of `isPrivateIp` that an on-prem appliance integration may legitimately need
+// to reach (e.g. a Pi-hole / AdGuard Home box on the LAN). Deliberately
+// EXCLUDES loopback (127/8, ::1), link-local + cloud metadata (169.254/16,
+// fe80::/10), CGNAT (100.64/10), unspecified (0/8), multicast/reserved, and
+// documentation/TEST-NET ranges — those are never a legitimate appliance
+// target and remain blocked even when private networking is opted in.
+function isRfc1918V4(ip: string): boolean {
+  const octets = parseV4(ip);
+  if (!octets) return false;
+  return (
+    octets[0] === 10 || // 10.0.0.0/8
+    (octets[0] === 192 && octets[1] === 168) || // 192.168.0.0/16
+    (octets[0] === 172 && octets[1]! >= 16 && octets[1]! <= 31) // 172.16.0.0/12
+  );
+}
+
+/**
+ * True only for RFC1918 IPv4 or ULA IPv6 (fc00::/7) addresses — the ranges an
+ * on-prem appliance integration may opt into reaching. Loopback, link-local,
+ * metadata, CGNAT, multicast, etc. are NOT included here (see `isAlwaysBlockedIp`).
+ */
+export function isRfc1918OrUla(ip: string): boolean {
+  if (!ip) return false;
+  const stripped = ip.startsWith('::ffff:') ? ip.slice('::ffff:'.length) : ip;
+  if (stripped.includes(':')) {
+    const lower = stripped.toLowerCase();
+    // ULA fc00::/7 — first byte 0xfc or 0xfd.
+    return lower.startsWith('fc') || lower.startsWith('fd');
+  }
+  return isRfc1918V4(stripped);
+}
+
+/**
+ * IPs that must NEVER be dialed even when `allowPrivateNetwork` is set: any
+ * private/loopback/link-local/metadata/CGNAT/multicast range that is NOT a
+ * plain RFC1918/ULA appliance address. Public IPs return false (allowed).
+ */
+export function isAlwaysBlockedIp(ip: string): boolean {
+  return isPrivateIp(ip) ? !isRfc1918OrUla(ip) : false;
+}
+
 // Optionally override DNS lookup in tests via module-level hook.
 type LookupAllFn = (
   hostname: string,
@@ -110,6 +152,13 @@ export function __setLookupForTests(fn: LookupAllFn | null): void {
 export interface SafeFetchInit extends Omit<RequestInit, 'signal'> {
   timeoutMs?: number;
   signal?: AbortSignal;
+  /**
+   * Opt-in for on-prem appliance integrations (e.g. Pi-hole / AdGuard Home on
+   * self-hosted deployments): allows RFC1918/ULA targets. Loopback, link-local,
+   * cloud metadata (169.254.169.254), CGNAT, multicast, etc. remain blocked
+   * even when this is true. Leave unset for strict (hosted-SaaS) behavior.
+   */
+  allowPrivateNetwork?: boolean;
 }
 
 /**
@@ -129,11 +178,16 @@ export async function safeFetch(urlStr: string, init: SafeFetchInit = {}): Promi
 
   const hostname = u.hostname.replace(/^\[|\]$/g, '');
 
+  // Pick the blocking predicate. With `allowPrivateNetwork`, RFC1918/ULA
+  // appliance addresses are permitted but metadata/loopback/link-local/CGNAT
+  // (etc.) are STILL blocked; otherwise every private range is blocked.
+  const block = init.allowPrivateNetwork ? isAlwaysBlockedIp : isPrivateIp;
+
   // If the URL itself is a literal private IP, reject without any DNS work.
   // (This also catches `localhost` via the DNS path below, but handling
   // literals first avoids needing to resolve them.)
   const isLiteral = /^[\d.]+$/.test(hostname) || hostname.includes(':');
-  if (isLiteral && isPrivateIp(hostname)) {
+  if (isLiteral && block(hostname)) {
     throw new SsrfBlockedError(`URL points to blocked address: ${hostname}`, {
       hostname,
       resolvedIps: [hostname]
@@ -153,7 +207,7 @@ export async function safeFetch(urlStr: string, init: SafeFetchInit = {}): Promi
   }
 
   const allIps = records.map((r) => r.address);
-  const safeRecord = records.find((r) => !isPrivateIp(r.address));
+  const safeRecord = records.find((r) => !block(r.address));
   if (!safeRecord) {
     throw new SsrfBlockedError(
       `all resolved IPs for ${hostname} are private/loopback/link-local`,

--- a/apps/docs/src/content/docs/reference/api-keys.mdx
+++ b/apps/docs/src/content/docs/reference/api-keys.mdx
@@ -118,7 +118,7 @@ The middleware performs these steps in order:
 
 ### Dual Authentication
 
-Some endpoints accept either a JWT bearer token or an API key. When both headers are present, the API key takes precedence. The `eitherAuthMiddleware` enables this by checking for `X-API-Key` first, then falling back to the `Authorization` bearer token.
+Some endpoints accept either a JWT bearer token or an API key. When both headers are present, the API key takes precedence: the route handler checks for `X-API-Key` first and authenticates via `apiKeyAuthMiddleware`, falling back to `authMiddleware` only when that header is absent.
 
 ### Key Rotation
 


### PR DESCRIPTION
## Summary

Fixes the actionable findings from the May 2026 security review (everything **except #1**, which another agent owns). Each finding was independently re-verified against source before fixing, implemented TDD, and given spec + code-quality review. Organized as one shippable workstream per finding.

| Finding | Sev | Fix |
|---|---|---|
| **#10** | LOW | Agent-auth skip carve-out converted from an open-ended `/approve\|/deny$` regex to an exact-match allowlist (`shouldSkipAgentAuth`); nested paths like `/:id/scripts/:sid/approve` now correctly **enforce** agent auth. Regression test added. |
| **#9** | LOW | Deleted dead `optionalAuthMiddleware` + `eitherAuthMiddleware` (the latter's `await next()` fall-through was an auth-bypass foot-gun if ever mounted standalone). Stale docs ref removed. |
| **#6** | MED | Replaced the hand-maintained 5-key secret strip-list with a drift-proof predicate (`isSecretYAMLKey`: explicit set + `_token`/`_secret_key`/`_access_key`/`_secret`/`_password` suffixes) used in all 3 sites — now catches `backup_s3_*`. `helper_auth_token` explicitly preserved in agent.yaml. Companion `Load` read-back added (+ guard comment). |
| **#8** | LOW | `secrets.yaml` chmod-enforce failure is now **fatal** (was warn-only). `agent.yaml`/dir enforce stays warn-only — invariant preserved: agent.yaml remains Helper-readable. |
| **#5** | MED | DNS-provider sync (`requestJson`) now routes through the DNS-pinning `safeFetch` instead of raw `fetch()`; on-prem providers (pihole/adguard) get an `allowPrivateNetwork` opt-in gated on `!IS_HOSTED` (RFC1918 allowed self-hosted, **metadata/loopback/CGNAT always blocked**). Review also surfaced a **Critical** IPv4-mapped-IPv6 hex-form metadata bypass (`http://[::ffff:a9fe:a9fe]/`) in the shared SSRF guard — fixed via a `mappedV4` normalizer, which hardens **all** safeFetch callers (webhooks/SSO/SentinelOne). |
| **#7** | LOW/MED | `access_reviews` partner-axis rows (`org_id=NULL`) had org-only RLS → app-layer-only filter (violates the no-app-layer-only invariant). New forward migration converts to Shape-4 dual-axis (`breeze_has_org_access(org_id) OR breeze_has_partner_access(partner_id)`). |
| **#3** | MED | **Warn-only** (deliberate decision — no boot-refusal, no gate behavior change, so a self-hosted 2FA-off deploy isn't locked out): corrected the misleading `ENABLE_2FA` warning to state it neuters **all** `requireMfa()` gates, and added a non-fatal config-validator warning that fires for any disabling value (matching `envFlag`). |
| **#2** | HIGH | PAM actuate-elevation route gated **OFF by default** (`PAM_ACTUATOR_ENABLED !== 'true'` → 403), auth still runs first. The full Track-6 hardening (#2a server-minted JIT creds, #2b agent-side target re-validation, #4 separation-of-duties approval flow) is **deferred** with a design section in the plan — do **not** enable in production until those land. |

**Out of scope:** #1 (other agent). The build-breaker (stray `pl` token in `agent/internal/collectors/command_limits.go`) is an uncommitted change in the *main* checkout, not this branch — fix it there.

Plan + design (incl. deferred Track-6): `docs/superpowers/plans/2026-05-29-security-review-batch2-fixes.md`.

## Test Plan

- [x] API changed-area suites: **373 tests** green (`agentAuthSkip`, `apiKeyAuth`, `auth`, `dnsProviders`, `urlSafety`, `validate`, `actuateElevation`)
- [x] `tsc --noEmit` clean
- [x] Go `internal/config`: tests pass (`go test -race`)
- [x] **#7 RLS verified against a real DB**: `rls-coverage` contract test 17/17, and a live `breeze_app` cross-tenant forge confirmed partner-B insert rejected with `new row violates row-level security policy` while partner-A succeeds
- [x] **#5 metadata bypass** proven: pre-fix test confirmed `safeFetch` was dispatching to `::ffff:a9fe:a9fe`; post-fix blocked in strict **and** on-prem modes
- [ ] CI: full + RLS + integration suites
- [ ] Pre-merge: rebase onto current `origin/main` (advanced to `de29c3fe` / #994,#995 after branch point — verified non-conflicting: #995 touches `validate.ts:260`, mine at 384/965/1034)

🤖 Generated with [Claude Code](https://claude.com/claude-code)