### PR TITLE
feat(ai): PAM Brain elevation tools — request/revoke/get_elevation_history (#1160)

### DIFF
--- a/apps/api/src/services/aiToolSchemas.ts
+++ b/apps/api/src/services/aiToolSchemas.ts
@@ -104,6 +104,29 @@ export const toolInputSchemas: Record<string, z.ZodType> = {
     deviceId: uuid,
   }),
 
+  // PAM Brain elevation tools (#1160). durationMinutes/limit are intentionally
+  // un-capped here — the handlers clamp them (480 / 100) so the Brain can pass a
+  // larger value without a validation failure.
+  request_elevation: z.object({
+    deviceId: uuid,
+    subjectUsername: z.string().min(1).max(255),
+    reason: z.string().min(1).max(2000),
+    durationMinutes: z.number().int().min(1).optional(),
+    subjectAdGroups: z.array(z.string().min(1).max(255)).max(200).optional(),
+  }),
+
+  revoke_elevation: z.object({
+    elevationRequestId: uuid,
+    reason: z.string().min(1).max(2000),
+  }),
+
+  get_elevation_history: z.object({
+    deviceId: uuid.optional(),
+    status: z.enum(['pending', 'approved', 'auto_approved', 'denied', 'expired', 'revoked', 'actuating']).optional(),
+    flowType: z.enum(['uac_intercept', 'tech_jit_admin', 'ai_tool_action']).optional(),
+    limit: z.number().int().min(1).optional(),
+  }),
+
   get_ip_history: z.object({
     device_id: uuid.optional(),
     ip_address: ipAddress.optional(),

--- a/apps/api/src/services/aiTools.ts
+++ b/apps/api/src/services/aiTools.ts
@@ -56,6 +56,7 @@ import { registerRemoteTools } from './aiToolsRemote';
 import { registerAgentMgmtTools } from './aiToolsAgentMgmt';
 import { registerUITools } from './aiToolsUI';
 import { registerTicketingTools } from './aiToolsTicketing';
+import { registerPamTools } from './aiToolsPam';
 // M365 helpdesk tools are session-aware (handler signature includes a sessionId)
 // so they are NOT registered in the `aiTools` execution registry — they run via
 // makeSessionAwareHandler in the SDK server. Their tiers still must be visible to
@@ -238,6 +239,7 @@ registerDocsTools(aiTools);
 registerRemoteTools(aiTools);
 registerAgentMgmtTools(aiTools);
 registerUITools(aiTools);
+registerPamTools(aiTools);
 
 // ============================================
 // Exports

--- a/apps/api/src/services/aiToolsPam.test.ts
+++ b/apps/api/src/services/aiToolsPam.test.ts
@@ -1,0 +1,476 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    transaction: vi.fn(),
+  },
+}));
+
+vi.mock('./eventBus', () => ({
+  publishEvent: vi.fn(),
+}));
+
+import { db } from '../db';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+import { validateToolInput } from './aiToolSchemas';
+import { publishEvent } from './eventBus';
+import { registerPamTools } from './aiToolsPam';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const SITE_ID = '22222222-2222-2222-2222-222222222222';
+const DEVICE_ID = '33333333-3333-3333-3333-333333333333';
+const PARTNER_ID = '44444444-4444-4444-8444-444444444444';
+const REQUEST_ID = '55555555-5555-4555-8555-555555555555';
+const RULE_ID = '66666666-6666-4666-8666-666666666666';
+
+const EXPECTED_TOOLS = [
+  'request_elevation',
+  'revoke_elevation',
+  'get_elevation_history',
+] as const;
+
+const EXPECTED_TIERS: Record<(typeof EXPECTED_TOOLS)[number], number> = {
+  request_elevation: 3,
+  revoke_elevation: 2,
+  get_elevation_history: 1,
+};
+
+function createQueryChain(rows: any[] = []) {
+  const chain: any = {};
+  chain.from = vi.fn(() => chain);
+  chain.innerJoin = vi.fn(() => chain);
+  chain.leftJoin = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.groupBy = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.offset = vi.fn(() => chain);
+  chain.then = (resolve: (value: any[]) => unknown, reject?: (error: unknown) => unknown) =>
+    Promise.resolve(rows).then(resolve, reject);
+  return chain;
+}
+
+function createInsertChain(rows: any[] = []) {
+  const chain: any = {};
+  chain.values = vi.fn(() => chain);
+  chain.returning = vi.fn(() => Promise.resolve(rows));
+  chain.then = (resolve: (value: any) => unknown, reject?: (error: unknown) => unknown) =>
+    Promise.resolve(rows).then(resolve, reject);
+  return chain;
+}
+
+function createUpdateChain(rows: any[] = []) {
+  const chain: any = {};
+  chain.set = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.returning = vi.fn(() => Promise.resolve(rows));
+  chain.then = (resolve: (value: any[]) => unknown, reject?: (error: unknown) => unknown) =>
+    Promise.resolve(rows).then(resolve, reject);
+  return chain;
+}
+
+function setDefaultDbMocks() {
+  vi.mocked(db.select).mockImplementation(() => createQueryChain([]) as any);
+  vi.mocked(db.insert).mockImplementation(() => createInsertChain([]) as any);
+  vi.mocked(db.update).mockImplementation(() => createUpdateChain([]) as any);
+  vi.mocked(db.delete).mockImplementation(() => createQueryChain([]) as any);
+  vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(db));
+  vi.mocked(publishEvent).mockResolvedValue('event-1');
+}
+
+function mockSelectSequence(rowsList: any[][]) {
+  let index = 0;
+  vi.mocked(db.select).mockImplementation(() => createQueryChain(rowsList[index++] ?? []) as any);
+}
+
+function mockInsertSequence(rowsList: any[][]) {
+  let index = 0;
+  vi.mocked(db.insert).mockImplementation(() => createInsertChain(rowsList[index++] ?? []) as any);
+}
+
+function makeAuth(): AuthContext {
+  return {
+    user: { id: 'user-1', email: 'test@example.com', name: 'Test User', isPlatformAdmin: false },
+    token: {} as any,
+    partnerId: PARTNER_ID,
+    orgId: ORG_ID,
+    scope: 'organization',
+    accessibleOrgIds: [ORG_ID],
+    canAccessOrg: (orgId: string) => orgId === ORG_ID,
+    canAccessSite: (siteId: string | null | undefined) => siteId === SITE_ID,
+    orgCondition: vi.fn(() => undefined),
+  } as any;
+}
+
+function buildToolMap(): Map<string, AiTool> {
+  const toolMap = new Map<string, AiTool>();
+  registerPamTools(toolMap);
+  return toolMap;
+}
+
+function deviceRow() {
+  return {
+    id: DEVICE_ID,
+    orgId: ORG_ID,
+    siteId: SITE_ID,
+    partnerId: PARTNER_ID,
+  };
+}
+
+function pamRule(verdict: 'auto_approve' | 'auto_deny' | 'require_approval' | 'ignore') {
+  return {
+    id: RULE_ID,
+    orgId: ORG_ID,
+    siteId: null,
+    name: `${verdict} rule`,
+    enabled: true,
+    priority: 10,
+    matchSigner: null,
+    matchHash: null,
+    matchPathGlob: null,
+    matchParentImage: null,
+    matchUser: 'localadmin',
+    matchAdGroup: null,
+    matchToolName: null,
+    matchRiskTier: null,
+    timeWindow: null,
+    verdict,
+    approvalDurationMinutes: null,
+    createdAt: new Date('2026-06-01T00:00:00.000Z'),
+  };
+}
+
+describe('registerPamTools', () => {
+  let toolMap: Map<string, AiTool>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setDefaultDbMocks();
+    toolMap = buildToolMap();
+  });
+
+  it('registers all expected PAM Brain tools', () => {
+    expect(toolMap.size).toBe(EXPECTED_TOOLS.length);
+    expect(Array.from(toolMap.keys()).sort()).toEqual([...EXPECTED_TOOLS].sort());
+  });
+
+  it.each(Object.entries(EXPECTED_TIERS))('assigns tier %s -> %s', (toolName, tier) => {
+    expect(toolMap.get(toolName)!.tier).toBe(tier);
+  });
+
+  it('declares deviceArgs for tools that take a deviceId', () => {
+    expect(toolMap.get('request_elevation')!.deviceArgs).toEqual(['deviceId']);
+    expect(toolMap.get('get_elevation_history')!.deviceArgs).toEqual(['deviceId']);
+    expect(toolMap.get('revoke_elevation')!.deviceArgs ?? []).toEqual([]);
+  });
+
+  it.each([
+    ['request_elevation', { deviceId: DEVICE_ID, subjectUsername: 'localadmin', reason: 'Patch', durationMinutes: 999 }],
+    ['revoke_elevation', { elevationRequestId: REQUEST_ID, reason: 'No longer needed' }],
+    ['get_elevation_history', { deviceId: DEVICE_ID, status: 'pending', flowType: 'tech_jit_admin', limit: 500 }],
+  ])('accepts valid input for %s', (toolName, input) => {
+    expect(validateToolInput(toolName, input as Record<string, unknown>)).toEqual({ success: true });
+  });
+
+  it.each([
+    ['request_elevation', { deviceId: 'not-a-uuid', subjectUsername: 'localadmin', reason: 'Patch' }],
+    ['request_elevation', { deviceId: DEVICE_ID, reason: 'Patch' }],
+    ['revoke_elevation', { elevationRequestId: REQUEST_ID }],
+    ['get_elevation_history', { deviceId: 'not-a-uuid' }],
+  ])('rejects invalid input for %s', (toolName, input) => {
+    const result = validateToolInput(toolName, input as Record<string, unknown>);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('aiToolsPam handlers', () => {
+  let toolMap: Map<string, AiTool>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setDefaultDbMocks();
+    toolMap = buildToolMap();
+  });
+
+  it.each([
+    ['request_elevation', { deviceId: DEVICE_ID, subjectUsername: 'localadmin', reason: 'Install driver' }],
+    ['revoke_elevation', { elevationRequestId: REQUEST_ID, reason: 'No longer needed' }],
+    ['get_elevation_history', { deviceId: DEVICE_ID }],
+  ])('%s handler returns a JSON string', async (toolName, input) => {
+    if (toolName === 'request_elevation') {
+      mockSelectSequence([[deviceRow()], []]);
+      mockInsertSequence([[{ id: REQUEST_ID, status: 'pending', expiresAt: null }], []]);
+    } else if (toolName === 'revoke_elevation') {
+      mockSelectSequence([[{ id: REQUEST_ID, orgId: ORG_ID, deviceId: DEVICE_ID, flowType: 'tech_jit_admin', status: 'approved' }]]);
+      vi.mocked(db.update).mockImplementation(() => createUpdateChain([{ id: REQUEST_ID }]) as any);
+    } else {
+      mockSelectSequence([[{ id: REQUEST_ID, deviceId: DEVICE_ID, status: 'pending', flowType: 'tech_jit_admin', subjectUsername: 'localadmin', reason: 'Install driver', requestedAt: new Date(), expiresAt: null }]]);
+    }
+
+    const result = await toolMap.get(toolName)!.handler(input as Record<string, unknown>, makeAuth());
+    expect(typeof result).toBe('string');
+    expect(() => JSON.parse(result)).not.toThrow();
+  });
+
+  it('creates a pending Brain elevation request when no PAM rule matches', async () => {
+    mockSelectSequence([[deviceRow()], []]);
+    mockInsertSequence([[{ id: REQUEST_ID, status: 'pending', expiresAt: null }], []]);
+
+    const result = await toolMap.get('request_elevation')!.handler(
+      { deviceId: DEVICE_ID, subjectUsername: 'localadmin', reason: 'Install driver' },
+      makeAuth(),
+    );
+    const parsed = JSON.parse(result);
+    const requestInsert = vi.mocked(db.insert).mock.results[0]!.value;
+    const requestValues = requestInsert.values.mock.calls[0]![0];
+
+    expect(parsed).toMatchObject({ elevationRequestId: REQUEST_ID, status: 'pending' });
+    expect(requestValues).toMatchObject({
+      orgId: ORG_ID,
+      siteId: SITE_ID,
+      partnerId: PARTNER_ID,
+      deviceId: DEVICE_ID,
+      flowType: 'tech_jit_admin',
+      subjectUsername: 'localadmin',
+      reason: 'Install driver',
+      status: 'pending',
+      metadata: expect.objectContaining({
+        triggerSource: 'brain',
+        requestedByUserId: 'user-1',
+      }),
+    });
+    expect(requestValues.metadata).not.toHaveProperty('trigger_source');
+    expect(publishEvent).toHaveBeenCalledWith(
+      'elevation.requested',
+      ORG_ID,
+      expect.objectContaining({
+        elevationRequestId: REQUEST_ID,
+        deviceId: DEVICE_ID,
+        flowType: 'tech_jit_admin',
+        status: 'pending',
+        subjectUsername: 'localadmin',
+        triggerSource: 'brain',
+      }),
+      'brain',
+    );
+  });
+
+  it('auto-approves a request when an auto_approve PAM rule matches', async () => {
+    mockSelectSequence([[deviceRow()], [pamRule('auto_approve')]]);
+    mockInsertSequence([[{ id: REQUEST_ID, status: 'auto_approved', expiresAt: new Date('2026-06-11T00:30:00.000Z') }], []]);
+
+    const result = await toolMap.get('request_elevation')!.handler(
+      { deviceId: DEVICE_ID, subjectUsername: 'localadmin', reason: 'Patch', durationMinutes: 30 },
+      makeAuth(),
+    );
+    const parsed = JSON.parse(result);
+    const requestInsert = vi.mocked(db.insert).mock.results[0]!.value;
+    const requestValues = requestInsert.values.mock.calls[0]![0];
+    const auditInsert = vi.mocked(db.insert).mock.results[1]!.value;
+    const auditValues = auditInsert.values.mock.calls[0]![0];
+
+    expect(parsed.status).toBe('auto_approved');
+    expect(parsed.expiresAt).toBeTruthy();
+    expect(requestValues.status).toBe('auto_approved');
+    expect(requestValues.approvedAt).toBeInstanceOf(Date);
+    expect(requestValues.expiresAt).toBeInstanceOf(Date);
+    expect(requestValues.metadata).toMatchObject({ triggerSource: 'brain', pamRuleId: RULE_ID });
+    expect(auditValues.map((r: any) => r.eventType)).toEqual(['requested', 'auto_approved']);
+    expect(auditValues[0].actor).toBe('system');
+    expect(auditValues[1].actor).toBe('policy');
+    expect(publishEvent).toHaveBeenCalledWith(
+      'elevation.auto_approved',
+      ORG_ID,
+      expect.objectContaining({ elevationRequestId: REQUEST_ID, pamRuleId: RULE_ID, triggerSource: 'brain' }),
+      'brain',
+    );
+  });
+
+  it('denies a request when an auto_deny PAM rule matches', async () => {
+    mockSelectSequence([[deviceRow()], [pamRule('auto_deny')]]);
+    mockInsertSequence([[{ id: REQUEST_ID, status: 'denied', expiresAt: null }], []]);
+
+    const result = await toolMap.get('request_elevation')!.handler(
+      { deviceId: DEVICE_ID, subjectUsername: 'localadmin', reason: 'Patch' },
+      makeAuth(),
+    );
+    const parsed = JSON.parse(result);
+    const requestInsert = vi.mocked(db.insert).mock.results[0]!.value;
+    const requestValues = requestInsert.values.mock.calls[0]![0];
+    const auditInsert = vi.mocked(db.insert).mock.results[1]!.value;
+    const auditValues = auditInsert.values.mock.calls[0]![0];
+
+    expect(parsed.status).toBe('denied');
+    expect(requestValues).toMatchObject({
+      status: 'denied',
+      denialReason: 'Blocked by PAM rule "auto_deny rule"',
+    });
+    expect(auditValues.map((r: any) => r.eventType)).toEqual(['requested', 'denied']);
+    expect(auditValues[1].actor).toBe('policy');
+    expect(publishEvent).toHaveBeenCalledWith(
+      'elevation.denied',
+      ORG_ID,
+      expect.objectContaining({ elevationRequestId: REQUEST_ID, pamRuleId: RULE_ID, triggerSource: 'brain' }),
+      'brain',
+    );
+  });
+
+  it('honors orgCondition while creating Brain elevation requests', async () => {
+    mockSelectSequence([[deviceRow()], []]);
+    mockInsertSequence([[{ id: REQUEST_ID, status: 'pending', expiresAt: null }], []]);
+    const auth = makeAuth();
+
+    await toolMap.get('request_elevation')!.handler(
+      { deviceId: DEVICE_ID, subjectUsername: 'localadmin', reason: 'Install driver' },
+      auth,
+    );
+
+    expect(auth.orgCondition).toHaveBeenCalled();
+  });
+
+  it('revokes an active elevation request with CAS, audit, and event', async () => {
+    mockSelectSequence([[{ id: REQUEST_ID, orgId: ORG_ID, deviceId: DEVICE_ID, flowType: 'tech_jit_admin', status: 'approved' }]]);
+    vi.mocked(db.update).mockImplementation(() => createUpdateChain([{ id: REQUEST_ID }]) as any);
+    mockInsertSequence([[]]);
+
+    const result = await toolMap.get('revoke_elevation')!.handler(
+      { elevationRequestId: REQUEST_ID, reason: 'No longer needed' },
+      makeAuth(),
+    );
+    const parsed = JSON.parse(result);
+    const updateChain = vi.mocked(db.update).mock.results[0]!.value;
+    const updateValues = updateChain.set.mock.calls[0]![0];
+    const auditChain = vi.mocked(db.insert).mock.results[0]!.value;
+    const auditValues = auditChain.values.mock.calls[0]![0];
+
+    expect(parsed).toEqual({ elevationRequestId: REQUEST_ID, status: 'revoked' });
+    expect(updateValues).toMatchObject({
+      status: 'revoked',
+      revokedByUserId: 'user-1',
+      revokedReason: 'No longer needed',
+    });
+    expect(auditValues).toMatchObject({
+      orgId: ORG_ID,
+      elevationRequestId: REQUEST_ID,
+      eventType: 'revoked',
+      actor: 'system',
+      actorUserId: 'user-1',
+      details: { reason: 'No longer needed', triggerSource: 'brain' },
+    });
+    expect(publishEvent).toHaveBeenCalledWith(
+      'elevation.revoked',
+      ORG_ID,
+      expect.objectContaining({
+        elevationRequestId: REQUEST_ID,
+        deviceId: DEVICE_ID,
+        flowType: 'tech_jit_admin',
+        status: 'revoked',
+        triggerSource: 'brain',
+      }),
+      'brain',
+    );
+  });
+
+  it.each(['pending', 'denied', 'expired'])('refuses to revoke a %s elevation request', async (status) => {
+    mockSelectSequence([[{ id: REQUEST_ID, orgId: ORG_ID, deviceId: DEVICE_ID, flowType: 'tech_jit_admin', status }]]);
+    vi.mocked(db.update).mockImplementation(() => createUpdateChain([]) as any);
+
+    const result = await toolMap.get('revoke_elevation')!.handler(
+      { elevationRequestId: REQUEST_ID, reason: 'No longer needed' },
+      makeAuth(),
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.error).toContain(`current status: ${status}`);
+    expect(publishEvent).not.toHaveBeenCalled();
+  });
+
+  it('refuses to revoke a request whose site is outside the caller allowlist', async () => {
+    mockSelectSequence([[{ id: REQUEST_ID, orgId: ORG_ID, siteId: 'ffffffff-ffff-4fff-8fff-ffffffffffff', deviceId: DEVICE_ID, flowType: 'tech_jit_admin', status: 'approved' }]]);
+    vi.mocked(db.update).mockImplementation(() => createUpdateChain([{ id: REQUEST_ID }]) as any);
+
+    const result = await toolMap.get('revoke_elevation')!.handler(
+      { elevationRequestId: REQUEST_ID, reason: 'No longer needed' },
+      makeAuth(),
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.error).toContain('not found or access denied');
+    expect(db.update).not.toHaveBeenCalled();
+    expect(publishEvent).not.toHaveBeenCalled();
+  });
+
+  it('honors orgCondition while revoking elevation requests', async () => {
+    mockSelectSequence([[{ id: REQUEST_ID, orgId: ORG_ID, deviceId: DEVICE_ID, flowType: 'tech_jit_admin', status: 'approved' }]]);
+    vi.mocked(db.update).mockImplementation(() => createUpdateChain([{ id: REQUEST_ID }]) as any);
+    const auth = makeAuth();
+
+    await toolMap.get('revoke_elevation')!.handler(
+      { elevationRequestId: REQUEST_ID, reason: 'No longer needed' },
+      auth,
+    );
+
+    expect(auth.orgCondition).toHaveBeenCalled();
+  });
+
+  it('returns compact history rows with filters and limit clamp', async () => {
+    const requestedAt = new Date('2026-06-11T00:00:00.000Z');
+    mockSelectSequence([[
+      {
+        id: REQUEST_ID,
+        deviceId: DEVICE_ID,
+        status: 'pending',
+        flowType: 'tech_jit_admin',
+        subjectUsername: 'localadmin',
+        reason: 'Install driver',
+        requestedAt,
+        approvedAt: null,
+        expiresAt: null,
+        revokedAt: null,
+        denialReason: null,
+        revokedReason: null,
+        metadata: { triggerSource: 'brain' },
+      },
+    ]]);
+    const auth = makeAuth();
+
+    const result = await toolMap.get('get_elevation_history')!.handler(
+      { deviceId: DEVICE_ID, status: 'pending', flowType: 'tech_jit_admin', limit: 500 },
+      auth,
+    );
+    const parsed = JSON.parse(result);
+    const selectChain = vi.mocked(db.select).mock.results[0]!.value;
+
+    expect(parsed).toEqual([
+      expect.objectContaining({
+        elevationRequestId: REQUEST_ID,
+        deviceId: DEVICE_ID,
+        status: 'pending',
+        flowType: 'tech_jit_admin',
+        subjectUsername: 'localadmin',
+        requestedAt: requestedAt.toISOString(),
+      }),
+    ]);
+    expect(selectChain.limit).toHaveBeenCalledWith(100);
+    expect(auth.orgCondition).toHaveBeenCalled();
+  });
+
+  it('safeHandler returns error JSON when the handler throws', async () => {
+    vi.mocked(db.select).mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    const result = await toolMap.get('get_elevation_history')!.handler({}, makeAuth());
+    const parsed = JSON.parse(result);
+
+    expect(parsed).toEqual({ error: 'Operation failed. Check server logs for details.' });
+  });
+});

--- a/apps/api/src/services/aiToolsPam.ts
+++ b/apps/api/src/services/aiToolsPam.ts
@@ -1,0 +1,472 @@
+import { and, desc, eq, inArray, isNull, or, type SQL } from 'drizzle-orm';
+import { db } from '../db';
+import {
+  devices,
+  elevationAudit,
+  elevationRequests,
+  organizations,
+  pamRules,
+  type NewElevationAuditEntry,
+} from '../db/schema';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+import { publishEvent, type EventType } from './eventBus';
+import { evaluatePamRules, type PamRuleMatch } from './pamRuleEngine';
+
+// Input schemas for these tools live in the canonical `toolInputSchemas`
+// registry in ./aiToolSchemas (validated centrally by executeTool).
+
+type PamHandler = (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
+type ElevationStatus = 'pending' | 'auto_approved' | 'denied';
+
+const ACTIVE_STATUSES = ['approved', 'auto_approved', 'actuating'] as const;
+const DEFAULT_DURATION_MINUTES = 30;
+
+function orgWhere(auth: AuthContext, orgIdCol: Parameters<AuthContext['orgCondition']>[0]): SQL | undefined {
+  return auth.orgCondition(orgIdCol) ?? undefined;
+}
+
+function safeHandler(toolName: string, fn: PamHandler): PamHandler {
+  return async (input, auth) => {
+    try {
+      return await fn(input, auth);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Internal error';
+      console.error(`[pam:${toolName}] ${err?.constructor?.name ?? 'Error'}:`, message, err);
+      return JSON.stringify({ error: 'Operation failed. Check server logs for details.' });
+    }
+  };
+}
+
+async function safePublish(
+  type: EventType,
+  orgId: string,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  try {
+    await publishEvent(type, orgId, payload, 'brain');
+  } catch (err) {
+    console.error(`[PAM Brain] event publish failed (${type}):`, err);
+  }
+}
+
+function clampNumber(value: unknown, fallback: number, max: number): number {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(Math.max(1, Math.trunc(n)), max);
+}
+
+function toIso(value: unknown): string | null {
+  return value instanceof Date ? value.toISOString() : typeof value === 'string' ? value : null;
+}
+
+async function loadDeviceWithAccess(deviceId: string, auth: AuthContext) {
+  const conditions: SQL[] = [eq(devices.id, deviceId)];
+  const oc = orgWhere(auth, devices.orgId);
+  if (oc) conditions.push(oc);
+
+  const [device] = await db
+    .select({
+      id: devices.id,
+      orgId: devices.orgId,
+      siteId: devices.siteId,
+      partnerId: organizations.partnerId,
+    })
+    .from(devices)
+    .innerJoin(organizations, eq(devices.orgId, organizations.id))
+    .where(and(...conditions))
+    .limit(1);
+
+  if (!device) return null;
+  if (auth.canAccessSite && !auth.canAccessSite(device.siteId)) return null;
+  return device;
+}
+
+async function loadEnabledPamRules(device: { orgId: string; siteId: string | null }, auth: AuthContext) {
+  const conditions: SQL[] = [
+    eq(pamRules.orgId, device.orgId),
+    eq(pamRules.enabled, true),
+    device.siteId
+      ? or(isNull(pamRules.siteId), eq(pamRules.siteId, device.siteId))!
+      : isNull(pamRules.siteId),
+  ];
+  const oc = orgWhere(auth, pamRules.orgId);
+  if (oc) conditions.push(oc);
+
+  return db.select().from(pamRules).where(and(...conditions));
+}
+
+function resolveDecision(
+  ruleMatch: PamRuleMatch | null,
+  requestedDurationMinutes: number,
+): {
+  status: ElevationStatus;
+  expiresAt: Date | null;
+  approvedAt: Date | null;
+  denialReason: string | null;
+  effectiveDurationMinutes: number;
+} {
+  const now = new Date();
+  const effectiveDurationMinutes = clampNumber(
+    ruleMatch?.approvalDurationMinutes ?? requestedDurationMinutes,
+    requestedDurationMinutes,
+    480,
+  );
+
+  if (ruleMatch?.verdict === 'auto_approve') {
+    return {
+      status: 'auto_approved',
+      approvedAt: now,
+      expiresAt: new Date(now.getTime() + effectiveDurationMinutes * 60_000),
+      denialReason: null,
+      effectiveDurationMinutes,
+    };
+  }
+  if (ruleMatch?.verdict === 'auto_deny') {
+    return {
+      status: 'denied',
+      approvedAt: null,
+      expiresAt: null,
+      denialReason: `Blocked by PAM rule "${ruleMatch.ruleName}"`,
+      effectiveDurationMinutes,
+    };
+  }
+  return { status: 'pending', approvedAt: null, expiresAt: null, denialReason: null, effectiveDurationMinutes };
+}
+
+function eventPayload(row: {
+  id: string;
+  deviceId: string;
+  flowType: string;
+  status: string;
+  subjectUsername?: string;
+}, ruleMatch?: PamRuleMatch | null) {
+  return {
+    elevationRequestId: row.id,
+    deviceId: row.deviceId,
+    flowType: row.flowType,
+    status: row.status,
+    ...(row.subjectUsername ? { subjectUsername: row.subjectUsername } : {}),
+    triggerSource: 'brain',
+    ...(ruleMatch ? { pamRuleId: ruleMatch.ruleId } : {}),
+  };
+}
+
+export function registerPamTools(aiTools: Map<string, AiTool>): void {
+  function registerTool(tool: AiTool): void {
+    aiTools.set(tool.definition.name, tool);
+  }
+
+  registerTool({
+    tier: 3,
+    deviceArgs: ['deviceId'],
+    definition: {
+      name: 'request_elevation',
+      description: 'Request a temporary PAM elevation for an OS/user account on a managed device.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          deviceId: { type: 'string', description: 'Target device UUID' },
+          subjectUsername: { type: 'string', description: 'OS or local/domain username to elevate' },
+          reason: { type: 'string', description: 'Reason for the elevation request' },
+          durationMinutes: { type: 'number', description: 'Requested duration in minutes (default 30, max 480)' },
+          subjectAdGroups: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Optional AD/local groups for PAM rule matching',
+          },
+        },
+        required: ['deviceId', 'subjectUsername', 'reason'],
+      },
+    },
+    handler: safeHandler('request_elevation', async (input, auth) => {
+      const deviceId = input.deviceId as string;
+      const subjectUsername = input.subjectUsername as string;
+      const reason = input.reason as string;
+      if (!deviceId || !subjectUsername || !reason) {
+        return JSON.stringify({ error: 'deviceId, subjectUsername, and reason are required' });
+      }
+
+      const device = await loadDeviceWithAccess(deviceId, auth);
+      if (!device) return JSON.stringify({ error: 'Device not found or access denied' });
+
+      const now = new Date();
+      const durationMinutes = clampNumber(input.durationMinutes, DEFAULT_DURATION_MINUTES, 480);
+      const rules = await loadEnabledPamRules(device, auth);
+      const ruleMatch = evaluatePamRules(rules as any, {
+        subjectUsername,
+        subjectAdGroups: Array.isArray(input.subjectAdGroups)
+          ? input.subjectAdGroups.filter((g): g is string => typeof g === 'string')
+          : undefined,
+        at: now,
+      });
+      const decision = resolveDecision(ruleMatch, durationMinutes);
+      const metadata = {
+        triggerSource: 'brain',
+        requestedByUserId: auth.user.id,
+        requestedDurationMinutes: durationMinutes,
+        ...(ruleMatch ? { pamRuleId: ruleMatch.ruleId, pamRuleName: ruleMatch.ruleName } : {}),
+      };
+
+      const [row] = await db
+        .insert(elevationRequests)
+        .values({
+          orgId: device.orgId,
+          siteId: device.siteId ?? null,
+          partnerId: device.partnerId ?? auth.partnerId ?? null,
+          deviceId: device.id,
+          flowType: 'tech_jit_admin',
+          subjectUserId: null,
+          subjectUsername,
+          reason,
+          status: decision.status,
+          requestedAt: now,
+          approvedAt: decision.approvedAt,
+          expiresAt: decision.expiresAt,
+          denialReason: decision.denialReason,
+          metadata,
+        })
+        .returning({
+          id: elevationRequests.id,
+          status: elevationRequests.status,
+          expiresAt: elevationRequests.expiresAt,
+        });
+
+      if (!row) return JSON.stringify({ error: 'Failed to record elevation request' });
+
+      const auditRows: NewElevationAuditEntry[] = [
+        {
+          orgId: device.orgId,
+          elevationRequestId: row.id,
+          eventType: 'requested',
+          actor: 'system',
+          actorUserId: auth.user.id,
+          details: {
+            subjectUsername,
+            reason,
+            triggerSource: 'brain',
+          },
+          occurredAt: now,
+        },
+      ];
+      if (ruleMatch && (decision.status === 'auto_approved' || decision.status === 'denied')) {
+        auditRows.push({
+          orgId: device.orgId,
+          elevationRequestId: row.id,
+          eventType: decision.status,
+          actor: 'policy',
+          details: {
+            pamRuleId: ruleMatch.ruleId,
+            pamRuleName: ruleMatch.ruleName,
+            triggerSource: 'brain',
+            ...(decision.status === 'auto_approved'
+              ? { durationMinutes: decision.effectiveDurationMinutes }
+              : {}),
+          },
+          occurredAt: now,
+        });
+      }
+      await db.insert(elevationAudit).values(auditRows);
+
+      const payload = eventPayload(
+        {
+          id: row.id,
+          deviceId: device.id,
+          flowType: 'tech_jit_admin',
+          status: row.status,
+          subjectUsername,
+        },
+        ruleMatch,
+      );
+      await safePublish('elevation.requested', device.orgId, payload);
+      if (decision.status === 'auto_approved') {
+        await safePublish('elevation.auto_approved', device.orgId, payload);
+      } else if (decision.status === 'denied') {
+        await safePublish('elevation.denied', device.orgId, payload);
+      }
+
+      return JSON.stringify({
+        elevationRequestId: row.id,
+        status: row.status,
+        ...(row.expiresAt ? { expiresAt: toIso(row.expiresAt) } : {}),
+        ...(ruleMatch ? { pamRuleId: ruleMatch.ruleId } : {}),
+      });
+    }),
+  });
+
+  registerTool({
+    tier: 2,
+    definition: {
+      name: 'revoke_elevation',
+      description: 'Revoke an active PAM elevation request.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          elevationRequestId: { type: 'string', description: 'Elevation request UUID to revoke' },
+          reason: { type: 'string', description: 'Reason for revocation' },
+        },
+        required: ['elevationRequestId', 'reason'],
+      },
+    },
+    handler: safeHandler('revoke_elevation', async (input, auth) => {
+      const elevationRequestId = input.elevationRequestId as string;
+      const reason = input.reason as string;
+      if (!elevationRequestId || !reason) {
+        return JSON.stringify({ error: 'elevationRequestId and reason are required' });
+      }
+
+      const now = new Date();
+      const result = await db.transaction(async (tx) => {
+        const conditions: SQL[] = [eq(elevationRequests.id, elevationRequestId)];
+        const oc = orgWhere(auth, elevationRequests.orgId);
+        if (oc) conditions.push(oc);
+
+        const [existing] = await tx
+          .select({
+            id: elevationRequests.id,
+            orgId: elevationRequests.orgId,
+            siteId: elevationRequests.siteId,
+            deviceId: elevationRequests.deviceId,
+            flowType: elevationRequests.flowType,
+            status: elevationRequests.status,
+          })
+          .from(elevationRequests)
+          .where(and(...conditions))
+          .limit(1);
+
+        if (!existing) return { kind: 'not_found' as const };
+        // Site axis (parity with routes/pam.ts revoke): deny a request whose
+        // device site is outside a site-restricted caller's allowlist. Reported
+        // as not_found so it doesn't leak the row's existence.
+        if (auth.canAccessSite && existing.siteId && !auth.canAccessSite(existing.siteId)) {
+          return { kind: 'not_found' as const };
+        }
+
+        const updateConditions: SQL[] = [
+          eq(elevationRequests.id, elevationRequestId),
+          inArray(elevationRequests.status, [...ACTIVE_STATUSES]),
+        ];
+        const updateOrg = orgWhere(auth, elevationRequests.orgId);
+        if (updateOrg) updateConditions.push(updateOrg);
+
+        const updated = await tx
+          .update(elevationRequests)
+          .set({
+            status: 'revoked',
+            revokedAt: now,
+            revokedByUserId: auth.user.id,
+            revokedReason: reason,
+            updatedAt: now,
+          })
+          .where(and(...updateConditions))
+          .returning({ id: elevationRequests.id });
+
+        if (updated.length === 0) {
+          return { kind: 'conflict' as const, currentStatus: existing.status };
+        }
+
+        await tx.insert(elevationAudit).values({
+          orgId: existing.orgId,
+          elevationRequestId: existing.id,
+          eventType: 'revoked',
+          actor: 'system',
+          actorUserId: auth.user.id,
+          details: { reason, triggerSource: 'brain' },
+          occurredAt: now,
+        });
+
+        return { kind: 'ok' as const, row: existing };
+      });
+
+      if (result.kind === 'not_found') {
+        return JSON.stringify({ error: 'Elevation request not found or access denied' });
+      }
+      if (result.kind === 'conflict') {
+        return JSON.stringify({
+          error: `Request is not active (current status: ${result.currentStatus})`,
+        });
+      }
+
+      await safePublish('elevation.revoked', result.row.orgId, {
+        elevationRequestId: result.row.id,
+        deviceId: result.row.deviceId,
+        flowType: result.row.flowType,
+        status: 'revoked',
+        revokedByUserId: auth.user.id,
+        triggerSource: 'brain',
+      });
+
+      return JSON.stringify({ elevationRequestId: result.row.id, status: 'revoked' });
+    }),
+  });
+
+  registerTool({
+    tier: 1,
+    deviceArgs: ['deviceId'],
+    definition: {
+      name: 'get_elevation_history',
+      description: 'List recent PAM elevation requests in the accessible organization scope.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          deviceId: { type: 'string', description: 'Optional target device UUID filter' },
+          status: { type: 'string', description: 'Optional elevation status filter' },
+          flowType: { type: 'string', description: 'Optional elevation flow type filter' },
+          limit: { type: 'number', description: 'Max rows (default 25, max 100)' },
+        },
+        required: [],
+      },
+    },
+    handler: safeHandler('get_elevation_history', async (input, auth) => {
+      const conditions: SQL[] = [];
+      const oc = orgWhere(auth, elevationRequests.orgId);
+      if (oc) conditions.push(oc);
+      if (typeof input.deviceId === 'string') conditions.push(eq(elevationRequests.deviceId, input.deviceId));
+      if (typeof input.status === 'string') conditions.push(eq(elevationRequests.status, input.status as any));
+      if (typeof input.flowType === 'string') conditions.push(eq(elevationRequests.flowType, input.flowType as any));
+
+      const limit = clampNumber(input.limit, 25, 100);
+      const rows = await db
+        .select({
+          id: elevationRequests.id,
+          deviceId: elevationRequests.deviceId,
+          flowType: elevationRequests.flowType,
+          status: elevationRequests.status,
+          subjectUsername: elevationRequests.subjectUsername,
+          reason: elevationRequests.reason,
+          requestedAt: elevationRequests.requestedAt,
+          approvedAt: elevationRequests.approvedAt,
+          expiresAt: elevationRequests.expiresAt,
+          revokedAt: elevationRequests.revokedAt,
+          denialReason: elevationRequests.denialReason,
+          revokedReason: elevationRequests.revokedReason,
+          metadata: elevationRequests.metadata,
+        })
+        .from(elevationRequests)
+        .where(conditions.length > 0 ? and(...conditions) : undefined)
+        .orderBy(desc(elevationRequests.requestedAt))
+        .limit(limit);
+
+      return JSON.stringify(
+        rows.map((row) => ({
+          elevationRequestId: row.id,
+          deviceId: row.deviceId,
+          flowType: row.flowType,
+          status: row.status,
+          subjectUsername: row.subjectUsername,
+          reason: row.reason,
+          requestedAt: toIso(row.requestedAt),
+          approvedAt: toIso(row.approvedAt),
+          expiresAt: toIso(row.expiresAt),
+          revokedAt: toIso(row.revokedAt),
+          denialReason: row.denialReason,
+          revokedReason: row.revokedReason,
+          triggerSource:
+            row.metadata && typeof row.metadata === 'object'
+              ? (row.metadata as Record<string, unknown>).triggerSource
+              : undefined,
+        })),
+      );
+    }),
+  });
+}

--- a/docs/superpowers/plans/2026-06-11-pam-brain-elevation-tools.md
+++ b/docs/superpowers/plans/2026-06-11-pam-brain-elevation-tools.md
@@ -1,0 +1,56 @@
+# Plan: PAM Brain elevation AI tools (#1160)
+
+**Issue:** #1160 — Brain integration: `request_elevation` / `revoke_elevation` / `get_elevation_history` tools
+**Branch:** `feat/pam-brain-elevation-tools`
+**Scope:** Register PAM as a first-class Brain (AI agent) capability so the Brain can request, revoke, and inspect elevations as part of automated workflows. API-only; additive footprint.
+
+## Design decisions (settled — do not re-litigate)
+
+1. **New files only.** `apps/api/src/services/aiToolsPam.ts` (tools) + `aiToolsPam.test.ts` (tests). Register via `registerPamTools(aiTools)` in `apps/api/src/services/aiTools.ts` (one import + one call, alongside the other `registerXTools(aiTools)` lines). No edits to `routes/pam.ts`. No schema migration.
+
+2. **Flow modeling — no new enum, no migration.** Brain elevation requests are written with `flowType = 'tech_jit_admin'` and `metadata = { triggerSource: 'brain', requestedByUserId, requestedByAiSession?, ... }`. There is **no** `trigger_source` column today (verified); record Brain origin in the existing `metadata` jsonb. (Follow-up, out of scope: promote `triggerSource` to a first-class column if querying by it is ever needed.)
+
+3. **Tiers** (matches issue): `get_elevation_history` = 1, `revoke_elevation` = 2, `request_elevation` = 3. Tiers are fixed (not scope-dependent in v1).
+
+4. **Safe default = pending.** `request_elevation` runs the existing `evaluatePamRules` (from `services/pamRuleEngine.ts`) so an org *can* configure auto-approve/auto-deny rules — but **with no matching rule the request is created `pending`** and requires human approval (web `/pam` Requests tab today; mobile path when #1154 lands). Brain-initiated elevation must never silently self-approve. The pending request IS the step-up the issue calls for.
+
+5. **No new approval_requests / MFA plumbing.** Tier gating is handled by the existing guardrail system (these tools are registered in the `aiTools` map, so `getToolTier` resolves their tier automatically). Do not invent new step-up plumbing — that is #1163 governance territory and is not wired for any tool yet.
+
+6. **Tenant scoping.** Declare `deviceArgs: ['deviceId']` on every tool that takes a deviceId, so the central `enforceDeviceArgs` gate runs `verifyDeviceAccess` before the handler. Additionally narrow all queries with `auth.orgCondition(elevationRequests.orgId)`. Use the bare `db` import exactly like the other `aiTools*` services (handlers run inside the request's ambient DB context).
+
+7. **Events + audit.** Reuse `publishEvent` (`services/eventBus.ts`) with a best-effort `safePublish` wrapper (copy the pattern from `routes/pam.ts`). Source string: `'brain'`. Insert `elevation_audit` rows mirroring the patterns in `routes/agents/elevationRequests.ts` and `routes/pam.ts`.
+
+## Tools
+
+### `request_elevation` (tier 3, deviceArgs: ['deviceId'])
+- **Input:** `deviceId` (string, required), `subjectUsername` (string, required — OS/user account to elevate), `reason` (string, required), `durationMinutes` (number, optional, default 30, clamp 1..480), `subjectAdGroups` (string[], optional — for rule matching).
+- **Behavior:**
+  1. `verifyDeviceAccess` (also enforced centrally via deviceArgs).
+  2. Build a `PamRuleCandidate` `{ subjectUsername, subjectAdGroups, at: now }`; load the org's enabled `pam_rules` and call `evaluatePamRules`.
+  3. Map verdict → status: `auto_approve` → `auto_approved` (set `approvedAt`, `expiresAt = now + durationMinutes`), `auto_deny` → `denied` (set `denialReason`), `require_approval`/`ignore`/no-match → `pending`.
+  4. Insert one `elevation_requests` row (orgId, siteId, partnerId, deviceId from the verified device; `flowType='tech_jit_admin'`; `subjectUsername`; `reason`; `status`; `requestedAt=now`; `metadata={triggerSource:'brain', requestedByUserId: auth.user.id, pamRuleId?}`; lifecycle timestamps per verdict).
+  5. Insert `elevation_audit` row `eventType='requested'`, `actor='system'` (+ a second `auto_approved`/`denied` row with `actor='policy'` when a rule fired).
+  6. `safePublish` `elevation.requested` (+ `elevation.auto_approved`/`elevation.denied` when applicable) with `{elevationRequestId, deviceId, flowType, status, subjectUsername, triggerSource:'brain', pamRuleId?}`.
+  7. Return JSON `{ elevationRequestId, status, expiresAt? , ... }`.
+
+### `revoke_elevation` (tier 2, deviceArgs: [])
+- **Input:** `elevationRequestId` (string, required), `reason` (string, required).
+- **Behavior:** CAS update — load the row scoped by `auth.orgCondition`; only transition when `status IN ('approved','auto_approved','actuating')` → `revoked` (set `revokedAt`, `revokedReason`, `revokedByUserId=auth.user.id`). Insert `elevation_audit` `eventType='revoked'`, `actor='system'`. `safePublish` `elevation.revoked`. Mirror the CAS + audit + event logic already in `routes/pam.ts` revoke handler (replicate locally; do **not** refactor the route). Return `{ elevationRequestId, status:'revoked' }` or a clear `{ error }` if not in a revocable state / not found.
+
+### `get_elevation_history` (tier 1, deviceArgs: ['deviceId'] when deviceId provided)
+- **Input:** `deviceId` (string, optional), `status` (string, optional), `flowType` (string, optional), `limit` (number, optional, default 25, clamp 1..100).
+- **Behavior:** Read-only list from `elevation_requests` narrowed by `auth.orgCondition(elevationRequests.orgId)` (+ optional deviceId/status/flowType filters), ordered by `requestedAt desc`, limited. Return JSON array of compact rows. If `deviceId` is supplied it must pass `verifyDeviceAccess` (declare it in `deviceArgs`).
+
+## Tests (`aiToolsPam.test.ts`)
+Mirror `aiToolsHyperv.test.ts`:
+- Registry: all three tools registered, correct tiers (`it.each`).
+- `request_elevation`: returns JSON; inserts a row with `flowType='tech_jit_admin'` + `metadata.triggerSource='brain'`; no-rule-match → `pending`; auto_approve rule → `auto_approved` with `expiresAt`; auto_deny rule → `denied`; emits the right event(s); honors `orgCondition`.
+- `revoke_elevation`: CAS to `revoked` + `elevation.revoked` event; refuses a `pending`/`denied`/`expired` row with an error; honors org scope.
+- `get_elevation_history`: returns JSON array; applies `orgCondition` + filters + limit clamp.
+- Error path: handler throws → safe error JSON (matches the `executeTool` safeHandler convention).
+
+## Cross-cutting checklist
+- Update any registry-count / tier-pinning assertions that break (`aiTools.test.ts`, `helperToolFilter.test.ts`, guardrail tier tests). These Brain tools are **fleet automation, not Helper/device-local** — if `helperToolFilter.ts` has an allowlist, do **not** add them to the Helper-exposed set; update the pinning test to reflect that they exist but are excluded from Helper context.
+- `npx tsc --noEmit` clean (ignore the pre-existing `agents.test.ts` / `apiKeyAuth.test.ts` errors noted in CLAUDE memory).
+- `vitest run aiToolsPam` green; full `aiTools*`-touching suite green.
+- Files stay under the 500-line soft guideline (declarative tool file may run longer).


### PR DESCRIPTION
## Summary

Registers PAM as a first-class **Brain (AI agent)** capability so the Brain can request, revoke, and inspect privileged elevations as part of automated workflows. Closes #1160.

Additive, API-only — a new `aiToolsPam` service, three entries in the `toolInputSchemas` registry, and one line in the `aiTools` hub. **No schema migration, no changes to `routes/pam.ts`.**

| Tool | Tier | Behavior |
|---|---|---|
| `request_elevation` | 3 | Creates a `tech_jit_admin` `elevation_request`; runs `evaluatePamRules` so an org *can* auto-approve/auto-deny, but the safe default with no matching rule is **`pending`** (human approval via `/pam`). Brain-initiated elevation never self-approves. |
| `revoke_elevation` | 2 | CAS revoke of an active request (`approved`/`auto_approved`/`actuating` → `revoked`) + audit + event. Org- and site-axis scoped for parity with the `routes/pam.ts` revoke handler. |
| `get_elevation_history` | 1 | Org-scoped read with `deviceId`/`status`/`flowType` filters and a clamped limit. |

All three emit `elevation.*` events (source `'brain'`, best-effort) and write `elevation_audit` rows (`actor='system'` for the request, `actor='policy'` for a rule-driven decision).

## Two design calls (flagged on the issue)

1. **No `trigger_source` column exists** in `elevation_requests` — the BE-17 doc / Discussion #858 treat it as first-class, but it never shipped. Brain origin is recorded as `flowType='tech_jit_admin'` + `metadata.triggerSource='brain'`. No migration; reversible. Promoting it to a real column is a noted follow-up if we ever need to query by it.
2. **Safe default = `pending`.** The pending request *is* the step-up the issue calls for — it surfaces in the web `/pam` Requests tab today and the mobile approval path once #1154 lands.

Tools are fleet-wide automation and are **excluded from the Helper context** (not added to `HELPER_TOOL_SCOPING`).

## Tenant isolation

Every query is narrowed by `auth.orgCondition(...)`; `request_elevation`/`get_elevation_history` declare `deviceArgs: ['deviceId']` so the central `enforceDeviceArgs` gate runs `verifyDeviceAccess` before the handler. `request_elevation` and `revoke_elevation` both apply the site-axis `canAccessSite` check, matching the human revoke route.

## Testing

- **27 unit tests** in `aiToolsPam.test.ts`: registry/tiers/`deviceArgs`, input-schema accept/reject, pending-default + `auto_approve`/`auto_deny` paths, CAS revoke + non-active refusal + site-axis denial, history filters/clamp, `safeHandler` error path.
- Full `aiTools*` + `helperToolFilter` suite green (**500 tests**), `tsc --noEmit` clean, eslint clean.

Plan/spec: `docs/superpowers/plans/2026-06-11-pam-brain-elevation-tools.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)