### PR TITLE
fix(api): harden third-party integration egress against SSRF (Huntress, DNS, M365, SentinelOne)

### DIFF
--- a/apps/api/migrations/2026-05-31-c2c-tenant-id-guid-check.sql
+++ b/apps/api/migrations/2026-05-31-c2c-tenant-id-guid-check.sql
@@ -1,0 +1,28 @@
+-- Defense-in-depth CHECK on c2c_connections.tenant_id, mirroring the
+-- createConnectionSchema superRefine (apps/api/src/routes/c2c/schemas.ts) and
+-- M365_TENANT_ID_REGEX (apps/api/src/services/c2cM365.ts).
+--
+-- tenant_id is varchar(100), NULLABLE, and SHARED across providers:
+-- google_workspace (and future providers) legitimately store non-GUID values,
+-- so the constraint is provider-conditional (only microsoft_365) and allows
+-- NULL. The GUID match is case-insensitive (~*) to mirror the app-layer regex.
+--
+-- Added NOT VALID so existing (grandfathered) rows are not retroactively
+-- rejected — a dev/prod DB may already hold legacy non-GUID microsoft_365 rows,
+-- and a validated ADD would crash autoMigrate. NOT VALID still enforces the
+-- predicate on every future INSERT/UPDATE, which is the trust boundary we care
+-- about. Idempotent via a pg_constraint existence guard (re-apply = no-op).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'c2c_connections_m365_tenant_guid_chk'
+  ) THEN
+    ALTER TABLE c2c_connections
+      ADD CONSTRAINT c2c_connections_m365_tenant_guid_chk
+      CHECK (
+        provider <> 'microsoft_365'
+        OR tenant_id IS NULL
+        OR tenant_id ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+      ) NOT VALID;
+  END IF;
+END $$;

--- a/apps/api/src/db/migration-c2c-tenant-guid.test.ts
+++ b/apps/api/src/db/migration-c2c-tenant-guid.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { M365_TENANT_ID_REGEX } from '../services/c2cM365';
+
+/**
+ * Migration ↔ regex parity.
+ *
+ * The DB-side defense-in-depth CHECK in
+ * `migrations/2026-05-31-c2c-tenant-id-guid-check.sql` embeds a GUID pattern
+ * that MUST stay in lock-step with the app-layer `M365_TENANT_ID_REGEX`
+ * (apps/api/src/services/c2cM365.ts). If one drifts, the database and the
+ * application would silently disagree about what a valid tenant id is.
+ *
+ * The SQL uses the case-insensitive `~*` operator, so its `[0-9a-f]` classes
+ * are equivalent to the TS regex's `[0-9a-fA-F]` classes — the two patterns are
+ * the same set. This test fails the moment either side drifts.
+ */
+describe('c2c tenant-id GUID CHECK migration parity', () => {
+  const migrationPath = join(
+    __dirname,
+    '../../migrations/2026-05-31-c2c-tenant-id-guid-check.sql'
+  );
+  const sql = readFileSync(migrationPath, 'utf8');
+
+  const SQL_PATTERN =
+    "tenant_id ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'";
+
+  it('embeds the case-insensitive GUID CHECK pattern verbatim', () => {
+    expect(sql).toContain(SQL_PATTERN);
+  });
+
+  it('keeps M365_TENANT_ID_REGEX in sync with the SQL pattern', () => {
+    expect(M365_TENANT_ID_REGEX.source).toBe(
+      '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+    );
+  });
+});

--- a/apps/api/src/jobs/dnsSyncJob.test.ts
+++ b/apps/api/src/jobs/dnsSyncJob.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { runSequentialDomainMutations } from './dnsSyncJob';
+import { runSequentialDomainMutations, tenantVisibleSyncError } from './dnsSyncJob';
+import { DnsProviderHttpError } from '../services/dnsProviders';
 
 describe('runSequentialDomainMutations (issue #827 — policy-sync rule clobbering)', () => {
   it('runs domain mutations one at a time, never concurrently', async () => {
@@ -71,5 +72,61 @@ describe('runSequentialDomainMutations (issue #827 — policy-sync rule clobberi
 
     // Sequential execution means the failure halts before later domains run.
     expect(processed).toEqual(['ok1.com']);
+  });
+});
+
+describe('tenantVisibleSyncError — no upstream body in stored sync error (SSRF read oracle)', () => {
+  it('stores only the HTTP status line for a DnsProviderHttpError, never the upstream body', () => {
+    const error = new DnsProviderHttpError(
+      502,
+      'Bad Gateway',
+      'SECRET_INTERNAL_BODY_MARKER leaked from an upstream public host'
+    );
+
+    const stored = tenantVisibleSyncError(error);
+
+    // The value persisted to lastSyncError / syncError is the body-free status line.
+    expect(stored).toMatch(/HTTP \d{3}/);
+    expect(stored).toBe('HTTP 502 Bad Gateway');
+    // SECURITY: the upstream response body (the partial-read oracle) must NOT
+    // appear in the tenant-visible column.
+    expect(stored).not.toContain('SECRET_INTERNAL_BODY_MARKER');
+    // ...and certainly not the raw responseBody field verbatim.
+    expect(stored).not.toContain(error.responseBody);
+  });
+
+  it('stores the body-free message for an invalid-JSON DnsProviderHttpError', () => {
+    const error = new DnsProviderHttpError(
+      200,
+      'OK',
+      'not json SECRET_INTERNAL_BODY_MARKER',
+      'Provider returned invalid JSON payload'
+    );
+
+    const stored = tenantVisibleSyncError(error);
+
+    expect(stored).toBe('Provider returned invalid JSON payload');
+    expect(stored).not.toContain('SECRET_INTERNAL_BODY_MARKER');
+  });
+
+  it('redacts secrets from a non-HTTP (transport) error message', () => {
+    // Transport/SSRF errors carry no upstream body, but a Pi-hole URL can carry
+    // ?auth=<apiKey> in a fetch error message — must still be redacted.
+    const stored = tenantVisibleSyncError(
+      new Error('connect failed for https://pihole.local/admin/api.php?auth=SUPERSECRETKEY')
+    );
+
+    expect(stored).not.toContain('SUPERSECRETKEY');
+    expect(stored).toContain('[REDACTED]');
+  });
+
+  it('caps the stored value at 2000 chars', () => {
+    const stored = tenantVisibleSyncError(new Error('x'.repeat(5000)));
+    expect(stored.length).toBe(2000);
+  });
+
+  it('handles non-Error throwables without leaking', () => {
+    expect(tenantVisibleSyncError('plain string failure')).toBe('plain string failure');
+    expect(tenantVisibleSyncError(undefined)).toBe('undefined');
   });
 });

--- a/apps/api/src/jobs/dnsSyncJob.ts
+++ b/apps/api/src/jobs/dnsSyncJob.ts
@@ -16,7 +16,7 @@ import {
   type DnsPolicyDomain,
   type DnsThreatCategory
 } from '../db/schema';
-import { createDnsProvider, type DnsEvent } from '../services/dnsProviders';
+import { createDnsProvider, DnsProviderHttpError, type DnsEvent } from '../services/dnsProviders';
 import { getBullMQConnection } from '../services/redis';
 import { isReusableState } from '../services/bullmqUtils';
 import { decryptForColumn } from '../services/secretCrypto';
@@ -85,6 +85,64 @@ export function getDnsSyncQueue(): Queue<DnsSyncJobData> {
     });
   }
   return dnsSyncQueue;
+}
+
+/** Max length persisted to a tenant-visible sync-error column. */
+const SYNC_ERROR_MAX_LENGTH = 2000;
+
+/**
+ * Build the message to persist in a tenant-visible sync-error column
+ * (`dns_filter_integrations.lastSyncError` / `dns_policies.syncError`).
+ *
+ * SECURITY: For a {@link DnsProviderHttpError} we store ONLY the body-free
+ * `.message` (the `HTTP <status> <statusText>` status line). The upstream
+ * response body lives on `.responseBody` and is logged server-side by the
+ * caller — never returned to the tenant, because for self-hosted Pi-hole/AdGuard
+ * the tenant controls the endpoint host and an echoed body would be a
+ * partial-read oracle for arbitrary public hosts. Other error types
+ * (transport/SSRF/config) carry no upstream body, so their message is safe to
+ * store. `redactLogMessage` is still applied as defense-in-depth (e.g. a
+ * Pi-hole error could echo back the `?auth=<apiKey>` secret).
+ */
+export function tenantVisibleSyncError(error: unknown): string {
+  const message =
+    error instanceof DnsProviderHttpError
+      ? error.message // "HTTP <status> <statusText>", body-free by construction
+      : error instanceof Error
+        ? error.message
+        : String(error);
+  return redactLogMessage(message).slice(0, SYNC_ERROR_MAX_LENGTH);
+}
+
+/**
+ * Log full failure detail to the SERVER-SIDE log only. For an upstream HTTP
+ * error this includes the (redacted) response body that we deliberately keep
+ * out of the tenant-visible column.
+ */
+function logSyncFailureServerSide(
+  context: Record<string, unknown>,
+  error: unknown
+): void {
+  if (error instanceof DnsProviderHttpError) {
+    console.error(
+      '[DnsSyncJob] sync failed (upstream HTTP error)',
+      JSON.stringify({
+        ...context,
+        status: error.status,
+        statusText: error.statusText,
+        // Redacted: a Pi-hole upstream body can echo back `?auth=<apiKey>`.
+        responseBody: redactLogMessage(error.responseBody),
+      })
+    );
+    return;
+  }
+  console.error(
+    '[DnsSyncJob] sync failed',
+    JSON.stringify({
+      ...context,
+      error: redactLogMessage(error instanceof Error ? error.message : String(error)),
+    })
+  );
 }
 
 function parseIntegrationConfig(value: unknown): DnsIntegrationConfig {
@@ -576,15 +634,18 @@ async function processSyncIntegration(data: SyncIntegrationJobData): Promise<{
       inserted: insertedCount
     };
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    // Redact before persisting. Pi-hole puts the API key in the URL query
-    // string (?auth=<key>); a Node fetch error whose .cause echoes the URL
-    // would otherwise land in dnsFilterIntegrations.lastSyncError verbatim.
+    // Full detail (including the upstream response body, redacted) goes to the
+    // SERVER-SIDE log only.
+    logSyncFailureServerSide({ integrationId: integration.id, orgId: integration.orgId }, error);
+    // Store ONLY a body-free, redacted message in the tenant-visible column.
+    // Pi-hole puts the API key in the URL query string (?auth=<key>) and an
+    // upstream body could echo arbitrary public-host content (SSRF read
+    // oracle) — neither may land in dnsFilterIntegrations.lastSyncError.
     await db
       .update(dnsFilterIntegrations)
       .set({
         lastSyncStatus: 'error',
-        lastSyncError: redactLogMessage(message).slice(0, 2000),
+        lastSyncError: tenantVisibleSyncError(error),
         updatedAt: new Date()
       })
       .where(eq(dnsFilterIntegrations.id, integration.id));
@@ -654,12 +715,14 @@ async function processPolicySync(data: SyncPolicyJobData): Promise<{
       removed: removeDomains.length
     };
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    // Full detail (including the upstream response body, redacted) goes to the
+    // SERVER-SIDE log only; the tenant-visible column gets a body-free message.
+    logSyncFailureServerSide({ policyId: row.policy.id, orgId: row.integration.orgId }, error);
     await db
       .update(dnsPolicies)
       .set({
         syncStatus: 'error',
-        syncError: redactLogMessage(message).slice(0, 2000),
+        syncError: tenantVisibleSyncError(error),
         updatedAt: new Date()
       })
       .where(eq(dnsPolicies.id, row.policy.id));

--- a/apps/api/src/jobs/s1Sync.test.ts
+++ b/apps/api/src/jobs/s1Sync.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   applyPollFailure,
   dedupeThreatDetections,
+  logSyncFailureServerSide,
   normalizeSeverity,
   normalizeThreatStatus,
   normalizeS1SiteName,
@@ -11,6 +12,7 @@ import {
   resolveDeviceIdForAgent,
   truncateError
 } from './s1Sync';
+import { SentinelOneHttpError } from '../services/sentinelOne/client';
 
 describe('s1Sync helpers', () => {
   it('deduplicates threat detections by SentinelOne threat ID', () => {
@@ -39,6 +41,54 @@ describe('s1Sync helpers', () => {
     const out = truncateError(new Error('s1 fetch failed: Authorization: Bearer s1_token_secret at /web/api'));
     expect(out).not.toContain('s1_token_secret');
     expect(out).toContain('[REDACTED]');
+  });
+
+  it('truncateError reads only the body-free message of a SentinelOneHttpError', () => {
+    // The persisted lastSyncError column is fed by truncateError, which reads
+    // `.message`. SentinelOneHttpError keeps the upstream body OFF `.message`
+    // (it lives on `.responseBody`), so the tenant-visible column must never
+    // receive the raw upstream body. This pins that invariant: drift in either
+    // the error class or truncateError would leak the body into the DB column.
+    const out = truncateError(
+      new SentinelOneHttpError('GET', '/web/api/v2.1/agents', 401, 'SECRET_UPSTREAM_BODY')
+    );
+    expect(out).toBe('SentinelOne API GET /web/api/v2.1/agents failed (401)');
+    expect(out).not.toContain('SECRET_UPSTREAM_BODY');
+  });
+});
+
+describe('logSyncFailureServerSide', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('logs the status and a redacted responseBody for a SentinelOneHttpError', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    logSyncFailureServerSide(
+      { integrationId: 'int-1', orgId: 'org-1' },
+      new SentinelOneHttpError('GET', '/web/api/v2.1/agents', 500, 'Authorization: Bearer s1_secret')
+    );
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    // The logger calls console.error(label, JSON.stringify({...})). Join the
+    // raw string args of the call so we assert on the actual logged payload
+    // (the inner JSON is already a string — no double-encoding).
+    const logged = spy.mock.calls[0]!.map((arg) => String(arg)).join(' ');
+    expect(logged).toContain('"status":500');
+    // responseBody is redacted server-side even though the server log is
+    // allowed to carry more detail than the persisted column.
+    expect(logged).not.toContain('s1_secret');
+    expect(logged).toContain('[REDACTED]');
+  });
+
+  it('logs a plain Error via the fallback branch without throwing', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() =>
+      logSyncFailureServerSide({ actionId: 'act-1', orgId: 'org-1' }, new Error('boom'))
+    ).not.toThrow();
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 
   it('transitions action polling failures to terminal failure at threshold', () => {

--- a/apps/api/src/jobs/s1Sync.ts
+++ b/apps/api/src/jobs/s1Sync.ts
@@ -13,7 +13,7 @@ import {
 import { getBullMQConnection } from '../services/redis';
 import { isReusableState } from '../services/bullmqUtils';
 import { decryptForColumn } from '../services/secretCrypto';
-import { S1_THREAT_ACTIONS, SentinelOneClient, type S1ThreatAction, type S1ActionStatus } from '../services/sentinelOne/client';
+import { S1_THREAT_ACTIONS, SentinelOneClient, SentinelOneHttpError, type S1ThreatAction, type S1ActionStatus } from '../services/sentinelOne/client';
 import { captureException } from '../services/sentry';
 import { redactLogMessage } from '../services/logRedaction';
 import { publishEvent } from '../services/eventBus';
@@ -130,8 +130,42 @@ export function truncateError(err: unknown): string {
   const message = err instanceof Error ? err.message : String(err);
   // Redact before truncating. S1 bearer tokens go in headers (not URL), but
   // an HTTP error message can still echo back a Cookie or Authorization
-  // header — strip those before persisting to DB.
+  // header — strip those before persisting to DB. For a SentinelOneHttpError
+  // the `.message` is body-free by construction (status line only), so the
+  // upstream response body never reaches the tenant-visible column.
   return redactLogMessage(message).slice(0, 2_000);
+}
+
+/**
+ * Log full failure detail to the SERVER-SIDE log only. For an upstream HTTP
+ * error this includes the (redacted) response body that we deliberately keep
+ * out of the tenant-visible column (`s1_integrations.lastSyncError` /
+ * `s1_actions.error`). The tenant column is written separately via
+ * {@link truncateError}, which reads only the body-free `.message`.
+ */
+export function logSyncFailureServerSide(
+  context: Record<string, unknown>,
+  error: unknown
+): void {
+  if (error instanceof SentinelOneHttpError) {
+    console.error(
+      '[S1SyncJob] sync failed (upstream HTTP error)',
+      JSON.stringify({
+        ...context,
+        status: error.status,
+        // Redacted defense-in-depth: an upstream body could echo back a header.
+        responseBody: redactLogMessage(error.responseBody),
+      })
+    );
+    return;
+  }
+  console.error(
+    '[S1SyncJob] sync failed',
+    JSON.stringify({
+      ...context,
+      error: redactLogMessage(error instanceof Error ? error.message : String(error)),
+    })
+  );
 }
 
 export function dedupeThreatDetections<T extends { s1ThreatId: string }>(rows: T[]): T[] {
@@ -611,6 +645,10 @@ async function processSyncIntegration(data: SyncIntegrationJobData) {
       truncated: wasTruncated
     };
   } catch (error) {
+    // Full detail (including the upstream response body, redacted) goes to the
+    // SERVER-SIDE log only. The tenant-visible column gets a body-free message
+    // via truncateError — a SentinelOneHttpError's `.message` carries no body.
+    logSyncFailureServerSide({ integrationId: integration.id, orgId: integration.orgId }, error);
     try {
       await db
         .update(s1Integrations)
@@ -806,7 +844,10 @@ async function processPollActions() {
         }
       }
     } catch (error) {
-      console.error('[S1SyncJob] Action status polling failed:', error);
+      // Full detail (incl. redacted upstream body) → server-side log only. The
+      // tenant-visible s1_actions.error is set via applyPollFailure →
+      // truncateError, which reads the body-free `.message`.
+      logSyncFailureServerSide({ actionId: action.id, orgId: action.orgId }, error);
       const failure = applyPollFailure(action.payload, error);
       const nextStatus: S1ActionStatus = failure.shouldFail ? 'failed' : 'in_progress';
 

--- a/apps/api/src/routes/c2c/connections.test.ts
+++ b/apps/api/src/routes/c2c/connections.test.ts
@@ -4,6 +4,8 @@ import { connectionsRoutes } from './connections';
 
 const ORG_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
 const CONNECTION_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+// Microsoft 365 tenant ids must be Entra GUIDs (validated by createConnectionSchema).
+const TENANT_GUID = '11111111-1111-1111-1111-111111111111';
 
 vi.mock('../../services', () => ({}));
 
@@ -75,6 +77,10 @@ vi.mock('../../services/auditEvents', () => ({
 
 vi.mock('../../services/c2cM365', () => ({
   ensureFreshToken: (...args: unknown[]) => ensureFreshTokenMock(...(args as [])),
+  // createConnectionSchema (in ./schemas) imports this regex to validate M365
+  // tenant ids, so the mock must expose the real pattern.
+  M365_TENANT_ID_REGEX:
+    /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/,
 }));
 
 vi.mock('../../services/secretCrypto', () => ({
@@ -113,7 +119,7 @@ function makeConnection(overrides: Record<string, unknown> = {}) {
     provider: 'microsoft_365',
     authMethod: 'manual',
     displayName: 'M365 Tenant',
-    tenantId: 'tenant-1',
+    tenantId: TENANT_GUID,
     clientId: 'client-id-1234567890',
     clientSecret: 'super-secret',
     refreshToken: null,
@@ -172,7 +178,7 @@ describe('c2c connection routes', () => {
       body: JSON.stringify({
         provider: 'microsoft_365',
         displayName: 'M365 Tenant',
-        tenantId: 'tenant-1',
+        tenantId: TENANT_GUID,
         clientId: 'client-id-1234567890',
         clientSecret: 'super-secret',
         scopes: 'mail calendar',
@@ -200,7 +206,7 @@ describe('c2c connection routes', () => {
       body: JSON.stringify({
         provider: 'microsoft_365',
         displayName: 'M365 Tenant',
-        tenantId: 'tenant-1',
+        tenantId: TENANT_GUID,
         clientId: 'client-id-1234567890',
         clientSecret: 'super-secret',
       }),
@@ -215,7 +221,7 @@ describe('c2c connection routes', () => {
       body: JSON.stringify({
         provider: 'microsoft_365',
         displayName: 'M365 Tenant',
-        tenantId: 'tenant-1',
+        tenantId: TENANT_GUID,
         clientId: 'client-id-1234567890',
         clientSecret: 'super-secret',
       }),

--- a/apps/api/src/routes/c2c/m365Auth.test.ts
+++ b/apps/api/src/routes/c2c/m365Auth.test.ts
@@ -5,6 +5,8 @@ import { m365AuthRoutes, m365CallbackRoute } from './m365Auth';
 
 const ORG_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
 const CONNECTION_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+// Entra tenant ids are GUIDs; the callback now rejects anything else.
+const TENANT_GUID = '11111111-1111-1111-1111-111111111111';
 
 function chainMock(resolvedValue: unknown = []) {
   const chain: Record<string, any> = {};
@@ -100,6 +102,10 @@ vi.mock('../../services/c2cM365', () => ({
   getFrontendBaseUrl: (...args: unknown[]) => getFrontendBaseUrlMock(...(args as [])),
   acquireClientCredentialsToken: (...args: unknown[]) => acquireClientCredentialsTokenMock(...(args as [])),
   testGraphAccess: (...args: unknown[]) => testGraphAccessMock(...(args as [])),
+  // The callback validates the tenant query param against this regex, so the
+  // mock must expose the real pattern rather than a stub.
+  M365_TENANT_ID_REGEX:
+    /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/,
 }));
 
 vi.mock('../../middleware/auth', () => ({
@@ -144,7 +150,7 @@ function makeConnection(overrides: Record<string, unknown> = {}) {
     provider: 'microsoft_365',
     authMethod: 'platform_app',
     displayName: 'Microsoft 365 - Contoso',
-    tenantId: 'tenant-1',
+    tenantId: TENANT_GUID,
     clientId: null,
     clientSecret: null,
     accessToken: 'enc:old-token',
@@ -230,7 +236,7 @@ describe('m365 auth routes', () => {
   });
 
   it('rejects callback requests without the binding cookie', async () => {
-    const res = await callbackApp.request('/api/v1/c2c/m365/callback?state=test-state&tenant=tenant-1&admin_consent=True');
+    const res = await callbackApp.request(`/api/v1/c2c/m365/callback?state=test-state&tenant=${TENANT_GUID}&admin_consent=True`);
 
     expect(res.status).toBe(302);
     expect(res.headers.get('location')).toContain('c2c_error=Invalid%20or%20expired%20consent%20session');
@@ -261,7 +267,7 @@ describe('m365 auth routes', () => {
       expiresIn: 3600,
     });
 
-    const callbackRes = await callbackApp.request(`/api/v1/c2c/m365/callback?state=${consentState}&tenant=tenant-1&admin_consent=True`, {
+    const callbackRes = await callbackApp.request(`/api/v1/c2c/m365/callback?state=${consentState}&tenant=${TENANT_GUID}&admin_consent=True`, {
       method: 'GET',
       headers: { Cookie: cookie ?? '' },
     });
@@ -273,5 +279,72 @@ describe('m365 auth routes', () => {
     expect(updateValues.scopes).toContain('token_scope=https://graph.microsoft.com/.default');
     expect(updateValues.scopes).toContain('requested_display_scopes=Mail.Read');
     expect(updateValues.scopes).toContain('actual_grants=Entra admin-consented application permissions');
+  });
+
+  it('rejects a callback whose tenant is not an Entra GUID before fetching a token', async () => {
+    const consentState = 'state-bad-tenant';
+    const cookieValue = createHmac('sha256', 'platform-secret')
+      .update(`c2c-m365-consent:${consentState}`)
+      .digest('hex');
+    const cookie = `breeze_c2c_m365_consent=${encodeURIComponent(cookieValue)}`;
+
+    deleteMock.mockReturnValueOnce(chainMock([{
+      orgId: ORG_ID,
+      userId: 'user-123',
+      state: consentState,
+      provider: 'microsoft_365',
+      displayName: 'Contoso',
+      scopes: 'Mail.Read',
+      expiresAt: new Date(Date.now() + 60_000),
+    }]));
+
+    const callbackRes = await callbackApp.request(`/api/v1/c2c/m365/callback?state=${consentState}&tenant=not-a-guid&admin_consent=True`, {
+      method: 'GET',
+      headers: { Cookie: cookie },
+    });
+
+    expect(callbackRes.status).toBe(302);
+    expect(callbackRes.headers.get('location')).toContain('c2c_error=Invalid%20tenant%20identifier');
+    // The malformed tenant must never reach token acquisition or persistence.
+    expect(acquireClientCredentialsTokenMock).not.toHaveBeenCalled();
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts a valid Entra GUID tenant and creates a new connection', async () => {
+    const consentState = 'state-good-tenant';
+    const cookieValue = createHmac('sha256', 'platform-secret')
+      .update(`c2c-m365-consent:${consentState}`)
+      .digest('hex');
+    const cookie = `breeze_c2c_m365_consent=${encodeURIComponent(cookieValue)}`;
+
+    deleteMock.mockReturnValueOnce(chainMock([{
+      orgId: ORG_ID,
+      userId: 'user-123',
+      state: consentState,
+      provider: 'microsoft_365',
+      displayName: 'Contoso',
+      scopes: 'Mail.Read',
+      expiresAt: new Date(Date.now() + 60_000),
+    }]));
+    // No existing connection — exercise the insert path.
+    selectMock.mockReturnValueOnce(chainMock([]));
+    insertMock.mockReturnValueOnce(chainMock([makeConnection()]));
+    acquireClientCredentialsTokenMock.mockResolvedValueOnce({
+      accessToken: 'fresh-access-token',
+      expiresIn: 3600,
+    });
+
+    const callbackRes = await callbackApp.request(`/api/v1/c2c/m365/callback?state=${consentState}&tenant=${TENANT_GUID}&admin_consent=True`, {
+      method: 'GET',
+      headers: { Cookie: cookie },
+    });
+
+    expect(callbackRes.status).toBe(302);
+    expect(callbackRes.headers.get('location')).toContain(`c2c_connected=true&connectionId=${CONNECTION_ID}`);
+    expect(acquireClientCredentialsTokenMock).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: TENANT_GUID })
+    );
+    expect(insertMock).toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/c2c/m365Auth.test.ts
+++ b/apps/api/src/routes/c2c/m365Auth.test.ts
@@ -102,8 +102,11 @@ vi.mock('../../services/c2cM365', () => ({
   getFrontendBaseUrl: (...args: unknown[]) => getFrontendBaseUrlMock(...(args as [])),
   acquireClientCredentialsToken: (...args: unknown[]) => acquireClientCredentialsTokenMock(...(args as [])),
   testGraphAccess: (...args: unknown[]) => testGraphAccessMock(...(args as [])),
-  // The callback validates the tenant query param against this regex, so the
-  // mock must expose the real pattern rather than a stub.
+  // The callback validates the tenant query param via isM365TenantId, so the
+  // mock must apply the real GUID pattern rather than a stub.
+  isM365TenantId: (x: string) =>
+    /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(x),
+  // Retained because schemas.ts (imported transitively) still reads the regex.
   M365_TENANT_ID_REGEX:
     /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/,
 }));

--- a/apps/api/src/routes/c2c/m365Auth.ts
+++ b/apps/api/src/routes/c2c/m365Auth.ts
@@ -14,7 +14,7 @@ import {
   getFrontendBaseUrl,
   acquireClientCredentialsToken,
   testGraphAccess,
-  M365_TENANT_ID_REGEX,
+  isM365TenantId,
 } from '../../services/c2cM365';
 import { resolveScopedOrgId } from './helpers';
 import { getCookieValue } from '../auth/helpers';
@@ -224,8 +224,10 @@ m365CallbackRoute.get('/c2c/m365/callback', async (c) => {
   }
 
   // Microsoft returns the concrete Entra tenant GUID here; reject anything that
-  // doesn't match before it flows into token acquisition or storage.
-  if (!M365_TENANT_ID_REGEX.test(tenantId)) {
+  // doesn't match before it flows into token acquisition or storage. The guard
+  // narrows `tenantId` to the branded `M365TenantId` for the rest of the
+  // handler, so it flows into acquireClientCredentialsToken without a cast.
+  if (!isM365TenantId(tenantId)) {
     console.warn('[c2c/m365/callback] Rejected non-GUID tenant in callback', { orgId: session.orgId });
     clearCookie();
     return c.redirect(`${frontendBase}/c2c?c2c_error=${encodeURIComponent('Invalid tenant identifier')}`);

--- a/apps/api/src/routes/c2c/m365Auth.ts
+++ b/apps/api/src/routes/c2c/m365Auth.ts
@@ -14,6 +14,7 @@ import {
   getFrontendBaseUrl,
   acquireClientCredentialsToken,
   testGraphAccess,
+  M365_TENANT_ID_REGEX,
 } from '../../services/c2cM365';
 import { resolveScopedOrgId } from './helpers';
 import { getCookieValue } from '../auth/helpers';
@@ -220,6 +221,14 @@ m365CallbackRoute.get('/c2c/m365/callback', async (c) => {
     console.warn('[c2c/m365/callback] Admin consent not granted', { tenantId, adminConsent, orgId: session.orgId });
     clearCookie();
     return c.redirect(`${frontendBase}/c2c?c2c_error=${encodeURIComponent('Admin consent was not granted')}`);
+  }
+
+  // Microsoft returns the concrete Entra tenant GUID here; reject anything that
+  // doesn't match before it flows into token acquisition or storage.
+  if (!M365_TENANT_ID_REGEX.test(tenantId)) {
+    console.warn('[c2c/m365/callback] Rejected non-GUID tenant in callback', { orgId: session.orgId });
+    clearCookie();
+    return c.redirect(`${frontendBase}/c2c?c2c_error=${encodeURIComponent('Invalid tenant identifier')}`);
   }
 
   try {

--- a/apps/api/src/routes/c2c/schemas.test.ts
+++ b/apps/api/src/routes/c2c/schemas.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { createConnectionSchema } from './schemas';
+
+const GUID = '11111111-1111-1111-1111-111111111111';
+
+describe('createConnectionSchema tenantId validation', () => {
+  it('accepts a Microsoft 365 manual connection with a GUID tenantId', () => {
+    const result = createConnectionSchema.safeParse({
+      provider: 'microsoft_365',
+      displayName: 'M365',
+      tenantId: GUID,
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      authMethod: 'manual',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a Microsoft 365 connection with a non-GUID tenantId', () => {
+    const result = createConnectionSchema.safeParse({
+      provider: 'microsoft_365',
+      displayName: 'M365',
+      tenantId: 'not-a-guid',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      authMethod: 'manual',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.includes('tenantId'))).toBe(true);
+    }
+  });
+
+  // tenantId is shared across providers; Google Workspace must not be forced
+  // into the Entra GUID shape.
+  it('allows a non-GUID tenantId for google_workspace', () => {
+    const result = createConnectionSchema.safeParse({
+      provider: 'google_workspace',
+      displayName: 'Workspace',
+      tenantId: 'example.com',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      authMethod: 'manual',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('allows an omitted tenantId for Microsoft 365', () => {
+    const result = createConnectionSchema.safeParse({
+      provider: 'microsoft_365',
+      displayName: 'M365',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      authMethod: 'manual',
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/api/src/routes/c2c/schemas.ts
+++ b/apps/api/src/routes/c2c/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { M365_TENANT_ID_REGEX } from '../../services/c2cM365';
 
 // ── Connection schemas ──────────────────────────────────────────────────────
 
@@ -10,7 +11,7 @@ export const createConnectionSchema = z
   .object({
     provider: z.enum(c2cProviders),
     displayName: z.string().min(1).max(200),
-    tenantId: z.string().max(100).optional(),
+    tenantId: z.string().trim().max(100).optional(),
     clientId: z.string().min(1).max(200).optional(),
     clientSecret: z.string().min(1).optional(),
     scopes: z.string().optional(),
@@ -24,7 +25,23 @@ export const createConnectionSchema = z
       return true;
     },
     { message: 'clientId and clientSecret are required for manual connections' }
-  );
+  )
+  // tenantId is shared across providers; only Microsoft 365 tenant ids are
+  // Entra GUIDs, so enforce the GUID shape only for that provider and leave
+  // google_workspace (and other future providers) free to use their own format.
+  .superRefine((data, ctx) => {
+    if (
+      data.provider === 'microsoft_365' &&
+      data.tenantId !== undefined &&
+      !M365_TENANT_ID_REGEX.test(data.tenantId)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['tenantId'],
+        message: 'tenantId must be an Entra tenant GUID',
+      });
+    }
+  });
 
 export const idParamSchema = z.object({ id: z.string().uuid() });
 

--- a/apps/api/src/routes/sentinelOne.ts
+++ b/apps/api/src/routes/sentinelOne.ts
@@ -20,11 +20,11 @@ import {
 } from '../services/sentinelOne/actions';
 import { escapeLike } from '../utils/sql';
 import { checkSsrfSafe } from '../services/ssrfGuard';
-
 // SentinelOne deploys as managed SaaS only. Per-tenant management consoles
 // use the .sentinelone.net suffix (e.g. usea1-partners.sentinelone.net).
-// Any tenant-supplied URL pointing elsewhere is treated as SSRF.
-const S1_HOSTNAME_ALLOWLIST = ['.sentinelone.net'] as const;
+// Any tenant-supplied URL pointing elsewhere is treated as SSRF. Shared with
+// the client's egress-time re-check so the allowlist has a single source of truth.
+import { S1_HOSTNAME_ALLOWLIST } from '../services/sentinelOne/constants';
 
 export const sentinelOneRoutes = new Hono();
 sentinelOneRoutes.use('*', authMiddleware);

--- a/apps/api/src/services/c2cM365.test.ts
+++ b/apps/api/src/services/c2cM365.test.ts
@@ -6,6 +6,8 @@ vi.mock('./sentry', () => ({
 
 import {
   M365_TENANT_ID_REGEX,
+  type M365TenantId,
+  isM365TenantId,
   acquireClientCredentialsToken,
   ensureFreshToken,
   testGraphAccess,
@@ -32,6 +34,24 @@ describe('M365_TENANT_ID_REGEX', () => {
   });
 });
 
+describe('isM365TenantId', () => {
+  it('accepts (and narrows) a canonical Entra tenant GUID', () => {
+    expect(isM365TenantId('72f988bf-86f1-41af-91ab-2d7cd011db47')).toBe(true);
+  });
+
+  it('rejects the well-known alias `common`', () => {
+    expect(isM365TenantId('common')).toBe(false);
+  });
+
+  it('rejects a malformed value', () => {
+    expect(isM365TenantId('not-a-guid')).toBe(false);
+  });
+
+  it('rejects the empty string', () => {
+    expect(isM365TenantId('')).toBe(false);
+  });
+});
+
 describe('acquireClientCredentialsToken', () => {
   const fetchMock = vi.fn();
 
@@ -47,7 +67,9 @@ describe('acquireClientCredentialsToken', () => {
   it('throws on a non-GUID tenantId before performing any fetch', async () => {
     await expect(
       acquireClientCredentialsToken({
-        tenantId: 'not-a-guid',
+        // Cast to simulate a caller that bypassed validation — proves the
+        // runtime assertion still fails closed even when the brand is forged.
+        tenantId: 'not-a-guid' as M365TenantId,
         clientId: 'client',
         clientSecret: 'secret',
       })
@@ -63,7 +85,7 @@ describe('acquireClientCredentialsToken', () => {
     });
 
     const result = await acquireClientCredentialsToken({
-      tenantId: '11111111-1111-1111-1111-111111111111',
+      tenantId: '11111111-1111-1111-1111-111111111111' as M365TenantId,
       clientId: 'client',
       clientSecret: 'secret',
     });

--- a/apps/api/src/services/c2cM365.test.ts
+++ b/apps/api/src/services/c2cM365.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./sentry', () => ({
+  captureException: vi.fn(),
+}));
+
+import {
+  M365_TENANT_ID_REGEX,
+  acquireClientCredentialsToken,
+  ensureFreshToken,
+  testGraphAccess,
+} from './c2cM365';
+
+
+describe('M365_TENANT_ID_REGEX', () => {
+  it('accepts a canonical Entra tenant GUID', () => {
+    expect(M365_TENANT_ID_REGEX.test('11111111-1111-1111-1111-111111111111')).toBe(true);
+    expect(M365_TENANT_ID_REGEX.test('72f988bf-86f1-41af-91ab-2d7cd011db47')).toBe(true);
+  });
+
+  it('rejects the well-known aliases (invalid for client_credentials)', () => {
+    expect(M365_TENANT_ID_REGEX.test('common')).toBe(false);
+    expect(M365_TENANT_ID_REGEX.test('organizations')).toBe(false);
+    expect(M365_TENANT_ID_REGEX.test('consumers')).toBe(false);
+  });
+
+  it('rejects path-injection / malformed values', () => {
+    expect(M365_TENANT_ID_REGEX.test('not-a-guid')).toBe(false);
+    expect(M365_TENANT_ID_REGEX.test('../../evil')).toBe(false);
+    expect(M365_TENANT_ID_REGEX.test('11111111-1111-1111-1111-111111111111/extra')).toBe(false);
+    expect(M365_TENANT_ID_REGEX.test('')).toBe(false);
+  });
+});
+
+describe('acquireClientCredentialsToken', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('throws on a non-GUID tenantId before performing any fetch', async () => {
+    await expect(
+      acquireClientCredentialsToken({
+        tenantId: 'not-a-guid',
+        clientId: 'client',
+        clientSecret: 'secret',
+      })
+    ).rejects.toThrow('Invalid M365 tenant id');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses to follow redirects on the token fetch for a valid tenant', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: 'tok', expires_in: 3600 }),
+    });
+
+    const result = await acquireClientCredentialsToken({
+      tenantId: '11111111-1111-1111-1111-111111111111',
+      clientId: 'client',
+      clientSecret: 'secret',
+    });
+
+    expect(result).toEqual({ accessToken: 'tok', expiresIn: 3600 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const call = fetchMock.mock.calls[0]!;
+    expect(call[0]).toBe(
+      'https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/oauth2/v2.0/token'
+    );
+    expect(call[1]).toMatchObject({ redirect: 'error' });
+  });
+});
+
+describe('testGraphAccess', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('passes redirect:error and the bearer header to the Graph fetch', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ value: [{ displayName: 'Contoso Ltd.' }] }),
+    });
+
+    const result = await testGraphAccess('access-token-abc');
+
+    expect(result).toEqual({ ok: true, orgDisplayName: 'Contoso Ltd.' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const call = fetchMock.mock.calls[0]!;
+    expect(call[0]).toBe('https://graph.microsoft.com/v1.0/organization');
+    expect(call[1]).toMatchObject({ redirect: 'error' });
+    expect(call[1].headers).toMatchObject({ Authorization: 'Bearer access-token-abc' });
+  });
+
+  it('does not leak the upstream Graph error body into the returned error', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      text: async () => 'UPSTREAM_GRAPH_BODY_MARKER: detailed Azure AD failure',
+    });
+
+    const result = await testGraphAccess('access-token-abc');
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).not.toContain('UPSTREAM_GRAPH_BODY_MARKER');
+  });
+});
+
+describe('ensureFreshToken', () => {
+  const fetchMock = vi.fn();
+  const ORIGINAL_CLIENT_ID = process.env.C2C_M365_CLIENT_ID;
+  const ORIGINAL_CLIENT_SECRET = process.env.C2C_M365_CLIENT_SECRET;
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+    // Platform config must be present so ensureFreshToken proceeds to the
+    // refresh branch (it returns null early when these are unset).
+    process.env.C2C_M365_CLIENT_ID = 'platform-client-id';
+    process.env.C2C_M365_CLIENT_SECRET = 'platform-client-secret';
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (ORIGINAL_CLIENT_ID === undefined) delete process.env.C2C_M365_CLIENT_ID;
+    else process.env.C2C_M365_CLIENT_ID = ORIGINAL_CLIENT_ID;
+    if (ORIGINAL_CLIENT_SECRET === undefined) delete process.env.C2C_M365_CLIENT_SECRET;
+    else process.env.C2C_M365_CLIENT_SECRET = ORIGINAL_CLIENT_SECRET;
+  });
+
+  it('rejects a non-GUID tenantId on the refresh path before any fetch', async () => {
+    // currentToken: null forces the refresh branch, which delegates to
+    // acquireClientCredentialsToken — where the GUID guard lives.
+    await expect(
+      ensureFreshToken({
+        tenantId: 'not-a-guid',
+        currentToken: null,
+        tokenExpiresAt: null,
+      })
+    ).rejects.toThrow('Invalid M365 tenant id');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/c2cM365.ts
+++ b/apps/api/src/services/c2cM365.ts
@@ -7,6 +7,18 @@
 
 import { captureException } from './sentry';
 
+// ── Tenant id validation ─────────────────────────────────────────────────────
+
+/**
+ * Entra (Azure AD) tenant ids are GUIDs. Microsoft's admin-consent callback
+ * returns the concrete tenant GUID in `?tenant=`, and the client-credentials
+ * flow used here requires a concrete tenant — the well-known aliases
+ * `common` / `organizations` / `consumers` are NOT valid for this grant, so we
+ * deliberately accept GUIDs only.
+ */
+export const M365_TENANT_ID_REGEX =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
 // ── Platform config ────────────────────────────────────────────────────────
 
 export interface C2cM365PlatformConfig {
@@ -75,6 +87,15 @@ export async function acquireClientCredentialsToken(params: {
   clientSecret: string;
   scope?: string;
 }): Promise<TokenResult> {
+  // Last line of defense at the trust boundary: tenantId is tenant-controlled
+  // (admin-consent callback / stored connection). The host is a hard-coded
+  // literal and encodeURIComponent keeps tenantId inside its path segment (no
+  // authority/path break-out), but reject anything that isn't an Entra GUID
+  // before we ever build a URL from it.
+  if (!M365_TENANT_ID_REGEX.test(params.tenantId)) {
+    throw new Error('Invalid M365 tenant id');
+  }
+
   const tokenUrl = `https://login.microsoftonline.com/${encodeURIComponent(params.tenantId)}/oauth2/v2.0/token`;
 
   const body = new URLSearchParams({
@@ -88,6 +109,9 @@ export async function acquireClientCredentialsToken(params: {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: body.toString(),
+    // undici's fetch follows redirects by default; the token endpoint never
+    // legitimately redirects, so refuse to chase one off-host.
+    redirect: 'error',
   });
 
   if (!res.ok) {
@@ -126,6 +150,9 @@ export async function testGraphAccess(
   try {
     const res = await fetch('https://graph.microsoft.com/v1.0/organization', {
       headers: { Authorization: `Bearer ${accessToken}` },
+      // Don't follow a redirect off graph.microsoft.com while carrying the
+      // bearer token in the Authorization header.
+      redirect: 'error',
     });
 
     if (!res.ok) {

--- a/apps/api/src/services/c2cM365.ts
+++ b/apps/api/src/services/c2cM365.ts
@@ -19,6 +19,20 @@ import { captureException } from './sentry';
 export const M365_TENANT_ID_REGEX =
   /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
+/**
+ * A tenant id that has passed `M365_TENANT_ID_REGEX`. The brand makes
+ * "validated → trusted" a type-level fact: a value can only acquire this type
+ * by flowing through `isM365TenantId` (or an explicit, audited cast), so the
+ * token-URL builder can require it as a precondition rather than re-validating
+ * by convention.
+ */
+export type M365TenantId = string & { readonly __brand: 'M365TenantId' };
+
+/** Type guard: true (and narrows) iff `x` is a canonical Entra tenant GUID. */
+export function isM365TenantId(x: string): x is M365TenantId {
+  return M365_TENANT_ID_REGEX.test(x);
+}
+
 // ── Platform config ────────────────────────────────────────────────────────
 
 export interface C2cM365PlatformConfig {
@@ -82,16 +96,17 @@ export interface TokenResult {
  * Uses the platform app credentials + customer tenant ID.
  */
 export async function acquireClientCredentialsToken(params: {
-  tenantId: string;
+  tenantId: M365TenantId;
   clientId: string;
   clientSecret: string;
   scope?: string;
 }): Promise<TokenResult> {
-  // Last line of defense at the trust boundary: tenantId is tenant-controlled
-  // (admin-consent callback / stored connection). The host is a hard-coded
-  // literal and encodeURIComponent keeps tenantId inside its path segment (no
-  // authority/path break-out), but reject anything that isn't an Entra GUID
-  // before we ever build a URL from it.
+  // Defense-in-depth assertion: the `M365TenantId` brand already guarantees a
+  // validated GUID, so this only fires for a caller that bypassed the type with
+  // a cast. tenantId is tenant-controlled (admin-consent callback / stored
+  // connection); the host is a hard-coded literal and encodeURIComponent keeps
+  // tenantId inside its path segment (no authority/path break-out), but we still
+  // fail closed before building a URL from anything that isn't an Entra GUID.
   if (!M365_TENANT_ID_REGEX.test(params.tenantId)) {
     throw new Error('Invalid M365 tenant id');
   }
@@ -205,6 +220,14 @@ export async function ensureFreshToken(params: {
       accessToken: params.currentToken!,
       expiresIn: Math.floor((params.tokenExpiresAt!.getTime() - Date.now()) / 1000),
     };
+  }
+
+  // params.tenantId comes from a stored connection row (plain string). Narrow
+  // it to the branded type before handing it to the token-URL builder; this
+  // keeps a non-GUID stored tenantId from ever reaching a fetch (fails closed
+  // with the same message as the in-builder assertion).
+  if (!isM365TenantId(params.tenantId)) {
+    throw new Error('Invalid M365 tenant id');
   }
 
   return acquireClientCredentialsToken({

--- a/apps/api/src/services/dnsProviders/http.test.ts
+++ b/apps/api/src/services/dnsProviders/http.test.ts
@@ -1,8 +1,34 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import https from 'https';
 import { EventEmitter } from 'events';
-import { requestJson } from './http';
+import { requestJson, DnsProviderHttpError } from './http';
 import { SsrfBlockedError, __setLookupForTests } from '../urlSafety';
+
+/**
+ * Build an https.request mock that lands one response with the given status and
+ * body. Used (with a literal IP + allowPrivateNetwork) to exercise the response
+ * path past the SSRF gate without real network I/O.
+ */
+function mockHttpsOnce(opts: { statusCode: number; statusMessage: string; body: string }) {
+  return vi
+    .spyOn(https, 'request')
+    .mockImplementation((_options: any, callback?: any) => {
+      const req = new EventEmitter() as any;
+      req.write = vi.fn();
+      req.destroy = vi.fn();
+      req.setTimeout = vi.fn();
+      req.end = vi.fn(() => {
+        const res = new EventEmitter() as any;
+        res.statusCode = opts.statusCode;
+        res.statusMessage = opts.statusMessage;
+        res.headers = { 'content-type': 'application/json' };
+        callback?.(res);
+        res.emit('data', Buffer.from(opts.body));
+        res.emit('end');
+      });
+      return req;
+    });
+}
 
 describe('requestJson — SSRF safety via safeFetch', () => {
   afterEach(() => {
@@ -216,6 +242,64 @@ describe('requestJson — SSRF safety via safeFetch', () => {
 
       expect(result).toEqual({});
       expect(requestSpy.mock.calls.length).toBeGreaterThan(1);
+    });
+  });
+
+  describe('DnsProviderHttpError — no upstream body in .message', () => {
+    it('throws a body-free DnsProviderHttpError on a non-2xx response, keeping the body on responseBody', async () => {
+      // 4xx is non-retriable, so a single transport attempt surfaces the error.
+      mockHttpsOnce({
+        statusCode: 403,
+        statusMessage: 'Forbidden',
+        body: 'UPSTREAM_BODY_MARKER: secret internal detail'
+      });
+
+      const error = await requestJson('https://10.0.0.5/x', {
+        allowPrivateNetwork: true,
+        maxRetries: 0
+      }).then(
+        () => {
+          throw new Error('expected requestJson to reject');
+        },
+        (e: unknown) => e
+      );
+
+      expect(error).toBeInstanceOf(DnsProviderHttpError);
+      const httpError = error as DnsProviderHttpError;
+      expect(httpError.status).toBe(403);
+      expect(httpError.statusText).toBe('Forbidden');
+      // SECURITY: status line only — the upstream body must NOT leak into the
+      // (tenant-visible) message.
+      expect(httpError.message).toBe('HTTP 403 Forbidden');
+      expect(httpError.message).not.toContain('UPSTREAM_BODY_MARKER');
+      // Raw body preserved for server-side logging only.
+      expect(httpError.responseBody).toBe('UPSTREAM_BODY_MARKER: secret internal detail');
+    });
+
+    it('throws a body-free DnsProviderHttpError on an unparseable 2xx body, keeping the body on responseBody', async () => {
+      mockHttpsOnce({
+        statusCode: 200,
+        statusMessage: 'OK',
+        body: 'not json UPSTREAM_BODY_MARKER'
+      });
+
+      const error = await requestJson('https://10.0.0.5/x', {
+        allowPrivateNetwork: true,
+        maxRetries: 0
+      }).then(
+        () => {
+          throw new Error('expected requestJson to reject');
+        },
+        (e: unknown) => e
+      );
+
+      expect(error).toBeInstanceOf(DnsProviderHttpError);
+      const httpError = error as DnsProviderHttpError;
+      expect(httpError.message).toBe('Provider returned invalid JSON payload');
+      // SECURITY: the raw payload must NOT leak into the tenant-visible message.
+      expect(httpError.message).not.toContain('UPSTREAM_BODY_MARKER');
+      // Raw text preserved for server-side logging only.
+      expect(httpError.responseBody).toBe('not json UPSTREAM_BODY_MARKER');
     });
   });
 });

--- a/apps/api/src/services/dnsProviders/http.ts
+++ b/apps/api/src/services/dnsProviders/http.ts
@@ -14,10 +14,35 @@ interface RequestJsonInit extends RequestInit {
   allowPrivateNetwork?: boolean;
 }
 
-function toErrorMessage(status: number, statusText: string, body: string): string {
-  const trimmed = body.trim();
-  const bodyPreview = trimmed.length > 0 ? trimmed.slice(0, 400) : '<empty>';
-  return `HTTP ${status} ${statusText}: ${bodyPreview}`;
+/**
+ * Error thrown for a non-2xx (or unparseable) DNS provider response.
+ *
+ * SECURITY: `.message` is deliberately body-free — for an HTTP error it is just
+ * the `HTTP <status> <statusText>` status line. The raw upstream response body
+ * is preserved on `.responseBody` for SERVER-SIDE logging ONLY. It must never be
+ * persisted to a tenant-visible column (e.g. `dns_filter_integrations.lastSyncError`
+ * or `dns_policies.syncError`): for self-hosted Pi-hole/AdGuard providers the
+ * tenant supplies the endpoint host, so reflecting an upstream body back to them
+ * is a partial-read oracle / confused-deputy for arbitrary public hosts.
+ */
+export class DnsProviderHttpError extends Error {
+  public readonly status: number;
+  public readonly statusText: string;
+  public readonly responseBody: string;
+
+  constructor(
+    status: number,
+    statusText: string,
+    responseBody: string,
+    /** Optional body-free message override; defaults to the status line. */
+    message?: string
+  ) {
+    super(message ?? `HTTP ${status} ${statusText}`);
+    this.name = 'DnsProviderHttpError';
+    this.status = status;
+    this.statusText = statusText;
+    this.responseBody = responseBody;
+  }
 }
 
 export async function requestJson<T>(
@@ -82,7 +107,9 @@ export async function requestJson<T>(
           await sleep(computeBackoffMs(attempt, response.headers.get('retry-after')));
           continue;
         }
-        throw new Error(toErrorMessage(response.status, response.statusText, text));
+        // Body-free `.message` (status line); raw body kept on `.responseBody`
+        // for server-side logging only — never reflect it to the tenant.
+        throw new DnsProviderHttpError(response.status, response.statusText, text);
       }
 
       if (!text.trim()) {
@@ -92,7 +119,14 @@ export async function requestJson<T>(
       try {
         return JSON.parse(text) as T;
       } catch {
-        throw new Error(`Provider returned invalid JSON payload: ${text.slice(0, 300)}`);
+        // Same rule for an unparseable 2xx body: body-free message, raw text
+        // retained on `.responseBody` for server-side logging only.
+        throw new DnsProviderHttpError(
+          response.status,
+          response.statusText,
+          text,
+          'Provider returned invalid JSON payload'
+        );
       }
     } catch (error) {
       // An SSRF policy violation must NOT be retried — fail fast. SsrfBlockedError
@@ -103,10 +137,13 @@ export async function requestJson<T>(
       // safeFetch surfaces transport/TLS failures as plain Error (with `cause`)
       // and timeouts/aborts as Error('request timed out…')/Error('aborted'). Treat
       // those — plus the legacy fetch TypeError — as retriable transient failures.
+      // A DnsProviderHttpError reaching here is a non-retriable 4xx (or an already
+      // retry-exhausted 5xx) / invalid-JSON — never retry it.
       const isNetwork =
         error instanceof TypeError ||
         (error instanceof Error &&
           !isSsrfBlocked &&
+          !(error instanceof DnsProviderHttpError) &&
           (/timed out/i.test(error.message) ||
             error.message === 'aborted' ||
             error.message === 'socket hang up' ||

--- a/apps/api/src/services/dnsProviders/index.ts
+++ b/apps/api/src/services/dnsProviders/index.ts
@@ -84,3 +84,8 @@ export {
   PiHoleProvider,
   AdGuardHomeProvider
 };
+
+// Re-export so the sync job can identify upstream HTTP errors (and read the
+// body off `.responseBody` for server-side logging) without reaching into the
+// per-provider http module.
+export { DnsProviderHttpError } from './http';

--- a/apps/api/src/services/huntressClient.test.ts
+++ b/apps/api/src/services/huntressClient.test.ts
@@ -1,28 +1,50 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// HuntressClient routes every outbound call through `safeFetch` (SSRF-safe:
+// DNS-pinned, no redirect following, *.huntress.io re-asserted on the final
+// URL). Mock the urlSafety module so the client never touches the real network
+// and we can assert on what it asked safeFetch to do.
+vi.mock('./urlSafety', () => ({
+  safeFetch: vi.fn(),
+  SsrfBlockedError: class SsrfBlockedError extends Error {},
+}));
+
 import { HuntressClient } from './huntressClient';
+import { safeFetch } from './urlSafety';
+
+const safeFetchMock = vi.mocked(safeFetch);
 
 // Regression coverage for the Huntress sync fixes:
 //  1. HTTP Basic auth (not Bearer/X-API-Key).
 //  2. Incidents come from /incident_reports (not /incidents).
 //  3. Numeric ids (Huntress returns id/agent_id as numbers) survive normalization
 //     instead of being dropped as "missing required fields".
+//  4. SSRF: outbound calls go through safeFetch (not global fetch); a redirect
+//     (3xx) from safeFetch is treated as an error and NOT followed to another host.
 
-type Captured = { url: URL; init: RequestInit };
+type Captured = { url: string; init: { method?: string; headers?: unknown; timeoutMs?: number } };
 
-function mockFetch(bodyFor: (pathname: string) => unknown) {
+// Build a minimal Response-shaped object. The client only reads `.ok`,
+// `.status`, `.statusText`, `.text()`, and `.headers.get('Retry-After')`.
+function fakeResponse(status: number, body: unknown, retryAfter?: string) {
+  const text = typeof body === 'string' ? body : JSON.stringify(body);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : `Status ${status}`,
+    text: async () => text,
+    headers: { get: (name: string) => (name === 'Retry-After' ? retryAfter ?? null : null) },
+  } as unknown as Response;
+}
+
+// Drive safeFetch by request pathname; default to a 200 with the given body.
+function mockSafeFetch(bodyFor: (pathname: string) => unknown) {
   const calls: Captured[] = [];
-  const fn = vi.fn(async (url: URL, init: RequestInit) => {
-    calls.push({ url, init });
-    const body = bodyFor(url.pathname);
-    return {
-      ok: true,
-      status: 200,
-      statusText: 'OK',
-      text: async () => JSON.stringify(body),
-      headers: { get: () => null },
-    } as unknown as Response;
+  safeFetchMock.mockImplementation(async (url: string, init?: unknown) => {
+    calls.push({ url, init: (init ?? {}) as Captured['init'] });
+    const pathname = new URL(url).pathname;
+    return fakeResponse(200, bodyFor(pathname));
   });
-  vi.stubGlobal('fetch', fn);
   return calls;
 }
 
@@ -32,14 +54,17 @@ const onePage = (key: string, rows: unknown[]) => ({
   pagination: { current_page: 1, current_page_count: rows.length, limit: 100, total_count: rows.length, next_page: null },
 });
 
+beforeEach(() => {
+  safeFetchMock.mockReset();
+});
+
 afterEach(() => {
-  vi.unstubAllGlobals();
   vi.clearAllMocks();
 });
 
 describe('HuntressClient', () => {
   it('authenticates with HTTP Basic (base64 of the key:secret pair), not Bearer/X-API-Key', async () => {
-    const calls = mockFetch((p) => (p.endsWith('/agents') ? onePage('agents', []) : onePage('incident_reports', [])));
+    const calls = mockSafeFetch((p) => (p.endsWith('/agents') ? onePage('agents', []) : onePage('incident_reports', [])));
     const client = new HuntressClient({ apiKey: 'mykey:mysecret' });
     await client.listAgents();
 
@@ -50,16 +75,16 @@ describe('HuntressClient', () => {
   });
 
   it('reads incidents from /incident_reports, not /incidents', async () => {
-    const calls = mockFetch(() => onePage('incident_reports', []));
+    const calls = mockSafeFetch(() => onePage('incident_reports', []));
     const client = new HuntressClient({ apiKey: 'k:s' });
     await client.listIncidents();
 
-    expect(calls.some((c) => c.url.pathname.endsWith('/incident_reports'))).toBe(true);
-    expect(calls.some((c) => c.url.pathname.endsWith('/incidents'))).toBe(false);
+    expect(calls.some((c) => new URL(c.url).pathname.endsWith('/incident_reports'))).toBe(true);
+    expect(calls.some((c) => new URL(c.url).pathname.endsWith('/incidents'))).toBe(false);
   });
 
   it('keeps agent records whose id is a number (numeric ids are coerced, not dropped)', async () => {
-    mockFetch(() =>
+    mockSafeFetch(() =>
       onePage('agents', [{ id: 12345, hostname: 'HOST-1', platform: 'windows', status: 'active' }])
     );
     const client = new HuntressClient({ apiKey: 'k:s' });
@@ -71,7 +96,7 @@ describe('HuntressClient', () => {
   });
 
   it('keeps incident records with a numeric id and maps the real fields (subject/body/sent_at)', async () => {
-    mockFetch(() =>
+    mockSafeFetch(() =>
       onePage('incident_reports', [
         { id: 678, agent_id: 99, subject: 'Suspicious login', body: 'Details here', severity: 'high', status: 'sent', sent_at: '2026-05-01T00:00:00Z' },
       ])
@@ -84,5 +109,78 @@ describe('HuntressClient', () => {
     expect(incidents[0]!.title).toBe('Suspicious login'); // from `subject`
     expect(incidents[0]!.description).toBe('Details here'); // from `body`
     expect(incidents[0]!.reportedAt?.toISOString()).toBe('2026-05-01T00:00:00.000Z'); // from `sent_at`
+  });
+
+  // --- SSRF regression coverage ---
+
+  it('routes outbound calls through safeFetch with an https *.huntress.io URL (not global fetch)', async () => {
+    // Swap global fetch for a spy that throws: if the client ever reaches for
+    // raw fetch instead of safeFetch, the test fails loudly.
+    const globalFetchSpy = vi.fn(() => {
+      throw new Error('global fetch must not be used — call safeFetch');
+    });
+    vi.stubGlobal('fetch', globalFetchSpy);
+
+    const calls = mockSafeFetch(() => onePage('agents', []));
+    const client = new HuntressClient({ apiKey: 'k:s' });
+    await client.listAgents();
+
+    expect(safeFetchMock).toHaveBeenCalled();
+    expect(globalFetchSpy).not.toHaveBeenCalled();
+
+    const requested = new URL(calls[0]!.url);
+    expect(requested.protocol).toBe('https:');
+    expect(requested.hostname.endsWith('.huntress.io')).toBe(true);
+    vi.unstubAllGlobals();
+  });
+
+  it('treats a 3xx from safeFetch as an error and does NOT follow it to another host', async () => {
+    // safeFetch never follows redirects: it returns the raw 3xx. The client must
+    // reject it rather than chase the Location header into internal address space.
+    safeFetchMock.mockResolvedValueOnce(
+      fakeResponse(302, '') as Response
+    );
+    // If the client wrongly followed the redirect, it would call safeFetch again.
+    const client = new HuntressClient({ apiKey: 'k:s' });
+
+    await expect(client.listAgents()).rejects.toThrow(/Huntress API request failed \(302/);
+    // Exactly one outbound call — the redirect was not followed.
+    expect(safeFetchMock).toHaveBeenCalledTimes(1);
+    // And every call that was made targeted a huntress.io host.
+    for (const call of safeFetchMock.mock.calls) {
+      const target = new URL(call[0] as string);
+      expect(target.hostname.endsWith('.huntress.io')).toBe(true);
+    }
+  });
+
+  it('does not retry a 3xx (only 429/5xx are retried)', async () => {
+    safeFetchMock.mockResolvedValue(fakeResponse(301, '') as Response);
+    const client = new HuntressClient({ apiKey: 'k:s' });
+
+    await expect(client.listIncidents()).rejects.toThrow(/Huntress API request failed \(301/);
+    expect(safeFetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes a timeout to safeFetch so the SSRF-safe transport enforces it', async () => {
+    const calls = mockSafeFetch(() => onePage('agents', []));
+    const client = new HuntressClient({ apiKey: 'k:s' });
+    await client.listAgents();
+
+    expect(typeof calls[0]!.init.timeoutMs).toBe('number');
+    expect(calls[0]!.init.timeoutMs!).toBeGreaterThan(0);
+  });
+
+  // The per-request host re-assertion in request() is defense-in-depth. The
+  // constructor already rejects any non-HTTPS / non-*.huntress.io base URL, and
+  // pathname/query joined onto a validated base cannot change the origin, so we
+  // cannot reach the re-assertion via the public API — exercising the
+  // constructor guard documents the boundary instead.
+  it('rejects a non-huntress base URL at construction (origin can never drift off-host)', () => {
+    expect(() => new HuntressClient({ apiKey: 'k:s', baseUrl: 'https://evil.example.com/v1' })).toThrow(
+      /Must be HTTPS \*\.huntress\.io/
+    );
+    expect(() => new HuntressClient({ apiKey: 'k:s', baseUrl: 'http://api.huntress.io/v1' })).toThrow(
+      /Must be HTTPS \*\.huntress\.io/
+    );
   });
 });

--- a/apps/api/src/services/huntressClient.ts
+++ b/apps/api/src/services/huntressClient.ts
@@ -1,4 +1,5 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
+import { safeFetch } from './urlSafety';
 
 const DEFAULT_HUNTRESS_BASE_URL = 'https://api.huntress.io/v1';
 const DEFAULT_TIMEOUT_MS = 20_000;
@@ -296,16 +297,36 @@ function normalizeWebhookPayload(payload: unknown): {
 
 const MAX_RETRIES = 3;
 
+// Recognize the timeout/abort rejections produced by either the legacy fetch
+// path (DOMException 'AbortError') or safeFetch (plain Error whose message is
+// 'request timed out after Nms' or 'aborted'). safeFetch routes through
+// http(s).request, which never throws a DOMException, so we must match on the
+// message too.
+function isTimeoutError(err: unknown): boolean {
+  if (err instanceof DOMException && err.name === 'AbortError') return true;
+  if (err instanceof Error) {
+    return /request timed out after \d+ms/.test(err.message) || err.message === 'aborted';
+  }
+  return false;
+}
+
 async function fetchJson(
   url: URL,
   init: RequestInit,
   timeoutMs: number = DEFAULT_TIMEOUT_MS
 ): Promise<unknown> {
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      const response = await fetch(url, { ...init, signal: controller.signal });
+      // Route through safeFetch (SSRF-safe): it pins DNS to a validated public
+      // IP, never follows redirects (a 3xx is returned raw, so the non-2xx
+      // branch below rejects it instead of chasing a Location into internal
+      // address space), and enforces the timeout itself via `timeoutMs`.
+      const response = await safeFetch(url.toString(), {
+        method: init.method,
+        headers: init.headers,
+        body: init.body as BodyInit | undefined,
+        timeoutMs,
+      });
       const text = await response.text();
 
       // Retry on transient errors (429, 5xx)
@@ -321,6 +342,8 @@ async function fetchJson(
         }
       }
 
+      // Any non-2xx (including a raw 3xx from safeFetch, which never follows
+      // redirects) is an error — we never parse it as JSON or chase Location.
       if (!response.ok) {
         const preview = text.trim().slice(0, 400);
         throw new Error(`Huntress API request failed (${response.status} ${response.statusText}): ${preview || '<empty>'}`);
@@ -335,21 +358,18 @@ async function fetchJson(
         );
       }
     } catch (err) {
-      clearTimeout(timer);
       // Retry on timeouts
-      if (err instanceof DOMException && err.name === 'AbortError' && attempt < MAX_RETRIES) {
+      if (isTimeoutError(err) && attempt < MAX_RETRIES) {
         console.warn(
           `[HuntressClient] Request to ${url.pathname} timed out after ${timeoutMs}ms (attempt ${attempt + 1}/${MAX_RETRIES})`
         );
         continue;
       }
-      // Wrap raw AbortError with context
-      if (err instanceof DOMException && err.name === 'AbortError') {
+      // Wrap raw timeout/abort with context
+      if (isTimeoutError(err)) {
         throw new Error(`Huntress API request to ${url.pathname} timed out after ${timeoutMs}ms`);
       }
       throw err;
-    } finally {
-      clearTimeout(timer);
     }
   }
   // Should not be reached, but satisfies TypeScript
@@ -378,6 +398,12 @@ export class HuntressClient {
     const url = new URL(pathname.replace(/^\//, ''), this.baseUrl.toString().endsWith('/') ? this.baseUrl : new URL(`${this.baseUrl.toString()}/`));
     for (const [key, value] of Object.entries(query ?? {})) {
       url.searchParams.set(key, value);
+    }
+    // Re-assert the host on the FINAL per-request URL (defense against off-host
+    // drift: a path/query that somehow resolved to a different origin). The
+    // constructor validates the base URL, but this guards every outbound call.
+    if (url.protocol !== 'https:' || !url.hostname.endsWith('.huntress.io')) {
+      throw new Error(`Refusing to call non-Huntress host: ${url.origin}. Must be HTTPS *.huntress.io`);
     }
     // Huntress API only accepts HTTP Basic auth (verified live 2026-05-29: Bearer and
     // X-API-Key both return 401 "Missing or incorrect authorization scheme"). The

--- a/apps/api/src/services/sentinelOne/actions.test.ts
+++ b/apps/api/src/services/sentinelOne/actions.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SentinelOneHttpError } from './client';
+
+// actions.ts pulls in ../../db (and transitively ../../jobs/s1Sync) at import
+// time. We only exercise the pure helpers (truncateError /
+// logActionDispatchFailureServerSide), so stub the heavy deps to keep this a
+// fast unit test rather than wiring a full DB/queue mock.
+vi.mock('../../db', () => ({
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../../jobs/s1Sync', () => ({
+  dispatchS1Isolation: vi.fn(),
+  dispatchS1ThreatAction: vi.fn(),
+  scheduleS1ActionPoll: vi.fn(),
+}));
+
+import { truncateError, logActionDispatchFailureServerSide } from './actions';
+
+const UPSTREAM_BODY_MARKER = 'UPSTREAM_BODY_MARKER_should_never_reach_tenant';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('truncateError', () => {
+  it('keeps a SentinelOneHttpError body-free (upstream body never reaches the tenant)', () => {
+    const err = new SentinelOneHttpError(
+      'POST',
+      '/web/api/v2.1/agents/actions/disconnect',
+      500,
+      `{"errors":[{"detail":"${UPSTREAM_BODY_MARKER}"}]}`
+    );
+
+    const text = truncateError(err);
+
+    // `.message` is the status line only; the upstream `.responseBody` is excluded.
+    expect(text).not.toContain(UPSTREAM_BODY_MARKER);
+    expect(text).toContain('failed (500)');
+  });
+
+  it('redacts a secret-shaped Authorization header in a non-S1HttpError message', () => {
+    const err = new Error('connect failed sending Authorization: Bearer s3cr3t-token-value to host');
+
+    const text = truncateError(err);
+
+    expect(text).not.toContain('s3cr3t-token-value');
+    expect(text).toContain('[REDACTED]');
+  });
+
+  it('truncates very long messages to 2000 chars', () => {
+    const err = new Error('x'.repeat(5_000));
+    expect(truncateError(err).length).toBe(2_000);
+  });
+});
+
+describe('logActionDispatchFailureServerSide', () => {
+  it('logs the (redacted) upstream responseBody server-side for a SentinelOneHttpError', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const err = new SentinelOneHttpError(
+      'POST',
+      '/web/api/v2.1/threats/mitigate/kill',
+      502,
+      `body Authorization: Bearer leaked-token ${UPSTREAM_BODY_MARKER}`
+    );
+
+    logActionDispatchFailureServerSide({ orgId: 'org-1', integrationId: 'int-1' }, err);
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const [, payload] = errorSpy.mock.calls[0] as [string, string];
+    // The diagnostic body IS captured server-side (it was being dropped before).
+    expect(payload).toContain(UPSTREAM_BODY_MARKER);
+    expect(payload).toContain('org-1');
+    expect(payload).toContain('"status":502');
+    // But any header secret echoed inside the body is redacted.
+    expect(payload).not.toContain('leaked-token');
+    expect(payload).toContain('[REDACTED]');
+  });
+
+  it('logs a redacted message for a non-S1HttpError', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const err = new Error('transport error Authorization: Bearer another-secret');
+
+    logActionDispatchFailureServerSide({ orgId: 'org-2', integrationId: 'int-2' }, err);
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const [, payload] = errorSpy.mock.calls[0] as [string, string];
+    expect(payload).toContain('org-2');
+    expect(payload).not.toContain('another-secret');
+    expect(payload).toContain('[REDACTED]');
+  });
+});

--- a/apps/api/src/services/sentinelOne/actions.ts
+++ b/apps/api/src/services/sentinelOne/actions.ts
@@ -7,7 +7,8 @@ import {
   scheduleS1ActionPoll
 } from '../../jobs/s1Sync';
 import { captureException } from '../sentry';
-import type { S1ThreatAction } from './client';
+import { redactLogMessage } from '../logRedaction';
+import { SentinelOneHttpError, type S1ThreatAction } from './client';
 
 const NO_ACTIVITY_ID_WARNING = 'Provider did not return activityId; action cannot be tracked';
 
@@ -55,13 +56,48 @@ export interface S1ActionSuccessResult<TData> {
   data: TData;
 }
 
-function truncateError(err: unknown): string {
+export function truncateError(err: unknown): string {
   const message = err instanceof Error ? err.message : String(err);
-  return message.slice(0, 2_000);
+  // Redact before truncating/persisting. S1 bearer tokens go in headers, but an
+  // error message can echo a Cookie/Authorization header; for a SentinelOneHttpError
+  // the body lives on `.responseBody` (logged server-side), never on `.message`.
+  return redactLogMessage(message).slice(0, 2_000);
 }
 
 function formatDispatchError(err: unknown): string {
   return `SentinelOne action dispatch failed: ${truncateError(err)}`;
+}
+
+/**
+ * Log full failure detail to the SERVER-SIDE log only. For an upstream HTTP error
+ * this includes the (redacted) `.responseBody` that we deliberately keep out of
+ * the tenant-visible `s1_actions.error` column / action dispatch result. The
+ * tenant-visible text is written separately via {@link truncateError}, which
+ * reads only the body-free `.message`. Mirrors `logSyncFailureServerSide` in
+ * jobs/s1Sync.ts but kept local to avoid a service→job import.
+ */
+export function logActionDispatchFailureServerSide(
+  context: Record<string, unknown>,
+  error: unknown
+): void {
+  if (error instanceof SentinelOneHttpError) {
+    console.error(
+      '[s1-actions] dispatch failed (upstream HTTP error)',
+      JSON.stringify({
+        ...context,
+        status: error.status,
+        responseBody: redactLogMessage(error.responseBody),
+      })
+    );
+    return;
+  }
+  console.error(
+    '[s1-actions] dispatch failed',
+    JSON.stringify({
+      ...context,
+      error: redactLogMessage(error instanceof Error ? error.message : String(error)),
+    })
+  );
 }
 
 export async function getActiveS1IntegrationForOrg(orgId: string): Promise<S1ActiveIntegration | null> {
@@ -166,6 +202,13 @@ export async function executeS1IsolationForOrg(params: {
       status = 'completed';
     }
   } catch (error) {
+    // Capture full detail (incl. redacted upstream body) server-side BEFORE we
+    // build the body-free tenant-visible warning — otherwise the diagnostic
+    // `.responseBody` is dropped entirely on a failed isolate dispatch.
+    logActionDispatchFailureServerSide(
+      { orgId: params.orgId, integrationId: params.integrationId },
+      error
+    );
     warning = formatDispatchError(error);
     errorText = warning;
     providerRaw = { error: warning };
@@ -314,6 +357,13 @@ export async function executeS1ThreatActionForOrg(params: {
       status = 'completed';
     }
   } catch (error) {
+    // Capture full detail (incl. redacted upstream body) server-side BEFORE we
+    // build the body-free tenant-visible warning — otherwise the diagnostic
+    // `.responseBody` is dropped entirely on a failed threat-action dispatch.
+    logActionDispatchFailureServerSide(
+      { orgId: params.orgId, integrationId: params.integrationId },
+      error
+    );
     warning = formatDispatchError(error);
     errorText = warning;
     providerRaw = { error: warning };

--- a/apps/api/src/services/sentinelOne/client.test.ts
+++ b/apps/api/src/services/sentinelOne/client.test.ts
@@ -87,6 +87,32 @@ describe('SentinelOneClient error handling', () => {
     expect(safeFetchMock).not.toHaveBeenCalled();
   });
 
+  it('rejects HTTPS management URLs outside the .sentinelone.net allowlist before sending tokens', () => {
+    expect(() => new SentinelOneClient({
+      managementUrl: 'https://internal-vault.cluster.local',
+      apiToken: 'token',
+    })).toThrow(/sentinelone|allowed/i);
+    // Fail closed: the token must never reach egress for a non-allowed host.
+    expect(safeFetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects look-alike hosts that only embed sentinelone.net as a substring', () => {
+    // .endsWith('.sentinelone.net') correctly rejects this — the host ends with
+    // .attacker.test, guarding against suffix-vs-substring confusion.
+    expect(() => new SentinelOneClient({
+      managementUrl: 'https://evil-sentinelone.net.attacker.test',
+      apiToken: 'token',
+    })).toThrow();
+    expect(safeFetchMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts regional/partner .sentinelone.net subdomains', () => {
+    expect(() => new SentinelOneClient({
+      managementUrl: 'https://usea1-partners.sentinelone.net',
+      apiToken: 'token',
+    })).not.toThrow();
+  });
+
   it('throws on non-OK HTTP response with status and body', async () => {
     safeFetchMock.mockResolvedValue({
       ok: false,

--- a/apps/api/src/services/sentinelOne/client.test.ts
+++ b/apps/api/src/services/sentinelOne/client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { SentinelOneClient } from './client';
+import { SentinelOneClient, SentinelOneHttpError } from './client';
 
 const ORIGINAL_MAX_PAGES = process.env.S1_SYNC_MAX_PAGES;
 const { safeFetchMock } = vi.hoisted(() => ({
@@ -113,11 +113,12 @@ describe('SentinelOneClient error handling', () => {
     })).not.toThrow();
   });
 
-  it('throws on non-OK HTTP response with status and body', async () => {
+  it('throws a SentinelOneHttpError with body-free message and status on non-OK HTTP response', async () => {
+    const bodyMarker = 'Unauthorized: Invalid API token';
     safeFetchMock.mockResolvedValue({
       ok: false,
       status: 401,
-      text: async () => 'Unauthorized: Invalid API token',
+      text: async () => bodyMarker,
     });
 
     const client = new SentinelOneClient({
@@ -125,8 +126,21 @@ describe('SentinelOneClient error handling', () => {
       apiToken: 'bad-token',
     });
 
-    await expect(client.listAgents()).rejects.toThrow('failed (401)');
-    await expect(client.listAgents()).rejects.toThrow('Unauthorized');
+    const error = await client.listAgents().then(
+      () => { throw new Error('expected listAgents to reject'); },
+      (err: unknown) => err,
+    );
+
+    // Typed error with structured status + raw body retained for server-side logging.
+    expect(error).toBeInstanceOf(SentinelOneHttpError);
+    const httpError = error as SentinelOneHttpError;
+    expect(httpError.status).toBe(401);
+    expect(httpError.responseBody).toContain(bodyMarker);
+
+    // SECURITY: the upstream body must NOT be reflected into `.message` (the
+    // tenant-visible surface). `.message` is the body-free status line only.
+    expect(httpError.message).toBe('SentinelOne API GET /web/api/v2.1/agents failed (401)');
+    expect(httpError.message).not.toContain(bodyMarker);
   });
 
   it('throws on non-object JSON response', async () => {

--- a/apps/api/src/services/sentinelOne/client.ts
+++ b/apps/api/src/services/sentinelOne/client.ts
@@ -1,5 +1,6 @@
 import { captureException } from '../sentry';
 import { safeFetch } from '../urlSafety';
+import { S1_HOSTNAME_ALLOWLIST } from './constants';
 
 type HttpMethod = 'GET' | 'POST';
 
@@ -82,6 +83,14 @@ function normalizeManagementUrl(rawUrl: string): string {
 
   if (parsed.protocol !== 'https:') {
     throw new Error('SentinelOneClient: managementUrl must use HTTPS');
+  }
+
+  // Re-assert the vendor-domain allowlist at the point of egress (the route guard
+  // also enforces it at write time). Fail closed so a token is never sent to a host
+  // outside `.sentinelone.net`, even if a future non-route caller skips the guard.
+  const host = parsed.hostname.toLowerCase();
+  if (!S1_HOSTNAME_ALLOWLIST.some((suffix) => host.endsWith(suffix))) {
+    throw new Error('SentinelOneClient: managementUrl host is not an allowed SentinelOne console');
   }
 
   parsed.username = '';

--- a/apps/api/src/services/sentinelOne/client.ts
+++ b/apps/api/src/services/sentinelOne/client.ts
@@ -73,6 +73,35 @@ interface S1ClientOptions {
 
 const DEFAULT_MAX_PAGES = 25;
 
+/**
+ * Error thrown for a non-OK SentinelOne API HTTP response.
+ *
+ * SECURITY: `.message` is deliberately body-free — it is just our own request
+ * metadata (`SentinelOne API <method> <pathname> failed (<status>)`), none of
+ * which is attacker-influenced. The raw upstream response body is preserved on
+ * `.responseBody` for SERVER-SIDE logging ONLY. It must never be persisted to a
+ * tenant-visible column (e.g. `s1_integrations.lastSyncError`, the action
+ * dispatch result surfaced via routes/AI tools): although SentinelOne's host is
+ * a fixed `.sentinelone.net` vendor host (not a tenant-controlled SSRF oracle),
+ * reflecting the upstream body back to tenants is an information-hygiene leak —
+ * the same rule we apply to {@link DnsProviderHttpError}. `truncateError`
+ * (s1Sync.ts / actions.ts) reads only `.message`, so the body is automatically
+ * kept out of the tenant column; `logSyncFailureServerSide` logs `.responseBody`
+ * (redacted) server-side.
+ */
+export class SentinelOneHttpError extends Error {
+  public readonly status: number;
+  public readonly responseBody: string;
+
+  constructor(method: HttpMethod, pathname: string, status: number, responseBody: string) {
+    // Body-free message: only our own request metadata, never the upstream body.
+    super(`SentinelOne API ${method} ${pathname} failed (${status})`);
+    this.name = 'SentinelOneHttpError';
+    this.status = status;
+    this.responseBody = responseBody;
+  }
+}
+
 function normalizeManagementUrl(rawUrl: string): string {
   let parsed: URL;
   try {
@@ -403,7 +432,9 @@ export class SentinelOneClient {
 
       if (!response.ok) {
         const text = await response.text().catch(() => '');
-        throw new Error(`SentinelOne API ${method} ${url.pathname} failed (${response.status}): ${text.slice(0, 500)}`);
+        // Body-free `.message` (status line); raw body kept on `.responseBody`
+        // for server-side logging only — never reflect it to the tenant.
+        throw new SentinelOneHttpError(method, url.pathname, response.status, text);
       }
 
       const payload = await response.json() as unknown;

--- a/apps/api/src/services/sentinelOne/client.ts
+++ b/apps/api/src/services/sentinelOne/client.ts
@@ -85,9 +85,11 @@ const DEFAULT_MAX_PAGES = 25;
  * a fixed `.sentinelone.net` vendor host (not a tenant-controlled SSRF oracle),
  * reflecting the upstream body back to tenants is an information-hygiene leak —
  * the same rule we apply to {@link DnsProviderHttpError}. `truncateError`
- * (s1Sync.ts / actions.ts) reads only `.message`, so the body is automatically
- * kept out of the tenant column; `logSyncFailureServerSide` logs `.responseBody`
- * (redacted) server-side.
+ * (s1Sync.ts / actions.ts) reads the body-free `.message` (and additionally
+ * redacts it defense-in-depth), so the `.responseBody` is automatically kept out
+ * of the tenant column; the server-side loggers (`logSyncFailureServerSide` in
+ * s1Sync.ts, `logActionDispatchFailureServerSide` in actions.ts) log
+ * `.responseBody` (redacted) server-side instead.
  */
 export class SentinelOneHttpError extends Error {
   public readonly status: number;

--- a/apps/api/src/services/sentinelOne/constants.ts
+++ b/apps/api/src/services/sentinelOne/constants.ts
@@ -1,0 +1,5 @@
+/** SentinelOne consoles are always served from the vendor's `.sentinelone.net`
+ *  domain (incl. regional/partner subdomains, e.g. usea1-partners.sentinelone.net).
+ *  Shared by the write-time route guard and the client's egress-time re-check so
+ *  the allowlist has a single source of truth. */
+export const S1_HOSTNAME_ALLOWLIST = ['.sentinelone.net'] as const;

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -61,4 +61,4 @@ The integration emits normalized events on the Breeze event bus:
 - Integration management and manual sync endpoints require authenticated org write access and MFA.
 - Webhook ingestion is unauthenticated by user session but cryptographically validated via HMAC-SHA256 signature.
 - Integration health and incident read APIs remain org-scoped for partner/system contexts.
-- The `apiBaseUrl` field is restricted to HTTPS URLs on `*.huntress.io` to prevent SSRF.
+- The `apiBaseUrl` field is restricted to HTTPS URLs on `*.huntress.io`, and every outbound Huntress request is made through the SSRF-safe HTTP client (`safeFetch`: DNS-pinned to the resolved public IP, with no redirect following). The hostname allowlist alone is insufficient — DNS rebinding or an upstream redirect could otherwise reach an internal address — so the pinned, no-redirect transport is what actually prevents SSRF.


### PR DESCRIPTION
## Summary

Security review of the third-party integrations (Huntress, SentinelOne, DNS providers, M365/Delegant) surfaced four SSRF / egress-hardening gaps. The repo already has a DNS-pinned, redirect-refusing `safeFetch` (`urlSafety.ts`) and a static write-time `checkSsrfSafe` (`ssrfGuard.ts`); this PR brings the remaining integration paths in line and closes two information-reflection channels.

**No CRITICAL/HIGH SSRF was exploitable as shipped** — integration writes are MFA + `ORGS_WRITE` gated, and `safeFetch` already blocks internal/metadata IPs. These are defense-in-depth fixes plus two reflection-channel closures, with regression tests for every invariant.

## The four fixes

### 1. Huntress — route egress through `safeFetch` (`services/huntressClient.ts`)
Was calling raw global `fetch()`: followed redirects by default, no DNS pinning, and the `.huntress.io` allowlist was only checked on the **initial** base URL — so an upstream `3xx Location: http://169.254.169.254/...` (or `127.0.0.1:<port>`) would be chased into internal address space.
- All outbound calls now go through `safeFetch` (DNS-pinned; follows **no** redirects → a raw 3xx is rejected by the non-2xx branch, never chased).
- Re-assert `https` + `.huntress.io` on the **final** per-request URL (defense in depth).
- `isTimeoutError()` now recognizes `safeFetch`'s timeout/abort error shapes (it routes through `http(s).request`, not undici, so the old `DOMException('AbortError')` check alone would miss timeouts).

### 2. DNS providers — stop reflecting upstream error bodies to tenants (`services/dnsProviders/{http,index}.ts`, `jobs/dnsSyncJob.ts`)
The upstream provider error body (≤400 chars) was reflected to tenants via `dns_filter_integrations.lastSyncError` / `dns_policies.syncError` — a partial-read oracle / confused-deputy for tenant-supplied Pi-hole/AdGuard endpoints.
- New `DnsProviderHttpError` carries `status`/`statusText`/`responseBody` with a **body-free** `.message`.
- Both tenant-visible columns now store only the status line; full detail (redacted via `redactLogMessage`) is logged **server-side**, and the error is re-thrown so the BullMQ `failed` handler / Sentry still fire.

### 3. M365 / c2c — validate `tenantId`, harden token fetches (`services/c2cM365.ts`, `routes/c2c/{schemas,m365Auth}.ts`)
Tenant-controlled `tenantId` reached the Azure token URL with no format validation (`encodeURIComponent` kept the host pinned, so this was path-injection, not host-control SSRF — but the missing validation was a real input-hygiene gap).
- Validate **GUID-only** at the schema (provider-conditional `superRefine` — Google Workspace and other providers are unaffected), at the public callback, and at the service trust boundary (`acquireClientCredentialsToken`, which also covers the `ensureFreshToken` / `/test` refresh path).
- Add `redirect: 'error'` to the token and Graph `fetch`es (undici **does** honor this) so a bearer-bearing request can't be redirected off-host.

### 4. SentinelOne — re-assert the allowlist at egress (`services/sentinelOne/{client,constants}.ts`, `routes/sentinelOne.ts`)
The `.sentinelone.net` allowlist was enforced only at the write route. The client is constructed in several background-job sites that bypass that route guard.
- Share one `S1_HOSTNAME_ALLOWLIST` constant (single source of truth) and re-assert it in `normalizeManagementUrl` (fail closed) so a token is never sent to a non-allowed host, even via a future non-route writer.

## Testing

- `npx tsc --noEmit` (api): clean.
- Affected suites: **10 files / 93 tests pass**, including new regression tests that would fail on revert:
  - Huntress: global `fetch` is never used (only `safeFetch`); a 3xx is rejected and **not** followed to another host; timeout passed through.
  - DNS: upstream body marker is **absent** from both `lastSyncError` and `syncError`; full body logged server-side; `?auth=<key>` redaction.
  - M365: non-GUID `tenant` rejected at schema / callback / service **before any fetch**; Google Workspace still accepts non-GUID; `testGraphAccess` passes `redirect:'error'` and does not leak the Graph error body.
  - SentinelOne: token is **never sent** (safeFetch not called) for a disallowed or look-alike host; regional `*.sentinelone.net` subdomains still accepted.

## Review provenance

Findings were generated via a two-pass SSRF review, each independently re-confirmed by a separate read-only agent (refute-first), then this changeset was reviewed by the PR-review toolkit (code / silent-failure / tests / types / comments) — all three review-pass items applied here.

## Follow-ups (not in this PR)

- `docs/SECURITY.md` overstates the pre-fix Huntress protection ("restricted to `*.huntress.io` to prevent SSRF") — wording correction.
- SentinelOne `s1Sync.ts` still stores a 500-char upstream body in `lastSyncError` (pre-existing; fixed-vendor host, weaker risk) — apply the same `DnsProviderHttpError`-style split for consistency.
- Optional: brand `M365TenantId` so "validated → trusted" is a type-level fact; `c2c_connections.tenant_id` DB `CHECK` constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
