### PR TITLE
fix(watchdog): execute commands delivered inline on the heartbeat response (#1103)

### DIFF
--- a/agent/cmd/breeze-watchdog/heartbeat_commands_test.go
+++ b/agent/cmd/breeze-watchdog/heartbeat_commands_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/watchdog"
+)
+
+// TestProcessHeartbeatResponse_ExecutesInlineCommands is a regression test for
+// #1103. The server claims pending watchdog-targeted commands during the
+// heartbeat itself (marking them 'sent') and returns them inline on the
+// heartbeat response, so the separate command poll never sees them. Before the
+// fix, processHeartbeatResponse ignored resp.Commands, so a watchdog-targeted
+// command (e.g. restart_agent) was consumed but never executed.
+//
+// An unknown command type is used so the dispatch path is exercised end to end
+// (handleFailoverCommand -> SubmitCommandResult) without triggering a real
+// service restart. wd/cfg/tokens/recovery are unused for an unknown type, so
+// nil is safe.
+func TestProcessHeartbeatResponse_ExecutesInlineCommands(t *testing.T) {
+	var (
+		mu        sync.Mutex
+		gotResult bool
+		gotStatus string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/commands/cmd-test-1/result") {
+			body, _ := io.ReadAll(r.Body)
+			var parsed map[string]any
+			_ = json.Unmarshal(body, &parsed)
+			mu.Lock()
+			gotResult = true
+			gotStatus, _ = parsed["status"].(string)
+			mu.Unlock()
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	fc := watchdog.NewFailoverClient(srv.URL, "agent-1", "token", nil)
+	journal, err := watchdog.NewJournal(t.TempDir(), 1, 1)
+	if err != nil {
+		t.Fatalf("NewJournal: %v", err)
+	}
+
+	resp := &watchdog.HeartbeatResponse{
+		Commands: []watchdog.FailoverCommand{
+			{ID: "cmd-test-1", Type: "unknown_test_command"},
+		},
+	}
+
+	processHeartbeatResponse(fc, resp, nil, journal, nil, nil, nil)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !gotResult {
+		t.Fatal("inline heartbeat command was not dispatched (SubmitCommandResult never called) — #1103 regression")
+	}
+	if gotStatus != "failed" {
+		t.Fatalf("expected status \"failed\" for an unknown command type, got %q", gotStatus)
+	}
+}

--- a/agent/cmd/breeze-watchdog/main.go
+++ b/agent/cmd/breeze-watchdog/main.go
@@ -465,7 +465,7 @@ func runWatchdog(stopCh <-chan struct{}) {
 						"error": err.Error(),
 					})
 				} else {
-					processHeartbeatResponse(resp, wd, journal, cfg, tokenStore, recovery)
+					processHeartbeatResponse(failoverClient, resp, wd, journal, cfg, tokenStore, recovery)
 				}
 			}
 
@@ -569,7 +569,7 @@ func handleFailoverPoll(
 		})
 		return
 	}
-	processHeartbeatResponse(resp, wd, journal, cfg, tokens, recovery)
+	processHeartbeatResponse(fc, resp, wd, journal, cfg, tokens, recovery)
 
 	// Poll for commands.
 	commands, err := fc.PollCommands()
@@ -585,8 +585,9 @@ func handleFailoverPoll(
 	}
 }
 
-// processHeartbeatResponse handles upgrade directives from the API.
+// processHeartbeatResponse handles upgrade directives and commands from the API.
 func processHeartbeatResponse(
+	fc *watchdog.FailoverClient,
 	resp *watchdog.HeartbeatResponse,
 	wd *watchdog.Watchdog,
 	journal *watchdog.Journal,
@@ -608,6 +609,14 @@ func processHeartbeatResponse(
 			"version": resp.WatchdogUpgradeTo,
 		})
 		doUpdateWatchdog(resp.WatchdogUpgradeTo, cfg, tokens, journal)
+	}
+	// Execute commands delivered inline on the heartbeat response. The server
+	// claims pending watchdog-targeted commands during the heartbeat itself
+	// (marking them 'sent') and returns them here, so the separate command
+	// poll never sees them. Without dispatching them here a watchdog-targeted
+	// command (e.g. restart_agent) is consumed but never run. (#1103)
+	for _, cmd := range resp.Commands {
+		handleFailoverCommand(fc, cmd, wd, journal, cfg, tokens, recovery)
 	}
 }
 


### PR DESCRIPTION
Fixes #1103.

## Problem
The failover heartbeat claims pending watchdog-targeted commands server-side (`heartbeat.ts:160` → `commandDispatch.ts` flips them `pending`→`sent`) and returns them in the response `commands` array (`heartbeat.ts:195-199`). But `processHeartbeatResponse` only branched on `UpgradeTo`/`WatchdogUpgradeTo` and **ignored `resp.Commands`**, while the watchdog only *executed* commands from the separate `PollCommands()` (which returns only `pending`). Since the heartbeat runs first each cycle and marks the rows `sent`, the poll returns nothing — so a watchdog-targeted command (e.g. `restart_agent`) was consumed but never run, stuck `sent` forever.

## Fix
Dispatch `resp.Commands` via `handleFailoverCommand` inside `processHeartbeatResponse` (threading the `FailoverClient` through so results are reported). This mirrors how the agent's main loop already handles heartbeat-delivered commands, and is the option recommended in the issue triage. The existing `PollCommands()` path is left in place as a harmless no-op fallback.

## Verification
- New regression test `TestProcessHeartbeatResponse_ExecutesInlineCommands` (uses an unknown command type so it exercises the dispatch path end-to-end — `handleFailoverCommand` → `SubmitCommandResult` — without triggering a real service restart). Fails before the change, passes after.
- `CGO_ENABLED=0 go test ./cmd/breeze-watchdog/ ./internal/watchdog/...` ✅
- `CGO_ENABLED=0 go build ./...` and `go vet ./...` clean.

Verified against `main` HEAD. Pairs with #1104; per the triage, landing this first unblocks command-based recovery of a same-version wedged agent.
