### PR TITLE
fix(agent): Windows agent crash on startup — nil context to ETW consumer (CRITICAL)

### DIFF
--- a/agent/internal/etwlua/etwlua_windows.go
+++ b/agent/internal/etwlua/etwlua_windows.go
@@ -3,6 +3,7 @@
 package etwlua
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -65,7 +66,13 @@ func NewETWSubscriber() (Subscriber, error) {
 		return nil, fmt.Errorf("etwlua: enable LUA provider: %w", err)
 	}
 
-	consumer := etw.NewRealTimeConsumer(nil).FromSessions(session)
+	// NewRealTimeConsumer derives its context via context.WithCancel(parent)
+	// and PANICS on a nil parent ("cannot create context from nil parent"),
+	// which crashed the agent on startup on every Windows host running as
+	// SYSTEM. The consumer is explicitly torn down by etwSession.Stop()
+	// (consumer.Stop()), invoked from etwlua.Start's `defer sub.Stop()` on
+	// ctx.Done(), so context.Background() here is sufficient and leak-free.
+	consumer := etw.NewRealTimeConsumer(context.Background()).FromSessions(session)
 
 	s := &etwSession{
 		consumer: consumer,


### PR DESCRIPTION
## CRITICAL: v0.68.0 / v0.68.1 Windows agent is dead on arrival

The PAM ETW LUA subscriber (#959) calls `etw.NewRealTimeConsumer(nil)` in `etwlua_windows.go`. The library runs `context.WithCancel(parent)` on it and **panics** `cannot create context from nil parent`, so the agent **crashes on startup on every Windows host running as SYSTEM** (the normal service):
- `startETWLua` only gates on `privilege.IsRunningAsRoot()` — always true for the SYSTEM service.
- `EnableProvider` succeeds for SYSTEM → execution always reaches the `nil`-context call → panic.

**Observed on the Windows test VM:** the v0.68.0 agent starts, inits the broker, then dies ~1s later, repeatedly; the MSI in-place upgrade fails with **Error 1920** and rolls back. Captured stack:
```
panic: cannot create context from nil parent
  context.WithCancel({0x0, 0x0})
  golang-etw/etw.NewRealTimeConsumer({0x0, 0x0})
  etwlua.NewETWSubscriber()  etwlua_windows.go:68
  main.startETWLua(...)      etwlua_start_windows.go:37
```
macOS/Linux unaffected (ETW is Windows-only; stubbed elsewhere).

**Why CI missed it:** CI cross-compiles the Windows agent but never *runs* it on Windows. (Follow-up: add a Windows runtime smoke.)

## Fix
Pass `context.Background()` to `NewRealTimeConsumer`. Leak-free: the consumer is explicitly stopped by `etwSession.Stop()` (→ `consumer.Stop()`), invoked from `etwlua.Start`'s `defer sub.Stop()` on `ctx.Done()`.

## Verification
- Windows cross-build + `go test ./internal/etwlua/...` pass.
- **Windows test VM (real runtime):** fixed agent boots → `etwlua started` → `agent is running`, stays up 18s, **no panic, empty stderr**. (Before: instant panic.)

## Impact / rollout
- Target: **v0.68.2**. Treat the v0.68.0/v0.68.1 **Windows agent** as do-not-deploy.
- Field self-protection: MSI in-place upgrade rolls back on failure, so endpoints attempting an MSI upgrade stay on their (working) prior agent. Binary-swap auto-update paths would crash-loop — confirm the update channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)