### PR TITLE
fix(agent): helper downgrade fail-closed when version unreadable (post-merge follow-up to #1198)

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -2322,7 +2322,7 @@ func (h *Heartbeat) sendHeartbeat() {
 	// Handle helper upgrade if requested
 	if response.HelperUpgradeTo != "" {
 		installedHelper := h.helperMgr.InstalledVersion()
-		if allowed, reason := helperUpgradeAllowed(response.HelperUpgradeTo, installedHelper); !allowed {
+		if allowed, reason := helperUpgradeAllowed(response.HelperUpgradeTo, installedHelper, h.helperMgr.IsInstalled()); !allowed {
 			// SECURITY: never auto-downgrade the helper. The signed manifest
 			// only binds manifest.Release == requested version, so a
 			// compromised/MITM'd control plane could replay an older,

--- a/agent/internal/heartbeat/version_downgrade.go
+++ b/agent/internal/heartbeat/version_downgrade.go
@@ -63,13 +63,21 @@ func isDowngrade(target, current string) bool {
 // unparseable installed version means we cannot prove the directive isn't
 // a downgrade replay.
 //
-// An empty installed version means the helper isn't installed yet — that is
-// a fresh install, not a downgrade, so it is allowed.
-func helperUpgradeAllowed(target, installed string) (allowed bool, reason string) {
+// An empty installed version is only treated as a fresh install (allowed)
+// when the helper binary is genuinely absent from disk (installedOnDisk
+// false). If the binary IS on disk but its version is unreadable — e.g. no
+// user session has written a status file yet, or a status read failed — we
+// must FAIL CLOSED: an attacker-replayed older signed release could otherwise
+// be installed during that window. Distinguishing "absent" from "present but
+// version unknown" is the caller's job (helper.Manager.IsInstalled()).
+func helperUpgradeAllowed(target, installed string, installedOnDisk bool) (allowed bool, reason string) {
 	if _, _, _, ok := parseSemver(target); !ok {
 		return false, "target version is not a parseable semver"
 	}
 	if strings.TrimSpace(installed) == "" {
+		if installedOnDisk {
+			return false, "helper present on disk but installed version is unreadable; cannot rule out downgrade replay"
+		}
 		// Helper not installed yet — fresh install, not a downgrade.
 		return true, ""
 	}

--- a/agent/internal/heartbeat/version_downgrade_test.go
+++ b/agent/internal/heartbeat/version_downgrade_test.go
@@ -36,51 +36,58 @@ func TestIsDowngrade(t *testing.T) {
 
 func TestHelperUpgradeAllowed(t *testing.T) {
 	cases := []struct {
-		name        string
-		target      string
-		installed   string
-		wantAllowed bool
-		wantReason  bool // expect a non-empty refusal reason
+		name            string
+		target          string
+		installed       string
+		installedOnDisk bool
+		wantAllowed     bool
+		wantReason      bool // expect a non-empty refusal reason
 	}{
 		// Downgrades refused (the MUST-FIX: replayed older signed release).
-		{"downgrade patch refused", "0.68.1", "0.68.2", false, true},
-		{"downgrade minor refused", "0.67.9", "0.68.0", false, true},
-		{"downgrade major refused", "0.99.9", "1.0.0", false, true},
-		{"v-prefix downgrade refused", "v0.68.1", "0.68.2", false, true},
+		{name: "downgrade patch refused", target: "0.68.1", installed: "0.68.2", installedOnDisk: true, wantAllowed: false, wantReason: true},
+		{name: "downgrade minor refused", target: "0.67.9", installed: "0.68.0", installedOnDisk: true, wantAllowed: false, wantReason: true},
+		{name: "downgrade major refused", target: "0.99.9", installed: "1.0.0", installedOnDisk: true, wantAllowed: false, wantReason: true},
+		{name: "v-prefix downgrade refused", target: "v0.68.1", installed: "0.68.2", installedOnDisk: true, wantAllowed: false, wantReason: true},
 
 		// Upgrades allowed.
-		{"upgrade patch allowed", "0.68.3", "0.68.2", true, false},
-		{"upgrade minor allowed", "0.69.0", "0.68.9", true, false},
-		{"upgrade major allowed", "1.0.0", "0.99.9", true, false},
-		{"v-prefix upgrade allowed", "v0.69.0", "v0.68.2", true, false},
+		{name: "upgrade patch allowed", target: "0.68.3", installed: "0.68.2", installedOnDisk: true, wantAllowed: true, wantReason: false},
+		{name: "upgrade minor allowed", target: "0.69.0", installed: "0.68.9", installedOnDisk: true, wantAllowed: true, wantReason: false},
+		{name: "upgrade major allowed", target: "1.0.0", installed: "0.99.9", installedOnDisk: true, wantAllowed: true, wantReason: false},
+		{name: "v-prefix upgrade allowed", target: "v0.69.0", installed: "v0.68.2", installedOnDisk: true, wantAllowed: true, wantReason: false},
 
 		// Equal version allowed through (CheckUpdate/applyPendingUpdate
 		// already no-op when installed == target).
-		{"same version allowed", "0.68.2", "0.68.2", true, false},
+		{name: "same version allowed", target: "0.68.2", installed: "0.68.2", installedOnDisk: true, wantAllowed: true, wantReason: false},
 
-		// Fresh install: no helper installed yet — not a downgrade.
-		{"fresh install empty installed allowed", "0.68.2", "", true, false},
-		{"fresh install whitespace installed allowed", "0.68.2", "   ", true, false},
+		// Fresh install: no helper installed yet (not on disk) — not a downgrade.
+		{name: "fresh install empty installed allowed", target: "0.68.2", installed: "", installedOnDisk: false, wantAllowed: true, wantReason: false},
+		{name: "fresh install whitespace installed allowed", target: "0.68.2", installed: "   ", installedOnDisk: false, wantAllowed: true, wantReason: false},
+
+		// SECURITY (the fix): helper present on disk but version unreadable.
+		// Empty version + on-disk must FAIL CLOSED — we cannot prove the
+		// directive isn't a downgrade replay.
+		{name: "on-disk but version unreadable refused", target: "0.68.2", installed: "", installedOnDisk: true, wantAllowed: false, wantReason: true},
+		{name: "on-disk but version whitespace refused", target: "0.68.2", installed: "   ", installedOnDisk: true, wantAllowed: false, wantReason: true},
 
 		// Malformed versions fail closed (unlike agent-path isDowngrade).
-		{"malformed target refused", "dev", "0.68.2", false, true},
-		{"empty target refused", "", "0.68.2", false, true},
-		{"two-part target refused", "0.68", "0.68.2", false, true},
-		{"malformed installed refused", "0.68.3", "dev", false, true},
-		{"both malformed refused", "dev", "dev", false, true},
+		{name: "malformed target refused", target: "dev", installed: "0.68.2", installedOnDisk: true, wantAllowed: false, wantReason: true},
+		{name: "empty target refused", target: "", installed: "0.68.2", installedOnDisk: true, wantAllowed: false, wantReason: true},
+		{name: "two-part target refused", target: "0.68", installed: "0.68.2", installedOnDisk: true, wantAllowed: false, wantReason: true},
+		{name: "malformed installed refused", target: "0.68.3", installed: "dev", installedOnDisk: true, wantAllowed: false, wantReason: true},
+		{name: "both malformed refused", target: "dev", installed: "dev", installedOnDisk: true, wantAllowed: false, wantReason: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			allowed, reason := helperUpgradeAllowed(tc.target, tc.installed)
+			allowed, reason := helperUpgradeAllowed(tc.target, tc.installed, tc.installedOnDisk)
 			if allowed != tc.wantAllowed {
-				t.Fatalf("helperUpgradeAllowed(%q, %q) allowed = %v, want %v (reason=%q)",
-					tc.target, tc.installed, allowed, tc.wantAllowed, reason)
+				t.Fatalf("helperUpgradeAllowed(%q, %q, %v) allowed = %v, want %v (reason=%q)",
+					tc.target, tc.installed, tc.installedOnDisk, allowed, tc.wantAllowed, reason)
 			}
 			if tc.wantReason && reason == "" {
-				t.Fatalf("helperUpgradeAllowed(%q, %q) refused without a reason", tc.target, tc.installed)
+				t.Fatalf("helperUpgradeAllowed(%q, %q, %v) refused without a reason", tc.target, tc.installed, tc.installedOnDisk)
 			}
 			if !tc.wantReason && reason != "" {
-				t.Fatalf("helperUpgradeAllowed(%q, %q) allowed but returned reason %q", tc.target, tc.installed, reason)
+				t.Fatalf("helperUpgradeAllowed(%q, %q, %v) allowed but returned reason %q", tc.target, tc.installed, tc.installedOnDisk, reason)
 			}
 		})
 	}

--- a/agent/internal/helper/manager.go
+++ b/agent/internal/helper/manager.go
@@ -490,6 +490,13 @@ func (m *Manager) isInstalled() bool {
 	return err == nil
 }
 
+// IsInstalled reports whether the helper binary is present on disk. Exported
+// so the heartbeat downgrade guard can distinguish "not installed" from
+// "installed but version unreadable" (the latter must fail closed).
+func (m *Manager) IsInstalled() bool {
+	return m.isInstalled()
+}
+
 // downloadAndInstall downloads, INTEGRITY-VERIFIES, and installs the
 // platform-appropriate helper package for the given target version.
 //


### PR DESCRIPTION
## Post-merge follow-up to #1198

The PR-review fix for #1198 was pushed to the branch **after** #1198 had already merged, so it did not land in `main`. This re-applies it.

**Finding:** `helperUpgradeAllowed` treated an empty installed version as "fresh install → allow", but `InstalledVersion()` returns `""` when the helper binary is present on disk yet its version is unreadable (no user session has written a status file, or a status read failed). In that window a compromised/MITM control plane could replay an older, validly-signed helper release.

**Fix:** add an `installedOnDisk` param (wired from the new `Manager.IsInstalled()`); empty version + on-disk now fails closed. Primary signed-manifest + SHA-256 verification (from #1198) is unchanged — this hardens the secondary downgrade-replay guard to match its own documented fail-closed contract.

Tests: `version_downgrade_test.go` gains the on-disk-but-unreadable cases; Go heartbeat suite green.

> Surfaced by the pr-review-toolkit pass over the security PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
