### PR TITLE
feat(pam): Phase 1 — Helper privileged-action governance via PAM (finding A)

### DIFF
--- a/apps/api/migrations/2026-06-10-a-elevation-flow-type-ai-tool-action.sql
+++ b/apps/api/migrations/2026-06-10-a-elevation-flow-type-ai-tool-action.sql
@@ -1,0 +1,9 @@
+-- 2026-06-10-a-elevation-flow-type-ai-tool-action.sql
+--
+-- Phase 1 of Helper privileged-action governance (security finding A):
+-- Helper AI tool actions become PAM elevation requests. The enum value is
+-- added in its own migration file because the -b- file's CHECK constraint
+-- references it, and PG forbids using a new enum value in the transaction
+-- that added it ("unsafe use of new value of enum type"). autoMigrate wraps
+-- each file in one transaction, so the file split is the transaction split.
+ALTER TYPE elevation_flow_type ADD VALUE IF NOT EXISTS 'ai_tool_action';

--- a/apps/api/migrations/2026-06-10-b-helper-tool-action-elevations.sql
+++ b/apps/api/migrations/2026-06-10-b-helper-tool-action-elevations.sql
@@ -1,0 +1,44 @@
+-- 2026-06-10-b-helper-tool-action-elevations.sql
+--
+-- Phase 1 (Helper tool-action governance, spec 2026-06-10):
+--   * elevation_requests gains the ai_tool_action shape: execution_id links
+--     the PAM decision back to ai_tool_executions (the gate waitForApproval
+--     polls), plus tool_name / action_digest / risk_tier.
+--   * pam_rules gains tool-action match criteria (match_tool_name,
+--     match_risk_tier) so org/site policy can auto_approve / auto_deny /
+--     require_approval specific Helper tools.
+-- No RLS changes: both tables are already Shape-1 org-scoped; new columns
+-- inherit the existing policies.
+
+-- elevation_requests: ai_tool_action columns ------------------------------
+ALTER TABLE elevation_requests
+  ADD COLUMN IF NOT EXISTS execution_id uuid REFERENCES ai_tool_executions(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS tool_name varchar(100),
+  ADD COLUMN IF NOT EXISTS action_digest varchar(64),
+  ADD COLUMN IF NOT EXISTS risk_tier smallint;
+
+-- Mirror-lookup hot path: /respond resolves execution_id for ai_tool_action rows.
+CREATE INDEX IF NOT EXISTS elevation_requests_execution_id_idx
+  ON elevation_requests (execution_id)
+  WHERE execution_id IS NOT NULL;
+
+-- Re-create the flow-shape constraint with the third branch. Note:
+-- execution_id is deliberately NOT required by the constraint — its FK is
+-- ON DELETE SET NULL, so requiring it would make ai_tool_executions rows
+-- undeletable underneath historical elevations.
+ALTER TABLE elevation_requests
+  DROP CONSTRAINT IF EXISTS elevation_requests_flow_shape_chk;
+ALTER TABLE elevation_requests
+  ADD CONSTRAINT elevation_requests_flow_shape_chk
+  CHECK (
+    (flow_type = 'tech_jit_admin' AND subject_user_id IS NOT NULL)
+    OR
+    (flow_type = 'uac_intercept' AND target_executable_path IS NOT NULL)
+    OR
+    (flow_type = 'ai_tool_action' AND tool_name IS NOT NULL)
+  );
+
+-- pam_rules: tool-action match criteria -----------------------------------
+ALTER TABLE pam_rules
+  ADD COLUMN IF NOT EXISTS match_tool_name varchar(100),
+  ADD COLUMN IF NOT EXISTS match_risk_tier smallint;

--- a/apps/api/src/db/schema/elevations.ts
+++ b/apps/api/src/db/schema/elevations.ts
@@ -5,6 +5,7 @@ import {
   jsonb,
   pgEnum,
   pgTable,
+  smallint,
   text,
   timestamp,
   unique,
@@ -16,14 +17,18 @@ import { users } from './users';
 import { devices } from './devices';
 import { approvalRequests } from './approvals';
 import { softwarePolicies } from './softwarePolicies';
+import { aiToolExecutions } from './ai';
 
 // PAM Track 1: privileged access management.
 //
-// Two flows on one table, distinguished by `flow_type`:
+// Three flows on one table, distinguished by `flow_type`:
 //   * uac_intercept  — end-user UAC prompt captured by the agent, requests
 //                      temporary admin via Breeze policy.
 //   * tech_jit_admin — technician-initiated just-in-time admin grant against
 //                      a device they're managing.
+//   * ai_tool_action — a governed (tier>=2) Breeze Helper AI tool invocation
+//                      (Phase 1 of security finding A, spec 2026-06-10);
+//                      links back to ai_tool_executions via execution_id.
 //
 // Tenancy Shape 1: direct `org_id` column. site_id / partner_id are
 // denormalized for ops queries (mirrors devices.ts). RLS policies key on
@@ -32,6 +37,7 @@ import { softwarePolicies } from './softwarePolicies';
 export const elevationFlowTypeEnum = pgEnum('elevation_flow_type', [
   'uac_intercept',
   'tech_jit_admin',
+  'ai_tool_action',
 ]);
 
 // Distinct from approval_status — adds auto_approved (allowlist hit, no
@@ -122,6 +128,16 @@ export const elevationRequests = pgTable(
       () => softwarePolicies.id,
       { onDelete: 'set null' },
     ),
+
+    // ai_tool_action flow (Phase 1, spec 2026-06-10): links the PAM decision
+    // back to the AI tool gate. ON DELETE SET NULL — historical elevations
+    // outlive their execution rows; flow_shape_chk requires tool_name only.
+    executionId: uuid('execution_id').references(() => aiToolExecutions.id, {
+      onDelete: 'set null',
+    }),
+    toolName: varchar('tool_name', { length: 100 }),
+    actionDigest: varchar('action_digest', { length: 64 }),
+    riskTier: smallint('risk_tier'),
 
     // Session info, set by the agent once the grant is exercised.
     sessionStartedAt: timestamp('session_started_at', { withTimezone: true }),

--- a/apps/api/src/db/schema/pam.ts
+++ b/apps/api/src/db/schema/pam.ts
@@ -17,6 +17,7 @@ import {
   jsonb,
   pgEnum,
   pgTable,
+  smallint,
   text,
   timestamp,
   uuid,
@@ -69,6 +70,11 @@ export const pamRules = pgTable(
     matchParentImage: text('match_parent_image'),
     matchUser: varchar('match_user', { length: 255 }),
     matchAdGroup: varchar('match_ad_group', { length: 255 }),
+    // Tool-action criteria (Phase 1 Helper governance). A rule is either
+    // executable-shaped (signer/hash/path/parent) or tool-action-shaped
+    // (tool name / risk tier) — the API layer rejects mixing the two.
+    matchToolName: varchar('match_tool_name', { length: 100 }),
+    matchRiskTier: smallint('match_risk_tier'),
     timeWindow: jsonb('time_window').$type<PamRuleTimeWindow | null>(),
 
     verdict: pamRuleVerdictEnum('verdict').notNull(),

--- a/apps/api/src/routes/pam.test.ts
+++ b/apps/api/src/routes/pam.test.ts
@@ -44,6 +44,7 @@ vi.mock('../db/schema', () => ({
     requestedAt: 'requestedAt',
     approvedAt: 'approvedAt',
     expiresAt: 'expiresAt',
+    executionId: 'executionId',
   },
   elevationAudit: { id: 'id' },
   pamRules: {
@@ -52,6 +53,7 @@ vi.mock('../db/schema', () => ({
     priority: 'priority',
     createdAt: 'createdAt',
   },
+  aiToolExecutions: { id: 'id', status: 'status' },
 }));
 
 vi.mock('../services/auditEvents', () => ({
@@ -91,12 +93,15 @@ function setAuth() {
 interface TxRigOptions {
   row?: Record<string, unknown> | null;
   casWins?: boolean;
+  /** Whether the ai_tool_action execution mirror CAS flips a row (default true). */
+  mirrorWins?: boolean;
 }
 
 function rigTransaction(opts: TxRigOptions) {
   const updateSetCalls: unknown[] = [];
   const auditInserts: unknown[] = [];
   vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
+    let updateCallCount = 0;
     const tx = {
       select: vi.fn(() => ({
         from: vi.fn(() => ({
@@ -105,20 +110,23 @@ function rigTransaction(opts: TxRigOptions) {
           })),
         })),
       })),
-      update: vi.fn(() => ({
-        set: vi.fn((setArg: unknown) => {
-          updateSetCalls.push(setArg);
-          return {
-            where: vi.fn(() => ({
-              returning: vi
-                .fn()
-                .mockResolvedValue(
-                  opts.casWins ? [{ id: REQ_ID, status: 'approved' }] : [],
-                ),
-            })),
-          };
-        }),
-      })),
+      update: vi.fn(() => {
+        updateCallCount += 1;
+        const isMirror = updateCallCount > 1;
+        const wins = isMirror ? (opts.mirrorWins ?? true) : opts.casWins;
+        return {
+          set: vi.fn((setArg: unknown) => {
+            updateSetCalls.push(setArg);
+            return {
+              where: vi.fn(() => ({
+                returning: vi
+                  .fn()
+                  .mockResolvedValue(wins ? [{ id: REQ_ID, status: 'approved' }] : []),
+              })),
+            };
+          }),
+        };
+      }),
       insert: vi.fn(() => ({
         values: vi.fn((v: unknown) => {
           auditInserts.push(v);
@@ -298,6 +306,61 @@ describe('POST /pam/rules', () => {
     expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
   });
 
+  it('creates a tool-action rule (matchToolName only)', async () => {
+    const returning = vi.fn().mockResolvedValue([
+      { id: 'rule-2', name: 'govern services', verdict: 'require_approval', priority: 100 },
+    ]);
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn(() => ({ returning })),
+    } as any);
+
+    const res = await app().request('/pam/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'govern services',
+        verdict: 'require_approval',
+        matchToolName: 'manage_services',
+        matchRiskTier: 2,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const valuesArg = (vi.mocked(db.insert).mock.results[0]!.value.values as any).mock
+      .calls[0][0] as { matchToolName: string; matchRiskTier: number };
+    expect(valuesArg.matchToolName).toBe('manage_services');
+    expect(valuesArg.matchRiskTier).toBe(2);
+  });
+
+  it('rejects a rule mixing executable and tool-action criteria (400)', async () => {
+    const res = await app().request('/pam/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'mixed rule',
+        verdict: 'auto_approve',
+        matchHash: 'a'.repeat(64),
+        matchToolName: 'manage_services',
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+  });
+
+  it("rejects verdict 'ignore' on a tool-action rule (400)", async () => {
+    const res = await app().request('/pam/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'ignore tool rule',
+        verdict: 'ignore',
+        matchToolName: 'manage_services',
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+  });
+
   it('creates a rule with a criterion and lowercases the hash', async () => {
     const returning = vi.fn().mockResolvedValue([
       { id: 'rule-1', name: 'allow tool', verdict: 'auto_approve', priority: 100 },
@@ -321,5 +384,174 @@ describe('POST /pam/rules', () => {
       .calls[0][0] as { matchHash: string; orgId: string };
     expect(valuesArg.matchHash).toBe('a'.repeat(64));
     expect(valuesArg.orgId).toBe(ORG_ID);
+  });
+});
+
+describe('ai_tool_action elevation requests (Phase 1)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setAuth();
+    busMocks.publishEvent.mockResolvedValue('evt');
+  });
+
+  const toolActionRow = {
+    id: REQ_ID,
+    orgId: ORG_ID,
+    siteId: null,
+    deviceId: 'dev-1',
+    flowType: 'ai_tool_action',
+    status: 'pending',
+    executionId: 'exec-1',
+  };
+
+  function mockListSelect(rows: unknown[] = [], total = 0) {
+    vi.mocked(db.select).mockImplementation(((sel: Record<string, unknown> | undefined) => {
+      const isCount = Boolean(sel && 'total' in sel);
+      const chain: any = Promise.resolve(isCount ? [{ total }] : rows);
+      chain.from = vi.fn(() => chain);
+      chain.leftJoin = vi.fn(() => chain);
+      chain.where = vi.fn(() => chain);
+      chain.orderBy = vi.fn(() => chain);
+      chain.limit = vi.fn(() => chain);
+      chain.offset = vi.fn(() => chain);
+      return chain;
+    }) as any);
+  }
+
+  it('accepts flowType=ai_tool_action on the list filter', async () => {
+    mockListSelect([], 0);
+    const res = await app().request('/pam/elevation-requests?flowType=ai_tool_action');
+    expect(res.status).toBe(200);
+  });
+
+  it('still rejects unknown flowType values', async () => {
+    mockListSelect([], 0);
+    const res = await app().request('/pam/elevation-requests?flowType=bogus');
+    expect(res.status).toBe(400);
+  });
+
+  it('approve mirrors the linked execution to approved in the same transaction', async () => {
+    const { updateSetCalls } = rigTransaction({ row: toolActionRow, casWins: true, mirrorWins: true });
+
+    const res = await app().request(`/pam/elevation-requests/${REQ_ID}/respond`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ decision: 'approve' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(updateSetCalls.length).toBe(2);
+    const mirrorSet = updateSetCalls[1] as { status: string; approvedBy: string };
+    expect(mirrorSet.status).toBe('approved');
+    expect(mirrorSet.approvedBy).toBe(USER_ID);
+  });
+
+  it('deny mirrors the linked execution to rejected', async () => {
+    const { updateSetCalls } = rigTransaction({ row: toolActionRow, casWins: true, mirrorWins: true });
+
+    const res = await app().request(`/pam/elevation-requests/${REQ_ID}/respond`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ decision: 'deny', reason: 'not on my watch' }),
+    });
+
+    expect(res.status).toBe(200);
+    const mirrorSet = updateSetCalls[1] as { status: string };
+    expect(mirrorSet.status).toBe('rejected');
+  });
+
+  it('409s (and rolls back) when the linked execution is no longer pending', async () => {
+    rigTransaction({ row: toolActionRow, casWins: true, mirrorWins: false });
+
+    const res = await app().request(`/pam/elevation-requests/${REQ_ID}/respond`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ decision: 'approve' }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(busMocks.publishEvent).not.toHaveBeenCalled();
+  });
+
+  it('uac_intercept respond never touches the execution mirror', async () => {
+    const { updateSetCalls } = rigTransaction({ row: activeRow, casWins: true });
+
+    const res = await app().request(`/pam/elevation-requests/${REQ_ID}/respond`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ decision: 'approve' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(updateSetCalls.length).toBe(1);
+  });
+});
+
+describe('PATCH /pam/rules/:id shape validation (Phase 1)', () => {
+  const RULE_ID = '7b41c9a2-0000-4000-8000-000000000009';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setAuth();
+  });
+
+  function mockExistingRule(rule: Record<string, unknown>) {
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn().mockResolvedValue([rule]),
+        })),
+      })),
+    } as any);
+  }
+
+  const toolRule = {
+    id: RULE_ID,
+    orgId: ORG_ID,
+    name: 'tool rule',
+    matchSigner: null,
+    matchHash: null,
+    matchPathGlob: null,
+    matchParentImage: null,
+    matchUser: null,
+    matchAdGroup: null,
+    matchToolName: 'manage_services',
+    matchRiskTier: null,
+    verdict: 'require_approval',
+  };
+
+  it('rejects an update that strips the last criterion (400)', async () => {
+    mockExistingRule(toolRule);
+    const res = await app().request(`/pam/rules/${RULE_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ matchToolName: null }),
+    });
+    expect(res.status).toBe(400);
+    expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+  });
+
+  it('rejects an update that mixes executable criteria onto a tool-action rule (400)', async () => {
+    mockExistingRule(toolRule);
+    const res = await app().request(`/pam/rules/${RULE_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ matchHash: 'a'.repeat(64) }),
+    });
+    expect(res.status).toBe(400);
+    expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+  });
+
+  it("rejects flipping a tool-action rule's verdict to ignore (400)", async () => {
+    mockExistingRule(toolRule);
+    const res = await app().request(`/pam/rules/${RULE_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ verdict: 'ignore' }),
+    });
+    expect(res.status).toBe(400);
+    expect(vi.mocked(db.update)).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/pam.ts
+++ b/apps/api/src/routes/pam.ts
@@ -35,7 +35,21 @@ import { authMiddleware, requireMfa, requirePermission, requireScope } from '../
 import { PERMISSIONS, canAccessSite, type UserPermissions } from '../services/permissions';
 import { writeAuditEvent } from '../services/auditEvents';
 import { publishEvent, type EventType } from '../services/eventBus';
+import { mirrorElevationDecisionToExecution } from '../services/pamToolActionGovernance';
 import { resolveOrgIdForWrite } from './softwarePolicies';
+
+/**
+ * Thrown inside the respond transaction when an ai_tool_action elevation is
+ * decided but its linked ai_tool_executions row is no longer pending (the
+ * SDK gate's 5-minute wait already timed out and rejected it). Approving
+ * the elevation anyway would be a lie — the throw rolls the whole
+ * transaction back and the handler returns 409.
+ */
+class StaleExecutionError extends Error {
+  constructor() {
+    super('Linked tool execution is no longer pending');
+  }
+}
 
 const requirePamRead = requirePermission(
   PERMISSIONS.DEVICES_READ.resource,
@@ -98,7 +112,7 @@ const listQuerySchema = z.object({
   status: z
     .enum(['pending', 'approved', 'auto_approved', 'denied', 'expired', 'revoked', 'actuating'])
     .optional(),
-  flowType: z.enum(['uac_intercept', 'tech_jit_admin']).optional(),
+  flowType: z.enum(['uac_intercept', 'tech_jit_admin', 'ai_tool_action']).optional(),
   deviceId: z.string().uuid().optional(),
   siteId: z.string().uuid().optional(),
   from: z.string().datetime({ offset: true }).optional(),
@@ -235,68 +249,107 @@ pamRoutes.post(
     const approve = body.decision === 'approve';
     const durationMinutes = body.durationMinutes ?? DEFAULT_APPROVAL_DURATION_MINUTES;
 
-    const result = await db.transaction(async (tx) => {
-      const [row] = await tx
-        .select({
-          id: elevationRequests.id,
-          orgId: elevationRequests.orgId,
-          siteId: elevationRequests.siteId,
-          deviceId: elevationRequests.deviceId,
-          flowType: elevationRequests.flowType,
-          status: elevationRequests.status,
-        })
-        .from(elevationRequests)
-        .where(eq(elevationRequests.id, id))
-        .limit(1);
+    let result:
+      | { kind: 'not_found' }
+      | { kind: 'forbidden' }
+      | { kind: 'conflict'; currentStatus: string }
+      | {
+          kind: 'ok';
+          row: { id: string; orgId: string; deviceId: string; flowType: string };
+          newStatus: string;
+        };
+    try {
+      result = await db.transaction(async (tx) => {
+        const [row] = await tx
+          .select({
+            id: elevationRequests.id,
+            orgId: elevationRequests.orgId,
+            siteId: elevationRequests.siteId,
+            deviceId: elevationRequests.deviceId,
+            flowType: elevationRequests.flowType,
+            status: elevationRequests.status,
+            executionId: elevationRequests.executionId,
+          })
+          .from(elevationRequests)
+          .where(eq(elevationRequests.id, id))
+          .limit(1);
 
-      if (!row) return { kind: 'not_found' as const };
-      if (!auth.canAccessOrg(row.orgId)) return { kind: 'not_found' as const };
-      if (perms && row.siteId && !canAccessSite(perms, row.siteId)) {
-        return { kind: 'forbidden' as const };
-      }
+        if (!row) return { kind: 'not_found' as const };
+        if (!auth.canAccessOrg(row.orgId)) return { kind: 'not_found' as const };
+        if (perms && row.siteId && !canAccessSite(perms, row.siteId)) {
+          return { kind: 'forbidden' as const };
+        }
 
-      // CAS: only a pending row can be decided. The WHERE clause re-checks
-      // status so a concurrent respond/reaper loses cleanly (0 rows).
-      const updated = await tx
-        .update(elevationRequests)
-        .set(
-          approve
-            ? {
-                status: 'approved',
-                approvedByUserId: auth.user.id,
-                approvedAt: now,
-                expiresAt: new Date(now.getTime() + durationMinutes * 60_000),
-                updatedAt: now,
-              }
-            : {
-                status: 'denied',
-                deniedByUserId: auth.user.id,
-                denialReason: body.reason ?? null,
-                updatedAt: now,
-              },
-        )
-        .where(and(eq(elevationRequests.id, id), eq(elevationRequests.status, 'pending')))
-        .returning({ id: elevationRequests.id, status: elevationRequests.status });
+        // CAS: only a pending row can be decided. The WHERE clause re-checks
+        // status so a concurrent respond/reaper loses cleanly (0 rows).
+        const updated = await tx
+          .update(elevationRequests)
+          .set(
+            approve
+              ? {
+                  status: 'approved',
+                  approvedByUserId: auth.user.id,
+                  approvedAt: now,
+                  expiresAt: new Date(now.getTime() + durationMinutes * 60_000),
+                  updatedAt: now,
+                }
+              : {
+                  status: 'denied',
+                  deniedByUserId: auth.user.id,
+                  denialReason: body.reason ?? null,
+                  updatedAt: now,
+                },
+          )
+          .where(and(eq(elevationRequests.id, id), eq(elevationRequests.status, 'pending')))
+          .returning({ id: elevationRequests.id, status: elevationRequests.status });
 
-      if (updated.length === 0) {
-        return { kind: 'conflict' as const, currentStatus: row.status };
-      }
+        if (updated.length === 0) {
+          return { kind: 'conflict' as const, currentStatus: row.status };
+        }
 
-      await tx.insert(elevationAudit).values({
-        orgId: row.orgId,
-        elevationRequestId: row.id,
-        eventType: approve ? 'approved' : 'denied',
-        actor: 'technician',
-        actorUserId: auth.user.id,
-        details: {
-          reason: body.reason,
-          ...(approve ? { duration_minutes: durationMinutes } : {}),
-        },
-        occurredAt: now,
+        await tx.insert(elevationAudit).values({
+          orgId: row.orgId,
+          elevationRequestId: row.id,
+          eventType: approve ? 'approved' : 'denied',
+          actor: 'technician',
+          actorUserId: auth.user.id,
+          details: {
+            reason: body.reason,
+            ...(approve ? { duration_minutes: durationMinutes } : {}),
+          },
+          occurredAt: now,
+        });
+
+        // ai_tool_action rows: mirror the decision onto the linked
+        // ai_tool_executions row the SDK gate is polling — in the SAME
+        // transaction (Phase 1, security finding A). If the execution is no
+        // longer pending, roll everything back and 409.
+        if (row.flowType === 'ai_tool_action' && row.executionId) {
+          const flipped = await mirrorElevationDecisionToExecution(
+            tx,
+            row.executionId,
+            approve,
+            approve ? auth.user.id : null,
+          );
+          if (!flipped) {
+            throw new StaleExecutionError();
+          }
+        }
+
+        return { kind: 'ok' as const, row, newStatus: updated[0]!.status };
       });
-
-      return { kind: 'ok' as const, row, newStatus: updated[0]!.status };
-    });
+    } catch (err) {
+      if (err instanceof StaleExecutionError) {
+        return c.json(
+          {
+            success: false,
+            error: 'Linked tool execution is no longer pending (it likely timed out)',
+          },
+          409,
+        );
+      }
+      throw err;
+    }
 
     if (result.kind === 'not_found') {
       return c.json({ error: 'Elevation request not found' }, 404);
@@ -498,6 +551,8 @@ const ruleBaseSchema = z.object({
   matchParentImage: z.string().min(1).max(4096).nullable().optional(),
   matchUser: z.string().min(1).max(255).nullable().optional(),
   matchAdGroup: z.string().min(1).max(255).nullable().optional(),
+  matchToolName: z.string().min(1).max(100).nullable().optional(),
+  matchRiskTier: z.number().int().min(0).max(4).nullable().optional(),
   timeWindow: timeWindowSchema.nullable().optional(),
   verdict: z.enum(['auto_approve', 'auto_deny', 'require_approval', 'ignore']),
   approvalDurationMinutes: z
@@ -509,22 +564,64 @@ const ruleBaseSchema = z.object({
     .optional(),
 });
 
-// A rule must carry at least one executable-identifying criterion. A rule
-// scoped only by time window (or nothing) must never exist — it would match
-// every elevation in the org (catastrophic for verdict=auto_approve).
-function hasExecutableCriterion(rule: {
+type RuleCriteriaShape = {
   matchSigner?: string | null;
   matchHash?: string | null;
   matchPathGlob?: string | null;
   matchParentImage?: string | null;
   matchUser?: string | null;
   matchAdGroup?: string | null;
-}): boolean {
-  return ruleCriteriaFields.some((f) => Boolean(rule[f]));
+  matchToolName?: string | null;
+  matchRiskTier?: number | null;
+  verdict?: 'auto_approve' | 'auto_deny' | 'require_approval' | 'ignore';
+};
+
+// A rule must carry at least one identifying criterion. A rule scoped only
+// by time window (or nothing) must never exist — it would match every
+// elevation in the org (catastrophic for verdict=auto_approve).
+function hasAnyCriterion(rule: RuleCriteriaShape): boolean {
+  return ruleCriteriaFields.some((f) => Boolean(rule[f])) || hasToolActionCriteria(rule);
 }
 
-const createRuleSchema = ruleBaseSchema.refine(hasExecutableCriterion, {
-  message: 'At least one match criterion (signer/hash/path/parent/user/group) is required',
+// Binary-identifying criteria — what makes a rule executable-shaped (user/
+// group/time only narrow; they don't identify a binary).
+const executableCriteriaFields = [
+  'matchSigner',
+  'matchHash',
+  'matchPathGlob',
+  'matchParentImage',
+] as const;
+
+function hasToolActionCriteria(rule: RuleCriteriaShape): boolean {
+  return Boolean(rule.matchToolName) || rule.matchRiskTier != null;
+}
+
+function hasExecutableShapeCriteria(rule: RuleCriteriaShape): boolean {
+  return executableCriteriaFields.some((f) => Boolean(rule[f]));
+}
+
+/**
+ * A rule is either executable-shaped or tool-action-shaped (Phase 1 helper
+ * governance) — mixing the two is rejected because no single candidate
+ * carries both kinds of field, so a mixed rule could never match anything.
+ * Returns an error string, or null when the rule shape is valid.
+ */
+function validateRuleShape(rule: RuleCriteriaShape): string | null {
+  if (!hasAnyCriterion(rule)) {
+    return 'At least one match criterion (signer/hash/path/parent/user/group/tool/tier) is required';
+  }
+  if (hasExecutableShapeCriteria(rule) && hasToolActionCriteria(rule)) {
+    return 'A rule cannot mix executable criteria with tool-action criteria';
+  }
+  if (hasToolActionCriteria(rule) && rule.verdict === 'ignore') {
+    return "verdict 'ignore' is not valid for tool-action rules — a tool action must be decided";
+  }
+  return null;
+}
+
+const createRuleSchema = ruleBaseSchema.superRefine((rule, ctx) => {
+  const err = validateRuleShape(rule);
+  if (err) ctx.addIssue({ code: z.ZodIssueCode.custom, message: err });
 });
 
 pamRoutes.get('/rules', requirePamRead, async (c) => {
@@ -561,6 +658,8 @@ pamRoutes.post('/rules', requirePamWrite, requireMfa(), zValidator('json', creat
       matchParentImage: payload.matchParentImage ?? null,
       matchUser: payload.matchUser ?? null,
       matchAdGroup: payload.matchAdGroup ?? null,
+      matchToolName: payload.matchToolName ?? null,
+      matchRiskTier: payload.matchRiskTier ?? null,
       timeWindow: payload.timeWindow ?? null,
       verdict: payload.verdict,
       approvalDurationMinutes: payload.approvalDurationMinutes ?? null,
@@ -600,13 +699,12 @@ pamRoutes.patch('/rules/:id', requirePamWrite, requireMfa(), zValidator('json', 
     return c.json({ error: 'Rule not found' }, 404);
   }
 
-  // The merged result must still carry at least one criterion.
+  // The merged result must still be a valid rule shape (criterion present,
+  // no executable/tool-action mixing, no ignore on tool-action rules).
   const merged = { ...existing, ...payload };
-  if (!hasExecutableCriterion(merged)) {
-    return c.json(
-      { error: 'At least one match criterion (signer/hash/path/parent/user/group) is required' },
-      400,
-    );
+  const shapeError = validateRuleShape(merged);
+  if (shapeError) {
+    return c.json({ error: shapeError }, 400);
   }
 
   const [updated] = await db
@@ -627,6 +725,8 @@ pamRoutes.patch('/rules/:id', requirePamWrite, requireMfa(), zValidator('json', 
         : {}),
       ...(payload.matchUser !== undefined ? { matchUser: payload.matchUser } : {}),
       ...(payload.matchAdGroup !== undefined ? { matchAdGroup: payload.matchAdGroup } : {}),
+      ...(payload.matchToolName !== undefined ? { matchToolName: payload.matchToolName } : {}),
+      ...(payload.matchRiskTier !== undefined ? { matchRiskTier: payload.matchRiskTier } : {}),
       ...(payload.timeWindow !== undefined ? { timeWindow: payload.timeWindow } : {}),
       ...(payload.verdict !== undefined ? { verdict: payload.verdict } : {}),
       ...(payload.approvalDurationMinutes !== undefined

--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -93,6 +93,12 @@ vi.mock('./expoPush', () => ({
   buildApprovalPush: (...args: unknown[]) => mockBuildApprovalPush(...args),
 }));
 
+const mockDecideHelperToolAction = vi.fn();
+vi.mock('./pamToolActionGovernance', () => ({
+  decideHelperToolAction: (...args: unknown[]) => mockDecideHelperToolAction(...args),
+  mirrorElevationDecisionToExecution: vi.fn(),
+}));
+
 // ============================================
 // Test helpers
 // ============================================
@@ -595,6 +601,132 @@ describe('createSessionPreToolUse', () => {
     });
     expect(checkGuardrails).not.toHaveBeenCalled();
     expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  describe('helper sessions (PAM governance, Phase 1)', () => {
+    function makeHelperSession(overrides: Record<string, unknown> = {}) {
+      return makeActiveSession({
+        auth: makeAuth({
+          scope: 'organization',
+          helperDeviceId: 'device-7',
+          user: { id: 'device-7', email: 'helper@host-01', name: 'HOST-01' },
+        } as any),
+        approvalMode: 'per_step',
+        ...overrides,
+      });
+    }
+
+    it('routes tier-2 tools through PAM governance, skipping the approval_requests bridge and push', async () => {
+      vi.mocked(checkGuardrails).mockReturnValue({
+        allowed: true,
+        tier: 2,
+        requiresApproval: false,
+        description: 'Take screenshot',
+      } as any);
+      const { values } = mockInsertReturning({ id: 'exec-h1' });
+      mockDecideHelperToolAction.mockResolvedValue('pending');
+      vi.mocked(waitForApproval).mockResolvedValue(true);
+      const mockSet = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+      vi.mocked(db.update).mockReturnValue({ set: mockSet } as any);
+      const session = makeHelperSession();
+
+      const result = await createSessionPreToolUse(session)('take_screenshot', { deviceId: 'forged' });
+
+      expect(result).toEqual({ allowed: true });
+      // Only the ai_tool_executions insert — NO approval_requests row.
+      expect(values).toHaveBeenCalledTimes(1);
+      expect(values).toHaveBeenCalledWith(expect.objectContaining({
+        sessionId: 'session-1',
+        toolName: 'take_screenshot',
+        status: 'pending',
+      }));
+      expect(mockGetUserPushTokens).not.toHaveBeenCalled();
+      expect(mockSendExpoPush).not.toHaveBeenCalled();
+
+      expect(mockDecideHelperToolAction).toHaveBeenCalledWith({
+        orgId: 'org-1',
+        deviceId: 'device-7',
+        executionId: 'exec-h1',
+        toolName: 'take_screenshot',
+        toolInput: { deviceId: 'forged' },
+        riskTier: 2,
+        subjectUsername: 'HOST-01',
+      });
+
+      // SSE event marks the approval as admin-side.
+      expect(session.eventBus.publish).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'approval_required',
+        executionId: 'exec-h1',
+        requiresAdminApproval: true,
+      }));
+
+      expect(waitForApproval).toHaveBeenCalledWith('exec-h1', 300_000, expect.any(AbortSignal));
+      // Marked executing after approval.
+      expect(mockSet).toHaveBeenCalledWith({ status: 'executing' });
+    });
+
+    it('policy auto-deny short-circuits without waiting', async () => {
+      vi.mocked(checkGuardrails).mockReturnValue({
+        allowed: true,
+        tier: 3,
+        requiresApproval: true,
+        description: 'Execute command',
+      } as any);
+      mockInsertReturning({ id: 'exec-h2' });
+      mockDecideHelperToolAction.mockResolvedValue('denied');
+      const session = makeHelperSession();
+
+      const result = await createSessionPreToolUse(session)('execute_command', {});
+
+      expect(result).toEqual({
+        allowed: false,
+        error: 'This action was denied by organization policy',
+      });
+      expect(waitForApproval).not.toHaveBeenCalled();
+    });
+
+    it('rejection or timeout after pending decision denies the tool', async () => {
+      vi.mocked(checkGuardrails).mockReturnValue({
+        allowed: true,
+        tier: 3,
+        requiresApproval: true,
+        description: 'Execute command',
+      } as any);
+      mockInsertReturning({ id: 'exec-h3' });
+      mockDecideHelperToolAction.mockResolvedValue('pending');
+      vi.mocked(waitForApproval).mockResolvedValue(false);
+      const session = makeHelperSession();
+
+      const result = await createSessionPreToolUse(session)('execute_command', {});
+
+      expect(result).toEqual({
+        allowed: false,
+        error: 'Tool execution was rejected or timed out awaiting administrator approval',
+      });
+    });
+
+    it('auto_approve session mode cannot bypass PAM for helper sessions', async () => {
+      vi.mocked(checkGuardrails).mockReturnValue({
+        allowed: true,
+        tier: 2,
+        requiresApproval: false,
+        description: 'Take screenshot',
+      } as any);
+      const { values } = mockInsertReturning({ id: 'exec-h4' });
+      mockDecideHelperToolAction.mockResolvedValue('auto_approved');
+      vi.mocked(waitForApproval).mockResolvedValue(true);
+      const mockSet = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+      vi.mocked(db.update).mockReturnValue({ set: mockSet } as any);
+      const session = makeHelperSession({ approvalMode: 'auto_approve' });
+
+      const result = await createSessionPreToolUse(session)('take_screenshot', {});
+
+      expect(result).toEqual({ allowed: true });
+      // Went through governance, not the auto-approve 'executing' fast path.
+      expect(mockDecideHelperToolAction).toHaveBeenCalled();
+      expect(values).toHaveBeenCalledWith(expect.objectContaining({ status: 'pending' }));
+      expect(waitForApproval).toHaveBeenCalled();
+    });
   });
 
   it('matches session allowlists across MCP server prefixes', async () => {

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -23,6 +23,7 @@ import { writeAuditEvent, requestLikeFromSnapshot, type RequestLike } from './au
 import type { ActiveSession, AuditSnapshot } from './streamingSessionManager';
 import { compactToolResultForChat } from './aiToolOutput';
 import { buildApprovalPush, getUserPushTokens, sendExpoPush } from './expoPush';
+import { decideHelperToolAction } from './pamToolActionGovernance';
 import { loadSession, loadConnection } from './m365Helpers';
 import type { DelegantM365ConnectionRow } from '../db/schema/delegant';
 
@@ -263,6 +264,91 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
     // wrapped in withDbAccessContext({scope:'organization', orgId: session.orgId, ...})
     // to set the correct PostgreSQL GUCs under RLS.
     if (guardrailCheck.tier >= 2) {
+      // Helper sessions: PAM governs (Phase 1, security finding A). This
+      // branch precedes the auto_approve/plan shortcuts on purpose — a
+      // helper token must never self-relax the approval gate. The
+      // approval_requests/mobile bridge is skipped: the synthetic helper
+      // "user" id is a device id (no users-FK row, no mobile owner).
+      // Approval happens via POST /pam/elevation-requests/:id/respond
+      // (separate identity), which mirrors onto this execution row.
+      if (session.auth.helperDeviceId) {
+        const helperDeviceId = session.auth.helperDeviceId;
+        let helperExec: { id: string } | undefined;
+        try {
+          const [row] = await withDbAccessContext(
+            { scope: 'organization', orgId: session.orgId, accessibleOrgIds: [session.orgId] },
+            () =>
+              db
+                .insert(aiToolExecutions)
+                .values({
+                  sessionId: session.breezeSessionId,
+                  toolName,
+                  toolInput: input,
+                  status: 'pending',
+                })
+                .returning()
+          );
+          helperExec = row;
+        } catch (err) {
+          console.error('[AI-SDK] Failed to create helper approval record:', toolName, err);
+          return { allowed: false, error: 'Failed to create approval record' };
+        }
+        if (!helperExec) {
+          return { allowed: false, error: 'Failed to create approval record' };
+        }
+
+        session.eventBus.publish({
+          type: 'approval_required',
+          executionId: helperExec.id,
+          toolName,
+          input,
+          description: guardrailCheck.description ?? `Execute ${toolName}`,
+          requiresAdminApproval: true,
+        });
+
+        const decision = await decideHelperToolAction({
+          orgId: session.orgId,
+          deviceId: helperDeviceId,
+          executionId: helperExec.id,
+          toolName: stripMcpPrefix(toolName),
+          toolInput: input as Record<string, unknown>,
+          riskTier: guardrailCheck.tier,
+          subjectUsername: session.auth.user.name ?? 'helper',
+        });
+
+        if (decision === 'denied') {
+          return { allowed: false, error: 'This action was denied by organization policy' };
+        }
+
+        // Block until PAM decides (an auto-approved elevation has already
+        // flipped the row, so this returns on the first poll).
+        const approved = await waitForApproval(
+          helperExec.id,
+          300_000,
+          session.abortController.signal,
+        );
+        if (!approved) {
+          return {
+            allowed: false,
+            error: 'Tool execution was rejected or timed out awaiting administrator approval',
+          };
+        }
+
+        try {
+          await withDbAccessContext(
+            { scope: 'organization', orgId: session.orgId, accessibleOrgIds: [session.orgId] },
+            () =>
+              db
+                .update(aiToolExecutions)
+                .set({ status: 'executing' })
+                .where(eq(aiToolExecutions.id, helperExec!.id))
+          );
+        } catch (err) {
+          console.error('[AI-SDK] Failed to update helper approval to executing:', helperExec.id, err);
+        }
+        return { allowed: true };
+      }
+
       // Determine effective approval mode (pause overrides to per_step)
       const effectiveMode: AiApprovalMode = session.isPaused ? 'per_step' : session.approvalMode;
 

--- a/apps/api/src/services/aiTools.ts
+++ b/apps/api/src/services/aiTools.ts
@@ -255,10 +255,12 @@ export function getToolTier(toolName: string): AiToolTier | undefined {
  * Helper device-scoping (security finding A, Phase 0).
  * Maps each tool the Breeze Helper may run to the input field naming its
  * target device. A tool absent from this map is org-wide and is DENIED under
- * a Helper context. The Helper's default tool set (helperToolFilter `basic`)
- * is kept in sync with these keys.
+ * a Helper context. Every tool in helperToolFilter's whitelists must have an
+ * entry here (pinned by helperToolFilter.test.ts); mutating tools (tier>=2)
+ * are additionally PAM-governed at the preToolUse gate (Phase 1).
  */
 export const HELPER_TOOL_SCOPING: Record<string, 'deviceId' | 'deviceIds'> = {
+  // Read-only (Phase 0 `basic` set).
   get_device_details: 'deviceId',
   analyze_metrics: 'deviceId',
   analyze_disk_usage: 'deviceId',
@@ -267,6 +269,20 @@ export const HELPER_TOOL_SCOPING: Record<string, 'deviceId' | 'deviceIds'> = {
   take_screenshot: 'deviceId',
   analyze_screen: 'deviceId',
   search_logs: 'deviceIds',
+  // Device-pinned safe actions (`standard`, Phase 1 governed).
+  get_active_users: 'deviceId',
+  get_user_experience_metrics: 'deviceId',
+  manage_alerts: 'deviceId',
+  manage_services: 'deviceId',
+  disk_cleanup: 'deviceId',
+  file_operations: 'deviceId',
+  // Device-pinned destructive tools (`extended`, Phase 1 governed).
+  computer_control: 'deviceId',
+  execute_command: 'deviceId',
+  security_scan: 'deviceId',
+  s1_isolate_device: 'deviceId',
+  network_discovery: 'deviceId',
+  apply_cis_remediation: 'deviceId',
 };
 
 /**

--- a/apps/api/src/services/helperToolFilter.test.ts
+++ b/apps/api/src/services/helperToolFilter.test.ts
@@ -29,9 +29,19 @@ const ORG_WIDE = [
 ];
 
 describe('helper basic tool set (finding A, Phase 0)', () => {
-  it('basic set is exactly the device-scoped allowlist keys', () => {
-    expect([...getHelperAllowedTools('basic')].sort())
-      .toEqual(Object.keys(HELPER_TOOL_SCOPING).sort());
+  it('basic set is unchanged: the 8 read-only device-scoped tools', () => {
+    expect([...getHelperAllowedTools('basic')].sort()).toEqual(
+      [
+        'get_device_details',
+        'analyze_metrics',
+        'analyze_disk_usage',
+        'get_cis_device_report',
+        'get_security_posture',
+        'take_screenshot',
+        'analyze_screen',
+        'search_logs',
+      ].sort(),
+    );
   });
 
   it('basic set contains no mutating tools', () => {
@@ -42,5 +52,74 @@ describe('helper basic tool set (finding A, Phase 0)', () => {
   it('basic set contains no org-wide enumeration tools', () => {
     const basic = getHelperAllowedTools('basic');
     for (const t of ORG_WIDE) expect(basic).not.toContain(t);
+  });
+});
+
+describe('helper governed tool sets (finding A, Phase 1)', () => {
+  it('standard adds device-pinned safe-action tools to basic', () => {
+    const standard = getHelperAllowedTools('standard');
+    for (const t of getHelperAllowedTools('basic')) expect(standard).toContain(t);
+    for (const t of [
+      'get_active_users',
+      'get_user_experience_metrics',
+      'manage_alerts',
+      'manage_services',
+      'disk_cleanup',
+      'file_operations',
+    ]) {
+      expect(standard).toContain(t);
+    }
+  });
+
+  it('extended adds device-pinned destructive tools to standard', () => {
+    const extended = getHelperAllowedTools('extended');
+    for (const t of getHelperAllowedTools('standard')) expect(extended).toContain(t);
+    for (const t of [
+      'computer_control',
+      'execute_command',
+      'security_scan',
+      's1_isolate_device',
+      'network_discovery',
+      'apply_cis_remediation',
+    ]) {
+      expect(extended).toContain(t);
+    }
+  });
+
+  it('run_backup_verification stays excluded (no executeTool registration exists)', () => {
+    for (const level of ['basic', 'standard', 'extended'] as const) {
+      expect(getHelperAllowedTools(level)).not.toContain('run_backup_verification');
+    }
+  });
+
+  it('no level contains org-wide tools (the device-scope gate would deny them)', () => {
+    for (const level of ['basic', 'standard', 'extended'] as const) {
+      const tools = getHelperAllowedTools(level);
+      for (const t of [
+        ...ORG_WIDE,
+        'get_backup_health',
+        'get_recovery_readiness',
+        'get_cis_compliance',
+      ]) {
+        expect(tools, `${level} must not contain org-wide tool ${t}`).not.toContain(t);
+      }
+    }
+  });
+
+  it('s1_threat_action stays excluded (threat-keyed, not device-pinnable)', () => {
+    for (const level of ['basic', 'standard', 'extended'] as const) {
+      expect(getHelperAllowedTools(level)).not.toContain('s1_threat_action');
+    }
+  });
+
+  it('every helper-whitelisted tool is device-scopable by the executeTool gate', () => {
+    for (const level of ['basic', 'standard', 'extended'] as const) {
+      for (const tool of getHelperAllowedTools(level)) {
+        expect(
+          HELPER_TOOL_SCOPING[tool],
+          `${level}:${tool} has no HELPER_TOOL_SCOPING entry — the gate would deny it`,
+        ).toBeDefined();
+      }
+    }
   });
 });

--- a/apps/api/src/services/helperToolFilter.ts
+++ b/apps/api/src/services/helperToolFilter.ts
@@ -9,84 +9,55 @@
 
 export type HelperPermissionLevel = 'basic' | 'standard' | 'extended';
 
+// Every tool at every level MUST be single-device: it needs a
+// HELPER_TOOL_SCOPING entry in services/aiTools.ts (the executeTool gate
+// pins the declared device field to the Helper's own device and DENIES any
+// unscoped tool — security finding A, Phase 0). Org-wide enumeration tools
+// (query_devices, get_fleet_health, …) and tools keyed on non-device
+// resources (s1_threat_action takes threatIds) therefore cannot appear here.
+//
+// Mutating tools (tier>=2) are governed by PAM (Phase 1): each invocation
+// becomes an elevation_request(ai_tool_action) decided by pam_rules —
+// default posture require_approval via POST /pam/elevation-requests/:id/respond.
+const BASIC_TOOLS = [
+  'get_device_details',
+  'analyze_metrics',
+  'analyze_disk_usage',
+  'get_cis_device_report',
+  'get_security_posture',
+  'take_screenshot',
+  'analyze_screen',
+  'search_logs',
+] as const;
+
+// basic + device-pinned safe actions. The mutating ones are PAM-governed.
+const STANDARD_TOOLS = [
+  ...BASIC_TOOLS,
+  'get_active_users',
+  'get_user_experience_metrics',
+  'manage_alerts',
+  'manage_services',
+  'disk_cleanup',
+  'file_operations',
+] as const;
+
+// standard + device-pinned destructive tools — always PAM-governed.
+// (run_backup_verification is deliberately absent: it is declared on the SDK
+// MCP server but has no executeTool registration, so it cannot run anywhere.)
+const EXTENDED_TOOLS = [
+  ...STANDARD_TOOLS,
+  'computer_control',
+  'execute_command',
+  'security_scan',
+  's1_isolate_device',
+  'network_discovery',
+  'apply_cis_remediation',
+] as const;
+
 const TOOL_WHITELIST: Record<HelperPermissionLevel, readonly string[]> = {
-  // Read-only single-device allowlist (security finding A, Phase 0). Kept in
-  // sync with HELPER_TOOL_SCOPING in services/aiTools.ts — every tool here is
-  // device-scoped by the executeTool gate. Org-wide enumeration and mutating
-  // tools are deliberately excluded; full capability returns under PAM
-  // governance in Phase 1.
-  basic: [
-    'get_device_details',
-    'analyze_metrics',
-    'analyze_disk_usage',
-    'get_cis_device_report',
-    'get_security_posture',
-    'take_screenshot',
-    'analyze_screen',
-    'search_logs',
-  ],
-  standard: [
-    'take_screenshot',
-    'analyze_screen',
-    'query_devices',
-    'get_device_details',
-    'analyze_metrics',
-    'get_active_users',
-    'get_user_experience_metrics',
-    'get_security_posture',
-    'get_cis_compliance',
-    'get_cis_device_report',
-    'get_fleet_health',
-    'get_s1_status',
-    'get_s1_threats',
-    'get_backup_health',
-    'get_recovery_readiness',
-    'analyze_disk_usage',
-    'query_audit_log',
-    'search_logs',
-    'get_log_trends',
-    'detect_log_correlations',
-    'query_change_log',
-    'manage_alerts',
-    'manage_services',
-    'disk_cleanup',
-    'file_operations',
-  ],
-  extended: [
-    'take_screenshot',
-    'analyze_screen',
-    'query_devices',
-    'get_device_details',
-    'analyze_metrics',
-    'get_active_users',
-    'get_user_experience_metrics',
-    'get_security_posture',
-    'get_cis_compliance',
-    'get_cis_device_report',
-    'get_fleet_health',
-    'get_s1_status',
-    'get_s1_threats',
-    'get_backup_health',
-    'get_recovery_readiness',
-    'analyze_disk_usage',
-    'query_audit_log',
-    'search_logs',
-    'get_log_trends',
-    'detect_log_correlations',
-    'query_change_log',
-    'manage_alerts',
-    'manage_services',
-    'disk_cleanup',
-    'file_operations',
-    'computer_control',
-    'execute_command',
-    'security_scan',
-    's1_isolate_device',
-    's1_threat_action',
-    'network_discovery',
-    'apply_cis_remediation',
-    'run_backup_verification',
-  ],
+  basic: BASIC_TOOLS,
+  standard: STANDARD_TOOLS,
+  extended: EXTENDED_TOOLS,
 };
 
 const MCP_PREFIX = 'mcp__breeze__';

--- a/apps/api/src/services/pamRuleEngine.test.ts
+++ b/apps/api/src/services/pamRuleEngine.test.ts
@@ -3,7 +3,12 @@
  */
 import { describe, expect, it } from 'vitest';
 import type { PamRule } from '../db/schema/pam';
-import { evaluatePamRules, isWithinTimeWindow, type PamRuleCandidate } from './pamRuleEngine';
+import {
+  evaluatePamRules,
+  evaluatePamToolActionRules,
+  isWithinTimeWindow,
+  type PamRuleCandidate,
+} from './pamRuleEngine';
 
 let seq = 0;
 function rule(overrides: Partial<PamRule>): PamRule {
@@ -22,6 +27,8 @@ function rule(overrides: Partial<PamRule>): PamRule {
     matchParentImage: null,
     matchUser: null,
     matchAdGroup: null,
+    matchToolName: null,
+    matchRiskTier: null,
     timeWindow: null,
     verdict: 'require_approval',
     approvalDurationMinutes: null,
@@ -222,5 +229,89 @@ describe('isWithinTimeWindow', () => {
   it('time-window-only rules still never match (no executable criterion)', () => {
     const r = rule({ timeWindow: { start: '00:00', end: '23:59' }, verdict: 'auto_approve' });
     expect(evaluatePamRules([r], candidate)).toBeNull();
+  });
+});
+
+describe('tool-action rules (Phase 1 helper governance)', () => {
+  const toolCandidate: PamRuleCandidate = {
+    toolName: 'manage_services',
+    riskTier: 2,
+    subjectUsername: 'HOST-01',
+  };
+
+  it('matches on tool name, case-insensitive', () => {
+    const r = rule({ matchToolName: 'Manage_Services', verdict: 'auto_approve' });
+    expect(evaluatePamToolActionRules([r], toolCandidate)?.verdict).toBe('auto_approve');
+  });
+
+  it('does not match a different tool name', () => {
+    const r = rule({ matchToolName: 'execute_command', verdict: 'auto_approve' });
+    expect(evaluatePamToolActionRules([r], toolCandidate)).toBeNull();
+  });
+
+  it('matches risk tier exactly', () => {
+    expect(
+      evaluatePamToolActionRules([rule({ matchRiskTier: 2, verdict: 'auto_deny' })], toolCandidate)
+        ?.verdict,
+    ).toBe('auto_deny');
+    expect(
+      evaluatePamToolActionRules([rule({ matchRiskTier: 3, verdict: 'auto_deny' })], toolCandidate),
+    ).toBeNull();
+  });
+
+  it('ANDs tool criteria with user and time window', () => {
+    const r = rule({
+      matchToolName: 'manage_services',
+      matchUser: 'host-01',
+      timeWindow: { start: '00:00', end: '23:59' },
+      verdict: 'auto_approve',
+    });
+    expect(
+      evaluatePamToolActionRules([r], { ...toolCandidate, at: new Date() })?.verdict,
+    ).toBe('auto_approve');
+    expect(
+      evaluatePamToolActionRules([r], {
+        ...toolCandidate,
+        subjectUsername: 'other',
+        at: new Date(),
+      }),
+    ).toBeNull();
+  });
+
+  it('a matchUser-only rule never matches tool actions (no tool-action criterion)', () => {
+    const r = rule({ matchUser: 'host-01', verdict: 'auto_approve' });
+    expect(evaluatePamToolActionRules([r], toolCandidate)).toBeNull();
+  });
+
+  it('an executable rule never matches tool actions', () => {
+    const r = rule({ matchHash: 'a'.repeat(64), verdict: 'auto_approve' });
+    expect(evaluatePamToolActionRules([r], toolCandidate)).toBeNull();
+  });
+
+  it('a tool-action rule never matches an executable candidate via evaluatePamRules', () => {
+    const r = rule({ matchToolName: 'manage_services', verdict: 'auto_approve' });
+    expect(
+      evaluatePamRules([r], {
+        targetExecutablePath: 'C:\\x.exe',
+        subjectUsername: 'alice',
+      }),
+    ).toBeNull();
+  });
+
+  it('criteria-less rules still match nothing', () => {
+    expect(evaluatePamToolActionRules([rule({ verdict: 'auto_approve' })], toolCandidate)).toBeNull();
+  });
+
+  it('matchPathGlob fails closed when candidate has no executable path', () => {
+    const r = rule({ matchPathGlob: '**', verdict: 'auto_approve' });
+    expect(
+      evaluatePamRules([r], { subjectUsername: 'a', toolName: 't' }),
+    ).toBeNull();
+  });
+
+  it('priority ordering applies across tool-action rules', () => {
+    const deny = rule({ matchToolName: 'manage_services', verdict: 'auto_deny', priority: 10 });
+    const approve = rule({ matchToolName: 'manage_services', verdict: 'auto_approve', priority: 20 });
+    expect(evaluatePamToolActionRules([approve, deny], toolCandidate)?.verdict).toBe('auto_deny');
   });
 });

--- a/apps/api/src/services/pamRuleEngine.ts
+++ b/apps/api/src/services/pamRuleEngine.ts
@@ -25,18 +25,27 @@
  *   rules simply never match that flow until the agent ships groups).
  * - time_window: "HH:MM"–"HH:MM" with optional days[0-6] in the window's
  *   timezone (default UTC). Overnight windows (start > end) wrap midnight.
+ * - tool_name / risk_tier (Phase 1 helper governance): exact tool-name
+ *   (case-insensitive) and exact tier match for ai_tool_action candidates;
+ *   evaluated via evaluatePamToolActionRules, which only considers rules
+ *   carrying a tool-action criterion.
  */
 import type { PamRule, PamRuleTimeWindow } from '../db/schema/pam';
 import { matchPathGlob } from './pamBridge';
 
 export interface PamRuleCandidate {
-  targetExecutablePath: string;
+  /** Absent for ai_tool_action candidates. */
+  targetExecutablePath?: string;
   targetExecutableHash?: string;
   targetExecutableSigner?: string;
   subjectUsername: string;
   parentImage?: string;
   /** AD/local group names of the subject, when known. */
   subjectAdGroups?: string[];
+  /** ai_tool_action candidates: bare tool name (no mcp__ prefix). */
+  toolName?: string;
+  /** ai_tool_action candidates: guardrail tier (2–3 today). */
+  riskTier?: number;
   /** Evaluation instant; injectable for tests. Defaults to now. */
   at?: Date;
 }
@@ -61,8 +70,21 @@ function hasAnyCriteria(rule: PamRule): boolean {
       rule.matchPathGlob ||
       rule.matchParentImage ||
       rule.matchUser ||
-      rule.matchAdGroup,
+      rule.matchAdGroup ||
+      rule.matchToolName ||
+      rule.matchRiskTier != null,
   );
+}
+
+/**
+ * A rule is tool-action-shaped when it carries a tool-action criterion
+ * (Phase 1 helper governance). Tool-action evaluation only considers these
+ * rules; the API layer rejects mixing them with executable criteria.
+ */
+export function hasToolActionCriterion(
+  rule: Pick<PamRule, 'matchToolName' | 'matchRiskTier'>,
+): boolean {
+  return Boolean(rule.matchToolName) || rule.matchRiskTier != null;
 }
 
 /** Exported for tests. */
@@ -122,6 +144,7 @@ function ruleMatches(rule: PamRule, candidate: PamRuleCandidate): boolean {
     if (!eqCi(rule.matchSigner, candidate.targetExecutableSigner)) return false;
   }
   if (rule.matchPathGlob) {
+    if (!candidate.targetExecutablePath) return false;
     if (!matchPathGlob(rule.matchPathGlob, candidate.targetExecutablePath)) return false;
   }
   if (rule.matchParentImage) {
@@ -134,6 +157,14 @@ function ruleMatches(rule: PamRule, candidate: PamRuleCandidate): boolean {
   if (rule.matchAdGroup) {
     const groups = candidate.subjectAdGroups ?? [];
     if (!groups.some((g) => eqCi(g, rule.matchAdGroup!))) return false;
+  }
+  if (rule.matchToolName) {
+    if (!candidate.toolName) return false;
+    if (!eqCi(rule.matchToolName, candidate.toolName)) return false;
+  }
+  if (rule.matchRiskTier != null) {
+    if (candidate.riskTier == null) return false;
+    if (rule.matchRiskTier !== candidate.riskTier) return false;
   }
   if (rule.timeWindow) {
     if (!isWithinTimeWindow(rule.timeWindow, candidate.at ?? new Date())) return false;
@@ -170,4 +201,17 @@ export function evaluatePamRules(
     }
   }
   return null;
+}
+
+/**
+ * Evaluate an ai_tool_action candidate (Phase 1 helper governance). Only
+ * rules carrying at least one tool-action criterion participate — a
+ * pre-existing user-only or executable rule must never govern Helper tool
+ * actions (e.g. a matchUser-only UAC rule with verdict=auto_approve).
+ */
+export function evaluatePamToolActionRules(
+  rules: PamRule[],
+  candidate: PamRuleCandidate,
+): PamRuleMatch | null {
+  return evaluatePamRules(rules.filter(hasToolActionCriterion), candidate);
 }

--- a/apps/api/src/services/pamToolActionGovernance.test.ts
+++ b/apps/api/src/services/pamToolActionGovernance.test.ts
@@ -112,7 +112,7 @@ function mockInserts(elevationId = 'elev-1') {
 
 function mockUpdate(flippedRows: Array<{ id: string }>) {
   const where = vi.fn(() => ({ returning: vi.fn().mockResolvedValue(flippedRows) }));
-  const set = vi.fn(() => ({ where }));
+  const set = vi.fn((_vals: Record<string, unknown>) => ({ where }));
   vi.mocked(db.update).mockReturnValue({ set } as any);
   return { set, where };
 }
@@ -288,7 +288,7 @@ describe('mirrorElevationDecisionToExecution', () => {
     expect(set).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'approved', approvedBy: 'user-9' }),
     );
-    expect(set.mock.calls[0]![0].approvedAt).toBeInstanceOf(Date);
+    expect(set.mock.calls[0]?.[0]?.approvedAt).toBeInstanceOf(Date);
   });
 
   it('flips pending → rejected', async () => {

--- a/apps/api/src/services/pamToolActionGovernance.test.ts
+++ b/apps/api/src/services/pamToolActionGovernance.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Phase 1 helper tool-action governance unit tests (security finding A).
+ * Drizzle-mocked — covers verdict mapping, fail-safe, audit/events, and the
+ * execution status bridge CAS.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../db', () => ({
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  devices: { id: 'id', siteId: 'siteId', partnerId: 'partnerId' },
+  elevationRequests: { id: 'id', status: 'status' },
+  elevationAudit: { id: 'id' },
+  pamRules: { id: 'id', orgId: 'orgId', siteId: 'siteId', enabled: 'enabled' },
+  aiToolExecutions: { id: 'id', status: 'status' },
+}));
+
+const eventMocks = vi.hoisted(() => ({ publishEvent: vi.fn() }));
+vi.mock('./eventBus', () => ({ publishEvent: eventMocks.publishEvent }));
+
+import { createHash } from 'node:crypto';
+import { db } from '../db';
+import {
+  decideHelperToolAction,
+  mirrorElevationDecisionToExecution,
+} from './pamToolActionGovernance';
+
+const params = {
+  orgId: 'org-1',
+  deviceId: 'device-1',
+  executionId: 'exec-1',
+  toolName: 'manage_services',
+  toolInput: { deviceId: 'device-1', action: 'restart', service: 'spooler' },
+  riskTier: 2,
+  subjectUsername: 'HOST-01',
+};
+
+/** A pam_rules row shaped like the engine expects. */
+function toolRule(overrides: Record<string, unknown>) {
+  return {
+    id: 'rule-1',
+    orgId: 'org-1',
+    siteId: null,
+    name: 'tool rule',
+    description: null,
+    enabled: true,
+    priority: 100,
+    matchSigner: null,
+    matchHash: null,
+    matchPathGlob: null,
+    matchParentImage: null,
+    matchUser: null,
+    matchAdGroup: null,
+    matchToolName: null,
+    matchRiskTier: null,
+    timeWindow: null,
+    verdict: 'require_approval',
+    approvalDurationMinutes: null,
+    createdByUserId: null,
+    createdAt: new Date('2026-06-01T00:00:00Z'),
+    updatedAt: new Date('2026-06-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+/**
+ * db.select chain serving BOTH shapes the service uses:
+ *   device lookup:  .from().where().limit()  -> deviceRows
+ *   pam_rules load: .from().where()  (awaited) -> ruleRows
+ */
+function mockSelects(
+  deviceRows: Array<{ siteId: string | null; partnerId: string | null }>,
+  ruleRows: unknown[] = [],
+) {
+  vi.mocked(db.select).mockImplementation(
+    () =>
+      ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => {
+            const thenable: any = Promise.resolve(ruleRows);
+            thenable.limit = vi.fn().mockResolvedValue(deviceRows);
+            return thenable;
+          }),
+        })),
+      }) as any,
+  );
+}
+
+/** Captures inserts; elevation insert returns `returning`, audit insert is awaited bare. */
+function mockInserts(elevationId = 'elev-1') {
+  const captured: Array<{ table: unknown; values: Record<string, unknown> }> = [];
+  vi.mocked(db.insert).mockImplementation(
+    (table: unknown) =>
+      ({
+        values: vi.fn((vals: Record<string, unknown>) => {
+          captured.push({ table, values: vals });
+          const thenable: any = Promise.resolve([]);
+          thenable.returning = vi.fn().mockResolvedValue([{ id: elevationId }]);
+          return thenable;
+        }),
+      }) as any,
+  );
+  return captured;
+}
+
+function mockUpdate(flippedRows: Array<{ id: string }>) {
+  const where = vi.fn(() => ({ returning: vi.fn().mockResolvedValue(flippedRows) }));
+  const set = vi.fn(() => ({ where }));
+  vi.mocked(db.update).mockReturnValue({ set } as any);
+  return { set, where };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('decideHelperToolAction', () => {
+  it('auto_approve rule → auto_approved elevation, execution mirrored to approved, audit + events', async () => {
+    mockSelects(
+      [{ siteId: 'site-1', partnerId: 'partner-1' }],
+      [toolRule({ matchToolName: 'manage_services', verdict: 'auto_approve' })],
+    );
+    const inserts = mockInserts();
+    const { set } = mockUpdate([{ id: 'exec-1' }]);
+
+    const decision = await decideHelperToolAction(params);
+
+    expect(decision).toBe('auto_approved');
+
+    const elevation = inserts[0]!.values;
+    expect(elevation.flowType).toBe('ai_tool_action');
+    expect(elevation.executionId).toBe('exec-1');
+    expect(elevation.toolName).toBe('manage_services');
+    expect(elevation.riskTier).toBe(2);
+    expect(elevation.status).toBe('auto_approved');
+    expect(elevation.approvedAt).toBeInstanceOf(Date);
+    expect(elevation.expiresAt).toBeInstanceOf(Date);
+    expect(elevation.orgId).toBe('org-1');
+    expect(elevation.siteId).toBe('site-1');
+    expect(elevation.subjectUserId).toBeNull();
+    expect(elevation.actionDigest).toBe(
+      createHash('sha256').update(JSON.stringify(params.toolInput)).digest('hex'),
+    );
+
+    // Audit: requested + auto_approved.
+    const auditEvents = inserts.slice(1).map((i) => i.values.eventType);
+    expect(auditEvents).toEqual(['requested', 'auto_approved']);
+
+    // Mirror flipped the execution to approved.
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'approved', approvedBy: null }),
+    );
+
+    expect(eventMocks.publishEvent).toHaveBeenCalledWith(
+      'elevation.auto_approved',
+      'org-1',
+      expect.objectContaining({ flowType: 'ai_tool_action', executionId: 'exec-1' }),
+      expect.any(String),
+    );
+  });
+
+  it('auto_deny rule → denied elevation with denialReason, execution rejected', async () => {
+    mockSelects(
+      [{ siteId: null, partnerId: null }],
+      [toolRule({ matchToolName: 'manage_services', verdict: 'auto_deny', name: 'no spooler' })],
+    );
+    const inserts = mockInserts();
+    const { set } = mockUpdate([{ id: 'exec-1' }]);
+
+    const decision = await decideHelperToolAction(params);
+
+    expect(decision).toBe('denied');
+    const elevation = inserts[0]!.values;
+    expect(elevation.status).toBe('denied');
+    expect(elevation.denialReason).toContain('no spooler');
+    expect(set).toHaveBeenCalledWith(expect.objectContaining({ status: 'rejected' }));
+    expect(eventMocks.publishEvent).toHaveBeenCalledWith(
+      'elevation.denied',
+      'org-1',
+      expect.anything(),
+      expect.any(String),
+    );
+  });
+
+  it('require_approval rule → pending elevation, execution untouched', async () => {
+    mockSelects(
+      [{ siteId: null, partnerId: null }],
+      [toolRule({ matchToolName: 'manage_services', verdict: 'require_approval' })],
+    );
+    const inserts = mockInserts();
+    mockUpdate([]);
+
+    const decision = await decideHelperToolAction(params);
+
+    expect(decision).toBe('pending');
+    expect(inserts[0]!.values.status).toBe('pending');
+    expect(db.update).not.toHaveBeenCalled();
+    expect(eventMocks.publishEvent).toHaveBeenCalledWith(
+      'elevation.requested',
+      'org-1',
+      expect.anything(),
+      expect.any(String),
+    );
+  });
+
+  it('no matching rule → pending (default posture)', async () => {
+    mockSelects([{ siteId: null, partnerId: null }], []);
+    const inserts = mockInserts();
+
+    const decision = await decideHelperToolAction(params);
+
+    expect(decision).toBe('pending');
+    expect(inserts[0]!.values.status).toBe('pending');
+  });
+
+  it("'ignore' verdict → pending (no suppress semantics for tool actions)", async () => {
+    mockSelects(
+      [{ siteId: null, partnerId: null }],
+      [toolRule({ matchToolName: 'manage_services', verdict: 'ignore' })],
+    );
+    const inserts = mockInserts();
+
+    const decision = await decideHelperToolAction(params);
+
+    expect(decision).toBe('pending');
+    expect(inserts[0]!.values.status).toBe('pending');
+  });
+
+  it('a matchUser-only UAC rule never governs tool actions', async () => {
+    mockSelects(
+      [{ siteId: null, partnerId: null }],
+      [toolRule({ matchUser: 'host-01', verdict: 'auto_approve' })],
+    );
+    const inserts = mockInserts();
+
+    const decision = await decideHelperToolAction(params);
+
+    expect(decision).toBe('pending');
+    expect(inserts[0]!.values.status).toBe('pending');
+  });
+
+  it('decisioning error → fail-safe pending, never throws', async () => {
+    vi.mocked(db.select).mockImplementation(() => {
+      throw new Error('db down');
+    });
+
+    await expect(decideHelperToolAction(params)).resolves.toBe('pending');
+  });
+
+  it('audit insert failure does not flip a decided verdict', async () => {
+    mockSelects(
+      [{ siteId: null, partnerId: null }],
+      [toolRule({ matchToolName: 'manage_services', verdict: 'auto_approve' })],
+    );
+    let call = 0;
+    vi.mocked(db.insert).mockImplementation(
+      () =>
+        ({
+          values: vi.fn(() => {
+            call += 1;
+            if (call === 1) {
+              const thenable: any = Promise.resolve([]);
+              thenable.returning = vi.fn().mockResolvedValue([{ id: 'elev-1' }]);
+              return thenable;
+            }
+            return Promise.reject(new Error('audit down'));
+          }),
+        }) as any,
+    );
+    mockUpdate([{ id: 'exec-1' }]);
+
+    await expect(decideHelperToolAction(params)).resolves.toBe('auto_approved');
+  });
+});
+
+describe('mirrorElevationDecisionToExecution', () => {
+  it('flips pending → approved with approvedBy', async () => {
+    const { set } = mockUpdate([{ id: 'exec-1' }]);
+    const flipped = await mirrorElevationDecisionToExecution(db, 'exec-1', true, 'user-9');
+    expect(flipped).toBe(true);
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'approved', approvedBy: 'user-9' }),
+    );
+    expect(set.mock.calls[0]![0].approvedAt).toBeInstanceOf(Date);
+  });
+
+  it('flips pending → rejected', async () => {
+    const { set } = mockUpdate([{ id: 'exec-1' }]);
+    const flipped = await mirrorElevationDecisionToExecution(db, 'exec-1', false, null);
+    expect(flipped).toBe(true);
+    expect(set).toHaveBeenCalledWith({ status: 'rejected' });
+  });
+
+  it('returns false when execution is not pending (CAS 0 rows)', async () => {
+    mockUpdate([]);
+    const flipped = await mirrorElevationDecisionToExecution(db, 'exec-1', true, 'user-9');
+    expect(flipped).toBe(false);
+  });
+});

--- a/apps/api/src/services/pamToolActionGovernance.ts
+++ b/apps/api/src/services/pamToolActionGovernance.ts
@@ -1,0 +1,225 @@
+/**
+ * Phase 1 Helper privileged-action governance (security finding A).
+ *
+ * Models a governed (tier>=2) Helper tool invocation as a PAM elevation
+ * request (flow_type='ai_tool_action') and decides it through the PAM rule
+ * engine. pamBridge is deliberately skipped — it is executable-shaped and
+ * has no binding for a tool action. The decision is mirrored onto
+ * ai_tool_executions.status so the SDK gate's waitForApproval() unblocks
+ * with no change to its polling contract:
+ *   auto_approve            → elevation auto_approved → execution approved
+ *   auto_deny               → elevation denied        → execution rejected
+ *   require_approval / none → elevation pending; an admin decides via
+ *     POST /pam/elevation-requests/:id/respond (separate identity,
+ *     pam:execute + MFA), whose handler calls the mirror in-transaction.
+ * FAIL SAFE: any error → 'pending' (never auto-approve on failure).
+ */
+import { createHash } from 'node:crypto';
+import { and, eq, isNull, or } from 'drizzle-orm';
+import { db, withDbAccessContext } from '../db';
+import {
+  aiToolExecutions,
+  devices,
+  elevationAudit,
+  elevationRequests,
+  pamRules,
+} from '../db/schema';
+import { evaluatePamToolActionRules } from './pamRuleEngine';
+import { publishEvent } from './eventBus';
+
+const AUTO_APPROVE_DEFAULT_DURATION_MINUTES = 15;
+
+export type ToolActionDecision = 'auto_approved' | 'denied' | 'pending';
+
+export interface ToolActionParams {
+  orgId: string;
+  deviceId: string;
+  /** The pending ai_tool_executions row the SDK gate is polling. */
+  executionId: string;
+  /** Bare tool name (mcp__breeze__ prefix already stripped). */
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  /** Guardrail tier (2–3 today). */
+  riskTier: number;
+  /** Helper identity — the device hostname. */
+  subjectUsername: string;
+}
+
+type DbExecutor = Pick<typeof db, 'update'>;
+
+/**
+ * CAS the linked ai_tool_executions row out of 'pending'. Returns whether a
+ * row actually flipped — false means the execution was already decided
+ * (e.g. waitForApproval timed out and marked it rejected). Accepts a
+ * transaction handle so /respond can mirror atomically with its own CAS.
+ */
+export async function mirrorElevationDecisionToExecution(
+  executor: DbExecutor,
+  executionId: string,
+  approved: boolean,
+  approvedByUserId: string | null,
+): Promise<boolean> {
+  const updated = await executor
+    .update(aiToolExecutions)
+    .set(
+      approved
+        ? { status: 'approved', approvedBy: approvedByUserId, approvedAt: new Date() }
+        : { status: 'rejected' },
+    )
+    .where(and(eq(aiToolExecutions.id, executionId), eq(aiToolExecutions.status, 'pending')))
+    .returning({ id: aiToolExecutions.id });
+  return updated.length > 0;
+}
+
+/**
+ * Create + decide the elevation request for a Helper tool action. Called
+ * from the preToolUse helper branch (services/aiAgentSdk.ts), which runs
+ * outside the request's ALS DB context — all DB work is wrapped here.
+ */
+export async function decideHelperToolAction(
+  params: ToolActionParams,
+): Promise<ToolActionDecision> {
+  try {
+    return await withDbAccessContext(
+      { scope: 'organization', orgId: params.orgId, accessibleOrgIds: [params.orgId] },
+      () => decideInContext(params),
+    );
+  } catch (err) {
+    console.error('[PAM-ToolAction] decisioning failed — failing safe to pending:', err);
+    return 'pending';
+  }
+}
+
+async function decideInContext(params: ToolActionParams): Promise<ToolActionDecision> {
+  const now = new Date();
+
+  const [device] = await db
+    .select({ siteId: devices.siteId, partnerId: devices.partnerId })
+    .from(devices)
+    .where(eq(devices.id, params.deviceId))
+    .limit(1);
+  const siteId = device?.siteId ?? null;
+
+  // Org rules, site-narrowed like ingest: an org-wide rule (site_id null)
+  // or a rule scoped to the device's own site.
+  const rules = await db
+    .select()
+    .from(pamRules)
+    .where(
+      and(
+        eq(pamRules.orgId, params.orgId),
+        eq(pamRules.enabled, true),
+        siteId ? or(isNull(pamRules.siteId), eq(pamRules.siteId, siteId)) : isNull(pamRules.siteId),
+      ),
+    );
+
+  const match = evaluatePamToolActionRules(rules, {
+    toolName: params.toolName,
+    riskTier: params.riskTier,
+    subjectUsername: params.subjectUsername,
+    at: now,
+  });
+
+  // 'ignore' has no suppress semantics for a tool action (the action must be
+  // decided one way or the other) — treat as no-match → pending.
+  const verdict = match && match.verdict !== 'ignore' ? match.verdict : null;
+  const decision: ToolActionDecision =
+    verdict === 'auto_approve' ? 'auto_approved' : verdict === 'auto_deny' ? 'denied' : 'pending';
+
+  const actionDigest = createHash('sha256')
+    .update(JSON.stringify(params.toolInput ?? {}))
+    .digest('hex');
+
+  const durationMinutes = match?.approvalDurationMinutes ?? AUTO_APPROVE_DEFAULT_DURATION_MINUTES;
+  const [row] = await db
+    .insert(elevationRequests)
+    .values({
+      orgId: params.orgId,
+      siteId,
+      partnerId: device?.partnerId ?? null,
+      deviceId: params.deviceId,
+      flowType: 'ai_tool_action',
+      subjectUserId: null,
+      subjectUsername: params.subjectUsername,
+      reason: `Breeze Helper requested AI tool '${params.toolName}' (tier ${params.riskTier})`,
+      status: decision,
+      requestedAt: now,
+      approvedAt: decision === 'auto_approved' ? now : null,
+      expiresAt:
+        decision === 'auto_approved'
+          ? new Date(now.getTime() + durationMinutes * 60_000)
+          : null,
+      denialReason:
+        decision === 'denied' ? `Denied by PAM rule '${match!.ruleName}'` : null,
+      executionId: params.executionId,
+      toolName: params.toolName,
+      actionDigest,
+      riskTier: params.riskTier,
+      metadata: match ? { pam_rule_id: match.ruleId, pam_rule_name: match.ruleName } : {},
+    })
+    .returning({ id: elevationRequests.id });
+
+  // Audit chain (best-effort — an audit hiccup must not flip a safe decision
+  // into a throw, mirroring ingest's posture).
+  try {
+    await db.insert(elevationAudit).values({
+      orgId: params.orgId,
+      elevationRequestId: row!.id,
+      eventType: 'requested',
+      actor: 'system',
+      actorUserId: null,
+      details: {
+        tool_name: params.toolName,
+        risk_tier: params.riskTier,
+        execution_id: params.executionId,
+      },
+      occurredAt: now,
+    });
+    if (decision !== 'pending') {
+      await db.insert(elevationAudit).values({
+        orgId: params.orgId,
+        elevationRequestId: row!.id,
+        eventType: decision === 'auto_approved' ? 'auto_approved' : 'denied',
+        actor: 'policy',
+        actorUserId: null,
+        details: { pam_rule_id: match!.ruleId, pam_rule_name: match!.ruleName },
+        occurredAt: now,
+      });
+    }
+  } catch (err) {
+    console.error('[PAM-ToolAction] audit insert failed (non-fatal):', err);
+  }
+
+  // Mirror auto verdicts onto the execution row the SDK gate is polling.
+  if (decision !== 'pending') {
+    await mirrorElevationDecisionToExecution(db, params.executionId, decision === 'auto_approved', null);
+  }
+
+  // Events (best-effort).
+  try {
+    const eventType =
+      decision === 'auto_approved'
+        ? ('elevation.auto_approved' as const)
+        : decision === 'denied'
+          ? ('elevation.denied' as const)
+          : ('elevation.requested' as const);
+    await publishEvent(
+      eventType,
+      params.orgId,
+      {
+        elevationRequestId: row!.id,
+        deviceId: params.deviceId,
+        flowType: 'ai_tool_action',
+        status: decision,
+        toolName: params.toolName,
+        executionId: params.executionId,
+        ...(match ? { pamRuleId: match.ruleId } : {}),
+      },
+      'pam-tool-action',
+    );
+  } catch (err) {
+    console.error('[PAM-ToolAction] event publish failed (non-fatal):', err);
+  }
+
+  return decision;
+}

--- a/apps/api/src/services/pamToolActionGovernance.ts
+++ b/apps/api/src/services/pamToolActionGovernance.ts
@@ -94,7 +94,7 @@ async function decideInContext(params: ToolActionParams): Promise<ToolActionDeci
   const now = new Date();
 
   const [device] = await db
-    .select({ siteId: devices.siteId, partnerId: devices.partnerId })
+    .select({ siteId: devices.siteId })
     .from(devices)
     .where(eq(devices.id, params.deviceId))
     .limit(1);
@@ -136,7 +136,7 @@ async function decideInContext(params: ToolActionParams): Promise<ToolActionDeci
     .values({
       orgId: params.orgId,
       siteId,
-      partnerId: device?.partnerId ?? null,
+      // partner_id stays null, matching the uac_intercept ingest.
       deviceId: params.deviceId,
       flowType: 'ai_tool_action',
       subjectUserId: null,

--- a/docs/superpowers/plans/2026-06-10-helper-pam-phase1-tool-action-governance.md
+++ b/docs/superpowers/plans/2026-06-10-helper-pam-phase1-tool-action-governance.md
@@ -1,0 +1,1020 @@
+# Helper Tool-Action PAM Governance (Phase 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Model mutating Breeze Helper tool invocations as PAM `elevation_requests` (new `flow_type='ai_tool_action'`), decide them through `pamRuleEngine` tool-action rules (fail-safe to pending), approve them only via the existing separate-identity `POST /pam/elevation-requests/:id/respond`, and bridge the decision back to `ai_tool_executions.status` so `waitForApproval` unblocks unchanged — then re-enable mutating Helper tools under this governance.
+
+**Architecture:** The hook point is the per-step approval branch of `createSessionPreToolUse` (`services/aiAgentSdk.ts`), which already inserts the pending `ai_tool_executions` row and blocks on `waitForApproval`. When `session.auth.helperDeviceId` is set, a new service (`pamToolActionGovernance.ts`) creates the elevation row, runs tool-action rules (`matchToolName`/`matchRiskTier`, new columns on `pam_rules`), and mirrors auto verdicts onto the execution row. Manual approvals flow through the existing `/respond` handler, which gains an in-transaction mirror keyed on the new `elevation_requests.execution_id`. `pamBridge` (executable-shaped) is deliberately skipped.
+
+**Tech Stack:** Hono + Drizzle + Vitest (API), hand-written idempotent SQL migrations, PG enums + RLS (elevation_requests/pam_rules already Shape-1 covered).
+
+**Spec:** `docs/superpowers/specs/2026-06-10-helper-privileged-action-pam-governance-design.md` (Phase 1 sections 1.1–1.6).
+
+**Ground truths discovered during planning (do not re-derive):**
+- `#1183` is merged; PAM code is on main. There is **no `/pam` admin web UI yet** (the `2026-06-09-pam-web-admin-ui.md` plan is unshipped) — spec §1.5's UI surfacing reduces to API support (list `flowType` filter + rules CRUD criteria). Do not build a web UI in this plan.
+- `ALTER TYPE ... ADD VALUE` + a CHECK constraint referencing the new value **cannot share one transaction** ("unsafe use of new value of enum type"). `autoMigrate` wraps each *file* in one transaction → two migration files (`-a-`/`-b-`).
+- The existing `elevation_requests_flow_shape_chk` has no branch for a third flow_type — it must be re-created or every `ai_tool_action` insert fails.
+- Helper sessions have a synthetic user whose `id` is the **device id** — the `approval_requests` bridge (FK to `users`) and mobile push must be skipped on the helper path.
+- Tier source is `guardrailCheck.tier` (from `checkGuardrails`, tiers 1–4; tier ≥ 2 requires approval; tier 4 is blocked earlier).
+- `s1_threat_action` takes `threatIds` (not device-pinnable) — it must NOT return to the helper tool sets. All other returning tools take `deviceId`.
+- `waitForApproval` (`services/aiAgent.ts:181`) polls for `'approved'`/`'rejected'` and times out at the caller-supplied 300s, marking the row `rejected`. Its contract is untouched.
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `apps/api/migrations/2026-06-10-a-elevation-flow-type-ai-tool-action.sql` | Create — enum value only |
+| `apps/api/migrations/2026-06-10-b-helper-tool-action-elevations.sql` | Create — columns, constraint, indexes |
+| `apps/api/src/db/schema/elevations.ts` | Modify — flow enum + 4 columns |
+| `apps/api/src/db/schema/pam.ts` | Modify — 2 match-criteria columns |
+| `apps/api/src/services/pamRuleEngine.ts` | Modify — tool-action candidate + criteria |
+| `apps/api/src/services/pamRuleEngine.test.ts` | Modify — new criteria tests |
+| `apps/api/src/services/pamToolActionGovernance.ts` | Create — decision + status bridge |
+| `apps/api/src/services/pamToolActionGovernance.test.ts` | Create |
+| `apps/api/src/services/aiAgentSdk.ts` | Modify — helper branch in preToolUse |
+| `apps/api/src/services/aiAgentSdk.test.ts` | Modify — helper-branch tests |
+| `apps/api/src/routes/pam.ts` | Modify — flowType filter, respond mirror, rules criteria |
+| `apps/api/src/routes/pam.test.ts` | Modify |
+| `apps/api/src/services/helperToolFilter.ts` | Modify — governed standard/extended sets |
+| `apps/api/src/services/helperToolFilter.test.ts` | Modify |
+| `apps/api/src/services/aiTools.ts` | Modify — HELPER_TOOL_SCOPING additions |
+| `apps/api/src/services/aiTools.test.ts` (or wherever Phase 0 gate tests live) | Modify |
+
+One PR for the whole plan (single logical change: Phase 1 governance pipeline). Commit after every task.
+
+Environment: work in the `helper-pam-phase1` worktree; prefix all pnpm/vitest/tsc with `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH`. Run API tests as e.g. `PATH=... npx vitest run src/services/pamRuleEngine.test.ts` from `apps/api/`. Known pre-existing tsc errors: `agents.test.ts`, `apiKeyAuth.test.ts`. Full-suite parallel flakiness is known — verify via affected files single-fork, trust CI for the rest.
+
+---
+
+### Task 1: Migrations + Drizzle schema
+
+**Files:**
+- Create: `apps/api/migrations/2026-06-10-a-elevation-flow-type-ai-tool-action.sql`
+- Create: `apps/api/migrations/2026-06-10-b-helper-tool-action-elevations.sql`
+- Modify: `apps/api/src/db/schema/elevations.ts`
+- Modify: `apps/api/src/db/schema/pam.ts`
+
+- [ ] **Step 1: Write migration `-a-` (enum value only — must be its own file/transaction)**
+
+```sql
+-- 2026-06-10-a-elevation-flow-type-ai-tool-action.sql
+--
+-- Phase 1 of Helper privileged-action governance (security finding A):
+-- Helper AI tool actions become PAM elevation requests. The enum value is
+-- added in its own migration file because the -b- file's CHECK constraint
+-- references it, and PG forbids using a new enum value in the transaction
+-- that added it ("unsafe use of new value of enum type"). autoMigrate wraps
+-- each file in one transaction, so the file split is the transaction split.
+ALTER TYPE elevation_flow_type ADD VALUE IF NOT EXISTS 'ai_tool_action';
+```
+
+- [ ] **Step 2: Write migration `-b-` (columns, constraint, indexes)**
+
+```sql
+-- 2026-06-10-b-helper-tool-action-elevations.sql
+--
+-- Phase 1 (Helper tool-action governance, spec 2026-06-10):
+--   * elevation_requests gains the ai_tool_action shape: execution_id links
+--     the PAM decision back to ai_tool_executions (the gate waitForApproval
+--     polls), plus tool_name / action_digest / risk_tier.
+--   * pam_rules gains tool-action match criteria (match_tool_name,
+--     match_risk_tier) so org/site policy can auto_approve / auto_deny /
+--     require_approval specific Helper tools.
+-- No RLS changes: both tables are already Shape-1 org-scoped; new columns
+-- inherit the existing policies.
+
+-- elevation_requests: ai_tool_action columns ------------------------------
+ALTER TABLE elevation_requests
+  ADD COLUMN IF NOT EXISTS execution_id uuid REFERENCES ai_tool_executions(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS tool_name varchar(100),
+  ADD COLUMN IF NOT EXISTS action_digest varchar(64),
+  ADD COLUMN IF NOT EXISTS risk_tier smallint;
+
+-- Mirror-lookup hot path: /respond resolves execution_id for ai_tool_action rows.
+CREATE INDEX IF NOT EXISTS elevation_requests_execution_id_idx
+  ON elevation_requests (execution_id)
+  WHERE execution_id IS NOT NULL;
+
+-- Re-create the flow-shape constraint with the third branch. Note:
+-- execution_id is deliberately NOT required by the constraint — its FK is
+-- ON DELETE SET NULL, so requiring it would make ai_tool_executions rows
+-- undeletable underneath historical elevations.
+ALTER TABLE elevation_requests
+  DROP CONSTRAINT IF EXISTS elevation_requests_flow_shape_chk;
+ALTER TABLE elevation_requests
+  ADD CONSTRAINT elevation_requests_flow_shape_chk
+  CHECK (
+    (flow_type = 'tech_jit_admin' AND subject_user_id IS NOT NULL)
+    OR
+    (flow_type = 'uac_intercept' AND target_executable_path IS NOT NULL)
+    OR
+    (flow_type = 'ai_tool_action' AND tool_name IS NOT NULL)
+  );
+
+-- pam_rules: tool-action match criteria -----------------------------------
+ALTER TABLE pam_rules
+  ADD COLUMN IF NOT EXISTS match_tool_name varchar(100),
+  ADD COLUMN IF NOT EXISTS match_risk_tier smallint;
+```
+
+- [ ] **Step 3: Update `apps/api/src/db/schema/elevations.ts`**
+
+Add `'ai_tool_action'` to the flow-type enum:
+
+```ts
+export const elevationFlowTypeEnum = pgEnum('elevation_flow_type', [
+  'uac_intercept',
+  'tech_jit_admin',
+  'ai_tool_action',
+]);
+```
+
+Add the columns to `elevationRequests` directly after the `softwarePolicyMatchId` block (import `aiToolExecutions` from `./ai` at the top of the file):
+
+```ts
+    // ai_tool_action flow (Phase 1, spec 2026-06-10): links the PAM decision
+    // back to the AI tool gate. ON DELETE SET NULL — historical elevations
+    // outlive their execution rows; flow_shape_chk requires tool_name only.
+    executionId: uuid('execution_id').references(() => aiToolExecutions.id, {
+      onDelete: 'set null',
+    }),
+    toolName: varchar('tool_name', { length: 100 }),
+    actionDigest: varchar('action_digest', { length: 64 }),
+    riskTier: smallint('risk_tier'),
+```
+
+Add `smallint` to the `drizzle-orm/pg-core` import in that file.
+
+- [ ] **Step 4: Update `apps/api/src/db/schema/pam.ts`**
+
+After `matchAdGroup`:
+
+```ts
+    // Tool-action criteria (Phase 1 Helper governance). A rule is either
+    // executable-shaped (signer/hash/path/parent) or tool-action-shaped
+    // (tool name / risk tier) — the API layer rejects mixing the two.
+    matchToolName: varchar('match_tool_name', { length: 100 }),
+    matchRiskTier: smallint('match_risk_tier'),
+```
+
+Add `smallint` to the pg-core import.
+
+- [ ] **Step 5: Verify drift + migration ordering test**
+
+```bash
+cd /Users/toddhebebrand/breeze/.claude/worktrees/helper-pam-phase1
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm db:check-drift
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/db/autoMigrate.test.ts
+```
+Expected: no drift; ordering test passes (date-prefixed `-a-` < `-b-`). If the local DB doesn't have the migrations applied, apply by booting the API once or running autoMigrate; drift check requires migrations applied.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/migrations/2026-06-10-a-elevation-flow-type-ai-tool-action.sql \
+        apps/api/migrations/2026-06-10-b-helper-tool-action-elevations.sql \
+        apps/api/src/db/schema/elevations.ts apps/api/src/db/schema/pam.ts
+git commit -m "feat(pam): ai_tool_action elevation flow + tool-action rule criteria (Phase 1 schema)"
+```
+
+---
+
+### Task 2: pamRuleEngine — tool-action candidate + criteria (TDD)
+
+**Files:**
+- Modify: `apps/api/src/services/pamRuleEngine.ts`
+- Test: `apps/api/src/services/pamRuleEngine.test.ts`
+
+**Design (locked):**
+- `PamRuleCandidate.targetExecutablePath` becomes optional; new optional `toolName` / `riskTier`. Every criterion treats an absent candidate field as **no match** (this is already the pattern for hash/signer/parent).
+- `matchToolName`: exact, case-insensitive. `matchRiskTier`: exact numeric equality (predictable; tiers are 2/3 in practice).
+- `hasAnyCriteria` includes the new fields (a matchToolName-only rule is valid).
+- New export `evaluatePamToolActionRules(rules, candidate)`: pre-filters to rules carrying **at least one tool-action criterion**, then delegates to `evaluatePamRules`. This is the safety wall: a pre-existing matchUser-only UAC rule must never auto-approve Helper tool actions.
+- The executable path needs no filtering: a rule with `matchToolName`/`matchRiskTier` set can't match an executable candidate because those candidate fields are absent → criterion fails.
+
+- [ ] **Step 1: Write the failing tests** (append a `describe` block to `pamRuleEngine.test.ts`, reusing the file's existing rule-factory helper if present — otherwise build rules as plain objects matching `PamRule`):
+
+```ts
+describe('tool-action rules (Phase 1 helper governance)', () => {
+  const baseRule = (over: Partial<PamRule>): PamRule => ({
+    id: '00000000-0000-0000-0000-000000000001',
+    orgId: 'org-1', siteId: null,
+    name: 'r', description: null, enabled: true, priority: 100,
+    matchSigner: null, matchHash: null, matchPathGlob: null,
+    matchParentImage: null, matchUser: null, matchAdGroup: null,
+    matchToolName: null, matchRiskTier: null,
+    timeWindow: null, verdict: 'auto_approve', approvalDurationMinutes: null,
+    createdByUserId: null, createdAt: new Date('2026-01-01'), updatedAt: new Date('2026-01-01'),
+    ...over,
+  });
+  const toolCandidate = { toolName: 'manage_services', riskTier: 2, subjectUsername: 'HOST-01' };
+
+  it('matches on tool name, case-insensitive', () => {
+    const m = evaluatePamToolActionRules([baseRule({ matchToolName: 'Manage_Services' })], toolCandidate);
+    expect(m?.verdict).toBe('auto_approve');
+  });
+
+  it('does not match a different tool name', () => {
+    expect(evaluatePamToolActionRules([baseRule({ matchToolName: 'execute_command' })], toolCandidate)).toBeNull();
+  });
+
+  it('matches risk tier exactly', () => {
+    expect(evaluatePamToolActionRules([baseRule({ matchRiskTier: 2 })], toolCandidate)?.verdict).toBe('auto_approve');
+    expect(evaluatePamToolActionRules([baseRule({ matchRiskTier: 3 })], toolCandidate)).toBeNull();
+  });
+
+  it('ANDs tool criteria with user and time window', () => {
+    const rule = baseRule({
+      matchToolName: 'manage_services', matchUser: 'host-01',
+      timeWindow: { start: '00:00', end: '23:59' },
+    });
+    expect(evaluatePamToolActionRules([rule], { ...toolCandidate, at: new Date() })?.verdict).toBe('auto_approve');
+    expect(evaluatePamToolActionRules([rule], { ...toolCandidate, subjectUsername: 'other', at: new Date() })).toBeNull();
+  });
+
+  it('a matchUser-only rule never matches tool actions (filtered out)', () => {
+    expect(evaluatePamToolActionRules([baseRule({ matchUser: 'host-01' })], toolCandidate)).toBeNull();
+  });
+
+  it('an executable rule never matches tool actions', () => {
+    expect(evaluatePamToolActionRules([baseRule({ matchHash: 'a'.repeat(64) })], toolCandidate)).toBeNull();
+  });
+
+  it('a tool-action rule never matches an executable candidate via evaluatePamRules', () => {
+    const m = evaluatePamRules([baseRule({ matchToolName: 'manage_services' })], {
+      targetExecutablePath: 'C:\\x.exe', subjectUsername: 'alice',
+    });
+    expect(m).toBeNull();
+  });
+
+  it('criteria-less rules still match nothing', () => {
+    expect(evaluatePamToolActionRules([baseRule({})], toolCandidate)).toBeNull();
+  });
+
+  it('matchPathGlob fails closed when candidate has no executable path', () => {
+    expect(evaluatePamRules([baseRule({ matchPathGlob: '**' })], { subjectUsername: 'a', toolName: 't' })).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/services/pamRuleEngine.test.ts
+```
+Expected: FAIL — `evaluatePamToolActionRules` not exported; type errors for new candidate fields.
+
+- [ ] **Step 3: Implement in `pamRuleEngine.ts`**
+
+Candidate interface:
+
+```ts
+export interface PamRuleCandidate {
+  /** Absent for ai_tool_action candidates. */
+  targetExecutablePath?: string;
+  targetExecutableHash?: string;
+  targetExecutableSigner?: string;
+  subjectUsername: string;
+  parentImage?: string;
+  /** AD/local group names of the subject, when known. */
+  subjectAdGroups?: string[];
+  /** ai_tool_action candidates: bare tool name (no mcp__ prefix). */
+  toolName?: string;
+  /** ai_tool_action candidates: guardrail tier (2–3 today). */
+  riskTier?: number;
+  /** Evaluation instant; injectable for tests. Defaults to now. */
+  at?: Date;
+}
+```
+
+`hasAnyCriteria` gains the two fields (note `matchRiskTier` can legitimately be `0`, use explicit null check):
+
+```ts
+function hasAnyCriteria(rule: PamRule): boolean {
+  return Boolean(
+    rule.matchSigner ||
+      rule.matchHash ||
+      rule.matchPathGlob ||
+      rule.matchParentImage ||
+      rule.matchUser ||
+      rule.matchAdGroup ||
+      rule.matchToolName ||
+      rule.matchRiskTier != null,
+  );
+}
+```
+
+In `ruleMatches`, make the path criterion fail closed on absent path, and add the new criteria:
+
+```ts
+  if (rule.matchPathGlob) {
+    if (!candidate.targetExecutablePath) return false;
+    if (!matchPathGlob(rule.matchPathGlob, candidate.targetExecutablePath)) return false;
+  }
+  // ... existing parent/user/adGroup checks unchanged ...
+  if (rule.matchToolName) {
+    if (!candidate.toolName) return false;
+    if (!eqCi(rule.matchToolName, candidate.toolName)) return false;
+  }
+  if (rule.matchRiskTier != null) {
+    if (candidate.riskTier == null) return false;
+    if (rule.matchRiskTier !== candidate.riskTier) return false;
+  }
+```
+
+New export at the bottom:
+
+```ts
+/** A rule is tool-action-shaped when it carries a tool-action criterion. */
+export function hasToolActionCriterion(rule: Pick<PamRule, 'matchToolName' | 'matchRiskTier'>): boolean {
+  return Boolean(rule.matchToolName) || rule.matchRiskTier != null;
+}
+
+/**
+ * Evaluate an ai_tool_action candidate. Only rules carrying at least one
+ * tool-action criterion participate — a pre-existing user-only or
+ * executable rule must never govern Helper tool actions.
+ */
+export function evaluatePamToolActionRules(
+  rules: PamRule[],
+  candidate: PamRuleCandidate,
+): PamRuleMatch | null {
+  return evaluatePamRules(rules.filter(hasToolActionCriterion), candidate);
+}
+```
+
+Update the file-top doc comment to mention tool-action criteria.
+
+- [ ] **Step 4: Run tests to verify they pass** (same command). Also run `npx vitest run src/services/pamBridge.test.ts src/routes/agents/elevationRequests.test.ts` — the candidate type widening must not regress the UAC ingest path or its types.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/pamRuleEngine.ts apps/api/src/services/pamRuleEngine.test.ts
+git commit -m "feat(pam): tool-action rule criteria (matchToolName/matchRiskTier) in rule engine"
+```
+
+---
+
+### Task 3: Governance service + status bridge (TDD)
+
+**Files:**
+- Create: `apps/api/src/services/pamToolActionGovernance.ts`
+- Test: `apps/api/src/services/pamToolActionGovernance.test.ts`
+
+**Design (locked):**
+- `decideHelperToolAction(params)` — called from the preToolUse helper branch *after* the pending `ai_tool_executions` row exists. Creates the elevation row, evaluates rules, writes elevation_audit rows, emits events, mirrors auto verdicts. Returns `'auto_approved' | 'denied' | 'pending'`.
+- **Fail-safe:** any throw → log + return `'pending'` (mirrors ingest). A pending elevation that was never inserted simply lets `waitForApproval` time out (reject) — still safe.
+- Verdict mapping: `auto_approve` → elevation `auto_approved` (+ `approvedAt`, `expiresAt = now + (rule.approvalDurationMinutes ?? 15) min` — required by `status_timestamps_chk` is `approved_at` only, but keep the expiry for the Active tab semantics); `auto_deny` → `denied` (+ `denialReason`); `require_approval`, `ignore`, or no match → `pending`. `ignore` has no suppress semantics for tool actions — an action must be decided; treat as pending (document in code).
+- `subjectUserId` stays null (helper has no real user); `subjectUsername` = helper device hostname.
+- `actionDigest` = sha256 hex of `JSON.stringify(toolInput)`.
+- The service wraps all DB work in `withDbAccessContext({scope:'organization', orgId, accessibleOrgIds:[orgId]})` because preToolUse runs outside the request ALS context (same pattern as the surrounding aiAgentSdk.ts code). All work is fast DB-only — no slow I/O inside the context (per the txn pool-poison rule).
+- `mirrorElevationDecisionToExecution(executor, executionId, approved, approvedByUserId)` — CAS `pending → approved|rejected` on `ai_tool_executions`; returns whether a row flipped. Shared with `routes/pam.ts` (pass `tx`).
+
+- [ ] **Step 1: Write the failing tests.** Follow the repo's Drizzle-mock pattern (see `breeze-testing` skill and `apps/api/src/routes/agents/elevationRequests.test.ts` for the established mock style: `vi.mock('../db', ...)` with chainable query builders). Cover:
+
+```ts
+// pamToolActionGovernance.test.ts — outline; flesh out with the repo mock helpers
+describe('decideHelperToolAction', () => {
+  it('auto_approve rule → elevation auto_approved, execution mirrored to approved, audit requested+auto_approved, events requested+auto_approved');
+  it('auto_deny rule → elevation denied with denialReason, execution mirrored to rejected, audit denied');
+  it('require_approval rule → elevation pending, execution untouched, returns "pending"');
+  it('no matching rule → pending (default posture)');
+  it('ignore verdict → pending (no suppress semantics for tool actions)');
+  it('rule loading throws → returns "pending", logs, does not throw');
+  it('elevation insert includes flowType ai_tool_action, executionId, toolName, riskTier, sha256 actionDigest, device org/site');
+});
+describe('mirrorElevationDecisionToExecution', () => {
+  it('flips pending → approved with approvedBy/approvedAt');
+  it('flips pending → rejected');
+  it('returns false when execution is not pending (CAS 0 rows)');
+});
+```
+
+Assert the insert payload via the mock's captured `values()` argument; assert the mirror's `where` includes the `status='pending'` CAS condition.
+
+- [ ] **Step 2: Run to verify failure** (`npx vitest run src/services/pamToolActionGovernance.test.ts` → module not found).
+
+- [ ] **Step 3: Implement `pamToolActionGovernance.ts`:**
+
+```ts
+/**
+ * Phase 1 Helper privileged-action governance (security finding A).
+ *
+ * Models a governed (tier>=2) Helper tool invocation as a PAM elevation
+ * request (flow_type='ai_tool_action') and decides it through the PAM rule
+ * engine. pamBridge is deliberately skipped — it is executable-shaped and
+ * has no binding for a tool action. The decision is mirrored onto
+ * ai_tool_executions.status so the SDK gate's waitForApproval() unblocks
+ * with no change to its polling contract:
+ *   auto_approve            → elevation auto_approved → execution approved
+ *   auto_deny               → elevation denied        → execution rejected
+ *   require_approval / none → elevation pending; an admin decides via
+ *     POST /pam/elevation-requests/:id/respond (separate identity,
+ *     pam:execute + MFA), whose handler calls the mirror in-transaction.
+ * FAIL SAFE: any error → 'pending' (never auto-approve on failure).
+ */
+import { createHash } from 'node:crypto';
+import { and, eq, isNull, or } from 'drizzle-orm';
+import { db, withDbAccessContext } from '../db';
+import { aiToolExecutions, devices, elevationAudit, elevationRequests, pamRules } from '../db/schema';
+import { evaluatePamToolActionRules } from './pamRuleEngine';
+import { publishEvent } from '../services/eventBus';
+
+const AUTO_APPROVE_DEFAULT_DURATION_MINUTES = 15;
+
+export type ToolActionDecision = 'auto_approved' | 'denied' | 'pending';
+
+export interface ToolActionParams {
+  orgId: string;
+  deviceId: string;
+  executionId: string;
+  /** Bare tool name (mcp__breeze__ prefix already stripped). */
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  /** Guardrail tier (2–3). */
+  riskTier: number;
+  /** Helper identity — the device hostname. */
+  subjectUsername: string;
+}
+
+type DbExecutor = Pick<typeof db, 'update'>;
+
+/**
+ * CAS the linked ai_tool_executions row out of 'pending'. Returns whether a
+ * row actually flipped — false means the execution was already decided
+ * (e.g. waitForApproval timed out and marked it rejected).
+ */
+export async function mirrorElevationDecisionToExecution(
+  executor: DbExecutor,
+  executionId: string,
+  approved: boolean,
+  approvedByUserId: string | null,
+): Promise<boolean> {
+  const updated = await executor
+    .update(aiToolExecutions)
+    .set(
+      approved
+        ? { status: 'approved', approvedBy: approvedByUserId, approvedAt: new Date() }
+        : { status: 'rejected' },
+    )
+    .where(and(eq(aiToolExecutions.id, executionId), eq(aiToolExecutions.status, 'pending')))
+    .returning({ id: aiToolExecutions.id });
+  return updated.length > 0;
+}
+
+export async function decideHelperToolAction(params: ToolActionParams): Promise<ToolActionDecision> {
+  try {
+    return await withDbAccessContext(
+      { scope: 'organization', orgId: params.orgId, accessibleOrgIds: [params.orgId] },
+      () => decideInContext(params),
+    );
+  } catch (err) {
+    console.error('[PAM-ToolAction] decisioning failed — failing safe to pending:', err);
+    return 'pending';
+  }
+}
+
+async function decideInContext(params: ToolActionParams): Promise<ToolActionDecision> {
+  const now = new Date();
+
+  const [device] = await db
+    .select({ siteId: devices.siteId, partnerId: devices.partnerId })
+    .from(devices)
+    .where(eq(devices.id, params.deviceId))
+    .limit(1);
+  const siteId = device?.siteId ?? null;
+
+  // Org rules, site-narrowed the same way ingest narrows them: an org-wide
+  // rule (site_id null) or a rule for the device's own site.
+  const rules = await db
+    .select()
+    .from(pamRules)
+    .where(
+      and(
+        eq(pamRules.orgId, params.orgId),
+        eq(pamRules.enabled, true),
+        siteId ? or(isNull(pamRules.siteId), eq(pamRules.siteId, siteId)) : isNull(pamRules.siteId),
+      ),
+    );
+
+  const match = evaluatePamToolActionRules(rules, {
+    toolName: params.toolName,
+    riskTier: params.riskTier,
+    subjectUsername: params.subjectUsername,
+    at: now,
+  });
+
+  // 'ignore' has no suppress semantics for a tool action (the action must be
+  // decided one way or the other) — treat as no-match → pending.
+  const verdict = match && match.verdict !== 'ignore' ? match.verdict : null;
+  const decision: ToolActionDecision =
+    verdict === 'auto_approve' ? 'auto_approved' : verdict === 'auto_deny' ? 'denied' : 'pending';
+
+  const actionDigest = createHash('sha256')
+    .update(JSON.stringify(params.toolInput ?? {}))
+    .digest('hex');
+
+  const durationMinutes = match?.approvalDurationMinutes ?? AUTO_APPROVE_DEFAULT_DURATION_MINUTES;
+  const [row] = await db
+    .insert(elevationRequests)
+    .values({
+      orgId: params.orgId,
+      siteId,
+      partnerId: device?.partnerId ?? null,
+      deviceId: params.deviceId,
+      flowType: 'ai_tool_action',
+      subjectUserId: null,
+      subjectUsername: params.subjectUsername,
+      reason: `Breeze Helper requested AI tool '${params.toolName}' (tier ${params.riskTier})`,
+      status: decision,
+      requestedAt: now,
+      approvedAt: decision === 'auto_approved' ? now : null,
+      expiresAt: decision === 'auto_approved' ? new Date(now.getTime() + durationMinutes * 60_000) : null,
+      denialReason: decision === 'denied' ? `Denied by PAM rule '${match!.ruleName}'` : null,
+      executionId: params.executionId,
+      toolName: params.toolName,
+      actionDigest,
+      riskTier: params.riskTier,
+      metadata: match ? { pam_rule_id: match.ruleId, pam_rule_name: match.ruleName } : {},
+    })
+    .returning({ id: elevationRequests.id });
+
+  // Audit chain (best-effort — must not flip a safe decision into a throw).
+  try {
+    await db.insert(elevationAudit).values({
+      orgId: params.orgId,
+      elevationRequestId: row!.id,
+      eventType: 'requested',
+      actor: 'system',
+      actorUserId: null,
+      details: { tool_name: params.toolName, risk_tier: params.riskTier, execution_id: params.executionId },
+      occurredAt: now,
+    });
+    if (decision !== 'pending') {
+      await db.insert(elevationAudit).values({
+        orgId: params.orgId,
+        elevationRequestId: row!.id,
+        eventType: decision === 'auto_approved' ? 'auto_approved' : 'denied',
+        actor: 'policy',
+        actorUserId: null,
+        details: { pam_rule_id: match!.ruleId, pam_rule_name: match!.ruleName },
+        occurredAt: now,
+      });
+    }
+  } catch (err) {
+    console.error('[PAM-ToolAction] audit insert failed (non-fatal):', err);
+  }
+
+  // Mirror auto verdicts onto the execution row the SDK gate is polling.
+  if (decision !== 'pending') {
+    await mirrorElevationDecisionToExecution(db, params.executionId, decision === 'auto_approved', null);
+  }
+
+  // Events (best-effort).
+  try {
+    const eventType =
+      decision === 'auto_approved'
+        ? 'elevation.auto_approved'
+        : decision === 'denied'
+          ? 'elevation.denied'
+          : 'elevation.requested';
+    await publishEvent(eventType, params.orgId, {
+      elevationRequestId: row!.id,
+      deviceId: params.deviceId,
+      flowType: 'ai_tool_action',
+      status: decision,
+      toolName: params.toolName,
+      executionId: params.executionId,
+      ...(match ? { pamRuleId: match.ruleId } : {}),
+    }, 'pam-tool-action');
+  } catch (err) {
+    console.error('[PAM-ToolAction] event publish failed (non-fatal):', err);
+  }
+
+  return decision;
+}
+```
+
+Verify against the real `publishEvent` signature and the ingest's rule-loading condition (`routes/agents/elevationRequests.ts` ~lines 191–235) — copy its exact site-narrowing shape if it differs from the above. Verify `EventType` includes `elevation.requested`/`elevation.auto_approved`/`elevation.denied` (it does — ingest emits them).
+
+- [ ] **Step 4: Run tests to verify they pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/pamToolActionGovernance.ts apps/api/src/services/pamToolActionGovernance.test.ts
+git commit -m "feat(pam): helper tool-action governance service + execution status bridge"
+```
+
+---
+
+### Task 4: preToolUse helper branch in aiAgentSdk.ts (TDD)
+
+**Files:**
+- Modify: `apps/api/src/services/aiAgentSdk.ts` (inside the `guardrailCheck.tier >= 2` block, currently lines ~265–538)
+- Test: `apps/api/src/services/aiAgentSdk.test.ts`
+
+**Design (locked):**
+- The helper branch comes **first** in the tier≥2 block, before the `auto_approve`-mode and plan-mode shortcuts — a Helper session must never bypass PAM via session approval mode.
+- It skips the `approval_requests` bridge and mobile push entirely (the synthetic helper user id is a **device id**; the users-FK insert would fail, and there is no mobile owner to push to).
+- It still publishes the `approval_required` SSE event (with `requiresAdminApproval: true`) so the Helper UI can render "waiting for administrator approval", and still ends with `waitForApproval` + mark-executing — the polling contract is unchanged. An auto-approved elevation flips the row before the first poll, so the wait returns immediately.
+
+- [ ] **Step 1: Write the failing tests.** Check how `aiAgentSdk.test.ts` builds an `ActiveSession` fixture and mocks `../db`; extend it. Mock `./pamToolActionGovernance`:
+
+```ts
+vi.mock('./pamToolActionGovernance', () => ({
+  decideHelperToolAction: vi.fn(),
+  mirrorElevationDecisionToExecution: vi.fn(),
+}));
+vi.mock('./aiAgent', async (orig) => ({ ...(await orig()), waitForApproval: vi.fn() }));
+```
+
+Cases (helper session = fixture whose `session.auth.helperDeviceId = 'dev-1'`):
+1. Tier-2 tool on a helper session calls `decideHelperToolAction` with `{ orgId, deviceId: 'dev-1', executionId: <inserted id>, toolName: <bare name>, riskTier: 2 }` and does **not** insert an `approval_requests` row.
+2. `decideHelperToolAction` resolves `'denied'` → preToolUse returns `{ allowed: false }` and `waitForApproval` is never called.
+3. `decideHelperToolAction` resolves `'pending'`, `waitForApproval` resolves `true` → `{ allowed: true }` and execution marked executing.
+4. Helper session with `session.approvalMode = 'auto_approve'` and a tier-2 tool **still** goes through `decideHelperToolAction` (no bypass).
+5. Non-helper session behavior unchanged (existing tests keep passing).
+
+- [ ] **Step 2: Run to verify failure** (`npx vitest run src/services/aiAgentSdk.test.ts`).
+
+- [ ] **Step 3: Implement.** At the top of the `if (guardrailCheck.tier >= 2) {` block, insert:
+
+```ts
+      // Helper sessions: PAM governs (Phase 1, security finding A). This
+      // branch precedes the auto_approve/plan shortcuts on purpose — a
+      // helper token must never self-relax the approval gate. The
+      // approval_requests/mobile bridge is skipped: the synthetic helper
+      // "user" id is a device id (no users-FK row, no mobile owner).
+      if (session.auth.helperDeviceId) {
+        const helperDeviceId = session.auth.helperDeviceId;
+        let helperExec: { id: string } | undefined;
+        try {
+          const [row] = await withDbAccessContext(
+            { scope: 'organization', orgId: session.orgId, accessibleOrgIds: [session.orgId] },
+            () =>
+              db
+                .insert(aiToolExecutions)
+                .values({
+                  sessionId: session.breezeSessionId,
+                  toolName,
+                  toolInput: input,
+                  status: 'pending',
+                })
+                .returning()
+          );
+          helperExec = row;
+        } catch (err) {
+          console.error('[AI-SDK] Failed to create helper approval record:', toolName, err);
+          return { allowed: false, error: 'Failed to create approval record' };
+        }
+        if (!helperExec) {
+          return { allowed: false, error: 'Failed to create approval record' };
+        }
+
+        session.eventBus.publish({
+          type: 'approval_required',
+          executionId: helperExec.id,
+          toolName,
+          input,
+          description: guardrailCheck.description ?? `Execute ${toolName}`,
+          requiresAdminApproval: true,
+        });
+
+        const decision = await decideHelperToolAction({
+          orgId: session.orgId,
+          deviceId: helperDeviceId,
+          executionId: helperExec.id,
+          toolName: stripMcpPrefix(toolName),
+          toolInput: input as Record<string, unknown>,
+          riskTier: guardrailCheck.tier,
+          subjectUsername: session.auth.user.name ?? 'helper',
+        });
+
+        if (decision === 'denied') {
+          return { allowed: false, error: 'This action was denied by organization policy' };
+        }
+
+        const approved = await waitForApproval(helperExec.id, 300_000, session.abortController.signal);
+        if (!approved) {
+          return { allowed: false, error: 'Tool execution was rejected or timed out awaiting administrator approval' };
+        }
+
+        try {
+          await withDbAccessContext(
+            { scope: 'organization', orgId: session.orgId, accessibleOrgIds: [session.orgId] },
+            () =>
+              db
+                .update(aiToolExecutions)
+                .set({ status: 'executing' })
+                .where(eq(aiToolExecutions.id, helperExec!.id))
+          );
+        } catch (err) {
+          console.error('[AI-SDK] Failed to update helper approval to executing:', helperExec.id, err);
+        }
+        return { allowed: true };
+      }
+```
+
+Import `decideHelperToolAction` from `./pamToolActionGovernance`. If the session event-bus payload type rejects `requiresAdminApproval`, extend the `approval_required` event type where it is defined (find via `type: 'approval_required'` in `streamingSessionManager.ts` / event type unions) with an optional `requiresAdminApproval?: boolean`.
+
+- [ ] **Step 4: Run the test file + neighbors:**
+
+```bash
+npx vitest run src/services/aiAgentSdk.test.ts src/services/aiAgentSdk.m365risk.test.ts src/services/aiAgentSdkTools.sessionAware.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/aiAgentSdk.ts apps/api/src/services/aiAgentSdk.test.ts
+git commit -m "feat(ai): route helper tier-2+ tool calls through PAM governance at preToolUse"
+```
+
+---
+
+### Task 5: routes/pam.ts — flowType filter, respond mirror, tool-action rule CRUD (TDD)
+
+**Files:**
+- Modify: `apps/api/src/routes/pam.ts`
+- Test: `apps/api/src/routes/pam.test.ts`
+
+**Design (locked):**
+- `listQuerySchema.flowType` gains `'ai_tool_action'`.
+- `/respond` for `ai_tool_action` rows mirrors onto the execution **inside the same transaction**, ordered: elevation CAS → audit → mirror CAS; a failed mirror (execution no longer pending, e.g. the 5-min wait already timed out) rolls the whole transaction back via `tx.rollback()` and returns 409 — approving a stale request must not leave an `approved` elevation pointing at a rejected execution.
+- Rules CRUD: add `matchToolName` / `matchRiskTier` to the zod schema and inserts/updates. Validation refine: a rule must have ≥1 criterion, must NOT mix executable criteria with tool-action criteria, and a tool-action rule may not use `verdict: 'ignore'` (no suppress semantics for tool actions). Same checks on the PATCH merged result.
+
+- [ ] **Step 1: Write the failing tests** (extend `pam.test.ts`, following its existing handler-test style):
+
+1. `GET /elevation-requests?flowType=ai_tool_action` is accepted (200) and filters.
+2. `/respond` approve on an `ai_tool_action` row with a pending execution → 200; execution updated to `approved` with `approvedBy = auth.user.id`; elevation `approved`; audit row written.
+3. `/respond` deny → execution `rejected`, elevation `denied`.
+4. `/respond` approve when the linked execution is no longer pending (mirror CAS returns 0 rows) → 409, transaction rolled back.
+5. `POST /rules` with only `matchToolName` → 201.
+6. `POST /rules` mixing `matchHash` + `matchToolName` → 400.
+7. `POST /rules` with `matchToolName` + `verdict: 'ignore'` → 400.
+8. `POST /rules` with no criteria still → 400 (regression).
+9. `PATCH /rules/:id` that would strip the last criterion or produce a mixed/ignore-tool-action rule → 400.
+
+- [ ] **Step 2: Run to verify failure** (`npx vitest run src/routes/pam.test.ts`).
+
+- [ ] **Step 3: Implement.**
+
+List filter:
+
+```ts
+  flowType: z.enum(['uac_intercept', 'tech_jit_admin', 'ai_tool_action']).optional(),
+```
+
+Respond — add `executionId: elevationRequests.executionId` to the initial `tx.select({...})`, and after the `elevationAudit` insert (before `return { kind: 'ok' ... }`):
+
+```ts
+      // ai_tool_action rows: mirror the decision onto the linked
+      // ai_tool_executions row the SDK gate is polling — in the SAME
+      // transaction. If the execution is no longer pending (the 5-min
+      // waitForApproval already timed out and rejected it), approving the
+      // elevation would be a lie: roll everything back and 409.
+      if (row.flowType === 'ai_tool_action' && row.executionId) {
+        const flipped = await mirrorElevationDecisionToExecution(
+          tx,
+          row.executionId,
+          approve,
+          approve ? auth.user.id : null,
+        );
+        if (!flipped) {
+          tx.rollback(); // throws TransactionRollbackError
+        }
+      }
+```
+
+Catch the rollback outside (drizzle's `tx.rollback()` throws; wrap the `db.transaction(...)` call):
+
+```ts
+    let result: Awaited<ReturnType<typeof runRespondTx>>;
+    try {
+      result = await runRespondTx();
+    } catch (err) {
+      if (err instanceof TransactionRollbackError) {
+        return c.json(
+          { success: false, error: 'Linked tool execution is no longer pending (it likely timed out)' },
+          409,
+        );
+      }
+      throw err;
+    }
+```
+
+(Where `runRespondTx` is the existing `db.transaction(async (tx) => {...})` extracted into a closure, unchanged otherwise. Import `TransactionRollbackError` from `drizzle-orm`; import `mirrorElevationDecisionToExecution` from `../services/pamToolActionGovernance`.)
+
+Rules CRUD — schema additions to `ruleBaseSchema`:
+
+```ts
+  matchToolName: z.string().min(1).max(100).nullable().optional(),
+  matchRiskTier: z.number().int().min(0).max(4).nullable().optional(),
+```
+
+Validation helpers (replace the single `createRuleSchema` refine; keep `hasExecutableCriterion` as-is but rename-safe):
+
+```ts
+type RuleCriteriaShape = {
+  matchSigner?: string | null; matchHash?: string | null; matchPathGlob?: string | null;
+  matchParentImage?: string | null; matchUser?: string | null; matchAdGroup?: string | null;
+  matchToolName?: string | null; matchRiskTier?: number | null;
+  verdict?: 'auto_approve' | 'auto_deny' | 'require_approval' | 'ignore';
+};
+
+const executableCriteriaFields = ['matchSigner', 'matchHash', 'matchPathGlob', 'matchParentImage'] as const;
+
+function hasToolActionCriteria(rule: RuleCriteriaShape): boolean {
+  return Boolean(rule.matchToolName) || rule.matchRiskTier != null;
+}
+function hasExecutableShapeCriteria(rule: RuleCriteriaShape): boolean {
+  return executableCriteriaFields.some((f) => Boolean(rule[f]));
+}
+
+/** Returns an error string, or null when the rule shape is valid. */
+function validateRuleShape(rule: RuleCriteriaShape): string | null {
+  if (!hasExecutableCriterion(rule) && !hasToolActionCriteria(rule)) {
+    return 'At least one match criterion (signer/hash/path/parent/user/group/tool/tier) is required';
+  }
+  if (hasExecutableShapeCriteria(rule) && hasToolActionCriteria(rule)) {
+    return 'A rule cannot mix executable criteria with tool-action criteria';
+  }
+  if (hasToolActionCriteria(rule) && rule.verdict === 'ignore') {
+    return "verdict 'ignore' is not valid for tool-action rules — a tool action must be decided";
+  }
+  return null;
+}
+
+const createRuleSchema = ruleBaseSchema.superRefine((rule, ctx) => {
+  const err = validateRuleShape(rule);
+  if (err) ctx.addIssue({ code: z.ZodIssueCode.custom, message: err });
+});
+```
+
+Note: `hasExecutableCriterion`'s field list (`ruleCriteriaFields`) already includes user/group; leave it — `validateRuleShape`'s first check uses it for "any criterion at all" together with the tool-action check. In the POST handler add to `.values({...})`:
+
+```ts
+      matchToolName: payload.matchToolName ?? null,
+      matchRiskTier: payload.matchRiskTier ?? null,
+```
+
+In PATCH: replace the `if (!hasExecutableCriterion(merged))` block with `const shapeErr = validateRuleShape(merged); if (shapeErr) return c.json({ error: shapeErr }, 400);` and add the two spread-set lines:
+
+```ts
+      ...(payload.matchToolName !== undefined ? { matchToolName: payload.matchToolName } : {}),
+      ...(payload.matchRiskTier !== undefined ? { matchRiskTier: payload.matchRiskTier } : {}),
+```
+
+- [ ] **Step 4: Run tests** (`npx vitest run src/routes/pam.test.ts`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/pam.ts apps/api/src/routes/pam.test.ts
+git commit -m "feat(pam): ai_tool_action respond mirror + tool-action rule criteria in admin API"
+```
+
+---
+
+### Task 6: Re-enable mutating Helper tools under governance (TDD)
+
+**Files:**
+- Modify: `apps/api/src/services/helperToolFilter.ts`
+- Modify: `apps/api/src/services/aiTools.ts` (`HELPER_TOOL_SCOPING`)
+- Test: `apps/api/src/services/helperToolFilter.test.ts` and the Phase 0 gate tests (find via `grep -rn "HELPER_TOOL_SCOPING" apps/api/src --include='*.test.ts'`)
+
+**Design (locked):**
+- Every tool in any helper set MUST have a `HELPER_TOOL_SCOPING` entry (the Phase 0 gate denies unscoped tools). Therefore the org-wide tools currently listed in `standard`/`extended` (`query_devices`, `get_fleet_health`, `get_s1_threats`, `get_backup_health`, `get_recovery_readiness`, `query_audit_log`, `get_log_trends`, `detect_log_correlations`, `query_change_log`, `get_cis_compliance`) are **removed** — they were dead weight (gate-denied) and a single-device assistant doesn't need fleet queries.
+- `s1_threat_action` is removed: it is keyed on `threatIds`, not a device, so it cannot be device-pinned.
+- New sets — **verify each tool's input schema actually declares `deviceId` before adding its scoping entry** (all were spot-checked during planning, but re-check `get_user_experience_metrics` in `aiToolsPerformance.ts` and `run_backup_verification`'s registration; drop any that are not device-keyed):
+
+```ts
+  basic: [ /* unchanged Phase 0 list */ ],
+  // standard = basic + device-pinned safe actions. Mutations are governed:
+  // tier>=2 calls go through PAM (flow_type=ai_tool_action) at the
+  // preToolUse gate — default posture require_approval unless an org rule
+  // says otherwise. Org-wide tools stay excluded (cannot be device-pinned).
+  standard: [
+    ...basic list...,
+    'get_active_users',
+    'get_user_experience_metrics',
+    'manage_alerts',
+    'manage_services',
+    'disk_cleanup',
+    'file_operations',
+  ],
+  // extended adds destructive single-device tools — always PAM-governed.
+  // s1_threat_action is deliberately absent (threat-keyed, not device-pinnable).
+  extended: [
+    ...standard list...,
+    'computer_control',
+    'execute_command',
+    'security_scan',
+    's1_isolate_device',
+    'network_discovery',
+    'apply_cis_remediation',
+    'run_backup_verification',
+  ],
+```
+
+- `HELPER_TOOL_SCOPING` additions in `aiTools.ts` (all `'deviceId'`): `get_active_users`, `get_user_experience_metrics`, `manage_alerts`, `manage_services`, `disk_cleanup`, `file_operations`, `computer_control`, `execute_command`, `security_scan`, `s1_isolate_device`, `network_discovery`, `apply_cis_remediation`, `run_backup_verification`.
+- Update the Phase-0 comment on both maps: capability is back under PAM governance; the two lists must stay in sync (every whitelisted tool has a scoping entry).
+
+- [ ] **Step 1: Write/extend failing tests:**
+  - `helperToolFilter.test.ts`: `standard` contains `manage_services`/`file_operations` but not `query_devices`/`s1_threat_action`; `extended` contains `execute_command` but no org-wide tool; `basic` unchanged.
+  - Cross-consistency test (place next to the existing Phase 0 gate tests): every tool in every `TOOL_WHITELIST` level exists in `HELPER_TOOL_SCOPING` — this pins the invariant the gate depends on:
+
+```ts
+import { HELPER_TOOL_SCOPING } from './aiTools';
+import { getHelperAllowedTools } from './helperToolFilter';
+
+it('every helper-whitelisted tool is device-scopable by the executeTool gate', () => {
+  for (const level of ['basic', 'standard', 'extended'] as const) {
+    for (const tool of getHelperAllowedTools(level)) {
+      expect(HELPER_TOOL_SCOPING[tool], `${level}:${tool}`).toBeDefined();
+    }
+  }
+});
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+- [ ] **Step 3: Implement both file changes.**
+
+- [ ] **Step 4: Run the filter tests + Phase 0 gate tests + helper route tests:**
+
+```bash
+npx vitest run src/services/helperToolFilter.test.ts src/services/aiTools.test.ts src/routes/helper/index.test.ts
+```
+
+(Adjust the gate-test path to wherever `HELPER_TOOL_SCOPING` tests actually live.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/helperToolFilter.ts apps/api/src/services/aiTools.ts \
+        apps/api/src/services/helperToolFilter.test.ts
+git commit -m "feat(helper): re-enable mutating single-device tools under PAM governance"
+```
+
+---
+
+### Task 7: Verification + PR
+
+- [ ] **Step 1: Type-check** — `cd apps/api && PATH=... npx tsc --noEmit` (pre-existing errors only: `agents.test.ts`, `apiKeyAuth.test.ts`).
+- [ ] **Step 2: Affected-file test sweep (single fork):**
+
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run \
+  src/services/pamRuleEngine.test.ts src/services/pamBridge.test.ts \
+  src/services/pamToolActionGovernance.test.ts src/services/aiAgentSdk.test.ts \
+  src/routes/pam.test.ts src/routes/agents/elevationRequests.test.ts \
+  src/services/helperToolFilter.test.ts src/routes/helper/index.test.ts \
+  src/db/autoMigrate.test.ts
+```
+
+- [ ] **Step 3: RLS contract test against local DB if available** (`vitest.config.rls.ts` / `rls-coverage.integration.test.ts`) — no allowlist change expected (no new tables; columns only). If the local DB isn't running, note it and trust CI/smoke.
+- [ ] **Step 4: Drift check** — `pnpm db:check-drift`.
+- [ ] **Step 5: Manual cross-tenant probe (if local DB available):** as `breeze_app`, forge an `ai_tool_action` insert for another org — must fail with the RLS violation (existing policies cover the new flow type automatically; this is a confidence check, not new coverage).
+- [ ] **Step 6: Push + PR** targeting `main`:
+
+```bash
+git push -u origin worktree-helper-pam-phase1
+gh pr create --title "feat(pam): Phase 1 — Helper privileged-action governance via PAM (finding A)" --body "$(cat <<'EOF'
+## Summary
+Phase 1 of the Helper privileged-action governance design (spec: docs/superpowers/specs/2026-06-10-helper-privileged-action-pam-governance-design.md). Folds Helper mutating-tool approval into PAM:
+
+- **Model**: `elevation_requests` gains `flow_type='ai_tool_action'` + `execution_id` FK to `ai_tool_executions`, `tool_name`, `action_digest`, `risk_tier` (new idempotent migrations `2026-06-10-a/-b-`; flow-shape CHECK re-created with the third branch).
+- **Decide**: tier>=2 Helper tool calls create an elevation at the preToolUse gate and run through `pamRuleEngine` tool-action criteria (`matchToolName`, `matchRiskTier` on `pam_rules`); `pamBridge` is skipped (executable-shaped). Fail-safe to pending. Helper sessions cannot bypass via session approval mode.
+- **Approve**: only the existing separate-identity `POST /pam/elevation-requests/:id/respond` (pam:execute + MFA, audited, emits `elevation.approved`). No new approval surface; the helper self-approve path stays deleted (Phase 0).
+- **Bridge**: PAM decision mirrors onto `ai_tool_executions.status` keyed by `execution_id` — in-transaction on /respond (409 + rollback if the execution already timed out), in-service for auto verdicts. `waitForApproval` polling contract unchanged.
+- **Re-enable**: mutating single-device Helper tools return to `standard`/`extended` under governance; org-wide and non-device-pinnable tools (`query_devices`, `s1_threat_action`, …) stay out; every whitelisted tool is pinned by `HELPER_TOOL_SCOPING`.
+
+Note: the /pam admin web UI does not exist yet (separate plan); list/rules API supports `ai_tool_action` for when it lands.
+
+## Test plan
+- [ ] Rule-engine tool-action criteria unit tests (incl. cross-shape isolation)
+- [ ] Governance service: auto_approve/auto_deny/pending/error fail-safe, audit + events, digest
+- [ ] preToolUse helper branch: PAM call, deny short-circuit, no approval_requests/mobile bridge, no auto_approve bypass
+- [ ] /respond mirror CAS + stale-execution 409 rollback; rules CRUD shape validation
+- [ ] helper filter/scoping consistency tests
+- [ ] db:check-drift + autoMigrate ordering
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 7: When CI is green:** `gh pr merge --squash --admin`.
+
+---
+
+## Self-review notes (spec coverage)
+
+- §1.1 model → Task 1. §1.2 decisioning (skip pamBridge, criteria, fail-safe) → Tasks 2–4. §1.3 approval reuse → Task 5 (no new surface). §1.4 bridge → Tasks 3 + 5. §1.5 policy+UI → Task 5 API-side; web UI explicitly out (does not exist yet — ground truth above). §1.6 re-enable → Task 6. Acceptance bullets map to the listed tests.
+- Deliberate deviations from spec wording: `action_digest` is a sha256 hex (varchar(64)) rather than free text; `ignore` verdict is rejected for tool-action rules and treated as pending by the engine path; flow-shape CHECK requires `tool_name` (not `execution_id`) so execution deletion stays possible.

--- a/packages/shared/src/types/ai.ts
+++ b/packages/shared/src/types/ai.ts
@@ -105,7 +105,7 @@ export type AiStreamEvent =
   | { type: 'content_delta'; delta: string }
   | { type: 'tool_use_start'; toolName: string; toolUseId: string; input: Record<string, unknown> }
   | { type: 'tool_result'; toolUseId: string; output: unknown; isError: boolean }
-  | { type: 'approval_required'; executionId: string; approvalRequestId?: string; toolName: string; input: Record<string, unknown>; description: string; deviceContext?: { hostname: string; displayName?: string; status: string; lastSeenAt?: string; activeSessions?: Array<{ username: string; activityState?: string; idleMinutes?: number; sessionType: string }> } }
+  | { type: 'approval_required'; executionId: string; approvalRequestId?: string; toolName: string; input: Record<string, unknown>; description: string; requiresAdminApproval?: boolean; deviceContext?: { hostname: string; displayName?: string; status: string; lastSeenAt?: string; activeSessions?: Array<{ username: string; activityState?: string; idleMinutes?: number; sessionType: string }> } }
   | { type: 'plan_approval_required'; planId: string; steps: ActionPlanStep[] }
   | { type: 'plan_step_start'; planId: string; stepIndex: number; toolName: string }
   | { type: 'plan_step_complete'; planId: string; stepIndex: number; toolName: string; isError: boolean }


### PR DESCRIPTION
## Summary

Phase 1 of the Helper privileged-action governance design (spec: `docs/superpowers/specs/2026-06-10-helper-privileged-action-pam-governance-design.md`; follows Phase 0 #1214; depends on the merged PAM control plane #1183). Implementation plan included in this PR (`docs/superpowers/plans/2026-06-10-helper-pam-phase1-tool-action-governance.md`).

**Model:** `elevation_requests` gains `flow_type='ai_tool_action'` plus `execution_id` (FK → `ai_tool_executions`, ON DELETE SET NULL), `tool_name`, `action_digest` (sha256 of args), `risk_tier`. Two new idempotent migrations (`2026-06-10-a-`/`-b-`): the enum value must live in its own file because the re-created `flow_shape_chk` CHECK references it and PG forbids using a new enum value in the transaction that added it. The CHECK's third branch requires `tool_name` only, so execution rows stay deletable under historical elevations.

**Decide:** tier>=2 Helper tool calls hit a new branch at the preToolUse gate (`aiAgentSdk.ts`) that precedes the auto_approve/plan shortcuts — a helper session can never self-relax approval. It creates the elevation via `services/pamToolActionGovernance.ts` and evaluates `pamRuleEngine` tool-action criteria (`matchToolName` exact case-insensitive, `matchRiskTier` exact) — new columns on `pam_rules`. `pamBridge` is skipped (executable-shaped, no binding for a tool action). Tool-action evaluation only considers rules carrying a tool-action criterion, so a pre-existing matchUser-only UAC rule can never auto-approve Helper actions; conversely tool-action rules never match executable candidates. Any decisioning error fails safe to pending. `verdict='ignore'` is rejected for tool-action rules (an action must be decided) and treated as pending by the engine path.

**Approve:** only the existing separate-identity `POST /pam/elevation-requests/:id/respond` (authMiddleware + `pam:execute` + MFA, site-narrowed, audited, emits `elevation.approved`). No new approval surface; the Phase 0 removal of helper self-approve stands. The helper's `approval_requests`/mobile-push bridge is skipped on this path — the synthetic helper "user" id is a device id (no users-FK row, no mobile owner).

**Bridge:** PAM decisions mirror onto `ai_tool_executions.status` keyed by `execution_id` (`approved`/`auto_approved` → `approved`; `denied` → `rejected`) via a shared CAS helper — called in-service for auto verdicts and inside the `/respond` transaction for manual ones. If the linked execution is no longer pending (the 5-min wait already timed out), `/respond` rolls the whole transaction back and returns 409 instead of leaving an approved elevation pointing at a rejected execution. `waitForApproval`'s polling contract is unchanged.

**Re-enable:** mutating single-device tools return to the helper `standard`/`extended` sets under this governance, each pinned by a new `HELPER_TOOL_SCOPING` entry (the Phase 0 schema-consistency regression guard validates every entry). Deliberately excluded: org-wide tools (`query_devices`, `get_fleet_health`, … — gate-denied since Phase 0), `s1_threat_action` (threat-keyed, not device-pinnable), and `run_backup_verification` (declared on the SDK MCP server but has **no** `executeTool` registration — pre-existing dead entry, caught by the consistency guard).

**Note:** the `/pam` admin web UI does not exist yet (separate plan `2026-06-09-pam-web-admin-ui.md`); the list `flowType=ai_tool_action` filter and tool-action rule CRUD land here so the UI can surface them when it ships. Until then admins respond via the REST endpoint.

## Test plan
- [x] Rule engine: tool-action criteria matching, cross-shape isolation (executable rules never match tool actions and vice versa), criteria-less guard, priority ordering, path-criterion fails closed without a path (30 tests)
- [x] Governance service: auto_approve/auto_deny/require_approval/ignore/no-match mapping, fail-safe-to-pending on errors, audit rows (requested + policy decision), event emission, digest + insert shape, mirror CAS (11 tests)
- [x] preToolUse helper branch: PAM call with correct params, deny short-circuit, no approval_requests/push bridge, auto_approve session mode cannot bypass, timeout rejection message (4 new tests; existing non-helper behavior unchanged)
- [x] /respond: in-txn mirror approve/deny, stale-execution 409 rollback, uac_intercept untouched; list flowType filter; rules CRUD shape validation (tool-action create, mixed-criteria 400, ignore-verdict 400, PATCH merged-shape 400s) (21 tests)
- [x] helper filter/scoping: governed sets, exclusions, every-tool-scopable invariant, schema-consistency guard (21 tests)
- [x] Migrations applied against local Postgres (columns/enum/constraint/index verified via psql); autoMigrate ordering test; `tsc --noEmit` clean (pre-existing exclusions only); shared package 604 tests pass
- [ ] RLS contract test: no allowlist change expected (new columns on already-covered Shape-1 tables; no new tables) — relying on CI smoke for the integration run

🤖 Generated with [Claude Code](https://claude.com/claude-code)