### PR TITLE
feat(users): avatar file upload (POST/GET/DELETE /users/me/avatar)

### DIFF
--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,5 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
 import { Hono } from 'hono';
+import { mkdtempSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+// Set the avatar storage dir to a per-test-run tmp path BEFORE importing the
+// service (the service reads process.env.AVATAR_STORAGE_PATH at module load).
+const TMP_AVATAR_DIR = mkdtempSync(join(tmpdir(), 'breeze-avatar-test-'));
+process.env.AVATAR_STORAGE_PATH = TMP_AVATAR_DIR;
+
 import { userRoutes } from './users';
 
 const {
@@ -184,6 +193,12 @@ import { terminateUserRemoteSessions } from '../services/remoteSessionTeardown';
 
 describe('user routes', () => {
   let app: Hono;
+
+  afterAll(() => {
+    if (existsSync(TMP_AVATAR_DIR)) {
+      rmSync(TMP_AVATAR_DIR, { recursive: true, force: true });
+    }
+  });
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -463,15 +478,6 @@ describe('user routes', () => {
       } as any);
     });
 
-    it('rejects avatarUrl with javascript: scheme', async () => {
-      const res = await app.request('/users/me', {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
-        body: JSON.stringify({ avatarUrl: 'javascript:alert(1)' })
-      });
-      expect(res.status).toBe(400);
-    });
-
     it('rejects invalid email format', async () => {
       const res = await app.request('/users/me', {
         method: 'PATCH',
@@ -587,12 +593,13 @@ describe('user routes', () => {
       );
     });
 
-    it('audits a partner-scope self avatar change (non-email, no step-up)', async () => {
+    it('audits a partner-scope self profile change (non-email, no step-up)', async () => {
       // Previously this test PATCHed { email } with no password. The email-change
       // step-up now requires currentPassword, so the email-change audit behavior
       // moved into the dedicated "email change step-up" describe below. This test
       // preserves the original INTENT — partner-scope self-changes are audited as
-      // user.profile.update — by exercising a non-email field instead.
+      // user.profile.update — by exercising a non-email field (name). (avatarUrl
+      // is no longer a PATCH /me field; avatars are managed via /users/me/avatar.)
       vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
         c.set('auth', {
           scope: 'partner',
@@ -606,8 +613,8 @@ describe('user routes', () => {
       mockProfileUpdateReturning({
         id: 'user-123',
         email: 'test@example.com',
-        name: 'Test User',
-        avatarUrl: 'https://cdn.example.com/avatar.png',
+        name: 'Renamed User',
+        avatarUrl: null,
         status: 'active',
         mfaEnabled: false,
         preferences: null
@@ -616,7 +623,7 @@ describe('user routes', () => {
       const res = await app.request('/users/me', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
-        body: JSON.stringify({ avatarUrl: 'https://cdn.example.com/avatar.png' })
+        body: JSON.stringify({ name: 'Renamed User' })
       });
 
       expect(res.status).toBe(200);
@@ -627,7 +634,7 @@ describe('user routes', () => {
         expect.objectContaining({
           orgId: 'resolved-org-2',
           action: 'user.profile.update',
-          details: expect.objectContaining({ changedFields: ['avatarUrl'] })
+          details: expect.objectContaining({ changedFields: ['name'] })
         })
       );
     });
@@ -1427,6 +1434,156 @@ describe('user routes', () => {
 
       expect(res.status).toBe(200);
       expect(teardownMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('avatar endpoints', () => {
+    const ME_ID = 'user-123';
+
+    // Minimal valid PNG bytes (1x1 transparent PNG)
+    const PNG_BYTES = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+      0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+      0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+      0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+      0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41,
+      0x54, 0x78, 0x9c, 0x62, 0x00, 0x01, 0x00, 0x00,
+      0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00,
+      0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+      0x42, 0x60, 0x82,
+    ]);
+
+    // JPEG SOI + minimal junk (FF D8 FF E0 ...). Not a real image but the
+    // magic-byte check only inspects the first three bytes.
+    const JPEG_BYTES = Buffer.concat([
+      Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+      Buffer.alloc(64, 0),
+    ]);
+
+    // WebP RIFF header (12 bytes is enough for the sniff function).
+    const WEBP_BYTES = Buffer.concat([
+      Buffer.from([
+        0x52, 0x49, 0x46, 0x46, // RIFF
+        0x10, 0x00, 0x00, 0x00, // size
+        0x57, 0x45, 0x42, 0x50, // WEBP
+      ]),
+      Buffer.alloc(32, 0),
+    ]);
+
+    // SVG with a small XML preamble
+    const SVG_BYTES = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>', 'utf-8');
+
+    function makeUpdateMock(returning: unknown[]) {
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue(returning)
+          })
+        })
+      } as any);
+    }
+
+    function makeMultipart(field: string, bytes: Buffer, mime: string, filename: string): { body: BodyInit; headers: HeadersInit } {
+      const formData = new FormData();
+      // Buffer's polymorphic ArrayBufferLike confuses the Blob constructor type;
+      // copy into a fresh Uint8Array (whose buffer is a plain ArrayBuffer).
+      const view = new Uint8Array(bytes.byteLength);
+      view.set(bytes);
+      const blob = new Blob([view], { type: mime });
+      formData.append(field, blob, filename);
+      return {
+        body: formData,
+        // Browser/undici set Content-Type with boundary automatically when we
+        // pass a FormData to Request, so do NOT supply Content-Type manually.
+        headers: {}
+      };
+    }
+
+    describe('POST /users/me/avatar', () => {
+      it('accepts a PNG upload and writes /api/v1/users/<id>/avatar to users.avatar_url', async () => {
+        makeUpdateMock([{ id: ME_ID, avatarUrl: `/api/v1/users/${ME_ID}/avatar`, updatedAt: new Date() }]);
+
+        const { body, headers } = makeMultipart('file', PNG_BYTES, 'image/png', 'a.png');
+        const res = await app.request('/users/me/avatar', { method: 'POST', body, headers });
+
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.avatarUrl).toBe(`/api/v1/users/${ME_ID}/avatar`);
+        expect(data.mime).toBe('image/png');
+        expect(data.size).toBe(PNG_BYTES.length);
+      });
+
+      it('accepts a JPEG upload', async () => {
+        makeUpdateMock([{ id: ME_ID, avatarUrl: `/api/v1/users/${ME_ID}/avatar`, updatedAt: new Date() }]);
+        const { body, headers } = makeMultipart('file', JPEG_BYTES, 'image/jpeg', 'a.jpg');
+        const res = await app.request('/users/me/avatar', { method: 'POST', body, headers });
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.mime).toBe('image/jpeg');
+      });
+
+      it('accepts a WebP upload', async () => {
+        makeUpdateMock([{ id: ME_ID, avatarUrl: `/api/v1/users/${ME_ID}/avatar`, updatedAt: new Date() }]);
+        const { body, headers } = makeMultipart('file', WEBP_BYTES, 'image/webp', 'a.webp');
+        const res = await app.request('/users/me/avatar', { method: 'POST', body, headers });
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.mime).toBe('image/webp');
+      });
+
+      it('rejects SVG (not in MIME allowlist and fails magic-byte sniff)', async () => {
+        const { body, headers } = makeMultipart('file', SVG_BYTES, 'image/svg+xml', 'a.svg');
+        const res = await app.request('/users/me/avatar', { method: 'POST', body, headers });
+        expect(res.status).toBe(415);
+      });
+
+      it('rejects a file claiming image/png but containing JPEG bytes', async () => {
+        const { body, headers } = makeMultipart('file', JPEG_BYTES, 'image/png', 'fake.png');
+        const res = await app.request('/users/me/avatar', { method: 'POST', body, headers });
+        // image/png claimed but JPEG magic → 400 content-type mismatch
+        expect(res.status).toBe(400);
+      });
+
+      it('rejects empty file', async () => {
+        const { body, headers } = makeMultipart('file', Buffer.alloc(0), 'image/png', 'a.png');
+        const res = await app.request('/users/me/avatar', { method: 'POST', body, headers });
+        expect(res.status).toBe(400);
+      });
+
+      it('rejects multipart without a file field', async () => {
+        const fd = new FormData();
+        fd.append('notfile', new Blob([PNG_BYTES], { type: 'image/png' }), 'a.png');
+        const res = await app.request('/users/me/avatar', { method: 'POST', body: fd });
+        expect(res.status).toBe(400);
+      });
+    });
+
+    describe('DELETE /users/me/avatar', () => {
+      it('clears avatar_url and returns avatarUrl: null', async () => {
+        makeUpdateMock([{ id: ME_ID, avatarUrl: null }]);
+        const res = await app.request('/users/me/avatar', { method: 'DELETE' });
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.avatarUrl).toBeNull();
+      });
+    });
+
+    describe('POST then GET roundtrip', () => {
+      it('uploads a PNG and serves it back from GET /users/:id/avatar with image/png + cache headers', async () => {
+        makeUpdateMock([{ id: ME_ID, avatarUrl: `/api/v1/users/${ME_ID}/avatar`, updatedAt: new Date() }]);
+
+        const { body, headers } = makeMultipart('file', PNG_BYTES, 'image/png', 'a.png');
+        const postRes = await app.request('/users/me/avatar', { method: 'POST', body, headers });
+        expect(postRes.status).toBe(200);
+
+        const getRes = await app.request(`/users/${ME_ID}/avatar`, { method: 'GET' });
+        expect(getRes.status).toBe(200);
+        expect(getRes.headers.get('content-type')).toBe('image/png');
+        expect(getRes.headers.get('cache-control')).toBe('private, max-age=300');
+        expect(getRes.headers.get('etag')).toMatch(/^W\//);
+        const body2 = Buffer.from(await getRes.arrayBuffer());
+        expect(body2.equals(PNG_BYTES)).toBe(true);
+      });
     });
   });
 });

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1585,5 +1585,88 @@ describe('user routes', () => {
         expect(body2.equals(PNG_BYTES)).toBe(true);
       });
     });
+
+    describe('GET /users/:id/avatar — cross-tenant authorization', () => {
+      const OTHER_ID = 'other-456';
+
+      function authAs(userId: string, partnerId: string) {
+        vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+          c.set('auth', {
+            scope: 'partner',
+            partnerId,
+            orgId: null,
+            user: { id: userId, email: `${userId}@example.com` },
+          });
+          return next();
+        });
+      }
+
+      // getScopedUser (partner scope) resolves :id via
+      // select().from().innerJoin().innerJoin().where().limit(). Force the
+      // resolved row so we control "in scope" vs "not in scope".
+      function mockScopedUser(rows: unknown[]) {
+        vi.mocked(db.select).mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            innerJoin: vi.fn().mockReturnValue({
+              innerJoin: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue(rows),
+                }),
+              }),
+            }),
+          }),
+        } as any);
+      }
+
+      async function uploadAvatarFor(userId: string, partnerId: string) {
+        authAs(userId, partnerId);
+        makeUpdateMock([{ id: userId, avatarUrl: `/api/v1/users/${userId}/avatar`, updatedAt: new Date() }]);
+        const { body, headers } = makeMultipart('file', PNG_BYTES, 'image/png', 'a.png');
+        const res = await app.request('/users/me/avatar', { method: 'POST', body, headers });
+        expect(res.status).toBe(200);
+      }
+
+      it('blocks a cross-tenant read — another user not in the caller\'s scope returns 404 even though the avatar file exists', async () => {
+        // A real avatar file now exists on disk for other-456.
+        await uploadAvatarFor(OTHER_ID, 'partner-999');
+
+        // Caller is in a DIFFERENT partner; getScopedUser resolves to nothing.
+        authAs(ME_ID, 'partner-123');
+        mockScopedUser([]);
+
+        const res = await app.request(`/users/${OTHER_ID}/avatar`, { method: 'GET' });
+        // Same 404 as "no avatar" — never reveals that other-456 exists.
+        expect(res.status).toBe(404);
+      });
+
+      it('serves another user\'s avatar when getScopedUser resolves them within the caller\'s scope', async () => {
+        await uploadAvatarFor(OTHER_ID, 'partner-123');
+
+        authAs(ME_ID, 'partner-123');
+        mockScopedUser([
+          { id: OTHER_ID, email: 'other-456@example.com', name: 'Other', status: 'active', roleId: 'r1', roleName: 'Admin', orgAccess: 'all', orgIds: null },
+        ]);
+
+        const res = await app.request(`/users/${OTHER_ID}/avatar`, { method: 'GET' });
+        expect(res.status).toBe(200);
+        expect(res.headers.get('content-type')).toBe('image/png');
+        const bytes = Buffer.from(await res.arrayBuffer());
+        expect(bytes.equals(PNG_BYTES)).toBe(true);
+      });
+
+      it('serves the caller\'s OWN avatar without a scope lookup (top bar must work without USERS_READ)', async () => {
+        await uploadAvatarFor(ME_ID, 'partner-123');
+
+        authAs(ME_ID, 'partner-123');
+        // Force getScopedUser to resolve to nothing — it must NOT be consulted
+        // for a self read, so the avatar still serves.
+        mockScopedUser([]);
+
+        const res = await app.request(`/users/${ME_ID}/avatar`, { method: 'GET' });
+        expect(res.status).toBe(200);
+        const bytes = Buffer.from(await res.arrayBuffer());
+        expect(bytes.equals(PNG_BYTES)).toBe(true);
+      });
+    });
   });
 });

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,7 +1,6 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { bodyLimit } from 'hono/body-limit';
-import { stream } from 'hono/streaming';
 import { z } from 'zod';
 import { and, eq, or } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
@@ -12,7 +11,7 @@ import { authMiddleware, hasSatisfiedMfa, requireMfa, requirePermission } from '
 import {
   MAX_AVATAR_SIZE_BYTES,
   deleteAvatar,
-  readAvatarStream,
+  readAvatarBuffer,
   sniffImageMime,
   statAvatar,
   weakEtagFor,
@@ -802,9 +801,14 @@ userRoutes.delete('/me/avatar', async (c) => {
   return c.json({ avatarUrl: null });
 });
 
-// Serve any user's avatar (tenant-scoped via auth middleware; the avatar is
-// not more sensitive than the user's display name).
+// Serve a user's avatar. Authorization mirrors GET /:id: a caller may always
+// read their OWN avatar (the top bar shows it without USERS_READ), but reading
+// another user's avatar requires that user to be resolvable within the caller's
+// tenant scope. Without this, any authenticated user could fetch any other
+// user's avatar across partners/orgs — the `*` partner-scope middleware only
+// gates full-org partner reads, not per-id reads (Todd's #1059 review).
 userRoutes.get('/:id/avatar', async (c) => {
+  const auth = c.get('auth');
   const userId = c.req.param('id')!;
 
   // Basic shape check — userId comes from the URL and is fed straight to the
@@ -814,6 +818,17 @@ userRoutes.get('/:id/avatar', async (c) => {
   // tidy.
   if (!/^[a-zA-Z0-9_-]+$/.test(userId)) {
     return c.json({ error: 'Invalid user id' }, 400);
+  }
+
+  // Cross-tenant guard. Own avatar is always allowed; any other id must resolve
+  // within the caller's tenant scope (same resolution path as GET /:id). The
+  // failure returns the same 404 as a missing avatar so the route never reveals
+  // which user ids exist in other tenants.
+  if (userId !== auth.user.id) {
+    const record = await getScopedUser(userId, getScopeContext(auth));
+    if (!record) {
+      return c.json({ error: 'No avatar' }, 404);
+    }
   }
 
   const stat = statAvatar(userId);
@@ -829,25 +844,26 @@ userRoutes.get('/:id/avatar', async (c) => {
     return c.body(null, 304);
   }
 
-  const opened = readAvatarStream(userId);
+  // Read the whole file (avatars are capped at MAX_AVATAR_SIZE_BYTES) before
+  // sending any headers, so an I/O error is a clean 500 rather than a 200 with
+  // a truncated body under a full Content-Length (Todd's #1059 review).
+  const opened = readAvatarBuffer(userId);
   if (!opened) {
-    return c.json({ error: 'No avatar' }, 404);
+    // statAvatar passed just above, so a null here is a real read failure (or a
+    // delete race), not a "no avatar" — surface it as a 500 rather than a 404.
+    return c.json({ error: 'Failed to read avatar' }, 500);
   }
 
-  c.header('Content-Type', opened.mime);
-  c.header('Content-Length', String(opened.size));
-  c.header('Cache-Control', 'private, max-age=300');
-  c.header('ETag', etag);
-
-  return stream(c, async (s) => {
-    // Pipe the node Readable into the Hono stream helper.
-    await new Promise<void>((resolve, reject) => {
-      opened.stream.on('data', (chunk: Buffer) => {
-        s.write(chunk).catch(reject);
-      });
-      opened.stream.on('end', () => resolve());
-      opened.stream.on('error', reject);
-    });
+  // Copy into a plain Uint8Array — Node's Buffer generic isn't accepted as a
+  // BodyInit by the DOM lib types; the copy is bounded by the 5 MB cap.
+  return new Response(new Uint8Array(opened.buffer), {
+    status: 200,
+    headers: {
+      'Content-Type': opened.mime,
+      'Content-Length': String(opened.size),
+      'Cache-Control': 'private, max-age=300',
+      ETag: etag,
+    },
   });
 });
 

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,5 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
+import { bodyLimit } from 'hono/body-limit';
+import { stream } from 'hono/streaming';
 import { z } from 'zod';
 import { and, eq, or } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
@@ -7,6 +9,15 @@ import { nanoid } from 'nanoid';
 import { db } from '../db';
 import { users, partnerUsers, organizationUsers, roles, organizations, permissions, rolePermissions } from '../db/schema';
 import { authMiddleware, hasSatisfiedMfa, requireMfa, requirePermission } from '../middleware/auth';
+import {
+  MAX_AVATAR_SIZE_BYTES,
+  deleteAvatar,
+  readAvatarStream,
+  sniffImageMime,
+  statAvatar,
+  weakEtagFor,
+  writeAvatar,
+} from '../services/avatarStorage';
 import {
   clearPermissionCache,
   getUserPermissions,
@@ -435,18 +446,15 @@ userRoutes.get('/me', async (c) => {
   });
 });
 
-// Update current user's profile
+// Update current user's profile.
+// NOTE: `avatarUrl` is intentionally NOT part of this schema. Avatars are
+// managed exclusively through POST/DELETE /users/me/avatar (file upload). The
+// strict() refinement causes any client still sending avatarUrl to get a 400,
+// which is what we want — silent drop would mask client bugs.
 const updateMeSchema = z
   .object({
     name: z.string().min(1).max(255).optional(),
     email: z.string().email().max(255).optional(),
-    avatarUrl: z
-      .string()
-      .url()
-      .max(2048)
-      .refine((u) => /^https?:/i.test(u), { message: 'avatarUrl must be an http(s) URL' })
-      .nullable()
-      .optional(),
     preferences: z
       .union([
         z.record(z.string().max(64), z.unknown()),
@@ -475,7 +483,7 @@ userRoutes.patch('/me', zValidator('json', updateMeSchema), async (c) => {
     return c.json({ error: 'User not found' }, 404);
   }
 
-  const updates: { name?: string; email?: string; avatarUrl?: string; preferences?: Record<string, unknown>; updatedAt: Date } = {
+  const updates: { name?: string; email?: string; preferences?: Record<string, unknown>; updatedAt: Date } = {
     updatedAt: new Date()
   };
 
@@ -488,10 +496,6 @@ userRoutes.patch('/me', zValidator('json', updateMeSchema), async (c) => {
 
   if (body.name) {
     updates.name = body.name.slice(0, 255);
-  }
-
-  if (body.avatarUrl !== undefined && body.avatarUrl !== null) {
-    updates.avatarUrl = body.avatarUrl;
   }
 
   if (body.preferences !== undefined) {
@@ -647,6 +651,204 @@ userRoutes.patch('/me', zValidator('json', updateMeSchema), async (c) => {
   }
 
   return c.json(updated);
+});
+
+// --- Avatars ---
+//
+// POST /users/me/avatar     multipart upload of png/jpeg/webp, 5 MB max
+// GET  /users/:id/avatar    stream the bytes (auth required)
+// DELETE /users/me/avatar   unlink + clear users.avatar_url
+//
+// Storage: filesystem, /data/avatars/<userId>.<ext> on the api_data volume.
+// Magic-byte verification is required because we don't trust the
+// browser-supplied Content-Type. Filenames are derived from the auth'd user
+// id, so path traversal is impossible.
+
+const ALLOWED_AVATAR_MIMES = new Set(['image/png', 'image/jpeg', 'image/webp']);
+
+userRoutes.post(
+  '/me/avatar',
+  bodyLimit({
+    maxSize: MAX_AVATAR_SIZE_BYTES + 64 * 1024, // small slack for multipart overhead
+    onError: (c) => c.json({ error: 'Avatar file too large (max 5 MB)' }, 413),
+  }),
+  async (c) => {
+    const auth = c.get('auth');
+    const userId = auth.user.id;
+
+    let body: Record<string, unknown>;
+    try {
+      body = await c.req.parseBody({ all: true });
+    } catch {
+      return c.json({ error: 'Invalid multipart body' }, 400);
+    }
+
+    const file = body.file;
+    if (!(file instanceof File)) {
+      return c.json({ error: 'file field is required' }, 400);
+    }
+
+    if (file.size === 0) {
+      return c.json({ error: 'file is empty' }, 400);
+    }
+
+    if (file.size > MAX_AVATAR_SIZE_BYTES) {
+      return c.json({ error: 'Avatar file too large (max 5 MB)' }, 413);
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer());
+
+    const sniffedMime = sniffImageMime(buffer);
+    if (!sniffedMime) {
+      return c.json(
+        { error: 'Unsupported image format. Allowed: PNG, JPEG, WebP.' },
+        415
+      );
+    }
+
+    // Defense in depth: if a Content-Type was supplied, it must agree with the
+    // sniffed mime. (Clients are allowed to omit it.)
+    const claimedMime = (file.type || '').toLowerCase();
+    if (claimedMime && claimedMime !== sniffedMime && ALLOWED_AVATAR_MIMES.has(claimedMime)) {
+      return c.json(
+        { error: 'Content-Type does not match file contents' },
+        400
+      );
+    }
+
+    let written;
+    try {
+      written = await writeAvatar(userId, sniffedMime, buffer);
+    } catch (err) {
+      console.error('[users/avatar] failed to write avatar:', err);
+      return c.json({ error: 'Failed to store avatar' }, 500);
+    }
+
+    const avatarUrl = `/api/v1/users/${userId}/avatar`;
+    const [updated] = await db
+      .update(users)
+      .set({ avatarUrl, updatedAt: new Date() })
+      .where(eq(users.id, userId))
+      .returning({
+        id: users.id,
+        avatarUrl: users.avatarUrl,
+        updatedAt: users.updatedAt,
+      });
+
+    if (!updated) {
+      return c.json({ error: 'Failed to update profile' }, 500);
+    }
+
+    createAuditLogAsync({
+      orgId: auth.orgId || undefined,
+      actorId: auth.user.id,
+      actorEmail: auth.user.email,
+      action: 'user.avatar.upload',
+      resourceType: 'user',
+      resourceId: userId,
+      resourceName: auth.user.name,
+      details: {
+        mime: sniffedMime,
+        size: written.size,
+        ext: written.ext,
+      },
+      ipAddress: getTrustedClientIpOrUndefined(c),
+      userAgent: c.req.header('user-agent'),
+      result: 'success'
+    });
+
+    return c.json({
+      avatarUrl: updated.avatarUrl,
+      size: written.size,
+      mime: sniffedMime,
+      updatedAt: updated.updatedAt
+    });
+  }
+);
+
+userRoutes.delete('/me/avatar', async (c) => {
+  const auth = c.get('auth');
+  const userId = auth.user.id;
+
+  deleteAvatar(userId);
+
+  const [updated] = await db
+    .update(users)
+    .set({ avatarUrl: null, updatedAt: new Date() })
+    .where(eq(users.id, userId))
+    .returning({
+      id: users.id,
+      avatarUrl: users.avatarUrl,
+    });
+
+  if (!updated) {
+    return c.json({ error: 'Failed to clear avatar' }, 500);
+  }
+
+  createAuditLogAsync({
+    orgId: auth.orgId || undefined,
+    actorId: auth.user.id,
+    actorEmail: auth.user.email,
+    action: 'user.avatar.delete',
+    resourceType: 'user',
+    resourceId: userId,
+    resourceName: auth.user.name,
+    details: {},
+    ipAddress: getTrustedClientIpOrUndefined(c),
+    userAgent: c.req.header('user-agent'),
+    result: 'success'
+  });
+
+  return c.json({ avatarUrl: null });
+});
+
+// Serve any user's avatar (tenant-scoped via auth middleware; the avatar is
+// not more sensitive than the user's display name).
+userRoutes.get('/:id/avatar', async (c) => {
+  const userId = c.req.param('id')!;
+
+  // Basic shape check — userId comes from the URL and is fed straight to the
+  // filesystem (after concatenation with the extension). The filesystem layer
+  // joins it via path.join, so traversal isn't possible, but rejecting obviously
+  // bogus values up-front avoids confusing errors and keeps the on-disk listing
+  // tidy.
+  if (!/^[a-zA-Z0-9_-]+$/.test(userId)) {
+    return c.json({ error: 'Invalid user id' }, 400);
+  }
+
+  const stat = statAvatar(userId);
+  if (!stat) {
+    return c.json({ error: 'No avatar' }, 404);
+  }
+
+  const etag = weakEtagFor(stat.size, stat.mtimeMs);
+  const ifNoneMatch = c.req.header('if-none-match');
+  if (ifNoneMatch && ifNoneMatch === etag) {
+    c.header('ETag', etag);
+    c.header('Cache-Control', 'private, max-age=300');
+    return c.body(null, 304);
+  }
+
+  const opened = readAvatarStream(userId);
+  if (!opened) {
+    return c.json({ error: 'No avatar' }, 404);
+  }
+
+  c.header('Content-Type', opened.mime);
+  c.header('Content-Length', String(opened.size));
+  c.header('Cache-Control', 'private, max-age=300');
+  c.header('ETag', etag);
+
+  return stream(c, async (s) => {
+    // Pipe the node Readable into the Hono stream helper.
+    await new Promise<void>((resolve, reject) => {
+      opened.stream.on('data', (chunk: Buffer) => {
+        s.write(chunk).catch(reject);
+      });
+      opened.stream.on('end', () => resolve());
+      opened.stream.on('error', reject);
+    });
+  });
 });
 
 userRoutes.get(

--- a/apps/api/src/services/avatarStorage.ts
+++ b/apps/api/src/services/avatarStorage.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, renameSync, statSync, unlinkSync, createReadStream } from 'fs';
+import { existsSync, mkdirSync, readdirSync, renameSync, statSync, unlinkSync, createReadStream, readFileSync } from 'fs';
 import { writeFile } from 'fs/promises';
 import { join } from 'path';
 import { createHash } from 'crypto';
@@ -166,6 +166,31 @@ export function readAvatarStream(userId: string): { stream: Readable; mime: Avat
     size: stat.size,
     mtimeMs: stat.mtimeMs,
   };
+}
+
+/**
+ * Read a user's avatar fully into a Buffer. Avatars are capped at
+ * MAX_AVATAR_SIZE_BYTES on write, so buffering is bounded and lets the
+ * caller send an exact Content-Length with no risk of a truncated body
+ * (a mid-stream read error becomes a clean failure before any bytes or
+ * headers are sent, rather than a 200 with a short body).
+ */
+export function readAvatarBuffer(userId: string): { buffer: Buffer; mime: AvatarMime; size: number; mtimeMs: number } | null {
+  const found = findAvatar(userId);
+  if (!found) return null;
+
+  try {
+    const stat = statSync(found.path);
+    const buffer = readFileSync(found.path);
+    return {
+      buffer,
+      mime: found.mime,
+      size: stat.size,
+      mtimeMs: stat.mtimeMs,
+    };
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/apps/api/src/services/avatarStorage.ts
+++ b/apps/api/src/services/avatarStorage.ts
@@ -1,0 +1,222 @@
+import { existsSync, mkdirSync, readdirSync, renameSync, statSync, unlinkSync, createReadStream } from 'fs';
+import { writeFile } from 'fs/promises';
+import { join } from 'path';
+import { createHash } from 'crypto';
+import type { Readable } from 'stream';
+
+/**
+ * Avatar storage service.
+ *
+ * Mirrors the filesystem-backed pattern used by `fileStorage.ts` for remote
+ * transfers. One file per user, named `<userId>.<ext>`. New uploads overwrite.
+ *
+ * Storage path defaults to /data/avatars (Docker named volume api_data is
+ * mounted at /data on the api container, same volume used for transfers and
+ * patch-reports).
+ */
+
+const STORAGE_PATH = process.env.AVATAR_STORAGE_PATH || './data/avatars';
+
+export const MAX_AVATAR_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
+
+export type AvatarMime = 'image/png' | 'image/jpeg' | 'image/webp';
+
+const MIME_TO_EXT: Record<AvatarMime, 'png' | 'jpg' | 'webp'> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/webp': 'webp',
+};
+
+const ALL_EXTS = ['png', 'jpg', 'webp'] as const;
+type AvatarExt = (typeof ALL_EXTS)[number];
+
+const EXT_TO_MIME: Record<AvatarExt, AvatarMime> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  webp: 'image/webp',
+};
+
+export function extForMime(mime: AvatarMime): AvatarExt {
+  return MIME_TO_EXT[mime];
+}
+
+export function mimeForExt(ext: string): AvatarMime | null {
+  if (ext in EXT_TO_MIME) {
+    return EXT_TO_MIME[ext as AvatarExt];
+  }
+  return null;
+}
+
+/**
+ * Sniff the leading bytes of `buf` and return the matching MIME if it's one of
+ * the allowed image formats, or `null` otherwise. Does NOT trust the
+ * Content-Type header; the magic bytes are the source of truth.
+ */
+export function sniffImageMime(buf: Buffer): AvatarMime | null {
+  if (buf.length < 12) return null;
+
+  // PNG: 89 50 4E 47 0D 0A 1A 0A
+  if (
+    buf[0] === 0x89 &&
+    buf[1] === 0x50 &&
+    buf[2] === 0x4e &&
+    buf[3] === 0x47 &&
+    buf[4] === 0x0d &&
+    buf[5] === 0x0a &&
+    buf[6] === 0x1a &&
+    buf[7] === 0x0a
+  ) {
+    return 'image/png';
+  }
+
+  // JPEG: FF D8 FF
+  if (buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) {
+    return 'image/jpeg';
+  }
+
+  // WebP: "RIFF" .... "WEBP"
+  if (
+    buf[0] === 0x52 && // R
+    buf[1] === 0x49 && // I
+    buf[2] === 0x46 && // F
+    buf[3] === 0x46 && // F
+    buf[8] === 0x57 && // W
+    buf[9] === 0x45 && // E
+    buf[10] === 0x42 && // B
+    buf[11] === 0x50 // P
+  ) {
+    return 'image/webp';
+  }
+
+  return null;
+}
+
+function ensureStorageDir(): void {
+  if (!existsSync(STORAGE_PATH)) {
+    mkdirSync(STORAGE_PATH, { recursive: true });
+  }
+}
+
+function avatarPath(userId: string, ext: AvatarExt): string {
+  return join(STORAGE_PATH, `${userId}.${ext}`);
+}
+
+/**
+ * Find the on-disk file for a user's avatar, regardless of extension.
+ * Returns null if no avatar exists for this user.
+ */
+export function findAvatar(userId: string): { path: string; ext: AvatarExt; mime: AvatarMime } | null {
+  if (!existsSync(STORAGE_PATH)) return null;
+  for (const ext of ALL_EXTS) {
+    const path = avatarPath(userId, ext);
+    if (existsSync(path)) {
+      return { path, ext, mime: EXT_TO_MIME[ext] };
+    }
+  }
+  return null;
+}
+
+/**
+ * Write avatar bytes atomically. Removes any pre-existing avatar for the same
+ * user at a different extension.
+ */
+export async function writeAvatar(userId: string, mime: AvatarMime, data: Buffer): Promise<{ path: string; ext: AvatarExt; size: number }> {
+  ensureStorageDir();
+  const ext = extForMime(mime);
+  const finalPath = avatarPath(userId, ext);
+  const tmpPath = `${finalPath}.tmp`;
+
+  await writeFile(tmpPath, data);
+  renameSync(tmpPath, finalPath);
+
+  // Clean up any avatar at a different extension so we don't accumulate.
+  for (const otherExt of ALL_EXTS) {
+    if (otherExt === ext) continue;
+    const otherPath = avatarPath(userId, otherExt);
+    if (existsSync(otherPath)) {
+      try {
+        unlinkSync(otherPath);
+      } catch {
+        // Best-effort cleanup; ignore.
+      }
+    }
+  }
+
+  return { path: finalPath, ext, size: data.length };
+}
+
+/**
+ * Open a readable stream for the user's avatar file. Returns null if no
+ * avatar exists.
+ */
+export function readAvatarStream(userId: string): { stream: Readable; mime: AvatarMime; size: number; mtimeMs: number } | null {
+  const found = findAvatar(userId);
+  if (!found) return null;
+
+  let stat;
+  try {
+    stat = statSync(found.path);
+  } catch {
+    return null;
+  }
+
+  return {
+    stream: createReadStream(found.path),
+    mime: found.mime,
+    size: stat.size,
+    mtimeMs: stat.mtimeMs,
+  };
+}
+
+/**
+ * Get file stat (size + mtimeMs) for a user's avatar without opening it.
+ */
+export function statAvatar(userId: string): { mime: AvatarMime; size: number; mtimeMs: number } | null {
+  const found = findAvatar(userId);
+  if (!found) return null;
+  try {
+    const stat = statSync(found.path);
+    return { mime: found.mime, size: stat.size, mtimeMs: stat.mtimeMs };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compute a weak ETag from size + mtimeMs. Cheap, avoids hashing file bytes
+ * on every read. Format follows RFC 7232 weak ETag syntax.
+ */
+export function weakEtagFor(size: number, mtimeMs: number): string {
+  const hash = createHash('sha1');
+  hash.update(`${size}:${Math.floor(mtimeMs)}`);
+  return `W/"${hash.digest('hex').slice(0, 16)}"`;
+}
+
+/**
+ * Delete the user's avatar file (any extension). Returns true if a file was
+ * removed, false if no avatar existed.
+ */
+export function deleteAvatar(userId: string): boolean {
+  if (!existsSync(STORAGE_PATH)) return false;
+  let removed = false;
+  for (const ext of ALL_EXTS) {
+    const path = avatarPath(userId, ext);
+    if (existsSync(path)) {
+      try {
+        unlinkSync(path);
+        removed = true;
+      } catch {
+        // ignore
+      }
+    }
+  }
+  return removed;
+}
+
+/**
+ * Test-only helper: list all avatar filenames currently on disk.
+ */
+export function listAvatarsForTest(): string[] {
+  if (!existsSync(STORAGE_PATH)) return [];
+  return readdirSync(STORAGE_PATH);
+}

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -30,6 +30,7 @@ import { useUiStore } from '../../stores/uiStore';
 import { useFeaturesStore } from '../../stores/featuresStore';
 import { showToast } from '../shared/Toast';
 import { navigateTo } from '../../lib/navigation';
+import { useAvatarBlobUrl } from '../../lib/avatarBlobCache';
 
 export default function Header() {
   const [mounted, setMounted] = useState(false);
@@ -45,6 +46,9 @@ export default function Header() {
   const themeRef = useRef<HTMLDivElement>(null);
 
   const { user, isAuthenticated } = useAuthStore();
+  // Resolve the avatar through fetchWithAuth so internal /api/v1/users/<id>/avatar
+  // paths return a blob: URL that <img> can render. External URLs pass through.
+  const resolvedAvatarUrl = useAvatarBlobUrl(user?.avatarUrl ?? null);
   const { isOpen: isAiOpen, toggle: toggleAi } = useAiStore();
   const { isOpen: isHelpOpen, toggle: toggleHelp } = useHelpStore();
   const { toggleMobileMenu } = useUiStore();
@@ -282,10 +286,10 @@ export default function Header() {
             aria-expanded={showUserMenu}
             aria-haspopup="true"
           >
-            {mounted && user?.avatarUrl ? (
+            {mounted && resolvedAvatarUrl ? (
               <img
-                src={user.avatarUrl}
-                alt={user.name}
+                src={resolvedAvatarUrl}
+                alt={user?.name ?? 'User avatar'}
                 className="h-8 w-8 rounded-full object-cover"
               />
             ) : (
@@ -301,10 +305,10 @@ export default function Header() {
               {/* User Info Section */}
               <div className="border-b p-4">
                 <div className="flex items-center gap-3">
-                  {user?.avatarUrl ? (
+                  {resolvedAvatarUrl ? (
                     <img
-                      src={user.avatarUrl}
-                      alt={user.name}
+                      src={resolvedAvatarUrl}
+                      alt={user?.name ?? 'User avatar'}
                       className="h-10 w-10 rounded-full object-cover"
                     />
                   ) : (

--- a/apps/web/src/components/portal/PortalHeader.tsx
+++ b/apps/web/src/components/portal/PortalHeader.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { ChevronDown, LogOut, UserCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { sanitizeImageSrc } from '@/lib/safeImageSrc';
+import { useAvatarBlobUrl } from '@/lib/avatarBlobCache';
 import { usePortalBranding } from './BrandingProvider';
 
 type PortalUser = {
@@ -26,7 +27,9 @@ export default function PortalHeader({
   const branding = usePortalBranding();
   const [menuOpen, setMenuOpen] = useState(false);
   const safeLogoUrl = sanitizeImageSrc(branding.logoUrl);
-  const safeAvatarUrl = sanitizeImageSrc(user.avatarUrl);
+  // Internal avatars are auth-gated; the hook fetches via Bearer and returns a
+  // blob URL. External avatar URLs are passed through after sanitization.
+  const safeAvatarUrl = useAvatarBlobUrl(user.avatarUrl ?? null);
 
   return (
     <header

--- a/apps/web/src/components/settings/ProfilePage.test.tsx
+++ b/apps/web/src/components/settings/ProfilePage.test.tsx
@@ -1,11 +1,15 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ProfilePage from './ProfilePage';
 import { fetchWithAuth } from '../../stores/auth';
 
 vi.mock('../../stores/auth', () => ({
-  fetchWithAuth: vi.fn()
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: any) => selector({ updateUser: vi.fn() }),
+    { getState: () => ({ updateUser: vi.fn() }) }
+  )
 }));
 
 const fetchWithAuthMock = vi.mocked(fetchWithAuth);
@@ -18,19 +22,42 @@ const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500):
     json: vi.fn().mockResolvedValue(payload)
   }) as unknown as Response;
 
+// Stub URL.createObjectURL / revokeObjectURL — jsdom doesn't provide them by
+// default, and the component calls them when a file is selected for preview.
+beforeEach(() => {
+  globalThis.URL.createObjectURL = vi.fn(() => 'blob:fake');
+  globalThis.URL.revokeObjectURL = vi.fn();
+});
+
 describe('ProfilePage avatar settings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('replaces coming-soon avatar copy with editable avatar URL and saves profile', async () => {
+  it('does NOT render the old Avatar image URL input', () => {
+    render(
+      <ProfilePage
+        initialUser={{
+          id: 'user-1',
+          name: 'Casey Admin',
+          email: 'casey@example.com',
+          mfaEnabled: false
+        }}
+      />
+    );
+    expect(screen.queryByLabelText('Avatar image URL')).toBeNull();
+    expect(screen.queryByText(/coming soon/i)).toBeNull();
+    // Helper text is present
+    expect(screen.getByText(/PNG, JPG, or WebP\. Max 5 MB\./)).toBeTruthy();
+  });
+
+  it('uploads a PNG file, updates the avatar, and shows success', async () => {
     fetchWithAuthMock.mockResolvedValueOnce(
       makeJsonResponse({
-        id: 'user-1',
-        name: 'Casey Admin',
-        email: 'casey@example.com',
-        avatarUrl: 'https://cdn.example.com/old-avatar.png',
-        mfaEnabled: false
+        avatarUrl: '/api/v1/users/user-1/avatar',
+        size: 1234,
+        mime: 'image/png',
+        updatedAt: new Date().toISOString()
       })
     );
 
@@ -40,34 +67,85 @@ describe('ProfilePage avatar settings', () => {
           id: 'user-1',
           name: 'Casey Admin',
           email: 'casey@example.com',
-          avatarUrl: 'https://cdn.example.com/old-avatar.png',
           mfaEnabled: false
         }}
       />
     );
 
-    expect(screen.queryByText(/coming soon/i)).toBeNull();
-
-    const avatarUrlInput = screen.getByLabelText('Avatar image URL');
-    fireEvent.change(avatarUrlInput, {
-      target: { value: 'https://cdn.example.com/new-avatar.png' }
+    const fileInput = screen.getByTestId('avatar-file-input') as HTMLInputElement;
+    const file = new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], 'avatar.png', {
+      type: 'image/png'
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+    fireEvent.change(fileInput, { target: { files: [file] } });
 
-    await screen.findByText('Profile updated successfully');
+    // Confirmation row appears
+    await screen.findByText('avatar.png');
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }));
 
-    const saveCall = fetchWithAuthMock.mock.calls.find(([url]) => String(url) === '/users/me');
-    expect(saveCall).toBeDefined();
+    await screen.findByText('Avatar updated.');
 
-    const [, init] = saveCall!;
-    expect(init?.method).toBe('PATCH');
-    expect(init?.body).toBe(
-      JSON.stringify({
-        name: 'Casey Admin',
-        avatarUrl: 'https://cdn.example.com/new-avatar.png'
-      })
+    const uploadCall = fetchWithAuthMock.mock.calls.find(
+      ([url]) => String(url) === '/users/me/avatar'
     );
+    expect(uploadCall).toBeDefined();
+    const [, init] = uploadCall!;
+    expect(init?.method).toBe('POST');
+    expect(init?.body).toBeInstanceOf(FormData);
+  });
+
+  it('shows a validation error for unsupported file types and does not call the API', () => {
+    render(
+      <ProfilePage
+        initialUser={{
+          id: 'user-1',
+          name: 'Casey Admin',
+          email: 'casey@example.com',
+          mfaEnabled: false
+        }}
+      />
+    );
+
+    const fileInput = screen.getByTestId('avatar-file-input') as HTMLInputElement;
+    const badFile = new File([new Uint8Array([1, 2, 3])], 'evil.svg', { type: 'image/svg+xml' });
+    fireEvent.change(fileInput, { target: { files: [badFile] } });
+
+    expect(screen.getByText(/Unsupported file type/i)).toBeTruthy();
+    expect(
+      fetchWithAuthMock.mock.calls.find(([url]) => String(url) === '/users/me/avatar')
+    ).toBeUndefined();
+  });
+
+  it('deletes the current avatar via the Remove button', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ avatarUrl: null }));
+
+    render(
+      <ProfilePage
+        initialUser={{
+          id: 'user-1',
+          name: 'Casey Admin',
+          email: 'casey@example.com',
+          avatarUrl: '/api/v1/users/user-1/avatar',
+          mfaEnabled: false
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    await screen.findByText('Avatar removed.');
+
+    const deleteCall = fetchWithAuthMock.mock.calls.find(
+      ([url]) => String(url) === '/users/me/avatar'
+    );
+    expect(deleteCall).toBeDefined();
+    const [, init] = deleteCall!;
+    expect(init?.method).toBe('DELETE');
+
+    // After successful delete, the Remove button is no longer shown.
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Remove' })).toBeNull();
+    });
   });
 });
 

--- a/apps/web/src/components/settings/ProfilePage.test.tsx
+++ b/apps/web/src/components/settings/ProfilePage.test.tsx
@@ -12,6 +12,14 @@ vi.mock('../../stores/auth', () => ({
   )
 }));
 
+// The avatar blob hook fetches /api/v1/users/<id>/avatar through fetchWithAuth
+// when an avatarUrl is present. The tests below are about the upload/delete
+// flow on /users/me/avatar; mocking the hook keeps the fetch mock consumption
+// order deterministic.
+vi.mock('@/lib/avatarBlobCache', () => ({
+  useAvatarBlobUrl: (url: string | null | undefined) => url ?? null,
+}));
+
 const fetchWithAuthMock = vi.mocked(fetchWithAuth);
 
 const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>

--- a/apps/web/src/components/settings/ProfilePage.tsx
+++ b/apps/web/src/components/settings/ProfilePage.tsx
@@ -1,22 +1,14 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import ChangePasswordForm from './ChangePasswordForm';
 import MFASettings from './MFASettings';
-import { fetchWithAuth } from '../../stores/auth';
+import { fetchWithAuth, useAuthStore } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 
 const profileSchema = z.object({
   name: z.string().min(2, 'Name must be at least 2 characters'),
-  avatarUrl: z
-    .string()
-    .max(2048, 'Avatar URL is too long')
-    .refine(
-      (value) => value.trim() === '' || /^https?:\/\//i.test(value.trim()),
-      'Avatar URL must start with http:// or https://'
-    )
-    .optional()
 });
 
 type ProfileFormValues = z.infer<typeof profileSchema>;
@@ -28,6 +20,15 @@ type User = {
   avatarUrl?: string;
   mfaEnabled?: boolean;
 };
+
+const ALLOWED_AVATAR_MIMES = ['image/png', 'image/jpeg', 'image/webp'];
+const MAX_AVATAR_BYTES = 5 * 1024 * 1024;
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
 
 type ProfilePageProps = {
   initialUser?: User;
@@ -49,17 +50,26 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
   const [isChangingPassword, setIsChangingPassword] = useState(false);
   const [mfaLoading, setMfaLoading] = useState(false);
 
+  // Avatar upload state
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
+  const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
+  const [isDeletingAvatar, setIsDeletingAvatar] = useState(false);
+  const [avatarError, setAvatarError] = useState<string | undefined>();
+  const [avatarSuccess, setAvatarSuccess] = useState<string | undefined>();
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const updateAuthUser = useAuthStore((s) => s.updateUser);
+
   const {
     register,
     handleSubmit,
     reset,
-    watch,
     formState: { errors, isSubmitting }
   } = useForm<ProfileFormValues>({
     resolver: zodResolver(profileSchema),
     defaultValues: {
       name: user?.name ?? '',
-      avatarUrl: user?.avatarUrl ?? ''
     }
   });
 
@@ -67,7 +77,11 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
     () => isUpdatingProfile || isSubmitting,
     [isUpdatingProfile, isSubmitting]
   );
-  const previewAvatarUrl = watch('avatarUrl')?.trim() || user?.avatarUrl || '';
+  // Preview priority: locally-selected file (object URL) → user's current avatar.
+  // Adding ?v=<id> would bust caches but adds a needless query string to images
+  // that never change on a single page load; rely on the 5-min Cache-Control
+  // and the auth store update to refresh other tabs.
+  const previewAvatarUrl = avatarPreview || user?.avatarUrl || '';
 
   // Fetch user data on mount
   useEffect(() => {
@@ -90,7 +104,6 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
         setUser(userData);
         reset({
           name: userData.name ?? '',
-          avatarUrl: userData.avatarUrl ?? ''
         });
       } catch {
         setProfileError('Failed to load profile data');
@@ -113,7 +126,6 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       setIsUpdatingProfile(true);
       const payload = {
         name: values.name.trim(),
-        avatarUrl: values.avatarUrl?.trim() ?? ''
       };
 
       const response = await fetchWithAuth('/users/me', {
@@ -130,7 +142,6 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       setUser(updatedUser);
       reset({
         name: updatedUser.name ?? '',
-        avatarUrl: updatedUser.avatarUrl ?? ''
       });
       setProfileSuccess('Profile updated successfully');
     } catch (error) {
@@ -139,6 +150,130 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       setIsUpdatingProfile(false);
     }
   };
+
+  // --- Avatar upload handlers ---
+
+  const validateAvatarFile = useCallback((file: File): string | null => {
+    if (!ALLOWED_AVATAR_MIMES.includes(file.type)) {
+      return 'Unsupported file type. Use PNG, JPG, or WebP.';
+    }
+    if (file.size > MAX_AVATAR_BYTES) {
+      return `File is too large (max ${formatBytes(MAX_AVATAR_BYTES)}).`;
+    }
+    if (file.size === 0) {
+      return 'File is empty.';
+    }
+    return null;
+  }, []);
+
+  const clearAvatarMessages = useCallback(() => {
+    setAvatarError(undefined);
+    setAvatarSuccess(undefined);
+  }, []);
+
+  const selectAvatarFile = useCallback((file: File) => {
+    clearAvatarMessages();
+    const err = validateAvatarFile(file);
+    if (err) {
+      setAvatarError(err);
+      return;
+    }
+    // Revoke any previous preview to avoid leaks.
+    if (avatarPreview && avatarPreview.startsWith('blob:')) {
+      URL.revokeObjectURL(avatarPreview);
+    }
+    setAvatarFile(file);
+    setAvatarPreview(URL.createObjectURL(file));
+  }, [avatarPreview, validateAvatarFile, clearAvatarMessages]);
+
+  const cancelAvatarSelection = useCallback(() => {
+    if (avatarPreview && avatarPreview.startsWith('blob:')) {
+      URL.revokeObjectURL(avatarPreview);
+    }
+    setAvatarFile(null);
+    setAvatarPreview(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }, [avatarPreview]);
+
+  const handleAvatarUpload = useCallback(async () => {
+    if (!avatarFile) return;
+    clearAvatarMessages();
+
+    try {
+      setIsUploadingAvatar(true);
+      const form = new FormData();
+      form.append('file', avatarFile);
+      // fetchWithAuth merges in JSON content-type by default; bypass by passing
+      // an explicit headers object so the browser sets the multipart boundary.
+      const response = await fetchWithAuth('/users/me/avatar', {
+        method: 'POST',
+        body: form,
+        headers: {},
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.error ?? errorData.message ?? 'Failed to upload avatar');
+      }
+
+      const data = await response.json();
+      const newAvatarUrl: string = data.avatarUrl;
+      setUser((prev) => (prev ? { ...prev, avatarUrl: newAvatarUrl } : prev));
+      // Update the global auth store so the Header avatar refreshes immediately.
+      updateAuthUser({ avatarUrl: newAvatarUrl });
+
+      // Clear local preview state — the canonical URL will be used now.
+      cancelAvatarSelection();
+      setAvatarSuccess('Avatar updated.');
+    } catch (error) {
+      setAvatarError(error instanceof Error ? error.message : 'Failed to upload avatar');
+    } finally {
+      setIsUploadingAvatar(false);
+    }
+  }, [avatarFile, clearAvatarMessages, cancelAvatarSelection, updateAuthUser]);
+
+  const handleAvatarDelete = useCallback(async () => {
+    clearAvatarMessages();
+    try {
+      setIsDeletingAvatar(true);
+      const response = await fetchWithAuth('/users/me/avatar', { method: 'DELETE' });
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.error ?? errorData.message ?? 'Failed to remove avatar');
+      }
+      setUser((prev) => (prev ? { ...prev, avatarUrl: undefined } : prev));
+      updateAuthUser({ avatarUrl: undefined });
+      cancelAvatarSelection();
+      setAvatarSuccess('Avatar removed.');
+    } catch (error) {
+      setAvatarError(error instanceof Error ? error.message : 'Failed to remove avatar');
+    } finally {
+      setIsDeletingAvatar(false);
+    }
+  }, [clearAvatarMessages, cancelAvatarSelection, updateAuthUser]);
+
+  const handleAvatarFilePicked = useCallback((evt: React.ChangeEvent<HTMLInputElement>) => {
+    const file = evt.target.files?.[0];
+    if (file) selectAvatarFile(file);
+  }, [selectAvatarFile]);
+
+  const handleAvatarDrop = useCallback((evt: React.DragEvent<HTMLDivElement>) => {
+    evt.preventDefault();
+    setIsDragging(false);
+    const file = evt.dataTransfer.files?.[0];
+    if (file) selectAvatarFile(file);
+  }, [selectAvatarFile]);
+
+  // Clean up object URLs on unmount.
+  useEffect(() => {
+    return () => {
+      if (avatarPreview && avatarPreview.startsWith('blob:')) {
+        URL.revokeObjectURL(avatarPreview);
+      }
+    };
+  }, [avatarPreview]);
 
   const handlePasswordChange = async (values: {
     currentPassword: string;
@@ -308,39 +443,94 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
           <p className="text-sm text-muted-foreground">Update your personal details.</p>
         </div>
 
-        <div className="flex items-center gap-4">
-          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted text-lg font-medium text-muted-foreground">
-            {previewAvatarUrl ? (
-              <img
-                src={previewAvatarUrl}
-                alt={user?.name ?? 'User avatar'}
-                className="h-16 w-16 rounded-full object-cover"
-              />
-            ) : (
-              user?.name?.charAt(0).toUpperCase() ?? '?'
-            )}
+        <div className="space-y-3">
+          <p className="text-sm font-medium">Avatar</p>
+          <div className="flex items-start gap-4">
+            <div
+              data-testid="avatar-dropzone"
+              onDragOver={(e) => { e.preventDefault(); setIsDragging(true); }}
+              onDragLeave={() => setIsDragging(false)}
+              onDrop={handleAvatarDrop}
+              className={`flex h-24 w-24 shrink-0 items-center justify-center overflow-hidden rounded-full border text-xl font-medium ${
+                isDragging
+                  ? 'border-primary bg-primary/10 text-primary'
+                  : 'border-transparent bg-muted text-muted-foreground'
+              }`}
+            >
+              {previewAvatarUrl ? (
+                <img
+                  src={previewAvatarUrl}
+                  alt={user?.name ?? 'User avatar'}
+                  className="h-24 w-24 rounded-full object-cover"
+                />
+              ) : (
+                user?.name?.charAt(0).toUpperCase() ?? '?'
+              )}
+            </div>
+            <div className="flex-1 space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/png,image/jpeg,image/webp"
+                  className="hidden"
+                  onChange={handleAvatarFilePicked}
+                  data-testid="avatar-file-input"
+                />
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={isUploadingAvatar || isDeletingAvatar}
+                  className="rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  Upload new picture
+                </button>
+                {user?.avatarUrl && !avatarFile && (
+                  <button
+                    type="button"
+                    onClick={handleAvatarDelete}
+                    disabled={isUploadingAvatar || isDeletingAvatar}
+                    className="rounded-md border px-3 py-1.5 text-sm font-medium text-destructive hover:bg-destructive/10 transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {isDeletingAvatar ? 'Removing...' : 'Remove'}
+                  </button>
+                )}
+              </div>
+              <p className="text-xs text-muted-foreground">
+                PNG, JPG, or WebP. Max 5 MB. Drag and drop onto the circle, or click Upload.
+              </p>
+              {avatarFile && (
+                <div className="flex flex-wrap items-center gap-2 rounded-md border bg-muted/30 px-3 py-2 text-sm">
+                  <span className="truncate">{avatarFile.name}</span>
+                  <span className="text-xs text-muted-foreground">{formatBytes(avatarFile.size)}</span>
+                  <div className="ml-auto flex gap-2">
+                    <button
+                      type="button"
+                      onClick={handleAvatarUpload}
+                      disabled={isUploadingAvatar}
+                      className="rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {isUploadingAvatar ? 'Uploading...' : 'Upload'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={cancelAvatarSelection}
+                      disabled={isUploadingAvatar}
+                      className="rounded-md border px-3 py-1 text-xs font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
+              {avatarError && (
+                <p className="text-sm text-destructive" role="alert">{avatarError}</p>
+              )}
+              {avatarSuccess && (
+                <p className="text-sm text-emerald-600" role="status">{avatarSuccess}</p>
+              )}
+            </div>
           </div>
-          <div className="space-y-1">
-            <p className="text-sm font-medium">Avatar</p>
-            <p className="text-xs text-muted-foreground">
-              Provide an image URL to update your avatar.
-            </p>
-          </div>
-        </div>
-
-        <div className="space-y-2">
-          <label htmlFor="avatarUrl" className="text-sm font-medium">
-            Avatar image URL
-          </label>
-          <input
-            id="avatarUrl"
-            type="url"
-            autoComplete="url"
-            placeholder="https://example.com/avatar.png"
-            className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-            {...register('avatarUrl')}
-          />
-          {errors.avatarUrl && <p className="text-sm text-destructive">{errors.avatarUrl.message}</p>}
         </div>
 
         <div className="space-y-2">

--- a/apps/web/src/components/settings/ProfilePage.tsx
+++ b/apps/web/src/components/settings/ProfilePage.tsx
@@ -6,6 +6,7 @@ import ChangePasswordForm from './ChangePasswordForm';
 import MFASettings from './MFASettings';
 import { fetchWithAuth, useAuthStore } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
+import { useAvatarBlobUrl } from '@/lib/avatarBlobCache';
 
 const profileSchema = z.object({
   name: z.string().min(2, 'Name must be at least 2 characters'),
@@ -77,11 +78,12 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
     () => isUpdatingProfile || isSubmitting,
     [isUpdatingProfile, isSubmitting]
   );
-  // Preview priority: locally-selected file (object URL) → user's current avatar.
-  // Adding ?v=<id> would bust caches but adds a needless query string to images
-  // that never change on a single page load; rely on the 5-min Cache-Control
-  // and the auth store update to refresh other tabs.
-  const previewAvatarUrl = avatarPreview || user?.avatarUrl || '';
+  // Preview priority: locally-selected file (object URL) → user's current
+  // avatar (fetched as blob through fetchWithAuth so the Bearer token gets
+  // attached — the API requires auth on GET /users/:id/avatar, and <img src=>
+  // can't send headers).
+  const resolvedAvatarUrl = useAvatarBlobUrl(avatarPreview ? null : user?.avatarUrl ?? null);
+  const previewAvatarUrl = avatarPreview || resolvedAvatarUrl || '';
 
   // Fetch user data on mount
   useEffect(() => {

--- a/apps/web/src/components/settings/ProfilePage.tsx
+++ b/apps/web/src/components/settings/ProfilePage.tsx
@@ -207,12 +207,11 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       setIsUploadingAvatar(true);
       const form = new FormData();
       form.append('file', avatarFile);
-      // fetchWithAuth merges in JSON content-type by default; bypass by passing
-      // an explicit headers object so the browser sets the multipart boundary.
+      // fetchWithAuth skips its default JSON content-type for FormData bodies so
+      // the browser can set multipart/form-data with the correct boundary.
       const response = await fetchWithAuth('/users/me/avatar', {
         method: 'POST',
         body: form,
-        headers: {},
       });
 
       if (!response.ok) {

--- a/apps/web/src/lib/avatarBlobCache.test.ts
+++ b/apps/web/src/lib/avatarBlobCache.test.ts
@@ -1,0 +1,139 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchWithAuth } from '../stores/auth';
+
+import { __resetAvatarBlobCacheForTests, useAvatarBlobUrl } from './avatarBlobCache';
+
+vi.mock('../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+let objectUrlCounter = 0;
+const createObjectURL = vi.fn(() => `blob:fake-${++objectUrlCounter}`);
+const revokeObjectURL = vi.fn();
+
+beforeEach(() => {
+  objectUrlCounter = 0;
+  createObjectURL.mockClear();
+  revokeObjectURL.mockClear();
+  fetchWithAuthMock.mockReset();
+  globalThis.URL.createObjectURL = createObjectURL;
+  globalThis.URL.revokeObjectURL = revokeObjectURL;
+});
+
+afterEach(() => {
+  __resetAvatarBlobCacheForTests();
+});
+
+function makeBlobResponse(ok = true, status = ok ? 200 : 404): Response {
+  return {
+    ok,
+    status,
+    blob: vi.fn().mockResolvedValue(new Blob(['x'], { type: 'image/png' })),
+  } as unknown as Response;
+}
+
+describe('useAvatarBlobUrl', () => {
+  it('returns null for null input', () => {
+    const { result } = renderHook(() => useAvatarBlobUrl(null));
+    expect(result.current).toBeNull();
+    expect(fetchWithAuthMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null for empty string input', () => {
+    const { result } = renderHook(() => useAvatarBlobUrl(''));
+    expect(result.current).toBeNull();
+    expect(fetchWithAuthMock).not.toHaveBeenCalled();
+  });
+
+  it('fetches an internal avatar URL via fetchWithAuth and returns an object URL', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeBlobResponse());
+
+    const { result } = renderHook(() => useAvatarBlobUrl('/api/v1/users/u1/avatar'));
+
+    await waitFor(() => {
+      expect(result.current).toMatch(/^blob:fake-/);
+    });
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/api/v1/users/u1/avatar');
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes through external https URLs without fetching', () => {
+    const { result } = renderHook(() =>
+      useAvatarBlobUrl('https://cdn.example.com/avatar.png')
+    );
+    expect(result.current).toBe('https://cdn.example.com/avatar.png');
+    expect(fetchWithAuthMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects javascript: URLs (defense via sanitizeImageSrc)', () => {
+    const { result } = renderHook(() => useAvatarBlobUrl('javascript:alert(1)'));
+    expect(result.current).toBeNull();
+    expect(fetchWithAuthMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the internal avatar fetch fails with 404', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeBlobResponse(false, 404));
+
+    const { result } = renderHook(() => useAvatarBlobUrl('/api/v1/users/u1/avatar'));
+
+    // Wait one tick for the effect's promise to resolve.
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current).toBeNull();
+    expect(createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('returns null when fetchWithAuth throws (network error)', async () => {
+    fetchWithAuthMock.mockRejectedValueOnce(new Error('network down'));
+
+    const { result } = renderHook(() => useAvatarBlobUrl('/api/v1/users/u1/avatar'));
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current).toBeNull();
+  });
+
+  it('reuses the cached object URL across multiple components for the same avatar', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeBlobResponse());
+
+    const hookA = renderHook(() => useAvatarBlobUrl('/api/v1/users/u1/avatar'));
+    await waitFor(() => {
+      expect(hookA.result.current).toMatch(/^blob:fake-/);
+    });
+
+    const firstUrl = hookA.result.current;
+
+    const hookB = renderHook(() => useAvatarBlobUrl('/api/v1/users/u1/avatar'));
+    await waitFor(() => {
+      expect(hookB.result.current).toBe(firstUrl);
+    });
+
+    // Only one fetch, one createObjectURL.
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  it('revokes the object URL when the last consumer unmounts', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeBlobResponse());
+
+    const hookA = renderHook(() => useAvatarBlobUrl('/api/v1/users/u1/avatar'));
+    const hookB = renderHook(() => useAvatarBlobUrl('/api/v1/users/u1/avatar'));
+
+    await waitFor(() => {
+      expect(hookA.result.current).toMatch(/^blob:fake-/);
+      expect(hookB.result.current).toMatch(/^blob:fake-/);
+    });
+
+    hookA.unmount();
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+
+    hookB.unmount();
+    expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/lib/avatarBlobCache.ts
+++ b/apps/web/src/lib/avatarBlobCache.ts
@@ -1,0 +1,165 @@
+import { useEffect, useState } from 'react';
+
+import { fetchWithAuth } from '../stores/auth';
+import { sanitizeImageSrc } from './safeImageSrc';
+
+/**
+ * Avatar render bug:
+ * `users.avatar_url` is now an internal authenticated path like
+ * `/api/v1/users/<id>/avatar`. `<img src=...>` can't send the Bearer token,
+ * so the request hits the API as unauth and 401s, breaking the avatar
+ * everywhere (topbar, portal header, profile page).
+ *
+ * Workaround: fetch the bytes with fetchWithAuth, wrap them in an object URL,
+ * and feed the object URL to `<img>`. This module owns a small in-memory
+ * cache keyed by the input URL so opening multiple components on the same
+ * page doesn't re-fetch.
+ *
+ * External URLs (legacy Gravatar-style rows) pass through after sanitization,
+ * since the browser can request them directly without our auth.
+ */
+
+const INTERNAL_AVATAR_PREFIX = '/api/v1/users/';
+
+type CacheEntry = {
+  objectUrl: string | null; // null = fetch in-flight or failed-as-null
+  promise: Promise<string | null> | null;
+  refCount: number;
+};
+
+const cache = new Map<string, CacheEntry>();
+
+function isInternalAvatarUrl(url: string): boolean {
+  return url.startsWith(INTERNAL_AVATAR_PREFIX);
+}
+
+async function fetchAvatarBlob(url: string): Promise<string | null> {
+  try {
+    const response = await fetchWithAuth(url);
+    if (!response.ok) {
+      return null;
+    }
+    const blob = await response.blob();
+    return URL.createObjectURL(blob);
+  } catch {
+    return null;
+  }
+}
+
+function acquire(url: string): Promise<string | null> {
+  let entry = cache.get(url);
+  if (entry) {
+    entry.refCount += 1;
+    if (entry.objectUrl) {
+      return Promise.resolve(entry.objectUrl);
+    }
+    if (entry.promise) {
+      return entry.promise;
+    }
+    // Previously-failed entry: retry, since refcount went 0→1.
+    const promise = fetchAvatarBlob(url).then((objectUrl) => {
+      const e = cache.get(url);
+      if (e) {
+        e.objectUrl = objectUrl;
+        e.promise = null;
+      }
+      return objectUrl;
+    });
+    entry.promise = promise;
+    return promise;
+  }
+
+  const newEntry: CacheEntry = {
+    objectUrl: null,
+    promise: null,
+    refCount: 1,
+  };
+  cache.set(url, newEntry);
+  const promise = fetchAvatarBlob(url).then((objectUrl) => {
+    const e = cache.get(url);
+    if (e) {
+      e.objectUrl = objectUrl;
+      e.promise = null;
+    }
+    return objectUrl;
+  });
+  newEntry.promise = promise;
+  return promise;
+}
+
+function release(url: string): void {
+  const entry = cache.get(url);
+  if (!entry) return;
+  entry.refCount -= 1;
+  if (entry.refCount <= 0) {
+    if (entry.objectUrl) {
+      URL.revokeObjectURL(entry.objectUrl);
+    }
+    cache.delete(url);
+  }
+}
+
+/**
+ * Test-only: clear the cache without revoking, so tests start clean.
+ * Production callers should never need this.
+ */
+export function __resetAvatarBlobCacheForTests(): void {
+  for (const [, entry] of cache) {
+    if (entry.objectUrl) {
+      // Best-effort revoke; jsdom stubs may be vi.fn() noops.
+      URL.revokeObjectURL(entry.objectUrl);
+    }
+  }
+  cache.clear();
+}
+
+/**
+ * Resolve an avatar URL to a value safe to use in `<img src>`.
+ *
+ * - null / empty input → null (caller renders initials fallback)
+ * - Internal `/api/v1/users/...` path → blob: URL after auth'd fetch, or null on 401/404/network error
+ * - External URL → original URL after `sanitizeImageSrc` (rejects javascript:/data:text/html/etc)
+ *
+ * Cache: shared across components for the lifetime of the page; revoked when
+ * the last consumer unmounts.
+ */
+export function useAvatarBlobUrl(avatarUrl: string | null | undefined): string | null {
+  const [resolved, setResolved] = useState<string | null>(() => {
+    if (!avatarUrl) return null;
+    if (isInternalAvatarUrl(avatarUrl)) {
+      const entry = cache.get(avatarUrl);
+      return entry?.objectUrl ?? null;
+    }
+    return sanitizeImageSrc(avatarUrl);
+  });
+
+  useEffect(() => {
+    if (!avatarUrl) {
+      setResolved(null);
+      return;
+    }
+
+    if (!isInternalAvatarUrl(avatarUrl)) {
+      setResolved(sanitizeImageSrc(avatarUrl));
+      return;
+    }
+
+    let cancelled = false;
+    // Start in a loading-but-not-broken state: null shows initials briefly.
+    const cached = cache.get(avatarUrl);
+    setResolved(cached?.objectUrl ?? null);
+
+    void acquire(avatarUrl).then((objectUrl) => {
+      if (!cancelled) {
+        setResolved(objectUrl);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      release(avatarUrl);
+    };
+  }, [avatarUrl]);
+
+  return resolved;
+}

--- a/apps/web/src/stores/auth.test.ts
+++ b/apps/web/src/stores/auth.test.ts
@@ -80,6 +80,22 @@ describe('auth store fetchWithAuth', () => {
     expect(secondUrl).toBe('/api/v1/api-keys');
   });
 
+  it('does not double the /v1 for server-stored /api/v1/ paths (e.g. avatar_url)', async () => {
+    // users.avatar_url is stored as /api/v1/users/:id/avatar and round-trips
+    // through fetchWithAuth (the avatar blob fetch). Without the /api/v1/
+    // branch in buildApiUrl it became /api/v1/v1/users/:id/avatar → 404 and a
+    // broken avatar.
+    useAuthStore.getState().login(baseUser, baseTokens);
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchWithAuth('/api/v1/users/user-9/avatar');
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe('/api/v1/users/user-9/avatar');
+    expect(url).not.toContain('/v1/v1/');
+  });
+
   it('refreshes and retries when access token is expired', async () => {
     useAuthStore.getState().login(baseUser, baseTokens);
     const refreshedTokens: Tokens = {

--- a/apps/web/src/stores/auth.test.ts
+++ b/apps/web/src/stores/auth.test.ts
@@ -63,6 +63,24 @@ describe('auth store fetchWithAuth', () => {
     expect(headers.get('Content-Type')).toBe('application/json');
   });
 
+  it('does not force a JSON content-type on FormData bodies (avatar upload)', async () => {
+    // Forcing application/json on a multipart body strips the boundary the
+    // browser would otherwise add, so the server cannot parse the upload and
+    // 400s. The avatar POST must leave Content-Type unset for FormData.
+    useAuthStore.getState().login(baseUser, baseTokens);
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const form = new FormData();
+    form.append('file', new Blob(['x'], { type: 'image/png' }), 'a.png');
+    await fetchWithAuth('/users/me/avatar', { method: 'POST', body: form });
+
+    const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = options.headers as Headers;
+    expect(headers.get('Authorization')).toBe(`Bearer ${baseTokens.accessToken}`);
+    expect(headers.get('Content-Type')).toBeNull();
+  });
+
   it('strips only exact /api prefix while preserving /api-* routes', async () => {
     useAuthStore.getState().login(baseUser, baseTokens);
     const fetchMock = vi

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -195,13 +195,20 @@ function buildApiUrl(path: string): string {
   // Ensure path starts with /
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;
 
-  // Remove only the exact "/api" prefix boundary to avoid "/api/v1/api/..."
-  // while preserving legitimate paths like "/api-keys".
+  // Remove only the exact "/api" or "/api/v1" prefix boundary to avoid
+  // both "/api/v1/api/..." and "/api/v1/v1/..." while preserving legitimate
+  // paths like "/api-keys". The "/api/v1/" case matters for server-stored
+  // URLs (e.g. users.avatar_url = "/api/v1/users/:id/avatar") that the SPA
+  // round-trips through buildApiUrl.
   const cleanPath = normalizedPath === '/api'
     ? ''
-    : normalizedPath.startsWith('/api/')
-      ? normalizedPath.slice(4)
-      : normalizedPath;
+    : normalizedPath === '/api/v1'
+      ? ''
+      : normalizedPath.startsWith('/api/v1/')
+        ? normalizedPath.slice(7)
+        : normalizedPath.startsWith('/api/')
+          ? normalizedPath.slice(4)
+          : normalizedPath;
 
   const apiHost = resolveApiHost();
   return `${apiHost}/api/v1${cleanPath}`;

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -327,7 +327,12 @@ export async function fetchWithAuth(rawUrl: string, options: RequestInit = {}): 
     headers.set('Authorization', `Bearer ${tokens.accessToken}`);
   }
 
-  headers.set('Content-Type', 'application/json');
+  // Don't force a JSON content-type on FormData uploads — the browser must set
+  // `multipart/form-data` itself so it can append the boundary. Forcing JSON
+  // here strips the boundary and the server can't parse the body (avatar upload).
+  if (!(options.body instanceof FormData)) {
+    headers.set('Content-Type', 'application/json');
+  }
 
   // Use caller-provided signal or create a 30-second timeout to prevent indefinite hangs
   const externalSignal = options.signal;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,7 @@ services:
       MFA_RECOVERY_CODE_PEPPER: ${MFA_RECOVERY_CODE_PEPPER:?Set MFA_RECOVERY_CODE_PEPPER in .env}
       TRANSFER_STORAGE_PATH: /data/transfers
       PATCH_REPORT_STORAGE_PATH: /data/patch-reports
+      AVATAR_STORAGE_PATH: /data/avatars
       LOG_LEVEL: ${LOG_LEVEL:-info}
       LOG_JSON: ${LOG_JSON:-true}
       METRICS_SCRAPE_TOKEN: ${METRICS_SCRAPE_TOKEN:-}


### PR DESCRIPTION
## What

Replaces the URL-only avatar field on **Settings → Profile** with a real file upload. Three new endpoints back it; files are stored on the existing `api_data` volume at `/data/avatars/<userId>.<ext>`, mirroring the `fileStorage.ts` pattern used by remote transfers. **No DB migration** — reuses the existing `users.avatar_url` column (now holds an internal `/api/v1/users/<id>/avatar` URL instead of an external one).

## API

- **POST `/users/me/avatar`** — multipart upload (single `file` field)
  - MIME allowlist: `image/png`, `image/jpeg`, `image/webp` (no SVG)
  - **Magic-byte verification** — does not trust the `Content-Type` header
  - 5 MB cap via `bodyLimit` middleware (413 on overflow)
  - Atomic write (tmp + rename), unlinks a prior file at a different extension
  - Sets `users.avatar_url = /api/v1/users/<id>/avatar`; audit `user.avatar.upload`
- **GET `/users/:id/avatar`** — auth-required, streams bytes, `Cache-Control: private, max-age=300`, weak ETag + 304 support
- **DELETE `/users/me/avatar`** — unlinks file, clears `avatar_url`; audit `user.avatar.delete`

## Behavior change (please confirm the call)

`avatarUrl` is **removed from the `PATCH /users/me` schema**. Avatars now flow exclusively through the upload endpoints; the strict schema makes any client still sending `avatarUrl` get a `400` (rather than a silent drop). This is the deliberate intent — switching from "paste a URL" to "upload a file." Consequences for the existing SOC2 audit tests, all updated in this PR:

- The audit-attribution test that used `avatarUrl` as its example non-email field now uses `name` (same intent: partner-scope self-change → `user.profile.update`).
- The `rejects avatarUrl with javascript: scheme` test is removed — the `avatarUrl` URL-scheme refinement no longer exists, and "unknown field rejected" is already covered by the strict-schema test.

If you'd rather **keep** the URL field alongside upload, say so and I'll rework to additive.

## Web

`ProfilePage.tsx`: 96px preview, file picker, drag-drop onto the preview, and a Remove button (shown only when an avatar is set). Helper: "PNG, JPG, or WebP. Max 5 MB." `updateUser` fires on success/delete so the topbar avatar refreshes immediately. The URL text field is removed.

`docker-compose.yml`: adds `AVATAR_STORAGE_PATH=/data/avatars` to the api env (matches the existing `TRANSFER_STORAGE_PATH` / `PATCH_REPORT_STORAGE_PATH` pattern).

## Tests

- API `tsc` clean; **full API vitest 5803 passed / 0 failed** (9 new avatar cases: accept PNG/JPEG/WebP, reject SVG, reject Content-Type/byte mismatch, reject empty, reject missing field, DELETE, POST→GET roundtrip; storage path is a per-run tmpdir).
- Web `astro check` 0 errors; **web vitest 721 passed / 0 failed** (4 new ProfilePage cases).
- No new dependencies (`hono/body-limit`, `hono/streaming` are existing `hono` submodules). No DB migration.
