### PR TITLE
docs(deploy): Cloudflare Tunnel HTTP-origin requirement + Caddy-bypass option

### DIFF
--- a/apps/docs/src/content/docs/deploy/cloudflare-tunnel.mdx
+++ b/apps/docs/src/content/docs/deploy/cloudflare-tunnel.mdx
@@ -33,6 +33,59 @@ Both the dashboard and agent traffic arrive on the same hostname (port 443) and 
 
 ---
 
+## TLS Termination: HTTP Origin Required
+
+Cloudflare terminates HTTPS at its edge, and the tunnel from `cloudflared` to your server is already encrypted. The hop from `cloudflared` into Breeze must therefore be **plain HTTP**. If Caddy also tries to obtain its own Let's Encrypt certificate, the two TLS layers collide — ACME validation has no inbound port to answer on, and the tunnel fails to connect.
+
+There are two supported ways to satisfy this. **Option A keeps Caddy** as the path router (recommended). **Option B bypasses Caddy** and routes paths in the tunnel itself.
+
+### Option A — Caddy in HTTP mode (recommended)
+
+Keep Caddy in front and have it listen on plain `:80`. Caddy still handles the path split, compression, security headers, and SSE tuning. Plain `:80` is the default `CADDY_SITE_ADDRESS`, so the only rule is: **do not set `CADDY_SITE_ADDRESS` to a domain** — a domain value switches Caddy into Let's Encrypt mode, which is exactly what you must avoid behind a tunnel.
+
+**Breeze `.env`:**
+
+```bash
+# Plain HTTP — let Cloudflare handle TLS at the edge.
+# Do NOT set this to a domain when behind a tunnel.
+CADDY_SITE_ADDRESS=:80
+```
+
+**Tunnel ingress (`/opt/breeze/cloudflared/config.yml`):**
+
+```yaml
+ingress:
+  - hostname: breeze.example.com
+    service: http://caddy:80
+  - service: http_status:404
+```
+
+In the Cloudflare dashboard, the public hostname's **Service** is `HTTP` → `caddy:80`. No origin certificate is needed.
+
+### Option B — Bypass Caddy
+
+Point the tunnel straight at the `api` and `web` containers and replicate the path split in the tunnel's ingress rules. cloudflared evaluates rules top to bottom, first match wins.
+
+**Tunnel ingress (`/opt/breeze/cloudflared/config.yml`):**
+
+```yaml
+ingress:
+  # API surface: REST, agents, websockets, health, metrics, oauth, activation
+  - hostname: breeze.example.com
+    path: '^/(api|oauth|\.well-known|s|i|activate|health|metrics|ready)(/.*)?$'
+    service: http://api:3001
+  # Everything else → the dashboard
+  - hostname: breeze.example.com
+    service: http://web:4321
+  - service: http_status:404
+```
+
+<Aside type="caution">
+  Bypassing Caddy means you give up what Caddy provides: gzip/zstd compression, the HSTS and `X-Content-Type-Options` security headers, SSE flush tuning for AI streaming, the OAuth consent-page split, and the billing sidecar route. Only choose this if you are not running Caddy at all. For most deployments, Option A is simpler and safer.
+</Aside>
+
+---
+
 ## Prerequisites
 
 - A domain on a Cloudflare account (the zone must be active on Cloudflare).
@@ -51,14 +104,14 @@ Both the dashboard and agent traffic arrive on the same hostname (port 443) and 
 
 2. **Add a public hostname**
 
-   In the tunnel's **Public Hostname** tab, add your Breeze hostname (for example `breeze.example.com`) and point its **Service** at the Caddy container:
+   In the tunnel's **Public Hostname** tab, add your Breeze hostname (for example `breeze.example.com`) and point its **Service** at the Caddy container. The service type must be **HTTP**, not HTTPS — see [TLS Termination](#tls-termination-http-origin-required) above.
 
    ```
    Service type: HTTP
    URL: caddy:80
    ```
 
-   In the bundled compose, `cloudflared` and `caddy` share the `breeze` network, so `caddy:80` resolves directly. If you run `cloudflared` on the host instead, use `http://localhost:80`.
+   In the bundled compose, `cloudflared` and `caddy` share the `breeze` network, so `caddy:80` resolves directly. If you run `cloudflared` on the host instead, use `http://localhost:80`. (Using Option B? Point the service at `api:3001` / `web:4321` per the ingress rules instead.)
 
 3. **Provide the tunnel credentials**
 
@@ -94,6 +147,8 @@ Both the dashboard and agent traffic arrive on the same hostname (port 443) and 
    <Aside type="danger">
      In production, when `TRUST_PROXY_HEADERS=true` the API refuses to boot unless `TRUSTED_PROXY_CIDRS` is set. This prevents header spoofing of client IPs (used by rate limiting and audit logs). See [Environment Variables](/deploy/environment/).
    </Aside>
+
+   Using **Option B** (no Caddy)? The API's immediate upstream is now `cloudflared`, so set `TRUSTED_PROXY_CIDRS=172.30.0.10/32` and omit the `CADDY_*` variables.
 
 5. **Start the stack**
 


### PR DESCRIPTION
## Summary
Follow-up to #1088. Documents that a Cloudflare Tunnel terminates TLS at the edge, so the `cloudflared → origin` hop must be plain HTTP. If Caddy also provisions Let's Encrypt, the two TLS layers collide and the tunnel won't connect.

Adds a **TLS Termination** section with two configurations:
- **Option A (recommended):** keep Caddy in HTTP mode — `CADDY_SITE_ADDRESS=:80`, do not set a domain; tunnel ingress → `caddy:80`.
- **Option B:** bypass Caddy — route paths to `api:3001` / `web:4321` directly in the cloudflared ingress, with a caution listing the Caddy features you give up (compression, security headers, SSE tuning, OAuth consent split, billing route).

Also notes Option B trusts the cloudflared CIDR (`172.30.0.10/32`) instead of the Caddy hop for proxy-trust, and flags the HTTP (not HTTPS) service type in the public-hostname step.

## Verification
- `astro build` passes locally (116 pages; page renders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)