### PR TITLE
fix(web): self-host Plus Jakarta Sans so the brand font survives CSP (#1230)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "@astrojs/node": "^10.1.4",
     "@astrojs/react": "^5.0.7",
     "@astrojs/tailwind": "^6.0.0",
+    "@fontsource/plus-jakarta-sans": "^5.2.8",
     "@hookform/resolvers": "^5.4.0",
     "@monaco-editor/react": "^4.6.0",
     "@novnc/novnc": "1.7.0",

--- a/apps/web/src/layouts/AuthLayout.astro
+++ b/apps/web/src/layouts/AuthLayout.astro
@@ -16,9 +16,6 @@ const { title } = Astro.props;
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Breeze RMM - Remote Monitoring and Management" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <title>{title} | Breeze RMM</title>
     <ClientRouter />
   </head>

--- a/apps/web/src/layouts/AuthShellBranded.astro
+++ b/apps/web/src/layouts/AuthShellBranded.astro
@@ -22,9 +22,6 @@ const {
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <title>{title} | Breeze RMM</title>
     <ClientRouter />
   </head>

--- a/apps/web/src/layouts/Layout.astro
+++ b/apps/web/src/layouts/Layout.astro
@@ -16,9 +16,6 @@ const { title } = Astro.props;
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Breeze RMM - Remote Monitoring and Management" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <!--
       Theme bootstrap is an external script (not is:inline) so it's covered by
       script-src 'self' under the strict hash-based CSP. Keeping it inline would

--- a/apps/web/src/layouts/SetupLayout.astro
+++ b/apps/web/src/layouts/SetupLayout.astro
@@ -16,9 +16,6 @@ const { title } = Astro.props;
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Breeze RMM - Initial Setup" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <title>{title} | Breeze RMM</title>
     <ClientRouter />
   </head>

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1,3 +1,13 @@
+/* Self-hosted Plus Jakarta Sans (weights used by tailwind.config.mjs). Bundled
+   by Vite and served from our own origin, so it works under the app's CSP
+   (font-src 'self') without the Google Fonts CDN — which style-src-elem/font-src
+   block, leaving every page on the system fallback font (issue #1230). Must
+   precede the @tailwind directives: CSS requires @import before other rules. */
+@import '@fontsource/plus-jakarta-sans/400.css';
+@import '@fontsource/plus-jakarta-sans/500.css';
+@import '@fontsource/plus-jakarta-sans/600.css';
+@import '@fontsource/plus-jakarta-sans/700.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1,12 +1,20 @@
-/* Self-hosted Plus Jakarta Sans (weights used by tailwind.config.mjs). Bundled
-   by Vite and served from our own origin, so it works under the app's CSP
-   (font-src 'self') without the Google Fonts CDN — which style-src-elem/font-src
-   block, leaving every page on the system fallback font (issue #1230). Must
-   precede the @tailwind directives: CSS requires @import before other rules. */
-@import '@fontsource/plus-jakarta-sans/400.css';
-@import '@fontsource/plus-jakarta-sans/500.css';
-@import '@fontsource/plus-jakarta-sans/600.css';
-@import '@fontsource/plus-jakarta-sans/700.css';
+/* Self-hosted Plus Jakarta Sans — the family in tailwind.config.mjs, weights
+   400/500/600/700. Bundled by Vite and served from our own origin, so the CSS
+   passes style-src-elem 'self' and the .woff2 files pass font-src 'self' — the
+   Google Fonts CDN failed both directives, leaving every page on the system
+   fallback font (issue #1230). Only the latin + latin-ext subsets are imported
+   (the UI is English; this drops the cyrillic-ext/vietnamese subsets the bare
+   weight entrypoints would otherwise pull in). These @imports must stay above
+   the @tailwind directives: Vite's postcss-import resolves them at build time
+   and drops any @import that isn't first. */
+@import '@fontsource/plus-jakarta-sans/latin-400.css';
+@import '@fontsource/plus-jakarta-sans/latin-500.css';
+@import '@fontsource/plus-jakarta-sans/latin-600.css';
+@import '@fontsource/plus-jakarta-sans/latin-700.css';
+@import '@fontsource/plus-jakarta-sans/latin-ext-400.css';
+@import '@fontsource/plus-jakarta-sans/latin-ext-500.css';
+@import '@fontsource/plus-jakarta-sans/latin-ext-600.css';
+@import '@fontsource/plus-jakarta-sans/latin-ext-700.css';
 
 @tailwind base;
 @tailwind components;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12557,7 +12557,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.85.3': {}
 
@@ -14009,7 +14011,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(jsdom@27.4.0)(vite@8.0.12(@types/node@25.9.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(jsdom@27.4.0)(vite@8.0.12(@types/node@25.9.2)(esbuild@0.27.2)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@4.1.8':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -512,6 +512,9 @@ importers:
       '@astrojs/tailwind':
         specifier: ^6.0.0
         version: 6.0.2(astro@6.4.5(@types/node@25.9.2)(ioredis@5.10.1)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.61.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.9.0))
+      '@fontsource/plus-jakarta-sans':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@hookform/resolvers':
         specifier: ^5.4.0
         version: 5.4.0(react-hook-form@7.75.0(react@19.2.7))
@@ -2290,6 +2293,9 @@ packages:
   '@firebase/util@1.14.0':
     resolution: {integrity: sha512-/gnejm7MKkVIXnSJGpc9L2CvvvzJvtDPeAEq5jAwgVlf/PeNxot+THx/bpD20wQ8uL5sz0xqgXy1nisOYMU+mw==}
     engines: {node: '>=20.0.0'}
+
+  '@fontsource/plus-jakarta-sans@5.2.8':
+    resolution: {integrity: sha512-P5qE49fqdeD+7DXH1KBxmMPlB17LTz1zvBhFH0tFzfnYTKVJVyb0pR6plh0ZGXxcB+Oayb54FZZw3V42/DawTw==}
 
   '@google-cloud/firestore@7.11.6':
     resolution: {integrity: sha512-EW/O8ktzwLfyWBOsNuhRoMi8lrC3clHM5LVFhGvO1HCsLozCOOXRAlHrYBoE6HL42Sc8yYMuCb2XqcnJ4OOEpw==}
@@ -11732,6 +11738,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@fontsource/plus-jakarta-sans@5.2.8': {}
+
   '@google-cloud/firestore@7.11.6':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -12549,9 +12557,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.85.3': {}
 
@@ -14003,7 +14009,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(jsdom@27.4.0)(vite@8.0.12(@types/node@25.9.2)(esbuild@0.27.2)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(jsdom@27.4.0)(vite@8.0.12(@types/node@25.9.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@4.1.8':
     dependencies:


### PR DESCRIPTION
Closes #1230.

## Problem
All four layouts load *Plus Jakarta Sans* from the Google Fonts CDN, but the app's CSP allows neither `https://fonts.googleapis.com` in `style-src-elem` nor `https://fonts.gstatic.com` in `font-src`. The browser blocks the stylesheet on **every page**, silently dropping the UI to the system fallback font. This is not specific to self-hosted domains — the CSP is identical on `2breeze.app`.

```
Loading the stylesheet 'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:...'
violates the following CSP directive: "style-src-elem 'self' 'unsafe-inline' ...". Blocked.
```

## Fix
Self-host the font via `@fontsource/plus-jakarta-sans` (weights 400/500/600/700, matching `tailwind.config.mjs`), imported once in `globals.css`. Vite bundles the woff2 and serves it from our own origin, so it passes `font-src 'self'` with **no CSP change** and no third-party CDN — consistent with the Monaco self-host in #1143/#1023. The static `@fontsource` package keeps the family name `'Plus Jakarta Sans'`, so tailwind needs no change. Removed the now-dead Google `<link>`/`<preconnect>` tags from all four layouts.

## Verification (production build + live SSR render)
- No `fonts.googleapis` reference in any rendered page (`/login`, `/scripts/new`, …).
- `@font-face` resolves to `/_astro/plus-jakarta-sans-*.woff2`, served **`200 font/woff2`** from `'self'`.
- CSP `font-src 'self' data:` covers it.
- 84 web tests pass; `tsc --noEmit` clean.

## Context
One of three distinct problems surfaced from the same console log as #1186 (the Monaco white-box bug, fixed in #1233). The other two (#1231 docs-iframe framing, #1232 CSP script-hash drift) turned out to be **already handled at HEAD / not reproducible** — see my notes on those issues. This font one is the only genuinely-shipping bug of the set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)