### PR TITLE
fix(api): reject software version pin on non-Windows endpoints (#993)

### DIFF
--- a/apps/api/src/routes/devices/softwareActions.test.ts
+++ b/apps/api/src/routes/devices/softwareActions.test.ts
@@ -127,13 +127,14 @@ describe('device software actions routes', () => {
       );
     });
 
-    it('passes version through to the agent payload when provided', async () => {
+    it('passes version through to the agent payload on a Windows device', async () => {
       (getDeviceWithOrgCheck as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: 'device-1',
         orgId: 'org-123',
         siteId: null,
         hostname: 'host-1',
         status: 'online',
+        osType: 'windows',
       });
       queueCommandForExecutionMock.mockResolvedValue({
         command: { id: 'cmd-2', status: 'pending' },
@@ -150,6 +151,59 @@ describe('device software actions routes', () => {
         'device-1',
         'software_update',
         { name: 'Google Chrome', version: '125.0.6422.142', source: 'device_software_tab' },
+        expect.objectContaining({ userId: 'user-123' })
+      );
+    });
+
+    it.each(['macos', 'linux'])(
+      'rejects a version pin with 422 on a %s device (agent ignores it)',
+      async (osType) => {
+        (getDeviceWithOrgCheck as ReturnType<typeof vi.fn>).mockResolvedValue({
+          id: 'device-1',
+          orgId: 'org-123',
+          siteId: null,
+          hostname: 'host-1',
+          status: 'online',
+          osType,
+        });
+
+        const res = await app.request('/devices/device-1/software/update', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ name: 'Google Chrome', version: '125.0.6422.142' }),
+        });
+
+        expect(res.status).toBe(422);
+        const body = await res.json();
+        expect(body.error).toContain(osType);
+        expect(queueCommandForExecutionMock).not.toHaveBeenCalled();
+      }
+    );
+
+    it('allows a version-less update on a non-Windows device', async () => {
+      (getDeviceWithOrgCheck as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'device-1',
+        orgId: 'org-123',
+        siteId: null,
+        hostname: 'host-1',
+        status: 'online',
+        osType: 'macos',
+      });
+      queueCommandForExecutionMock.mockResolvedValue({
+        command: { id: 'cmd-3', status: 'sent' },
+      });
+
+      const res = await app.request('/devices/device-1/software/update', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Google Chrome' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(queueCommandForExecutionMock).toHaveBeenCalledWith(
+        'device-1',
+        'software_update',
+        { name: 'Google Chrome', source: 'device_software_tab' },
         expect.objectContaining({ userId: 'user-123' })
       );
     });

--- a/apps/api/src/routes/devices/softwareActions.ts
+++ b/apps/api/src/routes/devices/softwareActions.ts
@@ -74,6 +74,18 @@ softwareActionsRoutes.post(
     if (device.status === 'decommissioned') {
       return c.json({ error: 'Cannot send commands to a decommissioned device' }, 400);
     }
+    // Version pinning is only honored by the agent's Windows update path
+    // (winget --version). updateSoftwareMacOS/updateSoftwareLinux ignore the
+    // version and always upgrade to the latest, so accepting a pin here would
+    // silently violate the intended hold. Reject it up front instead. See #993.
+    if (data.version && device.osType !== 'windows') {
+      return c.json(
+        {
+          error: `Version pinning is only supported on Windows endpoints; this device runs ${device.osType}. Resubmit without a version to upgrade to the latest available.`,
+        },
+        422
+      );
+    }
 
     const payload: Record<string, unknown> = { name: data.name, source: 'device_software_tab' };
     if (data.version) payload.version = data.version;


### PR DESCRIPTION
Follow-up to #974, addresses #993.

## Problem
The software **update** route (`apps/api/src/routes/devices/softwareActions.ts`) accepts an optional `version` for all platforms, but the agent only honors it on Windows — `updateSoftwareWindows` prepends a `winget --version <v>` attempt (`agent/internal/remote/tools/software_update.go:68`). `updateSoftwareMacOS` (`:121`) and `updateSoftwareLinux` (`:132`) take no version argument and always upgrade to the latest. So a version pin submitted against a macOS/Linux endpoint was silently ignored — a no-op with no error, which could quietly violate an intended compliance hold.

## Fix (option 1 from the issue — API 422)
After the device is loaded (the route already has the full row; `osType` is a `notNull` enum of `windows | macos | linux`), reject the request with **422** when a `version` is supplied and `device.osType !== 'windows'`:

```
Version pinning is only supported on Windows endpoints; this device runs macos.
Resubmit without a version to upgrade to the latest available.
```

This closes the gap at the single choke point that protects every caller (web, mobile, scripts), not just the UI. No extra query, no agent round-trip.

Unchanged: version-less updates on any OS, all uninstall behavior, and the Windows version-pin path.

## Scope / deferred
- **UI-disable mirror** (option 2) and the **secondary English success-string match** note from the issue are intentionally left out to keep this surgical. Happy to fold the UI guard into this PR if you'd prefer it here rather than a follow-up — your call. Left #993 open rather than auto-closing for the same reason.

## Tests
- `it.each(['macos','linux'])` → 422, command not queued
- version-less update on a non-Windows device → still 200, queued
- the version-passthrough happy path now asserts an explicit Windows device (it encodes Windows-only semantics)

## Verification (local)
- `tsc --noEmit` apps/api ✅ and apps/web ✅ (0 errors)
- `apps/api` vitest: **5240 passed, 30 skipped, 0 failed**
- `softwareActions.test.ts`: 14 passed
- agent `go build ./...` + `go vet ./internal/remote/tools/` ✅ (agent untouched; CGO_ENABLED=0 on local toolchain)

Branched clean off `main`; diff is two files (route + test).
