### PR TITLE
harden(web): client-side redirect/href defense-in-depth

### DIFF
--- a/apps/web/src/components/admin/ThirdPartyCatalog.test.tsx
+++ b/apps/web/src/components/admin/ThirdPartyCatalog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ThirdPartyCatalog from './ThirdPartyCatalog';
@@ -52,6 +52,24 @@ const sampleItems = [
     notes: null,
     homepageUrl: null,
   },
+  {
+    // Hostile homepageUrl — getSafeExternalHref must reject the javascript:
+    // scheme so this can never become an <a href="javascript:...">. Regression
+    // guard against reverting the wiring to href={entry.homepageUrl}.
+    id: '3',
+    source: 'third_party',
+    packageId: 'Evil.Corp',
+    vendor: 'Evil Corp',
+    friendlyName: 'Evil Corp Suite',
+    category: 'application',
+    defaultSeverity: 'critical',
+    breezeTested: false,
+    lastTestedAt: null,
+    lastTestedVersion: null,
+    lastTestedResult: null,
+    notes: null,
+    homepageUrl: 'javascript:alert(1)',
+  },
 ];
 
 describe('ThirdPartyCatalog', () => {
@@ -68,6 +86,44 @@ describe('ThirdPartyCatalog', () => {
     expect(screen.getByText('Google.Chrome')).toBeTruthy();
   });
 
+  it('renders the friendlyName as a safe external link when homepageUrl passes the guard', async () => {
+    render(<ThirdPartyCatalog />);
+    await screen.findByText('Mozilla Firefox');
+
+    const row = screen.getByTestId('catalog-row-1');
+    const link = within(row).getByText('Mozilla Firefox').closest('a');
+    expect(link).not.toBeNull();
+    // href must be exactly the safe URL — not href={entry.homepageUrl} raw.
+    expect(link).toHaveAttribute('href', 'https://www.mozilla.org/firefox/');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer');
+  });
+
+  it('renders a hostile javascript: homepageUrl as plain text with no anchor (#xss guard)', async () => {
+    render(<ThirdPartyCatalog />);
+    await screen.findByText('Evil Corp Suite');
+
+    const row = screen.getByTestId('catalog-row-3');
+    // The friendlyName is present...
+    expect(within(row).getByText('Evil Corp Suite')).toBeTruthy();
+    // ...but it must NOT be wrapped in an anchor (guard rejected the scheme),
+    // and there must be no href smuggling the javascript: payload through.
+    expect(within(row).getByText('Evil Corp Suite').closest('a')).toBeNull();
+    expect(within(row).queryByRole('link')).toBeNull();
+    expect(row.querySelector('a')).toBeNull();
+    expect(row.querySelector('[href]')).toBeNull();
+  });
+
+  it('renders the friendlyName as plain text when homepageUrl is null', async () => {
+    render(<ThirdPartyCatalog />);
+    await screen.findByText('Google Chrome');
+
+    const row = screen.getByTestId('catalog-row-2');
+    expect(within(row).getByText('Google Chrome')).toBeTruthy();
+    expect(within(row).getByText('Google Chrome').closest('a')).toBeNull();
+    expect(within(row).queryByRole('link')).toBeNull();
+  });
+
   it('shows breeze-tested badge only on tested entries', async () => {
     render(<ThirdPartyCatalog />);
     await screen.findByText('Mozilla Firefox');
@@ -78,7 +134,7 @@ describe('ThirdPartyCatalog', () => {
   it('shows total count', async () => {
     render(<ThirdPartyCatalog />);
     await waitFor(() => {
-      expect(screen.getByTestId('catalog-total').textContent).toBe('2');
+      expect(screen.getByTestId('catalog-total').textContent).toBe(String(sampleItems.length));
     });
   });
 

--- a/apps/web/src/components/admin/ThirdPartyCatalog.tsx
+++ b/apps/web/src/components/admin/ThirdPartyCatalog.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Package, Search, ShieldCheck, AlertTriangle, RefreshCw, Plus, Pencil, Trash2, Play, Lock } from 'lucide-react';
 import { fetchWithAuth } from '@/stores/auth';
+import { getSafeExternalHref } from '@/lib/safeHref';
 import ThirdPartyCatalogEditor, { type CatalogEditorInitial } from './ThirdPartyCatalogEditor';
 
 const testResultStyles: Record<string, string> = {
@@ -335,18 +336,21 @@ export default function ThirdPartyCatalog() {
                 >
                   <td className="px-4 py-2">{entry.vendor}</td>
                   <td className="px-4 py-2">
-                    {entry.homepageUrl ? (
-                      <a
-                        href={entry.homepageUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-blue-600 hover:underline"
-                      >
-                        {entry.friendlyName}
-                      </a>
-                    ) : (
-                      entry.friendlyName
-                    )}
+                    {(() => {
+                      const homepageHref = getSafeExternalHref(entry.homepageUrl);
+                      return homepageHref ? (
+                        <a
+                          href={homepageHref}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-blue-600 hover:underline"
+                        >
+                          {entry.friendlyName}
+                        </a>
+                      ) : (
+                        entry.friendlyName
+                      );
+                    })()}
                   </td>
                   <td className="px-4 py-2 font-mono text-xs text-gray-600">
                     {entry.packageId}

--- a/apps/web/src/components/ai/AiChatMessages.tsx
+++ b/apps/web/src/components/ai/AiChatMessages.tsx
@@ -7,7 +7,7 @@ import AiApprovalDialog from './AiApprovalDialog';
 import AiPlanReviewCard from './AiPlanReviewCard';
 import AiPlanProgressBar from './AiPlanProgressBar';
 import type { ActionPlanStep } from '@breeze/shared';
-import { DOCS_BASE_URL } from '@breeze/shared';
+import { isDocsUrl } from '@/lib/safeHref';
 import { useHelpStore } from '@/stores/helpStore';
 
 interface Message {
@@ -128,7 +128,11 @@ export default function AiChatMessages({
                     remarkPlugins={[remarkGfm]}
                     components={{
                       a: ({ href, children }) => {
-                        if (href && DOCS_BASE_URL && href.startsWith(DOCS_BASE_URL)) {
+                        // Origin check (not a string prefix): a docs-lookalike host
+                        // (e.g. docs.breezermm.com.evil.com) is NOT treated as a
+                        // trusted in-app docs link and instead falls through to the
+                        // safe external-link branch below.
+                        if (isDocsUrl(href)) {
                           return (
                             <a
                               href={href}

--- a/apps/web/src/components/auth/AuthGuard.tsx
+++ b/apps/web/src/components/auth/AuthGuard.tsx
@@ -61,10 +61,6 @@ export default function AuthGuard({ children }: AuthGuardProps) {
 
     // Not authenticated — redirect to login
     if (!isAuthenticated || !tokens?.accessToken) {
-      const currentPath = window.location.pathname + window.location.search;
-      if (currentPath !== '/login' && currentPath !== '/register') {
-        sessionStorage.setItem('redirectAfterLogin', currentPath);
-      }
       void navigateTo('/login', { replace: true });
     }
 

--- a/apps/web/src/components/auth/AuthOverlay.tsx
+++ b/apps/web/src/components/auth/AuthOverlay.tsx
@@ -107,9 +107,5 @@ export default function AuthOverlay() {
 }
 
 function redirectToLogin() {
-  const currentPath = window.location.pathname + window.location.search;
-  if (currentPath !== '/login' && currentPath !== '/register') {
-    sessionStorage.setItem('redirectAfterLogin', currentPath);
-  }
   void navigateTo('/login', { replace: true });
 }

--- a/apps/web/src/components/layout/DashboardWrapper.tsx
+++ b/apps/web/src/components/layout/DashboardWrapper.tsx
@@ -53,10 +53,6 @@ export default function DashboardWrapper({ children, currentPath }: DashboardWra
       const hasValidAuth = isAuthenticated && tokens?.accessToken;
 
       if (!hasValidAuth) {
-        // Store the current URL to redirect back after login
-        if (currentPath !== '/login' && currentPath !== '/register') {
-          sessionStorage.setItem('redirectAfterLogin', currentPath);
-        }
         void navigateTo('/login', { replace: true });
       }
     }

--- a/apps/web/src/components/reports/ScheduledReports.test.tsx
+++ b/apps/web/src/components/reports/ScheduledReports.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RunHistoryModal } from './ScheduledReports';
+
+// RunHistoryModal is a pure presentational component (it receives `runs` as a
+// prop and does no fetching of its own), so no `fetchWithAuth` mock is needed.
+// We render it directly to exercise the three Output-column download branches.
+
+type Run = {
+  id: string;
+  scheduleId: string;
+  status: 'pending' | 'running' | 'completed' | 'failed';
+  startedAt?: string | null;
+  completedAt?: string | null;
+  outputUrl?: string | null;
+  errorMessage?: string | null;
+};
+
+const schedule = {
+  id: 'sched-1',
+  reportId: 'rep-1',
+  reportName: 'Asset Inventory',
+  frequency: 'daily' as const,
+  time: '09:00',
+  enabled: true,
+  recipients: ['ops@example.com'],
+  createdAt: '2026-05-01T00:00:00.000Z',
+  updatedAt: '2026-05-01T00:00:00.000Z'
+};
+
+const renderModal = (runs: Run[]) =>
+  render(
+    <RunHistoryModal
+      schedule={schedule}
+      runs={runs}
+      loading={false}
+      onClose={() => {}}
+      reportName="Asset Inventory"
+      timezone="UTC"
+    />
+  );
+
+// Helper: locate the table row for a run by its (unique) started timestamp,
+// so assertions about the Output cell are scoped to that specific run.
+const rowForStartedAt = (label: string): HTMLElement => {
+  const cell = screen.getByText(label);
+  const row = cell.closest('tr');
+  if (!row) throw new Error(`No <tr> found for run started at "${label}"`);
+  return row as HTMLElement;
+};
+
+describe('RunHistoryModal download links', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // jsdom origin is http://localhost, so getSafeHttpHref resolves and
+    // allowlists same-origin relative URLs against window.location.
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it('renders a live Download link for a completed run with a safe same-origin URL', () => {
+    renderModal([
+      {
+        id: 'r1',
+        scheduleId: 'sched-1',
+        status: 'completed',
+        startedAt: '2026-05-20T10:00:00.000Z',
+        completedAt: '2026-05-20T10:01:00.000Z',
+        outputUrl: '/api/reports/runs/r1/download'
+      }
+    ]);
+
+    const row = rowForStartedAt(new Date('2026-05-20T10:00:00.000Z').toLocaleString([], { timeZone: 'UTC' }));
+    const link = within(row).getByRole('link', { name: 'Download' });
+    expect(link).toBeInTheDocument();
+    // getSafeHttpHref resolves the relative URL against the jsdom origin and
+    // allowlists it (the page's own origin is always allowed).
+    expect(link).toHaveAttribute(
+      'href',
+      `${window.location.origin}/api/reports/runs/r1/download`
+    );
+    // No security breadcrumb for a link that resolved cleanly.
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('renders a disabled, titled label (no live link) for a completed run whose cross-origin URL is rejected', () => {
+    renderModal([
+      {
+        id: 'r2',
+        scheduleId: 'sched-1',
+        status: 'completed',
+        startedAt: '2026-05-21T10:00:00.000Z',
+        completedAt: '2026-05-21T10:01:00.000Z',
+        // Cross-origin absolute URL — passes the scheme check but fails the
+        // origin allowlist in getSafeHttpHref, so the live <a> is suppressed.
+        outputUrl: 'https://evil.example/x'
+      }
+    ]);
+
+    const row = rowForStartedAt(new Date('2026-05-21T10:00:00.000Z').toLocaleString([], { timeZone: 'UTC' }));
+
+    // No live anchor should be rendered for the rejected URL.
+    expect(within(row).queryByRole('link')).toBeNull();
+
+    // A disabled, explained label is shown instead.
+    const disabled = within(row).getByText('Download');
+    expect(disabled.tagName).toBe('SPAN');
+    expect(disabled).toHaveClass('cursor-not-allowed');
+    expect(disabled).toHaveClass('opacity-60');
+    expect(disabled).toHaveAttribute(
+      'title',
+      "This report's download link was blocked for security reasons"
+    );
+
+    // The should-never-happen rejection leaves a console breadcrumb.
+    expect(warnSpy).toHaveBeenCalledWith('[ScheduledReports] rejected outputUrl for run', 'r2');
+  });
+
+  it('renders the "-" placeholder for a non-completed run with no output URL', () => {
+    renderModal([
+      {
+        id: 'r3',
+        scheduleId: 'sched-1',
+        status: 'running',
+        startedAt: '2026-05-22T10:00:00.000Z',
+        completedAt: null,
+        outputUrl: null
+      }
+    ]);
+
+    const row = rowForStartedAt(new Date('2026-05-22T10:00:00.000Z').toLocaleString([], { timeZone: 'UTC' }));
+
+    // Neither a live link nor a disabled Download label — just the placeholder.
+    expect(within(row).queryByRole('link')).toBeNull();
+    expect(within(row).queryByText('Download')).toBeNull();
+    // The Output cell is the last cell in the row.
+    const cells = within(row).getAllByRole('cell');
+    expect(cells[cells.length - 1]).toHaveTextContent('-');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/reports/ScheduledReports.tsx
+++ b/apps/web/src/components/reports/ScheduledReports.tsx
@@ -17,6 +17,7 @@ import {
   Plus
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { getSafeHttpHref } from '@/lib/safeHref';
 import type { Report } from './ReportsList';
 
 const getBrowserTimezone = () => Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -275,16 +276,30 @@ function RunHistoryModal({ schedule, runs, loading, onClose, reportName, timezon
                         {formatDateTime(run.completedAt, timezone)}
                       </td>
                       <td className="px-4 py-3 text-right">
-                        {run.status === 'completed' && run.outputUrl ? (
-                          <a
-                            href={run.outputUrl}
-                            className="inline-flex h-8 items-center gap-1 rounded-md border px-3 text-sm hover:bg-muted"
-                          >
-                            Download
-                          </a>
-                        ) : (
-                          <span className="text-xs text-muted-foreground">-</span>
-                        )}
+                        {(() => {
+                          const downloadHref =
+                            run.status === 'completed' ? getSafeHttpHref(run.outputUrl) : null;
+                          if (downloadHref) {
+                            return (
+                              <a
+                                href={downloadHref}
+                                className="inline-flex h-8 items-center gap-1 rounded-md border px-3 text-sm hover:bg-muted"
+                              >
+                                Download
+                              </a>
+                            );
+                          }
+                          if (run.status === 'completed' && run.outputUrl) {
+                            // Completed with a URL the scheme guard rejected — show a
+                            // disabled label instead of a live/broken link.
+                            return (
+                              <span className="inline-flex h-8 cursor-not-allowed items-center gap-1 rounded-md border px-3 text-sm text-muted-foreground opacity-60">
+                                Download
+                              </span>
+                            );
+                          }
+                          return <span className="text-xs text-muted-foreground">-</span>;
+                        })()}
                       </td>
                     </tr>
                   );

--- a/apps/web/src/components/reports/ScheduledReports.tsx
+++ b/apps/web/src/components/reports/ScheduledReports.tsx
@@ -203,7 +203,7 @@ type RunHistoryModalProps = {
   timezone?: string;
 };
 
-function RunHistoryModal({ schedule, runs, loading, onClose, reportName, timezone }: RunHistoryModalProps) {
+export function RunHistoryModal({ schedule, runs, loading, onClose, reportName, timezone }: RunHistoryModalProps) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 py-8">
       <div className="w-full max-w-3xl rounded-lg border bg-card p-6 shadow-sm">
@@ -290,10 +290,16 @@ function RunHistoryModal({ schedule, runs, loading, onClose, reportName, timezon
                             );
                           }
                           if (run.status === 'completed' && run.outputUrl) {
-                            // Completed with a URL the scheme guard rejected — show a
-                            // disabled label instead of a live/broken link.
+                            // Completed with a URL the origin allowlist rejected — show a
+                            // disabled label instead of a live/broken link. This should
+                            // never happen for trusted server-issued URLs, so leave a
+                            // breadcrumb to aid investigation.
+                            console.warn('[ScheduledReports] rejected outputUrl for run', run.id);
                             return (
-                              <span className="inline-flex h-8 cursor-not-allowed items-center gap-1 rounded-md border px-3 text-sm text-muted-foreground opacity-60">
+                              <span
+                                className="inline-flex h-8 cursor-not-allowed items-center gap-1 rounded-md border px-3 text-sm text-muted-foreground opacity-60"
+                                title="This report's download link was blocked for security reasons"
+                              >
                                 Download
                               </span>
                             );

--- a/apps/web/src/lib/navigation.test.ts
+++ b/apps/web/src/lib/navigation.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Control the dynamic `astro:transitions/client` import. The vitest config
+// aliases this virtual module to a stub, but we re-mock it here so we can
+// assert on / reject from `navigate`.
+const navigateMock = vi.fn();
+vi.mock('astro:transitions/client', () => ({
+  navigate: (...args: unknown[]) => navigateMock(...args),
+}));
+
+import { navigateTo } from './navigation';
+
+describe('navigateTo same-origin guard', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    navigateMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('safe internal paths pass through unchanged', () => {
+    const safePaths = [
+      '/',
+      '/devices/123?tab=info',
+      '/settings#x',
+      '/alerts?severity=high',
+      '/configuration-policies/abc-def',
+    ];
+
+    for (const path of safePaths) {
+      it(`passes ${JSON.stringify(path)} to navigate verbatim`, async () => {
+        await navigateTo(path);
+        expect(navigateMock).toHaveBeenCalledTimes(1);
+        expect(navigateMock).toHaveBeenCalledWith(path, { history: 'auto' });
+      });
+    }
+  });
+
+  describe('unsafe inputs are replaced with the "/" fallback', () => {
+    const unsafePaths = [
+      'https://evil.com',
+      '//evil.com',
+      '/\\evil.com',
+      'javascript:alert(1)',
+      'relative/no/leading/slash',
+      '/with\u0000control',
+    ];
+
+    for (const path of unsafePaths) {
+      it(`rewrites ${JSON.stringify(path)} to "/"`, async () => {
+        await navigateTo(path);
+        expect(navigateMock).toHaveBeenCalledTimes(1);
+        expect(navigateMock).toHaveBeenCalledWith('/', { history: 'auto' });
+      });
+    }
+  });
+
+  it('honors the replace option in the history mode', async () => {
+    await navigateTo('/devices/123', { replace: true });
+    expect(navigateMock).toHaveBeenCalledWith('/devices/123', { history: 'replace' });
+  });
+
+  describe('catch / fallback branch uses the sanitized value', () => {
+    let assignSpy: ReturnType<typeof vi.fn>;
+    let replaceSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      assignSpy = vi.fn();
+      replaceSpy = vi.fn();
+      // jsdom's window.location is not directly assignable; redefine it with
+      // assign/replace stubs so we can observe the fallback navigation.
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: { assign: assignSpy, replace: replaceSpy } as unknown as Location,
+      });
+      navigateMock.mockRejectedValue(new Error('navigate failed'));
+    });
+
+    it('falls back to window.location.assign with a safe path', async () => {
+      await navigateTo('/devices/123?tab=info');
+      expect(assignSpy).toHaveBeenCalledWith('/devices/123?tab=info');
+      expect(replaceSpy).not.toHaveBeenCalled();
+    });
+
+    it('falls back to window.location.assign with the "/" fallback for unsafe input', async () => {
+      await navigateTo('https://evil.com');
+      expect(assignSpy).toHaveBeenCalledWith('/');
+    });
+
+    it('falls back to window.location.replace with a safe path when replace is set', async () => {
+      await navigateTo('/settings#x', { replace: true });
+      expect(replaceSpy).toHaveBeenCalledWith('/settings#x');
+      expect(assignSpy).not.toHaveBeenCalled();
+    });
+
+    it('falls back to window.location.replace with "/" for unsafe input when replace is set', async () => {
+      await navigateTo('//evil.com', { replace: true });
+      expect(replaceSpy).toHaveBeenCalledWith('/');
+    });
+  });
+});

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -1,3 +1,5 @@
+import { getSafeNext } from './authNext';
+
 interface NavigateOptions {
   replace?: boolean;
 }
@@ -7,16 +9,21 @@ export async function navigateTo(path: string, options: NavigateOptions = {}): P
     return;
   }
 
+  // Guard against open-redirect: callers may pass server-supplied values
+  // (e.g. notification/command `href`). Only allow same-origin relative paths;
+  // anything else falls back to '/'.
+  const safePath = getSafeNext(path, '/');
+
   try {
     const { navigate } = await import('astro:transitions/client');
-    await navigate(path, {
+    await navigate(safePath, {
       history: options.replace ? 'replace' : 'auto'
     });
   } catch {
     if (options.replace) {
-      window.location.replace(path);
+      window.location.replace(safePath);
     } else {
-      window.location.assign(path);
+      window.location.assign(safePath);
     }
   }
 }

--- a/apps/web/src/lib/safeHref.test.ts
+++ b/apps/web/src/lib/safeHref.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { getSafeExternalHref, getSafeHttpHref } from './safeHref';
+import { DOCS_BASE_URL } from '@breeze/shared';
+import { getSafeExternalHref, getSafeHttpHref, isDocsUrl } from './safeHref';
 
 describe('getSafeHttpHref', () => {
   it.each([
@@ -61,5 +62,38 @@ describe('getSafeExternalHref', () => {
     expect(getSafeExternalHref('https://www.mozilla.org/firefox/')).toBe(
       'https://www.mozilla.org/firefox/',
     );
+  });
+});
+
+describe('isDocsUrl', () => {
+  it('accepts the docs origin and any path under it', () => {
+    expect(isDocsUrl(DOCS_BASE_URL)).toBe(true);
+    expect(isDocsUrl(`${DOCS_BASE_URL}/agents/install`)).toBe(true);
+    expect(isDocsUrl(`${DOCS_BASE_URL}/features/device-groups/?x=1#frag`)).toBe(true);
+  });
+
+  it.each([
+    // Prefix-bypass lookalikes the old startsWith() check let through:
+    'https://docs.breezermm.com.evil.com/phish',
+    'https://docs.breezermm.com@evil.com/x',
+    'https://docs.breezermm.comevil.com',
+    // Other unsafe / non-matching values:
+    'javascript:alert(1)',
+    '//docs.breezermm.com',
+    'https://evil.example/x',
+    '',
+    '   ',
+  ])('rejects non-docs-origin value %j', (value) => {
+    expect(isDocsUrl(value)).toBe(false);
+  });
+
+  it('rejects null and undefined', () => {
+    expect(isDocsUrl(null)).toBe(false);
+    expect(isDocsUrl(undefined)).toBe(false);
+  });
+
+  it('rejects an http:// docs URL because origin includes the scheme', () => {
+    // DOCS_BASE_URL is https; the http variant is a different origin.
+    expect(isDocsUrl('http://docs.breezermm.com/agents/install')).toBe(false);
   });
 });

--- a/apps/web/src/lib/safeHref.test.ts
+++ b/apps/web/src/lib/safeHref.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getSafeHttpHref } from './safeHref';
+import { getSafeExternalHref, getSafeHttpHref } from './safeHref';
 
 describe('getSafeHttpHref', () => {
   it.each([
@@ -22,6 +22,44 @@ describe('getSafeHttpHref', () => {
     ).toBe('https://cdn.example.com/recording.mp4');
     expect(getSafeHttpHref('/recordings/session-1.mp4', 'https://app.2breeze.app/sessions')).toBe(
       'https://app.2breeze.app/recordings/session-1.mp4',
+    );
+  });
+});
+
+describe('getSafeExternalHref', () => {
+  it.each([
+    'javascript:alert(1)',
+    'data:text/html,<script>alert(1)</script>',
+    'vbscript:msgbox(1)',
+    '//evil.example.com/vendor',
+    'https://user:pass@vendor.example.com/page',
+    'https://vendor.example.com/' + '\u0000' + 'page',
+    '',
+    '   ',
+  ])('rejects unsafe external href %j', (href) => {
+    expect(getSafeExternalHref(href)).toBeNull();
+  });
+
+  it('rejects null and undefined', () => {
+    expect(getSafeExternalHref(null)).toBeNull();
+    expect(getSafeExternalHref(undefined)).toBeNull();
+  });
+
+  it('rejects relative paths because external links must be absolute', () => {
+    expect(getSafeExternalHref('/vendor/page')).toBeNull();
+    expect(getSafeExternalHref('vendor/page')).toBeNull();
+  });
+
+  it('accepts http and https absolute vendor URLs', () => {
+    expect(getSafeExternalHref('https://vendor.example/page')).toBe('https://vendor.example/page');
+    expect(getSafeExternalHref('http://vendor.example/page')).toBe('http://vendor.example/page');
+  });
+
+  it('allows an external https origin different from the current origin (key difference from getSafeHttpHref)', () => {
+    // getSafeHttpHref would null this out because the origin is not allowlisted;
+    // getSafeExternalHref intentionally permits any http(s) origin for vendor links.
+    expect(getSafeExternalHref('https://www.mozilla.org/firefox/')).toBe(
+      'https://www.mozilla.org/firefox/',
     );
   });
 });

--- a/apps/web/src/lib/safeHref.ts
+++ b/apps/web/src/lib/safeHref.ts
@@ -49,3 +49,31 @@ export function getSafeHttpHref(
     return null;
   }
 }
+
+/**
+ * Scheme-only guard for intentionally external links (e.g. vendor homepage URLs).
+ *
+ * Unlike {@link getSafeHttpHref}, this does NOT constrain the origin — any
+ * http(s) origin is permitted. It only ensures the value is an absolute URL
+ * with a safe scheme and no embedded credentials, so a hostile value can never
+ * turn into a `javascript:`/`data:`/`vbscript:` href or a credentials-leaking
+ * link. Returns the normalized href, or null if the value is unsafe.
+ */
+export function getSafeExternalHref(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed.startsWith('//') || /[\u0000-\u001F\u007F]/.test(trimmed)) {
+    return null;
+  }
+
+  try {
+    // No base: external links must be absolute URLs.
+    const url = new URL(trimmed);
+    if (!SAFE_LINK_PROTOCOLS.has(url.protocol) || url.username || url.password) {
+      return null;
+    }
+
+    return url.href;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/safeHref.ts
+++ b/apps/web/src/lib/safeHref.ts
@@ -1,4 +1,26 @@
+import { DOCS_BASE_URL } from '@breeze/shared';
+
 const SAFE_LINK_PROTOCOLS = new Set(['http:', 'https:']);
+
+/**
+ * True only when `url` parses as an absolute URL whose origin (scheme + host +
+ * port) strictly equals the docs origin. This is an ORIGIN check, not a string
+ * prefix check: lookalikes such as `https://docs.breezermm.com.evil.com/x`,
+ * `https://docs.breezermm.com@evil.com/x`, or `https://docs.breezermm.comevil.com`
+ * are rejected even though they share the `DOCS_BASE_URL` string prefix.
+ *
+ * Used to decide whether a value is safe to treat as a trusted in-app docs link
+ * (e.g. consumed as an `<iframe src>` / passed to `window.open`). Returns false
+ * for unparseable, scheme-relative, null, or undefined values.
+ */
+export function isDocsUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  try {
+    return new URL(url).origin === new URL(DOCS_BASE_URL).origin;
+  } catch {
+    return false;
+  }
+}
 
 function parseAllowedOrigins(configuredOrigins: string | undefined): Set<string> {
   const origins = new Set<string>();

--- a/apps/web/src/stores/helpStore.test.ts
+++ b/apps/web/src/stores/helpStore.test.ts
@@ -43,7 +43,13 @@ describe('help store open() href hardening', () => {
   it.each([
     'javascript:alert(1)',
     'https://evil.example/x',
-    '//evil.com'
+    '//evil.com',
+    // Prefix-bypass lookalike: shares the DOCS_BASE_URL string prefix but is a
+    // different origin. The old startsWith() check let this through; an origin
+    // check must reject it. This case would have caught the original bug.
+    'https://docs.breezermm.com.evil.com',
+    'https://docs.breezermm.com@evil.com/x',
+    'https://docs.breezermm.comevil.com'
   ])('does not write untrusted url %s into docsUrl', (malicious) => {
     const expected = getDocsForPath('/devices');
 

--- a/apps/web/src/stores/helpStore.test.ts
+++ b/apps/web/src/stores/helpStore.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// open() lazily imports ./aiStore to close the AI panel; stub it so tests
+// don't pull in the real aiStore (network/auth) module.
+vi.mock('./aiStore', () => ({
+  useAiStore: {
+    getState: () => ({ close: vi.fn() })
+  }
+}));
+
+import { getDocsForPath, DOCS_BASE_URL } from '@breeze/shared';
+import { useHelpStore } from './helpStore';
+
+const setPathname = (pathname: string) => {
+  Object.defineProperty(window, 'location', {
+    value: { pathname },
+    writable: true,
+    configurable: true
+  });
+};
+
+describe('help store open() href hardening', () => {
+  beforeEach(() => {
+    useHelpStore.setState({
+      isOpen: false,
+      docsUrl: DOCS_BASE_URL,
+      label: 'Documentation'
+    });
+    setPathname('/devices');
+  });
+
+  it('keeps a DOCS_BASE_URL-prefixed url as docsUrl and opens', () => {
+    const trusted = `${DOCS_BASE_URL}/features/device-groups/`;
+
+    useHelpStore.getState().open(trusted);
+
+    const state = useHelpStore.getState();
+    expect(state.isOpen).toBe(true);
+    expect(state.docsUrl).toBe(trusted);
+    expect(state.label).toBe('Documentation');
+  });
+
+  it.each([
+    'javascript:alert(1)',
+    'https://evil.example/x',
+    '//evil.com'
+  ])('does not write untrusted url %s into docsUrl', (malicious) => {
+    const expected = getDocsForPath('/devices');
+
+    useHelpStore.getState().open(malicious);
+
+    const state = useHelpStore.getState();
+    expect(state.isOpen).toBe(true);
+    // The malicious value must never reach the iframe-bound docsUrl.
+    expect(state.docsUrl).not.toBe(malicious);
+    // Instead it falls back to the safe contextual docs page.
+    expect(state.docsUrl).toBe(expected.url);
+    expect(state.label).toBe(expected.label);
+  });
+
+  it('resolves contextual docs via getDocsForPath when called with no arg', () => {
+    setPathname('/alerts');
+    const expected = getDocsForPath('/alerts');
+
+    useHelpStore.getState().open();
+
+    const state = useHelpStore.getState();
+    expect(state.isOpen).toBe(true);
+    expect(state.docsUrl).toBe(expected.url);
+    expect(state.label).toBe(expected.label);
+  });
+});

--- a/apps/web/src/stores/helpStore.ts
+++ b/apps/web/src/stores/helpStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { getDocsForPath, DOCS_BASE_URL } from '@breeze/shared';
+import { isDocsUrl } from '@/lib/safeHref';
 
 interface HelpState {
   isOpen: boolean;
@@ -31,10 +32,12 @@ export const useHelpStore = create<HelpState>((set) => ({
       .then(({ useAiStore }) => useAiStore.getState().close())
       .catch((err) => console.warn('[HelpStore] Failed to close AI panel:', err));
 
-    // Only a docs-prefixed url may be written into docsUrl, which is consumed
-    // as an <iframe src>. Any untrusted value falls back to the safe
-    // contextual docs page for the current path.
-    if (url && DOCS_BASE_URL && url.startsWith(DOCS_BASE_URL)) {
+    // Only a url whose ORIGIN exactly matches the docs site may be written into
+    // docsUrl, which is consumed as an <iframe src>. This is an origin check
+    // (via isDocsUrl), not a string-prefix match, so docs-lookalike hosts such
+    // as docs.breezermm.com.evil.com are rejected. Any untrusted value falls
+    // back to the safe contextual docs page for the current path.
+    if (isDocsUrl(url)) {
       set({ isOpen: true, docsUrl: url, label: 'Documentation' });
     } else {
       const { url: resolved, label } = getDocsForPath(window.location.pathname);

--- a/apps/web/src/stores/helpStore.ts
+++ b/apps/web/src/stores/helpStore.ts
@@ -31,7 +31,10 @@ export const useHelpStore = create<HelpState>((set) => ({
       .then(({ useAiStore }) => useAiStore.getState().close())
       .catch((err) => console.warn('[HelpStore] Failed to close AI panel:', err));
 
-    if (url) {
+    // Only a docs-prefixed url may be written into docsUrl, which is consumed
+    // as an <iframe src>. Any untrusted value falls back to the safe
+    // contextual docs page for the current path.
+    if (url && DOCS_BASE_URL && url.startsWith(DOCS_BASE_URL)) {
       set({ isOpen: true, docsUrl: url, label: 'Documentation' });
     } else {
       const { url: resolved, label } = getDocsForPath(window.location.pathname);


### PR DESCRIPTION
**Context:** Follow-ups from a security review of `apps/web` (scope: runAction handlers, `dangerouslySetInnerHTML`, client-trust, hash-state, auth redirects). The review found **no exploitable vulnerabilities** — these are defense-in-depth hardening items. Each was independently re-confirmed by a separate verification agent before implementation; that pass also **refuted** one candidate (the CSP `cdn.jsdelivr.net` allowance is load-bearing for the Monaco editor, not vestigial — deferred, see below).

**Fixes:**

- **Open-redirect guard on `navigateTo`** (`apps/web/src/lib/navigation.ts`): the target is now routed through the existing `getSafeNext`, so a server-supplied `href` (e.g. `NotificationCenter.tsx:302`, `CommandPalette.tsx:365`) can never become a cross-origin redirect. Same-origin relative paths only; anything else falls back to `/`. Latent today (those APIs don't emit absolute hrefs) — this closes the seam.
- **`helpStore.open` iframe-src guard** (`apps/web/src/stores/helpStore.ts`): only a `DOCS_BASE_URL`-prefixed url may reach the HelpPanel `<iframe src>`; any untrusted value falls back to the contextual docs page. Moves the guard from the sole caller into the store.
- **Dynamic-href scheme guards**: new `getSafeExternalHref` (scheme-only, for intentionally external links) in `apps/web/src/lib/safeHref.ts`; wired `ScheduledReports.tsx:280` (`outputUrl`, same-origin via `getSafeHttpHref`) and `ThirdPartyCatalog.tsx:340` (`homepageUrl`, external). A rejected URL renders as plain text / disabled — never a live bad link.
- **Dead-code removal**: dropped the never-read `sessionStorage['redirectAfterLogin']` writes in `AuthGuard.tsx`, `AuthOverlay.tsx`, `DashboardWrapper.tsx` (real post-login redirect uses `?next=` -> `getSafeNext`).

**Tests:** new `navigation.test.ts` (16) and `helpStore.test.ts` (5); added `getSafeExternalHref` cases to `safeHref.test.ts`. Full web suite **662 passing**, `tsc --noEmit` clean, eslint clean.

**Deferred (separate change, needs browser verification):** self-host Monaco (bundled `monaco-editor@0.55.1` via `loader.config`) to drop `cdn.jsdelivr.net` from CSP `script-src`/`style-src`. Not bundled here because it touches build tooling and needs a manual check that the Script editor still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
