### PR TITLE
fix(audit): deferred commit-time chain sealing — stops concurrent-write forks without the #1240 deadlock (#1002)

### DIFF
--- a/apps/api/migrations/2026-06-11-g-audit-chain-table.sql
+++ b/apps/api/migrations/2026-06-11-g-audit-chain-table.sql
@@ -16,7 +16,8 @@
 CREATE TABLE IF NOT EXISTS audit_log_chain (
   chain_seq bigserial PRIMARY KEY,
   audit_id uuid NOT NULL REFERENCES audit_logs(id) ON DELETE CASCADE,
-  org_id uuid REFERENCES organizations(id),
+  -- ON DELETE CASCADE: chain entries are org-scoped metadata; orphans (audit rows removed via replica-role test cleanup or manual clearing) must not block org deletion. GDPR erasure still deletes chain rows explicitly first; audit_logs's own FK still blocks org deletes while audit rows exist.
+  org_id uuid REFERENCES organizations(id) ON DELETE CASCADE,
   content_checksum varchar(128) NOT NULL,
   prev_chain_checksum varchar(128),
   chain_checksum varchar(128) NOT NULL,
@@ -84,14 +85,25 @@ GRANT SELECT, DELETE ON TABLE audit_log_chain TO breeze_audit_admin;
 REVOKE UPDATE ON TABLE audit_log_chain FROM breeze_audit_admin;
 
 -- Append-only enforcement, mirroring audit_log_immutable on audit_logs:
--- DELETE only under the retention GUC; UPDATE is NEVER allowed (no re-anchor
--- exists in this design — rewriting a sealed entry is always tampering).
+-- DELETE only under the retention GUC or via an FK cascade; UPDATE is NEVER
+-- allowed (no re-anchor exists in this design — rewriting a sealed entry is
+-- always tampering).
+--
+-- pg_trigger_depth() > 1 means this DELETE was issued by another trigger —
+-- in practice the RI cascade from a parent-row delete (depth 2), since both
+-- FKs here are ON DELETE CASCADE. Cascades are safe to admit: the audit_logs
+-- parent is itself guarded by its own append-only trigger (so its rows only
+-- die under the retention GUC anyway), and an organizations parent delete is
+-- a total org erasure where blocking orphaned chain rows would be pointless
+-- (GDPR cascade deletes chain rows explicitly first; this branch matters for
+-- orphans left by replica-role test cleanup / manual audit clearing). A
+-- direct SQL DELETE always runs the trigger at depth 1 and stays blocked.
 CREATE OR REPLACE FUNCTION audit_log_chain_immutable() RETURNS trigger
 LANGUAGE plpgsql AS $$
 DECLARE
   allow_retention text := current_setting('breeze.allow_audit_retention', true);
 BEGIN
-  IF TG_OP = 'DELETE' AND allow_retention = '1' THEN
+  IF TG_OP = 'DELETE' AND (allow_retention = '1' OR pg_trigger_depth() > 1) THEN
     RETURN OLD;
   END IF;
 

--- a/apps/api/migrations/2026-06-11-g-audit-chain-table.sql
+++ b/apps/api/migrations/2026-06-11-g-audit-chain-table.sql
@@ -1,0 +1,111 @@
+-- Issue #1002 (part 1 of 2): side table for the audit tamper-evidence chain.
+--
+-- The in-row chain (checksum/prev_checksum on audit_logs, PR #900) forks under
+-- concurrent same-org inserts, and the obvious fix — an advisory lock held in
+-- the BEFORE INSERT trigger — deadlocks against the codebase's two-connection
+-- audit-write pattern (caller-tx insert + logSessionAudit on a separate pooled
+-- connection; see draft PR #1240 and
+-- docs/superpowers/specs/2026-06-11-audit-chain-deferred-sealing-design.md).
+--
+-- Linkage moves into this append-only side table, written by a DEFERRED
+-- commit-time trigger (the -h- migration). chain_seq (bigserial) is the chain
+-- order; per-org subsequences are walked by org_id + chain_seq. The companion
+-- -h- migration installs the seal trigger, backfills existing rows, and
+-- redefines audit_log_verify_chain over this table.
+
+CREATE TABLE IF NOT EXISTS audit_log_chain (
+  chain_seq bigserial PRIMARY KEY,
+  audit_id uuid NOT NULL REFERENCES audit_logs(id) ON DELETE CASCADE,
+  org_id uuid REFERENCES organizations(id),
+  content_checksum varchar(128) NOT NULL,
+  prev_chain_checksum varchar(128),
+  chain_checksum varchar(128) NOT NULL,
+  sealed_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- One seal per audit row; also serves the verify join and the unsealed-row sweep.
+CREATE UNIQUE INDEX IF NOT EXISTS audit_log_chain_audit_id_uniq
+  ON audit_log_chain (audit_id);
+
+-- Head lookup in the seal function: WHERE org_id = $1 (or IS NULL) ORDER BY chain_seq DESC.
+CREATE INDEX IF NOT EXISTS audit_log_chain_org_seq_idx
+  ON audit_log_chain (org_id, chain_seq DESC);
+
+-- Anti-fork hard guarantees (defense-in-depth — e.g. against a future
+-- REPEATABLE READ caller whose commit-time head read could be stale):
+-- (1) no two entries may chain off the same predecessor;
+CREATE UNIQUE INDEX IF NOT EXISTS audit_log_chain_prev_uniq
+  ON audit_log_chain (prev_chain_checksum)
+  WHERE prev_chain_checksum IS NOT NULL;
+-- (2) one genesis (prev IS NULL) per org chain (NULL org = the system chain).
+CREATE UNIQUE INDEX IF NOT EXISTS audit_log_chain_genesis_uniq
+  ON audit_log_chain ((COALESCE(org_id::text, 'NULL')))
+  WHERE prev_chain_checksum IS NULL;
+
+-- RLS: tenancy shape 1 (direct org_id) — the standard four policies, exactly
+-- what rls-coverage.integration.test.ts auto-discovery expects. NULL-org rows
+-- (system chain) are reachable only by system scope, mirroring audit_logs.
+ALTER TABLE audit_log_chain ENABLE ROW LEVEL SECURITY;
+ALTER TABLE audit_log_chain FORCE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname = 'public'
+                 AND tablename = 'audit_log_chain' AND policyname = 'breeze_org_isolation_select') THEN
+    CREATE POLICY breeze_org_isolation_select ON public.audit_log_chain
+      FOR SELECT USING (public.breeze_has_org_access(org_id));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname = 'public'
+                 AND tablename = 'audit_log_chain' AND policyname = 'breeze_org_isolation_insert') THEN
+    CREATE POLICY breeze_org_isolation_insert ON public.audit_log_chain
+      FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname = 'public'
+                 AND tablename = 'audit_log_chain' AND policyname = 'breeze_org_isolation_update') THEN
+    CREATE POLICY breeze_org_isolation_update ON public.audit_log_chain
+      FOR UPDATE USING (public.breeze_has_org_access(org_id))
+      WITH CHECK (public.breeze_has_org_access(org_id));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname = 'public'
+                 AND tablename = 'audit_log_chain' AND policyname = 'breeze_org_isolation_delete') THEN
+    CREATE POLICY breeze_org_isolation_delete ON public.audit_log_chain
+      FOR DELETE USING (public.breeze_has_org_access(org_id));
+  END IF;
+END $$;
+
+-- Privileges: breeze_app may read and append, never mutate. Retention/erasure
+-- DELETE via breeze_audit_admin (post-#915 a separate login credential), gated
+-- additionally by the append-only trigger below. Nobody gets UPDATE: the
+-- design never rewrites a chain entry (verify treats the first surviving
+-- entry's prev as the trusted anchor after retention pruning — see the spec).
+GRANT SELECT, INSERT ON TABLE audit_log_chain TO breeze_app;
+REVOKE UPDATE, DELETE ON TABLE audit_log_chain FROM breeze_app;
+GRANT USAGE ON SEQUENCE audit_log_chain_chain_seq_seq TO breeze_app;
+GRANT SELECT, DELETE ON TABLE audit_log_chain TO breeze_audit_admin;
+REVOKE UPDATE ON TABLE audit_log_chain FROM breeze_audit_admin;
+
+-- Append-only enforcement, mirroring audit_log_immutable on audit_logs:
+-- DELETE only under the retention GUC; UPDATE is NEVER allowed (no re-anchor
+-- exists in this design — rewriting a sealed entry is always tampering).
+CREATE OR REPLACE FUNCTION audit_log_chain_immutable() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+  allow_retention text := current_setting('breeze.allow_audit_retention', true);
+BEGIN
+  IF TG_OP = 'DELETE' AND allow_retention = '1' THEN
+    RETURN OLD;
+  END IF;
+
+  RAISE EXCEPTION USING
+    ERRCODE = 'P0001',
+    MESSAGE = 'audit log chain is append-only',
+    HINT = 'audit_log_chain entries cannot be modified or deleted. Retention pruning and tenant erasure use breeze_audit_admin plus the breeze.allow_audit_retention GUC (DELETE only); see jobs/auditRetention.ts and services/tenantCascade.ts.';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS audit_log_chain_block_update ON audit_log_chain;
+CREATE TRIGGER audit_log_chain_block_update BEFORE UPDATE ON audit_log_chain
+  FOR EACH ROW EXECUTE FUNCTION audit_log_chain_immutable();
+
+DROP TRIGGER IF EXISTS audit_log_chain_block_delete ON audit_log_chain;
+CREATE TRIGGER audit_log_chain_block_delete BEFORE DELETE ON audit_log_chain
+  FOR EACH ROW EXECUTE FUNCTION audit_log_chain_immutable();

--- a/apps/api/migrations/2026-06-11-h-audit-chain-seal-and-verify.sql
+++ b/apps/api/migrations/2026-06-11-h-audit-chain-seal-and-verify.sql
@@ -1,0 +1,182 @@
+-- Issue #1002 (part 2 of 2): deferred commit-time sealing + verify v2.
+--
+-- 1. audit_log_compute_checksum (BEFORE INSERT) becomes content-only: no
+--    predecessor read, no lock, prev_checksum := NULL. Linkage moves to the
+--    audit_log_chain side table (the -g- migration).
+-- 2. audit_log_seal_one(row) appends a chain entry under a per-org advisory
+--    lock; the DEFERRED constraint trigger calls it at COMMIT, so the lock is
+--    held only through commit processing — never across application awaits.
+--    (The held-to-commit variant deadlocks; see draft PR #1240 and the design
+--    spec docs/superpowers/specs/2026-06-11-audit-chain-deferred-sealing-design.md.)
+-- 3. Backfill seals every existing audit row per org in (timestamp, id) order,
+--    ignoring the legacy (possibly forked) prev_checksum values entirely.
+-- 4. audit_log_verify_chain keeps its signature but walks the side table.
+--
+-- Lock namespace 1000200 (from issue #1002) is reserved for this chain lock.
+
+-- (1) Content-only BEFORE INSERT trigger. Reuses audit_log_canonical_payload
+-- from 2026-05-25-c with prev := NULL. convert_to(...,'UTF8'), not ::bytea —
+-- the cast throws on the backslash escapes jsonb details::text emits (#994).
+CREATE OR REPLACE FUNCTION audit_log_compute_checksum() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.prev_checksum := NULL;
+  NEW.checksum := encode(sha256(convert_to(audit_log_canonical_payload(NEW, NULL), 'UTF8')), 'hex');
+  RETURN NEW;
+END;
+$$;
+-- The existing trigger audit_log_chain_checksum (BEFORE INSERT, from -b-)
+-- already points at this function; CREATE OR REPLACE rebinds it in place.
+
+-- (2) Seal one audit row into the chain. Shared by the commit-time trigger and
+-- the backfill loop below. SECURITY INVOKER: runs under the inserting caller's
+-- RLS context — the chain row's org matches the audit row's org, so the
+-- standard shape-1 WITH CHECK passes for exactly the callers that could insert
+-- the audit row in the first place.
+CREATE OR REPLACE FUNCTION audit_log_seal_one(a audit_logs) RETURNS void
+LANGUAGE plpgsql AS $$
+DECLARE
+  prev_chain varchar(128);
+  content varchar(128);
+BEGIN
+  -- Serialize same-org seals. At commit time this is held only through the
+  -- remaining commit processing (sub-ms), so the #1240 two-connection deadlock
+  -- cannot occur. Reentrant for multi-row same-org batches in one tx.
+  PERFORM pg_advisory_xact_lock(1000200, hashtext(COALESCE(a.org_id::text, 'NULL')));
+
+  -- Head lookup, branched on NULL so both arms are index-friendly
+  -- (audit_log_chain_org_seq_idx; btree supports IS NULL scans).
+  IF a.org_id IS NULL THEN
+    SELECT chain_checksum INTO prev_chain
+    FROM audit_log_chain WHERE org_id IS NULL
+    ORDER BY chain_seq DESC LIMIT 1;
+  ELSE
+    SELECT chain_checksum INTO prev_chain
+    FROM audit_log_chain WHERE org_id = a.org_id
+    ORDER BY chain_seq DESC LIMIT 1;
+  END IF;
+
+  -- Content hash recomputed from the row (NOT read from a.checksum): uniform
+  -- for backfilled legacy rows (whose stored checksum is the old chained
+  -- value) and new rows alike, and keeps the chain independent of the
+  -- vestigial in-row columns.
+  content := encode(sha256(convert_to(audit_log_canonical_payload(a, NULL), 'UTF8')), 'hex');
+
+  INSERT INTO audit_log_chain (audit_id, org_id, content_checksum, prev_chain_checksum, chain_checksum)
+  VALUES (
+    a.id,
+    a.org_id,
+    content,
+    prev_chain,
+    encode(sha256(convert_to(COALESCE(prev_chain, '') || '|' || content, 'UTF8')), 'hex')
+  );
+END;
+$$;
+
+-- Commit-time wrapper.
+CREATE OR REPLACE FUNCTION audit_log_seal_chain() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  PERFORM audit_log_seal_one(NEW);
+  RETURN NULL;
+END;
+$$;
+
+-- Constraint triggers are the only trigger kind that can defer to COMMIT.
+DROP TRIGGER IF EXISTS audit_log_chain_seal ON audit_logs;
+CREATE CONSTRAINT TRIGGER audit_log_chain_seal
+  AFTER INSERT ON audit_logs
+  DEFERRABLE INITIALLY DEFERRED
+  FOR EACH ROW EXECUTE FUNCTION audit_log_seal_chain();
+
+-- (3) Backfill: seal every not-yet-sealed audit row, per org, in (timestamp,
+-- id) order. NOT EXISTS guard makes re-application a no-op, and also seals any
+-- straggler rows written by a not-yet-migrated API instance between -g- and
+-- -h- on a rolling deploy.
+DO $$
+DECLARE
+  rec audit_logs;
+BEGIN
+  FOR rec IN
+    SELECT a.* FROM audit_logs a
+    WHERE NOT EXISTS (SELECT 1 FROM audit_log_chain c WHERE c.audit_id = a.id)
+    ORDER BY a.org_id NULLS FIRST, a.timestamp, a.id
+  LOOP
+    PERFORM audit_log_seal_one(rec);
+  END LOOP;
+END $$;
+
+-- (4) Verify v2 — SAME signature as -c- (cron + tests call it unchanged) —
+-- but walks the side table. Flags, in chain_seq order:
+--   linkage break, chain-hash mismatch, content tamper (recomputed from the
+--   live audit row), dangling seal (audit row gone), and finally any UNSEALED
+--   audit row (a deleted chain entry). The FIRST surviving entry's prev is the
+--   trusted anchor: NULL for a virgin chain, or a reference to legitimately
+--   retention-pruned history — there is deliberately no re-anchor rewrite
+--   (rewriting the head's chain_checksum would invalidate its successor's
+--   stored prev; see the design spec).
+CREATE OR REPLACE FUNCTION audit_log_verify_chain(p_org_id uuid)
+RETURNS TABLE (broken_id uuid, expected varchar, actual varchar)
+LANGUAGE plpgsql AS $$
+DECLARE
+  c record;
+  a audit_logs;
+  prev varchar(128) := NULL;
+  is_first boolean := true;
+  expected_hash varchar(128);
+BEGIN
+  FOR c IN
+    SELECT ch.chain_seq, ch.audit_id, ch.content_checksum, ch.prev_chain_checksum, ch.chain_checksum
+    FROM audit_log_chain ch
+    WHERE ch.org_id IS NOT DISTINCT FROM p_org_id
+    ORDER BY ch.chain_seq
+  LOOP
+    -- Linkage. The FIRST surviving entry's prev is the trusted anchor (NULL =
+    -- virgin chain; non-NULL = retention pruned the prefix), so it is not
+    -- compared. Every later entry must reference its immediate predecessor.
+    IF NOT is_first AND c.prev_chain_checksum IS DISTINCT FROM prev THEN
+      broken_id := c.audit_id; expected := prev; actual := c.prev_chain_checksum;
+      RETURN NEXT;
+    END IF;
+    is_first := false;
+
+    -- Chain-hash integrity.
+    expected_hash := encode(sha256(convert_to(
+      COALESCE(c.prev_chain_checksum, '') || '|' || c.content_checksum, 'UTF8')), 'hex');
+    IF c.chain_checksum IS DISTINCT FROM expected_hash THEN
+      broken_id := c.audit_id; expected := expected_hash; actual := c.chain_checksum;
+      RETURN NEXT;
+    END IF;
+
+    -- Content integrity, recomputed from the live audit row.
+    SELECT * INTO a FROM audit_logs WHERE id = c.audit_id;
+    IF NOT FOUND THEN
+      broken_id := c.audit_id; expected := c.content_checksum; actual := NULL;
+      RETURN NEXT;
+    ELSE
+      expected_hash := encode(sha256(convert_to(audit_log_canonical_payload(a, NULL), 'UTF8')), 'hex');
+      IF expected_hash IS DISTINCT FROM c.content_checksum THEN
+        broken_id := c.audit_id; expected := expected_hash; actual := c.content_checksum;
+        RETURN NEXT;
+      END IF;
+    END IF;
+
+    prev := c.chain_checksum;
+  END LOOP;
+
+  -- Unsealed audit rows: every committed row gets a seal atomically, so a
+  -- missing entry means the chain row was deleted (or the seal trigger was
+  -- disabled) — flag it.
+  FOR a IN
+    SELECT al.* FROM audit_logs al
+    WHERE al.org_id IS NOT DISTINCT FROM p_org_id
+      AND NOT EXISTS (SELECT 1 FROM audit_log_chain ch WHERE ch.audit_id = al.id)
+    ORDER BY al.timestamp, al.id
+  LOOP
+    broken_id := a.id;
+    expected := 'sealed';
+    actual := NULL;
+    RETURN NEXT;
+  END LOOP;
+END;
+$$;

--- a/apps/api/src/__tests__/integration/audit-append-only.integration.test.ts
+++ b/apps/api/src/__tests__/integration/audit-append-only.integration.test.ts
@@ -141,7 +141,8 @@ describe('audit_logs append-only enforcement', () => {
     expect(caught).toBeDefined();
     const cause = (caught as { cause?: { message?: string } } | undefined)?.cause
       ?? (caught as { message?: string } | undefined);
-    expect(String(cause?.message)).toMatch(/audit log is append-only/i);
+    // audit_log_chain's FK now rejects plain TRUNCATE before the append-only trigger fires (TRUNCATE ... CASCADE would hit the trigger); either rejection preserves the property.
+    expect(String(cause?.message)).toMatch(/audit log is append-only|cannot truncate a table referenced in a foreign key/i);
 
     // Defense-in-depth: confirm the row survived.
     const rows = (await getTestDb().execute(

--- a/apps/api/src/__tests__/integration/audit-checksum.integration.test.ts
+++ b/apps/api/src/__tests__/integration/audit-checksum.integration.test.ts
@@ -333,6 +333,86 @@ describe('audit_logs checksum chain', () => {
     });
   });
 
+  // Deleting a chain entry (hiding a row from the chain) is flagged by the
+  // unsealed-row sweep.
+  it('verify_chain flags an audit row whose chain entry was deleted', async () => {
+    let targetId = '';
+    await withSystemDbAccessContext(async () => {
+      const rows = (await db.execute(sql`
+        INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result)
+        VALUES (${orgId}, 'system', gen_random_uuid(), 'chain-delete-victim', 'test', 'success')
+        RETURNING id
+      `)) as unknown as Array<{ id: string }>;
+      targetId = rows[0]!.id;
+    });
+
+    // Superuser + trigger disable simulates a DBA-level attacker (same pattern
+    // as the existing UPDATE-tamper test).
+    const sudo = getTestDb();
+    await sudo.execute(sql`ALTER TABLE audit_log_chain DISABLE TRIGGER audit_log_chain_block_delete`);
+    try {
+      await sudo.execute(sql`DELETE FROM audit_log_chain WHERE audit_id = ${targetId}`);
+    } finally {
+      await sudo.execute(sql`ALTER TABLE audit_log_chain ENABLE TRIGGER audit_log_chain_block_delete`);
+    }
+
+    const breaks = (await sudo.execute(sql`
+      SELECT broken_id, expected FROM public.audit_log_verify_chain(${orgId}::uuid)
+    `)) as unknown as Array<{ broken_id: string; expected: string | null }>;
+    // The victim is flagged unsealed; its successor (if any) is flagged for
+    // linkage. At minimum the victim appears.
+    expect(breaks.map((b) => b.broken_id)).toContain(targetId);
+    // Restore chain consistency for subsequent tests in this file: re-seal.
+    await sudo.execute(sql`SELECT audit_log_seal_one(a) FROM audit_logs a WHERE a.id = ${targetId}`);
+  });
+
+  // breeze_app cannot mutate the chain at all (append-only + REVOKE).
+  // Implementation note: we run the mutation attempts OUTSIDE withSystemDbAccessContext
+  // so they hit the breeze_app pool directly (no transaction wrapper). Inside a
+  // withSystemDbAccessContext transaction, a PostgresError aborts the whole transaction
+  // and the outer begin() also rejects, making it impossible to catch just the inner
+  // error cleanly. Running outside the context keeps each rejection self-contained.
+  // The underlying PostgresError message is "permission denied for table audit_log_chain";
+  // Drizzle wraps it in DrizzleQueryError (message: "Failed query: …") with the original
+  // in .cause — we walk the cause chain to match "permission denied" precisely.
+  it('chain table rejects UPDATE/DELETE from app-level SQL', async () => {
+    const expectPermissionDenied = async (promise: Promise<unknown>) => {
+      const err = await promise.then(
+        () => null,
+        (e: unknown) => e,
+      );
+      expect(err).not.toBeNull();
+      // Walk the cause chain: Drizzle wraps the original PostgresError in a
+      // DrizzleQueryError whose .cause holds the real "permission denied" message.
+      const messages: string[] = [];
+      let cur: unknown = err;
+      while (cur instanceof Error) {
+        messages.push(cur.message);
+        cur = (cur as Error & { cause?: unknown }).cause;
+      }
+      const matched = messages.some((m) => /append-only|permission denied/i.test(m));
+      if (!matched) {
+        throw new Error(
+          `Expected "permission denied" or "append-only" in error chain, got:\n` +
+          messages.join('\n  caused by: '),
+        );
+      }
+    };
+
+    // runOutsideDbContext so db resolves to the bare breeze_app pool (no
+    // transaction wrapper). This keeps each rejection self-contained.
+    await runOutsideDbContext(() =>
+      expectPermissionDenied(
+        db.execute(sql`UPDATE audit_log_chain SET chain_checksum = 'forged' WHERE org_id = ${orgId}::uuid`),
+      )
+    );
+    await runOutsideDbContext(() =>
+      expectPermissionDenied(
+        db.execute(sql`DELETE FROM audit_log_chain WHERE org_id = ${orgId}::uuid`),
+      )
+    );
+  });
+
   // Retention prefix-cut: prune old rows, then the chain must still verify
   // clean WITHOUT any re-anchor — the first surviving entry's prev is the
   // trusted anchor. (Chain order is deterministic here because beforeEach

--- a/apps/api/src/__tests__/integration/audit-checksum.integration.test.ts
+++ b/apps/api/src/__tests__/integration/audit-checksum.integration.test.ts
@@ -50,20 +50,45 @@ describe('audit_logs checksum chain', () => {
     });
   });
 
+  // Linkage lives in the audit_log_chain side table since migration
+  // 2026-06-11-h (issue #1002): the in-row prev_checksum is now always NULL
+  // and each row's seal entry chains to the previous seal for its org.
+  // The seal trigger is DEFERRED to COMMIT, so the chain rows are only
+  // visible after the inserting transaction commits — hence the second
+  // withSystemDbAccessContext for the assertions.
   it('each subsequent row chains to the previous within an org', async () => {
+    let aId = '';
+    let bId = '';
     await withSystemDbAccessContext(async () => {
       const a = (await db.execute(sql`
         INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result)
         VALUES (${orgId}, 'system', gen_random_uuid(), 'a', 'test', 'success')
-        RETURNING checksum
-      `)) as unknown as Array<{ checksum: string }>;
+        RETURNING id
+      `)) as unknown as Array<{ id: string }>;
+      aId = a[0]!.id;
       const b = (await db.execute(sql`
         INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result)
         VALUES (${orgId}, 'system', gen_random_uuid(), 'b', 'test', 'success')
-        RETURNING checksum, prev_checksum
-      `)) as unknown as Array<{ checksum: string; prev_checksum: string }>;
-      expect(b[0]!.prev_checksum).toEqual(a[0]!.checksum);
-      expect(b[0]!.checksum).not.toEqual(a[0]!.checksum);
+        RETURNING id
+      `)) as unknown as Array<{ id: string }>;
+      bId = b[0]!.id;
+    });
+
+    await withSystemDbAccessContext(async () => {
+      const seals = (await db.execute(sql`
+        SELECT audit_id, prev_chain_checksum, chain_checksum
+        FROM audit_log_chain
+        WHERE org_id = ${orgId}::uuid
+        ORDER BY chain_seq
+      `)) as unknown as Array<{
+        audit_id: string;
+        prev_chain_checksum: string | null;
+        chain_checksum: string;
+      }>;
+      expect(seals.map((s) => s.audit_id)).toEqual([aId, bId]);
+      expect(seals[0]!.prev_chain_checksum).toBeNull();
+      expect(seals[1]!.prev_chain_checksum).toEqual(seals[0]!.chain_checksum);
+      expect(seals[1]!.chain_checksum).not.toEqual(seals[0]!.chain_checksum);
     });
   });
 
@@ -107,8 +132,9 @@ describe('audit_logs checksum chain', () => {
   // insert order, producing false-positive "breaks" with no actual tampering.
   // Real production audit traffic flows row-per-API-call (separate
   // transactions, distinct timestamps), so this matches the production case.
-  // Fixing the chain to handle same-tx batches robustly requires a chain_seq
-  // bigserial + per-org advisory lock — tracked as future-task hardening.
+  // Same-transaction batches are now handled by the deferred commit-time seal
+  // (migration 2026-06-11-h, issue #1002) — covered by the 'multiple same-org
+  // inserts in ONE transaction' test below.
 
   it('audit_log_verify_chain returns no breaks on a freshly written chain', async () => {
     for (const action of ['a', 'b', 'c']) {

--- a/apps/api/src/__tests__/integration/audit-checksum.integration.test.ts
+++ b/apps/api/src/__tests__/integration/audit-checksum.integration.test.ts
@@ -332,4 +332,64 @@ describe('audit_logs checksum chain', () => {
       expect(breaks).toEqual([]);
     });
   });
+
+  // Retention prefix-cut: prune old rows, then the chain must still verify
+  // clean WITHOUT any re-anchor — the first surviving entry's prev is the
+  // trusted anchor. (Chain order is deterministic here because beforeEach
+  // creates a FRESH org per test, so these three rows are the org's only
+  // chain entries: olds get the lowest chain_seq, the new row the highest.)
+  it('retention prefix-cut prune leaves a clean chain with no re-anchor', async () => {
+    // Three rows: two backdated past any cutoff, one current. Timestamps can
+    // be set explicitly — the BEFORE trigger no longer rewrites them.
+    for (const [action, ts] of [
+      ['retain-old-1', "now() - interval '400 days'"],
+      ['retain-old-2', "now() - interval '399 days'"],
+      ['retain-new', 'now()'],
+    ] as const) {
+      await withSystemDbAccessContext(async () => {
+        await db.execute(sql.raw(`
+          INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result, timestamp)
+          VALUES ('${orgId}', 'system', gen_random_uuid(), '${action}', 'test', 'success', ${ts})
+        `));
+      });
+    }
+
+    // Prune at 365 days as superuser with the retention GUC (mirrors the
+    // audit-admin path; this test pins the SQL semantics, the privsep file
+    // pins the role/pool wiring). MUST run inside ONE transaction — SET LOCAL
+    // and the DELETE have to share a connection, and separate execute() calls
+    // on the pooled client may not (use the drizzle transaction API, never
+    // raw BEGIN/COMMIT executes).
+    const sudo = getTestDb();
+    await sudo.transaction(async (tx) => {
+      await tx.execute(sql`SET LOCAL breeze.allow_audit_retention = '1'`);
+      await tx.execute(sql`
+        DELETE FROM audit_logs
+        WHERE id IN (
+          SELECT c.audit_id FROM audit_log_chain c
+          WHERE c.org_id = ${orgId}
+            AND c.chain_seq < COALESCE(
+              (SELECT MIN(c2.chain_seq) FROM audit_log_chain c2
+               JOIN audit_logs a2 ON a2.id = c2.audit_id
+               WHERE c2.org_id = ${orgId} AND a2.timestamp >= (now() - interval '365 days')),
+              (SELECT MAX(c3.chain_seq) + 1 FROM audit_log_chain c3 WHERE c3.org_id = ${orgId})
+            )
+        )
+      `);
+    });
+
+    await withSystemDbAccessContext(async () => {
+      const old = (await db.execute(sql`
+        SELECT 1 FROM audit_logs WHERE org_id = ${orgId}::uuid AND action LIKE 'retain-old-%'
+      `)) as unknown as unknown[];
+      expect(old).toHaveLength(0);
+
+      // No re-anchor ran: the surviving head still carries a non-NULL prev
+      // pointing at pruned history — and verify must accept it as the anchor.
+      const breaks = (await db.execute(sql`
+        SELECT broken_id FROM public.audit_log_verify_chain(${orgId}::uuid)
+      `)) as unknown as Array<{ broken_id: string }>;
+      expect(breaks).toEqual([]);
+    });
+  });
 });

--- a/apps/api/src/__tests__/integration/audit-checksum.integration.test.ts
+++ b/apps/api/src/__tests__/integration/audit-checksum.integration.test.ts
@@ -22,7 +22,7 @@ import './setup';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { createHash } from 'node:crypto';
 import { sql } from 'drizzle-orm';
-import { db, withSystemDbAccessContext } from '../../db';
+import { db, withSystemDbAccessContext, withDbAccessContext, runOutsideDbContext } from '../../db';
 import { getTestDb } from './setup';
 import { createPartner, createOrganization } from './db-utils';
 
@@ -211,5 +211,99 @@ describe('audit_logs checksum chain', () => {
     `)) as unknown as Array<{ broken_id: string }>;
     expect(breaks.length).toBeGreaterThanOrEqual(1);
     expect(breaks.map(b => b.broken_id)).toContain(inserted[1]!.id);
+  });
+
+  // ——— issue #1002 regression suite ———
+
+  // Fork regression: N independent transactions inserting same-org rows
+  // concurrently. Pre-fix, each reads the same committed head as `prev` and
+  // the chain forks → verify reports false breaks. Post-fix (-h- migration,
+  // deferred commit-time sealing) the seal serializes at commit → 0 breaks.
+  it('verify_chain returns no breaks under concurrent same-org inserts', async () => {
+    const N = 25;
+    await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        withSystemDbAccessContext(async () => {
+          await db.execute(sql`
+            INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result)
+            VALUES (${orgId}, 'system', gen_random_uuid(), ${'concurrent-' + i}, 'test', 'success')
+          `);
+        })
+      )
+    );
+
+    await withSystemDbAccessContext(async () => {
+      const breaks = (await db.execute(sql`
+        SELECT broken_id FROM public.audit_log_verify_chain(${orgId}::uuid)
+      `)) as unknown as Array<{ broken_id: string }>;
+      expect(breaks).toEqual([]);
+    });
+  });
+
+  // Deadlock regression (the bug that killed draft PR #1240): an in-tx audit
+  // insert followed — while that tx is still open — by a same-org insert on a
+  // SEPARATE pooled connection. With any lock held from insert to commit, the
+  // second insert blocks on the first while the first awaits the second: a
+  // JS-level deadlock Postgres can't detect (30s test timeout). With deferred
+  // sealing the first tx holds nothing until commit, so this completes fast.
+  // Generous explicit timeout so a regression fails loudly as a timeout here,
+  // not flakily elsewhere.
+  it('in-tx insert + separate-connection same-org insert does not deadlock', { timeout: 20_000 }, async () => {
+    await expect(
+      withDbAccessContext(
+        { scope: 'organization', orgId, accessibleOrgIds: [orgId] },
+        async () => {
+          await db.execute(sql`
+            INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result)
+            VALUES (${orgId}, 'system', gen_random_uuid(), 'deadlock-caller-tx', 'test', 'success')
+          `);
+          // Escape the caller tx exactly like logSessionAudit does.
+          await runOutsideDbContext(() =>
+            withSystemDbAccessContext(async () => {
+              await db.execute(sql`
+                INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result)
+                VALUES (${orgId}, 'system', gen_random_uuid(), 'deadlock-escaped', 'test', 'success')
+              `);
+            })
+          );
+          throw new Error('simulated caller rollback');
+        }
+      )
+    ).rejects.toThrow('simulated caller rollback');
+
+    await withSystemDbAccessContext(async () => {
+      // The escaped row committed and sealed; the rolled-back row left no
+      // orphan seal; the chain stayed clean.
+      const rows = (await db.execute(sql`
+        SELECT action FROM audit_logs WHERE org_id = ${orgId}::uuid AND action LIKE 'deadlock-%'
+      `)) as unknown as Array<{ action: string }>;
+      expect(rows.map((r) => r.action)).toEqual(['deadlock-escaped']);
+
+      const breaks = (await db.execute(sql`
+        SELECT broken_id FROM public.audit_log_verify_chain(${orgId}::uuid)
+      `)) as unknown as Array<{ broken_id: string }>;
+      expect(breaks).toEqual([]);
+    });
+  });
+
+  // Same-transaction multi-row batches were the OTHER documented limitation of
+  // the in-row chain. Deferred seals fire per row at commit in insertion order
+  // within one lock hold, so batches link correctly.
+  it('multiple same-org inserts in ONE transaction seal in order with no breaks', async () => {
+    await withSystemDbAccessContext(async () => {
+      await db.execute(sql`
+        INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result)
+        VALUES (${orgId}, 'system', gen_random_uuid(), 'batch-1', 'test', 'success'),
+               (${orgId}, 'system', gen_random_uuid(), 'batch-2', 'test', 'success'),
+               (${orgId}, 'system', gen_random_uuid(), 'batch-3', 'test', 'success')
+      `);
+    });
+
+    await withSystemDbAccessContext(async () => {
+      const breaks = (await db.execute(sql`
+        SELECT broken_id FROM public.audit_log_verify_chain(${orgId}::uuid)
+      `)) as unknown as Array<{ broken_id: string }>;
+      expect(breaks).toEqual([]);
+    });
   });
 });

--- a/apps/api/src/db/ensureAppRole.ts
+++ b/apps/api/src/db/ensureAppRole.ts
@@ -106,6 +106,13 @@ export async function ensureAppRole(): Promise<void> {
           -- bypass. Idempotent re-revoke is a no-op.
           REVOKE TRUNCATE ON TABLE audit_logs FROM PUBLIC;
         END IF;
+        -- audit_log_chain is also append-only from breeze_app's perspective:
+        -- the chain seal trigger + REVOKE in migration -g- together enforce
+        -- immutability, but the blanket GRANT above re-permits UPDATE/DELETE.
+        -- Re-revoke here so the privilege restriction actually sticks on boot.
+        IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='audit_log_chain') THEN
+          REVOKE UPDATE, DELETE, TRUNCATE ON TABLE audit_log_chain FROM breeze_app;
+        END IF;
       END $$;
     `);
 

--- a/apps/api/src/db/ensureAppRole.ts
+++ b/apps/api/src/db/ensureAppRole.ts
@@ -112,6 +112,16 @@ export async function ensureAppRole(): Promise<void> {
         -- Re-revoke here so the privilege restriction actually sticks on boot.
         IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='audit_log_chain') THEN
           REVOKE UPDATE, DELETE, TRUNCATE ON TABLE audit_log_chain FROM breeze_app;
+          -- The blanket sequence GRANT in step 4 also re-permits UPDATE (setval)
+          -- on chain_seq. setval() lets breeze_app rewind or jump the sequence,
+          -- causing PK collisions and sealing failures — DoS-grade. Revoke UPDATE
+          -- only; SELECT (currval) and USAGE (nextval via column DEFAULT) are safe
+          -- and harmless to keep. The INSERT DEFAULT calls nextval as the table
+          -- owner, so USAGE alone is sufficient for normal sealing.
+          IF EXISTS (SELECT 1 FROM information_schema.sequences WHERE sequence_schema='public' AND sequence_name='audit_log_chain_chain_seq_seq') THEN
+            REVOKE UPDATE ON SEQUENCE audit_log_chain_chain_seq_seq FROM breeze_app;
+            GRANT USAGE ON SEQUENCE audit_log_chain_chain_seq_seq TO breeze_app;
+          END IF;
         END IF;
       END $$;
     `);

--- a/apps/api/src/db/schema/audit.ts
+++ b/apps/api/src/db/schema/audit.ts
@@ -34,7 +34,7 @@ export const auditLogs = pgTable('audit_logs', {
 export const auditLogChain = pgTable('audit_log_chain', {
   chainSeq: bigserial('chain_seq', { mode: 'number' }).primaryKey(),
   auditId: uuid('audit_id').notNull().references(() => auditLogs.id, { onDelete: 'cascade' }),
-  orgId: uuid('org_id').references(() => organizations.id),
+  orgId: uuid('org_id').references(() => organizations.id, { onDelete: 'cascade' }),
   contentChecksum: varchar('content_checksum', { length: 128 }).notNull(),
   prevChainChecksum: varchar('prev_chain_checksum', { length: 128 }),
   chainChecksum: varchar('chain_checksum', { length: 128 }).notNull(),

--- a/apps/api/src/db/schema/audit.ts
+++ b/apps/api/src/db/schema/audit.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, varchar, text, timestamp, jsonb, pgEnum, integer, boolean } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, varchar, text, timestamp, jsonb, pgEnum, integer, boolean, bigserial } from 'drizzle-orm/pg-core';
 import { organizations } from './orgs';
 
 export const actorTypeEnum = pgEnum('actor_type', ['user', 'api_key', 'agent', 'system']);
@@ -24,6 +24,21 @@ export const auditLogs = pgTable('audit_logs', {
   checksum: varchar('checksum', { length: 128 }),
   prevChecksum: varchar('prev_checksum', { length: 128 }),
   initiatedBy: initiatedByEnum('initiated_by'),
+});
+
+// Side table for the tamper-evidence chain (issue #1002). Written ONLY by the
+// deferred commit-time seal trigger (see migration 2026-06-11-h, issue #1002) — application
+// code never inserts here directly. chain_seq is the chain order; the legacy
+// checksum/prev_checksum columns on audit_logs are vestigial (content-only /
+// NULL for new rows).
+export const auditLogChain = pgTable('audit_log_chain', {
+  chainSeq: bigserial('chain_seq', { mode: 'number' }).primaryKey(),
+  auditId: uuid('audit_id').notNull().references(() => auditLogs.id, { onDelete: 'cascade' }),
+  orgId: uuid('org_id').references(() => organizations.id),
+  contentChecksum: varchar('content_checksum', { length: 128 }).notNull(),
+  prevChainChecksum: varchar('prev_chain_checksum', { length: 128 }),
+  chainChecksum: varchar('chain_checksum', { length: 128 }).notNull(),
+  sealedAt: timestamp('sealed_at', { withTimezone: true }).notNull().defaultNow(),
 });
 
 export const auditRetentionPolicies = pgTable('audit_retention_policies', {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -136,6 +136,10 @@ import { initializeIPHistoryRetention, shutdownIPHistoryRetention } from './jobs
 import { initializeChangeLogRetention, shutdownChangeLogRetention } from './jobs/changeLogRetention';
 import { initializeOauthCleanupWorker, shutdownOauthCleanupWorker } from './jobs/oauthCleanup';
 import { initializeAuditRetentionWorker, shutdownAuditRetentionWorker } from './jobs/auditRetention';
+import {
+  initializeAuditChainVerifyWorker,
+  shutdownAuditChainVerifyWorker,
+} from './jobs/auditChainVerify';
 import { initializeTenantErasureWorker, shutdownTenantErasureWorker } from './jobs/tenantErasure';
 import { initializeDiscoveryWorker, shutdownDiscoveryWorker } from './jobs/discoveryWorker';
 import { initializeNetworkBaselineWorker, shutdownNetworkBaselineWorker } from './jobs/networkBaselineWorker';
@@ -1018,6 +1022,7 @@ async function initializeWorkers(): Promise<void> {
     ['changeLogRetention', initializeChangeLogRetention],
     ['oauthCleanup', initializeOauthCleanupWorker],
     ['auditRetention', initializeAuditRetentionWorker],
+    ['auditChainVerify', initializeAuditChainVerifyWorker],
     ['tenantErasure', initializeTenantErasureWorker],
     ['playbookRetention', initializePlaybookRetention],
     ['discoveryWorker', initializeDiscoveryWorker],
@@ -1185,6 +1190,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownChangeLogRetention,
     shutdownOauthCleanupWorker,
     shutdownAuditRetentionWorker,
+    shutdownAuditChainVerifyWorker,
     shutdownTenantErasureWorker,
     shutdownPlaybookRetention,
     shutdownSecurityPostureWorker,

--- a/apps/api/src/jobs/auditChainVerify.test.ts
+++ b/apps/api/src/jobs/auditChainVerify.test.ts
@@ -6,8 +6,8 @@
  * Sentry are stubbed so we can assert scheduling, the per-org verify loop,
  * and incident-raising behavior without a real Postgres.
  *
- * The verify_chain SQL itself (and the advisory-lock / fork-heal fixes from
- * #1002 that make a non-empty result trustworthy) are exercised by the
+ * The verify_chain SQL itself (and the deferred commit-time sealing from
+ * #1002 that makes a non-empty result trustworthy) are exercised by the
  * audit-chain integration tests, not here.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';

--- a/apps/api/src/jobs/auditChainVerify.test.ts
+++ b/apps/api/src/jobs/auditChainVerify.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Unit tests for the audit-chain verification worker (issue #916 bonus /
+ * #917 L-2).
+ *
+ * Mirrors auditRetention.test.ts: BullMQ, the db module, the event bus and
+ * Sentry are stubbed so we can assert scheduling, the per-org verify loop,
+ * and incident-raising behavior without a real Postgres.
+ *
+ * The verify_chain SQL itself (and the advisory-lock / fork-heal fixes from
+ * #1002 that make a non-empty result trustworthy) are exercised by the
+ * audit-chain integration tests, not here.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  addMock,
+  getRepeatableJobsMock,
+  removeRepeatableByKeyMock,
+  queueCloseMock,
+  workerCloseMock,
+  withSystemDbAccessContextMock,
+  runOutsideDbContextMock,
+  dbExecuteMock,
+  dbInsertMock,
+  insertValuesMock,
+  insertReturningMock,
+  publishEventMock,
+  captureExceptionMock,
+  capturedWorkerProcessor,
+} = vi.hoisted(() => ({
+  addMock: vi.fn(),
+  getRepeatableJobsMock: vi.fn(),
+  removeRepeatableByKeyMock: vi.fn(),
+  queueCloseMock: vi.fn(),
+  workerCloseMock: vi.fn(),
+  withSystemDbAccessContextMock: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  runOutsideDbContextMock: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  dbExecuteMock: vi.fn(),
+  dbInsertMock: vi.fn(),
+  insertValuesMock: vi.fn(),
+  insertReturningMock: vi.fn(),
+  publishEventMock: vi.fn(),
+  captureExceptionMock: vi.fn(),
+  capturedWorkerProcessor: { current: null as null | ((job: unknown) => Promise<unknown>) },
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    name: string;
+    constructor(name: string) {
+      this.name = name;
+    }
+    add = (...args: unknown[]) => addMock(...(args as []));
+    getRepeatableJobs = () => getRepeatableJobsMock();
+    removeRepeatableByKey = (...args: unknown[]) => removeRepeatableByKeyMock(...(args as []));
+    close = () => queueCloseMock();
+  },
+  Worker: class {
+    name: string;
+    constructor(name: string, processor: (job: unknown) => Promise<unknown>) {
+      this.name = name;
+      capturedWorkerProcessor.current = processor;
+    }
+    on = vi.fn();
+    close = () => workerCloseMock();
+  },
+  Job: class {},
+}));
+
+vi.mock('../db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db')>();
+  return {
+    ...actual,
+    withSystemDbAccessContext: (fn: () => Promise<unknown>) => withSystemDbAccessContextMock(fn),
+    runOutsideDbContext: (fn: () => Promise<unknown>) => runOutsideDbContextMock(fn),
+    db: {
+      execute: (...args: unknown[]) => dbExecuteMock(...(args as [])),
+      insert: (...args: unknown[]) => dbInsertMock(...(args as [])),
+    },
+  };
+});
+
+vi.mock('../services/redis', () => ({
+  getRedisConnection: vi.fn(() => ({})),
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+  isBullMQAvailable: vi.fn(() => true),
+}));
+
+vi.mock('../services/sentry', () => ({
+  captureException: (...args: unknown[]) => captureExceptionMock(...(args as [])),
+}));
+
+vi.mock('../services/eventBus', () => ({
+  publishEvent: (...args: unknown[]) => publishEventMock(...(args as [])),
+}));
+
+import {
+  __testOnly,
+  scheduleAuditChainVerify,
+  shutdownAuditChainVerifyWorker,
+  verifyAuditChains,
+} from './auditChainVerify';
+
+const ORIGINAL_FLAG = process.env.AUDIT_CHAIN_VERIFY_ENABLED;
+
+/** Re-arm the chained Drizzle insert builder for one .insert() call. */
+function primeInsert(returnedId = 'incident-1') {
+  insertReturningMock.mockResolvedValue([{ id: returnedId }]);
+  insertValuesMock.mockReturnValue({ returning: insertReturningMock });
+  dbInsertMock.mockReturnValue({ values: insertValuesMock });
+}
+
+describe('auditChainVerify worker', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    withSystemDbAccessContextMock.mockImplementation(async (fn: () => Promise<unknown>) => fn());
+    runOutsideDbContextMock.mockImplementation(async (fn: () => Promise<unknown>) => fn());
+    getRepeatableJobsMock.mockResolvedValue([]);
+    addMock.mockResolvedValue(undefined);
+    removeRepeatableByKeyMock.mockResolvedValue(undefined);
+    queueCloseMock.mockResolvedValue(undefined);
+    workerCloseMock.mockResolvedValue(undefined);
+    dbExecuteMock.mockResolvedValue([]);
+    publishEventMock.mockResolvedValue('evt-1');
+    primeInsert();
+    capturedWorkerProcessor.current = null;
+    delete process.env.AUDIT_CHAIN_VERIFY_ENABLED;
+  });
+
+  afterEach(async () => {
+    await shutdownAuditChainVerifyWorker();
+    if (ORIGINAL_FLAG === undefined) {
+      delete process.env.AUDIT_CHAIN_VERIFY_ENABLED;
+    } else {
+      process.env.AUDIT_CHAIN_VERIFY_ENABLED = ORIGINAL_FLAG;
+    }
+  });
+
+  it('exposes a daily cron and stable identifiers', () => {
+    expect(__testOnly.DAILY_CRON).toBe('15 4 * * *');
+    expect(__testOnly.JOB_NAME).toBe('audit-chain-verify');
+    expect(__testOnly.REPEAT_JOB_ID).toBe('audit-chain-verify');
+  });
+
+  it('isEnabled defaults ON and accepts standard falsy values', () => {
+    delete process.env.AUDIT_CHAIN_VERIFY_ENABLED;
+    expect(__testOnly.isEnabled()).toBe(true);
+    process.env.AUDIT_CHAIN_VERIFY_ENABLED = 'false';
+    expect(__testOnly.isEnabled()).toBe(false);
+    process.env.AUDIT_CHAIN_VERIFY_ENABLED = '0';
+    expect(__testOnly.isEnabled()).toBe(false);
+    process.env.AUDIT_CHAIN_VERIFY_ENABLED = 'off';
+    expect(__testOnly.isEnabled()).toBe(false);
+    process.env.AUDIT_CHAIN_VERIFY_ENABLED = 'true';
+    expect(__testOnly.isEnabled()).toBe(true);
+  });
+
+  describe('scheduleAuditChainVerify', () => {
+    it('registers a daily repeatable with a stable jobId', async () => {
+      await scheduleAuditChainVerify();
+      expect(addMock).toHaveBeenCalledTimes(1);
+      const [, , opts] = addMock.mock.calls[0] as [unknown, unknown, Record<string, unknown>];
+      expect((opts.repeat as { pattern: string }).pattern).toBe('15 4 * * *');
+      expect(opts.jobId).toBe('audit-chain-verify');
+    });
+
+    it('clears any prior repeatable before registering', async () => {
+      getRepeatableJobsMock.mockResolvedValue([
+        { name: 'audit-chain-verify', key: 'old-key' },
+        { name: 'something-else', key: 'keep' },
+      ]);
+      await scheduleAuditChainVerify();
+      expect(removeRepeatableByKeyMock).toHaveBeenCalledWith('old-key');
+      expect(removeRepeatableByKeyMock).not.toHaveBeenCalledWith('keep');
+    });
+
+    it('skips registration when disabled by env flag', async () => {
+      process.env.AUDIT_CHAIN_VERIFY_ENABLED = 'false';
+      await scheduleAuditChainVerify();
+      expect(addMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('verifyAuditChains', () => {
+    // dbExecuteMock is called once for the org enumeration, then once per
+    // org for SELECT * FROM audit_log_verify_chain(org). Wire the calls in
+    // order via mockResolvedValueOnce.
+    function mockOrgs(orgIds: string[]) {
+      dbExecuteMock.mockResolvedValueOnce(orgIds.map((id) => ({ id })));
+    }
+
+    it('raises no incident when every chain is intact', async () => {
+      mockOrgs(['org-1', 'org-2']);
+      dbExecuteMock.mockResolvedValueOnce([]); // org-1 verify → clean
+      dbExecuteMock.mockResolvedValueOnce([]); // org-2 verify → clean
+
+      const stats = await verifyAuditChains();
+
+      expect(stats.orgsChecked).toBe(2);
+      expect(stats.orgsBroken).toBe(0);
+      expect(stats.alertsRaised).toBe(0);
+      expect(dbInsertMock).not.toHaveBeenCalled();
+      expect(publishEventMock).not.toHaveBeenCalled();
+      expect(captureExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('raises exactly one incident for an org whose chain is broken', async () => {
+      mockOrgs(['org-1', 'org-2']);
+      dbExecuteMock.mockResolvedValueOnce([]); // org-1 clean
+      dbExecuteMock.mockResolvedValueOnce([
+        { broken_id: 'row-aaa', expected: 'exp1', actual: 'act1' },
+        { broken_id: 'row-bbb', expected: 'exp2', actual: 'act2' },
+      ]); // org-2 → 2 breaks
+
+      const stats = await verifyAuditChains();
+
+      expect(stats.orgsChecked).toBe(2);
+      expect(stats.orgsBroken).toBe(1);
+      expect(stats.alertsRaised).toBe(1);
+
+      // Exactly one incident inserted, for org-2, p1 / detected / audit_integrity.
+      expect(dbInsertMock).toHaveBeenCalledTimes(1);
+      const values = insertValuesMock.mock.calls[0]![0] as Record<string, unknown>;
+      expect(values.orgId).toBe('org-2');
+      expect(values.severity).toBe('p1');
+      expect(values.status).toBe('detected');
+      expect(values.classification).toBe('audit_integrity');
+      // First broken_id and the break count must be carried in the payload.
+      expect(String(values.summary)).toContain('row-aaa');
+      expect(String(values.summary)).toContain('2');
+
+      // The incident.created event is published once for the broken org.
+      expect(publishEventMock).toHaveBeenCalledTimes(1);
+      const [type, orgId, payload, source] = publishEventMock.mock.calls[0] as [
+        string,
+        string,
+        Record<string, unknown>,
+        string,
+      ];
+      expect(type).toBe('incident.created');
+      expect(orgId).toBe('org-2');
+      expect(source).toBe('audit-chain-verify');
+      expect(payload.brokenId).toBe('row-aaa');
+      expect(payload.breakCount).toBe(2);
+    });
+
+    it('isolates a per-org verify failure without aborting the sweep', async () => {
+      mockOrgs(['org-1', 'org-2']);
+      dbExecuteMock.mockRejectedValueOnce(new Error('verify boom')); // org-1 throws
+      dbExecuteMock.mockResolvedValueOnce([]); // org-2 still checked → clean
+
+      const stats = await verifyAuditChains();
+
+      // org-1 threw (counted as an error, not a successful check); org-2 was
+      // still reached and verified clean — the sweep did not abort.
+      expect(stats.orgsChecked).toBe(1);
+      expect(stats.errors).toBe(1);
+      expect(stats.orgsBroken).toBe(0);
+      expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('runs the per-org verify outside the long-held enumeration txn', async () => {
+      mockOrgs(['org-1']);
+      dbExecuteMock.mockResolvedValueOnce([]);
+
+      await verifyAuditChains();
+
+      // The org list is read in one short system txn; the per-org sweep runs
+      // via runOutsideDbContext so we never hold a connection idle-in-txn
+      // across the loop (#1105 pattern).
+      expect(runOutsideDbContextMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('worker processor', () => {
+    it('runs the sweep for the scheduled job name', async () => {
+      // Build the worker to capture its processor.
+      const { createAuditChainVerifyWorker } = await import('./auditChainVerify');
+      createAuditChainVerifyWorker();
+      expect(capturedWorkerProcessor.current).toBeTypeOf('function');
+
+      dbExecuteMock.mockResolvedValueOnce([{ id: 'org-1' }]); // enumeration
+      dbExecuteMock.mockResolvedValueOnce([]); // org-1 clean
+
+      const result = await capturedWorkerProcessor.current!({ name: 'audit-chain-verify' });
+      expect((result as { orgsChecked: number }).orgsChecked).toBe(1);
+    });
+
+    it('ignores unknown job names', async () => {
+      const { createAuditChainVerifyWorker } = await import('./auditChainVerify');
+      createAuditChainVerifyWorker();
+      const result = await capturedWorkerProcessor.current!({ name: 'bogus' });
+      expect((result as { skipped: boolean }).skipped).toBe(true);
+      expect(dbExecuteMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/jobs/auditChainVerify.ts
+++ b/apps/api/src/jobs/auditChainVerify.ts
@@ -1,12 +1,12 @@
 /**
  * Audit-Chain Verification Worker (issue #916 bonus / #917 sub-item L-2)
  *
- * `audit_log_verify_chain(org_id)` (migration
- * 2026-05-25-c-audit-log-checksum-canonical-fix.sql) walks each org's audit
- * hash-chain in (timestamp, id) order and returns one row
- * `(broken_id, expected, actual)` per break — a checksum that doesn't match
- * the canonical re-computation or a prev_checksum link that doesn't match the
- * preceding row. An empty result set means the chain is intact.
+ * `audit_log_verify_chain(org_id)` (v2 — migration
+ * 2026-06-11-h-audit-chain-seal-and-verify.sql) walks each org's audit
+ * hash-chain in `chain_seq` order on the `audit_log_chain` side table and
+ * returns one row `(broken_id, expected, actual)` per break — a checksum that
+ * doesn't match the canonical re-computation. An empty result set means the
+ * chain is intact.
  *
  * Until now that function was only ever called by tests: a forged or
  * truncated audit chain was *detectable* but never *observed* in production.
@@ -18,11 +18,15 @@
  *   Before #1002, concurrent same-org inserts could fork the chain and make
  *   verify_chain report *false-positive* breaks under load. The sibling
  *   migrations in this branch —
- *     2026-06-11-a-audit-chain-advisory-lock.sql (serializes the read-prev /
- *       assign-checksum critical section with a per-org advisory lock), and
- *     2026-06-11-b-audit-chain-fork-heal.sql (re-anchors already-forked rows)
- *   — eliminate that false-positive source. So a non-empty verify result is
- *   now a real tamper/integrity signal worth paging on.
+ *     2026-06-11-g-audit-chain-table.sql (creates the append-only
+ *       `audit_log_chain` side table), and
+ *     2026-06-11-h-audit-chain-seal-and-verify.sql (DEFERRABLE INITIALLY
+ *       DEFERRED constraint trigger seals each audit row into the side table
+ *       at COMMIT under a momentary per-org advisory lock; backfill sealed
+ *       historical rows)
+ *   — eliminate that false-positive source: linkage is sealed serially at
+ *   commit, so a non-empty verify result is a real tamper/integrity signal
+ *   worth paging on.
  *
  * #1105 long-transaction pitfall:
  *   `withSystemDbAccessContext` wraps its whole callback in a single
@@ -139,10 +143,10 @@ async function raiseChainBreakIncident(orgId: string, breaks: ChainBreakRow[]): 
   const title = 'Audit log hash-chain integrity break detected';
   const summary =
     `audit_log_verify_chain reported ${breakCount} break row(s) for this organization. ` +
-    `First broken audit_logs.id=${firstBrokenId}. A break means a stored checksum or ` +
-    `prev_checksum no longer matches the canonical re-computation — i.e. an audit row was ` +
-    `altered, deleted, or inserted out of band. Investigate immediately. ` +
-    `(#1002 advisory-lock + fork-heal fixes are in place, so this is not a concurrency ` +
+    `First broken audit_log_chain.broken_id=${firstBrokenId}. A break means a stored checksum ` +
+    `no longer matches the canonical re-computation — i.e. an audit row was altered, deleted, ` +
+    `or inserted out of band. Investigate immediately. ` +
+    `(#1002 deferred commit-time sealing is in place, so this is not a concurrency ` +
     `false-positive.)`;
 
   const timeline: IncidentTimelineEntry[] = [

--- a/apps/api/src/jobs/auditChainVerify.ts
+++ b/apps/api/src/jobs/auditChainVerify.ts
@@ -1,0 +1,388 @@
+/**
+ * Audit-Chain Verification Worker (issue #916 bonus / #917 sub-item L-2)
+ *
+ * `audit_log_verify_chain(org_id)` (migration
+ * 2026-05-25-c-audit-log-checksum-canonical-fix.sql) walks each org's audit
+ * hash-chain in (timestamp, id) order and returns one row
+ * `(broken_id, expected, actual)` per break — a checksum that doesn't match
+ * the canonical re-computation or a prev_checksum link that doesn't match the
+ * preceding row. An empty result set means the chain is intact.
+ *
+ * Until now that function was only ever called by tests: a forged or
+ * truncated audit chain was *detectable* but never *observed* in production.
+ * This worker runs the verifier per org once a day and raises a P1 security
+ * incident for any org whose chain returns ≥1 break row, so tampering pages
+ * an operator instead of sitting silent.
+ *
+ * Why we can trust a non-empty result now (issue #1002):
+ *   Before #1002, concurrent same-org inserts could fork the chain and make
+ *   verify_chain report *false-positive* breaks under load. The sibling
+ *   migrations in this branch —
+ *     2026-06-11-a-audit-chain-advisory-lock.sql (serializes the read-prev /
+ *       assign-checksum critical section with a per-org advisory lock), and
+ *     2026-06-11-b-audit-chain-fork-heal.sql (re-anchors already-forked rows)
+ *   — eliminate that false-positive source. So a non-empty verify result is
+ *   now a real tamper/integrity signal worth paging on.
+ *
+ * #1105 long-transaction pitfall:
+ *   `withSystemDbAccessContext` wraps its whole callback in a single
+ *   transaction. We therefore read the org list inside one short system txn
+ *   and then run the per-org verify sweep via `runOutsideDbContext` so the
+ *   connection is NOT held idle-in-transaction across the (potentially long)
+ *   per-org loop. Each per-org verify opens and closes its own short system
+ *   txn. This mirrors the guidance in CLAUDE.md ("DB Access Context").
+ *
+ * Throughput: this is a once-a-day integrity sweep, not a hot path. Each org
+ * verify is a single function call; we run them sequentially with a small
+ * delay between orgs so a large fleet doesn't hammer the primary. Per-org
+ * failures are isolated (try/catch + captureException) so one bad org can't
+ * abort the whole pass — same isolation rationale as auditRetention.
+ *
+ * Schedule: daily at 04:15 UTC — offset from auditRetention (03:30) and
+ * oauthCleanup (03:00) so the integrity crons don't pile onto one minute, and
+ * late enough that the nightly retention prune (which re-anchors chain heads)
+ * has already settled.
+ *
+ * Kill switch: `AUDIT_CHAIN_VERIFY_ENABLED=false` skips schedule registration
+ * (the worker still drains manual `add()` calls for incident response).
+ */
+
+import { Queue, Worker, Job } from 'bullmq';
+import { sql } from 'drizzle-orm';
+import * as dbModule from '../db';
+import { incidents, type IncidentTimelineEntry } from '../db/schema/incidentResponse';
+import { captureException } from '../services/sentry';
+import { publishEvent } from '../services/eventBus';
+import { getBullMQConnection } from '../services/redis';
+
+const QUEUE_NAME = 'audit-chain-verify';
+const JOB_NAME = 'audit-chain-verify';
+const REPEAT_JOB_ID = 'audit-chain-verify';
+// Daily at 04:15 UTC — after retention (03:30) and oauthCleanup (03:00).
+const DAILY_CRON = '15 4 * * *';
+// Small breather between per-org verifies so a large fleet doesn't hammer the
+// primary during the sweep. Daily job — latency is irrelevant.
+const INTER_ORG_DELAY_MS = 50;
+
+const INCIDENT_CLASSIFICATION = 'audit_integrity';
+const INCIDENT_SEVERITY = 'p1' as const;
+const EVENT_SOURCE = 'audit-chain-verify';
+
+function isEnabled(): boolean {
+  const raw = process.env.AUDIT_CHAIN_VERIFY_ENABLED;
+  if (raw === undefined || raw === '') return true; // default ON
+  const v = raw.trim().toLowerCase();
+  return !(v === '0' || v === 'false' || v === 'no' || v === 'off');
+}
+
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  if (typeof dbModule.withSystemDbAccessContext !== 'function') {
+    throw new Error(
+      '[AuditChainVerify] withSystemDbAccessContext is not available — DB module may not have loaded correctly',
+    );
+  }
+  return dbModule.withSystemDbAccessContext(fn);
+};
+
+const runOutsideDbContext = async <T>(fn: () => Promise<T>): Promise<T> => {
+  if (typeof dbModule.runOutsideDbContext !== 'function') {
+    // Without the helper we can still run, just not detached from any
+    // ambient context — acceptable since this worker has no ambient txn.
+    return fn();
+  }
+  return dbModule.runOutsideDbContext(fn);
+};
+
+export interface ChainVerifyStats {
+  orgsChecked: number;
+  orgsBroken: number;
+  alertsRaised: number;
+  errors: number;
+  durationMs: number;
+}
+
+interface OrgRow {
+  id: string;
+}
+
+interface ChainBreakRow {
+  broken_id: string;
+  expected: string | null;
+  actual: string | null;
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run the verifier for one org in its own short system transaction and return
+ * any break rows. Kept tiny so the txn is never held open across the loop.
+ */
+async function verifyOrgChain(orgId: string): Promise<ChainBreakRow[]> {
+  return runWithSystemDbAccess(async () => {
+    const rows = (await dbModule.db.execute(sql`
+      SELECT broken_id, expected, actual
+      FROM audit_log_verify_chain(${orgId}::uuid)
+    `)) as unknown as ChainBreakRow[];
+    return Array.isArray(rows) ? rows : [];
+  });
+}
+
+/**
+ * Raise a P1 security incident for an org whose audit chain is broken, then
+ * publish `incident.created` so existing escalation/notification fans out.
+ * Runs in its own system txn (separate from the verify read).
+ */
+async function raiseChainBreakIncident(orgId: string, breaks: ChainBreakRow[]): Promise<void> {
+  const now = new Date();
+  const firstBrokenId = breaks[0]?.broken_id ?? 'unknown';
+  const breakCount = breaks.length;
+  const title = 'Audit log hash-chain integrity break detected';
+  const summary =
+    `audit_log_verify_chain reported ${breakCount} break row(s) for this organization. ` +
+    `First broken audit_logs.id=${firstBrokenId}. A break means a stored checksum or ` +
+    `prev_checksum no longer matches the canonical re-computation — i.e. an audit row was ` +
+    `altered, deleted, or inserted out of band. Investigate immediately. ` +
+    `(#1002 advisory-lock + fork-heal fixes are in place, so this is not a concurrency ` +
+    `false-positive.)`;
+
+  const timeline: IncidentTimelineEntry[] = [
+    {
+      at: now.toISOString(),
+      type: 'incident_created',
+      actor: 'system',
+      summary: `Audit-chain verification sweep detected ${breakCount} break row(s).`,
+      metadata: {
+        firstBrokenId,
+        breakCount,
+        // Cap the embedded sample so a fully-rewritten chain can't bloat the row.
+        sample: breaks.slice(0, 20).map((b) => ({
+          brokenId: b.broken_id,
+          expected: b.expected,
+          actual: b.actual,
+        })),
+      },
+    },
+  ];
+
+  const [incident] = await runWithSystemDbAccess(async () =>
+    dbModule.db
+      .insert(incidents)
+      .values({
+        orgId,
+        title,
+        classification: INCIDENT_CLASSIFICATION,
+        severity: INCIDENT_SEVERITY,
+        status: 'detected',
+        summary,
+        relatedAlerts: [],
+        affectedDevices: [],
+        timeline,
+        detectedAt: now,
+      })
+      .returning(),
+  );
+
+  // Publish best-effort: a failure here must not lose the (already-persisted)
+  // incident, but should still surface to Sentry.
+  try {
+    await publishEvent(
+      'incident.created',
+      orgId,
+      {
+        incidentId: incident?.id,
+        title,
+        classification: INCIDENT_CLASSIFICATION,
+        severity: INCIDENT_SEVERITY,
+        brokenId: firstBrokenId,
+        breakCount,
+      },
+      EVENT_SOURCE,
+    );
+  } catch (err) {
+    captureException(err);
+    console.error(
+      `[AuditChainVerify] incident raised (id=${incident?.id}) but incident.created publish failed for org=${orgId}:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+}
+
+/**
+ * Walk every active organization, verify its audit hash-chain, and raise a P1
+ * incident for any org that returns break rows.
+ *
+ * Exported for direct invocation (tests, manual incident response). The worker
+ * processor calls this and surfaces the stats in the job return value.
+ */
+export async function verifyAuditChains(): Promise<ChainVerifyStats> {
+  const startedAt = Date.now();
+  const stats: ChainVerifyStats = {
+    orgsChecked: 0,
+    orgsBroken: 0,
+    alertsRaised: 0,
+    errors: 0,
+    durationMs: 0,
+  };
+
+  // Read the org list in one short system txn. We deliberately do NOT keep
+  // this txn open across the per-org loop (#1105) — the loop runs detached.
+  const orgs = await runWithSystemDbAccess(async () => {
+    const rows = (await dbModule.db.execute(sql`
+      SELECT id FROM organizations WHERE status = 'active'
+    `)) as unknown as OrgRow[];
+    return rows;
+  });
+
+  // Detach from any ambient db context so the per-org sweep can't hold a
+  // connection idle-in-transaction across the whole loop.
+  await runOutsideDbContext(async () => {
+    for (const org of orgs) {
+      try {
+        const breaks = await verifyOrgChain(org.id);
+        stats.orgsChecked += 1;
+
+        if (breaks.length > 0) {
+          stats.orgsBroken += 1;
+          console.error(
+            `[AuditChainVerify] CHAIN BREAK org=${org.id} breaks=${breaks.length} firstBrokenId=${breaks[0]?.broken_id}`,
+          );
+          await raiseChainBreakIncident(org.id, breaks);
+          stats.alertsRaised += 1;
+          // Surface to Sentry too so ops paging fires even if the incident
+          // notification pipeline is degraded.
+          captureException(
+            new Error(
+              `Audit hash-chain integrity break: org=${org.id} breaks=${breaks.length} firstBrokenId=${breaks[0]?.broken_id}`,
+            ),
+          );
+        }
+      } catch (err) {
+        stats.errors += 1;
+        captureException(err);
+        console.error(
+          `[AuditChainVerify] verify failed for org=${org.id}:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+
+      if (INTER_ORG_DELAY_MS > 0) {
+        await sleep(INTER_ORG_DELAY_MS);
+      }
+    }
+  });
+
+  stats.durationMs = Date.now() - startedAt;
+  console.log(
+    `[AuditChainVerify] Verified ${stats.orgsChecked} org chain(s); ${stats.orgsBroken} broken, ${stats.alertsRaised} incident(s) raised in ${stats.durationMs}ms (errors=${stats.errors})`,
+  );
+  return stats;
+}
+
+let verifyQueue: Queue | null = null;
+let verifyWorker: Worker | null = null;
+
+export function getAuditChainVerifyQueue(): Queue {
+  if (!verifyQueue) {
+    verifyQueue = new Queue(QUEUE_NAME, {
+      connection: getBullMQConnection(),
+    });
+  }
+  return verifyQueue;
+}
+
+export function createAuditChainVerifyWorker(): Worker {
+  verifyWorker = new Worker(
+    QUEUE_NAME,
+    async (job: Job) => {
+      if (job.name !== JOB_NAME) {
+        console.warn(`[AuditChainVerify] Ignoring unknown job name: ${job.name}`);
+        return { skipped: true, orgsChecked: 0 };
+      }
+      return verifyAuditChains();
+    },
+    {
+      connection: getBullMQConnection(),
+      concurrency: 1,
+    },
+  );
+  return verifyWorker;
+}
+
+export async function scheduleAuditChainVerify(
+  queue: Queue = getAuditChainVerifyQueue(),
+): Promise<void> {
+  // Clear any prior repeatable so a cron-pattern change takes effect on
+  // redeploy (BullMQ keys repeatables by the full option set).
+  const existingJobs = await queue.getRepeatableJobs();
+  for (const job of existingJobs) {
+    if (job.name === JOB_NAME) {
+      await queue.removeRepeatableByKey(job.key);
+    }
+  }
+
+  if (!isEnabled()) {
+    console.log(
+      '[AuditChainVerify] AUDIT_CHAIN_VERIFY_ENABLED=false — skipping schedule registration',
+    );
+    return;
+  }
+
+  await queue.add(
+    JOB_NAME,
+    {},
+    {
+      // Stable jobId gives BullMQ multi-replica dedup: only one replica wins
+      // the scheduled-job insert per fire time.
+      jobId: REPEAT_JOB_ID,
+      repeat: { pattern: DAILY_CRON },
+      removeOnComplete: { count: 10 },
+      removeOnFail: { count: 25 },
+    },
+  );
+  console.log(
+    `[AuditChainVerify] Scheduled daily verification (cron "${DAILY_CRON}", jobId=${REPEAT_JOB_ID})`,
+  );
+}
+
+export async function initializeAuditChainVerifyWorker(): Promise<void> {
+  try {
+    createAuditChainVerifyWorker();
+
+    verifyWorker?.on('error', (error) => {
+      console.error('[AuditChainVerify] Worker error:', error);
+      captureException(error);
+    });
+
+    verifyWorker?.on('failed', (job, error) => {
+      console.error(`[AuditChainVerify] Job ${job?.id} failed:`, error);
+      captureException(error);
+    });
+
+    await scheduleAuditChainVerify();
+    console.log('[AuditChainVerify] Worker initialized');
+  } catch (error) {
+    console.error('[AuditChainVerify] Failed to initialize:', error);
+    throw error;
+  }
+}
+
+export async function shutdownAuditChainVerifyWorker(): Promise<void> {
+  if (verifyWorker) {
+    await verifyWorker.close();
+    verifyWorker = null;
+  }
+  if (verifyQueue) {
+    await verifyQueue.close();
+    verifyQueue = null;
+  }
+}
+
+// Exported for test introspection.
+export const __testOnly = {
+  QUEUE_NAME,
+  JOB_NAME,
+  REPEAT_JOB_ID,
+  DAILY_CRON,
+  INCIDENT_CLASSIFICATION,
+  isEnabled,
+};

--- a/apps/api/src/jobs/auditRetention.test.ts
+++ b/apps/api/src/jobs/auditRetention.test.ts
@@ -189,15 +189,15 @@ describe('auditRetention worker', () => {
       expect(stats.errors).toBe(0);
     });
 
-    it('issues SET LOCAL ROLE + SET LOCAL GUC before DELETE and re-anchors the chain', async () => {
+    it('issues SET LOCAL ROLE + SET LOCAL GUC before the prefix-cut and unsealed-sweep DELETEs, with no UPDATE', async () => {
       dbExecuteMock
         .mockResolvedValueOnce([
           { id: 'p1', org_id: 'org-a', retention_days: 30 },
         ]) // policy list
         .mockResolvedValueOnce(undefined) // SET LOCAL ROLE
         .mockResolvedValueOnce(undefined) // SET LOCAL GUC
-        .mockResolvedValueOnce({ rowCount: 5 }) // DELETE
-        .mockResolvedValueOnce(undefined) // re-anchor UPDATE (rows were deleted)
+        .mockResolvedValueOnce({ rowCount: 5 }) // prefix-cut DELETE
+        .mockResolvedValueOnce(undefined) // unsealed-old-rows sweep DELETE
         .mockResolvedValueOnce(undefined); // UPDATE last_cleanup_at
 
       const stats = await pruneExpiredAuditLogs();
@@ -206,7 +206,7 @@ describe('auditRetention worker', () => {
       expect(stats.rowsDeleted).toBe(5);
       expect(stats.errors).toBe(0);
 
-      // 1 select + 3 (role/guc/delete) + 1 re-anchor + 1 last_cleanup_at update = 6 calls.
+      // 1 select + 4 (role/guc/prefix-cut delete/unsealed sweep) + 1 last_cleanup_at update = 6 calls.
       expect(dbExecuteMock).toHaveBeenCalledTimes(6);
 
       const callTexts = dbExecuteMock.mock.calls.map((call: unknown[]) => {
@@ -221,25 +221,50 @@ describe('auditRetention worker', () => {
       });
       expect(callTexts[1]).toMatch(/SET LOCAL ROLE breeze_audit_admin/);
       expect(callTexts[2]).toMatch(/SET LOCAL breeze\.allow_audit_retention/);
+      // (a) prefix-cut DELETE: removes the maximal all-old chain prefix.
       expect(callTexts[3]).toMatch(/DELETE FROM audit_logs/);
-      // Re-anchor UPDATE rewrites prev_checksum=NULL on the new chain head.
-      expect(callTexts[4]).toMatch(/prev_checksum = NULL/);
+      expect(callTexts[3]).toMatch(/SELECT c\.audit_id/);
+      expect(callTexts[3]).toMatch(/FROM audit_log_chain c/);
+      // (b) unsealed-old-rows sweep: old rows with no chain entry.
+      expect(callTexts[4]).toMatch(/DELETE FROM audit_logs a/);
+      expect(callTexts[4]).toMatch(/NOT EXISTS \(SELECT 1 FROM audit_log_chain c WHERE c\.audit_id = a\.id\)/);
+      // The deferred-sealing design (issue #1002) never re-anchors: retention
+      // must issue NO UPDATE of audit_logs or audit_log_chain — the only
+      // UPDATE in the whole pass is the last_cleanup_at bookkeeping.
+      const updates = callTexts.filter((t) => /UPDATE/i.test(t));
+      expect(updates).toHaveLength(1);
+      expect(updates[0]).toMatch(/UPDATE audit_retention_policies/);
     });
 
-    it('skips chain re-anchor when no rows were deleted', async () => {
+    it('never issues an UPDATE even when no rows were deleted (no re-anchor exists)', async () => {
       dbExecuteMock
         .mockResolvedValueOnce([
           { id: 'p1', org_id: 'org-a', retention_days: 30 },
         ])
         .mockResolvedValueOnce(undefined) // SET LOCAL ROLE
         .mockResolvedValueOnce(undefined) // SET LOCAL GUC
-        .mockResolvedValueOnce({ rowCount: 0 }) // DELETE — no rows
+        .mockResolvedValueOnce({ rowCount: 0 }) // prefix-cut DELETE — no rows
+        .mockResolvedValueOnce(undefined) // unsealed-old-rows sweep DELETE
         .mockResolvedValueOnce(undefined); // UPDATE last_cleanup_at
 
       const stats = await pruneExpiredAuditLogs();
       expect(stats.rowsDeleted).toBe(0);
-      // 1 select + 3 (role/guc/delete) + 1 last_cleanup_at = 5 calls. No re-anchor.
-      expect(dbExecuteMock).toHaveBeenCalledTimes(5);
+      // 1 select + 4 (role/guc/prefix-cut delete/unsealed sweep) + 1 last_cleanup_at = 6 calls.
+      expect(dbExecuteMock).toHaveBeenCalledTimes(6);
+      // Design guarantee (issue #1002): retention never UPDATEs audit_logs or
+      // audit_log_chain — verify treats the first surviving entry's prev as
+      // the trusted anchor, so no re-anchor rewrite is ever issued.
+      const callTexts = dbExecuteMock.mock.calls.map((call: unknown[]) => {
+        const q = call[0];
+        const sqlObj = q as { queryChunks?: Array<{ value?: string[] } | string> };
+        if (Array.isArray(sqlObj.queryChunks)) {
+          return sqlObj.queryChunks
+            .map((c) => (typeof c === 'string' ? c : Array.isArray((c as { value?: unknown }).value) ? ((c as { value: string[] }).value).join('') : ''))
+            .join(' ');
+        }
+        return String(q);
+      });
+      expect(callTexts.some((t) => /UPDATE audit_logs|UPDATE audit_log_chain|prev_checksum/.test(t))).toBe(false);
     });
 
     it('continues to the next policy when one fails', async () => {
@@ -252,7 +277,7 @@ describe('auditRetention worker', () => {
         .mockResolvedValueOnce(undefined)
         .mockResolvedValueOnce(undefined)
         .mockRejectedValueOnce(new Error('connection lost'))
-        // org-b: role, guc, DELETE ok, re-anchor ok, UPDATE ok
+        // org-b: role, guc, prefix-cut DELETE ok, sweep DELETE ok, last_cleanup_at UPDATE ok
         .mockResolvedValueOnce(undefined)
         .mockResolvedValueOnce(undefined)
         .mockResolvedValueOnce({ rowCount: 3 })

--- a/apps/api/src/jobs/auditRetention.ts
+++ b/apps/api/src/jobs/auditRetention.ts
@@ -111,53 +111,59 @@ function extractRowCount(result: unknown): number {
 }
 
 /**
- * The DELETE + chain re-anchor for a single org, parameterized over the
- * executor so it can run on either pool. Assumes the caller has already
- * armed the trigger-bypass GUC (`breeze.allow_audit_retention = '1'`) on
- * the same transaction/connection.
+ * The retention DELETE for a single org, parameterized over the executor so
+ * it can run on either pool. Assumes the caller has already armed the
+ * trigger-bypass GUC (`breeze.allow_audit_retention = '1'`) on the same
+ * transaction/connection.
  */
-async function deleteAndReanchor(exec: SqlExecutor, policy: PolicyRow): Promise<number> {
+async function deleteChainPrefix(exec: SqlExecutor, policy: PolicyRow): Promise<number> {
+  // Prefix-cut delete (issue #1002 redesign): chain_seq order is COMMIT order,
+  // which can disagree with timestamp order around long transactions, so a raw
+  // `timestamp < cutoff` delete could remove a mid-chain entry and leave a
+  // permanent linkage hole. Instead delete the maximal chain PREFIX that is
+  // entirely older than the cutoff — everything below the first "young" row in
+  // chain order. Old stragglers sitting behind a young row survive one extra
+  // nightly cycle and are caught as the prefix advances.
+  //
+  // No re-anchor follows: audit_log_verify_chain treats the first surviving
+  // entry's prev_chain_checksum as the trusted anchor (it references the
+  // legitimately pruned prefix), so retention never UPDATEs the chain — or
+  // audit_logs — at all. The FK ON DELETE CASCADE removes the pruned rows'
+  // chain entries; their BEFORE DELETE trigger passes because both call paths
+  // set breeze.allow_audit_retention='1' SET LOCAL before calling this.
   const result = await exec.execute(sql`
     DELETE FROM audit_logs
-    WHERE org_id = ${policy.org_id}
-      AND timestamp < (now() - (${policy.retention_days}::int * interval '1 day'))
+    WHERE id IN (
+      SELECT c.audit_id
+      FROM audit_log_chain c
+      WHERE c.org_id = ${policy.org_id}
+        AND c.chain_seq < COALESCE(
+          (
+            SELECT MIN(c2.chain_seq)
+            FROM audit_log_chain c2
+            JOIN audit_logs a2 ON a2.id = c2.audit_id
+            WHERE c2.org_id = ${policy.org_id}
+              AND a2.timestamp >= (now() - (${policy.retention_days}::int * interval '1 day'))
+          ),
+          (
+            SELECT MAX(c3.chain_seq) + 1
+            FROM audit_log_chain c3
+            WHERE c3.org_id = ${policy.org_id}
+          )
+        )
+    )
   `);
   const count = extractRowCount(result);
 
-  // Re-anchor the chain. After the DELETE the new oldest surviving row
-  // still carries prev_checksum pointing at the deleted row, which makes
-  // audit_log_verify_chain flag it as a break the next morning — defeating
-  // the entire tamper-detection signal.
-  //
-  // Find the new chain head per org and rewrite prev_checksum to NULL +
-  // checksum to the canonical hash with prev=NULL. The WHERE filter on the
-  // existing prev_checksum makes this a no-op when no rows were deleted
-  // (oldest row's prev_checksum already NULL) and avoids unnecessary writes
-  // on idempotent reruns.
-  if (count > 0) {
-    await exec.execute(sql`
-      WITH head AS (
-        SELECT a.*
-        FROM audit_logs a
-        WHERE a.org_id IS NOT DISTINCT FROM ${policy.org_id}
-        ORDER BY a.timestamp, a.id
-        LIMIT 1
-      )
-      UPDATE audit_logs
-      SET prev_checksum = NULL,
-          checksum = encode(
-            -- convert_to(... ,'UTF8'), not ::bytea: the text->bytea cast
-            -- throws on the backslash escapes jsonb details::text emits.
-            -- Must match the trigger/verifier hash exactly or this
-            -- re-anchor would itself break the chain.
-            sha256(convert_to(audit_log_canonical_payload(head, NULL), 'UTF8')),
-            'hex'
-          )
-      FROM head
-      WHERE audit_logs.id = head.id
-        AND head.prev_checksum IS NOT NULL
-    `);
-  }
+  // Sweep any UNSEALED old rows too (shouldn't exist post-backfill; keeps
+  // retention complete if one ever appears). The chain has no entry for them,
+  // so deleting them can't affect linkage.
+  await exec.execute(sql`
+    DELETE FROM audit_logs a
+    WHERE a.org_id = ${policy.org_id}
+      AND a.timestamp < (now() - (${policy.retention_days}::int * interval '1 day'))
+      AND NOT EXISTS (SELECT 1 FROM audit_log_chain c WHERE c.audit_id = a.id)
+  `);
 
   return count;
 }
@@ -192,7 +198,7 @@ async function pruneOrg(policy: PolicyRow): Promise<number> {
       // Trigger bypass; the connection logs in AS breeze_audit_admin, which
       // already holds the DELETE privilege (no SET ROLE needed).
       await tx.execute(sql`SET LOCAL breeze.allow_audit_retention = '1'`);
-      return deleteAndReanchor(tx as unknown as SqlExecutor, policy);
+      return deleteChainPrefix(tx as unknown as SqlExecutor, policy);
     });
   }
 
@@ -202,7 +208,7 @@ async function pruneOrg(policy: PolicyRow): Promise<number> {
     // transaction and revert on commit/rollback automatically.
     await dbModule.db.execute(sql`SET LOCAL ROLE breeze_audit_admin`);
     await dbModule.db.execute(sql`SET LOCAL breeze.allow_audit_retention = '1'`);
-    return deleteAndReanchor(dbModule.db as unknown as SqlExecutor, policy);
+    return deleteChainPrefix(dbModule.db as unknown as SqlExecutor, policy);
   });
 }
 

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -73,6 +73,7 @@ export const ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'audit_baseline_apply_approvals',
   'audit_baseline_results',
   'audit_baselines',
+  'audit_log_chain',
   'audit_logs',
   'audit_policy_states',
   'audit_retention_policies',
@@ -272,7 +273,7 @@ const ASSOCIATED_SYSTEM_SCOPED_TABLES: ReadonlyArray<{
  * to DELETE. These are gated by the audit_log_immutable trigger and
  * the per-role DELETE grant established in migration 2026-05-25-i.
  */
-const AUDIT_ADMIN_REQUIRED_TABLES: ReadonlySet<string> = new Set<string>(['audit_logs']);
+const AUDIT_ADMIN_REQUIRED_TABLES: ReadonlySet<string> = new Set<string>(['audit_logs', 'audit_log_chain']);
 
 interface FkEdge {
   // SQL aliases are snake_case (postgres-js does not auto-camelCase).

--- a/docs/superpowers/plans/2026-06-11-audit-chain-deferred-sealing.md
+++ b/docs/superpowers/plans/2026-06-11-audit-chain-deferred-sealing.md
@@ -1,0 +1,967 @@
+# Audit Chain Deferred Commit-Time Sealing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix audit hash-chain forks under concurrent writes (#1002) without the held-to-commit lock deadlock that killed draft PR #1240, by sealing the chain in a side table via a deferred commit-time trigger.
+
+**Architecture:** `audit_logs` inserts compute a content-only hash (no lock, no predecessor read). A `DEFERRABLE INITIALLY DEFERRED` constraint trigger fires at commit, takes a per-org advisory lock for microseconds, and appends a linkage entry to a new append-only `audit_log_chain` side table ordered by `chain_seq bigserial`. `audit_log_verify_chain()` is redefined (same signature) to walk the side table. Full design + rationale: `docs/superpowers/specs/2026-06-11-audit-chain-deferred-sealing-design.md`.
+
+**Tech Stack:** PostgreSQL (plpgsql triggers, hand-written idempotent migrations), Drizzle ORM (schema parity only), Vitest integration tests against the docker test DB (`breeze-postgres-test`, port 5433).
+
+---
+
+## Ground rules for the executing engineer
+
+- **Workspace:** `/Users/toddhebebrand/bz-sec-cluster` (existing git worktree of this repo). All commands below assume you start there. Do NOT work in `/Users/toddhebebrand/breeze` (the user's main checkout).
+- **Node env:** prefix EVERY pnpm/npx/vitest command with `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH` (default node 23 breaks pnpm engine-strict). Shown explicitly in each Run line.
+- **Migrations** (CLAUDE.md): idempotent (`IF NOT EXISTS` / `CREATE OR REPLACE` / `DO $$` + `pg_policies` checks), NO inner `BEGIN;`/`COMMIT;` (the runner wraps each file in a transaction), never edit a shipped migration. Filenames `2026-06-11-g-…` / `2026-06-11-h-…` — `-d-/-e-/-f-` are shipped today, `-a-/-b-` were burned by unmerged draft #1240 (never reuse those names: local DBs recorded their checksums; reuse with different content crashes `autoMigrate`).
+- **Do not run the full `vitest run`** — known flaky in parallel. Run only the named test files.
+- **Integration tests** auto-apply migrations on startup (setup.ts runs autoMigrate against `postgresql://breeze_test:breeze_test@localhost:5433/breeze_test`).
+- **Commit after every task** with the exact message given.
+
+---
+
+### Task 0: Branch + clean test DB
+
+**Files:** none (setup)
+
+- [ ] **Step 0.1: Create the branch off origin/main**
+
+```bash
+cd /Users/toddhebebrand/bz-sec-cluster
+git fetch origin main
+git checkout -b fix/audit-chain-deferred-sealing origin/main
+```
+
+Expected: `branch 'fix/audit-chain-deferred-sealing' set up to track 'origin/main'` (or plain "Switched to a new branch").
+
+- [ ] **Step 0.2: Ensure deps are installed**
+
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm install --prefer-offline
+```
+
+Expected: `Done in …s`.
+
+- [ ] **Step 0.3: Recreate the test DB from scratch** (the draft #1240 migrations were applied to it; fresh state avoids stale-trigger confusion)
+
+```bash
+cd apps/api
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm test:docker:down
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm test:docker:up
+docker ps --format '{{.Names}}' | grep breeze-postgres-test
+```
+
+Expected: last command prints `breeze-postgres-test`. If `test:docker:down`/`up` scripts behave differently than expected, inspect `apps/api/package.json` scripts and use whatever brings up the 5433 test stack fresh (`down -v` semantics).
+
+- [ ] **Step 0.4: Sanity baseline — the two suites this work must keep green**
+
+```bash
+cd /Users/toddhebebrand/bz-sec-cluster/apps/api
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run --config vitest.integration.config.ts src/__tests__/integration/audit-checksum.integration.test.ts src/__tests__/integration/audit-logs-rls.integration.test.ts
+```
+
+Expected: both files PASS (audit-checksum ~6 tests, audit-logs-rls 5 tests). If audit-logs-rls is flaky on re-run (append-only accumulation — known), re-run once before concluding breakage.
+
+---
+
+### Task 1: Cherry-pick the verify-alerting cron from draft #1240
+
+The daily `verify_chain` sweep (P1 incident + Sentry on breaks) was built and reviewed on the draft branch; it calls `audit_log_verify_chain(org)` whose signature we preserve, so it carries over unchanged.
+
+**Files:**
+- Cherry-picked: `apps/api/src/jobs/auditChainVerify.ts`, `apps/api/src/jobs/auditChainVerify.test.ts`, `apps/api/src/index.ts` (init + shutdown wiring)
+
+- [ ] **Step 1.1: Cherry-pick the cron commit**
+
+```bash
+cd /Users/toddhebebrand/bz-sec-cluster
+git cherry-pick e19ef4d5
+```
+
+Expected: clean pick, OR a conflict only in `apps/api/src/index.ts` (main moved since). If conflicted: keep BOTH sides — the cherry-pick adds (1) an import block for `initializeAuditChainVerifyWorker, shutdownAuditChainVerifyWorker` from `./jobs/auditChainVerify`, (2) an `['auditChainVerify', initializeAuditChainVerifyWorker]` entry in the workers init array, (3) `shutdownAuditChainVerifyWorker()` in the shutdown sequence. Then `git add apps/api/src/index.ts && git cherry-pick --continue`.
+
+- [ ] **Step 1.2: Verify it compiles and its unit tests pass**
+
+```bash
+cd apps/api
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit 2>&1 | grep -vE "agents\.test\.ts|apiKeyAuth\.test\.ts"
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/jobs/auditChainVerify.test.ts
+```
+
+Expected: tsc prints nothing (the two greps are known pre-existing failures); vitest `11 passed`.
+
+(No commit needed — the cherry-pick IS the commit.)
+
+---
+
+### Task 2: Migration `-g-` — the `audit_log_chain` table
+
+**Files:**
+- Create: `apps/api/migrations/2026-06-11-g-audit-chain-table.sql`
+- Modify: `apps/api/src/db/schema/audit.ts` (append `auditLogChain`)
+
+- [ ] **Step 2.1: Write the migration**
+
+Create `apps/api/migrations/2026-06-11-g-audit-chain-table.sql` with exactly:
+
+```sql
+-- Issue #1002 (part 1 of 2): side table for the audit tamper-evidence chain.
+--
+-- The in-row chain (checksum/prev_checksum on audit_logs, PR #900) forks under
+-- concurrent same-org inserts, and the obvious fix — an advisory lock held in
+-- the BEFORE INSERT trigger — deadlocks against the codebase's two-connection
+-- audit-write pattern (caller-tx insert + logSessionAudit on a separate pooled
+-- connection; see draft PR #1240 and
+-- docs/superpowers/specs/2026-06-11-audit-chain-deferred-sealing-design.md).
+--
+-- Linkage moves into this append-only side table, written by a DEFERRED
+-- commit-time trigger (the -h- migration). chain_seq (bigserial) is the chain
+-- order; per-org subsequences are walked by org_id + chain_seq. The companion
+-- -h- migration installs the seal trigger, backfills existing rows, and
+-- redefines audit_log_verify_chain over this table.
+
+CREATE TABLE IF NOT EXISTS audit_log_chain (
+  chain_seq bigserial PRIMARY KEY,
+  audit_id uuid NOT NULL REFERENCES audit_logs(id) ON DELETE CASCADE,
+  org_id uuid REFERENCES organizations(id),
+  content_checksum varchar(128) NOT NULL,
+  prev_chain_checksum varchar(128),
+  chain_checksum varchar(128) NOT NULL,
+  sealed_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- One seal per audit row; also serves the verify join and the unsealed-row sweep.
+CREATE UNIQUE INDEX IF NOT EXISTS audit_log_chain_audit_id_uniq
+  ON audit_log_chain (audit_id);
+
+-- Head lookup in the seal function: WHERE org_id = $1 (or IS NULL) ORDER BY chain_seq DESC.
+CREATE INDEX IF NOT EXISTS audit_log_chain_org_seq_idx
+  ON audit_log_chain (org_id, chain_seq DESC);
+
+-- Anti-fork hard guarantees (defense-in-depth — e.g. against a future
+-- REPEATABLE READ caller whose commit-time head read could be stale):
+-- (1) no two entries may chain off the same predecessor;
+CREATE UNIQUE INDEX IF NOT EXISTS audit_log_chain_prev_uniq
+  ON audit_log_chain (prev_chain_checksum)
+  WHERE prev_chain_checksum IS NOT NULL;
+-- (2) one genesis (prev IS NULL) per org chain (NULL org = the system chain).
+CREATE UNIQUE INDEX IF NOT EXISTS audit_log_chain_genesis_uniq
+  ON audit_log_chain ((COALESCE(org_id::text, 'NULL')))
+  WHERE prev_chain_checksum IS NULL;
+
+-- RLS: tenancy shape 1 (direct org_id) — the standard four policies, exactly
+-- what rls-coverage.integration.test.ts auto-discovery expects. NULL-org rows
+-- (system chain) are reachable only by system scope, mirroring audit_logs.
+ALTER TABLE audit_log_chain ENABLE ROW LEVEL SECURITY;
+ALTER TABLE audit_log_chain FORCE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname = 'public'
+                 AND tablename = 'audit_log_chain' AND policyname = 'breeze_org_isolation_select') THEN
+    CREATE POLICY breeze_org_isolation_select ON public.audit_log_chain
+      FOR SELECT USING (public.breeze_has_org_access(org_id));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname = 'public'
+                 AND tablename = 'audit_log_chain' AND policyname = 'breeze_org_isolation_insert') THEN
+    CREATE POLICY breeze_org_isolation_insert ON public.audit_log_chain
+      FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname = 'public'
+                 AND tablename = 'audit_log_chain' AND policyname = 'breeze_org_isolation_update') THEN
+    CREATE POLICY breeze_org_isolation_update ON public.audit_log_chain
+      FOR UPDATE USING (public.breeze_has_org_access(org_id))
+      WITH CHECK (public.breeze_has_org_access(org_id));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname = 'public'
+                 AND tablename = 'audit_log_chain' AND policyname = 'breeze_org_isolation_delete') THEN
+    CREATE POLICY breeze_org_isolation_delete ON public.audit_log_chain
+      FOR DELETE USING (public.breeze_has_org_access(org_id));
+  END IF;
+END $$;
+
+-- Privileges: breeze_app may read and append, never mutate. Retention/erasure
+-- DELETE via breeze_audit_admin (post-#915 a separate login credential), gated
+-- additionally by the append-only trigger below. Nobody gets UPDATE: the
+-- design never rewrites a chain entry (verify treats the first surviving
+-- entry's prev as the trusted anchor after retention pruning — see the spec).
+GRANT SELECT, INSERT ON TABLE audit_log_chain TO breeze_app;
+REVOKE UPDATE, DELETE ON TABLE audit_log_chain FROM breeze_app;
+GRANT USAGE ON SEQUENCE audit_log_chain_chain_seq_seq TO breeze_app;
+GRANT SELECT, DELETE ON TABLE audit_log_chain TO breeze_audit_admin;
+REVOKE UPDATE ON TABLE audit_log_chain FROM breeze_audit_admin;
+
+-- Append-only enforcement, mirroring audit_log_immutable on audit_logs:
+-- DELETE only under the retention GUC; UPDATE is NEVER allowed (no re-anchor
+-- exists in this design — rewriting a sealed entry is always tampering).
+CREATE OR REPLACE FUNCTION audit_log_chain_immutable() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+  allow_retention text := current_setting('breeze.allow_audit_retention', true);
+BEGIN
+  IF TG_OP = 'DELETE' AND allow_retention = '1' THEN
+    RETURN OLD;
+  END IF;
+
+  RAISE EXCEPTION USING
+    ERRCODE = 'P0001',
+    MESSAGE = 'audit log chain is append-only',
+    HINT = 'audit_log_chain entries cannot be modified or deleted. Retention pruning and tenant erasure use breeze_audit_admin plus the breeze.allow_audit_retention GUC (DELETE only); see jobs/auditRetention.ts and services/tenantCascade.ts.';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS audit_log_chain_block_update ON audit_log_chain;
+CREATE TRIGGER audit_log_chain_block_update BEFORE UPDATE ON audit_log_chain
+  FOR EACH ROW EXECUTE FUNCTION audit_log_chain_immutable();
+
+DROP TRIGGER IF EXISTS audit_log_chain_block_delete ON audit_log_chain;
+CREATE TRIGGER audit_log_chain_block_delete BEFORE DELETE ON audit_log_chain
+  FOR EACH ROW EXECUTE FUNCTION audit_log_chain_immutable();
+```
+
+- [ ] **Step 2.2: Add the Drizzle schema** (drift-check parity)
+
+In `apps/api/src/db/schema/audit.ts`: add `bigserial` to the existing `drizzle-orm/pg-core` import line, then append after the `auditLogs` table definition:
+
+```typescript
+// Side table for the tamper-evidence chain (issue #1002). Written ONLY by the
+// deferred commit-time seal trigger (see migration 2026-06-11-h) — application
+// code never inserts here directly. chain_seq is the chain order; the legacy
+// checksum/prev_checksum columns on audit_logs are vestigial (content-only /
+// NULL for new rows).
+export const auditLogChain = pgTable('audit_log_chain', {
+  chainSeq: bigserial('chain_seq', { mode: 'number' }).primaryKey(),
+  auditId: uuid('audit_id').notNull().references(() => auditLogs.id, { onDelete: 'cascade' }),
+  orgId: uuid('org_id').references(() => organizations.id),
+  contentChecksum: varchar('content_checksum', { length: 128 }).notNull(),
+  prevChainChecksum: varchar('prev_chain_checksum', { length: 128 }),
+  chainChecksum: varchar('chain_checksum', { length: 128 }).notNull(),
+  sealedAt: timestamp('sealed_at', { withTimezone: true }).notNull().defaultNow(),
+});
+```
+
+(`audit.ts` is already re-exported by `apps/api/src/db/schema/index.ts` via `export * from './audit'` — verify with `grep -n "audit" apps/api/src/db/schema/index.ts`; if it uses named exports instead, add `auditLogChain` there.)
+
+- [ ] **Step 2.3: Apply + verify the migration is idempotent**
+
+```bash
+cd /Users/toddhebebrand/bz-sec-cluster/apps/api
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run --config vitest.integration.config.ts src/__tests__/integration/audit-checksum.integration.test.ts 2>&1 | grep -E "auto-migrate|passed|failed"
+```
+
+Expected: log shows `[auto-migrate] Applying: 2026-06-11-g-audit-chain-table.sql`; existing tests still pass (behavior unchanged — old trigger still active). Then prove idempotency by re-applying by hand:
+
+```bash
+docker exec -i breeze-postgres-test psql -U breeze_test -d breeze_test < migrations/2026-06-11-g-audit-chain-table.sql
+```
+
+Expected: completes with only NOTICEs (`already exists, skipping`), zero errors.
+
+- [ ] **Step 2.4: Verify tsc + commit**
+
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit 2>&1 | grep -vE "agents\.test\.ts|apiKeyAuth\.test\.ts"
+cd /Users/toddhebebrand/bz-sec-cluster
+git add apps/api/migrations/2026-06-11-g-audit-chain-table.sql apps/api/src/db/schema/audit.ts apps/api/src/db/schema/index.ts
+git commit -m "feat(audit): audit_log_chain side table — RLS, grants, append-only (#1002 part 1)"
+```
+
+---
+
+### Task 3: Lifecycle-contract registrations for the new table
+
+A new `org_id`-columned table trips two contracts (learned the hard way on PR #1244): the GDPR cascade list and — because it's append-only — the cascade's audit-admin bypass set.
+
+**Files:**
+- Modify: `apps/api/src/services/tenantCascade.ts` (two edits)
+
+- [ ] **Step 3.1: Register in `ORG_CASCADE_DELETE_ORDER`**
+
+In `apps/api/src/services/tenantCascade.ts`, the alphabetical list at ~line 58, insert between `'audit_baselines'` and `'audit_logs'`:
+
+```typescript
+  'audit_baselines',
+  'audit_log_chain',
+  'audit_logs',
+```
+
+- [ ] **Step 3.2: Extend the audit-admin bypass set**
+
+Same file, ~line 275:
+
+```typescript
+const AUDIT_ADMIN_REQUIRED_TABLES: ReadonlySet<string> = new Set<string>(['audit_logs', 'audit_log_chain']);
+```
+
+(Why: the cascade's FK topo-sort direct-DELETEs `audit_log_chain` *before* `audit_logs`; without the `SET LOCAL ROLE breeze_audit_admin` + `breeze.allow_audit_retention='1'` bypass, the new append-only trigger blocks it and the whole erasure aborts.)
+
+- [ ] **Step 3.3: Run the contract + erasure integration tests**
+
+```bash
+cd /Users/toddhebebrand/bz-sec-cluster/apps/api
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run --config vitest.integration.config.ts src/__tests__/integration/tenantCascade.integration.test.ts src/__tests__/integration/tenantCascadeExecution.integration.test.ts
+```
+
+Expected: both PASS (list contract sees the new entry; execution test erases an org incl. the empty chain table without trigger errors).
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+cd /Users/toddhebebrand/bz-sec-cluster
+git add apps/api/src/services/tenantCascade.ts
+git commit -m "feat(audit): register audit_log_chain in GDPR cascade + audit-admin bypass (#1002)"
+```
+
+---### Task 4: Failing tests first — concurrency, deadlock-regression, same-tx linkage
+
+These go in `apps/api/src/__tests__/integration/audit-checksum.integration.test.ts`, inside the existing top-level describe, after the existing tests. They reference the suite's existing `orgId` / `db` / `withSystemDbAccessContext` / `getTestDb` helpers — match the file's existing imports (add `runOutsideDbContext` and `withDbAccessContext` to the import from `'../../db'` if not present).
+
+**Files:**
+- Modify: `apps/api/src/__tests__/integration/audit-checksum.integration.test.ts`
+
+- [ ] **Step 4.1: Add the three tests**
+
+```typescript
+  // ——— issue #1002 regression suite ———
+
+  // Fork regression: N independent transactions inserting same-org rows
+  // concurrently. Pre-fix, each reads the same committed head as `prev` and
+  // the chain forks → verify reports false breaks. Post-fix (-h- migration,
+  // deferred commit-time sealing) the seal serializes at commit → 0 breaks.
+  it('verify_chain returns no breaks under concurrent same-org inserts', async () => {
+    const N = 25;
+    await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        withSystemDbAccessContext(async () => {
+          await db.execute(sql`
+            INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result)
+            VALUES (${orgId}, 'system', gen_random_uuid(), ${'concurrent-' + i}, 'test', 'success')
+          `);
+        })
+      )
+    );
+
+    await withSystemDbAccessContext(async () => {
+      const breaks = (await db.execute(sql`
+        SELECT broken_id FROM public.audit_log_verify_chain(${orgId}::uuid)
+      `)) as unknown as Array<{ broken_id: string }>;
+      expect(breaks).toEqual([]);
+    });
+  });
+
+  // Deadlock regression (the bug that killed draft PR #1240): an in-tx audit
+  // insert followed — while that tx is still open — by a same-org insert on a
+  // SEPARATE pooled connection. With any lock held from insert to commit, the
+  // second insert blocks on the first while the first awaits the second: a
+  // JS-level deadlock Postgres can't detect (30s test timeout). With deferred
+  // sealing the first tx holds nothing until commit, so this completes fast.
+  // Generous explicit timeout so a regression fails loudly as a timeout here,
+  // not flakily elsewhere.
+  it('in-tx insert + separate-connection same-org insert does not deadlock', { timeout: 20_000 }, async () => {
+    await expect(
+      withDbAccessContext(
+        { scope: 'organization', orgId, accessibleOrgIds: [orgId] },
+        async () => {
+          await db.execute(sql`
+            INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result)
+            VALUES (${orgId}, 'system', gen_random_uuid(), 'deadlock-caller-tx', 'test', 'success')
+          `);
+          // Escape the caller tx exactly like logSessionAudit does.
+          await runOutsideDbContext(() =>
+            withSystemDbAccessContext(async () => {
+              await db.execute(sql`
+                INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result)
+                VALUES (${orgId}, 'system', gen_random_uuid(), 'deadlock-escaped', 'test', 'success')
+              `);
+            })
+          );
+          throw new Error('simulated caller rollback');
+        }
+      )
+    ).rejects.toThrow('simulated caller rollback');
+
+    await withSystemDbAccessContext(async () => {
+      // The escaped row committed and sealed; the rolled-back row left no
+      // orphan seal; the chain stayed clean.
+      const rows = (await db.execute(sql`
+        SELECT action FROM audit_logs WHERE org_id = ${orgId}::uuid AND action LIKE 'deadlock-%'
+      `)) as unknown as Array<{ action: string }>;
+      expect(rows.map((r) => r.action)).toEqual(['deadlock-escaped']);
+
+      const breaks = (await db.execute(sql`
+        SELECT broken_id FROM public.audit_log_verify_chain(${orgId}::uuid)
+      `)) as unknown as Array<{ broken_id: string }>;
+      expect(breaks).toEqual([]);
+    });
+  });
+
+  // Same-transaction multi-row batches were the OTHER documented limitation of
+  // the in-row chain. Deferred seals fire per row at commit in insertion order
+  // within one lock hold, so batches link correctly.
+  it('multiple same-org inserts in ONE transaction seal in order with no breaks', async () => {
+    await withSystemDbAccessContext(async () => {
+      await db.execute(sql`
+        INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result)
+        VALUES (${orgId}, 'system', gen_random_uuid(), 'batch-1', 'test', 'success'),
+               (${orgId}, 'system', gen_random_uuid(), 'batch-2', 'test', 'success'),
+               (${orgId}, 'system', gen_random_uuid(), 'batch-3', 'test', 'success')
+      `);
+    });
+
+    await withSystemDbAccessContext(async () => {
+      const breaks = (await db.execute(sql`
+        SELECT broken_id FROM public.audit_log_verify_chain(${orgId}::uuid)
+      `)) as unknown as Array<{ broken_id: string }>;
+      expect(breaks).toEqual([]);
+    });
+  });
+```
+
+- [ ] **Step 4.2: Run — confirm the concurrency test FAILS (fork) before the fix**
+
+```bash
+cd /Users/toddhebebrand/bz-sec-cluster/apps/api
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run --config vitest.integration.config.ts src/__tests__/integration/audit-checksum.integration.test.ts -t "concurrent same-org inserts"
+```
+
+Expected: **FAIL** — `breaks` is non-empty (the old in-row trigger forks). This is the TDD red. (The deadlock + batch tests may pass or fail at this stage depending on old-verify semantics; only the concurrency test's red matters here.)
+
+- [ ] **Step 4.3: Commit the red tests**
+
+```bash
+cd /Users/toddhebebrand/bz-sec-cluster
+git add apps/api/src/__tests__/integration/audit-checksum.integration.test.ts
+git commit -m "test(audit): #1002 regression suite — concurrency fork, deadlock, same-tx batch (red)"
+```
+
+---
+
+### Task 5: Migration `-h-` — seal function, deferred trigger, backfill, verify v2
+
+**Files:**
+- Create: `apps/api/migrations/2026-06-11-h-audit-chain-seal-and-verify.sql`
+
+- [ ] **Step 5.1: Write the migration**
+
+Create `apps/api/migrations/2026-06-11-h-audit-chain-seal-and-verify.sql` with exactly:
+
+```sql
+-- Issue #1002 (part 2 of 2): deferred commit-time sealing + verify v2.
+--
+-- 1. audit_log_compute_checksum (BEFORE INSERT) becomes content-only: no
+--    predecessor read, no lock, prev_checksum := NULL. Linkage moves to the
+--    audit_log_chain side table (the -g- migration).
+-- 2. audit_log_seal_one(row) appends a chain entry under a per-org advisory
+--    lock; the DEFERRED constraint trigger calls it at COMMIT, so the lock is
+--    held only through commit processing — never across application awaits.
+--    (The held-to-commit variant deadlocks; see draft PR #1240 and the design
+--    spec docs/superpowers/specs/2026-06-11-audit-chain-deferred-sealing-design.md.)
+-- 3. Backfill seals every existing audit row per org in (timestamp, id) order,
+--    ignoring the legacy (possibly forked) prev_checksum values entirely.
+-- 4. audit_log_verify_chain keeps its signature but walks the side table.
+--
+-- Lock namespace 1000200 (from issue #1002) is reserved for this chain lock.
+
+-- (1) Content-only BEFORE INSERT trigger. Reuses audit_log_canonical_payload
+-- from 2026-05-25-c with prev := NULL. convert_to(...,'UTF8'), not ::bytea —
+-- the cast throws on the backslash escapes jsonb details::text emits (#994).
+CREATE OR REPLACE FUNCTION audit_log_compute_checksum() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.prev_checksum := NULL;
+  NEW.checksum := encode(sha256(convert_to(audit_log_canonical_payload(NEW, NULL), 'UTF8')), 'hex');
+  RETURN NEW;
+END;
+$$;
+-- The existing trigger audit_log_chain_checksum (BEFORE INSERT, from -b-)
+-- already points at this function; CREATE OR REPLACE rebinds it in place.
+
+-- (2) Seal one audit row into the chain. Shared by the commit-time trigger and
+-- the backfill loop below. SECURITY INVOKER: runs under the inserting caller's
+-- RLS context — the chain row's org matches the audit row's org, so the
+-- standard shape-1 WITH CHECK passes for exactly the callers that could insert
+-- the audit row in the first place.
+CREATE OR REPLACE FUNCTION audit_log_seal_one(a audit_logs) RETURNS void
+LANGUAGE plpgsql AS $$
+DECLARE
+  prev_chain varchar(128);
+  content varchar(128);
+BEGIN
+  -- Serialize same-org seals. At commit time this is held only through the
+  -- remaining commit processing (sub-ms), so the #1240 two-connection deadlock
+  -- cannot occur. Reentrant for multi-row same-org batches in one tx.
+  PERFORM pg_advisory_xact_lock(1000200, hashtext(COALESCE(a.org_id::text, 'NULL')));
+
+  -- Head lookup, branched on NULL so both arms are index-friendly
+  -- (audit_log_chain_org_seq_idx; btree supports IS NULL scans).
+  IF a.org_id IS NULL THEN
+    SELECT chain_checksum INTO prev_chain
+    FROM audit_log_chain WHERE org_id IS NULL
+    ORDER BY chain_seq DESC LIMIT 1;
+  ELSE
+    SELECT chain_checksum INTO prev_chain
+    FROM audit_log_chain WHERE org_id = a.org_id
+    ORDER BY chain_seq DESC LIMIT 1;
+  END IF;
+
+  -- Content hash recomputed from the row (NOT read from a.checksum): uniform
+  -- for backfilled legacy rows (whose stored checksum is the old chained
+  -- value) and new rows alike, and keeps the chain independent of the
+  -- vestigial in-row columns.
+  content := encode(sha256(convert_to(audit_log_canonical_payload(a, NULL), 'UTF8')), 'hex');
+
+  INSERT INTO audit_log_chain (audit_id, org_id, content_checksum, prev_chain_checksum, chain_checksum)
+  VALUES (
+    a.id,
+    a.org_id,
+    content,
+    prev_chain,
+    encode(sha256(convert_to(COALESCE(prev_chain, '') || '|' || content, 'UTF8')), 'hex')
+  );
+END;
+$$;
+
+-- Commit-time wrapper.
+CREATE OR REPLACE FUNCTION audit_log_seal_chain() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  PERFORM audit_log_seal_one(NEW);
+  RETURN NULL;
+END;
+$$;
+
+-- Constraint triggers are the only trigger kind that can defer to COMMIT.
+DROP TRIGGER IF EXISTS audit_log_chain_seal ON audit_logs;
+CREATE CONSTRAINT TRIGGER audit_log_chain_seal
+  AFTER INSERT ON audit_logs
+  DEFERRABLE INITIALLY DEFERRED
+  FOR EACH ROW EXECUTE FUNCTION audit_log_seal_chain();
+
+-- (3) Backfill: seal every not-yet-sealed audit row, per org, in (timestamp,
+-- id) order. NOT EXISTS guard makes re-application a no-op, and also seals any
+-- straggler rows written by a not-yet-migrated API instance between -g- and
+-- -h- on a rolling deploy.
+DO $$
+DECLARE
+  rec audit_logs;
+BEGIN
+  FOR rec IN
+    SELECT a.* FROM audit_logs a
+    WHERE NOT EXISTS (SELECT 1 FROM audit_log_chain c WHERE c.audit_id = a.id)
+    ORDER BY a.org_id NULLS FIRST, a.timestamp, a.id
+  LOOP
+    PERFORM audit_log_seal_one(rec);
+  END LOOP;
+END $$;
+
+-- (4) Verify v2 — SAME signature as -c- (cron + tests call it unchanged) —
+-- but walks the side table. Flags, in chain_seq order:
+--   linkage break, chain-hash mismatch, content tamper (recomputed from the
+--   live audit row), dangling seal (audit row gone), and finally any UNSEALED
+--   audit row (a deleted chain entry). The FIRST surviving entry's prev is the
+--   trusted anchor: NULL for a virgin chain, or a reference to legitimately
+--   retention-pruned history — there is deliberately no re-anchor rewrite
+--   (rewriting the head's chain_checksum would invalidate its successor's
+--   stored prev; see the design spec).
+CREATE OR REPLACE FUNCTION audit_log_verify_chain(p_org_id uuid)
+RETURNS TABLE (broken_id uuid, expected varchar, actual varchar)
+LANGUAGE plpgsql AS $$
+DECLARE
+  c record;
+  a audit_logs;
+  prev varchar(128) := NULL;
+  is_first boolean := true;
+  expected_hash varchar(128);
+BEGIN
+  FOR c IN
+    SELECT ch.chain_seq, ch.audit_id, ch.content_checksum, ch.prev_chain_checksum, ch.chain_checksum
+    FROM audit_log_chain ch
+    WHERE ch.org_id IS NOT DISTINCT FROM p_org_id
+    ORDER BY ch.chain_seq
+  LOOP
+    -- Linkage. The FIRST surviving entry's prev is the trusted anchor (NULL =
+    -- virgin chain; non-NULL = retention pruned the prefix), so it is not
+    -- compared. Every later entry must reference its immediate predecessor.
+    IF NOT is_first AND c.prev_chain_checksum IS DISTINCT FROM prev THEN
+      broken_id := c.audit_id; expected := prev; actual := c.prev_chain_checksum;
+      RETURN NEXT;
+    END IF;
+    is_first := false;
+
+    -- Chain-hash integrity.
+    expected_hash := encode(sha256(convert_to(
+      COALESCE(c.prev_chain_checksum, '') || '|' || c.content_checksum, 'UTF8')), 'hex');
+    IF c.chain_checksum IS DISTINCT FROM expected_hash THEN
+      broken_id := c.audit_id; expected := expected_hash; actual := c.chain_checksum;
+      RETURN NEXT;
+    END IF;
+
+    -- Content integrity, recomputed from the live audit row.
+    SELECT * INTO a FROM audit_logs WHERE id = c.audit_id;
+    IF NOT FOUND THEN
+      broken_id := c.audit_id; expected := c.content_checksum; actual := NULL;
+      RETURN NEXT;
+    ELSE
+      expected_hash := encode(sha256(convert_to(audit_log_canonical_payload(a, NULL), 'UTF8')), 'hex');
+      IF expected_hash IS DISTINCT FROM c.content_checksum THEN
+        broken_id := c.audit_id; expected := expected_hash; actual := c.content_checksum;
+        RETURN NEXT;
+      END IF;
+    END IF;
+
+    prev := c.chain_checksum;
+  END LOOP;
+
+  -- Unsealed audit rows: every committed row gets a seal atomically, so a
+  -- missing entry means the chain row was deleted (or the seal trigger was
+  -- disabled) — flag it.
+  FOR a IN
+    SELECT al.* FROM audit_logs al
+    WHERE al.org_id IS NOT DISTINCT FROM p_org_id
+      AND NOT EXISTS (SELECT 1 FROM audit_log_chain ch WHERE ch.audit_id = al.id)
+    ORDER BY al.timestamp, al.id
+  LOOP
+    broken_id := a.id;
+    expected := 'sealed';
+    actual := NULL;
+    RETURN NEXT;
+  END LOOP;
+END;
+$$;
+```
+
+- [ ] **Step 5.2: Run the #1002 regression suite — red turns green**
+
+```bash
+cd /Users/toddhebebrand/bz-sec-cluster/apps/api
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run --config vitest.integration.config.ts src/__tests__/integration/audit-checksum.integration.test.ts
+```
+
+Expected: log shows `[auto-migrate] Applying: 2026-06-11-h-…`; ALL tests in the file pass — the three new ones AND the pre-existing ones (tamper-detect via UPDATE still flags `broken_id` because verify v2's content check catches it; insert/verify basics unchanged). If a pre-existing test asserts in-row `prev_checksum` linkage specifics, update that assertion to query `audit_log_chain` instead — the test's *intent* (linkage exists and verifies) is preserved by checking `verify_chain` returns empty.
+
+- [ ] **Step 5.3: THE deadlock proof — run the suite that hung draft #1240**
+
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run --config vitest.integration.config.ts src/__tests__/integration/audit-logs-rls.integration.test.ts
+```
+
+Expected: all 5 PASS, with the "transaction isolation: audit row persists even when caller request tx rolls back" test completing in normal time (**< 10 s**, not 30 s timeout). This is the go/no-go gate for the whole design.
+
+- [ ] **Step 5.4: Idempotency re-apply check**
+
+```bash
+docker exec -i breeze-postgres-test psql -U breeze_test -d breeze_test < migrations/2026-06-11-h-audit-chain-seal-and-verify.sql
+docker exec -i breeze-postgres-test psql -U breeze_test -d breeze_test -c "SELECT COUNT(*) AS dup FROM (SELECT audit_id FROM audit_log_chain GROUP BY audit_id HAVING COUNT(*) > 1) d;"
+```
+
+Expected: re-apply completes without error; `dup` = 0 (backfill NOT EXISTS guard held).
+
+- [ ] **Step 5.5: Update the stale limitation comment + commit**
+
+In `audit-checksum.integration.test.ts`, find the comment block (~lines 100-111) saying the same-transaction case "requires a chain_seq bigserial + per-org advisory lock — tracked as future-task hardening" and replace that sentence with: `Same-transaction batches are now handled by the deferred commit-time seal (migration 2026-06-11-h, issue #1002) — covered by the 'multiple same-org inserts in ONE transaction' test below.` If that block wraps a test that *asserts* the old limitation (e.g. expects a fork or skips), make it assert clean linkage instead (verify returns `[]`).
+
+```bash
+cd /Users/toddhebebrand/bz-sec-cluster
+git add apps/api/migrations/2026-06-11-h-audit-chain-seal-and-verify.sql apps/api/src/__tests__/integration/audit-checksum.integration.test.ts
+git commit -m "feat(audit): deferred commit-time chain sealing + verify v2 (#1002 part 2)"
+```
+
+---
+
+### Task 6: Retention prefix-cut (no re-anchor)
+
+`chain_seq` (commit) order can disagree with `timestamp` order around long transactions, so a raw timestamp-cutoff DELETE could punch a mid-chain hole. Retention switches to deleting the maximal chain **prefix** that is entirely older than the cutoff. There is **no re-anchor step**: verify v2 treats the first surviving entry's prev as the trusted anchor, so retention never modifies a chain entry (or any `audit_logs` column) — it only deletes.
+
+**Files:**
+- Modify: `apps/api/src/jobs/auditRetention.ts` (replace `deleteAndReanchor` with `deleteChainPrefix`)
+- Modify: `apps/api/src/__tests__/integration/auditRetentionPrivSep.integration.test.ts` (only if it asserts old re-anchor internals — check first)
+
+- [ ] **Step 6.1: Replace `deleteAndReanchor` with `deleteChainPrefix`**
+
+In `apps/api/src/jobs/auditRetention.ts`, replace the entire existing `deleteAndReanchor` function with:
+
+```typescript
+async function deleteChainPrefix(exec: SqlExecutor, policy: PolicyRow): Promise<number> {
+  // Prefix-cut delete (issue #1002 redesign): chain_seq order is COMMIT order,
+  // which can disagree with timestamp order around long transactions, so a raw
+  // `timestamp < cutoff` delete could remove a mid-chain entry and leave a
+  // permanent linkage hole. Instead delete the maximal chain PREFIX that is
+  // entirely older than the cutoff — everything below the first "young" row in
+  // chain order. Old stragglers sitting behind a young row survive one extra
+  // nightly cycle and are caught as the prefix advances.
+  //
+  // No re-anchor follows: audit_log_verify_chain treats the first surviving
+  // entry's prev_chain_checksum as the trusted anchor (it references the
+  // legitimately pruned prefix), so retention never UPDATEs the chain — or
+  // audit_logs — at all. The FK ON DELETE CASCADE removes the pruned rows'
+  // chain entries; their BEFORE DELETE trigger passes because both call paths
+  // set breeze.allow_audit_retention='1' SET LOCAL before calling this.
+  const result = await exec.execute(sql`
+    DELETE FROM audit_logs
+    WHERE id IN (
+      SELECT c.audit_id
+      FROM audit_log_chain c
+      WHERE c.org_id = ${policy.org_id}
+        AND c.chain_seq < COALESCE(
+          (
+            SELECT MIN(c2.chain_seq)
+            FROM audit_log_chain c2
+            JOIN audit_logs a2 ON a2.id = c2.audit_id
+            WHERE c2.org_id = ${policy.org_id}
+              AND a2.timestamp >= (now() - (${policy.retention_days}::int * interval '1 day'))
+          ),
+          (
+            SELECT MAX(c3.chain_seq) + 1
+            FROM audit_log_chain c3
+            WHERE c3.org_id = ${policy.org_id}
+          )
+        )
+    )
+  `);
+  const count = extractRowCount(result);
+
+  // Sweep any UNSEALED old rows too (shouldn't exist post-backfill; keeps
+  // retention complete if one ever appears). The chain has no entry for them,
+  // so deleting them can't affect linkage.
+  await exec.execute(sql`
+    DELETE FROM audit_logs a
+    WHERE a.org_id = ${policy.org_id}
+      AND a.timestamp < (now() - (${policy.retention_days}::int * interval '1 day'))
+      AND NOT EXISTS (SELECT 1 FROM audit_log_chain c WHERE c.audit_id = a.id)
+  `);
+
+  return count;
+}
+```
+
+Then update the two call sites in the same file (the dedicated-pool path and the legacy `SET ROLE` fallback — both currently call `deleteAndReanchor(tx …, policy)` / `deleteAndReanchor(dbModule.db …, policy)`): rename the call to `deleteChainPrefix(...)`, arguments unchanged. No other call-site changes — both paths already set `breeze.allow_audit_retention='1'` `SET LOCAL`, which is what authorizes the chain-entry cascade deletes.
+
+- [ ] **Step 6.2: Add the retention round-trip test**
+
+Append to `apps/api/src/__tests__/integration/audit-checksum.integration.test.ts` (uses the suite's existing helpers; `getTestDb()` is the superuser client):
+
+```typescript
+  // Retention prefix-cut: prune old rows, then the chain must still verify
+  // clean WITHOUT any re-anchor — the first surviving entry's prev is the
+  // trusted anchor.
+  it('retention prefix-cut prune leaves a clean chain with no re-anchor', async () => {
+    // Three rows: two backdated past any cutoff, one current. Timestamps can
+    // be set explicitly — the BEFORE trigger no longer rewrites them.
+    for (const [action, ts] of [
+      ['retain-old-1', "now() - interval '400 days'"],
+      ['retain-old-2', "now() - interval '399 days'"],
+      ['retain-new', 'now()'],
+    ] as const) {
+      await withSystemDbAccessContext(async () => {
+        await db.execute(sql.raw(`
+          INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result, timestamp)
+          VALUES ('${orgId}', 'system', gen_random_uuid(), '${action}', 'test', 'success', ${ts})
+        `));
+      });
+    }
+
+    // Prune at 365 days as superuser with the retention GUC (mirrors the
+    // audit-admin path; this test pins the SQL semantics, the privsep file
+    // pins the role/pool wiring). MUST run inside ONE transaction — SET LOCAL
+    // and the DELETE have to share a connection, and separate execute() calls
+    // on the pooled client may not (use the drizzle transaction API, never
+    // raw BEGIN/COMMIT executes).
+    const sudo = getTestDb();
+    await sudo.transaction(async (tx) => {
+      await tx.execute(sql`SET LOCAL breeze.allow_audit_retention = '1'`);
+      await tx.execute(sql`
+        DELETE FROM audit_logs
+        WHERE id IN (
+          SELECT c.audit_id FROM audit_log_chain c
+          WHERE c.org_id = ${orgId}
+            AND c.chain_seq < COALESCE(
+              (SELECT MIN(c2.chain_seq) FROM audit_log_chain c2
+               JOIN audit_logs a2 ON a2.id = c2.audit_id
+               WHERE c2.org_id = ${orgId} AND a2.timestamp >= (now() - interval '365 days')),
+              (SELECT MAX(c3.chain_seq) + 1 FROM audit_log_chain c3 WHERE c3.org_id = ${orgId})
+            )
+        )
+      `);
+    });
+
+    await withSystemDbAccessContext(async () => {
+      const old = (await db.execute(sql`
+        SELECT 1 FROM audit_logs WHERE org_id = ${orgId}::uuid AND action LIKE 'retain-old-%'
+      `)) as unknown as unknown[];
+      expect(old).toHaveLength(0);
+
+      // No re-anchor ran: the surviving head still carries a non-NULL prev
+      // pointing at pruned history — and verify must accept it as the anchor.
+      const breaks = (await db.execute(sql`
+        SELECT broken_id FROM public.audit_log_verify_chain(${orgId}::uuid)
+      `)) as unknown as Array<{ broken_id: string }>;
+      expect(breaks).toEqual([]);
+    });
+  });
+```
+
+(If the suite's `orgId` has accumulated rows from earlier tests in the same file run, the prefix-cut may also prune other backdated rows — there are none; all other tests insert with default `now()` timestamps, so they sit above the cutoff and survive. The `retain-new` row plus all prior rows must still verify clean.)
+
+- [ ] **Step 6.3: Run retention tests**
+
+```bash
+cd /Users/toddhebebrand/bz-sec-cluster/apps/api
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run --config vitest.integration.config.ts src/__tests__/integration/audit-checksum.integration.test.ts src/__tests__/integration/auditRetentionPrivSep.integration.test.ts
+```
+
+Expected: both files PASS. If `auditRetentionPrivSep` asserts old re-anchor internals (grep it for `prev_checksum` and `deleteAndReanchor` first), update those assertions to: rows-older-than-cutoff deleted, AND `audit_log_verify_chain(org)` returns `[]` afterwards (no re-anchor exists to assert anymore).
+
+- [ ] **Step 6.4: Commit**
+
+```bash
+cd /Users/toddhebebrand/bz-sec-cluster
+git add apps/api/src/jobs/auditRetention.ts apps/api/src/__tests__/integration/audit-checksum.integration.test.ts apps/api/src/__tests__/integration/auditRetentionPrivSep.integration.test.ts
+git commit -m "feat(audit): retention prefix-cut delete, no chain re-anchor needed (#1002)"
+```
+
+---
+
+### Task 7: Tamper-detection coverage for the new attack surfaces
+
+Verify v2 introduces two new detection paths that need pinning: chain-row deletion (unsealed-row sweep) and chain rewrite (hash mismatch).
+
+**Files:**
+- Modify: `apps/api/src/__tests__/integration/audit-checksum.integration.test.ts`
+
+- [ ] **Step 7.1: Add the two tests**
+
+```typescript
+  // Deleting a chain entry (hiding a row from the chain) is flagged by the
+  // unsealed-row sweep.
+  it('verify_chain flags an audit row whose chain entry was deleted', async () => {
+    let targetId = '';
+    await withSystemDbAccessContext(async () => {
+      const rows = (await db.execute(sql`
+        INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result)
+        VALUES (${orgId}, 'system', gen_random_uuid(), 'chain-delete-victim', 'test', 'success')
+        RETURNING id
+      `)) as unknown as Array<{ id: string }>;
+      targetId = rows[0]!.id;
+    });
+
+    // Superuser + trigger disable simulates a DBA-level attacker (same pattern
+    // as the existing UPDATE-tamper test).
+    const sudo = getTestDb();
+    await sudo.execute(sql`ALTER TABLE audit_log_chain DISABLE TRIGGER audit_log_chain_block_delete`);
+    try {
+      await sudo.execute(sql`DELETE FROM audit_log_chain WHERE audit_id = ${targetId}`);
+    } finally {
+      await sudo.execute(sql`ALTER TABLE audit_log_chain ENABLE TRIGGER audit_log_chain_block_delete`);
+    }
+
+    const breaks = (await sudo.execute(sql`
+      SELECT broken_id, expected FROM public.audit_log_verify_chain(${orgId}::uuid)
+    `)) as unknown as Array<{ broken_id: string; expected: string | null }>;
+    // The victim is flagged unsealed; its successor (if any) is flagged for
+    // linkage. At minimum the victim appears.
+    expect(breaks.map((b) => b.broken_id)).toContain(targetId);
+    // Restore chain consistency for subsequent tests in this file: re-seal.
+    await sudo.execute(sql`SELECT audit_log_seal_one(a) FROM audit_logs a WHERE a.id = ${targetId}`);
+  });
+
+  // breeze_app cannot mutate the chain at all (append-only + REVOKE).
+  it('chain table rejects UPDATE/DELETE from app-level SQL', async () => {
+    await withSystemDbAccessContext(async () => {
+      await expect(
+        db.execute(sql`UPDATE audit_log_chain SET chain_checksum = 'forged' WHERE org_id = ${orgId}::uuid`)
+      ).rejects.toThrow(/append-only|permission denied/);
+      await expect(
+        db.execute(sql`DELETE FROM audit_log_chain WHERE org_id = ${orgId}::uuid`)
+      ).rejects.toThrow(/append-only|permission denied/);
+    });
+  });
+```
+
+- [ ] **Step 7.2: Run + commit**
+
+```bash
+cd /Users/toddhebebrand/bz-sec-cluster/apps/api
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run --config vitest.integration.config.ts src/__tests__/integration/audit-checksum.integration.test.ts
+cd /Users/toddhebebrand/bz-sec-cluster
+git add apps/api/src/__tests__/integration/audit-checksum.integration.test.ts
+git commit -m "test(audit): pin chain-deletion and chain-mutation tamper detection (#1002)"
+```
+
+---
+
+### Task 8: Full verification sweep
+
+- [ ] **Step 8.1: Targeted test files (everything this change can touch)**
+
+```bash
+cd /Users/toddhebebrand/bz-sec-cluster/apps/api
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run --config vitest.integration.config.ts \
+  src/__tests__/integration/audit-checksum.integration.test.ts \
+  src/__tests__/integration/audit-logs-rls.integration.test.ts \
+  src/__tests__/integration/auditRetentionPrivSep.integration.test.ts \
+  src/__tests__/integration/tenantCascade.integration.test.ts \
+  src/__tests__/integration/tenantCascadeExecution.integration.test.ts
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run --config vitest.config.rls-coverage.ts
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/jobs/auditChainVerify.test.ts src/db/autoMigrate.test.ts
+```
+
+Expected: all integration files PASS. rls-coverage: `audit_log_chain` auto-discovered as shape 1 and passing (3 pre-existing local failures on `approval_requests` Shape 6 are known-unrelated — confirm the failures, if any, do NOT mention `audit_log_chain`). Unit files PASS (autoMigrate ordering test validates the `-g-`/`-h-` names).
+
+- [ ] **Step 8.2: Typecheck + drift**
+
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit 2>&1 | grep -vE "agents\.test\.ts|apiKeyAuth\.test\.ts"
+DATABASE_URL="postgresql://breeze_test:breeze_test@localhost:5433/breeze_test" PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm db:check-drift
+```
+
+Expected: tsc clean; drift check reports no drift (the Drizzle `auditLogChain` definition matches migration `-g-`). If drift flags a `bigserial` vs identity or timestamptz mismatch, fix the **Drizzle schema** to match the migration (never the shipped migration).
+
+- [ ] **Step 8.3: Commit any straggler fixes**
+
+```bash
+cd /Users/toddhebebrand/bz-sec-cluster
+git status --short   # commit anything outstanding with a descriptive message
+```
+
+---
+
+### Task 9: Ship
+
+- [ ] **Step 9.1: Push and open the PR**
+
+```bash
+cd /Users/toddhebebrand/bz-sec-cluster
+git push -u origin fix/audit-chain-deferred-sealing
+gh pr create --repo LanternOps/breeze --base main --head fix/audit-chain-deferred-sealing \
+  --title "fix(audit): deferred commit-time chain sealing — stops concurrent-write forks without the #1240 deadlock (#1002)" \
+  --body-file - <<'EOF'
+**Closes #1002.** Supersedes draft PR #1240.
+
+Design spec: `docs/superpowers/specs/2026-06-11-audit-chain-deferred-sealing-design.md`.
+
+**Problem:** the in-row audit hash chain forks under concurrent same-org inserts (false-positive `verify_chain` breaks in prod, US v0.68.2). The obvious fix — an advisory lock in the BEFORE INSERT trigger — deadlocks against the two-connection audit-write pattern (caller-tx insert + `logSessionAudit` escaping to a separate connection); proven deterministically on #1240.
+
+**Fix:** linkage moves to an append-only `audit_log_chain` side table written by a `DEFERRABLE INITIALLY DEFERRED` constraint trigger — the per-org advisory lock is held only through commit processing (sub-ms), never across application awaits. Inserts compute a content-only hash with no lock. `audit_log_verify_chain()` keeps its signature (the daily alerting cron from #1240 rides along unchanged) but walks the side table, detecting linkage breaks, chain-hash mismatches, content tamper, dangling seals, and deleted chain entries. Two partial unique indexes turn any residual fork into a loud constraint violation. Retention switches to prefix-cut deletes with NO re-anchor (the verifier trusts the first surviving link as the anchor), so neither `audit_logs` nor the chain is ever UPDATEd — both are strictly append-only. Same-transaction batches — the other documented limitation — now seal correctly too.
+
+**Proof:** `audit-logs-rls.integration.test.ts` rollback-isolation test (the one that hung #1240 at 30 s) passes in normal time; 25-way concurrency test → 0 breaks; tamper/chain-deletion/retention round-trips pinned.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+```
+
+- [ ] **Step 9.2: Close the superseded draft + cross-link**
+
+```bash
+gh pr close 1240 --repo LanternOps/breeze --comment "Superseded by the deferred commit-time sealing redesign — see the new PR (fix/audit-chain-deferred-sealing) and docs/superpowers/specs/2026-06-11-audit-chain-deferred-sealing-design.md. The verify-alerting cron from this draft was cherry-picked into the new branch unchanged."
+gh issue comment 1002 --repo LanternOps/breeze --body "Redesigned fix is up — deferred commit-time sealing into an append-only audit_log_chain side table (no held-to-commit lock, so the deadlock documented above cannot occur). See the new PR replacing draft #1240; design spec in docs/superpowers/specs/2026-06-11-audit-chain-deferred-sealing-design.md."
+```
+
+---
+
+## Self-review notes (done at planning time)
+
+- **Spec coverage:** fork fix (Tasks 4-5), deadlock proof (5.3), backfill/heal (5.1 §3), verify v2 incl. unsealed sweep + trusted-anchor first entry (5.1 §4), retention prefix-cut with no re-anchor (6), GDPR/contract registrations (3), RLS/grants/append-only (2), cron carry-over (1), anti-fork unique indexes (2.1). External anchor + telemetry-exclusion explicitly out of scope (spec).
+- **Design fix found during self-review:** the original draft re-anchored the surviving head after retention (rewriting its `chain_checksum`) — that would invalidate the *successor's* stored `prev_chain_checksum`, a self-inflicted break. Replaced with the trusted-anchor rule; as a result the chain table is strictly append-only (UPDATE never allowed, no UPDATE grants) and retention only deletes.
+- **Type consistency:** `audit_log_seal_one(a audit_logs)` used by trigger (5.1), backfill (5.1), and the re-seal in Task 7.1. Chain-hash formula `COALESCE(prev,'')||'|'||content_checksum` identical in seal and verify (both 5.1). GUC name `breeze.allow_audit_retention` everywhere. Verify signature `(broken_id uuid, expected varchar, actual varchar)` matches cron + existing tests. Renamed retention helper `deleteChainPrefix` with both call sites updated (6.1).
+- **Test-correctness fix found during self-review:** raw `BEGIN`/`COMMIT` via separate `execute()` calls on the pooled superuser client can land on different connections (postgres.js pool) — `SET LOCAL` would not bind to the `DELETE`. Test 6.2 uses `sudo.transaction(...)` instead.
+- **Known judgment calls left to the executor:** exact conflict resolution in 1.1; whether pre-existing tests assert in-row linkage internals (5.2, 6.3 — guidance given).

--- a/docs/superpowers/specs/2026-06-11-audit-chain-deferred-sealing-design.md
+++ b/docs/superpowers/specs/2026-06-11-audit-chain-deferred-sealing-design.md
@@ -48,7 +48,7 @@ inside commit processing, where no application code can interleave an `await`.
    |---|---|---|
    | `chain_seq` | `bigserial` PK | total order of the chain (per-org subsequences are walked by `WHERE org_id … ORDER BY chain_seq`) |
    | `audit_id` | `uuid` FK → `audit_logs(id)` ON DELETE CASCADE, UNIQUE | one seal per audit row |
-   | `org_id` | `uuid` NULL, FK → `organizations(id)` | chain key; NULL = system chain (mirrors `audit_logs.org_id`) |
+   | `org_id` | `uuid` NULL, FK → `organizations(id)` ON DELETE CASCADE (orphaned chain entries must not block org hard-deletes; GDPR erasure deletes explicitly first) | chain key; NULL = system chain (mirrors `audit_logs.org_id`) |
    | `content_checksum` | `varchar(128)` NOT NULL | `sha256(audit_log_canonical_payload(row, NULL))` — content-only, recomputable from the audit row |
    | `prev_chain_checksum` | `varchar(128)` NULL | previous entry's `chain_checksum` (NULL = genesis; non-NULL on an org's first surviving entry = retention-pruned history, treated as the trusted anchor) |
    | `chain_checksum` | `varchar(128)` NOT NULL | `sha256(COALESCE(prev,'') \|\| '\|' \|\| content_checksum)` |
@@ -123,7 +123,10 @@ REPEATABLE READ, where the head SELECT could read a stale snapshot) into a
 shape-1 policies (`breeze_has_org_access(org_id)` — auto-discovered by
 `rls-coverage`, no allowlist entry); `breeze_app` gets SELECT+INSERT only
 (UPDATE/DELETE revoked); append-only trigger allows **DELETE only** under
-`breeze.allow_audit_retention='1'` — **UPDATE is never allowed**, not even for
+`breeze.allow_audit_retention='1'` or via an FK cascade (`pg_trigger_depth() > 1`
+— the audit_logs parent is itself retention-GUC-guarded, and an organizations
+parent delete is total org erasure; direct SQL DELETE stays blocked) —
+**UPDATE is never allowed**, not even for
 retention, because the design needs no chain rewrite ever (see Retention).
 DELETE granted to `breeze_audit_admin` only (post-#915 a separate login
 credential). Hiding an `audit_logs` tamper by rewriting the chain therefore

--- a/docs/superpowers/specs/2026-06-11-audit-chain-deferred-sealing-design.md
+++ b/docs/superpowers/specs/2026-06-11-audit-chain-deferred-sealing-design.md
@@ -1,0 +1,185 @@
+# Audit Hash-Chain: Deferred Commit-Time Sealing (issue #1002)
+
+**Status:** approved design, ready to implement (plan: `docs/superpowers/plans/2026-06-11-audit-chain-deferred-sealing.md`)
+**Supersedes:** draft PR #1240 (advisory-lock-in-BEFORE-trigger — proven to deadlock, see below)
+
+## Problem
+
+The `audit_logs` tamper-evidence chain (PR #900) forks under concurrent same-org
+inserts: the BEFORE INSERT trigger reads the latest committed checksum as `prev`
+with no serialization, so N concurrent transactions all chain off the same
+predecessor. `audit_log_verify_chain()` then reports false-positive breaks
+(observed in production: US droplet, v0.68.2, ~20 false breaks in minutes).
+False positives make real tampering indistinguishable — the control is dead
+until fixed.
+
+## Why the obvious fix deadlocks (do not re-attempt)
+
+Draft PR #1240 added `pg_advisory_xact_lock(1000200, hashtext(org))` inside the
+BEFORE INSERT trigger. The lock is held **until the transaction commits**, and
+this codebase legitimately writes audit rows on **two connections within one
+logical flow**:
+
+- (a) the caller's own audit insert **inside** its request transaction
+  (`withDbAccessContext` wraps the request in a tx; the row must roll back with it), and
+- (b) `logSessionAudit` (`apps/api/src/routes/remote/helpers.ts`), which
+  deliberately **escapes** onto a separate pooled connection so the audit row
+  survives a caller rollback.
+
+Same org → (a) holds the advisory lock for the whole caller tx; (b)'s trigger
+blocks on that lock; the caller tx is `await`ing (b) in JS. Postgres cannot see
+the JS-side wait, so there is no deadlock detection — it hangs until timeout.
+Reproduced deterministically by
+`audit-logs-rls.integration.test.ts > "transaction isolation: audit row persists
+even when caller request tx rolls back"` (30 s timeout). **Any** held-to-commit
+per-org serialization (advisory lock, `SELECT … FOR UPDATE` on a head row) has
+the same hang.
+
+## Design: seal the chain at COMMIT, in a side table
+
+Move chain linkage out of the insert path entirely. Serialization happens only
+inside commit processing, where no application code can interleave an `await`.
+
+### Components
+
+1. **`audit_log_chain` side table** — one row per sealed audit row:
+
+   | column | type | notes |
+   |---|---|---|
+   | `chain_seq` | `bigserial` PK | total order of the chain (per-org subsequences are walked by `WHERE org_id … ORDER BY chain_seq`) |
+   | `audit_id` | `uuid` FK → `audit_logs(id)` ON DELETE CASCADE, UNIQUE | one seal per audit row |
+   | `org_id` | `uuid` NULL, FK → `organizations(id)` | chain key; NULL = system chain (mirrors `audit_logs.org_id`) |
+   | `content_checksum` | `varchar(128)` NOT NULL | `sha256(audit_log_canonical_payload(row, NULL))` — content-only, recomputable from the audit row |
+   | `prev_chain_checksum` | `varchar(128)` NULL | previous entry's `chain_checksum` (NULL = genesis; non-NULL on an org's first surviving entry = retention-pruned history, treated as the trusted anchor) |
+   | `chain_checksum` | `varchar(128)` NOT NULL | `sha256(COALESCE(prev,'') \|\| '\|' \|\| content_checksum)` |
+   | `sealed_at` | `timestamptz` DEFAULT now() | informational |
+
+2. **BEFORE INSERT trigger** (`audit_log_compute_checksum`, redefined): computes
+   a **content-only** checksum (`canonical_payload(NEW, NULL)`), sets
+   `prev_checksum := NULL`. **No predecessor read, no lock.** The legacy
+   `checksum`/`prev_checksum` columns on `audit_logs` become vestigial (old rows
+   keep their historical values; nothing reads them — verified by grep).
+
+3. **Deferred seal trigger** — `CREATE CONSTRAINT TRIGGER … AFTER INSERT ON
+   audit_logs DEFERRABLE INITIALLY DEFERRED FOR EACH ROW` → `audit_log_seal_chain()`,
+   which calls a shared `audit_log_seal_one(audit_logs)` function:
+   - `pg_advisory_xact_lock(1000200, hashtext(COALESCE(org,'NULL')))` — acquired
+     **at commit time**, held only through the remaining commit processing
+     (sub-millisecond), never across application awaits.
+   - Read the org's chain head (`ORDER BY chain_seq DESC LIMIT 1`, branched on
+     NULL org for index use).
+   - Insert the chain entry.
+
+4. **`audit_log_verify_chain(p_org_id)` v2** — same name and signature
+   (`RETURNS TABLE (broken_id uuid, expected varchar, actual varchar)`), so the
+   daily alerting cron (`auditChainVerify.ts`, from #1240) and existing tests
+   work unchanged. Walks the chain table in `chain_seq` order and flags:
+   - linkage break (`prev_chain_checksum` ≠ previous entry's `chain_checksum`);
+     the **first surviving entry's prev is the trusted anchor** (NULL for a
+     virgin chain; a non-NULL value refers to retention-pruned history — see
+     "Retention" below for why there is deliberately no re-anchor rewrite);
+   - chain-hash mismatch (recompute `sha256(prev || '|' || content)`);
+   - content tamper (recompute canonical hash from the live `audit_logs` row,
+     compare to `content_checksum`);
+   - dangling seal (chain entry whose audit row is gone);
+   - **unsealed audit row** (audit row with no chain entry = chain-row deletion).
+
+5. **Backfill** (in the same migration): seal every existing un-sealed audit row
+   per org in `(org NULLS FIRST, timestamp, id)` order via `audit_log_seal_one`.
+   `NOT EXISTS`-guarded → idempotent; ignores the legacy (possibly forked)
+   `prev_checksum` values entirely — no UPDATE of `audit_logs`, no history rewrite.
+
+### Why this kills the deadlock (trace of the failing test)
+
+T1 (caller tx) inserts audit row → BEFORE trigger computes content hash, **no
+lock**. T1 awaits `logSessionAudit` → T2 (separate connection) inserts + commits
+→ T2's deferred seal takes the lock (free — T1 holds nothing), seals, releases at
+commit end. T1 throws → rollback → T1's row and its **pending** deferred trigger
+vanish. No deadlock; no fork; (b) sealed, (a) gone — exactly the required
+semantics.
+
+Concurrent same-org commits serialize on the lock for microseconds at commit;
+each seal's head SELECT runs in a fresh READ COMMITTED snapshot taken after the
+previous committer released the lock (advisory xact locks release in post-commit
+cleanup, after the commit is visible), so it sees the new head. Same-tx
+multi-row batches seal in insertion order within one lock hold — this also fixes
+the *other* documented limitation (same-transaction batches, noted in
+`audit-checksum.integration.test.ts`).
+
+### Anti-fork hard guarantees (defense-in-depth)
+
+Two partial unique indexes convert any residual fork (e.g. a future caller using
+REPEATABLE READ, where the head SELECT could read a stale snapshot) into a
+**loud constraint violation** instead of a silent fork:
+
+- `UNIQUE (prev_chain_checksum) WHERE prev_chain_checksum IS NOT NULL` — no two
+  entries may chain off the same predecessor.
+- `UNIQUE ((COALESCE(org_id::text,'NULL'))) WHERE prev_chain_checksum IS NULL` —
+  one genesis per org chain.
+
+### Tamper-resistance of the side table
+
+**Stronger than `audit_logs`:** RLS enabled + forced with the standard four
+shape-1 policies (`breeze_has_org_access(org_id)` — auto-discovered by
+`rls-coverage`, no allowlist entry); `breeze_app` gets SELECT+INSERT only
+(UPDATE/DELETE revoked); append-only trigger allows **DELETE only** under
+`breeze.allow_audit_retention='1'` — **UPDATE is never allowed**, not even for
+retention, because the design needs no chain rewrite ever (see Retention).
+DELETE granted to `breeze_audit_admin` only (post-#915 a separate login
+credential). Hiding an `audit_logs` tamper by rewriting the chain therefore
+requires DBA-level access, not just app-level SQL or even the audit-admin
+credential.
+
+### Retention: prefix-cut delete, NO re-anchor
+
+`chain_seq` order is **commit order**, which can disagree with `timestamp` order
+around long-running transactions. A raw `timestamp < cutoff` DELETE could
+therefore punch a mid-chain hole. Fix: retention deletes the **maximal chain
+prefix entirely older than the cutoff** (everything with `chain_seq` below the
+first "young" row), plus any unsealed old rows. Stragglers behind a young row
+survive one extra cycle and are caught as the prefix advances.
+
+**There is deliberately no re-anchor rewrite.** Recomputing the surviving
+head's `chain_checksum` (the v1 approach) would invalidate its *successor's*
+stored `prev_chain_checksum` — a self-inflicted break. Instead the verifier
+treats the first surviving entry's `prev_chain_checksum` as the trusted anchor:
+its linkage refers to legitimately pruned history. The chain-hash and content
+checks still apply to that entry in full. Trust-model consequence: an actor who
+can DELETE chain+audit rows (audit-admin credential + GUC) can truncate a
+prefix undetectably — identical to the previous design's trust model, since
+retention is exactly that operation. Mid-chain deletions remain detectable
+(unsealed-row sweep + successor linkage break). `deleteAndReanchor` in
+`auditRetention.ts` becomes `deleteChainPrefix` and stops touching
+`audit_logs.checksum`/`prev_checksum` entirely — `audit_logs` itself is never
+UPDATEd by retention anymore.
+
+### GDPR / tenant erasure
+
+`audit_log_chain` has `org_id` → it joins `ORG_CASCADE_DELETE_ORDER` (between
+`audit_baselines` and `audit_logs`; FK topo-sort deletes it before `audit_logs`
+anyway) and `AUDIT_ADMIN_REQUIRED_TABLES` in `tenantCascade.ts` (its direct
+DELETE needs the same `SET LOCAL ROLE breeze_audit_admin` + retention-GUC bypass
+as `audit_logs`). `tenantExport` picks it up automatically from the list.
+
+## Accepted edges (documented, not blocking)
+
+- **Cross-org multi-row transactions** can theoretically deadlock at commit if
+  two such transactions seal orgs in opposite orders. This is a *DB-detectable*
+  deadlock (instant `40P01` error on one side, retryable) — not a silent hang.
+  Multi-org single-tx audit writers are rare system jobs; acceptable.
+- **Chain order ≠ timestamp order** near long transactions. Verification and
+  retention key on `chain_seq`; timestamp ordering is display-only.
+- **`breeze_migrations` note:** draft #1240's `2026-06-11-a-/-b-` migrations were
+  never merged but *were applied to local dev/test DBs*. New migrations use fresh
+  filenames (`-g-`, `-h-`); recorded-but-absent filenames are ignored by the
+  runner, and `-h-`'s `CREATE OR REPLACE` converges any DB that ran the draft
+  trigger. Fresh test DB (`pnpm test:docker:down && pnpm test:docker:up`) is the
+  clean path locally.
+
+## Out of scope (tracked elsewhere)
+
+- External anchor for the chain head (#916) — infra decision pending.
+- Excluding high-volume telemetry from the chain — worthwhile follow-up to shrink
+  the chain; not needed for correctness now.
+- Making `audit_logs` strictly append-only again (retention no longer UPDATEs it)
+  — possible future hardening of `audit_log_immutable`.


### PR DESCRIPTION
**Closes #1002.** Supersedes draft PR #1240.

Design spec (on this branch): `docs/superpowers/specs/2026-06-11-audit-chain-deferred-sealing-design.md`.

**Problem:** the in-row audit hash chain forks under concurrent same-org inserts (false-positive `verify_chain` breaks in prod, US v0.68.2). The obvious fix — an advisory lock in the BEFORE INSERT trigger — deadlocks against the two-connection audit-write pattern (caller-tx insert + `logSessionAudit` escaping to a separate connection); proven deterministically on #1240 (30 s hang).

**Fix:** linkage moves to an append-only `audit_log_chain` side table written by a `DEFERRABLE INITIALLY DEFERRED` constraint trigger — the per-org advisory lock is held only through commit processing (sub-ms), never across application awaits. Inserts compute a content-only hash with no lock. `audit_log_verify_chain()` keeps its signature (the daily alerting cron from #1240 rides along unchanged) but walks the side table, detecting linkage breaks, chain-hash mismatches, content tamper, dangling seals, and deleted chain entries. Two partial unique indexes turn any residual fork into a loud constraint violation. Retention switches to prefix-cut deletes with NO re-anchor (the verifier trusts the first surviving link as the anchor), so neither `audit_logs` nor the chain is ever UPDATEd — both are strictly append-only. Same-transaction batches — the other documented limitation — now seal correctly too.

**Bonus fixes found during implementation:**
- `ensureAppRole.ts` blanket-GRANTed `UPDATE, DELETE` (tables) and `UPDATE` (sequences) back to `breeze_app` on every boot, silently neutering the migration's REVOKEs — now re-revoked in the same step that already protected `audit_logs` (incl. `setval` on the chain sequence).
- Stale operator-facing incident text in the verify cron described the abandoned #1240 mechanism — aligned.

**Proof:** the `audit-logs-rls` rollback-isolation test (which deterministically hung #1240 at 30 s) passes in ~0.6-0.9 s; 25-way same-org concurrency → 0 breaks; same-tx batches → 0 breaks; tamper (row UPDATE), chain-entry deletion, app-level chain mutation, retention round-trip, and GDPR-erasure paths all pinned by tests. Full sweep: 27/27 across 5 integration files, 54/54 unit, tsc clean, no migration drift, `audit_log_chain` passes RLS shape-1 auto-discovery.

**Deploy notes:**
- The `-h-` backfill seals existing rows one-time at boot (~0.3-1 ms/row: ~90k prod rows ≈ under 2 min; self-hosters with multi-million-row audit tables should expect a proportionally longer first boot).
- Dev machines that ran draft #1240's `-a-`/`-b-` migrations: `-h-`'s `CREATE OR REPLACE` fully supersedes the draft trigger; recorded-but-absent draft filenames are ignored by the runner. Fresh test DBs rebuild clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)