### PR TITLE
fix(jobs): drop ':' from BullMQ custom job ids across 16 enqueue sites

### DIFF
--- a/apps/api/src/jobs/alertWorker.test.ts
+++ b/apps/api/src/jobs/alertWorker.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
 
-const { addBulkMock, warnSpy, devicesSchema, organizationsSchema, fleetState } = vi.hoisted(() => ({
+const { addBulkMock, addMock, getJobMock, warnSpy, devicesSchema, organizationsSchema, fleetState } = vi.hoisted(() => ({
   addBulkMock: vi.fn(async () => undefined),
+  addMock: vi.fn(async () => ({ id: 'queued-job-1' })),
+  getJobMock: vi.fn(async () => null),
   warnSpy: vi.fn(),
   devicesSchema: { id: 'devices.id', orgId: 'devices.orgId', status: 'devices.status', lastSeenAt: 'devices.lastSeenAt' } as const,
   organizationsSchema: { id: 'organizations.id', status: 'organizations.status' } as const,
@@ -63,6 +65,8 @@ vi.mock('../db', () => ({
 vi.mock('bullmq', () => ({
   Queue: class {
     addBulk = addBulkMock;
+    add = addMock;
+    getJob = getJobMock;
   },
   Worker: class {
     on = vi.fn();
@@ -85,7 +89,7 @@ vi.mock('../services/bullmqUtils', () => ({
   isReusableState: vi.fn(() => false)
 }));
 
-import { processEvaluateAll } from './alertWorker';
+import { processEvaluateAll, triggerFullEvaluation } from './alertWorker';
 
 describe('alertWorker.processEvaluateAll cursor fan-out', () => {
   beforeEach(() => {
@@ -166,5 +170,31 @@ describe('alertWorker.processEvaluateAll cursor fan-out', () => {
 
     expect(result.queued).toBe(0);
     expect(addBulkMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('alertWorker.triggerFullEvaluation jobId', () => {
+  beforeEach(() => {
+    addMock.mockClear();
+    getJobMock.mockClear();
+    getJobMock.mockResolvedValue(null);
+    addMock.mockResolvedValue({ id: 'queued-job-1' });
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Regression for "Custom Id cannot contain :" — BullMQ rejects a custom
+  // jobId whose colon-split length !== 3. `alert-evaluate-all:<slot>` is 2
+  // parts and would throw, silently dropping the full-evaluation enqueue.
+  it('does not use a colon in the enqueued BullMQ job id', async () => {
+    await triggerFullEvaluation();
+
+    expect(addMock).toHaveBeenCalled();
+    const [, , opts] = addMock.mock.calls[0] as unknown as [string, unknown, { jobId: string }];
+    expect(String(opts.jobId)).not.toContain(':');
+    expect(String(opts.jobId)).toMatch(/^alert-evaluate-all-[a-z0-9]+$/);
   });
 });

--- a/apps/api/src/jobs/alertWorker.ts
+++ b/apps/api/src/jobs/alertWorker.ts
@@ -386,7 +386,7 @@ export async function triggerDeviceEvaluation(deviceId: string, orgId: string): 
 export async function triggerFullEvaluation(): Promise<string> {
   const queue = getAlertQueue();
   const slot = Math.floor(Date.now() / ON_DEMAND_ALERT_DEDUPE_WINDOW_MS).toString(36);
-  const jobId = `alert-evaluate-all:${slot}`;
+  const jobId = `alert-evaluate-all-${slot}`;
   const existing = await queue.getJob(jobId);
   if (existing) {
     const state = await existing.getState();

--- a/apps/api/src/jobs/automationQueue.test.ts
+++ b/apps/api/src/jobs/automationQueue.test.ts
@@ -87,7 +87,7 @@ describe('enqueueAutomationRun', () => {
     expect(addMock).toHaveBeenCalledWith(
       'execute-run',
       expect.objectContaining({ runId: 'run-1', targetDeviceIds: ['device-1'] }),
-      expect.objectContaining({ jobId: 'automation-run:run-1' }),
+      expect.objectContaining({ jobId: 'automation-run-run-1' }),
     );
     expect(result).toEqual({ enqueued: true, jobId: 'queue-job-1' });
   });

--- a/apps/api/src/jobs/automationWorker.ts
+++ b/apps/api/src/jobs/automationWorker.ts
@@ -310,7 +310,9 @@ export async function enqueueAutomationRun(
 
   try {
     const queue = getAutomationQueue();
-    const stableJobId = `automation-run:${runId}`;
+    // '-' separator (not ':') — BullMQ rejects custom jobIds whose colon-split
+    // length !== 3, and this 2-part id would throw. See #1101.
+    const stableJobId = `automation-run-${runId}`;
     const existing = await queue.getJob(stableJobId);
     if (existing) {
       const state = await existing.getState();

--- a/apps/api/src/jobs/browserSecurityJobs.test.ts
+++ b/apps/api/src/jobs/browserSecurityJobs.test.ts
@@ -68,7 +68,7 @@ describe('triggerBrowserPolicyEvaluation', () => {
       'evaluate',
       expect.objectContaining({ orgId: 'org-1', policyId: 'policy-1' }),
       expect.objectContaining({
-        jobId: expect.stringMatching(/^browser-policy-eval:org-1:policy-1:[a-z0-9]+$/),
+        jobId: expect.stringMatching(/^browser-policy-eval-org-1-policy-1-[a-z0-9]+$/),
       }),
     );
   });

--- a/apps/api/src/jobs/browserSecurityJobs.ts
+++ b/apps/api/src/jobs/browserSecurityJobs.ts
@@ -95,7 +95,9 @@ export async function triggerBrowserPolicyEvaluation(
 ): Promise<string> {
   const queue = getEvalQueue();
   const slot = Math.floor(Date.now() / ON_DEMAND_EVAL_DEDUPE_WINDOW_MS).toString(36);
-  const jobId = ['browser-policy-eval', orgId, policyId ?? 'all', slot].join(':');
+  // '-' separator (not ':') — BullMQ rejects custom jobIds whose colon-split
+  // length !== 3, and this 4-part id would throw. See #1101.
+  const jobId = ['browser-policy-eval', orgId, policyId ?? 'all', slot].join('-');
   const existing = await queue.getJob(jobId);
   if (existing) {
     const state = await existing.getState();

--- a/apps/api/src/jobs/c2cEnqueue.test.ts
+++ b/apps/api/src/jobs/c2cEnqueue.test.ts
@@ -42,7 +42,7 @@ describe('c2c enqueue helpers', () => {
     expect(addMock).toHaveBeenCalledWith(
       'run-sync',
       expect.objectContaining({ jobId: 'job-123', configId: 'cfg-1' }),
-      expect.objectContaining({ jobId: 'c2c-sync:job-123' }),
+      expect.objectContaining({ jobId: 'c2c-sync-job-123' }),
     );
   });
 
@@ -64,7 +64,7 @@ describe('c2c enqueue helpers', () => {
     expect(addMock).toHaveBeenCalledWith(
       'process-restore',
       expect.objectContaining({ restoreJobId: 'restore-123', itemIds: ['item-1'] }),
-      expect.objectContaining({ jobId: 'c2c-restore:restore-123' }),
+      expect.objectContaining({ jobId: 'c2c-restore-restore-123' }),
     );
   });
 });

--- a/apps/api/src/jobs/c2cEnqueue.ts
+++ b/apps/api/src/jobs/c2cEnqueue.ts
@@ -76,7 +76,7 @@ export async function enqueueC2cSync(
       configId,
       orgId,
     },
-    `c2c-sync:${jobId}`,
+    `c2c-sync-${jobId}`,
     {
       removeOnComplete: { count: 50 },
       removeOnFail: { count: 100 },
@@ -102,7 +102,7 @@ export async function enqueueC2cRestore(
       itemIds,
       targetConnectionId,
     },
-    `c2c-restore:${restoreJobId}`,
+    `c2c-restore-${restoreJobId}`,
     {
       removeOnComplete: { count: 50 },
       removeOnFail: { count: 100 },

--- a/apps/api/src/jobs/cisJobs.test.ts
+++ b/apps/api/src/jobs/cisJobs.test.ts
@@ -81,7 +81,7 @@ describe('scheduleCisScan', () => {
       'run-baseline-scan',
       expect.objectContaining({ baselineId: 'baseline-1', deviceIds: ['device-1', 'device-2'] }),
       expect.objectContaining({
-        jobId: expect.stringMatching(/^cis-manual-scan:baseline-1:device-1,device-2:[a-z0-9]+$/),
+        jobId: expect.stringMatching(/^cis-manual-scan-baseline-1-device-1,device-2-[a-z0-9]+$/),
       }),
     );
   });

--- a/apps/api/src/jobs/cisJobs.ts
+++ b/apps/api/src/jobs/cisJobs.ts
@@ -463,12 +463,14 @@ export async function scheduleCisScan(
     ? Array.from(new Set(options.deviceIds.filter((id) => typeof id === 'string' && id.length > 0))).sort()
     : undefined;
   const slot = Math.floor(Date.now() / ON_DEMAND_CIS_SCAN_DEDUPE_WINDOW_MS).toString(36);
+  // '-' separator (not ':') — BullMQ rejects custom jobIds whose colon-split
+  // length !== 3, and this 4-part id would throw. See #1101.
   const jobId = [
     'cis-manual-scan',
     baselineId,
     normalizedDeviceIds ? normalizedDeviceIds.join(',') : 'all',
     slot,
-  ].join(':');
+  ].join('-');
   const existing = await queue.getJob(jobId);
   if (existing) {
     const state = await existing.getState();

--- a/apps/api/src/jobs/deploymentWorker.test.ts
+++ b/apps/api/src/jobs/deploymentWorker.test.ts
@@ -172,7 +172,7 @@ describe('deployment worker queueing', () => {
     expect(shared.addMock).toHaveBeenCalledWith(
       'process-deployment',
       { deploymentId: 'deployment-2' },
-      { jobId: 'deployment-process:deployment-2' },
+      { jobId: 'deployment-process-deployment-2' },
     );
   });
 

--- a/apps/api/src/jobs/deploymentWorker.ts
+++ b/apps/api/src/jobs/deploymentWorker.ts
@@ -231,7 +231,7 @@ let deploymentQueue: Queue | null = null;
 let deploymentDeviceQueue: Queue | null = null;
 
 function getDeploymentProcessJobId(deploymentId: string): string {
-  return `deployment-process:${deploymentId}`;
+  return `deployment-process-${deploymentId}`;
 }
 
 function getDeploymentNextBatchJobId(

--- a/apps/api/src/jobs/drExecutionWorker.test.ts
+++ b/apps/api/src/jobs/drExecutionWorker.test.ts
@@ -51,7 +51,7 @@ describe('dr execution queueing', () => {
         meta: expect.objectContaining({ actorType: 'system' }),
       }),
       expect.objectContaining({
-        jobId: 'dr-execution:exec-1',
+        jobId: 'dr-execution-exec-1',
         delay: 1234,
         attempts: 3,
       }),

--- a/apps/api/src/jobs/drExecutionWorker.ts
+++ b/apps/api/src/jobs/drExecutionWorker.ts
@@ -23,7 +23,7 @@ let drExecutionQueue: Queue<DrExecutionQueueJobData> | null = null;
 let drExecutionWorkerInstance: Worker<DrExecutionQueueJobData> | null = null;
 
 function getDrExecutionReconcileJobId(executionId: string): string {
-  return `dr-execution:${executionId}`;
+  return `dr-execution-${executionId}`;
 }
 
 function getDrExecutionQueue(): Queue<DrExecutionQueueJobData> {

--- a/apps/api/src/jobs/logCorrelation.test.ts
+++ b/apps/api/src/jobs/logCorrelation.test.ts
@@ -67,7 +67,7 @@ describe('log correlation queue helpers', () => {
       'rules-detect',
       expect.objectContaining({ orgId: 'org-1', ruleIds: ['r1', 'r2'] }),
       expect.objectContaining({
-        jobId: expect.stringMatching(/^log-correlation-rules:org-1:[a-z0-9]+:[a-z0-9]+$/),
+        jobId: expect.stringMatching(/^log-correlation-rules-org-1-[a-z0-9]+-[a-z0-9]+$/),
       }),
     );
   });

--- a/apps/api/src/jobs/logCorrelation.ts
+++ b/apps/api/src/jobs/logCorrelation.ts
@@ -172,12 +172,14 @@ export async function enqueueLogCorrelationDetection(options?: {
     ? Array.from(new Set(options.ruleIds.filter((ruleId) => typeof ruleId === 'string' && ruleId.length > 0))).sort()
     : undefined;
   const slot = Math.floor(Date.now() / ON_DEMAND_DEDUPE_WINDOW_MS).toString(36);
+  // '-' separator (not ':') — BullMQ rejects custom jobIds whose colon-split
+  // length !== 3, and this 4-part id would throw. See #1101.
   const jobId = [
     'log-correlation-rules',
     options?.orgId ?? 'all',
     stableShortHash(JSON.stringify(normalizedRuleIds ?? [])),
     slot,
-  ].join(':');
+  ].join('-');
   const existing = await queue.getJob(jobId);
   if (existing) {
     const state = await existing.getState();

--- a/apps/api/src/jobs/networkBaselineWorker.test.ts
+++ b/apps/api/src/jobs/networkBaselineWorker.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { addMock } = vi.hoisted(() => ({
+  addMock: vi.fn(async () => ({ id: 'queued-job-1' })),
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    add = addMock;
+    getRepeatableJobs = vi.fn(async () => []);
+    removeRepeatableByKey = vi.fn(async () => undefined);
+  },
+  Worker: class {
+    on = vi.fn();
+    close = vi.fn();
+  },
+  Job: class {},
+}));
+
+vi.mock('../services/redis', () => ({
+  getBullMQConnection: vi.fn(() => ({})),
+}));
+
+vi.mock('../db', () => ({
+  db: {},
+  withSystemDbAccessContext: vi.fn(),
+}));
+
+vi.mock('../db/schema', () => ({
+  discoveryJobs: {},
+  discoveryProfiles: {},
+  networkBaselines: {},
+  networkChangeEvents: {},
+}));
+
+vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../services/networkBaseline', () => ({
+  compareBaselineScan: vi.fn(),
+  normalizeBaselineScanSchedule: vi.fn(),
+}));
+vi.mock('./discoveryWorker', () => ({ enqueueDiscoveryScan: vi.fn() }));
+vi.mock('../services/discoveryJobCreation', () => ({ createDiscoveryJobIfIdle: vi.fn() }));
+
+import { enqueueBaselineScan } from './networkBaselineWorker';
+
+describe('networkBaselineWorker.enqueueBaselineScan jobId', () => {
+  beforeEach(() => {
+    addMock.mockClear();
+    addMock.mockResolvedValue({ id: 'queued-job-1' });
+  });
+
+  // Regression for "Custom Id cannot contain :" — BullMQ rejects a custom
+  // jobId whose colon-split length !== 3. `baseline-scan:<id>` is 2 parts and
+  // would throw, silently dropping the baseline-scan enqueue.
+  it('does not use a colon in the enqueued BullMQ job id', async () => {
+    await enqueueBaselineScan('baseline-1', 'org-1', 'site-1', '10.0.0.0/24');
+
+    expect(addMock).toHaveBeenCalled();
+    const [, , opts] = addMock.mock.calls[0] as unknown as [string, unknown, { jobId: string }];
+    expect(String(opts.jobId)).not.toContain(':');
+    expect(String(opts.jobId)).toBe('baseline-scan-baseline-1');
+  });
+});

--- a/apps/api/src/jobs/networkBaselineWorker.ts
+++ b/apps/api/src/jobs/networkBaselineWorker.ts
@@ -133,7 +133,7 @@ async function processScheduleScans(): Promise<{ enqueued: number }> {
           subnet: baseline.subnet
         },
         {
-          jobId: `baseline-scan:${baseline.id}`,
+          jobId: `baseline-scan-${baseline.id}`,
           removeOnComplete: { count: 50 },
           removeOnFail: { count: 100 }
         }
@@ -354,7 +354,7 @@ export async function enqueueBaselineScan(
       subnet
     },
     {
-      jobId: `baseline-scan:${baselineId}`,
+      jobId: `baseline-scan-${baselineId}`,
       removeOnComplete: { count: 50 },
       removeOnFail: { count: 100 }
     }

--- a/apps/api/src/jobs/patchJobExecutor.test.ts
+++ b/apps/api/src/jobs/patchJobExecutor.test.ts
@@ -135,7 +135,7 @@ describe('patch job executor queueing', () => {
       'execute-patch-job',
       { type: 'execute-patch-job', patchJobId: 'job-2' },
       expect.objectContaining({
-        jobId: 'patch-job:job-2',
+        jobId: 'patch-job-job-2',
         delay: 1234,
         removeOnComplete: { count: 100 },
         removeOnFail: { count: 200 },
@@ -176,7 +176,7 @@ describe('patch job executor queueing', () => {
         orgId: 'org-1',
       },
       {
-        jobId: 'patch-job-device:job-1:device-1',
+        jobId: 'patch-job-device-job-1-device-1',
         removeOnComplete: { count: 100 },
         removeOnFail: { count: 200 },
       },
@@ -185,12 +185,42 @@ describe('patch job executor queueing', () => {
       'check-completion',
       { type: 'check-completion', patchJobId: 'job-1' },
       expect.objectContaining({
-        jobId: 'patch-job-completion:job-1',
+        jobId: 'patch-job-completion-job-1',
         removeOnComplete: { count: 50 },
         removeOnFail: { count: 100 },
       }),
     );
     expect(result).toEqual({ dispatched: 2 });
+  });
+
+  // Regression for "Custom Id cannot contain :" — BullMQ throws when a custom
+  // jobId contains a single ':' (it only allows the legacy 3-part repeatable
+  // form), which silently stopped scheduled patching from being enqueued
+  // (observed daily on EU prod). No enqueued jobId may contain a ':'.
+  it('does not use a colon in any enqueued BullMQ job id', async () => {
+    // Direct enqueue path
+    await enqueuePatchJob('job-2', 1234);
+
+    // Worker fanout path (per-device + completion ids)
+    vi.mocked(db.select)
+      .mockImplementationOnce(() => createSelectChain([{
+        id: 'job-1',
+        orgId: 'org-1',
+        status: 'scheduled',
+        targets: { deviceIds: ['device-1'] },
+      }]) as any);
+    vi.mocked(db.update)
+      .mockImplementationOnce(() => createUpdateChain([{ id: 'job-1' }]) as any);
+
+    createPatchJobWorker();
+    await shared.processorRef({
+      data: { type: 'execute-patch-job', patchJobId: 'job-1' },
+    });
+
+    expect(shared.addMock.mock.calls.length).toBeGreaterThan(0);
+    for (const call of shared.addMock.mock.calls) {
+      expect(String(call[2].jobId)).not.toContain(':');
+    }
   });
 
   it('skips fanout when another worker already claimed the job row', async () => {

--- a/apps/api/src/jobs/patchJobExecutor.ts
+++ b/apps/api/src/jobs/patchJobExecutor.ts
@@ -51,19 +51,23 @@ const PATCH_JOB_COMPLETION_RETENTION = {
 let patchJobQueue: Queue | null = null;
 let patchJobDeviceQueue: Queue | null = null;
 
+// NOTE: BullMQ rejects a custom jobId containing ':' (it reserves that for the
+// legacy 3-part repeatable-job form), so these ids use '-' as the separator.
+// A ':' here silently breaks queue.add() — see #1101 (SNMP) for the same bug.
+// patchJobId/deviceId are UUID-shaped (no ':'), so ids stay stable and unique.
 function getPatchJobExecutionId(patchJobId: string): string {
-  return `patch-job:${patchJobId}`;
+  return `patch-job-${patchJobId}`;
 }
 
 function getPatchJobDeviceExecutionId(
   patchJobId: string,
   deviceId: string
 ): string {
-  return `patch-job-device:${patchJobId}:${deviceId}`;
+  return `patch-job-device-${patchJobId}-${deviceId}`;
 }
 
 function getPatchJobCompletionId(patchJobId: string): string {
-  return `patch-job-completion:${patchJobId}`;
+  return `patch-job-completion-${patchJobId}`;
 }
 
 async function resolveActiveQueueJob(queue: Queue, candidateIds: string[]) {

--- a/apps/api/src/jobs/peripheralJobs.test.ts
+++ b/apps/api/src/jobs/peripheralJobs.test.ts
@@ -91,7 +91,7 @@ describe('schedulePeripheralPolicyDistribution', () => {
     const addCall = queueMock.add.mock.calls[0];
     expect(addCall?.[0]).toBe('policy-distribution');
     expect(addCall?.[1]?.changedPolicyIds).toEqual(['pA', 'pB']);
-    expect(addCall?.[2]?.jobId).toBe('policy-distribution:org-2');
+    expect(addCall?.[2]?.jobId).toBe('policy-distribution-org-2');
   });
 
   it('removes stale completed job before creating a new one', async () => {
@@ -117,7 +117,7 @@ describe('schedulePeripheralPolicyDistribution', () => {
     expect(jobId).toBe('job-new');
     const addCall = queueMock.add.mock.calls[0];
     expect(addCall?.[1]?.changedPolicyIds).toEqual(['p-new']);
-    expect(addCall?.[2]?.jobId).toBe('policy-distribution:org-3');
+    expect(addCall?.[2]?.jobId).toBe('policy-distribution-org-3');
   });
 
   it('still creates a new job when stale job removal fails', async () => {

--- a/apps/api/src/jobs/peripheralJobs.ts
+++ b/apps/api/src/jobs/peripheralJobs.ts
@@ -284,7 +284,7 @@ export async function schedulePeripheralPolicyDistribution(
   reason: string = 'manual'
 ): Promise<string> {
   const queue = getPeripheralPolicyDistributionQueue();
-  const jobId = `policy-distribution:${orgId}`;
+  const jobId = `policy-distribution-${orgId}`;
   const normalizedPolicyIds = Array.from(new Set(policyIds.filter((id) => typeof id === 'string' && id.length > 0)));
 
   const existing = await queue.getJob(jobId);

--- a/apps/api/src/jobs/recoveryBootMediaWorker.test.ts
+++ b/apps/api/src/jobs/recoveryBootMediaWorker.test.ts
@@ -46,7 +46,7 @@ describe('recovery boot media queueing', () => {
     expect(shared.addMock).toHaveBeenCalledWith(
       'build-boot-media',
       expect.objectContaining({ artifactId: 'artifact-1' }),
-      expect.objectContaining({ jobId: 'recovery-boot-media:artifact-1' }),
+      expect.objectContaining({ jobId: 'recovery-boot-media-artifact-1' }),
     );
   });
 

--- a/apps/api/src/jobs/recoveryBootMediaWorker.ts
+++ b/apps/api/src/jobs/recoveryBootMediaWorker.ts
@@ -57,7 +57,7 @@ function createRecoveryBootMediaWorker(): Worker<RecoveryBootMediaQueueJobData> 
 
 export async function enqueueRecoveryBootMediaBuild(artifactId: string): Promise<string> {
   const queue = getRecoveryBootMediaQueue();
-  const stableJobId = `recovery-boot-media:${artifactId}`;
+  const stableJobId = `recovery-boot-media-${artifactId}`;
   const existing = await queue.getJob(stableJobId);
   if (existing) {
     const state = await existing.getState();

--- a/apps/api/src/jobs/recoveryMediaWorker.test.ts
+++ b/apps/api/src/jobs/recoveryMediaWorker.test.ts
@@ -46,7 +46,7 @@ describe('recovery media queueing', () => {
     expect(shared.addMock).toHaveBeenCalledWith(
       'build-media',
       expect.objectContaining({ artifactId: 'artifact-1' }),
-      expect.objectContaining({ jobId: 'recovery-media:artifact-1' }),
+      expect.objectContaining({ jobId: 'recovery-media-artifact-1' }),
     );
   });
 

--- a/apps/api/src/jobs/recoveryMediaWorker.ts
+++ b/apps/api/src/jobs/recoveryMediaWorker.ts
@@ -57,7 +57,7 @@ function createRecoveryMediaWorker(): Worker<RecoveryMediaQueueJobData> {
 
 export async function enqueueRecoveryMediaBuild(artifactId: string): Promise<string> {
   const queue = getRecoveryMediaQueue();
-  const stableJobId = `recovery-media:${artifactId}`;
+  const stableJobId = `recovery-media-${artifactId}`;
   const existing = await queue.getJob(stableJobId);
   if (existing) {
     const state = await existing.getState();

--- a/apps/api/src/jobs/softwareComplianceWorker.test.ts
+++ b/apps/api/src/jobs/softwareComplianceWorker.test.ts
@@ -1,5 +1,29 @@
-import { describe, expect, it } from 'vitest';
-import { readEarliestUnauthorizedDetection, shouldQueueAutoRemediation } from './softwareComplianceWorker';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { addMock } = vi.hoisted(() => ({
+  addMock: vi.fn(async () => ({ id: 'queued-job-1' })),
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    add = addMock;
+  },
+  Worker: class {
+    on = vi.fn();
+    close = vi.fn();
+  },
+  Job: class {},
+}));
+
+vi.mock('../services/redis', () => ({
+  getBullMQConnection: vi.fn(() => ({})),
+}));
+
+import {
+  readEarliestUnauthorizedDetection,
+  scheduleSoftwareComplianceCheck,
+  shouldQueueAutoRemediation,
+} from './softwareComplianceWorker';
 
 const NOW = new Date('2025-01-15T12:00:00Z');
 const PAST_VIOLATION = [{ type: 'unauthorized', detectedAt: '2025-01-01T00:00:00Z' }];
@@ -138,5 +162,25 @@ describe('readEarliestUnauthorizedDetection', () => {
     ];
     const result = readEarliestUnauthorizedDetection(violations);
     expect(result?.toISOString()).toBe('2025-01-05T00:00:00.000Z');
+  });
+});
+
+describe('scheduleSoftwareComplianceCheck jobId', () => {
+  beforeEach(() => {
+    addMock.mockClear();
+    addMock.mockResolvedValue({ id: 'queued-job-1' });
+  });
+
+  // Regression for "Custom Id cannot contain :" — BullMQ rejects a custom
+  // jobId whose colon-split length !== 3. The per-policy id is 4 parts and
+  // would throw, silently dropping the compliance-check enqueue.
+  it('does not use a colon in the per-policy BullMQ job id', async () => {
+    await scheduleSoftwareComplianceCheck('policy-1', ['device-1']);
+
+    expect(addMock).toHaveBeenCalled();
+    const [, , opts] = addMock.mock.calls[0] as unknown as [string, unknown, { jobId?: string }];
+    expect(opts.jobId).toBeDefined();
+    expect(String(opts.jobId)).not.toContain(':');
+    expect(String(opts.jobId)).toMatch(/^software-compliance-policy-1-[a-z0-9]+-[a-z0-9]+$/);
   });
 });

--- a/apps/api/src/jobs/softwareComplianceWorker.ts
+++ b/apps/api/src/jobs/softwareComplianceWorker.ts
@@ -578,13 +578,15 @@ export async function scheduleSoftwareComplianceCheck(
         type: 'scan-policies',
       },
     {
+      // '-' separator (not ':') — BullMQ rejects custom jobIds whose colon-split
+      // length !== 3, and this 4-part id would throw. See #1101.
       jobId: policyId
         ? [
           'software-compliance',
           policyId,
           stableShortHash(JSON.stringify(uniqueDeviceIds ?? [])),
           Math.floor(Date.now() / ON_DEMAND_DEDUPE_WINDOW_MS).toString(36),
-        ].join(':')
+        ].join('-')
         : undefined,
       removeOnComplete: { count: 100 },
       removeOnFail: { count: 200 },

--- a/apps/api/src/jobs/tenantErasure.test.ts
+++ b/apps/api/src/jobs/tenantErasure.test.ts
@@ -74,7 +74,7 @@ import {
 describe('tenantErasure worker', () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    addMock.mockResolvedValue({ id: 'tenant-erasure:org-xyz' });
+    addMock.mockResolvedValue({ id: 'tenant-erasure-org-xyz' });
     queueCloseMock.mockResolvedValue(undefined);
     workerCloseMock.mockResolvedValue(undefined);
     cascadeDeleteOrgMock.mockResolvedValue({
@@ -108,7 +108,7 @@ describe('tenantErasure worker', () => {
       'tenant-erasure',
       { orgId: 'org-xyz', performedBy: 'admin-1', performedByEmail: 'admin@example.com' },
       expect.objectContaining({
-        jobId: 'tenant-erasure:org-xyz',
+        jobId: 'tenant-erasure-org-xyz',
         attempts: 1,
       }),
     );
@@ -125,14 +125,14 @@ describe('tenantErasure worker', () => {
     const processor = capturedWorkerProcessor.current!;
     const result = await processor({
       name: 'tenant-erasure',
-      id: 'tenant-erasure:org-xyz',
+      id: 'tenant-erasure-org-xyz',
       data: { orgId: 'org-xyz', performedBy: 'admin-1', performedByEmail: 'admin@example.com' },
     });
     expect(cascadeDeleteOrgMock).toHaveBeenCalledWith('org-xyz', 'admin-1', 'admin@example.com');
     expect(result).toMatchObject({
       orgId: 'org-xyz',
       totalRowsDeleted: 2,
-      jobId: 'tenant-erasure:org-xyz',
+      jobId: 'tenant-erasure-org-xyz',
     });
   });
 
@@ -156,7 +156,7 @@ describe('tenantErasure worker', () => {
     await expect(
       processor({
         name: 'tenant-erasure',
-        id: 'tenant-erasure:org-xyz',
+        id: 'tenant-erasure-org-xyz',
         data: { orgId: 'org-xyz', performedBy: 'admin-1' },
       }),
     ).rejects.toThrow(/cascade boom/);

--- a/apps/api/src/jobs/tenantErasure.ts
+++ b/apps/api/src/jobs/tenantErasure.ts
@@ -15,7 +15,7 @@
  *
  * No cron / no kill switch: this queue ONLY runs when a platform admin
  * POSTs to `/admin/tenant-erasure`. Jobs are uniquely identified by
- * `tenant-erasure:<orgId>` so a double-POST collapses to a single job.
+ * `tenant-erasure-<orgId>` so a double-POST collapses to a single job.
  *
  * On failure: BullMQ's default retry is disabled here (`attempts: 1`)
  * because a partial-cascade re-run could hide a structural issue
@@ -52,7 +52,7 @@ export function getTenantErasureQueue(): Queue {
 }
 
 /**
- * Enqueue an erasure job. `jobId = tenant-erasure:<orgId>` so a
+ * Enqueue an erasure job. `jobId = tenant-erasure-<orgId>` so a
  * double-POST coalesces (BullMQ refuses to enqueue a duplicate). The
  * returned Job's id will be that jobId on first enqueue; subsequent
  * enqueues for the same org while the first is still in queue return
@@ -62,7 +62,7 @@ export async function enqueueTenantErasure(
   payload: TenantErasureJobPayload,
 ): Promise<{ id: string }> {
   const queue = getTenantErasureQueue();
-  const jobId = `tenant-erasure:${payload.orgId}`;
+  const jobId = `tenant-erasure-${payload.orgId}`;
   const job = await queue.add(JOB_NAME, payload, {
     jobId,
     attempts: 1,


### PR DESCRIPTION
## Problem

BullMQ's `Job.validateOptions` (verified against `bullmq@5.78.0`) throws `Custom Id cannot contain :` when a custom `jobId` contains a `:` unless it splits into **exactly 3 parts**:

```js
if (this.opts?.jobId.includes(':') && this.opts?.jobId.split(':').length !== 3)
    throw new Error('Custom Id cannot contain :');
```

So a **1-colon (2-part)** or **3+-colon (4-part)** custom `jobId` makes `queue.add()` throw — the job is silently never enqueued.

**Surfaced in EU prod logs**, failing daily at 22:13 UTC, silently dropping scheduled patching for a config policy:

```
[PatchScheduler] Error processing config policy cf8bcd04-…: Custom Id cannot contain :
```

`getPatchJobExecutionId` built `patch-job:<uuid>` (1 colon → 2 parts → throw). Auditing the rest of `apps/api/src/jobs/*.ts` found the **same latent bug at 15 more enqueue sites** — exactly the follow-up audit the SNMP fix (#1101) flagged. All are event/periodic-triggered and would throw when their `.add()` is reached (they just hadn't fired in EU's 7-day window).

## Fix

Switch the `:` separator to `-` at every offending site. Interpolated values are UUID/base-36 (no colons), so ids stay stable and unique, and `getJob()` dedup lookups still match.

**16 enqueue sites fixed (13 files):**
- `patchJobExecutor` — `patch-job` / `patch-job-device` / `patch-job-completion`
- `alertWorker` — `alert-evaluate-all`
- `networkBaselineWorker` — `baseline-scan` (×2)
- `peripheralJobs` — `policy-distribution`
- `tenantErasure` — `tenant-erasure`
- `c2cEnqueue` — `c2c-sync`, `c2c-restore`
- `drExecutionWorker` — `dr-execution`
- `deploymentWorker` — `deployment-process`
- `recoveryMediaWorker` / `recoveryBootMediaWorker` — `recovery(-boot)-media`
- `logCorrelation` — `log-correlation-rules` (4-part)
- `cisJobs` — `cis-manual-scan` (4-part)
- `browserSecurityJobs` — `browser-policy-eval` (4-part)
- `softwareComplianceWorker` — `software-compliance` (4-part)
- `automationWorker` — `automation-run`

> Note: `software-compliance` and `automation-run` were **not** in the original audit list — caught by a manual sweep here. Both are genuine 4-part / 2-part throwers.

**Left unchanged** (valid 0- or 2-colon ids): `alert-evaluate-device`, `deployment-device(-deferred)`, `deployment-next-batch`, `audit-policy-collection`, `audit-drift-evaluator`, `offline-detect`, `reliability-device`, `*-recompute`, `baseline-compare`, `log-correlation-pattern`, `cp-automation-run`. Confirmed `formatScheduleTriggerKey` emits no colon, so the schedule slot keys are colon-free.

## Why tests didn't catch it

Unit tests mock `queue.add`, so BullMQ's `validateOptions` never ran and the colon ids looked fine. Each fixed site now has a regression test asserting the enqueued `jobId` contains no `:` (new `triggerFullEvaluation`, `enqueueBaselineScan`, `scheduleSoftwareComplianceCheck` coverage + a `patchJobExecutor` regression test; existing exact-shape assertions flipped to the colon-free ids). Each new test verified RED against the colon version, GREEN after the fix.

## Testing

- `pnpm --filter=@breeze/api vitest run src/jobs/` — **44 files / 203 tests pass**
- `tsc --noEmit` clean on all changed files

## Deploy note

Once this ships to EU, config policy `cf8bcd04-…` will resume scheduled patching (currently failing nightly).

Follows up #1101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)