### PR TITLE
test(security): contract test for dead permissions-sourced site gates

### DIFF
--- a/apps/api/src/__tests__/helpers/routeScan.test.ts
+++ b/apps/api/src/__tests__/helpers/routeScan.test.ts
@@ -95,6 +95,213 @@ describe('analyzeRouteSource — input-sourced device-data detector', () => {
   });
 });
 
+describe('analyzeRouteSource — dead permissions-sourced site gate detector', () => {
+  // The vulnerability class: a handler gates site access with the fail-open
+  // idiom `if (perms?.allowedSiteIds && !canAccessSite(perms, …))` where
+  // `perms = c.get('permissions')`. That context value is populated ONLY by
+  // `requirePermission` middleware (auth.ts) — never by `authMiddleware` /
+  // `requireScope`. With no live source, `perms` is `undefined`, the guard is
+  // skipped, and a site-restricted user reads/writes out-of-site devices. The
+  // existing scanner passes these because they DO reference `canAccessSite` /
+  // `allowedSiteIds`; this flag catches that the gate is never actually live.
+
+  it('flags a direct fail-open perms gate with no requirePermission in the chain', () => {
+    const src = [
+      `router.get(`,
+      `  '/:deviceId/posture',`,
+      `  requireScope('organization', 'partner', 'system'),`,
+      `  async (c) => {`,
+      `    const perms = c.get('permissions') as UserPermissions | undefined;`,
+      `    if (perms?.allowedSiteIds && (typeof device.siteId !== 'string' || !canAccessSite(perms, device.siteId))) {`,
+      `      return c.json({ error: 'Access to this site denied' }, 403);`,
+      `    }`,
+      `    return c.json(await getPosture(device.id));`,
+      `  }`,
+      `);`,
+    ].join('\n');
+    const route = analyzeRouteSource('routes/x.ts', src, DEVICE_TABLES)[0]!;
+    expect(route.sitePermsGateDead).toBe(true);
+  });
+
+  it('does NOT flag when requirePermission is in the middleware chain (perms is live)', () => {
+    const src = [
+      `router.get(`,
+      `  '/:deviceId/posture',`,
+      `  requireScope('organization', 'partner', 'system'),`,
+      `  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),`,
+      `  async (c) => {`,
+      `    const perms = c.get('permissions') as UserPermissions | undefined;`,
+      `    if (perms?.allowedSiteIds && !canAccessSite(perms, device.siteId)) {`,
+      `      return c.json({ error: 'Access to this site denied' }, 403);`,
+      `    }`,
+      `    return c.json(await getPosture(device.id));`,
+      `  }`,
+      `);`,
+    ].join('\n');
+    const route = analyzeRouteSource('routes/x.ts', src, DEVICE_TABLES)[0]!;
+    expect(route.sitePermsGateDead).toBe(false);
+  });
+
+  it('does NOT flag when a getUserPermissions fallback makes the read live', () => {
+    // The security/{posture,status,threats} pattern (#900): reads
+    // c.get('permissions') but fetches it itself if the middleware didn't.
+    const src = [
+      `router.get(`,
+      `  '/:deviceId/status',`,
+      `  requireScope('organization', 'partner', 'system'),`,
+      `  async (c) => {`,
+      `    let perms = c.get('permissions') as UserPermissions | undefined;`,
+      `    if (!perms) {`,
+      `      const fetched = await getUserPermissions(auth.user.id, { orgId: auth.orgId });`,
+      `      perms = fetched || undefined;`,
+      `    }`,
+      `    if (perms?.allowedSiteIds && !canAccessSite(perms, device.siteId)) {`,
+      `      return c.json({ error: 'Access to this site denied' }, 403);`,
+      `    }`,
+      `    return c.json(status);`,
+      `  }`,
+      `);`,
+    ].join('\n');
+    const route = analyzeRouteSource('routes/x.ts', src, DEVICE_TABLES)[0]!;
+    expect(route.sitePermsGateDead).toBe(false);
+  });
+
+  it('flags a perms gate reached via a file-local helper with no requirePermission', () => {
+    // The tunnels.ts pattern: getDeviceForTunnel reads c.get('permissions')
+    // and gates on canAccessSite; the calling route has only requireScope.
+    const src = [
+      `async function getDeviceForX(c, deviceId, auth) {`,
+      `  const [device] = await db.select().from(devices).where(eq(devices.id, deviceId)).limit(1);`,
+      `  if (!device) return null;`,
+      `  if (!auth.canAccessOrg(device.orgId)) return null;`,
+      `  const permissions = c.get('permissions') as UserPermissions | undefined;`,
+      `  if (permissions?.allowedSiteIds && (typeof device.siteId !== 'string' || !canAccessSite(permissions, device.siteId))) {`,
+      `    return 'SITE_ACCESS_DENIED';`,
+      `  }`,
+      `  return device;`,
+      `}`,
+      `router.get(`,
+      `  '/:id',`,
+      `  requireScope('organization', 'partner', 'system'),`,
+      `  async (c) => {`,
+      `    const device = await getDeviceForX(c, c.req.param('id'), auth);`,
+      `    return c.json(device);`,
+      `  }`,
+      `);`,
+    ].join('\n');
+    const route = analyzeRouteSource('routes/x.ts', src, DEVICE_TABLES).find(
+      (r) => r.id === "routes/x.ts:GET /:id",
+    )!;
+    expect(route.sitePermsGateDead).toBe(true);
+  });
+
+  it('does NOT flag the same helper-gated route when requirePermission is present', () => {
+    const src = [
+      `async function getDeviceForX(c, deviceId, auth) {`,
+      `  const permissions = c.get('permissions') as UserPermissions | undefined;`,
+      `  if (permissions?.allowedSiteIds && !canAccessSite(permissions, device.siteId)) {`,
+      `    return 'SITE_ACCESS_DENIED';`,
+      `  }`,
+      `  return device;`,
+      `}`,
+      `router.post(`,
+      `  '/',`,
+      `  requireScope('organization', 'partner', 'system'),`,
+      `  requirePermission(PERMISSIONS.DEVICES_EXECUTE.resource, PERMISSIONS.DEVICES_EXECUTE.action),`,
+      `  async (c) => {`,
+      `    const device = await getDeviceForX(c, body.deviceId, auth);`,
+      `    return c.json(device);`,
+      `  }`,
+      `);`,
+    ].join('\n');
+    const route = analyzeRouteSource('routes/x.ts', src, DEVICE_TABLES).find(
+      (r) => r.id === "routes/x.ts:POST /",
+    )!;
+    expect(route.sitePermsGateDead).toBe(false);
+  });
+
+  it('does NOT flag when a requirePermission-bound middleware const is in the chain', () => {
+    // Real-world idiom: routes use `const requireXRead = requirePermission(…)`
+    // and put `requireXRead` in the chain. That populates c.get('permissions')
+    // exactly like inline requirePermission — so the gate is live.
+    const src = [
+      `const requireMonitorRead = requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action);`,
+      `router.get(`,
+      `  '/',`,
+      `  requireScope('organization', 'partner', 'system'),`,
+      `  requireMonitorRead,`,
+      `  async (c) => {`,
+      `    const perms = c.get('permissions') as UserPermissions | undefined;`,
+      `    if (perms?.allowedSiteIds && !canAccessSite(perms, asset.siteId)) return c.json({}, 403);`,
+      `    return c.json(results);`,
+      `  }`,
+      `);`,
+    ].join('\n');
+    const route = analyzeRouteSource('routes/x.ts', src, DEVICE_TABLES).find(
+      (r) => r.id === "routes/x.ts:GET /",
+    )!;
+    expect(route.sitePermsGateDead).toBe(false);
+  });
+
+  it('does NOT flag when requireSiteAccess middleware is in the chain', () => {
+    // requireSiteAccess self-resolves perms (getUserPermissions fallback) and
+    // does its own canAccessSite check — so the route is gated live.
+    const src = [
+      `router.get(`,
+      `  '/sites/:siteId/report',`,
+      `  requireScope('organization', 'partner', 'system'),`,
+      `  requireSiteAccess('siteId'),`,
+      `  async (c) => {`,
+      `    const perms = c.get('permissions');`,
+      `    if (perms?.allowedSiteIds && !canAccessSite(perms, siteId)) return c.json({}, 403);`,
+      `    return c.json(report);`,
+      `  }`,
+      `);`,
+    ].join('\n');
+    const route = analyzeRouteSource('routes/x.ts', src, DEVICE_TABLES)[0]!;
+    expect(route.sitePermsGateDead).toBe(false);
+  });
+
+  it('does NOT flag a fail-closed helper that throws when perms is missing', () => {
+    // The getDeviceWithOrgAndSiteCheck pattern: throws 500 if perms absent, so
+    // a missing requirePermission breaks the request rather than silently
+    // granting cross-site access — not a security hole.
+    const src = [
+      `async function getDeviceChecked(c, deviceId, auth) {`,
+      `  const userPerms = c.get('permissions') as UserPermissions | undefined;`,
+      `  if (!userPerms) {`,
+      `    throw new HTTPException(500, { message: 'called without requirePermission middleware' });`,
+      `  }`,
+      `  if (!userPerms.allowedSiteIds) return device;`,
+      `  if (!canAccessSite(userPerms, device.siteId)) return SITE_ACCESS_DENIED;`,
+      `  return device;`,
+      `}`,
+      `router.get(`,
+      `  '/:deviceId',`,
+      `  requireScope('organization', 'partner', 'system'),`,
+      `  async (c) => {`,
+      `    const device = await getDeviceChecked(c, c.req.param('deviceId'), auth);`,
+      `    return c.json(device);`,
+      `  }`,
+      `);`,
+    ].join('\n');
+    const route = analyzeRouteSource('routes/x.ts', src, DEVICE_TABLES).find(
+      (r) => r.id === "routes/x.ts:GET /:deviceId",
+    )!;
+    expect(route.sitePermsGateDead).toBe(false);
+  });
+
+  it('does NOT flag a plain org-only handler with no perms-sourced site gate', () => {
+    const src = `
+      router.get('/settings', async (c) => {
+        return c.json(await db.select().from(orgSettings).where(eq(orgSettings.orgId, auth.orgId)));
+      });
+    `;
+    const route = analyzeRouteSource('routes/x.ts', src, DEVICE_TABLES)[0]!;
+    expect(route.sitePermsGateDead).toBe(false);
+  });
+});
+
 describe('findDeviceScopedTables — schema-derived table set', () => {
   it('includes known device/site-scoped tables', async () => {
     const tables = await findDeviceScopedTables();

--- a/apps/api/src/__tests__/helpers/routeScan.ts
+++ b/apps/api/src/__tests__/helpers/routeScan.ts
@@ -44,6 +44,25 @@ export interface RouteInfo {
    * input-sourced / list-style class the `:deviceId`-URL scan can't see.
    */
   touchesDeviceData: boolean;
+  /**
+   * True iff the handler gates site access through the request-scoped
+   * `permissions` context (`c.get('permissions')` → `canAccessSite` /
+   * `allowedSiteIds`), directly or via a file-local helper, but has NO live
+   * source for that context: no `requirePermission(` in the middleware chain,
+   * no `getUserPermissions(` fallback, no self-resolving `requireSiteAccess`.
+   *
+   * This is the dead-gate blind spot: `permissions` is populated ONLY by
+   * `requirePermission` (`middleware/auth.ts` does `c.set('permissions', …)`),
+   * never by `authMiddleware`/`requireScope`. The fail-open idiom
+   * `if (perms?.allowedSiteIds && !canAccessSite(perms, …))` therefore SKIPS
+   * the check when `perms` is `undefined`, silently granting a site-restricted
+   * user access to out-of-site devices. The {@link usesSiteScopeGate} flag
+   * does NOT catch this — the gate *text* is present, it just never runs.
+   * Fail-closed helpers (which `throw` when `permissions` is absent, e.g.
+   * `getDeviceWithOrgAndSiteCheck`) are excluded: they break the request
+   * rather than leak. See #1042 re-review.
+   */
+  sitePermsGateDead: boolean;
 }
 
 const ROUTE_DIR = path.resolve(__dirname, '../../routes');
@@ -126,6 +145,43 @@ const HANDLER_SLICE_BYTES = 4000;
  *  function`, or `(` (arrow / function-expression) to exclude calls. */
 const LOCAL_HELPER_DECL = /^(?:async\s+)?function\s+(\w+)\s*[\(<]|^(?:export\s+)?const\s+(\w+)\s*=\s*(?:async\s+)?(?:function\b|\()/gm;
 
+// --- Dead permissions-sourced site-gate detection (see RouteInfo.sitePermsGateDead) ---
+
+/** Reads the request-scoped permissions object. Populated ONLY by
+ *  `requirePermission` middleware (`auth.ts` does `c.set('permissions', …)`),
+ *  never by `authMiddleware`/`requireScope`. */
+const PERMS_CONTEXT_READ = /c\.get\(\s*['"`]permissions['"`]\s*\)/;
+/** Site-gating tokens that operate on the permissions object. */
+const PERMS_SITE_TOKEN = /\bcanAccessSite\b|\ballowedSiteIds\b/;
+/** A live source of permissions in the route's middleware chain or handler:
+ *  `requirePermission(` populates the context; `getUserPermissions(` is the
+ *  inline fallback; `requireSiteAccess` self-resolves perms and gates itself. */
+const LIVE_PERMS_SOURCE = /\brequirePermission\s*\(|\bgetUserPermissions\s*\(|\brequireSiteAccess\b/;
+/** Fail-closed guard: `if (!perms) { … throw … }`. A handler/helper that
+ *  throws when the permissions context is absent breaks the request rather
+ *  than silently granting cross-site access, so a missing `requirePermission`
+ *  is a 500, not a leak (e.g. `getDeviceWithOrgAndSiteCheck`). */
+const FAIL_CLOSED_PERMS = /if\s*\(\s*!\s*\w*[Pp]erm\w*\s*\)\s*\{[^}]*\bthrow\b/;
+/** File-local middleware constants bound to a `requirePermission(...)` call,
+ *  e.g. `const requireMonitorRead = requirePermission(PERMISSIONS.DEVICES_READ…)`.
+ *  Putting one of these in a route's chain populates `c.get('permissions')`
+ *  exactly as inline `requirePermission(...)` does — so it is a LIVE source.
+ *  The bare `requirePermission(` literal in {@link LIVE_PERMS_SOURCE} only
+ *  catches inline use, not the (very common) named-const middleware. */
+const REQUIRE_PERMISSION_CONST = /\bconst\s+(\w+)\s*=\s*requirePermission\s*\(/g;
+
+/** Names of file-local consts bound to `requirePermission(...)` (live perms
+ *  middleware). See {@link REQUIRE_PERMISSION_CONST}. */
+function findRequirePermissionConsts(text: string): string[] {
+  const names: string[] = [];
+  REQUIRE_PERMISSION_CONST.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = REQUIRE_PERMISSION_CONST.exec(text)) !== null) {
+    if (m[1]) names.push(m[1]);
+  }
+  return names;
+}
+
 async function listTsFiles(dir: string): Promise<string[]> {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   const files: string[] = [];
@@ -143,16 +199,16 @@ async function listTsFiles(dir: string): Promise<string[]> {
   return files;
 }
 
+type LocalDecl = { index: number; name: string };
+
 /**
- * One-pass: collect names of file-local helpers that reference a canonical
- * gate anywhere in their body. The body window starts at the declaration
- * and ends at either HANDLER_SLICE_BYTES OR the start of the next top-level
- * declaration, whichever comes first. This prevents a helper's slice from
- * spilling into an unrelated function further down the file.
+ * Collect every top-level function/arrow declaration with its body window.
+ * The window starts at the declaration and ends at either HANDLER_SLICE_BYTES
+ * OR the start of the next top-level declaration, whichever comes first — so a
+ * helper's slice can't spill into an unrelated function further down the file.
  */
-function findLocalGateWrappers(text: string): string[] {
-  type Decl = { index: number; name: string };
-  const decls: Decl[] = [];
+function collectLocalDeclBodies(text: string): Array<LocalDecl & { body: string }> {
+  const decls: LocalDecl[] = [];
   LOCAL_HELPER_DECL.lastIndex = 0;
   let match: RegExpExecArray | null;
   while ((match = LOCAL_HELPER_DECL.exec(text)) !== null) {
@@ -160,16 +216,45 @@ function findLocalGateWrappers(text: string): string[] {
     if (!name) continue;
     decls.push({ index: match.index, name });
   }
-
-  const names: string[] = [];
-  for (let i = 0; i < decls.length; i++) {
-    const decl = decls[i];
-    if (!decl) continue;
-    if (CANONICAL_GATE_NAMES.includes(decl.name as (typeof CANONICAL_GATE_NAMES)[number])) continue;
+  return decls.map((decl, i) => {
     const nextStart = decls[i + 1]?.index ?? text.length;
     const bodyEnd = Math.min(decl.index + HANDLER_SLICE_BYTES, nextStart);
-    const body = text.slice(decl.index, bodyEnd);
-    if (CANONICAL_GATE_PATTERNS.some((re) => re.test(body))) {
+    return { ...decl, body: text.slice(decl.index, bodyEnd) };
+  });
+}
+
+/**
+ * Names of file-local helpers that reference a canonical gate anywhere in
+ * their body. Routes that call these are gated even when the handler slice
+ * doesn't show the gate name directly.
+ */
+function findLocalGateWrappers(text: string): string[] {
+  const names: string[] = [];
+  for (const decl of collectLocalDeclBodies(text)) {
+    if (CANONICAL_GATE_NAMES.includes(decl.name as (typeof CANONICAL_GATE_NAMES)[number])) continue;
+    if (CANONICAL_GATE_PATTERNS.some((re) => re.test(decl.body))) names.push(decl.name);
+  }
+  return names;
+}
+
+/**
+ * Names of file-local helpers that gate site access by reading the permissions
+ * CONTEXT (`c.get('permissions')` → `canAccessSite`/`allowedSiteIds`) WITHOUT a
+ * self-sufficient source — no `getUserPermissions(` fallback and no fail-closed
+ * `throw`. A route that calls one of these is only safe if it itself runs
+ * `requirePermission`; otherwise the gate is dead. See the `sitePermsGateDead`
+ * computation in {@link analyzeRouteSource} (the tunnels `getDeviceForTunnel`
+ * shape from the #1042 re-review).
+ */
+function findPermsContextGateHelpers(text: string): string[] {
+  const names: string[] = [];
+  for (const decl of collectLocalDeclBodies(text)) {
+    if (
+      PERMS_CONTEXT_READ.test(decl.body) &&
+      PERMS_SITE_TOKEN.test(decl.body) &&
+      !/\bgetUserPermissions\s*\(/.test(decl.body) &&
+      !FAIL_CLOSED_PERMS.test(decl.body)
+    ) {
       names.push(decl.name);
     }
   }
@@ -196,6 +281,25 @@ export function analyzeRouteSource(
     ...CANONICAL_GATE_PATTERNS,
     ...localGateNames.map((n) => new RegExp(`\\b${n}\\b`)),
   ];
+
+  // File-local helpers that gate via the permissions CONTEXT with no
+  // self-sufficient source — calling one without `requirePermission` is dead.
+  const permsGateHelpers = findPermsContextGateHelpers(text);
+  const permsHelperCallPattern =
+    permsGateHelpers.length > 0
+      ? new RegExp(`\\b(?:${permsGateHelpers.map(escapeRegExp).join('|')})\\s*\\(`)
+      : null;
+
+  // A live source of the permissions context in a route's chain: the inline
+  // forms (LIVE_PERMS_SOURCE) plus any file-local requirePermission-bound
+  // middleware const used by name.
+  const permConstNames = findRequirePermissionConsts(text);
+  const livePermsPattern =
+    permConstNames.length > 0
+      ? new RegExp(
+          `${LIVE_PERMS_SOURCE.source}|\\b(?:${permConstNames.map(escapeRegExp).join('|')})\\b`,
+        )
+      : LIVE_PERMS_SOURCE;
 
   const tableColPattern =
     deviceTables.size > 0
@@ -233,6 +337,16 @@ export function analyzeRouteSource(
       (tableColPattern !== null && tableColPattern.test(slice)) ||
       JOIN_DEVICES_PATTERN.test(slice);
 
+    // Dead permissions-sourced site gate: the handler gates on the
+    // `permissions` context (directly or via a perms-context helper) but the
+    // route has no live source for it, so the gate never runs. Fail-closed
+    // handlers (throw on missing perms) are excluded.
+    const permsSiteGate =
+      (PERMS_CONTEXT_READ.test(slice) && PERMS_SITE_TOKEN.test(slice)) ||
+      (permsHelperCallPattern !== null && permsHelperCallPattern.test(slice));
+    const sitePermsGateDead =
+      permsSiteGate && !livePermsPattern.test(slice) && !FAIL_CLOSED_PERMS.test(slice);
+
     const line = text.slice(0, cur.index).split('\n').length;
 
     results.push({
@@ -242,6 +356,7 @@ export function analyzeRouteSource(
       usesSiteScopeGate,
       deviceOrSiteUrlParam,
       touchesDeviceData,
+      sitePermsGateDead,
     });
   }
 
@@ -306,4 +421,15 @@ export async function findRoutesTouchingDevices(): Promise<RouteInfo[]> {
  */
 export async function findRoutesTouchingDeviceData(): Promise<RouteInfo[]> {
   return (await scanAllRoutes()).filter((r) => r.touchesDeviceData);
+}
+
+/**
+ * Routes whose site gate depends on the request-scoped `permissions` context
+ * but which lack a live source for it ({@link RouteInfo.sitePermsGateDead}) —
+ * the dead-gate class where the site check is present in source but never runs
+ * because no `requirePermission` populated `permissions`. Backs the
+ * live-permissions contract test.
+ */
+export async function findRoutesWithDeadPermsSiteGate(): Promise<RouteInfo[]> {
+  return (await scanAllRoutes()).filter((r) => r.sitePermsGateDead);
 }

--- a/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   findRoutesTouchingDevices,
   findRoutesTouchingDeviceData,
+  findRoutesWithDeadPermsSiteGate,
   type RouteInfo,
 } from '../helpers/routeScan';
 
@@ -284,6 +285,100 @@ describe('site-scope coverage — input-sourced / list-style', () => {
         ? ''
         : `\nBaseline/exempt entries no longer flagged (handler fixed or moved — ` +
           `remove them so the ratchet tightens):\n` +
+          stale.map((s) => `  - ${s}`).join('\n');
+    expect(stale, message).toEqual([]);
+  });
+});
+
+/**
+ * Third detector: DEAD permissions-sourced site gates. This is the blind spot
+ * the #1042 re-review uncovered. The two detectors above check whether a
+ * site-scope gate is *present* in source. They do NOT check whether it ever
+ * *runs*: the fail-open idiom
+ *
+ *     const perms = c.get('permissions');
+ *     if (perms?.allowedSiteIds && !canAccessSite(perms, device.siteId)) deny();
+ *
+ * reads `permissions` from the request context — which is populated ONLY by
+ * `requirePermission` middleware (`middleware/auth.ts` does
+ * `c.set('permissions', …)`), NEVER by `authMiddleware`/`requireScope`. A route
+ * carrying only `requireScope` leaves `perms` `undefined`, so `perms?.…` is
+ * falsy, the guard is skipped, and a site-restricted partner user reads/writes
+ * out-of-site devices. The gate text is present (so the detectors above pass),
+ * but it is dead. The original scanner treated `canAccessSite`/`allowedSiteIds`
+ * as proof of a gate; this detector additionally requires a LIVE source for the
+ * `permissions` context.
+ *
+ * {@link findRoutesWithDeadPermsSiteGate} flags a route when its handler — or a
+ * file-local helper it calls — gates on the `permissions` context with no live
+ * source (`requirePermission(` in the chain, a `getUserPermissions(` fallback,
+ * or self-resolving `requireSiteAccess`). Fail-closed helpers that THROW on a
+ * missing context (`getDeviceWithOrgAndSiteCheck`) are excluded — they break
+ * the request rather than leak.
+ *
+ * Routes that legitimately gate via `getUserPermissions` fallback are NOT
+ * flagged — e.g. `routes/security/{posture,status,threats}.ts`, which fetch
+ * permissions themselves (PR #900) and so stay live under plain `requireScope`.
+ */
+// Vetted-safe: confirmed NOT a dead gate despite matching the static shape.
+// Each entry MUST carry a one-line justification.
+const DEAD_PERMS_GATE_EXEMPT: ReadonlySet<string> = new Set<string>([
+]);
+
+// BASELINE RATCHET — routes whose perms-sourced site gate is dead RIGHT NOW,
+// carried as frozen debt so this detector lands green and blocks NEW offenders.
+// The "shrink-only" test makes the ratchet one-directional: as each entry gains
+// a live perms source (and drops out of the flagged set), its line MUST be
+// removed.
+//
+// EMPTY: when this detector was first written (against the pre-merge scanner
+// base) it flagged 5 dead gates — dnsSecurity GET /events+/stats, huntress GET
+// /incidents, peripheralControl GET /activity, sentinelOne GET /threats — the
+// 2026-05 sweep (commit b6da267a) had added their `allowedSiteIds` narrowing
+// but not the `requirePermission` that populates `c.get('permissions')`. All 5
+// were independently fixed in #1036's final revision (now in main: each route
+// carries `requirePermission(DEVICES_READ)`), so the detector finds zero
+// offenders here. It ships with no residual debt; any future offender fails the
+// test above and must be fixed.
+const DEAD_PERMS_GATE_BASELINE: ReadonlySet<string> = new Set<string>([
+]);
+
+describe('site-scope coverage — dead permissions-sourced gate', () => {
+  it('no route gates on the permissions context without a live source', async () => {
+    const routes = await findRoutesWithDeadPermsSiteGate();
+    const offenders = routes.filter(
+      (r) =>
+        !DEAD_PERMS_GATE_EXEMPT.has(r.id) && !DEAD_PERMS_GATE_BASELINE.has(r.id),
+    );
+
+    const message =
+      offenders.length === 0
+        ? ''
+        : `\n${offenders.length} route(s) gate site access on the \`permissions\` ` +
+          `context but have no live source for it (no requirePermission in the ` +
+          `chain, no getUserPermissions fallback, no requireSiteAccess) — the ` +
+          `site gate is present in source but NEVER runs:\n` +
+          offenders.map(formatOffender).join('\n') +
+          `\n\nFix by adding requirePermission(DEVICES_READ/…) to the middleware ` +
+          `chain (populates c.get('permissions')), OR a getUserPermissions ` +
+          `fallback in the handler. If genuinely safe, add the id to ` +
+          `DEAD_PERMS_GATE_EXEMPT with a one-line reason. Do NOT extend ` +
+          `DEAD_PERMS_GATE_BASELINE — that set is frozen and only shrinks.`;
+
+    expect(offenders, message).toEqual([]);
+  });
+
+  it('the baseline/allowlist shrink-only (no stale entries)', async () => {
+    const routes = await findRoutesWithDeadPermsSiteGate();
+    const stillFlagged = new Set(routes.map((r) => r.id));
+    const stale = [...DEAD_PERMS_GATE_BASELINE, ...DEAD_PERMS_GATE_EXEMPT].filter(
+      (e) => !stillFlagged.has(e),
+    );
+    const message =
+      stale.length === 0
+        ? ''
+        : `\nDead-perms-gate baseline/exempt entries no longer flagged (handler ` +
+          `gained a live source or moved — remove them so the ratchet tightens):\n` +
           stale.map((s) => `  - ${s}`).join('\n');
     expect(stale, message).toEqual([]);
   });


### PR DESCRIPTION
A permanent contract test for the dead-site-gate class — the blind spot the #1042 re-review surfaced. **Detector-only:** the 5 routes it originally flagged were already fixed in `main`, so this ships with an empty baseline and zero residual debt.

## The blind spot

The site-scope scanner verified a gate was *present* in source, never that it *runs*. The fail-open idiom

```ts
const perms = c.get('permissions');
if (perms?.allowedSiteIds && !canAccessSite(perms, device.siteId)) deny();
```

is dead under `authMiddleware`/`requireScope`: `c.get('permissions')` is populated ONLY by `requirePermission` (`middleware/auth.ts` does `c.set('permissions', …)`). With no live source `perms` is `undefined`, the guard is skipped, and a site-restricted partner user reads out-of-site data. The original scanner passed these because the gate *text* references `canAccessSite`/`allowedSiteIds` — it just never executes. This is the exact blind spot that let the #1042 dead code through both the code and the first review.

## The detector

`RouteInfo.sitePermsGateDead` + `findRoutesWithDeadPermsSiteGate` in `routeScan.ts`, plus a third block in `site-scope-coverage.integration.test.ts`. A route is flagged when its handler — or a file-local helper it calls — gates on the `permissions` context with no live source: no `requirePermission(` (inline OR a `const requireXRead = requirePermission(...)` named-const middleware), no `getUserPermissions(` fallback, no self-resolving `requireSiteAccess`. Fail-closed helpers that throw on missing perms (`getDeviceWithOrgAndSiteCheck`) are excluded — they 500, they don't leak.

Recognizing the named-const middleware was load-bearing — it cut real-code hits from **36 → the genuine set**, false-positive-free.

## Why the baseline is empty

Run against the pre-merge scanner base, the detector flagged 5 real dead gates (dnsSecurity GET /events+/stats, huntress GET /incidents, peripheralControl GET /activity, sentinelOne GET /threats) — residual from the 2026-05 sweep (`b6da267a`), which added the narrowing but not the `requirePermission`. **All 5 were independently fixed in #1036's final revision** (now in `main` — each carries `requirePermission(DEVICES_READ)`). So the detector finds zero offenders and ships with an empty baseline; any new offender fails the test.

## Not a hole: a re-review false alarm corrected

`routes/security/{posture,status,threats}.ts` were flagged in the #1042 re-review as the same dead-code pattern — they are NOT. All three fetch perms via a `getUserPermissions` fallback (#900), so their gate is live under plain `requireScope`. The detector does not flag them.

## Verification

RED→GREEN with 9 unit fixtures. routeScan **17/17**, site-scope-coverage **6/6** (empty baseline, against main's fixed routes), `tsc` clean. Refactor extracted a shared `collectLocalDeclBodies` — existing `findRoutesTouchingDevices`/`findRoutesTouchingDeviceData` detectors unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
