### PR TITLE
feat(pam): backend control plane — admin REST API, decisioning wiring, lifecycle jobs, elevation events (#1163)

### DIFF
--- a/apps/api/migrations/2026-06-09-pam-rules.sql
+++ b/apps/api/migrations/2026-06-09-pam-rules.sql
@@ -1,0 +1,73 @@
+-- PAM-native rules table (#1163).
+-- The Rules tab of the /pam admin UI manages these; ingest evaluates them
+-- when no software_policy binds (services/pamRuleEngine.ts).
+-- Tenancy: Shape 1 (direct org_id), RLS mirrors elevation_requests (#905).
+-- Idempotent: re-applying is a no-op.
+
+DO $$ BEGIN
+  CREATE TYPE pam_rule_verdict AS ENUM (
+    'auto_approve',
+    'auto_deny',
+    'require_approval',
+    'ignore'
+  );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS pam_rules (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Tenancy (Shape 1)
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  site_id uuid REFERENCES sites(id),
+
+  name varchar(255) NOT NULL,
+  description text,
+  enabled boolean NOT NULL DEFAULT true,
+
+  -- Lower number = evaluated first. Ties broken by created_at then id.
+  priority integer NOT NULL DEFAULT 100,
+
+  -- Match criteria — all provided criteria must match (AND).
+  match_signer varchar(255),
+  match_hash varchar(64),
+  match_path_glob text,
+  match_parent_image text,
+  match_user varchar(255),
+  match_ad_group varchar(255),
+  time_window jsonb,
+
+  verdict pam_rule_verdict NOT NULL,
+
+  approval_duration_minutes integer,
+
+  created_by_user_id uuid REFERENCES users(id) ON DELETE SET NULL,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS pam_rules_org_id_idx ON pam_rules (org_id);
+CREATE INDEX IF NOT EXISTS pam_rules_org_enabled_priority_idx
+  ON pam_rules (org_id, enabled, priority);
+
+-- ============================================================
+-- RLS — pam_rules (Shape 1, mirrors elevation_requests #905)
+-- ============================================================
+ALTER TABLE pam_rules ENABLE ROW LEVEL SECURITY;
+ALTER TABLE pam_rules FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON pam_rules;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON pam_rules;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON pam_rules;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON pam_rules;
+
+CREATE POLICY breeze_org_isolation_select ON pam_rules
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON pam_rules
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON pam_rules
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON pam_rules
+  FOR DELETE USING (public.breeze_has_org_access(org_id));

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -1,6 +1,7 @@
 export * from './accountDeletion';
 export * from './approvals';
 export * from './elevations';
+export * from './pam';
 export * from './orgs';
 export * from './oauth';
 export * from './users';

--- a/apps/api/src/db/schema/pam.ts
+++ b/apps/api/src/db/schema/pam.ts
@@ -1,0 +1,98 @@
+/**
+ * PAM-native rules (#1163).
+ *
+ * Distinct from `software_policies`: the bridge (services/pamBridge.ts)
+ * consults the device's winning software policy first; when no software
+ * policy binds, ingest falls through to these PAM-native rules. The Rules
+ * tab of the /pam admin UI (#1159) manages this table.
+ *
+ * Tenancy: Shape 1 (direct org_id) — RLS policies in the migration use
+ * breeze_has_org_access(org_id), mirroring elevation_requests (#905).
+ * site_id narrows a rule to one site; null = org-wide.
+ */
+import {
+  boolean,
+  index,
+  integer,
+  jsonb,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+  varchar,
+} from 'drizzle-orm/pg-core';
+
+import { organizations, sites } from './orgs';
+import { users } from './users';
+
+export const pamRuleVerdictEnum = pgEnum('pam_rule_verdict', [
+  'auto_approve',
+  'auto_deny',
+  'require_approval',
+  'ignore',
+]);
+
+/**
+ * Optional time window during which a rule is active.
+ * Times are "HH:MM" 24h in the org's timezone; days are 0-6 (Sun-Sat).
+ * Absent/null window = always active.
+ */
+export interface PamRuleTimeWindow {
+  start: string;
+  end: string;
+  days?: number[];
+  timezone?: string;
+}
+
+export const pamRules = pgTable(
+  'pam_rules',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+
+    // Tenancy (Shape 1)
+    orgId: uuid('org_id').notNull().references(() => organizations.id),
+    siteId: uuid('site_id').references(() => sites.id),
+
+    name: varchar('name', { length: 255 }).notNull(),
+    description: text('description'),
+    enabled: boolean('enabled').notNull().default(true),
+
+    // Lower number = evaluated first. Ties broken by created_at then id.
+    priority: integer('priority').notNull().default(100),
+
+    // Match criteria — all provided criteria must match (AND). A rule with
+    // no criteria matches nothing (guarded at the API layer).
+    matchSigner: varchar('match_signer', { length: 255 }),
+    matchHash: varchar('match_hash', { length: 64 }),
+    matchPathGlob: text('match_path_glob'),
+    matchParentImage: text('match_parent_image'),
+    matchUser: varchar('match_user', { length: 255 }),
+    matchAdGroup: varchar('match_ad_group', { length: 255 }),
+    timeWindow: jsonb('time_window').$type<PamRuleTimeWindow | null>(),
+
+    verdict: pamRuleVerdictEnum('verdict').notNull(),
+
+    // For verdict='auto_approve' / approve flows: how long the elevation
+    // stays valid. Null falls back to the org default at decision time.
+    approvalDurationMinutes: integer('approval_duration_minutes'),
+
+    createdByUserId: uuid('created_by_user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    orgIdIdx: index('pam_rules_org_id_idx').on(table.orgId),
+    orgEnabledPriorityIdx: index('pam_rules_org_enabled_priority_idx').on(
+      table.orgId,
+      table.enabled,
+      table.priority,
+    ),
+  }),
+);
+
+export type PamRule = typeof pamRules.$inferSelect;
+export type NewPamRule = typeof pamRules.$inferInsert;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -22,6 +22,7 @@ import { configRoutes } from './routes/config';
 import { externalServicesRoutes } from './routes/externalServices';
 import { agentRoutes } from './routes/agents';
 import { deviceRoutes } from './routes/devices';
+import { pamRoutes } from './routes/pam';
 import { scriptRoutes } from './routes/scripts';
 import { scriptLibraryRoutes } from './routes/scriptLibrary';
 import { automationRoutes, automationWebhookRoutes } from './routes/automations';
@@ -182,6 +183,7 @@ import {
 } from './jobs/incidentJobs';
 import { initializeStaleCommandReaper, shutdownStaleCommandReaper } from './jobs/staleCommandReaper';
 import { initializeApprovalExpiryReaper, shutdownApprovalExpiryReaper } from './jobs/approvalExpiryReaper';
+import { initializePamJobs, shutdownPamJobs } from './jobs/pamJobs';
 import { initializePolicyAlertBridge } from './services/policyAlertBridge';
 import { getWebhookWorker, initializeWebhookDelivery } from './workers/webhookDelivery';
 import { initializeTransferCleanup, stopTransferCleanup } from './workers/transferCleanup';
@@ -701,6 +703,7 @@ api.route('/config', configRoutes);
 api.route('/', externalServicesRoutes);
 api.route('/agents', agentRoutes);
 api.route('/devices', deviceRoutes);
+api.route('/pam', pamRoutes);
 api.route('/scripts', scriptRoutes);
 api.route('/script-library', scriptLibraryRoutes);
 api.route('/automations/webhooks', automationWebhookRoutes);
@@ -1041,6 +1044,7 @@ async function initializeWorkers(): Promise<void> {
     ['incidentSlaMonitor', initializeIncidentSlaMonitor],
     ['staleCommandReaper', initializeStaleCommandReaper],
     ['approvalExpiryReaper', initializeApprovalExpiryReaper],
+    ['pamJobs', initializePamJobs],
   ];
 
   await Promise.allSettled(
@@ -1192,6 +1196,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownAlertWorkers,
     shutdownStaleCommandReaper,
     shutdownApprovalExpiryReaper,
+    shutdownPamJobs,
     shutdownEventDispatcher,
     async () => getEventBus().close(),
     closeRedis,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -182,8 +182,8 @@ import {
   shutdownIncidentSlaMonitor,
 } from './jobs/incidentJobs';
 import { initializeStaleCommandReaper, shutdownStaleCommandReaper } from './jobs/staleCommandReaper';
-import { initializeApprovalExpiryReaper, shutdownApprovalExpiryReaper } from './jobs/approvalExpiryReaper';
 import { initializePamJobs, shutdownPamJobs } from './jobs/pamJobs';
+import { initializeApprovalExpiryReaper, shutdownApprovalExpiryReaper } from './jobs/approvalExpiryReaper';
 import { initializePolicyAlertBridge } from './services/policyAlertBridge';
 import { getWebhookWorker, initializeWebhookDelivery } from './workers/webhookDelivery';
 import { initializeTransferCleanup, stopTransferCleanup } from './workers/transferCleanup';
@@ -1043,8 +1043,8 @@ async function initializeWorkers(): Promise<void> {
     ['incidentTimelineEnricher', initializeIncidentTimelineEnricher],
     ['incidentSlaMonitor', initializeIncidentSlaMonitor],
     ['staleCommandReaper', initializeStaleCommandReaper],
-    ['approvalExpiryReaper', initializeApprovalExpiryReaper],
     ['pamJobs', initializePamJobs],
+    ['approvalExpiryReaper', initializeApprovalExpiryReaper],
   ];
 
   await Promise.allSettled(
@@ -1195,8 +1195,8 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownOfflineDetector,
     shutdownAlertWorkers,
     shutdownStaleCommandReaper,
-    shutdownApprovalExpiryReaper,
     shutdownPamJobs,
+    shutdownApprovalExpiryReaper,
     shutdownEventDispatcher,
     async () => getEventBus().close(),
     closeRedis,

--- a/apps/api/src/jobs/pamJobs.ts
+++ b/apps/api/src/jobs/pamJobs.ts
@@ -1,0 +1,299 @@
+/**
+ * PAM lifecycle jobs (#1163). Two reapers cloned from the
+ * approvalExpiryReaper pattern (BullMQ repeatable job + worker, CTE-bounded
+ * UPDATE, withSystemDbAccessContext, audit + event per transition):
+ *
+ *   - elevation-expiry-enforcer (every 60s): active elevations
+ *     (approved / auto_approved / actuating) whose expires_at has passed →
+ *     status='expired'. This is the core time-bound safety guarantee.
+ *
+ *   - stale-request-expirer (every 5 min): pending requests older than the
+ *     TTL → status='expired' (keeps the approval queue signal-only).
+ *
+ * Agent-side revoke commands for expired tech_jit_admin grants are #1150
+ * scope (group-flip undo handler) — until that lands, expiry is a
+ * server-side state change, audited and event-emitted.
+ */
+import { Job, Queue, Worker } from 'bullmq';
+import { sql } from 'drizzle-orm';
+
+import * as dbModule from '../db';
+import { db } from '../db';
+import { elevationAudit, elevationRequests } from '../db/schema';
+import { getBullMQConnection } from '../services/redis';
+import { captureException } from '../services/sentry';
+import { publishEvent } from '../services/eventBus';
+import { writeAuditEvent, requestLikeFromSnapshot } from '../services/auditEvents';
+
+const ENFORCER_QUEUE = 'pam-elevation-expiry-enforcer';
+const ENFORCER_INTERVAL_MS = 60 * 1000; // every 60s
+const STALE_QUEUE = 'pam-stale-request-expirer';
+const STALE_INTERVAL_MS = 5 * 60 * 1000; // every 5 min
+const MAX_PER_RUN = 500;
+
+// Pending requests older than this are expired. Overridable for ops via env.
+const STALE_PENDING_TTL_MINUTES = Number.parseInt(
+  process.env.PAM_PENDING_REQUEST_TTL_MINUTES ?? '15',
+  10,
+);
+
+type PamJobData = { type: 'enforce-elevation-expiry' | 'expire-stale-requests'; queuedAt: string };
+
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const withSystem = dbModule.withSystemDbAccessContext;
+  if (typeof withSystem !== 'function') {
+    throw new Error(
+      '[PamJobs] withSystemDbAccessContext not available — reapers cannot run without system DB access',
+    );
+  }
+  return withSystem(fn);
+};
+
+interface TransitionedRow extends Record<string, unknown> {
+  id: string;
+  org_id: string;
+  device_id: string;
+  flow_type: string;
+  prior_status: string;
+}
+
+function extractRows(result: unknown): TransitionedRow[] {
+  const maybe = result as { rows?: TransitionedRow[] };
+  const rows = maybe.rows ?? (result as TransitionedRow[]);
+  return Array.isArray(rows) ? rows : [];
+}
+
+/** Shared post-transition side effects: PAM audit chain + event + audit log. */
+async function emitExpiryEffects(rows: TransitionedRow[], cause: 'window' | 'stale'): Promise<void> {
+  if (rows.length === 0) return;
+  const now = new Date();
+
+  // PAM-specific audit chain (one row per transition). Best-effort.
+  try {
+    await db.insert(elevationAudit).values(
+      rows.map((row) => ({
+        orgId: row.org_id,
+        elevationRequestId: row.id,
+        eventType: 'expired' as const,
+        actor: 'system' as const,
+        details: { cause, prior_status: row.prior_status },
+        occurredAt: now,
+      })),
+    );
+  } catch (err) {
+    console.error('[PamJobs] elevation_audit write failed:', err);
+    captureException(err instanceof Error ? err : new Error(String(err)));
+  }
+
+  const requestLike = requestLikeFromSnapshot({});
+  for (const row of rows) {
+    try {
+      writeAuditEvent(requestLike, {
+        orgId: row.org_id,
+        action: 'pam.elevation_request.expired',
+        resourceType: 'elevation_request',
+        resourceId: row.id,
+        actorType: 'system',
+        actorId: null,
+        result: 'success',
+        details: { cause, prior_status: row.prior_status, flow_type: row.flow_type },
+      });
+    } catch (err) {
+      console.error('[PamJobs] audit event write failed:', err);
+    }
+    try {
+      await publishEvent(
+        'elevation.expired',
+        row.org_id,
+        {
+          elevationRequestId: row.id,
+          deviceId: row.device_id,
+          flowType: row.flow_type,
+          status: 'expired',
+          cause,
+        },
+        'pam-jobs',
+      );
+    } catch (err) {
+      console.error('[PamJobs] event publish failed:', err);
+    }
+  }
+}
+
+/**
+ * Flip active elevations whose window has passed to `expired`.
+ * Returns the number of rows transitioned. Exported for tests.
+ */
+export async function enforceElevationExpiry(): Promise<number> {
+  const transitioned = await db.execute<TransitionedRow>(sql`
+    WITH due AS (
+      SELECT id
+      FROM ${elevationRequests}
+      WHERE ${elevationRequests.status} IN ('approved', 'auto_approved', 'actuating')
+        AND ${elevationRequests.expiresAt} IS NOT NULL
+        AND ${elevationRequests.expiresAt} < now()
+      ORDER BY ${elevationRequests.expiresAt} ASC
+      LIMIT ${MAX_PER_RUN}
+      FOR UPDATE SKIP LOCKED
+    )
+    UPDATE ${elevationRequests} AS e
+    SET status = 'expired',
+        expired_at = now(),
+        updated_at = now()
+    FROM due
+    WHERE e.id = due.id
+      AND e.status IN ('approved', 'auto_approved', 'actuating')
+    RETURNING
+      e.id,
+      e.org_id,
+      e.device_id,
+      e.flow_type,
+      'active'::text AS prior_status;
+  `);
+
+  const rows = extractRows(transitioned);
+  await emitExpiryEffects(rows, 'window');
+
+  if (rows.length === MAX_PER_RUN) {
+    console.warn(`[PamJobs] expiry enforcer hit ${MAX_PER_RUN}-item cap — backlog may be growing`);
+  }
+  return rows.length;
+}
+
+/**
+ * Expire pending requests older than the TTL. Returns rows transitioned.
+ * Exported for tests.
+ */
+export async function expireStaleRequests(): Promise<number> {
+  const ttlMinutes = Number.isFinite(STALE_PENDING_TTL_MINUTES) && STALE_PENDING_TTL_MINUTES > 0
+    ? STALE_PENDING_TTL_MINUTES
+    : 15;
+  const transitioned = await db.execute<TransitionedRow>(sql`
+    WITH due AS (
+      SELECT id
+      FROM ${elevationRequests}
+      WHERE ${elevationRequests.status} = 'pending'
+        AND ${elevationRequests.requestedAt} < now() - (${ttlMinutes} * interval '1 minute')
+      ORDER BY ${elevationRequests.requestedAt} ASC
+      LIMIT ${MAX_PER_RUN}
+      FOR UPDATE SKIP LOCKED
+    )
+    UPDATE ${elevationRequests} AS e
+    SET status = 'expired',
+        expired_at = now(),
+        updated_at = now()
+    FROM due
+    WHERE e.id = due.id
+      AND e.status = 'pending'
+    RETURNING
+      e.id,
+      e.org_id,
+      e.device_id,
+      e.flow_type,
+      'pending'::text AS prior_status;
+  `);
+
+  const rows = extractRows(transitioned);
+  await emitExpiryEffects(rows, 'stale');
+
+  if (rows.length === MAX_PER_RUN) {
+    console.warn(`[PamJobs] stale expirer hit ${MAX_PER_RUN}-item cap — backlog may be growing`);
+  }
+  return rows.length;
+}
+
+// ============================================================
+// BullMQ wiring (mirrors approvalExpiryReaper)
+// ============================================================
+
+let enforcerQueue: Queue<PamJobData> | null = null;
+let enforcerWorker: Worker<PamJobData> | null = null;
+let staleQueue: Queue<PamJobData> | null = null;
+let staleWorker: Worker<PamJobData> | null = null;
+
+async function scheduleRepeatable(
+  queue: Queue<PamJobData>,
+  type: PamJobData['type'],
+  everyMs: number,
+): Promise<void> {
+  await queue.add(
+    type,
+    { type, queuedAt: new Date().toISOString() },
+    {
+      jobId: `${type}-repeat`,
+      repeat: { every: everyMs },
+      removeOnComplete: { count: 20 },
+      removeOnFail: { count: 200 },
+    },
+  );
+}
+
+function wireWorkerLogging(worker: Worker<PamJobData>, label: string): void {
+  worker.on('error', (error) => {
+    console.error(`[PamJobs] ${label} worker error:`, error);
+    captureException(error);
+  });
+  worker.on('failed', (_job, error) => {
+    console.error(`[PamJobs] ${label} job failed:`, error);
+    captureException(error);
+  });
+}
+
+export async function initializePamJobs(): Promise<void> {
+  if (enforcerWorker || staleWorker) return;
+
+  enforcerWorker = new Worker<PamJobData>(
+    ENFORCER_QUEUE,
+    async (_job: Job<PamJobData>) => {
+      const expired = await runWithSystemDbAccess(enforceElevationExpiry);
+      if (expired > 0) {
+        console.log(`[PamJobs] Expired ${expired} elevation window(s)`);
+      }
+      return { expired };
+    },
+    { connection: getBullMQConnection(), concurrency: 1 },
+  );
+  wireWorkerLogging(enforcerWorker, 'expiry-enforcer');
+
+  staleWorker = new Worker<PamJobData>(
+    STALE_QUEUE,
+    async (_job: Job<PamJobData>) => {
+      const expired = await runWithSystemDbAccess(expireStaleRequests);
+      if (expired > 0) {
+        console.log(`[PamJobs] Expired ${expired} stale pending request(s)`);
+      }
+      return { expired };
+    },
+    { connection: getBullMQConnection(), concurrency: 1 },
+  );
+  wireWorkerLogging(staleWorker, 'stale-expirer');
+
+  try {
+    enforcerQueue = new Queue<PamJobData>(ENFORCER_QUEUE, { connection: getBullMQConnection() });
+    staleQueue = new Queue<PamJobData>(STALE_QUEUE, { connection: getBullMQConnection() });
+    await scheduleRepeatable(enforcerQueue, 'enforce-elevation-expiry', ENFORCER_INTERVAL_MS);
+    await scheduleRepeatable(staleQueue, 'expire-stale-requests', STALE_INTERVAL_MS);
+  } catch (err) {
+    await shutdownPamJobs();
+    throw err;
+  }
+
+  console.log('[PamJobs] Initialized (expiry enforcer 60s, stale expirer 5m)');
+}
+
+export async function shutdownPamJobs(): Promise<void> {
+  const closers = [enforcerWorker, staleWorker, enforcerQueue, staleQueue];
+  enforcerWorker = null;
+  staleWorker = null;
+  enforcerQueue = null;
+  staleQueue = null;
+  for (const closable of closers) {
+    if (closable) {
+      try {
+        await closable.close();
+      } catch (err) {
+        console.error('[PamJobs] close failed:', err);
+      }
+    }
+  }
+}

--- a/apps/api/src/routes/agents/elevationRequests.test.ts
+++ b/apps/api/src/routes/agents/elevationRequests.test.ts
@@ -22,6 +22,32 @@ vi.mock('../../db/schema', () => ({
     id: 'id',
     status: 'status',
   },
+  elevationAudit: {
+    id: 'id',
+    orgId: 'orgId',
+    elevationRequestId: 'elevationRequestId',
+  },
+  pamRules: {
+    id: 'id',
+    orgId: 'orgId',
+    siteId: 'siteId',
+    enabled: 'enabled',
+    priority: 'priority',
+  },
+}));
+
+const pamMocks = vi.hoisted(() => ({
+  evaluatePamBridge: vi.fn(),
+  publishEvent: vi.fn(),
+}));
+vi.mock('../../services/pamBridge', async (importOriginal) => {
+  // Keep the real matchPathGlob (the rule engine imports it); only stub the
+  // DB-touching evaluator.
+  const actual = await importOriginal<typeof import('../../services/pamBridge')>();
+  return { ...actual, evaluatePamBridge: pamMocks.evaluatePamBridge };
+});
+vi.mock('../../services/eventBus', () => ({
+  publishEvent: pamMocks.publishEvent,
 }));
 
 const mocks = vi.hoisted(() => ({
@@ -74,6 +100,29 @@ function buildApp(opts: { skipAuth?: boolean } = {}): Hono {
   return app;
 }
 
+/**
+ * db.select chain serving BOTH shapes the route uses:
+ *   device lookup:  .from().where().limit()  -> deviceRows
+ *   pam_rules load: .from().where()  (awaited) -> ruleRows
+ */
+function mockSelects(
+  deviceRows: Array<{ id: string; orgId: string; siteId: string | null }>,
+  ruleRows: unknown[] = [],
+) {
+  vi.mocked(db.select).mockImplementation(
+    () =>
+      ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => {
+            const thenable: any = Promise.resolve(ruleRows);
+            thenable.limit = vi.fn().mockResolvedValue(deviceRows);
+            return thenable;
+          }),
+        })),
+      }) as any,
+  );
+}
+
 function happyPathInsert(returningRows: Array<{ id: string; status: string }>) {
   const returning = vi.fn().mockResolvedValue(returningRows);
   const values = vi.fn().mockReturnValue({ returning });
@@ -89,15 +138,10 @@ describe('agent elevation-requests ingestion route', () => {
       remaining: 599,
       resetAt: new Date(Date.now() + 60_000),
     });
-    vi.mocked(db.select).mockReturnValue({
-      from: vi.fn(() => ({
-        where: vi.fn(() => ({
-          limit: vi.fn().mockResolvedValue([
-            { id: 'device-1', orgId: 'org-1', siteId: 'site-1' },
-          ]),
-        })),
-      })),
-    } as any);
+    mockSelects([{ id: 'device-1', orgId: 'org-1', siteId: 'site-1' }]);
+    // Default: no software policy binds, no PAM rules -> 'pending'.
+    pamMocks.evaluatePamBridge.mockResolvedValue({ match: null, auditMatches: [] });
+    pamMocks.publishEvent.mockResolvedValue('evt-1');
   });
 
   it('inserts an elevation request and returns id + status', async () => {
@@ -130,13 +174,7 @@ describe('agent elevation-requests ingestion route', () => {
 
   it('returns 404 when the agent_id does not match any device', async () => {
     happyPathInsert([{ id: 'req-uuid', status: 'pending' }]);
-    vi.mocked(db.select).mockReturnValue({
-      from: vi.fn(() => ({
-        where: vi.fn(() => ({
-          limit: vi.fn().mockResolvedValue([]),
-        })),
-      })),
-    } as any);
+    mockSelects([]);
 
     const app = buildApp();
     const response = await app.request('/agents/agent-unknown/elevation-requests', {
@@ -257,6 +295,166 @@ describe('agent elevation-requests ingestion route', () => {
       'elevation:rate:device:device-1',
       600,
       60,
+    );
+  });
+});
+
+describe('ingest decisioning (#1163)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.rateLimiter.mockResolvedValue({
+      allowed: true,
+      remaining: 599,
+      resetAt: new Date(Date.now() + 60_000),
+    });
+    mockSelects([{ id: 'device-1', orgId: 'org-1', siteId: 'site-1' }]);
+    pamMocks.evaluatePamBridge.mockResolvedValue({ match: null, auditMatches: [] });
+    pamMocks.publishEvent.mockResolvedValue('evt-1');
+  });
+
+  async function post(app: Hono) {
+    return app.request('/agents/agent-123/elevation-requests', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(goodPayload),
+    });
+  }
+
+  it('blocklist policy match -> denied + elevation.denied event', async () => {
+    pamMocks.evaluatePamBridge.mockResolvedValue({
+      match: 'blocklist',
+      policyId: 'pol-1',
+      auditMatches: [],
+    });
+    const { values } = happyPathInsert([{ id: 'req-1', status: 'denied' }]);
+
+    const res = await post(buildApp());
+    expect(res.status).toBe(201);
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'denied',
+        softwarePolicyMatchId: 'pol-1',
+        denialReason: 'Blocked by software policy',
+      }),
+    );
+    expect(pamMocks.publishEvent).toHaveBeenCalledWith(
+      'elevation.denied',
+      'org-1',
+      expect.objectContaining({ elevationRequestId: 'req-1' }),
+      'pam-ingest',
+    );
+  });
+
+  it('allowlist policy match -> auto_approved with expiry + event', async () => {
+    pamMocks.evaluatePamBridge.mockResolvedValue({
+      match: 'allowlist',
+      policyId: 'pol-2',
+      auditMatches: [],
+    });
+    const { values } = happyPathInsert([{ id: 'req-2', status: 'auto_approved' }]);
+
+    const res = await post(buildApp());
+    expect(res.status).toBe(201);
+    const call = vi
+      .mocked(values)
+      .mock.calls.find(
+        (args) => (args[0] as { status?: string }).status === 'auto_approved',
+      );
+    expect(call).toBeTruthy();
+    const inserted = call![0] as { expiresAt: Date; approvedAt: Date; softwarePolicyMatchId: string };
+    expect(inserted.softwarePolicyMatchId).toBe('pol-2');
+    expect(inserted.approvedAt).toBeInstanceOf(Date);
+    expect(inserted.expiresAt.getTime()).toBeGreaterThan(Date.now());
+    expect(pamMocks.publishEvent).toHaveBeenCalledWith(
+      'elevation.auto_approved',
+      'org-1',
+      expect.objectContaining({ softwarePolicyId: 'pol-2' }),
+      'pam-ingest',
+    );
+  });
+
+  it('pam rule auto_deny (real engine) -> denied with rule metadata', async () => {
+    const rule = {
+      id: 'rule-1',
+      orgId: 'org-1',
+      siteId: null,
+      name: 'Block mmc',
+      description: null,
+      enabled: true,
+      priority: 10,
+      matchSigner: null,
+      matchHash: null,
+      matchPathGlob: 'C:\\Windows\\System32\\mmc.exe',
+      matchParentImage: null,
+      matchUser: null,
+      matchAdGroup: null,
+      timeWindow: null,
+      verdict: 'auto_deny',
+      approvalDurationMinutes: null,
+      createdByUserId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    mockSelects([{ id: 'device-1', orgId: 'org-1', siteId: 'site-1' }], [rule]);
+    const { values } = happyPathInsert([{ id: 'req-3', status: 'denied' }]);
+
+    const res = await post(buildApp());
+    expect(res.status).toBe(201);
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'denied',
+        denialReason: 'Blocked by PAM rule "Block mmc"',
+        softwarePolicyMatchId: null,
+      }),
+    );
+  });
+
+  it('pam rule ignore -> no insert, 200 ignored', async () => {
+    const rule = {
+      id: 'rule-2',
+      orgId: 'org-1',
+      siteId: null,
+      name: 'Ignore mmc noise',
+      description: null,
+      enabled: true,
+      priority: 5,
+      matchSigner: null,
+      matchHash: null,
+      matchPathGlob: 'C:\\Windows\\System32\\*.exe',
+      matchParentImage: null,
+      matchUser: null,
+      matchAdGroup: null,
+      timeWindow: null,
+      verdict: 'ignore',
+      approvalDurationMinutes: null,
+      createdByUserId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    mockSelects([{ id: 'device-1', orgId: 'org-1', siteId: 'site-1' }], [rule]);
+    happyPathInsert([{ id: 'never', status: 'never' }]);
+
+    const res = await post(buildApp());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: null, status: 'ignored' });
+    expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+    expect(vi.mocked(writeAuditEvent)).toHaveBeenCalledOnce();
+  });
+
+  it('bridge failure fails SAFE to pending (never auto-approves on error)', async () => {
+    pamMocks.evaluatePamBridge.mockRejectedValue(new Error('policy resolver down'));
+    const { values } = happyPathInsert([{ id: 'req-4', status: 'pending' }]);
+
+    const res = await post(buildApp());
+    expect(res.status).toBe(201);
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'pending' }),
+    );
+    expect(pamMocks.publishEvent).toHaveBeenCalledWith(
+      'elevation.requested',
+      'org-1',
+      expect.anything(),
+      'pam-ingest',
     );
   });
 });

--- a/apps/api/src/routes/agents/elevationRequests.ts
+++ b/apps/api/src/routes/agents/elevationRequests.ts
@@ -1,21 +1,33 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { eq } from 'drizzle-orm';
+import { and, eq, isNull, or } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { db } from '../../db';
-import { devices, elevationRequests } from '../../db/schema';
+import { devices, elevationAudit, elevationRequests, pamRules } from '../../db/schema';
 import { writeAuditEvent } from '../../services/auditEvents';
 import { getRedis } from '../../services/redis';
 import { rateLimiter } from '../../services/rate-limit';
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
 import { requireAgentRole } from '../../middleware/requireAgentRole';
+import { evaluatePamBridge, type PamBridgeVerdict } from '../../services/pamBridge';
+import { evaluatePamRules, type PamRuleMatch } from '../../services/pamRuleEngine';
+import { publishEvent, type EventType } from '../../services/eventBus';
 
 // PAM Track 3: agent-side endpoint that records UAC consent.exe observations
 // as `elevation_requests` rows with flow_type='uac_intercept'. Auth is the
 // standard agent bearer token (agentAuthMiddleware, mounted in
 // routes/agents/index.ts). The middleware attaches { deviceId, agentId,
 // orgId, siteId, role } to ctx.var.agent.
+//
+// #1163: ingest now runs the decisioning chain before inserting —
+//   1. software-policy bridge (services/pamBridge.ts): allowlist →
+//      auto_approved, blocklist → denied;
+//   2. PAM-native rules (services/pamRuleEngine.ts) when no policy binds:
+//      auto_approve / auto_deny / require_approval / ignore;
+//   3. otherwise the row stays 'pending' (manual approval queue).
+// Every outcome writes elevation_audit + emits an elevation.* event.
+// Decisioning errors fail SAFE to 'pending' — never auto-approve on error.
 
 // Body cap: 32 KB. Agent CommandLine fields can be long (multi-arg installer
 // invocations) but anything beyond 32 KB is almost certainly junk or abuse.
@@ -26,6 +38,11 @@ const ELEVATION_REQUEST_MAX_BODY_BYTES = 32 * 1024;
 // 60-second window approximates 10/s while smoothing over bursts.
 const ELEVATION_REQUEST_RATE_LIMIT = 600;
 const ELEVATION_REQUEST_RATE_WINDOW_SECONDS = 60;
+
+// How long an auto-approved elevation stays valid when neither the matching
+// pam_rule nor (future) org config specifies a duration. Conservative: the
+// uac_intercept flow only needs the window in which consent.exe is satisfied.
+const PAM_DEFAULT_AUTO_APPROVAL_DURATION_MINUTES = 15;
 
 export const elevationRequestSchema = z.object({
   subject_username: z.string().min(1).max(255),
@@ -39,6 +56,31 @@ export const elevationRequestSchema = z.object({
 });
 
 export type ElevationRequestPayload = z.infer<typeof elevationRequestSchema>;
+
+type IngestDecision =
+  | { kind: 'pending' }
+  | {
+      kind: 'auto_approved';
+      source: 'policy' | 'rule';
+      policyId?: string;
+      rule?: PamRuleMatch;
+      durationMinutes: number;
+    }
+  | { kind: 'denied'; source: 'policy' | 'rule'; policyId?: string; rule?: PamRuleMatch }
+  | { kind: 'ignored'; rule: PamRuleMatch };
+
+/** Event emission must never fail ingest — the row is already committed. */
+async function safePublish(
+  type: EventType,
+  orgId: string,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  try {
+    await publishEvent(type, orgId, payload, 'pam-ingest');
+  } catch (err) {
+    console.error(`[ElevationRequests] event publish failed (${type}):`, err);
+  }
+}
 
 export const elevationRequestsRoutes = new Hono();
 // Elevation-request ingest is the main agent's job; reject watchdog tokens.
@@ -116,6 +158,120 @@ elevationRequestsRoutes.post(
     // it doesn't get to write arbitrary reason text.
     const reason = `UAC consent UI observed for ${payload.target_executable_path}`;
 
+    // ------------------------------------------------------------------
+    // Decisioning (#1163). Both evaluators run inside the request's
+    // org-scoped withDbAccessContext (opened by agentAuthMiddleware), so
+    // policy/rule lookups are RLS-scoped to the device's org. Any error
+    // fails SAFE to 'pending' — an evaluator outage must never become an
+    // auto-approval, and degrading a blocklist deny to a pending row is
+    // preferable to dropping the observation entirely.
+    // ------------------------------------------------------------------
+    let bridgeVerdict: PamBridgeVerdict | null = null;
+    let decision: IngestDecision = { kind: 'pending' };
+    try {
+      bridgeVerdict = await evaluatePamBridge({
+        orgId: device.orgId,
+        deviceId: device.id,
+        targetExecutablePath: payload.target_executable_path,
+        targetExecutableHash: payload.target_executable_hash,
+        targetExecutableSigner: payload.target_executable_signer,
+      });
+
+      if (bridgeVerdict.match === 'blocklist') {
+        decision = { kind: 'denied', source: 'policy', policyId: bridgeVerdict.policyId };
+      } else if (bridgeVerdict.match === 'allowlist') {
+        decision = {
+          kind: 'auto_approved',
+          source: 'policy',
+          policyId: bridgeVerdict.policyId,
+          durationMinutes: PAM_DEFAULT_AUTO_APPROVAL_DURATION_MINUTES,
+        };
+      } else {
+        // No software policy bound — fall through to PAM-native rules.
+        const orgRules = await db
+          .select()
+          .from(pamRules)
+          .where(
+            and(
+              eq(pamRules.orgId, device.orgId),
+              eq(pamRules.enabled, true),
+              device.siteId
+                ? or(isNull(pamRules.siteId), eq(pamRules.siteId, device.siteId))
+                : isNull(pamRules.siteId),
+            ),
+          );
+        const ruleMatch = evaluatePamRules(orgRules, {
+          targetExecutablePath: payload.target_executable_path,
+          targetExecutableHash: payload.target_executable_hash,
+          targetExecutableSigner: payload.target_executable_signer,
+          subjectUsername: payload.subject_username,
+          parentImage: payload.parent_image,
+          at: observedAt,
+        });
+        if (ruleMatch) {
+          switch (ruleMatch.verdict) {
+            case 'auto_approve':
+              decision = {
+                kind: 'auto_approved',
+                source: 'rule',
+                rule: ruleMatch,
+                durationMinutes:
+                  ruleMatch.approvalDurationMinutes ??
+                  PAM_DEFAULT_AUTO_APPROVAL_DURATION_MINUTES,
+              };
+              break;
+            case 'auto_deny':
+              decision = { kind: 'denied', source: 'rule', rule: ruleMatch };
+              break;
+            case 'ignore':
+              decision = { kind: 'ignored', rule: ruleMatch };
+              break;
+            case 'require_approval':
+            default:
+              decision = { kind: 'pending' };
+              break;
+          }
+        }
+      }
+    } catch (err) {
+      console.error(
+        `[ElevationRequests] decisioning failed for device=${device.id} org=${device.orgId} (failing safe to pending):`,
+        err,
+      );
+      decision = { kind: 'pending' };
+    }
+
+    // 'ignore' rules suppress the request entirely: no elevation_requests
+    // row (the approval queue stays signal-only), but the observation is
+    // still recorded in the general audit log for forensics.
+    if (decision.kind === 'ignored') {
+      writeAuditEvent(c, {
+        orgId: agent?.orgId ?? device.orgId,
+        actorType: 'agent',
+        actorId: agent?.agentId ?? agentId,
+        action: 'agent.elevation_request.ignored',
+        resourceType: 'elevation_request',
+        resourceId: decision.rule.ruleId,
+        details: {
+          flow_type: 'uac_intercept',
+          subject_username: payload.subject_username,
+          target_executable_path: payload.target_executable_path,
+          pam_rule_id: decision.rule.ruleId,
+          pam_rule_name: decision.rule.ruleName,
+        },
+      });
+      // The agent treats any 200/201 as success and ignores the body.
+      return c.json({ id: null, status: 'ignored' }, 200);
+    }
+
+    const now = new Date();
+    const status =
+      decision.kind === 'auto_approved'
+        ? 'auto_approved'
+        : decision.kind === 'denied'
+          ? 'denied'
+          : 'pending';
+
     try {
       const inserted = await db
         .insert(elevationRequests)
@@ -130,14 +286,32 @@ elevationRequestsRoutes.post(
           targetExecutablePath: payload.target_executable_path,
           targetExecutableHash: payload.target_executable_hash ?? null,
           targetExecutableSigner: payload.target_executable_signer ?? null,
-          status: 'pending',
+          status,
           requestedAt: observedAt,
+          approvedAt: decision.kind === 'auto_approved' ? now : null,
+          expiresAt:
+            decision.kind === 'auto_approved'
+              ? new Date(now.getTime() + decision.durationMinutes * 60_000)
+              : null,
+          denialReason:
+            decision.kind === 'denied'
+              ? decision.source === 'policy'
+                ? 'Blocked by software policy'
+                : `Blocked by PAM rule "${decision.rule?.ruleName ?? ''}"`
+              : null,
+          softwarePolicyMatchId:
+            decision.kind !== 'pending' && decision.source === 'policy'
+              ? (decision.policyId ?? null)
+              : null,
           clientIp: clientIp ?? null,
           userAgent,
           metadata: {
             pid: payload.pid,
             parent_image: payload.parent_image,
             command_line: payload.command_line,
+            ...(decision.kind !== 'pending' && decision.rule
+              ? { pam_rule_id: decision.rule.ruleId, pam_rule_name: decision.rule.ruleName }
+              : {}),
           },
         })
         .returning({ id: elevationRequests.id, status: elevationRequests.status });
@@ -145,6 +319,62 @@ elevationRequestsRoutes.post(
       const row = inserted[0];
       if (!row) {
         return c.json({ error: 'Insert returned no row' }, 500);
+      }
+
+      // PAM-specific audit chain: one 'requested' row always, plus the
+      // auto-decision row when policy/rule decided, plus evidence rows for
+      // audit-mode policy hits. Best-effort: the request row is committed;
+      // an audit-chain insert failure must not 500 the agent.
+      try {
+        const auditRows: (typeof elevationAudit.$inferInsert)[] = [
+          {
+            orgId: device.orgId,
+            elevationRequestId: row.id,
+            eventType: 'requested',
+            actor: 'end_user',
+            details: {
+              subject_username: payload.subject_username,
+              target_executable_path: payload.target_executable_path,
+            },
+            occurredAt: observedAt,
+          },
+        ];
+        if (decision.kind === 'auto_approved' || decision.kind === 'denied') {
+          auditRows.push({
+            orgId: device.orgId,
+            elevationRequestId: row.id,
+            eventType: decision.kind === 'auto_approved' ? 'auto_approved' : 'denied',
+            actor: 'policy',
+            details:
+              decision.source === 'policy'
+                ? { software_policy_id: decision.policyId }
+                : {
+                    pam_rule_id: decision.rule?.ruleId,
+                    pam_rule_name: decision.rule?.ruleName,
+                  },
+            occurredAt: now,
+          });
+        }
+        for (const evidence of bridgeVerdict?.auditMatches ?? []) {
+          auditRows.push({
+            orgId: device.orgId,
+            elevationRequestId: row.id,
+            eventType: 'evidence_attached',
+            actor: 'policy',
+            details: {
+              software_policy_id: evidence.policyId,
+              rule_name: evidence.ruleName,
+              matched_field: evidence.matchedField,
+            },
+            occurredAt: now,
+          });
+        }
+        await db.insert(elevationAudit).values(auditRows);
+      } catch (auditErr) {
+        console.error(
+          `[ElevationRequests] elevation_audit write failed for request=${row.id}:`,
+          auditErr,
+        );
       }
 
       writeAuditEvent(c, {
@@ -158,7 +388,29 @@ elevationRequestsRoutes.post(
           flow_type: 'uac_intercept',
           subject_username: payload.subject_username,
           target_executable_path: payload.target_executable_path,
+          ingest_status: row.status,
         },
+      });
+
+      const eventType: EventType =
+        decision.kind === 'auto_approved'
+          ? 'elevation.auto_approved'
+          : decision.kind === 'denied'
+            ? 'elevation.denied'
+            : 'elevation.requested';
+      await safePublish(eventType, device.orgId, {
+        elevationRequestId: row.id,
+        deviceId: device.id,
+        flowType: 'uac_intercept',
+        status: row.status,
+        subjectUsername: payload.subject_username,
+        targetExecutablePath: payload.target_executable_path,
+        ...(decision.kind !== 'pending' && decision.source === 'policy'
+          ? { softwarePolicyId: decision.policyId }
+          : {}),
+        ...(decision.kind !== 'pending' && 'rule' in decision && decision.rule
+          ? { pamRuleId: decision.rule.ruleId }
+          : {}),
       });
 
       return c.json({ id: row.id, status: row.status }, 201);

--- a/apps/api/src/routes/pam.test.ts
+++ b/apps/api/src/routes/pam.test.ts
@@ -1,0 +1,325 @@
+/**
+ * PAM admin route tests (#1163) — CAS guards on respond/revoke, the
+ * no-criteria rule refine, and runAction-compatible bodies.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const authMocks = vi.hoisted(() => ({
+  authMiddlewareMock: vi.fn(),
+  requireScopeMock: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermissionMock: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfaMock: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: authMocks.authMiddlewareMock,
+  requireScope: authMocks.requireScopeMock,
+  requirePermission: authMocks.requirePermissionMock,
+  requireMfa: authMocks.requireMfaMock,
+}));
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    transaction: vi.fn(),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  devices: { id: 'id', hostname: 'hostname' },
+  sites: { id: 'id', name: 'name' },
+  elevationRequests: {
+    id: 'id',
+    orgId: 'orgId',
+    siteId: 'siteId',
+    deviceId: 'deviceId',
+    flowType: 'flowType',
+    status: 'status',
+    requestedAt: 'requestedAt',
+    approvedAt: 'approvedAt',
+    expiresAt: 'expiresAt',
+  },
+  elevationAudit: { id: 'id' },
+  pamRules: {
+    id: 'id',
+    orgId: 'orgId',
+    priority: 'priority',
+    createdAt: 'createdAt',
+  },
+}));
+
+vi.mock('../services/auditEvents', () => ({
+  writeAuditEvent: vi.fn(),
+}));
+
+const busMocks = vi.hoisted(() => ({ publishEvent: vi.fn() }));
+vi.mock('../services/eventBus', () => ({ publishEvent: busMocks.publishEvent }));
+
+vi.mock('./softwarePolicies', () => ({
+  resolveOrgIdForWrite: vi.fn((auth: { orgId?: string }, orgId?: string) =>
+    orgId ? { orgId } : { orgId: auth?.orgId ?? undefined },
+  ),
+}));
+
+import { db } from '../db';
+import { pamRoutes } from './pam';
+
+const ORG_ID = '7b41c9a2-0000-4000-8000-000000000001';
+const REQ_ID = '7b41c9a2-0000-4000-8000-000000000002';
+const USER_ID = '7b41c9a2-0000-4000-8000-000000000003';
+
+function setAuth() {
+  authMocks.authMiddlewareMock.mockImplementation((c: any, next: any) => {
+    c.set('auth', {
+      user: { id: USER_ID, email: 't@example.com' },
+      scope: 'organization',
+      orgId: ORG_ID,
+      canAccessOrg: (orgId: string) => orgId === ORG_ID,
+      orgCondition: () => undefined,
+    });
+    c.set('permissions', undefined); // no site restriction
+    return next();
+  });
+}
+
+interface TxRigOptions {
+  row?: Record<string, unknown> | null;
+  casWins?: boolean;
+}
+
+function rigTransaction(opts: TxRigOptions) {
+  const updateSetCalls: unknown[] = [];
+  const auditInserts: unknown[] = [];
+  vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
+    const tx = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn().mockResolvedValue(opts.row ? [opts.row] : []),
+          })),
+        })),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn((setArg: unknown) => {
+          updateSetCalls.push(setArg);
+          return {
+            where: vi.fn(() => ({
+              returning: vi
+                .fn()
+                .mockResolvedValue(
+                  opts.casWins ? [{ id: REQ_ID, status: 'approved' }] : [],
+                ),
+            })),
+          };
+        }),
+      })),
+      insert: vi.fn(() => ({
+        values: vi.fn((v: unknown) => {
+          auditInserts.push(v);
+          return Promise.resolve();
+        }),
+      })),
+    };
+    return fn(tx);
+  });
+  return { updateSetCalls, auditInserts };
+}
+
+function app(): Hono {
+  const a = new Hono();
+  a.route('/pam', pamRoutes);
+  return a;
+}
+
+const activeRow = {
+  id: REQ_ID,
+  orgId: ORG_ID,
+  siteId: null,
+  deviceId: 'dev-1',
+  flowType: 'uac_intercept',
+  status: 'pending',
+};
+
+describe('POST /pam/elevation-requests/:id/respond', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setAuth();
+    busMocks.publishEvent.mockResolvedValue('evt');
+  });
+
+  it('approves a pending request (CAS wins) and emits elevation.approved', async () => {
+    const { updateSetCalls, auditInserts } = rigTransaction({ row: activeRow, casWins: true });
+
+    const res = await app().request(`/pam/elevation-requests/${REQ_ID}/respond`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ decision: 'approve', durationMinutes: 30 }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    const set = updateSetCalls[0] as { status: string; approvedByUserId: string; expiresAt: Date };
+    expect(set.status).toBe('approved');
+    expect(set.approvedByUserId).toBe(USER_ID);
+    expect(set.expiresAt.getTime()).toBeGreaterThan(Date.now());
+    expect(auditInserts.length).toBe(1);
+    expect(busMocks.publishEvent).toHaveBeenCalledWith(
+      'elevation.approved',
+      ORG_ID,
+      expect.objectContaining({ elevationRequestId: REQ_ID }),
+      'pam-admin',
+    );
+  });
+
+  it('denies with reason', async () => {
+    const { updateSetCalls } = rigTransaction({ row: activeRow, casWins: true });
+
+    const res = await app().request(`/pam/elevation-requests/${REQ_ID}/respond`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ decision: 'deny', reason: 'nope' }),
+    });
+
+    expect(res.status).toBe(200);
+    const set = updateSetCalls[0] as { status: string; denialReason: string };
+    expect(set.status).toBe('denied');
+    expect(set.denialReason).toBe('nope');
+  });
+
+  it('409s when the CAS loses (request no longer pending)', async () => {
+    rigTransaction({ row: { ...activeRow, status: 'denied' }, casWins: false });
+
+    const res = await app().request(`/pam/elevation-requests/${REQ_ID}/respond`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ decision: 'approve' }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(busMocks.publishEvent).not.toHaveBeenCalled();
+  });
+
+  it('404s for a row outside the caller org (canAccessOrg false)', async () => {
+    rigTransaction({ row: { ...activeRow, orgId: 'other-org' }, casWins: true });
+
+    const res = await app().request(`/pam/elevation-requests/${REQ_ID}/respond`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ decision: 'approve' }),
+    });
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /pam/elevation-requests/:id/revoke', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setAuth();
+    busMocks.publishEvent.mockResolvedValue('evt');
+  });
+
+  it('revokes an active elevation and emits elevation.revoked', async () => {
+    const { updateSetCalls } = rigTransaction({
+      row: { ...activeRow, status: 'approved' },
+      casWins: true,
+    });
+
+    const res = await app().request(`/pam/elevation-requests/${REQ_ID}/revoke`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason: 'compromised' }),
+    });
+
+    expect(res.status).toBe(200);
+    const set = updateSetCalls[0] as { status: string; revokedReason: string };
+    expect(set.status).toBe('revoked');
+    expect(set.revokedReason).toBe('compromised');
+    expect(busMocks.publishEvent).toHaveBeenCalledWith(
+      'elevation.revoked',
+      ORG_ID,
+      expect.objectContaining({ elevationRequestId: REQ_ID }),
+      'pam-admin',
+    );
+  });
+
+  it('409s when the request is not in an active status', async () => {
+    rigTransaction({ row: { ...activeRow, status: 'pending' }, casWins: false });
+
+    const res = await app().request(`/pam/elevation-requests/${REQ_ID}/revoke`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason: 'nope' }),
+    });
+
+    expect(res.status).toBe(409);
+  });
+
+  it('requires a reason', async () => {
+    rigTransaction({ row: { ...activeRow, status: 'approved' }, casWins: true });
+
+    const res = await app().request(`/pam/elevation-requests/${REQ_ID}/revoke`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /pam/rules', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setAuth();
+  });
+
+  it('rejects a rule with no executable criterion (400)', async () => {
+    const res = await app().request('/pam/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'naked rule',
+        verdict: 'auto_approve',
+        timeWindow: { start: '00:00', end: '23:59' },
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+  });
+
+  it('creates a rule with a criterion and lowercases the hash', async () => {
+    const returning = vi.fn().mockResolvedValue([
+      { id: 'rule-1', name: 'allow tool', verdict: 'auto_approve', priority: 100 },
+    ]);
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn(() => ({ returning })),
+    } as any);
+
+    const res = await app().request('/pam/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'allow tool',
+        verdict: 'auto_approve',
+        matchHash: 'A'.repeat(64),
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const valuesArg = (vi.mocked(db.insert).mock.results[0]!.value.values as any).mock
+      .calls[0][0] as { matchHash: string; orgId: string };
+    expect(valuesArg.matchHash).toBe('a'.repeat(64));
+    expect(valuesArg.orgId).toBe(ORG_ID);
+  });
+});

--- a/apps/api/src/routes/pam.ts
+++ b/apps/api/src/routes/pam.ts
@@ -1,0 +1,678 @@
+/**
+ * PAM admin control plane (#1163).
+ *
+ * The /api/v1/pam/* REST surface behind the /pam admin UI (#1159):
+ *   - GET    /elevation-requests          list/filter (Requests + Audit tabs)
+ *   - POST   /elevation-requests/:id/respond   approve / deny (CAS on pending)
+ *   - POST   /elevation-requests/:id/revoke    revoke mid-window
+ *   - GET    /active                      currently-active elevations
+ *   - GET/POST/PATCH/DELETE /rules        pam_rules CRUD (Rules tab)
+ *
+ * Tenancy: org isolation is enforced by RLS (every handler runs inside the
+ * request's withDbAccessContext); site narrowing for site-restricted techs
+ * is applied in-query via permissions.allowedSiteIds. Mutations are
+ * additionally gated app-layer with auth.canAccessOrg / site checks —
+ * defense in depth, same posture as routes/devices/actuateElevation.ts.
+ *
+ * Agent-side revoke commands (tech_jit_admin group-flip undo) are #1150
+ * scope: revoke/expiry here transitions state + audits + emits only. The
+ * #960 admin actuate route remains the path that issues agent commands.
+ */
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { SQL, and, desc, eq, gt, gte, inArray, isNull, lte, or, sql } from 'drizzle-orm';
+import { z } from 'zod';
+
+import { db } from '../db';
+import {
+  devices,
+  elevationAudit,
+  elevationRequests,
+  pamRules,
+  sites,
+} from '../db/schema';
+import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
+import { PERMISSIONS, canAccessSite, type UserPermissions } from '../services/permissions';
+import { writeAuditEvent } from '../services/auditEvents';
+import { publishEvent, type EventType } from '../services/eventBus';
+import { resolveOrgIdForWrite } from './softwarePolicies';
+
+const requirePamRead = requirePermission(
+  PERMISSIONS.DEVICES_READ.resource,
+  PERMISSIONS.DEVICES_READ.action,
+);
+const requirePamWrite = requirePermission(
+  PERMISSIONS.DEVICES_WRITE.resource,
+  PERMISSIONS.DEVICES_WRITE.action,
+);
+const requirePamExecute = requirePermission(
+  PERMISSIONS.DEVICES_EXECUTE.resource,
+  PERMISSIONS.DEVICES_EXECUTE.action,
+);
+
+// Bounds for approval windows. Default matches ingest's auto-approval
+// default in routes/agents/elevationRequests.ts.
+const DEFAULT_APPROVAL_DURATION_MINUTES = 15;
+const MAX_APPROVAL_DURATION_MINUTES = 24 * 60;
+
+const ACTIVE_STATUSES = ['approved', 'auto_approved', 'actuating'] as const;
+
+export const pamRoutes = new Hono();
+pamRoutes.use('*', authMiddleware);
+pamRoutes.use('*', requireScope('organization', 'partner', 'system'));
+
+/** Event emission is best-effort post-commit; never fail the request. */
+async function safePublish(
+  type: EventType,
+  orgId: string,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  try {
+    await publishEvent(type, orgId, payload, 'pam-admin');
+  } catch (err) {
+    console.error(`[PAM] event publish failed (${type}):`, err);
+  }
+}
+
+/** Site narrowing for site-restricted technicians (allowedSiteIds). */
+function siteScopeCondition(perms: UserPermissions | undefined): SQL | undefined {
+  if (!perms?.allowedSiteIds) return undefined;
+  if (perms.allowedSiteIds.length === 0) {
+    // Restricted to zero sites — match nothing.
+    return sql`false`;
+  }
+  return inArray(elevationRequests.siteId, perms.allowedSiteIds);
+}
+
+function getPagination(query: { page?: string; limit?: string }) {
+  const page = Math.max(1, Number.parseInt(query.page ?? '1', 10) || 1);
+  const limit = Math.min(100, Math.max(1, Number.parseInt(query.limit ?? '50', 10) || 50));
+  return { page, limit, offset: (page - 1) * limit };
+}
+
+// ============================================================
+// Elevation requests — list
+// ============================================================
+
+const listQuerySchema = z.object({
+  status: z
+    .enum(['pending', 'approved', 'auto_approved', 'denied', 'expired', 'revoked', 'actuating'])
+    .optional(),
+  flowType: z.enum(['uac_intercept', 'tech_jit_admin']).optional(),
+  deviceId: z.string().uuid().optional(),
+  siteId: z.string().uuid().optional(),
+  from: z.string().datetime({ offset: true }).optional(),
+  to: z.string().datetime({ offset: true }).optional(),
+  page: z.string().optional(),
+  limit: z.string().optional(),
+});
+
+pamRoutes.get('/elevation-requests', requirePamRead, zValidator('query', listQuerySchema), async (c) => {
+  const auth = c.get('auth');
+  const perms = c.get('permissions') as UserPermissions | undefined;
+  const q = c.req.valid('query');
+  const { page, limit, offset } = getPagination(q);
+
+  const conditions: (SQL | undefined)[] = [
+    auth.orgCondition(elevationRequests.orgId),
+    siteScopeCondition(perms),
+  ];
+  if (q.status) conditions.push(eq(elevationRequests.status, q.status));
+  if (q.flowType) conditions.push(eq(elevationRequests.flowType, q.flowType));
+  if (q.deviceId) conditions.push(eq(elevationRequests.deviceId, q.deviceId));
+  if (q.siteId) {
+    if (perms && !canAccessSite(perms, q.siteId)) {
+      return c.json({ error: 'Site access denied' }, 403);
+    }
+    conditions.push(eq(elevationRequests.siteId, q.siteId));
+  }
+  if (q.from) conditions.push(gte(elevationRequests.requestedAt, new Date(q.from)));
+  if (q.to) conditions.push(lte(elevationRequests.requestedAt, new Date(q.to)));
+
+  const where = and(...conditions.filter((cond): cond is SQL => cond !== undefined));
+
+  const [rows, countRows] = await Promise.all([
+    db
+      .select({
+        request: elevationRequests,
+        deviceHostname: devices.hostname,
+        siteName: sites.name,
+      })
+      .from(elevationRequests)
+      .leftJoin(devices, eq(elevationRequests.deviceId, devices.id))
+      .leftJoin(sites, eq(elevationRequests.siteId, sites.id))
+      .where(where)
+      .orderBy(desc(elevationRequests.requestedAt))
+      .limit(limit)
+      .offset(offset),
+    db
+      .select({ total: sql<number>`count(*)::int` })
+      .from(elevationRequests)
+      .where(where),
+  ]);
+
+  return c.json({
+    success: true,
+    requests: rows.map((r) => ({
+      ...r.request,
+      deviceHostname: r.deviceHostname,
+      siteName: r.siteName,
+    })),
+    pagination: { page, limit, total: countRows[0]?.total ?? 0 },
+  });
+});
+
+// ============================================================
+// Elevation requests — active
+// ============================================================
+
+pamRoutes.get('/active', requirePamRead, async (c) => {
+  const auth = c.get('auth');
+  const perms = c.get('permissions') as UserPermissions | undefined;
+
+  const where = and(
+    ...[
+      auth.orgCondition(elevationRequests.orgId),
+      siteScopeCondition(perms),
+      inArray(elevationRequests.status, [...ACTIVE_STATUSES]),
+      or(isNull(elevationRequests.expiresAt), gt(elevationRequests.expiresAt, new Date())),
+    ].filter((cond): cond is SQL => cond !== undefined),
+  );
+
+  const rows = await db
+    .select({
+      request: elevationRequests,
+      deviceHostname: devices.hostname,
+      siteName: sites.name,
+    })
+    .from(elevationRequests)
+    .leftJoin(devices, eq(elevationRequests.deviceId, devices.id))
+    .leftJoin(sites, eq(elevationRequests.siteId, sites.id))
+    .where(where)
+    .orderBy(desc(elevationRequests.approvedAt))
+    .limit(500);
+
+  return c.json({
+    success: true,
+    active: rows.map((r) => ({
+      ...r.request,
+      deviceHostname: r.deviceHostname,
+      siteName: r.siteName,
+    })),
+  });
+});
+
+// ============================================================
+// Elevation requests — respond (approve / deny)
+// ============================================================
+
+const respondSchema = z.object({
+  decision: z.enum(['approve', 'deny']),
+  reason: z.string().max(2000).optional(),
+  durationMinutes: z
+    .number()
+    .int()
+    .min(1)
+    .max(MAX_APPROVAL_DURATION_MINUTES)
+    .optional(),
+});
+
+pamRoutes.post(
+  '/elevation-requests/:id/respond',
+  requirePamExecute,
+  requireMfa(),
+  zValidator('json', respondSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    const id = c.req.param('id');
+    const body = c.req.valid('json');
+    if (!z.string().uuid().safeParse(id).success) {
+      return c.json({ error: 'Invalid elevation request id' }, 400);
+    }
+
+    const now = new Date();
+    const approve = body.decision === 'approve';
+    const durationMinutes = body.durationMinutes ?? DEFAULT_APPROVAL_DURATION_MINUTES;
+
+    const result = await db.transaction(async (tx) => {
+      const [row] = await tx
+        .select({
+          id: elevationRequests.id,
+          orgId: elevationRequests.orgId,
+          siteId: elevationRequests.siteId,
+          deviceId: elevationRequests.deviceId,
+          flowType: elevationRequests.flowType,
+          status: elevationRequests.status,
+        })
+        .from(elevationRequests)
+        .where(eq(elevationRequests.id, id))
+        .limit(1);
+
+      if (!row) return { kind: 'not_found' as const };
+      if (!auth.canAccessOrg(row.orgId)) return { kind: 'not_found' as const };
+      if (perms && row.siteId && !canAccessSite(perms, row.siteId)) {
+        return { kind: 'forbidden' as const };
+      }
+
+      // CAS: only a pending row can be decided. The WHERE clause re-checks
+      // status so a concurrent respond/reaper loses cleanly (0 rows).
+      const updated = await tx
+        .update(elevationRequests)
+        .set(
+          approve
+            ? {
+                status: 'approved',
+                approvedByUserId: auth.user.id,
+                approvedAt: now,
+                expiresAt: new Date(now.getTime() + durationMinutes * 60_000),
+                updatedAt: now,
+              }
+            : {
+                status: 'denied',
+                deniedByUserId: auth.user.id,
+                denialReason: body.reason ?? null,
+                updatedAt: now,
+              },
+        )
+        .where(and(eq(elevationRequests.id, id), eq(elevationRequests.status, 'pending')))
+        .returning({ id: elevationRequests.id, status: elevationRequests.status });
+
+      if (updated.length === 0) {
+        return { kind: 'conflict' as const, currentStatus: row.status };
+      }
+
+      await tx.insert(elevationAudit).values({
+        orgId: row.orgId,
+        elevationRequestId: row.id,
+        eventType: approve ? 'approved' : 'denied',
+        actor: 'technician',
+        actorUserId: auth.user.id,
+        details: {
+          reason: body.reason,
+          ...(approve ? { duration_minutes: durationMinutes } : {}),
+        },
+        occurredAt: now,
+      });
+
+      return { kind: 'ok' as const, row, newStatus: updated[0]!.status };
+    });
+
+    if (result.kind === 'not_found') {
+      return c.json({ error: 'Elevation request not found' }, 404);
+    }
+    if (result.kind === 'forbidden') {
+      return c.json({ error: 'Site access denied' }, 403);
+    }
+    if (result.kind === 'conflict') {
+      return c.json(
+        {
+          success: false,
+          error: `Request is not pending (current status: ${result.currentStatus})`,
+        },
+        409,
+      );
+    }
+
+    writeAuditEvent(c, {
+      orgId: result.row.orgId,
+      actorType: 'user',
+      actorId: auth.user.id,
+      action: approve ? 'pam.elevation_request.approve' : 'pam.elevation_request.deny',
+      resourceType: 'elevation_request',
+      resourceId: result.row.id,
+      details: { reason: body.reason, duration_minutes: approve ? durationMinutes : undefined },
+    });
+
+    await safePublish(
+      approve ? 'elevation.approved' : 'elevation.denied',
+      result.row.orgId,
+      {
+        elevationRequestId: result.row.id,
+        deviceId: result.row.deviceId,
+        flowType: result.row.flowType,
+        status: result.newStatus,
+        decidedByUserId: auth.user.id,
+      },
+    );
+
+    // NOTE: actuation of approved uac_intercept rows stays on the existing
+    // admin actuate route (#960) until #1150 makes the agent the credential
+    // authority — approving here does not enqueue an agent command.
+    return c.json({ success: true, id: result.row.id, status: result.newStatus });
+  },
+);
+
+// ============================================================
+// Elevation requests — revoke
+// ============================================================
+
+const revokeSchema = z.object({
+  reason: z.string().min(1).max(2000),
+});
+
+pamRoutes.post(
+  '/elevation-requests/:id/revoke',
+  requirePamExecute,
+  requireMfa(),
+  zValidator('json', revokeSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    const id = c.req.param('id');
+    const body = c.req.valid('json');
+    if (!z.string().uuid().safeParse(id).success) {
+      return c.json({ error: 'Invalid elevation request id' }, 400);
+    }
+
+    const now = new Date();
+    const result = await db.transaction(async (tx) => {
+      const [row] = await tx
+        .select({
+          id: elevationRequests.id,
+          orgId: elevationRequests.orgId,
+          siteId: elevationRequests.siteId,
+          deviceId: elevationRequests.deviceId,
+          flowType: elevationRequests.flowType,
+          status: elevationRequests.status,
+        })
+        .from(elevationRequests)
+        .where(eq(elevationRequests.id, id))
+        .limit(1);
+
+      if (!row) return { kind: 'not_found' as const };
+      if (!auth.canAccessOrg(row.orgId)) return { kind: 'not_found' as const };
+      if (perms && row.siteId && !canAccessSite(perms, row.siteId)) {
+        return { kind: 'forbidden' as const };
+      }
+
+      const updated = await tx
+        .update(elevationRequests)
+        .set({
+          status: 'revoked',
+          revokedAt: now,
+          revokedByUserId: auth.user.id,
+          revokedReason: body.reason,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(elevationRequests.id, id),
+            inArray(elevationRequests.status, [...ACTIVE_STATUSES]),
+          ),
+        )
+        .returning({ id: elevationRequests.id });
+
+      if (updated.length === 0) {
+        return { kind: 'conflict' as const, currentStatus: row.status };
+      }
+
+      await tx.insert(elevationAudit).values({
+        orgId: row.orgId,
+        elevationRequestId: row.id,
+        eventType: 'revoked',
+        actor: 'technician',
+        actorUserId: auth.user.id,
+        details: { reason: body.reason },
+        occurredAt: now,
+      });
+
+      return { kind: 'ok' as const, row };
+    });
+
+    if (result.kind === 'not_found') {
+      return c.json({ error: 'Elevation request not found' }, 404);
+    }
+    if (result.kind === 'forbidden') {
+      return c.json({ error: 'Site access denied' }, 403);
+    }
+    if (result.kind === 'conflict') {
+      return c.json(
+        {
+          success: false,
+          error: `Request is not active (current status: ${result.currentStatus})`,
+        },
+        409,
+      );
+    }
+
+    writeAuditEvent(c, {
+      orgId: result.row.orgId,
+      actorType: 'user',
+      actorId: auth.user.id,
+      action: 'pam.elevation_request.revoke',
+      resourceType: 'elevation_request',
+      resourceId: result.row.id,
+      details: { reason: body.reason },
+    });
+
+    await safePublish('elevation.revoked', result.row.orgId, {
+      elevationRequestId: result.row.id,
+      deviceId: result.row.deviceId,
+      flowType: result.row.flowType,
+      status: 'revoked',
+      revokedByUserId: auth.user.id,
+    });
+
+    // NOTE: for tech_jit_admin the agent-side group-flip undo command is
+    // #1150 scope; until it lands, revoke is a server-side state change
+    // (the expiry enforcer provides the time-bound safety net).
+    return c.json({ success: true, id: result.row.id, status: 'revoked' });
+  },
+);
+
+// ============================================================
+// Rules CRUD
+// ============================================================
+
+const ruleCriteriaFields = [
+  'matchSigner',
+  'matchHash',
+  'matchPathGlob',
+  'matchParentImage',
+  'matchUser',
+  'matchAdGroup',
+] as const;
+
+const timeWindowSchema = z.object({
+  start: z.string().regex(/^\d{1,2}:\d{2}$/),
+  end: z.string().regex(/^\d{1,2}:\d{2}$/),
+  days: z.array(z.number().int().min(0).max(6)).max(7).optional(),
+  timezone: z.string().max(64).optional(),
+});
+
+const ruleBaseSchema = z.object({
+  orgId: z.string().uuid().optional(),
+  siteId: z.string().uuid().nullable().optional(),
+  name: z.string().min(1).max(255),
+  description: z.string().max(2000).nullable().optional(),
+  enabled: z.boolean().optional(),
+  priority: z.number().int().min(0).max(100000).optional(),
+  matchSigner: z.string().min(1).max(255).nullable().optional(),
+  matchHash: z
+    .string()
+    .regex(/^[0-9a-fA-F]{64}$/, 'must be a sha256 hex digest')
+    .nullable()
+    .optional(),
+  matchPathGlob: z.string().min(1).max(4096).nullable().optional(),
+  matchParentImage: z.string().min(1).max(4096).nullable().optional(),
+  matchUser: z.string().min(1).max(255).nullable().optional(),
+  matchAdGroup: z.string().min(1).max(255).nullable().optional(),
+  timeWindow: timeWindowSchema.nullable().optional(),
+  verdict: z.enum(['auto_approve', 'auto_deny', 'require_approval', 'ignore']),
+  approvalDurationMinutes: z
+    .number()
+    .int()
+    .min(1)
+    .max(MAX_APPROVAL_DURATION_MINUTES)
+    .nullable()
+    .optional(),
+});
+
+// A rule must carry at least one executable-identifying criterion. A rule
+// scoped only by time window (or nothing) must never exist — it would match
+// every elevation in the org (catastrophic for verdict=auto_approve).
+function hasExecutableCriterion(rule: {
+  matchSigner?: string | null;
+  matchHash?: string | null;
+  matchPathGlob?: string | null;
+  matchParentImage?: string | null;
+  matchUser?: string | null;
+  matchAdGroup?: string | null;
+}): boolean {
+  return ruleCriteriaFields.some((f) => Boolean(rule[f]));
+}
+
+const createRuleSchema = ruleBaseSchema.refine(hasExecutableCriterion, {
+  message: 'At least one match criterion (signer/hash/path/parent/user/group) is required',
+});
+
+pamRoutes.get('/rules', requirePamRead, async (c) => {
+  const auth = c.get('auth');
+  const rows = await db
+    .select()
+    .from(pamRules)
+    .where(auth.orgCondition(pamRules.orgId))
+    .orderBy(pamRules.priority, pamRules.createdAt);
+  return c.json({ success: true, rules: rows });
+});
+
+pamRoutes.post('/rules', requirePamWrite, requireMfa(), zValidator('json', createRuleSchema), async (c) => {
+  const auth = c.get('auth');
+  const payload = c.req.valid('json');
+
+  const resolvedOrg = resolveOrgIdForWrite(auth, payload.orgId ?? c.req.query('orgId') ?? undefined);
+  if (!resolvedOrg.orgId) {
+    return c.json({ error: resolvedOrg.error ?? 'Organization resolution failed' }, 400);
+  }
+
+  const [created] = await db
+    .insert(pamRules)
+    .values({
+      orgId: resolvedOrg.orgId,
+      siteId: payload.siteId ?? null,
+      name: payload.name,
+      description: payload.description ?? null,
+      enabled: payload.enabled ?? true,
+      priority: payload.priority ?? 100,
+      matchSigner: payload.matchSigner ?? null,
+      matchHash: payload.matchHash ? payload.matchHash.toLowerCase() : null,
+      matchPathGlob: payload.matchPathGlob ?? null,
+      matchParentImage: payload.matchParentImage ?? null,
+      matchUser: payload.matchUser ?? null,
+      matchAdGroup: payload.matchAdGroup ?? null,
+      timeWindow: payload.timeWindow ?? null,
+      verdict: payload.verdict,
+      approvalDurationMinutes: payload.approvalDurationMinutes ?? null,
+      createdByUserId: auth.user.id,
+    })
+    .returning();
+
+  if (!created) {
+    return c.json({ error: 'Rule insert returned no row' }, 500);
+  }
+
+  writeAuditEvent(c, {
+    orgId: resolvedOrg.orgId,
+    actorType: 'user',
+    actorId: auth.user.id,
+    action: 'pam.rule.create',
+    resourceType: 'pam_rule',
+    resourceId: created.id,
+    details: { name: created.name, verdict: created.verdict, priority: created.priority },
+  });
+
+  return c.json({ success: true, rule: created }, 201);
+});
+
+const updateRuleSchema = ruleBaseSchema.partial().omit({ orgId: true });
+
+pamRoutes.patch('/rules/:id', requirePamWrite, requireMfa(), zValidator('json', updateRuleSchema), async (c) => {
+  const auth = c.get('auth');
+  const id = c.req.param('id');
+  const payload = c.req.valid('json');
+  if (!z.string().uuid().safeParse(id).success) {
+    return c.json({ error: 'Invalid rule id' }, 400);
+  }
+
+  const [existing] = await db.select().from(pamRules).where(eq(pamRules.id, id!)).limit(1);
+  if (!existing || !auth.canAccessOrg(existing.orgId)) {
+    return c.json({ error: 'Rule not found' }, 404);
+  }
+
+  // The merged result must still carry at least one criterion.
+  const merged = { ...existing, ...payload };
+  if (!hasExecutableCriterion(merged)) {
+    return c.json(
+      { error: 'At least one match criterion (signer/hash/path/parent/user/group) is required' },
+      400,
+    );
+  }
+
+  const [updated] = await db
+    .update(pamRules)
+    .set({
+      ...(payload.siteId !== undefined ? { siteId: payload.siteId } : {}),
+      ...(payload.name !== undefined ? { name: payload.name } : {}),
+      ...(payload.description !== undefined ? { description: payload.description } : {}),
+      ...(payload.enabled !== undefined ? { enabled: payload.enabled } : {}),
+      ...(payload.priority !== undefined ? { priority: payload.priority } : {}),
+      ...(payload.matchSigner !== undefined ? { matchSigner: payload.matchSigner } : {}),
+      ...(payload.matchHash !== undefined
+        ? { matchHash: payload.matchHash ? payload.matchHash.toLowerCase() : null }
+        : {}),
+      ...(payload.matchPathGlob !== undefined ? { matchPathGlob: payload.matchPathGlob } : {}),
+      ...(payload.matchParentImage !== undefined
+        ? { matchParentImage: payload.matchParentImage }
+        : {}),
+      ...(payload.matchUser !== undefined ? { matchUser: payload.matchUser } : {}),
+      ...(payload.matchAdGroup !== undefined ? { matchAdGroup: payload.matchAdGroup } : {}),
+      ...(payload.timeWindow !== undefined ? { timeWindow: payload.timeWindow } : {}),
+      ...(payload.verdict !== undefined ? { verdict: payload.verdict } : {}),
+      ...(payload.approvalDurationMinutes !== undefined
+        ? { approvalDurationMinutes: payload.approvalDurationMinutes }
+        : {}),
+      updatedAt: new Date(),
+    })
+    .where(eq(pamRules.id, id!))
+    .returning();
+
+  writeAuditEvent(c, {
+    orgId: existing.orgId,
+    actorType: 'user',
+    actorId: auth.user.id,
+    action: 'pam.rule.update',
+    resourceType: 'pam_rule',
+    resourceId: id,
+    details: { changed: Object.keys(payload) },
+  });
+
+  return c.json({ success: true, rule: updated });
+});
+
+pamRoutes.delete('/rules/:id', requirePamWrite, requireMfa(), async (c) => {
+  const auth = c.get('auth');
+  const id = c.req.param('id');
+  if (!z.string().uuid().safeParse(id).success) {
+    return c.json({ error: 'Invalid rule id' }, 400);
+  }
+
+  const [existing] = await db.select().from(pamRules).where(eq(pamRules.id, id!)).limit(1);
+  if (!existing || !auth.canAccessOrg(existing.orgId)) {
+    return c.json({ error: 'Rule not found' }, 404);
+  }
+
+  await db.delete(pamRules).where(eq(pamRules.id, id!));
+
+  writeAuditEvent(c, {
+    orgId: existing.orgId,
+    actorType: 'user',
+    actorId: auth.user.id,
+    action: 'pam.rule.delete',
+    resourceType: 'pam_rule',
+    resourceId: id,
+    details: { name: existing.name },
+  });
+
+  return c.json({ success: true });
+});

--- a/apps/api/src/services/eventBus.ts
+++ b/apps/api/src/services/eventBus.ts
@@ -91,7 +91,16 @@ export type EventType =
   | 'session.logout'
   // Service & process monitoring events
   | 'monitoring.check_failed'
-  | 'monitoring.check_recovered';
+  | 'monitoring.check_recovered'
+  // PAM elevation lifecycle events (#1163). Consumed by the /pam admin UI
+  // (#1159) via the events WS and by the Brain context feed (#1160).
+  | 'elevation.requested'
+  | 'elevation.auto_approved'
+  | 'elevation.approved'
+  | 'elevation.denied'
+  | 'elevation.activated'
+  | 'elevation.expired'
+  | 'elevation.revoked';
 
 export type EventPriority = 'low' | 'normal' | 'high' | 'critical';
 

--- a/apps/api/src/services/pamRuleEngine.test.ts
+++ b/apps/api/src/services/pamRuleEngine.test.ts
@@ -1,0 +1,226 @@
+/**
+ * PAM-native rule engine unit tests (#1163). Pure matcher — no DB.
+ */
+import { describe, expect, it } from 'vitest';
+import type { PamRule } from '../db/schema/pam';
+import { evaluatePamRules, isWithinTimeWindow, type PamRuleCandidate } from './pamRuleEngine';
+
+let seq = 0;
+function rule(overrides: Partial<PamRule>): PamRule {
+  seq += 1;
+  return {
+    id: overrides.id ?? `rule-${seq}`,
+    orgId: 'org-1',
+    siteId: null,
+    name: overrides.name ?? `rule ${seq}`,
+    description: null,
+    enabled: true,
+    priority: 100,
+    matchSigner: null,
+    matchHash: null,
+    matchPathGlob: null,
+    matchParentImage: null,
+    matchUser: null,
+    matchAdGroup: null,
+    timeWindow: null,
+    verdict: 'require_approval',
+    approvalDurationMinutes: null,
+    createdByUserId: null,
+    createdAt: new Date('2026-06-01T00:00:00Z'),
+    updatedAt: new Date('2026-06-01T00:00:00Z'),
+    ...overrides,
+  } as PamRule;
+}
+
+const candidate: PamRuleCandidate = {
+  targetExecutablePath: 'C:\\Program Files\\Vendor\\tool.exe',
+  targetExecutableHash: 'a'.repeat(64),
+  targetExecutableSigner: 'Vendor Inc.',
+  subjectUsername: 'CORP\\alice',
+  parentImage: 'C:\\Windows\\explorer.exe',
+};
+
+describe('evaluatePamRules', () => {
+  it('returns null when no rules', () => {
+    expect(evaluatePamRules([], candidate)).toBeNull();
+  });
+
+  it('matches on exact hash, case-insensitive', () => {
+    const r = rule({ matchHash: 'A'.repeat(64), verdict: 'auto_approve' });
+    expect(evaluatePamRules([r], candidate)?.verdict).toBe('auto_approve');
+  });
+
+  it('matches signer case-insensitively', () => {
+    const r = rule({ matchSigner: 'vendor inc.', verdict: 'auto_deny' });
+    expect(evaluatePamRules([r], candidate)?.verdict).toBe('auto_deny');
+  });
+
+  it('matches path via windows-style glob (* stays in segment, ** crosses)', () => {
+    const single = rule({ matchPathGlob: 'C:\\Program Files\\Vendor\\*.exe' });
+    const cross = rule({ matchPathGlob: 'C:\\Program Files\\**' });
+    const noCross = rule({ matchPathGlob: 'C:\\*' });
+    expect(evaluatePamRules([single], candidate)).not.toBeNull();
+    expect(evaluatePamRules([cross], candidate)).not.toBeNull();
+    expect(evaluatePamRules([noCross], candidate)).toBeNull();
+  });
+
+  it('matches parent image via glob', () => {
+    const r = rule({ matchParentImage: 'C:\\Windows\\*.exe' });
+    expect(evaluatePamRules([r], candidate)).not.toBeNull();
+    expect(
+      evaluatePamRules([r], { ...candidate, parentImage: undefined }),
+    ).toBeNull();
+  });
+
+  it('ANDs multiple criteria — all must match', () => {
+    const both = rule({
+      matchSigner: 'Vendor Inc.',
+      matchPathGlob: 'C:\\Program Files\\**',
+    });
+    const oneWrong = rule({
+      matchSigner: 'Vendor Inc.',
+      matchPathGlob: 'D:\\**',
+    });
+    expect(evaluatePamRules([both], candidate)).not.toBeNull();
+    expect(evaluatePamRules([oneWrong], candidate)).toBeNull();
+  });
+
+  it('a rule with no criteria never matches (no tenant-wide auto_approve)', () => {
+    const empty = rule({ verdict: 'auto_approve' });
+    expect(evaluatePamRules([empty], candidate)).toBeNull();
+  });
+
+  it('skips disabled rules', () => {
+    const r = rule({ matchSigner: 'Vendor Inc.', enabled: false });
+    expect(evaluatePamRules([r], candidate)).toBeNull();
+  });
+
+  it('hash criterion requires a hash on the candidate', () => {
+    const r = rule({ matchHash: 'b'.repeat(64) });
+    expect(
+      evaluatePamRules([r], { ...candidate, targetExecutableHash: undefined }),
+    ).toBeNull();
+  });
+
+  it('ad_group rules only match when groups are supplied', () => {
+    const r = rule({ matchAdGroup: 'Helpdesk' });
+    expect(evaluatePamRules([r], candidate)).toBeNull();
+    expect(
+      evaluatePamRules([r], { ...candidate, subjectAdGroups: ['HELPDESK'] }),
+    ).not.toBeNull();
+  });
+
+  it('lowest priority number wins; ties break by createdAt then id', () => {
+    const low = rule({
+      id: 'low',
+      priority: 10,
+      matchSigner: 'Vendor Inc.',
+      verdict: 'auto_deny',
+    });
+    const high = rule({
+      id: 'high',
+      priority: 200,
+      matchSigner: 'Vendor Inc.',
+      verdict: 'auto_approve',
+    });
+    // Order given shouldn't matter.
+    expect(evaluatePamRules([high, low], candidate)?.ruleId).toBe('low');
+
+    const older = rule({
+      id: 'older',
+      priority: 50,
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      matchSigner: 'Vendor Inc.',
+    });
+    const newer = rule({
+      id: 'newer',
+      priority: 50,
+      createdAt: new Date('2026-05-01T00:00:00Z'),
+      matchSigner: 'Vendor Inc.',
+    });
+    expect(evaluatePamRules([newer, older], candidate)?.ruleId).toBe('older');
+  });
+
+  it('first matching rule wins even if a later rule also matches', () => {
+    const ignore = rule({
+      priority: 1,
+      matchPathGlob: 'C:\\Program Files\\**',
+      verdict: 'ignore',
+    });
+    const deny = rule({
+      priority: 2,
+      matchSigner: 'Vendor Inc.',
+      verdict: 'auto_deny',
+    });
+    expect(evaluatePamRules([deny, ignore], candidate)?.verdict).toBe('ignore');
+  });
+
+  it('returns approvalDurationMinutes from the matched rule', () => {
+    const r = rule({
+      matchSigner: 'Vendor Inc.',
+      verdict: 'auto_approve',
+      approvalDurationMinutes: 30,
+    });
+    expect(evaluatePamRules([r], candidate)?.approvalDurationMinutes).toBe(30);
+  });
+});
+
+describe('isWithinTimeWindow', () => {
+  // 2026-06-09T15:30:00Z is a Tuesday.
+  const tueAfternoonUtc = new Date('2026-06-09T15:30:00Z');
+
+  it('inside a same-day window (UTC default)', () => {
+    expect(isWithinTimeWindow({ start: '09:00', end: '17:00' }, tueAfternoonUtc)).toBe(true);
+  });
+
+  it('outside the window', () => {
+    expect(isWithinTimeWindow({ start: '16:00', end: '17:00' }, tueAfternoonUtc)).toBe(false);
+  });
+
+  it('overnight window wraps midnight', () => {
+    const lateUtc = new Date('2026-06-09T23:30:00Z');
+    expect(isWithinTimeWindow({ start: '22:00', end: '06:00' }, lateUtc)).toBe(true);
+    expect(isWithinTimeWindow({ start: '22:00', end: '06:00' }, tueAfternoonUtc)).toBe(false);
+  });
+
+  it('day-of-week restriction', () => {
+    // Tuesday = 2
+    expect(
+      isWithinTimeWindow({ start: '09:00', end: '17:00', days: [2] }, tueAfternoonUtc),
+    ).toBe(true);
+    expect(
+      isWithinTimeWindow({ start: '09:00', end: '17:00', days: [0, 6] }, tueAfternoonUtc),
+    ).toBe(false);
+  });
+
+  it('timezone shifts the evaluation (15:30Z = 10:30 in Chicago)', () => {
+    expect(
+      isWithinTimeWindow(
+        { start: '09:00', end: '11:00', timezone: 'America/Chicago' },
+        tueAfternoonUtc,
+      ),
+    ).toBe(true);
+    expect(
+      isWithinTimeWindow(
+        { start: '09:00', end: '11:00', timezone: 'UTC' },
+        tueAfternoonUtc,
+      ),
+    ).toBe(false);
+  });
+
+  it('malformed times or timezone never activate the rule', () => {
+    expect(isWithinTimeWindow({ start: '9am', end: '17:00' }, tueAfternoonUtc)).toBe(false);
+    expect(isWithinTimeWindow({ start: '25:00', end: '26:00' }, tueAfternoonUtc)).toBe(false);
+    expect(
+      isWithinTimeWindow(
+        { start: '09:00', end: '17:00', timezone: 'Not/AZone' },
+        tueAfternoonUtc,
+      ),
+    ).toBe(false);
+  });
+
+  it('time-window-only rules still never match (no executable criterion)', () => {
+    const r = rule({ timeWindow: { start: '00:00', end: '23:59' }, verdict: 'auto_approve' });
+    expect(evaluatePamRules([r], candidate)).toBeNull();
+  });
+});

--- a/apps/api/src/services/pamRuleEngine.ts
+++ b/apps/api/src/services/pamRuleEngine.ts
@@ -1,0 +1,173 @@
+/**
+ * PAM-native rule engine (#1163).
+ *
+ * Pure matcher over `pam_rules` rows for an elevation candidate. Consulted
+ * by ingest (routes/agents/elevationRequests.ts) AFTER the software-policy
+ * bridge (services/pamBridge.ts) returns no binding verdict. Same contract
+ * as the bridge: verdict in, side-effect-free verdict out — the caller does
+ * all inserts/audits/events.
+ *
+ * Matching semantics
+ * ------------------
+ * - Rules are evaluated in (priority ASC, createdAt ASC, id ASC) order;
+ *   the FIRST enabled rule whose criteria all match wins.
+ * - All provided criteria on a rule are ANDed. A rule with no criteria at
+ *   all matches nothing (the API layer rejects creating those, but the
+ *   engine guards anyway — a criteria-less rule must never become a
+ *   tenant-wide auto_approve).
+ * - signer / user: exact, case-insensitive.
+ * - hash: exact, case-insensitive (sha256 hex).
+ * - path / parent image: Windows-style case-insensitive glob via
+ *   pamBridge.matchPathGlob (shared semantics — `*` is single-segment,
+ *   `**` crosses segments).
+ * - ad_group: matches only when the caller supplies the subject's group
+ *   list (the uac_intercept ingest payload doesn't today, so ad_group
+ *   rules simply never match that flow until the agent ships groups).
+ * - time_window: "HH:MM"–"HH:MM" with optional days[0-6] in the window's
+ *   timezone (default UTC). Overnight windows (start > end) wrap midnight.
+ */
+import type { PamRule, PamRuleTimeWindow } from '../db/schema/pam';
+import { matchPathGlob } from './pamBridge';
+
+export interface PamRuleCandidate {
+  targetExecutablePath: string;
+  targetExecutableHash?: string;
+  targetExecutableSigner?: string;
+  subjectUsername: string;
+  parentImage?: string;
+  /** AD/local group names of the subject, when known. */
+  subjectAdGroups?: string[];
+  /** Evaluation instant; injectable for tests. Defaults to now. */
+  at?: Date;
+}
+
+export interface PamRuleMatch {
+  ruleId: string;
+  ruleName: string;
+  verdict: PamRule['verdict'];
+  approvalDurationMinutes: number | null;
+}
+
+const eqCi = (a: string, b: string) => a.toLowerCase() === b.toLowerCase();
+
+// A time window NARROWS a rule; it is not an identifying criterion on its
+// own. A rule whose only "criterion" is a time window would match every
+// elevation in the org while active — catastrophic for verdict=auto_approve.
+// The API layer rejects creating such rules; the engine refuses them too.
+function hasAnyCriteria(rule: PamRule): boolean {
+  return Boolean(
+    rule.matchSigner ||
+      rule.matchHash ||
+      rule.matchPathGlob ||
+      rule.matchParentImage ||
+      rule.matchUser ||
+      rule.matchAdGroup,
+  );
+}
+
+/** Exported for tests. */
+export function isWithinTimeWindow(window: PamRuleTimeWindow, at: Date): boolean {
+  const parse = (s: string): number | null => {
+    const m = /^(\d{1,2}):(\d{2})$/.exec(s);
+    if (!m) return null;
+    const h = Number(m[1]);
+    const min = Number(m[2]);
+    if (h > 23 || min > 59) return null;
+    return h * 60 + min;
+  };
+  const start = parse(window.start);
+  const end = parse(window.end);
+  if (start === null || end === null) return false; // malformed → never active
+
+  // Resolve weekday + minutes in the window's timezone (default UTC).
+  let weekday: number;
+  let minutes: number;
+  try {
+    const fmt = new Intl.DateTimeFormat('en-US', {
+      timeZone: window.timezone ?? 'UTC',
+      weekday: 'short',
+      hour: 'numeric',
+      minute: 'numeric',
+      hour12: false,
+    });
+    const parts = fmt.formatToParts(at);
+    const get = (type: string) => parts.find((p) => p.type === type)?.value ?? '';
+    const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    weekday = dayNames.indexOf(get('weekday'));
+    // 'hour' can render as "24" for midnight in some ICU versions; normalize.
+    minutes = (Number(get('hour')) % 24) * 60 + Number(get('minute'));
+  } catch {
+    return false; // bad timezone string → never active
+  }
+  if (weekday < 0 || Number.isNaN(minutes)) return false;
+
+  if (window.days && window.days.length > 0 && !window.days.includes(weekday)) {
+    return false;
+  }
+  // Overnight windows (e.g. 22:00–06:00) wrap midnight.
+  return start <= end
+    ? minutes >= start && minutes <= end
+    : minutes >= start || minutes <= end;
+}
+
+function ruleMatches(rule: PamRule, candidate: PamRuleCandidate): boolean {
+  if (!hasAnyCriteria(rule)) return false;
+
+  if (rule.matchHash) {
+    if (!candidate.targetExecutableHash) return false;
+    if (!eqCi(rule.matchHash, candidate.targetExecutableHash)) return false;
+  }
+  if (rule.matchSigner) {
+    if (!candidate.targetExecutableSigner) return false;
+    if (!eqCi(rule.matchSigner, candidate.targetExecutableSigner)) return false;
+  }
+  if (rule.matchPathGlob) {
+    if (!matchPathGlob(rule.matchPathGlob, candidate.targetExecutablePath)) return false;
+  }
+  if (rule.matchParentImage) {
+    if (!candidate.parentImage) return false;
+    if (!matchPathGlob(rule.matchParentImage, candidate.parentImage)) return false;
+  }
+  if (rule.matchUser) {
+    if (!eqCi(rule.matchUser, candidate.subjectUsername)) return false;
+  }
+  if (rule.matchAdGroup) {
+    const groups = candidate.subjectAdGroups ?? [];
+    if (!groups.some((g) => eqCi(g, rule.matchAdGroup!))) return false;
+  }
+  if (rule.timeWindow) {
+    if (!isWithinTimeWindow(rule.timeWindow, candidate.at ?? new Date())) return false;
+  }
+  return true;
+}
+
+/**
+ * Evaluate a candidate against a pre-fetched, RLS-scoped list of rules.
+ * Returns the first matching enabled rule in priority order, or null.
+ * The caller fetches rules (org-scoped, optionally site-narrowed) — this
+ * function is pure so tests and the offline-cache sync can reuse it.
+ */
+export function evaluatePamRules(
+  rules: PamRule[],
+  candidate: PamRuleCandidate,
+): PamRuleMatch | null {
+  const ordered = [...rules].sort((a, b) => {
+    if (a.priority !== b.priority) return a.priority - b.priority;
+    const at = a.createdAt?.getTime() ?? 0;
+    const bt = b.createdAt?.getTime() ?? 0;
+    if (at !== bt) return at - bt;
+    return a.id.localeCompare(b.id);
+  });
+  for (const rule of ordered) {
+    if (!rule.enabled) continue;
+    if (ruleMatches(rule, candidate)) {
+      return {
+        ruleId: rule.id,
+        ruleName: rule.name,
+        verdict: rule.verdict,
+        approvalDurationMinutes: rule.approvalDurationMinutes ?? null,
+      };
+    }
+  }
+  return null;
+}

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -169,6 +169,7 @@ export const ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'oauth_grants',
   'oauth_refresh_tokens',
   'organization_users',
+  'pam_rules',
   'patch_approvals',
   'patch_compliance_reports',
   'patch_compliance_snapshots',


### PR DESCRIPTION
Implements **#1163** per the plan in `docs/superpowers/plans/2026-06-09-pam-backend-control-plane.md` (merged in #1166). This is the missing control plane between the merged PAM data/agent layer (#905 / #906 / #907 / #959 / #960) and the /pam admin UI (#1159) — after this, #1159 has real endpoints + a live event feed, and a technician can list/approve/deny/revoke elevations end-to-end via the API.

## What's here

**1. `pam_rules` schema + migration** — `db/schema/pam.ts` + `migrations/2026-06-09-pam-rules.sql`. Shape-1 (direct `org_id`) with RLS enabled+forced+policies mirroring the #905 elevation tables; verdict enum `auto_approve | auto_deny | require_approval | ignore`; `(org_id, enabled, priority)` index; idempotent migration, no inner txn.

**2. Decisioning wired into ingest** (`routes/agents/elevationRequests.ts`) — `evaluatePamBridge` (#906, previously zero call sites) runs first: allowlist → `auto_approved` (+expiry), blocklist → `denied`. No policy bound → PAM-native rules via a new pure `services/pamRuleEngine.ts` (priority order, ANDed criteria, shared `matchPathGlob` glob semantics, tz-aware time windows with overnight wrap). `ignore` suppresses the queue row (general-audit-logged). **Decisioning errors fail SAFE to `pending`** — an evaluator outage can never become an auto-approval. Every outcome writes `elevation_audit` + emits an `elevation.*` event; bridge audit-mode hits land as `evidence_attached`.

**3. Admin REST API** (`routes/pam.ts`, mounted at `/api/v1/pam`) — `GET /elevation-requests` (status/flow/device/site/date filters, pagination, device+site names, `allowedSiteIds` narrowing), `POST /:id/respond` (**CAS on `pending`** — concurrent decide/reap loses cleanly with 409), `POST /:id/revoke` (CAS on active statuses), `GET /active`, full rules CRUD. `DEVICES_READ/WRITE/EXECUTE` gates + `requireMfa()` on mutations (mirrors the actuate route + softwarePolicies); `runAction`-compatible bodies.

**4. Lifecycle jobs** (`jobs/pamJobs.ts`) — `elevation-expiry-enforcer` (60s) + `stale-request-expirer` (5m, TTL via `PAM_PENDING_REQUEST_TTL_MINUTES`, default 15), cloned from `approvalExpiryReaper` (CTE-bounded `FOR UPDATE SKIP LOCKED`, `withSystemDbAccessContext`, audit + event per transition, init/shutdown registered in `index.ts`).

**5. Events** — `elevation.requested / auto_approved / approved / denied / activated / expired / revoked` added to the `EventType` union; emitted from ingest, respond/revoke, and both reapers (`elevation.activated` is emitted nowhere yet — that's the actuator-success hook, #960/#1150 territory, left for that work as the plan suggests).

## Deliberate scope decisions (flagging for review)

- **No agent changes, no actuator auto-queue.** The plan's "queue the actuator on auto-approve/approve" step would require sending server-side credentials that #1150 explicitly deprecates ("a server cannot set a local Windows account's password"). Approving here transitions state only; the existing #960 admin actuate route stays the actuation path until #1150 lands. `tech_jit_admin` revoke/expiry likewise degrade to audited state changes.
- **`ignore` rules create no `elevation_requests` row** (the approval queue stays signal-only); the observation is still recorded via the general audit log. Happy to flip this to insert-then-suppress if you'd rather keep the PAM audit chain complete.
- **A rule must carry ≥1 executable-identifying criterion** (signer/hash/path/parent/user/group) — enforced in the API *and* the engine. A time-window-only rule would otherwise match every elevation in the org while active (tenant-wide auto-approve). Test-covered.

## Verification (local, CI-replica)

- **API**: `tsc --noEmit` clean; **5997/5997** unit tests pass (43 new: rule engine 20, pam routes 9, ingest decisioning 14 incl. fail-safe + CAS paths).
- **Web**: **807/807** pass in a clean `node:22` container (pnpm 10.33.4, frozen lockfile).
- **Security**: `pnpm audit --audit-level=critical` clean · Trivy fs HIGH/CRIT exit 0 · gitleaks clean · `govulncheck` (linux, CGO off) 0 reachable vulns.
- **Agent**: untouched — `git diff main..HEAD -- agent/` is empty.
- Migration ordering covered by `autoMigrate.test.ts` (in the green API run). RLS contract: `pam_rules` is Shape-1 so it's auto-discovered by `rls-coverage.integration.test.ts`; cross-tenant insert verification needs the real-DB integration run (CI smoke job).

Closes #1163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)