### PR TITLE
feat(web): table + page density preference (Comfortable/Compact/Dense)

### DIFF
--- a/apps/web/public/theme-bootstrap.js
+++ b/apps/web/public/theme-bootstrap.js
@@ -7,12 +7,27 @@
     document.documentElement.classList.toggle('dark', dark);
   }
 
+  // Apply data-density on <html> before first paint so page-level CSS
+  // density rules in globals.css take effect without a flash of the
+  // comfortable layout. Mirrors breeze.density localStorage key set by
+  // apps/web/src/lib/density.ts. Default is comfortable (no attribute
+  // needed, but we set it for consistency / selector simplicity).
+  function applyDensity() {
+    var d = localStorage.getItem('breeze.density');
+    if (d !== 'comfortable' && d !== 'compact' && d !== 'dense') {
+      d = 'comfortable';
+    }
+    document.documentElement.setAttribute('data-density', d);
+  }
+
   applyTheme();
+  applyDensity();
 
   if (!window.__themeSwap) {
     window.__themeSwap = true;
     document.addEventListener('astro:after-swap', function () {
       applyTheme();
+      applyDensity();
       var main = document.querySelector('main');
       if (main) main.scrollTop = 0;
     });

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, useEffect, useRef } from 'react';
-import { Search, ChevronLeft, ChevronRight, ChevronUp, ChevronDown, ArrowUpDown, MoreHorizontal, MoreVertical, Filter, Terminal, FileCode, RotateCcw, Settings, Trash2, Zap, Columns3 } from 'lucide-react';
+import { Search, ChevronLeft, ChevronRight, ChevronUp, ChevronDown, ArrowUpDown, MoreHorizontal, MoreVertical, Filter, Terminal, FileCode, RotateCcw, Settings, Trash2, Zap, Columns3, Rows3, Rows4, AlignJustify } from 'lucide-react';
 import type { DesktopAccessState, FilterConditionGroup, RemoteAccessPolicy } from '@breeze/shared';
 import { fetchWithAuth } from '../../stores/auth';
 import ConnectDesktopButton from '../remote/ConnectDesktopButton';
@@ -20,6 +20,14 @@ import {
   writeColumnVisibility,
   type ColumnId,
 } from './columnVisibility';
+import {
+  DENSITY_OPTIONS,
+  densityTableClasses,
+  readDensity,
+  subscribeDensity,
+  writeDensity,
+  type Density,
+} from '@/lib/density';
 import { OSIcon } from './osIcons';
 
 export type DeviceStatus = 'online' | 'offline' | 'maintenance' | 'decommissioned' | 'quarantined' | 'updating' | 'pending';
@@ -202,6 +210,15 @@ export default function DeviceList({
   const [columnOrder, setColumnOrder] = useState<ColumnId[]>(() => readColumnOrder());
   const [columnsMenuOpen, setColumnsMenuOpen] = useState(false);
   const columnsMenuRef = useRef<HTMLDivElement>(null);
+  // Table density preference (account-wide via localStorage). Subscribe so
+  // a sibling instance on the same page that flips density updates this
+  // one without a reload.
+  const [density, setDensity] = useState<Density>(() => readDensity());
+  useEffect(() => subscribeDensity(setDensity), []);
+  const handleDensityChange = (next: Density) => {
+    setDensity(next);
+    writeDensity(next);
+  };
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkMenuOpen, setBulkMenuOpen] = useState(false);
   const [rowMenuOpenId, setRowMenuOpenId] = useState<string | null>(null);
@@ -819,6 +836,32 @@ export default function DeviceList({
                 </span>
               )}
             </button>
+            {/* Density toggle: comfortable / compact / dense. Single
+                account-wide preference (breeze.density in localStorage),
+                applied to descendant td/th via Tailwind arbitrary
+                variants on the table element. */}
+            <div className="inline-flex h-10 items-center rounded-md border" role="group" aria-label="Row density">
+              {DENSITY_OPTIONS.map((opt, idx) => {
+                const Icon = opt === 'comfortable' ? Rows3 : opt === 'compact' ? Rows4 : AlignJustify;
+                const label = opt.charAt(0).toUpperCase() + opt.slice(1);
+                const isActive = density === opt;
+                return (
+                  <button
+                    key={opt}
+                    type="button"
+                    onClick={() => handleDensityChange(opt)}
+                    aria-pressed={isActive}
+                    aria-label={`${label} row density`}
+                    title={`${label} row density`}
+                    className={`flex h-full items-center justify-center px-2.5 text-sm transition ${
+                      isActive ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted/60'
+                    } ${idx === 0 ? 'rounded-l-md' : ''} ${idx === DENSITY_OPTIONS.length - 1 ? 'rounded-r-md' : 'border-r'}`}
+                  >
+                    <Icon className="h-3.5 w-3.5" />
+                  </button>
+                );
+              })}
+            </div>
             <div className="relative" ref={columnsMenuRef}>
               <button
                 type="button"
@@ -1113,7 +1156,7 @@ export default function DeviceList({
       )}
 
       <div className="mt-6 overflow-x-auto rounded-md border">
-        <table className="w-full divide-y">
+        <table className={`w-full divide-y ${densityTableClasses(density)}`}>
           <thead className="bg-muted/40">
             <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
               <th className="px-3 py-3">

--- a/apps/web/src/lib/density.test.ts
+++ b/apps/web/src/lib/density.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_DENSITY,
+  DENSITY_OPTIONS,
+  DENSITY_STORAGE_KEY,
+  applyDensityAttribute,
+  densityTableClasses,
+  isValidDensity,
+  readDensity,
+  subscribeDensity,
+  writeDensity,
+} from './density';
+
+// Tiny in-memory localStorage installed onto `window` before each test.
+// Same rationale as pageSizePreference.test.ts: under Node 22+ the
+// `localStorage` global is intercepted before jsdom attaches its own, so
+// `window.localStorage` reads as `undefined`. The unit under test guards
+// with `typeof`, and production always runs in a real browser, so we
+// substitute a behaviourally-equivalent stub here.
+function makeMemoryStorage(): Storage {
+  const data = new Map<string, string>();
+  return {
+    get length() {
+      return data.size;
+    },
+    clear() {
+      data.clear();
+    },
+    getItem(key: string) {
+      return data.has(key) ? (data.get(key) as string) : null;
+    },
+    setItem(key: string, value: string) {
+      data.set(key, String(value));
+    },
+    removeItem(key: string) {
+      data.delete(key);
+    },
+    key(i: number) {
+      return Array.from(data.keys())[i] ?? null;
+    },
+  };
+}
+
+describe('density', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'localStorage', {
+      value: makeMemoryStorage(),
+      writable: true,
+      configurable: true,
+    });
+    document.documentElement.removeAttribute('data-density');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('isValidDensity', () => {
+    it('accepts every option in DENSITY_OPTIONS', () => {
+      for (const opt of DENSITY_OPTIONS) {
+        expect(isValidDensity(opt)).toBe(true);
+      }
+    });
+
+    it('rejects values not in DENSITY_OPTIONS', () => {
+      expect(isValidDensity('cozy')).toBe(false);
+      expect(isValidDensity('')).toBe(false);
+      expect(isValidDensity(2)).toBe(false);
+      expect(isValidDensity(null)).toBe(false);
+      expect(isValidDensity(undefined)).toBe(false);
+      expect(isValidDensity({})).toBe(false);
+    });
+  });
+
+  describe('readDensity', () => {
+    it('returns DEFAULT_DENSITY when localStorage has no entry', () => {
+      expect(readDensity()).toBe(DEFAULT_DENSITY);
+    });
+
+    it('returns the stored value when valid', () => {
+      window.localStorage.setItem(DENSITY_STORAGE_KEY, 'dense');
+      expect(readDensity()).toBe('dense');
+    });
+
+    it('falls back to DEFAULT_DENSITY when the stored value is not recognized', () => {
+      window.localStorage.setItem(DENSITY_STORAGE_KEY, 'banana');
+      expect(readDensity()).toBe(DEFAULT_DENSITY);
+    });
+
+    it('returns DEFAULT_DENSITY when localStorage.getItem throws (Safari private mode)', () => {
+      vi.spyOn(window.localStorage, 'getItem').mockImplementation(() => {
+        throw new DOMException('SecurityError', 'SecurityError');
+      });
+      expect(readDensity()).toBe(DEFAULT_DENSITY);
+    });
+  });
+
+  describe('writeDensity', () => {
+    it('persists the chosen density', () => {
+      writeDensity('compact');
+      expect(window.localStorage.getItem(DENSITY_STORAGE_KEY)).toBe('compact');
+      expect(readDensity()).toBe('compact');
+    });
+
+    it('mirrors the value to the data-density attribute on <html>', () => {
+      writeDensity('dense');
+      expect(document.documentElement.getAttribute('data-density')).toBe('dense');
+    });
+
+    it('ignores an invalid value (no persist, no attribute change)', () => {
+      writeDensity('cozy' as never);
+      expect(window.localStorage.getItem(DENSITY_STORAGE_KEY)).toBeNull();
+      expect(document.documentElement.getAttribute('data-density')).toBeNull();
+    });
+
+    it('still applies the attribute and notifies when setItem throws (quota/SecurityError)', () => {
+      vi.spyOn(window.localStorage, 'setItem').mockImplementation(() => {
+        throw new DOMException('QuotaExceededError', 'QuotaExceededError');
+      });
+      const seen: string[] = [];
+      const unsub = subscribeDensity((v) => seen.push(v));
+      writeDensity('compact');
+      expect(document.documentElement.getAttribute('data-density')).toBe('compact');
+      expect(seen).toEqual(['compact']);
+      unsub();
+    });
+  });
+
+  describe('applyDensityAttribute', () => {
+    it('sets data-density on documentElement', () => {
+      applyDensityAttribute('compact');
+      expect(document.documentElement.getAttribute('data-density')).toBe('compact');
+    });
+  });
+
+  describe('subscribeDensity', () => {
+    it('invokes the subscriber with the new value on writeDensity', () => {
+      const seen: string[] = [];
+      const unsub = subscribeDensity((v) => seen.push(v));
+      writeDensity('dense');
+      writeDensity('compact');
+      expect(seen).toEqual(['dense', 'compact']);
+      unsub();
+    });
+
+    it('stops invoking after unsubscribe', () => {
+      const seen: string[] = [];
+      const unsub = subscribeDensity((v) => seen.push(v));
+      writeDensity('dense');
+      unsub();
+      writeDensity('compact');
+      expect(seen).toEqual(['dense']);
+    });
+
+    it('a throwing subscriber does not break writeDensity or other subscribers', () => {
+      const seen: string[] = [];
+      const unsubBad = subscribeDensity(() => {
+        throw new Error('boom');
+      });
+      const unsubGood = subscribeDensity((v) => seen.push(v));
+      expect(() => writeDensity('dense')).not.toThrow();
+      expect(seen).toEqual(['dense']);
+      unsubBad();
+      unsubGood();
+    });
+  });
+
+  describe('densityTableClasses', () => {
+    it('returns no overrides for comfortable (matches pre-feature default)', () => {
+      expect(densityTableClasses('comfortable')).toBe('');
+    });
+
+    it('tightens vertical padding for compact', () => {
+      expect(densityTableClasses('compact')).toBe('[&_td]:py-2 [&_th]:py-2');
+    });
+
+    it('tightens padding and font size for dense', () => {
+      expect(densityTableClasses('dense')).toBe('[&_td]:py-1.5 [&_th]:py-1.5 [&_td]:text-xs');
+    });
+  });
+});

--- a/apps/web/src/lib/density.ts
+++ b/apps/web/src/lib/density.ts
@@ -1,0 +1,108 @@
+// Per-user table density preference. Persisted in localStorage under a
+// single account-wide key (not per-table) so the choice applies anywhere
+// a table opts in. Mirrors the pageSizePreference / columnVisibility
+// pattern: SSR-safe getter, silent-fail setter, and a small subscribe
+// helper so unrelated component instances can re-render when one of
+// them changes the preference.
+
+export const DENSITY_OPTIONS = ['comfortable', 'compact', 'dense'] as const;
+export type Density = (typeof DENSITY_OPTIONS)[number];
+
+export const DEFAULT_DENSITY: Density = 'comfortable';
+export const DENSITY_STORAGE_KEY = 'breeze.density';
+
+export function isValidDensity(value: unknown): value is Density {
+  return typeof value === 'string' && (DENSITY_OPTIONS as readonly string[]).includes(value);
+}
+
+// readDensity returns the stored preference if present and recognized,
+// otherwise DEFAULT_DENSITY. SSR-safe: localStorage access during server
+// render or in Safari private mode (SecurityError on getItem) falls back
+// to the default.
+export function readDensity(): Density {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return DEFAULT_DENSITY;
+  }
+  try {
+    const raw = window.localStorage.getItem(DENSITY_STORAGE_KEY);
+    if (raw === null) return DEFAULT_DENSITY;
+    return isValidDensity(raw) ? raw : DEFAULT_DENSITY;
+  } catch {
+    return DEFAULT_DENSITY;
+  }
+}
+
+// writeDensity persists the chosen density. Silently swallows quota /
+// SecurityError errors — the choice still applies in component state,
+// only persistence across reload is lost. Notifies subscribers so other
+// table instances on the same page re-read and re-render. Also mirrors
+// the value to a data-density attribute on <html> so the page-level CSS
+// rules in globals.css can tighten outer padding, card padding, gaps,
+// header height, sidebar nav rows, and modal padding.
+export function writeDensity(value: Density): void {
+  if (!isValidDensity(value)) return;
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') return;
+  try {
+    window.localStorage.setItem(DENSITY_STORAGE_KEY, value);
+  } catch {
+    // Quota / SecurityError — ignore.
+  }
+  applyDensityAttribute(value);
+  for (const fn of subscribers) {
+    try {
+      fn(value);
+    } catch {
+      // Subscriber errors must not break setter.
+    }
+  }
+}
+
+// applyDensityAttribute sets data-density on <html> so descendant CSS
+// rules can target it. theme-bootstrap.js also does this inline on
+// first paint to avoid FOUC; this function exists so subsequent
+// React-driven changes stay in sync.
+export function applyDensityAttribute(value: Density): void {
+  if (typeof document === 'undefined') return;
+  try {
+    document.documentElement.setAttribute('data-density', value);
+  } catch {
+    // Unusable DOM (jsdom edge cases) — ignore.
+  }
+}
+
+const subscribers = new Set<(value: Density) => void>();
+
+// subscribeDensity registers a listener invoked synchronously after a
+// successful writeDensity call in the same tab. Returns an unsubscribe
+// function. Does not cover cross-tab updates (would need a `storage`
+// event listener); v1 scope is the one-tab case.
+export function subscribeDensity(fn: (value: Density) => void): () => void {
+  subscribers.add(fn);
+  return () => {
+    subscribers.delete(fn);
+  };
+}
+
+// densityTableClasses returns the Tailwind utility string applied to the
+// <table> element. Uses arbitrary-variant child selectors so every td/th
+// inside the table picks up the override without touching individual
+// cell className strings. Comfortable matches the pre-feature defaults
+// (py-3, text-sm) so existing visual is unchanged.
+//
+// Padding scale (vertical):
+//   comfortable: py-3  (12px)  — existing
+//   compact:     py-2  (8px)   — ~33% less
+//   dense:       py-1.5 (6px) — ~50% less
+//
+// Font size only shrinks at dense to keep compact readable.
+export function densityTableClasses(density: Density): string {
+  switch (density) {
+    case 'compact':
+      return '[&_td]:py-2 [&_th]:py-2';
+    case 'dense':
+      return '[&_td]:py-1.5 [&_th]:py-1.5 [&_td]:text-xs';
+    case 'comfortable':
+    default:
+      return '';
+  }
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -8767,3 +8767,177 @@ select {
     height: 100% !important;
   }
 }
+
+/* ---------------------------------------------------------------------------
+   Page-level density rules.
+
+   The density preference (apps/web/src/lib/density.ts, breeze.density in
+   localStorage) is mirrored to <html data-density="..."> by both
+   theme-bootstrap.js (pre-paint) and writeDensity() (on change). These
+   rules tighten outer padding, card padding, section gaps, header
+   height, and sidebar nav rows across every page that uses the
+   DashboardLayout.
+
+   Targets are matched by the Tailwind utility classes the components
+   already use (e.g. .p-6, .gap-6, .space-y-3) — no component code
+   changes needed. Comfortable is the default and has NO overrides
+   here; the rules only activate on compact/dense so the default
+   layout is byte-for-byte unchanged.
+
+   Scoping: the body padding/gap/space rules are scoped under `main` so
+   the Sidebar (.sidebar-nav, narrow padding by design), the Header
+   (precise icon-button padding), and floating UI (dialogs, toasts,
+   tooltips, command palette) don't get clobbered. Only page body
+   content tightens.
+
+   Coverage: an audit of class frequency across the page components
+   (Dashboard, Alerts, Audit, Incidents, etc.) showed the most-used
+   spacing utilities are px-3, gap-2, py-3, py-2, space-y-2, gap-3,
+   space-y-3 — none of which the original v1 of this block touched.
+   This revision adds those plus the rest of the common scale (p-2/3/8,
+   px/py-2/3/8/12/16, gap-2/3/8, space-y-2/3/5/8, mt/mb-3/4/6) so the
+   visual change shows on Dashboard, Alerts, Audit Trail, Settings,
+   Reports, and similar list/card-heavy pages, not just Devices.
+
+   Scale (rough): compact ≈ 25–35% tighter than comfortable, dense ≈
+   40–55% tighter. Values use Tailwind's spacing scale so they read
+   naturally next to the utility classes they override.
+
+   `!important` is used because the override has to beat Tailwind
+   utility selectors of identical specificity that are emitted later
+   in the cascade. The data-attribute + descendant + class selector
+   would already win by specificity, but minification and HMR
+   ordering have made bare specificity unreliable before.
+   --------------------------------------------------------------------------- */
+
+/* Compact ------------------------------------------------------------------ */
+
+/* Main content wrapper: p-4 md:p-6 → p-3 md:p-4 */
+[data-density='compact'] main.flex-1 {
+  padding: 0.75rem !important;
+}
+@media (min-width: 768px) {
+  [data-density='compact'] main.flex-1 {
+    padding: 1rem !important;
+  }
+}
+
+/* Cards / panels / inner content. Scoped under main so the Header,
+   Sidebar, dialogs, and Toasts keep their tuned spacing — only page
+   body content tightens. The p-/px-/py- utilities are the same Tailwind
+   atomic classes the components already emit, so no component edits. */
+[data-density='compact'] main .p-8 { padding: 1.25rem !important; }
+[data-density='compact'] main .p-6 { padding: 1rem !important; }
+[data-density='compact'] main .p-5 { padding: 0.875rem !important; }
+[data-density='compact'] main .p-4 { padding: 0.75rem !important; }
+[data-density='compact'] main .p-3 { padding: 0.5rem !important; }
+[data-density='compact'] main .p-2 { padding: 0.375rem !important; }
+
+[data-density='compact'] main .px-8 { padding-left: 1.25rem !important; padding-right: 1.25rem !important; }
+[data-density='compact'] main .px-6 { padding-left: 1rem !important; padding-right: 1rem !important; }
+[data-density='compact'] main .px-4 { padding-left: 0.75rem !important; padding-right: 0.75rem !important; }
+[data-density='compact'] main .px-3 { padding-left: 0.5rem !important; padding-right: 0.5rem !important; }
+[data-density='compact'] main .px-2 { padding-left: 0.375rem !important; padding-right: 0.375rem !important; }
+
+[data-density='compact'] main .py-16 { padding-top: 2.5rem !important; padding-bottom: 2.5rem !important; }
+[data-density='compact'] main .py-12 { padding-top: 1.75rem !important; padding-bottom: 1.75rem !important; }
+[data-density='compact'] main .py-8 { padding-top: 1.25rem !important; padding-bottom: 1.25rem !important; }
+[data-density='compact'] main .py-6 { padding-top: 1rem !important; padding-bottom: 1rem !important; }
+[data-density='compact'] main .py-4 { padding-top: 0.75rem !important; padding-bottom: 0.75rem !important; }
+[data-density='compact'] main .py-3 { padding-top: 0.5rem !important; padding-bottom: 0.5rem !important; }
+[data-density='compact'] main .py-2 { padding-top: 0.375rem !important; padding-bottom: 0.375rem !important; }
+
+/* Section gaps and stacks — the workhorses on every page */
+[data-density='compact'] main .gap-8 { gap: 1.25rem !important; }
+[data-density='compact'] main .gap-6 { gap: 1rem !important; }
+[data-density='compact'] main .gap-4 { gap: 0.75rem !important; }
+[data-density='compact'] main .gap-3 { gap: 0.5rem !important; }
+[data-density='compact'] main .gap-2 { gap: 0.375rem !important; }
+
+[data-density='compact'] main .space-y-8 > * + * { margin-top: 1.25rem !important; }
+[data-density='compact'] main .space-y-6 > * + * { margin-top: 1rem !important; }
+[data-density='compact'] main .space-y-5 > * + * { margin-top: 0.875rem !important; }
+[data-density='compact'] main .space-y-4 > * + * { margin-top: 0.75rem !important; }
+[data-density='compact'] main .space-y-3 > * + * { margin-top: 0.5rem !important; }
+[data-density='compact'] main .space-y-2 > * + * { margin-top: 0.375rem !important; }
+
+/* Block margins commonly used around headings + section spacers */
+[data-density='compact'] main .mt-6 { margin-top: 1rem !important; }
+[data-density='compact'] main .mt-4 { margin-top: 0.75rem !important; }
+[data-density='compact'] main .mt-3 { margin-top: 0.5rem !important; }
+[data-density='compact'] main .mb-6 { margin-bottom: 1rem !important; }
+[data-density='compact'] main .mb-4 { margin-bottom: 0.75rem !important; }
+[data-density='compact'] main .mb-3 { margin-bottom: 0.5rem !important; }
+
+/* Header — slightly shorter */
+[data-density='compact'] header.h-16 {
+  height: 3.5rem !important;
+}
+
+/* Sidebar nav rows: px-3 py-2 → px-2 py-1.5 */
+[data-density='compact'] .sidebar-nav a {
+  padding-top: 0.375rem !important;
+  padding-bottom: 0.375rem !important;
+}
+
+/* Dense -------------------------------------------------------------------- */
+
+[data-density='dense'] main.flex-1 {
+  padding: 0.5rem !important;
+}
+@media (min-width: 768px) {
+  [data-density='dense'] main.flex-1 {
+    padding: 0.75rem !important;
+  }
+}
+
+[data-density='dense'] main .p-8 { padding: 0.875rem !important; }
+[data-density='dense'] main .p-6 { padding: 0.75rem !important; }
+[data-density='dense'] main .p-5 { padding: 0.625rem !important; }
+[data-density='dense'] main .p-4 { padding: 0.5rem !important; }
+[data-density='dense'] main .p-3 { padding: 0.375rem !important; }
+[data-density='dense'] main .p-2 { padding: 0.25rem !important; }
+
+[data-density='dense'] main .px-8 { padding-left: 0.875rem !important; padding-right: 0.875rem !important; }
+[data-density='dense'] main .px-6 { padding-left: 0.75rem !important; padding-right: 0.75rem !important; }
+[data-density='dense'] main .px-4 { padding-left: 0.5rem !important; padding-right: 0.5rem !important; }
+[data-density='dense'] main .px-3 { padding-left: 0.375rem !important; padding-right: 0.375rem !important; }
+[data-density='dense'] main .px-2 { padding-left: 0.25rem !important; padding-right: 0.25rem !important; }
+
+[data-density='dense'] main .py-16 { padding-top: 1.75rem !important; padding-bottom: 1.75rem !important; }
+[data-density='dense'] main .py-12 { padding-top: 1.25rem !important; padding-bottom: 1.25rem !important; }
+[data-density='dense'] main .py-8 { padding-top: 0.875rem !important; padding-bottom: 0.875rem !important; }
+[data-density='dense'] main .py-6 { padding-top: 0.75rem !important; padding-bottom: 0.75rem !important; }
+[data-density='dense'] main .py-4 { padding-top: 0.5rem !important; padding-bottom: 0.5rem !important; }
+[data-density='dense'] main .py-3 { padding-top: 0.375rem !important; padding-bottom: 0.375rem !important; }
+[data-density='dense'] main .py-2 { padding-top: 0.25rem !important; padding-bottom: 0.25rem !important; }
+
+[data-density='dense'] main .gap-8 { gap: 0.875rem !important; }
+[data-density='dense'] main .gap-6 { gap: 0.75rem !important; }
+[data-density='dense'] main .gap-4 { gap: 0.5rem !important; }
+[data-density='dense'] main .gap-3 { gap: 0.375rem !important; }
+[data-density='dense'] main .gap-2 { gap: 0.25rem !important; }
+
+[data-density='dense'] main .space-y-8 > * + * { margin-top: 0.875rem !important; }
+[data-density='dense'] main .space-y-6 > * + * { margin-top: 0.75rem !important; }
+[data-density='dense'] main .space-y-5 > * + * { margin-top: 0.625rem !important; }
+[data-density='dense'] main .space-y-4 > * + * { margin-top: 0.5rem !important; }
+[data-density='dense'] main .space-y-3 > * + * { margin-top: 0.375rem !important; }
+[data-density='dense'] main .space-y-2 > * + * { margin-top: 0.25rem !important; }
+
+[data-density='dense'] main .mt-6 { margin-top: 0.75rem !important; }
+[data-density='dense'] main .mt-4 { margin-top: 0.5rem !important; }
+[data-density='dense'] main .mt-3 { margin-top: 0.375rem !important; }
+[data-density='dense'] main .mb-6 { margin-bottom: 0.75rem !important; }
+[data-density='dense'] main .mb-4 { margin-bottom: 0.5rem !important; }
+[data-density='dense'] main .mb-3 { margin-bottom: 0.375rem !important; }
+
+[data-density='dense'] header.h-16 {
+  height: 3rem !important;
+}
+
+[data-density='dense'] .sidebar-nav a {
+  padding-top: 0.25rem !important;
+  padding-bottom: 0.25rem !important;
+}
+


### PR DESCRIPTION
## What

Adds an account-wide **UI density** preference (Comfortable / Compact / Dense) for data tables and overall page chrome. Persisted in `localStorage` and mirrored to a `data-density` attribute on `<html>`, so CSS tightens spacing without touching every component's className.

## How

- **New `lib/density.ts`** — SSR-safe `readDensity`/`writeDensity`, a `subscribeDensity` helper so unrelated table instances re-render when one changes the preference, and `densityTableClasses()` returning arbitrary-variant child selectors (`[&_td]:py-2` etc.) so every cell in an opted-in `<table>` picks up the override. **Comfortable == the pre-feature default**, so existing visuals are unchanged unless a user opts in.
- **`DeviceList.tsx`** wires the toggle into its table.
- **`globals.css`** adds page-level rules scoped under `[data-density]` (outer/card padding, gaps, header height, sidebar nav rows, modal padding) so Compact/Dense tighten more than just table rows.
- **`theme-bootstrap.js`** applies `data-density` inline on first paint to avoid a flash of the comfortable layout before React hydrates (same pattern as the existing theme bootstrap).

## Tests

- **New `density.test.ts` — 17 cases**: `isValidDensity`; `readDensity` (default / stored / malformed / `getItem` throws in Safari private mode); `writeDensity` (persist, attribute mirror, invalid-ignored, `setItem`-throw still applies attribute + notifies subscribers); `applyDensityAttribute`; `subscribeDensity` (notify / unsubscribe / a throwing subscriber doesn't break the setter); `densityTableClasses`. Uses the project's `makeMemoryStorage` stub pattern (Node 22 shadows the `localStorage` global).
- Full web vitest **735 passed / 0 failed**; `astro check` 0 errors. Web-only — no API, agent, or DB-migration changes.

Notes: density is a single account-wide key (not per-table), mirroring the existing `pageSizePreference` / `columnVisibility` patterns. Cross-tab sync (a `storage` listener) is intentionally out of scope for v1.
