### PR TITLE
feat(web): Current-org / All-orgs scope toggle on Devices page

### DIFF
--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -92,6 +92,11 @@ type DeviceListProps = {
   // (see pageSizePreference.ts); subsequent changes to this prop are ignored.
   pageSize?: number;
   serverFilter?: FilterConditionGroup | null;
+  // External lock for the org filter. When set, overrides the user's
+  // dropdown selection and hides the dropdown itself (the parent owns
+  // the choice — e.g. via the Current-org / All-orgs scope toggle on
+  // DevicesPage). `null` means "do not lock; user controls via dropdown."
+  lockedOrgFilter?: string | null;
 };
 
 const statusColors: Record<DeviceStatus, string> = {
@@ -174,7 +179,8 @@ export default function DeviceList({
   onAction,
   onBulkAction,
   pageSize = 10,
-  serverFilter = null
+  serverFilter = null,
+  lockedOrgFilter = null
 }: DeviceListProps) {
   // Use provided timezone or browser default
   const effectiveTimezone = timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -356,7 +362,13 @@ export default function DeviceList({
         : device.status === statusFilter;
       const matchesOs = osFilter === 'all' ? true : device.os === osFilter;
       const matchesRole = roleFilter === 'all' ? true : device.deviceRole === roleFilter;
-      const matchesOrg = orgFilter === 'all' ? true : device.orgId === orgFilter;
+      // When the parent locks the org filter (Current-org scope on DevicesPage),
+      // its choice wins over the internal dropdown. `null` lock means the user
+      // controls via the dropdown.
+      const effectiveOrgFilter = lockedOrgFilter ?? orgFilter;
+      const matchesOrg = effectiveOrgFilter === 'all' || !effectiveOrgFilter
+        ? true
+        : device.orgId === effectiveOrgFilter;
       const matchesSite = siteFilter === 'all' ? true : device.siteId === siteFilter;
       const matchesGroup = groupFilter.length === 0
         ? true
@@ -364,7 +376,7 @@ export default function DeviceList({
 
       return matchesQuery && matchesStatus && matchesOs && matchesRole && matchesOrg && matchesSite && matchesGroup;
     });
-  }, [devices, query, statusFilter, osFilter, roleFilter, orgFilter, siteFilter, groupFilter, groupMembershipMap, serverFilterIds]);
+  }, [devices, query, statusFilter, osFilter, roleFilter, orgFilter, siteFilter, groupFilter, groupMembershipMap, serverFilterIds, lockedOrgFilter]);
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {
@@ -933,7 +945,7 @@ export default function DeviceList({
                   </option>
                 ))}
               </select>
-              {orgs.length > 0 && (
+              {orgs.length > 0 && lockedOrgFilter === null && (
                 <select
                   value={orgFilter}
                   aria-label="Filter by organization"

--- a/apps/web/src/components/devices/DevicesPage.toggle.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.toggle.test.tsx
@@ -1,0 +1,194 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchWithAuth } from '../../stores/auth';
+
+// Stub the heavy deps so the test only exercises the Current-org / All-orgs
+// toggle wiring on DevicesPage (state, hash sync, lockedOrgFilter prop).
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+
+const useOrgStoreMock = vi.fn();
+vi.mock('../../stores/orgStore', () => ({ useOrgStore: () => useOrgStoreMock() }));
+
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+
+vi.mock('../../hooks/useEventStream', () => ({
+  useEventStream: () => ({
+    subscribe: vi.fn(() => () => undefined),
+    unsubscribe: vi.fn(),
+    status: 'open' as const,
+  }),
+}));
+
+// DeviceList rendering would pull in localStorage / FilterBuilder / charts.
+// The toggle test only cares that the lockedOrgFilter prop is threaded
+// through correctly, so render a thin probe in its place.
+vi.mock('./DeviceList', () => ({
+  __esModule: true,
+  default: (props: { lockedOrgFilter: string | null; devices: Array<{ id: string }> }) => (
+    <div
+      data-testid="device-list-stub"
+      data-locked-org={String(props.lockedOrgFilter)}
+      data-device-count={props.devices.length}
+    />
+  ),
+}));
+
+vi.mock('./DeviceCard', () => ({
+  __esModule: true,
+  default: ({ device }: { device: { id: string; orgId: string } }) => (
+    <div data-testid="device-card" data-org-id={device.orgId}>{device.id}</div>
+  ),
+}));
+
+vi.mock('./ScriptPickerModal', () => ({ __esModule: true, default: () => null }));
+vi.mock('./DeviceSettingsModal', () => ({ __esModule: true, default: () => null }));
+vi.mock('./AddDeviceModal', () => ({ __esModule: true, default: () => null }));
+vi.mock('./CreateGroupModal', () => ({ __esModule: true, default: () => null }));
+vi.mock('../filters/DeviceFilterBar', () => ({
+  __esModule: true,
+  DeviceFilterBar: () => null,
+  default: () => null,
+}));
+vi.mock('../shared/ProgressBar', () => ({ __esModule: true, default: () => null }));
+
+import DevicesPage from './DevicesPage';
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+function jsonResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return ({
+    ok,
+    status,
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+}
+
+function mockApis(devices: Array<Record<string, unknown>>, orgs: Array<{ id: string; name: string }>) {
+  fetchWithAuthMock.mockImplementation((url: string) => {
+    if (url.startsWith('/devices?')) return Promise.resolve(jsonResponse({ data: devices }));
+    if (url.startsWith('/orgs/sites')) return Promise.resolve(jsonResponse({ data: [] }));
+    if (url.startsWith('/orgs')) return Promise.resolve(jsonResponse({ data: orgs }));
+    if (url.startsWith('/device-groups')) return Promise.resolve(jsonResponse({ data: [] }));
+    return Promise.resolve(jsonResponse({}));
+  });
+}
+
+describe('DevicesPage — Current-org / All-orgs scope toggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useOrgStoreMock.mockReturnValue({
+      currentOrgId: 'org-a',
+      organizations: [
+        { id: 'org-a', name: 'Acme Inc' },
+        { id: 'org-b', name: 'Beta LLC' },
+      ],
+    });
+    window.history.replaceState(null, '', '/devices');
+  });
+
+  it('defaults to Current-org scope and threads currentOrgId down to DeviceList as lockedOrgFilter', async () => {
+    mockApis(
+      [
+        { id: 'd1', orgId: 'org-a', hostname: 'pc-a-1', osType: 'windows', status: 'online' },
+        { id: 'd2', orgId: 'org-b', hostname: 'pc-b-1', osType: 'windows', status: 'online' },
+      ],
+      [
+        { id: 'org-a', name: 'Acme Inc' },
+        { id: 'org-b', name: 'Beta LLC' },
+      ]
+    );
+
+    render(<DevicesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('device-list-stub')).toBeInTheDocument();
+    });
+
+    const currentBtn = screen.getByTestId('org-scope-current');
+    const allBtn = screen.getByTestId('org-scope-all');
+    expect(currentBtn).toHaveAttribute('aria-pressed', 'true');
+    expect(allBtn).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByTestId('device-list-stub')).toHaveAttribute('data-locked-org', 'org-a');
+  });
+
+  it('switches to All-orgs, sets lockedOrgFilter to null, and writes #scope=all to the URL hash', async () => {
+    mockApis(
+      [{ id: 'd1', orgId: 'org-a', hostname: 'pc-a-1', osType: 'windows', status: 'online' }],
+      [{ id: 'org-a', name: 'Acme Inc' }]
+    );
+
+    render(<DevicesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('device-list-stub')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('org-scope-all'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('org-scope-all')).toHaveAttribute('aria-pressed', 'true');
+    });
+    expect(screen.getByTestId('org-scope-current')).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByTestId('device-list-stub')).toHaveAttribute('data-locked-org', 'null');
+    expect(window.location.hash).toBe('#scope=all');
+  });
+
+  it('clears the hash when toggling back from All-orgs to Current-org', async () => {
+    window.history.replaceState(null, '', '/devices#scope=all');
+    mockApis(
+      [{ id: 'd1', orgId: 'org-a', hostname: 'pc-a', osType: 'windows', status: 'online' }],
+      [{ id: 'org-a', name: 'Acme' }]
+    );
+
+    render(<DevicesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('org-scope-all')).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    fireEvent.click(screen.getByTestId('org-scope-current'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('org-scope-current')).toHaveAttribute('aria-pressed', 'true');
+    });
+    expect(window.location.hash).toBe('');
+  });
+
+  it('hydrates the toggle from #scope=all on initial mount (URL deep-link)', async () => {
+    window.history.replaceState(null, '', '/devices#scope=all');
+    mockApis(
+      [{ id: 'd1', orgId: 'org-a', hostname: 'pc-a', osType: 'windows', status: 'online' }],
+      [{ id: 'org-a', name: 'Acme' }]
+    );
+
+    render(<DevicesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('device-list-stub')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('org-scope-all')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('device-list-stub')).toHaveAttribute('data-locked-org', 'null');
+  });
+
+  it('disables the Current-org button when no currentOrgId is set (forces All-orgs view)', async () => {
+    useOrgStoreMock.mockReturnValue({
+      currentOrgId: null,
+      organizations: [{ id: 'org-a', name: 'Acme Inc' }],
+    });
+    mockApis(
+      [{ id: 'd1', orgId: 'org-a', hostname: 'pc-a', osType: 'windows', status: 'online' }],
+      [{ id: 'org-a', name: 'Acme Inc' }]
+    );
+
+    render(<DevicesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('device-list-stub')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('org-scope-current')).toBeDisabled();
+    // lockedOrgFilter is null when currentOrgId is null regardless of scope.
+    expect(screen.getByTestId('device-list-stub')).toHaveAttribute('data-locked-org', 'null');
+  });
+});

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useEventStream } from '../../hooks/useEventStream';
-import { List, Grid, Plus, AlertCircle } from 'lucide-react';
+import { List, Grid, Plus, AlertCircle, Globe, Building2 } from 'lucide-react';
 import { showToast } from '../shared/Toast';
 import type { FilterConditionGroup } from '@breeze/shared';
 import DeviceList, { type Device, type DeviceStatus, type OSType } from './DeviceList';
@@ -13,6 +13,7 @@ import CreateGroupModal from './CreateGroupModal';
 import { DeviceFilterBar } from '../filters/DeviceFilterBar';
 import { fetchWithAuth } from '../../stores/auth';
 import { fetchAllDevices } from '../../lib/devicesFetch';
+import { useOrgStore } from '../../stores/orgStore';
 import { sendDeviceCommand, sendBulkCommand, executeScript, toggleMaintenanceMode, decommissionDevice, bulkDecommissionDevices, restoreDevice, permanentDeleteDevice, sendWakeCommand, sendBulkWakeCommand, summarizeBulkWakeFailures, summarizeBulkCommandFailures, watchWakeOutcome, WakeCommandError, wakeFriendlyErrorMessage } from '../../services/deviceActions';
 import { navigateTo } from '@/lib/navigation';
 import { getErrorMessage, getErrorTitle } from '@/lib/errorMessages';
@@ -61,6 +62,51 @@ export default function DevicesPage() {
   const [showCreateGroup, setShowCreateGroup] = useState(false);
   const [autoSelectGroupId, setAutoSelectGroupId] = useState<string | null>(null);
 
+  const { currentOrgId, organizations } = useOrgStore();
+
+  // Org scope toggle: 'current' narrows the list to currentOrgId, 'all' shows
+  // every device the caller's auth scope grants access to. URL-hash synced so
+  // the choice survives reload and is shareable. Default is 'current' so the
+  // org switcher's selection visibly narrows the list (it didn't before this
+  // toggle existed — the page silently showed every accessible org).
+  const [orgScope, setOrgScope] = useState<'current' | 'all'>(() => {
+    if (typeof window === 'undefined') return 'current';
+    const params = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+    return params.get('scope') === 'all' ? 'all' : 'current';
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+    if (orgScope === 'all') {
+      params.set('scope', 'all');
+    } else {
+      params.delete('scope');
+    }
+    const next = params.toString();
+    const desired = next ? `#${next}` : '';
+    if (window.location.hash !== desired) {
+      window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}${desired}`);
+    }
+  }, [orgScope]);
+
+  // When 'current' scope is active and we have a currentOrgId, lock the
+  // DeviceList's internal org filter to it. When 'all', leave the filter
+  // unlocked so the user sees every accessible org. null = unlocked.
+  const lockedOrgFilter: string | null = orgScope === 'current' ? currentOrgId : null;
+
+  const currentOrgName = useMemo(
+    () => organizations.find((o) => o.id === currentOrgId)?.name ?? 'Current org',
+    [organizations, currentOrgId]
+  );
+
+  // Grid view doesn't pass through DeviceList's filter logic, so apply the
+  // same scope filter here for parity.
+  const scopedDevices = useMemo(
+    () => (lockedOrgFilter ? devices.filter((d) => d.orgId === lockedOrgFilter) : devices),
+    [devices, lockedOrgFilter]
+  );
+
   // Track every in-flight wake watcher so navigating away aborts the
   // long-running poll loop. Without this, each wake fired on this page
   // keeps polling /devices/:id for up to 4 minutes after unmount and
@@ -107,6 +153,13 @@ export default function DevicesPage() {
       const [devicesResult, orgsResponse, sitesResponse, groupsResponse] = await Promise.all([
         fetchAllDevices({
           includeDecommissioned: true,
+          // Opt out of the auto-injected orgId so the server returns every
+          // device in the caller's accessible scope (all accessible orgs),
+          // not just the current-org subset. The Current/All-orgs toggle
+          // narrows client-side via DeviceList's lockedOrgFilter (and
+          // scopedDevices for grid view). The server still enforces access
+          // via accessibleOrgIds, so this only widens within authorized scope.
+          skipOrgIdInjection: true,
           signal,
           // Surface the silent-cap case (#778 review). Without this, hitting
           // the safety ceiling would render an incomplete device list and
@@ -672,7 +725,43 @@ export default function DevicesPage() {
             Manage and monitor your fleet.
           </p>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <div
+            className="inline-flex rounded-md border"
+            role="group"
+            aria-label="Organization scope"
+            data-testid="org-scope-toggle"
+          >
+            <button
+              type="button"
+              onClick={() => setOrgScope('current')}
+              disabled={!currentOrgId}
+              title={currentOrgId ? `Show only ${currentOrgName}` : 'No current organization selected'}
+              aria-pressed={orgScope === 'current'}
+              data-testid="org-scope-current"
+              className={`flex h-10 items-center gap-1.5 rounded-l-md px-3 text-xs font-medium transition ${
+                orgScope === 'current' ? 'bg-muted' : 'hover:bg-muted/50'
+              } disabled:cursor-not-allowed disabled:opacity-50`}
+            >
+              <Building2 className="h-3.5 w-3.5" />
+              <span className="hidden sm:inline">Current org</span>
+              <span className="sm:hidden">Org</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => setOrgScope('all')}
+              title="Show every endpoint across all accessible organizations"
+              aria-pressed={orgScope === 'all'}
+              data-testid="org-scope-all"
+              className={`flex h-10 items-center gap-1.5 rounded-r-md border-l px-3 text-xs font-medium transition ${
+                orgScope === 'all' ? 'bg-muted' : 'hover:bg-muted/50'
+              }`}
+            >
+              <Globe className="h-3.5 w-3.5" />
+              <span className="hidden sm:inline">All orgs</span>
+              <span className="sm:hidden">All</span>
+            </button>
+          </div>
           <div className="flex rounded-md border">
             <button
               type="button"
@@ -761,10 +850,11 @@ export default function DevicesPage() {
           onCreateGroup={() => setShowCreateGroup(true)}
           autoSelectGroupId={autoSelectGroupId}
           onAutoSelectConsumed={handleAutoSelectConsumed}
+          lockedOrgFilter={lockedOrgFilter}
         />
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {devices.map(device => (
+          {scopedDevices.map(device => (
             <DeviceCard
               key={device.id}
               device={device}

--- a/apps/web/src/lib/devicesFetch.test.ts
+++ b/apps/web/src/lib/devicesFetch.test.ts
@@ -28,6 +28,23 @@ describe('fetchAllDevices', () => {
     expect(firstCall).not.toContain('cursor=');
   });
 
+  it('passes skipOrgIdInjection through to the fetcher (All-orgs view widens server scope)', async () => {
+    const fetcher = vi.fn().mockResolvedValueOnce(
+      jsonResponse({ data: [{ id: 'a' }], pagination: { page: 1, limit: 200, total: 1 } }),
+    );
+    await fetchAllDevices({ fetcher, skipOrgIdInjection: true });
+    // Third arg to fetchWithAuth carries the opt-out flag.
+    expect(fetcher.mock.calls[0][2]).toEqual({ skipOrgIdInjection: true });
+  });
+
+  it('defaults skipOrgIdInjection to undefined (keeps the org-scoped behaviour)', async () => {
+    const fetcher = vi.fn().mockResolvedValueOnce(
+      jsonResponse({ data: [{ id: 'a' }], pagination: { page: 1, limit: 200, total: 1 } }),
+    );
+    await fetchAllDevices({ fetcher });
+    expect(fetcher.mock.calls[0][2]).toEqual({ skipOrgIdInjection: undefined });
+  });
+
   it('new cursor API — walks pages until nextCursor goes null', async () => {
     const fetcher = vi
       .fn()

--- a/apps/web/src/lib/devicesFetch.ts
+++ b/apps/web/src/lib/devicesFetch.ts
@@ -76,6 +76,14 @@ export interface FetchAllDevicesOptions {
    *  arrived partial). Callers should display this rather than the
    *  pagesWalked * pageLimit product. (Todd's #778 review.) */
   onTruncated?: (info: { pagesWalked: number; pageLimit: number; actualCount: number }) => void;
+  /** Opt out of `fetchWithAuth`'s auto-injected `orgId` query param so the
+   *  server returns every device in the caller's accessible scope (across
+   *  all accessible orgs), not just the current-org subset. Used by the
+   *  Devices page's All-orgs view; the server still enforces access via the
+   *  user's accessibleOrgIds / site allowlist, so this only widens within
+   *  what the user is authorized to see. Default (false) keeps the current
+   *  org-scoped behaviour. */
+  skipOrgIdInjection?: boolean;
 }
 
 /**
@@ -124,7 +132,11 @@ export async function fetchAllDevices(
     // received on page 0.
     if (pageNum === 0) params.set('includeTotal', 'true');
 
-    const resp = await fetcher(`/devices?${params.toString()}`);
+    const resp = await fetcher(
+      `/devices?${params.toString()}`,
+      {},
+      { skipOrgIdInjection: options.skipOrgIdInjection },
+    );
     if (!resp.ok) throw resp;
     const body = (await resp.json()) as {
       data?: Record<string, unknown>[];

--- a/apps/web/src/stores/auth.test.ts
+++ b/apps/web/src/stores/auth.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Tokens, User } from './auth';
 import {
   apiAcceptInvite,
@@ -8,6 +8,7 @@ import {
   apiResetPassword,
   apiVerifyMFA,
   fetchWithAuth,
+  registerOrgIdProvider,
   restoreAccessTokenFromCookie,
   useAuthStore,
   waitForPendingRefresh
@@ -204,6 +205,54 @@ describe('auth store fetchWithAuth', () => {
     expect(second.ok).toBe(true);
     expect(useAuthStore.getState().tokens?.accessToken).toBe(refreshedTokens.accessToken);
     expect(fetchMock.mock.calls.filter(([url]) => String(url).endsWith('/api/v1/auth/refresh'))).toHaveLength(1);
+  });
+});
+
+describe('fetchWithAuth orgId injection + skipOrgIdInjection opt-out', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.removeItem('breeze-auth');
+    document.cookie = 'breeze_csrf_token=csrf-test-token; path=/';
+    useAuthStore.getState().login(baseUser, baseTokens);
+    // Simulate a selected current org so the auto-injection has something to add.
+    registerOrgIdProvider(() => 'org-x');
+  });
+
+  afterEach(() => {
+    // Reset the module-level provider so this block doesn't leak an orgId
+    // into the other fetchWithAuth tests (which assert exact URLs).
+    registerOrgIdProvider(() => null);
+  });
+
+  it('auto-injects orgId by default (preserves existing always-scoped behaviour)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchWithAuth('/devices');
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe('/api/v1/devices?orgId=org-x');
+  });
+
+  it('skips orgId injection when skipOrgIdInjection is true (All-orgs view)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchWithAuth('/devices?limit=200', {}, { skipOrgIdInjection: true });
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe('/api/v1/devices?limit=200');
+    expect(url).not.toContain('orgId=');
+  });
+
+  it('still injects orgId when skipOrgIdInjection is explicitly false', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchWithAuth('/devices', {}, { skipOrgIdInjection: false });
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain('orgId=org-x');
   });
 });
 

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -291,13 +291,33 @@ export async function restoreAccessTokenFromCookie(): Promise<boolean> {
   }
 }
 
-export async function fetchWithAuth(rawUrl: string, options: RequestInit = {}): Promise<Response> {
+export interface FetchWithAuthOptions {
+  /**
+   * Opt out of the auto-injected `orgId` query param. Use when the caller
+   * wants the server to return everything in the user's accessible scope
+   * (e.g. the All-orgs view on Devices), not just the current-org subset.
+   * Default false preserves the existing "always-scoped" behaviour for
+   * every other caller. The server still enforces access via the user's
+   * accessibleOrgIds / site allowlist (devices core.ts orgCondition), so
+   * this only widens the client's view within what the user is already
+   * authorized to see — it is not a tenant-isolation bypass.
+   */
+  skipOrgIdInjection?: boolean;
+}
+
+export async function fetchWithAuth(
+  rawUrl: string,
+  options: RequestInit = {},
+  opts: FetchWithAuthOptions = {}
+): Promise<Response> {
   // Auto-inject orgId from the org store so partner/system users always scope API calls
   let url = rawUrl;
-  const orgId = _getOrgId?.();
-  if (orgId && !url.includes('orgId=')) {
-    const separator = url.includes('?') ? '&' : '?';
-    url = `${url}${separator}orgId=${orgId}`;
+  if (!opts.skipOrgIdInjection) {
+    const orgId = _getOrgId?.();
+    if (orgId && !url.includes('orgId=')) {
+      const separator = url.includes('?') ? '&' : '?';
+      url = `${url}${separator}orgId=${orgId}`;
+    }
   }
 
   const { tokens: initialTokens, isAuthenticated, logout, setTokens } = useAuthStore.getState();


### PR DESCRIPTION
## What

An always-visible **Current-org / All-orgs** pill toggle in the Devices page header. Current-org narrows the list to the selected org; All-orgs shows every endpoint across every org the caller can access. Default is **Current-org** so the org switcher's selection visibly narrows the list. URL-hash synced (`#scope=all`) so the choice survives reload and is shareable; coexists with the existing `#add-device` deep-link.

## Tenant-isolation note (please scrutinize — it touches the orgId path)

The toggle only *widens* by **omitting** the client-injected `orgId` query param, never by bypassing server scoping:

- `fetchWithAuth` auto-injects `&orgId=<currentOrgId>` into every API call, so `GET /devices` pre-filters to the current org. I added an opt-out (`FetchWithAuthOptions { skipOrgIdInjection }`, default off) used only by the Devices page.
- The server is the real boundary: `routes/devices/core.ts` applies `auth.orgCondition(devices.orgId)` from the user's pre-computed `accessibleOrgIds` as the **base** filter on every request, and access-checks any explicit `orgId` / `orgIds` (403 on a non-accessible org). So dropping the param falls back to "all orgs this user can access" — it cannot surface a device outside the user's authorized scope. Verified against the current handler.
- Default behaviour is byte-identical for every other `fetchWithAuth` caller.

## How

- `fetchWithAuth`: new optional third arg `{ skipOrgIdInjection }`. Plumbed through `fetchAllDevices`'s options to its internal call — the cursor-walk, `AbortSignal`, and `onTruncated` truncation handling are untouched.
- `DevicesPage`: owns `orgScope: 'current' | 'all'` + hash sync, renders the two-button toggle (Building2 / Globe), threads `lockedOrgFilter` (currentOrgId when Current, null when All) into `DeviceList`, and applies the same filter to grid view via `scopedDevices`. Current-org is disabled when no org is selected (partner with no current org).
- `DeviceList`: new optional `lockedOrgFilter` prop — when set it overrides the internal org dropdown and hides it (parent owns the choice); `null` = user-controlled.

## Tests (web vitest, all green)

- `DevicesPage.toggle.test.tsx` — 5 cases: default threads currentOrgId as the lock; toggle to All nulls the lock + writes `#scope=all`; toggle back clears the hash; deep-link `#scope=all` hydrates on mount; Current-org disabled when no org.
- `auth.test.ts` — 3 cases: default injects orgId; `skipOrgIdInjection` omits it; explicit `false` still injects.
- `devicesFetch.test.ts` — 2 cases: the flag passes through to the fetcher; defaults to undefined (org-scoped) otherwise.
- Full web suite **728 passed / 0 failed**; `astro check` 0 errors. Web-only — no API, agent, or DB-migration changes.
