### PR TITLE
fix(web): keep Monaco editor styled across View-Transition nav (#1186)

### DIFF
--- a/apps/web/src/components/scripts/ScriptForm.test.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.test.tsx
@@ -1,0 +1,65 @@
+import { render, waitFor, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Track every Monaco editor instance the mock hands to ScriptForm's onMount, so
+// we can assert the component disposes them rather than leaking them across
+// Astro View-Transition DOM swaps (issue #1186).
+const { editorInstances } = vi.hoisted(() => ({
+  editorInstances: [] as Array<{ layout: ReturnType<typeof vi.fn>; dispose: ReturnType<typeof vi.fn> }>
+}));
+
+vi.mock('@monaco-editor/react', async () => {
+  const React = (await vi.importActual<typeof import('react')>('react'));
+  const loader = { config: vi.fn() };
+  function MockEditor({ onMount, value }: { onMount?: (e: unknown) => void; value?: string }) {
+    React.useEffect(() => {
+      const instance = { layout: vi.fn(), dispose: vi.fn() };
+      editorInstances.push(instance);
+      onMount?.(instance);
+      // The real wrapper disposes on its own unmount; the mock deliberately does
+      // NOT, so the test only passes if ScriptForm itself disposes the instance.
+    }, []);
+    return React.createElement('div', { 'data-testid': 'mock-monaco' }, value);
+  }
+  return { __esModule: true, default: MockEditor, loader };
+});
+
+vi.mock('@/stores/scriptAiStore', () => ({
+  useScriptAiStore: () => ({ panelOpen: false, togglePanel: vi.fn() })
+}));
+
+import ScriptForm from './ScriptForm';
+
+describe('ScriptForm Monaco lifecycle (issue #1186)', () => {
+  beforeEach(() => {
+    editorInstances.length = 0;
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('disposes the prior editor instance on an Astro View-Transition swap instead of leaking it', async () => {
+    render(<ScriptForm />);
+    await waitFor(() => expect(editorInstances).toHaveLength(1));
+    const first = editorInstances[0];
+    expect(first.dispose).not.toHaveBeenCalled();
+
+    // Astro swaps the document on SPA navigation; ScriptForm re-runs loadEditor.
+    // It must dispose the now-orphaned editor before reloading.
+    act(() => {
+      document.dispatchEvent(new Event('astro:after-swap'));
+    });
+
+    await waitFor(() => expect(first.dispose).toHaveBeenCalledTimes(1));
+  });
+
+  it('disposes the editor instance when the form unmounts', async () => {
+    const { unmount } = render(<ScriptForm />);
+    await waitFor(() => expect(editorInstances).toHaveLength(1));
+    const first = editorInstances[0];
+    expect(first.dispose).not.toHaveBeenCalled();
+
+    unmount();
+    expect(first.dispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/scripts/ScriptForm.test.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.test.tsx
@@ -1,5 +1,7 @@
 import { render, waitFor, act } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+// Raw source of the component under test, for the build-mechanism guard below.
+import scriptFormSource from './ScriptForm.tsx?raw';
 
 // Track every Monaco editor instance the mock hands to ScriptForm's onMount, so
 // we can assert the component disposes them rather than leaking them across
@@ -61,5 +63,38 @@ describe('ScriptForm Monaco lifecycle (issue #1186)', () => {
 
     unmount();
     expect(first.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('tolerates a throwing dispose on swap — logs and continues instead of aborting the reload', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(<ScriptForm />);
+    await waitFor(() => expect(editorInstances).toHaveLength(1));
+    // A real Monaco dispose can throw on a double-dispose / internal edge case.
+    // Unguarded, that throw escapes the astro:after-swap listener and leaves a
+    // stale ref the layout() handler would call into. The dispose must be caught.
+    editorInstances[0].dispose.mockImplementation(() => {
+      throw new Error('monaco dispose failed');
+    });
+
+    expect(() => {
+      act(() => {
+        document.dispatchEvent(new Event('astro:after-swap'));
+      });
+    }).not.toThrow();
+
+    expect(editorInstances[0].dispose).toHaveBeenCalledTimes(1);
+    expect(errSpy).toHaveBeenCalledWith(
+      'Failed to dispose previous Monaco editor:',
+      expect.any(Error)
+    );
+    errSpy.mockRestore();
+  });
+
+  // Build-mechanism guard: the white-box cure (#1186) is the static editor.main.css
+  // import landing in the route <head> so it survives View-Transition swaps. That's
+  // invisible to jsdom (CSS imports are no-ops in vitest), so nothing else here would
+  // catch someone "cleaning up an unused import" and silently regressing the fix.
+  it('keeps the static Monaco editor.main.css import (headline #1186 cure)', () => {
+    expect(scriptFormSource).toMatch(/import\s+['"]monaco-editor\/min\/vs\/editor\/editor\.main\.css['"]/);
   });
 });

--- a/apps/web/src/components/scripts/ScriptForm.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect, useRef, type ComponentType } from 'react';
+import { useMemo, useState, useEffect, useRef, useCallback, type ComponentType } from 'react';
 import { useForm, useFieldArray, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Plus, Trash2, Sparkles } from 'lucide-react';
@@ -11,9 +11,10 @@ import type { EditorProps } from '@monaco-editor/react';
 // injection and leaving the editor's hidden `.inputarea` <textarea> rendered as
 // a bare unstyled white box on SPA navigation (issue #1186). A build-time <link>
 // is part of every editor route's server markup, so it survives the swap. The
-// stylesheet is self-contained (its codicon font is an inline data: URI), so
-// Vite processes it without external asset resolution. CSS-only — does not pull
-// the Monaco JS wrapper into the static bundle (see lib/monacoLoader.ts).
+// stylesheet is self-contained (all its url() assets — the codicon font and a
+// few images — are inline data: URIs), so Vite processes it without external
+// asset resolution. CSS-only — does not pull the Monaco JS wrapper into the
+// static bundle (see lib/monacoLoader.ts).
 import 'monaco-editor/min/vs/editor/editor.main.css';
 
 import ScriptAiPanel from './ScriptAiPanel';
@@ -58,6 +59,21 @@ export default function ScriptForm({
   // on SPA back-navigation (e.g. scripts list → edit → list → edit).
   const [MonacoEditor, setMonacoEditor] = useState<ComponentType<EditorProps> | null>(null);
   const [editorLoadError, setEditorLoadError] = useState<string | null>(null);
+
+  // Tear down the current Monaco instance, tolerating a throw from dispose()
+  // (double-dispose, or a Monaco-internal edge case). A swallowed-but-logged
+  // failure here must not abort the editor reload below or leave a stale ref
+  // that the astro:page-load layout() handler would then call into. See #1186.
+  const disposeEditor = useCallback(() => {
+    try {
+      editorInstanceRef.current?.dispose();
+    } catch (err) {
+      console.error('Failed to dispose previous Monaco editor:', err);
+    } finally {
+      editorInstanceRef.current = null;
+    }
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
     const loadEditor = () => {
@@ -65,8 +81,7 @@ export default function ScriptForm({
       // swap Astro replaces the document without unmounting this React tree, so
       // the wrapper's own dispose never fires — without this the orphaned editor
       // (and its listeners/DOM) leaks on every SPA back-nav (issue #1186).
-      editorInstanceRef.current?.dispose();
-      editorInstanceRef.current = null;
+      disposeEditor();
       setEditorLoadError(null);
       // Point Monaco's loader at our self-hosted /monaco/vs assets before the
       // editor module initialises it, so it never reaches cdn.jsdelivr.net
@@ -89,10 +104,9 @@ export default function ScriptForm({
     return () => {
       cancelled = true;
       document.removeEventListener('astro:after-swap', loadEditor);
-      editorInstanceRef.current?.dispose();
-      editorInstanceRef.current = null;
+      disposeEditor();
     };
-  }, []);
+  }, [disposeEditor]);
 
   // Force editor relayout after View Transition navigation completes
   useEffect(() => {

--- a/apps/web/src/components/scripts/ScriptForm.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.tsx
@@ -4,6 +4,18 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Plus, Trash2, Sparkles } from 'lucide-react';
 import type { EditorProps } from '@monaco-editor/react';
 
+// Statically import Monaco's editor stylesheet so Astro bundles it into the
+// route's <head> as a hashed <link>. @monaco-editor/loader otherwise injects
+// this CSS into <head> at runtime, and Astro's View-Transition document swap
+// rebuilds <head> from the new page's server markup — dropping that runtime
+// injection and leaving the editor's hidden `.inputarea` <textarea> rendered as
+// a bare unstyled white box on SPA navigation (issue #1186). A build-time <link>
+// is part of every editor route's server markup, so it survives the swap. The
+// stylesheet is self-contained (its codicon font is an inline data: URI), so
+// Vite processes it without external asset resolution. CSS-only — does not pull
+// the Monaco JS wrapper into the static bundle (see lib/monacoLoader.ts).
+import 'monaco-editor/min/vs/editor/editor.main.css';
+
 import ScriptAiPanel from './ScriptAiPanel';
 import CollapsibleSection from './CollapsibleSection';
 import { cn } from '@/lib/utils';
@@ -49,6 +61,11 @@ export default function ScriptForm({
   useEffect(() => {
     let cancelled = false;
     const loadEditor = () => {
+      // Dispose the previous instance before reloading. On a View-Transition
+      // swap Astro replaces the document without unmounting this React tree, so
+      // the wrapper's own dispose never fires — without this the orphaned editor
+      // (and its listeners/DOM) leaks on every SPA back-nav (issue #1186).
+      editorInstanceRef.current?.dispose();
       editorInstanceRef.current = null;
       setEditorLoadError(null);
       // Point Monaco's loader at our self-hosted /monaco/vs assets before the
@@ -72,6 +89,8 @@ export default function ScriptForm({
     return () => {
       cancelled = true;
       document.removeEventListener('astro:after-swap', loadEditor);
+      editorInstanceRef.current?.dispose();
+      editorInstanceRef.current = null;
     };
   }, []);
 


### PR DESCRIPTION
Closes #1186.

## Problem
Opening a script for editing via in-app (SPA) navigation showed a phantom **white input box** over the Script Content editor — Monaco's hidden `.inputarea` `<textarea>` rendered **unstyled** (native resize grip and all). A hard refresh cleared it; SPA nav brought it back.

## Root cause
Monaco's `editor.main.css` is injected into `<head>` **at runtime** by `@monaco-editor/loader` and is absent from server markup. Astro's View-Transition document swap rebuilds `<head>` from the new page's server markup and **drops that runtime injection**, so the re-mounted editor renders unstyled.

**This is not fixed by self-hosting Monaco (#1143):** that only moves the asset origin (jsdelivr → `/monaco/vs`); the CSS is still runtime-injected and still stripped by the swap. Please don't let the #1143 release auto-close #1186.

## Fix
- **Statically import `monaco-editor/min/vs/editor/editor.main.css`** in `ScriptForm.tsx` → Astro bundles it into the route's `<head>` as a build-time `<link>`. Being part of every editor route's server markup, it survives the swap. The stylesheet is self-contained (codicon font is an inline `data:` URI), so Vite needs no external asset resolution, and a CSS-only import keeps the Monaco JS wrapper out of the static graph (per `lib/monacoLoader.ts`).
- **Dispose the prior Monaco instance** on `astro:after-swap` reload and on unmount — the wrapper's own dispose never fires when Astro swaps the DOM without unmounting the React tree, leaking an orphaned editor on every SPA back-nav.

## Verification
This bug class is invisible to tsc/unit alone, so verified three ways:
- **Unit** — `ScriptForm.test.tsx` (new): dispose-on-swap + dispose-on-unmount. Targeted suite 29 passed; `tsc --noEmit` clean.
- **Build** — production `astro build` succeeds; Monaco CSS extracted into a route-scoped `ScriptEditPage.*.css` chunk.
- **Live SSR render** — built server serves `<link rel="stylesheet" href="/_astro/ScriptEditPage.*.css">` in the `<head>` of both `/scripts/[id]` and `/scripts/new`.

A full Playwright guard (assert `.monaco-editor` styling after a View-Transition nav) is worth adding but needs new `data-testid` hooks + a ScriptsPage POM + seeded data — left as follow-up.

## Related (separate problems from the same console log, not this PR)
- #1230 — Google Fonts blocked by CSP on every page (self-hosted domains)
- #1231 — In-app docs/HelpPanel iframe blocked on self-hosted domains
- #1232 — CSP script-hash drift → blocked Astro hydration + React #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)