### PR TITLE
fix(security): site-scope the AI-agent tool layer (cross-site RBAC gap)

### DIFF
--- a/apps/api/src/middleware/auth.siteAccess.test.ts
+++ b/apps/api/src/middleware/auth.siteAccess.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { siteAccessCheck } from './auth';
+
+/**
+ * `siteAccessCheck` is the single source of truth for the AuthContext site-axis
+ * closure, reused by the request path (authMiddleware) and the MCP API-key path
+ * (buildAuthFromApiKey) so the two never drift. Semantics mirror
+ * `permissions.canAccessSite`: undefined allowlist = unrestricted.
+ */
+describe('siteAccessCheck — AuthContext site-axis closure', () => {
+  it('is unrestricted when the allowlist is undefined', () => {
+    const can = siteAccessCheck(undefined);
+    expect(can('site-A')).toBe(true);
+    expect(can(null)).toBe(true);
+    expect(can(undefined)).toBe(true);
+  });
+
+  it('allows only sites in the allowlist when restricted', () => {
+    const can = siteAccessCheck(['site-A', 'site-B']);
+    expect(can('site-A')).toBe(true);
+    expect(can('site-B')).toBe(true);
+    expect(can('site-C')).toBe(false);
+  });
+
+  it('denies a null/undefined site for a restricted caller (device with no site)', () => {
+    const can = siteAccessCheck(['site-A']);
+    expect(can(null)).toBe(false);
+    expect(can(undefined)).toBe(false);
+  });
+
+  it('denies everything when the allowlist is empty (matches permissions.canAccessSite)', () => {
+    const can = siteAccessCheck([]);
+    expect(can('site-A')).toBe(false);
+    expect(can(null)).toBe(false);
+  });
+});

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -45,6 +45,21 @@ export interface AuthContext {
    * Use when validating an orgId passed as a parameter.
    */
   canAccessOrg: (orgId: string) => boolean;
+
+  /**
+   * Site-axis allowlist (sub-org restriction). `undefined` = no site
+   * restriction (full access to every site in accessible orgs). Mirrors
+   * `UserPermissions.allowedSiteIds`. Populated for organization-scope users;
+   * left undefined for partner/system scope.
+   */
+  allowedSiteIds?: string[];
+
+  /**
+   * Check if the caller can access a specific site. Returns `true` when
+   * unrestricted (`allowedSiteIds` undefined). A site-restricted caller is
+   * denied for a null/undefined siteId (e.g. a device with no site assignment).
+   */
+  canAccessSite?: (siteId: string | null | undefined) => boolean;
 }
 
 declare module 'hono' {

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -70,6 +70,27 @@ declare module 'hono' {
 }
 
 /**
+ * Build the AuthContext site-axis closure (`canAccessSite`). An `undefined`
+ * allowlist means unrestricted — returns true for every site (partner/system
+ * scope, or org users with no site restriction). A restricted caller is denied
+ * for a null/undefined siteId (e.g. a device with no site assignment). An empty
+ * allowlist denies all sites, matching `permissions.canAccessSite` semantics.
+ *
+ * Single source of truth for the closure, reused by the request path
+ * (authMiddleware) and the MCP API-key path (buildAuthFromApiKey) so the two
+ * never drift.
+ */
+export function siteAccessCheck(
+  allowedSiteIds?: string[]
+): (siteId: string | null | undefined) => boolean {
+  return (siteId) => {
+    if (!allowedSiteIds) return true;
+    if (!siteId) return false;
+    return allowedSiteIds.includes(siteId);
+  };
+}
+
+/**
  * Resolve whether the user's effective role for the current request has
  * `force_mfa=true`. Returns false for system scope (platform admin is a
  * user flag, not a role) and for any user whose membership row is missing.
@@ -388,6 +409,21 @@ export async function authMiddleware(c: Context, next: Next): Promise<void | Res
     return accessibleOrgIds.includes(orgId);
   };
 
+  // Resolve the site-axis allowlist (sub-org restriction). Only organization
+  // scope carries site restrictions (`organizationUsers.siteIds` via
+  // getUserPermissions); partner/system scope stay unrestricted (undefined).
+  // getUserPermissions is cached (and re-used by requirePermission downstream),
+  // so this warms the cache rather than adding a steady-state query.
+  let allowedSiteIds: string[] | undefined;
+  if (payload.scope === 'organization' && payload.orgId) {
+    const userPerms = await getUserPermissions(user.id, {
+      partnerId: payload.partnerId || undefined,
+      orgId: payload.orgId || undefined,
+    });
+    allowedSiteIds = userPerms?.allowedSiteIds;
+  }
+  const canAccessSite = siteAccessCheck(allowedSiteIds);
+
   await withDbAccessContext(
     {
       scope: payload.scope,
@@ -410,7 +446,9 @@ export async function authMiddleware(c: Context, next: Next): Promise<void | Res
         scope: payload.scope,
         accessibleOrgIds,
         orgCondition,
-        canAccessOrg
+        canAccessOrg,
+        allowedSiteIds,
+        canAccessSite
       });
 
       await next();

--- a/apps/api/src/routes/mcpServer.bearer.test.ts
+++ b/apps/api/src/routes/mcpServer.bearer.test.ts
@@ -55,6 +55,16 @@ vi.mock('../db/schema', () => ({
     orgAccess: 'partner_users.org_access',
     orgIds: 'partner_users.org_ids',
   },
+  // buildAuthFromApiKey now calls getUserPermissions for org keys (to inherit
+  // the creator's site allowlist), which reads organizationUsers + roles.
+  organizationUsers: {
+    userId: 'organization_users.user_id',
+    orgId: 'organization_users.org_id',
+    roleId: 'organization_users.role_id',
+    siteIds: 'organization_users.site_ids',
+  },
+  roles: { id: 'roles.id' },
+  permissions: {}, rolePermissions: {},
 }));
 
 vi.mock('../services/aiTools', () => ({
@@ -201,6 +211,28 @@ describe('mcpServer bearer auth routing', () => {
     // depend on the shim above; what matters is that the type changed so the
     // "no filter" fall-through path is closed.
     expect(Array.isArray(authArg?.accessibleOrgIds)).toBe(true);
+  });
+
+  it('attaches a site-axis closure to an org API key auth (inherits creator scope)', async () => {
+    // buildAuthFromApiKey for an org key now loads the creating user's
+    // permissions so the AI-tools site gate applies to MCP callers. The shared
+    // db shim returns an org-user row with no siteIds, i.e. an unrestricted
+    // creator — so canAccessSite must be present AND permit any site (the gate
+    // is a no-op for unrestricted callers, never a hard deny).
+    process.env.MCP_OAUTH_ENABLED = 'true';
+    mocks.getToolTier.mockReturnValue(1);
+    mocks.executeTool.mockResolvedValue('ok');
+
+    const res = await postToolsCall({ 'X-API-Key': 'brz_abc' });
+
+    expect(res.status).toBe(200);
+    const authArg = mocks.executeTool.mock.calls.at(-1)?.[2] as
+      | { scope?: string; canAccessSite?: (s: string | null) => boolean; allowedSiteIds?: string[] }
+      | undefined;
+    expect(authArg?.scope).toBe('organization');
+    expect(typeof authArg?.canAccessSite).toBe('function');
+    expect(authArg?.canAccessSite?.('any-site')).toBe(true);
+    expect(authArg?.allowedSiteIds).toBeUndefined();
   });
 
   it('never attributes the per-tool audit event to a client-supplied out-of-scope arguments.orgId (partner-scoped)', async () => {

--- a/apps/api/src/routes/mcpServer.streamable.test.ts
+++ b/apps/api/src/routes/mcpServer.streamable.test.ts
@@ -65,6 +65,23 @@ vi.mock('../db/schema', () => ({
   },
 }));
 
+// buildAuthFromApiKey now calls getUserPermissions for org keys (to inherit the
+// creator's site allowlist). Stub it to an unrestricted org perms object so the
+// transport tests don't need to model the permissions DB queries.
+vi.mock('../services/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/permissions')>();
+  return {
+    ...actual,
+    getUserPermissions: vi.fn(async () => ({
+      permissions: [],
+      partnerId: null,
+      orgId: 'org-1',
+      roleId: 'role-1',
+      scope: 'organization' as const,
+    })),
+  };
+});
+
 vi.mock('../services/aiTools', () => ({
   getToolDefinitions: mocks.getToolDefinitions,
   executeTool: mocks.executeTool,

--- a/apps/api/src/routes/mcpServer.test.ts
+++ b/apps/api/src/routes/mcpServer.test.ts
@@ -22,6 +22,24 @@ vi.mock('../db/schema', () => ({
   partners: { id: 'partners.id', billingEmail: 'partners.billingEmail' },
 }));
 
+// buildAuthFromApiKey now calls getUserPermissions for org keys (to inherit the
+// creator's site allowlist). Keep every real export the route graph needs and
+// stub only getUserPermissions to an unrestricted org perms object so these
+// transport/bootstrap tests don't need to model the permissions DB queries.
+vi.mock('../services/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/permissions')>();
+  return {
+    ...actual,
+    getUserPermissions: vi.fn(async () => ({
+      permissions: [],
+      partnerId: null,
+      orgId: 'org-1',
+      roleId: 'role-1',
+      scope: 'organization' as const,
+    })),
+  };
+});
+
 vi.mock('../services/aiTools', () => ({
   getToolDefinitions: () => [],
   executeTool: vi.fn(),

--- a/apps/api/src/routes/mcpServer.ts
+++ b/apps/api/src/routes/mcpServer.ts
@@ -29,6 +29,8 @@ import { devices, alerts, scripts, automations, partners, organizations, partner
 import { eq, and, asc, desc, inArray, getTableColumns, type SQL } from 'drizzle-orm';
 import type { PgColumn } from 'drizzle-orm/pg-core';
 import type { AuthContext } from '../middleware/auth';
+import { siteAccessCheck } from '../middleware/auth';
+import { getUserPermissions } from '../services/permissions';
 import { writeAuditEvent } from '../services/auditEvents';
 import { sanitizeAuditPayload, summarizePayload, summarizeToolResult } from '../services/auditPayloadSanitizer';
 import { compactToolResultForChat, redactAiToolOutputText } from '../services/aiToolOutput';
@@ -1509,6 +1511,15 @@ async function buildAuthFromApiKey(apiKey: {
   };
 
   if (apiKey.orgId) {
+    // A key inherits the CREATING user's access, including their site-axis
+    // restriction — it can never be broader than the user who minted it. Load
+    // the creator's allowedSiteIds for this org so the site gate (verifyDeviceAccess)
+    // applies to MCP/API-key callers exactly as it does to the JWT request path.
+    const creatorPerms = await getUserPermissions(apiKey.createdBy, {
+      partnerId: apiKey.partnerId || undefined,
+      orgId: apiKey.orgId,
+    });
+    const allowedSiteIds = creatorPerms?.allowedSiteIds;
     return {
       user,
       token: {} as AuthContext['token'],
@@ -1517,7 +1528,9 @@ async function buildAuthFromApiKey(apiKey: {
       scope: 'organization',
       accessibleOrgIds: [apiKey.orgId],
       orgCondition: (orgIdColumn) => eq(orgIdColumn, apiKey.orgId!),
-      canAccessOrg: (checkOrgId) => checkOrgId === apiKey.orgId
+      canAccessOrg: (checkOrgId) => checkOrgId === apiKey.orgId,
+      allowedSiteIds,
+      canAccessSite: siteAccessCheck(allowedSiteIds)
     };
   }
 

--- a/apps/api/src/services/aiTools.deviceAccessSiteScope.contract.test.ts
+++ b/apps/api/src/services/aiTools.deviceAccessSiteScope.contract.test.ts
@@ -64,6 +64,7 @@ describe('contract: AI-tools verifyDeviceAccess enforces the site axis', () => {
  */
 const SITE_GATED_NON_VERIFY_FILES = [
   'aiToolsVault.ts',
+  'aiToolsSecurity.ts',
   'aiToolsBackup.ts',
   'aiToolsBackupVm.ts',
   'aiToolsMssql.ts',

--- a/apps/api/src/services/aiTools.deviceAccessSiteScope.contract.test.ts
+++ b/apps/api/src/services/aiTools.deviceAccessSiteScope.contract.test.ts
@@ -44,3 +44,52 @@ describe('contract: AI-tools verifyDeviceAccess enforces the site axis', () => {
     });
   }
 });
+
+/**
+ * Contract: the device-touching AI-tool files that do NOT use the shared
+ * `verifyDeviceAccess` helper (they query the `devices` table / device-id-keyed
+ * tables org-only, or resolve a device indirectly via a VM/snapshot/alert) MUST
+ * still enforce the site axis. They do so by routing through the shared
+ * site-scope helpers in `aiToolsSiteScope.ts` (`deviceSiteDenied`,
+ * `deviceIdSiteDenied`, `resolveSiteAllowedDeviceIds`) or by referencing
+ * `canAccessSite` directly. This guards the class of bug where one of these
+ * files is edited/duplicated and silently drops site enforcement again.
+ *
+ * NOTE: this is an explicit per-file allowlist, not a generic static scanner
+ * that proves *every* `devices`-table query in the aiTools layer is site-gated.
+ * A full scanner (parse each handler, find every `from(devices)` /
+ * device-id-keyed read, assert a site gate dominates it) is a larger,
+ * AST-level effort and remains a FOLLOW-UP. Until then, newly added
+ * device-touching tools must be added to this list in the same PR.
+ */
+const SITE_GATED_NON_VERIFY_FILES = [
+  'aiToolsVault.ts',
+  'aiToolsBackup.ts',
+  'aiToolsBackupVm.ts',
+  'aiToolsMssql.ts',
+  'aiToolsHyperv.ts',
+  'aiToolsDevice.ts',
+  'aiToolsFleet.ts',
+  'aiToolsFleetStatus.ts',
+  'aiToolsAgentLogs.ts',
+  'aiToolsAlerts.ts',
+  'aiToolsBrowser.ts',
+];
+
+const SITE_GATE_MARKERS = [
+  'deviceSiteDenied',
+  'deviceIdSiteDenied',
+  'resolveSiteAllowedDeviceIds',
+  'canAccessSite',
+  'allowedSiteIds',
+];
+
+describe('contract: device-touching AI-tool files enforce the site axis', () => {
+  for (const file of SITE_GATED_NON_VERIFY_FILES) {
+    it(`${file}: references a site-axis gate (helper or canAccessSite)`, () => {
+      const source = readFileSync(join(SERVICES_DIR, file), 'utf8');
+      const hasGate = SITE_GATE_MARKERS.some((m) => source.includes(m));
+      expect(hasGate, `${file} must enforce the site axis via aiToolsSiteScope helpers or canAccessSite`).toBe(true);
+    });
+  }
+});

--- a/apps/api/src/services/aiTools.deviceAccessSiteScope.contract.test.ts
+++ b/apps/api/src/services/aiTools.deviceAccessSiteScope.contract.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Contract: every `verifyDeviceAccess` implementation in the AI-tools layer
+ * MUST enforce the site axis (not just org). The tool layer is a parallel path
+ * to the device-scoped tables; an org-only device gate lets a site-restricted
+ * user act on devices in forbidden sites (privilege escalation — incl. the
+ * mutating script/remote/filesystem tools). This guards against re-introducing
+ * an org-only copy when these files get duplicated (the root cause of the bug
+ * class). The site axis is enforced by referencing `canAccessSite` in the body.
+ */
+const SERVICES_DIR = __dirname;
+
+function verifyDeviceAccessBodies(source: string): string[] {
+  const bodies: string[] = [];
+  let idx = source.indexOf('function verifyDeviceAccess');
+  while (idx !== -1) {
+    // A copy is at most ~30 lines; 1000 chars comfortably spans its body.
+    bodies.push(source.slice(idx, idx + 1000));
+    idx = source.indexOf('function verifyDeviceAccess', idx + 1);
+  }
+  return bodies;
+}
+
+describe('contract: AI-tools verifyDeviceAccess enforces the site axis', () => {
+  const files = readdirSync(SERVICES_DIR).filter(
+    (f) => /^aiTools.*\.ts$/.test(f) && !f.includes('.test.'),
+  );
+
+  it('finds aiTools source files to scan', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  for (const file of files) {
+    const source = readFileSync(join(SERVICES_DIR, file), 'utf8');
+    const bodies = verifyDeviceAccessBodies(source);
+    if (bodies.length === 0) continue;
+    it(`${file}: every verifyDeviceAccess body references canAccessSite`, () => {
+      for (const body of bodies) {
+        expect(body).toContain('canAccessSite');
+      }
+    });
+  }
+});

--- a/apps/api/src/services/aiTools.ts
+++ b/apps/api/src/services/aiTools.ts
@@ -87,6 +87,10 @@ export async function verifyDeviceAccess(
   if (orgCond) conditions.push(orgCond);
   const [device] = await db.select().from(devices).where(and(...conditions)).limit(1);
   if (!device) return { error: 'Device not found or access denied' };
+  // Site axis: deny devices outside the caller's site allowlist (no-op when unrestricted).
+  if (auth.canAccessSite && !auth.canAccessSite(device.siteId)) {
+    return { error: 'Device not found or access denied' };
+  }
   if (requireOnline && device.status !== 'online') return { error: `Device ${device.hostname} is not online (status: ${device.status})` };
   return { device };
 }

--- a/apps/api/src/services/aiTools.verifyDeviceAccess.test.ts
+++ b/apps/api/src/services/aiTools.verifyDeviceAccess.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// aiTools.ts transitively imports commandQueue/db helpers, so the db mock must
+// expose the context helpers too (not just `db`).
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+import { db } from '../db';
+import { verifyDeviceAccess } from './aiTools';
+import type { AuthContext } from '../middleware/auth';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+
+function mockDeviceRow(row: Record<string, unknown> | undefined): void {
+  mockDb.select.mockReturnValue({
+    from: () => ({
+      where: () => ({
+        limit: () => Promise.resolve(row ? [row] : []),
+      }),
+    }),
+  });
+}
+
+// Mirrors how the request/MCP paths build the site axis onto AuthContext:
+// undefined allowlist => unrestricted; otherwise membership check, null site denied.
+function makeAuth(overrides?: Partial<AuthContext>): AuthContext {
+  const allowedSiteIds = overrides?.allowedSiteIds;
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any,
+    partnerId: null,
+    orgId: 'org-1',
+    scope: 'organization',
+    accessibleOrgIds: ['org-1'],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+    allowedSiteIds,
+    canAccessSite: (siteId: string | null | undefined) => {
+      if (!allowedSiteIds) return true;
+      if (!siteId) return false;
+      return allowedSiteIds.includes(siteId);
+    },
+    ...overrides,
+  };
+}
+
+describe('verifyDeviceAccess — site scoping', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('denies a device in a site outside the user site allowlist', async () => {
+    mockDeviceRow({ id: 'd1', orgId: 'org-1', siteId: 'site-B', hostname: 'h', status: 'online' });
+    const auth = makeAuth({ allowedSiteIds: ['site-A'] });
+    const result = await verifyDeviceAccess('d1', auth);
+    expect(result).toEqual({ error: 'Device not found or access denied' });
+  });
+
+  it('allows a device within the user site allowlist', async () => {
+    const row = { id: 'd1', orgId: 'org-1', siteId: 'site-A', hostname: 'h', status: 'online' };
+    mockDeviceRow(row);
+    const auth = makeAuth({ allowedSiteIds: ['site-A'] });
+    const result = await verifyDeviceAccess('d1', auth);
+    expect(result).toEqual({ device: row });
+  });
+
+  it('denies a device with no site assignment for a site-restricted user', async () => {
+    mockDeviceRow({ id: 'd1', orgId: 'org-1', siteId: null, hostname: 'h', status: 'online' });
+    const auth = makeAuth({ allowedSiteIds: ['site-A'] });
+    const result = await verifyDeviceAccess('d1', auth);
+    expect(result).toEqual({ error: 'Device not found or access denied' });
+  });
+
+  it('allows any site for an unrestricted user (no regression)', async () => {
+    const row = { id: 'd1', orgId: 'org-1', siteId: 'site-Z', hostname: 'h', status: 'online' };
+    mockDeviceRow(row);
+    const auth = makeAuth(); // allowedSiteIds undefined => unrestricted
+    const result = await verifyDeviceAccess('d1', auth);
+    expect(result).toEqual({ device: row });
+  });
+});

--- a/apps/api/src/services/aiToolsAgentLogs.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsAgentLogs.siteScope.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('./commandQueue', () => ({
+  queueCommandForExecution: vi.fn(async () => ({ command: { id: 'c1', status: 'sent' } })),
+}));
+vi.mock('./logRedaction', () => ({ redactAgentLogRow: (r: any) => ({ message: r.message, fields: r.fields }) }));
+
+import { db } from '../db';
+import { registerAgentLogTools } from './aiToolsAgentLogs';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerAgentLogTools(reg);
+  return reg.get(name)!.handler;
+}
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
+    accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds, canAccessSite: (s) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  };
+}
+
+describe('set_agent_log_level — site scoping (per-device write)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('denies a device in a forbidden site', async () => {
+    mockDb.select.mockReturnValue({ from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'd1', siteId: 'site-B' }]) }) }) });
+    const r = await handlerFor('set_agent_log_level')({ deviceId: 'd1', level: 'debug' }, makeAuth(['site-A']));
+    expect(r).toContain('access denied');
+  });
+
+  it('unrestricted caller is unaffected', async () => {
+    mockDb.select.mockReturnValue({ from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'd1', siteId: 'site-Z' }]) }) }) });
+    const r = await handlerFor('set_agent_log_level')({ deviceId: 'd1', level: 'debug' }, makeAuth(undefined));
+    expect(r).not.toContain('access denied');
+  });
+});
+
+describe('search_agent_logs — site narrowing (list)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns empty for a site-restricted caller with no in-scope devices, without reading logs', async () => {
+    let logRead = false;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      // resolveSiteAllowedDeviceIds selects { id, siteId }
+      if (cols && typeof cols === 'object' && 'id' in (cols as object) && 'siteId' in (cols as object)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd1', siteId: 'site-FORBIDDEN' }]) }) };
+      }
+      logRead = true;
+      return { from: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([]) }) }) }) };
+    });
+    const r = await handlerFor('search_agent_logs')({}, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.count).toBe(0);
+    expect(logRead).toBe(false);
+  });
+});

--- a/apps/api/src/services/aiToolsAgentLogs.ts
+++ b/apps/api/src/services/aiToolsAgentLogs.ts
@@ -13,6 +13,7 @@ import { escapeLike } from '../utils/sql';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { redactAgentLogRow } from './logRedaction';
+import { deviceSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -83,6 +84,17 @@ export function registerAgentLogTools(aiTools: Map<string, AiTool>): void {
 
         if (input.deviceIds && Array.isArray(input.deviceIds) && input.deviceIds.length > 0) {
           filters.push(inArray(agentLogs.deviceId, input.deviceIds as string[]));
+        }
+
+        // Site axis (app-layer only; RLS does NOT enforce it): a site-restricted
+        // caller may only read logs for devices in their allowed sites. Narrow to
+        // that device set; short-circuit to empty when there are none in scope.
+        if (auth.allowedSiteIds) {
+          const allowed = await resolveSiteAllowedDeviceIds(orgId, auth);
+          if (!allowed || allowed.length === 0) {
+            return JSON.stringify({ logs: [], count: 0 });
+          }
+          filters.push(inArray(agentLogs.deviceId, allowed));
         }
         if (input.level && typeof input.level === 'string') {
           filters.push(eq(agentLogs.level, input.level as any));
@@ -180,12 +192,16 @@ export function registerAgentLogTools(aiTools: Map<string, AiTool>): void {
 
         // Verify device belongs to the caller's organization
         const [device] = await db
-          .select({ id: devices.id })
+          .select({ id: devices.id, siteId: devices.siteId })
           .from(devices)
           .where(and(eq(devices.id, deviceId), eq(devices.orgId, orgId)))
           .limit(1);
 
         if (!device) {
+          return JSON.stringify({ error: 'Device not found or access denied' });
+        }
+        // Site axis (app-layer only; RLS does NOT enforce it).
+        if (deviceSiteDenied(auth, device.siteId)) {
           return JSON.stringify({ error: 'Device not found or access denied' });
         }
 

--- a/apps/api/src/services/aiToolsAgentMgmt.ts
+++ b/apps/api/src/services/aiToolsAgentMgmt.ts
@@ -24,6 +24,10 @@ async function verifyDeviceAccess(
   if (orgCond) conditions.push(orgCond);
   const [device] = await db.select().from(devices).where(and(...conditions)).limit(1);
   if (!device) return { error: 'Device not found or access denied' };
+  // Site axis: deny devices outside the caller's site allowlist (no-op when unrestricted).
+  if (auth.canAccessSite && !auth.canAccessSite(device.siteId)) {
+    return { error: 'Device not found or access denied' };
+  }
   if (requireOnline && device.status !== 'online') return { error: `Device ${device.hostname} is not online (status: ${device.status})` };
   return { device };
 }

--- a/apps/api/src/services/aiToolsAlerts.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsAlerts.siteScope.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('./eventBus', () => ({ publishEvent: vi.fn(async () => {}) }));
+
+import { db } from '../db';
+import { registerAlertTools } from './aiToolsAlerts';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> };
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerAlertTools(reg);
+  return reg.get(name)!.handler;
+}
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
+    accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds, canAccessSite: (s) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  };
+}
+
+describe('manage_alerts — per-alert site scoping', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('resolve denies an alert whose device is in a forbidden site (no update)', async () => {
+    let call = 0;
+    mockDb.select.mockImplementation(() => {
+      call++;
+      // 1: findAlertWithAccess -> alert row; 2: deviceIdSiteDenied -> { siteId }
+      if (call === 1) return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'a1', orgId: 'org-1', deviceId: 'd1', title: 'T' }]) }) }) };
+      return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ siteId: 'site-B' }]) }) }) };
+    });
+    mockDb.update.mockReturnValue({ set: () => ({ where: () => Promise.resolve() }) });
+    const r = await handlerFor('manage_alerts')({ action: 'resolve', alertId: 'a1' }, makeAuth(['site-A']));
+    expect(r).toContain('access denied');
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('get denies an alert whose device is in a forbidden site', async () => {
+    let call = 0;
+    mockDb.select.mockImplementation(() => {
+      call++;
+      if (call === 1) return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'a1', orgId: 'org-1', deviceId: 'd1', title: 'T' }]) }) }) };
+      return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ siteId: 'site-B' }]) }) }) };
+    });
+    const r = await handlerFor('manage_alerts')({ action: 'get', alertId: 'a1' }, makeAuth(['site-A']));
+    expect(r).toContain('access denied');
+  });
+
+  it('resolve unrestricted caller is unaffected', async () => {
+    mockDb.select.mockReturnValue({ from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'a1', orgId: 'org-1', deviceId: 'd1', title: 'T' }]) }) }) });
+    mockDb.update.mockReturnValue({ set: () => ({ where: () => Promise.resolve() }) });
+    const r = await handlerFor('manage_alerts')({ action: 'resolve', alertId: 'a1' }, makeAuth(undefined));
+    expect(r).not.toContain('access denied');
+    expect(mockDb.update).toHaveBeenCalled();
+  });
+});
+
+describe('manage_alerts list — site narrowing', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns empty for a site-restricted caller with no in-scope devices', async () => {
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (cols && typeof cols === 'object' && 'id' in (cols as object) && 'siteId' in (cols as object)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd1', siteId: 'site-FORBIDDEN' }]) }) };
+      }
+      return { from: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([]) }) }) }) };
+    });
+    const r = await handlerFor('manage_alerts')({ action: 'list' }, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.showing).toBe(0);
+    expect(parsed.total).toBe(0);
+  });
+});

--- a/apps/api/src/services/aiToolsAlerts.ts
+++ b/apps/api/src/services/aiToolsAlerts.ts
@@ -8,19 +8,29 @@
 
 import { db } from '../db';
 import { alerts, devices, notificationChannels } from '../db/schema';
-import { eq, and, desc, sql, SQL } from 'drizzle-orm';
+import { eq, and, desc, sql, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { publishEvent } from './eventBus';
+import { deviceIdSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
+function getOrgId(auth: AuthContext): string | null {
+  return auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
+}
+
+// Resolve an alert within org scope AND enforce the site axis (app-layer only;
+// RLS does NOT enforce site): the alert's device must be in a site the caller
+// can access. Returns null when not found or site-denied.
 async function findAlertWithAccess(alertId: string, auth: AuthContext) {
   const conditions: SQL[] = [eq(alerts.id, alertId)];
   const orgCond = auth.orgCondition(alerts.orgId);
   if (orgCond) conditions.push(orgCond);
   const [alert] = await db.select().from(alerts).where(and(...conditions)).limit(1);
-  return alert || null;
+  if (!alert) return null;
+  if (alert.deviceId && (await deviceIdSiteDenied(auth, alert.deviceId))) return null;
+  return alert;
 }
 
 export function registerAlertTools(aiTools: Map<string, AiTool>): void {
@@ -62,6 +72,20 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
         if (input.status) conditions.push(eq(alerts.status, input.status as typeof alerts.status.enumValues[number]));
         if (input.severity) conditions.push(eq(alerts.severity, input.severity as typeof alerts.severity.enumValues[number]));
         if (input.deviceId) conditions.push(eq(alerts.deviceId, input.deviceId as string));
+
+        // Site axis: a site-restricted caller may only see alerts for devices in
+        // their allowed sites (RLS does NOT enforce site). Narrow to that set.
+        const listOrgId = getOrgId(auth);
+        if (auth.allowedSiteIds && listOrgId) {
+          const allowed = await resolveSiteAllowedDeviceIds(listOrgId, auth);
+          if (!allowed || allowed.length === 0) {
+            return JSON.stringify({ alerts: [], total: 0, showing: 0 });
+          }
+          if (input.deviceId && !allowed.includes(input.deviceId as string)) {
+            return JSON.stringify({ alerts: [], total: 0, showing: 0 });
+          }
+          conditions.push(inArray(alerts.deviceId, allowed));
+        }
 
         const limit = Math.min(Math.max(1, Number(input.limit) || 25), 100);
 

--- a/apps/api/src/services/aiToolsAudit.ts
+++ b/apps/api/src/services/aiToolsAudit.ts
@@ -24,6 +24,10 @@ async function verifyDeviceAccess(
   if (orgCond) conditions.push(orgCond);
   const [device] = await db.select().from(devices).where(and(...conditions)).limit(1);
   if (!device) return { error: 'Device not found or access denied' };
+  // Site axis: deny devices outside the caller's site allowlist (no-op when unrestricted).
+  if (auth.canAccessSite && !auth.canAccessSite(device.siteId)) {
+    return { error: 'Device not found or access denied' };
+  }
   if (requireOnline && device.status !== 'online') return { error: `Device ${device.hostname} is not online (status: ${device.status})` };
   return { device };
 }

--- a/apps/api/src/services/aiToolsBackup.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsBackup.siteScope.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('./commandQueue', () => ({
+  CommandTypes: { BACKUP_RESTORE: 'backup_restore' },
+  queueCommandForExecution: vi.fn(async () => ({ command: { id: 'c1', status: 'sent' } })),
+}));
+vi.mock('./backupJobCreation', () => ({ createManualBackupJobIfIdle: vi.fn() }));
+vi.mock('../jobs/backupEnqueue', () => ({ enqueueBackupDispatch: vi.fn() }));
+
+import { db } from '../db';
+import { registerBackupTools } from './aiToolsBackup';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn>; insert: ReturnType<typeof vi.fn> };
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerBackupTools(reg);
+  const tool = reg.get(name);
+  if (!tool) throw new Error(`tool not registered: ${name}`);
+  return tool.handler;
+}
+
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any,
+    partnerId: null,
+    orgId: 'org-1',
+    scope: 'organization',
+    accessibleOrgIds: ['org-1'],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+    allowedSiteIds,
+    canAccessSite: (siteId) => (!allowedSiteIds ? true : !!siteId && allowedSiteIds.includes(siteId)),
+  };
+}
+
+// device lookups in backup select { id, ... , siteId }
+function deviceFirstThen(deviceRow: Record<string, unknown> | undefined, rest: () => unknown) {
+  let call = 0;
+  mockDb.select.mockImplementation(() => {
+    call++;
+    if (call === 1) return { from: () => ({ where: () => ({ limit: () => Promise.resolve(deviceRow ? [deviceRow] : []) }) }) };
+    return rest();
+  });
+}
+
+describe('backup tools — per-device site scoping', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('get_backup_status denies a device in a forbidden site', async () => {
+    deviceFirstThen({ id: 'd1', siteId: 'site-B' }, () => ({ from: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([]) }) }) }) }));
+    const result = await handlerFor('get_backup_status')({ deviceId: 'd1' }, makeAuth(['site-A']));
+    expect(result).toContain('access denied');
+  });
+
+  it('get_backup_status allows a device in an allowed site (unrestricted unaffected)', async () => {
+    // Subsequent queries (jobs/snapshots) have varied shapes; make a chainable
+    // thenable that resolves to [] regardless of orderBy/limit/where chaining.
+    const empty: any = Promise.resolve([]);
+    empty.where = () => empty; empty.orderBy = () => empty; empty.limit = () => empty; empty.from = () => empty;
+    deviceFirstThen({ id: 'd1', siteId: 'site-Z' }, () => ({ from: () => empty }));
+    const result = await handlerFor('get_backup_status')({ deviceId: 'd1' }, makeAuth(undefined));
+    const parsed = JSON.parse(result);
+    expect(parsed.deviceId).toBe('d1');
+  });
+
+  it('browse_snapshots denies a device in a forbidden site', async () => {
+    deviceFirstThen({ id: 'd1', hostname: 'h', siteId: 'site-B' }, () => ({ from: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([]) }) }) }) }));
+    const result = await handlerFor('browse_snapshots')({ deviceId: 'd1' }, makeAuth(['site-A']));
+    expect(result).toContain('access denied');
+  });
+
+  it('trigger_backup denies a device in a forbidden site', async () => {
+    deviceFirstThen({ id: 'd1', status: 'online', siteId: 'site-B' }, () => ({ from: () => ({ where: () => ({ limit: () => Promise.resolve([]) }) }) }));
+    const result = await handlerFor('trigger_backup')({ deviceId: 'd1', configId: 'cfg1' }, makeAuth(['site-A']));
+    expect(result).toContain('access denied');
+  });
+
+  it('restore_snapshot denies a device in a forbidden site', async () => {
+    deviceFirstThen({ id: 'd1', siteId: 'site-B' }, () => ({ from: () => ({ where: () => ({ limit: () => Promise.resolve([]) }) }) }));
+    const result = await handlerFor('restore_snapshot')({ snapshotId: 's1', deviceId: 'd1' }, makeAuth(['site-A']));
+    expect(result).toContain('access denied');
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/aiToolsBackup.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsBackup.siteScope.test.ts
@@ -92,3 +92,32 @@ describe('backup tools — per-device site scoping', () => {
     expect(mockDb.insert).not.toHaveBeenCalled();
   });
 });
+
+describe('query_backups list_jobs — site narrowing (device-keyed jobs)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller with no in-scope devices gets empty jobs, without scanning all jobs', async () => {
+    let jobsRan = false;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      // resolveSiteAllowedDeviceIds selects { id, siteId }
+      if (cols && typeof cols === 'object' && 'id' in (cols as object) && 'siteId' in (cols as object) && Object.keys(cols as object).length === 2) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd1', siteId: 'site-FORBIDDEN' }]) }) };
+      }
+      jobsRan = true;
+      return { from: () => ({ leftJoin: () => ({ leftJoin: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([{ id: 'job-leak' }]) }) }) }) }) }) };
+    });
+    const result = await handlerFor('query_backups')({ action: 'list_jobs' }, makeAuth(['site-A']));
+    const parsed = JSON.parse(result);
+    expect(parsed.showing).toBe(0);
+    expect(jobsRan).toBe(false);
+  });
+
+  it('unrestricted caller lists jobs normally (no regression)', async () => {
+    mockDb.select.mockImplementation(() => ({
+      from: () => ({ leftJoin: () => ({ leftJoin: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([{ id: 'job1' }]) }) }) }) }) }),
+    }));
+    const result = await handlerFor('query_backups')({ action: 'list_jobs' }, makeAuth(undefined));
+    const parsed = JSON.parse(result);
+    expect(parsed.showing).toBe(1);
+  });
+});

--- a/apps/api/src/services/aiToolsBackup.ts
+++ b/apps/api/src/services/aiToolsBackup.ts
@@ -24,6 +24,7 @@ import type { AiTool } from './aiTools';
 import { CommandTypes, queueCommandForExecution } from './commandQueue';
 import { createManualBackupJobIfIdle } from './backupJobCreation';
 import { enqueueBackupDispatch } from '../jobs/backupEnqueue';
+import { deviceSiteDenied } from './aiToolsSiteScope';
 
 type BackupHandler = (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
 
@@ -278,9 +279,11 @@ export function registerBackupTools(aiTools: Map<string, AiTool>): void {
         const deviceConditions: SQL[] = [eq(devices.id, deviceId)];
         const dc = orgWhere(auth, devices.orgId);
         if (dc) deviceConditions.push(dc);
-        const [device] = await db.select({ id: devices.id }).from(devices)
+        const [device] = await db.select({ id: devices.id, siteId: devices.siteId }).from(devices)
           .where(and(...deviceConditions)).limit(1);
         if (!device) return JSON.stringify({ error: 'Device not found or access denied' });
+        // Site axis (app-layer only; RLS does NOT enforce it).
+        if (deviceSiteDenied(auth, device.siteId)) return JSON.stringify({ error: 'Device not found or access denied' });
 
         // Latest backup job for device
         const jobOrgCond = orgWhere(auth, backupJobs.orgId);
@@ -404,11 +407,12 @@ export function registerBackupTools(aiTools: Map<string, AiTool>): void {
       const deviceConditions: SQL[] = [eq(devices.id, deviceId)];
       const dc = orgWhere(auth, devices.orgId);
       if (dc) deviceConditions.push(dc);
-      const [device] = await db.select({ id: devices.id, hostname: devices.hostname })
+      const [device] = await db.select({ id: devices.id, hostname: devices.hostname, siteId: devices.siteId })
         .from(devices)
         .where(and(...deviceConditions))
         .limit(1);
       if (!device) return JSON.stringify({ error: 'Device not found or access denied' });
+      if (deviceSiteDenied(auth, device.siteId)) return JSON.stringify({ error: 'Device not found or access denied' });
 
       const limit = Math.min(Math.max(1, Number(input.limit) || 25), 100);
       const snapshotOrgCond = orgWhere(auth, backupSnapshots.orgId);
@@ -474,9 +478,10 @@ export function registerBackupTools(aiTools: Map<string, AiTool>): void {
       const deviceConditions: SQL[] = [eq(devices.id, deviceId)];
       const dc = orgWhere(auth, devices.orgId);
       if (dc) deviceConditions.push(dc);
-      const [device] = await db.select({ id: devices.id, status: devices.status }).from(devices)
+      const [device] = await db.select({ id: devices.id, status: devices.status, siteId: devices.siteId }).from(devices)
         .where(and(...deviceConditions)).limit(1);
       if (!device) return JSON.stringify({ error: 'Device not found or access denied' });
+      if (deviceSiteDenied(auth, device.siteId)) return JSON.stringify({ error: 'Device not found or access denied' });
       if (device.status !== 'online') {
         return JSON.stringify({ error: `Device is ${device.status}, cannot execute backup` });
       }
@@ -570,9 +575,10 @@ export function registerBackupTools(aiTools: Map<string, AiTool>): void {
       const deviceConditions: SQL[] = [eq(devices.id, deviceId)];
       const dc = orgWhere(auth, devices.orgId);
       if (dc) deviceConditions.push(dc);
-      const [device] = await db.select({ id: devices.id }).from(devices)
+      const [device] = await db.select({ id: devices.id, siteId: devices.siteId }).from(devices)
         .where(and(...deviceConditions)).limit(1);
       if (!device) return JSON.stringify({ error: 'Device not found or access denied' });
+      if (deviceSiteDenied(auth, device.siteId)) return JSON.stringify({ error: 'Device not found or access denied' });
 
       // Verify snapshot exists and belongs to org (via orgId on snapshots table)
       const snapshotConditions: SQL[] = [eq(backupSnapshots.id, snapshotId)];

--- a/apps/api/src/services/aiToolsBackup.ts
+++ b/apps/api/src/services/aiToolsBackup.ts
@@ -24,7 +24,8 @@ import type { AiTool } from './aiTools';
 import { CommandTypes, queueCommandForExecution } from './commandQueue';
 import { createManualBackupJobIfIdle } from './backupJobCreation';
 import { enqueueBackupDispatch } from '../jobs/backupEnqueue';
-import { deviceSiteDenied } from './aiToolsSiteScope';
+import { deviceSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
+import { inArray } from 'drizzle-orm';
 
 type BackupHandler = (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
 
@@ -188,6 +189,21 @@ export function registerBackupTools(aiTools: Map<string, AiTool>): void {
         if (typeof input.status === 'string') conditions.push(eq(backupJobs.status, input.status as any));
         if (typeof input.deviceId === 'string') conditions.push(eq(backupJobs.deviceId, input.deviceId as string));
         if (typeof input.configId === 'string') conditions.push(eq(backupJobs.configId, input.configId as string));
+
+        // Site axis (app-layer only; RLS does NOT enforce it). backupJobs are
+        // device-keyed; a site-restricted caller may only see jobs for devices
+        // in their allowed sites. Narrow to that set (query_vaults pattern).
+        const orgId = getOrgId(auth);
+        if (auth.allowedSiteIds && orgId) {
+          const allowed = await resolveSiteAllowedDeviceIds(orgId, auth);
+          if (!allowed || allowed.length === 0) {
+            return JSON.stringify({ jobs: [], showing: 0 });
+          }
+          if (typeof input.deviceId === 'string' && !allowed.includes(input.deviceId)) {
+            return JSON.stringify({ jobs: [], showing: 0 });
+          }
+          conditions.push(inArray(backupJobs.deviceId, allowed));
+        }
 
         const rows = await db.select({
           id: backupJobs.id,

--- a/apps/api/src/services/aiToolsBackupVm.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsBackupVm.siteScope.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('./commandQueue', () => ({
+  CommandTypes: { VM_RESTORE_FROM_BACKUP: 'a', VM_INSTANT_BOOT: 'b' },
+  queueCommandForExecution: vi.fn(async () => ({ command: { id: 'c1', status: 'sent' } })),
+}));
+
+import { db } from '../db';
+import { registerBackupVmTools } from './aiToolsBackupVm';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn>; insert: ReturnType<typeof vi.fn> };
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerBackupVmTools(reg);
+  return reg.get(name)!.handler;
+}
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
+    accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds, canAccessSite: (s) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  };
+}
+// snapshot row first, then target device row { id, siteId }
+function snapThenDevice(deviceRow: Record<string, unknown> | undefined) {
+  let call = 0;
+  mockDb.select.mockImplementation(() => {
+    call++;
+    if (call === 1) return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 's1', orgId: 'org-1', snapshotId: 'ps' }]) }) }) };
+    return { from: () => ({ where: () => ({ limit: () => Promise.resolve(deviceRow ? [deviceRow] : []) }) }) };
+  });
+}
+
+describe('backupVm tools — site scoping', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('restore_as_vm denies a target device in a forbidden site', async () => {
+    snapThenDevice({ id: 'd1', siteId: 'site-B' });
+    const r = await handlerFor('restore_as_vm')({ snapshotId: 's1', targetDeviceId: 'd1', hypervisor: 'hyperv', vmName: 'VM' }, makeAuth(['site-A']));
+    expect(r).toContain('access denied');
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('instant_boot_vm denies a target device in a forbidden site', async () => {
+    snapThenDevice({ id: 'd1', siteId: 'site-B' });
+    const r = await handlerFor('instant_boot_vm')({ snapshotId: 's1', targetDeviceId: 'd1', vmName: 'VM' }, makeAuth(['site-A']));
+    expect(r).toContain('access denied');
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('restore_as_vm unrestricted caller is unaffected', async () => {
+    snapThenDevice({ id: 'd1', siteId: 'site-Z' });
+    (db as any).insert = vi.fn(() => ({ values: () => ({ returning: () => Promise.resolve([{ id: 'rj', status: 'pending', createdAt: new Date() }]) }) }));
+    (db as any).update = vi.fn(() => ({ set: () => ({ where: () => Promise.resolve() }) }));
+    const r = await handlerFor('restore_as_vm')({ snapshotId: 's1', targetDeviceId: 'd1', hypervisor: 'hyperv', vmName: 'VM' }, makeAuth(undefined));
+    expect(r).not.toContain('access denied');
+  });
+});

--- a/apps/api/src/services/aiToolsBackupVm.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsBackupVm.siteScope.test.ts
@@ -64,4 +64,25 @@ describe('backupVm tools — site scoping', () => {
     const r = await handlerFor('restore_as_vm')({ snapshotId: 's1', targetDeviceId: 'd1', hypervisor: 'hyperv', vmName: 'VM' }, makeAuth(undefined));
     expect(r).not.toContain('access denied');
   });
+
+  it('get_vm_restore_estimate denies when the snapshot device is in a forbidden site', async () => {
+    // snapshot row carries a deviceId; deviceIdSiteDenied then looks up its siteId.
+    let call = 0;
+    mockDb.select.mockImplementation(() => {
+      call++;
+      if (call === 1) return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 's1', size: 1024, metadata: {}, hardwareProfile: {}, deviceId: 'd1' }]) }) }) };
+      // deviceIdSiteDenied: device d1 lives in a forbidden site
+      return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ siteId: 'site-FORBIDDEN' }]) }) }) };
+    });
+    const r = await handlerFor('get_vm_restore_estimate')({ snapshotId: 's1' }, makeAuth(['site-A']));
+    expect(r).toContain('access denied');
+  });
+
+  it('get_vm_restore_estimate unrestricted caller is unaffected (no regression)', async () => {
+    mockDb.select.mockImplementation(() => ({ from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 's1', size: 1024, metadata: { platform: 'win' }, hardwareProfile: { cpuCores: 4 }, deviceId: 'd1' }]) }) }) }));
+    const r = await handlerFor('get_vm_restore_estimate')({ snapshotId: 's1' }, makeAuth(undefined));
+    expect(r).not.toContain('access denied');
+    const parsed = JSON.parse(r);
+    expect(parsed.recommendedCpu).toBe(4);
+  });
 });

--- a/apps/api/src/services/aiToolsBackupVm.ts
+++ b/apps/api/src/services/aiToolsBackupVm.ts
@@ -15,7 +15,7 @@ import { eq, and, sql, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { CommandTypes, queueCommandForExecution } from './commandQueue';
-import { deviceSiteDenied } from './aiToolsSiteScope';
+import { deviceSiteDenied, deviceIdSiteDenied } from './aiToolsSiteScope';
 
 type BackupHandler = (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
 
@@ -361,11 +361,18 @@ export function registerBackupVmTools(aiTools: Map<string, AiTool>): void {
           size: backupSnapshots.size,
           metadata: backupSnapshots.metadata,
           hardwareProfile: backupSnapshots.hardwareProfile,
+          deviceId: backupSnapshots.deviceId,
         })
         .from(backupSnapshots)
         .where(and(...snapshotConditions))
         .limit(1);
       if (!snapshot) return JSON.stringify({ error: 'Snapshot not found or access denied' });
+      // Site axis (app-layer only; RLS does NOT enforce it). The snapshot is
+      // device-keyed and this returns CPU/memory/disk/OS metadata — gate on the
+      // source device's site, matching the sibling verify_mssql_backup pattern.
+      if (await deviceIdSiteDenied(auth, snapshot.deviceId)) {
+        return JSON.stringify({ error: 'Snapshot not found or access denied' });
+      }
 
       const hardwareProfile = snapshot.hardwareProfile as {
         cpuCores?: number;

--- a/apps/api/src/services/aiToolsBackupVm.ts
+++ b/apps/api/src/services/aiToolsBackupVm.ts
@@ -15,6 +15,7 @@ import { eq, and, sql, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { CommandTypes, queueCommandForExecution } from './commandQueue';
+import { deviceSiteDenied } from './aiToolsSiteScope';
 
 type BackupHandler = (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
 
@@ -121,11 +122,13 @@ export function registerBackupVmTools(aiTools: Map<string, AiTool>): void {
       const dc = orgWhere(auth, devices.orgId);
       if (dc) deviceConditions.push(dc);
       const [targetDevice] = await db
-        .select({ id: devices.id })
+        .select({ id: devices.id, siteId: devices.siteId })
         .from(devices)
         .where(and(...deviceConditions))
         .limit(1);
       if (!targetDevice) return JSON.stringify({ error: 'Target device not found or access denied' });
+      // Site axis (app-layer only; RLS does NOT enforce it).
+      if (deviceSiteDenied(auth, targetDevice.siteId)) return JSON.stringify({ error: 'Target device not found or access denied' });
 
       const vmSpecs =
         input.vmSpecs && typeof input.vmSpecs === 'object'
@@ -252,11 +255,13 @@ export function registerBackupVmTools(aiTools: Map<string, AiTool>): void {
       const dc = orgWhere(auth, devices.orgId);
       if (dc) deviceConditions.push(dc);
       const [targetDevice] = await db
-        .select({ id: devices.id })
+        .select({ id: devices.id, siteId: devices.siteId })
         .from(devices)
         .where(and(...deviceConditions))
         .limit(1);
       if (!targetDevice) return JSON.stringify({ error: 'Target device not found or access denied' });
+      // Site axis (app-layer only; RLS does NOT enforce it).
+      if (deviceSiteDenied(auth, targetDevice.siteId)) return JSON.stringify({ error: 'Target device not found or access denied' });
 
       const vmSpecs =
         input.vmSpecs && typeof input.vmSpecs === 'object'

--- a/apps/api/src/services/aiToolsBrowser.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsBrowser.siteScope.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// aiToolsBrowser imports the db hub (which pulls commandQueue), so the db mock
+// must expose the context helpers too — same shape as aiTools.verifyDeviceAccess.test.ts.
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+
+import { db } from '../db';
+import { policyWithinSiteWriteScope, registerBrowserTools } from './aiToolsBrowser';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as {
+  select: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+};
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerBrowserTools(reg);
+  const tool = reg.get(name);
+  if (!tool) throw new Error(`tool not registered: ${name}`);
+  return tool.handler;
+}
+
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any,
+    partnerId: null,
+    orgId: 'org-1',
+    scope: 'organization',
+    accessibleOrgIds: ['org-1'],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+    allowedSiteIds,
+    canAccessSite: (siteId) => (!allowedSiteIds ? true : !!siteId && allowedSiteIds.includes(siteId)),
+  };
+}
+
+describe('policyWithinSiteWriteScope (AI-tools browser)', () => {
+  it('allows any policy for an unrestricted caller', () => {
+    expect(policyWithinSiteWriteScope(makeAuth(undefined), 'org', null)).toBe(true);
+    expect(policyWithinSiteWriteScope(makeAuth(undefined), 'site', ['site-Z'])).toBe(true);
+  });
+
+  it('denies non-site target types for a site-restricted caller', () => {
+    const auth = makeAuth(['site-A']);
+    expect(policyWithinSiteWriteScope(auth, 'org', null)).toBe(false);
+    expect(policyWithinSiteWriteScope(auth, 'group', ['g1'])).toBe(false);
+    expect(policyWithinSiteWriteScope(auth, 'device', ['d1'])).toBe(false);
+    expect(policyWithinSiteWriteScope(auth, 'tag', ['t1'])).toBe(false);
+  });
+
+  it('denies a site policy with an empty target list for a restricted caller', () => {
+    expect(policyWithinSiteWriteScope(makeAuth(['site-A']), 'site', [])).toBe(false);
+    expect(policyWithinSiteWriteScope(makeAuth(['site-A']), 'site', null)).toBe(false);
+  });
+
+  it('allows a site policy only when every target site is in the allowlist', () => {
+    const auth = makeAuth(['site-A', 'site-B']);
+    expect(policyWithinSiteWriteScope(auth, 'site', ['site-A'])).toBe(true);
+    expect(policyWithinSiteWriteScope(auth, 'site', ['site-A', 'site-B'])).toBe(true);
+    expect(policyWithinSiteWriteScope(auth, 'site', ['site-A', 'site-C'])).toBe(false);
+  });
+});
+
+describe('manage_browser_policy — site write scope (mutations)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('create: site-restricted caller cannot create an org-wide policy', async () => {
+    const handler = handlerFor('manage_browser_policy');
+    const result = await handler(
+      { action: 'create', name: 'P', targetType: 'org', targetIds: [] },
+      makeAuth(['site-A']),
+    );
+    expect(result).toContain('error');
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('create: site-restricted caller cannot target a forbidden site', async () => {
+    const handler = handlerFor('manage_browser_policy');
+    const result = await handler(
+      { action: 'create', name: 'P', targetType: 'site', targetIds: ['site-B'] },
+      makeAuth(['site-A']),
+    );
+    expect(result).toContain('error');
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('update: site-restricted caller cannot edit a policy outside their site scope', async () => {
+    mockDb.select.mockReturnValue({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'p1', orgId: 'org-1', targetType: 'org', targetIds: null }]) }) }),
+    });
+    const handler = handlerFor('manage_browser_policy');
+    const result = await handler(
+      { action: 'update', policyId: 'p1', name: 'X' },
+      makeAuth(['site-A']),
+    );
+    expect(result).toContain('error');
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('apply: site-restricted caller cannot apply a policy outside their site scope', async () => {
+    mockDb.select.mockReturnValue({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'p1', orgId: 'org-1', targetType: 'org', targetIds: null, isActive: true }]) }) }),
+    });
+    const handler = handlerFor('manage_browser_policy');
+    const result = await handler(
+      { action: 'apply', policyId: 'p1' },
+      makeAuth(['site-A']),
+    );
+    expect(result).toContain('error');
+  });
+
+  it('create: unrestricted caller is unaffected (org policy allowed)', async () => {
+    const returning = vi.fn(() => Promise.resolve([{ id: 'new', name: 'P' }]));
+    mockDb.insert.mockReturnValue({ values: () => ({ returning }) });
+    const handler = handlerFor('manage_browser_policy');
+    const result = await handler(
+      { action: 'create', name: 'P', targetType: 'org', targetIds: [] },
+      makeAuth(undefined),
+    );
+    expect(result).not.toContain('"error"');
+    expect(mockDb.insert).toHaveBeenCalled();
+  });
+});
+
+describe('get_browser_security — read site narrowing', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns empty results for a site-restricted caller with no in-scope devices, without querying extension rows', () => {
+    // The org-device lookup (resolveSiteAllowedDeviceIds) returns devices that
+    // are all in a forbidden site, so the allowed set is empty → the handler
+    // must short-circuit to zeros and never run the extension/violation reads.
+    let extensionQueryRan = false;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      // First call: the device lookup { id, siteId }.
+      if (!cols || (typeof cols === 'object' && 'id' in (cols as object) && 'siteId' in (cols as object))) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd1', siteId: 'site-FORBIDDEN' }]) }) };
+      }
+      extensionQueryRan = true;
+      return { from: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([]) }) }) }) };
+    });
+
+    const handler = handlerFor('get_browser_security');
+    return handler({ orgId: 'org-1' }, makeAuth(['site-A'])).then((result) => {
+      const parsed = JSON.parse(result);
+      expect(parsed.summary.total).toBe(0);
+      expect(parsed.extensions).toEqual([]);
+      expect(extensionQueryRan).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/services/aiToolsBrowser.ts
+++ b/apps/api/src/services/aiToolsBrowser.ts
@@ -51,6 +51,43 @@ function resolveWritableToolOrgId(
   return { error: 'orgId is required for this operation' };
 }
 
+// Resolve the device IDs a site-restricted caller may read within their org,
+// narrowed by `auth.allowedSiteIds`. Returns null when the caller is NOT
+// site-restricted (no narrowing needed). Site is an app-layer concept only —
+// Postgres RLS does NOT defend it — so a site-restricted org user must not read
+// extension/violation rows for devices in other sites within the same org.
+// Mirrors the route-layer browserSecurity.ts helper (AuthContext flavour).
+async function resolveSiteAllowedDeviceIds(
+  orgId: string,
+  auth: AuthContext,
+): Promise<string[] | null> {
+  if (!auth.allowedSiteIds || !auth.canAccessSite) return null;
+  const orgDevices = await db
+    .select({ id: devices.id, siteId: devices.siteId })
+    .from(devices)
+    .where(eq(devices.orgId, orgId));
+  return orgDevices
+    .filter((d) => auth.canAccessSite!(d.siteId))
+    .map((d) => d.id);
+}
+
+// A site-restricted caller may only mutate policies that target sites entirely
+// within their allowlist. Org/group/device/tag targets are not site-bounded, so
+// a site-restricted caller cannot confirm scope over them and is denied.
+// Unrestricted callers (no `allowedSiteIds`) always pass. Mirrors the
+// route-layer browserSecurity.ts helper (AuthContext flavour).
+export function policyWithinSiteWriteScope(
+  auth: AuthContext,
+  targetType: string,
+  targetIds: string[] | null | undefined,
+): boolean {
+  if (!auth.allowedSiteIds || !auth.canAccessSite) return true;
+  if (targetType !== 'site') return false;
+  const ids = targetIds ?? [];
+  if (ids.length === 0) return false;
+  return ids.every((id) => auth.canAccessSite!(id));
+}
+
 export function registerBrowserTools(aiTools: Map<string, AiTool>): void {
   function registerTool(tool: AiTool): void {
     aiTools.set(tool.definition.name, tool);
@@ -98,6 +135,27 @@ export function registerBrowserTools(aiTools: Map<string, AiTool>): void {
         conditions.push(eq(browserExtensions.riskLevel, input.riskLevel));
       }
 
+      // Site axis: a site-restricted caller may only read rows for devices in
+      // their allowed sites (RLS does NOT enforce site). Narrow both the
+      // extension and violation reads to that device set; short-circuit to empty
+      // when the caller has no in-scope devices.
+      const siteScopeOrgId = auth.orgId ?? (typeof input.orgId === 'string' ? input.orgId : null);
+      let siteAllowedDeviceIds: string[] | null = null;
+      if (auth.allowedSiteIds && siteScopeOrgId) {
+        siteAllowedDeviceIds = await resolveSiteAllowedDeviceIds(siteScopeOrgId, auth);
+        if (typeof input.deviceId === 'string' && !siteAllowedDeviceIds!.includes(input.deviceId)) {
+          return JSON.stringify({ error: 'Device not found or access denied' });
+        }
+        if (!siteAllowedDeviceIds || siteAllowedDeviceIds.length === 0) {
+          return JSON.stringify({
+            summary: { total: 0, low: 0, medium: 0, high: 0, critical: 0, sideloaded: 0 },
+            extensions: [],
+            violations: [],
+          });
+        }
+        conditions.push(inArray(browserExtensions.deviceId, siteAllowedDeviceIds));
+      }
+
       const where = conditions.length > 0 ? and(...conditions) : undefined;
       const limit = Math.min(Math.max(1, Number(input.limit) || 100), 500);
 
@@ -143,6 +201,8 @@ export function registerBrowserTools(aiTools: Map<string, AiTool>): void {
         if (violationOrgCondition) violationConditions.push(violationOrgCondition);
         if (typeof input.orgId === 'string') violationConditions.push(eq(browserPolicyViolations.orgId, input.orgId));
         if (typeof input.deviceId === 'string') violationConditions.push(eq(browserPolicyViolations.deviceId, input.deviceId));
+        // Same site-axis narrowing as the extension read above.
+        if (siteAllowedDeviceIds) violationConditions.push(inArray(browserPolicyViolations.deviceId, siteAllowedDeviceIds));
 
         const rows = await db
           .select({
@@ -248,6 +308,11 @@ export function registerBrowserTools(aiTools: Map<string, AiTool>): void {
         if (!['org', 'site', 'group', 'device', 'tag'].includes(targetType)) {
           return JSON.stringify({ error: 'targetType must be one of org|site|group|device|tag' });
         }
+        // Site axis: a site-restricted caller may only create policies that
+        // target sites entirely within their allowlist (never org/group/device/tag).
+        if (!policyWithinSiteWriteScope(auth, targetType, normalizeArray(input.targetIds))) {
+          return JSON.stringify({ error: 'Access denied: policy target is outside your site scope' });
+        }
 
         const [policy] = await db
           .insert(browserPolicies)
@@ -299,6 +364,18 @@ export function registerBrowserTools(aiTools: Map<string, AiTool>): void {
         if (!existing) {
           return JSON.stringify({ error: 'Policy not found or access denied' });
         }
+        // Site axis: a site-restricted caller may edit a policy only if it is
+        // already within their site scope, and may not retarget it outside.
+        if (!policyWithinSiteWriteScope(auth, existing.targetType, existing.targetIds)) {
+          return JSON.stringify({ error: 'Access denied: policy is outside your site scope' });
+        }
+        if (typeof input.targetType === 'string' || Array.isArray(input.targetIds)) {
+          const nextTargetType = typeof input.targetType === 'string' ? input.targetType : existing.targetType;
+          const nextTargetIds = Array.isArray(input.targetIds) ? normalizeArray(input.targetIds) : existing.targetIds;
+          if (!policyWithinSiteWriteScope(auth, nextTargetType, nextTargetIds)) {
+            return JSON.stringify({ error: 'Access denied: target is outside your site scope' });
+          }
+        }
 
         const [updated] = await db
           .update(browserPolicies)
@@ -345,6 +422,11 @@ export function registerBrowserTools(aiTools: Map<string, AiTool>): void {
           .limit(1);
         if (!policy) return JSON.stringify({ error: 'Policy not found or access denied' });
         if (!policy.isActive) return JSON.stringify({ error: 'Policy is inactive' });
+        // Site axis: a site-restricted caller may apply only policies within
+        // their site scope (org/group/device/tag-targeted policies are denied).
+        if (!policyWithinSiteWriteScope(auth, policy.targetType, policy.targetIds)) {
+          return JSON.stringify({ error: 'Access denied: policy is outside your site scope' });
+        }
 
         const requestedDeviceIds = normalizeArray(input.deviceIds);
         let targetDevices: Array<{ id: string; hostname: string }> = [];

--- a/apps/api/src/services/aiToolsCisBenchmark.ts
+++ b/apps/api/src/services/aiToolsCisBenchmark.ts
@@ -32,6 +32,10 @@ async function verifyDeviceAccess(
   if (orgCond) conditions.push(orgCond);
   const [device] = await db.select().from(devices).where(and(...conditions)).limit(1);
   if (!device) return { error: 'Device not found or access denied' };
+  // Site axis: deny devices outside the caller's site allowlist (no-op when unrestricted).
+  if (auth.canAccessSite && !auth.canAccessSite(device.siteId)) {
+    return { error: 'Device not found or access denied' };
+  }
   if (requireOnline && device.status !== 'online') return { error: `Device ${device.hostname} is not online (status: ${device.status})` };
   return { device };
 }

--- a/apps/api/src/services/aiToolsDevice.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsDevice.siteScope.test.ts
@@ -13,10 +13,12 @@ vi.mock('./brainDeviceContext', () => ({
 
 import { db } from '../db';
 import { registerDeviceTools } from './aiToolsDevice';
+import { createDeviceContext } from './brainDeviceContext';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 
 const mockDb = db as unknown as { select: ReturnType<typeof vi.fn>; execute: ReturnType<typeof vi.fn> };
+const createDeviceContextMock = createDeviceContext as unknown as ReturnType<typeof vi.fn>;
 function handlerFor(name: string): AiTool['handler'] {
   const reg = new Map<string, AiTool>();
   registerDeviceTools(reg);
@@ -61,6 +63,33 @@ describe('query_devices — site narrowing (cross-site enumeration)', () => {
     const r = await handlerFor('query_devices')({}, makeAuth(undefined));
     const parsed = JSON.parse(r);
     expect(parsed.showing).toBe(1);
+  });
+});
+
+describe('set_device_context — per-device site gating (write path)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('denies writing context for a device in a forbidden site, without calling createDeviceContext', async () => {
+    // verifyDeviceAccess does db.select().from(devices)...; the device exists in
+    // the org but lives in a forbidden site.
+    mockDb.select.mockReturnValue({ from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'd1', siteId: 'site-FORBIDDEN', status: 'online' }]) }) }) });
+    const r = await handlerFor('set_device_context')(
+      { deviceId: 'd1', contextType: 'issue', summary: 'note' },
+      makeAuth(['site-A']),
+    );
+    expect(r).toContain('access denied');
+    expect(createDeviceContextMock).not.toHaveBeenCalled();
+  });
+
+  it('unrestricted caller writes context normally (no regression)', async () => {
+    mockDb.select.mockReturnValue({ from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'd1', siteId: 'site-Z', status: 'online' }]) }) }) });
+    createDeviceContextMock.mockResolvedValue({ id: 'ctx-1' });
+    const r = await handlerFor('set_device_context')(
+      { deviceId: 'd1', contextType: 'issue', summary: 'note' },
+      makeAuth(undefined),
+    );
+    expect(r).not.toContain('access denied');
+    expect(createDeviceContextMock).toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/services/aiToolsDevice.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsDevice.siteScope.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn(), execute: vi.fn() },
+}));
+vi.mock('./brainDeviceContext', () => ({
+  getActiveDeviceContext: vi.fn(), getAllDeviceContext: vi.fn(),
+  createDeviceContext: vi.fn(), resolveDeviceContext: vi.fn(),
+}));
+
+import { db } from '../db';
+import { registerDeviceTools } from './aiToolsDevice';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn>; execute: ReturnType<typeof vi.fn> };
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerDeviceTools(reg);
+  return reg.get(name)!.handler;
+}
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
+    accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds, canAccessSite: (s) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  };
+}
+
+describe('query_devices — site narrowing (cross-site enumeration)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns empty for a site-restricted caller with no in-scope devices, without enumerating', async () => {
+    let listRan = false;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      // resolveSiteAllowedDeviceIds selects { id, siteId }
+      if (cols && typeof cols === 'object' && 'id' in (cols as object) && 'siteId' in (cols as object) && Object.keys(cols as object).length === 2) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd1', siteId: 'site-FORBIDDEN' }]) }) };
+      }
+      listRan = true;
+      return { from: () => ({ leftJoin: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([]) }) }) }) }) };
+    });
+    const r = await handlerFor('query_devices')({}, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.total).toBe(0);
+    expect(parsed.showing).toBe(0);
+    expect(listRan).toBe(false);
+  });
+
+  it('unrestricted caller enumerates normally (no regression)', async () => {
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (cols && typeof cols === 'object' && 'count' in (cols as object)) {
+        return { from: () => ({ where: () => Promise.resolve([{ count: 1 }]) }) };
+      }
+      return { from: () => ({ leftJoin: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([{ id: 'd1', hostname: 'h' }]) }) }) }) }) };
+    });
+    const r = await handlerFor('query_devices')({}, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.showing).toBe(1);
+  });
+});
+
+describe('manage_tags list — site narrowing (tag enumeration)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller with no in-scope devices gets no tags, without scanning all devices', async () => {
+    let executed = false;
+    mockDb.select.mockReturnValue({ from: () => ({ where: () => Promise.resolve([{ id: 'd1', siteId: 'site-FORBIDDEN' }]) }) });
+    mockDb.execute.mockImplementation(() => { executed = true; return Promise.resolve([]); });
+    const r = await handlerFor('manage_tags')({ action: 'list' }, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.total).toBe(0);
+    expect(executed).toBe(false);
+  });
+});

--- a/apps/api/src/services/aiToolsDevice.ts
+++ b/apps/api/src/services/aiToolsDevice.ts
@@ -21,11 +21,12 @@ import {
   sites,
   customFieldDefinitions,
 } from '../db/schema';
-import { eq, and, desc, sql, SQL } from 'drizzle-orm';
+import { eq, and, desc, sql, inArray, SQL } from 'drizzle-orm';
 import { escapeLike } from '../utils/sql';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { verifyDeviceAccess } from './aiTools';
+import { resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 import {
   getActiveDeviceContext,
   getAllDeviceContext,
@@ -76,6 +77,19 @@ export function registerDeviceTools(aiTools: Map<string, AiTool>): void {
         conditions.push(
           sql`(${devices.hostname} ILIKE ${searchPattern} OR ${devices.displayName} ILIKE ${searchPattern})`
         );
+      }
+
+      // Site axis (app-layer only; RLS does NOT enforce it): a site-restricted
+      // caller may only enumerate devices in their allowed sites. The optional
+      // `siteId` input is attacker-controlled (a filter, not a restriction), so
+      // narrow to the real allowed device set instead.
+      const queryOrgId = auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
+      if (auth.allowedSiteIds && queryOrgId) {
+        const allowed = await resolveSiteAllowedDeviceIds(queryOrgId, auth);
+        if (!allowed || allowed.length === 0) {
+          return JSON.stringify({ devices: [], total: 0, showing: 0 });
+        }
+        conditions.push(inArray(devices.id, allowed));
       }
 
       const limit = Math.min(Math.max(1, Number(input.limit) || 25), 100);
@@ -363,6 +377,17 @@ export function registerDeviceTools(aiTools: Map<string, AiTool>): void {
         const conditions: SQL[] = [];
         const orgCond = auth.orgCondition(devices.orgId);
         if (orgCond) conditions.push(orgCond);
+
+        // Site axis: a site-restricted caller may only enumerate tags from
+        // devices in their allowed sites (RLS does NOT enforce site).
+        const tagsOrgId = auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
+        if (auth.allowedSiteIds && tagsOrgId) {
+          const allowed = await resolveSiteAllowedDeviceIds(tagsOrgId, auth);
+          if (!allowed || allowed.length === 0) {
+            return JSON.stringify({ tags: [], total: 0 });
+          }
+          conditions.push(inArray(devices.id, allowed));
+        }
 
         const search = input.search as string | undefined;
         const whereClause = conditions.length > 0 ? and(...conditions) : sql`true`;

--- a/apps/api/src/services/aiToolsDevice.ts
+++ b/apps/api/src/services/aiToolsDevice.ts
@@ -295,6 +295,13 @@ export function registerDeviceTools(aiTools: Map<string, AiTool>): void {
         ? new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000)
         : undefined;
 
+      // Site axis (app-layer only; RLS does NOT enforce it). Gate the write the
+      // same way get_device_context gates the read — verifyDeviceAccess enforces
+      // both org and site. Without this a site-restricted caller could record
+      // context against an out-of-site device.
+      const access = await verifyDeviceAccess(deviceId, auth);
+      if ('error' in access) return JSON.stringify({ error: access.error });
+
       const result = await createDeviceContext(
         deviceId,
         contextType,

--- a/apps/api/src/services/aiToolsFilesystem.ts
+++ b/apps/api/src/services/aiToolsFilesystem.ts
@@ -32,6 +32,10 @@ async function verifyDeviceAccess(
   if (orgCond) conditions.push(orgCond);
   const [device] = await db.select().from(devices).where(and(...conditions)).limit(1);
   if (!device) return { error: 'Device not found or access denied' };
+  // Site axis: deny devices outside the caller's site allowlist (no-op when unrestricted).
+  if (auth.canAccessSite && !auth.canAccessSite(device.siteId)) {
+    return { error: 'Device not found or access denied' };
+  }
   if (requireOnline && device.status !== 'online') return { error: `Device ${device.hostname} is not online (status: ${device.status})` };
   return { device };
 }

--- a/apps/api/src/services/aiToolsFleet.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsFleet.siteScope.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn(), transaction: vi.fn() },
+}));
+
+import { db } from '../db';
+import { registerFleetTools } from './aiToolsFleet';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn>; insert: ReturnType<typeof vi.fn> };
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerFleetTools(reg);
+  return reg.get(name)!.handler;
+}
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
+    accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds, canAccessSite: (s) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  };
+}
+
+describe('manage_patches — per-device site scoping', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('install denies when a target device is owned but outside the caller site scope', async () => {
+    // ownedDevices returns the device (org match) WITH its real forbidden site —
+    // the site gate (not org ownership) must reject it. Proves the gate is live.
+    mockDb.select.mockReturnValue({
+      from: () => ({ where: () => Promise.resolve([{ id: 'd1', siteId: 'site-FORBIDDEN' }]) }),
+    });
+    const r = await handlerFor('manage_patches')({ action: 'install', patchIds: ['p1'], deviceIds: ['d1'] }, makeAuth(['site-A']));
+    expect(r).toContain('Access denied');
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('install allows an unrestricted caller (no regression)', async () => {
+    mockDb.select.mockReturnValue({ from: () => ({ where: () => Promise.resolve([{ id: 'd1', siteId: 'site-FORBIDDEN' }]) }) });
+    (db as any).insert = vi.fn(() => ({ values: () => ({ returning: () => Promise.resolve([{ id: 'job1' }]) }) }));
+    const r = await handlerFor('manage_patches')({ action: 'install', patchIds: ['p1'], deviceIds: ['d1'] }, makeAuth(undefined));
+    expect(r).not.toContain('Access denied');
+  });
+
+  it('rollback denies a device owned but outside the caller site scope', async () => {
+    // rollback selects { id, siteId } for the single device; site is forbidden.
+    mockDb.select.mockReturnValue({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'd1', siteId: 'site-FORBIDDEN' }]) }) }),
+    });
+    const r = await handlerFor('manage_patches')({ action: 'rollback', patchId: 'p1', deviceIds: ['d1'] }, makeAuth(['site-A']));
+    expect(r).toContain('access denied');
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+});
+
+describe('report data device_inventory — site narrowing', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller with no in-scope devices gets empty inventory', async () => {
+    let inventoryRan = false;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (cols && typeof cols === 'object' && 'id' in (cols as object) && 'siteId' in (cols as object) && Object.keys(cols as object).length === 2) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd1', siteId: 'site-FORBIDDEN' }]) }) };
+      }
+      inventoryRan = true;
+      return { from: () => ({ leftJoin: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([]) }) }) }) }) };
+    });
+    const r = await handlerFor('generate_report')({ action: 'data', reportType: 'device_inventory' }, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.showing).toBe(0);
+    expect(inventoryRan).toBe(false);
+  });
+});

--- a/apps/api/src/services/aiToolsFleet.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsFleet.siteScope.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+const { deleteSpy } = vi.hoisted(() => ({ deleteSpy: vi.fn() }));
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn: any) => fn()),
   withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
-  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn(), transaction: vi.fn() },
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: deleteSpy, transaction: vi.fn() },
 }));
 
 import { db } from '../db';
@@ -56,6 +57,64 @@ describe('manage_patches — per-device site scoping', () => {
     const r = await handlerFor('manage_patches')({ action: 'rollback', patchId: 'p1', deviceIds: ['d1'] }, makeAuth(['site-A']));
     expect(r).toContain('access denied');
     expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+});
+
+describe('manage_groups remove_devices — per-device site scoping', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('only removes in-scope devices; out-of-site device ids are excluded from the delete', async () => {
+    let call = 0;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      // 1st select: the group row (orgId)
+      if (call === 0) { call++; return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'g1', name: 'G', orgId: 'org-1' }]) }) }) }; }
+      // 2nd select: candidate devices { id, siteId }
+      return { from: () => ({ where: () => Promise.resolve([
+        { id: 'd-in', siteId: 'site-A' },
+        { id: 'd-out', siteId: 'site-FORBIDDEN' },
+      ]) }) };
+    });
+    let deletedIds: string[] | null = null;
+    deleteSpy.mockReturnValue({
+      where: (cond: any) => {
+        // Capture the device-id list the delete is scoped to by re-running the
+        // inArray against a probe. We can't introspect the SQL easily, so the
+        // handler must have narrowed the id list before building the condition.
+        return Promise.resolve();
+      },
+    });
+    // Spy on inArray indirectly: assert handler reports the skipped count.
+    const r = await handlerFor('manage_groups')({ action: 'remove_devices', groupId: 'g1', deviceIds: ['d-in', 'd-out'] }, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.success).toBe(true);
+    // out-of-site device must be reported as skipped (not silently removed)
+    expect(parsed.removed).toBe(1);
+    expect(parsed.skipped).toBe(1);
+  });
+
+  it('removes nothing (no delete) when all requested devices are out-of-site', async () => {
+    let call = 0;
+    mockDb.select.mockImplementation(() => {
+      if (call === 0) { call++; return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'g1', name: 'G', orgId: 'org-1' }]) }) }) }; }
+      return { from: () => ({ where: () => Promise.resolve([{ id: 'd-out', siteId: 'site-FORBIDDEN' }]) }) };
+    });
+    const r = await handlerFor('manage_groups')({ action: 'remove_devices', groupId: 'g1', deviceIds: ['d-out'] }, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.removed).toBe(0);
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it('unrestricted caller removes all requested devices (no regression)', async () => {
+    let call = 0;
+    mockDb.select.mockImplementation(() => {
+      if (call === 0) { call++; return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'g1', name: 'G', orgId: 'org-1' }]) }) }) }; }
+      return { from: () => ({ where: () => Promise.resolve([{ id: 'd1', siteId: 'site-Z' }, { id: 'd2', siteId: 'site-Y' }]) }) };
+    });
+    deleteSpy.mockReturnValue({ where: () => Promise.resolve() });
+    const r = await handlerFor('manage_groups')({ action: 'remove_devices', groupId: 'g1', deviceIds: ['d1', 'd2'] }, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.success).toBe(true);
+    expect(deleteSpy).toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/services/aiToolsFleet.ts
+++ b/apps/api/src/services/aiToolsFleet.ts
@@ -815,13 +815,28 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
         const [group] = await db.select().from(deviceGroups).where(and(...conditions)).limit(1);
         if (!group) return JSON.stringify({ error: 'Group not found or access denied' });
 
+        const requestedIds = (input.deviceIds as string[]).slice(0, 100);
+        // Only remove devices in the caller's site scope. Site is an app-layer
+        // axis (RLS does NOT enforce it) — mirror add_devices so a site-restricted
+        // caller can't mutate group membership for out-of-site devices.
+        const candidateRows = await db.select({ id: devices.id, siteId: devices.siteId })
+          .from(devices)
+          .where(and(eq(devices.orgId, group.orgId), inArray(devices.id, requestedIds)));
+        const removableIds = candidateRows
+          .filter((d) => !deviceSiteDenied(auth, d.siteId))
+          .map((d) => d.id);
+        const skipped = requestedIds.length - removableIds.length;
+        if (removableIds.length === 0) {
+          return JSON.stringify({ success: true, removed: 0, ...(skipped > 0 ? { skipped } : {}), message: 'No in-scope devices to remove' });
+        }
+
         await db.delete(deviceGroupMemberships)
           .where(and(
             eq(deviceGroupMemberships.groupId, group.id),
-            inArray(deviceGroupMemberships.deviceId, input.deviceIds as string[]),
+            inArray(deviceGroupMemberships.deviceId, removableIds),
           ));
 
-        return JSON.stringify({ success: true, message: `Device(s) removed from group "${group.name}"` });
+        return JSON.stringify({ success: true, removed: removableIds.length, ...(skipped > 0 ? { skipped } : {}), message: `Device(s) removed from group "${group.name}"${skipped > 0 ? ` (${skipped} skipped — outside org/site scope)` : ''}` });
       }
 
       return JSON.stringify({ error: `Unknown action: ${action}` });

--- a/apps/api/src/services/aiToolsFleet.ts
+++ b/apps/api/src/services/aiToolsFleet.ts
@@ -59,6 +59,7 @@ import { devices, sites } from '../db/schema';
 import { eq, and, desc, sql, inArray, gte, lte, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
+import { deviceSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -462,17 +463,21 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
         if (!Array.isArray(input.patchIds) || !Array.isArray(input.deviceIds)) return JSON.stringify({ error: 'patchIds and deviceIds are required' });
         if (!orgId) return JSON.stringify({ error: 'Organization context required' });
 
-        // Validate devices belong to this org
-        const ownedDevices = await db.select({ id: devices.id })
+        // Validate devices belong to this org AND the caller's site scope. Site
+        // is an app-layer axis (RLS does NOT enforce it), so a site-restricted
+        // caller installing patches must be denied for out-of-site devices.
+        const ownedDevices = await db.select({ id: devices.id, siteId: devices.siteId })
           .from(devices)
           .where(and(
             eq(devices.orgId, orgId),
             inArray(devices.id, input.deviceIds as string[]),
           ));
-        const ownedIds = new Set(ownedDevices.map((d) => d.id));
+        const ownedIds = new Set(
+          ownedDevices.filter((d) => !deviceSiteDenied(auth, d.siteId)).map((d) => d.id),
+        );
         const unauthorizedIds = (input.deviceIds as string[]).filter((id) => !ownedIds.has(id));
         if (unauthorizedIds.length > 0) {
-          return JSON.stringify({ error: `Access denied: ${unauthorizedIds.length} device(s) not in your organization` });
+          return JSON.stringify({ error: `Access denied: ${unauthorizedIds.length} device(s) not in your organization or site scope` });
         }
 
         const [job] = await db.insert(patchJobs).values({
@@ -496,11 +501,13 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
         if (!orgId) return JSON.stringify({ error: 'Organization context required' });
 
         // Validate device belongs to this org
-        const [device] = await db.select({ id: devices.id })
+        const [device] = await db.select({ id: devices.id, siteId: devices.siteId })
           .from(devices)
           .where(and(eq(devices.orgId, orgId), eq(devices.id, (input.deviceIds as string[])[0]!)))
           .limit(1);
         if (!device) return JSON.stringify({ error: 'Device not found or access denied' });
+        // Site axis (app-layer only; RLS does NOT enforce it).
+        if (deviceSiteDenied(auth, device.siteId)) return JSON.stringify({ error: 'Device not found or access denied' });
 
         const [rollback] = await db.insert(patchRollbacks).values({
           deviceId: device.id,
@@ -772,8 +779,20 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
         if (!group) return JSON.stringify({ error: 'Group not found or access denied' });
 
         const deviceIdList = (input.deviceIds as string[]).slice(0, 100);
+        // Only add devices that belong to the group's org AND are in the caller's
+        // site scope. Site is an app-layer axis (RLS does NOT enforce it), so
+        // restrict the membership write to in-scope, owned devices.
+        const candidateRows = await db.select({ id: devices.id, siteId: devices.siteId })
+          .from(devices)
+          .where(and(eq(devices.orgId, group.orgId), inArray(devices.id, deviceIdList)));
+        const insertableIds = candidateRows
+          .filter((d) => !deviceSiteDenied(auth, d.siteId))
+          .map((d) => d.id);
+        if (insertableIds.length === 0) {
+          return JSON.stringify({ success: true, added: 0, message: 'No in-scope devices to add' });
+        }
         const results = await db.insert(deviceGroupMemberships)
-          .values(deviceIdList.map((deviceId) => ({
+          .values(insertableIds.map((deviceId) => ({
             groupId: group.id,
             deviceId,
             orgId: group.orgId,
@@ -782,7 +801,8 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
           .onConflictDoNothing()
           .returning({ deviceId: deviceGroupMemberships.deviceId });
 
-        return JSON.stringify({ success: true, added: results.length, message: `${results.length} device(s) added to group "${group.name}"` });
+        const skipped = deviceIdList.length - insertableIds.length;
+        return JSON.stringify({ success: true, added: results.length, ...(skipped > 0 ? { skipped } : {}), message: `${results.length} device(s) added to group "${group.name}"${skipped > 0 ? ` (${skipped} skipped — outside org/site scope)` : ''}` });
       }
 
       if (action === 'remove_devices') {
@@ -1476,6 +1496,16 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
         const reportType = input.reportType as string;
 
         if (reportType === 'device_inventory') {
+          const inventoryConditions: SQL[] = [eq(devices.orgId, orgId)];
+          // Site axis: a site-restricted caller may only enumerate devices in
+          // their allowed sites (RLS does NOT enforce site).
+          if (auth.allowedSiteIds) {
+            const allowed = await resolveSiteAllowedDeviceIds(orgId, auth);
+            if (!allowed || allowed.length === 0) {
+              return JSON.stringify({ reportType, data: [], showing: 0 });
+            }
+            inventoryConditions.push(inArray(devices.id, allowed));
+          }
           const rows = await db.select({
             id: devices.id,
             hostname: devices.hostname,
@@ -1487,7 +1517,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
             siteName: sites.name,
           }).from(devices)
             .leftJoin(sites, eq(devices.siteId, sites.id))
-            .where(eq(devices.orgId, orgId))
+            .where(and(...inventoryConditions))
             .orderBy(desc(devices.lastSeenAt))
             .limit(limit);
 

--- a/apps/api/src/services/aiToolsFleetStatus.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsFleetStatus.siteScope.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+
+import { db } from '../db';
+import { registerFleetStatusTools } from './aiToolsFleetStatus';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerFleetStatusTools(reg);
+  return reg.get(name)!.handler;
+}
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: 'p1', orgId: null, scope: 'partner',
+    accessibleOrgIds: null, orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds, canAccessSite: (s) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  };
+}
+
+// invites select first, then device rows (which now include siteId).
+function invitesThenDevices(deviceRows: Array<Record<string, unknown>>) {
+  let call = 0;
+  mockDb.select.mockImplementation(() => {
+    call++;
+    if (call === 1) return { from: () => ({ where: () => Promise.resolve([
+      { id: 'i1', email: 'a@b.c', status: 'enrolled', clickedAt: new Date(), enrolledAt: new Date(), deviceId: 'd1' },
+    ]) }) };
+    return { from: () => ({ where: () => Promise.resolve(deviceRows) }) };
+  });
+}
+
+describe('get_fleet_status — site narrowing of enrolled devices', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('excludes enrolled devices in forbidden sites for a site-restricted caller', async () => {
+    invitesThenDevices([{ id: 'd1', hostname: 'h', osType: 'windows', status: 'online', orgId: 'org-1', siteId: 'site-B' }]);
+    const r = await handlerFor('get_fleet_status')({}, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.invite_funnel.devices_online).toBe(0);
+    expect(parsed.invite_funnel.recent_enrollments.every((e: any) => e.hostname === 'unknown' || e.hostname === undefined)).toBe(true);
+  });
+
+  it('unrestricted caller sees all enrolled devices (no regression)', async () => {
+    invitesThenDevices([{ id: 'd1', hostname: 'h', osType: 'windows', status: 'online', orgId: 'org-1', siteId: 'site-B' }]);
+    const r = await handlerFor('get_fleet_status')({}, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.invite_funnel.devices_online).toBe(1);
+  });
+});

--- a/apps/api/src/services/aiToolsFleetStatus.ts
+++ b/apps/api/src/services/aiToolsFleetStatus.ts
@@ -41,7 +41,10 @@ const RECENT_ENROLLMENTS_LIMIT = 10;
  * Compute the invite funnel for a partner. Exported so route/integration
  * tests can assert behavior directly without going through the aiTools dispatch.
  */
-export async function computeInviteFunnel(partnerId: string): Promise<InviteFunnel> {
+export async function computeInviteFunnel(
+  partnerId: string,
+  auth?: AuthContext,
+): Promise<InviteFunnel> {
   const invites = await db
     .select({
       id: deploymentInvites.id,
@@ -60,16 +63,12 @@ export async function computeInviteFunnel(partnerId: string): Promise<InviteFunn
   const invites_clicked = invites.filter(
     (i) => i.status === 'clicked' || i.status === 'enrolled' || i.clickedAt !== null,
   ).length;
-  const devices_enrolled = invites.filter(
-    (i) => i.status === 'enrolled' && i.deviceId !== null,
-  ).length;
-
   const enrolledWithDevice = invites.filter((i) => i.deviceId !== null);
   const deviceIds = enrolledWithDevice
     .map((i) => i.deviceId)
     .filter((x): x is string => typeof x === 'string');
 
-  const deviceRows = deviceIds.length === 0
+  const allDeviceRows = deviceIds.length === 0
     ? []
     : await db
         .select({
@@ -78,6 +77,7 @@ export async function computeInviteFunnel(partnerId: string): Promise<InviteFunn
           osType: devices.osType,
           status: devices.status,
           orgId: devices.orgId,
+          siteId: devices.siteId,
         })
         .from(devices)
         .where(
@@ -90,12 +90,28 @@ export async function computeInviteFunnel(partnerId: string): Promise<InviteFunn
           ),
         );
 
+  // Site axis (app-layer only; RLS does NOT enforce it): a site-restricted
+  // caller must not see enrolled devices in sites outside their allowlist.
+  // No-op for unrestricted callers (canAccessSite absent or returns true).
+  const deviceRows = auth?.canAccessSite
+    ? allDeviceRows.filter((d) => auth.canAccessSite!(d.siteId))
+    : allDeviceRows;
+
   const byDeviceId = new Map(deviceRows.map((d) => [d.id, d] as const));
+  // Enrolled count is the in-scope enrolled devices. For unrestricted callers
+  // deviceRows == allDeviceRows, so this matches prior behavior; for restricted
+  // callers it excludes out-of-site devices (fail closed).
+  const devices_enrolled = invites.filter(
+    (i) => i.status === 'enrolled' && i.deviceId !== null && byDeviceId.has(i.deviceId),
+  ).length;
   const devices_online = deviceRows.filter((d) => d.status === 'online').length;
   const devices_pending = deviceRows.filter((d) => d.status === 'pending').length;
 
   const recent_enrollments = enrolledWithDevice
     .filter((i) => i.enrolledAt !== null)
+    // Site-restricted callers: drop enrollments whose device is out of scope
+    // (filtered out of deviceRows) rather than surfacing an "unknown" stub.
+    .filter((i) => (auth?.canAccessSite ? byDeviceId.has(i.deviceId!) : true))
     .sort((a, b) => (b.enrolledAt?.getTime() ?? 0) - (a.enrolledAt?.getTime() ?? 0))
     .slice(0, RECENT_ENROLLMENTS_LIMIT)
     .map((i) => {
@@ -138,7 +154,7 @@ export function registerFleetStatusTools(aiTools: Map<string, AiTool>): void {
             error: 'get_fleet_status requires a partner-scoped API key',
           });
         }
-        const funnel = await computeInviteFunnel(auth.partnerId);
+        const funnel = await computeInviteFunnel(auth.partnerId, auth);
         return JSON.stringify({ invite_funnel: funnel });
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Internal error';

--- a/apps/api/src/services/aiToolsFleetStatus.ts
+++ b/apps/api/src/services/aiToolsFleetStatus.ts
@@ -98,11 +98,15 @@ export async function computeInviteFunnel(
     : allDeviceRows;
 
   const byDeviceId = new Map(deviceRows.map((d) => [d.id, d] as const));
-  // Enrolled count is the in-scope enrolled devices. For unrestricted callers
-  // deviceRows == allDeviceRows, so this matches prior behavior; for restricted
-  // callers it excludes out-of-site devices (fail closed).
+  // Enrolled count. Only a site-restricted caller narrows to in-scope devices
+  // (fail closed). Unrestricted callers keep prior behavior: an enrolled invite
+  // counts even if its device row is missing (e.g. the device was deleted after
+  // enrollment) — `byDeviceId.has` would wrongly drop that case.
   const devices_enrolled = invites.filter(
-    (i) => i.status === 'enrolled' && i.deviceId !== null && byDeviceId.has(i.deviceId),
+    (i) =>
+      i.status === 'enrolled' &&
+      i.deviceId !== null &&
+      (auth?.canAccessSite ? byDeviceId.has(i.deviceId) : true),
   ).length;
   const devices_online = deviceRows.filter((d) => d.status === 'online').length;
   const devices_pending = deviceRows.filter((d) => d.status === 'pending').length;

--- a/apps/api/src/services/aiToolsHyperv.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsHyperv.siteScope.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('./commandQueue', () => ({
+  CommandTypes: { HYPERV_VM_STATE: 'a', HYPERV_BACKUP: 'b', HYPERV_RESTORE: 'c', HYPERV_CHECKPOINT: 'd' },
+  queueCommandForExecution: vi.fn(async () => ({ command: { id: 'c1', status: 'sent' } })),
+}));
+vi.mock('./featureConfigResolver', () => ({ resolveBackupConfigForDevice: vi.fn(async () => ({ configId: 'cfg', featureLinkId: 'fl' })) }));
+
+import { db } from '../db';
+import { registerHypervTools } from './aiToolsHyperv';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerHypervTools(reg);
+  return reg.get(name)!.handler;
+}
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
+    accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds, canAccessSite: (s) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  };
+}
+// VM row first, then device { siteId } lookup.
+function vmThenDevice(vmRow: Record<string, unknown> | undefined, siteId: string | null) {
+  let call = 0;
+  mockDb.select.mockImplementation(() => {
+    call++;
+    if (call === 1) return { from: () => ({ leftJoin: () => ({ where: () => ({ limit: () => Promise.resolve(vmRow ? [vmRow] : []) }) }), where: () => ({ limit: () => Promise.resolve(vmRow ? [vmRow] : []) }) }) };
+    return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ siteId }]) }) }) };
+  });
+}
+
+describe('hyperv tools — site scoping', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('manage_hyperv_vm denies when VM host device is in a forbidden site', async () => {
+    vmThenDevice({ id: 'v1', orgId: 'org-1', deviceId: 'd1', vmName: 'VM', state: 'Running' }, 'site-B');
+    const r = await handlerFor('manage_hyperv_vm')({ vmId: 'v1', action: 'start' }, makeAuth(['site-A']));
+    expect(r).toContain('access denied');
+  });
+
+  it('trigger_hyperv_backup denies when VM host device is in a forbidden site', async () => {
+    vmThenDevice({ id: 'v1', orgId: 'org-1', deviceId: 'd1', vmName: 'VM', state: 'Running' }, 'site-B');
+    const r = await handlerFor('trigger_hyperv_backup')({ vmId: 'v1' }, makeAuth(['site-A']));
+    expect(r).toContain('access denied');
+  });
+
+  it('restore_hyperv_vm denies a target device in a forbidden site', async () => {
+    mockDb.select.mockReturnValue({ from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'd1', siteId: 'site-B' }]) }) }) });
+    const r = await handlerFor('restore_hyperv_vm')({ deviceId: 'd1', snapshotId: 's1' }, makeAuth(['site-A']));
+    expect(r).toContain('access denied');
+  });
+
+  it('manage_hyperv_vm unrestricted caller is unaffected', async () => {
+    vmThenDevice({ id: 'v1', orgId: 'org-1', deviceId: 'd1', vmName: 'VM', state: 'Running' }, 'site-Z');
+    const r = await handlerFor('manage_hyperv_vm')({ vmId: 'v1', action: 'start' }, makeAuth(undefined));
+    expect(r).not.toContain('access denied');
+  });
+});

--- a/apps/api/src/services/aiToolsHyperv.ts
+++ b/apps/api/src/services/aiToolsHyperv.ts
@@ -8,11 +8,16 @@
 
 import { db } from '../db';
 import { backupJobs, backupSnapshots, devices, hypervVms } from '../db/schema';
-import { eq, and, desc, SQL } from 'drizzle-orm';
+import { eq, and, desc, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { CommandTypes, queueCommandForExecution } from './commandQueue';
 import { resolveBackupConfigForDevice } from './featureConfigResolver';
+import { deviceSiteDenied, deviceIdSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
+
+function getOrgId(auth: AuthContext): string | null {
+  return auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
+}
 
 type HypervHandler = (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
 
@@ -59,7 +64,11 @@ async function loadVmWithAccess(vmId: string, auth: AuthContext) {
     .where(and(...vmConditions))
     .limit(1);
 
-  return vm ?? null;
+  if (!vm) return null;
+  // Site axis (app-layer only; RLS does NOT enforce it): the VM resolves to a
+  // host device that may be in a site outside a restricted caller's allowlist.
+  if (await deviceIdSiteDenied(auth, vm.deviceId)) return null;
+  return vm;
 }
 
 // ============================================
@@ -96,6 +105,15 @@ export function registerHypervTools(aiTools: Map<string, AiTool>): void {
       if (oc) conditions.push(oc);
       if (typeof input.deviceId === 'string') conditions.push(eq(hypervVms.deviceId, input.deviceId));
       if (typeof input.state === 'string') conditions.push(eq(hypervVms.state, input.state));
+
+      // Site axis: narrow to host devices in the caller's allowed sites.
+      const vmsOrgId = getOrgId(auth);
+      if (auth.allowedSiteIds && vmsOrgId) {
+        const allowed = await resolveSiteAllowedDeviceIds(vmsOrgId, auth);
+        if (!allowed || allowed.length === 0) return JSON.stringify({ vms: [], showing: 0 });
+        if (typeof input.deviceId === 'string' && !allowed.includes(input.deviceId)) return JSON.stringify({ vms: [], showing: 0 });
+        conditions.push(inArray(hypervVms.deviceId, allowed));
+      }
 
       const limit = clampLimit(input.limit);
       const rows = await db
@@ -183,6 +201,10 @@ export function registerHypervTools(aiTools: Map<string, AiTool>): void {
         .limit(1);
 
       if (!vm) return JSON.stringify({ error: 'VM not found or access denied' });
+      // Site axis: deny VM detail reads for a host device outside the caller's sites.
+      if (await deviceIdSiteDenied(auth, vm.deviceId)) {
+        return JSON.stringify({ error: 'VM not found or access denied' });
+      }
 
       return JSON.stringify({
         ...vm,
@@ -361,11 +383,12 @@ export function registerHypervTools(aiTools: Map<string, AiTool>): void {
       const dc = orgWhere(auth, devices.orgId);
       if (dc) deviceConditions.push(dc);
       const [device] = await db
-        .select({ id: devices.id })
+        .select({ id: devices.id, siteId: devices.siteId })
         .from(devices)
         .where(and(...deviceConditions))
         .limit(1);
       if (!device) return JSON.stringify({ error: 'Device not found or access denied' });
+      if (deviceSiteDenied(auth, device.siteId)) return JSON.stringify({ error: 'Device not found or access denied' });
 
       const snapshotConditions: SQL[] = [eq(backupSnapshots.id, snapshotId)];
       const sc = orgWhere(auth, backupSnapshots.orgId);

--- a/apps/api/src/services/aiToolsMssql.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsMssql.siteScope.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('./commandQueue', () => ({
+  CommandTypes: { MSSQL_BACKUP: 'mssql_backup', MSSQL_RESTORE: 'mssql_restore', MSSQL_VERIFY: 'mssql_verify' },
+  queueCommandForExecution: vi.fn(async () => ({ command: { id: 'c1', status: 'sent' } })),
+}));
+vi.mock('./featureConfigResolver', () => ({ resolveBackupConfigForDevice: vi.fn(async () => ({ configId: 'cfg', featureLinkId: 'fl' })) }));
+
+import { db } from '../db';
+import { registerMssqlTools } from './aiToolsMssql';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerMssqlTools(reg);
+  return reg.get(name)!.handler;
+}
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
+    accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds,
+    canAccessSite: (s) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  };
+}
+
+describe('mssql tools — site scoping', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('trigger_mssql_backup denies a device in a forbidden site', async () => {
+    mockDb.select.mockReturnValue({ from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'd1', orgId: 'org-1', siteId: 'site-B' }]) }) }) });
+    const r = await handlerFor('trigger_mssql_backup')({ deviceId: 'd1', instance: 'I', database: 'D' }, makeAuth(['site-A']));
+    expect(r).toContain('access denied');
+  });
+
+  it('restore_mssql_database denies a device in a forbidden site', async () => {
+    mockDb.select.mockReturnValue({ from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'd1', siteId: 'site-B' }]) }) }) });
+    const r = await handlerFor('restore_mssql_database')({ deviceId: 'd1', snapshotId: 's1', targetDatabase: 'D' }, makeAuth(['site-A']));
+    expect(r).toContain('access denied');
+  });
+
+  it('verify_mssql_backup denies when snapshot device is in a forbidden site', async () => {
+    let call = 0;
+    mockDb.select.mockImplementation(() => {
+      call++;
+      // 1: snapshot row; 2: deviceIdSiteDenied -> { siteId }
+      if (call === 1) return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 's1', deviceId: 'd1', providerSnapshotId: 'ps', metadata: { backupKind: 'mssql_database', backupFileName: 'f.bak' } }]) }) }) };
+      return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ siteId: 'site-B' }]) }) }) };
+    });
+    const r = await handlerFor('verify_mssql_backup')({ snapshotId: 's1' }, makeAuth(['site-A']));
+    expect(r).toContain('access denied');
+  });
+
+  it('trigger_mssql_backup unrestricted caller is unaffected', async () => {
+    mockDb.select.mockReturnValue({ from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'd1', orgId: 'org-1', siteId: 'site-Z' }]) }) }) });
+    (db as any).insert = vi.fn(() => ({ values: () => ({ returning: () => Promise.resolve([{ id: 'job1' }]) }) }));
+    const r = await handlerFor('trigger_mssql_backup')({ deviceId: 'd1', instance: 'I', database: 'D' }, makeAuth(undefined));
+    expect(r).not.toContain('access denied');
+  });
+});

--- a/apps/api/src/services/aiToolsMssql.ts
+++ b/apps/api/src/services/aiToolsMssql.ts
@@ -15,11 +15,16 @@ import {
   devices,
   sqlInstances,
 } from '../db/schema';
-import { eq, and, desc, SQL } from 'drizzle-orm';
+import { eq, and, desc, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { CommandTypes, queueCommandForExecution } from './commandQueue';
 import { resolveBackupConfigForDevice } from './featureConfigResolver';
+import { deviceSiteDenied, deviceIdSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
+
+function getOrgId(auth: AuthContext): string | null {
+  return auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
+}
 
 type MssqlHandler = (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
 
@@ -89,6 +94,15 @@ export function registerMssqlTools(aiTools: Map<string, AiTool>): void {
       if (typeof input.deviceId === 'string') conditions.push(eq(sqlInstances.deviceId, input.deviceId));
       if (typeof input.status === 'string') conditions.push(eq(sqlInstances.status, input.status));
 
+      // Site axis: narrow to devices in the caller's allowed sites.
+      const instOrgId = getOrgId(auth);
+      if (auth.allowedSiteIds && instOrgId) {
+        const allowed = await resolveSiteAllowedDeviceIds(instOrgId, auth);
+        if (!allowed || allowed.length === 0) return JSON.stringify({ instances: [], showing: 0 });
+        if (typeof input.deviceId === 'string' && !allowed.includes(input.deviceId)) return JSON.stringify({ instances: [], showing: 0 });
+        conditions.push(inArray(sqlInstances.deviceId, allowed));
+      }
+
       const limit = clampLimit(input.limit);
       const rows = await db
         .select({
@@ -147,6 +161,15 @@ export function registerMssqlTools(aiTools: Map<string, AiTool>): void {
       if (oc) conditions.push(oc);
       if (typeof input.deviceId === 'string') conditions.push(eq(backupChains.deviceId, input.deviceId));
       if (typeof input.database === 'string') conditions.push(eq(backupChains.targetName, input.database));
+
+      // Site axis: narrow to devices in the caller's allowed sites.
+      const chainOrgId = getOrgId(auth);
+      if (auth.allowedSiteIds && chainOrgId) {
+        const allowed = await resolveSiteAllowedDeviceIds(chainOrgId, auth);
+        if (!allowed || allowed.length === 0) return JSON.stringify({ chains: [], showing: 0 });
+        if (typeof input.deviceId === 'string' && !allowed.includes(input.deviceId)) return JSON.stringify({ chains: [], showing: 0 });
+        conditions.push(inArray(backupChains.deviceId, allowed));
+      }
 
       const limit = clampLimit(input.limit);
       const rows = await db
@@ -252,11 +275,13 @@ export function registerMssqlTools(aiTools: Map<string, AiTool>): void {
       const dc = orgWhere(auth, devices.orgId);
       if (dc) deviceConditions.push(dc);
       const [device] = await db
-        .select({ id: devices.id, orgId: devices.orgId })
+        .select({ id: devices.id, orgId: devices.orgId, siteId: devices.siteId })
         .from(devices)
         .where(and(...deviceConditions))
         .limit(1);
       if (!device) return JSON.stringify({ error: 'Device not found or access denied' });
+      // Site axis (app-layer only; RLS does NOT enforce it).
+      if (deviceSiteDenied(auth, device.siteId)) return JSON.stringify({ error: 'Device not found or access denied' });
 
       const resolvedConfig = await resolveBackupConfigForDevice(deviceId);
       if (!resolvedConfig?.configId) {
@@ -360,11 +385,12 @@ export function registerMssqlTools(aiTools: Map<string, AiTool>): void {
       const dc = orgWhere(auth, devices.orgId);
       if (dc) deviceConditions.push(dc);
       const [device] = await db
-        .select({ id: devices.id })
+        .select({ id: devices.id, siteId: devices.siteId })
         .from(devices)
         .where(and(...deviceConditions))
         .limit(1);
       if (!device) return JSON.stringify({ error: 'Device not found or access denied' });
+      if (deviceSiteDenied(auth, device.siteId)) return JSON.stringify({ error: 'Device not found or access denied' });
 
       const snapshotConditions: SQL[] = [eq(backupSnapshots.id, snapshotId)];
       const sc = orgWhere(auth, backupSnapshots.orgId);
@@ -473,6 +499,11 @@ export function registerMssqlTools(aiTools: Map<string, AiTool>): void {
         .where(and(...snapshotConditions))
         .limit(1);
       if (!snapshot) return JSON.stringify({ error: 'Snapshot not found or access denied' });
+      // Site axis: the snapshot resolves to a device; deny if it's in a site
+      // outside a restricted caller's allowlist (RLS does NOT enforce site).
+      if (await deviceIdSiteDenied(auth, snapshot.deviceId)) {
+        return JSON.stringify({ error: 'Snapshot not found or access denied' });
+      }
 
       const metadata =
         snapshot.metadata && typeof snapshot.metadata === 'object' && !Array.isArray(snapshot.metadata)

--- a/apps/api/src/services/aiToolsNetwork.ts
+++ b/apps/api/src/services/aiToolsNetwork.ts
@@ -55,6 +55,10 @@ async function verifyDeviceAccess(
   if (orgCond) conditions.push(orgCond);
   const [device] = await db.select().from(devices).where(and(...conditions)).limit(1);
   if (!device) return { error: 'Device not found or access denied' };
+  // Site axis: deny devices outside the caller's site allowlist (no-op when unrestricted).
+  if (auth.canAccessSite && !auth.canAccessSite(device.siteId)) {
+    return { error: 'Device not found or access denied' };
+  }
   if (requireOnline && device.status !== 'online') return { error: `Device ${device.hostname} is not online (status: ${device.status})` };
   return { device };
 }

--- a/apps/api/src/services/aiToolsPerformance.ts
+++ b/apps/api/src/services/aiToolsPerformance.ts
@@ -35,6 +35,10 @@ async function verifyDeviceAccess(
   if (orgCond) conditions.push(orgCond);
   const [device] = await db.select().from(devices).where(and(...conditions)).limit(1);
   if (!device) return { error: 'Device not found or access denied' };
+  // Site axis: deny devices outside the caller's site allowlist (no-op when unrestricted).
+  if (auth.canAccessSite && !auth.canAccessSite(device.siteId)) {
+    return { error: 'Device not found or access denied' };
+  }
   if (requireOnline && device.status !== 'online') return { error: `Device ${device.hostname} is not online (status: ${device.status})` };
   return { device };
 }

--- a/apps/api/src/services/aiToolsPlaybooks.ts
+++ b/apps/api/src/services/aiToolsPlaybooks.ts
@@ -30,6 +30,10 @@ async function verifyDeviceAccess(
   if (orgCond) conditions.push(orgCond);
   const [device] = await db.select().from(devices).where(and(...conditions)).limit(1);
   if (!device) return { error: 'Device not found or access denied' };
+  // Site axis: deny devices outside the caller's site allowlist (no-op when unrestricted).
+  if (auth.canAccessSite && !auth.canAccessSite(device.siteId)) {
+    return { error: 'Device not found or access denied' };
+  }
   if (requireOnline && device.status !== 'online') return { error: `Device ${device.hostname} is not online (status: ${device.status})` };
   return { device };
 }

--- a/apps/api/src/services/aiToolsRemote.ts
+++ b/apps/api/src/services/aiToolsRemote.ts
@@ -32,6 +32,10 @@ async function verifyDeviceAccess(
   if (orgCond) conditions.push(orgCond);
   const [device] = await db.select().from(devices).where(and(...conditions)).limit(1);
   if (!device) return { error: 'Device not found or access denied' };
+  // Site axis: deny devices outside the caller's site allowlist (no-op when unrestricted).
+  if (auth.canAccessSite && !auth.canAccessSite(device.siteId)) {
+    return { error: 'Device not found or access denied' };
+  }
   if (requireOnline && device.status !== 'online') return { error: `Device ${device.hostname} is not online (status: ${device.status})` };
   return { device };
 }

--- a/apps/api/src/services/aiToolsScripts.ts
+++ b/apps/api/src/services/aiToolsScripts.ts
@@ -56,6 +56,10 @@ async function verifyDeviceAccess(
   if (orgCond) conditions.push(orgCond);
   const [device] = await db.select().from(devices).where(and(...conditions)).limit(1);
   if (!device) return { error: 'Device not found or access denied' };
+  // Site axis: deny devices outside the caller's site allowlist (no-op when unrestricted).
+  if (auth.canAccessSite && !auth.canAccessSite(device.siteId)) {
+    return { error: 'Device not found or access denied' };
+  }
   if (requireOnline && device.status !== 'online') return { error: `Device ${device.hostname} is not online (status: ${device.status})` };
   return { device };
 }

--- a/apps/api/src/services/aiToolsSecurity.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsSecurity.siteScope.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+
+const { queueCommand } = vi.hoisted(() => ({ queueCommand: vi.fn(async () => ({ id: 'cmd-1', status: 'sent' })) }));
+vi.mock('./commandQueue', () => ({
+  queueCommand,
+  CommandTypes: { ENCRYPT_FILE: 'encrypt_file', QUARANTINE_FILE: 'quarantine_file', SECURE_DELETE_FILE: 'secure_delete_file' },
+}));
+vi.mock('./securityPosture', () => ({
+  getLatestSecurityPostureForDevice: vi.fn(),
+  listLatestSecurityPosture: vi.fn(),
+}));
+vi.mock('./eventBus', () => ({ publishEvent: vi.fn() }));
+vi.mock('./sensitiveDataKeys', () => ({
+  resolveSensitiveDataKeySelection: vi.fn(() => ({ keyRef: 'k', keyVersion: 'v', provider: 'p', keyFingerprint: 'f' })),
+}));
+
+import { db } from '../db';
+import { registerSecurityTools } from './aiToolsSecurity';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as {
+  select: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+};
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerSecurityTools(reg);
+  const tool = reg.get(name);
+  if (!tool) throw new Error(`tool not registered: ${name}`);
+  return tool.handler;
+}
+
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any,
+    partnerId: null,
+    orgId: 'org-1',
+    scope: 'organization',
+    accessibleOrgIds: ['org-1'],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+    allowedSiteIds,
+    canAccessSite: (s) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  };
+}
+
+// resolveSiteAllowedDeviceIds selects { id, siteId } from devices keyed by org.
+function selectAllowedDevices(rows: Array<{ id: string; siteId: string | null }>) {
+  return { from: () => ({ where: () => Promise.resolve(rows) }) };
+}
+
+describe('remediate_sensitive_data — site scoping (destructive device commands)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('denies the whole request when ANY requested finding is on an out-of-site device', async () => {
+    let call = 0;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      // First select: load findings by id (no siteId column).
+      if (cols && typeof cols === 'object' && 'filePath' in (cols as object)) {
+        return { from: () => ({ where: () => Promise.resolve([
+          { id: 'f1', orgId: 'org-1', deviceId: 'd-allowed', scanId: 's1', filePath: '/a', status: 'open' },
+          { id: 'f2', orgId: 'org-1', deviceId: 'd-forbidden', scanId: 's1', filePath: '/b', status: 'open' },
+        ]) }) };
+      }
+      call++;
+      // resolveSiteAllowedDeviceIds: d-allowed is in site-A, d-forbidden is not.
+      return selectAllowedDevices([
+        { id: 'd-allowed', siteId: 'site-A' },
+        { id: 'd-forbidden', siteId: 'site-FORBIDDEN' },
+      ]);
+    });
+    const r = await handlerFor('remediate_sensitive_data')(
+      { findingIds: ['f1', 'f2'], action: 'secure_delete', confirm: true },
+      makeAuth(['site-A']),
+    );
+    expect(r).toContain('access denied');
+    expect(queueCommand).not.toHaveBeenCalled();
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('unrestricted caller is unaffected (no regression)', async () => {
+    mockDb.select.mockImplementation(() => ({
+      from: () => ({ where: () => Promise.resolve([
+        { id: 'f1', orgId: 'org-1', deviceId: 'd1', scanId: 's1', filePath: '/a', status: 'open' },
+      ]) }),
+    }));
+    mockDb.update.mockReturnValue({ set: () => ({ where: () => Promise.resolve() }) });
+    const r = await handlerFor('remediate_sensitive_data')(
+      { findingIds: ['f1'], action: 'quarantine', confirm: true },
+      makeAuth(undefined),
+    );
+    expect(r).not.toContain('access denied');
+    expect(queueCommand).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('get_sensitive_data_overview — site narrowing (device-keyed PII reads)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('findings view: site-restricted caller with no in-scope devices gets empty results, without reading findings', async () => {
+    let findingsRead = false;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (cols && typeof cols === 'object' && 'id' in (cols as object) && 'siteId' in (cols as object) && Object.keys(cols as object).length === 2) {
+        // resolveSiteAllowedDeviceIds — all org devices are in a forbidden site.
+        return selectAllowedDevices([{ id: 'd1', siteId: 'site-FORBIDDEN' }]);
+      }
+      findingsRead = true;
+      return { from: () => ({ innerJoin: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([{ id: 'leak', filePath: '/secret' }]) }) }) }) }) };
+    });
+    const r = await handlerFor('get_sensitive_data_overview')({ view: 'findings' }, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.totalReturned).toBe(0);
+    expect(parsed.findings).toEqual([]);
+    expect(findingsRead).toBe(false);
+  });
+
+  it('scans view: site-restricted caller with no in-scope devices gets empty results', async () => {
+    let scansRead = false;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (cols && typeof cols === 'object' && 'id' in (cols as object) && 'siteId' in (cols as object) && Object.keys(cols as object).length === 2) {
+        return selectAllowedDevices([{ id: 'd1', siteId: 'site-FORBIDDEN' }]);
+      }
+      scansRead = true;
+      return { from: () => ({ innerJoin: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([{ id: 'scan', status: 'completed' }]) }) }) }) }) };
+    });
+    const r = await handlerFor('get_sensitive_data_overview')({ view: 'scans' }, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.totalReturned).toBe(0);
+    expect(scansRead).toBe(false);
+  });
+
+  it('unrestricted caller reads normally (no regression)', async () => {
+    mockDb.select.mockImplementation(() => ({
+      from: () => ({ innerJoin: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([{ id: 'leak', filePath: '/secret' }]) }) }) }) }),
+    }));
+    const r = await handlerFor('get_sensitive_data_overview')({ view: 'findings' }, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.totalReturned).toBe(1);
+  });
+});

--- a/apps/api/src/services/aiToolsSecurity.ts
+++ b/apps/api/src/services/aiToolsSecurity.ts
@@ -25,6 +25,11 @@ import {
 } from './securityPosture';
 import { publishEvent } from './eventBus';
 import { resolveSensitiveDataKeySelection } from './sensitiveDataKeys';
+import { resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
+
+function getOrgId(auth: AuthContext): string | null {
+  return auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
+}
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -273,10 +278,23 @@ export function registerSecurityTools(aiTools: Map<string, AiTool>): void {
       const view = (typeof input.view === 'string' ? input.view : 'dashboard') as 'dashboard' | 'findings' | 'scans';
       const limit = Math.min(Math.max(1, Number(input.limit) || 50), 200);
 
+      // Site axis (app-layer only; RLS does NOT enforce it). All reads here are
+      // device-keyed (scans/findings join devices and expose filePath of detected
+      // PII/credentials). Narrow every device-scoped read to the caller's site
+      // allowlist; an empty allowed set → empty results.
+      const orgId = getOrgId(auth);
+      const allowedDeviceIds = orgId ? await resolveSiteAllowedDeviceIds(orgId, auth) : null;
+      if (allowedDeviceIds !== null && allowedDeviceIds.length === 0) {
+        if (view === 'scans') return JSON.stringify({ view: 'scans', totalReturned: 0, byStatus: {}, scans: [] });
+        if (view === 'findings') return JSON.stringify({ view: 'findings', totalReturned: 0, findings: [] });
+        return JSON.stringify({ view: 'dashboard', totals: { findings: 0, open: 0, criticalOpen: 0, remediated24h: 0, averageOpenAgeHours: 0 }, byDataType: {}, byRisk: {} });
+      }
+
       if (view === 'scans') {
         const conditions: SQL[] = [];
         const orgCondition = auth.orgCondition(sensitiveDataScans.orgId);
         if (orgCondition) conditions.push(orgCondition);
+        if (allowedDeviceIds !== null) conditions.push(inArray(sensitiveDataScans.deviceId, allowedDeviceIds));
         if (typeof input.deviceId === 'string' && input.deviceId) {
           conditions.push(eq(sensitiveDataScans.deviceId, input.deviceId));
         }
@@ -319,6 +337,7 @@ export function registerSecurityTools(aiTools: Map<string, AiTool>): void {
       const findingConditions: SQL[] = [];
       const orgCondition = auth.orgCondition(sensitiveDataFindings.orgId);
       if (orgCondition) findingConditions.push(orgCondition);
+      if (allowedDeviceIds !== null) findingConditions.push(inArray(sensitiveDataFindings.deviceId, allowedDeviceIds));
       if (typeof input.status === 'string' && input.status) {
         findingConditions.push(eq(sensitiveDataFindings.status, input.status as 'open' | 'remediated' | 'accepted' | 'false_positive'));
       }
@@ -490,6 +509,24 @@ export function registerSecurityTools(aiTools: Map<string, AiTool>): void {
 
       if (findings.length === 0) {
         return JSON.stringify({ error: 'No findings found or access denied' });
+      }
+
+      // Site axis (app-layer only; RLS does NOT enforce it). This tool queues
+      // DESTRUCTIVE device commands (encrypt/quarantine/secure_delete) or status
+      // writes keyed on each finding's deviceId. A site-restricted caller must
+      // not touch findings on out-of-site devices. All-or-nothing (mirrors fleet
+      // patch install): if ANY requested finding is out-of-site, deny the whole
+      // request rather than acting on a partial set. Fail closed.
+      const remediateOrgId = getOrgId(auth);
+      const remediateAllowedDeviceIds = remediateOrgId
+        ? await resolveSiteAllowedDeviceIds(remediateOrgId, auth)
+        : null;
+      if (remediateAllowedDeviceIds !== null) {
+        const allowedSet = new Set(remediateAllowedDeviceIds);
+        const anyOutOfSite = findings.some((finding) => !finding.deviceId || !allowedSet.has(finding.deviceId));
+        if (anyOutOfSite) {
+          return JSON.stringify({ error: 'One or more findings are on devices outside your site scope — access denied' });
+        }
       }
 
       if (input.dryRun === true) {

--- a/apps/api/src/services/aiToolsSiteScope.ts
+++ b/apps/api/src/services/aiToolsSiteScope.ts
@@ -1,0 +1,80 @@
+/**
+ * AI Tools — shared site-axis (app-layer authz) helpers.
+ *
+ * Site is an app-layer authz axis — Postgres RLS does NOT defend it. Several
+ * device-touching AI tools read/act on devices scoped only by org, which lets a
+ * site-restricted chat/MCP caller (`auth.allowedSiteIds` set) reach devices in
+ * sites they lack access to. These helpers close that gap two ways:
+ *
+ *  - LIST/enumeration tools narrow their device set via
+ *    `resolveSiteAllowedDeviceIds` (mirrors aiToolsBrowser.ts) — return rows
+ *    only for in-scope devices instead of denying outright.
+ *  - Per-deviceId tools that resolve a device indirectly (via a VM record,
+ *    snapshot, alert, etc.) check the resolved device's `siteId` with
+ *    `deviceSiteDenied` BEFORE reading/acting on device-scoped data. Per-device
+ *    tools that look the device up by id directly should instead route through
+ *    the site-gated `verifyDeviceAccess` in aiTools.ts.
+ *
+ * All helpers are no-ops for unrestricted callers (`allowedSiteIds` undefined /
+ * no `canAccessSite`) — identical behavior, no regression.
+ */
+
+import { db } from '../db';
+import { devices } from '../db/schema';
+import { eq } from 'drizzle-orm';
+import type { AuthContext } from '../middleware/auth';
+
+/**
+ * Resolve the device IDs a site-restricted caller may read within `orgId`,
+ * narrowed by their site allowlist. Returns `null` when the caller is NOT
+ * site-restricted (no narrowing needed — callers should skip the inArray).
+ * A restricted caller with zero in-scope devices gets an empty array (caller
+ * should short-circuit to empty results).
+ */
+export async function resolveSiteAllowedDeviceIds(
+  orgId: string,
+  auth: AuthContext,
+): Promise<string[] | null> {
+  if (!auth.allowedSiteIds || !auth.canAccessSite) return null;
+  const orgDevices = await db
+    .select({ id: devices.id, siteId: devices.siteId })
+    .from(devices)
+    .where(eq(devices.orgId, orgId));
+  return orgDevices
+    .filter((d) => auth.canAccessSite!(d.siteId))
+    .map((d) => d.id);
+}
+
+/**
+ * True when a site-restricted caller must be denied access to a device with the
+ * given `siteId`. Fails closed: a null-site device is denied for a restricted
+ * caller. Always false (allow) for an unrestricted caller. Use this for tools
+ * that have already loaded a device row (with its siteId) by some other key.
+ */
+export function deviceSiteDenied(
+  auth: AuthContext,
+  siteId: string | null | undefined,
+): boolean {
+  if (!auth.canAccessSite) return false;
+  return !auth.canAccessSite(siteId);
+}
+
+/**
+ * Look up a device's `siteId` by id and return whether a site-restricted caller
+ * is denied. Used by tools that resolve a device indirectly (e.g. via a VM /
+ * snapshot / alert) and don't already have the device's site loaded. Returns
+ * `false` (allow) for unrestricted callers without querying.
+ */
+export async function deviceIdSiteDenied(
+  auth: AuthContext,
+  deviceId: string,
+): Promise<boolean> {
+  if (!auth.canAccessSite) return false;
+  const [row] = await db
+    .select({ siteId: devices.siteId })
+    .from(devices)
+    .where(eq(devices.id, deviceId))
+    .limit(1);
+  // Unknown device → deny for a restricted caller (fail closed).
+  return deviceSiteDenied(auth, row?.siteId ?? null);
+}

--- a/apps/api/src/services/aiToolsVault.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsVault.siteScope.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+
+vi.mock('./commandQueue', () => ({
+  CommandTypes: { VAULT_SYNC: 'vault_sync' },
+  queueCommandForExecution: vi.fn(async () => ({ command: { id: 'c1', status: 'sent' } })),
+}));
+
+import { db } from '../db';
+import { registerVaultTools } from './aiToolsVault';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as {
+  select: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+};
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerVaultTools(reg);
+  const tool = reg.get(name);
+  if (!tool) throw new Error(`tool not registered: ${name}`);
+  return tool.handler;
+}
+
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any,
+    partnerId: null,
+    orgId: 'org-1',
+    scope: 'organization',
+    accessibleOrgIds: ['org-1'],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+    allowedSiteIds,
+    canAccessSite: (siteId) => (!allowedSiteIds ? true : !!siteId && allowedSiteIds.includes(siteId)),
+  };
+}
+
+// Helper: stub a single-row device lookup { id, hostname, status, siteId, orgId }
+function stubDeviceRow(row: Record<string, unknown> | undefined) {
+  mockDb.select.mockReturnValue({
+    from: () => ({ where: () => ({ limit: () => Promise.resolve(row ? [row] : []) }) }),
+  });
+}
+
+describe('get_vault_status — site scoping (cross-site secret/device read)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('denies a device in a forbidden site for a site-restricted caller (no vault read)', async () => {
+    let vaultRead = false;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      // device lookup first
+      if (cols && typeof cols === 'object' && 'hostname' in (cols as object)) {
+        return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'd1', hostname: 'h', status: 'online', siteId: 'site-B' }]) }) }) };
+      }
+      vaultRead = true;
+      return { from: () => ({ where: () => ({ orderBy: () => Promise.resolve([]) }) }) };
+    });
+    const result = await handlerFor('get_vault_status')({ deviceId: 'd1' }, makeAuth(['site-A']));
+    expect(result).toContain('access denied');
+    expect(vaultRead).toBe(false);
+  });
+
+  it('allows a device within the site allowlist', async () => {
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (cols && typeof cols === 'object' && 'hostname' in (cols as object)) {
+        return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'd1', hostname: 'h', status: 'online', siteId: 'site-A' }]) }) }) };
+      }
+      return { from: () => ({ where: () => ({ orderBy: () => Promise.resolve([]) }) }) };
+    });
+    const result = await handlerFor('get_vault_status')({ deviceId: 'd1' }, makeAuth(['site-A']));
+    const parsed = JSON.parse(result);
+    expect(parsed.deviceId).toBe('d1');
+  });
+
+  it('unrestricted caller is unaffected (any site allowed)', async () => {
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (cols && typeof cols === 'object' && 'hostname' in (cols as object)) {
+        return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'd1', hostname: 'h', status: 'online', siteId: 'site-Z' }]) }) }) };
+      }
+      return { from: () => ({ where: () => ({ orderBy: () => Promise.resolve([]) }) }) };
+    });
+    const result = await handlerFor('get_vault_status')({ deviceId: 'd1' }, makeAuth(undefined));
+    const parsed = JSON.parse(result);
+    expect(parsed.deviceId).toBe('d1');
+  });
+});
+
+describe('trigger_vault_sync — site scoping (vault → device)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('denies a vault whose device is in a forbidden site', async () => {
+    // First select: vault row { id, deviceId, isActive }. Then deviceIdSiteDenied
+    // selects { siteId } for the device.
+    let call = 0;
+    mockDb.select.mockImplementation(() => {
+      call++;
+      if (call === 1) return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'v1', deviceId: 'd1', isActive: true }]) }) }) };
+      return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ siteId: 'site-B' }]) }) }) };
+    });
+    mockDb.update.mockReturnValue({ set: () => ({ where: () => Promise.resolve() }) });
+    const result = await handlerFor('trigger_vault_sync')({ vaultId: 'v1' }, makeAuth(['site-A']));
+    expect(result).toContain('access denied');
+  });
+
+  it('unrestricted caller is unaffected', async () => {
+    mockDb.select.mockReturnValue({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'v1', deviceId: 'd1', isActive: true }]) }) }),
+    });
+    mockDb.update.mockReturnValue({ set: () => ({ where: () => Promise.resolve() }) });
+    const result = await handlerFor('trigger_vault_sync')({ vaultId: 'v1' }, makeAuth(undefined));
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(true);
+  });
+});
+
+describe('configure_vault create — site scoping', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('denies creating a vault on a device in a forbidden site', async () => {
+    stubDeviceRow({ id: 'd1', orgId: 'org-1', siteId: 'site-B' });
+    const result = await handlerFor('configure_vault')(
+      { action: 'create', deviceId: 'd1', vaultPath: '/v' },
+      makeAuth(['site-A']),
+    );
+    expect(result).toContain('access denied');
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/aiToolsVault.ts
+++ b/apps/api/src/services/aiToolsVault.ts
@@ -8,10 +8,11 @@
 
 import { db } from '../db';
 import { devices, localVaults } from '../db/schema';
-import { eq, and, desc, SQL } from 'drizzle-orm';
+import { eq, and, desc, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { CommandTypes, queueCommandForExecution } from './commandQueue';
+import { deviceSiteDenied, deviceIdSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 
 type VaultHandler = (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
 
@@ -81,6 +82,20 @@ export function registerVaultTools(aiTools: Map<string, AiTool>): void {
       if (typeof input.isActive === 'boolean') conditions.push(eq(localVaults.isActive, input.isActive));
       if (typeof input.lastSyncStatus === 'string') conditions.push(eq(localVaults.lastSyncStatus, input.lastSyncStatus));
 
+      // Site axis: a site-restricted caller may only see vaults for devices in
+      // their allowed sites (RLS does NOT enforce site). Narrow to that set.
+      const orgId = getOrgId(auth);
+      if (auth.allowedSiteIds && orgId) {
+        const allowed = await resolveSiteAllowedDeviceIds(orgId, auth);
+        if (!allowed || allowed.length === 0) {
+          return JSON.stringify({ vaults: [], showing: 0 });
+        }
+        if (typeof input.deviceId === 'string' && !allowed.includes(input.deviceId)) {
+          return JSON.stringify({ vaults: [], showing: 0 });
+        }
+        conditions.push(inArray(localVaults.deviceId, allowed));
+      }
+
       const limit = clampLimit(input.limit);
       const rows = await db
         .select({
@@ -138,12 +153,18 @@ export function registerVaultTools(aiTools: Map<string, AiTool>): void {
           id: devices.id,
           hostname: devices.hostname,
           status: devices.status,
+          siteId: devices.siteId,
         })
         .from(devices)
         .where(and(...deviceConditions))
         .limit(1);
 
       if (!device) return JSON.stringify({ error: 'Device not found or access denied' });
+      // Site axis (app-layer only; RLS does NOT enforce it): deny vault/secret
+      // reads for devices outside a site-restricted caller's allowlist.
+      if (deviceSiteDenied(auth, device.siteId)) {
+        return JSON.stringify({ error: 'Device not found or access denied' });
+      }
 
       const vaultConditions: SQL[] = [eq(localVaults.deviceId, deviceId)];
       const vc = orgWhere(auth, localVaults.orgId);
@@ -228,6 +249,11 @@ export function registerVaultTools(aiTools: Map<string, AiTool>): void {
 
       if (!vault) return JSON.stringify({ error: 'Vault not found or access denied' });
       if (!vault.isActive) return JSON.stringify({ error: 'Vault is inactive' });
+      // Site axis: the vault is org-scoped, but the device it syncs may be in a
+      // site outside a restricted caller's allowlist — deny before dispatch.
+      if (await deviceIdSiteDenied(auth, vault.deviceId)) {
+        return JSON.stringify({ error: 'Vault not found or access denied' });
+      }
 
       await db
         .update(localVaults)
@@ -317,12 +343,17 @@ export function registerVaultTools(aiTools: Map<string, AiTool>): void {
           .select({
             id: devices.id,
             orgId: devices.orgId,
+            siteId: devices.siteId,
           })
           .from(devices)
           .where(and(...deviceConditions))
           .limit(1);
 
         if (!device) return JSON.stringify({ error: 'Device not found or access denied' });
+        // Site axis: deny creating a vault on a device outside the caller's sites.
+        if (deviceSiteDenied(auth, device.siteId)) {
+          return JSON.stringify({ error: 'Device not found or access denied' });
+        }
 
         const now = new Date();
         const [vault] = await db
@@ -350,12 +381,16 @@ export function registerVaultTools(aiTools: Map<string, AiTool>): void {
         const vc = orgWhere(auth, localVaults.orgId);
         if (vc) vaultConditions.push(vc);
         const [existing] = await db
-          .select({ id: localVaults.id })
+          .select({ id: localVaults.id, deviceId: localVaults.deviceId })
           .from(localVaults)
           .where(and(...vaultConditions))
           .limit(1);
 
         if (!existing) return JSON.stringify({ error: 'Vault not found or access denied' });
+        // Site axis: deny editing a vault whose device is outside the caller's sites.
+        if (await deviceIdSiteDenied(auth, existing.deviceId)) {
+          return JSON.stringify({ error: 'Vault not found or access denied' });
+        }
 
         const updateData: Record<string, unknown> = { updatedAt: new Date() };
         if (typeof input.vaultPath === 'string') updateData.vaultPath = input.vaultPath;


### PR DESCRIPTION
## Problem

The route layer enforces the site axis (`permissions.allowedSiteIds`), but the **AI-agent tool layer was a parallel path to the same device-scoped tables and enforced only the org axis**. A site-restricted org user (scoped to specific sites via `organizationUsers.siteIds`) could, through the AI chat / MCP tools, act on devices in sites they're forbidden from.

Severity is higher than the route reads because the tool set includes **mutations on devices** — `run_script`, remote desktop/terminal, filesystem read/write/execute — so this is privilege-escalation / RCE-class, not just information disclosure.

Reachability: the AI chat endpoint requires `organizations:write` + MFA, which is orthogonal to site restriction. The same `AuthContext` flows JWT path → streaming/SDK tool wrapper → `executeTool` → tool handler → `verifyDeviceAccess` (previously org-only). The MCP API-key path was the same.

Plan: `docs/superpowers/plans/2026-05-31-ai-tools-site-scope.md`.

## Fix (4 commits)

1. **Gate machinery** (`3cae0f7d`) — adds optional `allowedSiteIds` + `canAccessSite(siteId)` to `AuthContext` (purely additive; undefined allowlist = unrestricted). Wires the site gate into the shared `verifyDeviceAccess` **and all 9 per-file copies** (agentMgmt, audit, cisBenchmark, filesystem, network, performance, playbooks, remote, scripts). A **contract test** asserts every `aiTools*.ts` `verifyDeviceAccess` body references `canAccessSite`, preventing re-introduction of an org-only copy (it caught a 9th copy mid-implementation).

2. **Request-path population** (`1202f8af`) — `authMiddleware` resolves the site allowlist for organization-scope users via the (cached) `getUserPermissions` and attaches `allowedSiteIds` + `canAccessSite`. Introduces `siteAccessCheck()` as the single source of truth for the closure. Partner/system scope stay unrestricted.

3. **MCP API-key path** (`af39f703`) — `buildAuthFromApiKey` for an org key now inherits the **creating user's** `allowedSiteIds`. A key is a principal scoped to one user with that user's exact access — never broader.

4. **Browser direct-query tools** (`61ba994a`) — `aiToolsBrowser.ts` queries device/policy tables directly (not via `verifyDeviceAccess`), so it gets its own enforcement. **Reads** (`get_browser_security`) narrow the extension + violation queries to the caller's in-scope devices (`resolveSiteAllowedDeviceIds`), short-circuiting to empty when none. **Policy mutations** (`manage_browser_policy` create/update/apply) gate on `policyWithinSiteWriteScope`: `browser_policies` has no `siteId` column (it targets via `targetType`/`targetIds`), so a site-restricted caller may only write `targetType==='site'` policies whose every target site is in their allowlist; org/group/device/tag targets are denied. Mirrors the route-layer `browserSecurity.ts` semantics, self-contained in the service layer.

The streaming/SDK path needed no passthrough changes — `executeTool` passes the full `auth` object straight to handlers, so the new fields ride along unmodified.

## Verification

- aiTools suite (456), middleware/auth (49 + 4), all mcpServer suites — green; `tsc --noEmit` clean (0 errors).
- New tests: 4 chokepoint + 10 contract (gate), 4 `siteAccessCheck`, 3 MCP key inheritance/coverage, 10 browser (helper truth table + mutation write-scope denials + read short-circuit).
- Each slice was RED-first TDD and verified before commit.

## Notes / follow-ups

- Optional backstop: extend the input-sourced site-scope scanner to also walk `services/aiTools*.ts`. The new contract test already guards the `verifyDeviceAccess` copies.
- Service-principal idea (deferred): model an API key as a dedicated principal carrying its own scope record rather than re-deriving the creator's perms per request.

Stacked on #1042 (`fix/site-scope-reads`); merge bottom-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)