### PR TITLE
fix(web): honor the global org-scope toggle on the pages that ignored it

### DIFF
--- a/apps/web/src/components/alerts/AlertsPage.tsx
+++ b/apps/web/src/components/alerts/AlertsPage.tsx
@@ -6,6 +6,7 @@ import AlertsSummary from './AlertsSummary';
 import AlertsTabStrip from './AlertsTabStrip';
 import type { AlertSeverity } from './alertConfig';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
 import type { FilterConditionGroup } from '@breeze/shared';
 import { DeviceFilterBar } from '../filters/DeviceFilterBar';
 import { navigateTo } from '@/lib/navigation';
@@ -29,6 +30,13 @@ export default function AlertsPage() {
   const [deviceFilterIds, setDeviceFilterIds] = useState<Set<string> | null>(null);
   const [pendingBulk, setPendingBulk] = useState<{ action: string; alerts: Alert[] } | null>(null);
 
+  // Honor the global Current/All-orgs scope toggle: when it flips (or the
+  // current org changes), re-run the fetches so the list reflects the new
+  // scope. fetchWithAuth's chokepoint already drops orgId when scope is 'all';
+  // this just makes the page refetch instead of showing the previous scope.
+  const orgScope = useOrgStore((s) => s.orgScope);
+  const currentOrgId = useOrgStore((s) => s.currentOrgId);
+
   const fetchAlerts = useCallback(async () => {
     try {
       setLoading(true);
@@ -48,7 +56,7 @@ export default function AlertsPage() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [orgScope, currentOrgId]);
 
   const fetchDevices = useCallback(async () => {
     try {
@@ -66,7 +74,7 @@ export default function AlertsPage() {
     } catch (err) {
       console.error('Failed to fetch devices:', err);
     }
-  }, []);
+  }, [orgScope, currentOrgId]);
 
   const fetchAlertDetails = useCallback(async (alertId: string) => {
     try {

--- a/apps/web/src/components/dashboard/DashboardStats.tsx
+++ b/apps/web/src/components/dashboard/DashboardStats.tsx
@@ -3,6 +3,7 @@ import { Monitor, CheckCircle, AlertTriangle, XCircle, AlertCircle, ArrowRight, 
 import { cn } from '@/lib/utils';
 import { getErrorMessage, getErrorTitle } from '@/lib/errorMessages';
 import { fetchWithAuth, useAuthStore } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
 import { useAiStore } from '@/stores/aiStore';
 
 interface DashboardStatsData {
@@ -29,6 +30,12 @@ export default function DashboardStats() {
   const [retryCount, setRetryCount] = useState(0);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [updatedText, setUpdatedText] = useState('');
+
+  // Re-fetch when the global org scope toggle (or selected org) changes so the
+  // tiles track the All-orgs / Current view like the rest of the app. Without
+  // these in the fetch effect's deps the stats are stale after a toggle.
+  const currentOrgId = useOrgStore((s) => s.currentOrgId);
+  const orgScope = useOrgStore((s) => s.orgScope);
 
   useEffect(() => { setGreeting(getGreeting()); }, []);
 
@@ -74,7 +81,7 @@ export default function DashboardStats() {
     };
 
     fetchStats();
-  }, [retryCount]);
+  }, [retryCount, currentOrgId, orgScope]);
 
   // Auto-refresh every 60 seconds
   useEffect(() => {

--- a/apps/web/src/components/dashboard/DeviceStatusChart.tsx
+++ b/apps/web/src/components/dashboard/DeviceStatusChart.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { AlertCircle, CheckCircle2, WifiOff } from 'lucide-react';
 import { getErrorMessage, getErrorTitle } from '@/lib/errorMessages';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
 import { formatTimeAgo } from '@/lib/formatTime';
 import { cn } from '@/lib/utils';
 
@@ -21,6 +22,8 @@ export default function DeviceStatusChart() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<unknown>(null);
   const [retryCount, setRetryCount] = useState(0);
+  const currentOrgId = useOrgStore((s) => s.currentOrgId);
+  const orgScope = useOrgStore((s) => s.orgScope);
 
   useEffect(() => {
     const fetchDeviceStatus = async () => {
@@ -56,7 +59,7 @@ export default function DeviceStatusChart() {
     };
 
     fetchDeviceStatus();
-  }, [retryCount]);
+  }, [retryCount, currentOrgId, orgScope]);
 
   // Auto-refresh every 60 seconds
   useEffect(() => {

--- a/apps/web/src/components/integrations/MonitoringIntegration.tsx
+++ b/apps/web/src/components/integrations/MonitoringIntegration.tsx
@@ -13,6 +13,7 @@ import {
   Webhook
 } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
 import { extractApiError } from '@/lib/apiError';
 
 type WebhookEndpoint = {
@@ -188,6 +189,13 @@ export default function MonitoringIntegration() {
   const [newWebhookName, setNewWebhookName] = useState('');
   const [newWebhookUrl, setNewWebhookUrl] = useState('');
 
+  // Monitoring settings are per organization. When the global scope toggle is
+  // on "All orgs" there is no single org to load/save, and the API rejects the
+  // request with a 400; show a prompt instead of firing a doomed call.
+  const currentOrgId = useOrgStore((s) => s.currentOrgId);
+  const orgScope = useOrgStore((s) => s.orgScope);
+  const isAllOrgs = orgScope === 'all';
+
   const selectedMetricsCount = settings.metrics.selected.length;
 
   const normalizeSettings = useCallback((payload?: Partial<MonitoringSettings> | null): MonitoringSettings => {
@@ -241,8 +249,13 @@ export default function MonitoringIntegration() {
   }, [normalizeSettings]);
 
   useEffect(() => {
+    if (isAllOrgs) {
+      setLoading(false);
+      setLoadError(undefined);
+      return;
+    }
     fetchSettings();
-  }, [fetchSettings]);
+  }, [fetchSettings, isAllOrgs, currentOrgId]);
 
   function updateSection<K extends keyof MonitoringSettings>(key: K, updates: Partial<MonitoringSettings[K]>) {
     setSettings(prev => ({
@@ -381,6 +394,24 @@ export default function MonitoringIntegration() {
       });
     }
   };
+
+  if (isAllOrgs) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-semibold">Monitoring integrations</h1>
+          <p className="text-sm text-muted-foreground">
+            Connect observability platforms, alerting tools, and external monitoring endpoints.
+          </p>
+        </div>
+        <div className="rounded-md border bg-muted/40 p-4 text-sm text-muted-foreground">
+          Monitoring integrations are configured per organization. Switch the scope in the top bar
+          from <span className="font-medium text-foreground">All orgs</span> to a single organization
+          to view or edit its monitoring settings.
+        </div>
+      </div>
+    );
+  }
 
   if (loading) {
     return (

--- a/apps/web/src/components/integrations/SecurityIntegration.tsx
+++ b/apps/web/src/components/integrations/SecurityIntegration.tsx
@@ -12,6 +12,7 @@ import {
   Unplug
 } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
 
 type Integration = {
   id: string;
@@ -76,6 +77,13 @@ export default function SecurityIntegration() {
   const [syncState, setSyncState] = useState<SyncState>({ status: 'idle' });
   const [siteMapSaving, setSiteMapSaving] = useState<Record<string, boolean>>({});
   const [siteMapError, setSiteMapError] = useState<string | null>(null);
+
+  // The SentinelOne integration is per organization. Under the "All orgs" scope
+  // toggle there is no single org to load, and the API returns a 400; show a
+  // prompt instead of firing a doomed call.
+  const currentOrgId = useOrgStore((s) => s.currentOrgId);
+  const orgScope = useOrgStore((s) => s.orgScope);
+  const isAllOrgs = orgScope === 'all';
 
   const fetchIntegration = useCallback(async () => {
     try {
@@ -143,14 +151,20 @@ export default function SecurityIntegration() {
   }, []);
 
   useEffect(() => {
+    if (isAllOrgs) {
+      setIsLoading(false);
+      setLoadError(null);
+      return;
+    }
     const load = async () => {
       setIsLoading(true);
+      setLoadError(null);
       await fetchIntegration();
       await Promise.all([fetchStatus(), fetchSites(), fetchOrgs()]);
       setIsLoading(false);
     };
     load();
-  }, [fetchIntegration, fetchStatus, fetchSites, fetchOrgs]);
+  }, [fetchIntegration, fetchStatus, fetchSites, fetchOrgs, isAllOrgs, currentOrgId]);
 
   const handleSave = async () => {
     setSaveState({ status: 'saving' });
@@ -225,6 +239,22 @@ export default function SecurityIntegration() {
       setSiteMapSaving((prev) => ({ ...prev, [siteName]: false }));
     }
   };
+
+  if (isAllOrgs) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-semibold">SentinelOne Integration</h1>
+          <p className="text-sm text-muted-foreground">Connect your SentinelOne tenant for endpoint detection and response.</p>
+        </div>
+        <div className="rounded-md border bg-muted/40 p-4 text-sm text-muted-foreground">
+          The SentinelOne integration is configured per organization. Switch the scope in the top bar
+          from <span className="font-medium text-foreground">All orgs</span> to a single organization
+          to view or edit its connection.
+        </div>
+      </div>
+    );
+  }
 
   if (isLoading) {
     return (

--- a/apps/web/src/components/monitoring/MonitoringAssetsDashboard.tsx
+++ b/apps/web/src/components/monitoring/MonitoringAssetsDashboard.tsx
@@ -121,7 +121,12 @@ type Props = {
 };
 
 export default function MonitoringAssetsDashboard({ initialAssetId, onOpenChecks }: Props) {
-  const { currentOrgId } = useOrgStore();
+  const currentOrgId = useOrgStore((s) => s.currentOrgId);
+  const orgScope = useOrgStore((s) => s.orgScope);
+  // Monitoring assets are scoped to a single org; the API returns 400
+  // ("orgId is required when partner has multiple organizations") for a
+  // multi-org partner with no orgId. Prompt for one org instead of erroring.
+  const needsOrgSelection = orgScope === 'all' || !currentOrgId;
   const [assets, setAssets] = useState<MonitoringAsset[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
@@ -136,12 +141,20 @@ export default function MonitoringAssetsDashboard({ initialAssetId, onOpenChecks
   const [actionError, setActionError] = useState<string>();
 
   const fetchAssets = useCallback(async () => {
+    // Don't fire a per-org request with no org — it 400s. The render shows a
+    // "pick an organization" prompt in this state.
+    if (orgScope === 'all' || !currentOrgId) {
+      setAssets([]);
+      setError(undefined);
+      setLoading(false);
+      return;
+    }
     try {
       setLoading(true);
       setError(undefined);
       const params = new URLSearchParams();
       if (showAll) params.set('includeUnconfigured', 'true');
-      if (currentOrgId) params.set('orgId', currentOrgId);
+      params.set('orgId', currentOrgId);
       const qs = params.toString() ? `?${params.toString()}` : '';
       const res = await fetchWithAuth(`/monitoring/assets${qs}`);
       if (!res.ok) throw new Error('Failed to fetch monitoring assets');
@@ -152,7 +165,7 @@ export default function MonitoringAssetsDashboard({ initialAssetId, onOpenChecks
     } finally {
       setLoading(false);
     }
-  }, [showAll, currentOrgId]);
+  }, [showAll, currentOrgId, orgScope]);
 
   useEffect(() => {
     fetchAssets();
@@ -255,6 +268,16 @@ export default function MonitoringAssetsDashboard({ initialAssetId, onOpenChecks
       setActionLoading(null);
     }
   };
+
+  if (needsOrgSelection) {
+    return (
+      <div className="rounded-md border bg-muted/40 p-4 text-sm text-muted-foreground">
+        Network monitoring assets are scoped to a single organization. Switch the scope in the top bar
+        from <span className="font-medium text-foreground">All orgs</span> to a specific organization
+        to view its monitoring assets.
+      </div>
+    );
+  }
 
   if (loading && assets.length === 0) {
     return (


### PR DESCRIPTION
## What

The global **Current / All orgs** scope pill (`orgStore.orgScope`, #985) flips `fetchWithAuth`'s `orgId` auto-injection, but a page only reacts when `orgScope` is in its fetch deps. Six widgets weren't subscribed, so flipping to **All orgs** (or switching orgs) left them showing the previous scope until a manual reload.

## How — two shapes, by what each page can do under All-orgs

**Refetch-on-scope** (these aggregate across orgs fine) — subscribe to `orgScope` + add it to the fetch deps so they refetch on a flip:
- `DeviceStatusChart` (Fleet Status), `DashboardStats`, `AlertsPage`

**Skip-and-prompt** (inherently per-org; the API returns 400 without a single org) — under All-orgs, short-circuit the doomed fetch and render a small prompt asking the user to switch back to a single org:
- `MonitoringIntegration`, `SecurityIntegration`, `MonitoringAssetsDashboard`

No per-page scope pill is added — #985 deliberately replaced per-page org toggles with the one global control.

## Tests

The scope mechanism itself (the `orgId`-injection short-circuit) is covered by `orgStore.scope.test.ts` + `auth.test.ts`. These six components have **no existing unit tests**; the refetch fixes are dep-only and the skip-and-prompt guard is a simple `isAllOrgs` branch, so I haven't added bespoke component tests (happy to if you'd prefer). Full web suite **718 passed**; astro check / eslint / Trivy / Gitleaks clean.