### PR TITLE
docs(deploy): add Cloudflare Tunnel setup guide

### DIFF
--- a/apps/docs/src/content/docs/deploy/cloudflare-tunnel.mdx
+++ b/apps/docs/src/content/docs/deploy/cloudflare-tunnel.mdx
@@ -1,0 +1,163 @@
+---
+title: Cloudflare Tunnel
+description: Run Breeze behind a Cloudflare Tunnel with no inbound ports, and optionally lock the dashboard behind Cloudflare Access.
+sidebar:
+  order: 5
+  label: Cloudflare Tunnel
+---
+
+import { Steps, Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+
+A [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) lets you expose Breeze without opening any inbound ports on your server. The `cloudflared` daemon makes an outbound connection to Cloudflare's edge, and all traffic reaches Breeze through that tunnel. Your origin IP stays hidden, and the firewall can deny all inbound traffic.
+
+This is a popular self-hosting setup, and the bundled Caddy config is built to support it out of the box.
+
+## Traffic Chain
+
+```
+Internet → Cloudflare edge → cloudflared → Caddy → API / Web
+```
+
+Both the dashboard and agent traffic arrive on the same hostname (port 443) and are split by path inside Caddy:
+
+| Path | Backend |
+|---|---|
+| `/api/v1/agents/*`, `/api/v1/agent-ws/*` | API (agent REST + WebSocket) |
+| `/api/v1/desktop-ws`, `/api/v1/tunnel-ws`, `/api/v1/remote/sessions` | API (remote desktop / terminal) |
+| `/api/*`, `/health`, `/metrics/*` | API |
+| `/` (catch-all) | Web dashboard |
+
+<Aside type="caution">
+  A Cloudflare Tunnel only carries TCP/HTTP. TURN, which powers remote desktop across NATs, needs UDP and **cannot run on the same host** behind a tunnel. Deploy TURN on a separate VPS — see [TURN Server](/deploy/turn-server/).
+</Aside>
+
+---
+
+## Prerequisites
+
+- A domain on a Cloudflare account (the zone must be active on Cloudflare).
+- A working Breeze stack reachable internally on the Caddy container.
+- The bundled `tunnel` (cloudflared) service from `deploy/docker-compose.prod.yml`, or your own `cloudflared` install.
+
+---
+
+## Setup
+
+<Steps>
+
+1. **Create the tunnel in the Cloudflare dashboard**
+
+   Go to **Zero Trust → Networks → Tunnels → Create a tunnel**, choose **Cloudflared**, and name it (for example `breeze`). Cloudflare generates a tunnel token. Copy it.
+
+2. **Add a public hostname**
+
+   In the tunnel's **Public Hostname** tab, add your Breeze hostname (for example `breeze.example.com`) and point its **Service** at the Caddy container:
+
+   ```
+   Service type: HTTP
+   URL: caddy:80
+   ```
+
+   In the bundled compose, `cloudflared` and `caddy` share the `breeze` network, so `caddy:80` resolves directly. If you run `cloudflared` on the host instead, use `http://localhost:80`.
+
+3. **Provide the tunnel credentials**
+
+   The bundled `tunnel` service reads its config from `/opt/breeze/cloudflared/config.yml`:
+
+   ```yaml
+   tunnel: <TUNNEL_ID>
+   credentials-file: /etc/cloudflared/<TUNNEL_ID>.json
+   ingress:
+     - hostname: breeze.example.com
+       service: http://caddy:80
+     - service: http_status:404
+   ```
+
+   Place the matching `<TUNNEL_ID>.json` credentials file (downloaded from Cloudflare) in the same directory. Set `CLOUDFLARED_IMAGE_REF` in your `.env` to a digest-pinned `cloudflared` image.
+
+4. **Tell Breeze it sits behind a proxy**
+
+   Because every request now arrives from `cloudflared` → Caddy, both layers must be told which hop to trust for the real client IP. The traffic chain is `cloudflared (172.30.0.10) → caddy (172.30.0.11) → api`.
+
+   In your `.env`:
+
+   ```bash
+   # Caddy trusts the cloudflared hop for CF-Connecting-IP / X-Forwarded-For
+   CADDY_TRUSTED_PROXIES=172.30.0.10/32
+   CADDY_CLIENT_IP_HEADERS=CF-Connecting-IP X-Forwarded-For
+
+   # The API trusts the Caddy hop
+   TRUST_PROXY_HEADERS=true
+   TRUSTED_PROXY_CIDRS=172.30.0.11/32
+   ```
+
+   <Aside type="danger">
+     In production, when `TRUST_PROXY_HEADERS=true` the API refuses to boot unless `TRUSTED_PROXY_CIDRS` is set. This prevents header spoofing of client IPs (used by rate limiting and audit logs). See [Environment Variables](/deploy/environment/).
+   </Aside>
+
+5. **Start the stack**
+
+   ```bash
+   docker compose up -d
+   ```
+
+   `cloudflared` connects outbound to Cloudflare and registers the hostname. You can now close all inbound ports on the host firewall.
+
+6. **Verify**
+
+   ```bash
+   curl https://breeze.example.com/health
+   ```
+
+   A `200` confirms traffic is flowing Internet → Cloudflare → tunnel → Caddy → API.
+
+</Steps>
+
+---
+
+## Restricting the Dashboard with Cloudflare Access
+
+Breeze has no built-in IP allowlist for the dashboard, so IP or identity restrictions belong at the proxy. With a tunnel already in place, [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/applications/) is the cleanest way to gate the admin UI while leaving agent traffic open to the internet.
+
+The key constraint: agents connect from wherever your managed machines live (roaming laptops, customer sites, dynamic IPs), so you cannot allowlist the agents. Instead, protect everything **except** the agent paths.
+
+<Steps>
+
+1. **Create an Access application**
+
+   In **Zero Trust → Access → Applications**, add a **Self-hosted** application for `breeze.example.com`.
+
+2. **Add a bypass policy for agent paths**
+
+   Agents and remote sessions must reach these paths without an Access login. Add an **Access policy** with action **Bypass** (source: *Everyone*) scoped to the agent paths, or define the Access application path so it excludes them:
+
+   - `/api/v1/agents/*` — agent REST (enroll, heartbeat, logs)
+   - `/api/v1/agent-ws/*` — agent WebSocket (the live connection)
+   - `/api/v1/desktop-ws`, `/api/v1/tunnel-ws`, `/api/v1/remote/sessions` — remote desktop / terminal
+
+3. **Require identity for everything else**
+
+   Add an **Allow** policy on the application that requires your identity provider (Google Workspace, Okta, one-time PIN to an email domain, etc.). Now the dashboard and dashboard API require an Access login, while agents keep connecting normally.
+
+</Steps>
+
+<Aside type="tip">
+  Prefer plain IP filtering over Access? You can do the same split in Caddy with a `remote_ip` matcher: allow the agent paths from anywhere, and return `403` on every other path unless the source is one of your office/VPN CIDRs. Because Caddy trusts `CF-Connecting-IP` (set in step 4), `remote_ip` sees the real visitor, not the Cloudflare edge.
+</Aside>
+
+---
+
+## Troubleshooting
+
+**Client IP shows as a Cloudflare address in audit logs / rate limits**
+- Confirm `CADDY_TRUSTED_PROXIES` lists the `cloudflared` hop and `CADDY_CLIENT_IP_HEADERS` includes `CF-Connecting-IP`.
+- Confirm `TRUST_PROXY_HEADERS=true` and `TRUSTED_PROXY_CIDRS` lists the Caddy hop.
+
+**API container won't start after enabling proxy trust**
+- In production, `TRUST_PROXY_HEADERS=true` requires a non-empty `TRUSTED_PROXY_CIDRS`. Set it to the Caddy container's CIDR (default `172.30.0.11/32`).
+
+**Remote desktop fails behind the tunnel**
+- Expected if TURN runs on the same host. The tunnel can't carry UDP. Move TURN to a separate VPS — see [TURN Server](/deploy/turn-server/).
+
+**Agents can't connect after adding Cloudflare Access**
+- The Access bypass for `/api/v1/agents/*` and `/api/v1/agent-ws/*` is missing or too narrow. Agents have no browser session and will be blocked by an identity policy.

--- a/scripts/docs-review/mapping.json
+++ b/scripts/docs-review/mapping.json
@@ -4,7 +4,8 @@
       "pattern": "apps/api/src/services/clientIp.ts",
       "docs": [
         "reference/audit-logs.mdx",
-        "security/hardening.mdx"
+        "security/hardening.mdx",
+        "deploy/cloudflare-tunnel.mdx"
       ]
     },
     {
@@ -744,6 +745,20 @@
       "docs": [
         "deploy/production.mdx",
         "security/overview.mdx"
+      ]
+    },
+    {
+      "pattern": "docker/Caddyfile.prod",
+      "docs": [
+        "deploy/cloudflare-tunnel.mdx",
+        "deploy/production.mdx"
+      ]
+    },
+    {
+      "pattern": "deploy/docker-compose.prod.yml",
+      "docs": [
+        "deploy/cloudflare-tunnel.mdx",
+        "deploy/production.mdx"
       ]
     }
   ]


### PR DESCRIPTION
## Summary
Adds a Cloudflare Tunnel deployment guide to the docs site (`deploy/cloudflare-tunnel.mdx`), prompted by community questions about IP-restricting the dashboard and recommended tunnel setup.

Covers:
- The `cloudflared → Caddy → API/web` traffic chain and the path-based split between dashboard and agent traffic
- Tunnel creation, pointing ingress at `caddy:80`, and the `config.yml`
- The proxy-trust env vars Breeze needs behind a tunnel (`CADDY_TRUSTED_PROXIES`, `CADDY_CLIENT_IP_HEADERS`, `TRUST_PROXY_HEADERS`, `TRUSTED_PROXY_CIDRS`) with the real `172.30.0.10/.11` hops from `deploy/docker-compose.prod.yml`
- Optional **Cloudflare Access** section to gate the dashboard while bypassing agent paths (`/api/v1/agents`, `/api/v1/agent-ws`, remote session WS), since agents roam and can't be IP-allowlisted
- Cross-links the existing TURN doc for the UDP-can't-tunnel caveat

Also updates `scripts/docs-review/mapping.json` for `docker/Caddyfile.prod`, the prod compose, and `clientIp.ts`.

## Verification
- `astro build` passes locally (116 pages; new page renders)
- Auto-appears in the Deployment sidebar (autogenerated directory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)