### PR TITLE
fix(docker): patch openssl CVE-2026-45447 in api/web images (Security Scanning red on main)

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,4 +1,7 @@
 FROM node:24-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS base
+# CVE-2026-45447: base digest ships openssl 3.5.6-r0; pull the fixed 3.5.7-r0
+# from the alpine 3.23 repo until the node:24-alpine digest is refreshed.
+RUN apk upgrade --no-cache libcrypto3 libssl3
 RUN npm install -g pnpm@10.33.4
 
 FROM base AS deps

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -1,4 +1,7 @@
 FROM node:24-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS base
+# CVE-2026-45447: base digest ships openssl 3.5.6-r0; pull the fixed 3.5.7-r0
+# from the alpine 3.23 repo until the node:24-alpine digest is refreshed.
+RUN apk upgrade --no-cache libcrypto3 libssl3
 RUN npm install -g pnpm@10.33.4
 
 FROM base AS deps


### PR DESCRIPTION
## Summary

Security Scanning went red on main starting with the 21:37Z push (run 27307986039): Trivy flags **CVE-2026-45447 (HIGH)** in `libcrypto3`/`libssl3` **3.5.6-r0** from alpine 3.23.4 — the OS layer of the `node:24-alpine` digest both shipped images pin. Fixed version **3.5.7-r0** is already published in the alpine 3.23 repo, so this failure now reproduces on every main push regardless of content (the 20:09Z run passed; nothing in the repo changed the image OS layer between them — the CVE entered the vuln DB).

## Change

One `apk upgrade --no-cache libcrypto3 libssl3` line in the shared `base` stage of `docker/Dockerfile.api` and `docker/Dockerfile.web`, with a comment tying it to the CVE so it can be dropped when the upstream digest is refreshed (or the dependabot alpine bump supersedes it).

## Verification (local, CI-equivalent commands)

- `docker build -f docker/Dockerfile.web -t breeze-web:security-scan .` then `trivy image --severity HIGH,CRITICAL --exit-code 1 breeze-web:security-scan` → **exit 0, alpine vulnerabilities 0** (this is the exact failing CI check, green).
- `docker build --target base -f docker/Dockerfile.api` probe + same scan → **exit 0, alpine 0**; `apk list --installed` in the probe shows `libcrypto3-3.5.7-r0` / `libssl3-3.5.7-r0`.
- Full local api-image build hits a pre-existing local-runner OOM in tsup's dts worker (reproduces identically without this diff; unrelated — the patched apk layer builds before pnpm runs, and CI built this Dockerfile green four times today). The web image full scan + api base-stage scan cover everything this diff changes.

No node/app layer changes; no version changes.
