### PR TITLE
fix(agent): strip device token on cross-host enroll redirect (#1043)

### DIFF
--- a/agent/pkg/api/client.go
+++ b/agent/pkg/api/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -102,22 +103,38 @@ type AgentConfig struct {
 	EnabledCollectors                []string `json:"enabledCollectors,omitempty"`
 }
 
-// stripCredentialsOnCrossHostRedirect drops any header carrying the agent's
-// credentials when an HTTP redirect leaves the host the request was originally
-// sent to. Go's http.Client already strips Authorization/Cookie on a cross-host
-// redirect, but it forwards arbitrary custom headers, so the agent's existing
-// device token (sent as x-agent-reenrollment-token during a forced re-enroll)
-// would otherwise leak to a host a compromised or MITM'd server redirects to.
-// Same-host redirects (e.g. path or scheme-upgrade redirects from the legitimate
-// server) are trusted and keep the headers. See #1043.
-func stripCredentialsOnCrossHostRedirect(req *http.Request, via []*http.Request) error {
+// refuseUntrustedRedirect is the http.Client.CheckRedirect policy for the agent
+// API client. Every request the client makes carries the device token — Enroll
+// sends it as the custom x-agent-reenrollment-token header, the other calls send
+// it as Authorization: Bearer. Go follows redirects by default and, while it
+// drops Authorization/Cookie once a redirect leaves the original domain (it
+// still trusts subdomains), it forwards arbitrary custom headers — so a
+// compromised or MITM'd server could 30x a request to a host it controls and
+// harvest the token.
+//
+// Merely stripping the headers is not enough: following the redirect would still
+// hand the request body (during enroll: hostname, hardware serial, OS info) to
+// the attacker and let it forge the response the agent parses and persists
+// (e.g. authToken / mTLS cert). A legitimate Breeze server never redirects an
+// agent to a different host, so refuse the redirect outright and surface it to
+// the caller (which wraps the resulting error). Trusted redirects on the same
+// endpoint — a different path, or an http->https upgrade — are still followed.
+// An https->http downgrade is refused because it would expose the token over
+// cleartext. See #1043.
+func refuseUntrustedRedirect(req *http.Request, via []*http.Request) error {
 	if len(via) == 0 {
 		return nil
 	}
-	if req.URL.Host != via[len(via)-1].URL.Host {
-		req.Header.Del("x-agent-reenrollment-token")
-		req.Header.Del("Authorization")
-		req.Header.Del("Cookie")
+	prev := via[len(via)-1]
+	// The hostname is the trust boundary: the agent already trusts its
+	// configured server, so a same-host redirect (different path or port, or
+	// an http->https upgrade) is fine, but a redirect to any other host is not.
+	// Compared case-insensitively since hostnames are.
+	if !strings.EqualFold(req.URL.Hostname(), prev.URL.Hostname()) {
+		return fmt.Errorf("refusing redirect from host %s to untrusted host %s during credentialed request", prev.URL.Hostname(), req.URL.Hostname())
+	}
+	if prev.URL.Scheme == "https" && req.URL.Scheme != "https" {
+		return fmt.Errorf("refusing https->%s downgrade redirect to %s during credentialed request", req.URL.Scheme, req.URL.Hostname())
 	}
 	return nil
 }
@@ -129,7 +146,7 @@ func NewClient(baseURL, authToken, agentID string) *Client {
 		agentID:   agentID,
 		httpClient: &http.Client{
 			Timeout:       30 * time.Second,
-			CheckRedirect: stripCredentialsOnCrossHostRedirect,
+			CheckRedirect: refuseUntrustedRedirect,
 		},
 	}
 }
@@ -147,7 +164,7 @@ func NewClientWithTLS(baseURL, authToken, agentID string, tlsCfg *tls.Config) *C
 		httpClient: &http.Client{
 			Timeout:       30 * time.Second,
 			Transport:     transport,
-			CheckRedirect: stripCredentialsOnCrossHostRedirect,
+			CheckRedirect: refuseUntrustedRedirect,
 		},
 	}
 }

--- a/agent/pkg/api/client.go
+++ b/agent/pkg/api/client.go
@@ -102,13 +102,34 @@ type AgentConfig struct {
 	EnabledCollectors                []string `json:"enabledCollectors,omitempty"`
 }
 
+// stripCredentialsOnCrossHostRedirect drops any header carrying the agent's
+// credentials when an HTTP redirect leaves the host the request was originally
+// sent to. Go's http.Client already strips Authorization/Cookie on a cross-host
+// redirect, but it forwards arbitrary custom headers, so the agent's existing
+// device token (sent as x-agent-reenrollment-token during a forced re-enroll)
+// would otherwise leak to a host a compromised or MITM'd server redirects to.
+// Same-host redirects (e.g. path or scheme-upgrade redirects from the legitimate
+// server) are trusted and keep the headers. See #1043.
+func stripCredentialsOnCrossHostRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) == 0 {
+		return nil
+	}
+	if req.URL.Host != via[len(via)-1].URL.Host {
+		req.Header.Del("x-agent-reenrollment-token")
+		req.Header.Del("Authorization")
+		req.Header.Del("Cookie")
+	}
+	return nil
+}
+
 func NewClient(baseURL, authToken, agentID string) *Client {
 	return &Client{
 		baseURL:   baseURL,
 		authToken: authToken,
 		agentID:   agentID,
 		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout:       30 * time.Second,
+			CheckRedirect: stripCredentialsOnCrossHostRedirect,
 		},
 	}
 }
@@ -124,8 +145,9 @@ func NewClientWithTLS(baseURL, authToken, agentID string, tlsCfg *tls.Config) *C
 		authToken: authToken,
 		agentID:   agentID,
 		httpClient: &http.Client{
-			Timeout:   30 * time.Second,
-			Transport: transport,
+			Timeout:       30 * time.Second,
+			Transport:     transport,
+			CheckRedirect: stripCredentialsOnCrossHostRedirect,
 		},
 	}
 }

--- a/agent/pkg/api/client_test.go
+++ b/agent/pkg/api/client_test.go
@@ -4,8 +4,17 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
+
+// crossHostURL rewrites an httptest server URL (always 127.0.0.1) to a different
+// hostname so it models a redirect that leaves the agent's trusted host. The
+// target is never actually dialed in these tests — the redirect is refused
+// first — so it only needs a distinct hostname.
+func crossHostURL(serverURL, path string) string {
+	return strings.Replace(serverURL, "127.0.0.1", "localhost", 1) + path
+}
 
 func TestErrHTTPStatus_Error(t *testing.T) {
 	err := &ErrHTTPStatus{StatusCode: 401, Body: `{"error":"invalid key"}`}
@@ -107,39 +116,137 @@ func TestEnrollPresentsReenrollToken(t *testing.T) {
 	}
 }
 
-// A compromised or MITM'd server can answer the enroll request with a redirect
-// to a host it controls. Go's http.Client auto-strips Authorization/Cookie on a
-// cross-host redirect but NOT arbitrary custom headers, so the agent's existing
-// device token (sent as x-agent-reenrollment-token) would be forwarded to the
-// attacker's host. The client must drop the token when the redirect crosses to
-// a different host. See #1043.
-func TestEnrollDropsReenrollTokenOnCrossHostRedirect(t *testing.T) {
+// refuseUntrustedRedirect is the http.Client.CheckRedirect policy. It must
+// reject any redirect that would carry the agent's credentials off the endpoint
+// the request originally targeted, and allow trusted same-endpoint redirects.
+// See #1043.
+func TestRefuseUntrustedRedirect(t *testing.T) {
 	t.Parallel()
 
-	var attackerSawToken string
+	mustReq := func(rawURL string) *http.Request {
+		r, err := http.NewRequest(http.MethodGet, rawURL, nil)
+		if err != nil {
+			t.Fatalf("bad url %q: %v", rawURL, err)
+		}
+		return r
+	}
+
+	tests := []struct {
+		name    string
+		target  string
+		prev    string
+		wantErr bool
+	}{
+		{name: "same host and scheme, different path", target: "https://api.example.com/b", prev: "https://api.example.com/a", wantErr: false},
+		{name: "http to https upgrade on same host", target: "https://api.example.com/b", prev: "http://api.example.com/a", wantErr: false},
+		{name: "host comparison is case-insensitive", target: "https://API.Example.com/b", prev: "https://api.example.com/a", wantErr: false},
+		{name: "different port on same host is allowed", target: "https://api.example.com:8443/b", prev: "https://api.example.com/a", wantErr: false},
+		{name: "different host is refused", target: "https://evil.example.com/b", prev: "https://api.example.com/a", wantErr: true},
+		{name: "https to http downgrade is refused", target: "http://api.example.com:8443/b", prev: "https://api.example.com:8443/a", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := refuseUntrustedRedirect(mustReq(tt.target), []*http.Request{mustReq(tt.prev)})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("refuseUntrustedRedirect() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+
+	// The first call (no prior hops) must always be allowed.
+	if err := refuseUntrustedRedirect(mustReq("https://api.example.com/a"), nil); err != nil {
+		t.Fatalf("empty via should be allowed, got %v", err)
+	}
+}
+
+// A compromised or MITM'd server can answer the enroll request with a redirect
+// to a host it controls. Stripping the token would not be enough: following the
+// redirect still hands the enrollment body (hostname, hardware serial, OS info)
+// to the attacker and lets it forge the EnrollResponse the agent persists. The
+// client must refuse the redirect outright and never contact the other host.
+// See #1043.
+func TestEnrollRefusesCrossHostRedirect(t *testing.T) {
+	t.Parallel()
+
+	var attackerHits int
 	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		attackerSawToken = r.Header.Get("x-agent-reenrollment-token")
-		_, _ = w.Write([]byte(`{"agentId":"agent-1","authToken":"brz_new"}`))
+		attackerHits++
+		_, _ = w.Write([]byte(`{"agentId":"attacker","authToken":"brz_evil"}`))
 	}))
 	defer attacker.Close()
 
 	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, attacker.URL+"/api/v1/agents/enroll", http.StatusTemporaryRedirect)
+		http.Redirect(w, r, crossHostURL(attacker.URL, "/api/v1/agents/enroll"), http.StatusTemporaryRedirect)
 	}))
 	defer origin.Close()
 
 	client := NewClient(origin.URL, "brz_existing", "agent-1")
-	if _, err := client.Enroll(&EnrollRequest{EnrollmentKey: "key", Hostname: "host-1"}); err != nil {
-		t.Fatalf("Enroll() error = %v", err)
+	resp, err := client.Enroll(&EnrollRequest{EnrollmentKey: "key", Hostname: "host-1"})
+	if err == nil {
+		t.Fatalf("Enroll() should refuse the cross-host redirect, got resp = %+v", resp)
 	}
-	if attackerSawToken != "" {
-		t.Fatalf("re-enrollment token leaked to cross-host redirect target: %q", attackerSawToken)
+	if attackerHits != 0 {
+		t.Fatalf("agent contacted attacker host %d time(s); the request must never be sent there", attackerHits)
 	}
 }
 
-// A same-host redirect (e.g. a path or scheme-upgrade redirect from the
-// legitimate server) is trusted, so the token must still be presented at the
-// final hop — otherwise stripping it would break legitimate re-enrollment.
+// The same protection applies to every credentialed call, not just Enroll,
+// because all methods share one http.Client. RotateToken sends the device token
+// as Authorization: Bearer, which must never follow a cross-host redirect.
+func TestAuthenticatedRequestRefusesCrossHostRedirect(t *testing.T) {
+	t.Parallel()
+
+	var attackerHits int
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attackerHits++
+		_, _ = w.Write([]byte(`{"authToken":"brz_evil"}`))
+	}))
+	defer attacker.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, crossHostURL(attacker.URL, "/rotate"), http.StatusTemporaryRedirect)
+	}))
+	defer origin.Close()
+
+	client := NewClient(origin.URL, "brz_token", "agent-1")
+	if _, err := client.RotateToken(); err == nil {
+		t.Fatal("RotateToken() should refuse the cross-host redirect")
+	}
+	if attackerHits != 0 {
+		t.Fatalf("Authorization header would have leaked: attacker contacted %d time(s)", attackerHits)
+	}
+}
+
+// NewClientWithTLS (the mTLS production path) must wire the same redirect
+// policy as NewClient — exercised here so a regression in that constructor
+// cannot ship silently.
+func TestEnrollWithTLSClientRefusesCrossHostRedirect(t *testing.T) {
+	t.Parallel()
+
+	var attackerHits int
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attackerHits++
+		_, _ = w.Write([]byte(`{"agentId":"attacker"}`))
+	}))
+	defer attacker.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, crossHostURL(attacker.URL, "/api/v1/agents/enroll"), http.StatusTemporaryRedirect)
+	}))
+	defer origin.Close()
+
+	client := NewClientWithTLS(origin.URL, "brz_existing", "agent-1", nil)
+	if _, err := client.Enroll(&EnrollRequest{EnrollmentKey: "key", Hostname: "host-1"}); err == nil {
+		t.Fatal("Enroll() via NewClientWithTLS should refuse the cross-host redirect")
+	}
+	if attackerHits != 0 {
+		t.Fatalf("TLS client contacted attacker host %d time(s)", attackerHits)
+	}
+}
+
+// A same-endpoint redirect (e.g. a path redirect from the legitimate server) is
+// trusted, so the token must still reach the final hop — otherwise refusing it
+// would break legitimate re-enrollment.
 func TestEnrollKeepsReenrollTokenOnSameHostRedirect(t *testing.T) {
 	t.Parallel()
 

--- a/agent/pkg/api/client_test.go
+++ b/agent/pkg/api/client_test.go
@@ -106,3 +106,62 @@ func TestEnrollPresentsReenrollToken(t *testing.T) {
 		})
 	}
 }
+
+// A compromised or MITM'd server can answer the enroll request with a redirect
+// to a host it controls. Go's http.Client auto-strips Authorization/Cookie on a
+// cross-host redirect but NOT arbitrary custom headers, so the agent's existing
+// device token (sent as x-agent-reenrollment-token) would be forwarded to the
+// attacker's host. The client must drop the token when the redirect crosses to
+// a different host. See #1043.
+func TestEnrollDropsReenrollTokenOnCrossHostRedirect(t *testing.T) {
+	t.Parallel()
+
+	var attackerSawToken string
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attackerSawToken = r.Header.Get("x-agent-reenrollment-token")
+		_, _ = w.Write([]byte(`{"agentId":"agent-1","authToken":"brz_new"}`))
+	}))
+	defer attacker.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL+"/api/v1/agents/enroll", http.StatusTemporaryRedirect)
+	}))
+	defer origin.Close()
+
+	client := NewClient(origin.URL, "brz_existing", "agent-1")
+	if _, err := client.Enroll(&EnrollRequest{EnrollmentKey: "key", Hostname: "host-1"}); err != nil {
+		t.Fatalf("Enroll() error = %v", err)
+	}
+	if attackerSawToken != "" {
+		t.Fatalf("re-enrollment token leaked to cross-host redirect target: %q", attackerSawToken)
+	}
+}
+
+// A same-host redirect (e.g. a path or scheme-upgrade redirect from the
+// legitimate server) is trusted, so the token must still be presented at the
+// final hop — otherwise stripping it would break legitimate re-enrollment.
+func TestEnrollKeepsReenrollTokenOnSameHostRedirect(t *testing.T) {
+	t.Parallel()
+
+	var finalSawToken string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/agents/enroll":
+			http.Redirect(w, r, "/api/v1/agents/enroll-final", http.StatusTemporaryRedirect)
+		case "/api/v1/agents/enroll-final":
+			finalSawToken = r.Header.Get("x-agent-reenrollment-token")
+			_, _ = w.Write([]byte(`{"agentId":"agent-1","authToken":"brz_new"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	client := NewClient(ts.URL, "brz_existing", "agent-1")
+	if _, err := client.Enroll(&EnrollRequest{EnrollmentKey: "key", Hostname: "host-1"}); err != nil {
+		t.Fatalf("Enroll() error = %v", err)
+	}
+	if finalSawToken != "brz_existing" {
+		t.Fatalf("same-host redirect should preserve re-enrollment token, got %q", finalSawToken)
+	}
+}


### PR DESCRIPTION
## Summary
The enroll client sends the agent's device token on every request — `Enroll` as the custom `x-agent-reenrollment-token` header (added in #1032 for #1028), other calls as `Authorization: Bearer`. Go follows redirects by default and forwards arbitrary custom headers, so a compromised or MITM'd server could `30x`-redirect a request to a host it controls and harvest the token.

This adds a `CheckRedirect` policy (`refuseUntrustedRedirect`) to both `NewClient` and `NewClientWithTLS` (`agent/pkg/api/client.go`) that **refuses** any redirect leaving the trusted hostname, or downgrading `https`→`http`, returning an error surfaced to the caller. Stripping the header alone is insufficient — following the redirect would still hand the request body (hostname, hardware serial, OS info) to the attacker and let it forge the `EnrollResponse` (authToken / mTLS cert) the agent persists. Same-host redirects (path change, `http`→`https` upgrade) are still followed. Comparison is on hostname (case-insensitive), not `host:port`, so default-vs-explicit ports and scheme upgrades don't false-positive and break legitimate re-enrollment.

## Test Plan
- [x] `TestRefuseUntrustedRedirect` — table-driven: cross-host refused, https→http downgrade refused, same-host/path/port/case/scheme-upgrade allowed, empty `via` allowed
- [x] `TestEnrollRefusesCrossHostRedirect` — end-to-end; asserts the attacker host is **never contacted**
- [x] `TestAuthenticatedRequestRefusesCrossHostRedirect` — `Authorization`-bearing call (`RotateToken`) also refuses
- [x] `TestEnrollWithTLSClientRefusesCrossHostRedirect` — covers the `NewClientWithTLS` (mTLS) constructor path
- [x] `TestEnrollKeepsReenrollTokenOnSameHostRedirect` — legitimate same-host redirect still delivers the token
- [x] `go test ./pkg/api/ -race` green, `go vet` clean, `go build` OK

Closes #1043

🤖 Generated with [Claude Code](https://claude.com/claude-code)