### PR TITLE
fix(api): canonicalize NODE_ENV at boot so prod gates aren't silently downgraded (#917 L-6)

### DIFF
--- a/apps/api/src/config/normalizeNodeEnv.test.ts
+++ b/apps/api/src/config/normalizeNodeEnv.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, it, expect, vi } from 'vitest';
+
+import { canonicalNodeEnv, normalizeNodeEnv } from './normalizeNodeEnv';
+
+// #917 L-6: a non-canonical NODE_ENV (Production / prod / PROD) used to silently
+// downgrade prod security gates to dev mode because every gate did an exact
+// `=== 'production'` match. We canonicalize NODE_ENV once at boot instead.
+describe('canonicalNodeEnv', () => {
+  it('maps every production spelling to "production"', () => {
+    for (const raw of ['production', 'Production', 'PRODUCTION', 'prod', 'PROD', '  Prod ']) {
+      expect(canonicalNodeEnv(raw)).toBe('production');
+    }
+  });
+
+  it('maps development spellings to "development"', () => {
+    for (const raw of ['development', 'Development', 'DEV', 'dev']) {
+      expect(canonicalNodeEnv(raw)).toBe('development');
+    }
+  });
+
+  it('maps test spellings to "test"', () => {
+    expect(canonicalNodeEnv('test')).toBe('test');
+    expect(canonicalNodeEnv('TEST')).toBe('test');
+  });
+
+  it('returns null for unrecognized values so they are left untouched (zod still rejects them)', () => {
+    expect(canonicalNodeEnv('staging')).toBeNull();
+    expect(canonicalNodeEnv('')).toBeNull();
+  });
+});
+
+describe('normalizeNodeEnv', () => {
+  it('rewrites a non-canonical production value in place', () => {
+    const env: NodeJS.ProcessEnv = { NODE_ENV: 'Production' };
+    const result = normalizeNodeEnv(env);
+    expect(env.NODE_ENV).toBe('production');
+    expect(result).toEqual({ from: 'Production', to: 'production', changed: true });
+  });
+
+  it('leaves an already-canonical value unchanged (no spurious rewrite)', () => {
+    const env: NodeJS.ProcessEnv = { NODE_ENV: 'production' };
+    const result = normalizeNodeEnv(env);
+    expect(env.NODE_ENV).toBe('production');
+    expect(result.changed).toBe(false);
+  });
+
+  it('leaves an undefined NODE_ENV untouched (preserves the downstream default)', () => {
+    const env: NodeJS.ProcessEnv = {};
+    const result = normalizeNodeEnv(env);
+    expect('NODE_ENV' in env).toBe(false);
+    expect(result.changed).toBe(false);
+  });
+
+  it('leaves an unrecognized value untouched so zod can fail-fast on it', () => {
+    const env: NodeJS.ProcessEnv = { NODE_ENV: 'staging' };
+    const result = normalizeNodeEnv(env);
+    expect(env.NODE_ENV).toBe('staging');
+    expect(result.changed).toBe(false);
+  });
+});
+
+describe('import side effect', () => {
+  const original = process.env.NODE_ENV;
+  afterEach(() => {
+    process.env.NODE_ENV = original;
+    vi.resetModules();
+  });
+
+  it('normalizes the live process.env.NODE_ENV when the module is imported (boot path)', async () => {
+    // This is the mechanism that protects the import-time gates: importing the
+    // module (as index.ts does, right after dotenv) must canonicalize NODE_ENV.
+    vi.resetModules();
+    process.env.NODE_ENV = 'Production';
+    await import('./normalizeNodeEnv');
+    expect(process.env.NODE_ENV).toBe('production');
+  });
+});

--- a/apps/api/src/config/normalizeNodeEnv.test.ts
+++ b/apps/api/src/config/normalizeNodeEnv.test.ts
@@ -48,21 +48,23 @@ describe('normalizeNodeEnv', () => {
     const env: NodeJS.ProcessEnv = {};
     const result = normalizeNodeEnv(env);
     expect('NODE_ENV' in env).toBe(false);
-    expect(result.changed).toBe(false);
+    expect(result).toEqual({ from: undefined, to: undefined, changed: false });
   });
 
   it('leaves an unrecognized value untouched so zod can fail-fast on it', () => {
     const env: NodeJS.ProcessEnv = { NODE_ENV: 'staging' };
     const result = normalizeNodeEnv(env);
     expect(env.NODE_ENV).toBe('staging');
-    expect(result.changed).toBe(false);
+    expect(result).toEqual({ from: 'staging', to: 'staging', changed: false });
   });
 });
 
 describe('import side effect', () => {
   const original = process.env.NODE_ENV;
   afterEach(() => {
-    process.env.NODE_ENV = original;
+    if (original === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = original;
+    vi.restoreAllMocks();
     vi.resetModules();
   });
 
@@ -73,5 +75,21 @@ describe('import side effect', () => {
     process.env.NODE_ENV = 'Production';
     await import('./normalizeNodeEnv');
     expect(process.env.NODE_ENV).toBe('production');
+  });
+
+  it('logs the resolved mode only when it actually rewrites the value', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    vi.resetModules();
+    process.env.NODE_ENV = 'Production';
+    await import('./normalizeNodeEnv');
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0]?.[0]).toContain('"Production" -> production');
+
+    log.mockClear();
+    vi.resetModules();
+    process.env.NODE_ENV = 'production';
+    await import('./normalizeNodeEnv');
+    expect(log).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/config/normalizeNodeEnv.ts
+++ b/apps/api/src/config/normalizeNodeEnv.ts
@@ -1,0 +1,52 @@
+// Canonicalize NODE_ENV at process start so production security gates are never
+// silently downgraded by a non-canonical value. Almost every gate in the API
+// does an exact `process.env.NODE_ENV === 'production'` match, so a deploy with
+// `NODE_ENV=Production` (or `prod` / `PROD`) used to read as *not* production —
+// quietly running prod with dev-mode gates. We rewrite the value to its
+// canonical form once, before anything reads it. See issue #917 (L-6).
+//
+// This module MUST be imported before any module that reads NODE_ENV at import
+// time (e.g. routes/metrics.ts, routes/docs.ts, routes/portal/schemas.ts) — it
+// is imported in index.ts immediately after `dotenv/config`, so .env is loaded
+// first and every later import observes the canonical value.
+
+/**
+ * Returns the canonical NODE_ENV for a raw value, or null if it is not a
+ * recognized spelling (unknown values are left untouched so the config zod enum
+ * can still fail-fast on them rather than us guessing a mode).
+ */
+export function canonicalNodeEnv(raw: string): string | null {
+  const v = raw.trim().toLowerCase();
+  if (v === 'production' || v === 'prod') return 'production';
+  if (v === 'development' || v === 'dev') return 'development';
+  if (v === 'test') return 'test';
+  return null;
+}
+
+export interface NodeEnvNormalization {
+  from: string | undefined;
+  to: string | undefined;
+  changed: boolean;
+}
+
+/**
+ * Rewrites `env.NODE_ENV` to its canonical form in place. Undefined and
+ * unrecognized values are left exactly as-is (undefined preserves the
+ * downstream `?? 'development'` / zod default behavior; unknown values stay so
+ * config validation can reject them).
+ */
+export function normalizeNodeEnv(env: NodeJS.ProcessEnv = process.env): NodeEnvNormalization {
+  const from = env.NODE_ENV;
+  if (from === undefined) return { from, to: from, changed: false };
+  const canon = canonicalNodeEnv(from);
+  if (canon === null || canon === from) return { from, to: from, changed: false };
+  env.NODE_ENV = canon;
+  return { from, to: canon, changed: true };
+}
+
+// Side effect on import: normalize the live process environment and surface the
+// resolved mode at boot so a misconfigured deploy is visible in the logs.
+const result = normalizeNodeEnv();
+if (result.changed) {
+  console.log(`[config] NODE_ENV normalized: ${JSON.stringify(result.from)} -> ${result.to}`);
+}

--- a/apps/api/src/db/autoMigrate.ts
+++ b/apps/api/src/db/autoMigrate.ts
@@ -1,3 +1,6 @@
+// Canonicalize NODE_ENV before anything reads it — this is a standalone CLI
+// entrypoint (db:migrate) that, via seed, gates on NODE_ENV. See #917 (L-6).
+import '../config/normalizeNodeEnv';
 import { createHash } from 'node:crypto';
 import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -1,3 +1,6 @@
+// Canonicalize NODE_ENV first — seed gates the bootstrap admin on it and runs
+// as a standalone CLI (db:seed) as well as from autoMigrate. See #917 (L-6).
+import '../config/normalizeNodeEnv';
 import { db, withSystemDbAccessContext } from './index';
 import { roles, permissions, rolePermissions, scripts, alertTemplates, partners, organizations, sites, users, partnerUsers } from './schema';
 import { eq, and } from 'drizzle-orm';

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,8 @@
 import 'dotenv/config';
+// Canonicalize NODE_ENV before any module reads it (some routes/services gate
+// on `NODE_ENV === 'production'` at import time). Must stay directly after
+// dotenv so .env is loaded first. See #917 (L-6).
+import './config/normalizeNodeEnv';
 import { serve } from '@hono/node-server';
 import { createNodeWebSocket } from '@hono/node-ws';
 import { Hono } from 'hono';


### PR DESCRIPTION
## Summary

Addresses **L-6** of the #917 hardening cluster. Nearly every production gate in the API does an exact `process.env.NODE_ENV === 'production'` match, so a deploy with `NODE_ENV=Production` (or `prod` / `PROD`) reads as **not** production — silently running prod with dev-mode security gates (insecure-redis warning suppressed, metrics scrape token disabled, API docs UI exposed, portal Redis backend off, …). A real self-hoster foot-gun.

## Why normalize-at-source (not a per-site sweep or a zod-only fix)

There are ~30 `NODE_ENV === 'production'` checks across the API. Critically, **5 of them read `NODE_ENV` at module import time** (`routes/metrics.ts`, `routes/docs.ts`, `routes/portal/schemas.ts`, `index.ts`'s `REQUIRE_REDIS_ON_STARTUP`), which run *before* `validateConfig()`. So normalizing only inside the config zod schema wouldn't fix those, and a 30-site sweep risks polarity errors on security gates.

Instead, canonicalize once at the source:
- New `apps/api/src/config/normalizeNodeEnv.ts` — `canonicalNodeEnv()` maps `Production`/`PROD`/`prod` → `production` (and `dev` → `development`, `TEST` → `test`); `normalizeNodeEnv()` rewrites `process.env.NODE_ENV` in place. Unknown values (e.g. `staging`) and `undefined` are **left untouched** so the config zod enum still fails fast and the downstream `?? 'development'` default still applies.
- Imported in `index.ts` immediately after `dotenv/config`, **before any gate module loads**, so every import-time and call-time check observes the canonical value. The resolved mode is logged at boot.

## Verification
- Unit tests: `canonicalNodeEnv` / `normalizeNodeEnv` mappings, in-place rewrite, no-op on canonical/undefined/unknown, and the **import side effect** that normalizes the live env (the mechanism protecting the import-time gates).
- Booted both `tsx src/index.ts` **and the bundled `dist/index.cjs`** (what prod runs) with `NODE_ENV=Production`:
  - `[config] NODE_ENV normalized: "Production" -> production`
  - `[remoteSessionAuth] tickets backend: redis (NODE_ENV=production, …)` — a gate now sees production
  - config validation runs in **production mode** (demands prod-only secrets) — pre-fix it would not have.
- `api` lint + typecheck clean; `config` / `secretCrypto` / `clientIp` suites green (161).

The existing call-time `=== 'production'` checks are now correct without modification, so the diff stays tiny and low-risk.

Addresses **L-6** of #917. The other sub-items (L-1 is time-gated to 2026-06-15, L-2/L-3/L-5/M-6) remain tracked in that umbrella — leaving #917 open intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)