### PR TITLE
fix(enrollment): CLI onboarding token can enroll a batch; honest expiry (#1108)

### DIFF
--- a/apps/api/src/routes/devices.test.ts
+++ b/apps/api/src/routes/devices.test.ts
@@ -357,6 +357,85 @@ describe('device routes', () => {
       expect(body.maxUsage).toBe(1000);
       expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({ maxUsage: 1000 }));
     });
+
+    it('floors a zero/negative/garbage count to a single use (#1108)', async () => {
+      vi.stubEnv('AGENT_ENROLLMENT_SECRET', '');
+      for (const badCount of [0, -5, 'abc']) {
+        const valuesMock = vi.fn().mockResolvedValue(undefined);
+        vi.mocked(db.select).mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ id: 'site-1' }])
+            })
+          })
+        } as any);
+        vi.mocked(db.insert).mockReturnValueOnce({ values: valuesMock } as any);
+
+        const res = await app.request('/devices/onboarding-token', {
+          method: 'POST',
+          headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+          body: JSON.stringify({ count: badCount })
+        });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.maxUsage).toBe(1);
+        expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({ maxUsage: 1 }));
+      }
+    });
+
+    it('defaults the token TTL to 60 minutes and honors a supplied ttlMinutes (#1108)', async () => {
+      vi.stubEnv('AGENT_ENROLLMENT_SECRET', '');
+
+      const captureExpiry = () => {
+        const valuesMock = vi.fn().mockResolvedValue(undefined);
+        vi.mocked(db.select).mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ id: 'site-1' }])
+            })
+          })
+        } as any);
+        vi.mocked(db.insert).mockReturnValueOnce({ values: valuesMock } as any);
+        return valuesMock;
+      };
+
+      const expiryMinutesFrom = (valuesMock: ReturnType<typeof vi.fn>): number => {
+        const { expiresAt } = valuesMock.mock.calls[0][0] as { expiresAt: Date };
+        return Math.round((expiresAt.getTime() - Date.now()) / 60000);
+      };
+
+      // Default (no ttlMinutes) → 60 min.
+      let valuesMock = captureExpiry();
+      let res = await app.request('/devices/onboarding-token', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+      expect(res.status).toBe(200);
+      expect(expiryMinutesFrom(valuesMock)).toBeGreaterThanOrEqual(59);
+      expect(expiryMinutesFrom(valuesMock)).toBeLessThanOrEqual(61);
+
+      // Supplied 1440 → ~24h.
+      valuesMock = captureExpiry();
+      res = await app.request('/devices/onboarding-token', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ttlMinutes: 1440 })
+      });
+      expect(res.status).toBe(200);
+      expect(expiryMinutesFrom(valuesMock)).toBeGreaterThanOrEqual(1439);
+      expect(expiryMinutesFrom(valuesMock)).toBeLessThanOrEqual(1441);
+
+      // Over-cap → clamped to 365 days.
+      valuesMock = captureExpiry();
+      res = await app.request('/devices/onboarding-token', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ttlMinutes: 99_999_999 })
+      });
+      expect(res.status).toBe(200);
+      expect(expiryMinutesFrom(valuesMock)).toBe(525_600);
+    });
   });
 
   describe('GET /devices', () => {

--- a/apps/api/src/routes/devices.test.ts
+++ b/apps/api/src/routes/devices.test.ts
@@ -401,7 +401,7 @@ describe('device routes', () => {
       };
 
       const expiryMinutesFrom = (valuesMock: ReturnType<typeof vi.fn>): number => {
-        const { expiresAt } = valuesMock.mock.calls[0][0] as { expiresAt: Date };
+        const { expiresAt } = valuesMock.mock.calls[0]![0] as { expiresAt: Date };
         return Math.round((expiresAt.getTime() - Date.now()) / 60000);
       };
 

--- a/apps/api/src/routes/devices.test.ts
+++ b/apps/api/src/routes/devices.test.ts
@@ -286,6 +286,77 @@ describe('device routes', () => {
       expect(body.additionalSecretRequired).toBe(true);
       expect(body.enrollmentSecret).toBe('global-secret');
     });
+
+    it('defaults to a single-use token when no count is supplied (#1108)', async () => {
+      vi.stubEnv('AGENT_ENROLLMENT_SECRET', '');
+      const valuesMock = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: 'site-1' }])
+          })
+        })
+      } as any);
+      vi.mocked(db.insert).mockReturnValueOnce({ values: valuesMock } as any);
+
+      const res = await app.request('/devices/onboarding-token', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.maxUsage).toBe(1);
+      expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({ maxUsage: 1 }));
+    });
+
+    it('honors a caller-supplied count as maxUsage for multi-machine installs (#1108)', async () => {
+      vi.stubEnv('AGENT_ENROLLMENT_SECRET', '');
+      const valuesMock = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: 'site-1' }])
+          })
+        })
+      } as any);
+      vi.mocked(db.insert).mockReturnValueOnce({ values: valuesMock } as any);
+
+      const res = await app.request('/devices/onboarding-token', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ count: 5, ttlMinutes: 1440 })
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.maxUsage).toBe(5);
+      expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({ maxUsage: 5 }));
+    });
+
+    it('clamps an out-of-range count to the allowed bounds (#1108)', async () => {
+      vi.stubEnv('AGENT_ENROLLMENT_SECRET', '');
+      const valuesMock = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: 'site-1' }])
+          })
+        })
+      } as any);
+      vi.mocked(db.insert).mockReturnValueOnce({ values: valuesMock } as any);
+
+      const res = await app.request('/devices/onboarding-token', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ count: 999999 })
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.maxUsage).toBe(1000);
+      expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({ maxUsage: 1000 }));
+    });
   });
 
   describe('GET /devices', () => {

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -192,6 +192,12 @@ function envInt(name: string, fallback: number): number {
   return Number.isFinite(parsed) ? parsed : fallback;
 }
 
+// #1108: caller-supplied onboarding-token limits. Count maps to maxUsage so one
+// copied CLI command can enroll a whole batch; TTL cap mirrors the enrollment-
+// keys route's 365-day ceiling.
+const ENROLL_TOKEN_MAX_COUNT = 1000;
+const ENROLL_TOKEN_MAX_TTL_MINUTES = 525_600; // 365 days
+
 // POST /devices/onboarding-token - Generate a short-lived enrollment key.
 // If AGENT_ENROLLMENT_SECRET is configured, enrollment also requires that
 // shared secret; otherwise the short-lived key stands on its own.
@@ -235,9 +241,24 @@ coreRoutes.post(
       return c.json({ error: 'No site found for this organization. Create a site first.' }, 400);
     }
 
+    // Optional caller-supplied multi-use / TTL controls (#1108). A copied CLI
+    // command is frequently pasted onto several machines during a migration;
+    // without these the historical hard-coded single-use token failed on every
+    // machine after the first. Defaults preserve the old single-use, 60-min
+    // behaviour for callers that send no body.
+    const body = await c.req.json().catch(() => ({} as Record<string, unknown>));
+    const rawCount = Number((body as { count?: unknown }).count);
+    const maxUsage = Number.isFinite(rawCount)
+      ? Math.min(ENROLL_TOKEN_MAX_COUNT, Math.max(1, Math.trunc(rawCount)))
+      : 1;
+    const rawTtl = Number((body as { ttlMinutes?: unknown }).ttlMinutes);
+    const defaultTtlMinutes = envInt('ENROLLMENT_KEY_DEFAULT_TTL_MINUTES', 60);
+    const ttlMinutes = Number.isFinite(rawTtl)
+      ? Math.min(ENROLL_TOKEN_MAX_TTL_MINUTES, Math.max(1, Math.trunc(rawTtl)))
+      : defaultTtlMinutes;
+
     const key = `enroll_${randomBytes(24).toString('hex')}`;
     const keyHash = hashEnrollmentKey(key);
-    const ttlMinutes = envInt('ENROLLMENT_KEY_DEFAULT_TTL_MINUTES', 60);
     const expiresAt = new Date(Date.now() + ttlMinutes * 60 * 1000);
 
     await db.insert(enrollmentKeys).values({
@@ -245,7 +266,7 @@ coreRoutes.post(
       siteId: site.id,
       name: `Onboarding token (${new Date().toISOString().slice(0, 10)})`,
       key: keyHash,
-      maxUsage: 1,
+      maxUsage,
       expiresAt,
       createdBy: auth.user.id,
     });
@@ -255,6 +276,7 @@ coreRoutes.post(
 
     return c.json({
       token: key,
+      maxUsage,
       expiresAt: expiresAt.toISOString(),
       enrollmentSecretMode: secretRequired ? 'global_env' : 'none',
       additionalSecretRequired: secretRequired,

--- a/apps/web/src/components/devices/AddDeviceModal.test.tsx
+++ b/apps/web/src/components/devices/AddDeviceModal.test.tsx
@@ -395,4 +395,27 @@ describe('AddDeviceModal', () => {
       expect(screen.getByText(/Valid for 5 device enrollments/)).toBeDefined();
     });
   });
+
+  it('shows the real token expiry instead of a hard-coded "24 hours" (#1108)', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(
+      makeJsonResponse({
+        token: 'token-exp',
+        maxUsage: 1,
+        // ~1 hour out → formatTokenExpiry renders "in about 1 hour".
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      })
+    );
+
+    render(<AddDeviceModal isOpen onClose={vi.fn()} />);
+    fireEvent.click(screen.getByText('CLI Commands'));
+
+    await waitFor(() => {
+      expect(screen.getByText('token-exp')).toBeDefined();
+    });
+
+    // The corrected, server-derived copy is shown…
+    expect(screen.getByText(/expires in about 1 hour/)).toBeDefined();
+    // …and the old misleading hard-coded string is gone.
+    expect(screen.queryByText(/expires in 24 hours/)).toBeNull();
+  });
 });

--- a/apps/web/src/components/devices/AddDeviceModal.test.tsx
+++ b/apps/web/src/components/devices/AddDeviceModal.test.tsx
@@ -349,11 +349,50 @@ describe('AddDeviceModal', () => {
     fireEvent.click(screen.getByText('CLI Commands'));
 
     await waitFor(() => {
-      expect(fetchWithAuthMock).toHaveBeenCalledWith('/devices/onboarding-token', { method: 'POST' });
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        '/devices/onboarding-token',
+        // #1108: the request now carries a device count → maxUsage.
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({ count: 1 }) })
+      );
     });
 
     await waitFor(() => {
       expect(screen.getByText('test-token-xyz')).toBeDefined();
+    });
+  });
+
+  it('requests a multi-use token after the operator raises the device count (#1108)', async () => {
+    // Initial single-device fetch on tab open.
+    fetchWithAuthMock.mockResolvedValueOnce(
+      makeJsonResponse({ token: 'token-single', maxUsage: 1, expiresAt: new Date(Date.now() + 3600_000).toISOString() })
+    );
+
+    render(<AddDeviceModal isOpen onClose={vi.fn()} />);
+    fireEvent.click(screen.getByText('CLI Commands'));
+
+    await waitFor(() => {
+      expect(screen.getByText('token-single')).toBeDefined();
+    });
+
+    // Operator bumps the count and regenerates → server returns a 5-use token.
+    fetchWithAuthMock.mockResolvedValueOnce(
+      makeJsonResponse({ token: 'token-multi', maxUsage: 5, expiresAt: new Date(Date.now() + 3600_000).toISOString() })
+    );
+
+    const countInput = screen.getByLabelText('Number of devices') as HTMLInputElement;
+    fireEvent.change(countInput, { target: { value: '5' } });
+    fireEvent.click(screen.getByText('Generate new token'));
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenLastCalledWith(
+        '/devices/onboarding-token',
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({ count: 5 }) })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('token-multi')).toBeDefined();
+      expect(screen.getByText(/Valid for 5 device enrollments/)).toBeDefined();
     });
   });
 });

--- a/apps/web/src/components/devices/AddDeviceModal.tsx
+++ b/apps/web/src/components/devices/AddDeviceModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Download, Copy, Loader2, Check, Link } from 'lucide-react';
 import { Dialog } from '../shared/Dialog';
 import { showToast } from '../shared/Toast';
@@ -156,11 +156,20 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
     }
   }, [isOpen]);
 
-  // Fetch a CLI onboarding token for `count` machines (#1108). Always fetches —
-  // the once-per-open gating lives at the call site (handleTabChange) so the
-  // "Generate new token" button and error-retry can re-mint freely without
-  // fighting a stale cliInitialized closure.
+  // Guards against overlapping CLI token fetches (the auto-init effect racing a
+  // manual "Generate new token", or a fast double-click). A ref, not state, so
+  // the check is synchronous and never stale inside the useCallback. Without it
+  // two in-flight POSTs could resolve out of order and display a token whose
+  // real maxUsage disagrees with the UI — the exact defect #1108 fixes.
+  const cliFetchInFlight = useRef(false);
+
+  // Fetch a CLI onboarding token for `count` machines (#1108). The once-per-open
+  // gating lives in the auto-init effect; the "Generate new token" button and
+  // error-retry call this directly to re-mint, so it only self-guards against
+  // concurrent runs rather than against being called again.
   const initializeCli = useCallback(async (count: number) => {
+    if (cliFetchInFlight.current) return;
+    cliFetchInFlight.current = true;
     setCliInitialized(true);
     setTokenLoading(true);
     setOnboardingToken('');
@@ -221,6 +230,7 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
       );
     } finally {
       setTokenLoading(false);
+      cliFetchInFlight.current = false;
     }
   }, []);
 

--- a/apps/web/src/components/devices/AddDeviceModal.tsx
+++ b/apps/web/src/components/devices/AddDeviceModal.tsx
@@ -35,6 +35,22 @@ function extractApiError(body: unknown): string {
   return '';
 }
 
+/**
+ * Render a CLI onboarding token's expiry as friendly relative text (#1108).
+ * Falls back to the absolute local time for windows beyond a day so the copy
+ * never silently claims "24 hours" when the real TTL differs.
+ */
+function formatTokenExpiry(iso: string): string {
+  const expiresMs = new Date(iso).getTime();
+  if (!Number.isFinite(expiresMs)) return 'after a short period';
+  const diffMinutes = Math.round((expiresMs - Date.now()) / 60000);
+  if (diffMinutes <= 0) return 'shortly';
+  if (diffMinutes < 60) return `in about ${diffMinutes} minute${diffMinutes === 1 ? '' : 's'}`;
+  const diffHours = Math.round(diffMinutes / 60);
+  if (diffHours < 48) return `in about ${diffHours} hour${diffHours === 1 ? '' : 's'}`;
+  return `on ${new Date(expiresMs).toLocaleString()}`;
+}
+
 interface AddDeviceModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -85,6 +101,12 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
   const [tokenLoading, setTokenLoading] = useState(false);
   const [tokenError, setTokenError] = useState<string>();
   const [tokenCopied, setTokenCopied] = useState(false);
+  // #1108: how many machines this CLI token may enroll, and its real expiry,
+  // both reported by the server so the UI never advertises a stale single-use
+  // token as good for the whole fleet.
+  const [cliDeviceCount, setCliDeviceCount] = useState(1);
+  const [tokenMaxUsage, setTokenMaxUsage] = useState<number | null>(null);
+  const [tokenExpiresAt, setTokenExpiresAt] = useState<string | null>(null);
   const [selectedOS, setSelectedOS] = useState<'windows' | 'macos' | 'linux'>(userOS);
   const [sha256s, setSha256s] = useState<Record<string, string>>({});
 
@@ -125,23 +147,33 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
       setCliInitialized(false);
       setOnboardingToken('');
       setTokenError(undefined);
+      setCliDeviceCount(1);
+      setTokenMaxUsage(null);
+      setTokenExpiresAt(null);
       setGeneratedLink('');
       setLinkError(undefined);
       setLinkCopied(false);
     }
   }, [isOpen]);
 
-  // Lazy-load CLI token when CLI tab is first opened
-  const initializeCli = useCallback(async () => {
-    if (cliInitialized) return;
+  // Fetch a CLI onboarding token for `count` machines (#1108). Always fetches —
+  // the once-per-open gating lives at the call site (handleTabChange) so the
+  // "Generate new token" button and error-retry can re-mint freely without
+  // fighting a stale cliInitialized closure.
+  const initializeCli = useCallback(async (count: number) => {
     setCliInitialized(true);
     setTokenLoading(true);
     setOnboardingToken('');
     setEnrollmentSecret('');
     setTokenError(undefined);
+    setTokenMaxUsage(null);
+    setTokenExpiresAt(null);
 
     try {
-      const response = await fetchWithAuth('/devices/onboarding-token', { method: 'POST' });
+      const response = await fetchWithAuth('/devices/onboarding-token', {
+        method: 'POST',
+        body: JSON.stringify({ count }),
+      });
 
       if (!response.ok) {
         if (response.status === 401) {
@@ -174,6 +206,12 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
         return;
       }
       setOnboardingToken(data.token);
+      if (typeof data.maxUsage === 'number') {
+        setTokenMaxUsage(data.maxUsage);
+      }
+      if (typeof data.expiresAt === 'string') {
+        setTokenExpiresAt(data.expiresAt);
+      }
       if (data.enrollmentSecret) {
         setEnrollmentSecret(data.enrollmentSecret);
       }
@@ -184,7 +222,14 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
     } finally {
       setTokenLoading(false);
     }
-  }, [cliInitialized]);
+  }, []);
+
+  // Re-mint the CLI token, e.g. after the operator bumps the device count or
+  // wants a fresh one mid-session (#1108).
+  const regenerateCliToken = useCallback((count: number) => {
+    setTokenCopied(false);
+    void initializeCli(count);
+  }, [initializeCli]);
 
   // Exchange a raw enrollment key token for a short-lived one-time handle, then
   // navigate to the public-download URL. This keeps the raw token out of browser
@@ -200,11 +245,17 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
     window.location.href = `/api/v1/enrollment-keys/public-download/${platform}?h=${encodeURIComponent(handle)}`;
   }
 
+  // Auto-load the CLI token whenever the CLI tab is showing and we haven't
+  // minted one yet. This single effect covers both an explicit tab click and
+  // the Linux default where the CLI tab is already active on open (#1108).
+  useEffect(() => {
+    if (isOpen && activeTab === 'cli' && !cliInitialized) {
+      void initializeCli(cliDeviceCount);
+    }
+  }, [isOpen, activeTab, cliInitialized, cliDeviceCount, initializeCli]);
+
   const handleTabChange = (tab: 'installer' | 'cli') => {
     setActiveTab(tab);
-    if (tab === 'cli') {
-      void initializeCli();
-    }
   };
 
   // --- Installer download ---
@@ -692,10 +743,7 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
                     {tokenError}
                     <button
                       type="button"
-                      onClick={() => {
-                        setCliInitialized(false);
-                        void initializeCli();
-                      }}
+                      onClick={() => { void initializeCli(cliDeviceCount); }}
                       className="ml-2 underline hover:no-underline"
                     >
                       Retry
@@ -705,6 +753,48 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
                   <code className="block rounded-md bg-background p-3 text-sm font-mono break-all">
                     {onboardingToken || 'No token available'}
                   </code>
+                )}
+
+                {/* #1108: a single CLI command is single-use by default — make
+                    multi-machine installs explicit and let the operator re-mint. */}
+                {!tokenLoading && !tokenError && (
+                  <div className="mt-3 flex flex-wrap items-end justify-between gap-3 border-t pt-3">
+                    <div className="flex items-end gap-2">
+                      <div>
+                        <label
+                          htmlFor="cli-device-count"
+                          className="block text-xs font-medium text-muted-foreground mb-1"
+                        >
+                          Number of devices
+                        </label>
+                        <input
+                          id="cli-device-count"
+                          type="number"
+                          min={1}
+                          max={1000}
+                          value={cliDeviceCount}
+                          onChange={(e) =>
+                            setCliDeviceCount(Math.min(1000, Math.max(1, Number(e.target.value) || 1)))
+                          }
+                          className="w-24 rounded-md border bg-background px-2 py-1 text-sm"
+                        />
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => regenerateCliToken(cliDeviceCount)}
+                        className="inline-flex items-center gap-1 rounded-md border px-3 py-1.5 text-xs font-medium hover:bg-muted"
+                      >
+                        Generate new token
+                      </button>
+                    </div>
+                    {onboardingToken && (
+                      <p className="text-xs text-muted-foreground">
+                        {tokenMaxUsage === 1
+                          ? 'Single-use — valid for one device. Generate a new token for each additional machine.'
+                          : `Valid for ${tokenMaxUsage ?? cliDeviceCount} device enrollments.`}
+                      </p>
+                    )}
+                  </div>
                 )}
               </div>
             </div>
@@ -778,8 +868,10 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
               </p>
               <div className="rounded-md border border-blue-500/40 bg-blue-500/10 p-4 text-sm">
                 <p className="text-blue-600 text-xs">
-                  The installation token expires in 24 hours. Your device will appear in the list
-                  once the agent connects.
+                  {tokenExpiresAt
+                    ? `The installation token expires ${formatTokenExpiry(tokenExpiresAt)}.`
+                    : 'The installation token expires after a short period.'}{' '}
+                  Your device will appear in the list once the agent connects.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
Fixes #1108.

## Problem
The CLI install command embedded a hard-coded **single-use** (`maxUsage:1`) onboarding token, so pasting one copied command onto several machines failed on every machine after the first (`401`). The UI also hard-coded "expires in 24 hours" while the server default is **60 minutes** — actively misleading during a multi-host migration.

## Changes
**API** — `routes/devices/core.ts`
- `POST /devices/onboarding-token` now honors an optional `count` (→ `maxUsage`, clamped 1–1000) and `ttlMinutes`, and returns `maxUsage`.
- No body = the historical single-use, 60-min default (backward compatible).

**Web** — `components/devices/AddDeviceModal.tsx` (CLI tab)
- "Number of devices" input + "Generate new token" button; the count is sent to the token request.
- Replaced the bogus "24 hours" copy with the server's real expiry + use-count.
- Refactored away a latent stale-closure bug in the token init/retry path (the old error-retry button could no-op).

## Tests
- `devices.test.ts`: default single-use, `count`→`maxUsage`, out-of-range clamp.
- `AddDeviceModal.test.tsx`: request body carries the count; regenerate fetches a multi-use token and shows "Valid for N device enrollments".

## Note (ops, not code)
The literal `enrollment_key_not_found` in the report — given the A→B hostname migration — is most likely an `ENROLLMENT_KEY_PEPPER` mismatch across the two deployments (keys hashed under one pepper can't be validated under another). That's an ops action tracked in the issue; this PR fixes the single-use/UX side that affects everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)