### PR TITLE
fix(agent): keep terminal/PTY output on UTF-8 boundaries across read chunks (complements #976)

### DIFF
--- a/agent/internal/terminal/pty_windows.go
+++ b/agent/internal/terminal/pty_windows.go
@@ -130,35 +130,11 @@ func (s *Session) startPipes() error {
 	s.cmd = cmd
 	s.stdin = stdin
 
-	go func() {
-		buf := make([]byte, 4096)
-		for {
-			n, err := stdout.Read(buf)
-			if n > 0 && s.onOutput != nil {
-				data := make([]byte, n)
-				copy(data, buf[:n])
-				s.onOutput(data)
-			}
-			if err != nil {
-				return
-			}
-		}
-	}()
-
-	go func() {
-		buf := make([]byte, 4096)
-		for {
-			n, err := stderr.Read(buf)
-			if n > 0 && s.onOutput != nil {
-				data := make([]byte, n)
-				copy(data, buf[:n])
-				s.onOutput(data)
-			}
-			if err != nil {
-				return
-			}
-		}
-	}()
+	// Forward on UTF-8 rune boundaries so a multibyte char split across a
+	// 4096-byte read isn't decoded into U+FFFD downstream (streamUTF8 flushes
+	// any held tail on EOF).
+	go func() { _ = streamUTF8(stdout, s.onOutput, nil) }()
+	go func() { _ = streamUTF8(stderr, s.onOutput, nil) }()
 
 	go func() {
 		err := s.waitCmd()

--- a/agent/internal/terminal/terminal.go
+++ b/agent/internal/terminal/terminal.go
@@ -257,36 +257,22 @@ func (s *Session) notifyClosed(err error) {
 	})
 }
 
-// readLoop reads output from the PTY and sends it to the callback
+// readLoop reads output from the PTY and sends it to the callback. Output is
+// forwarded on UTF-8 rune boundaries (streamUTF8) so a multibyte character
+// split across a read boundary isn't decoded into U+FFFD downstream.
 func (s *Session) readLoop() {
 	defer observability.Recoverer("terminal.readLoop")
 	log.Info("readLoop started", "sessionId", s.ID)
-	buf := make([]byte, 4096)
-	firstRead := true
 
-	for {
-		n, err := s.pty.Read(buf)
-		if err != nil {
-			if err != io.EOF {
-				log.Warn("session read error", "sessionId", s.ID, "error", err)
-			} else {
-				log.Info("readLoop EOF", "sessionId", s.ID)
-			}
-			s.notifyClosed(err)
-			return
-		}
-
-		if n > 0 && s.onOutput != nil {
-			if firstRead {
-				log.Info("readLoop first data", "sessionId", s.ID, "bytes", n)
-				firstRead = false
-			}
-			// Make a copy of the data
-			data := make([]byte, n)
-			copy(data, buf[:n])
-			s.onOutput(data)
-		}
+	err := streamUTF8(s.pty, s.onOutput, func(n int) {
+		log.Info("readLoop first data", "sessionId", s.ID, "bytes", n)
+	})
+	if err != nil && err != io.EOF {
+		log.Warn("session read error", "sessionId", s.ID, "error", err)
+	} else {
+		log.Info("readLoop EOF", "sessionId", s.ID)
 	}
+	s.notifyClosed(err)
 }
 
 // getDefaultShell returns the default shell for the current OS

--- a/agent/internal/terminal/utf8stream.go
+++ b/agent/internal/terminal/utf8stream.go
@@ -1,0 +1,78 @@
+package terminal
+
+import (
+	"io"
+	"unicode/utf8"
+)
+
+// splitUTF8Boundary splits b at the last complete UTF-8 rune boundary. It
+// returns the leading bytes that end on a complete boundary (emit) plus any
+// trailing incomplete multibyte sequence (hold, at most utf8.UTFMax-1 bytes)
+// that must be prepended to the next read before decoding.
+//
+// Complete input — including pure ASCII — returns (b, nil). Bytes that are
+// invalid UTF-8 but are NOT a truncated trailing sequence (e.g. a stray
+// continuation byte or a lone 0xFF) are left in emit: they decode to width-1
+// U+FFFD errors regardless of buffering, so holding them would only stall.
+//
+// Rationale: PTY/pipe output is read in fixed-size chunks, so a multibyte rune
+// can straddle a chunk boundary. Forwarding the halves separately makes each
+// chunk get UTF-8-decoded independently downstream (e.g. Buffer.toString in the
+// API), turning the split rune into U+FFFD. Holding the trailing partial bytes
+// until the next read keeps every forwarded chunk on a rune boundary.
+func splitUTF8Boundary(b []byte) (emit, hold []byte) {
+	if len(b) == 0 {
+		return b, nil
+	}
+	// The last rune starts no earlier than UTFMax-1 bytes from the end. Scan
+	// back to the most recent lead byte and decide whether its sequence is
+	// complete.
+	for i := len(b) - 1; i >= 0 && i >= len(b)-(utf8.UTFMax-1); i-- {
+		if utf8.RuneStart(b[i]) {
+			if utf8.FullRune(b[i:]) {
+				return b, nil // last rune is complete
+			}
+			return b[:i], b[i:] // last rune is truncated — hold it for the next read
+		}
+	}
+	// No lead byte within the trailing UTFMax-1 bytes (malformed run); nothing
+	// sensible to hold, emit as-is.
+	return b, nil
+}
+
+// streamUTF8 reads from r in 4096-byte chunks and forwards data to onOutput on
+// UTF-8 rune boundaries, holding back a trailing incomplete rune across reads
+// and flushing any held bytes when the stream ends. It returns the terminating
+// read error (io.EOF on a clean close). onFirst, if non-nil, is invoked once
+// with the byte count of the first non-empty read (for first-data logging).
+func streamUTF8(r io.Reader, onOutput func([]byte), onFirst func(int)) error {
+	buf := make([]byte, 4096)
+	var pending []byte
+	for {
+		n, err := r.Read(buf)
+		if n > 0 && onOutput != nil {
+			if onFirst != nil {
+				onFirst(n)
+				onFirst = nil
+			}
+			// Fresh allocation each iteration so the held tail (a subslice of
+			// combined) stays valid as `pending` without aliasing buf.
+			combined := make([]byte, len(pending)+n)
+			copy(combined, pending)
+			copy(combined[len(pending):], buf[:n])
+			emit, hold := splitUTF8Boundary(combined)
+			pending = hold
+			if len(emit) > 0 {
+				onOutput(emit)
+			}
+		}
+		if err != nil {
+			// Flush any trailing bytes (even an incomplete rune) so output at
+			// stream end is never silently dropped.
+			if len(pending) > 0 && onOutput != nil {
+				onOutput(pending)
+			}
+			return err
+		}
+	}
+}

--- a/agent/internal/terminal/utf8stream_test.go
+++ b/agent/internal/terminal/utf8stream_test.go
@@ -1,0 +1,118 @@
+package terminal
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestSplitUTF8Boundary(t *testing.T) {
+	euro := []byte("€")           // 3 bytes: E2 82 AC
+	emoji := []byte("\U0001F600") // 4 bytes: F0 9F 98 80
+	eacute := []byte("é")         // 2 bytes: C3 A9
+
+	tests := []struct {
+		name     string
+		in       []byte
+		wantEmit []byte
+		wantHold []byte
+	}{
+		{"empty", []byte{}, []byte{}, nil},
+		{"ascii", []byte("hello"), []byte("hello"), nil},
+		{"complete 2-byte at end", []byte("café"), []byte("café"), nil},
+		{"complete 3-byte at end", append([]byte("a"), euro...), append([]byte("a"), euro...), nil},
+		{"complete 4-byte at end", emoji, emoji, nil},
+		{"truncated 2-byte (1 of 2)", []byte{'x', eacute[0]}, []byte{'x'}, []byte{eacute[0]}},
+		{"truncated 3-byte (1 of 3)", []byte{'x', euro[0]}, []byte{'x'}, []byte{euro[0]}},
+		{"truncated 3-byte (2 of 3)", []byte{'x', euro[0], euro[1]}, []byte{'x'}, []byte{euro[0], euro[1]}},
+		{"truncated 4-byte (3 of 4)", append([]byte("x"), emoji[:3]...), []byte("x"), emoji[:3]},
+		{"lone continuation byte", []byte{'x', 0xA9}, []byte{'x', 0xA9}, nil}, // not a truncated lead; emit as-is
+		{"invalid 0xFF at end", []byte{'x', 0xFF}, []byte{'x', 0xFF}, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			emit, hold := splitUTF8Boundary(tt.in)
+			if !bytes.Equal(emit, tt.wantEmit) {
+				t.Errorf("emit = %v, want %v", emit, tt.wantEmit)
+			}
+			if !bytes.Equal(hold, tt.wantHold) {
+				t.Errorf("hold = %v, want %v", hold, tt.wantHold)
+			}
+		})
+	}
+}
+
+type chunkReader struct {
+	chunks [][]byte
+	i      int
+}
+
+func (c *chunkReader) Read(p []byte) (int, error) {
+	if c.i >= len(c.chunks) {
+		return 0, io.EOF
+	}
+	n := copy(p, c.chunks[c.i])
+	c.i++
+	return n, nil
+}
+
+func TestStreamUTF8ReassemblesSplitRune(t *testing.T) {
+	euro := []byte("€") // E2 82 AC
+	// "abc€def" with the euro split across two reads: "abc"+E2 82 | AC+"def".
+	chunks := [][]byte{
+		append([]byte("abc"), euro[0], euro[1]),
+		append([]byte{euro[2]}, []byte("def")...),
+	}
+	var emits [][]byte
+	var all bytes.Buffer
+	err := streamUTF8(&chunkReader{chunks: chunks}, func(b []byte) {
+		cp := append([]byte(nil), b...)
+		emits = append(emits, cp)
+		all.Write(cp)
+	}, nil)
+	if err != io.EOF {
+		t.Fatalf("err = %v, want io.EOF", err)
+	}
+	// Every forwarded chunk must be valid UTF-8 (the split rune is never halved).
+	for i, e := range emits {
+		if !utf8.Valid(e) {
+			t.Errorf("emit[%d] = %v is not valid UTF-8", i, e)
+		}
+	}
+	if got := all.String(); got != "abc€def" {
+		t.Errorf("reassembled = %q, want %q", got, "abc€def")
+	}
+}
+
+func TestStreamUTF8FlushesTruncatedTailOnEOF(t *testing.T) {
+	euro := []byte("€")
+	// Stream ends with a genuinely truncated rune ("abc" + E2 82, then EOF).
+	chunks := [][]byte{append([]byte("abc"), euro[0], euro[1])}
+	var all bytes.Buffer
+	err := streamUTF8(&chunkReader{chunks: chunks}, func(b []byte) { all.Write(b) }, nil)
+	if err != io.EOF {
+		t.Fatalf("err = %v, want io.EOF", err)
+	}
+	// The trailing partial bytes must be flushed, not dropped, so no data loss.
+	want := append([]byte("abc"), euro[0], euro[1])
+	if !bytes.Equal(all.Bytes(), want) {
+		t.Errorf("flushed output = %v, want %v", all.Bytes(), want)
+	}
+}
+
+func TestStreamUTF8FirstCallback(t *testing.T) {
+	calls := 0
+	firstN := 0
+	chunks := [][]byte{[]byte("hi"), []byte("there")}
+	_ = streamUTF8(&chunkReader{chunks: chunks}, func(b []byte) {}, func(n int) {
+		calls++
+		firstN = n
+	})
+	if calls != 1 {
+		t.Errorf("onFirst called %d times, want 1", calls)
+	}
+	if firstN != 2 {
+		t.Errorf("onFirst n = %d, want 2", firstN)
+	}
+}


### PR DESCRIPTION
## Problem

The terminal PTY/pipe read loops forward fixed **4096-byte** chunks verbatim:

- `terminal.go` `readLoop` (used by unix PTYs and the Windows ConPTY path)
- the `startPipes` stdout/stderr goroutines in `pty_windows.go` (the ConPTY-unavailable fallback)

A multibyte UTF-8 character that straddles a 4096-byte boundary is split across two sends. Each chunk is then UTF-8-decoded **independently** downstream — the API does `decoded.toString('utf8')` (`agentWs.ts`) — and Node replaces the incomplete trailing byte sequence with `U+FFFD`. Result: a `�` in the web terminal for accented/CJK output, even when the source bytes are perfectly valid UTF-8.

This is pre-existing: the old `string(data)` path split runes the same way.

## Fix

A small shared helper in `agent/internal/terminal/utf8stream.go`:

- `splitUTF8Boundary(b)` → `(emit, hold)`: returns the leading bytes ending on a complete rune boundary plus any trailing incomplete sequence (≤ `utf8.UTFMax-1` bytes). Pure ASCII / complete input passes through whole; bytes that are invalid-but-not-truncated (a lone continuation byte, `0xFF`) are emitted as-is rather than held forever.
- `streamUTF8(r, onOutput, onFirst)`: reads in 4096-byte chunks, prepends the held tail, forwards only on rune boundaries, and **flushes any held bytes on EOF** so end-of-stream output is never dropped (the one correctness trap of a hold-back buffer).

Wired into `readLoop` (covers unix + ConPTY — both call it) and both `startPipes` goroutines. Net `−54/+16` plus the helper, so the read loops actually get simpler.

## Relationship to #976

Complementary, not overlapping. #976 fixes (a) the source locale (`ApplyEnv`) and (b) wire-transport corruption (base64 the terminal payload so raw bytes survive JSON). This fixes (c) the *independent per-chunk decode* of a rune split across a read boundary — base64 moves the bytes intact but each chunk is still decoded on its own, so a boundary-split rune still becomes `U+FFFD`. Filed separately because it lives in a different subsystem (terminal/ConPTY read loops), needs its own EOF-flush tests, and stands on its own without #976.

## Tests

- `splitUTF8Boundary` table: 2/3/4-byte truncation cases, complete runes, lone continuation byte, invalid `0xFF`, ASCII, empty.
- `streamUTF8`: reassembly of a euro sign split across two reads (asserts every forwarded chunk is valid UTF-8 and the result is lossless); EOF-flush of a genuinely truncated tail (no data loss); first-data callback fires once.

Full agent suite green under `go test -race ./...`; `windows/amd64` cross-build clean; `go vet`/`gofmt` clean; no dependency changes.
