### PR TITLE
fix: unbreak main — Windows agent GetOEMCP + agentWs.test typecheck

### DIFF
--- a/agent/internal/procoutput/encoding_windows.go
+++ b/agent/internal/procoutput/encoding_windows.go
@@ -4,6 +4,16 @@ package procoutput
 
 import "golang.org/x/sys/windows"
 
+// GetOEMCP is not exposed by golang.org/x/sys/windows, so bind it directly from
+// kernel32. Signature: UINT GetOEMCP(void) — returns the OEM code page and
+// cannot fail (no error out-param), so Call's error return is ignored.
+var procGetOEMCP = windows.NewLazySystemDLL("kernel32.dll").NewProc("GetOEMCP")
+
+func getOEMCP() uint32 {
+	r, _, _ := procGetOEMCP.Call()
+	return uint32(r)
+}
+
 func decodeWindowsConsoleBytes(b []byte) (string, bool) {
 	cp, ok := activeConsoleCodePage()
 	if !ok {
@@ -19,7 +29,7 @@ func activeConsoleCodePage() (uint32, bool) {
 	if cp, err := windows.GetConsoleOutputCP(); err == nil && cp != 0 && cp != 65001 {
 		return cp, true
 	}
-	if cp, err := windows.GetOEMCP(); err == nil && cp != 0 && cp != 65001 {
+	if cp := getOEMCP(); cp != 0 && cp != 65001 {
 		return cp, true
 	}
 	return 0, false

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -286,7 +286,7 @@ describe('agent websocket handshake', () => {
     await handlers.onOpen({}, ws as any);
 
     expect(ws.send).toHaveBeenCalledTimes(1);
-    const payload = JSON.parse(vi.mocked(ws.send).mock.calls[0][0] as string);
+    const payload = JSON.parse(vi.mocked(ws.send).mock.calls[0]![0] as string);
     expect(payload.type).toBe('connected');
     expect(payload.capabilities).toEqual([...AGENT_WS_CAPABILITIES]);
   });


### PR DESCRIPTION
Main's CI is red after today's merge run (lint / api tests / web tests all pass; **Type Check**, **Test Agent**, and **Build Agent (windows/amd64)** fail). Two root causes, both small:

## 1. Windows agent build — `undefined: windows.GetOEMCP`
#976 added `internal/procoutput/encoding_windows.go`, which calls `windows.GetOEMCP()`. That symbol is **not exported** by the pinned `golang.org/x/sys/windows` (`GetConsoleOutputCP` is; `GetOEMCP` isn't). So:
- **Build Agent (windows/amd64)** fails to cross-compile.
- **Test Agent** fails too — `TestUserHelperBinaryHasGUISubsystem` / `TestAgentBinaryHasCUISubsystem` cross-compile a Windows binary inside the test (`subsystem_test.go`), hitting the same undefined symbol ("cross-compile failed: exit status 1").

**Fix:** bind `GetOEMCP` directly from kernel32 via a `LazyProc` (`UINT GetOEMCP(void)`, cannot fail, so the error return is ignored) — the standard pattern for syscalls `x/sys/windows` doesn't wrap. Behavior is identical.

## 2. Type Check — `agentWs.test.ts:289` TS2532
`vi.mocked(ws.send).mock.calls[0][0]` — `calls[0]` is possibly `undefined` under the strict config. Added a non-null assertion (the preceding line already asserts `toHaveBeenCalledTimes(1)`).

## Verification (local, on merged main + this fix)
- `GOOS=windows GOARCH=amd64 go build ./...` — clean
- `go build ./...` (linux) — clean
- `TestUserHelperBinaryHasGUISubsystem` + `TestAgentBinaryHasCUISubsystem` — **PASS**
- `agentWs.test.ts` — 31/31
- api `tsc --noEmit` — 0 errors