### PR TITLE
fix(agent): harden update channel — gate dev_update + refuse auto-downgrades

### DIFF
--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -120,6 +120,14 @@ type Config struct {
 	// Auto-update toggle (default: true)
 	AutoUpdate bool `mapstructure:"auto_update"`
 
+	// AllowDevUpdate gates the `dev_update` command, which installs a binary
+	// from a server-supplied URL verified ONLY against a server-supplied
+	// checksum — it bypasses the Ed25519 signed-manifest trust root. Default
+	// false so a compromised/MITM'd control plane cannot use dev_update to push
+	// an arbitrary unsigned binary (SYSTEM/root code exec). Set true only on
+	// developer/test machines that need manual dev pushes.
+	AllowDevUpdate bool `mapstructure:"allow_dev_update" yaml:"allow_dev_update"`
+
 	// PinnedManifestPubKeys are deployment-specific Ed25519 pubkeys delivered
 	// via enrollment/heartbeat and pinned TOFU-style. Format: "<keyId>:<base64-raw-pubkey>".
 	// Merged with the embedded LanternOps trust root in updater.trustedManifestKeys()
@@ -407,6 +415,7 @@ func SaveTo(cfg *Config, cfgFile string) error {
 	viper.Set("log_level", cfg.LogLevel)
 	viper.Set("log_shipping_level", cfg.LogShippingLevel)
 	viper.Set("auto_update", cfg.AutoUpdate)
+	viper.Set("allow_dev_update", cfg.AllowDevUpdate)
 	viper.Set("pinned_manifest_pub_keys", cfg.PinnedManifestPubKeys)
 	// Write only the helper-scoped token to agent.yaml. Full agent and watchdog
 	// bearer tokens are persisted below in root-only secrets.yaml.

--- a/agent/internal/heartbeat/handlers_devupdate.go
+++ b/agent/internal/heartbeat/handlers_devupdate.go
@@ -38,6 +38,19 @@ func init() {
 func handleDevUpdate(h *Heartbeat, cmd Command) tools.CommandResult {
 	start := time.Now()
 
+	// SECURITY: dev_update installs a binary from a server-supplied URL verified
+	// only against a server-supplied checksum — it does NOT verify against the
+	// Ed25519 signed-manifest trust root. A compromised or MITM'd control plane
+	// could therefore push an arbitrary unsigned binary that runs as SYSTEM/root.
+	// Gate it behind an explicit, default-off opt-in so production agents reject
+	// it outright; developer/test machines set allow_dev_update: true.
+	if h.config == nil || !h.config.AllowDevUpdate {
+		return tools.NewErrorResult(
+			fmt.Errorf("dev_update is disabled on this agent (set allow_dev_update: true to enable manual dev pushes)"),
+			time.Since(start).Milliseconds(),
+		)
+	}
+
 	downloadURL := tools.GetPayloadString(cmd.Payload, "downloadUrl", "")
 	if downloadURL == "" {
 		return tools.NewErrorResult(fmt.Errorf("missing required field: downloadUrl"), 0)

--- a/agent/internal/heartbeat/handlers_devupdate_test.go
+++ b/agent/internal/heartbeat/handlers_devupdate_test.go
@@ -3,6 +3,7 @@ package heartbeat
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -34,6 +35,48 @@ auto_update: true
 		t.Fatalf("config.Load: %v", err)
 	}
 	return cfg
+}
+
+func TestHandleDevUpdate_RejectedWhenDisabled(t *testing.T) {
+	// Default (allow_dev_update unset → false): a dev_update command with a
+	// valid URL + checksum must be refused outright, BEFORE any download, so a
+	// compromised/MITM'd control plane cannot push an unsigned binary.
+	h := &Heartbeat{config: &config.Config{AllowDevUpdate: false}}
+	cmd := Command{Payload: map[string]any{
+		"downloadUrl": "https://api.example.test/agent-binary",
+		"checksum":    "abc123",
+		"component":   "agent",
+	}}
+
+	result := handleDevUpdate(h, cmd)
+
+	if result.Status != "failed" {
+		t.Fatalf("expected failed result when dev_update disabled, got %q", result.Status)
+	}
+	if !strings.Contains(result.Error, "disabled") {
+		t.Fatalf("expected 'disabled' rejection, got %q", result.Error)
+	}
+}
+
+func TestHandleDevUpdate_GatePassesWhenEnabled(t *testing.T) {
+	// With allow_dev_update: true the gate is passed — the command proceeds
+	// (and then fails downloading from the unreachable test URL). The point is
+	// that it is NOT rejected by the disabled-gate.
+	cfg := loadEphemeralConfigForPersist(t)
+	cfg.AllowDevUpdate = true
+	h := &Heartbeat{config: cfg}
+	cmd := Command{Payload: map[string]any{
+		"downloadUrl":        "https://api.example.test/agent-binary",
+		"checksum":           "abc123",
+		"component":          "agent",
+		"preserveAutoUpdate": true,
+	}}
+
+	result := handleDevUpdate(h, cmd)
+
+	if strings.Contains(result.Error, "disabled") {
+		t.Fatalf("gate should pass when allow_dev_update=true, but got disabled rejection: %q", result.Error)
+	}
 }
 
 func TestApplyDevUpdateAutoUpdatePolicy_DefaultDisablesAutoUpdate(t *testing.T) {

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -2280,7 +2280,16 @@ func (h *Heartbeat) sendHeartbeat() {
 
 	// Handle upgrade if requested and auto-update is enabled
 	if response.UpgradeTo != "" && response.UpgradeTo != h.agentVersion {
-		if h.manifestTrustRotationRejected.Load() {
+		if isDowngrade(response.UpgradeTo, h.agentVersion) {
+			// SECURITY: never auto-downgrade. A compromised/MITM'd control plane
+			// could otherwise force a fleet-wide rollback to an older,
+			// still-validly-signed, known-vulnerable build. Deliberate rollback
+			// is an operator action via the (default-off) dev_update path.
+			log.Error("SECURITY: refusing server-directed auto-update downgrade",
+				"currentVersion", h.agentVersion,
+				"targetVersion", response.UpgradeTo,
+				"hint", "deliberate rollback uses the operator dev_update path")
+		} else if h.manifestTrustRotationRejected.Load() {
 			log.Error("SECURITY: skipping auto-update — manifest trust rotation rejection unresolved",
 				"targetVersion", response.UpgradeTo)
 		} else if h.config.AutoUpdate {

--- a/agent/internal/heartbeat/version_downgrade.go
+++ b/agent/internal/heartbeat/version_downgrade.go
@@ -1,0 +1,50 @@
+package heartbeat
+
+import (
+	"strconv"
+	"strings"
+)
+
+// parseSemver extracts major/minor/patch from a version string like "0.68.2"
+// or "v0.68.2". A pre-release/build suffix (after '-' or '+') is ignored.
+// Returns ok=false for anything that isn't three dotted non-negative integers
+// (e.g. "dev", "") so callers can fail open.
+func parseSemver(v string) (maj, min, patch int, ok bool) {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	parts := strings.Split(v, ".")
+	if len(parts) != 3 {
+		return 0, 0, 0, false
+	}
+	var out [3]int
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 {
+			return 0, 0, 0, false
+		}
+		out[i] = n
+	}
+	return out[0], out[1], out[2], true
+}
+
+// isDowngrade reports whether target is a strictly lower semver than current.
+// Fail-open: returns false when either version is unparseable, so updates we
+// cannot reason about (e.g. "dev" builds) are never blocked — the security
+// goal is to stop a control plane forcing a real older release onto agents
+// running a real newer one, not to police non-semver builds.
+func isDowngrade(target, current string) bool {
+	tMaj, tMin, tPatch, tOk := parseSemver(target)
+	cMaj, cMin, cPatch, cOk := parseSemver(current)
+	if !tOk || !cOk {
+		return false
+	}
+	if tMaj != cMaj {
+		return tMaj < cMaj
+	}
+	if tMin != cMin {
+		return tMin < cMin
+	}
+	return tPatch < cPatch
+}

--- a/agent/internal/heartbeat/version_downgrade_test.go
+++ b/agent/internal/heartbeat/version_downgrade_test.go
@@ -1,0 +1,35 @@
+package heartbeat
+
+import "testing"
+
+func TestIsDowngrade(t *testing.T) {
+	cases := []struct {
+		name    string
+		target  string
+		current string
+		want    bool
+	}{
+		{"older patch", "0.68.1", "0.68.2", true},
+		{"older minor", "0.67.9", "0.68.0", true},
+		{"older major", "0.99.9", "1.0.0", true},
+		{"same version", "0.68.2", "0.68.2", false},
+		{"newer patch", "0.68.3", "0.68.2", false},
+		{"newer minor", "0.69.0", "0.68.9", false},
+		{"newer major", "1.0.0", "0.99.9", false},
+		{"v-prefix older", "v0.68.1", "0.68.2", true},
+		{"v-prefix newer", "v0.69.0", "v0.68.2", false},
+		{"prerelease suffix ignored, older", "0.68.1-rc1", "0.68.2", true},
+		{"prerelease suffix ignored, newer", "0.69.0-rc1", "0.68.2", false},
+		{"unparseable target fails open", "dev", "0.68.2", false},
+		{"unparseable current fails open", "0.68.1", "dev", false},
+		{"both unparseable fails open", "dev", "dev", false},
+		{"empty target fails open", "", "0.68.2", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isDowngrade(tc.target, tc.current); got != tc.want {
+				t.Fatalf("isDowngrade(%q, %q) = %v, want %v", tc.target, tc.current, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hardens the agent update channel against a compromised/MITM'd control plane — defense-in-depth around the Ed25519 signed-manifest trust root. Two related commits.

## 1. Gate `dev_update` behind a default-off flag
`dev_update` installs a binary from a server-supplied URL verified only against a server-supplied checksum — it bypasses the signed-manifest trust root that bounds what even a compromised control plane can install. Added an `allow_dev_update` config flag (**default false**); production agents now reject the command outright. Developer/test machines opt in via `allow_dev_update: true`.

_Dev-only breaking: workflows that rely on `dev_update` must set the flag._

## 2. Refuse server-directed auto-update downgrades
The heartbeat auto-update path accepted any version the server named, including older ones — a compromised control plane could force a fleet-wide rollback to an older, still-validly-signed, known-vulnerable build (manifest signing doesn't stop this; it's a real prior release). Auto-update is now **monotonic**: `UpgradeTo` is refused when it parses as a strictly lower semver than the running version. Comparison fails open for unparseable builds (`dev`). Deliberate rollback remains an operator action via the now-gated `dev_update` path.

_Behavior change: no server-driven automatic rollback to a "last good" build; rollback is operator-initiated._

## Test plan
`cd agent && go test ./internal/heartbeat/ ./internal/config/` — dev_update gate (rejected when disabled / passes when enabled) + table-driven `isDowngrade` (older/newer/equal across major·minor·patch, v-prefix, prerelease suffixes, fail-open on unparseable). Full heartbeat + config suites green; cross-compiles linux/windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)