### PR TITLE
fix(agent): allowlist Helper's real Windows install path for assist IPC

### DIFF
--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -1731,9 +1731,32 @@ func (b *Broker) allowedHelperPaths() []string {
 // skipped silently by computeAllowedHashes, so listing all platform candidates
 // is safe even when the helper is not installed.
 func assistHelperBinaryPaths(agentDir string) []string {
-	switch runtime.GOOS {
+	return assistHelperBinaryPathsForOS(agentDir, runtime.GOOS, os.Getenv("ProgramFiles"))
+}
+
+// assistHelperBinaryPathsForOS is the OS-parameterized core, exported-for-test
+// so the Windows path (which can't run on the CI host) is verified directly.
+//
+// IMPORTANT: the Helper MSI installs to "<ProgramFiles>\Breeze Helper\"
+// (Tauri productName "Breeze Helper"), NOT the agent's install dir. An earlier
+// version allowlisted only "<agentDir>\breeze-helper.exe", which never matches
+// the real install location, so the genuine Helper's hash was never added to
+// the allowlist and the assist IPC session was rejected on Windows. We now
+// cover the real install path (ProgramFiles + agent-dir sibling) plus the
+// legacy colocated path; missing candidates are skipped by computeAllowedHashes.
+func assistHelperBinaryPathsForOS(agentDir, goos, programFiles string) []string {
+	switch goos {
 	case "windows":
-		return []string{filepath.Join(agentDir, "breeze-helper.exe")}
+		paths := []string{
+			// Sibling of the agent dir, e.g. C:\Program Files\Breeze ->
+			// C:\Program Files\Breeze Helper. Robust to ProgramFiles localization.
+			filepath.Join(filepath.Dir(agentDir), "Breeze Helper", "breeze-helper.exe"),
+			filepath.Join(agentDir, "breeze-helper.exe"), // legacy/colocated
+		}
+		if programFiles != "" {
+			paths = append(paths, filepath.Join(programFiles, "Breeze Helper", "breeze-helper.exe"))
+		}
+		return paths
 	case "darwin":
 		return []string{
 			"/Applications/Breeze Helper.app/Contents/MacOS/breeze-helper",

--- a/agent/internal/sessionbroker/broker_test.go
+++ b/agent/internal/sessionbroker/broker_test.go
@@ -931,6 +931,25 @@ func TestAssistHelperBinaryPathsIncludeBreezeHelper(t *testing.T) {
 	}
 }
 
+// TestAssistHelperBinaryPathsWindowsRealInstallPath guards the regression where
+// the Windows allowlist used the agent dir instead of the Helper MSI's real
+// "<ProgramFiles>\Breeze Helper\" install location, causing the broker to reject
+// the genuine Helper on Windows. Runs on any host via the OS-parameterized core.
+func TestAssistHelperBinaryPathsWindowsRealInstallPath(t *testing.T) {
+	paths := assistHelperBinaryPathsForOS(`C:\Program Files\Breeze`, "windows", `C:\Program Files`)
+	// At least one candidate must point at the "Breeze Helper" install dir
+	// (not the agent's "Breeze" dir) and be the breeze-helper.exe binary.
+	found := false
+	for _, p := range paths {
+		if strings.Contains(p, "Breeze Helper") && strings.HasSuffix(p, "breeze-helper.exe") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("windows assist paths %v missing a 'Breeze Helper\\breeze-helper.exe' candidate", paths)
+	}
+}
+
 func TestSetSessionAuthenticatedHandler(t *testing.T) {
 	b := New("/tmp/does-not-matter.sock", func(*Session, *ipc.Envelope) {})
 	var got *Session


### PR DESCRIPTION
## Problem (found by real Windows install testing)
The assist IPC binary-hash allowlist used `<agentDir>\breeze-helper.exe` (`C:\Program Files\Breeze\…`), but the Helper MSI (Tauri productName **"Breeze Helper"**) installs to **`C:\Program Files\Breeze Helper\breeze-helper.exe`**. The paths never match, so `RefreshAllowedHashes` never hashes the real Helper → the broker rejects the assist session on the binary-path/hash gate → IPC token delivery silently fails and the Helper falls back to the `agent.yaml` token.

**Impact:** not user-breaking today (Phase 1 file fallback covers it), but the IPC path is effectively dead on Windows, and **Phase 2 (removing the file token) would break the Helper on Windows entirely.**

This is the kind of wrong-install-path assumption that unit/in-process tests can't catch — surfaced by installing the actual MSI on a Windows host (it landed in `…\Breeze Helper\`, confirmed via `Win32_Product`).

## Fix
Allowlist the real install location: `<ProgramFiles>\Breeze Helper\breeze-helper.exe` + the agent-dir sibling (`Dir(agentDir)\Breeze Helper\…`, robust to ProgramFiles localization) + the legacy colocated path. Missing candidates are skipped by `computeAllowedHashes`, so extra paths are harmless. Extracted `assistHelperBinaryPathsForOS(agentDir, goos, programFiles)` so the Windows path is unit-tested on the CI host. macOS path was already correct.

## Tests
`go test ./internal/sessionbroker/ -run TestAssistHelperBinaryPaths` passes (new `…WindowsRealInstallPath` case + existing). Windows cross-build OK.

## Note
Full end-to-end Windows assist handshake (Rust Helper → broker, SID match, token receipt) still needs an **interactive** Windows session — the Tauri GUI doesn't initialize its IPC client headlessly. Recommend a 2-min manual check on an RDP'd-in session. Tracked alongside the CI Windows-runtime-smoke gap (#1000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)