### PR TITLE
fix(enrollment): emit 'error' anomaly metric on validation-failure exits (#984)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ concurrency:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '10.33.4'
-  GO_VERSION: '1.25.10'
+  GO_VERSION: '1.25.11'
 
 # SR-007: least-privilege default. CI runs on every PR (including forks) and
 # only needs to read the repo. Any job needing more must opt in per-job.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
           cache-dependency-path: agent/go.sum
 
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '10.33.4'
-  GO_VERSION: '1.25.10'
+  GO_VERSION: '1.25.11'
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '10.33.4'
-  GO_VERSION: '1.25.10'
+  GO_VERSION: '1.25.11'
 
 permissions:
   actions: read

--- a/apps/api/src/routes/agents/enrollment.test.ts
+++ b/apps/api/src/routes/agents/enrollment.test.ts
@@ -28,6 +28,10 @@ vi.mock('../../services/sentry', () => ({
   captureException: vi.fn(),
 }));
 
+vi.mock('../../services/anomalyMetrics', () => ({
+  recordAgentEnrollment: vi.fn(),
+}));
+
 vi.mock('../../db/schema', () => ({
   enrollmentKeys: {
     id: 'id',
@@ -98,6 +102,7 @@ vi.mock('../../services/tenantStatus', () => ({
 
 import { db } from '../../db';
 import { writeAuditEvent } from '../../services/auditEvents';
+import { recordAgentEnrollment } from '../../services/anomalyMetrics';
 import { getActiveOrgTenant } from '../../services/tenantStatus';
 import * as manifestSigning from '../../services/manifestSigning';
 import { enrollmentRoutes } from './enrollment';
@@ -848,6 +853,8 @@ describe('POST /agents/enroll — ENROLLMENT_SECRET_ENFORCEMENT_MODE', () => {
         result: 'denied',
       })
     );
+    // #984: the rejection must be visible to the EnrollmentSpike anomaly metric.
+    expect(recordAgentEnrollment).toHaveBeenCalledWith('error');
   });
 
   it('blocks production enrollment with no secret when mode is explicitly enforce', async () => {

--- a/apps/api/src/routes/agents/enrollment.ts
+++ b/apps/api/src/routes/agents/enrollment.ts
@@ -196,6 +196,7 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
           result: 'denied',
           errorMessage: 'Enrollment secret required',
         });
+        recordAgentEnrollment('error');
         return c.json({ error: 'Enrollment secret required' }, 403);
       }
 
@@ -211,6 +212,7 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
           result: 'denied',
           errorMessage: 'Invalid enrollment secret',
         });
+        recordAgentEnrollment('error');
         return c.json({ error: 'Invalid enrollment secret' }, 403);
       }
     } else if (configuredSecret) {
@@ -225,6 +227,7 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
           result: 'denied',
           errorMessage: 'Enrollment secret required',
         });
+        recordAgentEnrollment('error');
         return c.json({ error: 'Enrollment secret required' }, 403);
       }
 
@@ -239,6 +242,7 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
           result: 'denied',
           errorMessage: 'Invalid enrollment secret',
         });
+        recordAgentEnrollment('error');
         return c.json({ error: 'Invalid enrollment secret' }, 403);
       }
     } else if (process.env.NODE_ENV === 'production') {
@@ -281,6 +285,7 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
           result: 'denied',
           errorMessage: 'Enrollment secret required in production',
         });
+        recordAgentEnrollment('error');
         return c.json({ error: 'Enrollment secret required' }, 403);
       }
     }
@@ -560,6 +565,7 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
           }).catch((err) => {
             console.error('[Enrollment] Failed to dispatch device-limit hook:', err instanceof Error ? err.message : err);
           });
+          recordAgentEnrollment('error', deviceLimitPartnerId);
           throw new HTTPException(403, {
             message: JSON.stringify({
               error: 'Device limit reached',


### PR DESCRIPTION
Closes #984.

## Problem
`recordAgentEnrollment` was only called on two exits — rate-limit `'denied'` and the final `'success'`. Every **secret-validation 403** and the **device-limit rejection** recorded nothing, and the recorder's declared `'error'` variant was never emitted anywhere. So the **EnrollmentSpike** alert (fires on enrollment volume `by (tenant)`, description: *'verify this matches an expected rollout, not a leaked enrollment key'*) is blind to a burst of invalid-secret 403s — exactly the signature of someone probing with a leaked/guessed key.

## Fix
Emit `recordAgentEnrollment('error')` at:
- the 5 secret-validation 403 exits (missing + invalid secret; key-based, configured-secret, and production-enforce paths)
- the device-limit rejection — with the resolved `deviceLimitPartnerId` so it carries the tenant

Metric calls only; no change to enrollment behavior or responses. Verified: `apps/api` tsc clean, the 22-case enrollment suite passes including a new assertion that `'error'` is recorded on the production-enforce rejection.

## Note
Stacked on #1096 (Go-1.25.11 govuln fix) so Security Scanning is green; the 4 Go-workflow lines drop out when #1096 merges.