### PR TITLE
fix(api): send agent upgradeTo on the watchdog heartbeat so a live watchdog can recover a wedged agent (#1104)

### DIFF
--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -191,6 +191,38 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
       }
     }
 
+    // Check for a pending *agent* upgrade so a live watchdog can recover a
+    // wedged or behind-version main agent. The watchdog already acts on
+    // `upgradeTo` (processHeartbeatResponse -> doUpdateAgent) but the server
+    // never populated it on the watchdog branch, so a watchdog had no way to
+    // pull the main agent forward. The watchdog reports its *own* version in
+    // `data.agentVersion`, so compare the device's recorded main-agent version
+    // (`device.agentVersion`) against the latest agent release. (#1104)
+    let upgradeTo: string | undefined;
+    if (normalizedArch && device.agentVersion && !device.agentVersion.startsWith('dev-')) {
+      try {
+        const [latestAgent] = await db
+          .select({ version: agentVersions.version })
+          .from(agentVersions)
+          .where(
+            and(
+              eq(agentVersions.platform, device.osType),
+              eq(agentVersions.architecture, normalizedArch),
+              eq(agentVersions.component, 'agent'),
+              eq(agentVersions.isLatest, true)
+            )
+          )
+          .orderBy(desc(agentVersions.createdAt)) // newest first if multiple isLatest rows exist
+          .limit(1);
+
+        if (latestAgent && compareAgentVersions(latestAgent.version, device.agentVersion) > 0) {
+          upgradeTo = latestAgent.version;
+        }
+      } catch (err) {
+        console.error(`[agents] failed to evaluate agent upgrade target (watchdog path) for ${agentId}:`, err);
+      }
+    }
+
     return c.json({
       commands: watchdogCommands.map(cmd => ({
         id: cmd.id,
@@ -198,6 +230,7 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
         payload: cmd.payload,
       })),
       watchdogUpgradeTo,
+      upgradeTo,
     });
   }
 


### PR DESCRIPTION
Fixes #1104.

## Problem
The watchdog branch of `POST /agents/:id/heartbeat` returned `commands` and `watchdogUpgradeTo` but **never an agent `upgradeTo`**, even when the device's recorded main-agent version was behind latest. The watchdog already acts on `upgradeTo` (`processHeartbeatResponse` → `doUpdateAgent`), and the #800 detector already flags the watchdog-alive / main-agent-silent asymmetry — but nothing handed the watchdog an actionable directive. So a wedged or behind-version main agent had **no server-side recovery path**: the watchdog could update itself but was never told to update/restart the agent.

## Fix
Compute the agent upgrade target in the watchdog branch, mirroring the adjacent `watchdogUpgradeTo` block and the main-agent path: compare the device's recorded **main-agent** version (`device.agentVersion` — not the watchdog's own reported `data.agentVersion`) against the latest `agent` release via `compareAgentVersions`, and return it as `upgradeTo`. `dev-*` builds are left alone, matching the main-agent path.

## Verification
- `tsc --noEmit` clean.
- Full API vitest suite green: **5808 passed, 28 skipped, 0 failed** (incl. the watchdog-role heartbeat tests).
- `eslint` clean on the changed file.

## Notes
Pairs with #1103 (PR #1111). Per the triage, version-gated recovery here covers a *behind-version* wedge; a *same-version* wedged agent is recovered by a `restart_agent` command, whose delivery #1103 fixes — so the two together give full coverage. Verified against `main` HEAD.
