### PR TITLE
fix(agent): relax Linux systemd sandbox so remote terminal/scripts run like root SSH

### DIFF
--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -712,8 +712,9 @@ func retryTCCGrant() {
 // - Receiving pending commands from the server via heartbeat response
 // - Executing commands and reporting results back to the server
 func runAgent() {
-	// Self-heal launchd plists on macOS (fixes KeepAlive config from older installs).
-	healLaunchdPlistsIfNeeded()
+	// Self-heal the installed service unit from older installs (launchd plists on
+	// macOS; systemd unit on Linux) after a binary-only auto-update.
+	reconcileServiceUnitIfNeeded()
 
 	// On Windows, if launched by the SCM, run under the service framework
 	// so we report Running/Stopped status back to the SCM correctly. The

--- a/agent/cmd/breeze-agent/service_cmd_darwin.go
+++ b/agent/cmd/breeze-agent/service_cmd_darwin.go
@@ -466,8 +466,9 @@ var serviceStatusCmd = &cobra.Command{
 	},
 }
 
-// healLaunchdPlistsIfNeeded is the darwin implementation.
-func healLaunchdPlistsIfNeeded() {
+// reconcileServiceUnitIfNeeded is the darwin implementation: it self-heals
+// launchd plists from older installs.
+func reconcileServiceUnitIfNeeded() {
 	healLaunchdPlists()
 	ensureDesktopHelpersLoaded()
 }

--- a/agent/cmd/breeze-agent/service_cmd_linux.go
+++ b/agent/cmd/breeze-agent/service_cmd_linux.go
@@ -89,8 +89,14 @@ func reconcileServiceUnitIfNeeded() {
 		// an unrestricted namespace; being a child of PID 1 it also survives
 		// the agent restart it triggers. --collect garbage-collects the
 		// transient unit on failure so a later retry is never blocked.
+		//
+		// The unit name is suffixed with our PID so that if the restart the
+		// child triggers races a freshly-started agent into reconcile again, the
+		// second systemd-run can't collide with a still-running first transient
+		// unit (--collect only reaps dead units, not running ones).
+		unitFlag := fmt.Sprintf("--unit=breeze-unit-reconcile-%d", os.Getpid())
 		out, err := exec.Command("systemd-run", "--quiet", "--collect",
-			"--unit=breeze-unit-reconcile", linuxBinaryPath, "service", "reconcile-unit").CombinedOutput()
+			unitFlag, linuxBinaryPath, "service", "reconcile-unit").CombinedOutput()
 		if err != nil {
 			fmt.Fprintf(os.Stderr,
 				"Warning: failed to auto-heal outdated systemd unit via systemd-run: %s. "+
@@ -406,6 +412,9 @@ var serviceReconcileUnitCmd = &cobra.Command{
 		if os.Geteuid() != 0 {
 			return fmt.Errorf("must run as root")
 		}
+		// Best-effort heal: if a later step fails the unit is already v2 on disk,
+		// so the next startup won't re-attempt the restart — the relaxed sandbox
+		// then applies on the following natural service restart rather than now.
 		if err := os.WriteFile(linuxUnitDst, []byte(linuxUnit), 0644); err != nil {
 			return fmt.Errorf("write unit: %w", err)
 		}

--- a/agent/cmd/breeze-agent/service_cmd_linux.go
+++ b/agent/cmd/breeze-agent/service_cmd_linux.go
@@ -28,52 +28,6 @@ const (
 	linuxWatchdogServiceName = "breeze-watchdog"
 )
 
-// Embedded systemd unit — matches agent/service/systemd/breeze-agent.service
-const linuxUnit = `[Unit]
-Description=Breeze RMM Agent
-Documentation=https://github.com/breeze-rmm/breeze
-After=network-online.target
-Wants=network-online.target
-StartLimitIntervalSec=60
-StartLimitBurst=5
-
-[Service]
-Type=simple
-ExecStart=/usr/local/bin/breeze-agent start
-WorkingDirectory=/etc/breeze
-Restart=on-failure
-# 30s cooldown spreads respawn across a fleet that crashes simultaneously
-# (e.g. correlated network blip). Combined with StartLimitBurst=5 over
-# StartLimitIntervalSec=60, a misbehaving host backs off entirely instead
-# of stampeding the API.
-RestartSec=30
-
-# Cap total stop time so a hung HTTP flush during OS shutdown (network
-# going down) doesn't block system power-off for the 90s systemd default.
-TimeoutStopSec=15
-KillMode=mixed
-
-# Security hardening
-ProtectSystem=strict
-ProtectHome=read-only
-ReadWritePaths=/etc/breeze /var/lib/breeze /var/log/breeze /var/run/breeze /var/cache/apt /var/lib/apt /var/lib/dpkg /var/log/apt /usr/local/bin -/run/ufw.lock
-PrivateTmp=true
-NoNewPrivileges=false
-CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN CAP_SYS_PTRACE CAP_DAC_READ_SEARCH CAP_FOWNER
-AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN CAP_FOWNER
-
-# Logging (stdout goes to journald)
-StandardOutput=journal
-StandardError=journal
-SyslogIdentifier=breeze-agent
-
-# File limits
-LimitNOFILE=8192
-
-[Install]
-WantedBy=multi-user.target
-`
-
 // Embedded user-helper unit
 const linuxUserUnit = `[Unit]
 Description=Breeze RMM User Helper

--- a/agent/cmd/breeze-agent/service_cmd_linux.go
+++ b/agent/cmd/breeze-agent/service_cmd_linux.go
@@ -69,7 +69,16 @@ func reconcileServiceUnitIfNeeded() {
 		}
 		data, err := os.ReadFile(linuxUnitDst)
 		if err != nil {
-			return // not installed via systemd / unreadable — nothing to heal
+			// ErrNotExist = not installed via systemd: genuinely nothing to heal.
+			// Any other read error on a host that may be running the old sandboxed
+			// unit means we couldn't even evaluate the heal — don't fail silently.
+			if !os.IsNotExist(err) {
+				fmt.Fprintf(os.Stderr,
+					"Warning: could not read %s to check for an outdated systemd unit: %v. "+
+						"If the remote terminal/scripts hit privilege errors, run: "+
+						"sudo breeze-agent service install\n", linuxUnitDst, err)
+			}
+			return
 		}
 		if !unitNeedsReconcile(string(data), currentUnitVersion) {
 			return
@@ -84,19 +93,13 @@ func reconcileServiceUnitIfNeeded() {
 		// TRANSIENT SERVICE, deliberately NOT --scope: a scope child is forked
 		// from this (sandboxed) process and only its cgroup moves — it would
 		// inherit our read-only /etc (ProtectSystem) and restricted CapBnd and
-		// fail with the same Permission denied. Without --scope, PID 1 spawns
-		// the command in a fresh execution environment with full root caps and
-		// an unrestricted namespace; being a child of PID 1 it also survives
-		// the agent restart it triggers. --collect garbage-collects the
-		// transient unit on failure so a later retry is never blocked.
-		//
-		// The unit name is suffixed with our PID so that if the restart the
-		// child triggers races a freshly-started agent into reconcile again, the
-		// second systemd-run can't collide with a still-running first transient
-		// unit (--collect only reaps dead units, not running ones).
-		unitFlag := fmt.Sprintf("--unit=breeze-unit-reconcile-%d", os.Getpid())
-		out, err := exec.Command("systemd-run", "--quiet", "--collect",
-			unitFlag, linuxBinaryPath, "service", "reconcile-unit").CombinedOutput()
+		// fail with the same Permission denied. Without --scope, PID 1 spawns the
+		// command in systemd's default execution environment — NOT inheriting this
+		// unit's ProtectSystem or CapabilityBoundingSet — so it can write
+		// /etc/systemd/system; being a child of PID 1 it also survives the agent
+		// restart it triggers. See reconcileTransientArgs for the flag invariants.
+		out, err := exec.Command(
+			"systemd-run", reconcileTransientArgs(os.Getpid(), linuxBinaryPath)...).CombinedOutput()
 		if err != nil {
 			fmt.Fprintf(os.Stderr,
 				"Warning: failed to auto-heal outdated systemd unit via systemd-run: %s. "+
@@ -419,14 +422,14 @@ var serviceReconcileUnitCmd = &cobra.Command{
 			return fmt.Errorf("write unit: %w", err)
 		}
 		if out, err := exec.Command("systemctl", "daemon-reload").CombinedOutput(); err != nil {
-			return fmt.Errorf("daemon-reload: %s", strings.TrimSpace(string(out)))
+			return fmt.Errorf("daemon-reload: %w: %s", err, strings.TrimSpace(string(out)))
 		}
 		fmt.Printf("Reconciled %s to unit version %d; restarting service.\n", linuxUnitDst, currentUnitVersion)
 		// Restart so the relaxed sandbox applies to the live process. This kills
 		// the old agent; we run as a systemd-run transient service whose parent
 		// is PID 1 (not the agent), so this child survives to finish the restart.
 		if out, err := exec.Command("systemctl", "restart", linuxServiceName).CombinedOutput(); err != nil {
-			return fmt.Errorf("restart: %s", strings.TrimSpace(string(out)))
+			return fmt.Errorf("restart: %w: %s", err, strings.TrimSpace(string(out)))
 		}
 		return nil
 	},

--- a/agent/cmd/breeze-agent/service_cmd_linux.go
+++ b/agent/cmd/breeze-agent/service_cmd_linux.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/breeze-rmm/agent/internal/config"
 	"github.com/spf13/cobra"
@@ -52,9 +53,51 @@ var serviceCmd = &cobra.Command{
 var withUserHelper bool
 var noWatchdog bool
 
-// reconcileServiceUnitIfNeeded rewrites an outdated systemd unit on startup.
-// Real implementation added in the next change.
-func reconcileServiceUnitIfNeeded() {}
+var reconcileOnce sync.Once
+
+// reconcileServiceUnitIfNeeded runs at startup. If the installed unit predates
+// currentUnitVersion, it rewrites it. The running agent is itself sandboxed and
+// cannot write /etc/systemd/system (ProtectSystem=strict on old units), so it
+// escapes via a systemd-run TRANSIENT SERVICE: PID 1 spawns the reconcile in a
+// fresh execution environment, outside this unit's mount namespace and
+// capability bounding set. Best-effort: on failure it logs and continues.
+func reconcileServiceUnitIfNeeded() {
+	reconcileOnce.Do(func() {
+		// Only act as the installed systemd service running as root.
+		if os.Geteuid() != 0 || os.Getenv("INVOCATION_ID") == "" {
+			return
+		}
+		data, err := os.ReadFile(linuxUnitDst)
+		if err != nil {
+			return // not installed via systemd / unreadable — nothing to heal
+		}
+		if !unitNeedsReconcile(string(data), currentUnitVersion) {
+			return
+		}
+		if _, err := exec.LookPath("systemd-run"); err != nil {
+			fmt.Fprintf(os.Stderr,
+				"Warning: breeze-agent systemd unit is outdated (pre-v%d) and systemd-run is "+
+					"unavailable to auto-heal it. The remote terminal/scripts may hit privilege "+
+					"errors (e.g. apt). Fix: sudo breeze-agent service install\n", currentUnitVersion)
+			return
+		}
+		// TRANSIENT SERVICE, deliberately NOT --scope: a scope child is forked
+		// from this (sandboxed) process and only its cgroup moves — it would
+		// inherit our read-only /etc (ProtectSystem) and restricted CapBnd and
+		// fail with the same Permission denied. Without --scope, PID 1 spawns
+		// the command in a fresh execution environment with full root caps and
+		// an unrestricted namespace; being a child of PID 1 it also survives
+		// the agent restart it triggers. --collect garbage-collects the
+		// transient unit on failure so a later retry is never blocked.
+		out, err := exec.Command("systemd-run", "--quiet", "--collect",
+			"--unit=breeze-unit-reconcile", linuxBinaryPath, "service", "reconcile-unit").CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(os.Stderr,
+				"Warning: failed to auto-heal outdated systemd unit via systemd-run: %s. "+
+					"Fix: sudo breeze-agent service install\n", strings.TrimSpace(string(out)))
+		}
+	})
+}
 
 func init() {
 	rootCmd.AddCommand(serviceCmd)
@@ -63,6 +106,7 @@ func init() {
 	serviceCmd.AddCommand(serviceStartCmd)
 	serviceCmd.AddCommand(serviceStopCmd)
 	serviceCmd.AddCommand(serviceStatusCmd)
+	serviceCmd.AddCommand(serviceReconcileUnitCmd)
 	serviceInstallCmd.Flags().BoolVar(&withUserHelper, "with-user-helper", false, "Also install the per-user desktop helper systemd unit")
 	serviceInstallCmd.Flags().BoolVar(&noWatchdog, "no-watchdog", false, "Skip automatic watchdog installation")
 }
@@ -350,6 +394,31 @@ var serviceStatusCmd = &cobra.Command{
 			}
 		}
 		fmt.Println(strings.TrimSpace(string(out)))
+		return nil
+	},
+}
+
+var serviceReconcileUnitCmd = &cobra.Command{
+	Use:    "reconcile-unit",
+	Short:  "Rewrite the systemd unit to the current version and restart (internal)",
+	Hidden: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if os.Geteuid() != 0 {
+			return fmt.Errorf("must run as root")
+		}
+		if err := os.WriteFile(linuxUnitDst, []byte(linuxUnit), 0644); err != nil {
+			return fmt.Errorf("write unit: %w", err)
+		}
+		if out, err := exec.Command("systemctl", "daemon-reload").CombinedOutput(); err != nil {
+			return fmt.Errorf("daemon-reload: %s", strings.TrimSpace(string(out)))
+		}
+		fmt.Printf("Reconciled %s to unit version %d; restarting service.\n", linuxUnitDst, currentUnitVersion)
+		// Restart so the relaxed sandbox applies to the live process. This kills
+		// the old agent; we run as a systemd-run transient service whose parent
+		// is PID 1 (not the agent), so this child survives to finish the restart.
+		if out, err := exec.Command("systemctl", "restart", linuxServiceName).CombinedOutput(); err != nil {
+			return fmt.Errorf("restart: %s", strings.TrimSpace(string(out)))
+		}
 		return nil
 	},
 }

--- a/agent/cmd/breeze-agent/service_cmd_linux.go
+++ b/agent/cmd/breeze-agent/service_cmd_linux.go
@@ -52,8 +52,9 @@ var serviceCmd = &cobra.Command{
 var withUserHelper bool
 var noWatchdog bool
 
-// healLaunchdPlistsIfNeeded is a no-op on Linux.
-func healLaunchdPlistsIfNeeded() {}
+// reconcileServiceUnitIfNeeded rewrites an outdated systemd unit on startup.
+// Real implementation added in the next change.
+func reconcileServiceUnitIfNeeded() {}
 
 func init() {
 	rootCmd.AddCommand(serviceCmd)

--- a/agent/cmd/breeze-agent/service_cmd_windows.go
+++ b/agent/cmd/breeze-agent/service_cmd_windows.go
@@ -21,8 +21,8 @@ var serviceCmd = &cobra.Command{
 	Short: "Manage the Breeze Agent Windows service",
 }
 
-// healLaunchdPlistsIfNeeded is a no-op on Windows.
-func healLaunchdPlistsIfNeeded() {}
+// reconcileServiceUnitIfNeeded is a no-op on Windows.
+func reconcileServiceUnitIfNeeded() {}
 
 var noWatchdog bool
 

--- a/agent/cmd/breeze-agent/systemd_unit.go
+++ b/agent/cmd/breeze-agent/systemd_unit.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -46,7 +47,7 @@ KillMode=mixed
 
 # INTENTIONALLY UNSANDBOXED. The remote terminal and remote script execution
 # features spawn child processes that must behave like a root SSH session:
-#   - package managers drop privileges to unprivileged users (needs CAP_SETUID/SETGID)
+#   - package managers drop privileges to unprivileged users (needs CAP_SETUID/SETGID/CHOWN)
 #   - admins write under /home, /usr, /etc, and expect a shared /tmp
 # systemd sandbox restrictions are INHERITED by those children and silently break
 # these operations. Do not re-add them.
@@ -87,4 +88,23 @@ func unitNeedsReconcile(existing string, want int) bool {
 		return true
 	}
 	return v < want
+}
+
+// reconcileTransientArgs builds the systemd-run argv for the sandbox-escape that
+// rewrites the unit. The invariants below are safety-critical and guarded by
+// TestReconcileTransientArgs:
+//   - --collect: a failed transient unit is garbage-collected so a later retry
+//     is never blocked by a leftover dead unit.
+//   - NEVER --scope: a scope child is forked from the (sandboxed) agent and
+//     inherits its mount namespace + capability bounding set, so it would fail
+//     to write /etc/systemd/system exactly like the agent — defeating the escape.
+//   - PID-suffixed unit name: if the restart the child triggers races a freshly
+//     started agent into reconcile again, the two transient units can't collide
+//     (--collect only reaps dead units, not a still-running one).
+func reconcileTransientArgs(pid int, binPath string) []string {
+	return []string{
+		"--quiet", "--collect",
+		fmt.Sprintf("--unit=breeze-unit-reconcile-%d", pid),
+		binPath, "service", "reconcile-unit",
+	}
 }

--- a/agent/cmd/breeze-agent/systemd_unit.go
+++ b/agent/cmd/breeze-agent/systemd_unit.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+)
+
+// currentUnitVersion is the breeze-unit-version this binary ships. Bump it
+// whenever linuxUnit changes in a way the deployed fleet must pick up; the
+// startup reconcile rewrites any on-disk unit older than this.
+const currentUnitVersion = 2
+
+const unitVersionPrefix = "# breeze-unit-version:"
+
+// parseUnitVersion extracts the breeze-unit-version marker from a unit file.
+// Returns (version, true) when a well-formed marker is present, else (0, false).
+func parseUnitVersion(existing string) (int, bool) {
+	for _, line := range strings.Split(existing, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, unitVersionPrefix) {
+			continue
+		}
+		v, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(line, unitVersionPrefix)))
+		if err != nil {
+			return 0, false
+		}
+		return v, true
+	}
+	return 0, false
+}
+
+// unitNeedsReconcile reports whether the on-disk unit is older than what this
+// binary ships. Missing/garbage marker or a lower version => reconcile. Equal
+// or higher (a newer binary wrote it) => leave it alone, never downgrade.
+func unitNeedsReconcile(existing string, want int) bool {
+	v, ok := parseUnitVersion(existing)
+	if !ok {
+		return true
+	}
+	return v < want
+}

--- a/agent/cmd/breeze-agent/systemd_unit.go
+++ b/agent/cmd/breeze-agent/systemd_unit.go
@@ -31,7 +31,16 @@ Type=simple
 ExecStart=/usr/local/bin/breeze-agent start
 WorkingDirectory=/etc/breeze
 Restart=on-failure
+# 30s cooldown spreads respawn across a fleet that crashes simultaneously
+# (e.g. correlated network blip). Combined with StartLimitBurst=5 over
+# StartLimitIntervalSec=60, a misbehaving host backs off entirely instead
+# of stampeding the API.
 RestartSec=30
+
+# Cap total stop time so a hung HTTP flush during OS shutdown (network
+# going down) doesn't block system power-off for the 90s systemd default.
+# KillMode=mixed sends SIGTERM to the main process, then SIGKILL to the
+# whole cgroup after TimeoutStopSec.
 TimeoutStopSec=15
 KillMode=mixed
 

--- a/agent/cmd/breeze-agent/systemd_unit.go
+++ b/agent/cmd/breeze-agent/systemd_unit.go
@@ -8,9 +8,49 @@ import (
 // currentUnitVersion is the breeze-unit-version this binary ships. Bump it
 // whenever linuxUnit changes in a way the deployed fleet must pick up; the
 // startup reconcile rewrites any on-disk unit older than this.
+// Version 1 is the legacy unversioned/hardened unit (any unit without a marker
+// is treated as pre-v2).
 const currentUnitVersion = 2
 
 const unitVersionPrefix = "# breeze-unit-version:"
+
+// linuxUnit is the canonical systemd unit, embedded so the agent can rewrite
+// the installed copy. agent/service/systemd/breeze-agent.service must stay
+// byte-identical (enforced by TestStaticUnitMatchesEmbedded).
+const linuxUnit = `[Unit]
+Description=Breeze RMM Agent
+Documentation=https://github.com/breeze-rmm/breeze
+After=network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Service]
+# breeze-unit-version: 2
+Type=simple
+ExecStart=/usr/local/bin/breeze-agent start
+WorkingDirectory=/etc/breeze
+Restart=on-failure
+RestartSec=30
+TimeoutStopSec=15
+KillMode=mixed
+
+# INTENTIONALLY UNSANDBOXED. The remote terminal and remote script execution
+# features spawn child processes that must behave like a root SSH session:
+#   - package managers drop privileges to unprivileged users (needs CAP_SETUID/SETGID)
+#   - admins write under /home, /usr, /etc, and expect a shared /tmp
+# systemd sandbox restrictions are INHERITED by those children and silently break
+# these operations. Do not re-add them.
+# See docs/superpowers/specs/2026-06-09-agent-systemd-sandbox-remote-terminal-design.md
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=breeze-agent
+LimitNOFILE=8192
+
+[Install]
+WantedBy=multi-user.target
+`
 
 // parseUnitVersion extracts the breeze-unit-version marker from a unit file.
 // Returns (version, true) when a well-formed marker is present, else (0, false).

--- a/agent/cmd/breeze-agent/systemd_unit_test.go
+++ b/agent/cmd/breeze-agent/systemd_unit_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"strings"
+	"testing"
+)
 
 func TestParseUnitVersion(t *testing.T) {
 	cases := []struct {
@@ -44,5 +48,39 @@ func TestUnitNeedsReconcile(t *testing.T) {
 				t.Fatalf("unitNeedsReconcile(%q,%d) = %v, want %v", tc.existing, tc.want, got, tc.expect)
 			}
 		})
+	}
+}
+
+func TestStaticUnitMatchesEmbedded(t *testing.T) {
+	// Test runs with cwd = package dir (agent/cmd/breeze-agent).
+	data, err := os.ReadFile("../../service/systemd/breeze-agent.service")
+	if err != nil {
+		t.Fatalf("read static unit: %v", err)
+	}
+	if string(data) != linuxUnit {
+		t.Fatalf("static breeze-agent.service is not byte-identical to embedded linuxUnit.\n" +
+			"Keep them in sync (the auto-heal writes the embedded copy).")
+	}
+}
+
+func TestUnitIsNotReHardened(t *testing.T) {
+	forbidden := []string{
+		"ProtectSystem=strict",
+		"ProtectHome=read-only",
+		"CapabilityBoundingSet",
+		"AmbientCapabilities",
+		"PrivateTmp=true",
+	}
+	for _, f := range forbidden {
+		if strings.Contains(linuxUnit, f) {
+			t.Errorf("linuxUnit re-introduced a sandbox directive that breaks the remote "+
+				"terminal/scripts: %q (see the spec — do not re-add)", f)
+		}
+	}
+	if _, ok := parseUnitVersion(linuxUnit); !ok {
+		t.Errorf("linuxUnit is missing its %q marker", unitVersionPrefix)
+	}
+	if v, _ := parseUnitVersion(linuxUnit); v != currentUnitVersion {
+		t.Errorf("linuxUnit marker version != currentUnitVersion (%d)", currentUnitVersion)
 	}
 }

--- a/agent/cmd/breeze-agent/systemd_unit_test.go
+++ b/agent/cmd/breeze-agent/systemd_unit_test.go
@@ -18,6 +18,15 @@ func TestParseUnitVersion(t *testing.T) {
 		{"missing", "[Service]\nType=simple\n", 0, false},
 		{"garbage value", "# breeze-unit-version: abc\n", 0, false},
 		{"empty", "", 0, false},
+		// CRLF must stay tolerated: a unit copied through Windows-touched tooling
+		// must NOT read as version-less (which would trigger needless reconcile loops).
+		{"crlf tolerated", "# breeze-unit-version: 2\r\n", 2, true},
+		// Overflow and non-numeric both fail to (0,false) => unitNeedsReconcile true (fail safe).
+		{"overflow not ok", "# breeze-unit-version: 99999999999999999999\n", 0, false},
+		{"negative parses", "# breeze-unit-version: -1\n", -1, true},
+		// First marker wins, and a garbage first marker short-circuits the scan
+		// (a real concern only if a second marker is ever appended).
+		{"garbage first marker short-circuits", "# breeze-unit-version: x\n# breeze-unit-version: 3\n", 0, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -48,6 +57,31 @@ func TestUnitNeedsReconcile(t *testing.T) {
 				t.Fatalf("unitNeedsReconcile(%q,%d) = %v, want %v", tc.existing, tc.want, got, tc.expect)
 			}
 		})
+	}
+}
+
+func TestReconcileTransientArgs(t *testing.T) {
+	args := reconcileTransientArgs(4242, "/usr/local/bin/breeze-agent")
+	joined := strings.Join(args, " ")
+
+	if !strings.Contains(joined, "--collect") {
+		t.Error("must pass --collect so a failed transient unit doesn't block a later retry")
+	}
+	for _, a := range args {
+		if a == "--scope" || strings.HasPrefix(a, "--scope=") {
+			t.Error("must NOT use --scope: a scope child inherits the sandbox and defeats the escape")
+		}
+	}
+	if !strings.Contains(joined, "--unit=breeze-unit-reconcile-4242") {
+		t.Errorf("transient unit name must be PID-suffixed; got %q", joined)
+	}
+	// The trailing argv must invoke the hidden subcommand on the given binary.
+	if len(args) < 3 {
+		t.Fatalf("argv too short: %v", args)
+	}
+	tail := args[len(args)-3:]
+	if tail[0] != "/usr/local/bin/breeze-agent" || tail[1] != "service" || tail[2] != "reconcile-unit" {
+		t.Errorf("must invoke `<bin> service reconcile-unit`; got trailing %v", tail)
 	}
 }
 

--- a/agent/cmd/breeze-agent/systemd_unit_test.go
+++ b/agent/cmd/breeze-agent/systemd_unit_test.go
@@ -1,0 +1,48 @@
+package main
+
+import "testing"
+
+func TestParseUnitVersion(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantVer int
+		wantOK  bool
+	}{
+		{"present", "[Service]\n# breeze-unit-version: 2\nType=simple\n", 2, true},
+		{"present higher", "# breeze-unit-version: 7\n", 7, true},
+		{"missing", "[Service]\nType=simple\n", 0, false},
+		{"garbage value", "# breeze-unit-version: abc\n", 0, false},
+		{"empty", "", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ver, ok := parseUnitVersion(tc.input)
+			if ver != tc.wantVer || ok != tc.wantOK {
+				t.Fatalf("parseUnitVersion(%q) = (%d,%v), want (%d,%v)", tc.input, ver, ok, tc.wantVer, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestUnitNeedsReconcile(t *testing.T) {
+	cases := []struct {
+		name     string
+		existing string
+		want     int
+		expect   bool
+	}{
+		{"missing marker -> reconcile", "[Service]\nType=simple\n", 2, true},
+		{"older -> reconcile", "# breeze-unit-version: 1\n", 2, true},
+		{"equal -> skip", "# breeze-unit-version: 2\n", 2, false},
+		{"newer -> skip (no downgrade)", "# breeze-unit-version: 3\n", 2, false},
+		{"garbage -> reconcile", "# breeze-unit-version: x\n", 2, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := unitNeedsReconcile(tc.existing, tc.want); got != tc.expect {
+				t.Fatalf("unitNeedsReconcile(%q,%d) = %v, want %v", tc.existing, tc.want, got, tc.expect)
+			}
+		})
+	}
+}

--- a/agent/cmd/breeze-agent/systemd_unit_test.go
+++ b/agent/cmd/breeze-agent/systemd_unit_test.go
@@ -58,18 +58,31 @@ func TestStaticUnitMatchesEmbedded(t *testing.T) {
 		t.Fatalf("read static unit: %v", err)
 	}
 	if string(data) != linuxUnit {
-		t.Fatalf("static breeze-agent.service is not byte-identical to embedded linuxUnit.\n" +
-			"Keep them in sync (the auto-heal writes the embedded copy).")
+		got, want := string(data), linuxUnit
+		i := 0
+		for i < len(got) && i < len(want) && got[i] == want[i] {
+			i++
+		}
+		t.Fatalf("static breeze-agent.service is not byte-identical to embedded linuxUnit "+
+			"(first divergence at byte %d: file has %q, const has %q). "+
+			"Keep them in sync (the auto-heal writes the embedded copy).",
+			i, snippetAt(got, i), snippetAt(want, i))
 	}
 }
 
 func TestUnitIsNotReHardened(t *testing.T) {
 	forbidden := []string{
-		"ProtectSystem=strict",
-		"ProtectHome=read-only",
+		// Directive-NAME prefixes, not specific values: ProtectSystem=full,
+		// ProtectHome=tmpfs, PrivateTmp=yes etc. break children just the same.
+		"ProtectSystem=",
+		"ProtectHome=",
+		"PrivateTmp=",
 		"CapabilityBoundingSet",
 		"AmbientCapabilities",
-		"PrivateTmp=true",
+		// NoNewPrivileges=false is harmless (and was the old explicit value);
+		// only forbid turning it ON, which breaks sudo/su in the terminal.
+		"NoNewPrivileges=true",
+		"NoNewPrivileges=yes",
 	}
 	for _, f := range forbidden {
 		if strings.Contains(linuxUnit, f) {
@@ -83,4 +96,13 @@ func TestUnitIsNotReHardened(t *testing.T) {
 	if v, _ := parseUnitVersion(linuxUnit); v != currentUnitVersion {
 		t.Errorf("linuxUnit marker version != currentUnitVersion (%d)", currentUnitVersion)
 	}
+}
+
+// snippetAt returns a short window of s around byte offset i for error messages.
+func snippetAt(s string, i int) string {
+	end := i + 20
+	if end > len(s) {
+		end = len(s)
+	}
+	return s[i:end]
 }

--- a/agent/cmd/breeze-agent/systemd_unit_test.go
+++ b/agent/cmd/breeze-agent/systemd_unit_test.go
@@ -77,8 +77,21 @@ func TestUnitIsNotReHardened(t *testing.T) {
 		"ProtectSystem=",
 		"ProtectHome=",
 		"PrivateTmp=",
+		"PrivateDevices=",
 		"CapabilityBoundingSet",
 		"AmbientCapabilities",
+		// Other sandbox directives that are equally inherited by the terminal/
+		// script child processes and would re-break admin tasks (read-only FS,
+		// blocked syscalls/namespaces, no device nodes, etc.).
+		"ReadOnlyPaths=",
+		"ReadWritePaths=",
+		"InaccessiblePaths=",
+		"SystemCallFilter=",
+		"RestrictAddressFamilies=",
+		"RestrictNamespaces=",
+		"ProtectKernelModules=",
+		"ProtectKernelTunables=",
+		"MemoryDenyWriteExecute=",
 		// NoNewPrivileges=false is harmless (and was the old explicit value);
 		// only forbid turning it ON, which breaks sudo/su in the terminal.
 		"NoNewPrivileges=true",

--- a/agent/service/systemd/breeze-agent.service
+++ b/agent/service/systemd/breeze-agent.service
@@ -27,7 +27,7 @@ KillMode=mixed
 
 # INTENTIONALLY UNSANDBOXED. The remote terminal and remote script execution
 # features spawn child processes that must behave like a root SSH session:
-#   - package managers drop privileges to unprivileged users (needs CAP_SETUID/SETGID)
+#   - package managers drop privileges to unprivileged users (needs CAP_SETUID/SETGID/CHOWN)
 #   - admins write under /home, /usr, /etc, and expect a shared /tmp
 # systemd sandbox restrictions are INHERITED by those children and silently break
 # these operations. Do not re-add them.

--- a/agent/service/systemd/breeze-agent.service
+++ b/agent/service/systemd/breeze-agent.service
@@ -12,7 +12,16 @@ Type=simple
 ExecStart=/usr/local/bin/breeze-agent start
 WorkingDirectory=/etc/breeze
 Restart=on-failure
+# 30s cooldown spreads respawn across a fleet that crashes simultaneously
+# (e.g. correlated network blip). Combined with StartLimitBurst=5 over
+# StartLimitIntervalSec=60, a misbehaving host backs off entirely instead
+# of stampeding the API.
 RestartSec=30
+
+# Cap total stop time so a hung HTTP flush during OS shutdown (network
+# going down) doesn't block system power-off for the 90s systemd default.
+# KillMode=mixed sends SIGTERM to the main process, then SIGKILL to the
+# whole cgroup after TimeoutStopSec.
 TimeoutStopSec=15
 KillMode=mixed
 

--- a/agent/service/systemd/breeze-agent.service
+++ b/agent/service/systemd/breeze-agent.service
@@ -7,38 +7,26 @@ StartLimitIntervalSec=60
 StartLimitBurst=5
 
 [Service]
+# breeze-unit-version: 2
 Type=simple
 ExecStart=/usr/local/bin/breeze-agent start
 WorkingDirectory=/etc/breeze
 Restart=on-failure
-# 30s cooldown spreads respawn across a fleet that crashes simultaneously
-# (e.g. correlated network blip). Combined with StartLimitBurst=5 over
-# StartLimitIntervalSec=60, a misbehaving host backs off entirely instead
-# of stampeding the API.
 RestartSec=30
-
-# Cap total stop time so a hung HTTP flush during OS shutdown (network
-# going down) doesn't block system power-off for the 90s systemd default.
-# KillMode=mixed sends SIGTERM to the main process, then SIGKILL to the
-# whole cgroup after TimeoutStopSec.
 TimeoutStopSec=15
 KillMode=mixed
 
-# Security hardening
-ProtectSystem=strict
-ProtectHome=read-only
-ReadWritePaths=/etc/breeze /var/lib/breeze /var/log/breeze /var/run/breeze /var/cache/apt /var/lib/apt /var/lib/dpkg /var/log/apt /usr/local/bin
-PrivateTmp=true
-NoNewPrivileges=false
-CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN CAP_SYS_PTRACE CAP_DAC_READ_SEARCH CAP_FOWNER
-AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN CAP_FOWNER
+# INTENTIONALLY UNSANDBOXED. The remote terminal and remote script execution
+# features spawn child processes that must behave like a root SSH session:
+#   - package managers drop privileges to unprivileged users (needs CAP_SETUID/SETGID)
+#   - admins write under /home, /usr, /etc, and expect a shared /tmp
+# systemd sandbox restrictions are INHERITED by those children and silently break
+# these operations. Do not re-add them.
+# See docs/superpowers/specs/2026-06-09-agent-systemd-sandbox-remote-terminal-design.md
 
-# Logging (stdout goes to journald)
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=breeze-agent
-
-# File limits
 LimitNOFILE=8192
 
 [Install]

--- a/docs/superpowers/plans/2026-06-09-agent-systemd-sandbox-remote-terminal.md
+++ b/docs/superpowers/plans/2026-06-09-agent-systemd-sandbox-remote-terminal.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make the Linux agent's remote terminal and remote script execution behave like a root SSH session by removing the inherited systemd sandbox, and auto-heal the already-deployed fleet on next startup.
 
-**Architecture:** Relax the `breeze-agent.service` unit (remove `CapabilityBoundingSet`/`ProtectSystem`/`ProtectHome`/`PrivateTmp`), version-stamp it, and on agent startup detect an outdated on-disk unit and rewrite it by escaping the sandbox via `systemd-run --scope` running a new `service reconcile-unit` subcommand. The watchdog unit stays hardened.
+**Architecture:** Relax the `breeze-agent.service` unit (remove `CapabilityBoundingSet`/`ProtectSystem`/`ProtectHome`/`PrivateTmp`), version-stamp it, and on agent startup detect an outdated on-disk unit and rewrite it by escaping the sandbox via a `systemd-run` **transient service** (PID 1 spawns `service reconcile-unit` outside the agent's namespace/caps — NOT `--scope`, which inherits both). The watchdog unit stays hardened.
 
 **Tech Stack:** Go (agent), systemd, cobra CLI. Tests: Go standard `testing`.
 
@@ -223,7 +223,9 @@ Expected: PASS (unchanged).
 
 - [ ] **Step 2: Write the failing drift / anti-re-hardening test**
 
-Add to `agent/cmd/breeze-agent/systemd_unit_test.go`:
+Add to `agent/cmd/breeze-agent/systemd_unit_test.go`. The file already imports
+`"testing"` from Task 1 — **merge** `"os"` and `"strings"` into that existing import
+block (do not paste a second one):
 
 ```go
 import (
@@ -394,8 +396,8 @@ var serviceReconcileUnitCmd = &cobra.Command{
 		}
 		fmt.Printf("Reconciled %s to unit version %d; restarting service.\n", linuxUnitDst, currentUnitVersion)
 		// Restart so the relaxed sandbox applies to the live process. This kills
-		// the old agent; we run in a separate systemd-run scope, so this child
-		// survives to finish the restart call.
+		// the old agent; we run as a systemd-run transient service whose parent
+		// is PID 1 (not the agent), so this child survives to finish the restart.
 		if out, err := exec.Command("systemctl", "restart", linuxServiceName).CombinedOutput(); err != nil {
 			return fmt.Errorf("restart: %s", strings.TrimSpace(string(out)))
 		}
@@ -420,8 +422,9 @@ var reconcileOnce sync.Once
 // reconcileServiceUnitIfNeeded runs at startup. If the installed unit predates
 // currentUnitVersion, it rewrites it. The running agent is itself sandboxed and
 // cannot write /etc/systemd/system (ProtectSystem=strict on old units), so it
-// escapes via `systemd-run --scope` into a transient cgroup outside this unit's
-// sandbox. Best-effort: on any failure it logs and continues on the old unit.
+// escapes via a systemd-run TRANSIENT SERVICE: PID 1 spawns the reconcile in a
+// fresh execution environment, outside this unit's mount namespace and
+// capability bounding set. Best-effort: on failure it logs and continues.
 func reconcileServiceUnitIfNeeded() {
 	reconcileOnce.Do(func() {
 		// Only act as the installed systemd service running as root.
@@ -442,10 +445,17 @@ func reconcileServiceUnitIfNeeded() {
 					"errors (e.g. apt). Fix: sudo breeze-agent service install\n", currentUnitVersion)
 			return
 		}
-		// --scope: run synchronously in a separate transient cgroup NOT under
-		// breeze-agent.service's sandbox, so the child can write the unit and
-		// survives the agent restart it triggers.
-		out, err := exec.Command("systemd-run", "--scope", "--quiet",
+		// TRANSIENT SERVICE, deliberately NOT --scope: a scope child is forked
+		// from this (sandboxed) process and only its cgroup moves — it would
+		// inherit our read-only /etc (ProtectSystem) and restricted CapBnd and
+		// fail with the same Permission denied. Without --scope, PID 1 spawns
+		// the command in a fresh execution environment with full root caps and
+		// an unrestricted namespace; being a child of PID 1 it also survives
+		// the agent restart it triggers. --collect garbage-collects the
+		// transient unit on failure so a later retry is never blocked.
+		// Fire-and-forget: systemd-run returns once the service starts; the
+		// child rewrites the unit, daemon-reloads, and restarts us.
+		out, err := exec.Command("systemd-run", "--quiet", "--collect",
 			"--unit=breeze-unit-reconcile", linuxBinaryPath, "service", "reconcile-unit").CombinedOutput()
 		if err != nil {
 			fmt.Fprintf(os.Stderr,
@@ -469,7 +479,7 @@ Expected: clean build/vet; tests PASS.
 
 ```bash
 git add agent/cmd/breeze-agent/service_cmd_linux.go
-git commit -m "feat(agent): auto-heal outdated systemd unit via systemd-run scope on startup"
+git commit -m "feat(agent): auto-heal outdated systemd unit via systemd-run transient service"
 ```
 
 ---

--- a/docs/superpowers/plans/2026-06-09-agent-systemd-sandbox-remote-terminal.md
+++ b/docs/superpowers/plans/2026-06-09-agent-systemd-sandbox-remote-terminal.md
@@ -1,0 +1,539 @@
+# Agent systemd Sandbox Relaxation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Linux agent's remote terminal and remote script execution behave like a root SSH session by removing the inherited systemd sandbox, and auto-heal the already-deployed fleet on next startup.
+
+**Architecture:** Relax the `breeze-agent.service` unit (remove `CapabilityBoundingSet`/`ProtectSystem`/`ProtectHome`/`PrivateTmp`), version-stamp it, and on agent startup detect an outdated on-disk unit and rewrite it by escaping the sandbox via `systemd-run --scope` running a new `service reconcile-unit` subcommand. The watchdog unit stays hardened.
+
+**Tech Stack:** Go (agent), systemd, cobra CLI. Tests: Go standard `testing`.
+
+**Spec:** `docs/superpowers/specs/2026-06-09-agent-systemd-sandbox-remote-terminal-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Build tag |
+|---|---|---|
+| `agent/cmd/breeze-agent/systemd_unit.go` (**new**) | Canonical relaxed unit string (`linuxUnit`), `currentUnitVersion`, `parseUnitVersion`, `unitNeedsReconcile` — pure, no OS APIs | none (compiles everywhere, so tests run on macOS dev + linux CI) |
+| `agent/cmd/breeze-agent/systemd_unit_test.go` (**new**) | Table tests for the decision logic + drift / anti-re-hardening guard | none |
+| `agent/cmd/breeze-agent/service_cmd_linux.go` (modify) | Remove the old embedded `const linuxUnit`; implement `reconcileServiceUnitIfNeeded()`; add `serviceReconcileUnitCmd` | linux |
+| `agent/cmd/breeze-agent/service_cmd_darwin.go` (modify) | Rename hook `healLaunchdPlistsIfNeeded` → `reconcileServiceUnitIfNeeded` | darwin |
+| `agent/cmd/breeze-agent/service_cmd_windows.go` (modify) | Rename no-op hook | windows |
+| `agent/cmd/breeze-agent/main.go` (modify, line ~716) | Update the renamed call site + comment | none |
+| `agent/service/systemd/breeze-agent.service` (modify) | Rewrite to the canonical relaxed unit (byte-identical to `linuxUnit`) | n/a |
+
+**Canonical relaxed unit** (used verbatim in BOTH `systemd_unit.go`'s `linuxUnit` const and the static `breeze-agent.service`):
+
+```ini
+[Unit]
+Description=Breeze RMM Agent
+Documentation=https://github.com/breeze-rmm/breeze
+After=network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Service]
+# breeze-unit-version: 2
+Type=simple
+ExecStart=/usr/local/bin/breeze-agent start
+WorkingDirectory=/etc/breeze
+Restart=on-failure
+RestartSec=30
+TimeoutStopSec=15
+KillMode=mixed
+
+# INTENTIONALLY UNSANDBOXED. The remote terminal and remote script execution
+# features spawn child processes that must behave like a root SSH session:
+#   - `apt` drops privileges to the _apt user (needs CAP_SETUID/SETGID/CHOWN)
+#   - admins write under /home, /usr, /etc, and expect a shared /tmp
+# systemd sandbox directives (CapabilityBoundingSet, ProtectSystem, ProtectHome,
+# PrivateTmp) are INHERITED by those children and silently break these operations.
+# Do not re-add them. See docs/superpowers/specs/2026-06-09-agent-systemd-sandbox-remote-terminal-design.md
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=breeze-agent
+LimitNOFILE=8192
+
+[Install]
+WantedBy=multi-user.target
+```
+
+> **Note on `apt` workaround (relay to the reporting user — independent of this change):**
+> `sudo apt -o APT::Sandbox::User=root update` clears the errors today without any agent change.
+
+All commands below assume:
+```bash
+export PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH   # repo node pin (not needed for Go, harmless)
+cd agent
+```
+
+---
+
+## Task 1: Pure unit-version decision logic (TDD)
+
+**Files:**
+- Create: `agent/cmd/breeze-agent/systemd_unit.go`
+- Test: `agent/cmd/breeze-agent/systemd_unit_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agent/cmd/breeze-agent/systemd_unit_test.go`:
+
+```go
+package main
+
+import "testing"
+
+func TestParseUnitVersion(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantVer int
+		wantOK  bool
+	}{
+		{"present", "[Service]\n# breeze-unit-version: 2\nType=simple\n", 2, true},
+		{"present higher", "# breeze-unit-version: 7\n", 7, true},
+		{"missing", "[Service]\nType=simple\n", 0, false},
+		{"garbage value", "# breeze-unit-version: abc\n", 0, false},
+		{"empty", "", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ver, ok := parseUnitVersion(tc.input)
+			if ver != tc.wantVer || ok != tc.wantOK {
+				t.Fatalf("parseUnitVersion(%q) = (%d,%v), want (%d,%v)", tc.input, ver, ok, tc.wantVer, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestUnitNeedsReconcile(t *testing.T) {
+	cases := []struct {
+		name     string
+		existing string
+		want     int
+		expect   bool
+	}{
+		{"missing marker -> reconcile", "[Service]\nType=simple\n", 2, true},
+		{"older -> reconcile", "# breeze-unit-version: 1\n", 2, true},
+		{"equal -> skip", "# breeze-unit-version: 2\n", 2, false},
+		{"newer -> skip (no downgrade)", "# breeze-unit-version: 3\n", 2, false},
+		{"garbage -> reconcile", "# breeze-unit-version: x\n", 2, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := unitNeedsReconcile(tc.existing, tc.want); got != tc.expect {
+				t.Fatalf("unitNeedsReconcile(%q,%d) = %v, want %v", tc.existing, tc.want, got, tc.expect)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/breeze-agent/ -run 'TestParseUnitVersion|TestUnitNeedsReconcile' -v`
+Expected: FAIL — `undefined: parseUnitVersion`, `undefined: unitNeedsReconcile`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `agent/cmd/breeze-agent/systemd_unit.go`:
+
+```go
+package main
+
+import (
+	"strconv"
+	"strings"
+)
+
+// currentUnitVersion is the breeze-unit-version this binary ships. Bump it
+// whenever linuxUnit changes in a way the deployed fleet must pick up; the
+// startup reconcile rewrites any on-disk unit older than this.
+const currentUnitVersion = 2
+
+const unitVersionPrefix = "# breeze-unit-version:"
+
+// parseUnitVersion extracts the breeze-unit-version marker from a unit file.
+// Returns (version, true) when a well-formed marker is present, else (0, false).
+func parseUnitVersion(existing string) (int, bool) {
+	for _, line := range strings.Split(existing, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, unitVersionPrefix) {
+			continue
+		}
+		v, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(line, unitVersionPrefix)))
+		if err != nil {
+			return 0, false
+		}
+		return v, true
+	}
+	return 0, false
+}
+
+// unitNeedsReconcile reports whether the on-disk unit is older than what this
+// binary ships. Missing/garbage marker or a lower version => reconcile. Equal
+// or higher (a newer binary wrote it) => leave it alone, never downgrade.
+func unitNeedsReconcile(existing string, want int) bool {
+	v, ok := parseUnitVersion(existing)
+	if !ok {
+		return true
+	}
+	return v < want
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./cmd/breeze-agent/ -run 'TestParseUnitVersion|TestUnitNeedsReconcile' -v`
+Expected: PASS (8 subtests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/cmd/breeze-agent/systemd_unit.go agent/cmd/breeze-agent/systemd_unit_test.go
+git commit -m "feat(agent): unit-version marker parsing + reconcile decision"
+```
+
+---
+
+## Task 2: Relax the unit + drift guard (TDD)
+
+Move the embedded unit const into the tag-free file with the relaxed content, rewrite the static unit to match, and lock both with a test.
+
+**Files:**
+- Modify: `agent/cmd/breeze-agent/systemd_unit.go` (add `linuxUnit` const)
+- Modify: `agent/cmd/breeze-agent/service_cmd_linux.go:32` (remove old `const linuxUnit`)
+- Modify: `agent/service/systemd/breeze-agent.service` (rewrite to canonical)
+- Test: `agent/cmd/breeze-agent/systemd_unit_test.go` (add drift test)
+
+- [ ] **Step 1: Move `const linuxUnit` verbatim into the tag-free file (pure refactor)**
+
+Cut the entire `const linuxUnit = \`...\`` block (currently `service_cmd_linux.go:32`–end of that string) and paste it into `systemd_unit.go` **unchanged for now**. Leave `linuxUserUnit` and everything else in `service_cmd_linux.go` untouched.
+
+Run: `GOOS=linux go build ./cmd/breeze-agent/`
+Expected: builds (linux file still references the now-relocated `linuxUnit`; same package).
+
+Run: `go test ./cmd/breeze-agent/ -run 'TestParseUnitVersion|TestUnitNeedsReconcile'`
+Expected: PASS (unchanged).
+
+- [ ] **Step 2: Write the failing drift / anti-re-hardening test**
+
+Add to `agent/cmd/breeze-agent/systemd_unit_test.go`:
+
+```go
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestStaticUnitMatchesEmbedded(t *testing.T) {
+	// Test runs with cwd = package dir (agent/cmd/breeze-agent).
+	data, err := os.ReadFile("../../service/systemd/breeze-agent.service")
+	if err != nil {
+		t.Fatalf("read static unit: %v", err)
+	}
+	if string(data) != linuxUnit {
+		t.Fatalf("static breeze-agent.service is not byte-identical to embedded linuxUnit.\n"+
+			"Keep them in sync (the auto-heal writes the embedded copy).")
+	}
+}
+
+func TestUnitIsNotReHardened(t *testing.T) {
+	forbidden := []string{
+		"ProtectSystem=strict",
+		"ProtectHome=read-only",
+		"CapabilityBoundingSet",
+		"AmbientCapabilities",
+		"PrivateTmp=true",
+	}
+	for _, f := range forbidden {
+		if strings.Contains(linuxUnit, f) {
+			t.Errorf("linuxUnit re-introduced a sandbox directive that breaks the remote "+
+				"terminal/scripts: %q (see the spec — do not re-add)", f)
+		}
+	}
+	if _, ok := parseUnitVersion(linuxUnit); !ok {
+		t.Errorf("linuxUnit is missing its %q marker", unitVersionPrefix)
+	}
+	if v, _ := parseUnitVersion(linuxUnit); v != currentUnitVersion {
+		t.Errorf("linuxUnit marker version != currentUnitVersion (%d)", currentUnitVersion)
+	}
+}
+```
+
+Run: `go test ./cmd/breeze-agent/ -run 'TestStaticUnitMatchesEmbedded|TestUnitIsNotReHardened' -v`
+Expected: FAIL — embedded still hardened (no marker, contains `ProtectSystem=strict`), and the static file differs from the embedded copy.
+
+- [ ] **Step 3: Replace both unit definitions with the canonical relaxed unit**
+
+In `systemd_unit.go`, replace the `linuxUnit` const body with the **Canonical relaxed unit** from the File Structure section (backtick string). Then overwrite `agent/service/systemd/breeze-agent.service` with the **exact same** text.
+
+> Critical: the two must be byte-for-byte identical (same trailing newline). The const is a backtick raw string starting `[Unit]\n` and ending after `WantedBy=multi-user.target\n`.
+
+- [ ] **Step 4: Run tests + build**
+
+Run: `go test ./cmd/breeze-agent/ -run 'TestStaticUnitMatchesEmbedded|TestUnitIsNotReHardened|TestParseUnitVersion|TestUnitNeedsReconcile' -v`
+Expected: PASS.
+
+Run: `GOOS=linux go build ./cmd/breeze-agent/ && go vet ./cmd/breeze-agent/`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/cmd/breeze-agent/systemd_unit.go agent/cmd/breeze-agent/service_cmd_linux.go agent/service/systemd/breeze-agent.service agent/cmd/breeze-agent/systemd_unit_test.go
+git commit -m "fix(agent): relax systemd sandbox so remote terminal/scripts run like root SSH
+
+Removes CapabilityBoundingSet/ProtectSystem/ProtectHome/PrivateTmp which
+are inherited by terminal/script children and break apt's _apt privilege
+drop (CAP_SETUID/SETGID/CHOWN) and filesystem writes. Adds a version
+marker + drift guard. Fixes the Ubuntu 'setgroups/seteuid Operation not
+permitted' report."
+```
+
+---
+
+## Task 3: Rename the startup hook across all platforms (refactor)
+
+`healLaunchdPlistsIfNeeded` becomes `reconcileServiceUnitIfNeeded` — a neutral name now that Linux does real work. No behavior change in this task.
+
+**Files:**
+- Modify: `agent/cmd/breeze-agent/service_cmd_darwin.go:470`
+- Modify: `agent/cmd/breeze-agent/service_cmd_linux.go:102`
+- Modify: `agent/cmd/breeze-agent/service_cmd_windows.go:25`
+- Modify: `agent/cmd/breeze-agent/main.go:716`
+
+- [ ] **Step 1: Rename darwin impl**
+
+In `service_cmd_darwin.go`, rename the outer function only (keep `healLaunchdPlists()`/`ensureDesktopHelpersLoaded()` calls):
+
+```go
+// reconcileServiceUnitIfNeeded is the darwin implementation: it self-heals
+// launchd plists from older installs.
+func reconcileServiceUnitIfNeeded() {
+	healLaunchdPlists()
+	ensureDesktopHelpersLoaded()
+}
+```
+
+- [ ] **Step 2: Rename windows no-op**
+
+In `service_cmd_windows.go`:
+
+```go
+// reconcileServiceUnitIfNeeded is a no-op on Windows.
+func reconcileServiceUnitIfNeeded() {}
+```
+
+- [ ] **Step 3: Rename linux no-op (real impl comes in Task 4)**
+
+In `service_cmd_linux.go`, replace the existing no-op:
+
+```go
+// reconcileServiceUnitIfNeeded rewrites an outdated systemd unit on startup.
+// Real implementation added in the next change.
+func reconcileServiceUnitIfNeeded() {}
+```
+
+- [ ] **Step 4: Update the call site**
+
+In `main.go` (~line 716), replace:
+
+```go
+	// Self-heal the installed service unit from older installs (launchd plists on
+	// macOS; systemd unit on Linux) after a binary-only auto-update.
+	reconcileServiceUnitIfNeeded()
+```
+
+- [ ] **Step 5: Build all three platforms + commit**
+
+Run:
+```bash
+go build ./cmd/breeze-agent/                       # darwin (host)
+GOOS=linux   go build ./cmd/breeze-agent/
+GOOS=windows go build ./cmd/breeze-agent/
+```
+Expected: all succeed (no lingering `healLaunchdPlistsIfNeeded` references).
+
+```bash
+git add agent/cmd/breeze-agent/service_cmd_darwin.go agent/cmd/breeze-agent/service_cmd_windows.go agent/cmd/breeze-agent/service_cmd_linux.go agent/cmd/breeze-agent/main.go
+git commit -m "refactor(agent): rename startup heal hook to reconcileServiceUnitIfNeeded"
+```
+
+---
+
+## Task 4: Linux auto-heal — `reconcile-unit` subcommand + sandbox escape
+
+**Files:**
+- Modify: `agent/cmd/breeze-agent/service_cmd_linux.go` (implement `reconcileServiceUnitIfNeeded`, add `serviceReconcileUnitCmd`, register it)
+
+- [ ] **Step 1: Add the `service reconcile-unit` subcommand**
+
+In `service_cmd_linux.go`, add a new command (model the body on `serviceInstallCmd`'s unit write + daemon-reload at lines ~166/183). It is root-gated, idempotent, writes the unit, reloads, and restarts so the relaxed sandbox takes effect:
+
+```go
+var serviceReconcileUnitCmd = &cobra.Command{
+	Use:    "reconcile-unit",
+	Short:  "Rewrite the systemd unit to the current version and restart (internal)",
+	Hidden: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if os.Geteuid() != 0 {
+			return fmt.Errorf("must run as root")
+		}
+		if err := os.WriteFile(linuxUnitDst, []byte(linuxUnit), 0644); err != nil {
+			return fmt.Errorf("write unit: %w", err)
+		}
+		if out, err := exec.Command("systemctl", "daemon-reload").CombinedOutput(); err != nil {
+			return fmt.Errorf("daemon-reload: %s", strings.TrimSpace(string(out)))
+		}
+		fmt.Printf("Reconciled %s to unit version %d; restarting service.\n", linuxUnitDst, currentUnitVersion)
+		// Restart so the relaxed sandbox applies to the live process. This kills
+		// the old agent; we run in a separate systemd-run scope, so this child
+		// survives to finish the restart call.
+		if out, err := exec.Command("systemctl", "restart", linuxServiceName).CombinedOutput(); err != nil {
+			return fmt.Errorf("restart: %s", strings.TrimSpace(string(out)))
+		}
+		return nil
+	},
+}
+```
+
+Register it in `init()` alongside the others:
+
+```go
+	serviceCmd.AddCommand(serviceReconcileUnitCmd)
+```
+
+- [ ] **Step 2: Implement `reconcileServiceUnitIfNeeded` with the sandbox escape + fallback**
+
+Replace the Task 3 no-op in `service_cmd_linux.go`. Add `"sync"` to imports.
+
+```go
+var reconcileOnce sync.Once
+
+// reconcileServiceUnitIfNeeded runs at startup. If the installed unit predates
+// currentUnitVersion, it rewrites it. The running agent is itself sandboxed and
+// cannot write /etc/systemd/system (ProtectSystem=strict on old units), so it
+// escapes via `systemd-run --scope` into a transient cgroup outside this unit's
+// sandbox. Best-effort: on any failure it logs and continues on the old unit.
+func reconcileServiceUnitIfNeeded() {
+	reconcileOnce.Do(func() {
+		// Only act as the installed systemd service running as root.
+		if os.Geteuid() != 0 || os.Getenv("INVOCATION_ID") == "" {
+			return
+		}
+		data, err := os.ReadFile(linuxUnitDst)
+		if err != nil {
+			return // not installed via systemd / unreadable — nothing to heal
+		}
+		if !unitNeedsReconcile(string(data), currentUnitVersion) {
+			return
+		}
+		if _, err := exec.LookPath("systemd-run"); err != nil {
+			fmt.Fprintf(os.Stderr,
+				"Warning: breeze-agent systemd unit is outdated (pre-v%d) and systemd-run is "+
+					"unavailable to auto-heal it. The remote terminal/scripts may hit privilege "+
+					"errors (e.g. apt). Fix: sudo breeze-agent service install\n", currentUnitVersion)
+			return
+		}
+		// --scope: run synchronously in a separate transient cgroup NOT under
+		// breeze-agent.service's sandbox, so the child can write the unit and
+		// survives the agent restart it triggers.
+		out, err := exec.Command("systemd-run", "--scope", "--quiet",
+			"--unit=breeze-unit-reconcile", linuxBinaryPath, "service", "reconcile-unit").CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(os.Stderr,
+				"Warning: failed to auto-heal outdated systemd unit via systemd-run: %s. "+
+					"Fix: sudo breeze-agent service install\n", strings.TrimSpace(string(out)))
+		}
+	})
+}
+```
+
+- [ ] **Step 3: Build linux + vet**
+
+Run:
+```bash
+GOOS=linux go build ./cmd/breeze-agent/ && GOOS=linux go vet ./cmd/breeze-agent/
+go test ./cmd/breeze-agent/ -run 'Unit'   # existing tests still green
+```
+Expected: clean build/vet; tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add agent/cmd/breeze-agent/service_cmd_linux.go
+git commit -m "feat(agent): auto-heal outdated systemd unit via systemd-run scope on startup"
+```
+
+---
+
+## Task 5: Full agent build + manual verification on a Linux host
+
+This task has no new code — it verifies the end-to-end behavior the unit tests cannot (systemctl/systemd-run side effects).
+
+- [ ] **Step 1: Full agent compile (race) on linux**
+
+Run: `GOOS=linux go build ./... && go test ./cmd/breeze-agent/...`
+Expected: builds; package tests pass.
+
+- [ ] **Step 2: Reproduce the bug with the OLD unit**
+
+On a throwaway Ubuntu 24.04 VM, install an agent built from `main` (old hardened unit). In the remote terminal:
+```bash
+grep Cap /proc/$(pidof breeze-agent)/status   # CapBnd is the restricted set
+apt update                                     # reproduces setgroups/seteuid/chown errors
+```
+
+- [ ] **Step 3: Upgrade to the new binary and observe auto-heal**
+
+Deploy the new binary (binary-only, as the updater does) and restart once. Watch the journal:
+```bash
+journalctl -u breeze-agent -f
+# expect: reconcile escape runs, unit rewritten, daemon-reload, service restart
+systemctl cat breeze-agent | grep breeze-unit-version   # => 2
+```
+
+- [ ] **Step 4: Confirm the fix**
+
+```bash
+grep Cap /proc/$(pidof breeze-agent)/status    # CapBnd now full (0x...1ffffffffff-class)
+# In the remote terminal:
+apt update                                      # succeeds, no privilege errors
+# Remote SCRIPT that runs `apt update` and writes under /home:
+#   also succeeds
+```
+
+- [ ] **Step 5: Confirm graceful fallback**
+
+On a host without `systemd-run` (or D-Bus unavailable), start the agent with an outdated unit and confirm it logs the one-time WARNING and keeps running (no crash, no restart loop):
+```bash
+journalctl -u breeze-agent | grep "systemd unit is outdated"
+```
+
+- [ ] **Step 6: Final commit / PR**
+
+```bash
+git add docs/superpowers/specs/2026-06-09-agent-systemd-sandbox-remote-terminal-design.md docs/superpowers/plans/2026-06-09-agent-systemd-sandbox-remote-terminal.md
+git commit -m "docs(agent): systemd sandbox relaxation spec + plan"
+# open PR from this branch
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:**
+- §5.1 relaxed unit → Task 2. §5.2 versioned marker + `unitNeedsReconcile` → Task 1. §5.3 escape + `reconcile-unit` → Task 4. §5.4 loop prevention → Task 4 (`sync.Once` guard + restart-only-after-write in the subcommand). §5.5 fallback → Task 4 Step 2 + Task 5 Step 5. §5.6 startup wiring/rename → Task 3. §6 apt workaround → File Structure note + Task 5 Step 2. §8 tests (decision + drift/anti-re-harden) → Tasks 1–2. §9 verification → Task 5. Watchdog untouched (non-goal) — no task, correct.
+- Added beyond spec: rename of the **windows** no-op (Task 3 Step 2) — required or the windows build breaks; the spec only named darwin+linux.
+
+**Placeholder scan:** none — every code/command step is concrete.
+
+**Type/name consistency:** `linuxUnit`, `currentUnitVersion`, `unitVersionPrefix`, `parseUnitVersion`, `unitNeedsReconcile`, `reconcileServiceUnitIfNeeded`, `serviceReconcileUnitCmd`, `linuxUnitDst`, `linuxBinaryPath`, `linuxServiceName` are used identically across tasks and match the existing symbols in `service_cmd_linux.go`.
+```

--- a/docs/superpowers/specs/2026-06-09-agent-systemd-sandbox-remote-terminal-design.md
+++ b/docs/superpowers/specs/2026-06-09-agent-systemd-sandbox-remote-terminal-design.md
@@ -1,0 +1,289 @@
+and a # Linux Agent systemd Sandbox Relaxation for Remote Terminal & Script Execution
+
+**Status:** Design / approved direction
+**Date:** 2026-06-09
+**Author:** Todd Hebebrand (with Claude)
+**Area:** Go agent — `agent/cmd/breeze-agent`, `agent/service/systemd`
+
+---
+
+## 1. Problem
+
+A user on a fresh agent install (Ubuntu 24.04 server) ran `apt update` through the
+agent's **remote terminal** and got a wall of privilege-drop failures:
+
+```
+E: setgroups 65534 failed - setgroups (1: Operation not permitted)
+E: setegid 65534 failed - setegid (1: Operation not permitted)
+E: seteuid 42 failed - seteuid (1: Operation not permitted)
+W: chown to _apt:root of directory /var/lib/apt/lists/partial failed - SetupAPTPartialDirectory (1: Operation not permitted)
+E: The repository '... noble-security Release' no longer has a Release file.
+```
+
+The identical commands succeed over plain SSH, so the server itself is healthy.
+
+## 2. Root cause
+
+The agent runs as a systemd service whose unit deliberately hardens the **agent
+process** with an inherited sandbox (`agent/service/systemd/breeze-agent.service:27-34`,
+mirrored in the embedded template at `agent/cmd/breeze-agent/service_cmd_linux.go:32`):
+
+```ini
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/etc/breeze /var/lib/breeze /var/log/breeze /var/run/breeze /var/cache/apt /var/lib/apt /var/lib/dpkg /var/log/apt /usr/local/bin -/run/ufw.lock
+PrivateTmp=true
+NoNewPrivileges=false
+CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN CAP_SYS_PTRACE CAP_DAC_READ_SEARCH CAP_FOWNER
+AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN CAP_FOWNER
+```
+
+The remote terminal spawns its shell as a **child** of the agent process
+(`agent/internal/terminal/pty_unix.go:74` — only `Setsid`/`Setctty`, no credential
+manipulation). A child can never hold capabilities outside its parent's
+`CapabilityBoundingSet`, and it inherits the parent's mount namespace
+(`ProtectSystem`/`ProtectHome`/`PrivateTmp`). So the `bash → apt` chain is sandboxed.
+
+`apt` needs to drop privileges to the `_apt` user (uid 42, gid 65534) for its download
+sandbox, and to chown its partial dir. That requires three capabilities the unit removes:
+
+| apt failure | Missing capability |
+|---|---|
+| `setgroups`/`setegid 65534`, `seteuid 42 failed` | `CAP_SETUID`, `CAP_SETGID` |
+| `chown to _apt:root … failed` | `CAP_CHOWN` |
+
+Over SSH, `sshd` spawns the shell with the full capability set and an unrestricted
+filesystem view — hence the asymmetry. The agent's **remote script execution** path
+runs through the same agent process and inherits the same sandbox, so the bug is not
+limited to the interactive terminal.
+
+## 3. Goals / Non-goals
+
+**Goals**
+- Remote terminal and remote script execution behave like a root SSH session: full
+  capabilities, writable filesystem, shared `/tmp`.
+- The fix reaches the **already-deployed fleet**, not just new installs.
+- No regression to the agent's own features that currently rely on elevated caps
+  (discovery `CAP_NET_RAW`/`CAP_NET_ADMIN`, process monitoring `CAP_SYS_PTRACE`,
+  cross-user file reads `CAP_DAC_READ_SEARCH`).
+
+**Non-goals**
+- Hardening the watchdog differently — `breeze-watchdog.service` stays as-is (it is a
+  pure supervisor, never spawns admin shells).
+- Per-command privilege sandboxing of terminal/script output (out of scope; the product
+  contract is "run admin commands as root").
+- Windows/macOS — unaffected (different service models, no inherited Linux cap sandbox).
+
+## 4. Decision
+
+Two decisions were settled during brainstorming:
+
+- **Approach A — relax the agent unit** (chosen over Approach B, per-child sandbox escape
+  via `systemd-run` on every terminal/script spawn). The agent runs as root; a restrictive
+  bounding set on a root daemon whose *entire purpose* is running arbitrary root commands
+  provides marginal defense-in-depth while reliably breaking legitimate admin work. Approach
+  A is simple, dependency-free on the hot path, and works on every host.
+- **Rollout Option 2 — auto-heal** (chosen over Option 1 ship-and-document-manual and
+  Option 3 detect-and-warn). The deployed fleet is repaired automatically; the weaker
+  options remain as the graceful-degradation fallback.
+
+## 5. Design
+
+### 5.1 Relaxed unit (both definitions, kept byte-identical)
+
+Remove every directive that is inherited by child processes and breaks admin work:
+`CapabilityBoundingSet`, `AmbientCapabilities`, `ProtectSystem`, `ProtectHome`,
+`PrivateTmp`, and the now-meaningless `ReadWritePaths` (only had effect under
+`ProtectSystem`). Keep all operational directives. Add a version marker and an
+explanatory comment so nobody silently re-hardens it.
+
+```ini
+[Unit]
+Description=Breeze RMM Agent
+Documentation=https://github.com/breeze-rmm/breeze
+After=network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Service]
+# breeze-unit-version: 2
+Type=simple
+ExecStart=/usr/local/bin/breeze-agent start
+WorkingDirectory=/etc/breeze
+Restart=on-failure
+RestartSec=30
+TimeoutStopSec=15
+KillMode=mixed
+
+# INTENTIONALLY UNSANDBOXED. The remote terminal and remote script execution
+# features spawn child processes that must behave like a root SSH session:
+#   - `apt` drops privileges to the _apt user (needs CAP_SETUID/SETGID/CHOWN)
+#   - admins write under /home, /usr, /etc, and expect a shared /tmp
+# systemd sandbox directives (CapabilityBoundingSet, ProtectSystem, ProtectHome,
+# PrivateTmp) are INHERITED by those children and silently break these operations.
+# Do not re-add them. See docs/superpowers/specs/2026-06-09-agent-systemd-sandbox-remote-terminal-design.md
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=breeze-agent
+LimitNOFILE=8192
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Since the agent runs as root, removing `CapabilityBoundingSet` *restores* the full
+capability set — the agent's own elevated-cap features keep working because
+unrestricted-root is strictly more permissive than the previous allowlist.
+
+The two definitions to update (and keep identical):
+- `agent/service/systemd/breeze-agent.service` (static, shipped in repo)
+- `linuxUnit` constant — `agent/cmd/breeze-agent/service_cmd_linux.go:32`
+
+### 5.2 Versioned unit + reconcile decision
+
+Embed `# breeze-unit-version: N` in the unit. Bump to `2` for this change (the existing
+hardened unit is treated as implicit/unmarked v1). The binary knows the version it
+expects (`currentUnitVersion = 2`).
+
+A pure, unit-testable decision function:
+
+```go
+// unitNeedsReconcile reports whether the on-disk unit is older than what this
+// binary ships. Missing marker or lower version => reconcile. Equal or higher
+// (a newer binary wrote it, or we're mid-rollout) => leave it alone (no downgrade).
+func unitNeedsReconcile(existing string, want int) bool
+```
+
+The agent can always **read** `/etc/systemd/system/breeze-agent.service` (world-readable;
+`ProtectSystem` does not block reads), so detection works even under the old sandbox.
+
+### 5.3 Auto-heal via sandbox escape
+
+The running (old-sandbox) agent **cannot write** `/etc/systemd/system` — it's read-only
+under `ProtectSystem=strict`, and it is not in `ReadWritePaths`. The agent's self-update
+path (`agent/internal/updater/updater.go`) only swaps the binary and `systemctl restart`s;
+it never rewrites the unit. So healing must escape the sandbox.
+
+**Mechanism:** on startup, if `unitNeedsReconcile`, the agent runs:
+
+```
+systemd-run --scope --quiet --unit=breeze-unit-reconcile \
+    /usr/local/bin/breeze-agent service reconcile-unit
+```
+
+`--scope` runs the child synchronously in a **separate transient cgroup** that is NOT
+under `breeze-agent.service`'s sandbox, so it can write the unit. Because it is a separate
+scope, the agent restart it triggers does not kill it mid-write.
+
+**New subcommand `service reconcile-unit`** (root-gated, idempotent):
+1. Write the current `linuxUnit` to `/etc/systemd/system/breeze-agent.service`.
+2. `systemctl daemon-reload`.
+3. `systemctl restart breeze-agent` (so the relaxed sandbox takes effect on the live process).
+
+### 5.4 Loop prevention
+
+Structural: the restart in step 3 happens **only after** a successful unit write, and the
+freshly written unit carries the current marker. The restarted agent reads it, finds it
+current, and skips reconcile — no loop. Belt-and-suspenders: a per-boot guard ensures the
+escape is attempted at most once per process lifetime (e.g. an in-process `sync.Once` plus
+a short-lived breadcrumb file under `/var/lib/breeze` to suppress repeated attempts if a
+write somehow fails).
+
+### 5.5 Graceful fallback (absorbs Option 3)
+
+If `systemd-run` is absent (minimal images), or the scope fails (no D-Bus, container
+without a system manager), the agent does **not** loop or crash. It:
+- emits a one-time WARNING **diagnostic log** (ships to the API, visible as a device log)
+  instructing the operator to run `sudo breeze-agent service install`, and
+- continues running on the old sandbox.
+
+Worst case degrades to "documented manual remediation + fleet visibility," never to breakage.
+
+### 5.6 Startup wiring
+
+Rename the cross-platform startup hook `healLaunchdPlistsIfNeeded()` →
+`reconcileServiceUnitIfNeeded()` (it is currently a no-op on Linux at
+`service_cmd_linux.go:101` and the macOS plist-healer on darwin). Give Linux a real
+implementation; keep the darwin body unchanged behind the new name. It is already called
+once at startup before the heartbeat loop — early enough that the reconcile-triggered
+restart happens before any terminal/script child is spawned.
+
+## 6. Immediate user workaround (independent of this change)
+
+Relayed to the reporting user so they're unblocked today:
+
+```bash
+sudo apt -o APT::Sandbox::User=root update
+# or persist:
+echo 'APT::Sandbox::User "root";' | sudo tee /etc/apt/apt.conf.d/10no-sandbox
+```
+
+This tells apt to skip the `_apt` privilege-drop, clearing all `setuid`/`setgid`/`chown`
+errors without any agent change.
+
+## 7. Code changes
+
+| # | File | Change |
+|---|---|---|
+| 1 | `agent/service/systemd/breeze-agent.service` | Relax + version marker + comment |
+| 2 | `agent/cmd/breeze-agent/service_cmd_linux.go` | Relax embedded `linuxUnit`; add `currentUnitVersion`, `unitNeedsReconcile`, Linux `reconcileServiceUnitIfNeeded`, the `systemd-run` escape, and the `service reconcile-unit` subcommand |
+| 3 | `agent/cmd/breeze-agent/service_cmd_darwin.go` | Rename hook `healLaunchdPlistsIfNeeded` → `reconcileServiceUnitIfNeeded` (no behavior change) |
+| 4 | call site (`main.go` / wherever the hook is invoked) | Update to the renamed hook |
+| 5 | `agent/cmd/breeze-agent/service_cmd_linux_test.go` (new) | Tests — see §8 |
+
+The watchdog unit (`agent/cmd/breeze-watchdog/service_cmd_linux.go`) is **not** changed.
+
+## 8. Testing (TDD)
+
+Write tests first:
+
+- **`unitNeedsReconcile` table test** — missing marker → true; lower version → true; equal
+  → false; higher → false (no downgrade); malformed/garbage marker → true (heal).
+- **Drift / anti-re-hardening guard** — assert the static file
+  `agent/service/systemd/breeze-agent.service` and the embedded `linuxUnit` are
+  byte-identical, both contain `# breeze-unit-version: 2`, and **neither** contains
+  `ProtectSystem=strict`, `CapabilityBoundingSet`, `ProtectHome=read-only`, or `PrivateTmp`.
+  This is the regression backstop against someone silently re-hardening either copy.
+
+The `systemd-run` escape, the `service reconcile-unit` side effects, and the self-restart
+are integration/manual — structured so the decision logic is pure (tested) and the
+side-effecting exec is a thin, separately-reviewed wrapper.
+
+## 9. Verification (manual, on a Linux host)
+
+1. Install the **old** hardened unit, start the agent, confirm a terminal `apt update`
+   reproduces the `setuid`/`setgid`/`chown` errors and that
+   `grep Cap /proc/$(pidof breeze-agent)/status` shows the restricted `CapBnd`.
+2. Upgrade to the new binary; on startup observe the reconcile escape rewrite the unit and
+   self-restart (journal: unit rewritten, `daemon-reload`, restart).
+3. Confirm `CapBnd` of the new agent process is now full (`0x000001ffffffffff`-class) and
+   the unit on disk carries `# breeze-unit-version: 2`.
+4. Re-run `apt update` in the terminal — succeeds with no privilege errors.
+5. Re-run a remote **script** that does `apt update` and writes under `/home` — succeeds.
+6. On a host without `systemd-run` (or with D-Bus unavailable), confirm the agent logs the
+   one-time WARNING diagnostic and keeps running rather than looping/crashing.
+
+## 10. Security considerations
+
+- The agent already runs as root; relaxing the bounding set does not grant it any privilege
+  it could not already obtain via its own terminal/script features. The change widens the
+  *agent process'* ambient capability set, but the practical attack surface (root remote
+  command execution) is unchanged.
+- The `reconcile-unit` subcommand writes a fixed, in-binary unit string to a fixed path and
+  is root-gated; it takes no untrusted input.
+- `systemd-run --scope` is invoked with a fixed argv (no shell, no interpolation).
+- The watchdog remains sandboxed, preserving defense-in-depth for the supervisor that does
+  not need elevated behavior.
+
+## 11. Risks / edge cases
+
+- **Non-systemd or container hosts:** `systemd-run` may be missing/unusable → handled by
+  §5.5 fallback.
+- **Partial write:** restart only follows a successful write (§5.4), so a failed write
+  leaves the old (working-but-sandboxed) unit in place and logs the fallback warning.
+- **Concurrent fleet restart:** existing `StartLimitBurst`/`RestartSec` backoff is retained;
+  the one-time reconcile restart is per-host and not correlated.
+- **Drift between the two unit definitions:** prevented by the §8 byte-identical test.
+```

--- a/docs/superpowers/specs/2026-06-09-agent-systemd-sandbox-remote-terminal-design.md
+++ b/docs/superpowers/specs/2026-06-09-agent-systemd-sandbox-remote-terminal-design.md
@@ -1,4 +1,4 @@
-and a # Linux Agent systemd Sandbox Relaxation for Remote Terminal & Script Execution
+# Linux Agent systemd Sandbox Relaxation for Remote Terminal & Script Execution
 
 **Status:** Design / approved direction
 **Date:** 2026-06-09
@@ -169,13 +169,27 @@ it never rewrites the unit. So healing must escape the sandbox.
 **Mechanism:** on startup, if `unitNeedsReconcile`, the agent runs:
 
 ```
-systemd-run --scope --quiet --unit=breeze-unit-reconcile \
+systemd-run --quiet --collect --unit=breeze-unit-reconcile \
     /usr/local/bin/breeze-agent service reconcile-unit
 ```
 
-`--scope` runs the child synchronously in a **separate transient cgroup** that is NOT
-under `breeze-agent.service`'s sandbox, so it can write the unit. Because it is a separate
-scope, the agent restart it triggers does not kill it mid-write.
+This launches the reconcile as a **transient service**: `systemd-run` asks PID 1 over
+D-Bus to spawn the command, and PID 1 forks it in a **fresh execution environment** —
+full root capabilities and an unrestricted mount namespace — so it can write the unit.
+Because its parent is PID 1 (not the agent), the agent restart it triggers cannot kill
+it mid-write. `--collect` garbage-collects the transient unit even if it fails, so a
+retry on a later startup is never blocked by a leftover failed unit.
+
+> **Why NOT `systemd-run --scope`:** a scope child is forked by `systemd-run` itself —
+> a descendant of the sandboxed agent — and only its *cgroup* moves. The mount namespace
+> (`ProtectSystem=strict`) and the capability bounding set are inherited through
+> fork/exec regardless of cgroup, so a scope child would hit the same `Permission
+> denied` writing `/etc/systemd/system`. The escape MUST be a transient service.
+
+D-Bus from inside the sandbox is proven viable on the deployed fleet: the self-updater
+already calls `systemctl restart breeze-agent` from the sandboxed agent
+(`agent/internal/updater/restart_unix.go:30`) and that works in production — the same
+PID 1 round-trip `systemd-run` needs.
 
 **New subcommand `service reconcile-unit`** (root-gated, idempotent):
 1. Write the current `linuxUnit` to `/etc/systemd/system/breeze-agent.service`.
@@ -193,8 +207,8 @@ write somehow fails).
 
 ### 5.5 Graceful fallback (absorbs Option 3)
 
-If `systemd-run` is absent (minimal images), or the scope fails (no D-Bus, container
-without a system manager), the agent does **not** loop or crash. It:
+If `systemd-run` is absent (minimal images), or the transient service cannot be started
+(no D-Bus, container without a system manager), the agent does **not** loop or crash. It:
 - emits a one-time WARNING **diagnostic log** (ships to the API, visible as a device log)
   instructing the operator to run `sudo breeze-agent service install`, and
 - continues running on the old sandbox.
@@ -273,7 +287,7 @@ side-effecting exec is a thin, separately-reviewed wrapper.
   command execution) is unchanged.
 - The `reconcile-unit` subcommand writes a fixed, in-binary unit string to a fixed path and
   is root-gated; it takes no untrusted input.
-- `systemd-run --scope` is invoked with a fixed argv (no shell, no interpolation).
+- `systemd-run` is invoked with a fixed argv (no shell, no interpolation).
 - The watchdog remains sandboxed, preserving defense-in-depth for the supervisor that does
   not need elevated behavior.
 

--- a/docs/superpowers/specs/2026-06-09-agent-systemd-sandbox-remote-terminal-design.md
+++ b/docs/superpowers/specs/2026-06-09-agent-systemd-sandbox-remote-terminal-design.md
@@ -209,11 +209,21 @@ write somehow fails).
 
 If `systemd-run` is absent (minimal images), or the transient service cannot be started
 (no D-Bus, container without a system manager), the agent does **not** loop or crash. It:
-- emits a one-time WARNING **diagnostic log** (ships to the API, visible as a device log)
-  instructing the operator to run `sudo breeze-agent service install`, and
+- emits a one-time WARNING to stderr → **journald** under `breeze-agent`, instructing the
+  operator to run `sudo breeze-agent service install`, and
 - continues running on the old sandbox.
 
-Worst case degrades to "documented manual remediation + fleet visibility," never to breakage.
+Worst case degrades to "documented manual remediation + a local journald warning," never
+to breakage.
+
+> **Known limitation (follow-up candidate):** these warnings reach journald only, not the
+> fleet/API. `reconcileServiceUnitIfNeeded` runs at startup *before* the remote log shipper
+> is initialized, and the `reconcile-unit` subcommand's own failures are emitted under the
+> garbage-collected transient unit's journal. So a host whose auto-heal *fails* stays on the
+> old sandboxed unit with no fleet-visible signal — the operator only learns of it if a user
+> re-reports the symptom (e.g. `apt` failing in the terminal). Surfacing heal-failure as a
+> heartbeat/telemetry flag (so affected hosts are visible in the console without an SSH
+> session) is a worthwhile follow-up but is out of scope for this change.
 
 ### 5.6 Startup wiring
 

--- a/docs/superpowers/specs/2026-06-09-agent-systemd-sandbox-remote-terminal-design.md
+++ b/docs/superpowers/specs/2026-06-09-agent-systemd-sandbox-remote-terminal-design.md
@@ -223,7 +223,7 @@ to breakage.
 > old sandboxed unit with no fleet-visible signal — the operator only learns of it if a user
 > re-reports the symptom (e.g. `apt` failing in the terminal). Surfacing heal-failure as a
 > heartbeat/telemetry flag (so affected hosts are visible in the console without an SSH
-> session) is a worthwhile follow-up but is out of scope for this change.
+> session) is a worthwhile follow-up but is out of scope for this change. Tracked in #1201.
 
 ### 5.6 Startup wiring
 


### PR DESCRIPTION
## Problem

On a fresh agent install (Ubuntu 24.04), running `apt update` through the agent's **remote terminal** fails with a wall of privilege-drop errors:

```
E: setgroups 65534 failed - setgroups (1: Operation not permitted)
E: setegid 65534 failed - setegid (1: Operation not permitted)
E: seteuid 42 failed - seteuid (1: Operation not permitted)
W: chown to _apt:root ... SetupAPTPartialDirectory (1: Operation not permitted)
```

The same commands work fine over plain SSH.

## Root cause

The agent runs as a systemd service whose unit hardened the **agent process** (`CapabilityBoundingSet` without `CAP_SETUID`/`SETGID`/`CHOWN`, `ProtectSystem=strict`, `ProtectHome=read-only`, `PrivateTmp`). The remote terminal and remote script execution spawn their shell/command as **children** of the agent, which inherit that capability bounding set and mount namespace. `apt` needs to drop privileges to the `_apt` user (uid 42 / gid 65534) and chown its partial dir — impossible without those capabilities. SSH spawns shells with the full set, hence the asymmetry.

## What this does

1. **Relaxes the agent unit** — removes the inherited sandbox directives so terminal/script children behave like a root SSH session. Operational directives (Restart/StartLimit/TimeoutStopSec/KillMode/LimitNOFILE) are kept. The **watchdog** unit stays hardened (it never spawns admin shells). Both the static `breeze-agent.service` and the embedded `linuxUnit` are now byte-identical, enforced by a drift test.
2. **Auto-heals the deployed fleet** — the running agent is sandboxed and can't rewrite `/etc/systemd/system` itself, and the auto-updater only swaps the binary. So on startup, if the on-disk unit predates `# breeze-unit-version: 2`, the agent escapes the sandbox via a `systemd-run` **transient service** (PID 1 spawns the rewrite outside the agent's namespace/caps — deliberately not `--scope`, which would inherit both) that rewrites the unit + `daemon-reload` + `restart`. Gated on root + `INVOCATION_ID`, `sync.Once`, loop-safe, with a graceful stderr fallback if `systemd-run` is unavailable.

Immediate user workaround (no agent change): `sudo apt -o APT::Sandbox::User=root update`.

## Test plan

Automated (green):
- [x] `parseUnitVersion` / `unitNeedsReconcile` table tests
- [x] Drift guard: static unit == embedded `linuxUnit` (byte-identical)
- [x] Anti-re-harden guard: fails if any sandbox directive (ProtectSystem/ProtectHome/PrivateTmp/CapabilityBoundingSet/SystemCallFilter/…) reappears or the version marker drifts
- [x] `GOOS=linux|windows|darwin go build`, `go vet`, `go test -race ./cmd/breeze-agent/`

Manual on-host (Ubuntu 24.04 — **pending before merge**):
- [ ] Reproduce: old unit → `apt update` in terminal shows the setuid/chown errors; `grep Cap /proc/$(pidof breeze-agent)/status` shows restricted `CapBnd`
- [ ] Upgrade to new binary, restart once → journal shows reconcile escape + unit rewrite; `systemctl cat breeze-agent` shows `breeze-unit-version: 2`
- [ ] Confirm: full `CapBnd`; `apt update` and a remote script writing under `/home` both succeed
- [ ] Fallback: on a host without `systemd-run`, agent logs the one-time warning and keeps running (no loop/crash)

Spec: `docs/superpowers/specs/2026-06-09-agent-systemd-sandbox-remote-terminal-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)