### PR TITLE
fix(watchdog): execute failover-delivered commands + recover wedged agent (#1103, #1104)

### DIFF
--- a/agent/cmd/breeze-watchdog/failover_dispatch_test.go
+++ b/agent/cmd/breeze-watchdog/failover_dispatch_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/watchdog"
+)
+
+// #1103 — the watchdog failover loop sends a heartbeat (which the server
+// claims + marks 'sent', returning the commands inline) and THEN polls
+// (which only returns still-'pending' commands). Commands delivered by the
+// heartbeat must be executed; previously they were dropped. The poll set is
+// deduped against the heartbeat set so a command never runs twice.
+
+func runIDs(heartbeat, poll []watchdog.FailoverCommand) []string {
+	var ran []string
+	executeFailoverCommands(heartbeat, poll, func(cmd watchdog.FailoverCommand) {
+		ran = append(ran, cmd.ID)
+	})
+	return ran
+}
+
+func cmds(ids ...string) []watchdog.FailoverCommand {
+	out := make([]watchdog.FailoverCommand, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, watchdog.FailoverCommand{ID: id, Type: "collect_diagnostics"})
+	}
+	return out
+}
+
+func TestExecuteFailoverCommands_RunsHeartbeatDeliveredCommands(t *testing.T) {
+	// The core #1103 regression: a command delivered ONLY by the heartbeat
+	// (poll returns nothing because it was already marked 'sent') must run.
+	ran := runIDs(cmds("hb-1"), nil)
+	if !reflect.DeepEqual(ran, []string{"hb-1"}) {
+		t.Fatalf("expected heartbeat command to execute, got %v", ran)
+	}
+}
+
+func TestExecuteFailoverCommands_RunsPollDeliveredCommands(t *testing.T) {
+	ran := runIDs(nil, cmds("poll-1"))
+	if !reflect.DeepEqual(ran, []string{"poll-1"}) {
+		t.Fatalf("expected poll command to execute, got %v", ran)
+	}
+}
+
+func TestExecuteFailoverCommands_DedupesOverlappingIDs(t *testing.T) {
+	// Same command surfaced by both paths must execute exactly once.
+	ran := runIDs(cmds("x"), cmds("x"))
+	if !reflect.DeepEqual(ran, []string{"x"}) {
+		t.Fatalf("expected deduped single execution, got %v", ran)
+	}
+}
+
+func TestExecuteFailoverCommands_HeartbeatBeforePollPreservingOrder(t *testing.T) {
+	ran := runIDs(cmds("hb-1", "hb-2"), cmds("hb-1", "poll-1"))
+	// hb-1, hb-2 from heartbeat (in order); poll-1 from poll; the poll's
+	// duplicate hb-1 is skipped.
+	want := []string{"hb-1", "hb-2", "poll-1"}
+	if !reflect.DeepEqual(ran, want) {
+		t.Fatalf("expected %v, got %v", want, ran)
+	}
+}

--- a/agent/cmd/breeze-watchdog/main.go
+++ b/agent/cmd/breeze-watchdog/main.go
@@ -571,17 +571,50 @@ func handleFailoverPoll(
 	}
 	processHeartbeatResponse(resp, wd, journal, cfg, tokens, recovery)
 
-	// Poll for commands.
-	commands, err := fc.PollCommands()
+	// Commands targeted at the watchdog are claimed by the heartbeat (the
+	// server marks them 'sent' and returns them inline), so the poll below
+	// won't re-return them. Execute the heartbeat-delivered batch here, then
+	// the poll batch, deduped — otherwise a `restart_agent` etc. is consumed
+	// but never run (#1103).
+	var heartbeatCmds []watchdog.FailoverCommand
+	if resp != nil {
+		heartbeatCmds = resp.Commands
+	}
+
+	// Poll for any still-pending commands. A poll failure must not drop the
+	// heartbeat-delivered batch, so fall through with an empty poll set.
+	pollCmds, err := fc.PollCommands()
 	if err != nil {
 		journal.Log(watchdog.LevelError, "failover.poll_failed", map[string]any{
 			"error": err.Error(),
 		})
-		return
+		pollCmds = nil
 	}
 
-	for _, cmd := range commands {
+	executeFailoverCommands(heartbeatCmds, pollCmds, func(cmd watchdog.FailoverCommand) {
 		handleFailoverCommand(fc, cmd, wd, journal, cfg, tokens, recovery)
+	})
+}
+
+// executeFailoverCommands runs the heartbeat-delivered command batch first,
+// then the poll-delivered batch, invoking run() once per unique command id.
+// The server claims+marks heartbeat commands 'sent' so the poll normally
+// won't re-return them; the dedup is defensive against any overlap. Order is
+// preserved (heartbeat batch, then poll batch). (#1103)
+func executeFailoverCommands(
+	heartbeatCmds, pollCmds []watchdog.FailoverCommand,
+	run func(watchdog.FailoverCommand),
+) {
+	seen := make(map[string]bool, len(heartbeatCmds))
+	for _, cmd := range heartbeatCmds {
+		run(cmd)
+		seen[cmd.ID] = true
+	}
+	for _, cmd := range pollCmds {
+		if seen[cmd.ID] {
+			continue
+		}
+		run(cmd)
 	}
 }
 

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -613,3 +613,117 @@ describe('POST /agents/:id/heartbeat — watchdog restart-stats logging (#799)',
     expect(capturedInsertValues).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------
+// #1104 — watchdog-branch agent recovery: when the watchdog heartbeats
+// and the MAIN agent is silent (wedged) AND its recorded version is
+// behind latest, the response must carry an agent `upgradeTo` so the
+// watchdog's existing failover doUpdateAgent() path can recover it.
+// Gated on silence to avoid the watchdog and a healthy main agent both
+// updating the same binary.
+// ---------------------------------------------------------------------
+
+describe('POST /agents/:id/heartbeat — watchdog-branch agent recovery upgradeTo (#1104)', () => {
+  const sixteenMinutesAgo = new Date(Date.now() - 16 * 60 * 1000);
+  const oneMinuteAgo = new Date(Date.now() - 60 * 1000);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectMock.mockReset();
+    updateMock.mockReset();
+    insertMock.mockReset();
+    runOutsideDbContextMock.mockClear();
+    getActiveTrustKeysetMock.mockReset();
+    getActiveTrustKeysetMock.mockResolvedValue([]);
+    updateMock.mockReturnValue({
+      set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+    });
+  });
+
+  // device lookup (once) then all agentVersions lookups resolve to `latest`.
+  function primeSelects(deviceRow: Record<string, unknown>, latest: unknown[]) {
+    selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
+    selectMock.mockReturnValue(selectChainResolving(latest));
+  }
+
+  async function post() {
+    return buildWatchdogApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      // agentVersion here is the WATCHDOG's own version — not the agent's.
+      body: JSON.stringify({ role: 'watchdog', agentVersion: '0.65.20', watchdogState: 'FAILOVER' }),
+    });
+  }
+
+  it('main agent silent + recorded agentVersion behind → returns agent upgradeTo', async () => {
+    const { compareAgentVersions } = await import('./helpers');
+    vi.mocked(compareAgentVersions).mockReturnValue(1); // latest > recorded
+    primeSelects(
+      {
+        id: 'device-1', orgId: 'org-1', hostname: 'host', osType: 'windows',
+        architecture: 'amd64', agentVersion: '0.65.10', watchdogVersion: '0.65.20',
+        lastSeenAt: sixteenMinutesAgo, mainAgentSilentSince: null,
+      },
+      [{ version: '0.66.0' }],
+    );
+
+    const resp = await post();
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { upgradeTo?: string };
+    expect(body.upgradeTo).toBe('0.66.0');
+  });
+
+  it('main agent NOT silent (healthy) → no agent upgradeTo even if version behind', async () => {
+    const { compareAgentVersions } = await import('./helpers');
+    vi.mocked(compareAgentVersions).mockReturnValue(1);
+    primeSelects(
+      {
+        id: 'device-1', orgId: 'org-1', hostname: 'host', osType: 'windows',
+        architecture: 'amd64', agentVersion: '0.65.10', watchdogVersion: '0.65.20',
+        lastSeenAt: oneMinuteAgo, mainAgentSilentSince: null,
+      },
+      [{ version: '0.66.0' }],
+    );
+
+    const resp = await post();
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { upgradeTo?: string };
+    expect(body.upgradeTo).toBeUndefined();
+  });
+
+  it('main agent silent but already on latest → no agent upgradeTo', async () => {
+    const { compareAgentVersions } = await import('./helpers');
+    vi.mocked(compareAgentVersions).mockReturnValue(0); // up to date
+    primeSelects(
+      {
+        id: 'device-1', orgId: 'org-1', hostname: 'host', osType: 'windows',
+        architecture: 'amd64', agentVersion: '0.66.0', watchdogVersion: '0.65.20',
+        lastSeenAt: sixteenMinutesAgo, mainAgentSilentSince: new Date(),
+      },
+      [{ version: '0.66.0' }],
+    );
+
+    const resp = await post();
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { upgradeTo?: string };
+    expect(body.upgradeTo).toBeUndefined();
+  });
+
+  it('main agent silent but no recorded agentVersion → no agent upgradeTo', async () => {
+    const { compareAgentVersions } = await import('./helpers');
+    vi.mocked(compareAgentVersions).mockReturnValue(1);
+    primeSelects(
+      {
+        id: 'device-1', orgId: 'org-1', hostname: 'host', osType: 'windows',
+        architecture: 'amd64', agentVersion: null, watchdogVersion: '0.65.20',
+        lastSeenAt: sixteenMinutesAgo, mainAgentSilentSince: new Date(),
+      },
+      [{ version: '0.66.0' }],
+    );
+
+    const resp = await post();
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { upgradeTo?: string };
+    expect(body.upgradeTo).toBeUndefined();
+  });
+});

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -191,6 +191,45 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
       }
     }
 
+    // #1104 — agent recovery via the watchdog. A live watchdog whose main
+    // agent is wedged (silent past the #800 threshold) and behind the latest
+    // release has no other recovery path: the watchdog's failover loop routes
+    // an agent `upgradeTo` into doUpdateAgent(), which replaces the wedged
+    // binary. Compute it off the device's RECORDED main-agent version
+    // (`device.agentVersion`) — `data.agentVersion` in this branch is the
+    // WATCHDOG's own version. Gated on `mainAgentSilent` so a healthy main
+    // agent (which self-updates from its own heartbeat) and the watchdog never
+    // both write the same binary.
+    let agentUpgradeTo: string | undefined;
+    if (
+      mainAgentSilent &&
+      normalizedArch &&
+      device.agentVersion &&
+      !device.agentVersion.startsWith('dev-')
+    ) {
+      try {
+        const [latestAgent] = await db
+          .select({ version: agentVersions.version })
+          .from(agentVersions)
+          .where(
+            and(
+              eq(agentVersions.platform, device.osType),
+              eq(agentVersions.architecture, normalizedArch),
+              eq(agentVersions.component, 'agent'),
+              eq(agentVersions.isLatest, true)
+            )
+          )
+          .orderBy(desc(agentVersions.createdAt))
+          .limit(1);
+
+        if (latestAgent && compareAgentVersions(latestAgent.version, device.agentVersion) > 0) {
+          agentUpgradeTo = latestAgent.version;
+        }
+      } catch (err) {
+        console.error(`[agents] failed to evaluate watchdog-branch agent recovery target for ${agentId}:`, err);
+      }
+    }
+
     return c.json({
       commands: watchdogCommands.map(cmd => ({
         id: cmd.id,
@@ -198,6 +237,7 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
         payload: cmd.payload,
       })),
       watchdogUpgradeTo,
+      upgradeTo: agentUpgradeTo,
     });
   }
 


### PR DESCRIPTION
Two coupled watchdog failover-recovery fixes, triaged from Billy's reports.

## #1103 — watchdog never executed heartbeat-delivered commands
**Root cause:** the failover loop calls `SendHeartbeat()` then `PollCommands()` (`breeze-watchdog/main.go:563-586`). The watchdog heartbeat claims the device's watchdog commands and marks them `sent`, returning them inline (`heartbeat.ts:160`, `commandDispatch.ts:66-72`), but `processHeartbeatResponse()` only read `UpgradeTo`/`WatchdogUpgradeTo` and ignored `resp.Commands` (`main.go:588-612`). The subsequent poll only returns `pending` commands (`commandDispatch.ts:50-56`), which are already gone — so a `restart_agent` was consumed but never executed, stuck `sent` forever.

**Fix:** `handleFailoverPoll` now executes the heartbeat-delivered batch and then the poll batch through a new `executeFailoverCommands` helper that dedupes by command id (heartbeat wins) and preserves order. A poll failure no longer drops the heartbeat batch.

## #1104 — a live watchdog couldn't recover a wedged main agent
**Root cause:** the watchdog branch of the heartbeat returned `watchdogUpgradeTo` but never an agent `upgradeTo` (`heartbeat.ts` 75-201 vs the main-agent branch 527-543), even though the watchdog already routes `resp.UpgradeTo` → `doUpdateAgent()` (`main.go:600-605, 723-748`). The #800 detector flags the silent-main-agent condition (`heartbeat.ts:76-129`) but took no recovery action.

**Fix:** the watchdog branch now computes an agent `upgradeTo` off the device's **recorded** main-agent version (`device.agentVersion` — note `data.agentVersion` in that branch is the *watchdog's* version), reusing `compareAgentVersions`. **Gated on `mainAgentSilent`** so a healthy main agent (which self-updates from its own heartbeat) and the watchdog never both write the same binary — a deliberate tightening over the issue's "whenever behind" framing.

**Coupling:** version-stale wedges recover via #1104; same-version wedges still need the `restart_agent` command that #1103 unblocks. They ship together.

## Tests
- Go: new `executeFailoverCommands` unit tests — heartbeat-delivered run, poll run, dedup of overlapping ids, heartbeat-before-poll ordering.
- API: 4 `heartbeat.test.ts` cases — silent + behind → `upgradeTo`; healthy → none; on-latest → none; no recorded version → none.

Local: `go test -race ./cmd/breeze-watchdog/` green; `vitest run heartbeat.test.ts` 16/16 green; `tsc --noEmit` clean on the changed files.

Closes #1103. Closes #1104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)