### PR TITLE
fix(security): denormalize script_execution_batches org_id — RLS regression from #1016 (CRITICAL)

### DIFF
--- a/apps/api/migrations/2026-05-31-script-execution-batches-org-id.sql
+++ b/apps/api/migrations/2026-05-31-script-execution-batches-org-id.sql
@@ -1,0 +1,65 @@
+-- 2026-05-31: Denormalize org_id onto script_execution_batches + direct org RLS.
+--
+-- Why this is separate from 2026-05-30-fk-child-tables-rls.sql:
+-- script_execution_batches reaches its tenant only through `scripts`, whose
+-- org_id is NULLABLE (system/built-in scripts have org_id = NULL, is_system =
+-- true). A parent-FK join policy would need `s.is_system = true OR
+-- breeze_has_org_access(s.org_id)`, but that nested-RLS EXISTS does NOT evaluate
+-- the is_system branch correctly under the production driver's extended-protocol
+-- (bound-parameter) INSERTs — a tenant running a built-in script on 2+ devices
+-- (routes/scripts.ts) would get "new row violates row-level security policy"
+-- creating its batch. (Verified: org-script inserts pass, system-script inserts
+-- fail, only under bound parameters.)
+--
+-- Fix: carry the executing org directly on the row. routes/scripts.ts now sets
+-- org_id at insert (the org of the targeted devices, which the caller already
+-- has ensureOrgAccess to). RLS becomes a direct breeze_has_org_access(org_id) —
+-- no subquery, no is_system branch, deterministic under any protocol. A
+-- system-script batch now belongs to the org that ran it (so that org can read
+-- its own batch) while remaining isolated from other tenants.
+--
+-- All write paths satisfy the policy: the route INSERT/UPDATE run under the
+-- caller's org (breeze_has_org_access(org_id) = TRUE for their own org); the
+-- agent WS counter update and the stale-command reaper run wherever the sibling
+-- script_executions update already passes (system scope short-circuits TRUE,
+-- org/device scope matches the batch's org).
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS; backfill only touches NULL org_id rows;
+-- DROP POLICY IF EXISTS before CREATE (also removes the interim parent-FK join
+-- policies a DB may have applied from an earlier revision of 2026-05-30).
+-- autoMigrate wraps each file in a transaction — no inner BEGIN/COMMIT.
+
+ALTER TABLE script_execution_batches
+  ADD COLUMN IF NOT EXISTS org_id uuid REFERENCES organizations(id);
+
+CREATE INDEX IF NOT EXISTS script_execution_batches_org_id_idx
+  ON script_execution_batches(org_id);
+
+-- Backfill legacy rows from their (org-scoped) parent script. System-script
+-- batches (scripts.org_id IS NULL) cannot be attributed retroactively — they
+-- keep org_id = NULL and are reachable only under system scope, matching their
+-- pre-RLS exposure (there was no tenant read path for them).
+UPDATE script_execution_batches b
+   SET org_id = s.org_id
+  FROM scripts s
+ WHERE b.script_id = s.id
+   AND b.org_id IS NULL
+   AND s.org_id IS NOT NULL;
+
+ALTER TABLE script_execution_batches ENABLE ROW LEVEL SECURITY;
+ALTER TABLE script_execution_batches FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON script_execution_batches;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON script_execution_batches;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON script_execution_batches;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON script_execution_batches;
+
+CREATE POLICY breeze_org_isolation_select ON script_execution_batches
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON script_execution_batches
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON script_execution_batches
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON script_execution_batches
+  FOR DELETE USING (public.breeze_has_org_access(org_id));

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -5,6 +5,8 @@ import { partners, users, organizations } from '../../db/schema';
 import { approvalRequests } from '../../db/schema/approvals';
 import { manifestSigningKeys } from '../../db/schema/manifestSigningKeys';
 import { automations, automationRuns } from '../../db/schema/automations';
+import { configurationPolicies } from '../../db/schema/configurationPolicies';
+import { scripts, scriptExecutionBatches } from '../../db/schema/scripts';
 
 /**
  * Contract test: every tenant-scoped public table must have RLS enabled and
@@ -130,7 +132,10 @@ const PARENT_FK_JOIN_POLICY_TABLES: ReadonlyMap<string, readonly string[]> = new
   ['automation_runs', ['automations', 'configuration_policies']],
   ['ai_messages', ['ai_sessions']],
   ['ai_tool_executions', ['ai_sessions']],
-  ['script_execution_batches', ['scripts']],
+  // NOTE: script_execution_batches is NOT here — it carries a denormalized
+  // org_id column (2026-05-31 migration) and is auto-discovered as an ordinary
+  // org-tenant table, because a nested-RLS join through its nullable-org parent
+  // `scripts` could not satisfy the system-script INSERT under bound parameters.
   ['software_versions', ['software_catalog']],
   ['alert_correlations', ['alerts']],
   ['alert_notifications', ['alerts']],
@@ -1144,6 +1149,10 @@ describe('automation_runs RLS — cross-org forge enforcement (Shape 7)', () => 
   let orgBId: string;
   let automationAId: string;
   let runAId: string | null = null;
+  // Config-policy-driven run: automation_id is NULL, org reached via
+  // config_policy_id -> configuration_policies.org_id (the F2/F3 leak path).
+  let configPolicyAId: string;
+  let configRunAId: string | null = null;
 
   // Org-scoped context granting access to exactly one org and nothing else,
   // so no other policy can accidentally green-light a cross-org row.
@@ -1206,6 +1215,27 @@ describe('automation_runs RLS — cross-org forge enforcement (Shape 7)', () => 
         .returning({ id: automationRuns.id });
       if (!runA) throw new Error('failed to seed automation_run for forge');
       runAId = runA.id;
+
+      // Config-policy-driven run flavor (automation_id NULL): reaches its org
+      // only via config_policy_id -> configuration_policies.org_id.
+      const [policyA] = await db
+        .insert(configurationPolicies)
+        .values({ orgId: orgA.id, name: 'Org A config policy' })
+        .returning({ id: configurationPolicies.id });
+      if (!policyA) throw new Error('failed to seed configuration_policy for forge');
+      configPolicyAId = policyA.id;
+
+      const [configRunA] = await db
+        .insert(automationRuns)
+        .values({
+          configPolicyId: policyA.id, // automationId intentionally left NULL
+          configItemName: 'Org A config item',
+          triggeredBy: 'rls-forge-test',
+          status: 'completed',
+        })
+        .returning({ id: automationRuns.id });
+      if (!configRunA) throw new Error('failed to seed config-policy automation_run for forge');
+      configRunAId = configRunA.id;
     });
   }
 
@@ -1219,6 +1249,12 @@ describe('automation_runs RLS — cross-org forge enforcement (Shape 7)', () => 
         await db.delete(automationRuns).where(eq(automationRuns.automationId, automationAId));
       }
       if (automationAId) await db.delete(automations).where(eq(automations.id, automationAId));
+      // Config-policy runs (automation_id NULL) aren't caught by the automationId
+      // delete above; clear them + the policy before deleting the org (FK order).
+      if (configPolicyAId) {
+        await db.delete(automationRuns).where(eq(automationRuns.configPolicyId, configPolicyAId));
+        await db.delete(configurationPolicies).where(eq(configurationPolicies.id, configPolicyAId));
+      }
       if (orgAId) await db.delete(organizations).where(eq(organizations.id, orgAId));
       if (orgBId) await db.delete(organizations).where(eq(organizations.id, orgBId));
       if (partnerId) await db.delete(partners).where(eq(partners.id, partnerId));
@@ -1276,6 +1312,199 @@ describe('automation_runs RLS — cross-org forge enforcement (Shape 7)', () => 
       expect(message).toMatch(
         /new row violates row-level security policy for table "automation_runs"/,
       );
+    },
+  );
+
+  // --- config-policy-driven runs (automation_id NULL) — the F2/F3 branch ---
+  it.runIf(!!process.env.DATABASE_URL)(
+    'org A can SELECT its config-policy automation_run (config_policy_id reach)',
+    async () => {
+      await ensureFixtures();
+      const rows = await withDbAccessContext(orgContext(orgAId), async () =>
+        db
+          .select({ id: automationRuns.id })
+          .from(automationRuns)
+          .where(eq(automationRuns.id, configRunAId!)),
+      );
+      expect(rows.map((r) => r.id)).toEqual([configRunAId]);
+    },
+  );
+
+  it.runIf(!!process.env.DATABASE_URL)(
+    "org B cannot SELECT org A's config-policy automation_run (RLS hides it)",
+    async () => {
+      await ensureFixtures();
+      if (!configRunAId) throw new Error('seed test must run first');
+      const rows = await withDbAccessContext(orgContext(orgBId), async () =>
+        db
+          .select({ id: automationRuns.id })
+          .from(automationRuns)
+          .where(eq(automationRuns.id, configRunAId!)),
+      );
+      expect(rows).toEqual([]);
+    },
+  );
+
+  it.runIf(!!process.env.DATABASE_URL)(
+    "org B INSERT referencing org A's config policy is rejected by WITH CHECK",
+    async () => {
+      await ensureFixtures();
+      let caught: unknown;
+      try {
+        await withDbAccessContext(orgContext(orgBId), async () =>
+          db.insert(automationRuns).values({
+            configPolicyId: configPolicyAId, // forging a run under another tenant's config policy
+            configItemName: 'forged',
+            triggeredBy: 'rls-forge-test-crossorg-cp',
+            status: 'running',
+          }),
+        );
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeDefined();
+      const cause = caught as { cause?: { message?: string }; message?: string } | undefined;
+      const message = cause?.cause?.message ?? cause?.message ?? '';
+      expect(message).toMatch(
+        /new row violates row-level security policy for table "automation_runs"/,
+      );
+    },
+  );
+});
+
+// ===========================================================================
+// script_execution_batches RLS — denormalized org_id (2026-05-31 review fix)
+//
+// Batches carry a denormalized org_id (the executing org), so the policy is a
+// direct breeze_has_org_access(org_id) — no nested-RLS join through the
+// nullable-org `scripts` parent. This forge proves the two things the nested
+// `is_system` join FAILED at under the production driver's bound-parameter
+// INSERTs: (a) a tenant CAN insert a batch for a SYSTEM script under tenant
+// context (org_id = its own org), and (b) cross-org isolation holds — org B
+// cannot read org A's batch, and a forged cross-org INSERT is rejected.
+// ===========================================================================
+describe('script_execution_batches RLS — denormalized org_id', () => {
+  const runSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  let partnerId: string;
+  let orgAId: string;
+  let orgBId: string;
+  let systemScriptId: string;
+  let batchAId: string | null = null;
+
+  function orgContext(orgId: string) {
+    return {
+      scope: 'organization' as const,
+      orgId,
+      accessibleOrgIds: [orgId],
+      accessiblePartnerIds: [],
+      userId: null,
+    };
+  }
+
+  async function ensureFixtures(): Promise<void> {
+    if (partnerId) return;
+    await withSystemDbAccessContext(async () => {
+      const [partner] = await db
+        .insert(partners)
+        .values({
+          name: `RLS Batches Partner ${runSuffix}`,
+          slug: `rls-batches-${runSuffix}`,
+          type: 'msp',
+          plan: 'pro',
+          status: 'active',
+        })
+        .returning({ id: partners.id });
+      if (!partner) throw new Error('failed to seed partner for batches forge');
+      partnerId = partner.id;
+
+      const [orgA, orgB] = await db
+        .insert(organizations)
+        .values([
+          { partnerId: partner.id, name: 'RLS Batches Org A', slug: `rls-batches-a-${runSuffix}` },
+          { partnerId: partner.id, name: 'RLS Batches Org B', slug: `rls-batches-b-${runSuffix}` },
+        ])
+        .returning({ id: organizations.id });
+      if (!orgA || !orgB) throw new Error('failed to seed orgs for batches forge');
+      orgAId = orgA.id;
+      orgBId = orgB.id;
+
+      // A SYSTEM script (org_id NULL, is_system) — the case the nested-RLS join
+      // could not handle. With denormalization the batch (not the script) holds
+      // the executing org.
+      const [systemScript] = await db
+        .insert(scripts)
+        .values({
+          orgId: null,
+          isSystem: true,
+          name: 'System script',
+          osTypes: ['windows'],
+          language: 'powershell',
+          content: 'echo sys',
+        })
+        .returning({ id: scripts.id });
+      if (!systemScript) throw new Error('failed to seed system script for batches forge');
+      systemScriptId = systemScript.id;
+    });
+  }
+
+  afterAll(async () => {
+    await withSystemDbAccessContext(async () => {
+      if (systemScriptId) await db.delete(scriptExecutionBatches).where(eq(scriptExecutionBatches.scriptId, systemScriptId));
+      if (systemScriptId) await db.delete(scripts).where(eq(scripts.id, systemScriptId));
+      if (orgAId) await db.delete(organizations).where(eq(organizations.id, orgAId));
+      if (orgBId) await db.delete(organizations).where(eq(organizations.id, orgBId));
+      if (partnerId) await db.delete(partners).where(eq(partners.id, partnerId));
+    });
+  });
+
+  it.runIf(!!process.env.DATABASE_URL)(
+    'org A CAN INSERT a batch for a system script under tenant context (denormalized org_id; bound-parameter INSERT now works)',
+    async () => {
+      await ensureFixtures();
+      const inserted = await withDbAccessContext(orgContext(orgAId), async () =>
+        db
+          .insert(scriptExecutionBatches)
+          .values({ scriptId: systemScriptId, orgId: orgAId, devicesTargeted: 2, status: 'pending' })
+          .returning({ id: scriptExecutionBatches.id }),
+      );
+      expect(inserted).toHaveLength(1);
+      batchAId = inserted[0]!.id;
+    },
+  );
+
+  it.runIf(!!process.env.DATABASE_URL)(
+    "org A SELECTs its own batch; org B cannot (cross-org isolation)",
+    async () => {
+      await ensureFixtures();
+      if (!batchAId) throw new Error('insert test must run first');
+      const a = await withDbAccessContext(orgContext(orgAId), async () =>
+        db.select({ id: scriptExecutionBatches.id }).from(scriptExecutionBatches).where(eq(scriptExecutionBatches.id, batchAId!)),
+      );
+      expect(a.map((r) => r.id)).toEqual([batchAId]);
+      const b = await withDbAccessContext(orgContext(orgBId), async () =>
+        db.select({ id: scriptExecutionBatches.id }).from(scriptExecutionBatches).where(eq(scriptExecutionBatches.id, batchAId!)),
+      );
+      expect(b).toEqual([]);
+    },
+  );
+
+  it.runIf(!!process.env.DATABASE_URL)(
+    "org B INSERT with org_id = org A is rejected by WITH CHECK",
+    async () => {
+      await ensureFixtures();
+      let caught: unknown;
+      try {
+        await withDbAccessContext(orgContext(orgBId), async () =>
+          db.insert(scriptExecutionBatches).values({ scriptId: systemScriptId, orgId: orgAId, devicesTargeted: 2, status: 'pending' }),
+        );
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeDefined();
+      const cause = caught as { cause?: { message?: string }; message?: string } | undefined;
+      const message = cause?.cause?.message ?? cause?.message ?? '';
+      expect(message).toMatch(/new row violates row-level security policy for table "script_execution_batches"/);
     },
   );
 });

--- a/apps/api/src/db/schema/scripts.ts
+++ b/apps/api/src/db/schema/scripts.ts
@@ -121,6 +121,12 @@ export const scriptExecutions = pgTable('script_executions', {
 export const scriptExecutionBatches = pgTable('script_execution_batches', {
   id: uuid('id').primaryKey().defaultRandom(),
   scriptId: uuid('script_id').notNull().references(() => scripts.id),
+  // Denormalized tenant axis (set to the executing org at insert). Nullable
+  // only to allow backfill of legacy rows whose system-script parent has no
+  // org_id; new rows always carry it. Enables a direct org RLS policy instead
+  // of a nested-RLS join through `scripts` (which the system-script `is_system`
+  // carve-out could not satisfy under bound-parameter INSERTs).
+  orgId: uuid('org_id').references(() => organizations.id),
   triggeredBy: uuid('triggered_by').references(() => users.id),
   triggerType: triggerTypeEnum('trigger_type').notNull().default('manual'),
   parameters: jsonb('parameters'),
@@ -130,4 +136,6 @@ export const scriptExecutionBatches = pgTable('script_execution_batches', {
   status: executionStatusEnum('status').notNull().default('pending'),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   completedAt: timestamp('completed_at')
-});
+}, (table) => ({
+  orgIdIdx: index('script_execution_batches_org_id_idx').on(table.orgId)
+}));

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -700,10 +700,15 @@ scriptRoutes.post(
     // Create batch if multiple devices
     let batchId: string | null = null;
     if (executableDevices.length > 1) {
+      // Denormalize the executing org onto the batch (RLS tenant axis). All
+      // executableDevices passed ensureOrgAccess above; for a built-in/system
+      // script (scripts.org_id is NULL) this is the only tenant linkage.
+      const batchOrgId = executableDevices[0]!.orgId;
       const [batch] = await db
         .insert(scriptExecutionBatches)
         .values({
           scriptId,
+          orgId: batchOrgId,
           triggeredBy: auth.user.id,
           triggerType,
           parameters,

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -200,6 +200,7 @@ export const ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'saved_filters',
   'saved_queries',
   'script_categories',
+  'script_execution_batches',
   'script_executions',
   'script_tags',
   'scripts',


### PR DESCRIPTION
## Critical — regression now in `main`

#1016 (merged) added RLS to `script_execution_batches` via a **nested `EXISTS` through `scripts`**, whose `org_id` is NULL for system/built-in scripts, with an `is_system = true OR breeze_has_org_access(org_id)` carve-out for INSERT/UPDATE.

That nested-RLS branch **does not evaluate under the production driver** (Drizzle/postgres.js extended protocol, bound `$1` parameters). Result: a tenant running a **built-in/system script on 2+ devices** (`POST /scripts/:id/execute`, which inserts a `script_execution_batches` row under tenant context) hits `new row violates row-level security policy for table "script_execution_batches"` — the batch is never created and the run fails.

Verified empirically across protocols:
- `psql` (simple protocol, even prepared, even in a txn with LOCAL GUCs): INSERT **succeeds**.
- Drizzle/postgres.js (extended protocol, bound params — what the app uses): INSERT **fails**, and only for the `is_system` (nullable-org) branch — org-script inserts pass.

The other 6 tables from #1016 are unaffected (their parents have NOT-NULL `org_id`, i.e. the `breeze_has_org_access` path, which evaluates correctly under bound parameters).

## Fix-forward — denormalize the executing org onto the row

- **schema + `2026-05-31-script-execution-batches-org-id.sql`**: add `script_execution_batches.org_id` (+ index), backfill org-scoped rows from the parent script, then **DROP the nested-EXISTS policies and CREATE direct `breeze_has_org_access(org_id)` policies** (all four DML commands). No subquery, no `is_system` branch → deterministic under any protocol. A system-script batch now belongs to (and is readable by) the org that ran it, while staying isolated from other tenants.
- **`routes/scripts.ts`**: set `org_id` at batch insert — the targeted devices' org, which the caller already passed `ensureOrgAccess` for.
- **`rls-coverage.integration.test.ts`**: `script_execution_batches` drops out of the parent-FK allowlist (now auto-discovered as an org-tenant table via `org_id`). The rewritten forge proves the **bound-parameter system-script INSERT now works** *and* cross-org isolation (org B can't read org A's batch; a cross-org INSERT is rejected by WITH CHECK). Also forges the `automation_runs` config-policy branch (shares this file).

`2026-05-30` (shipped in #1016) is **left untouched** — this is a forward migration; its `DROP POLICY IF EXISTS` + `CREATE` supersede the batch policies idempotently.

## Test plan

- `tsc --noEmit`: clean
- `rls-coverage`: **27 passed**, incl. the denormalized batch forge (bound-parameter INSERT + cross-org isolation) and the config-policy forge
- autoMigrate ordering regression: **43 passed**
- `db:check-drift`: clean (214 migrations)

Found by the multi-agent review of #1016 (the forge it added caught this). A separate follow-up PR carries the remaining test/comment hardening from the #1016 and #1019 reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)