### PR TITLE
fix(helper): Phase 0 device-scope + approval hardening (finding A, HIGH)

### DIFF
--- a/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
@@ -152,7 +152,6 @@ const SITE_SCOPE_INPUT_EXEMPT: ReadonlySet<string> = new Set<string>([
   'routes/helper/index.ts:DELETE /chat/sessions/:id',
   'routes/helper/index.ts:GET /chat/sessions',
   'routes/helper/index.ts:GET /chat/sessions/:id/messages',
-  'routes/helper/index.ts:POST /chat/sessions/:id/approve/:executionId',
   'routes/helper/index.ts:POST /chat/sessions/:id/flag',
   'routes/tunnels.ts:GET /desktop-access',
   'routes/tunnels.ts:POST /downgrade-to-vnc',

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -61,6 +61,14 @@ export interface AuthContext {
    * denied for a null/undefined siteId (e.g. a device with no site assignment).
    */
   canAccessSite?: (siteId: string | null | undefined) => boolean;
+
+  /**
+   * Set ONLY for Breeze Helper sessions (helperAuth). When present, the
+   * AI-tools executeTool gate forces every tool's device input to this device
+   * id and denies org-wide tools — the Helper can act only on its own device.
+   * Undefined for all normal (user/agent) contexts.
+   */
+  helperDeviceId?: string;
 }
 
 declare module 'hono' {

--- a/apps/api/src/routes/helper/helperApprove.removed.test.ts
+++ b/apps/api/src/routes/helper/helperApprove.removed.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+// Mirror the db/schema/middleware mock shape used by the sibling index.test.ts
+// harness so helperAuth resolves an authenticated device for our request.
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+}));
+
+vi.mock('../../db/schema', () => ({
+  aiMessages: {},
+  aiSessions: {
+    id: 'aiSessions.id',
+    deviceId: 'aiSessions.deviceId',
+    updatedAt: 'aiSessions.updatedAt',
+  },
+  aiToolExecutions: {},
+  devices: {
+    id: 'devices.id',
+    agentId: 'devices.agentId',
+    orgId: 'devices.orgId',
+    siteId: 'devices.siteId',
+    hostname: 'devices.hostname',
+    osType: 'devices.osType',
+    osVersion: 'devices.osVersion',
+    agentVersion: 'devices.agentVersion',
+    helperTokenHash: 'devices.helperTokenHash',
+    previousHelperTokenHash: 'devices.previousHelperTokenHash',
+    previousHelperTokenExpiresAt: 'devices.previousHelperTokenExpiresAt',
+    status: 'devices.status',
+  },
+  organizations: {
+    id: 'organizations.id',
+    partnerId: 'organizations.partnerId',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((...args: unknown[]) => ({ eq: args })),
+  and: vi.fn((...args: unknown[]) => ({ and: args })),
+  or: vi.fn((...args: unknown[]) => ({ or: args })),
+  desc: vi.fn((...args: unknown[]) => ({ desc: args })),
+  asc: vi.fn((...args: unknown[]) => ({ asc: args })),
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ sql: strings, values })),
+}));
+
+vi.mock('../../middleware/agentAuth', () => ({
+  matchAgentTokenHash: vi.fn(() => true),
+}));
+
+vi.mock('../../services/helperPermissions', () => ({
+  resolveHelperPermissionLevelForDevice: vi.fn(),
+}));
+
+vi.mock('../../services/helperAiAgent', () => ({
+  buildHelperSystemPrompt: vi.fn(() => 'helper system prompt'),
+}));
+
+vi.mock('../../services/streamingSessionManager', () => ({
+  streamingSessionManager: {
+    getOrCreate: vi.fn(),
+    tryTransitionToProcessing: vi.fn(),
+    startTurnTimeout: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/aiInputSanitizer', () => ({
+  sanitizeUserMessage: vi.fn(() => ({ sanitized: 'hello', flags: [] })),
+}));
+
+vi.mock('../../services/screenshotStorage', () => ({
+  storeScreenshot: vi.fn(),
+}));
+
+vi.mock('../../services/aiCostTracker', () => ({
+  checkBudget: vi.fn(),
+  getRemainingBudgetUsd: vi.fn(),
+}));
+
+vi.mock('../../services', () => ({
+  getRedis: vi.fn(() => null),
+  rateLimiter: vi.fn(),
+}));
+
+vi.mock('../../services/aiAgentSdk', () => ({
+  createSessionPreToolUse: vi.fn(),
+  createSessionPostToolUse: vi.fn(),
+}));
+
+import { helperRoutes } from './index';
+import { db } from '../../db';
+
+function mockHelperAuthDevice() {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{
+            id: 'device-1',
+            agentId: 'agent-1',
+            orgId: 'org-1',
+            siteId: 'site-1',
+            hostname: 'host-1',
+            osType: 'linux',
+            osVersion: '6.8',
+            agentVersion: '1.0.0',
+            helperTokenHash: 'hash',
+            previousHelperTokenHash: null,
+            previousHelperTokenExpiresAt: null,
+            status: 'online',
+            partnerId: 'partner-1',
+          }]),
+        }),
+      }),
+    }),
+  } as never);
+}
+
+describe('Helper self-approve endpoint removal (finding A)', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/helper', helperRoutes);
+  });
+
+  it('POST /chat/sessions/:id/approve/:executionId no longer exists (404)', async () => {
+    mockHelperAuthDevice();
+    const res = await app.request('/helper/chat/sessions/s-1/approve/e-1', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer brz_token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ approved: true }),
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/api/src/routes/helper/index.test.ts
+++ b/apps/api/src/routes/helper/index.test.ts
@@ -161,7 +161,7 @@ describe('helper routes permission derivation', () => {
       previousTokenHash: null,
       previousTokenExpiresAt: null,
     }));
-    expect(resolveHelperPermissionLevelForDevice).toHaveBeenCalledWith('device-1', 'standard');
+    expect(resolveHelperPermissionLevelForDevice).toHaveBeenCalledWith('device-1', 'basic');
     expect((insertedValues?.contextSnapshot as Record<string, unknown>).permissionLevel).toBe('standard');
   });
 
@@ -176,7 +176,7 @@ describe('helper routes permission derivation', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.permissionLevel).toBe('extended');
-    expect(resolveHelperPermissionLevelForDevice).toHaveBeenCalledWith('device-1', 'standard');
+    expect(resolveHelperPermissionLevelForDevice).toHaveBeenCalledWith('device-1', 'basic');
   });
 
   it('uses server-derived permissionLevel and allowlist when sending messages', async () => {
@@ -241,6 +241,6 @@ describe('helper routes permission derivation', () => {
     expect(systemPrompt).toBe('helper system prompt');
     expect(allowedTools).toContain('mcp__breeze__file_operations');
     expect(allowedTools).not.toContain('mcp__breeze__execute_command');
-    expect(resolveHelperPermissionLevelForDevice).toHaveBeenCalledWith('device-1', 'standard');
+    expect(resolveHelperPermissionLevelForDevice).toHaveBeenCalledWith('device-1', 'basic');
   });
 });

--- a/apps/api/src/routes/helper/index.ts
+++ b/apps/api/src/routes/helper/index.ts
@@ -13,8 +13,7 @@ import { streamSSE } from 'hono/streaming';
 import { createHash } from 'crypto';
 import { eq, and, desc, sql, asc, or } from 'drizzle-orm';
 import { db, withSystemDbAccessContext, withDbAccessContext } from '../../db';
-import { aiSessions, aiMessages, aiToolExecutions, devices, organizations } from '../../db/schema';
-import { approveToolSchema } from '@breeze/shared/validators/ai';
+import { aiSessions, aiMessages, devices, organizations } from '../../db/schema';
 import { streamingSessionManager } from '../../services/streamingSessionManager';
 import { buildHelperSystemPrompt } from '../../services/helperAiAgent';
 import { getHelperAllowedMcpToolNames, type HelperPermissionLevel } from '../../services/helperToolFilter';
@@ -634,61 +633,6 @@ helperRoutes.delete('/chat/sessions/:id', async (c) => {
 
   return c.json({ success: true });
 });
-
-// ============================================
-// POST /chat/sessions/:id/approve/:executionId — Approve or reject tool
-// ============================================
-
-helperRoutes.post(
-  '/chat/sessions/:id/approve/:executionId',
-  zValidator('json', approveToolSchema),
-  async (c) => {
-    const device = c.get('helperDevice');
-    const sessionId = c.req.param('id');
-    const executionId = c.req.param('executionId');
-    const { approved } = c.req.valid('json');
-
-    // Verify session belongs to this device
-    const [session] = await db
-      .select({ id: aiSessions.id })
-      .from(aiSessions)
-      .where(and(eq(aiSessions.id, sessionId), eq(aiSessions.deviceId, device.id)))
-      .limit(1);
-
-    if (!session) {
-      return c.json({ error: 'Session not found' }, 404);
-    }
-
-    // Verify execution belongs to session and is pending
-    const [execution] = await db
-      .select({ id: aiToolExecutions.id, status: aiToolExecutions.status })
-      .from(aiToolExecutions)
-      .where(and(
-        eq(aiToolExecutions.id, executionId),
-        eq(aiToolExecutions.sessionId, sessionId),
-      ))
-      .limit(1);
-
-    if (!execution) {
-      return c.json({ error: 'Execution not found' }, 404);
-    }
-
-    if (execution.status !== 'pending') {
-      return c.json({ error: 'Execution already processed' }, 409);
-    }
-
-    await db
-      .update(aiToolExecutions)
-      .set({
-        status: approved ? 'approved' : 'rejected',
-        approvedBy: null, // device context, not a user FK
-        approvedAt: new Date(),
-      })
-      .where(eq(aiToolExecutions.id, executionId));
-
-    return c.json({ success: true, approved });
-  },
-);
 
 // ============================================
 // POST /chat/sessions/:id/flag — Flag session for review

--- a/apps/api/src/routes/helper/index.ts
+++ b/apps/api/src/routes/helper/index.ts
@@ -30,7 +30,7 @@ import type { ActiveSession } from '../../services/streamingSessionManager';
 const SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const HELPER_RATE_LIMIT = 30;
 const HELPER_RATE_WINDOW_SECONDS = 60;
-const DEFAULT_PERMISSION_LEVEL: HelperPermissionLevel = 'standard';
+const DEFAULT_PERMISSION_LEVEL: HelperPermissionLevel = 'basic';
 
 export const helperRoutes = new Hono();
 

--- a/apps/api/src/routes/helper/index.ts
+++ b/apps/api/src/routes/helper/index.ts
@@ -156,6 +156,7 @@ async function helperAuth(c: import('hono').Context, next: import('hono').Next) 
     accessibleOrgIds: [device.orgId],
     orgCondition: (orgIdColumn) => eq(orgIdColumn, device.orgId),
     canAccessOrg: (orgId) => orgId === device.orgId,
+    helperDeviceId: device.id,
   };
 
   c.set('auth', syntheticAuth);

--- a/apps/api/src/services/aiTools.executeToolGate.test.ts
+++ b/apps/api/src/services/aiTools.executeToolGate.test.ts
@@ -85,4 +85,16 @@ describe('executeTool runs the declarative device gate before the handler', () =
     expect(JSON.parse(out).ranHandler).toBe(true);
     expect(handler).toHaveBeenCalledTimes(1);
   });
+
+  // Regression (finding A): the helper device-scope gate must ONLY engage when
+  // auth.helperDeviceId is set. A normal (non-helper) caller's input must reach
+  // the handler untouched — no forced/injected device field.
+  it('passes input through untouched for a normal (non-helper) caller', async () => {
+    vi.mocked(db.select).mockImplementation(
+      () => deviceLookup([{ id: OWN_DEVICE, hostname: 'h', siteId: 's', status: 'online' }]) as any,
+    );
+    const input = { deviceId: OWN_DEVICE, foo: 'bar' };
+    await executeTool(PROBE, input, makeAuth()); // makeAuth() has no helperDeviceId
+    expect(handler).toHaveBeenCalledWith(input, expect.anything());
+  });
 });

--- a/apps/api/src/services/aiTools.helperScope.test.ts
+++ b/apps/api/src/services/aiTools.helperScope.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { applyHelperDeviceScope, HELPER_TOOL_SCOPING } from './aiTools';
+
+const HELPER_DEVICE = '11111111-1111-1111-1111-111111111111';
+const OTHER_DEVICE = '22222222-2222-2222-2222-222222222222';
+
+describe('applyHelperDeviceScope', () => {
+  it('forces deviceId to the helper device, overriding a forged value', () => {
+    const r = applyHelperDeviceScope('get_device_details', { deviceId: OTHER_DEVICE }, HELPER_DEVICE);
+    expect('input' in r && r.input).toEqual({ deviceId: HELPER_DEVICE });
+  });
+
+  it('injects deviceId when the caller omitted it', () => {
+    const r = applyHelperDeviceScope('analyze_metrics', {}, HELPER_DEVICE);
+    expect('input' in r && r.input).toEqual({ deviceId: HELPER_DEVICE });
+  });
+
+  it('forces deviceIds to [helperDevice] for array-shaped tools', () => {
+    const r = applyHelperDeviceScope('search_logs', { deviceIds: [OTHER_DEVICE], level: ['error'] }, HELPER_DEVICE);
+    expect('input' in r && r.input).toEqual({ deviceIds: [HELPER_DEVICE], level: ['error'] });
+  });
+
+  it('denies an org-wide tool not in the scoping map', () => {
+    const r = applyHelperDeviceScope('query_devices', {}, HELPER_DEVICE);
+    expect('error' in r).toBe(true);
+  });
+
+  it('every scoped tool maps to a known device field name', () => {
+    for (const field of Object.values(HELPER_TOOL_SCOPING)) {
+      expect(['deviceId', 'deviceIds']).toContain(field);
+    }
+  });
+});

--- a/apps/api/src/services/aiTools.helperScope.test.ts
+++ b/apps/api/src/services/aiTools.helperScope.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { applyHelperDeviceScope, HELPER_TOOL_SCOPING } from './aiTools';
+import { applyHelperDeviceScope, HELPER_TOOL_SCOPING, verifyDeviceAccess } from './aiTools';
+import type { AuthContext } from '../middleware/auth';
 
 const HELPER_DEVICE = '11111111-1111-1111-1111-111111111111';
 const OTHER_DEVICE = '22222222-2222-2222-2222-222222222222';
@@ -29,5 +30,26 @@ describe('applyHelperDeviceScope', () => {
     for (const field of Object.values(HELPER_TOOL_SCOPING)) {
       expect(['deviceId', 'deviceIds']).toContain(field);
     }
+  });
+});
+
+function helperAuth(deviceId: string): AuthContext {
+  return {
+    user: { id: deviceId, email: 'h', name: 'h', isPlatformAdmin: false },
+    token: {} as AuthContext['token'],
+    partnerId: null,
+    orgId: 'org-1',
+    scope: 'organization',
+    accessibleOrgIds: ['org-1'],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+    helperDeviceId: deviceId,
+  };
+}
+
+describe('verifyDeviceAccess helper lock', () => {
+  it('denies a device other than helperDeviceId without touching the DB', async () => {
+    const res = await verifyDeviceAccess(OTHER_DEVICE, helperAuth(HELPER_DEVICE));
+    expect('error' in res).toBe(true);
   });
 });

--- a/apps/api/src/services/aiTools.helperScope.test.ts
+++ b/apps/api/src/services/aiTools.helperScope.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { applyHelperDeviceScope, HELPER_TOOL_SCOPING, verifyDeviceAccess } from './aiTools';
+import { applyHelperDeviceScope, HELPER_TOOL_SCOPING, verifyDeviceAccess, getToolDefinitions } from './aiTools';
 import type { AuthContext } from '../middleware/auth';
 
 const HELPER_DEVICE = '11111111-1111-1111-1111-111111111111';
@@ -29,6 +29,28 @@ describe('applyHelperDeviceScope', () => {
   it('every scoped tool maps to a known device field name', () => {
     for (const field of Object.values(HELPER_TOOL_SCOPING)) {
       expect(['deviceId', 'deviceIds']).toContain(field);
+    }
+  });
+});
+
+describe('HELPER_TOOL_SCOPING <-> tool schema consistency (finding A regression guard)', () => {
+  const byName = new Map(getToolDefinitions().map((d) => [d.name, d]));
+
+  // A scoped tool whose handler does NOT take the mapped field is an org-wide
+  // tool in disguise: the gate would force a field the handler ignores, leaking
+  // org-wide data (this is exactly what get_s1_status did). Require the field
+  // to exist in the tool's input schema so a future mismatch fails CI here.
+  it('every scoped tool actually declares its mapped device field in its input schema', () => {
+    for (const [tool, field] of Object.entries(HELPER_TOOL_SCOPING)) {
+      const def = byName.get(tool);
+      expect(def, `tool '${tool}' is in HELPER_TOOL_SCOPING but is not a registered tool`).toBeTruthy();
+      const props =
+        (def!.input_schema as { properties?: Record<string, unknown> }).properties ?? {};
+      expect(
+        props[field],
+        `tool '${tool}' maps to '${field}' but its input schema has no such property — ` +
+          `the helper gate would force a field the handler ignores (org-wide data leak)`,
+      ).toBeTruthy();
     }
   });
 });

--- a/apps/api/src/services/aiTools.ts
+++ b/apps/api/src/services/aiTools.ts
@@ -246,6 +246,42 @@ export function getToolTier(toolName: string): AiToolTier | undefined {
   return aiTools.get(toolName)?.tier ?? m365ToolTiers[toolName];
 }
 
+/**
+ * Helper device-scoping (security finding A, Phase 0).
+ * Maps each tool the Breeze Helper may run to the input field naming its
+ * target device. A tool absent from this map is org-wide and is DENIED under
+ * a Helper context. The Helper's default tool set (helperToolFilter `basic`)
+ * is kept in sync with these keys.
+ */
+export const HELPER_TOOL_SCOPING: Record<string, 'deviceId' | 'deviceIds'> = {
+  get_device_details: 'deviceId',
+  analyze_metrics: 'deviceId',
+  analyze_disk_usage: 'deviceId',
+  get_cis_device_report: 'deviceId',
+  get_s1_status: 'deviceId',
+  get_security_posture: 'deviceId',
+  take_screenshot: 'deviceId',
+  analyze_screen: 'deviceId',
+  search_logs: 'deviceIds',
+};
+
+/**
+ * Force a Helper tool call onto the Helper's own device, or deny it.
+ * Pure — the caller (executeTool) applies the result.
+ */
+export function applyHelperDeviceScope(
+  toolName: string,
+  input: Record<string, unknown>,
+  helperDeviceId: string
+): { input: Record<string, unknown> } | { error: string } {
+  const field = HELPER_TOOL_SCOPING[toolName];
+  if (!field) {
+    return { error: `Tool '${toolName}' is not available in the Helper context` };
+  }
+  const value = field === 'deviceIds' ? [helperDeviceId] : helperDeviceId;
+  return { input: { ...input, [field]: value } };
+}
+
 export async function executeTool(
   toolName: string,
   input: Record<string, unknown>,
@@ -254,8 +290,17 @@ export async function executeTool(
   const tool = aiTools.get(toolName);
   if (!tool) throw new Error(`Unknown tool: ${toolName}`);
 
+  // Helper device-scope gate (finding A): force the tool onto the Helper's own
+  // device, or deny org-wide tools, before anything else runs.
+  let effectiveInput = input;
+  if (auth.helperDeviceId) {
+    const scoped = applyHelperDeviceScope(toolName, input, auth.helperDeviceId);
+    if ('error' in scoped) return JSON.stringify({ error: scoped.error });
+    effectiveInput = scoped.input;
+  }
+
   // Validate input against Zod schema before execution
-  const validation = validateToolInput(toolName, input);
+  const validation = validateToolInput(toolName, effectiveInput);
   if (!validation.success) {
     return JSON.stringify({ error: validation.error });
   }
@@ -263,8 +308,8 @@ export async function executeTool(
   // Structural device-tenant gate: any id named in `tool.deviceArgs` is
   // org+site-checked before the handler runs, so a tool can't reach a device
   // outside the caller's scope even if its handler forgets to check.
-  const gate = await enforceDeviceArgs(tool, input, auth);
+  const gate = await enforceDeviceArgs(tool, effectiveInput, auth);
   if (!gate.ok) return JSON.stringify({ error: gate.error });
 
-  return tool.handler(input, auth);
+  return tool.handler(effectiveInput, auth);
 }

--- a/apps/api/src/services/aiTools.ts
+++ b/apps/api/src/services/aiTools.ts
@@ -263,7 +263,6 @@ export const HELPER_TOOL_SCOPING: Record<string, 'deviceId' | 'deviceIds'> = {
   analyze_metrics: 'deviceId',
   analyze_disk_usage: 'deviceId',
   get_cis_device_report: 'deviceId',
-  get_s1_status: 'deviceId',
   get_security_posture: 'deviceId',
   take_screenshot: 'deviceId',
   analyze_screen: 'deviceId',

--- a/apps/api/src/services/aiTools.ts
+++ b/apps/api/src/services/aiTools.ts
@@ -93,6 +93,11 @@ export async function verifyDeviceAccess(
   auth: AuthContext,
   requireOnline = false
 ): Promise<{ device: typeof devices.$inferSelect } | { error: string }> {
+  // Helper device lock (finding A, defense-in-depth): a Helper context may only
+  // ever resolve its own device. Return before any DB access.
+  if (auth.helperDeviceId && deviceId !== auth.helperDeviceId) {
+    return { error: 'Device not found or access denied' };
+  }
   const conditions: SQL[] = [eq(devices.id, deviceId)];
   const orgCond = auth.orgCondition(devices.orgId);
   if (orgCond) conditions.push(orgCond);

--- a/apps/api/src/services/helperToolFilter.test.ts
+++ b/apps/api/src/services/helperToolFilter.test.ts
@@ -4,6 +4,7 @@ import {
   getHelperAllowedTools,
   validateHelperToolAccess,
 } from './helperToolFilter';
+import { HELPER_TOOL_SCOPING } from './aiTools';
 
 describe('helperToolFilter', () => {
   it('excludes Tier 3 computer control from standard helper access', () => {
@@ -15,5 +16,31 @@ describe('helperToolFilter', () => {
   it('keeps computer control limited to extended helper access', () => {
     expect(getHelperAllowedTools('extended')).toContain('computer_control');
     expect(validateHelperToolAccess('mcp__breeze__computer_control', 'extended')).toBeNull();
+  });
+});
+
+const MUTATING = [
+  'manage_alerts', 'manage_services', 'disk_cleanup', 'file_operations',
+  'execute_command', 'computer_control', 's1_isolate_device',
+];
+const ORG_WIDE = [
+  'query_devices', 'get_fleet_health', 'get_s1_threats', 'get_log_trends',
+  'detect_log_correlations', 'query_audit_log', 'query_change_log',
+];
+
+describe('helper basic tool set (finding A, Phase 0)', () => {
+  it('basic set is exactly the device-scoped allowlist keys', () => {
+    expect([...getHelperAllowedTools('basic')].sort())
+      .toEqual(Object.keys(HELPER_TOOL_SCOPING).sort());
+  });
+
+  it('basic set contains no mutating tools', () => {
+    const basic = getHelperAllowedTools('basic');
+    for (const t of MUTATING) expect(basic).not.toContain(t);
+  });
+
+  it('basic set contains no org-wide enumeration tools', () => {
+    const basic = getHelperAllowedTools('basic');
+    for (const t of ORG_WIDE) expect(basic).not.toContain(t);
   });
 });

--- a/apps/api/src/services/helperToolFilter.ts
+++ b/apps/api/src/services/helperToolFilter.ts
@@ -10,27 +10,21 @@
 export type HelperPermissionLevel = 'basic' | 'standard' | 'extended';
 
 const TOOL_WHITELIST: Record<HelperPermissionLevel, readonly string[]> = {
+  // Read-only single-device allowlist (security finding A, Phase 0). Kept in
+  // sync with HELPER_TOOL_SCOPING in services/aiTools.ts — every tool here is
+  // device-scoped by the executeTool gate. Org-wide enumeration and mutating
+  // tools are deliberately excluded; full capability returns under PAM
+  // governance in Phase 1.
   basic: [
-    'take_screenshot',
-    'analyze_screen',
-    'query_devices',
     'get_device_details',
     'analyze_metrics',
-    'get_active_users',
-    'get_user_experience_metrics',
-    'get_security_posture',
-    'get_cis_compliance',
-    'get_cis_device_report',
-    'get_fleet_health',
-    'get_s1_status',
-    'get_s1_threats',
-    'get_backup_health',
-    'get_recovery_readiness',
     'analyze_disk_usage',
-    'query_audit_log',
+    'get_cis_device_report',
+    'get_s1_status',
+    'get_security_posture',
+    'take_screenshot',
+    'analyze_screen',
     'search_logs',
-    'get_log_trends',
-    'query_change_log',
   ],
   standard: [
     'take_screenshot',

--- a/apps/api/src/services/helperToolFilter.ts
+++ b/apps/api/src/services/helperToolFilter.ts
@@ -20,7 +20,6 @@ const TOOL_WHITELIST: Record<HelperPermissionLevel, readonly string[]> = {
     'analyze_metrics',
     'analyze_disk_usage',
     'get_cis_device_report',
-    'get_s1_status',
     'get_security_posture',
     'take_screenshot',
     'analyze_screen',


### PR DESCRIPTION
## Security fix — HIGH (finding A, Phase 0)

Closes the local-unprivileged-user → **org-wide RMM action** escalation via the Breeze Helper token. The `helper_auth_token` lives in the world-readable `agent.yaml` (intentional — the Helper runs as the logged-in user), but it granted (a) an **org-wide** synthetic auth context and (b) the ability to **self-approve** its own tier-2/3 tool executions. Threat model: untrusted end-user.

This is **Phase 0** of the approved design spec — it closes the HIGH without depending on PR #1183 (PAM). Phase 1 (fold mutating-tool governance into PAM) is tracked separately.

## Changes
- **Central device-scope gate** (`services/aiTools.ts` `executeTool`): new `AuthContext.helperDeviceId` (set by `helperAuth`). When present, a `HELPER_TOOL_SCOPING` map **forces** each tool's device input (`deviceId`/`deviceIds`) to the Helper's own device and **denies** org-wide tools that have no device param. (Ground truth: Helper read tools don't declare `deviceArgs` — they query org-wide and self-narrow — so a `verifyDeviceAccess` lock alone was insufficient.)
- **Defense-in-depth** lock in `verifyDeviceAccess` (denies any device ≠ `helperDeviceId`).
- **Self-approve endpoint removed** (`POST /chat/sessions/:id/approve/:executionId`). Approvals can now come only from the existing authenticated `/api/v1/sessions/:id/approve/:executionId` path (real user, audited).
- **Read-only single-device default**: `DEFAULT_PERMISSION_LEVEL` → `basic`; the `basic` set is now the curated single-device allowlist (org-wide enumeration + mutating tools removed). A stolen token → read of **its own device only** + rate-limited chat.

## Tests (TDD, RED→GREEN)
`aiTools.helperScope.test.ts` (gate forces deviceId / forces deviceIds[] / injects when omitted / denies org-wide / DiD lock), `helperToolFilter.test.ts` (basic == scoping keys, no mutating/org-wide), `helperApprove.removed.test.ts` (approve route → 404). New + touched suites green; `tsc` clean on changed files.

## Spec / plan
- Spec: `docs/superpowers/specs/2026-06-10-helper-privileged-action-pam-governance-design.md`
- Plan: `docs/superpowers/plans/2026-06-10-helper-phase0-device-scope-and-approval-hardening.md`

> Found via a defensive security review. Finding A verified at confidence 9/10 against `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
