### PR TITLE
feat(pam): approver/denier display names + audit tab live refresh (#1159 follow-up)

### DIFF
--- a/apps/api/src/routes/pam.test.ts
+++ b/apps/api/src/routes/pam.test.ts
@@ -34,6 +34,7 @@ vi.mock('../db', () => ({
 vi.mock('../db/schema', () => ({
   devices: { id: 'id', hostname: 'hostname' },
   sites: { id: 'id', name: 'name' },
+  users: { id: 'id', name: 'name' },
   elevationRequests: {
     id: 'id',
     orgId: 'orgId',
@@ -45,6 +46,9 @@ vi.mock('../db/schema', () => ({
     approvedAt: 'approvedAt',
     expiresAt: 'expiresAt',
     executionId: 'executionId',
+    approvedByUserId: 'approvedByUserId',
+    deniedByUserId: 'deniedByUserId',
+    revokedByUserId: 'revokedByUserId',
   },
   elevationAudit: { id: 'id' },
   pamRules: {
@@ -145,6 +149,21 @@ function app(): Hono {
   return a;
 }
 
+/** Rig db.select for the list/active read paths (count selects keyed on `total`). */
+function mockListSelect(rows: unknown[] = [], total = 0) {
+  vi.mocked(db.select).mockImplementation(((sel: Record<string, unknown> | undefined) => {
+    const isCount = Boolean(sel && 'total' in sel);
+    const chain: any = Promise.resolve(isCount ? [{ total }] : rows);
+    chain.from = vi.fn(() => chain);
+    chain.leftJoin = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.orderBy = vi.fn(() => chain);
+    chain.limit = vi.fn(() => chain);
+    chain.offset = vi.fn(() => chain);
+    return chain;
+  }) as any);
+}
+
 const activeRow = {
   id: REQ_ID,
   orgId: ORG_ID,
@@ -153,6 +172,68 @@ const activeRow = {
   flowType: 'uac_intercept',
   status: 'pending',
 };
+
+describe('GET /pam/elevation-requests and /pam/active — decider display names', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setAuth();
+  });
+
+  const listRow = {
+    request: {
+      id: REQ_ID,
+      orgId: ORG_ID,
+      deviceId: 'dev-1',
+      flowType: 'uac_intercept',
+      status: 'approved',
+      approvedByUserId: USER_ID,
+    },
+    deviceHostname: 'WS-ALPHA',
+    siteName: 'HQ',
+    approvedByName: 'Jane Admin',
+    deniedByName: null,
+    revokedByName: null,
+  };
+
+  it('list rows carry approvedByName/deniedByName/revokedByName from the user joins', async () => {
+    mockListSelect([listRow], 1);
+
+    const res = await app().request('/pam/elevation-requests');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.requests[0].approvedByName).toBe('Jane Admin');
+    expect(body.requests[0].deniedByName).toBeNull();
+    expect(body.requests[0].revokedByName).toBeNull();
+    // Existing joins are untouched.
+    expect(body.requests[0].deviceHostname).toBe('WS-ALPHA');
+    expect(body.requests[0].siteName).toBe('HQ');
+    expect(body.pagination).toEqual({ page: 1, limit: 50, total: 1 });
+
+    // The select projection asks for all three aliased user names.
+    const projection = vi.mocked(db.select).mock.calls[0]![0] as Record<string, unknown>;
+    expect(projection).toHaveProperty('approvedByName');
+    expect(projection).toHaveProperty('deniedByName');
+    expect(projection).toHaveProperty('revokedByName');
+  });
+
+  it('active rows carry the decider name fields', async () => {
+    mockListSelect([listRow]);
+
+    const res = await app().request('/pam/active');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.active[0].approvedByName).toBe('Jane Admin');
+    expect(body.active[0].revokedByName).toBeNull();
+    expect(body.active[0].deviceHostname).toBe('WS-ALPHA');
+
+    const projection = vi.mocked(db.select).mock.calls[0]![0] as Record<string, unknown>;
+    expect(projection).toHaveProperty('approvedByName');
+    expect(projection).toHaveProperty('deniedByName');
+    expect(projection).toHaveProperty('revokedByName');
+  });
+});
 
 describe('POST /pam/elevation-requests/:id/respond', () => {
   beforeEach(() => {
@@ -403,20 +484,6 @@ describe('ai_tool_action elevation requests (Phase 1)', () => {
     status: 'pending',
     executionId: 'exec-1',
   };
-
-  function mockListSelect(rows: unknown[] = [], total = 0) {
-    vi.mocked(db.select).mockImplementation(((sel: Record<string, unknown> | undefined) => {
-      const isCount = Boolean(sel && 'total' in sel);
-      const chain: any = Promise.resolve(isCount ? [{ total }] : rows);
-      chain.from = vi.fn(() => chain);
-      chain.leftJoin = vi.fn(() => chain);
-      chain.where = vi.fn(() => chain);
-      chain.orderBy = vi.fn(() => chain);
-      chain.limit = vi.fn(() => chain);
-      chain.offset = vi.fn(() => chain);
-      return chain;
-    }) as any);
-  }
 
   it('accepts flowType=ai_tool_action on the list filter', async () => {
     mockListSelect([], 0);

--- a/apps/api/src/routes/pam.ts
+++ b/apps/api/src/routes/pam.ts
@@ -21,6 +21,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { SQL, and, desc, eq, gt, gte, inArray, isNull, lte, or, sql } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
 import { z } from 'zod';
 
 import { db } from '../db';
@@ -30,6 +31,7 @@ import {
   elevationRequests,
   pamRules,
   sites,
+  users,
 } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { PERMISSIONS, canAccessSite, type UserPermissions } from '../services/permissions';
@@ -70,6 +72,14 @@ const DEFAULT_APPROVAL_DURATION_MINUTES = 15;
 const MAX_APPROVAL_DURATION_MINUTES = 24 * 60;
 
 const ACTIVE_STATUSES = ['approved', 'auto_approved', 'actuating'] as const;
+
+// Aliased user joins for the three decider columns (left joins — all three
+// ids are nullable). Reads run under the request's RLS context: a decider the
+// caller's users-policy can't see simply yields a null name (the UI falls
+// back to the user id).
+const approvedByUser = alias(users, 'approved_by_user');
+const deniedByUser = alias(users, 'denied_by_user');
+const revokedByUser = alias(users, 'revoked_by_user');
 
 export const pamRoutes = new Hono();
 pamRoutes.use('*', authMiddleware);
@@ -151,10 +161,16 @@ pamRoutes.get('/elevation-requests', requirePamRead, zValidator('query', listQue
         request: elevationRequests,
         deviceHostname: devices.hostname,
         siteName: sites.name,
+        approvedByName: approvedByUser.name,
+        deniedByName: deniedByUser.name,
+        revokedByName: revokedByUser.name,
       })
       .from(elevationRequests)
       .leftJoin(devices, eq(elevationRequests.deviceId, devices.id))
       .leftJoin(sites, eq(elevationRequests.siteId, sites.id))
+      .leftJoin(approvedByUser, eq(elevationRequests.approvedByUserId, approvedByUser.id))
+      .leftJoin(deniedByUser, eq(elevationRequests.deniedByUserId, deniedByUser.id))
+      .leftJoin(revokedByUser, eq(elevationRequests.revokedByUserId, revokedByUser.id))
       .where(where)
       .orderBy(desc(elevationRequests.requestedAt))
       .limit(limit)
@@ -171,6 +187,9 @@ pamRoutes.get('/elevation-requests', requirePamRead, zValidator('query', listQue
       ...r.request,
       deviceHostname: r.deviceHostname,
       siteName: r.siteName,
+      approvedByName: r.approvedByName,
+      deniedByName: r.deniedByName,
+      revokedByName: r.revokedByName,
     })),
     pagination: { page, limit, total: countRows[0]?.total ?? 0 },
   });
@@ -198,10 +217,16 @@ pamRoutes.get('/active', requirePamRead, async (c) => {
       request: elevationRequests,
       deviceHostname: devices.hostname,
       siteName: sites.name,
+      approvedByName: approvedByUser.name,
+      deniedByName: deniedByUser.name,
+      revokedByName: revokedByUser.name,
     })
     .from(elevationRequests)
     .leftJoin(devices, eq(elevationRequests.deviceId, devices.id))
     .leftJoin(sites, eq(elevationRequests.siteId, sites.id))
+    .leftJoin(approvedByUser, eq(elevationRequests.approvedByUserId, approvedByUser.id))
+    .leftJoin(deniedByUser, eq(elevationRequests.deniedByUserId, deniedByUser.id))
+    .leftJoin(revokedByUser, eq(elevationRequests.revokedByUserId, revokedByUser.id))
     .where(where)
     .orderBy(desc(elevationRequests.approvedAt))
     .limit(500);
@@ -212,6 +237,9 @@ pamRoutes.get('/active', requirePamRead, async (c) => {
       ...r.request,
       deviceHostname: r.deviceHostname,
       siteName: r.siteName,
+      approvedByName: r.approvedByName,
+      deniedByName: r.deniedByName,
+      revokedByName: r.revokedByName,
     })),
   });
 });

--- a/apps/web/src/components/pam/PamAuditTab.test.tsx
+++ b/apps/web/src/components/pam/PamAuditTab.test.tsx
@@ -35,6 +35,8 @@ const decided: ElevationRequest = {
   reason: 'Restart spooler, "quoted"',
   status: 'denied',
   denialReason: 'Out of window',
+  deniedByUserId: 'deadbeef-0000-4000-8000-000000000001',
+  deniedByName: 'Jane Admin',
   requestedAt: '2026-06-10T12:00:00.000Z',
 };
 
@@ -51,13 +53,60 @@ describe('PamAuditTab', () => {
         pagination: { page: 1, limit: 50, total: 1 },
       }),
     );
-    render(<PamAuditTab />);
+    render(<PamAuditTab liveTick={0} />);
     await waitFor(() => {
       expect(screen.getByTestId('pam-audit-row-aud-1')).toBeInTheDocument();
     });
     expect(screen.getByText('run_script')).toBeInTheDocument();
     // ai_tool_action rows carry a risk tier badge next to the target.
     expect(screen.getByTestId('pam-audit-risk-tier-aud-1')).toHaveTextContent('T2');
+  });
+
+  it('shows the decider display name, falling back to a truncated user id', async () => {
+    const revokedNoName: ElevationRequest = {
+      ...decided,
+      id: 'aud-2',
+      status: 'revoked',
+      deniedByUserId: null,
+      deniedByName: null,
+      revokedByUserId: 'deadbeef-0000-4000-8000-000000000001',
+    };
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        success: true,
+        requests: [decided, revokedNoName],
+        pagination: { page: 1, limit: 50, total: 2 },
+      }),
+    );
+    render(<PamAuditTab liveTick={0} />);
+    await waitFor(() => screen.getByTestId('pam-audit-row-aud-1'));
+    expect(screen.getByTestId('pam-audit-decided-by-aud-1')).toHaveTextContent('by Jane Admin');
+    expect(screen.getByTestId('pam-audit-decided-by-aud-1')).not.toHaveTextContent('deadbeef');
+    expect(screen.getByTestId('pam-audit-decided-by-aud-2')).toHaveTextContent('by deadbeef…');
+  });
+
+  it('refetches on a liveTick bump without clearing rendered rows', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        success: true,
+        requests: [decided],
+        pagination: { page: 1, limit: 50, total: 1 },
+      }),
+    );
+    const { rerender } = render(<PamAuditTab liveTick={0} />);
+    await waitFor(() => screen.getByTestId('pam-audit-row-aud-1'));
+    const callsBefore = fetchWithAuthMock.mock.calls.length;
+
+    // The refresh fetch never resolves so we can observe the mid-refresh state.
+    fetchWithAuthMock.mockImplementation(() => new Promise(() => {}) as Promise<Response>);
+    rerender(<PamAuditTab liveTick={1} />);
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock.mock.calls.length).toBe(callsBefore + 1);
+    });
+    // Rows stay rendered — no loading spinner replaces the table.
+    expect(screen.getByTestId('pam-audit-row-aud-1')).toBeInTheDocument();
+    expect(screen.queryByText(/Loading audit history/)).toBeNull();
   });
 
   it('refetches with a status filter applied', async () => {
@@ -68,7 +117,7 @@ describe('PamAuditTab', () => {
         pagination: { page: 1, limit: 50, total: 0 },
       }),
     );
-    render(<PamAuditTab />);
+    render(<PamAuditTab liveTick={0} />);
     await waitFor(() => screen.getByTestId('pam-audit-filter-status'));
     fireEvent.change(screen.getByTestId('pam-audit-filter-status'), {
       target: { value: 'denied' },
@@ -88,7 +137,7 @@ describe('PamAuditTab', () => {
         pagination: { page: 1, limit: 50, total: 0 },
       }),
     );
-    render(<PamAuditTab />);
+    render(<PamAuditTab liveTick={0} />);
     await waitFor(() => {
       expect(screen.getByTestId('pam-audit-export-btn')).toBeDisabled();
     });
@@ -108,5 +157,17 @@ describe('buildAuditCsv', () => {
   it('falls back to deviceId when hostname is missing', () => {
     const csv = buildAuditCsv([{ ...decided, deviceHostname: null }]);
     expect(csv.split('\n')[1]).toContain('dev-1');
+  });
+
+  it('exports decider columns, preferring display names over user ids', () => {
+    const csv = buildAuditCsv([decided]);
+    const lines = csv.split('\n');
+    expect(lines[0]).toContain('approvedBy,deniedBy,revokedBy');
+    expect(lines[1]).toContain('Jane Admin');
+    expect(lines[1]).not.toContain('deadbeef');
+
+    // Without the join, the full user id is exported (audit-grade fallback).
+    const fallbackCsv = buildAuditCsv([{ ...decided, deniedByName: null }]);
+    expect(fallbackCsv.split('\n')[1]).toContain('deadbeef-0000-4000-8000-000000000001');
   });
 });

--- a/apps/web/src/components/pam/PamAuditTab.tsx
+++ b/apps/web/src/components/pam/PamAuditTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Download, ScrollText } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
@@ -9,6 +9,7 @@ import {
   FLOW_LABELS,
   type Pagination,
   STATUS_LABELS,
+  decidedByLabel,
   requestTarget,
   statusBadgeClass,
 } from './types';
@@ -50,6 +51,9 @@ export function buildAuditCsv(rows: ElevationRequest[]): string {
     'reason',
     'denialReason',
     'revokedReason',
+    'approvedBy',
+    'deniedBy',
+    'revokedBy',
     'approvedAt',
     'expiresAt',
   ];
@@ -72,6 +76,11 @@ export function buildAuditCsv(rows: ElevationRequest[]): string {
         r.reason ?? '',
         r.denialReason ?? '',
         r.revokedReason ?? '',
+        // Prefer the joined display name; fall back to the full user id
+        // (audit-grade — no truncation in exports).
+        r.approvedByName ?? r.approvedByUserId ?? '',
+        r.deniedByName ?? r.deniedByUserId ?? '',
+        r.revokedByName ?? r.revokedByUserId ?? '',
         r.approvedAt ?? '',
         r.expiresAt ?? '',
       ]
@@ -82,7 +91,7 @@ export function buildAuditCsv(rows: ElevationRequest[]): string {
   return lines.join('\n');
 }
 
-export default function PamAuditTab() {
+export default function PamAuditTab({ liveTick }: { liveTick: number }) {
   const [rows, setRows] = useState<ElevationRequest[]>([]);
   const [pagination, setPagination] = useState<Pagination>({ page: 1, limit: 50, total: 0 });
   const [status, setStatus] = useState<ElevationStatus | ''>('');
@@ -109,8 +118,8 @@ export default function PamAuditTab() {
   );
 
   const fetchAudit = useCallback(
-    async (signal?: AbortSignal) => {
-      setLoading(true);
+    async (signal?: AbortSignal, opts: { silent?: boolean } = {}) => {
+      if (!opts.silent) setLoading(true);
       setError(null);
       try {
         const res = await fetchWithAuth(`/pam/elevation-requests?${buildParams(page, 50).toString()}`, {
@@ -136,11 +145,17 @@ export default function PamAuditTab() {
     [buildParams, page],
   );
 
+  // liveTick-driven refreshes are silent (rows stay rendered, same contract as
+  // the other tabs); filter/page changes (a new fetchAudit identity) show the
+  // loading state as before.
+  const lastTickRef = useRef(liveTick);
   useEffect(() => {
+    const silent = liveTick !== lastTickRef.current;
+    lastTickRef.current = liveTick;
     const controller = new AbortController();
-    void fetchAudit(controller.signal);
+    void fetchAudit(controller.signal, { silent });
     return () => controller.abort();
-  }, [fetchAudit]);
+  }, [fetchAudit, liveTick]);
 
   const exportCsv = async () => {
     if (exporting) return;
@@ -292,7 +307,9 @@ export default function PamAuditTab() {
               </tr>
             </thead>
             <tbody>
-              {rows.map((r) => (
+              {rows.map((r) => {
+                const decidedBy = decidedByLabel(r);
+                return (
                 <tr key={r.id} className="border-b last:border-0" data-testid={`pam-audit-row-${r.id}`}>
                   <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
                     {new Date(r.requestedAt).toLocaleString()}
@@ -326,9 +343,19 @@ export default function PamAuditTab() {
                     >
                       {STATUS_LABELS[r.status]}
                     </span>
+                    {decidedBy && (
+                      <div
+                        className="mt-0.5 max-w-[180px] truncate text-xs text-muted-foreground"
+                        data-testid={`pam-audit-decided-by-${r.id}`}
+                        title={`by ${decidedBy}`}
+                      >
+                        by {decidedBy}
+                      </div>
+                    )}
                   </td>
                 </tr>
-              ))}
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/apps/web/src/components/pam/PamOverviewTab.test.tsx
+++ b/apps/web/src/components/pam/PamOverviewTab.test.tsx
@@ -84,6 +84,72 @@ describe('PamOverviewTab', () => {
     expect(screen.getByText('No decided requests yet.')).toBeInTheDocument();
   });
 
+  it('shows the decider display name on recent decisions when joined by the API', async () => {
+    fetchWithAuthMock.mockImplementation(async (url: string) => {
+      if (url === '/pam/active') {
+        return makeJsonResponse({ success: true, active: [] });
+      }
+      if (url.includes('status=pending')) {
+        return makeJsonResponse({
+          success: true,
+          requests: [],
+          pagination: { page: 1, limit: 1, total: 0 },
+        });
+      }
+      return makeJsonResponse({
+        success: true,
+        requests: [
+          {
+            ...activeElevation,
+            id: 'dec-1',
+            status: 'denied',
+            deniedByUserId: 'deadbeef-0000-4000-8000-000000000001',
+            deniedByName: 'Jane Admin',
+          },
+        ],
+        pagination: { page: 1, limit: 10, total: 1 },
+      });
+    });
+
+    render(<PamOverviewTab liveTick={0} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pam-decided-by-dec-1')).toHaveTextContent('by Jane Admin');
+    });
+    expect(screen.getByTestId('pam-decided-by-dec-1')).not.toHaveTextContent('deadbeef');
+  });
+
+  it('falls back to a truncated user id when no name is joined', async () => {
+    fetchWithAuthMock.mockImplementation(async (url: string) => {
+      if (url === '/pam/active') {
+        return makeJsonResponse({ success: true, active: [] });
+      }
+      if (url.includes('status=pending')) {
+        return makeJsonResponse({
+          success: true,
+          requests: [],
+          pagination: { page: 1, limit: 1, total: 0 },
+        });
+      }
+      return makeJsonResponse({
+        success: true,
+        requests: [
+          {
+            ...activeElevation,
+            id: 'dec-2',
+            status: 'approved',
+            approvedByUserId: 'deadbeef-0000-4000-8000-000000000001',
+          },
+        ],
+        pagination: { page: 1, limit: 10, total: 1 },
+      });
+    });
+
+    render(<PamOverviewTab liveTick={0} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pam-decided-by-dec-2')).toHaveTextContent('by deadbeef…');
+    });
+  });
+
   it('surfaces an error banner when a query fails', async () => {
     fetchWithAuthMock.mockImplementation(async () => makeJsonResponse({}, false, 500));
     render(<PamOverviewTab liveTick={0} />);

--- a/apps/web/src/components/pam/PamOverviewTab.tsx
+++ b/apps/web/src/components/pam/PamOverviewTab.tsx
@@ -6,6 +6,7 @@ import {
   type ElevationRequest,
   FLOW_LABELS,
   STATUS_LABELS,
+  decidedByLabel,
   requestTarget,
   statusBadgeClass,
 } from './types';
@@ -161,20 +162,31 @@ export default function PamOverviewTab({ liveTick }: { liveTick: number }) {
           </div>
         ) : (
           <ul className="divide-y rounded-md border bg-card">
-            {data.recent.map((r) => (
-              <li key={r.id} className="flex items-center justify-between gap-3 px-3 py-2 text-sm">
-                <span className="min-w-0 flex-1 truncate" title={requestTarget(r)}>
-                  <span className="font-medium">{r.deviceHostname ?? r.deviceId}</span>
-                  <span className="text-muted-foreground"> · {r.subjectUsername} · </span>
-                  {requestTarget(r)}
-                </span>
-                <span
-                  className={`inline-flex shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${statusBadgeClass(r.status)}`}
-                >
-                  {STATUS_LABELS[r.status]}
-                </span>
-              </li>
-            ))}
+            {data.recent.map((r) => {
+              const decidedBy = decidedByLabel(r);
+              return (
+                <li key={r.id} className="flex items-center justify-between gap-3 px-3 py-2 text-sm">
+                  <span className="min-w-0 flex-1 truncate" title={requestTarget(r)}>
+                    <span className="font-medium">{r.deviceHostname ?? r.deviceId}</span>
+                    <span className="text-muted-foreground"> · {r.subjectUsername} · </span>
+                    {requestTarget(r)}
+                  </span>
+                  {decidedBy && (
+                    <span
+                      className="shrink-0 text-xs text-muted-foreground"
+                      data-testid={`pam-decided-by-${r.id}`}
+                    >
+                      by {decidedBy}
+                    </span>
+                  )}
+                  <span
+                    className={`inline-flex shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${statusBadgeClass(r.status)}`}
+                  >
+                    {STATUS_LABELS[r.status]}
+                  </span>
+                </li>
+              );
+            })}
           </ul>
         )}
       </section>

--- a/apps/web/src/components/pam/PamPage.tsx
+++ b/apps/web/src/components/pam/PamPage.tsx
@@ -123,7 +123,7 @@ export default function PamPage() {
       {activeTab === 'overview' && <PamOverviewTab liveTick={liveTick} />}
       {activeTab === 'requests' && <PamRequestsTab liveTick={liveTick} />}
       {activeTab === 'rules' && <PamRulesTab />}
-      {activeTab === 'audit' && <PamAuditTab />}
+      {activeTab === 'audit' && <PamAuditTab liveTick={liveTick} />}
     </div>
   );
 }

--- a/apps/web/src/components/pam/PamRequestsTab.test.tsx
+++ b/apps/web/src/components/pam/PamRequestsTab.test.tsx
@@ -159,6 +159,29 @@ describe('PamRequestsTab', () => {
     expect(screen.queryByTestId('pam-risk-tier-req-1')).toBeNull();
   });
 
+  it('shows who decided a request, preferring the joined display name', async () => {
+    const denied: ElevationRequest = {
+      ...pendingRequest,
+      id: 'req-3',
+      status: 'denied',
+      deniedByUserId: 'deadbeef-0000-4000-8000-000000000001',
+      deniedByName: 'Jane Admin',
+    };
+    const approvedNoName: ElevationRequest = {
+      ...pendingRequest,
+      id: 'req-4',
+      status: 'approved',
+      approvedByUserId: 'deadbeef-0000-4000-8000-000000000001',
+    };
+    fetchWithAuthMock.mockResolvedValueOnce(listResponse([denied, approvedNoName]));
+    render(<PamRequestsTab liveTick={0} />);
+    await waitFor(() => screen.getByTestId('pam-request-row-req-3'));
+    expect(screen.getByTestId('pam-decided-by-req-3')).toHaveTextContent('by Jane Admin');
+    expect(screen.getByTestId('pam-decided-by-req-3')).not.toHaveTextContent('deadbeef');
+    // Older cached rows without the join still show the truncated id.
+    expect(screen.getByTestId('pam-decided-by-req-4')).toHaveTextContent('by deadbeef…');
+  });
+
   it('fetches page=2 on Next and updates the footer range', async () => {
     fetchWithAuthMock.mockImplementation(async (url) => {
       const requestedPage = Number(

--- a/apps/web/src/components/pam/PamRequestsTab.tsx
+++ b/apps/web/src/components/pam/PamRequestsTab.tsx
@@ -12,6 +12,7 @@ import {
   FLOW_LABELS,
   type Pagination,
   STATUS_LABELS,
+  decidedByLabel,
   requestTarget,
   statusBadgeClass,
 } from './types';
@@ -162,6 +163,7 @@ export default function PamRequestsTab({ liveTick }: { liveTick: number }) {
               {requests.map((r) => {
                 const canRespond = r.status === 'pending';
                 const canRevoke = (ACTIVE_STATUSES as readonly string[]).includes(r.status);
+                const decidedBy = decidedByLabel(r);
                 return (
                   <tr key={r.id} className="border-b align-top last:border-0" data-testid={`pam-request-row-${r.id}`}>
                     <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
@@ -206,6 +208,15 @@ export default function PamRequestsTab({ liveTick }: { liveTick: number }) {
                       >
                         {STATUS_LABELS[r.status]}
                       </span>
+                      {decidedBy && (
+                        <div
+                          className="mt-0.5 max-w-[180px] truncate text-xs text-muted-foreground"
+                          data-testid={`pam-decided-by-${r.id}`}
+                          title={`by ${decidedBy}`}
+                        >
+                          by {decidedBy}
+                        </div>
+                      )}
                       {r.denialReason && (
                         <div className="mt-0.5 max-w-[180px] truncate text-xs text-muted-foreground" title={r.denialReason}>
                           {r.denialReason}

--- a/apps/web/src/components/pam/types.ts
+++ b/apps/web/src/components/pam/types.ts
@@ -33,6 +33,7 @@ export interface ElevationRequest {
   revokedReason?: string | null;
   approvedByUserId?: string | null;
   deniedByUserId?: string | null;
+  revokedByUserId?: string | null;
   denialReason?: string | null;
   toolName?: string | null;
   riskTier?: number | null;
@@ -40,6 +41,11 @@ export interface ElevationRequest {
   // Joined by the API
   deviceHostname?: string | null;
   siteName?: string | null;
+  // Decider display names joined by the API (null when unset or when the
+  // joined user row isn't visible to the caller).
+  approvedByName?: string | null;
+  deniedByName?: string | null;
+  revokedByName?: string | null;
 }
 
 export interface PamTimeWindow {
@@ -129,4 +135,29 @@ export function statusBadgeClass(status: ElevationStatus): string {
 export function requestTarget(r: ElevationRequest): string {
   if (r.flowType === 'ai_tool_action') return r.toolName ?? 'AI tool action';
   return r.targetExecutablePath ?? 'Elevation';
+}
+
+function shortUserId(id: string | null | undefined): string | null {
+  return id ? `${id.slice(0, 8)}…` : null;
+}
+
+/**
+ * Who approved/denied/revoked the request — prefers the API-joined display
+ * name, falling back to a truncated user id (older cached rows, or a decider
+ * the caller's users policy can't see). Null when no human decided yet
+ * (pending / auto_approved).
+ */
+export function decidedByLabel(r: ElevationRequest): string | null {
+  switch (r.status) {
+    case 'denied':
+      return r.deniedByName ?? shortUserId(r.deniedByUserId);
+    case 'revoked':
+      return r.revokedByName ?? shortUserId(r.revokedByUserId);
+    case 'approved':
+    case 'actuating':
+    case 'expired':
+      return r.approvedByName ?? shortUserId(r.approvedByUserId);
+    default:
+      return null;
+  }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1229 closing the two gaps noted at merge:

**Display names for deciders (API + web).** `GET /pam/elevation-requests` and `GET /pam/active` now left-join `users` three ways (Drizzle `alias()` — first use in the codebase; one row can reference approver, denier, and revoker) and project `approvedByName` / `deniedByName` / `revokedByName`. Envelopes are otherwise unchanged, and the count query is untouched. RLS posture is identical to the existing `auditLogs.ts` user-name join: a decider outside the caller's visibility yields a null name, and the web falls back to the truncated UUID. The web tabs (Overview recent decisions, Requests, Audit) render the name via a shared `decidedByLabel()` helper covering all seven statuses (`expired` shows the original approver; `pending`/`auto_approved` show nothing), and the Audit CSV export gains `approvedBy`/`deniedBy`/`revokedBy` columns with full-UUID fallback (audit-grade, deliberately untruncated).

**Audit tab live refresh.** `PamPage` now passes the debounced `elevation.*` `liveTick` to `PamAuditTab` as well; tick-driven refetches are silent (rows stay rendered), while filter/page changes still show the spinner.

## Verification

TDD (RED before GREEN both sides). API `pam.test.ts` 23 passed (2 new name-join tests); web `components/pam/` + `no-silent-mutations` guard 75 passed (6 new); full `@breeze/web` suite 127 files / 915 tests green; both `tsc --noEmit` clean (API has only the known pre-existing `agents.test.ts`/`apiKeyAuth.test.ts` errors). Reviewed for RLS structure, join correctness, and CSV escaping — no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
