### PR TITLE
fix(security): make 11 dead site-scope read gates live (requirePermission)

### DIFF
--- a/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
@@ -359,36 +359,20 @@ const DEAD_PERMS_GATE_EXEMPT: ReadonlySet<string> = new Set<string>([
 // GET /threats) — all independently fixed in #1036's final revision (now in
 // main), so they are NOT listed here.
 //
-// The 4 below were INTRODUCED by this PR (#1041): its mutation-gating added the
-// fail-open `if (perms?.allowedSiteIds && …)` idiom reading `c.get('permissions')`
-// but did NOT add the `requirePermission` that populates it — so on these routes
-// the new site narrowing never runs (no regression: they had no site-scope
-// before either). `remote/sessions.ts` has no `requirePermission` anywhere, so
-// the correct gate is a router-level decision for the #1041 author. Tracked as
-// FOLLOW-UP: add the appropriate `requirePermission(...)` to each chain (and
-// de-mask the new tests, which populate `permissions` via the auth-middleware
-// mock rather than a requirePermission mock). The detector keeps them visible
-// and blocks any NEW offender.
+// The 11 dead read/mutation gates introduced by #1041 (mutations batch1) and
+// #1042 (reads batch2) — networkBaselines GET /:id + /:id/changes, networkChanges
+// GET /:id, remote/sessions {DELETE /sessions/stale, GET /sessions, GET
+// /sessions/history, GET /sessions/:id, POST /sessions/:id/offer}, and
+// remote/transfers {GET /transfers, GET /transfers/:id, GET /transfers/:id/download}
+// — were all FIXED by #1051: each chain now carries
+// `requirePermission(DEVICES_READ)` immediately after `requireScope`, which
+// populates `c.get('permissions')` so the existing `allowedSiteIds` site
+// narrowing actually runs. DEVICES_READ is granted to every device-viewing role
+// (no lockout). The route tests were de-masked to populate `permissions` via a
+// `requirePermission` mock rather than the auth-middleware mock. The baseline is
+// therefore empty; the shrink-only ratchet keeps it that way and blocks any NEW
+// offender.
 const DEAD_PERMS_GATE_BASELINE: ReadonlySet<string> = new Set<string>([
-  // Introduced by #1041 (mutations batch1) — added the perms gate, omitted requirePermission.
-  'routes/networkBaselines.ts:GET /:id',
-  'routes/networkBaselines.ts:GET /:id/changes',
-  'routes/remote/sessions.ts:DELETE /sessions/stale',
-  'routes/remote/sessions.ts:POST /sessions/:id/offer',
-  // Introduced by #1042 (reads batch2) — same shape: these reads gate on
-  // `perms?.allowedSiteIds` (and pass `perms` to getDeviceWithOrgCheck) but no
-  // `requirePermission` populates `c.get('permissions')`, so the gate is dead.
-  // remote/sessions + remote/transfers routers carry NO requirePermission at all
-  // (router-level decision for the author). No regression — these reads had no
-  // site-scope before. FOLLOW-UP: one focused PR adds requirePermission(DEVICES_READ)
-  // to all 11 dead reads here + de-masks the route tests. Detector keeps them visible.
-  'routes/networkChanges.ts:GET /:id',
-  'routes/remote/sessions.ts:GET /sessions',
-  'routes/remote/sessions.ts:GET /sessions/history',
-  'routes/remote/sessions.ts:GET /sessions/:id',
-  'routes/remote/transfers.ts:GET /transfers',
-  'routes/remote/transfers.ts:GET /transfers/:id',
-  'routes/remote/transfers.ts:GET /transfers/:id/download',
 ]);
 
 describe('site-scope coverage — dead permissions-sourced gate', () => {

--- a/apps/api/src/routes/networkBaselines.ts
+++ b/apps/api/src/routes/networkBaselines.ts
@@ -317,6 +317,8 @@ networkBaselineRoutes.post(
 networkBaselineRoutes.get(
   '/:id',
   requireScope('organization', 'partner', 'system'),
+  // Populates c.get('permissions') so the allowedSiteIds site narrowing below runs (dead under requireScope alone — #1051 detector).
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
   async (c) => {
     const auth = c.get('auth');
     const baselineId = c.req.param('id')!;
@@ -431,6 +433,8 @@ networkBaselineRoutes.post(
 networkBaselineRoutes.get(
   '/:id/changes',
   requireScope('organization', 'partner', 'system'),
+  // Populates c.get('permissions') so the allowedSiteIds site narrowing below runs (dead under requireScope alone — #1051 detector).
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
   zValidator('query', baselineChangesQuerySchema),
   async (c) => {
     const auth = c.get('auth');

--- a/apps/api/src/routes/networkChanges.ts
+++ b/apps/api/src/routes/networkChanges.ts
@@ -195,6 +195,8 @@ networkChangeRoutes.get(
 networkChangeRoutes.get(
   '/:id',
   requireScope('organization', 'partner', 'system'),
+  // Populates c.get('permissions') so the allowedSiteIds site narrowing below runs (dead under requireScope alone — #1051 detector).
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
   async (c) => {
     const auth = c.get('auth');
     const eventId = c.req.param('id')!;

--- a/apps/api/src/routes/remote.test.ts
+++ b/apps/api/src/routes/remote.test.ts
@@ -31,7 +31,10 @@ vi.mock('../services/fileStorage', () => ({
 
 vi.mock('../services/permissions', () => ({
   PERMISSIONS: {
-    REMOTE_ACCESS: { resource: 'remote', action: 'access' }
+    REMOTE_ACCESS: { resource: 'remote', action: 'access' },
+    // sessions.ts/transfers.ts gained requirePermission(DEVICES_READ) — the mock
+    // must export it or the remote/ router fails to load here.
+    DEVICES_READ: { resource: 'devices', action: 'read' }
   }
 }));
 

--- a/apps/api/src/routes/remote/sessions.test.ts
+++ b/apps/api/src/routes/remote/sessions.test.ts
@@ -70,7 +70,9 @@ vi.mock('../../db/schema', () => ({
   users: { id: 'users.id', name: 'users.name', email: 'users.email' },
 }));
 
-// requireScope seeds auth + permissions; x-restrict-site opts into a single-site allowlist.
+// requireScope seeds auth; requirePermission seeds permissions (mirrors prod — only
+// requirePermission populates c.get('permissions'), which the site-scope gate reads).
+// x-restrict-site opts into a single-site allowlist.
 vi.mock('../../middleware/auth', () => ({
   requireScope: vi.fn(() => async (c: any, next: any) => {
     c.set('auth', {
@@ -81,6 +83,9 @@ vi.mock('../../middleware/auth', () => ({
       accessibleOrgIds: ['org-111'],
       canAccessOrg: (id: string) => id === 'org-111',
     });
+    return next();
+  }),
+  requirePermission: vi.fn(() => async (c: any, next: any) => {
     const restrict = c.req.header('x-restrict-site');
     c.set('permissions', {
       permissions: [],
@@ -96,6 +101,7 @@ vi.mock('../../middleware/auth', () => ({
 
 // Faithful canAccessSite so the route's site gate behaves like production.
 vi.mock('../../services/permissions', () => ({
+  PERMISSIONS: { DEVICES_READ: { resource: 'devices', action: 'read' } },
   canAccessSite: (perms: any, siteId: string) =>
     !perms?.allowedSiteIds || perms.allowedSiteIds.includes(siteId),
 }));

--- a/apps/api/src/routes/remote/sessions.ts
+++ b/apps/api/src/routes/remote/sessions.ts
@@ -9,7 +9,7 @@ import {
   deviceHardware,
   users
 } from '../../db/schema';
-import { requireScope } from '../../middleware/auth';
+import { requireScope, requirePermission } from '../../middleware/auth';
 import { sendCommandToAgent } from '../agentWs';
 import { checkRemoteAccess, resolveDesktopSessionPolicy } from '../../services/remoteAccessPolicy';
 import { createDesktopConnectCode, createWsTicket } from '../../services/remoteSessionAuth';
@@ -36,7 +36,7 @@ import {
 } from './helpers';
 import { revokeViewerSession } from '../../services/viewerTokenRevocation';
 import { normalizeRecordingUrl } from './recordingUrl';
-import { canAccessSite, type UserPermissions } from '../../services/permissions';
+import { canAccessSite, PERMISSIONS, type UserPermissions } from '../../services/permissions';
 
 export const sessionRoutes = new Hono();
 
@@ -53,6 +53,8 @@ async function resolveSiteAllowedDeviceIds(orgId: string, perms: UserPermissions
 sessionRoutes.delete(
   '/sessions/stale',
   requireScope('organization', 'partner', 'system'),
+  // Populates c.get('permissions') so the allowedSiteIds site narrowing below runs (dead under requireScope alone — #1051 detector).
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
   async (c) => {
     const auth = c.get('auth');
     const deviceId = c.req.query('deviceId');
@@ -271,6 +273,8 @@ sessionRoutes.post(
 sessionRoutes.get(
   '/sessions',
   requireScope('organization', 'partner', 'system'),
+  // Populates c.get('permissions') so the allowedSiteIds site narrowing below runs (dead under requireScope alone — #1051 detector).
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
   zValidator('query', listSessionsSchema),
   async (c) => {
     const auth = c.get('auth');
@@ -405,6 +409,8 @@ sessionRoutes.get(
 sessionRoutes.get(
   '/sessions/history',
   requireScope('organization', 'partner', 'system'),
+  // Populates c.get('permissions') so the allowedSiteIds site narrowing below runs (dead under requireScope alone — #1051 detector).
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
   zValidator('query', sessionHistorySchema),
   async (c) => {
     const auth = c.get('auth');
@@ -564,6 +570,8 @@ sessionRoutes.get(
 sessionRoutes.get(
   '/sessions/:id',
   requireScope('organization', 'partner', 'system'),
+  // Populates c.get('permissions') so the allowedSiteIds site narrowing below runs (dead under requireScope alone — #1051 detector).
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
   zValidator('param', sessionIdParamSchema),
   async (c) => {
     const auth = c.get('auth');
@@ -765,6 +773,8 @@ sessionRoutes.get(
 sessionRoutes.post(
   '/sessions/:id/offer',
   requireScope('organization', 'partner', 'system'),
+  // Populates c.get('permissions') so the allowedSiteIds site narrowing below runs (dead under requireScope alone — #1051 detector).
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
   zValidator('param', sessionIdParamSchema),
   zValidator('json', webrtcOfferSchema),
   async (c) => {

--- a/apps/api/src/routes/remote/transfers.test.ts
+++ b/apps/api/src/routes/remote/transfers.test.ts
@@ -35,6 +35,9 @@ vi.mock('../../db/schema', () => ({
   users: { id: 'users.id', name: 'users.name', email: 'users.email' },
 }));
 
+// requireScope seeds auth; requirePermission seeds permissions (mirrors prod — only
+// requirePermission populates c.get('permissions'), which the site-scope gate reads).
+// x-restrict-site opts into a single-site allowlist.
 vi.mock('../../middleware/auth', () => ({
   requireScope: vi.fn(() => async (c: any, next: any) => {
     c.set('auth', {
@@ -45,6 +48,9 @@ vi.mock('../../middleware/auth', () => ({
       accessibleOrgIds: ['org-111'],
       canAccessOrg: (id: string) => id === 'org-111',
     });
+    return next();
+  }),
+  requirePermission: vi.fn(() => async (c: any, next: any) => {
     const restrict = c.req.header('x-restrict-site');
     c.set('permissions', {
       permissions: [],
@@ -59,6 +65,7 @@ vi.mock('../../middleware/auth', () => ({
 }));
 
 vi.mock('../../services/permissions', () => ({
+  PERMISSIONS: { DEVICES_READ: { resource: 'devices', action: 'read' } },
   canAccessSite: (perms: any, siteId: string) =>
     !perms?.allowedSiteIds || perms.allowedSiteIds.includes(siteId),
 }));

--- a/apps/api/src/routes/remote/transfers.ts
+++ b/apps/api/src/routes/remote/transfers.ts
@@ -8,7 +8,7 @@ import {
   devices,
   users
 } from '../../db/schema';
-import { requireScope } from '../../middleware/auth';
+import { requireScope, requirePermission } from '../../middleware/auth';
 import { saveChunk, assembleChunks, getFileStream, getFileSize, hasAssembledFile, getTotalBytesReceived, MAX_TRANSFER_SIZE_BYTES } from '../../services/fileStorage';
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
 import { Readable } from 'stream';
@@ -23,7 +23,7 @@ import {
   MAX_ACTIVE_TRANSFERS_PER_ORG,
   MAX_ACTIVE_TRANSFERS_PER_USER
 } from './helpers';
-import { canAccessSite, type UserPermissions } from '../../services/permissions';
+import { canAccessSite, PERMISSIONS, type UserPermissions } from '../../services/permissions';
 
 export const transferRoutes = new Hono();
 
@@ -174,6 +174,8 @@ transferRoutes.post(
 transferRoutes.get(
   '/transfers',
   requireScope('organization', 'partner', 'system'),
+  // Populates c.get('permissions') so the allowedSiteIds site narrowing below runs (dead under requireScope alone — #1051 detector).
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
   zValidator('query', listTransfersSchema),
   async (c) => {
     const auth = c.get('auth');
@@ -299,6 +301,8 @@ transferRoutes.get(
 transferRoutes.get(
   '/transfers/:id',
   requireScope('organization', 'partner', 'system'),
+  // Populates c.get('permissions') so the allowedSiteIds site narrowing below runs (dead under requireScope alone — #1051 detector).
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
   async (c) => {
     const auth = c.get('auth');
     const transferId = c.req.param('id')!;
@@ -515,6 +519,8 @@ transferRoutes.post(
 transferRoutes.get(
   '/transfers/:id/download',
   requireScope('organization', 'partner', 'system'),
+  // Populates c.get('permissions') so the allowedSiteIds site narrowing below runs (dead under requireScope alone — #1051 detector).
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
   async (c) => {
     const auth = c.get('auth');
     const transferId = c.req.param('id')!;


### PR DESCRIPTION
Follow-up to the site-scope merge stack. The #1051 dead-perms-gate detector flagged **11 routes** whose site gate never runs: they gate via `if (perms?.allowedSiteIds && …)` reading `c.get('permissions')`, but that context is populated **only** by `requirePermission` (`auth.ts` does `c.set('permissions', …)`), never by `authMiddleware`/`requireScope`. #1041 and #1042 added the narrowing but omitted `requirePermission`, so the gate was dead. They were carried in `DEAD_PERMS_GATE_BASELINE`; **this empties it**.

**No regression:** these routes had no site-scope before either — this *adds* enforcement, it doesn't relax anything.

## The fix
`requirePermission(DEVICES_READ)` immediately after `requireScope` on each route. `DEVICES_READ` is granted to every device-viewing role → no lockout, and it populates the `permissions` context the existing `allowedSiteIds` narrowing reads.

- `networkBaselines` — `GET /:id`, `GET /:id/changes`
- `networkChanges` — `GET /:id`
- `remote/sessions` — `GET /sessions`, `GET /sessions/history`, `GET /sessions/:id`, `DELETE /sessions/stale`, `POST /sessions/:id/offer`
- `remote/transfers` — `GET /transfers`, `GET /transfers/:id`, `GET /transfers/:id/download`

`remote/sessions.ts` and `remote/transfers.ts` had no `requirePermission` anywhere — added the import. Their two test mocks were de-masked to be **prod-faithful**: `requireScope` now seeds only `auth`; a new `requirePermission` mock seeds `permissions` (preserving the `x-restrict-site` single-site toggle), and `DEVICES_READ` was added to their `PERMISSIONS` mock.

## Reviewer note — the 2 mutations
`DELETE /sessions/stale` and `POST /sessions/:id/offer` use `DEVICES_READ` purely to **populate the permissions context** so the site gate runs; it does not tighten action-level authz (`requireScope` + org checks already cover that). If you want a stricter write/execute permission on those two, that's a separate authz decision — flagging for awareness.

## Verification
`site-scope-coverage` 7/7 (empty baseline → detector reports 0 offenders), affected route suites **88/88**, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
