### PR TITLE
test(terminal): make TestSessionStartSetsTermEnv locale-deterministic

### DIFF
--- a/agent/internal/terminal/pty_test.go
+++ b/agent/internal/terminal/pty_test.go
@@ -66,6 +66,10 @@ func TestSessionStartInvalidShell(t *testing.T) {
 }
 
 func TestSessionStartSetsTermEnv(t *testing.T) {
+	t.Setenv("LANG", "")
+	t.Setenv("LC_ALL", "")
+	t.Setenv("LC_CTYPE", "")
+
 	s := &Session{
 		ID:       "start-env",
 		Cols:     100,
@@ -110,6 +114,31 @@ func TestSessionStartSetsTermEnv(t *testing.T) {
 	}
 	if !foundLang {
 		t.Fatal("expected LANG=C.UTF-8 in env")
+	}
+}
+
+func TestSessionStartPreservesExistingUTF8Locale(t *testing.T) {
+	t.Setenv("LANG", "en_US.UTF-8")
+
+	s := &Session{
+		ID:       "start-env-preserve",
+		Cols:     80,
+		Rows:     24,
+		Shell:    "/bin/sh",
+		onOutput: func([]byte) {},
+		onClose:  func(error) {},
+	}
+
+	if err := s.start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer s.close()
+
+	if !containsEnv(s.cmd.Env, "LANG=en_US.UTF-8") {
+		t.Fatalf("expected existing UTF-8 locale to be preserved, got %v", s.cmd.Env)
+	}
+	if containsEnv(s.cmd.Env, "LANG=C.UTF-8") {
+		t.Fatalf("expected LANG=C.UTF-8 not to be appended when UTF-8 locale exists, got %v", s.cmd.Env)
 	}
 }
 


### PR DESCRIPTION
Fixes #1045.

`TestSessionStartSetsTermEnv` asserted `LANG=C.UTF-8` is always appended, but `procoutput.ApplyEnv` only appends when the base env lacks a UTF-8 locale — correct production behavior that breaks the test on machines with `LANG=en_US.UTF-8`. This neutralizes inherited locale vars in that test and adds `TestSessionStartPreservesExistingUTF8Locale` for the preservation path.

Verified with:
- `LANG=en_US.UTF-8 go test -count=1 -run 'TestSessionStart' ./internal/terminal/...`
- `env -u LANG -u LC_ALL -u LC_CTYPE go test -count=1 -run 'TestSessionStart' ./internal/terminal/...`

Made with [Cursor](https://cursor.com)