### PR TITLE
fix(snmp): drop ':' from BullMQ poll job ids (Custom Id cannot contain :)

### DIFF
--- a/apps/api/src/jobs/snmpQueue.test.ts
+++ b/apps/api/src/jobs/snmpQueue.test.ts
@@ -80,7 +80,7 @@ describe('snmp queue helpers', () => {
     expect(addMock).toHaveBeenCalledWith(
       'poll-device',
       expect.objectContaining({ deviceId: 'device-1', orgId: 'org-1' }),
-      expect.objectContaining({ jobId: 'snmp-poll:device-1' }),
+      expect.objectContaining({ jobId: 'snmp-poll-device-1' }),
     );
   });
 
@@ -92,8 +92,22 @@ describe('snmp queue helpers', () => {
     expect(addMock).toHaveBeenCalledWith(
       'process-poll-results',
       expect.objectContaining({ deviceId: 'device-1', pollId: 'snmp-device-1-123' }),
-      expect.objectContaining({ jobId: 'snmp-result:snmp-device-1-123' }),
+      expect.objectContaining({ jobId: 'snmp-result-snmp-device-1-123' }),
     );
+  });
+
+  // Regression for "Custom Id cannot contain :" — BullMQ throws when a custom
+  // jobId contains a ':' (unless it has exactly two), which silently stopped all
+  // SNMP polling from being enqueued. The jobIds must never contain a ':'.
+  it('does not use a colon in the enqueued BullMQ job id', async () => {
+    getJobMock.mockResolvedValue(null);
+
+    await enqueueSnmpPoll('device-1', 'org-1');
+    await enqueueSnmpPollResults('device-1', [], 'snmp-device-1-123');
+
+    for (const call of addMock.mock.calls) {
+      expect(String(call[2].jobId)).not.toContain(':');
+    }
   });
 
   it('reuses an active queued poll result job for the same poll id', async () => {

--- a/apps/api/src/jobs/snmpWorker.ts
+++ b/apps/api/src/jobs/snmpWorker.ts
@@ -262,7 +262,10 @@ export async function enqueueSnmpPoll(
   orgId: string
 ): Promise<string> {
   const queue = getSnmpQueue();
-  const stableJobId = `snmp-poll:${deviceId}`;
+  // BullMQ rejects a custom jobId containing ':' (unless it has exactly two, a
+  // legacy repeatable-job carve-out), so use '-' as the separator. A ':' here
+  // makes queue.add throw "Custom Id cannot contain :" and polling never runs.
+  const stableJobId = `snmp-poll-${deviceId}`;
   const existing = await queue.getJob(stableJobId);
   if (existing) {
     const state = await existing.getState();
@@ -298,7 +301,8 @@ export async function enqueueSnmpPollResults(
   pollId?: string,
 ): Promise<string> {
   const queue = getSnmpQueue();
-  const stableJobId = pollId ? `snmp-result:${pollId}` : null;
+  // '-' separator, not ':', so BullMQ does not reject the custom jobId (see enqueueSnmpPoll).
+  const stableJobId = pollId ? `snmp-result-${pollId}` : null;
   if (stableJobId) {
     const existing = await queue.getJob(stableJobId);
     if (existing) {


### PR DESCRIPTION
## Problem

`enqueueSnmpPoll` and `enqueueSnmpPollResults` build custom BullMQ job ids with a `:` separator:

```ts
const stableJobId = `snmp-poll:${deviceId}`;
const stableJobId = pollId ? `snmp-result:${pollId}` : null;
```

BullMQ's `Job.validateOptions` rejects a custom `jobId` that contains `:` unless it splits into exactly three parts (a legacy repeatable-job carve-out):

```js
if (opts.jobId.includes(':') && opts.jobId.split(':').length !== 3)
    throw new Error('Custom Id cannot contain :');
```

`snmp-poll:<uuid>` has one colon (two parts), so `queue.add` throws and the poll is never enqueued. The reported symptom in #1100 matches exactly: SNMP status stays `unknown`, last poll `never`, and the API logs:

```
[SnmpWorker] Failed to enqueue poll for device <id>: Error: Custom Id cannot contain :
    at Job.validateOptions (.../bullmq/dist/cjs/classes/job.js:1045:23)
```

## Fix

Use `-` as the separator instead of `:`. `deviceId` and `pollId` are UUID-shaped (no colons), so the ids stay stable and unique, and the `getJob()` dedup lookup still matches because it uses the same constructed string.

## Why the tests didn't catch it

`snmpQueue.test.ts` mocks `queue.add`, so BullMQ's `validateOptions` never ran and the colon id looked fine. Added a regression assertion that the enqueued `jobId` contains no `:`.

## Note for maintainers

Other workers in `apps/api/src/jobs/*.ts` also construct single-colon `name:${id}` BullMQ job ids (e.g. `alert-evaluate-all:${slot}`, `automation-run:${runId}`). I did not change them here since I could not confirm them at runtime, but they appear to violate the same rule and may be worth a follow-up audit.

## Testing

- `pnpm exec tsc --noEmit --project apps/api/tsconfig.json` clean
- `pnpm --filter=@breeze/api lint` clean
- `pnpm test --filter=@breeze/api` — 5805 passed / 31 skipped, 0 failures

Fixes #1100
