### PR TITLE
fix(audit): connection-level privilege separation for audit retention (#915)

### DIFF
--- a/apps/api/migrations/2026-06-11-d-audit-retention-admin-login.sql
+++ b/apps/api/migrations/2026-06-11-d-audit-retention-admin-login.sql
@@ -1,0 +1,42 @@
+-- Audit-retention privilege separation (issue #915) — step 1 of 2.
+--
+-- Background: migration 2026-05-25-i created role `breeze_audit_admin`
+-- (DELETE on audit_logs) and GRANTed it TO `breeze_app` so the retention
+-- worker could `SET LOCAL ROLE breeze_audit_admin` from the shared
+-- breeze_app connection. That means an attacker with SQLi/RCE inside the
+-- API process can replicate the exact two-gate bypass and wipe audit rows
+-- from the same connection — the role membership is the hole.
+--
+-- The fix is to run retention on a SEPARATE pool that logs in *directly*
+-- as `breeze_audit_admin`, then REVOKE the membership from breeze_app
+-- (step 2, migration 2026-06-11-e, which is NOT auto-applied — see that
+-- file). This migration only makes the role connectable: it flips the
+-- NOLOGIN attribute to LOGIN so an operator-supplied password can be used
+-- for AUDIT_ADMIN_DATABASE_URL.
+--
+-- SECURITY / OPERATOR NOTE: this migration deliberately sets NO password.
+-- Committing a credential to the repo would defeat the entire point. The
+-- operator MUST, out-of-band, set a strong password on the role and supply
+-- it to the API via AUDIT_ADMIN_DATABASE_URL:
+--
+--     ALTER ROLE breeze_audit_admin PASSWORD '<strong-random-secret>';
+--
+-- and then set, in /opt/breeze/.env AND map in the api service
+-- `environment:` block of docker-compose.yml (compose only interpolates
+-- vars listed there):
+--
+--     AUDIT_ADMIN_DATABASE_URL=postgresql://breeze_audit_admin:<secret>@<host>:5432/breeze
+--
+-- Until AUDIT_ADMIN_DATABASE_URL is set, the worker runs in legacy
+-- shared-credential mode and logs a startup warning. LOGIN with no password
+-- is harmless on its own: Postgres rejects password auth for a passwordless
+-- role, and the role still has no membership chain beyond what 2026-05-25-i
+-- granted.
+--
+-- Idempotent: only ALTERs when the role exists and isn't already LOGIN.
+
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'breeze_audit_admin' AND rolcanlogin = false) THEN
+    ALTER ROLE breeze_audit_admin WITH LOGIN;
+  END IF;
+END $$;

--- a/apps/api/migrations/2026-06-11-e-audit-retention-revoke-breeze-app.sql
+++ b/apps/api/migrations/2026-06-11-e-audit-retention-revoke-breeze-app.sql
@@ -1,0 +1,49 @@
+-- Audit-retention privilege separation (issue #915) — step 2 of 2.
+--
+-- This migration would complete the #915 fix by revoking the
+-- `breeze_audit_admin` membership from `breeze_app`:
+--
+--     REVOKE breeze_audit_admin FROM breeze_app;
+--
+-- After that REVOKE, the main app pool can NEVER delete audit_logs rows —
+-- even a fully compromised API process holding a breeze_app connection
+-- can't `SET ROLE breeze_audit_admin` anymore. Retention then works ONLY
+-- via the dedicated breeze_audit_admin login pool (AUDIT_ADMIN_DATABASE_URL).
+--
+-- WHY THIS MIGRATION DOES NOT AUTO-APPLY THE REVOKE
+-- -------------------------------------------------
+-- The retention worker only uses the dedicated pool when
+-- AUDIT_ADMIN_DATABASE_URL is set in the API's environment. That credential
+-- lives in the application env (/opt/breeze/.env + compose), NOT in the
+-- database, so there is no reliable in-DB signal we can guard on to know
+-- the operator has actually provisioned and wired it. If we auto-REVOKEd
+-- here, any deploy that ran migrations before wiring AUDIT_ADMIN_DATABASE_URL
+-- would immediately break audit retention (the legacy SET ROLE path would
+-- start failing the privilege check). That violates the safe-rollout
+-- requirement.
+--
+-- Therefore this migration is intentionally a NO-OP that only emits a
+-- NOTICE. The REVOKE is a DOCUMENTED MANUAL FOLLOW-UP the operator runs
+-- AFTER confirming the dedicated pool works end-to-end.
+--
+-- OPERATOR RUNBOOK (perform in order, per region):
+--   1. ALTER ROLE breeze_audit_admin PASSWORD '<strong-random-secret>';
+--   2. Set AUDIT_ADMIN_DATABASE_URL in /opt/breeze/.env and map it in the
+--      api service `environment:` block of docker-compose.yml.
+--   3. Redeploy api; confirm the startup log shows
+--      "Dedicated audit-admin credential configured" (NOT the legacy
+--      shared-credential WARNING).
+--   4. Trigger / wait for one retention run and confirm rows prune.
+--   5. ONLY THEN run the manual REVOKE below as a superuser:
+--
+--        REVOKE breeze_audit_admin FROM breeze_app;
+--
+--      (Re-running is a no-op; REVOKE of a non-membership is harmless.)
+--
+-- After step 5, the integration test
+-- `auditRetentionPrivSep.integration.test.ts` proves a breeze_app
+-- connection can no longer `SET ROLE breeze_audit_admin`.
+
+DO $$ BEGIN
+  RAISE NOTICE '[#915] breeze_audit_admin is still GRANTed to breeze_app. The REVOKE is a documented MANUAL follow-up — see the runbook in this migration file. Provision AUDIT_ADMIN_DATABASE_URL first, verify retention, then run: REVOKE breeze_audit_admin FROM breeze_app;';
+END $$;

--- a/apps/api/src/__tests__/integration/auditRetentionPrivSep.integration.test.ts
+++ b/apps/api/src/__tests__/integration/auditRetentionPrivSep.integration.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Integration test for the #915 audit-retention privilege-separation fix.
+ *
+ * Two things only a real Postgres can prove:
+ *
+ *   1. SECURE PATH — when AUDIT_ADMIN_DATABASE_URL points at a dedicated
+ *      `breeze_audit_admin` login, `pruneExpiredAuditLogs` deletes expired
+ *      rows end-to-end through that pool (no SET ROLE involved).
+ *
+ *   2. POST-REVOKE — after `REVOKE breeze_audit_admin FROM breeze_app`, a
+ *      breeze_app connection can no longer `SET ROLE breeze_audit_admin`,
+ *      so the legacy in-process bypass is dead. (The grant is restored in
+ *      afterAll so other integration tests that exercise the legacy path
+ *      keep working.)
+ *
+ * audit_logs is append-only: the trigger blocks DELETE/TRUNCATE. setup.ts
+ * cleans it between tests via `session_replication_role = replica` + DELETE,
+ * which is the same lever we'd use for manual cleanup here.
+ */
+import './setup';
+import { describe, it, expect, beforeEach, afterAll, beforeAll } from 'vitest';
+import { sql } from 'drizzle-orm';
+import postgres from 'postgres';
+import { getTestDb } from './setup';
+import { createPartner, createOrganization } from './db-utils';
+import { pruneExpiredAuditLogs } from '../../jobs/auditRetention';
+import { closeAuditAdminPool, hasDedicatedAuditAdminPool } from '../../db/auditAdminPool';
+
+// Derive the dedicated audit-admin URL from DATABASE_URL_APP (same host /
+// port / db), swapping in the breeze_audit_admin role + a test password we
+// set on the role below. Mirrors how an operator would build
+// AUDIT_ADMIN_DATABASE_URL from their existing connection.
+const APP_URL =
+  process.env.DATABASE_URL_APP || 'postgresql://breeze_app:breeze_test@localhost:5433/breeze_test';
+const AUDIT_ADMIN_PASSWORD = 'audit_admin_test_pw';
+
+function buildAuditAdminUrl(): string {
+  const u = new URL(APP_URL);
+  u.username = 'breeze_audit_admin';
+  u.password = AUDIT_ADMIN_PASSWORD;
+  return u.toString();
+}
+
+const prevEnv = process.env.AUDIT_ADMIN_DATABASE_URL;
+
+describe('#915 audit-retention privilege separation', () => {
+  let orgId: string;
+
+  beforeAll(async () => {
+    // Make breeze_audit_admin a login role with a known password so the
+    // dedicated pool can connect AS that role directly. Idempotent.
+    await getTestDb().execute(sql`ALTER ROLE breeze_audit_admin WITH LOGIN`);
+    await getTestDb().execute(
+      sql.raw(`ALTER ROLE breeze_audit_admin PASSWORD '${AUDIT_ADMIN_PASSWORD}'`),
+    );
+  });
+
+  beforeEach(async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    orgId = org.id;
+  });
+
+  afterAll(async () => {
+    await closeAuditAdminPool();
+    if (prevEnv === undefined) {
+      delete process.env.AUDIT_ADMIN_DATABASE_URL;
+    } else {
+      process.env.AUDIT_ADMIN_DATABASE_URL = prevEnv;
+    }
+  });
+
+  it('runs retention end-to-end through the dedicated audit-admin pool', async () => {
+    process.env.AUDIT_ADMIN_DATABASE_URL = buildAuditAdminUrl();
+    // Ensure the lazily-built pool picks up this URL fresh.
+    await closeAuditAdminPool();
+    expect(hasDedicatedAuditAdminPool()).toBe(true);
+
+    await getTestDb().execute(sql`
+      INSERT INTO audit_retention_policies (org_id, retention_days)
+      VALUES (${orgId}, 30)
+    `);
+    await getTestDb().execute(sql`
+      INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result, timestamp)
+      VALUES (${orgId}, 'system', gen_random_uuid(), 'old.action', 'test', 'success', now() - interval '60 days')
+    `);
+
+    const stats = await pruneExpiredAuditLogs();
+    expect(stats.errors).toBe(0);
+    expect(stats.rowsDeleted).toBeGreaterThanOrEqual(1);
+
+    const after = (await getTestDb().execute(
+      sql`SELECT count(*)::int AS n FROM audit_logs WHERE org_id = ${orgId}`,
+    )) as unknown as Array<{ n: number }>;
+    expect(after[0]?.n).toBe(0);
+  });
+
+  it('after REVOKE, breeze_app can no longer SET ROLE breeze_audit_admin', async () => {
+    // Open a short-lived breeze_app connection so we can prove the
+    // privilege boundary directly, independent of the app pool.
+    const appClient = postgres(APP_URL, { max: 1, idle_timeout: 5, connect_timeout: 10 });
+    try {
+      // Sanity: while the grant exists, SET ROLE succeeds.
+      await appClient`SET ROLE breeze_audit_admin`;
+      await appClient`RESET ROLE`;
+
+      // Apply the #915 REVOKE (the documented manual follow-up).
+      await getTestDb().execute(sql`REVOKE breeze_audit_admin FROM breeze_app`);
+
+      // Reconnect: membership is checked at SET ROLE time; use a fresh
+      // connection to avoid any cached session-role state.
+      await appClient.end();
+      const appClient2 = postgres(APP_URL, { max: 1, idle_timeout: 5, connect_timeout: 10 });
+      try {
+        let caught: unknown;
+        try {
+          await appClient2`SET ROLE breeze_audit_admin`;
+        } catch (err) {
+          caught = err;
+        }
+        expect(caught).toBeDefined();
+        expect((caught as { message?: string })?.message ?? '').toMatch(
+          /permission denied|must be (?:a )?member/i,
+        );
+      } finally {
+        await appClient2.end();
+      }
+    } finally {
+      // Restore the grant so the legacy-path tests (audit-retention.integration)
+      // and any other consumer keep working.
+      await getTestDb().execute(sql`GRANT breeze_audit_admin TO breeze_app`);
+      // appClient may already be ended above; guard.
+      try {
+        await appClient.end();
+      } catch {
+        /* already closed */
+      }
+    }
+  });
+});

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -347,6 +347,22 @@ const envSchema = z
       .optional()
       .describe('Password for the breeze_app role. If unset, ensureAppRole falls back to POSTGRES_PASSWORD.'),
 
+    // Issue #915: dedicated connection string for the `breeze_audit_admin`
+    // login role used ONLY by the audit-log retention worker. When set,
+    // retention deletes run on a separate pool with connection-level
+    // privilege separation, so audit_logs DELETE is unreachable from the
+    // main breeze_app pool. When unset, retention falls back to the legacy
+    // shared-credential path and logs a startup warning. Optional so
+    // existing deploys keep working until they provision the credential.
+    AUDIT_ADMIN_DATABASE_URL: z
+      .string()
+      .optional()
+      .refine(
+        (v) => !v || v.startsWith('postgres://') || v.startsWith('postgresql://'),
+        { message: 'AUDIT_ADMIN_DATABASE_URL must be a valid postgres:// or postgresql:// URL' },
+      )
+      .describe('Optional dedicated connection for the breeze_audit_admin role (audit retention worker, issue #915). If unset, retention uses the legacy breeze_app + SET ROLE path.'),
+
     JWT_SECRET: z
       .string({ required_error: 'JWT_SECRET is required' })
       .min(1, 'JWT_SECRET must not be empty'),
@@ -1142,6 +1158,7 @@ export function validateConfig(): AppConfig {
     DATABASE_URL: env.DATABASE_URL,
     DATABASE_URL_APP: env.DATABASE_URL_APP,
     BREEZE_APP_DB_PASSWORD: env.BREEZE_APP_DB_PASSWORD,
+    AUDIT_ADMIN_DATABASE_URL: env.AUDIT_ADMIN_DATABASE_URL,
     JWT_SECRET: env.JWT_SECRET,
     JWT_SIGNING_KEYRING: env.JWT_SIGNING_KEYRING,
     JWT_ACTIVE_KID: env.JWT_ACTIVE_KID,

--- a/apps/api/src/db/auditAdminPool.ts
+++ b/apps/api/src/db/auditAdminPool.ts
@@ -1,0 +1,116 @@
+/**
+ * Dedicated audit-admin connection pool (issue #915).
+ *
+ * The audit-log retention worker is the only code path allowed to DELETE
+ * from `audit_logs`. Originally it ran on the shared `breeze_app` pool and
+ * relied on `SET LOCAL ROLE breeze_audit_admin` + a bypass GUC — but
+ * migration 2026-05-25-i granted `breeze_audit_admin` membership to
+ * `breeze_app`, which means an attacker with SQLi/RCE inside the API
+ * process could replicate the exact two-gate bypass and wipe audit rows
+ * from the same connection.
+ *
+ * The fix is a *separate* pool that logs in directly as the
+ * `breeze_audit_admin` role (no membership / SET ROLE involved). Once
+ * `breeze_audit_admin` is REVOKEd from `breeze_app`, the main app pool can
+ * never delete audit rows even if fully compromised — privilege separation
+ * at the connection layer rather than the statement layer.
+ *
+ * Configuration is OPTIONAL and gated on `AUDIT_ADMIN_DATABASE_URL`:
+ *   - SET   → secure path: retention runs on this dedicated pool.
+ *   - UNSET → legacy fallback: retention runs on the breeze_app pool with
+ *             SET LOCAL ROLE (the pre-#915 behavior), and a loud startup
+ *             warning is logged. This lets existing deploys keep working
+ *             until they provision the dedicated credential. The REVOKE
+ *             migration is intentionally NOT auto-applied (see
+ *             2026-06-11-e-...) so this fallback never breaks prod.
+ */
+
+import { sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import * as schema from './schema';
+
+export type AuditAdminDb = ReturnType<typeof drizzle<typeof schema>>;
+
+let cachedDb: AuditAdminDb | null = null;
+let cachedClient: ReturnType<typeof postgres> | null = null;
+let warnedLegacy = false;
+
+/**
+ * True when a dedicated audit-admin credential is configured. When false,
+ * the retention worker falls back to the legacy shared-credential path.
+ */
+export function hasDedicatedAuditAdminPool(): boolean {
+  const url = process.env.AUDIT_ADMIN_DATABASE_URL;
+  return typeof url === 'string' && url.trim().length > 0;
+}
+
+/**
+ * Returns the dedicated audit-admin Drizzle handle, lazily constructing
+ * the pool on first use. Throws if `AUDIT_ADMIN_DATABASE_URL` is unset —
+ * callers must gate on `hasDedicatedAuditAdminPool()` first.
+ *
+ * The pool is deliberately tiny: retention is a once-daily, single-org-at-
+ * a-time job, so a couple of connections is plenty. Keeping it small also
+ * minimizes the number of privileged connections sitting in the pool.
+ */
+export function getAuditAdminDb(): AuditAdminDb {
+  const url = process.env.AUDIT_ADMIN_DATABASE_URL;
+  if (!url || url.trim().length === 0) {
+    throw new Error(
+      '[AuditAdminPool] AUDIT_ADMIN_DATABASE_URL is not set — call hasDedicatedAuditAdminPool() before getAuditAdminDb()',
+    );
+  }
+  if (cachedDb) return cachedDb;
+
+  cachedClient = postgres(url, {
+    max: 2,
+    idle_timeout: 20,
+    max_lifetime: 60 * 30,
+    connect_timeout: 10,
+  });
+  cachedDb = drizzle(cachedClient, { schema });
+  return cachedDb;
+}
+
+/**
+ * One-time startup diagnostic, called from the worker initializer. Logs a
+ * loud warning when running in the insecure legacy shared-credential mode
+ * so operators are nudged to provision `AUDIT_ADMIN_DATABASE_URL`.
+ */
+export function logAuditAdminPoolMode(): void {
+  if (hasDedicatedAuditAdminPool()) {
+    console.log(
+      '[AuditRetention] Dedicated audit-admin credential configured (AUDIT_ADMIN_DATABASE_URL) — retention runs with connection-level privilege separation.',
+    );
+    return;
+  }
+  if (!warnedLegacy) {
+    warnedLegacy = true;
+    console.warn(
+      '[AuditRetention] SECURITY: AUDIT_ADMIN_DATABASE_URL is NOT set. ' +
+        'Retention is running in LEGACY shared-credential mode (breeze_app + SET LOCAL ROLE). ' +
+        'This means audit_logs DELETE is reachable from the main app connection (issue #915). ' +
+        'Provision a breeze_audit_admin login and set AUDIT_ADMIN_DATABASE_URL to close the bypass.',
+    );
+  }
+}
+
+/**
+ * Lightweight liveness check used by tests. Runs `SELECT 1` against the
+ * dedicated pool.
+ */
+export async function auditAdminPoolPing(): Promise<boolean> {
+  const adminDb = getAuditAdminDb();
+  await adminDb.execute(sql`SELECT 1`);
+  return true;
+}
+
+/** Closes the dedicated pool (graceful shutdown / test teardown). */
+export async function closeAuditAdminPool(): Promise<void> {
+  if (cachedClient) {
+    await cachedClient.end();
+  }
+  cachedClient = null;
+  cachedDb = null;
+}

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -165,6 +165,21 @@ export const db = Object.assign(proxiedDb, {
 
 export type Database = typeof db;
 
+// Dedicated audit-admin pool (issue #915). Re-exported here so the
+// retention worker has a single db import surface. See auditAdminPool.ts
+// for the rationale (connection-level privilege separation).
+export {
+  getAuditAdminDb,
+  hasDedicatedAuditAdminPool,
+  logAuditAdminPoolMode,
+  closeAuditAdminPool,
+  type AuditAdminDb,
+} from './auditAdminPool';
+
+import { closeAuditAdminPool as closeAuditAdminPoolInternal } from './auditAdminPool';
+
 export async function closeDb(): Promise<void> {
-  await client.end();
+  // Drain the dedicated audit-admin pool (#915) alongside the main pool so a
+  // graceful shutdown doesn't leak its connection.
+  await Promise.all([client.end(), closeAuditAdminPoolInternal()]);
 }

--- a/apps/api/src/jobs/auditRetention.ts
+++ b/apps/api/src/jobs/auditRetention.ts
@@ -1,22 +1,35 @@
 /**
- * Audit-Log Retention Worker (Task 29)
+ * Audit-Log Retention Worker (Task 29; hardened for issue #915)
  *
  * Walks `audit_retention_policies` daily and deletes `audit_logs` rows
- * older than each policy's `retention_days`. Bypasses Task 1's
- * append-only protections via two stacked layers (both required):
+ * older than each policy's `retention_days`.
  *
- *   1. `SET LOCAL ROLE breeze_audit_admin` — `breeze_app` has no DELETE
- *      privilege on `audit_logs` (migration 2026-05-25-a). The
- *      `breeze_audit_admin` role (migration 2026-05-25-i) does, and
- *      breeze_app is a member, so a SET LOCAL ROLE inside the
- *      transaction is sufficient to clear the privilege check.
+ * SECURE PATH (AUDIT_ADMIN_DATABASE_URL set, post-#915):
+ *   The DELETE runs on a *dedicated* pool that logs in directly as the
+ *   `breeze_audit_admin` role (db/auditAdminPool.ts). That role holds the
+ *   DELETE privilege; the main `breeze_app` pool does not and — once
+ *   `breeze_audit_admin` is REVOKEd from `breeze_app` — cannot acquire it.
+ *   Only the trigger-bypass GUC (layer 2 below) is still set; no SET ROLE
+ *   is needed because the connection already *is* the admin role. This is
+ *   the privilege-separation fix: an attacker inside the API process,
+ *   holding only a breeze_app connection, can no longer delete audit rows.
  *
- *   2. `SET LOCAL breeze.allow_audit_retention = '1'` — the
- *      `audit_log_immutable` trigger refuses every DELETE unless this
- *      session GUC is '1'. The bypass is per-transaction (SET LOCAL)
- *      and is never set outside this worker. Even another bug that
- *      somehow obtained the role membership cannot delete without
- *      explicitly setting this GUC in the same transaction.
+ * LEGACY FALLBACK (AUDIT_ADMIN_DATABASE_URL unset, pre-#915 behavior):
+ *   The DELETE runs on the shared breeze_app pool and defeats the
+ *   append-only protections via two stacked layers (both required):
+ *
+ *     1. `SET LOCAL ROLE breeze_audit_admin` — breeze_app is a member of
+ *        the role (migration 2026-05-25-i), so a SET LOCAL ROLE inside the
+ *        transaction clears the privilege check.
+ *     2. `SET LOCAL breeze.allow_audit_retention = '1'` — the
+ *        `audit_log_immutable` trigger refuses every DELETE unless this
+ *        session GUC is '1'.
+ *
+ *   This mode is reachable from the breeze_app connection (issue #915) and
+ *   logs a loud startup warning. Existing deploys keep working here until
+ *   they provision AUDIT_ADMIN_DATABASE_URL.
+ *
+ * In BOTH paths the trigger still requires `breeze.allow_audit_retention`:
  *
  * Per-policy transaction isolation: each policy runs in its own
  * `withSystemDbAccessContext` so a failure deleting for one org does
@@ -39,6 +52,11 @@
 import { Queue, Worker, Job } from 'bullmq';
 import { sql } from 'drizzle-orm';
 import * as dbModule from '../db';
+import {
+  getAuditAdminDb,
+  hasDedicatedAuditAdminPool,
+  logAuditAdminPoolMode,
+} from '../db/auditAdminPool';
 import { captureException } from '../services/sentry';
 import { getBullMQConnection } from '../services/redis';
 
@@ -78,6 +96,116 @@ interface PolicyRow {
   retention_days: number;
 }
 
+// Minimal shape of the postgres-js / drizzle handle we need. Both the
+// dedicated audit-admin pool and the request-scoped breeze_app tx expose
+// `.execute(sql)`, so the prune routine is agnostic to which one it runs on.
+interface SqlExecutor {
+  execute: (query: ReturnType<typeof sql>) => Promise<unknown>;
+}
+
+function extractRowCount(result: unknown): number {
+  const raw = result as { rowCount?: number; count?: number };
+  if (typeof raw.rowCount === 'number') return raw.rowCount;
+  if (typeof raw.count === 'number') return raw.count;
+  return Array.isArray(result) ? (result as unknown[]).length : 0;
+}
+
+/**
+ * The DELETE + chain re-anchor for a single org, parameterized over the
+ * executor so it can run on either pool. Assumes the caller has already
+ * armed the trigger-bypass GUC (`breeze.allow_audit_retention = '1'`) on
+ * the same transaction/connection.
+ */
+async function deleteAndReanchor(exec: SqlExecutor, policy: PolicyRow): Promise<number> {
+  const result = await exec.execute(sql`
+    DELETE FROM audit_logs
+    WHERE org_id = ${policy.org_id}
+      AND timestamp < (now() - (${policy.retention_days}::int * interval '1 day'))
+  `);
+  const count = extractRowCount(result);
+
+  // Re-anchor the chain. After the DELETE the new oldest surviving row
+  // still carries prev_checksum pointing at the deleted row, which makes
+  // audit_log_verify_chain flag it as a break the next morning — defeating
+  // the entire tamper-detection signal.
+  //
+  // Find the new chain head per org and rewrite prev_checksum to NULL +
+  // checksum to the canonical hash with prev=NULL. The WHERE filter on the
+  // existing prev_checksum makes this a no-op when no rows were deleted
+  // (oldest row's prev_checksum already NULL) and avoids unnecessary writes
+  // on idempotent reruns.
+  if (count > 0) {
+    await exec.execute(sql`
+      WITH head AS (
+        SELECT a.*
+        FROM audit_logs a
+        WHERE a.org_id IS NOT DISTINCT FROM ${policy.org_id}
+        ORDER BY a.timestamp, a.id
+        LIMIT 1
+      )
+      UPDATE audit_logs
+      SET prev_checksum = NULL,
+          checksum = encode(
+            -- convert_to(... ,'UTF8'), not ::bytea: the text->bytea cast
+            -- throws on the backslash escapes jsonb details::text emits.
+            -- Must match the trigger/verifier hash exactly or this
+            -- re-anchor would itself break the chain.
+            sha256(convert_to(audit_log_canonical_payload(head, NULL), 'UTF8')),
+            'hex'
+          )
+      FROM head
+      WHERE audit_logs.id = head.id
+        AND head.prev_checksum IS NOT NULL
+    `);
+  }
+
+  return count;
+}
+
+/**
+ * Prune one org's expired audit rows.
+ *
+ *  - SECURE path (AUDIT_ADMIN_DATABASE_URL set): open a transaction on the
+ *    dedicated breeze_audit_admin pool, arm only the bypass GUC, and run
+ *    the DELETE. No SET ROLE — the connection already holds DELETE.
+ *  - LEGACY path: run on the breeze_app pool via withSystemDbAccessContext,
+ *    arming BOTH the SET LOCAL ROLE and the bypass GUC (pre-#915 behavior).
+ */
+async function pruneOrg(policy: PolicyRow): Promise<number> {
+  if (hasDedicatedAuditAdminPool()) {
+    const adminDb = getAuditAdminDb();
+    // Run inside a transaction so SET LOCAL is scoped to this prune. The
+    // dedicated pool is NOT under the AsyncLocalStorage db-context, so we
+    // drive its own transaction directly.
+    return adminDb.transaction(async (tx) => {
+      // The dedicated pool is OUTSIDE the AsyncLocalStorage db-context, so it
+      // has none of the RLS GUCs set. audit_logs has RLS forced and
+      // breeze_audit_admin has no BYPASSRLS, so without system scope the
+      // DELETE policy `breeze_has_org_access(org_id)` would filter every row
+      // out (silent zero-delete). Establish system scope on this tx so the
+      // policy passes — same GUCs withSystemDbAccessContext sets.
+      await tx.execute(sql`select set_config('breeze.scope', 'system', true)`);
+      await tx.execute(sql`select set_config('breeze.org_id', '', true)`);
+      await tx.execute(sql`select set_config('breeze.accessible_org_ids', '*', true)`);
+      await tx.execute(sql`select set_config('breeze.accessible_partner_ids', '*', true)`);
+      await tx.execute(sql`select set_config('breeze.user_id', '', true)`);
+      // Trigger bypass; the connection logs in AS breeze_audit_admin, which
+      // already holds the DELETE privilege (no SET ROLE needed).
+      await tx.execute(sql`SET LOCAL breeze.allow_audit_retention = '1'`);
+      return deleteAndReanchor(tx as unknown as SqlExecutor, policy);
+    });
+  }
+
+  // Legacy shared-credential fallback (issue #915 not yet remediated).
+  return runWithSystemDbAccess(async () => {
+    // Both bypass layers are SET LOCAL — they apply only to this
+    // transaction and revert on commit/rollback automatically.
+    await dbModule.db.execute(sql`SET LOCAL ROLE breeze_audit_admin`);
+    await dbModule.db.execute(sql`SET LOCAL breeze.allow_audit_retention = '1'`);
+    return deleteAndReanchor(dbModule.db as unknown as SqlExecutor, policy);
+  });
+}
+
 /**
  * Walk all retention policies and prune expired audit_logs rows.
  *
@@ -109,61 +237,7 @@ export async function pruneExpiredAuditLogs(): Promise<RetentionStats> {
 
   for (const policy of policies) {
     try {
-      const rowsDeleted = await runWithSystemDbAccess(async () => {
-        // Both bypass layers are SET LOCAL — they apply only to this
-        // transaction and revert on commit/rollback automatically.
-        await dbModule.db.execute(sql`SET LOCAL ROLE breeze_audit_admin`);
-        await dbModule.db.execute(sql`SET LOCAL breeze.allow_audit_retention = '1'`);
-
-        const result = await dbModule.db.execute(sql`
-          DELETE FROM audit_logs
-          WHERE org_id = ${policy.org_id}
-            AND timestamp < (now() - (${policy.retention_days}::int * interval '1 day'))
-        `);
-        const raw = result as unknown as { rowCount?: number; count?: number };
-        const count = typeof raw.rowCount === 'number'
-          ? raw.rowCount
-          : typeof raw.count === 'number'
-            ? raw.count
-            : Array.isArray(result) ? (result as unknown[]).length : 0;
-
-        // Re-anchor the chain. After the DELETE the new oldest surviving
-        // row still carries prev_checksum pointing at the deleted row,
-        // which makes audit_log_verify_chain flag it as a break the next
-        // morning — defeating the entire tamper-detection signal.
-        //
-        // Find the new chain head per org and rewrite prev_checksum to
-        // NULL + checksum to the canonical hash with prev=NULL. The
-        // WHERE filter on the existing prev_checksum makes this a no-op
-        // when no rows were deleted (oldest row's prev_checksum already
-        // NULL) and avoids unnecessary writes on idempotent reruns.
-        if (count > 0) {
-          await dbModule.db.execute(sql`
-            WITH head AS (
-              SELECT a.*
-              FROM audit_logs a
-              WHERE a.org_id IS NOT DISTINCT FROM ${policy.org_id}
-              ORDER BY a.timestamp, a.id
-              LIMIT 1
-            )
-            UPDATE audit_logs
-            SET prev_checksum = NULL,
-                checksum = encode(
-                  -- convert_to(... ,'UTF8'), not ::bytea: the text->bytea cast
-                  -- throws on the backslash escapes jsonb details::text emits.
-                  -- Must match the trigger/verifier hash exactly or this
-                  -- re-anchor would itself break the chain.
-                  sha256(convert_to(audit_log_canonical_payload(head, NULL), 'UTF8')),
-                  'hex'
-                )
-            FROM head
-            WHERE audit_logs.id = head.id
-              AND head.prev_checksum IS NOT NULL
-          `);
-        }
-
-        return count;
-      });
+      const rowsDeleted = await pruneOrg(policy);
 
       stats.rowsDeleted += rowsDeleted;
       stats.orgsPruned += 1;
@@ -266,6 +340,11 @@ export async function scheduleAuditRetention(
 
 export async function initializeAuditRetentionWorker(): Promise<void> {
   try {
+    // Log secure-vs-legacy mode loudly so operators running pre-#915
+    // shared-credential retention are nudged to provision the dedicated
+    // AUDIT_ADMIN_DATABASE_URL credential.
+    logAuditAdminPoolMode();
+
     retentionWorker = createAuditRetentionWorker();
 
     retentionWorker.on('error', (error) => {


### PR DESCRIPTION
**Closes #915.**

`apps/api/migrations/2026-05-25-i-audit-retention-role.sql` did `GRANT breeze_audit_admin TO breeze_app`, so the two-gate retention design (`SET LOCAL ROLE breeze_audit_admin` + `allow_audit_retention` GUC) was fully reachable from the same `breeze_app` connection. An attacker with SQLi or RCE in the API process could replicate both gates in-process and `DELETE FROM audit_logs`. Append-only triggers close the accident cases; this is the sophisticated-attacker case.

## Fix
Split retention onto a **dedicated pool that logs in directly as `breeze_audit_admin`** (no `SET ROLE`), so deleting audit rows requires a distinct credential, not just code-execution in the API.

- `db/auditAdminPool.ts` — lazy pool keyed on a new optional `AUDIT_ADMIN_DATABASE_URL`.
- `jobs/auditRetention.ts` — secure path runs the `DELETE` on the dedicated pool. **Note:** `breeze_audit_admin` has no `BYPASSRLS` and `audit_logs` forces RLS, so the dedicated-pool delete must set the system-scope RLS GUCs on its txn or it silently deletes 0 rows. Legacy `breeze_app` + `SET ROLE` path retained as fallback when the env var is unset, with a loud startup warning.
- `closeDb()` now drains the dedicated pool too (was leaking on shutdown).
- `2026-06-11-d-…-admin-login.sql` — idempotent `ALTER ROLE breeze_audit_admin WITH LOGIN`.
- `2026-06-11-e-…-revoke-breeze-app.sql` — **NOTICE-only, no auto-REVOKE.** The credential lives in app env, so there's no reliable in-DB signal it's provisioned; auto-revoking would break retention on any deploy that migrated before wiring the env var. The `REVOKE` is a documented manual runbook step.
- Integration test: dedicated-pool delete end-to-end + post-`REVOKE` `SET ROLE` denial.

## ⚠️ Deploy steps to actually close the bypass
1. `ALTER ROLE breeze_audit_admin PASSWORD '<secret>';`
2. Add `AUDIT_ADMIN_DATABASE_URL=postgresql://breeze_audit_admin:<secret>@<host>:5432/breeze` to `/opt/breeze/.env` **and** map it in the `api` service `environment:` block (compose interpolation only happens for listed vars).
3. Redeploy; confirm the "dedicated audit-admin credential configured" startup log.
4. Verify a retention run.
5. Only then: `REVOKE breeze_audit_admin FROM breeze_app;`

Until step 5, retention runs in legacy shared-credential mode (warned) — no breakage. Applying the migration set alone is a no-op for retention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)