### PR TITLE
test(security): review hardening for #1016 + #1019 (test coverage + audit-notice logging)

### DIFF
--- a/apps/api/src/routes/admin/abuse.test.ts
+++ b/apps/api/src/routes/admin/abuse.test.ts
@@ -339,7 +339,7 @@ describe('admin/abuse — auth gate', () => {
   });
 
   // MFA step-up: re-enabling an abuse-suspended partner is privilege-restoring
-  // (flips status back to active + re-enables all its disabled users), so it
+  // (flips status back to active/pending + re-enables all its disabled users), so it
   // MUST require the same MFA step-up as suspend-for-abuse. requireMfa() is a
   // no-op when ENABLE_2FA is off, so this gate is free until 2FA is enabled.
   it('rejects /unsuspend when MFA is not satisfied (403)', async () => {

--- a/apps/api/src/routes/automations.test.ts
+++ b/apps/api/src/routes/automations.test.ts
@@ -843,6 +843,91 @@ describe('automations routes', () => {
     expect(body.automation).toBeNull();
   });
 
+  it('returns 404 for an automation-backed run whose org the caller cannot access', async () => {
+    // First select: the run (automationId set).
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: 'run-ab-1',
+              automationId: 'auto-OTHER',
+              configPolicyId: null,
+              status: 'running',
+              logs: [],
+            }])
+          })
+        })
+      } as any)
+      // Second select (getAutomationWithOrgCheck): the automation resolving to org-OTHER.
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: 'auto-OTHER',
+              name: 'Other Tenant Automation',
+              orgId: 'org-OTHER',
+            }])
+          })
+        })
+      } as any);
+
+    const res = await app.request('/automations/runs/run-ab-1', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer valid-token' }
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe('Automation run not found');
+    // Must not leak the automation name or the owning org id.
+    expect(JSON.stringify(body)).not.toContain('Other Tenant Automation');
+    expect(JSON.stringify(body)).not.toContain('org-OTHER');
+  });
+
+  it('returns 200 for an automation-backed run whose org the caller can access', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: 'run-ab-1',
+              automationId: 'auto-1',
+              configPolicyId: null,
+              status: 'completed',
+              logs: [],
+            }])
+          })
+        })
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: 'auto-1',
+              name: 'Automation One',
+              orgId: 'org-123',
+            }])
+          })
+        })
+      } as any);
+
+    const res = await app.request('/automations/runs/run-ab-1', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer valid-token' }
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe('run-ab-1');
+    expect(body.status).toBe('success');
+    expect(body.automation).toEqual({
+      id: 'auto-1',
+      name: 'Automation One',
+      orgId: 'org-123',
+    });
+  });
+
   // ============================================
   // F8 (audit): webhook-triggered run must be audited
   // ============================================

--- a/apps/api/src/routes/groups.test.ts
+++ b/apps/api/src/routes/groups.test.ts
@@ -163,6 +163,34 @@ describe('group routes', () => {
       expect(insertSpy).not.toHaveBeenCalled();
     });
 
+    it('rejects (403) the whole batch when one of several devices is out of scope (partial batch)', async () => {
+      setAuth(['site-x']);
+      const insertSpy = vi.mocked(db.insert);
+      vi.mocked(db.select)
+        // 1. group lookup
+        .mockReturnValueOnce(mockGroupSelect())
+        // 2. device {id, orgId} lookup — both devices belong to the right org
+        .mockReturnValueOnce(mockWhereResolves([
+          { id: DEVICE_IN_SITE_X, orgId: ORG },
+          { id: DEVICE_IN_SITE_Y, orgId: ORG }
+        ]))
+        // 3. canAccessDeviceSite for device-x — site-x, allowed
+        .mockReturnValueOnce(mockSiteSelect('site-x'))
+        // 4. canAccessDeviceSite for device-y — site-y, NOT allowed
+        .mockReturnValueOnce(mockSiteSelect('site-y'));
+
+      const res = await app.request(`/groups/${GROUP_ID}/devices`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deviceIds: [DEVICE_IN_SITE_X, DEVICE_IN_SITE_Y] })
+      });
+
+      expect(res.status).toBe(403);
+      // Fail closed — the whole batch is rejected, NOT the in-scope device
+      // (device-x) partially added.
+      expect(insertSpy).not.toHaveBeenCalled();
+    });
+
     it('allows a confined user to add a device whose site (site-x) is in scope', async () => {
       setAuth(['site-x']);
       vi.mocked(db.select)

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -59,8 +59,25 @@ vi.mock('../db', () => ({
 vi.mock('../db/schema', () => ({
   partners: {},
   organizations: {},
-  sites: {}
+  // Give sites.id a recognizable sentinel so the site-allowlist test can assert
+  // inArray was called against the sites.id column specifically.
+  sites: { id: { __column: 'sites.id' }, orgId: { __column: 'sites.orgId' } }
 }));
+
+// Spy on inArray so the site-allowlist test can assert the GET /orgs/sites
+// handler actually intersects the query with inArray(sites.id, allowedSiteIds).
+// Keep every other drizzle-orm export real.
+vi.mock('drizzle-orm', async (importActual) => {
+  const actual = await importActual<typeof import('drizzle-orm')>();
+  return {
+    ...actual,
+    // Return an opaque sentinel instead of building a real SQL fragment: the db
+    // is fully mocked, so the return value is never executed, but the sentinel
+    // columns ({ __column: ... }) aren't real Drizzle columns and would make the
+    // real inArray throw on introspection.
+    inArray: vi.fn((column: unknown, values: unknown) => ({ __inArray: { column, values } }))
+  };
+});
 
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => {
@@ -88,7 +105,9 @@ vi.mock('../middleware/auth', () => ({
   requireMfa: vi.fn(() => async (_c: any, next: any) => next())
 }));
 
+import { inArray } from 'drizzle-orm';
 import { db } from '../db';
+import { sites } from '../db/schema';
 import { authMiddleware } from '../middleware/auth';
 import { revokeOrganizationTenantAccess, revokePartnerTenantAccess } from '../services/tenantLifecycle';
 import { captureException } from '../services/sentry';
@@ -1223,6 +1242,10 @@ describe('org routes', () => {
         const body = await res.json();
         expect(body.data).toEqual([{ id: 'site-x' }]);
         expect(body.data).not.toContainEqual({ id: 'site-y' });
+        // Meaningful assertion: the handler must have intersected the query with
+        // inArray(sites.id, allowedSiteIds). This fails if the intersection in
+        // orgs.ts is removed (mocked DB would echo site-x regardless otherwise).
+        expect(inArray).toHaveBeenCalledWith(sites.id, ['site-x']);
       });
 
       it('does not restrict the list for an unconfined user (allowedSiteIds undefined)', async () => {

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -973,7 +973,8 @@ orgRoutes.get('/sites', requireScope('organization', 'partner', 'system'), requi
   // Per-user site confinement. ensureOrgAccess (above) is org-axis only and
   // RLS on `sites` is also org-axis only, so a site-confined user would
   // otherwise enumerate every sibling site in the org. Intersect the org
-  // filter with allowedSiteIds. Mirrors scripts.ts:858-869.
+  // filter with allowedSiteIds. Mirrors the allowedSiteIds intersection in the
+  // GET /scripts/:id/executions list handler.
   const permissions = c.get('permissions') as UserPermissions | undefined;
   const allowedSiteIds = permissions?.allowedSiteIds;
   if (allowedSiteIds?.length === 0) {

--- a/apps/api/src/routes/thirdPartyCatalog/list.test.ts
+++ b/apps/api/src/routes/thirdPartyCatalog/list.test.ts
@@ -6,6 +6,11 @@ import { thirdPartyCatalogRoutes } from './index';
 
 const mockPlatformAdminState = vi.hoisted(() => ({
   isPlatformAdmin: true,
+  // Step-up state on the auth token. List (read) routes are gated by
+  // platformAdminMiddleware ONLY — the router-level requireMfa() lives on
+  // operations.ts (writes). Reads must stay ungated, so an unsatisfied-MFA
+  // token must still read fine. Defaults to true; the asymmetry test flips it.
+  tokenMfa: true as boolean,
 }));
 
 const mockCatalogTable = vi.hoisted(() => ({
@@ -60,6 +65,7 @@ vi.mock('../../middleware/platformAdmin', () => ({
         email: 'platform@example.com',
         isPlatformAdmin: true,
       },
+      token: { mfa: mockPlatformAdminState.tokenMfa },
     });
     return next();
   }),
@@ -134,6 +140,7 @@ describe('third-party catalog routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPlatformAdminState.isPlatformAdmin = true;
+    mockPlatformAdminState.tokenMfa = true;
     app = new Hono();
     app.route('/third-party-catalog', thirdPartyCatalogRoutes);
   });
@@ -144,6 +151,21 @@ describe('third-party catalog routes', () => {
     const res = await app.request('/third-party-catalog');
 
     expect([401, 403]).toContain(res.status);
+  });
+
+  it('allows a GET read even when MFA step-up is NOT satisfied (reads bypass requireMfa)', async () => {
+    // The router-level requireMfa() gate lives on operations.ts (writes) only.
+    // This locks the read/write asymmetry: a future move of requireMfa to a
+    // shared parent router would start gating reads and fail this test.
+    mockPlatformAdminState.tokenMfa = false;
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectCatalogRows([catalogRow({})]) as never)
+      .mockReturnValueOnce(selectCount(1) as never);
+
+    const res = await app.request('/third-party-catalog');
+
+    expect(res.status).toBe(200);
   });
 
   it('lists catalog items with limit pagination', async () => {

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -9,12 +9,16 @@ const {
   resolveUserAuditOrgIdMock,
   requireCurrentPasswordStepUpMock,
   isPasswordAuthDisabledBySsoMock,
-  hasSatisfiedMfaMock
+  hasSatisfiedMfaMock,
+  captureExceptionMock,
+  getEmailServiceMock
 } = vi.hoisted(() => ({
   sendInviteMock: vi.fn().mockResolvedValue(undefined),
   sendEmailChangedMock: vi.fn().mockResolvedValue(undefined),
   createAuditLogAsyncMock: vi.fn().mockResolvedValue(undefined),
   resolveUserAuditOrgIdMock: vi.fn().mockResolvedValue(null),
+  captureExceptionMock: vi.fn(),
+  getEmailServiceMock: vi.fn(),
   // Default: step-up succeeds (returns null). Tests override to return a
   // Response to simulate a wrong password / rate-limit / Redis-down outcome.
   requireCurrentPasswordStepUpMock: vi.fn().mockResolvedValue(null),
@@ -131,10 +135,11 @@ vi.mock('./auth/ssoPolicy', () => ({
 }));
 
 vi.mock('../services/email', () => ({
-  getEmailService: vi.fn(() => ({
-    sendInvite: sendInviteMock,
-    sendEmailChanged: sendEmailChangedMock
-  }))
+  getEmailService: getEmailServiceMock
+}));
+
+vi.mock('../services/sentry', () => ({
+  captureException: captureExceptionMock
 }));
 
 vi.mock('../services/auditService', () => ({
@@ -201,6 +206,12 @@ describe('user routes', () => {
     isPasswordAuthDisabledBySsoMock.mockResolvedValue(false);
     hasSatisfiedMfaMock.mockReturnValue(true);
     sendEmailChangedMock.mockResolvedValue(undefined);
+    // Default: email service is configured. Tests override to null to exercise
+    // the "not configured" warning path.
+    getEmailServiceMock.mockReturnValue({
+      sendInvite: sendInviteMock,
+      sendEmailChanged: sendEmailChangedMock
+    });
     vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
       c.set('auth', {
         scope: 'partner',
@@ -754,6 +765,7 @@ describe('user routes', () => {
         expect.objectContaining({
           action: 'user.email.change',
           resourceId: 'user-123',
+          orgId: 'org-1',
           details: expect.objectContaining({
             previousEmail: 'old@example.com',
             newEmail: 'new@example.com',
@@ -831,6 +843,7 @@ describe('user routes', () => {
       expect(createAuditLogAsyncMock).toHaveBeenCalledWith(
         expect.objectContaining({
           action: 'user.email.change',
+          orgId: 'org-1',
           details: expect.objectContaining({
             previousEmail: 'old@example.com',
             newEmail: 'new@example.com',
@@ -913,6 +926,129 @@ describe('user routes', () => {
       expect(sendEmailChangedMock).not.toHaveBeenCalled();
       const actions = createAuditLogAsyncMock.mock.calls.map((c: any[]) => c[0].action);
       expect(actions).not.toContain('user.email.change');
+    });
+
+    it('case 8: PARTNER-scope email change resolves an attribution org for both audits', async () => {
+      // Partner-scope caller: auth.orgId === null, so the audit org must be
+      // resolved from the user's membership via resolveUserAuditOrgId — for the
+      // dedicated email-change audit too, not just the profile-update.
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          scope: 'partner',
+          partnerId: 'partner-123',
+          orgId: null,
+          user: { id: 'user-123', email: 'old@example.com' }
+        });
+        return next();
+      });
+      resolveUserAuditOrgIdMock.mockResolvedValueOnce('resolved-org-x');
+      mockSelfAndUniqueness({ email: 'old@example.com', passwordHash: 'hash' });
+      updateReturning(updatedRow('new@example.com'));
+      requireCurrentPasswordStepUpMock.mockResolvedValueOnce(null);
+
+      const res = await app.request('/users/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ email: 'new@example.com', currentPassword: 'correct-horse' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(resolveUserAuditOrgIdMock).toHaveBeenCalledWith('user-123');
+      expect(createAuditLogAsyncMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'user.email.change',
+          orgId: 'resolved-org-x',
+          details: expect.objectContaining({
+            previousEmail: 'old@example.com',
+            newEmail: 'new@example.com',
+            stepUp: 'password'
+          })
+        })
+      );
+    });
+
+    it('case 9: MIXED name+email change ⇒ profile.update lists BOTH fields AND email.change also fires', async () => {
+      orgScopeAuth();
+      mockSelfAndUniqueness({ email: 'old@example.com', passwordHash: 'hash' });
+      updateReturning({
+        id: 'user-123',
+        email: 'new@example.com',
+        name: 'New',
+        avatarUrl: null,
+        status: 'active',
+        mfaEnabled: false,
+        preferences: null
+      });
+      // Org scope, step-up passes (null).
+      requireCurrentPasswordStepUpMock.mockResolvedValueOnce(null);
+
+      const res = await app.request('/users/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ name: 'New', email: 'new@example.com', currentPassword: 'correct' })
+      });
+
+      expect(res.status).toBe(200);
+      const calls = createAuditLogAsyncMock.mock.calls.map((c: any[]) => c[0]);
+      const profileUpdate = calls.find((a) => a.action === 'user.profile.update');
+      expect(profileUpdate).toBeDefined();
+      expect(profileUpdate.details.changedFields).toEqual(
+        expect.arrayContaining(['name', 'email'])
+      );
+      const actions = calls.map((a) => a.action);
+      expect(actions).toContain('user.email.change');
+    });
+
+    it('case 10a: email service NOT configured ⇒ warns, does not attempt send, still 200', async () => {
+      orgScopeAuth();
+      mockSelfAndUniqueness({ email: 'old@example.com', passwordHash: 'hash' });
+      updateReturning(updatedRow('new@example.com'));
+      requireCurrentPasswordStepUpMock.mockResolvedValueOnce(null);
+      getEmailServiceMock.mockReturnValue(null);
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      try {
+        const res = await app.request('/users/me', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+          body: JSON.stringify({ email: 'new@example.com', currentPassword: 'correct-horse' })
+        });
+
+        expect(res.status).toBe(200);
+        expect(sendEmailChangedMock).not.toHaveBeenCalled();
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Email service not configured')
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('case 10b: sendEmailChanged throws ⇒ console.error + captureException, request still 200', async () => {
+      orgScopeAuth();
+      mockSelfAndUniqueness({ email: 'old@example.com', passwordHash: 'hash' });
+      updateReturning(updatedRow('new@example.com'));
+      requireCurrentPasswordStepUpMock.mockResolvedValueOnce(null);
+      const boom = new Error('smtp down');
+      sendEmailChangedMock.mockRejectedValueOnce(boom);
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      try {
+        const res = await app.request('/users/me', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+          body: JSON.stringify({ email: 'new@example.com', currentPassword: 'correct-horse' })
+        });
+
+        expect(res.status).toBe(200);
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Failed to send email-change security notice'),
+          boom
+        );
+        expect(captureExceptionMock).toHaveBeenCalledWith(boom);
+      } finally {
+        errorSpy.mockRestore();
+      }
     });
   });
 

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -18,6 +18,7 @@ import {
 import { createAuditLogAsync } from '../services/auditService';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
 import { getEmailService } from '../services/email';
+import { captureException } from '../services/sentry';
 import { getRedis } from '../services';
 import { INVITE_TOKEN_TTL_SECONDS } from './auth/schemas';
 import { hashInviteToken, inviteRedisKey, inviteUserRedisKey, requireCurrentPasswordStepUp, resolveUserAuditOrgId, userRequiresSetup } from './auth/helpers';
@@ -521,8 +522,9 @@ userRoutes.patch('/me', zValidator('json', updateMeSchema), async (c) => {
     const emailChanging = normalizedEmail !== self.email;
 
     if (emailChanging) {
-      // Account-takeover step-up — mirror change-password's SSO/password/MFA
-      // ordering, BEFORE any write.
+      // Account-takeover step-up — mirror change-password's SSO→password
+      // ordering; additionally allow MFA step-up for passwordless users
+      // (change-password rejects them with 400), BEFORE any write.
       // (a) SSO-enforced org: email is managed at the IdP.
       if (await isPasswordAuthDisabledBySso({ scope: auth.scope, orgId: auth.orgId })) {
         return c.json({ error: 'Email changes for this organization are managed through your SSO provider.' }, 403);
@@ -628,14 +630,19 @@ userRoutes.patch('/me', zValidator('json', updateMeSchema), async (c) => {
       result: 'success'
     });
 
-    // Notify the OLD address (best-effort: must never block or fail the request).
+    // Notify the OLD address (best-effort: never FAILs the request (errors are
+    // swallowed). It is awaited, so it adds the send latency to this (rare)
+    // email-change response).
     const emailService = getEmailService();
     if (emailService) {
       try {
         await emailService.sendEmailChanged({ to: previousEmail, name: updated.name, newEmail: updated.email });
       } catch (err) {
-        console.warn('Failed to send email-change notice', err);
+        console.error('[users] Failed to send email-change security notice', err);
+        captureException(err);
       }
+    } else {
+      console.warn('[users] Email service not configured; email-change security notice was not sent');
     }
   }
 


### PR DESCRIPTION
## Summary

Non-blocking follow-ups from the multi-agent reviews of #1016 and #1019. The **Critical** batch-RLS regression those reviews found is in a separate, focused PR (#1026). This PR is test-coverage + comment + one logging fix.

## #1016 — test coverage gaps the review found

- **`automations.test.ts`** — the `GET /automations/runs/:runId` **config-policy** branch had a cross-tenant 404 test, but the **automation-backed** branch did not. Added it (a run whose automation is in another org → 404, no name/org leak) + the positive control.
- **`orgs.test.ts`** — the "restricts the list to allowed sites" test was **tautological** (the db mock hard-coded the result, so it passed even if the `inArray(sites.id, allowedSiteIds)` intersection were deleted). Now asserts the filter is actually applied — verified to fail if the intersection is removed.
- **`groups.test.ts`** — bulk-add fail-closed was only tested with one device; added a **partial-batch** case (mixed in/out-of-scope → 403, `db.insert` not called).
- **`orgs.ts`** — replaced a rot-prone `scripts.ts:NNN` line reference with a symbol reference.

## #1019 — silent-failure + comment polish

- **`users.ts`** — the `PATCH /me` email-change **OLD-address security notice** is the account-takeover tripwire. It now logs `console.error` + `captureException` on a send failure (was `console.warn`) and logs when the email service is unconfigured (was a **silent** skip) — matching the `login.ts` account-locked convention. Plus two comment corrections: the notice is `await`ed (so it *does* block, contra the old comment); and `change-password` is SSO→password only — the MFA branch here is new, not "mirrored".
- **`users.test.ts`** — assert `orgId` on the `user.email.change` audit; a partner-scope email change (resolves org via `resolveUserAuditOrgId`); a mixed name+email change; and the notice logging paths (error+captureException on throw, warn on unconfigured).
- **`admin/abuse.test.ts`** — correct the `unsuspend` comment (status → active **or pending**).
- **`thirdPartyCatalog/list.test.ts`** — prove the read routes stay **ungated** by `requireMfa` (locks the read/write asymmetry; `requireMfa` lives on the operations router only).

## Test plan

- `tsc --noEmit`: clean
- **169 tests** across the 6 touched suites (automations, orgs, groups, users, abuse, list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)