### PR TITLE
fix(api): reconcile checksums for #994 audit-migration edits (unblocks v0.67.1→v0.68.x upgrade)

### DIFF
--- a/apps/api/src/db/autoMigrate.test.ts
+++ b/apps/api/src/db/autoMigrate.test.ts
@@ -5,6 +5,7 @@ import {
   hasNoTransactionDirective,
   splitSqlStatements,
   deriveAppConnectionString,
+  CHECKSUM_RECONCILIATIONS,
 } from './autoMigrate';
 import { createHash } from 'node:crypto';
 import { readdirSync, readFileSync } from 'node:fs';
@@ -387,5 +388,26 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS bar_idx ON t (b);`;
       expect(out[0]).toContain('foo_idx');
       expect(out[1]).toContain('bar_idx');
     });
+  });
+});
+
+describe('CHECKSUM_RECONCILIATIONS', () => {
+  const migrationsDir = path.resolve(__dirname, '../../migrations');
+
+  it('each entry targets a real shipped migration whose CURRENT content hashes to `to`', () => {
+    const entries = Object.entries(CHECKSUM_RECONCILIATIONS);
+    expect(entries.length).toBeGreaterThan(0);
+    for (const [filename, rec] of entries) {
+      // The current on-disk file must hash to the declared `to`. If someone
+      // edits one of these migrations again, this fails until `to` is updated —
+      // preventing a silently-stale heal map.
+      const content = readFileSync(path.join(migrationsDir, filename), 'utf8');
+      expect(hashSql(content)).toBe(rec.to);
+      // A reconciliation must represent an actual change, with valid checksums.
+      expect(rec.from).not.toBe(rec.to);
+      expect(rec.from).toMatch(/^[0-9a-f]{64}$/);
+      expect(rec.to).toMatch(/^[0-9a-f]{64}$/);
+      expect(rec.reason.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/apps/api/src/db/autoMigrate.ts
+++ b/apps/api/src/db/autoMigrate.ts
@@ -18,6 +18,41 @@ export function hashSql(content: string): string {
 }
 
 /**
+ * Known, verified-safe in-place edits to ALREADY-SHIPPED migrations.
+ *
+ * The checksum guard (step 6) normally refuses to boot if an applied
+ * migration's file content changed — editing shipped migrations is forbidden.
+ * The rare exception is a forward-fix that is provably equivalent/idempotent
+ * for any DB that already applied the original. For those, we heal the recorded
+ * checksum (from -> to) instead of crashing the upgrade.
+ *
+ * Each entry MUST be a deliberate, reviewed pair of exact checksums. A mismatch
+ * that is NOT an exact from->to match still throws. Only DBs that recorded the
+ * `from` checksum are touched — fresh installs / DBs that never applied the
+ * original are unaffected (they apply the current file normally).
+ *
+ * #994 edited 2026-05-25-b/c (`::bytea` -> `convert_to(payload, 'UTF8')`) to fix
+ * audit-chain hashing; the change is equivalent for already-chained rows. Only
+ * v0.67.1 DBs recorded the originals, so without this they crash on the
+ * v0.68.x upgrade with a checksum mismatch.
+ */
+export const CHECKSUM_RECONCILIATIONS: Record<
+  string,
+  { from: string; to: string; reason: string }
+> = {
+  '2026-05-25-b-audit-log-checksum-chain.sql': {
+    from: 'ccb3893ad6a659bcbebd759c9f3caef777f62ab0b9bc72b1d7a7bf7a6448fd7b',
+    to: '813160a82318e5e8da0320749efc2e47ee3319d949b9fc68e2447398c5313fdc',
+    reason: "#994: ::bytea -> convert_to(payload,'UTF8') for audit-chain hashing",
+  },
+  '2026-05-25-c-audit-log-checksum-canonical-fix.sql': {
+    from: '71df754e3171079848092df7fda360a3619e8760e288d219bdb76071fa6b0cde',
+    to: '214ebca196629d81d54610bad9ff79fef8b2b5bfb19c0b024a4cf2a6b230f693',
+    reason: '#994: canonical audit-chain fix (companion to 2026-05-25-b)',
+  },
+};
+
+/**
  * True if a migration file opts out of the default transactional apply.
  *
  * Detection: the directive `-- @no-transaction` must appear at the start
@@ -349,6 +384,25 @@ export async function autoMigrate(): Promise<void> {
       const currentChecksum = hashSql(content);
 
       if (priorChecksum !== currentChecksum) {
+        const reconciliation = CHECKSUM_RECONCILIATIONS[filename];
+        if (
+          reconciliation &&
+          reconciliation.from === priorChecksum &&
+          reconciliation.to === currentChecksum
+        ) {
+          // Known, verified-safe forward-fix to a shipped migration: heal the
+          // recorded checksum instead of crashing the upgrade. Exact from->to
+          // match only; any other change still throws below.
+          await client.unsafe(
+            `UPDATE ${MIGRATION_TABLE} SET checksum = $1 WHERE filename = $2`,
+            [currentChecksum, filename],
+          );
+          applied.set(filename, currentChecksum);
+          console.log(
+            `[auto-migrate] Reconciled checksum for ${filename} (known forward-fix: ${reconciliation.reason})`,
+          );
+          continue;
+        }
         throw new Error(
           `Migration checksum mismatch for ${filename}. ` +
             'The file changed after being applied. Add a new migration instead.',


### PR DESCRIPTION
## Problem
`#994` edited two **already-shipped** migrations in place — `2026-05-25-b-audit-log-checksum-chain.sql` and `-c-…-canonical-fix.sql` (`::bytea` → `convert_to(payload,'UTF8')`). `autoMigrate`'s checksum guard refuses to boot if an applied migration's content changed, so **any DB that recorded the originals (i.e. ran v0.67.1) crashes on upgrade to v0.68.x**:

> `[CRITICAL] API startup failed: Migration checksum mismatch for 2026-05-25-b-audit-log-checksum-chain.sql. The file changed after being applied.`

**Blast radius (confirmed by querying prod):** hosted EU (`0.66.1`) and US (`0.67.0`) never recorded `b/c` (`AUDIT_BC=0` on both) → unaffected. The break hits **self-hosters on v0.67.1**.

## Fix
A tightly-scoped `CHECKSUM_RECONCILIATIONS` allowlist in `autoMigrate.ts`. For these two known files only, when the recorded checksum is **exactly** the old value and the current file is **exactly** the new value, heal the recorded checksum (UPDATE `breeze_migrations`) instead of crashing. 
- Any other mismatch still throws (guard intact).
- Fresh installs / DBs that never recorded the originals are untouched (`if (!priorChecksum) continue`).

## Verification (local Docker, isolated stack)
- **New install (v0.68.0):** all migrations apply from baseline incl. the 2 new ones — clean (pre-existing).
- **Upgrade v0.67.1 → v0.68.0 (released image): CRASHED** with the checksum mismatch (reproduced).
- **Upgrade v0.67.1 → fixed image:** reconciles both checksums, applies the 2 pending migrations, boots healthy (`208 → 210`). ✅
- Unit test pins the reconciliation `to` checksums to the live migration files (43/43 autoMigrate tests pass).

## Notes
- No new migration — the fix is in the migrate-runner's checksum validation (a new migration couldn't help; the guard throws before any migration runs).
- Target release: **v0.68.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)