### PR TITLE
docs: download Caddyfile.prod in quickstart so caddy mount resolves

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ Requires [Docker](https://docs.docker.com/get-docker/) and Docker Compose.
 mkdir breeze && cd breeze
 curl -fsSLO https://raw.githubusercontent.com/lanternops/breeze/main/docker-compose.yml
 curl -fsSLO https://raw.githubusercontent.com/lanternops/breeze/main/.env.example
+# Caddy config — the compose file bind-mounts this, so it must exist on disk first.
+# (If it's missing, Docker creates docker/Caddyfile.prod as a directory and Caddy fails.)
+curl -fsSL --create-dirs -o docker/Caddyfile.prod https://raw.githubusercontent.com/lanternops/breeze/main/docker/Caddyfile.prod
 cp .env.example .env
 
 # Edit .env — at minimum set these:

--- a/apps/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/apps/docs/src/content/docs/getting-started/quickstart.mdx
@@ -18,8 +18,17 @@ Get a working Breeze instance running with a single `docker compose up`.
    mkdir breeze && cd breeze
    curl -fsSLO https://raw.githubusercontent.com/lanternops/breeze/main/docker-compose.yml
    curl -fsSLO https://raw.githubusercontent.com/lanternops/breeze/main/.env.example
+   # Caddy config — the compose file bind-mounts this, so it must exist on disk first
+   curl -fsSL --create-dirs -o docker/Caddyfile.prod https://raw.githubusercontent.com/lanternops/breeze/main/docker/Caddyfile.prod
    cp .env.example .env
    ```
+
+   <Aside type="caution">
+     Don't skip the `docker/Caddyfile.prod` download. The compose file bind-mounts
+     it into the `caddy` container; if the file isn't on disk when you run
+     `docker compose up`, Docker silently creates `docker/Caddyfile.prod` as an empty
+     **directory** and Caddy fails to start.
+   </Aside>
 
 2. **Edit `.env` and set the required values**
 


### PR DESCRIPTION
## Problem

The self-hosted quickstart (README + docs) tells users to download only two files:

```bash
curl -fsSLO .../docker-compose.yml
curl -fsSLO .../.env.example
```

But `docker-compose.yml` bind-mounts a third file that isn't in that bundle:

```yaml
caddy:
  volumes:
    - ./docker/Caddyfile.prod:/etc/caddy/Caddyfile:ro
```

When `./docker/Caddyfile.prod` isn't on the host, `docker compose up` makes the Docker daemon create it as an empty **directory** (standard behavior for a missing bind-mount source). Caddy then tries to load a directory as its config and `breeze-caddy` fails to start.

Reported by Ramphex: *"quickstart fails on breeze-caddy with a Caddyfile.prod error, it creates it as a directory since it's not part of the original curl bundle."*

## Fix

Add the missing download to both the README and the docs quickstart:

```bash
curl -fsSL --create-dirs -o docker/Caddyfile.prod \
  https://raw.githubusercontent.com/lanternops/breeze/main/docker/Caddyfile.prod
```

`--create-dirs` makes the `docker/` folder; `-o docker/Caddyfile.prod` lands it at the exact path the compose mount expects. Also adds a caution note in the quickstart explaining the directory-creation trap.

The Caddyfile is self-contained (no sibling `import`s), so it downloads standalone — consistent with the existing "single source of truth, mounted not inlined" design (see the file header + CLAUDE.md).

## Verification

- `https://raw.githubusercontent.com/lanternops/breeze/main/docker/Caddyfile.prod` returns HTTP 200.
- Confirmed `docker/Caddyfile.prod` has no `import` directives, so a standalone download is valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)