### PR TITLE
fix(devices): uncapped advanced-filter resolution; grid view respects filters

### DIFF
--- a/apps/api/src/routes/filters.ts
+++ b/apps/api/src/routes/filters.ts
@@ -5,7 +5,7 @@ import { and, desc, eq, inArray } from 'drizzle-orm';
 import { db } from '../db';
 import { savedFilters } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
-import { evaluateFilterWithPreview, validateFilter, FilterConditionGroup } from '../services/filterEngine';
+import { evaluateFilter, evaluateFilterWithPreview, validateFilter, FilterConditionGroup } from '../services/filterEngine';
 import { writeRouteAudit } from '../services/auditEvents';
 import { PERMISSIONS } from '../services/permissions';
 import {
@@ -116,11 +116,16 @@ filterRoutes.post(
   requireFilterRead,
   zValidator('json', z.object({
     conditions: filterConditionGroupSchema,
-    limit: z.number().int().positive().max(100).optional()
+    limit: z.number().int().positive().max(100).optional(),
+    // idsOnly mode returns ALL matching device ids (uncapped, ids only — no
+    // per-device objects). Used by the device list/grid so an advanced filter
+    // matching >100 devices doesn't silently hide rows (the preview cap is a
+    // UI nicety for the filter builder footer, not a result-set bound).
+    idsOnly: z.boolean().optional()
   })),
   async (c) => {
     const auth = c.get('auth');
-    const { conditions, limit } = c.req.valid('json');
+    const { conditions, limit, idsOnly } = c.req.valid('json');
 
     // Validate field/operator names (and regex length) up front so an unknown
     // field or over-long `matches` pattern returns a clean 400 instead of a 500
@@ -145,7 +150,43 @@ filterRoutes.post(
       orgIds = await getOrgIdsForAuth(auth);
     }
     if (!orgIds || orgIds.length === 0) {
+      if (idsOnly) {
+        return c.json({ data: { totalCount: 0, deviceIds: [], evaluatedAt: new Date().toISOString() } });
+      }
       return c.json({ data: { totalCount: 0, devices: [], evaluatedAt: new Date().toISOString() } });
+    }
+
+    // idsOnly: skip the preview/enrichment path entirely and return the full
+    // matching id set. evaluateFilter applies no row limit, so the per-org
+    // previewLimit cap never truncates this path.
+    if (idsOnly) {
+      const deviceIds: string[] = [];
+      for (const orgId of orgIds) {
+        const result = await evaluateFilter(
+          conditions as unknown as FilterConditionGroup,
+          { orgId }
+        );
+        deviceIds.push(...result.deviceIds);
+      }
+
+      writeRouteAudit(c, {
+        orgId: auth.orgId ?? (orgIds.length === 1 ? orgIds[0] : null),
+        action: 'filter.preview',
+        resourceType: 'saved_filter',
+        details: {
+          orgCount: orgIds.length,
+          totalCount: deviceIds.length,
+          idsOnly: true
+        }
+      });
+
+      return c.json({
+        data: {
+          totalCount: deviceIds.length,
+          deviceIds,
+          evaluatedAt: new Date().toISOString()
+        }
+      });
     }
 
     // Evaluate filter across all orgs the user has access to

--- a/apps/api/src/routes/filters_update_preview.test.ts
+++ b/apps/api/src/routes/filters_update_preview.test.ts
@@ -17,6 +17,12 @@ vi.mock('../services/auditEvents', () => ({
 vi.mock('../services/filterEngine', () => ({
   // /preview now validates conditions up front (#1044); default to valid.
   validateFilter: vi.fn(() => ({ valid: true, errors: [] })),
+  // idsOnly path — returns the complete uncapped id set.
+  evaluateFilter: vi.fn().mockResolvedValue({
+    deviceIds: Array.from({ length: 250 }, (_, i) => `dev-${i}`),
+    totalCount: 250,
+    evaluatedAt: new Date('2026-01-01')
+  }),
   evaluateFilterWithPreview: vi.fn().mockResolvedValue({
     totalCount: 2,
     devices: [
@@ -72,7 +78,7 @@ vi.mock('../middleware/auth', () => ({
 
 import { db } from '../db';
 import { authMiddleware } from '../middleware/auth';
-import { evaluateFilterWithPreview } from '../services/filterEngine';
+import { evaluateFilter, evaluateFilterWithPreview } from '../services/filterEngine';
 
 function makeFilter(overrides: Record<string, unknown> = {}) {
   return {
@@ -361,6 +367,133 @@ describe('filter routes', () => {
 
       expect(res.status).toBe(403);
       expect(evaluateFilterWithPreview).not.toHaveBeenCalled();
+    });
+
+    it('idsOnly returns ALL matching device ids uncapped (>100) and skips the preview path', async () => {
+      const res = await app.request('/filters/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          conditions: { operator: 'AND', conditions: [{ field: 'status', operator: 'equals', value: 'online' }] },
+          idsOnly: true
+        })
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // 250 matches — well past the 100-row preview cap (the bug this guards).
+      expect(body.data.totalCount).toBe(250);
+      expect(body.data.deviceIds).toHaveLength(250);
+      expect(body.data.deviceIds[0]).toBe('dev-0');
+      expect(body.data.deviceIds[249]).toBe('dev-249');
+      // ids only — no per-device enrichment payload.
+      expect(body.data.devices).toBeUndefined();
+      expect(evaluateFilter).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ orgId: ORG_ID })
+      );
+      expect(evaluateFilterWithPreview).not.toHaveBeenCalled();
+    });
+
+    it('idsOnly aggregates ids across all accessible orgs for partner scope', async () => {
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+          scope: 'partner',
+          orgId: null,
+          partnerId: PARTNER_ID,
+          accessibleOrgIds: [ORG_ID, ORG_ID_2],
+          canAccessOrg: (orgId: string) => orgId === ORG_ID || orgId === ORG_ID_2
+        });
+        return next();
+      });
+
+      const res = await app.request('/filters/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          conditions: { operator: 'AND', conditions: [{ field: 'status', operator: 'equals', value: 'online' }] },
+          idsOnly: true
+        })
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.totalCount).toBe(500); // 250 per org, both orgs, uncapped
+      expect(body.data.deviceIds).toHaveLength(500);
+      expect(evaluateFilter).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps the existing capped preview behavior when idsOnly is not set', async () => {
+      // Engine reports 150 matches and (hypothetically) returns 150 rows; the
+      // route must still trim the payload to the requested limit.
+      vi.mocked(evaluateFilterWithPreview).mockResolvedValueOnce({
+        totalCount: 150,
+        devices: Array.from({ length: 150 }, (_, i) => ({
+          id: `dev-${i}`, hostname: `host-${i}`, displayName: null, osType: 'linux', status: 'online', lastSeenAt: null
+        })),
+        evaluatedAt: new Date('2026-01-01')
+      } as any);
+
+      const res = await app.request('/filters/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          conditions: { operator: 'AND', conditions: [{ field: 'status', operator: 'equals', value: 'online' }] },
+          limit: 100
+        })
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.totalCount).toBe(150); // true count still reported
+      expect(body.data.devices).toHaveLength(100); // payload capped
+      expect(evaluateFilterWithPreview).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ orgId: ORG_ID, previewLimit: 100 })
+      );
+      expect(evaluateFilter).not.toHaveBeenCalled();
+    });
+
+    it('still rejects a non-idsOnly limit above 100', async () => {
+      const res = await app.request('/filters/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          conditions: { operator: 'AND', conditions: [{ field: 'status', operator: 'equals', value: 'online' }] },
+          limit: 500
+        })
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('idsOnly returns an empty id set when user has no org access', async () => {
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+          scope: 'organization',
+          orgId: null,
+          partnerId: null,
+          accessibleOrgIds: [],
+          canAccessOrg: () => false
+        });
+        return next();
+      });
+
+      const res = await app.request('/filters/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          conditions: { operator: 'AND', conditions: [{ field: 'status', operator: 'equals', value: 'online' }] },
+          idsOnly: true
+        })
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.totalCount).toBe(0);
+      expect(body.data.deviceIds).toEqual([]);
     });
 
     it('should return empty when user has no org access', async () => {

--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -131,3 +131,40 @@ describe('DeviceList — row action menu (#1013 clipping fix)', () => {
     expect(scrollWrapper?.contains(menuItem)).toBe(false);
   });
 });
+
+describe('DeviceList — advanced filter via serverFilterIds prop (uncapped id set)', () => {
+  it('renders only devices in the id set and shows the active-filter pill', () => {
+    const inFilter: Device = {
+      ...baseDevice,
+      id: '88888888-8888-8888-8888-888888888888',
+      hostname: 'host-in-filter',
+    };
+    const outOfFilter: Device = {
+      ...baseDevice,
+      id: '99999999-9999-9999-9999-999999999999',
+      hostname: 'host-not-in-filter',
+    };
+
+    render(
+      <DeviceList
+        devices={[inFilter, outOfFilter]}
+        serverFilterIds={new Set([inFilter.id])}
+      />
+    );
+
+    expect(screen.getByText('host-in-filter')).toBeTruthy();
+    expect(screen.queryByText('host-not-in-filter')).toBeNull();
+    expect(screen.getByText(/Advanced filter active/i)).toBeTruthy();
+  });
+
+  it('shows every device (no pill) when serverFilterIds is null — no advanced filter active', () => {
+    const a: Device = { ...baseDevice, id: 'aaaaaaa1-0000-0000-0000-000000000000', hostname: 'host-aa' };
+    const b: Device = { ...baseDevice, id: 'aaaaaaa2-0000-0000-0000-000000000000', hostname: 'host-bb' };
+
+    render(<DeviceList devices={[a, b]} serverFilterIds={null} />);
+
+    expect(screen.getByText('host-aa')).toBeTruthy();
+    expect(screen.getByText('host-bb')).toBeTruthy();
+    expect(screen.queryByText(/Advanced filter active/i)).toBeNull();
+  });
+});

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -1,8 +1,7 @@
 import { useMemo, useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { Search, ChevronLeft, ChevronRight, ChevronUp, ChevronDown, ArrowUpDown, MoreHorizontal, MoreVertical, Filter, Terminal, FileCode, RotateCcw, Settings, Trash2, Zap, Columns3, Rows3, Rows4, AlignJustify } from 'lucide-react';
-import type { DesktopAccessState, FilterConditionGroup, RemoteAccessPolicy } from '@breeze/shared';
-import { fetchWithAuth } from '../../stores/auth';
+import type { DesktopAccessState, RemoteAccessPolicy } from '@breeze/shared';
 import ConnectDesktopButton from '../remote/ConnectDesktopButton';
 import { widthPercentClass, formatUptime } from '@/lib/utils';
 import { formatLastSeen } from '@/lib/formatTime';
@@ -100,7 +99,11 @@ type DeviceListProps = {
   // Once the component mounts, the live page size comes from localStorage
   // (see pageSizePreference.ts); subsequent changes to this prop are ignored.
   pageSize?: number;
-  serverFilter?: FilterConditionGroup | null;
+  // Pre-resolved advanced-filter id set (null = no advanced filter active).
+  // Resolution lives in DevicesPage via useAdvancedFilterIds so the list and
+  // grid views filter against the same complete, uncapped id set.
+  serverFilterIds?: Set<string> | null;
+  serverFilterLoading?: boolean;
 };
 
 const statusColors: Record<DeviceStatus, string> = {
@@ -183,7 +186,8 @@ export default function DeviceList({
   onAction,
   onBulkAction,
   pageSize = 10,
-  serverFilter = null
+  serverFilterIds = null,
+  serverFilterLoading = false
 }: DeviceListProps) {
   // Use provided timezone or browser default
   const effectiveTimezone = timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -234,8 +238,6 @@ export default function DeviceList({
   const [rowMenuAnchor, setRowMenuAnchor] = useState<{ top: number; bottom: number; right: number } | null>(null);
   const rowMenuRef = useRef<HTMLDivElement>(null);
   const rowMenuButtonRef = useRef<HTMLButtonElement | null>(null);
-  const [serverFilterIds, setServerFilterIds] = useState<Set<string> | null>(null);
-  const [serverFilterLoading, setServerFilterLoading] = useState(false);
   const [showMoreFilters, setShowMoreFilters] = useState(false);
   const [sortField, setSortField] = useState<SortField>(null);
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
@@ -325,50 +327,6 @@ export default function DeviceList({
       onAutoSelectConsumed?.();
     }
   }, [autoSelectGroupId, groups, onAutoSelectConsumed]);
-
-  // Fetch matching device IDs from server when advanced filter changes
-  useEffect(() => {
-    if (!serverFilter) {
-      setServerFilterIds(null);
-      return;
-    }
-
-    const hasValidConditions = serverFilter.conditions.some(c => {
-      if ('conditions' in c) return true;
-      return c.value !== '' && c.value !== null && c.value !== undefined;
-    });
-
-    if (!hasValidConditions) {
-      setServerFilterIds(null);
-      return;
-    }
-
-    setServerFilterLoading(true);
-    const controller = new AbortController();
-
-    fetchWithAuth('/filters/preview', {
-      method: 'POST',
-      body: JSON.stringify({ conditions: serverFilter, limit: 100 }),
-      signal: controller.signal
-    })
-      .then(async (res) => {
-        if (res.ok) {
-          const data = await res.json();
-          const result = data.data ?? data;
-          const ids = new Set<string>((result.devices ?? []).map((d: { id: string }) => d.id));
-          setServerFilterIds(ids);
-        }
-      })
-      .catch((err) => {
-        if (!controller.signal.aborted) {
-          console.error('Filter preview failed:', err);
-          setServerFilterIds(null);
-        }
-      })
-      .finally(() => setServerFilterLoading(false));
-
-    return () => controller.abort();
-  }, [serverFilter]);
 
   const filteredDevices = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();

--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -1,0 +1,181 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import DevicesPage from './DevicesPage';
+import { fetchWithAuth } from '../../stores/auth';
+import { fetchAllDevices } from '../../lib/devicesFetch';
+
+// ---------------------------------------------------------------------------
+// Mocks — keep DevicesPage's own logic (including the real useAdvancedFilterIds
+// hook) live; stub network, side-effectful children, and the filter-URL state.
+// ---------------------------------------------------------------------------
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('../../lib/devicesFetch', () => ({
+  fetchAllDevices: vi.fn(),
+}));
+
+vi.mock('../../hooks/useEventStream', () => ({
+  useEventStream: () => ({ subscribe: vi.fn() }),
+}));
+
+vi.mock('../../services/deviceActions', () => ({
+  sendDeviceCommand: vi.fn(),
+  sendBulkCommand: vi.fn(),
+  executeScript: vi.fn(),
+  toggleMaintenanceMode: vi.fn(),
+  decommissionDevice: vi.fn(),
+  bulkDecommissionDevices: vi.fn(),
+  restoreDevice: vi.fn(),
+  permanentDeleteDevice: vi.fn(),
+  sendWakeCommand: vi.fn(),
+  sendBulkWakeCommand: vi.fn(),
+  summarizeBulkWakeFailures: vi.fn(() => ''),
+  summarizeBulkCommandFailures: vi.fn(() => ''),
+  watchWakeOutcome: vi.fn(),
+  WakeCommandError: class WakeCommandError extends Error { code = 'x'; },
+  wakeFriendlyErrorMessage: vi.fn(() => null),
+}));
+
+vi.mock('@/lib/navigation', () => ({
+  navigateTo: vi.fn(),
+}));
+
+vi.mock('../shared/Toast', () => ({
+  showToast: vi.fn(),
+}));
+
+// The advanced filter is seeded from the URL hash; stub it to an active filter
+// so the page mounts with `advancedFilter` set (v2 chip bar enabled).
+const activeFilter = {
+  operator: 'AND' as const,
+  conditions: [{ field: 'status', operator: 'equals' as const, value: 'online' }],
+};
+vi.mock('./filterUrl', () => ({
+  decodeFilterFromHash: vi.fn(() => activeFilter),
+  writeFilterToHash: vi.fn(),
+  isFiltersV2Enabled: vi.fn(() => true),
+}));
+
+// Presentational/heavy children — not under test.
+vi.mock('./ScriptPickerModal', () => ({ default: () => null }));
+vi.mock('./DeviceSettingsModal', () => ({ default: () => null }));
+vi.mock('./AddDeviceModal', () => ({ default: () => null }));
+vi.mock('./CreateGroupModal', () => ({ default: () => null }));
+vi.mock('../filters/DeviceFilterBar', () => ({ DeviceFilterBar: () => null }));
+vi.mock('./FilterChipBar', () => ({ FilterChipBar: () => null }));
+vi.mock('./QuickAddChips', () => ({ QuickAddChips: () => null }));
+vi.mock('../shared/ProgressBar', () => ({ default: () => null }));
+
+// DeviceCard stub renders the hostname so the grid contents are assertable.
+vi.mock('./DeviceCard', () => ({
+  default: ({ device }: { device: { id: string; hostname: string } }) => (
+    <div data-testid={`device-card-${device.id}`}>{device.hostname}</div>
+  ),
+}));
+
+// DeviceList stub exposes which id set it was handed.
+vi.mock('./DeviceList', () => ({
+  default: ({ devices, serverFilterIds }: { devices: { id: string }[]; serverFilterIds?: Set<string> | null }) => (
+    <div
+      data-testid="device-list"
+      data-device-count={devices.length}
+      data-filter-ids={serverFilterIds ? [...serverFilterIds].sort().join(',') : ''}
+    />
+  ),
+}));
+
+const DEV_1 = '11111111-1111-1111-1111-111111111111';
+const DEV_2 = '22222222-2222-2222-2222-222222222222';
+const DEV_3 = '33333333-3333-3333-3333-333333333333';
+
+function rawDevice(id: string, hostname: string) {
+  return {
+    id,
+    hostname,
+    osType: 'windows',
+    osVersion: '11',
+    status: 'online',
+    lastSeenAt: new Date().toISOString(),
+    orgId: 'org-1',
+    siteId: 'site-1',
+    agentVersion: '0.68.0',
+    tags: [],
+  };
+}
+
+function jsonResponse(payload: unknown) {
+  return { ok: true, json: async () => payload } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  vi.mocked(fetchAllDevices).mockResolvedValue({
+    data: [rawDevice(DEV_1, 'host-alpha'), rawDevice(DEV_2, 'host-beta'), rawDevice(DEV_3, 'host-gamma')],
+  } as never);
+
+  vi.mocked(fetchWithAuth).mockImplementation(async (url: string) => {
+    if (url.startsWith('/filters/preview')) {
+      // Advanced filter matches only DEV_1 and DEV_3.
+      return jsonResponse({
+        data: { totalCount: 2, deviceIds: [DEV_1, DEV_3], evaluatedAt: new Date().toISOString() },
+      });
+    }
+    return jsonResponse({ data: [] }); // /orgs, /orgs/sites, /device-groups
+  });
+});
+
+describe('DevicesPage — advanced filter applies to BOTH views', () => {
+  it('grid view renders only the devices matching the advanced filter (not the raw list)', async () => {
+    render(<DevicesPage />);
+
+    // Wait for initial load, then switch to grid view.
+    const gridButton = await screen.findByLabelText('Grid view');
+    fireEvent.click(gridButton);
+
+    // Filter resolution is async — wait for the excluded card to disappear.
+    await waitFor(() => {
+      expect(screen.queryByTestId(`device-card-${DEV_2}`)).toBeNull();
+    });
+
+    expect(screen.getByTestId(`device-card-${DEV_1}`).textContent).toBe('host-alpha');
+    expect(screen.getByTestId(`device-card-${DEV_3}`).textContent).toBe('host-gamma');
+
+    // The preview request must be the uncapped idsOnly form.
+    const previewCall = vi.mocked(fetchWithAuth).mock.calls.find(([url]) => String(url).startsWith('/filters/preview'));
+    expect(previewCall).toBeDefined();
+    const body = JSON.parse(previewCall![1]?.body as string);
+    expect(body.idsOnly).toBe(true);
+    expect(body.limit).toBeUndefined();
+  });
+
+  it('list view receives the same resolved id set via serverFilterIds', async () => {
+    render(<DevicesPage />);
+
+    const list = await screen.findByTestId('device-list');
+    await waitFor(() => {
+      expect(list.getAttribute('data-filter-ids')).toBe([DEV_1, DEV_3].sort().join(','));
+    });
+    // Full device array still flows in; DeviceList combines it with the id set.
+    expect(list.getAttribute('data-device-count')).toBe('3');
+  });
+
+  it('grid view shows all devices when no advanced filter is active', async () => {
+    const { decodeFilterFromHash } = await import('./filterUrl');
+    vi.mocked(decodeFilterFromHash).mockReturnValueOnce(null);
+
+    render(<DevicesPage />);
+
+    const gridButton = await screen.findByLabelText('Grid view');
+    fireEvent.click(gridButton);
+
+    expect(await screen.findByTestId(`device-card-${DEV_1}`)).toBeTruthy();
+    expect(screen.getByTestId(`device-card-${DEV_2}`)).toBeTruthy();
+    expect(screen.getByTestId(`device-card-${DEV_3}`)).toBeTruthy();
+    expect(vi.mocked(fetchWithAuth).mock.calls.some(([url]) => String(url).startsWith('/filters/preview'))).toBe(false);
+  });
+});

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useEventStream } from '../../hooks/useEventStream';
+import { useAdvancedFilterIds } from '../../hooks/useAdvancedFilterIds';
 import { List, Grid, Plus, AlertCircle } from 'lucide-react';
 import { showToast } from '../shared/Toast';
 import type { FilterConditionGroup } from '@breeze/shared';
@@ -67,6 +68,10 @@ export default function DevicesPage() {
     return decodeFilterFromHash(window.location.hash);
   });
   const filtersV2 = typeof window !== 'undefined' ? isFiltersV2Enabled() : false;
+  // Resolve the advanced filter to the complete (uncapped) matching id set
+  // once, here, so the list AND grid views render the same filtered fleet.
+  // The grid previously mapped the raw devices array and ignored the filter.
+  const { ids: advancedFilterIds, loading: advancedFilterLoading } = useAdvancedFilterIds(advancedFilter);
   const [showCreateGroup, setShowCreateGroup] = useState(false);
   const [autoSelectGroupId, setAutoSelectGroupId] = useState<string | null>(null);
 
@@ -96,6 +101,14 @@ export default function DevicesPage() {
     const unique = [...new Set(scriptTargetDevices.map(d => d.os))];
     return unique.length > 0 ? unique : undefined;
   }, [scriptTargetDevices]);
+
+  // Grid view applies the advanced filter here; the list view passes the id
+  // set into DeviceList, which combines it with its local quick-filters
+  // (search/status/os/etc. stay list-only).
+  const gridDevices = useMemo(
+    () => (advancedFilterIds === null ? devices : devices.filter(d => advancedFilterIds.has(d.id))),
+    [devices, advancedFilterIds]
+  );
 
   const fetchDevices = useCallback(async (signal?: AbortSignal) => {
     try {
@@ -785,14 +798,15 @@ export default function DevicesPage() {
           onSelect={handleSelectDevice}
           onAction={handleDeviceAction}
           onBulkAction={handleBulkAction}
-          serverFilter={advancedFilter}
+          serverFilterIds={advancedFilterIds}
+          serverFilterLoading={advancedFilterLoading}
           onCreateGroup={() => setShowCreateGroup(true)}
           autoSelectGroupId={autoSelectGroupId}
           onAutoSelectConsumed={handleAutoSelectConsumed}
         />
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {devices.map(device => (
+          {gridDevices.map(device => (
             <DeviceCard
               key={device.id}
               device={device}

--- a/apps/web/src/hooks/useAdvancedFilterIds.test.ts
+++ b/apps/web/src/hooks/useAdvancedFilterIds.test.ts
@@ -1,0 +1,94 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { FilterConditionGroup } from '@breeze/shared';
+
+import { useAdvancedFilterIds } from './useAdvancedFilterIds';
+import { fetchWithAuth } from '../stores/auth';
+
+vi.mock('../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+const filter: FilterConditionGroup = {
+  operator: 'AND',
+  conditions: [{ field: 'status', operator: 'equals', value: 'online' }],
+};
+
+function mockPreviewResponse(deviceIds: string[]) {
+  vi.mocked(fetchWithAuth).mockResolvedValue({
+    ok: true,
+    json: async () => ({ data: { totalCount: deviceIds.length, deviceIds, evaluatedAt: new Date().toISOString() } }),
+  } as unknown as Response);
+}
+
+describe('useAdvancedFilterIds', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null ids (no filtering) when no filter is active', () => {
+    const { result } = renderHook(() => useAdvancedFilterIds(null));
+
+    expect(result.current.ids).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(fetchWithAuth).not.toHaveBeenCalled();
+  });
+
+  it('returns null ids when the filter has no condition with a real value', () => {
+    const empty: FilterConditionGroup = {
+      operator: 'AND',
+      conditions: [{ field: 'hostname', operator: 'contains', value: '' }],
+    };
+    const { result } = renderHook(() => useAdvancedFilterIds(empty));
+
+    expect(result.current.ids).toBeNull();
+    expect(fetchWithAuth).not.toHaveBeenCalled();
+  });
+
+  it('requests idsOnly (no limit cap) and resolves the complete id set', async () => {
+    // 250 matches — past the old 100-row preview cap that silently hid devices.
+    const manyIds = Array.from({ length: 250 }, (_, i) => `dev-${i}`);
+    mockPreviewResponse(manyIds);
+
+    const { result } = renderHook(() => useAdvancedFilterIds(filter));
+
+    await waitFor(() => expect(result.current.ids).not.toBeNull());
+
+    expect(result.current.ids?.size).toBe(250);
+    expect(result.current.ids?.has('dev-249')).toBe(true);
+    expect(result.current.loading).toBe(false);
+
+    expect(fetchWithAuth).toHaveBeenCalledWith('/filters/preview', expect.objectContaining({ method: 'POST' }));
+    const body = JSON.parse(vi.mocked(fetchWithAuth).mock.calls[0][1]?.body as string);
+    expect(body.idsOnly).toBe(true);
+    expect(body.conditions).toEqual(filter);
+    expect(body.limit).toBeUndefined();
+  });
+
+  it('clears the id set when the filter is removed', async () => {
+    mockPreviewResponse(['dev-1']);
+
+    const { result, rerender } = renderHook(
+      ({ f }: { f: FilterConditionGroup | null }) => useAdvancedFilterIds(f),
+      { initialProps: { f: filter as FilterConditionGroup | null } }
+    );
+
+    await waitFor(() => expect(result.current.ids?.size).toBe(1));
+
+    rerender({ f: null });
+
+    expect(result.current.ids).toBeNull();
+  });
+
+  it('drops the id set (fails open) when the request errors', async () => {
+    vi.mocked(fetchWithAuth).mockRejectedValue(new Error('network down'));
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useAdvancedFilterIds(filter));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.ids).toBeNull();
+    consoleSpy.mockRestore();
+  });
+});

--- a/apps/web/src/hooks/useAdvancedFilterIds.ts
+++ b/apps/web/src/hooks/useAdvancedFilterIds.ts
@@ -1,0 +1,69 @@
+import { useState, useEffect } from 'react';
+import type { FilterConditionGroup } from '@breeze/shared';
+import { fetchWithAuth } from '../stores/auth';
+
+// A filter is worth sending to the server once it has at least one condition
+// with a real value (nested groups count as valid — the server validates the
+// leaves). Mirrors the check DeviceList used before the resolution was lifted
+// here so the list and grid share one id set (grid previously ignored the
+// advanced filter entirely).
+function hasValidConditions(filter: FilterConditionGroup): boolean {
+  return filter.conditions.some(c => {
+    if ('conditions' in c) return true;
+    return c.value !== '' && c.value !== null && c.value !== undefined;
+  });
+}
+
+export interface UseAdvancedFilterIdsReturn {
+  /**
+   * Set of device ids matching the advanced filter, or null when no filter is
+   * active (callers should treat null as "show everything").
+   */
+  ids: Set<string> | null;
+  loading: boolean;
+}
+
+/**
+ * Resolve an advanced filter (FilterConditionGroup) to the COMPLETE set of
+ * matching device ids via POST /filters/preview with `idsOnly: true`. Unlike
+ * the preview path this is uncapped — filters matching >100 devices return
+ * every id, so the device table/grid never silently hides matches.
+ */
+export function useAdvancedFilterIds(filter: FilterConditionGroup | null): UseAdvancedFilterIdsReturn {
+  const [ids, setIds] = useState<Set<string> | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!filter || !hasValidConditions(filter)) {
+      setIds(null);
+      return;
+    }
+
+    setLoading(true);
+    const controller = new AbortController();
+
+    fetchWithAuth('/filters/preview', {
+      method: 'POST',
+      body: JSON.stringify({ conditions: filter, idsOnly: true }),
+      signal: controller.signal
+    })
+      .then(async (res) => {
+        if (res.ok) {
+          const data = await res.json();
+          const result = data.data ?? data;
+          setIds(new Set<string>(result.deviceIds ?? []));
+        }
+      })
+      .catch((err) => {
+        if (!controller.signal.aborted) {
+          console.error('Filter preview failed:', err);
+          setIds(null);
+        }
+      })
+      .finally(() => setLoading(false));
+
+    return () => controller.abort();
+  }, [filter]);
+
+  return { ids, loading };
+}

--- a/apps/web/src/lib/runActionAllowlist.ts
+++ b/apps/web/src/lib/runActionAllowlist.ts
@@ -16,7 +16,8 @@ export const RUN_ACTION_MIGRATION_BACKLOG: ReadonlyArray<string> = [
   'apps/web/src/components/devices/DeviceBootPerformanceTab.tsx',
   'apps/web/src/components/devices/DeviceFilesystemTab.tsx',
   'apps/web/src/components/devices/DeviceGroupsPage.tsx',
-  'apps/web/src/components/devices/DeviceList.tsx',
+  // DeviceList.tsx removed: its only fetchWithAuth call (POST /filters/preview,
+  // a read) moved to hooks/useAdvancedFilterIds.ts — no mutating calls remain.
   'apps/web/src/components/devices/DevicePatchStatusTab.tsx',
   'apps/web/src/components/devices/DeviceSecurityTab.tsx',
   'apps/web/src/components/devices/DeviceSettingsModal.tsx',


### PR DESCRIPTION
**Root cause:** Verification of the v0.69.0..main Codex review confirmed two bugs in the advanced device filters (#1013):

1. `DeviceList` resolved the advanced filter via `POST /filters/preview` with `limit: 100` (the API schema also caps `limit` at 100) and used the returned ids as the authoritative client-side filter for the **main device table** — not a preview count. Any filter matching >100 devices (trivial at the 10k-agent target) silently showed at most 100 rows, and which 100 depended on per-org query order. The API's correct `totalCount` was ignored.
2. Grid view mapped the raw `devices` array (`DevicesPage.tsx:793`) while the active filter chip bar rendered above it — the UI displayed active filters over an unfiltered fleet.

**Fix:**
- `POST /filters/preview` gains an `idsOnly: true` mode returning the complete uncapped matching id set (ids only — no per-device enrichment; `evaluateFilter` applies no row limit so the per-org `previewLimit` never truncates). The capped enriched preview is unchanged for its existing caller (filter-builder footer).
- New shared `useAdvancedFilterIds` hook resolves the filter once at page level; the list view receives the id set via props (replacing its internal capped fetch) and the grid maps the same filtered set. Quick-filters (search/status/os/…) deliberately stay list-only.
- `runActionAllowlist`: DeviceList removed from the migration backlog (its only fetch moved into the hook).

**Tests:** API — idsOnly returns 250/250 ids uncapped, partner multi-org aggregation, capped path still trims 150→100 with true `totalCount`, `limit > 100` still 400 (17 pass, plus filters_crud + filterEngine 48 pass). Web — hook (5), DeviceList prop filtering, DevicesPage grid/list parity (16 pass), `no-silent-mutations` 24 pass. Web `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)