### PR TITLE
docs(pam): implementation plans for the Windows PAM MVP slice

### DIFF
--- a/docs/superpowers/plans/2026-06-09-pam-backend-control-plane.md
+++ b/docs/superpowers/plans/2026-06-09-pam-backend-control-plane.md
@@ -1,0 +1,103 @@
+# PAM Backend Control Plane — Implementation Plan
+
+**Issue:** LanternOps/breeze#1163
+**Blocks:** #1159 (Web PAM admin UI)
+**Design sources:** `internal/BE-17-privileged-access-management.md` (API Endpoints / Background Jobs / Event Emission); [Discussion #858](https://github.com/LanternOps/breeze/discussions/858) §2 (rule engine) + §7 Phase 1; [schema ruling](https://github.com/LanternOps/breeze/discussions/858#discussioncomment-17055625).
+**Status:** Draft, ready for pickup. Author: triage pass 2026-06-09.
+
+---
+
+## Goal
+
+Build the control plane between the merged data/agent layer and the UI: the `/api/v1/pam/*` admin REST surface, wire the orphaned decisioning function into ingest, add the elevation lifecycle jobs, and emit `elevation.*` events. After this lands, #1159 has real endpoints + a live feed to build against, and a technician can list/approve/deny/revoke elevations end-to-end via the API.
+
+## Current state (code-verified 2026-06-09)
+
+- ✅ Schema `elevation_requests` + `elevation_audit` complete — lifecycle timestamps (`requested_at/approved_at/expires_at/expired_at/revoked_at`), `approved_by_user_id`/`denied_by_user_id`/`revoked_by_user_id`, status enum (incl. `auto_approved`, `revoked`, `actuating`), audit event-type + actor enums all exist (`apps/api/src/db/schema/elevations.ts`).
+- ✅ Agent ETW ingest `POST /agents/:id/elevation-requests` (`routes/agents/elevationRequests.ts`) — inserts a `pending` row and stops.
+- ⚠️ `services/pamBridge.ts` `evaluatePamBridge()` — pure verdict function, **zero call sites**.
+- ✅ Admin actuate `POST /devices/:id/actuate-elevation` (`routes/devices/actuateElevation.ts`).
+- ❌ No `pam_rules` table. No `routes/pam.ts`. No `jobs/pamJobs.ts`. No `elevation.*` events.
+
+## Conventions (follow these existing patterns)
+
+- **Jobs:** model both reapers on `apps/api/src/jobs/approvalExpiryReaper.ts` (BullMQ Queue+Worker, `REAP_INTERVAL_MS`, `MAX_REAP_PER_RUN` CTE bound, `withSystemDbAccessContext`, audit per transition). Register in `apps/api/src/index.ts` next to the existing reaper.
+- **Events:** `import { publish } from '../services/eventBus'` → `publish('elevation.approved', orgId, payload, 'pam')`. Consumed by the WS at `/api/v1/events/ws` (`routes/eventWs.ts`) which `useEventStream.ts` already speaks.
+- **RLS:** every query through `withDbAccessContext` (request) / `withSystemDbAccessContext` (jobs). `elevation_requests` is Shape 1 (direct `org_id`); `pam_rules` will be Shape 1 too.
+- **Audit:** `writeAuditEvent` from `services/auditEvents`, plus an `elevation_audit` row per state transition (that table is the PAM-specific chain).
+- **Migrations:** `YYYY-MM-DD-<slug>.sql`, idempotent, no inner `BEGIN`/`COMMIT`; add `pam_rules` to `rls-coverage.integration.test.ts` allowlist in the same PR (CLAUDE.md §RLS).
+- **Route style:** mirror `routes/devices/actuateElevation.ts` (auth via `c.get('auth')`, site-scope via `canAccessDeviceSite`/permissions). Mount `pamRoutes` in `routes/index.ts`.
+
+---
+
+## Task 1 — `pam_rules` schema + migration
+
+The Rules tab manages **PAM-native** rules (distinct from `software_policies`, which the bridge already consults). New table.
+
+- **Schema** `apps/api/src/db/schema/pam.ts`: `pam_rules` with `id`, `org_id` (notNull, Shape-1 RLS pivot), `site_id`/`partner_id` nullable (scope inheritance device→site→org→partner), `name`, `enabled`, `priority` (int, ordering), match criteria (`match_signer`, `match_hash`, `match_path_glob`, `match_parent_image`, `match_user`, `match_ad_group`, `time_window` jsonb), `verdict` enum `pam_rule_verdict` = `auto_approve | auto_deny | require_approval | ignore`, `created_by_user_id`, timestamps. Add Drizzle relations + export from schema barrel.
+- **Migration** `apps/api/migrations/2026-06-DD-pam-rules.sql`: `CREATE TABLE IF NOT EXISTS`, enum via `DO $$`, `ENABLE ROW LEVEL SECURITY` + `FORCE`, policies using `breeze_has_org_access(org_id)` (mirror the `elevation_requests` policies from #905's migration).
+- **Allowlist:** add `pam_rules` to the auto-discovered direct-`org_id` set is automatic, but add to `rls-coverage.integration.test.ts` if the contract test flags it.
+- **Test:** RLS cross-tenant insert must fail with `new row violates row-level security policy` as `breeze_app`.
+
+## Task 2 — Wire `evaluatePamBridge` + `pam_rules` into ingest
+
+In `routes/agents/elevationRequests.ts`, after the device lookup and before the insert:
+
+1. Call `evaluatePamBridge({ deviceId, orgId, targetExecutablePath, hash, signer, ... })`.
+2. **Allowlist match** → insert with `status='auto_approved'`, `software_policy_match_id=verdict.policyId`; write `elevation_audit` (`event_type='auto_approved'`, `actor='policy'`); emit `elevation.auto_approved`. For `uac_intercept`, immediately queue the actuator (`actuateElevation` path) so the consent prompt is satisfied.
+3. **Blocklist match** → `status='denied'`; audit `denied`/`policy`; emit `elevation.denied`.
+4. **No software-policy match** → evaluate `pam_rules` (highest-priority enabled rule whose criteria match): `auto_approve`/`auto_deny`/`require_approval`/`ignore`. `require_approval` or audit-mode/no-rule → keep `status='pending'` and emit `elevation.requested` (this is what fans out to the mobile/web approval surface).
+5. Keep the existing rate-limit + body-cap guards. All DB work stays in the agent request's context (already RLS-scoped by `requireAgentRole`).
+
+> Keep the matcher logic in a small `services/pamRuleEngine.ts` (pure, unit-testable like `pamBridge.matchPoliciesAgainst`) so ingest stays thin and the same evaluator can be reused by the offline-cache sync.
+
+## Task 3 — Admin REST API `routes/pam.ts`
+
+Mount under `/api/v1/pam`. All handlers `withDbAccessContext` + site/permission scope.
+
+- `GET /elevation-requests` — filters: `status`, `flow_type`, `deviceId`, `siteId`, `from`/`to`, pagination. Joins device/site name for display. Powers **Requests + Audit** tabs.
+- `POST /elevation-requests/:id/respond` — body `{ decision: 'approve'|'deny', reason?, durationMinutes? }`. CAS on `status='pending'`; set `approved_by_user_id`/`denied_by_user_id`, `approved_at`, `expires_at = now + duration`; audit + emit `elevation.approved`/`elevation.denied`. On approve of a `uac_intercept` row, transition to `actuating` and queue the actuator.
+- `POST /elevation-requests/:id/revoke` — body `{ reason }`. Valid from `approved`/`auto_approved`/`actuating`. Set `revoked_at`/`revoked_by_user_id`/`revoked_reason`, `status='revoked'`; audit + emit `elevation.revoked`; for `tech_jit_admin`, enqueue the agent revoke command (group-flip undo — handler tracked in #1150 scope, no-op cleanly if absent).
+- `GET /active` — `status IN ('approved','auto_approved','actuating')` with non-expired `expires_at`, fleet-wide within tenancy. Powers **Overview**.
+- `GET/POST/PATCH/DELETE /rules` — `pam_rules` CRUD; priority reorder; validate criteria. Powers **Rules** tab.
+
+Return shapes are `runAction`-friendly (`{ success, ... }`) so the web layer's mutation wrapper surfaces outcomes (CLAUDE.md §runAction).
+
+## Task 4 — Lifecycle jobs `jobs/pamJobs.ts`
+
+Two reapers cloned from `approvalExpiryReaper.ts`:
+
+- `elevation-expiry-enforcer` (every **60s**): `status IN ('approved','auto_approved','actuating')` AND `expires_at < now()` → `status='expired'`, set `expired_at`; for `tech_jit_admin` enqueue the agent revoke command; audit `expired`/`system`; emit `elevation.expired`. CTE-bounded `MAX_PER_RUN`.
+- `stale-request-expirer` (every **5 min**): `status='pending'` AND `requested_at < now() - TTL` → `status='expired'`; audit + emit. TTL from config (default e.g. 15 min).
+
+Register both in `apps/api/src/index.ts` beside the approval reaper. Guard with `withSystemDbAccessContext`; `captureException` on failure.
+
+## Task 5 — Event emission audit pass
+
+Confirm every transition path (ingest auto-decision, respond, revoke, both jobs, actuator completion in `actuateElevation.ts`) emits the matching `elevation.*` event via `eventBus.publish`. Add the `elevation.activated` emit when the actuator reports success (Track 6 completion) if that hook exists; otherwise note it as a follow-up. These events are also the Brain context feed (#1160).
+
+## Task 6 — Tests + manual verification
+
+- Unit: `pamRuleEngine` matcher (table-driven, no DB), respond/revoke CAS guards (can't approve a non-pending row, can't revoke a denied row), filter query building.
+- Integration: RLS cross-tenant denial on `pam_rules` + cross-tenant `GET /elevation-requests` isolation.
+- Job: expiry-enforcer flips an expired approved row and emits once; stale-expirer respects TTL.
+- Manual: seed a `pending` row → `POST respond approve` → `GET active` shows it → wait/force expiry → `GET elevation-requests` shows `expired`; verify an `elevation.*` event lands on `/api/v1/events/ws`.
+
+---
+
+## Sequencing & estimate
+
+Task 1 → 2 → 3 in order (each depends on the prior); Tasks 4–5 can land in the same PR or a fast follow; Task 6 throughout (TDD). Effort: **L** (~1–1.5 wk single dev). Self-contained — no agent changes required to ship the API (the `tech_jit_admin` agent commands degrade to no-ops until #1150 lands), so this unblocks #1159 immediately.
+
+## Out of scope (tracked elsewhere)
+
+Agent `elevation_grant`/`elevation_revoke` group-flip handlers + dormant-admin (#1150); PAM dialog (#1152); Brain tool registration (#1160 — though this plan emits the events it consumes); the web UI itself (#1159).
+
+## Self-review checklist
+
+- [ ] Every new query is RLS-context-wrapped; `pam_rules` cross-tenant insert fails as `breeze_app`.
+- [ ] `pam_rules` added to `rls-coverage.integration.test.ts` in the same PR.
+- [ ] Migration idempotent + correctly date-ordered; never edits a shipped file.
+- [ ] State transitions are CAS (no lost-update between job and a concurrent respond).
+- [ ] One audit row + one event per transition; no double-emit.
+- [ ] Routes return `runAction`-compatible bodies.

--- a/docs/superpowers/plans/2026-06-09-pam-dialog-user-helper.md
+++ b/docs/superpowers/plans/2026-06-09-pam-dialog-user-helper.md
@@ -1,0 +1,94 @@
+# PAM Approval Dialog in `breeze-user-helper.exe` — Implementation Plan
+
+**Issue:** LanternOps/breeze#1152
+**Pairs with:** #959 (ETW subscriber — the trigger source), #1150 (account manager — runs on approve), #960 (actuator), #1163 (remote-approval alternative).
+**Design sources:** issue #1152; [Discussion #858 §5 step 2](https://github.com/LanternOps/breeze/discussions/858) (Breeze dialog on the user desktop while consent.exe idles); [Q2 ruling](https://github.com/LanternOps/breeze/discussions/858#discussioncomment-17033668) (broker stays in-agent).
+**Status:** Draft, ready for pickup. Author: triage pass 2026-06-09.
+
+---
+
+## Goal
+
+When the ETW subscriber detects a UAC prompt, render a branded native PAM dialog **on the user's interactive desktop** (via `breeze-user-helper.exe`) showing the executable, signer, and intent, with approve/deny. The SYSTEM broker drives it over the existing IPC channel and blocks on the result, which — combined with policy/remote-approval — decides whether to actuate (#1150 + #960).
+
+## EXISTS vs GREENFIELD
+
+- **EXISTS (cite-and-mirror):** IPC envelope + message-type pattern (`ipc/message.go`), broker→helper spawn + named-pipe channel (`sessionbroker/`), the request/response round-trip primitive `SendCommandAndWait` (`broker.go:980`), active-session detection (`detector_windows.go`), role/scope gating (`broker.go:209-217`), the helper's dispatch switch (`userhelper/client.go:358-396`), and the ETW detection hot path (`etwlua/etwlua.go:217`).
+- **GREENFIELD:** (1) the native Win32 dialog window — the helper has **no** windowing infra today (toast is PowerShell-shelled `notify_windows.go:13-38`; tray is a stub); (2) the wire from `etwlua` → broker → helper (the current explicit TODO seam); (3) the approval round-trip semantics.
+
+## Note on ETW event IDs
+
+The issue body cites events **15006/15007**; the shipped subscriber (#959, `etwlua/etwlua_windows.go:32-35`) actually keys on **4100/4101/4102** (`consent_prompted`/`granted`/`denied`). Use the real IDs from the existing code. Flag any discrepancy if 15006/15007 turn out to be needed for the "switch-to-secure-desktop precedes paint" latency win.
+
+## Conventions to mirror
+
+- **IPC types** (`ipc/message.go:9-72` const block; `NotifyRequest`/`NotifyResult:196-209` shape): add `TypePamRequestDialog = "pam_request_dialog"` + `TypePamDialogResult = "pam_dialog_result"`, with `PamRequestDialog{ExePath, Signer, Hash, SubjectUser, CommandLine, Reason, IntentSummary}` and `PamDialogResult{Approved bool, Reason string, DismissedByUser bool}`.
+- **Helper dispatch** (`userhelper/client.go:358`): add `case ipc.TypePamRequestDialog: safeGo("pam", func(){ c.handlePamDialog(env) })`.
+- **Round-trip** (`broker.go:980 SendCommandAndWait(session, id, cmdType, payload, timeout)`): the broker pushes the dialog to the active user session's helper and blocks for `PamDialogResult` (bounded timeout, e.g. consent.exe lifetime).
+- **Scope gating** (`broker.go:209-217`, `scopesForRole:1632-1651`, checks `:2141-2183`): add `ScopePam` const beside `ScopeAssist` (`ipc:121`) and `"pam"` to `userHelperScopes` — a user-facing modal on the interactive desktop belongs to the **user-token helper**, not the SYSTEM/desktop-capture role.
+
+---
+
+## Task 1 — IPC message types + structs
+
+- `ipc/message.go`: add the two `Type*` consts + the `PamRequestDialog`/`PamDialogResult` structs on the `NotifyRequest`/`NotifyResult` pattern. No HMAC/envelope changes (reuse `Envelope:102-109`).
+
+## Task 2 — Scope + role wiring
+
+- Add `ipc.ScopePam` const; append `"pam"` to `userHelperScopes` (`broker.go:213`); add a gate case alongside the `notify`/`tray` checks (`broker.go:2164+`); map it in `scopesForRole`. Confirm the user-token helper is the one spawned for the active console session (`SpawnUserHelperInSession`, `spawner_windows.go:169`).
+
+## Task 3 — Native dialog window (GREENFIELD)
+
+`userhelper/pam_dialog_windows.go` (`//go:build windows`):
+
+- The helper is GUI-subsystem (`spawner_windows.go:105-108`) so it can host a window, but there's no scaffolding. Two options:
+  - **MVP:** `MessageBoxW` with `MB_YESNO | MB_TOPMOST | MB_SYSTEMMODAL | MB_SETFOREGROUND`, title/body built from the `PamRequestDialog` fields. Minimal, ships fast, returns `IDYES`/`IDNO` → `PamDialogResult.Approved`. No reason-entry field.
+  - **Full:** `RegisterClassExW` + `CreateWindowEx` + message loop with branded layout (exe name, signer cert summary, requester-reason text field, AI intent summary placeholder for Phase 2), approve/deny buttons. Reuse SendInput primitives only from `pamactuator/wininput.go` if needed.
+- **Recommendation:** ship the `MessageBoxW` MVP first (unblocks the end-to-end flow), file a follow-up for the branded `CreateWindowEx` window. Note the tradeoff in the PR.
+- `pam_dialog_other.go` (`//go:build !windows`) stub returns `{Approved:false, DismissedByUser:true}`.
+- `handlePamDialog(env)` in `client.go`: decode `PamRequestDialog`, render, reply with `PamDialogResult` via the existing envelope-reply path.
+
+## Task 4 — Wire ETW → broker → helper (the TODO seam)
+
+In `etwlua/etwlua.go:217 handleEvent`, after the existing dedupe + `SendElevationRequest` POST:
+
+- Resolve the active user session (`detector_windows.go WTSGetActiveConsoleSessionId` / broker `FindCapableSession("pam", session)`).
+- Call broker `SendCommandAndWait(session, id, TypePamRequestDialog, payload, timeout)` and read `PamDialogResult`.
+- **Decision composition:** the dialog result is one input. Combine with policy (pamBridge/`pam_rules` verdict, if already evaluated agent-side or returned by the server) and the remote-approval path (#1163):
+  - end-user-allowed policy + dialog approve → proceed to actuate (#1150 promote → #960 type → demote).
+  - require-approval policy → dialog shows "awaiting tech approval"; the actual decision arrives via the server command path (#1163), not the local dialog.
+  - deny / dismiss → send Escape to consent.exe (the actuator's denial path) + audit.
+- This is the one new cross-package edge (`etwlua` → `sessionbroker`); keep it behind an interface so `etwlua` stays unit-testable without the broker.
+
+## Task 5 — Latency + dedupe
+
+- The dialog must appear within ~100ms of detection (consent.exe is idle awaiting input). Reuse the subscriber's existing `RateLimiter` dedupe so re-fired ETW events don't stack dialogs for one prompt.
+- Bound the `SendCommandAndWait` timeout to consent.exe's lifetime; on timeout, treat as deny + dismiss.
+
+## Task 6 — Tests
+
+- Cross-platform: IPC struct round-trip (marshal/unmarshal `PamRequestDialog`/`PamDialogResult`), the decision-composition logic (policy × dialog-result × remote-approval → action) as a pure table-driven test, scope-gating allows `pam` for user role + rejects it for others.
+- Windows-gated (VM/manual): real `MessageBoxW` render in an interactive session, broker→helper round-trip returns the click result, ETW-trigger → dialog appears.
+- Mock the broker edge in `etwlua` tests via the interface from Task 4.
+
+---
+
+## Sequencing & estimate
+
+Tasks 1→2→3→4 in order (each depends on the prior); 5–6 throughout. Effort: **M** (~1 wk incl. VM verification; less if MVP `MessageBoxW` only). Suggested build order from recon: IPC types → scope → `handlePamDialog` + dialog → the `etwlua`→broker wire (the seam). Pairs with #1150 to deliver the full local end-user elevation: detect → dialog → approve → promote → actuate → demote.
+
+## Risks / watch-items
+
+- **Native windowing is greenfield** — `MessageBoxW` MVP de-risks it; don't block the flow on the branded window.
+- **Secure-desktop vs user-desktop** — the Breeze dialog renders on the **user's** desktop (correct: that's where the user is looking); consent.exe sits on the secure desktop. Do not try to render the Breeze dialog on WINLOGON.
+- **CVE-2026-20824 / N-able deadlock** (§858 §5) — vet the dialog→actuate timing against the documented consent.exe hardening + N-able interaction before broad rollout.
+- **Two approval routes** — keep the local dialog (#1152) and remote mobile/web approval (#1163/#1159) cleanly separated; policy decides which applies.
+
+## Self-review checklist
+
+- [ ] Dialog renders on the user's interactive desktop via the user-token helper (`pam` scope), not SYSTEM/secure desktop.
+- [ ] Broker blocks on `PamDialogResult` with a bounded timeout; timeout = deny+dismiss.
+- [ ] Real ETW event IDs (4100/4101/4102) used, not the issue body's 15006/15007.
+- [ ] `etwlua`→broker edge behind an interface; `etwlua` unit tests don't need a live broker.
+- [ ] Dedupe prevents stacked dialogs per prompt.
+- [ ] Decision composition (policy × dialog × remote-approval) covered by a pure table test.

--- a/docs/superpowers/plans/2026-06-09-pam-dormant-admin-account.md
+++ b/docs/superpowers/plans/2026-06-09-pam-dormant-admin-account.md
@@ -1,0 +1,100 @@
+# PAM Dormant `~breeze_elev` Admin Account Lifecycle — Implementation Plan
+
+**Issue:** LanternOps/breeze#1150
+**Pairs with:** #960 (UAC actuator — consumes the credentials this produces), #1152 (dialog), #1163 (approval source).
+**Design sources:** issue #1150; [Discussion #858 §5](https://github.com/LanternOps/breeze/discussions/858) (credential-injection sequence, effort row "`~breeze_elev` dormant account"); [Q4 ruling](https://github.com/LanternOps/breeze/discussions/858#discussioncomment-17033668).
+**Status:** Draft, ready for pickup. Author: triage pass 2026-06-09.
+
+---
+
+## Goal
+
+Manage a dormant local Windows admin account (`~breeze_elev`) as the **just-in-time credential source** for approved UAC elevations: create it disabled/hidden on install, and on an approved elevation promote it to Administrators + rotate its password, hand the credential to the actuator (#960) **in-process**, then demote + re-randomize the moment consent.exe exits. Millisecond-window admin, fully audited.
+
+## Design correction (load-bearing — read first)
+
+The actuator (#960) today takes `Username`/`Password` off the **server** command payload (`actuateElevation.ts:198-209`, `handlers_actuate.go:39-44`), and its own header calls this "Track 6 — server-side credential generation." **That cannot be the real design:** a server cannot set a *local* Windows account's password — only the agent, via `NetUserSetInfo` on the box, can. So this work makes the **agent the credential authority**:
+
+- The dormant-account manager generates + rotates the password **locally** and invokes the actuator **in-process** with the just-minted credential. The secret never crosses the wire.
+- The server's `actuate_elevation` command degrades to a **"go" signal** — `{elevationRequestId, timeoutMs}` only; the `username`/`password` fields become deprecated/optional. Update `actuateElevation.ts` to stop requiring/sending them, and `handlers_actuate.go` to source creds from the account manager instead of the payload. (Coordinate this small server change in the same PR or a paired one.)
+
+This is the central architectural decision of #1150; everything below follows from it.
+
+## EXISTS vs GREENFIELD
+
+- **GREENFIELD:** local-account management is entirely new — grep of `agent/internal` for `NetUserAdd`/`NetLocalGroupAddMembers`/`NetUserSetInfo`/`netapi32` returns zero. You add the first `netapi32` syscall wrappers. No password generation/storage for this exists.
+- **REUSE:** config secret-at-rest (`config.go` `SetSecretAndPersist` → `secrets.yaml` `0600`, `atomicWriteFile:582`); handler registry (`handlers.go:11-17` + `init()`); build-tag split (`actuator_windows.go`/`_other.go`/shared); the agent already runs as SYSTEM so `netapi32` calls run **in-process** (no spawn needed — `sessionbroker` spawn helpers are not required here).
+
+## Conventions to mirror
+
+- **Package shape** = pamactuator's three-file split: `elevaccount.go` (shared interface + types, no build tag), `elevaccount_windows.go` (`//go:build windows`, netapi32), `elevaccount_other.go` (`//go:build !windows`, no-op returning a stable `unsupported_platform` reason).
+- **Handler registration:** add `CmdManageElevationAccount = "manage_elevation_account"` in `agent/internal/remote/tools/types.go` (beside `CmdActuateElevation:222`); new `handlers_elevation_account.go` with `func init(){ handlerRegistry[tools.CmdManageElevationAccount] = handle... }` (mirror `handlers_actuate.go:33-35`).
+- **Secret persistence:** rotated password (when it must survive a crash mid-window for cleanup) goes through `config.SetSecretAndPersist` → `secrets.yaml` only. **Never** `agent.yaml` (0644, Helper-readable).
+- **Tests:** package-level test with no build tag; `runtime.GOOS != "windows"` → `t.Skip`; cross-platform table tests for the state machine + payload parse, Windows-gated tests for netapi32 (mirror `actuator_test.go`).
+
+---
+
+## Task 1 — `elevaccount` package: netapi32 wrappers + account lifecycle
+
+New `agent/internal/elevaccount/`:
+
+- `elevaccount.go` — interface `AccountManager` with: `EnsureProvisioned() error` (idempotent create-if-absent), `Promote(ctx) (Credential, error)` (add to Administrators + rotate password, return cleartext cred), `Demote(ctx) error` (remove from Administrators + re-randomize). `Credential{Username, Password}` — password zeroed by caller after use.
+- `elevaccount_windows.go` (`//go:build windows`) — `syscall`/`golang.org/x/sys/windows` wrappers over `netapi32.dll`:
+  - `NetUserAdd` (USER_INFO_1, `UF_ACCOUNTDISABLE | UF_DONT_EXPIRE_PASSWD | UF_PASSWD_CANT_CHANGE`, hidden from logon) on `EnsureProvisioned`.
+  - `NetLocalGroupAddMembers` / `NetLocalGroupDelMembers` (Administrators by well-known SID `S-1-5-32-544`, resolve name via `LookupAccountSid` for locale-independence) on promote/demote.
+  - `NetUserSetInfo` USER_INFO_1003 for password rotation; `NetUserSetInfo` USER_INFO_1008 to set `UF_ACCOUNTDISABLE` off during the window.
+  - Password generator: 32+ char cryptographically-random (`crypto/rand`) meeting complexity policy.
+- `elevaccount_other.go` (`//go:build !windows`) — no-op stub.
+
+## Task 2 — Provision on install/startup
+
+- Call `EnsureProvisioned()` once on agent startup (Windows only), behind the same feature flag gating the actuator (`PAM_ACTUATOR_ENABLED`-equivalent agent config) so it's dormant until PAM is enabled for the org. Idempotent: existing account → no-op; verify it's disabled + not in Administrators at rest.
+- Account name `~breeze_elev` (leading `~` mirrors AutoElevate's `~0000AEAdmin`; keep it visually distinct + sortable-last). Hidden from the logon screen (registry `SpecialAccounts\UserList` = 0).
+
+## Task 3 — Promote/actuate/demote orchestration in the command handler
+
+`handlers_elevation_account.go` (or fold into the actuate handler):
+
+1. Receive the approved `actuate_elevation` "go" signal (`{elevationRequestId, timeoutMs}`).
+2. `Promote()` → cleartext cred in memory only.
+3. Invoke the **in-process** actuator (`pamactuator.New().Trigger(ctx, Request{ElevationRequestID, Username, Password, TimeoutMs})`) — no wire transit.
+4. On the consent.exe-exit ETW signal (event 4101/4102 from `etwlua`, or the actuator's `consent_did_not_close`/success result), `Demote()` + zero the password.
+5. **Guaranteed demotion:** a local monotonic-timer `defer` + a watchdog so a crash between promote and demote still demotes on next startup (`EnsureProvisioned` should detect "in Administrators at rest" as an anomaly → force-demote + audit). This is the core safety invariant.
+6. Audit every promote/demote with `elevationRequestId` correlation (ship via the agent's existing log/audit path → server `elevation_audit`).
+
+## Task 4 — Crash-safety + cleanup-on-startup
+
+- On startup, if `~breeze_elev` is found in Administrators (a leaked window from a crash), demote + re-randomize immediately and emit a `command_executed`/anomaly audit row. The rotated password persisted via `SetSecretAndPersist` is only needed if a future flow must re-authenticate during cleanup; prefer to **re-randomize blind** (we never need the old password to remove group membership) and avoid persisting the secret at all. Document the choice.
+
+## Task 5 — Server-side "go" signal change
+
+- `apps/api/src/routes/devices/actuateElevation.ts`: make `username`/`password` optional in `actuateElevationSchema` and stop populating them in the command payload (keep `elevationRequestId`, `timeoutMs`). Preserve the single-use CAS guard (`status approved → actuating`, the #960 review blocker). Update the route tests.
+- `handlers_actuate.go`: source the credential from `elevaccount.Promote()` rather than `parseActuatePayload`'s `username`/`password`.
+
+## Task 6 — Tests
+
+- Cross-platform: password-generator complexity/length, state-machine transitions (provisioned→promoted→demoted), crash-recovery detection logic (pure), payload parsing of the slimmed "go" signal.
+- Windows-gated (`runtime.GOOS=="windows"`, manual/VM): real `EnsureProvisioned`/`Promote`/`Demote` round-trip on a throwaway VM, verify group membership before/after via `net localgroup administrators`, verify account hidden from logon.
+- Negative: promote when already promoted (idempotent), demote when not a member (no-op), startup-cleanup of a forced-leaked membership.
+
+---
+
+## Sequencing & estimate
+
+Tasks 1→3 are the spine; 4 is the safety net; 5 is the paired server change; 6 throughout. Effort: **M** (~1 wk + VM verification). This is the piece that makes #960 actually usable in production (today the actuator has no real credential to type). Pairs with #1152 (dialog) for the full end-user flow but is independently testable.
+
+## Security notes
+
+- Account is disabled + non-member at rest; admin only during the millisecond actuation window.
+- Password is `crypto/rand`, rotated on every promote AND demote, never logged, zeroed after use, never sent over the wire.
+- Force-demote-on-startup closes the crash-leak window.
+- Every promote/demote audited with request correlation.
+
+## Self-review checklist
+
+- [ ] `~breeze_elev` disabled + not in Administrators at rest; verified by an at-rest assertion on startup.
+- [ ] Password never crosses the wire; actuator invoked in-process.
+- [ ] Demotion guaranteed by timer + defer + startup-cleanup (crash-safe).
+- [ ] Server payload no longer carries credentials; CAS single-use guard preserved.
+- [ ] netapi32 calls are locale-independent (well-known SID, not "Administrators" string).
+- [ ] Windows-only behind the PAM feature flag; clean no-op on other platforms.

--- a/docs/superpowers/plans/2026-06-09-pam-web-admin-ui.md
+++ b/docs/superpowers/plans/2026-06-09-pam-web-admin-ui.md
@@ -1,0 +1,89 @@
+# PAM Web Admin UI — Implementation Plan
+
+**Issue:** LanternOps/breeze#1159
+**Hard dependency:** #1163 (PAM backend control plane) — this UI calls `/api/v1/pam/*`, which #1163 creates. **Do not start until #1163 is merged.**
+**Reference scaffold:** DNS Security page (PR #847) — `apps/web/src/components/dnsSecurity/`, `apps/web/src/pages/dns-security.astro`.
+**Design sources:** issue #1159 body; `internal/BE-17-privileged-access-management.md` (Phase 4 UX); [Discussion #858](https://github.com/LanternOps/breeze/discussions/858) §2 + §7 Phase 1.
+**Status:** Draft, ready for pickup once #1163 lands. Author: triage pass 2026-06-09.
+
+---
+
+## Goal
+
+A `/pam` admin page with four tabs — **Overview** (active elevations, recent decisions), **Requests** (pending + decided queue with approve/deny/revoke), **Rules** (`pam_rules` CRUD), **Audit** (filterable history + export). Live-updating via the existing event stream. Mirrors the DNS Security 4-tab pattern; adds two things that page lacks but PAM requires: **role-gating** (privileged surface) and **`data-testid` coverage** (e2e).
+
+## Endpoints consumed (all from #1163)
+
+`GET /api/v1/pam/elevation-requests` · `POST .../:id/respond` · `POST .../:id/revoke` · `GET .../active` · `GET/POST/PATCH/DELETE .../rules`. Live feed: `elevation.*` events on `/api/v1/events/ws`.
+
+## Conventions (grounded in the reference page)
+
+- **Astro shell:** `apps/web/src/pages/pam.astro` = `<DashboardLayout title="PAM"><PamPage client:load /></DashboardLayout>` (mirror `dns-security.astro:6-7`). Auth/session gating is inherited from the layout (`AuthOverlay`/`AccountInactiveGuard`/`AdminSessionManager`).
+- **Tab state via `window.location.hash`** (CLAUDE.md URL-state rule): copy `readTabFromHash()` / `switchTab` (`window.location.hash = tab; setActiveTab(tab)`) / `hashchange` listener from `DnsSecurityPage.tsx:10-32`. `VALID_TABS = ['overview','requests','rules','audit']`.
+- **Per-tab data:** `fetchWithAuth` from `../../stores/auth` (no react-query, no service client — match `DnsSecurityPoliciesTab.tsx:3,46`). `useState` data/loading/error + `useCallback(signal)` fetcher + `useEffect` with `AbortController`. Unwrap `body.data ?? body`. 401 → `navigateTo('/login', { replace: true })`.
+- **Mutations via `runAction`** from `../../lib/runAction` (match `AddDnsPolicyModal.tsx:4,100-115`): `runAction({ request, errorFallback, successMessage, onUnauthorized })`. Catch `ActionError` 401 silently; non-401 already toasted. This satisfies the `no-silent-mutations` guard (CLAUDE.md §runAction).
+- **Modals:** `Dialog` from `../shared/Dialog`, `useId()` for field ids (match `AddDnsPolicyModal.tsx:2,31`). On success: `onSaved()` (parent refetch) then `onClose()`.
+- **Loading/error/empty:** spinner / `role="alert"` red banner / dashed-border placeholder, as in `DnsSecurityPoliciesTab.tsx:139-157`.
+
+---
+
+## Task 1 — Page shell + sidebar + tab routing
+
+- `apps/web/src/pages/pam.astro` and `apps/web/src/components/pam/PamPage.tsx` (hash tabs, `TabButton` with `role="tab"`/`aria-selected` from `DnsSecurityPage.tsx:71-98`).
+- Sidebar: add to `apps/web/src/components/layout/Sidebar.tsx` `navSections` **`'security'` section (~L124, next to DNS Security)**: `{ name: 'PAM', href: '/pam', icon: KeyRound }` (lucide-react import). `NavItem` shape is `{ name, href, icon }` — no role field on the entry itself (gating is Task 6).
+- Add `data-testid="pam-tab-{overview|requests|rules|audit}"` to each tab button (see Task 7).
+
+## Task 2 — Overview tab
+
+- `PamOverviewTab.tsx`: `GET /api/v1/pam/active` → table of active elevations (device, user, exe, flow_type, granted-by, expires-in countdown). Plus a recent-decisions strip (`GET elevation-requests?limit=10&status=approved,denied,auto_approved`). StatCards (active count, pending count, auto-elevate hit rate) — mirror `DnsSecurityOverviewTab.tsx` skeleton card pattern.
+- Live updates: subscribe via `useEventStream` (Task 5) to refetch on `elevation.activated/expired/revoked`.
+
+## Task 3 — Requests tab (the core operator surface)
+
+- `PamRequestsTab.tsx`: `GET elevation-requests` with filter controls (status, flow_type, device, date range). Paginated table; each row shows the request detail (exe path, signer, hash, parent process, requester reason, policy/rule match).
+- Row actions gated by role (Task 6): **Approve** (opens `RespondModal` → duration + optional reason → `POST :id/respond {decision:'approve'}`), **Deny** (`RespondModal` deny → reason), **Revoke** (for active rows → `POST :id/revoke {reason}`). All via `runAction`; on success refetch.
+- CAS-aware UX: a 409 from respond/revoke (row already transitioned) surfaces a friendly "already actioned — refreshing" toast and refetches, rather than an error.
+
+## Task 4 — Rules + Audit tabs
+
+- `PamRulesTab.tsx`: `GET .../rules` table ordered by priority; **Add/Edit Rule** modal (`PamRuleModal.tsx`) — name, criteria (signer/hash/path-glob/parent/user/AD-group/time-window), verdict (`auto_approve|auto_deny|require_approval|ignore`), scope (device/site/org/partner), enabled toggle. Priority reorder (drag handle like `OrganizationsPage.tsx:496` or up/down buttons). Create/update/delete via `runAction`.
+- `PamAuditTab.tsx`: `GET elevation-requests` (audit projection / or a dedicated audit endpoint if #1163 exposes one) with rich filters; **Export** button (CSV download of the filtered set). Read-only.
+
+## Task 5 — Live updates via `useEventStream`
+
+- The reference DNS page does **not** use live updates — this is net-new. Use the existing hook `apps/web/src/hooks/useEventStream.ts` (already consumed by `DevicesPage.tsx`/`DeviceDetailPage.tsx`; connects to `/api/v1/events/ws`). Subscribe in `PamPage` (or per-tab) and refetch the active/requests queries on `elevation.requested/approved/denied/expired/revoked`. Debounce bursty refetches.
+
+## Task 6 — Role-gating (PAM is privileged — reference page has none)
+
+- The DNS page has **no** role/permission gate; PAM must not be that permissive. Read the current user from `useAuthStore` (`apps/web/src/stores/auth.ts`) and gate **mutating actions** (approve/deny/revoke, rule CRUD) behind the PAM-manage permission/role; read-only viewers see the queues but disabled actions.
+- This is **defense-in-depth only** — the real enforcement is server-side in #1163, which mirrors `actuateElevation.ts:88-90`: `requireScope('organization','partner','system')` + `requirePermission(...)` + `requireMfa()`. Cross-ref: confirm #1163 introduces a `PERMISSIONS.PAM_MANAGE` (or reuses an existing privileged scope) — if it reuses `DEVICES_EXECUTE`, gate the web actions on the same. Note this dependency in the #1163 PR if the permission doesn't exist yet.
+
+## Task 7 — `data-testid` coverage + e2e spec
+
+- The reference page ships **zero** testids (relies on ARIA). CLAUDE.md requires e2e to query by `data-testid` only — so **add the convention here**: `data-testid="pam-tab-requests"`, `pam-request-row-{id}`, `pam-approve-btn-{id}`, `pam-deny-btn-{id}`, `pam-revoke-btn-{id}`, `pam-rule-row-{id}`, `pam-add-rule-btn`, `pam-active-row-{id}` (mirror the `org-row-${id}` style at `OrganizationsPage.tsx:479`).
+- Add a Playwright spec `e2e-tests/tests/*.spec.ts` (or a YAML test under `e2e-tests/tests/` per the runner) covering: load page → switch tabs → approve a seeded pending request → it leaves the Requests queue and appears in Overview/active. Page Object under `e2e-tests/pages/`.
+
+## Task 8 — Component tests
+
+- Vitest + jsdom per tab: loading/error/empty render; filter state; `runAction` success path refetches; 401 redirects; role-gate hides actions for non-privileged user. Mock `fetchWithAuth`. Place `*.test.tsx` alongside components (match the `dnsSecurity/*.test.tsx` set).
+
+---
+
+## Sequencing & estimate
+
+Task 1 first (shell unblocks all tabs). Tasks 2–4 parallelizable across tabs. Tasks 5–7 layer on. Effort: **L** (~1–1.5 wk). Ships the **Phase 1 demoable slice** together with #1163: a technician can watch a UAC-intercept request arrive, approve it from the web, and see it actuate — zero Windows-broker changes required (the agent already ingests via #959; #960 actuates).
+
+## Risks / watch-items
+
+- **Blocked on #1163** — every tab 404s without the API. Verify #1163 is merged and the endpoint shapes match before starting; if #1163's response envelopes differ from `body.data ?? body`, adjust the unwrap.
+- **Permission model** — if #1163 didn't add a PAM-specific permission, Task 6 has nothing precise to gate on; resolve in the #1163 PR.
+- **Astro island hydration** — `client:load` is required (forms need event handlers attached); don't use `client:visible` for the action buttons.
+
+## Self-review checklist
+
+- [ ] All mutations go through `runAction` (no silent mutations; `no-silent-mutations` test passes / allowlist untouched).
+- [ ] Tab state in `window.location.hash`, not query params (CLAUDE.md).
+- [ ] Mutating actions role-gated client-side; server enforces via #1163 guards.
+- [ ] `data-testid` on every interactive element + a Playwright spec exists.
+- [ ] 401 path redirects to `/login`; 409 (CAS race) refetches gracefully.
+- [ ] Live `elevation.*` events refresh the Overview/Requests views.


### PR DESCRIPTION
## Summary

Adds four grounded implementation plans for the PAM (Privileged Access Management) work tracked on [project board #3](https://github.com/orgs/LanternOps/projects/3), covering the complete Windows end-to-end elevation flow. These came out of a triage pass that mapped the merged PAM work (#905/#906/#959/#960/#907) against the board and found the remaining tracks had only design-level coverage in Discussion #858 — no per-track implementation plans.

Each plan is grounded in real `file:line` patterns (via code-recon of the actual agent/API/web source) and includes a self-review checklist.

## Plans

| Plan | Issue | Effort | Notable finding |
|---|---|---|---|
| `pam-backend-control-plane` | #1163 | L | The admin REST API + decisioning wiring + lifecycle jobs + `elevation.*` events that gate the UI. Surfaced that the Rules tab needs a **new `pam_rules` table** (`pamBridge` consults `software_policies`, which is distinct). |
| `pam-web-admin-ui` | #1159 | L | `/pam` 4-tab page mirroring the DNS Security scaffold (#847). Adds **role-gating + `data-testid` coverage** the reference page lacks. Blocked by #1163. |
| `pam-dormant-admin-account` | #1150 | M | `~breeze_elev` lifecycle. Establishes the **agent as credential authority** — a server can't set a local account's password — deprecating #960's server-sent creds to a `{elevationRequestId, timeoutMs}` "go" signal. |
| `pam-dialog-user-helper` | #1152 | M | Native approval dialog in `breeze-user-helper.exe` driven over IPC from the ETW subscriber (#959). Uses the real ETW IDs (4100/4101/4102, not the issue body's 15006/15007); recommends a `MessageBoxW` MVP. |

## Build order

**#1163 → #1159** (Phase 1, no Windows-broker changes — techs approve from the web) in parallel with **#1150 + #1152** (agent end-to-end: detect → dialog → promote → actuate → demote). Together this is the Windows MVP from Discussion #858 §7 Phases 1-2.

## Scope

Docs only — four new files under `docs/superpowers/plans/`, 386 insertions, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)