### PR TITLE
fix(api): gate agent telemetry ingest to the agent role (least privilege)

### DIFF
--- a/apps/api/src/middleware/requireAgentRole.test.ts
+++ b/apps/api/src/middleware/requireAgentRole.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Context } from 'hono';
+import { requireAgentRole } from './requireAgentRole';
+
+type TestContext = Context & { _getResponse: () => { status: number; body: unknown } | null };
+
+function createContext(agent?: { role: string } | undefined): TestContext {
+  const store = new Map<string, unknown>();
+  if (agent) store.set('agent', agent);
+  let response: { status: number; body: unknown } | null = null;
+  return {
+    get: (key: string) => store.get(key),
+    set: (key: string, value: unknown) => store.set(key, value),
+    json: (body: unknown, status?: number) => {
+      response = { status: status ?? 200, body };
+      return response;
+    },
+    _getResponse: () => response,
+  } as unknown as TestContext;
+}
+
+describe('requireAgentRole', () => {
+  it('rejects watchdog-role credentials with 403 and does not call next', async () => {
+    const c = createContext({ role: 'watchdog' });
+    const next = vi.fn();
+
+    await requireAgentRole(c, next as any);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(c._getResponse()).toEqual({
+      status: 403,
+      body: { error: 'This endpoint requires the agent credential' },
+    });
+  });
+
+  it('allows agent-role credentials through to next()', async () => {
+    const c = createContext({ role: 'agent' });
+    const next = vi.fn().mockResolvedValue(undefined);
+
+    await requireAgentRole(c, next as any);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(c._getResponse()).toBeNull();
+  });
+
+  it('rejects when no agent context is set (defense-in-depth)', async () => {
+    const c = createContext(undefined);
+    const next = vi.fn();
+
+    await requireAgentRole(c, next as any);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(c._getResponse()?.status).toBe(403);
+  });
+});

--- a/apps/api/src/middleware/requireAgentRole.ts
+++ b/apps/api/src/middleware/requireAgentRole.ts
@@ -1,0 +1,21 @@
+import type { Context, Next } from 'hono';
+
+/**
+ * requireAgentRole rejects requests authenticated with a non-agent credential
+ * (e.g. the watchdog token). Apply to telemetry/state-ingest routes that only
+ * the main agent should write: the watchdog's least privilege is monitoring +
+ * heartbeat, not fleet telemetry (inventory, sessions, state, elevation).
+ *
+ * Runs after agentAuthMiddleware, which sets `agent` on the context (the
+ * `agent: AgentAuthContext` ContextVariableMap augmentation lives in
+ * middleware/agentAuth.ts). This module is intentionally dependency-free (only
+ * hono types) so route modules can import it without pulling the agent-auth /
+ * services dependency graph into their unit-test mocks.
+ */
+export async function requireAgentRole(c: Context, next: Next) {
+  const agent = c.get('agent');
+  if (!agent || agent.role !== 'agent') {
+    return c.json({ error: 'This endpoint requires the agent credential' }, 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/agents/elevationRequests.ts
+++ b/apps/api/src/routes/agents/elevationRequests.ts
@@ -9,6 +9,7 @@ import { writeAuditEvent } from '../../services/auditEvents';
 import { getRedis } from '../../services/redis';
 import { rateLimiter } from '../../services/rate-limit';
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
+import { requireAgentRole } from '../../middleware/requireAgentRole';
 
 // PAM Track 3: agent-side endpoint that records UAC consent.exe observations
 // as `elevation_requests` rows with flow_type='uac_intercept'. Auth is the
@@ -40,6 +41,8 @@ export const elevationRequestSchema = z.object({
 export type ElevationRequestPayload = z.infer<typeof elevationRequestSchema>;
 
 export const elevationRequestsRoutes = new Hono();
+// Elevation-request ingest is the main agent's job; reject watchdog tokens.
+elevationRequestsRoutes.use('*', requireAgentRole);
 
 elevationRequestsRoutes.post(
   '/:id/elevation-requests',

--- a/apps/api/src/routes/agents/inventory.ts
+++ b/apps/api/src/routes/agents/inventory.ts
@@ -19,8 +19,11 @@ import {
 } from './schemas';
 import { sanitizeDate } from './helpers';
 import { upsertAgentWarranty } from '../../services/warrantySync';
+import { requireAgentRole } from '../../middleware/requireAgentRole';
 
 export const inventoryRoutes = new Hono();
+// Inventory ingest is the main agent's job; reject watchdog-role tokens.
+inventoryRoutes.use('*', requireAgentRole);
 
 inventoryRoutes.put('/:id/hardware', bodyLimit({ maxSize: 5 * 1024 * 1024, onError: (c) => c.json({ error: 'Request body too large' }, 413) }), zValidator('json', updateHardwareSchema), async (c) => {
   const agentId = c.req.param('id');

--- a/apps/api/src/routes/agents/sessions.ts
+++ b/apps/api/src/routes/agents/sessions.ts
@@ -7,8 +7,11 @@ import { writeAuditEvent } from '../../services/auditEvents';
 import { publishEvent } from '../../services/eventBus';
 import { submitSessionsSchema } from './schemas';
 import { sanitizeTimestamp } from './helpers';
+import { requireAgentRole } from '../../middleware/requireAgentRole';
 
 export const sessionsRoutes = new Hono();
+// Session ingest is the main agent's job; reject watchdog-role tokens.
+sessionsRoutes.use('*', requireAgentRole);
 
 function getSessionIdentityKey(input: {
   username: string;

--- a/apps/api/src/routes/agents/state.test.ts
+++ b/apps/api/src/routes/agents/state.test.ts
@@ -62,6 +62,18 @@ describe('state routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     app = new Hono();
+    // Simulate agentAuthMiddleware: requireAgentRole (now on stateRoutes)
+    // rejects requests without an agent-role context.
+    app.use('*', async (c, next) => {
+      c.set('agent', {
+        deviceId: DEVICE_ID,
+        agentId: AGENT_ID,
+        orgId: 'org-1',
+        siteId: 'site-1',
+        role: 'agent',
+      } as any);
+      return next();
+    });
     app.route('/agents', stateRoutes);
   });
 

--- a/apps/api/src/routes/agents/state.ts
+++ b/apps/api/src/routes/agents/state.ts
@@ -10,8 +10,11 @@ import {
 import { updateRegistryStateSchema, updateConfigStateSchema } from './schemas';
 import { normalizeStateValue, parseDate } from './helpers';
 import { sanitizePolicyConfigStateEntries } from './policyProbeSafety';
+import { requireAgentRole } from '../../middleware/requireAgentRole';
 
 export const stateRoutes = new Hono();
+// Registry/config state ingest is the main agent's job; reject watchdog tokens.
+stateRoutes.use('*', requireAgentRole);
 
 stateRoutes.put('/:id/registry-state', zValidator('json', updateRegistryStateSchema), async (c) => {
   const agentId = c.req.param('id');


### PR DESCRIPTION
Least-privilege hardening: the device telemetry/state-ingest endpoints accepted writes from **any** device credential, including the watchdog-role token — whose job is monitoring + heartbeat, not fleet telemetry. A watchdog token could write inventory / sessions / elevation / state for its device.

## Change
- New dependency-free `requireAgentRole` guard (rejects non-agent credentials with `403`).
- Applied to all four ingest route groups: `inventory`, `state`, `sessions`, `elevationRequests`.
- Kept the guard in its own module (hono types only) so route units don't pull the agent-auth/services dependency graph into their mocks.

## Notes
- Defense-in-depth / least-privilege (LOW severity): both the agent and watchdog tokens live in root-only `secrets.yaml`, so the watchdog token isn't independently obtainable — this closes the gap regardless.
- The watchdog's legitimate paths (`/heartbeat`, role-scoped commands) are untouched.

## Test plan
`pnpm --filter @breeze/api test agentAuth requireAgentRole state elevationRequests` — guard unit tests (watchdog→403, agent→next, no-context→403); `state.test.ts` updated to supply the agent-role context the guard now requires; full agentAuth + affected route suites green; `tsc --noEmit` clean for touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)