### PR TITLE
fix(api): unsuspend only restores suspension-disabled users (#917 L-5)

### DIFF
--- a/apps/api/migrations/2026-06-09-users-disabled-reason.sql
+++ b/apps/api/migrations/2026-06-09-users-disabled-reason.sql
@@ -1,0 +1,21 @@
+-- Add a marker recording WHY a user was disabled, so partner-unsuspend only
+-- re-enables users the suspension actually disabled — not users disabled for
+-- compromise, off-boarding, or a manual admin action. Before this, unsuspend
+-- did `UPDATE users SET status='active' WHERE partner_id=? AND status='disabled'`
+-- and indiscriminately re-enabled every disabled user. See issue #917 (L-5).
+--
+-- Nullable text (NULL = "disabled for some non-suspension reason"). Adding a
+-- column to the already-RLS-forced `users` table needs no policy change.
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS disabled_reason text;
+
+-- Backfill: users currently disabled under a still-suspended partner were
+-- disabled by that suspension, so tag them — otherwise a post-deploy unsuspend
+-- (which now filters on this marker) would silently stop restoring them.
+-- Idempotent: only touches NULL rows, so re-applying is a no-op. Users disabled
+-- under a non-suspended partner keep NULL and are never swept up by unsuspend.
+UPDATE users u
+SET disabled_reason = 'partner_suspended'
+WHERE u.status = 'disabled'
+  AND u.disabled_reason IS NULL
+  AND u.partner_id IN (SELECT p.id FROM partners p WHERE p.status = 'suspended');

--- a/apps/api/migrations/2026-06-09-users-disabled-reason.sql
+++ b/apps/api/migrations/2026-06-09-users-disabled-reason.sql
@@ -14,6 +14,15 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS disabled_reason text;
 -- (which now filters on this marker) would silently stop restoring them.
 -- Idempotent: only touches NULL rows, so re-applying is a no-op. Users disabled
 -- under a non-suspended partner keep NULL and are never swept up by unsuspend.
+--
+-- Known limitation: `partners.status='suspended'` is also set by the non-abuse
+-- partner-status path (orgs.ts), which does NOT disable users. So a user
+-- disabled for another reason under such a partner would be over-tagged here.
+-- Blast radius is tiny (one-time, only already-disabled users under already-
+-- suspended partners, and only matters if that partner is later abuse-
+-- unsuspended) and never worse than the pre-fix behavior, which re-enabled all
+-- disabled users regardless. Going forward, only suspend-for-abuse stamps the
+-- marker, so new suspensions are scoped exactly.
 UPDATE users u
 SET disabled_reason = 'partner_suspended'
 WHERE u.status = 'disabled'

--- a/apps/api/src/__tests__/integration/partnerUnsuspendScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/partnerUnsuspendScope.integration.test.ts
@@ -35,14 +35,26 @@ function readUser(id: string) {
   });
 }
 
+function makePlatformAdmin(id: string) {
+  return withSystemDbAccessContext(() =>
+    db.update(users).set({ isPlatformAdmin: true }).where(eq(users.id, id)),
+  );
+}
+
 describe('partner suspend/unsuspend user scoping (#917 L-5)', () => {
-  it('disables active users with the suspension marker and leaves other disabled users untouched', async () => {
+  it('disables only active users (with the marker) and leaves disabled, invited, and platform-admin users untouched', async () => {
     const partner = await createPartner({ status: 'active' });
     const stamp = Date.now();
     const active1 = await createUser({ partnerId: partner.id, status: 'active', email: `l5-active1-${stamp}@example.com` });
     const active2 = await createUser({ partnerId: partner.id, status: 'active', email: `l5-active2-${stamp}@example.com` });
     // Disabled for some other reason (compromise / off-boarding) → reason NULL.
     const preDisabled = await createUser({ partnerId: partner.id, status: 'disabled', email: `l5-pre-${stamp}@example.com` });
+    // An unaccepted invite must NOT be disabled (and so never promoted to active
+    // by a later unsuspend).
+    const invited = await createUser({ partnerId: partner.id, status: 'invited', email: `l5-inv-${stamp}@example.com` });
+    // A platform admin that happens to be a member must never be disabled.
+    const admin = await createUser({ partnerId: partner.id, status: 'active', email: `l5-admin-${stamp}@example.com` });
+    await makePlatformAdmin(admin.id);
 
     const disabled = await withSystemDbAccessContext(() =>
       db.transaction((tx) => disablePartnerUsersForSuspension(tx, partner.id)),
@@ -53,6 +65,24 @@ describe('partner suspend/unsuspend user scoping (#917 L-5)', () => {
     expect(await readUser(active2.id)).toEqual({ status: 'disabled', disabledReason: 'partner_suspended' });
     // The pre-disabled user is NOT re-stamped — its reason stays NULL.
     expect(await readUser(preDisabled.id)).toEqual({ status: 'disabled', disabledReason: null });
+    // Invited and platform-admin users are left exactly as they were.
+    expect(await readUser(invited.id)).toEqual({ status: 'invited', disabledReason: null });
+    expect(await readUser(admin.id)).toEqual({ status: 'active', disabledReason: null });
+  });
+
+  it('an invited user stays invited across a full suspend/unsuspend cycle (never promoted to active)', async () => {
+    const partner = await createPartner({ status: 'active' });
+    const stamp = Date.now();
+    const invited = await createUser({ partnerId: partner.id, status: 'invited', email: `l5-inv2-${stamp}@example.com` });
+
+    await withSystemDbAccessContext(() =>
+      db.transaction((tx) => disablePartnerUsersForSuspension(tx, partner.id)),
+    );
+    await withSystemDbAccessContext(() =>
+      db.transaction((tx) => reEnableSuspensionDisabledUsers(tx, partner.id)),
+    );
+
+    expect(await readUser(invited.id)).toEqual({ status: 'invited', disabledReason: null });
   });
 
   it('unsuspend re-enables only suspension-disabled users, leaving the rest disabled', async () => {

--- a/apps/api/src/__tests__/integration/partnerUnsuspendScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/partnerUnsuspendScope.integration.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Partner suspend/unsuspend user-scoping (#917 L-5)
+ *
+ * Before the fix, unsuspend did `UPDATE users SET status='active' WHERE
+ * partner_id=? AND status='disabled'` and re-enabled EVERY disabled user under
+ * the partner — including users disabled for compromise / off-boarding. These
+ * tests run the real `disablePartnerUsersForSuspension` /
+ * `reEnableSuspensionDisabledUsers` queries against Postgres to prove unsuspend
+ * only restores users the suspension itself disabled (those carrying the
+ * `disabled_reason='partner_suspended'` marker).
+ *
+ * Prerequisites: docker compose -f docker-compose.test.yml up -d
+ * Run: pnpm test:integration -- src/__tests__/integration/partnerUnsuspendScope.integration.test.ts
+ */
+import './setup';
+
+import { describe, it, expect } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { users } from '../../db/schema';
+import {
+  disablePartnerUsersForSuspension,
+  reEnableSuspensionDisabledUsers,
+} from '../../routes/admin/abuse';
+import { createPartner, createUser } from './db-utils';
+
+function readUser(id: string) {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db
+      .select({ status: users.status, disabledReason: users.disabledReason })
+      .from(users)
+      .where(eq(users.id, id))
+      .limit(1);
+    return row;
+  });
+}
+
+describe('partner suspend/unsuspend user scoping (#917 L-5)', () => {
+  it('disables active users with the suspension marker and leaves other disabled users untouched', async () => {
+    const partner = await createPartner({ status: 'active' });
+    const stamp = Date.now();
+    const active1 = await createUser({ partnerId: partner.id, status: 'active', email: `l5-active1-${stamp}@example.com` });
+    const active2 = await createUser({ partnerId: partner.id, status: 'active', email: `l5-active2-${stamp}@example.com` });
+    // Disabled for some other reason (compromise / off-boarding) → reason NULL.
+    const preDisabled = await createUser({ partnerId: partner.id, status: 'disabled', email: `l5-pre-${stamp}@example.com` });
+
+    const disabled = await withSystemDbAccessContext(() =>
+      db.transaction((tx) => disablePartnerUsersForSuspension(tx, partner.id)),
+    );
+
+    expect(disabled.map((r) => r.id).sort()).toEqual([active1.id, active2.id].sort());
+    expect(await readUser(active1.id)).toEqual({ status: 'disabled', disabledReason: 'partner_suspended' });
+    expect(await readUser(active2.id)).toEqual({ status: 'disabled', disabledReason: 'partner_suspended' });
+    // The pre-disabled user is NOT re-stamped — its reason stays NULL.
+    expect(await readUser(preDisabled.id)).toEqual({ status: 'disabled', disabledReason: null });
+  });
+
+  it('unsuspend re-enables only suspension-disabled users, leaving the rest disabled', async () => {
+    const partner = await createPartner({ status: 'active' });
+    const stamp = Date.now();
+    const active1 = await createUser({ partnerId: partner.id, status: 'active', email: `l5b-active1-${stamp}@example.com` });
+    const active2 = await createUser({ partnerId: partner.id, status: 'active', email: `l5b-active2-${stamp}@example.com` });
+    const preDisabled = await createUser({ partnerId: partner.id, status: 'disabled', email: `l5b-pre-${stamp}@example.com` });
+
+    await withSystemDbAccessContext(() =>
+      db.transaction((tx) => disablePartnerUsersForSuspension(tx, partner.id)),
+    );
+    const reEnabled = await withSystemDbAccessContext(() =>
+      db.transaction((tx) => reEnableSuspensionDisabledUsers(tx, partner.id)),
+    );
+
+    expect(reEnabled.map((r) => r.id).sort()).toEqual([active1.id, active2.id].sort());
+    expect(await readUser(active1.id)).toEqual({ status: 'active', disabledReason: null });
+    expect(await readUser(active2.id)).toEqual({ status: 'active', disabledReason: null });
+    // The user disabled for another reason is left disabled — the bug #917 L-5 fixes.
+    expect(await readUser(preDisabled.id)).toEqual({ status: 'disabled', disabledReason: null });
+  });
+});

--- a/apps/api/src/db/schema/users.ts
+++ b/apps/api/src/db/schema/users.ts
@@ -25,6 +25,11 @@ export const users = pgTable('users', {
   phoneVerified: boolean('phone_verified').notNull().default(false),
   mfaMethod: mfaMethodEnum('mfa_method'),
   status: userStatusEnum('status').notNull().default('invited'),
+  // Why the user is disabled. 'partner_suspended' is set by partner suspension
+  // so unsuspend re-enables exactly those users; NULL means disabled for some
+  // other reason (compromise, off-boarding, manual admin action) and unsuspend
+  // must leave them alone. See #917 (L-5).
+  disabledReason: text('disabled_reason'),
   avatarUrl: text('avatar_url'),
   lastLoginAt: timestamp('last_login_at'),
   passwordChangedAt: timestamp('password_changed_at'),

--- a/apps/api/src/routes/admin/abuse.ts
+++ b/apps/api/src/routes/admin/abuse.ts
@@ -33,9 +33,14 @@ const SUSPENSION_DISABLED_REASON = 'partner_suspended';
 type Tx = Parameters<Parameters<Database['transaction']>[0]>[0];
 
 /**
- * Disable every non-platform-admin user under a partner as part of suspension,
- * stamping the suspension marker. Users already disabled (for other reasons) are
- * left untouched — not re-stamped — so a later unsuspend won't resurrect them.
+ * Disable the currently-active non-platform-admin users under a partner as part
+ * of suspension, stamping the suspension marker so unsuspend restores exactly
+ * these (back to 'active'). We deliberately only touch `status='active'` users:
+ *  - already-`disabled` users keep their existing reason (e.g. compromise), so
+ *    unsuspend won't resurrect them; and
+ *  - `invited` users are left invited rather than disabled — the partner-level
+ *    suspension gate already blocks them, and stamping them would make unsuspend
+ *    silently promote an unaccepted invite into a full 'active' account.
  * Returns the ids actually disabled by this call.
  */
 export function disablePartnerUsersForSuspension(tx: Tx, partnerId: string) {
@@ -46,7 +51,7 @@ export function disablePartnerUsersForSuspension(tx: Tx, partnerId: string) {
       and(
         eq(users.partnerId, partnerId),
         eq(users.isPlatformAdmin, false),
-        ne(users.status, 'disabled'),
+        eq(users.status, 'active'),
       ),
     )
     .returning({ id: users.id });

--- a/apps/api/src/routes/admin/abuse.ts
+++ b/apps/api/src/routes/admin/abuse.ts
@@ -20,8 +20,55 @@ import { terminateUserRemoteSessions, TEARDOWN_FAILED } from '../../services/rem
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
 import { captureException } from '../../services/sentry';
 import { requireMfa } from '../../middleware/auth';
+import type { Database } from '../../db';
 
 export const abuseRoutes = new Hono();
+
+// The `users.disabled_reason` marker written by partner suspension. Unsuspend
+// re-enables exactly the users carrying it, leaving users disabled for any other
+// reason (compromise, off-boarding, manual admin action → NULL) untouched.
+// See #917 (L-5).
+const SUSPENSION_DISABLED_REASON = 'partner_suspended';
+
+type Tx = Parameters<Parameters<Database['transaction']>[0]>[0];
+
+/**
+ * Disable every non-platform-admin user under a partner as part of suspension,
+ * stamping the suspension marker. Users already disabled (for other reasons) are
+ * left untouched — not re-stamped — so a later unsuspend won't resurrect them.
+ * Returns the ids actually disabled by this call.
+ */
+export function disablePartnerUsersForSuspension(tx: Tx, partnerId: string) {
+  return tx
+    .update(users)
+    .set({ status: 'disabled', disabledReason: SUSPENSION_DISABLED_REASON, updatedAt: new Date() })
+    .where(
+      and(
+        eq(users.partnerId, partnerId),
+        eq(users.isPlatformAdmin, false),
+        ne(users.status, 'disabled'),
+      ),
+    )
+    .returning({ id: users.id });
+}
+
+/**
+ * Re-enable only the users that THIS partner's suspension disabled (marker set),
+ * clearing the marker. Users disabled for any other reason stay disabled.
+ */
+export function reEnableSuspensionDisabledUsers(tx: Tx, partnerId: string) {
+  return tx
+    .update(users)
+    .set({ status: 'active', disabledReason: null, updatedAt: new Date() })
+    .where(
+      and(
+        eq(users.partnerId, partnerId),
+        eq(users.status, 'disabled'),
+        eq(users.disabledReason, SUSPENSION_DISABLED_REASON),
+      ),
+    )
+    .returning({ id: users.id });
+}
 
 // confirmEmail must match the caller's account email on suspend — same
 // anti-typo gate as POST /admin/tenant-erasure. Suspend queues
@@ -126,17 +173,12 @@ abuseRoutes.post(
         }
 
         // Disable users — but never disable the calling platform admin if
-        // they happen to be a member of the partner being suspended.
-        const disableResult = await tx
-          .update(users)
-          .set({ status: 'disabled', updatedAt: new Date() })
-          .where(
-            and(
-              eq(users.partnerId, partnerId),
-              eq(users.isPlatformAdmin, false)
-            )
-          )
-          .returning({ id: users.id });
+        // they happen to be a member of the partner being suspended. Already-
+        // disabled users keep their existing disabled_reason so unsuspend can
+        // tell suspension-disabled users apart from the rest (#917 L-5). Token/
+        // session revocation below still covers ALL partner users via
+        // affectedUserIds, independent of this set.
+        const disableResult = await disablePartnerUsersForSuspension(tx, partnerId);
         const userCount = disableResult.length;
 
         // Revoke API keys for orgs under this partner.
@@ -359,16 +401,9 @@ abuseRoutes.post(
           .set({ status: newStatus, updatedAt: new Date() })
           .where(eq(partners.id, partnerId));
 
-        const reEnabled = await tx
-          .update(users)
-          .set({ status: 'active', updatedAt: new Date() })
-          .where(
-            and(
-              eq(users.partnerId, partnerId),
-              eq(users.status, 'disabled')
-            )
-          )
-          .returning({ id: users.id });
+        // Only restore users THIS suspension disabled — not users disabled for
+        // compromise / off-boarding / manual admin action (#917 L-5).
+        const reEnabled = await reEnableSuspensionDisabledUsers(tx, partnerId);
 
         return { notFound: false as const, status: newStatus, userCount: reEnabled.length };
       });

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1236,7 +1236,12 @@ userRoutes.patch(
       return c.json({ error: 'User not found' }, 404);
     }
 
-    const updates: { name?: string; status?: 'active' | 'invited' | 'disabled'; updatedAt: Date } = {
+    const updates: {
+      name?: string;
+      status?: 'active' | 'invited' | 'disabled';
+      disabledReason?: string | null;
+      updatedAt: Date;
+    } = {
       updatedAt: new Date()
     };
 
@@ -1246,6 +1251,11 @@ userRoutes.patch(
 
     if (data.status) {
       updates.status = data.status;
+      // Any status change made here is a manual admin action, not a partner
+      // suspension. Clear the suspension marker so a manual disable reads as
+      // "disabled for another reason" (partner unsuspend must not re-enable it)
+      // and so reactivation never leaves a stale marker behind. See #917 L-5.
+      updates.disabledReason = null;
     }
 
     const [updated] = await db


### PR DESCRIPTION
## Summary

Addresses **L-5** of the #917 hardening cluster. Partner unsuspend (`apps/api/src/routes/admin/abuse.ts`) did:

```ts
UPDATE users SET status='active' WHERE partner_id=? AND status='disabled'
```

— re-enabling **every** disabled user under the partner, regardless of why they were disabled. So a suspend → unsuspend cycle would silently resurrect users an operator had deliberately disabled for **compromise, off-boarding, or a manual admin action**.

## Fix — record why a user is disabled

- **Migration** `2026-06-09-users-disabled-reason.sql`: adds a nullable `users.disabled_reason` (NULL = "disabled for some non-suspension reason") and backfills users currently disabled under a still-`suspended` partner as `'partner_suspended'`, so in-flight suspensions still unsuspend correctly. Idempotent; adding a column to the already-RLS-forced `users` table needs no policy change.
- **Suspend** stamps `disabled_reason='partner_suspended'` on the users it disables, and now skips users already `disabled` so it never re-stamps an other-reason disable. Session/JWT/OAuth/remote-session revocation still covers **all** partner users (via the separate `affectedUserIds` set), so the suspension's security posture is unchanged.
- **Unsuspend** re-enables only `status='disabled' AND disabled_reason='partner_suspended'`, clearing the marker. Users disabled for any other reason stay disabled.

The two user-state queries are extracted into small exported helpers (`disablePartnerUsersForSuspension`, `reEnableSuspensionDisabledUsers`) so the handler and the integration test share the exact SQL.

## Tests
- New `partnerUnsuspendScope.integration.test.ts` (real Postgres) proves the row-filtering semantics end-to-end: a user disabled for another reason is **not** re-stamped by suspend and is **left disabled** after unsuspend, while suspension-disabled users are restored.
- Existing abuse unit suite (26) and the `autoMigrate` ordering guard (43) green; `tsc` + lint clean.

> Note: a local `db:check-drift` against the shared dev DB flags `2026-06-01-google-workspace-connections` / `m365-connections` ledger entries with no files — those are from the still-open #1053 branch (not on `main`), unrelated to this PR. The new migration applies cleanly on a fresh DB (verified via the integration runner's `autoMigrate`).

Addresses **L-5** of #917 (other sub-items tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)