### PR TITLE
harden(api): server-side same-origin guard for notification link (#1018 follow-up)

### DIFF
--- a/apps/api/migrations/2026-05-31-user-notifications-link-relative-check.sql
+++ b/apps/api/migrations/2026-05-31-user-notifications-link-relative-check.sql
@@ -1,0 +1,47 @@
+-- Defense-in-depth for the notification open-redirect class (web #1018).
+--
+-- `user_notifications.link` is followed client-side via navigateTo(), which
+-- routes through getSafeNext() (apps/web/src/lib/authNext.ts) and only allows
+-- a same-origin relative path. This constraint enforces the SAME rule at the
+-- storage layer so a hostile value can never be persisted in the first place,
+-- even if a future writer bypasses the app-layer toSafeRelativePath() guard
+-- (packages/shared/src/validators/safeRelativePath.ts).
+--
+-- Allowed: NULL, or a single-leading-slash relative path with no protocol-
+-- relative (`//`) or backslash (`/\`) host bypass and no control characters.
+-- The regex range [\x00-\x1F\x7F] matches getSafeNext exactly (C0 + DEL only,
+-- NOT C1) — verified against Postgres 16; chr(92) is the backslash, used to
+-- keep the literal unambiguous under standard_conforming_strings.
+
+-- 1. Heal any pre-existing non-conforming rows so ADD CONSTRAINT cannot fail.
+--    Hostile/legacy links are neutralized to NULL; the client recomputes a
+--    safe default href from the notification type when link is absent.
+UPDATE user_notifications
+SET link = NULL
+WHERE link IS NOT NULL
+  AND NOT (
+    left(link, 1) = '/'
+    AND left(link, 2) <> '//'
+    AND left(link, 2) <> '/' || chr(92)
+    AND link !~ '[\x00-\x1F\x7F]'
+  );
+
+-- 2. Add the CHECK constraint idempotently.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'user_notifications_link_relative_chk'
+  ) THEN
+    ALTER TABLE user_notifications
+      ADD CONSTRAINT user_notifications_link_relative_chk
+      CHECK (
+        link IS NULL
+        OR (
+          left(link, 1) = '/'
+          AND left(link, 2) <> '//'
+          AND left(link, 2) <> '/' || chr(92)
+          AND link !~ '[\x00-\x1F\x7F]'
+        )
+      );
+  END IF;
+END $$;

--- a/apps/api/src/services/notificationSenders/inAppSender.test.ts
+++ b/apps/api/src/services/notificationSenders/inAppSender.test.ts
@@ -48,7 +48,7 @@ vi.mock('drizzle-orm', () => ({
   }))
 }));
 
-import { sendInAppNotification } from './inAppSender';
+import { sendInAppNotification, sendInAppNotificationToUsers } from './inAppSender';
 import { and, eq, sql } from 'drizzle-orm';
 import { partnerUsers } from '../../db/schema';
 
@@ -130,5 +130,88 @@ describe('in-app sender', () => {
       notificationCount: 0
     });
     expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  // --- link open-redirect hardening (server-side defense-in-depth) ---
+  // A hostile/absolute link must never persist; it collapses to the safe
+  // /alerts/<id> fallback. Mirrors the client getSafeNext guard.
+
+  it('sanitizes a hostile payload.link to the /alerts/<id> fallback (sendInAppNotification)', async () => {
+    const valuesMock = vi.fn().mockResolvedValue(undefined);
+    insertMock.mockReturnValue({ values: valuesMock });
+
+    selectMock
+      .mockReturnValueOnce(createOrgSelect([{ partnerId: null }]) as any)
+      .mockReturnValueOnce(createUserSelect([{ userId: 'org-user-1' }]) as any);
+
+    const result = await sendInAppNotification({
+      alertId: 'alert-1',
+      alertName: 'CPU High',
+      severity: 'high',
+      message: 'CPU > 90%',
+      orgId: '00000000-0000-0000-0000-000000000001',
+      link: 'https://evil.com/phish'
+    });
+
+    expect(result.success).toBe(true);
+    const inserted = valuesMock.mock.calls[0]?.[0] as Array<{ link: string }>;
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]?.link).toBe('/alerts/alert-1');
+  });
+
+  it('preserves a safe relative payload.link (sendInAppNotification)', async () => {
+    const valuesMock = vi.fn().mockResolvedValue(undefined);
+    insertMock.mockReturnValue({ values: valuesMock });
+
+    selectMock
+      .mockReturnValueOnce(createOrgSelect([{ partnerId: null }]) as any)
+      .mockReturnValueOnce(createUserSelect([{ userId: 'org-user-1' }]) as any);
+
+    await sendInAppNotification({
+      alertId: 'alert-2',
+      alertName: 'Disk',
+      severity: 'low',
+      message: 'm',
+      orgId: '00000000-0000-0000-0000-000000000001',
+      link: '/devices/42'
+    });
+
+    const inserted = valuesMock.mock.calls[0]?.[0] as Array<{ link: string }>;
+    expect(inserted[0]?.link).toBe('/devices/42');
+  });
+
+  it('sanitizes a hostile payload.link to the /alerts/<id> fallback (sendInAppNotificationToUsers)', async () => {
+    const valuesMock = vi.fn().mockResolvedValue(undefined);
+    insertMock.mockReturnValue({ values: valuesMock });
+
+    const result = await sendInAppNotificationToUsers(['user-1', 'user-2'], {
+      alertId: 'alert-9',
+      alertName: 'Suspicious',
+      severity: 'critical',
+      message: 'm',
+      link: '//evil.com/phish'
+    });
+
+    expect(result.success).toBe(true);
+    const inserted = valuesMock.mock.calls[0]?.[0] as Array<{ link: string }>;
+    expect(inserted).toHaveLength(2);
+    expect(inserted[0]?.link).toBe('/alerts/alert-9');
+    expect(inserted[1]?.link).toBe('/alerts/alert-9');
+  });
+
+  it('preserves a safe relative payload.link (sendInAppNotificationToUsers)', async () => {
+    const valuesMock = vi.fn().mockResolvedValue(undefined);
+    insertMock.mockReturnValue({ values: valuesMock });
+
+    await sendInAppNotificationToUsers(['user-1'], {
+      alertId: 'alert-9',
+      alertName: 'X',
+      severity: 'low',
+      message: 'm',
+      link: '/scripts/7'
+    });
+
+    const inserted = valuesMock.mock.calls[0]?.[0] as Array<{ link: string }>;
+    expect(inserted[0]?.link).toBe('/scripts/7');
   });
 });

--- a/apps/api/src/services/notificationSenders/inAppSender.ts
+++ b/apps/api/src/services/notificationSenders/inAppSender.ts
@@ -8,6 +8,7 @@
 import { db } from '../../db';
 import { userNotifications, organizationUsers, users, partnerUsers, organizations } from '../../db/schema';
 import { eq, and, or, sql } from 'drizzle-orm';
+import { toSafeRelativePath } from '@breeze/shared';
 
 export type AlertSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
 
@@ -113,7 +114,9 @@ export async function sendInAppNotification(payload: InAppNotificationPayload): 
     }
 
     // Build notification link
-    const link = payload.link || `/alerts/${payload.alertId}`;
+    // Defense-in-depth: a caller-supplied link must be a safe same-origin
+    // relative path, else it collapses to the alert URL (mirrors getSafeNext).
+    const link = toSafeRelativePath(payload.link, `/alerts/${payload.alertId}`);
 
     // Build metadata
     const metadata = {
@@ -168,7 +171,9 @@ export async function sendInAppNotificationToUsers(
   }
 
   try {
-    const link = payload.link || `/alerts/${payload.alertId}`;
+    // Defense-in-depth: a caller-supplied link must be a safe same-origin
+    // relative path, else it collapses to the alert URL (mirrors getSafeNext).
+    const link = toSafeRelativePath(payload.link, `/alerts/${payload.alertId}`);
 
     const metadata = {
       alertId: payload.alertId,

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -15,6 +15,7 @@ export * from './reliability';
 export * from './businessEmail';
 export * from './remoteAccessLauncherScheme';
 export * from './remoteAccessInlineSettings';
+export * from './safeRelativePath';
 
 // ============================================
 // Device Roles

--- a/packages/shared/src/validators/safeRelativePath.test.ts
+++ b/packages/shared/src/validators/safeRelativePath.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isSafeRelativePath,
+  toSafeRelativePath,
+  safeRelativePathSchema,
+} from './safeRelativePath';
+
+// These cases mirror the client-side getSafeNext guard
+// (apps/web/src/lib/authNext.ts) so a value that would be stripped at
+// navigation time can never be persisted server-side in the first place.
+
+describe('isSafeRelativePath', () => {
+  it('accepts single-leading-slash relative paths', () => {
+    expect(isSafeRelativePath('/')).toBe(true);
+    expect(isSafeRelativePath('/devices')).toBe(true);
+    expect(isSafeRelativePath('/alerts/123e4567-e89b-12d3-a456-426614174000')).toBe(true);
+    expect(isSafeRelativePath('/oauth/consent?uid=abc')).toBe(true);
+    expect(isSafeRelativePath('/settings#section')).toBe(true);
+  });
+
+  it('passes through percent-encoded sequences (browsers do not decode %2F as a separator)', () => {
+    expect(isSafeRelativePath('/%2F%2Fevil.com')).toBe(true);
+    expect(isSafeRelativePath('/%5cevil.com')).toBe(true);
+  });
+
+  it('rejects empty, null, undefined, and non-string values', () => {
+    expect(isSafeRelativePath('')).toBe(false);
+    expect(isSafeRelativePath(null)).toBe(false);
+    expect(isSafeRelativePath(undefined)).toBe(false);
+    expect(isSafeRelativePath(42)).toBe(false);
+    expect(isSafeRelativePath({})).toBe(false);
+    expect(isSafeRelativePath(['/devices'])).toBe(false);
+  });
+
+  it('rejects protocol-relative URLs (//evil.com)', () => {
+    expect(isSafeRelativePath('//evil.com')).toBe(false);
+    expect(isSafeRelativePath('//evil.com/path')).toBe(false);
+  });
+
+  it('rejects the backslash host bypass (browsers may normalize \\ to /)', () => {
+    expect(isSafeRelativePath('/\\evil.com')).toBe(false);
+    expect(isSafeRelativePath('/\\\\evil.com')).toBe(false);
+  });
+
+  it('rejects absolute URLs and dangerous schemes', () => {
+    expect(isSafeRelativePath('https://evil.com')).toBe(false);
+    expect(isSafeRelativePath('http://evil.com')).toBe(false);
+    expect(isSafeRelativePath('javascript:alert(1)')).toBe(false);
+    expect(isSafeRelativePath('JaVaScRiPt:alert(1)')).toBe(false);
+    expect(isSafeRelativePath('data:text/html,<script>')).toBe(false);
+  });
+
+  it('rejects bare relative paths with no leading slash', () => {
+    expect(isSafeRelativePath('devices')).toBe(false);
+    expect(isSafeRelativePath('relative/path')).toBe(false);
+  });
+
+  it('rejects control characters anywhere in the path (CR/LF/tab/NUL/DEL)', () => {
+    expect(isSafeRelativePath('/foo\r\nLocation: x')).toBe(false);
+    expect(isSafeRelativePath('/foo\tbar')).toBe(false);
+    expect(isSafeRelativePath('/foo\x00bar')).toBe(false);
+    expect(isSafeRelativePath('/foo\x7Fbar')).toBe(false);
+  });
+});
+
+describe('toSafeRelativePath', () => {
+  it('returns the value unchanged when it is a safe relative path', () => {
+    expect(toSafeRelativePath('/devices', '/fallback')).toBe('/devices');
+    expect(toSafeRelativePath('/alerts/1?x=2#y', '/fallback')).toBe('/alerts/1?x=2#y');
+  });
+
+  it('returns the fallback for empty/null/undefined input', () => {
+    expect(toSafeRelativePath('', '/alerts/1')).toBe('/alerts/1');
+    expect(toSafeRelativePath(null, '/alerts/1')).toBe('/alerts/1');
+    expect(toSafeRelativePath(undefined, '/alerts/1')).toBe('/alerts/1');
+  });
+
+  it('returns the fallback for hostile inputs', () => {
+    expect(toSafeRelativePath('https://evil.com', '/alerts/1')).toBe('/alerts/1');
+    expect(toSafeRelativePath('//evil.com', '/alerts/1')).toBe('/alerts/1');
+    expect(toSafeRelativePath('/\\evil.com', '/alerts/1')).toBe('/alerts/1');
+    expect(toSafeRelativePath('javascript:alert(1)', '/alerts/1')).toBe('/alerts/1');
+    expect(toSafeRelativePath('/x\r\ny', '/alerts/1')).toBe('/alerts/1');
+  });
+});
+
+describe('safeRelativePathSchema', () => {
+  it('accepts safe relative paths', () => {
+    expect(safeRelativePathSchema.safeParse('/devices').success).toBe(true);
+    expect(safeRelativePathSchema.safeParse('/').success).toBe(true);
+  });
+
+  it('rejects unsafe values', () => {
+    for (const value of [
+      '',
+      '//evil.com',
+      '/\\evil.com',
+      'https://evil.com',
+      'javascript:alert(1)',
+      'relative/path',
+      '/with\nnewline',
+    ]) {
+      expect(safeRelativePathSchema.safeParse(value).success).toBe(false);
+    }
+  });
+});

--- a/packages/shared/src/validators/safeRelativePath.ts
+++ b/packages/shared/src/validators/safeRelativePath.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+
+// Rejects ASCII control characters (code points 0x00-0x1F and 0x7F), matching
+// the client getSafeNext guard. Implemented as a char-code scan rather than a
+// regex literal so the source carries no raw control bytes (which editors and
+// diff tooling can mangle) and needs no eslint no-control-regex exception.
+function hasControlChar(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
+
+/**
+ * True only for a safe same-origin relative path: a single leading slash (not
+ * `//` or `/\`, both of which browsers can resolve to an absolute host), with
+ * no embedded control characters.
+ *
+ * This is the server-side mirror of the client `getSafeNext` guard
+ * (apps/web/src/lib/authNext.ts). Persisting only values that pass this check
+ * means a stored notification `link` can never become an open redirect when the
+ * client later navigates to it — defense-in-depth even if the client guard is
+ * ever weakened. Absolute URLs, protocol-relative URLs, and custom schemes
+ * (javascript:, data:, ...) are all rejected.
+ */
+export function isSafeRelativePath(value: unknown): value is string {
+  if (typeof value !== 'string' || value.length === 0) return false;
+  if (!value.startsWith('/')) return false;
+  if (value.length > 1 && (value[1] === '/' || value[1] === '\\')) return false;
+  if (hasControlChar(value)) return false;
+  return true;
+}
+
+/**
+ * Returns `value` when it is a safe relative path, otherwise `fallback`.
+ * Server-side analogue of getSafeNext — use at write time so hostile or
+ * malformed link values collapse to a known-safe internal path.
+ */
+export function toSafeRelativePath(value: unknown, fallback: string): string {
+  return isSafeRelativePath(value) ? value : fallback;
+}
+
+/** Zod schema accepting only safe same-origin relative paths. */
+export const safeRelativePathSchema = z
+  .string()
+  .refine(isSafeRelativePath, {
+    message: 'must be a same-origin relative path starting with "/" (no //, no backslash, no control chars)',
+  });
+
+export type SafeRelativePath = z.infer<typeof safeRelativePathSchema>;


### PR DESCRIPTION
## Summary

Server-side **defense-in-depth** for the notification open-redirect class flagged in the apps/web security review. The client already routes notification navigation through `getSafeNext()` (web #1018); this adds the matching guard at the **write + storage** layers so a hostile `user_notifications.link` can never be persisted in the first place — even if a future writer or the client guard is weakened.

### Why (context)
The original review was run against a stale pre-#1018 base and flagged three client-side gaps that were **already fixed on `main` by #1018** (`navigation.ts` → `getSafeNext`, `ThirdPartyCatalog` → `getSafeExternalHref`, `ScheduledReports` → `getSafeHttpHref`; 80/80 web tests pass). The one residual risk is latent: `sendInAppNotificationToUsers` is exported, accepts a caller-supplied `link`, and writes `org_id: null` — a future caller populating `link` from user/integration/webhook data would create a stored open redirect firing on admins. This PR closes that gun.

## Changes
- **`packages/shared`** — new `safeRelativePath` validator (`isSafeRelativePath` / `toSafeRelativePath` / `safeRelativePathSchema`) mirroring `getSafeNext`'s exact accept/reject rules: single leading slash; reject `//`, `/\`, absolute URLs, custom schemes (`javascript:`/`data:`), and control chars. Implemented as a char-code scan so the source carries **no raw control bytes** and needs no `no-control-regex` eslint exception.
- **`apps/api`** — both `inAppSender` writers (`sendInAppNotification` + `sendInAppNotificationToUsers`) now run `payload.link` through `toSafeRelativePath(..., '/alerts/<id>')`, collapsing hostile values to the safe alert URL. Behavior-preserving for safe inputs.
- **migration** `2026-05-31-user-notifications-link-relative-check.sql` — idempotent `CHECK` constraint `user_notifications_link_relative_chk` enforcing the same rule, plus a heal `UPDATE` neutralizing any pre-existing non-conforming rows to `NULL` so `ADD CONSTRAINT` cannot fail.

## Testing
TDD with **observed RED**:
- shared validator RED proven by mutation (flipping the `startsWith('/')` guard → 4 fails), then GREEN **13/13**.
- inAppSender RED proven by stashing only the implementation (2 fails showing `https://evil.com` / `//evil.com` persisting) → GREEN **6/6**.
- `autoMigrate.test.ts` **43/43** (incl. the #506 ordering + filename-pattern regressions).
- Full shared suite **592/592**; `tsc --noEmit` 0 errors (api + shared); eslint clean on all changed files.

Migration applied against real **Postgres 16** (`breeze-postgres-test`): 4/4 safe values accepted, 6/6 hostile rejected (`23514`), re-apply is a no-op, test DB left clean. No RLS allowlist change needed (`user_notifications` is auto-discovered via `org_id`); constraint-only, so no Drizzle drift (matches existing `*-constraints.sql` precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)