### PR TITLE
fix(api): actually initialize Sentry at startup (error tracking was dark)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -114,7 +114,7 @@ import { c2cRoutes, m365CallbackRoute } from './routes/c2c';
 import { drRoutes } from './routes/dr';
 import { adminRoutes } from './routes/admin';
 import { bootstrapPlatformAdmins } from './services/platformAdminBootstrap';
-import { captureException } from './services/sentry';
+import { captureException, flushSentry, initSentry } from './services/sentry';
 import { partnerGuard } from './middleware/partnerGuard';
 import { API_VERSION } from './version';
 
@@ -1196,7 +1196,10 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
       if (typeof closeDb === 'function') {
         await closeDb();
       }
-    }
+    },
+    // Drain any buffered Sentry events before the process exits (no-op if
+    // Sentry is disabled). Bounded internally by a 2s flush timeout.
+    () => flushSentry(),
   ];
 
   // Stop accepting requests BEFORE tearing down workers/Redis/DB. Otherwise a
@@ -1265,6 +1268,11 @@ function installSignalHandlers(): void {
 
 async function bootstrap(): Promise<void> {
   console.log(`Breeze API starting on port ${port}...`);
+
+  // Initialize error reporting first so failures during the rest of startup
+  // (migrations, seeds, self-tests) and the global onError/unhandledRejection
+  // handlers are actually captured. No-op unless SENTRY_DSN is set.
+  initSentry();
 
   // Validate configuration before anything else — fail fast on missing/insecure secrets.
   // The validated config is stored as a singleton; retrieve later via getConfig().

--- a/apps/api/src/services/sentry.test.ts
+++ b/apps/api/src/services/sentry.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Mock the Sentry SDK so we can observe how initSentry/captureException/flushSentry
+// drive it without making real network calls.
+const initMock = vi.fn();
+const captureMock = vi.fn();
+const flushMock = vi.fn().mockResolvedValue(true);
+const withScopeMock = vi.fn((cb: (scope: unknown) => void) =>
+  cb({ setTag: vi.fn(), setContext: vi.fn() }),
+);
+
+vi.mock('@sentry/node', () => ({
+  init: (...args: unknown[]) => initMock(...args),
+  captureException: (...args: unknown[]) => captureMock(...args),
+  flush: (...args: unknown[]) => flushMock(...args),
+  withScope: (cb: (scope: unknown) => void) => withScopeMock(cb),
+}));
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe('sentry service', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    initMock.mockClear();
+    captureMock.mockClear();
+    flushMock.mockClear();
+    withScopeMock.mockClear();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it('tags the release with the running API version, not a stale SENTRY_RELEASE env', async () => {
+    // The droplets carry a stale SENTRY_RELEASE (e.g. 0.64.1) that nobody updates
+    // on deploy. The release Sentry sees must instead follow the deployed version
+    // (APP_VERSION -> API_VERSION -> BREEZE_VERSION) so issues are tagged correctly.
+    process.env.SENTRY_DSN = 'https://abc@o1.ingest.us.sentry.io/2';
+    process.env.SENTRY_RELEASE = '0.64.1';
+    process.env.APP_VERSION = '9.9.9-test';
+
+    const { initSentry } = await import('./sentry');
+    initSentry();
+
+    expect(initMock).toHaveBeenCalledTimes(1);
+    const initArg = initMock.mock.calls[0]![0] as { release?: string; dsn?: string };
+    expect(initArg.release).toBe('9.9.9-test');
+    expect(initArg.release).not.toBe('0.64.1');
+  });
+
+  it('does not initialize the SDK when no DSN is configured', async () => {
+    delete process.env.SENTRY_DSN;
+    const { initSentry, isSentryEnabled } = await import('./sentry');
+    initSentry();
+    expect(initMock).not.toHaveBeenCalled();
+    expect(isSentryEnabled()).toBe(false);
+  });
+
+  it('captureException is a no-op until initSentry has run', async () => {
+    process.env.SENTRY_DSN = 'https://abc@o1.ingest.us.sentry.io/2';
+    const { initSentry, captureException } = await import('./sentry');
+
+    captureException(new Error('before init'));
+    expect(captureMock).not.toHaveBeenCalled();
+
+    initSentry();
+    captureException(new Error('after init'));
+    expect(captureMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('sentry bootstrap wiring (index.ts)', () => {
+  const indexSource = readFileSync(
+    fileURLToPath(new URL('../index.ts', import.meta.url)),
+    'utf-8',
+  );
+
+  it('actually calls initSentry() during startup', () => {
+    // Regression guard: initSentry was defined but never invoked, so every
+    // captureException across the codebase silently no-op'd in production.
+    expect(indexSource).toMatch(/initSentry\s*\(/);
+  });
+
+  it('flushes Sentry on shutdown so buffered events are not lost', () => {
+    expect(indexSource).toMatch(/flushSentry\s*\(/);
+  });
+});

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/node';
 import type { Context } from 'hono';
+import { API_VERSION } from '../version';
 
 let initialized = false;
 
@@ -25,7 +26,11 @@ export function initSentry(): void {
   Sentry.init({
     dsn,
     environment: process.env.SENTRY_ENVIRONMENT ?? process.env.NODE_ENV ?? 'development',
-    release: process.env.SENTRY_RELEASE,
+    // Track the deployed version (API_VERSION <- APP_VERSION <- BREEZE_VERSION),
+    // which is already correct on every deploy. The old SENTRY_RELEASE env was
+    // hand-maintained and went stale on the droplets (pinned at 0.64.1 while the
+    // fleet ran 0.69.0), mistagging every event — so we no longer read it.
+    release: API_VERSION,
     tracesSampleRate
   });
 


### PR DESCRIPTION
## Problem

While reviewing prod after the v0.69.0 deploy, I found the `breeze` Sentry project had **zero events, ever** — despite a correctly-configured DSN (identical on both EU and US droplets).

Root cause: **`initSentry()` is defined but never called anywhere in the repo.** So `Sentry.init()` never runs, the module's `initialized` flag stays `false`, and all ~250 `captureException()` call sites — including the global `app.onError` handler (`index.ts:815`) and the `unhandledRejection` handler (`index.ts:1249`) — hit `if (!initialized) return` and silently no-op. Sentry has been dark in production since the original ops-tooling commit (`3b723dc8`).

Separately, `SENTRY_RELEASE` was hand-maintained in each droplet's `.env` and had gone stale (pinned at `0.64.1` while the fleet ran `0.69.0`), so any events that *did* fire would be mistagged.

## Fix

- **Call `initSentry()` at the top of `bootstrap()`** — as early as possible so startup failures (migrations, seeds, self-tests) and the global error handlers are actually captured. No-op unless `SENTRY_DSN` is set.
- **Flush Sentry on shutdown** (`flushSentry()` added to the shutdown tasks) so buffered events survive `SIGTERM`.
- **Tag the release with `API_VERSION`** (`<- APP_VERSION <- BREEZE_VERSION`), which is already correct on every deploy, instead of reading the stale `SENTRY_RELEASE` env (no longer read).

## Tests (`apps/api/src/services/sentry.test.ts`, new)

- Behavioral (SDK mocked): release follows the running version not the stale env; SDK stays off without a DSN; `captureException` no-ops until init.
- **Regression guards** that scan `index.ts` for the `initSentry(` / `flushSentry(` calls, so the exact "defined-but-never-called" bug cannot silently return.

## Verification

- `vitest run src/services/sentry.test.ts` → 5/5 pass (the 3 release/wiring tests were confirmed RED first).
- `tsc --noEmit` clean for all changed files.

## Ops note (no action required for this PR)

The stale `SENTRY_RELEASE=0.64.1` in the EU/US droplet `.env` files is now harmless (the code ignores it). It can be blanked out at leisure; release tagging no longer depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)