### PR TITLE
feat(agent): build and serve linux/arm64 agent binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,11 @@ jobs:
             suffix: ''
             cgo: '0'
             runner: ubuntu-latest
+          - goos: linux
+            goarch: arm64
+            suffix: ''
+            cgo: '0'
+            runner: ubuntu-latest
           - goos: darwin
             goarch: amd64
             suffix: ''

--- a/agent/cmd/breeze-agent/service_unix.go
+++ b/agent/cmd/breeze-agent/service_unix.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/breeze-rmm/agent/internal/config"
 	"github.com/breeze-rmm/agent/internal/logging"
+	"golang.org/x/sys/unix"
 )
 
 // isWindowsService reports whether the process is running as a system service.
@@ -82,7 +83,7 @@ func linuxHasGraphicalSession() bool {
 // redirectStderr points fd 2 at the given file so that Go runtime panics
 // are captured in the log file.
 func redirectStderr(f *os.File) {
-	syscall.Dup2(int(f.Fd()), 2)
+	unix.Dup2(int(f.Fd()), 2)
 }
 
 // runAsService runs the agent as a system daemon on Unix (launchd / systemd).

--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -24,6 +24,7 @@ const GH_PLATFORM_MAP: Record<string, string> = {
 
 const AGENT_TARGETS = [
   { goos: "linux", goarch: "amd64" },
+  { goos: "linux", goarch: "arm64" },
   { goos: "darwin", goarch: "amd64" },
   { goos: "darwin", goarch: "arm64" },
   { goos: "windows", goarch: "amd64" },


### PR DESCRIPTION
## What

Adds **`linux/arm64`** as a first-class agent build target, end-to-end — release build → signed manifest → server registration → install/download. Linux was previously **amd64-only**.

## Why

ARM64 Linux is increasingly common (cloud VMs, Ampere/Graviton fleets, Raspberry Pi / ARM edge boxes). The consumer side (install script arch detection, `/download/:os/:arch`, `VALID_ARCH`, filename parsing) already supported `arm64` — the only gaps were one Go portability blocker plus the build matrix and sync config.

## Changes

| File | Change |
|---|---|
| `agent/cmd/breeze-agent/service_unix.go` | **Compile blocker fix:** `syscall.Dup2` → `golang.org/x/sys/unix.Dup2`. `syscall.Dup2` doesn't exist on linux/arm64 (it only has `Dup3`), so `GOOS=linux GOARCH=arm64` failed with `undefined: syscall.Dup2`. `unix.Dup2` maps to `Dup3` on arm64 and is unchanged on amd64/darwin. |
| `.github/workflows/release.yml` | Add the `linux/arm64` entry to the `build-agent` matrix (CGO=0, ubuntu-latest). Asset copy (`breeze-agent-*` glob), the signed `release-artifact-manifest.json` (auto-discovers + hashes files), and `checksums.txt` all pick it up automatically. |
| `apps/api/src/services/binarySync.ts` | Add `{ goos: "linux", goarch: "arm64" }` to `AGENT_TARGETS` so the API registers and serves the new binary. The fetch loop uses `if (!asset) continue`, so this is order-tolerant w.r.t. the first release that ships the binary. |

## Already handled (no changes needed)

The consumer path was already arch-generic:
- Install script `detect_arch()` maps `aarch64|arm64 → arm64` (`routes/agents/download.ts`)
- `/download/:os/:arch` endpoint is arch-parametric; `VALID_ARCH` includes `arm64`
- `parseBinaryFilename` regex matches `linux-arm64`; `normalizeAgentArchitecture` maps `aarch64→arm64`
- Web UI enroll snippets use `uname -m` detection

## Verification

- ✅ `breeze-agent`, `breeze-backup`, `breeze-watchdog` all cross-compile for `linux/arm64` (CGO=0, matching the release job)
- ✅ No regression: `linux/amd64` and `darwin/arm64` still build
- ✅ `binarySync` test suites pass (9/9) — the new arm64 target is skipped when no asset is present, so existing assertions hold

## Out of scope

- **Helper (Tauri AppImage)** stays x86_64-only — `HELPER_TARGETS` linux has no arm64 AppImage. That's a separate, larger Tauri cross-build (needs an ARM runner) and the agent doesn't depend on it.
- **No PR-time arm64 cross-compile smoke check** — the matrix entry first exercises on a tagged release. A follow-up could add `linux/arm64` to `dev-build-agent.yml` or a `go build` cross-compile step in `ci.yml` to catch arch-specific breakage (like this `Dup2` issue) before release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
