### PR TITLE
fix(audit-logs): honor the selected org on the activity list (orgId was stripped)

### DIFF
--- a/apps/api/src/routes/auditLogs.ts
+++ b/apps/api/src/routes/auditLogs.ts
@@ -36,7 +36,12 @@ const listLogsSchema = z.object({
   to: z.string().datetime().optional(),
   // RecentActivity widget doesn't display "X of Y total"; the count(*) is a
   // 2-3s RLS-bound scan even with an index. Pass skipCount=true to skip it.
-  skipCount: z.enum(['true', 'false']).optional()
+  skipCount: z.enum(['true', 'false']).optional(),
+  // Explicit org filter from the org-selector dropdown. fetchWithAuth
+  // auto-injects ?orgId=<current-org>; whitelist it here so zValidator keeps
+  // it — otherwise it is stripped and every page spans the caller's full
+  // accessible-org set, ignoring the dropdown selection.
+  orgId: z.string().uuid().optional()
 });
 
 const searchSchema = listLogsSchema.extend({
@@ -525,7 +530,12 @@ function paginatedListHandler(
     const query = c.req.valid('query');
     const { page, limit, offset } = getPagination(query);
 
-    const orgCond = auth.orgCondition(auditLogsTable.orgId);
+    // Explicit per-request org scope from the org-selector dropdown. If the
+    // caller asks for an org they cannot access, return 403 — do NOT silently
+    // fall back to the full accessible-org set.
+    if (query.orgId && !auth.canAccessOrg(query.orgId)) {
+      return c.json({ error: 'Access denied' }, 403);
+    }
     // BY DESIGN: the audit-log list is scoped to the org only, NOT the caller's
     // site allowlist. Audit trails are an org-level compliance record and must
     // stay complete for any org member with audit-read permission; partitioning
@@ -533,22 +543,32 @@ function paginatedListHandler(
     // 'rawActorId' device join is not a reliable site key anyway). The by-id
     // detail view applies an agent-actor site check as defence-in-depth; the
     // list intentionally does not. (Site-scope review decision, 2026-05-31.)
+    // A pinned ?orgId= narrows to that single (accessible) org; otherwise the
+    // standard condition spans every accessible org.
+    const orgCond = query.orgId
+      ? eq(auditLogsTable.orgId, query.orgId)
+      : auth.orgCondition(auditLogsTable.orgId);
     const where = buildFilterConditions(orgCond, query);
     // count(*) on audit_logs is 2-3s under RLS even with the org_timestamp
     // index. The dashboard widget that calls /logs?limit=5 doesn't need the
     // count — it never displays "X of Y total". Pass skipCount=true there.
     const skipCount = query.skipCount === 'true';
     const hasFilters = !!(query.user || query.action || query.resource || query.from || query.to);
+    // Fast-path org list: a pinned ?orgId= scopes the LATERAL per-org scan to
+    // that single org; otherwise it spans every accessible org.
+    const fastPathOrgIds: string[] | null = query.orgId
+      ? [query.orgId]
+      : (Array.isArray(auth.accessibleOrgIds) ? (auth.accessibleOrgIds as string[]) : null);
     const canUseFastPath =
       skipCount &&
       offset === 0 &&
       !hasFilters &&
-      Array.isArray(auth.accessibleOrgIds) &&
-      auth.accessibleOrgIds.length > 0;
+      fastPathOrgIds !== null &&
+      fastPathOrgIds.length > 0;
     const [total, rows] = await Promise.all([
       skipCount ? Promise.resolve(-1) : countRows(where),
       canUseFastPath
-        ? queryLatestPerOrg(auth.accessibleOrgIds as string[], limit)
+        ? queryLatestPerOrg(fastPathOrgIds as string[], limit)
         : queryRows(where, limit, offset)
     ]);
 

--- a/apps/api/src/routes/auditLogs_org_scope.test.ts
+++ b/apps/api/src/routes/auditLogs_org_scope.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Regression: dashboard "Recent Activity" widget leaked rows across orgs for
+ * partner-scope users. The widget POSTs ?orgId=<thorne-uuid> but the API
+ * schema dropped the field and the LATERAL fast path scanned every
+ * accessibleOrgId. (Reported live 2026-05-21: switched UI to Thorne, saw
+ * agent enrollments from a different org.)
+ *
+ * GIVEN a partner-scope user with access to orgs A and B
+ *  WHEN they call GET /audit-logs/logs?limit=5&skipCount=true&orgId=A
+ *  THEN the LATERAL fast path runs against [A] only, NOT [A, B]
+ *   AND requesting an inaccessible org returns 403
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const ORG_A = '11111111-1111-1111-1111-111111111111';
+const ORG_B = '22222222-2222-2222-2222-222222222222';
+const FOREIGN_ORG = '33333333-3333-3333-3333-333333333333';
+
+vi.mock('../services', () => ({}));
+vi.mock('../services/auditEvents', () => ({
+  writeAuditEvent: vi.fn(),
+  writeRouteAudit: vi.fn(),
+}));
+
+// Capture the SQL fragments passed to db.execute so we can assert which orgs
+// the LATERAL CROSS JOIN was given. Drizzle's sql template builder produces
+// an object; we just need to inspect what the route SAW as the org list.
+const executeMock: ReturnType<typeof vi.fn> = vi.fn(async (..._args: unknown[]) => [] as unknown[]);
+
+// Same chain shape as auditLogs.test.ts; only adds db.execute.
+const createDbChain = () => ({
+  from: vi.fn().mockReturnValue({
+    leftJoin: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue(
+        Object.assign(Promise.resolve([]), {
+          orderBy: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({
+              offset: vi.fn().mockResolvedValue([]),
+            }),
+          }),
+        }),
+      ),
+    }),
+    where: vi.fn().mockReturnValue(
+      Object.assign(Promise.resolve([{ count: 0 }]), {
+        limit: vi.fn().mockResolvedValue([]),
+      }),
+    ),
+  }),
+});
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => createDbChain()),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    execute: executeMock,
+  },
+  withDbAccessContext: vi.fn(async (_ctx: any, fn: any) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: any) => fn()),
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  SYSTEM_DB_ACCESS_CONTEXT: { scope: 'system', orgId: null, accessibleOrgIds: null },
+}));
+
+vi.mock('../db/schema', () => ({
+  auditLogs: { orgId: 'orgId', actorId: 'actorId', timestamp: 'timestamp', id: 'id', action: 'action' },
+  users: { id: 'id', name: 'name' },
+  devices: { agentId: 'agentId', hostname: 'hostname', displayName: 'displayName' },
+}));
+
+// Partner-scope auth with access to ORG_A and ORG_B only.
+const canAccessOrgSpy = vi.fn((id: string) => id === ORG_A || id === ORG_B);
+const orgConditionSpy = vi.fn(() => undefined); // would be inArray(...) in prod
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', {
+      user: { id: 'partner-user-1', email: 'partner@example.com', name: 'Partner User' },
+      scope: 'partner',
+      orgId: null,
+      partnerId: 'partner-1',
+      accessibleOrgIds: [ORG_A, ORG_B],
+      canAccessOrg: canAccessOrgSpy,
+      orgCondition: orgConditionSpy,
+    });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+describe('audit-logs cross-org leak fix (dashboard Recent Activity widget)', () => {
+  let app: Hono;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    executeMock.mockResolvedValue([]);
+    const { auditLogRoutes } = await import('./auditLogs');
+    app = new Hono();
+    app.route('/audit-logs', auditLogRoutes);
+  });
+
+  it('scopes the LATERAL fast path to the requested orgId only', async () => {
+    const res = await app.request(
+      `/audit-logs/logs?limit=5&skipCount=true&orgId=${ORG_A}`,
+    );
+    expect(res.status).toBe(200);
+    expect(executeMock).toHaveBeenCalledTimes(1);
+
+    // Drizzle's `sql` template assembles a query object. We don't need to
+    // re-parse it — instead, walk every nested string/queryChunk and assert
+    // ORG_A appears and ORG_B does NOT. If the bug regresses, the LATERAL
+    // unnest(ARRAY[...]) will contain BOTH UUIDs.
+    const queryArg = executeMock.mock.calls[0]?.[0];
+    const serialized = JSON.stringify(queryArg);
+    expect(serialized).toContain(ORG_A);
+    expect(serialized).not.toContain(ORG_B);
+  });
+
+  it('returns 403 when the requested orgId is outside accessibleOrgIds', async () => {
+    const res = await app.request(
+      `/audit-logs/logs?limit=5&skipCount=true&orgId=${FOREIGN_ORG}`,
+    );
+    expect(res.status).toBe(403);
+    expect(executeMock).not.toHaveBeenCalled();
+  });
+
+  it('without orgId, fast path scans all accessibleOrgIds (existing behaviour)', async () => {
+    const res = await app.request(`/audit-logs/logs?limit=5&skipCount=true`);
+    expect(res.status).toBe(200);
+    expect(executeMock).toHaveBeenCalledTimes(1);
+
+    const serialized = JSON.stringify(executeMock.mock.calls[0]?.[0]);
+    expect(serialized).toContain(ORG_A);
+    expect(serialized).toContain(ORG_B);
+  });
+});


### PR DESCRIPTION
## What

The **Recent Activity** dashboard widget ignored the org-selector dropdown. It calls `/audit-logs/logs?limit=5&skipCount=true`, and `fetchWithAuth` auto-injects `?orgId=<current-org>` — but `listLogsSchema` didn't whitelist `orgId`, so `zValidator` stripped it and `paginatedListHandler` spanned the caller's **full** `accessibleOrgIds` set. A partner-scope user with one org selected still saw recent-activity rows from every org they can access.

To be precise: this is **not** a tenant-isolation breach. The standard path already scopes to `auth.orgCondition` (the user's *authorized* accessible-org set), so no unauthorized rows were ever exposed — it's the per-request **narrowing** to the selected org that was lost.

## How

- Whitelist `orgId` (uuid) in `listLogsSchema`.
- In `paginatedListHandler`: `403` if the pinned `orgId` isn't accessible (`auth.canAccessOrg`); scope `orgCond` to that single org; scope the LATERAL fast-path to `[orgId]` as well. Unpinned requests are byte-for-byte unchanged. The existing "audit list is org-scoped, not site-scoped" design comment is preserved.

## Tests

- `auditLogs_org_scope.test.ts` (3 cases): a pinned `orgId` narrows to that org; an inaccessible `orgId` returns `403`; no `orgId` spans the accessible set.
- Full API suite **5807 passed / 0 failed**; tsc / eslint / Trivy / Gitleaks clean. API-only, no migration.
