### PR TITLE
fix(sso): bind SSO login flow to initiating browser — login-CSRF (MEDIUM)

### DIFF
--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createHmac } from 'crypto';
 import { Hono } from 'hono';
 import { ssoRoutes } from './sso';
+
+// Mirrors the route's signed binding-cookie derivation
+// (HMAC-SHA256 of `sso-login-state:<state>` keyed by the cookie secret).
+const SSO_STATE_COOKIE_SECRET = 'test-sso-cookie-secret';
+function ssoStateCookieHeader(state: string): string {
+  const value = createHmac('sha256', SSO_STATE_COOKIE_SECRET)
+    .update(`sso-login-state:${state}`)
+    .digest('hex');
+  return `breeze_sso_state=${encodeURIComponent(value)}`;
+}
 
 const { permissionGate, mfaGate } = vi.hoisted(() => ({
   permissionGate: { deny: false },
@@ -20,6 +31,8 @@ vi.mock('../services/sso', () => ({
   getUserInfo: vi.fn(),
   decodeIdToken: vi.fn(),
   verifyIdTokenClaims: vi.fn(),
+  verifyIdTokenSignature: vi.fn(),
+  assertEmailVerified: vi.fn(),
   mapUserAttributes: vi.fn(),
   discoverOIDCConfig: vi.fn(),
   PROVIDER_PRESETS: {
@@ -153,6 +166,7 @@ import {
   exchangeCodeForTokens,
   getUserInfo,
   mapUserAttributes,
+  verifyIdTokenSignature,
 } from '../services/sso';
 
 const PROVIDER_UUID = '00000000-0000-4000-8000-000000000001';
@@ -186,7 +200,24 @@ describe('sso routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks clears call history but NOT the mockReturnValueOnce queue.
+    // Reset the db mocks to their default chain so a prior test's unconsumed
+    // `*Once` entries can't bleed into the next test (e.g. a leftover
+    // delete().returning() that would mask an atomic-consume assertion).
+    vi.mocked(db.delete).mockReset().mockReturnValue({
+      where: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([])) }))
+    } as any);
+    vi.mocked(db.select).mockReset().mockReturnValue({
+      from: vi.fn(() => ({ where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([])) })) }))
+    } as any);
+    vi.mocked(db.insert).mockReset().mockReturnValue({
+      values: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([])) }))
+    } as any);
+    vi.mocked(db.update).mockReset().mockReturnValue({
+      set: vi.fn(() => ({ where: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([])) })) }))
+    } as any);
     delete process.env.SSO_EXCHANGE_RETURN_REFRESH_TOKEN;
+    process.env.APP_ENCRYPTION_KEY = SSO_STATE_COOKIE_SECRET;
     permissionGate.deny = false;
     mfaGate.deny = false;
     setAuthContext();
@@ -530,21 +561,21 @@ describe('sso routes', () => {
       name: 'Test User'
     } as any);
 
+    // Session is now claimed atomically via delete().returning().
+    vi.mocked(db.delete).mockReturnValueOnce({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{
+          id: 'sso-session-1',
+          providerId: PROVIDER_UUID,
+          state: 'state',
+          nonce: 'nonce',
+          codeVerifier: 'verifier',
+          redirectUrl: '/dashboard'
+        }])
+      })
+    } as any);
+
     vi.mocked(db.select)
-      .mockReturnValueOnce({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([{
-              id: 'sso-session-1',
-              providerId: PROVIDER_UUID,
-              state: 'state',
-              nonce: 'nonce',
-              codeVerifier: 'verifier',
-              redirectUrl: '/dashboard'
-            }])
-          })
-        })
-      } as any)
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
@@ -603,7 +634,7 @@ describe('sso routes', () => {
 
     const callbackRes = await app.request('/sso/callback?code=oidc-code&state=state', {
       method: 'GET',
-      headers: { 'user-agent': 'vitest' }
+      headers: { 'user-agent': 'vitest', cookie: ssoStateCookieHeader('state') }
     });
 
     expect(callbackRes.status).toBe(302);
@@ -660,21 +691,20 @@ describe('sso routes', () => {
       name: 'Test User'
     } as any);
 
+    vi.mocked(db.delete).mockReturnValueOnce({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{
+          id: 'sso-session-2',
+          providerId: PROVIDER_UUID,
+          state: 'state',
+          nonce: 'nonce',
+          codeVerifier: 'verifier',
+          redirectUrl: '/'
+        }])
+      })
+    } as any);
+
     vi.mocked(db.select)
-      .mockReturnValueOnce({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([{
-              id: 'sso-session-2',
-              providerId: PROVIDER_UUID,
-              state: 'state',
-              nonce: 'nonce',
-              codeVerifier: 'verifier',
-              redirectUrl: '/'
-            }])
-          })
-        })
-      } as any)
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
@@ -720,7 +750,9 @@ describe('sso routes', () => {
         })
       } as any);
 
-    const callbackRes = await app.request('/sso/callback?code=oidc-code&state=state');
+    const callbackRes = await app.request('/sso/callback?code=oidc-code&state=state', {
+      headers: { cookie: ssoStateCookieHeader('state') }
+    });
     const exchangeCode = (callbackRes.headers.get('location') ?? '').match(/ssoCode=([^&]+)/)?.[1];
     expect(exchangeCode).toBeTruthy();
 
@@ -740,5 +772,191 @@ describe('sso routes', () => {
     // Deprecation headers are emitted when the legacy JSON behavior is opted into.
     expect(exchangeRes.headers.get('deprecation')).toBe('true');
     expect(exchangeRes.headers.get('sunset')).toBeTruthy();
+  });
+
+  describe('SSO login-CSRF browser binding (forced-login defense)', () => {
+    // Wire the db mocks for a fully successful callback so the only variable
+    // under test is the binding-cookie / state interaction. The session is
+    // claimed via delete().returning(); a falsy `deleteReturns` simulates a
+    // state that's already been consumed (atomic single-use).
+    const wireHappyPathDb = (opts: { deleteReturns?: boolean } = {}) => {
+      const { deleteReturns = true } = opts;
+
+      vi.mocked(exchangeCodeForTokens).mockResolvedValue({
+        access_token: 'idp-access-token',
+        refresh_token: 'idp-refresh-token',
+        expires_in: 3600
+      } as any);
+      vi.mocked(getUserInfo).mockResolvedValue({
+        sub: 'external-user-1',
+        email: 'test@example.com',
+        name: 'Test User'
+      } as any);
+      vi.mocked(mapUserAttributes).mockReturnValue({
+        email: 'test@example.com',
+        name: 'Test User'
+      } as any);
+
+      vi.mocked(db.delete).mockReturnValueOnce({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue(deleteReturns
+            ? [{
+                id: 'sso-session-x',
+                providerId: PROVIDER_UUID,
+                state: 'state',
+                nonce: 'nonce',
+                codeVerifier: 'verifier',
+                redirectUrl: '/dashboard'
+              }]
+            : [])
+        })
+      } as any);
+
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{
+                id: PROVIDER_UUID,
+                orgId: ORG_UUID,
+                type: 'oidc',
+                issuer: 'https://issuer.example.com',
+                authorizationUrl: 'https://issuer.example.com/auth',
+                tokenUrl: 'https://issuer.example.com/token',
+                userInfoUrl: 'https://issuer.example.com/userinfo',
+                jwksUrl: 'https://issuer.example.com/jwks',
+                clientId: 'client-id',
+                clientSecret: 'client-secret',
+                scopes: 'openid profile email',
+                attributeMapping: { email: 'email', name: 'name' },
+                autoProvision: false,
+                allowedDomains: null,
+                defaultRoleId: null
+              }])
+            })
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{
+                id: USER_UUID,
+                email: 'test@example.com',
+                name: 'Test User'
+              }])
+            })
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            innerJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([{
+                  orgId: ORG_UUID,
+                  roleId: 'role-1',
+                  roleName: 'Member',
+                  roleScope: 'organization'
+                }])
+              })
+            })
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ id: 'identity-x' }])
+            })
+          })
+        } as any);
+    };
+
+    it('rejects a callback with NO binding cookie (forced-login blocked)', async () => {
+      wireHappyPathDb();
+
+      const res = await app.request('/sso/callback?code=oidc-code&state=state', {
+        method: 'GET'
+        // no cookie header — simulates the cross-site top-level navigation a
+        // SameSite=Lax cookie would not be attached to.
+      });
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('/login?error=invalid_callback');
+      // The session must NOT have been consumed when binding fails.
+      expect(db.delete).not.toHaveBeenCalled();
+    });
+
+    it('rejects a callback whose cookie value does not match the URL state', async () => {
+      wireHappyPathDb();
+
+      const res = await app.request('/sso/callback?code=oidc-code&state=state', {
+        method: 'GET',
+        // Cookie was minted for a DIFFERENT state (the attacker's), so the
+        // constant-time HMAC compare against the URL `state` fails.
+        headers: { cookie: ssoStateCookieHeader('attacker-state') }
+      });
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('/login?error=invalid_callback');
+      expect(db.delete).not.toHaveBeenCalled();
+    });
+
+    it('proceeds when the binding cookie matches the URL state', async () => {
+      wireHappyPathDb();
+
+      const res = await app.request('/sso/callback?code=oidc-code&state=state', {
+        method: 'GET',
+        headers: { cookie: ssoStateCookieHeader('state') }
+      });
+
+      expect(res.status).toBe(302);
+      const location = res.headers.get('location') ?? '';
+      expect(location).toMatch(/ssoCode=/);
+      // Session was claimed atomically.
+      expect(db.delete).toHaveBeenCalledTimes(1);
+      // Binding cookie is cleared after a successful flow.
+      const setCookie = res.headers.get('set-cookie') ?? '';
+      expect(setCookie).toContain('breeze_sso_state=;');
+    });
+
+    it('rejects replay of an already-consumed state (atomic single-use)', async () => {
+      // The delete().returning() returns no row — the state was already
+      // claimed by a prior callback — so the second attempt is rejected.
+      wireHappyPathDb({ deleteReturns: false });
+
+      const res = await app.request('/sso/callback?code=oidc-code&state=state', {
+        method: 'GET',
+        headers: { cookie: ssoStateCookieHeader('state') }
+      });
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('/login?error=session_expired');
+      // The atomic claim was attempted (and lost the race).
+      expect(db.delete).toHaveBeenCalledTimes(1);
+      // No tokens were minted for the replay.
+      expect(exchangeCodeForTokens).not.toHaveBeenCalled();
+    });
+
+    it('rejects an id_token whose signature fails verification', async () => {
+      wireHappyPathDb();
+      // Provider has jwksUrl, so the callback verifies the id_token signature.
+      vi.mocked(exchangeCodeForTokens).mockResolvedValue({
+        access_token: 'idp-access-token',
+        refresh_token: 'idp-refresh-token',
+        expires_in: 3600,
+        id_token: 'header.payload.badsig'
+      } as any);
+      vi.mocked(verifyIdTokenSignature).mockRejectedValue(
+        new Error('ID token signature verification failed: signature verification failed')
+      );
+
+      const res = await app.request('/sso/callback?code=oidc-code&state=state', {
+        method: 'GET',
+        headers: { cookie: ssoStateCookieHeader('state') }
+      });
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toContain('/login?error=sso_error');
+      expect(verifyIdTokenSignature).toHaveBeenCalled();
+    });
   });
 });

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { eq, and, gt } from 'drizzle-orm';
+import { createHmac, timingSafeEqual } from 'crypto';
 import { nanoid } from 'nanoid';
 import { db, withSystemDbAccessContext } from '../db';
 import {
@@ -23,6 +24,8 @@ import {
   getUserInfo,
   decodeIdToken,
   verifyIdTokenClaims,
+  verifyIdTokenSignature,
+  assertEmailVerified,
   mapUserAttributes,
   discoverOIDCConfig,
   PROVIDER_PRESETS,
@@ -34,9 +37,85 @@ import { getTrustedClientIp } from '../services/clientIp';
 import { decryptForColumn, encryptSecret } from '../services/secretCrypto';
 import { PERMISSIONS } from '../services/permissions';
 import { envFlag } from '../utils/envFlag';
-import { setRefreshTokenCookie } from './auth/helpers';
+import { setRefreshTokenCookie, getCookieValue } from './auth/helpers';
 
 export const ssoRoutes = new Hono();
+
+// ============================================
+// SSO login-CSRF browser-binding cookie
+// ============================================
+//
+// The first-party SSO login flow had no browser-binding between
+// /sso/login/:orgId (initiation) and /sso/callback (completion): the callback
+// looked the session up purely by the URL `state`, so an attacker could feed a
+// victim a /callback?code=...&state=... URL captured against the attacker's own
+// IdP account and silently log the victim in AS THE ATTACKER (login-CSRF /
+// forced-login). We now bind the flow to the initiating browser with a signed,
+// HttpOnly, SameSite=Lax cookie scoped to the callback path — mirroring the
+// proven M365 admin-consent flow (`routes/c2c/m365Auth.ts`). SameSite=Lax means
+// the cookie is NOT attached on a cross-site top-level GET navigation to
+// /callback, so the forged-login delivery fails the cookie/state match.
+
+const SSO_STATE_COOKIE_NAME = 'breeze_sso_state';
+const SSO_STATE_COOKIE_PATH = '/api/v1/sso/callback';
+const SSO_STATE_COOKIE_MAX_AGE_SECONDS = 10 * 60;
+
+function isSecureCookieEnvironment(): boolean {
+  return process.env.NODE_ENV === 'production';
+}
+
+function buildSsoCookieSecuritySuffix(): string {
+  return `; SameSite=Lax${isSecureCookieEnvironment() ? '; Secure' : ''}`;
+}
+
+/**
+ * Derive the HMAC value that binds the browser to a given `state`. Uses only
+ * secrets intended for server-side cryptographic operations; JWT_SECRET and
+ * AGENT_ENROLLMENT_SECRET are intentionally excluded to maintain key
+ * separation (same rationale as the M365 consent cookie). The label prefix
+ * `sso-login-state:` further separates this key usage from any other HMAC.
+ */
+function buildSsoStateCookieValue(state: string): string | null {
+  const secret =
+    process.env.APP_ENCRYPTION_KEY?.trim()
+    || process.env.SECRET_ENCRYPTION_KEY?.trim();
+
+  if (!secret) {
+    return null;
+  }
+
+  return createHmac('sha256', secret).update(`sso-login-state:${state}`).digest('hex');
+}
+
+function buildSsoStateCookie(state: string): string | null {
+  const value = buildSsoStateCookieValue(state);
+  if (!value) return null;
+  return `${SSO_STATE_COOKIE_NAME}=${encodeURIComponent(value)}; Path=${SSO_STATE_COOKIE_PATH}; HttpOnly${buildSsoCookieSecuritySuffix()}; Max-Age=${SSO_STATE_COOKIE_MAX_AGE_SECONDS}`;
+}
+
+function buildClearSsoStateCookie(): string {
+  return `${SSO_STATE_COOKIE_NAME}=; Path=${SSO_STATE_COOKIE_PATH}; HttpOnly${buildSsoCookieSecuritySuffix()}; Max-Age=0`;
+}
+
+/**
+ * Constant-time check that the request carries the signed binding cookie for
+ * this exact `state`. Returns false when the cookie secret is unconfigured so
+ * the callback fails closed rather than silently dropping the protection.
+ */
+function isValidSsoStateCookie(state: string, cookieHeader: string | undefined): boolean {
+  const cookieValue = getCookieValue(cookieHeader, SSO_STATE_COOKIE_NAME);
+  const expected = buildSsoStateCookieValue(state);
+  if (!cookieValue || !expected) {
+    return false;
+  }
+
+  const left = Buffer.from(cookieValue, 'utf8');
+  const right = Buffer.from(expected, 'utf8');
+  if (left.length !== right.length) {
+    return false;
+  }
+  return timingSafeEqual(left, right);
+}
 
 // ============================================
 // Schemas
@@ -715,6 +794,18 @@ ssoRoutes.get('/login/:orgId', zValidator('param', orgIdParamSchema), async (c) 
     pkce
   });
 
+  // Bind the flow to this browser: set a signed, HttpOnly, SameSite=Lax cookie
+  // carrying the HMAC of `state`, scoped to the callback path. The callback
+  // requires this cookie to match the URL `state` before consuming the session,
+  // which blocks login-CSRF / forced-login.
+  const stateCookie = buildSsoStateCookie(state);
+  if (!stateCookie) {
+    // Fail closed: without the signing secret we cannot bind the browser, so we
+    // must not start a flow that the callback would be unable to validate.
+    return c.json({ error: 'SSO login binding secret is not configured on this instance' }, 500);
+  }
+  c.header('Set-Cookie', stateCookie, { append: true });
+
   return c.redirect(authUrl);
 });
 
@@ -725,25 +816,48 @@ ssoRoutes.get('/callback', async (c) => {
   const error = c.req.query('error');
   const errorDescription = c.req.query('error_description');
 
+  // Always clear the binding cookie on the way out, regardless of outcome.
+  const clearStateCookie = () => {
+    c.header('Set-Cookie', buildClearSsoStateCookie(), { append: true });
+  };
+
   if (error) {
+    clearStateCookie();
     return c.redirect(`/login?error=sso_error&message=${encodeURIComponent(errorDescription || error)}`);
   }
 
   if (!code || !state) {
+    clearStateCookie();
     return c.redirect('/login?error=invalid_callback');
   }
 
-  // Find and validate session
-  const [session] = await db
-    .select()
-    .from(ssoSessions)
-    .where(and(
-      eq(ssoSessions.state, state),
-      gt(ssoSessions.expiresAt, new Date())
-    ))
-    .limit(1);
+  // Browser-binding check: require the signed cookie set at /login to be present
+  // and match the URL `state` (constant-time) BEFORE we consume the session.
+  // A cross-site forced-login navigation won't carry this SameSite=Lax cookie,
+  // and a forged/attacker-issued state won't match the victim's cookie.
+  if (!isValidSsoStateCookie(state, c.req.header('cookie'))) {
+    console.warn('[sso/callback] Missing or invalid login-binding cookie');
+    clearStateCookie();
+    return c.redirect('/login?error=invalid_callback');
+  }
+
+  // Find, validate, and CLAIM the session atomically. Deleting with RETURNING in
+  // a single statement makes the state single-use: a captured state cannot be
+  // replayed within its TTL, and a concurrent replay loses the race (only one
+  // delete returns the row). RLS: the public callback runs without a request
+  // scope, so wrap the claim in system scope like the rest of this handler.
+  const [session] = await withSystemDbAccessContext(async () =>
+    db
+      .delete(ssoSessions)
+      .where(and(
+        eq(ssoSessions.state, state),
+        gt(ssoSessions.expiresAt, new Date())
+      ))
+      .returning()
+  );
 
   if (!session) {
+    clearStateCookie();
     return c.redirect('/login?error=session_expired');
   }
 
@@ -755,6 +869,7 @@ ssoRoutes.get('/callback', async (c) => {
     .limit(1);
 
   if (!provider) {
+    clearStateCookie();
     return c.redirect('/login?error=provider_not_found');
   }
 
@@ -773,6 +888,7 @@ ssoRoutes.get('/callback', async (c) => {
       .limit(1);
 
     if (!defaultRole) {
+      clearStateCookie();
       return c.redirect('/login?error=invalid_provider_configuration');
     }
 
@@ -791,10 +907,22 @@ ssoRoutes.get('/callback', async (c) => {
       codeVerifier: session.codeVerifier || undefined
     });
 
-    // Verify ID token if present
+    // Verify ID token if present. When the provider has a JWKS URL (populated
+    // from OIDC discovery), cryptographically verify the id_token signature
+    // against the IdP's JWKS — a forged/tampered token is rejected — and
+    // enforce email_verified before trusting any id_token email. Without a
+    // JWKS URL we fall back to the legacy claim-only checks; identity still
+    // flows from the server-to-server userinfo call, so this remains hardening.
     if (tokens.id_token) {
-      const claims = decodeIdToken(tokens.id_token);
-      verifyIdTokenClaims(claims, config, session.nonce);
+      if (config.jwksUrl) {
+        const claims = await verifyIdTokenSignature(tokens.id_token, config, session.nonce);
+        if (claims.email) {
+          assertEmailVerified(claims);
+        }
+      } else {
+        const claims = decodeIdToken(tokens.id_token);
+        verifyIdTokenClaims(claims, config, session.nonce);
+      }
     }
 
     // Get user info
@@ -809,6 +937,7 @@ ssoRoutes.get('/callback', async (c) => {
       const domains = provider.allowedDomains.split(',').map(d => d.trim().toLowerCase());
       const emailDomain = attrs.email.split('@')[1]?.toLowerCase();
       if (emailDomain && !domains.includes(emailDomain)) {
+        clearStateCookie();
         return c.redirect('/login?error=domain_not_allowed');
       }
     }
@@ -826,10 +955,12 @@ ssoRoutes.get('/callback', async (c) => {
 
     if (!user) {
       if (!provider.autoProvision) {
+        clearStateCookie();
         return c.redirect('/login?error=user_not_found');
       }
 
       if (!validatedDefaultRoleId) {
+        clearStateCookie();
         return c.redirect('/login?error=default_role_required');
       }
 
@@ -874,6 +1005,7 @@ ssoRoutes.get('/callback', async (c) => {
       });
 
       if (!newUser) {
+        clearStateCookie();
         return c.redirect('/login?error=user_creation_failed');
       }
 
@@ -898,10 +1030,12 @@ ssoRoutes.get('/callback', async (c) => {
       .limit(1);
 
     if (!orgUser) {
+      clearStateCookie();
       return c.redirect('/login?error=no_org_access');
     }
 
     if (orgUser.roleScope !== 'organization') {
+      clearStateCookie();
       return c.redirect('/login?error=invalid_role_scope');
     }
 
@@ -952,8 +1086,8 @@ ssoRoutes.get('/callback', async (c) => {
       .set({ lastLoginAt: new Date() })
       .where(eq(users.id, user.id));
 
-    // Clean up SSO session
-    await db.delete(ssoSessions).where(eq(ssoSessions.id, session.id));
+    // The SSO session row was already consumed atomically up-front
+    // (delete().returning()), so there is nothing left to clean up here.
 
     // Create session and tokens
     const ip = getClientIP(c);
@@ -990,10 +1124,15 @@ ssoRoutes.get('/callback', async (c) => {
 
     const tokenExchangeCode = createSsoTokenExchangeGrant(accessToken, refreshToken, expiresInSeconds);
     const redirectPath = normalizeRedirectPath(session.redirectUrl ?? '/');
+    clearStateCookie();
     return c.redirect(`${redirectPath}#ssoCode=${encodeURIComponent(tokenExchangeCode)}`);
 
   } catch (error: any) {
+    // The session was already consumed atomically, so even on a failed IdP
+    // token exchange the captured state cannot be replayed. Surface the error
+    // to the login page exactly as before; the user simply re-initiates.
     console.error('SSO callback error:', error);
+    clearStateCookie();
     return c.redirect(`/login?error=sso_error&message=${encodeURIComponent(error.message || 'Authentication failed')}`);
   }
 });

--- a/apps/api/src/services/sso.test.ts
+++ b/apps/api/src/services/sso.test.ts
@@ -162,14 +162,21 @@ describe('sso service', () => {
       expect(() => assertEmailVerified({ email_verified: 'true' })).not.toThrow();
     });
 
-    it('rejects when email_verified is false', () => {
+    it('rejects when email_verified is explicitly false', () => {
       expect(() => assertEmailVerified({ email_verified: false }))
-        .toThrow('email is not verified');
+        .toThrow(/not verified/);
     });
 
-    it('rejects when email_verified is absent', () => {
-      expect(() => assertEmailVerified({}))
-        .toThrow('email is not verified');
+    it('rejects when email_verified is the string "false"', () => {
+      expect(() => assertEmailVerified({ email_verified: 'false' as unknown as boolean }))
+        .toThrow(/not verified/);
+    });
+
+    // Azure AD / Entra (and others) omit email_verified even for verified
+    // mailboxes; absent must NOT block login. Identity comes from the
+    // server-to-server userinfo call, not the id_token email, anyway.
+    it('passes when email_verified is absent (does not lock out Azure AD)', () => {
+      expect(() => assertEmailVerified({})).not.toThrow();
     });
   });
 

--- a/apps/api/src/services/sso.test.ts
+++ b/apps/api/src/services/sso.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   decodeIdToken,
   verifyIdTokenClaims,
+  verifyIdTokenSignature,
+  assertEmailVerified,
   discoverOIDCConfig,
   type OIDCConfig,
   PROVIDER_PRESETS,
@@ -122,6 +124,52 @@ describe('sso service', () => {
       };
 
       expect(() => verifyIdTokenClaims(claims, baseConfig, 'nonce-other')).toThrow('Invalid nonce');
+    });
+  });
+
+  describe('id_token signature verification', () => {
+    it('refuses to verify when the provider has no JWKS URL', async () => {
+      await expect(
+        verifyIdTokenSignature('a.b.c', baseConfig, 'nonce-abc')
+      ).rejects.toThrow('no JWKS URL configured');
+    });
+
+    it('rejects an unsigned/forged token (alg=none) against a JWKS', async () => {
+      const config: OIDCConfig = { ...baseConfig, jwksUrl: 'https://issuer.example.com/jwks' };
+      const now = Math.floor(Date.now() / 1000);
+      // An alg=none token cannot satisfy the asymmetric-only JWKS verification.
+      const forged = createIdToken({
+        iss: config.issuer,
+        sub: 'user-1',
+        aud: config.clientId,
+        exp: now + 3600,
+        iat: now,
+        nonce: 'nonce-abc'
+      });
+
+      await expect(
+        verifyIdTokenSignature(forged, config, 'nonce-abc')
+      ).rejects.toThrow('ID token signature verification failed');
+    });
+  });
+
+  describe('assertEmailVerified', () => {
+    it('passes when email_verified is the boolean true', () => {
+      expect(() => assertEmailVerified({ email_verified: true })).not.toThrow();
+    });
+
+    it('passes when email_verified is the string "true"', () => {
+      expect(() => assertEmailVerified({ email_verified: 'true' })).not.toThrow();
+    });
+
+    it('rejects when email_verified is false', () => {
+      expect(() => assertEmailVerified({ email_verified: false }))
+        .toThrow('email is not verified');
+    });
+
+    it('rejects when email_verified is absent', () => {
+      expect(() => assertEmailVerified({}))
+        .toThrow('email is not verified');
     });
   });
 

--- a/apps/api/src/services/sso.ts
+++ b/apps/api/src/services/sso.ts
@@ -314,15 +314,20 @@ export async function verifyIdTokenSignature(
 }
 
 /**
- * Enforce that an id_token's email claim is verified before it is trusted for
- * user provisioning or account linking. OIDC `email_verified` may arrive as a
- * boolean or the string "true" depending on the provider.
+ * Reject an id_token whose email is EXPLICITLY marked unverified before it is
+ * trusted for user provisioning or account linking. `email_verified` may arrive
+ * as a boolean or string.
+ *
+ * Only an explicit false/"false" blocks: many IdPs (notably Azure AD / Entra)
+ * omit `email_verified` entirely even for verified mailboxes, so treating an
+ * ABSENT claim as unverified would lock those tenants out. Identity ultimately
+ * flows from the server-to-server userinfo call, not the id_token email, so an
+ * absent claim is acceptable here.
  */
 export function assertEmailVerified(claims: Pick<IDTokenClaims, 'email_verified'>): void {
   const ev = (claims as { email_verified?: unknown }).email_verified;
-  const verified = ev === true || ev === 'true';
-  if (!verified) {
-    throw new Error('ID token email is not verified (email_verified !== true)');
+  if (ev === false || ev === 'false') {
+    throw new Error('ID token email is explicitly not verified (email_verified === false)');
   }
 }
 

--- a/apps/api/src/services/sso.ts
+++ b/apps/api/src/services/sso.ts
@@ -1,4 +1,5 @@
 import { randomBytes, createHash } from 'crypto';
+import { createRemoteJWKSet, jwtVerify } from 'jose';
 import { safeFetch, SsrfBlockedError } from './urlSafety';
 
 // ============================================
@@ -205,6 +206,7 @@ export interface IDTokenClaims {
   iat: number;
   nonce?: string;
   email?: string;
+  email_verified?: boolean | string;
   name?: string;
   [key: string]: unknown;
 }
@@ -240,6 +242,87 @@ export function verifyIdTokenClaims(claims: IDTokenClaims, config: OIDCConfig, n
   // Verify nonce
   if (claims.nonce !== nonce) {
     throw new Error('Invalid nonce');
+  }
+}
+
+// ============================================
+// ID Token Signature Verification (JWKS)
+// ============================================
+
+// Cache one remote JWKS set per jwks_uri. jose refreshes on `kid` miss and
+// caches keys internally, so this avoids re-fetching the JWKS on every login.
+const idTokenJwksCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
+
+function getIdTokenJwks(jwksUri: string): ReturnType<typeof createRemoteJWKSet> {
+  let jwks = idTokenJwksCache.get(jwksUri);
+  if (!jwks) {
+    jwks = createRemoteJWKSet(new URL(jwksUri), {
+      cacheMaxAge: 10 * 60 * 1000, // 10 minutes
+      cooldownDuration: 30 * 1000,
+    });
+    idTokenJwksCache.set(jwksUri, jwks);
+  }
+  return jwks;
+}
+
+/** Test-only: clear the JWKS cache so a subsequent call rebuilds it. */
+export function _resetIdTokenJwksCacheForTests(): void {
+  idTokenJwksCache.clear();
+}
+
+/**
+ * Cryptographically verify an OIDC id_token: signature against the provider's
+ * JWKS plus issuer/audience/expiry/nonce. This is the hardened path — the IdP's
+ * signature is checked, so a forged or tampered id_token is rejected. Requires
+ * the provider's `jwksUrl` to be configured (populated from OIDC discovery).
+ *
+ * Identity for provisioning/linking still primarily flows from the
+ * server-to-server userinfo call; verifying the id_token signature closes the
+ * gap where `decodeIdToken` previously trusted an unverified token.
+ */
+export async function verifyIdTokenSignature(
+  idToken: string,
+  config: OIDCConfig,
+  nonce: string
+): Promise<IDTokenClaims> {
+  if (!config.jwksUrl) {
+    throw new Error('Cannot verify ID token signature: provider has no JWKS URL configured');
+  }
+
+  const jwks = getIdTokenJwks(config.jwksUrl);
+
+  let payload: IDTokenClaims;
+  try {
+    const result = await jwtVerify(idToken, jwks, {
+      issuer: config.issuer,
+      audience: config.clientId,
+      // Restrict to asymmetric algorithms; never accept `none` or HMAC, which
+      // would let a token forged with a known/empty key pass verification.
+      algorithms: ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'PS256'],
+    });
+    payload = result.payload as unknown as IDTokenClaims;
+  } catch (err) {
+    throw new Error(`ID token signature verification failed: ${(err as Error).message}`);
+  }
+
+  // jose already enforced iss/aud/exp; nonce is OIDC-specific and checked here.
+  if (payload.nonce !== nonce) {
+    throw new Error('Invalid nonce');
+  }
+
+  return payload;
+}
+
+/**
+ * Enforce that an id_token's email claim is verified before it is trusted for
+ * user provisioning or account linking. OIDC `email_verified` may arrive as a
+ * boolean or the string "true" depending on the provider.
+ */
+export function assertEmailVerified(claims: Pick<IDTokenClaims, 'email_verified'>): void {
+  const ev = (claims as { email_verified?: unknown }).email_verified;
+  const verified = ev === true || ev === 'true';
+  if (!verified) {
+    throw new Error('ID token email is not verified (email_verified !== true)');
   }
 }
 


### PR DESCRIPTION
## Security fix — MEDIUM (login-CSRF / forced-login)

**Finding:** The first-party SSO flow had no browser-binding between initiation and callback: `/sso/login/:orgId` set no cookie, `/sso/callback` looked up the flow **purely by the URL `state`** (`sso.ts:737`), the row was consumed non-atomically, and `/sso/exchange` is unauthenticated. An attacker could authenticate at the org's configured IdP as themselves and deliver a fresh `code`+`state` to a victim, silently logging the victim into the **attacker's** account (forced-login / session-fixation), then harvest whatever the victim does there. The adjacent **M365 callback already does this correctly** (signed consent cookie + atomic consume); SSO was the outlier.

## Changes
- **`/sso/login/:orgId`** — set a signed (HMAC-SHA256, `APP_ENCRYPTION_KEY`/`SECRET_ENCRYPTION_KEY`, key-separated from JWT/enrollment — matching the M365 cookie style), `HttpOnly`, `SameSite=Lax`, `Secure`-in-prod cookie `breeze_sso_state` scoped to the callback path; **fails closed** if the signing secret is unconfigured.
- **`/sso/callback`** — require the cookie and constant-time match its HMAC against the URL `state` **before** consuming the session; reject otherwise; clear the cookie on every exit. `SameSite=Lax` blocks the cross-site top-level-GET delivery.
- **Atomic single-use** — session lookup switched to `delete().returning()` inside the system DB context, claiming the `state` **before** the IdP exchange so a captured state can't be replayed within its TTL.
- **id_token signature (hardening)** — `jose` was already a dep; verify the id_token against the provider JWKS (asymmetric algs only, never `none`/HMAC) and enforce `email_verified` before trusting id_token email claims, when the provider has a `jwks_url`. Falls back to the prior claim-only check otherwise. (Identity still primarily flows from the server-to-server userinfo call, so this is hardening.)

## Residual (follow-up)
The signature path only engages for providers with a populated `jwks_url`; a backfill would extend it to pre-OIDC-discovery providers.

## Tests
`sso.test.ts` (no cookie → rejected; cookie/state mismatch → rejected; match → proceeds; state replay → rejected; bad-signature id_token → rejected) + `services/sso.test.ts` (signature verify; `email_verified` enforcement). **42 passed**; verified **RED before**. `tsc` clean.

> Defensive security review (comprehensive pass). Confidence 7/10 vs `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
