### PR TITLE
fix(agent): refuse re-enrollment of a quarantined device

### DIFF
--- a/apps/api/src/routes/agents/enrollment.test.ts
+++ b/apps/api/src/routes/agents/enrollment.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
+import { createHash } from 'node:crypto';
 
 // ---------- mocks ----------
 
@@ -677,6 +678,80 @@ describe('POST /agents/enroll — 401 reason disambiguation', () => {
       expect.objectContaining({
         details: expect.objectContaining({
           reason: 'decommissioned_row_reenrolled_fresh_id',
+        }),
+      })
+    );
+  });
+
+  it('refuses re-enrollment of a quarantined device even with a valid existing-device token (containment escape)', async () => {
+    // A quarantined device (mTLS expired-cert policy, or admin security
+    // quarantine) must NOT be able to clear its own containment by
+    // re-enrolling. Even presenting a VALID existing-device token,
+    // re-enrollment must be refused — only the admin /approve endpoint may
+    // clear quarantinedAt/quarantinedReason and return the device to service.
+    // Without this guard the quarantined row (or anyone holding its brz_
+    // token — exactly what quarantine is meant to contain) re-POSTs /enroll
+    // and the in-place UPDATE flips status back to 'online', resuming
+    // heartbeat/commands/remote-desktop with no operator approval.
+    const validToken = 'valid-existing-device-token';
+    const validHash = createHash('sha256').update(validToken).digest('hex');
+
+    mockKeyLookup({
+      id: 'key-quarantined',
+      orgId: 'org-quarantined',
+      siteId: 'site-quarantined',
+      keySecretHash: null,
+      expiresAt: new Date(Date.now() + 3600_000),
+      maxUsage: 10,
+      usageCount: 0,
+    });
+
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn().mockResolvedValue([{
+            id: 'key-quarantined',
+            orgId: 'org-quarantined',
+            siteId: 'site-quarantined',
+          }]),
+        })),
+      })),
+    } as any);
+
+    mockSelectRows([{ partnerId: 'partner-quarantined' }]);
+    mockSelectRows([{ maxDevices: null }]);
+    // Existing row: QUARANTINED, token NOT suspended, with a matching token —
+    // i.e. the device would otherwise authenticate and be flipped online.
+    mockSelectRows([{
+      id: 'device-quarantined',
+      status: 'quarantined',
+      agentTokenHash: validHash,
+      previousTokenHash: null,
+      previousTokenExpiresAt: null,
+      agentTokenSuspendedAt: null,
+    }]);
+
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-agent-reenrollment-token': validToken,
+      },
+      body: JSON.stringify(baseEnrollBody),
+    });
+
+    expect(resp.status).toBe(403);
+    const body = (await resp.json()) as Record<string, unknown>;
+    expect(body.reason).toBe('device_quarantined');
+    // Refusal is audited, not silently allowed.
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'agent.enroll',
+        resourceId: 'device-quarantined',
+        result: 'denied',
+        details: expect.objectContaining({
+          reason: 'quarantined_device_reenroll_refused',
         }),
       })
     );

--- a/apps/api/src/routes/agents/enrollment.ts
+++ b/apps/api/src/routes/agents/enrollment.ts
@@ -369,6 +369,42 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
     // the prior device's audit history (agent_logs, alerts, etc.).
     let decomBypassFreshRow = false;
     if (existingDevice) {
+      // Containment guard: a quarantined device must NOT be able to clear its
+      // own containment by re-enrolling. Even with a valid existing-device
+      // token, re-enrollment must be refused — only the admin /approve endpoint
+      // (mtls.ts POST /:id/approve) may clear quarantinedAt/quarantinedReason
+      // and return the device to 'online'. Without this gate, the quarantined
+      // row (or anyone holding its brz_ token — exactly what quarantine is
+      // meant to contain) re-POSTs /enroll and the in-place UPDATE below flips
+      // status back to 'online', resuming heartbeat/commands/remote-desktop
+      // with no operator approval and leaving stale quarantinedAt/Reason
+      // columns that mask the bypass in the UI.
+      if (existingDevice.status === 'quarantined') {
+        writeAuditEvent(c, {
+          orgId: key.orgId,
+          actorType: 'system',
+          action: 'agent.enroll',
+          resourceType: 'device',
+          resourceId: existingDevice.id,
+          resourceName: data.hostname,
+          details: {
+            reason: 'quarantined_device_reenroll_refused',
+            siteId,
+          },
+          result: 'denied',
+          errorMessage:
+            'Re-enrollment refused: device is quarantined and awaiting administrator approval',
+        });
+        return c.json(
+          {
+            error:
+              'Device is quarantined and awaiting administrator approval. Re-enrollment cannot clear quarantine; an administrator must approve the device.',
+            reason: 'device_quarantined',
+          },
+          403,
+        );
+      }
+
       const tokenSuspended = !!existingDevice.agentTokenSuspendedAt;
 
       if (tokenSuspended) {


### PR DESCRIPTION
## What

The `/enroll` handler now refuses re-enrollment of a device whose status is `quarantined`, returning `403` (audited) even when a valid existing-device token is presented.

## Why

`/enroll` special-cased only `decommissioned` and token-suspended devices. A `quarantined` device whose token was never suspended fell through to the token-auth path, and the in-place UPDATE flipped status back to `online` — returning the device to service with no operator approval and leaving stale `quarantinedAt`/`quarantinedReason` columns. The admin approval gate was effectively bypassable by re-enrolling.

## How

- Explicit `status === 'quarantined'` guard at the top of the existing-device branch in `enrollment.ts` → `403 { reason: 'device_quarantined' }` + a denied audit event.
- Recovery path unchanged: only the admin `/approve` endpoint (`mtls.ts` `POST /:id/approve`) clears `quarantinedAt`/`quarantinedReason` and returns the device to `online`.

## Test plan

`pnpm --filter @breeze/api test enrollment` — new test asserts a quarantined device + valid existing-device token → `403 device_quarantined` + denied audit; full enrollment suite 21/21; `tsc --noEmit` clean for the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)