### PR TITLE
fix(automations): enforce site scope on automation create/update/trigger (MED-HIGH)

### DIFF
--- a/apps/api/src/routes/automations.test.ts
+++ b/apps/api/src/routes/automations.test.ts
@@ -33,6 +33,11 @@ vi.mock('../services/automationRuntime', () => ({
   normalizeAutomationTrigger: vi.fn((trigger) => trigger),
   normalizeNotificationTargets: vi.fn((targets) => targets ?? {}),
   withWebhookDefaults: vi.fn((trigger) => trigger),
+  checkAutomationTargetsWithinSiteScope: vi.fn(async () => ({
+    ok: true,
+    outOfScopeDeviceIds: [],
+    unbounded: false,
+  })),
 }));
 
 vi.mock('../db', () => ({
@@ -81,6 +86,8 @@ vi.mock('../services/auditEvents', () => ({
   writeAuditEvent: vi.fn(),
 }));
 
+const mockState: { permissions: any } = { permissions: undefined };
+
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => {
     c.set('auth', {
@@ -92,6 +99,7 @@ vi.mock('../middleware/auth', () => ({
       accessibleOrgIds: ['org-123'],
       canAccessOrg: (orgId: string) => orgId === 'org-123'
     });
+    c.set('permissions', mockState.permissions);
     return next();
   }),
   requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
@@ -102,12 +110,19 @@ vi.mock('../middleware/auth', () => ({
 import { db } from '../db';
 import { getRedis } from '../services/redis';
 import { writeAuditEvent } from '../services/auditEvents';
+import { checkAutomationTargetsWithinSiteScope, createAutomationRunRecord } from '../services/automationRuntime';
 
 describe('automations routes', () => {
   let app: Hono;
 
 	  beforeEach(() => {
 	    vi.clearAllMocks();
+	    mockState.permissions = undefined;
+	    vi.mocked(checkAutomationTargetsWithinSiteScope).mockResolvedValue({
+	      ok: true,
+	      outOfScopeDeviceIds: [],
+	      unbounded: false,
+	    } as any);
 	    delete process.env.AUTOMATION_WEBHOOK_ALLOW_LEGACY_SECRET;
 	    delete process.env.AUTOMATION_WEBHOOK_ALLOW_LOCAL_REPLAY_FALLBACK;
 	    vi.mocked(getRedis).mockReturnValue(null);
@@ -390,6 +405,163 @@ describe('automations routes', () => {
     });
 
     expect(res.status).toBe(400);
+  });
+
+  // ============================================
+  // Site-scope enforcement (tenant isolation)
+  // ============================================
+
+  it('rejects create from a site-restricted caller when target set is unbounded (all-org)', async () => {
+    mockState.permissions = { allowedSiteIds: ['site-allowed'] };
+    vi.mocked(checkAutomationTargetsWithinSiteScope).mockResolvedValue({
+      ok: false,
+      outOfScopeDeviceIds: [],
+      unbounded: true,
+    } as any);
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: 'auto-x', name: 'x', orgId: 'org-123', trigger: { type: 'manual' } }])
+      })
+    } as any);
+
+    const res = await app.request('/automations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+      body: JSON.stringify({
+        name: 'All-org reboot',
+        trigger: { type: 'manual' },
+        conditions: { type: 'all' },
+        actions: [{ type: 'run_script', scriptId: 'script-1' }]
+      })
+    });
+
+    expect(res.status).toBe(403);
+    expect(vi.mocked(checkAutomationTargetsWithinSiteScope)).toHaveBeenCalled();
+    // Must not have written the automation.
+    expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+  });
+
+  it('allows create from a site-restricted caller when targets are within an allowed site', async () => {
+    mockState.permissions = { allowedSiteIds: ['site-allowed'] };
+    vi.mocked(checkAutomationTargetsWithinSiteScope).mockResolvedValue({
+      ok: true,
+      outOfScopeDeviceIds: [],
+      unbounded: false,
+    } as any);
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{
+          id: 'auto-ok',
+          name: 'Scoped reboot',
+          orgId: 'org-123',
+          trigger: { type: 'manual' },
+          enabled: true
+        }])
+      })
+    } as any);
+
+    const res = await app.request('/automations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+      body: JSON.stringify({
+        name: 'Scoped reboot',
+        trigger: { type: 'manual', deviceIds: ['device-in-allowed-site'] },
+        conditions: { type: 'devices', deviceIds: ['device-in-allowed-site'] },
+        actions: [{ type: 'run_script', scriptId: 'script-1' }]
+      })
+    });
+
+    expect(res.status).toBe(201);
+    expect(vi.mocked(db.insert)).toHaveBeenCalled();
+  });
+
+  it('rejects trigger from a site-restricted caller when resolved targets escape the allowlist', async () => {
+    mockState.permissions = { allowedSiteIds: ['site-allowed'] };
+    vi.mocked(checkAutomationTargetsWithinSiteScope).mockResolvedValue({
+      ok: false,
+      outOfScopeDeviceIds: ['device-elsewhere'],
+      unbounded: false,
+    } as any);
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{
+            id: 'auto-1',
+            name: 'Automation One',
+            orgId: 'org-123',
+            enabled: true,
+            runCount: 0,
+            trigger: { type: 'manual' }
+          }])
+        })
+      })
+    } as any);
+
+    const res = await app.request('/automations/auto-1/trigger', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer valid-token' }
+    });
+
+    expect(res.status).toBe(403);
+    expect(vi.mocked(createAutomationRunRecord)).not.toHaveBeenCalled();
+  });
+
+  it('allows trigger from a site-restricted caller when all targets are in scope', async () => {
+    mockState.permissions = { allowedSiteIds: ['site-allowed'] };
+    vi.mocked(checkAutomationTargetsWithinSiteScope).mockResolvedValue({
+      ok: true,
+      outOfScopeDeviceIds: [],
+      unbounded: false,
+    } as any);
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{
+            id: 'auto-1',
+            name: 'Automation One',
+            orgId: 'org-123',
+            enabled: true,
+            runCount: 0,
+            trigger: { type: 'manual' }
+          }])
+        })
+      })
+    } as any);
+
+    const res = await app.request('/automations/auto-1/run', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer valid-token' }
+    });
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(createAutomationRunRecord)).toHaveBeenCalled();
+  });
+
+  it('does not gate an unrestricted caller (no allowedSiteIds) on trigger', async () => {
+    mockState.permissions = undefined; // unrestricted org admin / partner / system
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{
+            id: 'auto-1',
+            name: 'Automation One',
+            orgId: 'org-123',
+            enabled: true,
+            runCount: 0,
+            trigger: { type: 'manual' }
+          }])
+        })
+      })
+    } as any);
+
+    const res = await app.request('/automations/auto-1/trigger', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer valid-token' }
+    });
+
+    expect(res.status).toBe(200);
+    // Helper still consulted (it short-circuits internally for unrestricted callers).
+    expect(vi.mocked(createAutomationRunRecord)).toHaveBeenCalled();
   });
 
 	  it('should trigger automation via webhook when signed payload is valid', async () => {

--- a/apps/api/src/routes/automations.test.ts
+++ b/apps/api/src/routes/automations.test.ts
@@ -325,6 +325,68 @@ describe('automations routes', () => {
     expect(body.enabled).toBe(false);
   });
 
+  it('rejects an UPDATE from a site-restricted caller when the new target set escapes their sites', async () => {
+    mockState.permissions = { allowedSiteIds: ['site-allowed'] };
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{
+            id: 'auto-1', name: 'Automation One', orgId: 'org-123',
+            enabled: true, conditions: [], trigger: { type: 'manual' },
+          }]),
+        }),
+      }),
+    } as any);
+    // Post-update target set resolves outside the caller's allowlist.
+    vi.mocked(checkAutomationTargetsWithinSiteScope).mockResolvedValue({
+      ok: false, outOfScopeDeviceIds: ['dev-out-of-site'], unbounded: false,
+    } as any);
+
+    const res = await app.request('/automations/auto-1', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+      body: JSON.stringify({ trigger: { type: 'all' } }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(vi.mocked(checkAutomationTargetsWithinSiteScope)).toHaveBeenCalled();
+    expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+  });
+
+  it('allows an UPDATE from a site-restricted caller when targets stay in scope', async () => {
+    mockState.permissions = { allowedSiteIds: ['site-allowed'] };
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{
+            id: 'auto-1', name: 'Automation One', orgId: 'org-123',
+            enabled: true, conditions: [], trigger: { type: 'manual' },
+          }]),
+        }),
+      }),
+    } as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: 'auto-1', enabled: false, trigger: { type: 'manual' } }]),
+        }),
+      }),
+    } as any);
+    // Default beforeEach mock already returns ok:true, but set it explicitly.
+    vi.mocked(checkAutomationTargetsWithinSiteScope).mockResolvedValue({
+      ok: true, outOfScopeDeviceIds: [], unbounded: false,
+    } as any);
+
+    const res = await app.request('/automations/auto-1', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+      body: JSON.stringify({ enabled: false }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(db.update)).toHaveBeenCalled();
+  });
+
   it('should delete an automation', async () => {
     vi.mocked(db.select)
       .mockReturnValueOnce({

--- a/apps/api/src/routes/automations.ts
+++ b/apps/api/src/routes/automations.ts
@@ -12,11 +12,12 @@ import {
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import { writeAuditEvent, writeRouteAudit } from '../services/auditEvents';
 import { getTrustedClientIp } from '../services/clientIp';
-import { PERMISSIONS } from '../services/permissions';
+import { PERMISSIONS, type UserPermissions } from '../services/permissions';
 import { getRedis } from '../services/redis';
 import { decryptForColumn, encryptSecret } from '../services/secretCrypto';
 import {
   AutomationValidationError,
+  checkAutomationTargetsWithinSiteScope,
   createAutomationRunRecord,
   normalizeAutomationActions,
   normalizeAutomationTrigger,
@@ -203,6 +204,36 @@ function getPagination(query: { page?: string; limit?: string }) {
 
 function ensureOrgAccess(orgId: string, auth: AuthContext) {
   return auth.canAccessOrg(orgId);
+}
+
+/**
+ * Site-scope gate for automations. Site is an app-layer authz axis RLS does not
+ * defend, and the automation runtime resolves targets org-wide (running actions
+ * as `system`). Sibling device-acting routes re-check `canAccessSite` per device;
+ * automations must do the same — both when a site-restricted user creates/updates
+ * an automation (the only gate for unattended schedule/event triggers) and when
+ * one is manually triggered (the resolved set may have drifted).
+ *
+ * Returns a 403 JSON response if the caller is site-restricted and the
+ * automation's target set escapes their allowlist, otherwise null (proceed).
+ * Unrestricted callers always pass.
+ */
+async function enforceAutomationSiteScope(
+  c: Context,
+  automation: Parameters<typeof checkAutomationTargetsWithinSiteScope>[0],
+) {
+  const perms = c.get('permissions') as UserPermissions | undefined;
+  const result = await checkAutomationTargetsWithinSiteScope(automation, perms);
+  if (!result.ok) {
+    if (result.unbounded) {
+      return c.json(
+        { error: 'Site-restricted users cannot create or run automations that target all devices in the organization' },
+        403,
+      );
+    }
+    return c.json({ error: 'Access to one or more target sites denied' }, 403);
+  }
+  return null;
 }
 
 async function getAutomationWithOrgCheck(automationId: string, auth: AuthContext) {
@@ -673,6 +704,18 @@ automationRoutes.post(
         normalizeIncomingNotificationTargets(data),
       );
 
+      // Site-scope gate: a site-restricted creator must not own an automation
+      // whose resolvable target set escapes their allowlist. This is the only
+      // gate for unattended schedule/event triggers (no caller context later).
+      const siteScopeDenied = await enforceAutomationSiteScope(c, {
+        orgId: orgId!,
+        conditions: data.conditions,
+        trigger: storedTrigger,
+      } as Parameters<typeof checkAutomationTargetsWithinSiteScope>[0]);
+      if (siteScopeDenied) {
+        return siteScopeDenied;
+      }
+
       const [automation] = await db
         .insert(automations)
         .values({
@@ -794,6 +837,18 @@ async function handleUpdateAutomation(c: Context) {
       );
     }
 
+    // Site-scope gate: re-validate the post-update target set against the
+    // caller's allowlist. Covers conditions/trigger changes that would widen
+    // the target set beyond a site-restricted editor's sites.
+    const siteScopeDenied = await enforceAutomationSiteScope(c, {
+      ...automation,
+      conditions: data.conditions !== undefined ? data.conditions : automation.conditions,
+      trigger: updates.trigger !== undefined ? updates.trigger : automation.trigger,
+    } as Parameters<typeof checkAutomationTargetsWithinSiteScope>[0]);
+    if (siteScopeDenied) {
+      return siteScopeDenied;
+    }
+
     const [updated] = await db
       .update(automations)
       .set(updates)
@@ -909,6 +964,14 @@ async function triggerAutomationRun(
 
   if (!automation.enabled) {
     return c.json({ error: 'Cannot trigger disabled automation' }, 400);
+  }
+
+  // Site-scope gate: re-validate the *current* resolved target set. Protects
+  // against a target set that drifted (new devices/sites) since creation, and
+  // against an automation created before the user's sites were restricted.
+  const siteScopeDenied = await enforceAutomationSiteScope(c, automation);
+  if (siteScopeDenied) {
+    return siteScopeDenied;
   }
 
   const { run, targetDeviceIds } = await createAutomationRunRecord({

--- a/apps/api/src/services/automationRuntime.siteScope.test.ts
+++ b/apps/api/src/services/automationRuntime.siteScope.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Mock the db so the resolver/site lookup queries are deterministic. The chain
+// supports both `select().from().where()` (resolver + site lookup) shapes used
+// by resolveAutomationTargetDeviceIds and checkAutomationTargetsWithinSiteScope.
+const selectRows: Array<unknown[]> = [];
+let selectCallIndex = 0;
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => Promise.resolve(selectRows[selectCallIndex++] ?? [])),
+      })),
+    })),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  alertRules: {},
+  alerts: {},
+  alertTemplates: {},
+  automations: {},
+  automationRuns: {},
+  configPolicyAutomations: {},
+  deviceGroupMemberships: {},
+  devices: { id: 'id', orgId: 'orgId', siteId: 'siteId', osType: 'osType', tags: 'tags' },
+  notificationChannels: {},
+  scripts: {},
+}));
+
+vi.mock('./deploymentEngine', () => ({
+  resolveDeploymentTargets: vi.fn(async () => ['device-deploy-1']),
+}));
+
+vi.mock('./commandQueue', () => ({
+  CommandTypes: {},
+  queueCommandForExecution: vi.fn(),
+}));
+
+vi.mock('./eventBus', () => ({ publishEvent: vi.fn() }));
+
+vi.mock('./notificationSenders', () => ({
+  getEmailRecipients: vi.fn(),
+  sendEmailNotification: vi.fn(),
+  sendWebhookNotification: vi.fn(),
+}));
+
+// Use the real canAccessSite semantics so the test exercises the actual gate.
+vi.mock('./permissions', () => ({
+  canAccessSite: (perms: { allowedSiteIds?: string[] }, siteId: string) => {
+    if (!perms.allowedSiteIds) return true;
+    return perms.allowedSiteIds.includes(siteId);
+  },
+}));
+
+import { checkAutomationTargetsWithinSiteScope } from './automationRuntime';
+
+function baseAutomation(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'auto-1',
+    orgId: 'org-1',
+    name: 'a',
+    conditions: { type: 'devices', deviceIds: ['device-1'] },
+    trigger: { type: 'manual' },
+    actions: [],
+    createdBy: 'user-1',
+    ...overrides,
+  } as any;
+}
+
+describe('checkAutomationTargetsWithinSiteScope', () => {
+  beforeEach(() => {
+    selectRows.length = 0;
+    selectCallIndex = 0;
+  });
+
+  it('passes immediately for an unrestricted caller (no allowedSiteIds)', async () => {
+    const result = await checkAutomationTargetsWithinSiteScope(baseAutomation(), undefined);
+    expect(result.ok).toBe(true);
+    expect(result.unbounded).toBe(false);
+  });
+
+  it('passes for unrestricted caller even with an all-org automation', async () => {
+    const result = await checkAutomationTargetsWithinSiteScope(
+      baseAutomation({ conditions: { type: 'all' } }),
+      { allowedSiteIds: undefined },
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects an empty-conditions/all-org automation for a site-restricted caller', async () => {
+    const result = await checkAutomationTargetsWithinSiteScope(
+      baseAutomation({ conditions: undefined, trigger: { type: 'manual' } }),
+      { allowedSiteIds: ['site-allowed'] },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.unbounded).toBe(true);
+  });
+
+  it('rejects a deployment config of type "all" for a site-restricted caller', async () => {
+    const result = await checkAutomationTargetsWithinSiteScope(
+      baseAutomation({ conditions: { type: 'all' } }),
+      { allowedSiteIds: ['site-allowed'] },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.unbounded).toBe(true);
+  });
+
+  it('rejects a legacy condition-array automation for a site-restricted caller', async () => {
+    const result = await checkAutomationTargetsWithinSiteScope(
+      baseAutomation({ conditions: [{ type: 'os', operator: 'is', value: 'windows' }] }),
+      { allowedSiteIds: ['site-allowed'] },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.unbounded).toBe(true);
+  });
+
+  it('rejects when a resolved explicit-target device is outside the allowlist', async () => {
+    // Bounded set via explicit trigger.deviceIds (non-deployment conditions):
+    // resolver runs a scoped device query, then the site lookup runs.
+    selectRows.push([{ id: 'device-1' }]); // resolveAutomationTargetDeviceIds scoped query
+    selectRows.push([{ id: 'device-1', siteId: 'site-forbidden' }]); // site lookup
+    const result = await checkAutomationTargetsWithinSiteScope(
+      baseAutomation({
+        conditions: undefined,
+        trigger: { type: 'manual', deviceIds: ['device-1'] },
+      }),
+      { allowedSiteIds: ['site-allowed'] },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.unbounded).toBe(false);
+    expect(result.outOfScopeDeviceIds).toEqual(['device-1']);
+  });
+
+  it('passes when all resolved explicit-target devices are within the allowlist', async () => {
+    selectRows.push([{ id: 'device-1' }]); // resolver scoped query
+    selectRows.push([{ id: 'device-1', siteId: 'site-allowed' }]); // site lookup
+    const result = await checkAutomationTargetsWithinSiteScope(
+      baseAutomation({
+        conditions: undefined,
+        trigger: { type: 'manual', deviceIds: ['device-1'] },
+      }),
+      { allowedSiteIds: ['site-allowed'] },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.outOfScopeDeviceIds).toEqual([]);
+  });
+
+  it('passes a bounded deployment config (type "devices") when targets are in scope', async () => {
+    // resolveDeploymentTargets is mocked -> ['device-deploy-1']; only the site
+    // lookup hits the db here.
+    selectRows.push([{ id: 'device-deploy-1', siteId: 'site-allowed' }]);
+    const result = await checkAutomationTargetsWithinSiteScope(
+      baseAutomation({ conditions: { type: 'devices', deviceIds: ['device-deploy-1'] } }),
+      { allowedSiteIds: ['site-allowed'] },
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects a device whose siteId is null for a site-restricted caller', async () => {
+    selectRows.push([{ id: 'device-1' }]);
+    selectRows.push([{ id: 'device-1', siteId: null }]);
+    const result = await checkAutomationTargetsWithinSiteScope(
+      baseAutomation({
+        conditions: undefined,
+        trigger: { type: 'manual', deviceIds: ['device-1'] },
+      }),
+      { allowedSiteIds: ['site-allowed'] },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.outOfScopeDeviceIds).toEqual(['device-1']);
+  });
+});

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -15,6 +15,7 @@ import {
   scripts,
 } from '../db/schema';
 import { resolveDeploymentTargets } from './deploymentEngine';
+import { canAccessSite, type UserPermissions } from './permissions';
 import { CommandTypes, queueCommandForExecution } from './commandQueue';
 import { publishEvent } from './eventBus';
 import {
@@ -501,6 +502,84 @@ export async function resolveAutomationTargetDeviceIds(automation: AutomationRow
     .where(eq(devices.orgId, automation.orgId));
 
   return orgDevices.map((device) => device.id);
+}
+
+/**
+ * Returns true when the automation's target set is NOT statically bounded to an
+ * explicit device list, i.e. it resolves to "every device in the org" (empty
+ * conditions, legacy fallback, or a deployment config of type `all`/`filter`).
+ *
+ * Site-restricted callers must never own such an automation: even if the org
+ * has zero out-of-scope devices today, a device added to a forbidden site
+ * tomorrow would silently become a target of a schedule/event trigger that
+ * runs with no caller context. We therefore reject these at create/update time.
+ */
+function isUnboundedOrgWideTarget(automation: Pick<AutomationRow, 'conditions' | 'trigger'>): boolean {
+  if (isDeploymentTargetConfig(automation.conditions)) {
+    const type = automation.conditions.type;
+    // `devices` / `groups` enumerate a concrete set; `all` / `filter` do not.
+    return type === 'all' || type === 'filter';
+  }
+
+  if (Array.isArray(automation.conditions)) {
+    // Legacy condition arrays are evaluated against the full org device set.
+    return true;
+  }
+
+  const trigger = isPlainRecord(automation.trigger) ? automation.trigger : null;
+  const triggerDeviceIds = trigger ? asStringArray(trigger.deviceIds) : [];
+  // No explicit deviceIds means the resolver falls back to all org devices.
+  return triggerDeviceIds.length === 0;
+}
+
+export interface AutomationSiteScopeCheck {
+  ok: boolean;
+  /** Device IDs in the resolved target set that fall outside the allowlist. */
+  outOfScopeDeviceIds: string[];
+  /** True when the target set is org-wide/unbounded (rejected for restricted callers). */
+  unbounded: boolean;
+}
+
+/**
+ * Validates that every device an automation would target is within the caller's
+ * site allowlist. Unrestricted callers (`allowedSiteIds` unset) always pass.
+ *
+ * Used at two seams:
+ *  - create/update time: a site-restricted creator must not own an automation
+ *    whose resolvable target set escapes their sites (this is the only gate for
+ *    scheduled/event triggers, which run later with no caller context).
+ *  - manual trigger/run time: re-validate against the *current* resolved set in
+ *    case devices/sites drifted since creation.
+ */
+export async function checkAutomationTargetsWithinSiteScope(
+  automation: AutomationRow,
+  perms: Pick<UserPermissions, 'allowedSiteIds'> | undefined,
+): Promise<AutomationSiteScopeCheck> {
+  // Unrestricted (partner/system/org-admin without a site allowlist): unaffected.
+  if (!perms?.allowedSiteIds) {
+    return { ok: true, outOfScopeDeviceIds: [], unbounded: false };
+  }
+
+  const unbounded = isUnboundedOrgWideTarget(automation);
+  if (unbounded) {
+    return { ok: false, outOfScopeDeviceIds: [], unbounded: true };
+  }
+
+  const targetDeviceIds = await resolveAutomationTargetDeviceIds(automation);
+  if (targetDeviceIds.length === 0) {
+    return { ok: true, outOfScopeDeviceIds: [], unbounded: false };
+  }
+
+  const targetDevices = await db
+    .select({ id: devices.id, siteId: devices.siteId })
+    .from(devices)
+    .where(and(eq(devices.orgId, automation.orgId), inArray(devices.id, targetDeviceIds)));
+
+  const outOfScopeDeviceIds = targetDevices
+    .filter((device) => !(typeof device.siteId === 'string' && canAccessSite(perms as UserPermissions, device.siteId)))
+    .map((device) => device.id);
+
+  return { ok: outOfScopeDeviceIds.length === 0, outOfScopeDeviceIds, unbounded: false };
 }
 
 function getExistingLogs(logs: unknown): AutomationLogEntry[] {


### PR DESCRIPTION
## Security fix — MEDIUM-HIGH (intra-org site-scope authz)

**Finding:** The automation engine enforced **org** scope but not **site** scope. Site is an app-layer authz axis Postgres RLS does not defend. A site-restricted org user holding `automations:write` (`siteIds` and `roleId` are independent columns on `organization_users`, so this config legitimately exists) could create an automation with empty conditions (or an all-org deployment target) + a `run_script`/`execute_command` action and trigger it — `resolveAutomationTargetDeviceIds` returned **every device in the org**, executing commands **as `system`** on devices in sites outside their allowlist. Every sibling device-acting route (`devices/scripts`, `devPush`, `mobile`, `remote/transfers`) re-checks `canAccessSite`; automations were the outlier (same class as #1199).

## Changes
- `automationRuntime.ts` — `checkAutomationTargetsWithinSiteScope()` reuses `resolveAutomationTargetDeviceIds`, runs each target device's `siteId` through `canAccessSite`. `isUnboundedOrgWideTarget()` flags empty-conditions / legacy conditions / deployment `type: all|filter` / no explicit `trigger.deviceIds`.
- `automations.ts` — `enforceAutomationSiteScope()` gate at **create**, **update**, and **manual trigger/run**. Restricted callers → 403; unrestricted unaffected.

## Scheduled triggers
Worker-run (no caller context) → protected by the create/update-time gate (a restricted user can't persist an unbounded/out-of-allowlist automation). Manual trigger/run re-validates the current resolved set.

## Residual (follow-up)
An automation created before its owner's sites were restricted can still fire via its scheduled trigger; closing that needs persisting creator site scope onto the automation.

## Tests
`automationRuntime.siteScope.test.ts` + `automations.test.ts` route gates — **87 passed** incl. regression, verified **RED before**. `tsc` clean.

> Defensive security review (comprehensive pass). Confidence 8/10 vs `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
