### PR TITLE
fix(audit): stop concurrent-write chain forks + daily verify_chain alerting (#1002)

### DIFF
--- a/apps/api/migrations/2026-06-11-a-audit-chain-advisory-lock.sql
+++ b/apps/api/migrations/2026-06-11-a-audit-chain-advisory-lock.sql
@@ -1,0 +1,80 @@
+-- Fix issue #1002: audit hash-chain forks under concurrent same-org inserts.
+--
+-- The BEFORE INSERT trigger audit_log_compute_checksum() (canonical version in
+-- 2026-05-25-c-audit-log-checksum-canonical-fix.sql) reads its predecessor
+-- checksum with a plain SELECT and no serialization. Under concurrent inserts
+-- into the same org chain, each transaction reads the SAME latest *committed*
+-- checksum as `prev` (it cannot see the other in-flight transactions'
+-- uncommitted rows), so all of them link back to the same predecessor. The
+-- per-org chain forks, and audit_log_verify_chain() then reports
+-- false-positive breaks even though no row was tampered or deleted. Confirmed
+-- in production (US droplet, v0.68.2). No data loss — only the tamper-detection
+-- signal degrades.
+--
+-- Fix: take a transaction-scoped advisory lock keyed on the chain's org_id
+-- BEFORE selecting the predecessor. pg_advisory_xact_lock auto-releases at
+-- commit/rollback, so concurrent same-org inserts serialize through the
+-- read-prev / assign-checksum critical section and each one picks up the
+-- previously-committed row in turn. Different orgs hash to different lock keys
+-- and proceed in parallel.
+--
+-- This is a CREATE OR REPLACE of the EXACT canonical function from the -c-
+-- migration, with only the advisory-lock PERFORM added before the predecessor
+-- SELECT. All other logic — including the convert_to(...,'UTF8') canonicalization
+-- from #994 (NOT ::bytea) and the audit_log_canonical_payload() call — is
+-- preserved byte-for-byte. Idempotent by construction (CREATE OR REPLACE).
+--
+-- Lock namespace: pg_advisory_xact_lock(key1 int, key2 int). We use a fixed
+-- project-stable namespace integer for key1 so this chain lock never collides
+-- with advisory locks taken elsewhere, and hashtext(org_id) for key2. The
+-- namespace value 1000200 is derived from the issue number (#1002) and is
+-- reserved exclusively for the audit-chain per-org lock.
+
+CREATE OR REPLACE FUNCTION audit_log_compute_checksum() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+  prev varchar(128);
+  prev_ts timestamp;
+BEGIN
+  -- Issue #1002: serialize concurrent same-org inserts through the
+  -- predecessor read so the chain cannot fork. Namespace 1000200 is reserved
+  -- for the audit-log per-org chain lock; the second key hashes the chain's
+  -- org_id (COALESCE to a sentinel so the NULL-org / system chain also
+  -- serializes on its own key). pg_advisory_xact_lock releases automatically
+  -- when this transaction commits or rolls back.
+  PERFORM pg_advisory_xact_lock(1000200, hashtext(COALESCE(NEW.org_id::text, 'NULL')));
+
+  -- Pick the current chain head: the most recent committed row in this org's
+  -- chain by the SAME (timestamp, id) total order audit_log_verify_chain walks
+  -- (DESC here = the max under that order). Grab its timestamp too so we can
+  -- keep the chain key monotonic below.
+  SELECT checksum, timestamp INTO prev, prev_ts
+  FROM audit_logs
+  WHERE org_id IS NOT DISTINCT FROM NEW.org_id
+    AND id <> NEW.id
+  ORDER BY timestamp DESC, id DESC
+  LIMIT 1;
+
+  -- Monotonicity guard (issue #1002). audit_logs.timestamp defaults to now()
+  -- = transaction_timestamp(), which is the transaction *start* time and is
+  -- constant within a transaction. Under concurrency the advisory lock
+  -- serializes the critical section, but a transaction that STARTED earlier
+  -- can acquire the lock LATER, so its (earlier) transaction_timestamp would
+  -- insert a row that sorts BEFORE the current chain head under (timestamp,
+  -- id) — re-forking the chain the verifier reconstructs. Because we hold the
+  -- per-org lock, clock_timestamp() is strictly increasing across serialized
+  -- inserts, so nudging NEW.timestamp just past the head restores a total
+  -- order that matches lock/commit order. In the common non-concurrent case
+  -- the head is older than now() and this branch is a no-op, preserving the
+  -- caller's real timestamp.
+  IF prev_ts IS NOT NULL AND NEW.timestamp <= prev_ts THEN
+    NEW.timestamp := GREATEST(clock_timestamp()::timestamp, prev_ts + interval '1 microsecond');
+  END IF;
+
+  NEW.prev_checksum := prev;
+  -- convert_to(... ,'UTF8'), not ::bytea — see note in -b-: the text->bytea cast
+  -- throws on the backslash escapes jsonb details::text emits.
+  NEW.checksum := encode(sha256(convert_to(audit_log_canonical_payload(NEW, prev), 'UTF8')), 'hex');
+  RETURN NEW;
+END;
+$$;

--- a/apps/api/migrations/2026-06-11-b-audit-chain-fork-heal.sql
+++ b/apps/api/migrations/2026-06-11-b-audit-chain-fork-heal.sql
@@ -1,0 +1,55 @@
+-- Heal already-forked audit chains (issue #1002).
+--
+-- The -a- migration (sorts before this one) installs the advisory lock that
+-- stops NEW forks. This migration re-anchors rows that already forked before
+-- the lock landed: it recomputes prev_checksum/checksum for every row, per org,
+-- walking each chain in (timestamp, id) order — the SAME order the BEFORE
+-- INSERT trigger establishes and audit_log_verify_chain() walks. After this
+-- runs, audit_log_verify_chain() returns zero breaks for every org chain
+-- (absent genuine tampering, which would have changed a row's content and so
+-- still surfaces as a break on the next verify against live trigger output).
+--
+-- Reuses audit_log_canonical_payload() — the SAME formula the trigger and
+-- verifier call — so the healed checksums match what a fresh insert would
+-- produce. No format drift possible.
+--
+-- Idempotent: re-running on an already-clean chain recomputes byte-identical
+-- checksums (the canonical payload is deterministic for a fixed row + prev),
+-- so the UPDATEs are no-ops in effect. Safe to re-apply.
+--
+-- Task 1's append-only trigger (audit_log_block_update) blocks UPDATE with an
+-- exception, so DISABLE it for the duration, mirroring the -b-/-c- backfills.
+-- autoMigrate wraps each file in client.begin(), so a failure rolls back the
+-- DISABLE alongside everything else. No inner BEGIN;/COMMIT; (the runner owns
+-- the transaction).
+
+ALTER TABLE audit_logs DISABLE TRIGGER audit_log_block_update;
+
+DO $$
+DECLARE
+  rec audit_logs;
+  prev varchar(128) := NULL;
+  prev_org uuid := NULL;
+  first_iter boolean := true;
+BEGIN
+  FOR rec IN
+    SELECT * FROM audit_logs ORDER BY org_id NULLS FIRST, timestamp, id
+  LOOP
+    -- Reset the running prev when crossing an org boundary so the first row of
+    -- each per-org chain (and the NULL-org / system chain) gets prev=NULL.
+    IF first_iter OR (prev_org IS DISTINCT FROM rec.org_id) THEN
+      prev := NULL;
+    END IF;
+    first_iter := false;
+
+    UPDATE audit_logs SET
+      prev_checksum = prev,
+      checksum = encode(sha256(convert_to(audit_log_canonical_payload(rec, prev), 'UTF8')), 'hex')
+    WHERE id = rec.id
+    RETURNING checksum INTO prev;
+
+    prev_org := rec.org_id;
+  END LOOP;
+END $$;
+
+ALTER TABLE audit_logs ENABLE TRIGGER audit_log_block_update;

--- a/apps/api/src/__tests__/integration/audit-checksum.integration.test.ts
+++ b/apps/api/src/__tests__/integration/audit-checksum.integration.test.ts
@@ -177,6 +177,48 @@ describe('audit_logs checksum chain', () => {
     });
   });
 
+  // Regression for issue #1002: the BEFORE INSERT trigger forks the chain
+  // under concurrent same-org inserts. Each transaction reads the SAME latest
+  // committed checksum as its `prev` (it can't see the other in-flight
+  // transactions' uncommitted rows), so N concurrent inserts all link back to
+  // the same predecessor → the per-org chain forks → audit_log_verify_chain
+  // reports false-positive breaks even though nothing was tampered.
+  //
+  // The fix (-a- advisory-lock migration) takes a per-org
+  // pg_advisory_xact_lock BEFORE the predecessor SELECT, serializing the
+  // read-checksum/assign-prev critical section across concurrent same-org
+  // inserts so each picks up the prior committed row in turn.
+  //
+  // Each insert runs in its own `withSystemDbAccessContext` call (separate
+  // pooled connection + transaction), and Promise.all fires them
+  // concurrently — this is the production shape (row-per-API-call) that
+  // surfaced the fork on the US droplet.
+  it('audit_log_verify_chain returns no breaks under concurrent same-org inserts', async () => {
+    const N = 25;
+    await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        withSystemDbAccessContext(async () => {
+          await db.execute(sql`
+            INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result)
+            VALUES (${orgId}, 'system', gen_random_uuid(), ${'concurrent-' + i}, 'test', 'success')
+          `);
+        })
+      )
+    );
+
+    await withSystemDbAccessContext(async () => {
+      const count = (await db.execute(sql`
+        SELECT COUNT(*)::int AS n FROM audit_logs WHERE org_id = ${orgId}::uuid
+      `)) as unknown as Array<{ n: number }>;
+      expect(count[0]!.n).toEqual(N);
+
+      const breaks = (await db.execute(sql`
+        SELECT broken_id FROM public.audit_log_verify_chain(${orgId}::uuid)
+      `)) as unknown as Array<{ broken_id: string }>;
+      expect(breaks).toEqual([]);
+    });
+  });
+
   it('audit_log_verify_chain detects tampering via direct SQL UPDATE', async () => {
     // Seed three rows each in their own transaction so the chain is
     // unambiguously ordered (see same-tx note above). Each insert returns the

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -136,6 +136,10 @@ import { initializeIPHistoryRetention, shutdownIPHistoryRetention } from './jobs
 import { initializeChangeLogRetention, shutdownChangeLogRetention } from './jobs/changeLogRetention';
 import { initializeOauthCleanupWorker, shutdownOauthCleanupWorker } from './jobs/oauthCleanup';
 import { initializeAuditRetentionWorker, shutdownAuditRetentionWorker } from './jobs/auditRetention';
+import {
+  initializeAuditChainVerifyWorker,
+  shutdownAuditChainVerifyWorker,
+} from './jobs/auditChainVerify';
 import { initializeTenantErasureWorker, shutdownTenantErasureWorker } from './jobs/tenantErasure';
 import { initializeDiscoveryWorker, shutdownDiscoveryWorker } from './jobs/discoveryWorker';
 import { initializeNetworkBaselineWorker, shutdownNetworkBaselineWorker } from './jobs/networkBaselineWorker';
@@ -1018,6 +1022,7 @@ async function initializeWorkers(): Promise<void> {
     ['changeLogRetention', initializeChangeLogRetention],
     ['oauthCleanup', initializeOauthCleanupWorker],
     ['auditRetention', initializeAuditRetentionWorker],
+    ['auditChainVerify', initializeAuditChainVerifyWorker],
     ['tenantErasure', initializeTenantErasureWorker],
     ['playbookRetention', initializePlaybookRetention],
     ['discoveryWorker', initializeDiscoveryWorker],
@@ -1185,6 +1190,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownChangeLogRetention,
     shutdownOauthCleanupWorker,
     shutdownAuditRetentionWorker,
+    shutdownAuditChainVerifyWorker,
     shutdownTenantErasureWorker,
     shutdownPlaybookRetention,
     shutdownSecurityPostureWorker,

--- a/apps/api/src/jobs/auditChainVerify.test.ts
+++ b/apps/api/src/jobs/auditChainVerify.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Unit tests for the audit-chain verification worker (issue #916 bonus /
+ * #917 L-2).
+ *
+ * Mirrors auditRetention.test.ts: BullMQ, the db module, the event bus and
+ * Sentry are stubbed so we can assert scheduling, the per-org verify loop,
+ * and incident-raising behavior without a real Postgres.
+ *
+ * The verify_chain SQL itself (and the advisory-lock / fork-heal fixes from
+ * #1002 that make a non-empty result trustworthy) are exercised by the
+ * audit-chain integration tests, not here.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  addMock,
+  getRepeatableJobsMock,
+  removeRepeatableByKeyMock,
+  queueCloseMock,
+  workerCloseMock,
+  withSystemDbAccessContextMock,
+  runOutsideDbContextMock,
+  dbExecuteMock,
+  dbInsertMock,
+  insertValuesMock,
+  insertReturningMock,
+  publishEventMock,
+  captureExceptionMock,
+  capturedWorkerProcessor,
+} = vi.hoisted(() => ({
+  addMock: vi.fn(),
+  getRepeatableJobsMock: vi.fn(),
+  removeRepeatableByKeyMock: vi.fn(),
+  queueCloseMock: vi.fn(),
+  workerCloseMock: vi.fn(),
+  withSystemDbAccessContextMock: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  runOutsideDbContextMock: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  dbExecuteMock: vi.fn(),
+  dbInsertMock: vi.fn(),
+  insertValuesMock: vi.fn(),
+  insertReturningMock: vi.fn(),
+  publishEventMock: vi.fn(),
+  captureExceptionMock: vi.fn(),
+  capturedWorkerProcessor: { current: null as null | ((job: unknown) => Promise<unknown>) },
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    name: string;
+    constructor(name: string) {
+      this.name = name;
+    }
+    add = (...args: unknown[]) => addMock(...(args as []));
+    getRepeatableJobs = () => getRepeatableJobsMock();
+    removeRepeatableByKey = (...args: unknown[]) => removeRepeatableByKeyMock(...(args as []));
+    close = () => queueCloseMock();
+  },
+  Worker: class {
+    name: string;
+    constructor(name: string, processor: (job: unknown) => Promise<unknown>) {
+      this.name = name;
+      capturedWorkerProcessor.current = processor;
+    }
+    on = vi.fn();
+    close = () => workerCloseMock();
+  },
+  Job: class {},
+}));
+
+vi.mock('../db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db')>();
+  return {
+    ...actual,
+    withSystemDbAccessContext: (fn: () => Promise<unknown>) => withSystemDbAccessContextMock(fn),
+    runOutsideDbContext: (fn: () => Promise<unknown>) => runOutsideDbContextMock(fn),
+    db: {
+      execute: (...args: unknown[]) => dbExecuteMock(...(args as [])),
+      insert: (...args: unknown[]) => dbInsertMock(...(args as [])),
+    },
+  };
+});
+
+vi.mock('../services/redis', () => ({
+  getRedisConnection: vi.fn(() => ({})),
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+  isBullMQAvailable: vi.fn(() => true),
+}));
+
+vi.mock('../services/sentry', () => ({
+  captureException: (...args: unknown[]) => captureExceptionMock(...(args as [])),
+}));
+
+vi.mock('../services/eventBus', () => ({
+  publishEvent: (...args: unknown[]) => publishEventMock(...(args as [])),
+}));
+
+import {
+  __testOnly,
+  scheduleAuditChainVerify,
+  shutdownAuditChainVerifyWorker,
+  verifyAuditChains,
+} from './auditChainVerify';
+
+const ORIGINAL_FLAG = process.env.AUDIT_CHAIN_VERIFY_ENABLED;
+
+/** Re-arm the chained Drizzle insert builder for one .insert() call. */
+function primeInsert(returnedId = 'incident-1') {
+  insertReturningMock.mockResolvedValue([{ id: returnedId }]);
+  insertValuesMock.mockReturnValue({ returning: insertReturningMock });
+  dbInsertMock.mockReturnValue({ values: insertValuesMock });
+}
+
+describe('auditChainVerify worker', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    withSystemDbAccessContextMock.mockImplementation(async (fn: () => Promise<unknown>) => fn());
+    runOutsideDbContextMock.mockImplementation(async (fn: () => Promise<unknown>) => fn());
+    getRepeatableJobsMock.mockResolvedValue([]);
+    addMock.mockResolvedValue(undefined);
+    removeRepeatableByKeyMock.mockResolvedValue(undefined);
+    queueCloseMock.mockResolvedValue(undefined);
+    workerCloseMock.mockResolvedValue(undefined);
+    dbExecuteMock.mockResolvedValue([]);
+    publishEventMock.mockResolvedValue('evt-1');
+    primeInsert();
+    capturedWorkerProcessor.current = null;
+    delete process.env.AUDIT_CHAIN_VERIFY_ENABLED;
+  });
+
+  afterEach(async () => {
+    await shutdownAuditChainVerifyWorker();
+    if (ORIGINAL_FLAG === undefined) {
+      delete process.env.AUDIT_CHAIN_VERIFY_ENABLED;
+    } else {
+      process.env.AUDIT_CHAIN_VERIFY_ENABLED = ORIGINAL_FLAG;
+    }
+  });
+
+  it('exposes a daily cron and stable identifiers', () => {
+    expect(__testOnly.DAILY_CRON).toBe('15 4 * * *');
+    expect(__testOnly.JOB_NAME).toBe('audit-chain-verify');
+    expect(__testOnly.REPEAT_JOB_ID).toBe('audit-chain-verify');
+  });
+
+  it('isEnabled defaults ON and accepts standard falsy values', () => {
+    delete process.env.AUDIT_CHAIN_VERIFY_ENABLED;
+    expect(__testOnly.isEnabled()).toBe(true);
+    process.env.AUDIT_CHAIN_VERIFY_ENABLED = 'false';
+    expect(__testOnly.isEnabled()).toBe(false);
+    process.env.AUDIT_CHAIN_VERIFY_ENABLED = '0';
+    expect(__testOnly.isEnabled()).toBe(false);
+    process.env.AUDIT_CHAIN_VERIFY_ENABLED = 'off';
+    expect(__testOnly.isEnabled()).toBe(false);
+    process.env.AUDIT_CHAIN_VERIFY_ENABLED = 'true';
+    expect(__testOnly.isEnabled()).toBe(true);
+  });
+
+  describe('scheduleAuditChainVerify', () => {
+    it('registers a daily repeatable with a stable jobId', async () => {
+      await scheduleAuditChainVerify();
+      expect(addMock).toHaveBeenCalledTimes(1);
+      const [, , opts] = addMock.mock.calls[0] as [unknown, unknown, Record<string, unknown>];
+      expect((opts.repeat as { pattern: string }).pattern).toBe('15 4 * * *');
+      expect(opts.jobId).toBe('audit-chain-verify');
+    });
+
+    it('clears any prior repeatable before registering', async () => {
+      getRepeatableJobsMock.mockResolvedValue([
+        { name: 'audit-chain-verify', key: 'old-key' },
+        { name: 'something-else', key: 'keep' },
+      ]);
+      await scheduleAuditChainVerify();
+      expect(removeRepeatableByKeyMock).toHaveBeenCalledWith('old-key');
+      expect(removeRepeatableByKeyMock).not.toHaveBeenCalledWith('keep');
+    });
+
+    it('skips registration when disabled by env flag', async () => {
+      process.env.AUDIT_CHAIN_VERIFY_ENABLED = 'false';
+      await scheduleAuditChainVerify();
+      expect(addMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('verifyAuditChains', () => {
+    // dbExecuteMock is called once for the org enumeration, then once per
+    // org for SELECT * FROM audit_log_verify_chain(org). Wire the calls in
+    // order via mockResolvedValueOnce.
+    function mockOrgs(orgIds: string[]) {
+      dbExecuteMock.mockResolvedValueOnce(orgIds.map((id) => ({ id })));
+    }
+
+    it('raises no incident when every chain is intact', async () => {
+      mockOrgs(['org-1', 'org-2']);
+      dbExecuteMock.mockResolvedValueOnce([]); // org-1 verify → clean
+      dbExecuteMock.mockResolvedValueOnce([]); // org-2 verify → clean
+
+      const stats = await verifyAuditChains();
+
+      expect(stats.orgsChecked).toBe(2);
+      expect(stats.orgsBroken).toBe(0);
+      expect(stats.alertsRaised).toBe(0);
+      expect(dbInsertMock).not.toHaveBeenCalled();
+      expect(publishEventMock).not.toHaveBeenCalled();
+      expect(captureExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('raises exactly one incident for an org whose chain is broken', async () => {
+      mockOrgs(['org-1', 'org-2']);
+      dbExecuteMock.mockResolvedValueOnce([]); // org-1 clean
+      dbExecuteMock.mockResolvedValueOnce([
+        { broken_id: 'row-aaa', expected: 'exp1', actual: 'act1' },
+        { broken_id: 'row-bbb', expected: 'exp2', actual: 'act2' },
+      ]); // org-2 → 2 breaks
+
+      const stats = await verifyAuditChains();
+
+      expect(stats.orgsChecked).toBe(2);
+      expect(stats.orgsBroken).toBe(1);
+      expect(stats.alertsRaised).toBe(1);
+
+      // Exactly one incident inserted, for org-2, p1 / detected / audit_integrity.
+      expect(dbInsertMock).toHaveBeenCalledTimes(1);
+      const values = insertValuesMock.mock.calls[0]![0] as Record<string, unknown>;
+      expect(values.orgId).toBe('org-2');
+      expect(values.severity).toBe('p1');
+      expect(values.status).toBe('detected');
+      expect(values.classification).toBe('audit_integrity');
+      // First broken_id and the break count must be carried in the payload.
+      expect(String(values.summary)).toContain('row-aaa');
+      expect(String(values.summary)).toContain('2');
+
+      // The incident.created event is published once for the broken org.
+      expect(publishEventMock).toHaveBeenCalledTimes(1);
+      const [type, orgId, payload, source] = publishEventMock.mock.calls[0] as [
+        string,
+        string,
+        Record<string, unknown>,
+        string,
+      ];
+      expect(type).toBe('incident.created');
+      expect(orgId).toBe('org-2');
+      expect(source).toBe('audit-chain-verify');
+      expect(payload.brokenId).toBe('row-aaa');
+      expect(payload.breakCount).toBe(2);
+    });
+
+    it('isolates a per-org verify failure without aborting the sweep', async () => {
+      mockOrgs(['org-1', 'org-2']);
+      dbExecuteMock.mockRejectedValueOnce(new Error('verify boom')); // org-1 throws
+      dbExecuteMock.mockResolvedValueOnce([]); // org-2 still checked → clean
+
+      const stats = await verifyAuditChains();
+
+      // org-1 threw (counted as an error, not a successful check); org-2 was
+      // still reached and verified clean — the sweep did not abort.
+      expect(stats.orgsChecked).toBe(1);
+      expect(stats.errors).toBe(1);
+      expect(stats.orgsBroken).toBe(0);
+      expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('runs the per-org verify outside the long-held enumeration txn', async () => {
+      mockOrgs(['org-1']);
+      dbExecuteMock.mockResolvedValueOnce([]);
+
+      await verifyAuditChains();
+
+      // The org list is read in one short system txn; the per-org sweep runs
+      // via runOutsideDbContext so we never hold a connection idle-in-txn
+      // across the loop (#1105 pattern).
+      expect(runOutsideDbContextMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('worker processor', () => {
+    it('runs the sweep for the scheduled job name', async () => {
+      // Build the worker to capture its processor.
+      const { createAuditChainVerifyWorker } = await import('./auditChainVerify');
+      createAuditChainVerifyWorker();
+      expect(capturedWorkerProcessor.current).toBeTypeOf('function');
+
+      dbExecuteMock.mockResolvedValueOnce([{ id: 'org-1' }]); // enumeration
+      dbExecuteMock.mockResolvedValueOnce([]); // org-1 clean
+
+      const result = await capturedWorkerProcessor.current!({ name: 'audit-chain-verify' });
+      expect((result as { orgsChecked: number }).orgsChecked).toBe(1);
+    });
+
+    it('ignores unknown job names', async () => {
+      const { createAuditChainVerifyWorker } = await import('./auditChainVerify');
+      createAuditChainVerifyWorker();
+      const result = await capturedWorkerProcessor.current!({ name: 'bogus' });
+      expect((result as { skipped: boolean }).skipped).toBe(true);
+      expect(dbExecuteMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/jobs/auditChainVerify.ts
+++ b/apps/api/src/jobs/auditChainVerify.ts
@@ -1,0 +1,388 @@
+/**
+ * Audit-Chain Verification Worker (issue #916 bonus / #917 sub-item L-2)
+ *
+ * `audit_log_verify_chain(org_id)` (migration
+ * 2026-05-25-c-audit-log-checksum-canonical-fix.sql) walks each org's audit
+ * hash-chain in (timestamp, id) order and returns one row
+ * `(broken_id, expected, actual)` per break — a checksum that doesn't match
+ * the canonical re-computation or a prev_checksum link that doesn't match the
+ * preceding row. An empty result set means the chain is intact.
+ *
+ * Until now that function was only ever called by tests: a forged or
+ * truncated audit chain was *detectable* but never *observed* in production.
+ * This worker runs the verifier per org once a day and raises a P1 security
+ * incident for any org whose chain returns ≥1 break row, so tampering pages
+ * an operator instead of sitting silent.
+ *
+ * Why we can trust a non-empty result now (issue #1002):
+ *   Before #1002, concurrent same-org inserts could fork the chain and make
+ *   verify_chain report *false-positive* breaks under load. The sibling
+ *   migrations in this branch —
+ *     2026-06-11-a-audit-chain-advisory-lock.sql (serializes the read-prev /
+ *       assign-checksum critical section with a per-org advisory lock), and
+ *     2026-06-11-b-audit-chain-fork-heal.sql (re-anchors already-forked rows)
+ *   — eliminate that false-positive source. So a non-empty verify result is
+ *   now a real tamper/integrity signal worth paging on.
+ *
+ * #1105 long-transaction pitfall:
+ *   `withSystemDbAccessContext` wraps its whole callback in a single
+ *   transaction. We therefore read the org list inside one short system txn
+ *   and then run the per-org verify sweep via `runOutsideDbContext` so the
+ *   connection is NOT held idle-in-transaction across the (potentially long)
+ *   per-org loop. Each per-org verify opens and closes its own short system
+ *   txn. This mirrors the guidance in CLAUDE.md ("DB Access Context").
+ *
+ * Throughput: this is a once-a-day integrity sweep, not a hot path. Each org
+ * verify is a single function call; we run them sequentially with a small
+ * delay between orgs so a large fleet doesn't hammer the primary. Per-org
+ * failures are isolated (try/catch + captureException) so one bad org can't
+ * abort the whole pass — same isolation rationale as auditRetention.
+ *
+ * Schedule: daily at 04:15 UTC — offset from auditRetention (03:30) and
+ * oauthCleanup (03:00) so the integrity crons don't pile onto one minute, and
+ * late enough that the nightly retention prune (which re-anchors chain heads)
+ * has already settled.
+ *
+ * Kill switch: `AUDIT_CHAIN_VERIFY_ENABLED=false` skips schedule registration
+ * (the worker still drains manual `add()` calls for incident response).
+ */
+
+import { Queue, Worker, Job } from 'bullmq';
+import { sql } from 'drizzle-orm';
+import * as dbModule from '../db';
+import { incidents, type IncidentTimelineEntry } from '../db/schema/incidentResponse';
+import { captureException } from '../services/sentry';
+import { publishEvent } from '../services/eventBus';
+import { getBullMQConnection } from '../services/redis';
+
+const QUEUE_NAME = 'audit-chain-verify';
+const JOB_NAME = 'audit-chain-verify';
+const REPEAT_JOB_ID = 'audit-chain-verify';
+// Daily at 04:15 UTC — after retention (03:30) and oauthCleanup (03:00).
+const DAILY_CRON = '15 4 * * *';
+// Small breather between per-org verifies so a large fleet doesn't hammer the
+// primary during the sweep. Daily job — latency is irrelevant.
+const INTER_ORG_DELAY_MS = 50;
+
+const INCIDENT_CLASSIFICATION = 'audit_integrity';
+const INCIDENT_SEVERITY = 'p1' as const;
+const EVENT_SOURCE = 'audit-chain-verify';
+
+function isEnabled(): boolean {
+  const raw = process.env.AUDIT_CHAIN_VERIFY_ENABLED;
+  if (raw === undefined || raw === '') return true; // default ON
+  const v = raw.trim().toLowerCase();
+  return !(v === '0' || v === 'false' || v === 'no' || v === 'off');
+}
+
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  if (typeof dbModule.withSystemDbAccessContext !== 'function') {
+    throw new Error(
+      '[AuditChainVerify] withSystemDbAccessContext is not available — DB module may not have loaded correctly',
+    );
+  }
+  return dbModule.withSystemDbAccessContext(fn);
+};
+
+const runOutsideDbContext = async <T>(fn: () => Promise<T>): Promise<T> => {
+  if (typeof dbModule.runOutsideDbContext !== 'function') {
+    // Without the helper we can still run, just not detached from any
+    // ambient context — acceptable since this worker has no ambient txn.
+    return fn();
+  }
+  return dbModule.runOutsideDbContext(fn);
+};
+
+export interface ChainVerifyStats {
+  orgsChecked: number;
+  orgsBroken: number;
+  alertsRaised: number;
+  errors: number;
+  durationMs: number;
+}
+
+interface OrgRow {
+  id: string;
+}
+
+interface ChainBreakRow {
+  broken_id: string;
+  expected: string | null;
+  actual: string | null;
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run the verifier for one org in its own short system transaction and return
+ * any break rows. Kept tiny so the txn is never held open across the loop.
+ */
+async function verifyOrgChain(orgId: string): Promise<ChainBreakRow[]> {
+  return runWithSystemDbAccess(async () => {
+    const rows = (await dbModule.db.execute(sql`
+      SELECT broken_id, expected, actual
+      FROM audit_log_verify_chain(${orgId}::uuid)
+    `)) as unknown as ChainBreakRow[];
+    return Array.isArray(rows) ? rows : [];
+  });
+}
+
+/**
+ * Raise a P1 security incident for an org whose audit chain is broken, then
+ * publish `incident.created` so existing escalation/notification fans out.
+ * Runs in its own system txn (separate from the verify read).
+ */
+async function raiseChainBreakIncident(orgId: string, breaks: ChainBreakRow[]): Promise<void> {
+  const now = new Date();
+  const firstBrokenId = breaks[0]?.broken_id ?? 'unknown';
+  const breakCount = breaks.length;
+  const title = 'Audit log hash-chain integrity break detected';
+  const summary =
+    `audit_log_verify_chain reported ${breakCount} break row(s) for this organization. ` +
+    `First broken audit_logs.id=${firstBrokenId}. A break means a stored checksum or ` +
+    `prev_checksum no longer matches the canonical re-computation — i.e. an audit row was ` +
+    `altered, deleted, or inserted out of band. Investigate immediately. ` +
+    `(#1002 advisory-lock + fork-heal fixes are in place, so this is not a concurrency ` +
+    `false-positive.)`;
+
+  const timeline: IncidentTimelineEntry[] = [
+    {
+      at: now.toISOString(),
+      type: 'incident_created',
+      actor: 'system',
+      summary: `Audit-chain verification sweep detected ${breakCount} break row(s).`,
+      metadata: {
+        firstBrokenId,
+        breakCount,
+        // Cap the embedded sample so a fully-rewritten chain can't bloat the row.
+        sample: breaks.slice(0, 20).map((b) => ({
+          brokenId: b.broken_id,
+          expected: b.expected,
+          actual: b.actual,
+        })),
+      },
+    },
+  ];
+
+  const [incident] = await runWithSystemDbAccess(async () =>
+    dbModule.db
+      .insert(incidents)
+      .values({
+        orgId,
+        title,
+        classification: INCIDENT_CLASSIFICATION,
+        severity: INCIDENT_SEVERITY,
+        status: 'detected',
+        summary,
+        relatedAlerts: [],
+        affectedDevices: [],
+        timeline,
+        detectedAt: now,
+      })
+      .returning(),
+  );
+
+  // Publish best-effort: a failure here must not lose the (already-persisted)
+  // incident, but should still surface to Sentry.
+  try {
+    await publishEvent(
+      'incident.created',
+      orgId,
+      {
+        incidentId: incident?.id,
+        title,
+        classification: INCIDENT_CLASSIFICATION,
+        severity: INCIDENT_SEVERITY,
+        brokenId: firstBrokenId,
+        breakCount,
+      },
+      EVENT_SOURCE,
+    );
+  } catch (err) {
+    captureException(err);
+    console.error(
+      `[AuditChainVerify] incident raised (id=${incident?.id}) but incident.created publish failed for org=${orgId}:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+}
+
+/**
+ * Walk every active organization, verify its audit hash-chain, and raise a P1
+ * incident for any org that returns break rows.
+ *
+ * Exported for direct invocation (tests, manual incident response). The worker
+ * processor calls this and surfaces the stats in the job return value.
+ */
+export async function verifyAuditChains(): Promise<ChainVerifyStats> {
+  const startedAt = Date.now();
+  const stats: ChainVerifyStats = {
+    orgsChecked: 0,
+    orgsBroken: 0,
+    alertsRaised: 0,
+    errors: 0,
+    durationMs: 0,
+  };
+
+  // Read the org list in one short system txn. We deliberately do NOT keep
+  // this txn open across the per-org loop (#1105) — the loop runs detached.
+  const orgs = await runWithSystemDbAccess(async () => {
+    const rows = (await dbModule.db.execute(sql`
+      SELECT id FROM organizations WHERE status = 'active'
+    `)) as unknown as OrgRow[];
+    return rows;
+  });
+
+  // Detach from any ambient db context so the per-org sweep can't hold a
+  // connection idle-in-transaction across the whole loop.
+  await runOutsideDbContext(async () => {
+    for (const org of orgs) {
+      try {
+        const breaks = await verifyOrgChain(org.id);
+        stats.orgsChecked += 1;
+
+        if (breaks.length > 0) {
+          stats.orgsBroken += 1;
+          console.error(
+            `[AuditChainVerify] CHAIN BREAK org=${org.id} breaks=${breaks.length} firstBrokenId=${breaks[0]?.broken_id}`,
+          );
+          await raiseChainBreakIncident(org.id, breaks);
+          stats.alertsRaised += 1;
+          // Surface to Sentry too so ops paging fires even if the incident
+          // notification pipeline is degraded.
+          captureException(
+            new Error(
+              `Audit hash-chain integrity break: org=${org.id} breaks=${breaks.length} firstBrokenId=${breaks[0]?.broken_id}`,
+            ),
+          );
+        }
+      } catch (err) {
+        stats.errors += 1;
+        captureException(err);
+        console.error(
+          `[AuditChainVerify] verify failed for org=${org.id}:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+
+      if (INTER_ORG_DELAY_MS > 0) {
+        await sleep(INTER_ORG_DELAY_MS);
+      }
+    }
+  });
+
+  stats.durationMs = Date.now() - startedAt;
+  console.log(
+    `[AuditChainVerify] Verified ${stats.orgsChecked} org chain(s); ${stats.orgsBroken} broken, ${stats.alertsRaised} incident(s) raised in ${stats.durationMs}ms (errors=${stats.errors})`,
+  );
+  return stats;
+}
+
+let verifyQueue: Queue | null = null;
+let verifyWorker: Worker | null = null;
+
+export function getAuditChainVerifyQueue(): Queue {
+  if (!verifyQueue) {
+    verifyQueue = new Queue(QUEUE_NAME, {
+      connection: getBullMQConnection(),
+    });
+  }
+  return verifyQueue;
+}
+
+export function createAuditChainVerifyWorker(): Worker {
+  verifyWorker = new Worker(
+    QUEUE_NAME,
+    async (job: Job) => {
+      if (job.name !== JOB_NAME) {
+        console.warn(`[AuditChainVerify] Ignoring unknown job name: ${job.name}`);
+        return { skipped: true, orgsChecked: 0 };
+      }
+      return verifyAuditChains();
+    },
+    {
+      connection: getBullMQConnection(),
+      concurrency: 1,
+    },
+  );
+  return verifyWorker;
+}
+
+export async function scheduleAuditChainVerify(
+  queue: Queue = getAuditChainVerifyQueue(),
+): Promise<void> {
+  // Clear any prior repeatable so a cron-pattern change takes effect on
+  // redeploy (BullMQ keys repeatables by the full option set).
+  const existingJobs = await queue.getRepeatableJobs();
+  for (const job of existingJobs) {
+    if (job.name === JOB_NAME) {
+      await queue.removeRepeatableByKey(job.key);
+    }
+  }
+
+  if (!isEnabled()) {
+    console.log(
+      '[AuditChainVerify] AUDIT_CHAIN_VERIFY_ENABLED=false — skipping schedule registration',
+    );
+    return;
+  }
+
+  await queue.add(
+    JOB_NAME,
+    {},
+    {
+      // Stable jobId gives BullMQ multi-replica dedup: only one replica wins
+      // the scheduled-job insert per fire time.
+      jobId: REPEAT_JOB_ID,
+      repeat: { pattern: DAILY_CRON },
+      removeOnComplete: { count: 10 },
+      removeOnFail: { count: 25 },
+    },
+  );
+  console.log(
+    `[AuditChainVerify] Scheduled daily verification (cron "${DAILY_CRON}", jobId=${REPEAT_JOB_ID})`,
+  );
+}
+
+export async function initializeAuditChainVerifyWorker(): Promise<void> {
+  try {
+    createAuditChainVerifyWorker();
+
+    verifyWorker?.on('error', (error) => {
+      console.error('[AuditChainVerify] Worker error:', error);
+      captureException(error);
+    });
+
+    verifyWorker?.on('failed', (job, error) => {
+      console.error(`[AuditChainVerify] Job ${job?.id} failed:`, error);
+      captureException(error);
+    });
+
+    await scheduleAuditChainVerify();
+    console.log('[AuditChainVerify] Worker initialized');
+  } catch (error) {
+    console.error('[AuditChainVerify] Failed to initialize:', error);
+    throw error;
+  }
+}
+
+export async function shutdownAuditChainVerifyWorker(): Promise<void> {
+  if (verifyWorker) {
+    await verifyWorker.close();
+    verifyWorker = null;
+  }
+  if (verifyQueue) {
+    await verifyQueue.close();
+    verifyQueue = null;
+  }
+}
+
+// Exported for test introspection.
+export const __testOnly = {
+  QUEUE_NAME,
+  JOB_NAME,
+  REPEAT_JOB_ID,
+  DAILY_CRON,
+  INCIDENT_CLASSIFICATION,
+  isEnabled,
+};


### PR DESCRIPTION
Audit hash-chain integrity hardening — two related changes that ship together (the cron is only trustworthy once the fork fix lands).

## #1002 — concurrent-write chain forks (`Closes #1002`)
The BEFORE INSERT trigger `audit_log_compute_checksum()` read its predecessor checksum with no serialization, so N concurrent same-org inserts each chained off the same committed head → the chain **forked** and `audit_log_verify_chain()` returned false-positive breaks under load (observed on US v0.68.2: ~20 false breaks in minutes, all live agent telemetry).

- `2026-06-11-a-audit-chain-advisory-lock.sql` — `CREATE OR REPLACE` the trigger to take `pg_advisory_xact_lock(1000200, hashtext(org_id))` before the predecessor SELECT. **Key subtlety:** the lock alone isn't enough — `audit_logs.timestamp` defaults to `transaction_timestamp()` (constant within a txn), so an earlier-*started* writer can acquire the lock later and insert a row that sorts behind the head under the verifier's `(timestamp, id)` order, re-forking. Inside the locked section we nudge `NEW.timestamp` forward past the head when needed (a no-op in the non-concurrent case). All prior logic — incl. the #994 `convert_to(...,'UTF8')` canonicalization — preserved byte-for-byte.
- `2026-06-11-b-audit-chain-fork-heal.sql` — idempotent per-org heal that re-anchors already-forked rows in `(timestamp, id)` order using the same formula.
- Concurrency regression test: 25 concurrent same-org inserts → `verify_chain` returns 0 breaks.

## verify_chain cron (bonus of #916, and #917 L-2)
`audit_log_verify_chain()` was only ever called by tests — a break was detectable but never observed. New daily 04:15 UTC per-org sweep raises a **P1 incident + Sentry capture** on any org returning break rows. `#1105`-safe (org list in a short txn, per-org verify via `runOutsideDbContext`), `AUDIT_CHAIN_VERIFY_ENABLED` kill switch, registered in `index.ts` init/shutdown. 11 unit tests.

> Does **not** close #916 (its primary deliverable, the external anchor to immutable storage, is deferred pending an infra decision) or #917 (umbrella; L-1/M-6 still open).

**Throughput note:** the per-org advisory lock serializes that org's audit inserts to commit. Fine for current volumes; if a single org's telemetry gets hot, the durable fix is a `chain_seq bigserial` ordering column (removes the timestamp-monotonicity dependence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)