### PR TITLE
feat(web): PAM admin UI — overview, requests, rules, audit tabs (#1159)

### DIFF
--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -124,6 +124,7 @@ const navSections: NavSection[] = [
       { name: 'Network Monitor', href: '/monitoring', icon: Activity },
       { name: 'Security', href: '/security', icon: ShieldCheck },
       { name: 'DNS Security', href: '/dns-security', icon: Network },
+      { name: 'PAM', href: '/pam', icon: KeyRound },
       { name: 'Sensitive Data', href: '/sensitive-data', icon: ScanSearch },
       { name: 'Peripherals', href: '/peripherals', icon: Usb },
       { name: 'AI Risk Engine', href: '/ai-risk', icon: BrainCircuit },

--- a/apps/web/src/components/pam/PamAuditTab.test.tsx
+++ b/apps/web/src/components/pam/PamAuditTab.test.tsx
@@ -56,6 +56,8 @@ describe('PamAuditTab', () => {
       expect(screen.getByTestId('pam-audit-row-aud-1')).toBeInTheDocument();
     });
     expect(screen.getByText('run_script')).toBeInTheDocument();
+    // ai_tool_action rows carry a risk tier badge next to the target.
+    expect(screen.getByTestId('pam-audit-risk-tier-aud-1')).toHaveTextContent('T2');
   });
 
   it('refetches with a status filter applied', async () => {

--- a/apps/web/src/components/pam/PamAuditTab.test.tsx
+++ b/apps/web/src/components/pam/PamAuditTab.test.tsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PamAuditTab, { buildAuditCsv } from './PamAuditTab';
+import { fetchWithAuth } from '../../stores/auth';
+import type { ElevationRequest } from './types';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('@/lib/navigation', () => ({
+  navigateTo: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+function makeJsonResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
+
+const decided: ElevationRequest = {
+  id: 'aud-1',
+  orgId: 'org-1',
+  deviceId: 'dev-1',
+  deviceHostname: 'WS-CHARLIE',
+  flowType: 'ai_tool_action',
+  toolName: 'run_script',
+  riskTier: 2,
+  subjectUsername: 'device-user',
+  reason: 'Restart spooler, "quoted"',
+  status: 'denied',
+  denialReason: 'Out of window',
+  requestedAt: '2026-06-10T12:00:00.000Z',
+};
+
+describe('PamAuditTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders history rows with filters', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        success: true,
+        requests: [decided],
+        pagination: { page: 1, limit: 50, total: 1 },
+      }),
+    );
+    render(<PamAuditTab />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pam-audit-row-aud-1')).toBeInTheDocument();
+    });
+    expect(screen.getByText('run_script')).toBeInTheDocument();
+  });
+
+  it('refetches with a status filter applied', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        success: true,
+        requests: [],
+        pagination: { page: 1, limit: 50, total: 0 },
+      }),
+    );
+    render(<PamAuditTab />);
+    await waitFor(() => screen.getByTestId('pam-audit-filter-status'));
+    fireEvent.change(screen.getByTestId('pam-audit-filter-status'), {
+      target: { value: 'denied' },
+    });
+    await waitFor(() => {
+      expect(
+        fetchWithAuthMock.mock.calls.some((c) => String(c[0]).includes('status=denied')),
+      ).toBe(true);
+    });
+  });
+
+  it('disables export when there are no rows', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        success: true,
+        requests: [],
+        pagination: { page: 1, limit: 50, total: 0 },
+      }),
+    );
+    render(<PamAuditTab />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pam-audit-export-btn')).toBeDisabled();
+    });
+  });
+});
+
+describe('buildAuditCsv', () => {
+  it('escapes quotes, commas, and newlines per RFC 4180', () => {
+    const csv = buildAuditCsv([decided]);
+    const lines = csv.split('\n');
+    expect(lines[0]).toContain('id,requestedAt,status');
+    expect(lines[1]).toContain('"Restart spooler, ""quoted"""');
+    expect(lines[1]).toContain('run_script');
+    expect(lines[1]).toContain('WS-CHARLIE');
+  });
+
+  it('falls back to deviceId when hostname is missing', () => {
+    const csv = buildAuditCsv([{ ...decided, deviceHostname: null }]);
+    expect(csv.split('\n')[1]).toContain('dev-1');
+  });
+});

--- a/apps/web/src/components/pam/PamAuditTab.tsx
+++ b/apps/web/src/components/pam/PamAuditTab.tsx
@@ -1,0 +1,345 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Download, ScrollText } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { navigateTo } from '@/lib/navigation';
+import {
+  type ElevationFlowType,
+  type ElevationRequest,
+  type ElevationStatus,
+  FLOW_LABELS,
+  type Pagination,
+  STATUS_LABELS,
+  requestTarget,
+  statusBadgeClass,
+} from './types';
+
+const STATUS_OPTIONS: Array<ElevationStatus | ''> = [
+  '',
+  'pending',
+  'approved',
+  'auto_approved',
+  'actuating',
+  'denied',
+  'expired',
+  'revoked',
+];
+const FLOW_OPTIONS: Array<ElevationFlowType | ''> = ['', 'uac_intercept', 'tech_jit_admin', 'ai_tool_action'];
+
+/** Hard cap on rows fetched for CSV export (10 pages of 100). */
+const EXPORT_MAX_ROWS = 1000;
+
+function csvEscape(value: unknown): string {
+  const s = value === null || value === undefined ? '' : String(value);
+  return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+export function buildAuditCsv(rows: ElevationRequest[]): string {
+  const header = [
+    'id',
+    'requestedAt',
+    'status',
+    'flowType',
+    'device',
+    'site',
+    'user',
+    'target',
+    'signer',
+    'hash',
+    'toolName',
+    'riskTier',
+    'reason',
+    'denialReason',
+    'revokedReason',
+    'approvedAt',
+    'expiresAt',
+  ];
+  const lines = [header.join(',')];
+  for (const r of rows) {
+    lines.push(
+      [
+        r.id,
+        r.requestedAt,
+        r.status,
+        r.flowType,
+        r.deviceHostname ?? r.deviceId,
+        r.siteName ?? '',
+        r.subjectUsername,
+        requestTarget(r),
+        r.targetExecutableSigner ?? '',
+        r.targetExecutableHash ?? '',
+        r.toolName ?? '',
+        r.riskTier ?? '',
+        r.reason ?? '',
+        r.denialReason ?? '',
+        r.revokedReason ?? '',
+        r.approvedAt ?? '',
+        r.expiresAt ?? '',
+      ]
+        .map(csvEscape)
+        .join(','),
+    );
+  }
+  return lines.join('\n');
+}
+
+export default function PamAuditTab() {
+  const [rows, setRows] = useState<ElevationRequest[]>([]);
+  const [pagination, setPagination] = useState<Pagination>({ page: 1, limit: 50, total: 0 });
+  const [status, setStatus] = useState<ElevationStatus | ''>('');
+  const [flowType, setFlowType] = useState<ElevationFlowType | ''>('');
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [exporting, setExporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const buildParams = useCallback(
+    (pageNum: number, limit: number) => {
+      const params = new URLSearchParams();
+      if (status) params.set('status', status);
+      if (flowType) params.set('flowType', flowType);
+      if (from) params.set('from', new Date(from).toISOString());
+      if (to) params.set('to', new Date(to).toISOString());
+      params.set('page', String(pageNum));
+      params.set('limit', String(limit));
+      return params;
+    },
+    [status, flowType, from, to],
+  );
+
+  const fetchAudit = useCallback(
+    async (signal?: AbortSignal) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetchWithAuth(`/pam/elevation-requests?${buildParams(page, 50).toString()}`, {
+          signal,
+        });
+        if (!res.ok) {
+          if (res.status === 401) {
+            void navigateTo('/login', { replace: true });
+            return;
+          }
+          throw new Error(`Failed to load audit history (HTTP ${res.status})`);
+        }
+        const body = await res.json();
+        setRows((body.requests ?? []) as ElevationRequest[]);
+        setPagination((body.pagination ?? { page: 1, limit: 50, total: 0 }) as Pagination);
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return;
+        setError(err instanceof Error ? err.message : 'Failed to load audit history');
+      } finally {
+        if (!signal?.aborted) setLoading(false);
+      }
+    },
+    [buildParams, page],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetchAudit(controller.signal);
+    return () => controller.abort();
+  }, [fetchAudit]);
+
+  const exportCsv = async () => {
+    if (exporting) return;
+    setExporting(true);
+    setError(null);
+    try {
+      const all: ElevationRequest[] = [];
+      let exportPage = 1;
+      for (;;) {
+        const res = await fetchWithAuth(
+          `/pam/elevation-requests?${buildParams(exportPage, 100).toString()}`,
+        );
+        if (!res.ok) throw new Error(`Export failed (HTTP ${res.status})`);
+        const body = await res.json();
+        const batch = (body.requests ?? []) as ElevationRequest[];
+        all.push(...batch);
+        const total = Number(body.pagination?.total ?? all.length);
+        if (batch.length === 0 || all.length >= Math.min(total, EXPORT_MAX_ROWS)) break;
+        exportPage += 1;
+      }
+      const csv = buildAuditCsv(all.slice(0, EXPORT_MAX_ROWS));
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `pam-audit-${new Date().toISOString().slice(0, 10)}.csv`;
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Export failed');
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const totalPages = Math.max(1, Math.ceil(pagination.total / pagination.limit));
+  const inputClass = 'rounded-md border bg-background px-2 py-1.5 text-sm';
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end gap-3">
+        <label className="flex items-center gap-2 text-sm">
+          <span className="text-muted-foreground">Status</span>
+          <select
+            value={status}
+            onChange={(e) => {
+              setPage(1);
+              setStatus(e.target.value as ElevationStatus | '');
+            }}
+            data-testid="pam-audit-filter-status"
+            className={inputClass}
+          >
+            {STATUS_OPTIONS.map((s) => (
+              <option key={s || 'all'} value={s}>
+                {s ? STATUS_LABELS[s] : 'All statuses'}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <span className="text-muted-foreground">Flow</span>
+          <select
+            value={flowType}
+            onChange={(e) => {
+              setPage(1);
+              setFlowType(e.target.value as ElevationFlowType | '');
+            }}
+            data-testid="pam-audit-filter-flow"
+            className={inputClass}
+          >
+            {FLOW_OPTIONS.map((f) => (
+              <option key={f || 'all'} value={f}>
+                {f ? FLOW_LABELS[f] : 'All flows'}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <span className="text-muted-foreground">From</span>
+          <input
+            type="date"
+            value={from}
+            onChange={(e) => {
+              setPage(1);
+              setFrom(e.target.value);
+            }}
+            data-testid="pam-audit-filter-from"
+            className={inputClass}
+          />
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <span className="text-muted-foreground">To</span>
+          <input
+            type="date"
+            value={to}
+            onChange={(e) => {
+              setPage(1);
+              setTo(e.target.value);
+            }}
+            data-testid="pam-audit-filter-to"
+            className={inputClass}
+          />
+        </label>
+        <button
+          type="button"
+          onClick={() => void exportCsv()}
+          disabled={exporting || pagination.total === 0}
+          data-testid="pam-audit-export-btn"
+          className="ml-auto inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-accent disabled:opacity-50"
+        >
+          <Download className="h-4 w-4" />
+          {exporting ? 'Exporting…' : 'Export CSV'}
+        </button>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        >
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center gap-2 rounded-md border bg-card px-4 py-6 text-sm text-muted-foreground">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          Loading audit history…
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="rounded-md border border-dashed bg-card px-4 py-8 text-center">
+          <ScrollText className="mx-auto h-8 w-8 text-muted-foreground" />
+          <p className="mt-2 text-sm font-medium">No matching history</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Adjust the filters to see elevation request history.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-md border bg-card">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-xs text-muted-foreground">
+                <th className="px-3 py-2 font-medium">Requested</th>
+                <th className="px-3 py-2 font-medium">Device</th>
+                <th className="px-3 py-2 font-medium">User</th>
+                <th className="px-3 py-2 font-medium">Target</th>
+                <th className="px-3 py-2 font-medium">Flow</th>
+                <th className="px-3 py-2 font-medium">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.id} className="border-b last:border-0" data-testid={`pam-audit-row-${r.id}`}>
+                  <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
+                    {new Date(r.requestedAt).toLocaleString()}
+                  </td>
+                  <td className="px-3 py-2">{r.deviceHostname ?? r.deviceId}</td>
+                  <td className="px-3 py-2">{r.subjectUsername}</td>
+                  <td className="max-w-[280px] truncate px-3 py-2" title={requestTarget(r)}>
+                    {requestTarget(r)}
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-2">{FLOW_LABELS[r.flowType]}</td>
+                  <td className="px-3 py-2">
+                    <span
+                      className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${statusBadgeClass(r.status)}`}
+                    >
+                      {STATUS_LABELS[r.status]}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-end gap-2 text-sm">
+          <button
+            type="button"
+            disabled={page <= 1}
+            onClick={() => setPage((p) => p - 1)}
+            className="rounded-md border px-2.5 py-1 text-xs disabled:opacity-50"
+          >
+            Previous
+          </button>
+          <span className="text-xs text-muted-foreground">
+            Page {pagination.page} of {totalPages}
+          </span>
+          <button
+            type="button"
+            disabled={page >= totalPages}
+            onClick={() => setPage((p) => p + 1)}
+            className="rounded-md border px-2.5 py-1 text-xs disabled:opacity-50"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/pam/PamAuditTab.tsx
+++ b/apps/web/src/components/pam/PamAuditTab.tsx
@@ -299,8 +299,25 @@ export default function PamAuditTab() {
                   </td>
                   <td className="px-3 py-2">{r.deviceHostname ?? r.deviceId}</td>
                   <td className="px-3 py-2">{r.subjectUsername}</td>
-                  <td className="max-w-[280px] truncate px-3 py-2" title={requestTarget(r)}>
-                    {requestTarget(r)}
+                  <td className="max-w-[280px] px-3 py-2">
+                    <div className="flex items-center gap-1.5">
+                      <span className="truncate" title={requestTarget(r)}>
+                        {requestTarget(r)}
+                      </span>
+                      {r.flowType === 'ai_tool_action' && r.riskTier != null && (
+                        <span
+                          data-testid={`pam-audit-risk-tier-${r.id}`}
+                          title={`Risk tier ${r.riskTier}`}
+                          className={`inline-flex shrink-0 rounded px-1 py-0.5 text-[10px] font-semibold ${
+                            r.riskTier >= 3
+                              ? 'bg-red-500/15 text-red-600 dark:text-red-400'
+                              : 'bg-amber-500/15 text-amber-600 dark:text-amber-400'
+                          }`}
+                        >
+                          T{r.riskTier}
+                        </span>
+                      )}
+                    </div>
                   </td>
                   <td className="whitespace-nowrap px-3 py-2">{FLOW_LABELS[r.flowType]}</td>
                   <td className="px-3 py-2">

--- a/apps/web/src/components/pam/PamOverviewTab.test.tsx
+++ b/apps/web/src/components/pam/PamOverviewTab.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PamOverviewTab from './PamOverviewTab';
+import { fetchWithAuth } from '../../stores/auth';
+import type { ElevationRequest } from './types';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('@/lib/navigation', () => ({
+  navigateTo: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+function makeJsonResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
+
+const activeElevation: ElevationRequest = {
+  id: 'act-1',
+  orgId: 'org-1',
+  deviceId: 'dev-1',
+  deviceHostname: 'SRV-BRAVO',
+  flowType: 'tech_jit_admin',
+  subjectUsername: 'tech1',
+  reason: 'Patch window',
+  status: 'approved',
+  requestedAt: '2026-06-10T12:00:00.000Z',
+  expiresAt: new Date(Date.now() + 30 * 60000).toISOString(),
+};
+
+describe('PamOverviewTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders stat cards and active elevations from the three queries', async () => {
+    fetchWithAuthMock.mockImplementation(async (url: string) => {
+      if (url === '/pam/active') {
+        return makeJsonResponse({ success: true, active: [activeElevation] });
+      }
+      if (url.includes('status=pending')) {
+        return makeJsonResponse({
+          success: true,
+          requests: [],
+          pagination: { page: 1, limit: 1, total: 4 },
+        });
+      }
+      return makeJsonResponse({
+        success: true,
+        requests: [{ ...activeElevation, id: 'dec-1', status: 'denied' }],
+        pagination: { page: 1, limit: 10, total: 1 },
+      });
+    });
+
+    render(<PamOverviewTab liveTick={0} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pam-stat-active')).toHaveTextContent('1');
+    });
+    expect(screen.getByTestId('pam-stat-pending')).toHaveTextContent('4');
+    expect(screen.getByTestId('pam-active-row-act-1')).toHaveTextContent('SRV-BRAVO');
+  });
+
+  it('shows empty states when nothing is active', async () => {
+    fetchWithAuthMock.mockImplementation(async () =>
+      makeJsonResponse({
+        success: true,
+        active: [],
+        requests: [],
+        pagination: { page: 1, limit: 10, total: 0 },
+      }),
+    );
+    render(<PamOverviewTab liveTick={0} />);
+    await waitFor(() => {
+      expect(screen.getByText('No active elevations')).toBeInTheDocument();
+    });
+    expect(screen.getByText('No decided requests yet.')).toBeInTheDocument();
+  });
+
+  it('surfaces an error banner when a query fails', async () => {
+    fetchWithAuthMock.mockImplementation(async () => makeJsonResponse({}, false, 500));
+    render(<PamOverviewTab liveTick={0} />);
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('HTTP 500');
+    });
+  });
+});

--- a/apps/web/src/components/pam/PamOverviewTab.tsx
+++ b/apps/web/src/components/pam/PamOverviewTab.tsx
@@ -1,0 +1,219 @@
+import { useCallback, useEffect, useState } from 'react';
+import { ShieldCheck, Timer, Inbox } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { navigateTo } from '@/lib/navigation';
+import {
+  type ElevationRequest,
+  FLOW_LABELS,
+  STATUS_LABELS,
+  requestTarget,
+  statusBadgeClass,
+} from './types';
+
+interface OverviewData {
+  active: ElevationRequest[];
+  pendingTotal: number;
+  recent: ElevationRequest[];
+}
+
+export default function PamOverviewTab({ liveTick }: { liveTick: number }) {
+  const [data, setData] = useState<OverviewData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchOverview = useCallback(async (signal?: AbortSignal) => {
+    setError(null);
+    try {
+      const [activeRes, pendingRes, recentRes] = await Promise.all([
+        fetchWithAuth('/pam/active', { signal }),
+        fetchWithAuth('/pam/elevation-requests?status=pending&limit=1', { signal }),
+        fetchWithAuth('/pam/elevation-requests?limit=10', { signal }),
+      ]);
+      for (const res of [activeRes, pendingRes, recentRes]) {
+        if (!res.ok) {
+          if (res.status === 401) {
+            void navigateTo('/login', { replace: true });
+            return;
+          }
+          throw new Error(`Failed to load overview (HTTP ${res.status})`);
+        }
+      }
+      const activeBody = await activeRes.json();
+      const pendingBody = await pendingRes.json();
+      const recentBody = await recentRes.json();
+      setData({
+        active: (activeBody.active ?? []) as ElevationRequest[],
+        pendingTotal: Number(pendingBody.pagination?.total ?? 0),
+        recent: ((recentBody.requests ?? []) as ElevationRequest[]).filter(
+          (r) => r.status !== 'pending',
+        ),
+      });
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return;
+      setError(err instanceof Error ? err.message : 'Failed to load overview');
+    } finally {
+      if (!signal?.aborted) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetchOverview(controller.signal);
+    return () => controller.abort();
+  }, [fetchOverview, liveTick]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border bg-card px-4 py-6 text-sm text-muted-foreground">
+        <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        Loading overview…
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {error && (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        >
+          {error}
+        </div>
+      )}
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <StatCard
+          icon={<ShieldCheck className="h-5 w-5 text-green-500" />}
+          label="Active elevations"
+          value={data?.active.length ?? 0}
+          testId="pam-stat-active"
+        />
+        <StatCard
+          icon={<Inbox className="h-5 w-5 text-yellow-500" />}
+          label="Pending requests"
+          value={data?.pendingTotal ?? 0}
+          testId="pam-stat-pending"
+        />
+        <StatCard
+          icon={<Timer className="h-5 w-5 text-blue-500" />}
+          label="Recent decisions"
+          value={data?.recent.length ?? 0}
+          testId="pam-stat-recent"
+        />
+      </div>
+
+      <section>
+        <h2 className="mb-2 text-sm font-semibold text-muted-foreground">Active elevations</h2>
+        {!data || data.active.length === 0 ? (
+          <div className="rounded-md border border-dashed bg-card px-4 py-8 text-center">
+            <ShieldCheck className="mx-auto h-8 w-8 text-muted-foreground" />
+            <p className="mt-2 text-sm font-medium">No active elevations</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Approved elevation windows will appear here until they expire or are revoked.
+            </p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto rounded-md border bg-card">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left text-xs text-muted-foreground">
+                  <th className="px-3 py-2 font-medium">Device</th>
+                  <th className="px-3 py-2 font-medium">User</th>
+                  <th className="px-3 py-2 font-medium">Target</th>
+                  <th className="px-3 py-2 font-medium">Flow</th>
+                  <th className="px-3 py-2 font-medium">Status</th>
+                  <th className="px-3 py-2 font-medium">Expires</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.active.map((r) => (
+                  <tr key={r.id} className="border-b last:border-0" data-testid={`pam-active-row-${r.id}`}>
+                    <td className="px-3 py-2">{r.deviceHostname ?? r.deviceId}</td>
+                    <td className="px-3 py-2">{r.subjectUsername}</td>
+                    <td className="max-w-[280px] truncate px-3 py-2" title={requestTarget(r)}>
+                      {requestTarget(r)}
+                    </td>
+                    <td className="px-3 py-2">{FLOW_LABELS[r.flowType]}</td>
+                    <td className="px-3 py-2">
+                      <span
+                        className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${statusBadgeClass(r.status)}`}
+                      >
+                        {STATUS_LABELS[r.status]}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 text-muted-foreground">
+                      {r.expiresAt ? <ExpiresIn at={r.expiresAt} /> : '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <section>
+        <h2 className="mb-2 text-sm font-semibold text-muted-foreground">Recent decisions</h2>
+        {!data || data.recent.length === 0 ? (
+          <div className="rounded-md border border-dashed bg-card px-4 py-6 text-center text-sm text-muted-foreground">
+            No decided requests yet.
+          </div>
+        ) : (
+          <ul className="divide-y rounded-md border bg-card">
+            {data.recent.map((r) => (
+              <li key={r.id} className="flex items-center justify-between gap-3 px-3 py-2 text-sm">
+                <span className="min-w-0 flex-1 truncate" title={requestTarget(r)}>
+                  <span className="font-medium">{r.deviceHostname ?? r.deviceId}</span>
+                  <span className="text-muted-foreground"> · {r.subjectUsername} · </span>
+                  {requestTarget(r)}
+                </span>
+                <span
+                  className={`inline-flex shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${statusBadgeClass(r.status)}`}
+                >
+                  {STATUS_LABELS[r.status]}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function StatCard({
+  icon,
+  label,
+  value,
+  testId,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: number;
+  testId: string;
+}) {
+  return (
+    <div className="rounded-md border bg-card px-4 py-3" data-testid={testId}>
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        {icon}
+        {label}
+      </div>
+      <div className="mt-1 text-2xl font-semibold">{value}</div>
+    </div>
+  );
+}
+
+function ExpiresIn({ at }: { at: string }) {
+  const ms = new Date(at).getTime() - Date.now();
+  if (Number.isNaN(ms)) return <>—</>;
+  if (ms <= 0) return <>expired</>;
+  const mins = Math.round(ms / 60000);
+  if (mins < 60) return <>{mins}m</>;
+  const hours = Math.floor(mins / 60);
+  return (
+    <>
+      {hours}h {mins % 60}m
+    </>
+  );
+}

--- a/apps/web/src/components/pam/PamPage.test.tsx
+++ b/apps/web/src/components/pam/PamPage.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PamPage from './PamPage';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('../shared/Toast', () => ({
+  showToast: vi.fn(),
+}));
+
+const subscribeMock = vi.fn();
+const unsubscribeMock = vi.fn();
+vi.mock('../../hooks/useEventStream', () => ({
+  useEventStream: vi.fn(() => ({
+    connected: true,
+    subscribe: subscribeMock,
+    unsubscribe: unsubscribeMock,
+  })),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+function makeJsonResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
+
+function emptyListResponse(): Response {
+  return makeJsonResponse({
+    success: true,
+    requests: [],
+    active: [],
+    rules: [],
+    pagination: { page: 1, limit: 50, total: 0 },
+  });
+}
+
+describe('PamPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.location.hash = '';
+    fetchWithAuthMock.mockImplementation(async () => emptyListResponse());
+  });
+
+  it('renders the heading, live indicator, and overview tab by default', async () => {
+    render(<PamPage />);
+    expect(screen.getByTestId('pam-heading')).toBeInTheDocument();
+    expect(screen.getByTestId('pam-live-indicator')).toHaveTextContent('Live');
+    await waitFor(() => {
+      expect(screen.getByTestId('pam-stat-active')).toBeInTheDocument();
+    });
+  });
+
+  it('subscribes to elevation events on mount', () => {
+    render(<PamPage />);
+    expect(subscribeMock).toHaveBeenCalledWith(
+      expect.arrayContaining(['elevation.requested', 'elevation.approved', 'elevation.revoked']),
+    );
+  });
+
+  it('switches tabs via the tab bar and updates the hash', async () => {
+    render(<PamPage />);
+    fireEvent.click(screen.getByTestId('pam-tab-rules'));
+    expect(window.location.hash).toBe('#rules');
+    await waitFor(() => {
+      expect(screen.getByTestId('pam-add-rule-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('pam-tab-requests'));
+    expect(window.location.hash).toBe('#requests');
+    await waitFor(() => {
+      expect(screen.getByTestId('pam-filter-status')).toBeInTheDocument();
+    });
+  });
+
+  it('honors a deep-link hash on first render', async () => {
+    window.location.hash = '#audit';
+    render(<PamPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pam-audit-export-btn')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/pam/PamPage.tsx
+++ b/apps/web/src/components/pam/PamPage.tsx
@@ -1,0 +1,161 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Activity, Inbox, ListChecks, ScrollText } from 'lucide-react';
+import { useEventStream } from '../../hooks/useEventStream';
+import PamOverviewTab from './PamOverviewTab';
+import PamRequestsTab from './PamRequestsTab';
+import PamRulesTab from './PamRulesTab';
+import PamAuditTab from './PamAuditTab';
+
+const VALID_TABS = ['overview', 'requests', 'rules', 'audit'] as const;
+type Tab = (typeof VALID_TABS)[number];
+
+const ELEVATION_EVENTS = [
+  'elevation.requested',
+  'elevation.auto_approved',
+  'elevation.approved',
+  'elevation.denied',
+  'elevation.activated',
+  'elevation.expired',
+  'elevation.revoked',
+];
+
+function readTabFromHash(): Tab {
+  if (typeof window === 'undefined') return 'overview';
+  const hash = window.location.hash.replace('#', '');
+  return (VALID_TABS as readonly string[]).includes(hash) ? (hash as Tab) : 'overview';
+}
+
+export default function PamPage() {
+  const [activeTab, setActiveTab] = useState<Tab>(readTabFromHash);
+  // Bumped on every elevation.* event (debounced); tabs refetch when it changes.
+  const [liveTick, setLiveTick] = useState(0);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const switchTab = useCallback((tab: Tab) => {
+    window.location.hash = tab;
+    setActiveTab(tab);
+  }, []);
+
+  useEffect(() => {
+    const onHashChange = () => setActiveTab(readTabFromHash());
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, []);
+
+  const { connected, subscribe, unsubscribe } = useEventStream({
+    onEvent: (event) => {
+      if (!event.type.startsWith('elevation.')) return;
+      // Debounce bursty event storms into a single refetch.
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => setLiveTick((t) => t + 1), 750);
+    },
+  });
+
+  useEffect(() => {
+    subscribe(ELEVATION_EVENTS);
+    return () => {
+      unsubscribe(ELEVATION_EVENTS);
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [subscribe, unsubscribe]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold" data-testid="pam-heading">
+            Privileged Access
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Elevation requests, approval rules, and audit history across the fleet.
+          </p>
+        </div>
+        <span
+          className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium ${
+            connected
+              ? 'bg-green-500/15 text-green-600 dark:text-green-400'
+              : 'bg-muted text-muted-foreground'
+          }`}
+          data-testid="pam-live-indicator"
+        >
+          <span
+            className={`h-1.5 w-1.5 rounded-full ${connected ? 'bg-green-500' : 'bg-muted-foreground'}`}
+          />
+          {connected ? 'Live' : 'Offline'}
+        </span>
+      </div>
+
+      <div role="tablist" className="flex gap-1 border-b">
+        <TabButton
+          active={activeTab === 'overview'}
+          onClick={() => switchTab('overview')}
+          icon={<Activity className="h-4 w-4" />}
+          testId="pam-tab-overview"
+        >
+          Overview
+        </TabButton>
+        <TabButton
+          active={activeTab === 'requests'}
+          onClick={() => switchTab('requests')}
+          icon={<Inbox className="h-4 w-4" />}
+          testId="pam-tab-requests"
+        >
+          Requests
+        </TabButton>
+        <TabButton
+          active={activeTab === 'rules'}
+          onClick={() => switchTab('rules')}
+          icon={<ListChecks className="h-4 w-4" />}
+          testId="pam-tab-rules"
+        >
+          Rules
+        </TabButton>
+        <TabButton
+          active={activeTab === 'audit'}
+          onClick={() => switchTab('audit')}
+          icon={<ScrollText className="h-4 w-4" />}
+          testId="pam-tab-audit"
+        >
+          Audit
+        </TabButton>
+      </div>
+
+      {activeTab === 'overview' && <PamOverviewTab liveTick={liveTick} />}
+      {activeTab === 'requests' && <PamRequestsTab liveTick={liveTick} />}
+      {activeTab === 'rules' && <PamRulesTab />}
+      {activeTab === 'audit' && <PamAuditTab />}
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  icon,
+  testId,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  testId: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      data-testid={testId}
+      className={`inline-flex items-center gap-2 border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
+        active
+          ? 'border-primary text-foreground'
+          : 'border-transparent text-muted-foreground hover:text-foreground'
+      }`}
+    >
+      {icon}
+      {children}
+    </button>
+  );
+}

--- a/apps/web/src/components/pam/PamRequestsTab.test.tsx
+++ b/apps/web/src/components/pam/PamRequestsTab.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import PamRequestsTab from './PamRequestsTab';
 import { fetchWithAuth } from '../../stores/auth';
 import { showToast } from '../shared/Toast';
+import { navigateTo } from '@/lib/navigation';
 import type { ElevationRequest } from './types';
 
 vi.mock('../../stores/auth', () => ({
@@ -19,6 +20,7 @@ vi.mock('@/lib/navigation', () => ({
 
 const fetchWithAuthMock = vi.mocked(fetchWithAuth);
 const showToastMock = vi.mocked(showToast);
+const navigateToMock = vi.mocked(navigateTo);
 
 function makeJsonResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
   return {
@@ -111,7 +113,7 @@ describe('PamRequestsTab', () => {
     });
   });
 
-  it('treats a 409 respond as already-actioned and refetches gracefully', async () => {
+  it('treats a 409 respond as already-actioned: refetches with only the runAction error toast', async () => {
     fetchWithAuthMock
       .mockResolvedValueOnce(listResponse([pendingRequest]))
       .mockResolvedValueOnce(
@@ -124,10 +126,91 @@ describe('PamRequestsTab', () => {
     fireEvent.click(screen.getByTestId('pam-respond-btn-req-1'));
     fireEvent.click(screen.getByTestId('pam-respond-submit'));
 
+    // runAction surfaces the server message as the single piece of feedback…
     await waitFor(() => {
       expect(showToastMock).toHaveBeenCalledWith(
-        expect.objectContaining({ message: expect.stringContaining('already actioned') }),
+        expect.objectContaining({ type: 'error', message: 'Request is not pending' }),
       );
+    });
+    // …and the modal must NOT stack a contradictory success toast on top.
+    expect(showToastMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'success' }),
+    );
+    expect(showToastMock).toHaveBeenCalledTimes(1);
+    // The list is still refetched (initial load + respond + refetch).
+    await waitFor(() => {
+      expect(fetchWithAuthMock.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  it('shows a risk tier badge for ai_tool_action rows and not for executable rows', async () => {
+    const toolRequest: ElevationRequest = {
+      ...pendingRequest,
+      id: 'req-9',
+      flowType: 'ai_tool_action',
+      toolName: 'run_script',
+      riskTier: 2,
+      targetExecutablePath: null,
+    };
+    fetchWithAuthMock.mockResolvedValueOnce(listResponse([pendingRequest, toolRequest]));
+    render(<PamRequestsTab liveTick={0} />);
+    await waitFor(() => screen.getByTestId('pam-request-row-req-9'));
+    expect(screen.getByTestId('pam-risk-tier-req-9')).toHaveTextContent('T2');
+    expect(screen.queryByTestId('pam-risk-tier-req-1')).toBeNull();
+  });
+
+  it('fetches page=2 on Next and updates the footer range', async () => {
+    fetchWithAuthMock.mockImplementation(async (url) => {
+      const requestedPage = Number(
+        new URLSearchParams(String(url).split('?')[1] ?? '').get('page') ?? '1',
+      );
+      return listResponseAt(requestedPage);
+    });
+    function listResponseAt(page: number): Response {
+      return makeJsonResponse({
+        success: true,
+        requests: [{ ...pendingRequest, id: `req-p${page}` }],
+        pagination: { page, limit: 50, total: 80 },
+      });
+    }
+
+    render(<PamRequestsTab liveTick={0} />);
+    await waitFor(() => {
+      expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => {
+      expect(
+        fetchWithAuthMock.mock.calls.some((c) => String(c[0]).includes('page=2')),
+      ).toBe(true);
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
+    });
+  });
+
+  it('redirects to /login when the list fetch returns 401', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({}, false, 401));
+    render(<PamRequestsTab liveTick={0} />);
+    await waitFor(() => {
+      expect(navigateToMock).toHaveBeenCalledWith('/login', { replace: true });
+    });
+  });
+
+  it('refetches with flowType=ai_tool_action when the flow filter changes', async () => {
+    fetchWithAuthMock.mockResolvedValue(listResponse([]));
+    render(<PamRequestsTab liveTick={0} />);
+    await waitFor(() => screen.getByTestId('pam-filter-flow'));
+    fireEvent.change(screen.getByTestId('pam-filter-flow'), {
+      target: { value: 'ai_tool_action' },
+    });
+    await waitFor(() => {
+      expect(
+        fetchWithAuthMock.mock.calls.some((c) =>
+          String(c[0]).includes('flowType=ai_tool_action'),
+        ),
+      ).toBe(true);
     });
   });
 

--- a/apps/web/src/components/pam/PamRequestsTab.test.tsx
+++ b/apps/web/src/components/pam/PamRequestsTab.test.tsx
@@ -1,0 +1,160 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PamRequestsTab from './PamRequestsTab';
+import { fetchWithAuth } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
+import type { ElevationRequest } from './types';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('../shared/Toast', () => ({
+  showToast: vi.fn(),
+}));
+
+vi.mock('@/lib/navigation', () => ({
+  navigateTo: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+const showToastMock = vi.mocked(showToast);
+
+function makeJsonResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
+
+const pendingRequest: ElevationRequest = {
+  id: 'req-1',
+  orgId: 'org-1',
+  deviceId: 'dev-1',
+  deviceHostname: 'WS-ALPHA',
+  flowType: 'uac_intercept',
+  subjectUsername: 'CONTOSO\\jdoe',
+  reason: 'Install printer driver',
+  targetExecutablePath: 'C:\\Temp\\driver.exe',
+  status: 'pending',
+  requestedAt: '2026-06-10T12:00:00.000Z',
+};
+
+function listResponse(requests: ElevationRequest[], total = requests.length): Response {
+  return makeJsonResponse({
+    success: true,
+    requests,
+    pagination: { page: 1, limit: 50, total },
+  });
+}
+
+describe('PamRequestsTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the empty state when no requests match', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(listResponse([]));
+    render(<PamRequestsTab liveTick={0} />);
+    await waitFor(() => {
+      expect(screen.getByText('No elevation requests')).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error banner when the list fails', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({}, false, 500));
+    render(<PamRequestsTab liveTick={0} />);
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('HTTP 500');
+    });
+  });
+
+  it('renders a pending request row with a respond action', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(listResponse([pendingRequest]));
+    render(<PamRequestsTab liveTick={0} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pam-request-row-req-1')).toBeInTheDocument();
+    });
+    expect(screen.getByText('WS-ALPHA')).toBeInTheDocument();
+    expect(screen.getByTestId('pam-respond-btn-req-1')).toBeInTheDocument();
+  });
+
+  it('approves a pending request through the modal and refetches', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(listResponse([pendingRequest]))
+      .mockResolvedValueOnce(makeJsonResponse({ success: true, id: 'req-1', status: 'approved' }))
+      .mockResolvedValueOnce(listResponse([]));
+
+    render(<PamRequestsTab liveTick={0} />);
+    await waitFor(() => screen.getByTestId('pam-respond-btn-req-1'));
+    fireEvent.click(screen.getByTestId('pam-respond-btn-req-1'));
+    fireEvent.click(screen.getByTestId('pam-respond-submit'));
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        '/pam/elevation-requests/req-1/respond',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+    const postCall = fetchWithAuthMock.mock.calls.find(
+      (c) => c[0] === '/pam/elevation-requests/req-1/respond',
+    );
+    expect(JSON.parse((postCall?.[1] as RequestInit).body as string)).toEqual({
+      decision: 'approve',
+      durationMinutes: 15,
+    });
+    // refetch after action
+    await waitFor(() => {
+      expect(fetchWithAuthMock.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  it('treats a 409 respond as already-actioned and refetches gracefully', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(listResponse([pendingRequest]))
+      .mockResolvedValueOnce(
+        makeJsonResponse({ success: false, error: 'Request is not pending' }, false, 409),
+      )
+      .mockResolvedValueOnce(listResponse([]));
+
+    render(<PamRequestsTab liveTick={0} />);
+    await waitFor(() => screen.getByTestId('pam-respond-btn-req-1'));
+    fireEvent.click(screen.getByTestId('pam-respond-btn-req-1'));
+    fireEvent.click(screen.getByTestId('pam-respond-submit'));
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('already actioned') }),
+      );
+    });
+  });
+
+  it('revokes an active elevation with a required reason', async () => {
+    const active: ElevationRequest = { ...pendingRequest, id: 'req-2', status: 'approved' };
+    fetchWithAuthMock
+      .mockResolvedValueOnce(listResponse([active]))
+      .mockResolvedValueOnce(makeJsonResponse({ success: true, id: 'req-2', status: 'revoked' }))
+      .mockResolvedValueOnce(listResponse([]));
+
+    render(<PamRequestsTab liveTick={0} />);
+    await waitFor(() => screen.getByTestId('pam-revoke-btn-req-2'));
+    fireEvent.click(screen.getByTestId('pam-revoke-btn-req-2'));
+
+    const submit = screen.getByTestId('pam-revoke-submit');
+    expect(submit).toBeDisabled();
+    fireEvent.change(screen.getByTestId('pam-revoke-reason'), {
+      target: { value: 'Window no longer needed' },
+    });
+    expect(submit).not.toBeDisabled();
+    fireEvent.click(submit);
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        '/pam/elevation-requests/req-2/revoke',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+  });
+});

--- a/apps/web/src/components/pam/PamRequestsTab.tsx
+++ b/apps/web/src/components/pam/PamRequestsTab.tsx
@@ -1,0 +1,276 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Inbox } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { navigateTo } from '@/lib/navigation';
+import PamRespondModal from './PamRespondModal';
+import PamRevokeModal from './PamRevokeModal';
+import {
+  ACTIVE_STATUSES,
+  type ElevationFlowType,
+  type ElevationRequest,
+  type ElevationStatus,
+  FLOW_LABELS,
+  type Pagination,
+  STATUS_LABELS,
+  requestTarget,
+  statusBadgeClass,
+} from './types';
+
+const STATUS_OPTIONS: Array<ElevationStatus | ''> = [
+  '',
+  'pending',
+  'approved',
+  'auto_approved',
+  'actuating',
+  'denied',
+  'expired',
+  'revoked',
+];
+const FLOW_OPTIONS: Array<ElevationFlowType | ''> = ['', 'uac_intercept', 'tech_jit_admin', 'ai_tool_action'];
+
+export default function PamRequestsTab({ liveTick }: { liveTick: number }) {
+  const [requests, setRequests] = useState<ElevationRequest[]>([]);
+  const [pagination, setPagination] = useState<Pagination>({ page: 1, limit: 50, total: 0 });
+  const [status, setStatus] = useState<ElevationStatus | ''>('pending');
+  const [flowType, setFlowType] = useState<ElevationFlowType | ''>('');
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [responding, setResponding] = useState<ElevationRequest | null>(null);
+  const [revoking, setRevoking] = useState<ElevationRequest | null>(null);
+
+  const fetchRequests = useCallback(
+    async (signal?: AbortSignal) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const params = new URLSearchParams();
+        if (status) params.set('status', status);
+        if (flowType) params.set('flowType', flowType);
+        params.set('page', String(page));
+        params.set('limit', '50');
+        const res = await fetchWithAuth(`/pam/elevation-requests?${params.toString()}`, { signal });
+        if (!res.ok) {
+          if (res.status === 401) {
+            void navigateTo('/login', { replace: true });
+            return;
+          }
+          throw new Error(`Failed to load requests (HTTP ${res.status})`);
+        }
+        const body = await res.json();
+        setRequests((body.requests ?? []) as ElevationRequest[]);
+        setPagination((body.pagination ?? { page: 1, limit: 50, total: 0 }) as Pagination);
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return;
+        setError(err instanceof Error ? err.message : 'Failed to load requests');
+      } finally {
+        if (!signal?.aborted) setLoading(false);
+      }
+    },
+    [status, flowType, page],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetchRequests(controller.signal);
+    return () => controller.abort();
+  }, [fetchRequests, liveTick]);
+
+  const totalPages = Math.max(1, Math.ceil(pagination.total / pagination.limit));
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <label className="flex items-center gap-2 text-sm">
+          <span className="text-muted-foreground">Status</span>
+          <select
+            value={status}
+            onChange={(e) => {
+              setPage(1);
+              setStatus(e.target.value as ElevationStatus | '');
+            }}
+            data-testid="pam-filter-status"
+            className="rounded-md border bg-background px-2 py-1.5 text-sm"
+          >
+            {STATUS_OPTIONS.map((s) => (
+              <option key={s || 'all'} value={s}>
+                {s ? STATUS_LABELS[s] : 'All statuses'}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <span className="text-muted-foreground">Flow</span>
+          <select
+            value={flowType}
+            onChange={(e) => {
+              setPage(1);
+              setFlowType(e.target.value as ElevationFlowType | '');
+            }}
+            data-testid="pam-filter-flow"
+            className="rounded-md border bg-background px-2 py-1.5 text-sm"
+          >
+            {FLOW_OPTIONS.map((f) => (
+              <option key={f || 'all'} value={f}>
+                {f ? FLOW_LABELS[f] : 'All flows'}
+              </option>
+            ))}
+          </select>
+        </label>
+        <span className="ml-auto text-xs text-muted-foreground">
+          {pagination.total} request{pagination.total === 1 ? '' : 's'}
+        </span>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        >
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center gap-2 rounded-md border bg-card px-4 py-6 text-sm text-muted-foreground">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          Loading requests…
+        </div>
+      ) : requests.length === 0 ? (
+        <div className="rounded-md border border-dashed bg-card px-4 py-8 text-center">
+          <Inbox className="mx-auto h-8 w-8 text-muted-foreground" />
+          <p className="mt-2 text-sm font-medium">No elevation requests</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Requests matching the current filters will appear here.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-md border bg-card">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-xs text-muted-foreground">
+                <th className="px-3 py-2 font-medium">Requested</th>
+                <th className="px-3 py-2 font-medium">Device</th>
+                <th className="px-3 py-2 font-medium">User</th>
+                <th className="px-3 py-2 font-medium">Target</th>
+                <th className="px-3 py-2 font-medium">Flow</th>
+                <th className="px-3 py-2 font-medium">Status</th>
+                <th className="px-3 py-2 font-medium" />
+              </tr>
+            </thead>
+            <tbody>
+              {requests.map((r) => {
+                const canRespond = r.status === 'pending';
+                const canRevoke = (ACTIVE_STATUSES as readonly string[]).includes(r.status);
+                return (
+                  <tr key={r.id} className="border-b align-top last:border-0" data-testid={`pam-request-row-${r.id}`}>
+                    <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
+                      {new Date(r.requestedAt).toLocaleString()}
+                    </td>
+                    <td className="px-3 py-2">{r.deviceHostname ?? r.deviceId}</td>
+                    <td className="px-3 py-2">{r.subjectUsername}</td>
+                    <td className="max-w-[260px] px-3 py-2">
+                      <div className="truncate" title={requestTarget(r)}>
+                        {requestTarget(r)}
+                      </div>
+                      {r.reason && (
+                        <div className="mt-0.5 truncate text-xs text-muted-foreground" title={r.reason}>
+                          {r.reason}
+                        </div>
+                      )}
+                      {r.targetExecutableSigner && (
+                        <div className="mt-0.5 truncate text-xs text-muted-foreground">
+                          Signer: {r.targetExecutableSigner}
+                        </div>
+                      )}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2">{FLOW_LABELS[r.flowType]}</td>
+                    <td className="px-3 py-2">
+                      <span
+                        className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${statusBadgeClass(r.status)}`}
+                      >
+                        {STATUS_LABELS[r.status]}
+                      </span>
+                      {r.denialReason && (
+                        <div className="mt-0.5 max-w-[180px] truncate text-xs text-muted-foreground" title={r.denialReason}>
+                          {r.denialReason}
+                        </div>
+                      )}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 text-right">
+                      {canRespond && (
+                        <button
+                          type="button"
+                          onClick={() => setResponding(r)}
+                          data-testid={`pam-respond-btn-${r.id}`}
+                          className="rounded-md border px-2.5 py-1 text-xs font-medium hover:bg-accent"
+                        >
+                          Respond
+                        </button>
+                      )}
+                      {canRevoke && (
+                        <button
+                          type="button"
+                          onClick={() => setRevoking(r)}
+                          data-testid={`pam-revoke-btn-${r.id}`}
+                          className="rounded-md border border-destructive/40 px-2.5 py-1 text-xs font-medium text-destructive hover:bg-destructive/10"
+                        >
+                          Revoke
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-end gap-2 text-sm">
+          <button
+            type="button"
+            disabled={page <= 1}
+            onClick={() => setPage((p) => p - 1)}
+            className="rounded-md border px-2.5 py-1 text-xs disabled:opacity-50"
+          >
+            Previous
+          </button>
+          <span className="text-xs text-muted-foreground">
+            Page {pagination.page} of {totalPages}
+          </span>
+          <button
+            type="button"
+            disabled={page >= totalPages}
+            onClick={() => setPage((p) => p + 1)}
+            className="rounded-md border px-2.5 py-1 text-xs disabled:opacity-50"
+          >
+            Next
+          </button>
+        </div>
+      )}
+
+      {responding && (
+        <PamRespondModal
+          request={responding}
+          onClose={() => setResponding(null)}
+          onActioned={() => {
+            setResponding(null);
+            void fetchRequests();
+          }}
+        />
+      )}
+      {revoking && (
+        <PamRevokeModal
+          request={revoking}
+          onClose={() => setRevoking(null)}
+          onActioned={() => {
+            setRevoking(null);
+            void fetchRequests();
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/pam/PamRequestsTab.tsx
+++ b/apps/web/src/components/pam/PamRequestsTab.tsx
@@ -170,8 +170,23 @@ export default function PamRequestsTab({ liveTick }: { liveTick: number }) {
                     <td className="px-3 py-2">{r.deviceHostname ?? r.deviceId}</td>
                     <td className="px-3 py-2">{r.subjectUsername}</td>
                     <td className="max-w-[260px] px-3 py-2">
-                      <div className="truncate" title={requestTarget(r)}>
-                        {requestTarget(r)}
+                      <div className="flex items-center gap-1.5">
+                        <span className="truncate" title={requestTarget(r)}>
+                          {requestTarget(r)}
+                        </span>
+                        {r.flowType === 'ai_tool_action' && r.riskTier != null && (
+                          <span
+                            data-testid={`pam-risk-tier-${r.id}`}
+                            title={`Risk tier ${r.riskTier}`}
+                            className={`inline-flex shrink-0 rounded px-1 py-0.5 text-[10px] font-semibold ${
+                              r.riskTier >= 3
+                                ? 'bg-red-500/15 text-red-600 dark:text-red-400'
+                                : 'bg-amber-500/15 text-amber-600 dark:text-amber-400'
+                            }`}
+                          >
+                            T{r.riskTier}
+                          </span>
+                        )}
                       </div>
                       {r.reason && (
                         <div className="mt-0.5 truncate text-xs text-muted-foreground" title={r.reason}>

--- a/apps/web/src/components/pam/PamRespondModal.tsx
+++ b/apps/web/src/components/pam/PamRespondModal.tsx
@@ -1,0 +1,176 @@
+import { useId, useState } from 'react';
+import { Dialog } from '../shared/Dialog';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, ActionError } from '../../lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+import { showToast } from '../shared/Toast';
+import { type ElevationRequest, FLOW_LABELS, requestTarget } from './types';
+
+export default function PamRespondModal({
+  request,
+  onClose,
+  onActioned,
+}: {
+  request: ElevationRequest;
+  onClose: () => void;
+  onActioned: () => void;
+}) {
+  const [decision, setDecision] = useState<'approve' | 'deny'>('approve');
+  const [reason, setReason] = useState('');
+  const [duration, setDuration] = useState('15');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const reasonId = useId();
+  const durationId = useId();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+
+    const body: Record<string, unknown> = { decision };
+    if (reason.trim()) body.reason = reason.trim();
+    if (decision === 'approve') {
+      const mins = Number.parseInt(duration, 10);
+      if (Number.isFinite(mins) && mins >= 1) body.durationMinutes = mins;
+    }
+
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth(`/pam/elevation-requests/${request.id}/respond`, {
+            method: 'POST',
+            body: JSON.stringify(body),
+          }),
+        errorFallback: `Failed to ${decision} request`,
+        successMessage: decision === 'approve' ? 'Elevation approved' : 'Elevation denied',
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+      onActioned();
+    } catch (err) {
+      if (err instanceof ActionError) {
+        if (err.status === 401) return;
+        if (err.status === 409) {
+          // CAS race: someone else (or a reaper) actioned it first.
+          showToast({ type: 'success', message: 'Request was already actioned — refreshing.' });
+          onActioned();
+          return;
+        }
+        setError(err.message);
+      } else {
+        setError(err instanceof Error ? err.message : 'Network error');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open onClose={onClose} title="Respond to elevation request" maxWidth="lg">
+      <form onSubmit={handleSubmit} className="space-y-4 p-6 pt-2">
+        <div className="rounded-md border bg-muted/40 px-3 py-2 text-sm">
+          <div className="font-medium">{requestTarget(request)}</div>
+          <div className="mt-0.5 text-xs text-muted-foreground">
+            {request.deviceHostname ?? request.deviceId} · {request.subjectUsername} ·{' '}
+            {FLOW_LABELS[request.flowType]}
+          </div>
+          {request.reason && (
+            <div className="mt-1 text-xs text-muted-foreground">Reason: {request.reason}</div>
+          )}
+        </div>
+
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => setDecision('approve')}
+            data-testid="pam-respond-approve-toggle"
+            className={`flex-1 rounded-md border px-3 py-2 text-sm font-medium ${
+              decision === 'approve'
+                ? 'border-green-500 bg-green-500/10 text-green-600 dark:text-green-400'
+                : 'text-muted-foreground hover:bg-accent'
+            }`}
+          >
+            Approve
+          </button>
+          <button
+            type="button"
+            onClick={() => setDecision('deny')}
+            data-testid="pam-respond-deny-toggle"
+            className={`flex-1 rounded-md border px-3 py-2 text-sm font-medium ${
+              decision === 'deny'
+                ? 'border-red-500 bg-red-500/10 text-red-600 dark:text-red-400'
+                : 'text-muted-foreground hover:bg-accent'
+            }`}
+          >
+            Deny
+          </button>
+        </div>
+
+        {decision === 'approve' && (
+          <div>
+            <label htmlFor={durationId} className="mb-1 block text-sm font-medium">
+              Approval window (minutes)
+            </label>
+            <input
+              id={durationId}
+              type="number"
+              min={1}
+              max={1440}
+              value={duration}
+              onChange={(e) => setDuration(e.target.value)}
+              data-testid="pam-respond-duration"
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+            />
+            <p className="mt-1 text-xs text-muted-foreground">1 to 1440 minutes (24h max).</p>
+          </div>
+        )}
+
+        <div>
+          <label htmlFor={reasonId} className="mb-1 block text-sm font-medium">
+            Reason {decision === 'deny' ? '(recommended)' : '(optional)'}
+          </label>
+          <textarea
+            id={reasonId}
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            maxLength={2000}
+            rows={3}
+            data-testid="pam-respond-reason"
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+            placeholder="Recorded in the audit trail"
+          />
+        </div>
+
+        {error && (
+          <div
+            role="alert"
+            className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-3 py-2 text-sm hover:bg-accent"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            data-testid="pam-respond-submit"
+            className={`rounded-md px-3 py-2 text-sm font-medium text-white disabled:opacity-50 ${
+              decision === 'approve' ? 'bg-green-600 hover:bg-green-700' : 'bg-red-600 hover:bg-red-700'
+            }`}
+          >
+            {submitting ? 'Submitting…' : decision === 'approve' ? 'Approve elevation' : 'Deny request'}
+          </button>
+        </div>
+      </form>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/pam/PamRespondModal.tsx
+++ b/apps/web/src/components/pam/PamRespondModal.tsx
@@ -3,7 +3,6 @@ import { Dialog } from '../shared/Dialog';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
-import { showToast } from '../shared/Toast';
 import { type ElevationRequest, FLOW_LABELS, requestTarget } from './types';
 
 export default function PamRespondModal({
@@ -52,8 +51,9 @@ export default function PamRespondModal({
       if (err instanceof ActionError) {
         if (err.status === 401) return;
         if (err.status === 409) {
-          // CAS race: someone else (or a reaper) actioned it first.
-          showToast({ type: 'success', message: 'Request was already actioned — refreshing.' });
+          // CAS race: someone else (or a reaper) actioned it first. runAction
+          // already toasted the server message (e.g. "Request is not pending")
+          // — just refresh the list, no extra toast.
           onActioned();
           return;
         }

--- a/apps/web/src/components/pam/PamRevokeModal.tsx
+++ b/apps/web/src/components/pam/PamRevokeModal.tsx
@@ -3,7 +3,6 @@ import { Dialog } from '../shared/Dialog';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
-import { showToast } from '../shared/Toast';
 import { type ElevationRequest, requestTarget } from './types';
 
 export default function PamRevokeModal({
@@ -42,7 +41,8 @@ export default function PamRevokeModal({
       if (err instanceof ActionError) {
         if (err.status === 401) return;
         if (err.status === 409) {
-          showToast({ type: 'success', message: 'Elevation already ended — refreshing.' });
+          // Already ended (race with expiry/another admin). runAction already
+          // toasted the server message — just refresh the list, no extra toast.
           onActioned();
           return;
         }

--- a/apps/web/src/components/pam/PamRevokeModal.tsx
+++ b/apps/web/src/components/pam/PamRevokeModal.tsx
@@ -1,0 +1,116 @@
+import { useId, useState } from 'react';
+import { Dialog } from '../shared/Dialog';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, ActionError } from '../../lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+import { showToast } from '../shared/Toast';
+import { type ElevationRequest, requestTarget } from './types';
+
+export default function PamRevokeModal({
+  request,
+  onClose,
+  onActioned,
+}: {
+  request: ElevationRequest;
+  onClose: () => void;
+  onActioned: () => void;
+}) {
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const reasonId = useId();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (submitting || !reason.trim()) return;
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth(`/pam/elevation-requests/${request.id}/revoke`, {
+            method: 'POST',
+            body: JSON.stringify({ reason: reason.trim() }),
+          }),
+        errorFallback: 'Failed to revoke elevation',
+        successMessage: 'Elevation revoked',
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+      onActioned();
+    } catch (err) {
+      if (err instanceof ActionError) {
+        if (err.status === 401) return;
+        if (err.status === 409) {
+          showToast({ type: 'success', message: 'Elevation already ended — refreshing.' });
+          onActioned();
+          return;
+        }
+        setError(err.message);
+      } else {
+        setError(err instanceof Error ? err.message : 'Network error');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open onClose={onClose} title="Revoke active elevation" maxWidth="md">
+      <form onSubmit={handleSubmit} className="space-y-4 p-6 pt-2">
+        <p className="text-sm text-muted-foreground">
+          Ends the elevation window for{' '}
+          <span className="font-medium text-foreground">{requestTarget(request)}</span> on{' '}
+          <span className="font-medium text-foreground">
+            {request.deviceHostname ?? request.deviceId}
+          </span>{' '}
+          immediately.
+        </p>
+
+        <div>
+          <label htmlFor={reasonId} className="mb-1 block text-sm font-medium">
+            Reason (required)
+          </label>
+          <textarea
+            id={reasonId}
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            maxLength={2000}
+            rows={3}
+            required
+            data-testid="pam-revoke-reason"
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+            placeholder="Recorded in the audit trail"
+          />
+        </div>
+
+        {error && (
+          <div
+            role="alert"
+            className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-3 py-2 text-sm hover:bg-accent"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting || !reason.trim()}
+            data-testid="pam-revoke-submit"
+            className="rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+          >
+            {submitting ? 'Revoking…' : 'Revoke elevation'}
+          </button>
+        </div>
+      </form>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/pam/PamRuleModal.tsx
+++ b/apps/web/src/components/pam/PamRuleModal.tsx
@@ -1,0 +1,352 @@
+import { useId, useState } from 'react';
+import { Dialog } from '../shared/Dialog';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, ActionError } from '../../lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+import { type PamRule, type PamVerdict, VERDICT_LABELS } from './types';
+
+/**
+ * Create/edit modal for pam_rules.
+ *
+ * Mirrors the server's shape validation (routes/pam.ts validateRuleShape):
+ *  - at least one match criterion
+ *  - executable criteria (signer/hash/path/parent) and tool-action criteria
+ *    (toolName/riskTier) are mutually exclusive
+ *  - tool-action rules cannot use verdict 'ignore'
+ * Client-side checks exist for fast feedback; the server remains authoritative.
+ */
+export default function PamRuleModal({
+  rule,
+  onClose,
+  onSaved,
+}: {
+  rule: PamRule | null;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const isEdit = rule !== null;
+  const [name, setName] = useState(rule?.name ?? '');
+  const [description, setDescription] = useState(rule?.description ?? '');
+  const [priority, setPriority] = useState(String(rule?.priority ?? 100));
+  const [verdict, setVerdict] = useState<PamVerdict>(rule?.verdict ?? 'require_approval');
+  const [enabled, setEnabled] = useState(rule?.enabled ?? true);
+  const [shape, setShape] = useState<'executable' | 'tool'>(
+    rule && (rule.matchToolName || typeof rule.matchRiskTier === 'number') ? 'tool' : 'executable',
+  );
+  const [matchSigner, setMatchSigner] = useState(rule?.matchSigner ?? '');
+  const [matchHash, setMatchHash] = useState(rule?.matchHash ?? '');
+  const [matchPathGlob, setMatchPathGlob] = useState(rule?.matchPathGlob ?? '');
+  const [matchParentImage, setMatchParentImage] = useState(rule?.matchParentImage ?? '');
+  const [matchUser, setMatchUser] = useState(rule?.matchUser ?? '');
+  const [matchAdGroup, setMatchAdGroup] = useState(rule?.matchAdGroup ?? '');
+  const [matchToolName, setMatchToolName] = useState(rule?.matchToolName ?? '');
+  const [matchRiskTier, setMatchRiskTier] = useState(
+    rule?.matchRiskTier !== null && rule?.matchRiskTier !== undefined ? String(rule.matchRiskTier) : '',
+  );
+  const [windowStart, setWindowStart] = useState(rule?.timeWindow?.start ?? '');
+  const [windowEnd, setWindowEnd] = useState(rule?.timeWindow?.end ?? '');
+  const [approvalDuration, setApprovalDuration] = useState(
+    rule?.approvalDurationMinutes ? String(rule.approvalDurationMinutes) : '',
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const nameId = useId();
+  const descId = useId();
+  const priorityId = useId();
+  const verdictId = useId();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (submitting) return;
+    setError(null);
+
+    const executable = {
+      matchSigner: matchSigner.trim() || null,
+      matchHash: matchHash.trim() || null,
+      matchPathGlob: matchPathGlob.trim() || null,
+      matchParentImage: matchParentImage.trim() || null,
+    };
+    const tool = {
+      matchToolName: matchToolName.trim() || null,
+      matchRiskTier: matchRiskTier === '' ? null : Number.parseInt(matchRiskTier, 10),
+    };
+    const common = {
+      matchUser: matchUser.trim() || null,
+      matchAdGroup: matchAdGroup.trim() || null,
+    };
+
+    const activeCriteria =
+      shape === 'executable'
+        ? { ...executable, matchToolName: null, matchRiskTier: null, ...common }
+        : {
+            matchSigner: null,
+            matchHash: null,
+            matchPathGlob: null,
+            matchParentImage: null,
+            ...tool,
+            ...common,
+          };
+
+    const hasCriterion = Object.entries(activeCriteria).some(
+      ([, v]) => v !== null && v !== '' && v !== undefined,
+    );
+    if (!hasCriterion) {
+      setError('At least one match criterion is required.');
+      return;
+    }
+    if (shape === 'tool' && verdict === 'ignore') {
+      setError('Tool-action rules cannot use the Ignore verdict.');
+      return;
+    }
+
+    const payload: Record<string, unknown> = {
+      name: name.trim(),
+      description: description.trim() || null,
+      enabled,
+      priority: Number.parseInt(priority, 10) || 100,
+      verdict,
+      ...activeCriteria,
+      timeWindow:
+        windowStart && windowEnd ? { start: windowStart, end: windowEnd } : null,
+      approvalDurationMinutes: approvalDuration
+        ? Number.parseInt(approvalDuration, 10) || null
+        : null,
+    };
+
+    setSubmitting(true);
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth(isEdit ? `/pam/rules/${rule.id}` : '/pam/rules', {
+            method: isEdit ? 'PATCH' : 'POST',
+            body: JSON.stringify(payload),
+          }),
+        errorFallback: isEdit ? 'Failed to update rule' : 'Failed to create rule',
+        successMessage: `Rule "${name.trim()}" ${isEdit ? 'updated' : 'created'}`,
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+      onSaved();
+    } catch (err) {
+      if (err instanceof ActionError) {
+        if (err.status === 401) return;
+        setError(err.message);
+      } else {
+        setError(err instanceof Error ? err.message : 'Network error');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const inputClass = 'w-full rounded-md border bg-background px-3 py-2 text-sm';
+
+  return (
+    <Dialog
+      open
+      onClose={onClose}
+      title={isEdit ? 'Edit PAM rule' : 'New PAM rule'}
+      maxWidth="lg"
+      className="max-h-[90vh] overflow-y-auto p-6"
+    >
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <label htmlFor={nameId} className="mb-1 block text-sm font-medium">
+              Name
+            </label>
+            <input
+              id={nameId}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              maxLength={255}
+              data-testid="pam-rule-name"
+              className={inputClass}
+            />
+          </div>
+          <div>
+            <label htmlFor={priorityId} className="mb-1 block text-sm font-medium">
+              Priority
+            </label>
+            <input
+              id={priorityId}
+              type="number"
+              min={0}
+              max={100000}
+              value={priority}
+              onChange={(e) => setPriority(e.target.value)}
+              data-testid="pam-rule-priority"
+              className={inputClass}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor={descId} className="mb-1 block text-sm font-medium">
+            Description (optional)
+          </label>
+          <input
+            id={descId}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            maxLength={2000}
+            className={inputClass}
+          />
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <label htmlFor={verdictId} className="mb-1 block text-sm font-medium">
+              Verdict
+            </label>
+            <select
+              id={verdictId}
+              value={verdict}
+              onChange={(e) => setVerdict(e.target.value as PamVerdict)}
+              data-testid="pam-rule-verdict"
+              className={inputClass}
+            >
+              {(Object.keys(VERDICT_LABELS) as PamVerdict[]).map((v) => (
+                <option key={v} value={v} disabled={shape === 'tool' && v === 'ignore'}>
+                  {VERDICT_LABELS[v]}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <span className="mb-1 block text-sm font-medium">Rule shape</span>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setShape('executable')}
+                data-testid="pam-rule-shape-executable"
+                className={`flex-1 rounded-md border px-3 py-2 text-sm ${
+                  shape === 'executable' ? 'border-primary bg-primary/10 font-medium' : 'text-muted-foreground'
+                }`}
+              >
+                Executable
+              </button>
+              <button
+                type="button"
+                onClick={() => setShape('tool')}
+                data-testid="pam-rule-shape-tool"
+                className={`flex-1 rounded-md border px-3 py-2 text-sm ${
+                  shape === 'tool' ? 'border-primary bg-primary/10 font-medium' : 'text-muted-foreground'
+                }`}
+              >
+                AI tool action
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {shape === 'executable' ? (
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field label="Signer" value={matchSigner} onChange={setMatchSigner} placeholder="e.g. Microsoft Corporation" testId="pam-rule-signer" />
+            <Field label="SHA-256 hash" value={matchHash} onChange={setMatchHash} placeholder="64 hex chars" testId="pam-rule-hash" />
+            <Field label="Path glob" value={matchPathGlob} onChange={setMatchPathGlob} placeholder="C:\\Program Files\\**" testId="pam-rule-path" />
+            <Field label="Parent image" value={matchParentImage} onChange={setMatchParentImage} placeholder="explorer.exe" testId="pam-rule-parent" />
+          </div>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field label="Tool name" value={matchToolName} onChange={setMatchToolName} placeholder="run_script" testId="pam-rule-toolname" />
+            <Field
+              label="Risk tier (0-4)"
+              value={matchRiskTier}
+              onChange={setMatchRiskTier}
+              placeholder="2"
+              type="number"
+              testId="pam-rule-risktier"
+            />
+          </div>
+        )}
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Field label="User (optional)" value={matchUser} onChange={setMatchUser} placeholder="DOMAIN\\user" testId="pam-rule-user" />
+          <Field label="AD group (optional)" value={matchAdGroup} onChange={setMatchAdGroup} placeholder="Helpdesk Tier 1" testId="pam-rule-adgroup" />
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-3">
+          <Field label="Window start (HH:MM)" value={windowStart} onChange={setWindowStart} placeholder="08:00" testId="pam-rule-window-start" />
+          <Field label="Window end (HH:MM)" value={windowEnd} onChange={setWindowEnd} placeholder="18:00" testId="pam-rule-window-end" />
+          <Field
+            label="Approval mins (optional)"
+            value={approvalDuration}
+            onChange={setApprovalDuration}
+            placeholder="15"
+            type="number"
+            testId="pam-rule-approval-mins"
+          />
+        </div>
+
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+            data-testid="pam-rule-enabled"
+          />
+          Enabled
+        </label>
+
+        {error && (
+          <div
+            role="alert"
+            className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onClose} className="rounded-md border px-3 py-2 text-sm hover:bg-accent">
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting || !name.trim()}
+            data-testid="pam-rule-submit"
+            className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {submitting ? 'Saving…' : isEdit ? 'Save changes' : 'Create rule'}
+          </button>
+        </div>
+      </form>
+    </Dialog>
+  );
+}
+
+function Field({
+  label,
+  value,
+  onChange,
+  placeholder,
+  testId,
+  type = 'text',
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  testId: string;
+  type?: string;
+}) {
+  const id = useId();
+  return (
+    <div>
+      <label htmlFor={id} className="mb-1 block text-sm font-medium">
+        {label}
+      </label>
+      <input
+        id={id}
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        data-testid={testId}
+        className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/pam/PamRuleModal.tsx
+++ b/apps/web/src/components/pam/PamRuleModal.tsx
@@ -1,9 +1,16 @@
-import { useId, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 import { Dialog } from '../shared/Dialog';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
 import { type PamRule, type PamVerdict, VERDICT_LABELS } from './types';
+
+const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
+
+interface NamedOption {
+  id: string;
+  name: string;
+}
 
 /**
  * Create/edit modal for pam_rules.
@@ -45,9 +52,19 @@ export default function PamRuleModal({
   );
   const [windowStart, setWindowStart] = useState(rule?.timeWindow?.start ?? '');
   const [windowEnd, setWindowEnd] = useState(rule?.timeWindow?.end ?? '');
+  const [windowDays, setWindowDays] = useState<number[]>(rule?.timeWindow?.days ?? []);
+  const [windowTimezone, setWindowTimezone] = useState(rule?.timeWindow?.timezone ?? '');
   const [approvalDuration, setApprovalDuration] = useState(
     rule?.approvalDurationMinutes ? String(rule.approvalDurationMinutes) : '',
   );
+  // Org/site scoping. On edit the org is fixed (PATCH has no orgId); on create
+  // partner-scoped users with >1 accessible org must pick one or the API 400s
+  // ("orgId is required for this scope" — resolveOrgIdForWrite).
+  const [orgs, setOrgs] = useState<NamedOption[]>([]);
+  const [orgsLoaded, setOrgsLoaded] = useState(false);
+  const [selectedOrgId, setSelectedOrgId] = useState('');
+  const [sites, setSites] = useState<NamedOption[]>([]);
+  const [siteId, setSiteId] = useState(rule?.siteId ?? '');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -55,6 +72,50 @@ export default function PamRuleModal({
   const descId = useId();
   const priorityId = useId();
   const verdictId = useId();
+  const orgSelectId = useId();
+  const siteSelectId = useId();
+  const timezoneId = useId();
+
+  useEffect(() => {
+    fetchWithAuth('/orgs/organizations?limit=100')
+      .then(async (res) => {
+        if (res.ok) {
+          const data = await res.json();
+          const items = (data.data ?? data.organizations ?? data ?? []) as NamedOption[];
+          setOrgs(items.map((o) => ({ id: o.id, name: o.name })));
+          if (!isEdit && items.length > 1) {
+            setSelectedOrgId((prev) => prev || items[0]!.id);
+          }
+        }
+      })
+      .catch(() => {})
+      .finally(() => setOrgsLoaded(true));
+  }, [isEdit]);
+
+  // Sites must belong to the rule's org. Explicit `organizationId` wins over
+  // the ambient orgId fetchWithAuth may inject (see routes/orgs.ts, #723).
+  const sitesOrgId = rule ? rule.orgId : selectedOrgId;
+  useEffect(() => {
+    if (!isEdit && !orgsLoaded) return;
+    const query = sitesOrgId
+      ? `?organizationId=${encodeURIComponent(sitesOrgId)}&limit=100`
+      : '?limit=100';
+    fetchWithAuth(`/orgs/sites${query}`)
+      .then(async (res) => {
+        if (res.ok) {
+          const data = await res.json();
+          const items = (data.data ?? data.sites ?? data ?? []) as NamedOption[];
+          setSites(items.map((s) => ({ id: s.id, name: s.name })));
+        }
+      })
+      .catch(() => {});
+  }, [isEdit, orgsLoaded, sitesOrgId]);
+
+  const toggleDay = (day: number) => {
+    setWindowDays((prev) =>
+      prev.includes(day) ? prev.filter((d) => d !== day) : [...prev, day].sort((a, b) => a - b),
+    );
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -99,6 +160,16 @@ export default function PamRuleModal({
       setError('Tool-action rules cannot use the Ignore verdict.');
       return;
     }
+    if (Boolean(windowStart) !== Boolean(windowEnd)) {
+      setError('Time window start and end must both be set (or both left empty).');
+      return;
+    }
+
+    // Omit days when none or all are selected — the rule engine treats a
+    // missing days array as "every day" (services/pamRuleEngine.ts).
+    const days =
+      windowDays.length > 0 && windowDays.length < 7 ? [...windowDays].sort((a, b) => a - b) : undefined;
+    const timezone = windowTimezone.trim() || undefined;
 
     const payload: Record<string, unknown> = {
       name: name.trim(),
@@ -107,8 +178,19 @@ export default function PamRuleModal({
       priority: Number.parseInt(priority, 10) || 100,
       verdict,
       ...activeCriteria,
+      siteId: siteId || null,
+      // Create only: the server resolves the org when omitted; multi-org
+      // partner users must send an explicit choice. PATCH never carries orgId.
+      ...(!isEdit && orgs.length > 1 && selectedOrgId ? { orgId: selectedOrgId } : {}),
       timeWindow:
-        windowStart && windowEnd ? { start: windowStart, end: windowEnd } : null,
+        windowStart && windowEnd
+          ? {
+              start: windowStart,
+              end: windowEnd,
+              ...(days ? { days } : {}),
+              ...(timezone ? { timezone } : {}),
+            }
+          : null,
       approvalDurationMinutes: approvalDuration
         ? Number.parseInt(approvalDuration, 10) || null
         : null,
@@ -196,6 +278,61 @@ export default function PamRuleModal({
         </div>
 
         <div className="grid gap-4 sm:grid-cols-2">
+          {orgs.length > 1 && (
+            <div>
+              <label htmlFor={orgSelectId} className="mb-1 block text-sm font-medium">
+                Organization
+              </label>
+              {rule ? (
+                <input
+                  id={orgSelectId}
+                  value={orgs.find((o) => o.id === rule.orgId)?.name ?? rule.orgId}
+                  readOnly
+                  disabled
+                  className={`${inputClass} text-muted-foreground`}
+                />
+              ) : (
+                <select
+                  id={orgSelectId}
+                  value={selectedOrgId}
+                  onChange={(e) => {
+                    setSelectedOrgId(e.target.value);
+                    setSiteId('');
+                  }}
+                  data-testid="pam-rule-org"
+                  className={inputClass}
+                >
+                  {orgs.map((o) => (
+                    <option key={o.id} value={o.id}>
+                      {o.name}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </div>
+          )}
+          <div>
+            <label htmlFor={siteSelectId} className="mb-1 block text-sm font-medium">
+              Scope
+            </label>
+            <select
+              id={siteSelectId}
+              value={siteId}
+              onChange={(e) => setSiteId(e.target.value)}
+              data-testid="pam-rule-site"
+              className={inputClass}
+            >
+              <option value="">Org-wide (all sites)</option>
+              {sites.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
           <div>
             <label htmlFor={verdictId} className="mb-1 block text-sm font-medium">
               Verdict
@@ -279,6 +416,46 @@ export default function PamRuleModal({
             testId="pam-rule-approval-mins"
           />
         </div>
+
+        {(windowStart !== '' || windowEnd !== '') && (
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <span className="mb-1 block text-sm font-medium">Days (none = every day)</span>
+              <div className="flex gap-1">
+                {DAY_LABELS.map((label, day) => (
+                  <button
+                    key={label}
+                    type="button"
+                    onClick={() => toggleDay(day)}
+                    aria-pressed={windowDays.includes(day)}
+                    data-testid={`pam-rule-window-day-${day}`}
+                    className={`flex-1 rounded-md border px-1.5 py-2 text-xs ${
+                      windowDays.includes(day)
+                        ? 'border-primary bg-primary/10 font-medium'
+                        : 'text-muted-foreground'
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div>
+              <label htmlFor={timezoneId} className="mb-1 block text-sm font-medium">
+                Timezone (optional)
+              </label>
+              <input
+                id={timezoneId}
+                value={windowTimezone}
+                onChange={(e) => setWindowTimezone(e.target.value)}
+                placeholder="UTC"
+                maxLength={64}
+                data-testid="pam-rule-window-timezone"
+                className={inputClass}
+              />
+            </div>
+          </div>
+        )}
 
         <label className="flex items-center gap-2 text-sm">
           <input

--- a/apps/web/src/components/pam/PamRuleModal.tsx
+++ b/apps/web/src/components/pam/PamRuleModal.tsx
@@ -111,6 +111,17 @@ export default function PamRuleModal({
       .catch(() => {});
   }, [isEdit, orgsLoaded, sitesOrgId]);
 
+  // Reset days/tz when the time window is fully cleared so stale values don't
+  // invisibly resurface if a start/end is re-entered later. Safe on mount: a
+  // rule without a window initializes these empty anyway, and a rule with a
+  // window has non-empty start/end so the condition is false.
+  useEffect(() => {
+    if (!windowStart && !windowEnd) {
+      setWindowDays([]);
+      setWindowTimezone('');
+    }
+  }, [windowStart, windowEnd]);
+
   const toggleDay = (day: number) => {
     setWindowDays((prev) =>
       prev.includes(day) ? prev.filter((d) => d !== day) : [...prev, day].sort((a, b) => a - b),

--- a/apps/web/src/components/pam/PamRulesTab.test.tsx
+++ b/apps/web/src/components/pam/PamRulesTab.test.tsx
@@ -1,0 +1,173 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PamRulesTab from './PamRulesTab';
+import { fetchWithAuth } from '../../stores/auth';
+import type { PamRule } from './types';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('../shared/Toast', () => ({
+  showToast: vi.fn(),
+}));
+
+vi.mock('@/lib/navigation', () => ({
+  navigateTo: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+function makeJsonResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
+
+const signedRule: PamRule = {
+  id: 'rule-1',
+  orgId: 'org-1',
+  name: 'Allow signed Microsoft installers',
+  enabled: true,
+  priority: 10,
+  matchSigner: 'Microsoft Corporation',
+  verdict: 'auto_approve',
+  createdAt: '2026-06-10T00:00:00.000Z',
+  updatedAt: '2026-06-10T00:00:00.000Z',
+};
+
+describe('PamRulesTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the empty state when no rules exist', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ success: true, rules: [] }));
+    render(<PamRulesTab />);
+    await waitFor(() => {
+      expect(screen.getByText('No PAM rules yet')).toBeInTheDocument();
+    });
+  });
+
+  it('renders rules sorted by priority with a criteria summary', async () => {
+    const catchAll: PamRule = {
+      ...signedRule,
+      id: 'rule-2',
+      name: 'Catch-all deny',
+      priority: 500,
+      matchSigner: null,
+      matchPathGlob: '**',
+      verdict: 'auto_deny',
+    };
+    fetchWithAuthMock.mockResolvedValueOnce(
+      makeJsonResponse({ success: true, rules: [catchAll, signedRule] }),
+    );
+    render(<PamRulesTab />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pam-rule-row-rule-1')).toBeInTheDocument();
+    });
+    const rows = screen.getAllByTestId(/^pam-rule-row-/);
+    // priority 10 sorts before priority 500
+    expect(rows[0]).toHaveAttribute('data-testid', 'pam-rule-row-rule-1');
+    expect(screen.getByText('signer=Microsoft Corporation')).toBeInTheDocument();
+  });
+
+  it('toggles a rule enabled state via PATCH', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(makeJsonResponse({ success: true, rules: [signedRule] }))
+      .mockResolvedValueOnce(
+        makeJsonResponse({ success: true, rule: { ...signedRule, enabled: false } }),
+      )
+      .mockResolvedValueOnce(
+        makeJsonResponse({ success: true, rules: [{ ...signedRule, enabled: false }] }),
+      );
+    render(<PamRulesTab />);
+    await waitFor(() => screen.getByTestId('pam-rule-toggle-rule-1'));
+    fireEvent.click(screen.getByTestId('pam-rule-toggle-rule-1'));
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        '/pam/rules/rule-1',
+        expect.objectContaining({ method: 'PATCH' }),
+      );
+    });
+    const patchCall = fetchWithAuthMock.mock.calls.find((c) => c[0] === '/pam/rules/rule-1');
+    expect(JSON.parse((patchCall?.[1] as RequestInit).body as string)).toEqual({ enabled: false });
+  });
+
+  it('creates a rule through the modal, sending a clean executable-shaped payload', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(makeJsonResponse({ success: true, rules: [] }))
+      .mockResolvedValueOnce(makeJsonResponse({ success: true, rule: signedRule }, true, 201))
+      .mockResolvedValueOnce(makeJsonResponse({ success: true, rules: [signedRule] }));
+
+    render(<PamRulesTab />);
+    await waitFor(() => screen.getByTestId('pam-add-rule-btn'));
+    fireEvent.click(screen.getByTestId('pam-add-rule-btn'));
+
+    fireEvent.change(screen.getByTestId('pam-rule-name'), {
+      target: { value: 'Allow signed Microsoft installers' },
+    });
+    fireEvent.change(screen.getByTestId('pam-rule-signer'), {
+      target: { value: 'Microsoft Corporation' },
+    });
+    fireEvent.click(screen.getByTestId('pam-rule-submit'));
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        '/pam/rules',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+    const postCall = fetchWithAuthMock.mock.calls.find(
+      (c) => c[0] === '/pam/rules' && (c[1] as RequestInit)?.method === 'POST',
+    );
+    const payload = JSON.parse((postCall?.[1] as RequestInit).body as string);
+    expect(payload).toMatchObject({
+      name: 'Allow signed Microsoft installers',
+      matchSigner: 'Microsoft Corporation',
+      matchToolName: null,
+      matchRiskTier: null,
+      verdict: 'require_approval',
+      enabled: true,
+    });
+  });
+
+  it('blocks submission client-side when no criterion is provided', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ success: true, rules: [] }));
+    render(<PamRulesTab />);
+    await waitFor(() => screen.getByTestId('pam-add-rule-btn'));
+    fireEvent.click(screen.getByTestId('pam-add-rule-btn'));
+
+    fireEvent.change(screen.getByTestId('pam-rule-name'), { target: { value: 'No criteria' } });
+    fireEvent.click(screen.getByTestId('pam-rule-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('At least one match criterion');
+    });
+    // No POST went out
+    expect(
+      fetchWithAuthMock.mock.calls.find(
+        (c) => c[0] === '/pam/rules' && (c[1] as RequestInit)?.method === 'POST',
+      ),
+    ).toBeUndefined();
+  });
+
+  it('blocks the ignore verdict for tool-action rules client-side', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ success: true, rules: [] }));
+    render(<PamRulesTab />);
+    await waitFor(() => screen.getByTestId('pam-add-rule-btn'));
+    fireEvent.click(screen.getByTestId('pam-add-rule-btn'));
+
+    fireEvent.change(screen.getByTestId('pam-rule-name'), { target: { value: 'Tool rule' } });
+    fireEvent.click(screen.getByTestId('pam-rule-shape-tool'));
+    fireEvent.change(screen.getByTestId('pam-rule-toolname'), { target: { value: 'run_script' } });
+    // The ignore option is disabled in the select for tool shape; force the state
+    // by asserting the option is disabled instead.
+    const verdictSelect = screen.getByTestId('pam-rule-verdict') as HTMLSelectElement;
+    const ignoreOption = Array.from(verdictSelect.options).find((o) => o.value === 'ignore');
+    expect(ignoreOption?.disabled).toBe(true);
+  });
+});

--- a/apps/web/src/components/pam/PamRulesTab.test.tsx
+++ b/apps/web/src/components/pam/PamRulesTab.test.tsx
@@ -39,13 +39,56 @@ const signedRule: PamRule = {
   updatedAt: '2026-06-10T00:00:00.000Z',
 };
 
+/**
+ * URL-routed fetch mock. The tab and modal now fetch /orgs/sites and
+ * /orgs/organizations alongside /pam/rules, so order-based Once-chains are
+ * brittle; route by URL+method instead.
+ */
+function installFetchRoutes({
+  rules = [] as PamRule[],
+  sites = [] as Array<{ id: string; name: string }>,
+  orgs = [{ id: 'org-1', name: 'Acme' }],
+}: {
+  rules?: PamRule[];
+  sites?: Array<{ id: string; name: string }>;
+  orgs?: Array<{ id: string; name: string }>;
+} = {}) {
+  fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? 'GET';
+    if (url.startsWith('/orgs/organizations')) return makeJsonResponse({ data: orgs });
+    if (url.startsWith('/orgs/sites')) return makeJsonResponse({ data: sites });
+    if (url === '/pam/rules' && method === 'POST') {
+      return makeJsonResponse({ success: true, rule: rules[0] ?? signedRule }, true, 201);
+    }
+    if (url.startsWith('/pam/rules/') && method !== 'GET') {
+      return makeJsonResponse({ success: true, rule: rules[0] ?? signedRule });
+    }
+    return makeJsonResponse({ success: true, rules });
+  });
+}
+
+function findMutationCall(url: string, method: string) {
+  return fetchWithAuthMock.mock.calls.find(
+    (c) => c[0] === url && (c[1] as RequestInit | undefined)?.method === method,
+  );
+}
+
+function bodyOf(call: ReturnType<typeof findMutationCall>): Record<string, unknown> {
+  return JSON.parse((call?.[1] as RequestInit).body as string);
+}
+
+async function openCreateModal() {
+  await waitFor(() => screen.getByTestId('pam-add-rule-btn'));
+  fireEvent.click(screen.getByTestId('pam-add-rule-btn'));
+}
+
 describe('PamRulesTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('shows the empty state when no rules exist', async () => {
-    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ success: true, rules: [] }));
+    installFetchRoutes({ rules: [] });
     render(<PamRulesTab />);
     await waitFor(() => {
       expect(screen.getByText('No PAM rules yet')).toBeInTheDocument();
@@ -62,9 +105,7 @@ describe('PamRulesTab', () => {
       matchPathGlob: '**',
       verdict: 'auto_deny',
     };
-    fetchWithAuthMock.mockResolvedValueOnce(
-      makeJsonResponse({ success: true, rules: [catchAll, signedRule] }),
-    );
+    installFetchRoutes({ rules: [catchAll, signedRule] });
     render(<PamRulesTab />);
     await waitFor(() => {
       expect(screen.getByTestId('pam-rule-row-rule-1')).toBeInTheDocument();
@@ -75,15 +116,28 @@ describe('PamRulesTab', () => {
     expect(screen.getByText('signer=Microsoft Corporation')).toBeInTheDocument();
   });
 
+  it('renders a scope cell: Org-wide or the resolved site name', async () => {
+    const siteScoped: PamRule = {
+      ...signedRule,
+      id: 'rule-3',
+      name: 'HQ only',
+      siteId: 'site-1',
+    };
+    installFetchRoutes({
+      rules: [signedRule, siteScoped],
+      sites: [{ id: 'site-1', name: 'HQ' }],
+    });
+    render(<PamRulesTab />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pam-rule-scope-rule-1')).toHaveTextContent('Org-wide');
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('pam-rule-scope-rule-3')).toHaveTextContent('HQ');
+    });
+  });
+
   it('toggles a rule enabled state via PATCH', async () => {
-    fetchWithAuthMock
-      .mockResolvedValueOnce(makeJsonResponse({ success: true, rules: [signedRule] }))
-      .mockResolvedValueOnce(
-        makeJsonResponse({ success: true, rule: { ...signedRule, enabled: false } }),
-      )
-      .mockResolvedValueOnce(
-        makeJsonResponse({ success: true, rules: [{ ...signedRule, enabled: false }] }),
-      );
+    installFetchRoutes({ rules: [signedRule] });
     render(<PamRulesTab />);
     await waitFor(() => screen.getByTestId('pam-rule-toggle-rule-1'));
     fireEvent.click(screen.getByTestId('pam-rule-toggle-rule-1'));
@@ -93,19 +147,13 @@ describe('PamRulesTab', () => {
         expect.objectContaining({ method: 'PATCH' }),
       );
     });
-    const patchCall = fetchWithAuthMock.mock.calls.find((c) => c[0] === '/pam/rules/rule-1');
-    expect(JSON.parse((patchCall?.[1] as RequestInit).body as string)).toEqual({ enabled: false });
+    expect(bodyOf(findMutationCall('/pam/rules/rule-1', 'PATCH'))).toEqual({ enabled: false });
   });
 
   it('creates a rule through the modal, sending a clean executable-shaped payload', async () => {
-    fetchWithAuthMock
-      .mockResolvedValueOnce(makeJsonResponse({ success: true, rules: [] }))
-      .mockResolvedValueOnce(makeJsonResponse({ success: true, rule: signedRule }, true, 201))
-      .mockResolvedValueOnce(makeJsonResponse({ success: true, rules: [signedRule] }));
-
+    installFetchRoutes({ rules: [] });
     render(<PamRulesTab />);
-    await waitFor(() => screen.getByTestId('pam-add-rule-btn'));
-    fireEvent.click(screen.getByTestId('pam-add-rule-btn'));
+    await openCreateModal();
 
     fireEvent.change(screen.getByTestId('pam-rule-name'), {
       target: { value: 'Allow signed Microsoft installers' },
@@ -121,10 +169,7 @@ describe('PamRulesTab', () => {
         expect.objectContaining({ method: 'POST' }),
       );
     });
-    const postCall = fetchWithAuthMock.mock.calls.find(
-      (c) => c[0] === '/pam/rules' && (c[1] as RequestInit)?.method === 'POST',
-    );
-    const payload = JSON.parse((postCall?.[1] as RequestInit).body as string);
+    const payload = bodyOf(findMutationCall('/pam/rules', 'POST'));
     expect(payload).toMatchObject({
       name: 'Allow signed Microsoft installers',
       matchSigner: 'Microsoft Corporation',
@@ -132,14 +177,16 @@ describe('PamRulesTab', () => {
       matchRiskTier: null,
       verdict: 'require_approval',
       enabled: true,
+      siteId: null,
     });
+    // Single accessible org: the server resolves it — no orgId in the body.
+    expect('orgId' in payload).toBe(false);
   });
 
   it('blocks submission client-side when no criterion is provided', async () => {
-    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ success: true, rules: [] }));
+    installFetchRoutes({ rules: [] });
     render(<PamRulesTab />);
-    await waitFor(() => screen.getByTestId('pam-add-rule-btn'));
-    fireEvent.click(screen.getByTestId('pam-add-rule-btn'));
+    await openCreateModal();
 
     fireEvent.change(screen.getByTestId('pam-rule-name'), { target: { value: 'No criteria' } });
     fireEvent.click(screen.getByTestId('pam-rule-submit'));
@@ -148,18 +195,13 @@ describe('PamRulesTab', () => {
       expect(screen.getByRole('alert')).toHaveTextContent('At least one match criterion');
     });
     // No POST went out
-    expect(
-      fetchWithAuthMock.mock.calls.find(
-        (c) => c[0] === '/pam/rules' && (c[1] as RequestInit)?.method === 'POST',
-      ),
-    ).toBeUndefined();
+    expect(findMutationCall('/pam/rules', 'POST')).toBeUndefined();
   });
 
   it('blocks the ignore verdict for tool-action rules client-side', async () => {
-    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ success: true, rules: [] }));
+    installFetchRoutes({ rules: [] });
     render(<PamRulesTab />);
-    await waitFor(() => screen.getByTestId('pam-add-rule-btn'));
-    fireEvent.click(screen.getByTestId('pam-add-rule-btn'));
+    await openCreateModal();
 
     fireEvent.change(screen.getByTestId('pam-rule-name'), { target: { value: 'Tool rule' } });
     fireEvent.click(screen.getByTestId('pam-rule-shape-tool'));
@@ -169,5 +211,217 @@ describe('PamRulesTab', () => {
     const verdictSelect = screen.getByTestId('pam-rule-verdict') as HTMLSelectElement;
     const ignoreOption = Array.from(verdictSelect.options).find((o) => o.value === 'ignore');
     expect(ignoreOption?.disabled).toBe(true);
+  });
+
+  describe('time window', () => {
+    const windowedRule: PamRule = {
+      ...signedRule,
+      id: 'rule-w',
+      name: 'Business hours',
+      timeWindow: { start: '08:00', end: '18:00', days: [1, 2, 3, 4, 5], timezone: 'Europe/Berlin' },
+    };
+
+    it('preserves days and timezone when editing only the name', async () => {
+      installFetchRoutes({ rules: [windowedRule] });
+      render(<PamRulesTab />);
+      await waitFor(() => screen.getByTestId('pam-rule-edit-rule-w'));
+      fireEvent.click(screen.getByTestId('pam-rule-edit-rule-w'));
+
+      fireEvent.change(screen.getByTestId('pam-rule-name'), {
+        target: { value: 'Business hours v2' },
+      });
+      fireEvent.click(screen.getByTestId('pam-rule-submit'));
+
+      await waitFor(() => {
+        expect(findMutationCall('/pam/rules/rule-w', 'PATCH')).toBeDefined();
+      });
+      const payload = bodyOf(findMutationCall('/pam/rules/rule-w', 'PATCH'));
+      expect(payload.timeWindow).toEqual({
+        start: '08:00',
+        end: '18:00',
+        days: [1, 2, 3, 4, 5],
+        timezone: 'Europe/Berlin',
+      });
+    });
+
+    it('round-trips days and timezone inputs into the create payload', async () => {
+      installFetchRoutes({ rules: [] });
+      render(<PamRulesTab />);
+      await openCreateModal();
+
+      // Days/timezone inputs only appear once the window section is active.
+      expect(screen.queryByTestId('pam-rule-window-day-1')).toBeNull();
+
+      fireEvent.change(screen.getByTestId('pam-rule-name'), { target: { value: 'Windowed' } });
+      fireEvent.change(screen.getByTestId('pam-rule-signer'), { target: { value: 'Acme Corp' } });
+      fireEvent.change(screen.getByTestId('pam-rule-window-start'), { target: { value: '08:00' } });
+      fireEvent.change(screen.getByTestId('pam-rule-window-end'), { target: { value: '18:00' } });
+      fireEvent.click(screen.getByTestId('pam-rule-window-day-1'));
+      fireEvent.click(screen.getByTestId('pam-rule-window-day-2'));
+      fireEvent.change(screen.getByTestId('pam-rule-window-timezone'), {
+        target: { value: 'Europe/Berlin' },
+      });
+      fireEvent.click(screen.getByTestId('pam-rule-submit'));
+
+      await waitFor(() => {
+        expect(findMutationCall('/pam/rules', 'POST')).toBeDefined();
+      });
+      const payload = bodyOf(findMutationCall('/pam/rules', 'POST'));
+      expect(payload.timeWindow).toEqual({
+        start: '08:00',
+        end: '18:00',
+        days: [1, 2],
+        timezone: 'Europe/Berlin',
+      });
+    });
+
+    it('omits days when none are selected and timezone when empty', async () => {
+      installFetchRoutes({ rules: [] });
+      render(<PamRulesTab />);
+      await openCreateModal();
+
+      fireEvent.change(screen.getByTestId('pam-rule-name'), { target: { value: 'Windowed' } });
+      fireEvent.change(screen.getByTestId('pam-rule-signer'), { target: { value: 'Acme Corp' } });
+      fireEvent.change(screen.getByTestId('pam-rule-window-start'), { target: { value: '08:00' } });
+      fireEvent.change(screen.getByTestId('pam-rule-window-end'), { target: { value: '18:00' } });
+      fireEvent.click(screen.getByTestId('pam-rule-submit'));
+
+      await waitFor(() => {
+        expect(findMutationCall('/pam/rules', 'POST')).toBeDefined();
+      });
+      const payload = bodyOf(findMutationCall('/pam/rules', 'POST'));
+      expect(payload.timeWindow).toEqual({ start: '08:00', end: '18:00' });
+    });
+
+    it('blocks submit with an inline error when start is set without end', async () => {
+      installFetchRoutes({ rules: [] });
+      render(<PamRulesTab />);
+      await openCreateModal();
+
+      fireEvent.change(screen.getByTestId('pam-rule-name'), { target: { value: 'Half window' } });
+      fireEvent.change(screen.getByTestId('pam-rule-signer'), { target: { value: 'Acme Corp' } });
+      fireEvent.change(screen.getByTestId('pam-rule-window-start'), { target: { value: '08:00' } });
+      fireEvent.click(screen.getByTestId('pam-rule-submit'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent(/start and end/i);
+      });
+      expect(findMutationCall('/pam/rules', 'POST')).toBeUndefined();
+    });
+  });
+
+  describe('site scoping', () => {
+    const sites = [
+      { id: 'site-1', name: 'HQ' },
+      { id: 'site-2', name: 'Warehouse' },
+    ];
+
+    it('sends the selected site uuid when a site is picked', async () => {
+      installFetchRoutes({ rules: [], sites });
+      render(<PamRulesTab />);
+      await openCreateModal();
+
+      await waitFor(() => {
+        expect(
+          (screen.getByTestId('pam-rule-site') as HTMLSelectElement).options.length,
+        ).toBeGreaterThan(1);
+      });
+      fireEvent.change(screen.getByTestId('pam-rule-name'), { target: { value: 'HQ rule' } });
+      fireEvent.change(screen.getByTestId('pam-rule-signer'), { target: { value: 'Acme Corp' } });
+      fireEvent.change(screen.getByTestId('pam-rule-site'), { target: { value: 'site-1' } });
+      fireEvent.click(screen.getByTestId('pam-rule-submit'));
+
+      await waitFor(() => {
+        expect(findMutationCall('/pam/rules', 'POST')).toBeDefined();
+      });
+      expect(bodyOf(findMutationCall('/pam/rules', 'POST')).siteId).toBe('site-1');
+    });
+
+    it('preselects the site when editing a site-scoped rule', async () => {
+      const siteScoped: PamRule = { ...signedRule, id: 'rule-s', siteId: 'site-2' };
+      installFetchRoutes({ rules: [siteScoped], sites });
+      render(<PamRulesTab />);
+      await waitFor(() => screen.getByTestId('pam-rule-edit-rule-s'));
+      fireEvent.click(screen.getByTestId('pam-rule-edit-rule-s'));
+
+      await waitFor(() => {
+        expect((screen.getByTestId('pam-rule-site') as HTMLSelectElement).value).toBe('site-2');
+      });
+    });
+  });
+
+  describe('organization scoping (partner scope)', () => {
+    const orgs = [
+      { id: 'org-1', name: 'Acme' },
+      { id: 'org-2', name: 'Beta LLC' },
+    ];
+
+    it('shows an org select for multi-org users, scopes the sites fetch, and sends the choice', async () => {
+      installFetchRoutes({ rules: [], orgs, sites: [{ id: 'site-9', name: 'Beta HQ' }] });
+      render(<PamRulesTab />);
+      await openCreateModal();
+
+      await waitFor(() => {
+        expect((screen.getByTestId('pam-rule-org') as HTMLSelectElement).value).toBe('org-1');
+      });
+      // Sites are fetched scoped to the selected org.
+      await waitFor(() => {
+        expect(
+          fetchWithAuthMock.mock.calls.some(
+            (c) => typeof c[0] === 'string' && c[0].includes('/orgs/sites') && c[0].includes('organizationId=org-1'),
+          ),
+        ).toBe(true);
+      });
+
+      fireEvent.change(screen.getByTestId('pam-rule-org'), { target: { value: 'org-2' } });
+      await waitFor(() => {
+        expect(
+          fetchWithAuthMock.mock.calls.some(
+            (c) => typeof c[0] === 'string' && c[0].includes('/orgs/sites') && c[0].includes('organizationId=org-2'),
+          ),
+        ).toBe(true);
+      });
+
+      fireEvent.change(screen.getByTestId('pam-rule-name'), { target: { value: 'Beta rule' } });
+      fireEvent.change(screen.getByTestId('pam-rule-signer'), { target: { value: 'Acme Corp' } });
+      fireEvent.click(screen.getByTestId('pam-rule-submit'));
+
+      await waitFor(() => {
+        expect(findMutationCall('/pam/rules', 'POST')).toBeDefined();
+      });
+      const payload = bodyOf(findMutationCall('/pam/rules', 'POST'));
+      expect(payload.orgId).toBe('org-2');
+      expect(payload.siteId).toBe(null);
+    });
+
+    it('hides the org select for single-org users', async () => {
+      installFetchRoutes({ rules: [] });
+      render(<PamRulesTab />);
+      await openCreateModal();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('pam-rule-site')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('pam-rule-org')).toBeNull();
+    });
+
+    it('does not send orgId on edit', async () => {
+      installFetchRoutes({ rules: [signedRule], orgs });
+      render(<PamRulesTab />);
+      await waitFor(() => screen.getByTestId('pam-rule-edit-rule-1'));
+      fireEvent.click(screen.getByTestId('pam-rule-edit-rule-1'));
+
+      // Org is fixed on edit: no editable org select.
+      await waitFor(() => screen.getByTestId('pam-rule-site'));
+      expect(screen.queryByTestId('pam-rule-org')).toBeNull();
+
+      fireEvent.change(screen.getByTestId('pam-rule-name'), { target: { value: 'Renamed' } });
+      fireEvent.click(screen.getByTestId('pam-rule-submit'));
+
+      await waitFor(() => {
+        expect(findMutationCall('/pam/rules/rule-1', 'PATCH')).toBeDefined();
+      });
+      expect('orgId' in bodyOf(findMutationCall('/pam/rules/rule-1', 'PATCH'))).toBe(false);
+    });
   });
 });

--- a/apps/web/src/components/pam/PamRulesTab.test.tsx
+++ b/apps/web/src/components/pam/PamRulesTab.test.tsx
@@ -325,6 +325,27 @@ describe('PamRulesTab', () => {
       expect(payload.timeWindow).toEqual({ start: '08:00', end: '18:00' });
     });
 
+    it('drops stale days and timezone after the window is fully cleared and re-entered', async () => {
+      installFetchRoutes({ rules: [windowedRule] });
+      render(<PamRulesTab />);
+      await waitFor(() => screen.getByTestId('pam-rule-edit-rule-w'));
+      fireEvent.click(screen.getByTestId('pam-rule-edit-rule-w'));
+
+      // Clear both ends of the window, then re-enter a new one.
+      fireEvent.change(screen.getByTestId('pam-rule-window-start'), { target: { value: '' } });
+      fireEvent.change(screen.getByTestId('pam-rule-window-end'), { target: { value: '' } });
+      fireEvent.change(screen.getByTestId('pam-rule-window-start'), { target: { value: '09:00' } });
+      fireEvent.change(screen.getByTestId('pam-rule-window-end'), { target: { value: '17:00' } });
+      fireEvent.click(screen.getByTestId('pam-rule-submit'));
+
+      await waitFor(() => {
+        expect(findMutationCall('/pam/rules/rule-w', 'PATCH')).toBeDefined();
+      });
+      const payload = bodyOf(findMutationCall('/pam/rules/rule-w', 'PATCH'));
+      // Old days/timezone must not silently resurface with the new window.
+      expect(payload.timeWindow).toEqual({ start: '09:00', end: '17:00' });
+    });
+
     it('blocks submit with an inline error when start is set without end', async () => {
       installFetchRoutes({ rules: [] });
       render(<PamRulesTab />);

--- a/apps/web/src/components/pam/PamRulesTab.test.tsx
+++ b/apps/web/src/components/pam/PamRulesTab.test.tsx
@@ -150,6 +150,38 @@ describe('PamRulesTab', () => {
     expect(bodyOf(findMutationCall('/pam/rules/rule-1', 'PATCH'))).toEqual({ enabled: false });
   });
 
+  it('gates rule deletion behind a confirm dialog', async () => {
+    installFetchRoutes({ rules: [signedRule] });
+    render(<PamRulesTab />);
+    await waitFor(() => screen.getByTestId('pam-rule-delete-rule-1'));
+
+    // First click opens the confirm dialog — no DELETE goes out yet.
+    fireEvent.click(screen.getByTestId('pam-rule-delete-rule-1'));
+    await waitFor(() => screen.getByTestId('pam-rule-delete-confirm'));
+    expect(findMutationCall('/pam/rules/rule-1', 'DELETE')).toBeUndefined();
+
+    // Confirming fires the DELETE.
+    fireEvent.click(screen.getByTestId('pam-rule-delete-confirm'));
+    await waitFor(() => {
+      expect(findMutationCall('/pam/rules/rule-1', 'DELETE')).toBeDefined();
+    });
+  });
+
+  it('does not DELETE when the confirm dialog is cancelled', async () => {
+    installFetchRoutes({ rules: [signedRule] });
+    render(<PamRulesTab />);
+    await waitFor(() => screen.getByTestId('pam-rule-delete-rule-1'));
+
+    fireEvent.click(screen.getByTestId('pam-rule-delete-rule-1'));
+    await waitFor(() => screen.getByTestId('pam-rule-delete-confirm'));
+    fireEvent.click(screen.getByText('Cancel'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('pam-rule-delete-confirm')).toBeNull();
+    });
+    expect(findMutationCall('/pam/rules/rule-1', 'DELETE')).toBeUndefined();
+  });
+
   it('creates a rule through the modal, sending a clean executable-shaped payload', async () => {
     installFetchRoutes({ rules: [] });
     render(<PamRulesTab />);

--- a/apps/web/src/components/pam/PamRulesTab.tsx
+++ b/apps/web/src/components/pam/PamRulesTab.tsx
@@ -1,0 +1,227 @@
+import { useCallback, useEffect, useState } from 'react';
+import { ListChecks, Plus } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, ActionError } from '../../lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+import { showToast } from '../shared/Toast';
+import PamRuleModal from './PamRuleModal';
+import { type PamRule, VERDICT_LABELS } from './types';
+
+function ruleCriteriaSummary(rule: PamRule): string {
+  const parts: string[] = [];
+  if (rule.matchSigner) parts.push(`signer=${rule.matchSigner}`);
+  if (rule.matchHash) parts.push(`hash=${rule.matchHash.slice(0, 12)}…`);
+  if (rule.matchPathGlob) parts.push(`path=${rule.matchPathGlob}`);
+  if (rule.matchParentImage) parts.push(`parent=${rule.matchParentImage}`);
+  if (rule.matchUser) parts.push(`user=${rule.matchUser}`);
+  if (rule.matchAdGroup) parts.push(`group=${rule.matchAdGroup}`);
+  if (rule.matchToolName) parts.push(`tool=${rule.matchToolName}`);
+  if (rule.matchRiskTier !== null && rule.matchRiskTier !== undefined)
+    parts.push(`tier=${rule.matchRiskTier}`);
+  if (rule.timeWindow) parts.push(`window=${rule.timeWindow.start}-${rule.timeWindow.end}`);
+  return parts.join(' · ');
+}
+
+export default function PamRulesTab() {
+  const [rules, setRules] = useState<PamRule[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editing, setEditing] = useState<PamRule | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const fetchRules = useCallback(async (signal?: AbortSignal) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchWithAuth('/pam/rules', { signal });
+      if (!res.ok) {
+        if (res.status === 401) {
+          void navigateTo('/login', { replace: true });
+          return;
+        }
+        throw new Error(`Failed to load rules (HTTP ${res.status})`);
+      }
+      const body = await res.json();
+      const list = ((body.rules ?? []) as PamRule[]).slice();
+      list.sort((a, b) => a.priority - b.priority || a.name.localeCompare(b.name));
+      setRules(list);
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return;
+      setError(err instanceof Error ? err.message : 'Failed to load rules');
+    } finally {
+      if (!signal?.aborted) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetchRules(controller.signal);
+    return () => controller.abort();
+  }, [fetchRules]);
+
+  const toggleEnabled = async (rule: PamRule) => {
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth(`/pam/rules/${rule.id}`, {
+            method: 'PATCH',
+            body: JSON.stringify({ enabled: !rule.enabled }),
+          }),
+        errorFallback: 'Failed to update rule',
+        successMessage: `Rule "${rule.name}" ${rule.enabled ? 'disabled' : 'enabled'}`,
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+      void fetchRules();
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return;
+      if (!(err instanceof ActionError)) {
+        showToast({ type: 'error', message: 'Failed to update rule' });
+      }
+    }
+  };
+
+  const deleteRule = async (rule: PamRule) => {
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/pam/rules/${rule.id}`, { method: 'DELETE' }),
+        errorFallback: 'Failed to delete rule',
+        successMessage: `Rule "${rule.name}" deleted`,
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+      void fetchRules();
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return;
+      if (!(err instanceof ActionError)) {
+        showToast({ type: 'error', message: 'Failed to delete rule' });
+      }
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          Rules are evaluated in priority order (lowest first); the first match decides.
+        </p>
+        <button
+          type="button"
+          onClick={() => setCreating(true)}
+          data-testid="pam-add-rule-btn"
+          className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          <Plus className="h-4 w-4" />
+          Add rule
+        </button>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        >
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center gap-2 rounded-md border bg-card px-4 py-6 text-sm text-muted-foreground">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          Loading rules…
+        </div>
+      ) : rules.length === 0 ? (
+        <div className="rounded-md border border-dashed bg-card px-4 py-8 text-center">
+          <ListChecks className="mx-auto h-8 w-8 text-muted-foreground" />
+          <p className="mt-2 text-sm font-medium">No PAM rules yet</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Without rules, every elevation request waits for a manual decision.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-md border bg-card">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-xs text-muted-foreground">
+                <th className="px-3 py-2 font-medium">Priority</th>
+                <th className="px-3 py-2 font-medium">Name</th>
+                <th className="px-3 py-2 font-medium">Criteria</th>
+                <th className="px-3 py-2 font-medium">Verdict</th>
+                <th className="px-3 py-2 font-medium">Enabled</th>
+                <th className="px-3 py-2 font-medium" />
+              </tr>
+            </thead>
+            <tbody>
+              {rules.map((rule) => (
+                <tr key={rule.id} className="border-b last:border-0" data-testid={`pam-rule-row-${rule.id}`}>
+                  <td className="px-3 py-2 text-muted-foreground">{rule.priority}</td>
+                  <td className="px-3 py-2">
+                    <div className="font-medium">{rule.name}</div>
+                    {rule.description && (
+                      <div className="mt-0.5 max-w-[240px] truncate text-xs text-muted-foreground" title={rule.description}>
+                        {rule.description}
+                      </div>
+                    )}
+                  </td>
+                  <td className="max-w-[320px] truncate px-3 py-2 text-xs text-muted-foreground" title={ruleCriteriaSummary(rule)}>
+                    {ruleCriteriaSummary(rule) || '—'}
+                  </td>
+                  <td className="px-3 py-2">{VERDICT_LABELS[rule.verdict]}</td>
+                  <td className="px-3 py-2">
+                    <button
+                      type="button"
+                      role="switch"
+                      aria-checked={rule.enabled}
+                      onClick={() => void toggleEnabled(rule)}
+                      data-testid={`pam-rule-toggle-${rule.id}`}
+                      className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+                        rule.enabled ? 'bg-green-500' : 'bg-muted'
+                      }`}
+                    >
+                      <span
+                        className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${
+                          rule.enabled ? 'translate-x-[18px]' : 'translate-x-[3px]'
+                        }`}
+                      />
+                    </button>
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-2 text-right">
+                    <button
+                      type="button"
+                      onClick={() => setEditing(rule)}
+                      data-testid={`pam-rule-edit-${rule.id}`}
+                      className="rounded-md border px-2.5 py-1 text-xs font-medium hover:bg-accent"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => void deleteRule(rule)}
+                      data-testid={`pam-rule-delete-${rule.id}`}
+                      className="ml-1.5 rounded-md border border-destructive/40 px-2.5 py-1 text-xs font-medium text-destructive hover:bg-destructive/10"
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {(creating || editing) && (
+        <PamRuleModal
+          rule={editing}
+          onClose={() => {
+            setCreating(false);
+            setEditing(null);
+          }}
+          onSaved={() => {
+            setCreating(false);
+            setEditing(null);
+            void fetchRules();
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/pam/PamRulesTab.tsx
+++ b/apps/web/src/components/pam/PamRulesTab.tsx
@@ -4,6 +4,7 @@ import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
 import { showToast } from '../shared/Toast';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
 import PamRuleModal from './PamRuleModal';
 import { type PamRule, VERDICT_LABELS } from './types';
 
@@ -28,6 +29,8 @@ export default function PamRulesTab() {
   const [error, setError] = useState<string | null>(null);
   const [editing, setEditing] = useState<PamRule | null>(null);
   const [creating, setCreating] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<PamRule | null>(null);
+  const [deleting, setDeleting] = useState(false);
   // siteId → name, resolved once for the Scope column (GET /pam/rules returns
   // only siteId; no per-row lookups).
   const [siteNames, setSiteNames] = useState<Record<string, string>>({});
@@ -94,7 +97,10 @@ export default function PamRulesTab() {
     }
   };
 
-  const deleteRule = async (rule: PamRule) => {
+  const confirmDeleteRule = async () => {
+    if (!deleteTarget || deleting) return;
+    const rule = deleteTarget;
+    setDeleting(true);
     try {
       await runAction({
         request: () => fetchWithAuth(`/pam/rules/${rule.id}`, { method: 'DELETE' }),
@@ -108,6 +114,9 @@ export default function PamRulesTab() {
       if (!(err instanceof ActionError)) {
         showToast({ type: 'error', message: 'Failed to delete rule' });
       }
+    } finally {
+      setDeleting(false);
+      setDeleteTarget(null);
     }
   };
 
@@ -169,7 +178,9 @@ export default function PamRulesTab() {
                 <tr key={rule.id} className="border-b last:border-0" data-testid={`pam-rule-row-${rule.id}`}>
                   <td className="px-3 py-2 text-muted-foreground">{rule.priority}</td>
                   <td className="px-3 py-2">
-                    <div className="font-medium">{rule.name}</div>
+                    <div className="font-medium" data-testid={`pam-rule-name-${rule.id}`}>
+                      {rule.name}
+                    </div>
                     {rule.description && (
                       <div className="mt-0.5 max-w-[240px] truncate text-xs text-muted-foreground" title={rule.description}>
                         {rule.description}
@@ -215,7 +226,7 @@ export default function PamRulesTab() {
                     </button>
                     <button
                       type="button"
-                      onClick={() => void deleteRule(rule)}
+                      onClick={() => setDeleteTarget(rule)}
                       data-testid={`pam-rule-delete-${rule.id}`}
                       className="ml-1.5 rounded-md border border-destructive/40 px-2.5 py-1 text-xs font-medium text-destructive hover:bg-destructive/10"
                     >
@@ -228,6 +239,18 @@ export default function PamRulesTab() {
           </table>
         </div>
       )}
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={() => void confirmDeleteRule()}
+        title="Delete PAM rule"
+        message={`Delete rule "${deleteTarget?.name ?? ''}"? Elevation requests will no longer match it.`}
+        confirmLabel="Delete rule"
+        variant="destructive"
+        isLoading={deleting}
+        confirmTestId="pam-rule-delete-confirm"
+      />
 
       {(creating || editing) && (
         <PamRuleModal

--- a/apps/web/src/components/pam/PamRulesTab.tsx
+++ b/apps/web/src/components/pam/PamRulesTab.tsx
@@ -28,6 +28,20 @@ export default function PamRulesTab() {
   const [error, setError] = useState<string | null>(null);
   const [editing, setEditing] = useState<PamRule | null>(null);
   const [creating, setCreating] = useState(false);
+  // siteId → name, resolved once for the Scope column (GET /pam/rules returns
+  // only siteId; no per-row lookups).
+  const [siteNames, setSiteNames] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    fetchWithAuth('/orgs/sites?limit=100')
+      .then(async (res) => {
+        if (!res.ok) return;
+        const data = await res.json();
+        const list = (data.data ?? data.sites ?? data ?? []) as Array<{ id: string; name: string }>;
+        setSiteNames(Object.fromEntries(list.map((s) => [s.id, s.name])));
+      })
+      .catch(() => {});
+  }, []);
 
   const fetchRules = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
@@ -144,6 +158,7 @@ export default function PamRulesTab() {
                 <th className="px-3 py-2 font-medium">Priority</th>
                 <th className="px-3 py-2 font-medium">Name</th>
                 <th className="px-3 py-2 font-medium">Criteria</th>
+                <th className="px-3 py-2 font-medium">Scope</th>
                 <th className="px-3 py-2 font-medium">Verdict</th>
                 <th className="px-3 py-2 font-medium">Enabled</th>
                 <th className="px-3 py-2 font-medium" />
@@ -163,6 +178,12 @@ export default function PamRulesTab() {
                   </td>
                   <td className="max-w-[320px] truncate px-3 py-2 text-xs text-muted-foreground" title={ruleCriteriaSummary(rule)}>
                     {ruleCriteriaSummary(rule) || '—'}
+                  </td>
+                  <td
+                    className="whitespace-nowrap px-3 py-2 text-xs text-muted-foreground"
+                    data-testid={`pam-rule-scope-${rule.id}`}
+                  >
+                    {rule.siteId ? siteNames[rule.siteId] ?? rule.siteId : 'Org-wide'}
                   </td>
                   <td className="px-3 py-2">{VERDICT_LABELS[rule.verdict]}</td>
                   <td className="px-3 py-2">

--- a/apps/web/src/components/pam/types.ts
+++ b/apps/web/src/components/pam/types.ts
@@ -1,0 +1,132 @@
+/** Shared shapes for the /pam admin UI (#1159), mirroring routes/pam.ts responses. */
+
+export type ElevationStatus =
+  | 'pending'
+  | 'approved'
+  | 'auto_approved'
+  | 'denied'
+  | 'expired'
+  | 'revoked'
+  | 'actuating';
+
+export type ElevationFlowType = 'uac_intercept' | 'tech_jit_admin' | 'ai_tool_action';
+
+export type PamVerdict = 'auto_approve' | 'auto_deny' | 'require_approval' | 'ignore';
+
+export interface ElevationRequest {
+  id: string;
+  orgId: string;
+  siteId?: string | null;
+  deviceId: string;
+  flowType: ElevationFlowType;
+  subjectUsername: string;
+  reason: string;
+  targetExecutablePath?: string | null;
+  targetExecutableHash?: string | null;
+  targetExecutableSigner?: string | null;
+  targetPublisher?: string | null;
+  status: ElevationStatus;
+  requestedAt: string;
+  approvedAt?: string | null;
+  expiresAt?: string | null;
+  revokedAt?: string | null;
+  revokedReason?: string | null;
+  approvedByUserId?: string | null;
+  deniedByUserId?: string | null;
+  denialReason?: string | null;
+  toolName?: string | null;
+  riskTier?: number | null;
+  executionId?: string | null;
+  // Joined by the API
+  deviceHostname?: string | null;
+  siteName?: string | null;
+}
+
+export interface PamTimeWindow {
+  start: string;
+  end: string;
+  days?: number[];
+  timezone?: string;
+}
+
+export interface PamRule {
+  id: string;
+  orgId: string;
+  siteId?: string | null;
+  name: string;
+  description?: string | null;
+  enabled: boolean;
+  priority: number;
+  matchSigner?: string | null;
+  matchHash?: string | null;
+  matchPathGlob?: string | null;
+  matchParentImage?: string | null;
+  matchUser?: string | null;
+  matchAdGroup?: string | null;
+  matchToolName?: string | null;
+  matchRiskTier?: number | null;
+  timeWindow?: PamTimeWindow | null;
+  verdict: PamVerdict;
+  approvalDurationMinutes?: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Pagination {
+  page: number;
+  limit: number;
+  total: number;
+}
+
+export const STATUS_LABELS: Record<ElevationStatus, string> = {
+  pending: 'Pending',
+  approved: 'Approved',
+  auto_approved: 'Auto-approved',
+  denied: 'Denied',
+  expired: 'Expired',
+  revoked: 'Revoked',
+  actuating: 'Actuating',
+};
+
+export const FLOW_LABELS: Record<ElevationFlowType, string> = {
+  uac_intercept: 'UAC intercept',
+  tech_jit_admin: 'Tech JIT admin',
+  ai_tool_action: 'AI tool action',
+};
+
+export const VERDICT_LABELS: Record<PamVerdict, string> = {
+  auto_approve: 'Auto-approve',
+  auto_deny: 'Auto-deny',
+  require_approval: 'Require approval',
+  ignore: 'Ignore',
+};
+
+export const ACTIVE_STATUSES: readonly ElevationStatus[] = [
+  'approved',
+  'auto_approved',
+  'actuating',
+];
+
+/** Badge color classes per status, matching the muted Tailwind palette used app-wide. */
+export function statusBadgeClass(status: ElevationStatus): string {
+  switch (status) {
+    case 'pending':
+      return 'bg-yellow-500/15 text-yellow-600 dark:text-yellow-400';
+    case 'approved':
+    case 'auto_approved':
+      return 'bg-green-500/15 text-green-600 dark:text-green-400';
+    case 'actuating':
+      return 'bg-blue-500/15 text-blue-600 dark:text-blue-400';
+    case 'denied':
+    case 'revoked':
+      return 'bg-red-500/15 text-red-600 dark:text-red-400';
+    case 'expired':
+      return 'bg-muted text-muted-foreground';
+  }
+}
+
+/** Human summary of what a request is asking for. */
+export function requestTarget(r: ElevationRequest): string {
+  if (r.flowType === 'ai_tool_action') return r.toolName ?? 'AI tool action';
+  return r.targetExecutablePath ?? 'Elevation';
+}

--- a/apps/web/src/components/shared/ConfirmDialog.tsx
+++ b/apps/web/src/components/shared/ConfirmDialog.tsx
@@ -10,6 +10,8 @@ export interface ConfirmDialogProps {
   confirmLabel?: string;
   variant?: 'destructive' | 'warning';
   isLoading?: boolean;
+  /** data-testid for the confirm button (e2e suites are testid-only). */
+  confirmTestId?: string;
 }
 
 export function ConfirmDialog({
@@ -21,6 +23,7 @@ export function ConfirmDialog({
   confirmLabel = 'Confirm',
   variant = 'destructive',
   isLoading = false,
+  confirmTestId,
 }: ConfirmDialogProps) {
   return (
     <Dialog open={open} onClose={onClose} title={title} maxWidth="md" className="p-6">
@@ -54,6 +57,7 @@ export function ConfirmDialog({
           type="button"
           onClick={onConfirm}
           disabled={isLoading}
+          data-testid={confirmTestId}
           className={`rounded-md px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50 ${
             variant === 'destructive'
               ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -38,6 +38,10 @@ const TARGET_GLOBS = [
   'src/components/dnsSecurity/DnsSecurityPoliciesTab.tsx',
   'src/components/dnsSecurity/AddDnsPolicyModal.tsx',
   'src/components/devices/DeviceSoftwareInventory.tsx',
+  'src/components/pam/PamRespondModal.tsx',
+  'src/components/pam/PamRevokeModal.tsx',
+  'src/components/pam/PamRuleModal.tsx',
+  'src/components/pam/PamRulesTab.tsx',
 ];
 
 const absoluteFiles: string[] = TARGET_GLOBS.map((rel) => resolve(WEB_ROOT, '..', rel));
@@ -229,7 +233,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(10);
+    expect(absoluteFiles.length).toBe(14);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/pages/pam.astro
+++ b/apps/web/src/pages/pam.astro
@@ -1,0 +1,8 @@
+---
+import DashboardLayout from '../layouts/DashboardLayout.astro';
+import PamPage from '../components/pam/PamPage';
+---
+
+<DashboardLayout title="Privileged Access">
+  <PamPage client:load />
+</DashboardLayout>

--- a/e2e-tests/pages/PamPage.ts
+++ b/e2e-tests/pages/PamPage.ts
@@ -1,0 +1,28 @@
+import type { Page } from '@playwright/test';
+
+export class PamPage {
+  url = '/pam';
+
+  constructor(private page: Page) {}
+
+  heading = () => this.page.getByTestId('pam-heading');
+  liveIndicator = () => this.page.getByTestId('pam-live-indicator');
+
+  tabOverview = () => this.page.getByTestId('pam-tab-overview');
+  tabRequests = () => this.page.getByTestId('pam-tab-requests');
+  tabRules = () => this.page.getByTestId('pam-tab-rules');
+  tabAudit = () => this.page.getByTestId('pam-tab-audit');
+
+  statActive = () => this.page.getByTestId('pam-stat-active');
+  filterStatus = () => this.page.getByTestId('pam-filter-status');
+  auditExportButton = () => this.page.getByTestId('pam-audit-export-btn');
+
+  addRuleButton = () => this.page.getByTestId('pam-add-rule-btn');
+  ruleName = () => this.page.getByTestId('pam-rule-name');
+  ruleSigner = () => this.page.getByTestId('pam-rule-signer');
+  rulePriority = () => this.page.getByTestId('pam-rule-priority');
+  ruleVerdict = () => this.page.getByTestId('pam-rule-verdict');
+  ruleSubmit = () => this.page.getByTestId('pam-rule-submit');
+  ruleRows = () => this.page.locator('[data-testid^="pam-rule-row-"]');
+  ruleDeleteButtons = () => this.page.locator('[data-testid^="pam-rule-delete-"]');
+}

--- a/e2e-tests/pages/PamPage.ts
+++ b/e2e-tests/pages/PamPage.ts
@@ -24,5 +24,25 @@ export class PamPage {
   ruleVerdict = () => this.page.getByTestId('pam-rule-verdict');
   ruleSubmit = () => this.page.getByTestId('pam-rule-submit');
   ruleRows = () => this.page.locator('[data-testid^="pam-rule-row-"]');
-  ruleDeleteButtons = () => this.page.locator('[data-testid^="pam-rule-delete-"]');
+  ruleRow = (id: string) => this.page.getByTestId(`pam-rule-row-${id}`);
+  ruleNameCells = () => this.page.locator('[data-testid^="pam-rule-name-"]');
+  ruleDeleteButton = (id: string) => this.page.getByTestId(`pam-rule-delete-${id}`);
+  ruleDeleteConfirmButton = () => this.page.getByTestId('pam-rule-delete-confirm');
+
+  /**
+   * Resolve a rule's id from its (unique) name without text-based locators:
+   * walk the `pam-rule-name-<id>` testid cells and compare textContent.
+   */
+  async ruleIdByName(name: string): Promise<string | null> {
+    const cells = this.ruleNameCells();
+    const count = await cells.count();
+    for (let i = 0; i < count; i++) {
+      const cell = cells.nth(i);
+      if ((await cell.textContent())?.trim() === name) {
+        const testId = await cell.getAttribute('data-testid');
+        return testId ? testId.replace('pam-rule-name-', '') : null;
+      }
+    }
+    return null;
+  }
 }

--- a/e2e-tests/tests/pam.spec.ts
+++ b/e2e-tests/tests/pam.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '../fixtures';
+import { clearRefreshState } from '../test-helpers';
+import { AuthPage } from '../pages/AuthPage';
+import { PamPage } from '../pages/PamPage';
+
+test.describe.configure({ mode: 'serial' });
+test.beforeEach(clearRefreshState);
+
+test.describe('pam admin', () => {
+  test('tabs, rule create and delete', async ({ cleanPage }) => {
+    test.setTimeout(120_000);
+
+    const auth = new AuthPage(cleanPage);
+    // Same hydration workaround as tickets.spec.ts: wait for the React fiber
+    // expando on the login form instead of the unmerged data-hydrated sentinel.
+    await cleanPage.goto(`${auth.url}?next=${encodeURIComponent('/pam')}`);
+    await auth.page_().waitFor();
+    await cleanPage.waitForFunction(() => {
+      const form = document.querySelector('form');
+      return !!form && Object.keys(form).some((k) => k.startsWith('__reactFiber$'));
+    });
+    await auth.signIn(process.env.E2E_ADMIN_EMAIL!, process.env.E2E_ADMIN_PASSWORD!, /\/pam(\?|$|#)/);
+
+    const pam = new PamPage(cleanPage);
+    await pam.heading().waitFor();
+
+    // Overview is the default tab.
+    await pam.statActive().waitFor();
+
+    // Requests tab via hash routing.
+    await pam.tabRequests().click();
+    await expect(cleanPage).toHaveURL(/#requests$/);
+    await pam.filterStatus().waitFor();
+
+    // Audit tab renders its export control.
+    await pam.tabAudit().click();
+    await pam.auditExportButton().waitFor();
+
+    // Rules tab: create a rule end-to-end against the real API.
+    await pam.tabRules().click();
+    await pam.addRuleButton().waitFor();
+
+    const before = await pam.ruleRows().count();
+    await pam.addRuleButton().click();
+    await pam.ruleName().waitFor();
+    const ruleName = `E2E signer rule ${Date.now()}`;
+    await pam.ruleName().fill(ruleName);
+    await pam.ruleSigner().fill('E2E Test Signer');
+    await pam.rulePriority().fill('9000');
+    await pam.ruleSubmit().click();
+
+    await expect(pam.ruleRows()).toHaveCount(before + 1, { timeout: 15_000 });
+    await expect(cleanPage.getByText(ruleName)).toBeVisible();
+
+    // Delete it again to leave the environment clean.
+    const row = cleanPage.locator('[data-testid^="pam-rule-row-"]', { hasText: ruleName });
+    await row.locator('[data-testid^="pam-rule-delete-"]').click();
+    await expect(pam.ruleRows()).toHaveCount(before, { timeout: 15_000 });
+  });
+});

--- a/e2e-tests/tests/pam.spec.ts
+++ b/e2e-tests/tests/pam.spec.ts
@@ -50,11 +50,17 @@ test.describe('pam admin', () => {
     await pam.ruleSubmit().click();
 
     await expect(pam.ruleRows()).toHaveCount(before + 1, { timeout: 15_000 });
-    await expect(cleanPage.getByText(ruleName)).toBeVisible();
 
-    // Delete it again to leave the environment clean.
-    const row = cleanPage.locator('[data-testid^="pam-rule-row-"]', { hasText: ruleName });
-    await row.locator('[data-testid^="pam-rule-delete-"]').click();
+    // Resolve the new row's id via the pam-rule-name-<id> testid cells
+    // (data-testid-only rule: no text/hasText locators).
+    const ruleId = await pam.ruleIdByName(ruleName);
+    expect(ruleId).not.toBeNull();
+    await expect(pam.ruleRow(ruleId!)).toBeVisible();
+
+    // Delete it again to leave the environment clean (delete is confirm-gated).
+    await pam.ruleDeleteButton(ruleId!).click();
+    await pam.ruleDeleteConfirmButton().waitFor();
+    await pam.ruleDeleteConfirmButton().click();
     await expect(pam.ruleRows()).toHaveCount(before, { timeout: 15_000 });
   });
 });


### PR DESCRIPTION
## Summary

Implements #1159: the `/pam` admin surface, built exactly to the implementation plan (`docs/superpowers/plans/2026-06-09-pam-web-admin-ui.md`) on top of the merged #1183 control plane, including the #1226 tool-action extensions.

**Four tabs** (hash-routed per the URL-state convention, DNS Security scaffold):
- **Overview** — stat cards (active / pending / recent), active-elevations table with expiry countdowns, recent-decisions strip.
- **Requests** — filterable queue (status, flow type, pagination); Respond modal (approve with duration 1-1440m + reason, or deny with reason); Revoke modal (reason required) for active rows. A 409 from respond/revoke surfaces as a friendly "already actioned — refreshing" toast + refetch, per the plan's CAS-aware UX.
- **Rules** — priority-ordered table with criteria summary, enable/disable switch, create/edit/delete modal covering both rule shapes: executable (signer/hash/path-glob/parent) and AI tool action (toolName/riskTier from #1226), shared user/AD-group/time-window criteria. Client mirrors the server's shape validation (at least one criterion; shapes mutually exclusive; no `ignore` verdict on tool-action rules) for fast feedback — the server stays authoritative.
- **Audit** — status/flow/date filters + CSV export of the filtered set (paged fetch, 1,000-row cap, RFC-4180 escaping).

**Live updates**: subscribes to all seven `elevation.*` events via the existing `useEventStream` hook; bursty events debounce into a single refetch (Overview + Requests).

**Sidebar**: PAM entry in the Security section. **Astro**: `pam.astro` with `client:load`.

**Testids + e2e** (plan Task 7, net-new convention for this page family): every interactive element carries a `data-testid`; Playwright spec `pam.spec.ts` + `PamPage` page object cover login → tab routing → rule create → rule delete against the real API.

**Note on plan Task 6 (client-side role-gating):** the web auth store exposes no permission codes — no existing page gates actions client-side (verified across the app; the DNS reference page included). Enforcement is server-side via #1183's `requirePermission` + `requireMfa` + `requireScope`; the UI surfaces denials through `runAction` error toasts. If a permissions surface is added to the auth store later, the gate drops in cleanly at the action buttons.

## Verification (local, CI-replica)

- Web vitest (node:22 container, frozen-lockfile install): **888/888 across 127 files** — includes the 19 new PAM tests and the `no-silent-mutations` guard (all mutations go through `runAction`).
- `astro check`: **0 errors, 0 warnings** (152 pre-existing hints).
- `pnpm exec tsc --noEmit --project apps/api/tsconfig.json`: clean (diff contains no API files).
- `astro build`: completed green.
- `pnpm audit --prod --audit-level high`: no known vulnerabilities.
- Trivy fs scan over the new code: clean.
- Go agent: untouched (zero files in diff).

Closes #1159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
