### PR TITLE
fix(auth): rotation leeway so a hard refresh doesn't log users out (#1107)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,14 @@ JWT_ACTIVE_KID=
 # AUTH_COOKIE_FORCE_SECURE=false
 # PORTAL_COOKIE_FORCE_SECURE=false
 
+# Refresh-token rotation leeway, in seconds (#1107). Within this window after a
+# refresh token is legitimately rotated, replaying the just-rotated token is
+# treated as a benign concurrent race (multi-tab / heartbeat / page reload mid-
+# refresh) instead of a reuse attack, so the browser is not logged out on a hard
+# refresh. The replayed token still cannot mint anything. Set to 0 to restore
+# strict, no-leeway reuse-detection. Default: 15.
+# REFRESH_ROTATION_GRACE_SECONDS=15
+
 # Agent enrollment secret (for device registration)
 # Use: openssl rand -hex 32
 # In production, agents must provide this during enrollment:

--- a/apps/api/src/__tests__/integration/refresh-token-family.integration.test.ts
+++ b/apps/api/src/__tests__/integration/refresh-token-family.integration.test.ts
@@ -14,7 +14,7 @@
  *
  * See Task 7 of the launch-readiness fixes plan.
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { Hono } from 'hono';
 import { eq } from 'drizzle-orm';
 import { generate, generateSecret } from 'otplib';
@@ -90,12 +90,25 @@ async function refreshWithCookies(
 describe('Refresh-Token Family Revocation (Task 7)', () => {
   let app: Hono;
   let testPartnerId: string;
+  let prevGrace: string | undefined;
 
   beforeEach(async () => {
+    // These tests assert the STRICT reuse-detection contract: an immediate
+    // replay of a revoked jti kills the family. The #1107 rotation-leeway
+    // (default 15s) would otherwise treat that immediate replay as a benign
+    // race, so we pin leeway to 0 here. The benign-race behaviour is covered
+    // separately below.
+    prevGrace = process.env.REFRESH_ROTATION_GRACE_SECONDS;
+    process.env.REFRESH_ROTATION_GRACE_SECONDS = '0';
     app = new Hono();
     app.route('/auth', authRoutes);
     const partner = await createPartner();
     testPartnerId = partner.id;
+  });
+
+  afterEach(() => {
+    if (prevGrace === undefined) delete process.env.REFRESH_ROTATION_GRACE_SECONDS;
+    else process.env.REFRESH_ROTATION_GRACE_SECONDS = prevGrace;
   });
 
   it('revokes the entire family when a revoked jti is replayed (reuse detected)', async () => {
@@ -271,5 +284,53 @@ describe('Refresh-Token Family Revocation (Task 7)', () => {
     // …but family 2 must still be alive — separate /login = separate family.
     const stillAlive = await refreshWithCookies(app, cookiesFam2);
     expect(stillAlive.status).toBe(200);
+  });
+});
+
+describe('Refresh-Token Rotation Leeway (#1107)', () => {
+  let app: Hono;
+  let testPartnerId: string;
+  let prevGrace: string | undefined;
+
+  beforeEach(async () => {
+    // Exercise the leeway path with a generous window so an immediate replay
+    // lands inside it.
+    prevGrace = process.env.REFRESH_ROTATION_GRACE_SECONDS;
+    process.env.REFRESH_ROTATION_GRACE_SECONDS = '30';
+    app = new Hono();
+    app.route('/auth', authRoutes);
+    const partner = await createPartner();
+    testPartnerId = partner.id;
+  });
+
+  afterEach(() => {
+    if (prevGrace === undefined) delete process.env.REFRESH_ROTATION_GRACE_SECONDS;
+    else process.env.REFRESH_ROTATION_GRACE_SECONDS = prevGrace;
+  });
+
+  it('does NOT kill the family when a just-rotated jti is replayed within the leeway window', async () => {
+    await createUser({
+      partnerId: testPartnerId,
+      email: 'leeway@example.com',
+      password: 'FamilyPass123!'
+    });
+
+    // login → A
+    const cookiesA = await loginAndExtractCookies(app, 'leeway@example.com', 'FamilyPass123!');
+
+    // rotate A → B (A revoked, grace marker dropped for A)
+    const r2 = await refreshWithCookies(app, cookiesA);
+    expect(r2.status).toBe(200);
+    const cookiesB = r2.nextCookies!;
+
+    // Replay A immediately (multi-tab / reload-mid-flight). Within the leeway
+    // window this is a benign race: rejected (can't mint) but the family must
+    // SURVIVE so the winning sibling's cookie B keeps working.
+    const replay = await refreshWithCookies(app, cookiesA);
+    expect(replay.status).toBe(401);
+
+    // The critical assertion: B is still alive — the family was NOT revoked.
+    const followup = await refreshWithCookies(app, cookiesB);
+    expect(followup.status).toBe(200);
   });
 });

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -26,6 +26,10 @@ vi.mock('../services', () => ({
   revokeAllUserTokens: vi.fn().mockResolvedValue(undefined),
   isRefreshTokenJtiRevoked: vi.fn().mockResolvedValue(false),
   revokeRefreshTokenJti: vi.fn().mockResolvedValue(true),
+  // #1107: rotation-grace helpers. Default mock = "not recently rotated" so
+  // existing reuse-detection tests keep exercising the family-kill path.
+  markRefreshTokenJtiRotated: vi.fn().mockResolvedValue(undefined),
+  wasRefreshTokenJtiRecentlyRotated: vi.fn().mockResolvedValue(false),
   // Task 7: refresh-token family revocation helpers. Default mock behaviour
   // mirrors a healthy "no reuse, no revocation" path so existing /refresh
   // tests continue to assert success on the happy path.
@@ -172,6 +176,10 @@ import {
   revokeAllUserTokens,
   isRefreshTokenJtiRevoked,
   revokeRefreshTokenJti,
+  markRefreshTokenJtiRotated,
+  wasRefreshTokenJtiRecentlyRotated,
+  revokeFamily,
+  getFamilyForJti,
   getTrustedClientIp,
   rateLimiter,
   getRedis,
@@ -203,6 +211,10 @@ describe('auth routes', () => {
     });
     vi.mocked(isUserTokenRevoked).mockResolvedValue(false);
     vi.mocked(isRefreshTokenJtiRevoked).mockResolvedValue(false);
+    // #1107: reset rotation-grace + family helpers to the happy-path baseline.
+    vi.mocked(revokeRefreshTokenJti).mockResolvedValue(true);
+    vi.mocked(wasRefreshTokenJtiRecentlyRotated).mockResolvedValue(false);
+    vi.mocked(getFamilyForJti).mockResolvedValue(null);
     vi.mocked(getTrustedClientIp).mockReturnValue('127.0.0.1');
     vi.mocked(rateLimiter).mockResolvedValue({ allowed: true, remaining: 4, resetAt: new Date() });
     // Task 10: reset lockout-helper mocks to the "not locked" happy path so
@@ -1227,6 +1239,123 @@ describe('auth routes', () => {
 
       expect(res.status).toBe(401);
       expect(createTokenPair).not.toHaveBeenCalled();
+      // #1107: a lost race must surface refresh_raced and must NOT clear the
+      // cookie — the winning sibling already set a fresh one this browser shares.
+      const body = await res.json();
+      expect(body.reason).toBe('refresh_raced');
+      const setCookie = res.headers.get('set-cookie') ?? '';
+      expect(setCookie).not.toContain('breeze_refresh_token=;');
+    });
+
+    it('#1107: benign concurrent replay within the rotation-grace window is not treated as reuse', async () => {
+      // The same cookie is replayed seconds after its own legitimate rotation
+      // (multi-tab / heartbeat / reload-mid-flight). isRefreshTokenJtiRevoked is
+      // true, but wasRefreshTokenJtiRecentlyRotated is also true → benign race.
+      vi.mocked(isRefreshTokenJtiRevoked).mockResolvedValue(true);
+      vi.mocked(wasRefreshTokenJtiRecentlyRotated).mockResolvedValue(true);
+      vi.mocked(getFamilyForJti).mockResolvedValue('fam-raced');
+      vi.mocked(verifyToken).mockResolvedValue({
+        sub: 'user-123',
+        email: 'test@example.com',
+        roleId: null,
+        orgId: null,
+        partnerId: null,
+        scope: 'system',
+        type: 'refresh',
+        mfa: false,
+        iat: 123456,
+        jti: 'refresh-jti-graced'
+      });
+
+      const res = await app.request('/auth/refresh', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-breeze-csrf': 'test-csrf-token',
+          Cookie: 'breeze_refresh_token=graced-refresh-token; breeze_csrf_token=test-csrf-token'
+        }
+      });
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.reason).toBe('refresh_raced');
+      // The whole point: the family must survive, and the cookie must NOT be cleared.
+      expect(revokeFamily).not.toHaveBeenCalled();
+      expect(createTokenPair).not.toHaveBeenCalled();
+      const setCookie = res.headers.get('set-cookie') ?? '';
+      expect(setCookie).not.toContain('breeze_refresh_token=;');
+    });
+
+    it('#1107: a genuine replay outside the grace window still kills the family', async () => {
+      // Revoked jti, NOT recently rotated → real token-reuse → family revoked.
+      vi.mocked(isRefreshTokenJtiRevoked).mockResolvedValue(true);
+      vi.mocked(wasRefreshTokenJtiRecentlyRotated).mockResolvedValue(false);
+      vi.mocked(getFamilyForJti).mockResolvedValue('fam-attacked');
+      vi.mocked(verifyToken).mockResolvedValue({
+        sub: 'user-123',
+        email: 'test@example.com',
+        roleId: null,
+        orgId: null,
+        partnerId: null,
+        scope: 'system',
+        type: 'refresh',
+        mfa: false,
+        iat: 123456,
+        jti: 'refresh-jti-stolen'
+      });
+
+      const res = await app.request('/auth/refresh', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-breeze-csrf': 'test-csrf-token',
+          Cookie: 'breeze_refresh_token=stolen-refresh-token; breeze_csrf_token=test-csrf-token'
+        }
+      });
+
+      expect(res.status).toBe(401);
+      expect(revokeFamily).toHaveBeenCalledWith('fam-attacked', 'reuse-detected');
+      // Genuine reuse DOES clear the cookie.
+      const setCookie = res.headers.get('set-cookie') ?? '';
+      expect(setCookie).toContain('breeze_refresh_token=;');
+    });
+
+    it('#1107: a successful refresh records a rotation-grace marker for the old jti', async () => {
+      vi.mocked(verifyToken).mockResolvedValue({
+        sub: 'user-123',
+        email: 'test@example.com',
+        roleId: 'role-1',
+        orgId: 'org-1',
+        partnerId: null,
+        scope: 'organization',
+        type: 'refresh',
+        mfa: false,
+        iat: 123456,
+        jti: 'refresh-jti-winner'
+      });
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: 'user-123',
+              email: 'test@example.com',
+              status: 'active'
+            }])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/auth/refresh', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-breeze-csrf': 'test-csrf-token',
+          Cookie: 'breeze_refresh_token=winning-refresh-token; breeze_csrf_token=test-csrf-token'
+        }
+      });
+
+      expect(res.status).toBe(200);
+      expect(markRefreshTokenJtiRotated).toHaveBeenCalledWith('refresh-jti-winner');
     });
 
     it('should re-derive token claims from current memberships', async () => {

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -1356,6 +1356,13 @@ describe('auth routes', () => {
 
       expect(res.status).toBe(200);
       expect(markRefreshTokenJtiRotated).toHaveBeenCalledWith('refresh-jti-winner');
+      // Ordering is load-bearing (#1107): the grace marker MUST be written
+      // before the jti is revoked, so a concurrent racer that observes the
+      // revoked state also observes the marker and treats the replay as benign
+      // instead of killing the family. Lock the order in against refactors.
+      const markOrder = vi.mocked(markRefreshTokenJtiRotated).mock.invocationCallOrder[0];
+      const revokeOrder = vi.mocked(revokeRefreshTokenJti).mock.invocationCallOrder[0];
+      expect(markOrder).toBeLessThan(revokeOrder);
     });
 
     it('should re-derive token claims from current memberships', async () => {

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -1360,8 +1360,8 @@ describe('auth routes', () => {
       // before the jti is revoked, so a concurrent racer that observes the
       // revoked state also observes the marker and treats the replay as benign
       // instead of killing the family. Lock the order in against refactors.
-      const markOrder = vi.mocked(markRefreshTokenJtiRotated).mock.invocationCallOrder[0];
-      const revokeOrder = vi.mocked(revokeRefreshTokenJti).mock.invocationCallOrder[0];
+      const markOrder = vi.mocked(markRefreshTokenJtiRotated).mock.invocationCallOrder[0]!;
+      const revokeOrder = vi.mocked(revokeRefreshTokenJti).mock.invocationCallOrder[0]!;
       expect(markOrder).toBeLessThan(revokeOrder);
     });
 

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -14,6 +14,8 @@ import {
   isRefreshTokenJtiRevoked,
   revokeAllUserTokens,
   revokeRefreshTokenJti,
+  markRefreshTokenJtiRotated,
+  wasRefreshTokenJtiRecentlyRotated,
   getFamilyForJti,
   revokeFamily,
   isFamilyRevoked,
@@ -560,6 +562,19 @@ loginRoutes.post('/refresh', async (c) => {
   // user's next rotation.
   const jtiAlreadyRevoked = await isRefreshTokenJtiRevoked(payload.jti);
   if (jtiAlreadyRevoked) {
+    // Distinguish a benign concurrent/double-fired refresh from a true
+    // token-reuse attack. The same cookie replayed within seconds of its own
+    // legitimate rotation (multiple tabs sharing the cookie jar, the periodic
+    // heartbeat refresh, or a page reload fired while a refresh was already in
+    // flight) is NOT an attack: the winning sibling already minted a fresh
+    // cookie this browser shares. We must NOT revoke the family and must NOT
+    // clear the cookie — clearing it would wipe the winner's valid token and
+    // log the user out (issue #1107). The loser just retries and picks up the
+    // winner's new token. Only a replay OUTSIDE the grace window (an old,
+    // long-rotated jti) is treated as reuse and kills the family.
+    if (await wasRefreshTokenJtiRecentlyRotated(payload.jti)) {
+      return c.json({ error: 'Refresh already in progress', reason: 'refresh_raced' }, 401);
+    }
     if (familyId) {
       await revokeFamily(familyId, 'reuse-detected');
       createAuditLogAsync({
@@ -625,6 +640,11 @@ loginRoutes.post('/refresh', async (c) => {
   // we must NOT issue a new cookie. `revokeRefreshTokenJti` returns false when
   // the jti was already claimed (NX failed) — that proves another /refresh
   // raced us, so the legitimate path is to refuse and let the loser retry.
+  // Drop the rotation-grace marker BEFORE revoking the old jti so it is
+  // already present whenever the revoked state becomes visible to a concurrent
+  // racer (see the reuse-detection branch above, issue #1107).
+  await markRefreshTokenJtiRotated(payload.jti);
+
   let claimedRevocation: boolean;
   try {
     claimedRevocation = await revokeRefreshTokenJti(payload.jti);
@@ -634,12 +654,13 @@ loginRoutes.post('/refresh', async (c) => {
     return c.json({ error: 'Invalid refresh token' }, 401);
   }
   if (!claimedRevocation) {
-    // Another /refresh already revoked this jti. Either the legitimate client
-    // double-fired the same cookie (e.g. React strict-mode) or an attacker is
-    // racing us. Both branches must refuse — only one new token pair can exist
-    // per old jti, and we are not the winner.
-    clearRefreshTokenCookie(c);
-    return c.json({ error: 'Invalid refresh token' }, 401);
+    // Another /refresh already revoked this jti — the legitimate client
+    // double-fired the same cookie (multi-tab, heartbeat, reload-mid-flight).
+    // We lost the race, so we must not mint a new pair, but we must also NOT
+    // clear the cookie: the winning sibling already set a fresh cookie this
+    // browser shares, and clearing it would log the user out (#1107). Surface
+    // a distinct reason so the client retries rather than redirecting to login.
+    return c.json({ error: 'Refresh already in progress', reason: 'refresh_raced' }, 401);
   }
 
   // Create new token pair. Inherit the family from the verified claim (or

--- a/apps/api/src/services/tokenRevocation.test.ts
+++ b/apps/api/src/services/tokenRevocation.test.ts
@@ -376,12 +376,48 @@ describe('tokenRevocation', () => {
 
   describe('rotation-grace markers (#1107)', () => {
     it('markRefreshTokenJtiRotated writes a short-lived grace key (default 15s)', async () => {
-      const { redis } = createMockRedis();
-      mockGetRedis.mockReturnValue(redis);
+      const prev = process.env.REFRESH_ROTATION_GRACE_SECONDS;
+      delete process.env.REFRESH_ROTATION_GRACE_SECONDS; // pin the default, don't rely on global state
+      try {
+        const { redis } = createMockRedis();
+        mockGetRedis.mockReturnValue(redis);
 
-      await markRefreshTokenJtiRotated('jti-rot');
+        await markRefreshTokenJtiRotated('jti-rot');
 
-      expect(redis.setex).toHaveBeenCalledWith('refresh-rotated-grace:jti-rot', 15, '1');
+        expect(redis.setex).toHaveBeenCalledWith('refresh-rotated-grace:jti-rot', 15, '1');
+      } finally {
+        if (prev === undefined) delete process.env.REFRESH_ROTATION_GRACE_SECONDS;
+        else process.env.REFRESH_ROTATION_GRACE_SECONDS = prev;
+      }
+    });
+
+    it('parses REFRESH_ROTATION_GRACE_SECONDS: honors a custom value, falls back to 15 on garbage/negative', async () => {
+      const prev = process.env.REFRESH_ROTATION_GRACE_SECONDS;
+      try {
+        // Custom positive value flows into the marker TTL end-to-end.
+        process.env.REFRESH_ROTATION_GRACE_SECONDS = '30';
+        let redis = createMockRedis().redis;
+        mockGetRedis.mockReturnValue(redis);
+        await markRefreshTokenJtiRotated('jti-30');
+        expect(redis.setex).toHaveBeenCalledWith('refresh-rotated-grace:jti-30', 30, '1');
+
+        // Non-numeric → default 15.
+        process.env.REFRESH_ROTATION_GRACE_SECONDS = 'abc';
+        redis = createMockRedis().redis;
+        mockGetRedis.mockReturnValue(redis);
+        await markRefreshTokenJtiRotated('jti-nan');
+        expect(redis.setex).toHaveBeenCalledWith('refresh-rotated-grace:jti-nan', 15, '1');
+
+        // Negative → default 15 (the `raw >= 0` guard rejects it).
+        process.env.REFRESH_ROTATION_GRACE_SECONDS = '-5';
+        redis = createMockRedis().redis;
+        mockGetRedis.mockReturnValue(redis);
+        await markRefreshTokenJtiRotated('jti-neg');
+        expect(redis.setex).toHaveBeenCalledWith('refresh-rotated-grace:jti-neg', 15, '1');
+      } finally {
+        if (prev === undefined) delete process.env.REFRESH_ROTATION_GRACE_SECONDS;
+        else process.env.REFRESH_ROTATION_GRACE_SECONDS = prev;
+      }
     });
 
     it('strict mode (REFRESH_ROTATION_GRACE_SECONDS=0) writes no marker and never reports recent rotation', async () => {

--- a/apps/api/src/services/tokenRevocation.test.ts
+++ b/apps/api/src/services/tokenRevocation.test.ts
@@ -11,7 +11,9 @@ import {
   isUserTokenRevoked,
   revokeAllUserTokens,
   isRefreshTokenJtiRevoked,
-  revokeRefreshTokenJti
+  revokeRefreshTokenJti,
+  markRefreshTokenJtiRotated,
+  wasRefreshTokenJtiRecentlyRotated
 } from './tokenRevocation';
 
 const mockGetRedis = vi.mocked(getRedis);
@@ -369,6 +371,86 @@ describe('tokenRevocation', () => {
         expect.stringContaining('Failed to revoke refresh token'),
         expect.any(Error)
       );
+    });
+  });
+
+  describe('rotation-grace markers (#1107)', () => {
+    it('markRefreshTokenJtiRotated writes a short-lived grace key (default 15s)', async () => {
+      const { redis } = createMockRedis();
+      mockGetRedis.mockReturnValue(redis);
+
+      await markRefreshTokenJtiRotated('jti-rot');
+
+      expect(redis.setex).toHaveBeenCalledWith('refresh-rotated-grace:jti-rot', 15, '1');
+    });
+
+    it('strict mode (REFRESH_ROTATION_GRACE_SECONDS=0) writes no marker and never reports recent rotation', async () => {
+      const prev = process.env.REFRESH_ROTATION_GRACE_SECONDS;
+      process.env.REFRESH_ROTATION_GRACE_SECONDS = '0';
+      try {
+        const { redis } = createMockRedis({ get: vi.fn().mockResolvedValue('1') });
+        mockGetRedis.mockReturnValue(redis);
+
+        await markRefreshTokenJtiRotated('jti-rot');
+        expect(redis.setex).not.toHaveBeenCalled();
+        await expect(wasRefreshTokenJtiRecentlyRotated('jti-rot')).resolves.toBe(false);
+      } finally {
+        if (prev === undefined) delete process.env.REFRESH_ROTATION_GRACE_SECONDS;
+        else process.env.REFRESH_ROTATION_GRACE_SECONDS = prev;
+      }
+    });
+
+    it('markRefreshTokenJtiRotated is a no-op (does not throw) when Redis is unavailable', async () => {
+      mockGetRedis.mockReturnValue(null as unknown as Redis);
+
+      await expect(markRefreshTokenJtiRotated('jti-rot')).resolves.toBeUndefined();
+    });
+
+    it('markRefreshTokenJtiRotated swallows Redis errors', async () => {
+      const { redis } = createMockRedis({
+        setex: vi.fn().mockRejectedValue(new Error('boom'))
+      });
+      mockGetRedis.mockReturnValue(redis);
+
+      await expect(markRefreshTokenJtiRotated('jti-rot')).resolves.toBeUndefined();
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to set refresh rotation-grace marker'),
+        expect.any(Error)
+      );
+    });
+
+    it('wasRefreshTokenJtiRecentlyRotated returns true when the grace key is present', async () => {
+      const { redis } = createMockRedis({
+        get: vi.fn().mockResolvedValue('1')
+      });
+      mockGetRedis.mockReturnValue(redis);
+
+      await expect(wasRefreshTokenJtiRecentlyRotated('jti-rot')).resolves.toBe(true);
+      expect(redis.get).toHaveBeenCalledWith('refresh-rotated-grace:jti-rot');
+    });
+
+    it('wasRefreshTokenJtiRecentlyRotated returns false on grace-key miss', async () => {
+      const { redis } = createMockRedis({
+        get: vi.fn().mockResolvedValue(null)
+      });
+      mockGetRedis.mockReturnValue(redis);
+
+      await expect(wasRefreshTokenJtiRecentlyRotated('jti-rot')).resolves.toBe(false);
+    });
+
+    it('wasRefreshTokenJtiRecentlyRotated fails toward false (genuine replay) when Redis is unavailable', async () => {
+      mockGetRedis.mockReturnValue(null as unknown as Redis);
+
+      await expect(wasRefreshTokenJtiRecentlyRotated('jti-rot')).resolves.toBe(false);
+    });
+
+    it('wasRefreshTokenJtiRecentlyRotated fails toward false when redis.get() throws', async () => {
+      const { redis } = createMockRedis({
+        get: vi.fn().mockRejectedValue(new Error('boom'))
+      });
+      mockGetRedis.mockReturnValue(redis);
+
+      await expect(wasRefreshTokenJtiRecentlyRotated('jti-rot')).resolves.toBe(false);
     });
   });
 });

--- a/apps/api/src/services/tokenRevocation.ts
+++ b/apps/api/src/services/tokenRevocation.ts
@@ -14,6 +14,25 @@ const REFRESH_FAMILY_REVOCATION_TTL_SECONDS = USER_REVOCATION_TTL_SECONDS;
 // token's family can be looked up without a DB round-trip on the hot
 // /refresh path. TTL matches the refresh token expiry + slop.
 const REFRESH_JTI_FAMILY_TTL_SECONDS = REFRESH_TOKEN_REVOCATION_TTL_SECONDS + ACCESS_TOKEN_REVOCATION_TTL_SECONDS;
+// Rotation-grace window. When a refresh jti is legitimately rotated we drop a
+// short-lived marker so that a benign concurrent/double-fired replay of the
+// SAME jti (multi-tab, the 5-min heartbeat, or a page reload fired while a
+// refresh was already in flight) is recognised as a race instead of an attack.
+// Within this window we suppress the family-wide reuse-detection kill — the
+// replayed jti is already revoked and cannot mint anything, so the only thing
+// suppressed is the escalation, never a real mint. 15s comfortably covers the
+// concurrency window (multi-tab, heartbeat, reload-mid-flight + one client
+// retry) while keeping the relaxed period — and thus the attack surface —
+// small. This is the standard "refresh-token rotation leeway / reuse interval"
+// pattern (cf. Auth0, IdentityServer). Overridable via env for ops tuning;
+// set REFRESH_ROTATION_GRACE_SECONDS=0 to restore strict, no-leeway
+// reuse-detection. Read per call so the value is runtime-tunable + testable.
+const DEFAULT_REFRESH_ROTATION_GRACE_SECONDS = 15;
+
+function getRotationGraceSeconds(): number {
+  const raw = Number.parseInt(process.env.REFRESH_ROTATION_GRACE_SECONDS ?? '', 10);
+  return Number.isFinite(raw) && raw >= 0 ? raw : DEFAULT_REFRESH_ROTATION_GRACE_SECONDS;
+}
 
 function getRevokedAccessKey(userId: string): string {
   return `token:revoked:${userId}`;
@@ -33,6 +52,10 @@ function getRefreshJtiFamilyKey(jti: string): string {
 
 function getRevokedFamilyKey(familyId: string): string {
   return `refresh-fam-revoked:${familyId}`;
+}
+
+function getRotationGraceKey(jti: string): string {
+  return `refresh-rotated-grace:${jti}`;
 }
 
 // Fail-closed: when Redis is unavailable we treat access tokens as revoked.
@@ -165,6 +188,48 @@ export async function revokeRefreshTokenJti(jti: string): Promise<boolean> {
   } catch (error) {
     console.error('[token-revocation] Failed to revoke refresh token:', error);
     throw error;
+  }
+}
+
+/**
+ * Marks a refresh-token jti as having just been legitimately rotated. Read by
+ * `wasRefreshTokenJtiRecentlyRotated` during reuse-detection to tell a benign
+ * concurrent/double-fired replay apart from a true token-reuse attack.
+ *
+ * Best-effort: a Redis outage means the marker is absent, so a concurrent
+ * replay falls through to the (conservative) family-revocation path — the
+ * safe direction. Set this BEFORE revoking the old jti so the marker is
+ * already present whenever the revoked state becomes visible to a racer.
+ */
+export async function markRefreshTokenJtiRotated(jti: string): Promise<void> {
+  const graceSeconds = getRotationGraceSeconds();
+  if (graceSeconds <= 0) return; // strict mode — no leeway marker
+  const redis = getRedis();
+  if (!redis) return;
+  try {
+    await redis.setex(getRotationGraceKey(jti), graceSeconds, '1');
+  } catch (error) {
+    console.warn('[token-revocation] Failed to set refresh rotation-grace marker:', error);
+  }
+}
+
+/**
+ * Returns true when the given jti was legitimately rotated within the
+ * rotation-grace window. A `true` result means a replay of this jti is a
+ * benign race (multi-tab / heartbeat / reload-mid-flight), not an attack.
+ *
+ * Fails toward `false` (treat as a genuine replay) on any Redis error — the
+ * conservative choice that preserves reuse-detection.
+ */
+export async function wasRefreshTokenJtiRecentlyRotated(jti: string): Promise<boolean> {
+  if (getRotationGraceSeconds() <= 0) return false; // strict mode — never benign
+  const redis = getRedis();
+  if (!redis) return false;
+  try {
+    return Boolean(await redis.get(getRotationGraceKey(jti)));
+  } catch (error) {
+    console.warn('[token-revocation] Failed to read refresh rotation-grace marker:', error);
+    return false;
   }
 }
 

--- a/apps/web/src/stores/auth.test.ts
+++ b/apps/web/src/stores/auth.test.ts
@@ -369,6 +369,33 @@ describe('refresh rotation-race recovery (#1107)', () => {
     expect(restored).toBe(false);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it('routes refresh through the Web Locks API when available, under the right lock name (#1107)', async () => {
+    // jsdom has no navigator.locks, so the rest of the suite exercises the
+    // fallback. Stub it here to prove the cross-tab serialization wiring:
+    // correct lock name, fn run inside the lock, result propagated.
+    const requestMock = vi.fn((_name: string, fn: () => Promise<unknown>) => fn());
+    const prevLocks = (navigator as unknown as { locks?: unknown }).locks;
+    Object.defineProperty(navigator, 'locks', { value: { request: requestMock }, configurable: true });
+
+    try {
+      const refreshed: Tokens = { accessToken: 'access-locked', expiresInSeconds: 3600 };
+      const fetchMock = vi.fn().mockResolvedValue(makeResponse({ tokens: refreshed }, true, 200));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const restored = await restoreAccessTokenFromCookie();
+
+      expect(restored).toBe(true);
+      expect(requestMock).toHaveBeenCalledWith('breeze-token-refresh', expect.any(Function));
+      expect(useAuthStore.getState().tokens?.accessToken).toBe('access-locked');
+    } finally {
+      if (prevLocks === undefined) {
+        delete (navigator as unknown as { locks?: unknown }).locks;
+      } else {
+        Object.defineProperty(navigator, 'locks', { value: prevLocks, configurable: true });
+      }
+    }
+  });
 });
 
 describe('waitForPendingRefresh (#950)', () => {

--- a/apps/web/src/stores/auth.test.ts
+++ b/apps/web/src/stores/auth.test.ts
@@ -306,6 +306,71 @@ describe('auth API helpers', () => {
   });
 });
 
+describe('refresh rotation-race recovery (#1107)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.removeItem('breeze-auth');
+    document.cookie = 'breeze_csrf_token=csrf-test-token; path=/';
+    useAuthStore.setState({
+      user: baseUser,
+      tokens: null,
+      isAuthenticated: true,
+      isLoading: false,
+      mfaPending: false,
+      mfaTempToken: null
+    });
+  });
+
+  const racedResponse = (): Response =>
+    ({
+      ok: false,
+      status: 401,
+      json: vi.fn().mockResolvedValue({ error: 'Refresh already in progress', reason: 'refresh_raced' })
+    }) as unknown as Response;
+
+  it('retries refresh once when the server reports a benign race, then succeeds', async () => {
+    const refreshed: Tokens = { accessToken: 'access-after-race', expiresInSeconds: 3600 };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(racedResponse())
+      .mockResolvedValueOnce(makeResponse({ tokens: refreshed }, true, 200));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const restored = await restoreAccessTokenFromCookie();
+
+    expect(restored).toBe(true);
+    // First attempt raced; the second (retry) won — exactly one retry.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls.every(([url]) => String(url).endsWith('/api/v1/auth/refresh'))).toBe(true);
+    expect(useAuthStore.getState().tokens?.accessToken).toBe('access-after-race');
+  });
+
+  it('gives up after a single retry if the race persists (no infinite loop)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(racedResponse())
+      .mockResolvedValueOnce(racedResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const restored = await restoreAccessTokenFromCookie();
+
+    expect(restored).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry on a non-raced 401 (genuine auth failure)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse({ error: 'Invalid refresh token' }, false, 401));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const restored = await restoreAccessTokenFromCookie();
+
+    expect(restored).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('waitForPendingRefresh (#950)', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -207,7 +207,15 @@ function buildApiUrl(path: string): string {
   return `${apiHost}/api/v1${cleanPath}`;
 }
 
-async function requestTokenRefresh(): Promise<Tokens | null> {
+const REFRESH_LOCK_NAME = 'breeze-token-refresh';
+
+// One low-level /auth/refresh attempt. Returns the new tokens on success, or a
+// discriminated result so the caller can tell a benign concurrent race (server
+// reason 'refresh_raced', #1107) — which is retryable — apart from a hard
+// failure. A raced 401 means the winning sibling already rotated the SHARED
+// refresh cookie and the server deliberately did NOT clear it or kill the
+// session family, so a retry picks up the fresh cookie.
+async function refreshFetchOnce(): Promise<{ tokens: Tokens | null; raced: boolean }> {
   const headers = new Headers({ 'Content-Type': 'application/json' });
   const csrfToken = readCookie(CSRF_COOKIE_NAME);
   if (csrfToken) {
@@ -227,17 +235,54 @@ async function requestTokenRefresh(): Promise<Tokens | null> {
       signal: controller.signal,
     });
   } catch {
-    return null;
+    return { tokens: null, raced: false };
   } finally {
     clearTimeout(timeout);
   }
 
-  if (!refreshResponse.ok) {
-    return null;
+  if (refreshResponse.ok) {
+    const { tokens } = await refreshResponse.json().catch(() => ({ tokens: undefined })) as { tokens?: Tokens };
+    return { tokens: tokens?.accessToken ? tokens : null, raced: false };
   }
 
-  const { tokens } = await refreshResponse.json() as { tokens?: Tokens };
-  return tokens?.accessToken ? tokens : null;
+  if (refreshResponse.status === 401) {
+    const body = await refreshResponse.json().catch(() => null) as { reason?: string } | null;
+    if (body?.reason === 'refresh_raced') {
+      return { tokens: null, raced: true };
+    }
+  }
+
+  return { tokens: null, raced: false };
+}
+
+// Serialize refresh across tabs AND across reloads via the Web Locks API.
+// Multiple browser contexts share one refresh cookie jar; without a lock they
+// can fire concurrent rotations that replay each other's just-revoked jti and
+// (pre-#1107) tripped reuse-detection, logging everyone out on a hard refresh.
+// Falls back to a direct call where Web Locks are unavailable (older browsers).
+async function withRefreshLock<T>(fn: () => Promise<T>): Promise<T> {
+  const locks = typeof navigator !== 'undefined'
+    ? (navigator as Navigator & { locks?: LockManager }).locks
+    : undefined;
+  if (!locks?.request) {
+    return fn();
+  }
+  return locks.request(REFRESH_LOCK_NAME, fn) as Promise<T>;
+}
+
+async function requestTokenRefresh(): Promise<Tokens | null> {
+  return withRefreshLock(async () => {
+    const first = await refreshFetchOnce();
+    if (first.tokens) return first.tokens;
+    if (!first.raced) return null;
+
+    // Benign race (#1107): a sibling context won the rotation. Give the
+    // winner's rotated cookie a beat to settle in the shared jar, then retry
+    // exactly once. The retry sends the now-current cookie and succeeds.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    const second = await refreshFetchOnce();
+    return second.tokens;
+  });
 }
 
 let tokenRefreshInFlight: Promise<Tokens | null> | null = null;


### PR DESCRIPTION
Fixes #1107.

## Problem
Access tokens live in memory only and are re-minted from the `breeze_refresh_token` cookie on every full page load. Browser contexts share one cookie jar, so a hard refresh, a second tab, or the 5-minute heartbeat can fire a `/auth/refresh` that replays a **just-rotated** refresh jti. The #900 reuse-detection sweep treated that benign race identically to a stolen-token replay: it revoked the entire token family and cleared the cookie, bouncing the user to `/login`. #950 only patched the `OrgSwitcher` reload path.

## ⚠️ Security-posture change (please review)
This introduces a **refresh-token rotation leeway** — the standard "reuse interval / leeway" pattern (Auth0, IdentityServer). Strict, zero-leeway OAuth 2.1 reuse-detection is fundamentally incompatible with a browser reloading mid-refresh on a shared cookie jar, so we relax it for a short, bounded window:

- Within `REFRESH_ROTATION_GRACE_SECONDS` (default **15s**, set `0` to restore strict) after a jti is legitimately rotated, replaying that jti returns `{reason:'refresh_raced'}` **without** revoking the family or clearing the cookie.
- Replays **outside** the window still kill the family — strict reuse-detection preserved.
- The replayed token is already revoked and **cannot mint anything** in either case; the leeway only suppresses the family-kill *escalation*, and it self-heals after the window.

This was an explicit product decision (leeway chosen over strict + client-only mitigation).

## Changes
**API**
- `services/tokenRevocation.ts`: `markRefreshTokenJtiRotated` / `wasRefreshTokenJtiRecentlyRotated` (env-tunable, `0` = strict).
- `routes/auth/login.ts`: leeway branch in reuse-detection; a lost NX-claim race no longer clears the cookie; both return `refresh_raced`.

**Web**
- `stores/auth.ts`: `/auth/refresh` serialized across tabs/reloads via the **Web Locks API**; retry once on a `refresh_raced` 401. Boot guards (`AuthOverlay`/`AuthGuard`/`DashboardWrapper`) inherit both.

**Ops**
- `.env.example` documents `REFRESH_ROTATION_GRACE_SECONDS`.
- Cross-origin self-hosters should set `AUTH_COOKIE_SAME_SITE=None` (secondary cause noted in the issue).

## Tests
- `tokenRevocation.test.ts`: leeway write, strict-mode no-op, fail-toward-strict on Redis error.
- `auth.test.ts`: benign race (no family-kill, cookie kept), genuine replay (family killed, cookie cleared), winner marks rotation, lost-NX keeps cookie.
- `refresh-token-family.integration.test.ts`: existing 4 reuse assertions pinned to strict + 1 new leeway test.
- web `auth.test.ts`: raced→retry→success, single-retry cap, no retry on genuine 401.

110 API + relevant web tests pass locally; integration tests run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)