### PR TITLE
fix(docker): patch libcrypto3/libssl3 to 3.5.7 in api/web images (CVE-2026-45447)

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -27,6 +27,9 @@ ENV NODE_ENV=production
 ARG APP_VERSION=0.2.0
 ENV APP_VERSION=${APP_VERSION}
 
+# CVE-2026-45447: pinned base ships libcrypto3/libssl3 3.5.6; drop once the
+# node:24-alpine digest is refreshed past 3.5.7
+RUN apk upgrade --no-cache libcrypto3 libssl3
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 hono

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -32,6 +32,10 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0
 
+# CVE-2026-45447: pinned base ships libcrypto3/libssl3 3.5.6; drop once the
+# node:24-alpine digest is refreshed past 3.5.7
+RUN apk upgrade --no-cache libcrypto3 libssl3
+
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 astro
 


### PR DESCRIPTION
## Summary

**Problem:** Trivy Image Scan has failed on every PR (and would fail on main) since 2026-06-10: the digest-pinned `node:24-alpine` base ships `libcrypto3`/`libssl3` 3.5.6-r0, and `CVE-2026-45447` (HIGH, fixed in 3.5.7) entered the vuln DB after main's last green scan. First seen on #1226, confirmed on #1229.

**Fix:** targeted `RUN apk upgrade --no-cache libcrypto3 libssl3` in the runner stages of `docker/Dockerfile.api` and `docker/Dockerfile.web` — verified against the pinned digest that the Alpine repo serves 3.5.7-r0 (`3.5.6-r0 → 3.5.7-r0` locally). Commented to drop the line once the base digest is refreshed past 3.5.7. The digest pin itself is unchanged (upstream hasn't rebuilt yet).

**Verification:** `docker run` against the exact pinned digest confirms the upgrade lands 3.5.7-r0 for both packages; the Trivy Image Scan job on this PR is the end-to-end proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
