### PR TITLE
fix(portal): run portal requests in a scoped DB access context

### DIFF
--- a/apps/api/migrations/2026-06-10-b-ticket-comments-portal-insert.sql
+++ b/apps/api/migrations/2026-06-10-b-ticket-comments-portal-insert.sql
@@ -5,8 +5,9 @@
 -- scope (portalAuthMiddleware establishes a withDbAccessContext, instead of
 -- querying the bare pool with no scope). The earlier
 -- 2026-06-10-a-ticket-comments-portal-visibility.sql migration noted that
--- portal-authored WRITES were left "system-scope-only"; that assumption held
--- only while portal routes ran context-less and is now superseded here.
+-- portal-authored WRITES were left "system-scope-only"; that NOTE is superseded
+-- for INSERT only. The -a- SELECT policy is left untouched, and portal
+-- UPDATE/DELETE remain system-scope-only (the portal exposes no edit/delete).
 --
 -- Problem: a portal customer replying to their own ticket produces a
 -- portal-authored row (user_id NULL, portal_user_id set). The Phase 6

--- a/apps/api/migrations/2026-06-10-b-ticket-comments-portal-insert.sql
+++ b/apps/api/migrations/2026-06-10-b-ticket-comments-portal-insert.sql
@@ -1,0 +1,44 @@
+-- 2026-06-10-b: ticket_comments — allow portal-authored comment INSERT under
+-- the customer's organization scope.
+--
+-- Context: portal request handlers now run under the portal user's ORGANIZATION
+-- scope (portalAuthMiddleware establishes a withDbAccessContext, instead of
+-- querying the bare pool with no scope). The earlier
+-- 2026-06-10-a-ticket-comments-portal-visibility.sql migration noted that
+-- portal-authored WRITES were left "system-scope-only"; that assumption held
+-- only while portal routes ran context-less and is now superseded here.
+--
+-- Problem: a portal customer replying to their own ticket produces a
+-- portal-authored row (user_id NULL, portal_user_id set). The Phase 6
+-- user-scoped INSERT policy (breeze_user_isolation_insert) rejects it under org
+-- scope — its `user_id IS NULL` branch is gated on system scope, and the
+-- org-scoped portal request matches none of the user-id branches.
+--
+-- Fix: a SECOND permissive INSERT policy (permissive policies are OR'd with the
+-- Phase 6 one) that admits a portal-authored comment when its parent ticket is
+-- org-accessible — mirroring breeze_ticket_parent_select so write access tracks
+-- read access. Deliberately narrow: only user_id-NULL / portal_user_id-set rows
+-- on an org-accessible ticket; staff comment write rules (user-id based) are
+-- untouched, and the parent-ticket gate (breeze_has_org_access) preserves
+-- cross-org isolation. Portal UPDATE/DELETE stay closed — the portal exposes
+-- comment creation only.
+--
+-- #1016/#1026 bound-param safety: tickets.org_id is NOT NULL and the tickets
+-- SELECT policy is a flat breeze_has_org_access(org_id) with no OR branches, so
+-- the EXISTS join is safe under postgres.js bound parameters — verified through
+-- the real driver in
+-- apps/api/src/__tests__/integration/portal-routes-rls.integration.test.ts.
+--
+-- Fully idempotent — safe to re-run.
+
+DROP POLICY IF EXISTS breeze_ticket_parent_portal_insert ON ticket_comments;
+CREATE POLICY breeze_ticket_parent_portal_insert ON ticket_comments
+  FOR INSERT WITH CHECK (
+    user_id IS NULL
+    AND portal_user_id IS NOT NULL
+    AND EXISTS (
+      SELECT 1 FROM tickets t
+       WHERE t.id = ticket_comments.ticket_id
+         AND public.breeze_has_org_access(t.org_id)
+    )
+  );

--- a/apps/api/src/__tests__/integration/portal-routes-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/portal-routes-rls.integration.test.ts
@@ -16,9 +16,11 @@
  * behavior production would see — `getTestDb()` (superuser) is used for SEED only.
  */
 import './setup';
+import { createHash } from 'crypto';
 import { Hono } from 'hono';
 import { describe, expect, it } from 'vitest';
 import { portalRoutes } from '../../routes/portal';
+import { portalResetTokens } from '../../routes/portal/helpers';
 import { portalUsers, devices, portalBranding } from '../../db/schema';
 import { hashPassword } from '../../services/password';
 import { createPartner, createOrganization, createSite } from './db-utils';
@@ -216,6 +218,47 @@ describe('portal routes — scoped DB access context (breeze_app pool)', () => {
     const listAfter = await authed('/portal/assets');
     const listAfterBody = await listAfter.json();
     expect(listAfterBody.data.map((a: any) => a.id)).not.toContain(deviceId);
+  });
+
+  it('reset-password updates the portal user password under the unprivileged pool (system scope)', async () => {
+    const { orgId } = await seedOrgWithDevice('portal-reset-host');
+    const portalUser = await seedPortalUser(orgId);
+    const app = buildPortalApp();
+
+    // PORTAL_USE_REDIS is false under NODE_ENV=test, so the reset route reads
+    // the token from the in-memory map — seed it directly with a known token.
+    const resetToken = `reset-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const tokenHash = createHash('sha256').update(resetToken).digest('hex');
+    portalResetTokens.set(tokenHash, {
+      userId: portalUser.id,
+      expiresAt: new Date(Date.now() + 60_000),
+      createdAt: new Date(),
+    });
+
+    const newPassword = 'NewPortalPass456!';
+    const resetRes = await app.request('/portal/auth/reset-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: resetToken, password: newPassword }),
+    });
+    expect(resetRes.status).toBe(200);
+
+    // The UPDATE runs under withSystemDbAccessContext; without it the breeze_app
+    // pool would update zero rows and the route would still 200 (silent no-op).
+    // Prove the row actually changed: the new password logs in, the old fails.
+    const loginNew = await app.request('/portal/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: portalUser.email, password: newPassword, orgId }),
+    });
+    expect(loginNew.status).toBe(200);
+
+    const loginOld = await app.request('/portal/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: portalUser.email, password: PORTAL_PASSWORD, orgId }),
+    });
+    expect(loginOld.status).toBe(401);
   });
 
   it('profile read + update works under org scope', async () => {

--- a/apps/api/src/__tests__/integration/portal-routes-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/portal-routes-rls.integration.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Portal routes — scoped DB access context end-to-end (breeze_app pool).
+ *
+ * Portal request handlers (routes/portal/*) historically queried through the
+ * bare `db` proxy with no `withDbAccessContext`, so under the unprivileged
+ * `breeze_app` role every portal table (RLS forced, org-keyed) was queried with
+ * `breeze_current_scope() = 'none'` → `breeze_has_org_access()` false → zero
+ * rows. The companion DB-layer proof lives in
+ * `ticket-comments-rls.integration.test.ts` ("stays fail-closed without a DB
+ * access context"). This suite proves the *route layer* now establishes the
+ * right context: public pre-auth lookups (login, branding) run under system
+ * scope, and authenticated requests run under the portal user's org scope.
+ *
+ * These run through the REAL postgres.js driver (db pool connects as
+ * `breeze_app`), so a missing/incorrect context surfaces as the same empty/401
+ * behavior production would see — `getTestDb()` (superuser) is used for SEED only.
+ */
+import './setup';
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import { portalRoutes } from '../../routes/portal';
+import { portalUsers, devices, portalBranding } from '../../db/schema';
+import { hashPassword } from '../../services/password';
+import { createPartner, createOrganization, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+const PORTAL_PASSWORD = 'PortalPass123!';
+
+function buildPortalApp(): Hono {
+  const app = new Hono();
+  app.route('/portal', portalRoutes);
+  return app;
+}
+
+interface SeededOrg {
+  orgId: string;
+  siteId: string;
+  partnerId: string;
+}
+
+async function seedOrgWithDevice(hostname: string): Promise<SeededOrg & { deviceId: string }> {
+  const admin = getTestDb() as any;
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const site = await createSite({ orgId: org.id });
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  const [device] = await admin
+    .insert(devices)
+    .values({
+      orgId: org.id,
+      siteId: site.id,
+      agentId: `portal-rls-agent-${unique}`,
+      hostname,
+      displayName: hostname,
+      osType: 'windows',
+      osVersion: '11',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'online',
+    })
+    .returning();
+
+  return { orgId: org.id, siteId: site.id, partnerId: partner.id, deviceId: device.id };
+}
+
+async function seedPortalUser(orgId: string): Promise<{ id: string; email: string }> {
+  const admin = getTestDb() as any;
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const email = `portal-rls-${unique}@example.test`;
+  const passwordHash = await hashPassword(PORTAL_PASSWORD);
+  const [portalUser] = await admin
+    .insert(portalUsers)
+    .values({ orgId, email, name: 'Portal Customer', passwordHash, status: 'active' })
+    .returning();
+  return { id: portalUser.id, email: portalUser.email };
+}
+
+async function loginPortal(app: Hono, email: string, orgId: string): Promise<string> {
+  const res = await app.request('/portal/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password: PORTAL_PASSWORD, orgId }),
+  });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.accessToken).toBeTruthy();
+  return body.accessToken as string;
+}
+
+describe('portal routes — scoped DB access context (breeze_app pool)', () => {
+  it('login resolves the portal user under the unprivileged pool (public, system scope)', async () => {
+    const { orgId } = await seedOrgWithDevice('portal-login-host');
+    const portalUser = await seedPortalUser(orgId);
+    const app = buildPortalApp();
+
+    // Pre-auth lookup must run under system scope or breeze_app RLS hides the
+    // portal_users row and login always returns "Invalid email or password".
+    const token = await loginPortal(app, portalUser.email, orgId);
+    expect(token).toBeTruthy();
+  });
+
+  it('authenticated device list returns the portal user\'s org devices (protected, org scope)', async () => {
+    const { orgId, deviceId } = await seedOrgWithDevice('portal-device-host');
+    const portalUser = await seedPortalUser(orgId);
+    const app = buildPortalApp();
+
+    const token = await loginPortal(app, portalUser.email, orgId);
+    const res = await app.request('/portal/devices', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.map((d: any) => d.id)).toContain(deviceId);
+  });
+
+  it('a portal user never sees another org\'s devices (org-scope isolation, not system)', async () => {
+    const orgA = await seedOrgWithDevice('portal-orgA-host');
+    const orgB = await seedOrgWithDevice('portal-orgB-host');
+    const portalUserA = await seedPortalUser(orgA.orgId);
+    const app = buildPortalApp();
+
+    const token = await loginPortal(app, portalUserA.email, orgA.orgId);
+    const res = await app.request('/portal/devices', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const ids = body.data.map((d: any) => d.id);
+    expect(ids).toContain(orgA.deviceId);
+    expect(ids).not.toContain(orgB.deviceId);
+  });
+
+  it('public branding resolves by verified domain under the unprivileged pool (system scope)', async () => {
+    const admin = getTestDb() as any;
+    const { orgId } = await seedOrgWithDevice('portal-branding-host');
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const domain = `portal-${unique}.example.test`;
+    await admin.insert(portalBranding).values({
+      orgId,
+      customDomain: domain,
+      domainVerified: true,
+      primaryColor: '#111111',
+    });
+
+    const app = buildPortalApp();
+    const res = await app.request(`/portal/branding/${encodeURIComponent(domain)}`);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.branding.customDomain).toBe(domain);
+  });
+
+  it('ticket round-trip (create → list → detail → comment) works under org scope', async () => {
+    const { orgId } = await seedOrgWithDevice('portal-ticket-host');
+    const portalUser = await seedPortalUser(orgId);
+    const app = buildPortalApp();
+    const token = await loginPortal(app, portalUser.email, orgId);
+    const authed = (path: string, init: RequestInit = {}) =>
+      app.request(path, { ...init, headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', ...(init.headers ?? {}) } });
+
+    const createRes = await authed('/portal/tickets', {
+      method: 'POST',
+      body: JSON.stringify({ subject: 'Cannot print', description: 'The office printer is offline', priority: 'high' }),
+    });
+    expect(createRes.status).toBe(201);
+    const createBody = await createRes.json();
+    const ticketId = createBody.ticket.id;
+    expect(ticketId).toBeTruthy();
+
+    const listRes = await authed('/portal/tickets');
+    expect(listRes.status).toBe(200);
+    const listBody = await listRes.json();
+    expect(listBody.data.map((t: any) => t.id)).toContain(ticketId);
+
+    const detailRes = await authed(`/portal/tickets/${ticketId}`);
+    expect(detailRes.status).toBe(200);
+    const detailBody = await detailRes.json();
+    expect(detailBody.ticket.id).toBe(ticketId);
+
+    const commentRes = await authed(`/portal/tickets/${ticketId}/comments`, {
+      method: 'POST',
+      body: JSON.stringify({ content: 'Still not working this morning' }),
+    });
+    expect(commentRes.status).toBe(201);
+    const commentBody = await commentRes.json();
+    expect(commentBody.comment.content).toBe('Still not working this morning');
+
+    const detailAfter = await authed(`/portal/tickets/${ticketId}`);
+    const detailAfterBody = await detailAfter.json();
+    expect(detailAfterBody.ticket.comments.map((c: any) => c.id)).toContain(commentBody.comment.id);
+  });
+
+  it('asset list + checkout works under org scope', async () => {
+    const { orgId, deviceId } = await seedOrgWithDevice('portal-asset-host');
+    const portalUser = await seedPortalUser(orgId);
+    const app = buildPortalApp();
+    const token = await loginPortal(app, portalUser.email, orgId);
+    const authed = (path: string, init: RequestInit = {}) =>
+      app.request(path, { ...init, headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', ...(init.headers ?? {}) } });
+
+    const listRes = await authed('/portal/assets');
+    expect(listRes.status).toBe(200);
+    const listBody = await listRes.json();
+    expect(listBody.data.map((a: any) => a.id)).toContain(deviceId);
+
+    const checkoutRes = await authed(`/portal/assets/${deviceId}/checkout`, {
+      method: 'POST',
+      body: JSON.stringify({ checkoutNotes: 'Taking home for the weekend' }),
+    });
+    expect(checkoutRes.status).toBe(201);
+
+    // Once checked out, the device drops off the available list.
+    const listAfter = await authed('/portal/assets');
+    const listAfterBody = await listAfter.json();
+    expect(listAfterBody.data.map((a: any) => a.id)).not.toContain(deviceId);
+  });
+
+  it('profile read + update works under org scope', async () => {
+    const { orgId } = await seedOrgWithDevice('portal-profile-host');
+    const portalUser = await seedPortalUser(orgId);
+    const app = buildPortalApp();
+    const token = await loginPortal(app, portalUser.email, orgId);
+    const authed = (path: string, init: RequestInit = {}) =>
+      app.request(path, { ...init, headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', ...(init.headers ?? {}) } });
+
+    const getRes = await authed('/portal/profile');
+    expect(getRes.status).toBe(200);
+    const getBody = await getRes.json();
+    expect(getBody.user.email).toBe(portalUser.email);
+
+    const patchRes = await authed('/portal/profile', {
+      method: 'PATCH',
+      body: JSON.stringify({ name: 'Renamed Customer' }),
+    });
+    expect(patchRes.status).toBe(200);
+    const patchBody = await patchRes.json();
+    expect(patchBody.user.name).toBe('Renamed Customer');
+  });
+});

--- a/apps/api/src/__tests__/integration/ticket-comments-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticket-comments-rls.integration.test.ts
@@ -202,4 +202,82 @@ describe('ticket_comments RLS — parent-ticket visibility (2026-06-10-a migrati
 
     expect(rows).toEqual([]);
   });
+
+  // ---- breeze_ticket_parent_portal_insert (2026-06-10-b migration) ----
+  // The portal route app-filters the parent ticket by org before inserting, so
+  // a cross-org INSERT is only reachable at the DB layer. Prove the WITH CHECK
+  // gate directly through the bound-param driver, both branches.
+
+  it('allows a portal-authored comment INSERT on an org-accessible ticket under org scope', async () => {
+    const { org, portalUser, ticket } = await seedTicketWithMixedComments();
+
+    const orgContext: DbAccessContext = {
+      scope: 'organization',
+      orgId: org.id,
+      accessibleOrgIds: [org.id],
+      accessiblePartnerIds: [],
+      userId: null,
+    };
+
+    const inserted = await withDbAccessContext(orgContext, () =>
+      db
+        .insert(ticketComments)
+        .values({
+          ticketId: ticket.id,
+          portalUserId: portalUser.id,
+          authorType: 'portal',
+          content: 'customer reply inserted under org scope',
+        })
+        .returning({ id: ticketComments.id })
+    );
+
+    expect(inserted).toHaveLength(1);
+  });
+
+  it('rejects a portal-authored comment INSERT on a cross-org ticket (WITH CHECK fail-closed)', async () => {
+    const { ticket } = await seedTicketWithMixedComments(); // org A's ticket
+
+    const adminDb = getTestDb() as any;
+    const otherPartner = await createPartner();
+    const otherOrg = await createOrganization({ partnerId: otherPartner.id });
+    const [otherPortalUser] = await adminDb
+      .insert(portalUsers)
+      .values({
+        orgId: otherOrg.id,
+        email: `tc-rls-other-portal-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.test`,
+        name: 'Other Portal Customer',
+      })
+      .returning();
+
+    const otherOrgContext: DbAccessContext = {
+      scope: 'organization',
+      orgId: otherOrg.id,
+      accessibleOrgIds: [otherOrg.id],
+      accessiblePartnerIds: [],
+      userId: null,
+    };
+
+    // org-B caller attempting to comment on org-A's ticket: the parent-ticket
+    // gate (breeze_has_org_access) is false, so the row violates WITH CHECK.
+    // postgres.js surfaces the policy error on `.cause` (drizzle wraps the
+    // top-level message as "Failed query: ...").
+    let caught: unknown;
+    try {
+      await withDbAccessContext(otherOrgContext, () =>
+        db.insert(ticketComments).values({
+          ticketId: ticket.id,
+          portalUserId: otherPortalUser.id,
+          authorType: 'portal',
+          content: 'cross-org injection attempt',
+        })
+      );
+    } catch (err) {
+      caught = err;
+    }
+
+    const cause = (caught as { cause?: { message?: string } } | undefined)?.cause;
+    expect(cause?.message).toMatch(
+      /new row violates row-level security policy for table "ticket_comments"/
+    );
+  });
 });

--- a/apps/api/src/routes/portal/auth.ts
+++ b/apps/api/src/routes/portal/auth.ts
@@ -4,7 +4,7 @@ import { zValidator } from '@hono/zod-validator';
 import { and, eq } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { createHash } from 'crypto';
-import { db } from '../../db';
+import { db, withDbAccessContext, withSystemDbAccessContext } from '../../db';
 import { portalUsers } from '../../db/schema';
 import { hashPassword, isPasswordStrong, verifyPassword } from '../../services/password';
 import { getEmailService } from '../../services/email';
@@ -99,18 +99,24 @@ export async function portalAuthMiddleware(c: Context, next: Next) {
     return c.json({ error: 'Invalid or expired session' }, 401);
   }
 
-  const [user] = await db
-    .select({
-      id: portalUsers.id,
-      orgId: portalUsers.orgId,
-      email: portalUsers.email,
-      name: portalUsers.name,
-      receiveNotifications: portalUsers.receiveNotifications,
-      status: portalUsers.status
-    })
-    .from(portalUsers)
-    .where(and(eq(portalUsers.id, sessionData.portalUserId), eq(portalUsers.orgId, sessionData.orgId)))
-    .limit(1);
+  // Pre-auth hydration: the session is already validated (Redis/in-memory),
+  // but the portal_users row lives behind org-forced RLS. Run this lookup
+  // under system scope so it resolves under the unprivileged breeze_app pool —
+  // the same pattern authMiddleware uses for its pre-auth users lookup.
+  const [user] = await withSystemDbAccessContext(() =>
+    db
+      .select({
+        id: portalUsers.id,
+        orgId: portalUsers.orgId,
+        email: portalUsers.email,
+        name: portalUsers.name,
+        receiveNotifications: portalUsers.receiveNotifications,
+        status: portalUsers.status
+      })
+      .from(portalUsers)
+      .where(and(eq(portalUsers.id, sessionData.portalUserId), eq(portalUsers.orgId, sessionData.orgId)))
+      .limit(1)
+  );
 
   if (!user) {
     if (PORTAL_USE_REDIS) {
@@ -159,7 +165,29 @@ export async function portalAuthMiddleware(c: Context, next: Next) {
   }
 
   c.set('portalAuth', { user, token, authMethod });
-  return next();
+
+  // Run the protected request under the portal user's organization scope so
+  // RLS on every portal-facing table (tickets, devices, assets, profile, ...)
+  // is satisfied — and enforced — under the unprivileged breeze_app pool.
+  // Session/Redis work above stays OUTSIDE this context so the wrapping
+  // transaction is not held open across slow I/O (#1105).
+  //
+  // Handlers run INSIDE this transaction, so a nested withSystemDbAccessContext()
+  // is a no-op for scope (db/index.ts short-circuits when a context is already
+  // active) — it still runs under org scope. A handler that genuinely needs a
+  // system-scoped sub-query must do runOutsideDbContext(() =>
+  // withSystemDbAccessContext(...)) explicitly. Likewise, any un-awaited db.*
+  // side effect must not capture this txn (mirror auditService's pattern).
+  return withDbAccessContext(
+    {
+      scope: 'organization',
+      orgId: user.orgId,
+      accessibleOrgIds: [user.orgId],
+      accessiblePartnerIds: [],
+      userId: null,
+    },
+    () => next()
+  );
 }
 
 // ============================================
@@ -183,23 +211,28 @@ authRoutes.post('/auth/login', zValidator('json', loginSchema), async (c) => {
     }
   }
 
-  const userRows = await db
-    .select({
-      id: portalUsers.id,
-      orgId: portalUsers.orgId,
-      email: portalUsers.email,
-      name: portalUsers.name,
-      passwordHash: portalUsers.passwordHash,
-      receiveNotifications: portalUsers.receiveNotifications,
-      status: portalUsers.status
-    })
-    .from(portalUsers)
-    .where(
-      orgId
-        ? and(eq(portalUsers.orgId, orgId), eq(portalUsers.email, normalizedEmail))
-        : eq(portalUsers.email, normalizedEmail)
-    )
-    .limit(orgId ? 1 : 2);
+  // Pre-auth credential lookup resolves a portal user by email (optionally
+  // scoped by orgId) before any tenant context exists — run under system scope
+  // so org-forced RLS doesn't hide the row under the breeze_app pool.
+  const userRows = await withSystemDbAccessContext(() =>
+    db
+      .select({
+        id: portalUsers.id,
+        orgId: portalUsers.orgId,
+        email: portalUsers.email,
+        name: portalUsers.name,
+        passwordHash: portalUsers.passwordHash,
+        receiveNotifications: portalUsers.receiveNotifications,
+        status: portalUsers.status
+      })
+      .from(portalUsers)
+      .where(
+        orgId
+          ? and(eq(portalUsers.orgId, orgId), eq(portalUsers.email, normalizedEmail))
+          : eq(portalUsers.email, normalizedEmail)
+      )
+      .limit(orgId ? 1 : 2)
+  );
 
   if (!orgId && userRows.length > 1) {
     return c.json({ error: 'Multiple portal accounts found for this email. Please provide organization context.' }, 400);
@@ -267,10 +300,12 @@ authRoutes.post('/auth/login', zValidator('json', loginSchema), async (c) => {
     capMapByOldest(portalSessions, PORTAL_SESSION_CAP, (session) => session.createdAt.getTime());
   }
 
-  await db
-    .update(portalUsers)
-    .set({ lastLoginAt: now, updatedAt: now })
-    .where(eq(portalUsers.id, user.id));
+  await withSystemDbAccessContext(() =>
+    db
+      .update(portalUsers)
+      .set({ lastLoginAt: now, updatedAt: now })
+      .where(eq(portalUsers.id, user.id))
+  );
 
   const resolvedAccountRateKey = `portal:login:account:${user.orgId}:${normalizedEmail}`;
   await clearRateLimitKeys([ipRateKey, accountRateKey, resolvedAccountRateKey]);
@@ -310,15 +345,17 @@ authRoutes.post('/auth/forgot-password', zValidator('json', forgotPasswordSchema
     return c.json({ error: 'Service temporarily unavailable' }, 503);
   }
 
-  const [user] = await db
-    .select({ id: portalUsers.id, email: portalUsers.email, orgId: portalUsers.orgId })
-    .from(portalUsers)
-    .where(
-      orgId
-        ? and(eq(portalUsers.orgId, orgId), eq(portalUsers.email, normalizedEmail))
-        : eq(portalUsers.email, normalizedEmail)
-    )
-    .limit(1);
+  const [user] = await withSystemDbAccessContext(() =>
+    db
+      .select({ id: portalUsers.id, email: portalUsers.email, orgId: portalUsers.orgId })
+      .from(portalUsers)
+      .where(
+        orgId
+          ? and(eq(portalUsers.orgId, orgId), eq(portalUsers.email, normalizedEmail))
+          : eq(portalUsers.email, normalizedEmail)
+      )
+      .limit(1)
+  );
 
   if (user) {
     const resetToken = nanoid(48);
@@ -418,10 +455,12 @@ authRoutes.post('/auth/reset-password', zValidator('json', resetPasswordSchema),
   const passwordHash = await hashPassword(password);
   const now = new Date();
 
-  await db
-    .update(portalUsers)
-    .set({ passwordHash, updatedAt: now })
-    .where(eq(portalUsers.id, storedUserId));
+  await withSystemDbAccessContext(() =>
+    db
+      .update(portalUsers)
+      .set({ passwordHash, updatedAt: now })
+      .where(eq(portalUsers.id, storedUserId))
+  );
 
   await clearRateLimitKeys([ipRateKey, tokenRateKey]);
 

--- a/apps/api/src/routes/portal/branding.ts
+++ b/apps/api/src/routes/portal/branding.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { eq } from 'drizzle-orm';
-import { db } from '../../db';
+import { db, withSystemDbAccessContext } from '../../db';
 import { portalBranding } from '../../db/schema';
 import { brandingParamSchema } from './schemas';
 import { applyPortalCacheHeaders, buildWeakEtag, isEtagFresh } from './helpers';
@@ -14,30 +14,35 @@ async function resolveBrandingByDomain(domain: string) {
     return null;
   }
 
-  const [branding] = await db
-    .select({
-      id: portalBranding.id,
-      orgId: portalBranding.orgId,
-      logoUrl: portalBranding.logoUrl,
-      faviconUrl: portalBranding.faviconUrl,
-      primaryColor: portalBranding.primaryColor,
-      secondaryColor: portalBranding.secondaryColor,
-      accentColor: portalBranding.accentColor,
-      customDomain: portalBranding.customDomain,
-      domainVerified: portalBranding.domainVerified,
-      welcomeMessage: portalBranding.welcomeMessage,
-      supportEmail: portalBranding.supportEmail,
-      supportPhone: portalBranding.supportPhone,
-      footerText: portalBranding.footerText,
-      customCss: portalBranding.customCss,
-      enableTickets: portalBranding.enableTickets,
-      enableAssetCheckout: portalBranding.enableAssetCheckout,
-      enableSelfService: portalBranding.enableSelfService,
-      enablePasswordReset: portalBranding.enablePasswordReset
-    })
-    .from(portalBranding)
-    .where(eq(portalBranding.customDomain, normalizedDomain))
-    .limit(1);
+  // Public, pre-auth lookup by custom domain — no tenant context exists yet,
+  // so run under system scope or portal_branding's org-forced RLS hides every
+  // row under the unprivileged breeze_app pool.
+  const [branding] = await withSystemDbAccessContext(() =>
+    db
+      .select({
+        id: portalBranding.id,
+        orgId: portalBranding.orgId,
+        logoUrl: portalBranding.logoUrl,
+        faviconUrl: portalBranding.faviconUrl,
+        primaryColor: portalBranding.primaryColor,
+        secondaryColor: portalBranding.secondaryColor,
+        accentColor: portalBranding.accentColor,
+        customDomain: portalBranding.customDomain,
+        domainVerified: portalBranding.domainVerified,
+        welcomeMessage: portalBranding.welcomeMessage,
+        supportEmail: portalBranding.supportEmail,
+        supportPhone: portalBranding.supportPhone,
+        footerText: portalBranding.footerText,
+        customCss: portalBranding.customCss,
+        enableTickets: portalBranding.enableTickets,
+        enableAssetCheckout: portalBranding.enableAssetCheckout,
+        enableSelfService: portalBranding.enableSelfService,
+        enablePasswordReset: portalBranding.enablePasswordReset
+      })
+      .from(portalBranding)
+      .where(eq(portalBranding.customDomain, normalizedDomain))
+      .limit(1)
+  );
 
   if (!branding || !branding.domainVerified) {
     return null;

--- a/apps/api/src/routes/portal/tickets.ts
+++ b/apps/api/src/routes/portal/tickets.ts
@@ -85,6 +85,10 @@ ticketRoutes.post('/tickets', zValidator('json', createTicketSchema), async (c) 
 
   let created: Awaited<ReturnType<typeof createTicket>>;
   try {
+    // NOTE: the actor `userId` here is a portal_users id, NOT a users.id. The
+    // ticket service only uses it for audit/event metadata (no FK). It must
+    // never be routed into a column that FKs users.id (e.g.
+    // ticket_comments.user_id) — portal comments set portal_user_id instead.
     created = await createTicket(
       {
         orgId: auth.user.orgId,
@@ -244,6 +248,13 @@ ticketRoutes.post(
         createdAt: ticketComments.createdAt
       });
     if (!comment) {
+      // Near-impossible (an insert that neither throws nor returns a row), but
+      // every other failure on this route flows through onError+Sentry — make
+      // this branch visible too rather than returning a silent 500.
+      console.error('[portal] ticket_comments insert returned no row', {
+        ticketId: ticket.id,
+        orgId: auth.user.orgId,
+      });
       return c.json({ error: 'Failed to create ticket comment' }, 500);
     }
 

--- a/apps/api/src/routes/portal/tickets.ts
+++ b/apps/api/src/routes/portal/tickets.ts
@@ -87,8 +87,10 @@ ticketRoutes.post('/tickets', zValidator('json', createTicketSchema), async (c) 
   try {
     // NOTE: the actor `userId` here is a portal_users id, NOT a users.id. The
     // ticket service only uses it for audit/event metadata (no FK). It must
-    // never be routed into a column that FKs users.id (e.g.
-    // ticket_comments.user_id) — portal comments set portal_user_id instead.
+    // never be routed into a column that FKs users.id — in particular, do NOT
+    // call addTicketComment from portal handlers (it writes actor.userId →
+    // ticket_comments.user_id). Portal comments set portal_user_id directly
+    // (see the POST /tickets/:id/comments handler below).
     created = await createTicket(
       {
         orgId: auth.user.orgId,


### PR DESCRIPTION
Portal route handlers now run inside the scoped DB access context (consistent with the rest of the API's request path), with a follow-up migration for the ticket-comments portal insert policy and real-driver integration coverage: portal routes RLS behavior, cross-org comment-insert denial, and reset-password scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)