### PR TITLE
fix(agent): self-heal from transient auth-dead instead of skipping forever

### DIFF
--- a/agent/internal/authstate/monitor.go
+++ b/agent/internal/authstate/monitor.go
@@ -4,7 +4,6 @@ import (
 	"log/slog"
 	"math/rand/v2"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -16,15 +15,29 @@ const (
 )
 
 // Monitor tracks consecutive HTTP 401 responses across all agent HTTP
-// callers. When the failure count reaches the threshold, ShouldSkip()
-// returns true and callers should skip their HTTP work.
+// callers. When the failure count reaches the threshold, the monitor enters
+// an auth-dead state and ShouldSkip() returns true so callers back off.
+//
+// While auth-dead, ShouldSkip() is TIME-GATED: it returns true only until the
+// current backoff has elapsed since the last failure, then returns false to
+// let the next attempt through (a backoff-gated retry). A success on that
+// retry clears the dead state (self-heal); another failure lengthens the
+// backoff (exponential, capped at maxBackoff). This is what lets an agent
+// recover on its own after a *transient* credential rejection (e.g. the
+// server momentarily 401s during a deploy/restore). Without the time gate the
+// agent would skip every tick forever and stay silent until the process is
+// restarted — even after auth had recovered.
 type Monitor struct {
-	dead        atomic.Bool
-	consecutive atomic.Int32
-	threshold   int32
+	threshold int32
 
-	mu      sync.Mutex
-	backoff time.Duration
+	mu          sync.Mutex
+	consecutive int32
+	dead        bool
+	backoff     time.Duration
+	lastFailure time.Time
+
+	// now is the clock, injectable for tests. Use clock() to read it.
+	now func() time.Time
 }
 
 // NewMonitor creates an auth monitor that trips after `threshold`
@@ -33,41 +46,52 @@ func NewMonitor(threshold int) *Monitor {
 	return &Monitor{
 		threshold: int32(threshold),
 		backoff:   initialBackoff,
+		now:       time.Now,
 	}
 }
 
-// RecordAuthFailure records a 401 response. If the consecutive count
-// reaches the threshold, the monitor enters auth-dead state.
-func (m *Monitor) RecordAuthFailure() {
-	n := m.consecutive.Add(1)
-	if n < m.threshold {
-		return
+func (m *Monitor) clock() time.Time {
+	if m.now != nil {
+		return m.now()
 	}
+	return time.Now()
+}
 
+// RecordAuthFailure records a 401 response. Below the threshold it only
+// advances the consecutive counter. At/after the threshold the monitor is
+// auth-dead; each subsequent (backoff-gated) failure lengthens the backoff so
+// retries slow down, capped at maxBackoff.
+func (m *Monitor) RecordAuthFailure() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	firstTrip := m.dead.CompareAndSwap(false, true)
-	if firstTrip {
+	m.lastFailure = m.clock()
+
+	if !m.dead {
+		m.consecutive++
+		if m.consecutive < m.threshold {
+			return
+		}
+		m.dead = true
+		m.backoff = initialBackoff
 		slog.Warn("auth-dead: consecutive 401s reached threshold, backing off",
-			"consecutive", n, "threshold", m.threshold)
-		// Keep backoff at initialBackoff for the first trip — do NOT advance here.
+			"consecutive", m.consecutive, "threshold", m.threshold)
 		return
 	}
 
-	// Already dead — advance backoff for the subsequent failure.
+	// Already dead — a backoff-gated retry failed. Lengthen the backoff.
 	m.backoff = time.Duration(float64(m.backoff) * backoffFactor)
 	if m.backoff > maxBackoff {
 		m.backoff = maxBackoff
 	}
 }
 
-// RecordSuccess clears the auth-dead state and resets the counter
-// and backoff.
+// RecordSuccess clears the auth-dead state and resets the counter and backoff.
 func (m *Monitor) RecordSuccess() {
 	m.mu.Lock()
-	wasDead := m.dead.Swap(false)
-	m.consecutive.Store(0)
+	wasDead := m.dead
+	m.dead = false
+	m.consecutive = 0
 	m.backoff = initialBackoff
 	m.mu.Unlock()
 
@@ -76,10 +100,18 @@ func (m *Monitor) RecordSuccess() {
 	}
 }
 
-// ShouldSkip returns true if the agent is in auth-dead state.
-// This is a single atomic read — safe to call on every tick.
+// ShouldSkip reports whether the caller should skip its HTTP work this tick.
+// When auth-dead it returns true only until the backoff has elapsed since the
+// last failure; once elapsed it returns false so the next attempt goes through
+// as a backoff-gated retry. This guarantees the agent keeps trying and can
+// self-heal once auth recovers, instead of skipping forever.
 func (m *Monitor) ShouldSkip() bool {
-	return m.dead.Load()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.dead {
+		return false
+	}
+	return m.clock().Sub(m.lastFailure) < m.backoff
 }
 
 // BackoffDuration returns the current backoff delay with jitter.

--- a/agent/internal/authstate/monitor_selfheal_test.go
+++ b/agent/internal/authstate/monitor_selfheal_test.go
@@ -1,0 +1,105 @@
+package authstate
+
+import (
+	"testing"
+	"time"
+)
+
+// trip drives the monitor to the auth-dead state using a controllable clock.
+func tripDead(m *Monitor, clk *time.Time) {
+	for i := 0; i < int(m.threshold); i++ {
+		m.RecordAuthFailure()
+	}
+	if !m.ShouldSkip() {
+		panic("expected dead immediately after threshold failures")
+	}
+	_ = clk
+}
+
+// Regression: once auth-dead, the agent must NOT skip forever. After the
+// backoff elapses, ShouldSkip() must return false so the next heartbeat is
+// attempted (a backoff-gated retry). Before the fix, ShouldSkip() returned the
+// raw dead flag and the agent stayed silent until the process restarted, even
+// after auth recovered.
+func TestMonitor_RetryAllowedAfterBackoff(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	m := NewMonitor(3)
+	m.now = func() time.Time { return now }
+
+	tripDead(m, &now)
+
+	// Within the (initial) 1s backoff window: still skipping.
+	now = now.Add(500 * time.Millisecond)
+	if !m.ShouldSkip() {
+		t.Fatal("expected ShouldSkip()=true within the backoff window")
+	}
+
+	// Backoff elapsed: a retry must be allowed.
+	now = now.Add(2 * time.Second)
+	if m.ShouldSkip() {
+		t.Fatal("expected ShouldSkip()=false after backoff elapsed (retry must be allowed) — this is the livelock fix")
+	}
+}
+
+// A successful retry after backoff clears the dead state (self-heal), which is
+// exactly what recovers an agent after a transient credential rejection.
+func TestMonitor_SelfHealsOnRetrySuccess(t *testing.T) {
+	now := time.Unix(2_000_000, 0)
+	m := NewMonitor(3)
+	m.now = func() time.Time { return now }
+
+	tripDead(m, &now)
+	now = now.Add(2 * time.Second) // past initial backoff
+	if m.ShouldSkip() {
+		t.Fatal("expected retry to be allowed after backoff")
+	}
+
+	m.RecordSuccess() // the retry succeeded
+	if m.ShouldSkip() {
+		t.Fatal("expected not-dead after a successful retry")
+	}
+}
+
+// A failed retry lengthens the backoff (exponential) and keeps skipping until
+// the new, longer window elapses — so retries slow down but never stop.
+func TestMonitor_FailedRetryLengthensBackoff(t *testing.T) {
+	now := time.Unix(3_000_000, 0)
+	m := NewMonitor(3)
+	m.now = func() time.Time { return now }
+
+	tripDead(m, &now)        // backoff = 1s
+	now = now.Add(2 * time.Second)
+	if m.ShouldSkip() {
+		t.Fatal("retry should be allowed after 1s backoff")
+	}
+
+	m.RecordAuthFailure() // retry failed -> backoff = 2s, lastFailure = now
+
+	now = now.Add(1 * time.Second) // within the new 2s window
+	if !m.ShouldSkip() {
+		t.Fatal("expected to skip within the lengthened 2s backoff window")
+	}
+	now = now.Add(2 * time.Second) // past 2s
+	if m.ShouldSkip() {
+		t.Fatal("expected retry allowed after the lengthened backoff elapsed")
+	}
+}
+
+// Backoff must cap at maxBackoff no matter how many retries fail.
+func TestMonitor_BackoffCapsAtMax(t *testing.T) {
+	now := time.Unix(4_000_000, 0)
+	m := NewMonitor(3)
+	m.now = func() time.Time { return now }
+
+	tripDead(m, &now)
+	for i := 0; i < 20; i++ {
+		m.RecordAuthFailure()
+	}
+	now = now.Add(maxBackoff)
+	// At exactly maxBackoff elapsed it should be on the boundary; just past it,
+	// a retry must be allowed (proves the window never exceeds maxBackoff).
+	now = now.Add(1 * time.Second)
+	if m.ShouldSkip() {
+		t.Fatal("expected retry allowed once maxBackoff elapsed (backoff must be capped)")
+	}
+}


### PR DESCRIPTION
## Problem

When the agent receives repeated `401`s it enters an "auth-dead" state (`authstate.Monitor`) and the heartbeat loop skips its work each tick (`heartbeat.go`: `if h.authMon.ShouldSkip() { continue }`). The intent is to back off during an auth outage.

But `ShouldSkip()` returns the raw `dead` flag and **ignores the backoff timer entirely**:

```go
func (m *Monitor) ShouldSkip() bool {
    return m.dead.Load()
}
```

`dead` is only cleared by `RecordSuccess()`, which fires on a **successful** request. Once auth-dead, every tick is skipped, so no request is made, so no success is ever recorded — the agent stays silent **forever, until the process is restarted**, even after auth has fully recovered. The `backoff`/`BackoffDuration()` machinery is computed but only ever used in a log line; there is no timed retry. There is also no token refresh on `401`.

### Impact

A **transient** credential rejection (e.g. the server momentarily returns `401` during a deploy or a database restore) permanently bricks an agent's reporting. The host stays up and healthy, but the agent never heartbeats again, so the device shows **offline indefinitely**. We observed a large fraction of a self-hosted fleet stuck "offline" this way while the machines were verifiably up — the agent processes were alive but dormant, and the server was accepting their (now-valid) credentials on a manual test. Restarting the agent immediately restored it, confirming the credential was valid and the agent was simply trapped in `ShouldSkip()`.

## Fix

Make auth-dead **time-gated** with exponential backoff:

- While dead, `ShouldSkip()` returns true only until `backoff` has elapsed since the last failure, then returns false so the **next** attempt goes through as a backoff-gated retry.
- A success on that retry clears the dead state (self-heal). A failure lengthens the backoff (exponential, capped at `maxBackoff`).

So an agent now keeps retrying on a backoff schedule and recovers on its own once auth is restored, instead of needing a process restart. Public API is unchanged (`ShouldSkip`/`RecordAuthFailure`/`RecordSuccess`/`BackoffDuration`), so all callers and the `AuthSkipper` interface are untouched.

Added a clock seam (`now func() time.Time`) for deterministic timing tests, and `monitor_selfheal_test.go` covering: retry allowed after backoff (the regression), self-heal on retry success, exponential lengthening on repeated failure, and the `maxBackoff` cap. Existing tests are unchanged and still pass.

## Testing

- `go test -race ./internal/authstate/` — green (existing + new self-heal tests)
- `GOOS=linux go build ./...` — clean (all importers compile)
- full `go test -race ./...` on linux — green

## Follow-ups (separate)

This makes the agent recover from *transient* rejections. For a *persistently* invalid credential (lost/rotated token), the agent should additionally re-enroll/refresh on sustained `401` rather than retry the same dead token forever — tracked separately.
