### PR TITLE
fix(agent): verify macOS update .pkg against signed release manifest

### DIFF
--- a/agent/internal/updater/pkg_darwin.go
+++ b/agent/internal/updater/pkg_darwin.go
@@ -11,11 +11,22 @@ import (
 	"runtime"
 )
 
-// installViaPkg downloads the macOS .pkg installer for the given version and
-// runs it via `installer -pkg`. The .pkg preserves the Apple Developer ID
-// code signature and executes pre/post-install scripts (which handle
-// LaunchDaemon/LaunchAgent setup and service restart).
-func (u *Updater) installViaPkg(version string) error {
+// installViaPkg downloads the macOS .pkg installer for the given version,
+// verifies it against the Ed25519-signed release manifest, and runs it via
+// `installer -pkg`. The .pkg preserves the Apple Developer ID code signature
+// and executes pre/post-install scripts (which handle LaunchDaemon/LaunchAgent
+// setup and service restart).
+//
+// expectedSHA256 is the signed checksum extracted by pkgAssetChecksum from the
+// same manifest that authenticated the agent binary. The .pkg bytes are
+// verified against it BEFORE `installer` runs as root — without this check a
+// TLS/DNS MITM toward github.com, a poisoned release asset, or a compromised
+// CDN edge would yield arbitrary root code execution fleet-wide. The caller
+// must never invoke this with an empty expectedSHA256.
+func (u *Updater) installViaPkg(version, expectedSHA256 string) error {
+	if expectedSHA256 == "" {
+		return fmt.Errorf("refusing to install .pkg without a signed checksum")
+	}
 	// Download .pkg directly from GitHub releases
 	pkgURL := fmt.Sprintf("https://github.com/LanternOps/breeze/releases/download/v%s/breeze-agent-darwin-%s.pkg",
 		version, runtime.GOARCH)
@@ -44,6 +55,13 @@ func (u *Updater) installViaPkg(version string) error {
 		return fmt.Errorf("failed to write pkg file: %w", err)
 	}
 	pkgFile.Close()
+
+	// SECURITY: verify the downloaded .pkg against the signed manifest checksum
+	// before handing it to `installer` as root. This is the trust binding that
+	// makes downloading the .pkg over the open internet safe.
+	if err := u.verifyChecksum(pkgPath, expectedSHA256); err != nil {
+		return fmt.Errorf("pkg checksum verification failed: %w", err)
+	}
 
 	// Run the .pkg installer (requires root, which the agent service has)
 	log.Info("installing pkg", "path", pkgPath)

--- a/agent/internal/updater/pkg_darwin_test.go
+++ b/agent/internal/updater/pkg_darwin_test.go
@@ -1,0 +1,16 @@
+//go:build darwin
+
+package updater
+
+import "testing"
+
+// installViaPkg must refuse to run `installer` when it has no signed checksum to
+// verify the .pkg against — the caller (UpdateTo) falls back to verified-binary
+// replacement in that case. This is the guard that prevents running unverified
+// bytes as root.
+func TestInstallViaPkg_RefusesEmptyChecksum(t *testing.T) {
+	u := New(&Config{})
+	if err := u.installViaPkg("1.0.0", ""); err == nil {
+		t.Fatal("installViaPkg must refuse an empty signed checksum")
+	}
+}

--- a/agent/internal/updater/pkg_other.go
+++ b/agent/internal/updater/pkg_other.go
@@ -5,6 +5,6 @@ package updater
 import "fmt"
 
 // installViaPkg is only available on macOS.
-func (u *Updater) installViaPkg(_ string) error {
+func (u *Updater) installViaPkg(_, _ string) error {
 	return fmt.Errorf("pkg install is only supported on macOS")
 }

--- a/agent/internal/updater/pkg_verify_test.go
+++ b/agent/internal/updater/pkg_verify_test.go
@@ -1,0 +1,87 @@
+package updater
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func buildReleaseManifest(t *testing.T, release string, assets []releaseArtifactAsset) []byte {
+	t.Helper()
+	m := releaseArtifactManifest{SchemaVersion: 1, Release: release, Assets: assets}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	return b
+}
+
+// The macOS auto-update path must verify the downloaded .pkg against the
+// Ed25519-signed release manifest before running `installer -pkg` as root.
+// pkgAssetChecksum extracts that signed SHA-256 from an already-verified
+// manifest payload; these tests pin its trust-binding behavior.
+
+func TestPkgAssetChecksum_ReturnsSignedSHAForPkg(t *testing.T) {
+	want := strings.Repeat("a", 64)
+	pkgName := fmt.Sprintf("breeze-agent-darwin-%s.pkg", runtime.GOARCH)
+	binName := fmt.Sprintf("breeze-agent-darwin-%s", runtime.GOARCH)
+	payload := buildReleaseManifest(t, "v1.2.3", []releaseArtifactAsset{
+		{Name: binName, SHA256: strings.Repeat("b", 64), Size: 10},
+		{Name: pkgName, SHA256: want, Size: 20},
+	})
+
+	got, err := pkgAssetChecksum(payload, "1.2.3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("checksum = %s, want %s", got, want)
+	}
+}
+
+func TestPkgAssetChecksum_FailsClosedWhenPkgAbsent(t *testing.T) {
+	// Manifest lists only the bare binary, no .pkg. pkgAssetChecksum MUST error
+	// so the caller falls back to verified-binary replacement rather than
+	// running `installer` on bytes never bound to the signed trust root.
+	binName := fmt.Sprintf("breeze-agent-darwin-%s", runtime.GOARCH)
+	payload := buildReleaseManifest(t, "v1.2.3", []releaseArtifactAsset{
+		{Name: binName, SHA256: strings.Repeat("b", 64), Size: 10},
+	})
+
+	if _, err := pkgAssetChecksum(payload, "1.2.3"); err == nil {
+		t.Fatal("expected error when .pkg asset absent, got nil")
+	}
+}
+
+func TestPkgAssetChecksum_RejectsVersionMismatch(t *testing.T) {
+	pkgName := fmt.Sprintf("breeze-agent-darwin-%s.pkg", runtime.GOARCH)
+	payload := buildReleaseManifest(t, "v9.9.9", []releaseArtifactAsset{
+		{Name: pkgName, SHA256: strings.Repeat("a", 64), Size: 20},
+	})
+
+	if _, err := pkgAssetChecksum(payload, "1.2.3"); err == nil {
+		t.Fatal("expected release-version-mismatch error, got nil")
+	}
+}
+
+func TestPkgAssetChecksum_RejectsNonHexChecksum(t *testing.T) {
+	pkgName := fmt.Sprintf("breeze-agent-darwin-%s.pkg", runtime.GOARCH)
+	payload := buildReleaseManifest(t, "v1.2.3", []releaseArtifactAsset{
+		{Name: pkgName, SHA256: strings.Repeat("z", 64), Size: 20}, // 64 chars but not hex
+	})
+
+	if _, err := pkgAssetChecksum(payload, "1.2.3"); err == nil {
+		t.Fatal("expected non-hex checksum error, got nil")
+	}
+}
+
+func TestPkgAssetChecksum_RejectsLegacyManifestWithoutAssets(t *testing.T) {
+	// A legacy single-asset updateManifest (no assets list) has no .pkg entry →
+	// fail closed.
+	payload := []byte(`{"version":"1.2.3","component":"agent","checksum":"` + strings.Repeat("a", 64) + `"}`)
+	if _, err := pkgAssetChecksum(payload, "1.2.3"); err == nil {
+		t.Fatal("expected error for legacy manifest without assets, got nil")
+	}
+}

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -181,6 +181,52 @@ func (u *Updater) expectedReleaseAssetNames() map[string]struct{} {
 	return map[string]struct{}{}
 }
 
+// pkgAssetName is the canonical filename of the macOS .pkg installer asset for
+// the running architecture. The .pkg is built and listed in the signed release
+// manifest's asset list alongside the bare binary (release.yml).
+func pkgAssetName() string {
+	return fmt.Sprintf("breeze-agent-darwin-%s.pkg", runtime.GOARCH)
+}
+
+// pkgAssetChecksum extracts the signed SHA-256 of the macOS .pkg installer from
+// an ALREADY-signature-verified release artifact manifest payload (the
+// info.Manifest bytes that verifyUpdateManifest checked the Ed25519 signature
+// over). It is the trust binding for the macOS update path: installViaPkg must
+// verify the downloaded .pkg against this value before running `installer` as
+// root.
+//
+// It deliberately FAILS CLOSED — returning an error when the manifest does not
+// list the .pkg (e.g. legacy single-asset manifests, or releases predating the
+// .pkg being added) — so the caller falls back to verified-binary replacement
+// rather than installing bytes never bound to the signed trust root.
+func pkgAssetChecksum(verifiedManifest []byte, version string) (string, error) {
+	var manifest releaseArtifactManifest
+	if err := json.Unmarshal(verifiedManifest, &manifest); err != nil {
+		return "", fmt.Errorf("invalid release artifact manifest JSON: %w", err)
+	}
+	if manifest.SchemaVersion != 1 {
+		return "", fmt.Errorf("unsupported release artifact manifest schema version %d", manifest.SchemaVersion)
+	}
+	if !releaseTagMatchesVersion(manifest.Release, version) {
+		return "", fmt.Errorf("release artifact manifest version mismatch: expected %s, got %s", version, manifest.Release)
+	}
+	name := pkgAssetName()
+	for i := range manifest.Assets {
+		if manifest.Assets[i].Name != name {
+			continue
+		}
+		sha := manifest.Assets[i].SHA256
+		if len(sha) != 64 {
+			return "", fmt.Errorf("release artifact manifest checksum for %s must be SHA-256 hex", name)
+		}
+		if _, err := hex.DecodeString(sha); err != nil {
+			return "", fmt.Errorf("release artifact manifest checksum for %s is not valid hex: %w", name, err)
+		}
+		return sha, nil
+	}
+	return "", fmt.Errorf("release artifact manifest does not include %s", name)
+}
+
 func (u *Updater) trustedManifestKeys() []ed25519.PublicKey {
 	configured := strings.TrimSpace(os.Getenv("BREEZE_UPDATE_MANIFEST_PUBLIC_KEYS"))
 	rawKeys := append([]string{}, trustedUpdateManifestPublicKeys...)
@@ -285,7 +331,7 @@ func (u *Updater) updateTo(version string, opts UpdateOptions) error {
 	}
 
 	// 1. Download binary to temp file
-	tempPath, manifest, err := u.downloadBinary(version)
+	tempPath, manifest, manifestPayload, err := u.downloadBinary(version)
 	if err != nil {
 		return fmt.Errorf("failed to download binary: %w", err)
 	}
@@ -335,14 +381,24 @@ func (u *Updater) updateTo(version string, opts UpdateOptions) error {
 	//    The .pkg preserves the Apple Developer ID code signature and runs
 	//    pre/post-install scripts. The raw binary approach destroys the
 	//    signature, which invalidates macOS TCC permission grants.
+	//
+	//    SECURITY: the .pkg is verified against the same Ed25519-signed release
+	//    manifest as the binary before `installer` runs it as root. If the
+	//    signed .pkg checksum is unavailable (legacy manifest, or the lookup
+	//    fails), installViaPkg is skipped and we fall through to verified-binary
+	//    replacement — we never run `installer` on bytes not bound to the trust
+	//    root. (issue: macOS update RCE.)
 	if runtime.GOOS == "darwin" {
 		defer removeCleanup(tempPath)
 		writeUpdateMarker(version)
-		pkgErr := u.installViaPkg(version)
-		if pkgErr == nil {
+		pkgChecksum, pkgErr := pkgAssetChecksum(manifestPayload, version)
+		if pkgErr != nil {
+			log.Warn("signed .pkg checksum unavailable, falling back to verified-binary replacement", "error", pkgErr.Error())
+		} else if installErr := u.installViaPkg(version, pkgChecksum); installErr != nil {
+			log.Warn("pkg install failed, falling back to binary replacement", "error", installErr.Error())
+		} else {
 			return nil // .pkg install handles binary replacement + restart
 		}
-		log.Warn("pkg install failed, falling back to binary replacement", "error", pkgErr.Error())
 	} else {
 		defer removeCleanup(tempPath)
 	}
@@ -564,7 +620,7 @@ func (u *Updater) verifyReleaseArtifactManifest(payload []byte, info downloadInf
 // manifest-vs-file distinction. The second verify is intentional and a
 // future simplifier should not delete it as "redundant".
 func (u *Updater) DownloadBinary(version string) (string, error) {
-	tempPath, manifest, err := u.downloadBinary(version)
+	tempPath, manifest, _, err := u.downloadBinary(version)
 	if err != nil {
 		return "", err
 	}
@@ -577,9 +633,15 @@ func (u *Updater) DownloadBinary(version string) (string, error) {
 
 // downloadBinary fetches download info from the API and then downloads the binary.
 // Supports both legacy redirect responses and JSON info responses.
-func (u *Updater) downloadBinary(version string) (string, updateManifest, error) {
+// downloadBinary returns the temp path of the downloaded binary, the verified
+// single-asset manifest view, and the raw signature-VERIFIED release manifest
+// payload (info.Manifest). The payload is returned so the macOS update path can
+// look up the .pkg asset's signed checksum from the same trust root without a
+// second round-trip; it is safe to use because verifyUpdateManifest has already
+// checked its Ed25519 signature.
+func (u *Updater) downloadBinary(version string) (string, updateManifest, []byte, error) {
 	if u.config.AuthToken == nil {
-		return "", updateManifest{}, fmt.Errorf("auth token not available")
+		return "", updateManifest{}, nil, fmt.Errorf("auth token not available")
 	}
 	// Step 1: Get download URL + checksum from API.
 	infoURL := fmt.Sprintf("%s/api/v1/agent-versions/%s/download?platform=%s&arch=%s&component=%s",
@@ -587,45 +649,48 @@ func (u *Updater) downloadBinary(version string) (string, updateManifest, error)
 
 	req, err := http.NewRequest("GET", infoURL, nil)
 	if err != nil {
-		return "", updateManifest{}, err
+		return "", updateManifest{}, nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+u.config.AuthToken.Reveal())
 
 	resp, err := u.requestWithoutRedirect(req)
 	if err != nil {
-		return "", updateManifest{}, err
+		return "", updateManifest{}, nil, err
 	}
 	defer resp.Body.Close()
 
 	info, err := u.parseDownloadInfo(resp)
 	if err != nil {
-		return "", updateManifest{}, err
+		return "", updateManifest{}, nil, err
 	}
 
 	manifest, err := u.verifyUpdateManifest(info, version)
 	if err != nil {
-		return "", updateManifest{}, err
+		return "", updateManifest{}, nil, err
 	}
+	// info.Manifest is now signature-verified; capture it for the macOS .pkg
+	// checksum lookup in UpdateTo.
+	verifiedPayload := []byte(info.Manifest)
 
 	// Step 2: Download the actual binary from the manifest URL. downloadFromURL
 	// enforces scheme and origin against the configured control-plane URL.
 	tempPath, err := u.downloadFromURL(info.URL)
 	if err != nil {
-		return "", updateManifest{}, err
+		return "", updateManifest{}, nil, err
 	}
 	if manifest.Size > 0 {
 		stat, err := os.Stat(tempPath)
 		if err != nil {
 			removeCleanup(tempPath)
-			return "", updateManifest{}, err
+			return "", updateManifest{}, nil, err
 		}
 		if stat.Size() != manifest.Size {
 			removeCleanup(tempPath)
-			return "", updateManifest{}, fmt.Errorf("downloaded binary size mismatch: expected %d, got %d", manifest.Size, stat.Size())
+			return "", updateManifest{}, nil, fmt.Errorf("downloaded binary size mismatch: expected %d, got %d", manifest.Size, stat.Size())
 		}
 	}
 
-	return tempPath, manifest, nil
+	return tempPath, manifest, verifiedPayload, nil
 }
 
 // verifyChecksum verifies the SHA256 checksum of a file

--- a/agent/internal/updater/updater_test.go
+++ b/agent/internal/updater/updater_test.go
@@ -395,7 +395,7 @@ func TestDownloadBinary(t *testing.T) {
 	})
 	u.client = server.Client()
 
-	tempPath, manifest, err := u.downloadBinary("1.0.0")
+	tempPath, manifest, _, err := u.downloadBinary("1.0.0")
 	if err != nil {
 		t.Fatalf("download failed: %v", err)
 	}
@@ -471,7 +471,7 @@ func TestDownloadBinaryRejectsTamperedSignedMetadata(t *testing.T) {
 	})
 	u.client = server.Client()
 
-	_, _, err = u.downloadBinary("1.0.0")
+	_, _, _, err = u.downloadBinary("1.0.0")
 	if err == nil {
 		t.Fatal("tampered manifest metadata should fail signature verification")
 	}
@@ -504,7 +504,7 @@ func TestDownloadBinaryAcceptsSignedReleaseArtifactManifest(t *testing.T) {
 	})
 	u.client = server.Client()
 
-	tempPath, manifest, err := u.downloadBinary("1.0.0")
+	tempPath, manifest, _, err := u.downloadBinary("1.0.0")
 	if err != nil {
 		t.Fatalf("download failed: %v", err)
 	}
@@ -563,7 +563,7 @@ func TestDownloadBinaryAcceptsServerRelativeUrlWithMatchingChecksum(t *testing.T
 	})
 	u.client = server.Client()
 
-	tempPath, manifest, err := u.downloadBinary("1.0.0")
+	tempPath, manifest, _, err := u.downloadBinary("1.0.0")
 	if err != nil {
 		t.Fatalf("server-relative URL with matching checksum should be accepted: %v", err)
 	}
@@ -599,7 +599,7 @@ func TestDownloadBinaryRejectsWrongSignedReleaseArtifact(t *testing.T) {
 	})
 	u.client = server.Client()
 
-	_, _, err := u.downloadBinary("1.0.0")
+	_, _, _, err := u.downloadBinary("1.0.0")
 	if err == nil {
 		t.Fatal("wrong signed release artifact should fail")
 	}
@@ -635,7 +635,7 @@ func TestDownloadBinaryRejectsRedirectResponseWithoutSignedManifest(t *testing.T
 	})
 	u.client = server.Client()
 
-	_, _, err := u.downloadBinary("1.0.0")
+	_, _, _, err := u.downloadBinary("1.0.0")
 	if err == nil {
 		t.Fatal("redirect response without signed manifest should fail")
 	}
@@ -654,7 +654,7 @@ func TestDownloadBinaryMissingChecksum(t *testing.T) {
 	u := New(&Config{ServerURL: server.URL})
 	u.client = server.Client()
 
-	_, _, err := u.downloadBinary("1.0.0")
+	_, _, _, err := u.downloadBinary("1.0.0")
 	if err == nil {
 		t.Fatal("should fail when checksum missing from JSON response")
 	}
@@ -669,7 +669,7 @@ func TestDownloadBinaryServerError(t *testing.T) {
 	u := New(&Config{ServerURL: server.URL})
 	u.client = server.Client()
 
-	_, _, err := u.downloadBinary("1.0.0")
+	_, _, _, err := u.downloadBinary("1.0.0")
 	if err == nil {
 		t.Fatal("should fail on server error")
 	}
@@ -782,7 +782,7 @@ func TestEndToEndUpdateWithoutRestart(t *testing.T) {
 
 	// We can't test the full UpdateTo because Restart() would fail,
 	// but we can test the download -> verify -> backup -> replace pipeline manually
-	tempPath, manifest, err := u.downloadBinary("1.0.0")
+	tempPath, manifest, _, err := u.downloadBinary("1.0.0")
 	if err != nil {
 		t.Fatalf("download: %v", err)
 	}


### PR DESCRIPTION
## What

The macOS auto-update path now verifies the downloaded `.pkg` installer against the same Ed25519-signed release manifest that authenticates the agent binary, before handing it to `installer` as root.

## Why

The darwin update branch downloaded the manifest-verified binary and then discarded it, fetching the `.pkg` separately with no checksum/signature check before running `installer -pkg -target /`. That left the `.pkg` outside the agent's signed-manifest trust root — the whole point of which is to not trust the transport/CDN.

## How

- `pkgAssetChecksum()` extracts the signed SHA-256 for `breeze-agent-darwin-<arch>.pkg` from the already-signature-verified release manifest payload. The `.pkg` is already listed in the manifest's `assets[]` (release.yml hashes every release asset), so **no release-pipeline change is needed.**
- `downloadBinary()` threads the verified manifest payload out so the darwin path can look it up without a second round-trip.
- `installViaPkg()` verifies the `.pkg`'s SHA-256 against the signed checksum before `installer`, and refuses to run with an empty checksum.
- **Fail-closed:** if the signed `.pkg` checksum is unavailable, `UpdateTo` falls back to verified-binary replacement rather than installing unverified bytes.

## Test plan

`cd agent && go test -race ./internal/updater/...` — 6 new tests (manifest lookup: present / absent→fail-closed / version-mismatch / non-hex / legacy; plus the empty-checksum guard) + full existing updater suite, green on darwin/linux/windows; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)