### PR TITLE
fix(ops): restore-test.sh success heartbeat / dead-man's-switch (#983)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ concurrency:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '10.33.4'
-  GO_VERSION: '1.25.10'
+  GO_VERSION: '1.25.11'
 
 # SR-007: least-privilege default. CI runs on every PR (including forks) and
 # only needs to read the repo. Any job needing more must opt in per-job.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
           cache-dependency-path: agent/go.sum
 
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '10.33.4'
-  GO_VERSION: '1.25.10'
+  GO_VERSION: '1.25.11'
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '10.33.4'
-  GO_VERSION: '1.25.10'
+  GO_VERSION: '1.25.11'
 
 permissions:
   actions: read

--- a/scripts/ops/restore-test.sh
+++ b/scripts/ops/restore-test.sh
@@ -30,6 +30,11 @@
 #                             (default: 1)
 #   RESTORE_TEST_ALERT_URL    optional webhook (Slack/Alertmanager) POSTed on
 #                             failure; if unset, failures only log + exit non-zero
+#   RESTORE_TEST_HEARTBEAT_URL optional dead-man's-switch ping URL (e.g. a
+#                             healthchecks.io check); pinged on each PASS so a
+#                             silently-stopped cron (host down, creds expired,
+#                             script removed) — which emits no failure — becomes
+#                             the alarm via absence of the ping. Unset = no ping.
 #
 # Exit codes:
 #   0 — restore verified
@@ -64,6 +69,16 @@ alert() {
     curl -fsS -m 10 -X POST -H 'Content-Type: application/json' \
       -d "{\"text\":\"[Breeze restore-test FAILED] ${msg}\"}" \
       "${RESTORE_TEST_ALERT_URL}" >/dev/null 2>&1 || log "WARNING: alert webhook POST failed"
+  fi
+}
+
+# Dead-man's-switch success ping. A failure-only alert can't distinguish "the
+# restore test passed" from "the test never ran" — both are silent. Ping a
+# monitor on every PASS so the monitor alerts when the ping goes stale.
+heartbeat() {
+  if [ -n "${RESTORE_TEST_HEARTBEAT_URL:-}" ]; then
+    curl -fsS -m 10 --retry 3 "${RESTORE_TEST_HEARTBEAT_URL}" >/dev/null 2>&1 \
+      || log "WARNING: success heartbeat ping failed"
   fi
 }
 
@@ -152,4 +167,5 @@ if [ "${device_count}" -lt "${MIN_DEVICES}" ]; then
 fi
 
 log "SUCCESS: restore verified — ${device_count} devices, dump ${dump_size}"
+heartbeat
 exit 0


### PR DESCRIPTION
Closes #983.

## Problem
`scripts/ops/restore-test.sh` only emits a signal on **failure** — `fail()` POSTs to `RESTORE_TEST_ALERT_URL` and exits non-zero; the happy path ends at a bare `exit 0` and sends nothing. So if the cron **silently stops** (host down, cron disabled, script removed, Spaces creds expired, container runtime broken) it emits no failure either, and "no alert" reads as "DR is healthy" when the check hasn't run in days. Classic dead-man's-switch gap: absence of a failure signal is indistinguishable from absence of the check.

## Fix
Add an optional `RESTORE_TEST_HEARTBEAT_URL` (healthchecks.io-style). On each **PASS**, after the SUCCESS log, ping it; the external monitor alerts when the ping goes stale — so silence becomes the alarm, not the all-clear.

- Mirrors the existing `alert()` style (same `curl` flags, quoted, default-expansion).
- Fully back-compatible: unset `RESTORE_TEST_HEARTBEAT_URL` = no ping, identical to today.
- `bash -n` clean; documented in the script header env-var block.