### PR TITLE
feat(api): surface watchdogState .catch collapse on heartbeat — observability for masked failover (#1121)

### DIFF
--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -747,3 +747,40 @@ describe('POST /agents/:id/heartbeat — watchdog-branch agent recovery upgradeT
     expect(body.upgradeTo).toBeUndefined();
   });
 });
+
+
+describe('detectWatchdogStateCollapse (#1121)', () => {
+  it('reports a collapse when raw body carried watchdogState but validation dropped it', async () => {
+    const { detectWatchdogStateCollapse } = await import('./heartbeat');
+    expect(
+      detectWatchdogStateCollapse({ agentVersion: '1', watchdogState: 42 }, undefined),
+    ).toEqual({ field: 'watchdogState', rawValue: '42' });
+    expect(
+      detectWatchdogStateCollapse({ watchdogState: { nested: true } }, undefined),
+    ).toEqual({ field: 'watchdogState', rawValue: '{"nested":true}' });
+  });
+
+  it('truncates oversized raw values to 100 chars', async () => {
+    const { detectWatchdogStateCollapse } = await import('./heartbeat');
+    const big = 'x'.repeat(5000);
+    // An oversized STRING would actually pass z.string(); simulate a
+    // corrupted huge non-string payload via an array of strings.
+    const res = detectWatchdogStateCollapse({ watchdogState: [big] }, undefined);
+    expect(res).not.toBeNull();
+    expect(res!.rawValue!.length).toBeLessThanOrEqual(100);
+  });
+
+  it('returns null when validation kept a value (no collapse)', async () => {
+    const { detectWatchdogStateCollapse } = await import('./heartbeat');
+    expect(
+      detectWatchdogStateCollapse({ watchdogState: 'FAILOVER' }, 'FAILOVER'),
+    ).toBeNull();
+  });
+
+  it('returns null when the raw body never had the key (normal main-agent heartbeat)', async () => {
+    const { detectWatchdogStateCollapse } = await import('./heartbeat');
+    expect(detectWatchdogStateCollapse({ agentVersion: '1' }, undefined)).toBeNull();
+    expect(detectWatchdogStateCollapse(null, undefined)).toBeNull();
+    expect(detectWatchdogStateCollapse('not-an-object', undefined)).toBeNull();
+  });
+});

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -30,6 +30,28 @@ import { captureException } from '../../services/sentry';
 import { resolveRemoteAccessForDevice } from '../../services/remoteAccessPolicy';
 import { getActiveTrustKeyset, type ManifestTrustKey } from '../../services/manifestSigning';
 
+/**
+ * #1121 — pure collapse detector for the watchdogState tolerance gap.
+ * Returns the structured-warn payload when the RAW heartbeat body carried a
+ * `watchdogState` key but schema validation collapsed it to undefined (the
+ * `.catch(undefined)` firing on a corrupted value), else null. Exported for
+ * unit tests; the route handler owns the actual console.warn.
+ */
+export function detectWatchdogStateCollapse(
+  rawBody: unknown,
+  validatedWatchdogState: string | undefined,
+): { field: 'watchdogState'; rawValue: string | undefined } | null {
+  if (validatedWatchdogState !== undefined) return null;
+  if (!rawBody || typeof rawBody !== 'object') return null;
+  const rawState = (rawBody as Record<string, unknown>).watchdogState;
+  if (rawState === undefined) return null;
+  const rawValue =
+    typeof rawState === 'string'
+      ? rawState.slice(0, 100)
+      : JSON.stringify(rawState)?.slice(0, 100);
+  return { field: 'watchdogState', rawValue };
+}
+
 export const heartbeatRoutes = new Hono();
 
 heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onError: (c) => c.json({ error: 'Request body too large' }, 413) }), zValidator('json', heartbeatSchema), async (c) => {
@@ -39,6 +61,32 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
 
   if (!agent?.deviceId) {
     return c.json({ error: 'Agent context not found' }, 401);
+  }
+
+  // #1121 — observability for the #1065 tolerance trade-off. watchdogState is
+  // an optional informational field guarded by .catch(undefined) in
+  // heartbeatSchema; if a corrupted value collapses to undefined, the
+  // `data.watchdogState === 'FAILOVER'` mapping below silently records
+  // watchdogStatus='connected', masking a genuine failover as healthy
+  // (pre-#1065 the same corruption produced a loud 400). Detect the collapse
+  // — raw body carried the key but the validated payload lost it — and emit
+  // a structured warn so it lands in logs/Sentry breadcrumbs instead of
+  // being indistinguishable from a healthy heartbeat. Hono caches the parsed
+  // JSON body (zValidator already consumed it), so the re-read is free; the
+  // check is gated to watchdog-role heartbeats, the only senders of the field.
+  if (agent.role === 'watchdog' && data.watchdogState === undefined) {
+    try {
+      const raw: unknown = await c.req.json();
+      const collapse = detectWatchdogStateCollapse(raw, data.watchdogState);
+      if (collapse) {
+        console.warn(
+          '[heartbeat] watchdogState collapsed by schema .catch — possible masked failover (#1121)',
+          { deviceId: agent.deviceId, agentId, ...collapse },
+        );
+      }
+    } catch {
+      // Raw body unavailable — nothing to report.
+    }
   }
 
   // #1105 — run the RLS-scoped DB work in a SHORT-LIVED context that is

--- a/apps/api/src/routes/agents/schemas.heartbeatTolerance.test.ts
+++ b/apps/api/src/routes/agents/schemas.heartbeatTolerance.test.ts
@@ -199,3 +199,35 @@ describe('heartbeatSchema — Layer A tolerance', () => {
     expect(result.success).toBe(false);
   });
 });
+
+// #1121 — the watchdogState collapse premise: a corrupted (non-string) value
+// must drop to undefined rather than 400 the heartbeat. The route-side
+// observability for this collapse is detectWatchdogStateCollapse in
+// heartbeat.ts (unit-tested in heartbeat.test.ts).
+describe('heartbeatSchema — watchdogState .catch collapse (#1121)', () => {
+  const minimal = { status: 'ok' as const, agentVersion: '0.65.15' };
+
+  it('corrupted watchdogState (number) collapses to undefined, heartbeat still parses', () => {
+    const result = heartbeatSchema.safeParse({
+      ...minimal,
+      role: 'watchdog',
+      watchdogState: 42,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.watchdogState).toBeUndefined();
+    }
+  });
+
+  it('valid FAILOVER passes through untouched', () => {
+    const result = heartbeatSchema.safeParse({
+      ...minimal,
+      role: 'watchdog',
+      watchdogState: 'FAILOVER',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.watchdogState).toBe('FAILOVER');
+    }
+  });
+});


### PR DESCRIPTION
Implements **#1121** (your follow-up to #1065) — the `.catch(undefined)` tolerance on `watchdogState` can silently record a genuine failover as `watchdogStatus='connected'`; this makes that collapse observable instead of indistinguishable from a healthy heartbeat.

## Approach

The catch fires inside `zValidator` middleware where the device context isn't available to a schema-level callback, so the detection lives in the handler — exactly the `{ deviceId, field, rawValue }` structured warn the issue asks for:

- **`detectWatchdogStateCollapse(rawBody, validatedValue)`** — pure, exported: returns the warn payload when the raw body carried `watchdogState` but validation dropped it (rawValue capped at 100 chars), else `null`.
- The handler calls it **only when `agent.role === 'watchdog'` and the validated value is `undefined`** — zero added work on main-agent heartbeats, and the raw re-read uses Hono's cached JSON body, so the #1105 hot-path posture is untouched.
- On detection: `console.warn('[heartbeat] watchdogState collapsed by schema .catch — possible masked failover (#1121)', { deviceId, agentId, field, rawValue })`.
- **No behavioral change** to the status mapping (kept out of scope per the issue).

## Tests

- `schemas.heartbeatTolerance.test.ts` (real schema): corrupted (number) `watchdogState` collapses to `undefined` while the heartbeat still parses; valid `'FAILOVER'` passes through.
- `heartbeat.test.ts`: unit coverage of the detector — collapse (number + nested object), 100-char truncation, no-collapse, absent-key/main-agent, and non-object bodies.

## Verification (local)

`tsc --noEmit` clean · API suite **5969/5969** · lint clean · `pnpm audit --audit-level=critical` clean · Trivy fs HIGH/CRIT exit 0 · gitleaks clean. Diff touches `apps/api` only.

Closes #1121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)