### PR TITLE
fix(agent): write live PID to agent.state early in startup (stale-PID half of #1029)

### DIFF
--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -435,6 +435,26 @@ func startAgent(cfg *config.Config) (*agentComponents, error) {
 
 	initLogging(cfg)
 
+	// Record this process's live PID immediately, before any startup step that
+	// can wedge (e.g. the mTLS renewal network call below). Otherwise a wedge
+	// leaves agent.state holding a prior run's dead PID, and the watchdog reads
+	// that stale PID forever — reporting check.process_gone on a process that
+	// is actually alive-but-wedged, and force-killing the wrong (dead) PID
+	// instead of the live one. Status flips to StatusRunning at the end of
+	// startup (below). Fields mirror that running-state write; LastHeartbeat
+	// stays zero (watchdog treats zero as a startup grace period) exactly as
+	// the running-state write does until the first heartbeat records it.
+	// See #1029.
+	startupStatePath := state.PathInDir(config.ConfigDir())
+	if err := state.Write(startupStatePath, &state.AgentState{
+		Status:    state.StatusStarting,
+		PID:       os.Getpid(),
+		Version:   version,
+		Timestamp: time.Now(),
+	}); err != nil {
+		log.Warn("failed to write startup state file", "error", err.Error())
+	}
+
 	// Auto-clear Safe Mode BCD flag on startup to prevent reboot loops.
 	// If the agent triggered a safe mode reboot, the safeboot BCD entry
 	// persists until explicitly removed. Clear it so the next reboot is normal.

--- a/agent/internal/state/state.go
+++ b/agent/internal/state/state.go
@@ -11,6 +11,13 @@ import (
 const FileName = "agent.state"
 
 const (
+	// StatusStarting is written early in startup, before the agent is fully
+	// initialized, so the watchdog records THIS process's live PID rather than
+	// a stale PID from a prior run if startup wedges. It flips to
+	// StatusRunning once startup completes. The watchdog does not branch on
+	// Status (only PID / LastHeartbeat / IPC drive health decisions), so this
+	// is purely an accurate-PID and diagnostic signal.
+	StatusStarting = "starting"
 	StatusRunning  = "running"
 	StatusStopping = "stopping"
 	StatusStopped  = "stopped"

--- a/agent/internal/state/state_test.go
+++ b/agent/internal/state/state_test.go
@@ -88,6 +88,42 @@ func TestWriteStopping(t *testing.T) {
 	}
 }
 
+func TestWriteStarting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, FileName)
+
+	// The early startup write records the live PID with StatusStarting and a
+	// zero LastHeartbeat (startup grace), so the watchdog sees the live process
+	// rather than a prior run's stale PID. See #1029.
+	s := &AgentState{
+		Status:    StatusStarting,
+		PID:       4321,
+		Version:   "2.0.0",
+		Timestamp: time.Now(),
+	}
+
+	if err := Write(path, s); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Read returned nil")
+	}
+	if got.Status != StatusStarting {
+		t.Errorf("Status = %q, want %q", got.Status, StatusStarting)
+	}
+	if got.PID != 4321 {
+		t.Errorf("PID = %d, want 4321", got.PID)
+	}
+	if !got.LastHeartbeat.IsZero() {
+		t.Errorf("LastHeartbeat = %v, want zero (startup grace)", got.LastHeartbeat)
+	}
+}
+
 func TestReadMissing(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "nonexistent.state")


### PR DESCRIPTION
## Problem

`startAgent` writes `StatusRunning` + `os.Getpid()` to `agent.state` only at the **end** of startup (`cmd/breeze-agent/main.go`), after the full init pipeline: mTLS cert renewal (a network call that can hang), log-shipper init, and heartbeat/WebSocket/ETW bring-up.

If startup wedges before that final write — the mTLS renewal is the most likely culprit — `agent.state` keeps the **prior run's now-dead PID**. The watchdog reads that stale PID indefinitely and:

1. Logs `check.process_gone` every `processTicker` tick (`cmd/breeze-watchdog/main.go`) on a process that is actually alive-but-wedged, and
2. On attempt-2 recovery, force-kills the **wrong (dead) PID** instead of the live wedged process — so the wedged process is never actually killed.

This was observed live as a fleet endpoint spamming `check.process_gone {pid: <stale>}` every 5s with `agent.state` frozen at a dead PID from the previous run.

## Fix

Write the live PID with a new `StatusStarting` state **immediately after logging init**, before any wedge-prone step. Status flips to `StatusRunning` at the end of startup exactly as before.

Why this is safe / inert for control flow (verified against current `main`):
- The watchdog drives every health decision on **PID** (`process_gone`), **LastHeartbeat** (`CheckHeartbeatStaleness`), and **IPC** (`CheckIPC`). It never branches on `Status` — `Status` is read only by the diagnostic status command (`Printf`). So introducing `StatusStarting` cannot alter recovery behavior; it only ensures the watchdog has the correct live PID during startup.
- `LastHeartbeat` is left zero, which the watchdog treats as a startup grace period (`CheckHeartbeatStaleness` returns `CheckOK` for zero) — identical to what the existing end-of-startup `StatusRunning` write already does until the first heartbeat records a real value. No new heartbeat semantics.

Net effect: a wedged-but-alive agent is now seen as alive (no false `process_gone`), and attempt-2 force-kill targets the live PID.

## Scope

This addresses the **stale-PID half** of #1029. The other half — `recovery.go`/`recovery_windows.go` treating Windows `ERROR_SERVICE_ALREADY_RUNNING (1056)` as a failed attempt rather than success — is Windows-SCM-specific and not verifiable on a non-Windows dev box, so I've left it for a follow-up that can be validated on a Windows runner rather than ship unverified SCM behavior.

## Tests

- Adds `state.TestWriteStarting` (round-trips the early `StatusStarting` write with a live PID and zero `LastHeartbeat`).
- Full agent suite green under `go test -race ./...`; `go vet` and `gofmt` clean. No dependency or `go.mod` changes.

Fixes the stale-PID portion of #1029.
