### PR TITLE
fix(remote-desktop): correct idle watchdog, teardown predicate & direct-mode clamp (post-#1034)

### DIFF
--- a/agent/internal/heartbeat/handlers_desktop.go
+++ b/agent/internal/heartbeat/handlers_desktop.go
@@ -19,6 +19,14 @@ const (
 	maxDesktopKeyBytes      = 64
 	maxDesktopModifierBytes = 16
 	maxDesktopModifiers     = 8
+
+	// Caps for caller-supplied session-lifetime limits in the direct-mode
+	// (map-payload) decoder. Same maxima as the IPC path (userhelper), but note
+	// the enforcement DIFFERS: this decoder has no error channel so it CLAMPS to
+	// these bounds, whereas the IPC path REJECTS out-of-range input with an
+	// error. Either way the agent can't be pushed past these. 0 = disabled.
+	maxIdleTimeoutMinutes   = 1440 // 24h
+	maxSessionDurationHours = 168  // 7d
 )
 
 var desktopInputTypes = map[string]struct{}{
@@ -224,11 +232,19 @@ func parseDesktopSessionPolicy(payload map[string]any) desktop.SessionPolicy {
 			policy.ClipboardViewerToHost = v
 		}
 	}
+	// Clamp the lifetime fields defensively. The server already clamps these
+	// (remoteAccessPolicy.ts), but this direct-mode decoder must never trust a
+	// hostile/buggy value verbatim: a <=0 value means "disabled" (matching the
+	// IPC decoder ResolveSessionPolicyFromIPC), and an over-cap value is clamped
+	// to the same maxima the IPC path rejects at — so it can't push the agent
+	// into never-idle-out / never-expire territory. NOTE the mechanism differs:
+	// the IPC path (userhelper.validateDesktopStartRequest) returns an error on
+	// out-of-range input; this map decoder has no error channel, so it clamps.
 	if v, ok := payload["idleTimeoutMinutes"].(float64); ok && v > 0 {
-		policy.IdleTimeout = time.Duration(v) * time.Minute
+		policy.IdleTimeout = time.Duration(math.Min(v, maxIdleTimeoutMinutes)) * time.Minute
 	}
 	if v, ok := payload["maxSessionDurationHours"].(float64); ok && v > 0 {
-		policy.MaxDuration = time.Duration(v) * time.Hour
+		policy.MaxDuration = time.Duration(math.Min(v, maxSessionDurationHours)) * time.Hour
 	}
 	return policy
 }

--- a/agent/internal/heartbeat/handlers_desktop_policy_test.go
+++ b/agent/internal/heartbeat/handlers_desktop_policy_test.go
@@ -68,6 +68,45 @@ func TestParseDesktopSessionPolicy(t *testing.T) {
 				ClipboardViewerToHost: true,
 			},
 		},
+		{
+			// Defense-in-depth: the server clamps these before sending, but if a
+			// hostile/buggy value reaches this direct-mode decoder it must be
+			// bounded — never trusted verbatim into never-idle-out / 10^9-hour
+			// territory. Caps mirror the IPC path (userhelper validateDesktop...).
+			name: "over-cap idle timeout clamped to 24h max",
+			payload: map[string]any{
+				"idleTimeoutMinutes": float64(100000),
+			},
+			want: desktop.SessionPolicy{
+				ClipboardHostToViewer: true,
+				ClipboardViewerToHost: true,
+				IdleTimeout:           1440 * time.Minute,
+			},
+		},
+		{
+			name: "over-cap max duration clamped to 7d max",
+			payload: map[string]any{
+				"maxSessionDurationHours": float64(100000),
+			},
+			want: desktop.SessionPolicy{
+				ClipboardHostToViewer: true,
+				ClipboardViewerToHost: true,
+				MaxDuration:           168 * time.Hour,
+			},
+		},
+		{
+			// Negative must NOT fail open. <=0 means disabled (consistent with the
+			// IPC decoder), never a negative duration.
+			name: "negative timeouts treated as disabled (not fail-open)",
+			payload: map[string]any{
+				"idleTimeoutMinutes":      float64(-5),
+				"maxSessionDurationHours": float64(-1),
+			},
+			want: desktop.SessionPolicy{
+				ClipboardHostToViewer: true,
+				ClipboardViewerToHost: true,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/agent/internal/remote/desktop/session.go
+++ b/agent/internal/remote/desktop/session.go
@@ -126,14 +126,14 @@ type Session struct {
 	// Nanoseconds since epoch of the last successful video sample write.
 	lastVideoWriteUnixNano atomic.Int64
 
-	// lastActivityUnixNano is the wall-clock nanos of the most recent sign of
-	// life from the viewer. It drives the idle-session watchdog (finding #2)
-	// and is updated both on "input" DataChannel traffic (mouse/keyboard) AND
-	// on "control" DataChannel traffic (e.g. viewer_stats, sent ~1s by an
-	// alive-but-watching viewer). This keeps a viewer that is merely watching
-	// from being killed by the idle watchdog, while a dead/closed viewer client
-	// — which sends nothing on either channel — still goes idle and is reaped.
-	lastActivityUnixNano atomic.Int64
+	// lastInputUnixNano is the wall-clock nanos of the most recent INPUT event
+	// (mouse/keyboard) from the viewer. It drives the idle-session watchdog
+	// (finding #2). Only genuine operator input resets it — control-channel
+	// traffic (e.g. the viewer's automated ~1s viewer_stats heartbeat) is NOT a
+	// presence signal and must not reset it, otherwise an unattended-but-open
+	// viewer would never idle out and the idle timeout would be defeated.
+	// Updated via recordInputActivity().
+	lastInputUnixNano atomic.Int64
 }
 
 // SessionManager manages remote desktop sessions

--- a/agent/internal/remote/desktop/session_control.go
+++ b/agent/internal/remote/desktop/session_control.go
@@ -87,6 +87,29 @@ func (s *Session) sendInputStatus() {
 	}
 }
 
+// recordInputActivity stamps the idle-watchdog clock with the current time.
+// Called ONLY for genuine operator input (mouse/keyboard), never for
+// control-channel traffic — see lastInputUnixNano in session.go for why.
+func (s *Session) recordInputActivity() {
+	s.lastInputUnixNano.Store(time.Now().UnixNano())
+}
+
+// onViewerDataChannelMessage routes an inbound viewer data-channel message by
+// label and applies the idle-watchdog policy in one place. Idle is reset on
+// "input" traffic only: control-channel traffic (e.g. the viewer's automated
+// ~1s viewer_stats heartbeat) is not a signal of operator presence, so letting
+// it reset the idle clock would defeat the idle timeout for any open-but-
+// unattended viewer (finding #1).
+func (s *Session) onViewerDataChannelMessage(label string, data []byte) {
+	switch label {
+	case "input":
+		s.recordInputActivity()
+		s.handleInputMessage(data)
+	case "control":
+		s.handleControlMessage(data)
+	}
+}
+
 // handleInputMessage processes input events from the data channel
 func (s *Session) handleInputMessage(data []byte) {
 	// Drop input events early when the handler cannot inject them (e.g. macOS

--- a/agent/internal/remote/desktop/session_webrtc.go
+++ b/agent/internal/remote/desktop/session_webrtc.go
@@ -136,7 +136,7 @@ func (m *SessionManager) StartSession(sessionID string, offer string, iceServers
 	// even when the server can't reach the agent to send stop_desktop. The
 	// goroutine exits on session.done (closed by Stop) and is intentionally not
 	// in session.wg, so the StopSession call below cannot deadlock on wg.Wait.
-	session.lastActivityUnixNano.Store(time.Now().UnixNano())
+	session.recordInputActivity()
 	if policy.MaxDuration > 0 || policy.IdleTimeout > 0 {
 		startWall := time.Now()
 		go func() {
@@ -148,7 +148,7 @@ func (m *SessionManager) StartSession(sessionID string, offer string, iceServers
 					return
 				case <-ticker.C:
 					now := time.Now()
-					lastActivity := time.Unix(0, session.lastActivityUnixNano.Load())
+					lastActivity := time.Unix(0, session.lastInputUnixNano.Load())
 					stop, reason := shouldStopForLifetime(now, startWall, lastActivity, policy)
 					if !stop {
 						continue
@@ -466,20 +466,14 @@ func (m *SessionManager) StartSession(sessionID string, offer string, iceServers
 			session.dataChannel = dc
 			session.mu.Unlock()
 			dc.OnMessage(func(msg webrtc.DataChannelMessage) {
-				session.lastActivityUnixNano.Store(time.Now().UnixNano())
-				session.handleInputMessage(msg.Data)
+				session.onViewerDataChannelMessage("input", msg.Data)
 			})
 		case "control":
 			session.mu.Lock()
 			session.controlDC = dc
 			session.mu.Unlock()
 			dc.OnMessage(func(msg webrtc.DataChannelMessage) {
-				// Any control-channel traffic (e.g. viewer_stats sent ~1s by an
-				// alive-but-watching viewer) counts as activity and resets the
-				// idle watchdog. A dead/closed viewer client sends nothing here,
-				// so it still goes idle and is reaped.
-				session.lastActivityUnixNano.Store(time.Now().UnixNano())
-				session.handleControlMessage(msg.Data)
+				session.onViewerDataChannelMessage("control", msg.Data)
 			})
 			dc.OnOpen(func() {
 				// Send the current cached desktop state to this viewer so it

--- a/agent/internal/remote/desktop/session_webrtc_test.go
+++ b/agent/internal/remote/desktop/session_webrtc_test.go
@@ -1,7 +1,6 @@
 package desktop
 
 import (
-	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -138,32 +137,49 @@ func TestShouldStopForLifetime(t *testing.T) {
 	}
 }
 
-// TestControlMessageResetsIdleViaActivity proves the mechanism that keeps a
-// watching (no input) viewer alive: control-channel traffic updates
-// lastActivityUnixNano, which feeds shouldStopForLifetime. We exercise the
-// store-on-control-message behavior directly (the OnMessage closure does
-// lastActivityUnixNano.Store(now)) and assert the idle decision then returns
-// false.
-func TestControlMessageResetsIdleViaActivity(t *testing.T) {
-	var lastActivity atomic.Int64
-	// Simulate a stale session whose only sign of life would be control msgs.
-	stale := time.Now().Add(-time.Hour)
-	lastActivity.Store(stale.UnixNano())
+// idlePolicyStops reports whether a 5-minute idle policy would reap a session
+// whose idle clock is at s.lastInputUnixNano. startWall is recent so only the
+// idle axis is in play.
+func idlePolicyStops(s *Session) bool {
+	now := time.Now()
+	stop, _ := shouldStopForLifetime(
+		now,
+		now.Add(-time.Minute),
+		time.Unix(0, s.lastInputUnixNano.Load()),
+		SessionPolicy{IdleTimeout: 5 * time.Minute},
+	)
+	return stop
+}
 
-	idlePolicy := SessionPolicy{IdleTimeout: 5 * time.Minute}
-
-	// Before any control message: stale → should stop.
-	beforeStop, _ := shouldStopForLifetime(time.Now(), time.Now().Add(-time.Hour), time.Unix(0, lastActivity.Load()), idlePolicy)
-	if !beforeStop {
-		t.Fatal("expected stale session to be idle before any activity")
+// TestInputTrafficResetsIdleWatchdog: an inbound input-channel message records
+// operator activity, so an otherwise-stale session is NOT reaped.
+func TestInputTrafficResetsIdleWatchdog(t *testing.T) {
+	s := &Session{id: "s1", inputHandler: &stubInputHandler{}}
+	s.lastInputUnixNano.Store(time.Now().Add(-time.Hour).UnixNano())
+	if !idlePolicyStops(s) {
+		t.Fatal("precondition: a stale session must be idle before any activity")
 	}
 
-	// Control message arrives — same store the OnMessage handler performs.
-	lastActivity.Store(time.Now().UnixNano())
+	s.onViewerDataChannelMessage("input", []byte(`{"type":"mouse_move","x":1,"y":2}`))
 
-	// After: fresh activity → must NOT stop.
-	afterStop, _ := shouldStopForLifetime(time.Now(), time.Now().Add(-time.Hour), time.Unix(0, lastActivity.Load()), idlePolicy)
-	if afterStop {
-		t.Fatal("session went idle despite a fresh control message resetting activity")
+	if idlePolicyStops(s) {
+		t.Fatal("input-channel traffic must reset the idle watchdog")
+	}
+}
+
+// TestControlTrafficDoesNotResetIdleWatchdog: control-channel traffic — e.g. the
+// viewer's automated ~1s viewer_stats heartbeat — is NOT a signal of operator
+// presence and MUST NOT keep an unattended session alive. Regression guard for
+// the "idle timeout defeated by viewer_stats heartbeat" finding (#1): an
+// operator who walks away (no input, tab still open streaming stats) must still
+// be reaped at the idle timeout.
+func TestControlTrafficDoesNotResetIdleWatchdog(t *testing.T) {
+	s := &Session{id: "s1"}
+	s.lastInputUnixNano.Store(time.Now().Add(-time.Hour).UnixNano())
+
+	s.onViewerDataChannelMessage("control", []byte(`{"type":"viewer_stats"}`))
+
+	if !idlePolicyStops(s) {
+		t.Fatal("control-channel traffic must not reset the idle watchdog")
 	}
 }

--- a/apps/api/src/services/remoteSessionTeardown.test.ts
+++ b/apps/api/src/services/remoteSessionTeardown.test.ts
@@ -14,13 +14,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const h = vi.hoisted(() => {
   const state = {
     whereCalls: 0,
+    whereArgs: [] as any[],
     deviceRowsResult: [] as Array<{ id: string; agentId: string | null }>,
   };
   const chain: Record<string, any> = {};
   for (const m of ['update', 'set', 'select', 'from']) {
     chain[m] = vi.fn(() => chain);
   }
-  chain.where = vi.fn(() => {
+  chain.where = vi.fn((arg: unknown) => {
+    state.whereArgs.push(arg);
     state.whereCalls += 1;
     // 1st where() = UPDATE (fluent); 2nd+ = device SELECT terminal.
     return state.whereCalls >= 2 ? Promise.resolve(state.deviceRowsResult) : chain;
@@ -35,6 +37,15 @@ const h = vi.hoisted(() => {
     captureException: vi.fn(),
   };
 });
+
+// Capture drizzle operator calls as inspectable tagged objects so a test can
+// assert WHICH status predicate the UPDATE targets (active-only vs ne-disconnected).
+vi.mock('drizzle-orm', () => ({
+  and: (...args: unknown[]) => ({ op: 'and', args }),
+  eq: (col: unknown, val: unknown) => ({ op: 'eq', col, val }),
+  ne: (col: unknown, val: unknown) => ({ op: 'ne', col, val }),
+  inArray: (col: unknown, vals: unknown) => ({ op: 'inArray', col, vals }),
+}));
 
 vi.mock('../db', () => ({
   db: h.chain,
@@ -84,19 +95,41 @@ describe('terminateUserRemoteSessions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     h.state.whereCalls = 0;
+    h.state.whereArgs = [];
     h.state.deviceRowsResult = [];
     // Re-establish fluent defaults wiped by clearAllMocks.
     h.chain.update.mockImplementation(() => h.chain);
     h.chain.set.mockImplementation(() => h.chain);
     h.chain.select.mockImplementation(() => h.chain);
     h.chain.from.mockImplementation(() => h.chain);
-    h.chain.where.mockImplementation(() => {
+    h.chain.where.mockImplementation((arg: unknown) => {
+      h.state.whereArgs.push(arg);
       h.state.whereCalls += 1;
       return h.state.whereCalls >= 2
         ? Promise.resolve(h.state.deviceRowsResult)
         : h.chain;
     });
     h.revokeViewerSession.mockResolvedValue(undefined);
+  });
+
+  it('targets only active statuses (pending/connecting/active) so terminal failed/disconnected rows are never clobbered', async () => {
+    seed([{ id: 's1', type: 'desktop', deviceId: 'd1' }], [{ id: 'd1', agentId: 'agent-1' }]);
+
+    await terminateUserRemoteSessions('u1');
+
+    // The UPDATE is the first where() call. Its predicate is and(eq(userId), <statusPredicate>).
+    const updateWhere = h.state.whereArgs[0] as { op: string; args: any[] };
+    expect(updateWhere.op).toBe('and');
+    const statusPredicate = updateWhere.args.find(
+      (a) => a?.col === 'remote_sessions.status',
+    );
+    expect(statusPredicate).toBeDefined();
+    // Must be an allowlist of live statuses — NOT `ne(status,'disconnected')`,
+    // which also matches terminal `failed` rows and would overwrite their endedAt.
+    expect(statusPredicate.op).toBe('inArray');
+    expect(statusPredicate.vals).toEqual(['pending', 'connecting', 'active']);
+    expect(statusPredicate.vals).not.toContain('failed');
+    expect(statusPredicate.vals).not.toContain('disconnected');
   });
 
   it('disconnects two desktop sessions: revokes each viewer token and signals stop_desktop per session, returns 2', async () => {

--- a/apps/api/src/services/remoteSessionTeardown.ts
+++ b/apps/api/src/services/remoteSessionTeardown.ts
@@ -1,9 +1,15 @@
-import { and, eq, inArray, ne } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { remoteSessions, devices } from '../db/schema';
 import { revokeViewerSession } from './viewerTokenRevocation';
 import { sendCommandToAgent } from '../routes/agentWs';
 import { captureException } from './sentry';
+
+// Live statuses a teardown may disconnect. Terminal rows (`disconnected`,
+// `failed`) are intentionally excluded: matching them (e.g. via
+// `ne(status,'disconnected')`) would also sweep historical `failed` rows and
+// overwrite their `endedAt`, corrupting session history for no benefit.
+const ACTIVE_REMOTE_SESSION_STATUSES = ['pending', 'connecting', 'active'] as const;
 
 /**
  * Sentinel returned by {@link terminateUserRemoteSessions} when teardown
@@ -59,7 +65,7 @@ export async function terminateUserRemoteSessions(userId: string): Promise<numbe
           .where(
             and(
               eq(remoteSessions.userId, userId),
-              ne(remoteSessions.status, 'disconnected')
+              inArray(remoteSessions.status, [...ACTIVE_REMOTE_SESSION_STATUSES])
             )
           )
           .returning({


### PR DESCRIPTION
**Context:** Three corrections to the remote-desktop follow-up that merged in #1034. A security review of that change surfaced bugs that #1034 shipped to `main`; this PR fixes them. Branched off current `main` (`1f2032bc`); one commit, each fix with a regression test that was watched failing against the current behavior.

**1. Idle watchdog defeated by `viewer_stats` (MEDIUM).** `session_webrtc.go` reset the idle clock on **any control-channel** traffic, and the viewer streams `viewer_stats` every ~1s regardless of human input — so the `idleTimeoutMinutes` policy never fires for an open-but-unattended viewer. Idle now resets on **input** (mouse/keyboard) only: renamed `lastActivityUnixNano` → `lastInputUnixNano`, routed both data channels through a single `onViewerDataChannelMessage` seam so only the input channel stamps the clock. Max-duration cap is unchanged. `agent/internal/remote/desktop/{session.go,session_control.go,session_webrtc.go}`.

**2. Teardown clobbers terminal `failed` rows.** `terminateUserRemoteSessions` used `ne(status,'disconnected')`, which also matches terminal `failed` rows and overwrites their `endedAt` on every suspend. Restored the explicit active-status allowlist `inArray(['pending','connecting','active'])`. `apps/api/src/services/remoteSessionTeardown.ts`.

**3. Direct-mode lifetime clamp.** `parseDesktopSessionPolicy` (console/map-payload path) trusted caller lifetime values verbatim; now clamps idle→1440m / max→168h via `math.Min`, matching the maxima the IPC path rejects at. Defense-in-depth. `agent/internal/heartbeat/handlers_desktop.go`.

**Tests:** idle — `TestInputTrafficResetsIdleWatchdog` / `TestControlTrafficDoesNotResetIdleWatchdog` (each proven to fail when the bug is reintroduced); clamp — over-cap cases in `TestParseDesktopSessionPolicy`; teardown — asserts the UPDATE predicate is the active-status allowlist, not `ne`. `go build ./...` + `-race` on desktop/heartbeat green; 6 `remoteSessionTeardown` tests green.

**Status:** supersedes the relevant slice of the now-closed #1039 (which predated #1034 and conflicted). No migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)