### PR TITLE
fix(ci): bump Go 1.25.10 -> 1.25.11 to clear 2 stdlib govulncheck findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ concurrency:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '10.33.4'
-  GO_VERSION: '1.25.10'
+  GO_VERSION: '1.25.11'
 
 # SR-007: least-privilege default. CI runs on every PR (including forks) and
 # only needs to read the repo. Any job needing more must opt in per-job.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
           cache-dependency-path: agent/go.sum
 
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '10.33.4'
-  GO_VERSION: '1.25.10'
+  GO_VERSION: '1.25.11'
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '10.33.4'
-  GO_VERSION: '1.25.10'
+  GO_VERSION: '1.25.11'
 
 permissions:
   actions: read


### PR DESCRIPTION
## Problem
The **Security Scanning** workflow (govulncheck) is **failing on main and every open PR** — verified on the latest main push (`367ae321`). It reports 2 Go **standard-library** vulnerabilities, both **fixed in go1.25.11**, while CI pins **1.25.10**:

- `GO-2026-5039` — net/textproto: arbitrary inputs included in errors without escaping
- `GO-2026-5037` — crypto/x509: inefficient candidate hostname parsing

`Your code is affected by 2 vulnerabilities from the Go standard library.`

A newly-published advisory started failing the scan on unchanged code (govulncheck pulls the live vuln DB). Not blocking (`Security Scanning` isn't a required check, so `CI Success` stays green) but it reds out main + all PRs.

## Fix
Bump the Go toolchain pin **1.25.10 → 1.25.11** (a released patch) in `ci.yml`, `codeql.yml`, and `release.yml`. Stdlib-only findings → no module changes. `agent/go.mod`'s `go 1.25.10` floor is left as-is (the toolchain that runs the scan / builds the release is what matters). This PR's own Security Scanning run validates it goes green.