### PR TITLE
fix(watchdog): execute commands from the initial failover heartbeat

### DIFF
--- a/agent/cmd/breeze-watchdog/failover_dispatch_test.go
+++ b/agent/cmd/breeze-watchdog/failover_dispatch_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/breeze-rmm/agent/internal/config"
 	"github.com/breeze-rmm/agent/internal/watchdog"
 )
 
@@ -61,4 +62,59 @@ func TestExecuteFailoverCommands_HeartbeatBeforePollPreservingOrder(t *testing.T
 	if !reflect.DeepEqual(ran, want) {
 		t.Fatalf("expected %v, got %v", want, ran)
 	}
+}
+
+func TestProcessInitialFailoverHeartbeatResponse_ExecutesCommandsAndProcessesUpgrades(t *testing.T) {
+	journal, err := watchdog.NewJournal(t.TempDir(), 1, 1)
+	if err != nil {
+		t.Fatalf("new journal: %v", err)
+	}
+	defer journal.Close()
+
+	cfg := &config.Config{
+		AgentID:   "agent-1",
+		ServerURL: "https://example.invalid",
+	}
+	wd := watchdog.NewWatchdog(watchdog.Config{})
+	tokens := &tokenHolder{}
+	recovery := watchdog.NewRecoveryManager(3, 0)
+
+	resp := &watchdog.HeartbeatResponse{
+		Commands: []watchdog.FailoverCommand{
+			{ID: "cmd-initial", Type: "collect_diagnostics"},
+		},
+		UpgradeTo:         "2.0.0",
+		WatchdogUpgradeTo: "2.1.0",
+	}
+
+	var ran []string
+	processInitialFailoverHeartbeatResponse(resp, wd, journal, cfg, tokens, recovery, func(cmd watchdog.FailoverCommand) {
+		ran = append(ran, cmd.ID)
+	})
+
+	if !reflect.DeepEqual(ran, []string{"cmd-initial"}) {
+		t.Fatalf("expected initial heartbeat command to execute, got %v", ran)
+	}
+
+	events := journal.Recent(0)
+	for _, tc := range []struct {
+		name  string
+		event string
+	}{
+		{name: "agent upgrade", event: "failover.upgrade_agent"},
+		{name: "watchdog upgrade", event: "failover.upgrade_watchdog"},
+	} {
+		if !hasJournalEvent(events, tc.event) {
+			t.Fatalf("expected %s event %q in journal, got %#v", tc.name, tc.event, events)
+		}
+	}
+}
+
+func hasJournalEvent(entries []watchdog.JournalEntry, event string) bool {
+	for _, entry := range entries {
+		if entry.Event == event {
+			return true
+		}
+	}
+	return false
 }

--- a/agent/cmd/breeze-watchdog/main.go
+++ b/agent/cmd/breeze-watchdog/main.go
@@ -465,7 +465,7 @@ func runWatchdog(stopCh <-chan struct{}) {
 						"error": err.Error(),
 					})
 				} else {
-					processHeartbeatResponse(resp, wd, journal, cfg, tokenStore, recovery)
+					handleInitialFailoverHeartbeatResponse(failoverClient, resp, wd, journal, cfg, tokenStore, recovery)
 				}
 			}
 
@@ -569,18 +569,13 @@ func handleFailoverPoll(
 		})
 		return
 	}
-	processHeartbeatResponse(resp, wd, journal, cfg, tokens, recovery)
+	heartbeatCmds := processHeartbeatResponse(resp, wd, journal, cfg, tokens, recovery)
 
 	// Commands targeted at the watchdog are claimed by the heartbeat (the
 	// server marks them 'sent' and returns them inline), so the poll below
 	// won't re-return them. Execute the heartbeat-delivered batch here, then
 	// the poll batch, deduped — otherwise a `restart_agent` etc. is consumed
 	// but never run (#1103).
-	var heartbeatCmds []watchdog.FailoverCommand
-	if resp != nil {
-		heartbeatCmds = resp.Commands
-	}
-
 	// Poll for any still-pending commands. A poll failure must not drop the
 	// heartbeat-delivered batch, so fall through with an empty poll set.
 	pollCmds, err := fc.PollCommands()
@@ -594,6 +589,36 @@ func handleFailoverPoll(
 	executeFailoverCommands(heartbeatCmds, pollCmds, func(cmd watchdog.FailoverCommand) {
 		handleFailoverCommand(fc, cmd, wd, journal, cfg, tokens, recovery)
 	})
+}
+
+// handleInitialFailoverHeartbeatResponse handles the first heartbeat sent when
+// failover starts. Those heartbeat commands are already claimed server-side, so
+// execute them immediately; there is no poll batch yet on this path.
+func handleInitialFailoverHeartbeatResponse(
+	fc *watchdog.FailoverClient,
+	resp *watchdog.HeartbeatResponse,
+	wd *watchdog.Watchdog,
+	journal *watchdog.Journal,
+	cfg *config.Config,
+	tokens *tokenHolder,
+	recovery *watchdog.RecoveryManager,
+) {
+	processInitialFailoverHeartbeatResponse(resp, wd, journal, cfg, tokens, recovery, func(cmd watchdog.FailoverCommand) {
+		handleFailoverCommand(fc, cmd, wd, journal, cfg, tokens, recovery)
+	})
+}
+
+func processInitialFailoverHeartbeatResponse(
+	resp *watchdog.HeartbeatResponse,
+	wd *watchdog.Watchdog,
+	journal *watchdog.Journal,
+	cfg *config.Config,
+	tokens *tokenHolder,
+	recovery *watchdog.RecoveryManager,
+	run func(watchdog.FailoverCommand),
+) {
+	heartbeatCmds := processHeartbeatResponse(resp, wd, journal, cfg, tokens, recovery)
+	executeFailoverCommands(heartbeatCmds, nil, run)
 }
 
 // executeFailoverCommands runs the heartbeat-delivered command batch first,
@@ -618,7 +643,8 @@ func executeFailoverCommands(
 	}
 }
 
-// processHeartbeatResponse handles upgrade directives from the API.
+// processHeartbeatResponse handles upgrade directives from the API and returns
+// any commands delivered inline with the heartbeat response.
 func processHeartbeatResponse(
 	resp *watchdog.HeartbeatResponse,
 	wd *watchdog.Watchdog,
@@ -626,9 +652,9 @@ func processHeartbeatResponse(
 	cfg *config.Config,
 	tokens *tokenHolder,
 	recovery *watchdog.RecoveryManager,
-) {
+) []watchdog.FailoverCommand {
 	if resp == nil {
-		return
+		return nil
 	}
 	if resp.UpgradeTo != "" {
 		journal.Log(watchdog.LevelInfo, "failover.upgrade_agent", map[string]any{
@@ -642,6 +668,7 @@ func processHeartbeatResponse(
 		})
 		doUpdateWatchdog(resp.WatchdogUpgradeTo, cfg, tokens, journal)
 	}
+	return resp.Commands
 }
 
 // handleFailoverCommand executes a single command from the API.


### PR DESCRIPTION
**Root cause:** Follow-up to #1115. The failover-entry branch in `runWatchdog` (`agent/cmd/breeze-watchdog/main.go:462`) sent the initial failover heartbeat and passed the response only to `processHeartbeatResponse`, which handles `UpgradeTo`/`WatchdogUpgradeTo` and discarded `resp.Commands`. Server-side, the heartbeat handler has already claimed those commands (`claimPendingCommandsForDevice` → `status='sent'`) and returns them inline; later polls only select `status='pending'`, so the batch was lost. Since `failoverClient` resets to `nil` in `StateMonitoring`, the loss window re-armed on every failover entry — and commands like `restart_agent` are queued precisely while the agent is down, so this defeated the dead-agent-restart path #1103/#1115 exist for. Lost commands surfaced as confusing "Server-side timeout" failures via the stale-command reaper.

**Fix:** `processHeartbeatResponse` now returns the inline command batch, and the entry path executes it through the same `executeFailoverCommands`/`handleFailoverCommand` path the steady-state poll uses (upgrade handling unchanged).

**Tests:** new regression coverage in `failover_dispatch_test.go` — initial heartbeat with inline commands → executed once each, upgrade directives still processed. `cd agent && go test -race ./cmd/breeze-watchdog/...` passes.

Implementation by Codex (gpt-5.5), reviewed by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)