### PR TITLE
fix(deps): remove duplicate @nodable/entities lockfile key (unbreak main CI)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13398,8 +13398,6 @@ snapshots:
   '@nodable/entities@2.1.0':
     optional: true
 
-  '@nodable/entities@2.1.1': {}
-
   '@nodable/entities@2.1.1':
     optional: true
 


### PR DESCRIPTION
## Problem
`main` CI is **red on every Node job** right now. `pnpm install --frozen-lockfile` fails with:

```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile at "pnpm-lock.yaml" is broken: duplicated mapping key (13403:3)
  13401 |   '@nodable/entities@2.1.1': {}
  13403 |   '@nodable/entities@2.1.1':
```

The `snapshots:` section lists `@nodable/entities@2.1.1` **twice** (once as `{}`, once as `optional: true`) — invalid YAML. It came from a back-to-back sequence of Dependabot lockfile bumps landing via admin-bypass; the lockfile auto-merge kept both entries. Verified on the latest main commit's CI run: Type Check / Test API / Test Web / Lint / Check Migrations / Security Audit all fail at the install step (only the Go agent job, which has no pnpm, passes).

## Fix
Remove the stale duplicate, keeping the `optional: true` form — consistent with the sibling `@nodable/entities@2.1.0` and **validated by a clean `pnpm install --frozen-lockfile`** (which checks the snapshot against the resolved graph).

## Verification (local, pnpm 10.33.4 = pinned CI version)
- `pnpm install --frozen-lockfile` → exit 0 (was failing)
- `tsc --noEmit --project apps/api/tsconfig.json` → 0 errors (no version drift; resolved set identical)
- Diff is **2 deleted lines, lockfile-only** — no dependency version changes.