### PR TITLE
fix(security): site-scope device reads + browser-policy mutations (cross-site RBAC gap)

### DIFF
--- a/apps/api/src/routes/analytics.test.ts
+++ b/apps/api/src/routes/analytics.test.ts
@@ -4,6 +4,16 @@ import { Hono } from 'hono';
 const ORG_ID = '11111111-1111-1111-1111-111111111111';
 const USER_ID = '11111111-1111-1111-1111-111111111112';
 
+// Site-scope test fixtures. allowedSiteIds restricts the caller to SITE_ALLOWED.
+const SITE_ALLOWED = '22222222-2222-2222-2222-222222222221';
+const SITE_DENIED = '22222222-2222-2222-2222-222222222222';
+const DEVICE_IN_SCOPE = '33333333-3333-3333-3333-333333333331';
+const DEVICE_OUT_OF_SCOPE = '33333333-3333-3333-3333-333333333332';
+
+// Mutable holder so individual tests can flip the caller's site restriction.
+// The authMiddleware mock reads this when setting c.get('permissions').
+let currentPermissions: { allowedSiteIds?: string[] } | undefined;
+
 vi.mock('drizzle-orm', () => {
   const sql = (strings: TemplateStringsArray, ...values: unknown[]) => ({
     strings,
@@ -18,6 +28,8 @@ vi.mock('drizzle-orm', () => {
     lte: (left: unknown, right: unknown) => ({ type: 'lte', left, right }),
     ne: (left: unknown, right: unknown) => ({ type: 'ne', left, right }),
     inArray: (left: unknown, right: unknown[]) => ({ type: 'inArray', left, right }),
+    isNull: (column: unknown) => ({ type: 'isNull', column }),
+    or: (...conditions: unknown[]) => ({ type: 'or', conditions }),
     desc: (column: unknown) => ({ type: 'desc', column }),
     sql
   };
@@ -25,6 +37,17 @@ vi.mock('drizzle-orm', () => {
 
 vi.mock('../services/auditEvents', () => ({
   writeRouteAudit: vi.fn()
+}));
+
+vi.mock('../services/permissions', () => ({
+  PERMISSIONS: {
+    DEVICES_READ: { resource: 'devices', action: 'read' },
+    ORGS_WRITE: { resource: 'orgs', action: 'write' }
+  },
+  // Faithful to the real implementation: unrestricted callers (no
+  // allowedSiteIds) always pass; restricted callers pass only for listed sites.
+  canAccessSite: (perms: any, siteId: string) =>
+    !perms?.allowedSiteIds || perms.allowedSiteIds.includes(siteId)
 }));
 
 vi.mock('../middleware/auth', () => ({
@@ -141,6 +164,7 @@ vi.mock('../db/schema', () => ({
   devices: {
     id: 'devices.id',
     orgId: 'devices.orgId',
+    siteId: 'devices.siteId',
     status: 'devices.status',
     enrolledAt: 'devices.enrolledAt',
     lastSeenAt: 'devices.lastSeenAt',
@@ -239,6 +263,8 @@ describe('analytics routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
+    currentPermissions = undefined;
+
     vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
       c.set('auth', {
         scope: 'organization',
@@ -249,6 +275,7 @@ describe('analytics routes', () => {
         canAccessOrg: (orgId: string) => orgId === ORG_ID,
         orgCondition: vi.fn((column: unknown) => ({ column, orgId: ORG_ID }))
       });
+      c.set('permissions', currentPermissions);
 
       return next();
     });
@@ -646,6 +673,164 @@ describe('analytics routes', () => {
       expect(body.slaId).toBe('sla-1');
       expect(body.history).toEqual([]);
       expect(body.liveUptime).toBe(50);
+    });
+  });
+
+  describe('site-scope authorization', () => {
+    // Org devices used to resolve the site allowlist into device IDs.
+    const ORG_DEVICE_ROWS = [
+      { id: DEVICE_IN_SCOPE, siteId: SITE_ALLOWED },
+      { id: DEVICE_OUT_OF_SCOPE, siteId: SITE_DENIED }
+    ];
+
+    describe('GET /analytics/capacity', () => {
+      it('returns 403 when a site-restricted caller drills into an out-of-scope deviceId', async () => {
+        currentPermissions = { allowedSiteIds: [SITE_ALLOWED] };
+        // Device-resolution select runs first when restricted.
+        mockSelectOnce(ORG_DEVICE_ROWS);
+
+        const res = await app.request(
+          `/analytics/capacity?deviceId=${DEVICE_OUT_OF_SCOPE}&metricType=disk`,
+          { method: 'GET', headers: { Authorization: 'Bearer token' } }
+        );
+
+        expect(res.status).toBe(403);
+        const body = await res.json();
+        expect(body.error).toBe('Device not found or access denied');
+      });
+
+      it('allows a site-restricted caller to drill into an in-scope deviceId', async () => {
+        currentPermissions = { allowedSiteIds: [SITE_ALLOWED] };
+        mockSelectOnce(ORG_DEVICE_ROWS); // device resolution
+        mockSelectOnce([
+          {
+            metricName: 'disk_used_percent',
+            currentValue: 50,
+            predictedValue: 55,
+            predictionDate: new Date('2026-02-01T00:00:00.000Z'),
+            growthRate: 1
+          }
+        ]); // predictions
+        mockSelectOnce([{ warningThreshold: 80, criticalThreshold: 90 }]); // thresholds
+
+        const res = await app.request(
+          `/analytics/capacity?deviceId=${DEVICE_IN_SCOPE}&metricType=disk`,
+          { method: 'GET', headers: { Authorization: 'Bearer token' } }
+        );
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.currentValue).toBe(50);
+      });
+
+      it('leaves the org-wide capacity aggregate (no deviceId) unchanged for a restricted caller', async () => {
+        currentPermissions = { allowedSiteIds: [SITE_ALLOWED] };
+        mockSelectOnce(ORG_DEVICE_ROWS); // device resolution
+        mockSelectOnce([]); // predictions empty -> fall through to live metrics
+        mockSelectOnce([]); // live device_metrics aggregate
+
+        const res = await app.request('/analytics/capacity?metricType=disk', {
+          method: 'GET',
+          headers: { Authorization: 'Bearer token' }
+        });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        // Aggregate still returns a forecast envelope (no 403, not narrowed away).
+        expect(Array.isArray(body.predictions)).toBe(true);
+      });
+
+      it('does not narrow capacity for an unrestricted caller (no extra resolution query)', async () => {
+        currentPermissions = undefined; // unrestricted
+        mockSelectOnce([
+          {
+            metricName: 'disk_used_percent',
+            currentValue: 72,
+            predictedValue: 76,
+            predictionDate: new Date('2026-02-01T00:00:00.000Z'),
+            growthRate: 1.5
+          }
+        ]); // predictions (first select — no resolution select)
+        mockSelectOnce([{ warningThreshold: 80, criticalThreshold: 90 }]);
+
+        const res = await app.request(
+          `/analytics/capacity?deviceId=${DEVICE_OUT_OF_SCOPE}&metricType=disk`,
+          { method: 'GET', headers: { Authorization: 'Bearer token' } }
+        );
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.currentValue).toBe(72);
+      });
+    });
+
+    describe('POST /analytics/query (timeseries)', () => {
+      it('returns 403 when any requested deviceId is out of the site allowlist', async () => {
+        currentPermissions = { allowedSiteIds: [SITE_ALLOWED] };
+        mockSelectOnce(ORG_DEVICE_ROWS); // device resolution
+
+        const res = await app.request('/analytics/query', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            deviceIds: [DEVICE_IN_SCOPE, DEVICE_OUT_OF_SCOPE],
+            metricTypes: ['cpu_usage'],
+            startTime: '2024-01-01T00:00:00Z',
+            endTime: '2024-01-02T00:00:00Z',
+            aggregation: 'avg',
+            interval: 'hour'
+          })
+        });
+
+        expect(res.status).toBe(403);
+        const body = await res.json();
+        expect(body.error).toBe('Access to one or more device sites denied');
+      });
+
+      it('allows a site-restricted caller when all requested deviceIds are in scope', async () => {
+        currentPermissions = { allowedSiteIds: [SITE_ALLOWED] };
+        mockSelectOnce(ORG_DEVICE_ROWS); // device resolution
+        mockSelectOnce([]); // metric series query
+
+        const res = await app.request('/analytics/query', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            deviceIds: [DEVICE_IN_SCOPE],
+            metricTypes: ['cpu_usage'],
+            startTime: '2024-01-01T00:00:00Z',
+            endTime: '2024-01-02T00:00:00Z',
+            aggregation: 'avg',
+            interval: 'hour'
+          })
+        });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.series).toHaveLength(1);
+      });
+
+      it('does not narrow timeseries for an unrestricted caller', async () => {
+        currentPermissions = undefined; // unrestricted — no resolution query
+        mockSelectOnce([]); // metric series query is the first select
+
+        const res = await app.request('/analytics/query', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            deviceIds: [DEVICE_OUT_OF_SCOPE],
+            metricTypes: ['cpu_usage'],
+            startTime: '2024-01-01T00:00:00Z',
+            endTime: '2024-01-02T00:00:00Z',
+            aggregation: 'avg',
+            interval: 'hour'
+          })
+        });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.series).toHaveLength(1);
+      });
     });
   });
 });

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { and, eq, sql, gte, lte, ne, inArray, desc } from 'drizzle-orm';
+import { and, eq, sql, gte, lte, ne, inArray, isNull, or, desc } from 'drizzle-orm';
 import { db } from '../db';
 import {
   analyticsDashboards,
@@ -15,7 +15,7 @@ import {
 } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
-import { PERMISSIONS } from '../services/permissions';
+import { PERMISSIONS, canAccessSite, type UserPermissions } from '../services/permissions';
 
 export const analyticsRoutes = new Hono();
 const requireAnalyticsRead = requirePermission(
@@ -63,6 +63,26 @@ async function getOrgIdsForAuth(
 
   // system scope - return null to indicate no filtering needed
   return null;
+}
+
+// Resolve the device IDs a site-restricted caller may read within their org,
+// narrowed by `permissions.allowedSiteIds`. Returns null when the caller has no
+// site restriction (no narrowing needed). Site is an app-layer concept only —
+// Postgres RLS does NOT defend it — so a site-restricted user must not read
+// per-device metrics / capacity predictions for devices in other sites within
+// the same org. Mirrors browserSecurity.ts `resolveSiteAllowedDeviceIds`.
+async function resolveSiteAllowedDeviceIds(
+  orgId: string,
+  perms: UserPermissions | undefined,
+): Promise<string[] | null> {
+  if (!perms?.allowedSiteIds) return null;
+  const orgDevices = await db
+    .select({ id: devices.id, siteId: devices.siteId })
+    .from(devices)
+    .where(eq(devices.orgId, orgId));
+  return orgDevices
+    .filter((d) => typeof d.siteId === 'string' && canAccessSite(perms, d.siteId))
+    .map((d) => d.id);
 }
 
 const timeSeriesQuerySchema = z.object({
@@ -235,6 +255,20 @@ analyticsRoutes.post(
     const endTime = new Date(data.endTime);
     if (Number.isNaN(startTime.getTime()) || Number.isNaN(endTime.getTime())) {
       return c.json({ error: 'Invalid startTime or endTime' }, 400);
+    }
+
+    // Site-scope gate: device IDs arrive in the request body, so the :deviceId
+    // URL scanner can't catch this. RLS only defends the org axis — a
+    // site-restricted caller must not read metrics for devices outside their
+    // site allowlist. If ANY requested id is out of scope, deny the batch
+    // (matches the project convention in sentinelOne.ts `hasDeniedDeviceSite`).
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    if (perms?.allowedSiteIds && auth.orgId) {
+      const allowedDeviceIds = await resolveSiteAllowedDeviceIds(auth.orgId, perms);
+      const allowedSet = new Set(allowedDeviceIds ?? []);
+      if (data.deviceIds.some((id) => !allowedSet.has(id))) {
+        return c.json({ error: 'Access to one or more device sites denied' }, 403);
+      }
     }
 
     const interval = data.interval;
@@ -853,6 +887,19 @@ analyticsRoutes.get(
     const query = c.req.valid('query');
     const metricType = query.metricType.toLowerCase();
 
+    // Site-scope gate. RLS defends only the org axis; a site-restricted caller
+    // must not drill into per-device capacity/metrics for devices in other
+    // sites within the same org. `allowedDeviceIds === null` means unrestricted.
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    let allowedDeviceIds: string[] | null = null;
+    if (perms?.allowedSiteIds && auth?.orgId) {
+      allowedDeviceIds = await resolveSiteAllowedDeviceIds(auth.orgId, perms);
+      // Explicit per-device drill-down must target an in-scope device.
+      if (query.deviceId && !(allowedDeviceIds ?? []).includes(query.deviceId)) {
+        return c.json({ error: 'Device not found or access denied' }, 403);
+      }
+    }
+
     const predictionOrgCondition =
       typeof auth?.orgCondition === 'function'
         ? auth.orgCondition(capacityPredictions.orgId)
@@ -860,10 +907,24 @@ analyticsRoutes.get(
           ? eq(capacityPredictions.orgId, auth.orgId)
           : undefined;
 
+    // When site-restricted and no explicit deviceId, constrain per-device
+    // predictions to the in-scope set while keeping org-wide rows (deviceId is
+    // nullable on capacity_predictions) visible.
+    const predictionSiteCondition =
+      allowedDeviceIds !== null && !query.deviceId
+        ? or(
+            isNull(capacityPredictions.deviceId),
+            ...(allowedDeviceIds.length > 0
+              ? [inArray(capacityPredictions.deviceId, allowedDeviceIds)]
+              : [])
+          )
+        : undefined;
+
     const predictionWhere = and(
       eq(capacityPredictions.metricType, metricType),
       ...(predictionOrgCondition ? [predictionOrgCondition] : []),
-      ...(query.deviceId ? [eq(capacityPredictions.deviceId, query.deviceId)] : [])
+      ...(query.deviceId ? [eq(capacityPredictions.deviceId, query.deviceId)] : []),
+      ...(predictionSiteCondition ? [predictionSiteCondition] : [])
     );
 
     const storedPredictions = await db
@@ -941,10 +1002,20 @@ analyticsRoutes.get(
           ? eq(devices.orgId, auth.orgId)
           : undefined;
 
+    // device_metrics.deviceId is NOT NULL — constrain the broad (no-deviceId)
+    // query to the in-scope device set when site-restricted, and short-circuit
+    // when none are in scope.
+    if (allowedDeviceIds !== null && !query.deviceId && allowedDeviceIds.length === 0) {
+      return c.json({ currentValue: 0, predictions: [], thresholds: undefined });
+    }
+
     const metricsWhere = and(
       gte(deviceMetrics.timestamp, rangeStart),
       ...(metricsOrgCondition ? [metricsOrgCondition] : []),
-      ...(query.deviceId ? [eq(deviceMetrics.deviceId, query.deviceId)] : [])
+      ...(query.deviceId ? [eq(deviceMetrics.deviceId, query.deviceId)] : []),
+      ...(allowedDeviceIds !== null && !query.deviceId && allowedDeviceIds.length > 0
+        ? [inArray(deviceMetrics.deviceId, allowedDeviceIds)]
+        : [])
     );
 
     const actualRows = await db

--- a/apps/api/src/routes/browserSecurity.ts
+++ b/apps/api/src/routes/browserSecurity.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { and, desc, eq, isNull, sql, type SQL } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, sql, type SQL } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../db';
 import {
@@ -19,12 +19,51 @@ export const browserSecurityRoutes = new Hono();
 browserSecurityRoutes.use('*', authMiddleware);
 browserSecurityRoutes.use('*', requireScope('organization', 'partner', 'system'));
 
+// Resolve the device IDs a site-restricted caller may read within their org,
+// narrowed by `permissions.allowedSiteIds`. Returns null when the caller has no
+// site restriction (no narrowing needed). Site is an app-layer concept only —
+// Postgres RLS does NOT defend it — so a site-restricted org user must not read
+// extension/violation rows for devices in other sites within the same org.
+// `allowedSiteIds` is only ever set for org-scope users (see permissions.ts), so
+// `orgId` is guaranteed present whenever narrowing applies. Mirrors the
+// software-inventory list route (PR #864/#868).
+async function resolveSiteAllowedDeviceIds(
+  orgId: string,
+  perms: UserPermissions | undefined,
+): Promise<string[] | null> {
+  if (!perms?.allowedSiteIds) return null;
+  const orgDevices = await db
+    .select({ id: devices.id, siteId: devices.siteId })
+    .from(devices)
+    .where(eq(devices.orgId, orgId));
+  return orgDevices
+    .filter((d) => typeof d.siteId === 'string' && canAccessSite(perms, d.siteId))
+    .map((d) => d.id);
+}
+
+// A site-restricted caller may only mutate policies that target sites entirely
+// within their allowlist. Org/group/device/tag targets are not site-bounded, so
+// a site-restricted caller cannot confirm scope over them and is denied.
+// Unrestricted callers (no `allowedSiteIds`) always pass.
+function policyWithinSiteWriteScope(
+  perms: UserPermissions | undefined,
+  targetType: string,
+  targetIds: string[] | null | undefined,
+): boolean {
+  if (!perms?.allowedSiteIds) return true;
+  if (targetType !== 'site') return false;
+  const ids = targetIds ?? [];
+  if (ids.length === 0) return false;
+  return ids.every((id) => canAccessSite(perms, id));
+}
+
 // GET /browser-security/extensions — list extensions with risk summary
 browserSecurityRoutes.get(
   '/extensions',
   requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
   async (c) => {
     const auth = c.get('auth') as AuthContext;
+    const perms = c.get('permissions') as UserPermissions | undefined;
     const { deviceId, browser, riskLevel, limit: rawLimit } = c.req.query();
 
     const conditions: SQL[] = [];
@@ -32,6 +71,21 @@ browserSecurityRoutes.get(
     if (deviceId) conditions.push(eq(browserExtensions.deviceId, deviceId));
     if (browser) conditions.push(eq(browserExtensions.browser, browser));
     if (riskLevel) conditions.push(eq(browserExtensions.riskLevel, riskLevel));
+
+    // Narrow to the caller's accessible devices when site-restricted.
+    if (perms?.allowedSiteIds && auth.orgId) {
+      const allowedDeviceIds = await resolveSiteAllowedDeviceIds(auth.orgId, perms);
+      if (deviceId && !allowedDeviceIds!.includes(deviceId)) {
+        return c.json({ error: 'Device not found or access denied' }, 403);
+      }
+      if (!allowedDeviceIds || allowedDeviceIds.length === 0) {
+        return c.json({
+          summary: { total: 0, low: 0, medium: 0, high: 0, critical: 0 },
+          extensions: [],
+        });
+      }
+      conditions.push(inArray(browserExtensions.deviceId, allowedDeviceIds));
+    }
 
     const where = conditions.length > 0 ? and(...conditions) : undefined;
     const limit = Math.min(Math.max(1, Number(rawLimit) || 100), 500);
@@ -79,12 +133,25 @@ browserSecurityRoutes.get(
   requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
   async (c) => {
     const auth = c.get('auth') as AuthContext;
+    const perms = c.get('permissions') as UserPermissions | undefined;
     const { deviceId, policyId } = c.req.query();
 
     const conditions: SQL[] = [isNull(browserPolicyViolations.resolvedAt)];
     if (auth.orgId) conditions.push(eq(browserPolicyViolations.orgId, auth.orgId));
     if (deviceId) conditions.push(eq(browserPolicyViolations.deviceId, deviceId));
     if (policyId) conditions.push(eq(browserPolicyViolations.policyId, policyId));
+
+    // Narrow to the caller's accessible devices when site-restricted.
+    if (perms?.allowedSiteIds && auth.orgId) {
+      const allowedDeviceIds = await resolveSiteAllowedDeviceIds(auth.orgId, perms);
+      if (deviceId && !allowedDeviceIds!.includes(deviceId)) {
+        return c.json({ error: 'Device not found or access denied' }, 403);
+      }
+      if (!allowedDeviceIds || allowedDeviceIds.length === 0) {
+        return c.json({ violations: [] });
+      }
+      conditions.push(inArray(browserPolicyViolations.deviceId, allowedDeviceIds));
+    }
 
     const violations = await db
       .select({
@@ -148,6 +215,12 @@ browserSecurityRoutes.post(
 
     const body = c.req.valid('json');
 
+    // Site-restricted callers may only create policies scoped to their sites.
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    if (!policyWithinSiteWriteScope(perms, body.targetType, body.targetIds)) {
+      return c.json({ error: 'Access to the targeted site(s) denied' }, 403);
+    }
+
     const [policy] = await db
       .insert(browserPolicies)
       .values({
@@ -205,6 +278,23 @@ browserSecurityRoutes.put(
     if (!existing) return c.json({ error: 'Policy not found' }, 404);
 
     const body = c.req.valid('json');
+
+    // Site-restricted callers must be able to act on the policy both as it
+    // stands and as it will be after the update (so they cannot retarget a
+    // policy onto a site outside their allowlist).
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    if (perms?.allowedSiteIds) {
+      const nextTargetType = body.targetType ?? existing.targetType;
+      const nextTargetIds =
+        body.targetIds !== undefined ? body.targetIds : existing.targetIds;
+      if (
+        !policyWithinSiteWriteScope(perms, existing.targetType, existing.targetIds) ||
+        !policyWithinSiteWriteScope(perms, nextTargetType, nextTargetIds)
+      ) {
+        return c.json({ error: 'Access to the targeted site(s) denied' }, 403);
+      }
+    }
+
     const [updated] = await db
       .update(browserPolicies)
       .set({
@@ -248,6 +338,24 @@ browserSecurityRoutes.delete(
 
     const conditions: SQL[] = [eq(browserPolicies.id, policyId)];
     if (auth.orgId) conditions.push(eq(browserPolicies.orgId, auth.orgId));
+
+    // Site-restricted callers can only delete policies scoped to their sites.
+    // Verify scope before deleting (the bare DELETE can't gate on site).
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    if (perms?.allowedSiteIds) {
+      const [existing] = await db
+        .select({
+          targetType: browserPolicies.targetType,
+          targetIds: browserPolicies.targetIds,
+        })
+        .from(browserPolicies)
+        .where(and(...conditions))
+        .limit(1);
+      if (!existing) return c.json({ error: 'Policy not found' }, 404);
+      if (!policyWithinSiteWriteScope(perms, existing.targetType, existing.targetIds)) {
+        return c.json({ error: 'Access to the targeted site(s) denied' }, 403);
+      }
+    }
 
     const [deleted] = await db
       .delete(browserPolicies)

--- a/apps/api/src/routes/browserSecurity_extensions_violations.test.ts
+++ b/apps/api/src/routes/browserSecurity_extensions_violations.test.ts
@@ -77,6 +77,10 @@ vi.mock('../services/permissions', () => ({
     DEVICES_READ: { resource: 'devices', action: 'read' },
     DEVICES_WRITE: { resource: 'devices', action: 'write' },
   },
+  // Faithful to the real implementation: unrestricted callers (no
+  // allowedSiteIds) always pass; otherwise the site must be in the allowlist.
+  canAccessSite: (perms: any, siteId: string) =>
+    !perms?.allowedSiteIds || perms.allowedSiteIds.includes(siteId),
 }));
 
 vi.mock('../jobs/browserSecurityJobs', () => ({
@@ -98,9 +102,15 @@ const ORG_ID = '11111111-1111-1111-1111-111111111111';
 const ORG_ID_2 = '22222222-2222-2222-2222-222222222222';
 const DEVICE_ID = '33333333-3333-3333-3333-333333333333';
 const POLICY_ID = '44444444-4444-4444-4444-444444444444';
+const SITE_ALLOWED = 'aaaaaaaa-0000-0000-0000-000000000001';
+const SITE_DENIED = 'bbbbbbbb-0000-0000-0000-000000000002';
+const DEVICE_DENIED = '55555555-5555-5555-5555-555555555555';
 const NOW = new Date('2026-03-13T12:00:00Z');
 
-function setAuth(overrides: Record<string, unknown> = {}) {
+function setAuth(
+  overrides: Record<string, unknown> = {},
+  permissions?: Record<string, unknown>
+) {
   vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
     c.set('auth', {
       user: { id: 'user-1', email: 'test@test.com', name: 'Test' },
@@ -112,8 +122,19 @@ function setAuth(overrides: Record<string, unknown> = {}) {
       orgCondition: () => undefined,
       ...overrides,
     });
+    if (permissions !== undefined) c.set('permissions', permissions);
     return next();
   });
+}
+
+// Mocks the device-resolution query a restricted reader runs first:
+// db.select({id, siteId}).from(devices).where(eq(orgId, ...)) → rows
+function mockDeviceResolution(rows: Array<{ id: string; siteId: string | null }>) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(rows),
+    }),
+  } as any);
 }
 
 function makeApp() {
@@ -389,6 +410,115 @@ describe('browserSecurity routes', () => {
       });
 
       expect(res.status).toBe(400);
+    });
+  });
+
+  // ────────────────────── Site-scope enforcement (reads) ──────────────────────
+  // A site-restricted org user (permissions.allowedSiteIds set) must not read
+  // extension inventory or violations for devices in sites outside their
+  // allowlist. Site is an app-layer concept only — RLS does not defend it.
+  describe('GET /extensions — site scope', () => {
+    it('denies an explicit deviceId outside the caller site allowlist (403)', async () => {
+      setAuth({}, { allowedSiteIds: [SITE_ALLOWED] });
+      // Device resolution: DEVICE_DENIED lives in a site the caller cannot access
+      mockDeviceResolution([
+        { id: DEVICE_ID, siteId: SITE_ALLOWED },
+        { id: DEVICE_DENIED, siteId: SITE_DENIED },
+      ]);
+
+      const res = await app.request(
+        `/browser-security/extensions?deviceId=${DEVICE_DENIED}`
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it('returns empty when the caller has no accessible devices', async () => {
+      setAuth({}, { allowedSiteIds: [SITE_ALLOWED] });
+      mockDeviceResolution([{ id: DEVICE_DENIED, siteId: SITE_DENIED }]);
+
+      const res = await app.request('/browser-security/extensions');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.extensions).toEqual([]);
+      expect(body.summary.total).toBe(0);
+    });
+
+    it('narrows to accessible devices and returns data', async () => {
+      setAuth({}, { allowedSiteIds: [SITE_ALLOWED] });
+      mockDeviceResolution([{ id: DEVICE_ID, siteId: SITE_ALLOWED }]);
+      // summary + list selects after narrowing
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ total: 1, low: 1, medium: 0, high: 0, critical: 0 }]),
+          }),
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            innerJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue([
+                    { id: 'ext-1', orgId: ORG_ID, deviceId: DEVICE_ID, name: 'Ad Blocker' },
+                  ]),
+                }),
+              }),
+            }),
+          }),
+        } as any);
+
+      const res = await app.request(`/browser-security/extensions?deviceId=${DEVICE_ID}`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.extensions).toHaveLength(1);
+    });
+  });
+
+  describe('GET /violations — site scope', () => {
+    it('denies an explicit deviceId outside the caller site allowlist (403)', async () => {
+      setAuth({}, { allowedSiteIds: [SITE_ALLOWED] });
+      mockDeviceResolution([
+        { id: DEVICE_ID, siteId: SITE_ALLOWED },
+        { id: DEVICE_DENIED, siteId: SITE_DENIED },
+      ]);
+
+      const res = await app.request(
+        `/browser-security/violations?deviceId=${DEVICE_DENIED}`
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it('returns empty when the caller has no accessible devices', async () => {
+      setAuth({}, { allowedSiteIds: [SITE_ALLOWED] });
+      mockDeviceResolution([{ id: DEVICE_DENIED, siteId: SITE_DENIED }]);
+
+      const res = await app.request('/browser-security/violations');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.violations).toEqual([]);
+    });
+
+    it('narrows to accessible devices and returns data', async () => {
+      setAuth({}, { allowedSiteIds: [SITE_ALLOWED] });
+      mockDeviceResolution([{ id: DEVICE_ID, siteId: SITE_ALLOWED }]);
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([
+                  { id: 'viol-1', orgId: ORG_ID, deviceId: DEVICE_ID, violationType: 'blocked_extension' },
+                ]),
+              }),
+            }),
+          }),
+        }),
+      } as any);
+
+      const res = await app.request(`/browser-security/violations?deviceId=${DEVICE_ID}`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.violations).toHaveLength(1);
     });
   });
 

--- a/apps/api/src/routes/browserSecurity_policy_crud_inventory.test.ts
+++ b/apps/api/src/routes/browserSecurity_policy_crud_inventory.test.ts
@@ -77,6 +77,10 @@ vi.mock('../services/permissions', () => ({
     DEVICES_READ: { resource: 'devices', action: 'read' },
     DEVICES_WRITE: { resource: 'devices', action: 'write' },
   },
+  // Faithful to the real implementation: unrestricted callers (no
+  // allowedSiteIds) always pass; otherwise the site must be in the allowlist.
+  canAccessSite: (perms: any, siteId: string) =>
+    !perms?.allowedSiteIds || perms.allowedSiteIds.includes(siteId),
 }));
 
 vi.mock('../jobs/browserSecurityJobs', () => ({
@@ -98,9 +102,14 @@ const ORG_ID = '11111111-1111-1111-1111-111111111111';
 const ORG_ID_2 = '22222222-2222-2222-2222-222222222222';
 const DEVICE_ID = '33333333-3333-3333-3333-333333333333';
 const POLICY_ID = '44444444-4444-4444-4444-444444444444';
+const SITE_ALLOWED = 'aaaaaaaa-0000-0000-0000-000000000001';
+const SITE_DENIED = 'bbbbbbbb-0000-0000-0000-000000000002';
 const NOW = new Date('2026-03-13T12:00:00Z');
 
-function setAuth(overrides: Record<string, unknown> = {}) {
+function setAuth(
+  overrides: Record<string, unknown> = {},
+  permissions?: Record<string, unknown>
+) {
   vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
     c.set('auth', {
       user: { id: 'user-1', email: 'test@test.com', name: 'Test' },
@@ -112,8 +121,20 @@ function setAuth(overrides: Record<string, unknown> = {}) {
       orgCondition: () => undefined,
       ...overrides,
     });
+    if (permissions !== undefined) c.set('permissions', permissions);
     return next();
   });
+}
+
+// Mocks a single policy-lookup select returning the given row (or none).
+function mockPolicyLookup(policy: Record<string, unknown> | null) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(policy ? [policy] : []),
+      }),
+    }),
+  } as any);
 }
 
 function makeApp() {
@@ -369,6 +390,157 @@ describe('browserSecurity routes', () => {
 
       const res = await app.request('/browser-security/policies');
       expect(res.status).toBe(200);
+    });
+  });
+
+  // ────────────────────── Site-scope enforcement (policy mutations) ──────────────────────
+  // A site-restricted org user (permissions.allowedSiteIds set) may only
+  // create/update/delete policies that target sites entirely within their
+  // allowlist. Org-wide (and group/device/tag) policies are out of their
+  // scope. Unrestricted users (no allowedSiteIds) are unaffected.
+  describe('policy mutations — site scope', () => {
+    describe('POST /policies', () => {
+      it('rejects an org-wide policy from a site-restricted user (403)', async () => {
+        setAuth({}, { allowedSiteIds: [SITE_ALLOWED] });
+        const res = await app.request('/browser-security/policies', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'Org Policy', targetType: 'org' }),
+        });
+        expect(res.status).toBe(403);
+        expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+      });
+
+      it('rejects a site policy targeting a denied site (403)', async () => {
+        setAuth({}, { allowedSiteIds: [SITE_ALLOWED] });
+        const res = await app.request('/browser-security/policies', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: 'Site Policy',
+            targetType: 'site',
+            targetIds: [SITE_DENIED],
+          }),
+        });
+        expect(res.status).toBe(403);
+        expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+      });
+
+      it('allows a site policy fully within the allowlist (201)', async () => {
+        setAuth({}, { allowedSiteIds: [SITE_ALLOWED] });
+        vi.mocked(db.insert).mockReturnValueOnce({
+          values: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([
+              { id: POLICY_ID, orgId: ORG_ID, name: 'Site Policy', targetType: 'site', targetIds: [SITE_ALLOWED] },
+            ]),
+          }),
+        } as any);
+
+        const res = await app.request('/browser-security/policies', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: 'Site Policy',
+            targetType: 'site',
+            targetIds: [SITE_ALLOWED],
+          }),
+        });
+        expect(res.status).toBe(201);
+      });
+    });
+
+    describe('PUT /policies/:policyId', () => {
+      it('rejects updating an org-wide policy as a site-restricted user (403)', async () => {
+        setAuth({}, { allowedSiteIds: [SITE_ALLOWED] });
+        mockPolicyLookup({
+          id: POLICY_ID, orgId: ORG_ID, name: 'Org Policy',
+          targetType: 'org', targetIds: null, isActive: true,
+        });
+
+        const res = await app.request(`/browser-security/policies/${POLICY_ID}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'Renamed' }),
+        });
+        expect(res.status).toBe(403);
+        expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+      });
+
+      it('allows updating a site policy within the allowlist (200)', async () => {
+        setAuth({}, { allowedSiteIds: [SITE_ALLOWED] });
+        mockPolicyLookup({
+          id: POLICY_ID, orgId: ORG_ID, name: 'Site Policy',
+          targetType: 'site', targetIds: [SITE_ALLOWED], isActive: true,
+        });
+        vi.mocked(db.update).mockReturnValueOnce({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([
+                { id: POLICY_ID, orgId: ORG_ID, name: 'Renamed', targetType: 'site', targetIds: [SITE_ALLOWED] },
+              ]),
+            }),
+          }),
+        } as any);
+
+        const res = await app.request(`/browser-security/policies/${POLICY_ID}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'Renamed' }),
+        });
+        expect(res.status).toBe(200);
+      });
+
+      it('rejects moving a site policy onto a denied site (403)', async () => {
+        setAuth({}, { allowedSiteIds: [SITE_ALLOWED] });
+        mockPolicyLookup({
+          id: POLICY_ID, orgId: ORG_ID, name: 'Site Policy',
+          targetType: 'site', targetIds: [SITE_ALLOWED], isActive: true,
+        });
+
+        const res = await app.request(`/browser-security/policies/${POLICY_ID}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ targetIds: [SITE_ALLOWED, SITE_DENIED] }),
+        });
+        expect(res.status).toBe(403);
+        expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('DELETE /policies/:policyId', () => {
+      it('rejects deleting an org-wide policy as a site-restricted user (403)', async () => {
+        setAuth({}, { allowedSiteIds: [SITE_ALLOWED] });
+        mockPolicyLookup({
+          id: POLICY_ID, orgId: ORG_ID, name: 'Org Policy',
+          targetType: 'org', targetIds: null,
+        });
+
+        const res = await app.request(`/browser-security/policies/${POLICY_ID}`, {
+          method: 'DELETE',
+        });
+        expect(res.status).toBe(403);
+        expect(vi.mocked(db.delete)).not.toHaveBeenCalled();
+      });
+
+      it('allows deleting a site policy within the allowlist (200)', async () => {
+        setAuth({}, { allowedSiteIds: [SITE_ALLOWED] });
+        mockPolicyLookup({
+          id: POLICY_ID, orgId: ORG_ID, name: 'Site Policy',
+          targetType: 'site', targetIds: [SITE_ALLOWED],
+        });
+        vi.mocked(db.delete).mockReturnValueOnce({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([
+              { id: POLICY_ID, orgId: ORG_ID, name: 'Site Policy' },
+            ]),
+          }),
+        } as any);
+
+        const res = await app.request(`/browser-security/policies/${POLICY_ID}`, {
+          method: 'DELETE',
+        });
+        expect(res.status).toBe(200);
+      });
     });
   });
 

--- a/apps/api/src/routes/dnsSecurity.test.ts
+++ b/apps/api/src/routes/dnsSecurity.test.ts
@@ -88,9 +88,15 @@ vi.mock('../services/secretCrypto', () => ({
 vi.mock('../services/permissions', () => ({
   PERMISSIONS: {
     ORGS_WRITE: { resource: 'organizations', action: 'write' }
-  }
+  },
+  // Faithful to the real implementation: unrestricted callers (no
+  // allowedSiteIds) always pass; otherwise the site must be in the allowlist.
+  canAccessSite: (perms: any, siteId: string) =>
+    !perms?.allowedSiteIds || perms.allowedSiteIds.includes(siteId)
 }));
 
+import { db } from '../db';
+import { authMiddleware } from '../middleware/auth';
 import { dnsSecurityRoutes } from './dnsSecurity';
 
 describe('dns security routes', () => {
@@ -203,5 +209,181 @@ describe('dns security routes', () => {
     // DB layer isn't mocked, so a 500 is also acceptable here — the assertion
     // is that we didn't reject at validation time.
     expect(res.status).not.toBe(400);
+  });
+
+  // ──────────────── Site-scope enforcement (reads) ────────────────
+  // A site-restricted org user (permissions.allowedSiteIds set) must not read
+  // DNS query/block events or hostnames for devices in sites outside their
+  // allowlist. Site is an app-layer concept only — RLS does not defend it.
+  // `dnsSecurityEvents.deviceId` is NULLABLE (provider-level events aren't
+  // device-bound), so provider-level rows must stay visible.
+  const SITE_ALLOWED = 'aaaaaaaa-0000-0000-0000-000000000001';
+  const SITE_DENIED = 'bbbbbbbb-0000-0000-0000-000000000002';
+  const DEVICE_ALLOWED = '33333333-3333-3333-3333-333333333333';
+  const DEVICE_DENIED = '55555555-5555-5555-5555-555555555555';
+
+  function setSiteScopedAuth(allowedSiteIds: string[] | undefined) {
+    vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+      c.set('auth', {
+        scope: 'organization',
+        orgId: '11111111-1111-1111-1111-111111111111',
+        accessibleOrgIds: ['11111111-1111-1111-1111-111111111111'],
+        canAccessOrg: (orgId: string) => orgId === '11111111-1111-1111-1111-111111111111',
+        orgCondition: () => undefined,
+        user: { id: 'user-123', email: 'test@example.com' }
+      });
+      if (allowedSiteIds !== undefined) c.set('permissions', { allowedSiteIds });
+      return next();
+    });
+  }
+
+  // Device-resolution query a restricted reader runs first:
+  // db.select({id, siteId}).from(devices).where(eq(orgId, ...)) → rows
+  function mockDeviceResolution(rows: Array<{ id: string; siteId: string | null }>) {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(rows)
+      })
+    } as any);
+  }
+
+  describe('GET /events — site scope', () => {
+    it('denies an explicit deviceId outside the caller site allowlist (403)', async () => {
+      setSiteScopedAuth([SITE_ALLOWED]);
+      mockDeviceResolution([
+        { id: DEVICE_ALLOWED, siteId: SITE_ALLOWED },
+        { id: DEVICE_DENIED, siteId: SITE_DENIED }
+      ]);
+
+      const res = await app.request(`/dns-security/events?deviceId=${DEVICE_DENIED}`);
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe('Device not found or access denied');
+    });
+
+    it('narrows to accessible + provider-level (null-device) rows', async () => {
+      setSiteScopedAuth([SITE_ALLOWED]);
+      mockDeviceResolution([{ id: DEVICE_ALLOWED, siteId: SITE_ALLOWED }]);
+      // events list + count
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            leftJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    offset: vi.fn().mockResolvedValue([
+                      { id: 'evt-1', deviceId: DEVICE_ALLOWED, domain: 'bad.example' },
+                      { id: 'evt-2', deviceId: null, domain: 'provider.example' }
+                    ])
+                  })
+                })
+              })
+            })
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 2 }])
+          })
+        } as any);
+
+      const res = await app.request('/dns-security/events');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toHaveLength(2);
+    });
+
+    it('does not narrow for unrestricted callers', async () => {
+      setSiteScopedAuth(undefined);
+      // No device-resolution select should run; first select is the events list.
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            leftJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    offset: vi.fn().mockResolvedValue([{ id: 'evt-1', deviceId: DEVICE_DENIED }])
+                  })
+                })
+              })
+            })
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 1 }])
+          })
+        } as any);
+
+      const res = await app.request('/dns-security/events');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toHaveLength(1);
+    });
+  });
+
+  describe('GET /stats — site scope', () => {
+    it('denies an explicit deviceId outside the caller site allowlist (403)', async () => {
+      setSiteScopedAuth([SITE_ALLOWED]);
+      mockDeviceResolution([
+        { id: DEVICE_ALLOWED, siteId: SITE_ALLOWED },
+        { id: DEVICE_DENIED, siteId: SITE_DENIED }
+      ]);
+
+      const res = await app.request(`/dns-security/stats?deviceId=${DEVICE_DENIED}`);
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe('Device not found or access denied');
+    });
+
+    it('narrows raw stats query for a restricted caller (200)', async () => {
+      setSiteScopedAuth([SITE_ALLOWED]);
+      mockDeviceResolution([{ id: DEVICE_ALLOWED, siteId: SITE_ALLOWED }]);
+      // raw path: summary, topBlockedDomains, topCategories, topDevices
+      const summarySel = {
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            { totalQueries: 5, blockedQueries: 2, allowedQueries: 3, redirectedQueries: 0 }
+          ])
+        })
+      };
+      const groupSel = {
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            groupBy: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([])
+              })
+            })
+          })
+        })
+      };
+      const deviceGroupSel = {
+        from: vi.fn().mockReturnValue({
+          leftJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              groupBy: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue([])
+                })
+              })
+            })
+          })
+        })
+      };
+      vi.mocked(db.select)
+        .mockReturnValueOnce(summarySel as any)
+        .mockReturnValueOnce(groupSel as any)
+        .mockReturnValueOnce(groupSel as any)
+        .mockReturnValueOnce(deviceGroupSel as any);
+
+      const res = await app.request('/dns-security/stats');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.summary.totalQueries).toBe(5);
+      expect(body.source).toBe('raw');
+    });
   });
 });

--- a/apps/api/src/routes/dnsSecurity.test.ts
+++ b/apps/api/src/routes/dnsSecurity.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
-const { permissionGate, mfaGate } = vi.hoisted(() => ({
+const { permissionGate, mfaGate, permsState } = vi.hoisted(() => ({
   permissionGate: { deny: false },
-  mfaGate: { deny: false }
+  mfaGate: { deny: false },
+  permsState: { permissions: undefined as { allowedSiteIds?: string[] } | undefined }
 }));
 
 vi.mock('../db', () => ({
@@ -62,6 +63,8 @@ vi.mock('../middleware/auth', () => ({
     if (permissionGate.deny) {
       return c.json({ error: 'Forbidden' }, 403);
     }
+    // Mirror prod: requirePermission (not authMiddleware) populates `permissions`.
+    c.set('permissions', permsState.permissions);
     return next();
   }),
   requireMfa: vi.fn(() => async (c: any, next: any) => {
@@ -87,7 +90,8 @@ vi.mock('../services/secretCrypto', () => ({
 
 vi.mock('../services/permissions', () => ({
   PERMISSIONS: {
-    ORGS_WRITE: { resource: 'organizations', action: 'write' }
+    ORGS_WRITE: { resource: 'organizations', action: 'write' },
+    DEVICES_READ: { resource: 'devices', action: 'read' }
   },
   // Faithful to the real implementation: unrestricted callers (no
   // allowedSiteIds) always pass; otherwise the site must be in the allowlist.
@@ -223,6 +227,10 @@ describe('dns security routes', () => {
   const DEVICE_DENIED = '55555555-5555-5555-5555-555555555555';
 
   function setSiteScopedAuth(allowedSiteIds: string[] | undefined) {
+    // `permissions` is populated by requirePermission (see global mock), not
+    // authMiddleware — faithful to prod, so a route lacking the permission gate
+    // will not receive site scoping and its tests will fail.
+    permsState.permissions = allowedSiteIds !== undefined ? { allowedSiteIds } : undefined;
     vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
       c.set('auth', {
         scope: 'organization',
@@ -232,7 +240,6 @@ describe('dns security routes', () => {
         orgCondition: () => undefined,
         user: { id: 'user-123', email: 'test@example.com' }
       });
-      if (allowedSiteIds !== undefined) c.set('permissions', { allowedSiteIds });
       return next();
     });
   }

--- a/apps/api/src/routes/dnsSecurity.ts
+++ b/apps/api/src/routes/dnsSecurity.ts
@@ -1,7 +1,8 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { and, desc, eq, gte, ilike, lte, sql, type SQL } from 'drizzle-orm';
+import { and, desc, eq, gte, ilike, inArray, isNull, lte, or, sql, type SQL } from 'drizzle-orm';
+import type { PgColumn } from 'drizzle-orm/pg-core';
 import { escapeLike } from '../utils/sql';
 import { db } from '../db';
 import {
@@ -20,7 +21,7 @@ import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthC
 import { scheduleDnsEventSync, schedulePolicySync } from '../jobs/dnsSyncJob';
 import { writeRouteAudit } from '../services/auditEvents';
 import { encryptSecret } from '../services/secretCrypto';
-import { PERMISSIONS } from '../services/permissions';
+import { PERMISSIONS, canAccessSite, type UserPermissions } from '../services/permissions';
 import { checkSsrfSafe, type SsrfMode } from '../services/ssrfGuard';
 
 // Per-provider URL guard mode.
@@ -88,6 +89,39 @@ function withOrgCondition(conditions: SQL[], condition: SQL | undefined): SQL[] 
 
 function whereOrUndefined(conditions: SQL[]): SQL | undefined {
   return conditions.length > 0 ? and(...conditions) : undefined;
+}
+
+// Resolve the device IDs a site-restricted caller may read within their org,
+// narrowed by `permissions.allowedSiteIds`. Returns null when the caller has no
+// site restriction (no narrowing needed). Site is an app-layer concept only —
+// Postgres RLS does NOT defend it — so a site-restricted user must not read DNS
+// events (or device hostnames) for devices in other sites within the same org.
+// Mirrors browserSecurity.ts `resolveSiteAllowedDeviceIds`.
+async function resolveSiteAllowedDeviceIds(
+  orgId: string,
+  perms: UserPermissions | undefined
+): Promise<string[] | null> {
+  if (!perms?.allowedSiteIds) return null;
+  const orgDevices = await db
+    .select({ id: devices.id, siteId: devices.siteId })
+    .from(devices)
+    .where(eq(devices.orgId, orgId));
+  return orgDevices
+    .filter((d) => typeof d.siteId === 'string' && canAccessSite(perms, d.siteId))
+    .map((d) => d.id);
+}
+
+// Build the site-scope narrowing condition for a NULLABLE deviceId column.
+// Keeps provider-level (null-device) rows visible while excluding rows for
+// devices in sites outside the caller's allowlist.
+function siteNarrowCondition(
+  column: PgColumn,
+  allowedDeviceIds: string[]
+): SQL {
+  if (allowedDeviceIds.length === 0) {
+    return isNull(column);
+  }
+  return or(isNull(column), inArray(column, allowedDeviceIds))!;
 }
 
 function resolveOrgId(
@@ -484,6 +518,18 @@ dnsSecurityRoutes.get(
     if (query.integrationId) conditions.push(eq(dnsSecurityEvents.integrationId, query.integrationId));
     if (query.domain) conditions.push(ilike(dnsSecurityEvents.domain, `%${escapeLike(query.domain)}%`));
 
+    // Site-scope narrowing (app-layer authz axis — RLS does not defend it).
+    // Only applies when the caller has `allowedSiteIds`. deviceId is NULLABLE,
+    // so provider-level (null-device) rows stay visible.
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    if (perms?.allowedSiteIds && auth.orgId) {
+      const allowedDeviceIds = await resolveSiteAllowedDeviceIds(auth.orgId, perms);
+      if (query.deviceId && !allowedDeviceIds!.includes(query.deviceId)) {
+        return c.json({ error: 'Device not found or access denied' }, 403);
+      }
+      conditions.push(siteNarrowCondition(dnsSecurityEvents.deviceId, allowedDeviceIds!));
+    }
+
     const limit = query.limit ?? 100;
     const offset = query.offset ?? 0;
     const where = whereOrUndefined(conditions);
@@ -562,6 +608,19 @@ dnsSecurityRoutes.get(
     if (query.action) conditions.push(eq(dnsSecurityEvents.action, query.action));
     if (query.category) conditions.push(eq(dnsSecurityEvents.category, query.category));
 
+    // Site-scope narrowing (app-layer authz axis — RLS does not defend it).
+    // Resolved once and applied to both the raw and aggregation code paths.
+    // deviceId is NULLABLE, so provider-level (null-device) rows stay visible.
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    let allowedDeviceIds: string[] | null = null;
+    if (perms?.allowedSiteIds && auth.orgId) {
+      allowedDeviceIds = await resolveSiteAllowedDeviceIds(auth.orgId, perms);
+      if (query.deviceId && !allowedDeviceIds!.includes(query.deviceId)) {
+        return c.json({ error: 'Device not found or access denied' }, 403);
+      }
+      conditions.push(siteNarrowCondition(dnsSecurityEvents.deviceId, allowedDeviceIds!));
+    }
+
     const topN = query.topN ?? 10;
     const where = whereOrUndefined(conditions);
 
@@ -573,6 +632,9 @@ dnsSecurityRoutes.get(
       if (query.integrationId) aggConditions.push(eq(dnsEventAggregations.integrationId, query.integrationId));
       if (query.deviceId) aggConditions.push(eq(dnsEventAggregations.deviceId, query.deviceId));
       if (query.category) aggConditions.push(eq(dnsEventAggregations.category, query.category));
+      if (allowedDeviceIds !== null) {
+        aggConditions.push(siteNarrowCondition(dnsEventAggregations.deviceId, allowedDeviceIds));
+      }
 
       const aggWhere = whereOrUndefined(aggConditions);
       const [aggCountRow] = await db

--- a/apps/api/src/routes/dnsSecurity.ts
+++ b/apps/api/src/routes/dnsSecurity.ts
@@ -488,6 +488,9 @@ dnsSecurityRoutes.post(
 dnsSecurityRoutes.get(
   '/events',
   requireScope('organization', 'partner', 'system'),
+  // Populates `permissions` in context (site-scope narrowing below depends on
+  // it) and gates device-telemetry reads behind DEVICES_READ.
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
   zValidator('query', listEventsQuerySchema),
   async (c) => {
     const auth = c.get('auth');
@@ -579,6 +582,9 @@ dnsSecurityRoutes.get(
 dnsSecurityRoutes.get(
   '/stats',
   requireScope('organization', 'partner', 'system'),
+  // Populates `permissions` in context (site-scope narrowing below depends on
+  // it) and gates device-telemetry reads behind DEVICES_READ.
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
   zValidator('query', statsQuerySchema),
   async (c) => {
     const auth = c.get('auth');

--- a/apps/api/src/routes/huntress.test.ts
+++ b/apps/api/src/routes/huntress.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
-const { permissionGate, mfaGate } = vi.hoisted(() => ({
+const { permissionGate, mfaGate, permsState } = vi.hoisted(() => ({
   permissionGate: { deny: false },
-  mfaGate: { deny: false }
+  mfaGate: { deny: false },
+  permsState: { permissions: undefined as { allowedSiteIds?: string[] } | undefined }
 }));
 
 vi.mock('../db', () => ({
@@ -19,6 +20,8 @@ vi.mock('../db/schema', () => ({
   devices: {
     id: 'id',
     hostname: 'hostname',
+    orgId: 'orgId',
+    siteId: 'siteId',
   },
   huntressIntegrations: {
     id: 'id',
@@ -71,6 +74,7 @@ vi.mock('../middleware/auth', () => ({
       orgCondition: vi.fn(() => undefined),
       user: { id: 'user-123', email: 'test@example.com' }
     });
+    c.set('permissions', permsState.permissions);
     return next();
   }),
   requireScope: vi.fn(() => async (_c: any, next: any) => next()),
@@ -114,7 +118,9 @@ vi.mock('../services/auditEvents', () => ({
 vi.mock('../services/permissions', () => ({
   PERMISSIONS: {
     ORGS_WRITE: { resource: 'organizations', action: 'write' }
-  }
+  },
+  canAccessSite: (perms: { allowedSiteIds?: string[] } | undefined, siteId: string) =>
+    !perms?.allowedSiteIds || perms.allowedSiteIds.includes(siteId),
 }));
 
 import { db } from '../db';
@@ -128,6 +134,7 @@ describe('huntress routes', () => {
     vi.clearAllMocks();
     permissionGate.deny = false;
     mfaGate.deny = false;
+    permsState.permissions = undefined;
     app = new Hono();
     app.route('/huntress', huntressRoutes);
   });
@@ -245,5 +252,141 @@ describe('huntress routes', () => {
     expect(res.status).toBe(409);
     const body = await res.json();
     expect(String(body.error)).toContain('account');
+  });
+
+  describe('GET /incidents site-scope narrowing', () => {
+    const ALLOWED_SITE = 'site-allowed';
+    const FOREIGN_SITE = 'site-foreign';
+    const ALLOWED_DEVICE = '22222222-2222-2222-2222-222222222222';
+    const FOREIGN_DEVICE = '33333333-3333-3333-3333-333333333333';
+
+    // Mock the device-resolution select (runs first when site-restricted),
+    // returning all org devices with their siteId for the narrowing filter.
+    function mockDeviceResolution() {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn(() => ({
+          where: vi.fn(async () => [
+            { id: ALLOWED_DEVICE, siteId: ALLOWED_SITE },
+            { id: FOREIGN_DEVICE, siteId: FOREIGN_SITE },
+          ]),
+        })),
+      } as any);
+    }
+
+    // Capture the where clause passed to the main incidents query so we can
+    // assert how the route narrowed, and return a fixed result set.
+    function mockIncidentQuery(captured: { where?: unknown }, rows: unknown[]) {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn(() => ({
+          leftJoin: vi.fn(() => ({
+            where: vi.fn((w: unknown) => {
+              captured.where = w;
+              return {
+                orderBy: vi.fn(() => ({
+                  limit: vi.fn(() => ({
+                    offset: vi.fn(async () => rows),
+                  })),
+                })),
+              };
+            }),
+          })),
+        })),
+      } as any);
+      // Count query
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn(() => ({
+          where: vi.fn(async () => [{ count: rows.length }]),
+        })),
+      } as any);
+    }
+
+    it('returns 403 when a site-restricted caller requests a deviceId outside their allowed sites', async () => {
+      permsState.permissions = { allowedSiteIds: [ALLOWED_SITE] };
+      mockDeviceResolution();
+
+      const res = await app.request(`/huntress/incidents?deviceId=${FOREIGN_DEVICE}`);
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(String(body.error)).toContain('access denied');
+    });
+
+    it('allows a site-restricted caller to request a deviceId within their allowed sites', async () => {
+      permsState.permissions = { allowedSiteIds: [ALLOWED_SITE] };
+      mockDeviceResolution();
+      const captured: { where?: unknown } = {};
+      mockIncidentQuery(captured, [
+        { id: 'inc-1', deviceId: ALLOWED_DEVICE, title: 'allowed' },
+      ]);
+
+      const res = await app.request(`/huntress/incidents?deviceId=${ALLOWED_DEVICE}`);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toHaveLength(1);
+    });
+
+    it('narrows results to allowed devices + provider-level (null-device) incidents for restricted callers', async () => {
+      permsState.permissions = { allowedSiteIds: [ALLOWED_SITE] };
+      mockDeviceResolution();
+      const captured: { where?: unknown } = {};
+      // The DB-level narrowing is asserted via the where clause; here we just
+      // confirm the route issues the query and returns rows successfully.
+      mockIncidentQuery(captured, [
+        { id: 'inc-allowed', deviceId: ALLOWED_DEVICE, title: 'allowed-device' },
+        { id: 'inc-provider', deviceId: null, title: 'provider-level' },
+      ]);
+
+      const res = await app.request('/huntress/incidents');
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toHaveLength(2);
+      // A narrowing condition must have been applied to the main query.
+      expect(captured.where).toBeDefined();
+    });
+
+    it('still narrows (allowing only null-device incidents) when the caller has no allowed devices', async () => {
+      permsState.permissions = { allowedSiteIds: ['site-with-no-devices'] };
+      // No org devices match the allowlist.
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn(() => ({
+          where: vi.fn(async () => [
+            { id: ALLOWED_DEVICE, siteId: ALLOWED_SITE },
+            { id: FOREIGN_DEVICE, siteId: FOREIGN_SITE },
+          ]),
+        })),
+      } as any);
+      const captured: { where?: unknown } = {};
+      mockIncidentQuery(captured, [
+        { id: 'inc-provider', deviceId: null, title: 'provider-level' },
+      ]);
+
+      const res = await app.request('/huntress/incidents');
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toHaveLength(1);
+      expect(captured.where).toBeDefined();
+    });
+
+    it('does not narrow for unrestricted callers (no device-resolution query issued)', async () => {
+      permsState.permissions = undefined; // unrestricted
+      const captured: { where?: unknown } = {};
+      // Only the main query + count query should be issued (no device resolution).
+      mockIncidentQuery(captured, [
+        { id: 'inc-1', deviceId: FOREIGN_DEVICE, title: 'foreign-device' },
+        { id: 'inc-2', deviceId: null, title: 'provider-level' },
+      ]);
+
+      const res = await app.request('/huntress/incidents');
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Unrestricted: foreign-device rows remain visible.
+      expect(body.data).toHaveLength(2);
+      // db.select called exactly twice (main + count), proving no device-resolution query.
+      expect(vi.mocked(db.select)).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/apps/api/src/routes/huntress.test.ts
+++ b/apps/api/src/routes/huntress.test.ts
@@ -74,7 +74,10 @@ vi.mock('../middleware/auth', () => ({
       orgCondition: vi.fn(() => undefined),
       user: { id: 'user-123', email: 'test@example.com' }
     });
-    c.set('permissions', permsState.permissions);
+    // NOTE: authMiddleware does NOT populate `permissions` in production — only
+    // requirePermission does (auth.ts). Setting it here would mask routes that
+    // rely on `c.get('permissions')` for site-scoping but lack a requirePermission
+    // gate. Keep this faithful to prod so such gaps fail their site-scope tests.
     return next();
   }),
   requireScope: vi.fn(() => async (_c: any, next: any) => next()),
@@ -82,6 +85,8 @@ vi.mock('../middleware/auth', () => ({
     if (permissionGate.deny) {
       return c.json({ error: 'Forbidden' }, 403);
     }
+    // Mirror prod: requirePermission is the gate that populates `permissions`.
+    c.set('permissions', permsState.permissions);
     return next();
   }),
   requireMfa: vi.fn(() => async (c: any, next: any) => {
@@ -117,7 +122,8 @@ vi.mock('../services/auditEvents', () => ({
 
 vi.mock('../services/permissions', () => ({
   PERMISSIONS: {
-    ORGS_WRITE: { resource: 'organizations', action: 'write' }
+    ORGS_WRITE: { resource: 'organizations', action: 'write' },
+    DEVICES_READ: { resource: 'devices', action: 'read' }
   },
   canAccessSite: (perms: { allowedSiteIds?: string[] } | undefined, siteId: string) =>
     !perms?.allowedSiteIds || perms.allowedSiteIds.includes(siteId),

--- a/apps/api/src/routes/huntress.ts
+++ b/apps/api/src/routes/huntress.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { and, desc, eq, ilike, isNotNull, sql, type SQL } from 'drizzle-orm';
+import { and, desc, eq, ilike, inArray, isNotNull, isNull, or, sql, type SQL } from 'drizzle-orm';
 import * as dbModule from '../db';
 import { db } from '../db';
 import {
@@ -22,7 +22,7 @@ import {
 } from '../services/huntressClient';
 import { decryptForColumn, encryptSecret } from '../services/secretCrypto';
 import { writeRouteAudit } from '../services/auditEvents';
-import { PERMISSIONS } from '../services/permissions';
+import { PERMISSIONS, canAccessSite, type UserPermissions } from '../services/permissions';
 import { captureException } from '../services/sentry';
 import { escapeLike } from '../utils/sql';
 import { offlineStatusSqlList, resolvedStatusSqlList } from '../services/huntressConstants';
@@ -623,6 +623,37 @@ huntressRoutes.get(
     }
     const orgCondition = auth.orgCondition(huntressIncidents.orgId);
     if (orgCondition) conditions.push(orgCondition);
+
+    // Site is an app-layer-only authz axis — Postgres RLS does NOT defend it.
+    // A site-restricted caller (org user with `permissions.allowedSiteIds`)
+    // must not read incident detail/hostnames for devices in sites outside
+    // their allowlist. `deviceId` is NULLABLE (provider-level incidents are not
+    // device-bound), so we keep null-device rows visible and only exclude rows
+    // attributed to foreign-site devices. Mirrors browserSecurity.ts (PR #864/#868).
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    if (perms?.allowedSiteIds) {
+      const orgDevices = await db
+        .select({ id: devices.id, siteId: devices.siteId })
+        .from(devices)
+        .where(eq(devices.orgId, orgResult.orgId));
+      const allowedDeviceIds = orgDevices
+        .filter((d) => typeof d.siteId === 'string' && canAccessSite(perms, d.siteId))
+        .map((d) => d.id);
+
+      if (query.deviceId && !allowedDeviceIds.includes(query.deviceId)) {
+        return c.json({ error: 'Device not found or access denied' }, 403);
+      }
+
+      // Keep provider-level (null-device) rows; exclude foreign-site devices.
+      // With an empty allowedDeviceIds, `inArray(..., [])` matches nothing, so
+      // only the null-device branch remains — exactly the intended behavior.
+      conditions.push(
+        or(
+          isNull(huntressIncidents.deviceId),
+          inArray(huntressIncidents.deviceId, allowedDeviceIds)
+        )!
+      );
+    }
 
     const where = and(...conditions);
 

--- a/apps/api/src/routes/huntress.ts
+++ b/apps/api/src/routes/huntress.ts
@@ -600,6 +600,9 @@ huntressRoutes.get(
 huntressRoutes.get(
   '/incidents',
   requireScope('organization', 'partner', 'system'),
+  // Populates `permissions` in context (the site-scope narrowing below depends
+  // on it) and gates device-telemetry reads behind DEVICES_READ.
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
   zValidator('query', listIncidentsQuerySchema),
   async (c) => {
     const auth = c.get('auth');

--- a/apps/api/src/routes/peripheralControl.test.ts
+++ b/apps/api/src/routes/peripheralControl.test.ts
@@ -64,12 +64,16 @@ vi.mock('../middleware/auth', () => ({
       orgCondition: () => undefined,
       user: { id: 'user-123', email: 'test@example.com' }
     });
-    c.set('permissions', permsState.perms);
+    // NOTE: authMiddleware does NOT populate `permissions` in production — only
+    // requirePermission does. Keeping this faithful to prod ensures a route that
+    // relies on `permissions` for site-scoping but lacks a permission gate fails.
     return next();
   }),
   requireScope: vi.fn(() => async (_c: any, next: any) => next()),
   requirePermission: vi.fn(() => async (c: any, next: any) => {
     if (permissionGate.deny) return c.json({ error: 'Forbidden' }, 403);
+    // Mirror prod: requirePermission is the gate that populates `permissions`.
+    c.set('permissions', permsState.perms);
     return next();
   }),
   requireMfa: vi.fn(() => async (c: any, next: any) => {
@@ -92,7 +96,8 @@ vi.mock('../services/eventBus', () => ({
 
 vi.mock('../services/permissions', () => ({
   PERMISSIONS: {
-    ORGS_WRITE: { resource: 'organizations', action: 'write' }
+    ORGS_WRITE: { resource: 'organizations', action: 'write' },
+    DEVICES_READ: { resource: 'devices', action: 'read' }
   },
   canAccessSite: (perms: { allowedSiteIds?: string[] } | undefined, siteId: string) =>
     !perms?.allowedSiteIds || perms.allowedSiteIds.includes(siteId)

--- a/apps/api/src/routes/peripheralControl.test.ts
+++ b/apps/api/src/routes/peripheralControl.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
-const { permissionGate, mfaGate } = vi.hoisted(() => ({
+const { permissionGate, mfaGate, permsState } = vi.hoisted(() => ({
   permissionGate: { deny: false },
-  mfaGate: { deny: false }
+  mfaGate: { deny: false },
+  permsState: { perms: undefined as { allowedSiteIds?: string[] } | undefined }
 }));
 
 vi.mock('../db', () => ({
@@ -45,6 +46,11 @@ vi.mock('../db/schema', () => ({
     targetType: 'targetType',
     isActive: 'isActive',
     updatedAt: 'updatedAt'
+  },
+  devices: {
+    id: 'id',
+    orgId: 'orgId',
+    siteId: 'siteId'
   }
 }));
 
@@ -58,6 +64,7 @@ vi.mock('../middleware/auth', () => ({
       orgCondition: () => undefined,
       user: { id: 'user-123', email: 'test@example.com' }
     });
+    c.set('permissions', permsState.perms);
     return next();
   }),
   requireScope: vi.fn(() => async (_c: any, next: any) => next()),
@@ -86,7 +93,9 @@ vi.mock('../services/eventBus', () => ({
 vi.mock('../services/permissions', () => ({
   PERMISSIONS: {
     ORGS_WRITE: { resource: 'organizations', action: 'write' }
-  }
+  },
+  canAccessSite: (perms: { allowedSiteIds?: string[] } | undefined, siteId: string) =>
+    !perms?.allowedSiteIds || perms.allowedSiteIds.includes(siteId)
 }));
 
 import { db } from '../db';
@@ -119,6 +128,7 @@ describe('peripheralControl routes', () => {
     vi.clearAllMocks();
     permissionGate.deny = false;
     mfaGate.deny = false;
+    permsState.perms = undefined;
     app = new Hono();
     app.route('/peripherals', peripheralControlRoutes);
   });
@@ -508,5 +518,167 @@ describe('peripheralControl routes', () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toContain('start must be before or equal to end');
+  });
+
+  describe('GET /activity site-scope narrowing', () => {
+    const inScopeSite = 'site-aaaa';
+    const outOfScopeSite = 'site-bbbb';
+    const inScopeDevice = '44444444-4444-4444-4444-444444444444';
+    const outOfScopeDevice = '55555555-5555-5555-5555-555555555555';
+
+    const activityRow = (deviceId: string) => ({
+      id: '33333333-3333-3333-3333-333333333333',
+      orgId,
+      deviceId,
+      policyId,
+      eventType: 'blocked',
+      peripheralType: 'storage',
+      vendor: 'SanDisk',
+      product: 'Ultra USB',
+      serialNumber: 'SN-12345',
+      occurredAt: new Date().toISOString(),
+      createdAt: new Date().toISOString()
+    });
+
+    // db.select() call order when site-restricted:
+    //   1. device-resolution select: .from().where() -> org devices
+    //   2. count select: .from().where()
+    //   3. rows select: .from().where().orderBy().limit().offset()
+    function mockRestrictedSelects(orgDevices: Array<{ id: string; siteId: string }>, rows: unknown[]) {
+      vi.mocked(db.select).mockReset();
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(orgDevices)
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: rows.length }])
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  offset: vi.fn().mockResolvedValue(rows)
+                })
+              })
+            })
+          })
+        } as any);
+    }
+
+    it('returns 403 when a site-restricted caller requests an out-of-scope deviceId', async () => {
+      permsState.perms = { allowedSiteIds: [inScopeSite] };
+      mockRestrictedSelects(
+        [
+          { id: inScopeDevice, siteId: inScopeSite },
+          { id: outOfScopeDevice, siteId: outOfScopeSite }
+        ],
+        []
+      );
+
+      const res = await app.request(
+        `/peripherals/activity?deviceId=${outOfScopeDevice}`,
+        { method: 'GET' }
+      );
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe('Device not found or access denied');
+    });
+
+    it('allows a site-restricted caller to read an in-scope deviceId', async () => {
+      permsState.perms = { allowedSiteIds: [inScopeSite] };
+      mockRestrictedSelects(
+        [
+          { id: inScopeDevice, siteId: inScopeSite },
+          { id: outOfScopeDevice, siteId: outOfScopeSite }
+        ],
+        [activityRow(inScopeDevice)]
+      );
+
+      const res = await app.request(
+        `/peripherals/activity?deviceId=${inScopeDevice}`,
+        { method: 'GET' }
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].deviceId).toBe(inScopeDevice);
+    });
+
+    it('narrows results to in-scope devices for a site-restricted caller (no explicit deviceId)', async () => {
+      permsState.perms = { allowedSiteIds: [inScopeSite] };
+      mockRestrictedSelects(
+        [
+          { id: inScopeDevice, siteId: inScopeSite },
+          { id: outOfScopeDevice, siteId: outOfScopeSite }
+        ],
+        [activityRow(inScopeDevice)]
+      );
+
+      const res = await app.request('/peripherals/activity', { method: 'GET' });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].deviceId).toBe(inScopeDevice);
+    });
+
+    it('short-circuits to an empty result when the caller has no in-scope devices', async () => {
+      permsState.perms = { allowedSiteIds: ['site-with-no-devices'] };
+      // Only the device-resolution select runs; no count/rows query.
+      vi.mocked(db.select).mockReset();
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            { id: outOfScopeDevice, siteId: outOfScopeSite }
+          ])
+        })
+      } as any);
+
+      const res = await app.request('/peripherals/activity', { method: 'GET' });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toEqual([]);
+      expect(body.pagination.total).toBe(0);
+      // No count/rows queries should have been issued beyond device resolution.
+      expect(vi.mocked(db.select)).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not narrow for an unrestricted caller (no allowedSiteIds)', async () => {
+      // No perms set -> unrestricted. Only count + rows selects run (no device resolution).
+      vi.mocked(db.select).mockReset();
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 1 }])
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  offset: vi.fn().mockResolvedValue([activityRow(outOfScopeDevice)])
+                })
+              })
+            })
+          })
+        } as any);
+
+      const res = await app.request('/peripherals/activity', { method: 'GET' });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toHaveLength(1);
+      // Unrestricted: exactly 2 selects (count + rows), no device-resolution query.
+      expect(vi.mocked(db.select)).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/apps/api/src/routes/peripheralControl.ts
+++ b/apps/api/src/routes/peripheralControl.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { and, desc, eq, gte, lte, sql, type SQL } from 'drizzle-orm';
+import { and, desc, eq, gte, inArray, lte, sql, type SQL } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../db';
 import {
@@ -10,13 +10,14 @@ import {
   peripheralPolicies,
   peripheralPolicyActionEnum,
   peripheralPolicyTargetTypeEnum,
+  devices,
   type PeripheralExceptionRule,
   type PeripheralPolicyTargetIds
 } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import { schedulePeripheralPolicyDistribution } from '../jobs/peripheralJobs';
 import { writeRouteAudit } from '../services/auditEvents';
-import { PERMISSIONS } from '../services/permissions';
+import { PERMISSIONS, canAccessSite, type UserPermissions } from '../services/permissions';
 import { publishEvent } from '../services/eventBus';
 
 export const peripheralControlRoutes = new Hono();
@@ -163,6 +164,27 @@ function resolveOrgIdForWrite(
   return { error: 'orgId is required for this scope', status: 400 };
 }
 
+// Resolve the device IDs a site-restricted caller may read within their org,
+// narrowed by `permissions.allowedSiteIds`. Returns null when the caller has no
+// site restriction (no narrowing needed). Site is an app-layer concept only —
+// Postgres RLS does NOT defend it — so a site-restricted org user must not read
+// peripheral/USB events for devices in other sites within the same org.
+// `allowedSiteIds` is only ever set for org-scope users (see permissions.ts), so
+// `orgId` is guaranteed present whenever narrowing applies. Mirrors browserSecurity.ts.
+async function resolveSiteAllowedDeviceIds(
+  orgId: string,
+  perms: UserPermissions | undefined,
+): Promise<string[] | null> {
+  if (!perms?.allowedSiteIds) return null;
+  const orgDevices = await db
+    .select({ id: devices.id, siteId: devices.siteId })
+    .from(devices)
+    .where(eq(devices.orgId, orgId));
+  return orgDevices
+    .filter((d) => typeof d.siteId === 'string' && canAccessSite(perms, d.siteId))
+    .map((d) => d.id);
+}
+
 function combineWarning(current: string | undefined, next: string): string {
   return current ? `${current}; ${next}` : next;
 }
@@ -219,6 +241,7 @@ peripheralControlRoutes.get(
   zValidator('query', listActivityQuerySchema),
   async (c) => {
     const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
     const query = c.req.valid('query');
 
     if (query.orgId && !auth.canAccessOrg(query.orgId)) {
@@ -255,9 +278,28 @@ peripheralControlRoutes.get(
     conditions.push(gte(peripheralEvents.occurredAt, effectiveStart));
     conditions.push(lte(peripheralEvents.occurredAt, effectiveEnd));
 
-    const where = conditions.length > 0 ? and(...conditions) : undefined;
     const limit = query.limit ?? 200;
     const offset = query.offset ?? 0;
+
+    // Narrow to the caller's accessible devices when site-restricted. RLS does
+    // not defend the site axis, so a site-scoped org user must not read events
+    // for devices outside their `allowedSiteIds`. Only org-scope users carry
+    // `allowedSiteIds`, so `auth.orgId` is present whenever this applies.
+    if (perms?.allowedSiteIds && auth.orgId) {
+      const allowedDeviceIds = await resolveSiteAllowedDeviceIds(auth.orgId, perms);
+      if (query.deviceId && !allowedDeviceIds!.includes(query.deviceId)) {
+        return c.json({ error: 'Device not found or access denied' }, 403);
+      }
+      if (!allowedDeviceIds || allowedDeviceIds.length === 0) {
+        return c.json({
+          data: [],
+          pagination: { total: 0, limit, offset }
+        });
+      }
+      conditions.push(inArray(peripheralEvents.deviceId, allowedDeviceIds));
+    }
+
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
 
     const [countRow] = await db
       .select({ count: sql<number>`count(*)` })

--- a/apps/api/src/routes/peripheralControl.ts
+++ b/apps/api/src/routes/peripheralControl.ts
@@ -238,6 +238,9 @@ async function emitPolicyChanged(
 
 peripheralControlRoutes.get(
   '/activity',
+  // Populates `permissions` in context (site-scope narrowing below depends on
+  // it) and gates device-telemetry reads behind DEVICES_READ.
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
   zValidator('query', listActivityQuerySchema),
   async (c) => {
     const auth = c.get('auth');

--- a/apps/api/src/routes/sentinelOne.test.ts
+++ b/apps/api/src/routes/sentinelOne.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
-const { permissionGate, mfaGate } = vi.hoisted(() => ({
+const { permissionGate, mfaGate, permsState } = vi.hoisted(() => ({
   permissionGate: { deny: false },
-  mfaGate: { deny: false }
+  mfaGate: { deny: false },
+  permsState: { permissions: undefined as { allowedSiteIds?: string[] } | undefined }
 }));
 
 vi.mock('../db', () => ({
@@ -82,6 +83,8 @@ vi.mock('../middleware/auth', () => ({
     if (permissionGate.deny) {
       return c.json({ error: 'Forbidden' }, 403);
     }
+    // Mirror prod: requirePermission (not authMiddleware) populates `permissions`.
+    c.set('permissions', permsState.permissions);
     return next();
   }),
   requireMfa: vi.fn(() => async (c: any, next: any) => {
@@ -114,7 +117,8 @@ vi.mock('../services/secretCrypto', () => ({
 vi.mock('../services/permissions', () => ({
   PERMISSIONS: {
     ORGS_WRITE: { resource: 'organizations', action: 'write' },
-    DEVICES_EXECUTE: { resource: 'devices', action: 'execute' }
+    DEVICES_EXECUTE: { resource: 'devices', action: 'execute' },
+    DEVICES_READ: { resource: 'devices', action: 'read' }
   },
   // Faithful to the real implementation: unrestricted callers (no
   // allowedSiteIds) always pass; otherwise the site must be in the allowlist.
@@ -392,6 +396,10 @@ describe('sentinel one routes', () => {
     const DEVICE_DENIED = '55555555-5555-5555-5555-555555555555';
 
     function setAuth(allowedSiteIds?: string[]) {
+      // `permissions` is populated by requirePermission (see global mock), not
+      // authMiddleware — faithful to prod, so a route lacking the permission
+      // gate will not receive site scoping and its tests will fail.
+      permsState.permissions = allowedSiteIds ? { allowedSiteIds } : undefined;
       vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
         c.set('auth', {
           scope: 'organization',
@@ -401,7 +409,6 @@ describe('sentinel one routes', () => {
           orgCondition: () => undefined,
           user: { id: 'user-123', email: 'test@example.com' }
         });
-        if (allowedSiteIds) c.set('permissions', { allowedSiteIds });
         return next();
       });
     }

--- a/apps/api/src/routes/sentinelOne.test.ts
+++ b/apps/api/src/routes/sentinelOne.test.ts
@@ -20,7 +20,7 @@ vi.mock('../db', () => ({
 }));
 
 vi.mock('../db/schema', () => ({
-  devices: { id: 'id', orgId: 'orgId', hostname: 'hostname' },
+  devices: { id: 'id', orgId: 'orgId', hostname: 'hostname', siteId: 'siteId' },
   s1Actions: {
     id: 'id',
     orgId: 'orgId',
@@ -72,6 +72,7 @@ vi.mock('../middleware/auth', () => ({
       orgId: '11111111-1111-1111-1111-111111111111',
       accessibleOrgIds: ['11111111-1111-1111-1111-111111111111'],
       canAccessOrg: (orgId: string) => orgId === '11111111-1111-1111-1111-111111111111',
+      orgCondition: () => undefined,
       user: { id: 'user-123', email: 'test@example.com' }
     });
     return next();
@@ -114,11 +115,16 @@ vi.mock('../services/permissions', () => ({
   PERMISSIONS: {
     ORGS_WRITE: { resource: 'organizations', action: 'write' },
     DEVICES_EXECUTE: { resource: 'devices', action: 'execute' }
-  }
+  },
+  // Faithful to the real implementation: unrestricted callers (no
+  // allowedSiteIds) always pass; otherwise the site must be in the allowlist.
+  canAccessSite: (perms: any, siteId: string) =>
+    !perms?.allowedSiteIds || perms.allowedSiteIds.includes(siteId)
 }));
 
 import { sentinelOneRoutes } from './sentinelOne';
 import { db } from '../db';
+import { authMiddleware } from '../middleware/auth';
 import {
   executeS1IsolationForOrg,
   executeS1ThreatActionForOrg,
@@ -371,5 +377,130 @@ describe('sentinel one routes', () => {
     const body = await res.json();
     expect(body.data.unmatchedThreatIds).toEqual(['missing-threat']);
     expect(body.data.matchedThreatIds).toEqual(['s1-threat-1']);
+  });
+
+  // ───────────────────── GET /threats — site scope ─────────────────────
+  // A site-restricted org user (permissions.allowedSiteIds set) must not list
+  // SentinelOne threats (or device hostnames) for devices in sites outside
+  // their allowlist, nor target a foreign-site device via ?deviceId=.
+  // Site is an app-layer concept only — Postgres RLS does not defend it.
+  describe('GET /threats — site scope', () => {
+    const ORG_ID = '11111111-1111-1111-1111-111111111111';
+    const SITE_ALLOWED = 'aaaaaaaa-0000-0000-0000-000000000001';
+    const SITE_DENIED = 'bbbbbbbb-0000-0000-0000-000000000002';
+    const DEVICE_ALLOWED = '33333333-3333-3333-3333-333333333333';
+    const DEVICE_DENIED = '55555555-5555-5555-5555-555555555555';
+
+    function setAuth(allowedSiteIds?: string[]) {
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          scope: 'organization',
+          orgId: ORG_ID,
+          accessibleOrgIds: [ORG_ID],
+          canAccessOrg: (orgId: string) => orgId === ORG_ID,
+          orgCondition: () => undefined,
+          user: { id: 'user-123', email: 'test@example.com' }
+        });
+        if (allowedSiteIds) c.set('permissions', { allowedSiteIds });
+        return next();
+      });
+    }
+    const setRestricted = (allowedSiteIds: string[]) => setAuth(allowedSiteIds);
+
+    // Mocks the device-resolution query a restricted reader runs first:
+    // db.select({id, siteId}).from(devices).where(...) → rows
+    function mockDeviceResolution(rows: Array<{ id: string; siteId: string | null }>) {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(rows)
+        })
+      } as any);
+    }
+
+    // Mocks the main threats list select (leftJoin) + count select.
+    function mockThreatsQueries(rows: any[], count: number) {
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            leftJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    offset: vi.fn().mockResolvedValue(rows)
+                  })
+                })
+              })
+            })
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count }])
+          })
+        } as any);
+    }
+
+    it('denies an explicit deviceId outside the caller site allowlist (403)', async () => {
+      setRestricted([SITE_ALLOWED]);
+      mockDeviceResolution([{ id: DEVICE_DENIED, siteId: SITE_DENIED }]);
+
+      const res = await app.request(`/s1/threats?deviceId=${DEVICE_DENIED}`);
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe('Device not found or access denied');
+    });
+
+    it('narrows the broad list to the caller accessible devices', async () => {
+      setRestricted([SITE_ALLOWED]);
+      // First select: device resolution (only DEVICE_ALLOWED is in-scope)
+      mockDeviceResolution([
+        { id: DEVICE_ALLOWED, siteId: SITE_ALLOWED },
+        { id: DEVICE_DENIED, siteId: SITE_DENIED }
+      ]);
+      // Then the threats list + count
+      mockThreatsQueries(
+        [{ id: 'threat-1', deviceId: DEVICE_ALLOWED, deviceName: 'PC-01' }],
+        1
+      );
+
+      const res = await app.request('/s1/threats');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].deviceId).toBe(DEVICE_ALLOWED);
+    });
+
+    it('allows an explicit in-scope deviceId for a restricted caller', async () => {
+      setRestricted([SITE_ALLOWED]);
+      mockDeviceResolution([{ id: DEVICE_ALLOWED, siteId: SITE_ALLOWED }]);
+      mockThreatsQueries(
+        [{ id: 'threat-1', deviceId: DEVICE_ALLOWED, deviceName: 'PC-01' }],
+        1
+      );
+
+      const res = await app.request(`/s1/threats?deviceId=${DEVICE_ALLOWED}`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toHaveLength(1);
+    });
+
+    it('does not narrow for an unrestricted caller (no allowedSiteIds)', async () => {
+      // No permissions set — only the threats list + count run, with NO
+      // device-resolution select beforehand.
+      setAuth();
+      mockThreatsQueries(
+        [
+          { id: 'threat-1', deviceId: DEVICE_ALLOWED, deviceName: 'PC-01' },
+          { id: 'threat-2', deviceId: DEVICE_DENIED, deviceName: 'PC-02' }
+        ],
+        2
+      );
+
+      const res = await app.request('/s1/threats');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toHaveLength(2);
+      expect(body.pagination.total).toBe(2);
+    });
   });
 });

--- a/apps/api/src/routes/sentinelOne.ts
+++ b/apps/api/src/routes/sentinelOne.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { and, desc, eq, gte, inArray, lte, or, sql, type SQL } from 'drizzle-orm';
+import { and, desc, eq, gte, inArray, isNull, lte, or, sql, type SQL } from 'drizzle-orm';
 import { db } from '../db';
 import { devices, organizations, s1Actions, s1Agents, s1Integrations, s1SiteMappings, s1Threats } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
@@ -40,6 +40,26 @@ function whereOrUndefined(conditions: SQL[]): SQL | undefined {
 function canAccessDeviceSite(device: { siteId?: string | null }, permissions: UserPermissions | undefined): boolean {
   if (!permissions?.allowedSiteIds) return true;
   return typeof device.siteId === 'string' && canAccessSite(permissions, device.siteId);
+}
+
+// Resolve the device IDs a site-restricted caller may read within their org,
+// narrowed by `permissions.allowedSiteIds`. Returns null when the caller has no
+// site restriction (no narrowing needed). Site is an app-layer concept only —
+// Postgres RLS does NOT defend it — so a site-restricted org user must not read
+// threat rows (or device hostnames) for devices in other sites within the same
+// org. Mirrors browserSecurity.ts `resolveSiteAllowedDeviceIds`.
+async function resolveSiteAllowedDeviceIds(
+  orgId: string,
+  permissions: UserPermissions | undefined,
+): Promise<string[] | null> {
+  if (!permissions?.allowedSiteIds) return null;
+  const orgDevices = await db
+    .select({ id: devices.id, siteId: devices.siteId })
+    .from(devices)
+    .where(eq(devices.orgId, orgId));
+  return orgDevices
+    .filter((d) => canAccessDeviceSite(d, permissions))
+    .map((d) => d.id);
 }
 
 async function hasDeniedDeviceSite(orgId: string, deviceIds: string[], permissions: UserPermissions | undefined): Promise<boolean> {
@@ -427,6 +447,24 @@ sentinelOneRoutes.get(
 
     const conditions: SQL[] = [eq(s1Threats.orgId, orgResult.orgId)];
     withOrgCondition(conditions, auth.orgCondition(s1Threats.orgId));
+
+    // Site-scope: site is an app-layer authz axis (RLS does not defend it).
+    // When the caller is site-restricted, deny an explicit out-of-scope
+    // deviceId and narrow the broad list to the caller's accessible devices.
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    if (perms?.allowedSiteIds) {
+      const allowedDeviceIds = await resolveSiteAllowedDeviceIds(orgResult.orgId, perms);
+      if (query.deviceId && !allowedDeviceIds!.includes(query.deviceId)) {
+        return c.json({ error: 'Device not found or access denied' }, 403);
+      }
+      // s1_threats.device_id is nullable; keep non-device-bound threat rows
+      // visible (they carry no site to gate on).
+      conditions.push(
+        allowedDeviceIds && allowedDeviceIds.length > 0
+          ? (or(isNull(s1Threats.deviceId), inArray(s1Threats.deviceId, allowedDeviceIds)) as SQL)
+          : isNull(s1Threats.deviceId),
+      );
+    }
 
     if (query.integrationId) conditions.push(eq(s1Threats.integrationId, query.integrationId));
     if (query.deviceId) conditions.push(eq(s1Threats.deviceId, query.deviceId));

--- a/apps/api/src/routes/sentinelOne.ts
+++ b/apps/api/src/routes/sentinelOne.ts
@@ -427,6 +427,9 @@ sentinelOneRoutes.get(
 sentinelOneRoutes.get(
   '/threats',
   requireScope('organization', 'partner', 'system'),
+  // Populates `permissions` in context (site-scope narrowing below depends on
+  // it) and gates device-telemetry reads behind DEVICES_READ.
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
   zValidator('query', listThreatsQuerySchema),
   async (c) => {
     const auth = c.get('auth');


### PR DESCRIPTION
## Summary

Closes a **site-scope authorization gap** reported privately against the live tree. Site is an app-layer-only authz axis — an org user can be restricted to a subset of sites via `permissions.allowedSiteIds`, and **Postgres RLS does not defend it**. Several user-facing read/mutation handlers filtered device-scoped data by **org only**, so a site-restricted technician could read data for — and in some cases act on — devices in sites outside their allowlist.

All of these evaded the existing `site-scope-coverage` contract test because its scanner only matches `:deviceId` **URL patterns**; these handlers take the device id via **query param / request body / list-style** queries. (Its own header note flags this exact blind spot.) A follow-up PR extends the scanner so this class can't recur.

## What changed

Every gate is a **no-op for unrestricted callers** (no `allowedSiteIds` → no behavior change) and mirrors the canonical `software.ts` pattern (`resolveSiteAllowedDeviceIds`).

| Route | Gap | Fix |
|---|---|---|
| `browserSecurity GET /extensions`, `/violations` | org-only reads (query-param + list-style) | narrow to accessible devices; 403 on out-of-scope `?deviceId`; empty when none in scope |
| `browserSecurity POST/PUT/DELETE /policies` | any site-restricted user could CRUD org-wide policies | may only mutate policies targeting sites entirely within their allowlist; PUT checks both current + resulting target |
| `sentinelOne GET /threats` | list org-only while `/isolate` + `/threat-action` were already gated | narrow list + 403 out-of-scope `?deviceId` (nullable deviceId → keep non-device rows) |
| `peripheralControl GET /activity` | `peripheral_events.deviceId` NOT NULL → unconditional cross-site leak | `inArray` narrowing + empty short-circuit |
| `huntress GET /incidents` | nullable deviceId | keep provider-level rows, exclude foreign-site devices; 403 out-of-scope |
| `dnsSecurity GET /events`, `/stats` | nullable deviceId; gate applied to raw **and** aggregation paths | same; `/top-blocked` left org-wide by design |
| `analytics GET /capacity`, `POST /query` | per-device drill-down + **body `deviceIds`** | 403 on out-of-scope; timeseries denies the batch if any id is out of scope; org-wide aggregates unchanged |

## Tests

TDD throughout — failing tests written and verified RED before each fix. **105 tests pass** across the 7 affected test files; `tsc --noEmit` clean on all 10 changed files.

## Not in this PR (follow-ups)

- **Scanner** extension to catch the query/body/list-style class (separate PR — plan written).
- **AI-agent tool layer** (`services/aiTools*.ts`) has the same gap on a larger, higher-severity surface (mutating tools); separate PR — plan written, design decisions captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)