### PR TITLE
fix(ai-tools): enforce site scope on AI enumeration tools (MED-HIGH)

### DIFF
--- a/apps/api/src/services/aiTools.deviceAccessSiteScope.contract.test.ts
+++ b/apps/api/src/services/aiTools.deviceAccessSiteScope.contract.test.ts
@@ -75,6 +75,15 @@ const SITE_GATED_NON_VERIFY_FILES = [
   'aiToolsAgentLogs.ts',
   'aiToolsAlerts.ts',
   'aiToolsBrowser.ts',
+  'aiToolsAnalytics.ts',
+  'aiToolsEventLogs.ts',
+  'aiToolsPeripherals.ts',
+  'aiToolsSentinelOne.ts',
+  'aiToolsCompliance.ts',
+  'aiToolsMonitoring.ts',
+  'aiToolsDns.ts',
+  'aiToolsHuntress.ts',
+  'aiToolsSLABackup.ts',
 ];
 
 const SITE_GATE_MARKERS = [

--- a/apps/api/src/services/aiToolsAnalytics.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsAnalytics.siteScope.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+
+import { db } from '../db';
+import { registerAnalyticsTools } from './aiToolsAnalytics';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerAnalyticsTools(reg);
+  return reg.get(name)!.handler;
+}
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
+    accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds, canAccessSite: (s: string | null | undefined) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  } as unknown as AuthContext;
+}
+function isDeviceResolverSelect(cols: unknown): boolean {
+  return (
+    !!cols && typeof cols === 'object' &&
+    'id' in (cols as object) && 'siteId' in (cols as object) &&
+    Object.keys(cols as object).length === 2
+  );
+}
+
+describe('query_analytics capacity_predictions — site narrowing', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller does NOT receive predictions for a device in a forbidden site', async () => {
+    let predictionScanRan = false;
+    const forbidden = { id: 'p1', deviceId: 'd-siteB', metricType: 'disk', metricName: 'C:' };
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd-siteB', siteId: 'site-B' }]) }) };
+      }
+      predictionScanRan = true;
+      return { from: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([forbidden]) }) }) }) };
+    });
+
+    const r = await handlerFor('query_analytics')({ action: 'capacity_predictions' }, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.showing).toBe(0);
+    expect(parsed.capacityPredictions).toEqual([]);
+    expect(predictionScanRan).toBe(false);
+  });
+
+  it('unrestricted caller reads predictions normally (no regression)', async () => {
+    mockDb.select.mockReturnValue({
+      from: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([{ id: 'p1', deviceId: 'd1', metricType: 'disk' }]) }) }) }),
+    });
+    const r = await handlerFor('query_analytics')({ action: 'capacity_predictions' }, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.showing).toBe(1);
+  });
+});

--- a/apps/api/src/services/aiToolsAnalytics.ts
+++ b/apps/api/src/services/aiToolsAnalytics.ts
@@ -16,7 +16,7 @@ import {
 import { eq, and, desc, asc, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
-import { resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
+import { resolveSiteAllowedDeviceIds, SITE_SCOPE_EMPTY_NOTE } from './aiToolsSiteScope';
 
 type AnalyticsHandler = (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
 
@@ -154,7 +154,7 @@ export function registerAnalyticsTools(aiTools: Map<string, AiTool>): void {
           }
           const allowed = await resolveSiteAllowedDeviceIds(queryOrgId, auth);
           if (!allowed || allowed.length === 0) {
-            return JSON.stringify({ capacityPredictions: [], showing: 0 });
+            return JSON.stringify({ capacityPredictions: [], showing: 0, scopeNote: SITE_SCOPE_EMPTY_NOTE });
           }
           conditions.push(inArray(capacityPredictions.deviceId, allowed));
         }

--- a/apps/api/src/services/aiToolsAnalytics.ts
+++ b/apps/api/src/services/aiToolsAnalytics.ts
@@ -13,9 +13,10 @@ import {
   capacityPredictions,
   executiveSummaries,
 } from '../db/schema';
-import { eq, and, desc, asc, SQL } from 'drizzle-orm';
+import { eq, and, desc, asc, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
+import { resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 
 type AnalyticsHandler = (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
 
@@ -140,6 +141,22 @@ export function registerAnalyticsTools(aiTools: Map<string, AiTool>): void {
         }
         if (typeof input.metricType === 'string') {
           conditions.push(eq(capacityPredictions.metricType, input.metricType));
+        }
+
+        // Site axis (app-layer only; RLS does NOT enforce it). capacityPredictions
+        // has no site_id column, so narrow by the in-scope device-id set. A
+        // restricted caller with zero in-scope devices yields empty results. This
+        // intersects with the optional deviceId filter above (most-restrictive wins).
+        if (auth.allowedSiteIds && auth.canAccessSite) {
+          const queryOrgId = auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
+          if (!queryOrgId) {
+            return JSON.stringify({ capacityPredictions: [], showing: 0 });
+          }
+          const allowed = await resolveSiteAllowedDeviceIds(queryOrgId, auth);
+          if (!allowed || allowed.length === 0) {
+            return JSON.stringify({ capacityPredictions: [], showing: 0 });
+          }
+          conditions.push(inArray(capacityPredictions.deviceId, allowed));
         }
 
         const rows = await db

--- a/apps/api/src/services/aiToolsCompliance.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsCompliance.siteScope.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn(), transaction: vi.fn() },
+}));
+vi.mock('../jobs/softwareComplianceWorker', () => ({ scheduleSoftwareComplianceCheck: vi.fn() }));
+vi.mock('../jobs/softwareRemediationWorker', () => ({ scheduleSoftwareRemediation: vi.fn(async () => 1) }));
+vi.mock('./softwarePolicyService', () => ({ normalizeSoftwarePolicyRules: vi.fn((r: any) => r) }));
+
+import { db } from '../db';
+import { scheduleSoftwareRemediation } from '../jobs/softwareRemediationWorker';
+import { registerComplianceTools } from './aiToolsCompliance';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerComplianceTools(reg);
+  return reg.get(name)!.handler;
+}
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
+    accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds, canAccessSite: (s: string | null | undefined) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  } as unknown as AuthContext;
+}
+function isDeviceResolverSelect(cols: unknown): boolean {
+  return (
+    !!cols && typeof cols === 'object' &&
+    'id' in (cols as object) && 'siteId' in (cols as object) &&
+    Object.keys(cols as object).length === 2
+  );
+}
+/** Generic chainable query mock that resolves to `result`. */
+function chain(result: unknown): any {
+  const p: any = Promise.resolve(result);
+  for (const m of ['from', 'innerJoin', 'leftJoin', 'where', 'orderBy', 'limit', 'groupBy', 'offset']) {
+    p[m] = () => p;
+  }
+  return p;
+}
+
+describe('get_software_compliance — site narrowing (cross-site enumeration)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller does NOT receive compliance rows for a device in a forbidden site', async () => {
+    let complianceScanRan = false;
+    const forbiddenRow = {
+      compliance: { policyId: 'p1', deviceId: 'd-siteB', status: 'violation', violations: [], lastChecked: null, remediationStatus: null },
+      policy: { id: 'p1', name: 'Policy', mode: 'blocklist' },
+      device: { id: 'd-siteB', hostname: 'forbidden-host' },
+    };
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd-siteB', siteId: 'site-B' }]) }) };
+      }
+      complianceScanRan = true;
+      return chain([forbiddenRow]);
+    });
+
+    const r = await handlerFor('get_software_compliance')({}, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.count).toBe(0);
+    expect(parsed.compliance).toEqual([]);
+    expect(complianceScanRan).toBe(false);
+    expect(JSON.stringify(parsed)).not.toContain('forbidden-host');
+  });
+
+  it('unrestricted caller enumerates compliance normally (no regression)', async () => {
+    mockDb.select.mockImplementation(() => chain([
+      {
+        compliance: { policyId: 'p1', deviceId: 'd1', status: 'compliant', violations: [], lastChecked: null, remediationStatus: null },
+        policy: { id: 'p1', name: 'Policy', mode: 'blocklist' },
+        device: { id: 'd1', hostname: 'h1' },
+      },
+    ]));
+    const r = await handlerFor('get_software_compliance')({}, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.count).toBe(1);
+  });
+});
+
+describe('get_compliance_status — site narrowing', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller does NOT receive compliance records for a device in a forbidden site', async () => {
+    let statusScanRan = false;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd-siteB', siteId: 'site-B' }]) }) };
+      }
+      statusScanRan = true;
+      return chain([{ policyId: 'pol-1', deviceId: 'd-siteB', status: 'non_compliant' }]);
+    });
+
+    const r = await handlerFor('get_compliance_status')({ policyId: 'pol-1' }, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.records).toEqual([]);
+    expect(parsed.total).toBe(0);
+    expect(parsed.showing).toBe(0);
+    expect(parsed.breakdown).toEqual({});
+    expect(statusScanRan).toBe(false);
+  });
+
+  it('unrestricted caller reads compliance status normally (no regression)', async () => {
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (cols && typeof cols === 'object' && 'count' in (cols as object) && 'status' in (cols as object)) {
+        return chain([{ status: 'compliant', count: 1 }]); // breakdown
+      }
+      if (cols && typeof cols === 'object' && 'count' in (cols as object)) {
+        return chain([{ count: 1 }]); // total
+      }
+      return chain([{ policyId: 'pol-1', deviceId: 'd1', status: 'compliant', details: null, lastCheckedAt: null, remediationAttempts: 0 }]);
+    });
+    const r = await handlerFor('get_compliance_status')({ policyId: 'pol-1' }, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.showing).toBe(1);
+    expect(parsed.total).toBe(1);
+    expect(parsed.breakdown).toEqual({ compliant: 1 });
+  });
+});
+
+describe('remediate_software_violation — site narrowing of the org-wide fallback enumeration', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller with no in-scope devices queues NO remediation', async () => {
+    let violationScanRan = false;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd-siteB', siteId: 'site-B' }]) }) };
+      }
+      if (cols === undefined) {
+        // policy lookup: db.select().from(softwarePolicies)...
+        return chain([{ id: 'pol-1', name: 'Policy', mode: 'blocklist' }]);
+      }
+      violationScanRan = true; // org-wide violation enumeration must not run
+      return chain([{ deviceId: 'd-siteB' }]);
+    });
+
+    const r = await handlerFor('remediate_software_violation')({ policyId: 'pol-1' }, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.queued).toBe(0);
+    expect(violationScanRan).toBe(false);
+    expect(scheduleSoftwareRemediation).not.toHaveBeenCalled();
+  });
+
+  it('unrestricted caller remediates via the fallback enumeration normally (no regression)', async () => {
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (cols === undefined) {
+        return chain([{ id: 'pol-1', name: 'Policy', mode: 'blocklist' }]);
+      }
+      return chain([{ deviceId: 'd1' }]);
+    });
+    const r = await handlerFor('remediate_software_violation')({ policyId: 'pol-1' }, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.queued).toBe(1);
+    expect(scheduleSoftwareRemediation).toHaveBeenCalledWith('pol-1', ['d1']);
+  });
+});

--- a/apps/api/src/services/aiToolsCompliance.ts
+++ b/apps/api/src/services/aiToolsCompliance.ts
@@ -23,6 +23,7 @@ import type { AiTool } from './aiTools';
 import { scheduleSoftwareComplianceCheck } from '../jobs/softwareComplianceWorker';
 import { scheduleSoftwareRemediation } from '../jobs/softwareRemediationWorker';
 import { normalizeSoftwarePolicyRules } from './softwarePolicyService';
+import { resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -89,6 +90,23 @@ registerTool({
     if (typeof input.status === 'string') conditions.push(eq(softwareComplianceStatus.status, input.status));
     if (Array.isArray(input.deviceIds) && input.deviceIds.length > 0) {
       conditions.push(inArray(softwareComplianceStatus.deviceId, input.deviceIds as string[]));
+    }
+
+    // Site axis (app-layer only; RLS does NOT enforce it). softwareComplianceStatus
+    // has no site_id column, so narrow by the in-scope device-id set. A restricted
+    // caller with zero in-scope devices short-circuits to empty results. This
+    // intersects with the optional caller-supplied deviceIds filter above
+    // (most-restrictive wins).
+    if (auth.allowedSiteIds && auth.canAccessSite) {
+      const queryOrgId = auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
+      if (!queryOrgId) {
+        return JSON.stringify({ count: 0, compliance: [] });
+      }
+      const allowed = await resolveSiteAllowedDeviceIds(queryOrgId, auth);
+      if (!allowed || allowed.length === 0) {
+        return JSON.stringify({ count: 0, compliance: [] });
+      }
+      conditions.push(inArray(softwareComplianceStatus.deviceId, allowed));
     }
 
     const limit = Math.min(Math.max(1, Number(input.limit) || 50), 500);
@@ -381,6 +399,24 @@ registerTool({
       const deviceOrgCondition = auth.orgCondition(devices.orgId);
       if (deviceOrgCondition) complianceConditions.push(deviceOrgCondition);
 
+      // Site axis (app-layer only; RLS does NOT enforce it). When the caller
+      // supplies no deviceIds, this fallback enumerates ALL violating devices
+      // org-wide and queues remediation (a mutation) against them — a
+      // site-restricted caller must only reach its in-scope device set.
+      // (Caller-supplied deviceIds are already org+site gated centrally via
+      // `deviceArgs` → enforceDeviceArgs.)
+      if (auth.allowedSiteIds && auth.canAccessSite) {
+        const queryOrgId = auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
+        if (!queryOrgId) {
+          return JSON.stringify({ message: 'No matching violation rows found for remediation', queued: 0 });
+        }
+        const allowed = await resolveSiteAllowedDeviceIds(queryOrgId, auth);
+        if (!allowed || allowed.length === 0) {
+          return JSON.stringify({ message: 'No matching violation rows found for remediation', queued: 0 });
+        }
+        complianceConditions.push(inArray(softwareComplianceStatus.deviceId, allowed));
+      }
+
       const rows = await db
         .select({ deviceId: softwareComplianceStatus.deviceId })
         .from(softwareComplianceStatus)
@@ -529,6 +565,22 @@ registerTool({
     }
     if (input.deviceId) {
       conditions.push(eq(automationPolicyCompliance.deviceId, input.deviceId as string));
+    }
+
+    // Site axis (app-layer only; RLS does NOT enforce it). automationPolicyCompliance
+    // has no site_id column, so narrow by the in-scope device-id set. A restricted
+    // caller with zero in-scope devices short-circuits to empty results. This
+    // intersects with the optional deviceId filter above (most-restrictive wins).
+    if (auth.allowedSiteIds && auth.canAccessSite) {
+      const queryOrgId = auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
+      if (!queryOrgId) {
+        return JSON.stringify({ records: [], total: 0, showing: 0, breakdown: {} });
+      }
+      const allowed = await resolveSiteAllowedDeviceIds(queryOrgId, auth);
+      if (!allowed || allowed.length === 0) {
+        return JSON.stringify({ records: [], total: 0, showing: 0, breakdown: {} });
+      }
+      conditions.push(inArray(automationPolicyCompliance.deviceId, allowed));
     }
 
     const records = await db

--- a/apps/api/src/services/aiToolsCompliance.ts
+++ b/apps/api/src/services/aiToolsCompliance.ts
@@ -23,7 +23,7 @@ import type { AiTool } from './aiTools';
 import { scheduleSoftwareComplianceCheck } from '../jobs/softwareComplianceWorker';
 import { scheduleSoftwareRemediation } from '../jobs/softwareRemediationWorker';
 import { normalizeSoftwarePolicyRules } from './softwarePolicyService';
-import { resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
+import { resolveSiteAllowedDeviceIds, SITE_SCOPE_EMPTY_NOTE } from './aiToolsSiteScope';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -104,7 +104,7 @@ registerTool({
       }
       const allowed = await resolveSiteAllowedDeviceIds(queryOrgId, auth);
       if (!allowed || allowed.length === 0) {
-        return JSON.stringify({ count: 0, compliance: [] });
+        return JSON.stringify({ count: 0, compliance: [], scopeNote: SITE_SCOPE_EMPTY_NOTE });
       }
       conditions.push(inArray(softwareComplianceStatus.deviceId, allowed));
     }
@@ -412,7 +412,11 @@ registerTool({
         }
         const allowed = await resolveSiteAllowedDeviceIds(queryOrgId, auth);
         if (!allowed || allowed.length === 0) {
-          return JSON.stringify({ message: 'No matching violation rows found for remediation', queued: 0 });
+          return JSON.stringify({
+            message: 'No matching violation rows found for remediation',
+            queued: 0,
+            scopeNote: SITE_SCOPE_EMPTY_NOTE,
+          });
         }
         complianceConditions.push(inArray(softwareComplianceStatus.deviceId, allowed));
       }
@@ -578,7 +582,7 @@ registerTool({
       }
       const allowed = await resolveSiteAllowedDeviceIds(queryOrgId, auth);
       if (!allowed || allowed.length === 0) {
-        return JSON.stringify({ records: [], total: 0, showing: 0, breakdown: {} });
+        return JSON.stringify({ records: [], total: 0, showing: 0, breakdown: {}, scopeNote: SITE_SCOPE_EMPTY_NOTE });
       }
       conditions.push(inArray(automationPolicyCompliance.deviceId, allowed));
     }

--- a/apps/api/src/services/aiToolsDns.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsDns.siteScope.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('../jobs/dnsSyncJob', () => ({ schedulePolicySync: vi.fn() }));
+
+import { db } from '../db';
+import { registerDnsTools } from './aiToolsDns';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerDnsTools(reg);
+  return reg.get(name)!.handler;
+}
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
+    accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds, canAccessSite: (s: string | null | undefined) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  } as unknown as AuthContext;
+}
+function isDeviceResolverSelect(cols: unknown): boolean {
+  return (
+    !!cols && typeof cols === 'object' &&
+    'id' in (cols as object) && 'siteId' in (cols as object) &&
+    Object.keys(cols as object).length === 2
+  );
+}
+/** Generic chainable query mock that resolves to `result`. */
+function chain(result: unknown): any {
+  const p: any = Promise.resolve(result);
+  for (const m of ['from', 'innerJoin', 'leftJoin', 'where', 'orderBy', 'limit', 'groupBy', 'offset']) {
+    p[m] = () => p;
+  }
+  return p;
+}
+
+// 1-day window keeps the handler on the raw-events path (no aggregation).
+const RAW_RANGE = { timeRange: { start: '2026-01-01T00:00:00Z', end: '2026-01-02T00:00:00Z' } };
+
+describe('get_dns_security — site narrowing (cross-site enumeration)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller does NOT receive DNS stats/hostnames for a device in a forbidden site', async () => {
+    let eventScanRan = false;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd-siteB', siteId: 'site-B' }]) }) };
+      }
+      eventScanRan = true;
+      if (cols && typeof cols === 'object' && 'hostname' in (cols as object)) {
+        return chain([{ deviceId: 'd-siteB', hostname: 'forbidden-host', blockedCount: 9 }]);
+      }
+      if (cols && typeof cols === 'object' && 'totalQueries' in (cols as object)) {
+        return chain([{ totalQueries: 9, blockedQueries: 9, allowedQueries: 0, redirectedQueries: 0 }]);
+      }
+      return chain([{ domain: 'secret-blocked-domain.example', category: 'malware', count: 9 }]);
+    });
+
+    const r = await handlerFor('get_dns_security')(RAW_RANGE, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.summary.totalQueries).toBe(0);
+    expect(parsed.topDevices).toEqual([]);
+    expect(parsed.topBlockedDomains).toEqual([]);
+    expect(eventScanRan).toBe(false);
+    expect(JSON.stringify(parsed)).not.toContain('forbidden-host');
+    expect(JSON.stringify(parsed)).not.toContain('secret-blocked-domain.example');
+  });
+
+  it('unrestricted caller reads DNS security stats normally (no regression)', async () => {
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (cols && typeof cols === 'object' && 'totalQueries' in (cols as object)) {
+        return chain([{ totalQueries: 10, blockedQueries: 4, allowedQueries: 6, redirectedQueries: 0 }]);
+      }
+      if (cols && typeof cols === 'object' && 'hostname' in (cols as object)) {
+        return chain([{ deviceId: 'd1', hostname: 'h1', blockedCount: 4 }]);
+      }
+      if (cols && typeof cols === 'object' && 'domain' in (cols as object)) {
+        return chain([{ domain: 'bad.example', category: 'malware', count: 4 }]);
+      }
+      return chain([{ category: 'malware', count: 4 }]);
+    });
+
+    const r = await handlerFor('get_dns_security')(RAW_RANGE, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.summary.totalQueries).toBe(10);
+    expect(parsed.topDevices).toHaveLength(1);
+    expect(parsed.source).toBe('raw');
+  });
+});

--- a/apps/api/src/services/aiToolsDns.ts
+++ b/apps/api/src/services/aiToolsDns.ts
@@ -20,7 +20,7 @@ import { eq, and, desc, sql, gte, lte, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { schedulePolicySync } from '../jobs/dnsSyncJob';
-import { resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
+import { resolveSiteAllowedDeviceIds, SITE_SCOPE_EMPTY_NOTE } from './aiToolsSiteScope';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -150,7 +150,8 @@ export function registerDnsTools(aiTools: Map<string, AiTool>): void {
             topBlockedDomains: [],
             topCategories: [],
             topDevices: [],
-            source: 'raw'
+            source: 'raw',
+            scopeNote: SITE_SCOPE_EMPTY_NOTE
           });
         }
         conditions.push(inArray(dnsSecurityEvents.deviceId, siteAllowedDeviceIds));

--- a/apps/api/src/services/aiToolsDns.ts
+++ b/apps/api/src/services/aiToolsDns.ts
@@ -16,10 +16,11 @@ import {
   dnsThreatCategoryEnum,
   type DnsPolicyDomain
 } from '../db/schema';
-import { eq, and, desc, sql, gte, lte, SQL } from 'drizzle-orm';
+import { eq, and, desc, sql, gte, lte, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { schedulePolicySync } from '../jobs/dnsSyncJob';
+import { resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -123,6 +124,38 @@ export function registerDnsTools(aiTools: Map<string, AiTool>): void {
         conditions.push(eq(dnsSecurityEvents.category, normalizedCategory as typeof dnsSecurityEvents.category.enumValues[number]));
       }
 
+      // Site axis (app-layer only; RLS does NOT enforce it). dnsSecurityEvents /
+      // dnsEventAggregations have no site_id column, so narrow by the in-scope
+      // device-id set (this also scopes the topDevices hostname join). A
+      // restricted caller with zero in-scope devices short-circuits to an empty
+      // summary. Intersects with the optional deviceId filter above
+      // (most-restrictive wins). Events with no deviceId are excluded for a
+      // restricted caller (fail closed).
+      let siteAllowedDeviceIds: string[] | null = null;
+      if (auth.allowedSiteIds && auth.canAccessSite) {
+        const queryOrgId = auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
+        siteAllowedDeviceIds = queryOrgId
+          ? await resolveSiteAllowedDeviceIds(queryOrgId, auth)
+          : [];
+        if (!siteAllowedDeviceIds || siteAllowedDeviceIds.length === 0) {
+          return JSON.stringify({
+            summary: {
+              totalQueries: 0,
+              blockedQueries: 0,
+              allowedQueries: 0,
+              redirectedQueries: 0,
+              blockedRate: 0,
+              timeRange: { start: start.toISOString(), end: end.toISOString() }
+            },
+            topBlockedDomains: [],
+            topCategories: [],
+            topDevices: [],
+            source: 'raw'
+          });
+        }
+        conditions.push(inArray(dnsSecurityEvents.deviceId, siteAllowedDeviceIds));
+      }
+
       const topN = Math.min(Math.max(1, Number(input.topN) || 10), 100);
       const where = and(...conditions);
 
@@ -139,6 +172,10 @@ export function registerDnsTools(aiTools: Map<string, AiTool>): void {
           aggConditions.push(
             eq(dnsEventAggregations.category, normalizedCategory as typeof dnsEventAggregations.category.enumValues[number])
           );
+        }
+        // Site axis narrowing for the aggregated path (see comment above).
+        if (siteAllowedDeviceIds) {
+          aggConditions.push(inArray(dnsEventAggregations.deviceId, siteAllowedDeviceIds));
         }
 
         const aggWhere = and(...aggConditions);

--- a/apps/api/src/services/aiToolsEventLogs.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsEventLogs.siteScope.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+
+import { db } from '../db';
+import { registerEventLogTools } from './aiToolsEventLogs';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerEventLogTools(reg);
+  return reg.get(name)!.handler;
+}
+
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any,
+    partnerId: null,
+    orgId: 'org-1',
+    scope: 'organization',
+    accessibleOrgIds: ['org-1'],
+    // org-scoped condition returns undefined (no SQL) like the real org owner path
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+    allowedSiteIds,
+    canAccessSite: (s: string | null | undefined) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  } as unknown as AuthContext;
+}
+
+/**
+ * `resolveSiteAllowedDeviceIds` issues a `select({ id, siteId }).from(devices).where(...)`.
+ * Detect that shape so the device-set resolver returns a device that lives in a
+ * FORBIDDEN site for a [site-A]-restricted caller (→ empty allowed set).
+ */
+function isDeviceResolverSelect(cols: unknown): boolean {
+  return (
+    !!cols &&
+    typeof cols === 'object' &&
+    'id' in (cols as object) &&
+    'siteId' in (cols as object) &&
+    Object.keys(cols as object).length === 2
+  );
+}
+
+describe('search_logs — site narrowing (cross-site enumeration)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller does NOT receive logs from a device in a forbidden site', async () => {
+    // The only device in the org lives in site-B; the caller may only access
+    // site-A. The data layer is wired to return a site-B log row if asked — the
+    // fix must short-circuit so that row never reaches the caller.
+    const siteBLogRow = {
+      log: {
+        id: 'leak',
+        timestamp: new Date('2026-01-01T01:00:00Z'),
+        level: 'error',
+        category: 'system',
+        source: 'svc',
+        eventId: '1',
+        message: 'SECRET cross-site message body',
+        deviceId: 'd-siteB',
+      },
+      device: { id: 'd-siteB', hostname: 'forbidden-host', displayName: 'F', siteId: 'site-B' },
+      site: { id: 'site-B', name: 'B' },
+    };
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd-siteB', siteId: 'site-B' }]) }) };
+      }
+      if (cols && typeof cols === 'object' && 'count' in (cols as object)) {
+        return { from: () => ({ leftJoin: () => ({ where: () => Promise.resolve([{ count: 1 }]) }) }) };
+      }
+      const limitResult: any = Promise.resolve([siteBLogRow]);
+      limitResult.offset = () => Promise.resolve([siteBLogRow]);
+      return {
+        from: () => ({
+          leftJoin: () => ({
+            leftJoin: () => ({
+              where: () => ({ orderBy: () => ({ limit: () => limitResult }) }),
+            }),
+          }),
+        }),
+      };
+    });
+
+    const r = await handlerFor('search_logs')(
+      { timeRange: { start: '2026-01-01T00:00:00Z', end: '2026-01-02T00:00:00Z' }, countMode: 'none' },
+      makeAuth(['site-A']),
+    );
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.showing).toBe(0);
+    expect(parsed.logs).toEqual([]);
+    expect(JSON.stringify(parsed)).not.toContain('SECRET cross-site message body');
+  });
+
+  it('unrestricted caller enumerates normally (no regression)', async () => {
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (cols && typeof cols === 'object' && 'count' in (cols as object)) {
+        return {
+          from: () => ({ leftJoin: () => ({ where: () => Promise.resolve([{ count: 1 }]) }) }),
+        };
+      }
+      // rows query
+      const rowsQuery: any = {
+        offset: () =>
+          Promise.resolve([
+            {
+              log: {
+                id: 'l1',
+                timestamp: new Date('2026-01-01T01:00:00Z'),
+                level: 'error',
+                category: 'system',
+                source: 'svc',
+                eventId: '1',
+                message: 'boom',
+                deviceId: 'd1',
+              },
+              device: { id: 'd1', hostname: 'h1', displayName: 'H1', siteId: 'site-Z' },
+              site: { id: 'site-Z', name: 'Z' },
+            },
+          ]),
+      };
+      // limit() returns a thenable that also has .offset()
+      const limitResult: any = Promise.resolve([
+        {
+          log: {
+            id: 'l1',
+            timestamp: new Date('2026-01-01T01:00:00Z'),
+            level: 'error',
+            category: 'system',
+            source: 'svc',
+            eventId: '1',
+            message: 'boom',
+            deviceId: 'd1',
+          },
+          device: { id: 'd1', hostname: 'h1', displayName: 'H1', siteId: 'site-Z' },
+          site: { id: 'site-Z', name: 'Z' },
+        },
+      ]);
+      limitResult.offset = rowsQuery.offset;
+      return {
+        from: () => ({
+          leftJoin: () => ({
+            leftJoin: () => ({
+              where: () => ({ orderBy: () => ({ limit: () => limitResult }) }),
+            }),
+          }),
+        }),
+      };
+    });
+
+    const r = await handlerFor('search_logs')(
+      { timeRange: { start: '2026-01-01T00:00:00Z', end: '2026-01-02T00:00:00Z' }, countMode: 'none' },
+      makeAuth(undefined),
+    );
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.showing).toBe(1);
+  });
+});
+
+describe('get_log_trends — site narrowing', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller does NOT receive trend rows for a device in a forbidden site', async () => {
+    // Data layer is wired to expose a site-B device's error counts. The fix must
+    // short-circuit (caller only has access to site-A) so nothing leaks.
+    const forbiddenTopDevice = {
+      deviceId: 'd-siteB',
+      hostname: 'forbidden-host',
+      count: 99,
+      errorCount: 50,
+      criticalCount: 9,
+    };
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd-siteB', siteId: 'site-B' }]) }) };
+      }
+      return {
+        from: () => ({
+          leftJoin: () => ({
+            where: () => ({
+              groupBy: () => ({
+                orderBy: () => {
+                  const r: any = Promise.resolve([forbiddenTopDevice]);
+                  r.limit = () => Promise.resolve([forbiddenTopDevice]);
+                  return r;
+                },
+              }),
+            }),
+          }),
+        }),
+      };
+    });
+
+    const r = await handlerFor('get_log_trends')(
+      { timeRange: { start: '2026-01-01T00:00:00Z', end: '2026-01-02T00:00:00Z' } },
+      makeAuth(['site-A']),
+    );
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.trends.topDevices).toEqual([]);
+    expect(JSON.stringify(parsed)).not.toContain('forbidden-host');
+  });
+
+  it('unrestricted caller reads trends normally (no regression)', async () => {
+    mockDb.select.mockImplementation(() => ({
+      from: () => ({
+        leftJoin: () => ({
+          where: () => ({
+            groupBy: () => ({
+              orderBy: () => {
+                const r: any = Promise.resolve([]);
+                r.limit = () => Promise.resolve([]);
+                return r;
+              },
+            }),
+          }),
+        }),
+      }),
+    }));
+    const r = await handlerFor('get_log_trends')(
+      { timeRange: { start: '2026-01-01T00:00:00Z', end: '2026-01-02T00:00:00Z' } },
+      makeAuth(undefined),
+    );
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.trends).toBeDefined();
+  });
+});
+
+describe('detect_log_correlations — site narrowing', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller with no in-scope devices detects no correlation without scanning event logs', async () => {
+    let eventLogScanRan = false;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd-siteB', siteId: 'site-B' }]) }) };
+      }
+      eventLogScanRan = true;
+      return {
+        from: () => ({
+          where: () => ({
+            groupBy: () => ({ orderBy: () => ({ limit: () => Promise.resolve([]) }) }),
+            orderBy: () => ({ limit: () => Promise.resolve([]) }),
+          }),
+          leftJoin: () => ({ where: () => ({ groupBy: () => ({ orderBy: () => Promise.resolve([]) }) }) }),
+        }),
+      };
+    });
+
+    const r = await handlerFor('detect_log_correlations')(
+      { pattern: 'kernel panic' },
+      makeAuth(['site-A']),
+    );
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.detected).toBe(false);
+    // The empty-allowed-set short-circuit means we never touch deviceEventLogs.
+    expect(eventLogScanRan).toBe(false);
+  });
+
+  it('unrestricted caller runs correlation detection normally (no regression)', async () => {
+    let eventLogScanRan = false;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd1', siteId: 'site-Z' }]) }) };
+      }
+      eventLogScanRan = true;
+      // summary / sample selects: .from().where()[.orderBy().limit()]
+      // affected-device select: .from().leftJoin().where().groupBy().orderBy()
+      return {
+        from: () => ({
+          where: () => {
+            const base: any = Promise.resolve([{ firstSeen: null, lastSeen: null, occurrences: 0 }]);
+            base.orderBy = () => ({ limit: () => Promise.resolve([]) });
+            base.groupBy = () => ({ orderBy: () => Promise.resolve([]) });
+            return base;
+          },
+          leftJoin: () => ({ where: () => ({ groupBy: () => ({ orderBy: () => Promise.resolve([]) }) }) }),
+        }),
+      };
+    });
+    const r = await handlerFor('detect_log_correlations')(
+      { pattern: 'kernel panic' },
+      makeAuth(undefined),
+    );
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    // Unrestricted caller: resolver NOT consulted (allowedSiteIds undefined),
+    // correlation scan runs and finds nothing (0 occurrences).
+    expect(parsed.detected).toBe(false);
+    expect(eventLogScanRan).toBe(true);
+  });
+});

--- a/apps/api/src/services/aiToolsEventLogs.ts
+++ b/apps/api/src/services/aiToolsEventLogs.ts
@@ -13,8 +13,22 @@ import {
   resolveSingleOrgId,
   searchFleetLogs,
 } from './logSearch';
+import { resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 
 type AiToolTier = 1 | 2 | 3 | 4;
+
+/**
+ * Resolve the device-id set a site-restricted caller may read across its org.
+ * Returns `null` for unrestricted callers (no narrowing) and `[]` for a
+ * site-restricted caller with zero in-scope devices (caller/query short-circuits
+ * to empty). The site axis is app-layer authz — Postgres RLS does NOT enforce it.
+ */
+async function resolveSiteScopedDeviceIds(auth: AuthContext): Promise<string[] | null> {
+  if (!auth.allowedSiteIds || !auth.canAccessSite) return null;
+  const orgId = auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
+  if (!orgId) return null;
+  return resolveSiteAllowedDeviceIds(orgId, auth);
+}
 
 export function registerEventLogTools(aiTools: Map<string, AiTool>): void {
   function registerTool(tool: AiTool): void {
@@ -64,7 +78,24 @@ export function registerEventLogTools(aiTools: Map<string, AiTool>): void {
     },
     handler: async (input: Record<string, unknown>, auth: AuthContext) => {
       try {
+        // Site axis (app-layer only; RLS does NOT enforce it): narrow a
+        // site-restricted caller to its in-scope device set before searching.
+        const allowedDeviceIds = await resolveSiteScopedDeviceIds(auth);
+        if (allowedDeviceIds != null && allowedDeviceIds.length === 0) {
+          // Restricted caller with zero in-scope devices — no logs are reachable.
+          return JSON.stringify({
+            total: 0,
+            totalMode: 'exact',
+            showing: 0,
+            limit: Math.min(Number(input.limit) || 50, 500),
+            offset: Math.max(0, Number(input.offset) || 0),
+            hasMore: false,
+            nextCursor: null,
+            logs: [],
+          });
+        }
         const result = await searchFleetLogs(auth, {
+          allowedDeviceIds,
           query: typeof input.query === 'string' ? input.query : undefined,
           timeRange: typeof input.timeRange === 'object' && input.timeRange !== null
             ? {
@@ -175,7 +206,32 @@ export function registerEventLogTools(aiTools: Map<string, AiTool>): void {
             }
           : {};
 
+        // Site axis (app-layer only; RLS does NOT enforce it): narrow a
+        // site-restricted caller to its in-scope device set.
+        const allowedDeviceIds = await resolveSiteScopedDeviceIds(auth);
+        if (allowedDeviceIds != null && allowedDeviceIds.length === 0) {
+          // Restricted caller with zero in-scope devices — no trend data reachable.
+          const end = timeRange.end ?? new Date().toISOString();
+          const start = timeRange.start
+            ?? new Date(new Date(end).getTime() - 24 * 60 * 60 * 1000).toISOString();
+          return JSON.stringify({
+            trends: {
+              start,
+              end,
+              minLevel: typeof input.minLevel === 'string' ? input.minLevel : 'info',
+              levelDistribution: [],
+              topSources: [],
+              topDevices: [],
+              errorTimeline: [],
+              spikes: [],
+              spikeThreshold: 3,
+            },
+            grouped: undefined,
+          });
+        }
+
         const trends = await getLogTrends(auth, {
+          allowedDeviceIds,
           start: timeRange.start,
           end: timeRange.end,
           minLevel: typeof input.minLevel === 'string'
@@ -190,6 +246,7 @@ export function registerEventLogTools(aiTools: Map<string, AiTool>): void {
         let groupingSummary: Awaited<ReturnType<typeof getLogAggregation>> | undefined;
         if (typeof input.groupBy === 'string') {
           groupingSummary = await getLogAggregation(auth, {
+            allowedDeviceIds,
             start: trends.start,
             end: trends.end,
             bucket: 'hour',
@@ -242,9 +299,18 @@ export function registerEventLogTools(aiTools: Map<string, AiTool>): void {
           return JSON.stringify({ error: 'orgId is required for this scope' });
         }
 
+        // Site axis (app-layer only; RLS does NOT enforce it): a site-restricted
+        // caller may only correlate across its in-scope devices. Resolve against
+        // the chosen org (not auth.orgId) so partner/system scope narrows too.
+        const allowedDeviceIds =
+          auth.allowedSiteIds && auth.canAccessSite
+            ? await resolveSiteAllowedDeviceIds(orgId, auth)
+            : null;
+
         const pattern = typeof input.pattern === 'string' ? input.pattern : '';
         const result = await detectPatternCorrelation({
           orgId,
+          allowedDeviceIds,
           pattern,
           isRegex: Boolean(input.isRegex),
           timeWindowSeconds: Number(input.timeWindow) || 300,

--- a/apps/api/src/services/aiToolsEventLogs.ts
+++ b/apps/api/src/services/aiToolsEventLogs.ts
@@ -13,7 +13,7 @@ import {
   resolveSingleOrgId,
   searchFleetLogs,
 } from './logSearch';
-import { resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
+import { resolveSiteAllowedDeviceIds, SITE_SCOPE_EMPTY_NOTE } from './aiToolsSiteScope';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -92,6 +92,7 @@ export function registerEventLogTools(aiTools: Map<string, AiTool>): void {
             hasMore: false,
             nextCursor: null,
             logs: [],
+            scopeNote: SITE_SCOPE_EMPTY_NOTE,
           });
         }
         const result = await searchFleetLogs(auth, {
@@ -227,6 +228,7 @@ export function registerEventLogTools(aiTools: Map<string, AiTool>): void {
               spikeThreshold: 3,
             },
             grouped: undefined,
+            scopeNote: SITE_SCOPE_EMPTY_NOTE,
           });
         }
 
@@ -319,9 +321,13 @@ export function registerEventLogTools(aiTools: Map<string, AiTool>): void {
         });
 
         if (!result) {
+          // Distinguish "nothing matched" from "the caller's site access covers
+          // zero devices" (detectPatternCorrelation short-circuits to null).
+          const scopeLimited = allowedDeviceIds != null && allowedDeviceIds.length === 0;
           return JSON.stringify({
             detected: false,
             message: 'No correlation matched the requested thresholds for this pattern.',
+            ...(scopeLimited ? { scopeNote: SITE_SCOPE_EMPTY_NOTE } : {}),
           });
         }
 

--- a/apps/api/src/services/aiToolsHuntress.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsHuntress.siteScope.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('../jobs/huntressSync', () => ({ scheduleHuntressSync: vi.fn() }));
+
+import { db } from '../db';
+import { registerHuntressTools } from './aiToolsHuntress';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerHuntressTools(reg);
+  return reg.get(name)!.handler;
+}
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
+    accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds, canAccessSite: (s: string | null | undefined) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  } as unknown as AuthContext;
+}
+function isDeviceResolverSelect(cols: unknown): boolean {
+  return (
+    !!cols && typeof cols === 'object' &&
+    'id' in (cols as object) && 'siteId' in (cols as object) &&
+    Object.keys(cols as object).length === 2
+  );
+}
+/** Generic chainable query mock that resolves to `result`. */
+function chain(result: unknown): any {
+  const p: any = Promise.resolve(result);
+  for (const m of ['from', 'innerJoin', 'leftJoin', 'where', 'orderBy', 'limit', 'groupBy', 'offset']) {
+    p[m] = () => p;
+  }
+  return p;
+}
+
+describe('get_huntress_incidents — site narrowing (cross-site enumeration)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller does NOT receive incidents/hostnames for a device in a forbidden site', async () => {
+    let incidentScanRan = false;
+    const forbiddenIncident = {
+      id: 'i1', orgId: 'org-1', deviceId: 'd-siteB',
+      title: 'SECRET cross-site incident', deviceHostname: 'forbidden-host',
+    };
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd-siteB', siteId: 'site-B' }]) }) };
+      }
+      incidentScanRan = true;
+      if (cols && typeof cols === 'object' && 'count' in (cols as object)) {
+        return chain([{ count: 1 }]);
+      }
+      return chain([forbiddenIncident]);
+    });
+
+    const r = await handlerFor('get_huntress_incidents')({}, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.total).toBe(0);
+    expect(parsed.incidents).toEqual([]);
+    expect(incidentScanRan).toBe(false);
+    expect(JSON.stringify(parsed)).not.toContain('forbidden-host');
+    expect(JSON.stringify(parsed)).not.toContain('SECRET cross-site incident');
+  });
+
+  it('unrestricted caller enumerates incidents normally (no regression)', async () => {
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (cols && typeof cols === 'object' && 'count' in (cols as object)) {
+        return chain([{ count: 1 }]);
+      }
+      return chain([{ id: 'i1', orgId: 'org-1', deviceId: 'd1', title: 'Incident', deviceHostname: 'h1' }]);
+    });
+    const r = await handlerFor('get_huntress_incidents')({}, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.total).toBe(1);
+    expect(parsed.incidents).toHaveLength(1);
+  });
+});

--- a/apps/api/src/services/aiToolsHuntress.ts
+++ b/apps/api/src/services/aiToolsHuntress.ts
@@ -19,7 +19,7 @@ import type { AuthContext } from '../middleware/auth';
 import { escapeLike } from '../utils/sql';
 import type { AiTool } from './aiTools';
 import { resolveWritableToolOrgId } from './aiTools';
-import { resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
+import { resolveSiteAllowedDeviceIds, SITE_SCOPE_EMPTY_NOTE } from './aiToolsSiteScope';
 import { scheduleHuntressSync } from '../jobs/huntressSync';
 import { offlineStatusSqlList, resolvedStatusSqlList } from './huntressConstants';
 
@@ -267,7 +267,7 @@ export function registerHuntressTools(aiTools: Map<string, AiTool>): void {
         const queryOrgId = requestedOrgId ?? auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
         const allowed = queryOrgId ? await resolveSiteAllowedDeviceIds(queryOrgId, auth) : [];
         if (!allowed || allowed.length === 0) {
-          return JSON.stringify({ incidents: [], total: 0, limit, offset, includeResolved });
+          return JSON.stringify({ incidents: [], total: 0, limit, offset, includeResolved, scopeNote: SITE_SCOPE_EMPTY_NOTE });
         }
         conditions.push(inArray(huntressIncidents.deviceId, allowed));
       }

--- a/apps/api/src/services/aiToolsHuntress.ts
+++ b/apps/api/src/services/aiToolsHuntress.ts
@@ -19,6 +19,7 @@ import type { AuthContext } from '../middleware/auth';
 import { escapeLike } from '../utils/sql';
 import type { AiTool } from './aiTools';
 import { resolveWritableToolOrgId } from './aiTools';
+import { resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 import { scheduleHuntressSync } from '../jobs/huntressSync';
 import { offlineStatusSqlList, resolvedStatusSqlList } from './huntressConstants';
 
@@ -253,6 +254,22 @@ export function registerHuntressTools(aiTools: Map<string, AiTool>): void {
       }
       if (!includeResolved) {
         conditions.push(sql`coalesce(lower(${huntressIncidents.status}), '') not in (${sql.raw(resolvedStatusSqlList())})`);
+      }
+
+      // Site axis (app-layer only; RLS does NOT enforce it). huntressIncidents
+      // has no site_id column, so narrow by the in-scope device-id set (this
+      // also scopes the deviceHostname join). A restricted caller with zero
+      // in-scope devices short-circuits to empty results. Intersects with the
+      // optional deviceId filter above (most-restrictive wins). Incidents not
+      // mapped to a device (deviceId null) are excluded for a restricted
+      // caller (fail closed).
+      if (auth.allowedSiteIds && auth.canAccessSite) {
+        const queryOrgId = requestedOrgId ?? auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
+        const allowed = queryOrgId ? await resolveSiteAllowedDeviceIds(queryOrgId, auth) : [];
+        if (!allowed || allowed.length === 0) {
+          return JSON.stringify({ incidents: [], total: 0, limit, offset, includeResolved });
+        }
+        conditions.push(inArray(huntressIncidents.deviceId, allowed));
       }
 
       const where = conditions.length > 0 ? and(...conditions) : undefined;

--- a/apps/api/src/services/aiToolsMonitoring.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsMonitoring.siteScope.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+
+import { db } from '../db';
+import { registerMonitoringTools } from './aiToolsMonitoring';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerMonitoringTools(reg);
+  return reg.get(name)!.handler;
+}
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
+    accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds, canAccessSite: (s: string | null | undefined) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  } as unknown as AuthContext;
+}
+function isDeviceResolverSelect(cols: unknown): boolean {
+  return (
+    !!cols && typeof cols === 'object' &&
+    'id' in (cols as object) && 'siteId' in (cols as object) &&
+    Object.keys(cols as object).length === 2
+  );
+}
+/** Generic chainable query mock that resolves to `result`. */
+function chain(result: unknown): any {
+  const p: any = Promise.resolve(result);
+  for (const m of ['from', 'innerJoin', 'leftJoin', 'where', 'orderBy', 'limit', 'groupBy', 'offset']) {
+    p[m] = () => p;
+  }
+  return p;
+}
+
+describe('query_monitors — site narrowing via the linked discovered asset', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller queries monitors through the asset-site join (site filter applied)', async () => {
+    let leftJoinCalled = false;
+    mockDb.select.mockImplementation(() => ({
+      from: () => ({
+        leftJoin: () => {
+          leftJoinCalled = true;
+          return { where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([]) }) }) };
+        },
+        where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([{ id: 'm1', name: 'forbidden-monitor' }]) }) }),
+      }),
+    }));
+
+    const r = await handlerFor('query_monitors')({}, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    // The restricted path MUST route through the discoveredAssets join (which
+    // carries the inArray(siteId) condition) — never the unjoined org-wide scan.
+    expect(leftJoinCalled).toBe(true);
+    expect(parsed.monitors).toEqual([]);
+    expect(JSON.stringify(parsed)).not.toContain('forbidden-monitor');
+  });
+
+  it('site-restricted caller with an empty site allowlist gets empty results without scanning', async () => {
+    const r = await handlerFor('query_monitors')({}, makeAuth([]));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.monitors).toEqual([]);
+    expect(parsed.showing).toBe(0);
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it('unrestricted caller takes the exact pre-existing unjoined query (no regression)', async () => {
+    let leftJoinCalled = false;
+    mockDb.select.mockImplementation(() => ({
+      from: () => ({
+        leftJoin: () => {
+          leftJoinCalled = true;
+          return { where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([]) }) }) };
+        },
+        where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([{ id: 'm1', name: 'Mon' }]) }) }),
+      }),
+    }));
+
+    const r = await handlerFor('query_monitors')({}, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(leftJoinCalled).toBe(false);
+    expect(parsed.showing).toBe(1);
+  });
+});
+
+describe('get_service_monitoring_status results — site narrowing (cross-site enumeration)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller does NOT receive check results for a device in a forbidden site', async () => {
+    let resultScanRan = false;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd-siteB', siteId: 'site-B' }]) }) };
+      }
+      resultScanRan = true;
+      return chain([{
+        id: 'r1', deviceId: 'd-siteB', watchType: 'service', name: 'secret-svc', status: 'running',
+        cpuPercent: null, memoryMb: null, pid: null, details: null,
+        autoRestartAttempted: false, autoRestartSucceeded: null, timestamp: new Date('2026-01-01T00:00:00Z'),
+      }]);
+    });
+
+    const r = await handlerFor('get_service_monitoring_status')({ action: 'results' }, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.data).toEqual([]);
+    expect(parsed.showing).toBe(0);
+    expect(resultScanRan).toBe(false);
+    expect(JSON.stringify(parsed)).not.toContain('secret-svc');
+  });
+
+  it('unrestricted caller enumerates check results normally (no regression)', async () => {
+    mockDb.select.mockImplementation(() => chain([{
+      id: 'r1', deviceId: 'd1', watchType: 'service', name: 'svc', status: 'running',
+      cpuPercent: null, memoryMb: null, pid: null, details: null,
+      autoRestartAttempted: false, autoRestartSucceeded: null, timestamp: new Date('2026-01-01T00:00:00Z'),
+    }]));
+    const r = await handlerFor('get_service_monitoring_status')({ action: 'results' }, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.showing).toBe(1);
+  });
+});
+
+describe('get_service_monitoring_status known_services — site narrowing', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller with no in-scope devices gets no names without scanning', async () => {
+    let nameScanRan = false;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd-siteB', siteId: 'site-B' }]) }) };
+      }
+      nameScanRan = true;
+      return chain([{ subject: 'secret-service-name' }]);
+    });
+
+    const r = await handlerFor('get_service_monitoring_status')({ action: 'known_services' }, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.data).toEqual([]);
+    expect(nameScanRan).toBe(false);
+  });
+});

--- a/apps/api/src/services/aiToolsMonitoring.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsMonitoring.siteScope.test.ts
@@ -42,6 +42,15 @@ function chain(result: unknown): any {
   }
   return p;
 }
+/** Chainable query mock that rejects with `err` when awaited. */
+function rejectChain(err: unknown): any {
+  const p: any = Promise.reject(err);
+  p.catch(() => {}); // prevent unhandled-rejection noise; the handler awaits p itself
+  for (const m of ['from', 'innerJoin', 'leftJoin', 'where', 'orderBy', 'limit', 'groupBy', 'offset']) {
+    p[m] = () => p;
+  }
+  return p;
+}
 
 describe('query_monitors — site narrowing via the linked discovered asset', () => {
   beforeEach(() => vi.clearAllMocks());
@@ -153,6 +162,64 @@ describe('get_service_monitoring_status known_services — site narrowing', () =
     const parsed = JSON.parse(r);
     expect(parsed.error).toBeUndefined();
     expect(parsed.data).toEqual([]);
+    // The empty result must be annotated as scope-limited, not "no services exist".
+    expect(parsed.scopeNote).toBeTruthy();
     expect(nameScanRan).toBe(false);
+  });
+});
+
+describe('get_service_monitoring_status known_services — DB error surfacing', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const isChangeLogSelect = (cols: unknown) =>
+    !!cols && typeof cols === 'object' && 'subject' in (cols as object);
+
+  it('an unknown DB error surfaces as a tool error — NOT a silent empty list', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      mockDb.select.mockImplementation((cols?: unknown) => {
+        if (isChangeLogSelect(cols)) {
+          return rejectChain(new Error('Connection terminated unexpectedly'));
+        }
+        return chain([{ name: 'nginx', watchType: 'service' }]);
+      });
+
+      const r = await handlerFor('get_service_monitoring_status')(
+        { action: 'known_services' }, makeAuth(undefined),
+      );
+      const parsed = JSON.parse(r);
+      expect(parsed.error).toBeDefined();
+      expect(parsed.data).toBeUndefined();
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it('a missing-table error is tolerated as an empty source (other sources still returned)', async () => {
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isChangeLogSelect(cols)) {
+        return rejectChain(new Error('relation "device_change_log" does not exist'));
+      }
+      return chain([{ name: 'nginx', watchType: 'service' }]);
+    });
+
+    const r = await handlerFor('get_service_monitoring_status')(
+      { action: 'known_services' }, makeAuth(undefined),
+    );
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.data).toEqual([{ name: 'nginx', source: 'check_results', watchType: 'service' }]);
+  });
+
+  it('both sources missing-table tolerated → empty list without error', async () => {
+    mockDb.select.mockImplementation(() =>
+      rejectChain(new Error('relation does not exist')));
+
+    const r = await handlerFor('get_service_monitoring_status')(
+      { action: 'known_services' }, makeAuth(undefined),
+    );
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.data).toEqual([]);
   });
 });

--- a/apps/api/src/services/aiToolsMonitoring.ts
+++ b/apps/api/src/services/aiToolsMonitoring.ts
@@ -16,7 +16,7 @@ import { deviceChangeLog, discoveredAssets } from '../db/schema';
 import { eq, and, desc, gte, lte, inArray, sql, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
-import { resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
+import { resolveSiteAllowedDeviceIds, SITE_SCOPE_EMPTY_NOTE } from './aiToolsSiteScope';
 
 type MonitoringHandler = (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
 
@@ -107,7 +107,7 @@ export function registerMonitoringTools(aiTools: Map<string, AiTool>): void {
       const siteRestricted = !!(allowedSites && auth.canAccessSite);
       if (siteRestricted) {
         if (allowedSites!.length === 0) {
-          return JSON.stringify({ monitors: [], showing: 0 });
+          return JSON.stringify({ monitors: [], showing: 0, scopeNote: SITE_SCOPE_EMPTY_NOTE });
         }
         conditions.push(inArray(discoveredAssets.siteId, allowedSites!));
       }
@@ -390,7 +390,7 @@ export function registerMonitoringTools(aiTools: Map<string, AiTool>): void {
         if (auth.allowedSiteIds && auth.canAccessSite) {
           const allowed = await resolveSiteAllowedDeviceIds(orgId, auth);
           if (!allowed || allowed.length === 0) {
-            return JSON.stringify({ data: [], showing: 0 });
+            return JSON.stringify({ data: [], showing: 0, scopeNote: SITE_SCOPE_EMPTY_NOTE });
           }
           conditions.push(inArray(serviceProcessCheckResults.deviceId, allowed));
         }
@@ -433,7 +433,7 @@ export function registerMonitoringTools(aiTools: Map<string, AiTool>): void {
         if (auth.allowedSiteIds && auth.canAccessSite) {
           siteAllowedDeviceIds = await resolveSiteAllowedDeviceIds(orgId, auth);
           if (!siteAllowedDeviceIds || siteAllowedDeviceIds.length === 0) {
-            return JSON.stringify({ data: [] });
+            return JSON.stringify({ data: [], scopeNote: SITE_SCOPE_EMPTY_NOTE });
           }
         }
 
@@ -453,10 +453,11 @@ export function registerMonitoringTools(aiTools: Map<string, AiTool>): void {
             .groupBy(deviceChangeLog.subject)
             .limit(1000);
         } catch (err) {
+          // Tolerate missing-table environments (older self-hosted schemas) as
+          // an empty source; any other DB error must surface as a tool error
+          // (via safeHandler / the aiAgentSdkTools catch), not a silent empty.
           const msg = err instanceof Error ? err.message : String(err);
-          if (!msg.includes('does not exist')) {
-            console.error(`[monitoring:known_services] Failed to query change log for org ${orgId}:`, err);
-          }
+          if (!msg.includes('does not exist')) throw err;
         }
 
         // Source 2: Distinct service/process names from check results
@@ -474,10 +475,10 @@ export function registerMonitoringTools(aiTools: Map<string, AiTool>): void {
             .groupBy(serviceProcessCheckResults.name, serviceProcessCheckResults.watchType)
             .limit(500);
         } catch (err) {
+          // Same policy as the change-log source: only missing-table errors are
+          // tolerated as an empty source; everything else surfaces as a tool error.
           const msg = err instanceof Error ? err.message : String(err);
-          if (!msg.includes('does not exist')) {
-            console.error(`[monitoring:known_services] Failed to query check results for org ${orgId}:`, err);
-          }
+          if (!msg.includes('does not exist')) throw err;
         }
 
         const seen = new Set<string>();

--- a/apps/api/src/services/aiToolsMonitoring.ts
+++ b/apps/api/src/services/aiToolsMonitoring.ts
@@ -12,10 +12,11 @@ import {
   networkMonitorAlertRules,
 } from '../db/schema/monitors';
 import { serviceProcessCheckResults } from '../db/schema/serviceProcessMonitoring';
-import { deviceChangeLog } from '../db/schema';
-import { eq, and, desc, gte, lte, sql, SQL } from 'drizzle-orm';
+import { deviceChangeLog, discoveredAssets } from '../db/schema';
+import { eq, and, desc, gte, lte, inArray, sql, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
+import { resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 
 type MonitoringHandler = (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
 
@@ -97,7 +98,21 @@ export function registerMonitoringTools(aiTools: Map<string, AiTool>): void {
 
       const limit = Math.min(Math.max(1, Number(input.limit) || 25), 100);
 
-      const rows = await db.select({
+      // Site axis (app-layer only; RLS does NOT enforce it). networkMonitors is
+      // not device-linked — its site is the linked discovered asset's site
+      // (mirrors hasMonitorSiteAccess in routes/monitors.ts). A site-restricted
+      // caller only sees monitors whose asset lives in an allowed site;
+      // monitors with no asset (siteId null) are denied (fail closed).
+      const allowedSites = auth.allowedSiteIds;
+      const siteRestricted = !!(allowedSites && auth.canAccessSite);
+      if (siteRestricted) {
+        if (allowedSites!.length === 0) {
+          return JSON.stringify({ monitors: [], showing: 0 });
+        }
+        conditions.push(inArray(discoveredAssets.siteId, allowedSites!));
+      }
+
+      const selection = {
         id: networkMonitors.id,
         name: networkMonitors.name,
         monitorType: networkMonitors.monitorType,
@@ -108,10 +123,19 @@ export function registerMonitoringTools(aiTools: Map<string, AiTool>): void {
         lastResponseMs: networkMonitors.lastResponseMs,
         consecutiveFailures: networkMonitors.consecutiveFailures,
         pollingInterval: networkMonitors.pollingInterval,
-      }).from(networkMonitors)
-        .where(conditions.length > 0 ? and(...conditions) : undefined)
-        .orderBy(desc(networkMonitors.updatedAt))
-        .limit(limit);
+      };
+
+      // Unrestricted callers take the exact pre-existing query (no join).
+      const rows = siteRestricted
+        ? await db.select(selection).from(networkMonitors)
+          .leftJoin(discoveredAssets, eq(networkMonitors.assetId, discoveredAssets.id))
+          .where(and(...conditions))
+          .orderBy(desc(networkMonitors.updatedAt))
+          .limit(limit)
+        : await db.select(selection).from(networkMonitors)
+          .where(conditions.length > 0 ? and(...conditions) : undefined)
+          .orderBy(desc(networkMonitors.updatedAt))
+          .limit(limit);
 
       return JSON.stringify({ monitors: rows, showing: rows.length });
     }),
@@ -358,6 +382,19 @@ export function registerMonitoringTools(aiTools: Map<string, AiTool>): void {
         if (typeof input.since === 'string') conditions.push(gte(serviceProcessCheckResults.timestamp, new Date(input.since)));
         if (typeof input.until === 'string') conditions.push(lte(serviceProcessCheckResults.timestamp, new Date(input.until)));
 
+        // Site axis (app-layer only; RLS does NOT enforce it). Without a
+        // caller-supplied deviceId this path enumerates check results org-wide,
+        // so narrow a site-restricted caller to its in-scope device-id set.
+        // (A caller-supplied deviceId is already org+site gated centrally via
+        // `deviceArgs` → enforceDeviceArgs; this intersects with it.)
+        if (auth.allowedSiteIds && auth.canAccessSite) {
+          const allowed = await resolveSiteAllowedDeviceIds(orgId, auth);
+          if (!allowed || allowed.length === 0) {
+            return JSON.stringify({ data: [], showing: 0 });
+          }
+          conditions.push(inArray(serviceProcessCheckResults.deviceId, allowed));
+        }
+
         const limit = Math.min(Math.max(1, Number(input.limit) || 100), 500);
 
         const results = await db
@@ -389,17 +426,30 @@ export function registerMonitoringTools(aiTools: Map<string, AiTool>): void {
       if (action === 'known_services') {
         if (!orgId) return JSON.stringify({ error: 'Organization context required' });
 
+        // Site axis (app-layer only; RLS does NOT enforce it). Both name sources
+        // below are derived per-device org-wide, so narrow a site-restricted
+        // caller to its in-scope device-id set (empty set ⇒ empty result).
+        let siteAllowedDeviceIds: string[] | null = null;
+        if (auth.allowedSiteIds && auth.canAccessSite) {
+          siteAllowedDeviceIds = await resolveSiteAllowedDeviceIds(orgId, auth);
+          if (!siteAllowedDeviceIds || siteAllowedDeviceIds.length === 0) {
+            return JSON.stringify({ data: [] });
+          }
+        }
+
         // Normalize service names by stripping per-user/per-device hex suffixes
         const normalizeServiceName = (name: string): string =>
           name.replace(/_[a-f0-9]{4,}$/i, '');
 
         // Source 1: Distinct service names from device change log
+        const changeLogConditions: SQL[] = [eq(deviceChangeLog.orgId, orgId), eq(deviceChangeLog.changeType, 'service')];
+        if (siteAllowedDeviceIds) changeLogConditions.push(inArray(deviceChangeLog.deviceId, siteAllowedDeviceIds));
         let changeLogNames: { subject: string }[] = [];
         try {
           changeLogNames = await db
             .select({ subject: deviceChangeLog.subject })
             .from(deviceChangeLog)
-            .where(and(eq(deviceChangeLog.orgId, orgId), eq(deviceChangeLog.changeType, 'service')))
+            .where(and(...changeLogConditions))
             .groupBy(deviceChangeLog.subject)
             .limit(1000);
         } catch (err) {
@@ -410,6 +460,8 @@ export function registerMonitoringTools(aiTools: Map<string, AiTool>): void {
         }
 
         // Source 2: Distinct service/process names from check results
+        const checkNameConditions: SQL[] = [eq(serviceProcessCheckResults.orgId, orgId)];
+        if (siteAllowedDeviceIds) checkNameConditions.push(inArray(serviceProcessCheckResults.deviceId, siteAllowedDeviceIds));
         let checkNames: { name: string; watchType: string }[] = [];
         try {
           checkNames = await db
@@ -418,7 +470,7 @@ export function registerMonitoringTools(aiTools: Map<string, AiTool>): void {
               watchType: serviceProcessCheckResults.watchType,
             })
             .from(serviceProcessCheckResults)
-            .where(eq(serviceProcessCheckResults.orgId, orgId))
+            .where(and(...checkNameConditions))
             .groupBy(serviceProcessCheckResults.name, serviceProcessCheckResults.watchType)
             .limit(500);
         } catch (err) {

--- a/apps/api/src/services/aiToolsPeripherals.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsPeripherals.siteScope.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('./eventBus', () => ({ publishEvent: vi.fn(async () => {}) }));
+vi.mock('../jobs/peripheralJobs', () => ({ schedulePeripheralPolicyDistribution: vi.fn(async () => {}) }));
+
+import { db } from '../db';
+import { registerPeripheralTools } from './aiToolsPeripherals';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerPeripheralTools(reg);
+  return reg.get(name)!.handler;
+}
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
+    accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds, canAccessSite: (s: string | null | undefined) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  } as unknown as AuthContext;
+}
+function isDeviceResolverSelect(cols: unknown): boolean {
+  return (
+    !!cols && typeof cols === 'object' &&
+    'id' in (cols as object) && 'siteId' in (cols as object) &&
+    Object.keys(cols as object).length === 2
+  );
+}
+
+describe('get_peripheral_activity — site narrowing (cross-site enumeration)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller does NOT receive events from a device in a forbidden site', async () => {
+    let eventScanRan = false;
+    const forbiddenEvent = { id: 'ev1', deviceId: 'd-siteB', eventType: 'connected', vendor: 'SECRET-VENDOR' };
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd-siteB', siteId: 'site-B' }]) }) };
+      }
+      // bare .select() (no projection) → peripheralEvents read
+      eventScanRan = true;
+      return { from: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([forbiddenEvent]) }) }) }) };
+    });
+
+    const r = await handlerFor('get_peripheral_activity')({}, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.summary.count).toBe(0);
+    expect(parsed.events).toEqual([]);
+    expect(eventScanRan).toBe(false);
+    expect(JSON.stringify(parsed)).not.toContain('SECRET-VENDOR');
+  });
+
+  it('unrestricted caller enumerates events normally (no regression)', async () => {
+    mockDb.select.mockReturnValue({
+      from: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([{ id: 'ev1', deviceId: 'd1', eventType: 'connected' }]) }) }) }),
+    });
+    const r = await handlerFor('get_peripheral_activity')({}, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.summary.count).toBe(1);
+  });
+});

--- a/apps/api/src/services/aiToolsPeripherals.ts
+++ b/apps/api/src/services/aiToolsPeripherals.ts
@@ -21,7 +21,7 @@ import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { publishEvent } from './eventBus';
 import { schedulePeripheralPolicyDistribution } from '../jobs/peripheralJobs';
-import { resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
+import { resolveSiteAllowedDeviceIds, SITE_SCOPE_EMPTY_NOTE } from './aiToolsSiteScope';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -155,6 +155,7 @@ export function registerPeripheralTools(aiTools: Map<string, AiTool>): void {
           return JSON.stringify({
             events: [],
             summary: { count: 0, byType: {}, start: start.toISOString(), end: end.toISOString() },
+            scopeNote: SITE_SCOPE_EMPTY_NOTE,
           });
         }
         conditions.push(inArray(peripheralEvents.deviceId, allowed));

--- a/apps/api/src/services/aiToolsPeripherals.ts
+++ b/apps/api/src/services/aiToolsPeripherals.ts
@@ -16,11 +16,12 @@ import {
   peripheralPolicyTargetTypeEnum,
   type PeripheralExceptionRule
 } from '../db/schema';
-import { eq, and, desc, sql, gte, lte, SQL } from 'drizzle-orm';
+import { eq, and, desc, sql, gte, lte, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { publishEvent } from './eventBus';
 import { schedulePeripheralPolicyDistribution } from '../jobs/peripheralJobs';
+import { resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -137,6 +138,26 @@ export function registerPeripheralTools(aiTools: Map<string, AiTool>): void {
       if (typeof input.policy_id === 'string') conditions.push(eq(peripheralEvents.policyId, input.policy_id));
       if (typeof input.event_type === 'string') {
         conditions.push(eq(peripheralEvents.eventType, input.event_type as typeof peripheralEvents.eventType.enumValues[number]));
+      }
+
+      // Site axis (app-layer only; RLS does NOT enforce it). peripheralEvents has
+      // no site_id column, so narrow by the in-scope device-id set. A restricted
+      // caller with zero in-scope devices short-circuits to empty results. This
+      // intersects with the optional caller-supplied device_id filter above
+      // (most-restrictive wins).
+      if (auth.allowedSiteIds && auth.canAccessSite) {
+        const queryOrgId = orgId ?? auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
+        if (!queryOrgId) {
+          return JSON.stringify({ error: 'Organization context required' });
+        }
+        const allowed = await resolveSiteAllowedDeviceIds(queryOrgId, auth);
+        if (!allowed || allowed.length === 0) {
+          return JSON.stringify({
+            events: [],
+            summary: { count: 0, byType: {}, start: start.toISOString(), end: end.toISOString() },
+          });
+        }
+        conditions.push(inArray(peripheralEvents.deviceId, allowed));
       }
 
       const limit = Math.min(Math.max(1, Number(input.limit) || 100), 500);

--- a/apps/api/src/services/aiToolsSLABackup.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsSLABackup.siteScope.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+
+import { db } from '../db';
+import { registerSLABackupTools } from './aiToolsSLABackup';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerSLABackupTools(reg);
+  return reg.get(name)!.handler;
+}
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
+    accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds, canAccessSite: (s: string | null | undefined) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  } as unknown as AuthContext;
+}
+function isDeviceResolverSelect(cols: unknown): boolean {
+  return (
+    !!cols && typeof cols === 'object' &&
+    'id' in (cols as object) && 'siteId' in (cols as object) &&
+    Object.keys(cols as object).length === 2
+  );
+}
+/** Generic chainable query mock that resolves to `result`. */
+function chain(result: unknown): any {
+  const p: any = Promise.resolve(result);
+  for (const m of ['from', 'innerJoin', 'leftJoin', 'where', 'orderBy', 'limit', 'groupBy', 'offset']) {
+    p[m] = () => p;
+  }
+  return p;
+}
+
+describe('get_sla_breaches — site narrowing (cross-site enumeration)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller does NOT receive breach rows/hostnames for a device in a forbidden site', async () => {
+    let breachScanRan = false;
+    const forbiddenBreach = {
+      id: 'b1', slaConfigId: 'c1', slaName: 'SLA', deviceId: 'd-siteB',
+      hostname: 'forbidden-host', eventType: 'rpo_breach', details: null,
+      detectedAt: new Date('2026-01-01T00:00:00Z'), resolvedAt: null,
+    };
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd-siteB', siteId: 'site-B' }]) }) };
+      }
+      breachScanRan = true;
+      return chain([forbiddenBreach]);
+    });
+
+    const r = await handlerFor('get_sla_breaches')({}, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.breaches).toEqual([]);
+    expect(parsed.showing).toBe(0);
+    expect(breachScanRan).toBe(false);
+    expect(JSON.stringify(parsed)).not.toContain('forbidden-host');
+  });
+
+  it('unrestricted caller enumerates breaches normally (no regression)', async () => {
+    mockDb.select.mockImplementation(() => chain([{
+      id: 'b1', slaConfigId: 'c1', slaName: 'SLA', deviceId: 'd1',
+      hostname: 'h1', eventType: 'rpo_breach', details: null,
+      detectedAt: new Date('2026-01-01T00:00:00Z'), resolvedAt: null,
+    }]));
+    const r = await handlerFor('get_sla_breaches')({}, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.showing).toBe(1);
+  });
+});
+
+describe('get_sla_compliance_report — site narrowing', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller with no in-scope devices gets an empty report without scanning', async () => {
+    let reportScanRan = false;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd-siteB', siteId: 'site-B' }]) }) };
+      }
+      reportScanRan = true;
+      if (cols && typeof cols === 'object' && 'avgRpo' in (cols as object)) {
+        return chain([{ avgRpo: 60, avgRto: 120 }]);
+      }
+      return chain([{ count: 7 }]);
+    });
+
+    const r = await handlerFor('get_sla_compliance_report')({}, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.activeBreaches).toBe(0);
+    expect(parsed.totalEventsInWindow).toBe(0);
+    expect(parsed.avgEstimatedRpoMinutes).toBe(0);
+    expect(parsed.avgEstimatedRtoMinutes).toBe(0);
+    expect(reportScanRan).toBe(false);
+  });
+
+  it('unrestricted caller reads the report normally (no regression)', async () => {
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (cols && typeof cols === 'object' && 'avgRpo' in (cols as object)) {
+        return chain([{ avgRpo: 60, avgRto: 120 }]);
+      }
+      return chain([{ count: 2 }]);
+    });
+    const r = await handlerFor('get_sla_compliance_report')({}, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.activeConfigs).toBe(2);
+    expect(parsed.activeBreaches).toBe(2);
+    expect(parsed.avgEstimatedRpoMinutes).toBe(60);
+    expect(parsed.avgEstimatedRtoMinutes).toBe(120);
+  });
+});
+
+describe('query_backup_sla — site narrowing of breach counts', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller with no in-scope devices sees configs with zero breach signal (no breach scan)', async () => {
+    let breachScanRan = false;
+    const config = {
+      id: 'c1', orgId: 'org-1', name: 'SLA Config', targetDevices: ['d-siteB'], targetGroups: [],
+      isActive: true, createdAt: new Date('2026-01-01T00:00:00Z'),
+    };
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd-siteB', siteId: 'site-B' }]) }) };
+      }
+      if (cols === undefined) {
+        return chain([config]); // config listing (org-level, not device-linked)
+      }
+      breachScanRan = true; // breach-count aggregation must not run
+      return chain([{ slaConfigId: 'c1', count: 5 }]);
+    });
+
+    const r = await handlerFor('query_backup_sla')({}, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.showing).toBe(1);
+    expect(parsed.configs[0].activeBreaches).toBe(0);
+    expect(parsed.configs[0].complianceStatus).toBe('compliant');
+    expect(breachScanRan).toBe(false);
+  });
+
+  it('unrestricted caller sees real breach counts (no regression)', async () => {
+    const config = {
+      id: 'c1', orgId: 'org-1', name: 'SLA Config', targetDevices: [], targetGroups: [],
+      isActive: true, createdAt: new Date('2026-01-01T00:00:00Z'),
+    };
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (cols === undefined) return chain([config]);
+      return chain([{ slaConfigId: 'c1', count: 5 }]);
+    });
+    const r = await handlerFor('query_backup_sla')({}, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.configs[0].activeBreaches).toBe(5);
+    expect(parsed.configs[0].complianceStatus).toBe('breach');
+  });
+});

--- a/apps/api/src/services/aiToolsSLABackup.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsSLABackup.siteScope.test.ts
@@ -66,6 +66,8 @@ describe('get_sla_breaches — site narrowing (cross-site enumeration)', () => {
     expect(parsed.error).toBeUndefined();
     expect(parsed.breaches).toEqual([]);
     expect(parsed.showing).toBe(0);
+    // The empty result must be annotated as scope-limited, not "no data exists".
+    expect(parsed.scopeNote).toBeTruthy();
     expect(breachScanRan).toBe(false);
     expect(JSON.stringify(parsed)).not.toContain('forbidden-host');
   });
@@ -86,27 +88,37 @@ describe('get_sla_breaches — site narrowing (cross-site enumeration)', () => {
 describe('get_sla_compliance_report — site narrowing', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('site-restricted caller with no in-scope devices gets an empty report without scanning', async () => {
-    let reportScanRan = false;
+  it('site-restricted caller with no in-scope devices gets an indeterminate report (configs counted, no device scans)', async () => {
+    let deviceLinkedScanRan = false;
+    let countQueries = 0;
     mockDb.select.mockImplementation((cols?: unknown) => {
       if (isDeviceResolverSelect(cols)) {
         return { from: () => ({ where: () => Promise.resolve([{ id: 'd-siteB', siteId: 'site-B' }]) }) };
       }
-      reportScanRan = true;
       if (cols && typeof cols === 'object' && 'avgRpo' in (cols as object)) {
+        deviceLinkedScanRan = true; // recoveryReadiness scan must not run
         return chain([{ avgRpo: 60, avgRto: 120 }]);
       }
+      countQueries += 1;
       return chain([{ count: 7 }]);
     });
 
     const r = await handlerFor('get_sla_compliance_report')({}, makeAuth(['site-A']));
     const parsed = JSON.parse(r);
     expect(parsed.error).toBeUndefined();
+    // Org-level config metadata stays visible (configs are not device-linked)…
+    expect(parsed.activeConfigs).toBe(7);
+    expect(countQueries).toBe(1); // only the config count — no breach/event scans
+    // …but device-derived compliance is indeterminate — never a fabricated 100%.
+    expect(parsed.compliancePercent).toBeNull();
+    expect(parsed.compliantConfigs).toBeNull();
+    expect(parsed.configsWithBreaches).toBeNull();
     expect(parsed.activeBreaches).toBe(0);
     expect(parsed.totalEventsInWindow).toBe(0);
-    expect(parsed.avgEstimatedRpoMinutes).toBe(0);
-    expect(parsed.avgEstimatedRtoMinutes).toBe(0);
-    expect(reportScanRan).toBe(false);
+    expect(parsed.avgEstimatedRpoMinutes).toBeNull();
+    expect(parsed.avgEstimatedRtoMinutes).toBeNull();
+    expect(parsed.scopeNote).toBeTruthy();
+    expect(deviceLinkedScanRan).toBe(false);
   });
 
   it('unrestricted caller reads the report normally (no regression)', async () => {
@@ -129,7 +141,7 @@ describe('get_sla_compliance_report — site narrowing', () => {
 describe('query_backup_sla — site narrowing of breach counts', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('site-restricted caller with no in-scope devices sees configs with zero breach signal (no breach scan)', async () => {
+  it('site-restricted caller with no in-scope devices sees configs with indeterminate compliance (no breach scan)', async () => {
     let breachScanRan = false;
     const config = {
       id: 'c1', orgId: 'org-1', name: 'SLA Config', targetDevices: ['d-siteB'], targetGroups: [],
@@ -150,8 +162,10 @@ describe('query_backup_sla — site narrowing of breach counts', () => {
     const parsed = JSON.parse(r);
     expect(parsed.error).toBeUndefined();
     expect(parsed.showing).toBe(1);
-    expect(parsed.configs[0].activeBreaches).toBe(0);
-    expect(parsed.configs[0].complianceStatus).toBe('compliant');
+    // Compliance must be indeterminate — never a fabricated healthy 'compliant'.
+    expect(parsed.configs[0].activeBreaches).toBeNull();
+    expect(parsed.configs[0].complianceStatus).toBe('unknown');
+    expect(parsed.scopeNote).toBeTruthy();
     expect(breachScanRan).toBe(false);
   });
 

--- a/apps/api/src/services/aiToolsSLABackup.ts
+++ b/apps/api/src/services/aiToolsSLABackup.ts
@@ -26,6 +26,7 @@ import {
 } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
+import { resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 
 type SlaHandler = (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
 
@@ -56,6 +57,19 @@ function safeHandler(toolName: string, fn: SlaHandler): SlaHandler {
 
 function clampLimit(value: unknown, fallback = 25, max = 100): number {
   return Math.min(Math.max(1, Number(value) || fallback), max);
+}
+
+/**
+ * Resolve the device-id set a site-restricted caller may read. Returns `null`
+ * for unrestricted callers (no narrowing) and `[]` for a site-restricted caller
+ * with zero in-scope devices (callers short-circuit to empty results). The site
+ * axis is app-layer authz — Postgres RLS does NOT enforce it.
+ */
+async function resolveSiteScopedDeviceIds(auth: AuthContext): Promise<string[] | null> {
+  if (!auth.allowedSiteIds || !auth.canAccessSite) return null;
+  const orgId = getOrgId(auth);
+  if (!orgId) return []; // restricted caller without an org context — fail closed
+  return resolveSiteAllowedDeviceIds(orgId, auth);
 }
 
 // ============================================
@@ -106,6 +120,25 @@ export function registerSLABackupTools(aiTools: Map<string, AiTool>): void {
       const breachConditions: SQL[] = [isNull(backupSlaEvents.resolvedAt), inArray(backupSlaEvents.slaConfigId, configs.map((config) => config.id))];
       const bc = orgWhere(auth, backupSlaEvents.orgId);
       if (bc) breachConditions.push(bc);
+
+      // Site axis (app-layer only; RLS does NOT enforce it): a site-restricted
+      // caller's breach counts must only reflect its in-scope devices.
+      const allowedDeviceIds = await resolveSiteScopedDeviceIds(auth);
+      if (allowedDeviceIds != null) {
+        if (allowedDeviceIds.length === 0) {
+          return JSON.stringify({
+            configs: configs.map((config) => ({
+              ...config,
+              complianceStatus: 'compliant',
+              activeBreaches: 0,
+              targetDeviceCount: Array.isArray(config.targetDevices) ? config.targetDevices.length : 0,
+              targetGroupCount: Array.isArray(config.targetGroups) ? config.targetGroups.length : 0,
+            })),
+            showing: configs.length,
+          });
+        }
+        breachConditions.push(inArray(backupSlaEvents.deviceId, allowedDeviceIds));
+      }
 
       const breachCounts = await db
         .select({
@@ -164,6 +197,21 @@ export function registerSLABackupTools(aiTools: Map<string, AiTool>): void {
       if (typeof input.deviceId === 'string') conditions.push(eq(backupSlaEvents.deviceId, input.deviceId));
       if (typeof input.eventType === 'string') conditions.push(eq(backupSlaEvents.eventType, input.eventType));
       if (input.unresolvedOnly === true) conditions.push(isNull(backupSlaEvents.resolvedAt));
+
+      // Site axis (app-layer only; RLS does NOT enforce it). backupSlaEvents has
+      // no site_id column, so narrow by the in-scope device-id set (this also
+      // scopes the hostname join). A restricted caller with zero in-scope
+      // devices short-circuits to empty results. Intersects with the optional
+      // deviceId filter above (most-restrictive wins). Breach events not tied
+      // to a device (deviceId null) are excluded for a restricted caller
+      // (fail closed).
+      const allowedDeviceIds = await resolveSiteScopedDeviceIds(auth);
+      if (allowedDeviceIds != null) {
+        if (allowedDeviceIds.length === 0) {
+          return JSON.stringify({ breaches: [], showing: 0 });
+        }
+        conditions.push(inArray(backupSlaEvents.deviceId, allowedDeviceIds));
+      }
 
       if (typeof input.from === 'string') {
         const from = new Date(input.from);
@@ -234,6 +282,33 @@ export function registerSLABackupTools(aiTools: Map<string, AiTool>): void {
       const readinessConditions: SQL[] = [];
       const rc = orgWhere(auth, recoveryReadiness.orgId);
       if (rc) readinessConditions.push(rc);
+
+      // Site axis (app-layer only; RLS does NOT enforce it). The report's
+      // device linkage is backupSlaEvents.deviceId / recoveryReadiness.deviceId,
+      // so narrow every device-linked aggregate to the in-scope device-id set.
+      // backupSlaConfigs is org-level config metadata (not device-linked) and
+      // stays org-scoped. A restricted caller with zero in-scope devices
+      // short-circuits before any scan (fail closed; events with deviceId null
+      // are excluded for a restricted caller).
+      const allowedDeviceIds = await resolveSiteScopedDeviceIds(auth);
+      if (allowedDeviceIds != null) {
+        if (allowedDeviceIds.length === 0) {
+          return JSON.stringify({
+            reportWindowDays: daysBack,
+            activeConfigs: 0,
+            compliantConfigs: 0,
+            activeBreaches: 0,
+            configsWithBreaches: 0,
+            compliancePercent: 100,
+            totalEventsInWindow: 0,
+            avgEstimatedRpoMinutes: 0,
+            avgEstimatedRtoMinutes: 0,
+          });
+        }
+        activeEventConditions.push(inArray(backupSlaEvents.deviceId, allowedDeviceIds));
+        historyConditions.push(inArray(backupSlaEvents.deviceId, allowedDeviceIds));
+        readinessConditions.push(inArray(recoveryReadiness.deviceId, allowedDeviceIds));
+      }
 
       const [activeConfigs, activeBreaches, totalEvents, readiness, configsWithBreaches] = await Promise.all([
         db

--- a/apps/api/src/services/aiToolsSLABackup.ts
+++ b/apps/api/src/services/aiToolsSLABackup.ts
@@ -26,7 +26,7 @@ import {
 } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
-import { resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
+import { resolveSiteAllowedDeviceIds, SITE_SCOPE_EMPTY_NOTE } from './aiToolsSiteScope';
 
 type SlaHandler = (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
 
@@ -126,15 +126,18 @@ export function registerSLABackupTools(aiTools: Map<string, AiTool>): void {
       const allowedDeviceIds = await resolveSiteScopedDeviceIds(auth);
       if (allowedDeviceIds != null) {
         if (allowedDeviceIds.length === 0) {
+          // No in-scope devices: the caller cannot observe any breach events, so
+          // compliance is indeterminate — never fabricate a healthy 'compliant'.
           return JSON.stringify({
             configs: configs.map((config) => ({
               ...config,
-              complianceStatus: 'compliant',
-              activeBreaches: 0,
+              complianceStatus: 'unknown',
+              activeBreaches: null,
               targetDeviceCount: Array.isArray(config.targetDevices) ? config.targetDevices.length : 0,
               targetGroupCount: Array.isArray(config.targetGroups) ? config.targetGroups.length : 0,
             })),
             showing: configs.length,
+            scopeNote: SITE_SCOPE_EMPTY_NOTE,
           });
         }
         breachConditions.push(inArray(backupSlaEvents.deviceId, allowedDeviceIds));
@@ -208,7 +211,7 @@ export function registerSLABackupTools(aiTools: Map<string, AiTool>): void {
       const allowedDeviceIds = await resolveSiteScopedDeviceIds(auth);
       if (allowedDeviceIds != null) {
         if (allowedDeviceIds.length === 0) {
-          return JSON.stringify({ breaches: [], showing: 0 });
+          return JSON.stringify({ breaches: [], showing: 0, scopeNote: SITE_SCOPE_EMPTY_NOTE });
         }
         conditions.push(inArray(backupSlaEvents.deviceId, allowedDeviceIds));
       }
@@ -293,16 +296,25 @@ export function registerSLABackupTools(aiTools: Map<string, AiTool>): void {
       const allowedDeviceIds = await resolveSiteScopedDeviceIds(auth);
       if (allowedDeviceIds != null) {
         if (allowedDeviceIds.length === 0) {
+          // No in-scope devices: device-derived metrics are indeterminate — never
+          // fabricate a healthy 100%. Configs are org-level metadata the caller
+          // may legitimately see, so still report the real org-scoped count.
+          const visibleActiveConfigs = await db
+            .select({ count: sql<number>`count(*)::int` })
+            .from(backupSlaConfigs)
+            .where(and(...configConditions))
+            .then((rows) => rows[0]?.count ?? 0);
           return JSON.stringify({
             reportWindowDays: daysBack,
-            activeConfigs: 0,
-            compliantConfigs: 0,
+            activeConfigs: visibleActiveConfigs,
+            compliantConfigs: null,
             activeBreaches: 0,
-            configsWithBreaches: 0,
-            compliancePercent: 100,
+            configsWithBreaches: null,
+            compliancePercent: null,
             totalEventsInWindow: 0,
-            avgEstimatedRpoMinutes: 0,
-            avgEstimatedRtoMinutes: 0,
+            avgEstimatedRpoMinutes: null,
+            avgEstimatedRtoMinutes: null,
+            scopeNote: SITE_SCOPE_EMPTY_NOTE,
           });
         }
         activeEventConditions.push(inArray(backupSlaEvents.deviceId, allowedDeviceIds));

--- a/apps/api/src/services/aiToolsSentinelOne.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsSentinelOne.siteScope.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('./sentinelOne/actions', () => ({
+  executeS1IsolationForOrg: vi.fn(),
+  executeS1ThreatActionForOrg: vi.fn(),
+  getActiveS1IntegrationForOrg: vi.fn(async () => ({ id: 'integ-1' })),
+}));
+vi.mock('../jobs/s1Sync', () => ({ isThreatAction: () => true }));
+
+import { db } from '../db';
+import { registerSentinelOneTools } from './aiToolsSentinelOne';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerSentinelOneTools(reg);
+  return reg.get(name)!.handler;
+}
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
+    accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds, canAccessSite: (s: string | null | undefined) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  } as unknown as AuthContext;
+}
+function isDeviceResolverSelect(cols: unknown): boolean {
+  return (
+    !!cols && typeof cols === 'object' &&
+    'id' in (cols as object) && 'siteId' in (cols as object) &&
+    Object.keys(cols as object).length === 2
+  );
+}
+
+describe('get_s1_threats — site narrowing (cross-site enumeration)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller does NOT receive threats for a device in a forbidden site', async () => {
+    let threatScanRan = false;
+    const forbiddenThreat = { id: 't1', deviceId: 'd-siteB', threatName: 'SECRET-THREAT', deviceName: 'forbidden-host' };
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd-siteB', siteId: 'site-B' }]) }) };
+      }
+      threatScanRan = true;
+      // rows query (leftJoin) and count query share this implementation
+      if (cols && typeof cols === 'object' && 'count' in (cols as object)) {
+        return { from: () => ({ where: () => Promise.resolve([{ count: 1 }]) }) };
+      }
+      return {
+        from: () => ({ leftJoin: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([forbiddenThreat]) }) }) }) }),
+      };
+    });
+
+    const r = await handlerFor('get_s1_threats')({}, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.total).toBe(0);
+    expect(parsed.threats).toEqual([]);
+    expect(threatScanRan).toBe(false);
+    expect(JSON.stringify(parsed)).not.toContain('SECRET-THREAT');
+  });
+
+  it('unrestricted caller reads threats normally (no regression)', async () => {
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (cols && typeof cols === 'object' && 'count' in (cols as object)) {
+        return { from: () => ({ where: () => Promise.resolve([{ count: 1 }]) }) };
+      }
+      return {
+        from: () => ({ leftJoin: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([{ id: 't1', deviceId: 'd1', threatName: 'mal' }]) }) }) }) }),
+      };
+    });
+    const r = await handlerFor('get_s1_threats')({}, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.total).toBe(1);
+    expect(parsed.threats.length).toBe(1);
+  });
+});

--- a/apps/api/src/services/aiToolsSentinelOne.ts
+++ b/apps/api/src/services/aiToolsSentinelOne.ts
@@ -21,7 +21,7 @@ import { hasSatisfiedMfa, type AuthContext } from '../middleware/auth';
 import { escapeLike } from '../utils/sql';
 import type { AiTool } from './aiTools';
 import { verifyDeviceAccess, resolveWritableToolOrgId } from './aiTools';
-import { resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
+import { resolveSiteAllowedDeviceIds, SITE_SCOPE_EMPTY_NOTE } from './aiToolsSiteScope';
 import {
   executeS1IsolationForOrg,
   executeS1ThreatActionForOrg,
@@ -216,7 +216,8 @@ export function registerSentinelOneTools(aiTools: Map<string, AiTool>): void {
             configured: true,
             integrationId: integration.id,
             total: 0,
-            threats: []
+            threats: [],
+            scopeNote: SITE_SCOPE_EMPTY_NOTE
           });
         }
         conditions.push(inArray(s1Threats.deviceId, allowed));

--- a/apps/api/src/services/aiToolsSentinelOne.ts
+++ b/apps/api/src/services/aiToolsSentinelOne.ts
@@ -16,11 +16,12 @@ import {
   s1Threats,
   s1Actions,
 } from '../db/schema';
-import { eq, and, desc, sql, SQL } from 'drizzle-orm';
+import { eq, and, desc, sql, inArray, SQL } from 'drizzle-orm';
 import { hasSatisfiedMfa, type AuthContext } from '../middleware/auth';
 import { escapeLike } from '../utils/sql';
 import type { AiTool } from './aiTools';
 import { verifyDeviceAccess, resolveWritableToolOrgId } from './aiTools';
+import { resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 import {
   executeS1IsolationForOrg,
   executeS1ThreatActionForOrg,
@@ -202,6 +203,23 @@ export function registerSentinelOneTools(aiTools: Map<string, AiTool>): void {
             or ${s1Threats.filePath} ilike ${pattern}
           )`
         );
+      }
+
+      // Site axis (app-layer only; RLS does NOT enforce it). s1Threats has no
+      // per-row site_id (it left-joins devices), so narrow by the in-scope
+      // device-id set. A restricted caller with zero in-scope devices gets empty
+      // results. Intersects with the optional deviceId filter above.
+      if (auth.allowedSiteIds && auth.canAccessSite) {
+        const allowed = await resolveSiteAllowedDeviceIds(orgId, auth);
+        if (!allowed || allowed.length === 0) {
+          return JSON.stringify({
+            configured: true,
+            integrationId: integration.id,
+            total: 0,
+            threats: []
+          });
+        }
+        conditions.push(inArray(s1Threats.deviceId, allowed));
       }
 
       const limit = Math.min(Math.max(1, Number(input.limit) || 100), 500);

--- a/apps/api/src/services/aiToolsSiteScope.ts
+++ b/apps/api/src/services/aiToolsSiteScope.ts
@@ -25,6 +25,15 @@ import { eq } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 
 /**
+ * Annotation for tool results that are empty/indeterminate solely because a
+ * site-restricted caller has zero in-scope devices (or sites). Lets the model
+ * distinguish "no data exists" from "data exists but is outside your site
+ * access" instead of silently reporting an empty (or worse, healthy) result.
+ */
+export const SITE_SCOPE_EMPTY_NOTE =
+  'No devices are within your site access — this result is limited by site-based access restrictions, not necessarily an absence of data.';
+
+/**
  * Resolve the device IDs a site-restricted caller may read within `orgId`,
  * narrowed by their site allowlist. Returns `null` when the caller is NOT
  * site-restricted (no narrowing needed — callers should skip the inArray).

--- a/apps/api/src/services/logSearch.ts
+++ b/apps/api/src/services/logSearch.ts
@@ -42,6 +42,13 @@ export interface LogSearchInput {
   source?: string;
   deviceIds?: string[];
   siteIds?: string[];
+  /**
+   * Site-axis app-layer authz narrowing: when non-null, results are constrained
+   * to this device-id set (intersected with any caller-supplied deviceIds). An
+   * empty array means the caller has zero in-scope devices. `null`/undefined =
+   * unrestricted caller, no narrowing. RLS does NOT enforce the site axis.
+   */
+  allowedDeviceIds?: string[] | null;
   limit?: number;
   offset?: number;
   cursor?: string;
@@ -60,6 +67,8 @@ export interface LogAggregationInput {
   source?: string;
   deviceIds?: string[];
   siteIds?: string[];
+  /** Site-axis app-layer authz narrowing (see LogSearchInput.allowedDeviceIds). */
+  allowedDeviceIds?: string[] | null;
   limit?: number;
 }
 
@@ -70,6 +79,8 @@ export interface LogTrendsInput {
   source?: string;
   deviceIds?: string[];
   siteIds?: string[];
+  /** Site-axis app-layer authz narrowing (see LogSearchInput.allowedDeviceIds). */
+  allowedDeviceIds?: string[] | null;
   limit?: number;
 }
 
@@ -81,6 +92,13 @@ export interface PatternDetectionInput {
   minDevices?: number;
   minOccurrences?: number;
   sampleLimit?: number;
+  /**
+   * Site-axis app-layer authz narrowing: when non-null, the correlation scan is
+   * constrained to this device-id set. An empty array means the caller has zero
+   * in-scope devices (no correlation possible). `null`/undefined = unrestricted.
+   * RLS does NOT enforce the site axis.
+   */
+  allowedDeviceIds?: string[] | null;
 }
 
 export interface PatternDetectionResult {
@@ -224,6 +242,17 @@ function buildSearchConditions(
 
   if (filters.siteIds && filters.siteIds.length > 0) {
     conditions.push(inArray(devices.siteId, filters.siteIds));
+  }
+
+  // Site-axis app-layer authz narrowing (most-restrictive wins; intersects with
+  // any caller-supplied deviceIds above). A restricted caller with zero in-scope
+  // devices yields an impossible condition so the query returns no rows.
+  if (filters.allowedDeviceIds != null) {
+    conditions.push(
+      filters.allowedDeviceIds.length > 0
+        ? inArray(deviceEventLogs.deviceId, filters.allowedDeviceIds)
+        : sql`false`,
+    );
   }
 
   return conditions;
@@ -467,6 +496,15 @@ export async function getLogAggregation(auth: AuthContext, input: LogAggregation
   if (input.siteIds && input.siteIds.length > 0) {
     conditions.push(inArray(devices.siteId, input.siteIds));
   }
+  // Site-axis app-layer authz narrowing (most-restrictive wins). RLS does NOT
+  // enforce the site axis. Empty set ⇒ no rows.
+  if (input.allowedDeviceIds != null) {
+    conditions.push(
+      input.allowedDeviceIds.length > 0
+        ? inArray(deviceEventLogs.deviceId, input.allowedDeviceIds)
+        : sql`false`,
+    );
+  }
 
   const bucketExpr = bucket === 'day'
     ? sql`date_trunc('day', ${deviceEventLogs.timestamp})`
@@ -566,6 +604,16 @@ export async function getLogTrends(auth: AuthContext, input: LogTrendsInput) {
 
   if (input.siteIds && input.siteIds.length > 0) {
     conditions.push(inArray(devices.siteId, input.siteIds));
+  }
+
+  // Site-axis app-layer authz narrowing (most-restrictive wins). RLS does NOT
+  // enforce the site axis. Empty set ⇒ no rows.
+  if (input.allowedDeviceIds != null) {
+    conditions.push(
+      input.allowedDeviceIds.length > 0
+        ? inArray(deviceEventLogs.deviceId, input.allowedDeviceIds)
+        : sql`false`,
+    );
   }
 
   const whereCondition = and(...conditions);
@@ -744,6 +792,7 @@ async function runPatternDetection(
   since: Date,
   sampleLimit: number,
   forceLike = false,
+  allowedDeviceIds?: string[] | null,
 ): Promise<{
   summary: { firstSeen: Date | null; lastSeen: Date | null; occurrences: number };
   affectedDevices: LogCorrelationAffectedDevice[];
@@ -754,10 +803,20 @@ async function runPatternDetection(
     ? ilike(deviceEventLogs.message, `%${escapeLike(pattern)}%`)
     : detected.condition;
 
+  // Site-axis app-layer authz narrowing (RLS does NOT enforce the site axis).
+  // A restricted caller with zero in-scope devices ⇒ impossible condition.
+  const siteScopeCondition =
+    allowedDeviceIds == null
+      ? undefined
+      : allowedDeviceIds.length > 0
+        ? inArray(deviceEventLogs.deviceId, allowedDeviceIds)
+        : sql`false`;
+
   const whereCondition = and(
     eq(deviceEventLogs.orgId, orgId),
     gte(deviceEventLogs.timestamp, since),
     condition,
+    ...(siteScopeCondition ? [siteScopeCondition] : []),
   );
 
   const [summaryRows, affectedDeviceRows, sampleRows] = await Promise.all([
@@ -827,16 +886,24 @@ export async function detectPatternCorrelation(input: PatternDetectionInput): Pr
   const sampleLimit = Math.min(Math.max(1, Number(input.sampleLimit) || 20), 100);
   const since = new Date(Date.now() - (timeWindowSeconds * 1000));
 
+  const allowedDeviceIds = input.allowedDeviceIds;
+
+  // Short-circuit: a site-restricted caller with zero in-scope devices can have
+  // no correlation. Avoid scanning event logs entirely.
+  if (allowedDeviceIds != null && allowedDeviceIds.length === 0) {
+    return null;
+  }
+
   let detected;
   try {
-    detected = await runPatternDetection(input.orgId, pattern, isRegex, since, sampleLimit);
+    detected = await runPatternDetection(input.orgId, pattern, isRegex, since, sampleLimit, false, allowedDeviceIds);
   } catch (error) {
     // PostgreSQL regex engine errors should gracefully fall back to plain ILIKE.
     if (!isRegex || !(error instanceof Error) || !error.message.toLowerCase().includes('regular expression')) {
       throw error;
     }
     console.warn('[logSearch] Regex pattern detection failed, falling back to ILIKE:', error.message);
-    detected = await runPatternDetection(input.orgId, pattern, false, since, sampleLimit, true);
+    detected = await runPatternDetection(input.orgId, pattern, false, since, sampleLimit, true, allowedDeviceIds);
   }
 
   if (detected.summary.occurrences === 0) {


### PR DESCRIPTION
## Security fix — MEDIUM-HIGH (intra-org site-scope authz)

**Finding:** Site scope is an app-layer authz axis that **Postgres RLS does not defend** (documented in `aiToolsSiteScope.ts`). It is enforced across ~12 AI-tool domains via `resolveSiteAllowedDeviceIds`, but several enumeration tools were never migrated — they filtered by **org only** and ignored `auth.allowedSiteIds`. The per-device gate (`enforceDeviceArgs`) only fires when the caller *supplies* a device id, so a **site-restricted org user** could omit `deviceIds`/`siteIds` in AI chat and receive org-wide rows (hostnames, siteIds, full log message bodies, USB events, capacity predictions, SentinelOne threats) for sites they cannot access.

**Repro:** a helpdesk user confined to Site A opens AI chat → "search all error logs in the last 24h" → receives Site B/C log contents.

## Tools fixed
| Tool | File |
|---|---|
| `search_logs`, `get_log_trends`, `detect_log_correlations` | `aiToolsEventLogs.ts` |
| `get_peripheral_activity` | `aiToolsPeripherals.ts` |
| `query_analytics` / `capacity_predictions` | `aiToolsAnalytics.ts` |
| `get_s1_threats` (list path) | `aiToolsSentinelOne.ts` |

## Approach
- Each handler resolves the caller's allowed device-id set via `resolveSiteAllowedDeviceIds`, short-circuits to empty results when the set is empty, and **intersects** with caller-supplied filters (most-restrictive wins).
- Unrestricted callers (`allowedSiteIds` unset) are unaffected; the existing `enforceDeviceArgs` gate still runs for supplied device ids — no double-block, no widening.
- `logSearch.ts` builders stay **pure**: the allowed set is threaded in as a parameter (mirroring `siteIds`/`deviceIds`), with a `sql\`false\`` guard as defense-in-depth. `detect_log_correlations` gains a site dimension it previously lacked entirely.

## Tests
New `aiTools{EventLogs,Peripherals,Analytics,SentinelOne}.siteScope.test.ts` — **12 tests**, each proving a site-restricted caller no longer receives forbidden-site data plus a no-regression unrestricted case. Verified RED against unfixed code first; relevant existing suites (logSearch, peripheralControl, analytics, sentinelOne, eventlogs) green.

> Found via a defensive security review of the most-committed areas. Confidence 9/10 (verified against `origin/main`). Follow-up to the cross-ORG hole closed in #1048; this closes the site axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
**Update 2026-06-10 (`cd7df377` + `f5465233`):** review found the same leak class in 5 more domains; coverage extended so the "closes the site axis" claim holds: `aiToolsCompliance` (incl. the org-wide remediation fallback), `aiToolsMonitoring` (`query_monitors` scoped via the asset's `siteId`, mirroring `hasMonitorSiteAccess`), `aiToolsDns`, `aiToolsHuntress`, `aiToolsSLABackup`. A silent-failure pass then hardened the short-circuits: no fabricated `compliant`/100% for site-restricted callers (now `unknown`/null + shared `scopeNote`), org-level config counts no longer zeroed, and `known_services` rethrows unknown DB errors instead of swallowing them into empty lists (missing-table tolerance kept). Contract-test allowlist lists all 9 site-gated files; +110 tests across the two commits.
