### PR TITLE
fix(api): provisioning creds via short-lived one-time-fetch URL (#917 L-3)

### DIFF
--- a/apps/api/migrations/2026-06-11-f-provision-onetime-fetch.sql
+++ b/apps/api/migrations/2026-06-11-f-provision-onetime-fetch.sql
@@ -1,0 +1,71 @@
+-- 2026-06-11: provision_credential_handles — short-TTL, single-use handles for
+-- the device-provision credential blob. Closes #917 L-3.
+--
+-- Background: POST /devices/provision previously returned the agent's
+-- long-lived secrets (auth_token, watchdog_auth_token, helper_auth_token,
+-- mtls.private_key) inline in the JSON body with no TTL. If the admin UI
+-- logged or persisted the response before transport, those long-lived
+-- secrets sat in plaintext.
+--
+-- Fix: provision now stores the credential blob server-side keyed by an
+-- unguessable token with a short TTL (default 5 min) and returns a one-time
+-- fetch URL. The blob is delivered exactly once via
+-- GET /devices/provision/fetch/:token and the handle is atomically marked
+-- consumed. A second fetch, or a fetch after expiry, 404/410s.
+--
+-- The blob column holds the same secrets transiently; the row is single-use
+-- and short-lived (minutes), and is hard-deleted on consume so plaintext
+-- secrets do not linger at rest. A periodic sweep / the next provision can
+-- also clean expired rows.
+--
+-- RLS Shape 1 (direct org_id) — auto-discovered by the rls-coverage
+-- integration test, no allowlist entry needed.
+--
+-- Fully idempotent — safe to re-run.
+
+CREATE TABLE IF NOT EXISTS provision_credential_handles (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  token TEXT NOT NULL UNIQUE,
+  org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  device_id UUID NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+  -- The full agent config blob (includes plaintext secrets). Transient:
+  -- single-use, short-TTL, deleted on consume.
+  credentials JSONB NOT NULL,
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  consumed_at TIMESTAMPTZ,
+  consumed_from_ip TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_provision_credential_handles_expires
+  ON provision_credential_handles(expires_at);
+
+-- expires_at must be strictly after created_at
+ALTER TABLE provision_credential_handles
+  DROP CONSTRAINT IF EXISTS provision_credential_handles_expires_after_created;
+ALTER TABLE provision_credential_handles
+  ADD CONSTRAINT provision_credential_handles_expires_after_created
+  CHECK (expires_at > created_at);
+
+-- ============================================================
+-- RLS — Shape 1, direct org_id, standard four breeze_org_isolation policies
+-- ============================================================
+
+ALTER TABLE provision_credential_handles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE provision_credential_handles FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON provision_credential_handles;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON provision_credential_handles;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON provision_credential_handles;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON provision_credential_handles;
+
+CREATE POLICY breeze_org_isolation_select ON provision_credential_handles
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON provision_credential_handles
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON provision_credential_handles
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON provision_credential_handles
+  FOR DELETE USING (public.breeze_has_org_access(org_id));

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -69,6 +69,7 @@ export * from './incidentResponse';
 export * from './thirdPartyCatalog';
 export * from './tunnels';
 export * from './installerBootstrapTokens';
+export * from './provisionCredentialHandles';
 export * from './deploymentInvites';
 export * from './emailVerificationTokens';
 export * from './manifestSigningKeys';

--- a/apps/api/src/db/schema/provisionCredentialHandles.ts
+++ b/apps/api/src/db/schema/provisionCredentialHandles.ts
@@ -1,0 +1,62 @@
+import {
+  pgTable,
+  uuid,
+  text,
+  jsonb,
+  timestamp,
+  index,
+} from "drizzle-orm/pg-core";
+import { organizations } from "./orgs";
+import { devices } from "./devices";
+import { users } from "./users";
+
+/**
+ * Short-TTL, single-use handle for the device-provision credential blob
+ * (#917 L-3). POST /devices/provision no longer returns the agent's
+ * long-lived secrets (auth_token, watchdog/helper tokens, mTLS private key)
+ * inline. Instead it stores the config blob here keyed by an unguessable
+ * token with a short TTL (default 5 min) and returns a one-time fetch URL.
+ *
+ * The blob is delivered exactly once via GET /devices/provision/fetch/:token,
+ * which atomically marks the handle consumed (and hard-deletes the row so the
+ * plaintext secrets do not linger at rest). A second fetch, or a fetch after
+ * expiry, returns 404/410.
+ *
+ * RLS Shape 1 (direct org_id) — auto-discovered, no allowlist entry needed.
+ */
+export const provisionCredentialHandles = pgTable(
+  "provision_credential_handles",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    token: text("token").notNull().unique(),
+    orgId: uuid("org_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    deviceId: uuid("device_id")
+      .notNull()
+      .references(() => devices.id, { onDelete: "cascade" }),
+    /**
+     * The full agent config blob — includes plaintext secrets. Transient:
+     * single-use, short-TTL, deleted on consume.
+     */
+    credentials: jsonb("credentials").notNull(),
+    createdBy: uuid("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    /** Must be strictly after created_at; enforced by DB CHECK. */
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    consumedAt: timestamp("consumed_at", { withTimezone: true }),
+    consumedFromIp: text("consumed_from_ip"),
+  },
+  (t) => ({
+    expiresIdx: index("idx_provision_credential_handles_expires").on(
+      t.expiresAt,
+    ),
+  }),
+);
+
+export type ProvisionCredentialHandle =
+  typeof provisionCredentialHandles.$inferSelect;

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -182,6 +182,9 @@ export const DEVICE_CASCADE_DELETE_TABLES = [
   'recovery_readiness',
   // PAM elevation requests (elevation_audit cascades automatically via FK ON DELETE CASCADE)
   'elevation_requests',
+  // Provisioning one-time credential handles (FK device_id → devices.id ON DELETE CASCADE;
+  // listed for the explicit-cascade coverage contract — leaf table, no children)
+  'provision_credential_handles',
 ] as const;
 
 export const coreRoutes = new Hono();

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -98,7 +98,7 @@ export const DEVICE_ORG_DENORMALIZED_TABLES = [
   'elevation_requests',
   'group_membership_log',
   'huntress_agents', 'huntress_incidents', 'hyperv_vms', 'local_vaults',
-  'peripheral_events', 'playbook_executions',
+  'peripheral_events', 'playbook_executions', 'provision_credential_handles',
   'recovery_readiness', 'recovery_tokens', 'remote_sessions', 'restore_jobs',
   's1_actions', 's1_agents', 's1_threats',
   'script_executions',

--- a/apps/api/src/routes/devices/provision.test.ts
+++ b/apps/api/src/routes/devices/provision.test.ts
@@ -13,6 +13,9 @@ vi.mock('../../db', () => ({
   db: {
     select: vi.fn(),
     transaction: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
   },
 }));
 
@@ -56,6 +59,16 @@ vi.mock('../../db/schema', () => ({
   organizations: { id: 'id', partnerId: 'partnerId' },
   sites: { id: 'id', orgId: 'orgId' },
   partners: { id: 'id', maxDevices: 'maxDevices' },
+  provisionCredentialHandles: {
+    id: 'id', token: 'token', orgId: 'orgId', deviceId: 'deviceId',
+    credentials: 'credentials', consumedAt: 'consumedAt', expiresAt: 'expiresAt',
+  },
+}));
+
+vi.mock('../../services/provisionCredentialHandle', () => ({
+  PROVISION_HANDLE_TOKEN_PATTERN: /^[a-f0-9]{64}$/,
+  generateProvisionHandleToken: vi.fn(() => 'a'.repeat(64)),
+  provisionHandleExpiresAt: vi.fn(() => new Date('2030-01-01T00:00:00.000Z')),
 }));
 
 import { db } from '../../db';
@@ -134,6 +147,45 @@ function mockTransactionSuccess(insertedRow: any) {
   });
 }
 
+/** Mocks `db.insert(...).values(...)` resolving successfully (handle persist). */
+function mockInsertSuccess() {
+  vi.mocked(db.insert).mockReturnValue({
+    values: vi.fn().mockResolvedValue(undefined),
+  } as any);
+}
+
+/** Mocks the fetch-endpoint's `db.select(...).from().where().limit()` lookup. */
+function mockHandleSelect(rows: any[]) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({
+        limit: vi.fn().mockResolvedValue(rows),
+      })),
+    })),
+  } as any);
+}
+
+/** Mocks the atomic `db.update(...).set().where().returning()` consume. */
+function mockHandleConsume(rows: any[]) {
+  vi.mocked(db.update).mockReturnValue({
+    set: vi.fn(() => ({
+      where: vi.fn(() => ({
+        returning: vi.fn().mockResolvedValue(rows),
+      })),
+    })),
+  } as any);
+}
+
+/** Mocks `db.delete(...).where()` (chainable, catch-able). */
+function mockHandleDelete() {
+  const chain: any = {
+    where: vi.fn(() => chain),
+    catch: vi.fn((cb: any) => Promise.resolve().catch(cb)),
+    then: (resolve: any) => Promise.resolve().then(resolve),
+  };
+  vi.mocked(db.delete).mockReturnValue(chain);
+}
+
 describe('POST /devices/provision', () => {
   let app: Hono;
 
@@ -159,7 +211,7 @@ describe('POST /devices/provision', () => {
   });
 
   describe('happy path', () => {
-    it('creates a device and returns the config blob', async () => {
+    it('creates a device and returns a one-time fetch URL (no inline secrets)', async () => {
       mockSelectRows([{ id: SITE_ID }]);     // site-in-org check
       mockSelectRows([]);                     // hostname collision check (none)
       mockTransactionSuccess({
@@ -170,6 +222,7 @@ describe('POST /devices/provision', () => {
         agentId: 'agent-prov-1',
         status: 'pending',
       });
+      mockInsertSuccess();                    // credential-handle persist
 
       const res = await app.request('/devices/provision', {
         method: 'POST',
@@ -181,14 +234,23 @@ describe('POST /devices/provision', () => {
       const body = await res.json();
       expect(body.success).toBe(true);
       expect(body.device.id).toBe('device-prov-id');
-      expect(body.config).toMatchObject({
-        agent_id: 'agent-prov-1',
-        server_url: 'https://breeze.example.com',
-        org_id: ORG_ID,
-        site_id: SITE_ID,
-        auth_token: 'brz_prov_token',
+
+      // SECURITY (#917 L-3): secrets must NOT be inline in the provision body.
+      expect(body.config).toBeUndefined();
+      const serialized = JSON.stringify(body);
+      expect(serialized).not.toContain('brz_prov_token');     // auth/watchdog/helper tokens
+      expect(serialized).not.toContain('private_key');
+
+      // Instead, a short-TTL single-use fetch handle is returned.
+      expect(body.credentials).toMatchObject({
+        fetch_url: '/api/v1/devices/provision/fetch/' + 'a'.repeat(64),
+        fetch_token: 'a'.repeat(64),
+        single_use: true,
       });
-      expect(body.config.manifest_trust_keys).toEqual([]);
+      expect(body.credentials.expires_at).toBe('2030-01-01T00:00:00.000Z');
+
+      // The blob WAS persisted server-side (keyed by the handle).
+      expect(db.insert).toHaveBeenCalled();
 
       // Audit was written on success
       expect(writeRouteAudit).toHaveBeenCalledWith(
@@ -215,6 +277,7 @@ describe('POST /devices/provision', () => {
           agentId: 'agent-prov-1',
           status: 'pending',
         });
+        mockInsertSuccess();
 
         const res = await app.request('/devices/provision', {
           method: 'POST',
@@ -350,6 +413,7 @@ describe('POST /devices/provision', () => {
         agentId: 'agent-prov-1',
         status: 'pending',
       });
+      mockInsertSuccess();
 
       const res = await app.request('/devices/provision', {
         method: 'POST',
@@ -375,6 +439,7 @@ describe('POST /devices/provision', () => {
         agentId: 'agent-prov-1',
         status: 'pending',
       });
+      mockInsertSuccess();
 
       const res = await app.request('/devices/provision', {
         method: 'POST',
@@ -384,6 +449,125 @@ describe('POST /devices/provision', () => {
 
       expect(res.status).toBe(201);
       expect(db.transaction).toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /devices/provision/fetch/:token (one-time credential fetch)', () => {
+    const TOKEN = 'a'.repeat(64);
+    const CONFIG = {
+      agent_id: 'agent-prov-1',
+      auth_token: 'brz_prov_token',
+      mtls: { private_key: 'SECRET-KEY' },
+    };
+
+    function fetchReq(token = TOKEN) {
+      return app.request(`/devices/provision/fetch/${token}`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer t' },
+      });
+    }
+
+    it('returns the credential blob exactly once, then deletes the handle', async () => {
+      mockHandleSelect([
+        {
+          id: 'handle-1',
+          orgId: ORG_ID,
+          deviceId: 'device-prov-id',
+          credentials: CONFIG,
+          expiresAt: new Date(Date.now() + 60_000),
+          consumedAt: null,
+        },
+      ]);
+      mockHandleConsume([{ id: 'handle-1' }]); // atomic consume wins
+      mockHandleDelete();
+
+      const res = await fetchReq();
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(body.config).toEqual(CONFIG);
+
+      // Handle was consumed AND hard-deleted (secrets don't linger at rest).
+      expect(db.update).toHaveBeenCalled();
+      expect(db.delete).toHaveBeenCalled();
+
+      // Fetch is audited.
+      expect(writeRouteAudit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ action: 'device.provision.fetch' }),
+      );
+    });
+
+    it('404s a second fetch of an already-consumed handle', async () => {
+      // Row exists but consume UPDATE returns empty (lost the single-use race).
+      mockHandleSelect([
+        {
+          id: 'handle-1',
+          orgId: ORG_ID,
+          deviceId: 'device-prov-id',
+          credentials: CONFIG,
+          expiresAt: new Date(Date.now() + 60_000),
+          consumedAt: null,
+        },
+      ]);
+      mockHandleConsume([]); // already consumed by a prior fetch
+
+      const res = await fetchReq();
+      expect(res.status).toBe(404);
+    });
+
+    it('404s an unknown / nonexistent token', async () => {
+      mockHandleSelect([]); // no row
+
+      const res = await fetchReq();
+      expect(res.status).toBe(404);
+      // Never attempts a consume on a missing handle.
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('410s an expired handle and never returns the blob', async () => {
+      mockHandleSelect([
+        {
+          id: 'handle-1',
+          orgId: ORG_ID,
+          deviceId: 'device-prov-id',
+          credentials: CONFIG,
+          expiresAt: new Date(Date.now() - 60_000), // already expired
+          consumedAt: null,
+        },
+      ]);
+      mockHandleDelete(); // best-effort cleanup of expired row
+
+      const res = await fetchReq();
+      expect(res.status).toBe(410);
+      const body = await res.json();
+      expect(body.config).toBeUndefined();
+      // Expired handles are never consumed.
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('404s when the caller cannot access the handle owning org', async () => {
+      setAuth({ canAccessOrg: () => false });
+      mockHandleSelect([
+        {
+          id: 'handle-1',
+          orgId: OTHER_ORG_ID,
+          deviceId: 'device-prov-id',
+          credentials: CONFIG,
+          expiresAt: new Date(Date.now() + 60_000),
+          consumedAt: null,
+        },
+      ]);
+
+      const res = await fetchReq();
+      expect(res.status).toBe(404);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('400s a malformed token (fails pattern, no DB lookup)', async () => {
+      const res = await fetchReq('not-a-valid-token');
+      expect(res.status).toBe(400);
+      expect(db.select).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/routes/devices/provision.ts
+++ b/apps/api/src/routes/devices/provision.ts
@@ -1,9 +1,9 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { and, eq, ne, sql } from 'drizzle-orm';
+import { and, eq, isNull, ne, sql } from 'drizzle-orm';
 import { createHash } from 'crypto';
 import { db } from '../../db';
-import { devices, organizations, sites, partners } from '../../db/schema';
+import { devices, organizations, sites, partners, provisionCredentialHandles } from '../../db/schema';
 import {
   authMiddleware,
   requireMfa,
@@ -16,6 +16,11 @@ import { provisionDeviceSchema } from './schemas';
 import { generateAgentId, generateApiKey, issueMtlsCertForDevice } from '../agents/helpers';
 import { getActiveTrustKeyset } from '../../services/manifestSigning';
 import { stripSensitiveDeviceFields } from './helpers';
+import {
+  PROVISION_HANDLE_TOKEN_PATTERN,
+  generateProvisionHandleToken,
+  provisionHandleExpiresAt,
+} from '../../services/provisionCredentialHandle';
 
 export const provisionRoutes = new Hono();
 
@@ -247,6 +252,50 @@ provisionRoutes.post(
     const mtlsCert = await issueMtlsCertForDevice(device.id, data.orgId);
     const manifestTrustKeys = await getActiveTrustKeyset();
 
+    // ----------- assemble the config blob (contains long-lived secrets) -----------
+    // SECURITY (#917 L-3): the secrets below — auth_token, watchdog/helper
+    // tokens and the mTLS private key — are long-lived and MUST NOT be
+    // returned inline in this response. If the admin UI logged or persisted
+    // the body before transport, those secrets would sit in plaintext. We
+    // stash the blob server-side keyed by a short-TTL, single-use handle and
+    // return a one-time fetch URL instead.
+    const configBlob = {
+      agent_id: agentId,
+      server_url: serverUrl,
+      auth_token: apiKey,
+      watchdog_auth_token: watchdogApiKey,
+      helper_auth_token: helperApiKey,
+      org_id: data.orgId,
+      site_id: data.siteId,
+      heartbeat_interval_seconds: 60,
+      metrics_interval_seconds: 30,
+      manifest_trust_keys: manifestTrustKeys,
+      mtls: mtlsCert
+        ? {
+            certificate: mtlsCert.certificate,
+            private_key: mtlsCert.privateKey,
+            expires_at: mtlsCert.expiresAt,
+            serial_number: mtlsCert.serialNumber,
+          }
+        : null,
+    };
+
+    const handleToken = generateProvisionHandleToken();
+    const handleExpiresAt = provisionHandleExpiresAt();
+    try {
+      await db.insert(provisionCredentialHandles).values({
+        token: handleToken,
+        orgId: data.orgId,
+        deviceId: device.id,
+        credentials: configBlob,
+        createdBy: auth.user?.id ?? null,
+        expiresAt: handleExpiresAt,
+      });
+    } catch (err) {
+      console.error('[devices.provision] failed to persist credential handle:', err);
+      return c.json({ error: 'Failed to issue provisioning credentials' }, 500);
+    }
+
     writeRouteAudit(c, {
       orgId: data.orgId,
       action: 'device.provision',
@@ -258,39 +307,113 @@ provisionRoutes.post(
         osType: data.osType,
         agentId,
         mtlsCertIssued: mtlsCert !== null,
+        credentialHandleIssued: true,
       },
     });
 
-    // ----------- response: config blob the admin ships to the endpoint -----------
+    // ----------- response: one-time fetch URL (NO inline secrets) -----------
     return c.json(
       {
         success: true,
         device: stripSensitiveDeviceFields(device),
-        config: {
-          agent_id: agentId,
-          server_url: serverUrl,
-          auth_token: apiKey,
-          watchdog_auth_token: watchdogApiKey,
-          helper_auth_token: helperApiKey,
-          org_id: data.orgId,
-          site_id: data.siteId,
-          heartbeat_interval_seconds: 60,
-          metrics_interval_seconds: 30,
-          manifest_trust_keys: manifestTrustKeys,
-          mtls: mtlsCert
-            ? {
-                certificate: mtlsCert.certificate,
-                private_key: mtlsCert.privateKey,
-                expires_at: mtlsCert.expiresAt,
-                serial_number: mtlsCert.serialNumber,
-              }
-            : null,
+        credentials: {
+          fetch_url: `/api/v1/devices/provision/fetch/${handleToken}`,
+          fetch_token: handleToken,
+          expires_at: handleExpiresAt.toISOString(),
+          single_use: true,
         },
       },
       201,
     );
   },
 );
+
+/**
+ * GET /devices/provision/fetch/:token
+ *
+ * One-time retrieval of the provisioning credential blob created by
+ * POST /devices/provision (#917 L-3). The handle token is the bearer
+ * credential; the caller must additionally be an authenticated admin with
+ * access to the owning org (defense-in-depth on top of the unguessable
+ * token). The handle is single-use: the first successful fetch returns the
+ * blob and atomically deletes the row, so a replay 404s. Expired handles
+ * are rejected with 410.
+ *
+ * Invalid / consumed / non-existent tokens all return 404 to avoid leaking
+ * which condition was hit. The same caller fetches immediately after
+ * provisioning, so the 5-minute default TTL is generous.
+ */
+provisionRoutes.get('/provision/fetch/:token', async (c) => {
+  const auth = c.get('auth');
+  const token = c.req.param('token');
+
+  if (!PROVISION_HANDLE_TOKEN_PATTERN.test(token)) {
+    return c.json({ error: 'invalid token' }, 400);
+  }
+
+  const ip = c.req.header('cf-connecting-ip') ?? null;
+
+  // ── 1. Look up the handle ───────────────────────────────────────────────
+  const [row] = await db
+    .select()
+    .from(provisionCredentialHandles)
+    .where(eq(provisionCredentialHandles.token, token))
+    .limit(1);
+
+  if (!row) {
+    return c.json({ error: 'handle invalid, expired, or already used' }, 404);
+  }
+
+  // ── 2. Org-access check (defense-in-depth on top of the token) ──────────
+  if (!auth.canAccessOrg(row.orgId)) {
+    return c.json({ error: 'handle invalid, expired, or already used' }, 404);
+  }
+
+  // ── 3. Expiry ───────────────────────────────────────────────────────────
+  if (new Date(row.expiresAt) < new Date()) {
+    // Best-effort cleanup of the expired row; ignore failures.
+    await db
+      .delete(provisionCredentialHandles)
+      .where(eq(provisionCredentialHandles.id, row.id))
+      .catch(() => {});
+    return c.json({ error: 'handle expired' }, 410);
+  }
+
+  // ── 4. Atomic single-use consume ────────────────────────────────────────
+  // Mark consumed only if not already consumed; the UPDATE serializes
+  // concurrent fetches so exactly one wins.
+  const [consumed] = await db
+    .update(provisionCredentialHandles)
+    .set({ consumedAt: new Date(), consumedFromIp: ip })
+    .where(
+      and(
+        eq(provisionCredentialHandles.id, row.id),
+        isNull(provisionCredentialHandles.consumedAt),
+      ),
+    )
+    .returning();
+
+  if (!consumed) {
+    // Lost the race — another fetch already consumed it.
+    return c.json({ error: 'handle invalid, expired, or already used' }, 404);
+  }
+
+  // ── 5. Hard-delete so plaintext secrets don't linger at rest ────────────
+  await db
+    .delete(provisionCredentialHandles)
+    .where(eq(provisionCredentialHandles.id, row.id))
+    .catch(() => {});
+
+  writeRouteAudit(c, {
+    orgId: row.orgId,
+    action: 'device.provision.fetch',
+    resourceType: 'device',
+    resourceId: row.deviceId,
+    details: { credentialHandleConsumed: true },
+  });
+
+  return c.json({ success: true, config: row.credentials }, 200);
+});
 
 class HttpDeviceLimitError extends Error {
   constructor(public current: number, public max: number) {

--- a/apps/api/src/services/provisionCredentialHandle.ts
+++ b/apps/api/src/services/provisionCredentialHandle.ts
@@ -1,0 +1,24 @@
+import { randomBytes } from 'node:crypto';
+
+/**
+ * Canonical shape of a provision credential-handle token: 64 chars of
+ * lowercase hex (32 bytes / 256 bits of CSPRNG entropy). The token IS the
+ * bearer credential for the one-time fetch, so it must be unguessable.
+ * Used by both the generator and the route-side input validator.
+ */
+export const PROVISION_HANDLE_TOKEN_PATTERN = /^[a-f0-9]{64}$/;
+
+/** Generates a 64-char hex provision credential-handle token (256 bits). */
+export function generateProvisionHandleToken(): string {
+  return randomBytes(32).toString('hex');
+}
+
+/**
+ * TTL for a freshly-issued provision credential handle. Short by design —
+ * the admin provisions and immediately fetches the blob in the same flow.
+ * Tunable via env for testing; production default is 5 minutes.
+ */
+export function provisionHandleExpiresAt(): Date {
+  const ttlMin = Number(process.env.PROVISION_HANDLE_TTL_MINUTES ?? 5);
+  return new Date(Date.now() + ttlMin * 60 * 1000);
+}

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -184,6 +184,7 @@ export const ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'plugins',
   'portal_branding',
   'portal_users',
+  'provision_credential_handles',
   'psa_connections',
   'recovery_boot_media_artifacts',
   'recovery_media_artifacts',


### PR DESCRIPTION
Addresses sub-item **L-3** of #917 (umbrella stays open — L-1 is time-gated to 2026-06-15, M-6 is a CORS audit).

`POST /devices/provision` returned `auth_token`, `watchdog_auth_token`, `helper_auth_token` and `mtls.private_key` **inline in the JSON body with no TTL**. If the admin UI logged or persisted the response before transport, those long-lived secrets sat in plaintext. (Note: #918's claimed prod-suppression is not actually present in the tree — this is a real, not duplicate, fix.)

## Fix — the installer-link pattern
Provision now stashes the config blob server-side keyed by a 256-bit CSPRNG token and returns only a short-TTL single-use fetch URL.

- `services/provisionCredentialHandle.ts` — token generator + TTL helper (default 5 min, `PROVISION_HANDLE_TTL_MINUTES`).
- `2026-06-11-f-provision-onetime-fetch.sql` — `provision_credential_handles` table, **RLS shape 1** (direct `org_id`, forced + 4 `breeze_has_org_access` policies, auto-discovered → no allowlist edit), `expires_at > created_at` CHECK, FK cascade.
- `GET /devices/provision/fetch/:token` — same admin-JWT + `canAccessOrg` check (defense-in-depth beyond the token), **atomic single-use consume** (`UPDATE … WHERE consumed_at IS NULL RETURNING` — no TOCTOU), **hard-deletes the row on consume** so plaintext doesn't linger, 410 on expiry, 404 on unknown/consumed/cross-org, 400 on malformed. Provision + fetch both audited.
- Provision response no longer contains the raw secrets in any field.
- 18 route tests (no inline secrets; blob returned exactly once; replay 404; expired 410; cross-org 404; malformed 400).

## Follow-ups (noted, not blocking)
- The blob is plaintext-at-rest for its ≤5-min lifetime (tight TTL + hard-delete-on-consume + forced RLS as mitigation); app-layer envelope encryption is worth a follow-up, or exclude the table from logical backups.
- Expired-but-never-fetched handles are only swept opportunistically — a small reaper on the existing cleanup cron would be tidier.
- No `apps/web` code calls `/devices/provision` today, so there's no client to migrate; a future admin UI POSTs to provision then GETs `fetch_url` once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)