### PR TITLE
feat(agent): PAM dormant ~breeze_elev admin account lifecycle (#1150)

### DIFF
--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/breeze-rmm/agent/internal/authstate"
 	"github.com/breeze-rmm/agent/internal/collectors"
 	"github.com/breeze-rmm/agent/internal/config"
+	"github.com/breeze-rmm/agent/internal/elevaccount"
 	"github.com/breeze-rmm/agent/internal/eventlog"
 	"github.com/breeze-rmm/agent/internal/heartbeat"
 	"github.com/breeze-rmm/agent/internal/ipc"
@@ -563,6 +564,13 @@ func startAgent(cfg *config.Config) (*agentComponents, error) {
 	// Only relevant on Windows when running as a service.
 	if cfg.IsService {
 		ensureSASPolicy()
+	}
+
+	if cfg.PAMEnabled && runtime.GOOS == "windows" {
+		if err := elevaccount.New().EnsureProvisioned(); err != nil {
+			log.Warn("failed to provision PAM dormant elevation account, continuing",
+				"error", err.Error())
+		}
 	}
 
 	// On macOS, the root daemon has Full Disk Access and can write to the

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -89,6 +89,10 @@ type Config struct {
 	// relay TURN, disconnect timeout, etc.) ship regardless.
 	DesktopDebug bool `mapstructure:"desktop_debug"`
 
+	// PAMEnabled gates privileged access management features, including the
+	// dormant local elevation account. Default false.
+	PAMEnabled bool `mapstructure:"pam_enabled"`
+
 	// Concurrency limits
 	MaxConcurrentCommands int `mapstructure:"max_concurrent_commands"`
 	CommandQueueSize      int `mapstructure:"command_queue_size"`
@@ -195,6 +199,7 @@ func Default() *Config {
 		LogMaxSizeMB:             50,
 		LogMaxBackups:            3,
 		LogShippingLevel:         "warn",
+		PAMEnabled:               false,
 		MaxConcurrentCommands:    10,
 		CommandQueueSize:         100,
 		AuditEnabled:             true,
@@ -422,6 +427,7 @@ func SaveTo(cfg *Config, cfgFile string) error {
 	viper.Set("policy_config_state_probes", cfg.PolicyConfigStateProbes)
 	viper.Set("log_level", cfg.LogLevel)
 	viper.Set("log_shipping_level", cfg.LogShippingLevel)
+	viper.Set("pam_enabled", cfg.PAMEnabled)
 	viper.Set("auto_update", cfg.AutoUpdate)
 	viper.Set("allow_dev_update", cfg.AllowDevUpdate)
 	viper.Set("pinned_manifest_pub_keys", cfg.PinnedManifestPubKeys)

--- a/agent/internal/elevaccount/elevaccount.go
+++ b/agent/internal/elevaccount/elevaccount.go
@@ -1,0 +1,123 @@
+package elevaccount
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"math/big"
+)
+
+const (
+	// AccountName is the dormant local admin account managed by the agent.
+	AccountName = "~breeze_elev"
+
+	defaultPasswordLength = 40
+	minPasswordLength     = 32
+)
+
+var (
+	upperChars  = []rune("ABCDEFGHJKLMNPQRSTUVWXYZ")
+	lowerChars  = []rune("abcdefghijkmnopqrstuvwxyz")
+	digitChars  = []rune("23456789")
+	symbolChars = []rune("!@#$%^&*_-+=?")
+	allChars    = []rune("ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789!@#$%^&*_-+=?")
+
+	// ErrUnsupportedPlatform is returned by the !windows stub.
+	ErrUnsupportedPlatform = errors.New("unsupported_platform")
+)
+
+// Credential is the cleartext credential minted locally for one actuation
+// window. Callers must clear Password after invoking the actuator.
+type Credential struct {
+	Username string
+	Password string
+}
+
+// AccountManager owns the lifecycle for the dormant local elevation account.
+type AccountManager interface {
+	EnsureProvisioned() error
+	Promote(ctx context.Context) (Credential, error)
+	Demote(ctx context.Context) error
+}
+
+// New returns the platform-default AccountManager. On non-Windows this is a
+// no-op manager whose Promote returns ErrUnsupportedPlatform.
+func New() AccountManager {
+	return newManager()
+}
+
+// GeneratePassword is exported for tests. It uses crypto/rand, enforces a
+// minimum length of 32, and guarantees upper/lower/digit/symbol complexity.
+func GeneratePassword(length int) (string, error) {
+	if length < minPasswordLength {
+		length = minPasswordLength
+	}
+
+	runes := make([]rune, length)
+	required := [][]rune{upperChars, lowerChars, digitChars, symbolChars}
+	for i, set := range required {
+		r, err := randomRune(set)
+		if err != nil {
+			return "", err
+		}
+		runes[i] = r
+	}
+	for i := len(required); i < len(runes); i++ {
+		r, err := randomRune(allChars)
+		if err != nil {
+			return "", err
+		}
+		runes[i] = r
+	}
+
+	for i := len(runes) - 1; i > 0; i-- {
+		j, err := randomInt(i + 1)
+		if err != nil {
+			return "", err
+		}
+		runes[i], runes[j] = runes[j], runes[i]
+	}
+
+	return string(runes), nil
+}
+
+func randomRune(set []rune) (rune, error) {
+	n, err := randomInt(len(set))
+	if err != nil {
+		return 0, err
+	}
+	return set[n], nil
+}
+
+func randomInt(max int) (int, error) {
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
+	if err != nil {
+		return 0, err
+	}
+	return int(n.Int64()), nil
+}
+
+type lifecycleState string
+
+const (
+	stateProvisioned lifecycleState = "provisioned"
+	statePromoted    lifecycleState = "promoted"
+	stateDemoted     lifecycleState = "demoted"
+)
+
+func nextLifecycleState(current lifecycleState, event string) lifecycleState {
+	switch event {
+	case "ensure":
+		return stateProvisioned
+	case "promote":
+		return statePromoted
+	case "demote":
+		return stateDemoted
+	default:
+		return current
+	}
+}
+
+func shouldStartupDemote(accountExists, inAdministrators bool) bool {
+	return accountExists && inAdministrators
+}

--- a/agent/internal/elevaccount/elevaccount_other.go
+++ b/agent/internal/elevaccount/elevaccount_other.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package elevaccount
+
+import "context"
+
+type noopManager struct{}
+
+func newManager() AccountManager { return &noopManager{} }
+
+func (*noopManager) EnsureProvisioned() error { return nil }
+
+func (*noopManager) Promote(context.Context) (Credential, error) {
+	return Credential{}, ErrUnsupportedPlatform
+}
+
+func (*noopManager) Demote(context.Context) error { return nil }

--- a/agent/internal/elevaccount/elevaccount_test.go
+++ b/agent/internal/elevaccount/elevaccount_test.go
@@ -1,0 +1,129 @@
+package elevaccount
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGeneratePasswordComplexityLengthAndUniqueness(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 20; i++ {
+		pw, err := GeneratePassword(32)
+		if err != nil {
+			t.Fatalf("GeneratePassword returned error: %v", err)
+		}
+		if len(pw) < 32 {
+			t.Fatalf("password length = %d, want >=32", len(pw))
+		}
+		if seen[pw] {
+			t.Fatalf("GeneratePassword produced duplicate password %q", pw)
+		}
+		seen[pw] = true
+		assertPasswordComplexity(t, pw)
+	}
+}
+
+func TestGeneratePasswordRaisesShortLengthToMinimum(t *testing.T) {
+	pw, err := GeneratePassword(8)
+	if err != nil {
+		t.Fatalf("GeneratePassword returned error: %v", err)
+	}
+	if len(pw) < minPasswordLength {
+		t.Fatalf("password length = %d, want >=%d", len(pw), minPasswordLength)
+	}
+}
+
+func TestNoopManagerReturnsUnsupportedReason(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no-op stub only compiled on non-Windows")
+	}
+
+	mgr := New()
+	if err := mgr.EnsureProvisioned(); err != nil {
+		t.Fatalf("EnsureProvisioned returned error: %v", err)
+	}
+	cred, err := mgr.Promote(context.Background())
+	if err == nil {
+		t.Fatalf("Promote returned nil error with cred %+v", cred)
+	}
+	if err != ErrUnsupportedPlatform {
+		t.Fatalf("Promote error = %q, want %q", err.Error(), ErrUnsupportedPlatform.Error())
+	}
+	if err := mgr.Demote(context.Background()); err != nil {
+		t.Fatalf("Demote returned error: %v", err)
+	}
+}
+
+func TestNoopManagerIsNonBlocking(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no-op stub only compiled on non-Windows")
+	}
+
+	mgr := New()
+	start := time.Now()
+	_, _ = mgr.Promote(context.Background())
+	_ = mgr.Demote(context.Background())
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("noop manager blocked for %v, expected near-instant", elapsed)
+	}
+}
+
+func TestLifecycleStateTransitions(t *testing.T) {
+	state := nextLifecycleState("", "ensure")
+	if state != stateProvisioned {
+		t.Fatalf("ensure state = %q, want %q", state, stateProvisioned)
+	}
+	state = nextLifecycleState(state, "promote")
+	if state != statePromoted {
+		t.Fatalf("promote state = %q, want %q", state, statePromoted)
+	}
+	state = nextLifecycleState(state, "demote")
+	if state != stateDemoted {
+		t.Fatalf("demote state = %q, want %q", state, stateDemoted)
+	}
+}
+
+func TestStartupCrashRecoveryDecision(t *testing.T) {
+	tests := []struct {
+		name             string
+		accountExists    bool
+		inAdministrators bool
+		want             bool
+	}{
+		{"missing account", false, false, false},
+		{"provisioned at rest", true, false, false},
+		{"leaked admin membership", true, true, true},
+		{"impossible missing admin member", false, true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldStartupDemote(tt.accountExists, tt.inAdministrators)
+			if got != tt.want {
+				t.Fatalf("shouldStartupDemote(%v, %v) = %v, want %v",
+					tt.accountExists, tt.inAdministrators, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWindowsNetapiRoundTripManual(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("netapi32 round-trip requires a Windows VM running with admin rights")
+	}
+	t.Skip("manual destructive local-account test; enable on a disposable Windows VM")
+}
+
+func assertPasswordComplexity(t *testing.T, pw string) {
+	t.Helper()
+	hasUpper := strings.ContainsAny(pw, string(upperChars))
+	hasLower := strings.ContainsAny(pw, string(lowerChars))
+	hasDigit := strings.ContainsAny(pw, string(digitChars))
+	hasSymbol := strings.ContainsAny(pw, string(symbolChars))
+	if !hasUpper || !hasLower || !hasDigit || !hasSymbol {
+		t.Fatalf("password does not meet complexity requirements: upper=%v lower=%v digit=%v symbol=%v",
+			hasUpper, hasLower, hasDigit, hasSymbol)
+	}
+}

--- a/agent/internal/elevaccount/elevaccount_windows.go
+++ b/agent/internal/elevaccount/elevaccount_windows.go
@@ -1,0 +1,314 @@
+//go:build windows
+
+package elevaccount
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
+)
+
+type windowsManager struct{}
+
+func newManager() AccountManager { return &windowsManager{} }
+
+var (
+	netapi32                    = syscall.NewLazyDLL("netapi32.dll")
+	procNetUserAdd              = netapi32.NewProc("NetUserAdd")
+	procNetUserSetInfo          = netapi32.NewProc("NetUserSetInfo")
+	procNetLocalGroupAddMembers = netapi32.NewProc("NetLocalGroupAddMembers")
+	procNetLocalGroupDelMembers = netapi32.NewProc("NetLocalGroupDelMembers")
+)
+
+const (
+	userInfoLevel1    = 1
+	userInfoLevel1003 = 1003
+	userInfoLevel1008 = 1008
+	localGroupLevel0  = 0
+
+	userPrivUser = 1
+
+	ufAccountDisable     = 0x0002
+	ufPasswdCantChange   = 0x0040
+	ufNormalAccount      = 0x0200
+	ufDontExpirePassword = 0x10000
+
+	accountDisabledFlags = ufNormalAccount | ufAccountDisable | ufPasswdCantChange | ufDontExpirePassword
+	accountEnabledFlags  = ufNormalAccount | ufPasswdCantChange | ufDontExpirePassword
+
+	nerrSuccess        = 0
+	nerrUserNotFound   = 2221
+	nerrUserExists     = 2224
+	nerrUserNotInGroup = 2237
+
+	errorMemberInAlias    = 1378
+	errorMemberNotInAlias = 1377
+
+	adminAliasSID = "S-1-5-32-544"
+
+	specialAccountsUserListPath = `SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\SpecialAccounts\UserList`
+)
+
+type userInfo1 struct {
+	Name        *uint16
+	Password    *uint16
+	PasswordAge uint32
+	Priv        uint32
+	HomeDir     *uint16
+	Comment     *uint16
+	Flags       uint32
+	ScriptPath  *uint16
+}
+
+type userInfo1003 struct {
+	Password *uint16
+}
+
+type userInfo1008 struct {
+	Flags uint32
+}
+
+type localGroupMembersInfo0 struct {
+	SID *windows.SID
+}
+
+func (*windowsManager) EnsureProvisioned() error {
+	password, err := GeneratePassword(defaultPasswordLength)
+	if err != nil {
+		return err
+	}
+	if err := netUserAddDisabled(AccountName, password); err != nil {
+		return err
+	}
+	if err := hideAccountFromLogon(AccountName); err != nil {
+		return err
+	}
+
+	// Crash cleanup does not need the old password: group membership removal
+	// and password rotation both work blind. Keep the secret out of agent.yaml
+	// and secrets.yaml by re-randomizing at rest instead of persisting it.
+	if err := removeFromAdministrators(AccountName); err != nil {
+		return err
+	}
+	password, err = GeneratePassword(defaultPasswordLength)
+	if err != nil {
+		return err
+	}
+	if err := setPassword(AccountName, password); err != nil {
+		return err
+	}
+	return setUserFlags(AccountName, accountDisabledFlags)
+}
+
+func (*windowsManager) Promote(ctx context.Context) (Credential, error) {
+	if err := ctx.Err(); err != nil {
+		return Credential{}, err
+	}
+	password, err := GeneratePassword(defaultPasswordLength)
+	if err != nil {
+		return Credential{}, err
+	}
+	if err := setPassword(AccountName, password); err != nil {
+		return Credential{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return Credential{}, err
+	}
+	if err := setUserFlags(AccountName, accountEnabledFlags); err != nil {
+		return Credential{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		cleanupAfterFailedPromote()
+		return Credential{}, err
+	}
+	if err := addToAdministrators(AccountName); err != nil {
+		cleanupAfterFailedPromote()
+		return Credential{}, err
+	}
+	return Credential{Username: AccountName, Password: password}, nil
+}
+
+func (*windowsManager) Demote(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := removeFromAdministrators(AccountName); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	password, err := GeneratePassword(defaultPasswordLength)
+	if err != nil {
+		return err
+	}
+	if err := setPassword(AccountName, password); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return setUserFlags(AccountName, accountDisabledFlags)
+}
+
+func netUserAddDisabled(username, password string) error {
+	namePtr, err := windows.UTF16PtrFromString(username)
+	if err != nil {
+		return err
+	}
+	passwordPtr, err := windows.UTF16PtrFromString(password)
+	if err != nil {
+		return err
+	}
+	commentPtr, err := windows.UTF16PtrFromString("Breeze dormant elevation account")
+	if err != nil {
+		return err
+	}
+
+	info := userInfo1{
+		Name:     namePtr,
+		Password: passwordPtr,
+		Priv:     userPrivUser,
+		Comment:  commentPtr,
+		Flags:    accountDisabledFlags,
+	}
+	var parmErr uint32
+	status, _, _ := procNetUserAdd.Call(
+		0,
+		uintptr(userInfoLevel1),
+		uintptr(unsafe.Pointer(&info)),
+		uintptr(unsafe.Pointer(&parmErr)),
+	)
+	switch uint32(status) {
+	case nerrSuccess, nerrUserExists:
+		return nil
+	default:
+		return fmt.Errorf("NetUserAdd %s failed: %w", username, syscall.Errno(status))
+	}
+}
+
+func setPassword(username, password string) error {
+	namePtr, err := windows.UTF16PtrFromString(username)
+	if err != nil {
+		return err
+	}
+	passwordPtr, err := windows.UTF16PtrFromString(password)
+	if err != nil {
+		return err
+	}
+	info := userInfo1003{Password: passwordPtr}
+	return netUserSetInfo(namePtr, userInfoLevel1003, unsafe.Pointer(&info))
+}
+
+func setUserFlags(username string, flags uint32) error {
+	namePtr, err := windows.UTF16PtrFromString(username)
+	if err != nil {
+		return err
+	}
+	info := userInfo1008{Flags: flags}
+	return netUserSetInfo(namePtr, userInfoLevel1008, unsafe.Pointer(&info))
+}
+
+func netUserSetInfo(namePtr *uint16, level uint32, info unsafe.Pointer) error {
+	var parmErr uint32
+	status, _, _ := procNetUserSetInfo.Call(
+		0,
+		uintptr(unsafe.Pointer(namePtr)),
+		uintptr(level),
+		uintptr(info),
+		uintptr(unsafe.Pointer(&parmErr)),
+	)
+	if status != nerrSuccess {
+		return fmt.Errorf("NetUserSetInfo level %d failed: %w", level, syscall.Errno(status))
+	}
+	return nil
+}
+
+func addToAdministrators(username string) error {
+	status, err := localGroupMembersCall(procNetLocalGroupAddMembers, username)
+	if err != nil {
+		return err
+	}
+	switch status {
+	case nerrSuccess, errorMemberInAlias:
+		return nil
+	default:
+		return fmt.Errorf("NetLocalGroupAddMembers failed: %w", syscall.Errno(status))
+	}
+}
+
+func removeFromAdministrators(username string) error {
+	status, err := localGroupMembersCall(procNetLocalGroupDelMembers, username)
+	if err != nil {
+		if errors.Is(err, windows.ERROR_NONE_MAPPED) {
+			return nil
+		}
+		return err
+	}
+	switch status {
+	case nerrSuccess, nerrUserNotFound, nerrUserNotInGroup, errorMemberNotInAlias:
+		return nil
+	default:
+		return fmt.Errorf("NetLocalGroupDelMembers failed: %w", syscall.Errno(status))
+	}
+}
+
+func localGroupMembersCall(proc *syscall.LazyProc, username string) (uint32, error) {
+	groupName, err := administratorsGroupName()
+	if err != nil {
+		return 0, err
+	}
+	groupPtr, err := windows.UTF16PtrFromString(groupName)
+	if err != nil {
+		return 0, err
+	}
+	userSID, _, _, err := windows.LookupSID("", username)
+	if err != nil {
+		return 0, err
+	}
+	info := localGroupMembersInfo0{SID: userSID}
+	status, _, _ := proc.Call(
+		0,
+		uintptr(unsafe.Pointer(groupPtr)),
+		uintptr(localGroupLevel0),
+		uintptr(unsafe.Pointer(&info)),
+		1,
+	)
+	return uint32(status), nil
+}
+
+func administratorsGroupName() (string, error) {
+	sid, err := windows.StringToSid(adminAliasSID)
+	if err != nil {
+		return "", err
+	}
+	account, _, _, err := sid.LookupAccount("")
+	if err != nil {
+		return "", err
+	}
+	if account == "" {
+		return "", fmt.Errorf("LookupAccountSid %s returned empty account name", adminAliasSID)
+	}
+	return account, nil
+}
+
+func hideAccountFromLogon(username string) error {
+	key, _, err := registry.CreateKey(registry.LOCAL_MACHINE, specialAccountsUserListPath, registry.SET_VALUE)
+	if err != nil {
+		return err
+	}
+	defer key.Close()
+	return key.SetDWordValue(username, 0)
+}
+
+func cleanupAfterFailedPromote() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_ = (&windowsManager{}).Demote(ctx)
+}

--- a/agent/internal/heartbeat/handlers_actuate.go
+++ b/agent/internal/heartbeat/handlers_actuate.go
@@ -4,31 +4,31 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"time"
 
+	"github.com/breeze-rmm/agent/internal/elevaccount"
 	"github.com/breeze-rmm/agent/internal/pamactuator"
 	"github.com/breeze-rmm/agent/internal/remote/tools"
 )
 
 // PAM Track 5: wire the server-pushed `actuate_elevation` device_command
 // into the pamactuator package. The server's approval-flow (Track 6) emits
-// this command after a tech approves an elevation request and the
-// dormant-admin credential has been minted. The agent types those creds
-// into the consent.exe prompt that's already up on the user's screen.
+// this command after a tech approves an elevation request. The command is a
+// go signal only; the agent mints the dormant-admin credential locally and
+// passes it to the actuator in-process.
 //
-// Payload shape (validated by apps/api/src/routes/agents/actuateElevation.ts):
+// Payload shape (validated by apps/api/src/routes/devices/actuateElevation.ts):
 //
 //	{
 //	  "elevationRequestId": "uuid",
-//	  "username":           "DOMAIN\\svc-pam",
-//	  "password":           "<one-time>",
 //	  "timeoutMs":          8000
 //	}
 //
-// We do NOT log the password or include it in the CommandResult. The
-// pamactuator's Reason field is mirrored into the result Stdout so the
-// server-side handler can switch on it for retry/escalate decisions
-// without parsing free-form text.
+// Deprecated username/password payload fields are ignored. The secret never
+// crosses the wire and is never included in CommandResult. The pamactuator's
+// Reason field is mirrored into Stdout so the server can switch on it without
+// parsing free-form text.
 
 func init() {
 	handlerRegistry[tools.CmdActuateElevation] = handleActuateElevation
@@ -38,8 +38,8 @@ func init() {
 // caller outside this file needs the shape.
 type actuatePayload struct {
 	ElevationRequestID string `json:"elevationRequestId"`
-	Username           string `json:"username"`
-	Password           string `json:"password"`
+	Username           string `json:"username,omitempty"`
+	Password           string `json:"password,omitempty"`
 	TimeoutMs          int    `json:"timeoutMs"`
 }
 
@@ -56,6 +56,9 @@ type actuateResult struct {
 // newActuator is an indirection so tests can install a fake without
 // touching package state in other tests. Set via swapActuatorForTest.
 var newActuator = pamactuator.New
+
+// newElevationAccountManager is test-swappable for handler safety tests.
+var newElevationAccountManager = elevaccount.New
 
 func handleActuateElevation(_ *Heartbeat, cmd Command) tools.CommandResult {
 	start := time.Now()
@@ -75,11 +78,34 @@ func handleActuateElevation(_ *Heartbeat, cmd Command) tools.CommandResult {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*timeout)
 	defer cancel()
 
+	manager := newElevationAccountManager()
+	cred, err := manager.Promote(ctx)
+	if err != nil {
+		out := actuateResult{
+			ElevationRequestID: payload.ElevationRequestID,
+			Success:            false,
+			Reason:             promoteFailureReason(err),
+			Message:            err.Error(),
+		}
+		return tools.NewSuccessResult(out, time.Since(start).Milliseconds())
+	}
+	defer func() {
+		demoteCtx, demoteCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer demoteCancel()
+		if err := manager.Demote(demoteCtx); err != nil {
+			log.Warn("actuate_elevation: demote failed",
+				"elevationRequestId", payload.ElevationRequestID,
+				"error", err.Error(),
+			)
+		}
+	}()
+	defer zeroCredential(&cred)
+
 	act := newActuator()
 	res := act.Trigger(ctx, pamactuator.Request{
 		ElevationRequestID: payload.ElevationRequestID,
-		Username:           payload.Username,
-		Password:           payload.Password,
+		Username:           cred.Username,
+		Password:           cred.Password,
 		TimeoutMs:          payload.TimeoutMs,
 	})
 
@@ -98,7 +124,8 @@ func handleActuateElevation(_ *Heartbeat, cmd Command) tools.CommandResult {
 }
 
 // parseActuatePayload validates the incoming payload. Required fields:
-// elevationRequestId, username, password. timeoutMs is optional.
+// elevationRequestId. timeoutMs is optional. Deprecated username/password
+// fields may be present but are ignored by the handler.
 func parseActuatePayload(p map[string]any) (actuatePayload, error) {
 	raw, err := json.Marshal(p)
 	if err != nil {
@@ -111,11 +138,25 @@ func parseActuatePayload(p map[string]any) (actuatePayload, error) {
 	if out.ElevationRequestID == "" {
 		return actuatePayload{}, errors.New("actuate_elevation: elevationRequestId is required")
 	}
-	if out.Username == "" {
-		return actuatePayload{}, errors.New("actuate_elevation: username is required")
-	}
-	if out.Password == "" {
-		return actuatePayload{}, errors.New("actuate_elevation: password is required")
-	}
 	return out, nil
+}
+
+func promoteFailureReason(err error) string {
+	if errors.Is(err, elevaccount.ErrUnsupportedPlatform) {
+		return elevaccount.ErrUnsupportedPlatform.Error()
+	}
+	if err == nil {
+		return "credential_promote_failed"
+	}
+	return "credential_promote_failed"
+}
+
+func zeroCredential(cred *elevaccount.Credential) {
+	if cred == nil {
+		return
+	}
+	if cred.Password != "" {
+		cred.Password = strings.Repeat("\x00", len(cred.Password))
+		cred.Password = ""
+	}
 }

--- a/agent/internal/heartbeat/handlers_actuate_test.go
+++ b/agent/internal/heartbeat/handlers_actuate_test.go
@@ -1,0 +1,213 @@
+package heartbeat
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/elevaccount"
+	"github.com/breeze-rmm/agent/internal/pamactuator"
+	"github.com/breeze-rmm/agent/internal/remote/tools"
+)
+
+type fakeElevationManager struct {
+	cred        elevaccount.Credential
+	promoteErr  error
+	promoteSeen int
+	demoteSeen  int
+}
+
+func (m *fakeElevationManager) EnsureProvisioned() error { return nil }
+
+func (m *fakeElevationManager) Promote(context.Context) (elevaccount.Credential, error) {
+	m.promoteSeen++
+	if m.promoteErr != nil {
+		return elevaccount.Credential{}, m.promoteErr
+	}
+	return m.cred, nil
+}
+
+func (m *fakeElevationManager) Demote(context.Context) error {
+	m.demoteSeen++
+	return nil
+}
+
+type fakeActuator struct {
+	trigger func(context.Context, pamactuator.Request) pamactuator.Result
+}
+
+func (a fakeActuator) Trigger(ctx context.Context, req pamactuator.Request) pamactuator.Result {
+	return a.trigger(ctx, req)
+}
+
+func TestParseActuatePayloadAcceptsSlimGoSignal(t *testing.T) {
+	payload, err := parseActuatePayload(map[string]any{
+		"elevationRequestId": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+		"timeoutMs":          float64(5000),
+	})
+	if err != nil {
+		t.Fatalf("parseActuatePayload returned error: %v", err)
+	}
+	if payload.ElevationRequestID != "cccccccc-cccc-4ccc-8ccc-cccccccccccc" {
+		t.Fatalf("ElevationRequestID = %q", payload.ElevationRequestID)
+	}
+	if payload.Username != "" || payload.Password != "" {
+		t.Fatalf("deprecated credential fields should be empty, got %+v", payload)
+	}
+	if payload.TimeoutMs != 5000 {
+		t.Fatalf("TimeoutMs = %d, want 5000", payload.TimeoutMs)
+	}
+}
+
+func TestParseActuatePayloadIgnoresDeprecatedCredentials(t *testing.T) {
+	payload, err := parseActuatePayload(map[string]any{
+		"elevationRequestId": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+		"username":           "server-user",
+		"password":           "server-password",
+	})
+	if err != nil {
+		t.Fatalf("parseActuatePayload returned error: %v", err)
+	}
+	if payload.Username != "server-user" || payload.Password != "server-password" {
+		t.Fatalf("expected deprecated fields to parse but be ignored later, got %+v", payload)
+	}
+}
+
+func TestHandleActuateElevationUsesLocalCredentialAndDemotes(t *testing.T) {
+	manager := &fakeElevationManager{
+		cred: elevaccount.Credential{Username: "~breeze_elev", Password: "minted-local-secret"},
+	}
+	var gotReq pamactuator.Request
+	swapElevationManagerForTest(t, func() elevaccount.AccountManager { return manager })
+	swapActuatorForTest(t, func() pamactuator.Actuator {
+		return fakeActuator{trigger: func(_ context.Context, req pamactuator.Request) pamactuator.Result {
+			gotReq = req
+			return pamactuator.Result{Success: true, Reason: "ok", DetailMessage: "typed"}
+		}}
+	})
+
+	result := handleActuateElevation(nil, Command{
+		ID:   "cmd-1",
+		Type: tools.CmdActuateElevation,
+		Payload: map[string]any{
+			"elevationRequestId": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+			"username":           "payload-user",
+			"password":           "payload-password",
+			"timeoutMs":          float64(5000),
+		},
+	})
+
+	if result.Status != "completed" {
+		t.Fatalf("Status = %q, want completed: %+v", result.Status, result)
+	}
+	if gotReq.Username != "~breeze_elev" {
+		t.Fatalf("actuator username = %q, want local credential", gotReq.Username)
+	}
+	if gotReq.Password != "minted-local-secret" {
+		t.Fatalf("actuator password = %q, want minted local secret", gotReq.Password)
+	}
+	if manager.promoteSeen != 1 {
+		t.Fatalf("Promote called %d times, want 1", manager.promoteSeen)
+	}
+	if manager.demoteSeen != 1 {
+		t.Fatalf("Demote called %d times, want 1", manager.demoteSeen)
+	}
+
+	var out actuateResult
+	if err := json.Unmarshal([]byte(result.Stdout), &out); err != nil {
+		t.Fatalf("stdout is not actuateResult JSON: %v", err)
+	}
+	if !out.Success || out.Reason != "ok" {
+		t.Fatalf("unexpected actuate result: %+v", out)
+	}
+}
+
+func TestHandleActuateElevationDemotesWhenActuatorPanics(t *testing.T) {
+	manager := &fakeElevationManager{
+		cred: elevaccount.Credential{Username: "~breeze_elev", Password: "minted-local-secret"},
+	}
+	swapElevationManagerForTest(t, func() elevaccount.AccountManager { return manager })
+	swapActuatorForTest(t, func() pamactuator.Actuator {
+		return fakeActuator{trigger: func(context.Context, pamactuator.Request) pamactuator.Result {
+			panic("actuator panic")
+		}}
+	})
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected actuator panic to propagate")
+		}
+		if manager.demoteSeen != 1 {
+			t.Fatalf("Demote called %d times after panic, want 1", manager.demoteSeen)
+		}
+	}()
+
+	_ = handleActuateElevation(nil, Command{
+		ID:   "cmd-1",
+		Type: tools.CmdActuateElevation,
+		Payload: map[string]any{
+			"elevationRequestId": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+			"timeoutMs":          float64(5000),
+		},
+	})
+}
+
+func TestHandleActuateElevationPromoteFailureReturnsStructuredResult(t *testing.T) {
+	manager := &fakeElevationManager{promoteErr: elevaccount.ErrUnsupportedPlatform}
+	swapElevationManagerForTest(t, func() elevaccount.AccountManager { return manager })
+	swapActuatorForTest(t, func() pamactuator.Actuator {
+		return fakeActuator{trigger: func(context.Context, pamactuator.Request) pamactuator.Result {
+			t.Fatal("actuator should not run when Promote fails")
+			return pamactuator.Result{}
+		}}
+	})
+
+	result := handleActuateElevation(nil, Command{
+		ID:   "cmd-1",
+		Type: tools.CmdActuateElevation,
+		Payload: map[string]any{
+			"elevationRequestId": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+		},
+	})
+
+	if result.Status != "completed" {
+		t.Fatalf("Status = %q, want completed", result.Status)
+	}
+	var out actuateResult
+	if err := json.Unmarshal([]byte(result.Stdout), &out); err != nil {
+		t.Fatalf("stdout is not actuateResult JSON: %v", err)
+	}
+	if out.Success {
+		t.Fatalf("Success = true, want false")
+	}
+	if out.Reason != "unsupported_platform" {
+		t.Fatalf("Reason = %q, want unsupported_platform", out.Reason)
+	}
+	if manager.demoteSeen != 0 {
+		t.Fatalf("Demote called %d times without successful Promote, want 0", manager.demoteSeen)
+	}
+}
+
+func TestPromoteFailureReason(t *testing.T) {
+	if got := promoteFailureReason(elevaccount.ErrUnsupportedPlatform); got != "unsupported_platform" {
+		t.Fatalf("unsupported reason = %q", got)
+	}
+	if got := promoteFailureReason(errors.New("boom")); got != "credential_promote_failed" {
+		t.Fatalf("generic reason = %q", got)
+	}
+}
+
+func swapActuatorForTest(t *testing.T, fn func() pamactuator.Actuator) {
+	t.Helper()
+	orig := newActuator
+	newActuator = fn
+	t.Cleanup(func() { newActuator = orig })
+}
+
+func swapElevationManagerForTest(t *testing.T, fn func() elevaccount.AccountManager) {
+	t.Helper()
+	orig := newElevationAccountManager
+	newElevationAccountManager = fn
+	t.Cleanup(func() { newElevationAccountManager = orig })
+}

--- a/agent/internal/pamactuator/actuator.go
+++ b/agent/internal/pamactuator/actuator.go
@@ -27,12 +27,12 @@
 //
 // Threat model: the actuator runs as SYSTEM (the agent service identity),
 // types the secret on the input desktop, and never persists it. The
-// caller (server-side approval flow, Track 6) is responsible for
+// caller (the agent-side elevation-account manager) is responsible for
 // generating the credential just-in-time and revoking it after use.
 //
 // Server contract: the actuator is triggered by a `actuate_elevation`
-// device_command whose payload carries the elevation_request id plus the
-// already-approved credential pair to type. See
+// device_command whose payload carries only a go signal. The heartbeat
+// handler mints the credential locally before calling this package. See
 // heartbeat/handlers_actuate.go.
 package pamactuator
 
@@ -48,8 +48,7 @@ type Request struct {
 	ElevationRequestID string
 
 	// Username is the dormant-admin account name to type into the
-	// consent.exe username field. Already includes any DOMAIN\ prefix
-	// the server chose to ship.
+	// consent.exe username field.
 	Username string
 
 	// Password is the cleartext credential to type into the password

--- a/apps/api/src/routes/devices/actuateElevation.test.ts
+++ b/apps/api/src/routes/devices/actuateElevation.test.ts
@@ -263,6 +263,18 @@ describe('POST /devices/:id/actuate-elevation', () => {
   });
 
   describe('input validation', () => {
+    it('accepts a slim go-signal body without username/password', async () => {
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValue(undefined as never);
+
+      const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ elevationRequestId: ELEVATION_ID }),
+      });
+      // 404 means validation passed and route logic ran (device not found).
+      expect(res.status).toBe(404);
+    });
+
     it('rejects missing elevationRequestId', async () => {
       const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
         method: 'POST',
@@ -456,7 +468,7 @@ describe('POST /devices/:id/actuate-elevation', () => {
       vi.mocked(getDeviceWithOrgCheck).mockResolvedValue(SAMPLE_DEVICE as never);
     });
 
-    it('queues actuate_elevation with full credential payload', async () => {
+    it('queues actuate_elevation with go-signal payload only', async () => {
       const { commandValues } = rigTransaction({
         elevationRow: SAMPLE_ELEVATION,
         commandRow: {
@@ -473,8 +485,6 @@ describe('POST /devices/:id/actuate-elevation', () => {
         headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
         body: JSON.stringify({
           elevationRequestId: ELEVATION_ID,
-          username: 'DOMAIN\\svc-admin',
-          password: 'one-time',
           timeoutMs: 5000,
         }),
       });
@@ -495,12 +505,13 @@ describe('POST /devices/:id/actuate-elevation', () => {
           createdBy: USER_ID,
           payload: expect.objectContaining({
             elevationRequestId: ELEVATION_ID,
-            username: 'DOMAIN\\svc-admin',
-            password: 'one-time',
             timeoutMs: 5000,
           }),
         }),
       );
+      const queued = commandValues.mock.calls[0]![0] as any;
+      expect(queued.payload).not.toHaveProperty('username');
+      expect(queued.payload).not.toHaveProperty('password');
     });
 
     it('applies the default 8000ms timeout when omitted', async () => {
@@ -520,8 +531,6 @@ describe('POST /devices/:id/actuate-elevation', () => {
         headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
         body: JSON.stringify({
           elevationRequestId: ELEVATION_ID,
-          username: 'u',
-          password: 'p',
         }),
       });
 
@@ -533,7 +542,7 @@ describe('POST /devices/:id/actuate-elevation', () => {
       );
     });
 
-    it('writes audit without the password and an elevation_audit happy-path row', async () => {
+    it('writes audit without credentials and an elevation_audit happy-path row', async () => {
       const { auditInsertCalls } = rigTransaction({
         elevationRow: SAMPLE_ELEVATION,
         commandRow: {
@@ -550,28 +559,30 @@ describe('POST /devices/:id/actuate-elevation', () => {
         headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
         body: JSON.stringify({
           elevationRequestId: ELEVATION_ID,
-          username: 'svc-admin',
-          password: 'do-not-log-me',
+          username: 'deprecated-payload-user',
+          password: 'deprecated-payload-password',
         }),
       });
 
       expect(writeRouteAudit).toHaveBeenCalledTimes(1);
       const auditPayload = vi.mocked(writeRouteAudit).mock.calls[0]![1] as any;
       expect(auditPayload.action).toBe('device.elevation.actuate');
-      expect(auditPayload.details.username).toBe('svc-admin');
-      expect(JSON.stringify(auditPayload)).not.toContain('do-not-log-me');
+      expect(auditPayload.details).not.toHaveProperty('username');
+      expect(JSON.stringify(auditPayload)).not.toContain('deprecated-payload-user');
+      expect(JSON.stringify(auditPayload)).not.toContain('deprecated-payload-password');
 
-      // elevation_audit row written inside the transaction, also password-free
+      // elevation_audit row written inside the transaction, also credential-free
       expect(auditInsertCalls).toHaveLength(1);
       const txAudit = auditInsertCalls[0]!.values as any;
       expect(txAudit.eventType).toBe('command_executed');
       expect(txAudit.details).toMatchObject({
         deviceId: DEVICE_ID,
         commandId: 'cmd-3',
-        username: 'svc-admin',
         timeoutMs: 8000,
       });
-      expect(JSON.stringify(txAudit)).not.toContain('do-not-log-me');
+      expect(txAudit.details).not.toHaveProperty('username');
+      expect(JSON.stringify(txAudit)).not.toContain('deprecated-payload-user');
+      expect(JSON.stringify(txAudit)).not.toContain('deprecated-payload-password');
     });
   });
 });

--- a/apps/api/src/routes/devices/actuateElevation.ts
+++ b/apps/api/src/routes/devices/actuateElevation.ts
@@ -39,24 +39,24 @@ actuateElevationRoutes.use('*', async (c, next) => {
  * POST /devices/:id/actuate-elevation
  *
  * PAM Track 5: queue an `actuate_elevation` device_command that the agent
- * picks up and uses to type the dormant-admin credentials into the
- * consent.exe prompt that's already up on the user's screen.
+ * picks up as a go signal for the consent.exe prompt that's already up on
+ * the user's screen. The agent mints the local dormant-admin credential and
+ * passes it to the actuator in-process; the secret never crosses the wire.
  *
  * This is the server-side push half of the actuator. The agent-side
  * implementation lives in `agent/internal/pamactuator/`.
  *
  * Scope: this PR ships only the command-queueing contract. The wider
  * approval flow that decides WHEN to call this — match elevation_requests
- * row against software_policies, mint a JIT credential, fan out to the
- * right agent — is Track 6.
+ * row against software_policies and fan out to the right agent — is Track 6.
  *
  * Auth: organization+ scope, DEVICES_EXECUTE permission, MFA. Same gates
  * as POST /devices/:id/commands, because functionally that's what this
- * is: a typed wrapper that validates the elevationRequestId / credential
+ * is: a typed wrapper that validates the elevationRequestId go-signal
  * payload before insertion.
  *
- * The credential is shipped through the command payload exactly once; the
- * agent does not persist it. device_commands is intentionally
+ * The command payload carries only the go signal; the credential is minted
+ * locally by the agent and never shipped. device_commands is intentionally
  * system-scoped (see CLAUDE.md tenancy notes), but RLS still covers the
  * `devices` row we read on the way in.
  *
@@ -70,8 +70,8 @@ actuateElevationRoutes.use('*', async (c, next) => {
 
 const actuateElevationSchema = z.object({
   elevationRequestId: z.string().uuid(),
-  username: z.string().min(1).max(255),
-  password: z.string().min(1).max(1024),
+  username: z.string().min(1).max(255).optional(),
+  password: z.string().min(1).max(1024).optional(),
   timeoutMs: z.number().int().min(1000).max(60000).optional(),
 });
 
@@ -200,8 +200,6 @@ actuateElevationRoutes.post(
           type: 'actuate_elevation',
           payload: {
             elevationRequestId: data.elevationRequestId,
-            username: data.username,
-            password: data.password,
             timeoutMs: data.timeoutMs ?? 8000,
           },
           status: 'pending',
@@ -215,7 +213,7 @@ actuateElevationRoutes.post(
       }
 
       // Blocker 2: elevation_audit insert on the happy path. The password
-      // is never recorded here — only the request id + command id + username.
+      // is agent-local and never present here.
       await tx.insert(elevationAudit).values({
         orgId: device.orgId,
         elevationRequestId: elevation.id,
@@ -225,7 +223,6 @@ actuateElevationRoutes.post(
         details: {
           deviceId,
           commandId: command.id,
-          username: data.username,
           timeoutMs: data.timeoutMs ?? 8000,
         },
         occurredAt: new Date(),
@@ -280,11 +277,8 @@ actuateElevationRoutes.post(
 
     const command = result.command;
 
-    // Audit log MUST NOT carry the password. elevationRequestId +
-    // username + deviceId is enough to correlate; the cleartext only
-    // exists in flight to the agent. (`commandAuditDetails` is not
-    // imported here because the default sanitizer would still see the
-    // password in the payload via deep-clone.)
+    // Audit log MUST NOT carry the password. The cleartext is minted by the
+    // agent only and is never present in this request or command payload.
     writeRouteAudit(c, {
       orgId: device.orgId,
       action: 'device.elevation.actuate',
@@ -294,7 +288,6 @@ actuateElevationRoutes.post(
       details: {
         deviceId,
         elevationRequestId: data.elevationRequestId,
-        username: data.username,
         timeoutMs: data.timeoutMs ?? 8000,
       },
     });


### PR DESCRIPTION
## Summary

Makes the **agent the just-in-time credential authority** for approved UAC elevations (the load-bearing design correction in the plan): the server can't set a *local* Windows account's password, so the agent mints + rotates the `~breeze_elev` password locally, hands it to the actuator in-process, and demotes the moment the consent window closes. **The secret never crosses the wire and never touches `agent.yaml`.** Closes #1150.

## What's here

**`agent/internal/elevaccount/`** — 3-file build-tag split mirroring `pamactuator`:
- `EnsureProvisioned` — `NetUserAdd` disabled + hidden from logon, idempotent (`NERR_UserExists` → success); **force-demotes + re-randomizes if found in Administrators at rest** (crash-leak recovery — never needs the old password).
- `Promote` — rotate password → enable → add to Administrators **by well-known SID `S-1-5-32-544` via `LookupAccount`** (locale-independent, not the literal "Administrators" string); cleans up on ctx-cancel / add-failure.
- `Demote` — remove from Administrators → re-randomize → disable.
- `crypto/rand` password generator (≥32 chars, complexity-guaranteed, Fisher-Yates, ambiguous-char-free).
- Non-Windows: no-op stub returning `unsupported_platform`.

**Wiring**
- `EnsureProvisioned()` on startup, **Windows-only, behind a new `pam_enabled` agent flag** (default false), non-fatal.
- `handlers_actuate.go` sources the credential from `Promote()` instead of the payload. **Guaranteed demotion:** `defer Demote()` uses its *own* fresh 10s context, so it runs on every path — actuator success, failure, **panic**, and even handler-ctx timeout — with the password zeroed after use. Deprecated payload `username`/`password` are ignored.

**Server (paired change)**
- `actuateElevation.ts`: `username`/`password` now optional and **dropped from the command payload and both audit sinks**; the command degrades to a `{elevationRequestId, timeoutMs}` go-signal. The **CAS single-use guard (`approved`→`actuating`) is preserved unchanged.**

## Testing & verification

- Cross-platform `elevaccount` unit tests (password gen, state machine, slim payload parse, stub reasons) + handler tests asserting `Promote`→actuator→`Demote` order, **demote-on-panic**, and **no-demote-without-promote**.
- `actuateElevation` route test updated (**17 pass**).
- `GOOS=windows go build ./...` + `go vet` pass — this **type-checks the entire netapi32 syscall layer** (struct layouts, proc signatures). `go build`/`go test` on darwin green (`elevaccount` + `heartbeat` packages), `tsc --noEmit` clean.

> ⚠️ **Runtime caveat:** the real netapi32 account round-trip (create/promote/demote, group membership, logon-hiding) can't be exercised on a non-Windows CI box — that's the plan's **Task-6 manual VM verification**. This PR is compile-verified + unit-tested for everything testable off-Windows. The optional `CmdManageElevationAccount` server command is intentionally deferred to keep the PR focused.

Plan: `docs/superpowers/plans/2026-06-09-pam-dormant-admin-account.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)