### PR TITLE
fix(agent): verify Breeze Helper installer against signed manifest before install (HIGH)

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -360,6 +360,8 @@ func NewWithVersion(cfg *config.Config, version string, token *secmem.SecureStri
 	if runtime.GOOS == "windows" && cfg.IsService {
 		h.helperMgr = helper.New(helperCtx, cfg.ServerURL, ftToken, cfg.AgentID,
 			helper.WithSessionEnumerator(helper.NewPlatformEnumerator()),
+			helper.WithAgentVersion(version),
+			helper.WithManifestKeys(cfg.PinnedManifestPubKeys),
 			helper.WithSpawnFunc(func(sessionKey, binaryPath string, args ...string) (int, error) {
 				// Try launching via connected user-role helper first (runs as
 				// the logged-in user, so the Tauri app inherits user identity).
@@ -384,6 +386,8 @@ func NewWithVersion(cfg *config.Config, version string, token *secmem.SecureStri
 		// IPC helper (LaunchAgent) so the Tauri app runs in the user session.
 		h.helperMgr = helper.New(helperCtx, cfg.ServerURL, ftToken, cfg.AgentID,
 			helper.WithSessionEnumerator(helper.NewPlatformEnumerator()),
+			helper.WithAgentVersion(version),
+			helper.WithManifestKeys(cfg.PinnedManifestPubKeys),
 			helper.WithSpawnFunc(func(sessionKey, binaryPath string, args ...string) (int, error) {
 				if err := h.sessionBroker.LaunchProcessViaUserHelperForSession(sessionKey, binaryPath, args...); err == nil {
 					return 0, nil // PID unknown when launched via IPC; refreshPID will reconcile
@@ -394,6 +398,8 @@ func NewWithVersion(cfg *config.Config, version string, token *secmem.SecureStri
 	} else {
 		h.helperMgr = helper.New(helperCtx, cfg.ServerURL, ftToken, cfg.AgentID,
 			helper.WithSessionEnumerator(helper.NewPlatformEnumerator()),
+			helper.WithAgentVersion(version),
+			helper.WithManifestKeys(cfg.PinnedManifestPubKeys),
 		)
 	}
 

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -2321,7 +2321,19 @@ func (h *Heartbeat) sendHeartbeat() {
 
 	// Handle helper upgrade if requested
 	if response.HelperUpgradeTo != "" {
-		h.helperMgr.CheckUpdate(response.HelperUpgradeTo)
+		installedHelper := h.helperMgr.InstalledVersion()
+		if allowed, reason := helperUpgradeAllowed(response.HelperUpgradeTo, installedHelper); !allowed {
+			// SECURITY: never auto-downgrade the helper. The signed manifest
+			// only binds manifest.Release == requested version, so a
+			// compromised/MITM'd control plane could replay an older,
+			// validly-signed, known-vulnerable helper release.
+			log.Error("SECURITY: refusing server-directed helper update",
+				"installedVersion", installedHelper,
+				"targetVersion", response.HelperUpgradeTo,
+				"reason", reason)
+		} else {
+			h.helperMgr.CheckUpdate(response.HelperUpgradeTo)
+		}
 	}
 
 	// Update tunnel manager policy flag

--- a/agent/internal/heartbeat/version_downgrade.go
+++ b/agent/internal/heartbeat/version_downgrade.go
@@ -48,3 +48,36 @@ func isDowngrade(target, current string) bool {
 	}
 	return tPatch < cPatch
 }
+
+// helperUpgradeAllowed reports whether a server-directed Helper upgrade to
+// target should proceed given the currently installed helper version. On
+// refusal it returns a short reason suitable for structured logging.
+//
+// SECURITY: this mirrors the agent self-update downgrade guard above —
+// the signed release manifest only binds manifest.Release == requested
+// version, so a compromised/MITM control plane could replay an older,
+// validly-signed, known-vulnerable helper release. Unlike isDowngrade
+// (fail-open, because agent "dev" builds must stay updatable), this check
+// fails CLOSED on unparseable versions: the target always originates from
+// the control plane and must be a real release semver, and a non-empty but
+// unparseable installed version means we cannot prove the directive isn't
+// a downgrade replay.
+//
+// An empty installed version means the helper isn't installed yet — that is
+// a fresh install, not a downgrade, so it is allowed.
+func helperUpgradeAllowed(target, installed string) (allowed bool, reason string) {
+	if _, _, _, ok := parseSemver(target); !ok {
+		return false, "target version is not a parseable semver"
+	}
+	if strings.TrimSpace(installed) == "" {
+		// Helper not installed yet — fresh install, not a downgrade.
+		return true, ""
+	}
+	if _, _, _, ok := parseSemver(installed); !ok {
+		return false, "installed helper version is not a parseable semver"
+	}
+	if isDowngrade(target, installed) {
+		return false, "target version is older than installed helper"
+	}
+	return true, ""
+}

--- a/agent/internal/heartbeat/version_downgrade_test.go
+++ b/agent/internal/heartbeat/version_downgrade_test.go
@@ -33,3 +33,55 @@ func TestIsDowngrade(t *testing.T) {
 		})
 	}
 }
+
+func TestHelperUpgradeAllowed(t *testing.T) {
+	cases := []struct {
+		name        string
+		target      string
+		installed   string
+		wantAllowed bool
+		wantReason  bool // expect a non-empty refusal reason
+	}{
+		// Downgrades refused (the MUST-FIX: replayed older signed release).
+		{"downgrade patch refused", "0.68.1", "0.68.2", false, true},
+		{"downgrade minor refused", "0.67.9", "0.68.0", false, true},
+		{"downgrade major refused", "0.99.9", "1.0.0", false, true},
+		{"v-prefix downgrade refused", "v0.68.1", "0.68.2", false, true},
+
+		// Upgrades allowed.
+		{"upgrade patch allowed", "0.68.3", "0.68.2", true, false},
+		{"upgrade minor allowed", "0.69.0", "0.68.9", true, false},
+		{"upgrade major allowed", "1.0.0", "0.99.9", true, false},
+		{"v-prefix upgrade allowed", "v0.69.0", "v0.68.2", true, false},
+
+		// Equal version allowed through (CheckUpdate/applyPendingUpdate
+		// already no-op when installed == target).
+		{"same version allowed", "0.68.2", "0.68.2", true, false},
+
+		// Fresh install: no helper installed yet — not a downgrade.
+		{"fresh install empty installed allowed", "0.68.2", "", true, false},
+		{"fresh install whitespace installed allowed", "0.68.2", "   ", true, false},
+
+		// Malformed versions fail closed (unlike agent-path isDowngrade).
+		{"malformed target refused", "dev", "0.68.2", false, true},
+		{"empty target refused", "", "0.68.2", false, true},
+		{"two-part target refused", "0.68", "0.68.2", false, true},
+		{"malformed installed refused", "0.68.3", "dev", false, true},
+		{"both malformed refused", "dev", "dev", false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			allowed, reason := helperUpgradeAllowed(tc.target, tc.installed)
+			if allowed != tc.wantAllowed {
+				t.Fatalf("helperUpgradeAllowed(%q, %q) allowed = %v, want %v (reason=%q)",
+					tc.target, tc.installed, allowed, tc.wantAllowed, reason)
+			}
+			if tc.wantReason && reason == "" {
+				t.Fatalf("helperUpgradeAllowed(%q, %q) refused without a reason", tc.target, tc.installed)
+			}
+			if !tc.wantReason && reason != "" {
+				t.Fatalf("helperUpgradeAllowed(%q, %q) allowed but returned reason %q", tc.target, tc.installed, reason)
+			}
+		})
+	}
+}

--- a/agent/internal/helper/download.go
+++ b/agent/internal/helper/download.go
@@ -1,42 +1,34 @@
 package helper
 
 import (
-	"fmt"
-	"io"
-	"net/http"
-	"os"
+	"github.com/breeze-rmm/agent/internal/secmem"
+	"github.com/breeze-rmm/agent/internal/updater"
 )
 
-// downloadFile downloads a URL to a local file path using the provided auth token.
-func downloadFile(url, destPath, authToken string) error {
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return fmt.Errorf("create request: %w", err)
+// defaultHelperDownloader returns the production verified-download function for
+// the Breeze Helper package. It mirrors the agent's own self-updater and the
+// user-helper companion download (issue #816): the returned func fetches the
+// signed release manifest for component="helper" WITHOUT following redirects,
+// verifies the Ed25519 manifest signature against the embedded trust root plus
+// any pinned/env keys, enforces that the binary download host matches the
+// configured control-plane ServerURL (blocking off-origin CDN redirects and
+// HTTPS->HTTP downgrades), and verifies the downloaded bytes' SHA-256 against
+// the signed manifest checksum. On success it returns the path to a verified
+// temp file; the caller is responsible for removing it.
+//
+// This is the integrity gate that the old downloadFile (http.DefaultClient,
+// which follows redirects, no checksum/signature) lacked — and is the reason a
+// poisoned release asset, CDN edge, or TLS/DNS MITM toward github.com can no
+// longer yield SYSTEM/root RCE via the helper install path.
+func defaultHelperDownloader(serverURL string, authToken *secmem.SecureString, agentVersion string, manifestKeys []string) func(version string) (string, error) {
+	return func(version string) (string, error) {
+		cfg := &updater.Config{
+			ServerURL:             serverURL,
+			AuthToken:             authToken,
+			CurrentVersion:        agentVersion,
+			Component:             "helper",
+			PinnedManifestPubKeys: manifestKeys,
+		}
+		return updater.New(cfg).DownloadBinary(version)
 	}
-	if authToken != "" {
-		req.Header.Set("Authorization", "Bearer "+authToken)
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("http request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status %d from %s", resp.StatusCode, url)
-	}
-
-	out, err := os.Create(destPath)
-	if err != nil {
-		return fmt.Errorf("create file: %w", err)
-	}
-	defer out.Close()
-
-	if _, err := io.Copy(out, resp.Body); err != nil {
-		os.Remove(destPath)
-		return fmt.Errorf("write file: %w", err)
-	}
-
-	return nil
 }

--- a/agent/internal/helper/download_test.go
+++ b/agent/internal/helper/download_test.go
@@ -1,0 +1,82 @@
+package helper
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/secmem"
+	"github.com/breeze-rmm/agent/internal/updater"
+)
+
+// TestDefaultHelperDownloaderRejectsOffOriginRedirect proves the production
+// helper download path (the updater-backed verified downloader) does NOT follow
+// a redirect off the configured control-plane origin to an attacker-controlled
+// CDN. This is the core of the HIGH-severity finding: the old downloadFile used
+// http.DefaultClient (follows redirects) and ran the result as SYSTEM/root with
+// no integrity check.
+func TestDefaultHelperDownloaderRejectsOffOriginRedirect(t *testing.T) {
+	// A malicious "CDN" that, if ever reached, would serve poisoned bytes.
+	evil := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("POISONED-INSTALLER-PAYLOAD"))
+	}))
+	defer evil.Close()
+
+	// The control plane: its download-info endpoint 302-redirects off-origin to
+	// the evil CDN (mirrors BINARY_SOURCE=github serving the helper download).
+	var infoHits int
+	control := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/download") {
+			infoHits++
+			http.Redirect(w, r, evil.URL+"/breeze-helper-windows.msi", http.StatusFound)
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer control.Close()
+
+	dl := defaultHelperDownloader(control.URL, secmem.NewSecureString("tok"), "1.2.3", nil)
+	path, err := dl("1.2.3")
+	if err == nil {
+		if path != "" {
+			_ = os.Remove(path)
+		}
+		t.Fatalf("expected verified download to reject the off-origin redirect, got success (path=%q)", path)
+	}
+	// The error must come from refusing the unsigned redirect, never from having
+	// fetched and trusted the evil payload.
+	if !strings.Contains(err.Error(), "redirect") && !strings.Contains(err.Error(), "signed") && !strings.Contains(err.Error(), "manifest") {
+		t.Fatalf("expected a redirect/manifest-trust rejection, got: %v", err)
+	}
+}
+
+// TestDefaultHelperDownloaderUsesHelperComponent confirms the verified
+// downloader queries the agent-versions download endpoint with
+// component=helper, so the signed release manifest's helper asset
+// (breeze-helper-*) is the trust anchor — not the unauthenticated
+// /download/helper/:os/:arch redirect route.
+func TestDefaultHelperDownloaderUsesHelperComponent(t *testing.T) {
+	var gotComponent string
+	control := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotComponent = r.URL.Query().Get("component")
+		// Return a well-formed-but-untrusted info body so the path proceeds past
+		// the request and into manifest verification (which will fail closed —
+		// that's fine; we only assert the component here).
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"url":"` + r.URL.Scheme + `","checksum":"x","manifest":"{}","manifestSignature":"AAAA"}`))
+	}))
+	defer control.Close()
+
+	dl := defaultHelperDownloader(control.URL, secmem.NewSecureString("tok"), "9.9.9", nil)
+	_, _ = dl("9.9.9") // error expected (untrusted manifest); we only inspect the request
+	if gotComponent != "helper" {
+		t.Fatalf("verified helper downloader queried component=%q, want %q", gotComponent, "helper")
+	}
+}
+
+// Compile-time guard: the default helper downloader signature must stay
+// compatible with updater.Updater.DownloadBinary so the production shim is a
+// one-liner and the seam stays honest.
+var _ func(string) (string, error) = (&updater.Updater{}).DownloadBinary

--- a/agent/internal/helper/manager.go
+++ b/agent/internal/helper/manager.go
@@ -62,6 +62,19 @@ func WithSessionEnumerator(e SessionEnumerator) Option {
 	return func(m *Manager) { m.sessionEnumerator = e }
 }
 
+// WithAgentVersion sets the currently-running agent version, forwarded to the
+// verified helper downloader as CurrentVersion.
+func WithAgentVersion(v string) Option {
+	return func(m *Manager) { m.agentVersion = v }
+}
+
+// WithManifestKeys sets deployment-pinned Ed25519 release-manifest public keys
+// (merged with the embedded trust root in the updater) so self-host
+// deployments can verify locally-signed helper manifests.
+func WithManifestKeys(keys []string) Option {
+	return func(m *Manager) { m.manifestKeys = keys }
+}
+
 // Manager handles helper binary lifecycle: install/update plus per-session runtime state.
 type Manager struct {
 	mu                sync.Mutex
@@ -76,6 +89,15 @@ type Manager struct {
 	sessions          map[string]*sessionState
 	isOurProcessFunc  func(pid int, binaryPath string) bool
 	stopByPIDFunc     func(pid int) error
+
+	// downloadFunc fetches and INTEGRITY-VERIFIES the helper package for the
+	// given version, returning the path to a verified temp file. In production
+	// this is the updater-backed verified downloader (defaultHelperDownloader)
+	// that enforces signed-manifest + SHA-256 verification and control-plane
+	// origin. Tests inject a stub. It is NEVER the old unverified fetch.
+	downloadFunc func(version string) (string, error)
+	agentVersion string
+	manifestKeys []string
 
 	pendingHelperVersion string
 	updateFailures       int
@@ -101,6 +123,9 @@ func New(ctx context.Context, serverURL string, authToken *secmem.SecureString, 
 	}
 	if m.spawnFunc == nil {
 		m.spawnFunc = defaultSpawnFunc
+	}
+	if m.downloadFunc == nil {
+		m.downloadFunc = defaultHelperDownloader(m.serverURL, m.authToken, m.agentVersion, m.manifestKeys)
 	}
 	return m
 }
@@ -175,7 +200,14 @@ func (m *Manager) Apply(settings *Settings) {
 	}
 
 	if settings.Enabled && !m.isInstalled() {
-		if err := m.downloadAndInstall(); err != nil {
+		// Install only when the server has pinned a concrete (signed) helper
+		// version via HelperUpgradeTo -> CheckUpdate. The heartbeat always
+		// supplies one when bootstrapping a first install, and it is processed
+		// before this Apply call within the same heartbeat. Without it we fail
+		// closed rather than fetch unverified bytes.
+		if m.pendingHelperVersion == "" {
+			log.Debug("breeze assist enabled but no signed target version yet; deferring install")
+		} else if err := m.downloadAndInstall(m.pendingHelperVersion); err != nil {
 			log.Error("failed to install breeze assist", "error", err.Error())
 			return
 		}
@@ -458,31 +490,44 @@ func (m *Manager) isInstalled() bool {
 	return err == nil
 }
 
-// downloadAndInstall downloads the platform-appropriate helper package.
-func (m *Manager) downloadAndInstall() error {
+// downloadAndInstall downloads, INTEGRITY-VERIFIES, and installs the
+// platform-appropriate helper package for the given target version.
+//
+// The download goes through m.downloadFunc (the verified, updater-backed
+// downloader) which enforces: Ed25519 signed-release-manifest verification, a
+// SHA-256 checksum match over the downloaded bytes, download host == configured
+// control-plane ServerURL, and refusal to follow off-origin redirects. Only
+// AFTER those checks pass is the privileged installer (installPackageFunc:
+// msiexec /i as SYSTEM, hdiutil + cp -R as root) invoked. This closes the
+// HIGH-severity RCE where unsigned bytes from a GitHub-CDN redirect were
+// executed with full privileges.
+//
+// Fails closed: with no signed target version there is no manifest entry to
+// verify against, so we refuse rather than fetch unversioned/unverified bytes.
+func (m *Manager) downloadAndInstall(version string) error {
 	if m.authToken == nil {
 		return fmt.Errorf("cannot download helper: auth token not available")
 	}
-	url := fmt.Sprintf("%s/api/v1/agents/download/helper/%s/%s", m.serverURL, runtime.GOOS, runtime.GOARCH)
-	log.Info("downloading helper package", "url", url)
-
-	tmpFile, err := os.CreateTemp("", "breeze-helper-install-*"+packageExtension())
-	if err != nil {
-		return fmt.Errorf("create temp file: %w", err)
+	if version == "" {
+		return fmt.Errorf("cannot install helper: no signed target version available (refusing to fetch unverified bytes)")
 	}
-	tmpPath := tmpFile.Name()
-	_ = tmpFile.Close()
-	defer os.Remove(tmpPath)
+	if m.downloadFunc == nil {
+		return fmt.Errorf("cannot download helper: verified downloader not configured")
+	}
 
-	if err := downloadFile(url, tmpPath, m.authToken.Reveal()); err != nil {
+	log.Info("downloading helper package (verified)", "version", version, "server", m.serverURL)
+
+	verifiedPath, err := m.downloadFunc(version)
+	if err != nil {
 		return fmt.Errorf("download helper: %w", err)
 	}
+	defer os.Remove(verifiedPath)
 
-	if err := installPackage(tmpPath, m.binaryPath); err != nil {
+	if err := installPackageFunc(verifiedPath, m.binaryPath); err != nil {
 		return fmt.Errorf("install helper package: %w", err)
 	}
 
-	log.Info("helper installed", "path", m.binaryPath)
+	log.Info("helper installed", "path", m.binaryPath, "version", version)
 	return nil
 }
 
@@ -574,7 +619,7 @@ func (m *Manager) applyPendingUpdate() {
 		log.Warn("failed to backup helper binary", "error", err.Error())
 	}
 
-	if err := m.downloadAndInstall(); err != nil {
+	if err := m.downloadAndInstall(m.pendingHelperVersion); err != nil {
 		m.updateFailures++
 		log.Error("failed to install helper update", "error", err.Error(), "failures", m.updateFailures)
 		if restoreErr := restoreBackup(backupPath, m.binaryPath); restoreErr != nil {

--- a/agent/internal/helper/manager_install_security_test.go
+++ b/agent/internal/helper/manager_install_security_test.go
@@ -1,0 +1,168 @@
+package helper
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/secmem"
+)
+
+// installSpy records whether installPackage (the SYSTEM/root exec) ran.
+type installRecorder struct {
+	called int
+	paths  []string
+}
+
+func withInstallRecorder(t *testing.T) *installRecorder {
+	t.Helper()
+	rec := &installRecorder{}
+	orig := installPackageFunc
+	t.Cleanup(func() { installPackageFunc = orig })
+	installPackageFunc = func(pkgPath, binaryPath string) error {
+		rec.called++
+		rec.paths = append(rec.paths, pkgPath)
+		return nil
+	}
+	return rec
+}
+
+func newInstallTestManager(t *testing.T, tmpDir string) *Manager {
+	t.Helper()
+	mgr := New(context.Background(), "https://control.example.test", secmem.NewSecureString("tok"), "agent-1")
+	mgr.baseDir = tmpDir
+	mgr.binaryPath = filepath.Join(tmpDir, "missing-helper") // isInstalled() == false
+	mgr.sessionEnumerator = &mockEnumerator{}
+	return mgr
+}
+
+// TestDownloadAndInstallAbortsBeforeInstallOnVerificationFailure is the core
+// regression for the HIGH finding: when the verified downloader rejects the
+// payload (checksum/signature mismatch, off-origin redirect, etc.),
+// installPackage — which runs msiexec/hdiutil as SYSTEM/root — MUST NOT run.
+func TestDownloadAndInstallAbortsBeforeInstallOnVerificationFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	rec := withInstallRecorder(t)
+	mgr := newInstallTestManager(t, tmpDir)
+
+	// Inject a downloader that simulates a failed integrity check.
+	mgr.downloadFunc = func(version string) (string, error) {
+		return "", errors.New("checksum verification failed: release artifact manifest does not match download metadata")
+	}
+
+	err := mgr.downloadAndInstall("1.2.3")
+	if err == nil {
+		t.Fatal("expected downloadAndInstall to fail when verification fails")
+	}
+	if rec.called != 0 {
+		t.Fatalf("installPackage ran %d time(s) after a verification failure — SYSTEM/root exec of unverified bytes!", rec.called)
+	}
+}
+
+// TestDownloadAndInstallInstallsVerifiedPackage confirms the happy path: a
+// successfully-verified package (downloader returns a real temp file) IS
+// installed, and the verified bytes are what gets handed to installPackage.
+func TestDownloadAndInstallInstallsVerifiedPackage(t *testing.T) {
+	tmpDir := t.TempDir()
+	rec := withInstallRecorder(t)
+	mgr := newInstallTestManager(t, tmpDir)
+
+	verifiedPkg := filepath.Join(tmpDir, "verified-helper"+packageExtension())
+	if err := os.WriteFile(verifiedPkg, []byte("VERIFIED"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	mgr.downloadFunc = func(version string) (string, error) {
+		if version != "2.0.0" {
+			t.Fatalf("downloader got version %q, want 2.0.0", version)
+		}
+		return verifiedPkg, nil
+	}
+
+	if err := mgr.downloadAndInstall("2.0.0"); err != nil {
+		t.Fatalf("downloadAndInstall failed on verified package: %v", err)
+	}
+	if rec.called != 1 {
+		t.Fatalf("installPackage called %d times, want 1", rec.called)
+	}
+	if len(rec.paths) != 1 || rec.paths[0] != verifiedPkg {
+		t.Fatalf("installPackage got path %v, want %q", rec.paths, verifiedPkg)
+	}
+}
+
+// TestDownloadAndInstallRefusesWithoutVersion proves the install path fails
+// closed: with no signed target version, there is no manifest entry to verify
+// against, so we must refuse rather than fetch unversioned/unverified bytes.
+func TestDownloadAndInstallRefusesWithoutVersion(t *testing.T) {
+	tmpDir := t.TempDir()
+	rec := withInstallRecorder(t)
+	mgr := newInstallTestManager(t, tmpDir)
+
+	called := false
+	mgr.downloadFunc = func(version string) (string, error) {
+		called = true
+		return "", nil
+	}
+
+	err := mgr.downloadAndInstall("")
+	if err == nil {
+		t.Fatal("expected downloadAndInstall to refuse an empty target version")
+	}
+	if called {
+		t.Fatal("downloader was invoked with an empty version — should fail closed first")
+	}
+	if rec.called != 0 {
+		t.Fatalf("installPackage ran %d time(s) with no target version", rec.called)
+	}
+}
+
+// TestApplyEnabledInstallUsesPendingVersion wires the realistic flow: the
+// server pushes HelperUpgradeTo (-> CheckUpdate) then enables the helper. Apply
+// must install using that pinned, signed version through the verified
+// downloader — never the legacy unverified path.
+func TestApplyEnabledInstallUsesPendingVersion(t *testing.T) {
+	tmpDir := t.TempDir()
+	rec := withInstallRecorder(t)
+
+	origRemove := removeAutoStartFunc
+	origStopLegacy := stopHelperLegacyFunc
+	t.Cleanup(func() {
+		removeAutoStartFunc = origRemove
+		stopHelperLegacyFunc = origStopLegacy
+	})
+	removeAutoStartFunc = func() error { return nil }
+	stopHelperLegacyFunc = func() {}
+
+	mgr := newInstallTestManager(t, tmpDir)
+
+	verifiedPkg := filepath.Join(tmpDir, "verified"+packageExtension())
+	if err := os.WriteFile(verifiedPkg, []byte("VERIFIED"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	var gotVersion string
+	mgr.downloadFunc = func(version string) (string, error) {
+		gotVersion = version
+		// Simulate install landing the binary so isInstalled flips true.
+		if err := os.WriteFile(mgr.binaryPath, []byte("bin"), 0755); err != nil {
+			return "", err
+		}
+		return verifiedPkg, nil
+	}
+
+	mgr.CheckUpdate("3.1.4")
+	mgr.Apply(&Settings{Enabled: true})
+
+	if gotVersion != "3.1.4" {
+		t.Fatalf("install used version %q, want pinned 3.1.4", gotVersion)
+	}
+	// At least the bootstrap install must have run via the verified path. (The
+	// subsequent applyPendingUpdate may also fire because our stub doesn't write
+	// a status file, leaving installedVersion empty — that's incidental; the
+	// security-relevant assertion is that every install went through the
+	// verified downloader with the pinned version, which the downloadFunc stub
+	// above guarantees.)
+	if rec.called < 1 {
+		t.Fatalf("installPackage called %d times, want >= 1", rec.called)
+	}
+}

--- a/agent/internal/helper/migrate.go
+++ b/agent/internal/helper/migrate.go
@@ -12,6 +12,11 @@ var (
 	stopHelperLegacyFunc  = stopHelperLegacy
 	migrationTargetsFunc  = migrationTargets
 	prepareSessionDirFunc = prepareSessionDir
+	// installPackageFunc is the seam for the privileged installer exec
+	// (msiexec /i as SYSTEM, hdiutil + cp -R to /Applications as root). It is
+	// a var so security tests can assert it does NOT run when integrity
+	// verification of the downloaded package fails.
+	installPackageFunc = installPackage
 )
 
 // legacyBinaryPath returns the old "Breeze Helper" binary path.

--- a/apps/api/src/routes/agentVersions.test.ts
+++ b/apps/api/src/routes/agentVersions.test.ts
@@ -451,7 +451,7 @@ describe("agentVersions routes", () => {
       }
     });
 
-    it("keeps canonical github URL for component=helper (download route is agent-only)", async () => {
+    it("rewrites downloadUrl to server-relative for component=helper (helper RCE fix: keep verified download on the trusted control-plane origin)", async () => {
       const canonical =
         "https://github.com/LanternOps/breeze/releases/download/v1.0.0/breeze-helper-windows.msi";
       const checksum = "b".repeat(64);
@@ -492,7 +492,65 @@ describe("agentVersions routes", () => {
         );
         expect(res.status).toBe(200);
         const body = await res.json();
-        expect(body.url).toBe(canonical);
+        // Server-relative so the agent's verified downloader (host==ServerURL)
+        // accepts it; the /agents/download/helper/:os/:arch route 302s to github
+        // server-side, and the signed-manifest SHA-256 binds the bytes.
+        expect(body.url).toBe(
+          "https://us.example.com/api/v1/agents/download/helper/windows/amd64",
+        );
+        // Manifest is unmodified; its url field still references the canonical
+        // github asset. Checksum is the trust binding.
+        expect(body.checksum).toBe(checksum);
+        expect(body.manifest).toBe(signed.manifest);
+      } finally {
+        delete process.env.PUBLIC_API_URL;
+      }
+    });
+
+    it("maps platform=macos to /darwin in the server-relative helper URL", async () => {
+      const canonical =
+        "https://github.com/LanternOps/breeze/releases/download/v1.0.0/breeze-helper-macos.dmg";
+      const checksum = "c".repeat(64);
+      const signed = makeSignedReleaseManifest({
+        component: "helper",
+        platform: "macos",
+        arch: "arm64",
+        url: canonical,
+        checksum,
+        size: 1234,
+      });
+
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              {
+                version: "1.0.0",
+                platform: "macos",
+                architecture: "arm64",
+                component: "helper",
+                downloadUrl: canonical,
+                checksum,
+                fileSize: BigInt(1234),
+                releaseManifest: signed.manifest,
+                manifestSignature: signed.signature,
+                signingKeyId: "test-key",
+              },
+            ]),
+          }),
+        }),
+      } as any);
+
+      process.env.PUBLIC_API_URL = "https://us.example.com";
+      try {
+        const res = await app.request(
+          "/agent-versions/1.0.0/download?platform=darwin&arch=arm64&component=helper",
+        );
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.url).toBe(
+          "https://us.example.com/api/v1/agents/download/helper/darwin/arm64",
+        );
       } finally {
         delete process.env.PUBLIC_API_URL;
       }

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -254,16 +254,24 @@ function dbPlatformToRouteOs(dbPlatform: string): string {
   return dbPlatform === "macos" ? "darwin" : dbPlatform;
 }
 
-// Construct the server-relative download URL the agent should use. Only
-// applies to component=agent today — helper/viewer auto-update flows have
-// their own update mechanisms and aren't served through the agent download
-// route. Returns null to signal "fall back to the canonical (github) URL".
+// Construct the server-relative download URL the agent should use. Applies to
+// component=agent and component=helper: both are pulled by the agent's verified
+// downloader (updater.downloadFromURL), which enforces host equality with the
+// agent's configured ServerURL. Without this rewrite the response would hand
+// back the canonical github.com asset URL, which the agent rejects — and, more
+// importantly, the helper used to be fetched via an UNVERIFIED redirect to that
+// CDN and run as SYSTEM/root (the HIGH-severity RCE fixed alongside this).
+// Rewriting to the control-plane origin keeps the helper download inside the
+// trusted origin; the existing /download[/helper]/:os/:arch route then 302s to
+// github server-side, and the signed-manifest SHA-256 binds the bytes either
+// way. Returns null to signal "fall back to the canonical (github) URL"
+// (components without a server-relative route, or no configured origin).
 function buildServerRelativeAgentDownloadUrl(
   dbPlatform: string,
   architecture: string,
   component: string,
 ): string | null {
-  if (component !== "agent") {
+  if (component !== "agent" && component !== "helper") {
     return null;
   }
   const origin = getServerOriginForDownloadResponse();
@@ -271,6 +279,9 @@ function buildServerRelativeAgentDownloadUrl(
     return null;
   }
   const os = dbPlatformToRouteOs(dbPlatform);
+  if (component === "helper") {
+    return `${origin}/api/v1/agents/download/helper/${os}/${architecture}`;
+  }
   return `${origin}/api/v1/agents/download/${os}/${architecture}`;
 }
 


### PR DESCRIPTION
## Security fix — HIGH

**Finding:** The Breeze Helper install/update path downloaded the installer package (`.msi`/`.dmg`/`.AppImage`) and executed it as **SYSTEM** (Windows: `msiexec /i`) / **root** (macOS: `hdiutil` + `cp -R`) with **no signature or checksum verification**, while following HTTP redirects off the control-plane origin to the GitHub CDN. A poisoned release asset, CDN edge, or TLS/DNS MITM toward github.com yielded **fleet-wide SYSTEM/root RCE**. It auto-triggers from the heartbeat (`HelperSettings.Enabled` / `HelperUpgradeTo`), not operator action.

**Why it was reachable:** the agent's own self-updater already defends against this exact threat (Ed25519-signed manifest, redirect rejection, same-origin enforcement, SHA-256), but the equally-privileged helper install/update path applied none of it. The signed release manifest *already* carries the helper assets (agent `expectedReleaseAssetNames`, API `binarySync.ts`), so the fix routes the helper download through the existing verified pipeline.

## Changes
- `helper/download.go` — replace the redirect-following `http.DefaultClient` download with the updater-backed verified downloader.
- `helper/manager.go` — verify SHA-256 against the signed manifest **before** the privileged installer runs; **fail closed** when no signed version is known.
- `helper/migrate.go` — injectable `installPackage` seam for testability.
- `heartbeat.go` — pass agent version + manifest keys into the helper.
- `agentVersions.ts` — rewrite the helper download URL to the control-plane origin (previously returned the raw GitHub URL, which the host check then rejects).

## Result
Off-origin redirects are rejected; checksum/signature mismatch aborts before `msiexec`/`hdiutil`.

## Behavior change (release-notes worthy)
Self-hosters on `BINARY_SOURCE=local` with **no** manifest signing configured will have the helper fail closed (won't auto-install). This matches the existing agent self-update requirement.

## Tests
- `download_test.go` — off-origin redirect rejected; helper component selected.
- `manager_install_security_test.go` — install aborts before the privileged step on verification failure; fail-closed without a signed version.
- `agentVersions.test.ts` — helper URL rewritten to control-plane origin.

Verified: `go build ./...`, `go vet`, `go test -race ./internal/helper/... ./internal/updater/... ./internal/heartbeat/...` green; touched API vitest green.

> Found via a defensive security review of the most-committed areas. Confidence 8/10 (verified against `origin/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
**Update 2026-06-10 (`2f1887f6`):** review caught a downgrade-replay gap — `HelperUpgradeTo` reached `CheckUpdate` with no version guard, while the agent self-update path refuses downgrades. Added `helperUpgradeAllowed` (fail-closed on malformed semver, fresh-install allowed) gating the helper path, mirroring the agent guard. 16 table-driven tests; cross-compiled windows/linux.
