### PR TITLE
feat(web): add 500 to the Devices page-size picker

### DIFF
--- a/apps/web/src/components/devices/pageSizePreference.test.ts
+++ b/apps/web/src/components/devices/pageSizePreference.test.ts
@@ -65,7 +65,7 @@ describe('pageSizePreference', () => {
       expect(isValidPageSize(7)).toBe(false);
       expect(isValidPageSize(0)).toBe(false);
       expect(isValidPageSize(-10)).toBe(false);
-      expect(isValidPageSize(500)).toBe(false);
+      expect(isValidPageSize(1000)).toBe(false);
       expect(isValidPageSize(NaN)).toBe(false);
     });
   });

--- a/apps/web/src/components/devices/pageSizePreference.ts
+++ b/apps/web/src/components/devices/pageSizePreference.ts
@@ -4,7 +4,10 @@
 // a future enhancement may lift it to users.settings.devicesPageSize so
 // the preference follows the user across browsers (see Discussion #684).
 
-export const PAGE_SIZE_OPTIONS = [10, 25, 50, 100, 200] as const;
+// This is a client-side table page size: the Devices list fetches the full
+// accessible fleet up front via the /devices cursor walk (devicesFetch.ts) and
+// paginates in memory, so 500 just lets a 200+-endpoint fleet show on one page.
+export const PAGE_SIZE_OPTIONS = [10, 25, 50, 100, 200, 500] as const;
 export type PageSize = (typeof PAGE_SIZE_OPTIONS)[number];
 
 export const DEFAULT_PAGE_SIZE: PageSize = 10;


### PR DESCRIPTION
The Devices list fetches the full accessible fleet up front via the `/devices` cursor walk (devicesFetch.ts) and paginates **in memory**, but the page-size picker stopped at 200 — so a 201+-endpoint fleet couldn't be shown on one page. Adds 500 to `PAGE_SIZE_OPTIONS` (the picker maps the options dynamically in DeviceList). It's a client-side table page size, not a server fetch limit. Updated the validator test that previously asserted 500 was out of range. Full web suite green; astro check / eslint / Trivy / Gitleaks clean.