### PR TITLE
feat(security): declarative deviceArgs gate — structural backstop for the AI-tool tenant-isolation class

### DIFF
--- a/apps/api/src/services/aiTools.deviceArgsCoverage.contract.test.ts
+++ b/apps/api/src/services/aiTools.deviceArgsCoverage.contract.test.ts
@@ -11,9 +11,13 @@ import { aiTools } from './aiTools';
  * caused.
  *
  * Tools that resolve the device indirectly (vmId/snapshotId/findingId/alertId)
- * or return a device LIST without a device-id input are NOT matched here — they
- * have no device-id property — and continue to narrow results via the
- * `aiToolsSiteScope` helpers.
+ * do not currently expose a top-level device-id property, so the regex does not
+ * match them; they continue to narrow via the `aiToolsSiteScope` helpers. If
+ * such a tool later adds a device-id filter it must declare it like any other.
+ * NOTE: coverage is only as strong as `DEVICE_ID_PROP` — a device-id input
+ * named outside this pattern (e.g. `agentId`) would be both ungated and
+ * invisible here. All device-id props in this codebase are device(s)/-id(s)
+ * shaped; keep it that way or widen the pattern.
  *
  * Ratchet: `DEVICE_ARGS_BASELINE` lists tools that expose a device-id property
  * but do not yet declare `deviceArgs`. It is frozen and shrink-only — fixing a
@@ -21,9 +25,13 @@ import { aiTools } from './aiTools';
  * device-arg tool fails until it declares. Drive this to empty.
  */
 
-// Property names that denote a device the tool acts on (string or string[]).
-// Excludes siteId, vmId, snapshotId, findingId, etc. (not direct device ids).
-const DEVICE_ID_PROP = /^(?:target)?device_?ids?$/i;
+// Property names that carry a device id / list of device ids (string or
+// string[]): device(s), with an optional target/affected/source prefix and an
+// optional id(s) suffix — e.g. deviceId, deviceIds, device_id, targetDeviceId,
+// targetDevices, devices, affectedDeviceIds. Deliberately does NOT match
+// agentId (the agent, not the device), siteId, vmId, snapshotId, or
+// deviceGroupId (a group, not a device).
+const DEVICE_ID_PROP = /^(?:target|affected|source)?_?devices?(?:_?ids?)?$/i;
 
 // Tools that expose a device-id property but have not yet been converted to a
 // `deviceArgs` declaration. SHRINK ONLY — never add. Each remaining entry is a
@@ -67,5 +75,19 @@ describe('contract: device-arg tools declare deviceArgs for the central gate', (
     const offenderNames = new Set(offenders.map((o) => o.name));
     const stale = [...DEVICE_ARGS_BASELINE].filter((n) => !offenderNames.has(n));
     expect(stale, `stale baseline entries — remove them: ${stale.join(', ')}`).toEqual([]);
+  });
+
+  it('every declared deviceArgs name exists as an input_schema property (no typos / dead declarations)', () => {
+    const bad: string[] = [];
+    for (const [name, tool] of aiTools.entries()) {
+      const declared = tool.deviceArgs ?? [];
+      if (declared.length === 0) continue;
+      const schema = tool.definition.input_schema as { properties?: Record<string, unknown> } | undefined;
+      const props = new Set(Object.keys(schema?.properties ?? {}));
+      for (const arg of declared) {
+        if (!props.has(arg)) bad.push(`${name}: deviceArgs entry '${arg}' is not an input_schema property`);
+      }
+    }
+    expect(bad, bad.join('\n')).toEqual([]);
   });
 });

--- a/apps/api/src/services/aiTools.deviceArgsCoverage.contract.test.ts
+++ b/apps/api/src/services/aiTools.deviceArgsCoverage.contract.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { aiTools } from './aiTools';
+
+/**
+ * Contract: every AI tool whose input schema exposes a top-level device-id
+ * property MUST declare it in `deviceArgs`, so the central dispatch
+ * (`executeTool` → `enforceDeviceArgs`) gates that id through the org+site
+ * `verifyDeviceAccess` before the handler runs. This is the structural backstop
+ * for the parallel-path bug class (a tool author can't forget the per-device
+ * tenant check) — see the cross-org incident-tool hole that a missing gate
+ * caused.
+ *
+ * Tools that resolve the device indirectly (vmId/snapshotId/findingId/alertId)
+ * or return a device LIST without a device-id input are NOT matched here — they
+ * have no device-id property — and continue to narrow results via the
+ * `aiToolsSiteScope` helpers.
+ *
+ * Ratchet: `DEVICE_ARGS_BASELINE` lists tools that expose a device-id property
+ * but do not yet declare `deviceArgs`. It is frozen and shrink-only — fixing a
+ * tool (adding the declaration) forces removing its baseline entry, and any NEW
+ * device-arg tool fails until it declares. Drive this to empty.
+ */
+
+// Property names that denote a device the tool acts on (string or string[]).
+// Excludes siteId, vmId, snapshotId, findingId, etc. (not direct device ids).
+const DEVICE_ID_PROP = /^(?:target)?device_?ids?$/i;
+
+// Tools that expose a device-id property but have not yet been converted to a
+// `deviceArgs` declaration. SHRINK ONLY — never add. Each remaining entry is a
+// tool whose handler still gates inline (or is pending conversion); the central
+// gate is belt-and-suspenders once declared.
+const DEVICE_ARGS_BASELINE: ReadonlySet<string> = new Set<string>([]);
+
+function deviceIdProps(tool: { definition: { input_schema?: unknown } }): string[] {
+  const schema = tool.definition.input_schema as
+    | { properties?: Record<string, unknown> }
+    | undefined;
+  const props = schema?.properties ?? {};
+  return Object.keys(props).filter((k) => DEVICE_ID_PROP.test(k));
+}
+
+describe('contract: device-arg tools declare deviceArgs for the central gate', () => {
+  const offenders: Array<{ name: string; props: string[]; declared: readonly string[] }> = [];
+
+  for (const [name, tool] of aiTools.entries()) {
+    const props = deviceIdProps(tool);
+    if (props.length === 0) continue;
+    const declared = tool.deviceArgs ?? [];
+    const ungated = props.filter((p) => !declared.includes(p));
+    if (ungated.length > 0) offenders.push({ name, props: ungated, declared });
+  }
+
+  it('every device-id property is covered by deviceArgs (modulo frozen baseline)', () => {
+    const newOffenders = offenders.filter((o) => !DEVICE_ARGS_BASELINE.has(o.name));
+    if (newOffenders.length > 0) {
+      const lines = newOffenders
+        .map((o) => `  - ${o.name}: input props [${o.props.join(', ')}] not in deviceArgs [${o.declared.join(', ')}]`)
+        .join('\n');
+      throw new Error(
+        `These tools expose a device-id input property but do not declare it in deviceArgs ` +
+          `(add \`deviceArgs: ['<prop>']\` to the tool registration so executeTool gates it):\n${lines}`,
+      );
+    }
+  });
+
+  it('baseline has no stale entries (a fixed tool must be removed from the baseline)', () => {
+    const offenderNames = new Set(offenders.map((o) => o.name));
+    const stale = [...DEVICE_ARGS_BASELINE].filter((n) => !offenderNames.has(n));
+    expect(stale, `stale baseline entries — remove them: ${stale.join(', ')}`).toEqual([]);
+  });
+});

--- a/apps/api/src/services/aiTools.deviceGate.test.ts
+++ b/apps/api/src/services/aiTools.deviceGate.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * SPIKE: declarative device-access gate.
+ *
+ * A tool declares `deviceArgs: ['deviceId']` naming the input properties that
+ * carry a device id. The central dispatch (`executeTool`) runs the org+site
+ * `verifyDeviceAccess` gate on each declared id BEFORE the handler runs, so a
+ * tool author can no longer forget the check. Handles a single id or an array.
+ * Unrestricted callers and tools with no `deviceArgs` are unaffected.
+ */
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn() },
+}));
+
+import { db } from '../db';
+import { enforceDeviceArgs } from './aiTools';
+import type { AuthContext } from '../middleware/auth';
+
+const OWN_DEVICE = '33333333-3333-3333-3333-333333333333';
+const FOREIGN_DEVICE = '99999999-9999-9999-9999-999999999999';
+
+// verifyDeviceAccess does db.select().from(devices).where(and(...)).limit(1).
+// An empty result == the org/site filter excluded the device (i.e. denied).
+function deviceLookup(rows: any[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  } as any;
+}
+
+function mockLookupSequence(resultsPerCall: any[][]) {
+  let i = 0;
+  vi.mocked(db.select).mockImplementation(() => deviceLookup(resultsPerCall[i++] ?? []) as any);
+}
+
+function makeAuth(): AuthContext {
+  return {
+    user: { id: 'user-1', email: 'u@example.com', name: 'U' },
+    token: {} as any,
+    partnerId: null,
+    orgId: 'org-123',
+    scope: 'organization',
+    accessibleOrgIds: ['org-123'],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+  } as any;
+}
+
+const ACCESSIBLE = [{ id: OWN_DEVICE, hostname: 'host-1', siteId: 'site-1', status: 'online' }];
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('enforceDeviceArgs — declarative device gate', () => {
+  it('returns null (no gate) when the tool declares no deviceArgs', async () => {
+    const result = await enforceDeviceArgs({ deviceArgs: undefined }, { deviceId: FOREIGN_DEVICE }, makeAuth());
+    expect(result).toBeNull();
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('denies when a declared single-id arg names a device the caller cannot access', async () => {
+    mockLookupSequence([[]]); // device lookup excluded by org/site filter
+    const result = await enforceDeviceArgs({ deviceArgs: ['deviceId'] }, { deviceId: FOREIGN_DEVICE }, makeAuth());
+    expect(result).not.toBeNull();
+    expect(JSON.parse(result!).error).toMatch(/not found or access denied/i);
+  });
+
+  it('allows when a declared single-id arg names an accessible device', async () => {
+    mockLookupSequence([ACCESSIBLE]);
+    const result = await enforceDeviceArgs({ deviceArgs: ['deviceId'] }, { deviceId: OWN_DEVICE }, makeAuth());
+    expect(result).toBeNull();
+  });
+
+  it('denies an array arg if ANY element is inaccessible (not just the first)', async () => {
+    mockLookupSequence([ACCESSIBLE, []]); // first id ok, second denied
+    const result = await enforceDeviceArgs(
+      { deviceArgs: ['deviceIds'] },
+      { deviceIds: [OWN_DEVICE, FOREIGN_DEVICE] },
+      makeAuth(),
+    );
+    expect(result).not.toBeNull();
+    expect(JSON.parse(result!).error).toMatch(/not found or access denied/i);
+  });
+
+  it('supports a custom property name (e.g. targetDeviceId)', async () => {
+    mockLookupSequence([[]]);
+    const result = await enforceDeviceArgs(
+      { deviceArgs: ['targetDeviceId'] },
+      { targetDeviceId: FOREIGN_DEVICE },
+      makeAuth(),
+    );
+    expect(JSON.parse(result!).error).toMatch(/not found or access denied/i);
+  });
+
+  it('skips a declared arg that is absent or non-string (presence is the handler\'s job)', async () => {
+    const result = await enforceDeviceArgs({ deviceArgs: ['deviceId'] }, {}, makeAuth());
+    expect(result).toBeNull();
+    expect(db.select).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/aiTools.deviceGate.test.ts
+++ b/apps/api/src/services/aiTools.deviceGate.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 /**
- * SPIKE: declarative device-access gate.
+ * Declarative device-access gate.
  *
  * A tool declares `deviceArgs: ['deviceId']` naming the input properties that
  * carry a device id. The central dispatch (`executeTool`) runs the org+site
- * `verifyDeviceAccess` gate on each declared id BEFORE the handler runs, so a
- * tool author can no longer forget the check. Handles a single id or an array.
- * Unrestricted callers and tools with no `deviceArgs` are unaffected.
+ * `verifyDeviceAccess` check on each declared id before the handler, returning
+ * `{ ok: false }` to block. Handles a single id or array; fails closed on a
+ * present-but-malformed id; no-op for tools without `deviceArgs` and for
+ * absent optional args.
  */
 
 vi.mock('../db', () => ({
@@ -25,13 +26,10 @@ const OWN_DEVICE = '33333333-3333-3333-3333-333333333333';
 const FOREIGN_DEVICE = '99999999-9999-9999-9999-999999999999';
 
 // verifyDeviceAccess does db.select().from(devices).where(and(...)).limit(1).
-// An empty result == the org/site filter excluded the device (i.e. denied).
 function deviceLookup(rows: any[]) {
   return {
     from: vi.fn().mockReturnValue({
-      where: vi.fn().mockReturnValue({
-        limit: vi.fn().mockResolvedValue(rows),
-      }),
+      where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
     }),
   } as any;
 }
@@ -41,6 +39,7 @@ function mockLookupSequence(resultsPerCall: any[][]) {
   vi.mocked(db.select).mockImplementation(() => deviceLookup(resultsPerCall[i++] ?? []) as any);
 }
 
+// Org-unrestricted caller (no site allowlist).
 function makeAuth(): AuthContext {
   return {
     user: { id: 'user-1', email: 'u@example.com', name: 'U' },
@@ -54,54 +53,81 @@ function makeAuth(): AuthContext {
   } as any;
 }
 
-const ACCESSIBLE = [{ id: OWN_DEVICE, hostname: 'host-1', siteId: 'site-1', status: 'online' }];
+// Caller restricted to site-1 within the org (org check passes, site check is the gate).
+function makeSiteRestrictedAuth(): AuthContext {
+  return {
+    ...makeAuth(),
+    allowedSiteIds: ['site-1'],
+    canAccessSite: (siteId: string | null) => siteId === 'site-1',
+  } as any;
+}
+
+const IN_SITE = [{ id: OWN_DEVICE, hostname: 'h', siteId: 'site-1', status: 'online' }];
+const OTHER_SITE = [{ id: OWN_DEVICE, hostname: 'h', siteId: 'site-2', status: 'online' }];
 
 beforeEach(() => vi.clearAllMocks());
 
 describe('enforceDeviceArgs — declarative device gate', () => {
-  it('returns null (no gate) when the tool declares no deviceArgs', async () => {
-    const result = await enforceDeviceArgs({ deviceArgs: undefined }, { deviceId: FOREIGN_DEVICE }, makeAuth());
-    expect(result).toBeNull();
+  it('allows (ok) when the tool declares no deviceArgs', async () => {
+    const r = await enforceDeviceArgs({ deviceArgs: undefined }, { deviceId: FOREIGN_DEVICE }, makeAuth());
+    expect(r).toEqual({ ok: true });
     expect(db.select).not.toHaveBeenCalled();
   });
 
-  it('denies when a declared single-id arg names a device the caller cannot access', async () => {
-    mockLookupSequence([[]]); // device lookup excluded by org/site filter
-    const result = await enforceDeviceArgs({ deviceArgs: ['deviceId'] }, { deviceId: FOREIGN_DEVICE }, makeAuth());
-    expect(result).not.toBeNull();
-    expect(JSON.parse(result!).error).toMatch(/not found or access denied/i);
+  it('denies when a declared single-id arg names a device outside the caller org', async () => {
+    mockLookupSequence([[]]); // org filter excludes it
+    const r = await enforceDeviceArgs({ deviceArgs: ['deviceId'] }, { deviceId: FOREIGN_DEVICE }, makeAuth());
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toMatch(/not found or access denied/i);
   });
 
   it('allows when a declared single-id arg names an accessible device', async () => {
-    mockLookupSequence([ACCESSIBLE]);
-    const result = await enforceDeviceArgs({ deviceArgs: ['deviceId'] }, { deviceId: OWN_DEVICE }, makeAuth());
-    expect(result).toBeNull();
+    mockLookupSequence([IN_SITE]);
+    expect(await enforceDeviceArgs({ deviceArgs: ['deviceId'] }, { deviceId: OWN_DEVICE }, makeAuth())).toEqual({ ok: true });
+  });
+
+  it('SITE AXIS: denies a same-org device in a site the caller cannot access', async () => {
+    // Org query returns the row (org matches); the site branch must reject it.
+    mockLookupSequence([OTHER_SITE]);
+    const r = await enforceDeviceArgs({ deviceArgs: ['deviceId'] }, { deviceId: OWN_DEVICE }, makeSiteRestrictedAuth());
+    expect(r.ok).toBe(false);
+  });
+
+  it('SITE AXIS: allows a same-org device within the caller site allowlist', async () => {
+    mockLookupSequence([IN_SITE]);
+    expect(await enforceDeviceArgs({ deviceArgs: ['deviceId'] }, { deviceId: OWN_DEVICE }, makeSiteRestrictedAuth())).toEqual({ ok: true });
   });
 
   it('denies an array arg if ANY element is inaccessible (not just the first)', async () => {
-    mockLookupSequence([ACCESSIBLE, []]); // first id ok, second denied
-    const result = await enforceDeviceArgs(
-      { deviceArgs: ['deviceIds'] },
-      { deviceIds: [OWN_DEVICE, FOREIGN_DEVICE] },
-      makeAuth(),
-    );
-    expect(result).not.toBeNull();
-    expect(JSON.parse(result!).error).toMatch(/not found or access denied/i);
+    mockLookupSequence([IN_SITE, []]); // first ok, second denied
+    const r = await enforceDeviceArgs({ deviceArgs: ['deviceIds'] }, { deviceIds: [OWN_DEVICE, FOREIGN_DEVICE] }, makeAuth());
+    expect(r.ok).toBe(false);
   });
 
   it('supports a custom property name (e.g. targetDeviceId)', async () => {
     mockLookupSequence([[]]);
-    const result = await enforceDeviceArgs(
-      { deviceArgs: ['targetDeviceId'] },
-      { targetDeviceId: FOREIGN_DEVICE },
-      makeAuth(),
-    );
-    expect(JSON.parse(result!).error).toMatch(/not found or access denied/i);
+    const r = await enforceDeviceArgs({ deviceArgs: ['targetDeviceId'] }, { targetDeviceId: FOREIGN_DEVICE }, makeAuth());
+    expect(r.ok).toBe(false);
   });
 
-  it('skips a declared arg that is absent or non-string (presence is the handler\'s job)', async () => {
-    const result = await enforceDeviceArgs({ deviceArgs: ['deviceId'] }, {}, makeAuth());
-    expect(result).toBeNull();
+  it('allows when a declared optional arg is absent (nothing to gate)', async () => {
+    expect(await enforceDeviceArgs({ deviceArgs: ['deviceId'] }, {}, makeAuth())).toEqual({ ok: true });
     expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('FAILS CLOSED on a present-but-malformed id (object/number), without trusting upstream validation', async () => {
+    const obj = await enforceDeviceArgs({ deviceArgs: ['deviceId'] }, { deviceId: { evil: true } }, makeAuth());
+    expect(obj.ok).toBe(false);
+    const num = await enforceDeviceArgs({ deviceArgs: ['deviceId'] }, { deviceId: 12345 }, makeAuth());
+    expect(num.ok).toBe(false);
+    const empty = await enforceDeviceArgs({ deviceArgs: ['deviceId'] }, { deviceId: '' }, makeAuth());
+    expect(empty.ok).toBe(false);
+    expect(db.select).not.toHaveBeenCalled(); // denied before any lookup
+  });
+
+  it('FAILS CLOSED if any array element is a non-string (mixed array)', async () => {
+    mockLookupSequence([IN_SITE]); // first element would pass if reached
+    const r = await enforceDeviceArgs({ deviceArgs: ['deviceIds'] }, { deviceIds: [OWN_DEVICE, { evil: true }] }, makeAuth());
+    expect(r.ok).toBe(false);
   });
 });

--- a/apps/api/src/services/aiTools.executeToolGate.test.ts
+++ b/apps/api/src/services/aiTools.executeToolGate.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Integration: `executeTool` (the universal dispatch chokepoint for the chat,
+ * MCP, and SDK paths) runs the declarative device gate BEFORE the handler, so a
+ * tool declaring `deviceArgs` cannot reach a device outside the caller's scope
+ * even if its handler does no checking of its own.
+ */
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn() },
+}));
+
+// Keep every real schema export; only force input validation to pass so the
+// probe tool (which has no registered Zod schema) reaches the gate.
+vi.mock('./aiToolSchemas', async (orig) => ({
+  ...(await orig<typeof import('./aiToolSchemas')>()),
+  validateToolInput: () => ({ success: true }),
+}));
+
+import { db } from '../db';
+import { aiTools, executeTool } from './aiTools';
+import type { AiTool } from './aiTools';
+import type { AuthContext } from '../middleware/auth';
+
+const PROBE = '__device_gate_probe__';
+const FOREIGN_DEVICE = '99999999-9999-9999-9999-999999999999';
+const OWN_DEVICE = '33333333-3333-3333-3333-333333333333';
+
+function deviceLookup(rows: any[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+    }),
+  } as any;
+}
+
+function makeAuth(): AuthContext {
+  return {
+    user: { id: 'user-1', email: 'u@example.com', name: 'U' },
+    token: {} as any,
+    partnerId: null,
+    orgId: 'org-123',
+    scope: 'organization',
+    accessibleOrgIds: ['org-123'],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+  } as any;
+}
+
+// A tool that ALWAYS succeeds and does NO checking of its own — so the only
+// thing that can deny a foreign device is the central gate.
+const handler = vi.fn(async () => JSON.stringify({ success: true, ranHandler: true }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  aiTools.set(PROBE, {
+    tier: 1,
+    deviceArgs: ['deviceId'],
+    definition: { name: PROBE, description: 'probe', input_schema: { type: 'object', properties: {} } },
+    handler,
+  } as AiTool);
+});
+
+afterEach(() => {
+  aiTools.delete(PROBE);
+});
+
+describe('executeTool runs the declarative device gate before the handler', () => {
+  it('denies a foreign device and never invokes the handler', async () => {
+    vi.mocked(db.select).mockImplementation(() => deviceLookup([]) as any); // gate lookup excluded
+    const out = await executeTool(PROBE, { deviceId: FOREIGN_DEVICE }, makeAuth());
+    expect(JSON.parse(out).error).toMatch(/not found or access denied/i);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('invokes the handler when the declared device is accessible', async () => {
+    vi.mocked(db.select).mockImplementation(
+      () => deviceLookup([{ id: OWN_DEVICE, hostname: 'h', siteId: 's', status: 'online' }]) as any,
+    );
+    const out = await executeTool(PROBE, { deviceId: OWN_DEVICE }, makeAuth());
+    expect(JSON.parse(out).ranHandler).toBe(true);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/services/aiTools.ts
+++ b/apps/api/src/services/aiTools.ts
@@ -71,6 +71,16 @@ export interface AiTool {
   definition: Anthropic.Tool;
   tier: AiToolTier;
   handler: (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
+  /**
+   * Names of the tool's input properties that carry a device id (each a string
+   * or string[]). When set, the central dispatch gates every supplied id
+   * through the org+site `verifyDeviceAccess` BEFORE the handler runs — so a
+   * tool author can no longer forget the per-device tenant check (the root
+   * cause of the cross-org incident-tool bug). Tools that resolve the device
+   * indirectly (via a VM/snapshot/alert record) or return a device LIST are
+   * NOT covered by this and must still narrow results themselves.
+   */
+  deviceArgs?: readonly string[];
 }
 
 // ============================================
@@ -93,6 +103,34 @@ export async function verifyDeviceAccess(
   }
   if (requireOnline && device.status !== 'online') return { error: `Device ${device.hostname} is not online (status: ${device.status})` };
   return { device };
+}
+
+/**
+ * Central declarative device-access gate. For each input property a tool names
+ * in `deviceArgs`, runs the org+site `verifyDeviceAccess` check on every id it
+ * carries (string or string[]). Returns an opaque error-JSON string on the
+ * first denial, or `null` to proceed. No-op for tools without `deviceArgs` and
+ * for unrestricted callers. This is the structural backstop that makes the
+ * per-handler check impossible to forget — see `executeTool`.
+ */
+export async function enforceDeviceArgs(
+  tool: Pick<AiTool, 'deviceArgs'>,
+  input: Record<string, unknown>,
+  auth: AuthContext
+): Promise<string | null> {
+  if (!tool.deviceArgs || tool.deviceArgs.length === 0) return null;
+  for (const argName of tool.deviceArgs) {
+    const raw = input[argName];
+    const ids = Array.isArray(raw) ? raw : raw == null ? [] : [raw];
+    for (const id of ids) {
+      // Shape (string vs array) is already Zod-validated upstream; skip
+      // anything that isn't a non-empty string and let the handler reject it.
+      if (typeof id !== 'string' || id.length === 0) continue;
+      const access = await verifyDeviceAccess(id, auth);
+      if ('error' in access) return JSON.stringify({ error: access.error });
+    }
+  }
+  return null;
 }
 
 export async function findAlertWithAccess(alertId: string, auth: AuthContext) {
@@ -206,6 +244,12 @@ export async function executeTool(
   if (!validation.success) {
     return JSON.stringify({ error: validation.error });
   }
+
+  // Structural device-tenant gate: any id named in `tool.deviceArgs` is
+  // org+site-checked before the handler runs, so a tool can't reach a device
+  // outside the caller's scope even if its handler forgets to check.
+  const deviceGateError = await enforceDeviceArgs(tool, input, auth);
+  if (deviceGateError !== null) return deviceGateError;
 
   return tool.handler(input, auth);
 }

--- a/apps/api/src/services/aiTools.ts
+++ b/apps/api/src/services/aiTools.ts
@@ -105,32 +105,45 @@ export async function verifyDeviceAccess(
   return { device };
 }
 
+/** Decision returned by {@link enforceDeviceArgs}: allow, or deny with a reason.
+ *  The caller (`executeTool`) owns serialization to the wire format. */
+export type DeviceGateResult = { ok: true } | { ok: false; error: string };
+
 /**
  * Central declarative device-access gate. For each input property a tool names
  * in `deviceArgs`, runs the org+site `verifyDeviceAccess` check on every id it
- * carries (string or string[]). Returns an opaque error-JSON string on the
- * first denial, or `null` to proceed. No-op for tools without `deviceArgs` and
- * for unrestricted callers. This is the structural backstop that makes the
- * per-handler check impossible to forget — see `executeTool`.
+ * carries (string or string[]). Returns `{ ok: false }` on the first denial,
+ * else `{ ok: true }`.
+ *
+ * Fail-closed: a tool with no `deviceArgs`, or an optional arg the caller did
+ * not supply, is allowed (nothing to gate); but a declared arg that IS present
+ * must be a non-empty string id (or array of them) — anything else is DENIED
+ * rather than skipped, so the gate does not depend on an upstream validator it
+ * cannot see. For a truly unrestricted caller `verifyDeviceAccess` returns the
+ * row, so the gate degrades to a plain existence check. This is the structural
+ * backstop that makes the per-handler check impossible to forget — see
+ * `executeTool`.
  */
 export async function enforceDeviceArgs(
   tool: Pick<AiTool, 'deviceArgs'>,
   input: Record<string, unknown>,
   auth: AuthContext
-): Promise<string | null> {
-  if (!tool.deviceArgs || tool.deviceArgs.length === 0) return null;
+): Promise<DeviceGateResult> {
+  if (!tool.deviceArgs || tool.deviceArgs.length === 0) return { ok: true };
+  const denied: DeviceGateResult = { ok: false, error: 'Device not found or access denied' };
   for (const argName of tool.deviceArgs) {
     const raw = input[argName];
-    const ids = Array.isArray(raw) ? raw : raw == null ? [] : [raw];
+    if (raw == null) continue; // optional arg not supplied — nothing to gate
+    const ids = Array.isArray(raw) ? raw : [raw];
     for (const id of ids) {
-      // Shape (string vs array) is already Zod-validated upstream; skip
-      // anything that isn't a non-empty string and let the handler reject it.
-      if (typeof id !== 'string' || id.length === 0) continue;
+      // A declared device arg that is present must be a non-empty string.
+      // Fail closed on anything else instead of trusting upstream validation.
+      if (typeof id !== 'string' || id.length === 0) return denied;
       const access = await verifyDeviceAccess(id, auth);
-      if ('error' in access) return JSON.stringify({ error: access.error });
+      if ('error' in access) return { ok: false, error: access.error };
     }
   }
-  return null;
+  return { ok: true };
 }
 
 export async function findAlertWithAccess(alertId: string, auth: AuthContext) {
@@ -248,8 +261,8 @@ export async function executeTool(
   // Structural device-tenant gate: any id named in `tool.deviceArgs` is
   // org+site-checked before the handler runs, so a tool can't reach a device
   // outside the caller's scope even if its handler forgets to check.
-  const deviceGateError = await enforceDeviceArgs(tool, input, auth);
-  if (deviceGateError !== null) return deviceGateError;
+  const gate = await enforceDeviceArgs(tool, input, auth);
+  if (!gate.ok) return JSON.stringify({ error: gate.error });
 
   return tool.handler(input, auth);
 }

--- a/apps/api/src/services/aiToolsAgentLogs.ts
+++ b/apps/api/src/services/aiToolsAgentLogs.ts
@@ -32,6 +32,7 @@ export function registerAgentLogTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1 as AiToolTier,
+    deviceArgs: ['deviceIds'],
     definition: {
       name: 'search_agent_logs',
       description:
@@ -151,6 +152,7 @@ export function registerAgentLogTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 2 as AiToolTier,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'set_agent_log_level',
       description:

--- a/apps/api/src/services/aiToolsAgentMgmt.ts
+++ b/apps/api/src/services/aiToolsAgentMgmt.ts
@@ -146,6 +146,7 @@ export function registerAgentMgmtTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 3 as AiToolTier,
+    deviceArgs: ['deviceIds'],
     definition: {
       name: 'trigger_agent_upgrade',
       description: 'Queue an agent upgrade for a device or group of devices.',

--- a/apps/api/src/services/aiToolsAlerts.ts
+++ b/apps/api/src/services/aiToolsAlerts.ts
@@ -44,6 +44,7 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1 as AiToolTier, // Base tier; acknowledge/resolve/suppress checked at runtime in guardrails
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'manage_alerts',
       description: 'Query, view, acknowledge, resolve, or suppress alerts. Use action "list" to search alerts, "get" for details, "acknowledge" to mark as seen, "resolve" to close, or "suppress" to temporarily silence an alert.',

--- a/apps/api/src/services/aiToolsAnalytics.ts
+++ b/apps/api/src/services/aiToolsAnalytics.ts
@@ -55,6 +55,7 @@ export function registerAnalyticsTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'query_analytics',
       description: 'Query analytics data including SLA compliance, capacity predictions, and SLA definitions.',

--- a/apps/api/src/services/aiToolsAudit.ts
+++ b/apps/api/src/services/aiToolsAudit.ts
@@ -101,6 +101,7 @@ export function registerAuditTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1 as AiToolTier,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'query_change_log',
       description: 'Search device configuration changes such as software installs/updates, service changes, startup drift, network changes, scheduled task changes, and user account changes.',

--- a/apps/api/src/services/aiToolsBackup.ts
+++ b/apps/api/src/services/aiToolsBackup.ts
@@ -135,6 +135,7 @@ export function registerBackupTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'query_backups',
       description: 'List backup configurations, jobs, and storage status for the organization.',
@@ -274,6 +275,7 @@ export function registerBackupTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'get_backup_status',
       description: 'Get backup health summary for a device or the entire organization.',
@@ -403,6 +405,7 @@ export function registerBackupTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'browse_snapshots',
       description: 'Browse available backup snapshots for a device.',
@@ -470,6 +473,7 @@ export function registerBackupTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 3,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'trigger_backup',
       description: 'Initiate an on-demand backup job for a device.',
@@ -561,6 +565,7 @@ export function registerBackupTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 3,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'restore_snapshot',
       description: 'Restore a backup snapshot to a device.',

--- a/apps/api/src/services/aiToolsBackupVm.ts
+++ b/apps/api/src/services/aiToolsBackupVm.ts
@@ -63,6 +63,7 @@ export function registerBackupVmTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 3,
+    deviceArgs: ['targetDeviceId'],
     definition: {
       name: 'restore_as_vm',
       description: 'Restore a backup snapshot as a virtual machine on a target device.',
@@ -207,6 +208,7 @@ export function registerBackupVmTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 3,
+    deviceArgs: ['targetDeviceId'],
     definition: {
       name: 'instant_boot_vm',
       description: 'Instant boot a backup snapshot as a VM on a target device.',

--- a/apps/api/src/services/aiToolsBrowser.ts
+++ b/apps/api/src/services/aiToolsBrowser.ts
@@ -99,6 +99,7 @@ export function registerBrowserTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'get_browser_security',
       description: 'Get browser extension inventory risk summary and active browser policy violations.',
@@ -244,6 +245,7 @@ export function registerBrowserTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 3,
+    deviceArgs: ['deviceIds'],
     definition: {
       name: 'manage_browser_policy',
       description: 'Create, update, list, and apply browser extension compliance policies.',

--- a/apps/api/src/services/aiToolsCisBenchmark.ts
+++ b/apps/api/src/services/aiToolsCisBenchmark.ts
@@ -51,6 +51,7 @@ export function registerCisBenchmarkTools(aiTools: Map<string, AiTool>): void {
 
 registerTool({
   tier: 1,
+  deviceArgs: ['deviceId'],
   definition: {
     name: 'get_cis_compliance',
     description: 'Retrieve CIS benchmark compliance status across devices, including latest score, failed check count, and baseline metadata.',
@@ -199,6 +200,7 @@ registerTool({
 
 registerTool({
   tier: 1,
+  deviceArgs: ['deviceId'],
   definition: {
     name: 'get_cis_device_report',
     description: 'Get detailed CIS findings for a specific device, including failed checks and evidence from the latest scans.',
@@ -275,6 +277,7 @@ registerTool({
 
 registerTool({
   tier: 3,
+  deviceArgs: ['deviceId'],
   definition: {
     name: 'apply_cis_remediation',
     description: 'Queue approved CIS remediation actions for one device and one or more failed checks.',

--- a/apps/api/src/services/aiToolsCompliance.ts
+++ b/apps/api/src/services/aiToolsCompliance.ts
@@ -67,6 +67,7 @@ export function registerComplianceTools(aiTools: Map<string, AiTool>): void {
 
 registerTool({
   tier: 1,
+  deviceArgs: ['deviceIds'],
   definition: {
     name: 'get_software_compliance',
     description: 'Check software compliance status across the fleet. Shows policy violations, unauthorized installations, and missing required software.',
@@ -339,6 +340,7 @@ registerTool({
 
 registerTool({
   tier: 3,
+  deviceArgs: ['deviceIds'],
   definition: {
     name: 'remediate_software_violation',
     description: 'Queue remediation for software policy violations by scheduling uninstall commands for unauthorized software.',
@@ -477,6 +479,7 @@ registerTool({
 
 registerTool({
   tier: 1,
+  deviceArgs: ['deviceId'],
   definition: {
     name: 'get_compliance_status',
     description: 'Get device-level compliance status for a specific policy.',

--- a/apps/api/src/services/aiToolsConfigPolicy.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.ts
@@ -114,6 +114,7 @@ export function registerConfigPolicyTools(aiTools: Map<string, AiTool>): void {
   // 2. get_effective_configuration — Tier 1 (read)
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'get_effective_configuration',
       description: 'Resolve the effective configuration for a device by evaluating all configuration policy assignments in the hierarchy (device > group > site > org > partner). Returns the winning policy per feature type with full inheritance chain for debugging.',
@@ -136,6 +137,7 @@ export function registerConfigPolicyTools(aiTools: Map<string, AiTool>): void {
   // 3. preview_configuration_change — Tier 1 (read)
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'preview_configuration_change',
       description: 'Preview how adding or removing configuration policy assignments would change the effective configuration for a device. Returns current vs proposed effective config.',

--- a/apps/api/src/services/aiToolsDR.ts
+++ b/apps/api/src/services/aiToolsDR.ts
@@ -324,6 +324,7 @@ export function registerDRTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 2,
+    deviceArgs: ['devices'],
     definition: {
       name: 'manage_dr_plan',
       description: 'Create or update disaster recovery plans and plan groups.',

--- a/apps/api/src/services/aiToolsDevice.ts
+++ b/apps/api/src/services/aiToolsDevice.ts
@@ -135,6 +135,7 @@ export function registerDeviceTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'get_device_details',
       description: 'Get comprehensive details about a specific device including hardware specs, network interfaces, disk usage, and recent metrics.',
@@ -190,6 +191,7 @@ export function registerDeviceTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'get_device_context',
       description: 'Retrieve past AI memory/context about a device. Returns known issues, quirks, follow-ups, and preferences from previous interactions. Use this AUTOMATICALLY when asked about a device to recall past conversations and context.',
@@ -253,6 +255,7 @@ export function registerDeviceTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 2,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'set_device_context',
       description: 'Record new context/memory about a device for future reference. Use this to remember issues, quirks, follow-ups, or preferences discovered during troubleshooting. This helps maintain continuity across conversations.',
@@ -355,6 +358,7 @@ export function registerDeviceTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 2,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'manage_tags',
       description: 'List all tags used across devices, or add/remove tags on a specific device.',
@@ -456,6 +460,7 @@ export function registerDeviceTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'query_custom_fields',
       description: 'Get custom field definitions for the organization, or get custom field values for a specific device.',

--- a/apps/api/src/services/aiToolsDns.ts
+++ b/apps/api/src/services/aiToolsDns.ts
@@ -61,6 +61,7 @@ export function registerDnsTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'get_dns_security',
       description: 'Get DNS security statistics including blocked domains, threat categories, and top offending devices.',

--- a/apps/api/src/services/aiToolsEventLogs.ts
+++ b/apps/api/src/services/aiToolsEventLogs.ts
@@ -23,6 +23,7 @@ export function registerEventLogTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1 as AiToolTier,
+    deviceArgs: ['deviceIds'],
     definition: {
       name: 'search_logs',
       description:
@@ -128,6 +129,7 @@ export function registerEventLogTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1 as AiToolTier,
+    deviceArgs: ['deviceIds'],
     definition: {
       name: 'get_log_trends',
       description:

--- a/apps/api/src/services/aiToolsFilesystem.ts
+++ b/apps/api/src/services/aiToolsFilesystem.ts
@@ -57,6 +57,7 @@ export function registerFilesystemTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1 as AiToolTier, // Runtime tier check for write/delete in guardrails
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'file_operations',
       description: 'Perform file operations on a device. List and read are safe; write, delete, mkdir, and rename require approval.',
@@ -107,6 +108,7 @@ export function registerFilesystemTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1 as AiToolTier,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'analyze_disk_usage',
       description: 'Analyze filesystem usage for a device and explain what is consuming disk space. Can optionally run a fresh scan.',
@@ -206,6 +208,7 @@ export function registerFilesystemTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1 as AiToolTier,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'disk_cleanup',
       description: 'Preview or execute disk cleanup. Preview is read-only. Execute deletes approved safe candidates and reports reclaimed space.',

--- a/apps/api/src/services/aiToolsFleet.ts
+++ b/apps/api/src/services/aiToolsFleet.ts
@@ -296,6 +296,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceIds'],
     definition: {
       name: 'manage_patches',
       description: 'Manage patches: list available patches, check compliance, trigger scans, approve/decline/defer patches, bulk approve, install on targets, or rollback. To configure patch schedules and auto-approval policies, use manage_policy_feature_link with featureType "patch".',
@@ -606,6 +607,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceIds'],
     definition: {
       name: 'manage_groups',
       description: 'Manage device groups: list groups, get details with members, preview dynamic filter results, view membership audit log, create/update/delete groups, add/remove devices.',
@@ -849,6 +851,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceIds'],
     definition: {
       name: 'manage_maintenance_windows',
       description: 'Query maintenance windows (read-only): list windows, get details with occurrences, check what is in maintenance right now. To create or modify maintenance windows, use manage_policy_feature_link with featureType "maintenance".',

--- a/apps/api/src/services/aiToolsHuntress.ts
+++ b/apps/api/src/services/aiToolsHuntress.ts
@@ -210,6 +210,7 @@ export function registerHuntressTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'get_huntress_incidents',
       description: 'Query Huntress incidents with filtering by status, severity, device, or integration.',

--- a/apps/api/src/services/aiToolsHyperv.ts
+++ b/apps/api/src/services/aiToolsHyperv.ts
@@ -86,6 +86,7 @@ export function registerHypervTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'query_hyperv_vms',
       description: 'List discovered Hyper-V virtual machines in the accessible organization scope.',
@@ -360,6 +361,7 @@ export function registerHypervTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 3,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'restore_hyperv_vm',
       description: 'Dispatch a Hyper-V restore/import command from a provider-backed snapshot to a host device.',

--- a/apps/api/src/services/aiToolsIncident.deviceGate.test.ts
+++ b/apps/api/src/services/aiToolsIncident.deviceGate.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * SPIKE demonstration: the declarative gate retroactively closes the cross-org
+ * incident-tool hole (execute_containment / collect_evidence) with NOTHING but
+ * a `deviceArgs: ['deviceId']` declaration — no change to the handler body.
+ *
+ * On this branch the incident handlers still validate only the incident's org
+ * and pass `input.deviceId` straight to queueCommandForExecution. Declaring the
+ * device arg makes the central dispatch gate (`enforceDeviceArgs`, run by
+ * `executeTool`) reject an out-of-tenant device before the handler runs.
+ */
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn() },
+}));
+
+import { db } from '../db';
+import { enforceDeviceArgs } from './aiTools';
+import type { AiTool } from './aiTools';
+import { registerIncidentTools } from './aiToolsIncident';
+import type { AuthContext } from '../middleware/auth';
+
+const FOREIGN_DEVICE = '99999999-9999-9999-9999-999999999999';
+const OWN_DEVICE = '33333333-3333-3333-3333-333333333333';
+
+function deviceLookup(rows: any[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+    }),
+  } as any;
+}
+
+function makeAuth(): AuthContext {
+  return {
+    user: { id: 'user-1', email: 'u@example.com', name: 'U' },
+    token: {} as any,
+    partnerId: null,
+    orgId: 'org-123',
+    scope: 'organization',
+    accessibleOrgIds: ['org-123'],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+  } as any;
+}
+
+function incidentTools(): Map<string, AiTool> {
+  const map = new Map<string, AiTool>();
+  registerIncidentTools(map);
+  return map;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('incident tools are closed by the declarative gate', () => {
+  it.each(['execute_containment', 'collect_evidence'])(
+    '%s declares its device arg',
+    (name) => {
+      expect(incidentTools().get(name)!.deviceArgs).toEqual(['deviceId']);
+    },
+  );
+
+  it.each(['execute_containment', 'collect_evidence'])(
+    'gate denies %s a device outside the caller org/site',
+    async (name) => {
+      vi.mocked(db.select).mockImplementation(() => deviceLookup([]) as any); // org/site filter excludes it
+      const tool = incidentTools().get(name)!;
+
+      const gateError = await enforceDeviceArgs(tool, { deviceId: FOREIGN_DEVICE }, makeAuth());
+
+      expect(gateError).not.toBeNull();
+      expect(JSON.parse(gateError!).error).toMatch(/not found or access denied/i);
+    },
+  );
+
+  it.each(['execute_containment', 'collect_evidence'])(
+    'gate allows %s an accessible device',
+    async (name) => {
+      vi.mocked(db.select).mockImplementation(
+        () => deviceLookup([{ id: OWN_DEVICE, hostname: 'h', siteId: 's', status: 'online' }]) as any,
+      );
+      const tool = incidentTools().get(name)!;
+
+      expect(await enforceDeviceArgs(tool, { deviceId: OWN_DEVICE }, makeAuth())).toBeNull();
+    },
+  );
+});

--- a/apps/api/src/services/aiToolsIncident.deviceGate.test.ts
+++ b/apps/api/src/services/aiToolsIncident.deviceGate.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 /**
- * SPIKE demonstration: the declarative gate retroactively closes the cross-org
+ * Demonstration: the declarative gate retroactively closes the cross-org
  * incident-tool hole (execute_containment / collect_evidence) with NOTHING but
  * a `deviceArgs: ['deviceId']` declaration — no change to the handler body.
  *
@@ -70,10 +70,10 @@ describe('incident tools are closed by the declarative gate', () => {
       vi.mocked(db.select).mockImplementation(() => deviceLookup([]) as any); // org/site filter excludes it
       const tool = incidentTools().get(name)!;
 
-      const gateError = await enforceDeviceArgs(tool, { deviceId: FOREIGN_DEVICE }, makeAuth());
+      const gate = await enforceDeviceArgs(tool, { deviceId: FOREIGN_DEVICE }, makeAuth());
 
-      expect(gateError).not.toBeNull();
-      expect(JSON.parse(gateError!).error).toMatch(/not found or access denied/i);
+      expect(gate.ok).toBe(false);
+      expect((gate as { error: string }).error).toMatch(/not found or access denied/i);
     },
   );
 
@@ -85,7 +85,7 @@ describe('incident tools are closed by the declarative gate', () => {
       );
       const tool = incidentTools().get(name)!;
 
-      expect(await enforceDeviceArgs(tool, { deviceId: OWN_DEVICE }, makeAuth())).toBeNull();
+      expect(await enforceDeviceArgs(tool, { deviceId: OWN_DEVICE }, makeAuth())).toEqual({ ok: true });
     },
   );
 });

--- a/apps/api/src/services/aiToolsIncident.ts
+++ b/apps/api/src/services/aiToolsIncident.ts
@@ -42,6 +42,7 @@ export function registerIncidentTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 2 as AiToolTier,
+    deviceArgs: ['affectedDeviceIds'],
     definition: {
       name: 'create_incident',
       description:

--- a/apps/api/src/services/aiToolsIncident.ts
+++ b/apps/api/src/services/aiToolsIncident.ts
@@ -172,6 +172,7 @@ export function registerIncidentTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 3 as AiToolTier,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'execute_containment',
       description:
@@ -275,6 +276,7 @@ export function registerIncidentTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 2 as AiToolTier,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'collect_evidence',
       description:

--- a/apps/api/src/services/aiToolsMonitoring.ts
+++ b/apps/api/src/services/aiToolsMonitoring.ts
@@ -253,6 +253,7 @@ export function registerMonitoringTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'get_service_monitoring_status',
       description: 'Query service and process monitoring status for managed devices. Actions: status (health overview), summary (latest result per watcher), results (check history), known_services (autocomplete).',

--- a/apps/api/src/services/aiToolsMssql.ts
+++ b/apps/api/src/services/aiToolsMssql.ts
@@ -74,6 +74,7 @@ export function registerMssqlTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'query_mssql_instances',
       description: 'List discovered SQL Server instances and their databases for the accessible organization scope.',
@@ -142,6 +143,7 @@ export function registerMssqlTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'get_mssql_backup_status',
       description: 'Get MSSQL backup chain status by database, including active chain metadata and latest full snapshot context.',
@@ -240,6 +242,7 @@ export function registerMssqlTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 3,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'trigger_mssql_backup',
       description: 'Dispatch an MSSQL backup command to a device for a specific instance and database.',
@@ -349,6 +352,7 @@ export function registerMssqlTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 3,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'restore_mssql_database',
       description: 'Dispatch an MSSQL restore command to a device.',

--- a/apps/api/src/services/aiToolsNetwork.ts
+++ b/apps/api/src/services/aiToolsNetwork.ts
@@ -355,6 +355,7 @@ export function registerNetworkTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['device_id'],
     definition: {
       name: 'get_ip_history',
       description: 'Query historical IP assignments. Supports timeline mode (device_id) and reverse lookup mode (ip_address + at_time).',
@@ -521,6 +522,7 @@ export function registerNetworkTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 3,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'network_discovery',
       description: 'Initiate a network discovery scan from a device to find other devices on the network.',

--- a/apps/api/src/services/aiToolsPerformance.ts
+++ b/apps/api/src/services/aiToolsPerformance.ts
@@ -99,6 +99,7 @@ export function registerPerformanceTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1 as AiToolTier,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'analyze_metrics',
       description: 'Query and analyze time-series metrics (CPU, RAM, disk, network) for a device. Supports time range filtering and aggregation.',
@@ -177,6 +178,7 @@ export function registerPerformanceTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1 as AiToolTier,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'get_active_users',
       description: 'Query active user sessions for one device or across the fleet. Returns session state and a reboot safety signal.',
@@ -282,6 +284,7 @@ export function registerPerformanceTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1 as AiToolTier,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'get_user_experience_metrics',
       description: 'Summarize login performance and session behavior trends for a device or user over time.',
@@ -400,6 +403,7 @@ export function registerPerformanceTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1 as AiToolTier,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'analyze_boot_performance',
       description: 'Analyze boot performance and startup items for a device. Returns boot time history, slowest startup items by impact score, and optimization recommendations.',
@@ -543,6 +547,7 @@ export function registerPerformanceTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 3 as AiToolTier,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'manage_startup_items',
       description: 'Disable or enable startup items on a device. Device must be online. Item must exist in the most recent boot performance record. Requires user approval. Use analyze_boot_performance first to identify high-impact items.',

--- a/apps/api/src/services/aiToolsPeripherals.ts
+++ b/apps/api/src/services/aiToolsPeripherals.ts
@@ -80,6 +80,7 @@ export function registerPeripheralTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['device_id'],
     definition: {
       name: 'get_peripheral_activity',
       description: 'Query USB/peripheral connection and enforcement activity.',

--- a/apps/api/src/services/aiToolsPlaybooks.ts
+++ b/apps/api/src/services/aiToolsPlaybooks.ts
@@ -105,6 +105,7 @@ registerTool({
 
 registerTool({
   tier: 3,
+  deviceArgs: ['deviceId'],
   definition: {
     name: 'execute_playbook',
     description: 'Create a self-healing playbook execution record for a device. This creates the audit trail; execute steps manually and update status as you progress.',
@@ -246,6 +247,7 @@ registerTool({
 
 registerTool({
   tier: 1,
+  deviceArgs: ['deviceId'],
   definition: {
     name: 'get_playbook_history',
     description: 'View past playbook executions for auditing and trend analysis.',

--- a/apps/api/src/services/aiToolsRemote.ts
+++ b/apps/api/src/services/aiToolsRemote.ts
@@ -57,6 +57,7 @@ export function registerRemoteTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 3 as AiToolTier,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'take_screenshot',
       description: 'Capture a screenshot of the device screen. Returns the image for visual analysis. Use this when you need to see what is displayed on the device screen.',
@@ -113,6 +114,7 @@ export function registerRemoteTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 3 as AiToolTier,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'analyze_screen',
       description: 'Take a screenshot and analyze what is visible on the device screen. Combines screenshot capture with device context for AI visual analysis. Use this for troubleshooting what the user sees.',
@@ -177,6 +179,7 @@ export function registerRemoteTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 3 as AiToolTier,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'computer_control',
       description: 'Control a device by sending mouse/keyboard input and capturing screenshots. Returns a screenshot after each action by default (configurable via captureAfter). Actions: screenshot, left_click, right_click, middle_click, double_click, mouse_move, scroll, key, type.',
@@ -253,6 +256,7 @@ export function registerRemoteTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1 as AiToolTier,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'list_remote_sessions',
       description: 'List active and recent remote sessions (terminal, desktop, file transfer).',
@@ -324,6 +328,7 @@ export function registerRemoteTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 3 as AiToolTier,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'create_remote_session',
       description: 'Create a new remote terminal or file transfer session to a device.',

--- a/apps/api/src/services/aiToolsSLABackup.ts
+++ b/apps/api/src/services/aiToolsSLABackup.ts
@@ -138,6 +138,7 @@ export function registerSLABackupTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'get_sla_breaches',
       description: 'List backup SLA breach events with optional filters for config, device, event type, and timeframe.',

--- a/apps/api/src/services/aiToolsSLABackup.ts
+++ b/apps/api/src/services/aiToolsSLABackup.ts
@@ -291,6 +291,7 @@ export function registerSLABackupTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 2,
+    deviceArgs: ['targetDevices'],
     definition: {
       name: 'configure_backup_sla',
       description: 'Create or update a backup SLA configuration.',

--- a/apps/api/src/services/aiToolsScripts.ts
+++ b/apps/api/src/services/aiToolsScripts.ts
@@ -75,6 +75,7 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 3,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'execute_command',
       description: 'Execute a system command on a device. Requires user approval. Use for process management, service control, file operations, etc.',
@@ -122,6 +123,7 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 3,
+    deviceArgs: ['deviceIds'],
     definition: {
       name: 'run_script',
       description: 'Execute a script on one or more devices. Existing scripts can be referenced by ID; inline scripts require approval.',
@@ -195,6 +197,7 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 3,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'manage_services',
       description: 'List, start, stop, or restart system services on a device.',
@@ -240,6 +243,7 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'manage_processes',
       description: 'List running processes on a device with CPU and memory usage, or terminate a process.',
@@ -690,6 +694,7 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'manage_scheduled_tasks',
       description: 'List, run, enable, disable, or delete Windows scheduled tasks on a device.',
@@ -750,6 +755,7 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'registry_operations',
       description: 'Read or modify Windows registry keys and values on a device.',

--- a/apps/api/src/services/aiToolsSecurity.ts
+++ b/apps/api/src/services/aiToolsSecurity.ts
@@ -57,6 +57,7 @@ export function registerSecurityTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 3,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'security_scan',
       description: 'Run security scans on a device, manage detected threats (quarantine, remove, restore), or query vulnerability data.',
@@ -164,6 +165,7 @@ export function registerSecurityTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'get_security_posture',
       description: 'Get fleet-wide or device-level security posture scores with factor breakdowns and prioritized recommendations.',
@@ -258,6 +260,7 @@ export function registerSecurityTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'get_sensitive_data_overview',
       description: 'Query sensitive-data discovery results. Supports dashboard totals, findings list, and recent scans.',

--- a/apps/api/src/services/aiToolsSentinelOne.ts
+++ b/apps/api/src/services/aiToolsSentinelOne.ts
@@ -144,6 +144,7 @@ export function registerSentinelOneTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'get_s1_threats',
       description: 'Query SentinelOne threats with filters for severity, status, device, and free-text search.',
@@ -249,6 +250,7 @@ export function registerSentinelOneTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 3,
+    deviceArgs: ['deviceId', 'deviceIds'],
     definition: {
       name: 's1_isolate_device',
       description: 'Isolate or unisolate one or more devices via SentinelOne. This is a high-risk containment action.',

--- a/apps/api/src/services/aiToolsVault.ts
+++ b/apps/api/src/services/aiToolsVault.ts
@@ -60,6 +60,7 @@ export function registerVaultTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'query_vaults',
       description: 'List local vault configurations and sync status for the accessible organization scope.',
@@ -130,6 +131,7 @@ export function registerVaultTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'get_vault_status',
       description: 'Get detailed vault status for a specific device, including all configured vaults and sync summaries.',
@@ -301,6 +303,7 @@ export function registerVaultTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 2,
+    deviceArgs: ['deviceId'],
     definition: {
       name: 'configure_vault',
       description: 'Create or update a local vault configuration.',


### PR DESCRIPTION
**Stacked on `fix/ai-tools-site-scope` (#1047)** — depends on its site-aware `verifyDeviceAccess`. Complements the per-file burn-down on that branch with a *structural* gate so the bug class can't recur.

## The idea

The AI-tool layer is a parallel path to the device tables, and the burn-down's safety rested on a convention: *every handler must remember to call a site gate*, enforced by a file-level "references `canAccessSite`" source scan. That convention is exactly what let the cross-org incident-tool hole (`execute_containment` / `collect_evidence`) sit undetected — and a file-level scan can't catch a per-handler or per-branch miss.

This PR makes the check **structural and declarative**:

- A tool declares the input props that carry a device id: `deviceArgs: ['deviceId']`.
- `executeTool` runs the org+site `verifyDeviceAccess` gate on each declared id **before** the handler. A tool author can no longer forget the per-device tenant check.

## Why `executeTool` alone is sufficient (no MCP bypass)

`executeTool` is the universal chokepoint for **every** device-tool path:
- Chat / SDK streaming — `aiAgentSdkTools.ts:277` → `executeTool`
- MCP tool calls — `mcpServer.ts:962` → `executeTool`
- Script builder — `scriptBuilderTools.ts:99` → `executeTool`

The only direct `tool.handler` call (`mcpServer.ts:1202`) is the **bootstrap-authTool** path (partner onboarding — no device tools). So gating `executeTool` covers all device tools; no per-path wiring needed. (My earlier spike note worried about an MCP bypass — verified false.)

## What's in the PR

1. `AiTool.deviceArgs` + `enforceDeviceArgs()` in `aiTools.ts`; wired into `executeTool` (one call before the handler). Handles a single id or array; opaque error on first denial; no-op for unrestricted callers / tools without `deviceArgs`.
2. **`deviceArgs` declared on all 75 device-arg tools** across 31 `aiTools*.ts` files (+ the 2 incident tools). Purely additive — the gate denies out-of-scope devices first; in-scope behavior is unchanged, so existing per-tool tests stay green. Inline `verifyDeviceAccess` calls remain where the handler needs the device object (now belt-and-suspenders).
3. **Contract-test ratchet** (`aiTools.deviceArgsCoverage.contract.test.ts`): introspects each registered tool's `input_schema` at runtime and fails if a `deviceId`/`deviceIds`/`device_id`/`targetDeviceId` property isn't declared in `deviceArgs`. Frozen shrink-only baseline, **now empty** — any new device-arg tool fails until it declares. Far more precise than the file-level source scan.

## Coverage / scope

- ✅ Fully gated: the ~75 tools with a direct device-id input prop (Class 1+2). This **retroactively closes** the incident cross-org hole via a 1-line declaration (demonstrated in `aiToolsIncident.deviceGate.test.ts`).
- ➖ Not covered by this mechanism (unchanged, still use the `aiToolsSiteScope` helpers from the burn-down): tools that resolve the device via a parent record (`vmId`/`snapshotId`/`findingId`) and list tools' no-device-id branches. The gate is necessary-but-not-sufficient for the split tools — it gates their *supplied* filter id; their list branch still needs `resolveSiteAllowedDeviceIds`.
- A `siteArgs` analogue for the ~8 `siteId`-keyed tools is a natural follow-up (not in this PR).

## Tests

- `aiTools.deviceGate.test.ts` (6) — gate logic
- `aiTools.executeToolGate.test.ts` (2) — proves `executeTool` runs the gate before the handler
- `aiToolsIncident.deviceGate.test.ts` (6) — declaration closes the cross-org incident hole
- `aiTools.deviceArgsCoverage.contract.test.ts` (2) — ratchet, baseline empty
- Full aiTools suite: 518 pass (1 pre-existing `aiToolsFleetStatus.test.ts` failure, fails identically without this change). `tsc --noEmit` clean.

## Relationship to the cross-org hotfix
The same incident bug is fixed for `main` in #1048 (org-only, off `main`). This PR closes it on the site-aware branch *structurally* (org **and** site) via the declaration — and prevents the whole class from recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)