### PR TITLE
fix(agent): normalize CRLF/CR to LF for bash/python scripts before execution (#1184)

### DIFF
--- a/agent/internal/executor/shell.go
+++ b/agent/internal/executor/shell.go
@@ -81,8 +81,26 @@ func GetScriptExtension(scriptType string) string {
 	}
 }
 
+// normalizeLineEndings converts CRLF (and stray CR) to LF for script types
+// interpreted by unix tooling. Scripts authored or pasted in a browser on
+// Windows arrive with \r\n; bash then sees tokens like `then\r` / `elif\r`
+// and fails with "syntax error near unexpected token" (#1184) — or, for
+// simple command lines, silently passes a trailing \r into arguments.
+// PowerShell and cmd handle (and in .bat's case, sometimes require) CRLF,
+// so Windows-native script types are left untouched.
+func normalizeLineEndings(content, scriptType string) string {
+	switch strings.ToLower(scriptType) {
+	case ScriptTypeBash, ScriptTypePython:
+		content = strings.ReplaceAll(content, "\r\n", "\n")
+		return strings.ReplaceAll(content, "\r", "\n")
+	default:
+		return content
+	}
+}
+
 // WriteScriptFile writes script content to a temporary file with the appropriate extension
 func WriteScriptFile(content, scriptType string) (string, error) {
+	content = normalizeLineEndings(content, scriptType)
 	// Get the temp directory
 	tempDir := os.TempDir()
 	scriptDir := filepath.Join(tempDir, "breeze-scripts")

--- a/agent/internal/executor/shell_crlf_test.go
+++ b/agent/internal/executor/shell_crlf_test.go
@@ -1,0 +1,99 @@
+package executor
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// #1184: user-created bash scripts with if/elif blocks fail when the content
+// carries CRLF line endings (browser-authored on Windows). bash is invoked
+// explicitly on the temp file, so `then\r` / `elif\r` are syntax errors.
+// WriteScriptFile must normalize EOLs for unix-interpreted script types and
+// leave Windows-native types (powershell, cmd) untouched.
+
+const crlfBashScript = "#!/bin/bash\r\n" +
+	"if command -v apt &> /dev/null; then\r\n" +
+	"    echo \"apt found\"\r\n" +
+	"elif command -v dnf &> /dev/null; then\r\n" +
+	"    echo \"dnf found\"\r\n" +
+	"else\r\n" +
+	"    echo \"unknown\"\r\n" +
+	"fi\r\n"
+
+func readScript(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read script file: %v", err)
+	}
+	return string(b)
+}
+
+func TestWriteScriptFileNormalizesEOLs(t *testing.T) {
+	tests := []struct {
+		name       string
+		scriptType string
+		content    string
+		wantCR     bool
+	}{
+		{"bash CRLF stripped", ScriptTypeBash, crlfBashScript, false},
+		{"bash lone CR stripped", ScriptTypeBash, "#!/bin/bash\rif true; then\recho hi\rfi\r", false},
+		{"python CRLF stripped", ScriptTypePython, "import sys\r\nprint(\"hi\")\r\n", false},
+		{"powershell CRLF preserved", ScriptTypePowerShell, "Write-Host 'a'\r\nWrite-Host 'b'\r\n", true},
+		{"cmd CRLF preserved", ScriptTypeCMD, "@echo off\r\necho hi\r\n", true},
+		{"bash LF unchanged", ScriptTypeBash, "#!/bin/bash\necho hi\n", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, err := WriteScriptFile(tt.content, tt.scriptType)
+			if err != nil {
+				t.Fatalf("WriteScriptFile: %v", err)
+			}
+			defer CleanupScript(path)
+			got := readScript(t, path)
+			hasCR := strings.Contains(got, "\r")
+			if hasCR != tt.wantCR {
+				t.Fatalf("CR presence = %v, want %v (content %q)", hasCR, tt.wantCR, got)
+			}
+			// Normalization must not lose any lines.
+			wantLines := strings.Count(strings.ReplaceAll(tt.content, "\r\n", "\n"), "\n")
+			gotLines := strings.Count(strings.ReplaceAll(got, "\r\n", "\n"), "\n")
+			if gotLines < wantLines {
+				t.Fatalf("line count shrank: got %d want >= %d", gotLines, wantLines)
+			}
+		})
+	}
+}
+
+// End-to-end repro from #1184: the exact reported script, with CRLF, must
+// now execute and produce stdout + exit 0 on unix.
+func TestExecuteCRLFBashIfElif(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash execution path; unix only")
+	}
+	if _, err := os.Stat("/bin/bash"); err != nil {
+		t.Skip("/bin/bash not available")
+	}
+	e := New(nil)
+	res, err := e.Execute(ScriptExecution{
+		ID:         "crlf-1184",
+		Script:     crlfBashScript,
+		ScriptType: ScriptTypeBash,
+		Timeout:    30,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v (error=%q stderr=%q)", err, res.Error, res.Stderr)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("exit=%d want 0; stderr=%q", res.ExitCode, res.Stderr)
+	}
+	out := strings.TrimSpace(res.Stdout)
+	if out != "apt found" && out != "dnf found" && out != "unknown" {
+		t.Fatalf("unexpected stdout %q", res.Stdout)
+	}
+	if strings.Contains(res.Stderr, "syntax error") {
+		t.Fatalf("syntax error leaked: %q", res.Stderr)
+	}
+}


### PR DESCRIPTION
Fixes **#1184** — user-created bash scripts with `if/elif` blocks failing while pre-shipped identical scripts work.

## Root cause (repro-verified)

Ran the exact reported script through the real `internal/executor` in a linux container, LF vs CRLF:

| Content | Result |
|---|---|
| LF | exit 0, `apt found` |
| CRLF | **exit 2, `syntax error near unexpected token 'elif' … '\r'`** |

The executor invokes `/bin/bash <tempfile>` explicitly, so CRLF content makes bash parse `then\r` / `elif\r` as malformed tokens. Browser-authored/pasted scripts on Windows carry `\r\n`; pre-shipped scripts are stored with LF — exactly the reported asymmetry. The reporter's workaround (plain `apt` lines, no control structures) works because a trailing `\r` on a simple command just rides along in the argument instead of breaking a syntax token. The reporter's line-ending hypothesis was correct.

## Fix

`WriteScriptFile` now normalizes `\r\n` and stray `\r` to `\n` for **unix-interpreted script types (bash, python)** before writing the temp file. PowerShell and cmd are deliberately untouched (CRLF-tolerant; `.bat` can require CRLF). Fixing at the agent covers every source — UI-created, API-created, automations, and scripts already stored with CRLF — with no server/data migration.

## Note on the "silent" part of the report

Agent-side this failure is *not* silent (stderr + exit 2 are produced, as the repro shows). The report's empty stderr / missing exit code in Execution Details may be a separate result-display issue worth a quick look — this PR fixes the underlying execution failure either way.

## Verification (linux container, CI-exact `CGO_ENABLED=0`)

- New `TestWriteScriptFileNormalizesEOLs` (6 cases: bash CRLF/lone-CR/LF, python CRLF, ps1 + bat preservation) — pass
- New `TestExecuteCRLFBashIfElif` end-to-end with the exact #1184 script — exit 0, correct stdout, no syntax error
- `go vet` clean; full `./internal/executor` package **ok** (run as non-root)

Fixes #1184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)