### PR TITLE
ci: blocking integration tests, main-red alerting, workflow lint, Windows cargo check, dependabot staggering

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,12 @@
 version: 2
 
+# Ecosystems are deliberately staggered across weekdays (npm Monday, Go
+# Tuesday, Actions Wednesday, Cargo Thursday) so the weekly batch doesn't
+# land as one Monday merge storm — on 2026-06-09 the storm churned the
+# lockfile 2,400+ lines mid-day, cancelled most main CI runs, and caused
+# PR-vs-main merge skew. Spreading the load keeps each day's batch small
+# enough to review and merge calmly.
+
 updates:
   # Node.js / pnpm dependencies for the root and all workspaces
   - package-ecosystem: "npm"
@@ -11,6 +18,19 @@ updates:
       timezone: "America/New_York"
     open-pull-requests-limit: 10
     groups:
+      # The whole mobile toolchain moves together — a solo expo major bump
+      # (55→56 on 2026-06-09) rewrote ~2,400 lockfile lines on its own and
+      # broke unrelated API test resolution. One PR per week for all of it.
+      mobile:
+        patterns:
+          - "expo"
+          - "expo-*"
+          - "@expo/*"
+          - "react-native"
+          - "react-native-*"
+          - "@react-native*"
+          - "metro"
+          - "metro-*"
       # Group minor and patch updates together
       typescript-tooling:
         patterns:
@@ -114,11 +134,18 @@ updates:
     directory: "/agent"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "tuesday"
       time: "09:00"
       timezone: "America/New_York"
     open-pull-requests-limit: 5
     groups:
+      # The AWS SDK ships several modules per release that must move
+      # together (credentials, s3/manager, etc. all landed as separate
+      # PRs on 2026-06-09).
+      aws-sdk:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2*"
+          - "github.com/aws/smithy-go"
       # Group related Go dependencies
       cobra-viper:
         patterns:
@@ -152,7 +179,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "wednesday"
       time: "09:00"
       timezone: "America/New_York"
     open-pull-requests-limit: 5
@@ -176,10 +203,24 @@ updates:
     directory: "/apps/helper/src-tauri"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "thursday"
       time: "09:00"
       timezone: "America/New_York"
     open-pull-requests-limit: 5
+    groups:
+      # RustCrypto crates share the `digest` core and break when bumped
+      # individually — sha2 0.11 + hmac 0.13 were an inseparable pair
+      # (#1082/#1083 each broke the build alone; merged together in #1146).
+      rustcrypto:
+        patterns:
+          - "sha2"
+          - "sha1"
+          - "hmac"
+          - "digest"
+          - "md-5"
+          - "cipher"
+          - "aes*"
+          - "crypto-common"
     labels:
       - "dependencies"
       - "rust"
@@ -194,10 +235,22 @@ updates:
     directory: "/apps/viewer/src-tauri"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "thursday"
       time: "09:00"
       timezone: "America/New_York"
     open-pull-requests-limit: 5
+    groups:
+      # Same coupling as the helper: RustCrypto crates move together.
+      rustcrypto:
+        patterns:
+          - "sha2"
+          - "sha1"
+          - "hmac"
+          - "digest"
+          - "md-5"
+          - "cipher"
+          - "aes*"
+          - "crypto-common"
     labels:
       - "dependencies"
       - "rust"

--- a/.github/workflows/ci-smoke-binary-source-github.yml
+++ b/.github/workflows/ci-smoke-binary-source-github.yml
@@ -31,6 +31,9 @@ on:
 env:
   PNPM_VERSION: '10.33.4'
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     name: BINARY_SOURCE=github download path

--- a/.github/workflows/ci-smoke-binary-source-local.yml
+++ b/.github/workflows/ci-smoke-binary-source-local.yml
@@ -21,6 +21,9 @@ on:
 env:
   PNPM_VERSION: '10.33.4'
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     name: BINARY_SOURCE=local download path

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,6 +481,139 @@ jobs:
         working-directory: apps/viewer/src-tauri
         run: cargo check --locked --all-targets
 
+  # ─── Rust Check (Windows) ─────────────────────────────────────────────
+  # The ubuntu rust-check can't compile [target.'cfg(windows)'] deps (the
+  # `windows` crate family) — historically only the release build verified
+  # those, so bumps like windows 0.58→0.61 sat unverifiable (#1081). This
+  # job closes that gap, but only when Cargo files actually change: it's
+  # path-filtered so the windows runner cost isn't paid on every PR.
+  # Deliberately NOT in the ci-success needs list — it's usually skipped,
+  # and "skipped" vs "passed" handling there isn't worth the complexity.
+  rust-check-windows:
+    name: Rust Check (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Detect Cargo changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        with:
+          filters: |
+            cargo:
+              - 'apps/helper/src-tauri/**'
+              - 'apps/viewer/src-tauri/**'
+
+      - name: Setup Rust
+        if: steps.changes.outputs.cargo == 'true'
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+
+      - name: Rust cache
+        if: steps.changes.outputs.cargo == 'true'
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: |
+            apps/helper/src-tauri -> target
+            apps/viewer/src-tauri -> target
+
+      - name: Check helper (windows)
+        if: steps.changes.outputs.cargo == 'true'
+        working-directory: apps/helper/src-tauri
+        run: cargo check --locked --all-targets
+
+      - name: Check viewer (windows)
+        if: steps.changes.outputs.cargo == 'true'
+        working-directory: apps/viewer/src-tauri
+        run: cargo check --locked --all-targets
+
+  # ─── Integration Tests ────────────────────────────────────────────────
+  # The API integration suite against a real Postgres + Redis (the only
+  # place RLS, tenant gates, and permission resolution are exercised
+  # without mocks). BLOCKING on PRs and main — it lived inside the
+  # non-blocking smoke-test job until 2026-06, which let two breakages
+  # (#1042's RBAC gate, #1092's org-scope lockout) merge "green" and keep
+  # main red for 8 days. ~2-3 min: no Docker image builds, just the
+  # docker-compose.test.yml stack (postgres + redis pulls).
+  integration-test:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck]
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Start test-stack containers
+        run: |
+          docker compose -f docker-compose.test.yml up -d
+          timeout 60 bash -c 'until docker exec breeze-postgres-test pg_isready -U breeze_test -d breeze_test; do sleep 1; done'
+          timeout 60 bash -c 'until docker exec breeze-redis-test redis-cli ping | grep -q PONG; do sleep 1; done'
+
+      - name: Run integration tests
+        env:
+          # DATABASE_URL_APP is the unprivileged role the integration tests
+          # actually hit (set up by autoMigrate's ensureAppRole on first
+          # run); DATABASE_URL is the superuser used for seeding +
+          # verification reads. See apps/api/src/__tests__/integration/
+          # loadEnv.ts for the full contract.
+          DATABASE_URL: postgresql://breeze_test:breeze_test@localhost:5433/breeze_test
+          DATABASE_URL_APP: postgresql://breeze_app:breeze_test@localhost:5433/breeze_test
+          BREEZE_APP_DB_PASSWORD: breeze_test
+          POSTGRES_PASSWORD: breeze_test
+          REDIS_URL: redis://localhost:6380
+          JWT_SECRET: ci-smoke-k7x9Qm4pR2vL8nW5jT3yF6hB0cA1dE4gI7
+          APP_ENCRYPTION_KEY: ci-smoke-Xz9Lm3Kp7Wn2Qr5Tv8Yb0Hd4Fg6Jc1Ae3
+          MFA_ENCRYPTION_KEY: ci-smoke-Nm4Rp8Ws2Kv6Tq0Yh3Bd7Fg1Jc5Le9Ax2
+          NODE_ENV: test
+        run: pnpm --filter=@breeze/api test:integration
+
+      # The rls-coverage contract test inspects pg_catalog to verify every
+      # tenant-scoped table has policies covering SELECT/INSERT/UPDATE/DELETE
+      # via the right access helper. Runs against the same test DB AFTER
+      # the integration suite (which has already triggered autoMigrate).
+      # Has its own runner because vitest.integration.config.ts excludes it:
+      # the read-only catalog inspection must not be hooked to setup.ts,
+      # which TRUNCATEs core tables on beforeEach.
+      - name: Run RLS coverage contract test
+        env:
+          DATABASE_URL: postgresql://breeze_test:breeze_test@localhost:5433/breeze_test
+          DATABASE_URL_APP: postgresql://breeze_app:breeze_test@localhost:5433/breeze_test
+          BREEZE_APP_DB_PASSWORD: breeze_test
+          POSTGRES_PASSWORD: breeze_test
+          JWT_SECRET: ci-smoke-k7x9Qm4pR2vL8nW5jT3yF6hB0cA1dE4gI7
+          APP_ENCRYPTION_KEY: ci-smoke-Xz9Lm3Kp7Wn2Qr5Tv8Yb0Hd4Fg6Jc1Ae3
+          MFA_ENCRYPTION_KEY: ci-smoke-Nm4Rp8Ws2Kv6Tq0Yh3Bd7Fg1Jc5Le9Ax2
+          NODE_ENV: test
+        run: pnpm --filter=@breeze/api test:rls-coverage
+
+      - name: Show container logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.test.yml logs --tail=200 || true
+
+      - name: Teardown
+        if: always()
+        run: docker compose -f docker-compose.test.yml down -v || true
+
   # ─── Smoke Test ───────────────────────────────────────────────────────
   # Builds Docker images, starts the full stack, and verifies:
   #   1. DB + Redis connectivity (health/ready)
@@ -488,6 +621,9 @@ jobs:
   #   3. Authenticated API endpoints (exercises core DB tables)
   #   4. Web page loads (SSR rendering works)
   # Non-blocking on PRs (continue-on-error), required on main pushes.
+  # The API integration suite used to run here too — it now has its own
+  # BLOCKING integration-test job above; this job is purely the Docker
+  # image build + stack boot + endpoint smoke.
   smoke-test:
     name: Smoke Test
     runs-on: ubuntu-latest
@@ -690,87 +826,19 @@ jobs:
           fi
           echo "All page smoke tests passed."
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-        with:
-          version: ${{ env.PNPM_VERSION }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      # Integration tests need their own Postgres/Redis on :5433/:6380 — they
-      # run TRUNCATE CASCADE on beforeEach, so `assertTestDatabase` refuses to
-      # touch the production stack's `breeze` DB on :5432. Spin up the
-      # ephemeral test stack alongside the running production stack.
-      - name: Start test-stack containers for integration tests
-        run: |
-          docker compose -f docker-compose.test.yml up -d
-          timeout 60 bash -c 'until docker exec breeze-postgres-test pg_isready -U breeze_test -d breeze_test; do sleep 1; done'
-          timeout 60 bash -c 'until docker exec breeze-redis-test redis-cli ping | grep -q PONG; do sleep 1; done'
-
-      - name: Run integration tests
-        env:
-          # Point at the ephemeral test stack, not the running production
-          # stack on :5432. DATABASE_URL_APP is the unprivileged role the
-          # integration tests actually hit (set up by autoMigrate's
-          # ensureAppRole on first run); DATABASE_URL is the superuser used
-          # for seeding + verification reads. See apps/api/src/__tests__/
-          # integration/loadEnv.ts for the full contract.
-          DATABASE_URL: postgresql://breeze_test:breeze_test@localhost:5433/breeze_test
-          DATABASE_URL_APP: postgresql://breeze_app:breeze_test@localhost:5433/breeze_test
-          BREEZE_APP_DB_PASSWORD: breeze_test
-          POSTGRES_PASSWORD: breeze_test
-          REDIS_URL: redis://localhost:6380
-          JWT_SECRET: ci-smoke-k7x9Qm4pR2vL8nW5jT3yF6hB0cA1dE4gI7
-          APP_ENCRYPTION_KEY: ci-smoke-Xz9Lm3Kp7Wn2Qr5Tv8Yb0Hd4Fg6Jc1Ae3
-          MFA_ENCRYPTION_KEY: ci-smoke-Nm4Rp8Ws2Kv6Tq0Yh3Bd7Fg1Jc5Le9Ax2
-          NODE_ENV: test
-        run: pnpm --filter=@breeze/api test:integration
-
-      # The rls-coverage contract test inspects pg_catalog to verify every
-      # tenant-scoped table has policies covering SELECT/INSERT/UPDATE/DELETE
-      # via the right access helper. Runs against the same test DB AFTER
-      # the integration suite (which has already triggered autoMigrate).
-      # Has its own runner because vitest.integration.config.ts excludes it:
-      # the read-only catalog inspection must not be hooked to setup.ts,
-      # which TRUNCATEs core tables on beforeEach.
-      - name: Run RLS coverage contract test
-        env:
-          DATABASE_URL: postgresql://breeze_test:breeze_test@localhost:5433/breeze_test
-          DATABASE_URL_APP: postgresql://breeze_app:breeze_test@localhost:5433/breeze_test
-          BREEZE_APP_DB_PASSWORD: breeze_test
-          POSTGRES_PASSWORD: breeze_test
-          JWT_SECRET: ci-smoke-k7x9Qm4pR2vL8nW5jT3yF6hB0cA1dE4gI7
-          APP_ENCRYPTION_KEY: ci-smoke-Xz9Lm3Kp7Wn2Qr5Tv8Yb0Hd4Fg6Jc1Ae3
-          MFA_ENCRYPTION_KEY: ci-smoke-Nm4Rp8Ws2Kv6Tq0Yh3Bd7Fg1Jc5Le9Ax2
-          NODE_ENV: test
-        run: pnpm --filter=@breeze/api test:rls-coverage
-
       - name: Show container logs on failure
         if: failure()
-        run: |
-          echo "=== production stack logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.override.yml.ci logs --tail=200 || true
-          echo "=== test stack logs ==="
-          docker compose -f docker-compose.test.yml logs --tail=200 || true
+        run: docker compose -f docker-compose.yml -f docker-compose.override.yml.ci logs --tail=200 || true
 
       - name: Teardown
         if: always()
-        run: |
-          docker compose -f docker-compose.yml -f docker-compose.override.yml.ci down -v || true
-          docker compose -f docker-compose.test.yml down -v || true
+        run: docker compose -f docker-compose.yml -f docker-compose.override.yml.ci down -v || true
 
   # Summary job that depends on all other jobs for branch protection
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test-api, test-web, security-audit, build-api, build-web, build-agent, test-agent, smoke-test]
+    needs: [lint, typecheck, test-api, test-web, security-audit, build-api, build-web, build-agent, test-agent, integration-test, rust-check, smoke-test]
     if: always()
     steps:
       - name: Check all jobs passed
@@ -784,6 +852,8 @@ jobs:
           BUILD_WEB_RESULT: ${{ needs.build-web.result }}
           BUILD_AGENT_RESULT: ${{ needs.build-agent.result }}
           TEST_AGENT_RESULT: ${{ needs.test-agent.result }}
+          INTEGRATION_TEST_RESULT: ${{ needs.integration-test.result }}
+          RUST_CHECK_RESULT: ${{ needs.rust-check.result }}
           SMOKE_TEST_RESULT: ${{ needs.smoke-test.result }}
           IS_PR: ${{ github.event_name == 'pull_request' }}
         run: |
@@ -795,7 +865,9 @@ jobs:
              [[ "${BUILD_API_RESULT}" != "success" ]] || \
              [[ "${BUILD_WEB_RESULT}" != "success" ]] || \
              [[ "${BUILD_AGENT_RESULT}" != "success" ]] || \
-             [[ "${TEST_AGENT_RESULT}" != "success" ]]; then
+             [[ "${TEST_AGENT_RESULT}" != "success" ]] || \
+             [[ "${INTEGRATION_TEST_RESULT}" != "success" ]] || \
+             [[ "${RUST_CHECK_RESULT}" != "success" ]]; then
             echo "One or more required jobs failed"
             exit 1
           fi
@@ -805,3 +877,53 @@ jobs:
             exit 1
           fi
           echo "All required jobs passed!"
+
+  # ─── Main-red alerting ────────────────────────────────────────────────
+  # Main was red for 8 days in June 2026 and nobody noticed, partly
+  # because the dependabot merge storms cancel most main runs and partly
+  # from alert fatigue. This keeps exactly one open `ci-red` issue while
+  # main is red and auto-closes it when main goes green — red is loud,
+  # green is silent, and a perpetually-open issue means "act now".
+  # Cancelled runs are ignored (they say nothing about main's health).
+  main-red-alert:
+    name: Main Red Alert
+    runs-on: ubuntu-latest
+    needs: [ci-success]
+    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      issues: write
+    steps:
+      - name: Open, update, or close the ci-red tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RESULT: ${{ needs.ci-success.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          gh label create ci-red --repo "$GITHUB_REPOSITORY" \
+            --color B60205 --description "CI is failing on main" 2>/dev/null || true
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --label ci-red --state open \
+            --json number --jq '.[0].number // empty')
+          short_sha="${SHA:0:8}"
+          case "$RESULT" in
+            success)
+              if [ -n "$existing" ]; then
+                gh issue close "$existing" --repo "$GITHUB_REPOSITORY" \
+                  --comment "Main is green again as of \`$short_sha\`: $RUN_URL"
+              fi
+              ;;
+            failure)
+              if [ -n "$existing" ]; then
+                gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" \
+                  --body "Still red at \`$short_sha\`: $RUN_URL"
+              else
+                gh issue create --repo "$GITHUB_REPOSITORY" --label ci-red \
+                  --title "CI is red on main" \
+                  --body "$(printf 'CI failed on a main push at `%s`.\n\nRun: %s\n\nThis issue is managed by the main-red-alert job: it stays open while main is red and closes automatically on the next green main run.' "$short_sha" "$RUN_URL")"
+              fi
+              ;;
+            *)
+              echo "ci-success result is '$RESULT' (cancelled/skipped) — no signal about main health, doing nothing."
+              ;;
+          esac

--- a/.github/workflows/doc-verify.yml
+++ b/.github/workflows/doc-verify.yml
@@ -8,6 +8,9 @@ on:
       - 'apps/docs/src/content/docs/agents/**'
       - 'e2e-tests/doc-verify/**'
 
+permissions:
+  contents: read
+
 env:
   PNPM_VERSION: '10.33.4'
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,10 +17,10 @@ env:
   PNPM_VERSION: '10.33.4'
   GO_VERSION: '1.25.11'
 
+# Least-privilege default; the SARIF-uploading job opts into
+# security-events: write per-job below.
 permissions:
-  actions: read
   contents: read
-  security-events: write
 
 jobs:
   npm-audit:
@@ -93,6 +93,9 @@ jobs:
   trivy-fs-scan:
     name: Trivy Filesystem Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -164,3 +167,30 @@ jobs:
           severity: 'HIGH,CRITICAL'
           format: 'table'
           exit-code: '1'
+
+  # Lints the workflow files themselves. actionlint catches real workflow
+  # bugs (bad expressions, wrong action inputs, invalid syntax); shellcheck
+  # integration is disabled because the existing style nits in release.yml
+  # would make this job perma-red — red must mean "act now". zizmor audits
+  # for security smells (template injection, unpinned third-party actions,
+  # excessive permissions); pin policy + accepted findings live in
+  # .github/zizmor.yml.
+  workflow-lint:
+    name: Workflow Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install actionlint (pinned + checksum-verified)
+        run: |
+          curl -sSfL -o actionlint.tar.gz \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
+          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint.tar.gz" | sha256sum -c -
+          tar xzf actionlint.tar.gz actionlint
+
+      - name: Run actionlint
+        run: ./actionlint -shellcheck=
+
+      - name: Run zizmor
+        run: pipx run zizmor==1.25.2 --no-progress --config .github/zizmor.yml --min-severity medium .github/workflows/

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,16 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # Repo posture: first-party GitHub-owned actions may float on major
+        # version tags; everything else must be pinned to a commit SHA.
+        actions/*: ref-pin
+        github/*: ref-pin
+        "*": hash-pin
+  cache-poisoning:
+    # Accepted tradeoff (2026-06): the release workflow uses setup-node /
+    # rust-cache / go caches while producing signed artifacts. Disabling
+    # caches there would add tens of minutes per release. Revisit if the
+    # threat model changes (e.g. untrusted PRs ever gain cache write).
+    ignore:
+      - release.yml

--- a/apps/api/src/__tests__/integration/audit-logs-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/audit-logs-rls.integration.test.ts
@@ -44,6 +44,7 @@
  *      really runs on its own connection, not inside the caller's tx.
  */
 import './setup';
+import { randomUUID } from 'node:crypto';
 import { describe, it, expect, vi } from 'vitest';
 import { eq } from 'drizzle-orm';
 import { db, withDbAccessContext } from '../../db';
@@ -93,7 +94,7 @@ describe('audit_logs RLS — logSessionAudit (issue #437)', () => {
   it('logSessionAudit with no outer context writes the row on its own system-scope connection', async () => {
     const partner = await createPartner();
     const org = await createOrganization({ partnerId: partner.id });
-    const sessionId = '11111111-1111-1111-1111-111111111111';
+    const sessionId = randomUUID(); // per-run: audit_logs rows survive cleanup (append-only)
     const actorId = '22222222-2222-2222-2222-222222222222';
 
     await logSessionAudit(
@@ -160,7 +161,7 @@ describe('audit_logs RLS — logSessionAudit (issue #437)', () => {
     const partner = await createPartner();
     const orgA = await createOrganization({ partnerId: partner.id });
     const orgB = await createOrganization({ partnerId: partner.id });
-    const sessionId = '66666666-6666-6666-6666-666666666666';
+    const sessionId = randomUUID(); // per-run: audit_logs rows survive cleanup (append-only)
 
     await withDbAccessContext(
       {
@@ -204,8 +205,8 @@ describe('audit_logs RLS — logSessionAudit (issue #437)', () => {
     // (b) remains.
     const partner = await createPartner();
     const org = await createOrganization({ partnerId: partner.id });
-    const rollbackMarkerId = '88888888-8888-8888-8888-888888888888';
-    const auditSurvivorSessionId = '99999999-9999-9999-9999-999999999999';
+    const rollbackMarkerId = randomUUID(); // per-run: audit_logs rows survive cleanup (append-only)
+    const auditSurvivorSessionId = randomUUID();
 
     await expect(
       withDbAccessContext(

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -46,8 +46,10 @@ export default defineConfig({
     // Longer timeouts for database operations
     testTimeout: 30000,
     hookTimeout: 30000,
-    // Fail fast on first error for easier debugging
-    bail: 1,
+    // No `bail` here on purpose: the suite is ~90s, and bail:1 masks
+    // stacked breakages — in June 2026 it hid #1092's org-scope lockout
+    // behind #1042's RBAC 403 for a day because each CI run only ever
+    // surfaced the first failure. Always report every failure.
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Why

Follow-up to the June red-main postmortem (#1144/#1146), with one organizing principle: **nothing is red by default — red means act now.** Main was red for 8 days partly because chronic background red trained everyone to ignore it.

## What

**Blocking integration tests** — the API integration suite moves out of the non-blocking smoke-test job into its own `integration-test` job, required on PRs *and* main via `ci-success`. This is the gate that would have stopped #1042 and #1092 from merging. It boots only `docker-compose.test.yml` (no image builds) — ~2-3 min. The smoke job keeps the Docker build + endpoint smoke, still non-blocking on PRs. `rust-check` is promoted to required as well.

**`bail: 1` removed** from the integration config — it surfaced only the first failure per run, which hid #1092's lockout behind #1042's 403 for a day.

**Main-red alerting** — a `main-red-alert` job keeps exactly one open `ci-red` issue while main is red and auto-closes it on the next green main push. Cancelled runs (dependabot storms) are ignored. One loud, self-resolving signal instead of a wall of silently-cancelled runs.

**`rust-check-windows`** — compiles both Tauri apps on a windows runner, path-filtered to `src-tauri/**` changes, closing the `cfg(windows)` gap the ubuntu rust-check can't cover (the #1081 problem). Skipped (fast, green) on non-Cargo PRs.

**Workflow Lint job** (security workflow) — actionlint core checks + zizmor at medium severity, both verified green against this tree before gating. shellcheck integration is deliberately off (release.yml's 13 style nits would make it perma-red). `.github/zizmor.yml` encodes the pin policy (first-party actions float on tags, everything else hash-pinned) and the one accepted finding class (release build caches). zizmor's first sweep also scoped `security-events: write` per-job and added missing least-privilege `permissions:` blocks to three workflows.

**Dependabot staggering + coupling groups** — npm Monday, Go Tuesday, Actions Wednesday, Cargo Thursday (no more Monday merge storm), plus groups for deps that break when bumped solo: `mobile` (expo/react-native/metro), `aws-sdk` (gomod), `rustcrypto` (the sha2/hmac pair from #1082/#1083).

**Local-flake kill** — `audit-logs-rls.integration.test.ts` used hardcoded resourceIds against the append-only `audit_logs` table, so every second local run failed on accumulated rows (the "clear audit_logs between runs" papercut). Per-run UUIDs fix it; verified by running the suite twice against a dirty DB — 91/91 green both times.

## Deliberately deferred

A nightly Playwright e2e job is viable but the suite currently has a broken import (`test-helpers.ts` doesn't exist) and unverified seed data for the catalog specs — shipping it now would create a red-by-default job. Tracked as a follow-up.

## Verification

- `actionlint -shellcheck=` and `zizmor --min-severity medium` exit 0 across all workflows locally.
- Integration suite (no-bail config): 22 files / 91 tests green, twice, against a dirty DB.
- The new `integration-test`, `rust-check-windows` (skip path), and `workflow-lint` jobs all run on this very PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)