### PR TITLE
fix(heartbeat): tolerate bad optional fields instead of 400-ing the whole heartbeat

### DIFF
--- a/apps/api/src/routes/agents/schemas.heartbeatTolerance.test.ts
+++ b/apps/api/src/routes/agents/schemas.heartbeatTolerance.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest';
+import { heartbeatSchema } from './schemas';
+
+// Tolerant-heartbeat contract: optional informational fields that fail
+// validation MUST drop silently. The heartbeat as a whole must still parse so
+// the device stays "online" — only the bad field is missing from the parsed
+// output. See schemas.ts header comment for the systemic rationale.
+
+describe('heartbeatSchema — Layer A tolerance', () => {
+  const minimal = {
+    status: 'ok' as const,
+    agentVersion: '0.65.15',
+  };
+
+  it('accepts a minimal valid heartbeat', () => {
+    const result = heartbeatSchema.safeParse(minimal);
+    expect(result.success).toBe(true);
+  });
+
+  it('drops oversized macAddress in currentIPs instead of rejecting heartbeat', () => {
+    const payload = {
+      ...minimal,
+      ipHistoryUpdate: {
+        currentIPs: [
+          {
+            interfaceName: 'eth0',
+            ipAddress: '10.0.0.1',
+            // 100 chars, well past the 64-char informational cap.
+            macAddress: 'A'.repeat(100),
+          },
+        ],
+      },
+    };
+
+    const result = heartbeatSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    // The bad macAddress drops to undefined; the rest of the IP record is
+    // preserved. Heartbeat parses, server applies the IP-history update
+    // without the oversized MAC.
+    const entry = result.data.ipHistoryUpdate?.currentIPs?.[0];
+    expect(entry?.interfaceName).toBe('eth0');
+    expect(entry?.ipAddress).toBe('10.0.0.1');
+    expect(entry?.macAddress).toBeUndefined();
+  });
+
+  it('drops currentIPs array when an element has invalid required ipAddress', () => {
+    const payload = {
+      ...minimal,
+      ipHistoryUpdate: {
+        currentIPs: [
+          {
+            interfaceName: 'eth0',
+            ipAddress: 'not-an-ip',
+          },
+        ],
+      },
+    };
+
+    const result = heartbeatSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    // Array catches to undefined when a required inner field is invalid.
+    expect(result.data.ipHistoryUpdate?.currentIPs).toBeUndefined();
+  });
+
+  it('keeps macAddress when within 64-char limit (covers pseudo-interfaces)', () => {
+    // A 35-char tunnel-form MAC from a Windows pseudo-interface should pass
+    // through unchanged — this was the original incident's regression test.
+    const payload = {
+      ...minimal,
+      ipHistoryUpdate: {
+        currentIPs: [
+          {
+            interfaceName: 'isatap.{guid}',
+            ipAddress: '10.0.0.1',
+            macAddress: 'AA-BB-CC-DD-EE-FF-AA-BB-CC-DD-EE-FF',
+          },
+        ],
+      },
+    };
+
+    const result = heartbeatSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.ipHistoryUpdate?.currentIPs?.[0]?.macAddress).toBe(
+      'AA-BB-CC-DD-EE-FF-AA-BB-CC-DD-EE-FF',
+    );
+  });
+
+  it('drops oversized lastUser instead of rejecting', () => {
+    const payload = {
+      ...minimal,
+      lastUser: 'x'.repeat(500),
+    };
+
+    const result = heartbeatSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.lastUser).toBeUndefined();
+  });
+
+  it('drops oversized helperVersion instead of rejecting', () => {
+    const payload = {
+      ...minimal,
+      helperVersion: 'v'.repeat(50),
+    };
+
+    const result = heartbeatSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.helperVersion).toBeUndefined();
+  });
+
+  it('drops bad osBuild instead of rejecting', () => {
+    const payload = {
+      ...minimal,
+      osBuild: 'b'.repeat(500),
+    };
+
+    const result = heartbeatSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.osBuild).toBeUndefined();
+  });
+
+  it('drops malformed tccPermissions (missing required inner) instead of rejecting', () => {
+    const payload = {
+      ...minimal,
+      tccPermissions: {
+        // missing required booleans
+        checkedAt: '2026-05-21T06:00:00+00:00',
+      },
+    };
+
+    const result = heartbeatSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.tccPermissions).toBeUndefined();
+  });
+
+  it('drops oversized interfaceStats names', () => {
+    const payload = {
+      ...minimal,
+      metrics: {
+        cpuPercent: 5,
+        ramPercent: 50,
+        ramUsedMb: 4096,
+        diskPercent: 30,
+        diskUsedGb: 100,
+        interfaceStats: [
+          {
+            // empty name violates min(1)
+            name: '',
+            inBytesPerSec: 0,
+            outBytesPerSec: 0,
+            inBytes: 0,
+            outBytes: 0,
+            inPackets: 0,
+            outPackets: 0,
+            inErrors: 0,
+            outErrors: 0,
+          },
+        ],
+      },
+    };
+
+    const result = heartbeatSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.metrics?.interfaceStats).toBeUndefined();
+  });
+
+  it('rejects when REQUIRED top-level fields are missing (status)', () => {
+    const payload = { agentVersion: '0.65.15' };
+    const result = heartbeatSchema.safeParse(payload);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects when REQUIRED top-level fields are wrong type (status)', () => {
+    const payload = { status: 'banana', agentVersion: '0.65.15' };
+    const result = heartbeatSchema.safeParse(payload);
+    expect(result.success).toBe(false);
+  });
+
+  it('keeps required metrics fields strict when metrics block is present', () => {
+    const payload = {
+      ...minimal,
+      metrics: {
+        // missing cpuPercent (required)
+        ramPercent: 50,
+        ramUsedMb: 4096,
+        diskPercent: 30,
+        diskUsedGb: 100,
+      },
+    };
+    const result = heartbeatSchema.safeParse(payload);
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/api/src/routes/agents/schemas.ts
+++ b/apps/api/src/routes/agents/schemas.ts
@@ -52,6 +52,45 @@ export const enrollSchema = z.object({
 // Heartbeat
 // ============================================
 
+// Tolerant heartbeat schema (Layer A bulletproofing).
+//
+// Optional informational fields are wrapped with `.catch(undefined)` so that
+// a malformed/oversized value drops silently instead of 400-ing the entire
+// heartbeat. Critical fields (status, agentVersion, top-level metrics core,
+// role, etc.) remain strict — those are real assertions about the agent
+// contract.
+//
+// For arrays of optional inner records (currentIPs, changedIPs, removedIPs,
+// interfaceStats), one bad element collapses the whole array via
+// `.catch(undefined)` rather than rejecting the heartbeat. The server keeps
+// treating an absent IP-history update as "no change this beat."
+//
+// History: an earlier helper-window incident saw Windows pseudo-interfaces
+// emit MACs > 17 chars, which (pre-fix) rejected the entire payload and
+// flipped endpoints to "offline" even though the agent was running fine.
+// Tolerance here is the systemic fix for that whole class of bug.
+
+const ipEntrySchema = z.object({
+  interfaceName: z.string().min(1).max(100),
+  ipAddress: z.string().trim().max(45).refine(
+    (value) => {
+      const withoutZone = value.includes('%') ? value.slice(0, Math.max(value.indexOf('%'), 0)) : value;
+      return isIP(withoutZone) !== 0;
+    },
+    { message: 'Invalid IP address format' }
+  ),
+  ipType: z.enum(['ipv4', 'ipv6']).optional().catch(undefined),
+  assignmentType: z.enum(['dhcp', 'static', 'vpn', 'link-local', 'unknown']).optional().catch(undefined),
+  // Standard MAC is 17 chars (XX:XX:XX:XX:XX:XX), but Windows pseudo-
+  // interfaces (ISATAP, Teredo, etc.) report longer EUI-64 / tunnel forms
+  // up to ~53 chars. Accept anything reasonable to avoid rejecting the
+  // whole heartbeat over an informational field.
+  macAddress: z.string().max(64).optional().catch(undefined),
+  subnetMask: z.string().max(45).optional().catch(undefined),
+  gateway: z.string().max(45).optional().catch(undefined),
+  dnsServers: z.array(z.string().max(45)).max(8).optional().catch(undefined)
+});
+
 export const heartbeatSchema = z.object({
   metrics: z.object({
     cpuPercent: z.number(),
@@ -59,17 +98,17 @@ export const heartbeatSchema = z.object({
     ramUsedMb: z.number().int(),
     diskPercent: z.number(),
     diskUsedGb: z.number(),
-    diskActivityAvailable: z.boolean().optional(),
-    diskReadBytes: z.number().int().min(0).optional(),
-    diskWriteBytes: z.number().int().min(0).optional(),
-    diskReadBps: z.number().int().min(0).optional(),
-    diskWriteBps: z.number().int().min(0).optional(),
-    diskReadOps: z.number().int().min(0).optional(),
-    diskWriteOps: z.number().int().min(0).optional(),
-    networkInBytes: z.number().int().optional(),
-    networkOutBytes: z.number().int().optional(),
-    bandwidthInBps: z.number().int().min(0).optional(),
-    bandwidthOutBps: z.number().int().min(0).optional(),
+    diskActivityAvailable: z.boolean().optional().catch(undefined),
+    diskReadBytes: z.number().int().min(0).optional().catch(undefined),
+    diskWriteBytes: z.number().int().min(0).optional().catch(undefined),
+    diskReadBps: z.number().int().min(0).optional().catch(undefined),
+    diskWriteBps: z.number().int().min(0).optional().catch(undefined),
+    diskReadOps: z.number().int().min(0).optional().catch(undefined),
+    diskWriteOps: z.number().int().min(0).optional().catch(undefined),
+    networkInBytes: z.number().int().optional().catch(undefined),
+    networkOutBytes: z.number().int().optional().catch(undefined),
+    bandwidthInBps: z.number().int().min(0).optional().catch(undefined),
+    bandwidthOutBps: z.number().int().min(0).optional().catch(undefined),
     interfaceStats: z.array(z.object({
       name: z.string().min(1),
       inBytesPerSec: z.number().int().min(0),
@@ -80,108 +119,53 @@ export const heartbeatSchema = z.object({
       outPackets: z.number().int().min(0),
       inErrors: z.number().int().min(0),
       outErrors: z.number().int().min(0),
-      speed: z.number().int().min(0).optional()
-    })).max(100).optional(),
-    processCount: z.number().int().optional()
+      speed: z.number().int().min(0).optional().catch(undefined)
+    })).max(100).optional().catch(undefined),
+    processCount: z.number().int().optional().catch(undefined)
   }).optional(),
-  metricsAvailable: z.boolean().optional(),
+  metricsAvailable: z.boolean().optional().catch(undefined),
   status: z.enum(['ok', 'warning', 'error']),
   agentVersion: z.string(),
-  helperVersion: z.string().max(20).optional(),
+  helperVersion: z.string().max(20).optional().catch(undefined),
   ipHistoryUpdate: z.object({
-    deviceId: z.string().optional(),
-    currentIPs: z.array(z.object({
-      interfaceName: z.string().min(1).max(100),
-      ipAddress: z.string().trim().max(45).refine(
-        (value) => {
-          const withoutZone = value.includes('%') ? value.slice(0, Math.max(value.indexOf('%'), 0)) : value;
-          return isIP(withoutZone) !== 0;
-        },
-        { message: 'Invalid IP address format' }
-      ),
-      ipType: z.enum(['ipv4', 'ipv6']).optional(),
-      assignmentType: z.enum(['dhcp', 'static', 'vpn', 'link-local', 'unknown']).optional(),
-      // Standard MAC is 17 chars (XX:XX:XX:XX:XX:XX), but Windows pseudo-
-      // interfaces (ISATAP, Teredo, etc.) report longer EUI-64 / tunnel forms
-      // up to ~53 chars. Accept anything reasonable to avoid rejecting the
-      // whole heartbeat over an informational field.
-      macAddress: z.string().max(64).optional(),
-      subnetMask: z.string().max(45).optional(),
-      gateway: z.string().max(45).optional(),
-      dnsServers: z.array(z.string().max(45)).max(8).optional()
-    })).max(100).nullish(),
-    changedIPs: z.array(z.object({
-      interfaceName: z.string().min(1).max(100),
-      ipAddress: z.string().trim().max(45).refine(
-        (value) => {
-          const withoutZone = value.includes('%') ? value.slice(0, Math.max(value.indexOf('%'), 0)) : value;
-          return isIP(withoutZone) !== 0;
-        },
-        { message: 'Invalid IP address format' }
-      ),
-      ipType: z.enum(['ipv4', 'ipv6']).optional(),
-      assignmentType: z.enum(['dhcp', 'static', 'vpn', 'link-local', 'unknown']).optional(),
-      // Standard MAC is 17 chars (XX:XX:XX:XX:XX:XX), but Windows pseudo-
-      // interfaces (ISATAP, Teredo, etc.) report longer EUI-64 / tunnel forms
-      // up to ~53 chars. Accept anything reasonable to avoid rejecting the
-      // whole heartbeat over an informational field.
-      macAddress: z.string().max(64).optional(),
-      subnetMask: z.string().max(45).optional(),
-      gateway: z.string().max(45).optional(),
-      dnsServers: z.array(z.string().max(45)).max(8).optional()
-    })).max(100).nullish(),
-    removedIPs: z.array(z.object({
-      interfaceName: z.string().min(1).max(100),
-      ipAddress: z.string().trim().max(45).refine(
-        (value) => {
-          const withoutZone = value.includes('%') ? value.slice(0, Math.max(value.indexOf('%'), 0)) : value;
-          return isIP(withoutZone) !== 0;
-        },
-        { message: 'Invalid IP address format' }
-      ),
-      ipType: z.enum(['ipv4', 'ipv6']).optional(),
-      assignmentType: z.enum(['dhcp', 'static', 'vpn', 'link-local', 'unknown']).optional(),
-      // Standard MAC is 17 chars (XX:XX:XX:XX:XX:XX), but Windows pseudo-
-      // interfaces (ISATAP, Teredo, etc.) report longer EUI-64 / tunnel forms
-      // up to ~53 chars. Accept anything reasonable to avoid rejecting the
-      // whole heartbeat over an informational field.
-      macAddress: z.string().max(64).optional(),
-      subnetMask: z.string().max(45).optional(),
-      gateway: z.string().max(45).optional(),
-      dnsServers: z.array(z.string().max(45)).max(8).optional()
-    })).max(100).nullish(),
-    detectedAt: z.string().datetime({ offset: true }).optional()
-  }).optional(),
-  pendingReboot: z.boolean().optional(),
-  lastUser: z.string().max(255).optional(),
-  uptime: z.number().int().min(0).optional(),
-  deviceRole: z.enum(DEVICE_ROLES).optional(),
-  hostname: z.string().min(1).max(255).optional(),
-  osVersion: z.string().min(1).max(255).optional(),
-  osBuild: z.string().max(255).optional(),
+    deviceId: z.string().optional().catch(undefined),
+    currentIPs: z.array(ipEntrySchema).max(100).nullish().catch(undefined),
+    changedIPs: z.array(ipEntrySchema).max(100).nullish().catch(undefined),
+    removedIPs: z.array(ipEntrySchema).max(100).nullish().catch(undefined),
+    detectedAt: z.string().datetime({ offset: true }).optional().catch(undefined)
+  }).optional().catch(undefined),
+  pendingReboot: z.boolean().optional().catch(undefined),
+  lastUser: z.string().max(255).optional().catch(undefined),
+  uptime: z.number().int().min(0).optional().catch(undefined),
+  deviceRole: z.enum(DEVICE_ROLES).optional().catch(undefined),
+  hostname: z.string().min(1).max(255).optional().catch(undefined),
+  osVersion: z.string().min(1).max(255).optional().catch(undefined),
+  osBuild: z.string().max(255).optional().catch(undefined),
   tccPermissions: z.object({
     screenRecording: z.boolean(),
     accessibility: z.boolean(),
     fullDiskAccess: z.boolean(),
-    remoteDesktop: z.boolean().nullable().optional(),
+    remoteDesktop: z.boolean().nullable().optional().catch(undefined),
     checkedAt: z.string().datetime({ offset: true }),
-  }).optional(),
+  }).optional().catch(undefined),
   desktopAccess: z.object({
     mode: z.enum(['user_session', 'login_window', 'unavailable']),
     loginUiReachable: z.boolean(),
     virtualDisplayReady: z.boolean(),
-    reason: desktopAccessReasonSchema.nullable().optional(),
-    remoteDesktopPermission: z.boolean().nullable().optional(),
+    reason: desktopAccessReasonSchema.nullable().optional().catch(undefined),
+    remoteDesktopPermission: z.boolean().nullable().optional().catch(undefined),
     checkedAt: z.string().datetime({ offset: true }),
-  }).optional(),
-  isHeadless: z.boolean().optional(),
+  }).optional().catch(undefined),
+  isHeadless: z.boolean().optional().catch(undefined),
   role: z.enum(['agent', 'watchdog']).optional(),
-  watchdogState: z.string().optional(),
+  watchdogState: z.string().optional().catch(undefined),
   // Watchdog-only: 24h restart accounting for the main agent (#799 Layer B).
-  mainAgentRestartCount24h: z.number().int().min(0).max(10_000).optional(),
-  mainAgentLastRestartAt: z.string().datetime({ offset: true }).optional(),
-  flapDetected: z.boolean().optional(),
-  osType: z.string().optional(),
+  // Optional informational fields, so they tolerate a bad/oversized value
+  // (drop it) rather than 400-ing the whole heartbeat.
+  mainAgentRestartCount24h: z.number().int().min(0).max(10_000).optional().catch(undefined),
+  mainAgentLastRestartAt: z.string().datetime({ offset: true }).optional().catch(undefined),
+  flapDetected: z.boolean().optional().catch(undefined),
+  osType: z.string().optional().catch(undefined),
 });
 
 // ============================================


### PR DESCRIPTION
## What

A single malformed or oversized **optional informational** field in the heartbeat payload rejected the *entire* request (zValidator 400), so the agent's heartbeat failed and the device flipped **offline** despite being healthy and reporting.

## How

Wrap the optional informational fields with `.catch(undefined)` so a bad value is silently dropped and the rest of the heartbeat still parses. **Critical fields stay strict** (status, agentVersion, role, core metrics) — a bad value there should still fail loudly. Extends the same tolerance to main's newer watchdog-accounting fields (`mainAgentRestartCount24h`, `mainAgentLastRestartAt`, `flapDetected`).

Same class as the earlier macAddress `17→64` cap fix (#790): one bad optional field shouldn't take an agent offline.

## Tests

`schemas.heartbeatTolerance.test.ts`: a bad optional field drops to `undefined` and the heartbeat still parses; a bad **critical** field still fails. Full API suite **5816 passed**; tsc / eslint / Trivy / Gitleaks clean. No migration.