### PR TITLE
fix(web): pill-shape agent-silent badge + portal device row menu

### DIFF
--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 
 import DeviceList, { type Device } from './DeviceList';
@@ -91,5 +91,43 @@ describe('DeviceList — agent-silent (watchdog OK) badge (#800 web-UI gap)', ()
     const badge = screen.getByTestId(`device-${device.id}-agent-silent-badge`);
     // 2h should render as "2h"
     expect(badge.textContent).toMatch(/2h/);
+  });
+
+  it('keeps the badge on a single line so it renders as a pill, not a circle (#1013)', () => {
+    const device: Device = {
+      ...baseDevice,
+      id: '66666666-6666-6666-6666-666666666666',
+      hostname: 'host-narrow-column',
+      mainAgentSilentSince: new Date(Date.now() - 12 * 24 * 3600 * 1000).toISOString(),
+      watchdogStatus: 'connected',
+    };
+
+    render(<DeviceList devices={[device]} />);
+
+    const badge = screen.getByTestId(`device-${device.id}-agent-silent-badge`);
+    // Without whitespace-nowrap the text wraps to multiple lines and rounded-full
+    // renders the box as a circular blob instead of a pill.
+    expect(badge.className).toContain('whitespace-nowrap');
+  });
+});
+
+describe('DeviceList — row action menu (#1013 clipping fix)', () => {
+  it('renders the action menu in a portal outside the overflow-x-auto table wrapper so it is not clipped', () => {
+    const device: Device = {
+      ...baseDevice,
+      id: '77777777-7777-7777-7777-777777777777',
+      hostname: 'host-menu',
+    };
+
+    const { container } = render(<DeviceList devices={[device]} />);
+
+    fireEvent.click(screen.getByLabelText('Device actions'));
+
+    const menuItem = screen.getByText('Remote Terminal');
+    // The scroll container that was clipping the dropdown.
+    const scrollWrapper = container.querySelector('.overflow-x-auto');
+    expect(scrollWrapper).not.toBeNull();
+    // The menu must live OUTSIDE that wrapper (portaled to body) so overflow can't clip it.
+    expect(scrollWrapper?.contains(menuItem)).toBe(false);
   });
 });

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { Search, ChevronLeft, ChevronRight, ChevronUp, ChevronDown, ArrowUpDown, MoreHorizontal, MoreVertical, Filter, Terminal, FileCode, RotateCcw, Settings, Trash2, Zap, Columns3, Rows3, Rows4, AlignJustify } from 'lucide-react';
 import type { DesktopAccessState, FilterConditionGroup, RemoteAccessPolicy } from '@breeze/shared';
 import { fetchWithAuth } from '../../stores/auth';
@@ -227,7 +228,12 @@ export default function DeviceList({
   // kebab sits <300px from the viewport bottom would otherwise render
   // its dropdown into the area below the table and get clipped.
   const [rowMenuFlipUp, setRowMenuFlipUp] = useState(false);
+  // Viewport-relative anchor for the portaled row menu. The menu is rendered into
+  // document.body (not inside the overflow-x-auto table wrapper, which would clip it),
+  // so it positions itself with `fixed` coordinates derived from the kebab button.
+  const [rowMenuAnchor, setRowMenuAnchor] = useState<{ top: number; bottom: number; right: number } | null>(null);
   const rowMenuRef = useRef<HTMLDivElement>(null);
+  const rowMenuButtonRef = useRef<HTMLButtonElement | null>(null);
   const [serverFilterIds, setServerFilterIds] = useState<Set<string> | null>(null);
   const [serverFilterLoading, setServerFilterLoading] = useState(false);
   const [showMoreFilters, setShowMoreFilters] = useState(false);
@@ -238,12 +244,21 @@ export default function DeviceList({
   useEffect(() => {
     if (!rowMenuOpenId) return;
     const handleClickOutside = (e: MouseEvent) => {
-      if (rowMenuRef.current && !rowMenuRef.current.contains(e.target as Node)) {
-        setRowMenuOpenId(null);
-      }
+      const target = e.target as Node;
+      // The menu is portaled outside the trigger, so check both the menu and the button.
+      if (rowMenuRef.current?.contains(target) || rowMenuButtonRef.current?.contains(target)) return;
+      setRowMenuOpenId(null);
     };
+    // The menu is fixed-positioned from a captured anchor; scrolling would detach it, so close instead.
+    const handleScroll = () => setRowMenuOpenId(null);
     document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    window.addEventListener('scroll', handleScroll, true);
+    window.addEventListener('resize', handleScroll);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      window.removeEventListener('scroll', handleScroll, true);
+      window.removeEventListener('resize', handleScroll);
+    };
   }, [rowMenuOpenId]);
 
   // Close group dropdown on outside click
@@ -629,7 +644,7 @@ export default function DeviceList({
               <span
                 data-testid={`device-${device.id}-agent-silent-badge`}
                 title={`Main agent has been silent for ${formatSilentDuration(device.mainAgentSilentSince!)}. Watchdog is still reporting in, so the box is alive but the agent has wedged.`}
-                className="inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium bg-warning/15 text-warning border-warning/30"
+                className="inline-flex items-center whitespace-nowrap rounded-full border px-2 py-0.5 text-[10px] font-medium bg-warning/15 text-warning border-warning/30"
               >
                 Agent silent · {formatSilentDuration(device.mainAgentSilentSince!)}
               </span>
@@ -1220,15 +1235,18 @@ export default function DeviceList({
                         desktopAccess={device.desktopAccess}
                         remoteAccessPolicy={device.remoteAccessPolicy}
                       />
-                      <div className="relative" ref={rowMenuOpenId === device.id ? rowMenuRef : undefined}>
+                      <div className="relative">
                         <button
                           type="button"
+                          aria-label="Device actions"
+                          ref={rowMenuOpenId === device.id ? rowMenuButtonRef : undefined}
                           onClick={(e) => {
                             if (rowMenuOpenId !== device.id) {
                               const rect = e.currentTarget.getBoundingClientRect();
                               // ~280px dropdown height (7 items × ~36px + padding/divider).
                               // Flip up when the space below the button is less than that.
                               setRowMenuFlipUp(window.innerHeight - rect.bottom < 300);
+                              setRowMenuAnchor({ top: rect.top, bottom: rect.bottom, right: rect.right });
                             }
                             setRowMenuOpenId(rowMenuOpenId === device.id ? null : device.id);
                           }}
@@ -1236,8 +1254,18 @@ export default function DeviceList({
                         >
                           <MoreVertical className="h-4 w-4" />
                         </button>
-                        {rowMenuOpenId === device.id && (
-                          <div className={`absolute right-0 z-50 w-48 rounded-md border bg-card shadow-lg ${rowMenuFlipUp ? 'bottom-full mb-1' : 'top-full mt-1'}`}>
+                        {rowMenuOpenId === device.id && rowMenuAnchor && createPortal(
+                          <div
+                            ref={rowMenuRef}
+                            style={{
+                              position: 'fixed',
+                              right: window.innerWidth - rowMenuAnchor.right,
+                              ...(rowMenuFlipUp
+                                ? { bottom: window.innerHeight - rowMenuAnchor.top + 4 }
+                                : { top: rowMenuAnchor.bottom + 4 }),
+                            }}
+                            className="z-50 w-48 rounded-md border bg-card shadow-lg"
+                          >
                             <button
                               type="button"
                               disabled={device.status !== 'online'}
@@ -1324,7 +1352,8 @@ export default function DeviceList({
                                 Decommission
                               </button>
                             )}
-                          </div>
+                          </div>,
+                          document.body
                         )}
                       </div>
                     </div>


### PR DESCRIPTION
Fixes two device-list UI defects spotted in the devices table.

## 1. "Agent silent · Nd" badge rendered as a circle
In a narrow Status column the amber badge text wrapped to multiple lines; combined with `rounded-full` (`border-radius: 9999px`) this turned the box into a circular blob instead of a pill.

**Fix:** add `whitespace-nowrap` so the badge stays a single-line pill.

## 2. Three-dot row action menu clipped / rendered under the row above
The dropdown was `position: absolute` inside the table wrapper `<div class="mt-6 overflow-x-auto …">`. Per CSS, `overflow-x: auto` forces `overflow-y: auto`, making that wrapper a scroll container that **clips** the dropdown vertically — so on flip-up it was cut off behind the content above it.

**Fix:** render the menu through `createPortal(…, document.body)` with `position: fixed` coordinates derived from the kebab button's rect (same pattern as `Dialog.tsx`), so it can no longer be clipped. Supporting changes:
- capture the button anchor on open
- close the menu on scroll/resize (a fixed-positioned menu would otherwise detach from a scrolled row)
- outside-click handler now checks both the portaled menu and the trigger button
- added `aria-label="Device actions"` to the kebab button (a11y + testability)

## Tests
Extended `DeviceList.test.tsx`:
- guards that the agent-silent badge keeps `whitespace-nowrap`
- guards that the open action menu renders **outside** the `.overflow-x-auto` wrapper (portal)

```
Tests  6 passed (6)   ·   tsc --noEmit clean   ·   eslint clean
```

## ⚠️ Needs manual UI testing
These are visual/layout fixes and the automated tests run in jsdom (no real layout engine), so they can't confirm the rendered result. Please verify in the browser:
- [ ] The "Agent silent · Nd" badge renders as a horizontal pill (not a circle), including in a narrow/resized Status column.
- [ ] The three-dot action menu opens fully visible and is **not** clipped by the table's horizontal scroll container, both when it drops down and when it flips up (open it on a row near the bottom of the viewport).
- [ ] Menu still closes on outside click, on selecting an item, and on scroll/resize.
- [ ] Menu right-aligns under the kebab button and the flip-up threshold behaves near the viewport bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)