### PR TITLE
feat(tickets): v1 closeout — PATCH audit trail, queue filters, bulk actions, docs

### DIFF
--- a/apps/api/src/data/docsIndex.json
+++ b/apps/api/src/data/docsIndex.json
@@ -66,6 +66,7 @@
       "`lock`",
       "`reboot_safe_mode`",
       "`set_auto_update`",
+      "`refresh_inventory`",
       "File Operations",
       "`file_list`",
       "`file_read`",
@@ -179,7 +180,8 @@
       "Token Security",
       "Enrollment Keys",
       "Bulk Enrollment",
-      "Re-enrollment"
+      "Re-enrollment",
+      "Reusing a hostname for a decommissioned device"
     ],
     "section": "agents"
   },
@@ -233,6 +235,7 @@
       "Public Installer Links",
       "Short Enrollment Links",
       "macOS GUI Installer",
+      "Pre-Provisioning Devices",
       "What Gets Installed",
       "What Enrollment Does",
       "Verifying Installation",
@@ -548,6 +551,36 @@
     "section": "deploy"
   },
   {
+    "path": "/deploy/cloudflare-access-trust/",
+    "title": "Cloudflare Access JWT trust",
+    "description": "Skip the Breeze login form when a deployment sits behind Cloudflare Access using the same identity provider.",
+    "headings": [
+      "How it works",
+      "Failure semantics",
+      "MFA",
+      "Configuration",
+      "Recommended Cloudflare Access setup",
+      "Disabling"
+    ],
+    "section": "deploy"
+  },
+  {
+    "path": "/deploy/cloudflare-tunnel/",
+    "title": "Cloudflare Tunnel",
+    "description": "Run Breeze behind a Cloudflare Tunnel with no inbound ports, and optionally lock the dashboard behind Cloudflare Access.",
+    "headings": [
+      "Traffic Chain",
+      "TLS Termination: HTTP Origin Required",
+      "Option A — Caddy in HTTP mode (recommended)",
+      "Option B — Bypass Caddy",
+      "Prerequisites",
+      "Setup",
+      "Restricting the Dashboard with Cloudflare Access",
+      "Troubleshooting"
+    ],
+    "section": "deploy"
+  },
+  {
     "path": "/deploy/code-signing/",
     "title": "Code Signing",
     "description": "Code signing for Breeze agent, viewer, and helper binaries on Windows and macOS.",
@@ -592,6 +625,7 @@
       "Feature Flags",
       "MCP Server",
       "Cloudflare mTLS",
+      "Cloudflare Access JWT trust",
       "Cloud-to-Cloud Backup (M365)",
       "Docker Deployment",
       "MSI Installer Signing",
@@ -1287,6 +1321,7 @@
       "Querying Events",
       "Event Query Parameters",
       "Event Response Fields",
+      "Automatic Threat Alerts",
       "Statistics and Analytics",
       "Summary Statistics",
       "Top Blocked Domains",
@@ -1825,6 +1860,7 @@
       "API Reference",
       "In-App Notification Endpoints",
       "Notification Channel Endpoints",
+      "Per-channel throttle",
       "Creating a channel",
       "Testing a channel",
       "Troubleshooting"
@@ -2237,6 +2273,7 @@
       "Privilege Levels",
       "Execution Status",
       "Trigger Types",
+      "Severity by Exit Code",
       "Creating Scripts via API",
       "Executing Scripts via API",
       "Single device execution",
@@ -2267,6 +2304,7 @@
     "title": "Security",
     "description": "Monitor endpoint security posture, detect threats, enforce compliance, and get AI-powered security recommendations.",
     "headings": [
+      "Admin IP Allowlist",
       "Security Status",
       "Collected Fields",
       "Detection Methods by Platform",
@@ -2586,6 +2624,22 @@
     "section": "features"
   },
   {
+    "path": "/features/ticketing/",
+    "title": "Ticketing",
+    "description": "Built-in ticketing for MSP workflows -- a triage queue, public replies and internal notes, SLA chips, and tickets linked to alerts and devices.",
+    "headings": [
+      "The Queue",
+      "Working a Ticket",
+      "Replies and Internal Notes",
+      "Keyboard Shortcuts",
+      "Bulk Actions",
+      "Creating Tickets",
+      "Categories and SLAs",
+      "Tickets on a Device"
+    ],
+    "section": "features"
+  },
+  {
     "path": "/features/update-rings/",
     "title": "Update Rings",
     "description": "Control patch rollout velocity with staged deployment rings, deferral periods, and per-category approval rules.",
@@ -2692,6 +2746,7 @@
       "State transitions",
       "Recovery",
       "Failover",
+      "Agent-Silent Detection",
       "Health Journal",
       "Configuration",
       "Watchdog Logs API",
@@ -3030,6 +3085,7 @@
       "Actor Types",
       "Action Categories",
       "Security Actions",
+      "Tamper Evidence",
       "Compliance Actions",
       "Writing Audit Events",
       "Filtering and Searching",
@@ -3246,6 +3302,7 @@
     "headings": [
       "Deployment Issues",
       "Deploy script fails with \"Missing required env var\"",
+      "API refuses to boot: `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS must be set in production`",
       "TLS certificate not provisioning",
       "Database migration fails",
       "Agent Issues",
@@ -3259,6 +3316,9 @@
       "Container Issues",
       "Container won't start",
       "Health check failing",
+      "Installer Issues",
+      "\"Generate Link\" fails with `Server URL not configured (set PUBLIC_API_URL or API_URL)`",
+      "\"Generate Link\" fails with `MSI build pipeline not reachable. Retry`",
       "Getting Help"
     ],
     "section": "reference"
@@ -3374,9 +3434,11 @@
       "Container Security",
       "Authentication",
       "Agent Security",
+      "Outbound Request Safety (SSRF)",
       "Monitoring",
       "Firewall Configuration",
       "Audit Logging",
+      "Tamper evidence",
       "Rate Limiting"
     ],
     "section": "security"

--- a/apps/api/src/jobs/ticketNotifyWorker.test.ts
+++ b/apps/api/src/jobs/ticketNotifyWorker.test.ts
@@ -182,6 +182,16 @@ describe('handleTicketEvent', () => {
     expect(call.html).not.toContain('<script>');
   });
 
+  it('ticket.updated is an explicit no-op — no ticket lookup, no insert, no email', async () => {
+    await handleTicketEvent({
+      type: 'ticket.updated', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
+      actorUserId: 'u-1', payload: { changed: ['subject', 'priority'] }
+    });
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(insertValuesMock).not.toHaveBeenCalled();
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
   it('ticket.status_changed to pending sends no email', async () => {
     selectMock.mockResolvedValueOnce([{
       id: 't-1', orgId: 'o-1', internalNumber: 'T-2026-0099', subject: 'Slow VPN',

--- a/apps/api/src/jobs/ticketNotifyWorker.ts
+++ b/apps/api/src/jobs/ticketNotifyWorker.ts
@@ -162,6 +162,11 @@ export async function handleTicketEvent(event: TicketEvent): Promise<void> {
         }
         return;
       }
+      case 'ticket.updated': {
+        // Plain field edits (subject, priority, …) notify no one in Phase 1 —
+        // explicit no-op case so the exhaustiveness default stays meaningful.
+        return;
+      }
       case 'ticket.status_changed': {
         if (event.payload.to === 'resolved') {
           const note = event.payload.resolutionNote ?? '';

--- a/apps/api/src/routes/tickets/bulk.ts
+++ b/apps/api/src/routes/tickets/bulk.ts
@@ -1,0 +1,94 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { requireScope, requirePermission } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { bulkTicketActionSchema } from '@breeze/shared';
+import { assignTicket, changeTicketStatus, TicketServiceError } from '../../services/ticketService';
+import { writeRouteAudit } from '../../services/auditEvents';
+import { actorFrom, getScopedTicketOr404 } from './tickets';
+
+// NOTE: authMiddleware is applied by the hub router in ./index.ts (alerts pattern) —
+// requireScope/requirePermission below depend on c.get('auth') being populated there.
+export const ticketsBulkRoutes = new Hono();
+
+// POST /tickets/bulk — bulk assign / status change.
+// Modeled on POST /alerts/bulk (alerts/alerts.ts): per-id iteration with
+// {updated, skipped, failed} aggregation and one bulk-level audit entry.
+// Taxonomy:
+//   - out-of-scope / not-found ids            → skipped (never reach the service)
+//   - TicketServiceError (FSM-invalid, CAS)   → skipped (not currently actionable)
+//   - unexpected per-id errors                → failed (logged; loop continues)
+// Per-ticket feed entries, events, and audits fire inside the service calls.
+// status=resolved is rejected by the schema — resolving requires a per-ticket
+// resolution note, so it stays a per-ticket action.
+ticketsBulkRoutes.post(
+  '/bulk',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.TICKETS_WRITE.resource, PERMISSIONS.TICKETS_WRITE.action),
+  zValidator('json', bulkTicketActionSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const body = c.req.valid('json');
+
+    if (auth.scope === 'organization' && !auth.orgId) {
+      return c.json({ error: 'Organization context required' }, 403);
+    }
+
+    const actor = actorFrom(c);
+    const results = { updated: 0, skipped: 0, failed: 0 };
+    let firstAccessible: { id: string; orgId: string } | null = null;
+
+    for (const ticketId of body.ticketIds) {
+      const ticket = await getScopedTicketOr404(auth, ticketId);
+      if (!ticket) {
+        results.skipped++; // out-of-scope or missing — indistinguishable by design
+        continue;
+      }
+      if (!firstAccessible) firstAccessible = ticket;
+
+      try {
+        if (body.action === 'assign') {
+          // Schema refine guarantees assigneeId is present (null = unassign).
+          await assignTicket(ticketId, body.assigneeId ?? null, actor);
+        } else {
+          // Schema refine guarantees status is present and not 'resolved'.
+          await changeTicketStatus(ticketId, body.status!, {}, actor);
+        }
+        results.updated++;
+      } catch (err) {
+        if (err instanceof TicketServiceError) {
+          // FSM-invalid transition, CAS conflict, or vanished ticket — not
+          // currently actionable; mirrors alerts bulk's "skipped" bucket.
+          results.skipped++;
+          console.warn(`[tickets/bulk] Skipped ${body.action} for ticket ${ticketId}: ${err.message}`);
+        } else {
+          results.failed++;
+          console.error(
+            `[tickets/bulk] Failed to ${body.action} ticket ${ticketId}:`,
+            err instanceof Error ? err.message : err
+          );
+        }
+      }
+    }
+
+    // One bulk-level audit entry (alerts bulk pattern), in addition to the
+    // per-ticket audits/events emitted by the service. Attributed to the first
+    // accessible ticket's org; skipped entirely when nothing was in scope.
+    if (firstAccessible) {
+      writeRouteAudit(c, {
+        orgId: firstAccessible.orgId,
+        action: `ticket.bulk_${body.action}`,
+        resourceType: 'ticket',
+        resourceId: firstAccessible.id,
+        resourceName: `Bulk ${body.action} (${results.updated} tickets)`,
+        details: {
+          ticketIds: body.ticketIds,
+          updated: results.updated,
+          skipped: results.skipped
+        }
+      });
+    }
+
+    return c.json({ data: { ...results, total: body.ticketIds.length } });
+  }
+);

--- a/apps/api/src/routes/tickets/index.ts
+++ b/apps/api/src/routes/tickets/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { authMiddleware } from '../../middleware/auth';
 import { ticketsRoutes as ticketsApiRoutes } from './tickets';
+import { ticketsBulkRoutes } from './bulk';
 
 export const ticketsRoutes = new Hono();
 
@@ -8,4 +9,6 @@ export const ticketsRoutes = new Hono();
 // sub-routers depend on c.get('auth') being populated (same pattern as alerts/index.ts)
 ticketsRoutes.use('*', authMiddleware);
 
+// /bulk before the param routes so it is never captured by a /:id matcher.
+ticketsRoutes.route('/', ticketsBulkRoutes);
 ticketsRoutes.route('/', ticketsApiRoutes);

--- a/apps/api/src/routes/tickets/tickets.test.ts
+++ b/apps/api/src/routes/tickets/tickets.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 
-const { serviceMocks, dbSelectMock, dbGroupByMock, authRef, lastWhereArgs } = vi.hoisted(() => {
+const { serviceMocks, dbSelectMock, dbGroupByMock, authRef, lastWhereArgs, writeRouteAuditMock } = vi.hoisted(() => {
   const lastWhereArgs: { conditions: unknown[] }[] = [];
   return {
     serviceMocks: {
@@ -15,6 +15,7 @@ const { serviceMocks, dbSelectMock, dbGroupByMock, authRef, lastWhereArgs } = vi
     },
     dbSelectMock: vi.fn(),
     dbGroupByMock: vi.fn(),
+    writeRouteAuditMock: vi.fn(),
     lastWhereArgs,
     /** Mutable ref so individual tests can override the injected auth context. */
     authRef: {
@@ -30,6 +31,10 @@ const { serviceMocks, dbSelectMock, dbGroupByMock, authRef, lastWhereArgs } = vi
     }
   };
 });
+
+vi.mock('../../services/auditEvents', () => ({
+  writeRouteAudit: writeRouteAuditMock
+}));
 
 vi.mock('../../services/ticketService', async () => {
   const actual = await vi.importActual<typeof import('../../services/ticketService')>('../../services/ticketService');
@@ -707,6 +712,108 @@ describe('PATCH /tickets/:id — delegates to updateTicketFields', () => {
         expect.objectContaining({ userId: 'u-1' })
       );
     });
+  });
+});
+
+describe('POST /tickets/bulk', () => {
+  beforeEach(() => { vi.clearAllMocks(); resetAuth(); });
+
+  const T1 = 'aaaaaaaa-1111-4222-8333-444455556666';
+  const T2 = 'bbbbbbbb-1111-4222-8333-444455556666';
+  const ASSIGNEE_ID = '5a6b7c8d-1234-4321-abcd-000011112222';
+
+  const post = (body: unknown) =>
+    makeApp().request('/tickets/bulk', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+
+  it('bulk assign: scope-checks each id, calls assignTicket per ticket, aggregates and audits', async () => {
+    dbSelectMock.mockResolvedValue([STUB_TICKET]); // every scoped lookup resolves
+    serviceMocks.assignTicket.mockResolvedValue({ ...STUB_TICKET, assignedTo: ASSIGNEE_ID });
+
+    const res = await post({ ticketIds: [T1, T2], action: 'assign', assigneeId: ASSIGNEE_ID });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual({ updated: 2, skipped: 0, failed: 0, total: 2 });
+
+    expect(serviceMocks.assignTicket).toHaveBeenCalledTimes(2);
+    expect(serviceMocks.assignTicket).toHaveBeenCalledWith(T1, ASSIGNEE_ID, expect.objectContaining({ userId: 'u-1' }));
+    expect(serviceMocks.assignTicket).toHaveBeenCalledWith(T2, ASSIGNEE_ID, expect.objectContaining({ userId: 'u-1' }));
+
+    // One bulk-level audit entry (mirrors alerts bulk), on top of per-ticket service audits.
+    expect(writeRouteAuditMock).toHaveBeenCalledTimes(1);
+    expect(writeRouteAuditMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'ticket.bulk_assign',
+        resourceType: 'ticket',
+        details: expect.objectContaining({ ticketIds: [T1, T2], updated: 2, skipped: 0 })
+      })
+    );
+  });
+
+  it('bulk assign with null assigneeId (unassign) passes null to the service', async () => {
+    dbSelectMock.mockResolvedValue([STUB_TICKET]);
+    serviceMocks.assignTicket.mockResolvedValue({ ...STUB_TICKET, assignedTo: null });
+
+    const res = await post({ ticketIds: [T1], action: 'assign', assigneeId: null });
+    expect(res.status).toBe(200);
+    expect(serviceMocks.assignTicket).toHaveBeenCalledWith(T1, null, expect.objectContaining({ userId: 'u-1' }));
+  });
+
+  it('bulk status: an FSM-invalid transition counts as skipped, not failed, and does not abort the loop', async () => {
+    dbSelectMock.mockResolvedValue([STUB_TICKET]);
+    serviceMocks.changeTicketStatus
+      .mockResolvedValueOnce({ ...STUB_TICKET, status: 'pending' })
+      .mockRejectedValueOnce(new TicketServiceError('Cannot transition ticket from closed to pending', 409));
+
+    const res = await post({ ticketIds: [T1, T2], action: 'status', status: 'pending' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual({ updated: 1, skipped: 1, failed: 0, total: 2 });
+    expect(serviceMocks.changeTicketStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('unexpected per-id errors count as failed without aborting the loop', async () => {
+    dbSelectMock.mockResolvedValue([STUB_TICKET]);
+    serviceMocks.changeTicketStatus
+      .mockRejectedValueOnce(new Error('connection reset'))
+      .mockResolvedValueOnce({ ...STUB_TICKET, status: 'closed' });
+
+    const res = await post({ ticketIds: [T1, T2], action: 'status', status: 'closed' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual({ updated: 1, skipped: 0, failed: 1, total: 2 });
+  });
+
+  it('rejects status=resolved with 400 (resolution note is per-ticket) without calling the service', async () => {
+    const res = await post({ ticketIds: [T1], action: 'status', status: 'resolved' });
+    expect(res.status).toBe(400);
+    expect(serviceMocks.changeTicketStatus).not.toHaveBeenCalled();
+  });
+
+  it('out-of-scope ids count as skipped and never reach the service or the audit log', async () => {
+    dbSelectMock.mockResolvedValue([]); // scoped lookup finds nothing
+    const res = await post({ ticketIds: [T1], action: 'assign', assigneeId: ASSIGNEE_ID });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual({ updated: 0, skipped: 1, failed: 0, total: 1 });
+    expect(serviceMocks.assignTicket).not.toHaveBeenCalled();
+    expect(writeRouteAuditMock).not.toHaveBeenCalled();
+  });
+
+  it('400s on an empty ticketIds array', async () => {
+    const res = await post({ ticketIds: [], action: 'assign', assigneeId: ASSIGNEE_ID });
+    expect(res.status).toBe(400);
+    expect(serviceMocks.assignTicket).not.toHaveBeenCalled();
+  });
+
+  it('400s when action=assign omits assigneeId (refine)', async () => {
+    const res = await post({ ticketIds: [T1], action: 'assign' });
+    expect(res.status).toBe(400);
+    expect(serviceMocks.assignTicket).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/tickets/tickets.test.ts
+++ b/apps/api/src/routes/tickets/tickets.test.ts
@@ -11,6 +11,7 @@ const { serviceMocks, dbSelectMock, dbGroupByMock, authRef, lastWhereArgs } = vi
       addTicketComment: vi.fn(),
       linkAlertToTicket: vi.fn(),
       unlinkAlertFromTicket: vi.fn(),
+      updateTicketFields: vi.fn(),
     },
     dbSelectMock: vi.fn(),
     dbGroupByMock: vi.fn(),
@@ -120,6 +121,9 @@ vi.mock('../../db/schema', () => ({
 // Import the hub router (./index), not ./tickets directly — the hub is what
 // apps/api/src/index.ts mounts and is where authMiddleware is applied.
 import { ticketsRoutes } from './index';
+// Real class (the service mock spreads importActual), so handleServiceError's
+// instanceof check in the route works against errors thrown by the mocks.
+import { TicketServiceError } from '../../services/ticketService';
 
 const TICKET_ID = '3f2f1d8e-1111-4222-8333-444455556666';
 const ORG_ID    = '3f2f1d8e-1111-4222-8333-444455556666';
@@ -572,17 +576,11 @@ describe('DELETE /tickets/:id/alerts/:alertId', () => {
   });
 });
 
-describe('PATCH /tickets/:id — scoped update', () => {
+describe('PATCH /tickets/:id — delegates to updateTicketFields', () => {
   beforeEach(() => { vi.clearAllMocks(); resetAuth(); });
 
-  it('returns 404 when the scoped UPDATE returns no rows (ticket out of scope)', async () => {
-    // PATCH goes directly to db.update(); returning empty array = out-of-scope / missing
-    const { db } = await import('../../db');
-    (db.update as any).mockReturnValue({
-      set: vi.fn(() => ({
-        where: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([])) }))
-      }))
-    });
+  it('returns 404 when the scoped pre-check finds no ticket (out of scope) and never calls the service', async () => {
+    dbSelectMock.mockResolvedValueOnce([]); // getScopedTicketOr404: no row
 
     const res = await makeApp().request(`/tickets/${TICKET_ID}`, {
       method: 'PATCH',
@@ -592,16 +590,12 @@ describe('PATCH /tickets/:id — scoped update', () => {
     expect(res.status).toBe(404);
     const body = await res.json();
     expect(body).toHaveProperty('error', 'Ticket not found');
+    expect(serviceMocks.updateTicketFields).not.toHaveBeenCalled();
   });
 
-  it('returns the updated ticket when it is in scope', async () => {
-    const updatedTicket = { ...STUB_TICKET, subject: 'Updated subject' };
-    const { db } = await import('../../db');
-    (db.update as any).mockReturnValue({
-      set: vi.fn(() => ({
-        where: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([updatedTicket])) }))
-      }))
-    });
+  it('returns the updated ticket from the service when it is in scope', async () => {
+    dbSelectMock.mockResolvedValueOnce([STUB_TICKET]); // scoped pre-check
+    serviceMocks.updateTicketFields.mockResolvedValue({ ...STUB_TICKET, subject: 'Updated subject' });
 
     const res = await makeApp().request(`/tickets/${TICKET_ID}`, {
       method: 'PATCH',
@@ -611,16 +605,34 @@ describe('PATCH /tickets/:id — scoped update', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.data).toMatchObject({ subject: 'Updated subject' });
+
+    expect(serviceMocks.updateTicketFields).toHaveBeenCalledWith(
+      TICKET_ID,
+      expect.objectContaining({ subject: 'Updated subject' }),
+      expect.objectContaining({ userId: 'u-1' })
+    );
   });
 
-  describe('deviceId reassignment cross-org guard', () => {
+  it('400s on an empty body without calling the service', async () => {
+    const res = await makeApp().request(`/tickets/${TICKET_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({})
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toHaveProperty('error', 'No fields to update');
+    expect(serviceMocks.updateTicketFields).not.toHaveBeenCalled();
+  });
+
+  describe('deviceId reassignment cross-org guard (enforced by the service)', () => {
     const DEVICE_ID = '9a8b7c6d-1111-4222-8333-444455556666';
 
     it('400s when the new deviceId belongs to a different org', async () => {
-      // selects in order: scoped ticket lookup, device lookup
-      dbSelectMock
-        .mockResolvedValueOnce([{ ...STUB_TICKET, orgId: 'org-1' }])
-        .mockResolvedValueOnce([{ id: DEVICE_ID, orgId: 'org-OTHER' }]);
+      dbSelectMock.mockResolvedValueOnce([{ ...STUB_TICKET, orgId: 'org-1' }]); // scoped pre-check
+      serviceMocks.updateTicketFields.mockRejectedValue(
+        new TicketServiceError('Device must belong to the same organization as the ticket', 400)
+      );
 
       const res = await makeApp().request(`/tickets/${TICKET_ID}`, {
         method: 'PATCH',
@@ -633,9 +645,8 @@ describe('PATCH /tickets/:id — scoped update', () => {
     });
 
     it('404s when the new deviceId does not exist', async () => {
-      dbSelectMock
-        .mockResolvedValueOnce([{ ...STUB_TICKET, orgId: 'org-1' }])
-        .mockResolvedValueOnce([]); // device lookup: no row
+      dbSelectMock.mockResolvedValueOnce([{ ...STUB_TICKET, orgId: 'org-1' }]);
+      serviceMocks.updateTicketFields.mockRejectedValue(new TicketServiceError('Device not found', 404));
 
       const res = await makeApp().request(`/tickets/${TICKET_ID}`, {
         method: 'PATCH',
@@ -658,19 +669,12 @@ describe('PATCH /tickets/:id — scoped update', () => {
       expect(res.status).toBe(404);
       const body = await res.json();
       expect(body).toHaveProperty('error', 'Ticket not found');
+      expect(serviceMocks.updateTicketFields).not.toHaveBeenCalled();
     });
 
     it('updates when the new deviceId belongs to the ticket org', async () => {
-      dbSelectMock
-        .mockResolvedValueOnce([{ ...STUB_TICKET, orgId: 'org-1' }])
-        .mockResolvedValueOnce([{ id: DEVICE_ID, orgId: 'org-1' }]);
-      const updatedTicket = { ...STUB_TICKET, deviceId: DEVICE_ID };
-      const { db } = await import('../../db');
-      (db.update as any).mockReturnValue({
-        set: vi.fn(() => ({
-          where: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([updatedTicket])) }))
-        }))
-      });
+      dbSelectMock.mockResolvedValueOnce([{ ...STUB_TICKET, orgId: 'org-1' }]);
+      serviceMocks.updateTicketFields.mockResolvedValue({ ...STUB_TICKET, deviceId: DEVICE_ID });
 
       const res = await makeApp().request(`/tickets/${TICKET_ID}`, {
         method: 'PATCH',
@@ -680,16 +684,16 @@ describe('PATCH /tickets/:id — scoped update', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.data).toMatchObject({ deviceId: DEVICE_ID });
+      expect(serviceMocks.updateTicketFields).toHaveBeenCalledWith(
+        TICKET_ID,
+        expect.objectContaining({ deviceId: DEVICE_ID }),
+        expect.objectContaining({ userId: 'u-1' })
+      );
     });
 
-    it('clearing deviceId (null) skips the device lookup and updates directly', async () => {
-      const updatedTicket = { ...STUB_TICKET, deviceId: null };
-      const { db } = await import('../../db');
-      (db.update as any).mockReturnValue({
-        set: vi.fn(() => ({
-          where: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([updatedTicket])) }))
-        }))
-      });
+    it('clearing deviceId (null) passes the null through to the service', async () => {
+      dbSelectMock.mockResolvedValueOnce([STUB_TICKET]);
+      serviceMocks.updateTicketFields.mockResolvedValue({ ...STUB_TICKET, deviceId: null });
 
       const res = await makeApp().request(`/tickets/${TICKET_ID}`, {
         method: 'PATCH',
@@ -697,8 +701,11 @@ describe('PATCH /tickets/:id — scoped update', () => {
         body: JSON.stringify({ deviceId: null })
       });
       expect(res.status).toBe(200);
-      // No scoped-ticket/device selects were consumed
-      expect(dbSelectMock).not.toHaveBeenCalled();
+      expect(serviceMocks.updateTicketFields).toHaveBeenCalledWith(
+        TICKET_ID,
+        expect.objectContaining({ deviceId: null }),
+        expect.objectContaining({ userId: 'u-1' })
+      );
     });
   });
 });

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -30,7 +30,7 @@ const CLOSED_STATUSES = ['resolved', 'closed'] as const;
 const PRIORITY_ORDER = sql`CASE ${tickets.priority}
   WHEN 'urgent' THEN 0 WHEN 'high' THEN 1 WHEN 'normal' THEN 2 ELSE 3 END`;
 
-function actorFrom(c: { get: (k: 'auth') => AuthContext }) {
+export function actorFrom(c: { get: (k: 'auth') => AuthContext }) {
   const auth = c.get('auth');
   return { userId: auth.user.id, name: auth.user.name, email: auth.user.email };
 }
@@ -55,7 +55,7 @@ function handleServiceError(c: { json: (b: unknown, s: number) => Response }, er
  * - partner scope: adds eq(partnerId, auth.partnerId); null partnerId as not-found
  * - system scope: no extra condition (unrestricted)
  */
-async function getScopedTicketOr404(
+export async function getScopedTicketOr404(
   auth: AuthContext,
   id: string
 ): Promise<(typeof tickets.$inferSelect) | null> {

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -12,7 +12,7 @@ import {
 } from '@breeze/shared';
 import {
   createTicket, changeTicketStatus, assignTicket, addTicketComment,
-  linkAlertToTicket, unlinkAlertFromTicket,
+  linkAlertToTicket, unlinkAlertFromTicket, updateTicketFields,
   TicketServiceError
 } from '../../services/ticketService';
 import type { AuthContext } from '../../middleware/auth';
@@ -309,7 +309,10 @@ ticketsRoutes.get(
   }
 );
 
-// PATCH /tickets/:id — field updates (not status/assignee; those have dedicated routes)
+// PATCH /tickets/:id — field updates (not status/assignee; those have dedicated routes).
+// Delegates to ticketService.updateTicketFields so plain edits produce a system
+// feed entry, an audit log, and a ticket.updated lifecycle event. The cross-org
+// deviceId guard lives in the service (mirrors createTicket's check).
 ticketsRoutes.patch(
   '/:id',
   requireScope('organization', 'partner', 'system'),
@@ -325,39 +328,15 @@ ticketsRoutes.patch(
     if (auth.scope === 'organization' && !auth.orgId) {
       return c.json({ error: 'Organization context required' }, 403);
     }
+    const found = await getScopedTicketOr404(auth, id);
+    if (!found) return c.json({ error: 'Ticket not found' }, 404);
 
-    // Cross-org guard: a deviceId reassignment must reference a device in the
-    // ticket's org (mirrors the same-org device check in createTicket).
-    if (typeof body.deviceId === 'string') {
-      const ticket = await getScopedTicketOr404(auth, id);
-      if (!ticket) return c.json({ error: 'Ticket not found' }, 404);
-      const deviceRows = await db
-        .select({ id: devices.id, orgId: devices.orgId })
-        .from(devices)
-        .where(eq(devices.id, body.deviceId))
-        .limit(1);
-      const device = deviceRows[0];
-      if (!device) return c.json({ error: 'Device not found' }, 404);
-      if (device.orgId !== ticket.orgId) {
-        return c.json({ error: 'Device must belong to the same organization as the ticket' }, 400);
-      }
+    try {
+      const ticket = await updateTicketFields(id, body, actorFrom(c));
+      return c.json({ data: ticket });
+    } catch (err) {
+      return handleServiceError(c, err);
     }
-
-    // Build the scoped WHERE for the UPDATE itself so the DB also sees the constraint.
-    const updateConditions: SQL[] = [eq(tickets.id, id)];
-    if (auth.scope === 'organization' && auth.orgId) {
-      updateConditions.push(eq(tickets.orgId, auth.orgId));
-    } else if (auth.scope === 'partner' && auth.partnerId) {
-      updateConditions.push(eq(tickets.partnerId, auth.partnerId));
-    }
-
-    const updated = await db
-      .update(tickets)
-      .set({ ...body, updatedAt: new Date() })
-      .where(and(...updateConditions))
-      .returning();
-    if (!updated[0]) return c.json({ error: 'Ticket not found' }, 404);
-    return c.json({ data: updated[0] });
   }
 );
 

--- a/apps/api/src/services/ticketEvents.ts
+++ b/apps/api/src/services/ticketEvents.ts
@@ -21,6 +21,7 @@ export type TicketEvent = TicketEventEnvelope & (
   | { type: 'ticket.status_changed'; payload: { from: TicketStatus; to: TicketStatus; resolutionNote: string | null } }
   | { type: 'ticket.assigned'; payload: { assigneeId: string | null } }
   | { type: 'ticket.commented'; payload: { commentId: string; isPublic: boolean } }
+  | { type: 'ticket.updated'; payload: { changed: string[] } }
 );
 
 export type TicketEventType = TicketEvent['type'];

--- a/apps/api/src/services/ticketEventsContract.test.ts
+++ b/apps/api/src/services/ticketEventsContract.test.ts
@@ -120,7 +120,7 @@ vi.mock('../services/emailLayout', () => ({
 
 // ── real implementations ─────────────────────────────────────────────────────
 
-import { createTicket, addTicketComment, changeTicketStatus } from './ticketService';
+import { createTicket, addTicketComment, changeTicketStatus, updateTicketFields } from './ticketService';
 import { handleTicketEvent } from '../jobs/ticketNotifyWorker';
 import type { TicketEvent } from './ticketEvents';
 
@@ -247,5 +247,38 @@ describe('ticket-events producer→consumer contract', () => {
     }));
     const emailCall = hoisted.sendEmailMock.mock.calls[0]![0] as { html: string };
     expect(emailCall.html).toContain('Fixed the printer.');
+  });
+
+  // ── updateTicketFields → ticket.updated ───────────────────────────────────
+
+  it('updateTicketFields: emitted ticket.updated event feeds handleTicketEvent → explicit no-op (no insert, no email)', async () => {
+    // Service selects: ticket lookup
+    hoisted.selectQueue.push([{
+      id: 't-c4', orgId: 'o-1', partnerId: 'p-1', status: 'open',
+      subject: 'Old subject', priority: 'normal', description: null,
+      categoryId: null, dueDate: null, deviceId: null, tags: []
+    }]);
+    // Service update: returning
+    hoisted.updateReturningQueue.push([{ id: 't-c4', subject: 'New subject', priority: 'high' }]);
+    // Service insert: system feed entry returning
+    hoisted.insertReturningQueue.push([{ id: 'feed-2' }]);
+
+    await updateTicketFields('t-c4', { subject: 'New subject', priority: 'high' }, actor);
+
+    expect(hoisted.emitCaptured).toHaveLength(1);
+    const event = hoisted.emitCaptured[0] as TicketEvent;
+    expect(event.type).toBe('ticket.updated');
+
+    // Verify payload field names via narrowed access — this is the seam assertion
+    if (event.type === 'ticket.updated') {
+      expect(event.payload.changed).toEqual(['subject', 'priority']);
+    }
+
+    hoisted.insertValuesMock.mockClear();
+
+    // Worker: ticket.updated is a deliberate no-op — must not throw, insert, or email
+    await expect(handleTicketEvent(event)).resolves.toBeUndefined();
+    expect(hoisted.insertValuesMock).not.toHaveBeenCalled();
+    expect(hoisted.sendEmailMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -67,6 +67,7 @@ vi.mock('../db/schema', () => ({
 import {
   createTicket, changeTicketStatus, assignTicket, addTicketComment,
   linkAlertToTicket, unlinkAlertFromTicket, createTicketFromAlert,
+  updateTicketFields,
   TicketServiceError, TICKET_STATUS_TRANSITIONS
 } from './ticketService';
 
@@ -553,6 +554,152 @@ describe('assignTicket — additional status cases', () => {
     const updatePayload = setMock.mock.calls[0]![0];
     expect(updatePayload).toMatchObject({ assignedTo: 'u-2' });
     expect(updatePayload).not.toHaveProperty('status');
+  });
+});
+
+describe('updateTicketFields', () => {
+  const BASE_TICKET = {
+    id: 't-1', orgId: 'o-1', partnerId: 'p-1', status: 'open',
+    subject: 'Printer offline', description: null, categoryId: null,
+    priority: 'normal', dueDate: null, deviceId: null, tags: []
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    valuesMock.mockClear();
+    setMock.mockClear();
+  });
+
+  it('applies changed fields, writes ONE system feed entry with the humanized field list, emits ticket.updated, audits', async () => {
+    dbMocks.selectResult.mockResolvedValue([BASE_TICKET]);
+    dbMocks.updateReturning.mockResolvedValue([{ ...BASE_TICKET, subject: 'New subject', priority: 'high' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+
+    const t = await updateTicketFields('t-1', { subject: 'New subject', priority: 'high' }, actor);
+    expect(t).toMatchObject({ subject: 'New subject', priority: 'high' });
+
+    // Update payload contains the changed fields + updatedAt stamp
+    const updatePayload = setMock.mock.calls[0]![0];
+    expect(updatePayload).toMatchObject({ subject: 'New subject', priority: 'high' });
+    expect(updatePayload.updatedAt).toBeInstanceOf(Date);
+
+    // Exactly ONE feed entry: system, private, lists the changed fields
+    expect(valuesMock).toHaveBeenCalledTimes(1);
+    const commentPayload = valuesMock.mock.calls[0]![0];
+    expect(commentPayload).toMatchObject({
+      ticketId: 't-1',
+      commentType: 'system',
+      isPublic: false,
+      authorName: 'Tess Tech',
+      content: 'Updated subject, priority'
+    });
+
+    expect(emitMock).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'ticket.updated',
+      ticketId: 't-1',
+      orgId: 'o-1',
+      partnerId: 'p-1',
+      actorUserId: 'u-1',
+      payload: { changed: ['subject', 'priority'] }
+    }));
+    expect(auditMock).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: 'o-1',
+      actorId: 'u-1',
+      action: 'ticket.update',
+      resourceType: 'ticket',
+      resourceId: 't-1',
+      result: 'success'
+    }));
+  });
+
+  it('no-op update (values identical) returns the ticket unchanged without update/feed/event/audit', async () => {
+    dbMocks.selectResult.mockResolvedValue([BASE_TICKET]);
+
+    const t = await updateTicketFields('t-1', { subject: 'Printer offline', priority: 'normal' }, actor);
+    expect(t).toBe(BASE_TICKET);
+
+    expect(setMock).not.toHaveBeenCalled();
+    expect(valuesMock).not.toHaveBeenCalled();
+    expect(emitMock).not.toHaveBeenCalled();
+    expect(auditMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a deviceId belonging to a different org with a 400 TicketServiceError and writes nothing', async () => {
+    // selects in order: ticket, device (cross-org)
+    dbMocks.selectResult
+      .mockResolvedValueOnce([BASE_TICKET])
+      .mockResolvedValueOnce([{ id: 'd-1', orgId: 'o-OTHER' }]);
+
+    const err = await updateTicketFields('t-1', { deviceId: 'd-1' }, actor).catch(e => e);
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(400);
+    expect(err.message).toMatch(/same organization/i);
+    expect(setMock).not.toHaveBeenCalled();
+    expect(valuesMock).not.toHaveBeenCalled();
+    expect(emitMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown deviceId with a 404 TicketServiceError', async () => {
+    dbMocks.selectResult
+      .mockResolvedValueOnce([BASE_TICKET])
+      .mockResolvedValueOnce([]); // device lookup: no row
+
+    const err = await updateTicketFields('t-1', { deviceId: 'd-missing' }, actor).catch(e => e);
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(404);
+    expect(err.message).toMatch(/device not found/i);
+    expect(setMock).not.toHaveBeenCalled();
+  });
+
+  it('clearing deviceId (null) skips the device lookup and records the change', async () => {
+    dbMocks.selectResult.mockResolvedValue([{ ...BASE_TICKET, deviceId: 'd-1' }]);
+    dbMocks.updateReturning.mockResolvedValue([{ ...BASE_TICKET, deviceId: null }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+
+    await updateTicketFields('t-1', { deviceId: null }, actor);
+
+    // Only ONE select consumed (the ticket lookup) — no device lookup for null
+    expect(dbMocks.selectResult).toHaveBeenCalledTimes(1);
+    expect(emitMock).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'ticket.updated',
+      payload: { changed: ['deviceId'] }
+    }));
+    expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({ content: 'Updated device' }));
+  });
+
+  it('throws 404 when the ticket does not exist', async () => {
+    dbMocks.selectResult.mockResolvedValue([]);
+    const err = await updateTicketFields('t-missing', { subject: 'x' }, actor).catch(e => e);
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(404);
+    expect(err.message).toMatch(/ticket not found/i);
+  });
+
+  it('treats equal dueDate (different Date instances) as a no-op but a new dueDate as a change', async () => {
+    const due = new Date('2026-07-01T00:00:00Z');
+    dbMocks.selectResult.mockResolvedValue([{ ...BASE_TICKET, dueDate: due }]);
+
+    // Same instant, different instance → no-op
+    await updateTicketFields('t-1', { dueDate: new Date('2026-07-01T00:00:00Z') }, actor);
+    expect(setMock).not.toHaveBeenCalled();
+    expect(emitMock).not.toHaveBeenCalled();
+
+    // Different instant → change, humanized as "due date"
+    dbMocks.updateReturning.mockResolvedValue([{ ...BASE_TICKET, dueDate: new Date('2026-08-01T00:00:00Z') }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+    await updateTicketFields('t-1', { dueDate: new Date('2026-08-01T00:00:00Z') }, actor);
+    expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({ content: 'Updated due date' }));
+    expect(emitMock).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'ticket.updated',
+      payload: { changed: ['dueDate'] }
+    }));
+  });
+
+  it('treats deep-equal tags as a no-op', async () => {
+    dbMocks.selectResult.mockResolvedValue([{ ...BASE_TICKET, tags: ['vip', 'hardware'] }]);
+    await updateTicketFields('t-1', { tags: ['vip', 'hardware'] }, actor);
+    expect(setMock).not.toHaveBeenCalled();
+    expect(emitMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -233,6 +233,117 @@ export async function changeTicketStatus(
   return updated[0];
 }
 
+export interface UpdateTicketFieldsInput {
+  subject?: string;
+  description?: string;
+  categoryId?: string | null;
+  priority?: 'low' | 'normal' | 'high' | 'urgent';
+  dueDate?: Date | null;
+  deviceId?: string | null;
+  tags?: string[];
+}
+
+/** Humanized labels for the system feed entry, in canonical field order. */
+const UPDATE_FIELD_LABELS: Record<keyof UpdateTicketFieldsInput, string> = {
+  subject: 'subject',
+  description: 'description',
+  categoryId: 'category',
+  priority: 'priority',
+  dueDate: 'due date',
+  deviceId: 'device',
+  tags: 'tags'
+};
+
+function ticketFieldChanged(key: keyof UpdateTicketFieldsInput, oldValue: unknown, newValue: unknown): boolean {
+  if (key === 'dueDate') {
+    const oldMs = oldValue instanceof Date ? oldValue.getTime() : null;
+    const newMs = newValue instanceof Date ? newValue.getTime() : null;
+    return oldMs !== newMs;
+  }
+  if (key === 'tags') {
+    return JSON.stringify(oldValue ?? []) !== JSON.stringify(newValue ?? []);
+  }
+  return (oldValue ?? null) !== (newValue ?? null);
+}
+
+export async function updateTicketFields(
+  ticketId: string,
+  fields: UpdateTicketFieldsInput,
+  actor: TicketActor
+) {
+  const ticket = await getTicketOrThrow(ticketId);
+
+  // Cross-org guard: a deviceId reassignment must reference a device in the
+  // ticket's org (mirrors the same-org device check in createTicket).
+  // null clears the device and needs no lookup.
+  if (typeof fields.deviceId === 'string') {
+    const deviceRows = await db
+      .select({ id: devices.id, orgId: devices.orgId })
+      .from(devices)
+      .where(eq(devices.id, fields.deviceId))
+      .limit(1);
+    const device = deviceRows[0];
+    if (!device) throw new TicketServiceError('Device not found', 404);
+    if (device.orgId !== ticket.orgId) {
+      throw new TicketServiceError('Device must belong to the same organization as the ticket', 400);
+    }
+  }
+
+  // Compute the actually-changed fields; ignore no-op keys so the feed and
+  // event stream don't accumulate noise from idempotent saves.
+  const changed: (keyof UpdateTicketFieldsInput)[] = [];
+  for (const key of Object.keys(UPDATE_FIELD_LABELS) as (keyof UpdateTicketFieldsInput)[]) {
+    if (fields[key] === undefined) continue;
+    if (ticketFieldChanged(key, (ticket as Record<string, unknown>)[key], fields[key])) {
+      changed.push(key);
+    }
+  }
+  if (changed.length === 0) return ticket;
+
+  const patch: Partial<typeof tickets.$inferInsert> = { updatedAt: new Date() };
+  for (const key of changed) {
+    (patch as Record<string, unknown>)[key] = fields[key] ?? null;
+  }
+
+  const updated = await db
+    .update(tickets)
+    .set(patch)
+    .where(eq(tickets.id, ticketId))
+    .returning();
+  if (updated.length === 0) {
+    throw new TicketServiceError('Ticket not found', 404);
+  }
+
+  await db.insert(ticketComments).values({
+    ticketId,
+    userId: actor.userId,
+    authorName: actor.name ?? null,
+    authorType: 'internal',
+    commentType: 'system',
+    content: `Updated ${changed.map((k) => UPDATE_FIELD_LABELS[k]).join(', ')}`,
+    isPublic: false
+  });
+
+  await emitTicketEvent({
+    type: 'ticket.updated',
+    ticketId,
+    orgId: ticket.orgId,
+    partnerId: ticket.partnerId ?? null,
+    actorUserId: actor.userId,
+    payload: { changed }
+  });
+  await createAuditLogAsync({
+    orgId: ticket.orgId,
+    actorId: actor.userId,
+    action: 'ticket.update',
+    resourceType: 'ticket',
+    resourceId: ticketId,
+    details: { changed },
+    result: 'success'
+  });
+  return updated[0];
+}
+
 export async function assignTicket(ticketId: string, assigneeId: string | null, actor: TicketActor) {
   const ticket = await getTicketOrThrow(ticketId);
   const prevAssignedTo = ticket.assignedTo;

--- a/apps/docs/src/content/docs/features/portal.mdx
+++ b/apps/docs/src/content/docs/features/portal.mdx
@@ -114,7 +114,7 @@ Each organization can customize the portal appearance and contact information. B
 
 ## Tickets
 
-Portal users can submit support tickets, track their status, and add comments to ongoing conversations.
+Portal users can submit support tickets, track their status, and add comments to ongoing conversations. Tickets submitted through the portal land directly in the technician [Tickets queue](/features/ticketing/) in the Breeze dashboard, where technicians triage, assign, and respond to them.
 
 ### Creating a Ticket
 
@@ -129,7 +129,7 @@ Tickets are automatically associated with the submitter's portal user account an
 
 ### Ticket Comments
 
-Both portal users and admin technicians can add comments to tickets. Portal users only see public comments (`isPublic: true`). Internal notes added by technicians with `isPublic: false` are hidden from the portal view.
+Both portal users and technicians can add comments to tickets. When a technician sends a public reply from the [Tickets queue](/features/ticketing/), it appears in the portal user's ticket conversation. Portal users only see public comments (`isPublic: true`). Internal notes added by technicians with `isPublic: false` are never shown in the portal view.
 
 ### External Ticket Integration
 

--- a/apps/docs/src/content/docs/features/ticketing.mdx
+++ b/apps/docs/src/content/docs/features/ticketing.mdx
@@ -1,0 +1,106 @@
+---
+title: Ticketing
+description: Built-in ticketing for MSP workflows -- a triage queue, public replies and internal notes, SLA chips, and tickets linked to alerts and devices.
+sidebar:
+  label: "Ticketing"
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+
+Breeze includes a built-in ticketing system designed for MSP technician workflows. Tickets arrive from the customer portal, from alerts, from technicians creating them by hand, and through the API -- and they all land in one queue. Open **Tickets** from the left sidebar to start working.
+
+Every ticket gets a number in the form `T-YYYY-NNNN` (for example `T-2026-0042`), which appears throughout the dashboard and is the easiest way to reference a ticket with your team or a customer.
+
+## The Queue
+
+The Tickets page is a split-pane workspace: the ticket list on the left, and a workbench for the selected ticket on the right. Selecting a ticket in the list opens it instantly in the workbench -- no page reloads. On narrower screens, selecting a ticket opens its full page instead.
+
+Across the top, view tabs slice the queue:
+
+| Tab | Shows |
+|---|---|
+| **My tickets** | Open tickets assigned to you |
+| **Unassigned** | Open tickets nobody owns yet |
+| **All open** | Every open ticket you can see |
+| **Breaching soon** | Open tickets whose SLA is at risk or already breached |
+| **Closed** | Resolved and closed tickets, newest first |
+
+Below the tabs, a filter bar narrows any view by **organization**, **priority**, **category**, and **assignee**, and a search box matches against ticket subjects. Each row shows the ticket number, subject, status, priority, and an SLA chip when the clock is running low.
+
+## Working a Ticket
+
+The workbench shows everything you need to resolve a ticket without leaving the queue:
+
+- **Status** -- move the ticket between New, Open, Pending, On hold, Resolved, and Closed. Resolving always asks for a **resolution note**, which is visible to the requester, so the customer sees what was done.
+- **Priority** -- change between Low, Normal, High, and Urgent.
+- **Assignee** -- assign or unassign the ticket. Press `a` to grab the selected ticket for yourself.
+- **Properties rail** -- requester, source, created date, due date, the reason a ticket is waiting, the resolution note, and any **linked alerts** with one-click navigation to the alert itself.
+
+Click the expand icon (or press `Enter`) to open the ticket as a full page when you need more room.
+
+## Replies and Internal Notes
+
+The composer at the bottom of every ticket has two modes:
+
+- **Reply** (the default) -- a public response. If the ticket came from the customer portal, your reply appears in the requester's portal conversation.
+- **Internal note** -- visible only to your team. The composer switches to a clearly marked highlighted style with an "Internal: not visible to requester" banner, so there is no ambiguity about who will see what you are typing.
+
+Portal users only ever see public replies. Internal notes, status changes, and assignment history stay inside the dashboard.
+
+Press `Cmd+Enter` (or `Ctrl+Enter`) to send without leaving the keyboard.
+
+## Keyboard Shortcuts
+
+The queue is built to be worked without a mouse:
+
+| Key | Action |
+|---|---|
+| `j` / `k` | Move down / up the list |
+| `Enter` or `o` | Open the selected ticket as a full page |
+| `a` | Assign the selected ticket to me |
+| `r` | Focus the reply composer |
+| `n` | Focus the internal note composer |
+| `e` | Open the resolve form (resolution note) |
+| `Esc` | Leave the composer / go back |
+
+## Bulk Actions
+
+Select tickets with the checkboxes in the list and an action bar slides up from the bottom of the pane. From there you can:
+
+- **Bulk assign** -- hand a batch of tickets to a technician, or unassign them.
+- **Bulk status** -- move a batch to New, Open, Pending, On hold, or Closed.
+
+You can act on up to 100 tickets at once. Resolving is intentionally excluded from bulk actions: every resolution needs a per-ticket resolution note, so tickets are resolved individually from the workbench.
+
+## Creating Tickets
+
+Tickets enter the queue from four directions:
+
+- **By a technician.** Click **Create ticket** on the Tickets page, pick the organization, enter a subject and description, and optionally attach a device, category, and priority.
+- **From an alert.** Open any alert and click its **Create ticket** button. The ticket is pre-filled from the alert and linked to it, so the alert shows up in the ticket's properties rail.
+- **From the customer portal.** End-users submit tickets through their [Customer Portal](/features/portal/), and those tickets land directly in the queue for triage.
+- **Through the API**, for integrations and automation.
+
+## Categories and SLAs
+
+Go to **Settings > Ticketing** to manage ticket categories.
+
+<Steps>
+
+1. Enter a category name, pick a color, and click **Add**.
+
+2. Use the categories to organize the queue -- they appear in the category filter and on the create-ticket form.
+
+3. Deactivate a category to retire it without losing the tickets already filed under it.
+
+</Steps>
+
+Categories also carry SLA targets (response and resolution times) and billing defaults. When a ticket's resolution target is running out, an **at-risk** chip appears in the queue, turning to **breached** once the target has passed -- and the **Breaching soon** tab collects all of them in one place.
+
+<Aside>
+  Today the SLA targets drive the at-risk and breached chips in the queue. The full automated SLA engine -- enforcement, escalations, and business-hours schedules -- arrives in a later release.
+</Aside>
+
+## Tickets on a Device
+
+Every device page has a **Tickets** tab listing the tickets attached to that device, with status, priority, and SLA chips. It is the fastest way to check whether the machine you are about to work on already has open issues.

--- a/apps/web/src/components/tickets/TicketQueueList.tsx
+++ b/apps/web/src/components/tickets/TicketQueueList.tsx
@@ -7,6 +7,8 @@ interface Props {
   selectedId: string | null;
   onSelect: (t: TicketSummary) => void;
   loading: boolean;
+  /** When set, the empty state offers a "Clear filters" action (UI brief: "View empty (filters)"). */
+  onClearFilters?: () => void;
 }
 
 function timeAgo(iso: string): string {
@@ -16,7 +18,7 @@ function timeAgo(iso: string): string {
   return `${Math.floor(mins / (60 * 24))}d ago`;
 }
 
-export default function TicketQueueList({ tickets, selectedId, onSelect, loading }: Props) {
+export default function TicketQueueList({ tickets, selectedId, onSelect, loading, onClearFilters }: Props) {
   if (loading) {
     return (
       <div className="divide-y" data-testid="tickets-queue-loading">
@@ -33,7 +35,17 @@ export default function TicketQueueList({ tickets, selectedId, onSelect, loading
   if (tickets.length === 0) {
     return (
       <div className="px-4 py-12 text-center text-sm text-muted-foreground" data-testid="tickets-queue-empty">
-        No tickets match.
+        <p>No tickets match.</p>
+        {onClearFilters && (
+          <button
+            type="button"
+            onClick={onClearFilters}
+            data-testid="tickets-filters-clear"
+            className="mt-2 rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+          >
+            Clear filters
+          </button>
+        )}
       </div>
     );
   }

--- a/apps/web/src/components/tickets/TicketQueueList.tsx
+++ b/apps/web/src/components/tickets/TicketQueueList.tsx
@@ -9,6 +9,9 @@ interface Props {
   loading: boolean;
   /** When set, the empty state offers a "Clear filters" action (UI brief: "View empty (filters)"). */
   onClearFilters?: () => void;
+  /** Bulk selection (UI brief §6). Checkboxes render only when onToggleSelect is provided. */
+  bulkSelectedIds?: Set<string>;
+  onToggleSelect?: (id: string) => void;
 }
 
 function timeAgo(iso: string): string {
@@ -18,7 +21,9 @@ function timeAgo(iso: string): string {
   return `${Math.floor(mins / (60 * 24))}d ago`;
 }
 
-export default function TicketQueueList({ tickets, selectedId, onSelect, loading, onClearFilters }: Props) {
+export default function TicketQueueList({ tickets, selectedId, onSelect, loading, onClearFilters, bulkSelectedIds, onToggleSelect }: Props) {
+  const anyBulkSelected = (bulkSelectedIds?.size ?? 0) > 0;
+
   if (loading) {
     return (
       <div className="divide-y" data-testid="tickets-queue-loading">
@@ -53,7 +58,25 @@ export default function TicketQueueList({ tickets, selectedId, onSelect, loading
   return (
     <ul className="divide-y" role="listbox" aria-label="Ticket queue" data-testid="tickets-queue">
       {tickets.map((t) => (
-        <li key={t.id}>
+        <li key={t.id} className="group relative">
+          {/* Sibling of the row button (not nested) so checkbox clicks never trigger
+              row selection. Hidden until row hover or an active selection (brief §6). */}
+          {onToggleSelect && (
+            <input
+              type="checkbox"
+              checked={bulkSelectedIds?.has(t.id) ?? false}
+              onChange={() => onToggleSelect(t.id)}
+              onClick={(e) => e.stopPropagation()}
+              aria-label={`Select ${t.internalNumber ?? t.subject}`}
+              data-testid={`ticket-select-${t.id}`}
+              className={cn(
+                'absolute left-2 top-3 z-10 h-4 w-4 cursor-pointer accent-primary transition-opacity',
+                anyBulkSelected || bulkSelectedIds?.has(t.id)
+                  ? 'opacity-100'
+                  : 'opacity-0 focus-visible:opacity-100 group-hover:opacity-100'
+              )}
+            />
+          )}
           <button
             type="button"
             role="option"
@@ -62,6 +85,7 @@ export default function TicketQueueList({ tickets, selectedId, onSelect, loading
             data-testid={`ticket-row-${t.id}`}
             className={cn(
               'w-full px-3 py-2.5 text-left hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+              onToggleSelect && 'pl-8', // reserve the checkbox gutter
               t.id === selectedId && 'bg-primary/5 border-l-0' // selection tint; brand color reserved for selection
             )}
           >

--- a/apps/web/src/components/tickets/TicketsPage.test.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.test.tsx
@@ -78,10 +78,13 @@ const ORGS = { data: [{ id: 'org-1', name: 'Acme Corp' }, { id: 'org-2', name: '
 const CATEGORIES = { data: [{ id: 'cat-1', name: 'Hardware', isActive: true }, { id: 'cat-2', name: 'Retired', isActive: false }] };
 const USERS = { data: [{ id: 'user-1', name: 'Todd', email: 'todd@example.com', status: 'active' }] };
 
+const BULK_RESULT = { data: { updated: 2, skipped: 0, failed: 0, total: 2 } };
+
 function mockListApi(tickets: TicketSummary[] | ((url: string) => TicketSummary[]), opts: { usersFail?: boolean } = {}) {
   fetchMock.mockImplementation(async (input) => {
     const url = String(input);
     if (url === '/tickets/stats') return makeJsonResponse(STATS);
+    if (url === '/tickets/bulk') return makeJsonResponse(BULK_RESULT);
     if (url.startsWith('/tickets?')) return makeJsonResponse({ data: typeof tickets === 'function' ? tickets(url) : tickets });
     if (url.startsWith('/orgs/organizations')) return makeJsonResponse(ORGS);
     if (url === '/ticket-categories') return makeJsonResponse(CATEGORIES);
@@ -233,6 +236,107 @@ describe('TicketsPage', () => {
     fireEvent.click(screen.getByTestId('tickets-tab-mine'));
     expect(screen.getByTestId('tickets-filter-assignee')).toBeDisabled();
     expect(screen.getByTestId('tickets-filter-assignee')).toHaveAttribute('title', 'Tab already filters by assignee');
+  });
+
+  describe('bulk selection', () => {
+    it('selecting two rows shows the bulk bar with "2 selected" without changing the workbench selection', async () => {
+      mockListApi([healthy, atRisk, breached]);
+      render(<TicketsPage />);
+
+      await screen.findByTestId('ticket-row-tk-healthy');
+      // Auto-select picks the first row for the workbench.
+      await waitFor(() => {
+        expect(screen.getByTestId('ticket-workbench-mock')).toHaveTextContent('tk-healthy');
+      });
+
+      fireEvent.click(screen.getByTestId('ticket-select-tk-healthy'));
+      fireEvent.click(screen.getByTestId('ticket-select-tk-risk'));
+
+      expect(screen.getByTestId('tickets-bulk-bar')).toHaveTextContent('2 selected');
+      // Checkbox clicks must NOT drive row selection (stopPropagation / sibling layout).
+      expect(screen.getByTestId('ticket-workbench-mock')).toHaveTextContent('tk-healthy');
+      expect(screen.getByTestId('ticket-row-tk-risk')).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('applying a status POSTs /tickets/bulk with both ids, toasts the aggregate, and clears the bar', async () => {
+      mockListApi([healthy, atRisk, breached]);
+      render(<TicketsPage />);
+
+      await screen.findByTestId('ticket-row-tk-healthy');
+      fireEvent.click(screen.getByTestId('ticket-select-tk-healthy'));
+      fireEvent.click(screen.getByTestId('ticket-select-tk-risk'));
+
+      fireEvent.change(screen.getByTestId('tickets-bulk-status'), { target: { value: 'closed' } });
+      fireEvent.click(screen.getByTestId('tickets-bulk-apply'));
+
+      await waitFor(() => {
+        const bulkCall = fetchMock.mock.calls.find((call) => String(call[0]) === '/tickets/bulk');
+        expect(bulkCall).toBeTruthy();
+        const body = JSON.parse(String((bulkCall![1] as RequestInit).body));
+        expect(body).toEqual({
+          ticketIds: expect.arrayContaining(['tk-healthy', 'tk-risk']),
+          action: 'status',
+          status: 'closed'
+        });
+        expect(body.ticketIds).toHaveLength(2);
+      });
+
+      await waitFor(() => {
+        expect(showToast).toHaveBeenCalledWith({ type: 'success', message: '2 updated' });
+      });
+      await waitFor(() => {
+        expect(screen.queryByTestId('tickets-bulk-bar')).toBeNull();
+      });
+    });
+
+    it('applying an assignee POSTs action=assign; "Unassign" maps to assigneeId null', async () => {
+      mockListApi([healthy, atRisk, breached]);
+      render(<TicketsPage />);
+
+      await screen.findByTestId('ticket-row-tk-healthy');
+      fireEvent.click(screen.getByTestId('ticket-select-tk-healthy'));
+
+      fireEvent.change(screen.getByTestId('tickets-bulk-assignee'), { target: { value: 'unassign' } });
+      fireEvent.click(screen.getByTestId('tickets-bulk-apply'));
+
+      await waitFor(() => {
+        const bulkCall = fetchMock.mock.calls.find((call) => String(call[0]) === '/tickets/bulk');
+        expect(bulkCall).toBeTruthy();
+        const body = JSON.parse(String((bulkCall![1] as RequestInit).body));
+        expect(body).toEqual({ ticketIds: ['tk-healthy'], action: 'assign', assigneeId: null });
+      });
+    });
+
+    it('switching tabs clears the selection and hides the bulk bar', async () => {
+      mockListApi([healthy, atRisk, breached]);
+      render(<TicketsPage />);
+
+      await screen.findByTestId('ticket-row-tk-healthy');
+      fireEvent.click(screen.getByTestId('ticket-select-tk-healthy'));
+      expect(screen.getByTestId('tickets-bulk-bar')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('tickets-tab-unassigned'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('tickets-bulk-bar')).toBeNull();
+      });
+    });
+
+    it('Clear empties the selection; Select all selects every visible row', async () => {
+      mockListApi([healthy, atRisk, breached]);
+      render(<TicketsPage />);
+
+      await screen.findByTestId('ticket-row-tk-healthy');
+      fireEvent.click(screen.getByTestId('ticket-select-tk-healthy'));
+
+      fireEvent.click(screen.getByTestId('tickets-bulk-select-all'));
+      expect(screen.getByTestId('tickets-bulk-bar')).toHaveTextContent('3 selected');
+
+      fireEvent.click(screen.getByTestId('tickets-bulk-clear'));
+      await waitFor(() => {
+        expect(screen.queryByTestId('tickets-bulk-bar')).toBeNull();
+      });
+    });
   });
 
   it('active filter with empty results shows clear-filters; clicking resets and refetches', async () => {

--- a/apps/web/src/components/tickets/TicketsPage.test.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.test.tsx
@@ -74,15 +74,26 @@ const breached = makeTicket({
 });
 
 const STATS = { data: { open: 3, unassigned: 1, mine: 0, breached: 1 } };
+const ORGS = { data: [{ id: 'org-1', name: 'Acme Corp' }, { id: 'org-2', name: 'Globex' }] };
+const CATEGORIES = { data: [{ id: 'cat-1', name: 'Hardware', isActive: true }, { id: 'cat-2', name: 'Retired', isActive: false }] };
+const USERS = { data: [{ id: 'user-1', name: 'Todd', email: 'todd@example.com', status: 'active' }] };
 
-function mockListApi(tickets: TicketSummary[]) {
+function mockListApi(tickets: TicketSummary[] | ((url: string) => TicketSummary[]), opts: { usersFail?: boolean } = {}) {
   fetchMock.mockImplementation(async (input) => {
     const url = String(input);
     if (url === '/tickets/stats') return makeJsonResponse(STATS);
-    if (url.startsWith('/tickets?')) return makeJsonResponse({ data: tickets });
+    if (url.startsWith('/tickets?')) return makeJsonResponse({ data: typeof tickets === 'function' ? tickets(url) : tickets });
+    if (url.startsWith('/orgs/organizations')) return makeJsonResponse(ORGS);
+    if (url === '/ticket-categories') return makeJsonResponse(CATEGORIES);
+    if (url === '/users') {
+      return opts.usersFail ? makeJsonResponse({ error: 'forbidden' }, false, 403) : makeJsonResponse(USERS);
+    }
     return makeJsonResponse({ error: 'unexpected' }, false, 404);
   });
 }
+
+const ticketFetchUrls = () =>
+  fetchMock.mock.calls.map((call) => String(call[0])).filter((url) => url.startsWith('/tickets?'));
 
 function clearHash() {
   history.replaceState(null, '', window.location.pathname);
@@ -163,5 +174,85 @@ describe('TicketsPage', () => {
       expect(screen.getByTestId('ticket-row-tk-healthy')).toHaveAttribute('aria-selected', 'true');
     });
     expect(screen.getByTestId('ticket-workbench-mock')).toHaveTextContent('tk-healthy');
+  });
+
+  it('picking a priority adds priority= to the fetch and re-renders from the result', async () => {
+    mockListApi((url) => (url.includes('priority=high') ? [atRisk] : [healthy, atRisk, breached]));
+    render(<TicketsPage />);
+
+    await screen.findByTestId('ticket-row-tk-healthy');
+
+    fireEvent.change(screen.getByTestId('tickets-filter-priority'), { target: { value: 'high' } });
+
+    await waitFor(() => {
+      expect(ticketFetchUrls().at(-1)).toContain('priority=high');
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('ticket-row-tk-healthy')).toBeNull();
+    });
+    expect(screen.getByTestId('ticket-row-tk-risk')).toBeInTheDocument();
+  });
+
+  it('org filter adds orgId; clearing back to all removes it', async () => {
+    mockListApi([healthy]);
+    render(<TicketsPage />);
+
+    await screen.findByTestId('ticket-row-tk-healthy');
+    // Wait for the org options to load before selecting one.
+    await screen.findByRole('option', { name: 'Globex' });
+
+    fireEvent.change(screen.getByTestId('tickets-filter-org'), { target: { value: 'org-2' } });
+    await waitFor(() => {
+      expect(ticketFetchUrls().at(-1)).toContain('orgId=org-2');
+    });
+
+    fireEvent.change(screen.getByTestId('tickets-filter-org'), { target: { value: '' } });
+    await waitFor(() => {
+      expect(ticketFetchUrls().at(-1)).not.toContain('orgId=');
+    });
+  });
+
+  it('hides the assignee select when the users request fails', async () => {
+    mockListApi([healthy], { usersFail: true });
+    render(<TicketsPage />);
+
+    await screen.findByTestId('ticket-row-tk-healthy');
+    // Other selects load their options; assignee stays hidden.
+    await screen.findByRole('option', { name: 'Globex' });
+    expect(screen.queryByTestId('tickets-filter-assignee')).toBeNull();
+    expect(screen.getByTestId('tickets-filter-org')).toBeInTheDocument();
+  });
+
+  it('shows the assignee select when users load, disabled on assignee tabs', async () => {
+    mockListApi([healthy]);
+    render(<TicketsPage />);
+
+    const select = await screen.findByTestId('tickets-filter-assignee');
+    expect(select).not.toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('tickets-tab-mine'));
+    expect(screen.getByTestId('tickets-filter-assignee')).toBeDisabled();
+    expect(screen.getByTestId('tickets-filter-assignee')).toHaveAttribute('title', 'Tab already filters by assignee');
+  });
+
+  it('active filter with empty results shows clear-filters; clicking resets and refetches', async () => {
+    mockListApi((url) => (url.includes('priority=') ? [] : [healthy]));
+    render(<TicketsPage />);
+
+    await screen.findByTestId('ticket-row-tk-healthy');
+
+    fireEvent.change(screen.getByTestId('tickets-filter-priority'), { target: { value: 'urgent' } });
+
+    await screen.findByTestId('tickets-queue-empty');
+    // Filtered-empty is the queue empty state, never the onboarding state.
+    expect(screen.queryByTestId('tickets-empty')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('tickets-filters-clear'));
+
+    await screen.findByTestId('ticket-row-tk-healthy');
+    const lastUrl = ticketFetchUrls().at(-1) ?? '';
+    expect(lastUrl).not.toContain('priority=');
+    expect(lastUrl).not.toContain('orgId=');
+    expect(lastUrl).not.toContain('categoryId=');
   });
 });

--- a/apps/web/src/components/tickets/TicketsPage.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.tsx
@@ -8,9 +8,11 @@ import { navigateTo } from '@/lib/navigation';
 import TicketQueueList from './TicketQueueList';
 import TicketWorkbench from './TicketWorkbench';
 import { useQueueKeyboard } from './useQueueKeyboard';
-import { slaState, type TicketSummary } from './ticketConfig';
+import { priorityConfig, slaState, type TicketPriority, type TicketSummary } from './ticketConfig';
 
 type Tab = 'mine' | 'unassigned' | 'open' | 'breaching' | 'closed';
+
+const PRIORITY_ORDER: TicketPriority[] = ['low', 'normal', 'high', 'urgent'];
 
 const TABS: Array<{ id: Tab; label: string }> = [
   { id: 'mine', label: 'My tickets' },
@@ -44,7 +46,54 @@ export default function TicketsPage() {
   const [error, setError] = useState<string>();
   const [selectedNumber, setSelectedNumber] = useState<string | null>(selectionFromHash);
   const [search, setSearch] = useState('');
+  const [orgFilter, setOrgFilter] = useState('');
+  const [priorityFilter, setPriorityFilter] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState('');
+  const [assigneeFilter, setAssigneeFilter] = useState('');
+  const [orgs, setOrgs] = useState<Array<{ id: string; name: string }>>([]);
+  const [categories, setCategories] = useState<Array<{ id: string; name: string }>>([]);
+  // null = assignee select hidden (e.g. caller lacks USERS_READ); graceful degradation, no error UI.
+  const [assignees, setAssignees] = useState<Array<{ id: string; name: string | null; email: string }> | null>(null);
   const fetchSeq = useRef(0);
+
+  // 'mine'/'unassigned' tabs already pin the assignee param; the filter select is locked there.
+  const assigneeLocked = tab === 'mine' || tab === 'unassigned';
+  const filtersActive = Boolean(orgFilter || priorityFilter || categoryFilter || assigneeFilter);
+
+  const clearFilters = useCallback(() => {
+    setOrgFilter('');
+    setPriorityFilter('');
+    setCategoryFilter('');
+    setAssigneeFilter('');
+  }, []);
+
+  // Filter options load once; failures degrade per-select (these are filters, not critical path).
+  useEffect(() => {
+    let cancelled = false;
+    const readJson = async (res: Response): Promise<unknown> => (res.ok ? res.json() : null);
+    void (async () => {
+      const [orgRes, catRes, userRes] = await Promise.allSettled([
+        fetchWithAuth('/orgs/organizations?limit=100').then(readJson),
+        fetchWithAuth('/ticket-categories').then(readJson),
+        fetchWithAuth('/users').then(readJson)
+      ]);
+      if (cancelled) return;
+      if (orgRes.status === 'fulfilled' && orgRes.value) {
+        const body = orgRes.value as { data?: Array<{ id: string; name: string }>; organizations?: Array<{ id: string; name: string }> };
+        setOrgs((body.data ?? body.organizations ?? []).filter((o) => o.id && o.name));
+      }
+      if (catRes.status === 'fulfilled' && catRes.value) {
+        const body = catRes.value as { data?: Array<{ id: string; name: string; isActive?: boolean }> };
+        setCategories((body.data ?? []).filter((cat) => cat.isActive !== false));
+      }
+      if (userRes.status === 'fulfilled' && userRes.value) {
+        const body = userRes.value as { data?: Array<{ id: string; name: string | null; email: string }> };
+        const rows = Array.isArray(body) ? body : body.data;
+        if (Array.isArray(rows)) setAssignees(rows.filter((u) => u.id));
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
 
   const fetchTickets = useCallback(async () => {
     const seq = ++fetchSeq.current;
@@ -53,6 +102,11 @@ export default function TicketsPage() {
     try {
       const params = new URLSearchParams(tabQuery(tab));
       if (search) params.set('search', search);
+      if (orgFilter) params.set('orgId', orgFilter);
+      if (priorityFilter) params.set('priority', priorityFilter);
+      if (categoryFilter) params.set('categoryId', categoryFilter);
+      // The 'mine'/'unassigned' tabs already set assignee; the filter applies only on the other tabs.
+      if (assigneeFilter && tab !== 'mine' && tab !== 'unassigned') params.set('assignee', assigneeFilter);
       params.set('limit', '100');
       const res = await fetchWithAuth(`/tickets?${params.toString()}`);
       if (!res.ok) {
@@ -68,7 +122,7 @@ export default function TicketsPage() {
     } finally {
       if (seq === fetchSeq.current) setLoading(false);
     }
-  }, [tab, search]);
+  }, [tab, search, orgFilter, priorityFilter, categoryFilter, assigneeFilter]);
 
   const fetchStats = useCallback(async () => {
     try {
@@ -178,7 +232,13 @@ export default function TicketsPage() {
     return null;
   };
 
-  const trueEmpty = !loading && tickets.length === 0 && tab === 'open' && !search && !error;
+  const trueEmpty = !loading && tickets.length === 0 && tab === 'open' && !search && !filtersActive && !error;
+
+  const filterSelectClass = (active: boolean) =>
+    cn(
+      'h-8 max-w-[180px] rounded-md border bg-background px-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50',
+      active ? 'text-foreground' : 'text-muted-foreground'
+    );
 
   return (
     <div className="flex h-full min-h-0 flex-col" data-testid="tickets-page">
@@ -219,6 +279,61 @@ export default function TicketsPage() {
         />
       </div>
 
+      <div className="mb-3 flex flex-wrap items-center gap-2" data-testid="tickets-filter-bar">
+        <select
+          value={orgFilter}
+          onChange={(e) => setOrgFilter(e.target.value)}
+          aria-label="Filter by organization"
+          data-testid="tickets-filter-org"
+          className={filterSelectClass(!!orgFilter)}
+        >
+          <option value="">All organizations</option>
+          {orgs.map((o) => (
+            <option key={o.id} value={o.id}>{o.name}</option>
+          ))}
+        </select>
+        <select
+          value={priorityFilter}
+          onChange={(e) => setPriorityFilter(e.target.value)}
+          aria-label="Filter by priority"
+          data-testid="tickets-filter-priority"
+          className={filterSelectClass(!!priorityFilter)}
+        >
+          <option value="">All priorities</option>
+          {PRIORITY_ORDER.map((p) => (
+            <option key={p} value={p}>{priorityConfig[p].label}</option>
+          ))}
+        </select>
+        <select
+          value={categoryFilter}
+          onChange={(e) => setCategoryFilter(e.target.value)}
+          aria-label="Filter by category"
+          data-testid="tickets-filter-category"
+          className={filterSelectClass(!!categoryFilter)}
+        >
+          <option value="">All categories</option>
+          {categories.map((cat) => (
+            <option key={cat.id} value={cat.id}>{cat.name}</option>
+          ))}
+        </select>
+        {assignees !== null && (
+          <select
+            value={assigneeFilter}
+            onChange={(e) => setAssigneeFilter(e.target.value)}
+            disabled={assigneeLocked}
+            title={assigneeLocked ? 'Tab already filters by assignee' : undefined}
+            aria-label="Filter by assignee"
+            data-testid="tickets-filter-assignee"
+            className={filterSelectClass(!!assigneeFilter)}
+          >
+            <option value="">All assignees</option>
+            {assignees.map((u) => (
+              <option key={u.id} value={u.id}>{u.name || u.email}</option>
+            ))}
+          </select>
+        )}
+      </div>
+
       {trueEmpty ? (
         <div className="flex flex-1 flex-col items-center justify-center text-center" data-testid="tickets-empty">
           <h2 className="text-base font-medium">No tickets yet</h2>
@@ -240,7 +355,13 @@ export default function TicketsPage() {
       ) : (
         <div className="flex min-h-0 flex-1 overflow-hidden rounded-lg border">
           <div className="w-full min-[1100px]:w-2/5 min-[1100px]:min-w-[320px] min-[1100px]:max-w-[480px] overflow-y-auto min-[1100px]:border-r">
-            <TicketQueueList tickets={visible} selectedId={selected?.id ?? null} onSelect={select} loading={loading} />
+            <TicketQueueList
+              tickets={visible}
+              selectedId={selected?.id ?? null}
+              onSelect={select}
+              loading={loading}
+              onClearFilters={filtersActive ? clearFilters : undefined}
+            />
           </div>
           <div className="hidden min-w-0 flex-1 min-[1100px]:block">
             {selected ? (

--- a/apps/web/src/components/tickets/TicketsPage.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.tsx
@@ -8,11 +8,15 @@ import { navigateTo } from '@/lib/navigation';
 import TicketQueueList from './TicketQueueList';
 import TicketWorkbench from './TicketWorkbench';
 import { useQueueKeyboard } from './useQueueKeyboard';
-import { priorityConfig, slaState, type TicketPriority, type TicketSummary } from './ticketConfig';
+import { priorityConfig, statusConfig, slaState, type TicketPriority, type TicketStatus, type TicketSummary } from './ticketConfig';
 
 type Tab = 'mine' | 'unassigned' | 'open' | 'breaching' | 'closed';
 
 const PRIORITY_ORDER: TicketPriority[] = ['low', 'normal', 'high', 'urgent'];
+
+// Bulk status options exclude 'resolved': resolving requires a per-ticket
+// resolution note, so it stays a per-ticket action (workbench).
+const BULK_STATUSES: TicketStatus[] = ['new', 'open', 'pending', 'on_hold', 'closed'];
 
 const TABS: Array<{ id: Tab; label: string }> = [
   { id: 'mine', label: 'My tickets' },
@@ -54,6 +58,10 @@ export default function TicketsPage() {
   const [categories, setCategories] = useState<Array<{ id: string; name: string }>>([]);
   // null = assignee select hidden (e.g. caller lacks USERS_READ); graceful degradation, no error UI.
   const [assignees, setAssignees] = useState<Array<{ id: string; name: string | null; email: string }> | null>(null);
+  // Bulk selection (UI brief §6): checkbox column + slide-up action bar.
+  const [bulkSelectedIds, setBulkSelectedIds] = useState<Set<string>>(new Set());
+  const [bulkAssignee, setBulkAssignee] = useState(''); // '' = none; 'unassign' sentinel = null assignee
+  const [bulkStatus, setBulkStatus] = useState('');
   const fetchSeq = useRef(0);
 
   // 'mine'/'unassigned' tabs already pin the assignee param; the filter select is locked there.
@@ -138,6 +146,13 @@ export default function TicketsPage() {
 
   useEffect(() => { void fetchTickets(); void fetchStats(); }, [fetchTickets, fetchStats]);
 
+  // Selection is per-view: switching tab or changing any filter/search clears it.
+  useEffect(() => {
+    setBulkSelectedIds(new Set());
+    setBulkAssignee('');
+    setBulkStatus('');
+  }, [tab, search, orgFilter, priorityFilter, categoryFilter, assigneeFilter]);
+
   useEffect(() => {
     const onHash = () => setSelectedNumber(selectionFromHash());
     window.addEventListener('hashchange', onHash);
@@ -204,6 +219,43 @@ export default function TicketsPage() {
       if (!(err instanceof ActionError)) showToast({ type: 'error', message: 'Assign failed. Retry.' });
     }
   }, [selected, fetchTickets, fetchStats]);
+
+  const toggleBulkSelect = useCallback((id: string) => {
+    setBulkSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const clearBulkSelection = useCallback(() => {
+    setBulkSelectedIds(new Set());
+    setBulkAssignee('');
+    setBulkStatus('');
+  }, []);
+
+  const applyBulk = useCallback(async () => {
+    const ticketIds = Array.from(bulkSelectedIds);
+    if (ticketIds.length === 0 || (!bulkAssignee && !bulkStatus)) return;
+    const body = bulkStatus
+      ? { ticketIds, action: 'status', status: bulkStatus }
+      : { ticketIds, action: 'assign', assigneeId: bulkAssignee === 'unassign' ? null : bulkAssignee };
+    try {
+      await runAction<{ data: { updated: number; skipped: number; failed: number; total: number } }>({
+        request: () => fetchWithAuth('/tickets/bulk', { method: 'POST', body: JSON.stringify(body) }),
+        errorFallback: 'Bulk update failed. Retry.',
+        successMessage: (r) => `${r.data.updated} updated${r.data.skipped ? `, ${r.data.skipped} skipped` : ''}`,
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
+      });
+      clearBulkSelection();
+      void fetchTickets();
+      void fetchStats();
+    } catch (err) {
+      // ActionError is already toasted by runAction; surface anything else too.
+      if (!(err instanceof ActionError)) showToast({ type: 'error', message: 'Bulk update failed. Retry.' });
+    }
+  }, [bulkSelectedIds, bulkAssignee, bulkStatus, clearBulkSelection, fetchTickets, fetchStats]);
 
   const focusComposer = useCallback((internal: boolean) => {
     const tabBtn = document.querySelector<HTMLButtonElement>(
@@ -354,14 +406,80 @@ export default function TicketsPage() {
         </div>
       ) : (
         <div className="flex min-h-0 flex-1 overflow-hidden rounded-lg border">
-          <div className="w-full min-[1100px]:w-2/5 min-[1100px]:min-w-[320px] min-[1100px]:max-w-[480px] overflow-y-auto min-[1100px]:border-r">
-            <TicketQueueList
-              tickets={visible}
-              selectedId={selected?.id ?? null}
-              onSelect={select}
-              loading={loading}
-              onClearFilters={filtersActive ? clearFilters : undefined}
-            />
+          <div className="relative flex w-full flex-col min-[1100px]:w-2/5 min-[1100px]:min-w-[320px] min-[1100px]:max-w-[480px] min-[1100px]:border-r">
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <TicketQueueList
+                tickets={visible}
+                selectedId={selected?.id ?? null}
+                onSelect={select}
+                loading={loading}
+                onClearFilters={filtersActive ? clearFilters : undefined}
+                bulkSelectedIds={bulkSelectedIds}
+                onToggleSelect={toggleBulkSelect}
+              />
+            </div>
+            {bulkSelectedIds.size > 0 && (
+              // Slide-up bar at the bottom of the list pane (brief §6). Reuses the
+              // global fade-up keyframes (translate-y + fade) at 180ms ease-out.
+              <div
+                className="absolute inset-x-0 bottom-0 z-10 border-t bg-background px-3 py-2 shadow-[0_-4px_12px_-6px_rgba(0,0,0,0.15)] animate-[fade-up_0.18s_ease-out_both]"
+                data-testid="tickets-bulk-bar"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-sm font-medium tabular-nums">{bulkSelectedIds.size} selected</span>
+                  <button
+                    type="button"
+                    onClick={() => setBulkSelectedIds(new Set(visible.map((t) => t.id)))}
+                    data-testid="tickets-bulk-select-all"
+                    className="text-sm text-primary hover:underline"
+                  >
+                    Select all
+                  </button>
+                  <select
+                    value={bulkAssignee}
+                    onChange={(e) => { setBulkAssignee(e.target.value); if (e.target.value) setBulkStatus(''); }}
+                    aria-label="Bulk assign to"
+                    data-testid="tickets-bulk-assignee"
+                    className="h-8 max-w-[150px] rounded-md border bg-background px-2 text-sm"
+                  >
+                    <option value="">Assign to…</option>
+                    <option value="unassign">Unassign</option>
+                    {(assignees ?? []).map((u) => (
+                      <option key={u.id} value={u.id}>{u.name || u.email}</option>
+                    ))}
+                  </select>
+                  <select
+                    value={bulkStatus}
+                    onChange={(e) => { setBulkStatus(e.target.value); if (e.target.value) setBulkAssignee(''); }}
+                    aria-label="Bulk set status"
+                    data-testid="tickets-bulk-status"
+                    className="h-8 max-w-[130px] rounded-md border bg-background px-2 text-sm"
+                  >
+                    <option value="">Set status…</option>
+                    {BULK_STATUSES.map((s) => (
+                      <option key={s} value={s}>{statusConfig[s].label}</option>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    onClick={() => void applyBulk()}
+                    disabled={!bulkAssignee && !bulkStatus}
+                    data-testid="tickets-bulk-apply"
+                    className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-white hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    Apply
+                  </button>
+                  <button
+                    type="button"
+                    onClick={clearBulkSelection}
+                    data-testid="tickets-bulk-clear"
+                    className="ml-auto rounded-md border px-2.5 py-1.5 text-sm hover:bg-muted"
+                  >
+                    Clear
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
           <div className="hidden min-w-0 flex-1 min-[1100px]:block">
             {selected ? (

--- a/packages/shared/src/utils/docsMapping.test.ts
+++ b/packages/shared/src/utils/docsMapping.test.ts
@@ -180,6 +180,26 @@ describe('getDocsForPath', () => {
     });
   });
 
+  describe('ticketing mappings', () => {
+    it('/tickets maps to ticketing docs', () => {
+      const result = getDocsForPath('/tickets');
+      expect(result.label).toBe('Ticketing');
+      expect(result.url).toContain('/features/ticketing/');
+    });
+
+    it('/tickets/abc-123 matches ticketing', () => {
+      const result = getDocsForPath('/tickets/abc-123');
+      expect(result.label).toBe('Ticketing');
+      expect(result.url).toContain('/features/ticketing/');
+    });
+
+    it('/settings/ticketing matches Ticketing, not generic Settings', () => {
+      const result = getDocsForPath('/settings/ticketing');
+      expect(result.label).toBe('Ticketing');
+      expect(result.url).toContain('/features/ticketing/');
+    });
+  });
+
   describe('trailing slash normalization', () => {
     it('/devices/ is treated the same as /devices', () => {
       const withSlash = getDocsForPath('/devices/');

--- a/packages/shared/src/utils/docsMapping.ts
+++ b/packages/shared/src/utils/docsMapping.ts
@@ -38,6 +38,7 @@ const docsMapping: DocsEntry[] = [
   { pattern: '/settings/partner', docsPath: '/reference/partner-management/', label: 'Partner Settings' },
   { pattern: '/settings/roles', docsPath: '/reference/users-and-roles/', label: 'Roles' },
   { pattern: '/settings/profile', docsPath: '/reference/users-and-roles/', label: 'Profile' },
+  { pattern: '/settings/ticketing', docsPath: '/features/ticketing/', label: 'Ticketing' },
   { pattern: '/settings', docsPath: '/reference/users-and-roles/', label: 'Settings' },
 
   // Admin / Partner
@@ -52,6 +53,7 @@ const docsMapping: DocsEntry[] = [
   { pattern: '/alerts/rules', docsPath: '/features/alert-templates/', label: 'Alert Rules' },
   { pattern: '/alerts/channels', docsPath: '/features/alerts/', label: 'Notification Channels' },
   { pattern: '/alerts', docsPath: '/features/alerts/', label: 'Alerts' },
+  { pattern: '/tickets', docsPath: '/features/ticketing/', label: 'Ticketing' },
   { pattern: '/scripts', docsPath: '/features/scripts/', label: 'Scripts' },
   { pattern: '/patches', docsPath: '/features/patch-management/', label: 'Patch Management' },
   { pattern: '/remote/tools', docsPath: '/features/system-tools/', label: 'System Tools' },

--- a/packages/shared/src/validators/tickets.test.ts
+++ b/packages/shared/src/validators/tickets.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   createTicketSchema, updateTicketSchema, changeTicketStatusSchema,
   assignTicketSchema, addTicketCommentSchema, listTicketsQuerySchema,
-  ticketCategoryInputSchema
+  ticketCategoryInputSchema, bulkTicketActionSchema
 } from './tickets';
 
 describe('ticket validators', () => {
@@ -59,5 +59,45 @@ describe('ticket validators', () => {
   it('category validates hex color', () => {
     expect(ticketCategoryInputSchema.safeParse({ name: 'Hardware', color: '#1c8a9e' }).success).toBe(true);
     expect(ticketCategoryInputSchema.safeParse({ name: 'Hardware', color: 'teal' }).success).toBe(false);
+  });
+
+  describe('bulkTicketActionSchema', () => {
+    const ID = '3f2f1d8e-1111-4222-8333-444455556666';
+    const ASSIGNEE = '5a6b7c8d-1234-4321-abcd-000011112222';
+
+    it('accepts assign with a uuid assignee and with null (unassign)', () => {
+      expect(bulkTicketActionSchema.safeParse({ ticketIds: [ID], action: 'assign', assigneeId: ASSIGNEE }).success).toBe(true);
+      expect(bulkTicketActionSchema.safeParse({ ticketIds: [ID], action: 'assign', assigneeId: null }).success).toBe(true);
+    });
+
+    it('rejects assign without an assigneeId (refine branch)', () => {
+      const r = bulkTicketActionSchema.safeParse({ ticketIds: [ID], action: 'assign' });
+      expect(r.success).toBe(false);
+      if (!r.success) expect(r.error.issues[0]?.path).toEqual(['assigneeId']);
+    });
+
+    it('accepts status for non-resolved statuses', () => {
+      expect(bulkTicketActionSchema.safeParse({ ticketIds: [ID], action: 'status', status: 'closed' }).success).toBe(true);
+      expect(bulkTicketActionSchema.safeParse({ ticketIds: [ID], action: 'status', status: 'on_hold' }).success).toBe(true);
+    });
+
+    it('rejects status action without a status (refine branch)', () => {
+      const r = bulkTicketActionSchema.safeParse({ ticketIds: [ID], action: 'status' });
+      expect(r.success).toBe(false);
+      if (!r.success) expect(r.error.issues[0]?.path).toEqual(['status']);
+    });
+
+    it('rejects resolved — resolving requires a per-ticket resolution note (refine branch)', () => {
+      const r = bulkTicketActionSchema.safeParse({ ticketIds: [ID], action: 'status', status: 'resolved' });
+      expect(r.success).toBe(false);
+      if (!r.success) expect(r.error.issues[0]?.path).toEqual(['status']);
+    });
+
+    it('enforces ticketIds bounds: 1-100 uuids', () => {
+      expect(bulkTicketActionSchema.safeParse({ ticketIds: [], action: 'status', status: 'closed' }).success).toBe(false);
+      expect(bulkTicketActionSchema.safeParse({ ticketIds: ['not-a-uuid'], action: 'status', status: 'closed' }).success).toBe(false);
+      const tooMany = Array.from({ length: 101 }, () => ID);
+      expect(bulkTicketActionSchema.safeParse({ ticketIds: tooMany, action: 'status', status: 'closed' }).success).toBe(false);
+    });
   });
 });

--- a/packages/shared/src/validators/tickets.ts
+++ b/packages/shared/src/validators/tickets.ts
@@ -40,6 +40,24 @@ export const assignTicketSchema = z.object({
   assigneeId: z.string().uuid().nullable()
 });
 
+// Bulk queue actions (assign / status). Resolving is intentionally excluded:
+// it requires a per-ticket resolution note, so it stays a per-ticket action.
+export const bulkTicketActionSchema = z.object({
+  ticketIds: z.array(z.string().uuid()).min(1).max(100),
+  action: z.enum(['assign', 'status']),
+  assigneeId: z.string().uuid().nullable().optional(),
+  status: ticketStatusSchema.optional()
+}).refine(
+  (v) => v.action !== 'assign' || v.assigneeId !== undefined,
+  { message: 'assigneeId is required when action is assign (null to unassign)', path: ['assigneeId'] }
+).refine(
+  (v) => v.action !== 'status' || v.status !== undefined,
+  { message: 'status is required when action is status', path: ['status'] }
+).refine(
+  (v) => v.action !== 'status' || v.status !== 'resolved',
+  { message: 'Resolving requires a per-ticket resolution note; resolve tickets individually', path: ['status'] }
+);
+
 export const addTicketCommentSchema = z.object({
   content: z.string().min(1).max(50_000),
   isPublic: z.boolean().default(true)

--- a/scripts/docs-review/mapping.json
+++ b/scripts/docs-review/mapping.json
@@ -767,6 +767,24 @@
         "deploy/cloudflare-tunnel.mdx",
         "deploy/production.mdx"
       ]
+    },
+    {
+      "pattern": "apps/api/src/routes/tickets/**",
+      "docs": [
+        "features/ticketing.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/routes/ticketCategories.ts",
+      "docs": [
+        "features/ticketing.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/web/src/components/tickets/**",
+      "docs": [
+        "features/ticketing.mdx"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Closes out the ticketing Phase 1 scope against the approved UI brief and the #1196 follow-up list:

- **PATCH through the service layer**: field edits on a ticket now produce a system feed entry ("Updated subject, priority"), an audit log, and a `ticket.updated` lifecycle event (union + consumer + contract tests updated). Device cross-org guard preserved.
- **Queue filter bar** (brief §4): organization, priority, category, and assignee filters; assignee select hides without USERS_READ and is disabled on tabs that already pin the assignee; filtered-empty state gets an inline "Clear filters" action.
- **Bulk actions** (brief §6): checkbox selection + slide-up bar (assign, status). New `POST /tickets/bulk` iterates per ticket through the service layer (feed entries/events/audit per ticket), aggregates `{updated, skipped, failed}`, scope-checks every id, caps at 100, and rejects bulk-resolve (resolution requires a per-ticket note). FSM-invalid transitions and out-of-scope ids count as skipped.
- **Docs**: new `features/ticketing.mdx` (queue, workbench, internal-note safety, shortcuts, bulk, categories/SLA chips with honest "SLA engine later" framing), portal.mdx now states portal tickets reach the technician queue, help-panel route mappings + docs index rebuilt.

Testing: API 106 (tickets routes incl. bulk taxonomy + service + events contract + notify worker), web 71 (components + no-silent-mutations guard), shared 52 (validators + docs mapping), tsc clean all three, astro docs build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)