### PR TITLE
test(security): input-sourced site-scope contract scanner (baseline ratchet) + AI-tools plan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,13 @@ jobs:
       - name: Run API tests
         run: pnpm test --filter=@breeze/api
 
+      # Site-scope contract tests are pure static analysis (walk routes/*.ts
+      # from disk, no DB/Redis), so they run here in the fast, blocking job
+      # rather than the non-blocking smoke-test. Guards both the `:deviceId`-URL
+      # coverage and the input-sourced/list-style detector against regressions.
+      - name: Run site-scope coverage contract test
+        run: pnpm --filter=@breeze/api test:site-scope-coverage
+
   # Real-Postgres apply of every migration against an empty database.
   # Catches ordering bugs (issue #506) and any SQL error the static
   # autoMigrate.test.ts cannot see. Cheap (~1 min) and blocking on PRs.

--- a/apps/api/src/__tests__/helpers/routeScan.test.ts
+++ b/apps/api/src/__tests__/helpers/routeScan.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+  analyzeRouteSource,
+  findDeviceScopedTables,
+} from './routeScan';
+
+// Device-scoped table export names used by the inline fixtures below.
+const DEVICE_TABLES = new Set([
+  'browserExtensions',
+  'deviceMetrics',
+  'peripheralEvents',
+  'devices',
+]);
+
+describe('analyzeRouteSource — input-sourced device-data detector', () => {
+  it('flags a query-param deviceId read with no site gate', () => {
+    const src = `
+      router.get('/extensions', async (c) => {
+        const { deviceId } = c.req.query();
+        const conditions = [eq(browserExtensions.orgId, auth.orgId)];
+        if (deviceId) conditions.push(eq(browserExtensions.deviceId, deviceId));
+        return c.json(await db.select().from(browserExtensions).where(and(...conditions)));
+      });
+    `;
+    const route = analyzeRouteSource('routes/x.ts', src, DEVICE_TABLES)[0]!;
+    expect(route.touchesDeviceData).toBe(true);
+    expect(route.usesSiteScopeGate).toBe(false);
+  });
+
+  it('does NOT flag when a site gate is present', () => {
+    const src = `
+      router.get('/extensions', async (c) => {
+        const perms = c.get('permissions');
+        const allowed = await resolveSiteAllowedDeviceIds(auth.orgId, perms);
+        const conditions = [eq(browserExtensions.orgId, auth.orgId)];
+        if (perms?.allowedSiteIds) conditions.push(inArray(browserExtensions.deviceId, allowed));
+        return c.json(await db.select().from(browserExtensions).where(and(...conditions)));
+      });
+    `;
+    const route = analyzeRouteSource('routes/x.ts', src, DEVICE_TABLES)[0]!;
+    expect(route.touchesDeviceData).toBe(true);
+    expect(route.usesSiteScopeGate).toBe(true);
+  });
+
+  it('flags a body-sourced deviceIds (inArray) read with no gate', () => {
+    const src = `
+      router.post('/query', async (c) => {
+        const data = c.req.valid('json');
+        const where = and(inArray(deviceMetrics.deviceId, data.deviceIds), eq(deviceMetrics.orgId, auth.orgId));
+        return c.json(await db.select().from(deviceMetrics).where(where));
+      });
+    `;
+    const route = analyzeRouteSource('routes/x.ts', src, DEVICE_TABLES)[0]!;
+    expect(route.touchesDeviceData).toBe(true);
+    expect(route.usesSiteScopeGate).toBe(false);
+  });
+
+  it('flags a list read that joins devices with no gate', () => {
+    const src = `
+      router.get('/incidents', async (c) => {
+        return c.json(await db.select().from(huntressIncidents)
+          .leftJoin(devices, eq(huntressIncidents.deviceId, devices.id))
+          .where(eq(huntressIncidents.orgId, auth.orgId)));
+      });
+    `;
+    const route = analyzeRouteSource('routes/x.ts', src, DEVICE_TABLES)[0]!;
+    expect(route.touchesDeviceData).toBe(true);
+    expect(route.usesSiteScopeGate).toBe(false);
+  });
+
+  it('does NOT flag a handler that never touches device-scoped data', () => {
+    const src = `
+      router.get('/settings', async (c) => {
+        return c.json(await db.select().from(orgSettings).where(eq(orgSettings.orgId, auth.orgId)));
+      });
+    `;
+    const route = analyzeRouteSource('routes/x.ts', src, DEVICE_TABLES)[0]!;
+    expect(route.touchesDeviceData).toBe(false);
+  });
+
+  it('resolves a site gate reached via a file-local helper wrapper', () => {
+    // Top-level helper declared at column 0, as in real route files
+    // (findLocalGateWrappers anchors helper declarations to line start).
+    const src = [
+      `function assertDeviceSite(c, id) { return canAccessSite(c.get('permissions'), id); }`,
+      `router.get('/activity', async (c) => {`,
+      `  const { deviceId } = c.req.query();`,
+      `  assertDeviceSite(c, deviceId);`,
+      `  return c.json(await db.select().from(peripheralEvents).where(eq(peripheralEvents.deviceId, deviceId)));`,
+      `});`,
+    ].join('\n');
+    const route = analyzeRouteSource('routes/x.ts', src, DEVICE_TABLES)[0]!;
+    expect(route.touchesDeviceData).toBe(true);
+    expect(route.usesSiteScopeGate).toBe(true);
+  });
+});
+
+describe('findDeviceScopedTables — schema-derived table set', () => {
+  it('includes known device/site-scoped tables', async () => {
+    const tables = await findDeviceScopedTables();
+    expect(tables.has('browserExtensions')).toBe(true);
+    expect(tables.has('peripheralEvents')).toBe(true);
+    expect(tables.has('deviceMetrics')).toBe(true);
+  });
+
+  it('excludes a clearly org-only table (organizations)', async () => {
+    const tables = await findDeviceScopedTables();
+    expect(tables.has('organizations')).toBe(false);
+  });
+});

--- a/apps/api/src/__tests__/helpers/routeScan.ts
+++ b/apps/api/src/__tests__/helpers/routeScan.ts
@@ -67,6 +67,14 @@ const CANONICAL_GATE_NAMES = [
   'resolveSiteAllowedDeviceIds',
   'hasDeniedDeviceSite',
   'hasDeniedThreatDeviceSite',
+  // NOTE: `getDeviceWithOrgCheck` (routes/remote/helpers.ts) is a cross-file
+  // site-aware resolver, but it is deliberately NOT listed as a gate token.
+  // It gates only the code path where a deviceId is supplied — e.g.
+  // DELETE /sessions/stale site-gates a specific device but falls back to
+  // org-only cleanup when deviceId is omitted. A global token would mask that
+  // real gap. The two genuinely-gated callers it would clear (remote POST
+  // /sessions, POST /transfers) stay in the baseline as known false positives
+  // instead. A future import-aware resolver could clear them precisely.
   // Bare token: every correct gate path references `allowedSiteIds` (directly
   // or through a helper), so this is a safe catch-all that keeps gated
   // handlers green even if they use a bespoke local helper.

--- a/apps/api/src/__tests__/helpers/routeScan.ts
+++ b/apps/api/src/__tests__/helpers/routeScan.ts
@@ -35,16 +35,42 @@ export interface RouteInfo {
   line: number;
   /** True iff the handler body references at least one site-scope gate. */
   usesSiteScopeGate: boolean;
+  /** True iff the URL pattern names a device (`:deviceId`) or sits under `/sites/:param`. */
+  deviceOrSiteUrlParam: boolean;
+  /**
+   * True iff the handler body reads/writes device-scoped data sourced from
+   * request input or a join — i.e. a Drizzle condition on a device/site column
+   * of a known device-scoped table, or a join to `devices`. This is the
+   * input-sourced / list-style class the `:deviceId`-URL scan can't see.
+   */
+  touchesDeviceData: boolean;
 }
 
 const ROUTE_DIR = path.resolve(__dirname, '../../routes');
 const SRC_DIR = path.resolve(__dirname, '../..');
+const SCHEMA_DIR = path.resolve(__dirname, '../../db/schema');
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// A join to the devices table exposes device rows alongside child-table data,
+// so it counts as touching device-scoped data.
+const JOIN_DEVICES_PATTERN = /\b(?:inner|left|right)Join\s*\(\s*devices\b/;
 
 const CANONICAL_GATE_NAMES = [
   'requireSiteAccess',
   'canAccessDeviceSite',
   'getDeviceWithOrgAndSiteCheck',
   'canAccessSite',
+  // Site-narrowing helpers established by the 2026-05 input-sourced sweep.
+  'resolveSiteAllowedDeviceIds',
+  'hasDeniedDeviceSite',
+  'hasDeniedThreatDeviceSite',
+  // Bare token: every correct gate path references `allowedSiteIds` (directly
+  // or through a helper), so this is a safe catch-all that keeps gated
+  // handlers green even if they use a bespoke local helper.
+  'allowedSiteIds',
 ] as const;
 
 const CANONICAL_GATE_PATTERNS: readonly RegExp[] = CANONICAL_GATE_NAMES.map(
@@ -142,65 +168,134 @@ function findLocalGateWrappers(text: string): string[] {
   return names;
 }
 
-export async function findRoutesTouchingDevices(): Promise<RouteInfo[]> {
-  const files = await listTsFiles(ROUTE_DIR);
+/**
+ * Pure analysis of one route file's source. Returns one {@link RouteInfo} per
+ * Hono route definition, with all three flags computed. Kept side-effect-free
+ * (no fs) so it can be unit-tested with inline source fixtures.
+ *
+ * @param deviceTables export names of device/site-scoped Drizzle tables (from
+ *   {@link findDeviceScopedTables}); a condition on `<table>.deviceId` /
+ *   `<table>.siteId` for one of these is the device-data signal.
+ */
+export function analyzeRouteSource(
+  relFile: string,
+  text: string,
+  deviceTables: ReadonlySet<string>,
+): RouteInfo[] {
+  // File-local helpers that wrap a canonical gate (e.g. `assertDeviceAccess`).
+  const localGateNames = findLocalGateWrappers(text);
+  const gatePatterns = [
+    ...CANONICAL_GATE_PATTERNS,
+    ...localGateNames.map((n) => new RegExp(`\\b${n}\\b`)),
+  ];
+
+  const tableColPattern =
+    deviceTables.size > 0
+      ? new RegExp(
+          `\\b(${[...deviceTables].map(escapeRegExp).join('|')})\\.(?:deviceId|siteId)\\b`,
+        )
+      : null;
+
+  type RouteMatch = { index: number; method: string; urlPattern: string };
+  const routeMatches: RouteMatch[] = [];
+  ROUTE_DEF_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = ROUTE_DEF_PATTERN.exec(text)) !== null) {
+    const method = match[1];
+    const urlPattern = match[2];
+    if (!method || !urlPattern) continue;
+    routeMatches.push({ index: match.index, method, urlPattern });
+  }
+
   const results: RouteInfo[] = [];
+  for (let i = 0; i < routeMatches.length; i++) {
+    const cur = routeMatches[i];
+    if (!cur) continue;
 
-  for (const file of files) {
-    const text = await fs.readFile(file, 'utf8');
+    // Each slice is bounded by the start of the next route so a handler that
+    // drops its gate cannot inherit a sibling's gate string.
+    const nextStart = routeMatches[i + 1]?.index ?? text.length;
+    const sliceEnd = Math.min(cur.index + HANDLER_SLICE_BYTES, nextStart);
+    const slice = text.slice(cur.index, sliceEnd);
 
-    // Discover file-local helpers that wrap a canonical gate (e.g.
-    // `assertDeviceAccess` in cisHardening.ts). Routes that call these
-    // are gated even though the handler slice doesn't show the gate name
-    // directly.
-    const localGateNames = findLocalGateWrappers(text);
-    const gatePatterns = [
-      ...CANONICAL_GATE_PATTERNS,
-      ...localGateNames.map((n) => new RegExp(`\\b${n}\\b`)),
-    ];
+    const usesSiteScopeGate = gatePatterns.some((re) => re.test(slice));
+    const deviceOrSiteUrlParam =
+      DEVICE_PARAM_IN_URL.test(cur.urlPattern) || SITE_PARAM_IN_URL.test(cur.urlPattern);
+    const touchesDeviceData =
+      (tableColPattern !== null && tableColPattern.test(slice)) ||
+      JOIN_DEVICES_PATTERN.test(slice);
 
-    // Collect all route definitions in this file first, so each slice is
-    // bounded by the start of the next route. Without this bound, a
-    // handler that drops its gate inherits the gate string from the
-    // following route's slice and falsely passes the contract test.
-    type RouteMatch = { index: number; method: string; urlPattern: string };
-    const routeMatches: RouteMatch[] = [];
-    ROUTE_DEF_PATTERN.lastIndex = 0;
-    let match: RegExpExecArray | null;
-    while ((match = ROUTE_DEF_PATTERN.exec(text)) !== null) {
-      const method = match[1];
-      const urlPattern = match[2];
-      if (!method || !urlPattern) continue;
-      routeMatches.push({ index: match.index, method, urlPattern });
-    }
+    const line = text.slice(0, cur.index).split('\n').length;
 
-    for (let i = 0; i < routeMatches.length; i++) {
-      const cur = routeMatches[i];
-      if (!cur) continue;
-      // Only flag routes whose URL pattern names a device explicitly
-      // (`:deviceId` etc) OR is a per-site handler under `/sites/:<param>`.
-      // Body-level references would catch list/filter routes too (which
-      // deserve site-scope checks but are too numerous to lock in via a
-      // single contract test); scope this test to per-device and per-site
-      // handlers — the audit's known offender classes.
-      if (!DEVICE_PARAM_IN_URL.test(cur.urlPattern) && !SITE_PARAM_IN_URL.test(cur.urlPattern)) continue;
-
-      const nextStart = routeMatches[i + 1]?.index ?? text.length;
-      const sliceEnd = Math.min(cur.index + HANDLER_SLICE_BYTES, nextStart);
-      const slice = text.slice(cur.index, sliceEnd);
-
-      const usesSiteScopeGate = gatePatterns.some((re) => re.test(slice));
-      const line = text.slice(0, cur.index).split('\n').length;
-      const relFile = path.relative(SRC_DIR, file).split(path.sep).join('/');
-
-      results.push({
-        id: `${relFile}:${cur.method.toUpperCase()} ${cur.urlPattern}`,
-        file: relFile,
-        line,
-        usesSiteScopeGate,
-      });
-    }
+    results.push({
+      id: `${relFile}:${cur.method.toUpperCase()} ${cur.urlPattern}`,
+      file: relFile,
+      line,
+      usesSiteScopeGate,
+      deviceOrSiteUrlParam,
+      touchesDeviceData,
+    });
   }
 
   return results;
+}
+
+/**
+ * Export names of every Drizzle table declaring a `device_id`/`deviceId` or
+ * `site_id`/`siteId` column. Derived from the schema source so the device-data
+ * detector can't drift as tables are added.
+ */
+export async function findDeviceScopedTables(): Promise<Set<string>> {
+  const files = await listTsFiles(SCHEMA_DIR);
+  const tables = new Set<string>();
+  // Split each schema file into per-table segments (`export const X = pgTable(`
+  // … up to the next such declaration) and keep names whose segment declares a
+  // device/site column.
+  const declPattern = /export\s+const\s+(\w+)\s*=\s*pgTable\(/g;
+  const colPattern = /\b(?:device_id|deviceId|site_id|siteId)\b/;
+  for (const file of files) {
+    const text = await fs.readFile(file, 'utf8');
+    type Decl = { index: number; name: string };
+    const decls: Decl[] = [];
+    declPattern.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = declPattern.exec(text)) !== null) {
+      if (m[1]) decls.push({ index: m.index, name: m[1] });
+    }
+    for (let i = 0; i < decls.length; i++) {
+      const decl = decls[i]!;
+      const end = decls[i + 1]?.index ?? text.length;
+      if (colPattern.test(text.slice(decl.index, end))) tables.add(decl.name);
+    }
+  }
+  return tables;
+}
+
+async function scanAllRoutes(): Promise<RouteInfo[]> {
+  const files = await listTsFiles(ROUTE_DIR);
+  const deviceTables = await findDeviceScopedTables();
+  const results: RouteInfo[] = [];
+  for (const file of files) {
+    const text = await fs.readFile(file, 'utf8');
+    const relFile = path.relative(SRC_DIR, file).split(path.sep).join('/');
+    results.push(...analyzeRouteSource(relFile, text, deviceTables));
+  }
+  return results;
+}
+
+/**
+ * Routes whose URL pattern names a device (`:deviceId`) or a site
+ * (`/sites/:param`). Backs the original per-device/per-site contract test.
+ */
+export async function findRoutesTouchingDevices(): Promise<RouteInfo[]> {
+  return (await scanAllRoutes()).filter((r) => r.deviceOrSiteUrlParam);
+}
+
+/**
+ * Routes that read/write device-scoped data sourced from request input or a
+ * `devices` join — the query/body/list-style class the `:deviceId`-URL scan
+ * misses. Backs the input-sourced contract test.
+ */
+export async function findRoutesTouchingDeviceData(): Promise<RouteInfo[]> {
+  return (await scanAllRoutes()).filter((r) => r.touchesDeviceData);
 }

--- a/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { findRoutesTouchingDevices, type RouteInfo } from '../helpers/routeScan';
+import {
+  findRoutesTouchingDevices,
+  findRoutesTouchingDeviceData,
+  type RouteInfo,
+} from '../helpers/routeScan';
 
 /**
  * Contract test: every per-device route under `apps/api/src/routes` must
@@ -101,6 +105,185 @@ describe('site-scope coverage', () => {
         : `\nSITE_SCOPE_EXEMPT_HANDLERS entries that no longer match any ` +
           `flagged route (handler was fixed or moved; remove from the ` +
           `allowlist):\n` +
+          stale.map((s) => `  - ${s}`).join('\n');
+    expect(stale, message).toEqual([]);
+  });
+});
+
+/**
+ * Second detector: the INPUT-SOURCED / list-style class the `:deviceId`-URL
+ * scan above cannot see. A handler is flagged when its body reads/writes
+ * device-scoped data (a Drizzle condition on a device/site column of a
+ * schema-derived device-scoped table, or a join to `devices`) AND references no
+ * site-scope gate. This is the exact blind spot the original scanner's header
+ * note documented; the 2026-05 sweep fixed the first 6 offenders
+ * (browserSecurity/sentinelOne/peripheralControl/huntress/dnsSecurity/analytics)
+ * — see docs/superpowers/plans/2026-05-31-site-scope-input-scanner.md.
+ *
+ * The allowlist below captures handlers that touch device-scoped data but do
+ * NOT need a site gate. Each entry MUST carry a one-line justification. The
+ * default action on a new offender is to FIX the handler (narrow by the
+ * caller's accessible devices), not extend the allowlist.
+ */
+// Vetted-safe handlers: confirmed NOT to need a site gate. Each entry MUST
+// carry a one-line justification. (Empty for now — the initial rollout uses the
+// baseline ratchet below rather than pre-vetting all 93 pre-existing hits.)
+const SITE_SCOPE_INPUT_EXEMPT: ReadonlySet<string> = new Set<string>([
+]);
+
+// BASELINE RATCHET — pre-existing handlers flagged at the time this detector
+// landed (2026-05-31). These are NOT vetted as safe; they are untriaged debt.
+// The test below gates against NEW offenders only — any handler added/edited
+// after this date that touches device-scoped data without a site gate must be
+// fixed (or, if genuinely safe, moved to SITE_SCOPE_INPUT_EXEMPT with a reason).
+//
+// Burn-down: each entry is either (a) a real site-scope gap to fix by narrowing
+// to the caller's accessible devices (see resolveSiteAllowedDeviceIds from the
+// 2026-05 sweep), or (b) genuinely exempt — an agent/system token path with no
+// user `permissions` context (e.g. routes/agents/*), or an org-wide aggregate
+// taking no device input. When triaged, REMOVE the entry here and either fix the
+// handler or add it to SITE_SCOPE_INPUT_EXEMPT. The "no stale entries" test makes
+// the ratchet one-directional — a fixed handler's baseline entry must be removed.
+// Full plan + triage guidance: docs/superpowers/plans/2026-05-31-site-scope-input-scanner.md
+const SITE_SCOPE_INPUT_BASELINE: ReadonlySet<string> = new Set<string>([
+  'routes/admin/abuse.ts:POST /partners/:id/suspend-for-abuse',
+  'routes/agents/bootPerformance.ts:POST /:id/boot-performance',
+  'routes/agents/changes.ts:PUT /:id/changes',
+  'routes/agents/commands.ts:POST /:id/commands/:commandId/result',
+  'routes/agents/connections.ts:PUT /:id/connections',
+  'routes/agents/elevationRequests.ts:POST /:id/elevation-requests',
+  'routes/agents/enrollment.ts:POST /enroll',
+  'routes/agents/inventory.ts:PUT /:id/disks',
+  'routes/agents/inventory.ts:PUT /:id/hardware',
+  'routes/agents/inventory.ts:PUT /:id/network',
+  'routes/agents/inventory.ts:PUT /:id/software',
+  'routes/agents/inventory.ts:PUT /:id/warranty-info',
+  'routes/agents/patches.ts:PUT /:id/patches',
+  'routes/agents/sessions.ts:PUT /:id/sessions',
+  'routes/agents/state.ts:PUT /:id/config-state',
+  'routes/agents/state.ts:PUT /:id/registry-state',
+  'routes/alerts/alerts.ts:GET /',
+  'routes/auditLogs.ts:GET /logs/:id',
+  'routes/backup/bmr.ts:GET /bmr/tokens',
+  'routes/backup/dashboard.ts:GET /dashboard',
+  'routes/backup/jobs.ts:GET /jobs',
+  'routes/backup/jobs.ts:GET /jobs/:id',
+  'routes/backup/restore.ts:GET /restore',
+  'routes/backup/sla.ts:GET /events',
+  'routes/backup/snapshots.ts:GET /snapshots',
+  'routes/backup/vault.ts:GET /',
+  'routes/changes.ts:GET /',
+  'routes/cisHardening.ts:GET /compliance',
+  'routes/cisHardening.ts:GET /remediations',
+  'routes/deployments.ts:GET /:id/devices',
+  'routes/desktopWs.ts:POST /connect/exchange',
+  'routes/devices/provision.ts:POST /provision',
+  'routes/discovery.ts:DELETE /assets/:id',
+  'routes/discovery.ts:GET /assets',
+  'routes/discovery.ts:POST /assets/:id/link',
+  'routes/groups.ts:GET /',
+  'routes/groups.ts:GET /:id/devices',
+  'routes/groups.ts:GET /:id/membership-log',
+  'routes/helper/index.ts:DELETE /chat/sessions/:id',
+  'routes/helper/index.ts:GET /chat/sessions',
+  'routes/helper/index.ts:GET /chat/sessions/:id/messages',
+  'routes/helper/index.ts:POST /chat/sessions/:id/approve/:executionId',
+  'routes/helper/index.ts:POST /chat/sessions/:id/flag',
+  'routes/huntress.ts:GET /status',
+  'routes/lifecycle.ts:GET /admin/users/:userId/mobile-devices',
+  'routes/lifecycle.ts:GET /me/mobile-devices',
+  'routes/metrics.ts:GET /',
+  'routes/metrics.ts:GET /trends',
+  'routes/mobile.ts:GET /alerts/inbox',
+  'routes/mobile.ts:GET /devices',
+  'routes/mobile.ts:GET /search',
+  'routes/mobile.ts:POST /devices',
+  'routes/mobile.ts:POST /notifications/register',
+  'routes/monitoring.ts:GET /assets',
+  'routes/monitoring.ts:GET /assets/:id',
+  'routes/monitoring.ts:GET /results',
+  'routes/networkBaselines.ts:GET /',
+  'routes/networkBaselines.ts:POST /',
+  'routes/networkChanges.ts:GET /',
+  'routes/patches/compliance.ts:GET /compliance',
+  'routes/playbooks.ts:GET /executions',
+  'routes/playbooks.ts:GET /executions/:id',
+  'routes/policyManagement/compliance.ts:GET /:id/compliance',
+  'routes/portal/assets.ts:GET /assets',
+  'routes/portal/assets.ts:POST /assets/:id/checkin',
+  'routes/portal/assets.ts:POST /assets/:id/checkout',
+  'routes/psa.ts:GET /connections/:id/tickets',
+  'routes/psa.ts:GET /tickets',
+  'routes/remote/sessions.ts:DELETE /sessions/stale',
+  'routes/remote/sessions.ts:GET /sessions',
+  'routes/remote/sessions.ts:GET /sessions/history',
+  'routes/remote/sessions.ts:POST /sessions',
+  'routes/remote/sessions.ts:POST /sessions/:id/offer',
+  'routes/remote/transfers.ts:GET /transfers',
+  'routes/remote/transfers.ts:POST /transfers',
+  'routes/reports/data.ts:GET /data/compliance',
+  'routes/reports/data.ts:GET /data/device-inventory',
+  'routes/reports/data.ts:GET /data/metrics',
+  'routes/reports/data.ts:GET /data/software-inventory',
+  'routes/reports/generate.ts:POST /generate',
+  'routes/scripts.ts:POST /executions/:id/cancel',
+  'routes/sentinelOne.ts:GET /status',
+  'routes/snmp.ts:GET /dashboard',
+  'routes/softwareInventory.ts:GET /',
+  'routes/softwareInventory.ts:GET /:name/devices',
+  'routes/softwarePolicies.ts:GET /compliance/overview',
+  'routes/softwarePolicies.ts:GET /violations',
+  'routes/softwarePolicies.ts:POST /:id/remediate',
+  'routes/tunnels.ts:GET /allowlist',
+  'routes/tunnels.ts:GET /desktop-access',
+  'routes/tunnels.ts:POST /downgrade-to-vnc',
+  'routes/tunnels.ts:POST /upgrade-to-webrtc',
+  'routes/updateRings.ts:GET /:id/compliance',
+]);
+
+describe('site-scope coverage — input-sourced / list-style', () => {
+  it('no NEW handler touches device-scoped data without a site-scope gate', async () => {
+    const routes = await findRoutesTouchingDeviceData();
+    const offenders = routes.filter(
+      (r) =>
+        !r.usesSiteScopeGate &&
+        !SITE_SCOPE_INPUT_EXEMPT.has(r.id) &&
+        !SITE_SCOPE_INPUT_BASELINE.has(r.id),
+    );
+
+    const message =
+      offenders.length === 0
+        ? ''
+        : `\n${offenders.length} NEW handler(s) read/write device-scoped data ` +
+          `(device/site column condition or devices join) without a site-scope ` +
+          `gate:\n` +
+          offenders.map(formatOffender).join('\n') +
+          `\n\nFix by narrowing to the caller's accessible devices (see ` +
+          `resolveSiteAllowedDeviceIds in the 2026-05 sweep). If genuinely safe ` +
+          `(agent/system token path, or an org-wide aggregate with no device ` +
+          `input), add the id to SITE_SCOPE_INPUT_EXEMPT with a one-line reason. ` +
+          `Do NOT add to SITE_SCOPE_INPUT_BASELINE — that set is frozen and only ` +
+          `shrinks.`;
+
+    expect(offenders, message).toEqual([]);
+  });
+
+  it('the baseline/allowlist shrink-only (no stale entries)', async () => {
+    // Ratchet: once a baseline handler is fixed (gains a gate) or removed, its
+    // entry must be deleted here. This prevents the baseline from masking a
+    // future regression on a handler that was fixed in the meantime.
+    const routes = await findRoutesTouchingDeviceData();
+    const stillFlagged = new Set(
+      routes.filter((r) => !r.usesSiteScopeGate).map((r) => r.id),
+    );
+    const stale = [...SITE_SCOPE_INPUT_BASELINE, ...SITE_SCOPE_INPUT_EXEMPT].filter(
+      (e) => !stillFlagged.has(e),
+    );
+    const message =
+      stale.length === 0
+        ? ''
+        : `\nBaseline/exempt entries no longer flagged (handler fixed or moved — ` +
+          `remove them so the ratchet tightens):\n` +
           stale.map((s) => `  - ${s}`).join('\n');
     expect(stale, message).toEqual([]);
   });

--- a/docs/superpowers/plans/2026-05-31-ai-tools-site-scope.md
+++ b/docs/superpowers/plans/2026-05-31-ai-tools-site-scope.md
@@ -1,0 +1,105 @@
+# Plan: site-scope the AI-agent tool layer (`services/aiTools*.ts`)
+
+**Status:** PROPOSED — separate PR, not started. Planning doc only.
+**Date:** 2026-05-31
+**Related:** `fix/browser-security-site-scope` (route-layer fixes for the same bug class).
+
+## Problem
+
+The route layer enforces the site-scope axis (`permissions.allowedSiteIds`), but the AI-agent
+tool layer is a parallel path to the same device-scoped tables and enforces **only the org
+axis**. Audit findings (verified on `origin/main`):
+
+- `grep -r 'canAccessSite\|allowedSiteIds\|requireSiteAccess' apps/api/src/services/aiTools*.ts`
+  → **zero matches** across ~40 files.
+- `AuthContext` (`apps/api/src/middleware/auth.ts:9-33`) has **no site field** — only
+  `orgId` / `accessibleOrgIds` / `orgCondition` / `canAccessOrg`. The tool layer is therefore
+  structurally incapable of site-gating; the data it would need is never propagated.
+- The shared device gate `verifyDeviceAccess` (`apps/api/src/services/aiTools.ts:80-92`) is
+  `eq(devices.id, …)` + `orgCondition` only. Per-file copies in `aiToolsScripts.ts`,
+  `aiToolsRemote.ts`, `aiToolsFilesystem.ts` are identical.
+
+### Reachability (why it matters)
+
+`allowedSiteIds` is set for org-scope users (`organizationUsers.siteIds`). The AI chat endpoint
+`POST /sessions/:id/messages` (`routes/ai.ts`) requires `organizations:write` + MFA — orthogonal
+to site restriction, so site-restricted users qualify. The `auth` (site-less `AuthContext`) is
+passed to the streaming session manager → SDK tool wrapper → `executeTool` → tool handler →
+`verifyDeviceAccess` (org-only). The MCP path (`routes/mcpServer.ts` `buildAuthFromApiKey`) is
+the same and gates only on API-key scopes.
+
+### Severity
+
+Worse than the route reads, because the tool set includes **mutations on devices**:
+`aiToolsScripts` (run scripts), `aiToolsRemote` (remote desktop / terminal), `aiToolsFilesystem`
+(read/write/execute files). A site-restricted user could act on devices in forbidden sites —
+privilege-escalation / RCE-class, not just information disclosure.
+
+## Design
+
+### 1. Thread a site axis onto `AuthContext`
+
+Add `allowedSiteIds?: string[]` to the `AuthContext` interface (`middleware/auth.ts`). Populate
+it at **every** construction site:
+- Request path (`auth.ts` ~465) — `userPerms.allowedSiteIds` is already in hand there.
+- MCP API-key path (`mcpServer.ts buildAuthFromApiKey`). **DECIDED (owner, 2026-05-31):** a key
+  inherits the **creator's** access, including `allowedSiteIds` — a key is a principal scoped to
+  one user with that user's exact access, never broader. So `buildAuthFromApiKey` must load the
+  creating user's `allowedSiteIds` (via `getUserPermissions` for the key's org context) and attach
+  it to the `AuthContext`. Key creation is likewise limited to the creator's own scope (a
+  site-restricted user cannot mint a key with broader site access than they hold).
+  - **Direction (idea, not this PR):** model an API key as a dedicated "service principal" /
+    special user-account type that carries its own scope record, rather than re-deriving the
+    creator's perms on each request. Tracked as a follow-up; for now, re-derive from the creator.
+  - Add a test asserting a key created by a site-restricted user yields an `AuthContext` with that
+    user's `allowedSiteIds` (and that the gated tools then deny out-of-scope devices through it).
+- Streaming session manager passthrough (`streamingSessionManager.ts`) and the SDK tool DB-access
+  context (`aiAgentSdkTools.ts`) — ensure the field survives each hop (currently they copy a
+  whitelist of fields; add `allowedSiteIds`).
+
+### 2. Gate the single chokepoint
+
+Update `verifyDeviceAccess` (`aiTools.ts:80`): after resolving the device, if
+`auth.allowedSiteIds` is set and the device's `siteId` is not accessible (reuse `canAccessSite`),
+return `{ error: 'Device not found or access denied' }` (same opaque message as today's org miss
+— don't leak existence). This one change covers the ~33 tools that route through it.
+
+### 3. Collapse the per-file copies
+
+`aiToolsScripts.ts:49`, `aiToolsRemote.ts:25`, `aiToolsFilesystem.ts:25` have their own
+org-only device lookups. Refactor them to call the shared `verifyDeviceAccess` (preferred) or
+apply the same site check inline. These are the high-privilege mutators — prioritize.
+
+### 4. Direct-query tools
+
+Tools that query device-scoped tables directly (not via `verifyDeviceAccess`):
+- `aiToolsBrowser.ts` — `browserExtensions` / `browserPolicyViolations` reads + `browserPolicies`
+  read/insert/update/apply. Mirror the route-layer fix (`resolveSiteAllowedDeviceIds` narrowing
+  for reads; `policyWithinSiteWriteScope` for policy mutations).
+- Sweep the remaining `aiTools*.ts` for list-style device reads and narrow by the allowed device
+  set when `auth.allowedSiteIds` is present.
+
+### 5. Tool exposure for site-restricted sessions
+
+**DECIDED (owner, 2026-05-31): follow suit with the human RBAC model — allowed, but scoped.** A
+site-restricted user may invoke the mutating AI tools, but only against devices within their site
+allowlist; out-of-scope devices are denied at the gate (steps 2-4). No separate "AI cannot
+mutate" guardrail is introduced — the site axis is enforced identically to the route layer.
+
+## Testing (TDD)
+
+- Unit test `verifyDeviceAccess`: site-restricted auth + device in a denied site → error;
+  in-scope → ok; unrestricted → ok (no regression).
+- Per-file: scripts/remote/filesystem device gates honor site scope.
+- `aiToolsBrowser`: read narrowing + policy write scope.
+- MCP path: assert the documented API-key site-scope decision.
+- Add an `aiTools`-layer analogue of the route contract test, OR extend the input-sourced
+  scanner (`2026-05-31-site-scope-input-scanner.md`) to also walk `services/aiTools*.ts`, so this
+  layer can't silently regress.
+
+## Risks
+
+- Wide blast radius (AuthContext touched everywhere) — land behind thorough tests; the field is
+  additive and optional, so unrestricted callers are unaffected.
+- Field-passthrough hops are easy to miss — the contract/scanner test in the Testing section is
+  the backstop.

--- a/docs/superpowers/plans/2026-05-31-site-scope-baseline-triage.md
+++ b/docs/superpowers/plans/2026-05-31-site-scope-baseline-triage.md
@@ -1,0 +1,110 @@
+# Site-scope baseline triage (the 93 input-sourced offenders)
+
+**Status:** TRIAGED — fixes pending (Claude, per the auth/authz delegation rule).
+**Date:** 2026-05-31
+**Source:** Codex `gpt-5.5`, `model_reasoning_effort=high`, read-only, over the worktree at this branch.
+**Validation:** Claude spot-checked a sample (5/5 correct): the agent-auth mount
+(`routes/agents/index.ts:41`), two REAL-GAP device joins (remote/sessions `GET /sessions`,
+softwareInventory `GET /:name/devices`), one EXEMPT-AGGREGATE (metrics `GET /` returns counts),
+and one EXEMPT-FALSE-POSITIVE (remote `getDeviceWithOrgCheck` site gate). Treat EXEMPT-AGGREGATE
+as the softest call — re-confirm "counts only, no per-device rows" when burning each down.
+
+## Summary
+
+| Category | Count | Meaning |
+|---|---:|---|
+| REAL-GAP | 52 | user-facing, device data filtered org-only — a site-restricted user reaches cross-site data. FIX. |
+| EXEMPT-AGENT | 24 | agent/helper/viewer token path, no user `permissions` context. Move to `SITE_SCOPE_INPUT_EXEMPT`. |
+| EXEMPT-AGGREGATE | 7 | returns only org-wide counts/distributions, no device rows. Move to exempt after re-confirm. |
+| EXEMPT-FALSE-POSITIVE | 10 | not the bug class (platform-admin, portal/mobile non-RMM, or a gate the scanner missed). |
+| **Total** | **93** | matches `SITE_SCOPE_INPUT_BASELINE`. |
+
+The full per-route report (with Codex's one-line justification for every entry) is the source of
+record; the actionable REAL-GAP set is reproduced below.
+
+## REAL-GAP (52) — fix by narrowing to the caller's accessible devices
+
+Pattern: when `permissions.allowedSiteIds` is set, resolve allowed device IDs (org devices whose
+`siteId` passes `canAccessSite`) and either 403 an explicit out-of-scope `deviceId`/`siteId` or
+add `inArray(<table>.deviceId, allowedDeviceIds)` (`or(isNull(...), inArray(...))` for nullable
+columns). Mirror `resolveSiteAllowedDeviceIds` from browserSecurity/software.
+
+### High severity — MUTATIONS (fix first)
+- `routes/devices/provision.ts:POST /provision` (L183) — require `canAccessSite(perms, data.siteId)` before insert.
+- `routes/discovery.ts:POST /assets/:id/link` (L1026) — gate `existing.siteId` and `targetDevice.siteId`.
+- `routes/discovery.ts:DELETE /assets/:id` (L1152) — gate `discoveredAssets.siteId` before delete cascade.
+- `routes/networkBaselines.ts:POST /` (L204) — require `canAccessSite` for `body.siteId`.
+- `routes/remote/sessions.ts:DELETE /sessions/stale` (L85) — **conditional gate**: site-gated only when `deviceId` given; when omitted it cleans all org sessions. Narrow the no-deviceId path to allowed sites.
+- `routes/remote/sessions.ts:POST /sessions/:id/offer` (L701) — `getSessionWithOrgCheck` lacks site gate; check `result.device.siteId`.
+- `routes/scripts.ts:POST /executions/:id/cancel` (L987) — `canAccessDeviceSite` before cancel.
+- `routes/softwarePolicies.ts:POST /:id/remediate` (L623) — narrow explicit + implicit target devices by site.
+
+### High severity — READS
+- `routes/alerts/alerts.ts:GET /` (L96)
+- `routes/backup/jobs.ts:GET /jobs` (L88), `GET /jobs/:id` (L118)
+- `routes/backup/restore.ts:GET /restore` (L109)
+- `routes/backup/snapshots.ts:GET /snapshots` (L214)
+- `routes/backup/vault.ts:GET /` (L48)
+- `routes/changes.ts:GET /` (L129)
+- `routes/cisHardening.ts:GET /compliance` (L469), `GET /remediations` (L955)
+- `routes/deployments.ts:GET /:id/devices` (L769)
+- `routes/groups.ts:GET /:id/devices` (L596)
+- `routes/mobile.ts:GET /alerts/inbox` (L581), `GET /devices` (L846), `GET /search` (L1226)
+- `routes/monitoring.ts:GET /assets` (L194), `GET /assets/:id` (L285), `GET /results` (L762)
+- `routes/networkChanges.ts:GET /` (L149)
+- `routes/patches/compliance.ts:GET /compliance` (L155)
+- `routes/playbooks.ts:GET /executions` (L145), `GET /executions/:id` (L183)
+- `routes/policyManagement/compliance.ts:GET /:id/compliance` (L519)
+- `routes/remote/sessions.ts:GET /sessions` (L308), `GET /sessions/history` (L441)
+- `routes/remote/transfers.ts:GET /transfers` (L225)
+- `routes/reports/data.ts:GET /data/device-inventory` (L60), `GET /data/software-inventory` (L140), `GET /data/metrics` (L473)
+- `routes/reports/generate.ts:POST /generate` (L120)
+- `routes/snmp.ts:GET /dashboard` (L680)
+- `routes/softwareInventory.ts:GET /:name/devices` (L536)
+- `routes/softwarePolicies.ts:GET /violations` (L352)
+
+### Medium / low severity — READS
+- `routes/auditLogs.ts:GET /logs/:id` (L588)
+- `routes/backup/bmr.ts:GET /bmr/tokens` (L363)
+- `routes/backup/dashboard.ts:GET /dashboard` (L171)
+- `routes/backup/sla.ts:GET /events` (L232)
+- `routes/discovery.ts:GET /assets` (L836)
+- `routes/groups.ts:GET /` (L245), `GET /:id/membership-log` (L1014)
+- `routes/networkBaselines.ts:GET /` (L166)
+- `routes/psa.ts:GET /connections/:id/tickets` (L742), `GET /tickets` (L688)
+- `routes/softwareInventory.ts:GET /` (L235)
+- `routes/tunnels.ts:GET /allowlist` (L342) — low; only if allowlist rows are site-specific.
+
+## EXEMPT-AGENT (24) — agent/helper/viewer token paths, no user permissions
+
+`routes/agents/*` (boot-performance, changes, commands, connections, elevation-requests, enroll,
+inventory ×5, patches, sessions, state ×2 = 16) — mounted under `agentAuthMiddleware`
+(`routes/agents/index.ts:41`). `routes/desktopWs.ts:POST /connect/exchange` — connect-code
+exchange, system DB context. `routes/helper/index.ts` chat endpoints (×5) — `helperAuth` `brz_`
+token, session bound to helper device. `routes/tunnels.ts` `GET /desktop-access`,
+`POST /upgrade-to-webrtc`, `POST /downgrade-to-vnc` — viewer-JWT path (`requireViewerToken`).
+
+## EXEMPT-AGGREGATE (7) — counts only, re-confirm before exempting
+
+`routes/huntress.ts:GET /status`, `routes/metrics.ts:GET /` + `GET /trends`,
+`routes/reports/data.ts:GET /data/compliance`, `routes/sentinelOne.ts:GET /status`,
+`routes/softwarePolicies.ts:GET /compliance/overview`, `routes/updateRings.ts:GET /:id/compliance`.
+
+## EXEMPT-FALSE-POSITIVE (10)
+
+- Not RMM-device / not user-permissions context: `routes/admin/abuse.ts` (platform admin),
+  `routes/lifecycle.ts` mobile-device endpoints (×2), `routes/mobile.ts:POST /devices` +
+  `POST /notifications/register` (mobile client rows), `routes/portal/assets.ts` (×3, portal session auth).
+- **Scanner miss (genuinely gated via cross-file helper):** `routes/remote/sessions.ts:POST /sessions`
+  and `routes/remote/transfers.ts:POST /transfers` use `getDeviceWithOrgCheck(..., permissions)`
+  (`routes/remote/helpers.ts:132`), which 403s on `SITE_ACCESS_DENIED`. The scanner's
+  local-helper resolution is same-file only, so these read as offenders. They stay in the baseline
+  as known false positives; a future import-aware resolver could clear them precisely. (Do NOT add
+  `getDeviceWithOrgCheck` as a blanket gate token — it would mask `DELETE /sessions/stale`, which
+  gates only its deviceId path.)
+
+## Recommended fix order
+1. High-severity mutations (8): provision, discovery link/delete, network-baseline create, stale-session cleanup, remote offer, script cancel, software remediation.
+2. Broad read surfaces: mobile, reports, backup, monitoring, software inventory, compliance detail.
+3. Secondary: groups, playbooks, PSA, audit-log detail, SNMP dashboard, tunnel allowlist.
+4. Each fix ships with `allowedSiteIds` regression tests (out-of-scope `deviceId`/`siteId` → 403; unfiltered list narrowed), and removes its entry from `SITE_SCOPE_INPUT_BASELINE`. Move confirmed EXEMPT-* entries to `SITE_SCOPE_INPUT_EXEMPT` with the justification above.

--- a/docs/superpowers/plans/2026-05-31-site-scope-input-scanner.md
+++ b/docs/superpowers/plans/2026-05-31-site-scope-input-scanner.md
@@ -1,8 +1,32 @@
 # Plan: extend the site-scope contract scanner to catch input-sourced / list-style device reads
 
-**Status:** PROPOSED — awaiting review before implementation.
+**Status:** IMPLEMENTED (detector + baseline ratchet) — triage/burn-down ongoing.
 **Date:** 2026-05-31
-**Related:** PR #864/#868 (original SP2 site-scope sweep + `:deviceId` scanner); this branch (`fix/browser-security-site-scope`) which fixed 6 handlers the current scanner can't see.
+**Related:** PR #864/#868 (original SP2 site-scope sweep + `:deviceId` scanner); PR #1036 (fixed the first 6 input-sourced handlers); branch `chore/site-scope-input-scanner` (this scanner).
+
+## What shipped vs. what's deferred
+
+**Shipped (this PR):**
+- `analyzeRouteSource` (pure, unit-tested) + `findDeviceScopedTables` (schema-derived) + the
+  `touchesDeviceData` detector + `findRoutesTouchingDeviceData` in `routeScan.ts`.
+- A second contract test in `site-scope-coverage.integration.test.ts` wired into CI (the
+  `test-api` job — it's static analysis, no DB, so it gates PRs there rather than in the
+  non-blocking smoke-test where `rls-coverage` lives). **Note:** neither site-scope contract test
+  ran in CI before this PR — the `test:site-scope-coverage` script existed but was never invoked.
+- **Baseline ratchet:** the detector found **93** pre-existing handlers. Rather than block on
+  triaging all 93 at once, they're enumerated in `SITE_SCOPE_INPUT_BASELINE` (frozen, shrink-only,
+  explicitly labeled *not vetted safe*). The test fails on any NEW offender, so the blind spot is
+  closed for all new/edited code immediately. A "no stale entries" test makes the ratchet
+  one-directional — fixing a handler forces removal of its baseline entry.
+
+**Deferred (burn-down backlog — the 93):** triage each baseline entry into either a real
+site-scope fix (narrow by accessible devices) or a vetted `SITE_SCOPE_INPUT_EXEMPT` entry
+(agent/system token path, or org-wide aggregate). Calibration during this PR showed the 93 is a
+genuine mix: e.g. `routes/agents/*` are agent-token paths (likely exempt), while `softwareInventory`,
+`remote/sessions`, and `metrics` have **zero** site-scope references anywhere (likely real gaps).
+Detector caveat: it's coarse — a flagged handler in a file that gates *other* handlers may be a
+false positive (gate via a helper/path the slice misses) or a real per-handler miss; triage
+confirms which.
 
 ## Problem
 

--- a/docs/superpowers/plans/2026-05-31-site-scope-input-scanner.md
+++ b/docs/superpowers/plans/2026-05-31-site-scope-input-scanner.md
@@ -1,0 +1,109 @@
+# Plan: extend the site-scope contract scanner to catch input-sourced / list-style device reads
+
+**Status:** PROPOSED — awaiting review before implementation.
+**Date:** 2026-05-31
+**Related:** PR #864/#868 (original SP2 site-scope sweep + `:deviceId` scanner); this branch (`fix/browser-security-site-scope`) which fixed 6 handlers the current scanner can't see.
+
+## Problem
+
+`apps/api/src/__tests__/helpers/routeScan.ts` + `site-scope-coverage.integration.test.ts`
+only flag handlers whose **URL pattern** names a device (`:deviceId` / `:deviceIds` /
+`:device_id`) or sits under `/sites/:param`. It deliberately does **not** scan body-level
+device references — see routeScan.ts:180-186 ("too numerous to lock in").
+
+That gap is exactly where this branch found 6 live cross-site leaks, all of which the
+scanner passed clean:
+
+| Handler | How the deviceId entered |
+|---|---|
+| `browserSecurity GET /extensions`, `/violations` | query param + list-style (org-only) |
+| `sentinelOne GET /threats` | query param |
+| `peripheralControl GET /activity` | query param |
+| `huntress GET /incidents` | query param |
+| `dnsSecurity GET /events`, `/stats` | query param |
+| `analytics GET /capacity`, `POST /query` | query param + **request body array** |
+
+We need a second detector for the input-sourced / list-style class.
+
+## Approach (chosen): static, input-sourced "smell"
+
+Add a detector alongside the existing `:deviceId`-URL one. A route handler is flagged when
+its body **touches device-scoped data** and references **no site-scope gate** — and is not
+allowlisted.
+
+### "Touches device-scoped data" signals (within the handler slice)
+
+Reuse the existing per-route slicing (bounded by the next route def + `HANDLER_SLICE_BYTES`).
+Flag if the slice matches any of:
+
+1. A Drizzle condition on a device/site column of a **known device-scoped table**:
+   `eq(<tbl>.deviceId, …)`, `inArray(<tbl>.deviceId, …)`, `eq(<tbl>.siteId, …)`,
+   `inArray(<tbl>.siteId, …)`.
+2. A join to devices: `innerJoin(\s*devices\b` / `leftJoin(\s*devices\b`.
+
+To keep precision, signal (1) is restricted to columns of tables in a generated
+`DEVICE_SCOPED_TABLES` set (see below) rather than any `*.deviceId` property access — this
+avoids false hits on plain-JS `someRow.deviceId` reads that aren't queries.
+
+### "Has a site-scope gate" tokens
+
+Extend `CANONICAL_GATE_NAMES` with the tokens this codebase now uses:
+
+```
+requireSiteAccess, canAccessDeviceSite, getDeviceWithOrgAndSiteCheck, canAccessSite,   // existing
+resolveSiteAllowedDeviceIds, hasDeniedDeviceSite, hasDeniedThreatDeviceSite, allowedSiteIds   // add
+```
+
+`allowedSiteIds` as a bare token is a safe catch-all: every correct gate path references it
+(directly or via a helper), and the local-helper-wrapper resolution (`findLocalGateWrappers`)
+already propagates gates reached through file-local helpers.
+
+### Generated device-scoped table list
+
+`DEVICE_SCOPED_TABLES` = every Drizzle table in `apps/api/src/db/schema/` declaring a
+`device_id`/`deviceId` or `site_id`/`siteId` column. Generate at test-time by scanning the
+schema source (regex for `pgTable('…', { … device_id / site_id … })`) so it can't drift as
+tables are added. Emit the resolved set in the failure message for debuggability.
+
+## Implementation steps (TDD)
+
+1. **`routeScan.ts`** — add `findDeviceScopedTables()` (schema scan) and a second pass in
+   `findRoutesTouchingDevices()` that sets a new `RouteInfo.touchesDeviceData` flag using the
+   signals above. Keep the existing `usesSiteScopeGate` computation; widen the gate token list.
+   Unit-test the helper against fixtures (a gated handler, an ungated query-param handler, an
+   agent/system handler, an org-wide aggregate) — RED first.
+2. **`site-scope-coverage.integration.test.ts`** — add a second `it(...)` that fails on
+   `touchesDeviceData && !usesSiteScopeGate && !allowlisted`. New allowlist
+   `SITE_SCOPE_INPUT_EXEMPT: ReadonlySet<string>` with the **same discipline** as today's set:
+   every entry carries a one-line justification; default action on a new offender is to fix the
+   handler, not allowlist it. Add the companion "no stale entries" guard test.
+3. **Triage pass (the real work).** Run the new detector once; it will flag a large initial
+   set (every device-data read/write, including legit ones). Triage each into:
+   - **real gap** → fix the handler (TDD, same pattern as this branch), OR
+   - **exempt** → allowlist with reason. Legit exempt classes already identified:
+     - agent/system paths (agent-token auth, no user `permissions` context) — e.g. agent
+       ingest/heartbeat routes;
+     - org-wide aggregates that take no device/site input by design (e.g.
+       `dnsSecurity /top-blocked`, analytics `/executive-summary`, `/os-distribution`, `/sla`);
+     - routes already gated through a pattern the token list somehow misses (prefer fixing the
+       token list over allowlisting).
+   This triage is likely to surface additional real gaps — treat finds as new fixes.
+4. Run full affected suite + `tsc --noEmit`. Document the initial allowlist size in the PR.
+
+## Risks / tradeoffs
+
+- **False positives → allowlist churn.** Mitigated by the schema-scoped table list + the
+  established justified-allowlist mechanism. The `allowedSiteIds` catch-all token keeps gated
+  handlers green.
+- **Static, not reachability-aware.** It can't tell whether a site-restricted user can actually
+  reach an agent/system handler. That's fine: those go in the allowlist with a reason. The
+  detector's job is "device data touched without a visible gate," not proof of exploitability.
+- **Won't catch non-route surfaces.** The AI-tools layer (`services/aiTools*.ts`) is the same
+  bug class but lives outside `routes/`; it is handled by a separate plan
+  (`2026-05-31-ai-tools-site-scope.md`), not this scanner.
+
+## Out of scope
+
+- Runtime/integration seeded-user contract test (considered, rejected as heavier-maintenance for
+  now; can layer on later if the static scanner proves insufficient).
+- The AI-tools layer (separate plan/PR).


### PR DESCRIPTION
Re-opens the work from #1037 (auto-closed when its base branch `fix/browser-security-site-scope` was deleted on #1036's merge). Rebased onto `main` — diff is the scanner + CI wiring + plan docs only; #1036's browser-security changes are already in `main`.

**Input-sourced site-scope contract scanner.** Extends `routeScan.ts` to flag handlers that read/write device-scoped data sourced from request input or a `devices` join (not just `:deviceId` URL params) without a site-scope gate, backed by a frozen baseline ratchet (`SITE_SCOPE_INPUT_BASELINE`, shrink-only). Adds the CI job wiring and the AI-tools/site-scope plan docs.

Bottom of the site-scope stack: #1041 → #1042 → #1047 → #1049 rebase on top of this; #1051 (dead-perms-gate detector) also stacks here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
