### PR TITLE
fix(security): SOC2 hardening — audit coverage + step-up (admin MFA + email change)

### DIFF
--- a/apps/api/src/routes/admin/abuse.test.ts
+++ b/apps/api/src/routes/admin/abuse.test.ts
@@ -168,11 +168,25 @@ vi.mock('../../services/clientIp', () => ({
 }));
 
 // Stub authMiddleware to short-circuit; the test injects its own auth context.
-// `requireMfa` is referenced by `tenantErasureRoutes` which is now mounted on
-// adminRoutes — provide a noop pass-through so the import resolves.
+// `requireMfa` is used by both `/partners/:id/suspend-for-abuse` and
+// `/partners/:id/unsuspend` (and by tenantErasureRoutes, mounted on
+// adminRoutes). Mirror the REAL requireMfa() behavior so the MFA step-up
+// gate is actually exercised: 401 when no auth, 403 when the token's
+// `mfa` claim is unsatisfied, pass-through otherwise. (requireMfa() is a
+// no-op when ENABLE_2FA is off, but our injected `auth.token.mfa` drives
+// this mock regardless, so the gate is tested deterministically.)
 vi.mock('../../middleware/auth', () => ({
   authMiddleware: vi.fn(async (_c: unknown, next: () => Promise<void>) => next()),
-  requireMfa: vi.fn(() => async (_c: unknown, next: () => Promise<void>) => next()),
+  requireMfa: vi.fn(() => async (c: any, next: () => Promise<void>) => {
+    const auth = c.get('auth');
+    if (!auth) {
+      return c.json({ error: 'Not authenticated' }, 401);
+    }
+    if (auth.token?.mfa === false) {
+      return c.json({ error: 'MFA required' }, 403);
+    }
+    await next();
+  }),
   hasSatisfiedMfa: vi.fn(() => true),
 }));
 
@@ -184,6 +198,7 @@ import { revokeAllPartnerOauthArtifacts } from '../../oauth/grantRevocation';
 
 type FakeAuth = {
   user: { id: string; email: string; name: string; isPlatformAdmin: boolean };
+  token: { mfa: boolean };
 };
 
 function buildApp(authToInject: FakeAuth | null) {
@@ -200,10 +215,17 @@ function buildApp(authToInject: FakeAuth | null) {
 
 const platformAdminAuth: FakeAuth = {
   user: { id: 'admin-1', email: 'admin@breeze.test', name: 'PA', isPlatformAdmin: true },
+  token: { mfa: true },
+};
+
+const platformAdminAuthNoMfa: FakeAuth = {
+  user: { id: 'admin-1', email: 'admin@breeze.test', name: 'PA', isPlatformAdmin: true },
+  token: { mfa: false },
 };
 
 const partnerAdminAuth: FakeAuth = {
   user: { id: 'pa-1', email: 'partner@x.com', name: 'PartnerAdmin', isPlatformAdmin: false },
+  token: { mfa: true },
 };
 
 function resetState() {
@@ -299,6 +321,51 @@ describe('admin/abuse — auth gate', () => {
       body: JSON.stringify({ reason: 'restoring legit customer' }),
     });
     expect(res.status).toBe(403);
+    expect(createAuditLog).not.toHaveBeenCalled();
+  });
+
+  // MFA step-up: re-enabling an abuse-suspended partner is privilege-restoring
+  // (flips status back to active + re-enables all its disabled users), so it
+  // MUST require the same MFA step-up as suspend-for-abuse. requireMfa() is a
+  // no-op when ENABLE_2FA is off, so this gate is free until 2FA is enabled.
+  it('rejects /unsuspend when MFA is not satisfied (403)', async () => {
+    const app = buildApp(platformAdminAuthNoMfa);
+    const res = await app.request('/admin/partners/partner-1/unsuspend', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'restoring legit customer mid-incident' }),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('MFA required');
+    expect(createAuditLog).not.toHaveBeenCalled();
+  });
+
+  it('allows /unsuspend when MFA IS satisfied (proceeds past the gate)', async () => {
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/partners/partner-1/unsuspend', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'restoring legit customer after review' }),
+    });
+    expect(res.status).toBe(200);
+    expect(createAuditLog).toHaveBeenCalledTimes(1);
+    const auditCall = vi.mocked(createAuditLog).mock.calls[0]![0]!;
+    expect(auditCall.action).toBe('partner.unsuspended');
+  });
+
+  // Parallel assertion for suspend-for-abuse — proves the MFA harness is wired
+  // correctly and that the EXISTING requireMfa() on suspend is exercised.
+  it('rejects /suspend-for-abuse when MFA is not satisfied (403)', async () => {
+    const app = buildApp(platformAdminAuthNoMfa);
+    const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ confirmEmail: 'admin@breeze.test', reason: 'mfa step-up gate on suspend' }),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('MFA required');
     expect(createAuditLog).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/routes/admin/abuse.ts
+++ b/apps/api/src/routes/admin/abuse.ts
@@ -304,6 +304,7 @@ abuseRoutes.post(
 
 abuseRoutes.post(
   '/partners/:id/unsuspend',
+  requireMfa(),
   zValidator('json', reasonSchema),
   async (c) => {
     const partnerId = c.req.param('id');

--- a/apps/api/src/routes/policyManagement/actions.ts
+++ b/apps/api/src/routes/policyManagement/actions.ts
@@ -31,6 +31,15 @@ actionRoutes.post(
       .where(eq(automationPolicies.id, id))
       .returning();
 
+    writeRouteAudit(c, {
+      orgId: policy.orgId,
+      action: 'policy.activate',
+      resourceType: 'policy',
+      resourceId: policy.id,
+      resourceName: policy.name,
+      details: { enabled: { from: policy.enabled, to: true } },
+    });
+
     return c.json(updated ? normalizePolicyResponse(updated) : policy);
   }
 );
@@ -54,6 +63,15 @@ actionRoutes.post(
       .set({ enabled: false, updatedAt: new Date() })
       .where(eq(automationPolicies.id, id))
       .returning();
+
+    writeRouteAudit(c, {
+      orgId: policy.orgId,
+      action: 'policy.deactivate',
+      resourceType: 'policy',
+      resourceId: policy.id,
+      resourceName: policy.name,
+      details: { enabled: { from: policy.enabled, to: false } },
+    });
 
     return c.json(updated ? normalizePolicyResponse(updated) : policy);
   }

--- a/apps/api/src/routes/policyManagement_actions.test.ts
+++ b/apps/api/src/routes/policyManagement_actions.test.ts
@@ -133,6 +133,7 @@ vi.mock('../middleware/auth', () => ({
 
 import { db } from '../db';
 import { authMiddleware } from '../middleware/auth';
+import { writeRouteAudit } from '../services/auditEvents';
 
 function makePolicy(overrides: Record<string, unknown> = {}) {
   return {
@@ -204,6 +205,41 @@ describe('policyManagement routes', () => {
       expect(body.enabled).toBe(true);
     });
 
+    it('should write a policy.activate audit event', async () => {
+      const policy = makePolicy({ enabled: false });
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([policy])
+          })
+        })
+      } as any);
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ ...policy, enabled: true }])
+          })
+        })
+      } as any);
+
+      const res = await app.request(`/policies/${POLICY_ID}/activate`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      expect(writeRouteAudit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: 'policy.activate',
+          resourceType: 'policy',
+          resourceId: POLICY_ID,
+          resourceName: policy.name,
+          orgId: ORG_ID,
+        })
+      );
+    });
+
     it('should return 404 for non-existent policy', async () => {
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
@@ -251,6 +287,41 @@ describe('policyManagement routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.enabled).toBe(false);
+    });
+
+    it('should write a policy.deactivate audit event', async () => {
+      const policy = makePolicy({ enabled: true });
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([policy])
+          })
+        })
+      } as any);
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ ...policy, enabled: false }])
+          })
+        })
+      } as any);
+
+      const res = await app.request(`/policies/${POLICY_ID}/deactivate`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      expect(writeRouteAudit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: 'policy.deactivate',
+          resourceType: 'policy',
+          resourceId: POLICY_ID,
+          resourceName: policy.name,
+          orgId: ORG_ID,
+        })
+      );
     });
   });
 

--- a/apps/api/src/routes/sensitiveData.test.ts
+++ b/apps/api/src/routes/sensitiveData.test.ts
@@ -63,8 +63,13 @@ vi.mock('../services/eventBus', () => ({
   publishEvent: vi.fn().mockResolvedValue('event-1')
 }));
 
+vi.mock('../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn()
+}));
+
 import { db } from '../db';
 import { queueCommand } from '../services/commandQueue';
+import { writeRouteAudit } from '../services/auditEvents';
 import { sensitiveDataRoutes } from './sensitiveData';
 
 function mockDeviceLookup(rows: any[]) {
@@ -80,6 +85,53 @@ function mockInsertReturning(rows: any[]) {
     values: vi.fn().mockReturnValue({
       returning: vi.fn().mockResolvedValue(rows)
     })
+  } as any);
+}
+
+// db.select().from().where() — used by the remediate findings lookup
+function mockSelectFromWhere(rows: any[]) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(rows)
+    })
+  } as any);
+}
+
+// db.select().from().where().limit() — used by policy update/delete existing lookup
+function mockSelectFromWhereLimit(rows: any[]) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows)
+      })
+    })
+  } as any);
+}
+
+// db.update().set().where() — status-flip / destructive metadata writes
+function mockUpdateSetWhere() {
+  vi.mocked(db.update).mockReturnValueOnce({
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined)
+    })
+  } as any);
+}
+
+// db.update().set().where().returning() — policy update
+function mockUpdateSetWhereReturning(rows: any[]) {
+  vi.mocked(db.update).mockReturnValueOnce({
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue(rows)
+      })
+    })
+  } as any);
+}
+
+// db.delete().where() — policy delete
+function mockDeleteWhere() {
+  vi.mocked(db.delete).mockReturnValueOnce({
+    where: vi.fn().mockResolvedValue(undefined)
   } as any);
 }
 
@@ -247,5 +299,148 @@ describe('sensitive data routes', () => {
     expect(body.data.dryRun).toBe(true);
     expect(body.data.eligible).toBe(1);
     expect(queueCommand).not.toHaveBeenCalled();
+  });
+
+  // --- SOC2 audit coverage ---
+
+  const findingId = '33333333-3333-3333-3333-333333333333';
+  const policyId = '44444444-4444-4444-4444-444444444444';
+  const orgId = '11111111-1111-1111-1111-111111111111';
+
+  it('audits status-flip remediation (accept_risk) as a risk-acceptance decision', async () => {
+    mockSelectFromWhere([
+      { id: findingId, orgId, deviceId, filePath: '/tmp/secret.txt', status: 'open' }
+    ]);
+    mockUpdateSetWhere();
+
+    const res = await app.request('/sensitive-data/remediate', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        findingIds: [findingId],
+        action: 'accept_risk'
+      })
+    });
+
+    expect(res.status).toBe(200);
+    expect(writeRouteAudit).toHaveBeenCalledTimes(1);
+    expect(writeRouteAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'sensitive_data.finding.accept_risk',
+        resourceType: 'sensitive_data_finding',
+        details: expect.objectContaining({
+          action: 'accept_risk',
+          findingIds: [findingId],
+          count: 1
+        })
+      })
+    );
+  });
+
+  it('audits destructive remediation (quarantine) with queued/failed counts', async () => {
+    mockSelectFromWhere([
+      { id: findingId, orgId, deviceId, filePath: '/tmp/secret.txt', status: 'open' }
+    ]);
+    mockUpdateSetWhere();
+
+    const res = await app.request('/sensitive-data/remediate', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        findingIds: [findingId],
+        action: 'quarantine',
+        confirm: true
+      })
+    });
+
+    expect(res.status).toBe(202);
+    expect(writeRouteAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'sensitive_data.finding.remediate',
+        resourceType: 'sensitive_data_finding',
+        details: expect.objectContaining({
+          action: 'quarantine',
+          queued: 1,
+          failed: 0
+        })
+      })
+    );
+  });
+
+  it('audits policy creation', async () => {
+    mockInsertReturning([
+      { id: policyId, orgId, name: 'My Policy', createdAt: new Date(), updatedAt: new Date() }
+    ]);
+
+    const res = await app.request('/sensitive-data/policies', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'My Policy',
+        detectionClasses: ['credential']
+      })
+    });
+
+    expect(res.status).toBe(201);
+    expect(writeRouteAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'sensitive_data_policy.create',
+        resourceType: 'sensitive_data_policy',
+        resourceId: policyId,
+        resourceName: 'My Policy'
+      })
+    );
+  });
+
+  it('audits policy update with changedFields', async () => {
+    mockSelectFromWhereLimit([
+      { id: policyId, orgId, name: 'Old Name', scope: {}, detectionClasses: ['credential'], schedule: null, isActive: true }
+    ]);
+    mockUpdateSetWhereReturning([
+      { id: policyId, orgId, name: 'New Name', createdAt: new Date(), updatedAt: new Date() }
+    ]);
+
+    const res = await app.request(`/sensitive-data/policies/${policyId}`, {
+      method: 'PUT',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'New Name' })
+    });
+
+    expect(res.status).toBe(200);
+    expect(writeRouteAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'sensitive_data_policy.update',
+        resourceType: 'sensitive_data_policy',
+        resourceId: policyId,
+        resourceName: 'New Name',
+        details: expect.objectContaining({
+          changedFields: expect.arrayContaining(['name'])
+        })
+      })
+    );
+  });
+
+  it('audits policy deletion', async () => {
+    mockSelectFromWhereLimit([{ id: policyId, name: 'My Policy', orgId }]);
+    mockDeleteWhere();
+
+    const res = await app.request(`/sensitive-data/policies/${policyId}`, {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(200);
+    expect(writeRouteAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'sensitive_data_policy.delete',
+        resourceType: 'sensitive_data_policy',
+        resourceId: policyId
+      })
+    );
   });
 });

--- a/apps/api/src/routes/sensitiveData.ts
+++ b/apps/api/src/routes/sensitiveData.ts
@@ -18,6 +18,7 @@ import { enqueueSensitiveDataScan } from '../jobs/sensitiveDataJobs';
 import { publishEvent } from '../services/eventBus';
 import { resolveSensitiveDataKeySelection } from '../services/sensitiveDataKeys';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../services/permissions';
+import { writeRouteAudit } from '../services/auditEvents';
 import {
   recordSensitiveDataRemediationDecision,
   recordSensitiveDataScanQueued
@@ -776,6 +777,24 @@ sensitiveDataRoutes.post(
       }
 
       recordSensitiveDataRemediationDecision(payload.action, findings.length);
+
+      const auditAction = payload.action === 'accept_risk'
+        ? 'sensitive_data.finding.accept_risk'
+        : payload.action === 'false_positive'
+          ? 'sensitive_data.finding.false_positive'
+          : 'sensitive_data.finding.mark_remediated';
+      const flippedFindingIds = findings.map((finding) => finding.id);
+      writeRouteAudit(c, {
+        orgId: findings[0]?.orgId,
+        action: auditAction,
+        resourceType: 'sensitive_data_finding',
+        details: {
+          action: payload.action,
+          findingIds: flippedFindingIds,
+          count: flippedFindingIds.length,
+        },
+      });
+
       return c.json({
         data: {
           updated: findings.length,
@@ -844,6 +863,17 @@ sensitiveDataRoutes.post(
       recordSensitiveDataRemediationDecision('queue_failed', failed.length);
     }
 
+    writeRouteAudit(c, {
+      orgId: findings[0]?.orgId,
+      action: 'sensitive_data.finding.remediate',
+      resourceType: 'sensitive_data_finding',
+      details: {
+        action: payload.action,
+        queued: queued.length,
+        failed: failed.length,
+      },
+    });
+
     return c.json({
       data: {
         queued,
@@ -909,6 +939,14 @@ sensitiveDataRoutes.post(
 
     if (!policy) return c.json({ error: 'Failed to create policy' }, 500);
 
+    writeRouteAudit(c, {
+      orgId: policy.orgId,
+      action: 'sensitive_data_policy.create',
+      resourceType: 'sensitive_data_policy',
+      resourceId: policy.id,
+      resourceName: policy.name,
+    });
+
     return c.json({
       data: {
         ...policy,
@@ -958,6 +996,15 @@ sensitiveDataRoutes.put(
 
     if (!updated) return c.json({ error: 'Failed to update policy' }, 500);
 
+    writeRouteAudit(c, {
+      orgId: updated.orgId,
+      action: 'sensitive_data_policy.update',
+      resourceType: 'sensitive_data_policy',
+      resourceId: updated.id,
+      resourceName: updated.name,
+      details: { changedFields: Object.keys(payload) },
+    });
+
     return c.json({
       data: {
         ...updated,
@@ -983,7 +1030,11 @@ sensitiveDataRoutes.delete(
     if (orgCondition) conditions.push(orgCondition);
 
     const [existing] = await db
-      .select({ id: sensitiveDataPolicies.id })
+      .select({
+        id: sensitiveDataPolicies.id,
+        name: sensitiveDataPolicies.name,
+        orgId: sensitiveDataPolicies.orgId
+      })
       .from(sensitiveDataPolicies)
       .where(and(...conditions))
       .limit(1);
@@ -991,6 +1042,15 @@ sensitiveDataRoutes.delete(
     if (!existing) return c.json({ error: 'Policy not found' }, 404);
 
     await db.delete(sensitiveDataPolicies).where(eq(sensitiveDataPolicies.id, id));
+
+    writeRouteAudit(c, {
+      orgId: existing.orgId,
+      action: 'sensitive_data_policy.delete',
+      resourceType: 'sensitive_data_policy',
+      resourceId: existing.id,
+      resourceName: existing.name,
+    });
+
     return c.json({ success: true });
   }
 );

--- a/apps/api/src/routes/thirdPartyCatalog/operations.test.ts
+++ b/apps/api/src/routes/thirdPartyCatalog/operations.test.ts
@@ -32,6 +32,10 @@ const mockInvalidate = vi.hoisted(() => vi.fn());
 
 const mockPlatformAdminState = vi.hoisted(() => ({
   isPlatformAdmin: true,
+  // MFA step-up state — drives the requireMfa() mock below. Defaults to
+  // satisfied so existing happy-path tests are unaffected; the MFA-gate
+  // tests flip this to false to assert the 403 step-up.
+  mfaSatisfied: true,
 }));
 
 vi.mock('drizzle-orm', () => ({
@@ -82,7 +86,27 @@ vi.mock('../../middleware/platformAdmin', () => ({
         email: 'platform@example.com',
         isPlatformAdmin: true,
       },
+      // Surface the MFA claim so the requireMfa() mock can gate on it,
+      // mirroring how real JWTs carry the `mfa` claim.
+      token: { mfa: mockPlatformAdminState.mfaSatisfied },
     });
+    return next();
+  }),
+}));
+
+// Mirror the REAL requireMfa() behavior: 401 when no auth, 403 when the
+// token's `mfa` claim is unsatisfied, pass-through otherwise. The mutating
+// operations routes (POST /, PATCH /:id, DELETE /:id, POST /:id/test) are
+// gated by requireMfa() on top of the platform-admin gate.
+vi.mock('../../middleware/auth', () => ({
+  requireMfa: vi.fn(() => async (c: any, next: any) => {
+    const auth = c.get('auth');
+    if (!auth) {
+      return c.json({ error: 'Not authenticated' }, 401);
+    }
+    if (auth.token?.mfa === false) {
+      return c.json({ error: 'MFA required' }, 403);
+    }
     return next();
   }),
 }));
@@ -158,8 +182,71 @@ describe('third-party catalog operations routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPlatformAdminState.isPlatformAdmin = true;
+    mockPlatformAdminState.mfaSatisfied = true;
     app = new Hono();
     app.route('/third-party-catalog', thirdPartyCatalogRoutes);
+  });
+
+  // MFA step-up: the mutating/destructive operations (create, update, hard
+  // delete, and the SSH-spawning release-test) MUST require MFA on top of the
+  // platform-admin gate. requireMfa() is a no-op when ENABLE_2FA is off, so the
+  // gate is free until 2FA is enabled. Read routes (GET) are intentionally NOT
+  // gated.
+  describe('MFA step-up on mutating operations', () => {
+    beforeEach(() => {
+      mockPlatformAdminState.mfaSatisfied = false;
+    });
+
+    it('rejects POST / (create) when MFA is not satisfied (403)', async () => {
+      const res = await app.request('/third-party-catalog', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          packageId: 'Mozilla.Firefox',
+          vendor: 'Mozilla',
+          friendlyName: 'Mozilla Firefox',
+        }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.text()).toContain('MFA required');
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('rejects PATCH /:id (update) when MFA is not satisfied (403)', async () => {
+      const res = await app.request('/third-party-catalog/22222222-2222-4222-8222-222222222222', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ friendlyName: 'Renamed' }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.text()).toContain('MFA required');
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects DELETE /:id (hard delete) when MFA is not satisfied (403)', async () => {
+      const res = await app.request('/third-party-catalog/22222222-2222-4222-8222-222222222222', {
+        method: 'DELETE',
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.text()).toContain('MFA required');
+      expect(db.delete).not.toHaveBeenCalled();
+    });
+
+    it('rejects POST /:id/test (spawns SSH runner) when MFA is not satisfied (403)', async () => {
+      const res = await app.request('/third-party-catalog/44444444-4444-4444-8444-444444444444/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ version: '121.0' }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.text()).toContain('MFA required');
+      expect(db.select).not.toHaveBeenCalled();
+      expect(mockEnqueue).not.toHaveBeenCalled();
+    });
   });
 
   it('rejects POST without platform admin access', async () => {

--- a/apps/api/src/routes/thirdPartyCatalog/operations.ts
+++ b/apps/api/src/routes/thirdPartyCatalog/operations.ts
@@ -6,6 +6,7 @@ import { db } from '../../db';
 import { thirdPartyPackageCatalog, thirdPartyReleaseTests } from '../../db/schema';
 import { upsertCatalogSchema } from './schemas';
 import { platformAdminMiddleware } from '../../middleware/platformAdmin';
+import { requireMfa } from '../../middleware/auth';
 import {
   enqueueWingetReleaseTest,
   executeWingetReleaseTest,
@@ -19,6 +20,11 @@ const triggerTestSchema = z.object({
 export const operationsRoutes = new Hono();
 
 operationsRoutes.use('*', platformAdminMiddleware);
+// MFA step-up for every mutating catalog op. This router is all-mutating
+// (reads live in list.ts), so gate it once at the router level rather than
+// per-route — that also preserves Hono's handler typing on the validator-less
+// DELETE, which breaks if a bare middleware precedes the handler inline.
+operationsRoutes.use('*', requireMfa());
 
 operationsRoutes.post('/', zValidator('json', upsertCatalogSchema), async (c) => {
   const data = c.req.valid('json');

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 import { userRoutes } from './users';
 
-const { sendInviteMock } = vi.hoisted(() => ({
-  sendInviteMock: vi.fn().mockResolvedValue(undefined)
+const { sendInviteMock, createAuditLogAsyncMock, resolveUserAuditOrgIdMock } = vi.hoisted(() => ({
+  sendInviteMock: vi.fn().mockResolvedValue(undefined),
+  createAuditLogAsyncMock: vi.fn().mockResolvedValue(undefined),
+  resolveUserAuditOrgIdMock: vi.fn().mockResolvedValue(null)
 }));
 
 vi.mock('../services/permissions', () => ({
@@ -112,6 +114,22 @@ vi.mock('../services/email', () => ({
     sendInvite: sendInviteMock
   }))
 }));
+
+vi.mock('../services/auditService', () => ({
+  createAuditLogAsync: createAuditLogAsyncMock
+}));
+
+vi.mock('../services/clientIp', () => ({
+  getTrustedClientIpOrUndefined: vi.fn(() => undefined)
+}));
+
+vi.mock('./auth/helpers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./auth/helpers')>();
+  return {
+    ...actual,
+    resolveUserAuditOrgId: resolveUserAuditOrgIdMock
+  };
+});
 
 vi.mock('../services/tokenRevocation', () => ({
   revokeAllUserTokens: vi.fn().mockResolvedValue(undefined)
@@ -406,6 +424,155 @@ describe('user routes', () => {
         body: JSON.stringify({ preferences: { blob: big } })
       });
       expect(res.status).toBe(400);
+    });
+  });
+
+  describe('PATCH /users/me audit coverage (SOC2)', () => {
+    // Every successful self-profile change MUST produce an audit_logs row,
+    // regardless of caller scope. Partner-scope callers have orgId === null,
+    // so the audit must resolve an attribution org via resolveUserAuditOrgId
+    // rather than being skipped entirely (the SOC2 coverage gap).
+    function mockProfileUpdateReturning(row: Record<string, unknown>) {
+      // db.select(...).from(...).where(...).limit(...) is hit only for an email
+      // uniqueness check; mock it to return no conflicting row. Then
+      // db.update(...).set(...).where(...).returning() yields the updated row.
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
+      } as any);
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([row])
+          })
+        })
+      } as any);
+    }
+
+    it('audits a partner-scope self-profile change (orgId resolved via resolveUserAuditOrgId)', async () => {
+      // Partner-scope caller: auth.orgId === null. Pre-fix the handler skips
+      // the audit because it is guarded by `if (auth.orgId)`. This asserts the
+      // audit fires with an org resolved from the user's membership.
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          scope: 'partner',
+          partnerId: 'partner-123',
+          orgId: null,
+          user: { id: 'user-123', email: 'test@example.com' }
+        });
+        return next();
+      });
+      resolveUserAuditOrgIdMock.mockResolvedValueOnce('resolved-org-1');
+      mockProfileUpdateReturning({
+        id: 'user-123',
+        email: 'test@example.com',
+        name: 'New Partner Name',
+        avatarUrl: null,
+        status: 'active',
+        mfaEnabled: false,
+        preferences: null
+      });
+
+      const res = await app.request('/users/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ name: 'New Partner Name' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(resolveUserAuditOrgIdMock).toHaveBeenCalledWith('user-123');
+      expect(createAuditLogAsyncMock).toHaveBeenCalledTimes(1);
+      expect(createAuditLogAsyncMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orgId: 'resolved-org-1',
+          actorId: 'user-123',
+          action: 'user.profile.update',
+          resourceType: 'user',
+          resourceId: 'user-123',
+          result: 'success',
+          details: expect.objectContaining({ changedFields: ['name'] })
+        })
+      );
+    });
+
+    it('audits a partner-scope self email change', async () => {
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          scope: 'partner',
+          partnerId: 'partner-123',
+          orgId: null,
+          user: { id: 'user-123', email: 'test@example.com' }
+        });
+        return next();
+      });
+      resolveUserAuditOrgIdMock.mockResolvedValueOnce('resolved-org-2');
+      mockProfileUpdateReturning({
+        id: 'user-123',
+        email: 'new@example.com',
+        name: 'Test User',
+        avatarUrl: null,
+        status: 'active',
+        mfaEnabled: false,
+        preferences: null
+      });
+
+      const res = await app.request('/users/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ email: 'new@example.com' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(createAuditLogAsyncMock).toHaveBeenCalledTimes(1);
+      expect(createAuditLogAsyncMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orgId: 'resolved-org-2',
+          action: 'user.profile.update',
+          details: expect.objectContaining({ changedFields: ['email'] })
+        })
+      );
+    });
+
+    it('still audits an org-scope self-profile change (no regression, no resolve needed)', async () => {
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          scope: 'organization',
+          partnerId: null,
+          orgId: 'org-1',
+          user: { id: 'user-123', email: 'test@example.com' }
+        });
+        return next();
+      });
+      mockProfileUpdateReturning({
+        id: 'user-123',
+        email: 'test@example.com',
+        name: 'New Org Name',
+        avatarUrl: null,
+        status: 'active',
+        mfaEnabled: false,
+        preferences: null
+      });
+
+      const res = await app.request('/users/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ name: 'New Org Name' })
+      });
+
+      expect(res.status).toBe(200);
+      // Org context is present, so no fallback resolution is required.
+      expect(resolveUserAuditOrgIdMock).not.toHaveBeenCalled();
+      expect(createAuditLogAsyncMock).toHaveBeenCalledTimes(1);
+      expect(createAuditLogAsyncMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orgId: 'org-1',
+          action: 'user.profile.update',
+          details: expect.objectContaining({ changedFields: ['name'] })
+        })
+      );
     });
   });
 

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -2,10 +2,26 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 import { userRoutes } from './users';
 
-const { sendInviteMock, createAuditLogAsyncMock, resolveUserAuditOrgIdMock } = vi.hoisted(() => ({
+const {
+  sendInviteMock,
+  sendEmailChangedMock,
+  createAuditLogAsyncMock,
+  resolveUserAuditOrgIdMock,
+  requireCurrentPasswordStepUpMock,
+  isPasswordAuthDisabledBySsoMock,
+  hasSatisfiedMfaMock
+} = vi.hoisted(() => ({
   sendInviteMock: vi.fn().mockResolvedValue(undefined),
+  sendEmailChangedMock: vi.fn().mockResolvedValue(undefined),
   createAuditLogAsyncMock: vi.fn().mockResolvedValue(undefined),
-  resolveUserAuditOrgIdMock: vi.fn().mockResolvedValue(null)
+  resolveUserAuditOrgIdMock: vi.fn().mockResolvedValue(null),
+  // Default: step-up succeeds (returns null). Tests override to return a
+  // Response to simulate a wrong password / rate-limit / Redis-down outcome.
+  requireCurrentPasswordStepUpMock: vi.fn().mockResolvedValue(null),
+  // Default: org does NOT enforce SSO.
+  isPasswordAuthDisabledBySsoMock: vi.fn().mockResolvedValue(false),
+  // Default: MFA is considered satisfied. Tests override to false.
+  hasSatisfiedMfaMock: vi.fn().mockReturnValue(true)
 }));
 
 vi.mock('../services/permissions', () => ({
@@ -106,12 +122,18 @@ vi.mock('../middleware/auth', () => ({
   }),
   requireScope: vi.fn(() => async (_c: any, next: any) => next()),
   requirePermission: vi.fn(() => (c: any, next: any) => next()),
-  requireMfa: vi.fn(() => (_c: any, next: any) => next())
+  requireMfa: vi.fn(() => (_c: any, next: any) => next()),
+  hasSatisfiedMfa: hasSatisfiedMfaMock
+}));
+
+vi.mock('./auth/ssoPolicy', () => ({
+  isPasswordAuthDisabledBySso: isPasswordAuthDisabledBySsoMock
 }));
 
 vi.mock('../services/email', () => ({
   getEmailService: vi.fn(() => ({
-    sendInvite: sendInviteMock
+    sendInvite: sendInviteMock,
+    sendEmailChanged: sendEmailChangedMock
   }))
 }));
 
@@ -127,7 +149,8 @@ vi.mock('./auth/helpers', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./auth/helpers')>();
   return {
     ...actual,
-    resolveUserAuditOrgId: resolveUserAuditOrgIdMock
+    resolveUserAuditOrgId: resolveUserAuditOrgIdMock,
+    requireCurrentPasswordStepUp: requireCurrentPasswordStepUpMock
   };
 });
 
@@ -153,6 +176,31 @@ describe('user routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks only clears call history — it does NOT drain queued
+    // mockReturnValueOnce implementations or reset mockReturnValue. Re-seed the
+    // db builders to safe defaults so each test starts from a clean chain and is
+    // order-independent (prevents leftover select/update mocks from one test
+    // poisoning the next, e.g. POST /users/:id/role).
+    vi.mocked(db.select).mockReset().mockReturnValue({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve([]))
+        }))
+      }))
+    } as any);
+    vi.mocked(db.update).mockReset().mockReturnValue({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(() => Promise.resolve([]))
+        }))
+      }))
+    } as any);
+    // Re-establish the step-up defaults each test: SSO off, MFA satisfied,
+    // password step-up passes.
+    requireCurrentPasswordStepUpMock.mockResolvedValue(null);
+    isPasswordAuthDisabledBySsoMock.mockResolvedValue(false);
+    hasSatisfiedMfaMock.mockReturnValue(true);
+    sendEmailChangedMock.mockResolvedValue(undefined);
     vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
       c.set('auth', {
         scope: 'partner',
@@ -386,6 +434,16 @@ describe('user routes', () => {
         });
         return next();
       });
+      // The handler loads the caller's own row first; provide it so body-level
+      // validation (e.g. the preferences-size guard) is reached. Zod-rejected
+      // cases short-circuit before the handler and are unaffected.
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ email: 'test@example.com', passwordHash: 'hash' }])
+          })
+        })
+      } as any);
     });
 
     it('rejects avatarUrl with javascript: scheme', async () => {
@@ -432,17 +490,31 @@ describe('user routes', () => {
     // regardless of caller scope. Partner-scope callers have orgId === null,
     // so the audit must resolve an attribution org via resolveUserAuditOrgId
     // rather than being skipped entirely (the SOC2 coverage gap).
-    function mockProfileUpdateReturning(row: Record<string, unknown>) {
-      // db.select(...).from(...).where(...).limit(...) is hit only for an email
-      // uniqueness check; mock it to return no conflicting row. Then
-      // db.update(...).set(...).where(...).returning() yields the updated row.
-      vi.mocked(db.select).mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([])
-          })
+
+    // Builds a select(...) chain node that resolves to `rows`.
+    const selectNode = (rows: unknown[]) => ({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue(rows)
         })
-      } as any);
+      })
+    });
+
+    function mockProfileUpdateReturning(
+      row: Record<string, unknown>,
+      self: { email: string; passwordHash: string | null } = {
+        email: 'test@example.com',
+        passwordHash: 'hash'
+      }
+    ) {
+      // The handler now issues db.select twice when the email changes:
+      //   1) load the caller's own row ({ email, passwordHash })
+      //   2) email uniqueness check (no conflicting row → [])
+      // Name-only changes only issue (1). Fall through default returns [] so the
+      // uniqueness check (when reached) never reports a conflict.
+      vi.mocked(db.select)
+        .mockReturnValueOnce(selectNode([self]) as any)
+        .mockReturnValue(selectNode([]) as any);
       vi.mocked(db.update).mockReturnValue({
         set: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
@@ -498,7 +570,12 @@ describe('user routes', () => {
       );
     });
 
-    it('audits a partner-scope self email change', async () => {
+    it('audits a partner-scope self avatar change (non-email, no step-up)', async () => {
+      // Previously this test PATCHed { email } with no password. The email-change
+      // step-up now requires currentPassword, so the email-change audit behavior
+      // moved into the dedicated "email change step-up" describe below. This test
+      // preserves the original INTENT — partner-scope self-changes are audited as
+      // user.profile.update — by exercising a non-email field instead.
       vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
         c.set('auth', {
           scope: 'partner',
@@ -511,9 +588,9 @@ describe('user routes', () => {
       resolveUserAuditOrgIdMock.mockResolvedValueOnce('resolved-org-2');
       mockProfileUpdateReturning({
         id: 'user-123',
-        email: 'new@example.com',
+        email: 'test@example.com',
         name: 'Test User',
-        avatarUrl: null,
+        avatarUrl: 'https://cdn.example.com/avatar.png',
         status: 'active',
         mfaEnabled: false,
         preferences: null
@@ -522,16 +599,18 @@ describe('user routes', () => {
       const res = await app.request('/users/me', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
-        body: JSON.stringify({ email: 'new@example.com' })
+        body: JSON.stringify({ avatarUrl: 'https://cdn.example.com/avatar.png' })
       });
 
       expect(res.status).toBe(200);
+      // No email change → no step-up of any kind.
+      expect(requireCurrentPasswordStepUpMock).not.toHaveBeenCalled();
       expect(createAuditLogAsyncMock).toHaveBeenCalledTimes(1);
       expect(createAuditLogAsyncMock).toHaveBeenCalledWith(
         expect.objectContaining({
           orgId: 'resolved-org-2',
           action: 'user.profile.update',
-          details: expect.objectContaining({ changedFields: ['email'] })
+          details: expect.objectContaining({ changedFields: ['avatarUrl'] })
         })
       );
     });
@@ -573,6 +652,267 @@ describe('user routes', () => {
           details: expect.objectContaining({ changedFields: ['name'] })
         })
       );
+    });
+  });
+
+  describe('PATCH /users/me email-change step-up (ATO hardening)', () => {
+    // Account-takeover step-up: changing the account email requires re-proving
+    // identity. Mirrors change-password — SSO-enforced orgs are blocked (managed
+    // at the IdP), local-password users must supply currentPassword, passwordless
+    // users must have satisfied MFA. On success the OLD address is notified.
+    const selectNode = (rows: unknown[]) => ({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue(rows)
+        })
+      })
+    });
+
+    const updateReturning = (row: Record<string, unknown>) => {
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([row])
+          })
+        })
+      } as any);
+    };
+
+    // First select = self load ({ email, passwordHash }); second select (only
+    // reached past the step-up gate) = email-uniqueness check.
+    const mockSelfAndUniqueness = (
+      self: { email: string; passwordHash: string | null },
+      uniqueness: unknown[] = []
+    ) => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce(selectNode([self]) as any)
+        .mockReturnValue(selectNode(uniqueness) as any);
+    };
+
+    const orgScopeAuth = () => {
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          scope: 'organization',
+          partnerId: null,
+          orgId: 'org-1',
+          user: { id: 'user-123', email: 'old@example.com' }
+        });
+        return next();
+      });
+    };
+
+    const updatedRow = (email: string) => ({
+      id: 'user-123',
+      email,
+      name: 'Test User',
+      avatarUrl: null,
+      status: 'active',
+      mfaEnabled: false,
+      preferences: null
+    });
+
+    it('case 1: email change with NO currentPassword ⇒ 400, email not updated', async () => {
+      orgScopeAuth();
+      mockSelfAndUniqueness({ email: 'old@example.com', passwordHash: 'hash' });
+      updateReturning(updatedRow('new@example.com'));
+
+      const res = await app.request('/users/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ email: 'new@example.com' })
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/current password is required/i);
+      expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+      expect(requireCurrentPasswordStepUpMock).not.toHaveBeenCalled();
+      expect(sendEmailChangedMock).not.toHaveBeenCalled();
+    });
+
+    it('case 2: email change with correct currentPassword ⇒ 200, audited, old address notified', async () => {
+      orgScopeAuth();
+      mockSelfAndUniqueness({ email: 'old@example.com', passwordHash: 'hash' });
+      updateReturning(updatedRow('new@example.com'));
+      requireCurrentPasswordStepUpMock.mockResolvedValueOnce(null);
+
+      const res = await app.request('/users/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ email: 'new@example.com', currentPassword: 'correct-horse' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(requireCurrentPasswordStepUpMock).toHaveBeenCalledWith(
+        expect.anything(),
+        'user-123',
+        'correct-horse',
+        'email-change:pwd'
+      );
+      // Dedicated email-change audit fired with stepUp === 'password'.
+      expect(createAuditLogAsyncMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'user.email.change',
+          resourceId: 'user-123',
+          details: expect.objectContaining({
+            previousEmail: 'old@example.com',
+            newEmail: 'new@example.com',
+            stepUp: 'password'
+          })
+        })
+      );
+      // Both audits: the generic profile-update + the dedicated email-change.
+      const actions = createAuditLogAsyncMock.mock.calls.map((c: any[]) => c[0].action);
+      expect(actions).toContain('user.profile.update');
+      expect(actions).toContain('user.email.change');
+      // Notify the OLD address.
+      expect(sendEmailChangedMock).toHaveBeenCalledWith(
+        expect.objectContaining({ to: 'old@example.com', newEmail: 'new@example.com' })
+      );
+    });
+
+    it('case 3: email change with wrong password ⇒ 401, not updated, no email-change audit/notice', async () => {
+      orgScopeAuth();
+      mockSelfAndUniqueness({ email: 'old@example.com', passwordHash: 'hash' });
+      updateReturning(updatedRow('new@example.com'));
+      // Simulate a wrong-password step-up: helper returns a 401 Response.
+      requireCurrentPasswordStepUpMock.mockImplementationOnce(async (c: any) =>
+        c.json({ error: 'Invalid credentials' }, 401)
+      );
+
+      const res = await app.request('/users/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ email: 'new@example.com', currentPassword: 'wrong' })
+      });
+
+      expect(res.status).toBe(401);
+      expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+      const actions = createAuditLogAsyncMock.mock.calls.map((c: any[]) => c[0].action);
+      expect(actions).not.toContain('user.email.change');
+      expect(sendEmailChangedMock).not.toHaveBeenCalled();
+    });
+
+    it('case 4a: passwordless user WITHOUT satisfied MFA ⇒ 403, not updated', async () => {
+      orgScopeAuth();
+      mockSelfAndUniqueness({ email: 'old@example.com', passwordHash: null });
+      updateReturning(updatedRow('new@example.com'));
+      hasSatisfiedMfaMock.mockReturnValue(false);
+
+      const res = await app.request('/users/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ email: 'new@example.com' })
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toMatch(/mfa/i);
+      expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+      // Passwordless → password step-up must not be attempted.
+      expect(requireCurrentPasswordStepUpMock).not.toHaveBeenCalled();
+      expect(sendEmailChangedMock).not.toHaveBeenCalled();
+    });
+
+    it('case 4b: passwordless user WITH satisfied MFA ⇒ 200, audited stepUp === mfa', async () => {
+      orgScopeAuth();
+      mockSelfAndUniqueness({ email: 'old@example.com', passwordHash: null });
+      updateReturning(updatedRow('new@example.com'));
+      hasSatisfiedMfaMock.mockReturnValue(true);
+
+      const res = await app.request('/users/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ email: 'new@example.com' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(requireCurrentPasswordStepUpMock).not.toHaveBeenCalled();
+      expect(createAuditLogAsyncMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'user.email.change',
+          details: expect.objectContaining({
+            previousEmail: 'old@example.com',
+            newEmail: 'new@example.com',
+            stepUp: 'mfa'
+          })
+        })
+      );
+      expect(sendEmailChangedMock).toHaveBeenCalledWith(
+        expect.objectContaining({ to: 'old@example.com', newEmail: 'new@example.com' })
+      );
+    });
+
+    it('case 5: enforce-SSO org ⇒ 403, email not updated', async () => {
+      orgScopeAuth();
+      mockSelfAndUniqueness({ email: 'old@example.com', passwordHash: 'hash' });
+      updateReturning(updatedRow('new@example.com'));
+      isPasswordAuthDisabledBySsoMock.mockResolvedValue(true);
+
+      const res = await app.request('/users/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ email: 'new@example.com', currentPassword: 'correct-horse' })
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toMatch(/sso/i);
+      expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+      expect(requireCurrentPasswordStepUpMock).not.toHaveBeenCalled();
+      expect(sendEmailChangedMock).not.toHaveBeenCalled();
+    });
+
+    it('case 6: name-only change ⇒ 200, no step-up invoked, audited as user.profile.update', async () => {
+      orgScopeAuth();
+      // Only the self-load select runs for a name-only change.
+      vi.mocked(db.select).mockReturnValue(
+        selectNode([{ email: 'old@example.com', passwordHash: 'hash' }]) as any
+      );
+      updateReturning({
+        id: 'user-123',
+        email: 'old@example.com',
+        name: 'Renamed',
+        avatarUrl: null,
+        status: 'active',
+        mfaEnabled: false,
+        preferences: null
+      });
+
+      const res = await app.request('/users/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ name: 'Renamed' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(requireCurrentPasswordStepUpMock).not.toHaveBeenCalled();
+      expect(isPasswordAuthDisabledBySsoMock).not.toHaveBeenCalled();
+      expect(sendEmailChangedMock).not.toHaveBeenCalled();
+      const actions = createAuditLogAsyncMock.mock.calls.map((c: any[]) => c[0].action);
+      expect(actions).toContain('user.profile.update');
+      expect(actions).not.toContain('user.email.change');
+    });
+
+    it('case 7: same-email "change" ⇒ no step-up required, 200', async () => {
+      orgScopeAuth();
+      // body.email === current email (after normalization) → not a real change.
+      mockSelfAndUniqueness({ email: 'old@example.com', passwordHash: 'hash' });
+      updateReturning(updatedRow('old@example.com'));
+
+      const res = await app.request('/users/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ email: 'OLD@example.com' })
+      });
+
+      expect(res.status).toBe(200);
+      // No real email change → no step-up gate, no notification, no dedicated audit.
+      expect(requireCurrentPasswordStepUpMock).not.toHaveBeenCalled();
+      expect(isPasswordAuthDisabledBySsoMock).not.toHaveBeenCalled();
+      expect(sendEmailChangedMock).not.toHaveBeenCalled();
+      const actions = createAuditLogAsyncMock.mock.calls.map((c: any[]) => c[0].action);
+      expect(actions).not.toContain('user.email.change');
     });
   });
 

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -6,7 +6,7 @@ import { HTTPException } from 'hono/http-exception';
 import { nanoid } from 'nanoid';
 import { db } from '../db';
 import { users, partnerUsers, organizationUsers, roles, organizations, permissions, rolePermissions } from '../db/schema';
-import { authMiddleware, requireMfa, requirePermission } from '../middleware/auth';
+import { authMiddleware, hasSatisfiedMfa, requireMfa, requirePermission } from '../middleware/auth';
 import {
   clearPermissionCache,
   getUserPermissions,
@@ -20,7 +20,8 @@ import { getTrustedClientIpOrUndefined } from '../services/clientIp';
 import { getEmailService } from '../services/email';
 import { getRedis } from '../services';
 import { INVITE_TOKEN_TTL_SECONDS } from './auth/schemas';
-import { hashInviteToken, inviteRedisKey, inviteUserRedisKey, resolveUserAuditOrgId, userRequiresSetup } from './auth/helpers';
+import { hashInviteToken, inviteRedisKey, inviteUserRedisKey, requireCurrentPasswordStepUp, resolveUserAuditOrgId, userRequiresSetup } from './auth/helpers';
+import { isPasswordAuthDisabledBySso } from './auth/ssoPolicy';
 import { revokeUserAccess } from '../services/userSuspension';
 import { revokeAllUserTokens } from '../services/tokenRevocation';
 
@@ -450,6 +451,9 @@ const updateMeSchema = z
         z.null(),
       ])
       .optional(),
+    // Account-takeover step-up for the email-change path. NEVER persisted and
+    // excluded from the audit changedFields — it is verified, then dropped.
+    currentPassword: z.string().optional(),
   })
   .strict();
 
@@ -457,9 +461,28 @@ userRoutes.patch('/me', zValidator('json', updateMeSchema), async (c) => {
   const auth = c.get('auth');
   const body = c.req.valid('json');
 
+  // Load the caller's own row once: needed to detect a real email change and to
+  // choose the right step-up factor (local password vs MFA).
+  const [self] = await db
+    .select({ email: users.email, passwordHash: users.passwordHash })
+    .from(users)
+    .where(eq(users.id, auth.user.id))
+    .limit(1);
+
+  if (!self) {
+    return c.json({ error: 'User not found' }, 404);
+  }
+
   const updates: { name?: string; email?: string; avatarUrl?: string; preferences?: Record<string, unknown>; updatedAt: Date } = {
     updatedAt: new Date()
   };
+
+  // Tracks how identity was re-proven for the email change so the dedicated
+  // audit can record it. Stays undefined for non-email changes.
+  let stepUpMethod: 'password' | 'mfa' | undefined;
+  // The address that owned the account before the change — used for the audit
+  // detail and the security notification to the OLD address.
+  let previousEmail: string | undefined;
 
   if (body.name) {
     updates.name = body.name.slice(0, 255);
@@ -492,15 +515,50 @@ userRoutes.patch('/me', zValidator('json', updateMeSchema), async (c) => {
 
   if (body.email) {
     const normalizedEmail = body.email.toLowerCase().trim().slice(0, 255);
-    // Check uniqueness
-    const [existing] = await db
-      .select({ id: users.id })
-      .from(users)
-      .where(eq(users.email, normalizedEmail))
-      .limit(1);
-    if (existing && existing.id !== auth.user.id) {
-      return c.json({ error: 'Email already in use' }, 409);
+    // self.email is already normalized in the DB; only step-up + notify when the
+    // email is genuinely changing. A same-email "change" is a no-op here.
+    const emailChanging = normalizedEmail !== self.email;
+
+    if (emailChanging) {
+      // Account-takeover step-up — mirror change-password's SSO/password/MFA
+      // ordering, BEFORE any write.
+      // (a) SSO-enforced org: email is managed at the IdP.
+      if (await isPasswordAuthDisabledBySso({ scope: auth.scope, orgId: auth.orgId })) {
+        return c.json({ error: 'Email changes for this organization are managed through your SSO provider.' }, 403);
+      }
+
+      if (self.passwordHash) {
+        // (b) Local-password user: require + verify the current password.
+        if (!body.currentPassword) {
+          return c.json({ error: 'Current password is required to change your email address.' }, 400);
+        }
+        const stepUp = await requireCurrentPasswordStepUp(c, auth.user.id, body.currentPassword, 'email-change:pwd');
+        if (stepUp) return stepUp; // 401 / 429 / 503 Response, or null on success
+        stepUpMethod = 'password';
+      } else {
+        // (c) Passwordless, non-SSO-enforced user: require satisfied MFA.
+        if (!hasSatisfiedMfa(auth)) {
+          return c.json({ error: 'MFA verification is required to change your email address.' }, 403);
+        }
+        stepUpMethod = 'mfa';
+      }
+
+      previousEmail = self.email;
+
+      // Uniqueness check (only matters when the email is actually changing).
+      const [existing] = await db
+        .select({ id: users.id })
+        .from(users)
+        .where(eq(users.email, normalizedEmail))
+        .limit(1);
+      if (existing && existing.id !== auth.user.id) {
+        return c.json({ error: 'Email already in use' }, 409);
+      }
     }
+
+    // Always include the (normalized) email in the write. When it's unchanged
+    // this is a harmless no-op that keeps a same-email PATCH a valid 200 rather
+    // than a "No valid updates provided" 400, and it requires no step-up.
     updates.email = normalizedEmail;
   }
 
@@ -547,6 +605,38 @@ userRoutes.patch('/me', zValidator('json', updateMeSchema), async (c) => {
     userAgent: c.req.header('user-agent'),
     result: 'success'
   });
+
+  // Dedicated email-change audit + security notification to the OLD address.
+  // Only fires on a genuine, step-up-cleared email change (previousEmail set).
+  if (previousEmail !== undefined) {
+    createAuditLogAsync({
+      orgId: auditOrgId,
+      actorId: auth.user.id,
+      actorEmail: auth.user.email,
+      action: 'user.email.change',
+      resourceType: 'user',
+      resourceId: updated.id,
+      resourceName: updated.name,
+      details: {
+        previousEmail,
+        newEmail: updated.email,
+        stepUp: stepUpMethod
+      },
+      ipAddress: getTrustedClientIpOrUndefined(c),
+      userAgent: c.req.header('user-agent'),
+      result: 'success'
+    });
+
+    // Notify the OLD address (best-effort: must never block or fail the request).
+    const emailService = getEmailService();
+    if (emailService) {
+      try {
+        await emailService.sendEmailChanged({ to: previousEmail, name: updated.name, newEmail: updated.email });
+      } catch (err) {
+        console.warn('Failed to send email-change notice', err);
+      }
+    }
+  }
 
   return c.json(updated);
 });

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -20,7 +20,7 @@ import { getTrustedClientIpOrUndefined } from '../services/clientIp';
 import { getEmailService } from '../services/email';
 import { getRedis } from '../services';
 import { INVITE_TOKEN_TTL_SECONDS } from './auth/schemas';
-import { hashInviteToken, inviteRedisKey, inviteUserRedisKey, userRequiresSetup } from './auth/helpers';
+import { hashInviteToken, inviteRedisKey, inviteUserRedisKey, resolveUserAuditOrgId, userRequiresSetup } from './auth/helpers';
 import { revokeUserAccess } from '../services/userSuspension';
 import { revokeAllUserTokens } from '../services/tokenRevocation';
 
@@ -526,23 +526,27 @@ userRoutes.patch('/me', zValidator('json', updateMeSchema), async (c) => {
     return c.json({ error: 'Failed to update profile' }, 500);
   }
 
-  if (auth.orgId) {
-    createAuditLogAsync({
-      orgId: auth.orgId,
-      actorId: auth.user.id,
-      actorEmail: auth.user.email,
-      action: 'user.profile.update',
-      resourceType: 'user',
-      resourceId: updated.id,
-      resourceName: updated.name,
-      details: {
-        changedFields: Object.keys(updates).filter((key) => key !== 'updatedAt')
-      },
-      ipAddress: getTrustedClientIpOrUndefined(c),
-      userAgent: c.req.header('user-agent'),
-      result: 'success'
-    });
-  }
+  // Every successful self-profile change MUST be audited regardless of caller
+  // scope (SOC2 coverage). Partner-scope callers have auth.orgId === null, so
+  // resolve an attribution org from the user's membership — mirrors the
+  // POST /auth/change-password handler. createAuditLogAsync + persistAuditLog
+  // accept a null orgId, so a null resolution still produces an audit row.
+  const auditOrgId = auth.orgId ?? await resolveUserAuditOrgId(auth.user.id);
+  createAuditLogAsync({
+    orgId: auditOrgId,
+    actorId: auth.user.id,
+    actorEmail: auth.user.email,
+    action: 'user.profile.update',
+    resourceType: 'user',
+    resourceId: updated.id,
+    resourceName: updated.name,
+    details: {
+      changedFields: Object.keys(updates).filter((key) => key !== 'updatedAt')
+    },
+    ipAddress: getTrustedClientIpOrUndefined(c),
+    userAgent: c.req.header('user-agent'),
+    result: 'success'
+  });
 
   return c.json(updated);
 });

--- a/apps/api/src/services/email.test.ts
+++ b/apps/api/src/services/email.test.ts
@@ -203,6 +203,58 @@ describe('email service', () => {
     expect(body.getAll('h:Reply-To')).toEqual(['support@example.com', 'help@example.com']);
   });
 
+  it('sendEmailChanged notifies the old address with a security notice', async () => {
+    process.env.EMAIL_PROVIDER = 'smtp';
+    process.env.SMTP_HOST = 'smtp.example.com';
+    process.env.SMTP_FROM = 'smtp-from@example.com';
+
+    const { getEmailService } = await import('./email');
+    const service = getEmailService();
+
+    expect(service).not.toBeNull();
+    await service!.sendEmailChanged({
+      to: 'old@example.com',
+      name: 'Jane Operator',
+      newEmail: 'new@example.com'
+    });
+
+    expect(smtpSendMailMock).toHaveBeenCalledTimes(1);
+    const sent = smtpSendMailMock.mock.calls[0]![0] as {
+      to: string;
+      subject: string;
+      html: string;
+      text: string;
+    };
+    expect(sent.to).toBe('old@example.com');
+    expect(sent.subject).toMatch(/email was changed/i);
+    // The new address appears in both HTML and text bodies.
+    expect(sent.html).toContain('new@example.com');
+    expect(sent.text).toContain('new@example.com');
+    // Security-notice tone: tells the user what to do if it wasn't them.
+    expect(sent.text).toMatch(/did not make this change/i);
+    expect(sent.html).toMatch(/did not make this change/i);
+  });
+
+  it('sendEmailChanged tolerates a null name', async () => {
+    process.env.EMAIL_PROVIDER = 'smtp';
+    process.env.SMTP_HOST = 'smtp.example.com';
+    process.env.SMTP_FROM = 'smtp-from@example.com';
+
+    const { getEmailService } = await import('./email');
+    const service = getEmailService();
+
+    await service!.sendEmailChanged({
+      to: 'old@example.com',
+      name: null,
+      newEmail: 'new@example.com'
+    });
+
+    expect(smtpSendMailMock).toHaveBeenCalledTimes(1);
+    const sent = smtpSendMailMock.mock.calls[0]![0] as { text: string };
+    // Falls back to the generic greeting rather than crashing on null.
+    expect(sent.text).toContain('Hi there,');
+  });
+
   it('falls back to Mailgun in auto mode when resend and smtp are not configured', async () => {
     process.env.MAILGUN_API_KEY = 'mg-key-123';
     process.env.MAILGUN_DOMAIN = 'mg.example.com';

--- a/apps/api/src/services/email.ts
+++ b/apps/api/src/services/email.ts
@@ -54,6 +54,13 @@ export interface AccountLockedEmailParams {
   supportEmail?: string;
 }
 
+export interface EmailChangedEmailParams {
+  to: string | string[];
+  name?: string | null;
+  newEmail: string;
+  supportEmail?: string;
+}
+
 export type AlertSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
 
 export interface AlertNotificationEmailParams {
@@ -232,6 +239,16 @@ export class EmailService {
 
   async sendAccountLocked(params: AccountLockedEmailParams): Promise<void> {
     const template = buildAccountLockedTemplate(params);
+    await this.sendEmail({
+      to: params.to,
+      subject: template.subject,
+      html: template.html,
+      text: template.text
+    });
+  }
+
+  async sendEmailChanged(params: EmailChangedEmailParams): Promise<void> {
+    const template = buildEmailChangedTemplate(params);
     await this.sendEmail({
       to: params.to,
       subject: template.subject,
@@ -673,6 +690,36 @@ function buildAccountLockedTemplate(params: AccountLockedEmailParams): EmailTemp
     `Reset your password: ${params.resetUrl}`,
     "If this wasn't you, someone may be trying to guess your password. Reset your password immediately and review recent activity.",
     support ? `Need help? Contact ${support}.` : null,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  return { subject, html, text };
+}
+
+function buildEmailChangedTemplate(params: EmailChangedEmailParams): EmailTemplate {
+  const name = params.name?.trim() || 'there';
+  const subject = 'Your Breeze account email was changed';
+  const preheader = `The email on your Breeze account was changed to ${params.newEmail}.`;
+  const body = `
+      <p style="${BODY_PARA}">Hi ${escapeHtml(name)},</p>
+      <p style="${BODY_PARA}">Your Breeze account email was changed to <strong>${escapeHtml(params.newEmail)}</strong>.</p>
+      <p style="${MUTED_PARA}"><strong>If you did not make this change</strong>, your account may be compromised. Contact support immediately to secure it.</p>
+  `;
+  const html = renderLayout({
+    title: subject,
+    preheader,
+    heading: 'Account email changed',
+    body,
+    footer: supportFooter(params.supportEmail, 'If you did not make this change, contact'),
+  });
+
+  const support = getSupportEmail(params.supportEmail);
+  const text = [
+    `Hi ${name},`,
+    `Your Breeze account email was changed to ${params.newEmail}.`,
+    'If you did not make this change, your account may be compromised. Contact support immediately to secure it.',
+    support ? `Contact ${support}.` : null,
   ]
     .filter(Boolean)
     .join('\n');

--- a/apps/web/src/components/setup/AccountSetupStep.tsx
+++ b/apps/web/src/components/setup/AccountSetupStep.tsx
@@ -34,6 +34,13 @@ export default function AccountSetupStep({ onNext }: AccountSetupStepProps) {
       return;
     }
 
+    // Changing the email now requires a step-up: the API re-verifies the
+    // current password on the email change (account-takeover protection).
+    if (email && email !== user?.email && !currentPassword) {
+      setError('Enter your current password to change your email address');
+      return;
+    }
+
     setLoading(true);
 
     try {
@@ -41,7 +48,7 @@ export default function AccountSetupStep({ onNext }: AccountSetupStepProps) {
       if (email && email !== user?.email) {
         const emailRes = await fetchWithAuth('/users/me', {
           method: 'PATCH',
-          body: JSON.stringify({ email })
+          body: JSON.stringify({ email, currentPassword })
         });
         if (!emailRes.ok) {
           const data = await emailRes.json().catch(() => null);
@@ -88,7 +95,10 @@ export default function AccountSetupStep({ onNext }: AccountSetupStepProps) {
   };
 
   const hasChanges = !!(email || (currentPassword && newPassword));
-  const partialPassword = !!(currentPassword ? !newPassword : newPassword);
+  // Only warn about an incomplete password change when a NEW password was
+  // entered without the current one. A current password alone is now valid on
+  // its own (it's the step-up for an email change), so it must not warn here.
+  const partialPassword = !!(newPassword && !currentPassword);
 
   return (
     <div className="space-y-6">
@@ -112,6 +122,11 @@ export default function AccountSetupStep({ onNext }: AccountSetupStepProps) {
             placeholder={user?.email || 'admin@breeze.local'}
             className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
           />
+          {email && email !== user?.email && (
+            <p className="mt-1 text-xs text-muted-foreground">
+              Changing your email requires your current password below.
+            </p>
+          )}
         </div>
 
         <div className="border-t pt-4">


### PR DESCRIPTION
## Summary

Security-hardening batch from the multi-tenant isolation review — confirmed audit-coverage, admin-MFA, and email-change-takeover gaps that sat just below the headline threshold. Independent of #1016 (different files). Each item was re-confirmed against source before fixing; all changes are TDD'd.

## Audit coverage — a state-changing action that wrote no `audit_logs` row

**`PATCH /users/me`** (`routes/users.ts`) — was gated on `if (auth.orgId)`, so **partner-scope** self-changes went unaudited. Now audits every change, resolving the attribution org via `resolveUserAuditOrgId`.

**sensitive-data** (`routes/sensitiveData.ts`) — remediate status-flip (`accept_risk`/`false_positive`/`mark_remediated`), destructive branch (encrypt/quarantine/secure_delete), and policy create/update/delete.

**automation policy `activate`/`deactivate`** (`routes/policyManagement/actions.ts`) — the `enabled` state-flip (siblings already audited).

## MFA step-up (`requireMfa()`)

**`POST /admin/partners/:id/unsuspend`** — matched the asymmetry with `suspend` (which already required MFA).

**third-party-catalog** mutating ops (`create`/`update`/`delete`/`test-trigger`) — gated once at the router level (all-mutating; reads live in `list.ts`).

## Email-change step-up — account-takeover hardening (`PATCH /users/me`)

Changing the account email instantly switched it after only a uniqueness check — **no re-authentication**. Now requires step-up BEFORE the switch, mirroring `change-password`:
- **SSO-enforced orgs** → `403` (email is managed at the IdP)
- **local-password users** → must submit + pass `currentPassword` (rate-limited 5/5min via the existing `requireCurrentPasswordStepUp`)
- **passwordless users** → must have a satisfied-MFA session

Name/avatar/preferences changes are unaffected; a same-email PATCH stays a `200` no-op. Emits a dedicated `user.email.change` audit (`previousEmail`/`newEmail`/`stepUp`) and a best-effort security notice to the **old** address (new `EmailService.sendEmailChanged`).

**Web:** the self-hosted setup wizard (`AccountSetupStep.tsx`) is the only UI caller that sends `email` — now includes `currentPassword` on the email change, validates client-side, and no longer misfires its password-change warning on email-only edits. `ProfilePage.tsx` already keeps email read-only (unchanged).

Scope decisions (with maintainer): **mirror change-password** for the SSO/passwordless path; **step-up + notify-old-address** depth — a full pending-email / new-address verification flow (confirmation token emailed to the new address) is a possible future enhancement, not in this pass.

## Test plan / verification

- API `tsc --noEmit`: clean (0 errors) · web `tsc --noEmit`: clean
- Full API unit suite: **5265 passed** (the occasional `oauthInteraction.test.ts` failure is a pre-existing non-deterministic mock-isolation flake on an untouched file; passes in isolation)
- Touched suites, RED→GREEN per fix: users (29) + email (8) + sensitiveData (10) + policyManagement (10) + abuse/operations (38)

**Status:** all green, ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)