### PR TITLE
fix(api): release the heartbeat RLS txn before the trust-keyset fetch (#1105)

### DIFF
--- a/apps/api/src/middleware/agentAuth.ts
+++ b/apps/api/src/middleware/agentAuth.ts
@@ -189,6 +189,14 @@ export async function suspendAgentToken(deviceId: string, reason: AgentTokenSusp
 }
 
 /**
+ * Final path segment of routes that open their own withDbAccessContext around
+ * their DB work instead of relying on the request-long wrap in
+ * agentAuthMiddleware. See the #1105 note at the wrap site. Auth still runs in
+ * full for these routes — only the org-context transaction wrap is skipped.
+ */
+const SELF_MANAGED_DB_CONTEXT_ACTIONS = new Set(['heartbeat']);
+
+/**
  * Middleware to authenticate agent requests via Bearer token.
  * Hashes the token and compares against the stored agentTokenHash.
  * Enforces per-agent rate limiting via Redis.
@@ -411,6 +419,19 @@ export async function agentAuthMiddleware(c: Context, next: Next) {
     siteId: device.siteId,
     role: match.role,
   });
+
+  // #1105 — high-frequency, high-concurrency routes that self-manage their DB
+  // context to avoid holding ONE transaction across the whole request (which
+  // pins a pooled connection idle-in-transaction across non-DB work and
+  // self-deadlocks the pool under a mass agent reconnect). These routes MUST
+  // open withDbAccessContext themselves around their DB work. Everything else
+  // keeps the convenient request-long wrap below.
+  const pathSegments = (c.req.path ?? '').split('/').filter(Boolean);
+  const action = pathSegments[pathSegments.length - 1] ?? '';
+  if (SELF_MANAGED_DB_CONTEXT_ACTIONS.has(action)) {
+    await next();
+    return;
+  }
 
   await withDbAccessContext(
     {

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -8,6 +8,11 @@ const updateMock = vi.fn();
 const insertMock = vi.fn();
 const runOutsideDbContextMock = vi.fn(async (fn: () => unknown) => fn());
 
+// Records the order of key lifecycle events so a test can assert the
+// manifest-trust-keyset fetch happens AFTER the org DB context closes
+// (the #1105 pool-poison fix). Reset per test.
+const callOrder: string[] = [];
+
 vi.mock('../../db', () => ({
   db: {
     select: (...args: unknown[]) => selectMock(...(args as [])),
@@ -16,6 +21,13 @@ vi.mock('../../db', () => ({
   },
   runOutsideDbContext: (...args: unknown[]) =>
     runOutsideDbContextMock(...(args as [any])),
+  // Pass-through that records when the scoped callback resolves — in
+  // production the org transaction is released at this point.
+  withDbAccessContext: async (_ctx: unknown, fn: () => Promise<unknown>) => {
+    const result = await fn();
+    callOrder.push('dbContext:released');
+    return result;
+  },
 }));
 
 vi.mock('../../db/schema', () => ({
@@ -119,8 +131,10 @@ vi.mock('../../services/remoteAccessPolicy', () => ({
 const getActiveTrustKeysetMock = vi.fn();
 
 vi.mock('../../services/manifestSigning', () => ({
-  getActiveTrustKeyset: (...args: unknown[]) =>
-    getActiveTrustKeysetMock(...(args as [])),
+  getActiveTrustKeyset: (...args: unknown[]) => {
+    callOrder.push('trustKeyset:fetched');
+    return getActiveTrustKeysetMock(...(args as []));
+  },
 }));
 
 import { heartbeatRoutes } from './heartbeat';
@@ -259,8 +273,9 @@ describe('POST /agents/:id/heartbeat — manifestTrustKeys delivery (#639)', () 
     expect(body.manifestTrustKeys).toEqual([]);
   });
 
-  it('invokes runOutsideDbContext so the system-scoped read isn\'t suppressed by tenant RLS', async () => {
+  it('#1105: fetches the trust keyset AFTER the org DB context is released (not while holding the tx)', async () => {
     getActiveTrustKeysetMock.mockResolvedValue([]);
+    callOrder.length = 0;
 
     await buildApp().request('/agents/device-1/heartbeat', {
       method: 'POST',
@@ -268,10 +283,15 @@ describe('POST /agents/:id/heartbeat — manifestTrustKeys delivery (#639)', () 
       body: JSON.stringify(minimalHeartbeatBody),
     });
 
-    // Confirm runOutsideDbContext was used — without it, the inner
-    // withSystemDbAccessContext inside getActiveTrustKeyset short-circuits
-    // and the manifest_signing_keys read returns zero rows.
-    expect(runOutsideDbContextMock).toHaveBeenCalled();
+    // The whole-request transaction must close before getActiveTrustKeyset
+    // runs — otherwise the heartbeat holds its org connection while the trust
+    // keyset acquires a SECOND pooled connection, which self-deadlocks the
+    // pool under a mass agent reconnect (#1105).
+    const released = callOrder.indexOf('dbContext:released');
+    const fetched = callOrder.indexOf('trustKeyset:fetched');
+    expect(released).toBeGreaterThanOrEqual(0);
+    expect(fetched).toBeGreaterThanOrEqual(0);
+    expect(released).toBeLessThan(fetched);
   });
 
   it('omits manifestTrustKeys (still 200) when getActiveTrustKeyset throws', async () => {

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { zValidator } from '@hono/zod-validator';
 import { and, desc, eq } from 'drizzle-orm';
-import { db, runOutsideDbContext } from '../../db';
+import { db, withDbAccessContext } from '../../db';
 import {
   devices,
   deviceMetrics,
@@ -40,6 +40,24 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
   if (!agent?.deviceId) {
     return c.json({ error: 'Agent context not found' }, 401);
   }
+
+  // #1105 — run the RLS-scoped DB work in a SHORT-LIVED context that is
+  // released before the manifest-trust-keyset fetch at the end. The heartbeat
+  // opts out of agentAuthMiddleware's request-long withDbAccessContext wrap
+  // (see agentAuth.ts) and self-manages here, so the org transaction is held
+  // only across this block — not across getActiveTrustKeyset(), which acquires
+  // its OWN (second) pooled connection. Holding both at once self-deadlocks the
+  // pool under a mass agent reconnect (idle-in-transaction → killed → outage).
+  const dbContext = {
+    scope: 'organization' as const,
+    orgId: agent.orgId,
+    accessibleOrgIds: [agent.orgId],
+    accessiblePartnerIds: [],
+  };
+
+  const scoped = await withDbAccessContext(
+    dbContext,
+    async (): Promise<Response | { mainResponse: Record<string, unknown> }> => {
 
   const [device] = await db
     .select()
@@ -507,40 +525,48 @@ if (latestHelper) {
     console.error('[heartbeat] Failed to resolve remote access policy:', err);
   }
 
-  // Returns the active signing keyset from manifest_signing_keys. On hosted
-  // SaaS the table is empty because nothing in the GitHub-source path calls
-  // ensureActiveSigningKey(); on self-host (BINARY_SOURCE=local) syncBinaries
-  // populates it. See docs/deploy/agent-update-trust-bootstrap.md (#625).
-  // runOutsideDbContext is required because this handler runs inside an
-  // agentAuthMiddleware withDbAccessContext(organization) scope, which would
-  // suppress the inner withSystemDbAccessContext inside getActiveTrustKeyset
-  // (short-circuit at db/index.ts:103-105), causing the RLS policy
-  // manifest_signing_keys_system_only to return zero rows.
+  // Main-branch response payload — built inside the org context, but the
+  // manifest-trust-keyset is fetched AFTER this context closes (see below).
+  return {
+    mainResponse: {
+      commands: commands.map(cmd => ({
+        id: cmd.id,
+        type: cmd.type,
+        payload: cmd.payload
+      })),
+      configUpdate: mergedConfigUpdate,
+      upgradeTo,
+      helperUpgradeTo: helperUpgradeTo ?? undefined,
+      watchdogUpgradeTo: watchdogUpgradeTo ?? undefined,
+      renewCert: renewCert || undefined,
+      rotateToken: rotateToken || undefined,
+      helperEnabled: helperSettings?.enabled ?? false,
+      helperSettings: helperSettings ?? undefined,
+      manageRemoteManagement: manageRemoteManagement || undefined,
+    },
+  };
+    },
+  );
+
+  // 404 / 401 / watchdog branches returned a Response directly from the scoped
+  // block — pass it through.
+  if (scoped instanceof Response) return scoped;
+
+  // #1105 — the org transaction is now released. Fetch the manifest trust
+  // keyset OUTSIDE it: getActiveTrustKeyset opens its own system-scoped
+  // context/connection, so no withDbAccessContext(org) is held while it
+  // acquires a second connection. (Returns the active signing keyset from
+  // manifest_signing_keys; empty on hosted SaaS — see
+  // docs/deploy/agent-update-trust-bootstrap.md, #625.)
   let manifestTrustKeys: ManifestTrustKey[] = [];
   try {
-    manifestTrustKeys = await runOutsideDbContext(() => getActiveTrustKeyset());
+    manifestTrustKeys = await getActiveTrustKeyset();
   } catch (err) {
     console.error(`[heartbeat] Failed to load manifest trust keyset for agentId=${agentId}:`, err);
     captureException(err);
   }
 
-  return c.json({
-    commands: commands.map(cmd => ({
-      id: cmd.id,
-      type: cmd.type,
-      payload: cmd.payload
-    })),
-    configUpdate: mergedConfigUpdate,
-    upgradeTo,
-    helperUpgradeTo: helperUpgradeTo ?? undefined,
-    watchdogUpgradeTo: watchdogUpgradeTo ?? undefined,
-    renewCert: renewCert || undefined,
-    rotateToken: rotateToken || undefined,
-    helperEnabled: helperSettings?.enabled ?? false,
-    helperSettings: helperSettings ?? undefined,
-    manageRemoteManagement: manageRemoteManagement || undefined,
-    manifestTrustKeys,
-  });
+  return c.json({ ...scoped.mainResponse, manifestTrustKeys });
 });
 
 // Receive service/process monitoring check results from agent


### PR DESCRIPTION
Mass agent reconnects could poison the Postgres pool — heartbeats `500`, login outage — until the API was restarted. This is the architectural cure (the "Option B" approach from the #1105 design discussion).

## Root cause
`agentAuthMiddleware` wrapped the **entire** heartbeat handler in `withDbAccessContext`, which opens `baseDb.transaction(...)` to set the RLS GUCs (`SET LOCAL`). So the whole handler ran inside one transaction holding one pooled connection. Near the end the handler calls `getActiveTrustKeyset`, which opens its **own** system-scoped context and needs a **second** pooled connection.

Under a mass reconnect, N concurrent heartbeats each hold their org connection **idle-in-transaction** while waiting for a second connection that the other held transactions have exhausted — a self-deadlock. `idle_in_transaction_session_timeout` then kills them, and the resulting `write CONNECTION_CLOSED postgres:5432` surfaces in whatever BullMQ worker next grabs a terminated connection (the worker is the victim, not the holder). The idle connections' last statement is the `config_policy_assignments` read from the config builders — exactly the production signature (~30 connections, idle 20–30s, **not** raw exhaustion at ~36/100).

## Fix
The heartbeat opts out of the middleware's request-long `withDbAccessContext` wrap (`SELF_MANAGED_DB_CONTEXT_ACTIONS` in `agentAuth.ts`) and self-manages a **short-lived** org context around just its DB work. The manifest trust keyset is fetched **after** that context is released, so no org transaction is held while it acquires its second connection.

- Context values are identical to what the middleware set (`scope=organization`, `orgId=device.orgId`) → **RLS behavior unchanged**.
- `runOutsideDbContext` is no longer needed for the keyset (there's no org context to escape) and is dropped.
- Auth still runs in full for the heartbeat — only the org-context transaction wrap is skipped.

**Diff note:** the 470-line handler body is left **byte-identical** inside the new context callback (not re-indented) to keep the diff reviewable — only the wrapper, the main-branch return shape, and the trust-keyset fetch site changed.

## Tests
- `heartbeat.test.ts` now mocks `withDbAccessContext` (pass-through) and adds a **call-order regression** asserting the trust keyset is fetched *after* the org context is released. The prior `runOutsideDbContext`-specific test is replaced by that invariant.
- All **197** agent-route + middleware tests pass; `tsc --noEmit` clean.
- The live `rls-coverage.integration` test (needs a DB) should run in CI — context values are unchanged so no policy impact is expected.

## Follow-ups
- `patchSchedulerWorker` holds one txn across its scan loop + Redis enqueues — same pattern, lower impact (a single cron worker, one connection). Worth a hygiene PR.
- Needs a **prod soak** to confirm the outage signature is gone — this is the confirmation, not the merge.

Addresses #1105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)