### PR TITLE
feat(auth): Cloudflare Access JWT trust + SSO redirect login (#702)

### DIFF
--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -55,3 +55,18 @@ export const DELEGANT_BASE_URL = process.env.DELEGANT_BASE_URL ?? '';
 export const DELEGANT_SERVICE_TOKEN = process.env.DELEGANT_SERVICE_TOKEN ?? '';
 export const DELEGANT_PRINCIPAL_SIGNING_KEY = process.env.DELEGANT_PRINCIPAL_SIGNING_KEY ?? '';
 export const DELEGANT_PRINCIPAL_KID = process.env.DELEGANT_PRINCIPAL_KID ?? '';
+
+// Cloudflare Access JWT trust on /auth/login (Discussion #702). Read at call
+// time so tests can flip per-test without resetting modules.
+export function cfAccessTrustEnabled(): boolean {
+  return envFlag('CF_ACCESS_TRUST_ENABLED');
+}
+export function cfAccessTeamDomain(): string {
+  return (process.env.CF_ACCESS_TEAM_DOMAIN ?? '').trim();
+}
+export function cfAccessAud(): string {
+  return (process.env.CF_ACCESS_AUD ?? '').trim();
+}
+export function cfAccessTrustsMfa(): boolean {
+  return envFlag('CF_ACCESS_TRUSTS_MFA');
+}

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -446,6 +446,16 @@ const envSchema = z
     DELEGANT_SERVICE_TOKEN: z.string().optional(),
     DELEGANT_PRINCIPAL_SIGNING_KEY: z.string().optional(),
     DELEGANT_PRINCIPAL_KID: z.string().optional(),
+    // -- Cloudflare Access JWT trust (Discussion #702) -----------------------
+    // Operator opt-in to short-circuiting /auth/login when a valid CF Access
+    // JWT is presented. Off by default. When on, TEAM_DOMAIN + AUD are
+    // required; TRUSTS_MFA controls whether the minted Breeze session is
+    // marked as MFA-satisfied by the CF Access policy (an operator
+    // assertion, not derivable from the JWT itself).
+    CF_ACCESS_TRUST_ENABLED: z.string().optional(),
+    CF_ACCESS_TEAM_DOMAIN: z.string().optional(),
+    CF_ACCESS_AUD: z.string().optional(),
+    CF_ACCESS_TRUSTS_MFA: z.string().optional(),
 
     // -- Optional with defaults -----------------------------------------------
     API_PORT: portSchema,
@@ -956,6 +966,58 @@ const envSchema = z
         ctx,
       );
     }
+
+    // CF Access JWT trust (Discussion #702). Independent of NODE_ENV: the
+    // feature is opt-in via CF_ACCESS_TRUST_ENABLED, and when enabled the
+    // team domain and AUD are load-bearing for verifying the JWT. Validate
+    // anywhere the flag is on so dev misconfig is caught at boot.
+    const cfAccessTrustRaw = (data.CF_ACCESS_TRUST_ENABLED ?? '').trim().toLowerCase();
+    if (cfAccessTrustRaw && !['', 'false', '0', 'no', 'off'].includes(cfAccessTrustRaw)) {
+      if (!['true', '1', 'yes', 'on'].includes(cfAccessTrustRaw)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['CF_ACCESS_TRUST_ENABLED'],
+          message:
+            'CF_ACCESS_TRUST_ENABLED must be a boolean (true/false, 1/0, yes/no, on/off) when set.',
+        });
+      } else {
+        const teamDomain = (data.CF_ACCESS_TEAM_DOMAIN ?? '').trim();
+        if (!teamDomain) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['CF_ACCESS_TEAM_DOMAIN'],
+            message:
+              'CF_ACCESS_TEAM_DOMAIN is required when CF_ACCESS_TRUST_ENABLED is true (e.g. example.cloudflareaccess.com, no scheme).',
+          });
+        } else if (teamDomain.includes('://')) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['CF_ACCESS_TEAM_DOMAIN'],
+            message:
+              'CF_ACCESS_TEAM_DOMAIN must not include a scheme. Use the bare hostname (e.g. example.cloudflareaccess.com).',
+          });
+        }
+        const aud = (data.CF_ACCESS_AUD ?? '').trim();
+        if (!aud) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['CF_ACCESS_AUD'],
+            message:
+              'CF_ACCESS_AUD is required when CF_ACCESS_TRUST_ENABLED is true. Get the application AUD tag from the Cloudflare Zero Trust dashboard.',
+          });
+        }
+        const trustsMfaRaw = (data.CF_ACCESS_TRUSTS_MFA ?? '').trim().toLowerCase();
+        const cfBoolValues = new Set(['true', 'false', '1', '0', 'yes', 'no', 'on', 'off']);
+        if (trustsMfaRaw && !cfBoolValues.has(trustsMfaRaw)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['CF_ACCESS_TRUSTS_MFA'],
+            message:
+              'CF_ACCESS_TRUSTS_MFA must be a boolean (true/false, 1/0, yes/no, on/off) when set. Defaults to false (does not satisfy MFA).',
+          });
+        }
+      }
+    }
   });
 
 // Inferred config type from the schema
@@ -1125,6 +1187,10 @@ export function validateConfig(): AppConfig {
     DELEGANT_SERVICE_TOKEN: env.DELEGANT_SERVICE_TOKEN,
     DELEGANT_PRINCIPAL_SIGNING_KEY: env.DELEGANT_PRINCIPAL_SIGNING_KEY,
     DELEGANT_PRINCIPAL_KID: env.DELEGANT_PRINCIPAL_KID,
+    CF_ACCESS_TRUST_ENABLED: env.CF_ACCESS_TRUST_ENABLED,
+    CF_ACCESS_TEAM_DOMAIN: env.CF_ACCESS_TEAM_DOMAIN,
+    CF_ACCESS_AUD: env.CF_ACCESS_AUD,
+    CF_ACCESS_TRUSTS_MFA: env.CF_ACCESS_TRUSTS_MFA,
     API_PORT: env.API_PORT,
     REDIS_URL: env.REDIS_URL,
     REDIS_HOST: env.REDIS_HOST,

--- a/apps/api/src/middleware/cfAccessLogin.test.ts
+++ b/apps/api/src/middleware/cfAccessLogin.test.ts
@@ -1,0 +1,390 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Context, Next } from 'hono';
+
+const envState = vi.hoisted(() => ({
+  enabled: false,
+  teamDomain: 'your-team.cloudflareaccess.com',
+  audience: 'aud-app-1234567890abcdef',
+  trustsMfa: false,
+}));
+
+vi.mock('../config/env', () => ({
+  cfAccessTrustEnabled: () => envState.enabled,
+  cfAccessTeamDomain: () => envState.teamDomain,
+  cfAccessAud: () => envState.audience,
+  cfAccessTrustsMfa: () => envState.trustsMfa,
+}));
+
+const verifyState = vi.hoisted(() => ({
+  next: undefined as
+    | { kind: 'claims'; claims: Record<string, unknown> }
+    | { kind: 'invalid'; code?: string }
+    | { kind: 'jwks-unavailable' }
+    | undefined,
+}));
+
+vi.mock('../services/cfAccessJwt', async () => {
+  const actual = await vi.importActual<typeof import('../services/cfAccessJwt')>(
+    '../services/cfAccessJwt'
+  );
+  return {
+    ...actual,
+    verifyCfAccessJwt: vi.fn(async () => {
+      const v = verifyState.next;
+      verifyState.next = undefined;
+      if (!v) throw new actual.CfAccessInvalidTokenError('no verifier setup');
+      if (v.kind === 'claims') return v.claims;
+      if (v.kind === 'invalid') throw new actual.CfAccessInvalidTokenError('invalid', v.code);
+      throw new actual.CfAccessJwksUnavailableError('jwks down');
+    }),
+  };
+});
+
+const dbState = vi.hoisted(() => ({
+  userRow: null as Record<string, unknown> | null,
+  lastUpdateId: null as string | null,
+}));
+
+vi.mock('../db', () => {
+  function makeChain(row: Record<string, unknown> | null) {
+    const rows = row ? [row] : [];
+    const limit = vi.fn(async () => rows);
+    const where = vi.fn(() => {
+      const thenable = Promise.resolve(rows) as Promise<unknown[]> & { limit: typeof limit };
+      thenable.limit = limit;
+      return thenable;
+    });
+    const from = vi.fn(() => ({ where, limit }));
+    return { from };
+  }
+  return {
+    withDbAccessContext: vi.fn(async (_context: unknown, fn: () => unknown) => fn()),
+    withSystemDbAccessContext: vi.fn(async (fn: () => unknown) => fn()),
+    runOutsideDbContext: vi.fn(async (fn: () => unknown) => fn()),
+    db: {
+      select: vi.fn(() => makeChain(dbState.userRow)),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn((predicate: unknown) => {
+            void predicate;
+            dbState.lastUpdateId = dbState.userRow?.id as string | null;
+            return Promise.resolve();
+          }),
+        })),
+      })),
+    },
+  };
+});
+
+const tokenState = vi.hoisted(() => ({
+  lastPayload: null as Record<string, unknown> | null,
+}));
+
+vi.mock('../services', () => ({
+  createTokenPair: vi.fn(async (payload: Record<string, unknown>) => {
+    tokenState.lastPayload = payload;
+    return { accessToken: 'access-tok', refreshToken: 'refresh-tok', expiresInSeconds: 900 };
+  }),
+  getRedis: vi.fn(() => ({
+    setex: vi.fn(async () => 'OK'),
+  })),
+}));
+
+const auditState = vi.hoisted(() => ({
+  audits: [] as Array<Record<string, unknown>>,
+  loginFailures: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock('../services/auditService', () => ({
+  createAuditLogAsync: vi.fn((entry: Record<string, unknown>) => {
+    auditState.audits.push(entry);
+  }),
+}));
+
+vi.mock('../routes/auth/helpers', async () => {
+  const actual = await vi.importActual<typeof import('../routes/auth/helpers')>(
+    '../routes/auth/helpers'
+  );
+  return {
+    ...actual,
+    auditUserLoginFailure: vi.fn((_c: unknown, entry: Record<string, unknown>) => {
+      auditState.loginFailures.push(entry);
+    }),
+    resolveCurrentUserTokenContext: vi.fn(async () => contextState.value),
+    setRefreshTokenCookie: vi.fn((c: Context, refreshToken: string) => {
+      cookieState.set = refreshToken;
+      // ape Hono's behaviour just enough for the test's purposes
+      c.header('set-cookie', `breeze_refresh=${refreshToken}; Path=/; HttpOnly`);
+    }),
+    toPublicTokens: actual.toPublicTokens,
+    userRequiresSetup: () => false,
+    getClientIP: () => '127.0.0.1',
+  };
+});
+
+vi.mock('../services/mobileDeviceBinding', () => ({
+  readMobileDeviceId: vi.fn(() => null),
+  carryForwardBinding: vi.fn((p: Record<string, unknown>) => p.mdid as string | undefined),
+}));
+
+const contextState = vi.hoisted(() => ({
+  value: {
+    roleId: 'role-1',
+    partnerId: 'partner-1',
+    orgId: null as string | null,
+    scope: 'partner' as 'partner' | 'organization' | 'system',
+  },
+}));
+
+const cookieState = vi.hoisted(() => ({
+  set: null as string | null,
+}));
+
+vi.mock('../routes/auth/schemas', async () => {
+  const actual = await vi.importActual<typeof import('../routes/auth/schemas')>(
+    '../routes/auth/schemas'
+  );
+  return { ...actual, ENABLE_2FA: true };
+});
+
+import { cfAccessLoginMiddleware } from './cfAccessLogin';
+
+function createContext(headers: Record<string, string | undefined> = {}): Context {
+  const normalized = Object.fromEntries(
+    Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v])
+  );
+  const responseHeaders: Record<string, string> = {};
+  const store = new Map<string, unknown>();
+
+  return {
+    req: {
+      header: (name: string) => normalized[name.toLowerCase()],
+    },
+    set: (key: string, value: unknown) => {
+      store.set(key, value);
+    },
+    get: (key: string) => store.get(key),
+    header: (name: string, value: string) => {
+      responseHeaders[name.toLowerCase()] = value;
+    },
+    json: (body: unknown, status?: number) => {
+      const res = new Response(JSON.stringify(body), {
+        status: status ?? 200,
+        headers: { 'content-type': 'application/json', ...responseHeaders },
+      });
+      return res;
+    },
+  } as unknown as Context;
+}
+
+function createNext(): { next: Next; called: () => boolean } {
+  let called = false;
+  const next: Next = async () => {
+    called = true;
+  };
+  return { next, called: () => called };
+}
+
+const activeUser = {
+  id: 'user-1',
+  email: 'user@example.com',
+  name: 'Billy Dunn',
+  status: 'active',
+  passwordHash: 'argon2hash',
+  mfaEnabled: false,
+  mfaSecret: null,
+  mfaMethod: null,
+  phoneNumber: null,
+  avatarUrl: null,
+  setupCompletedAt: new Date(),
+  preferences: null,
+  lastLoginAt: null,
+};
+
+describe('cfAccessLoginMiddleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    envState.enabled = false;
+    envState.teamDomain = 'your-team.cloudflareaccess.com';
+    envState.audience = 'aud-app-1234567890abcdef';
+    envState.trustsMfa = false;
+    verifyState.next = undefined;
+    dbState.userRow = null;
+    dbState.lastUpdateId = null;
+    tokenState.lastPayload = null;
+    auditState.audits = [];
+    auditState.loginFailures = [];
+    contextState.value = {
+      roleId: 'role-1',
+      partnerId: 'partner-1',
+      orgId: null,
+      scope: 'partner',
+    };
+    cookieState.set = null;
+  });
+
+  it('falls through when trust is disabled', async () => {
+    envState.enabled = false;
+    const { next, called } = createNext();
+    const res = await cfAccessLoginMiddleware(
+      createContext({ 'Cf-Access-Jwt-Assertion': 'any.jwt.here' }),
+      next
+    );
+    expect(res).toBeUndefined();
+    expect(called()).toBe(true);
+  });
+
+  it('falls through when the JWT header is absent', async () => {
+    envState.enabled = true;
+    const { next, called } = createNext();
+    const res = await cfAccessLoginMiddleware(createContext(), next);
+    expect(res).toBeUndefined();
+    expect(called()).toBe(true);
+  });
+
+  it('falls through and warns when team domain is missing', async () => {
+    envState.enabled = true;
+    envState.teamDomain = '';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { next, called } = createNext();
+    await cfAccessLoginMiddleware(
+      createContext({ 'Cf-Access-Jwt-Assertion': 'tok' }),
+      next
+    );
+    expect(called()).toBe(true);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('falls through on invalid JWT', async () => {
+    envState.enabled = true;
+    verifyState.next = { kind: 'invalid', code: 'ERR_JWT_EXPIRED' };
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { next, called } = createNext();
+    await cfAccessLoginMiddleware(
+      createContext({ 'Cf-Access-Jwt-Assertion': 'tok' }),
+      next
+    );
+    expect(called()).toBe(true);
+    warnSpy.mockRestore();
+  });
+
+  it('falls through on JWKS-unavailable', async () => {
+    envState.enabled = true;
+    verifyState.next = { kind: 'jwks-unavailable' };
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { next, called } = createNext();
+    await cfAccessLoginMiddleware(
+      createContext({ 'Cf-Access-Jwt-Assertion': 'tok' }),
+      next
+    );
+    expect(called()).toBe(true);
+    errSpy.mockRestore();
+  });
+
+  it('falls through when the JWT email does not match any Breeze user', async () => {
+    envState.enabled = true;
+    verifyState.next = {
+      kind: 'claims',
+      claims: { email: 'ghost@nowhere.test', sub: 'cf-1', aud: envState.audience, iss: `https://${envState.teamDomain}`, exp: 999, iat: 1 },
+    };
+    dbState.userRow = null;
+    const { next, called } = createNext();
+    await cfAccessLoginMiddleware(
+      createContext({ 'Cf-Access-Jwt-Assertion': 'tok' }),
+      next
+    );
+    expect(called()).toBe(true);
+  });
+
+  it('falls through when the matching user is inactive and audits the denial', async () => {
+    envState.enabled = true;
+    verifyState.next = {
+      kind: 'claims',
+      claims: { email: activeUser.email, sub: 'cf-1', aud: envState.audience, iss: `https://${envState.teamDomain}`, exp: 999, iat: 1 },
+    };
+    dbState.userRow = { ...activeUser, status: 'suspended' };
+    const { next, called } = createNext();
+    await cfAccessLoginMiddleware(
+      createContext({ 'Cf-Access-Jwt-Assertion': 'tok' }),
+      next
+    );
+    expect(called()).toBe(true);
+    expect(auditState.loginFailures).toHaveLength(1);
+    expect(auditState.loginFailures[0]).toMatchObject({
+      userId: activeUser.id,
+      reason: 'account_inactive',
+    });
+  });
+
+  it('mints tokens for a valid JWT + active user without MFA', async () => {
+    envState.enabled = true;
+    verifyState.next = {
+      kind: 'claims',
+      claims: { email: activeUser.email, sub: 'cf-1', aud: envState.audience, iss: `https://${envState.teamDomain}`, exp: 999, iat: 1 },
+    };
+    dbState.userRow = { ...activeUser };
+    const { next, called } = createNext();
+    const res = await cfAccessLoginMiddleware(
+      createContext({ 'Cf-Access-Jwt-Assertion': 'tok' }),
+      next
+    );
+    expect(called()).toBe(false);
+    expect(res).toBeInstanceOf(Response);
+    const body = await (res as Response).json();
+    expect(body.user.email).toBe(activeUser.email);
+    expect(body.tokens.accessToken).toBe('access-tok');
+    expect(body.mfaRequired).toBe(false);
+    expect(tokenState.lastPayload).toMatchObject({
+      sub: activeUser.id,
+      mfa: true, // vacuously satisfied because mfaEnabled=false
+    });
+    expect(cookieState.set).toBe('refresh-tok');
+    expect(dbState.lastUpdateId).toBe(activeUser.id);
+    expect(auditState.audits[0]).toMatchObject({
+      action: 'user.login',
+      details: expect.objectContaining({ method: 'cf_access_jwt' }),
+    });
+  });
+
+  it('issues an MFA temp token when user has MFA and TRUSTS_MFA is false', async () => {
+    envState.enabled = true;
+    envState.trustsMfa = false;
+    verifyState.next = {
+      kind: 'claims',
+      claims: { email: activeUser.email, sub: 'cf-1', aud: envState.audience, iss: `https://${envState.teamDomain}`, exp: 999, iat: 1 },
+    };
+    dbState.userRow = { ...activeUser, mfaEnabled: true, mfaSecret: 'encrypted', mfaMethod: 'totp' };
+    const { next, called } = createNext();
+    const res = await cfAccessLoginMiddleware(
+      createContext({ 'Cf-Access-Jwt-Assertion': 'tok' }),
+      next
+    );
+    expect(called()).toBe(false);
+    const body = await (res as Response).json();
+    expect(body.mfaRequired).toBe(true);
+    expect(body.tempToken).toBeTruthy();
+    expect(body.mfaMethod).toBe('totp');
+    expect(body.tokens).toBeNull();
+    expect(tokenState.lastPayload).toBeNull(); // no full token mint yet
+  });
+
+  it('mints tokens with mfa=true when TRUSTS_MFA is true even if user has MFA enabled', async () => {
+    envState.enabled = true;
+    envState.trustsMfa = true;
+    verifyState.next = {
+      kind: 'claims',
+      claims: { email: activeUser.email, sub: 'cf-1', aud: envState.audience, iss: `https://${envState.teamDomain}`, exp: 999, iat: 1 },
+    };
+    dbState.userRow = { ...activeUser, mfaEnabled: true, mfaSecret: 'encrypted', mfaMethod: 'totp' };
+    const { next, called } = createNext();
+    const res = await cfAccessLoginMiddleware(
+      createContext({ 'Cf-Access-Jwt-Assertion': 'tok' }),
+      next
+    );
+    expect(called()).toBe(false);
+    const body = await (res as Response).json();
+    expect(body.mfaRequired).toBe(false);
+    expect(tokenState.lastPayload).toMatchObject({ mfa: true });
+  });
+});

--- a/apps/api/src/middleware/cfAccessLogin.ts
+++ b/apps/api/src/middleware/cfAccessLogin.ts
@@ -1,0 +1,210 @@
+import type { Context, Next } from 'hono';
+import { eq } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+import * as dbModule from '../db';
+import { users } from '../db/schema';
+import {
+  cfAccessAud,
+  cfAccessTeamDomain,
+  cfAccessTrustEnabled,
+  cfAccessTrustsMfa,
+} from '../config/env';
+import {
+  CfAccessInvalidTokenError,
+  CfAccessJwksUnavailableError,
+  verifyCfAccessJwt,
+} from '../services/cfAccessJwt';
+import { createTokenPair } from '../services';
+import { getRedis } from '../services';
+import { createAuditLogAsync } from '../services/auditService';
+import { TenantInactiveError } from '../services/tenantStatus';
+import { ENABLE_2FA } from '../routes/auth/schemas';
+import {
+  auditUserLoginFailure,
+  getClientIP,
+  resolveCurrentUserTokenContext,
+  setRefreshTokenCookie,
+  toPublicTokens,
+  userRequiresSetup,
+} from '../routes/auth/helpers';
+import { readMobileDeviceId } from '../services/mobileDeviceBinding';
+
+const { db, withSystemDbAccessContext } = dbModule;
+
+const CF_ACCESS_JWT_HEADER = 'cf-access-jwt-assertion';
+
+/**
+ * Hono middleware that short-circuits `POST /auth/login` when a valid
+ * Cloudflare Access JWT is presented (Discussion #702).
+ *
+ * Behaviour:
+ *   - CF_ACCESS_TRUST_ENABLED unset/false  → next()
+ *   - Cf-Access-Jwt-Assertion header absent → next()
+ *   - JWT signature / claim invalid        → next() (fail-closed on trust)
+ *   - JWKS network blip                    → next() (fail-open on availability)
+ *   - User not found by email              → next() (let password handler 401)
+ *   - User inactive                        → next() (let password handler 401)
+ *   - User has MFA + CF_ACCESS_TRUSTS_MFA=false → issue MFA temp token
+ *   - Otherwise                            → mint token pair, set cookie, return
+ *
+ * Mount BEFORE the zValidator+password handler so the JWT path is tried first
+ * but the password path still validates its body when this falls through.
+ *
+ * See:
+ *   - apps/api/src/services/cfAccessJwt.ts (JWKS verifier)
+ *   - apps/api/src/routes/auth/login.ts (the handler this falls through to)
+ */
+export async function cfAccessLoginMiddleware(c: Context, next: Next): Promise<Response | void> {
+  if (!cfAccessTrustEnabled()) return next();
+
+  const token = c.req.header(CF_ACCESS_JWT_HEADER);
+  if (!token) return next();
+
+  const teamDomain = cfAccessTeamDomain();
+  const audience = cfAccessAud();
+  if (!teamDomain || !audience) {
+    // Trust is enabled but the deployment is misconfigured. Fail-open to
+    // the password handler rather than wedge /login for everyone. Surface
+    // a single warning so ops sees it.
+    console.warn(
+      '[cf-access-login] CF_ACCESS_TRUST_ENABLED=true but CF_ACCESS_TEAM_DOMAIN or CF_ACCESS_AUD is empty; ignoring header.'
+    );
+    return next();
+  }
+
+  let claims;
+  try {
+    claims = await verifyCfAccessJwt(token, { teamDomain, audience });
+  } catch (err) {
+    if (err instanceof CfAccessInvalidTokenError) {
+      // Don't log token contents; just the code. Repeated INVALID is
+      // either a stale CF Access session or an attacker probe — either
+      // way fall through and let the password handler do its thing.
+      console.warn('[cf-access-login] rejected JWT', { code: err.code });
+    } else if (err instanceof CfAccessJwksUnavailableError) {
+      console.error('[cf-access-login] JWKS unavailable, falling through to password', err);
+    } else {
+      console.error('[cf-access-login] unexpected verify error', err);
+    }
+    return next();
+  }
+
+  const normalizedEmail = claims.email.toLowerCase();
+
+  const [user] = await withSystemDbAccessContext(async () =>
+    db.select().from(users).where(eq(users.email, normalizedEmail)).limit(1)
+  );
+
+  if (!user) {
+    // No matching Breeze user. Fall through; password handler will 401
+    // generically. We don't want to leak "no such email" via this path
+    // either.
+    return next();
+  }
+
+  if (user.status !== 'active') {
+    void auditUserLoginFailure(c, {
+      userId: user.id,
+      email: user.email,
+      name: user.name,
+      reason: 'account_inactive',
+      result: 'denied',
+      details: { accountStatus: user.status, method: 'cf_access_jwt' },
+    });
+    return next();
+  }
+
+  let context;
+  try {
+    context = await resolveCurrentUserTokenContext(user.id);
+  } catch (err) {
+    if (!(err instanceof TenantInactiveError)) throw err;
+    void auditUserLoginFailure(c, {
+      userId: user.id,
+      email: user.email,
+      name: user.name,
+      reason: 'tenant_inactive',
+      result: 'denied',
+      details: { method: 'cf_access_jwt' },
+    });
+    return next();
+  }
+
+  // CF Access JWT cannot tell us whether the user satisfied MFA at the
+  // edge — that's an operator-level assertion via CF_ACCESS_TRUSTS_MFA.
+  // If the user has Breeze MFA enrolled and we don't trust CF Access as
+  // MFA, issue a temp token and require the user to complete TOTP, same
+  // shape the password handler uses.
+  const trustsMfa = cfAccessTrustsMfa();
+  if (ENABLE_2FA && user.mfaEnabled && (user.mfaSecret || user.mfaMethod === 'sms') && !trustsMfa) {
+    const redis = getRedis();
+    if (!redis) {
+      console.error('[cf-access-login] redis unavailable; cannot issue MFA temp token, falling through');
+      return next();
+    }
+    const tempToken = nanoid(32);
+    const mfaMethod = user.mfaMethod || 'totp';
+    await redis.setex(
+      `mfa:pending:${tempToken}`,
+      300,
+      JSON.stringify({ userId: user.id, mfaMethod })
+    );
+    return c.json({
+      mfaRequired: true,
+      tempToken,
+      mfaMethod,
+      phoneLast4: user.phoneNumber?.slice(-4) || null,
+      user: null,
+      tokens: null,
+    });
+  }
+
+  const mfaSatisfied = trustsMfa || !(ENABLE_2FA && user.mfaEnabled);
+
+  const tokens = await createTokenPair({
+    sub: user.id,
+    email: user.email,
+    roleId: context.roleId,
+    orgId: context.orgId,
+    partnerId: context.partnerId,
+    scope: context.scope,
+    mfa: mfaSatisfied,
+    mdid: readMobileDeviceId(c) ?? undefined,
+  });
+
+  await db.update(users).set({ lastLoginAt: new Date() }).where(eq(users.id, user.id));
+
+  createAuditLogAsync({
+    orgId: context.orgId ?? undefined,
+    actorId: user.id,
+    actorEmail: user.email,
+    action: 'user.login',
+    resourceType: 'user',
+    resourceId: user.id,
+    resourceName: user.name,
+    details: {
+      method: 'cf_access_jwt',
+      mfa: mfaSatisfied,
+      scope: context.scope,
+      cfAccessSub: claims.sub,
+    },
+    ipAddress: getClientIP(c),
+    userAgent: c.req.header('user-agent'),
+    result: 'success',
+  });
+
+  setRefreshTokenCookie(c, tokens.refreshToken);
+
+  return c.json({
+    user: {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      mfaEnabled: ENABLE_2FA ? user.mfaEnabled : false,
+      avatarUrl: user.avatarUrl,
+    },
+    tokens: toPublicTokens(tokens),
+    mfaRequired: false,
+    requiresSetup: userRequiresSetup(user),
+  });
+}

--- a/apps/api/src/routes/auth/cfAccessRedirectLogin.test.ts
+++ b/apps/api/src/routes/auth/cfAccessRedirectLogin.test.ts
@@ -1,0 +1,331 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const envState = vi.hoisted(() => ({
+  enabled: false,
+  teamDomain: 'your-team.cloudflareaccess.com',
+  audience: 'aud-app-1234567890abcdef',
+  trustsMfa: false,
+}));
+
+vi.mock('../../config/env', () => ({
+  cfAccessTrustEnabled: () => envState.enabled,
+  cfAccessTeamDomain: () => envState.teamDomain,
+  cfAccessAud: () => envState.audience,
+  cfAccessTrustsMfa: () => envState.trustsMfa,
+}));
+
+const verifyState = vi.hoisted(() => ({
+  next: undefined as
+    | { kind: 'claims'; claims: Record<string, unknown> }
+    | { kind: 'invalid'; code?: string }
+    | { kind: 'jwks-unavailable' }
+    | undefined,
+}));
+
+vi.mock('../../services/cfAccessJwt', async () => {
+  const actual = await vi.importActual<typeof import('../../services/cfAccessJwt')>(
+    '../../services/cfAccessJwt'
+  );
+  return {
+    ...actual,
+    verifyCfAccessJwt: vi.fn(async () => {
+      const v = verifyState.next;
+      verifyState.next = undefined;
+      if (!v) throw new actual.CfAccessInvalidTokenError('no verifier setup');
+      if (v.kind === 'claims') return v.claims;
+      if (v.kind === 'invalid') throw new actual.CfAccessInvalidTokenError('invalid', v.code);
+      throw new actual.CfAccessJwksUnavailableError('jwks down');
+    }),
+  };
+});
+
+const dbState = vi.hoisted(() => ({
+  userRow: null as Record<string, unknown> | null,
+}));
+
+vi.mock('../../db', () => {
+  function makeChain(row: Record<string, unknown> | null) {
+    const rows = row ? [row] : [];
+    const limit = vi.fn(async () => rows);
+    const where = vi.fn(() => {
+      const thenable = Promise.resolve(rows) as Promise<unknown[]> & { limit: typeof limit };
+      thenable.limit = limit;
+      return thenable;
+    });
+    const from = vi.fn(() => ({ where, limit }));
+    return { from };
+  }
+  return {
+    withDbAccessContext: vi.fn(async (_c: unknown, fn: () => unknown) => fn()),
+    withSystemDbAccessContext: vi.fn(async (fn: () => unknown) => fn()),
+    runOutsideDbContext: vi.fn(async (fn: () => unknown) => fn()),
+    db: {
+      select: vi.fn(() => makeChain(dbState.userRow)),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(() => Promise.resolve()),
+        })),
+      })),
+    },
+  };
+});
+
+vi.mock('../../services', () => ({
+  createTokenPair: vi.fn(async () => ({
+    accessToken: 'access-tok',
+    refreshToken: 'refresh-tok',
+    expiresInSeconds: 900,
+  })),
+}));
+
+const auditState = vi.hoisted(() => ({
+  audits: [] as Array<Record<string, unknown>>,
+  loginFailures: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock('../../services/auditService', () => ({
+  createAuditLogAsync: vi.fn((entry: Record<string, unknown>) => {
+    auditState.audits.push(entry);
+  }),
+}));
+
+const cookieState = vi.hoisted(() => ({ set: null as string | null, cleared: false }));
+
+vi.mock('./helpers', async () => {
+  const actual = await vi.importActual<typeof import('./helpers')>('./helpers');
+  return {
+    ...actual,
+    auditUserLoginFailure: vi.fn((_c: unknown, entry: Record<string, unknown>) => {
+      auditState.loginFailures.push(entry);
+    }),
+    resolveCurrentUserTokenContext: vi.fn(async () => ({
+      roleId: 'role-1',
+      partnerId: 'partner-1',
+      orgId: null as string | null,
+      scope: 'partner' as const,
+    })),
+    setRefreshTokenCookie: vi.fn((c: unknown, refreshToken: string) => {
+      void c;
+      cookieState.set = refreshToken;
+    }),
+    clearRefreshTokenCookie: vi.fn((c: unknown) => {
+      void c;
+      cookieState.set = null;
+      cookieState.cleared = true;
+    }),
+    getClientIP: () => '127.0.0.1',
+  };
+});
+
+vi.mock('./schemas', async () => {
+  const actual = await vi.importActual<typeof import('./schemas')>('./schemas');
+  return { ...actual, ENABLE_2FA: true };
+});
+
+import { cfAccessRedirectLoginRoutes } from './cfAccessRedirectLogin';
+
+const activeUser = {
+  id: 'user-1',
+  email: 'user@example.com',
+  name: 'Billy Dunn',
+  status: 'active',
+  passwordHash: 'argon2hash',
+  mfaEnabled: false,
+  mfaSecret: null,
+  mfaMethod: null,
+  phoneNumber: null,
+  avatarUrl: null,
+  setupCompletedAt: new Date(),
+  preferences: null,
+  lastLoginAt: null,
+};
+
+async function callGet(url: string, headers: Record<string, string> = {}): Promise<Response> {
+  return cfAccessRedirectLoginRoutes.request(url, { method: 'GET', headers });
+}
+
+describe('GET /cf-access-login', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    envState.enabled = false;
+    envState.teamDomain = 'your-team.cloudflareaccess.com';
+    envState.audience = 'aud-app-1234567890abcdef';
+    envState.trustsMfa = false;
+    verifyState.next = undefined;
+    dbState.userRow = null;
+    auditState.audits = [];
+    auditState.loginFailures = [];
+    cookieState.set = null;
+    cookieState.cleared = false;
+  });
+
+  it('redirects to /login with error=disabled when trust is off', async () => {
+    envState.enabled = false;
+    const res = await callGet('/cf-access-login', { 'Cf-Access-Jwt-Assertion': 'tok' });
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toContain('/login?');
+    expect(res.headers.get('Location')).toContain('reason=disabled');
+  });
+
+  it('redirects to /login with error=no-jwt when header missing', async () => {
+    envState.enabled = true;
+    const res = await callGet('/cf-access-login');
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toContain('reason=no-jwt');
+  });
+
+  it('redirects to /login with error=misconfigured when team domain absent', async () => {
+    envState.enabled = true;
+    envState.teamDomain = '';
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const res = await callGet('/cf-access-login', { 'Cf-Access-Jwt-Assertion': 'tok' });
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toContain('reason=misconfigured');
+    errSpy.mockRestore();
+  });
+
+  it('redirects to /login with error=invalid-jwt when verifier rejects token', async () => {
+    envState.enabled = true;
+    verifyState.next = { kind: 'invalid', code: 'ERR_JWT_EXPIRED' };
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const res = await callGet('/cf-access-login', { 'Cf-Access-Jwt-Assertion': 'tok' });
+    expect(res.headers.get('Location')).toContain('reason=invalid-jwt');
+    warnSpy.mockRestore();
+  });
+
+  it('redirects to /login with error=jwks-unavailable on JWKS network error', async () => {
+    envState.enabled = true;
+    verifyState.next = { kind: 'jwks-unavailable' };
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const res = await callGet('/cf-access-login', { 'Cf-Access-Jwt-Assertion': 'tok' });
+    expect(res.headers.get('Location')).toContain('reason=jwks-unavailable');
+    errSpy.mockRestore();
+  });
+
+  it('redirects to /login with error=no-user when JWT email does not match a Breeze user', async () => {
+    envState.enabled = true;
+    verifyState.next = {
+      kind: 'claims',
+      claims: {
+        email: 'ghost@nowhere.test',
+        sub: 'cf-1',
+        aud: envState.audience,
+        iss: `https://${envState.teamDomain}`,
+        exp: 999,
+        iat: 1,
+      },
+    };
+    dbState.userRow = null;
+    const res = await callGet('/cf-access-login', { 'Cf-Access-Jwt-Assertion': 'tok' });
+    expect(res.headers.get('Location')).toContain('reason=no-user');
+  });
+
+  it('redirects to /login with error=mfa-required when user has MFA and TRUSTS_MFA is false', async () => {
+    envState.enabled = true;
+    envState.trustsMfa = false;
+    verifyState.next = {
+      kind: 'claims',
+      claims: {
+        email: activeUser.email,
+        sub: 'cf-1',
+        aud: envState.audience,
+        iss: `https://${envState.teamDomain}`,
+        exp: 999,
+        iat: 1,
+      },
+    };
+    dbState.userRow = { ...activeUser, mfaEnabled: true, mfaSecret: 'encrypted', mfaMethod: 'totp' };
+    const res = await callGet('/cf-access-login', { 'Cf-Access-Jwt-Assertion': 'tok' });
+    expect(res.headers.get('Location')).toContain('reason=mfa-required');
+  });
+
+  it('mints a session and redirects to / with cf-access-login=success on success', async () => {
+    envState.enabled = true;
+    verifyState.next = {
+      kind: 'claims',
+      claims: {
+        email: activeUser.email,
+        sub: 'cf-1',
+        aud: envState.audience,
+        iss: `https://${envState.teamDomain}`,
+        exp: 999,
+        iat: 1,
+      },
+    };
+    dbState.userRow = { ...activeUser };
+    const res = await callGet('/cf-access-login', { 'Cf-Access-Jwt-Assertion': 'tok' });
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toMatch(/^\/\?cf-access-login=success$/);
+    expect(cookieState.set).toBe('refresh-tok');
+    expect(auditState.audits[0]).toMatchObject({
+      action: 'user.login',
+      details: expect.objectContaining({ method: 'cf_access_jwt_redirect' }),
+    });
+  });
+
+  it('preserves a safe next param and appends cf-access-login=success', async () => {
+    envState.enabled = true;
+    verifyState.next = {
+      kind: 'claims',
+      claims: {
+        email: activeUser.email,
+        sub: 'cf-1',
+        aud: envState.audience,
+        iss: `https://${envState.teamDomain}`,
+        exp: 999,
+        iat: 1,
+      },
+    };
+    dbState.userRow = { ...activeUser };
+    const res = await callGet('/cf-access-login?next=%2Fdevices', { 'Cf-Access-Jwt-Assertion': 'tok' });
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toMatch(/^\/devices\?cf-access-login=success$/);
+  });
+
+  it('logout endpoint chains app-domain + team-domain CF logouts ending at /login?signedOut=1', async () => {
+    envState.enabled = true;
+    const res = await cfAccessRedirectLoginRoutes.request('http://api.example/cf-access-logout', {
+      method: 'GET',
+      headers: { host: 'breeze.example.com' },
+    });
+    expect(res.status).toBe(302);
+    const loc = res.headers.get('Location') ?? '';
+    // Outer hop is the app-domain logout.
+    expect(loc.startsWith('https://breeze.example.com/cdn-cgi/access/logout?returnTo=')).toBe(true);
+    // Inner hop (decoded once) is the team-domain logout.
+    const innerEncoded = loc.split('returnTo=')[1] ?? '';
+    const inner = decodeURIComponent(innerEncoded);
+    expect(inner.startsWith(`https://${envState.teamDomain}/cdn-cgi/access/logout?returnTo=`)).toBe(true);
+    // Innermost (decoded twice) is the SPA landing page.
+    const finalEncoded = inner.split('returnTo=')[1] ?? '';
+    expect(decodeURIComponent(finalEncoded)).toBe('https://breeze.example.com/login?signedOut=1');
+    expect(cookieState.cleared).toBe(true);
+  });
+
+  it('logout endpoint falls back to /login?signedOut=1 when CF Access trust disabled', async () => {
+    envState.enabled = false;
+    const res = await cfAccessRedirectLoginRoutes.request('http://api.example/cf-access-logout', { method: 'GET' });
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe('/login?signedOut=1');
+    expect(cookieState.cleared).toBe(true);
+  });
+
+  it('rejects an unsafe next param and falls back to /', async () => {
+    envState.enabled = true;
+    verifyState.next = {
+      kind: 'claims',
+      claims: {
+        email: activeUser.email,
+        sub: 'cf-1',
+        aud: envState.audience,
+        iss: `https://${envState.teamDomain}`,
+        exp: 999,
+        iat: 1,
+      },
+    };
+    dbState.userRow = { ...activeUser };
+    const res = await callGet('/cf-access-login?next=%2F%2Fevil.com', { 'Cf-Access-Jwt-Assertion': 'tok' });
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toMatch(/^\/\?cf-access-login=success$/);
+  });
+});

--- a/apps/api/src/routes/auth/cfAccessRedirectLogin.ts
+++ b/apps/api/src/routes/auth/cfAccessRedirectLogin.ts
@@ -1,0 +1,271 @@
+import { Hono } from 'hono';
+import { eq } from 'drizzle-orm';
+import * as dbModule from '../../db';
+import { users } from '../../db/schema';
+import {
+  cfAccessAud,
+  cfAccessTeamDomain,
+  cfAccessTrustEnabled,
+  cfAccessTrustsMfa,
+} from '../../config/env';
+import {
+  CfAccessInvalidTokenError,
+  CfAccessJwksUnavailableError,
+  verifyCfAccessJwt,
+} from '../../services/cfAccessJwt';
+import { createTokenPair } from '../../services';
+import { createAuditLogAsync } from '../../services/auditService';
+import { TenantInactiveError } from '../../services/tenantStatus';
+import { ENABLE_2FA } from './schemas';
+import {
+  auditUserLoginFailure,
+  clearRefreshTokenCookie,
+  getClientIP,
+  resolveCurrentUserTokenContext,
+  setRefreshTokenCookie,
+} from './helpers';
+
+const { db, withSystemDbAccessContext } = dbModule;
+
+const CF_ACCESS_JWT_HEADER = 'cf-access-jwt-assertion';
+
+/**
+ * Same-origin guard for the `?next=` query param. Server-side variant of
+ * apps/web/src/lib/authNext.ts: only single-leading-/ paths, no //, no \\,
+ * no control characters (which also blocks CRLF Location-header injection).
+ */
+function safeNext(raw: string | undefined): string {
+  if (!raw) return '/';
+  if (!raw.startsWith('/')) return '/';
+  if (raw.length > 1 && (raw[1] === '/' || raw[1] === '\\')) return '/';
+  if (/[\x00-\x1F\x7F]/.test(raw)) return '/';
+  return raw;
+}
+
+function loginErrorRedirect(reason: string): Response {
+  const params = new URLSearchParams({ error: 'cf-access', reason });
+  return new Response(null, {
+    status: 302,
+    headers: { Location: `/login?${params.toString()}` },
+  });
+}
+
+export const cfAccessRedirectLoginRoutes = new Hono();
+
+/**
+ * GET /api/v1/auth/cf-access-login
+ *
+ * Top-level browser navigation entry-point for Cloudflare Access trust. The
+ * SPA redirects the browser to this URL when the deployment's CF Access
+ * trust is enabled and there's no Breeze session yet. CF Access enforces
+ * the path (more specific than any /api/* Bypass), forwards the
+ * Cf-Access-Jwt-Assertion header on a top-level GET (where redirects are
+ * survivable), and this handler:
+ *
+ *   1. Verifies the JWT against the configured team JWKS
+ *   2. Looks up the matching Breeze user
+ *   3. Mints a Breeze session, sets the refresh cookie
+ *   4. 302s back to the `next=` param (sanitized) or `/`
+ *
+ * Failure modes redirect to /login with an error query so the SPA can
+ * surface a useful message and the user can fall back to password login.
+ *
+ * See Discussion #702 and the companion XHR middleware at
+ * apps/api/src/middleware/cfAccessLogin.ts.
+ */
+cfAccessRedirectLoginRoutes.get('/cf-access-login', async (c) => {
+  if (!cfAccessTrustEnabled()) {
+    return loginErrorRedirect('disabled');
+  }
+
+  const token = c.req.header(CF_ACCESS_JWT_HEADER);
+  if (!token) {
+    return loginErrorRedirect('no-jwt');
+  }
+
+  const teamDomain = cfAccessTeamDomain();
+  const audience = cfAccessAud();
+  if (!teamDomain || !audience) {
+    console.error(
+      '[cf-access-redirect] CF_ACCESS_TRUST_ENABLED=true but team domain or AUD missing'
+    );
+    return loginErrorRedirect('misconfigured');
+  }
+
+  let claims;
+  try {
+    claims = await verifyCfAccessJwt(token, { teamDomain, audience });
+  } catch (err) {
+    if (err instanceof CfAccessInvalidTokenError) {
+      console.warn('[cf-access-redirect] rejected JWT', { code: err.code });
+      return loginErrorRedirect('invalid-jwt');
+    }
+    if (err instanceof CfAccessJwksUnavailableError) {
+      console.error('[cf-access-redirect] JWKS unavailable', err);
+      return loginErrorRedirect('jwks-unavailable');
+    }
+    console.error('[cf-access-redirect] unexpected verify error', err);
+    return loginErrorRedirect('verify-error');
+  }
+
+  const normalizedEmail = claims.email.toLowerCase();
+
+  const [user] = await withSystemDbAccessContext(async () =>
+    db.select().from(users).where(eq(users.email, normalizedEmail)).limit(1)
+  );
+
+  if (!user) {
+    return loginErrorRedirect('no-user');
+  }
+
+  if (user.status !== 'active') {
+    void auditUserLoginFailure(c, {
+      userId: user.id,
+      email: user.email,
+      name: user.name,
+      reason: 'account_inactive',
+      result: 'denied',
+      details: { accountStatus: user.status, method: 'cf_access_jwt_redirect' },
+    });
+    return loginErrorRedirect('inactive');
+  }
+
+  let context;
+  try {
+    context = await resolveCurrentUserTokenContext(user.id);
+  } catch (err) {
+    if (!(err instanceof TenantInactiveError)) throw err;
+    void auditUserLoginFailure(c, {
+      userId: user.id,
+      email: user.email,
+      name: user.name,
+      reason: 'tenant_inactive',
+      result: 'denied',
+      details: { method: 'cf_access_jwt_redirect' },
+    });
+    return loginErrorRedirect('tenant-inactive');
+  }
+
+  const trustsMfa = cfAccessTrustsMfa();
+  if (ENABLE_2FA && user.mfaEnabled && (user.mfaSecret || user.mfaMethod === 'sms') && !trustsMfa) {
+    // POC: MFA flow over redirect is deferred. For now, surface a clear
+    // error so the user falls back to password login (which CAN do MFA).
+    // Pre-PR follow-up: emit ?mfa=<tempToken>&mfaMethod=... and have the
+    // SPA hand off to MFAVerifyForm.
+    return loginErrorRedirect('mfa-required');
+  }
+
+  const mfaSatisfied = trustsMfa || !(ENABLE_2FA && user.mfaEnabled);
+
+  const tokens = await createTokenPair({
+    sub: user.id,
+    email: user.email,
+    roleId: context.roleId,
+    orgId: context.orgId,
+    partnerId: context.partnerId,
+    scope: context.scope,
+    mfa: mfaSatisfied,
+  });
+
+  await db.update(users).set({ lastLoginAt: new Date() }).where(eq(users.id, user.id));
+
+  createAuditLogAsync({
+    orgId: context.orgId ?? undefined,
+    actorId: user.id,
+    actorEmail: user.email,
+    action: 'user.login',
+    resourceType: 'user',
+    resourceId: user.id,
+    resourceName: user.name,
+    details: {
+      method: 'cf_access_jwt_redirect',
+      mfa: mfaSatisfied,
+      scope: context.scope,
+      cfAccessSub: claims.sub,
+    },
+    ipAddress: getClientIP(c),
+    userAgent: c.req.header('user-agent'),
+    result: 'success',
+  });
+
+  setRefreshTokenCookie(c, tokens.refreshToken);
+
+  // Redirect to `next` (sanitized) with a `cf-access-login=success` marker
+  // so the SPA's AuthOverlay knows to bootstrap from the refresh cookie
+  // (the SPA's normal post-login `setUser/setTokens` path didn't run since
+  // there's no JSON body to consume).
+  const next = safeNext(c.req.query('next'));
+  const url = new URL(next, 'http://placeholder');
+  url.searchParams.set('cf-access-login', 'success');
+  const location = url.pathname + url.search + url.hash;
+  return new Response(null, {
+    status: 302,
+    headers: { Location: location },
+  });
+});
+
+/**
+ * GET /api/v1/auth/cf-access-logout
+ *
+ * Top-level browser navigation entry-point for completing logout when CF
+ * Access trust is in front of Breeze. Without this, clicking "Sign out"
+ * only clears the Breeze session — CF Access still has an active session
+ * for the user, so the next visit re-enters Breeze via the SSO redirect
+ * loop with no user interaction.
+ *
+ * Flow:
+ *   1. Clear the Breeze refresh cookie.
+ *   2. 302 to CF Access logout endpoint with `returnTo` pointing back at
+ *      `/login?signedOut=1`. CF clears its own session and bounces the
+ *      user back. `LoginPage` honours the `signedOut=1` flag and shows
+ *      the password form instead of triggering the SSO redirect again.
+ *
+ * If CF Access trust is disabled, falls back to a plain 302 to /login
+ * after clearing the refresh cookie.
+ *
+ * Not authMiddleware-gated: a top-level GET navigation cannot present a
+ * Bearer token. The refresh cookie is enough to identify the session and
+ * the cookie is cleared regardless.
+ */
+cfAccessRedirectLoginRoutes.get('/cf-access-logout', (c) => {
+  clearRefreshTokenCookie(c);
+
+  if (!cfAccessTrustEnabled()) {
+    return new Response(null, { status: 302, headers: { Location: '/login?signedOut=1' } });
+  }
+
+  const teamDomain = cfAccessTeamDomain();
+  if (!teamDomain) {
+    return new Response(null, { status: 302, headers: { Location: '/login?signedOut=1' } });
+  }
+
+  // Reconstruct the public origin. The api sits behind a TLS-terminating
+  // proxy so `c.req.url` shows `http://`. Honour X-Forwarded-Proto when
+  // the proxy is trusted, otherwise default to `https://`.
+  const forwardedProto = c.req.header('x-forwarded-proto')?.split(',')[0]?.trim();
+  const trustProxy = (process.env.TRUST_PROXY_HEADERS ?? '').trim().toLowerCase();
+  const trustProxyOn = ['true', '1', 'yes', 'on'].includes(trustProxy);
+  const scheme = trustProxyOn && forwardedProto ? forwardedProto : 'https';
+  const host = c.req.header('host') ?? '';
+  const origin = host ? `${scheme}://${host}` : '';
+
+  // CF Access stores TWO `CF_Authorization` cookies per session:
+  // 1. Per-application cookie at the app domain (app.example.com)
+  // 2. Global session token at the team domain (your-team.cloudflareaccess.com)
+  // Each domain's `/cdn-cgi/access/logout` endpoint clears only its own
+  // cookie (per
+  // https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/).
+  // For a full logout we need to hit both. Chain them via returnTo:
+  //
+  //   app-logout (clears per-app cookie)
+  //   └─ returnTo=team-logout (clears global cookie)
+  //      └─ returnTo=/login?signedOut=1
+  //
+  // The `/cdn-cgi/access/*` paths are reserved by Cloudflare and
+  // intercepted at the edge, so they never hit the origin and aren't
+  // affected by the `/api/*` bypass app.
+  const finalReturn = `${origin}/login?signedOut=1`;
+  const teamLogout = `https://${teamDomain}/cdn-cgi/access/logout?returnTo=${encodeURIComponent(finalReturn)}`;
+  const appLogout = `${origin}/cdn-cgi/access/logout?returnTo=${encodeURIComponent(teamLogout)}`;
+  return new Response(null, { status: 302, headers: { Location: appLogout } });
+});

--- a/apps/api/src/routes/auth/index.ts
+++ b/apps/api/src/routes/auth/index.ts
@@ -8,6 +8,7 @@ import { inviteRoutes } from './invite';
 import { verifyEmailRoutes } from './verifyEmail';
 import { accountDeletionRoutes } from './accountDeletion';
 import { testApprovalRoutes } from './testApproval';
+import { cfAccessRedirectLoginRoutes } from './cfAccessRedirectLogin';
 
 export const authRoutes = new Hono();
 
@@ -23,4 +24,5 @@ authRoutes.route('/', inviteRoutes);
 authRoutes.route('/', verifyEmailRoutes);
 authRoutes.route('/', accountDeletionRoutes);
 authRoutes.route('/', testApprovalRoutes);
+authRoutes.route('/', cfAccessRedirectLoginRoutes);
 

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -51,6 +51,7 @@ import {
 } from './helpers';
 import { assertPasswordAuthAllowedBySso, SsoPasswordAuthRequiredError } from './ssoPolicy';
 import { readMobileDeviceId, carryForwardBinding } from '../../services/mobileDeviceBinding';
+import { cfAccessLoginMiddleware } from '../../middleware/cfAccessLogin';
 
 const { db, withSystemDbAccessContext } = dbModule;
 
@@ -171,8 +172,12 @@ async function recordAccountFailureAndMaybeNotify(
 
 export const loginRoutes = new Hono();
 
-// Login
-loginRoutes.post('/login', zValidator('json', loginSchema), async (c) => {
+// Login. cfAccessLoginMiddleware runs first; on a valid Cloudflare Access JWT
+// it short-circuits with a minted session. On any failure (trust disabled,
+// header absent, invalid JWT, JWKS down, user not found, etc.) it calls
+// next() and the password handler below validates the body normally.
+// See Discussion #702 and apps/api/src/middleware/cfAccessLogin.ts.
+loginRoutes.post('/login', cfAccessLoginMiddleware, zValidator('json', loginSchema), async (c) => {
   const { email, password } = c.req.valid('json');
   const ip = getClientIP(c);
   const rateLimitClient = getClientRateLimitKey(c);

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { cfAccessTrustEnabled } from '../config/env';
 
 export const configRoutes = new Hono();
 
@@ -11,6 +12,9 @@ configRoutes.get('/', (c) => {
     features: {
       billing: hasExternalServices,
       support: hasExternalServices,
+    },
+    cfAccessLogin: {
+      enabled: cfAccessTrustEnabled(),
     },
   });
 });

--- a/apps/api/src/services/cfAccessJwt.test.ts
+++ b/apps/api/src/services/cfAccessJwt.test.ts
@@ -1,0 +1,211 @@
+import { randomUUID } from 'crypto';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const jwksState = vi.hoisted(() => ({
+  importedPublicKey: undefined as unknown,
+}));
+
+vi.mock('jose', async () => {
+  const actual = await vi.importActual<typeof import('jose')>('jose');
+  return {
+    ...actual,
+    jwtVerify: vi.fn(actual.jwtVerify),
+    createRemoteJWKSet: vi.fn(
+      () => async () => jwksState.importedPublicKey as Awaited<ReturnType<typeof actual.importJWK>>
+    ),
+  };
+});
+
+import {
+  exportJWK,
+  generateKeyPair,
+  importJWK,
+  jwtVerify,
+  SignJWT,
+  type JWK,
+} from 'jose';
+import {
+  CfAccessInvalidTokenError,
+  CfAccessJwksUnavailableError,
+  _resetCfAccessJwksCacheForTests,
+  verifyCfAccessJwt,
+} from './cfAccessJwt';
+
+interface RsaKeypair {
+  privateJwk: JWK;
+  publicJwk: JWK;
+  kid: string;
+}
+
+async function generateRsaKeypair(): Promise<RsaKeypair> {
+  const { privateKey, publicKey } = await generateKeyPair('RS256', {
+    modulusLength: 2048,
+    extractable: true,
+  });
+  const kid = randomUUID();
+  return {
+    privateJwk: { ...(await exportJWK(privateKey)), kid, alg: 'RS256', use: 'sig' },
+    publicJwk: { ...(await exportJWK(publicKey)), kid, alg: 'RS256', use: 'sig' },
+    kid,
+  };
+}
+
+const teamDomain = 'your-team.cloudflareaccess.com';
+const issuer = `https://${teamDomain}`;
+const audience = 'aud-app-1234567890abcdef';
+const wrongAudience = 'aud-different-app';
+const wrongIssuer = 'https://attacker.cloudflareaccess.com';
+
+let keypair: RsaKeypair;
+
+async function mintCfAccessJwt(
+  claims: Record<string, unknown>,
+  opts: { issuer?: string; audience?: string; ttlSeconds?: number; signerKey?: JWK; signerKid?: string } = {}
+): Promise<string> {
+  const signerJwk = opts.signerKey ?? keypair.privateJwk;
+  const signerKid = opts.signerKid ?? keypair.kid;
+  const key = await importJWK(signerJwk, 'RS256');
+
+  const builder = new SignJWT(claims)
+    .setProtectedHeader({ alg: 'RS256', kid: signerKid })
+    .setIssuer(opts.issuer ?? issuer)
+    .setAudience(opts.audience ?? audience)
+    .setIssuedAt();
+
+  if (opts.ttlSeconds !== 0) {
+    builder.setExpirationTime(`${opts.ttlSeconds ?? 600}s`);
+  }
+
+  return builder.sign(key);
+}
+
+describe('verifyCfAccessJwt', () => {
+  beforeAll(async () => {
+    keypair = await generateRsaKeypair();
+    jwksState.importedPublicKey = await importJWK(keypair.publicJwk, 'RS256');
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetCfAccessJwksCacheForTests();
+  });
+
+  it('accepts a valid token and returns its claims', async () => {
+    const sub = 'cf-user-' + randomUUID();
+    const token = await mintCfAccessJwt({
+      email: 'user@example.com',
+      sub,
+      type: 'app',
+      identity_nonce: 'nonce-abc',
+      country: 'US',
+    });
+
+    const claims = await verifyCfAccessJwt(token, { teamDomain, audience });
+
+    expect(claims.email).toBe('user@example.com');
+    expect(claims.sub).toBe(sub);
+    expect(claims.aud).toBe(audience);
+    expect(claims.iss).toBe(issuer);
+    expect(claims.type).toBe('app');
+    expect(claims.identity_nonce).toBe('nonce-abc');
+    expect(claims.country).toBe('US');
+    expect(typeof claims.exp).toBe('number');
+    expect(typeof claims.iat).toBe('number');
+  });
+
+  it('rejects a token signed by a different key', async () => {
+    const attacker = await generateRsaKeypair();
+    const token = await mintCfAccessJwt(
+      { email: 'attacker@evil.com', sub: 'sub-x' },
+      { signerKey: attacker.privateJwk, signerKid: attacker.kid }
+    );
+
+    await expect(verifyCfAccessJwt(token, { teamDomain, audience })).rejects.toBeInstanceOf(
+      CfAccessInvalidTokenError
+    );
+  });
+
+  it('rejects a token with the wrong audience', async () => {
+    const token = await mintCfAccessJwt(
+      { email: 'user@example.com', sub: 'sub-1' },
+      { audience: wrongAudience }
+    );
+
+    await expect(verifyCfAccessJwt(token, { teamDomain, audience })).rejects.toBeInstanceOf(
+      CfAccessInvalidTokenError
+    );
+  });
+
+  it('rejects a token with the wrong issuer', async () => {
+    const token = await mintCfAccessJwt(
+      { email: 'user@example.com', sub: 'sub-1' },
+      { issuer: wrongIssuer }
+    );
+
+    await expect(verifyCfAccessJwt(token, { teamDomain, audience })).rejects.toBeInstanceOf(
+      CfAccessInvalidTokenError
+    );
+  });
+
+  it('rejects an expired token', async () => {
+    const token = await mintCfAccessJwt(
+      { email: 'user@example.com', sub: 'sub-1' },
+      { ttlSeconds: -60 }
+    );
+
+    await expect(verifyCfAccessJwt(token, { teamDomain, audience })).rejects.toBeInstanceOf(
+      CfAccessInvalidTokenError
+    );
+  });
+
+  it('rejects a token missing the email claim', async () => {
+    const token = await mintCfAccessJwt({ sub: 'sub-no-email' });
+
+    await expect(verifyCfAccessJwt(token, { teamDomain, audience })).rejects.toBeInstanceOf(
+      CfAccessInvalidTokenError
+    );
+  });
+
+  it('rejects a token using a disallowed algorithm', async () => {
+    const { generateKeyPair: gkp, exportJWK: exp, importJWK: imp } = await import('jose');
+    const { privateKey } = await gkp('EdDSA', { crv: 'Ed25519', extractable: true });
+    const otherKid = randomUUID();
+    const privateJwk = { ...(await exp(privateKey)), kid: otherKid, alg: 'EdDSA', use: 'sig' };
+    const key = await imp(privateJwk, 'EdDSA');
+
+    const token = await new SignJWT({ email: 'user@example.com', sub: 'sub-1' })
+      .setProtectedHeader({ alg: 'EdDSA', kid: otherKid })
+      .setIssuer(issuer)
+      .setAudience(audience)
+      .setIssuedAt()
+      .setExpirationTime('600s')
+      .sign(key);
+
+    await expect(verifyCfAccessJwt(token, { teamDomain, audience })).rejects.toBeInstanceOf(
+      CfAccessInvalidTokenError
+    );
+  });
+
+  it('surfaces a CfAccessJwksUnavailableError when JWKS fetch fails', async () => {
+    vi.mocked(jwtVerify).mockRejectedValueOnce(new TypeError('fetch failed'));
+
+    await expect(
+      verifyCfAccessJwt('any-token', { teamDomain, audience })
+    ).rejects.toBeInstanceOf(CfAccessJwksUnavailableError);
+  });
+
+  it('accepts when the configured audience is a one-element set containing the token aud', async () => {
+    const token = await mintCfAccessJwt({ email: 'user@example.com', sub: 'sub-set' });
+
+    const claims = await verifyCfAccessJwt(token, { teamDomain, audience: [audience] });
+    expect(claims.aud).toBe(audience);
+  });
+
+  it('rejects when the configured audience set does not include the token aud', async () => {
+    const token = await mintCfAccessJwt({ email: 'user@example.com', sub: 'sub-set' });
+
+    await expect(
+      verifyCfAccessJwt(token, { teamDomain, audience: ['some-other-aud'] })
+    ).rejects.toBeInstanceOf(CfAccessInvalidTokenError);
+  });
+});

--- a/apps/api/src/services/cfAccessJwt.ts
+++ b/apps/api/src/services/cfAccessJwt.ts
@@ -1,0 +1,176 @@
+import {
+  createRemoteJWKSet,
+  jwtVerify,
+  type JWTPayload,
+  type JWTVerifyResult,
+} from 'jose';
+
+/**
+ * Cloudflare Access JWT verification.
+ *
+ * When a self-hoster sits Breeze behind Cloudflare Access with the same IdP
+ * that Breeze itself is configured with, the user authenticates twice: once at
+ * the CF Access edge, once at the Breeze login form. This service lets a
+ * deployment opt into trusting the CF Access JWT and short-circuiting Breeze's
+ * password handler when a valid one is presented (see Discussion #702).
+ *
+ * Cloudflare Access JWT shape per
+ * https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/validating-json/:
+ *
+ *   {
+ *     "aud":      "<application-aud>",
+ *     "email":    "user@example.com",
+ *     "exp":      1234567890,
+ *     "iat":      1234567890,
+ *     "nbf":      1234567890,
+ *     "iss":      "https://<team>.cloudflareaccess.com",
+ *     "type":     "app" | "warp",
+ *     "identity_nonce": "...",
+ *     "sub":      "<cf-internal-user-id>",
+ *     "country":  "US"
+ *   }
+ *
+ * Notable absence: no MFA / auth-method claim. Whether the underlying CF
+ * Access policy required MFA is an operator-level assertion, not something
+ * the verifier can derive from the JWT itself. The caller decides via the
+ * `CF_ACCESS_TRUSTS_MFA` env flag whether to treat a valid JWT as
+ * MFA-satisfied for the minted Breeze session.
+ */
+
+export interface CfAccessJwtClaims {
+  email: string;
+  aud: string | string[];
+  iss: string;
+  sub: string;
+  exp: number;
+  iat: number;
+  nbf?: number;
+  type?: string;
+  identity_nonce?: string;
+  country?: string;
+}
+
+export interface CfAccessVerifyConfig {
+  /** Cloudflare team domain, e.g. `your-team.cloudflareaccess.com` (no scheme). */
+  teamDomain: string;
+  /** Allowed audiences. Currently a one-element set per Discussion #702 decision; plumbed as set for future multi-AUD. */
+  audience: string | readonly string[];
+}
+
+export class CfAccessJwksUnavailableError extends Error {
+  override readonly name = 'CfAccessJwksUnavailableError';
+  constructor(message: string, readonly cause?: unknown) {
+    super(message);
+  }
+}
+
+export class CfAccessInvalidTokenError extends Error {
+  override readonly name = 'CfAccessInvalidTokenError';
+  constructor(message: string, readonly code?: string) {
+    super(message);
+  }
+}
+
+const ALLOWED_ALGS = ['RS256'] as const;
+
+let cachedConfigKey = '';
+let cachedJwks: ReturnType<typeof createRemoteJWKSet> | null = null;
+
+function jwksUrl(teamDomain: string): URL {
+  return new URL(`https://${teamDomain}/cdn-cgi/access/certs`);
+}
+
+function getJwks(teamDomain: string): ReturnType<typeof createRemoteJWKSet> {
+  // Re-create the JWKS set when the team domain changes (e.g. tests, hot
+  // reconfig). In normal operation `teamDomain` is fixed by env and this
+  // function returns the same cached set for the lifetime of the process.
+  if (cachedConfigKey !== teamDomain || cachedJwks === null) {
+    cachedJwks = createRemoteJWKSet(jwksUrl(teamDomain), {
+      cacheMaxAge: 10 * 60 * 1000, // 10 minutes; jose refreshes on `kid` miss
+      cooldownDuration: 30 * 1000,
+    });
+    cachedConfigKey = teamDomain;
+  }
+  return cachedJwks;
+}
+
+/**
+ * Test-only: reset the JWKS cache so a subsequent call rebuilds it. Production
+ * callers never need this.
+ */
+export function _resetCfAccessJwksCacheForTests(): void {
+  cachedConfigKey = '';
+  cachedJwks = null;
+}
+
+/**
+ * Verify a Cloudflare Access JWT and return its claims.
+ *
+ * Throws `CfAccessInvalidTokenError` on signature failure, bad issuer/audience,
+ * expired/not-yet-valid token, or any other token-shape problem (jose `ERR_*`
+ * codes). Throws `CfAccessJwksUnavailableError` on JWKS fetch failures
+ * (network errors talking to `/cdn-cgi/access/certs`). The caller decides
+ * what to do with each. For the login short-circuit, both cases fall through
+ * to the password handler, but they're surfaced as distinct types so other
+ * callers (e.g. a future strictly-CF-Access-only deploy mode) can fail closed
+ * if they want.
+ */
+export async function verifyCfAccessJwt(
+  token: string,
+  config: CfAccessVerifyConfig,
+): Promise<CfAccessJwtClaims> {
+  const expectedIssuer = `https://${config.teamDomain}`;
+  const audience: string | string[] = typeof config.audience === 'string'
+    ? config.audience
+    : [...config.audience];
+
+  let result: JWTVerifyResult;
+  try {
+    result = await jwtVerify(token, getJwks(config.teamDomain), {
+      issuer: expectedIssuer,
+      audience,
+      algorithms: [...ALLOWED_ALGS],
+      requiredClaims: ['exp', 'iat', 'email', 'aud', 'iss', 'sub'],
+    });
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    const isJoseError = typeof code === 'string' && code.startsWith('ERR_');
+    if (!isJoseError) {
+      // Anything without a jose ERR_* code is a network/IO problem talking
+      // to JWKS. Distinct error type so the caller can fail-open on
+      // availability while still failing-closed on signature/claim
+      // validity (per Discussion #702 maintainer decision).
+      throw new CfAccessJwksUnavailableError(
+        `Failed to verify Cloudflare Access JWT: ${(err as Error).message ?? 'unknown error'}`,
+        err,
+      );
+    }
+    throw new CfAccessInvalidTokenError(
+      `Cloudflare Access JWT rejected: ${code}`,
+      code,
+    );
+  }
+
+  const payload = result.payload as JWTPayload;
+  const email = typeof payload.email === 'string' ? payload.email : null;
+  if (!email) {
+    throw new CfAccessInvalidTokenError(
+      'Cloudflare Access JWT missing email claim',
+      'ERR_JWT_CLAIM_VALIDATION_FAILED',
+    );
+  }
+
+  return {
+    email,
+    aud: payload.aud as string | string[],
+    iss: payload.iss as string,
+    sub: payload.sub as string,
+    exp: payload.exp as number,
+    iat: payload.iat as number,
+    nbf: typeof payload.nbf === 'number' ? payload.nbf : undefined,
+    type: typeof payload.type === 'string' ? payload.type : undefined,
+    identity_nonce:
+      typeof payload.identity_nonce === 'string' ? payload.identity_nonce : undefined,
+    country: typeof payload.country === 'string' ? payload.country : undefined,
+  };
+}

--- a/apps/docs/src/content/docs/deploy/cloudflare-access-trust.mdx
+++ b/apps/docs/src/content/docs/deploy/cloudflare-access-trust.mdx
@@ -1,0 +1,69 @@
+---
+title: Cloudflare Access JWT trust
+description: Skip the Breeze login form when a deployment sits behind Cloudflare Access using the same identity provider.
+sidebar:
+  order: 9
+  label: Cloudflare Access trust
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+When you put Breeze behind Cloudflare Access (or any Zero Trust gateway that mints CF Access JWTs) and use the same identity provider that you've configured users for in Breeze, the user ends up authenticating twice: once at the CF Access edge, once at the Breeze login form. Enabling Cloudflare Access JWT trust lets a valid `Cf-Access-Jwt-Assertion` header short-circuit `POST /api/v1/auth/login` and mint a Breeze session directly.
+
+This is an opt-in, deployment-wide flag. It does not affect any deployment that does not set `CF_ACCESS_TRUST_ENABLED=true`.
+
+<Aside type="caution">
+  Only turn this on if you actually have Cloudflare Access in front of `/api/v1/auth/login`. If the path is reachable without going through Access (for example: agent connections, installer short-links, or any bypass rule), an attacker could submit a self-signed JWT and bypass the password check. The verifier rejects anything that isn't signed by your team's JWKS, but the safer posture is to only enable trust when the path is guaranteed to be Access-protected.
+</Aside>
+
+## How it works
+
+1. The browser hits the Breeze SPA. Cloudflare Access authenticates the user against your IdP and attaches a signed `CF_Authorization` cookie plus the `Cf-Access-Jwt-Assertion` request header.
+2. The SPA POSTs `/api/v1/auth/login`. The CF Access middleware runs first.
+3. The middleware verifies the JWT using the team's JWKS at `https://<team-domain>/cdn-cgi/access/certs`. It checks:
+   - signature (RS256 only)
+   - issuer = `https://<team-domain>`
+   - audience = the configured AUD tag for your application
+   - `exp`, `iat`, `email`, `aud`, `iss`, `sub` claims all present
+4. On a verified JWT, it looks up the user by `email` claim, confirms the account is `active`, resolves the user's partner/org context, mints a token pair, and returns the same shape `POST /login` returns on a successful password login.
+5. On any failure — flag off, header absent, invalid signature, expired token, wrong audience, JWKS unreachable, user not in Breeze, user inactive — it falls through to the existing password handler. The browser then sees the normal login form.
+
+## Failure semantics
+
+| Failure | Behaviour | Reason |
+|---|---|---|
+| `CF_ACCESS_TRUST_ENABLED=false` or unset | No JWT path; password handler runs as before | Default off |
+| Header absent | Fall through to password | Not every browser session has a CF Access JWT |
+| Invalid signature, wrong issuer/aud, expired, missing claim | Fall through; logged as `[cf-access-login] rejected JWT` with the jose error code | Fail-closed on trust: we never mint a session from an unverified JWT |
+| JWKS fetch / network failure | Fall through; logged as `[cf-access-login] JWKS unavailable...` | Fail-open on availability: a transient CF outage shouldn't wedge `/login` |
+| User from JWT email not present in Breeze | Fall through | Password handler will 401 with the same generic error, no email enumeration |
+| User present but `status != 'active'` | Fall through; failure audited as `account_inactive` with `method: cf_access_jwt` | Same denial path as password login |
+
+## MFA
+
+The Cloudflare Access JWT does not carry an MFA claim — it tells you the user satisfied your CF Access policy, but not how. Whether your CF Access policy required step-up (hardware key, WARP attestation, etc.) is an operator-level assertion. `CF_ACCESS_TRUSTS_MFA` is the knob:
+
+- `CF_ACCESS_TRUSTS_MFA=false` (default) — even on a valid JWT, if the matched Breeze user has MFA enrolled, the middleware issues a `tempToken` and the SPA's normal MFA challenge runs. The user does not have to re-enter their password, but they do enter their TOTP code.
+- `CF_ACCESS_TRUSTS_MFA=true` — the minted Breeze session is marked as MFA-satisfied. Only turn this on if your CF Access policy actually requires step-up. The setting is honoured deployment-wide; it does not vary per partner or per user.
+
+## Configuration
+
+| Variable | Required when trust is on | Description |
+|---|---|---|
+| `CF_ACCESS_TRUST_ENABLED` | — | `true` to enable. Boolean (true/false/1/0/yes/no/on/off). Default off. |
+| `CF_ACCESS_TEAM_DOMAIN` | Yes | Bare hostname of your Cloudflare team domain, e.g. `example.cloudflareaccess.com`. No `https://` scheme. |
+| `CF_ACCESS_AUD` | Yes | The AUD tag for the Cloudflare Access application that protects Breeze. Get it from the Cloudflare Zero Trust dashboard → Access → Applications → your app → AUD. |
+| `CF_ACCESS_TRUSTS_MFA` | — | Boolean. Default false. See **MFA** above. |
+
+The config validator refuses to boot if `CF_ACCESS_TRUST_ENABLED=true` but `CF_ACCESS_TEAM_DOMAIN` or `CF_ACCESS_AUD` is empty, or if the team domain looks like a URL instead of a hostname.
+
+## Recommended Cloudflare Access setup
+
+- Application path: cover the SPA root and `/api/v1/auth/login` only. Leave bypass rules on `/api/*` agent paths, `/health`, `/installers/*`, and any installer short-links (the agent fleet does not have a CF Access session).
+- Identity provider: pick the same IdP whose `email` claim is the same one your Breeze users are provisioned with. If a Breeze user's email is `alice@acme.com` and your IdP issues the JWT with `email=alice@acme.com`, you're set.
+- Session duration: anything you like. Breeze mints its own refresh token independently of the CF Access cookie.
+- Application AUD: copy from the dashboard once the application is created. This is stable for the life of the application.
+
+## Disabling
+
+Set `CF_ACCESS_TRUST_ENABLED=false` (or remove the variable) and restart `breeze-api`. The middleware short-circuits to `next()` before reading any other env var, so disabling is instant.

--- a/apps/docs/src/content/docs/deploy/environment.mdx
+++ b/apps/docs/src/content/docs/deploy/environment.mdx
@@ -231,6 +231,15 @@ Two rate-limit tiers protect the API. The generic per-user limit covers logged-i
   mTLS is fully optional. When these variables are unset, Breeze operates normally without mutual TLS.
 </Aside>
 
+## Cloudflare Access JWT trust
+
+| Variable | Default | Description |
+|---|---|---|
+| `CF_ACCESS_TRUST_ENABLED` | `false` | Set `true` to short-circuit `POST /auth/login` when a valid `Cf-Access-Jwt-Assertion` header is present. Off by default. See [Cloudflare Access trust](/deploy/cloudflare-access-trust/). |
+| `CF_ACCESS_TEAM_DOMAIN` | — | Required when trust is enabled. Bare hostname of your Cloudflare team domain, e.g. `example.cloudflareaccess.com`. No scheme. |
+| `CF_ACCESS_AUD` | — | Required when trust is enabled. AUD tag for the Cloudflare Access application protecting Breeze. |
+| `CF_ACCESS_TRUSTS_MFA` | `false` | Treat a valid CF Access JWT as MFA-satisfied for the minted Breeze session. Only enable if your CF Access policy actually requires step-up MFA. |
+
 ## Cloud-to-Cloud Backup (M365)
 
 | Variable | Default | Description |

--- a/apps/web/src/components/auth/AuthOverlay.tsx
+++ b/apps/web/src/components/auth/AuthOverlay.tsx
@@ -1,13 +1,30 @@
 import { useEffect, useState } from 'react';
-import { restoreAccessTokenFromCookie, useAuthStore } from '../../stores/auth';
+import { bootstrapFromCfAccessRedirect, restoreAccessTokenFromCookie, useAuthStore } from '../../stores/auth';
 import { Loader2 } from 'lucide-react';
 import { navigateTo } from '../../lib/navigation';
+
+const CF_ACCESS_LOGIN_PARAM = 'cf-access-login';
+
+function consumeCfAccessLoginParam(): boolean {
+  if (typeof window === 'undefined') return false;
+  const params = new URLSearchParams(window.location.search);
+  if (params.get(CF_ACCESS_LOGIN_PARAM) !== 'success') return false;
+  params.delete(CF_ACCESS_LOGIN_PARAM);
+  const cleanSearch = params.toString();
+  const cleanUrl =
+    window.location.pathname +
+    (cleanSearch ? `?${cleanSearch}` : '') +
+    window.location.hash;
+  window.history.replaceState({}, '', cleanUrl);
+  return true;
+}
 
 export default function AuthOverlay() {
   const { isAuthenticated, isLoading, tokens } = useAuthStore();
   const [isChecking, setIsChecking] = useState(true);
   const [isRecovering, setIsRecovering] = useState(false);
   const [recoverAttempted, setRecoverAttempted] = useState(false);
+  const [cfBootstrapAttempted, setCfBootstrapAttempted] = useState(false);
   const [fadeState, setFadeState] = useState<'visible' | 'fading' | 'hidden'>('visible');
 
   useEffect(() => {
@@ -42,6 +59,27 @@ export default function AuthOverlay() {
       return;
     }
 
+    // CF Access redirect bootstrap: the server's GET /api/v1/auth/cf-access-login
+    // endpoint sets a refresh cookie and redirects here with ?cf-access-login=success.
+    // The SPA has no in-memory session yet, so trade the cookie for tokens and fetch
+    // the user before falling through to the normal "no session, redirect to /login"
+    // path. This runs once per overlay mount.
+    if (!isAuthenticated && !cfBootstrapAttempted) {
+      const shouldBootstrap = consumeCfAccessLoginParam();
+      if (shouldBootstrap) {
+        setCfBootstrapAttempted(true);
+        setIsRecovering(true);
+        void bootstrapFromCfAccessRedirect().then((ok) => {
+          if (cancelled) return;
+          setIsRecovering(false);
+          if (!ok) {
+            void navigateTo('/login?error=cf-access', { replace: true });
+          }
+        });
+        return () => { cancelled = true; };
+      }
+    }
+
     // Slow path: authenticated but no token (e.g. first load after login on another tab)
     if (isAuthenticated && !tokens?.accessToken && !recoverAttempted) {
       setRecoverAttempted(true);
@@ -68,7 +106,7 @@ export default function AuthOverlay() {
     }
 
     return () => { cancelled = true; };
-  }, [isAuthenticated, isLoading, isChecking, tokens, recoverAttempted, isRecovering]);
+  }, [isAuthenticated, isLoading, isChecking, tokens, recoverAttempted, isRecovering, cfBootstrapAttempted]);
 
   // Authenticated with token — fade out then unmount
   const shouldHide = !isChecking && !isLoading && isAuthenticated && !!tokens?.accessToken;

--- a/apps/web/src/components/auth/LoginPage.test.tsx
+++ b/apps/web/src/components/auth/LoginPage.test.tsx
@@ -17,6 +17,22 @@ vi.mock('../../lib/navigation', () => ({
   navigateTo: vi.fn(),
 }));
 
+// LoginPage now fetches /api/v1/config at mount to decide whether to redirect
+// the browser to the Cloudflare Access login endpoint. The default mock here
+// answers "feature disabled" so the existing happy-path tests render the
+// password form unchanged.
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      new Response(JSON.stringify({ cfAccessLogin: { enabled: false } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+  );
+});
+
 import LoginPage from './LoginPage';
 import { apiLogin, apiVerifyMFA } from '../../stores/auth';
 import { navigateTo } from '../../lib/navigation';
@@ -29,6 +45,9 @@ const baseLoginSuccess = {
 };
 
 async function fillAndSubmit(email = 'jane@example.com', password = 'Sup3rSecure!') {
+  // The config-check effect resolves on a microtask after mount; wait for the
+  // form to appear before driving it.
+  await waitFor(() => screen.getByLabelText(/email/i));
   fireEvent.change(screen.getByLabelText(/email/i), { target: { value: email } });
   fireEvent.change(screen.getByLabelText(/password/i), { target: { value: password } });
   fireEvent.click(screen.getByRole('button', { name: /sign in/i }));

--- a/apps/web/src/components/auth/LoginPage.tsx
+++ b/apps/web/src/components/auth/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import LoginForm from './LoginForm';
 import MFAVerifyForm from './MFAVerifyForm';
 import McpUrlCard from '../shared/McpUrlCard';
@@ -12,6 +12,34 @@ function getRegistrationDisabledNotice(): string | undefined {
   const params = new URLSearchParams(window.location.search);
   if (params.get('reason') === 'registration-disabled') {
     return 'New registrations are currently disabled. Please contact your administrator.';
+  }
+}
+
+function shouldSkipCfAccessRedirect(): boolean {
+  if (typeof window === 'undefined') return true;
+  const params = new URLSearchParams(window.location.search);
+  // Don't loop:
+  // - error=cf-access  → we just bounced off a failed JWT verification
+  // - cf-access-login=success → we just succeeded; AuthOverlay handles the rest
+  // - signedOut=1 → the user just hit Sign out; respect that intent
+  if (params.get('error') === 'cf-access') return true;
+  if (params.get('cf-access-login') === 'success') return true;
+  if (params.get('signedOut') === '1') return true;
+  return false;
+}
+
+async function checkCfAccessLoginEnabled(): Promise<boolean> {
+  try {
+    const apiHost = import.meta.env.PUBLIC_API_URL || '';
+    const res = await fetch(`${apiHost}/api/v1/config`, {
+      method: 'GET',
+      credentials: 'include',
+    });
+    if (!res.ok) return false;
+    const body = (await res.json()) as { cfAccessLogin?: { enabled?: boolean } };
+    return !!body.cfAccessLogin?.enabled;
+  } catch {
+    return false;
   }
 }
 
@@ -30,8 +58,29 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
   const [phoneLast4, setPhoneLast4] = useState<string>();
   const [smsSending, setSmsSending] = useState(false);
   const [smsSent, setSmsSent] = useState(false);
+  const [cfAccessRedirectChecked, setCfAccessRedirectChecked] = useState(shouldSkipCfAccessRedirect());
 
   const login = useAuthStore((state) => state.login);
+
+  // CF Access trust mode: if the deployment has it on AND we're not already
+  // in the post-redirect bounce (which AuthOverlay handles), top-level
+  // navigate to the redirect endpoint. The browser's redirect-following
+  // behaviour resolves CF Access's per-app cookie handshake silently when
+  // the user has an active session at the root app with the same IdP.
+  useEffect(() => {
+    if (cfAccessRedirectChecked) return;
+    let cancelled = false;
+    void checkCfAccessLoginEnabled().then((enabled) => {
+      if (cancelled) return;
+      if (enabled) {
+        const nextParam = safeNext === '/' ? '' : `?next=${encodeURIComponent(safeNext)}`;
+        window.location.assign(`/api/v1/auth/cf-access-login${nextParam}`);
+        return;
+      }
+      setCfAccessRedirectChecked(true);
+    });
+    return () => { cancelled = true; };
+  }, [cfAccessRedirectChecked, safeNext]);
 
   const handleLogin = async (values: { email: string; password: string }) => {
     setLoading(true);
@@ -107,6 +156,12 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
 
     setSmsSending(false);
   };
+
+  // While the CF Access config check is in flight, render an empty placeholder
+  // so the user doesn't see the password form flash before a redirect kicks in.
+  if (!cfAccessRedirectChecked) {
+    return <div data-testid="login-cf-access-check" className="min-h-[160px]" />;
+  }
 
   if (mfaRequired) {
     return (

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -156,6 +156,25 @@ export default function Header() {
 
   const handleSignOut = async () => {
     setIsLoggingOut(true);
+
+    // When CF Access trust is in front of Breeze, a normal SPA-side logout
+    // only clears the Breeze session — CF Access still holds a session for
+    // the user, so the SSO redirect on the next /login visit silently
+    // re-enters them. Route through the server-side cf-access-logout
+    // endpoint, which clears the Breeze refresh cookie and bounces the
+    // browser through CF Access's own logout endpoint with returnTo set
+    // to /login?signedOut=1.
+    const cfAccessEnabled = useFeaturesStore.getState().cfAccessLogin.enabled;
+    if (cfAccessEnabled) {
+      // Drop in-memory state first so any racing component doesn't read
+      // stale tokens before the navigation lands.
+      try { useAuthStore.getState().logout(); } catch { /* zustand always present */ }
+      try { localStorage.removeItem('breeze-auth'); } catch { /* localStorage may be unavailable */ }
+      try { localStorage.removeItem('breeze-org'); } catch { /* localStorage may be unavailable */ }
+      window.location.assign('/api/v1/auth/cf-access-logout');
+      return;
+    }
+
     try {
       await apiLogout();
       await navigateTo('/login', { replace: true });

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -291,6 +291,54 @@ export async function restoreAccessTokenFromCookie(): Promise<boolean> {
   }
 }
 
+/**
+ * Bootstraps the auth store after a Cloudflare Access redirect login.
+ *
+ * The server's GET /api/v1/auth/cf-access-login endpoint mints a Breeze
+ * session and sets the HttpOnly refresh cookie, but there's no JSON body
+ * for the SPA to consume since it's a 302 redirect. This helper completes
+ * the handshake:
+ *
+ *   1. Trade the refresh cookie for a fresh access token (`/auth/refresh`)
+ *   2. Fetch the user record (`/users/me`) with that token
+ *   3. Populate the store via `login(user, tokens)`
+ *
+ * Returns true if the store was populated; false if any step failed (the
+ * caller should fall back to the regular login form).
+ */
+export async function bootstrapFromCfAccessRedirect(): Promise<boolean> {
+  const tokens = await requestTokenRefreshShared();
+  if (!tokens?.accessToken) return false;
+
+  let meResponse: Response;
+  try {
+    meResponse = await fetch(buildApiUrl('/users/me'), {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${tokens.accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+    });
+  } catch {
+    return false;
+  }
+
+  if (!meResponse.ok) return false;
+
+  const user = (await meResponse.json()) as User | null;
+  if (!user || !user.id) return false;
+
+  useAuthStore.getState().login(user, tokens);
+
+  // Mirror what LoginPage does after a successful password login: pull
+  // /users/me into the store and apply the theme to the DOM. Without
+  // this, dark mode reverts to default and the onboarding tour reads
+  // an empty preferences object on first render.
+  await fetchAndApplyPreferences();
+  return true;
+}
+
 export async function fetchWithAuth(rawUrl: string, options: RequestInit = {}): Promise<Response> {
   // Auto-inject orgId from the org store so partner/system users always scope API calls
   let url = rawUrl;

--- a/apps/web/src/stores/featuresStore.ts
+++ b/apps/web/src/stores/featuresStore.ts
@@ -6,16 +6,23 @@ export interface Features {
   support: boolean;
 }
 
+export interface CfAccessLoginConfig {
+  enabled: boolean;
+}
+
 interface FeaturesState {
   features: Features;
+  cfAccessLogin: CfAccessLoginConfig;
   loaded: boolean;
   load: () => Promise<void>;
 }
 
-const DEFAULT: Features = { billing: false, support: false };
+const DEFAULT_FEATURES: Features = { billing: false, support: false };
+const DEFAULT_CF_ACCESS: CfAccessLoginConfig = { enabled: false };
 
 export const useFeaturesStore = create<FeaturesState>()((set, get) => ({
-  features: DEFAULT,
+  features: DEFAULT_FEATURES,
+  cfAccessLogin: DEFAULT_CF_ACCESS,
   loaded: false,
   load: async () => {
     if (get().loaded) return;
@@ -26,11 +33,17 @@ export const useFeaturesStore = create<FeaturesState>()((set, get) => ({
         set({ loaded: true });
         return;
       }
-      const data = (await res.json()) as { features?: Partial<Features> };
+      const data = (await res.json()) as {
+        features?: Partial<Features>;
+        cfAccessLogin?: Partial<CfAccessLoginConfig>;
+      };
       set({
         features: {
           billing: !!data.features?.billing,
           support: !!data.features?.support,
+        },
+        cfAccessLogin: {
+          enabled: !!data.cfAccessLogin?.enabled,
         },
         loaded: true,
       });


### PR DESCRIPTION
## What

Optional support for self-hosters who put Breeze behind **Cloudflare Access** (Zero Trust). Today such a deployment forces a double login: Cloudflare Access auth, then the Breeze login form. This adds two opt-in, off-by-default capabilities so the CF Access identity can satisfy Breeze:

1. **Trust a verified CF Access JWT on `/auth/login`** — when enabled, a request carrying a valid `Cf-Access-Jwt-Assertion` (verified against the team's JWKS, with AUD + issuer checks) logs the matching Breeze user in without re-prompting.
2. **Browser SSO redirect-login flow** — a redirect endpoint + a small web bootstrap (`bootstrapFromCfAccessRedirect`) that mints a Breeze session from the CF Access identity and a logout chain that breaks the SSO redirect loop on sign-out.

Addresses Discussion #702.

## Design / safety

- **Off by default.** Requires `CF_ACCESS_TRUST_ENABLED=true` **and** both `CF_ACCESS_TEAM_DOMAIN` and `CF_ACCESS_AUD` set; boot validation enforces this.
- JWT verification is fixed-host against `https://<team-domain>/cdn-cgi/access/certs` (no SSRF surface), checks signature, `aud`, and issuer. An attacker-issued token from a different team domain is rejected (covered by tests).
- `CF_ACCESS_TRUSTS_MFA` is a separate explicit opt-in: it marks the resulting session MFA-satisfied **by operator assertion** (i.e. the operator is asserting CF Access enforces MFA upstream). Default off.
- No change to the default login path when the flags are unset.

## Files

- New: `services/cfAccessJwt.ts`, `middleware/cfAccessLogin.ts`, `routes/auth/cfAccessRedirectLogin.ts` (+ tests).
- Wired: `routes/auth/login.ts`, `routes/auth/index.ts`, `routes/config.ts`, `config/env.ts`, `config/validate.ts`.
- Web: `stores/auth.ts` (`bootstrapFromCfAccessRedirect`), `stores/featuresStore.ts`, `components/auth/LoginPage.tsx`, `components/auth/AuthOverlay.tsx`.
- Docs: `deploy/cloudflare-access-trust.mdx`.

## Tests

- API `tsc` clean; full API vitest **5827 passed / 0 failed** (32 new tests across the 3 CF files cover happy path, wrong issuer, wrong aud, missing config, MFA assertion).
- Web `astro check` clean; web vitest green.
- All example domains/emails in code and tests are generic placeholders.
