### PR TITLE
fix(agent): present existing device token on forced re-enroll (token-present half of #1028)

### DIFF
--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -905,7 +905,13 @@ func enrollDevice(enrollmentKey string) {
 			err)
 	}
 
-	client := api.NewClient(cfg.ServerURL, "", "")
+	// Carry any existing device token into the enroll client. On a fresh
+	// enroll cfg.AuthToken is empty (no-op); on `--force` re-enroll it holds
+	// the token loaded from secrets.yaml, which Enroll presents as
+	// x-agent-reenrollment-token so the server re-enrolls the existing device
+	// row instead of 409-ing on a hostname collision with the agent's own
+	// active row (e.g. after a rename/re-image). See #1028.
+	client := api.NewClient(cfg.ServerURL, cfg.AuthToken, cfg.AgentID)
 
 	secret := enrollmentSecret
 	if secret == "" {

--- a/agent/pkg/api/client.go
+++ b/agent/pkg/api/client.go
@@ -143,6 +143,18 @@ func (c *Client) Enroll(req *EnrollRequest) (*EnrollResponse, error) {
 
 	httpReq.Header.Set("Content-Type", "application/json")
 
+	// On a forced re-enrollment the agent still holds its existing device
+	// token (loaded from secrets.yaml into the client). Present it so the
+	// server can match the existing device row and re-enroll it in place
+	// rather than treating this as a brand-new device and 409-ing on the
+	// hostname collision with the agent's own active row. The server reads
+	// this header in the enrollment route's existing-device branch. Empty on
+	// a fresh enroll (no stored token) -> header omitted, behaviour
+	// unchanged. See #1028.
+	if c.authToken != "" {
+		httpReq.Header.Set("x-agent-reenrollment-token", c.authToken)
+	}
+
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request: %w", err)

--- a/agent/pkg/api/client_test.go
+++ b/agent/pkg/api/client_test.go
@@ -66,3 +66,43 @@ func TestRotateToken(t *testing.T) {
 		t.Fatalf("RotatedAt = %q, want %q", resp.RotatedAt, "2026-03-31T20:00:00Z")
 	}
 }
+
+func TestEnrollPresentsReenrollToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		clientToken string
+		wantHeader  string
+	}{
+		{name: "force re-enroll presents existing token", clientToken: "brz_existing", wantHeader: "brz_existing"},
+		{name: "fresh enroll omits the header", clientToken: "", wantHeader: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sawReenroll string
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				sawReenroll = r.Header.Get("x-agent-reenrollment-token")
+				if r.Method != http.MethodPost || r.URL.Path != "/api/v1/agents/enroll" {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				_, _ = w.Write([]byte(`{"agentId":"agent-1","authToken":"brz_new"}`))
+			}))
+			defer ts.Close()
+
+			client := NewClient(ts.URL, tt.clientToken, "agent-1")
+			resp, err := client.Enroll(&EnrollRequest{EnrollmentKey: "key", Hostname: "host-1"})
+			if err != nil {
+				t.Fatalf("Enroll() error = %v", err)
+			}
+			if resp.AgentID != "agent-1" {
+				t.Fatalf("AgentID = %q, want %q", resp.AgentID, "agent-1")
+			}
+			if sawReenroll != tt.wantHeader {
+				t.Fatalf("x-agent-reenrollment-token = %q, want %q", sawReenroll, tt.wantHeader)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The agent's enroll client never presented the existing device token. So a `breeze-agent enroll --force` on an **already-enrolled** device — the path taken after a rename or re-image where the agent still holds its token in `secrets.yaml` — was treated as a brand-new enrollment. When the device's hostname collides with its **own active row**, the server returns:

```
409 hostname_collision_requires_existing_device_token
```

…and there is no agent-side way out: the error names an "admin-approved replacement workflow" that only exists for `decommissioned` rows, not active ones. The device is stuck until an operator intervenes server-side.

## Fix

`enrollDevice` already loads the existing config (including `cfg.AuthToken` from `secrets.yaml`). This change:

1. Constructs the enroll client with that token: `api.NewClient(cfg.ServerURL, cfg.AuthToken, cfg.AgentID)`.
2. `Enroll` sets `x-agent-reenrollment-token: <token>` when the client carries one — the exact header the enrollment route already reads (`getProvidedExistingDeviceToken`, `enrollment.ts:38`) in its existing-device branch.

The server then matches the existing device row and re-enrolls it in place instead of 409-ing.

**Additive and safe:** on a fresh enroll there is no stored token, so `cfg.AuthToken` is empty, the header is omitted, and behaviour is unchanged. A non-`--force` enroll on an enrolled device returns early ("already enrolled") and never reaches this path, so the token is only ever carried on an explicit `--force` re-enroll.

## Scope

This is the **agent half** of #1028 — the server already consumes the header. It covers the **token-still-present** collision (rename / re-image with `--force`). **Total credential loss** (no `secrets.yaml`, so no token to present) is out of scope here: that case has nothing to send and is recovered via the operator-side `POST /devices/:id/agent-token/rotate` endpoint.

## Tests

- `client_test.go`: table test asserting `x-agent-reenrollment-token` is sent when the client holds a token and omitted when it does not.
- Full agent suite green under `go test -race ./...`; `go vet`/`gofmt` clean; no dependency changes.

Addresses the token-present portion of #1028.
