### PR TITLE
fix(mcp): gate client-supplied orgId in tool-execution attribution

### DIFF
--- a/apps/api/src/routes/mcpExecutionOrg.test.ts
+++ b/apps/api/src/routes/mcpExecutionOrg.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+import type { AuthContext } from '../middleware/auth';
+import { resolveMcpExecutionOrgId } from './mcpExecutionOrg';
+
+// ============================================================================
+// resolveMcpExecutionOrgId — tenant-isolation regression (security)
+//
+// Regression for the cross-tenant audit/ledger attribution defect: a
+// partner-scoped MCP caller (OAuth bearer, org_id claim null) had apiKey.orgId
+// AND auth.orgId both null, so org resolution fell through to the
+// attacker-supplied arguments.orgId with no authorization check. That value is
+// used as the tenant attribution for the tool-execution ledger
+// (ai_sessions / ai_tool_executions) and the per-tool audit_logs event — so an
+// out-of-scope orgId let a partner forge audit/ledger rows in another tenant.
+//
+// The resolver MUST gate a client-supplied orgId through auth.canAccessOrg(),
+// mirroring resolveWritableToolOrgId (services/aiTools.ts).
+// ============================================================================
+
+const OWN_ORG = '11111111-1111-4111-8111-111111111111';
+const SECOND_ORG = '22222222-2222-4222-8222-222222222222';
+const VICTIM_ORG = '99999999-9999-4999-8999-999999999999';
+const KEY_ORG = '33333333-3333-4333-8333-333333333333';
+
+// Partner-scoped principal: orgId is null; access is bounded by accessibleOrgIds.
+// This is the exact shape an MSP partner-admin OAuth bearer produces.
+function partnerAuth(accessibleOrgIds: string[]): AuthContext {
+  return {
+    user: { id: '44444444-4444-4444-8444-444444444444', email: 'p@msp.example', name: 'P', isPlatformAdmin: false },
+    token: {} as AuthContext['token'],
+    partnerId: '55555555-5555-4555-8555-555555555555',
+    orgId: null,
+    scope: 'partner',
+    accessibleOrgIds,
+    orgCondition: () => undefined,
+    canAccessOrg: (orgId: string) => accessibleOrgIds.includes(orgId),
+  };
+}
+
+// Org-scoped principal: pinned to a single org.
+function orgAuth(orgId: string): AuthContext {
+  return {
+    user: { id: '66666666-6666-4666-8666-666666666666', email: 'u@org.example', name: 'U', isPlatformAdmin: false },
+    token: {} as AuthContext['token'],
+    partnerId: null,
+    orgId,
+    scope: 'organization',
+    accessibleOrgIds: [orgId],
+    orgCondition: () => undefined,
+    canAccessOrg: (id: string) => id === orgId,
+  };
+}
+
+// System-scoped principal (e.g. platform admin): can access ALL orgs, so
+// canAccessOrg returns true for any org and accessibleOrgIds is null.
+function systemAuth(): AuthContext {
+  return {
+    user: { id: '77777777-7777-4777-8777-777777777777', email: 's@breeze.example', name: 'S', isPlatformAdmin: true },
+    token: {} as AuthContext['token'],
+    partnerId: null,
+    orgId: null,
+    scope: 'system',
+    accessibleOrgIds: null,
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+  };
+}
+
+describe('resolveMcpExecutionOrgId — tenant isolation', () => {
+  it('does NOT honor an out-of-scope arguments.orgId for a partner-scoped caller', () => {
+    // Core defect: a partner names a victim org it cannot access.
+    const result = resolveMcpExecutionOrgId(
+      { orgId: null },
+      partnerAuth([OWN_ORG]),
+      { orgId: VICTIM_ORG },
+    );
+    expect(result).not.toBe(VICTIM_ORG);
+    // Falls back to an org the caller can actually access.
+    expect(result).toBe(OWN_ORG);
+  });
+
+  it('returns null (never the victim org) when an out-of-scope orgId is supplied and the caller has no accessible orgs', () => {
+    const result = resolveMcpExecutionOrgId(
+      { orgId: null },
+      partnerAuth([]),
+      { orgId: VICTIM_ORG },
+    );
+    expect(result).not.toBe(VICTIM_ORG);
+    expect(result).toBeNull();
+  });
+
+  it('honors an in-scope arguments.orgId for a partner-scoped caller', () => {
+    const result = resolveMcpExecutionOrgId(
+      { orgId: null },
+      partnerAuth([OWN_ORG, SECOND_ORG]),
+      { orgId: SECOND_ORG },
+    );
+    expect(result).toBe(SECOND_ORG);
+  });
+
+  it('falls back to the first accessible org when no orgId is supplied', () => {
+    const result = resolveMcpExecutionOrgId(
+      { orgId: null },
+      partnerAuth([OWN_ORG, SECOND_ORG]),
+      {},
+    );
+    expect(result).toBe(OWN_ORG);
+  });
+
+  it('pins to the API key org and ignores arguments.orgId (org-scoped X-API-Key)', () => {
+    const result = resolveMcpExecutionOrgId(
+      { orgId: KEY_ORG },
+      partnerAuth([OWN_ORG]),
+      { orgId: VICTIM_ORG },
+    );
+    expect(result).toBe(KEY_ORG);
+  });
+
+  it('pins to auth.orgId and ignores arguments.orgId (org-scoped principal)', () => {
+    const result = resolveMcpExecutionOrgId(
+      { orgId: null },
+      orgAuth(OWN_ORG),
+      { orgId: VICTIM_ORG },
+    );
+    expect(result).toBe(OWN_ORG);
+  });
+
+  it('ignores a non-string arguments.orgId and falls back to an accessible org', () => {
+    const result = resolveMcpExecutionOrgId(
+      { orgId: null },
+      partnerAuth([OWN_ORG]),
+      { orgId: 12345 },
+    );
+    expect(result).toBe(OWN_ORG);
+  });
+
+  it('treats an undefined principal like a partner with the supplied access check', () => {
+    // Defensive: even with no apiKey object, an out-of-scope input is rejected.
+    const result = resolveMcpExecutionOrgId(
+      undefined,
+      partnerAuth([OWN_ORG]),
+      { orgId: VICTIM_ORG },
+    );
+    expect(result).not.toBe(VICTIM_ORG);
+    expect(result).toBe(OWN_ORG);
+  });
+
+  it('honors any supplied orgId for a system-scoped caller (system can access all orgs)', () => {
+    const result = resolveMcpExecutionOrgId(
+      { orgId: null },
+      systemAuth(),
+      { orgId: VICTIM_ORG },
+    );
+    expect(result).toBe(VICTIM_ORG);
+  });
+
+  it('returns null for a system-scoped caller with no supplied orgId (no sensible default)', () => {
+    const result = resolveMcpExecutionOrgId(
+      { orgId: null },
+      systemAuth(),
+      {},
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/apps/api/src/routes/mcpExecutionOrg.ts
+++ b/apps/api/src/routes/mcpExecutionOrg.ts
@@ -1,0 +1,51 @@
+import type { AuthContext } from '../middleware/auth';
+
+/**
+ * Minimal shape this resolver needs from the MCP principal (X-API-Key or OAuth
+ * bearer context). Kept narrow so the resolver has no runtime dependencies and
+ * stays unit-testable in isolation. `McpApiKeyContext` in mcpServer.ts is
+ * structurally compatible (it carries `orgId`).
+ */
+export interface McpExecutionPrincipal {
+  orgId: string | null;
+}
+
+/**
+ * Resolve the org id used to ATTRIBUTE an MCP tool execution — the tenant the
+ * tool-execution ledger (ai_sessions / ai_tool_executions) and the per-tool
+ * audit_logs event are written under.
+ *
+ * Tenant-isolation contract: a client-supplied `toolInput.orgId` must NEVER be
+ * honored without an access check, because the ledger opens an RLS context for
+ * the resolved org and the audit row is written under the system (RLS-bypassed)
+ * context. Priority:
+ *   1. Org-scoped X-API-Key  → pinned to the key's org (input ignored).
+ *   2. Org-scoped principal  → pinned to `auth.orgId` (input ignored).
+ *   3. Partner-scoped principal → a supplied `orgId` is honored ONLY if it is
+ *      within the caller's accessible set (`auth.canAccessOrg`); otherwise it is
+ *      discarded and we fall back to the caller's first accessible org.
+ *   4. System scope (`auth.accessibleOrgIds === null`) → `auth.canAccessOrg`
+ *      returns true for every org, so a supplied `orgId` is honored (a system
+ *      caller may act on any tenant); with no input there is no sensible default
+ *      and we return null. (The MCP auth path does not mint system scope today;
+ *      this keeps the helper correct should it ever be reused.)
+ *
+ * Follows the same `canAccessOrg`-gating principle as `resolveWritableToolOrgId`
+ * (services/aiTools.ts).
+ */
+export function resolveMcpExecutionOrgId(
+  apiKey: McpExecutionPrincipal | undefined,
+  auth: AuthContext,
+  toolInput: Record<string, unknown>,
+): string | null {
+  // 1. Org-scoped X-API-Key: pinned to the key's org; client input is ignored.
+  if (apiKey?.orgId) return apiKey.orgId;
+  // 2. Org-scoped principal: pinned to auth.orgId; client input is ignored.
+  if (auth.orgId) return auth.orgId;
+  // 3. Partner-scoped principal: honor a client-supplied orgId ONLY if it is
+  //    within the caller's accessible set — never trust raw input. Otherwise
+  //    discard it and fall back to the caller's first accessible org.
+  const inputOrgId = typeof toolInput.orgId === 'string' ? toolInput.orgId : null;
+  if (inputOrgId && auth.canAccessOrg(inputOrgId)) return inputOrgId;
+  return auth.accessibleOrgIds?.[0] ?? null;
+}

--- a/apps/api/src/routes/mcpServer.bearer.test.ts
+++ b/apps/api/src/routes/mcpServer.bearer.test.ts
@@ -203,6 +203,53 @@ describe('mcpServer bearer auth routing', () => {
     expect(Array.isArray(authArg?.accessibleOrgIds)).toBe(true);
   });
 
+  it('never attributes the per-tool audit event to a client-supplied out-of-scope arguments.orgId (partner-scoped)', async () => {
+    // Regression for the cross-tenant attribution defect, exercised end-to-end
+    // through handleToolsCall (not just the unit resolver): a partner-scoped
+    // OAuth caller (apiKey.orgId null) that sets arguments.orgId to an org it
+    // cannot access must NOT have that org used as the audit_logs attribution.
+    // Proves the wiring resolveMcpExecutionOrgId -> executionOrgId ->
+    // writeMcpToolAuditEvent for the tier-1 sink reachable with mcp:read.
+    process.env.MCP_OAUTH_ENABLED = 'true';
+    mocks.bearerTokenAuthMiddleware.mockImplementation(async (c: any, next: any) => {
+      c.set('apiKey', {
+        id: 'oauth:jti-1', orgId: null, partnerId: 'partner-1',
+        name: 'OAuth bearer', keyPrefix: 'oauth',
+        scopes: ['ai:read'], rateLimit: 1000, createdBy: 'user-1',
+      });
+      return next();
+    });
+    mocks.getToolTier.mockReturnValue(1);
+    mocks.executeTool.mockResolvedValue('ok');
+
+    const VICTIM_ORG = '99999999-9999-4999-8999-999999999999';
+    const { app } = await appWithMcpRoutes();
+    const { writeAuditEvent } = await import('../services/auditEvents');
+
+    const res = await app.request('/mcp/message', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer foo' },
+      body: JSON.stringify({
+        jsonrpc: '2.0', id: 1, method: 'tools/call',
+        params: { name: 'inspect_scope', arguments: { orgId: VICTIM_ORG } },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    // tools/call emits two audit rows: a per-request `mcp.tools.call` (org via
+    // the safe resolveDefaultOrgId) and the per-tool `mcp.tool.<name>` written by
+    // writeMcpToolAuditEvent (org via the gated executionOrgId — the sink the fix
+    // touches). Assert the per-tool sink ran...
+    const events = ((writeAuditEvent as any).mock.calls as Array<[unknown, { orgId?: string | null; action?: string }]>)
+      .map((call) => call[1]);
+    expect(events.some((e) => e?.action === 'mcp.tool.inspect_scope')).toBe(true);
+    // ...and that NO audit row (per-tool or per-request) is attributed to the
+    // attacker-supplied org.
+    for (const e of events) {
+      expect(e?.orgId).not.toBe(VICTIM_ORG);
+    }
+  });
+
   it('no auth headers → 401 even with MCP_OAUTH_ENABLED (carve-out deleted in Phase 3)', async () => {
     process.env.MCP_OAUTH_ENABLED = 'true';
     delete process.env.IS_HOSTED;

--- a/apps/api/src/routes/mcpServer.ts
+++ b/apps/api/src/routes/mcpServer.ts
@@ -37,6 +37,7 @@ import {
   completeMcpToolExecutionLedger,
   type McpToolExecutionLedgerHandle,
 } from '../services/mcpToolExecutionLedger';
+import { resolveMcpExecutionOrgId } from './mcpExecutionOrg';
 import { getRedis } from '../services/redis';
 import { rateLimiter } from '../services/rate-limit';
 import { getTrustedClientIp } from '../services/clientIp';
@@ -285,15 +286,6 @@ type McpApiKeyContext = {
   partnerId?: string | null;
   oauthGrantId?: string | null;
 };
-
-function resolveMcpExecutionOrgId(
-  apiKey: McpApiKeyContext | undefined,
-  auth: AuthContext,
-  toolInput: Record<string, unknown>,
-): string | null {
-  const inputOrgId = typeof toolInput.orgId === 'string' ? toolInput.orgId : null;
-  return apiKey?.orgId ?? auth.orgId ?? inputOrgId ?? auth.accessibleOrgIds?.[0] ?? null;
-}
 
 function buildMcpAuditAction(method: string): string {
   const normalized = method
@@ -945,6 +937,7 @@ async function handleToolsCall(
     try {
       ledgerHandle = await beginMcpToolExecutionLedger({
         orgId: executionOrgId,
+        accessibleOrgIds: auth.accessibleOrgIds,
         toolName,
         tier,
         toolInput,
@@ -1064,8 +1057,11 @@ function writeMcpToolAuditEvent(
   if (!c || !event.apiKey) return;
 
   const error = event.error instanceof Error ? event.error : undefined;
-  const inputOrgId = typeof event.toolInput.orgId === 'string' ? event.toolInput.orgId : null;
-  const orgId = event.orgId ?? event.apiKey.orgId ?? event.auth.orgId ?? inputOrgId;
+  // event.orgId is the access-checked execution org (resolveMcpExecutionOrgId).
+  // NEVER fall back to a raw client-supplied toolInput.orgId here — doing so
+  // would let a partner-scoped caller forge cross-tenant audit_logs attribution
+  // (audit rows are written under the RLS-bypassed system context).
+  const orgId = event.orgId ?? event.apiKey.orgId ?? event.auth.orgId ?? null;
   writeAuditEvent(c, {
     orgId,
     actorType: 'api_key',

--- a/apps/api/src/services/mcpToolExecutionLedger.test.ts
+++ b/apps/api/src/services/mcpToolExecutionLedger.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ============================================================================
+// beginMcpToolExecutionLedger — tenant-isolation defense-in-depth (security)
+//
+// The ledger opens an RLS context scoped to input.orgId and inserts ai_sessions
+// / ai_tool_executions rows under it. If an upstream org-resolution bug ever
+// passed an org the caller cannot access, those rows would land in another
+// tenant. The ledger must assert input.orgId is within input.accessibleOrgIds
+// (null = system scope = all orgs) BEFORE opening the context / writing rows.
+//
+// db is mocked so the throw is observable as "no insert happened". The two
+// pure util modules (auditPayloadSanitizer, aiToolOutput) run for real.
+// ============================================================================
+
+vi.mock('../db', () => {
+  // values() must be awaitable (aiSessions insert) AND expose .returning()
+  // (aiToolExecutions insert) — model both with a resolved promise carrying a
+  // .returning method.
+  const makeValuesResult = () => {
+    const p: any = Promise.resolve(undefined);
+    p.returning = () => Promise.resolve([{ id: '00000000-0000-4000-8000-00000000c0de' }]);
+    return p;
+  };
+  return {
+    db: { insert: vi.fn(() => ({ values: vi.fn(() => makeValuesResult()) })) },
+    runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+    withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  };
+});
+
+vi.mock('../db/schema', () => ({
+  aiSessions: {},
+  aiToolExecutions: { id: 'aiToolExecutions.id' },
+}));
+
+import { beginMcpToolExecutionLedger, type BeginMcpToolExecutionLedgerInput } from './mcpToolExecutionLedger';
+import { db } from '../db';
+
+const OWN_ORG = '11111111-1111-4111-8111-111111111111';
+const VICTIM_ORG = '99999999-9999-4999-8999-999999999999';
+
+function baseInput(overrides: Partial<BeginMcpToolExecutionLedgerInput> = {}): BeginMcpToolExecutionLedgerInput {
+  return {
+    orgId: OWN_ORG,
+    accessibleOrgIds: [OWN_ORG],
+    toolName: 'list_remote_sessions',
+    tier: 3,
+    toolInput: { orgId: OWN_ORG },
+    principal: { apiKeyId: 'key-1', oauthGrantId: null, partnerId: 'p-1', actorUserId: null },
+    transportSessionId: null,
+    ...overrides,
+  };
+}
+
+describe('beginMcpToolExecutionLedger — tenant isolation (defense-in-depth)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws WITHOUT writing any ledger row when orgId is outside the caller accessible set', async () => {
+    await expect(
+      beginMcpToolExecutionLedger(baseInput({ orgId: VICTIM_ORG, accessibleOrgIds: [OWN_ORG] })),
+    ).rejects.toThrow(/outside caller tenancy/i);
+    // Critical: the RLS context must never be opened nor any row inserted.
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('proceeds when orgId is within the caller accessible set', async () => {
+    const handle = await beginMcpToolExecutionLedger(
+      baseInput({ orgId: OWN_ORG, accessibleOrgIds: [OWN_ORG] }),
+    );
+    expect(handle.orgId).toBe(OWN_ORG);
+    expect(handle.executionId).toBe('00000000-0000-4000-8000-00000000c0de');
+    expect(db.insert).toHaveBeenCalled();
+  });
+
+  it('proceeds for a system-scope caller (accessibleOrgIds = null) targeting any org', async () => {
+    const handle = await beginMcpToolExecutionLedger(
+      baseInput({ orgId: VICTIM_ORG, accessibleOrgIds: null }),
+    );
+    expect(handle.orgId).toBe(VICTIM_ORG);
+    expect(db.insert).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/mcpToolExecutionLedger.ts
+++ b/apps/api/src/services/mcpToolExecutionLedger.ts
@@ -21,6 +21,13 @@ export interface McpToolExecutionLedgerHandle {
 
 export interface BeginMcpToolExecutionLedgerInput {
   orgId: string;
+  /**
+   * The caller's accessible org set (auth.accessibleOrgIds). `null` = system
+   * scope (access to all orgs). Used to assert `orgId` is within the caller's
+   * tenancy before opening the RLS context — defense-in-depth so an upstream
+   * org-resolution bug can never attribute ledger rows to an arbitrary tenant.
+   */
+  accessibleOrgIds: string[] | null;
   toolName: string;
   tier: number;
   toolInput: Record<string, unknown>;
@@ -53,6 +60,15 @@ function sanitizePrincipal(principal: McpToolExecutionLedgerPrincipal): Record<s
 export async function beginMcpToolExecutionLedger(
   input: BeginMcpToolExecutionLedgerInput,
 ): Promise<McpToolExecutionLedgerHandle> {
+  // Defense-in-depth: the RLS context opened below is scoped to input.orgId, so
+  // the caller MUST have proven access to it. accessibleOrgIds === null means
+  // system scope (all orgs). Reject anything outside the caller's tenancy BEFORE
+  // touching the DB, so an upstream org-resolution bug can never write ledger
+  // rows into an arbitrary tenant.
+  if (input.accessibleOrgIds !== null && !input.accessibleOrgIds.includes(input.orgId)) {
+    throw new Error('MCP tool execution ledger org is outside caller tenancy');
+  }
+
   const sessionId = crypto.randomUUID();
   const principal = sanitizePrincipal(input.principal);
   const target = summarizePayload(input.toolInput, { maxStringLength: 512 });


### PR DESCRIPTION
## Summary

A partner-scoped MCP caller (OAuth bearer with a null `org_id` claim) could set `arguments.orgId` to an org **outside its tenancy** and have that value used as the tenant attribution for audit/ledger writes — a tenant-isolation integrity defect surfaced by a security review and independently confirmed.

**Root cause:** `resolveMcpExecutionOrgId` resolved the attribution org as `apiKey?.orgId ?? auth.orgId ?? toolInput.orgId ?? ...` with **no `canAccessOrg()` check**. For a partner-scoped OAuth principal both `apiKey.orgId` and `auth.orgId` are null, so the raw client-supplied `toolInput.orgId` won.

**Two sinks:**
- **`audit_logs`** — written under the RLS-bypassed system context (`auditService.persistAuditLog`); reachable at **tier-1 / `mcp:read`** in production (the per-tool audit write is unconditional).
- **tier-3 tool-execution ledger** (`ai_sessions` / `ai_tool_executions`) — `beginMcpToolExecutionLedger` opens an RLS context from the supplied org, so the insert passes RLS for a tenant the caller can't access.

**Impact:** audit/ledger **mis-attribution** (audit poisoning / forged "tool X ran in tenant Y" rows in the append-only, hash-chained `audit_logs`), **not** data exfiltration — tool bodies still scope reads via `auth.canAccessOrg` / `orgCondition`.

## Fix

- **Gate the resolver (primary):** extracted `resolveMcpExecutionOrgId` into a dependency-free module and honor a client-supplied `orgId` only if `auth.canAccessOrg(orgId)`; org-scoped principals stay pinned to their own org. Mirrors `resolveWritableToolOrgId` (`aiTools.ts:102`). — `apps/api/src/routes/mcpExecutionOrg.ts`
- **Audit path:** `writeMcpToolAuditEvent` no longer re-derives org from raw `toolInput.orgId`; it trusts the already-gated `executionOrgId`. — `apps/api/src/routes/mcpServer.ts`
- **Ledger (defense-in-depth):** `beginMcpToolExecutionLedger` asserts `orgId` is within `accessibleOrgIds` before opening its RLS context (`null` = system scope). — `apps/api/src/services/mcpToolExecutionLedger.ts`

## Tests (TDD, red→green)

- `mcpExecutionOrg.test.ts` — 10 cases: core out-of-scope defect, in-scope honored, org-scoped pinning, empty-access→null, non-string input, system scope.
- `mcpToolExecutionLedger.test.ts` — 3 cases: out-of-scope **throws without inserting**, in-scope / system-scope proceed.

## Verification

- Full API unit suite: **5249 passed / 0 failed** (476 files).
- `tsc --noEmit`: **0 errors**.
- Independent adversarial code review: fix confirmed correct & complete.

Confirmed no other un-gated `toolInput.orgId`→sink path (`resolveDefaultOrgId` derives from the authenticated `auth.partnerId`'s own orgs). No schema / migration / RLS-policy changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)