### PR TITLE
feat(audit-logs): excludeActions filter for routine-telemetry noise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ concurrency:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '10.33.4'
-  GO_VERSION: '1.25.10'
+  GO_VERSION: '1.25.11'
 
 # SR-007: least-privilege default. CI runs on every PR (including forks) and
 # only needs to read the repo. Any job needing more must opt in per-job.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
           cache-dependency-path: agent/go.sum
 
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '10.33.4'
-  GO_VERSION: '1.25.10'
+  GO_VERSION: '1.25.11'
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '10.33.4'
-  GO_VERSION: '1.25.10'
+  GO_VERSION: '1.25.11'
 
 permissions:
   actions: read

--- a/apps/api/src/routes/auditLogs.test.ts
+++ b/apps/api/src/routes/auditLogs.test.ts
@@ -141,6 +141,34 @@ describe('audit log routes', () => {
       const body = await res.json();
       expect(body.data).toEqual([]);
     });
+
+    it('accepts excludeActions on the standard query path', async () => {
+      const res = await app.request(
+        '/audit-logs/logs?action=device&excludeActions=agent.sessions.submit,mcp.tools.list'
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toEqual([]);
+    });
+
+    it('accepts excludeActions on the LATERAL fast path (skipCount)', async () => {
+      const res = await app.request(
+        '/audit-logs/logs?limit=5&skipCount=true&excludeActions=agent.sessions.submit'
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toEqual([]);
+    });
+
+    it('ignores empty excludeActions tokens', async () => {
+      const res = await app.request('/audit-logs/logs?excludeActions=,,%20,');
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toEqual([]);
+    });
   });
 
   describe('GET /audit-logs/logs/:id', () => {

--- a/apps/api/src/routes/auditLogs.ts
+++ b/apps/api/src/routes/auditLogs.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { and, desc, eq, gte, lte, ilike, or, sql, SQL } from 'drizzle-orm';
+import { and, desc, eq, gte, lte, ilike, inArray, not, or, sql, SQL } from 'drizzle-orm';
 import { db } from '../db';
 import { auditLogs as auditLogsTable, users, devices } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission } from '../middleware/auth';
@@ -41,7 +41,10 @@ const listLogsSchema = z.object({
   // auto-injects ?orgId=<current-org>; whitelist it here so zValidator keeps
   // it — otherwise it is stripped and every page spans the caller's full
   // accessible-org set, ignoring the dropdown selection.
-  orgId: z.string().uuid().optional()
+  orgId: z.string().uuid().optional(),
+  // CSV of action codes to exclude (e.g. routine agent telemetry). Applied to
+  // both the LATERAL fast-path (RecentActivity) and the standard query path.
+  excludeActions: z.string().optional()
 });
 
 const searchSchema = listLogsSchema.extend({
@@ -256,9 +259,17 @@ function toFullEntry(row: DbRow, includeDetails = true) {
   return entry;
 }
 
+function parseExcludeActions(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
 function buildFilterConditions(
   orgCond: SQL | undefined,
-  filters: { user?: string; action?: string; resource?: string; from?: string; to?: string }
+  filters: { user?: string; action?: string; resource?: string; from?: string; to?: string; excludeActions?: string }
 ): SQL | undefined {
   const conditions: SQL[] = [];
 
@@ -294,6 +305,11 @@ function buildFilterConditions(
 
   if (filters.to) {
     conditions.push(lte(auditLogsTable.timestamp, new Date(filters.to)));
+  }
+
+  const excludeList = parseExcludeActions(filters.excludeActions);
+  if (excludeList.length > 0) {
+    conditions.push(not(inArray(auditLogsTable.action, excludeList)));
   }
 
   return conditions.length > 0 ? and(...conditions) : undefined;
@@ -358,8 +374,18 @@ interface LateralAuditRow extends Record<string, unknown> {
   device_display_name: string | null;
 }
 
-async function queryLatestPerOrg(orgIds: string[], limit: number): Promise<DbRow[]> {
+async function queryLatestPerOrg(
+  orgIds: string[],
+  limit: number,
+  excludeActions: string[] = []
+): Promise<DbRow[]> {
   const orgIdsSql = sql.join(orgIds.map((id) => sql`${id}::uuid`), sql`, `);
+  // Apply the exclude filter INSIDE the LATERAL subquery so the per-org
+  // LIMIT N kicks in after filtering noise — otherwise we fetch N noisy rows
+  // per org and drop them all.
+  const excludeFilter = excludeActions.length > 0
+    ? sql` AND audit_logs.action <> ALL(ARRAY[${sql.join(excludeActions.map((a) => sql`${a}`), sql`, `)}]::text[])`
+    : sql``;
   const rows = await db.execute<LateralAuditRow>(sql`
     SELECT
       al.id, al.org_id, al.timestamp, al.actor_type, al.actor_id,
@@ -372,7 +398,7 @@ async function queryLatestPerOrg(orgIds: string[], limit: number): Promise<DbRow
     FROM unnest(ARRAY[${orgIdsSql}]::uuid[]) AS o(org_id)
     CROSS JOIN LATERAL (
       SELECT * FROM audit_logs
-      WHERE audit_logs.org_id = o.org_id
+      WHERE audit_logs.org_id = o.org_id${excludeFilter}
       ORDER BY timestamp DESC
       LIMIT ${limit}
     ) al
@@ -554,6 +580,10 @@ function paginatedListHandler(
     // count — it never displays "X of Y total". Pass skipCount=true there.
     const skipCount = query.skipCount === 'true';
     const hasFilters = !!(query.user || query.action || query.resource || query.from || query.to);
+    // excludeActions is compatible with the fast path — it's applied inside the
+    // LATERAL subquery before the per-org LIMIT. The standard path picks it up
+    // via buildFilterConditions(orgCond, query) above.
+    const excludeActions = parseExcludeActions(query.excludeActions);
     // Fast-path org list: a pinned ?orgId= scopes the LATERAL per-org scan to
     // that single org; otherwise it spans every accessible org.
     const fastPathOrgIds: string[] | null = query.orgId
@@ -568,7 +598,7 @@ function paginatedListHandler(
     const [total, rows] = await Promise.all([
       skipCount ? Promise.resolve(-1) : countRows(where),
       canUseFastPath
-        ? queryLatestPerOrg(fastPathOrgIds as string[], limit)
+        ? queryLatestPerOrg(fastPathOrgIds as string[], limit, excludeActions)
         : queryRows(where, limit, offset)
     ]);
 

--- a/apps/web/src/components/dashboard/RecentActivity.tsx
+++ b/apps/web/src/components/dashboard/RecentActivity.tsx
@@ -3,7 +3,7 @@ import { FileCode, User, Settings, Monitor, AlertCircle, Activity } from 'lucide
 import { getErrorMessage, getErrorTitle } from '@/lib/errorMessages';
 import { fetchWithAuth } from '../../stores/auth';
 import { formatTimeAgo } from '@/lib/formatTime';
-import { formatAuditAction } from '@/lib/auditFormat';
+import { formatAuditAction, DEFAULT_DASHBOARD_EXCLUDE_ACTIONS } from '@/lib/auditFormat';
 
 interface AuditLogEntry {
   id: string;
@@ -55,7 +55,10 @@ export default function RecentActivity() {
         setIsLoading(true);
         setError(null);
 
-        const response = await fetchWithAuth('/audit-logs/logs?limit=5&skipCount=true');
+        const excludeParam = encodeURIComponent(DEFAULT_DASHBOARD_EXCLUDE_ACTIONS.join(','));
+        const response = await fetchWithAuth(
+          `/audit-logs/logs?limit=5&skipCount=true&excludeActions=${excludeParam}`
+        );
 
         if (!response.ok) {
           throw response;

--- a/apps/web/src/lib/auditFormat.ts
+++ b/apps/web/src/lib/auditFormat.ts
@@ -1,3 +1,23 @@
+// Routine agent telemetry + MCP plumbing actions that saturate the
+// dashboard Recent Activity widget. Passed as a CSV `excludeActions=` query
+// param to GET /audit-logs/logs so the API filters them server-side. The
+// full Audit Log viewer does NOT use this list — it shows everything.
+export const DEFAULT_DASHBOARD_EXCLUDE_ACTIONS: readonly string[] = [
+  'agent.sessions.submit',
+  'agent.security_status.submit',
+  'agent.management_posture.submit',
+  'agent.patches.submit',
+  'agent.eventlogs.submit',
+  'agent.reliability.submit',
+  'agent.filesystem.threshold_scan.queued',
+  'mcp.tools.list',
+  'mcp.resources.list',
+  'mcp.notifications.initialized',
+  'mcp.initialize',
+  'api.post.events.ws-ticket',
+  'api.get.events.ws-ticket',
+];
+
 // Map raw audit action codes (dotted, machine-shaped) to human-readable
 // phrases. Falls back to a generic prettifier for unknown codes.
 


### PR DESCRIPTION
## What
Adds an optional CSV `excludeActions=` query param to `GET /audit-logs/logs` that filters out the given action codes server-side. Applied to **both** query paths:
- standard query — `not(inArray(audit_logs.action, ...))` in `buildFilterConditions`
- LATERAL per-org fast path — inside the subquery **before** the per-org `LIMIT`, so noise is dropped before the limit kicks in (otherwise we'd fetch N noisy rows per org and drop them all)

Web: a `DEFAULT_DASHBOARD_EXCLUDE_ACTIONS` list in `auditFormat.ts` (routine `agent.*.submit` telemetry + `mcp.*` plumbing + ws-ticket events) that the dashboard **Recent Activity** widget passes as the CSV param. Without it, the widget is saturated by high-volume agent telemetry and shows nothing useful. The full **Audit Log viewer is unaffected** — it still shows everything.

## Why
Surfaced during a prod↔main reconciliation: this was the one genuinely prod-only feature not yet upstreamed (a fleet running real agents drowns the dashboard activity feed in telemetry submissions). Small, self-contained, no schema change.

## Tests
3 new cases in `auditLogs.test.ts` (standard path, LATERAL fast path, empty-token handling). Verified locally: `tsc --noEmit` (apps/api) clean, `vitest run src/routes/auditLogs.test.ts` 16/16.