### PR TITLE
fix(scripts): soft-delete so deletion works once a script has run (#1208)

### DIFF
--- a/apps/api/migrations/2026-06-10-c-scripts-soft-delete.sql
+++ b/apps/api/migrations/2026-06-10-c-scripts-soft-delete.sql
@@ -1,0 +1,12 @@
+-- Soft delete for scripts (issue #1208).
+--
+-- Hard `DELETE FROM scripts` violates the FK constraints from script_executions
+-- / script_execution_batches (ON DELETE NO ACTION) as soon as a script has been
+-- run, so the delete throws a 500 and the script can never be removed. We switch
+-- to soft delete: the DELETE handler stamps deleted_at and all read paths filter
+-- `deleted_at IS NULL`, preserving execution history while hiding the script.
+
+ALTER TABLE scripts ADD COLUMN IF NOT EXISTS deleted_at timestamp;
+
+-- Partial index keeps the common "active scripts" listing fast.
+CREATE INDEX IF NOT EXISTS scripts_active_idx ON scripts (org_id) WHERE deleted_at IS NULL;

--- a/apps/api/migrations/2026-06-10-c-scripts-soft-delete.sql
+++ b/apps/api/migrations/2026-06-10-c-scripts-soft-delete.sql
@@ -3,8 +3,9 @@
 -- Hard `DELETE FROM scripts` violates the FK constraints from script_executions
 -- / script_execution_batches (ON DELETE NO ACTION) as soon as a script has been
 -- run, so the delete throws a 500 and the script can never be removed. We switch
--- to soft delete: the DELETE handler stamps deleted_at and all read paths filter
--- `deleted_at IS NULL`, preserving execution history while hiding the script.
+-- to soft delete: the DELETE handler stamps deleted_at and the listing/lookup
+-- read paths filter `deleted_at IS NULL`. Execution-history joins intentionally
+-- do NOT filter it, so past runs still show the script name.
 
 ALTER TABLE scripts ADD COLUMN IF NOT EXISTS deleted_at timestamp;
 

--- a/apps/api/src/__tests__/integration/scripts-soft-delete.integration.test.ts
+++ b/apps/api/src/__tests__/integration/scripts-soft-delete.integration.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Integration test for issue #1208 — user-created scripts cannot be deleted.
+ *
+ * Root cause: `scripts` is referenced by `script_executions` /
+ * `script_execution_batches` via FK constraints with the default
+ * `ON DELETE NO ACTION`. Once a script has been run, a hard
+ * `DELETE FROM scripts` throws a foreign-key violation, so the API
+ * returned 500 and the script could never be removed.
+ *
+ * Fix: soft delete. The DELETE handler stamps `deleted_at` instead of
+ * hard-deleting, which never trips the FK and preserves execution history.
+ *
+ * These tests run against a real Postgres (the mock-based unit suite cannot
+ * enforce FK behavior). They prove, with a script that has execution history:
+ *
+ *   1. A hard `DELETE FROM scripts` still throws the FK violation — this
+ *      documents *why* the soft delete exists and fails loudly if anyone
+ *      reverts to a hard delete.
+ *   2. The soft delete (UPDATE deleted_at) succeeds on the same row.
+ *   3. The execution-history row is preserved after the soft delete.
+ */
+import './setup';
+import { describe, it, expect } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { scripts, scriptExecutions, devices } from '../../db/schema';
+import { createPartner, createOrganization, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+async function seedScriptWithExecution() {
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const site = await createSite({ orgId: org.id });
+  const suffix = `${Date.now()}-${Math.floor(performance.now())}`;
+
+  return withSystemDbAccessContext(async () => {
+    const [script] = await db
+      .insert(scripts)
+      .values({
+        orgId: org.id,
+        name: `soft-delete-${suffix}`,
+        osTypes: ['linux'],
+        language: 'bash',
+        content: 'echo hi',
+        isSystem: false
+      })
+      .returning();
+
+    const [device] = await db
+      .insert(devices)
+      .values({
+        orgId: org.id,
+        siteId: site.id,
+        agentId: `agent-${suffix}`,
+        hostname: `host-${suffix}`,
+        osType: 'linux',
+        osVersion: '1.0',
+        architecture: 'x64',
+        agentVersion: '0.0.0'
+      })
+      .returning();
+
+    // Completed (not active) execution — the active-execution guard would not
+    // block deletion, but this row still holds the FK reference.
+    await db.insert(scriptExecutions).values({
+      scriptId: script!.id,
+      deviceId: device!.id,
+      orgId: org.id,
+      status: 'completed'
+    });
+
+    return { scriptId: script!.id, orgId: org.id };
+  });
+}
+
+describe('scripts soft delete — issue #1208', () => {
+  it('hard DELETE still throws an FK violation when execution history exists', async () => {
+    const { scriptId } = await seedScriptWithExecution();
+
+    let caught: unknown;
+    try {
+      await withSystemDbAccessContext(async () => {
+        await db.delete(scripts).where(eq(scripts.id, scriptId));
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeDefined();
+    const message = `${(caught as Error)?.message ?? ''} ${
+      (caught as { cause?: { message?: string } })?.cause?.message ?? ''
+    }`;
+    expect(message).toMatch(/violates foreign key constraint/);
+    expect(message).toMatch(/script_executions/);
+  });
+
+  it('soft delete (UPDATE deleted_at) succeeds and preserves execution history', async () => {
+    const { scriptId } = await seedScriptWithExecution();
+
+    const updated = await withSystemDbAccessContext(async () =>
+      db
+        .update(scripts)
+        .set({ deletedAt: new Date() })
+        .where(eq(scripts.id, scriptId))
+        .returning({ id: scripts.id })
+    );
+
+    expect(updated).toHaveLength(1);
+
+    // The row is marked deleted...
+    const [row] = await getTestDb().select().from(scripts).where(eq(scripts.id, scriptId));
+    expect(row?.deletedAt).not.toBeNull();
+
+    // ...and its execution history is preserved (FK intact, not cascaded away).
+    const history = await getTestDb()
+      .select()
+      .from(scriptExecutions)
+      .where(eq(scriptExecutions.scriptId, scriptId));
+    expect(history).toHaveLength(1);
+  });
+});

--- a/apps/api/src/db/schema/scripts.ts
+++ b/apps/api/src/db/schema/scripts.ts
@@ -33,7 +33,11 @@ export const scripts = pgTable('scripts', {
   exitCodeSeverityMapping: jsonb('exit_code_severity_mapping').$type<ScriptExitCodeSeverityMapping>(),
   createdBy: uuid('created_by').references(() => users.id),
   createdAt: timestamp('created_at').defaultNow().notNull(),
-  updatedAt: timestamp('updated_at').defaultNow().notNull()
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  // Soft delete. Hard deletes fail with FK violations once a script has any
+  // execution history (script_executions / batches reference it), so deleting
+  // a script marks it here instead. All read paths filter `deletedAt IS NULL`.
+  deletedAt: timestamp('deleted_at')
 });
 
 export const scriptCategories = pgTable('script_categories', {

--- a/apps/api/src/db/schema/scripts.ts
+++ b/apps/api/src/db/schema/scripts.ts
@@ -36,7 +36,9 @@ export const scripts = pgTable('scripts', {
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
   // Soft delete. Hard deletes fail with FK violations once a script has any
   // execution history (script_executions / batches reference it), so deleting
-  // a script marks it here instead. All read paths filter `deletedAt IS NULL`.
+  // a script marks it here instead. Listing/lookup read paths filter
+  // `deletedAt IS NULL`; execution-history joins intentionally keep it so past
+  // runs still show the script name.
   deletedAt: timestamp('deleted_at')
 });
 

--- a/apps/api/src/jobs/deploymentWorker.ts
+++ b/apps/api/src/jobs/deploymentWorker.ts
@@ -1,7 +1,7 @@
 import { Queue, Worker, Job } from 'bullmq';
 import { db } from '../db';
 import { deployments, deploymentDevices, devices, deviceCommands, scripts, users, organizationUsers, patches } from '../db/schema';
-import { eq, and, asc, inArray, sql } from 'drizzle-orm';
+import { eq, and, asc, inArray, isNull, sql } from 'drizzle-orm';
 import {
   getDeploymentProgress,
   shouldPauseDeployment,
@@ -824,7 +824,7 @@ async function executeScriptPayload(
   const [script] = await db
     .select()
     .from(scripts)
-    .where(eq(scripts.id, payload.scriptId))
+    .where(and(eq(scripts.id, payload.scriptId), isNull(scripts.deletedAt)))
     .limit(1);
 
   if (!script) {

--- a/apps/api/src/routes/mcpServer.ts
+++ b/apps/api/src/routes/mcpServer.ts
@@ -26,7 +26,7 @@ import { getToolDefinitions, executeTool, getToolTier } from '../services/aiTool
 import { checkGuardrails, checkToolPermission, checkToolRateLimit } from '../services/aiGuardrails';
 import { db, withSystemDbAccessContext } from '../db';
 import { devices, alerts, scripts, automations, partners, organizations, partnerUsers } from '../db/schema';
-import { eq, and, asc, desc, inArray, getTableColumns, type SQL } from 'drizzle-orm';
+import { eq, and, asc, desc, inArray, isNull, getTableColumns, type SQL } from 'drizzle-orm';
 import type { PgColumn } from 'drizzle-orm/pg-core';
 import type { AuthContext } from '../middleware/auth';
 import { siteAccessCheck } from '../middleware/auth';
@@ -1385,7 +1385,7 @@ async function handleResourcesRead(
         description: scripts.description,
         language: scripts.language,
         category: scripts.category
-      }, orgCond(scripts.orgId), { limit: 200 });
+      }, orgCond(scripts.orgId), { extraConditions: [isNull(scripts.deletedAt)], limit: 200 });
     }
 
     if (uri === 'breeze://automations') {

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { and, desc, eq, gte, ilike, inArray, like, or, sql } from 'drizzle-orm';
+import { and, desc, eq, gte, ilike, inArray, isNull, like, or, sql } from 'drizzle-orm';
 import { createHash } from 'crypto';
 import { db } from '../db';
 import {
@@ -931,7 +931,7 @@ mobileRoutes.post(
       const [script] = await db
         .select()
         .from(scripts)
-        .where(eq(scripts.id, data.scriptId as string))
+        .where(and(eq(scripts.id, data.scriptId as string), isNull(scripts.deletedAt)))
         .limit(1);
 
       if (!script) {

--- a/apps/api/src/routes/policyManagement/crud.ts
+++ b/apps/api/src/routes/policyManagement/crud.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { and, desc, eq, inArray, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
 import { db } from '../../db';
 import { automationPolicies, automationPolicyCompliance, scripts } from '../../db/schema';
 import { requireScope } from '../../middleware/auth';
@@ -121,7 +121,7 @@ crudRoutes.get(
       const [script] = await db
         .select({ id: scripts.id, name: scripts.name })
         .from(scripts)
-        .where(eq(scripts.id, policy.remediationScriptId))
+        .where(and(eq(scripts.id, policy.remediationScriptId), isNull(scripts.deletedAt)))
         .limit(1);
 
       remediationScript = script ?? null;

--- a/apps/api/src/routes/scripts.test.ts
+++ b/apps/api/src/routes/scripts.test.ts
@@ -301,6 +301,51 @@ describe('scripts routes', () => {
     expect(body.success).toBe(true);
   });
 
+  it('should soft-delete (not hard-delete) so scripts with execution history can be removed', async () => {
+    // Script exists, and the active-execution guard sees zero ACTIVE executions
+    // (completed/failed executions may still exist and hold FK references).
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: SCRIPT_ID_1,
+              name: 'Script One',
+              isSystem: false,
+              orgId: ORG_ID
+            }])
+          })
+        })
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ count: 0 }])
+        })
+      } as any);
+
+    const setMock = vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined)
+    });
+    vi.mocked(db.update).mockReturnValue({ set: setMock } as any);
+
+    const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer valid-token' }
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    // Must be a soft delete: UPDATE the row (set deletedAt), never a hard DELETE
+    // — a hard DELETE throws an FK violation when execution history exists.
+    expect(db.update).toHaveBeenCalled();
+    expect(db.delete).not.toHaveBeenCalled();
+    expect(setMock).toHaveBeenCalledWith(
+      expect.objectContaining({ deletedAt: expect.any(Date) })
+    );
+  });
+
   it.skip('should execute a script against multiple devices', async () => {
     // Skipped: Complex mock chain requires e2e testing
     vi.mocked(db.select)

--- a/apps/api/src/routes/scripts.test.ts
+++ b/apps/api/src/routes/scripts.test.ts
@@ -11,6 +11,10 @@ const EXECUTION_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
 // Mock all services
 vi.mock('../services', () => ({}));
 
+vi.mock('../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn()
+}));
+
 vi.mock('../db', () => ({
   db: {
     select: vi.fn(() => ({
@@ -99,6 +103,7 @@ vi.mock('../middleware/auth', () => ({
 }));
 
 import { db } from '../db';
+import { writeRouteAudit } from '../services/auditEvents';
 
 describe('scripts routes', () => {
   let app: Hono;
@@ -268,7 +273,9 @@ describe('scripts routes', () => {
     expect(body.error).toContain('active executions');
   });
 
-  it('should delete scripts without active executions', async () => {
+  // Mocks the script-found SELECT then the zero-active-executions count SELECT
+  // that the DELETE handler runs before deleting.
+  function mockDeletePreflight(): void {
     vi.mocked(db.select)
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
@@ -287,46 +294,25 @@ describe('scripts routes', () => {
           where: vi.fn().mockResolvedValue([{ count: 0 }])
         })
       } as any);
-    vi.mocked(db.delete).mockReturnValue({
-      where: vi.fn().mockResolvedValue(undefined)
-    } as any);
+  }
 
-    const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
-      method: 'DELETE',
-      headers: { Authorization: 'Bearer valid-token' }
+  // Builds the db.update mock chain (set -> where -> returning) used by the
+  // soft-delete handler, resolving the returning() call with `returnedRows`.
+  function mockSoftDeleteUpdate(returnedRows: Array<{ id: string }>) {
+    const setMock = vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue(returnedRows)
+      })
     });
-
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.success).toBe(true);
-  });
+    vi.mocked(db.update).mockReturnValue({ set: setMock } as any);
+    return setMock;
+  }
 
   it('should soft-delete (not hard-delete) so scripts with execution history can be removed', async () => {
     // Script exists, and the active-execution guard sees zero ACTIVE executions
     // (completed/failed executions may still exist and hold FK references).
-    vi.mocked(db.select)
-      .mockReturnValueOnce({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([{
-              id: SCRIPT_ID_1,
-              name: 'Script One',
-              isSystem: false,
-              orgId: ORG_ID
-            }])
-          })
-        })
-      } as any)
-      .mockReturnValueOnce({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue([{ count: 0 }])
-        })
-      } as any);
-
-    const setMock = vi.fn().mockReturnValue({
-      where: vi.fn().mockResolvedValue(undefined)
-    });
-    vi.mocked(db.update).mockReturnValue({ set: setMock } as any);
+    mockDeletePreflight();
+    const setMock = mockSoftDeleteUpdate([{ id: SCRIPT_ID_1 }]);
 
     const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
       method: 'DELETE',
@@ -344,6 +330,24 @@ describe('scripts routes', () => {
     expect(setMock).toHaveBeenCalledWith(
       expect.objectContaining({ deletedAt: expect.any(Date) })
     );
+  });
+
+  it('should return 404 (not a false success) when the soft-delete UPDATE matches zero rows', async () => {
+    // Simulates losing a race with a concurrent delete: the row is gone/already
+    // soft-deleted by the time the UPDATE runs, so returning() yields no rows.
+    mockDeletePreflight();
+    mockSoftDeleteUpdate([]);
+
+    const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer valid-token' }
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.success).toBeUndefined();
+    // No audit entry should be written for a delete that changed nothing.
+    expect(writeRouteAudit).not.toHaveBeenCalled();
   });
 
   it.skip('should execute a script against multiple devices', async () => {

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -39,7 +39,7 @@ async function getScriptWithOrgCheck(scriptId: string, auth: { canAccessOrg: (or
   const [script] = await db
     .select()
     .from(scripts)
-    .where(eq(scripts.id, scriptId))
+    .where(and(eq(scripts.id, scriptId), isNull(scripts.deletedAt)))
     .limit(1);
 
   if (!script) {
@@ -159,6 +159,9 @@ scriptRoutes.get(
 
     // Build conditions array
     const conditions: ReturnType<typeof eq>[] = [];
+
+    // Exclude soft-deleted scripts
+    conditions.push(isNull(scripts.deletedAt) as ReturnType<typeof eq>);
 
     // Filter by org access based on scope
     if (auth.scope === 'organization') {
@@ -287,7 +290,7 @@ scriptRoutes.get(
         language: scripts.language,
       })
       .from(scripts)
-      .where(eq(scripts.isSystem, true))
+      .where(and(eq(scripts.isSystem, true), isNull(scripts.deletedAt)))
       .orderBy(scripts.category, scripts.name);
 
     return c.json({ data: systemScripts });
@@ -311,7 +314,7 @@ scriptRoutes.post(
     const [source] = await db
       .select()
       .from(scripts)
-      .where(and(eq(scripts.id, sourceId), eq(scripts.isSystem, true)))
+      .where(and(eq(scripts.id, sourceId), eq(scripts.isSystem, true), isNull(scripts.deletedAt)))
       .limit(1);
 
     if (!source) {
@@ -352,7 +355,7 @@ scriptRoutes.post(
     const [existing] = await db
       .select({ id: scripts.id })
       .from(scripts)
-      .where(and(eq(scripts.orgId, orgId), eq(scripts.name, source.name)))
+      .where(and(eq(scripts.orgId, orgId), eq(scripts.name, source.name), isNull(scripts.deletedAt)))
       .limit(1);
 
     if (existing) {
@@ -599,11 +602,13 @@ scriptRoutes.delete(
       }, 409);
     }
 
-    // Soft delete by setting orgId to null and renaming (or use a deletedAt field if available)
-    // Since schema doesn't have deletedAt, we'll do a hard delete for now
-    // In production, you'd want to add a deletedAt column
+    // Soft delete: a hard `DELETE` throws an FK violation once the script has
+    // any execution history (script_executions / batches reference it), so we
+    // stamp deletedAt instead. All read paths filter `deletedAt IS NULL`, which
+    // hides the script while preserving its execution history.
     await db
-      .delete(scripts)
+      .update(scripts)
+      .set({ deletedAt: new Date() })
       .where(eq(scripts.id, scriptId));
 
     writeRouteAudit(c, {

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -604,12 +604,20 @@ scriptRoutes.delete(
 
     // Soft delete: a hard `DELETE` throws an FK violation once the script has
     // any execution history (script_executions / batches reference it), so we
-    // stamp deletedAt instead. All read paths filter `deletedAt IS NULL`, which
-    // hides the script while preserving its execution history.
-    await db
+    // stamp deletedAt instead. Script listing/lookup paths filter
+    // `deletedAt IS NULL` to hide it; execution-history joins intentionally do
+    // not, so past runs still show the script name. The `isNull` guard in the
+    // WHERE makes a concurrent re-delete a genuine no-op the row-count catches.
+    const [deleted] = await db
       .update(scripts)
       .set({ deletedAt: new Date() })
-      .where(eq(scripts.id, scriptId));
+      .where(and(eq(scripts.id, scriptId), isNull(scripts.deletedAt)))
+      .returning({ id: scripts.id });
+
+    if (!deleted) {
+      // Lost a race with a concurrent delete; surface it instead of a false success.
+      return c.json({ error: 'Script not found' }, 404);
+    }
 
     writeRouteAudit(c, {
       orgId: resolveScriptAuditOrgId(auth, script.orgId),

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { and, ilike, or } from 'drizzle-orm';
+import { and, ilike, isNull, or } from 'drizzle-orm';
 import type { PgColumn } from 'drizzle-orm/pg-core';
 import { db } from '../db';
 import { alerts, devices, scripts } from '../db/schema';
@@ -58,9 +58,12 @@ searchRoutes.get('/', zValidator('query', searchQuerySchema), async (c) => {
     ilike(devices.displayName, searchTerm),
     ilike(devices.lastUser, searchTerm)
   );
-  const scriptQuery = or(
-    ilike(scripts.name, searchTerm),
-    ilike(scripts.description, searchTerm)
+  const scriptQuery = and(
+    isNull(scripts.deletedAt),
+    or(
+      ilike(scripts.name, searchTerm),
+      ilike(scripts.description, searchTerm)
+    )
   );
   const alertQuery = or(
     ilike(alerts.title, searchTerm),

--- a/apps/api/src/services/aiToolsScripts.ts
+++ b/apps/api/src/services/aiToolsScripts.ts
@@ -25,7 +25,7 @@ import {
   scriptTemplates,
   scriptExecutions,
 } from '../db/schema';
-import { eq, and, desc, sql, ilike, SQL } from 'drizzle-orm';
+import { eq, and, desc, sql, ilike, isNull, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import { escapeLike } from '../utils/sql';
 import type { AiTool } from './aiTools';
@@ -143,7 +143,7 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
       const results: Record<string, unknown> = {};
 
       // Resolve script content upfront so the agent receives the full payload
-      const scriptConditions: SQL[] = [eq(scripts.id, input.scriptId as string)];
+      const scriptConditions: SQL[] = [eq(scripts.id, input.scriptId as string), isNull(scripts.deletedAt)];
       const orgCond = auth.orgCondition(scripts.orgId);
       if (orgCond) scriptConditions.push(orgCond);
 
@@ -328,7 +328,7 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
       },
     },
     handler: async (input, auth) => {
-      const conditions: SQL[] = [];
+      const conditions: SQL[] = [isNull(scripts.deletedAt)];
       const orgCondition = auth.orgCondition(scripts.orgId);
       if (orgCondition) conditions.push(orgCondition);
 
@@ -388,7 +388,7 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
       const includeExecutionStats = (input.includeExecutionStats as boolean) ?? false;
 
       // Query script with org scoping
-      const conditions: SQL[] = [eq(scripts.id, scriptId)];
+      const conditions: SQL[] = [eq(scripts.id, scriptId), isNull(scripts.deletedAt)];
       const orgCond = auth.orgCondition(scripts.orgId);
       if (orgCond) conditions.push(orgCond);
 
@@ -529,7 +529,7 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
     },
     handler: async (input, auth) => {
       // Verify the script belongs to the user's org before returning execution data
-      const scriptConditions: SQL[] = [eq(scripts.id, input.scriptId as string)];
+      const scriptConditions: SQL[] = [eq(scripts.id, input.scriptId as string), isNull(scripts.deletedAt)];
       const orgCondition = auth.orgCondition(scripts.orgId);
       if (orgCondition) scriptConditions.push(orgCondition);
 
@@ -592,7 +592,7 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
       const includeTemplates = (input.includeTemplates as boolean) ?? false;
 
       // Query org scripts
-      const conditions: SQL[] = [];
+      const conditions: SQL[] = [isNull(scripts.deletedAt)];
       const orgCond = auth.orgCondition(scripts.orgId);
       if (orgCond) conditions.push(orgCond);
 

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'crypto';
-import { and, eq, inArray, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 import type { DeploymentTargetConfig } from '@breeze/shared';
 import { db } from '../db';
 import {
@@ -1289,7 +1289,7 @@ export async function executeAutomationRun(
     ? await db
       .select()
       .from(scripts)
-      .where(inArray(scripts.id, scriptIds))
+      .where(and(inArray(scripts.id, scriptIds), isNull(scripts.deletedAt)))
     : [];
 
   const scriptsById = new Map(scriptRows.map((script) => [script.id, script]));
@@ -1701,7 +1701,7 @@ export async function executeConfigPolicyAutomationRun(
   )];
 
   const scriptRows = scriptIds.length > 0
-    ? await db.select().from(scripts).where(inArray(scripts.id, scriptIds))
+    ? await db.select().from(scripts).where(and(inArray(scripts.id, scriptIds), isNull(scripts.deletedAt)))
     : [];
   const scriptsById = new Map(scriptRows.map((s) => [s.id, s]));
 


### PR DESCRIPTION
## Problem

Deleting a user-created script that had ever run silently failed (issue #1208). The confirmation toast claimed success, but on refresh the script remained — and a second delete surfaced an error.

**Root cause:** the `DELETE /scripts/:id` handler hard-deleted the row, but `script_executions` and `script_execution_batches` hold `ON DELETE NO ACTION` foreign keys to `scripts`. Once a script had any execution history, Postgres raised a foreign-key violation and the API returned 500. The handler only guarded against *active* (pending/queued/running) executions, so completed/failed runs left the script permanently undeletable while still fully editable — matching the report exactly.

Reproduced against a live DB: a childless script deletes fine, but a script with one `completed` execution throws `update or delete on table "scripts" violates foreign key constraint "script_executions_script_id_scripts_id_fk"`.

## Fix

Switch script deletion to **soft delete**, which preserves execution history (audit-relevant in an RMM) and matches the handler's own pre-existing TODO comment.

- **Migration** `2026-06-10-c-scripts-soft-delete.sql`: adds nullable `deleted_at` + a partial index on active rows. Idempotent; verified re-applies as a no-op.
- **DELETE handler**: stamps `deletedAt` instead of hard-deleting. Re-deleting an already-removed script now returns a clean **404** instead of a 500.
- **Read paths**: filter `deletedAt IS NULL` everywhere a script is read — list/get, system-library + import dup-check, full-text search, mobile `run_script`, policy remediation lookup, deployment worker, automation runtime, and AI tools. The active-execution 409 guard is retained.

## Verification

- New unit test asserts the handler soft-deletes (UPDATE `deletedAt`) and never hard-deletes; full `scripts.test.ts` green (15 passed).
- Affected suites green: scripts, mobile, search, automationRuntime, deploymentWorker (70 passed).
- `tsc --noEmit`: no new errors (only the 5 pre-existing `archiver` type errors).
- Live DB: a script with a completed execution now soft-deletes, disappears from the active list, and **keeps its execution history**.

## Note

The web delete uses a 5s deferred `setTimeout` undo. With the server fixed the delete now succeeds, but that timer is still lost if the user navigates away mid-window — a separate UX hardening worth a follow-up, not addressed here.

Closes #1208

🤖 Generated with [Claude Code](https://claude.com/claude-code)