### PR TITLE
fix(security): cross-org device dispatch via incident AI tools (execute_containment / collect_evidence)

### DIFF
--- a/apps/api/src/services/aiToolsIncident.test.ts
+++ b/apps/api/src/services/aiToolsIncident.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Regression guard for a cross-org device-dispatch hole (verified 2026-05-31):
+ * `execute_containment` and `collect_evidence` validated only the incident's
+ * org, then passed an attacker-controlled `input.deviceId` straight to
+ * `queueCommandForExecution`, which resolves the device by id with NO tenant
+ * filter. A user with an incident in their own org could therefore run
+ * containment actions / forensic capture on ANY device in ANY org by id.
+ *
+ * The fix routes `input.deviceId` through the shared `verifyDeviceAccess`
+ * gate (org-scoped) before dispatch — the same gate every sibling AI tool
+ * uses. These tests assert the handler consults the gate and refuses to
+ * dispatch when the device is not accessible.
+ */
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('./commandQueue', () => ({
+  queueCommandForExecution: vi.fn(),
+}));
+
+vi.mock('./eventBus', () => ({
+  publishEvent: vi.fn(async () => undefined),
+}));
+
+// The device gate is a separately-tested collaborator
+// (aiTools.verifyDeviceAccess.test.ts). Mock it so we can drive the
+// accessible / not-accessible verdicts and assert the handler's control flow.
+vi.mock('./aiTools', () => ({
+  resolveWritableToolOrgId: vi.fn(() => ORG_ID),
+  verifyDeviceAccess: vi.fn(),
+}));
+
+import { db } from '../db';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+import { verifyDeviceAccess } from './aiTools';
+import { queueCommandForExecution } from './commandQueue';
+import { registerIncidentTools } from './aiToolsIncident';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const INCIDENT_ID = '22222222-2222-2222-2222-222222222222';
+const OWN_DEVICE_ID = '33333333-3333-3333-3333-333333333333';
+const FOREIGN_DEVICE_ID = '99999999-9999-9999-9999-999999999999';
+
+function createQueryChain(rows: any[] = []) {
+  const chain: any = {};
+  chain.from = vi.fn(() => chain);
+  chain.leftJoin = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.then = (resolve: (value: any[]) => unknown, reject?: (error: unknown) => unknown) =>
+    Promise.resolve(rows).then(resolve, reject);
+  return chain;
+}
+
+function createInsertChain(rows: any[] = []) {
+  const chain: any = {};
+  chain.values = vi.fn(() => chain);
+  chain.returning = vi.fn(() => Promise.resolve(rows));
+  return chain;
+}
+
+function makeAuth(): AuthContext {
+  return {
+    user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+    token: {} as any,
+    partnerId: null,
+    orgId: ORG_ID,
+    scope: 'organization',
+    accessibleOrgIds: [ORG_ID],
+    canAccessOrg: (orgId: string) => orgId === ORG_ID,
+    orgCondition: vi.fn(() => undefined),
+  } as any;
+}
+
+function buildToolMap(): Map<string, AiTool> {
+  const toolMap = new Map<string, AiTool>();
+  registerIncidentTools(toolMap);
+  return toolMap;
+}
+
+const INCIDENT_ROW = { id: INCIDENT_ID, orgId: ORG_ID, title: 'Test incident', severity: 'high', status: 'open' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // findIncidentWithAccess() select returns the caller's own incident.
+  vi.mocked(db.select).mockImplementation(() => createQueryChain([INCIDENT_ROW]) as any);
+  vi.mocked(db.insert).mockImplementation(() => createInsertChain([{ id: 'action-1' }]) as any);
+  vi.mocked(queueCommandForExecution).mockResolvedValue({ command: { id: 'cmd-1', status: 'queued' } } as any);
+});
+
+describe('incident AI tools — cross-org device gate', () => {
+  const cases = [
+    {
+      tool: 'execute_containment',
+      input: {
+        incidentId: INCIDENT_ID,
+        deviceId: FOREIGN_DEVICE_ID,
+        actionType: 'process_kill',
+        approvalRef: 'appr-1',
+        parameters: { pid: 1234 },
+      },
+    },
+    {
+      tool: 'collect_evidence',
+      input: {
+        incidentId: INCIDENT_ID,
+        deviceId: FOREIGN_DEVICE_ID,
+        evidenceTypes: ['screenshot'],
+      },
+    },
+  ] as const;
+
+  for (const { tool, input } of cases) {
+    it(`${tool} validates the target device against the caller's org`, async () => {
+      vi.mocked(verifyDeviceAccess).mockResolvedValue({ error: 'Device not found or access denied' } as any);
+      const toolMap = buildToolMap();
+
+      const result = await toolMap.get(tool)!.handler(input as Record<string, unknown>, makeAuth());
+
+      // The gate must be consulted with the user-supplied deviceId.
+      expect(verifyDeviceAccess).toHaveBeenCalledWith(FOREIGN_DEVICE_ID, expect.anything());
+      // And on denial, NO command may be dispatched to the foreign device.
+      expect(queueCommandForExecution).not.toHaveBeenCalled();
+      expect(JSON.parse(result).error).toMatch(/not found or access denied/i);
+    });
+
+    it(`${tool} dispatches when the device is accessible`, async () => {
+      vi.mocked(verifyDeviceAccess).mockResolvedValue({
+        device: { id: OWN_DEVICE_ID, orgId: ORG_ID, hostname: 'host-1', status: 'online' },
+      } as any);
+      const accessibleInput = { ...input, deviceId: OWN_DEVICE_ID };
+      const toolMap = buildToolMap();
+
+      const result = await toolMap.get(tool)!.handler(accessibleInput as Record<string, unknown>, makeAuth());
+
+      expect(verifyDeviceAccess).toHaveBeenCalledWith(OWN_DEVICE_ID, expect.anything());
+      expect(queueCommandForExecution).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(result).success).toBe(true);
+    });
+  }
+});

--- a/apps/api/src/services/aiToolsIncident.ts
+++ b/apps/api/src/services/aiToolsIncident.ts
@@ -15,7 +15,7 @@ import { incidents, incidentEvidence, incidentActions } from '../db/schema';
 import { eq, and, desc, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
-import { resolveWritableToolOrgId } from './aiTools';
+import { resolveWritableToolOrgId, verifyDeviceAccess } from './aiTools';
 import { queueCommandForExecution } from './commandQueue';
 import { publishEvent } from './eventBus';
 import type { IncidentTimelineEntry } from '../db/schema/incidentResponse';
@@ -216,6 +216,14 @@ export function registerIncidentTools(aiTools: Map<string, AiTool>): void {
       const incident = await findIncidentWithAccess(input.incidentId as string, auth);
       if (!incident) return JSON.stringify({ error: 'Incident not found or access denied' });
 
+      // The target device is supplied directly by the caller and reaches the
+      // agent via queueCommandForExecution (which looks the device up by id
+      // with NO tenant filter). Gate it through the org-scoped device check —
+      // otherwise a user with an incident in their own org could dispatch
+      // containment to a device in another tenant by id.
+      const deviceAccess = await verifyDeviceAccess(input.deviceId as string, auth);
+      if ('error' in deviceAccess) return JSON.stringify({ error: deviceAccess.error });
+
       const payload = {
         incidentId: input.incidentId as string,
         actionType: input.actionType as string,
@@ -303,6 +311,13 @@ export function registerIncidentTools(aiTools: Map<string, AiTool>): void {
 
       const incident = await findIncidentWithAccess(input.incidentId as string, auth);
       if (!incident) return JSON.stringify({ error: 'Incident not found or access denied' });
+
+      // Gate the caller-supplied device through the org-scoped device check
+      // before dispatch — queueCommandForExecution resolves the device by id
+      // with no tenant filter, so without this a user could collect forensic
+      // evidence (incl. screenshots) from a device in another tenant by id.
+      const deviceAccess = await verifyDeviceAccess(input.deviceId as string, auth);
+      if ('error' in deviceAccess) return JSON.stringify({ error: deviceAccess.error });
 
       const payload = {
         incidentId: input.incidentId as string,


### PR DESCRIPTION
## Summary

**Severity:** CRITICAL (cross-tenant), latent. **Root cause:** pre-existing since #305 (2026-03-29). **Not** introduced by the in-flight site-scope stack (#1036/#1037/#1041/#1042/#1047) — those don't touch this file.

Two AI-agent tools dispatched commands to an **attacker-controlled `deviceId`** after validating only the *incident's* org:

- `execute_containment` (Tier 3) — `aiToolsIncident.ts:216`
- `collect_evidence` (Tier 2) — `aiToolsIncident.ts:304`

Both call `findIncidentWithAccess(incidentId, auth)` (validates the incident's org) and then pass `input.deviceId` straight to `queueCommandForExecution`, which resolves the device by `eq(devices.id, deviceId)` with **no tenant filter** (`commandQueue.ts:502-506`).

**Impact:** any user who can create/access an incident in their own org could, by supplying another tenant's device UUID, run `process_kill` / `network_isolation` / `account_disable` / `usb_block` — or collect forensic evidence incl. **screenshots** — on **any device in any org**. RCE / data-exfiltration class. Reachable via the AI chat endpoint and the MCP API-key path. (`approvalRef` is an unvalidated free string and is not a gate.) Mitigant: device UUIDs are unguessable, so it needs a known/leaked id or a malicious insider — hence "latent CRITICAL", not active incident.

## Fix

Route `input.deviceId` through the shared org-scoped `verifyDeviceAccess` gate **before** dispatch — the exact pattern every sibling AI tool (Hyperv / Mssql / Backup / Vault / AgentLogs) already uses. On denial the tool returns the same opaque `Device not found or access denied` message (no existence leak) and dispatches nothing.

16-line source change, additive (two guard clauses + one import).

## Scope — is it just these two?

Audited **all 46** `queueCommand` / `queueCommandForExecution` call sites:
- 14 system/job/agent-WS paths (deviceId from server-resolved org-scoped rows)
- 30 user paths already org-validated before dispatch
- **2 vulnerable** — these two incident tools, the only places a user-controlled `deviceId` reached dispatch with no org anchor.

No broader refactor required.

## Tests

New `aiToolsIncident.test.ts` (4 tests, TDD — verified RED then GREEN): each handler must consult `verifyDeviceAccess` with the caller's `deviceId` and **refuse to dispatch** on denial; positive path still dispatches when the device is accessible.

`npx tsc --noEmit` clean on touched files.

## Notes / follow-ups
- This closes the **cross-org** hole (org axis). The **site** axis on these handlers is part of the separate site-scope burn-down tracked by the AI-tools scanner work.
- Defense-in-depth idea (not in this PR): give `queueCommandForExecution` an optional `orgId` guard so the trust never rests solely on callers remembering to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)