### PR TITLE
fix(devices): enforce target-site access on PATCH /devices/:id (MEDIUM)

### DIFF
--- a/apps/api/src/routes/devices/core.permissions.test.ts
+++ b/apps/api/src/routes/devices/core.permissions.test.ts
@@ -20,6 +20,7 @@ vi.mock('../../db', () => ({
     insert: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),
+    transaction: vi.fn(),
   },
 }));
 
@@ -108,7 +109,7 @@ vi.mock('../agents/enrollment', () => ({
   getGlobalEnrollmentSecret: vi.fn().mockReturnValue(null),
 }));
 
-import { coreRoutes } from './core';
+import { coreRoutes, DEVICE_SITE_DENORMALIZED_TABLES } from './core';
 import { hardwareRoutes } from './hardware';
 import { softwareRoutes } from './software';
 import { metricsRoutes } from './metrics';
@@ -151,6 +152,55 @@ function rigDeviceThenSiteLookup(device: unknown, targetSite: unknown) {
     .mockReturnValueOnce({ from: deviceFrom } as never)
     .mockReturnValueOnce({ from: siteFrom } as never);
   vi.mocked(db.update).mockReturnValue({ set: updateSet } as never);
+}
+
+function rigPlainUpdate(updatedRow: unknown) {
+  // Non-site-changing PATCHes run a plain db.update (no transaction).
+  const returning = vi.fn().mockResolvedValue([updatedRow]);
+  const where = vi.fn().mockReturnValue({ returning });
+  const set = vi.fn().mockReturnValue({ where });
+  vi.mocked(db.update).mockReturnValue({ set } as never);
+  return { set };
+}
+
+function rigPatchTransaction(updatedRow: unknown) {
+  // A siteId-changing PATCH runs the devices UPDATE plus the
+  // DEVICE_SITE_DENORMALIZED_TABLES propagation loop inside db.transaction.
+  // Each tx.execute() call is `UPDATE ${sql.identifier(table)} SET site_id =
+  // ${siteId}::uuid WHERE device_id = ...` — Drizzle exposes the identifier
+  // as queryChunks[1].value and the bound siteId Param as queryChunks[3].value
+  // (same extraction as moveOrg.test.ts).
+  const txExecuted: Array<{ table: unknown; siteId: unknown }> = [];
+  const txUpdateSets: Array<Record<string, unknown>> = [];
+
+  vi.mocked(db.transaction).mockImplementation(async (cb: any) => {
+    const tx = {
+      update: vi.fn().mockReturnValue({
+        set: vi.fn().mockImplementation((vals: Record<string, unknown>) => {
+          txUpdateSets.push(vals);
+          return {
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([updatedRow]),
+            }),
+          };
+        }),
+      }),
+      execute: vi.fn().mockImplementation(async (sqlVal: any) => {
+        const chunks = sqlVal?.queryChunks ?? [];
+        // chunks[3] is the bound siteId — pushed raw by the sql template
+        // (only wrapped into a Param at query-build time), so unwrap both shapes.
+        const rawSite = chunks[3];
+        const boundSiteId =
+          rawSite !== null && typeof rawSite === 'object' && 'value' in rawSite
+            ? (rawSite as { value: unknown }).value
+            : rawSite;
+        txExecuted.push({ table: chunks[1]?.value, siteId: boundSiteId });
+        return [];
+      }),
+    };
+    await cb(tx);
+  });
+  return { txExecuted, txUpdateSets };
 }
 
 function rigDeviceListRows(rows: unknown[]) {
@@ -619,12 +669,14 @@ describe('Device routes — permission / site / MFA gates (security-launch-fixes
       expect(res.status).toBe(403);
       const body = await res.json();
       expect(body.error).toMatch(/site denied/i);
-      // The 403 must fire BEFORE the UPDATE runs.
+      // The 403 must fire BEFORE any write runs (plain or transactional).
       expect(db.update).not.toHaveBeenCalled();
+      expect(db.transaction).not.toHaveBeenCalled();
     });
 
     it('allows an UNRESTRICTED caller to set the siteId (no regression)', async () => {
       rigDeviceThenSiteLookup(deviceInSiteAllowed, targetSiteRow);
+      rigPatchTransaction({ ...deviceInSiteAllowed, siteId: siteB });
       const res = await app.request(`/devices/${ACCESSIBLE_DEVICE.id}`, {
         method: 'PATCH',
         headers: {
@@ -635,7 +687,8 @@ describe('Device routes — permission / site / MFA gates (security-launch-fixes
         body: JSON.stringify({ siteId: siteB }),
       });
       expect(res.status).toBe(200);
-      expect(db.update).toHaveBeenCalled();
+      // Site changes run inside db.transaction (device flip + site_id propagation).
+      expect(db.transaction).toHaveBeenCalled();
     });
 
     it('allows a site-restricted caller to move WITHIN their allowlist (siteA → siteA2 both allowed)', async () => {
@@ -655,13 +708,7 @@ describe('Device routes — permission / site / MFA gates (security-launch-fixes
             where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([siteA2Row]) }),
           }),
         } as never);
-      vi.mocked(db.update).mockReturnValue({
-        set: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            returning: vi.fn().mockResolvedValue([{ ...deviceInSiteAllowed, siteId: siteA2 }]),
-          }),
-        }),
-      } as never);
+      rigPatchTransaction({ ...deviceInSiteAllowed, siteId: siteA2 });
 
       const res = await app.request(`/devices/${ACCESSIBLE_DEVICE.id}`, {
         method: 'PATCH',
@@ -673,7 +720,76 @@ describe('Device routes — permission / site / MFA gates (security-launch-fixes
         body: JSON.stringify({ siteId: siteA2 }),
       });
       expect(res.status).toBe(200);
+      expect(db.transaction).toHaveBeenCalled();
+    });
+  });
+
+  describe('PATCH /devices/:id — denormalized site_id propagation', () => {
+    // elevation_requests (and any future DEVICE_SITE_DENORMALIZED_TABLES
+    // entry) denormalizes site_id off the parent device. A PATCH that moves
+    // the device to another site MUST rewrite those rows in the same
+    // transaction — otherwise they strand under the OLD site_id and drift
+    // out of site-visibility scoping (the same hazard moveOrg.ts guards).
+    const siteAllowed = '77777777-7777-4777-8777-777777777777';
+    const siteB = '88888888-8888-4888-8888-888888888888';
+    const deviceInSiteAllowed = { ...ACCESSIBLE_DEVICE, siteId: siteAllowed };
+    const targetSiteRow = { id: siteB, orgId: 'org-123' };
+
+    it('rewrites site_id on every DEVICE_SITE_DENORMALIZED_TABLES table when the PATCH changes siteId', async () => {
+      rigDeviceThenSiteLookup(deviceInSiteAllowed, targetSiteRow);
+      const { txExecuted, txUpdateSets } = rigPatchTransaction({ ...deviceInSiteAllowed, siteId: siteB });
+
+      const res = await app.request(`/devices/${ACCESSIBLE_DEVICE.id}`, {
+        method: 'PATCH',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ siteId: siteB }),
+      });
+
+      expect(res.status).toBe(200);
+      // Sanity: the list this test guards is non-empty (elevation_requests).
+      expect(DEVICE_SITE_DENORMALIZED_TABLES.length).toBeGreaterThan(0);
+      // The devices row flip carries the new siteId…
+      expect(txUpdateSets[0]).toMatchObject({ siteId: siteB });
+      // …and every denormalized table got an UPDATE with the NEW siteId
+      // inside the same transaction.
+      expect(txExecuted.map((e) => e.table)).toEqual([...DEVICE_SITE_DENORMALIZED_TABLES]);
+      for (const e of txExecuted) {
+        expect(e.siteId).toBe(siteB);
+      }
+      // The plain (non-transactional) update path must NOT have been used.
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('does NOT propagate when the PATCH siteId equals the current site', async () => {
+      rigDeviceLookup(deviceInSiteAllowed);
+      rigPlainUpdate(deviceInSiteAllowed);
+
+      const res = await app.request(`/devices/${ACCESSIBLE_DEVICE.id}`, {
+        method: 'PATCH',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ siteId: siteAllowed }),
+      });
+
+      expect(res.status).toBe(200);
       expect(db.update).toHaveBeenCalled();
+      expect(db.transaction).not.toHaveBeenCalled();
+      expect(db.execute).not.toHaveBeenCalled();
+    });
+
+    it('does NOT propagate on a PATCH that does not touch siteId', async () => {
+      rigDeviceLookup(deviceInSiteAllowed);
+      rigPlainUpdate({ ...deviceInSiteAllowed, displayName: 'renamed' });
+
+      const res = await app.request(`/devices/${ACCESSIBLE_DEVICE.id}`, {
+        method: 'PATCH',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ displayName: 'renamed' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(db.update).toHaveBeenCalled();
+      expect(db.transaction).not.toHaveBeenCalled();
+      expect(db.execute).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/routes/devices/core.permissions.test.ts
+++ b/apps/api/src/routes/devices/core.permissions.test.ts
@@ -48,8 +48,11 @@ vi.mock('../../middleware/auth', () => ({
       return c.json({ error: 'Permission denied' }, 403);
     }
     // Mark permissions so getDeviceWithOrgAndSiteCheck can read them; if the
-    // request opts into site restrictions, narrow to a specific siteId.
-    const allowedSiteIds = c.req.header('x-restrict-site')
+    // request opts into site restrictions, narrow to a specific siteId. A
+    // comma-separated `x-restrict-site-list` allows multi-site allowlists.
+    const allowedSiteIds = c.req.header('x-restrict-site-list')
+      ? (c.req.header('x-restrict-site-list') as string).split(',')
+      : c.req.header('x-restrict-site')
       ? [c.req.header('x-restrict-site') as string]
       : undefined;
     c.set('permissions', {
@@ -125,6 +128,29 @@ function rigDeviceLookup(device: unknown) {
   const where = vi.fn().mockReturnValue({ limit });
   const from = vi.fn().mockReturnValue({ where });
   vi.mocked(db.select).mockReturnValue({ from } as never);
+}
+
+function rigDeviceThenSiteLookup(device: unknown, targetSite: unknown) {
+  // PATCH /devices/:id issues TWO sequential `db.select()...limit(1)` calls:
+  //   1. getDeviceWithOrgAndSiteCheck → fixture device
+  //   2. target-site same-org validation → target site row
+  // Return the device on the first call, the site on the second.
+  const deviceLimit = vi.fn().mockResolvedValue(device ? [device] : []);
+  const deviceWhere = vi.fn().mockReturnValue({ limit: deviceLimit });
+  const deviceFrom = vi.fn().mockReturnValue({ where: deviceWhere });
+
+  const siteLimit = vi.fn().mockResolvedValue(targetSite ? [targetSite] : []);
+  const siteWhere = vi.fn().mockReturnValue({ limit: siteLimit });
+  const siteFrom = vi.fn().mockReturnValue({ where: siteWhere });
+
+  const updateReturning = vi.fn().mockResolvedValue([{ ...(device as object), siteId: undefined }]);
+  const updateWhere = vi.fn().mockReturnValue({ returning: updateReturning });
+  const updateSet = vi.fn().mockReturnValue({ where: updateWhere });
+
+  vi.mocked(db.select)
+    .mockReturnValueOnce({ from: deviceFrom } as never)
+    .mockReturnValueOnce({ from: siteFrom } as never);
+  vi.mocked(db.update).mockReturnValue({ set: updateSet } as never);
 }
 
 function rigDeviceListRows(rows: unknown[]) {
@@ -563,6 +589,91 @@ describe('Device routes — permission / site / MFA gates (security-launch-fixes
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.data.map((device: { siteId: string }) => device.siteId)).toEqual([allowedListSiteId, deniedListSiteId]);
+    });
+  });
+
+  describe('PATCH /devices/:id — TARGET site-scope enforcement on move', () => {
+    // SR: a site-restricted caller could move a device they legitimately own
+    // (source site in their allowlist) into a TARGET site outside their
+    // allowlist. The source is gated by getDeviceWithOrgAndSiteCheck; the
+    // target must also be gated via canAccessSite, mirroring provision.ts.
+    // updateDeviceSchema validates siteId as a UUID, so use real UUIDs. The
+    // device's current site is also a UUID; the caller's allowlist contains it.
+    const siteAllowed = '77777777-7777-4777-8777-777777777777';
+    const siteB = '88888888-8888-4888-8888-888888888888'; // outside allowlist
+    const deviceInSiteAllowed = { ...ACCESSIBLE_DEVICE, siteId: siteAllowed };
+    const targetSiteRow = { id: siteB, orgId: 'org-123' };
+
+    it('returns 403 when a site-restricted caller moves a device to a TARGET site outside their allowlist', async () => {
+      rigDeviceThenSiteLookup(deviceInSiteAllowed, targetSiteRow);
+      const res = await app.request(`/devices/${ACCESSIBLE_DEVICE.id}`, {
+        method: 'PATCH',
+        headers: {
+          Authorization: 'Bearer t',
+          'Content-Type': 'application/json',
+          // Caller is restricted to site-1 (the device's current site) only.
+          'x-restrict-site': siteAllowed,
+        },
+        body: JSON.stringify({ siteId: siteB }),
+      });
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toMatch(/site denied/i);
+      // The 403 must fire BEFORE the UPDATE runs.
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('allows an UNRESTRICTED caller to set the siteId (no regression)', async () => {
+      rigDeviceThenSiteLookup(deviceInSiteAllowed, targetSiteRow);
+      const res = await app.request(`/devices/${ACCESSIBLE_DEVICE.id}`, {
+        method: 'PATCH',
+        headers: {
+          Authorization: 'Bearer t',
+          'Content-Type': 'application/json',
+          // No x-restrict-site → allowedSiteIds undefined → unrestricted.
+        },
+        body: JSON.stringify({ siteId: siteB }),
+      });
+      expect(res.status).toBe(200);
+      expect(db.update).toHaveBeenCalled();
+    });
+
+    it('allows a site-restricted caller to move WITHIN their allowlist (siteA → siteA2 both allowed)', async () => {
+      const siteA2 = '99999999-9999-4999-8999-999999999999';
+      const siteA2Row = { id: siteA2, orgId: 'org-123' };
+      // Caller's allowlist includes both the device's current site (siteAllowed)
+      // and the destination (siteA2). The mock middleware narrows to a single
+      // site per `x-restrict-site`, so widen it here for this case.
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([deviceInSiteAllowed]) }),
+          }),
+        } as never)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([siteA2Row]) }),
+          }),
+        } as never);
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ ...deviceInSiteAllowed, siteId: siteA2 }]),
+          }),
+        }),
+      } as never);
+
+      const res = await app.request(`/devices/${ACCESSIBLE_DEVICE.id}`, {
+        method: 'PATCH',
+        headers: {
+          Authorization: 'Bearer t',
+          'Content-Type': 'application/json',
+          'x-restrict-site-list': `${siteAllowed},${siteA2}`,
+        },
+        body: JSON.stringify({ siteId: siteA2 }),
+      });
+      expect(res.status).toBe(200);
+      expect(db.update).toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -16,7 +16,7 @@ import {
   partners,
 } from '../../db/schema';
 import { authMiddleware, requireMfa, requireScope, requirePermission } from '../../middleware/auth';
-import { PERMISSIONS, type UserPermissions } from '../../services/permissions';
+import { PERMISSIONS, canAccessSite, type UserPermissions } from '../../services/permissions';
 import {
   getPagination,
   getDeviceWithOrgAndSiteCheck,
@@ -970,7 +970,11 @@ coreRoutes.patch(
       return c.json({ error: 'Device not found' }, 404);
     }
 
-    // If moving to a different site, verify it's in the same org
+    // If moving to a different site, verify it's in the same org AND that a
+    // site-restricted caller is allowed to place a device into the TARGET site.
+    // The source device is already site-gated by getDeviceWithOrgAndSiteCheck
+    // above; without this the caller could move a device into a site outside
+    // their `allowedSiteIds` allowlist. Mirrors the gate in provision.ts.
     if (data.siteId && data.siteId !== device.siteId) {
       const [targetSite] = await db
         .select()
@@ -985,6 +989,11 @@ coreRoutes.patch(
 
       if (!targetSite) {
         return c.json({ error: 'Target site not found or belongs to a different organization' }, 400);
+      }
+
+      const perms = c.get('permissions') as UserPermissions | undefined;
+      if (perms?.allowedSiteIds && !canAccessSite(perms, data.siteId)) {
+        return c.json({ error: 'Access to this site denied' }, 403);
       }
     }
 

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -112,8 +112,11 @@ export const DEVICE_ORG_DENORMALIZED_TABLES = [
 
 /**
  * Tables that are both device-id scoped AND denormalize site_id for query-perf.
- * Cross-org-cross-site moves via POST /devices/:id/move-org must rewrite each
- * row's site_id alongside org_id, or those rows strand under the OLD site_id.
+ * EVERY write path that changes devices.site_id must rewrite each row's
+ * site_id in the same transaction, or those rows strand under the OLD
+ * site_id. Today that is two paths:
+ *   - POST /devices/:id/move-org (moveOrg.ts — cross-org-cross-site move)
+ *   - PATCH /devices/:id        (this file — same-org site change)
  * The moveOrg.coverage.test.ts drift-detector enforces that any future
  * schema PR adding site_id to a device-id-scoped table populates this list.
  */
@@ -1015,11 +1018,39 @@ coreRoutes.patch(
       updates.customFields = { ...existing, ...data.customFields };
     }
 
-    const [updated] = await db
-      .update(devices)
-      .set(updates)
-      .where(eq(devices.id, deviceId))
-      .returning();
+    // When the PATCH changes the device's site, the denormalized `site_id`
+    // on every table in DEVICE_SITE_DENORMALIZED_TABLES must be rewritten in
+    // the SAME transaction as the devices row flip — otherwise child rows
+    // (e.g. elevation_requests) stay pinned under the OLD site_id and drift
+    // out of site-visibility scoping. Mirrors moveOrg.ts. The proxied `db`
+    // resolves to the request-context tx via AsyncLocalStorage, so this
+    // opens a savepoint within the request transaction (established pattern).
+    const siteChanged = data.siteId !== undefined && data.siteId !== device.siteId;
+
+    let updated: typeof devices.$inferSelect | undefined;
+    if (siteChanged) {
+      await db.transaction(async (tx) => {
+        const [row] = await tx
+          .update(devices)
+          .set(updates)
+          .where(eq(devices.id, deviceId))
+          .returning();
+        updated = row;
+
+        for (const table of DEVICE_SITE_DENORMALIZED_TABLES) {
+          await tx.execute(
+            sql`UPDATE ${sql.identifier(table)} SET site_id = ${data.siteId}::uuid WHERE device_id = ${deviceId}::uuid`,
+          );
+        }
+      });
+    } else {
+      const [row] = await db
+        .update(devices)
+        .set(updates)
+        .where(eq(devices.id, deviceId))
+        .returning();
+      updated = row;
+    }
 
     writeRouteAudit(c, {
       orgId: device.orgId,

--- a/apps/api/src/routes/devices/moveOrg.coverage.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.coverage.test.ts
@@ -116,15 +116,21 @@ describe('DEVICE_ORG_DENORMALIZED_TABLES coverage', () => {
 /**
  * Mirror of the org_id coverage block, for `site_id`.
  *
- * `POST /devices/:id/move-org` can also change the device's site (within the
- * target org). Any device-id-scoped table that denormalizes `site_id` must
- * also be rewritten in the move transaction — otherwise child rows stay
- * pinned to the OLD site after the parent device has moved.
+ * Both write paths that change `devices.site_id` — `POST /devices/:id/move-org`
+ * (cross-org move) and `PATCH /devices/:id` (same-org site change) — must
+ * rewrite `site_id` on every table in DEVICE_SITE_DENORMALIZED_TABLES inside
+ * the same transaction, otherwise child rows stay pinned to the OLD site
+ * after the parent device has moved.
  *
- * As of this PR, NO device-id-scoped child table has a `site_id` column,
- * so DEVICE_SITE_DENORMALIZED_TABLES is empty. The drift detector below
- * exists so any future schema PR that adds such a column will fail CI
- * until the table is added to DEVICE_SITE_DENORMALIZED_TABLES in core.ts.
+ * The list currently contains `elevation_requests`. The drift detector below
+ * ensures any future schema PR that adds a `site_id` column to another
+ * device-id-scoped table fails CI until the table is added to
+ * DEVICE_SITE_DENORMALIZED_TABLES in core.ts.
+ *
+ * NOTE this detector only guards the CONSTANT against the schema — it cannot
+ * verify the route handlers actually consume the constant. Handler-level
+ * propagation is covered by behavior tests: moveOrg.test.ts (move-org path)
+ * and core.permissions.test.ts (PATCH path).
  */
 describe('DEVICE_SITE_DENORMALIZED_TABLES coverage', () => {
   const siteDenormSet = new Set<string>(DEVICE_SITE_DENORMALIZED_TABLES);

--- a/apps/api/src/routes/devices/moveOrg.ts
+++ b/apps/api/src/routes/devices/moveOrg.ts
@@ -148,11 +148,11 @@ moveOrgRoutes.post(
           );
         }
 
-        // Forward-defense: rewrite denormalized site_id on any device-scoped
-        // table that has one. Currently empty (no such table exists today),
-        // but kept in lockstep with the org_id loop so a future schema PR
-        // adding site_id to a device-id-scoped table is handled automatically
-        // once it lands in DEVICE_SITE_DENORMALIZED_TABLES.
+        // Rewrite denormalized site_id on every device-scoped table that has
+        // one (currently elevation_requests — see DEVICE_SITE_DENORMALIZED_TABLES
+        // in core.ts). Skipping any of these strands rows under the OLD
+        // site_id. PATCH /devices/:id (core.ts) performs the same propagation
+        // for same-org site changes; keep both loops in lockstep.
         for (const table of DEVICE_SITE_DENORMALIZED_TABLES) {
           await tx.execute(
             sql`UPDATE ${sql.identifier(table)} SET site_id = ${targetSiteId}::uuid WHERE device_id = ${deviceId}::uuid`,


### PR DESCRIPTION
## Security fix — MEDIUM (authz consistency)

**Finding:** `PATCH /devices/:id` let a **site-restricted organization user** move a device into a site **outside their `allowedSiteIds` allowlist**. The handler validated only that the target `siteId` belonged to the same org as the device — it never checked `canAccessSite` on the *target* site. The source device is already site-gated, so the gap was purely the target. The sibling write paths (`provision.ts:88`, `groups.ts`, `moveOrg.ts`) all perform this target-site gate, making PATCH the inconsistent outlier.

**Blast radius:** moderate / one-directional — the attacker can only push a device they already control *into* a site they can't see (inventory tampering; they then lose visibility of it), not pull a foreign device into their scope. Requires a sibling-site UUID, which `GET /sites` deliberately withholds. Worth fixing for consistency.

## Change
`apps/api/src/routes/devices/core.ts` — inside the existing `if (data.siteId && data.siteId !== device.siteId)` block, after the same-org validation:
```ts
const perms = c.get('permissions') as UserPermissions | undefined;
if (perms?.allowedSiteIds && !canAccessSite(perms, data.siteId)) {
  return c.json({ error: 'Access to this site denied' }, 403);
}
```
Mirrors `provision.ts`. Fires only on a changing `siteId` outside a restricted caller's allowlist; unrestricted callers unaffected.

## Tests
`core.permissions.test.ts`: 403 when a restricted caller moves a device to a target site outside their allowlist (asserts the UPDATE never runs); unrestricted caller can set `siteId` (no regression); restricted caller can move within their allowlist. Verified RED before the fix; sibling core route tests green.

> Found via a defensive security review of the most-committed areas. Confidence 6/10 (real, moderate blast radius; verified against `origin/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
**Update 2026-06-10 (`4c4adc65`):** review caught that `DEVICE_SITE_DENORMALIZED_TABLES` is *not* empty (it carries `elevation_requests` since #875) — a PATCH site move stranded those child rows where `moveOrg` propagates them. Site-changing PATCHes now run the device UPDATE + denorm propagation in one transaction; stale "currently empty" comments corrected; 3 propagation tests added.
