### PR TITLE
fix(deps): override shell-quote >=1.8.4 to clear critical npm-audit on main

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "pnpm": {
     "overrides": {
       "axios@>=1.0.0 <1.15.2": ">=1.15.2",
+      "shell-quote@<1.8.4": ">=1.8.4",
       "fast-xml-parser@<5.5.7": ">=5.5.7",
       "fast-xml-parser@<5.7.0": ">=5.7.0",
       "brace-expansion@<1.1.13": ">=1.1.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   axios@>=1.0.0 <1.15.2: '>=1.15.2'
+  shell-quote@<1.8.4: '>=1.8.4'
   fast-xml-parser@<5.5.7: '>=5.5.7'
   fast-xml-parser@<5.7.0: '>=5.7.0'
   brace-expansion@<1.1.13: '>=1.1.13'
@@ -9025,10 +9026,6 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
-    engines: {node: '>= 0.4'}
 
   shell-quote@1.8.4:
     resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
@@ -19731,7 +19728,7 @@ snapshots:
 
   react-devtools-core@6.1.5:
     dependencies:
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       ws: 7.5.10
     transitivePeerDependencies:
       - bufferutil
@@ -20504,10 +20501,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
-
-  shell-quote@1.8.4:
-    optional: true
+  shell-quote@1.8.4: {}
 
   shiki@4.2.0:
     dependencies:


### PR DESCRIPTION
## What

Main's **NPM Audit** (Security Scanning workflow) has been failing since the astro group merge ([#1142](https://github.com/LanternOps/breeze/pull/1142)) on a critical advisory:

- **Advisory:** [GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p) — `shell-quote` `quote()` does not escape newlines in object `.op` values
- **Vulnerable:** `>=1.1.0 <=1.8.3` · **Patched:** `>=1.8.4` (tree currently resolves `1.8.3`)
- **Path:** `apps/mobile > react-native > react-devtools-core > shell-quote` — a **dev-tooling transitive**, so real runtime exposure is nil, but `pnpm audit --audit-level=critical` fails the gate on every push to main.

## Fix

One `pnpm.overrides` entry forcing `shell-quote@>=1.8.4`, exactly the pattern already used in this repo for `axios`, `fast-xml-parser`, `brace-expansion`, `dompurify`, etc. `shell-quote` now resolves `1.8.3 -> 1.8.4`.

## Verification (with repo-pinned pnpm 10.33.4)

- `pnpm audit --audit-level=critical` -> **No known vulnerabilities found**
- `pnpm install --frozen-lockfile` -> clean
- Diff is minimal: `package.json` +1 line, lockfile shell-quote-only (3 insertions / 9 deletions)