### PR TITLE
fix(security): tenant-isolation & authz hardening (4 HIGH, 3 MED, 1 LOW)

### DIFF
--- a/apps/api/migrations/2026-05-30-fk-child-tables-rls.sql
+++ b/apps/api/migrations/2026-05-30-fk-child-tables-rls.sql
@@ -1,0 +1,214 @@
+-- 2026-05-30: RLS for tenant CHILD tables keyed by a parent FK (no org_id).
+--
+-- Root cause (security review F2/F5/F6/F7 + systemic): the RLS coverage
+-- contract test auto-discovers tenant tables by the presence of an `org_id`
+-- column. Tenant child tables that reach their tenant only through a parent
+-- FK (and carry no denormalized org_id) are therefore invisible to the test
+-- AND tended to ship with NO row-level security at all — violating the
+-- CLAUDE.md invariant "no app-layer-only fallback". This migration installs
+-- ENABLE + FORCE RLS and per-command policies on the seven such tables, and a
+-- companion change to rls-coverage.integration.test.ts adds a new
+-- "parent-FK join-policy" allowlist + assertion so the class stops recurring.
+--
+-- Shape: like the Phase-5 device-join policies, but the join target is the
+-- table's actual parent (automations / configuration_policies / ai_sessions /
+-- scripts / software_catalog / alerts) rather than `devices`. The org axis is
+-- the PARENT's org_id, reached via breeze_has_org_access(parent.org_id).
+--
+-- Safety (why this cannot break existing writes): every one of these child
+-- rows is created/updated in the SAME db-access context as a sibling that is
+-- ALREADY RLS-protected through the same parent (e.g. ai_messages alongside
+-- ai_sessions, automation_runs alongside automations, script_execution_batches
+-- alongside script_executions). A context that can write the protected sibling
+-- necessarily reaches the parent's org, so these EXISTS policies pass wherever
+-- the existing ones already pass. System/background writers run under
+-- withSystemDbAccessContext, where breeze_has_org_access short-circuits TRUE.
+--
+-- Two special cases:
+--   * automation_runs reaches its org via EITHER automation_id -> automations
+--     OR config_policy_id -> configuration_policies (config-policy-driven runs
+--     leave automation_id NULL). The policy OR's both EXISTS branches so
+--     neither run flavor becomes invisible/uninsertable.
+--   * script_execution_batches' parent `scripts` has a NULLABLE org_id: system
+--     scripts (is_system = true, org_id = NULL) are world-readable by design
+--     (see 2026-05-15-scripts-is-system-rls-select.sql). The batch policy
+--     mirrors that: `s.is_system = true OR breeze_has_org_access(s.org_id)`, so
+--     running a built-in script (which inserts a batch under tenant context)
+--     keeps working.
+--
+-- Idempotent: DROP POLICY IF EXISTS x4 before each CREATE; ENABLE/FORCE are
+-- no-ops when already set. Re-running converges to the same state.
+-- autoMigrate wraps each migration file in a transaction — no inner BEGIN/COMMIT.
+
+-- ---------------------------------------------------------------------------
+-- automation_runs  ->  automations(automation_id) OR configuration_policies(config_policy_id)
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS breeze_org_isolation_select ON automation_runs;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON automation_runs;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON automation_runs;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON automation_runs;
+ALTER TABLE automation_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE automation_runs FORCE ROW LEVEL SECURITY;
+CREATE POLICY breeze_org_isolation_select ON automation_runs FOR SELECT USING (
+  EXISTS (SELECT 1 FROM automations a WHERE a.id = automation_runs.automation_id AND public.breeze_has_org_access(a.org_id))
+  OR EXISTS (SELECT 1 FROM configuration_policies cp WHERE cp.id = automation_runs.config_policy_id AND public.breeze_has_org_access(cp.org_id))
+);
+CREATE POLICY breeze_org_isolation_insert ON automation_runs FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM automations a WHERE a.id = automation_runs.automation_id AND public.breeze_has_org_access(a.org_id))
+  OR EXISTS (SELECT 1 FROM configuration_policies cp WHERE cp.id = automation_runs.config_policy_id AND public.breeze_has_org_access(cp.org_id))
+);
+CREATE POLICY breeze_org_isolation_update ON automation_runs FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM automations a WHERE a.id = automation_runs.automation_id AND public.breeze_has_org_access(a.org_id))
+  OR EXISTS (SELECT 1 FROM configuration_policies cp WHERE cp.id = automation_runs.config_policy_id AND public.breeze_has_org_access(cp.org_id))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM automations a WHERE a.id = automation_runs.automation_id AND public.breeze_has_org_access(a.org_id))
+  OR EXISTS (SELECT 1 FROM configuration_policies cp WHERE cp.id = automation_runs.config_policy_id AND public.breeze_has_org_access(cp.org_id))
+);
+CREATE POLICY breeze_org_isolation_delete ON automation_runs FOR DELETE USING (
+  EXISTS (SELECT 1 FROM automations a WHERE a.id = automation_runs.automation_id AND public.breeze_has_org_access(a.org_id))
+  OR EXISTS (SELECT 1 FROM configuration_policies cp WHERE cp.id = automation_runs.config_policy_id AND public.breeze_has_org_access(cp.org_id))
+);
+
+-- ---------------------------------------------------------------------------
+-- ai_messages  ->  ai_sessions(session_id)
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS breeze_org_isolation_select ON ai_messages;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON ai_messages;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON ai_messages;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON ai_messages;
+ALTER TABLE ai_messages ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ai_messages FORCE ROW LEVEL SECURITY;
+CREATE POLICY breeze_org_isolation_select ON ai_messages FOR SELECT USING (
+  EXISTS (SELECT 1 FROM ai_sessions s WHERE s.id = ai_messages.session_id AND public.breeze_has_org_access(s.org_id))
+);
+CREATE POLICY breeze_org_isolation_insert ON ai_messages FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM ai_sessions s WHERE s.id = ai_messages.session_id AND public.breeze_has_org_access(s.org_id))
+);
+CREATE POLICY breeze_org_isolation_update ON ai_messages FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM ai_sessions s WHERE s.id = ai_messages.session_id AND public.breeze_has_org_access(s.org_id))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM ai_sessions s WHERE s.id = ai_messages.session_id AND public.breeze_has_org_access(s.org_id))
+);
+CREATE POLICY breeze_org_isolation_delete ON ai_messages FOR DELETE USING (
+  EXISTS (SELECT 1 FROM ai_sessions s WHERE s.id = ai_messages.session_id AND public.breeze_has_org_access(s.org_id))
+);
+
+-- ---------------------------------------------------------------------------
+-- ai_tool_executions  ->  ai_sessions(session_id)
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS breeze_org_isolation_select ON ai_tool_executions;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON ai_tool_executions;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON ai_tool_executions;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON ai_tool_executions;
+ALTER TABLE ai_tool_executions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ai_tool_executions FORCE ROW LEVEL SECURITY;
+CREATE POLICY breeze_org_isolation_select ON ai_tool_executions FOR SELECT USING (
+  EXISTS (SELECT 1 FROM ai_sessions s WHERE s.id = ai_tool_executions.session_id AND public.breeze_has_org_access(s.org_id))
+);
+CREATE POLICY breeze_org_isolation_insert ON ai_tool_executions FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM ai_sessions s WHERE s.id = ai_tool_executions.session_id AND public.breeze_has_org_access(s.org_id))
+);
+CREATE POLICY breeze_org_isolation_update ON ai_tool_executions FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM ai_sessions s WHERE s.id = ai_tool_executions.session_id AND public.breeze_has_org_access(s.org_id))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM ai_sessions s WHERE s.id = ai_tool_executions.session_id AND public.breeze_has_org_access(s.org_id))
+);
+CREATE POLICY breeze_org_isolation_delete ON ai_tool_executions FOR DELETE USING (
+  EXISTS (SELECT 1 FROM ai_sessions s WHERE s.id = ai_tool_executions.session_id AND public.breeze_has_org_access(s.org_id))
+);
+
+-- ---------------------------------------------------------------------------
+-- script_execution_batches  ->  scripts(script_id)  [system scripts world-readable]
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS breeze_org_isolation_select ON script_execution_batches;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON script_execution_batches;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON script_execution_batches;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON script_execution_batches;
+ALTER TABLE script_execution_batches ENABLE ROW LEVEL SECURITY;
+ALTER TABLE script_execution_batches FORCE ROW LEVEL SECURITY;
+CREATE POLICY breeze_org_isolation_select ON script_execution_batches FOR SELECT USING (
+  EXISTS (SELECT 1 FROM scripts s WHERE s.id = script_execution_batches.script_id AND (s.is_system = true OR public.breeze_has_org_access(s.org_id)))
+);
+CREATE POLICY breeze_org_isolation_insert ON script_execution_batches FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM scripts s WHERE s.id = script_execution_batches.script_id AND (s.is_system = true OR public.breeze_has_org_access(s.org_id)))
+);
+CREATE POLICY breeze_org_isolation_update ON script_execution_batches FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM scripts s WHERE s.id = script_execution_batches.script_id AND (s.is_system = true OR public.breeze_has_org_access(s.org_id)))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM scripts s WHERE s.id = script_execution_batches.script_id AND (s.is_system = true OR public.breeze_has_org_access(s.org_id)))
+);
+CREATE POLICY breeze_org_isolation_delete ON script_execution_batches FOR DELETE USING (
+  EXISTS (SELECT 1 FROM scripts s WHERE s.id = script_execution_batches.script_id AND (s.is_system = true OR public.breeze_has_org_access(s.org_id)))
+);
+
+-- ---------------------------------------------------------------------------
+-- software_versions  ->  software_catalog(catalog_id)
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS breeze_org_isolation_select ON software_versions;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON software_versions;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON software_versions;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON software_versions;
+ALTER TABLE software_versions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE software_versions FORCE ROW LEVEL SECURITY;
+CREATE POLICY breeze_org_isolation_select ON software_versions FOR SELECT USING (
+  EXISTS (SELECT 1 FROM software_catalog sc WHERE sc.id = software_versions.catalog_id AND public.breeze_has_org_access(sc.org_id))
+);
+CREATE POLICY breeze_org_isolation_insert ON software_versions FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM software_catalog sc WHERE sc.id = software_versions.catalog_id AND public.breeze_has_org_access(sc.org_id))
+);
+CREATE POLICY breeze_org_isolation_update ON software_versions FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM software_catalog sc WHERE sc.id = software_versions.catalog_id AND public.breeze_has_org_access(sc.org_id))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM software_catalog sc WHERE sc.id = software_versions.catalog_id AND public.breeze_has_org_access(sc.org_id))
+);
+CREATE POLICY breeze_org_isolation_delete ON software_versions FOR DELETE USING (
+  EXISTS (SELECT 1 FROM software_catalog sc WHERE sc.id = software_versions.catalog_id AND public.breeze_has_org_access(sc.org_id))
+);
+
+-- ---------------------------------------------------------------------------
+-- alert_correlations  ->  alerts(parent_alert_id)
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS breeze_org_isolation_select ON alert_correlations;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON alert_correlations;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON alert_correlations;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON alert_correlations;
+ALTER TABLE alert_correlations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE alert_correlations FORCE ROW LEVEL SECURITY;
+CREATE POLICY breeze_org_isolation_select ON alert_correlations FOR SELECT USING (
+  EXISTS (SELECT 1 FROM alerts al WHERE al.id = alert_correlations.parent_alert_id AND public.breeze_has_org_access(al.org_id))
+);
+CREATE POLICY breeze_org_isolation_insert ON alert_correlations FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM alerts al WHERE al.id = alert_correlations.parent_alert_id AND public.breeze_has_org_access(al.org_id))
+);
+CREATE POLICY breeze_org_isolation_update ON alert_correlations FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM alerts al WHERE al.id = alert_correlations.parent_alert_id AND public.breeze_has_org_access(al.org_id))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM alerts al WHERE al.id = alert_correlations.parent_alert_id AND public.breeze_has_org_access(al.org_id))
+);
+CREATE POLICY breeze_org_isolation_delete ON alert_correlations FOR DELETE USING (
+  EXISTS (SELECT 1 FROM alerts al WHERE al.id = alert_correlations.parent_alert_id AND public.breeze_has_org_access(al.org_id))
+);
+
+-- ---------------------------------------------------------------------------
+-- alert_notifications  ->  alerts(alert_id)
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS breeze_org_isolation_select ON alert_notifications;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON alert_notifications;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON alert_notifications;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON alert_notifications;
+ALTER TABLE alert_notifications ENABLE ROW LEVEL SECURITY;
+ALTER TABLE alert_notifications FORCE ROW LEVEL SECURITY;
+CREATE POLICY breeze_org_isolation_select ON alert_notifications FOR SELECT USING (
+  EXISTS (SELECT 1 FROM alerts al WHERE al.id = alert_notifications.alert_id AND public.breeze_has_org_access(al.org_id))
+);
+CREATE POLICY breeze_org_isolation_insert ON alert_notifications FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM alerts al WHERE al.id = alert_notifications.alert_id AND public.breeze_has_org_access(al.org_id))
+);
+CREATE POLICY breeze_org_isolation_update ON alert_notifications FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM alerts al WHERE al.id = alert_notifications.alert_id AND public.breeze_has_org_access(al.org_id))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM alerts al WHERE al.id = alert_notifications.alert_id AND public.breeze_has_org_access(al.org_id))
+);
+CREATE POLICY breeze_org_isolation_delete ON alert_notifications FOR DELETE USING (
+  EXISTS (SELECT 1 FROM alerts al WHERE al.id = alert_notifications.alert_id AND public.breeze_has_org_access(al.org_id))
+);

--- a/apps/api/src/__tests__/helpers/routeScan.ts
+++ b/apps/api/src/__tests__/helpers/routeScan.ts
@@ -64,6 +64,16 @@ const ROUTE_DEF_PATTERN = /\.(get|post|put|patch|delete)\(\s*['"`](\/[^'"`]*)['"
 // repo (`:deviceId`, `:deviceIds`, `:device_id`). Matched case-insensitively.
 const DEVICE_PARAM_IN_URL = /:device(?:Id|Ids|_id)\b/i;
 
+// Per-site handlers under a `/sites/:<param>` segment. These operate on a
+// single site row and MUST honor `permissions.allowedSiteIds` (the `sites`
+// RLS policy is org-axis only, so a site-confined user could otherwise
+// read/rename/hard-delete sibling sites — F1, broken access control). The
+// `:id` (or any) param after `/sites/` is intentionally generic so the
+// scanner doesn't depend on the exact param name. Kept deliberately narrow
+// (anchored to the `/sites/` segment) so we don't flag every unrelated
+// `:id` route across the codebase.
+const SITE_PARAM_IN_URL = /\/sites\/:\w+\b/i;
+
 /** Maximum bytes of source we inspect for each handler body. Per-route
  *  slices are additionally truncated at the next top-level route definition
  *  so a handler that drops its gate cannot be "rescued" by a sibling
@@ -168,11 +178,12 @@ export async function findRoutesTouchingDevices(): Promise<RouteInfo[]> {
       const cur = routeMatches[i];
       if (!cur) continue;
       // Only flag routes whose URL pattern names a device explicitly
-      // (`:deviceId` etc). Body-level references would catch list/filter
-      // routes too (which deserve site-scope checks but are too numerous
-      // to lock in via a single contract test); scope this test to
-      // per-device handlers — the audit's known offender class.
-      if (!DEVICE_PARAM_IN_URL.test(cur.urlPattern)) continue;
+      // (`:deviceId` etc) OR is a per-site handler under `/sites/:<param>`.
+      // Body-level references would catch list/filter routes too (which
+      // deserve site-scope checks but are too numerous to lock in via a
+      // single contract test); scope this test to per-device and per-site
+      // handlers — the audit's known offender classes.
+      if (!DEVICE_PARAM_IN_URL.test(cur.urlPattern) && !SITE_PARAM_IN_URL.test(cur.urlPattern)) continue;
 
       const nextStart = routeMatches[i + 1]?.index ?? text.length;
       const sliceEnd = Math.min(cur.index + HANDLER_SLICE_BYTES, nextStart);

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -1,9 +1,10 @@
 import { afterAll, describe, it, expect } from 'vitest';
 import { eq, sql } from 'drizzle-orm';
 import { db, withDbAccessContext, withSystemDbAccessContext } from '../../db';
-import { partners, users } from '../../db/schema';
+import { partners, users, organizations } from '../../db/schema';
 import { approvalRequests } from '../../db/schema/approvals';
 import { manifestSigningKeys } from '../../db/schema/manifestSigningKeys';
+import { automations, automationRuns } from '../../db/schema/automations';
 
 /**
  * Contract test: every tenant-scoped public table must have RLS enabled and
@@ -109,6 +110,30 @@ const DEVICE_ID_JOIN_POLICY_TABLES: ReadonlySet<string> = new Set<string>([
   'patch_job_results',
   'patch_rollbacks',
   'file_transfers',
+]);
+
+// Tables that reach their tenant through a PARENT FK (no device_id, no
+// denormalized org_id). Their RLS policies join through the named parent
+// table(s) to the org boundary. Each entry maps the child table to the
+// parent table name(s) its policy predicate must reference; the policy must
+// contain both `FROM <parent>` and `breeze_has_org_access` in the qual or
+// with_check (migration 2026-05-30-fk-child-tables-rls.sql).
+//
+// This is the generalization of the Phase 5 device-join shape: same EXISTS
+// structure, but the join target is the row's actual parent rather than
+// `devices`. A child table keyed by a parent FK is the single most common way
+// a tenant table escapes the org_id-column auto-discovery above and ships with
+// NO rls — keep this list authoritative so the contract test catches the next
+// one. automation_runs lists BOTH parents because config-policy-driven runs
+// leave automation_id NULL and reach their org via config_policy_id instead.
+const PARENT_FK_JOIN_POLICY_TABLES: ReadonlyMap<string, readonly string[]> = new Map<string, readonly string[]>([
+  ['automation_runs', ['automations', 'configuration_policies']],
+  ['ai_messages', ['ai_sessions']],
+  ['ai_tool_executions', ['ai_sessions']],
+  ['script_execution_batches', ['scripts']],
+  ['software_versions', ['software_catalog']],
+  ['alert_correlations', ['alerts']],
+  ['alert_notifications', ['alerts']],
 ]);
 
 // Tables scoped to the calling user via breeze_current_user_id().
@@ -257,6 +282,7 @@ describe('RLS coverage contract', () => {
       ...PARTNER_TENANT_TABLES.keys(),
       ...DUAL_AXIS_TENANT_TABLES,
       ...DEVICE_ID_JOIN_POLICY_TABLES,
+      ...PARENT_FK_JOIN_POLICY_TABLES.keys(),
       ...USER_ID_SCOPED_TABLES,
     ]));
 
@@ -644,6 +670,70 @@ describe('RLS coverage contract', () => {
     ).toEqual([]);
   });
 
+  it('every parent-FK join-policy table has RLS on and all four DML commands covered by a parent-join org-access policy', async () => {
+    const offenders: Array<{ table: string; rls_on: boolean; missing_cmds: string[] }> = [];
+
+    for (const [table, parents] of PARENT_FK_JOIN_POLICY_TABLES) {
+      // A covering policy must (a) reach the org via breeze_has_org_access and
+      // (b) actually join through one of the declared parent tables — so a
+      // policy that referenced breeze_has_org_access without the correct join
+      // (or vice versa) does NOT count. parents is a small fixed allowlist, so
+      // sql.raw interpolation here is safe (no user input).
+      const parentRef = parents
+        .map(
+          (p) =>
+            `(COALESCE(pp.qual, '') LIKE '%FROM ${p}%' OR COALESCE(pp.with_check, '') LIKE '%FROM ${p}%')`,
+        )
+        .join(' OR ');
+
+      const rows = (await db.execute(sql`
+        WITH t AS (
+          SELECT c.relname, c.relrowsecurity
+          FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE n.nspname = 'public' AND c.relkind = 'r' AND c.relname = ${table}
+        ),
+        covering_policies AS (
+          SELECT DISTINCT
+            CASE WHEN pp.cmd = 'ALL' THEN cmd_name ELSE pp.cmd END AS cmd
+          FROM pg_policies pp
+          CROSS JOIN UNNEST(ARRAY['SELECT','INSERT','UPDATE','DELETE']) AS cmd_name
+          WHERE pp.schemaname = 'public'
+            AND pp.tablename = ${table}
+            AND pp.permissive = 'PERMISSIVE'
+            AND (
+              COALESCE(pp.qual, '') LIKE '%breeze_has_org_access%'
+              OR COALESCE(pp.with_check, '') LIKE '%breeze_has_org_access%'
+            )
+            AND (${sql.raw(parentRef)})
+            AND (pp.cmd = 'ALL' OR pp.cmd = cmd_name)
+        )
+        SELECT
+          t.relname AS table_name,
+          t.relrowsecurity AS rls_on,
+          ARRAY(SELECT cmd FROM covering_policies ORDER BY cmd) AS covered_cmds
+        FROM t;
+      `)) as unknown as TableRow[];
+
+      const row = rows[0];
+      const covered = new Set<string>(row?.covered_cmds ?? []);
+      const missing = REQUIRED_CMDS.filter((cmd) => !covered.has(cmd));
+      if (!row || !row.rls_on || missing.length > 0) {
+        offenders.push({ table, rls_on: Boolean(row?.rls_on), missing_cmds: missing });
+      }
+    }
+
+    expect(
+      offenders,
+      `Parent-FK join-policy tables missing RLS coverage:\n${JSON.stringify(offenders, null, 2)}\n\n` +
+        `Fix: add an idempotent migration that runs ENABLE + FORCE ROW LEVEL SECURITY and installs ` +
+        `SELECT/INSERT/UPDATE/DELETE policies whose predicate joins through the table's parent and calls ` +
+        `breeze_has_org_access(parent.org_id), e.g.: ` +
+        `EXISTS (SELECT 1 FROM automations a WHERE a.id = automation_runs.automation_id AND breeze_has_org_access(a.org_id)). ` +
+        `See 2026-05-30-fk-child-tables-rls.sql for the canonical shape and the PARENT_FK_JOIN_POLICY_TABLES allowlist.`
+    ).toEqual([]);
+  });
+
   it('every Phase 6 user-id-scoped table has RLS on and all four DML commands covered by a breeze_current_user_id policy', async () => {
     const userTables = Array.from(USER_ID_SCOPED_TABLES);
 
@@ -1028,6 +1118,164 @@ describe('manifest_signing_keys RLS — system-only enforcement (#639)', () => {
       expect(result).toHaveLength(1);
       expect(result[0]!.keyId).toBe(keyId);
       insertedKeyIds.push(keyId);
+    },
+  );
+});
+
+// ===========================================================================
+// automation_runs — parent-FK join-policy forge test (Shape 7, findings F2/F3)
+//
+// The pg_catalog assertion above only proves a parent-join policy exists per
+// DML command. It does NOT prove Postgres actually hides another tenant's run.
+// automation_runs WAS the F2/F3 finding: no org_id, no RLS, and the
+// config-policy branch of GET /automations/runs/:runId returned the row with
+// no org check. This block forges cross-org reads/writes as `breeze_app` (the
+// unprivileged role) under real tenant contexts and asserts the new
+// EXISTS-join policy is enforced in practice — the durable backstop behind the
+// app-layer canAccessOrg fix in routes/automations.ts. Self-contained so it
+// runs under vitest.config.rls-coverage.ts (no setup.ts / no TRUNCATE):
+// fixtures are seeded via withSystemDbAccessContext and torn down by id.
+// ===========================================================================
+describe('automation_runs RLS — cross-org forge enforcement (Shape 7)', () => {
+  const runSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  let partnerId: string;
+  let orgAId: string;
+  let orgBId: string;
+  let automationAId: string;
+  let runAId: string | null = null;
+
+  // Org-scoped context granting access to exactly one org and nothing else,
+  // so no other policy can accidentally green-light a cross-org row.
+  function orgContext(orgId: string) {
+    return {
+      scope: 'organization' as const,
+      orgId,
+      accessibleOrgIds: [orgId],
+      accessiblePartnerIds: [],
+      userId: null,
+    };
+  }
+
+  async function ensureFixtures(): Promise<void> {
+    if (partnerId) return;
+    await withSystemDbAccessContext(async () => {
+      const [partner] = await db
+        .insert(partners)
+        .values({
+          name: `RLS AutoRuns Partner ${runSuffix}`,
+          slug: `rls-autoruns-${runSuffix}`,
+          type: 'msp',
+          plan: 'pro',
+          status: 'active',
+        })
+        .returning({ id: partners.id });
+      if (!partner) throw new Error('failed to seed partner for automation_runs forge');
+      partnerId = partner.id;
+
+      const [orgA, orgB] = await db
+        .insert(organizations)
+        .values([
+          { partnerId: partner.id, name: 'RLS AutoRuns Org A', slug: `rls-autoruns-a-${runSuffix}` },
+          { partnerId: partner.id, name: 'RLS AutoRuns Org B', slug: `rls-autoruns-b-${runSuffix}` },
+        ])
+        .returning({ id: organizations.id });
+      if (!orgA || !orgB) throw new Error('failed to seed orgs for automation_runs forge');
+      orgAId = orgA.id;
+      orgBId = orgB.id;
+
+      const [automationA] = await db
+        .insert(automations)
+        .values({
+          orgId: orgA.id,
+          name: 'Org A automation',
+          trigger: { type: 'manual' },
+          actions: [],
+        })
+        .returning({ id: automations.id });
+      if (!automationA) throw new Error('failed to seed automation for automation_runs forge');
+      automationAId = automationA.id;
+
+      const [runA] = await db
+        .insert(automationRuns)
+        .values({
+          automationId: automationA.id,
+          triggeredBy: 'rls-forge-test',
+          status: 'completed',
+        })
+        .returning({ id: automationRuns.id });
+      if (!runA) throw new Error('failed to seed automation_run for forge');
+      runAId = runA.id;
+    });
+  }
+
+  afterAll(async () => {
+    await withSystemDbAccessContext(async () => {
+      // Delete runs by automation_id (not just the seeded runAId) so a stray
+      // run from a forged INSERT — which exists only when RLS is NOT yet
+      // enforcing, i.e. a failing pre-migration run — can't block the parent
+      // automation delete via FK.
+      if (automationAId) {
+        await db.delete(automationRuns).where(eq(automationRuns.automationId, automationAId));
+      }
+      if (automationAId) await db.delete(automations).where(eq(automations.id, automationAId));
+      if (orgAId) await db.delete(organizations).where(eq(organizations.id, orgAId));
+      if (orgBId) await db.delete(organizations).where(eq(organizations.id, orgBId));
+      if (partnerId) await db.delete(partners).where(eq(partners.id, partnerId));
+    });
+  });
+
+  it.runIf(!!process.env.DATABASE_URL)(
+    'org A (owner) can SELECT its own automation_run via the parent-join policy',
+    async () => {
+      await ensureFixtures();
+      const rows = await withDbAccessContext(orgContext(orgAId), async () =>
+        db
+          .select({ id: automationRuns.id })
+          .from(automationRuns)
+          .where(eq(automationRuns.id, runAId!)),
+      );
+      expect(rows.map((r) => r.id)).toEqual([runAId]);
+    },
+  );
+
+  it.runIf(!!process.env.DATABASE_URL)(
+    "org B cannot SELECT org A's automation_run (RLS hides it — the F2/F3 leak)",
+    async () => {
+      await ensureFixtures();
+      if (!runAId) throw new Error('seed test must run first');
+      const rows = await withDbAccessContext(orgContext(orgBId), async () =>
+        db
+          .select({ id: automationRuns.id })
+          .from(automationRuns)
+          .where(eq(automationRuns.id, runAId!)),
+      );
+      expect(rows).toEqual([]);
+    },
+  );
+
+  it.runIf(!!process.env.DATABASE_URL)(
+    "org B INSERT referencing org A's automation is rejected by WITH CHECK",
+    async () => {
+      await ensureFixtures();
+      let caught: unknown;
+      try {
+        await withDbAccessContext(orgContext(orgBId), async () =>
+          db.insert(automationRuns).values({
+            automationId: automationAId, // forging a run under another tenant's automation
+            triggeredBy: 'rls-forge-test-crossorg',
+            status: 'running',
+          }),
+        );
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeDefined();
+      const cause = caught as { cause?: { message?: string }; message?: string } | undefined;
+      const message = cause?.cause?.message ?? cause?.message ?? '';
+      expect(message).toMatch(
+        /new row violates row-level security policy for table "automation_runs"/,
+      );
     },
   );
 });

--- a/apps/api/src/routes/automations.test.ts
+++ b/apps/api/src/routes/automations.test.ts
@@ -67,11 +67,18 @@ vi.mock('../db', () => ({
 vi.mock('../db/schema', () => ({
   automations: {},
   automationRuns: {},
+  configurationPolicies: {},
   policies: {},
   policyCompliance: {},
   organizations: {},
   devices: {},
   scripts: {}
+}));
+
+vi.mock('../services/auditEvents', () => ({
+  ANONYMOUS_ACTOR_ID: '00000000-0000-0000-0000-000000000000',
+  writeRouteAudit: vi.fn(),
+  writeAuditEvent: vi.fn(),
 }));
 
 vi.mock('../middleware/auth', () => ({
@@ -94,6 +101,7 @@ vi.mock('../middleware/auth', () => ({
 
 import { db } from '../db';
 import { getRedis } from '../services/redis';
+import { writeAuditEvent } from '../services/auditEvents';
 
 describe('automations routes', () => {
   let app: Hono;
@@ -753,5 +761,138 @@ describe('automations routes', () => {
     });
 
     expect(res.status).toBe(401);
+  });
+
+  // ============================================
+  // F3 (IDOR): config-policy run cross-tenant access
+  // ============================================
+
+  it('returns 404 for a config-policy run whose org the caller cannot access', async () => {
+    // First select: the run (automationId null, configPolicyId set).
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: 'run-cp-1',
+              automationId: null,
+              configPolicyId: 'policy-1',
+              configItemName: 'Patch Policy',
+              status: 'running',
+              logs: [],
+            }])
+          })
+        })
+      } as any)
+      // Second select: the config policy resolving to org-OTHER (not accessible).
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ orgId: 'org-OTHER' }])
+          })
+        })
+      } as any);
+
+    const res = await app.request('/automations/runs/run-cp-1', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer valid-token' }
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe('Automation run not found');
+    // Must not leak any of the config-policy run details.
+    expect(JSON.stringify(body)).not.toContain('policy-1');
+    expect(JSON.stringify(body)).not.toContain('Patch Policy');
+  });
+
+  it('returns 200 for a config-policy run whose org the caller can access', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: 'run-cp-1',
+              automationId: null,
+              configPolicyId: 'policy-1',
+              configItemName: 'Patch Policy',
+              status: 'running',
+              logs: [],
+            }])
+          })
+        })
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ orgId: 'org-123' }])
+          })
+        })
+      } as any);
+
+    const res = await app.request('/automations/runs/run-cp-1', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer valid-token' }
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe('run-cp-1');
+    expect(body.configPolicyId).toBe('policy-1');
+    expect(body.configItemName).toBe('Patch Policy');
+    expect(body.automation).toBeNull();
+  });
+
+  // ============================================
+  // F8 (audit): webhook-triggered run must be audited
+  // ============================================
+
+  it('writes an audit event when a signed webhook creates a run', async () => {
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{
+            id: 'auto-1',
+            name: 'Webhook Automation',
+            orgId: 'org-123',
+            enabled: true,
+            trigger: { type: 'webhook', secret: 'secret-123' },
+            actions: [{ type: 'execute_command', command: 'echo ok' }]
+          }])
+        })
+      })
+    } as any);
+    const rawBody = JSON.stringify({ ping: true });
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const signature = `sha256=${createHmac('sha256', 'secret-123').update(`${timestamp}.${rawBody}`).digest('hex')}`;
+
+    const res = await app.request('/automations/webhooks/auto-1', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-breeze-timestamp': timestamp,
+        'x-breeze-signature': signature,
+        'x-breeze-event-id': 'event-audit-1',
+      },
+      body: rawBody
+    });
+
+    expect(res.status).toBe(202);
+    expect(writeAuditEvent).toHaveBeenCalledTimes(1);
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        orgId: 'org-123',
+        action: 'automation.trigger.webhook',
+        resourceType: 'automation',
+        resourceId: 'auto-1',
+        resourceName: 'Webhook Automation',
+        actorType: 'system',
+        details: expect.objectContaining({
+          runId: 'run-1',
+          devicesTargeted: 2,
+        }),
+      }),
+    );
   });
 });

--- a/apps/api/src/routes/automations.ts
+++ b/apps/api/src/routes/automations.ts
@@ -7,9 +7,10 @@ import { db } from '../db';
 import {
   automations,
   automationRuns,
+  configurationPolicies,
 } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
-import { writeRouteAudit } from '../services/auditEvents';
+import { writeAuditEvent, writeRouteAudit } from '../services/auditEvents';
 import { getTrustedClientIp } from '../services/clientIp';
 import { PERMISSIONS } from '../services/permissions';
 import { getRedis } from '../services/redis';
@@ -459,8 +460,24 @@ automationRoutes.get(
       return c.json({ error: 'Automation run not found' }, 404);
     }
 
-    // For config policy runs (automationId is null), return a lightweight response
+    // For config policy runs (automationId is null), return a lightweight response.
+    // These runs have no automation row to org-check against, so resolve the
+    // owning org via the config policy and enforce tenant access the same way
+    // getAutomationWithOrgCheck does. 404 (not 403) on cross-tenant to avoid an
+    // existence oracle, matching the automation-backed branch below.
     if (!run.automationId) {
+      if (!run.configPolicyId) {
+        return c.json({ error: 'Automation run not found' }, 404);
+      }
+      const [policy] = await db
+        .select({ orgId: configurationPolicies.orgId })
+        .from(configurationPolicies)
+        .where(eq(configurationPolicies.id, run.configPolicyId))
+        .limit(1);
+      if (!policy || !ensureOrgAccess(policy.orgId, auth)) {
+        return c.json({ error: 'Automation run not found' }, 404);
+      }
+
       return c.json({
         ...run,
         status: toRunStatus(run.status),
@@ -1049,6 +1066,23 @@ automationWebhookRoutes.post('/:id', async (c) => {
   });
 
   await enqueueAutomationRun(run.id, targetDeviceIds);
+
+  // Webhook callers are anonymous (no auth user / no JWT), so writeRouteAudit's
+  // auth-derived actor doesn't apply. Use writeAuditEvent directly with a
+  // system actor: it records a non-user actor without touching auth context.
+  writeAuditEvent(c, {
+    orgId: automation.orgId,
+    action: 'automation.trigger.webhook',
+    resourceType: 'automation',
+    resourceId: automation.id,
+    resourceName: automation.name,
+    actorType: 'system',
+    details: {
+      runId: run.id,
+      devicesTargeted: targetDeviceIds.length,
+      triggeredBy: 'webhook',
+    },
+  });
 
   return c.json({
     accepted: true,

--- a/apps/api/src/routes/externalServices.test.ts
+++ b/apps/api/src/routes/externalServices.test.ts
@@ -82,6 +82,7 @@ const defaultAllowed = () => ({
 describe('externalServicesRoutes', () => {
   const originalEnv = {
     BREEZE_BILLING_URL: process.env.BREEZE_BILLING_URL,
+    BREEZE_BILLING_API_KEY: process.env.BREEZE_BILLING_API_KEY,
     DASHBOARD_URL: process.env.DASHBOARD_URL,
     PUBLIC_APP_URL: process.env.PUBLIC_APP_URL,
     CORS_ALLOWED_ORIGINS: process.env.CORS_ALLOWED_ORIGINS,
@@ -95,6 +96,7 @@ describe('externalServicesRoutes', () => {
     process.env.DASHBOARD_URL = 'https://app.example.com';
     delete process.env.PUBLIC_APP_URL;
     delete process.env.CORS_ALLOWED_ORIGINS;
+    delete process.env.BREEZE_BILLING_API_KEY;
     authGates.permissionDenied = false;
     authGates.mfaDenied = false;
     authState.value = {
@@ -120,6 +122,11 @@ describe('externalServicesRoutes', () => {
     expect(init).toBeDefined();
     expect(typeof init?.body).toBe('string');
     return JSON.parse(init!.body as string);
+  };
+  const fetchHeaders = (callIndex = 0): Record<string, string> => {
+    const init = fetchMock.mock.calls[callIndex]?.[1] as RequestInit | undefined;
+    expect(init).toBeDefined();
+    return (init?.headers ?? {}) as Record<string, string>;
   };
 
   describe('POST /billing/portal', () => {
@@ -375,6 +382,58 @@ describe('externalServicesRoutes', () => {
       });
       expect(res.status).toBe(429);
       expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('breeze-billing S2S auth header (F4)', () => {
+    it('attaches Authorization: Bearer <BREEZE_BILLING_API_KEY> on /portal-sessions', async () => {
+      process.env.BREEZE_BILLING_URL = 'http://billing';
+      process.env.BREEZE_BILLING_API_KEY = 's2s-secret-token';
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ url: 'https://stripe/x' }), { status: 200 })
+      );
+      const res = await app().request('/billing/portal', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ returnUrl: 'https://app.example.com/back' }),
+      });
+      expect(res.status).toBe(200);
+      const headers = fetchHeaders();
+      expect(headers['Authorization']).toBe('Bearer s2s-secret-token');
+    });
+
+    it('attaches Authorization: Bearer <BREEZE_BILLING_API_KEY> on /support', async () => {
+      process.env.BREEZE_BILLING_URL = 'http://billing';
+      process.env.BREEZE_BILLING_API_KEY = 's2s-secret-token';
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), { status: 200 })
+      );
+      const res = await app().request('/support', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ subject: 'hi', message: 'help' }),
+      });
+      expect(res.status).toBe(200);
+      const headers = fetchHeaders();
+      expect(headers['Authorization']).toBe('Bearer s2s-secret-token');
+    });
+
+    it('does NOT attach an Authorization header when BREEZE_BILLING_API_KEY is unset', async () => {
+      process.env.BREEZE_BILLING_URL = 'http://billing';
+      delete process.env.BREEZE_BILLING_API_KEY;
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ url: 'https://stripe/x' }), { status: 200 })
+      );
+      const res = await app().request('/billing/portal', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ returnUrl: 'https://app.example.com/back' }),
+      });
+      expect(res.status).toBe(200);
+      const headers = fetchHeaders();
+      expect(headers['Authorization']).toBeUndefined();
+      // Guard against the `Bearer undefined` footgun.
+      expect(JSON.stringify(headers)).not.toContain('Bearer undefined');
     });
   });
 });

--- a/apps/api/src/routes/externalServices.ts
+++ b/apps/api/src/routes/externalServices.ts
@@ -38,10 +38,18 @@ async function forward(path: string, body: unknown) {
     body && typeof body === 'object' && 'partner_id' in body
       ? (body as { partner_id?: unknown }).partner_id
       : undefined;
+  // Service-to-service auth to breeze-billing. The boot validator
+  // (config/validate.ts) requires BREEZE_BILLING_API_KEY whenever
+  // BREEZE_BILLING_URL is set, so in production the key is guaranteed present.
+  // Only attach the header when the key exists to avoid sending
+  // `Bearer undefined` from dev/test deployments without billing configured.
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  const billingKey = process.env.BREEZE_BILLING_API_KEY;
+  if (billingKey) headers['Authorization'] = `Bearer ${billingKey}`;
   try {
     const res = await fetch(`${baseUrl}${path}`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers,
       body: JSON.stringify(body),
     });
     const text = await res.text();

--- a/apps/api/src/routes/groups.test.ts
+++ b/apps/api/src/routes/groups.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import { groupRoutes } from './groups';
+
+vi.mock('../services', () => ({}));
+
+vi.mock('../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn(),
+  writeAuditEvent: vi.fn()
+}));
+
+vi.mock('../services/filterEngine', () => ({
+  evaluateFilterWithPreview: vi.fn(),
+  extractFieldsFromFilter: vi.fn(() => []),
+  validateFilter: vi.fn(() => ({ valid: true }))
+}));
+
+vi.mock('../services/groupMembership', () => ({
+  evaluateGroupMembership: vi.fn(),
+  pinDeviceToGroup: vi.fn()
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve([]))
+        }))
+      }))
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => Promise.resolve())
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(() => Promise.resolve([]))
+        }))
+      }))
+    })),
+    delete: vi.fn(() => ({
+      where: vi.fn(() => Promise.resolve())
+    }))
+  }
+}));
+
+vi.mock('../db/schema', () => ({
+  deviceGroups: {},
+  deviceGroupMemberships: {},
+  devices: { id: 'devices.id', siteId: 'devices.siteId' },
+  groupMembershipLog: {},
+  sites: {}
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => next()),
+  requireScope: vi.fn((...scopes: string[]) => (c: any, next: any) => {
+    const auth = c.get('auth');
+    if (!scopes.includes(auth?.scope)) {
+      return c.json({ error: 'Forbidden' }, 403);
+    }
+    return next();
+  }),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next())
+}));
+
+import { db } from '../db';
+import { authMiddleware } from '../middleware/auth';
+
+const GROUP_ID = '00000000-0000-0000-0000-0000000000a1';
+const DEVICE_IN_SITE_X = '00000000-0000-0000-0000-0000000000d1';
+const DEVICE_IN_SITE_Y = '00000000-0000-0000-0000-0000000000d2';
+const ORG = '11111111-1111-1111-1111-111111111111';
+
+describe('group routes', () => {
+  let app: Hono;
+
+  // The bulk-add path queries the DB in this order:
+  //   1. getGroupWithAccess -> select deviceGroups (.limit)
+  //   2. select device {id, orgId} by inArray (terminal promise on .where)
+  //   3. (per device) canAccessDeviceSite -> select devices.siteId (.limit)
+  //   4. select existing memberships (terminal promise on .where)
+  //   5. getDeviceCountForGroup -> select count (terminal promise on .where)
+  // We drive these by chaining db.select mock return values in order.
+  const mockGroupSelect = () =>
+    ({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([
+            { id: GROUP_ID, orgId: ORG, name: 'Static Group', type: 'static' }
+          ])
+        })
+      })
+    } as any);
+
+  // Returns a select whose terminal `.where` resolves to the given rows
+  // (used for the device-by-inArray lookup and existing-memberships lookup).
+  const mockWhereResolves = (rows: unknown[]) =>
+    ({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(rows)
+      })
+    } as any);
+
+  // canAccessDeviceSite's per-device select: from().where().limit() -> [{ siteId }]
+  const mockSiteSelect = (siteId: string | null) =>
+    ({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue(siteId === null ? [] : [{ siteId }])
+        })
+      })
+    } as any);
+
+  const setAuth = (allowedSiteIds: string[] | undefined) => {
+    vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+      c.set('auth', {
+        user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+        token: {},
+        partnerId: 'partner-123',
+        orgId: ORG,
+        scope: 'partner',
+        accessibleOrgIds: [ORG],
+        orgCondition: () => undefined,
+        canAccessOrg: () => true
+      } as any);
+      c.set('permissions', {
+        scope: 'partner',
+        allowedSiteIds
+      } as any);
+      return next();
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/groups', groupRoutes);
+  });
+
+  describe('POST /groups/:id/devices (bulk-add) site-scope confinement', () => {
+    it('rejects (403) when a confined user adds a device whose site (site-y) is out of scope', async () => {
+      setAuth(['site-x']);
+      const insertSpy = vi.mocked(db.insert);
+      vi.mocked(db.select)
+        // 1. group lookup
+        .mockReturnValueOnce(mockGroupSelect())
+        // 2. device {id, orgId} lookup — device belongs to the right org
+        .mockReturnValueOnce(mockWhereResolves([{ id: DEVICE_IN_SITE_Y, orgId: ORG }]))
+        // 3. canAccessDeviceSite per-device lookup — site-y, NOT allowed
+        .mockReturnValueOnce(mockSiteSelect('site-y'));
+
+      const res = await app.request(`/groups/${GROUP_ID}/devices`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deviceIds: [DEVICE_IN_SITE_Y] })
+      });
+
+      expect(res.status).toBe(403);
+      // Fail closed — nothing inserted.
+      expect(insertSpy).not.toHaveBeenCalled();
+    });
+
+    it('allows a confined user to add a device whose site (site-x) is in scope', async () => {
+      setAuth(['site-x']);
+      vi.mocked(db.select)
+        // 1. group lookup
+        .mockReturnValueOnce(mockGroupSelect())
+        // 2. device lookup
+        .mockReturnValueOnce(mockWhereResolves([{ id: DEVICE_IN_SITE_X, orgId: ORG }]))
+        // 3. canAccessDeviceSite per-device lookup — site-x, allowed
+        .mockReturnValueOnce(mockSiteSelect('site-x'))
+        // 4. existing memberships lookup — none
+        .mockReturnValueOnce(mockWhereResolves([]))
+        // 5. getDeviceCountForGroup
+        .mockReturnValueOnce(mockWhereResolves([{ count: 1 }]));
+
+      const res = await app.request(`/groups/${GROUP_ID}/devices`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deviceIds: [DEVICE_IN_SITE_X] })
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.data.added).toBe(1);
+    });
+
+    it('fails closed (403) for a confined user when a device has no site', async () => {
+      setAuth(['site-x']);
+      const insertSpy = vi.mocked(db.insert);
+      vi.mocked(db.select)
+        .mockReturnValueOnce(mockGroupSelect())
+        .mockReturnValueOnce(mockWhereResolves([{ id: DEVICE_IN_SITE_Y, orgId: ORG }]))
+        // canAccessDeviceSite: device row missing siteId -> []
+        .mockReturnValueOnce(mockSiteSelect(null));
+
+      const res = await app.request(`/groups/${GROUP_ID}/devices`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deviceIds: [DEVICE_IN_SITE_Y] })
+      });
+
+      expect(res.status).toBe(403);
+      expect(insertSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not site-gate an unconfined user (allowedSiteIds undefined)', async () => {
+      setAuth(undefined);
+      vi.mocked(db.select)
+        // 1. group lookup
+        .mockReturnValueOnce(mockGroupSelect())
+        // 2. device lookup (device in any site)
+        .mockReturnValueOnce(mockWhereResolves([{ id: DEVICE_IN_SITE_Y, orgId: ORG }]))
+        // canAccessDeviceSite short-circuits (no allowedSiteIds) -> no site select.
+        // 3. existing memberships lookup
+        .mockReturnValueOnce(mockWhereResolves([]))
+        // 4. getDeviceCountForGroup
+        .mockReturnValueOnce(mockWhereResolves([{ count: 1 }]));
+
+      const res = await app.request(`/groups/${GROUP_ID}/devices`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deviceIds: [DEVICE_IN_SITE_Y] })
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.data.added).toBe(1);
+    });
+  });
+});

--- a/apps/api/src/routes/groups.ts
+++ b/apps/api/src/routes/groups.ts
@@ -665,6 +665,17 @@ groupRoutes.post(
       }, 400);
     }
 
+    // Site-scope gate: a partner-scope user confined via allowedSiteIds must
+    // not bulk-add a device from a site they cannot access, even though the
+    // device shares the group's org (RLS is org-axis only here). Fail closed —
+    // reject the entire batch if any device's site is out of scope. Mirrors the
+    // single-device delete/pin handlers in this file.
+    for (const deviceId of payload.deviceIds) {
+      if (!(await canAccessDeviceSite(c, deviceId))) {
+        return c.json({ error: 'Access to this site denied' }, 403);
+      }
+    }
+
     // Get existing memberships to avoid duplicates
     const existingMemberships = await db
       .select({ deviceId: deviceGroupMemberships.deviceId })

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -104,6 +104,10 @@ describe('org routes', () => {
     scope: 'system' | 'partner' | 'organization';
     accessibleOrgIds: string[] | null;
     canAccessOrg: (orgId: string) => boolean;
+    // Per-user site confinement. When provided (even as []), it is exposed via
+    // c.get('permissions').allowedSiteIds, mirroring the production permissions
+    // middleware. Omit for an unconfined user (allowedSiteIds undefined).
+    allowedSiteIds: string[];
   }> = {}) => {
     const scope = overrides.scope ?? 'system';
     const accessibleOrgIds = 'accessibleOrgIds' in overrides
@@ -125,6 +129,10 @@ describe('org routes', () => {
           if (!Array.isArray(accessibleOrgIds)) return true;
           return accessibleOrgIds.includes(orgId);
         })
+      } as any);
+      c.set('permissions', {
+        scope,
+        allowedSiteIds: 'allowedSiteIds' in overrides ? overrides.allowedSiteIds : undefined
       } as any);
       return next();
     });
@@ -1021,6 +1029,228 @@ describe('org routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.success).toBe(true);
+    });
+  });
+
+  // Per-user site confinement (allowedSiteIds). A site-confined org user must
+  // not be able to read, rename, or delete sibling sites in the same org, nor
+  // enumerate them. The org-axis ensureOrgAccess check passes for all sites in
+  // the user's org, so the site-axis check is the only defense (RLS is
+  // org-axis only for `sites`). F1 — broken access control, intra-org.
+  describe('site-scope confinement (allowedSiteIds)', () => {
+    const ORG = '11111111-1111-1111-1111-111111111111';
+    // site-y belongs to the same org as the user but is NOT in allowedSiteIds.
+    const siblingSiteRow = (id: string) => ({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ id, name: 'Sibling', orgId: ORG }])
+        })
+      })
+    });
+
+    describe('GET /orgs/sites/:id', () => {
+      it('denies a site-confined user reading a sibling site (site-y) with 403', async () => {
+        setAuthContext({ scope: 'organization', orgId: ORG, allowedSiteIds: ['site-x'] });
+        vi.mocked(db.select).mockReturnValue(siblingSiteRow('site-y') as any);
+
+        const res = await app.request('/orgs/sites/site-y');
+
+        expect(res.status).toBe(403);
+      });
+
+      it('allows a site-confined user reading their own site (site-x)', async () => {
+        setAuthContext({ scope: 'organization', orgId: ORG, allowedSiteIds: ['site-x'] });
+        vi.mocked(db.select).mockReturnValue(siblingSiteRow('site-x') as any);
+
+        const res = await app.request('/orgs/sites/site-x');
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.id).toBe('site-x');
+      });
+
+      it('allows an unconfined user (allowedSiteIds undefined) to read any sibling site', async () => {
+        setAuthContext({ scope: 'organization', orgId: ORG });
+        vi.mocked(db.select).mockReturnValue(siblingSiteRow('site-y') as any);
+
+        const res = await app.request('/orgs/sites/site-y');
+
+        expect(res.status).toBe(200);
+      });
+    });
+
+    describe('PATCH /orgs/sites/:id', () => {
+      it('denies a site-confined user renaming a sibling site (site-y) with 403', async () => {
+        setAuthContext({ scope: 'organization', orgId: ORG, allowedSiteIds: ['site-x'] });
+        vi.mocked(db.select).mockReturnValue(siblingSiteRow('site-y') as any);
+        const updateSpy = vi.mocked(db.update).mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: 'site-y', name: 'Pwned' }])
+            })
+          })
+        } as any);
+
+        const res = await app.request('/orgs/sites/site-y', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'Pwned' })
+        });
+
+        expect(res.status).toBe(403);
+        expect(updateSpy).not.toHaveBeenCalled();
+      });
+
+      it('allows a site-confined user renaming their own site (site-x)', async () => {
+        setAuthContext({ scope: 'organization', orgId: ORG, allowedSiteIds: ['site-x'] });
+        vi.mocked(db.select).mockReturnValue(siblingSiteRow('site-x') as any);
+        vi.mocked(db.update).mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: 'site-x', name: 'Renamed' }])
+            })
+          })
+        } as any);
+
+        const res = await app.request('/orgs/sites/site-x', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'Renamed' })
+        });
+
+        expect(res.status).toBe(200);
+      });
+
+      it('allows an unconfined user to rename any sibling site', async () => {
+        setAuthContext({ scope: 'organization', orgId: ORG });
+        vi.mocked(db.select).mockReturnValue(siblingSiteRow('site-y') as any);
+        vi.mocked(db.update).mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: 'site-y', name: 'Renamed' }])
+            })
+          })
+        } as any);
+
+        const res = await app.request('/orgs/sites/site-y', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'Renamed' })
+        });
+
+        expect(res.status).toBe(200);
+      });
+    });
+
+    describe('DELETE /orgs/sites/:id', () => {
+      it('denies a site-confined user hard-deleting a sibling site (site-y) with 403', async () => {
+        setAuthContext({ scope: 'organization', orgId: ORG, allowedSiteIds: ['site-x'] });
+        vi.mocked(db.select).mockReturnValue(siblingSiteRow('site-y') as any);
+        const deleteSpy = vi.mocked(db.delete).mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined)
+        } as any);
+
+        const res = await app.request('/orgs/sites/site-y', { method: 'DELETE' });
+
+        expect(res.status).toBe(403);
+        expect(deleteSpy).not.toHaveBeenCalled();
+      });
+
+      it('allows a site-confined user deleting their own site (site-x)', async () => {
+        setAuthContext({ scope: 'organization', orgId: ORG, allowedSiteIds: ['site-x'] });
+        vi.mocked(db.select).mockReturnValue(siblingSiteRow('site-x') as any);
+        vi.mocked(db.delete).mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined)
+        } as any);
+
+        const res = await app.request('/orgs/sites/site-x', { method: 'DELETE' });
+
+        expect(res.status).toBe(200);
+      });
+
+      it('allows an unconfined user to delete any sibling site', async () => {
+        setAuthContext({ scope: 'organization', orgId: ORG });
+        vi.mocked(db.select).mockReturnValue(siblingSiteRow('site-y') as any);
+        vi.mocked(db.delete).mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined)
+        } as any);
+
+        const res = await app.request('/orgs/sites/site-y', { method: 'DELETE' });
+
+        expect(res.status).toBe(200);
+      });
+    });
+
+    describe('GET /orgs/sites (list)', () => {
+      it('returns an empty page without querying when allowedSiteIds is empty', async () => {
+        setAuthContext({ scope: 'organization', orgId: ORG, allowedSiteIds: [] });
+
+        const res = await app.request(`/orgs/sites?orgId=${ORG}`);
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.data).toEqual([]);
+        expect(body.pagination.total).toBe(0);
+        expect(db.select).not.toHaveBeenCalled();
+      });
+
+      it('restricts the list to allowed sites for a confined user (only site-x)', async () => {
+        setAuthContext({ scope: 'organization', orgId: ORG, allowedSiteIds: ['site-x'] });
+        // The handler must intersect the org filter with inArray(sites.id,
+        // allowedSiteIds); the mocked DB echoes back only what an
+        // allowlist-filtered query would: site-x, never site-y.
+        vi.mocked(db.select)
+          .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockResolvedValue([{ count: 1 }])
+            })
+          } as any)
+          .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  offset: vi.fn().mockReturnValue({
+                    orderBy: vi.fn().mockResolvedValue([{ id: 'site-x' }])
+                  })
+                })
+              })
+            })
+          } as any);
+
+        const res = await app.request(`/orgs/sites?orgId=${ORG}`);
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.data).toEqual([{ id: 'site-x' }]);
+        expect(body.data).not.toContainEqual({ id: 'site-y' });
+      });
+
+      it('does not restrict the list for an unconfined user (allowedSiteIds undefined)', async () => {
+        setAuthContext({ scope: 'organization', orgId: ORG });
+        vi.mocked(db.select)
+          .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockResolvedValue([{ count: 2 }])
+            })
+          } as any)
+          .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  offset: vi.fn().mockReturnValue({
+                    orderBy: vi.fn().mockResolvedValue([{ id: 'site-x' }, { id: 'site-y' }])
+                  })
+                })
+              })
+            })
+          } as any);
+
+        const res = await app.request(`/orgs/sites?orgId=${ORG}`);
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.data).toHaveLength(2);
+      });
     });
   });
 

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -8,7 +8,7 @@ import { authMiddleware, requireMfa, requirePermission, requireScope, requirePar
 import { writeAuditEvent, writeRouteAudit } from '../services/auditEvents';
 import { getEffectiveOrgSettings, assertNotLocked } from '../services/effectiveSettings';
 import { clearPartnerScopePolicyCache } from '../oauth/partnerScopePolicy';
-import { PERMISSIONS } from '../services/permissions';
+import { PERMISSIONS, canAccessSite, type UserPermissions } from '../services/permissions';
 import { revokeOrganizationTenantAccess, revokePartnerTenantAccess } from '../services/tenantLifecycle';
 import { applyOrganizationOrder, sanitizeOrganizationOrder } from '../services/orgOrdering';
 import { captureException } from '../services/sentry';
@@ -970,7 +970,20 @@ orgRoutes.get('/sites', requireScope('organization', 'partner', 'system'), requi
     }
   }
 
-  const whereCondition = conditions ?? sql`true`;
+  // Per-user site confinement. ensureOrgAccess (above) is org-axis only and
+  // RLS on `sites` is also org-axis only, so a site-confined user would
+  // otherwise enumerate every sibling site in the org. Intersect the org
+  // filter with allowedSiteIds. Mirrors scripts.ts:858-869.
+  const permissions = c.get('permissions') as UserPermissions | undefined;
+  const allowedSiteIds = permissions?.allowedSiteIds;
+  if (allowedSiteIds?.length === 0) {
+    return c.json({ data: [], pagination: { page, limit, total: 0 } });
+  }
+
+  const baseCondition = conditions ?? sql`true`;
+  const whereCondition = allowedSiteIds
+    ? and(baseCondition, inArray(sites.id, allowedSiteIds))
+    : baseCondition;
 
   const countResult = await db
     .select({ count: sql<number>`count(*)` })
@@ -1043,6 +1056,11 @@ orgRoutes.get('/sites/:id', requireScope('organization', 'partner', 'system'), r
     return c.json({ error: 'Access to this site denied' }, 403);
   }
 
+  const permissions = c.get('permissions') as UserPermissions | undefined;
+  if (permissions?.allowedSiteIds && !canAccessSite(permissions, site.id)) {
+    return c.json({ error: 'Access to this site denied' }, 403);
+  }
+
   return c.json(site);
 });
 
@@ -1067,6 +1085,11 @@ orgRoutes.patch('/sites/:id', requireScope('organization', 'partner', 'system'),
 
   const allowed = await ensureOrgAccess(site.orgId, auth);
   if (!allowed) {
+    return c.json({ error: 'Access to this site denied' }, 403);
+  }
+
+  const permissions = c.get('permissions') as UserPermissions | undefined;
+  if (permissions?.allowedSiteIds && !canAccessSite(permissions, site.id)) {
     return c.json({ error: 'Access to this site denied' }, 403);
   }
 
@@ -1111,6 +1134,11 @@ orgRoutes.delete('/sites/:id', requireScope('organization', 'partner', 'system')
 
   const allowed = await ensureOrgAccess(site.orgId, auth);
   if (!allowed) {
+    return c.json({ error: 'Access to this site denied' }, 403);
+  }
+
+  const permissions = c.get('permissions') as UserPermissions | undefined;
+  if (permissions?.allowedSiteIds && !canAccessSite(permissions, site.id)) {
     return c.json({ error: 'Access to this site denied' }, 403);
   }
 

--- a/apps/api/src/services/breezeBillingClient.test.ts
+++ b/apps/api/src/services/breezeBillingClient.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import { createBreezeBillingClient } from './breezeBillingClient';
 
 describe('breezeBillingClient', () => {
@@ -38,5 +38,50 @@ describe('breezeBillingClient', () => {
     await expect(
       client.createSetupIntent({ partnerId: 'p1', returnUrl: 'x' }),
     ).rejects.toMatchObject({ code: 'BILLING_UNAVAILABLE', message: expect.stringContaining('svc down') });
+  });
+
+  describe('breeze-billing S2S auth header (F4)', () => {
+    const originalKey = process.env.BREEZE_BILLING_API_KEY;
+
+    beforeEach(() => {
+      delete process.env.BREEZE_BILLING_API_KEY;
+    });
+
+    afterEach(() => {
+      if (originalKey === undefined) {
+        delete process.env.BREEZE_BILLING_API_KEY;
+      } else {
+        process.env.BREEZE_BILLING_API_KEY = originalKey;
+      }
+    });
+
+    it('attaches Authorization: Bearer <BREEZE_BILLING_API_KEY> on /setup-intents', async () => {
+      process.env.BREEZE_BILLING_API_KEY = 's2s-secret-token';
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ setup_url: 'https://stripe.example/setup/abc', customer_id: 'cus_123' }),
+      });
+      const client = createBreezeBillingClient({ baseUrl: 'http://billing.local', fetch: fetchMock as any });
+      await client.createSetupIntent({ partnerId: 'p1', returnUrl: 'https://app.example.com/back' });
+      const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+      if (!init) throw new Error('fetch was not called');
+      expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer s2s-secret-token');
+    });
+
+    it('does NOT attach an Authorization header when BREEZE_BILLING_API_KEY is unset', async () => {
+      delete process.env.BREEZE_BILLING_API_KEY;
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ setup_url: 'https://stripe.example/setup/abc', customer_id: 'cus_123' }),
+      });
+      const client = createBreezeBillingClient({ baseUrl: 'http://billing.local', fetch: fetchMock as any });
+      await client.createSetupIntent({ partnerId: 'p1', returnUrl: 'https://app.example.com/back' });
+      const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+      if (!init) throw new Error('fetch was not called');
+      const headers = init.headers as Record<string, string>;
+      expect(headers['Authorization']).toBeUndefined();
+      // Guard against the `Bearer undefined` footgun.
+      expect(JSON.stringify(headers)).not.toContain('Bearer undefined');
+    });
   });
 });

--- a/apps/api/src/services/breezeBillingClient.ts
+++ b/apps/api/src/services/breezeBillingClient.ts
@@ -18,9 +18,17 @@ export function createBreezeBillingClient(opts: {
   const doFetch = opts.fetch ?? fetch;
   return {
     async createSetupIntent({ partnerId, returnUrl }) {
+      // Service-to-service auth to breeze-billing. The boot validator
+      // (config/validate.ts) requires BREEZE_BILLING_API_KEY whenever
+      // BREEZE_BILLING_URL is set, so in production the key is guaranteed
+      // present. Only attach the header when the key exists to avoid sending
+      // `Bearer undefined` from dev/test without billing configured.
+      const headers: Record<string, string> = { 'content-type': 'application/json' };
+      const billingKey = process.env.BREEZE_BILLING_API_KEY;
+      if (billingKey) headers['Authorization'] = `Bearer ${billingKey}`;
       const res = await doFetch(`${opts.baseUrl}/setup-intents`, {
         method: 'POST',
-        headers: { 'content-type': 'application/json' },
+        headers,
         body: JSON.stringify({ partner_id: partnerId, return_url: returnUrl }),
       });
       if (!res.ok) {


### PR DESCRIPTION
## Summary

A multi-tenant isolation + authorization pass across all API routes, from a two-pass adversarial security review (4 HIGH, 3 MEDIUM, 1 LOW). Each finding was independently re-confirmed against source before fixing; all changes are TDD'd.

The through-line for 5 of 8 findings is one **systemic blind spot**: the RLS coverage contract test auto-discovers tenant tables by the presence of an `org_id` column, so tenant CHILD tables keyed by a parent FK silently shipped with **no RLS and no CI coverage**. This PR closes the individual leaks *and* extends the contract test so the class can't recur.

## Findings & fixes

**F1 — HIGH, intra-org broken access control** (`routes/orgs.ts`, `routes/groups.ts`)
Site CRUD/list gated only on org access, ignoring per-user `allowedSiteIds`; a site-confined user could read/rename/hard-delete sibling sites and enumerate every org site (the `sites` RLS policy is org-axis only). Now gates `GET/PATCH/DELETE /sites/:id` and constrains `GET /sites` via `canAccessSite`; same fix on the groups bulk-add path (`POST /:id/devices`). Static site-scope scanner extended to `/sites/:param`.

**F2 / F5 / F6 / F7 + systemic — HIGH/MED, missing RLS** (`migrations/2026-05-30-fk-child-tables-rls.sql`, `__tests__/integration/rls-coverage.integration.test.ts`)
Seven FK-child tables — `automation_runs`, `ai_messages`, `ai_tool_executions`, `script_execution_batches`, `software_versions`, `alert_correlations`, `alert_notifications` — carried zero RLS. Added ENABLE+FORCE RLS + parent-FK `EXISTS`-join policies (org reached via the parent's `org_id`). Added a new `PARENT_FK_JOIN_POLICY_TABLES` allowlist + parent-aware assertion (the existing Shape-5 assertion hard-codes `FROM devices`) + a live cross-org forge. Edge cases: `automation_runs` reaches org via `automation_id` OR `config_policy_id` (config-policy runs leave `automation_id` NULL); `script_execution_batches` mirrors the scripts policy's `is_system = true OR breeze_has_org_access(org_id)` so built-in scripts keep working.

**F3 — HIGH, IDOR** (`routes/automations.ts`)
`GET /automations/runs/:runId` config-policy branch returned the run with no org check (`requireAutomationRead` is RBAC-only). Now resolves org via `configPolicyId → configuration_policies.org_id` and enforces `ensureOrgAccess` (404 cross-tenant). F2's RLS policy is the defense-in-depth backstop.

**F4 — HIGH, missing S2S auth** (`routes/externalServices.ts`, `services/breezeBillingClient.ts`)
Outbound calls to breeze-billing sent no auth header though `BREEZE_BILLING_API_KEY` is boot-required. Now attaches `Authorization: Bearer <key>` when the key is present. (breeze-billing's inbound enforcement is out-of-tree; this hardens the client side — sends the boot-required secret instead of leaving it orphaned.)

**F8 — LOW, missing audit** (`routes/automations.ts`)
The unauthenticated webhook automation trigger queued fleet-wide execution with no audit row. Emits `writeAuditEvent(actorType:'system', action:'automation.trigger.webhook')`.

## Test plan / verification

- `tsc --noEmit`: clean (0 errors)
- Full API unit suite: **5262 passed**
- `rls-coverage`: **21 passed**, incl. cross-org forge — org B cannot read org A's run; cross-org `INSERT` rejected by `WITH CHECK` as `breeze_app`
- site-scope coverage + autoMigrate-ordering contracts: pass
- Migration idempotent, applied via the real `autoMigrate` runner; `db:check-drift` clean (213 migrations)

**Status:** all green, ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)