### PR TITLE
fix(tickets): e2e findings sweep — org-scope UI, workbench assignment, category settings, bulk feedback

### DIFF
--- a/apps/api/src/routes/ticketCategories.test.ts
+++ b/apps/api/src/routes/ticketCategories.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 
-const { authRef, dbInsertReturning, dbUpdateReturning, dbSelectResult } = vi.hoisted(() => {
+const { authRef, dbInsertReturning, dbUpdateReturning, dbSelectResult, runOutsideDbContextSpy, withSystemDbAccessContextSpy } = vi.hoisted(() => {
+  // Spies for system-DB-context helpers; default to pass-through so existing tests are unaffected.
+  const runOutsideDbContextSpy = vi.fn((fn: () => unknown) => fn());
+  const withSystemDbAccessContextSpy = vi.fn((fn: () => unknown) => fn());
   return {
     authRef: {
       current: {
@@ -16,7 +19,9 @@ const { authRef, dbInsertReturning, dbUpdateReturning, dbSelectResult } = vi.hoi
     },
     dbInsertReturning: vi.fn(),
     dbUpdateReturning: vi.fn(),
-    dbSelectResult: vi.fn()
+    dbSelectResult: vi.fn(),
+    runOutsideDbContextSpy,
+    withSystemDbAccessContextSpy
   };
 });
 
@@ -42,6 +47,10 @@ vi.mock('../middleware/auth', () => ({
 }));
 
 vi.mock('../db', () => ({
+  // Pass-throughs for the system-scope context helpers used by the org branch of GET /.
+  // The spies are exposed via vi.hoisted so individual tests can assert call counts.
+  runOutsideDbContext: runOutsideDbContextSpy,
+  withSystemDbAccessContext: withSystemDbAccessContextSpy,
   db: {
     select: vi.fn(() => ({
       from: vi.fn(() => ({
@@ -161,6 +170,36 @@ describe('GET /ticket-categories', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.data).toHaveLength(2);
+  });
+
+  it('org scope: category read uses runOutsideDbContext + withSystemDbAccessContext', async () => {
+    resetAuth({ scope: 'organization', orgId: 'org-1', partnerId: null });
+    // First call: org lookup to get partnerId
+    // Second call: category list (runs inside the system DB context)
+    dbSelectResult
+      .mockResolvedValueOnce([{ partnerId: 'p-1' }])
+      .mockResolvedValueOnce([{ id: 'cat-1', name: 'Hardware', partnerId: 'p-1' }]);
+
+    const res = await makeApp().request('/ticket-categories');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+
+    // The category SELECT must be wrapped in both context helpers.
+    expect(runOutsideDbContextSpy).toHaveBeenCalledTimes(1);
+    expect(withSystemDbAccessContextSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('partner scope: category read does NOT use the system DB context helpers', async () => {
+    resetAuth({ scope: 'partner', partnerId: 'p-1' });
+    dbSelectResult.mockResolvedValue([{ id: 'cat-1', name: 'Hardware', partnerId: 'p-1' }]);
+
+    const res = await makeApp().request('/ticket-categories');
+    expect(res.status).toBe(200);
+
+    // Partner reads stay in the request context — helpers must not be called.
+    expect(runOutsideDbContextSpy).not.toHaveBeenCalled();
+    expect(withSystemDbAccessContextSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/ticketCategories.test.ts
+++ b/apps/api/src/routes/ticketCategories.test.ts
@@ -190,6 +190,47 @@ describe('GET /ticket-categories', () => {
     expect(withSystemDbAccessContextSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('org scope: response never exposes billing defaults and only selects active categories', async () => {
+    resetAuth({ scope: 'organization', orgId: 'org-1', partnerId: null });
+    // First call: org lookup; second: category list returning the projected shape
+    // (the route's explicit column projection means billing columns never reach the row).
+    const projectedRow = {
+      id: 'cat-1',
+      name: 'Hardware',
+      color: '#1c8a9e',
+      parentId: null,
+      defaultPriority: 'normal',
+      sortOrder: 0,
+      isActive: true
+    };
+    dbSelectResult
+      .mockResolvedValueOnce([{ partnerId: 'p-1' }])
+      .mockResolvedValueOnce([projectedRow]);
+
+    const res = await makeApp().request('/ticket-categories');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Rows pass through the projection untouched...
+    expect(body.data).toEqual([projectedRow]);
+    // ...and the MSP's billing defaults must never appear anywhere in the response.
+    const serialized = JSON.stringify(body);
+    expect(serialized.includes('defaultHourlyRate')).toBe(false);
+    expect(serialized.includes('defaultBillable')).toBe(false);
+
+    const { db } = await import('../db');
+    // Second select (the category list) must use an explicit column projection —
+    // never select-all — and that projection must exclude billing columns.
+    const projectionArg = vi.mocked(db.select).mock.calls[1]?.[0] as Record<string, unknown> | undefined;
+    expect(projectionArg).toBeDefined();
+    expect(Object.keys(projectionArg!).sort()).toEqual(
+      ['color', 'defaultPriority', 'id', 'isActive', 'name', 'parentId', 'sortOrder']
+    );
+    // The WHERE must filter to active categories (isActive condition present).
+    const whereArg = vi.mocked(db.select).mock.results[1]?.value.from.mock.results[0]?.value.where.mock.calls[0]?.[0];
+    expect(JSON.stringify(whereArg)).toContain('isActive');
+  });
+
   it('partner scope: category read does NOT use the system DB context helpers', async () => {
     resetAuth({ scope: 'partner', partnerId: 'p-1' });
     dbSelectResult.mockResolvedValue([{ id: 'cat-1', name: 'Hardware', partnerId: 'p-1' }]);

--- a/apps/api/src/routes/ticketCategories.ts
+++ b/apps/api/src/routes/ticketCategories.ts
@@ -53,12 +53,23 @@ ticketCategoriesRoutes.get(
       // never from caller input — is the security boundary, same pattern as
       // ticketService.assertCategoryInPartner. Org users get read-only visibility
       // of their MSP's categories; the write routes below remain partner/system.
+      // The column projection + isActive filter are deliberate: org users get the
+      // selectable catalog only — never the MSP's billing defaults
+      // (defaultHourlyRate/defaultBillable) or retired categories.
       const data = await runOutsideDbContext(() =>
         withSystemDbAccessContext(() =>
           db
-            .select()
+            .select({
+              id: ticketCategories.id,
+              name: ticketCategories.name,
+              color: ticketCategories.color,
+              parentId: ticketCategories.parentId,
+              defaultPriority: ticketCategories.defaultPriority,
+              sortOrder: ticketCategories.sortOrder,
+              isActive: ticketCategories.isActive
+            })
             .from(ticketCategories)
-            .where(eq(ticketCategories.partnerId, partnerId))
+            .where(and(eq(ticketCategories.partnerId, partnerId), eq(ticketCategories.isActive, true)))
             .orderBy(asc(ticketCategories.sortOrder), asc(ticketCategories.name))
         )
       );

--- a/apps/api/src/routes/ticketCategories.ts
+++ b/apps/api/src/routes/ticketCategories.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { and, asc, eq, type SQL } from 'drizzle-orm';
-import { db } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { ticketCategories, organizations } from '../db/schema';
 import { authMiddleware, requireScope, requirePermission } from '../middleware/auth';
 import { PERMISSIONS } from '../services/permissions';
@@ -46,11 +46,22 @@ ticketCategoriesRoutes.get(
         .limit(1);
       const partnerId = orgRows[0]?.partnerId;
       if (!partnerId) return c.json({ data: [] });
-      const data = await db
-        .select()
-        .from(ticketCategories)
-        .where(eq(ticketCategories.partnerId, partnerId))
-        .orderBy(asc(ticketCategories.sortOrder), asc(ticketCategories.name));
+      // The org→partner resolution above stays in the request context (RLS lets an
+      // org user read their own org row). The category read runs in a system DB
+      // context: ticket_categories is partner-axis RLS, invisible to org-scoped
+      // request contexts. The explicit partnerId filter — derived from auth.orgId,
+      // never from caller input — is the security boundary, same pattern as
+      // ticketService.assertCategoryInPartner. Org users get read-only visibility
+      // of their MSP's categories; the write routes below remain partner/system.
+      const data = await runOutsideDbContext(() =>
+        withSystemDbAccessContext(() =>
+          db
+            .select()
+            .from(ticketCategories)
+            .where(eq(ticketCategories.partnerId, partnerId))
+            .orderBy(asc(ticketCategories.sortOrder), asc(ticketCategories.name))
+        )
+      );
       return c.json({ data });
     }
 

--- a/apps/api/src/routes/tickets/tickets.test.ts
+++ b/apps/api/src/routes/tickets/tickets.test.ts
@@ -639,8 +639,9 @@ describe('PATCH /tickets/:id — delegates to updateTicketFields', () => {
     expect(serviceMocks.updateTicketFields).not.toHaveBeenCalled();
   });
 
+  // No dbSelectMock setup needed for the hint tests: the 400 fires before the scoped DB lookup.
   it('400 with a status-route hint when only status is sent', async () => {
-    const res = await makeApp().request('/tickets/11111111-1111-4111-8111-111111111111', {
+    const res = await makeApp().request(`/tickets/${TICKET_ID}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ status: 'open' })
@@ -650,7 +651,7 @@ describe('PATCH /tickets/:id — delegates to updateTicketFields', () => {
   });
 
   it('400 with an assign-route hint when only assigneeId is sent', async () => {
-    const res = await makeApp().request('/tickets/11111111-1111-4111-8111-111111111111', {
+    const res = await makeApp().request(`/tickets/${TICKET_ID}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ assigneeId: '22222222-2222-4222-8222-222222222222' })

--- a/apps/api/src/routes/tickets/tickets.test.ts
+++ b/apps/api/src/routes/tickets/tickets.test.ts
@@ -639,6 +639,26 @@ describe('PATCH /tickets/:id — delegates to updateTicketFields', () => {
     expect(serviceMocks.updateTicketFields).not.toHaveBeenCalled();
   });
 
+  it('400 with a status-route hint when only status is sent', async () => {
+    const res = await makeApp().request('/tickets/11111111-1111-4111-8111-111111111111', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'open' })
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/POST \/tickets\/:id\/status/);
+  });
+
+  it('400 with an assign-route hint when only assigneeId is sent', async () => {
+    const res = await makeApp().request('/tickets/11111111-1111-4111-8111-111111111111', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ assigneeId: '22222222-2222-4222-8222-222222222222' })
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/POST \/tickets\/:id\/assign/);
+  });
+
   describe('deviceId reassignment cross-org guard (enforced by the service)', () => {
     const DEVICE_ID = '9a8b7c6d-1111-4222-8333-444455556666';
 

--- a/apps/api/src/routes/tickets/tickets.test.ts
+++ b/apps/api/src/routes/tickets/tickets.test.ts
@@ -650,6 +650,18 @@ describe('PATCH /tickets/:id — delegates to updateTicketFields', () => {
     expect((await res.json()).error).toMatch(/POST \/tickets\/:id\/status/);
   });
 
+  it('400 with the status hint when status is mixed into an otherwise-valid body (no silent drop)', async () => {
+    const res = await makeApp().request(`/tickets/${TICKET_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ priority: 'high', status: 'closed' })
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/POST \/tickets\/:id\/status/);
+    // priority must NOT be applied while status is silently dropped
+    expect(serviceMocks.updateTicketFields).not.toHaveBeenCalled();
+  });
+
   it('400 with an assign-route hint when only assigneeId is sent', async () => {
     const res = await makeApp().request(`/tickets/${TICKET_ID}`, {
       method: 'PATCH',

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -400,6 +400,9 @@ ticketsRoutes.patch(
     if (Object.keys(body).length === 0) {
       // zod strips unknown keys, so a {status}/{assigneeId} body lands here looking
       // empty — point callers at the dedicated routes instead of a generic 400.
+      // c.req.json() re-reads Hono's memoized body (zValidator already consumed the
+      // stream); if Hono ever stops memoizing, this falls back to null and only the
+      // hint is lost, never the 400 itself.
       const raw = (await c.req.json().catch(() => null)) as Record<string, unknown> | null;
       if (raw && 'status' in raw) {
         return c.json({ error: 'Status is not updatable via PATCH — use POST /tickets/:id/status' }, 400);

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -397,21 +397,19 @@ ticketsRoutes.patch(
     const auth = c.get('auth');
     const { id } = c.req.valid('param');
     const body = c.req.valid('json');
-    if (Object.keys(body).length === 0) {
-      // zod strips unknown keys, so a {status}/{assigneeId} body lands here looking
-      // empty — point callers at the dedicated routes instead of a generic 400.
-      // c.req.json() re-reads Hono's memoized body (zValidator already consumed the
-      // stream); if Hono ever stops memoizing, this falls back to null and only the
-      // hint is lost, never the 400 itself.
-      const raw = (await c.req.json().catch(() => null)) as Record<string, unknown> | null;
-      if (raw && 'status' in raw) {
-        return c.json({ error: 'Status is not updatable via PATCH — use POST /tickets/:id/status' }, 400);
-      }
-      if (raw && ('assigneeId' in raw || 'assignedTo' in raw)) {
-        return c.json({ error: 'Assignee is not updatable via PATCH — use POST /tickets/:id/assign' }, 400);
-      }
-      return c.json({ error: 'No fields to update' }, 400);
+    // zod strips unknown keys, so status/assignee changes sent here would silently
+    // vanish — reject them outright and point at the dedicated routes.
+    // c.req.json() re-reads Hono's memoized body (zValidator already consumed the
+    // stream); if Hono ever stops memoizing, this falls back to null and only the
+    // hint is lost, never the 400 itself.
+    const raw = (await c.req.json().catch(() => null)) as Record<string, unknown> | null;
+    if (raw && 'status' in raw) {
+      return c.json({ error: 'Status is not updatable via PATCH — use POST /tickets/:id/status' }, 400);
     }
+    if (raw && ('assigneeId' in raw || 'assignedTo' in raw)) {
+      return c.json({ error: 'Assignee is not updatable via PATCH — use POST /tickets/:id/assign' }, 400);
+    }
+    if (Object.keys(body).length === 0) return c.json({ error: 'No fields to update' }, 400);
 
     if (auth.scope === 'organization' && !auth.orgId) {
       return c.json({ error: 'Organization context required' }, 403);

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -397,7 +397,18 @@ ticketsRoutes.patch(
     const auth = c.get('auth');
     const { id } = c.req.valid('param');
     const body = c.req.valid('json');
-    if (Object.keys(body).length === 0) return c.json({ error: 'No fields to update' }, 400);
+    if (Object.keys(body).length === 0) {
+      // zod strips unknown keys, so a {status}/{assigneeId} body lands here looking
+      // empty — point callers at the dedicated routes instead of a generic 400.
+      const raw = (await c.req.json().catch(() => null)) as Record<string, unknown> | null;
+      if (raw && 'status' in raw) {
+        return c.json({ error: 'Status is not updatable via PATCH — use POST /tickets/:id/status' }, 400);
+      }
+      if (raw && ('assigneeId' in raw || 'assignedTo' in raw)) {
+        return c.json({ error: 'Assignee is not updatable via PATCH — use POST /tickets/:id/assign' }, 400);
+      }
+      return c.json({ error: 'No fields to update' }, 400);
+    }
 
     if (auth.scope === 'organization' && !auth.orgId) {
       return c.json({ error: 'Organization context required' }, 403);

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -169,7 +169,7 @@ describe('createTicket', () => {
     expect(insertPayload).toMatchObject({ deviceId: 'd-1' });
   });
 
-  it('non-portal ticket defaults submitterName/Email to the actor when the actor has name+email', async () => {
+  it('non-portal ticket defaults submitterName to the actor but NEVER stamps submitterEmail', async () => {
     dbMocks.selectResult.mockResolvedValue([{ id: 'o-1', partnerId: 'p-1' }]);
     dbMocks.insertReturning.mockResolvedValue([{ id: 't-5', orgId: 'o-1', internalNumber: 'T-2026-0042', status: 'new' }]);
 
@@ -178,10 +178,13 @@ describe('createTicket', () => {
       { userId: 'u-1', name: 'Tech One', email: 'tech@msp.com' }
     );
 
+    // submitterEmail must stay null even when the actor has an email: the
+    // notify worker emails submitterEmail on every public comment/resolution
+    // with portal-oriented copy and no self-actor suppression.
     const insertPayload = valuesMock.mock.calls[0]![0];
     expect(insertPayload).toMatchObject({
       submitterName: 'Tech One',
-      submitterEmail: 'tech@msp.com',
+      submitterEmail: null,
       submittedBy: null
     });
   });

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -169,6 +169,40 @@ describe('createTicket', () => {
     expect(insertPayload).toMatchObject({ deviceId: 'd-1' });
   });
 
+  it('non-portal ticket defaults submitterName/Email to the actor when the actor has name+email', async () => {
+    dbMocks.selectResult.mockResolvedValue([{ id: 'o-1', partnerId: 'p-1' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 't-5', orgId: 'o-1', internalNumber: 'T-2026-0042', status: 'new' }]);
+
+    await createTicket(
+      { orgId: 'o-1', subject: 'Printer offline', source: 'manual' },
+      { userId: 'u-1', name: 'Tech One', email: 'tech@msp.com' }
+    );
+
+    const insertPayload = valuesMock.mock.calls[0]![0];
+    expect(insertPayload).toMatchObject({
+      submitterName: 'Tech One',
+      submitterEmail: 'tech@msp.com',
+      submittedBy: null
+    });
+  });
+
+  it('non-portal ticket sets both submitter fields to null when actor has no name/email', async () => {
+    dbMocks.selectResult.mockResolvedValue([{ id: 'o-1', partnerId: 'p-1' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 't-6', orgId: 'o-1', internalNumber: 'T-2026-0042', status: 'new' }]);
+
+    await createTicket(
+      { orgId: 'o-1', subject: 'Headless ticket', source: 'alert' },
+      { userId: 'u-sys' }
+    );
+
+    const insertPayload = valuesMock.mock.calls[0]![0];
+    expect(insertPayload).toMatchObject({
+      submitterName: null,
+      submitterEmail: null,
+      submittedBy: null
+    });
+  });
+
   it('passes through portal submitter fields to the insert payload', async () => {
     dbMocks.selectResult.mockResolvedValue([{ id: 'o-1', partnerId: 'p-1' }]);
     dbMocks.insertReturning.mockResolvedValue([{ id: 't-3', orgId: 'o-1', internalNumber: 'T-2026-0044', status: 'new' }]);

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -226,9 +226,12 @@ export async function createTicket(input: CreateTicketInput, actor: TicketActor)
     status: (input.assigneeId ? 'open' : 'new') as typeof tickets.$inferInsert['status'],
     source: input.source,
     submittedBy: isPortal ? input.submittedBy : null,
-    // Non-portal tickets default the requester to the acting user — a technician
-    // logging a ticket is its requester unless the portal supplied one.
-    submitterEmail: isPortal ? input.submitterEmail : (actor.email ?? null),
+    // Non-portal tickets show the acting user as the requester NAME only (fixes
+    // "Unknown" requester in the UI). submitterEmail deliberately stays null for
+    // non-portal sources: the notify worker emails submitterEmail on every public
+    // comment/resolution with portal-oriented copy and no self-actor suppression,
+    // so staff-created tickets must keep "no external requester" semantics.
+    submitterEmail: isPortal ? input.submitterEmail : null,
     submitterName: isPortal ? (input.submitterName ?? null) : (actor.name ?? null),
     category: null
   } satisfies typeof tickets.$inferInsert;

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -226,8 +226,10 @@ export async function createTicket(input: CreateTicketInput, actor: TicketActor)
     status: (input.assigneeId ? 'open' : 'new') as typeof tickets.$inferInsert['status'],
     source: input.source,
     submittedBy: isPortal ? input.submittedBy : null,
-    submitterEmail: isPortal ? input.submitterEmail : null,
-    submitterName: isPortal ? (input.submitterName ?? null) : null,
+    // Non-portal tickets default the requester to the acting user — a technician
+    // logging a ticket is its requester unless the portal supplied one.
+    submitterEmail: isPortal ? input.submitterEmail : (actor.email ?? null),
+    submitterName: isPortal ? (input.submitterName ?? null) : (actor.name ?? null),
     category: null
   } satisfies typeof tickets.$inferInsert;
 

--- a/apps/web/src/components/help/HelpPanel.test.tsx
+++ b/apps/web/src/components/help/HelpPanel.test.tsx
@@ -1,0 +1,56 @@
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useHelpStore } from '@/stores/helpStore';
+import HelpPanel from './HelpPanel';
+
+// Mock the aiStore lazy import inside helpStore
+vi.mock('@/stores/aiStore', () => ({
+  useAiStore: Object.assign(vi.fn(), { getState: () => ({ close: vi.fn() }) }),
+}));
+
+// Stub open to suppress navigation side-effects
+vi.stubGlobal('open', vi.fn());
+
+beforeEach(() => {
+  useHelpStore.setState({ isOpen: false });
+});
+
+describe('HelpPanel keyboard shortcut', () => {
+  it('Cmd+Shift+H (uppercase H) toggles the panel open', () => {
+    render(<HelpPanel />);
+    expect(useHelpStore.getState().isOpen).toBe(false);
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'H', metaKey: true, shiftKey: true, bubbles: true })
+    );
+
+    expect(useHelpStore.getState().isOpen).toBe(true);
+  });
+
+  it('Ctrl+Shift+h (lowercase) also toggles', () => {
+    render(<HelpPanel />);
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'h', ctrlKey: true, shiftKey: true, bubbles: true })
+    );
+    expect(useHelpStore.getState().isOpen).toBe(true);
+  });
+
+  it('Cmd+Shift+H while open closes the panel', () => {
+    useHelpStore.setState({ isOpen: true });
+    render(<HelpPanel />);
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'H', metaKey: true, shiftKey: true, bubbles: true })
+    );
+
+    expect(useHelpStore.getState().isOpen).toBe(false);
+  });
+
+  it('does not trigger without shift', () => {
+    render(<HelpPanel />);
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'h', metaKey: true, bubbles: true })
+    );
+    expect(useHelpStore.getState().isOpen).toBe(false);
+  });
+});

--- a/apps/web/src/components/help/HelpPanel.tsx
+++ b/apps/web/src/components/help/HelpPanel.tsx
@@ -13,7 +13,7 @@ export default function HelpPanel() {
   // Keyboard shortcut: Cmd+Shift+H to toggle
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'h') {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'h') {
         e.preventDefault();
         toggle();
       }

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -41,9 +41,10 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useUiStore } from '../../stores/uiStore';
-import { fetchWithAuth, useAuthStore } from '../../stores/auth';
+import { fetchWithAuth } from '../../stores/auth';
 import { WEB_VERSION } from '../../lib/version';
 import { semverCompare } from '@breeze/shared';
+import { getJwtClaims } from '../../lib/authScope';
 import BrandHeader from './BrandHeader';
 
 interface SidebarProps {
@@ -290,17 +291,7 @@ export default function Sidebar({ currentPath: initialPath = '/' }: SidebarProps
   // a non-partner scope; falls through to the server (which will 403) when the scope
   // cannot be decoded.
   useEffect(() => {
-    // Decode the JWT scope without verification (safe browser-side, used only to avoid a known 403).
-    const token = useAuthStore.getState().tokens?.accessToken;
-    let scope: string | null = null;
-    if (token) {
-      try {
-        const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
-        scope = typeof payload.scope === 'string' ? payload.scope : null;
-      } catch {
-        // If decode fails, fall through and let the server respond (it will 403 for non-partner).
-      }
-    }
+    const { scope } = getJwtClaims();
     if (scope !== null && scope !== 'partner') return;
 
     let cancelled = false;

--- a/apps/web/src/components/settings/PartnerSettingsPage.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.tsx
@@ -7,7 +7,8 @@ import {
   Save,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { fetchWithAuth, useAuthStore } from '../../stores/auth';
+import { fetchWithAuth } from '../../stores/auth';
+import { getJwtClaims } from '../../lib/authScope';
 import { useOrgStore } from '../../stores/orgStore';
 import KnownGuestsSettings from './KnownGuestsSettings';
 import PartnerSecurityTab, { currentIpCovered } from './PartnerSecurityTab';
@@ -197,15 +198,12 @@ export default function PartnerSettingsPage() {
     if (contextLoading) return;
     // No partner context in store yet. Try to seed it from the JWT (handles
     // first-login and cleared-storage cases where currentPartnerId is null).
-    const token = useAuthStore.getState().tokens?.accessToken;
-    if (token) {
-      try {
-        const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
-        if (payload.scope === 'partner' && payload.partnerId) {
-          setPartnerContext(payload.partnerId as string);
-          return; // Re-render will follow with currentPartnerId set
-        }
-      } catch { /* ignore decode failures */ }
+    // getJwtClaims returns all-null on a missing/undecodable token, so the
+    // access-denied fall-through below covers those cases too.
+    const { scope, partnerId } = getJwtClaims();
+    if (scope === 'partner' && partnerId) {
+      setPartnerContext(partnerId);
+      return; // Re-render will follow with currentPartnerId set
     }
     setLoading(false); // JWT confirms non-partner scope; show access denied
   }, [currentPartnerId, contextLoading, fetchPartner, setPartnerContext]);

--- a/apps/web/src/components/settings/TicketCategoriesPage.test.tsx
+++ b/apps/web/src/components/settings/TicketCategoriesPage.test.tsx
@@ -307,6 +307,74 @@ describe('TicketCategoriesPage', () => {
     });
   });
 
+  describe('hierarchy defensive rendering', () => {
+    it('renders a grandchild (parent exists but is itself a child) instead of hiding it', async () => {
+      // A → B → C chain: C's parent B is itself a child. The API tolerates this
+      // via PATCH even though the UI only offers roots — management must never
+      // hide a row.
+      const A = { ...CAT_PARENT, id: 'a1', name: 'A Root' };
+      const B = { ...CAT_CHILD, id: 'b1', name: 'B Child', parentId: 'a1' };
+      const C = { ...CAT_CHILD, id: 'c9', name: 'C Grandchild', parentId: 'b1' };
+      mockGetCategories([A, B, C]);
+      render(<TicketCategoriesPage />);
+
+      await screen.findByTestId('ticket-category-row-a1');
+      expect(screen.getByTestId('ticket-category-row-b1')).toBeInTheDocument();
+      // Without the defensive append, C would silently vanish from management.
+      const cRow = screen.getByTestId('ticket-category-row-c9');
+      expect(cRow).toBeInTheDocument();
+      expect(cRow.getAttribute('data-depth')).toBe('0');
+    });
+  });
+
+  describe('numeric guard on save', () => {
+    it.each(['60a', '1e999'])('refuses non-finite numeric input %s with an error toast and no PATCH', async (bad) => {
+      mockGetCategories([CAT_CHILD]);
+      render(<TicketCategoriesPage />);
+      await screen.findByTestId(`ticket-category-edit-${CAT_CHILD.id}`);
+
+      fireEvent.click(screen.getByTestId(`ticket-category-edit-${CAT_CHILD.id}`));
+      // '60a' → NaN; '1e999' → Infinity. Both JSON-serialize to null, silently
+      // nulling the field server-side — the guard must refuse both.
+      // jsdom sanitizes invalid strings on type=number inputs to '' before React
+      // sees them (real browsers pass e.g. '1e999' through), so flip the type to
+      // text for the change event to exercise the guard the way a browser would.
+      const rateInput = screen.getByTestId('ticket-category-edit-rate') as HTMLInputElement;
+      rateInput.type = 'text';
+      fireEvent.change(rateInput, { target: { value: bad } });
+      fireEvent.click(screen.getByTestId(`ticket-category-save-${CAT_CHILD.id}`));
+
+      await waitFor(() => {
+        expect(showToast).toHaveBeenCalledWith({ type: 'error', message: 'SLA minutes and hourly rate must be numbers.' });
+      });
+      expect(fetchMock).not.toHaveBeenCalledWith(
+        `/ticket-categories/${CAT_CHILD.id}`,
+        expect.objectContaining({ method: 'PATCH' })
+      );
+    });
+  });
+
+  describe('priority options from priorityConfig', () => {
+    it('edit panel lists None + the priorityConfig entries in declared order', async () => {
+      mockGetCategories([CAT_CHILD]);
+      render(<TicketCategoriesPage />);
+      await screen.findByTestId(`ticket-category-edit-${CAT_CHILD.id}`);
+
+      fireEvent.click(screen.getByTestId(`ticket-category-edit-${CAT_CHILD.id}`));
+      const prioritySelect = screen.getByTestId('ticket-category-edit-priority');
+      const options = Array.from(prioritySelect.querySelectorAll('option')).map((o) => (o as HTMLOptionElement).value);
+      expect(options).toEqual(['', 'urgent', 'high', 'normal', 'low']);
+      expect(screen.getByRole('option', { name: 'Urgent' })).toBeInTheDocument();
+    });
+
+    it('defaults summary uses the priorityConfig label', async () => {
+      mockGetCategories([{ ...CAT_CHILD, defaultPriority: 'high' }]);
+      render(<TicketCategoriesPage />);
+      const row = await screen.findByTestId(`ticket-category-row-${CAT_CHILD.id}`);
+      expect(row.textContent).toContain('High');
+    });
+  });
+
   describe('parent select in edit panel', () => {
     it('excludes the category itself and its children from the parent dropdown', async () => {
       // p1 is parent, c1 is child, r2 is another root

--- a/apps/web/src/components/settings/TicketCategoriesPage.test.tsx
+++ b/apps/web/src/components/settings/TicketCategoriesPage.test.tsx
@@ -1,0 +1,341 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import TicketCategoriesPage from './TicketCategoriesPage';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn()
+}));
+
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+
+vi.mock('../../lib/authScope', () => ({
+  loginPathWithNext: () => '/login?next=%2Fsettings%2Ftickets'
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload)
+  }) as unknown as Response;
+
+const CAT_PARENT = {
+  id: 'p1', name: 'Hardware', color: '#ff0000', parentId: null,
+  defaultPriority: null, responseSlaMinutes: null, resolutionSlaMinutes: null,
+  defaultBillable: false, defaultHourlyRate: null, sortOrder: 0, isActive: true
+};
+const CAT_CHILD = {
+  id: 'c1', name: 'Printers', color: '#00ff00', parentId: 'p1',
+  defaultPriority: 'high', responseSlaMinutes: 60, resolutionSlaMinutes: 480,
+  defaultBillable: true, defaultHourlyRate: '150.00', sortOrder: 0, isActive: true
+};
+const CAT_ROOT2 = {
+  id: 'r2', name: 'Software', color: '#0000ff', parentId: null,
+  defaultPriority: null, responseSlaMinutes: null, resolutionSlaMinutes: null,
+  defaultBillable: false, defaultHourlyRate: null, sortOrder: 1, isActive: true
+};
+
+function mockGetCategories(cats: unknown[]) {
+  fetchMock.mockImplementation(async (input, init) => {
+    const url = String(input);
+    if (url === '/ticket-categories' && !init?.method) {
+      return makeJsonResponse({ data: cats });
+    }
+    if (url === '/ticket-categories' && init?.method === 'POST') {
+      return makeJsonResponse({ data: { id: 'new-1', ...(cats[0] as object) } });
+    }
+    if (url.match(/\/ticket-categories\/.+/) && init?.method === 'PATCH') {
+      return makeJsonResponse({ data: {} });
+    }
+    return makeJsonResponse({ error: 'unexpected' }, false, 404);
+  });
+}
+
+describe('TicketCategoriesPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --- Existing tests preserved ---
+
+  it('renders heading and create form', async () => {
+    mockGetCategories([]);
+    render(<TicketCategoriesPage />);
+    expect(screen.getByTestId('ticket-categories-heading')).toBeInTheDocument();
+    expect(screen.getByTestId('ticket-categories-name-input')).toBeInTheDocument();
+    expect(screen.getByTestId('ticket-categories-color-input')).toBeInTheDocument();
+    expect(screen.getByTestId('ticket-categories-create-button')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no categories', async () => {
+    mockGetCategories([]);
+    render(<TicketCategoriesPage />);
+    await screen.findByTestId('ticket-categories-empty');
+  });
+
+  it('shows error + retry on fetch failure', async () => {
+    fetchMock.mockResolvedValue(makeJsonResponse({ error: 'boom' }, false, 500));
+    render(<TicketCategoriesPage />);
+    await screen.findByTestId('ticket-categories-error');
+    expect(screen.getByTestId('ticket-categories-retry')).toBeInTheDocument();
+
+    // Retry recovers
+    mockGetCategories([CAT_PARENT]);
+    fireEvent.click(screen.getByTestId('ticket-categories-retry'));
+    await screen.findByTestId(`ticket-category-row-${CAT_PARENT.id}`);
+    expect(screen.queryByTestId('ticket-categories-error')).toBeNull();
+  });
+
+  it('creates a category and reloads list', async () => {
+    mockGetCategories([]);
+    render(<TicketCategoriesPage />);
+    await screen.findByTestId('ticket-categories-empty');
+
+    // Load returns the new category after creation
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === '/ticket-categories' && !init?.method) return makeJsonResponse({ data: [CAT_PARENT] });
+      if (url === '/ticket-categories' && init?.method === 'POST') return makeJsonResponse({ data: CAT_PARENT });
+      return makeJsonResponse({ error: 'unexpected' }, false, 404);
+    });
+
+    fireEvent.change(screen.getByTestId('ticket-categories-name-input'), { target: { value: 'Hardware' } });
+    fireEvent.click(screen.getByTestId('ticket-categories-create-button'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/ticket-categories', expect.objectContaining({ method: 'POST' }));
+    });
+    await screen.findByTestId(`ticket-category-row-${CAT_PARENT.id}`);
+  });
+
+  it('toggles active/inactive', async () => {
+    mockGetCategories([CAT_PARENT]);
+    render(<TicketCategoriesPage />);
+    await screen.findByTestId(`ticket-category-toggle-${CAT_PARENT.id}`);
+
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === '/ticket-categories' && !init?.method) return makeJsonResponse({ data: [{ ...CAT_PARENT, isActive: false }] });
+      if (url.match(/\/ticket-categories\/.+/) && init?.method === 'PATCH') return makeJsonResponse({ data: {} });
+      return makeJsonResponse({ error: 'unexpected' }, false, 404);
+    });
+
+    fireEvent.click(screen.getByTestId(`ticket-category-toggle-${CAT_PARENT.id}`));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/ticket-categories/${CAT_PARENT.id}`,
+        expect.objectContaining({ method: 'PATCH' })
+      );
+    });
+  });
+
+  // --- New tests ---
+
+  describe('hierarchy display', () => {
+    it('renders parent p1, child c1, root r2 in order; c1 has data-depth="1"', async () => {
+      // The API may return them in any order; we pass [c1, r2, p1] to stress the ordering
+      mockGetCategories([CAT_CHILD, CAT_ROOT2, CAT_PARENT]);
+      render(<TicketCategoriesPage />);
+
+      await screen.findByTestId(`ticket-category-row-${CAT_PARENT.id}`);
+      await screen.findByTestId(`ticket-category-row-${CAT_CHILD.id}`);
+      await screen.findByTestId(`ticket-category-row-${CAT_ROOT2.id}`);
+
+      const rows = screen.getAllByRole('row');
+      // Find data rows by testid
+      const p1Index = rows.findIndex((r) => r.getAttribute('data-testid') === `ticket-category-row-${CAT_PARENT.id}`);
+      const c1Index = rows.findIndex((r) => r.getAttribute('data-testid') === `ticket-category-row-${CAT_CHILD.id}`);
+      const r2Index = rows.findIndex((r) => r.getAttribute('data-testid') === `ticket-category-row-${CAT_ROOT2.id}`);
+
+      expect(p1Index).toBeGreaterThan(0); // exists
+      expect(c1Index).toBeGreaterThan(p1Index); // child after parent
+      expect(r2Index).toBeGreaterThan(c1Index); // root2 after child
+
+      // c1 must have data-depth="1"
+      const c1Row = screen.getByTestId(`ticket-category-row-${CAT_CHILD.id}`);
+      expect(c1Row.getAttribute('data-depth')).toBe('1');
+
+      // p1 and r2 must have data-depth="0"
+      const p1Row = screen.getByTestId(`ticket-category-row-${CAT_PARENT.id}`);
+      expect(p1Row.getAttribute('data-depth')).toBe('0');
+    });
+  });
+
+  describe('create with parent', () => {
+    it('includes parentId in POST when parent is selected', async () => {
+      mockGetCategories([CAT_PARENT]);
+      render(<TicketCategoriesPage />);
+      await screen.findByTestId(`ticket-category-row-${CAT_PARENT.id}`);
+
+      let postBody: Record<string, unknown> = {};
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === '/ticket-categories' && !init?.method) return makeJsonResponse({ data: [CAT_PARENT] });
+        if (url === '/ticket-categories' && init?.method === 'POST') {
+          postBody = JSON.parse(String(init.body)) as Record<string, unknown>;
+          return makeJsonResponse({ data: CAT_CHILD });
+        }
+        return makeJsonResponse({ error: 'unexpected' }, false, 404);
+      });
+
+      fireEvent.change(screen.getByTestId('ticket-categories-name-input'), { target: { value: 'Printers' } });
+      fireEvent.change(screen.getByTestId('ticket-categories-parent-input'), { target: { value: 'p1' } });
+      fireEvent.click(screen.getByTestId('ticket-categories-create-button'));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith('/ticket-categories', expect.objectContaining({ method: 'POST' }));
+      });
+      expect(postBody.parentId).toBe('p1');
+      expect(postBody.name).toBe('Printers');
+    });
+
+    it('omits parentId when None is selected', async () => {
+      mockGetCategories([CAT_PARENT]);
+      render(<TicketCategoriesPage />);
+      await screen.findByTestId(`ticket-category-row-${CAT_PARENT.id}`);
+
+      let postBody: Record<string, unknown> = {};
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === '/ticket-categories' && !init?.method) return makeJsonResponse({ data: [CAT_PARENT] });
+        if (url === '/ticket-categories' && init?.method === 'POST') {
+          postBody = JSON.parse(String(init.body)) as Record<string, unknown>;
+          return makeJsonResponse({ data: CAT_PARENT });
+        }
+        return makeJsonResponse({ error: 'unexpected' }, false, 404);
+      });
+
+      fireEvent.change(screen.getByTestId('ticket-categories-name-input'), { target: { value: 'Networking' } });
+      // parent stays None (default)
+      fireEvent.click(screen.getByTestId('ticket-categories-create-button'));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith('/ticket-categories', expect.objectContaining({ method: 'POST' }));
+      });
+      expect(postBody).not.toHaveProperty('parentId');
+    });
+  });
+
+  describe('edit flow', () => {
+    it('prefills edit fields from category data and PATCHes with correctly typed payload', async () => {
+      mockGetCategories([CAT_CHILD]);
+      render(<TicketCategoriesPage />);
+      await screen.findByTestId(`ticket-category-edit-${CAT_CHILD.id}`);
+
+      fireEvent.click(screen.getByTestId(`ticket-category-edit-${CAT_CHILD.id}`));
+
+      // Verify prefilled values
+      expect(screen.getByTestId('ticket-category-edit-response-sla')).toHaveValue(60);
+      const rateInput = screen.getByTestId('ticket-category-edit-rate') as HTMLInputElement;
+      expect(rateInput.value).toBe('150.00');
+
+      // Change name, clear response SLA, set rate to 99.5
+      fireEvent.change(screen.getByTestId('ticket-category-edit-name'), { target: { value: 'New name' } });
+      fireEvent.change(screen.getByTestId('ticket-category-edit-response-sla'), { target: { value: '' } });
+      fireEvent.change(screen.getByTestId('ticket-category-edit-rate'), { target: { value: '99.5' } });
+
+      let patchBody: Record<string, unknown> = {};
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === '/ticket-categories' && !init?.method) return makeJsonResponse({ data: [CAT_CHILD] });
+        if (url === `/ticket-categories/${CAT_CHILD.id}` && init?.method === 'PATCH') {
+          patchBody = JSON.parse(String(init.body)) as Record<string, unknown>;
+          return makeJsonResponse({ data: {} });
+        }
+        return makeJsonResponse({ error: 'unexpected' }, false, 404);
+      });
+
+      fireEvent.click(screen.getByTestId(`ticket-category-save-${CAT_CHILD.id}`));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          `/ticket-categories/${CAT_CHILD.id}`,
+          expect.objectContaining({ method: 'PATCH' })
+        );
+      });
+
+      expect(patchBody.name).toBe('New name');
+      expect(patchBody.responseSlaMinutes).toBeNull();
+      expect(patchBody.defaultHourlyRate).toBe(99.5);
+      // These must be numbers, not strings
+      expect(typeof patchBody.defaultHourlyRate).toBe('number');
+    });
+
+    it('closes edit panel on cancel without saving', async () => {
+      mockGetCategories([CAT_PARENT]);
+      render(<TicketCategoriesPage />);
+      await screen.findByTestId(`ticket-category-edit-${CAT_PARENT.id}`);
+
+      fireEvent.click(screen.getByTestId(`ticket-category-edit-${CAT_PARENT.id}`));
+
+      // Edit fields visible
+      expect(screen.getByTestId('ticket-category-edit-name')).toBeInTheDocument();
+
+      // Click cancel
+      fireEvent.click(screen.getByTestId(`ticket-category-cancel-${CAT_PARENT.id}`));
+
+      // Edit fields gone
+      expect(screen.queryByTestId('ticket-category-edit-name')).toBeNull();
+
+      // No PATCH was called
+      expect(fetchMock).not.toHaveBeenCalledWith(
+        expect.stringContaining('/ticket-categories/'),
+        expect.objectContaining({ method: 'PATCH' })
+      );
+    });
+
+    it('save button disabled when name is empty', async () => {
+      mockGetCategories([CAT_PARENT]);
+      render(<TicketCategoriesPage />);
+      await screen.findByTestId(`ticket-category-edit-${CAT_PARENT.id}`);
+
+      fireEvent.click(screen.getByTestId(`ticket-category-edit-${CAT_PARENT.id}`));
+
+      const nameInput = screen.getByTestId('ticket-category-edit-name');
+      fireEvent.change(nameInput, { target: { value: '' } });
+
+      expect(screen.getByTestId(`ticket-category-save-${CAT_PARENT.id}`)).toBeDisabled();
+    });
+  });
+
+  describe('parent select in edit panel', () => {
+    it('excludes the category itself and its children from the parent dropdown', async () => {
+      // p1 is parent, c1 is child, r2 is another root
+      mockGetCategories([CAT_PARENT, CAT_CHILD, CAT_ROOT2]);
+      render(<TicketCategoriesPage />);
+      await screen.findByTestId(`ticket-category-edit-${CAT_PARENT.id}`);
+
+      // Edit p1 — cannot choose p1 itself or c1 (its child) as parent
+      fireEvent.click(screen.getByTestId(`ticket-category-edit-${CAT_PARENT.id}`));
+      const parentSelect = screen.getByTestId('ticket-category-edit-parent');
+      const options = Array.from(parentSelect.querySelectorAll('option')).map((o) => (o as HTMLOptionElement).value);
+
+      expect(options).not.toContain(CAT_PARENT.id); // self excluded
+      expect(options).not.toContain(CAT_CHILD.id);  // child excluded
+      expect(options).toContain(CAT_ROOT2.id);       // sibling root included
+    });
+
+    it('allows a child to pick a different root as parent', async () => {
+      mockGetCategories([CAT_PARENT, CAT_CHILD, CAT_ROOT2]);
+      render(<TicketCategoriesPage />);
+      await screen.findByTestId(`ticket-category-edit-${CAT_CHILD.id}`);
+
+      fireEvent.click(screen.getByTestId(`ticket-category-edit-${CAT_CHILD.id}`));
+      const parentSelect = screen.getByTestId('ticket-category-edit-parent');
+      const options = Array.from(parentSelect.querySelectorAll('option')).map((o) => (o as HTMLOptionElement).value);
+
+      expect(options).toContain(CAT_PARENT.id); // current parent available (to keep it)
+      expect(options).toContain(CAT_ROOT2.id);   // other root available
+      expect(options).not.toContain(CAT_CHILD.id); // self excluded
+    });
+  });
+});

--- a/apps/web/src/components/settings/TicketCategoriesPage.tsx
+++ b/apps/web/src/components/settings/TicketCategoriesPage.tsx
@@ -2,18 +2,75 @@ import { useCallback, useEffect, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
+import { loginPathWithNext } from '../../lib/authScope';
 
 interface Category {
-  id: string; name: string; color: string; defaultPriority: string | null;
-  responseSlaMinutes: number | null; resolutionSlaMinutes: number | null; isActive: boolean;
+  id: string;
+  name: string;
+  color: string;
+  parentId: string | null;
+  defaultPriority: string | null;
+  responseSlaMinutes: number | null;
+  resolutionSlaMinutes: number | null;
+  defaultBillable: boolean;
+  defaultHourlyRate: string | null;
+  sortOrder: number;
+  isActive: boolean;
 }
+
+interface EditDraft {
+  name: string;
+  color: string;
+  parentId: string;
+  defaultPriority: string;
+  responseSlaMinutes: string;
+  resolutionSlaMinutes: string;
+  defaultBillable: boolean;
+  defaultHourlyRate: string;
+}
+
+function hierarchyOrder(cats: Category[]): Array<Category & { depth: number }> {
+  const byRank = (a: Category, b: Category) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name);
+  const roots = cats.filter((c) => !c.parentId || !cats.some((p) => p.id === c.parentId));
+  const out: Array<Category & { depth: number }> = [];
+  for (const r of [...roots].sort(byRank)) {
+    out.push({ ...r, depth: 0 });
+    for (const ch of cats.filter((c) => c.parentId === r.id).sort(byRank)) {
+      out.push({ ...ch, depth: 1 });
+    }
+  }
+  return out;
+}
+
+function defaultsSummary(c: Category): string {
+  const parts: string[] = [];
+  if (c.defaultPriority) parts.push(c.defaultPriority.charAt(0).toUpperCase() + c.defaultPriority.slice(1));
+  if (c.responseSlaMinutes != null) parts.push(`${c.responseSlaMinutes}m response`);
+  if (c.resolutionSlaMinutes != null) parts.push(`${c.resolutionSlaMinutes}m resolve`);
+  if (c.defaultHourlyRate) parts.push(`$${c.defaultHourlyRate}/h`);
+  if (c.defaultBillable) parts.push('billable');
+  else if (parts.length > 0) parts.push('non-billable');
+  return parts.length > 0 ? parts.join(' · ') : '—';
+}
+
+const UNAUTHORIZED = () => void navigateTo(loginPathWithNext(), { replace: true });
 
 export default function TicketCategoriesPage() {
   const [categories, setCategories] = useState<Category[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+
+  // Create form state
   const [name, setName] = useState('');
   const [color, setColor] = useState('#1c8a9e');
+  const [createParentId, setCreateParentId] = useState('');
+
+  // Edit state
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draft, setDraft] = useState<EditDraft>({
+    name: '', color: '#1c8a9e', parentId: '', defaultPriority: '',
+    responseSlaMinutes: '', resolutionSlaMinutes: '', defaultBillable: false, defaultHourlyRate: ''
+  });
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -32,26 +89,29 @@ export default function TicketCategoriesPage() {
 
   const create = useCallback(async () => {
     if (!name.trim()) return;
+    const body: Record<string, unknown> = { name: name.trim(), color };
+    if (createParentId) body.parentId = createParentId;
     try {
       await runAction({
-        request: () => fetchWithAuth('/ticket-categories', { method: 'POST', body: JSON.stringify({ name: name.trim(), color }) }),
+        request: () => fetchWithAuth('/ticket-categories', { method: 'POST', body: JSON.stringify(body) }),
         errorFallback: 'Category creation failed. Retry.',
         successMessage: `Category "${name.trim()}" created`,
-        onUnauthorized: () => void navigateTo('/login', { replace: true })
+        onUnauthorized: UNAUTHORIZED
       });
       setName('');
+      setCreateParentId('');
       void load();
     } catch (err) {
       if (!(err instanceof ActionError)) throw err;
     }
-  }, [name, color, load]);
+  }, [name, color, createParentId, load]);
 
   const toggleActive = useCallback(async (cat: Category) => {
     try {
       await runAction({
         request: () => fetchWithAuth(`/ticket-categories/${cat.id}`, { method: 'PATCH', body: JSON.stringify({ isActive: !cat.isActive }) }),
         errorFallback: 'Update failed. Retry.',
-        onUnauthorized: () => void navigateTo('/login', { replace: true })
+        onUnauthorized: UNAUTHORIZED
       });
       void load();
     } catch (err) {
@@ -59,47 +119,281 @@ export default function TicketCategoriesPage() {
     }
   }, [load]);
 
+  const startEdit = useCallback((cat: Category) => {
+    setEditingId(cat.id);
+    setDraft({
+      name: cat.name,
+      color: cat.color,
+      parentId: cat.parentId ?? '',
+      defaultPriority: cat.defaultPriority ?? '',
+      responseSlaMinutes: cat.responseSlaMinutes?.toString() ?? '',
+      resolutionSlaMinutes: cat.resolutionSlaMinutes?.toString() ?? '',
+      defaultBillable: cat.defaultBillable,
+      defaultHourlyRate: cat.defaultHourlyRate ?? ''
+    });
+  }, []);
+
+  const saveEdit = useCallback(async (id: string) => {
+    if (!draft.name.trim()) return;
+    const payload = {
+      name: draft.name.trim(),
+      color: draft.color,
+      parentId: draft.parentId || null,
+      defaultPriority: draft.defaultPriority || null,
+      responseSlaMinutes: draft.responseSlaMinutes === '' ? null : Number(draft.responseSlaMinutes),
+      resolutionSlaMinutes: draft.resolutionSlaMinutes === '' ? null : Number(draft.resolutionSlaMinutes),
+      defaultBillable: draft.defaultBillable,
+      defaultHourlyRate: draft.defaultHourlyRate === '' ? null : Number(draft.defaultHourlyRate)
+    };
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/ticket-categories/${id}`, { method: 'PATCH', body: JSON.stringify(payload) }),
+        errorFallback: 'Update failed. Retry.',
+        successMessage: 'Category updated',
+        onUnauthorized: UNAUTHORIZED
+      });
+      setEditingId(null);
+      void load();
+    } catch (err) {
+      if (!(err instanceof ActionError)) throw err;
+    }
+  }, [draft, load]);
+
+  // Root categories that can be a parent in the create form (active, no parent)
+  const createParentOptions = categories.filter((c) => !c.parentId && c.isActive);
+
+  // Parent options for edit: exclude self and self's children
+  function editParentOptions(id: string): Category[] {
+    const childIds = categories.filter((c) => c.parentId === id).map((c) => c.id);
+    const excluded = new Set([id, ...childIds]);
+    // Only allow roots (depth=0) as parents; exclude self/children
+    return categories.filter((c) => !c.parentId && !excluded.has(c.id));
+  }
+
+  const ordered = hierarchyOrder(categories);
+
   return (
     <div className="max-w-3xl" data-testid="ticket-categories-page">
       <h1 className="text-xl font-semibold" data-testid="ticket-categories-heading">Ticketing</h1>
-      <p className="mt-1 text-sm text-muted-foreground">Categories organize the queue and carry SLA and billing defaults (SLA enforcement arrives with the SLA engine).</p>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Categories organize the queue and carry SLA and billing defaults (SLA enforcement arrives with the SLA engine).
+      </p>
 
       <div className="mt-4 flex items-end gap-2">
         <div className="flex-1">
           <label className="text-sm font-medium" htmlFor="cat-name">New category</label>
-          <input id="cat-name" value={name} onChange={(e) => setName(e.target.value)} className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm" data-testid="ticket-categories-name-input" />
+          <input
+            id="cat-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+            data-testid="ticket-categories-name-input"
+          />
         </div>
-        <input type="color" value={color} onChange={(e) => setColor(e.target.value)} className="h-9 w-12 rounded-md border" aria-label="Category color" data-testid="ticket-categories-color-input" />
-        <button type="button" onClick={() => void create()} disabled={!name.trim()} className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50" data-testid="ticket-categories-create-button">Add</button>
+        <input
+          type="color"
+          value={color}
+          onChange={(e) => setColor(e.target.value)}
+          className="h-9 w-12 rounded-md border"
+          aria-label="Category color"
+          data-testid="ticket-categories-color-input"
+        />
+        <select
+          value={createParentId}
+          onChange={(e) => setCreateParentId(e.target.value)}
+          className="rounded-md border bg-background px-2.5 py-1.5 text-sm"
+          aria-label="Parent category"
+          data-testid="ticket-categories-parent-input"
+        >
+          <option value="">None</option>
+          {createParentOptions.map((p) => (
+            <option key={p.id} value={p.id}>{p.name}</option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={() => void create()}
+          disabled={!name.trim()}
+          className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+          data-testid="ticket-categories-create-button"
+        >
+          Add
+        </button>
       </div>
 
       <table className="mt-4 min-w-full divide-y" data-testid="ticket-categories-table">
         <thead className="bg-muted/40">
           <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            <th className="px-4 py-2">Name</th><th className="px-4 py-2">Color</th><th className="px-4 py-2">Status</th><th className="px-4 py-2" />
+            <th className="px-4 py-2">Name</th>
+            <th className="px-4 py-2">Defaults</th>
+            <th className="px-4 py-2">Status</th>
+            <th className="px-4 py-2" />
           </tr>
         </thead>
         <tbody className="divide-y">
           {loading ? (
             <tr><td colSpan={4} className="px-4 py-6 text-center text-sm text-muted-foreground">Loading.</td></tr>
           ) : error ? (
-            <tr><td colSpan={4} className="px-4 py-6 text-center text-sm text-muted-foreground" data-testid="ticket-categories-error">
-              Categories failed to load.{' '}
-              <button type="button" onClick={() => void load()} className="underline hover:text-foreground" data-testid="ticket-categories-retry">Retry</button>
-            </td></tr>
-          ) : categories.length === 0 ? (
-            <tr><td colSpan={4} className="px-4 py-6 text-center text-sm text-muted-foreground" data-testid="ticket-categories-empty">No categories yet. Add the first one above.</td></tr>
-          ) : categories.map((c) => (
-            <tr key={c.id} data-testid={`ticket-category-row-${c.id}`}>
-              <td className="px-4 py-2 text-sm">{c.name}</td>
-              <td className="px-4 py-2"><span className="inline-block h-4 w-4 rounded" style={{ backgroundColor: c.color }} /></td>
-              <td className="px-4 py-2 text-sm">{c.isActive ? 'Active' : 'Inactive'}</td>
-              <td className="px-4 py-2 text-right">
-                <button type="button" onClick={() => void toggleActive(c)} className="text-sm text-muted-foreground hover:text-foreground" data-testid={`ticket-category-toggle-${c.id}`}>
-                  {c.isActive ? 'Deactivate' : 'Activate'}
-                </button>
+            <tr>
+              <td colSpan={4} className="px-4 py-6 text-center text-sm text-muted-foreground" data-testid="ticket-categories-error">
+                Categories failed to load.{' '}
+                <button type="button" onClick={() => void load()} className="underline hover:text-foreground" data-testid="ticket-categories-retry">Retry</button>
               </td>
             </tr>
+          ) : categories.length === 0 ? (
+            <tr>
+              <td colSpan={4} className="px-4 py-6 text-center text-sm text-muted-foreground" data-testid="ticket-categories-empty">
+                No categories yet. Add the first one above.
+              </td>
+            </tr>
+          ) : ordered.map((c) => (
+            <>
+              <tr key={c.id} data-testid={`ticket-category-row-${c.id}`} data-depth={c.depth}>
+                <td className={`px-4 py-2 text-sm${c.depth > 0 ? ' pl-10' : ''}`}>
+                  <span className="mr-1.5 inline-block h-3 w-3 rounded-sm align-middle" style={{ backgroundColor: c.color }} />
+                  {c.name}
+                </td>
+                <td className="px-4 py-2 text-sm text-muted-foreground">{defaultsSummary(c)}</td>
+                <td className="px-4 py-2 text-sm">{c.isActive ? 'Active' : 'Inactive'}</td>
+                <td className="px-4 py-2 text-right space-x-2">
+                  <button
+                    type="button"
+                    onClick={() => startEdit(c)}
+                    className="text-sm text-muted-foreground hover:text-foreground"
+                    data-testid={`ticket-category-edit-${c.id}`}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void toggleActive(c)}
+                    className="text-sm text-muted-foreground hover:text-foreground"
+                    data-testid={`ticket-category-toggle-${c.id}`}
+                  >
+                    {c.isActive ? 'Deactivate' : 'Activate'}
+                  </button>
+                </td>
+              </tr>
+              {editingId === c.id && (
+                <tr key={`edit-${c.id}`}>
+                  <td colSpan={4} className="bg-muted/30 px-4 py-3">
+                    <div className="grid grid-cols-2 gap-3">
+                      <div>
+                        <label className="text-xs font-medium">Name</label>
+                        <input
+                          value={draft.name}
+                          onChange={(e) => setDraft((d) => ({ ...d, name: e.target.value }))}
+                          className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+                          data-testid="ticket-category-edit-name"
+                        />
+                      </div>
+                      <div>
+                        <label className="text-xs font-medium">Color</label>
+                        <input
+                          type="color"
+                          value={draft.color}
+                          onChange={(e) => setDraft((d) => ({ ...d, color: e.target.value }))}
+                          className="h-9 w-full rounded-md border"
+                          data-testid="ticket-category-edit-color"
+                        />
+                      </div>
+                      <div>
+                        <label className="text-xs font-medium">Parent</label>
+                        <select
+                          value={draft.parentId}
+                          onChange={(e) => setDraft((d) => ({ ...d, parentId: e.target.value }))}
+                          className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+                          data-testid="ticket-category-edit-parent"
+                        >
+                          <option value="">None</option>
+                          {editParentOptions(c.id).map((p) => (
+                            <option key={p.id} value={p.id}>{p.name}</option>
+                          ))}
+                        </select>
+                      </div>
+                      <div>
+                        <label className="text-xs font-medium">Default priority</label>
+                        <select
+                          value={draft.defaultPriority}
+                          onChange={(e) => setDraft((d) => ({ ...d, defaultPriority: e.target.value }))}
+                          className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+                          data-testid="ticket-category-edit-priority"
+                        >
+                          <option value="">None</option>
+                          <option value="low">Low</option>
+                          <option value="normal">Normal</option>
+                          <option value="high">High</option>
+                          <option value="urgent">Urgent</option>
+                        </select>
+                      </div>
+                      <div>
+                        <label className="text-xs font-medium">Response SLA (minutes)</label>
+                        <input
+                          type="number"
+                          min={1}
+                          value={draft.responseSlaMinutes}
+                          onChange={(e) => setDraft((d) => ({ ...d, responseSlaMinutes: e.target.value }))}
+                          className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+                          data-testid="ticket-category-edit-response-sla"
+                        />
+                      </div>
+                      <div>
+                        <label className="text-xs font-medium">Resolution SLA (minutes)</label>
+                        <input
+                          type="number"
+                          min={1}
+                          value={draft.resolutionSlaMinutes}
+                          onChange={(e) => setDraft((d) => ({ ...d, resolutionSlaMinutes: e.target.value }))}
+                          className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+                          data-testid="ticket-category-edit-resolution-sla"
+                        />
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          id={`billable-${c.id}`}
+                          checked={draft.defaultBillable}
+                          onChange={(e) => setDraft((d) => ({ ...d, defaultBillable: e.target.checked }))}
+                          data-testid="ticket-category-edit-billable"
+                        />
+                        <label htmlFor={`billable-${c.id}`} className="text-xs font-medium">Billable by default</label>
+                      </div>
+                      <div>
+                        <label className="text-xs font-medium">Default hourly rate ($)</label>
+                        <input
+                          type="number"
+                          min={0}
+                          step={0.01}
+                          value={draft.defaultHourlyRate}
+                          onChange={(e) => setDraft((d) => ({ ...d, defaultHourlyRate: e.target.value }))}
+                          className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+                          data-testid="ticket-category-edit-rate"
+                        />
+                      </div>
+                    </div>
+                    <div className="mt-3 flex gap-2">
+                      <button
+                        type="button"
+                        onClick={() => void saveEdit(c.id)}
+                        disabled={!draft.name.trim()}
+                        className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+                        data-testid={`ticket-category-save-${c.id}`}
+                      >
+                        Save
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setEditingId(null)}
+                        className="rounded-md border px-3 py-1.5 text-sm font-medium"
+                        data-testid={`ticket-category-cancel-${c.id}`}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              )}
+            </>
           ))}
         </tbody>
       </table>

--- a/apps/web/src/components/settings/TicketCategoriesPage.tsx
+++ b/apps/web/src/components/settings/TicketCategoriesPage.tsx
@@ -1,9 +1,10 @@
-import { Fragment, useCallback, useEffect, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
 import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
 import { loginPathWithNext } from '../../lib/authScope';
+import { priorityConfig, type TicketPriority } from '../tickets/ticketConfig';
 
 interface Category {
   id: string;
@@ -31,8 +32,7 @@ interface EditDraft {
 }
 
 // One level of nesting only — the UI never offers non-root parents and the API
-// stays two-level in practice. A grandchild (parent exists but isn't a root)
-// would not be emitted here; revisit if the schema ever allows deeper trees.
+// stays two-level in practice.
 function hierarchyOrder(cats: Category[]): Array<Category & { depth: number }> {
   const byRank = (a: Category, b: Category) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name);
   const roots = cats.filter((c) => !c.parentId || !cats.some((p) => p.id === c.parentId));
@@ -43,12 +43,19 @@ function hierarchyOrder(cats: Category[]): Array<Category & { depth: number }> {
       out.push({ ...ch, depth: 1 });
     }
   }
+  // Defensive: the API tolerates deeper/cyclic parents (PATCH can produce a
+  // grandchild whose parent is itself a child); never hide a row from
+  // management — append anything not emitted above at depth 0.
+  const emitted = new Set(out.map((c) => c.id));
+  for (const c of cats.filter((cat) => !emitted.has(cat.id)).sort(byRank)) {
+    out.push({ ...c, depth: 0 });
+  }
   return out;
 }
 
 function defaultsSummary(c: Category): string {
   const parts: string[] = [];
-  if (c.defaultPriority) parts.push(c.defaultPriority.charAt(0).toUpperCase() + c.defaultPriority.slice(1));
+  if (c.defaultPriority) parts.push(priorityConfig[c.defaultPriority as TicketPriority]?.label ?? c.defaultPriority);
   if (c.responseSlaMinutes != null) parts.push(`${c.responseSlaMinutes}m response`);
   if (c.resolutionSlaMinutes != null) parts.push(`${c.resolutionSlaMinutes}m resolve`);
   if (c.defaultHourlyRate) parts.push(`$${parseFloat(c.defaultHourlyRate).toFixed(2)}/h`);
@@ -139,9 +146,10 @@ export default function TicketCategoriesPage() {
 
   const saveEdit = useCallback(async (id: string) => {
     if (!draft.name.trim()) return;
-    // Number('60a') is NaN, which JSON-serializes to null — refuse instead of silently nulling.
+    // Number('60a') is NaN and Number('1e999') is Infinity — both JSON-serialize
+    // to null, so refuse anything non-finite instead of silently nulling.
     const numeric = [draft.responseSlaMinutes, draft.resolutionSlaMinutes, draft.defaultHourlyRate];
-    if (numeric.some((v) => v !== '' && Number.isNaN(Number(v)))) {
+    if (numeric.some((v) => v !== '' && !Number.isFinite(Number(v)))) {
       showToast({ type: 'error', message: 'SLA minutes and hourly rate must be numbers.' });
       return;
     }
@@ -180,7 +188,7 @@ export default function TicketCategoriesPage() {
     return categories.filter((c) => !c.parentId && !excluded.has(c.id));
   }
 
-  const ordered = hierarchyOrder(categories);
+  const ordered = useMemo(() => hierarchyOrder(categories), [categories]);
 
   return (
     <div className="max-w-3xl" data-testid="ticket-categories-page">
@@ -334,10 +342,9 @@ export default function TicketCategoriesPage() {
                           data-testid="ticket-category-edit-priority"
                         >
                           <option value="">None</option>
-                          <option value="low">Low</option>
-                          <option value="normal">Normal</option>
-                          <option value="high">High</option>
-                          <option value="urgent">Urgent</option>
+                          {(Object.keys(priorityConfig) as TicketPriority[]).map((p) => (
+                            <option key={p} value={p}>{priorityConfig[p].label}</option>
+                          ))}
                         </select>
                       </div>
                       <div>

--- a/apps/web/src/components/settings/TicketCategoriesPage.tsx
+++ b/apps/web/src/components/settings/TicketCategoriesPage.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useCallback, useEffect, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
+import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
 import { loginPathWithNext } from '../../lib/authScope';
 
@@ -29,6 +30,9 @@ interface EditDraft {
   defaultHourlyRate: string;
 }
 
+// One level of nesting only — the UI never offers non-root parents and the API
+// stays two-level in practice. A grandchild (parent exists but isn't a root)
+// would not be emitted here; revisit if the schema ever allows deeper trees.
 function hierarchyOrder(cats: Category[]): Array<Category & { depth: number }> {
   const byRank = (a: Category, b: Category) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name);
   const roots = cats.filter((c) => !c.parentId || !cats.some((p) => p.id === c.parentId));
@@ -47,7 +51,7 @@ function defaultsSummary(c: Category): string {
   if (c.defaultPriority) parts.push(c.defaultPriority.charAt(0).toUpperCase() + c.defaultPriority.slice(1));
   if (c.responseSlaMinutes != null) parts.push(`${c.responseSlaMinutes}m response`);
   if (c.resolutionSlaMinutes != null) parts.push(`${c.resolutionSlaMinutes}m resolve`);
-  if (c.defaultHourlyRate) parts.push(`$${c.defaultHourlyRate}/h`);
+  if (c.defaultHourlyRate) parts.push(`$${parseFloat(c.defaultHourlyRate).toFixed(2)}/h`);
   if (c.defaultBillable) parts.push('billable');
   else if (parts.length > 0) parts.push('non-billable');
   return parts.length > 0 ? parts.join(' · ') : '—';
@@ -135,6 +139,12 @@ export default function TicketCategoriesPage() {
 
   const saveEdit = useCallback(async (id: string) => {
     if (!draft.name.trim()) return;
+    // Number('60a') is NaN, which JSON-serializes to null — refuse instead of silently nulling.
+    const numeric = [draft.responseSlaMinutes, draft.resolutionSlaMinutes, draft.defaultHourlyRate];
+    if (numeric.some((v) => v !== '' && Number.isNaN(Number(v)))) {
+      showToast({ type: 'error', message: 'SLA minutes and hourly rate must be numbers.' });
+      return;
+    }
     const payload = {
       name: draft.name.trim(),
       color: draft.color,
@@ -279,30 +289,33 @@ export default function TicketCategoriesPage() {
                   <td colSpan={4} className="bg-muted/30 px-4 py-3">
                     <div className="grid grid-cols-2 gap-3">
                       <div>
-                        <label className="text-xs font-medium">Name</label>
+                        <label className="text-xs font-medium" htmlFor="edit-name">Name</label>
                         <input
                           value={draft.name}
                           onChange={(e) => setDraft((d) => ({ ...d, name: e.target.value }))}
                           className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+                          id="edit-name"
                           data-testid="ticket-category-edit-name"
                         />
                       </div>
                       <div>
-                        <label className="text-xs font-medium">Color</label>
+                        <label className="text-xs font-medium" htmlFor="edit-color">Color</label>
                         <input
                           type="color"
                           value={draft.color}
                           onChange={(e) => setDraft((d) => ({ ...d, color: e.target.value }))}
                           className="h-9 w-full rounded-md border"
+                          id="edit-color"
                           data-testid="ticket-category-edit-color"
                         />
                       </div>
                       <div>
-                        <label className="text-xs font-medium">Parent</label>
+                        <label className="text-xs font-medium" htmlFor="edit-parent">Parent</label>
                         <select
                           value={draft.parentId}
                           onChange={(e) => setDraft((d) => ({ ...d, parentId: e.target.value }))}
                           className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+                          id="edit-parent"
                           data-testid="ticket-category-edit-parent"
                         >
                           <option value="">None</option>
@@ -312,11 +325,12 @@ export default function TicketCategoriesPage() {
                         </select>
                       </div>
                       <div>
-                        <label className="text-xs font-medium">Default priority</label>
+                        <label className="text-xs font-medium" htmlFor="edit-priority">Default priority</label>
                         <select
                           value={draft.defaultPriority}
                           onChange={(e) => setDraft((d) => ({ ...d, defaultPriority: e.target.value }))}
                           className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+                          id="edit-priority"
                           data-testid="ticket-category-edit-priority"
                         >
                           <option value="">None</option>
@@ -327,24 +341,26 @@ export default function TicketCategoriesPage() {
                         </select>
                       </div>
                       <div>
-                        <label className="text-xs font-medium">Response SLA (minutes)</label>
+                        <label className="text-xs font-medium" htmlFor="edit-response-sla">Response SLA (minutes)</label>
                         <input
                           type="number"
                           min={1}
                           value={draft.responseSlaMinutes}
                           onChange={(e) => setDraft((d) => ({ ...d, responseSlaMinutes: e.target.value }))}
                           className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+                          id="edit-response-sla"
                           data-testid="ticket-category-edit-response-sla"
                         />
                       </div>
                       <div>
-                        <label className="text-xs font-medium">Resolution SLA (minutes)</label>
+                        <label className="text-xs font-medium" htmlFor="edit-resolution-sla">Resolution SLA (minutes)</label>
                         <input
                           type="number"
                           min={1}
                           value={draft.resolutionSlaMinutes}
                           onChange={(e) => setDraft((d) => ({ ...d, resolutionSlaMinutes: e.target.value }))}
                           className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+                          id="edit-resolution-sla"
                           data-testid="ticket-category-edit-resolution-sla"
                         />
                       </div>
@@ -359,7 +375,7 @@ export default function TicketCategoriesPage() {
                         <label htmlFor={`billable-${c.id}`} className="text-xs font-medium">Billable by default</label>
                       </div>
                       <div>
-                        <label className="text-xs font-medium">Default hourly rate ($)</label>
+                        <label className="text-xs font-medium" htmlFor="edit-rate">Default hourly rate ($)</label>
                         <input
                           type="number"
                           min={0}
@@ -367,6 +383,7 @@ export default function TicketCategoriesPage() {
                           value={draft.defaultHourlyRate}
                           onChange={(e) => setDraft((d) => ({ ...d, defaultHourlyRate: e.target.value }))}
                           className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+                          id="edit-rate"
                           data-testid="ticket-category-edit-rate"
                         />
                       </div>

--- a/apps/web/src/components/settings/TicketCategoriesPage.tsx
+++ b/apps/web/src/components/settings/TicketCategoriesPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { Fragment, useCallback, useEffect, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
@@ -247,7 +247,7 @@ export default function TicketCategoriesPage() {
               </td>
             </tr>
           ) : ordered.map((c) => (
-            <>
+            <Fragment key={c.id}>
               <tr key={c.id} data-testid={`ticket-category-row-${c.id}`} data-depth={c.depth}>
                 <td className={`px-4 py-2 text-sm${c.depth > 0 ? ' pl-10' : ''}`}>
                   <span className="mr-1.5 inline-block h-3 w-3 rounded-sm align-middle" style={{ backgroundColor: c.color }} />
@@ -393,7 +393,7 @@ export default function TicketCategoriesPage() {
                   </td>
                 </tr>
               )}
-            </>
+            </Fragment>
           ))}
         </tbody>
       </table>

--- a/apps/web/src/components/shared/Toast.test.tsx
+++ b/apps/web/src/components/shared/Toast.test.tsx
@@ -136,6 +136,8 @@ describe('ToastContainer', () => {
 
     const toast = screen.getByTestId('toast');
     expect(toast).toHaveAttribute('data-toast-type', 'warning');
+    // The triangle icon is the only visual cue distinguishing warning from success.
+    expect(toast.querySelector('svg.lucide-triangle-alert, svg.lucide-alert-triangle')).not.toBeNull();
     expect(toast).toHaveAttribute('role', 'status');
     expect(toast).toHaveTextContent('heads up');
   });

--- a/apps/web/src/components/shared/Toast.test.tsx
+++ b/apps/web/src/components/shared/Toast.test.tsx
@@ -127,6 +127,19 @@ describe('ToastContainer', () => {
     });
   });
 
+  it('renders a warning toast with role=status and the correct data-toast-type', () => {
+    render(<ToastContainer />);
+
+    act(() => {
+      showToast({ type: 'warning', message: 'heads up' });
+    });
+
+    const toast = screen.getByTestId('toast');
+    expect(toast).toHaveAttribute('data-toast-type', 'warning');
+    expect(toast).toHaveAttribute('role', 'status');
+    expect(toast).toHaveTextContent('heads up');
+  });
+
   it('auto-dismisses after the default 5000ms', async () => {
     vi.useFakeTimers();
     try {

--- a/apps/web/src/components/shared/Toast.tsx
+++ b/apps/web/src/components/shared/Toast.tsx
@@ -82,6 +82,7 @@ export default function ToastContainer() {
             <span className={`flex-1 text-sm ${isError ? '' : 'text-foreground'}`}>{toast.message}</span>
             {toast.type === 'undo' && toast.onUndo && (
               <button
+                type="button"
                 onClick={() => { toast.onUndo?.(); dismiss(toast.id); }}
                 className="flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-primary hover:bg-muted transition-colors"
               >
@@ -90,6 +91,7 @@ export default function ToastContainer() {
               </button>
             )}
             <button
+              type="button"
               onClick={() => dismiss(toast.id)}
               aria-label="Dismiss"
               className={`rounded p-0.5 transition-colors ${

--- a/apps/web/src/components/shared/Toast.tsx
+++ b/apps/web/src/components/shared/Toast.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect, useCallback } from 'react';
-import { CheckCircle, X, Undo2, XCircle } from 'lucide-react';
+import { AlertTriangle, CheckCircle, X, Undo2, XCircle } from 'lucide-react';
 
 interface ToastData {
   id: string;
   message: string;
-  type: 'success' | 'error' | 'undo';
+  type: 'success' | 'error' | 'undo' | 'warning';
   onUndo?: () => void;
   duration?: number;
 }
@@ -54,6 +54,7 @@ export default function ToastContainer() {
     <div className="fixed bottom-6 right-6 z-50 flex flex-col gap-2" data-testid="toast-container">
       {toasts.map(toast => {
         const isError = toast.type === 'error';
+        const isWarning = toast.type === 'warning';
         return (
           <div
             key={toast.id}
@@ -65,12 +66,16 @@ export default function ToastContainer() {
             className={`flex items-center gap-3 rounded-lg border px-4 py-3 shadow-lg animate-in ${
               isError
                 ? 'bg-destructive text-destructive-foreground border-destructive/40'
-                : 'bg-card'
+                : isWarning
+                  ? 'bg-card border-warning/50'
+                  : 'bg-card'
             }`}
             style={{ minWidth: 280, maxWidth: 400 }}
           >
             {isError ? (
               <XCircle className="h-4 w-4 shrink-0" />
+            ) : isWarning ? (
+              <AlertTriangle className="h-4 w-4 shrink-0 text-warning" />
             ) : (
               <CheckCircle className="h-4 w-4 shrink-0 text-success" />
             )}

--- a/apps/web/src/components/tickets/CreateTicketPage.test.tsx
+++ b/apps/web/src/components/tickets/CreateTicketPage.test.tsx
@@ -14,6 +14,13 @@ vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
 const navigateTo = vi.fn();
 vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
 
+// Mock authScope so each test can control getJwtClaims behaviour.
+const mockGetJwtClaims = vi.fn(() => ({ scope: 'partner' as const, orgId: null, partnerId: 'p-1' }));
+vi.mock('../../lib/authScope', () => ({
+  getJwtClaims: (...args: unknown[]) => mockGetJwtClaims(...args),
+  loginPathWithNext: () => '/login?next=%2Ftickets%2Fnew'
+}));
+
 const fetchMock = vi.mocked(fetchWithAuth);
 
 const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
@@ -46,6 +53,8 @@ function mockOptionsApi() {
 describe('CreateTicketPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default to partner scope so existing tests behave as before.
+    mockGetJwtClaims.mockReturnValue({ scope: 'partner', orgId: null, partnerId: 'p-1' });
   });
 
   it('omits deviceId, categoryId and description from the payload when left empty', async () => {
@@ -131,5 +140,96 @@ describe('CreateTicketPage', () => {
     await screen.findByTestId('create-ticket-form');
     expect(screen.queryByTestId('create-ticket-load-error')).toBeNull();
     expect(screen.getByText('Org A')).toBeInTheDocument();
+  });
+
+  describe('org-scope fixes', () => {
+    it('org-scoped session: no /orgs/organizations fetch, no org input, devices fetched for the session org, submit sends correct orgId', async () => {
+      mockGetJwtClaims.mockReturnValue({ scope: 'organization', orgId: 'org-1', partnerId: null });
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === '/orgs/organizations?limit=100') return makeJsonResponse({ data: [] });
+        if (url === '/ticket-categories') return makeJsonResponse({ data: [{ id: 'cat-1', name: 'Hardware', isActive: true }] });
+        if (url === '/devices?orgId=org-1') return makeJsonResponse({ data: [{ id: 'dev-1', displayName: 'PC-1' }] });
+        if (url === '/tickets' && init?.method === 'POST') return makeJsonResponse({ data: { id: 'tk-1', internalNumber: 'T-1' } });
+        return makeJsonResponse({ error: 'unexpected' }, false, 404);
+      });
+
+      render(<CreateTicketPage />);
+      await screen.findByTestId('create-ticket-form');
+
+      // Org input hidden (orgLocked = true)
+      expect(screen.queryByTestId('create-ticket-org-input')).toBeNull();
+
+      // Device list fetched for org-1 automatically
+      await screen.findByText('PC-1');
+      expect(fetchMock).toHaveBeenCalledWith('/devices?orgId=org-1');
+
+      // No /orgs/organizations call
+      const allUrls = fetchMock.mock.calls.map((c) => String(c[0]));
+      expect(allUrls.every((u) => !u.includes('/orgs/organizations'))).toBe(true);
+
+      // Fill subject and submit
+      fireEvent.change(screen.getByTestId('create-ticket-subject-input'), { target: { value: 'Printer down' } });
+      fireEvent.click(screen.getByTestId('create-ticket-submit'));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith('/tickets', expect.objectContaining({ method: 'POST' }));
+      });
+      const postCall = fetchMock.mock.calls.find(([url, init]) => String(url) === '/tickets' && init?.method === 'POST');
+      const body = JSON.parse(String(postCall?.[1]?.body)) as Record<string, unknown>;
+      expect(body.orgId).toBe('org-1');
+    });
+
+    it('orgs fetch 403 + late org-scoped getJwtClaims: no load error, form becomes usable', async () => {
+      // First call to getJwtClaims (during loadOptions) returns all-null;
+      // second call (late-claims fallback in the 403 branch) returns org claims.
+      mockGetJwtClaims
+        .mockReturnValueOnce({ scope: null, orgId: null, partnerId: null })
+        .mockReturnValue({ scope: 'organization', orgId: 'org-1', partnerId: null });
+
+      fetchMock.mockImplementation(async (input) => {
+        const url = String(input);
+        if (url === '/orgs/organizations?limit=100') return makeJsonResponse({ error: 'Forbidden' }, false, 403);
+        if (url === '/ticket-categories') return makeJsonResponse({ data: [{ id: 'cat-1', name: 'Hardware', isActive: true }] });
+        if (url.startsWith('/devices?orgId=')) return makeJsonResponse({ data: [] });
+        return makeJsonResponse({ error: 'unexpected' }, false, 404);
+      });
+
+      render(<CreateTicketPage />);
+      await screen.findByTestId('create-ticket-form');
+
+      // No load-error shown — late claims resolved the 403.
+      expect(screen.queryByTestId('create-ticket-load-error')).toBeNull();
+      // Org input hidden because orgLocked was set via the fallback.
+      expect(screen.queryByTestId('create-ticket-org-input')).toBeNull();
+    });
+
+    it('categories with parent/child: child option text shows "Parent / Child"', async () => {
+      mockOptionsApi();
+      // Override categories to include a parent+child pair.
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === '/orgs/organizations?limit=100') return makeJsonResponse({ data: [{ id: 'org-a', name: 'Org A' }, { id: 'org-b', name: 'Org B' }] });
+        if (url === '/ticket-categories') {
+          return makeJsonResponse({
+            data: [
+              { id: 'p', name: 'Hardware', parentId: null, isActive: true },
+              { id: 'c', name: 'Printers', parentId: 'p', isActive: true }
+            ]
+          });
+        }
+        if (url.startsWith('/devices?orgId=')) return makeJsonResponse({ data: [] });
+        if (url === '/tickets' && init?.method === 'POST') return makeJsonResponse({ data: { id: 'tk-1', internalNumber: 'T-1' } });
+        return makeJsonResponse({ error: 'unexpected' }, false, 404);
+      });
+
+      render(<CreateTicketPage />);
+      await screen.findByTestId('create-ticket-form');
+
+      // Wait for categories to load
+      await screen.findByRole('option', { name: 'Hardware / Printers' });
+      // The parent category itself still shows with just its name
+      expect(screen.getByRole('option', { name: 'Hardware' })).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/components/tickets/CreateTicketPage.test.tsx
+++ b/apps/web/src/components/tickets/CreateTicketPage.test.tsx
@@ -15,9 +15,10 @@ const navigateTo = vi.fn();
 vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
 
 // Mock authScope so each test can control getJwtClaims behaviour.
-const mockGetJwtClaims = vi.fn(() => ({ scope: 'partner' as const, orgId: null, partnerId: 'p-1' }));
+import type { JwtClaims } from '../../lib/authScope';
+const mockGetJwtClaims = vi.fn((): JwtClaims => ({ scope: 'partner', orgId: null, partnerId: 'p-1' }));
 vi.mock('../../lib/authScope', () => ({
-  getJwtClaims: (...args: unknown[]) => mockGetJwtClaims(...args),
+  getJwtClaims: () => mockGetJwtClaims(),
   loginPathWithNext: () => '/login?next=%2Ftickets%2Fnew'
 }));
 

--- a/apps/web/src/components/tickets/CreateTicketPage.tsx
+++ b/apps/web/src/components/tickets/CreateTicketPage.tsx
@@ -1,16 +1,19 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
+import { getJwtClaims, loginPathWithNext } from '../../lib/authScope';
 import type { TicketPriority } from './ticketConfig';
 
 interface Option { id: string; name: string }
+interface CategoryOption { id: string; name: string; parentId: string | null }
 
 export default function CreateTicketPage() {
   const [orgs, setOrgs] = useState<Option[]>([]);
   const [devices, setDevices] = useState<Option[]>([]);
-  const [categories, setCategories] = useState<Option[]>([]);
+  const [categories, setCategories] = useState<CategoryOption[]>([]);
   const [orgId, setOrgId] = useState('');
+  const [orgLocked, setOrgLocked] = useState(false);
   const [subject, setSubject] = useState('');
   const [description, setDescription] = useState('');
   const [deviceId, setDeviceId] = useState('');
@@ -21,18 +24,44 @@ export default function CreateTicketPage() {
 
   const loadOptions = useCallback(async () => {
     setLoadError(false);
+    const claims = getJwtClaims();
+    const isOrgScoped = claims.scope === 'organization' && !!claims.orgId;
     try {
-      const [orgRes, catRes] = await Promise.all([fetchWithAuth('/orgs/organizations?limit=100'), fetchWithAuth('/ticket-categories')]);
-      if (!orgRes.ok) {
-        // No orgs means the org select stays empty and submit stays disabled — surface it.
-        setLoadError(true);
-        return;
+      const [orgRes, catRes] = await Promise.all([
+        // Org-scoped users can't list organizations (and don't need to — the org
+        // is fixed by the session); skip the call instead of dead-ending on 403.
+        isOrgScoped ? Promise.resolve(null) : fetchWithAuth('/orgs/organizations?limit=100'),
+        fetchWithAuth('/ticket-categories')
+      ]);
+      if (isOrgScoped) {
+        setOrgId(claims.orgId as string);
+        setOrgLocked(true);
+      } else if (orgRes && orgRes.ok) {
+        const b = await orgRes.json();
+        setOrgs((b.data ?? b.organizations ?? []).map((o: { id: string; name: string }) => ({ id: o.id, name: o.name })));
+      } else {
+        // 403 here usually means an org-scoped session whose token landed after
+        // mount — re-read the claims before declaring failure.
+        const late = getJwtClaims();
+        if (orgRes?.status === 403 && late.scope === 'organization' && late.orgId) {
+          setOrgId(late.orgId);
+          setOrgLocked(true);
+        } else {
+          setLoadError(true);
+          return;
+        }
       }
-      const b = await orgRes.json();
-      setOrgs((b.data ?? b.organizations ?? []).map((o: { id: string; name: string }) => ({ id: o.id, name: o.name })));
       if (catRes.ok) {
         const cb = await catRes.json();
-        setCategories((cb.data ?? []).filter((c: { isActive: boolean }) => c.isActive).map((c: { id: string; name: string }) => ({ id: c.id, name: c.name })));
+        setCategories(
+          (cb.data ?? [])
+            .filter((c: { isActive: boolean }) => c.isActive)
+            .map((c: { id: string; name: string; parentId?: string | null }) => ({
+              id: c.id,
+              name: c.name,
+              parentId: c.parentId ?? null
+            }))
+        );
       }
       // else: category is an optional field — degrade to "None" rather than blocking the form.
     } catch {
@@ -41,6 +70,15 @@ export default function CreateTicketPage() {
   }, []);
 
   useEffect(() => { void loadOptions(); }, [loadOptions]);
+
+  // Build "Parent / Child" labels for category options; plain name when no parent.
+  const categoryLabel = useMemo(() => {
+    const byId = new Map(categories.map((c) => [c.id, c]));
+    return (c: CategoryOption) => {
+      const parent = c.parentId ? byId.get(c.parentId) : undefined;
+      return parent ? `${parent.name} / ${c.name}` : c.name;
+    };
+  }, [categories]);
 
   useEffect(() => {
     if (!orgId) { setDevices([]); setDeviceId(''); return; }
@@ -77,7 +115,7 @@ export default function CreateTicketPage() {
         }),
         errorFallback: 'Ticket creation failed. Retry.',
         successMessage: (r) => `Ticket ${r.data.internalNumber ?? ''} created`,
-        onUnauthorized: () => void navigateTo('/login', { replace: true })
+        onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
       });
       void navigateTo(`/tickets#${created.data.internalNumber ?? created.data.id}`);
     } catch (err) {
@@ -104,13 +142,15 @@ export default function CreateTicketPage() {
   return (
     <form onSubmit={submit} className="mx-auto max-w-2xl space-y-4" data-testid="create-ticket-form">
       <h1 className="text-xl font-semibold" data-testid="create-ticket-heading">Create ticket</h1>
-      <div>
-        <label className="text-sm font-medium" htmlFor="ct-org">Organization</label>
-        <select id="ct-org" value={orgId} onChange={(e) => setOrgId(e.target.value)} required className={selectCls} data-testid="create-ticket-org-input">
-          <option value="">Select organization</option>
-          {orgs.map((o) => <option key={o.id} value={o.id}>{o.name}</option>)}
-        </select>
-      </div>
+      {!orgLocked && (
+        <div>
+          <label className="text-sm font-medium" htmlFor="ct-org">Organization</label>
+          <select id="ct-org" value={orgId} onChange={(e) => setOrgId(e.target.value)} required className={selectCls} data-testid="create-ticket-org-input">
+            <option value="">Select organization</option>
+            {orgs.map((o) => <option key={o.id} value={o.id}>{o.name}</option>)}
+          </select>
+        </div>
+      )}
       <div>
         <label className="text-sm font-medium" htmlFor="ct-subject">Subject</label>
         <input id="ct-subject" value={subject} onChange={(e) => setSubject(e.target.value)} required maxLength={255} className={selectCls} data-testid="create-ticket-subject-input" />
@@ -131,7 +171,7 @@ export default function CreateTicketPage() {
           <label className="text-sm font-medium" htmlFor="ct-cat">Category</label>
           <select id="ct-cat" value={categoryId} onChange={(e) => setCategoryId(e.target.value)} className={selectCls} data-testid="create-ticket-category-input">
             <option value="">None</option>
-            {categories.map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}
+            {categories.map((c) => <option key={c.id} value={c.id}>{categoryLabel(c)}</option>)}
           </select>
         </div>
         <div>

--- a/apps/web/src/components/tickets/SlaChip.test.tsx
+++ b/apps/web/src/components/tickets/SlaChip.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import SlaChip from './SlaChip';
+import type { TicketSummary } from './ticketConfig';
+
+const NOW = new Date(); // must match slaState's default which uses new Date()
+
+const makeTicket = (overrides: Partial<TicketSummary> & { id: string }): TicketSummary => ({
+  internalNumber: null,
+  subject: 'Test',
+  status: 'open',
+  priority: 'normal',
+  source: 'portal',
+  orgId: 'org-1',
+  orgName: 'Acme',
+  deviceId: null,
+  deviceHostname: null,
+  assignedTo: null,
+  assigneeName: null,
+  categoryId: null,
+  dueDate: null,
+  slaBreachedAt: null,
+  firstResponseAt: null,
+  createdAt: '2026-06-11T09:00:00.000Z',
+  updatedAt: '2026-06-11T09:00:00.000Z',
+  ...overrides,
+});
+
+describe('SlaChip', () => {
+  it('renders nothing (null) when no SLA is configured', () => {
+    const { container } = render(
+      <SlaChip ticket={makeTicket({ id: 'tk-1' })} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing for a resolved ticket (no SLA applies)', () => {
+    const { container } = render(
+      <SlaChip ticket={makeTicket({ id: 'tk-2', status: 'resolved', resolutionSlaMinutes: 60 })} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the time remaining for an ok SLA', () => {
+    // 30 minutes elapsed of a 120-minute SLA (25% = well within ok)
+    const ticket = makeTicket({
+      id: 'tk-3',
+      resolutionSlaMinutes: 120,
+      createdAt: new Date(NOW.getTime() - 30 * 60_000).toISOString(),
+    });
+    render(<SlaChip ticket={ticket} />);
+    expect(screen.getByTestId('ticket-sla-tk-3')).toBeInTheDocument();
+  });
+
+  it('renders an at-risk chip for a nearly-breached SLA', () => {
+    // 90 minutes elapsed of a 100-minute SLA (90% > 80% threshold)
+    const ticket = makeTicket({
+      id: 'tk-4',
+      resolutionSlaMinutes: 100,
+      createdAt: new Date(NOW.getTime() - 90 * 60_000).toISOString(),
+    });
+    render(<SlaChip ticket={ticket} />);
+    const chip = screen.getByTestId('ticket-sla-tk-4');
+    expect(chip.textContent).toContain('left');
+  });
+
+  it('renders "Breached" when slaBreachedAt is set', () => {
+    const ticket = makeTicket({
+      id: 'tk-5',
+      slaBreachedAt: new Date(NOW.getTime() - 10 * 60_000).toISOString(),
+    });
+    render(<SlaChip ticket={ticket} />);
+    expect(screen.getByTestId('ticket-sla-tk-5').textContent).toBe('Breached');
+  });
+});

--- a/apps/web/src/components/tickets/SlaChip.tsx
+++ b/apps/web/src/components/tickets/SlaChip.tsx
@@ -2,7 +2,7 @@ import { slaState, formatRelative, type TicketSummary } from './ticketConfig';
 
 export default function SlaChip({ ticket }: { ticket: TicketSummary }) {
   const s = slaState(ticket);
-  if (s.kind === 'none') return <span className="text-xs text-muted-foreground">–</span>;
+  if (s.kind === 'none') return null;
   if (s.kind === 'ok') {
     return <span className="text-xs text-muted-foreground" data-testid={`ticket-sla-${ticket.id}`}>{formatRelative(s.minutesLeft)}</span>;
   }

--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -267,7 +267,7 @@ describe('TicketWorkbench assignee picker', () => {
 
     await new Promise((r) => setTimeout(r, 50));
     expect(
-      fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST' && String(fetchMock.mock.calls[0][0]).includes('/assign'))
+      fetchMock.mock.calls.filter(([url, init]) => init?.method === 'POST' && String(url).includes('/assign'))
     ).toHaveLength(0);
   });
 

--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -89,20 +89,21 @@ describe('TicketWorkbench resolve-flow gating', () => {
     expect(mutationCalls()).toHaveLength(0);
   });
 
-  it('non-resolved status change posts immediately without the resolve form', async () => {
+  it('non-resolved, non-gated status change (e.g. open→closed) posts immediately without any form', async () => {
     mockTicketApi({ 'tk-1': makeTicket() });
     render(<TicketWorkbench ticketId="tk-1" />);
 
     await screen.findByTestId('ticket-workbench');
-    fireEvent.change(screen.getByTestId('ticket-workbench-status'), { target: { value: 'pending' } });
+    fireEvent.change(screen.getByTestId('ticket-workbench-status'), { target: { value: 'closed' } });
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
         '/tickets/tk-1/status',
-        expect.objectContaining({ method: 'POST', body: JSON.stringify({ status: 'pending' }) })
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({ status: 'closed' }) })
       );
     });
     expect(screen.queryByTestId('ticket-workbench-resolve-form')).toBeNull();
+    expect(screen.queryByTestId('ticket-workbench-pending-form')).toBeNull();
   });
 
   it('resolve submit is disabled until a note is entered, then posts status+resolutionNote', async () => {
@@ -200,5 +201,252 @@ describe('TicketWorkbench load errors', () => {
     await screen.findByTestId('ticket-workbench-error');
     expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
     expect(screen.queryByTestId('ticket-workbench-back')).toBeNull();
+  });
+
+  it('404 shows the updated not-found copy including access hint', async () => {
+    fetchMock.mockResolvedValue(makeJsonResponse({ error: 'Not found' }, false, 404));
+    render(<TicketWorkbench ticketId="tk-gone" />);
+
+    await screen.findByTestId('ticket-workbench-error');
+    expect(screen.getByText(/may not have access to it/i)).toBeInTheDocument();
+  });
+});
+
+/** Helper: mock ticket + /users with a given list of users (or fail the /users call). */
+function mockTicketApiWithUsers(
+  detailById: Record<string, TicketDetail>,
+  users: Array<{ id: string; name: string | null; email: string }> | 'fail' = []
+) {
+  fetchMock.mockImplementation(async (input, init) => {
+    const url = String(input);
+    if (url === '/users') {
+      if (users === 'fail') return makeJsonResponse({ error: 'forbidden' }, false, 403);
+      return makeJsonResponse({ data: users });
+    }
+    if (!init?.method || init.method === 'GET') {
+      const match = url.match(/^\/tickets\/([^/]+)$/);
+      if (match && detailById[match[1]]) {
+        return makeJsonResponse({ data: detailById[match[1]] });
+      }
+    }
+    return makeJsonResponse({ success: true });
+  });
+}
+
+describe('TicketWorkbench assignee picker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows an assignee select when /users succeeds; changing value POSTs /assign', async () => {
+    const users = [{ id: 'u-9', name: 'Alice', email: 'alice@test.com' }];
+    mockTicketApiWithUsers({ 'tk-1': makeTicket() }, users);
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    const select = await screen.findByTestId('ticket-workbench-assignee');
+    expect(select).toBeInTheDocument();
+
+    fireEvent.change(select, { target: { value: 'u-9' } });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/assign',
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({ assigneeId: 'u-9' }) })
+      );
+    });
+  });
+
+  it('no-op guard: changing select to empty on unassigned ticket does NOT POST', async () => {
+    const users = [{ id: 'u-9', name: 'Alice', email: 'alice@test.com' }];
+    mockTicketApiWithUsers({ 'tk-1': makeTicket({ assignedTo: null }) }, users);
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    const select = await screen.findByTestId('ticket-workbench-assignee');
+    // Ticket is unassigned (value=''); changing to '' is a no-op
+    fireEvent.change(select, { target: { value: '' } });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(
+      fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST' && String(fetchMock.mock.calls[0][0]).includes('/assign'))
+    ).toHaveLength(0);
+  });
+
+  it('changing select to empty on an assigned ticket POSTs assigneeId null', async () => {
+    const users = [{ id: 'u-9', name: 'Alice', email: 'alice@test.com' }];
+    mockTicketApiWithUsers({ 'tk-1': makeTicket({ assignedTo: 'u-9', assigneeName: 'Alice' }) }, users);
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    const select = await screen.findByTestId('ticket-workbench-assignee');
+    fireEvent.change(select, { target: { value: '' } });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/assign',
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({ assigneeId: null }) })
+      );
+    });
+  });
+
+  it('RLS-invisible assignee shows a redacted "MSP staff" option', async () => {
+    // Ticket has assignedTo='partner-u' but /users does not include that id
+    const users = [{ id: 'u-9', name: 'Alice', email: 'alice@test.com' }];
+    mockTicketApiWithUsers(
+      { 'tk-1': makeTicket({ assignedTo: 'partner-u', assigneeName: null }) },
+      users
+    );
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    await screen.findByTestId('ticket-workbench-assignee');
+    expect(screen.getByRole('option', { name: 'MSP staff' })).toBeInTheDocument();
+  });
+
+  it('/users failure on assigned ticket: degraded unassign button works', async () => {
+    mockTicketApiWithUsers({ 'tk-1': makeTicket({ assignedTo: 'u-9', assigneeName: 'Alice' }) }, 'fail');
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    const unassignBtn = await screen.findByTestId('ticket-workbench-unassign');
+    expect(unassignBtn).toBeInTheDocument();
+    expect(screen.queryByTestId('ticket-workbench-assignee')).toBeNull();
+
+    fireEvent.click(unassignBtn);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/assign',
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({ assigneeId: null }) })
+      );
+    });
+  });
+
+  it('/users failure on unassigned ticket: plain "Unassigned" span, no POST possible', async () => {
+    mockTicketApiWithUsers({ 'tk-1': makeTicket({ assignedTo: null }) }, 'fail');
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    const span = await screen.findByTestId('ticket-workbench-unassigned');
+    expect(span).toBeInTheDocument();
+    expect(screen.queryByTestId('ticket-workbench-assignee')).toBeNull();
+    expect(screen.queryByTestId('ticket-workbench-unassign')).toBeNull();
+  });
+});
+
+describe('TicketWorkbench pending/on_hold prompt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('choosing pending does not POST immediately; pending form appears', async () => {
+    mockTicketApiWithUsers({ 'tk-1': makeTicket() });
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    await screen.findByTestId('ticket-workbench');
+    expect(screen.queryByTestId('ticket-workbench-pending-form')).toBeNull();
+
+    fireEvent.change(screen.getByTestId('ticket-workbench-status'), { target: { value: 'pending' } });
+
+    expect(screen.getByTestId('ticket-workbench-pending-form')).toBeInTheDocument();
+    expect(mutationCalls()).toHaveLength(0);
+  });
+
+  it('pending submit with reason POSTs {status:pending, pendingReason}', async () => {
+    mockTicketApiWithUsers({ 'tk-1': makeTicket() });
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    await screen.findByTestId('ticket-workbench');
+    fireEvent.change(screen.getByTestId('ticket-workbench-status'), { target: { value: 'pending' } });
+
+    fireEvent.change(screen.getByTestId('ticket-workbench-pending-reason'), {
+      target: { value: 'Waiting on vendor' },
+    });
+    fireEvent.click(screen.getByTestId('ticket-workbench-pending-submit'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/status',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ status: 'pending', pendingReason: 'Waiting on vendor' }),
+        })
+      );
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('ticket-workbench-pending-form')).toBeNull();
+    });
+  });
+
+  it('pending submit with empty reason POSTs {status:pending} only (no pendingReason key)', async () => {
+    mockTicketApiWithUsers({ 'tk-1': makeTicket() });
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    await screen.findByTestId('ticket-workbench');
+    fireEvent.change(screen.getByTestId('ticket-workbench-status'), { target: { value: 'pending' } });
+    fireEvent.click(screen.getByTestId('ticket-workbench-pending-submit'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/status',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ status: 'pending' }),
+        })
+      );
+    });
+  });
+
+  it('on_hold opens the same pending form with "Put on hold" button label', async () => {
+    mockTicketApiWithUsers({ 'tk-1': makeTicket() });
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    await screen.findByTestId('ticket-workbench');
+    fireEvent.change(screen.getByTestId('ticket-workbench-status'), { target: { value: 'on_hold' } });
+
+    expect(screen.getByTestId('ticket-workbench-pending-form')).toBeInTheDocument();
+    expect(screen.getByTestId('ticket-workbench-pending-submit')).toHaveTextContent('Put on hold');
+  });
+});
+
+describe('TicketWorkbench rail and resolution note visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolutionNote is NOT shown when status is open', async () => {
+    mockTicketApiWithUsers({
+      'tk-1': makeTicket({ status: 'open', resolutionNote: 'Fixed the thing' }),
+    });
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    await screen.findByTestId('ticket-workbench-rail');
+    expect(screen.queryByText('Fixed the thing')).toBeNull();
+  });
+
+  it('resolutionNote IS shown when status is resolved', async () => {
+    mockTicketApiWithUsers({
+      'tk-1': makeTicket({ status: 'resolved', resolutionNote: 'Fixed the thing' }),
+    });
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    await screen.findByTestId('ticket-workbench-rail');
+    expect(screen.getByText('Fixed the thing')).toBeInTheDocument();
+  });
+});
+
+describe('TicketWorkbench refreshToken prop', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('bumping refreshToken refetches the ticket detail', async () => {
+    mockTicketApiWithUsers({ 'tk-1': makeTicket() });
+    const { rerender } = render(<TicketWorkbench ticketId="tk-1" refreshToken={0} />);
+
+    await screen.findByTestId('ticket-workbench');
+    const initialFetchCount = fetchMock.mock.calls.filter(([url]) => String(url) === '/tickets/tk-1').length;
+
+    rerender(<TicketWorkbench ticketId="tk-1" refreshToken={1} />);
+
+    await waitFor(() => {
+      const newCount = fetchMock.mock.calls.filter(([url]) => String(url) === '/tickets/tk-1').length;
+      expect(newCount).toBeGreaterThan(initialFetchCount);
+    });
   });
 });

--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -449,4 +449,111 @@ describe('TicketWorkbench refreshToken prop', () => {
       expect(newCount).toBeGreaterThan(initialFetchCount);
     });
   });
+
+  it('switching tickets with a non-zero refreshToken fetches the new ticket exactly once', async () => {
+    mockTicketApiWithUsers({
+      'tk-a': makeTicket({ id: 'tk-a', internalNumber: 'T-2026-0001' }),
+      'tk-b': makeTicket({ id: 'tk-b', internalNumber: 'T-2026-0002' })
+    });
+    const { rerender } = render(<TicketWorkbench ticketId="tk-a" refreshToken={1} />);
+
+    await screen.findByTestId('ticket-workbench');
+
+    // j/k switch: only the ticketId changes; the token stays at its bumped value.
+    rerender(<TicketWorkbench ticketId="tk-b" refreshToken={1} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ticket-workbench-number')).toHaveTextContent('T-2026-0002');
+    });
+    // Without the ref guard, the stale refreshToken effect re-fires on the new
+    // load identity and double-fetches the ticket on every switch.
+    expect(fetchMock.mock.calls.filter(([url]) => String(url) === '/tickets/tk-b')).toHaveLength(1);
+  });
+});
+
+/** Helper: ticket GETs succeed, but POST /tickets/:id/status fails with a 500. */
+function mockTicketApiWithFailingStatus(detailById: Record<string, TicketDetail>) {
+  fetchMock.mockImplementation(async (input, init) => {
+    const url = String(input);
+    if (url === '/users') return makeJsonResponse({ data: [] });
+    if (init?.method === 'POST' && /\/status$/.test(url)) {
+      return makeJsonResponse({ error: 'boom' }, false, 500);
+    }
+    if (!init?.method || init.method === 'GET') {
+      const match = url.match(/^\/tickets\/([^/]+)$/);
+      if (match && detailById[match[1]]) {
+        return makeJsonResponse({ data: detailById[match[1]] });
+      }
+    }
+    return makeJsonResponse({ success: true });
+  });
+}
+
+describe('TicketWorkbench forms keep input when the status POST fails', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('pending form stays open and retains the typed reason on a failed POST', async () => {
+    mockTicketApiWithFailingStatus({ 'tk-1': makeTicket() });
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    await screen.findByTestId('ticket-workbench');
+    fireEvent.change(screen.getByTestId('ticket-workbench-status'), { target: { value: 'pending' } });
+    fireEvent.change(screen.getByTestId('ticket-workbench-pending-reason'), {
+      target: { value: 'Waiting on vendor' }
+    });
+    fireEvent.click(screen.getByTestId('ticket-workbench-pending-submit'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/tickets/tk-1/status', expect.objectContaining({ method: 'POST' }));
+    });
+    // Failure must NOT close the form or clear what the tech typed.
+    expect(screen.getByTestId('ticket-workbench-pending-form')).toBeInTheDocument();
+    expect(screen.getByTestId('ticket-workbench-pending-reason')).toHaveValue('Waiting on vendor');
+  });
+
+  it('resolve form stays open and retains the typed note on a failed POST', async () => {
+    mockTicketApiWithFailingStatus({ 'tk-1': makeTicket() });
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    await screen.findByTestId('ticket-workbench');
+    fireEvent.change(screen.getByTestId('ticket-workbench-status'), { target: { value: 'resolved' } });
+    fireEvent.change(screen.getByTestId('ticket-workbench-resolve-note'), {
+      target: { value: 'Replaced the toner cartridge.' }
+    });
+    fireEvent.click(screen.getByTestId('ticket-workbench-resolve-submit'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/tickets/tk-1/status', expect.objectContaining({ method: 'POST' }));
+    });
+    expect(screen.getByTestId('ticket-workbench-resolve-form')).toBeInTheDocument();
+    expect(screen.getByTestId('ticket-workbench-resolve-note')).toHaveValue('Replaced the toner cartridge.');
+  });
+});
+
+describe('TicketWorkbench host-supplied assignees prop', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the provided list and never self-fetches /users', async () => {
+    mockTicketApi({ 'tk-1': makeTicket() });
+    const provided = [{ id: 'u-7', name: 'Hosted Hank', email: 'hank@test.com' }];
+    render(<TicketWorkbench ticketId="tk-1" assignees={provided} />);
+
+    const select = await screen.findByTestId('ticket-workbench-assignee');
+    expect(select).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Hosted Hank' })).toBeInTheDocument();
+    expect(fetchMock.mock.calls.filter(([url]) => String(url) === '/users')).toHaveLength(0);
+  });
+
+  it('assignees={null} hides the picker (degraded mode) without fetching /users', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ assignedTo: 'u-9', assigneeName: 'Alice' }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={null} />);
+
+    await screen.findByTestId('ticket-workbench-unassign');
+    expect(screen.queryByTestId('ticket-workbench-assignee')).toBeNull();
+    expect(fetchMock.mock.calls.filter(([url]) => String(url) === '/users')).toHaveLength(0);
+  });
 });

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ExternalLink } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '../../stores/auth';
@@ -16,12 +16,17 @@ interface Props {
   expanded?: boolean;            // full-page mode
   resolveRequestToken?: number;  // increments when the page-level `e` shortcut asks to open the resolve form
   refreshToken?: number;         // bumped by bulk actions in the queue after they mutate tickets
+  // Host-supplied assignee list (TicketsPage already fetches /users for its
+  // filter bar). When provided — including null for "picker hidden" — the
+  // workbench skips its own /users fetch; undefined keeps the standalone
+  // self-fetch (full-page /tickets/[id] view).
+  assignees?: Array<{ id: string; name: string | null; email: string }> | null;
 }
 
 const STATUS_OPTIONS: TicketStatus[] = ['new', 'open', 'pending', 'on_hold', 'resolved', 'closed'];
 const PRIORITY_OPTIONS: TicketPriority[] = ['urgent', 'high', 'normal', 'low'];
 
-export default function TicketWorkbench({ ticketId, onChanged, expanded, resolveRequestToken, refreshToken }: Props) {
+export default function TicketWorkbench({ ticketId, onChanged, expanded, resolveRequestToken, refreshToken, assignees: assigneesProp }: Props) {
   const [ticket, setTicket] = useState<TicketDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
@@ -33,7 +38,9 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
   const [railOpen] = useState(true);
 
   // null = picker hidden (no USERS_READ etc.); degrade to a label + unassign-only button.
-  const [assignees, setAssignees] = useState<Array<{ id: string; name: string | null; email: string }> | null>(null);
+  const [fetchedAssignees, setFetchedAssignees] = useState<Array<{ id: string; name: string | null; email: string }> | null>(null);
+  const assigneesProvided = assigneesProp !== undefined;
+  const assignees = assigneesProvided ? assigneesProp : fetchedAssignees;
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -61,8 +68,17 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
   useEffect(() => { void load(); }, [load]);
 
   // Bulk actions in the queue mutate tickets behind the pane's back; the parent
-  // bumps refreshToken after a bulk apply so the detail can't go stale.
-  useEffect(() => { if (refreshToken) void load(); }, [refreshToken, load]);
+  // bumps refreshToken after a bulk apply so the detail can't go stale. The ref
+  // guard makes the effect fire only on an actual token bump — without it, a
+  // ticketId change (new `load` identity) with a non-zero token would refetch a
+  // second time on every j/k switch.
+  const lastRefreshToken = useRef(refreshToken ?? 0);
+  useEffect(() => {
+    if (refreshToken !== undefined && refreshToken !== lastRefreshToken.current) {
+      lastRefreshToken.current = refreshToken;
+      void load();
+    }
+  }, [refreshToken, load]);
 
   // Reset the inline resolve form when switching tickets — otherwise ticket B
   // could be resolved with ticket A's note (`e` on A, then `j` to B).
@@ -79,7 +95,9 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
   }, [resolveRequestToken]);
 
   // Fetch assignees once; degrade gracefully if the endpoint is unavailable.
+  // Skipped entirely when the host already supplies the list via the prop.
   useEffect(() => {
+    if (assigneesProvided) return;
     let cancelled = false;
     void fetchWithAuth('/users')
       .then(async (r) => (r.ok ? r.json() : null))
@@ -87,13 +105,15 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
         if (cancelled || !body) return;
         const rows = Array.isArray(body) ? body : (body as { data?: unknown }).data;
         if (Array.isArray(rows))
-          setAssignees((rows as Array<{ id: string; name: string | null; email: string }>).filter((u) => u.id));
+          setFetchedAssignees((rows as Array<{ id: string; name: string | null; email: string }>).filter((u) => u.id));
       })
       .catch(() => { /* degraded mode keeps the unassign-only affordance */ });
     return () => { cancelled = true; };
-  }, []);
+  }, [assigneesProvided]);
 
-  const mutate = useCallback(async (path: string, body: unknown, success: string) => {
+  // Returns true on success, false on a swallowed ActionError — callers with
+  // form state (resolve/pending) must only close/clear when the POST landed.
+  const mutate = useCallback(async (path: string, body: unknown, success: string): Promise<boolean> => {
     try {
       await runAction({
         request: () => fetchWithAuth(`/tickets/${ticketId}${path}`, { method: 'POST', body: JSON.stringify(body) }),
@@ -103,8 +123,10 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
       });
       await load();
       onChanged?.();
+      return true;
     } catch (err) {
       if (!(err instanceof ActionError)) throw err;
+      return false; // already toasted by runAction
     }
   }, [ticketId, load, onChanged]);
 
@@ -116,7 +138,8 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
 
   const submitResolve = useCallback(async () => {
     if (!resolutionNote.trim()) return;
-    await mutate('/status', { status: 'resolved', resolutionNote: resolutionNote.trim() }, 'Ticket resolved');
+    const ok = await mutate('/status', { status: 'resolved', resolutionNote: resolutionNote.trim() }, 'Ticket resolved');
+    if (!ok) return; // keep the form open and the typed note intact on failure
     setResolveOpen(false);
     setResolutionNote('');
   }, [mutate, resolutionNote]);
@@ -124,7 +147,8 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
   const submitPending = useCallback(async () => {
     if (!pendingOpen) return;
     const reason = pendingReason.trim();
-    await mutate('/status', { status: pendingOpen, ...(reason ? { pendingReason: reason } : {}) }, 'Status updated');
+    const ok = await mutate('/status', { status: pendingOpen, ...(reason ? { pendingReason: reason } : {}) }, 'Status updated');
+    if (!ok) return; // keep the form open and the typed reason intact on failure
     setPendingOpen(null);
     setPendingReason('');
   }, [mutate, pendingOpen, pendingReason]);

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
+import { loginPathWithNext } from '../../lib/authScope';
 import TicketFeed from './TicketFeed';
 import TicketComposer from './TicketComposer';
 import SlaChip from './SlaChip';
@@ -14,19 +15,25 @@ interface Props {
   onChanged?: () => void;       // queue refresh hook
   expanded?: boolean;            // full-page mode
   resolveRequestToken?: number;  // increments when the page-level `e` shortcut asks to open the resolve form
+  refreshToken?: number;         // bumped by bulk actions in the queue after they mutate tickets
 }
 
 const STATUS_OPTIONS: TicketStatus[] = ['new', 'open', 'pending', 'on_hold', 'resolved', 'closed'];
 const PRIORITY_OPTIONS: TicketPriority[] = ['urgent', 'high', 'normal', 'low'];
 
-export default function TicketWorkbench({ ticketId, onChanged, expanded, resolveRequestToken }: Props) {
+export default function TicketWorkbench({ ticketId, onChanged, expanded, resolveRequestToken, refreshToken }: Props) {
   const [ticket, setTicket] = useState<TicketDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
   const [errorKind, setErrorKind] = useState<'not-found' | 'load' | undefined>();
   const [resolveOpen, setResolveOpen] = useState(false);
   const [resolutionNote, setResolutionNote] = useState('');
+  const [pendingOpen, setPendingOpen] = useState<'pending' | 'on_hold' | null>(null);
+  const [pendingReason, setPendingReason] = useState('');
   const [railOpen] = useState(true);
+
+  // null = picker hidden (no USERS_READ etc.); degrade to a label + unassign-only button.
+  const [assignees, setAssignees] = useState<Array<{ id: string; name: string | null; email: string }> | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -36,7 +43,7 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
       const res = await fetchWithAuth(`/tickets/${ticketId}`);
       if (res.status === 404 || res.status === 403) {
         setTicket(null);
-        setError('Ticket not found. It may have been deleted.');
+        setError('Ticket not found. It may have been deleted, or you may not have access to it.');
         setErrorKind('not-found');
         return;
       }
@@ -53,11 +60,17 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
 
   useEffect(() => { void load(); }, [load]);
 
+  // Bulk actions in the queue mutate tickets behind the pane's back; the parent
+  // bumps refreshToken after a bulk apply so the detail can't go stale.
+  useEffect(() => { if (refreshToken) void load(); }, [refreshToken, load]);
+
   // Reset the inline resolve form when switching tickets — otherwise ticket B
   // could be resolved with ticket A's note (`e` on A, then `j` to B).
   useEffect(() => {
     setResolveOpen(false);
     setResolutionNote('');
+    setPendingOpen(null);
+    setPendingReason('');
   }, [ticketId]);
 
   // Page-level `e` shortcut: open the inline resolve form (UI brief: `e` opens the resolution-note form)
@@ -65,13 +78,28 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
     if (resolveRequestToken) setResolveOpen(true);
   }, [resolveRequestToken]);
 
+  // Fetch assignees once; degrade gracefully if the endpoint is unavailable.
+  useEffect(() => {
+    let cancelled = false;
+    void fetchWithAuth('/users')
+      .then(async (r) => (r.ok ? r.json() : null))
+      .then((body) => {
+        if (cancelled || !body) return;
+        const rows = Array.isArray(body) ? body : (body as { data?: unknown }).data;
+        if (Array.isArray(rows))
+          setAssignees((rows as Array<{ id: string; name: string | null; email: string }>).filter((u) => u.id));
+      })
+      .catch(() => { /* degraded mode keeps the unassign-only affordance */ });
+    return () => { cancelled = true; };
+  }, []);
+
   const mutate = useCallback(async (path: string, body: unknown, success: string) => {
     try {
       await runAction({
         request: () => fetchWithAuth(`/tickets/${ticketId}${path}`, { method: 'POST', body: JSON.stringify(body) }),
         errorFallback: `${success} failed. Retry.`,
         successMessage: success,
-        onUnauthorized: () => void navigateTo('/login', { replace: true })
+        onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
       });
       await load();
       onChanged?.();
@@ -82,6 +110,7 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
 
   const onStatusChange = useCallback(async (status: TicketStatus) => {
     if (status === 'resolved') { setResolveOpen(true); return; }
+    if (status === 'pending' || status === 'on_hold') { setPendingOpen(status); return; }
     await mutate('/status', { status }, 'Status updated');
   }, [mutate]);
 
@@ -92,11 +121,19 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
     setResolutionNote('');
   }, [mutate, resolutionNote]);
 
+  const submitPending = useCallback(async () => {
+    if (!pendingOpen) return;
+    const reason = pendingReason.trim();
+    await mutate('/status', { status: pendingOpen, ...(reason ? { pendingReason: reason } : {}) }, 'Status updated');
+    setPendingOpen(null);
+    setPendingReason('');
+  }, [mutate, pendingOpen, pendingReason]);
+
   const sendComment = useCallback(async (content: string, isPublic: boolean) => {
     await runAction({
       request: () => fetchWithAuth(`/tickets/${ticketId}/comments`, { method: 'POST', body: JSON.stringify({ content, isPublic }) }),
       errorFallback: 'Reply failed. Retry.',
-      onUnauthorized: () => void navigateTo('/login', { replace: true })
+      onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
     });
     await load();
     onChanged?.();
@@ -160,7 +197,7 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
               void runAction({
                 request: () => fetchWithAuth(`/tickets/${ticketId}`, { method: 'PATCH', body: JSON.stringify({ priority: e.target.value }) }),
                 errorFallback: 'Priority update failed. Retry.',
-                onUnauthorized: () => void navigateTo('/login', { replace: true })
+                onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
               }).then(() => { void load(); onChanged?.(); }).catch((err) => { if (!(err instanceof ActionError)) throw err; });
             }}
             className={cn('rounded-md border px-2 py-1 text-xs font-medium', priorityConfig[ticket.priority].color)}
@@ -169,14 +206,38 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
           >
             {PRIORITY_OPTIONS.map((p) => <option key={p} value={p}>{priorityConfig[p].label}</option>)}
           </select>
-          <button
-            type="button"
-            onClick={() => void mutate('/assign', { assigneeId: null }, 'Unassigned')}
-            className="rounded-md border px-2 py-1 text-xs hover:bg-muted"
-            data-testid="ticket-workbench-unassign"
-          >
-            {ticket.assigneeName ? `Assignee: ${ticket.assigneeName} ✕` : 'Unassigned'}
-          </button>
+          {assignees !== null ? (
+            <select
+              value={ticket.assignedTo ?? ''}
+              onChange={(e) => {
+                const next = e.target.value || null;
+                if (next === (ticket.assignedTo ?? null)) return; // no-op guard: never write a bogus feed entry
+                void mutate('/assign', { assigneeId: next }, next ? 'Assigned' : 'Unassigned');
+              }}
+              className="max-w-[180px] rounded-md border px-2 py-1 text-xs"
+              data-testid="ticket-workbench-assignee"
+              aria-label="Assignee"
+            >
+              <option value="">Unassigned</option>
+              {ticket.assignedTo && !assignees.some((u) => u.id === ticket.assignedTo) && (
+                // Assignee exists but is RLS-invisible to this caller (partner staff seen
+                // from org scope) — show a redacted label instead of pretending unassigned.
+                <option value={ticket.assignedTo}>{ticket.assigneeName ?? 'MSP staff'}</option>
+              )}
+              {assignees.map((u) => <option key={u.id} value={u.id}>{u.name || u.email}</option>)}
+            </select>
+          ) : ticket.assignedTo ? (
+            <button
+              type="button"
+              onClick={() => void mutate('/assign', { assigneeId: null }, 'Unassigned')}
+              className="rounded-md border px-2 py-1 text-xs hover:bg-muted"
+              data-testid="ticket-workbench-unassign"
+            >
+              Assignee: {ticket.assigneeName ?? 'MSP staff'} ✕
+            </button>
+          ) : (
+            <span className="rounded-md border px-2 py-1 text-xs text-muted-foreground" data-testid="ticket-workbench-unassigned">Unassigned</span>
+          )}
         </div>
         {resolveOpen && (
           <div className="mt-2 rounded-md border bg-muted/30 p-2" data-testid="ticket-workbench-resolve-form">
@@ -199,6 +260,31 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
                 data-testid="ticket-workbench-resolve-submit"
               >
                 Resolve ticket
+              </button>
+            </div>
+          </div>
+        )}
+        {pendingOpen && (
+          <div className="mt-2 rounded-md border bg-muted/30 p-2" data-testid="ticket-workbench-pending-form">
+            <label className="text-xs font-medium" htmlFor="pending-reason">What are you waiting on? (optional)</label>
+            <textarea
+              id="pending-reason"
+              value={pendingReason}
+              onChange={(e) => setPendingReason(e.target.value)}
+              rows={2}
+              maxLength={500}
+              className="mt-1 w-full rounded-md border bg-background px-2 py-1.5 text-sm"
+              data-testid="ticket-workbench-pending-reason"
+            />
+            <div className="mt-1.5 flex justify-end gap-2">
+              <button type="button" onClick={() => { setPendingOpen(null); setPendingReason(''); }} className="rounded-md border px-2 py-1 text-xs hover:bg-muted">Cancel</button>
+              <button
+                type="button"
+                onClick={() => void submitPending()}
+                className="rounded-md bg-primary px-2 py-1 text-xs font-medium text-white"
+                data-testid="ticket-workbench-pending-submit"
+              >
+                {pendingOpen === 'pending' ? 'Set pending' : 'Put on hold'}
               </button>
             </div>
           </div>
@@ -226,7 +312,9 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
               <div><dt className="text-xs text-muted-foreground">Created</dt><dd>{new Date(ticket.createdAt).toLocaleString()}</dd></div>
               {ticket.dueDate && <div><dt className="text-xs text-muted-foreground">Due</dt><dd>{new Date(ticket.dueDate).toLocaleString()}</dd></div>}
               {ticket.pendingReason && <div><dt className="text-xs text-muted-foreground">Waiting on</dt><dd>{ticket.pendingReason}</dd></div>}
-              {ticket.resolutionNote && <div><dt className="text-xs text-muted-foreground">Resolution</dt><dd>{ticket.resolutionNote}</dd></div>}
+              {ticket.resolutionNote && (ticket.status === 'resolved' || ticket.status === 'closed') && (
+                <div><dt className="text-xs text-muted-foreground">Resolution</dt><dd>{ticket.resolutionNote}</dd></div>
+              )}
               <div>
                 <dt className="text-xs text-muted-foreground">Linked alerts</dt>
                 <dd className="space-y-1">

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -8,7 +8,7 @@ import { loginPathWithNext } from '../../lib/authScope';
 import TicketFeed from './TicketFeed';
 import TicketComposer from './TicketComposer';
 import SlaChip from './SlaChip';
-import { statusConfig, priorityConfig, type TicketDetail, type TicketStatus, type TicketPriority } from './ticketConfig';
+import { statusConfig, priorityConfig, slaState, type TicketDetail, type TicketStatus, type TicketPriority } from './ticketConfig';
 
 interface Props {
   ticketId: string;
@@ -178,8 +178,13 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
               <a className="hover:text-foreground hover:underline" href={`/devices?device=${ticket.deviceId}`}>{ticket.deviceHostname}</a>
             </>
           )}
-          <span>·</span>
-          <SlaChip ticket={ticket} />
+          {slaState(ticket).kind !== 'none' && (
+            // SlaChip renders nothing for no-SLA tickets — the separator must follow suit.
+            <>
+              <span>·</span>
+              <SlaChip ticket={ticket} />
+            </>
+          )}
         </div>
         <div className="mt-2 flex flex-wrap items-center gap-2">
           <select

--- a/apps/web/src/components/tickets/TicketsPage.test.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.test.tsx
@@ -396,6 +396,36 @@ describe('TicketsPage', () => {
       expect(screen.queryByTestId('tickets-filter-org')).toBeNull();
     });
 
+    it('cold load: claims are null-scope at mount (memory-only token), org user still never fetches /orgs/organizations', async () => {
+      // Simulate the token bootstrapping during the first authenticated fetches:
+      // claims read null until any fetch has happened, organization afterwards.
+      let tokenBootstrapped = false;
+      mockGetJwtClaims.mockImplementation(() =>
+        tokenBootstrapped
+          ? { scope: 'organization', orgId: 'org-1', partnerId: null }
+          : { scope: null, orgId: null, partnerId: null }
+      );
+      fetchMock.mockImplementation(async (input) => {
+        const url = String(input);
+        tokenBootstrapped = true; // fetchWithAuth refreshes the access token
+        if (url === '/tickets/stats') return makeJsonResponse(STATS);
+        if (url.startsWith('/tickets?')) return makeJsonResponse({ data: [healthy] });
+        if (url.startsWith('/orgs/organizations')) return makeJsonResponse(ORGS);
+        if (url === '/ticket-categories') return makeJsonResponse(CATEGORIES);
+        if (url === '/users') return makeJsonResponse(USERS);
+        return makeJsonResponse({ error: 'unexpected' }, false, 404);
+      });
+
+      render(<TicketsPage />);
+      await screen.findByTestId('ticket-row-tk-healthy');
+      // Wait for the options effect to settle (categories rendered).
+      await screen.findByRole('option', { name: 'Hardware' });
+
+      const allFetchUrls = fetchMock.mock.calls.map((call) => String(call[0]));
+      expect(allFetchUrls.every((u) => !u.includes('/orgs/organizations'))).toBe(true);
+      expect(screen.queryByTestId('tickets-filter-org')).toBeNull();
+    });
+
     it('partner scope with one org returned: org filter hidden; with two orgs: visible', async () => {
       // First: one org returned
       fetchMock.mockImplementation(async (input) => {
@@ -462,9 +492,35 @@ describe('TicketsPage', () => {
         );
       });
       const call = showToast.mock.calls[0]?.[0] as { type: string; message: string };
-      expect(call.message).toContain('2 skipped');
+      expect(call.message).toContain('0 updated, 2 skipped');
       expect(call.message).toContain('out of your scope');
       expect(call.message).toContain('invalid status change');
+      // No failures → the failed segment is omitted entirely.
+      expect(call.message).not.toContain('failed');
+    });
+
+    it('failed writes are reported distinctly from skips in the warning toast', async () => {
+      mockListApi([healthy, atRisk, breached], {
+        bulkResult: { data: { updated: 1, skipped: 1, failed: 1, total: 3, skippedReasons: { OUT_OF_SCOPE: 1 } } } as typeof BULK_RESULT
+      });
+
+      render(<TicketsPage />);
+      await screen.findByTestId('ticket-row-tk-healthy');
+
+      fireEvent.click(screen.getByTestId('ticket-select-tk-healthy'));
+      fireEvent.click(screen.getByTestId('ticket-select-tk-risk'));
+      fireEvent.click(screen.getByTestId('ticket-select-tk-breach'));
+      fireEvent.change(screen.getByTestId('tickets-bulk-status'), { target: { value: 'closed' } });
+      fireEvent.click(screen.getByTestId('tickets-bulk-apply'));
+
+      await waitFor(() => {
+        expect(showToast).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'warning', message: expect.stringContaining(', 1 failed') })
+        );
+      });
+      const call = showToast.mock.calls[0]?.[0] as { type: string; message: string };
+      expect(call.message).toContain('1 updated, 1 skipped, 1 failed');
+      expect(call.message).toContain('out of your scope');
     });
 
     it('fully-successful bulk shows a success toast with updated count', async () => {

--- a/apps/web/src/components/tickets/TicketsPage.test.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.test.tsx
@@ -19,9 +19,10 @@ const navigateTo = vi.fn();
 vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
 
 // Mock authScope so each test can control getJwtClaims behaviour.
-const mockGetJwtClaims = vi.fn(() => ({ scope: 'partner' as const, orgId: null, partnerId: 'p-1' }));
+import type { JwtClaims } from '../../lib/authScope';
+const mockGetJwtClaims = vi.fn((): JwtClaims => ({ scope: 'partner', orgId: null, partnerId: 'p-1' }));
 vi.mock('../../lib/authScope', () => ({
-  getJwtClaims: (...args: unknown[]) => mockGetJwtClaims(...args),
+  getJwtClaims: () => mockGetJwtClaims(),
   loginPathWithNext: () => '/login?next=%2F'
 }));
 
@@ -92,11 +93,14 @@ const USERS = { data: [{ id: 'user-1', name: 'Todd', email: 'todd@example.com', 
 
 const BULK_RESULT = { data: { updated: 2, skipped: 0, failed: 0, total: 2 } };
 
-function mockListApi(tickets: TicketSummary[] | ((url: string) => TicketSummary[]), opts: { usersFail?: boolean } = {}) {
+function mockListApi(
+  tickets: TicketSummary[] | ((url: string) => TicketSummary[]),
+  opts: { usersFail?: boolean; bulkResult?: typeof BULK_RESULT } = {}
+) {
   fetchMock.mockImplementation(async (input) => {
     const url = String(input);
     if (url === '/tickets/stats') return makeJsonResponse(STATS);
-    if (url === '/tickets/bulk') return makeJsonResponse(BULK_RESULT);
+    if (url === '/tickets/bulk') return makeJsonResponse(opts.bulkResult ?? BULK_RESULT);
     if (url.startsWith('/tickets?')) return makeJsonResponse({ data: typeof tickets === 'function' ? tickets(url) : tickets });
     if (url.startsWith('/orgs/organizations')) return makeJsonResponse(ORGS);
     if (url === '/ticket-categories') return makeJsonResponse(CATEGORIES);
@@ -464,7 +468,8 @@ describe('TicketsPage', () => {
     });
 
     it('fully-successful bulk shows a success toast with updated count', async () => {
-      mockListApi([healthy, atRisk, breached]);
+      // 3 selected, 3 updated — the toast count must come from the server response.
+      mockListApi([healthy, atRisk, breached], { bulkResult: { data: { updated: 3, skipped: 0, failed: 0, total: 3 } } });
       render(<TicketsPage />);
 
       await screen.findByTestId('ticket-row-tk-healthy');
@@ -476,7 +481,7 @@ describe('TicketsPage', () => {
       fireEvent.click(screen.getByTestId('tickets-bulk-apply'));
 
       await waitFor(() => {
-        expect(showToast).toHaveBeenCalledWith({ type: 'success', message: '2 updated' });
+        expect(showToast).toHaveBeenCalledWith({ type: 'success', message: '3 updated' });
       });
     });
   });

--- a/apps/web/src/components/tickets/TicketsPage.test.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.test.tsx
@@ -18,9 +18,21 @@ vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
 const navigateTo = vi.fn();
 vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
 
+// Mock authScope so each test can control getJwtClaims behaviour.
+const mockGetJwtClaims = vi.fn(() => ({ scope: 'partner' as const, orgId: null, partnerId: 'p-1' }));
+vi.mock('../../lib/authScope', () => ({
+  getJwtClaims: (...args: unknown[]) => mockGetJwtClaims(...args),
+  loginPathWithNext: () => '/login?next=%2F'
+}));
+
 // Keep the page test focused on the queue: the workbench fetch/load cycle has its own suite.
+// Extended to accept refreshToken so the pane-refresh assertion can inspect props.
+const capturedWorkbenchProps: Array<{ ticketId: string; refreshToken?: number }> = [];
 vi.mock('./TicketWorkbench', () => ({
-  default: ({ ticketId }: { ticketId: string }) => <div data-testid="ticket-workbench-mock">{ticketId}</div>
+  default: (props: { ticketId: string; refreshToken?: number }) => {
+    capturedWorkbenchProps.push({ ticketId: props.ticketId, refreshToken: props.refreshToken });
+    return <div data-testid="ticket-workbench-mock" data-refresh={props.refreshToken}>{props.ticketId}</div>;
+  }
 }));
 
 const fetchMock = vi.mocked(fetchWithAuth);
@@ -106,6 +118,9 @@ describe('TicketsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     clearHash();
+    capturedWorkbenchProps.length = 0;
+    // Default to partner scope so existing tests behave as before.
+    mockGetJwtClaims.mockReturnValue({ scope: 'partner', orgId: null, partnerId: 'p-1' });
     // jsdom defaults to 1024, which is below the 1100px split-pane breakpoint;
     // select() would navigate to the full page instead of selecting in-pane.
     Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: 1280 });
@@ -358,5 +373,138 @@ describe('TicketsPage', () => {
     expect(lastUrl).not.toContain('priority=');
     expect(lastUrl).not.toContain('orgId=');
     expect(lastUrl).not.toContain('categoryId=');
+  });
+
+  describe('org-scope hygiene', () => {
+    it('org-scoped session: does not fetch /orgs/organizations and hides the org filter select', async () => {
+      mockGetJwtClaims.mockReturnValue({ scope: 'organization', orgId: 'org-1', partnerId: null });
+      mockListApi([healthy]);
+      render(<TicketsPage />);
+
+      await screen.findByTestId('ticket-row-tk-healthy');
+      // Give options effect time to settle.
+      await waitFor(() => {
+        expect(screen.queryByTestId('tickets-queue-loading')).toBeNull();
+      });
+
+      const allFetchUrls = fetchMock.mock.calls.map((call) => String(call[0]));
+      expect(allFetchUrls.every((u) => !u.includes('/orgs/organizations'))).toBe(true);
+      expect(screen.queryByTestId('tickets-filter-org')).toBeNull();
+    });
+
+    it('partner scope with one org returned: org filter hidden; with two orgs: visible', async () => {
+      // First: one org returned
+      fetchMock.mockImplementation(async (input) => {
+        const url = String(input);
+        if (url === '/tickets/stats') return makeJsonResponse(STATS);
+        if (url.startsWith('/tickets?')) return makeJsonResponse({ data: [healthy] });
+        if (url.startsWith('/orgs/organizations')) return makeJsonResponse({ data: [{ id: 'org-1', name: 'Acme Corp' }] });
+        if (url === '/ticket-categories') return makeJsonResponse(CATEGORIES);
+        if (url === '/users') return makeJsonResponse(USERS);
+        return makeJsonResponse({ error: 'unexpected' }, false, 404);
+      });
+
+      const { unmount } = render(<TicketsPage />);
+      await screen.findByTestId('ticket-row-tk-healthy');
+      // Options load asynchronously — wait for categories to confirm effect settled.
+      await screen.findByRole('option', { name: 'Hardware' });
+
+      expect(screen.queryByTestId('tickets-filter-org')).toBeNull();
+      unmount();
+
+      vi.clearAllMocks();
+      capturedWorkbenchProps.length = 0;
+
+      // Second: two orgs returned
+      mockListApi([healthy]);
+      render(<TicketsPage />);
+
+      await screen.findByTestId('ticket-row-tk-healthy');
+      await screen.findByRole('option', { name: 'Globex' });
+
+      expect(screen.getByTestId('tickets-filter-org')).toBeInTheDocument();
+    });
+  });
+
+  describe('bulk outcome toasts', () => {
+    it('partial result with skippedReasons shows a warning toast with counts and labels', async () => {
+      fetchMock.mockImplementation(async (input) => {
+        const url = String(input);
+        if (url === '/tickets/stats') return makeJsonResponse(STATS);
+        if (url.startsWith('/tickets?')) return makeJsonResponse({ data: [healthy, atRisk] });
+        if (url.startsWith('/orgs/organizations')) return makeJsonResponse(ORGS);
+        if (url === '/ticket-categories') return makeJsonResponse(CATEGORIES);
+        if (url === '/users') return makeJsonResponse(USERS);
+        if (url === '/tickets/bulk') {
+          return makeJsonResponse({ data: { updated: 0, skipped: 2, failed: 0, total: 2, skippedReasons: { OUT_OF_SCOPE: 1, INVALID_TRANSITION: 1 } } });
+        }
+        return makeJsonResponse({ error: 'unexpected' }, false, 404);
+      });
+
+      render(<TicketsPage />);
+      await screen.findByTestId('ticket-row-tk-healthy');
+
+      fireEvent.click(screen.getByTestId('ticket-select-tk-healthy'));
+      fireEvent.click(screen.getByTestId('ticket-select-tk-risk'));
+      fireEvent.change(screen.getByTestId('tickets-bulk-status'), { target: { value: 'closed' } });
+      fireEvent.click(screen.getByTestId('tickets-bulk-apply'));
+
+      await waitFor(() => {
+        expect(showToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'warning',
+            message: expect.stringContaining('0 updated')
+          })
+        );
+      });
+      const call = showToast.mock.calls[0]?.[0] as { type: string; message: string };
+      expect(call.message).toContain('2 skipped');
+      expect(call.message).toContain('out of your scope');
+      expect(call.message).toContain('invalid status change');
+    });
+
+    it('fully-successful bulk shows a success toast with updated count', async () => {
+      mockListApi([healthy, atRisk, breached]);
+      render(<TicketsPage />);
+
+      await screen.findByTestId('ticket-row-tk-healthy');
+      fireEvent.click(screen.getByTestId('ticket-select-tk-healthy'));
+      fireEvent.click(screen.getByTestId('ticket-select-tk-risk'));
+      fireEvent.click(screen.getByTestId('ticket-select-tk-breach'));
+
+      fireEvent.change(screen.getByTestId('tickets-bulk-status'), { target: { value: 'closed' } });
+      fireEvent.click(screen.getByTestId('tickets-bulk-apply'));
+
+      await waitFor(() => {
+        expect(showToast).toHaveBeenCalledWith({ type: 'success', message: '2 updated' });
+      });
+    });
+  });
+
+  describe('pane refresh after bulk', () => {
+    it('increments refreshToken on TicketWorkbench after a successful bulk apply', async () => {
+      mockListApi([healthy, atRisk, breached]);
+      render(<TicketsPage />);
+
+      await screen.findByTestId('ticket-row-tk-healthy');
+      await waitFor(() => {
+        expect(screen.getByTestId('ticket-workbench-mock')).toBeInTheDocument();
+      });
+
+      const tokenBefore = Number(screen.getByTestId('ticket-workbench-mock').getAttribute('data-refresh') ?? '0');
+
+      fireEvent.click(screen.getByTestId('ticket-select-tk-healthy'));
+      fireEvent.change(screen.getByTestId('tickets-bulk-status'), { target: { value: 'closed' } });
+      fireEvent.click(screen.getByTestId('tickets-bulk-apply'));
+
+      await waitFor(() => {
+        expect(showToast).toHaveBeenCalled();
+      });
+
+      await waitFor(() => {
+        const tokenAfter = Number(screen.getByTestId('ticket-workbench-mock').getAttribute('data-refresh') ?? '0');
+        expect(tokenAfter).toBeGreaterThan(tokenBefore);
+      });
+    });
   });
 });

--- a/apps/web/src/components/tickets/TicketsPage.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.tsx
@@ -54,7 +54,11 @@ function selectionFromHash(): string | null {
 }
 
 export default function TicketsPage() {
-  // Read once on mount — scope is stable for the lifetime of the page.
+  // Re-read per render to hide the org filter for org-scoped users. On a cold
+  // page load the memory-only access token may not exist yet, so this can read
+  // null scope before token bootstrap — the options effect below re-reads the
+  // claims after its first fetches bootstrap the token, and `orgs.length > 1`
+  // keeps the filter hidden either way (belt and braces).
   const orgScoped = getJwtClaims().scope === 'organization';
 
   const [tab, setTab] = useState<Tab>('open');
@@ -96,18 +100,14 @@ export default function TicketsPage() {
     let cancelled = false;
     const readJson = async (res: Response): Promise<unknown> => (res.ok ? res.json() : null);
     void (async () => {
-      const [orgRes, catRes, userRes] = await Promise.allSettled([
-        // Org-scoped users can't list organizations (403 console spam) and don't need
-        // the filter — their queue is already single-org.
-        orgScoped ? Promise.resolve(null) : fetchWithAuth('/orgs/organizations?limit=100').then(readJson),
+      // Categories + users first: access tokens are memory-only, so on a cold
+      // load the JWT claims are unreadable at mount — these fetches bootstrap
+      // the token before we decide whether the orgs fetch is allowed.
+      const [catRes, userRes] = await Promise.allSettled([
         fetchWithAuth('/ticket-categories').then(readJson),
         fetchWithAuth('/users').then(readJson)
       ]);
       if (cancelled) return;
-      if (orgRes.status === 'fulfilled' && orgRes.value) {
-        const body = orgRes.value as { data?: Array<{ id: string; name: string }>; organizations?: Array<{ id: string; name: string }> };
-        setOrgs((body.data ?? body.organizations ?? []).filter((o) => o.id && o.name));
-      }
       if (catRes.status === 'fulfilled' && catRes.value) {
         const body = catRes.value as { data?: Array<{ id: string; name: string; isActive?: boolean }> };
         setCategories((body.data ?? []).filter((cat) => cat.isActive !== false));
@@ -117,10 +117,18 @@ export default function TicketsPage() {
         const rows = Array.isArray(body) ? body : body.data;
         if (Array.isArray(rows)) setAssignees(rows.filter((u) => u.id));
       }
+      // Token is bootstrapped by the fetches above, so the claims read is reliable now.
+      // Org-scoped users can't list organizations (403 console spam) and don't need
+      // the filter — their queue is already single-org.
+      const orgScopedNow = getJwtClaims().scope === 'organization';
+      if (!orgScopedNow) {
+        const orgBody = await fetchWithAuth('/orgs/organizations?limit=100').then(readJson).catch(() => null);
+        if (cancelled || !orgBody) return;
+        const body = orgBody as { data?: Array<{ id: string; name: string }>; organizations?: Array<{ id: string; name: string }> };
+        setOrgs((body.data ?? body.organizations ?? []).filter((o) => o.id && o.name));
+      }
     })();
     return () => { cancelled = true; };
-    // orgScoped is stable (computed once from JWT on render), so omitting it
-    // from deps is intentional — the effect runs once and doesn't need to re-run.
   }, []);
 
   const fetchTickets = useCallback(async () => {
@@ -268,12 +276,13 @@ export default function TicketsPage() {
         onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
       });
       const { updated, skipped, failed, skippedReasons } = result.data;
-      const missed = skipped + failed;
-      if (missed > 0) {
+      if (skipped + failed > 0) {
         const reasons = Object.entries(skippedReasons ?? {})
           .map(([code, n]) => `${n} ${SKIP_REASON_LABELS[code] ?? code.toLowerCase().replace(/_/g, ' ')}`)
           .join(', ');
-        showToast({ type: 'warning', message: `${updated} updated, ${missed} skipped${reasons ? ` — ${reasons}` : ''}` });
+        // Failures are reported distinctly from skips — "skipped" implies a
+        // pre-validation outcome, "failed" means the write itself errored.
+        showToast({ type: 'warning', message: `${updated} updated, ${skipped} skipped${failed ? `, ${failed} failed` : ''}${reasons ? ` — ${reasons}` : ''}` });
       } else {
         showToast({ type: 'success', message: `${updated} updated` });
       }
@@ -515,7 +524,7 @@ export default function TicketsPage() {
           </div>
           <div className="hidden min-w-0 flex-1 min-[1100px]:block">
             {selected ? (
-              <TicketWorkbench ticketId={selected.id} resolveRequestToken={resolveToken} refreshToken={paneRefresh} onChanged={() => { void fetchTickets(); void fetchStats(); }} />
+              <TicketWorkbench ticketId={selected.id} resolveRequestToken={resolveToken} refreshToken={paneRefresh} assignees={assignees} onChanged={() => { void fetchTickets(); void fetchStats(); }} />
             ) : (
               <div className="flex h-full items-center justify-center text-sm text-muted-foreground" data-testid="tickets-no-selection">
                 <p>Select a ticket. Use j/k to move, Enter to expand.</p>

--- a/apps/web/src/components/tickets/TicketsPage.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.tsx
@@ -119,9 +119,8 @@ export default function TicketsPage() {
       }
     })();
     return () => { cancelled = true; };
-    // orgScoped is stable (computed once from JWT on render), so omitting from
-    // deps is intentional — the effect runs once and doesn't need to re-run.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // orgScoped is stable (computed once from JWT on render), so omitting it
+    // from deps is intentional — the effect runs once and doesn't need to re-run.
   }, []);
 
   const fetchTickets = useCallback(async () => {

--- a/apps/web/src/components/tickets/TicketsPage.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.tsx
@@ -5,10 +5,22 @@ import { fetchWithAuth, useAuthStore } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
 import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
+import { getJwtClaims, loginPathWithNext } from '../../lib/authScope';
 import TicketQueueList from './TicketQueueList';
 import TicketWorkbench from './TicketWorkbench';
 import { useQueueKeyboard } from './useQueueKeyboard';
 import { priorityConfig, statusConfig, slaState, type TicketPriority, type TicketStatus, type TicketSummary } from './ticketConfig';
+
+// Human-readable labels for bulk-skip reason codes returned by POST /tickets/bulk.
+const SKIP_REASON_LABELS: Record<string, string> = {
+  OUT_OF_SCOPE: 'out of your scope',
+  INVALID_TRANSITION: 'invalid status change',
+  ASSIGNEE_NOT_FOUND: 'assignee not found',
+  ASSIGNEE_WRONG_PARTNER: 'assignee belongs to another partner',
+  CONCURRENT_MODIFICATION: 'modified by someone else',
+  TICKET_PARTNER_UNRESOLVABLE: 'ticket partner unresolvable',
+  OTHER: 'other errors'
+};
 
 type Tab = 'mine' | 'unassigned' | 'open' | 'breaching' | 'closed';
 
@@ -42,8 +54,12 @@ function selectionFromHash(): string | null {
 }
 
 export default function TicketsPage() {
+  // Read once on mount — scope is stable for the lifetime of the page.
+  const orgScoped = getJwtClaims().scope === 'organization';
+
   const [tab, setTab] = useState<Tab>('open');
   const [resolveToken, setResolveToken] = useState(0);
+  const [paneRefresh, setPaneRefresh] = useState(0);
   const [tickets, setTickets] = useState<TicketSummary[]>([]);
   const [stats, setStats] = useState<{ open: number; unassigned: number; mine: number; breached: number } | null>(null);
   const [loading, setLoading] = useState(true);
@@ -81,7 +97,9 @@ export default function TicketsPage() {
     const readJson = async (res: Response): Promise<unknown> => (res.ok ? res.json() : null);
     void (async () => {
       const [orgRes, catRes, userRes] = await Promise.allSettled([
-        fetchWithAuth('/orgs/organizations?limit=100').then(readJson),
+        // Org-scoped users can't list organizations (403 console spam) and don't need
+        // the filter — their queue is already single-org.
+        orgScoped ? Promise.resolve(null) : fetchWithAuth('/orgs/organizations?limit=100').then(readJson),
         fetchWithAuth('/ticket-categories').then(readJson),
         fetchWithAuth('/users').then(readJson)
       ]);
@@ -101,6 +119,9 @@ export default function TicketsPage() {
       }
     })();
     return () => { cancelled = true; };
+    // orgScoped is stable (computed once from JWT on render), so omitting from
+    // deps is intentional — the effect runs once and doesn't need to re-run.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const fetchTickets = useCallback(async () => {
@@ -118,7 +139,7 @@ export default function TicketsPage() {
       params.set('limit', '100');
       const res = await fetchWithAuth(`/tickets?${params.toString()}`);
       if (!res.ok) {
-        if (res.status === 401) { void navigateTo('/login', { replace: true }); return; }
+        if (res.status === 401) { void navigateTo(loginPathWithNext(), { replace: true }); return; }
         throw new Error('Tickets failed to load.');
       }
       const body = await res.json();
@@ -210,7 +231,7 @@ export default function TicketsPage() {
         request: () => fetchWithAuth(`/tickets/${selected.id}/assign`, { method: 'POST', body: JSON.stringify({ assigneeId: userId }) }),
         errorFallback: 'Assign failed. Retry.',
         successMessage: 'Assigned to you',
-        onUnauthorized: () => void navigateTo('/login', { replace: true })
+        onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
       });
       void fetchTickets();
       void fetchStats();
@@ -242,13 +263,23 @@ export default function TicketsPage() {
       ? { ticketIds, action: 'status', status: bulkStatus }
       : { ticketIds, action: 'assign', assigneeId: bulkAssignee === 'unassign' ? null : bulkAssignee };
     try {
-      await runAction<{ data: { updated: number; skipped: number; failed: number; total: number } }>({
+      const result = await runAction<{ data: { updated: number; skipped: number; failed: number; total: number; skippedReasons?: Record<string, number> } }>({
         request: () => fetchWithAuth('/tickets/bulk', { method: 'POST', body: JSON.stringify(body) }),
         errorFallback: 'Bulk update failed. Retry.',
-        successMessage: (r) => `${r.data.updated} updated${r.data.skipped ? `, ${r.data.skipped} skipped` : ''}`,
-        onUnauthorized: () => void navigateTo('/login', { replace: true })
+        onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
       });
+      const { updated, skipped, failed, skippedReasons } = result.data;
+      const missed = skipped + failed;
+      if (missed > 0) {
+        const reasons = Object.entries(skippedReasons ?? {})
+          .map(([code, n]) => `${n} ${SKIP_REASON_LABELS[code] ?? code.toLowerCase().replace(/_/g, ' ')}`)
+          .join(', ');
+        showToast({ type: 'warning', message: `${updated} updated, ${missed} skipped${reasons ? ` — ${reasons}` : ''}` });
+      } else {
+        showToast({ type: 'success', message: `${updated} updated` });
+      }
       clearBulkSelection();
+      setPaneRefresh((t) => t + 1);
       void fetchTickets();
       void fetchStats();
     } catch (err) {
@@ -332,18 +363,20 @@ export default function TicketsPage() {
       </div>
 
       <div className="mb-3 flex flex-wrap items-center gap-2" data-testid="tickets-filter-bar">
-        <select
-          value={orgFilter}
-          onChange={(e) => setOrgFilter(e.target.value)}
-          aria-label="Filter by organization"
-          data-testid="tickets-filter-org"
-          className={filterSelectClass(!!orgFilter)}
-        >
-          <option value="">All organizations</option>
-          {orgs.map((o) => (
-            <option key={o.id} value={o.id}>{o.name}</option>
-          ))}
-        </select>
+        {!orgScoped && orgs.length > 1 && (
+          <select
+            value={orgFilter}
+            onChange={(e) => setOrgFilter(e.target.value)}
+            aria-label="Filter by organization"
+            data-testid="tickets-filter-org"
+            className={filterSelectClass(!!orgFilter)}
+          >
+            <option value="">All organizations</option>
+            {orgs.map((o) => (
+              <option key={o.id} value={o.id}>{o.name}</option>
+            ))}
+          </select>
+        )}
         <select
           value={priorityFilter}
           onChange={(e) => setPriorityFilter(e.target.value)}
@@ -483,7 +516,7 @@ export default function TicketsPage() {
           </div>
           <div className="hidden min-w-0 flex-1 min-[1100px]:block">
             {selected ? (
-              <TicketWorkbench ticketId={selected.id} resolveRequestToken={resolveToken} onChanged={() => { void fetchTickets(); void fetchStats(); }} />
+              <TicketWorkbench ticketId={selected.id} resolveRequestToken={resolveToken} refreshToken={paneRefresh} onChanged={() => { void fetchTickets(); void fetchStats(); }} />
             ) : (
               <div className="flex h-full items-center justify-center text-sm text-muted-foreground" data-testid="tickets-no-selection">
                 <p>Select a ticket. Use j/k to move, Enter to expand.</p>

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -42,6 +42,7 @@ const TARGET_GLOBS = [
   'src/components/pam/PamRevokeModal.tsx',
   'src/components/pam/PamRuleModal.tsx',
   'src/components/pam/PamRulesTab.tsx',
+  'src/components/settings/TicketCategoriesPage.tsx',
 ];
 
 const absoluteFiles: string[] = TARGET_GLOBS.map((rel) => resolve(WEB_ROOT, '..', rel));
@@ -233,7 +234,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(14);
+    expect(absoluteFiles.length).toBe(15);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/authScope.test.ts
+++ b/apps/web/src/lib/authScope.test.ts
@@ -82,6 +82,11 @@ describe('getJwtClaims', () => {
 });
 
 describe('loginPathWithNext', () => {
+  const originalLocation = window.location;
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+  });
+
   it('returns /login when at root', () => {
     // jsdom sets pathname to '/' by default
     expect(loginPathWithNext()).toBe('/login');

--- a/apps/web/src/lib/authScope.test.ts
+++ b/apps/web/src/lib/authScope.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { useAuthStore } from '../stores/auth';
+import { getJwtClaims, loginPathWithNext } from './authScope';
+
+function makeToken(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = btoa(JSON.stringify(payload)).replace(/=/g, '');
+  return `${header}.${body}.sig`;
+}
+
+function makeTokenBase64Url(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+  const body = btoa(JSON.stringify(payload)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+  return `${header}.${body}.sig`;
+}
+
+beforeEach(() => {
+  useAuthStore.setState({ tokens: null });
+});
+
+afterEach(() => {
+  useAuthStore.setState({ tokens: null });
+});
+
+describe('getJwtClaims', () => {
+  it('returns all-null when no token', () => {
+    const claims = getJwtClaims();
+    expect(claims).toEqual({ scope: null, orgId: null, partnerId: null });
+  });
+
+  it('decodes org scope claims correctly', () => {
+    const tok = makeToken({ scope: 'organization', orgId: 'org-1', partnerId: 'p-2' });
+    useAuthStore.setState({ tokens: { accessToken: tok, expiresInSeconds: 900 } });
+    expect(getJwtClaims()).toEqual({ scope: 'organization', orgId: 'org-1', partnerId: 'p-2' });
+  });
+
+  it('decodes partner scope claims', () => {
+    const tok = makeToken({ scope: 'partner', orgId: null, partnerId: 'p-1' });
+    useAuthStore.setState({ tokens: { accessToken: tok, expiresInSeconds: 900 } });
+    const c = getJwtClaims();
+    expect(c.scope).toBe('partner');
+    expect(c.partnerId).toBe('p-1');
+  });
+
+  it('decodes system scope claims', () => {
+    const tok = makeToken({ scope: 'system' });
+    useAuthStore.setState({ tokens: { accessToken: tok, expiresInSeconds: 900 } });
+    expect(getJwtClaims().scope).toBe('system');
+  });
+
+  it('returns null scope for unknown scope values', () => {
+    const tok = makeToken({ scope: 'admin' });
+    useAuthStore.setState({ tokens: { accessToken: tok, expiresInSeconds: 900 } });
+    expect(getJwtClaims().scope).toBeNull();
+  });
+
+  it('returns all-null for a malformed token (no dots)', () => {
+    useAuthStore.setState({ tokens: { accessToken: 'notavalidjwt', expiresInSeconds: 900 } });
+    expect(getJwtClaims()).toEqual({ scope: null, orgId: null, partnerId: null });
+  });
+
+  it('returns all-null when payload is invalid JSON', () => {
+    useAuthStore.setState({ tokens: { accessToken: 'x.bm90anNvbg.y', expiresInSeconds: 900 } });
+    expect(getJwtClaims()).toEqual({ scope: null, orgId: null, partnerId: null });
+  });
+
+  it('handles base64url characters (- and _) in the payload', () => {
+    const tok = makeTokenBase64Url({ scope: 'organization', orgId: 'org-1' });
+    useAuthStore.setState({ tokens: { accessToken: tok, expiresInSeconds: 900 } });
+    const c = getJwtClaims();
+    expect(c.scope).toBe('organization');
+    expect(c.orgId).toBe('org-1');
+  });
+
+  it('returns null for orgId/partnerId when they are not strings', () => {
+    const tok = makeToken({ scope: 'organization', orgId: 123, partnerId: true });
+    useAuthStore.setState({ tokens: { accessToken: tok, expiresInSeconds: 900 } });
+    const c = getJwtClaims();
+    expect(c.orgId).toBeNull();
+    expect(c.partnerId).toBeNull();
+  });
+});
+
+describe('loginPathWithNext', () => {
+  it('returns /login when at root', () => {
+    // jsdom sets pathname to '/' by default
+    expect(loginPathWithNext()).toBe('/login');
+  });
+
+  it('encodes the current path into next param', () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { pathname: '/tickets', search: '', hash: '' } as Location,
+    });
+    expect(loginPathWithNext()).toBe('/login?next=%2Ftickets');
+  });
+
+  it('includes search and hash in the next param', () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { pathname: '/tickets', search: '?q=open', hash: '#T-1' } as Location,
+    });
+    expect(loginPathWithNext()).toBe('/login?next=%2Ftickets%3Fq%3Dopen%23T-1');
+  });
+});

--- a/apps/web/src/lib/authScope.ts
+++ b/apps/web/src/lib/authScope.ts
@@ -1,0 +1,41 @@
+import { useAuthStore } from '../stores/auth';
+
+export interface JwtClaims {
+  scope: 'system' | 'partner' | 'organization' | null;
+  orgId: string | null;
+  partnerId: string | null;
+}
+
+const NO_CLAIMS: JwtClaims = { scope: null, orgId: null, partnerId: null };
+
+/**
+ * Decode the access-token claims WITHOUT verification. Browser-side only, used
+ * to avoid known 403s (partner-only endpoints under org scope) and to pre-fill
+ * context — never as an authorization decision; the server re-checks everything.
+ * Returns all-null when the token is absent or undecodable; callers must fall
+ * through to server behavior in that case.
+ */
+export function getJwtClaims(): JwtClaims {
+  const token = useAuthStore.getState().tokens?.accessToken;
+  if (!token) return NO_CLAIMS;
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
+    return {
+      scope:
+        payload.scope === 'system' || payload.scope === 'partner' || payload.scope === 'organization'
+          ? payload.scope
+          : null,
+      orgId: typeof payload.orgId === 'string' ? payload.orgId : null,
+      partnerId: typeof payload.partnerId === 'string' ? payload.partnerId : null,
+    };
+  } catch {
+    return NO_CLAIMS;
+  }
+}
+
+/** Login URL that round-trips the current location through LoginPage's ?next= handling. */
+export function loginPathWithNext(): string {
+  if (typeof window === 'undefined') return '/login';
+  const here = window.location.pathname + window.location.search + window.location.hash;
+  return here && here !== '/' ? `/login?next=${encodeURIComponent(here)}` : '/login';
+}

--- a/apps/web/src/lib/authScope.ts
+++ b/apps/web/src/lib/authScope.ts
@@ -6,7 +6,7 @@ export interface JwtClaims {
   partnerId: string | null;
 }
 
-const NO_CLAIMS: JwtClaims = { scope: null, orgId: null, partnerId: null };
+const NO_CLAIMS: Readonly<JwtClaims> = { scope: null, orgId: null, partnerId: null };
 
 /**
  * Decode the access-token claims WITHOUT verification. Browser-side only, used

--- a/docs/superpowers/plans/2026-06-11-ticketing-e2e-fixes.md
+++ b/docs/superpowers/plans/2026-06-11-ticketing-e2e-fixes.md
@@ -1,0 +1,648 @@
+# Ticketing e2e Findings — Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix all 8 bugs (plus two one-line UX items) from `docs/superpowers/specs/2026-06-11-ticketing-e2e-findings.md` in one PR on branch `worktree-ticketing-review-followups`.
+
+**Architecture:** Three small API fixes (PATCH error hint, requester defaults from actor, org-scope category reads via system DB context — same pattern as `ticketService.assertCategoryInPartner`). Web fixes center on a new `lib/authScope.ts` JWT-claims helper (extracted from Sidebar) so ticketing pages stop calling partner-only endpoints under org scope, plus workbench assignment/pending-reason UI, bulk `skippedReasons` warning toasts, and a real settings page for categories (edit/parent/SLA fields against the existing PATCH endpoint).
+
+**Tech Stack:** Hono + Drizzle (API, vitest with chained Drizzle mocks), React + Astro islands (web, vitest + jsdom + testing-library), `runAction` for all mutations.
+
+**Out of scope (UX notes deliberately deferred):** queue sort control, device-select search/grouping, sticky composer tab, cross-tab bulk selection, site-restricted banner, "Breaching soon" empty state, feed old→new for field edits.
+
+**Execution groups (sequential):**
+- **Group A (API):** Tasks 1–3
+- **Group B (web, workbench + small components):** Tasks 4–8
+- **Group C (web, queue + create):** Tasks 9–10 (depends on B: `refreshToken` prop, `authScope`, warning toast)
+- **Group D (web, settings):** Task 11
+- **Task 12:** full verification
+
+Conventions for every task: test files live alongside sources; run web tests with
+`PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run <file> --root apps/web`
+and API tests with `--root apps/api`. Commit after each task with the message given in the task.
+
+---
+
+### Task 1 (API): PATCH /tickets/:id — pointed error when `status`/`assigneeId` sent
+
+Bug 8g: `updateTicketSchema` strips unknown keys, so `PATCH {status}` falls into the generic "No fields to update" 400.
+
+**Files:**
+- Modify: `apps/api/src/routes/tickets/tickets.ts` (~line 400, the empty-body branch)
+- Test: `apps/api/src/routes/tickets/tickets.test.ts`
+
+- [ ] **Step 1: Write failing tests** in the existing PATCH describe block of `tickets.test.ts`, matching the file's existing `makeApp()` style:
+
+```typescript
+it('400 with a status-route hint when only status is sent', async () => {
+  const res = await makeApp().request('/tickets/11111111-1111-4111-8111-111111111111', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status: 'open' })
+  });
+  expect(res.status).toBe(400);
+  expect((await res.json()).error).toMatch(/POST \/tickets\/:id\/status/);
+});
+
+it('400 with an assign-route hint when only assigneeId is sent', async () => {
+  const res = await makeApp().request('/tickets/11111111-1111-4111-8111-111111111111', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ assigneeId: '22222222-2222-4222-8222-222222222222' })
+  });
+  expect(res.status).toBe(400);
+  expect((await res.json()).error).toMatch(/POST \/tickets\/:id\/assign/);
+});
+```
+
+- [ ] **Step 2: Run to verify both fail** (they currently get `No fields to update`).
+- [ ] **Step 3: Implement** — replace the empty-body branch in the PATCH handler:
+
+```typescript
+if (Object.keys(body).length === 0) {
+  // zod strips unknown keys, so a {status}/{assigneeId} body lands here looking
+  // empty — point callers at the dedicated routes instead of a generic 400.
+  const raw = (await c.req.json().catch(() => null)) as Record<string, unknown> | null;
+  if (raw && 'status' in raw) {
+    return c.json({ error: 'Status is not updatable via PATCH — use POST /tickets/:id/status' }, 400);
+  }
+  if (raw && ('assigneeId' in raw || 'assignedTo' in raw)) {
+    return c.json({ error: 'Assignee is not updatable via PATCH — use POST /tickets/:id/assign' }, 400);
+  }
+  return c.json({ error: 'No fields to update' }, 400);
+}
+```
+
+- [ ] **Step 4: Run the test file; all pass.**
+- [ ] **Step 5: Commit** `fix(tickets): point PATCH callers at the status/assign routes`
+
+---
+
+### Task 2 (API): default requester to the acting technician on non-portal tickets
+
+Bug 8d: manual tickets have `submitterName/Email = null` → rail shows "Unknown". `actorFrom(c)` already carries `name` and `email`.
+
+**Files:**
+- Modify: `apps/api/src/services/ticketService.ts` (`createTicket` insertValues, ~line 228)
+- Test: `apps/api/src/services/ticketService.test.ts` (or wherever createTicket is unit-tested; add alongside existing createTicket tests)
+
+- [ ] **Step 1: Write failing test:** createTicket with `source: 'manual'` and actor `{ userId: 'u-1', name: 'Tech One', email: 'tech@msp.com' }` inserts `submitterName: 'Tech One'`, `submitterEmail: 'tech@msp.com'`, `submittedBy: null`. Assert via the existing insert-mock capture pattern in that file. Also a case with an actor lacking name/email → both null.
+- [ ] **Step 2: Run; fails (currently null).**
+- [ ] **Step 3: Implement** in insertValues:
+
+```typescript
+submittedBy: isPortal ? input.submittedBy : null,
+// Non-portal tickets default the requester to the acting user — a technician
+// logging a ticket is its requester unless the portal supplied one.
+submitterEmail: isPortal ? input.submitterEmail : (actor.email ?? null),
+submitterName: isPortal ? (input.submitterName ?? null) : (actor.name ?? null),
+```
+
+- [ ] **Step 4: Run service tests; pass.**
+- [ ] **Step 5: Commit** `fix(tickets): default requester to the acting user on non-portal tickets`
+
+---
+
+### Task 3 (API): org-scope `GET /ticket-categories` returns the MSP's categories
+
+Bug 7: the org branch already resolves the org's partner and filters by `partner_id`, but partner-axis RLS hides the rows from org-scoped request contexts → `[]`. Product call (per findings): org users get **read-only** visibility of their MSP's categories. Write routes stay partner/system.
+
+**Files:**
+- Modify: `apps/api/src/routes/ticketCategories.ts` (org branch of GET `/`)
+- Test: `apps/api/src/routes/ticketCategories.test.ts`
+
+- [ ] **Step 1: Write failing test:** under an org-scope auth context, GET `/` runs its category read through `runOutsideDbContext` + `withSystemDbAccessContext` (mock both as pass-through spies like `tickets.test.ts` does) and returns the partner's category rows.
+- [ ] **Step 2: Run; fails** (current code queries `db` directly; spies not called).
+- [ ] **Step 3: Implement** — import `runOutsideDbContext, withSystemDbAccessContext` from `../db` and wrap only the category SELECT in the org branch:
+
+```typescript
+// The org→partner resolution above stays in the request context (RLS lets an
+// org user read their own org row). The category read runs in a system DB
+// context: ticket_categories is partner-axis RLS, invisible to org-scoped
+// request contexts. The explicit partnerId filter — derived from auth.orgId,
+// never from caller input — is the security boundary, same pattern as
+// ticketService.assertCategoryInPartner. Org users get read-only visibility
+// of their MSP's categories; the write routes below remain partner/system.
+const data = await runOutsideDbContext(() =>
+  withSystemDbAccessContext(() =>
+    db
+      .select()
+      .from(ticketCategories)
+      .where(eq(ticketCategories.partnerId, partnerId))
+      .orderBy(asc(ticketCategories.sortOrder), asc(ticketCategories.name))
+  )
+);
+return c.json({ data });
+```
+
+- [ ] **Step 4: Run the route test file; pass.**
+- [ ] **Step 5: Commit** `fix(tickets): org-scope category reads run in system DB context (read-only MSP catalog)`
+
+---
+
+### Task 4 (web): `lib/authScope.ts` — JWT claims helper, Sidebar refactor
+
+Foundation for Tasks 9–10. Sidebar currently inline-decodes the JWT to read `scope`.
+
+**Files:**
+- Create: `apps/web/src/lib/authScope.ts`
+- Create: `apps/web/src/lib/authScope.test.ts`
+- Modify: `apps/web/src/components/layout/Sidebar.tsx` (~lines 292–304) to use the helper
+
+- [ ] **Step 1: Write failing tests** (forge a token: `x.${btoa(JSON.stringify({scope:'organization',orgId:'org-1',partnerId:null}))}.y`; set it via `useAuthStore.setState({ tokens: { accessToken, expiresInSeconds: 900 } })`). Cases: org-scope claims decoded; missing token → all-null; malformed token → all-null; base64url payload (`-`/`_` chars) decoded.
+- [ ] **Step 2: Run; fails (module missing).**
+- [ ] **Step 3: Implement:**
+
+```typescript
+import { useAuthStore } from '../stores/auth';
+
+export interface JwtClaims {
+  scope: 'system' | 'partner' | 'organization' | null;
+  orgId: string | null;
+  partnerId: string | null;
+}
+
+const NO_CLAIMS: JwtClaims = { scope: null, orgId: null, partnerId: null };
+
+/**
+ * Decode the access-token claims WITHOUT verification. Browser-side only, used
+ * to avoid known 403s (partner-only endpoints under org scope) and to pre-fill
+ * context — never as an authorization decision; the server re-checks everything.
+ * Returns all-null when the token is absent or undecodable; callers must fall
+ * through to server behavior in that case.
+ */
+export function getJwtClaims(): JwtClaims {
+  const token = useAuthStore.getState().tokens?.accessToken;
+  if (!token) return NO_CLAIMS;
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
+    return {
+      scope: payload.scope === 'system' || payload.scope === 'partner' || payload.scope === 'organization' ? payload.scope : null,
+      orgId: typeof payload.orgId === 'string' ? payload.orgId : null,
+      partnerId: typeof payload.partnerId === 'string' ? payload.partnerId : null
+    };
+  } catch {
+    return NO_CLAIMS;
+  }
+}
+```
+
+- [ ] **Step 4: Refactor Sidebar** to `const { scope } = getJwtClaims();` replacing the inline decode (keep the existing `if (scope !== null && scope !== 'partner') return;` behavior). Run Sidebar tests if any.
+- [ ] **Step 5: Run new tests; pass. Commit** `refactor(web): extract JWT claims decode into lib/authScope`
+
+---
+
+### Task 5 (web): HelpPanel Cmd+Shift+H
+
+Bug 4: with Shift held, `e.key` is `'H'`.
+
+**Files:**
+- Modify: `apps/web/src/components/help/HelpPanel.tsx:16`
+- Test: `apps/web/src/components/help/HelpPanel.test.tsx` (create if missing)
+
+- [ ] **Step 1: Failing test:** render, dispatch `new KeyboardEvent('keydown', { key: 'H', metaKey: true, shiftKey: true, bubbles: true })` on window, assert the panel toggles open (mock `useHelpStore` or assert on its state).
+- [ ] **Step 2: Implement:** `if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'h') {`
+- [ ] **Step 3: Tests pass. Commit** `fix(web): Cmd+Shift+H help shortcut matches shifted key`
+
+---
+
+### Task 6 (web): SlaChip renders nothing when no SLA
+
+UX note (explicit in findings): the "–" placeholder on every row reads as broken.
+
+**Files:**
+- Modify: `apps/web/src/components/tickets/SlaChip.tsx:5` → `if (s.kind === 'none') return null;`
+- Test: update `SlaChip.test.tsx` / any queue-list test asserting the "–".
+
+- [ ] **Step 1: Update/write test:** no-SLA ticket renders nothing (`container.firstChild` null).
+- [ ] **Step 2: Implement; run web ticket component tests** (`SlaChip`, `TicketQueueList`, `TicketsPage`) to catch layout assertions on "–".
+- [ ] **Step 3: Commit** `fix(web): drop the misleading SLA dash placeholder`
+
+---
+
+### Task 7 (web): `warning` toast type
+
+Needed by Task 9's partial-success bulk toast.
+
+**Files:**
+- Modify: `apps/web/src/components/shared/Toast.tsx`
+- Test: `apps/web/src/components/shared/Toast.test.tsx` (follow existing tests if present)
+
+- [ ] **Step 1: Failing test:** `showToast({ type: 'warning', message: 'heads up' })` renders with `data-toast-type="warning"`, `role="status"`, and a triangle icon.
+- [ ] **Step 2: Implement:** extend the union `type: 'success' | 'error' | 'undo' | 'warning'`; import `AlertTriangle` from lucide; render branch:
+
+```tsx
+const isWarning = toast.type === 'warning';
+// container className: error styles unchanged; warning gets
+// 'bg-card border-warning/50' ; icon:
+{isError ? <XCircle className="h-4 w-4 shrink-0" />
+  : isWarning ? <AlertTriangle className="h-4 w-4 shrink-0 text-warning" />
+  : <CheckCircle className="h-4 w-4 shrink-0 text-success" />}
+```
+
+- [ ] **Step 3: Tests pass. Commit** `feat(web): warning toast variant`
+
+---
+
+### Task 8 (web): TicketWorkbench — assign select, pending-reason prompt, resolution-note visibility, not-found copy, refresh prop, login next
+
+Bugs 2, 6 (label), 8a, 8c, 5 (workbench half), 8f (workbench call sites), plus the not-found copy UX line.
+
+**Files:**
+- Modify: `apps/web/src/components/tickets/TicketWorkbench.tsx`
+- Test: `apps/web/src/components/tickets/TicketWorkbench.test.tsx`
+
+- [ ] **Step 1: Write failing tests** (use the file's existing fetch-mock style):
+  1. **Assignee select replaces the unassign button.** With detail `{assignedTo: null, assigneeName: null}` and `/users` → `{data:[{id:'u-9',name:'Tech',email:'t@x'}]}`: a `select[data-testid="ticket-workbench-assignee"]` shows value `''` ("Unassigned"); changing it to `u-9` POSTs `/tickets/t-1/assign` with `{assigneeId:'u-9'}`.
+  2. **No bogus unassign:** with `assignedTo: null`, firing `change` with value `''` does NOT call `/assign`.
+  3. **Unassign works:** with `assignedTo:'u-9'`, selecting `''` POSTs `{assigneeId:null}`.
+  4. **MSP staff label:** detail `{assignedTo:'partner-u', assigneeName:null}` and `/users` list not containing `partner-u` → the select shows an option labeled `MSP staff` selected.
+  5. **Degraded mode:** `/users` rejects → no select; when assigned, a button labeled `Assignee: Tech ✕` unassigns on click; when unassigned, a plain `Unassigned` span (no button, no POST possible).
+  6. **Pending prompt:** choosing status `pending` does NOT immediately POST; a form `ticket-workbench-pending-form` appears; typing a reason and submitting POSTs `/status` `{status:'pending', pendingReason:'vendor reply'}`; submitting empty posts `{status:'pending'}` (no pendingReason key).
+  7. **on_hold prompts too** (same form, submit posts `{status:'on_hold'}`).
+  8. **Resolution note hidden after reopen:** detail with `resolutionNote:'fixed'` and `status:'open'` → no "Resolution" rail entry; with `status:'resolved'` → entry shown.
+  9. **Not-found copy:** 404 → text `Ticket not found. It may have been deleted, or you may not have access to it.`
+  10. **refreshToken prop:** rerender with `refreshToken={1}` refetches the ticket (fetch called again).
+- [ ] **Step 2: Run; fail.**
+- [ ] **Step 3: Implement:**
+
+Props: `refreshToken?: number`. Add effect:
+
+```typescript
+// Bulk actions in the queue mutate tickets behind the pane's back; the parent
+// bumps refreshToken after a bulk apply so the detail can't go stale.
+useEffect(() => { if (refreshToken) void load(); }, [refreshToken, load]);
+```
+
+Assignees fetch (once, graceful):
+
+```typescript
+// null = picker hidden (no USERS_READ etc.); degrade to a label + unassign-only button.
+const [assignees, setAssignees] = useState<Array<{ id: string; name: string | null; email: string }> | null>(null);
+useEffect(() => {
+  let cancelled = false;
+  void fetchWithAuth('/users')
+    .then(async (r) => (r.ok ? r.json() : null))
+    .then((body) => {
+      if (cancelled || !body) return;
+      const rows = Array.isArray(body) ? body : (body as { data?: unknown }).data;
+      if (Array.isArray(rows)) setAssignees(rows.filter((u) => u.id));
+    })
+    .catch(() => { /* degraded mode keeps the unassign-only affordance */ });
+  return () => { cancelled = true; };
+}, []);
+```
+
+Replace the unassign button block:
+
+```tsx
+{assignees !== null ? (
+  <select
+    value={ticket.assignedTo ?? ''}
+    onChange={(e) => {
+      const next = e.target.value || null;
+      if (next === (ticket.assignedTo ?? null)) return; // no-op guard: never write a bogus feed entry
+      void mutate('/assign', { assigneeId: next }, next ? 'Assigned' : 'Unassigned');
+    }}
+    className="max-w-[180px] rounded-md border px-2 py-1 text-xs"
+    data-testid="ticket-workbench-assignee"
+    aria-label="Assignee"
+  >
+    <option value="">Unassigned</option>
+    {ticket.assignedTo && !assignees.some((u) => u.id === ticket.assignedTo) && (
+      // Assignee exists but is RLS-invisible to this caller (partner staff seen
+      // from org scope) — show a redacted label instead of pretending unassigned.
+      <option value={ticket.assignedTo}>{ticket.assigneeName ?? 'MSP staff'}</option>
+    )}
+    {assignees.map((u) => <option key={u.id} value={u.id}>{u.name || u.email}</option>)}
+  </select>
+) : ticket.assignedTo ? (
+  <button
+    type="button"
+    onClick={() => void mutate('/assign', { assigneeId: null }, 'Unassigned')}
+    className="rounded-md border px-2 py-1 text-xs hover:bg-muted"
+    data-testid="ticket-workbench-unassign"
+  >
+    Assignee: {ticket.assigneeName ?? 'MSP staff'} ✕
+  </button>
+) : (
+  <span className="rounded-md border px-2 py-1 text-xs text-muted-foreground" data-testid="ticket-workbench-unassigned">Unassigned</span>
+)}
+```
+
+Pending prompt (mirror the resolve form; reset both on `ticketId` change):
+
+```typescript
+const [pendingOpen, setPendingOpen] = useState<'pending' | 'on_hold' | null>(null);
+const [pendingReason, setPendingReason] = useState('');
+
+const onStatusChange = useCallback(async (status: TicketStatus) => {
+  if (status === 'resolved') { setResolveOpen(true); return; }
+  if (status === 'pending' || status === 'on_hold') { setPendingOpen(status); return; }
+  await mutate('/status', { status }, 'Status updated');
+}, [mutate]);
+
+const submitPending = useCallback(async () => {
+  if (!pendingOpen) return;
+  const reason = pendingReason.trim();
+  await mutate('/status', { status: pendingOpen, ...(reason ? { pendingReason: reason } : {}) }, 'Status updated');
+  setPendingOpen(null);
+  setPendingReason('');
+}, [mutate, pendingOpen, pendingReason]);
+```
+
+```tsx
+{pendingOpen && (
+  <div className="mt-2 rounded-md border bg-muted/30 p-2" data-testid="ticket-workbench-pending-form">
+    <label className="text-xs font-medium" htmlFor="pending-reason">
+      What are you waiting on? (optional)
+    </label>
+    <textarea
+      id="pending-reason"
+      value={pendingReason}
+      onChange={(e) => setPendingReason(e.target.value)}
+      rows={2}
+      maxLength={500}
+      className="mt-1 w-full rounded-md border bg-background px-2 py-1.5 text-sm"
+      data-testid="ticket-workbench-pending-reason"
+    />
+    <div className="mt-1.5 flex justify-end gap-2">
+      <button type="button" onClick={() => { setPendingOpen(null); setPendingReason(''); }} className="rounded-md border px-2 py-1 text-xs hover:bg-muted">Cancel</button>
+      <button type="button" onClick={() => void submitPending()} className="rounded-md bg-primary px-2 py-1 text-xs font-medium text-white" data-testid="ticket-workbench-pending-submit">
+        {pendingOpen === 'pending' ? 'Set pending' : 'Put on hold'}
+      </button>
+    </div>
+  </div>
+)}
+```
+
+Rail resolution-note visibility:
+
+```tsx
+{ticket.resolutionNote && (ticket.status === 'resolved' || ticket.status === 'closed') && (
+  <div><dt className="text-xs text-muted-foreground">Resolution</dt><dd>{ticket.resolutionNote}</dd></div>
+)}
+```
+
+Not-found copy: `setError('Ticket not found. It may have been deleted, or you may not have access to it.');`
+
+Login next: every `navigateTo('/login', { replace: true })` in this file becomes `navigateTo(loginPathWithNext(), { replace: true })` — add to `apps/web/src/lib/navigation.ts` (or a sibling) once:
+
+```typescript
+/** Login URL that round-trips the current location through LoginPage's ?next= handling. */
+export function loginPathWithNext(): string {
+  if (typeof window === 'undefined') return '/login';
+  const here = window.location.pathname + window.location.search + window.location.hash;
+  return here && here !== '/' ? `/login?next=${encodeURIComponent(here)}` : '/login';
+}
+```
+
+(Check `apps/web/src/lib/authNext.ts` `getSafeNext` accepts such values — it does for same-origin relative paths.)
+
+- [ ] **Step 4: Run TicketWorkbench tests; all pass. Also run TicketsPage tests (workbench mock shape may need the new prop).**
+- [ ] **Step 5: Commit** `fix(tickets): workbench assignment picker, pending-reason prompt, stale-note/not-found fixes`
+
+---
+
+### Task 9 (web): TicketsPage — org-scope hygiene, bulk partial-outcome toast, pane refresh, queue MSP-staff label
+
+Bugs 8e, 8b, 5 (queue half), 6 (queue label), 8f.
+
+**Files:**
+- Modify: `apps/web/src/components/tickets/TicketsPage.tsx`
+- Modify: `apps/web/src/components/tickets/TicketQueueList.tsx` (only if it renders assignee names)
+- Test: `apps/web/src/components/tickets/TicketsPage.test.tsx`
+
+- [ ] **Step 1: Failing tests:**
+  1. With mocked `getJwtClaims` → `{scope:'organization', orgId:'org-1'}`: no fetch to `/orgs/organizations`; `tickets-filter-org` absent.
+  2. Partner scope with a single org in the response: `tickets-filter-org` absent; with two orgs: present.
+  3. Bulk response `{data:{updated:0, skipped:2, failed:0, total:2, skippedReasons:{OUT_OF_SCOPE:1, INVALID_TRANSITION:1}}}` → `showToast` called with `type:'warning'` and a message containing `0 updated`, `2 skipped`, `out of your scope`, `invalid status change`. No success toast.
+  4. Bulk response `{updated:3, skipped:0, failed:0}` → success toast `3 updated`.
+  5. After a successful bulk apply, the workbench receives an incremented `refreshToken` (assert via the mocked TicketWorkbench's props, or fetch-count on `/tickets/:id` if unmocked).
+- [ ] **Step 2: Run; fail.**
+- [ ] **Step 3: Implement:**
+
+Imports: `import { getJwtClaims } from '@/lib/authScope';`, `loginPathWithNext`.
+
+Options effect — skip the orgs call under org scope (claims may be null pre-token; that case keeps today's behavior and the fetch degrades silently):
+
+```typescript
+const orgScoped = getJwtClaims().scope === 'organization';
+// inside the effect:
+const [orgRes, catRes, userRes] = await Promise.allSettled([
+  orgScoped ? Promise.resolve(null) : fetchWithAuth('/orgs/organizations?limit=100').then(readJson),
+  fetchWithAuth('/ticket-categories').then(readJson),
+  fetchWithAuth('/users').then(readJson)
+]);
+```
+
+Org filter render condition (hides the useless single-org filter too):
+
+```tsx
+{!orgScoped && orgs.length > 1 && (
+  <select ... data-testid="tickets-filter-org" ...>...</select>
+)}
+```
+
+Bulk apply — replace `successMessage` with explicit outcome toasts:
+
+```typescript
+const SKIP_REASON_LABELS: Record<string, string> = {
+  OUT_OF_SCOPE: 'out of your scope',
+  INVALID_TRANSITION: 'invalid status change',
+  ASSIGNEE_NOT_FOUND: 'assignee not found',
+  ASSIGNEE_WRONG_PARTNER: 'assignee belongs to another partner',
+  CONCURRENT_MODIFICATION: 'modified by someone else',
+  TICKET_PARTNER_UNRESOLVABLE: 'ticket partner unresolvable',
+  OTHER: 'other errors'
+};
+```
+
+```typescript
+const result = await runAction<{ data: { updated: number; skipped: number; failed: number; total: number; skippedReasons?: Record<string, number> } }>({
+  request: () => fetchWithAuth('/tickets/bulk', { method: 'POST', body: JSON.stringify(body) }),
+  errorFallback: 'Bulk update failed. Retry.',
+  onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
+});
+const { updated, skipped, failed, skippedReasons } = result.data;
+const missed = skipped + failed;
+if (missed > 0) {
+  const reasons = Object.entries(skippedReasons ?? {})
+    .map(([code, n]) => `${n} ${SKIP_REASON_LABELS[code] ?? code.toLowerCase().replace(/_/g, ' ')}`)
+    .join(', ');
+  showToast({ type: 'warning', message: `${updated} updated, ${missed} skipped${reasons ? ` — ${reasons}` : ''}` });
+} else {
+  showToast({ type: 'success', message: `${updated} updated` });
+}
+clearBulkSelection();
+setPaneRefresh((t) => t + 1);
+void fetchTickets();
+void fetchStats();
+```
+
+Pane refresh: `const [paneRefresh, setPaneRefresh] = useState(0);` and pass `refreshToken={paneRefresh + resolveToken * 0}`… no — pass a dedicated prop: `<TicketWorkbench ticketId={selected.id} refreshToken={paneRefresh} resolveRequestToken={resolveToken} onChanged={...} />`.
+
+Queue-list label: if `TicketQueueList` renders `assigneeName`, apply `t.assigneeName ?? (t.assignedTo ? 'MSP staff' : null)`; if it doesn't render assignees, skip.
+
+Login next: replace `/login` navigations in this file with `loginPathWithNext()`.
+
+- [ ] **Step 4: Run TicketsPage (+ QueueList) tests; pass.**
+- [ ] **Step 5: Commit** `fix(tickets): org-scope queue hygiene, partial-bulk warning toasts, pane refresh after bulk`
+
+---
+
+### Task 10 (web): CreateTicketPage works under org scope
+
+Bug 1 (HIGH) + hierarchy labels in the category select (cheap once parentId is fetched).
+
+**Files:**
+- Modify: `apps/web/src/components/tickets/CreateTicketPage.tsx`
+- Test: `apps/web/src/components/tickets/CreateTicketPage.test.tsx`
+
+- [ ] **Step 1: Failing tests** (mock `@/lib/authScope` per test):
+  1. Org scope (`{scope:'organization', orgId:'org-1'}`): no fetch to `/orgs/organizations`; no org select rendered; device fetch fires for `org-1`; submitting subject-only POSTs `/tickets` with `orgId:'org-1'`.
+  2. Org-scope fallback: claims null but orgs fetch 403s **and** a second `getJwtClaims` call (post-token) returns `orgId` → form still usable. (If awkward to simulate, simply assert: 403 + claims `{scope:'organization',orgId:'org-1'}` → no dead-end error screen.)
+  3. Partner scope unchanged: orgs fetch happens, select rendered, 403/500 → existing `create-ticket-load-error` screen.
+  4. Category options render hierarchy labels: categories `[{id:'p',name:'Hardware',parentId:null},{id:'c',name:'Printers',parentId:'p'}]` → option text `Hardware / Printers` for `c`.
+- [ ] **Step 2: Run; fail.**
+- [ ] **Step 3: Implement:**
+
+```typescript
+interface CategoryOption { id: string; name: string; parentId: string | null }
+const [categories, setCategories] = useState<CategoryOption[]>([]);
+const [orgLocked, setOrgLocked] = useState(false); // org-scoped: org comes from the session, no picker
+
+const loadOptions = useCallback(async () => {
+  setLoadError(false);
+  const claims = getJwtClaims();
+  const orgScoped = claims.scope === 'organization' && !!claims.orgId;
+  try {
+    const [orgRes, catRes] = await Promise.all([
+      // Org-scoped users can't list organizations (and don't need to — the org
+      // is fixed by the session); skip the call instead of dead-ending on 403.
+      orgScoped ? Promise.resolve(null) : fetchWithAuth('/orgs/organizations?limit=100'),
+      fetchWithAuth('/ticket-categories')
+    ]);
+    if (orgScoped) {
+      setOrgId(claims.orgId!);
+      setOrgLocked(true);
+    } else if (orgRes && orgRes.ok) {
+      const b = await orgRes.json();
+      setOrgs((b.data ?? b.organizations ?? []).map((o: { id: string; name: string }) => ({ id: o.id, name: o.name })));
+    } else {
+      // 403 here usually means an org-scoped session whose token landed after
+      // mount — fall back to the claims before declaring failure.
+      const late = getJwtClaims();
+      if (orgRes?.status === 403 && late.scope === 'organization' && late.orgId) {
+        setOrgId(late.orgId);
+        setOrgLocked(true);
+      } else {
+        setLoadError(true);
+        return;
+      }
+    }
+    if (catRes.ok) {
+      const cb = await catRes.json();
+      setCategories(
+        (cb.data ?? [])
+          .filter((c: { isActive: boolean }) => c.isActive)
+          .map((c: { id: string; name: string; parentId: string | null }) => ({ id: c.id, name: c.name, parentId: c.parentId ?? null }))
+      );
+    }
+  } catch {
+    setLoadError(true);
+  }
+}, []);
+```
+
+Render: wrap the Organization field in `{!orgLocked && (<div>…org select…</div>)}`. Category option labels:
+
+```typescript
+const categoryLabel = useMemo(() => {
+  const byId = new Map(categories.map((c) => [c.id, c]));
+  return (c: CategoryOption) => {
+    const parent = c.parentId ? byId.get(c.parentId) : undefined;
+    return parent ? `${parent.name} / ${c.name}` : c.name;
+  };
+}, [categories]);
+```
+
+```tsx
+{categories.map((c) => <option key={c.id} value={c.id}>{categoryLabel(c)}</option>)}
+```
+
+Login next on `onUnauthorized` here too.
+
+- [ ] **Step 4: Run; pass.**
+- [ ] **Step 5: Commit** `fix(tickets): org-scoped users can create tickets in the UI`
+
+---
+
+### Task 11 (web): `/settings/ticketing` — edit, hierarchy, SLA/billing/priority fields
+
+Bug 3. Use the existing `PATCH /ticket-categories/:id` (validators: `ticketCategoryInputSchema` — name, color, parentId, defaultPriority, responseSlaMinutes, resolutionSlaMinutes, defaultBillable, defaultHourlyRate, sortOrder, isActive). Note `defaultHourlyRate` arrives from the API as a **string** (numeric column) and must be sent as a **number|null**.
+
+**Files:**
+- Modify: `apps/web/src/components/settings/TicketCategoriesPage.tsx` (full rework)
+- Test: `apps/web/src/components/settings/TicketCategoriesPage.test.tsx`
+
+**Design:**
+- `Category` interface gains `parentId: string | null`, `defaultBillable: boolean`, `defaultHourlyRate: string | null`, `sortOrder: number`.
+- **Hierarchy display:** order rows parent-first then its children (sorted by `sortOrder`, `name`); indent child names (`pl-6` + `└` prefix or muted parent breadcrumb). Children of inactive/missing parents render at root level (defensive).
+
+```typescript
+function hierarchyOrder(cats: Category[]): Array<Category & { depth: number }> {
+  const roots = cats.filter((c) => !c.parentId || !cats.some((p) => p.id === c.parentId));
+  const childrenOf = (id: string) => cats.filter((c) => c.parentId === id);
+  const out: Array<Category & { depth: number }> = [];
+  for (const r of [...roots].sort((a, b) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name))) {
+    out.push({ ...r, depth: 0 });
+    for (const ch of childrenOf(r.id).sort((a, b) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name))) {
+      out.push({ ...ch, depth: 1 });
+    }
+  }
+  return out;
+}
+```
+
+- **Create form:** name + color + parent select (`None` + active root categories).
+- **Edit:** per-row `Edit` button (`data-testid="ticket-category-edit-<id>"`) opens an inline edit panel below the row (single `editingId` state) with: name (text), color (color input), parent (select excluding self and its children), default priority (select None/low/normal/high/urgent), response SLA minutes + resolution SLA minutes (number inputs, empty → null), billable by default (checkbox), default hourly rate (number input, empty → null). `Save` PATCHes via `runAction` with:
+
+```typescript
+const payload = {
+  name: draft.name.trim(),
+  color: draft.color,
+  parentId: draft.parentId || null,
+  defaultPriority: draft.defaultPriority || null,
+  responseSlaMinutes: draft.responseSlaMinutes === '' ? null : Number(draft.responseSlaMinutes),
+  resolutionSlaMinutes: draft.resolutionSlaMinutes === '' ? null : Number(draft.resolutionSlaMinutes),
+  defaultBillable: draft.defaultBillable,
+  defaultHourlyRate: draft.defaultHourlyRate === '' ? null : Number(draft.defaultHourlyRate)
+};
+```
+
+- **Table columns:** Name (indented), Color swatch, Defaults (e.g. `High · 1h response · 8h resolve · $150/h`, dash when none), Status, actions (Edit / Deactivate). Keep all existing `data-testid`s (`ticket-categories-table`, `ticket-category-row-<id>`, `ticket-category-toggle-<id>`, name/color inputs, create button).
+
+- [ ] **Step 1: Failing tests:**
+  1. Hierarchy: parent + child render in order with the child indented (assert row order + a `data-depth="1"` attr or `└` text).
+  2. Create with parent: choosing a parent POSTs `{name, color, parentId}`.
+  3. Edit flow: click `ticket-category-edit-<id>` → panel shows prefilled values (incl. SLA minutes and hourly rate parsed from string); save PATCHes `/ticket-categories/<id>` with the typed values (numbers, not strings; empty SLA → null).
+  4. Self-exclusion: the parent select inside the edit panel contains neither the category itself nor its children.
+- [ ] **Step 2: Run; fail. Step 3: Implement. Step 4: Run; pass.**
+- [ ] **Step 5: Commit** `feat(tickets): category settings — edit, hierarchy, SLA/billing/priority defaults`
+
+---
+
+### Task 12: Verification sweep
+
+- [ ] Run all touched web test files in one pass: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/components/tickets src/components/settings/TicketCategoriesPage.test.tsx src/components/shared/Toast.test.tsx src/components/help src/lib/authScope.test.ts --root apps/web`
+- [ ] Run API tests: `npx vitest run src/routes/tickets src/routes/ticketCategories.test.ts src/services/ticketService.test.ts --root apps/api`
+- [ ] Type-check both: `npx tsc --noEmit` in `apps/api` (pre-existing errors in `agents.test.ts`/`apiKeyAuth.test.ts` are known) and `apps/web` (`npx astro check` or the repo's web typecheck script if present).
+- [ ] Run `apps/web/src/lib/__tests__/no-silent-mutations.test.ts` (all mutations still flow through `runAction`).
+- [ ] Commit any stragglers.
+
+## Self-review notes
+
+- Spec coverage: bugs 1→T10, 2→T8, 3→T11, 4→T5, 5→T8+T9, 6→T8+T9, 7→T3, 8a→T8, 8b→T7+T9, 8c→T8, 8d→T2, 8e→T9, 8f→T8/T9/T10, 8g→T1; UX one-liners (SLA dash, not-found copy)→T6/T8. Deferred items listed up top.
+- Bulk-to-`pending` sends no reason (service nulls it) — acceptable; the prompt is a single-ticket affordance.
+- `tokens` are not persisted in the auth store, so `getJwtClaims()` can be all-null at first paint; both consumers fall back to server behavior (and CreateTicketPage re-reads claims on 403).


### PR DESCRIPTION
Fixes all 8 bugs (plus two one-line UX items) from the 2026-06-11 ticketing e2e browser-test findings (`docs/superpowers/specs/2026-06-11-ticketing-e2e-findings.md`; plan: `docs/superpowers/plans/2026-06-11-ticketing-e2e-fixes.md`).

**Bug 1 (HIGH) — org-scope users couldn't create tickets in the UI.** `CreateTicketPage` no longer dead-ends on the partner-only `GET /orgs/organizations` 403: under org scope it skips the call, locks the org from the JWT claims (new `lib/authScope.ts` helper, extracted from Sidebar's inline decode), and hides the org select. Includes a late-token 403 fallback.

**Bug 2 — workbench had no assign affordance** (the "Unassigned" button was hardwired to unassign, writing bogus feed entries). Replaced with an assignee select (`/users`-fed, graceful degradation when that fetch fails) with a no-op guard.

**Bug 3 — `/settings/ticketing` was a stub.** Now a real category manager: hierarchy display (parent → indented children), parent picker on create/edit, inline edit panel with default priority, response/resolution SLA minutes, billable flag and hourly rate against the existing PATCH endpoint, NaN guard, labeled inputs, enrolled in `no-silent-mutations`.

**Bug 4 — Cmd+Shift+H was dead.** `e.key.toLowerCase() === 'h'` (Shift yields `'H'`).

**Bug 5 — detail pane went stale after bulk actions.** `TicketsPage` bumps a `refreshToken` prop that makes `TicketWorkbench` refetch.

**Bug 6 — partner-staff assignees displayed as "Unassigned" to org users** (users-table RLS hides the name). The workbench now shows a redacted "MSP staff" label.

**Bug 7 — `GET /ticket-categories` returned `[]` under org scope.** The org branch's category read now runs in a system DB context (same pattern as `ticketService.assertCategoryInPartner`, commit precedent 1137a7e2) with the server-derived partnerId filter as the boundary. Product call per findings: org users get read-only visibility of their MSP's catalog; write routes stay partner/system.

**Bug 8 (minors):** pending/on_hold now prompt for an optional reason (API already stored it) • bulk partial outcomes render a warning-styled toast with `skippedReasons` breakdown (new `warning` toast variant) • stale "Resolution" rail note hidden unless resolved/closed • technician-created tickets default the requester to the acting user (was "Unknown") • org filter hidden under org scope and for single-org partners; org-scope sessions no longer 403-spam `/orgs/organizations` • login redirects round-trip the current location via `?next=` • `PATCH /tickets/:id {status}` now answers with a pointer to `POST /tickets/:id/status` instead of "No fields to update".

**UX one-liners from the findings:** SlaChip renders nothing instead of a "–" on every row (separator follows suit); not-found copy now reads "…or you may not have access to it."

**Deliberately deferred (UX notes, not bugs):** queue sort control, device-select search/grouping, sticky composer tab, cross-tab bulk selection, site-restricted banner, feed old→new for field edits.

**Tests:** API 156 passing (tickets routes 74, service 54, categories 28); web 240 passing across tickets/settings/toast/help/authScope/layout incl. 40+ new cases; `tsc --noEmit` clean on both apps. Each task was implemented TDD with spec + quality reviews; review findings (dangling SLA separator, vacuous no-op-guard test, NaN payload guard, a11y labels, keyed fragments) are fixed in the `polish(...)` commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)