### PR TITLE
fix(remote-access): allowlist-first launcher scheme guard + mirror it client-side (#714)

### DIFF
--- a/apps/web/src/components/settings/PartnerRemoteAccessTab.test.ts
+++ b/apps/web/src/components/settings/PartnerRemoteAccessTab.test.ts
@@ -21,7 +21,14 @@ describe('urlTemplateError', () => {
     expect(urlTemplateError('file:///etc/passwd')).toMatch(/not permitted|blocked|allowed/i);
   });
 
-  it('accepts allowlisted and custom non-dangerous schemes', () => {
+  it('mirrors the server {id}-placeholder requirement inline', () => {
+    // The server rejects a template without {id}; surface that inline too so the
+    // user does not only find out on save.
+    expect(urlTemplateError('https://acme.example.com/static')).toMatch(/\{id\}/i);
+    expect(urlTemplateError('rustdesk://host?password={password}')).toMatch(/\{id\}/i);
+  });
+
+  it('accepts allowlisted and custom non-dangerous schemes with {id}', () => {
     expect(urlTemplateError('rustdesk://{id}?password={password}')).toBeNull();
     expect(urlTemplateError('https://acme.example.com/Host#Access///{id}/Join')).toBeNull();
     expect(urlTemplateError('bdunn-rustremote://{id}')).toBeNull();

--- a/apps/web/src/components/settings/PartnerRemoteAccessTab.test.ts
+++ b/apps/web/src/components/settings/PartnerRemoteAccessTab.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+
+import { urlTemplateError } from './PartnerRemoteAccessTab';
+
+// #714 / #680: the inline URL-template validation must mirror the server's
+// scheme guard so a partner admin gets immediate feedback on a blocked scheme
+// (e.g. javascript:) instead of only finding out on save.
+describe('urlTemplateError', () => {
+  it('returns null for an empty template (no error until the user types)', () => {
+    expect(urlTemplateError('')).toBeNull();
+  });
+
+  it('flags a template with no scheme', () => {
+    expect(urlTemplateError('rustdesk{id}')).toMatch(/scheme/i);
+    expect(urlTemplateError('//acme.example.com/{id}')).toMatch(/scheme/i);
+  });
+
+  it('mirrors the server denylist — rejects dangerous schemes inline', () => {
+    expect(urlTemplateError('javascript:alert(1)')).toMatch(/not permitted|blocked|allowed/i);
+    expect(urlTemplateError('data:text/html,<script>')).toMatch(/not permitted|blocked|allowed/i);
+    expect(urlTemplateError('file:///etc/passwd')).toMatch(/not permitted|blocked|allowed/i);
+  });
+
+  it('accepts allowlisted and custom non-dangerous schemes', () => {
+    expect(urlTemplateError('rustdesk://{id}?password={password}')).toBeNull();
+    expect(urlTemplateError('https://acme.example.com/Host#Access///{id}/Join')).toBeNull();
+    expect(urlTemplateError('bdunn-rustremote://{id}')).toBeNull();
+  });
+});

--- a/apps/web/src/components/settings/PartnerRemoteAccessTab.tsx
+++ b/apps/web/src/components/settings/PartnerRemoteAccessTab.tsx
@@ -1,7 +1,24 @@
 import { useCallback } from 'react';
 import { Plus, Trash2, MonitorPlay, Eye, EyeOff } from 'lucide-react';
 import { useState } from 'react';
+import { isAllowedLauncherScheme } from '@breeze/shared';
 import type { InheritableRemoteAccessSettings, RemoteAccessProvider } from '@breeze/shared';
+
+const SCHEME_PREFIX = /^[a-zA-Z][a-zA-Z0-9+.\-]*:/;
+
+// Inline validation for a provider's URL template. Mirrors the server guard
+// (orgs.ts uses isAllowedLauncherScheme) so a partner admin sees a blocked
+// scheme immediately instead of only on save. See #714/#680.
+export function urlTemplateError(template: string): string | null {
+  if (template.length === 0) return null;
+  if (!SCHEME_PREFIX.test(template)) {
+    return 'URL template must start with a scheme followed by a colon (e.g. rustdesk:, https:)';
+  }
+  if (!isAllowedLauncherScheme(template)) {
+    return 'That URL scheme is not permitted — javascript:, data:, vbscript:, file:, about:, chrome:, jar:, blob:, view-source: and filesystem: are blocked.';
+  }
+  return null;
+}
 
 type Props = {
   data: InheritableRemoteAccessSettings;
@@ -118,10 +135,7 @@ export default function PartnerRemoteAccessTab({ data, onChange }: Props) {
       ) : (
         <div className="space-y-3">
           {providers.map((p, idx) => {
-            const templateError =
-              p.urlTemplate.length > 0 && !/^[a-zA-Z][a-zA-Z0-9+.\-]*:/.test(p.urlTemplate)
-                ? 'URL template must start with a scheme followed by a colon (e.g. rustdesk:, https:)'
-                : null;
+            const templateError = urlTemplateError(p.urlTemplate);
             const isDefault = p.id === defaultProviderId;
             return (
               <div

--- a/apps/web/src/components/settings/PartnerRemoteAccessTab.tsx
+++ b/apps/web/src/components/settings/PartnerRemoteAccessTab.tsx
@@ -7,8 +7,8 @@ import type { InheritableRemoteAccessSettings, RemoteAccessProvider } from '@bre
 const SCHEME_PREFIX = /^[a-zA-Z][a-zA-Z0-9+.\-]*:/;
 
 // Inline validation for a provider's URL template. Mirrors the server guard
-// (orgs.ts uses isAllowedLauncherScheme) so a partner admin sees a blocked
-// scheme immediately instead of only on save. See #714/#680.
+// (orgs.ts: allowed scheme + the {id} placeholder) so a partner admin sees a
+// problem immediately instead of only on save. See #714/#680.
 export function urlTemplateError(template: string): string | null {
   if (template.length === 0) return null;
   if (!SCHEME_PREFIX.test(template)) {
@@ -16,6 +16,9 @@ export function urlTemplateError(template: string): string | null {
   }
   if (!isAllowedLauncherScheme(template)) {
     return 'That URL scheme is not permitted — javascript:, data:, vbscript:, file:, about:, chrome:, jar:, blob:, view-source: and filesystem: are blocked.';
+  }
+  if (!template.includes('{id}')) {
+    return 'URL template must include the {id} placeholder for the per-device value.';
   }
   return null;
 }

--- a/packages/shared/src/validators/remoteAccessLauncherScheme.test.ts
+++ b/packages/shared/src/validators/remoteAccessLauncherScheme.test.ts
@@ -1,7 +1,20 @@
 import { describe, it, expect } from 'vitest';
-import { ALLOWED_LAUNCHER_SCHEMES, isAllowedLauncherScheme } from './remoteAccessLauncherScheme';
+import {
+  ALLOWED_LAUNCHER_SCHEMES,
+  DISALLOWED_LAUNCHER_SCHEMES,
+  isAllowedLauncherScheme,
+} from './remoteAccessLauncherScheme';
 
 describe('isAllowedLauncherScheme', () => {
+  it('keeps the allowlist and the dangerous denylist disjoint', () => {
+    // Load-bearing invariant: the allowlist short-circuits before the denylist,
+    // so a scheme on BOTH lists would be silently un-blocked — reintroducing the
+    // exact XSS vector this guard exists to prevent. The denylist is the floor.
+    for (const scheme of ALLOWED_LAUNCHER_SCHEMES) {
+      expect(DISALLOWED_LAUNCHER_SCHEMES.has(scheme)).toBe(false);
+    }
+  });
+
   it('exposes the known-good scheme allowlist', () => {
     // The guard is allowlist-first: these well-known remote-access (and web)
     // schemes are explicitly permitted. The set is exported so the client can

--- a/packages/shared/src/validators/remoteAccessLauncherScheme.test.ts
+++ b/packages/shared/src/validators/remoteAccessLauncherScheme.test.ts
@@ -1,7 +1,22 @@
 import { describe, it, expect } from 'vitest';
-import { isAllowedLauncherScheme } from './remoteAccessLauncherScheme';
+import { ALLOWED_LAUNCHER_SCHEMES, isAllowedLauncherScheme } from './remoteAccessLauncherScheme';
 
 describe('isAllowedLauncherScheme', () => {
+  it('exposes the known-good scheme allowlist', () => {
+    // The guard is allowlist-first: these well-known remote-access (and web)
+    // schemes are explicitly permitted. The set is exported so the client can
+    // reuse it for inline hints.
+    expect(ALLOWED_LAUNCHER_SCHEMES).toEqual(
+      new Set(['https', 'http', 'rustdesk', 'teamviewer', 'anydesk', 'splashtop', 'screenconnect']),
+    );
+  });
+
+  it('accepts every scheme on the known-good allowlist', () => {
+    for (const scheme of ALLOWED_LAUNCHER_SCHEMES) {
+      expect(isAllowedLauncherScheme(`${scheme}://host/{id}`)).toBe(true);
+    }
+  });
+
   it('accepts known-safe remote-access schemes', () => {
     expect(isAllowedLauncherScheme('rustdesk://{id}?password={password}')).toBe(true);
     expect(isAllowedLauncherScheme('teamviewer://{id}')).toBe(true);
@@ -11,6 +26,14 @@ describe('isAllowedLauncherScheme', () => {
     expect(isAllowedLauncherScheme('http://127.0.0.1:42/{id}')).toBe(true);
     expect(isAllowedLauncherScheme('breeze://connect?id={id}')).toBe(true);
     expect(isAllowedLauncherScheme('bdunn-rustremote://{id}')).toBe(true);
+  });
+
+  it('still accepts custom (off-allowlist) schemes that are not dangerous', () => {
+    // Non-breaking: partner-configured custom protocols outside the allowlist
+    // remain allowed as long as they are not on the dangerous denylist.
+    expect(isAllowedLauncherScheme('breeze://connect?id={id}')).toBe(true);
+    expect(isAllowedLauncherScheme('bdunn-rustremote://{id}')).toBe(true);
+    expect(isAllowedLauncherScheme('my-custom-tool://{id}')).toBe(true);
   });
 
   it('rejects javascript: in any case (stored XSS via partner-admin)', () => {

--- a/packages/shared/src/validators/remoteAccessLauncherScheme.ts
+++ b/packages/shared/src/validators/remoteAccessLauncherScheme.ts
@@ -19,7 +19,11 @@ export const ALLOWED_LAUNCHER_SCHEMES: ReadonlySet<string> = new Set([
   'https', 'http', 'rustdesk', 'teamviewer', 'anydesk', 'splashtop', 'screenconnect',
 ]);
 
-const DISALLOWED_SCHEMES: ReadonlySet<string> = new Set([
+// The hard floor: no scheme — allowlisted or custom — may ever cross this set.
+// Exported so callers/tests can assert it stays disjoint from the allowlist (a
+// scheme on both lists would be silently un-blocked by the allowlist short
+// circuit below).
+export const DISALLOWED_LAUNCHER_SCHEMES: ReadonlySet<string> = new Set([
   'javascript', 'data', 'vbscript', 'file', 'about', 'chrome', 'jar', 'blob',
   'view-source', 'filesystem',
 ]);
@@ -32,5 +36,5 @@ export function isAllowedLauncherScheme(urlOrTemplate: string): boolean {
   const scheme = m[1]?.toLowerCase();
   if (!scheme) return false;
   if (ALLOWED_LAUNCHER_SCHEMES.has(scheme)) return true;
-  return !DISALLOWED_SCHEMES.has(scheme);
+  return !DISALLOWED_LAUNCHER_SCHEMES.has(scheme);
 }

--- a/packages/shared/src/validators/remoteAccessLauncherScheme.ts
+++ b/packages/shared/src/validators/remoteAccessLauncherScheme.ts
@@ -7,6 +7,17 @@
 // crafted urlTemplate. We block those at validation time AND on the client
 // before firing, since one source of truth on a sensitive guard like this
 // is brittle.
+//
+// The guard is allowlist-first (#714/#680): the well-known remote-access and
+// web schemes below are explicitly permitted. Anything off the allowlist is
+// still accepted as long as it is not on the dangerous denylist — partners
+// configure their own custom protocol handlers (e.g. niche remote tools), so a
+// strict allowlist would break legitimate setups. The denylist remains the
+// hard floor that no scheme, listed or custom, may cross.
+
+export const ALLOWED_LAUNCHER_SCHEMES: ReadonlySet<string> = new Set([
+  'https', 'http', 'rustdesk', 'teamviewer', 'anydesk', 'splashtop', 'screenconnect',
+]);
 
 const DISALLOWED_SCHEMES: ReadonlySet<string> = new Set([
   'javascript', 'data', 'vbscript', 'file', 'about', 'chrome', 'jar', 'blob',
@@ -20,5 +31,6 @@ export function isAllowedLauncherScheme(urlOrTemplate: string): boolean {
   if (!m) return false;
   const scheme = m[1]?.toLowerCase();
   if (!scheme) return false;
+  if (ALLOWED_LAUNCHER_SCHEMES.has(scheme)) return true;
   return !DISALLOWED_SCHEMES.has(scheme);
 }


### PR DESCRIPTION
## Summary

Resolves the still-valid nits from the #680 remote-desktop launcher review pass (issue #714). Per the issue owner's [triage comment](https://github.com/LanternOps/breeze/issues/714#issuecomment), the `#700` `preflight.sh` items are moot and `#705` is tracking-only, so this covers the two open `#680` items — which are coupled (the client reuses the shared validator).

## Changes

**1. Allowlist-first scheme guard** — `packages/shared/src/validators/remoteAccessLauncherScheme.ts`
- Introduces an explicit, exported `ALLOWED_LAUNCHER_SCHEMES` set (`https`, `http`, `rustdesk`, `teamviewer`, `anydesk`, `splashtop`, `screenconnect`). The guard now allowlists these first, and any off-allowlist scheme is still accepted **only** if it clears the dangerous denylist (`javascript:`, `data:`, `vbscript:`, `file:`, …).
- Chosen for **no regression**: partners configure their own custom protocol handlers (the tests include e.g. `bdunn-rustremote://`), so a strict allowlist would break legitimate setups. Accept/reject behaviour is unchanged vs. the old denylist — the value is the explicit, reusable allowlist and clearer intent.

**2. Client mirrors the server guard** — `apps/web/src/components/settings/PartnerRemoteAccessTab.tsx`
- The inline URL-template validation previously only checked for a scheme's *presence*. It now reuses `isAllowedLauncherScheme` via an extracted, unit-tested `urlTemplateError()` helper, so a partner admin sees a blocked scheme (`javascript:`, etc.) **immediately** instead of only when the server rejects it on save.

## Items already addressed / moot (verified)
- `makeProviderId()` already uses `crypto.randomUUID()` (a prior commit, with a `#714` comment).
- `EffectiveOrgSettings.remoteAccessProviders` **does not exist** — the field lives on `PartnerSettings` and is actively used; nothing dead to remove.
- `#700` `scripts/security/preflight.sh` nits — struck by the issue owner (script not on `main`).
- `#705` localStorage persistence — tracking-only by design.

## Tests
- Shared: `ALLOWED_LAUNCHER_SCHEMES` is exported and every entry passes; custom off-allowlist non-dangerous schemes still pass; dangerous schemes still rejected.
- Web: new `urlTemplateError` suite (empty → no error, missing scheme, dangerous scheme rejected inline, allowlisted/custom accepted).
- Suites green: shared **595**, web **806**, API remote-access-launch **6** + orgs **93**; `astro check` 0 errors, lint clean.

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)