### PR TITLE
fix(api): drain HTTP server before tearing down workers/DB on shutdown

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1199,14 +1199,31 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     }
   ];
 
+  // Stop accepting requests BEFORE tearing down workers/Redis/DB. Otherwise a
+  // heartbeat that arrives mid-shutdown hits an already-closed Postgres pool,
+  // returns HTTP 500, and permanently wedges the agent's heartbeat loop
+  // (cause of fleetwide false-offline after a restart).
+  if (server) {
+    const httpServer = server as unknown as import('http').Server;
+    // Make readiness fail so any load balancer stops routing to us.
+    readinessState.workersHealthy = false;
+    readinessState.checkedAt = new Date().toISOString();
+    httpServer.close();                 // stop accepting NEW connections
+    if (typeof httpServer.closeIdleConnections === 'function') {
+      httpServer.closeIdleConnections(); // drop idle keep-alive sockets now
+    }
+    // Bounded grace for in-flight requests to finish, then force-close stragglers
+    // so server.close() can't hang on keep-alive connections.
+    await new Promise<void>((resolve) =>
+      setTimeout(resolve, Number(process.env.SHUTDOWN_DRAIN_MS ?? '5000'))
+    );
+    if (typeof httpServer.closeAllConnections === 'function') {
+      httpServer.closeAllConnections();
+    }
+  }
+
   const shutdownResults = await Promise.allSettled(shutdownTasks.map((task) => task()));
   const shutdownFailures = shutdownResults.filter((result) => result.status === 'rejected');
-
-  if (server) {
-    await new Promise<void>((resolve) => {
-      server?.close(() => resolve());
-    });
-  }
 
   if (shutdownFailures.length > 0) {
     console.error(`[shutdown] Completed with ${shutdownFailures.length} failure(s)`);


### PR DESCRIPTION
## Problem
On `SIGTERM`, `shutdownRuntime` closed the HTTP listener **after** `closeDb()` (and the worker/Redis teardown). So during shutdown the server kept accepting requests while the Postgres pool was already gone. A heartbeat arriving in that window throws `write CONNECTION_ENDED` and returns **HTTP 500**. An agent that gets a 500 in this window wedges its heartbeat loop permanently (the process stays alive but never heartbeats again), so the device is marked offline by the offline-detector and **stays** offline until the agent service is manually restarted. One API restart can take a large batch of hosts offline at once.

## Fix
Move the HTTP drain **before** the worker/Redis/DB teardown: mark readiness unhealthy, `close()` the listener, `closeIdleConnections()`, wait a bounded grace (`SHUTDOWN_DRAIN_MS`, default 5s) for in-flight requests, then `closeAllConnections()` — so no request is served after the pool is gone. The set of shutdown tasks is unchanged; only the ordering plus the idle/all-connection close with a grace window.

## Notes
- Casts/guards mirror the existing `typeof closeDb === 'function'` pattern; `closeIdleConnections` / `closeAllConnections` exist on Node 18.2+.
- Agent-side self-recovery and watchdog `restart_agent` robustness are intentionally **separate** follow-ups, not bundled here.

Local: tsc, full api vitest, eslint, and Trivy all green.
