### PR TITLE
docs: publish the default RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS value

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -181,7 +181,10 @@ MFA_RECOVERY_CODE_PEPPER=generate-a-random-hex-string-for-production
 #           accept unsigned manifests, defeating the agent-update trust chain.
 # Comma-separate multiple raw base64 Ed25519 public keys during release-manifest
 # signing key rotation.
-RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=
+# The value below is the trust anchor for the official Breeze GitHub releases.
+# It is a PUBLIC key (also embedded in the agent and CI), so it is safe to ship.
+# Leave it as-is unless you build and sign your own binaries.
+RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=
 # Default TTL (minutes) for newly created enrollment keys when expiresAt is not provided.
 ENROLLMENT_KEY_DEFAULT_TTL_MINUTES=60
 

--- a/apps/docs/src/content/docs/deploy/binaries.mdx
+++ b/apps/docs/src/content/docs/deploy/binaries.mdx
@@ -36,7 +36,13 @@ On startup, the API calls GitHub's Releases API to register the current version'
 
 In production, GitHub mode requires the `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` env var. This is the base64 SPKI of the Ed25519 public key that signs our release manifests. The API verifies every fetched manifest against this key before trusting its checksums, so a compromised GitHub release alone can't deliver tampered binaries.
 
-The published default works for the official Breeze releases; only override it if you build and sign your own binaries. The API refuses to start in production without it.
+For the official Breeze releases, use the published trust anchor:
+
+```bash
+RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=
+```
+
+This is a public key (also embedded in the agent and CI), so it is safe to commit. Only override it if you build and sign your own binaries. The API refuses to start in production without it. During a signing-key rotation you can trust multiple keys at once by comma-separating them (`RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=old,new`).
 
 ### Local Mode
 

--- a/apps/docs/src/content/docs/deploy/environment.mdx
+++ b/apps/docs/src/content/docs/deploy/environment.mdx
@@ -105,7 +105,7 @@ All configuration is done through environment variables, defined in your `.env.p
 | `HELPER_BINARY_DIR` | `/data/binaries/helper` | | Local directory containing helper binaries |
 | `BINARY_VERSION_FILE` | — | | Path to `VERSION` file for local mode DB registration (set automatically in Docker Compose) |
 | `BINARY_VERSION` | — | | Release tag for GitHub redirect mode (falls back to `BREEZE_VERSION`, then `latest`) |
-| `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` | — | Yes (prod) | Comma-separated base64 SPKI of the Ed25519 keys that sign release manifests. The API refuses to start in production without it. `BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` is accepted as an alias. |
+| `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` | `yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=` (official releases) | Yes (prod) | Comma-separated raw base64 Ed25519 public keys that sign release manifests. Use the published default for official Breeze releases (it is a public key, safe to commit); only change it if you sign your own binaries. The API refuses to start in production without it. `BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` is accepted as an alias. |
 
 See [Binary Distribution](/deploy/binaries/) for details on local vs GitHub mode and S3 offloading.
 

--- a/apps/docs/src/content/docs/deploy/production.mdx
+++ b/apps/docs/src/content/docs/deploy/production.mdx
@@ -73,10 +73,10 @@ An optional monitoring stack (Prometheus, Grafana, Alertmanager, Loki, Promtail,
    # Self-hosted by default. Set to "true" only if you're running the hosted SaaS edition.
    IS_HOSTED=false
 
-   # Base64 SPKI of the Ed25519 key used to sign release manifests. The hosted releases
-   # we publish on GitHub are anchored to this key — leave the published default unless
-   # you build and sign your own binaries.
-   RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=<base64-spki>
+   # Trust anchor (raw base64 Ed25519 public key) for the official Breeze GitHub
+   # releases. This is a public key — also embedded in the agent and CI — so it is
+   # safe to commit. Leave the default below unless you build and sign your own binaries.
+   RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=
    ```
 
    If Breeze is behind a reverse proxy, also set `TRUST_PROXY_HEADERS=true` and list the proxy's CIDRs in `TRUSTED_PROXY_CIDRS`. See [Environment Variables](/deploy/environment/) for details.

--- a/apps/docs/src/content/docs/reference/troubleshooting.mdx
+++ b/apps/docs/src/content/docs/reference/troubleshooting.mdx
@@ -23,6 +23,20 @@ AGENT_ENROLLMENT_SECRET, METRICS_SCRAPE_TOKEN, PUBLIC_API_URL,
 GRAFANA_ADMIN_PASSWORD
 ```
 
+### API refuses to boot: `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS must be set in production`
+
+**Cause**: This variable is the trust anchor that the API uses to verify signed release manifests before serving binaries (so a compromised GitHub release alone can't deliver tampered binaries). It is **required in production** for both `BINARY_SOURCE=github` and `BINARY_SOURCE=local`. Older `.env` templates shipped it empty, so upgrades can surface this on first boot.
+
+**Fix**: For the official Breeze releases, use the published trust anchor:
+
+```bash
+RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=
+```
+
+This is a **public** key (also embedded in the agent and CI), so it is safe to commit. Only change it if you build and sign your own binaries. `BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` is accepted as an alias.
+
+**Do not auto-rotate or overwrite this value.** It is a deliberately pinned trust anchor — automatically replacing it with a "new" key defeats the protection, since the source of that key becomes the thing an attacker targets. If a real signing-key rotation ever ships, trust both keys during the overlap by comma-separating them (`RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=old,new`) rather than replacing.
+
 ### TLS certificate not provisioning
 
 **Cause**: DNS not pointing to server, or ports 80/443 blocked.

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -75,7 +75,10 @@ APP_ENCRYPTION_KEY=
 MFA_ENCRYPTION_KEY=
 ENROLLMENT_KEY_PEPPER=
 MFA_RECOVERY_CODE_PEPPER=
-RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=
+# Trust anchor for the official Breeze GitHub releases. Required in production for
+# both BINARY_SOURCE=github and BINARY_SOURCE=local. This is a PUBLIC key (also
+# embedded in the agent and CI); leave it as-is unless you sign your own binaries.
+RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=
 
 # Kill-switches for the launch-readiness MFA and lockout features.
 # Defaults are secure (gate ON, lockout 5-in-15min). Operators can flip


### PR DESCRIPTION
## Problem

Self-hosters deploying with `BINARY_SOURCE=github` hit a hard boot failure (`RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS must be set in production`) because the var is required in prod but its "published default" was never actually printed anywhere they look:

- `.env.example` and `deploy/.env.example` shipped the var **empty**
- `production.mdx` showed a `<base64-spki>` placeholder
- `binaries.mdx` referenced "the published default" without giving the value
- release assets only include the manifest + signatures, not the public key

Reported by a v0.69.0 self-hoster in Discord (after checking all of the above). Tracked in #1109.

## Fix

The key is already public (committed in `agent/internal/updater/updater.go` as the agent's embedded trust root, and in CI), so printing it leaks nothing. This PR:

- Pre-fills `yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=` in both `.env.example` files
- Prints it in `production.mdx`, `binaries.mdx`, and the `environment.mdx` reference table
- Notes it is a public key (safe to commit) and that rotation supports a comma-separated `old,new` list

Value verified to match the canonical anchor in `agent/internal/updater/updater.go` exactly.

## Files

- `.env.example`, `deploy/.env.example`
- `apps/docs/src/content/docs/deploy/production.mdx`
- `apps/docs/src/content/docs/deploy/binaries.mdx`
- `apps/docs/src/content/docs/deploy/environment.mdx`

Closes #1109

🤖 Generated with [Claude Code](https://claude.com/claude-code)