### PR TITLE
fix(agent): bind assist/user Helper IPC roles to active console session (#1009)

### DIFF
--- a/agent/internal/heartbeat/handlers_script.go
+++ b/agent/internal/heartbeat/handlers_script.go
@@ -86,9 +86,11 @@ func resolveRunAsSession(broker *sessionbroker.Broker, runAs string) *sessionbro
 	}
 
 	// runAs=user means "current interactive user". Prefer a user-role helper
-	// (runs as the logged-in user) over a SYSTEM helper.
+	// (runs as the logged-in user) over a SYSTEM helper. On Windows the
+	// candidate is constrained to the active console session so a co-logged-in
+	// user's helper can't intercept the script (#1009).
 	if strings.EqualFold(target, "user") {
-		return broker.PreferredSessionWithScope("run_as_user")
+		return broker.PreferredRunAsUserSession()
 	}
 
 	// Legacy path: explicit usernames still resolve directly.

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -2596,6 +2596,14 @@ func (h *Heartbeat) handleHelperSessionAuthenticated(session *sessionbroker.Sess
 	if session == nil || !shouldPushHelperToken(session.AllowedScopes) {
 		return
 	}
+	// #1009: never deliver the device helper token to an assist helper outside
+	// the active console session — on a multi-user host that would hand a
+	// co-logged-in user org-scoped fleet access. Inert on single-user/non-Windows.
+	if h.sessionBroker != nil && !h.sessionBroker.SessionInConsoleSession(session) {
+		log.Warn("withholding helper token from non-console assist session",
+			"sessionId", session.SessionID, "winSessionId", session.WinSessionID)
+		return
+	}
 	token := h.currentHelperToken()
 	if token == "" {
 		return
@@ -2614,6 +2622,12 @@ func (h *Heartbeat) sendHelperTokenUpdate(newToken string) {
 	}
 	for _, sess := range h.sessionBroker.SessionsWithScope(ipc.ScopeAssist) {
 		if !shouldPushHelperToken(sess.AllowedScopes) {
+			continue
+		}
+		// #1009: only the console-session assist helper may receive the token.
+		if !h.sessionBroker.SessionInConsoleSession(sess) {
+			log.Warn("withholding rotated helper token from non-console assist session",
+				"sessionId", sess.SessionID, "winSessionId", sess.WinSessionID)
 			continue
 		}
 		h.pushHelperToken(sess, newToken)
@@ -3489,7 +3503,7 @@ func (h *Heartbeat) makeUserExecFunc() patching.UserExecFunc {
 			return "", "", -1, fmt.Errorf("no session broker available")
 		}
 
-		session := h.sessionBroker.PreferredSessionWithScope("run_as_user")
+		session := h.sessionBroker.PreferredRunAsUserSession()
 		if session == nil {
 			return "", "", -1, fmt.Errorf("no user helper connected")
 		}

--- a/agent/internal/heartbeat/heartbeat_token_test.go
+++ b/agent/internal/heartbeat/heartbeat_token_test.go
@@ -95,6 +95,38 @@ func TestSendHelperTokenUpdateOnlyReachesAssistSessions(t *testing.T) {
 	}
 }
 
+// TestHelperTokenNotDeliveredToNonConsoleAssist proves the #1009 fix at the
+// heartbeat wiring layer: on a multi-user host an assist session that is NOT in
+// the active console session must never receive the device helper token, even
+// though it carries assist scope. The console assist session still receives it.
+//
+// The active console session id is injected via the broker's test seam so this
+// runs deterministically on darwin without Windows APIs.
+func TestHelperTokenNotDeliveredToNonConsoleAssist(t *testing.T) {
+	const secret = "brz_secret"
+
+	consoleAssist := newHelperTokenSession(t, "assist-console", []string{ipc.ScopeAssist})
+	consoleAssist.session.WinSessionID = "1"
+
+	otherAssist := newHelperTokenSession(t, "assist-other", []string{ipc.ScopeAssist})
+	otherAssist.session.WinSessionID = "3"
+
+	broker := newTestBrokerWithSessions(t, consoleAssist.session, otherAssist.session)
+	broker.SetConsoleSessionIDFunc(func() string { return "1" })
+	broker.SetGOOSForTest("windows") // exercise the multi-user console-session binding
+
+	h := &Heartbeat{sessionBroker: broker}
+	h.setHelperToken(secret)
+	h.sendHelperTokenUpdate(secret)
+
+	if token, _ := awaitHelperToken(t, consoleAssist.client); token != secret {
+		t.Fatalf("console assist: expected helper token %q, got %q", secret, token)
+	}
+	if _, gotFrame := awaitHelperToken(t, otherAssist.client); gotFrame {
+		t.Fatal("non-console assist session received a frame; helper token must never leave the console session")
+	}
+}
+
 // TestHandleHelperSessionAuthenticatedPushesOnlyToAssist proves the connect-time
 // push path: a freshly authenticated assist session receives the retained token,
 // while a watchdog session does not — even when both are driven through the same

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -272,6 +272,18 @@ type Broker struct {
 	onSessionClosed SessionClosedHandler
 	onSessionAuthed SessionAuthenticatedHandler
 	selfHashes      map[string]struct{} // SHA-256 of allowed helper binaries
+
+	// consoleSessionIDFn returns the active console (physical-monitor) Windows
+	// session id. It is the injectable seam that makes the assist/user
+	// console-session binding (#1009) unit-testable on non-Windows hosts: the
+	// platform-specific WTSGetActiveConsoleSessionId lookup lives behind the
+	// build-tagged GetConsoleSessionID(), which this defaults to in New().
+	consoleSessionIDFn func() string
+
+	// goos is the effective OS for console-session-binding decisions. Defaults
+	// to runtime.GOOS in New(); tests override it to drive the Windows
+	// multi-user code path on a darwin host.
+	goos string
 }
 
 // New creates a new session broker.
@@ -281,9 +293,11 @@ func New(socketPath string, onMessage MessageHandler) *Broker {
 		rateLimiter:  ipc.NewRateLimiter(RateLimitAttempts, RateLimitWindow),
 		startTime:    time.Now(),
 		sessions:     make(map[string]*Session),
-		byIdentity:   make(map[string][]*Session),
-		staleHelpers: make(map[string][]int),
-		onMessage:    onMessage,
+		byIdentity:         make(map[string][]*Session),
+		staleHelpers:       make(map[string][]int),
+		onMessage:          onMessage,
+		consoleSessionIDFn: GetConsoleSessionID,
+		goos:               runtime.GOOS,
 	}
 	b.selfHashes = b.computeAllowedHashes()
 	b.publishSnapshotLocked() // initialise with empty maps
@@ -528,6 +542,120 @@ func (b *Broker) PreferredSessionWithScope(scope string) *Session {
 	var best *Session
 	for _, s := range b.sessions {
 		if !s.HasScope(scope) {
+			continue
+		}
+		if best == nil {
+			best = s
+			continue
+		}
+		if s.HelperRole == ipc.HelperRoleUser && best.HelperRole != ipc.HelperRoleUser {
+			best = s
+			continue
+		}
+		if s.HelperRole != ipc.HelperRoleUser && best.HelperRole == ipc.HelperRoleUser {
+			continue
+		}
+		if betterSession(s, best) {
+			best = s
+		}
+	}
+	return best
+}
+
+// ConsoleSessionID returns the active console (physical-monitor) Windows
+// session id via the injectable seam (defaults to GetConsoleSessionID()). On
+// non-Windows hosts GetConsoleSessionID() returns "1".
+func (b *Broker) ConsoleSessionID() string {
+	var id string
+	if b.consoleSessionIDFn != nil {
+		id = b.consoleSessionIDFn()
+	} else {
+		id = GetConsoleSessionID()
+	}
+	// "0" is both the services/SYSTEM session (Session 0 isolation reserves it —
+	// no non-SYSTEM interactive user is ever legitimately there since Vista) and
+	// the sentinel GetConsoleSessionID() returns when WTSGetActiveConsoleSessionId
+	// fails or no session is attached (the API returns 0xFFFFFFFF). Either way it
+	// is not a valid interactive console session, so normalize it to "" — every
+	// consumer treats "" as "unknown → fail closed" for the assist/user binding,
+	// rather than admitting a peer that happens to report session 0 (#1009).
+	if id == "0" {
+		return ""
+	}
+	return id
+}
+
+// SetConsoleSessionIDFunc overrides the active-console-session lookup. Used by
+// tests to drive the assist/user console-session binding (#1009) deterministically
+// on non-Windows hosts.
+func (b *Broker) SetConsoleSessionIDFunc(fn func() string) {
+	b.mu.Lock()
+	b.consoleSessionIDFn = fn
+	b.mu.Unlock()
+}
+
+// SetGOOSForTest overrides the effective OS used for console-session-binding
+// decisions, letting tests drive the Windows multi-user code path on darwin.
+func (b *Broker) SetGOOSForTest(goos string) {
+	b.mu.Lock()
+	b.goos = goos
+	b.mu.Unlock()
+}
+
+// effectiveGOOS returns the OS used for console-session-binding decisions,
+// defaulting to runtime.GOOS for Broker fixtures constructed without New().
+func (b *Broker) effectiveGOOS() string {
+	if b.goos != "" {
+		return b.goos
+	}
+	return runtime.GOOS
+}
+
+// SessionInConsoleSession reports whether the given session is bound to the
+// active console session. Used to gate delivery of the device helper token so a
+// co-logged-in non-console assist helper can never receive it (#1009).
+//
+// The console-session binding is a Windows multi-user (RDS/terminal-server)
+// concept, so on non-Windows it always returns true (single interactive session
+// — no cross-user boundary to enforce here).
+func (b *Broker) SessionInConsoleSession(s *Session) bool {
+	if s == nil {
+		return false
+	}
+	if b.effectiveGOOS() != "windows" {
+		return true
+	}
+	return s.WinSessionID == b.ConsoleSessionID()
+}
+
+// PreferredRunAsUserSession returns the run_as_user helper to target for the
+// current host. On Windows it is constrained to the active console session so a
+// co-logged-in user's helper can never intercept a run_as_user script meant for
+// the console operator (#1009).
+func (b *Broker) PreferredRunAsUserSession() *Session {
+	return b.preferredRunAsUserSessionForOS(b.effectiveGOOS())
+}
+
+// preferredRunAsUserSessionForOS is the goos-parameterized core of
+// PreferredRunAsUserSession, kept separate so the console-session filter is
+// unit-testable on non-Windows hosts.
+func (b *Broker) preferredRunAsUserSessionForOS(goos string) *Session {
+	if goos != "windows" {
+		// Non-Windows: single interactive session; preserve prior behavior.
+		return b.PreferredSessionWithScope("run_as_user")
+	}
+
+	consoleSession := b.ConsoleSessionID()
+
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	var best *Session
+	for _, s := range b.sessions {
+		if !s.HasScope("run_as_user") {
+			continue
+		}
+		if s.WinSessionID != consoleSession {
 			continue
 		}
 		if best == nil {
@@ -1314,16 +1442,30 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 		return
 	}
 
+	// Kernel-verify the peer's Windows session id (from peer PID, via
+	// ProcessIdToSessionId) BEFORE the role gate so the gate can bind the
+	// assist/user roles to the active console session. On non-Windows / failure
+	// this is "" and the console binding is inert (Unix path returns early).
+	verifiedWinSession := ""
+	if vsid := peerWinSessionID(creds.PID); vsid != 0 {
+		verifiedWinSession = fmt.Sprintf("%d", vsid)
+	}
+	consoleWinSession := b.ConsoleSessionID()
+
 	// Step 10: Validate role matches peer identity to prevent privilege escalation.
 	// On Windows, SYSTEM helpers must run as SYSTEM (S-1-5-18), and user/assist
 	// helpers must NOT run as SYSTEM. This prevents a non-SYSTEM process from
 	// claiming system role to get desktop scopes, or SYSTEM from claiming user
-	// role. The watchdog must also run as root/SYSTEM. The decision is factored
-	// into roleIdentityRejection so the gate can be unit-tested with an injected
-	// peer-cred SID/UID (a real peer-cred SID can't be faked over a pipe).
-	if reason, rejected := roleIdentityRejection(helperRole, creds.SID, creds.UID, runtime.GOOS); rejected {
+	// role. The watchdog must also run as root/SYSTEM. Additionally, assist/user
+	// are bound to the active console session so a co-logged-in user on a
+	// multi-user host can't register them from another session (#1009). The
+	// decision is factored into roleIdentityRejection so the gate can be
+	// unit-tested with an injected peer-cred SID/UID and session ids (none of
+	// which can be faked over a pipe).
+	if reason, rejected := roleIdentityRejection(helperRole, creds.SID, creds.UID, verifiedWinSession, consoleWinSession, runtime.GOOS); rejected {
 		log.Warn("role/identity mismatch",
 			"reason", reason, "role", helperRole, "sid", creds.SID, "uid", creds.UID,
+			"peerWinSession", verifiedWinSession, "consoleWinSession", consoleWinSession,
 			"pid", creds.PID, "binaryKind", authReq.BinaryKind)
 		_ = conn.SendTyped(env.ID, ipc.TypeAuthResponse, ipc.AuthResponse{
 			Accepted:  false,
@@ -1364,14 +1506,16 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 	}
 	session.DesktopContext = authReq.DesktopContext
 
-	// Use kernel-verified Windows session ID (from peer PID) instead of
-	// trusting the self-reported value, preventing session-jumping attacks.
-	if verifiedSID := peerWinSessionID(creds.PID); verifiedSID != 0 {
-		session.WinSessionID = fmt.Sprintf("%d", verifiedSID)
-		if verifiedSID != authReq.WinSessionID {
+	// Use the kernel-verified Windows session ID (computed above from the peer
+	// PID) instead of trusting the self-reported value, preventing
+	// session-jumping attacks. Falls back to the self-reported value only when
+	// the kernel lookup failed (verifiedWinSession == "").
+	if verifiedWinSession != "" {
+		session.WinSessionID = verifiedWinSession
+		if verifiedWinSession != fmt.Sprintf("%d", authReq.WinSessionID) {
 			log.Warn("WinSessionID mismatch — using kernel-verified value",
 				"reported", authReq.WinSessionID,
-				"verified", verifiedSID,
+				"verified", verifiedWinSession,
 				"pid", creds.PID,
 			)
 		}
@@ -1597,11 +1741,23 @@ const systemSID = "S-1-5-18"
 // rejected, and the rejection reason. All role/identity mismatches are
 // permanent. It returns ("", false) when the role/identity pairing is allowed.
 //
+// peerWinSession is the kernel-verified Windows session id of the peer (from
+// ProcessIdToSessionId) and consoleWinSession is the active console session id.
+// On Windows the assist/user roles are additionally bound to the active console
+// session: a co-logged-in non-SYSTEM user on a multi-user host (RDS/terminal
+// server) running the genuine allowlisted Helper from a NON-console session must
+// not be able to register as assist/user — otherwise it would obtain the device
+// helper token and intercept run_as_user scripts meant for the console operator
+// (#1009). The SYSTEM-capture gate is unchanged (still SID-only). The console
+// binding does not apply on Unix (single interactive session; the macOS desktop
+// helper authenticates as user-role from the GUI/loginwindow session).
+//
 // Pure and OS-parameterized so the privilege-escalation gate can be unit-tested
-// with an injected SID/UID — a real peer-cred SID can't be forged over a named
-// pipe / Unix socket, so end-to-end pipe tests can only exercise the current
-// test process's own identity.
-func roleIdentityRejection(role, sid string, uid uint32, goos string) (reason string, rejected bool) {
+// with an injected SID/UID and session ids — a real peer-cred SID and
+// kernel-verified session id can't be forged over a named pipe / Unix socket,
+// so end-to-end pipe tests can only exercise the current test process's own
+// identity.
+func roleIdentityRejection(role, sid string, uid uint32, peerWinSession, consoleWinSession, goos string) (reason string, rejected bool) {
 	if goos == "windows" {
 		switch {
 		case role == ipc.HelperRoleSystem && sid != systemSID:
@@ -1612,6 +1768,23 @@ func roleIdentityRejection(role, sid string, uid uint32, goos string) (reason st
 			return "assist role requires non-SYSTEM identity", true
 		case role == ipc.HelperRoleWatchdog && sid != systemSID:
 			return "watchdog role requires SYSTEM identity", true
+		}
+		// Positive console-session assertion for the cross-user roles. An unknown
+		// console session — "" (lookup failed) or "0" (the Session-0 services
+		// sentinel / WTS-failure value; Broker.ConsoleSessionID normalizes it to
+		// "", but the raw value is rejected here too so this pure gate is correct
+		// in isolation) — is treated as "no match" so we fail closed rather than
+		// admit an arbitrary session.
+		consoleUnknown := consoleWinSession == "" || consoleWinSession == "0"
+		switch role {
+		case ipc.HelperRoleAssist:
+			if consoleUnknown || peerWinSession != consoleWinSession {
+				return "assist role requires the active console session", true
+			}
+		case ipc.HelperRoleUser:
+			if consoleUnknown || peerWinSession != consoleWinSession {
+				return "user role requires the active console session", true
+			}
 		}
 		return "", false
 	}

--- a/agent/internal/sessionbroker/broker_windows_test.go
+++ b/agent/internal/sessionbroker/broker_windows_test.go
@@ -523,7 +523,9 @@ func TestAssistRoleRejectsSystemSID(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			reason, rejected := roleIdentityRejection(tc.role, tc.sid, 0, "windows")
+			// Console session matches peer session so the SID gate (not the
+			// console-session binding) is the assertion under test here.
+			reason, rejected := roleIdentityRejection(tc.role, tc.sid, 0, "1", "1", "windows")
 			if rejected != tc.wantReject {
 				t.Fatalf("rejected = %v, want %v (reason %q)", rejected, tc.wantReject, reason)
 			}

--- a/agent/internal/sessionbroker/console_session_gate_test.go
+++ b/agent/internal/sessionbroker/console_session_gate_test.go
@@ -1,0 +1,248 @@
+package sessionbroker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
+)
+
+// TestRoleIdentityRejectionConsoleSessionBinding verifies the positive
+// console-session assertion added for the assist/user IPC roles (#1009): on a
+// multi-user Windows host, a non-SYSTEM peer in a non-console session that
+// claims assist/user must be rejected, while the same role from the active
+// console session is accepted. The SYSTEM/watchdog paths must be unchanged.
+//
+// The comparison is pure (peer WinSessionID vs active console session id), so it
+// is fully table-testable on darwin without any Windows APIs.
+func TestRoleIdentityRejectionConsoleSessionBinding(t *testing.T) {
+	const nonSystemSID = "S-1-5-21-1-2-3-1001"
+
+	cases := []struct {
+		name           string
+		role           string
+		sid            string
+		peerWinSession string
+		consoleSession string
+		wantReason     string
+		wantReject     bool
+	}{
+		{
+			name:           "assist from console session accepted",
+			role:           ipc.HelperRoleAssist,
+			sid:            nonSystemSID,
+			peerWinSession: "1",
+			consoleSession: "1",
+			wantReject:     false,
+		},
+		{
+			name:           "assist from non-console session rejected",
+			role:           ipc.HelperRoleAssist,
+			sid:            nonSystemSID,
+			peerWinSession: "3",
+			consoleSession: "1",
+			wantReason:     "assist role requires the active console session",
+			wantReject:     true,
+		},
+		{
+			name:           "user from console session accepted",
+			role:           ipc.HelperRoleUser,
+			sid:            nonSystemSID,
+			peerWinSession: "2",
+			consoleSession: "2",
+			wantReject:     false,
+		},
+		{
+			name:           "user from non-console session rejected",
+			role:           ipc.HelperRoleUser,
+			sid:            nonSystemSID,
+			peerWinSession: "2",
+			consoleSession: "1",
+			wantReason:     "user role requires the active console session",
+			wantReject:     true,
+		},
+		{
+			// SYSTEM is gated by SID only and must be unaffected by the
+			// console-session binding regardless of which session it runs in.
+			name:           "system role unaffected by console session",
+			role:           ipc.HelperRoleSystem,
+			sid:            systemSID,
+			peerWinSession: "0",
+			consoleSession: "1",
+			wantReject:     false,
+		},
+		{
+			name:           "watchdog role unaffected by console session",
+			role:           ipc.HelperRoleWatchdog,
+			sid:            systemSID,
+			peerWinSession: "0",
+			consoleSession: "1",
+			wantReject:     false,
+		},
+		{
+			// Existing SID gate still fires before the console check.
+			name:           "assist as SYSTEM still rejected on SID",
+			role:           ipc.HelperRoleAssist,
+			sid:            systemSID,
+			peerWinSession: "1",
+			consoleSession: "1",
+			wantReason:     "assist role requires non-SYSTEM identity",
+			wantReject:     true,
+		},
+		{
+			// Defensive: an unknown/empty console session id must not silently
+			// admit assist/user from an arbitrary session.
+			name:           "assist rejected when console session unknown",
+			role:           ipc.HelperRoleAssist,
+			sid:            nonSystemSID,
+			peerWinSession: "1",
+			consoleSession: "",
+			wantReason:     "assist role requires the active console session",
+			wantReject:     true,
+		},
+		{
+			// Fail-closed: GetConsoleSessionID() returns "0" when
+			// WTSGetActiveConsoleSessionId fails (API returns 0xFFFFFFFF). A peer
+			// whose kernel session is also "0" (Session-0 services) must NOT be
+			// admitted just because peer == console == "0" — "0" is not a valid
+			// interactive console session (#1009 review fail-closed hole).
+			name:           "assist rejected when console lookup failed (session 0 sentinel)",
+			role:           ipc.HelperRoleAssist,
+			sid:            nonSystemSID,
+			peerWinSession: "0",
+			consoleSession: "0",
+			wantReason:     "assist role requires the active console session",
+			wantReject:     true,
+		},
+		{
+			name:           "user rejected when console lookup failed (session 0 sentinel)",
+			role:           ipc.HelperRoleUser,
+			sid:            nonSystemSID,
+			peerWinSession: "0",
+			consoleSession: "0",
+			wantReason:     "user role requires the active console session",
+			wantReject:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reason, rejected := roleIdentityRejection(
+				tc.role, tc.sid, 0, tc.peerWinSession, tc.consoleSession, "windows",
+			)
+			if rejected != tc.wantReject {
+				t.Fatalf("rejected = %v, want %v (reason %q)", rejected, tc.wantReject, reason)
+			}
+			if reason != tc.wantReason {
+				t.Fatalf("reason = %q, want %q", reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+// TestRoleIdentityRejectionUnixUnchangedByConsoleBinding asserts that the
+// console-session binding is a Windows-only concept: on Unix, assist/user have
+// no per-session console gate (the macOS desktop helper authenticates as
+// user-role from the GUI/loginwindow session). Passing mismatched session ids
+// must NOT cause a rejection on goos != windows.
+func TestRoleIdentityRejectionUnixUnchangedByConsoleBinding(t *testing.T) {
+	reason, rejected := roleIdentityRejection(
+		ipc.HelperRoleUser, "", 1000, "99", "1", "darwin",
+	)
+	if rejected {
+		t.Fatalf("unix user role unexpectedly rejected: reason=%q", reason)
+	}
+}
+
+// TestPreferredRunAsUserSessionFiltersByConsoleSession verifies that
+// run_as_user routing only ever selects a helper in the active console session,
+// never a co-logged-in user's helper in another session (#1009). A newer helper
+// in a non-console session must be ignored in favour of the console helper, even
+// though it is more recent.
+func TestPreferredRunAsUserSessionFiltersByConsoleSession(t *testing.T) {
+	now := time.Now()
+
+	consoleUser, consoleClient := newTestUserSession(t, "console-user", "alice", now.Add(-20*time.Minute))
+	defer consoleClient.Close()
+	consoleUser.WinSessionID = "1"
+
+	// Co-logged-in attacker session — newer, so it would win a naive
+	// "newest user helper" selection.
+	otherUser, otherClient := newTestUserSession(t, "other-user", "mallory", now.Add(-1*time.Minute))
+	defer otherClient.Close()
+	otherUser.WinSessionID = "3"
+
+	b := &Broker{
+		sessions: map[string]*Session{
+			consoleUser.SessionID: consoleUser,
+			otherUser.SessionID:   otherUser,
+		},
+		byIdentity:         make(map[string][]*Session),
+		staleHelpers:       make(map[string][]int),
+		consoleSessionIDFn: func() string { return "1" },
+	}
+
+	// Drive the Windows code path explicitly; the console-session filter is a
+	// Windows multi-user (RDS/terminal-server) concept.
+	got := b.preferredRunAsUserSessionForOS("windows")
+	if got != consoleUser {
+		var gotID string
+		if got != nil {
+			gotID = got.SessionID
+		}
+		t.Fatalf("preferredRunAsUserSessionForOS(windows) = %q, want console session %q", gotID, consoleUser.SessionID)
+	}
+
+	// On non-Windows the console filter does not apply: the newest user helper
+	// wins as before (otherUser is newer).
+	if got := b.preferredRunAsUserSessionForOS("darwin"); got != otherUser {
+		t.Fatalf("preferredRunAsUserSessionForOS(darwin) selected the wrong session")
+	}
+}
+
+// TestPreferredRunAsUserSessionNoConsoleHelper asserts that when no helper is in
+// the active console session, run_as_user routing selects nothing rather than
+// falling back to a helper in another (attacker-controlled) session.
+func TestPreferredRunAsUserSessionNoConsoleHelper(t *testing.T) {
+	now := time.Now()
+
+	otherUser, otherClient := newTestUserSession(t, "other-user", "mallory", now.Add(-1*time.Minute))
+	defer otherClient.Close()
+	otherUser.WinSessionID = "3"
+
+	b := &Broker{
+		sessions: map[string]*Session{
+			otherUser.SessionID: otherUser,
+		},
+		byIdentity:         make(map[string][]*Session),
+		staleHelpers:       make(map[string][]int),
+		consoleSessionIDFn: func() string { return "1" },
+	}
+
+	if got := b.preferredRunAsUserSessionForOS("windows"); got != nil {
+		t.Fatalf("preferredRunAsUserSessionForOS(windows) = %q, want nil (no console helper)", got.SessionID)
+	}
+}
+
+// TestConsoleSessionIDDefaultsToGetConsoleSessionID verifies the broker's
+// console-session seam defaults to the platform GetConsoleSessionID() when no
+// override is injected (the production path), and honours the override when set
+// (the test path). On darwin GetConsoleSessionID() returns "1".
+func TestConsoleSessionIDSeam(t *testing.T) {
+	b := New("/tmp/does-not-matter.sock", nil)
+	if got := b.ConsoleSessionID(); got != GetConsoleSessionID() {
+		t.Fatalf("default ConsoleSessionID() = %q, want %q", got, GetConsoleSessionID())
+	}
+
+	b.consoleSessionIDFn = func() string { return "7" }
+	if got := b.ConsoleSessionID(); got != "7" {
+		t.Fatalf("overridden ConsoleSessionID() = %q, want %q", got, "7")
+	}
+
+	// "0" (Session-0 services sentinel / WTS-failure value) is normalized to ""
+	// so every consumer fails closed for the assist/user binding (#1009).
+	b.consoleSessionIDFn = func() string { return "0" }
+	if got := b.ConsoleSessionID(); got != "" {
+		t.Fatalf("ConsoleSessionID() with session-0 sentinel = %q, want \"\"", got)
+	}
+}


### PR DESCRIPTION
**Closes #1009.**

The `assist` and `user` Helper IPC roles were gated only by "must not be SYSTEM" + the binary path/hash allowlist — with **no binding to the kernel-verified console session**. On multi-user / RDS / terminal-server hosts (which RMM agents commonly run on), a *second* co-logged-in non-SYSTEM user who launches the genuine, signed, allowlisted Helper could register as `assist`/`user` and obtain:
1. the device **Helper API token** → an org-scoped synthetic auth context (org-wide AI tools, fleet health, audit-log queries, screenshots), and
2. interception of `run_as_user` scripts the operator dispatched expecting the console user's context.

The SYSTEM-capture gate (`S-1-5-18`) was never affected — this is strictly a **local cross-user** boundary gap between co-logged-in non-SYSTEM principals.

## Fix
`roleIdentityRejection` was negative-only (rejected bad pairings, never asserted a positive identity for `user`/`assist`). Now:
- **Positive assertion:** on Windows, `assist`/`user` require the peer's kernel-verified `WinSessionID` to match the active console session (`WTSGetActiveConsoleSessionId`). Both values are kernel-verified and unforgeable over the pipe. All existing SYSTEM/SID negative checks kept; SYSTEM-capture gate untouched.
- **Token push** (`handleHelperSessionAuthenticated` / `sendHelperTokenUpdate`) and **`run_as_user` routing** (`PreferredRunAsUserSession`) now gate on the same console-session match — a non-console helper is never pushed the token nor selected for a user-script.
- **Fail closed:** `ConsoleSessionID()` normalizes `"0"` (the Session-0 services value, *and* the sentinel `GetConsoleSessionID()` returns on a WTS lookup failure) to `""`, so a console-API failure can't admit a session-0 peer via `peer == console == "0"`. The pure gate rejects `"0"` independently too.

## Cross-platform / no-regression
The decision logic is a `goos`-parameterized pure function with an injectable console-session seam (test-only broker methods, not reachable from the IPC peer), so the Windows multi-user path is **fully table-tested on darwin**. Inert on macOS/Linux (single interactive session — the macOS desktop helper legitimately authenticates user-role from the loginwindow session) and on single-user Windows hosts (the logged-in user *is* the console session). `go build ./...`, `go vet`, and `go test -race ./internal/sessionbroker/... ./internal/heartbeat/...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)