### PR TITLE
fix(security): IPv6 trusted-proxy CIDR matching + partner settings allowlist hardening

### DIFF
--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -392,6 +392,102 @@ describe('org routes', () => {
 
       expect(res.status).toBe(404);
     });
+
+    describe('settings.security.ipAllowlist (system scope)', () => {
+      function mockCurrentPartnerSelect(settings: Record<string, unknown>) {
+        vi.mocked(db.select).mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([])
+              }),
+              limit: vi.fn().mockResolvedValue([{ id: 'partner-1', name: 'P', settings }])
+            })
+          })
+        } as any);
+      }
+
+      function mockUpdateCapture() {
+        let captured: any;
+        vi.mocked(db.update).mockReturnValue({
+          set: vi.fn().mockImplementation((data: any) => {
+            captured = data;
+            return {
+              where: vi.fn().mockReturnValue({
+                returning: vi.fn().mockResolvedValue([{ id: 'partner-1', name: 'P', settings: data.settings }])
+              })
+            };
+          })
+        } as any);
+        return () => captured;
+      }
+
+      function patchPartner(body: unknown) {
+        return app.request('/orgs/partners/partner-1', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        });
+      }
+
+      it('rejects a malformed ipAllowlist entry with 400 (same validation as /partners/me)', async () => {
+        const res = await patchPartner({ settings: { security: { ipAllowlist: ['not-an-ip'] } } });
+        expect(res.status).toBe(400);
+        expect(db.update).not.toHaveBeenCalled();
+      });
+
+      it('accepts valid entries and clears the partner allowlist cache', async () => {
+        mockCurrentPartnerSelect({});
+        mockUpdateCapture();
+
+        const res = await patchPartner({ settings: { security: { ipAllowlist: ['203.0.113.0/24', '2001:db8::/32'] } } });
+
+        expect(res.status).toBe(200);
+        expect(clearPartnerAllowlistCache).toHaveBeenCalledWith('partner-1');
+      });
+
+      it('does not clear the allowlist cache when settings are untouched', async () => {
+        mockUpdateCapture();
+
+        const res = await patchPartner({ name: 'Renamed' });
+
+        expect(res.status).toBe(200);
+        expect(clearPartnerAllowlistCache).not.toHaveBeenCalled();
+      });
+
+      it('preserves an active allowlist when the incoming security object omits the key', async () => {
+        mockCurrentPartnerSelect({ security: { ipAllowlist: ['203.0.113.0/24'], requireMfa: true } });
+        const getCaptured = mockUpdateCapture();
+
+        const res = await patchPartner({ settings: { security: { requireMfa: false } } });
+
+        expect(res.status).toBe(200);
+        expect(getCaptured().settings.security.ipAllowlist).toEqual(['203.0.113.0/24']);
+        expect(getCaptured().settings.security.requireMfa).toBe(false);
+      });
+
+      it('preserves an active allowlist when the incoming settings omit security entirely', async () => {
+        mockCurrentPartnerSelect({ security: { ipAllowlist: ['203.0.113.0/24'] } });
+        const getCaptured = mockUpdateCapture();
+
+        const res = await patchPartner({ settings: { branding: { primaryColor: '#ff0000' } } });
+
+        expect(res.status).toBe(200);
+        expect(getCaptured().settings.security.ipAllowlist).toEqual(['203.0.113.0/24']);
+        expect(getCaptured().settings.branding).toEqual({ primaryColor: '#ff0000' });
+      });
+
+      it('clears the allowlist when the caller sends an explicit empty array', async () => {
+        mockCurrentPartnerSelect({ security: { ipAllowlist: ['203.0.113.0/24'] } });
+        const getCaptured = mockUpdateCapture();
+
+        const res = await patchPartner({ settings: { security: { ipAllowlist: [] } } });
+
+        expect(res.status).toBe(200);
+        expect(getCaptured().settings.security.ipAllowlist).toEqual([]);
+        expect(clearPartnerAllowlistCache).toHaveBeenCalledWith('partner-1');
+      });
+    });
   });
 
   describe('DELETE /orgs/partners/:id', () => {
@@ -1847,6 +1943,74 @@ describe('org routes', () => {
         const res = await patchPartner({ settings: { security: { ipAllowlist: ['203.0.113.0/24'] } } });
 
         expect(res.status).toBe(200);
+        expect(clearPartnerAllowlistCache).toHaveBeenCalledWith('partner-123');
+      });
+
+      function mockPartnerUpdateCapture(currentSettings: Record<string, unknown>) {
+        const currentPartner = { id: 'partner-123', name: 'Acme MSP', settings: currentSettings };
+        vi.mocked(db.select).mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([])
+              }),
+              limit: vi.fn().mockResolvedValue([currentPartner])
+            })
+          })
+        } as any);
+        let captured: any;
+        vi.mocked(db.update).mockReturnValue({
+          set: vi.fn().mockImplementation((data: any) => {
+            captured = data;
+            return {
+              where: vi.fn().mockReturnValue({
+                returning: vi.fn().mockResolvedValue([{ ...currentPartner, settings: data.settings }])
+              })
+            };
+          })
+        } as any);
+        return () => captured;
+      }
+
+      it('deep-merges security: a PATCH omitting ipAllowlist preserves the active allowlist and siblings', async () => {
+        const getCaptured = mockPartnerUpdateCapture({
+          security: { ipAllowlist: ['203.0.113.0/24'], sessionTimeout: 30 }
+        });
+        vi.mocked(getTrustedClientIpOrUndefined).mockReturnValue('203.0.113.10');
+
+        const res = await patchPartner({ settings: { security: { requireMfa: true } } });
+
+        expect(res.status).toBe(200);
+        expect(getCaptured().settings.security).toEqual({
+          ipAllowlist: ['203.0.113.0/24'],
+          sessionTimeout: 30,
+          requireMfa: true
+        });
+      });
+
+      it('a PATCH whose settings omit security entirely preserves the active allowlist', async () => {
+        const getCaptured = mockPartnerUpdateCapture({
+          security: { ipAllowlist: ['203.0.113.0/24'] }
+        });
+        vi.mocked(getTrustedClientIpOrUndefined).mockReturnValue('203.0.113.10');
+
+        const res = await patchPartner({ settings: { branding: { primaryColor: '#ff0000' } } });
+
+        expect(res.status).toBe(200);
+        expect(getCaptured().settings.security).toEqual({ ipAllowlist: ['203.0.113.0/24'] });
+      });
+
+      it('an explicit empty ipAllowlist still clears the list deliberately', async () => {
+        const getCaptured = mockPartnerUpdateCapture({
+          security: { ipAllowlist: ['203.0.113.0/24'], requireMfa: true }
+        });
+        vi.mocked(getTrustedClientIpOrUndefined).mockReturnValue('203.0.113.10');
+
+        const res = await patchPartner({ settings: { security: { ipAllowlist: [] } } });
+
+        expect(res.status).toBe(200);
+        expect(getCaptured().settings.security.ipAllowlist).toEqual([]);
+        expect(getCaptured().settings.security.requireMfa).toBe(true);
         expect(clearPartnerAllowlistCache).toHaveBeenCalledWith('partner-123');
       });
     });

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -47,9 +47,50 @@ const createPartnerSchema = z.object({
   billingEmail: z.string().email().optional()
 });
 
+// The system-scoped partner routes accept free-form settings (z.any()), but
+// security.ipAllowlist entries must still be valid IPs/CIDRs — otherwise a
+// platform-admin write would bypass the validation /partners/me enforces and
+// store entries the matcher can never satisfy (silent fail-open).
+function settingsAllowlistEntriesValid(settings: unknown): boolean {
+  if (settings === null || typeof settings !== 'object') return true;
+  const security = (settings as Record<string, unknown>).security;
+  if (security === null || typeof security !== 'object') return true;
+  const list = (security as Record<string, unknown>).ipAllowlist;
+  if (list === undefined) return true;
+  return Array.isArray(list) && list.every((entry) => typeof entry === 'string' && isValidIpOrCidr(entry));
+}
+
 const updatePartnerSchema = createPartnerSchema.partial().extend({
-  status: z.enum(['pending', 'active', 'suspended', 'churned']).optional()
+  status: z.enum(['pending', 'active', 'suspended', 'churned']).optional(),
+  settings: z.any().optional().refine(settingsAllowlistEntriesValid, {
+    message: 'Each IP allowlist entry must be a valid IP address or CIDR range',
+  }),
 });
+
+// PATCH /partners/:id writes the settings column wholesale. A write whose
+// settings (or security object) simply omits `ipAllowlist` must not silently
+// delete an active allowlist (fail-open); an explicit `ipAllowlist: []` still
+// clears it deliberately. (/partners/me instead deep-merges `security`, which
+// gives the same guarantee there.)
+function preserveIpAllowlistOnOmit(
+  currentSettings: unknown,
+  incomingSettings: Record<string, unknown>,
+): Record<string, unknown> {
+  const currentSecurity = (currentSettings as Record<string, unknown> | null | undefined)?.security;
+  const currentList = (currentSecurity as Record<string, unknown> | null | undefined)?.ipAllowlist;
+  if (!Array.isArray(currentList) || currentList.length === 0) return incomingSettings;
+
+  const incomingSecurity = incomingSettings.security;
+  if (
+    incomingSecurity !== undefined
+    && (incomingSecurity === null || typeof incomingSecurity !== 'object' || Array.isArray(incomingSecurity))
+  ) {
+    return incomingSettings; // malformed security value — leave the write as-is
+  }
+  const security = (incomingSecurity ?? {}) as Record<string, unknown>;
+  if ('ipAllowlist' in security) return incomingSettings; // explicit value (incl. []) wins
+  return { ...incomingSettings, security: { ...security, ipAllowlist: currentList } };
+}
 
 const createOrganizationSchema = z.object({
   partnerId: z.string().uuid().optional(),
@@ -439,11 +480,23 @@ orgRoutes.patch('/partners/me', requireScope('partner'), requirePartner, require
     return c.json({ error: 'Partner not found' }, 404);
   }
 
-  // Merge settings
+  // Merge settings (top-level shallow merge, except `security` below)
   const currentSettings = (current.settings as Record<string, unknown>) || {};
-  const newSettings = body.settings
+  const newSettings: Record<string, unknown> = body.settings
     ? { ...currentSettings, ...body.settings }
-    : currentSettings;
+    : { ...currentSettings };
+
+  // Deep-merge the `security` sub-object: it carries many sibling fields (MFA
+  // policy, session limits, ipAllowlist, ...), so a wholesale replace would let
+  // a PATCH that merely omits `ipAllowlist` silently delete an active allowlist
+  // (fail-open). Incoming security fields still override individually, and an
+  // explicit `ipAllowlist: []` still clears the list deliberately.
+  if (body.settings?.security) {
+    newSettings.security = {
+      ...((currentSettings.security as Record<string, unknown> | undefined) ?? {}),
+      ...body.settings.security,
+    };
+  }
 
   // Enable-gate: turning the allowlist on (empty -> non-empty) requires that
   // the API can actually see real client IPs, otherwise enforcement would
@@ -531,8 +584,23 @@ orgRoutes.patch('/partners/:id', requireScope('system'), requireOrgWrite, requir
     return c.json({ error: 'No updates provided' }, 400);
   }
 
-  // Encrypt secret-bearing fields in partners.settings before writing.
   if (updates.settings !== undefined) {
+    // Wholesale settings write: keep an active security.ipAllowlist unless the
+    // caller explicitly clears it (see preserveIpAllowlistOnOmit).
+    if (updates.settings && typeof updates.settings === 'object' && !Array.isArray(updates.settings)) {
+      const [currentPartner] = await db
+        .select()
+        .from(partners)
+        .where(and(eq(partners.id, id), isNull(partners.deletedAt)))
+        .limit(1);
+      if (currentPartner) {
+        updates.settings = preserveIpAllowlistOnOmit(
+          currentPartner.settings,
+          updates.settings as Record<string, unknown>,
+        );
+      }
+    }
+    // Encrypt secret-bearing fields in partners.settings before writing.
     updates.settings = encryptColumnValueForWrite('partners', 'settings', updates.settings);
   }
 
@@ -548,6 +616,11 @@ orgRoutes.patch('/partners/:id', requireScope('system'), requireOrgWrite, requir
 
   // Invalidate the OAuth scope-policy cache (settings may have changed).
   clearPartnerScopePolicyCache(partner.id);
+  // Settings writes can change security.ipAllowlist — drop the 30s cache so
+  // enforcement picks up the new list immediately (mirrors /partners/me).
+  if (data.settings !== undefined) {
+    clearPartnerAllowlistCache(partner.id);
+  }
   // Only the terminal-ish states sever the fleet. `pending` is reversible
   // (signup/billing limbo) and is already blocked for agents by the live
   // tenant cascade (getActivePartner is strict) — severing here would expire

--- a/apps/api/src/services/clientIp.test.ts
+++ b/apps/api/src/services/clientIp.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { getTrustedClientIp, getTrustedClientIpOrUndefined } from './clientIp';
+import { getTrustedClientIp, getTrustedClientIpOrUndefined, isTrustedProxySource } from './clientIp';
 import type { RequestLike } from './auditEvents';
 
 function makeContext(headers: Record<string, string | undefined>, remoteAddress?: string): RequestLike {
@@ -166,6 +166,50 @@ describe('clientIp', () => {
         makeContext({ 'cf-connecting-ip': '203.0.113.10' }),
       );
       expect(ip).toBe('unknown');
+    });
+  });
+
+  describe('isTrustedProxySource — IPv6 + IPv4-mapped CIDR matching', () => {
+    const cases: Array<{ name: string; cidrs: string; peer: string; expected: boolean }> = [
+      // IPv6 prefixes shorter than /128 (previously never matched — fail-open
+      // for the partner IP allowlist via getTrustedClientIpOrUndefined).
+      { name: 'IPv6 peer inside a /64', cidrs: '2001:db8:1:2::/64', peer: '2001:db8:1:2::5', expected: true },
+      { name: 'IPv6 peer inside a /32', cidrs: '2001:db8::/32', peer: '2001:db8:ffff::1', expected: true },
+      { name: 'IPv6 peer outside the /32', cidrs: '2001:db8::/32', peer: '2001:db9::1', expected: false },
+      { name: 'exact /128 still matches', cidrs: '2001:db8::1/128', peer: '2001:db8::1', expected: true },
+      { name: 'compressed-form /128 matches expanded peer', cidrs: '2001:db8:0:0:0:0:0:1/128', peer: '2001:db8::1', expected: true },
+      // IPv4-mapped IPv6 peers (dual-stack listeners) match both list forms.
+      { name: 'IPv4-mapped peer vs IPv4 CIDR form', cidrs: '127.0.0.1/32', peer: '::ffff:127.0.0.1', expected: true },
+      { name: 'IPv4-mapped peer vs IPv6 CIDR form', cidrs: '::ffff:0:0/96', peer: '::ffff:127.0.0.1', expected: true },
+      { name: 'IPv4-mapped peer vs bare IPv4 entry', cidrs: '127.0.0.1', peer: '::ffff:127.0.0.1', expected: true },
+      { name: 'IPv4-mapped peer outside the IPv4 CIDR', cidrs: '10.0.0.0/8', peer: '::ffff:127.0.0.1', expected: false },
+      // Malformed entries must not throw and must not match.
+      { name: 'malformed IPv6 network never matches', cidrs: 'zzzz::/64', peer: '2001:db8::1', expected: false },
+      { name: 'out-of-range IPv6 prefix never matches', cidrs: '2001:db8::/200', peer: '2001:db8::1', expected: false },
+      { name: 'non-numeric prefix never matches', cidrs: '2001:db8::/abc', peer: '2001:db8::1', expected: false },
+      // IPv4 behavior is unchanged.
+      { name: 'IPv4 peer inside an IPv4 CIDR', cidrs: '172.30.0.0/16', peer: '172.30.0.44', expected: true },
+      { name: 'IPv4 peer outside an IPv4 CIDR', cidrs: '172.30.0.0/16', peer: '172.31.0.44', expected: false },
+      // Mixed lists: any entry matching is enough.
+      { name: 'IPv6 peer matches the v6 entry in a mixed list', cidrs: '10.0.0.0/8, 2001:db8::/32', peer: '2001:db8::9', expected: true },
+    ];
+
+    it.each(cases)('$name', ({ cidrs, peer, expected }) => {
+      process.env.TRUSTED_PROXY_CIDRS = cidrs;
+      expect(isTrustedProxySource(peer)).toBe(expected);
+    });
+
+    it('does not throw on malformed CIDR entries', () => {
+      process.env.TRUSTED_PROXY_CIDRS = 'zzzz::/64, 2001:db8::/200, /, garbage';
+      expect(() => isTrustedProxySource('2001:db8::1')).not.toThrow();
+      expect(isTrustedProxySource('2001:db8::1')).toBe(false);
+    });
+
+    it('end-to-end: an IPv6 peer inside a /32 unlocks proxy headers (allowlist enforceable)', () => {
+      process.env.TRUSTED_PROXY_CIDRS = '2001:db8::/32';
+      const ctx = makeContext({ 'cf-connecting-ip': '203.0.113.10' }, '2001:db8::5');
+      expect(getTrustedClientIp(ctx, '2001:db8::5')).toBe('203.0.113.10');
+      expect(getTrustedClientIpOrUndefined(ctx)).toBe('203.0.113.10');
     });
   });
 

--- a/apps/api/src/services/clientIp.ts
+++ b/apps/api/src/services/clientIp.ts
@@ -1,5 +1,6 @@
 import type { RequestLike } from './auditEvents';
 import { isIP } from 'net';
+import { ipMatchesAny } from './ipMatch';
 
 const TRUST_PROXY_AUTO = 'auto';
 
@@ -77,27 +78,11 @@ function firstValidIpFromCsv(value: string | undefined): string | null {
   return null;
 }
 
-function ipv4ToInt(ip: string): number | null {
-  const parts = ip.split('.');
-  if (parts.length !== 4) return null;
-  let result = 0;
-  for (const part of parts) {
-    const parsed = Number.parseInt(part, 10);
-    if (!Number.isInteger(parsed) || parsed < 0 || parsed > 255) return null;
-    result = (result << 8) | parsed;
-  }
-  return result >>> 0;
-}
-
-function ipv4InCidr(ip: string, cidr: string): boolean {
-  const [network, bitsRaw] = cidr.split('/');
-  const bits = Number.parseInt(bitsRaw ?? '', 10);
-  if (!network || !Number.isInteger(bits) || bits < 0 || bits > 32) return false;
-  const ipNum = ipv4ToInt(ip);
-  const netNum = ipv4ToInt(network);
-  if (ipNum === null || netNum === null) return false;
-  const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
-  return (ipNum & mask) === (netNum & mask);
+// ::ffff:a.b.c.d -> a.b.c.d (IPv4-mapped IPv6); null when not in mapped form.
+function ipv4MappedToV4(ip: string): string | null {
+  const match = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(ip);
+  if (!match || !match[1]) return null;
+  return isIP(match[1]) === 4 ? match[1] : null;
 }
 
 export function isTrustedProxySource(sourceIp: string | undefined): boolean {
@@ -111,21 +96,20 @@ export function isTrustedProxySource(sourceIp: string | undefined): boolean {
     return false;
   }
 
-  for (const cidr of cidrs) {
-    if (!cidr.includes('/')) {
-      if (normalizeIpCandidate(cidr) === normalizedSource) return true;
-      continue;
-    }
+  // IPv4-mapped IPv6 peers (::ffff:a.b.c.d — common on dual-stack listeners)
+  // should match whether the operator wrote the trusted-proxy entry in IPv4
+  // form (127.0.0.1/32) or IPv6 form (::ffff:0:0/96), so check both shapes.
+  const candidates = [normalizedSource];
+  const mapped = ipv4MappedToV4(normalizedSource);
+  if (mapped) candidates.push(mapped);
 
-    if (isIP(normalizedSource) === 4 && ipv4InCidr(normalizedSource, cidr)) {
-      return true;
-    }
-    if (isIP(normalizedSource) === 6) {
-      const [network, bitsRaw] = cidr.split('/');
-      if (bitsRaw === '128' && normalizeIpCandidate(network ?? '') === normalizedSource) {
-        return true;
-      }
-    }
+  for (const cidr of cidrs) {
+    // Bare-IP entries may use bracketed/port forms; normalize them first.
+    // CIDR math for both families is delegated to the shared BigInt matcher
+    // (services/ipMatch.ts) — malformed entries never match and never throw.
+    const entry = cidr.includes('/') ? cidr : normalizeIpCandidate(cidr);
+    if (!entry) continue;
+    if (candidates.some((ip) => ipMatchesAny(ip, [entry]))) return true;
   }
 
   return false;


### PR DESCRIPTION
**Root cause:** Verification of the v0.69.0..main Codex review confirmed three gaps in the partner IP allowlist feature (#1092):

1. `isTrustedProxySource()` (`clientIp.ts:123`) implemented CIDR math for IPv4 only — IPv6 sources matched only exact `/128` entries. Any IPv6 trusted-proxy range with a shorter prefix (or an IPv4-mapped `::ffff:` peer on a dual-stack listener) never matched → `getTrustedClientIpOrUndefined` returned `undefined` → `evaluateIpAllowlist` mapped that to `{decision:'skip', reason:'untrusted_ip'}` — i.e. the partner allowlist was **silently not enforced** for every user behind an IPv6-fronted proxy. (Notably fail-open at the allowlist layer, not an XFF-spoofing hole.)
2. The system-scoped `PATCH /partners/:id` accepted `settings: z.any()`, bypassing the `isValidIpOrCidr` validation `/partners/me` enforces, and never called `clearPartnerAllowlistCache` — leaving up to 30s of stale enforcement after a write.
3. Both routes could silently wipe an active allowlist: `/partners/me` shallow-merged at the top level (a PATCH updating any other `security` sibling deleted `ipAllowlist`), and `/partners/:id` replaced settings wholesale. The enable-gate only guards the off→on transition, so removal was ungated.

**Fix:**
- `clientIp.ts` delegates both address families to the shared BigInt matcher in `services/ipMatch.ts` (the weaker duplicate IPv4 implementation is deleted); IPv4-mapped peers are checked in both mapped-IPv6 and dotted-quad form; malformed entries never match and never throw.
- `PATCH /partners/:id`: `settings.security.ipAllowlist` entries validated with `isValidIpOrCidr` (same 400 error shape as `/partners/me`); `clearPartnerAllowlistCache` called on settings writes.
- `/partners/me` deep-merges the `security` sub-object; `/partners/:id` re-injects an active allowlist when the incoming settings omit the key. Explicit `ipAllowlist: []` still clears deliberately on both.

**Tests:** table-driven `isTrustedProxySource` cases (IPv6 /64, /32, /128, IPv4-mapped peer in both entry forms, malformed/no-throw, mixed lists) + end-to-end IPv6-peer test through `getTrustedClientIpOrUndefined`; 9 new route tests covering validation, cache clearing, preserve-on-omit, and explicit-clear. `clientIp` + `ipMatch` + `orgs`: 150/150 pass; downstream `ipAllowlist` suite: 15/15 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)