### PR TITLE
fix(api): stop counting 'missing' tombstones as outstanding patches

### DIFF
--- a/apps/api/src/__tests__/integration/patchApprovalEvaluatorTombstone.integration.test.ts
+++ b/apps/api/src/__tests__/integration/patchApprovalEvaluatorTombstone.integration.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Patch approval automation must not act on stale 'missing' tombstones.
+ *
+ * `resolveApprovedPatchesForDevice` selects which patches to actually install on
+ * a device. It previously queried device_patches `status IN ('pending','missing')`,
+ * so on a device with a large tombstone backlog (see the pressless case in
+ * patchComplianceTombstone.integration.test.ts) automation could try to install
+ * hundreds of patches the device no longer reports — phantom installs. Only
+ * 'pending' is outstanding; 'missing' is a tombstone (OUTSTANDING_DEVICE_PATCH_STATUSES).
+ *
+ * Prerequisites:
+ *   docker compose -f docker-compose.test.yml up -d
+ * Run:
+ *   pnpm test:integration -- src/__tests__/integration/patchApprovalEvaluatorTombstone.integration.test.ts
+ */
+import './setup';
+
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getTestDb } from './setup';
+import { withDbAccessContext } from '../../db';
+import { devices, patches, devicePatches, patchApprovals } from '../../db/schema';
+import { resolveApprovedPatchesForDevice, type RingConfig } from '../../services/patchApprovalEvaluator';
+import { setupTestEnvironment } from './db-utils';
+
+let agentSeq = 0;
+async function seedDevice(orgId: string, siteId: string, hostname: string): Promise<string> {
+  const tdb = getTestDb();
+  agentSeq++;
+  const [row] = await tdb
+    .insert(devices)
+    .values({
+      orgId,
+      siteId,
+      agentId: `agent-eval-${agentSeq}-${Date.now()}`,
+      hostname,
+      displayName: hostname,
+      osType: 'linux',
+      osVersion: '22.04',
+      osBuild: 'jammy',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'online',
+      enrolledAt: new Date(),
+    })
+    .returning({ id: devices.id });
+  if (!row) throw new Error('seedDevice: no row');
+  return row.id;
+}
+
+/** Seed a patch + a device_patches row + a manual 'approved' approval (org-wide).
+ *  Returns the patchId. The approval means automation WOULD install it if the
+ *  row is treated as outstanding. */
+async function seedApprovedPatch(opts: {
+  orgId: string;
+  deviceId: string;
+  status: 'pending' | 'missing';
+}): Promise<string> {
+  const tdb = getTestDb();
+  const [patch] = await tdb
+    .insert(patches)
+    .values({
+      source: 'linux',
+      externalId: `linux:${randomUUID()}`,
+      title: 'Eval test patch',
+      severity: 'important',
+    })
+    .returning({ id: patches.id });
+  if (!patch) throw new Error('seedApprovedPatch: no patch');
+  await tdb.insert(devicePatches).values({
+    deviceId: opts.deviceId,
+    orgId: opts.orgId,
+    patchId: patch.id,
+    status: opts.status,
+    lastCheckedAt: new Date(),
+  });
+  await tdb.insert(patchApprovals).values({
+    orgId: opts.orgId,
+    patchId: patch.id,
+    ringId: null,
+    status: 'approved',
+  });
+  return patch.id;
+}
+
+const RING_CONFIG: RingConfig = {
+  ringId: null,
+  categoryRules: [],
+  autoApprove: null,
+  deferralDays: 0,
+};
+
+describe('resolveApprovedPatchesForDevice — tombstone exclusion', () => {
+  let orgId: string;
+  let siteId: string;
+
+  beforeEach(async () => {
+    const env = await setupTestEnvironment({ scope: 'organization' });
+    orgId = env.organization.id;
+    siteId = env.site.id;
+  });
+
+  it('does not select stale "missing" tombstones for installation, even when approved', async () => {
+    const deviceId = await seedDevice(orgId, siteId, 'eval-device');
+    const pendingPatchId = await seedApprovedPatch({ orgId, deviceId, status: 'pending' });
+    // An approved-but-tombstoned patch: must be ignored by automation.
+    await seedApprovedPatch({ orgId, deviceId, status: 'missing' });
+
+    const approved = await withDbAccessContext(
+      {
+        scope: 'organization',
+        orgId,
+        accessibleOrgIds: [orgId],
+        accessiblePartnerIds: null,
+        userId: null,
+      },
+      () => resolveApprovedPatchesForDevice(deviceId, orgId, RING_CONFIG),
+    );
+
+    expect(approved).toHaveLength(1);
+    expect(approved[0]!.patchId).toBe(pendingPatchId);
+  });
+});

--- a/apps/api/src/__tests__/integration/patchComplianceTombstone.integration.test.ts
+++ b/apps/api/src/__tests__/integration/patchComplianceTombstone.integration.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Patch compliance must not count 'missing' tombstones as outstanding patches.
+ *
+ * Reproduces the production discrepancy where the US "pressless" Linux device
+ * showed ~960 "missing" in the Patch-Management Compliance tab while its own
+ * device Patches tab showed nothing to install.
+ *
+ * Root cause: the agent scan ingestion (routes/agents/patches.ts) marks ALL of
+ * a device's existing device_patches rows `status='missing'` at the start of a
+ * scan, then re-inserts the rows the current scan reports as 'pending' or
+ * 'installed'. Rows left at 'missing' are STALE TOMBSTONES from a prior scan
+ * (e.g. a linux package upgraded to a new externalId), NOT patches the device
+ * still needs. The device-detail endpoint correctly treats 'missing' as stale
+ * (compliance = installed / (pending + installed)), but the compliance endpoint
+ * counted `status IN ('pending','missing')`, inflating every device's
+ * "missing" count by its tombstone backlog.
+ *
+ * The only status that means "device still needs this patch installed" is
+ * 'pending'. These tests assert the compliance endpoint counts accordingly,
+ * against a real DB so the SQL aggregation itself is exercised (a Drizzle mock
+ * would happily return whatever rows we fabricate and never run the filter).
+ *
+ * Prerequisites:
+ *   docker compose -f docker-compose.test.yml up -d
+ * Run:
+ *   pnpm test:integration -- src/__tests__/integration/patchComplianceTombstone.integration.test.ts
+ */
+import './setup';
+
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import { getTestDb } from './setup';
+import { authMiddleware } from '../../middleware/auth';
+import { patchRoutes } from '../../routes/patches';
+import { devices, patches, devicePatches } from '../../db/schema';
+import { createIntegrationTestClient, type IntegrationTestClient } from './db-utils';
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.use('*', authMiddleware);
+  app.route('/patches', patchRoutes);
+  return app;
+}
+
+let agentSeq = 0;
+async function seedDevice(orgId: string, siteId: string, hostname: string): Promise<string> {
+  const tdb = getTestDb();
+  agentSeq++;
+  const [row] = await tdb
+    .insert(devices)
+    .values({
+      orgId,
+      siteId,
+      agentId: `agent-patchcompliance-${agentSeq}-${Date.now()}`,
+      hostname,
+      displayName: hostname,
+      osType: 'linux',
+      osVersion: '22.04',
+      osBuild: 'jammy',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'online',
+      enrolledAt: new Date(),
+    })
+    .returning({ id: devices.id });
+  if (!row) throw new Error('seedDevice: no row returned');
+  return row.id;
+}
+
+let patchSeq = 0;
+async function seedDevicePatch(opts: {
+  orgId: string;
+  deviceId: string;
+  status: 'pending' | 'installed' | 'missing' | 'failed' | 'skipped';
+  source?: 'microsoft' | 'apple' | 'linux' | 'third_party' | 'custom';
+  severity?: 'critical' | 'important' | 'moderate' | 'low' | 'unknown';
+}): Promise<void> {
+  const tdb = getTestDb();
+  patchSeq++;
+  const source = opts.source ?? 'linux';
+  // `patches` is a GLOBAL catalog table — cleanupDatabase() only truncates
+  // tenant tables, so externalId must be globally unique to avoid colliding
+  // with rows left by earlier tests/runs (patches_source_external_id_unique).
+  const [patch] = await tdb
+    .insert(patches)
+    .values({
+      source,
+      externalId: `${source}:${randomUUID()}`,
+      title: `Test patch ${patchSeq}`,
+      severity: opts.severity ?? 'unknown',
+    })
+    .returning({ id: patches.id });
+  if (!patch) throw new Error('seedDevicePatch: no patch row');
+  await tdb.insert(devicePatches).values({
+    deviceId: opts.deviceId,
+    orgId: opts.orgId,
+    patchId: patch.id,
+    status: opts.status,
+    lastCheckedAt: new Date(),
+  });
+}
+
+describe('GET /patches/compliance — tombstone exclusion', () => {
+  let client: IntegrationTestClient;
+  let orgId: string;
+  let siteId: string;
+
+  beforeEach(async () => {
+    const app = buildApp();
+    client = await createIntegrationTestClient(app, { scope: 'organization' });
+    orgId = client.env.organization.id;
+    siteId = client.env.site.id;
+  });
+
+  it('excludes a fully-patched device whose only outstanding rows are stale "missing" tombstones', async () => {
+    // Exactly the pressless shape: 0 pending, several 'missing' tombstones,
+    // and a pile of 'installed'. The device needs nothing installed.
+    const deviceId = await seedDevice(orgId, siteId, 'pressless-like');
+    for (let i = 0; i < 5; i++) {
+      await seedDevicePatch({ orgId, deviceId, status: 'missing' });
+    }
+    for (let i = 0; i < 3; i++) {
+      await seedDevicePatch({ orgId, deviceId, status: 'installed' });
+    }
+
+    const res = await client.get(`/patches/compliance?orgId=${orgId}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const listed = body.data.devicesNeedingPatches.find((d: { id: string }) => d.id === deviceId);
+    // 0 pending → device is fully patched → must NOT appear in the list.
+    expect(listed).toBeUndefined();
+  });
+
+  it('counts only pending (not missing) as the per-device missing/critical/osMissing total', async () => {
+    const deviceId = await seedDevice(orgId, siteId, 'partial-device');
+    // 2 genuinely outstanding pending patches (one critical) ...
+    await seedDevicePatch({ orgId, deviceId, status: 'pending', severity: 'critical' });
+    await seedDevicePatch({ orgId, deviceId, status: 'pending', severity: 'important' });
+    // ... plus 4 stale tombstones (one critical, which must NOT inflate counts) ...
+    await seedDevicePatch({ orgId, deviceId, status: 'missing', severity: 'critical' });
+    await seedDevicePatch({ orgId, deviceId, status: 'missing', severity: 'low' });
+    await seedDevicePatch({ orgId, deviceId, status: 'missing', severity: 'low' });
+    await seedDevicePatch({ orgId, deviceId, status: 'missing', severity: 'low' });
+    // ... plus installed rows that don't count as outstanding.
+    await seedDevicePatch({ orgId, deviceId, status: 'installed' });
+
+    const res = await client.get(`/patches/compliance?orgId=${orgId}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const listed = body.data.devicesNeedingPatches.find((d: { id: string }) => d.id === deviceId);
+    expect(listed).toBeDefined();
+    // 2 pending only — tombstones excluded.
+    expect(listed.missingCount).toBe(2);
+    // 1 pending critical — the tombstone critical must not be counted.
+    expect(listed.criticalCount).toBe(1);
+    expect(listed.importantCount).toBe(1);
+    // Both pending patches are linux (OS), zero third-party.
+    expect(listed.osMissing).toBe(2);
+    expect(listed.thirdPartyMissing).toBe(0);
+  });
+
+  it('computes summary compliancePercent and severity summaries over installed+outstanding, excluding tombstones', async () => {
+    const deviceId = await seedDevice(orgId, siteId, 'summary-device');
+    // 1 installed, 1 outstanding critical pending, 3 stale tombstones (2 critical).
+    await seedDevicePatch({ orgId, deviceId, status: 'installed' });
+    await seedDevicePatch({ orgId, deviceId, status: 'pending', severity: 'critical' });
+    await seedDevicePatch({ orgId, deviceId, status: 'missing', severity: 'critical' });
+    await seedDevicePatch({ orgId, deviceId, status: 'missing', severity: 'critical' });
+    await seedDevicePatch({ orgId, deviceId, status: 'missing', severity: 'low' });
+
+    const res = await client.get(`/patches/compliance?orgId=${orgId}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // installed=1, outstanding=1 → 1/(1+1)=50%. (Buggy code divided by all 5 rows → 20%.)
+    expect(body.data.compliancePercent).toBe(50);
+    // Critical relevant set is just the 1 pending critical; the 2 tombstone
+    // criticals must not appear. (Buggy code reported total=3, pending=3.)
+    expect(body.data.criticalSummary).toEqual({ total: 1, patched: 0, pending: 1 });
+  });
+});

--- a/apps/api/src/db/schema/patches.ts
+++ b/apps/api/src/db/schema/patches.ts
@@ -48,6 +48,23 @@ export const devicePatchStatusEnum = pgEnum('device_patch_status', [
   'missing'
 ]);
 
+/**
+ * device_patches.status values that mean "the device still needs this patch
+ * installed" — the set that counts toward outstanding / "missing patch" metrics
+ * and that patch automation is allowed to act on.
+ *
+ * IMPORTANT: 'missing' is deliberately NOT in this set. Despite its name,
+ * 'missing' is a TOMBSTONE, not "a patch the device is missing". Agent scan
+ * ingestion (routes/agents/patches.ts) marks ALL of a device's existing rows
+ * 'missing' at the start of every scan, then re-inserts the rows the current
+ * scan actually reports as 'pending' / 'installed'. Rows left at 'missing' are
+ * stale records from a prior scan that the latest scan no longer reports (e.g.
+ * a package upgraded to a new externalId) — they never get cleaned up and grow
+ * unbounded. Counting them as outstanding made a fully-patched Linux box report
+ * ~960 "missing" patches in the compliance view. Only 'pending' is outstanding.
+ */
+export const OUTSTANDING_DEVICE_PATCH_STATUSES = ['pending'] as const;
+
 export const patchJobStatusEnum = pgEnum('patch_job_status', [
   'scheduled',
   'running',

--- a/apps/api/src/routes/patches/compliance.ts
+++ b/apps/api/src/routes/patches/compliance.ts
@@ -12,12 +12,17 @@ import {
   devicePatches,
   patchApprovals,
   patchComplianceReports,
-  devices
+  devices,
+  OUTSTANDING_DEVICE_PATCH_STATUSES
 } from '../../db/schema';
 import { complianceSchema, complianceReportSchema } from './schemas';
 import { resolvePatchReportOrgId } from './helpers';
 
 export const complianceRoutes = new Hono();
+
+// A device_patches row that still needs installing. 'missing' is a stale
+// tombstone, NOT an outstanding patch — see OUTSTANDING_DEVICE_PATCH_STATUSES.
+const isOutstanding = inArray(devicePatches.status, [...OUTSTANDING_DEVICE_PATCH_STATUSES]);
 const requireReportRead = requirePermission(PERMISSIONS.REPORTS_READ.resource, PERMISSIONS.REPORTS_READ.action);
 const requireReportExport = requirePermission(PERMISSIONS.REPORTS_EXPORT.resource, PERMISSIONS.REPORTS_EXPORT.action);
 
@@ -137,8 +142,13 @@ complianceRoutes.get(
       }
     }
 
-    const compliancePercent = summary.total > 0
-      ? Math.round((summary.installed / summary.total) * 100)
+    // Compliance % is installed over the RELEVANT set (installed + outstanding),
+    // not over summary.total — total includes stale 'missing' tombstones and
+    // 'skipped' rows, which would otherwise deflate the percentage. This matches
+    // the device-detail view (routes/devices/patches.ts: installed / (pending + installed)).
+    const relevantTotal = summary.installed + summary.pending;
+    const compliancePercent = relevantTotal > 0
+      ? Math.round((summary.installed / relevantTotal) * 100)
       : 100;
 
     // Per-device patch breakdown for "devices needing patches" table
@@ -148,11 +158,11 @@ complianceRoutes.get(
         hostname: devices.hostname,
         osType: devices.osType,
         lastSeenAt: devices.lastSeenAt,
-        missingCount: sql<number>`count(*) filter (where ${devicePatches.status} in ('pending', 'missing'))`,
-        criticalCount: sql<number>`count(*) filter (where ${devicePatches.status} in ('pending', 'missing') and ${patches.severity} = 'critical')`,
-        importantCount: sql<number>`count(*) filter (where ${devicePatches.status} in ('pending', 'missing') and ${patches.severity} = 'important')`,
-        osMissing: sql<number>`count(*) filter (where ${devicePatches.status} in ('pending', 'missing') and ${patches.source} in ('microsoft', 'apple', 'linux'))`,
-        thirdPartyMissing: sql<number>`count(*) filter (where ${devicePatches.status} in ('pending', 'missing') and ${patches.source} in ('third_party', 'custom'))`,
+        missingCount: sql<number>`count(*) filter (where ${isOutstanding})`,
+        criticalCount: sql<number>`count(*) filter (where ${isOutstanding} and ${patches.severity} = 'critical')`,
+        importantCount: sql<number>`count(*) filter (where ${isOutstanding} and ${patches.severity} = 'important')`,
+        osMissing: sql<number>`count(*) filter (where ${isOutstanding} and ${patches.source} in ('microsoft', 'apple', 'linux'))`,
+        thirdPartyMissing: sql<number>`count(*) filter (where ${isOutstanding} and ${patches.source} in ('third_party', 'custom'))`,
         lastInstalledAt: sql<string | null>`max(case when ${devicePatches.status} = 'installed' and ${devicePatches.installedAt} is not null then ${devicePatches.installedAt}::timestamptz::text end)`,
         pendingReboot: sql<boolean>`bool_or(${patches.requiresReboot} and ${devicePatches.status} = 'installed' and ${devicePatches.installedAt} is not null)`,
         lastScannedAt: sql<string | null>`max(${devicePatches.lastCheckedAt})::timestamptz::text`
@@ -162,8 +172,8 @@ complianceRoutes.get(
       .innerJoin(devices, eq(devicePatches.deviceId, devices.id))
       .where(and(...complianceConditions))
       .groupBy(devicePatches.deviceId, devices.hostname, devices.osType, devices.lastSeenAt)
-      .having(sql`count(*) filter (where ${devicePatches.status} in ('pending', 'missing')) > 0`)
-      .orderBy(sql`count(*) filter (where ${devicePatches.status} in ('pending', 'missing') and ${patches.severity} = 'critical') desc`);
+      .having(sql`count(*) filter (where ${isOutstanding}) > 0`)
+      .orderBy(sql`count(*) filter (where ${isOutstanding} and ${patches.severity} = 'critical') desc`);
 
     const devicesNeedingPatches = deviceBreakdown.map(row => ({
       id: row.deviceId,
@@ -180,12 +190,14 @@ complianceRoutes.get(
       lastSeen: row.lastSeenAt?.toISOString() ?? undefined
     }));
 
-    // Severity-level summaries
+    // Severity-level summaries. "total" is the RELEVANT set (installed +
+    // outstanding) for that severity, NOT count(*) over all statuses — stale
+    // 'missing' tombstones must not be counted as pending here either.
     const severityCounts = await db
       .select({
         severity: patches.severity,
-        total: sql<number>`count(*)`,
-        installed: sql<number>`count(*) filter (where ${devicePatches.status} = 'installed')`
+        installed: sql<number>`count(*) filter (where ${devicePatches.status} = 'installed')`,
+        outstanding: sql<number>`count(*) filter (where ${isOutstanding})`
       })
       .from(devicePatches)
       .innerJoin(patches, eq(devicePatches.patchId, patches.id))
@@ -195,12 +207,13 @@ complianceRoutes.get(
     const severityMap: Record<string, { total: number; patched: number; pending: number }> = {};
     for (const row of severityCounts) {
       const key = row.severity ?? 'unknown';
-      const total = Number(row.total);
       const patched = Number(row.installed);
-      severityMap[key] = { total, patched, pending: total - patched };
+      const pending = Number(row.outstanding);
+      severityMap[key] = { total: patched + pending, patched, pending };
     }
 
-    // Device-level compliance: a device is compliant if it has zero pending/missing patches
+    // Device-level compliance: a device is compliant if it has zero outstanding
+    // (pending) patches. devicesNeedingPatches already excludes 'missing' tombstones.
     const compliantDeviceCount = deviceIds.length - devicesNeedingPatches.length;
 
     return c.json({

--- a/apps/api/src/routes/patches/index.test.ts
+++ b/apps/api/src/routes/patches/index.test.ts
@@ -107,7 +107,8 @@ vi.mock('../../db/schema', () => ({
     initiatedBy: 'patchRollbacks.initiatedBy',
     status: 'patchRollbacks.status',
     reason: 'patchRollbacks.reason'
-  }
+  },
+  OUTSTANDING_DEVICE_PATCH_STATUSES: ['pending']
 }));
 
 vi.mock('../../services/commandQueue', () => ({

--- a/apps/api/src/services/patchApprovalEvaluator.ts
+++ b/apps/api/src/services/patchApprovalEvaluator.ts
@@ -6,7 +6,7 @@
  */
 
 import { db } from '../db';
-import { devicePatches, patches, patchApprovals } from '../db/schema';
+import { devicePatches, patches, patchApprovals, OUTSTANDING_DEVICE_PATCH_STATUSES } from '../db/schema';
 import { and, eq, inArray } from 'drizzle-orm';
 
 // ============================================
@@ -47,7 +47,9 @@ export async function resolveApprovedPatchesForDevice(
   orgId: string,
   ringConfig: RingConfig
 ): Promise<ApprovedPatch[]> {
-  // 1. Query devicePatches with status pending or missing, joined with patch details
+  // 1. Query outstanding (needs-install) devicePatches, joined with patch details.
+  //    Only 'pending' is outstanding — 'missing' is a stale tombstone (see
+  //    OUTSTANDING_DEVICE_PATCH_STATUSES); automation must never try to install it.
   const pendingPatches = await db
     .select({
       devicePatchId: devicePatches.id,
@@ -64,7 +66,7 @@ export async function resolveApprovedPatchesForDevice(
     .where(
       and(
         eq(devicePatches.deviceId, deviceId),
-        inArray(devicePatches.status, ['pending', 'missing'])
+        inArray(devicePatches.status, [...OUTSTANDING_DEVICE_PATCH_STATUSES])
       )
     );
 


### PR DESCRIPTION
**Symptom:** The Patch-Management Compliance tab showed `pressless` (a fully-patched Linux device on US) with **960 "missing"** OS patches, while the device's own Patches tab correctly showed nothing to install.

**Root cause:** `device_patches.status = 'missing'` is overloaded. Agent scan ingestion (`routes/agents/patches.ts`) marks **all** of a device's existing rows `'missing'` at the start of every scan, then re-inserts the rows the current scan reports as `'pending'`/`'installed'`. Rows left at `'missing'` are **stale tombstones** from a prior scan (e.g. a package upgraded to a new `externalId`), *not* patches the device needs. The device-detail endpoint already treats `'missing'` as stale (`installed / (pending + installed)`), but `routes/patches/compliance.ts` and `services/patchApprovalEvaluator.ts` both counted `status IN ('pending','missing')`, inflating every device by its tombstone backlog.

**Prod evidence (US, 2026-05-29):**

| device | compliance tab showed | true `pending` | stale tombstones |
|---|---|---|---|
| pressless | 960 | **0** | 960 |
| MacBook-Pro-3 | 309 | 3 | 306 |
| win-build | 4 | 1 | 3 |

**Fix (read-side only):**
- Single source of truth `OUTSTANDING_DEVICE_PATCH_STATUSES` (= `['pending']`) next to the enum in `db/schema/patches.ts`, consumed by both call sites so they can't drift again.
- `compliance.ts`: per-device counts, `HAVING`/`ORDER BY`, **and** the summary `compliancePercent` + severity summaries now exclude tombstones (the latter is the "0% compliant" headline — its denominator previously included tombstones).
- `patchApprovalEvaluator.ts`: automation no longer selects tombstoned patches for install (was the worse-than-cosmetic side — it could try to install hundreds of phantom patches).

**Tests** (real-DB integration — the bug is in SQL aggregation, which a Drizzle mock can't exercise; both verified red→green):
- `patchComplianceTombstone.integration.test.ts` — reproduces the pressless shape; asserts exclusion across per-device counts, `devicesNeedingPatches`, `compliancePercent`, and `criticalSummary`.
- `patchApprovalEvaluatorTombstone.integration.test.ts` — an approved-but-tombstoned patch is not selected for install.

Full suite: 463 files / 5160 unit tests pass · `tsc --noEmit` clean · eslint clean.

**Out of scope (follow-up #1004):** this does not stop the tombstone rows from accumulating. A reconcile-on-scan approach was prototyped and dropped from this PR during review — scoping deletes by the coarse `source` enum is unsafe because the agent maps multiple providers (winget/chocolatey/homebrew → `third_party`) onto one source and submits partial payloads on partial-provider failure, so a successful provider could delete a failed sibling's still-valid rows. The cleanup needs an agent-side "authoritative provider" signal. Tracked in #1004.

🤖 Generated with [Claude Code](https://claude.com/claude-code)