### PR TITLE
fix(remote-desktop): policy-validation + teardown/viewer hardening (security-review follow-ups)

### DIFF
--- a/agent/internal/heartbeat/handlers_desktop.go
+++ b/agent/internal/heartbeat/handlers_desktop.go
@@ -19,6 +19,14 @@ const (
 	maxDesktopKeyBytes      = 64
 	maxDesktopModifierBytes = 16
 	maxDesktopModifiers     = 8
+
+	// Caps for caller-supplied session-lifetime limits in the direct-mode
+	// (map-payload) decoder. Same maxima as the IPC path (userhelper), but note
+	// the enforcement DIFFERS: this decoder has no error channel so it CLAMPS to
+	// these bounds, whereas the IPC path REJECTS out-of-range input with an
+	// error. Either way the agent can't be pushed past these. 0 = disabled.
+	maxIdleTimeoutMinutes   = 1440 // 24h
+	maxSessionDurationHours = 168  // 7d
 )
 
 var desktopInputTypes = map[string]struct{}{
@@ -224,11 +232,12 @@ func parseDesktopSessionPolicy(payload map[string]any) desktop.SessionPolicy {
 			policy.ClipboardViewerToHost = v
 		}
 	}
+	// Clamp direct-mode lifetime limits to the same maxima enforced by IPC validation.
 	if v, ok := payload["idleTimeoutMinutes"].(float64); ok && v > 0 {
-		policy.IdleTimeout = time.Duration(v) * time.Minute
+		policy.IdleTimeout = time.Duration(math.Min(v, maxIdleTimeoutMinutes)) * time.Minute
 	}
 	if v, ok := payload["maxSessionDurationHours"].(float64); ok && v > 0 {
-		policy.MaxDuration = time.Duration(v) * time.Hour
+		policy.MaxDuration = time.Duration(math.Min(v, maxSessionDurationHours)) * time.Hour
 	}
 	return policy
 }

--- a/agent/internal/heartbeat/handlers_desktop.go
+++ b/agent/internal/heartbeat/handlers_desktop.go
@@ -220,10 +220,10 @@ func handleStartDesktop(h *Heartbeat, cmd Command) tools.CommandResult {
 // older API that doesn't send them preserves existing behavior; timeouts of 0
 // mean disabled. Findings #2 and #7.
 func parseDesktopSessionPolicy(payload map[string]any) desktop.SessionPolicy {
-	policy := desktop.SessionPolicy{
-		ClipboardHostToViewer: true,
-		ClipboardViewerToHost: true,
-	}
+	// Start from the shared default so this map-payload decoder and the IPC
+	// decoder (desktop.ResolveSessionPolicyFromIPC) can't drift on what "default"
+	// means (permissive clipboard, no lifetime limits).
+	policy := desktop.DefaultSessionPolicy()
 	if cb, ok := payload["clipboard"].(map[string]any); ok {
 		if v, ok := cb["hostToViewer"].(bool); ok {
 			policy.ClipboardHostToViewer = v

--- a/agent/internal/heartbeat/handlers_desktop_policy_test.go
+++ b/agent/internal/heartbeat/handlers_desktop_policy_test.go
@@ -58,6 +58,28 @@ func TestParseDesktopSessionPolicy(t *testing.T) {
 			},
 		},
 		{
+			name: "idle timeout clamps to direct-mode cap",
+			payload: map[string]any{
+				"idleTimeoutMinutes": float64(100000),
+			},
+			want: desktop.SessionPolicy{
+				ClipboardHostToViewer: true,
+				ClipboardViewerToHost: true,
+				IdleTimeout:           1440 * time.Minute,
+			},
+		},
+		{
+			name: "max session duration clamps to direct-mode cap",
+			payload: map[string]any{
+				"maxSessionDurationHours": float64(100000),
+			},
+			want: desktop.SessionPolicy{
+				ClipboardHostToViewer: true,
+				ClipboardViewerToHost: true,
+				MaxDuration:           168 * time.Hour,
+			},
+		},
+		{
 			name: "zero/absent timeouts mean disabled",
 			payload: map[string]any{
 				"idleTimeoutMinutes":      float64(0),

--- a/agent/internal/remote/clipboard/gate_test.go
+++ b/agent/internal/remote/clipboard/gate_test.go
@@ -1,6 +1,9 @@
 package clipboard
 
 import (
+	"bytes"
+	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -103,6 +106,11 @@ func TestClipboardWatchGate_HostToViewerEnabled(t *testing.T) {
 // clipboard untouched.
 func TestClipboardReceiveGate_ViewerToHostDisabled(t *testing.T) {
 	prov := &gateProvider{}
+	var logs bytes.Buffer
+	originalLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	defer slog.SetDefault(originalLogger)
+
 	c := &ClipboardSync{
 		sender:       &gateSender{},
 		provider:     prov,
@@ -116,6 +124,9 @@ func TestClipboardReceiveGate_ViewerToHostDisabled(t *testing.T) {
 	}
 	if got := prov.setCount(); got != 0 {
 		t.Fatalf("viewer→host disabled: expected host clipboard untouched, got %d SetContent calls", got)
+	}
+	if got := logs.String(); !strings.Contains(got, "clipboard transfer blocked by policy") {
+		t.Fatalf("viewer→host disabled: expected blocked transfer audit log, got %q", got)
 	}
 }
 

--- a/agent/internal/remote/clipboard/sync.go
+++ b/agent/internal/remote/clipboard/sync.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -170,10 +171,13 @@ func (c *ClipboardSync) Send(content Content) error {
 
 	// Audit the egress transfer (finding #8). Host→viewer is the silent
 	// exfiltration direction, so make each transfer forensically visible
-	// (type + size). NOTE: this lands in the agent diagnostic log stream, not
-	// yet the tamper-evident central audit_logs table (follow-up).
-	log.Printf("[audit] clipboard transfer direction=host_to_viewer type=%s bytes=%d",
-		content.Type, len(content.Text)+len(content.RTF)+len(content.Image))
+	// (type + size). NOTE: this lands in the agent diagnostic log stream
+	// (slog → agent_logs), not yet the tamper-evident central audit_logs table.
+	// TODO(#1012): route clipboard/filedrop transfers to central audit_logs.
+	slog.Info("clipboard transfer",
+		"direction", "host_to_viewer",
+		"type", string(content.Type),
+		"bytes", len(content.Text)+len(content.RTF)+len(content.Image))
 
 	c.mu.Lock()
 	c.lastSentHash = fingerprint(content)
@@ -186,9 +190,16 @@ func (c *ClipboardSync) Receive(msg webrtc.DataChannelMessage) error {
 	if c.provider == nil {
 		return errClipboardSyncUnconfigured
 	}
-	// Viewer→host writes disabled by policy: drop inbound clipboard silently
-	// rather than overwriting the host clipboard. Finding #7.
+	// Viewer→host writes disabled by policy: drop inbound clipboard rather than
+	// overwriting the host clipboard. Finding #7. A denied paste is a
+	// security-relevant event, so audit it instead of dropping silently. Bytes
+	// is the raw inbound message size (payload not decoded on the blocked path).
+	// NOTE: diagnostic-log, not central audit_logs.
+	// TODO(#1012): route clipboard/filedrop transfers to central audit_logs.
 	if !c.policy.ViewerToHost {
+		slog.Info("clipboard transfer blocked by policy",
+			"direction", "viewer_to_host",
+			"bytes", len(msg.Data))
 		return nil
 	}
 	if len(msg.Data) > maxClipboardMessageBytes {
@@ -228,8 +239,11 @@ func (c *ClipboardSync) Receive(msg webrtc.DataChannelMessage) error {
 
 	// Audit the ingress transfer (finding #8): the viewer writing the host
 	// clipboard. Same diagnostic-log caveat as the egress path above.
-	log.Printf("[audit] clipboard transfer direction=viewer_to_host type=%s bytes=%d",
-		content.Type, len(content.Text)+len(content.RTF)+len(content.Image))
+	// TODO(#1012): route clipboard/filedrop transfers to central audit_logs.
+	slog.Info("clipboard transfer",
+		"direction", "viewer_to_host",
+		"type", string(content.Type),
+		"bytes", len(content.Text)+len(content.RTF)+len(content.Image))
 
 	fp := fingerprint(content)
 	c.mu.Lock()

--- a/agent/internal/remote/desktop/session_policy.go
+++ b/agent/internal/remote/desktop/session_policy.go
@@ -1,0 +1,77 @@
+package desktop
+
+import (
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
+)
+
+// DefaultSessionPolicy returns the baseline policy used by every decoder:
+// clipboard permissive in both directions, lifetime timers unset (callers layer
+// explicit limits on top). Centralizing this prevents the IPC decoder
+// (ResolveSessionPolicyFromIPC) and the map-payload decoder
+// (heartbeat.parseDesktopSessionPolicy) from disagreeing on what "default" means.
+//
+// Note: a zero-value SessionPolicy{} is fail-CLOSED for clipboard (both
+// directions disabled) and fail-OPEN for lifetime (both timers disabled), so
+// construct via this function rather than the zero value when permissive
+// clipboard defaults are intended.
+func DefaultSessionPolicy() SessionPolicy {
+	return SessionPolicy{
+		ClipboardHostToViewer: true,
+		ClipboardViewerToHost: true,
+	}
+}
+
+// clipboardEnabled reports whether the policy permits any clipboard transfer.
+func (p SessionPolicy) clipboardEnabled() bool {
+	return p.ClipboardHostToViewer || p.ClipboardViewerToHost
+}
+
+// shouldStopForLifetime is the pure per-tick decision for the lifetime watchdog.
+// It returns true (with a reason) when the session must be torn down because the
+// max-duration or idle-timeout threshold has been crossed. A zero threshold
+// means "no limit" for that axis; if both are zero the session is never stopped
+// on lifetime grounds. Max-duration takes precedence over idle.
+//
+// `lastInput` is the wall-clock time of the most recent viewer INPUT event
+// (mouse/keyboard) — see Session.lastInputUnixNano. Control-channel traffic does
+// NOT feed this, so an open-but-unattended viewer still idles out.
+func shouldStopForLifetime(now, startWall, lastInput time.Time, policy SessionPolicy) (bool, string) {
+	if policy.MaxDuration > 0 && now.Sub(startWall) >= policy.MaxDuration {
+		return true, "max_session_duration_exceeded"
+	}
+	if policy.IdleTimeout > 0 && now.Sub(lastInput) >= policy.IdleTimeout {
+		return true, "idle_timeout_exceeded"
+	}
+	return false, ""
+}
+
+// ResolveSessionPolicyFromIPC is the single authoritative decoder that turns an
+// ipc.DesktopStartRequest into a SessionPolicy. Callers (the user helper) must
+// NOT inline the nil→permissive logic — funnel through here so it can't drift
+// from the map-payload decoder (heartbeat.parseDesktopSessionPolicy). Both start
+// from DefaultSessionPolicy().
+//
+//   - nil *bool clipboard fields resolve to the permissive default (true); an
+//     explicit false disables that direction.
+//   - timeout ints <= 0 mean "no limit" for that axis. Bounds enforcement
+//     (negative/over-cap rejection) is the caller's job before calling this
+//     (see userhelper.validateDesktopStartRequest); this decoder assumes
+//     already-validated input and simply treats <=0 as unset.
+func ResolveSessionPolicyFromIPC(r ipc.DesktopStartRequest) SessionPolicy {
+	p := DefaultSessionPolicy()
+	if r.ClipboardHostToViewer != nil {
+		p.ClipboardHostToViewer = *r.ClipboardHostToViewer
+	}
+	if r.ClipboardViewerToHost != nil {
+		p.ClipboardViewerToHost = *r.ClipboardViewerToHost
+	}
+	if r.IdleTimeoutMinutes > 0 {
+		p.IdleTimeout = time.Duration(r.IdleTimeoutMinutes) * time.Minute
+	}
+	if r.MaxSessionDurationHours > 0 {
+		p.MaxDuration = time.Duration(r.MaxSessionDurationHours) * time.Hour
+	}
+	return p
+}

--- a/agent/internal/remote/desktop/session_policy_test.go
+++ b/agent/internal/remote/desktop/session_policy_test.go
@@ -1,0 +1,137 @@
+package desktop
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultSessionPolicy(t *testing.T) {
+	p := DefaultSessionPolicy()
+	if !p.ClipboardHostToViewer || !p.ClipboardViewerToHost {
+		t.Fatalf("DefaultSessionPolicy clipboard must be permissive in both directions, got %+v", p)
+	}
+	if p.IdleTimeout != 0 || p.MaxDuration != 0 {
+		t.Fatalf("DefaultSessionPolicy lifetime timers must be unset, got %+v", p)
+	}
+}
+
+func TestClipboardEnabled(t *testing.T) {
+	cases := []struct {
+		h, v bool
+		want bool
+	}{
+		{false, false, false},
+		{true, false, true},
+		{false, true, true},
+		{true, true, true},
+	}
+	for _, c := range cases {
+		p := SessionPolicy{ClipboardHostToViewer: c.h, ClipboardViewerToHost: c.v}
+		if got := p.clipboardEnabled(); got != c.want {
+			t.Fatalf("clipboardEnabled(h=%v,v=%v)=%v want %v", c.h, c.v, got, c.want)
+		}
+	}
+}
+
+func TestShouldStopForLifetime(t *testing.T) {
+	now := time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name       string
+		startWall  time.Time
+		lastInput  time.Time
+		policy     SessionPolicy
+		wantStop   bool
+		wantReason string
+	}{
+		{
+			name:      "both zero never stops",
+			startWall: now.Add(-100 * time.Hour),
+			lastInput: now.Add(-100 * time.Hour),
+			policy:    SessionPolicy{},
+			wantStop:  false,
+		},
+		{
+			name:       "max duration exceeded",
+			startWall:  now.Add(-2 * time.Hour),
+			lastInput:  now,
+			policy:     SessionPolicy{MaxDuration: time.Hour},
+			wantStop:   true,
+			wantReason: "max_session_duration_exceeded",
+		},
+		{
+			name:      "max duration not exceeded",
+			startWall: now.Add(-30 * time.Minute),
+			lastInput: now,
+			policy:    SessionPolicy{MaxDuration: time.Hour},
+			wantStop:  false,
+		},
+		{
+			name:       "max duration exact boundary stops",
+			startWall:  now.Add(-time.Hour),
+			lastInput:  now,
+			policy:     SessionPolicy{MaxDuration: time.Hour},
+			wantStop:   true,
+			wantReason: "max_session_duration_exceeded",
+		},
+		{
+			name:      "max duration one ns short does not stop",
+			startWall: now.Add(-time.Hour + time.Nanosecond),
+			lastInput: now,
+			policy:    SessionPolicy{MaxDuration: time.Hour},
+			wantStop:  false,
+		},
+		{
+			name:       "idle exceeded",
+			startWall:  now.Add(-time.Minute),
+			lastInput:  now.Add(-10 * time.Minute),
+			policy:     SessionPolicy{IdleTimeout: 5 * time.Minute},
+			wantStop:   true,
+			wantReason: "idle_timeout_exceeded",
+		},
+		{
+			name:      "idle not exceeded",
+			startWall: now.Add(-time.Minute),
+			lastInput: now.Add(-2 * time.Minute),
+			policy:    SessionPolicy{IdleTimeout: 5 * time.Minute},
+			wantStop:  false,
+		},
+		{
+			name:       "idle exact boundary stops",
+			startWall:  now.Add(-time.Minute),
+			lastInput:  now.Add(-5 * time.Minute),
+			policy:     SessionPolicy{IdleTimeout: 5 * time.Minute},
+			wantStop:   true,
+			wantReason: "idle_timeout_exceeded",
+		},
+		{
+			name:       "max duration takes precedence over idle",
+			startWall:  now.Add(-2 * time.Hour),
+			lastInput:  now.Add(-10 * time.Minute),
+			policy:     SessionPolicy{MaxDuration: time.Hour, IdleTimeout: 5 * time.Minute},
+			wantStop:   true,
+			wantReason: "max_session_duration_exceeded",
+		},
+		{
+			// Unit correctness: a 5-minute idle threshold must mean 5 minutes,
+			// not 5 seconds. After 6 seconds idle the session must NOT be stopped.
+			name:      "5 minute idle not triggered after 6 seconds",
+			startWall: now.Add(-time.Minute),
+			lastInput: now.Add(-6 * time.Second),
+			policy:    SessionPolicy{IdleTimeout: 5 * time.Minute},
+			wantStop:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stop, reason := shouldStopForLifetime(now, tt.startWall, tt.lastInput, tt.policy)
+			if stop != tt.wantStop {
+				t.Fatalf("stop=%v want %v (reason=%q)", stop, tt.wantStop, reason)
+			}
+			if stop && reason != tt.wantReason {
+				t.Fatalf("reason=%q want %q", reason, tt.wantReason)
+			}
+		})
+	}
+}

--- a/agent/internal/remote/desktop/session_webrtc.go
+++ b/agent/internal/remote/desktop/session_webrtc.go
@@ -143,27 +143,27 @@ func (m *SessionManager) StartSession(sessionID string, offer string, iceServers
 					return
 				case <-ticker.C:
 					now := time.Now()
-					if policy.MaxDuration > 0 && now.Sub(startWall) >= policy.MaxDuration {
+					// Idle is driven by lastInputUnixNano (viewer INPUT only) — see
+					// shouldStopForLifetime. Control-channel traffic (e.g. the
+					// viewer_stats heartbeat) does not reset it, so an open-but-
+					// unattended viewer still idles out.
+					lastInput := time.Unix(0, session.lastInputUnixNano.Load())
+					stop, reason := shouldStopForLifetime(now, startWall, lastInput, policy)
+					if !stop {
+						continue
+					}
+					if reason == "idle_timeout_exceeded" {
+						slog.Warn("Desktop session idle timeout, stopping",
+							"session", sessionID, "idleFor", now.Sub(lastInput).Round(time.Second))
+					} else {
 						slog.Warn("Desktop session reached max duration, stopping",
 							"session", sessionID, "maxDuration", policy.MaxDuration)
-						m.StopSession(sessionID)
-						if m.OnSessionStopped != nil {
-							go m.OnSessionStopped(sessionID)
-						}
-						return
 					}
-					if policy.IdleTimeout > 0 {
-						idleFor := now.Sub(time.Unix(0, session.lastInputUnixNano.Load()))
-						if idleFor >= policy.IdleTimeout {
-							slog.Warn("Desktop session idle timeout, stopping",
-								"session", sessionID, "idleFor", idleFor.Round(time.Second))
-							m.StopSession(sessionID)
-							if m.OnSessionStopped != nil {
-								go m.OnSessionStopped(sessionID)
-							}
-							return
-						}
+					m.StopSession(sessionID)
+					if m.OnSessionStopped != nil {
+						go m.OnSessionStopped(sessionID)
 					}
+					return
 				}
 			}
 		}()
@@ -394,7 +394,7 @@ func (m *SessionManager) StartSession(sessionID string, offer string, iceServers
 	// never run the watcher (no passive exfiltration of whatever the end user
 	// copies); with viewer→host off inbound writes are dropped. Skip the channel
 	// entirely when both directions are disabled.
-	if policy.ClipboardHostToViewer || policy.ClipboardViewerToHost {
+	if policy.clipboardEnabled() {
 		clipboardDC, cbErr := peerConn.CreateDataChannel("clipboard", nil)
 		if cbErr != nil {
 			slog.Warn("Failed to create clipboard DataChannel", "session", sessionID, "error", cbErr.Error())

--- a/agent/internal/remote/filedrop/handler.go
+++ b/agent/internal/remote/filedrop/handler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -274,10 +275,12 @@ func (h *FileDropHandler) handleStart(message Message) error {
 		file: file,
 	}
 
-	// Audit the start of an inbound file drop (finding #8): the viewer is
-	// pushing a file onto the host. name + declared size + transfer id.
-	log.Printf("[audit] filedrop start name=%q bytes=%d transferId=%s",
-		safeName, message.Size, message.TransferID)
+	// NOTE: diagnostic-log (slog → agent_logs), not central audit_logs.
+	// TODO(#1012): route clipboard/filedrop transfers to central audit_logs.
+	slog.Info("filedrop start",
+		"name", safeName,
+		"bytes", message.Size,
+		"transferId", message.TransferID)
 
 	return nil
 }
@@ -351,10 +354,12 @@ func (h *FileDropHandler) handleComplete(message Message) error {
 		Size:       transfer.size,
 	}
 
-	// Audit completion of an inbound file drop (finding #8): file fully written
-	// to the host. name + size + transfer id.
-	log.Printf("[audit] filedrop complete name=%q bytes=%d transferId=%s",
-		transfer.name, transfer.size, message.TransferID)
+	// NOTE: diagnostic-log (slog → agent_logs), not central audit_logs.
+	// TODO(#1012): route clipboard/filedrop transfers to central audit_logs.
+	slog.Info("filedrop complete",
+		"name", transfer.name,
+		"bytes", transfer.size,
+		"transferId", message.TransferID)
 
 	select {
 	case h.completed <- result:

--- a/agent/internal/userhelper/desktop.go
+++ b/agent/internal/userhelper/desktop.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"image"
 	"regexp"
-	"time"
 
 	"github.com/breeze-rmm/agent/internal/ipc"
 	"github.com/breeze-rmm/agent/internal/remote/desktop"
@@ -50,18 +49,11 @@ func (h *helperDesktopManager) startSession(req *ipc.DesktopStartRequest) (*ipc.
 		h.mgr.SetGPUVendor(req.GPUVendor)
 	}
 
-	// Build the agent-enforced policy from the IPC request. Absent clipboard
-	// fields (older service) default to permissive to preserve behavior.
-	policy := desktop.SessionPolicy{
-		ClipboardHostToViewer: req.ClipboardHostToViewer == nil || *req.ClipboardHostToViewer,
-		ClipboardViewerToHost: req.ClipboardViewerToHost == nil || *req.ClipboardViewerToHost,
-	}
-	if req.IdleTimeoutMinutes > 0 {
-		policy.IdleTimeout = time.Duration(req.IdleTimeoutMinutes) * time.Minute
-	}
-	if req.MaxSessionDurationHours > 0 {
-		policy.MaxDuration = time.Duration(req.MaxSessionDurationHours) * time.Hour
-	}
+	// Build the agent-enforced policy via the single centralized decoder so the
+	// nil→permissive clipboard logic and the <=0→unset timeout logic live in
+	// exactly one place (shared with the map-payload decoder). Bounds were
+	// already enforced upstream by validateDesktopStartRequest (client.go).
+	policy := desktop.ResolveSessionPolicyFromIPC(*req)
 
 	answer, err := h.mgr.StartSession(req.SessionID, req.Offer, iceServers, req.DisplayIndex, policy)
 	if err != nil {

--- a/apps/api/src/routes/admin/abuse.test.ts
+++ b/apps/api/src/routes/admin/abuse.test.ts
@@ -201,7 +201,8 @@ vi.mock('../../middleware/auth', () => ({
 // suite doesn't load the whole remote-desktop / agentWs / policy chain — which
 // would otherwise drag many transitive modules into this route's mocks.
 vi.mock('../../services/remoteSessionTeardown', () => ({
-  terminateUserRemoteSessions: vi.fn(async () => undefined),
+  TEARDOWN_FAILED: -1,
+  terminateUserRemoteSessions: vi.fn(async () => 0),
 }));
 
 import { Hono } from 'hono';
@@ -209,6 +210,7 @@ import { adminRoutes } from './index';
 import { createAuditLog } from '../../services/auditService';
 import { revokeAllUserTokens } from '../../services/tokenRevocation';
 import { revokeAllPartnerOauthArtifacts } from '../../oauth/grantRevocation';
+import { terminateUserRemoteSessions } from '../../services/remoteSessionTeardown';
 
 type FakeAuth = {
   user: { id: string; email: string; name: string; isPlatformAdmin: boolean };
@@ -265,6 +267,7 @@ describe('admin/abuse — auth gate', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetState();
+    vi.mocked(terminateUserRemoteSessions).mockReset().mockResolvedValue(0);
     process.env.NODE_ENV = 'test';
   });
 
@@ -413,6 +416,7 @@ describe('admin/abuse — suspend mutation behavior', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetState();
+    vi.mocked(terminateUserRemoteSessions).mockReset().mockResolvedValue(0);
     process.env.NODE_ENV = 'test';
   });
 
@@ -474,6 +478,25 @@ describe('admin/abuse — suspend mutation behavior', () => {
       deviceCount: 3,
       userCount: 2,
       apiKeyCount: 3,
+    });
+  });
+
+  it('counts TEARDOWN_FAILED remote-session results in the audit details', async () => {
+    vi.mocked(terminateUserRemoteSessions).mockImplementation(async (userId: string) =>
+      userId === 'u-1' ? -1 : 0
+    );
+
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ confirmEmail: 'admin@breeze.test', reason: 'remote session teardown failure audit' }),
+    });
+
+    expect(res.status).toBe(200);
+    const auditCall = vi.mocked(createAuditLog).mock.calls[0]![0]!;
+    expect(auditCall.details).toMatchObject({
+      remoteSessionTeardownFailures: 1,
     });
   });
 

--- a/apps/api/src/routes/admin/abuse.ts
+++ b/apps/api/src/routes/admin/abuse.ts
@@ -15,7 +15,7 @@ import {
 import { createAuditLog } from '../../services/auditService';
 import { revokeAllUserTokens } from '../../services/tokenRevocation';
 import { revokeAllPartnerOauthArtifacts } from '../../oauth/grantRevocation';
-import { terminateUserRemoteSessions } from '../../services/remoteSessionTeardown';
+import { terminateUserRemoteSessions, TEARDOWN_FAILED } from '../../services/remoteSessionTeardown';
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
 import { captureException } from '../../services/sentry';
 import { requireMfa } from '../../middleware/auth';
@@ -214,11 +214,20 @@ abuseRoutes.post(
 
     // Terminate any live remote-desktop sessions held by the suspended users so
     // a rogue operator can't keep screen / input / clipboard control after the
-    // partner is suspended for abuse. Best-effort (never throws); the
-    // OAuth/JWT/API-key revocation above already cut new access. Finding #3.
-    await Promise.allSettled(
+    // partner is suspended for abuse. Finding #3.
+    //
+    // A per-user TEARDOWN_FAILED (already reported to Sentry inside the service)
+    // does NOT abort the suspend, but we count it so the audit trail records
+    // that some operators may have retained live control.
+    let remoteSessionTeardownFailures = 0;
+    const teardownResults = await Promise.allSettled(
       result.affectedUserIds.map((id) => terminateUserRemoteSessions(id))
     );
+    for (const settled of teardownResults) {
+      if (settled.status === 'rejected' || settled.value === TEARDOWN_FAILED) {
+        remoteSessionTeardownFailures += 1;
+      }
+    }
 
     const auditResult: 'success' | 'failure' =
       tokenRevocationFailures.length === 0 && oauthRevocationError === null
@@ -239,6 +248,7 @@ abuseRoutes.post(
           deviceCount: result.deviceCount,
           userCount: result.userCount,
           apiKeyCount: result.apiKeyCount,
+          remoteSessionTeardownFailures,
           requestedBy: callerId,
           oauthGrantsRevoked: oauthRevocationResult?.grantsRevoked ?? 0,
           oauthRefreshTokensRevoked: oauthRevocationResult?.refreshTokensRevoked ?? 0,
@@ -292,6 +302,7 @@ abuseRoutes.post(
           deviceCount: result.deviceCount,
           userCount: result.userCount,
           apiKeyCount: result.apiKeyCount,
+          remoteSessionTeardownFailures,
           queuedUninstalls: result.deviceCount,
         },
         500,
@@ -304,6 +315,7 @@ abuseRoutes.post(
       deviceCount: result.deviceCount,
       userCount: result.userCount,
       apiKeyCount: result.apiKeyCount,
+      remoteSessionTeardownFailures,
       queuedUninstalls: result.deviceCount,
       oauthGrantsRevoked: oauthRevocationResult?.grantsRevoked ?? 0,
       oauthRefreshTokensRevoked: oauthRevocationResult?.refreshTokensRevoked ?? 0,
@@ -393,4 +405,3 @@ abuseRoutes.post(
     });
   }
 );
-

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -714,6 +714,8 @@ coreRoutes.get(
         webrtcDesktop: remoteAccess.settings.webrtcDesktop,
         vncRelay: remoteAccess.settings.vncRelay,
         remoteTools: remoteAccess.settings.remoteTools,
+        clipboardHostToViewer: remoteAccess.settings.clipboardHostToViewer,
+        clipboardViewerToHost: remoteAccess.settings.clipboardViewerToHost,
         enableProxy: remoteAccess.settings.enableProxy,
         policyName: remoteAccess.policyName,
         policyId: remoteAccess.policyId,

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -10,6 +10,7 @@ const {
   requireCurrentPasswordStepUpMock,
   isPasswordAuthDisabledBySsoMock,
   hasSatisfiedMfaMock,
+  terminateUserRemoteSessionsMock,
   captureExceptionMock,
   getEmailServiceMock
 } = vi.hoisted(() => ({
@@ -25,7 +26,8 @@ const {
   // Default: org does NOT enforce SSO.
   isPasswordAuthDisabledBySsoMock: vi.fn().mockResolvedValue(false),
   // Default: MFA is considered satisfied. Tests override to false.
-  hasSatisfiedMfaMock: vi.fn().mockReturnValue(true)
+  hasSatisfiedMfaMock: vi.fn().mockReturnValue(true),
+  terminateUserRemoteSessionsMock: vi.fn().mockResolvedValue(0)
 }));
 
 vi.mock('../services/permissions', () => ({
@@ -171,10 +173,16 @@ vi.mock('../services/userSuspension', () => ({
   })
 }));
 
+vi.mock('../services/remoteSessionTeardown', () => ({
+  TEARDOWN_FAILED: -1,
+  terminateUserRemoteSessions: terminateUserRemoteSessionsMock
+}));
+
 import { db } from '../db';
 import { clearPermissionCache, getUserPermissions } from '../services/permissions';
 import { authMiddleware } from '../middleware/auth';
 import { revokeAllUserTokens } from '../services/tokenRevocation';
+import { terminateUserRemoteSessions } from '../services/remoteSessionTeardown';
 
 describe('user routes', () => {
   let app: Hono;
@@ -205,6 +213,7 @@ describe('user routes', () => {
     requireCurrentPasswordStepUpMock.mockResolvedValue(null);
     isPasswordAuthDisabledBySsoMock.mockResolvedValue(false);
     hasSatisfiedMfaMock.mockReturnValue(true);
+    terminateUserRemoteSessionsMock.mockReset().mockResolvedValue(0);
     sendEmailChangedMock.mockResolvedValue(undefined);
     // Default: email service is configured. Tests override to null to exercise
     // the "not configured" warning path.
@@ -1053,6 +1062,54 @@ describe('user routes', () => {
   });
 
   describe('PATCH /users/:id (admin update)', () => {
+    it('returns 503 when remote-session teardown fails during suspension', async () => {
+      const scopedUser = {
+        id: '11111111-1111-1111-1111-111111111111',
+        email: 'operator@example.com',
+        name: 'Operator',
+        status: 'active',
+        roleId: 'role-1',
+        roleName: 'Admin',
+        orgAccess: 'all',
+        orgIds: [],
+      };
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn(() => ({
+          innerJoin: vi.fn(() => ({
+            innerJoin: vi.fn(() => ({
+              where: vi.fn(() => ({
+                limit: vi.fn().mockResolvedValue([scopedUser])
+              }))
+            }))
+          }))
+        }))
+      } as any);
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn(() => ({
+          where: vi.fn(() => ({
+            returning: vi.fn().mockResolvedValue([{
+              id: '11111111-1111-1111-1111-111111111111',
+              email: 'operator@example.com',
+              name: 'Operator',
+              status: 'disabled',
+            }])
+          }))
+        }))
+      } as any);
+      vi.mocked(terminateUserRemoteSessions).mockResolvedValueOnce(-1);
+
+      const res = await app.request('/users/11111111-1111-1111-1111-111111111111', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ status: 'disabled' })
+      });
+
+      expect(res.status).toBe(503);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to terminate active remote sessions; suspension is partial. Retry.');
+      expect(terminateUserRemoteSessions).toHaveBeenCalledWith('11111111-1111-1111-1111-111111111111');
+    });
+
     it('rejects unknown top-level fields including roleId (strict schema)', async () => {
       // The Edit dialog historically sent { email, name, roleId } and roleId was
       // silently dropped because updateUserSchema lacked .strict(). After the

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -24,7 +24,7 @@ import { INVITE_TOKEN_TTL_SECONDS } from './auth/schemas';
 import { hashInviteToken, inviteRedisKey, inviteUserRedisKey, requireCurrentPasswordStepUp, resolveUserAuditOrgId, userRequiresSetup } from './auth/helpers';
 import { isPasswordAuthDisabledBySso } from './auth/ssoPolicy';
 import { revokeUserAccess } from '../services/userSuspension';
-import { terminateUserRemoteSessions } from '../services/remoteSessionTeardown';
+import { terminateUserRemoteSessions, TEARDOWN_FAILED } from '../services/remoteSessionTeardown';
 import { revokeAllUserTokens } from '../services/tokenRevocation';
 
 export const userRoutes = new Hono();
@@ -1061,8 +1061,14 @@ userRoutes.patch(
       // Kill any live remote-desktop sessions immediately so a suspended /
       // deactivated operator loses screen, input and clipboard control right
       // away — revoking JWT/OAuth alone does not touch viewer tokens or the
-      // peer-to-peer WebRTC stream. Best-effort (never throws). Finding #3.
-      await terminateUserRemoteSessions(updated.id);
+      // peer-to-peer WebRTC stream. Finding #3.
+      const teardownResult = await terminateUserRemoteSessions(updated.id);
+      if (teardownResult === TEARDOWN_FAILED) {
+        return c.json(
+          { error: 'Failed to terminate active remote sessions; suspension is partial. Retry.' },
+          503
+        );
+      }
       try {
         oauthRevocation = await revokeUserAccess(updated.id);
       } catch (err) {

--- a/apps/api/src/services/remoteAccessPolicy.test.ts
+++ b/apps/api/src/services/remoteAccessPolicy.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { resolveEffectiveConfigMock } = vi.hoisted(() => ({
+  resolveEffectiveConfigMock: vi.fn(),
+}));
+
+vi.mock('./configurationPolicy', () => ({
+  resolveEffectiveConfig: resolveEffectiveConfigMock,
+}));
+
+import {
+  invalidateRemoteAccessCache,
+  resolveDesktopSessionPolicy,
+  resolveRemoteAccessForDevice,
+} from './remoteAccessPolicy';
+
+function makeEffectiveRemoteAccessConfig(deviceId: string, inlineSettings: unknown): any {
+  return {
+    deviceId,
+    features: {
+      remote_access: {
+        featureType: 'remote_access',
+        featurePolicyId: null,
+        inlineSettings,
+        sourceLevel: 'device',
+        sourceTargetId: deviceId,
+        sourcePolicyId: 'policy-1',
+        sourcePolicyName: 'Remote Access Policy',
+        sourcePriority: 100,
+      },
+    },
+    inheritanceChain: [],
+  };
+}
+
+describe('remoteAccessPolicy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invalidateRemoteAccessCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    invalidateRemoteAccessCache();
+  });
+
+  it('parses valid inlineSettings and merges them over defaults', async () => {
+    const deviceId = 'device-valid-inline';
+    resolveEffectiveConfigMock.mockResolvedValue(
+      makeEffectiveRemoteAccessConfig(deviceId, {
+        clipboardHostToViewer: false,
+        defaultAllowedPorts: [22, 3389],
+        maxConcurrentTunnels: 9,
+        idleTimeoutMinutes: 1440,
+        maxSessionDurationHours: 168,
+      })
+    );
+
+    const resolved = await resolveRemoteAccessForDevice(deviceId);
+
+    expect(resolved.policyName).toBe('Remote Access Policy');
+    expect(resolved.policyId).toBe('policy-1');
+    expect(resolved.settings).toMatchObject({
+      webrtcDesktop: true,
+      vncRelay: true,
+      remoteTools: true,
+      clipboardHostToViewer: false,
+      clipboardViewerToHost: true,
+      enableProxy: true,
+      defaultAllowedPorts: [22, 3389],
+      autoEnableProxy: false,
+      maxConcurrentTunnels: 9,
+      idleTimeoutMinutes: 1440,
+      maxSessionDurationHours: 168,
+    });
+  });
+
+  it('falls back to defaults for invalid inlineSettings without throwing or passing bad values through', async () => {
+    const deviceId = 'device-invalid-inline';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    resolveEffectiveConfigMock.mockResolvedValue(
+      makeEffectiveRemoteAccessConfig(deviceId, {
+        clipboardHostToViewer: 'yes',
+        idleTimeoutMinutes: 'banana',
+      })
+    );
+
+    const resolved = await resolveRemoteAccessForDevice(deviceId);
+
+    expect(resolved.settings.idleTimeoutMinutes).toBe(5);
+    expect(resolved.settings.maxSessionDurationHours).toBe(8);
+    expect(typeof resolved.settings.clipboardHostToViewer).toBe('boolean');
+    expect(resolved.settings.clipboardHostToViewer).not.toBe('yes');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid remote_access inlineSettings'),
+      expect.stringContaining('clipboardHostToViewer')
+    );
+  });
+
+  it('clamps desktop session lifetime fields even if over-cap values bypass validation', async () => {
+    const deviceId = 'device-clamp-cached-settings';
+    resolveEffectiveConfigMock.mockResolvedValue(
+      makeEffectiveRemoteAccessConfig(deviceId, {
+        idleTimeoutMinutes: 30,
+        maxSessionDurationHours: 12,
+      })
+    );
+    const resolved = await resolveRemoteAccessForDevice(deviceId);
+
+    resolved.settings.idleTimeoutMinutes = 999999;
+    resolved.settings.maxSessionDurationHours = 999999;
+
+    const policy = await resolveDesktopSessionPolicy(deviceId);
+
+    expect(policy.idleTimeoutMinutes).toBe(1440);
+    expect(policy.maxSessionDurationHours).toBe(168);
+  });
+
+  it('returns failsafe desktop session policy when policy resolution throws', async () => {
+    const deviceId = 'device-failsafe-policy';
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    resolveEffectiveConfigMock.mockRejectedValue(new Error('config engine unavailable'));
+
+    const policy = await resolveDesktopSessionPolicy(deviceId);
+
+    expect(policy).toEqual({
+      clipboard: { hostToViewer: false, viewerToHost: false },
+      idleTimeoutMinutes: 5,
+      maxSessionDurationHours: 8,
+    });
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to resolve desktop session policy'),
+      'config engine unavailable'
+    );
+  });
+});

--- a/apps/api/src/services/remoteAccessPolicy.ts
+++ b/apps/api/src/services/remoteAccessPolicy.ts
@@ -10,6 +10,7 @@
 
 import { resolveEffectiveConfig } from './configurationPolicy';
 import type { AuthContext } from '../middleware/auth';
+import { remoteAccessInlineSettingsSchema } from '@breeze/shared/validators';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -87,6 +88,23 @@ interface CacheEntry {
   expiresAt: number;
 }
 
+// Defensive clamps for the agent-enforced session-lifetime fields. Even after
+// Zod validation these are clamped again here so a future schema relaxation (or
+// a DEFAULTS edit) can never push the agent into never-idle-out / never-expire
+// territory. 0 is a legitimate "disabled" sentinel for both.
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(Math.max(Math.trunc(value), min), max);
+}
+
+function clampSettings(settings: RemoteAccessSettings): RemoteAccessSettings {
+  return {
+    ...settings,
+    idleTimeoutMinutes: clamp(settings.idleTimeoutMinutes, 0, 1440),
+    maxSessionDurationHours: clamp(settings.maxSessionDurationHours, 0, 168),
+  };
+}
+
 const cache = new Map<string, CacheEntry>();
 const CACHE_TTL_MS = 30_000;
 
@@ -148,8 +166,21 @@ export async function resolveRemoteAccessForDevice(deviceId: string): Promise<Re
 
   if (effective?.features?.remote_access) {
     const feature = effective.features.remote_access;
-    const inline = (feature.inlineSettings ?? {}) as Partial<RemoteAccessSettings>;
-    settings = { ...DEFAULTS, ...inline };
+    // The inlineSettings blob is untyped JSONB — validate it through Zod before
+    // it can flow to the agent. A bad value (non-boolean clipboard flag, a
+    // zero/negative/huge maxSessionDurationHours) would otherwise be trusted
+    // verbatim. On parse failure fall back to DEFAULTS rather than shipping
+    // garbage. Numeric lifetime fields are additionally clamped below.
+    const parsed = remoteAccessInlineSettingsSchema.safeParse(feature.inlineSettings ?? {});
+    if (parsed.success) {
+      settings = clampSettings({ ...DEFAULTS, ...parsed.data });
+    } else {
+      console.warn(
+        `[RemoteAccessPolicy] Invalid remote_access inlineSettings for device ${deviceId}; falling back to defaults:`,
+        parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ')
+      );
+      settings = { ...DEFAULTS };
+    }
     policyName = feature.sourcePolicyName ?? null;
     policyId = feature.sourcePolicyId ?? null;
   }
@@ -221,14 +252,42 @@ export interface DesktopSessionPolicy {
   maxSessionDurationHours: number;
 }
 
+// Safe-but-restrictive policy shipped to the agent when policy resolution
+// fails. Clipboard is OFF in both directions (no silent exfil, no paste) and
+// the session gets a short idle timeout + the default max duration so a
+// resolution outage can't leave a long-lived, fully-permissive session. The
+// capability gate itself is already enforced fail-closed by `checkRemoteAccess`
+// (which the offer handlers call first), so this only governs the in-session
+// clipboard/lifetime knobs.
+const FAILSAFE_DESKTOP_POLICY: DesktopSessionPolicy = {
+  clipboard: { hostToViewer: false, viewerToHost: false },
+  idleTimeoutMinutes: 5,
+  maxSessionDurationHours: 8,
+};
+
 export async function resolveDesktopSessionPolicy(deviceId: string): Promise<DesktopSessionPolicy> {
-  const { settings } = await resolveRemoteAccessForDevice(deviceId);
+  // Fail-closed: `resolveRemoteAccessForDevice` can throw (e.g. config-engine
+  // DB error). The offer handlers `await` this without their own guard, so an
+  // unhandled throw here would 500 the request. Degrade to a restrictive policy
+  // instead and let the request proceed (the capability check already gated it).
+  let settings: RemoteAccessSettings;
+  try {
+    ({ settings } = await resolveRemoteAccessForDevice(deviceId));
+  } catch (err) {
+    console.error(
+      `[RemoteAccessPolicy] Failed to resolve desktop session policy for device ${deviceId}; using failsafe restrictive policy:`,
+      err instanceof Error ? err.message : err
+    );
+    return FAILSAFE_DESKTOP_POLICY;
+  }
+
+  const clamped = clampSettings(settings);
   return {
     clipboard: {
-      hostToViewer: settings.clipboardHostToViewer,
-      viewerToHost: settings.clipboardViewerToHost,
+      hostToViewer: clamped.clipboardHostToViewer,
+      viewerToHost: clamped.clipboardViewerToHost,
     },
-    idleTimeoutMinutes: settings.idleTimeoutMinutes,
-    maxSessionDurationHours: settings.maxSessionDurationHours,
+    idleTimeoutMinutes: clamped.idleTimeoutMinutes,
+    maxSessionDurationHours: clamped.maxSessionDurationHours,
   };
 }

--- a/apps/api/src/services/remoteSessionTeardown.test.ts
+++ b/apps/api/src/services/remoteSessionTeardown.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const state = {
+    activeRows: [] as Array<{ id: string; type: string; agentId: string | null }>,
+    enumerateError: null as Error | null,
+    updateError: null as Error | null,
+  };
+
+  return {
+    state,
+    revokeViewerSessionMock: vi.fn(async () => undefined),
+    sendCommandToAgentMock: vi.fn(),
+    captureExceptionMock: vi.fn(),
+    dbMock: {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          innerJoin: vi.fn(() => ({
+            where: vi.fn(() => {
+              if (state.enumerateError) {
+                throw state.enumerateError;
+              }
+              return Promise.resolve(state.activeRows);
+            }),
+          })),
+        })),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(() => {
+            if (state.updateError) {
+              throw state.updateError;
+            }
+            return Promise.resolve(undefined);
+          }),
+        })),
+      })),
+    },
+  };
+});
+
+vi.mock('../db', () => ({
+  db: mocks.dbMock,
+  runOutsideDbContext: vi.fn((fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn((fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  remoteSessions: {
+    id: 'remote_sessions.id',
+    type: 'remote_sessions.type',
+    deviceId: 'remote_sessions.device_id',
+    userId: 'remote_sessions.user_id',
+    status: 'remote_sessions.status',
+  },
+  devices: {
+    id: 'devices.id',
+    agentId: 'devices.agent_id',
+  },
+}));
+
+vi.mock('../routes/agentWs', () => ({
+  sendCommandToAgent: mocks.sendCommandToAgentMock,
+}));
+
+vi.mock('./viewerTokenRevocation', () => ({
+  revokeViewerSession: mocks.revokeViewerSessionMock,
+}));
+
+vi.mock('./sentry', () => ({
+  captureException: mocks.captureExceptionMock,
+}));
+
+import { sendCommandToAgent } from '../routes/agentWs';
+import { revokeViewerSession } from './viewerTokenRevocation';
+import { captureException } from './sentry';
+import { TEARDOWN_FAILED, terminateUserRemoteSessions } from './remoteSessionTeardown';
+
+describe('terminateUserRemoteSessions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.state.activeRows = [];
+    mocks.state.enumerateError = null;
+    mocks.state.updateError = null;
+  });
+
+  it('returns the active-session count, revokes each viewer session, and stops desktop sessions with agents', async () => {
+    mocks.state.activeRows = [
+      { id: 'session-1', type: 'desktop', agentId: 'agent-1' },
+      { id: 'session-2', type: 'terminal', agentId: 'agent-2' },
+      { id: 'session-3', type: 'desktop', agentId: null },
+    ];
+
+    const result = await terminateUserRemoteSessions('user-1');
+
+    expect(result).toBe(3);
+    expect(revokeViewerSession).toHaveBeenCalledTimes(3);
+    expect(revokeViewerSession).toHaveBeenCalledWith('session-1');
+    expect(revokeViewerSession).toHaveBeenCalledWith('session-2');
+    expect(revokeViewerSession).toHaveBeenCalledWith('session-3');
+    expect(sendCommandToAgent).toHaveBeenCalledTimes(1);
+    expect(sendCommandToAgent).toHaveBeenCalledWith('agent-1', {
+      id: 'desk-stop-session-1',
+      type: 'stop_desktop',
+      payload: { sessionId: 'session-1' },
+    });
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('returns TEARDOWN_FAILED, reports to Sentry, and skips per-row teardown when enumerate/disconnect throws', async () => {
+    const error = new Error('database unavailable');
+    mocks.state.enumerateError = error;
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const result = await terminateUserRemoteSessions('user-1');
+
+      expect(result).toBe(TEARDOWN_FAILED);
+      expect(result).toBe(-1);
+      expect(captureException).toHaveBeenCalledTimes(1);
+      expect(captureException).toHaveBeenCalledWith(error);
+      expect(revokeViewerSession).not.toHaveBeenCalled();
+      expect(sendCommandToAgent).not.toHaveBeenCalled();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it('returns 0 when there are no active sessions', async () => {
+    mocks.state.activeRows = [];
+
+    const result = await terminateUserRemoteSessions('user-1');
+
+    expect(result).toBe(0);
+    expect(revokeViewerSession).not.toHaveBeenCalled();
+    expect(sendCommandToAgent).not.toHaveBeenCalled();
+    expect(captureException).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/remoteSessionTeardown.ts
+++ b/apps/api/src/services/remoteSessionTeardown.ts
@@ -3,8 +3,17 @@ import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { remoteSessions, devices } from '../db/schema';
 import { revokeViewerSession } from './viewerTokenRevocation';
 import { sendCommandToAgent } from '../routes/agentWs';
+import { captureException } from './sentry';
 
 const ACTIVE_REMOTE_SESSION_STATUSES = ['pending', 'connecting', 'active'] as const;
+
+/**
+ * Sentinel returned by {@link terminateUserRemoteSessions} when teardown
+ * FAILED (enumeration / bulk-disconnect threw). Distinct from `0`, which
+ * means "nothing to do". Callers MUST surface this — a silent `0` on failure
+ * would let a suspended operator keep live remote control with no alert.
+ */
+export const TEARDOWN_FAILED = -1;
 
 /**
  * Force-terminate every live remote session owned by a user. Called from
@@ -29,10 +38,11 @@ const ACTIVE_REMOTE_SESSION_STATUSES = ['pending', 'connecting', 'active'] as co
  * `withSystemDbAccessContext` establishes system scope on a separate
  * connection (same pattern as `logSessionAudit`).
  *
- * Best-effort by design: never throws to its caller — the suspend/deactivate
- * has already cut new access via JWT/OAuth/API-key revocation, and the agent's
- * max-session-duration timer is the ultimate backstop. Returns the number of
- * sessions it tore down.
+ * Per-row viewer-token revocation and stop_desktop commands are best-effort:
+ * individual failures are logged and do not throw to the caller. A hard
+ * enumerate / bulk-disconnect failure returns TEARDOWN_FAILED (and is reported
+ * to Sentry); callers MUST surface that sentinel because teardown did not run.
+ * On success, returns the number of sessions it tore down.
  */
 export async function terminateUserRemoteSessions(userId: string): Promise<number> {
   let active: Array<{ id: string; type: string; agentId: string | null }> = [];
@@ -69,8 +79,13 @@ export async function terminateUserRemoteSessions(userId: string): Promise<numbe
       })
     );
   } catch (err) {
+    // Hard failure: the suspend-time teardown did not run. Alert via Sentry so
+    // it is not silently swallowed, and signal the caller (sentinel) so it can
+    // surface a degraded/partial result instead of reporting a clean success
+    // while the operator may retain live screen/input/clipboard control.
     console.error(`[remoteSessionTeardown] Failed to enumerate/disconnect sessions for user ${userId}:`, err);
-    return 0;
+    captureException(err instanceof Error ? err : new Error(String(err)));
+    return TEARDOWN_FAILED;
   }
 
   await Promise.all(

--- a/apps/viewer/src/lib/sessionEnded.test.ts
+++ b/apps/viewer/src/lib/sessionEnded.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { isSessionEndedResponse, SessionEndedError } from './webrtc';
+
+describe('isSessionEndedResponse', () => {
+  it('returns false for non-401 statuses', () => {
+    expect(isSessionEndedResponse(200, 'Session ended')).toBe(false);
+    expect(isSessionEndedResponse(200, null)).toBe(false);
+  });
+
+  it('treats bare 401 responses as terminal', () => {
+    expect(isSessionEndedResponse(401)).toBe(true);
+    expect(isSessionEndedResponse(401, null)).toBe(true);
+    expect(isSessionEndedResponse(401, '')).toBe(true);
+  });
+
+  it('detects session-ended 401 response bodies', () => {
+    expect(isSessionEndedResponse(401, 'Session ended')).toBe(true);
+    expect(isSessionEndedResponse(401, 'Viewer token revoked')).toBe(true);
+    expect(isSessionEndedResponse(401, 'no longer active')).toBe(true);
+  });
+
+  it('returns false for present but unrelated 401 response bodies', () => {
+    expect(isSessionEndedResponse(401, 'Unauthorized')).toBe(false);
+  });
+});
+
+describe('SessionEndedError', () => {
+  it('sets the expected name and extends Error', () => {
+    const error = new SessionEndedError();
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('SessionEndedError');
+  });
+
+  it('respects a custom message', () => {
+    const error = new SessionEndedError('Custom ended message');
+
+    expect(error.message).toBe('Custom ended message');
+  });
+});

--- a/apps/viewer/src/lib/transports/webrtc.ts
+++ b/apps/viewer/src/lib/transports/webrtc.ts
@@ -4,7 +4,7 @@
  * React refs/state are threaded in via WebRTCDeps callbacks.
  */
 
-import { createWebRTCSession, AgentSessionError, type AuthenticatedConnectionParams } from '../webrtc';
+import { createWebRTCSession, AgentSessionError, SessionEndedError, type AuthenticatedConnectionParams } from '../webrtc';
 import type { TransportSession } from './types';
 import { capabilitiesFor } from './types';
 
@@ -188,6 +188,12 @@ export async function connectWebRTC(
     // no encoder), propagate it so the viewer shows the real error instead
     // of silently falling back to WebSocket which will also fail.
     if (err instanceof AgentSessionError) {
+      throw err;
+    }
+    // A SessionEndedError means the server rejected the session as ended (401).
+    // Propagate it so the reconnect loop stops retrying the same dead sessionId
+    // and the viewer shows a terminal "session ended" state.
+    if (err instanceof SessionEndedError) {
       throw err;
     }
     console.warn('WebRTC connection failed:', err);

--- a/apps/viewer/src/lib/webrtc.ts
+++ b/apps/viewer/src/lib/webrtc.ts
@@ -18,6 +18,33 @@ export class AgentSessionError extends Error {
   }
 }
 
+/**
+ * Error thrown when the server rejects access to the session because it has
+ * already ended (HTTP 401 'Session ended' from the mid-session revocation
+ * guard). The single-session viewer token can never connect to this session
+ * again, so callers MUST stop retrying the same sessionId and surface a
+ * terminal "session ended" state rather than hammering the endpoint.
+ */
+export class SessionEndedError extends Error {
+  constructor(message = 'This remote session has ended.') {
+    super(message);
+    this.name = 'SessionEndedError';
+  }
+}
+
+/**
+ * Best-effort detection of the server's "session ended" rejection. The server
+ * returns HTTP 401 with a body/error mentioning the session has ended; we also
+ * treat a bare 401 on the viewer offer/poll path as terminal because a
+ * single-session viewer token only ever authorizes one (still-live) session —
+ * once it's 401ing there is nothing a retry can recover.
+ */
+export function isSessionEndedResponse(status: number, body?: string | null): boolean {
+  if (status !== 401) return false;
+  if (!body) return true;
+  return /session\s*ended|ended|revoked|no longer active/i.test(body);
+}
+
 export interface AuthenticatedConnectionParams {
   sessionId: string;
   apiUrl: string;
@@ -131,6 +158,11 @@ export async function createWebRTCSession(
 
     if (!offerResp.ok) {
       const msg = await offerResp.text().catch(() => 'unknown error');
+      // A 401 here means the session was ended/revoked server-side — retrying
+      // the same sessionId is futile. Surface a terminal error.
+      if (isSessionEndedResponse(offerResp.status, msg)) {
+        throw new SessionEndedError();
+      }
       throw new Error(`Failed to submit WebRTC offer: ${msg}`);
     }
 
@@ -200,6 +232,14 @@ async function pollForAnswer(params: AuthenticatedConnectionParams, timeoutMs: n
       // If the agent reported a failure, surface it immediately
       if (data.status === 'failed') {
         throw new AgentSessionError(data.errorMessage || 'Remote desktop failed to start on agent');
+      }
+    } else if (resp.status === 401) {
+      // Session ended/revoked server-side mid-poll — stop immediately so the
+      // caller can surface a terminal state instead of polling to timeout
+      // and then retrying the same dead session.
+      const body = await resp.text().catch(() => null);
+      if (isSessionEndedResponse(resp.status, body)) {
+        throw new SessionEndedError();
       }
     }
 

--- a/apps/web/src/components/configurationPolicies/featureTabs/RemoteAccessTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/RemoteAccessTab.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import RemoteAccessTab from './RemoteAccessTab';
+
+const saveMock = vi.fn();
+const removeMock = vi.fn();
+const clearErrorMock = vi.fn();
+
+vi.mock('./useFeatureLink', () => ({
+  useFeatureLink: () => ({
+    save: saveMock,
+    remove: removeMock,
+    saving: false,
+    error: undefined,
+    clearError: clearErrorMock,
+  }),
+}));
+
+const HOST_TO_VIEWER = 'Remote machine → operator (copy out)';
+const VIEWER_TO_HOST = 'Operator → remote machine (paste in)';
+
+describe('RemoteAccessTab — clipboard direction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    saveMock.mockResolvedValue({
+      id: 'link-1',
+      featureType: 'remote_access',
+      featurePolicyId: null,
+      inlineSettings: {},
+    });
+  });
+
+  it('defaults host→viewer OFF (egress) and viewer→host ON (paste)', () => {
+    render(
+      <RemoteAccessTab
+        policyId="policy-1"
+        existingLink={undefined}
+        linkedPolicyId={null}
+        onLinkChanged={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('switch', { name: HOST_TO_VIEWER })).toHaveAttribute('aria-checked', 'false');
+    expect(screen.getByRole('switch', { name: VIEWER_TO_HOST })).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('persists clipboard direction into inlineSettings on save', async () => {
+    render(
+      <RemoteAccessTab
+        policyId="policy-1"
+        existingLink={undefined}
+        linkedPolicyId={null}
+        onLinkChanged={vi.fn()}
+      />
+    );
+
+    // Enable host→viewer egress (off by default).
+    fireEvent.click(screen.getByRole('switch', { name: HOST_TO_VIEWER }));
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    expect(saveMock).toHaveBeenCalledWith(
+      null,
+      expect.objectContaining({
+        featureType: 'remote_access',
+        inlineSettings: expect.objectContaining({
+          clipboardHostToViewer: true,
+          clipboardViewerToHost: true,
+        }),
+      }),
+    );
+  });
+
+  it('reflects an existing link that disables paste (viewer→host)', () => {
+    render(
+      <RemoteAccessTab
+        policyId="policy-1"
+        existingLink={{
+          id: 'link-1',
+          featureType: 'remote_access' as const,
+          featurePolicyId: null,
+          inlineSettings: { clipboardHostToViewer: true, clipboardViewerToHost: false },
+        }}
+        linkedPolicyId={null}
+        onLinkChanged={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('switch', { name: HOST_TO_VIEWER })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('switch', { name: VIEWER_TO_HOST })).toHaveAttribute('aria-checked', 'false');
+  });
+});

--- a/apps/web/src/components/configurationPolicies/featureTabs/RemoteAccessTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/RemoteAccessTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Monitor, Network, Gauge, Plus, X } from 'lucide-react';
+import { Monitor, Network, Gauge, Plus, X, ClipboardCopy } from 'lucide-react';
 import type { FeatureTabProps } from './types';
 import { FEATURE_META } from './types';
 import { useFeatureLink } from './useFeatureLink';
@@ -9,6 +9,8 @@ type RemoteAccessSettings = {
   webrtcDesktop: boolean;
   vncRelay: boolean;
   remoteTools: boolean;
+  clipboardHostToViewer: boolean;
+  clipboardViewerToHost: boolean;
   enableProxy: boolean;
   defaultAllowedPorts: number[];
   autoEnableProxy: boolean;
@@ -21,6 +23,11 @@ const defaults: RemoteAccessSettings = {
   webrtcDesktop: true,
   vncRelay: false,
   remoteTools: true,
+  // Host→viewer is the data-egress direction (whatever the end user copies —
+  // passwords, MFA codes — would stream to the operator); default OFF. Operator
+  // paste into the remote machine is operator-initiated; default ON.
+  clipboardHostToViewer: false,
+  clipboardViewerToHost: true,
   enableProxy: false,
   defaultAllowedPorts: [80, 443, 8080, 8443],
   autoEnableProxy: false,
@@ -43,6 +50,9 @@ function ToggleRow({ label, description, checked, onChange }: {
       </div>
       <button
         type="button"
+        role="switch"
+        aria-checked={checked}
+        aria-label={label}
         onClick={() => onChange(!checked)}
         className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full border transition ${checked ? 'bg-emerald-500/80' : 'bg-muted'}`}
       >
@@ -183,6 +193,31 @@ export default function RemoteAccessTab({ policyId, existingLink, onLinkChanged,
               ))}
             </select>
           </div>
+        </div>
+      </div>
+
+      {/* Clipboard */}
+      <div className="mt-6">
+        <div className="flex items-center gap-2">
+          <ClipboardCopy className="h-4 w-4 text-muted-foreground" />
+          <h3 className="text-sm font-semibold">Clipboard Sync</h3>
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Clipboard sharing over the remote desktop session, gated per direction and enforced on the agent.
+        </p>
+        <div className="mt-3 space-y-3">
+          <ToggleRow
+            label="Remote machine → operator (copy out)"
+            description="Stream the remote machine's clipboard to the operator's viewer. This is the data-egress direction — whatever the end user copies (passwords, MFA codes) would reach the operator. Off by default."
+            checked={settings.clipboardHostToViewer}
+            onChange={(v) => update('clipboardHostToViewer', v)}
+          />
+          <ToggleRow
+            label="Operator → remote machine (paste in)"
+            description="Allow the operator to paste into the remote machine. Operator-initiated; on by default."
+            checked={settings.clipboardViewerToHost}
+            onChange={(v) => update('clipboardViewerToHost', v)}
+          />
         </div>
       </div>
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -257,6 +257,13 @@ export interface RemoteAccessPolicy {
   webrtcDesktop: boolean;
   vncRelay: boolean;
   remoteTools: boolean;
+  // Clipboard sync over the WebRTC desktop channel, gated per direction.
+  // `clipboardHostToViewer` (remote machine → operator's viewer) is the
+  // data-egress direction and defaults off on hosted SaaS; `clipboardViewerToHost`
+  // (operator paste → remote machine) is operator-initiated and defaults on.
+  // Enforced agent-side. Mirrors the API's RemoteAccessSettings.
+  clipboardHostToViewer: boolean;
+  clipboardViewerToHost: boolean;
   enableProxy: boolean;
   policyName: string | null;
   policyId: string | null;

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -14,6 +14,7 @@ import {
 export * from './reliability';
 export * from './businessEmail';
 export * from './remoteAccessLauncherScheme';
+export * from './remoteAccessInlineSettings';
 
 // ============================================
 // Device Roles

--- a/packages/shared/src/validators/remoteAccessInlineSettings.test.ts
+++ b/packages/shared/src/validators/remoteAccessInlineSettings.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { remoteAccessInlineSettingsSchema } from './remoteAccessInlineSettings';
+
+describe('remoteAccessInlineSettingsSchema', () => {
+  it('parses a valid partial object', () => {
+    const result = remoteAccessInlineSettingsSchema.safeParse({
+      clipboardHostToViewer: false,
+      idleTimeoutMinutes: 15,
+      maxSessionDurationHours: 12,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('fails for a non-boolean clipboard flag', () => {
+    const result = remoteAccessInlineSettingsSchema.safeParse({
+      clipboardHostToViewer: 'yes',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('fails for lifetime values above the configured maximums', () => {
+    expect(
+      remoteAccessInlineSettingsSchema.safeParse({ idleTimeoutMinutes: 1441 }).success
+    ).toBe(false);
+    expect(
+      remoteAccessInlineSettingsSchema.safeParse({ maxSessionDurationHours: 169 }).success
+    ).toBe(false);
+  });
+
+  it('fails for negative lifetime values', () => {
+    expect(
+      remoteAccessInlineSettingsSchema.safeParse({ idleTimeoutMinutes: -1 }).success
+    ).toBe(false);
+    expect(
+      remoteAccessInlineSettingsSchema.safeParse({ maxSessionDurationHours: -1 }).success
+    ).toBe(false);
+  });
+
+  it('parses an empty object', () => {
+    const result = remoteAccessInlineSettingsSchema.safeParse({});
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/shared/src/validators/remoteAccessInlineSettings.ts
+++ b/packages/shared/src/validators/remoteAccessInlineSettings.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+// Zod schema for the `remote_access` configuration-policy inlineSettings JSONB.
+//
+// The effective-config engine stores this blob untyped (JSONB), so a malformed
+// value (a non-boolean clipboard flag, a zero/negative/huge session-duration)
+// could otherwise flow straight to the agent. The resolver parses raw
+// inlineSettings through this schema and falls back to safe defaults on failure.
+//
+// `.partial()` because a policy may set only a subset of fields; unset fields
+// are merged over the resolver's DEFAULTS. Numeric lifetime fields are clamped
+// to sane ranges via `.min()/.max()` so a hostile/buggy JSONB value can't push
+// the agent into never-idle-out / never-expire territory.
+//
+// Ranges:
+//   idleTimeoutMinutes      0..1440 (0 = idle timeout disabled, max 24h)
+//   maxSessionDurationHours 0..168  (0 = no max duration, max 7 days)
+export const remoteAccessInlineSettingsSchema = z
+  .object({
+    webrtcDesktop: z.boolean(),
+    vncRelay: z.boolean(),
+    remoteTools: z.boolean(),
+    clipboardHostToViewer: z.boolean(),
+    clipboardViewerToHost: z.boolean(),
+    enableProxy: z.boolean(),
+    defaultAllowedPorts: z.array(z.number().int().min(1).max(65535)).max(100),
+    autoEnableProxy: z.boolean(),
+    maxConcurrentTunnels: z.number().int().min(0).max(100),
+    idleTimeoutMinutes: z.number().int().min(0).max(1440),
+    maxSessionDurationHours: z.number().int().min(0).max(168),
+  })
+  .partial();
+
+export type RemoteAccessInlineSettings = z.infer<typeof remoteAccessInlineSettingsSchema>;


### PR DESCRIPTION
**Context:** Net-new remote-desktop hardening surfaced by a security review of the merged #1020 work. Each item was verified absent from `main` before porting (the bug-fix items #1020 already covered — idle-input-only, teardown allowlist — are intentionally NOT duplicated here). Branched off `origin/main`; 7 focused commits, each with tests.

**The one real gap — untyped policy → agent (`42666555`):** `remote_access` `inlineSettings` is untyped JSONB and was spread verbatim into the policy shipped to the agent (`{ ...DEFAULTS, ...inline }` with an `as Partial` cast). A malformed/hostile value (non-boolean clipboard flag, negative/huge session-duration) flowed through unchecked. Now parsed through a Zod schema (`packages/shared/src/validators/remoteAccessInlineSettings.ts`); parse failure falls back to `DEFAULTS`; lifetime fields clamped (idle 0..1440, max 0..168); `resolveDesktopSessionPolicy` fails closed to a restrictive `FAILSAFE` policy instead of 500-ing.

**Agent direct-mode clamp (`1f8f7976`):** `parseDesktopSessionPolicy` (map-payload / console path) trusted lifetime values verbatim; now clamps to the same maxima the IPC path rejects at (`agent/internal/heartbeat/handlers_desktop.go`).

**Teardown-failure surfacing (`e24bf1a2`):** `terminateUserRemoteSessions` returned `0` for both "nothing to do" and a hard failure, so a suspended operator could retain live control with no signal. Added a `TEARDOWN_FAILED` sentinel reported to Sentry; `PATCH /users/:id` returns 503 (partial suspension) and partner abuse-suspend records `remoteSessionTeardownFailures` in the audit trail.

**Viewer terminal-state (`088756dc`):** the viewer kept retrying a dead `sessionId` on the server's 401 ended-session rejection; added `SessionEndedError` + `isSessionEndedResponse` so the offer/poll paths stop and surface a terminal state (`apps/viewer/src/lib/webrtc.ts`).

**Blocked-paste audit (`b3994e5d`):** a policy-denied viewer→host paste was dropped silently; now audited (`agent/internal/remote/clipboard/sync.go`), and clipboard/filedrop transfer audit lines migrated to structured `slog` (still diagnostic-log, central `audit_logs` tracked as #1012).

**Refactor (`10753c09`):** extracted `DefaultSessionPolicy` / `clipboardEnabled` / `shouldStopForLifetime` / `ResolveSessionPolicyFromIPC` into `session_policy.go` so the IPC and map decoders can't drift and the watchdog decision is unit-testable. Behavior-preserving — idle still reads `lastInputUnixNano` (viewer **input** only); control-channel traffic does not reset it.

**Clipboard-direction UI (`1792f1b8`):** per-direction clipboard sync is now configurable from the Remote Access policy tab (host→viewer egress OFF by default, viewer→host paste ON); added the fields to the shared `RemoteAccessPolicy` type and the device-detail response.

**Tests:** Zod schema 5 + remoteAccessPolicy 4 (valid/invalid→defaults/clamp/failsafe); Go `parseDesktopSessionPolicy` clamp cases; `remoteSessionTeardown` service (sentinel + Sentry) + users 503 + abuse audit-count; viewer 6; clipboard gate (drop + blocked-policy audit); `session_policy` table-driven `shouldStopForLifetime`; web RTL 3 (defaults / save payload / existing link). `go build ./...` + `-race` on desktop/heartbeat/userhelper/clipboard/filedrop green; shared `tsc --noEmit` clean.

**Status:** ready for review; no schema migrations; no changes to the already-merged #1020 behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)