### PR TITLE
fix(agent): close two transient plaintext-secret exposure windows in config persistence

### DIFF
--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -324,6 +324,26 @@ func Load(cfgFile string) (*Config, error) {
 // to the existing config file. Any legacy inline secrets are migrated to
 // secrets.yaml and scrubbed from agent.yaml after the write.
 func SetAndPersist(key string, value any) error {
+	path := viper.ConfigFileUsed()
+
+	// SECURITY: move any legacy inline secrets out of the on-disk agent.yaml into
+	// root-only secrets.yaml BEFORE re-serializing viper, and clear them from
+	// viper memory, so the WriteConfig below can never write a plaintext secret
+	// to the world-readable (0644) agent.yaml. Previously WriteConfig serialized
+	// the full viper state — including still-loaded legacy inline secrets — to
+	// agent.yaml first and only stripped them afterwards, a transient plaintext
+	// bearer-token exposure on the first run after an upgrade.
+	if path != "" {
+		if err := migrateInlineSecretsToSecretFile(path); err != nil {
+			return err
+		}
+	}
+	for _, k := range viper.AllKeys() {
+		if isSecretYAMLKey(k) {
+			viper.Set(k, nil)
+		}
+	}
+
 	if isSecretConfigKey(key) {
 		if err := SetSecretAndPersist(key, value); err != nil {
 			return err
@@ -335,7 +355,9 @@ func SetAndPersist(key string, value any) error {
 	if err := viper.WriteConfig(); err != nil {
 		return err
 	}
-	if path := viper.ConfigFileUsed(); path != "" {
+	if path != "" {
+		// Defense-in-depth: clear any nil'd secret keys / late inline secrets
+		// from agent.yaml after the write.
 		if err := migrateInlineSecretsToSecretFile(path); err != nil {
 			return err
 		}
@@ -363,32 +385,18 @@ func SetSecretAndPersist(key string, value any) error {
 	}
 	sv.Set(key, value)
 
-	ext := filepath.Ext(path)
-	tmpPath := path[:len(path)-len(ext)] + ".tmp" + ext
-	if err := sv.WriteConfigAs(tmpPath); err != nil {
-		return err
-	}
-	sf, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	// SECURITY: write atomically at 0600 — never via a 0644 temp file. The
+	// previous WriteConfigAs(tmp) path created a world-readable (0644) temp file
+	// holding the plaintext secret in the config dir before copying to the 0600
+	// target, a local-user read window. atomicWriteFile creates its .partial tmp
+	// at the requested 0600, so the secret is never world-readable on disk.
+	secretsYAML, err := yaml.Marshal(sv.AllSettings())
 	if err != nil {
-		os.Remove(tmpPath)
+		return fmt.Errorf("marshaling secrets file: %w", err)
+	}
+	if err := atomicWriteFile(path, secretsYAML, 0600); err != nil {
 		return err
 	}
-	data, err := os.ReadFile(tmpPath)
-	if err != nil {
-		sf.Close()
-		os.Remove(tmpPath)
-		return err
-	}
-	if _, err := sf.Write(data); err != nil {
-		sf.Close()
-		os.Remove(tmpPath)
-		return err
-	}
-	if err := sf.Close(); err != nil {
-		os.Remove(tmpPath)
-		return err
-	}
-	os.Remove(tmpPath)
 	return enforceSecretFilePermissions(path)
 }
 

--- a/agent/internal/config/config_test.go
+++ b/agent/internal/config/config_test.go
@@ -174,6 +174,61 @@ log_level: info
 	}
 }
 
+// TestSetSecretAndPersistWritesSecretsAt0600 guards that SetSecretAndPersist
+// writes secrets.yaml at 0600 with no world-readable temp file left in the
+// config dir. The previous implementation wrote the plaintext secret to a 0644
+// `secrets.tmp.yaml` before copying to the 0600 target — a local-user read
+// window. The fix routes the write through atomicWriteFile(0600).
+func TestSetSecretAndPersistWritesSecretsAt0600(t *testing.T) {
+	defer viper.Reset()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`agent_id: 00000000-0000-0000-0000-000000000001
+server_url: https://api.example.test
+log_level: info
+`), 0o640); err != nil {
+		t.Fatalf("write agent.yaml: %v", err)
+	}
+	if _, err := Load(cfgPath); err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	if err := SetSecretAndPersist("auth_token", "brz_super_secret"); err != nil {
+		t.Fatalf("SetSecretAndPersist returned error: %v", err)
+	}
+
+	secretsPath := filepath.Join(dir, "secrets.yaml")
+	info, err := os.Stat(secretsPath)
+	if err != nil {
+		t.Fatalf("stat secrets.yaml: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Fatalf("secrets.yaml perm = %o, want 0600", perm)
+		}
+	}
+	data, err := os.ReadFile(secretsPath)
+	if err != nil {
+		t.Fatalf("read secrets.yaml: %v", err)
+	}
+	if !strings.Contains(string(data), "auth_token: brz_super_secret") {
+		t.Fatalf("secrets.yaml missing token:\n%s", data)
+	}
+
+	// No world-readable scratch file (e.g. the old secrets.tmp.yaml) left behind.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read config dir: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if strings.Contains(name, ".tmp") || strings.HasSuffix(name, ".partial") {
+			t.Fatalf("leftover scratch file in config dir: %s", name)
+		}
+	}
+}
+
 // TestSaveToWritesAtomicallyWithoutLeftoverTempFiles guards #642: SaveTo must
 // not leave .partial scratch files behind on success, and the on-disk files
 // must contain the full serialized config (not zero-length or truncated).


### PR DESCRIPTION
Defense-in-depth: closes two short-lived windows where a config secret was world-readable on disk during a write. Both require a local foothold (local-user read), so hardening class.

## H3 — secret written to a 0644 temp file
`SetSecretAndPersist` wrote the plaintext secret to a `secrets.tmp.yaml` in the config dir via viper's `WriteConfigAs` (**0644**) before copying to the 0600 target. Routed the write through the existing `atomicWriteFile`, whose `.partial` temp is created at the requested **0600** — the secret is never world-readable on disk.

## H4 — full viper state (incl. legacy inline secrets) written to world-readable agent.yaml
`SetAndPersist` called `viper.WriteConfig()` (serializing the entire viper state, including still-loaded legacy inline secrets) to the world-readable **0644** `agent.yaml` and only stripped them afterwards — a transient plaintext bearer-token exposure on the first run after an upgrade. Now migrates legacy inline secrets to root-only `secrets.yaml` and nils them in viper **before** the write, so a plaintext secret is never serialized to `agent.yaml`.

## Test plan
`cd agent && go test -race ./internal/config/` — new `TestSetSecretAndPersistWritesSecretsAt0600` (0600 perms + no scratch-file leak); existing `TestSetAndPersistScrubsLegacyInlineSecrets` stays green through the H4 reorder. Full config suite green with `-race`; cross-compiles linux/windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)