### PR TITLE
fix(installer,agent): per-arch macOS installer + restore Full Disk Access guidance

### DIFF
--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -697,6 +697,11 @@ func retryTCCGrant() {
 		log.Debug("retrying TCC permission auto-grant")
 		if attemptTCCGrant() {
 			log.Info("TCC permissions all granted, stopping retries")
+			// The user just granted Full Disk Access, letting us write the
+			// Screen Recording + Accessibility grants. Already-running desktop
+			// helpers cached the old (denied) state — kickstart them so the new
+			// permissions take effect without the user manually restarting.
+			heartbeat.KickstartDesktopHelpers()
 			return
 		}
 	}

--- a/agent/internal/heartbeat/handlers_desktop_helper.go
+++ b/agent/internal/heartbeat/handlers_desktop_helper.go
@@ -610,6 +610,15 @@ func findGUIUserUIDs() []string {
 	return parseGUIUserUIDs(string(out))
 }
 
+// KickstartDesktopHelpers restarts the macOS desktop helper LaunchAgents so they
+// re-evaluate TCC permissions. Exported for the daemon's TCC auto-grant retry
+// path (main): once the user grants Full Disk Access, the daemon writes the
+// Screen Recording + Accessibility grants, but already-running helpers cached the
+// old denied state and need a restart to pick them up.
+func KickstartDesktopHelpers() {
+	kickstartDarwinDesktopHelpers()
+}
+
 // kickstartDarwinDesktopHelpers re-kickstarts the macOS desktop helper
 // LaunchAgents for every logged-in GUI user session. This is called after a
 // self-update restart to force helpers to reconnect to the new IPC socket

--- a/agent/internal/userhelper/tcc_darwin.go
+++ b/agent/internal/userhelper/tcc_darwin.go
@@ -188,7 +188,10 @@ func RunTCCCheckLoop(conn *ipc.Conn, stopChan chan struct{}, desktopContext stri
 	var seq uint64
 	var consecutiveFailures int
 	allGranted := false
+	wasAllGranted := false
+	firstCheck := true
 	var lastRemoteDesktop *bool
+	promptFile := tccPromptFilePath()
 
 	check := func() {
 		allowProbe := true
@@ -208,11 +211,22 @@ func RunTCCCheckLoop(conn *ipc.Conn, stopChan chan struct{}, desktopContext stri
 		} else {
 			consecutiveFailures = 0
 		}
-		// User guidance via osascript dialogs removed — the web UI banner
-		// handles admin-facing permission messaging. The system-level TCC
-		// prompts (CGRequestScreenCaptureAccess, AXIsProcessTrustedWithOptions)
-		// still trigger on first run via RequestScreenRecording() and
-		// CheckTCCPermissions().
+
+		// General osascript nagging was removed in favor of the web UI banner.
+		// But Full Disk Access is special: macOS provides NO API to prompt for it
+		// (unlike Screen Recording / Accessibility, whose system dialogs fire via
+		// RequestScreenRecording() and CheckTCCPermissions()). Without an
+		// on-machine dialog the user gets no signal that the one required manual
+		// grant is missing — exactly the "no third popup" report. Surface it here.
+		handleFullDiskAccessGuidance(status, promptFile)
+
+		// Tell the user when setup finishes. Skip the first check so a machine
+		// that was already fully granted doesn't get a spurious notification.
+		if allGranted && !wasAllGranted && !firstCheck {
+			showTCCCompleteNotification()
+		}
+		wasAllGranted = allGranted
+		firstCheck = false
 	}
 
 	// On first run, trigger the Screen Recording system prompt via
@@ -271,12 +285,19 @@ func sendTCCStatus(conn *ipc.Conn, status *ipc.TCCStatus, seq *uint64) error {
 	return nil
 }
 
-// handleUserGuidance shows a dialog or notification if permissions are missing.
-func handleUserGuidance(status *ipc.TCCStatus, promptFile string) {
-	missing := missingPermissions(status)
-	if len(missing) == 0 {
+// handleFullDiskAccessGuidance surfaces an on-machine dialog/notification when
+// Full Disk Access is missing. FDA is the only required permission macOS gives
+// no API to prompt for, so this is the sole on-machine signal the user gets that
+// a manual grant is needed. We deliberately do NOT nag for Screen Recording or
+// Accessibility here — those raise their own system prompts and are auto-granted
+// by the root daemon once FDA is available. Shows an actionable dialog with
+// "Open Settings" on first detection (guarded by a marker file), then quieter
+// notifications on later checks.
+func handleFullDiskAccessGuidance(status *ipc.TCCStatus, promptFile string) {
+	if status.FullDiskAccess {
 		return
 	}
+	missing := []string{"Full Disk Access"}
 
 	if _, err := os.Stat(promptFile); os.IsNotExist(err) {
 		// First detection — show dialog and create marker file
@@ -289,6 +310,15 @@ func handleUserGuidance(status *ipc.TCCStatus, promptFile string) {
 		// Subsequent checks — notification only
 		showTCCNotification(missing)
 	}
+}
+
+// showTCCCompleteNotification tells the user that all required permissions are
+// now granted, shown once on the transition to fully-granted.
+func showTCCCompleteNotification() {
+	showNotificationOS(ipc.NotifyRequest{
+		Title: "Breeze: Setup Complete",
+		Body:  "All required permissions are granted — Breeze Agent is ready.",
+	})
 }
 
 func missingPermissions(status *ipc.TCCStatus) []string {

--- a/agent/internal/userhelper/tcc_darwin.go
+++ b/agent/internal/userhelper/tcc_darwin.go
@@ -409,14 +409,14 @@ func showTCCDialog(missing []string) {
 
 	var msg, script string
 	if fdaMissing {
-		msg = "Breeze Agent needs Full Disk Access to function properly.\\n\\nPlease grant it in System Settings > Privacy & Security > Full Disk Access.\\n\\nScreen Recording and Accessibility will be configured automatically."
+		msg = "Breeze Agent needs Full Disk Access to function properly.\n\nPlease grant it in System Settings > Privacy & Security > Full Disk Access.\n\nScreen Recording and Accessibility will be configured automatically."
 		script = fmt.Sprintf(
 			`display dialog "%s" `+
 				`buttons {"Later", "Open Settings"} default button "Open Settings" with title "Breeze: Permissions Required" giving up after 60`,
 			escapeAppleScript(msg),
 		)
 	} else {
-		msg = "Screen Recording and Accessibility are being configured automatically.\\n\\nThis should resolve within a few minutes. If this persists, check agent logs or restart the agent."
+		msg = "Screen Recording and Accessibility are being configured automatically.\n\nThis should resolve within a few minutes. If this persists, check agent logs or restart the agent."
 		script = fmt.Sprintf(
 			`display dialog "%s" `+
 				`buttons {"OK"} default button "OK" with title "Breeze: Permissions Configuring" giving up after 60`,

--- a/agent/internal/userhelper/tcc_guidance_darwin_test.go
+++ b/agent/internal/userhelper/tcc_guidance_darwin_test.go
@@ -1,0 +1,33 @@
+//go:build darwin && cgo
+
+package userhelper
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
+)
+
+// When Full Disk Access is already granted, the FDA guidance must be a no-op
+// even if Screen Recording / Accessibility are still missing — those raise their
+// own OS prompts and are auto-granted by the root daemon, so nagging for them
+// here is exactly the behavior we removed. A no-op means no marker file is
+// written and no osascript dialog is launched.
+func TestHandleFullDiskAccessGuidance_NoOpWhenFDAGranted(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "tcc-prompted")
+
+	status := &ipc.TCCStatus{
+		ScreenRecording: false,
+		Accessibility:   false,
+		FullDiskAccess:  true,
+	}
+
+	handleFullDiskAccessGuidance(status, promptFile)
+
+	if _, err := os.Stat(promptFile); !os.IsNotExist(err) {
+		t.Fatalf("expected no marker file when FDA is granted, got err=%v", err)
+	}
+}

--- a/apps/api/src/modules/mcpInvites/inviteLandingRoutes.test.ts
+++ b/apps/api/src/modules/mcpInvites/inviteLandingRoutes.test.ts
@@ -39,13 +39,11 @@ vi.mock('../../db/schema', () => ({
 const buildWindowsInstallerZipMock = vi.fn(async (..._args: unknown[]) => Buffer.from('windows-zip'));
 const buildMacosInstallerZipMock = vi.fn(async (..._args: unknown[]) => Buffer.from('macos-zip'));
 const fetchRegularMsiMock = vi.fn(async () => Buffer.from('fake-msi'));
-const fetchMacosPkgMock = vi.fn(async () => Buffer.from('fake-pkg'));
 
 vi.mock('../../services/installerBuilder', () => ({
   buildWindowsInstallerZip: (...args: unknown[]) => buildWindowsInstallerZipMock(...args),
   buildMacosInstallerZip: (...args: unknown[]) => buildMacosInstallerZipMock(...args),
   fetchRegularMsi: () => fetchRegularMsiMock(),
-  fetchMacosPkg: () => fetchMacosPkgMock(),
 }));
 
 // ============================================================
@@ -206,7 +204,8 @@ describe('GET /i/:shortCode/download/:os', () => {
     const res = await buildApp().request('/i/abc1234567/download/mac');
     expect(res.status).toBe(200);
     expect(res.headers.get('content-disposition')).toContain('breeze-agent-macos.zip');
-    expect(fetchMacosPkgMock).toHaveBeenCalledTimes(1);
+    // macOS no longer fetches a pkg server-side — install.sh downloads the
+    // arch-matched pkg at install time; only the zip is built here.
     expect(buildMacosInstallerZipMock).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/api/src/modules/mcpInvites/inviteLandingRoutes.ts
+++ b/apps/api/src/modules/mcpInvites/inviteLandingRoutes.ts
@@ -9,7 +9,6 @@ import {
 import {
   buildMacosInstallerZip,
   buildWindowsInstallerZip,
-  fetchMacosPkg,
   fetchRegularMsi,
 } from '../../services/installerBuilder';
 
@@ -217,8 +216,9 @@ export function mountInviteLandingRoutes(app: Hono): void {
         });
         filename = 'breeze-agent-windows.zip';
       } else {
-        const pkg = await fetchMacosPkg();
-        buf = await buildMacosInstallerZip(pkg, {
+        // macOS: install.sh downloads the arch-matched pkg at install time, so
+        // no binary is bundled here (one zip serves Intel + Apple Silicon).
+        buf = await buildMacosInstallerZip({
           serverUrl,
           enrollmentKey: redeemed.rawKey,
           enrollmentSecret,

--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -17,7 +17,12 @@ vi.mock('../../services/binarySource', () => ({
   },
 }));
 
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { downloadRoutes } from './download';
+import { getBinarySource, getGithubAgentPkgUrl } from '../../services/binarySource';
+import { isS3Configured, getPresignedUrl } from '../../services/s3Storage';
 
 describe('public agent binary downloads', () => {
   const originalAgentDir = process.env.AGENT_BINARY_DIR;
@@ -80,5 +85,89 @@ describe('public agent binary downloads', () => {
   it('rejects non-darwin pkg requests', async () => {
     const res = await downloadRoutes.request('/download/linux/amd64/pkg');
     expect(res.status).toBe(400);
+  });
+});
+
+describe('public agent .pkg downloads — per-arch serving', () => {
+  const originalAgentDir = process.env.AGENT_BINARY_DIR;
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'breeze-pkg-'));
+    process.env.AGENT_BINARY_DIR = tmp;
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.mocked(getBinarySource).mockReturnValue('local');
+    vi.mocked(isS3Configured).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    if (originalAgentDir === undefined) delete process.env.AGENT_BINARY_DIR;
+    else process.env.AGENT_BINARY_DIR = originalAgentDir;
+    vi.restoreAllMocks();
+    vi.mocked(getBinarySource).mockReset();
+    vi.mocked(isS3Configured).mockReset();
+    vi.mocked(getPresignedUrl).mockReset();
+    vi.mocked(getGithubAgentPkgUrl).mockReset();
+  });
+
+  it('serves amd64 and arm64 as DISTINCT packages (the Bad CPU type regression guard)', async () => {
+    // The whole point of the fix: each arch must resolve to its OWN file, never
+    // a hardcoded one. Write distinct bodies and prove they come back distinct.
+    writeFileSync(join(tmp, 'breeze-agent-darwin-amd64.pkg'), 'AMD64-PKG-BODY');
+    writeFileSync(join(tmp, 'breeze-agent-darwin-arm64.pkg'), 'ARM64-PKG-BODY');
+
+    const amd = await downloadRoutes.request('/download/darwin/amd64/pkg');
+    const arm = await downloadRoutes.request('/download/darwin/arm64/pkg');
+
+    expect(amd.status).toBe(200);
+    expect(arm.status).toBe(200);
+    expect(amd.headers.get('content-disposition')).toContain('breeze-agent-darwin-amd64.pkg');
+    expect(arm.headers.get('content-disposition')).toContain('breeze-agent-darwin-arm64.pkg');
+
+    const amdBody = await amd.text();
+    const armBody = await arm.text();
+    expect(amdBody).toBe('AMD64-PKG-BODY');
+    expect(armBody).toBe('ARM64-PKG-BODY');
+    expect(amdBody).not.toBe(armBody);
+  });
+
+  it('redirects to the GitHub release asset in github mode', async () => {
+    vi.mocked(getBinarySource).mockReturnValue('github');
+    vi.mocked(getGithubAgentPkgUrl).mockReturnValue(
+      'https://github.test/breeze-agent-darwin-amd64.pkg',
+    );
+
+    const res = await downloadRoutes.request('/download/darwin/amd64/pkg');
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('https://github.test/breeze-agent-darwin-amd64.pkg');
+    expect(getGithubAgentPkgUrl).toHaveBeenCalledWith('darwin', 'amd64');
+  });
+
+  it('redirects to a presigned S3 URL for the requested arch when S3 is configured', async () => {
+    vi.mocked(isS3Configured).mockReturnValue(true);
+    vi.mocked(getPresignedUrl).mockResolvedValue('https://s3.test/presigned-arm64');
+
+    const res = await downloadRoutes.request('/download/darwin/arm64/pkg');
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('https://s3.test/presigned-arm64');
+    expect(getPresignedUrl).toHaveBeenCalledWith('agent/breeze-agent-darwin-arm64.pkg');
+  });
+
+  it('falls back to disk (and warns) when the S3 object is missing', async () => {
+    vi.mocked(isS3Configured).mockReturnValue(true);
+    vi.mocked(getPresignedUrl).mockRejectedValue(
+      Object.assign(new Error('not found'), { name: 'NoSuchKey' }),
+    );
+    // No file on disk → 404 after fallback; the S3 miss is logged at warn (not error).
+    const res = await downloadRoutes.request('/download/darwin/amd64/pkg');
+
+    expect(res.status).toBe(404);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('[pkg-download] S3 presign failed'),
+      expect.anything(),
+    );
   });
 });

--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -62,4 +62,23 @@ describe('public agent binary downloads', () => {
       { filename: 'breeze-desktop-helper-linux-amd64' },
     );
   });
+
+  it('serves the architecture-matched pkg from local disk in non-github mode', async () => {
+    // Intel Macs hitting the per-arch pkg endpoint must resolve to the amd64
+    // package, not a hardcoded arm64 one (the "Bad CPU type" regression).
+    const res = await downloadRoutes.request('/download/darwin/amd64/pkg');
+    const body = await res.text();
+
+    expect(res.status).toBe(404);
+    expect(body).not.toContain('/tmp/breeze-secret-agent-binaries');
+    expect(console.warn).toHaveBeenCalledWith(
+      '[pkg-download] Local package missing',
+      { filename: 'breeze-agent-darwin-amd64.pkg' },
+    );
+  });
+
+  it('rejects non-darwin pkg requests', async () => {
+    const res = await downloadRoutes.request('/download/linux/amd64/pkg');
+    expect(res.status).toBe(400);
+  });
 });

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -128,7 +128,75 @@ downloadRoutes.get('/download/:os/:arch/pkg', async (c) => {
     return c.json({ error: 'Invalid architecture', message: `Supported values: amd64, arm64. Got: ${arch}` }, 400);
   }
 
-  return c.redirect(getGithubAgentPkgUrl(os, arch), 302);
+  const filename = `breeze-agent-darwin-${arch}.pkg`;
+
+  // GitHub redirect mode — no local packages needed
+  if (getBinarySource() === 'github') {
+    return c.redirect(getGithubAgentPkgUrl(os, arch), 302);
+  }
+
+  // Local mode: try S3 presigned redirect first (bandwidth offload)
+  if (isS3Configured()) {
+    try {
+      const url = await getPresignedUrl(`agent/${filename}`);
+      return c.redirect(url, 302);
+    } catch (err) {
+      const errName = (err as { name?: string }).name;
+      const isNotFound = errName === 'NotFound' || errName === 'NoSuchKey';
+      const level = isNotFound ? 'warn' : 'error';
+      console[level](`[pkg-download] S3 presign failed for ${filename}, falling back to disk:`, err);
+    }
+  }
+
+  // Local mode: serve from disk
+  const binaryDir = resolve(process.env.AGENT_BINARY_DIR || './agent/bin');
+  const filePath = join(binaryDir, filename);
+
+  let fileStat: ReturnType<typeof statSync>;
+  let stream: ReturnType<typeof createReadStream>;
+  try {
+    fileStat = statSync(filePath);
+    stream = createReadStream(filePath);
+  } catch (err) {
+    const isNotFound = err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT';
+    if (!isNotFound) {
+      console.error(`[pkg-download] Failed to read package ${filename}:`, err);
+      return c.json({ error: 'Internal server error', message: 'Failed to read installer package' }, 500);
+    }
+    console.warn('[pkg-download] Local package missing', { filename });
+    return c.json(
+      {
+        error: 'Package not found',
+        message: `Installer package "${filename}" is not available.`,
+      },
+      404
+    );
+  }
+
+  const webStream = new ReadableStream({
+    start(controller) {
+      stream.on('data', (chunk: string | Buffer) => {
+        const bytes = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+        controller.enqueue(new Uint8Array(bytes));
+      });
+      stream.on('end', () => { controller.close(); });
+      stream.on('error', (err) => {
+        console.error(`[pkg-download] Stream error while serving ${filename}:`, err);
+        controller.error(err);
+      });
+    },
+    cancel() { stream.destroy(); },
+  });
+
+  return new Response(webStream, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+      'Content-Length': String(fileStat.size),
+      'Cache-Control': 'no-cache',
+    },
+  });
 });
 
 // ============================================

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -471,6 +471,15 @@ if [[ "\$OS" == "darwin" ]]; then
 
   success "Downloaded installer package ($(wc -c < "\$TMPPKG" | tr -d ' ') bytes)"
 
+  # Verify Apple notarization/signature before installing as root — the installer
+  # CLI does not enforce Gatekeeper on its own, so a tampered/MITM'd download
+  # would otherwise be installed with full privileges.
+  info "Verifying installer package signature..."
+  if ! spctl --assess --type install "\$TMPPKG" >/dev/null 2>&1; then
+    fatal "Installer package failed Gatekeeper notarization assessment. Refusing to install."
+  fi
+  success "Verified installer package notarization"
+
   info "Installing Breeze Agent..."
   installer -pkg "\$TMPPKG" -target /
   success "Package installed (binary, launchd service, directories)"
@@ -497,8 +506,12 @@ if [[ "\$OS" == "darwin" ]]; then
   fi
   success "Agent enrolled successfully"
 
-  # Restart the service so it picks up the new enrollment config
-  launchctl kickstart -k system/com.breeze.agent 2>/dev/null || true
+  # Restart the service so it picks up the new enrollment config. Surface a
+  # failure instead of swallowing it — otherwise an enrolled device that never
+  # starts looks like a success to the operator.
+  if ! launchctl kickstart -k system/com.breeze.agent 2>/dev/null; then
+    warn "Could not restart the agent service automatically; it will start on next login or reboot."
+  fi
 
   echo ""
   success "Breeze agent installation complete!"

--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -81,7 +81,7 @@ vi.mock("../services/installerBuilder", () => ({
   buildWindowsInstallerZip: vi.fn(async () => Buffer.from("windows-zip")),
   buildMacosInstallerZip: vi.fn(async () => Buffer.from("macos-zip")),
   fetchRegularMsi: vi.fn(async () => Buffer.from("regular-msi")),
-  fetchMacosPkg: vi.fn(async () => Buffer.from("macos-pkg")),
+  assertMacosInstallerPkgsReachable: vi.fn(async () => {}),
   fetchMacosInstallerAppZip: vi.fn(async () => null),
 }));
 
@@ -802,7 +802,7 @@ describe("GET /public-download/:platform", () => {
   it("uses the remote signing service (no local binary fetch) when configured", async () => {
     // Regression guard for the most-hit installer path in production. When
     // MsiSigningService is configured, serveInstaller must:
-    //   1. NOT call fetchRegularMsi / fetchMacosPkg / anything local,
+    //   1. NOT call fetchRegularMsi / macOS reachability probe / anything local,
     //   2. call buildAndSignMsi with the correct version + properties,
     //   3. serve the result as application/octet-stream.
     process.env.BINARY_VERSION = "0.62.24";
@@ -828,7 +828,7 @@ describe("GET /public-download/:platform", () => {
       }),
     } as any);
 
-    const { fetchRegularMsi, fetchMacosPkg } =
+    const { fetchRegularMsi, assertMacosInstallerPkgsReachable } =
       await import("../services/installerBuilder");
 
     consumeDownloadHandleMock.mockResolvedValueOnce(
@@ -845,7 +845,7 @@ describe("GET /public-download/:platform", () => {
     );
 
     expect(fetchRegularMsi).not.toHaveBeenCalled();
-    expect(fetchMacosPkg).not.toHaveBeenCalled();
+    expect(assertMacosInstallerPkgsReachable).not.toHaveBeenCalled();
 
     expect(buildAndSignMsi).toHaveBeenCalledTimes(1);
     const req = (

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -27,7 +27,7 @@ import {
   buildMacosInstallerZip,
   buildWindowsInstallerZip,
   fetchRegularMsi,
-  fetchMacosPkg,
+  assertMacosInstallerPkgsReachable,
   fetchMacosInstallerAppZip,
 } from "../services/installerBuilder";
 import { renameAppInZip } from "../services/installerAppZip";
@@ -190,7 +190,7 @@ function writeEnrollmentKeyAudit(
   });
 }
 
-// fetchRegularMsi, fetchMacosPkg moved to installerBuilder.ts
+// fetchRegularMsi and the macOS installer helpers live in installerBuilder.ts
 
 const shortCodeAlphabet =
   "23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz";
@@ -1400,7 +1400,9 @@ enrollmentKeyRoutes.post(
           await fetchRegularMsi();
         }
       } else {
-        await fetchMacosPkg();
+        // macOS installer downloads the arch-matched pkg at install time —
+        // validate BOTH architectures are reachable, not just arm64.
+        await assertMacosInstallerPkgsReachable();
       }
     } catch (err) {
       console.error(

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -1074,9 +1074,9 @@ enrollmentKeyRoutes.get(
     try {
       if (platform === "windows" && !signingService) {
         binaryBuffer = await fetchRegularMsi();
-      } else if (platform === "macos") {
-        binaryBuffer = await fetchMacosPkg();
       }
+      // macOS no longer fetches a binary here — the bundled install.sh downloads
+      // the architecture-matched pkg at install time.
     } catch (err) {
       console.error(`[installer] Failed to fetch ${platform} binary:`, err);
       return c.json(
@@ -1170,16 +1170,14 @@ enrollmentKeyRoutes.get(
         return c.body(resultBuffer as unknown as ArrayBuffer);
       }
 
-      // macOS — unchanged
-      const zipBuffer = await buildMacosInstallerZip(
-        ensureBuffer(binaryBuffer, "installer/macos zip"),
-        {
-          serverUrl,
-          enrollmentKey: rawChildKey,
-          enrollmentSecret: globalSecret,
-          siteId: parentKey.siteId,
-        },
-      );
+      // macOS — install.sh downloads the architecture-matched pkg at install
+      // time, so no binary is bundled here (one zip serves Intel + Apple Silicon).
+      const zipBuffer = await buildMacosInstallerZip({
+        serverUrl,
+        enrollmentKey: rawChildKey,
+        enrollmentSecret: globalSecret,
+        siteId: parentKey.siteId,
+      });
 
       writeEnrollmentKeyAudit(c, auth, {
         orgId: parentKey.orgId,
@@ -1676,9 +1674,9 @@ async function serveInstaller(
   try {
     if (platform === "windows" && !signingService) {
       binaryBuffer = await fetchRegularMsi();
-    } else if (platform === "macos") {
-      binaryBuffer = await fetchMacosPkg();
     }
+    // macOS no longer fetches a binary here — the bundled install.sh downloads
+    // the architecture-matched pkg at install time.
   } catch (err) {
     console.error(`[public-download] Failed to fetch ${platform} binary:`, err);
     return c.json({ error: "Installer binary not available" }, 503);
@@ -1716,16 +1714,14 @@ async function serveInstaller(
         filename = "breeze-agent-windows.zip";
       }
     } else {
-      // macOS
-      resultBuffer = await buildMacosInstallerZip(
-        ensureBuffer(binaryBuffer, "public-download/macos zip"),
-        {
-          serverUrl,
-          enrollmentKey: rawToken,
-          enrollmentSecret: globalSecret,
-          siteId: keyRow.siteId,
-        },
-      );
+      // macOS — install.sh downloads the architecture-matched pkg at install
+      // time; nothing is bundled (one zip serves Intel + Apple Silicon).
+      resultBuffer = await buildMacosInstallerZip({
+        serverUrl,
+        enrollmentKey: rawToken,
+        enrollmentSecret: globalSecret,
+        siteId: keyRow.siteId,
+      });
       contentType = "application/zip";
       filename = "breeze-agent-macos.zip";
     }

--- a/apps/api/src/routes/enrollmentKeys_installer.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_installer.test.ts
@@ -67,7 +67,7 @@ vi.mock('../services/installerBuilder', () => ({
   buildMacosInstallerZip: vi.fn(async () => Buffer.from('fake-zip')),
   buildWindowsInstallerZip: vi.fn(async () => Buffer.from('fake-windows-zip')),
   fetchRegularMsi: vi.fn(async () => Buffer.alloc(2048, 0xbb)),
-  fetchMacosPkg: vi.fn(async () => Buffer.alloc(2048, 0xcc)),
+  assertMacosInstallerPkgsReachable: vi.fn(async () => {}),
   // Plan C — returns null so macOS tests fall through to the legacy pkg path.
   fetchMacosInstallerAppZip: vi.fn(async () => null),
 }));

--- a/apps/api/src/services/installerBuilder.test.ts
+++ b/apps/api/src/services/installerBuilder.test.ts
@@ -1,7 +1,15 @@
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import { createHash, generateKeyPairSync, randomBytes, sign } from 'node:crypto';
 import JSZip from 'jszip';
-import { buildMacosInstallerZip, buildWindowsInstallerZip, fetchRegularMsi } from './installerBuilder';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  buildMacosInstallerZip,
+  buildWindowsInstallerZip,
+  fetchRegularMsi,
+  assertMacosInstallerPkgsReachable,
+} from './installerBuilder';
 
 // Real keys are 64 lowercase hex chars produced by randomBytes(32).toString('hex').
 // Tests use that exact generator so a future drift between generator and validator
@@ -162,6 +170,117 @@ describe('buildMacosInstallerZip — install.sh content', () => {
 
     // Service restart so newly-enrolled config is picked up.
     expect(script).toContain('launchctl kickstart');
+  });
+
+  it('install.sh verifies pkg notarization before installing as root (security gate)', async () => {
+    const zipBuffer = await buildMacosInstallerZip({
+      serverUrl: 'https://x.com',
+      enrollmentKey: realEnrollmentKey(),
+      enrollmentSecret: '',
+      siteId: '550e8400-e29b-41d4-a716-446655440000',
+    });
+
+    const zip = await JSZip.loadAsync(zipBuffer);
+    const script = await zip.files['install.sh']!.async('string');
+
+    // The installer CLI does not enforce Gatekeeper; the script must spctl-assess
+    // (fail closed) BEFORE handing the downloaded pkg to `installer -pkg` as root.
+    const gateIdx = script.indexOf('spctl --assess --type install');
+    const installIdx = script.indexOf('installer -pkg');
+    expect(gateIdx).toBeGreaterThan(-1);
+    expect(installIdx).toBeGreaterThan(-1);
+    expect(gateIdx).toBeLessThan(installIdx);
+    expect(script).toMatch(/Refusing to install/);
+  });
+
+  it('install.sh removes the credential file on any exit (no secret left behind)', async () => {
+    const zipBuffer = await buildMacosInstallerZip({
+      serverUrl: 'https://x.com',
+      enrollmentKey: realEnrollmentKey(),
+      enrollmentSecret: '',
+      siteId: '550e8400-e29b-41d4-a716-446655440000',
+    });
+
+    const zip = await JSZip.loadAsync(zipBuffer);
+    const script = await zip.files['install.sh']!.async('string');
+
+    // enrollment.json holds the enrollment secret — the EXIT trap must remove it
+    // so a failed/aborted install never leaves it in the extracted download dir.
+    expect(script).toMatch(/trap '.*rm -f "\$ENROLLMENT_JSON".*' EXIT/);
+  });
+});
+
+describe('assertMacosInstallerPkgsReachable', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.unstubAllGlobals();
+  });
+
+  it('github mode: HEAD-checks BOTH architectures (not just arm64)', async () => {
+    process.env.BINARY_SOURCE = 'github';
+    process.env.BINARY_VERSION = '1.2.3';
+
+    const seen: string[] = [];
+    const fetchMock = vi.fn(async (url: string, opts?: { method?: string }) => {
+      seen.push(url);
+      expect(opts?.method).toBe('HEAD');
+      return new Response(null, { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(assertMacosInstallerPkgsReachable()).resolves.toBeUndefined();
+    expect(seen.some((u) => u.endsWith('breeze-agent-darwin-amd64.pkg'))).toBe(true);
+    expect(seen.some((u) => u.endsWith('breeze-agent-darwin-arm64.pkg'))).toBe(true);
+  });
+
+  it('github mode: throws when an architecture is unreachable (Intel-only outage guard)', async () => {
+    process.env.BINARY_SOURCE = 'github';
+    process.env.BINARY_VERSION = '1.2.3';
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith('breeze-agent-darwin-amd64.pkg')) {
+        return new Response(null, { status: 404 });
+      }
+      return new Response(null, { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(assertMacosInstallerPkgsReachable()).rejects.toThrow(/amd64/);
+  });
+
+  it('local mode: resolves when both arch packages exist on disk', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'breeze-pkg-probe-'));
+    try {
+      process.env.BINARY_SOURCE = 'local';
+      delete process.env.S3_BUCKET; // force the disk path, not the S3 early-return
+      process.env.AGENT_BINARY_DIR = dir;
+      writeFileSync(join(dir, 'breeze-agent-darwin-amd64.pkg'), 'x');
+      writeFileSync(join(dir, 'breeze-agent-darwin-arm64.pkg'), 'x');
+
+      await expect(assertMacosInstallerPkgsReachable()).resolves.toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('local mode: throws when an arch package is missing on disk', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'breeze-pkg-probe-'));
+    try {
+      process.env.BINARY_SOURCE = 'local';
+      delete process.env.S3_BUCKET; // force the disk path, not the S3 early-return
+      process.env.AGENT_BINARY_DIR = dir;
+      writeFileSync(join(dir, 'breeze-agent-darwin-arm64.pkg'), 'x'); // amd64 missing
+
+      await expect(assertMacosInstallerPkgsReachable()).rejects.toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/apps/api/src/services/installerBuilder.test.ts
+++ b/apps/api/src/services/installerBuilder.test.ts
@@ -71,11 +71,10 @@ describe('fetchRegularMsi', () => {
 });
 
 describe('buildMacosInstallerZip', () => {
-  it('produces a zip with pkg, enrollment.json, and install.sh', async () => {
-    const fakePkg = Buffer.from('fake-pkg-contents');
+  it('produces a zip with enrollment.json and install.sh (no bundled pkg)', async () => {
     const validKey = realEnrollmentKey();
 
-    const zipBuffer = await buildMacosInstallerZip(fakePkg, {
+    const zipBuffer = await buildMacosInstallerZip({
       serverUrl: 'https://breeze.example.com',
       enrollmentKey: validKey,
       enrollmentSecret: 'secret456',
@@ -85,9 +84,11 @@ describe('buildMacosInstallerZip', () => {
     const zip = await JSZip.loadAsync(zipBuffer);
     const entries = Object.keys(zip.files);
 
-    expect(entries).toContain('breeze-agent.pkg');
     expect(entries).toContain('enrollment.json');
     expect(entries).toContain('install.sh');
+    // The pkg is downloaded per-architecture at install time, not bundled —
+    // this is what lets one zip work on both Intel and Apple Silicon.
+    expect(entries).not.toContain('breeze-agent.pkg');
 
     const jsonStr = await zip.files['enrollment.json']!.async('string');
     const config = JSON.parse(jsonStr);
@@ -95,13 +96,10 @@ describe('buildMacosInstallerZip', () => {
     expect(config.enrollmentKey).toBe(validKey);
     expect(config.enrollmentSecret).toBe('secret456');
     expect(config.siteId).toBe('550e8400-e29b-41d4-a716-446655440000');
-
-    const pkgData = await zip.files['breeze-agent.pkg']!.async('nodebuffer');
-    expect(pkgData.equals(fakePkg)).toBe(true);
   });
 
   it('sets enrollmentSecret to empty string when not provided', async () => {
-    const zipBuffer = await buildMacosInstallerZip(Buffer.from('pkg'), {
+    const zipBuffer = await buildMacosInstallerZip({
       serverUrl: 'https://x.com',
       enrollmentKey: realEnrollmentKey(),
       enrollmentSecret: '',
@@ -115,7 +113,7 @@ describe('buildMacosInstallerZip', () => {
 
   it('rejects a key with the legacy brz_ prefix (drift guard)', async () => {
     await expect(
-      buildMacosInstallerZip(Buffer.from('pkg'), {
+      buildMacosInstallerZip({
         serverUrl: 'https://x.com',
         enrollmentKey: 'brz_' + realEnrollmentKey(),
         enrollmentSecret: '',
@@ -127,7 +125,7 @@ describe('buildMacosInstallerZip', () => {
 
 describe('buildMacosInstallerZip — install.sh content', () => {
   it('install.sh contains shebang and enrollment command', async () => {
-    const zipBuffer = await buildMacosInstallerZip(Buffer.from('pkg'), {
+    const zipBuffer = await buildMacosInstallerZip({
       serverUrl: 'https://x.com',
       enrollmentKey: realEnrollmentKey(),
       enrollmentSecret: '',
@@ -139,6 +137,31 @@ describe('buildMacosInstallerZip — install.sh content', () => {
     expect(script).toContain('#!/bin/bash');
     expect(script).toContain('breeze-agent enroll');
     expect(script).toContain('enrollment.json');
+  });
+
+  it('install.sh detects CPU arch and downloads the matching pkg', async () => {
+    const zipBuffer = await buildMacosInstallerZip({
+      serverUrl: 'https://x.com',
+      enrollmentKey: realEnrollmentKey(),
+      enrollmentSecret: '',
+      siteId: '550e8400-e29b-41d4-a716-446655440000',
+    });
+
+    const zip = await JSZip.loadAsync(zipBuffer);
+    const script = await zip.files['install.sh']!.async('string');
+
+    // Architecture detection — both Intel and Apple Silicon must be handled.
+    expect(script).toContain('uname -m');
+    expect(script).toMatch(/x86_64\|amd64/);
+    expect(script).toMatch(/arm64\|aarch64/);
+
+    // Per-arch download from the server's pkg endpoint (literal ${ARCH}, not
+    // a JS-interpolated value — the bash variable must survive into the script).
+    expect(script).toContain('/api/v1/agents/download/darwin/${ARCH}/pkg');
+    expect(script).not.toContain('undefined');
+
+    // Service restart so newly-enrolled config is picked up.
+    expect(script).toContain('launchctl kickstart');
   });
 });
 

--- a/apps/api/src/services/installerBuilder.ts
+++ b/apps/api/src/services/installerBuilder.ts
@@ -126,16 +126,43 @@ if [ ! -f "$ENROLLMENT_JSON" ]; then
   exit 1
 fi
 
-# Install the PKG
-echo "Installing Breeze Agent..."
-sudo installer -pkg "$SCRIPT_DIR/breeze-agent.pkg" -target /
-
 # Read enrollment config via plutil (ships with macOS, no Xcode CLT required).
 # /usr/bin/python3 is only a stub on fresh Macs and triggers the "requires developer tools" popup.
 SERVER_URL=$(plutil -extract serverUrl raw -o - "$ENROLLMENT_JSON")
 ENROLLMENT_KEY=$(plutil -extract enrollmentKey raw -o - "$ENROLLMENT_JSON")
 ENROLLMENT_SECRET=$(plutil -extract enrollmentSecret raw -o - "$ENROLLMENT_JSON" 2>/dev/null || echo "")
 SITE_ID=$(plutil -extract siteId raw -o - "$ENROLLMENT_JSON" 2>/dev/null || echo "")
+SERVER_URL="\${SERVER_URL%/}"
+
+# Detect CPU architecture so Intel and Apple Silicon Macs each receive a
+# compatible binary. A single-arch bundle cannot serve both, and shipping the
+# wrong one causes "Bad CPU type in executable" on enroll (the bug this fixes).
+case "$(uname -m)" in
+  x86_64|amd64) ARCH="amd64" ;;
+  arm64|aarch64) ARCH="arm64" ;;
+  *) echo "Error: unsupported CPU architecture: $(uname -m)"; exit 1 ;;
+esac
+
+# Download the architecture-matched installer package from the server.
+PKG_URL="\${SERVER_URL}/api/v1/agents/download/darwin/\${ARCH}/pkg"
+TMPPKG_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMPPKG_DIR"' EXIT
+TMPPKG="$TMPPKG_DIR/breeze-agent.pkg"
+
+echo "Downloading Breeze Agent installer (\${ARCH})..."
+HTTP_CODE="$(curl -fsSL -w '%{http_code}' -o "$TMPPKG" "$PKG_URL" 2>/dev/null)" || true
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "Error: failed to download installer package (HTTP $HTTP_CODE) from $PKG_URL"
+  exit 1
+fi
+if [ ! -s "$TMPPKG" ]; then
+  echo "Error: downloaded installer package is empty (architecture \${ARCH} may be unavailable)"
+  exit 1
+fi
+
+# Install the PKG
+echo "Installing Breeze Agent..."
+sudo installer -pkg "$TMPPKG" -target /
 
 # Build enrollment command
 ENROLL_ARGS=("$ENROLLMENT_KEY" --server "$SERVER_URL")
@@ -143,7 +170,10 @@ ENROLL_ARGS=("$ENROLLMENT_KEY" --server "$SERVER_URL")
 [ -n "$SITE_ID" ] && ENROLL_ARGS+=(--site-id "$SITE_ID")
 
 echo "Enrolling agent..."
-sudo /usr/local/bin/breeze-agent enroll "${'$'}{ENROLL_ARGS[@]}"
+sudo /usr/local/bin/breeze-agent enroll "\${ENROLL_ARGS[@]}"
+
+# Restart the service so it picks up the new enrollment config.
+sudo launchctl kickstart -k system/com.breeze.agent 2>/dev/null || true
 
 # Clean up credentials
 rm -f "$ENROLLMENT_JSON"
@@ -158,8 +188,9 @@ interface MacosZipValues {
   siteId: string;
 }
 
+// The pkg is no longer bundled — install.sh downloads the architecture-matched
+// package at install time, so one zip works on both Intel and Apple Silicon.
 export async function buildMacosInstallerZip(
-  pkgBuffer: Buffer,
   values: MacosZipValues
 ): Promise<Buffer> {
   assertValidEnrollmentKey(values.enrollmentKey);
@@ -177,8 +208,6 @@ export async function buildMacosInstallerZip(
         console.error('[installer] Archiver warning during macOS zip build:', err);
       }
     });
-
-    archive.append(pkgBuffer, { name: 'breeze-agent.pkg' });
 
     const enrollmentJson = JSON.stringify(
       {

--- a/apps/api/src/services/installerBuilder.ts
+++ b/apps/api/src/services/installerBuilder.ts
@@ -12,6 +12,7 @@ import {
   getGithubReleaseRepository,
 } from './binarySource';
 import { verifyGithubReleaseArtifactBuffer } from './releaseArtifactManifest';
+import { isS3Configured } from './s3Storage';
 
 // --- Enrollment key validation ---
 
@@ -144,9 +145,12 @@ case "$(uname -m)" in
 esac
 
 # Download the architecture-matched installer package from the server.
+# Clean up BOTH the temp pkg and the credential file on any exit — every guard
+# below can abort under \`set -e\`, and enrollment.json holds the enrollment
+# secret, so it must never be left behind in the extracted download folder.
 PKG_URL="\${SERVER_URL}/api/v1/agents/download/darwin/\${ARCH}/pkg"
 TMPPKG_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMPPKG_DIR"' EXIT
+trap 'rm -rf "$TMPPKG_DIR"; rm -f "$ENROLLMENT_JSON"' EXIT
 TMPPKG="$TMPPKG_DIR/breeze-agent.pkg"
 
 echo "Downloading Breeze Agent installer (\${ARCH})..."
@@ -157,6 +161,15 @@ if [ "$HTTP_CODE" != "200" ]; then
 fi
 if [ ! -s "$TMPPKG" ]; then
   echo "Error: downloaded installer package is empty (architecture \${ARCH} may be unavailable)"
+  exit 1
+fi
+
+# Verify the package is Apple-notarized and Developer-ID signed BEFORE installing
+# as root. The \`installer\` CLI does NOT enforce Gatekeeper/notarization on its
+# own (stapling is only checked in the Finder double-click flow), so without this
+# an MITM'd or tampered download would be installed with full root privileges.
+if ! spctl --assess --type install "$TMPPKG" >/dev/null 2>&1; then
+  echo "Error: installer package failed Gatekeeper notarization assessment. Refusing to install."
   exit 1
 fi
 
@@ -172,12 +185,14 @@ ENROLL_ARGS=("$ENROLLMENT_KEY" --server "$SERVER_URL")
 echo "Enrolling agent..."
 sudo /usr/local/bin/breeze-agent enroll "\${ENROLL_ARGS[@]}"
 
-# Restart the service so it picks up the new enrollment config.
-sudo launchctl kickstart -k system/com.breeze.agent 2>/dev/null || true
+# Restart the service so it picks up the new enrollment config. Surface a failure
+# rather than swallowing it — a silent kickstart failure leaves an enrolled
+# device that never checks in, with the user told everything succeeded.
+if ! sudo launchctl kickstart -k system/com.breeze.agent 2>/dev/null; then
+  echo "Note: could not restart the agent service automatically; it will start on next login or reboot."
+fi
 
-# Clean up credentials
-rm -f "$ENROLLMENT_JSON"
-
+# Credentials are removed by the EXIT trap above.
 echo "Breeze agent installed and enrolled successfully."
 `;
 
@@ -249,25 +264,34 @@ export async function fetchRegularMsi(): Promise<Buffer> {
   return readFile(join(binaryDir, 'breeze-agent.msi'));
 }
 
-export async function fetchMacosPkg(): Promise<Buffer> {
+/**
+ * Pre-flight reachability check for the macOS installer, run at link-creation
+ * time so a broken installer fails fast for the admin instead of silently at
+ * install time on the end user's Mac. The installer downloads the arch-matched
+ * pkg at install time, so BOTH architectures are validated here (not just arm64
+ * — an amd64-only outage must not pass a probe that Intel customers then hit).
+ */
+export async function assertMacosInstallerPkgsReachable(): Promise<void> {
+  const arches = ['amd64', 'arm64'] as const;
   if (getBinarySource() === 'github') {
-    const url = getGithubAgentPkgUrl('darwin', 'arm64');
-    const resp = await fetch(url, { redirect: 'follow' });
-    if (!resp.ok) throw new Error(`Failed to fetch macOS PKG: ${resp.status}`);
-    const buffer = Buffer.from(await resp.arrayBuffer());
-    await verifyGithubReleaseArtifactBuffer({
-      assetName: 'breeze-agent-darwin-arm64.pkg',
-      assetBuffer: buffer,
-      manifestUrl: getGithubReleaseArtifactManifestUrl(),
-      signatureUrl: getGithubReleaseArtifactManifestSignatureUrl(),
-      expectedRepository: getGithubReleaseRepository(),
-      expectedRelease: getGithubExpectedReleaseTag(),
-      expectedPlatformTrust: 'macos-developer-id-notarization-required',
-    });
-    return buffer;
+    for (const arch of arches) {
+      const url = getGithubAgentPkgUrl('darwin', arch);
+      const resp = await fetch(url, { method: 'HEAD', redirect: 'follow' });
+      if (!resp.ok) {
+        throw new Error(`macOS ${arch} installer package not reachable: ${resp.status}`);
+      }
+    }
+    return;
   }
+  // Local mode: the /download/:os/:arch/pkg endpoint resolves S3 then disk at
+  // request time. When S3 is configured we can't verify here without duplicating
+  // that logic, so don't false-fail; otherwise confirm both arch packages exist
+  // on disk (catches the common "binaries not staged" misconfig).
+  if (isS3Configured()) return;
   const binaryDir = resolve(process.env.AGENT_BINARY_DIR || './agent/bin');
-  return readFile(join(binaryDir, 'breeze-agent-darwin-arm64.pkg'));
+  for (const arch of arches) {
+    await stat(join(binaryDir, `breeze-agent-darwin-${arch}.pkg`));
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes two macOS issues reported on v0.69.0 (Intel iMac, Ventura 13.7.8).

## Issue 1 — "Bad CPU type in executable" on Intel Macs

**Root cause:** `fetchMacosPkg()` hardcoded the **arm64** `.pkg`, and the bundled `install.sh` ran that prebuilt package with no architecture check. Every Intel Mac using the `.zip` installer received an arm64 binary → enrollment failed with `sudo: unable to execute /usr/local/bin/breeze-agent: Bad CPU type in executable`. A download link can be opened from either an Intel or Apple Silicon Mac, so a single-arch bundle can never be correct. (The CLI `install.sh` already did `uname -m` detection, which is why a CLI reinstall worked.)

**Fix:**
- `services/installerBuilder.ts` — bundled `install.sh` now detects `uname -m` (`x86_64|amd64`→amd64, `arm64|aarch64`→arm64) and downloads the architecture-matched `.pkg` from `/api/v1/agents/download/darwin/${ARCH}/pkg` at install time. One zip now works on both architectures; no `.pkg` is bundled. Also kickstarts the service post-enroll.
- `routes/enrollmentKeys.ts` — both installer paths (authenticated + short-code) stop fetching a server-side pkg and use the new no-pkg builder.
- `routes/agents/download.ts` — `/download/:os/:arch/pkg` now also serves S3/local packages in self-hosted mode (it previously *always* redirected to GitHub, which would have regressed local-binary/air-gapped self-hosters now that the bundle depends on it).

**Tradeoff:** the bundle no longer runs the in-house `verifyGithubReleaseArtifactBuffer` manifest check on the macOS pkg — it relies on Apple notarization (Gatekeeper) at install instead, inherent to downloading rather than bundling.

## Issue 2 — No Full Disk Access prompt (+ restart-to-apply)

**Root cause:** `handleUserGuidance`/`showTCCDialog` had become **dead code** when osascript dialogs were removed in favor of the web-UI banner. Screen Recording and Accessibility still prompt via their OS APIs, but **FDA is the only required permission macOS provides no API to prompt for** — so its sole on-machine signal disappeared and the user got nothing.

**Fix:**
- `userhelper/tcc_darwin.go` — the TCC check loop now calls an **FDA-specific** guidance dialog (actionable "Open Settings" deep-link, marker-file guarded), without re-introducing nagging for the auto-granted Screen Recording / Accessibility. Adds a one-time "Setup Complete" notification on the transition to fully-granted.
- `cmd/breeze-agent/main.go` + `heartbeat/handlers_desktop_helper.go` — **restart-to-apply**: when the daemon's auto-grant retry succeeds (user just granted FDA, letting the daemon write the SR/Accessibility grants), it kickstarts the desktop helpers so the new grants take effect without a manual restart.

There is no way to produce a literal "third popup" — macOS has no API to trigger an FDA consent dialog; the guidance dialog + Settings deep-link is the best achievable.

## Tests
- `installerBuilder.test.ts` — arch-detection + non-bundled-pkg + launchctl assertions
- `download.test.ts` — local pkg endpoint resolves per-arch; non-darwin rejected
- `tcc_guidance_darwin_test.go` — FDA-granted = no-op (no nagging for the other two)
- API suite (installerBuilder + download + 93 enrollmentKeys) green; Go agent builds clean (darwin/cgo), vet + userhelper/tcc tests green; rendered `install.sh` passes `bash -n`.

## Follow-up (not in this PR)
The newer "Installer.app" bundle path (which takes precedence when that asset is published) was not touched — worth confirming separately whether its embedded binary is universal or per-arch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)