### PR TITLE
feat(tickets): Phase 2 SLA engine — targets, pause, monitor, notifications, queue + UI

### DIFF
--- a/apps/api/migrations/2026-06-11-g-ticket-sla-indexes.sql
+++ b/apps/api/migrations/2026-06-11-g-ticket-sla-indexes.sql
@@ -1,0 +1,10 @@
+-- Phase 2 SLA engine (spec §8a): index-backed sweep + queue SLA filters.
+-- Sweep scans active, unpaused tickets ordered by created_at.
+CREATE INDEX IF NOT EXISTS tickets_sla_sweep_idx
+  ON tickets (created_at)
+  WHERE status IN ('new', 'open') AND sla_paused_at IS NULL;
+
+-- Breached-queue filter + stats count.
+CREATE INDEX IF NOT EXISTS tickets_sla_breached_idx
+  ON tickets (partner_id, status)
+  WHERE sla_breached_at IS NOT NULL;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -187,6 +187,7 @@ import { initializeStaleCommandReaper, shutdownStaleCommandReaper } from './jobs
 import { initializePamJobs, shutdownPamJobs } from './jobs/pamJobs';
 import { initializeApprovalExpiryReaper, shutdownApprovalExpiryReaper } from './jobs/approvalExpiryReaper';
 import { initializeTicketNotifyWorker, shutdownTicketNotifyWorker } from './jobs/ticketNotifyWorker';
+import { initializeTicketSlaWorker, shutdownTicketSlaWorker } from './jobs/ticketSlaWorker';
 import { initializePolicyAlertBridge } from './services/policyAlertBridge';
 import { getWebhookWorker, initializeWebhookDelivery } from './workers/webhookDelivery';
 import { initializeTransferCleanup, stopTransferCleanup } from './workers/transferCleanup';
@@ -1051,6 +1052,7 @@ async function initializeWorkers(): Promise<void> {
     ['pamJobs', initializePamJobs],
     ['approvalExpiryReaper', initializeApprovalExpiryReaper],
     ['ticketNotifyWorker', initializeTicketNotifyWorker],
+    ['ticketSlaWorker', initializeTicketSlaWorker],
   ];
 
   await Promise.allSettled(
@@ -1204,6 +1206,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownPamJobs,
     shutdownApprovalExpiryReaper,
     shutdownTicketNotifyWorker,
+    shutdownTicketSlaWorker,
     shutdownEventDispatcher,
     async () => getEventBus().close(),
     closeRedis,

--- a/apps/api/src/jobs/ticketNotifyWorker.test.ts
+++ b/apps/api/src/jobs/ticketNotifyWorker.test.ts
@@ -159,6 +159,71 @@ describe('handleTicketEvent', () => {
     expect(sendEmailMock).not.toHaveBeenCalled();
   });
 
+  // ── ticket.sla_breached fan-out tests ──────────────────────────────────────
+
+  it('ticket.sla_breached notifies the assignee in-app and by email', async () => {
+    selectMock
+      .mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', internalNumber: 'T-2026-0001', subject: 'Printer', submitterEmail: 'requester@acme.example' }])
+      .mockResolvedValueOnce([{ id: 'u-2', email: 'tech@msp.example' }]);
+
+    await handleTicketEvent({
+      type: 'ticket.sla_breached', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
+      actorUserId: null, payload: { target: 'response', internalNumber: 'T-2026-0001', subject: 'Printer', assigneeId: 'u-2' }
+    });
+
+    expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'u-2',
+      orgId: 'o-1',
+      type: 'ticket',
+      priority: 'normal',
+      title: 'SLA breached: T-2026-0001',
+      message: expect.stringContaining('response'),
+      link: '/tickets#T-2026-0001'
+    }));
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(sendEmailMock).toHaveBeenCalledWith(expect.objectContaining({
+      to: 'tech@msp.example',
+      subject: 'SLA breached: T-2026-0001 — Printer',
+      html: expect.stringContaining('response')
+    }));
+  });
+
+  it('ticket.sla_breached with no assignee creates no notification and no email', async () => {
+    selectMock
+      .mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', internalNumber: 'T-2026-0001', subject: 'Printer', submitterEmail: null }])
+      .mockResolvedValueOnce([]); // assignee user row absent (deleted user)
+
+    await expect(handleTicketEvent({
+      type: 'ticket.sla_breached', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
+      actorUserId: null, payload: { target: 'resolution', internalNumber: 'T-2026-0001', subject: 'Printer', assigneeId: 'u-deleted' }
+    })).resolves.toBeUndefined();
+
+    expect(selectMock).toHaveBeenCalledTimes(2);
+    expect(insertValuesMock).not.toHaveBeenCalled();
+    expect(sendEmailMock).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    selectMock.mockReset();
+
+    await expect(handleTicketEvent({
+      type: 'ticket.sla_breached', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
+      actorUserId: null, payload: { target: 'response', internalNumber: 'T-2026-0001', subject: 'Printer', assigneeId: null }
+    })).resolves.toBeUndefined();
+
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(insertValuesMock).not.toHaveBeenCalled();
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it('ticket.sla_breached throws when the ticket row is missing (retryable, pre-commit contract)', async () => {
+    selectMock.mockResolvedValueOnce([]); // no ticket row
+
+    await expect(handleTicketEvent({
+      type: 'ticket.sla_breached', ticketId: 'missing', orgId: 'o-1', partnerId: 'p-1',
+      actorUserId: null, payload: { target: 'response', internalNumber: 'T-2026-0001', subject: 'Printer', assigneeId: 'u-2' }
+    })).rejects.toThrow(/not found/i);
+  });
+
   // ── ticket.status_changed fan-out tests ────────────────────────────────────
 
   it('ticket.status_changed to resolved sends email with internal number and HTML-escaped resolution note', async () => {

--- a/apps/api/src/jobs/ticketNotifyWorker.ts
+++ b/apps/api/src/jobs/ticketNotifyWorker.ts
@@ -6,6 +6,7 @@
  *   - ticket.assigned / ticket.created (with assignee) → in-app + email to assignee
  *   - ticket.commented (isPublic) → email to requester
  *   - ticket.status_changed → resolved → email to requester
+ *   - ticket.sla_breached → in-app + email to assignee
  *
  * Pre-commit emission contract: ticketService emits events while the request
  * transaction is still open (see emitTicketEvent usage in ticketService.ts).
@@ -135,6 +136,47 @@ async function collectRequesterEmail(
   }];
 }
 
+async function collectSlaBreachNotification(
+  event: Extract<TicketEvent, { type: 'ticket.sla_breached' }>,
+  assigneeId: string
+): Promise<EmailPayload[]> {
+  const ticket = await getTicket(event.ticketId);
+  if (!ticket) {
+    throw new Error(`Ticket not found (likely uncommitted): ${event.ticketId}`);
+  }
+
+  const assigneeRows = await db.select({ id: users.id, email: users.email })
+    .from(users)
+    .where(eq(users.id, assigneeId))
+    .limit(1);
+  const assignee = assigneeRows[0];
+  if (!assignee) {
+    return [];
+  }
+
+  const label = event.payload.internalNumber ?? event.ticketId;
+  const target = event.payload.target;
+
+  await db.insert(userNotifications).values({
+    userId: assigneeId,
+    orgId: event.orgId,
+    type: 'ticket',
+    priority: 'normal',
+    title: `SLA breached: ${label}`,
+    message: `${target} SLA breached for ${event.payload.subject}`,
+    link: `/tickets#${event.payload.internalNumber ?? event.ticketId}`
+  }).returning();
+
+  if (!assignee.email) return [];
+
+  return [{
+    to: assignee.email,
+    subject: `SLA breached: ${label} — ${event.payload.subject}`,
+    html: `<p>The ${escapeHtml(target)} SLA breached for ticket <strong>${escapeHtml(label)}</strong>: ${escapeHtml(event.payload.subject)}</p>`,
+    bestEffort: true
+  }];
+}
+
 /**
  * Core handler: runs DB work inside the system context, collects email payloads,
  * then sends emails after the context exits.
@@ -149,6 +191,13 @@ export async function handleTicketEvent(event: TicketEvent): Promise<void> {
         const assigneeId = event.payload.assigneeId;
         if (assigneeId) {
           emailPayloads = await collectAssigneeNotification(event, assigneeId);
+        }
+        return;
+      }
+      case 'ticket.sla_breached': {
+        const assigneeId = event.payload.assigneeId;
+        if (assigneeId) {
+          emailPayloads = await collectSlaBreachNotification(event, assigneeId);
         }
         return;
       }

--- a/apps/api/src/jobs/ticketSlaWorker.test.ts
+++ b/apps/api/src/jobs/ticketSlaWorker.test.ts
@@ -133,6 +133,8 @@ describe('ticketSlaWorker', () => {
       expect(responseSql).toContain('sla_paused_at IS NULL');
       expect(responseSql).toContain('first_response_at IS NULL');
       expect(responseSql).toContain('string_to_array');
+      expect(responseSql).toContain('NOT (');
+      expect(responseSql).toContain('= ANY(string_to_array(COALESCE(sla_breach_reason');
       expect(responseSql).toContain('FOR UPDATE SKIP LOCKED');
 
       const resolutionSql = sqlText(executeMock.mock.calls[1]?.[0]);

--- a/apps/api/src/jobs/ticketSlaWorker.test.ts
+++ b/apps/api/src/jobs/ticketSlaWorker.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  executeMock,
+  withSystemDbAccessContextMock,
+  emitTicketEventMock,
+  publishMock,
+  queueAddMock,
+  getRepeatableJobsMock,
+  removeRepeatableByKeyMock,
+  workerCapture,
+  callOrder,
+} = vi.hoisted(() => ({
+  executeMock: vi.fn(),
+  withSystemDbAccessContextMock: vi.fn(),
+  emitTicketEventMock: vi.fn(),
+  publishMock: vi.fn(),
+  queueAddMock: vi.fn(),
+  getRepeatableJobsMock: vi.fn(),
+  removeRepeatableByKeyMock: vi.fn(),
+  workerCapture: { processor: null as null | ((job: { data: unknown }) => Promise<unknown>) },
+  callOrder: [] as string[],
+}));
+
+vi.mock('bullmq', () => ({
+  // Regular functions (not arrows) so `new Worker(...)` / `new Queue(...)` work.
+  Worker: vi.fn(function (_name: string, processor: (job: { data: unknown }) => Promise<unknown>) {
+    workerCapture.processor = processor;
+    return { on: vi.fn(), close: vi.fn() };
+  }),
+  Queue: vi.fn(function () {
+    return {
+      add: queueAddMock,
+      getRepeatableJobs: getRepeatableJobsMock,
+      removeRepeatableByKey: removeRepeatableByKeyMock,
+      close: vi.fn(),
+    };
+  }),
+  Job: class {},
+}));
+
+vi.mock('../db', () => ({
+  db: { execute: executeMock },
+  withSystemDbAccessContext: withSystemDbAccessContextMock,
+}));
+
+vi.mock('../services/redis', () => ({
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+}));
+
+vi.mock('../services/sentry', () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock('../services/ticketEvents', () => ({
+  emitTicketEvent: emitTicketEventMock,
+  TICKET_EVENTS_QUEUE: 'ticket-events',
+}));
+
+vi.mock('../services/eventBus', () => ({
+  getEventBus: vi.fn(() => ({ publish: publishMock })),
+}));
+
+import { sweepTicketSlaBreaches, initializeTicketSlaWorker } from './ticketSlaWorker';
+
+/**
+ * Flattens a drizzle sql`` object to its static SQL text (StringChunks and
+ * nested sql.raw chunks only — bound params contribute nothing). Same
+ * introspection approach as auditRetention.test.ts.
+ */
+function sqlText(q: unknown): string {
+  if (q == null) return '';
+  if (typeof q === 'string') return q;
+  const obj = q as { queryChunks?: unknown[]; value?: unknown };
+  if (Array.isArray(obj.queryChunks)) {
+    return obj.queryChunks.map(sqlText).join(' ');
+  }
+  if (Array.isArray(obj.value)) {
+    return (obj.value as string[]).join('');
+  }
+  return '';
+}
+
+const breachedRow = {
+  id: 't-1',
+  org_id: 'o-1',
+  partner_id: 'p-1',
+  internal_number: 'T-2026-0001',
+  subject: 'Printer down',
+  assigned_to: 'u-9',
+};
+
+describe('ticketSlaWorker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    callOrder.length = 0;
+    withSystemDbAccessContextMock.mockImplementation(async (fn: () => Promise<unknown>) => {
+      const result = await fn();
+      callOrder.push('db-context-resolved');
+      return result;
+    });
+    emitTicketEventMock.mockImplementation(async () => {
+      callOrder.push('emit');
+    });
+    publishMock.mockResolvedValue('event-id');
+    getRepeatableJobsMock.mockResolvedValue([]);
+    queueAddMock.mockResolvedValue({});
+  });
+
+  describe('sweepTicketSlaBreaches', () => {
+    it('runs response and resolution passes and returns rows tagged by target', async () => {
+      executeMock
+        .mockResolvedValueOnce({ rows: [breachedRow] }) // response pass
+        .mockResolvedValueOnce({ rows: [] }); // resolution pass
+
+      const rows = await sweepTicketSlaBreaches();
+
+      expect(executeMock).toHaveBeenCalledTimes(2);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.target).toBe('response');
+      expect(rows[0]?.id).toBe('t-1');
+    });
+
+    it('sweep SQL excludes paused, already-breached-target, and non-active tickets', async () => {
+      executeMock
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      await sweepTicketSlaBreaches();
+
+      const responseSql = sqlText(executeMock.mock.calls[0]?.[0]);
+      expect(responseSql).toContain("status IN ('new', 'open')");
+      expect(responseSql).toContain('sla_paused_at IS NULL');
+      expect(responseSql).toContain('first_response_at IS NULL');
+      expect(responseSql).toContain('string_to_array');
+      expect(responseSql).toContain('FOR UPDATE SKIP LOCKED');
+
+      const resolutionSql = sqlText(executeMock.mock.calls[1]?.[0]);
+      expect(resolutionSql).toContain('resolved_at IS NULL');
+      expect(resolutionSql).toContain("status IN ('new', 'open')");
+      expect(resolutionSql).toContain('sla_paused_at IS NULL');
+      expect(resolutionSql).toContain('FOR UPDATE SKIP LOCKED');
+    });
+  });
+
+  describe('worker handler', () => {
+    it('emits one ticket.sla_breached per stamped row, after the system DB context resolved', async () => {
+      executeMock
+        .mockResolvedValueOnce({ rows: [breachedRow] }) // response pass
+        .mockResolvedValueOnce({ rows: [] }); // resolution pass
+
+      await initializeTicketSlaWorker();
+      expect(workerCapture.processor).toBeTypeOf('function');
+
+      const result = await workerCapture.processor!({
+        data: { type: 'sla-sweep', queuedAt: new Date().toISOString() },
+      });
+
+      expect(result).toEqual({ breached: 1 });
+      expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
+      expect(emitTicketEventMock).toHaveBeenCalledTimes(1);
+      expect(emitTicketEventMock).toHaveBeenCalledWith({
+        type: 'ticket.sla_breached',
+        ticketId: 't-1',
+        orgId: 'o-1',
+        partnerId: 'p-1',
+        actorUserId: null,
+        payload: {
+          target: 'response',
+          internalNumber: 'T-2026-0001',
+          subject: 'Printer down',
+          assigneeId: 'u-9',
+        },
+      });
+
+      // #1105 pool-poison rule: emits happen AFTER withSystemDbAccessContext's
+      // callback has fully resolved.
+      const contextResolvedIdx = callOrder.indexOf('db-context-resolved');
+      const firstEmitIdx = callOrder.indexOf('emit');
+      expect(contextResolvedIdx).toBeGreaterThanOrEqual(0);
+      expect(firstEmitIdx).toBeGreaterThan(contextResolvedIdx);
+
+      // Routing-rule hook: eventBus publish mirrors the breach.
+      expect(publishMock).toHaveBeenCalledWith(
+        'ticket.sla_breached',
+        'o-1',
+        expect.objectContaining({
+          ticketId: 't-1',
+          internalNumber: 'T-2026-0001',
+          subject: 'Printer down',
+          target: 'response',
+          assigneeId: 'u-9',
+        }),
+        'ticket-sla-monitor'
+      );
+    });
+
+    it('emits nothing when the sweep stamps zero rows', async () => {
+      executeMock
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      await initializeTicketSlaWorker();
+      const result = await workerCapture.processor!({
+        data: { type: 'sla-sweep', queuedAt: new Date().toISOString() },
+      });
+
+      expect(result).toEqual({ breached: 0 });
+      expect(emitTicketEventMock).not.toHaveBeenCalled();
+      expect(publishMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/jobs/ticketSlaWorker.ts
+++ b/apps/api/src/jobs/ticketSlaWorker.ts
@@ -1,0 +1,211 @@
+import { Job, Queue, Worker } from 'bullmq';
+import { sql } from 'drizzle-orm';
+import * as dbModule from '../db';
+import { db } from '../db';
+import { getBullMQConnection } from '../services/redis';
+import { captureException } from '../services/sentry';
+import { emitTicketEvent } from '../services/ticketEvents';
+import { getEventBus } from '../services/eventBus';
+
+/**
+ * Ticket SLA monitor (spec §3, Phase 2): every 60s, stamp sla_breached_at /
+ * sla_breach_reason on active tickets whose response or resolution deadline
+ * has passed, then emit ticket.sla_breached per stamped target.
+ *
+ * Targets are one-shot (D3): sla_breach_reason is a CSV of breached targets and
+ * the sweep's WHERE excludes targets already present. Deadlines are wall-clock
+ * (D1): created_at + (target_minutes + sla_paused_minutes). Paused tickets
+ * (sla_paused_at set / status pending|on_hold) are skipped entirely.
+ *
+ * DB work runs inside withSystemDbAccessContext (one short transaction);
+ * event emission happens AFTER the context exits (#1105 pool-poison rule).
+ */
+
+const QUEUE_NAME = 'ticket-sla-monitor';
+const SWEEP_INTERVAL_MS = 60 * 1000;
+const MAX_BREACHES_PER_RUN = 200; // per target per sweep
+
+type SlaSweepJobData = { type: 'sla-sweep'; queuedAt: string };
+
+export type BreachedTicketRow = {
+  id: string;
+  org_id: string;
+  partner_id: string | null;
+  internal_number: string | null;
+  subject: string;
+  assigned_to: string | null;
+};
+
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const withSystem = dbModule.withSystemDbAccessContext;
+  if (typeof withSystem !== 'function') {
+    throw new Error('[TicketSlaWorker] withSystemDbAccessContext not available');
+  }
+  return withSystem(fn);
+};
+
+let slaQueue: Queue<SlaSweepJobData> | null = null;
+let slaWorker: Worker<SlaSweepJobData> | null = null;
+
+function getQueue(): Queue<SlaSweepJobData> {
+  if (!slaQueue) {
+    slaQueue = new Queue<SlaSweepJobData>(QUEUE_NAME, { connection: getBullMQConnection() });
+  }
+  return slaQueue;
+}
+
+function extractRows<T>(result: unknown): T[] {
+  const maybe = result as { rows?: T[] };
+  return maybe.rows ?? (result as T[]);
+}
+
+async function stampBreaches(target: 'response' | 'resolution'): Promise<BreachedTicketRow[]> {
+  const targetColumn = target === 'response' ? sql.raw('response_sla_minutes') : sql.raw('resolution_sla_minutes');
+  const unmetCondition = target === 'response'
+    ? sql.raw('first_response_at IS NULL')
+    : sql.raw('resolved_at IS NULL');
+
+  const result = await db.execute<BreachedTicketRow>(sql`
+    WITH due AS (
+      SELECT id
+      FROM tickets
+      WHERE status IN ('new', 'open')
+        AND sla_paused_at IS NULL
+        AND ${unmetCondition}
+        AND ${targetColumn} IS NOT NULL
+        AND NOT (${sql.raw(`'${target}'`)} = ANY(string_to_array(COALESCE(sla_breach_reason, ''), ',')))
+        AND now() >= created_at
+          + (${targetColumn} + COALESCE(sla_paused_minutes, 0)) * interval '1 minute'
+      ORDER BY created_at ASC
+      LIMIT ${MAX_BREACHES_PER_RUN}
+      FOR UPDATE SKIP LOCKED
+    )
+    UPDATE tickets t
+    SET sla_breached_at = COALESCE(t.sla_breached_at, now()),
+        sla_breach_reason = CASE
+          WHEN COALESCE(t.sla_breach_reason, '') = '' THEN ${target}
+          ELSE t.sla_breach_reason || ',' || ${target}
+        END,
+        updated_at = now()
+    FROM due
+    WHERE t.id = due.id
+    RETURNING t.id, t.org_id, t.partner_id, t.internal_number, t.subject, t.assigned_to;
+  `);
+  return extractRows<BreachedTicketRow>(result);
+}
+
+export async function sweepTicketSlaBreaches(): Promise<Array<BreachedTicketRow & { target: 'response' | 'resolution' }>> {
+  const response = await stampBreaches('response');
+  const resolution = await stampBreaches('resolution');
+  if (response.length === MAX_BREACHES_PER_RUN || resolution.length === MAX_BREACHES_PER_RUN) {
+    console.warn(`[TicketSlaWorker] Hit ${MAX_BREACHES_PER_RUN}-row cap — breach backlog may be growing`);
+  }
+  return [
+    ...response.map((r) => ({ ...r, target: 'response' as const })),
+    ...resolution.map((r) => ({ ...r, target: 'resolution' as const }))
+  ];
+}
+
+async function notifyBreaches(rows: Array<BreachedTicketRow & { target: 'response' | 'resolution' }>): Promise<void> {
+  for (const row of rows) {
+    await emitTicketEvent({
+      type: 'ticket.sla_breached',
+      ticketId: row.id,
+      orgId: row.org_id,
+      partnerId: row.partner_id,
+      actorUserId: null,
+      payload: { target: row.target, internalNumber: row.internal_number, subject: row.subject, assigneeId: row.assigned_to }
+    });
+    try {
+      // Routing-rule hook, mirroring backupSlaWorker's breach publish.
+      // Signature verified against eventBus.ts: publish(type, orgId, payload, source, options?)
+      // — matches as written; 'ticket.sla_breached' added to the EventType union.
+      await getEventBus().publish('ticket.sla_breached', row.org_id, {
+        ticketId: row.id,
+        internalNumber: row.internal_number,
+        subject: row.subject,
+        target: row.target,
+        assigneeId: row.assigned_to
+      }, 'ticket-sla-monitor');
+    } catch (err) {
+      console.error('[TicketSlaWorker] eventBus publish failed:', err instanceof Error ? err.message : err);
+    }
+  }
+}
+
+function createWorker(): Worker<SlaSweepJobData> {
+  return new Worker<SlaSweepJobData>(
+    QUEUE_NAME,
+    async (_job: Job<SlaSweepJobData>) => {
+      try {
+        // DB stamping inside the system context; notifications after it exits.
+        const rows = await runWithSystemDbAccess(sweepTicketSlaBreaches);
+        if (rows.length > 0) {
+          console.log(`[TicketSlaWorker] Stamped ${rows.length} SLA breach(es)`);
+          await notifyBreaches(rows);
+        }
+        return { breached: rows.length };
+      } catch (err) {
+        console.error('[TicketSlaWorker] Sweep failed:', err);
+        captureException(err instanceof Error ? err : new Error(String(err)));
+        throw err;
+      }
+    },
+    { connection: getBullMQConnection(), concurrency: 1 }
+  );
+}
+
+async function scheduleRepeatableJob(): Promise<void> {
+  const queue = getQueue();
+  const repeatables = await queue.getRepeatableJobs();
+  for (const job of repeatables) {
+    if (job.name === 'sla-sweep') {
+      await queue.removeRepeatableByKey(job.key);
+    }
+  }
+  await queue.add(
+    'sla-sweep',
+    { type: 'sla-sweep', queuedAt: new Date().toISOString() },
+    {
+      // jobId rule: '-' separators, 0 colons (BullMQ repeat-key parsing, #1118)
+      jobId: 'ticket-sla-monitor-sweep',
+      repeat: { every: SWEEP_INTERVAL_MS },
+      removeOnComplete: { count: 20 },
+      removeOnFail: { count: 200 }
+    }
+  );
+}
+
+export async function initializeTicketSlaWorker(): Promise<void> {
+  if (slaWorker) return;
+  slaWorker = createWorker();
+  slaWorker.on('error', (error) => {
+    console.error('[TicketSlaWorker] Worker error:', error);
+    captureException(error);
+  });
+  slaWorker.on('failed', (job, error) => {
+    console.error(`[TicketSlaWorker] Job ${job?.id} failed:`, error);
+    captureException(error);
+  });
+  try {
+    await scheduleRepeatableJob();
+  } catch (err) {
+    await slaWorker.close();
+    slaWorker = null;
+    throw err;
+  }
+  console.log('[TicketSlaWorker] Initialized');
+}
+
+export async function shutdownTicketSlaWorker(): Promise<void> {
+  const worker = slaWorker;
+  const queue = slaQueue;
+  slaWorker = null;
+  slaQueue = null;
+  if (worker) {
+    try { await worker.close(); } catch (err) { console.error('[TicketSlaWorker] Error closing worker:', err); }
+  }
+  if (queue) {
+    try { await queue.close(); } catch (err) { console.error('[TicketSlaWorker] Error closing queue:', err); }
+  }
+}

--- a/apps/api/src/jobs/ticketSlaWorker.ts
+++ b/apps/api/src/jobs/ticketSlaWorker.ts
@@ -19,6 +19,7 @@ import { getEventBus } from '../services/eventBus';
  *
  * DB work runs inside withSystemDbAccessContext (one short transaction);
  * event emission happens AFTER the context exits (#1105 pool-poison rule).
+ * If the process dies after stamping but before notifyBreaches completes, those breach notifications are lost by design — the one-shot guard prevents re-stamping (duplicate notifications would be worse); sla_breached_at remains queryable for auditing gaps.
  */
 
 const QUEUE_NAME = 'ticket-sla-monitor';
@@ -73,7 +74,7 @@ async function stampBreaches(target: 'response' | 'resolution'): Promise<Breache
         AND sla_paused_at IS NULL
         AND ${unmetCondition}
         AND ${targetColumn} IS NOT NULL
-        AND NOT (${sql.raw(`'${target}'`)} = ANY(string_to_array(COALESCE(sla_breach_reason, ''), ',')))
+        AND NOT (${target} = ANY(string_to_array(COALESCE(sla_breach_reason, ''), ',')))
         AND now() >= created_at
           + (${targetColumn} + COALESCE(sla_paused_minutes, 0)) * interval '1 minute'
       ORDER BY created_at ASC

--- a/apps/api/src/routes/tickets/tickets.test.ts
+++ b/apps/api/src/routes/tickets/tickets.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 
-const { serviceMocks, dbSelectMock, dbGroupByMock, authRef, lastWhereArgs, writeRouteAuditMock } = vi.hoisted(() => {
+const { serviceMocks, dbSelectMock, dbGroupByMock, authRef, lastWhereArgs, lastOrderByArgs, writeRouteAuditMock } = vi.hoisted(() => {
   const lastWhereArgs: { conditions: unknown[] }[] = [];
+  const lastOrderByArgs: unknown[][] = [];
   return {
     serviceMocks: {
       createTicket: vi.fn(),
@@ -18,6 +19,7 @@ const { serviceMocks, dbSelectMock, dbGroupByMock, authRef, lastWhereArgs, write
     dbGroupByMock: vi.fn(),
     writeRouteAuditMock: vi.fn(),
     lastWhereArgs,
+    lastOrderByArgs,
     /** Mutable ref so individual tests can override the injected auth context. */
     authRef: {
       current: {
@@ -83,9 +85,12 @@ vi.mock('../../db', () => ({
               where: vi.fn((...args: unknown[]) => {
                 lastWhereArgs.push({ conditions: args });
                 return {
-                  orderBy: vi.fn(() => ({
+                  orderBy: vi.fn((...orderArgs: unknown[]) => {
+                    lastOrderByArgs.push(orderArgs);
+                    return {
                     limit: vi.fn(() => ({ offset: vi.fn(() => dbSelectMock()) }))
-                  })),
+                    };
+                  }),
                   limit: vi.fn(() => dbSelectMock())
                 };
               })
@@ -99,12 +104,18 @@ vi.mock('../../db', () => ({
           // single leftJoin → where (e.g. ticketAlertLinks joined with alerts)
           where: vi.fn(() => Promise.resolve(dbSelectMock() ?? []))
         })),
-        where: vi.fn(() => ({
+        where: vi.fn((...args: unknown[]) => {
+          lastWhereArgs.push({ conditions: args });
+          const result = {
           orderBy: vi.fn(() => Promise.resolve([])),
           groupBy: vi.fn(() => dbGroupByMock()),
           // getScopedTicketOr404 and GET /:id single-row lookups both use .limit(1)
-          limit: vi.fn(() => dbSelectMock())
-        }))
+          limit: vi.fn(() => dbSelectMock()),
+          then: (resolve: (value: unknown) => unknown, reject: (reason?: unknown) => unknown) =>
+            Promise.resolve(dbSelectMock()).then(resolve, reject)
+          };
+          return result;
+        })
       }))
     })),
     update: vi.fn(() => ({
@@ -120,8 +131,10 @@ vi.mock('../../db/schema', () => ({
     priority: 'priority', assignedTo: 'assignedTo', categoryId: 'categoryId',
     internalNumber: 'internalNumber', subject: 'subject', createdAt: 'createdAt',
     updatedAt: 'updatedAt', dueDate: 'dueDate', deviceId: 'deviceId',
-    source: 'source', slaBreachedAt: 'slaBreachedAt', firstResponseAt: 'firstResponseAt',
-    resolutionSlaMinutes: 'resolutionSlaMinutes'
+    source: 'source', slaBreachedAt: 'sla_breached_at', firstResponseAt: 'first_response_at',
+    responseSlaMinutes: 'response_sla_minutes', resolutionSlaMinutes: 'resolution_sla_minutes',
+    slaPausedAt: 'sla_paused_at', slaPausedMinutes: 'sla_paused_minutes',
+    slaBreachReason: 'sla_breach_reason'
   },
   ticketComments: { ticketId: 'ticketId', deletedAt: 'deletedAt', createdAt: 'createdAt' },
   ticketCategories: {},
@@ -162,6 +175,7 @@ function makeApp() {
 function resetAuth() {
   authRef.current = { ...DEFAULT_AUTH, canAccessOrg: () => true };
   lastWhereArgs.length = 0;
+  lastOrderByArgs.length = 0;
 }
 
 describe('GET /tickets', () => {
@@ -176,14 +190,29 @@ describe('GET /tickets', () => {
     expect(body).toHaveProperty('pagination');
   });
 
-  it('selects resolutionSlaMinutes and returns it in list rows (SLA chips)', async () => {
+  it('selects SLA fields and returns them in list rows (SLA chips)', async () => {
     dbSelectMock.mockResolvedValue([
-      { id: 't-1', internalNumber: 'T-2026-0001', subject: 'Printer', resolutionSlaMinutes: 240 }
+      {
+        id: 't-1',
+        internalNumber: 'T-2026-0001',
+        subject: 'Printer',
+        responseSlaMinutes: 60,
+        resolutionSlaMinutes: 240,
+        slaPausedAt: null,
+        slaPausedMinutes: 15,
+        slaBreachReason: null
+      }
     ]);
     const res = await makeApp().request('/tickets');
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.data[0]).toMatchObject({ resolutionSlaMinutes: 240 });
+    expect(body.data[0]).toMatchObject({
+      responseSlaMinutes: 60,
+      resolutionSlaMinutes: 240,
+      slaPausedAt: null,
+      slaPausedMinutes: 15,
+      slaBreachReason: null
+    });
 
     // The selection object passed to db.select must include the column —
     // the mock returns rows verbatim, so assert the query shape too.
@@ -191,9 +220,56 @@ describe('GET /tickets', () => {
     const selectionCalls = (db.select as any).mock.calls.filter(
       (args: unknown[]) => args[0] && typeof args[0] === 'object'
     );
-    expect(selectionCalls.some(
-      (args: any[]) => 'resolutionSlaMinutes' in args[0]
-    )).toBe(true);
+    const listSelection = selectionCalls.find(
+      (args: any[]) => args[0] && 'internalNumber' in args[0] && 'subject' in args[0]
+    )?.[0];
+    expect(listSelection).toMatchObject({
+      responseSlaMinutes: 'response_sla_minutes',
+      resolutionSlaMinutes: 'resolution_sla_minutes',
+      slaPausedAt: 'sla_paused_at',
+      slaPausedMinutes: 'sla_paused_minutes',
+      slaBreachReason: 'sla_breach_reason'
+    });
+  });
+
+  it('GET /tickets?slaState=breached filters on sla_breached_at IS NOT NULL', async () => {
+    dbSelectMock.mockResolvedValue([]);
+    const res = await makeApp().request('/tickets?slaState=breached');
+    expect(res.status).toBe(200);
+
+    expect(lastWhereArgs.length).toBeGreaterThan(0);
+    const serialized = JSON.stringify(lastWhereArgs[0]!.conditions);
+    expect(serialized).toContain('sla_breached_at');
+    expect(serialized).toContain('IS NOT NULL');
+  });
+
+  it('GET /tickets?slaState=breaching ORs breached with the at-risk expression', async () => {
+    dbSelectMock.mockResolvedValue([]);
+    const res = await makeApp().request('/tickets?slaState=breaching');
+    expect(res.status).toBe(200);
+
+    expect(lastWhereArgs.length).toBeGreaterThan(0);
+    const serialized = JSON.stringify(lastWhereArgs[0]!.conditions);
+    expect(serialized).toContain('sla_breached_at');
+    expect(serialized).toContain('OR');
+    expect(serialized).toContain('sla_paused_at');
+    expect(serialized).toContain('response_sla_minutes');
+    expect(serialized).toContain('resolution_sla_minutes');
+  });
+
+  it('triage sort orders breached first, then at-risk, then priority', async () => {
+    dbSelectMock.mockResolvedValue([]);
+    const res = await makeApp().request('/tickets?sort=triage');
+    expect(res.status).toBe(200);
+
+    expect(lastOrderByArgs.length).toBeGreaterThan(0);
+    const serialized = JSON.stringify(lastOrderByArgs[0]);
+    const breachedIndex = serialized.indexOf('sla_breached_at');
+    const atRiskIndex = serialized.indexOf('sla_paused_at');
+    const priorityIndex = serialized.indexOf('urgent');
+    expect(breachedIndex).toBeGreaterThanOrEqual(0);
+    expect(atRiskIndex).toBeGreaterThan(breachedIndex);
+    expect(priorityIndex).toBeGreaterThan(atRiskIndex);
   });
 
   it('rejects an invalid statusGroup', async () => {
@@ -307,7 +383,7 @@ describe('POST /tickets', () => {
 describe('GET /tickets/stats', () => {
   beforeEach(() => { vi.clearAllMocks(); resetAuth(); });
 
-  it('aggregates open / unassigned / mine / breached counts via groupBy', async () => {
+  it('aggregates open / unassigned / mine / breached counts via groupBy and returns atRisk', async () => {
     // auth user id is 'u-1' (set in requireScope mock above)
     // Rows: open+assigned-to-u1+not-breached(3), new+unassigned+breached(2)
     const mockRows = [
@@ -315,6 +391,7 @@ describe('GET /tickets/stats', () => {
       { status: 'new',  assignedTo: null,   breached: true,  count: 2 }
     ];
     dbGroupByMock.mockResolvedValue(mockRows);
+    dbSelectMock.mockResolvedValue([{ atRisk: 4 }]);
 
     const res = await makeApp().request('/tickets/stats');
     expect(res.status).toBe(200);
@@ -324,7 +401,7 @@ describe('GET /tickets/stats', () => {
     // unassigned: row 2 has no assignedTo → 2
     // mine: row 1 has assignedTo === 'u-1' → 3
     // breached: row 2 has breached=true → 2
-    expect(body.data).toEqual({ open: 5, unassigned: 2, mine: 3, breached: 2 });
+    expect(body.data).toEqual({ open: 5, unassigned: 2, mine: 3, breached: 2, atRisk: 4 });
 
     // Ensure groupBy was used (not orderBy) — the mock resolves via dbGroupByMock
     expect(dbGroupByMock).toHaveBeenCalledTimes(1);

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -30,6 +30,25 @@ const CLOSED_STATUSES = ['resolved', 'closed'] as const;
 const PRIORITY_ORDER = sql`CASE ${tickets.priority}
   WHEN 'urgent' THEN 0 WHEN 'high' THEN 1 WHEN 'normal' THEN 2 ELSE 3 END`;
 
+// SQL twins of services/ticketSla.ts rules — change them together.
+// Active elapsed = now - created_at - paused; at-risk at 80% of the tighter target (D7).
+const SLA_BREACHED = sql`${tickets.slaBreachedAt} IS NOT NULL`;
+const SLA_AT_RISK = sql`(
+  ${tickets.slaBreachedAt} IS NULL
+  AND ${tickets.status} IN ('new', 'open')
+  AND ${tickets.slaPausedAt} IS NULL
+  AND (
+    (${tickets.firstResponseAt} IS NULL AND ${tickets.responseSlaMinutes} IS NOT NULL
+      AND now() >= ${tickets.createdAt}
+        + COALESCE(${tickets.slaPausedMinutes}, 0) * interval '1 minute'
+        + ${tickets.responseSlaMinutes} * interval '1 minute' * 0.8)
+    OR (${tickets.resolutionSlaMinutes} IS NOT NULL
+      AND now() >= ${tickets.createdAt}
+        + COALESCE(${tickets.slaPausedMinutes}, 0) * interval '1 minute'
+        + ${tickets.resolutionSlaMinutes} * interval '1 minute' * 0.8)
+  )
+)`;
+
 export function actorFrom(c: { get: (k: 'auth') => AuthContext }) {
   const auth = c.get('auth');
   return { userId: auth.user.id, name: auth.user.name, email: auth.user.email };
@@ -197,7 +216,12 @@ ticketsRoutes.get(
         if (r.breached) breached += n;
       }
     }
-    return c.json({ data: { open, unassigned, mine, breached } });
+    const slaRows = await db
+      .select({ atRisk: sql<number>`count(*) FILTER (WHERE ${SLA_AT_RISK})` })
+      .from(tickets)
+      .where(whereCondition);
+    const atRisk = Number(slaRows[0]?.atRisk ?? 0);
+    return c.json({ data: { open, unassigned, mine, breached, atRisk } });
   }
 );
 
@@ -240,6 +264,10 @@ ticketsRoutes.get(
     else if (q.assignee) conditions.push(eq(tickets.assignedTo, q.assignee));
     if (q.categoryId) conditions.push(eq(tickets.categoryId, q.categoryId));
     if (q.priority) conditions.push(eq(tickets.priority, q.priority));
+    if (q.slaState === 'breached') conditions.push(SLA_BREACHED);
+    else if (q.slaState === 'at_risk') conditions.push(SLA_AT_RISK);
+    else if (q.slaState === 'breaching') conditions.push(sql`(${SLA_BREACHED} OR ${SLA_AT_RISK})`);
+    else if (q.slaState === 'ok') conditions.push(sql`(NOT ${SLA_BREACHED} AND NOT ${SLA_AT_RISK})`);
     if (q.search) {
       // Escape ILIKE special chars so literal % and _ in the query aren't wildcards.
       const escaped = q.search.replace(/[%_]/g, '\\$&');
@@ -253,7 +281,7 @@ ticketsRoutes.get(
       q.sort === 'newest' ? [desc(tickets.createdAt), desc(tickets.id)]
       : q.sort === 'oldest' ? [asc(tickets.createdAt), asc(tickets.id)]
       : q.sort === 'due' ? [asc(tickets.dueDate), asc(tickets.id)]
-      : [PRIORITY_ORDER, asc(tickets.createdAt), asc(tickets.id)]; // triage
+      : [desc(SLA_BREACHED), desc(SLA_AT_RISK), PRIORITY_ORDER, asc(tickets.createdAt), asc(tickets.id)]; // triage: breaches surface first
 
     const data = await db
       .select({
@@ -273,7 +301,11 @@ ticketsRoutes.get(
         dueDate: tickets.dueDate,
         slaBreachedAt: tickets.slaBreachedAt,
         firstResponseAt: tickets.firstResponseAt,
+        responseSlaMinutes: tickets.responseSlaMinutes,
         resolutionSlaMinutes: tickets.resolutionSlaMinutes,
+        slaPausedAt: tickets.slaPausedAt,
+        slaPausedMinutes: tickets.slaPausedMinutes,
+        slaBreachReason: tickets.slaBreachReason,
         createdAt: tickets.createdAt,
         updatedAt: tickets.updatedAt
       })

--- a/apps/api/src/services/eventBus.ts
+++ b/apps/api/src/services/eventBus.ts
@@ -52,6 +52,8 @@ export type EventType =
   // Backup SLA events
   | 'backup.sla_breach'
   | 'backup.sla_resolved'
+  // Ticket SLA events (Phase 2, ticketSlaWorker)
+  | 'ticket.sla_breached'
   // Security events
   | 'security.score_changed'
   // CIS compliance events

--- a/apps/api/src/services/ticketEvents.test.ts
+++ b/apps/api/src/services/ticketEvents.test.ts
@@ -43,6 +43,18 @@ describe('emitTicketEvent', () => {
     );
   });
 
+  it('enqueues ticket.sla_breached with target payload', async () => {
+    await emitTicketEvent({
+      type: 'ticket.sla_breached',
+      ticketId: 't1',
+      orgId: 'o1',
+      partnerId: 'p1',
+      actorUserId: null,
+      payload: { target: 'response', internalNumber: 'T-2026-0001', subject: 'Printer on fire', assigneeId: 'u1' }
+    });
+    expect(addMock).toHaveBeenCalledWith('ticket.sla_breached', expect.objectContaining({ type: 'ticket.sla_breached' }), expect.anything());
+  });
+
   it('never throws to the caller when the queue is down', async () => {
     addMock.mockRejectedValueOnce(new Error('redis down'));
     await expect(emitTicketEvent({

--- a/apps/api/src/services/ticketEvents.ts
+++ b/apps/api/src/services/ticketEvents.ts
@@ -22,6 +22,7 @@ export type TicketEvent = TicketEventEnvelope & (
   | { type: 'ticket.assigned'; payload: { assigneeId: string | null } }
   | { type: 'ticket.commented'; payload: { commentId: string; isPublic: boolean } }
   | { type: 'ticket.updated'; payload: { changed: string[] } }
+  | { type: 'ticket.sla_breached'; payload: { target: 'response' | 'resolution'; internalNumber: string | null; subject: string; assigneeId: string | null } }
 );
 
 export type TicketEventType = TicketEvent['type'];

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -722,6 +722,21 @@ describe('updateTicketFields', () => {
     expect(auditMock).not.toHaveBeenCalled();
   });
 
+  it('updateTicketFields persists SLA overrides and labels them in the feed comment', async () => {
+    dbMocks.selectResult.mockResolvedValue([BASE_TICKET]);
+    dbMocks.updateReturning.mockResolvedValue([{ ...BASE_TICKET, responseSlaMinutes: 15 }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+
+    await updateTicketFields('t-1', { responseSlaMinutes: 15 }, actor);
+
+    const updatePayload = setMock.mock.calls[0]![0];
+    expect(updatePayload).toMatchObject({ responseSlaMinutes: 15 });
+    expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({
+      commentType: 'system',
+      content: expect.stringContaining('response SLA')
+    }));
+  });
+
   it('rejects a deviceId belonging to a different org with a 400 TicketServiceError and writes nothing', async () => {
     // selects in order: ticket, device (cross-org)
     dbMocks.selectResult

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Recorders for insert().values(v) and update().set(v) arguments
 const valuesMock = vi.fn();

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -265,6 +265,17 @@ describe('createTicket', () => {
     const insertPayload = valuesMock.mock.calls[0]![0];
     expect(insertPayload).toMatchObject({ responseSlaMinutes: null, resolutionSlaMinutes: null });
   });
+
+  it('stamps no SLA when priority is omitted entirely', async () => {
+    // no priority key, no categoryId → implicit 'normal' default → null SLA targets
+    dbMocks.selectResult.mockResolvedValueOnce([{ id: 'o-1', partnerId: 'p-1' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 't-sla-4', orgId: 'o-1', internalNumber: 'T-2026-0042', status: 'new' }]);
+
+    await createTicket({ orgId: 'o-1', subject: 'No priority field', source: 'manual' }, actor);
+
+    const insertPayload = valuesMock.mock.calls[0]![0];
+    expect(insertPayload).toMatchObject({ responseSlaMinutes: null, resolutionSlaMinutes: null });
+  });
 });
 
 describe('changeTicketStatus', () => {
@@ -1004,5 +1015,101 @@ describe('assignee tenant validation', () => {
     expect(err.status).toBe(500);
     expect(err.code).toBe('TICKET_PARTNER_UNRESOLVABLE');
     expect(setMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('changeTicketStatus — SLA pause/resume (D4)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    valuesMock.mockClear();
+    setMock.mockClear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('sets slaPausedAt when entering pending', async () => {
+    const now = new Date('2026-06-11T10:00:00Z');
+    vi.setSystemTime(now);
+
+    dbMocks.selectResult.mockResolvedValue([{
+      id: 't-1', orgId: 'o-1', partnerId: 'p-1',
+      status: 'open',
+      slaPausedAt: null,
+      slaPausedMinutes: 0
+    }]);
+    dbMocks.updateReturning.mockResolvedValue([{ id: 't-1', status: 'pending' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+
+    await changeTicketStatus('t-1', 'pending', {}, actor);
+
+    const updatePayload = setMock.mock.calls[0]![0];
+    expect(updatePayload.slaPausedAt).toBeInstanceOf(Date);
+  });
+
+  it('folds paused time into slaPausedMinutes when leaving on_hold', async () => {
+    const now = new Date('2026-06-11T10:30:00Z');
+    vi.setSystemTime(now);
+    const pausedAt = new Date('2026-06-11T10:00:00Z'); // 30 minutes ago
+
+    dbMocks.selectResult.mockResolvedValue([{
+      id: 't-1', orgId: 'o-1', partnerId: 'p-1',
+      status: 'on_hold',
+      slaPausedAt: pausedAt,
+      slaPausedMinutes: 10
+    }]);
+    dbMocks.updateReturning.mockResolvedValue([{ id: 't-1', status: 'open' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+
+    await changeTicketStatus('t-1', 'open', {}, actor);
+
+    const updatePayload = setMock.mock.calls[0]![0];
+    expect(updatePayload.slaPausedAt).toBeNull();
+    expect(updatePayload.slaPausedMinutes).toBe(40); // 10 existing + 30 elapsed
+  });
+
+  it('folds pause on resolve directly from pending', async () => {
+    const now = new Date('2026-06-11T10:05:00Z');
+    vi.setSystemTime(now);
+    const pausedAt = new Date('2026-06-11T10:00:00Z'); // 5 minutes ago
+
+    dbMocks.selectResult.mockResolvedValue([{
+      id: 't-1', orgId: 'o-1', partnerId: 'p-1',
+      status: 'pending',
+      slaPausedAt: pausedAt,
+      slaPausedMinutes: 0,
+      resolvedAt: null
+    }]);
+    dbMocks.updateReturning.mockResolvedValue([{ id: 't-1', status: 'resolved' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+
+    await changeTicketStatus('t-1', 'resolved', { resolutionNote: 'Fixed it' }, actor);
+
+    const updatePayload = setMock.mock.calls[0]![0];
+    expect(updatePayload.slaPausedAt).toBeNull();
+    expect(updatePayload.slaPausedMinutes).toBe(5); // 0 existing + 5 elapsed
+  });
+
+  it('does not touch pause fields for open -> resolved', async () => {
+    const now = new Date('2026-06-11T10:00:00Z');
+    vi.setSystemTime(now);
+
+    dbMocks.selectResult.mockResolvedValue([{
+      id: 't-1', orgId: 'o-1', partnerId: 'p-1',
+      status: 'open',
+      slaPausedAt: null,
+      slaPausedMinutes: 0,
+      resolvedAt: null
+    }]);
+    dbMocks.updateReturning.mockResolvedValue([{ id: 't-1', status: 'resolved' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+
+    await changeTicketStatus('t-1', 'resolved', { resolutionNote: 'Done' }, actor);
+
+    const updatePayload = setMock.mock.calls[0]![0];
+    expect(updatePayload).not.toHaveProperty('slaPausedAt');
+    expect(updatePayload).not.toHaveProperty('slaPausedMinutes');
   });
 });

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -1112,4 +1112,67 @@ describe('changeTicketStatus — SLA pause/resume (D4)', () => {
     expect(updatePayload).not.toHaveProperty('slaPausedAt');
     expect(updatePayload).not.toHaveProperty('slaPausedMinutes');
   });
+
+  it('leaving pending with slaPausedAt: null (anomalous legacy row) clears slaPausedAt and does not set slaPausedMinutes', async () => {
+    const now = new Date('2026-06-11T10:00:00Z');
+    vi.setSystemTime(now);
+
+    dbMocks.selectResult.mockResolvedValue([{
+      id: 't-1', orgId: 'o-1', partnerId: 'p-1',
+      status: 'pending',
+      slaPausedAt: null,
+      slaPausedMinutes: 10,
+      resolvedAt: null
+    }]);
+    dbMocks.updateReturning.mockResolvedValue([{ id: 't-1', status: 'open' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+
+    await changeTicketStatus('t-1', 'open', {}, actor);
+
+    const updatePayload = setMock.mock.calls[0]![0];
+    expect(updatePayload.slaPausedAt).toBeNull();
+    expect(updatePayload).not.toHaveProperty('slaPausedMinutes');
+  });
+
+  it('pending -> on_hold touches neither pause field', async () => {
+    const now = new Date('2026-06-11T11:00:00Z');
+    vi.setSystemTime(now);
+    const pausedAt = new Date('2026-06-11T10:00:00Z'); // 60 minutes ago
+
+    dbMocks.selectResult.mockResolvedValue([{
+      id: 't-1', orgId: 'o-1', partnerId: 'p-1',
+      status: 'pending',
+      slaPausedAt: pausedAt,
+      slaPausedMinutes: 5
+    }]);
+    dbMocks.updateReturning.mockResolvedValue([{ id: 't-1', status: 'on_hold' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+
+    await changeTicketStatus('t-1', 'on_hold', {}, actor);
+
+    const updatePayload = setMock.mock.calls[0]![0];
+    expect(updatePayload).not.toHaveProperty('slaPausedAt');
+    expect(updatePayload).not.toHaveProperty('slaPausedMinutes');
+  });
+
+  it('floor boundary: 90 seconds paused yields slaPausedMinutes: 1 (floor of 1.5)', async () => {
+    const now = new Date('2026-06-11T10:01:30Z');
+    vi.setSystemTime(now);
+    const pausedAt = new Date('2026-06-11T10:00:00Z'); // 90 seconds ago
+
+    dbMocks.selectResult.mockResolvedValue([{
+      id: 't-1', orgId: 'o-1', partnerId: 'p-1',
+      status: 'on_hold',
+      slaPausedAt: pausedAt,
+      slaPausedMinutes: 0
+    }]);
+    dbMocks.updateReturning.mockResolvedValue([{ id: 't-1', status: 'open' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+
+    await changeTicketStatus('t-1', 'open', {}, actor);
+
+    const updatePayload = setMock.mock.calls[0]![0];
+    expect(updatePayload.slaPausedAt).toBeNull();
+    expect(updatePayload.slaPausedMinutes).toBe(1); // floor(1.5) = 1
+  });
 });

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -65,7 +65,7 @@ vi.mock('../db/schema', () => ({
   alerts: { id: 'id', orgId: 'orgId' },
   devices: { id: 'id', orgId: 'orgId' },
   users: { id: 'id', partnerId: 'partnerId' },
-  ticketCategories: { id: 'id', partnerId: 'partnerId' },
+  ticketCategories: { id: 'id', partnerId: 'partnerId', responseSlaMinutes: 'responseSlaMinutes', resolutionSlaMinutes: 'resolutionSlaMinutes' },
   ticketStatusEnum: { enumValues: ['new', 'open', 'pending', 'on_hold', 'resolved', 'closed'] },
   ticketSourceEnum: { enumValues: ['portal', 'email', 'alert', 'manual', 'api', 'ai'] }
 }));
@@ -226,6 +226,44 @@ describe('createTicket', () => {
       submitterEmail: 'alice@example.com',
       submitterName: 'Alice',
     });
+  });
+
+  it('stamps SLA targets from the category when set', async () => {
+    // selects: org, category (with SLA fields set)
+    dbMocks.selectResult
+      .mockResolvedValueOnce([{ id: 'o-1', partnerId: 'p-1' }])
+      .mockResolvedValueOnce([{ id: 'cat-1', partnerId: 'p-1', responseSlaMinutes: 30, resolutionSlaMinutes: 120 }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 't-sla-1', orgId: 'o-1', internalNumber: 'T-2026-0042', status: 'new' }]);
+
+    await createTicket({ orgId: 'o-1', subject: 'SLA test', source: 'manual', categoryId: 'cat-1', priority: 'urgent' }, actor);
+
+    const insertPayload = valuesMock.mock.calls[0]![0];
+    expect(insertPayload).toMatchObject({ responseSlaMinutes: 30, resolutionSlaMinutes: 120 });
+  });
+
+  it('falls back to priority defaults when the category has no SLA', async () => {
+    // selects: org, category (with null SLA fields)
+    dbMocks.selectResult
+      .mockResolvedValueOnce([{ id: 'o-1', partnerId: 'p-1' }])
+      .mockResolvedValueOnce([{ id: 'cat-1', partnerId: 'p-1', responseSlaMinutes: null, resolutionSlaMinutes: null }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 't-sla-2', orgId: 'o-1', internalNumber: 'T-2026-0042', status: 'new' }]);
+
+    await createTicket({ orgId: 'o-1', subject: 'SLA fallback', source: 'manual', categoryId: 'cat-1', priority: 'urgent' }, actor);
+
+    // urgent priority defaults: response=60, resolution=240
+    const insertPayload = valuesMock.mock.calls[0]![0];
+    expect(insertPayload).toMatchObject({ responseSlaMinutes: 60, resolutionSlaMinutes: 240 });
+  });
+
+  it('stamps no SLA for normal priority without category targets', async () => {
+    // no categoryId → no category select
+    dbMocks.selectResult.mockResolvedValueOnce([{ id: 'o-1', partnerId: 'p-1' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 't-sla-3', orgId: 'o-1', internalNumber: 'T-2026-0042', status: 'new' }]);
+
+    await createTicket({ orgId: 'o-1', subject: 'No SLA', source: 'manual', priority: 'normal' }, actor);
+
+    const insertPayload = valuesMock.mock.calls[0]![0];
+    expect(insertPayload).toMatchObject({ responseSlaMinutes: null, resolutionSlaMinutes: null });
   });
 });
 

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -325,6 +325,21 @@ export async function changeTicketStatus(
     patch.pendingReason = null;
   }
 
+  // SLA clock pause/resume (spec §3, decision D4): the clock pauses while the
+  // ticket sits in pending/on_hold. Fold elapsed pause time on ANY exit —
+  // including resolve/close — so reopen resumes from a consistent ledger.
+  const wasPaused = fromStatus === 'pending' || fromStatus === 'on_hold';
+  const willBePaused = toStatus === 'pending' || toStatus === 'on_hold';
+  if (!wasPaused && willBePaused) {
+    patch.slaPausedAt = now;
+  } else if (wasPaused && !willBePaused) {
+    if (ticket.slaPausedAt) {
+      const elapsedMinutes = Math.max(0, Math.round((now.getTime() - new Date(ticket.slaPausedAt).getTime()) / 60_000));
+      patch.slaPausedMinutes = (ticket.slaPausedMinutes ?? 0) + elapsedMinutes;
+    }
+    patch.slaPausedAt = null;
+  }
+
   // Compare-and-swap: include fromStatus in the WHERE so a concurrent update is detected.
   const updated = await db
     .update(tickets)
@@ -425,6 +440,7 @@ export async function updateTicketFields(
   }
 
   if (typeof fields.categoryId === 'string') {
+    // D2: category changes after create do not restamp SLA targets — return value deliberately discarded.
     await assertCategoryInPartner(fields.categoryId, await resolveTicketPartnerId(ticket));
   }
 

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -389,6 +389,8 @@ export interface UpdateTicketFieldsInput {
   categoryId?: string | null;
   priority?: 'low' | 'normal' | 'high' | 'urgent';
   dueDate?: Date | null;
+  responseSlaMinutes?: number | null;
+  resolutionSlaMinutes?: number | null;
   deviceId?: string | null;
   tags?: string[];
 }
@@ -400,6 +402,8 @@ const UPDATE_FIELD_LABELS: Record<keyof UpdateTicketFieldsInput, string> = {
   categoryId: 'category',
   priority: 'priority',
   dueDate: 'due date',
+  responseSlaMinutes: 'response SLA',
+  resolutionSlaMinutes: 'resolution SLA',
   deviceId: 'device',
   tags: 'tags'
 };

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -334,7 +334,7 @@ export async function changeTicketStatus(
     patch.slaPausedAt = now;
   } else if (wasPaused && !willBePaused) {
     if (ticket.slaPausedAt) {
-      const elapsedMinutes = Math.max(0, Math.round((now.getTime() - new Date(ticket.slaPausedAt).getTime()) / 60_000));
+      const elapsedMinutes = Math.max(0, Math.floor((now.getTime() - new Date(ticket.slaPausedAt).getTime()) / 60_000));
       patch.slaPausedMinutes = (ticket.slaPausedMinutes ?? 0) + elapsedMinutes;
     }
     patch.slaPausedAt = null;

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -5,6 +5,7 @@ import { tickets, ticketComments, ticketAlertLinks, organizations, alerts, devic
 import { allocateInternalTicketNumber } from './ticketNumbers';
 import { emitTicketEvent } from './ticketEvents';
 import { createAuditLogAsync } from './auditService';
+import { resolveSlaTargets } from './ticketSla';
 
 export type TicketStatus = (typeof ticketStatusEnum.enumValues)[number];
 export type TicketSource = (typeof ticketSourceEnum.enumValues)[number];
@@ -140,7 +141,12 @@ async function assertCategoryInPartner(categoryId: string, partnerId: string | n
   const rows = await runOutsideDbContext(() =>
     withSystemDbAccessContext(() =>
       db
-        .select({ id: ticketCategories.id, partnerId: ticketCategories.partnerId })
+        .select({
+          id: ticketCategories.id,
+          partnerId: ticketCategories.partnerId,
+          responseSlaMinutes: ticketCategories.responseSlaMinutes,
+          resolutionSlaMinutes: ticketCategories.resolutionSlaMinutes
+        })
         .from(ticketCategories)
         .where(eq(ticketCategories.id, categoryId))
         .limit(1)
@@ -152,6 +158,7 @@ async function assertCategoryInPartner(categoryId: string, partnerId: string | n
   if (category.partnerId !== partnerId) {
     throw new TicketServiceError('Category must belong to the same partner as the ticket', 400, 'CATEGORY_WRONG_PARTNER');
   }
+  return category;
 }
 
 interface BaseCreateTicketInput {
@@ -204,9 +211,16 @@ export async function createTicket(input: CreateTicketInput, actor: TicketActor)
     await assertAssigneeInPartner(input.assigneeId, org.partnerId);
   }
 
+  let category: Awaited<ReturnType<typeof assertCategoryInPartner>> | null = null;
   if (input.categoryId) {
-    await assertCategoryInPartner(input.categoryId, org.partnerId);
+    category = await assertCategoryInPartner(input.categoryId, org.partnerId);
   }
+
+  const slaTargets = resolveSlaTargets({
+    categoryResponseMinutes: category?.responseSlaMinutes ?? null,
+    categoryResolutionMinutes: category?.resolutionSlaMinutes ?? null,
+    priority: input.priority ?? 'normal'
+  });
 
   const internalNumber = await allocateInternalTicketNumber(org.partnerId);
 
@@ -233,7 +247,9 @@ export async function createTicket(input: CreateTicketInput, actor: TicketActor)
     // so staff-created tickets must keep "no external requester" semantics.
     submitterEmail: isPortal ? input.submitterEmail : null,
     submitterName: isPortal ? (input.submitterName ?? null) : (actor.name ?? null),
-    category: null
+    category: null,
+    responseSlaMinutes: slaTargets.responseMinutes,
+    resolutionSlaMinutes: slaTargets.resolutionMinutes
   } satisfies typeof tickets.$inferInsert;
 
   const inserted = await db

--- a/apps/api/src/services/ticketSla.test.ts
+++ b/apps/api/src/services/ticketSla.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PRIORITY_SLA_DEFAULTS,
+  SLA_AT_RISK_RATIO,
+  resolveSlaTargets,
+  breachedTargets,
+  appendBreachTarget
+} from './ticketSla';
+
+describe('PRIORITY_SLA_DEFAULTS', () => {
+  it('tracks urgent and high only (D5)', () => {
+    expect(PRIORITY_SLA_DEFAULTS.urgent).toEqual({ responseMinutes: 60, resolutionMinutes: 240 });
+    expect(PRIORITY_SLA_DEFAULTS.high).toEqual({ responseMinutes: 240, resolutionMinutes: 1440 });
+    expect(PRIORITY_SLA_DEFAULTS.normal).toEqual({ responseMinutes: null, resolutionMinutes: null });
+    expect(PRIORITY_SLA_DEFAULTS.low).toEqual({ responseMinutes: null, resolutionMinutes: null });
+  });
+});
+
+describe('resolveSlaTargets', () => {
+  const cases: Array<{ name: string; input: Parameters<typeof resolveSlaTargets>[0]; expected: { responseMinutes: number | null; resolutionMinutes: number | null } }> = [
+    { name: 'override wins over category and priority',
+      input: { overrideResponseMinutes: 5, overrideResolutionMinutes: 10, categoryResponseMinutes: 30, categoryResolutionMinutes: 60, priority: 'urgent' },
+      expected: { responseMinutes: 5, resolutionMinutes: 10 } },
+    { name: 'category wins over priority',
+      input: { categoryResponseMinutes: 30, categoryResolutionMinutes: 60, priority: 'urgent' },
+      expected: { responseMinutes: 30, resolutionMinutes: 60 } },
+    { name: 'priority default fallback for urgent',
+      input: { priority: 'urgent' },
+      expected: { responseMinutes: 60, resolutionMinutes: 240 } },
+    { name: 'normal priority with no category yields no SLA',
+      input: { priority: 'normal' },
+      expected: { responseMinutes: null, resolutionMinutes: null } },
+    { name: 'per-target independence: category sets resolution only, response falls to priority',
+      input: { categoryResolutionMinutes: 90, priority: 'high' },
+      expected: { responseMinutes: 240, resolutionMinutes: 90 } }
+  ];
+  for (const c of cases) {
+    it(c.name, () => expect(resolveSlaTargets(c.input)).toEqual(c.expected));
+  }
+});
+
+describe('breachedTargets / appendBreachTarget', () => {
+  it('parses null/empty as no targets', () => {
+    expect(breachedTargets(null).size).toBe(0);
+    expect(breachedTargets('').size).toBe(0);
+  });
+  it('parses CSV and ignores unknown entries', () => {
+    expect([...breachedTargets('response')]).toEqual(['response']);
+    expect([...breachedTargets('response,resolution')].sort()).toEqual(['resolution', 'response'].sort());
+    expect([...breachedTargets('response,bogus')]).toEqual(['response']);
+  });
+  it('appends without duplicating', () => {
+    expect(appendBreachTarget(null, 'response')).toBe('response');
+    expect(appendBreachTarget('response', 'resolution')).toBe('response,resolution');
+    expect(appendBreachTarget('response', 'response')).toBe('response');
+  });
+  it('does not confuse response with resolution substrings', () => {
+    expect(breachedTargets('resolution').has('response')).toBe(false);
+  });
+});
+
+describe('SLA_AT_RISK_RATIO', () => {
+  it('is 80% per spec §3', () => expect(SLA_AT_RISK_RATIO).toBe(0.8));
+});

--- a/apps/api/src/services/ticketSla.ts
+++ b/apps/api/src/services/ticketSla.ts
@@ -1,0 +1,57 @@
+// Pure SLA math for native ticketing Phase 2. No DB access, no IO — keep it
+// trivially unit-testable. The SQL twins of these rules live in
+// jobs/ticketSlaWorker.ts (sweep) and routes/tickets/tickets.ts (filters);
+// change them together.
+
+export type TicketSlaPriority = 'low' | 'normal' | 'high' | 'urgent';
+export type SlaTargetKind = 'response' | 'resolution';
+
+/**
+ * Third link of the resolution chain (D5): only urgent/high carry built-in
+ * targets so partners without category SLAs aren't flooded with breaches.
+ */
+export const PRIORITY_SLA_DEFAULTS: Record<TicketSlaPriority, { responseMinutes: number | null; resolutionMinutes: number | null }> = {
+  urgent: { responseMinutes: 60, resolutionMinutes: 240 },
+  high: { responseMinutes: 240, resolutionMinutes: 1440 },
+  normal: { responseMinutes: null, resolutionMinutes: null },
+  low: { responseMinutes: null, resolutionMinutes: null }
+};
+
+/** At-risk begins at 80% of the target elapsed (spec §3). */
+export const SLA_AT_RISK_RATIO = 0.8;
+
+export interface ResolveSlaTargetsInput {
+  overrideResponseMinutes?: number | null;
+  overrideResolutionMinutes?: number | null;
+  categoryResponseMinutes?: number | null;
+  categoryResolutionMinutes?: number | null;
+  priority: TicketSlaPriority;
+}
+
+/** Spec §3 chain, per target: ticket override → category default → priority default. */
+export function resolveSlaTargets(input: ResolveSlaTargetsInput): { responseMinutes: number | null; resolutionMinutes: number | null } {
+  const defaults = PRIORITY_SLA_DEFAULTS[input.priority];
+  return {
+    responseMinutes: input.overrideResponseMinutes ?? input.categoryResponseMinutes ?? defaults.responseMinutes,
+    resolutionMinutes: input.overrideResolutionMinutes ?? input.categoryResolutionMinutes ?? defaults.resolutionMinutes
+  };
+}
+
+const SLA_TARGET_KINDS: ReadonlySet<string> = new Set(['response', 'resolution']);
+
+/** Parse the sla_breach_reason CSV (D3) into the set of already-breached targets. */
+export function breachedTargets(reason: string | null | undefined): Set<SlaTargetKind> {
+  const out = new Set<SlaTargetKind>();
+  for (const part of (reason ?? '').split(',')) {
+    const trimmed = part.trim();
+    if (SLA_TARGET_KINDS.has(trimmed)) out.add(trimmed as SlaTargetKind);
+  }
+  return out;
+}
+
+/** Append a target to the CSV, idempotently. Mirrors the SQL CASE in ticketSlaWorker. */
+export function appendBreachTarget(reason: string | null | undefined, target: SlaTargetKind): string {
+  const existing = breachedTargets(reason);
+  if (existing.has(target)) return reason ?? target;
+  return existing.size === 0 ? target : `${[...existing].join(',')},${target}`;
+}

--- a/apps/web/src/components/tickets/SlaChip.test.tsx
+++ b/apps/web/src/components/tickets/SlaChip.test.tsx
@@ -64,6 +64,21 @@ describe('SlaChip', () => {
     expect(chip.textContent).toContain('left');
   });
 
+  it('renders a paused chip while slaPausedAt is set', () => {
+    // 30 minutes elapsed of a 120-minute SLA, paused now
+    const ticket = makeTicket({
+      id: 'tk-6',
+      resolutionSlaMinutes: 120,
+      createdAt: new Date(NOW.getTime() - 30 * 60_000).toISOString(),
+      slaPausedAt: NOW.toISOString(),
+      slaPausedMinutes: 0,
+    });
+    render(<SlaChip ticket={ticket} />);
+    const chip = screen.getByTestId('ticket-sla-tk-6');
+    expect(chip.textContent).toContain('Paused');
+    expect(chip.textContent).toContain('left');
+  });
+
   it('renders "Breached" when slaBreachedAt is set', () => {
     const ticket = makeTicket({
       id: 'tk-5',

--- a/apps/web/src/components/tickets/SlaChip.tsx
+++ b/apps/web/src/components/tickets/SlaChip.tsx
@@ -6,6 +6,16 @@ export default function SlaChip({ ticket }: { ticket: TicketSummary }) {
   if (s.kind === 'ok') {
     return <span className="text-xs text-muted-foreground" data-testid={`ticket-sla-${ticket.id}`}>{formatRelative(s.minutesLeft)}</span>;
   }
+  if (s.kind === 'paused') {
+    return (
+      <span
+        className="inline-flex items-center rounded-md border px-1.5 py-0.5 text-xs font-medium bg-muted text-muted-foreground border-border"
+        data-testid={`ticket-sla-${ticket.id}`}
+      >
+        Paused · {formatRelative(s.minutesLeft)} left
+      </span>
+    );
+  }
   if (s.kind === 'at-risk') {
     return (
       <span

--- a/apps/web/src/components/tickets/SlaTimers.test.tsx
+++ b/apps/web/src/components/tickets/SlaTimers.test.tsx
@@ -106,4 +106,35 @@ describe('SlaTimers', () => {
     render(<SlaTimers ticket={mkTicket()} />);
     expect(screen.queryByTestId('sla-timers')).toBeNull();
   });
+
+  it('resolved ticket with unmet response SLA shows Not met, not a countdown', () => {
+    render(
+      <SlaTimers
+        ticket={mkTicket({
+          responseSlaMinutes: 60,
+          firstResponseAt: null,
+          status: 'resolved',
+          resolvedAt: new Date(NOW.getTime() - 5 * 60_000).toISOString(),
+          slaBreachReason: null,
+        })}
+      />
+    );
+    expect(screen.getByTestId('sla-timer-response')).toHaveTextContent('Not met');
+    expect(screen.getByTestId('sla-timer-response')).not.toHaveTextContent(/left/);
+  });
+
+  it('resolved ticket with breached response SLA shows Breached', () => {
+    render(
+      <SlaTimers
+        ticket={mkTicket({
+          responseSlaMinutes: 60,
+          firstResponseAt: null,
+          status: 'resolved',
+          resolvedAt: new Date(NOW.getTime() - 5 * 60_000).toISOString(),
+          slaBreachReason: 'response',
+        })}
+      />
+    );
+    expect(screen.getByTestId('sla-timer-response')).toHaveTextContent('Breached');
+  });
 });

--- a/apps/web/src/components/tickets/SlaTimers.test.tsx
+++ b/apps/web/src/components/tickets/SlaTimers.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { SlaTimers } from './SlaTimers';
+import type { TicketDetail } from './ticketConfig';
+
+const NOW = new Date(); // must match the component's default `now = new Date()`
+
+const mkTicket = (overrides: Partial<TicketDetail> = {}): TicketDetail => ({
+  id: 'tk-1',
+  internalNumber: null,
+  subject: 'Test',
+  status: 'open',
+  priority: 'normal',
+  source: 'portal',
+  orgId: 'org-1',
+  orgName: 'Acme',
+  deviceId: null,
+  deviceHostname: null,
+  assignedTo: null,
+  assigneeName: null,
+  categoryId: null,
+  dueDate: null,
+  slaBreachedAt: null,
+  firstResponseAt: null,
+  // 10 minutes elapsed by default — well within any target used below.
+  createdAt: new Date(NOW.getTime() - 10 * 60_000).toISOString(),
+  updatedAt: NOW.toISOString(),
+  description: null,
+  submitterName: null,
+  submitterEmail: null,
+  pendingReason: null,
+  resolutionNote: null,
+  resolvedAt: null,
+  comments: [],
+  alertLinks: [],
+  ...overrides,
+});
+
+describe('SlaTimers', () => {
+  it('renders both timers with countdowns', () => {
+    render(<SlaTimers ticket={mkTicket({ responseSlaMinutes: 60, resolutionSlaMinutes: 240 })} />);
+    expect(screen.getByTestId('sla-timer-response')).toHaveTextContent(/left/);
+    expect(screen.getByTestId('sla-timer-resolution')).toHaveTextContent(/left/);
+  });
+
+  it('shows response as met once firstResponseAt is set', () => {
+    render(
+      <SlaTimers
+        ticket={mkTicket({
+          responseSlaMinutes: 60,
+          resolutionSlaMinutes: 240,
+          firstResponseAt: new Date(NOW.getTime() - 5 * 60_000).toISOString(),
+        })}
+      />
+    );
+    expect(screen.getByTestId('sla-timer-response')).toHaveTextContent('Met');
+    // Resolution target is untouched by the first response.
+    expect(screen.getByTestId('sla-timer-resolution')).toHaveTextContent(/left/);
+  });
+
+  it('shows resolution as met from resolvedAt', () => {
+    render(
+      <SlaTimers
+        ticket={mkTicket({
+          resolutionSlaMinutes: 240,
+          status: 'resolved',
+          resolvedAt: new Date(NOW.getTime() - 5 * 60_000).toISOString(),
+        })}
+      />
+    );
+    expect(screen.getByTestId('sla-timer-resolution')).toHaveTextContent('Met');
+  });
+
+  it('shows breached targets from slaBreachReason', () => {
+    render(
+      <SlaTimers
+        ticket={mkTicket({
+          responseSlaMinutes: 60,
+          resolutionSlaMinutes: 240,
+          slaBreachedAt: new Date(NOW.getTime() - 5 * 60_000).toISOString(),
+          slaBreachReason: 'response',
+        })}
+      />
+    );
+    expect(screen.getByTestId('sla-timer-response')).toHaveTextContent('Breached');
+    // The resolution target is not in the breach reason — still counting.
+    expect(screen.getByTestId('sla-timer-resolution')).toHaveTextContent(/left/);
+  });
+
+  it('shows a paused note while slaPausedAt is set', () => {
+    render(
+      <SlaTimers
+        ticket={mkTicket({
+          responseSlaMinutes: 60,
+          status: 'pending',
+          slaPausedAt: NOW.toISOString(),
+          slaPausedMinutes: 0,
+        })}
+      />
+    );
+    expect(screen.getByTestId('sla-timers-paused')).toBeInTheDocument();
+    expect(screen.getByTestId('sla-timer-response')).toHaveTextContent('Paused');
+  });
+
+  it('renders nothing when the ticket has no SLA targets', () => {
+    render(<SlaTimers ticket={mkTicket()} />);
+    expect(screen.queryByTestId('sla-timers')).toBeNull();
+  });
+});

--- a/apps/web/src/components/tickets/SlaTimers.tsx
+++ b/apps/web/src/components/tickets/SlaTimers.tsx
@@ -1,0 +1,76 @@
+import type { TicketDetail } from './ticketConfig';
+import { formatRelative } from './ticketConfig';
+
+// Per-target SLA state for the detail rail. Unlike SlaChip (single most-urgent
+// state for queue rows), each target gets its own met/breached/counting/paused
+// row. Clock math mirrors slaState in ticketConfig.ts — change together.
+type TimerState =
+  | { kind: 'met'; at: string }
+  | { kind: 'breached' }
+  | { kind: 'counting'; minutesLeft: number }
+  | { kind: 'paused'; minutesLeft: number };
+
+function timerState(
+  target: number,
+  metAt: string | null,
+  breached: boolean,
+  createdAt: string,
+  slaPausedAt: string | null | undefined,
+  slaPausedMinutes: number | null | undefined,
+  now: Date
+): TimerState {
+  if (metAt) return { kind: 'met', at: metAt };
+  if (breached) return { kind: 'breached' };
+  const clockEnd = slaPausedAt ? new Date(slaPausedAt) : now; // frozen while paused
+  const activeElapsed = (clockEnd.getTime() - new Date(createdAt).getTime()) / 60_000 - (slaPausedMinutes ?? 0);
+  const minutesLeft = Math.max(0, target - activeElapsed);
+  return slaPausedAt ? { kind: 'paused', minutesLeft } : { kind: 'counting', minutesLeft };
+}
+
+function TimerRow({ label, state, testId }: { label: string; state: TimerState; testId: string }) {
+  const text =
+    state.kind === 'met' ? 'Met'
+    : state.kind === 'breached' ? 'Breached'
+    : state.kind === 'paused' ? `Paused · ${formatRelative(state.minutesLeft)} left`
+    : `${formatRelative(state.minutesLeft)} left`;
+  const tone =
+    state.kind === 'breached' ? 'text-red-700 dark:text-red-400'
+    : state.kind === 'met' ? 'text-success'
+    : 'text-muted-foreground';
+  return (
+    <div className="flex items-center justify-between text-sm" data-testid={testId}>
+      <span className="text-muted-foreground">{label}</span>
+      <span className={tone}>{text}</span>
+    </div>
+  );
+}
+
+export function SlaTimers({ ticket, now = new Date() }: { ticket: TicketDetail; now?: Date }) {
+  const breached = new Set((ticket.slaBreachReason ?? '').split(',').map((s) => s.trim()));
+  const hasResponse = !!ticket.responseSlaMinutes;
+  const hasResolution = !!ticket.resolutionSlaMinutes;
+  if (!hasResponse && !hasResolution) return null;
+  const terminal = ticket.status === 'resolved' || ticket.status === 'closed';
+  return (
+    <div className="space-y-2" data-testid="sla-timers">
+      <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">SLA</h3>
+      {hasResponse && (
+        <TimerRow label="First response" testId="sla-timer-response"
+          state={timerState(ticket.responseSlaMinutes!, ticket.firstResponseAt, breached.has('response'),
+            ticket.createdAt, ticket.slaPausedAt, ticket.slaPausedMinutes, now)} />
+      )}
+      {hasResolution && (
+        <TimerRow label="Resolution" testId="sla-timer-resolution"
+          // resolvedAt is stamped on resolve/close and cleared on reopen (ticketService);
+          // terminal + updatedAt covers legacy rows that predate the stamp.
+          state={timerState(ticket.resolutionSlaMinutes!, ticket.resolvedAt ?? (terminal ? ticket.updatedAt : null),
+            breached.has('resolution'), ticket.createdAt, ticket.slaPausedAt, ticket.slaPausedMinutes, now)} />
+      )}
+      {ticket.slaPausedAt && !terminal && (
+        <p className="text-xs text-muted-foreground" data-testid="sla-timers-paused">
+          Clock paused while the ticket is {ticket.status === 'on_hold' ? 'on hold' : 'pending'}.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/tickets/SlaTimers.tsx
+++ b/apps/web/src/components/tickets/SlaTimers.tsx
@@ -1,11 +1,12 @@
 import type { TicketDetail } from './ticketConfig';
 import { formatRelative } from './ticketConfig';
 
-// Per-target SLA state for the detail rail. Unlike SlaChip (single most-urgent
-// state for queue rows), each target gets its own met/breached/counting/paused
-// row. Clock math mirrors slaState in ticketConfig.ts — change together.
+// Clock math mirrors slaState in ticketConfig.ts, which is the client twin of
+// services/ticketSla.ts, jobs/ticketSlaWorker.ts, and the SQL in routes/tickets/tickets.ts.
+// Change all of them together.
 type TimerState =
-  | { kind: 'met'; at: string }
+  | { kind: 'met' }
+  | { kind: 'missed' }
   | { kind: 'breached' }
   | { kind: 'counting'; minutesLeft: number }
   | { kind: 'paused'; minutesLeft: number };
@@ -14,13 +15,15 @@ function timerState(
   target: number,
   metAt: string | null,
   breached: boolean,
+  terminal: boolean,
   createdAt: string,
   slaPausedAt: string | null | undefined,
   slaPausedMinutes: number | null | undefined,
   now: Date
 ): TimerState {
-  if (metAt) return { kind: 'met', at: metAt };
+  if (metAt) return { kind: 'met' };
   if (breached) return { kind: 'breached' };
+  if (terminal) return { kind: 'missed' };
   const clockEnd = slaPausedAt ? new Date(slaPausedAt) : now; // frozen while paused
   const activeElapsed = (clockEnd.getTime() - new Date(createdAt).getTime()) / 60_000 - (slaPausedMinutes ?? 0);
   const minutesLeft = Math.max(0, target - activeElapsed);
@@ -30,6 +33,7 @@ function timerState(
 function TimerRow({ label, state, testId }: { label: string; state: TimerState; testId: string }) {
   const text =
     state.kind === 'met' ? 'Met'
+    : state.kind === 'missed' ? 'Not met'
     : state.kind === 'breached' ? 'Breached'
     : state.kind === 'paused' ? `Paused · ${formatRelative(state.minutesLeft)} left`
     : `${formatRelative(state.minutesLeft)} left`;
@@ -57,14 +61,14 @@ export function SlaTimers({ ticket, now = new Date() }: { ticket: TicketDetail; 
       {hasResponse && (
         <TimerRow label="First response" testId="sla-timer-response"
           state={timerState(ticket.responseSlaMinutes!, ticket.firstResponseAt, breached.has('response'),
-            ticket.createdAt, ticket.slaPausedAt, ticket.slaPausedMinutes, now)} />
+            terminal, ticket.createdAt, ticket.slaPausedAt, ticket.slaPausedMinutes, now)} />
       )}
       {hasResolution && (
         <TimerRow label="Resolution" testId="sla-timer-resolution"
           // resolvedAt is stamped on resolve/close and cleared on reopen (ticketService);
           // terminal + updatedAt covers legacy rows that predate the stamp.
           state={timerState(ticket.resolutionSlaMinutes!, ticket.resolvedAt ?? (terminal ? ticket.updatedAt : null),
-            breached.has('resolution'), ticket.createdAt, ticket.slaPausedAt, ticket.slaPausedMinutes, now)} />
+            breached.has('resolution'), terminal, ticket.createdAt, ticket.slaPausedAt, ticket.slaPausedMinutes, now)} />
       )}
       {ticket.slaPausedAt && !terminal && (
         <p className="text-xs text-muted-foreground" data-testid="sla-timers-paused">

--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -49,6 +49,7 @@ const makeTicket = (overrides: Partial<TicketDetail> = {}): TicketDetail => ({
   submitterEmail: null,
   pendingReason: null,
   resolutionNote: null,
+  resolvedAt: null,
   comments: [],
   alertLinks: [],
   ...overrides

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -8,6 +8,7 @@ import { loginPathWithNext } from '../../lib/authScope';
 import TicketFeed from './TicketFeed';
 import TicketComposer from './TicketComposer';
 import SlaChip from './SlaChip';
+import { SlaTimers } from './SlaTimers';
 import { statusConfig, priorityConfig, slaState, type TicketDetail, type TicketStatus, type TicketPriority } from './ticketConfig';
 
 interface Props {
@@ -335,27 +336,31 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
         </div>
         {railOpen && (
           <aside className="w-64 shrink-0 overflow-y-auto border-l p-3 text-sm hidden lg:block" data-testid="ticket-workbench-rail">
-            <dl className="space-y-3">
-              <div><dt className="text-xs text-muted-foreground">Requester</dt><dd>{ticket.submitterName ?? ticket.submitterEmail ?? 'Unknown'}</dd></div>
-              <div><dt className="text-xs text-muted-foreground">Source</dt><dd className="capitalize">{ticket.source}</dd></div>
-              <div><dt className="text-xs text-muted-foreground">Created</dt><dd>{new Date(ticket.createdAt).toLocaleString()}</dd></div>
-              {ticket.dueDate && <div><dt className="text-xs text-muted-foreground">Due</dt><dd>{new Date(ticket.dueDate).toLocaleString()}</dd></div>}
-              {ticket.pendingReason && <div><dt className="text-xs text-muted-foreground">Waiting on</dt><dd>{ticket.pendingReason}</dd></div>}
-              {ticket.resolutionNote && (ticket.status === 'resolved' || ticket.status === 'closed') && (
-                <div><dt className="text-xs text-muted-foreground">Resolution</dt><dd>{ticket.resolutionNote}</dd></div>
-              )}
-              <div>
-                <dt className="text-xs text-muted-foreground">Linked alerts</dt>
-                <dd className="space-y-1">
-                  {ticket.alertLinks.length === 0 && <span className="text-muted-foreground">None</span>}
-                  {ticket.alertLinks.map((l) => (
-                    <a key={l.id} href={`/alerts#${l.alertId}`} className="block truncate hover:underline" data-testid={`ticket-alert-link-${l.alertId}`}>
-                      {l.alertTitle ?? l.alertId}
-                    </a>
-                  ))}
-                </dd>
-              </div>
-            </dl>
+            <div className="space-y-3">
+              {/* Per-target SLA timers; renders nothing (no gap) when the ticket has no SLA targets. */}
+              <SlaTimers ticket={ticket} />
+              <dl className="space-y-3">
+                <div><dt className="text-xs text-muted-foreground">Requester</dt><dd>{ticket.submitterName ?? ticket.submitterEmail ?? 'Unknown'}</dd></div>
+                <div><dt className="text-xs text-muted-foreground">Source</dt><dd className="capitalize">{ticket.source}</dd></div>
+                <div><dt className="text-xs text-muted-foreground">Created</dt><dd>{new Date(ticket.createdAt).toLocaleString()}</dd></div>
+                {ticket.dueDate && <div><dt className="text-xs text-muted-foreground">Due</dt><dd>{new Date(ticket.dueDate).toLocaleString()}</dd></div>}
+                {ticket.pendingReason && <div><dt className="text-xs text-muted-foreground">Waiting on</dt><dd>{ticket.pendingReason}</dd></div>}
+                {ticket.resolutionNote && (ticket.status === 'resolved' || ticket.status === 'closed') && (
+                  <div><dt className="text-xs text-muted-foreground">Resolution</dt><dd>{ticket.resolutionNote}</dd></div>
+                )}
+                <div>
+                  <dt className="text-xs text-muted-foreground">Linked alerts</dt>
+                  <dd className="space-y-1">
+                    {ticket.alertLinks.length === 0 && <span className="text-muted-foreground">None</span>}
+                    {ticket.alertLinks.map((l) => (
+                      <a key={l.id} href={`/alerts#${l.alertId}`} className="block truncate hover:underline" data-testid={`ticket-alert-link-${l.alertId}`}>
+                        {l.alertTitle ?? l.alertId}
+                      </a>
+                    ))}
+                  </dd>
+                </div>
+              </dl>
+            </div>
           </aside>
         )}
       </div>

--- a/apps/web/src/components/tickets/TicketsPage.test.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.test.tsx
@@ -95,11 +95,11 @@ const BULK_RESULT = { data: { updated: 2, skipped: 0, failed: 0, total: 2 } };
 
 function mockListApi(
   tickets: TicketSummary[] | ((url: string) => TicketSummary[]),
-  opts: { usersFail?: boolean; bulkResult?: typeof BULK_RESULT } = {}
+  opts: { usersFail?: boolean; bulkResult?: typeof BULK_RESULT; stats?: unknown } = {}
 ) {
   fetchMock.mockImplementation(async (input) => {
     const url = String(input);
-    if (url === '/tickets/stats') return makeJsonResponse(STATS);
+    if (url === '/tickets/stats') return makeJsonResponse(opts.stats ?? STATS);
     if (url === '/tickets/bulk') return makeJsonResponse(opts.bulkResult ?? BULK_RESULT);
     if (url.startsWith('/tickets?')) return makeJsonResponse({ data: typeof tickets === 'function' ? tickets(url) : tickets });
     if (url.startsWith('/orgs/organizations')) return makeJsonResponse(ORGS);
@@ -130,8 +130,11 @@ describe('TicketsPage', () => {
     Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: 1280 });
   });
 
-  it('breaching tab shows only at-risk and breached tickets', async () => {
-    mockListApi([healthy, atRisk, breached]);
+  it('breaching tab requests slaState=breaching from the API', async () => {
+    // The server owns the breaching definition (breached ∪ at-risk, pause-aware).
+    // Returning the healthy row from the slaState=breaching request proves the
+    // client renders rows as-is, with no client-side slaState filtering.
+    mockListApi((url) => (url.includes('slaState=breaching') ? [healthy, atRisk, breached] : [healthy]));
     render(<TicketsPage />);
 
     await screen.findByTestId('ticket-row-tk-healthy');
@@ -139,10 +142,25 @@ describe('TicketsPage', () => {
     fireEvent.click(screen.getByTestId('tickets-tab-breaching'));
 
     await waitFor(() => {
-      expect(screen.queryByTestId('ticket-row-tk-healthy')).toBeNull();
+      expect(ticketFetchUrls().at(-1)).toContain('slaState=breaching');
     });
-    expect(screen.getByTestId('ticket-row-tk-risk')).toBeInTheDocument();
+    expect(ticketFetchUrls().at(-1)).toContain('statusGroup=open');
+
+    await screen.findByTestId('ticket-row-tk-risk');
     expect(screen.getByTestId('ticket-row-tk-breach')).toBeInTheDocument();
+    // Server-returned rows render unfiltered — the old client-side slaState() filter is gone.
+    expect(screen.getByTestId('ticket-row-tk-healthy')).toBeInTheDocument();
+  });
+
+  it('breaching tab badge shows breached + atRisk from /tickets/stats', async () => {
+    mockListApi([healthy], { stats: { data: { open: 3, unassigned: 1, mine: 0, breached: 2, atRisk: 3 } } });
+    render(<TicketsPage />);
+
+    await screen.findByTestId('ticket-row-tk-healthy');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('tickets-tab-breaching')).toHaveTextContent('5');
+    });
   });
 
   it('renders the error state (not the onboarding empty state) when the list fetch fails', async () => {

--- a/apps/web/src/components/tickets/TicketsPage.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.tsx
@@ -9,7 +9,7 @@ import { getJwtClaims, loginPathWithNext } from '../../lib/authScope';
 import TicketQueueList from './TicketQueueList';
 import TicketWorkbench from './TicketWorkbench';
 import { useQueueKeyboard } from './useQueueKeyboard';
-import { priorityConfig, statusConfig, slaState, type TicketPriority, type TicketStatus, type TicketSummary } from './ticketConfig';
+import { priorityConfig, statusConfig, type TicketPriority, type TicketStatus, type TicketSummary } from './ticketConfig';
 
 // Human-readable labels for bulk-skip reason codes returned by POST /tickets/bulk.
 const SKIP_REASON_LABELS: Record<string, string> = {
@@ -43,7 +43,9 @@ function tabQuery(tab: Tab): string {
     case 'mine': return 'statusGroup=open&assignee=me';
     case 'unassigned': return 'statusGroup=open&assignee=unassigned';
     case 'open': return 'statusGroup=open';
-    case 'breaching': return 'statusGroup=open'; // client-filters to at-risk/breached below
+    // Server-defined: breached ∪ at-risk (pause-aware — paused clocks are frozen, so
+    // paused tickets are intentionally excluded). Rows arrive pre-filtered.
+    case 'breaching': return 'statusGroup=open&slaState=breaching';
     case 'closed': return 'statusGroup=closed&sort=newest';
   }
 }
@@ -65,7 +67,7 @@ export default function TicketsPage() {
   const [resolveToken, setResolveToken] = useState(0);
   const [paneRefresh, setPaneRefresh] = useState(0);
   const [tickets, setTickets] = useState<TicketSummary[]>([]);
-  const [stats, setStats] = useState<{ open: number; unassigned: number; mine: number; breached: number } | null>(null);
+  const [stats, setStats] = useState<{ open: number; unassigned: number; mine: number; breached: number; atRisk?: number } | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
   const [selectedNumber, setSelectedNumber] = useState<string | null>(selectionFromHash);
@@ -187,25 +189,20 @@ export default function TicketsPage() {
     return () => window.removeEventListener('hashchange', onHash);
   }, []);
 
-  const visible = useMemo(() => {
-    if (tab !== 'breaching') return tickets;
-    return tickets.filter((t) => ['at-risk', 'breached'].includes(slaState(t).kind));
-  }, [tickets, tab]);
-
   const selected = useMemo(
-    () => visible.find((t) => t.internalNumber === selectedNumber || t.id === selectedNumber) ?? null,
-    [visible, selectedNumber]
+    () => tickets.find((t) => t.internalNumber === selectedNumber || t.id === selectedNumber) ?? null,
+    [tickets, selectedNumber]
   );
 
   // Auto-select first row when nothing valid is selected (UI brief: no-selection state auto-selects)
   useEffect(() => {
-    if (!loading && visible.length > 0 && !selected) {
-      const first = visible[0];
+    if (!loading && tickets.length > 0 && !selected) {
+      const first = tickets[0];
       const key = first.internalNumber ?? first.id;
       history.replaceState(null, '', `#${key}`);
       setSelectedNumber(key);
     }
-  }, [loading, visible, selected]);
+  }, [loading, tickets, selected]);
 
   const select = useCallback((t: TicketSummary) => {
     // Below the split-pane breakpoint the workbench pane is hidden; navigate
@@ -220,11 +217,11 @@ export default function TicketsPage() {
   }, []);
 
   const move = useCallback((delta: 1 | -1) => {
-    if (visible.length === 0) return;
-    const idx = selected ? visible.findIndex((t) => t.id === selected.id) : -1;
-    const next = visible[Math.min(visible.length - 1, Math.max(0, idx + delta))];
+    if (tickets.length === 0) return;
+    const idx = selected ? tickets.findIndex((t) => t.id === selected.id) : -1;
+    const next = tickets[Math.min(tickets.length - 1, Math.max(0, idx + delta))];
     if (next) select(next);
-  }, [visible, selected, select]);
+  }, [tickets, selected, select]);
 
   const assignMe = useCallback(async () => {
     if (!selected) return;
@@ -319,7 +316,9 @@ export default function TicketsPage() {
     if (id === 'mine') return stats.mine;
     if (id === 'unassigned') return stats.unassigned;
     if (id === 'open') return stats.open;
-    // No badge for 'breaching': the server stat counts only breached, but the tab also shows at-risk — no honest count available cheaply.
+    // Matches the tab's server definition (breached ∪ at-risk). Older /tickets/stats
+    // payloads may lack atRisk — treat as 0 rather than hiding the badge.
+    if (id === 'breaching') return stats.breached + (stats.atRisk ?? 0);
     return null;
   };
 
@@ -450,7 +449,7 @@ export default function TicketsPage() {
           <div className="relative flex w-full flex-col min-[1100px]:w-2/5 min-[1100px]:min-w-[320px] min-[1100px]:max-w-[480px] min-[1100px]:border-r">
             <div className="min-h-0 flex-1 overflow-y-auto">
               <TicketQueueList
-                tickets={visible}
+                tickets={tickets}
                 selectedId={selected?.id ?? null}
                 onSelect={select}
                 loading={loading}
@@ -470,7 +469,7 @@ export default function TicketsPage() {
                   <span className="text-sm font-medium tabular-nums">{bulkSelectedIds.size} selected</span>
                   <button
                     type="button"
-                    onClick={() => setBulkSelectedIds(new Set(visible.map((t) => t.id)))}
+                    onClick={() => setBulkSelectedIds(new Set(tickets.map((t) => t.id)))}
                     data-testid="tickets-bulk-select-all"
                     className="text-sm text-primary hover:underline"
                   >

--- a/apps/web/src/components/tickets/ticketConfig.test.ts
+++ b/apps/web/src/components/tickets/ticketConfig.test.ts
@@ -25,6 +25,35 @@ describe('slaState', () => {
   it('closed/resolved tickets are never at-risk', () => {
     expect(slaState(ticket({ resolutionSlaMinutes: 10, status: 'resolved' }) as never, new Date('2026-06-10T00:00:00Z')).kind).toBe('none');
   });
+
+  describe('pause- and response-aware rules', () => {
+    const base = { status: 'open' as const, slaBreachedAt: null, createdAt: new Date(Date.now() - 60 * 60_000).toISOString(), firstResponseAt: null };
+
+    it('uses the response target when first response is outstanding', () => {
+      // 60m elapsed, response target 90m (66% — ok), resolution 480m
+      const s = slaState({ ...base, responseSlaMinutes: 90, resolutionSlaMinutes: 480 });
+      expect(s.kind).toBe('ok');
+      // 60m elapsed, response target 70m (86% — at-risk)
+      expect(slaState({ ...base, responseSlaMinutes: 70, resolutionSlaMinutes: 480 }).kind).toBe('at-risk');
+    });
+
+    it('ignores the response target once firstResponseAt is set', () => {
+      const s = slaState({ ...base, firstResponseAt: new Date().toISOString(), responseSlaMinutes: 10, resolutionSlaMinutes: 480 });
+      expect(s.kind).toBe('ok');
+    });
+
+    it('freezes the clock while paused and reports paused', () => {
+      const s = slaState({ ...base, slaPausedAt: new Date().toISOString(), resolutionSlaMinutes: 90, slaPausedMinutes: 0 });
+      expect(s.kind).toBe('paused');
+    });
+
+    it('subtracts accumulated pause minutes', () => {
+      // 60m wall elapsed, 30m paused → 30m active; target 90m → ok with 60m left
+      const s = slaState({ ...base, resolutionSlaMinutes: 90, slaPausedMinutes: 30 });
+      expect(s.kind).toBe('ok');
+      if (s.kind === 'ok') expect(Math.round(s.minutesLeft)).toBe(60);
+    });
+  });
 });
 
 describe('config completeness', () => {

--- a/apps/web/src/components/tickets/ticketConfig.ts
+++ b/apps/web/src/components/tickets/ticketConfig.ts
@@ -19,6 +19,10 @@ export interface TicketSummary {
   dueDate: string | null;
   slaBreachedAt: string | null;
   resolutionSlaMinutes?: number | null;
+  responseSlaMinutes?: number | null;
+  slaPausedAt?: string | null;
+  slaPausedMinutes?: number | null;
+  slaBreachReason?: string | null;
   firstResponseAt: string | null;
   createdAt: string;
   updatedAt: string;
@@ -78,21 +82,32 @@ export type SlaState =
   | { kind: 'none' }
   | { kind: 'ok'; minutesLeft: number }
   | { kind: 'at-risk'; minutesLeft: number }
+  | { kind: 'paused'; minutesLeft: number }
   | { kind: 'breached'; minutesAgo: number };
 
-// "Quiet until it matters" — see SlaChip for per-state rendering. At-risk begins at 80% of resolutionSlaMinutes elapsed.
+// "Quiet until it matters" — see SlaChip for per-state rendering. At-risk begins at 80% of the target elapsed.
+// Client twin of the server SLA rules (services/ticketSla.ts) — change together.
 export function slaState(
-  t: Pick<TicketSummary, 'slaBreachedAt' | 'createdAt' | 'status'> & { resolutionSlaMinutes?: number | null },
+  t: Pick<TicketSummary, 'slaBreachedAt' | 'createdAt' | 'status' | 'firstResponseAt'> &
+     { resolutionSlaMinutes?: number | null; responseSlaMinutes?: number | null; slaPausedAt?: string | null; slaPausedMinutes?: number | null },
   now: Date = new Date()
 ): SlaState {
   if (t.status === 'resolved' || t.status === 'closed') return { kind: 'none' };
   if (t.slaBreachedAt) {
     return { kind: 'breached', minutesAgo: (now.getTime() - new Date(t.slaBreachedAt).getTime()) / 60_000 };
   }
-  if (!t.resolutionSlaMinutes) return { kind: 'none' };
-  const elapsed = (now.getTime() - new Date(t.createdAt).getTime()) / 60_000;
-  const left = t.resolutionSlaMinutes - elapsed;
+  const targets: number[] = [];
+  if (t.responseSlaMinutes && !t.firstResponseAt) targets.push(t.responseSlaMinutes);
+  if (t.resolutionSlaMinutes) targets.push(t.resolutionSlaMinutes);
+  if (targets.length === 0) return { kind: 'none' };
+
+  // Both targets share the createdAt clock, so the smallest target is the most urgent.
+  const target = Math.min(...targets);
+  const clockEnd = t.slaPausedAt ? new Date(t.slaPausedAt) : now; // frozen while paused
+  const activeElapsed = (clockEnd.getTime() - new Date(t.createdAt).getTime()) / 60_000 - (t.slaPausedMinutes ?? 0);
+  const left = target - activeElapsed;
+  if (t.slaPausedAt) return { kind: 'paused', minutesLeft: Math.max(0, left) };
   if (left <= 0) return { kind: 'breached', minutesAgo: -left };
-  if (elapsed >= 0.8 * t.resolutionSlaMinutes) return { kind: 'at-risk', minutesLeft: left };
+  if (activeElapsed >= 0.8 * target) return { kind: 'at-risk', minutesLeft: left };
   return { kind: 'ok', minutesLeft: left };
 }

--- a/apps/web/src/components/tickets/ticketConfig.ts
+++ b/apps/web/src/components/tickets/ticketConfig.ts
@@ -48,6 +48,9 @@ export interface TicketDetail extends TicketSummary {
   submitterEmail: string | null;
   pendingReason: string | null;
   resolutionNote: string | null;
+  // Stamped by the API on resolve/close, cleared on reopen. The detail endpoint
+  // returns the full ticket row, so this is always present (unlike the list).
+  resolvedAt: string | null;
   comments: TicketComment[];
   alertLinks: Array<{ id: string; alertId: string; linkType: string; alertTitle: string | null; alertSeverity: string | null; alertStatus: string | null }>;
 }

--- a/apps/web/src/components/tickets/ticketConfig.ts
+++ b/apps/web/src/components/tickets/ticketConfig.ts
@@ -86,7 +86,7 @@ export type SlaState =
   | { kind: 'breached'; minutesAgo: number };
 
 // "Quiet until it matters" — see SlaChip for per-state rendering. At-risk begins at 80% of the target elapsed.
-// Client twin of the server SLA rules (services/ticketSla.ts) — change together.
+// Client twin of the server SLA rules (services/ticketSla.ts and the SQL fragments in routes/tickets/tickets.ts) — change together.
 export function slaState(
   t: Pick<TicketSummary, 'slaBreachedAt' | 'createdAt' | 'status' | 'firstResponseAt'> &
      { resolutionSlaMinutes?: number | null; responseSlaMinutes?: number | null; slaPausedAt?: string | null; slaPausedMinutes?: number | null },

--- a/docs/superpowers/plans/2026-06-11-ticketing-residual-pickups.md
+++ b/docs/superpowers/plans/2026-06-11-ticketing-residual-pickups.md
@@ -1,0 +1,338 @@
+# Ticketing Residual Pickups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close out the smaller ticketing follow-ups left open after PR #1245 / #1238: the org-roles `organizations:read` grant, alert-link site-gating, the `devices(site_id)` index, device hard-delete ticket preservation, and three small UX items.
+
+**Architecture:** Independent, individually shippable fixes. R1-R4 are API/data-safety; R5-R7 are web-only. No new tables; one permission-grant migration and one index migration.
+
+**Tech Stack:** Hono + Drizzle (API), React islands (web), Vitest.
+
+**Companion plan:** `docs/superpowers/plans/2026-06-11-ticketing-sla-engine.md` (Phase 2 main thread). These pickups are independent of it and can land before, after, or interleaved.
+
+---
+
+## Delegation matrix
+
+| Task | Owner | Why |
+|---|---|---|
+| R1 organizations:read grant | Claude | authz change |
+| R2 alert-link site gating | Claude | tenant/site isolation |
+| R3 devices(site_id) index | **Codex (low)** | mechanical migration |
+| R4 hard-delete detaches tickets | Claude | destructive-path semantics |
+| R5 queue sort control | Claude (in-session) | UI |
+| R6 sticky composer tab | Claude (in-session) | UI |
+| R7 cross-tab bulk selection | Claude (in-session) | UI |
+
+Codex template: see the SLA plan's "Codex invocation template" — identical, pointing at this file's task.
+
+**PR grouping:** PR-1 = R1 (authz, reviewable alone). PR-2 = R2 + R4 (ticket data-safety/site-gating) + R3 riding along. PR-3 = R5-R7 (UX).
+
+**Deferred (documented, not in this plan):** device-select searchable combobox (M), site-limited banner (M — needs an API surface exposing `allowedSiteIds`; JWT doesn't carry site ids), feed old→new values for field edits (M — `updateTicketFields` writes no oldValue/newValue), `GET /tickets/:id` alertLinks title redaction for out-of-site alerts (decide alongside a broader read-side redaction pass), "Breaching soon" empty state (covered by SLA plan UI work).
+
+---
+
+## Task R1: Grant `organizations:read` to org-scope system roles — **Claude**
+
+The deep fix for the cold-load orgs 403: `GET /orgs/organizations` (orgs.ts:690) already supports org scope but is gated by `requirePermission('organizations','read')` (orgs.ts:28), which the seeded `Org Admin`/`Org Technician`/`Org Viewer` roles lack (`apps/api/src/db/seed.ts` SYSTEM_ROLES ~:161-240). PR #1245 shipped a client-side skip; this makes the permission real.
+
+**Files:**
+- Create: `apps/api/migrations/2026-06-12-b-org-roles-organizations-read.sql` (re-date to execution date)
+- Modify: `apps/api/src/db/seed.ts` (the three org-scope SYSTEM_ROLES permission arrays)
+
+- [ ] **Step 1: Audit the blast radius.** `requireOrgRead` also gates routes in `integrations.ts`, `networkKnownGuests.ts`, `psa.ts`, `patchPolicies.ts`, `apiKeys.ts`. List every `PERMISSIONS.ORGS_READ` call site (`grep -rn "ORGS_READ" apps/api/src/routes/`) and confirm each also carries a `requireScope`/partner guard that keeps org users out where intended. Record the list in the PR description. Also confirm the org-scope branch of `GET /organizations` (orgs.ts:701-705) returns only id/name-level fields. If anything looks newly exposed, stop and re-scope.
+
+- [ ] **Step 2: Write the migration** (modeled on the role-grant block in `2026-06-09-a-native-ticketing-core.sql:163-180`, hardened with `is_system = true` — the report-permissions precedent omitted it and could hit same-named custom roles):
+
+```sql
+-- Org-scope system roles need organizations:read so org users can cold-load
+-- GET /orgs/organizations (tickets org selector; residual from PR #1245).
+-- The permission row ships in the baseline; grant only, no permission insert.
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON p.resource = 'organizations' AND p.action = 'read'
+WHERE r.name IN ('Org Admin', 'Org Technician', 'Org Viewer')
+  AND r.is_system = true
+  AND NOT EXISTS (
+    SELECT 1 FROM role_permissions x
+    WHERE x.role_id = r.id AND x.permission_id = p.id
+  );
+```
+
+Verify the `roles.is_system` column name against `apps/api/src/db/schema/users.ts:47` before committing (adjust to the actual column if it differs).
+
+- [ ] **Step 3: Update `seed.ts`** — add `'organizations:read'` to the permission arrays of `Org Admin`, `Org Technician`, `Org Viewer` so fresh installs match migrated ones.
+
+- [ ] **Step 4: Apply + verify locally**
+
+```bash
+# restart API to run autoMigrate, then:
+docker exec -i breeze-postgres psql -U breeze -d breeze -c "
+SELECT r.name FROM roles r
+JOIN role_permissions rp ON rp.role_id = r.id
+JOIN permissions p ON p.id = rp.permission_id
+WHERE p.resource = 'organizations' AND p.action = 'read' AND r.name LIKE 'Org %';"
+```
+
+Expected: the three org roles. Re-run autoMigrate → no duplicate rows (NOT EXISTS guard). Then log in as an org-scope user and confirm `GET /orgs/organizations` returns 200 (permission cache refreshes within ≤5 min; bump the `permission-cache:version` Redis key for instant effect while testing).
+
+- [ ] **Step 5: Leave the client-side skip in place** (`TicketsPage.tsx:62,123-125`, `CreateTicketPage.tsx:27-49`) — it becomes a harmless fast path; removing it is optional cleanup, not required.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/migrations/2026-06-12-b-org-roles-organizations-read.sql apps/api/src/db/seed.ts
+git commit -m "fix(rbac): grant organizations:read to org-scope system roles (#1245 residual)"
+```
+
+---
+
+## Task R2: Site-gate the alert-link paths — **Claude**
+
+A site-restricted org user can currently link/unlink alerts whose device is outside their sites, and create tickets from such alerts (the resulting ticket is then invisible to them). The ticket side is gated (`getScopedTicketOr404` → `deviceInSiteScope`); the alert side is org-checked only (`linkAlertToTicket` at ticketService.ts:571-583; `getAlertWithOrgCheck` in routes/alerts/helpers.ts:68).
+
+**Files:**
+- Create: `apps/api/src/routes/tickets/siteScope.ts` (extract `deviceInSiteScope` + `ticketSiteScopeCondition` from `tickets.ts:60-133` — they're module-private today and now needed by the alerts route)
+- Modify: `apps/api/src/routes/tickets/tickets.ts` (import from `siteScope.ts`; gate POST `/:id/alerts` :520 and DELETE `/:id/alerts/:alertId` :547)
+- Modify: `apps/api/src/routes/alerts/alerts.ts` (gate POST `/alerts/:id/create-ticket` :660-696)
+- Test: `apps/api/src/routes/tickets/tickets.test.ts`, `apps/api/src/routes/alerts/alerts.test.ts` (or the alerts route test file's actual name)
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// tickets.test.ts
+it('POST /tickets/:id/alerts returns 404 when the alert device is outside the caller site scope', async () => {
+  // auth: org-scope user with allowedSiteIds ['site-a']
+  // alert row: deviceId belonging to 'site-b'
+  // expect 404 { error: 'Alert not found' } and linkAlertToTicket NOT called
+});
+it('DELETE /tickets/:id/alerts/:alertId applies the same gate', async () => {});
+it('alert links for in-site devices still work for restricted users', async () => {});
+
+// alerts route test
+it('POST /alerts/:id/create-ticket returns 404 for out-of-site alert devices', async () => {});
+```
+
+- [ ] **Step 2: Run — expect FAIL:**
+
+```bash
+cd apps/api && npx vitest run src/routes/tickets/tickets.test.ts src/routes/alerts/*.test.ts --pool=forks --poolOptions.forks.singleFork=true
+```
+
+- [ ] **Step 3: Implement.**
+  - Move `deviceInSiteScope(auth, deviceId)` and `ticketSiteScopeCondition(auth)` verbatim into `apps/api/src/routes/tickets/siteScope.ts`, export both, and re-import in `tickets.ts` (no behavior change — run the existing suite to prove it).
+  - In both ticket alert-link handlers, after `getScopedTicketOr404` succeeds: load the alert's `deviceId` (single select on `alerts`), and if it has a device not in scope, return 404:
+
+```ts
+    const alertRows = await db.select({ deviceId: alerts.deviceId }).from(alerts).where(eq(alerts.id, alertId)).limit(1);
+    const alertRow = alertRows[0];
+    if (!alertRow) return c.json({ error: 'Alert not found' }, 404);
+    if (alertRow.deviceId && !(await deviceInSiteScope(auth, alertRow.deviceId))) {
+      // Out-of-site alerts are invisible, not forbidden — same shape as the ticket gate.
+      return c.json({ error: 'Alert not found' }, 404);
+    }
+```
+
+  - In `POST /alerts/:id/create-ticket`: after `getAlertWithOrgCheck`, apply the same `deviceInSiteScope` check on `alert.deviceId` before calling `createTicketFromAlert`.
+  - Keep `linkAlertToTicket`'s same-org check unchanged (service stays site-agnostic; the route layer owns the site axis — matches the existing pattern where `tickets.ts` routes gate and the service guards org/partner only).
+
+- [ ] **Step 4: Run — expect PASS** (both suites, plus the untouched alert-link happy-path tests).
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/tickets/siteScope.ts apps/api/src/routes/tickets/tickets.ts apps/api/src/routes/alerts/alerts.ts apps/api/src/routes/tickets/tickets.test.ts apps/api/src/routes/alerts/
+git commit -m "fix(tickets): site-gate alert link/unlink and create-from-alert (#1238 follow-up)"
+```
+
+---
+
+## Task R3: `devices(site_id)` index — **Codex (low)**
+
+No index exists on `devices.site_id` (FKs don't create indexes in PG; baseline has only management/mtls partials). Every site-restricted ticket query subqueries `devices.site_id`.
+
+**Files:**
+- Create: `apps/api/migrations/2026-06-12-c-devices-site-id-index.sql` (re-date at execution)
+- Modify: `apps/api/src/db/schema/devices.ts` (:13-80 — add an extras block if drift check demands it)
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Site-axis queries (ticket site scoping, site device lists) filter on
+-- devices.site_id; the FK alone creates no index.
+CREATE INDEX IF NOT EXISTS devices_site_id_idx ON devices (site_id);
+```
+
+- [ ] **Step 2: Apply locally** (restart API or apply manually), verify with `\di devices_site_id_idx`, re-apply to confirm no-op.
+
+- [ ] **Step 3: Drift check** — `pnpm db:check-drift`. If the new index is flagged, add to the `devices` pgTable:
+
+```ts
+}, (table) => ({
+  siteIdIdx: index('devices_site_id_idx').on(table.siteId)
+}));
+```
+
+(plus the `index` import from `drizzle-orm/pg-core`). If not flagged, leave the schema untouched — match the repo's existing index-in-SQL-only convention for this table.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/migrations/2026-06-12-c-devices-site-id-index.sql apps/api/src/db/schema/devices.ts
+git commit -m "perf(devices): index devices.site_id for site-axis scoping queries"
+```
+
+---
+
+## Task R4: Device hard-delete detaches tickets instead of cascading — **Claude**
+
+`DELETE /devices/:id/permanent` lists `'tickets'` in `DEVICE_CASCADE_DELETE_TABLES` (routes/devices/core.ts:137-188), destroying ticket history — and it's actually broken today: tickets with comments hit the `ticket_comments.ticket_id` FK (no cascade) → 409. Tickets are business records; detach them (`device_id = NULL` is first-class — deviceless tickets already work).
+
+**Files:**
+- Modify: `apps/api/src/routes/devices/core.ts` (cascade list :137-188, delete transaction :1214-1280)
+- Test: `apps/api/src/routes/devices/cascadeDelete.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+it('hard delete detaches tickets (device_id -> NULL) instead of deleting them', async () => {
+  // device with one ticket (with comments); run the permanent delete
+  // expect UPDATE tickets SET device_id = NULL ... captured, no DELETE FROM tickets
+  // expect 200 (previously this scenario 409'd on the ticket_comments FK)
+});
+
+// cascadeDelete.test.ts contract: every device_id-FK table must be in the
+// cascade list — add an explicit DETACH exception set and assert membership
+// of every device_id FK table in exactly one of the two sets.
+it('tickets is in the detach set, not the cascade set', () => {
+  expect(DEVICE_DETACH_DEVICE_ID_TABLES).toContain('tickets');
+  expect(DEVICE_CASCADE_DELETE_TABLES).not.toContain('tickets');
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL:**
+
+```bash
+cd apps/api && npx vitest run src/routes/devices/cascadeDelete.test.ts --pool=forks --poolOptions.forks.singleFork=true
+```
+
+- [ ] **Step 3: Implement.**
+  - Remove `'tickets'` from `DEVICE_CASCADE_DELETE_TABLES`.
+  - Add beside it: `export const DEVICE_DETACH_DEVICE_ID_TABLES = ['tickets'] as const;` with a comment: tickets are tenant business records — preserve history, detach the device.
+  - In the delete transaction, next to the existing `DEVICE_LINKED_DEVICE_ID_TABLES` NULL-out loop (:1267-1269), add the detach loop:
+
+```ts
+      for (const table of DEVICE_DETACH_DEVICE_ID_TABLES) {
+        await tx.execute(sql`UPDATE ${sql.raw(table)} SET device_id = NULL WHERE device_id = ${deviceId}`);
+      }
+```
+
+  (Match the exact style of the adjacent linked-device loop — if it uses a different query helper, copy that.)
+  - Update the contract test as in Step 1 so the "every device_id FK table is accounted for" invariant still holds across both lists.
+
+- [ ] **Step 4: Run — expect PASS** (cascadeDelete + any devices core route tests).
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/devices/core.ts apps/api/src/routes/devices/cascadeDelete.test.ts
+git commit -m "fix(devices): hard delete detaches tickets instead of destroying them (#1238 follow-up)"
+```
+
+---
+
+## Task R5: Queue sort control — **Claude (in-session)**
+
+The API already supports `?sort=triage|newest|oldest|due` (validator :77, orderBy tickets.ts:252-256). The queue UI never exposes it.
+
+**Files:**
+- Modify: `apps/web/src/components/tickets/TicketsPage.tsx` (params built ~:139)
+- Test: `apps/web/src/components/tickets/TicketsPage.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('sort select passes sort=newest to the API and persists in the location hash', async () => {
+  // change the select to 'newest'; assert fetch URL contains 'sort=newest'
+  // and window.location.hash reflects it (hash-based UI state per CLAUDE.md)
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL.**
+- [ ] **Step 3: Implement.** Add a `sort` state (default `'triage'`), a small `<select data-testid="ticket-sort">` beside the existing filter controls with options Triage / Newest / Oldest / Due date, include it in the request params, and persist it in the hash alongside the existing tab state (follow the component's current hash pattern exactly).
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/tickets/TicketsPage.tsx apps/web/src/components/tickets/TicketsPage.test.tsx
+git commit -m "feat(tickets/web): queue sort control (triage/newest/oldest/due)"
+```
+
+---
+
+## Task R6: Sticky composer tab — **Claude (in-session)**
+
+`TicketComposer`'s public/internal mode resets after send because `sendComment → load()` flips `TicketWorkbench` through its loading-skeleton branch (:166-170), unmounting the composer (mode state at TicketComposer.tsx:12).
+
+**Files:**
+- Modify: `apps/web/src/components/tickets/TicketWorkbench.tsx` (:156-170)
+- Test: `apps/web/src/components/tickets/TicketWorkbench.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('keeps the composer mounted (and its internal-note tab selected) across a refresh after send', async () => {
+  // select internal tab, send a comment (triggers reload)
+  // assert the composer still shows the internal tab selected
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL.**
+- [ ] **Step 3: Implement.** Distinguish initial load from refresh: render the loading skeleton only when `loading && !ticket` (first load); during refreshes keep the current tree mounted (optionally dim/disable via `aria-busy`). This keeps `TicketComposer` mounted so its mode state survives. Do not lift the mode state unless the mount fix proves insufficient.
+- [ ] **Step 4: Run — expect PASS** (whole workbench suite — the skeleton-branch tests may need their setup adjusted to assert on first load only).
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/tickets/TicketWorkbench.tsx apps/web/src/components/tickets/TicketWorkbench.test.tsx
+git commit -m "fix(tickets/web): composer tab no longer resets after sending (skeleton only on first load)"
+```
+
+---
+
+## Task R7: Cross-tab bulk selection — **Claude (in-session)**
+
+`bulkSelectedIds` is cleared on every tab/filter change (effect at TicketsPage.tsx:177-182). The backend `POST /tickets/bulk` takes raw ids and doesn't care about tabs.
+
+**Files:**
+- Modify: `apps/web/src/components/tickets/TicketsPage.tsx` (:82 state, :177-182 effect, :462-470 bulk bar)
+- Test: `apps/web/src/components/tickets/TicketsPage.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+it('keeps selections when switching tabs', async () => {
+  // select 2 tickets on the open tab, switch to mine, assert bulk bar still shows '2 selected'
+});
+it('clears selections when filters change', async () => {
+  // changing org/priority/search filters still clears (results genuinely change meaning)
+});
+it('bulk bar shows count and a clear button when selection spans hidden rows', async () => {});
+```
+
+- [ ] **Step 2: Run — expect FAIL.**
+- [ ] **Step 3: Implement.** Narrow the clearing effect's dependency list to the filter inputs only (org/priority/category/assignee/search), excluding the tab. Update the bulk bar to show `N selected` (count of all selected ids, not just visible ones) plus a `Clear` button (`data-testid="bulk-clear"`). Selected rows not in the current view stay selected silently — the count chip is the indicator.
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/tickets/TicketsPage.tsx apps/web/src/components/tickets/TicketsPage.test.tsx
+git commit -m "feat(tickets/web): bulk selection survives tab switches"
+```
+
+---
+
+## Verification
+
+- [ ] Affected API suites single-fork (`tickets`, `alerts`, `devices` cascadeDelete, validators); web `src/components/tickets/`; `npx tsc --noEmit`.
+- [ ] R1 live check: org-scope login → tickets page cold load shows the org name with no 403 in the network tab.
+- [ ] R4 live check: hard-delete a dev device that has a commented ticket → 200, ticket survives deviceless.
+- [ ] PRs per the grouping above; `superpowers:requesting-code-review` before each merge.

--- a/docs/superpowers/plans/2026-06-11-ticketing-sla-engine.md
+++ b/docs/superpowers/plans/2026-06-11-ticketing-sla-engine.md
@@ -1,0 +1,1297 @@
+# Ticketing Phase 2 — SLA Engine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Activate the dormant ticket SLA columns: stamp targets at create, pause the clock on `pending`/`on_hold`, detect breaches with a 1-minute BullMQ sweep, notify on breach, and surface SLA state in queue filters/sort/stats and the ticket UI.
+
+**Architecture:** SLA targets are materialized onto the ticket row at create time (override → category default → priority default), so all queue filtering/sorting is plain SQL over `tickets` columns. A repeatable BullMQ sweep (`ticket-sla-monitor`, every 60s) stamps `sla_breached_at`/`sla_breach_reason` per target (one-shot each for `response` and `resolution`) and emits a new `ticket.sla_breached` lifecycle event consumed by the existing `ticketNotifyWorker`. Pause/resume lives in `changeTicketStatus` (the single status-change chokepoint). No new tables, no RLS changes — only an index migration.
+
+**Tech Stack:** Hono + Drizzle + BullMQ (API), Zod validators in `packages/shared`, React islands (web), Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-06-09-native-ticketing-design.md` — Phase 2 (§8): "SLA resolution chain, monitor job, pause logic, queue countdown + breaching-soon tab, breach notifications."
+
+---
+
+## Design decisions (resolving spec ambiguities)
+
+The spec is silent or ambiguous on six points. These are the decisions this plan implements — do not re-litigate them mid-execution; if one proves wrong, stop and flag it.
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **24×7 wall-clock SLA.** No business-hours calendars in Phase 2. | Spec never mentions business hours. Calendars change breach math retroactively — defer until a partner asks. |
+| D2 | **Resolution chain collapses at create time.** `createTicket` stamps `response_sla_minutes`/`resolution_sla_minutes` from category defaults, else priority defaults. The sweep and all SQL read ticket columns only. Pre-Phase-2 tickets (null targets) simply have no SLA — no backfill. Category/priority changes after create do NOT restamp; `PATCH /tickets/:id` accepts explicit overrides. | The queue filter ("SLA state") and triage sort must be index-backed SQL; resolving a 3-level chain per row per query is not. Stamping is equivalent to the spec's chain for new tickets and far simpler. |
+| D3 | **Per-target one-shot breach.** `sla_breach_reason` holds a comma-joined list (`response`, `resolution`). `sla_breached_at` records the FIRST breach and is never overwritten. Each target notifies at most once, ever (no re-fire after un-pause or reopen). | One column pair, two targets. CSV-in-reason avoids a schema change and is SQL-checkable for sweep idempotency. |
+| D4 | **Pause is status-driven only.** Entering `pending`/`on_hold` sets `sla_paused_at = now()`; leaving (to ANY status, including `resolved`/`closed`) folds elapsed minutes into `sla_paused_minutes` and clears `sla_paused_at`. Customer replies do not affect the clock. | Exactly what spec §3 says; the resolve-from-paused fold keeps the columns consistent for reopen. |
+| D5 | **Priority defaults (the chain's third link): `urgent` 60/240 min, `high` 240/1440 min, `normal`/`low` none.** Hardcoded constants in `ticketSla.ts`. | Spec names "priority default" but defines no values and no settings home. Hardcoding only urgent/high keeps breach noise near zero for partners who haven't configured categories, while making urgent tickets visibly tracked. Making them configurable is deferred. |
+| D6 | **Breach notification = `ticket.sla_breached` TicketEvent → `ticketNotifyWorker` (in-app + email to the assignee) + an eventBus publish (`ticket.sla_breached`) mirroring `backupSlaWorker`'s breach publish.** Unassigned tickets get the eventBus publish only. | `alertService.createAlert` is rule/device-centric — a poor fit. The eventBus publish is the hook into `notificationRoutingRules`/channels the spec names, matching the `backup.sla_breach` precedent. Escalation-policy wiring is explicitly deferred by spec §8. |
+| D7 | **At-risk = 80% of active elapsed time, computed (never stored), UI + filter only — no at-risk notifications.** `slaState` filter values: `ok` \| `at_risk` \| `breached` \| `breaching` (= at_risk ∪ breached; the queue tab uses this). | Spec defines 80% and a filter/tab, not an at-risk notification. |
+
+**Out of scope (do not build):** business-hours calendars, escalation policies, configurable priority defaults, per-partner SLA policy objects/tables, at-risk notifications, dashboard widget (stats endpoint exposes the counts; widget is a follow-up), portal-side SLA visibility, e2e spec additions (tracked in `docs/testing/e2e-coverage-index.md` follow-ups), Phase 3 (time tracking/parts), Phase 4 (email-to-ticket).
+
+---
+
+## Delegation matrix
+
+Per CLAUDE.md (Codex for isolated, well-scoped tasks; Claude keeps tenant isolation, auth/authz, cross-module work) and the standing preference that UI work runs in-session.
+
+| Task | Owner | Codex reasoning effort |
+|---|---|---|
+| 1. `ticketSla.ts` pure helpers + tests | **Codex** | medium |
+| 2. Stamp targets in `createTicket` | Claude | — |
+| 3. Pause/resume in `changeTicketStatus` | Claude | — |
+| 4. `ticket.sla_breached` event variant | **Codex** | low |
+| 5. SLA monitor worker + registration | Claude | — |
+| 6. Notify worker breach handling | **Codex** | high |
+| 7. Validators + PATCH SLA override | **Codex** | medium |
+| 8. List filter / triage sort / stats | **Codex** | high |
+| 9. Index migration | **Codex** | low |
+| 10. Web: `slaState()` pause-aware + SlaChip | Claude (in-session) | — |
+| 11. Web: breaching tab server-driven + countdown | Claude (in-session) | — |
+| 12. Web: workbench SLA timers rail | Claude (in-session) | — |
+
+**Codex invocation template** (run from the execution worktree root; node 22 PATH prefix per repo convention):
+
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH codex exec "$(cat <<'EOF'
+Read docs/superpowers/plans/2026-06-11-ticketing-sla-engine.md, Task N.
+Implement it exactly as written: write the failing test first, run it (expect fail),
+implement, run again (expect pass). Use the exact file paths, names, and code from
+the plan. Run tests with:
+  cd apps/api && npx vitest run <test files> --pool=forks --poolOptions.forks.singleFork=true
+Do not commit.
+EOF
+)" --full-auto -m gpt-5.5 -c 'model_reasoning_effort="<level>"' -C "$(git rev-parse --show-toplevel)"
+```
+
+After every Codex task: review `git diff` (correctness, tenancy, conventions), run the task's tests yourself, then commit. Claude owns all commits.
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `apps/api/src/services/ticketSla.ts` | Create | Pure SLA math: priority defaults, target resolution, breach-reason CSV helpers, state computation. No DB, no IO. |
+| `apps/api/src/services/ticketSla.test.ts` | Create | Table-driven tests for the above. |
+| `apps/api/src/services/ticketService.ts` | Modify | Stamp targets at create (~:207-237); pause/resume in `changeTicketStatus` (~:288-310); SLA override fields in `updateTicketFields`. |
+| `apps/api/src/services/ticketEvents.ts` | Modify | Add `ticket.sla_breached` to the `TicketEvent` union (:19-25). |
+| `apps/api/src/jobs/ticketSlaWorker.ts` | Create | Repeatable 60s breach sweep; stamps + emits. Modeled on `approvalExpiryReaper.ts`. |
+| `apps/api/src/jobs/ticketSlaWorker.test.ts` | Create | Sweep SQL shape + emit behavior tests (Drizzle mocks). |
+| `apps/api/src/jobs/ticketNotifyWorker.ts` | Modify | Handle `ticket.sla_breached`: in-app + email to assignee. |
+| `apps/api/src/index.ts` | Modify | Register `initializeTicketSlaWorker`/`shutdownTicketSlaWorker` beside `ticketNotifyWorker` (~:1053). |
+| `packages/shared/src/validators/tickets.ts` | Modify | `slaState` in `listTicketsQuerySchema`; `responseSlaMinutes`/`resolutionSlaMinutes` in `updateTicketSchema`. |
+| `apps/api/src/routes/tickets/tickets.ts` | Modify | SLA filter conditions, SLA-aware triage sort, `atRisk` stat, projection additions. |
+| `apps/api/migrations/2026-06-12-a-ticket-sla-indexes.sql` | Create | Partial indexes for sweep + breached filtering. (Re-date to the actual execution date.) |
+| `apps/web/src/components/tickets/ticketConfig.ts` | Modify | Pause/response-aware `slaState()`, new `paused` kind, `TicketSummary` fields. |
+| `apps/web/src/components/tickets/SlaChip.tsx` | Modify | Render `paused` state. |
+| `apps/web/src/components/tickets/TicketsPage.tsx` | Modify | Server-driven breaching tab (`slaState=breaching`). |
+| `apps/web/src/components/tickets/SlaTimers.tsx` | Create | Response/resolution timers for the detail right rail. |
+| `apps/web/src/components/tickets/TicketWorkbench.tsx` | Modify | Mount `SlaTimers`. |
+
+---
+
+## Task 0: Worktree + baseline
+
+- [ ] **Step 1: Isolated workspace.** If not already in one (this plan was authored in `worktree-ticketing-sla-plan`, which can be reused), create via the native worktree tool. Then:
+
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm install
+```
+
+- [ ] **Step 2: Baseline the affected test files** (full-suite parallel runs are known-flaky; use single-fork on affected files and trust CI for the rest):
+
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run \
+  src/services/ticketService.test.ts src/services/ticketEvents.test.ts \
+  src/routes/tickets/tickets.test.ts src/jobs/ticketNotifyWorker.test.ts \
+  --pool=forks --poolOptions.forks.singleFork=true
+```
+
+Expected: all pass. If not, stop and report before changing anything.
+
+---
+
+## Task 1: `ticketSla.ts` pure helpers — **Codex (medium)**
+
+**Files:**
+- Create: `apps/api/src/services/ticketSla.ts`
+- Test: `apps/api/src/services/ticketSla.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// apps/api/src/services/ticketSla.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  PRIORITY_SLA_DEFAULTS,
+  SLA_AT_RISK_RATIO,
+  resolveSlaTargets,
+  breachedTargets,
+  appendBreachTarget
+} from './ticketSla';
+
+describe('PRIORITY_SLA_DEFAULTS', () => {
+  it('tracks urgent and high only (D5)', () => {
+    expect(PRIORITY_SLA_DEFAULTS.urgent).toEqual({ responseMinutes: 60, resolutionMinutes: 240 });
+    expect(PRIORITY_SLA_DEFAULTS.high).toEqual({ responseMinutes: 240, resolutionMinutes: 1440 });
+    expect(PRIORITY_SLA_DEFAULTS.normal).toEqual({ responseMinutes: null, resolutionMinutes: null });
+    expect(PRIORITY_SLA_DEFAULTS.low).toEqual({ responseMinutes: null, resolutionMinutes: null });
+  });
+});
+
+describe('resolveSlaTargets', () => {
+  const cases: Array<{ name: string; input: Parameters<typeof resolveSlaTargets>[0]; expected: { responseMinutes: number | null; resolutionMinutes: number | null } }> = [
+    { name: 'override wins over category and priority',
+      input: { overrideResponseMinutes: 5, overrideResolutionMinutes: 10, categoryResponseMinutes: 30, categoryResolutionMinutes: 60, priority: 'urgent' },
+      expected: { responseMinutes: 5, resolutionMinutes: 10 } },
+    { name: 'category wins over priority',
+      input: { categoryResponseMinutes: 30, categoryResolutionMinutes: 60, priority: 'urgent' },
+      expected: { responseMinutes: 30, resolutionMinutes: 60 } },
+    { name: 'priority default fallback for urgent',
+      input: { priority: 'urgent' },
+      expected: { responseMinutes: 60, resolutionMinutes: 240 } },
+    { name: 'normal priority with no category yields no SLA',
+      input: { priority: 'normal' },
+      expected: { responseMinutes: null, resolutionMinutes: null } },
+    { name: 'per-target independence: category sets resolution only, response falls to priority',
+      input: { categoryResolutionMinutes: 90, priority: 'high' },
+      expected: { responseMinutes: 240, resolutionMinutes: 90 } }
+  ];
+  for (const c of cases) {
+    it(c.name, () => expect(resolveSlaTargets(c.input)).toEqual(c.expected));
+  }
+});
+
+describe('breachedTargets / appendBreachTarget', () => {
+  it('parses null/empty as no targets', () => {
+    expect(breachedTargets(null).size).toBe(0);
+    expect(breachedTargets('').size).toBe(0);
+  });
+  it('parses CSV and ignores unknown entries', () => {
+    expect([...breachedTargets('response')]).toEqual(['response']);
+    expect([...breachedTargets('response,resolution')].sort()).toEqual(['resolution', 'response'].sort());
+    expect([...breachedTargets('response,bogus')]).toEqual(['response']);
+  });
+  it('appends without duplicating', () => {
+    expect(appendBreachTarget(null, 'response')).toBe('response');
+    expect(appendBreachTarget('response', 'resolution')).toBe('response,resolution');
+    expect(appendBreachTarget('response', 'response')).toBe('response');
+  });
+  it('does not confuse response with resolution substrings', () => {
+    expect(breachedTargets('resolution').has('response')).toBe(false);
+  });
+});
+
+describe('SLA_AT_RISK_RATIO', () => {
+  it('is 80% per spec §3', () => expect(SLA_AT_RISK_RATIO).toBe(0.8);
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd apps/api && npx vitest run src/services/ticketSla.test.ts --pool=forks --poolOptions.forks.singleFork=true
+```
+
+Expected: FAIL — module `./ticketSla` not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// apps/api/src/services/ticketSla.ts
+// Pure SLA math for native ticketing Phase 2. No DB access, no IO — keep it
+// trivially unit-testable. The SQL twins of these rules live in
+// jobs/ticketSlaWorker.ts (sweep) and routes/tickets/tickets.ts (filters);
+// change them together.
+
+export type TicketSlaPriority = 'low' | 'normal' | 'high' | 'urgent';
+export type SlaTargetKind = 'response' | 'resolution';
+
+/**
+ * Third link of the resolution chain (D5): only urgent/high carry built-in
+ * targets so partners without category SLAs aren't flooded with breaches.
+ */
+export const PRIORITY_SLA_DEFAULTS: Record<TicketSlaPriority, { responseMinutes: number | null; resolutionMinutes: number | null }> = {
+  urgent: { responseMinutes: 60, resolutionMinutes: 240 },
+  high: { responseMinutes: 240, resolutionMinutes: 1440 },
+  normal: { responseMinutes: null, resolutionMinutes: null },
+  low: { responseMinutes: null, resolutionMinutes: null }
+};
+
+/** At-risk begins at 80% of the target elapsed (spec §3). */
+export const SLA_AT_RISK_RATIO = 0.8;
+
+export interface ResolveSlaTargetsInput {
+  overrideResponseMinutes?: number | null;
+  overrideResolutionMinutes?: number | null;
+  categoryResponseMinutes?: number | null;
+  categoryResolutionMinutes?: number | null;
+  priority: TicketSlaPriority;
+}
+
+/** Spec §3 chain, per target: ticket override → category default → priority default. */
+export function resolveSlaTargets(input: ResolveSlaTargetsInput): { responseMinutes: number | null; resolutionMinutes: number | null } {
+  const defaults = PRIORITY_SLA_DEFAULTS[input.priority];
+  return {
+    responseMinutes: input.overrideResponseMinutes ?? input.categoryResponseMinutes ?? defaults.responseMinutes,
+    resolutionMinutes: input.overrideResolutionMinutes ?? input.categoryResolutionMinutes ?? defaults.resolutionMinutes
+  };
+}
+
+const SLA_TARGET_KINDS: ReadonlySet<string> = new Set(['response', 'resolution']);
+
+/** Parse the sla_breach_reason CSV (D3) into the set of already-breached targets. */
+export function breachedTargets(reason: string | null | undefined): Set<SlaTargetKind> {
+  const out = new Set<SlaTargetKind>();
+  for (const part of (reason ?? '').split(',')) {
+    const trimmed = part.trim();
+    if (SLA_TARGET_KINDS.has(trimmed)) out.add(trimmed as SlaTargetKind);
+  }
+  return out;
+}
+
+/** Append a target to the CSV, idempotently. Mirrors the SQL CASE in ticketSlaWorker. */
+export function appendBreachTarget(reason: string | null | undefined, target: SlaTargetKind): string {
+  const existing = breachedTargets(reason);
+  if (existing.has(target)) return reason ?? target;
+  return existing.size === 0 ? target : `${[...existing].join(',')},${target}`;
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS** (same command as Step 2).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/ticketSla.ts apps/api/src/services/ticketSla.test.ts
+git commit -m "feat(tickets): SLA target resolution + breach-reason helpers (phase 2)"
+```
+
+---
+
+## Task 2: Stamp SLA targets at create — **Claude**
+
+**Files:**
+- Modify: `apps/api/src/services/ticketService.ts` (`assertCategoryInPartner` :139-155, `createTicket` :178-264)
+- Test: `apps/api/src/services/ticketService.test.ts`
+
+- [ ] **Step 1: Write the failing tests** — add to the `createTicket` describe block in `ticketService.test.ts`, following the file's existing Drizzle-mock pattern (mock the category select to return SLA fields):
+
+```ts
+it('stamps SLA targets from the category when set', async () => {
+  // arrange mocks: org row; category row { id, partnerId, responseSlaMinutes: 30, resolutionSlaMinutes: 120 }
+  const ticket = await createTicket({ orgId, subject: 'x', categoryId, priority: 'urgent', source: 'manual' }, actor);
+  const inserted = capturedInsertValues(); // per the file's existing mock-capture helper
+  expect(inserted.responseSlaMinutes).toBe(30);
+  expect(inserted.resolutionSlaMinutes).toBe(120);
+});
+
+it('falls back to priority defaults when the category has no SLA', async () => {
+  // category row with null SLA fields, priority 'urgent'
+  expect(inserted.responseSlaMinutes).toBe(60);
+  expect(inserted.resolutionSlaMinutes).toBe(240);
+});
+
+it('stamps no SLA for normal priority without category targets', async () => {
+  // no categoryId, priority 'normal'
+  expect(inserted.responseSlaMinutes).toBeNull();
+  expect(inserted.resolutionSlaMinutes).toBeNull();
+});
+```
+
+(Adapt assertion plumbing to the file's existing mock-capture style — `ticketService.test.ts` already captures `insert().values()` args in its create tests.)
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd apps/api && npx vitest run src/services/ticketService.test.ts --pool=forks --poolOptions.forks.singleFork=true
+```
+
+Expected: new tests FAIL — `responseSlaMinutes` undefined on insert values.
+
+- [ ] **Step 3: Implement.** In `assertCategoryInPartner`, widen the select and return the row:
+
+```ts
+async function assertCategoryInPartner(categoryId: string, partnerId: string | null) {
+  const rows = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(() =>
+      db
+        .select({
+          id: ticketCategories.id,
+          partnerId: ticketCategories.partnerId,
+          responseSlaMinutes: ticketCategories.responseSlaMinutes,
+          resolutionSlaMinutes: ticketCategories.resolutionSlaMinutes
+        })
+        .from(ticketCategories)
+        .where(eq(ticketCategories.id, categoryId))
+        .limit(1)
+    )
+  );
+  const category = rows[0];
+  if (!category) throw new TicketServiceError('Category not found', 404, 'CATEGORY_NOT_FOUND');
+  throwIfPartnerUnresolvable(partnerId);
+  if (category.partnerId !== partnerId) {
+    throw new TicketServiceError('Category must belong to the same partner as the ticket', 400, 'CATEGORY_WRONG_PARTNER');
+  }
+  return category;
+}
+```
+
+In `createTicket`, capture the category and stamp targets (import `resolveSlaTargets` from `./ticketSla`):
+
+```ts
+let category: Awaited<ReturnType<typeof assertCategoryInPartner>> | null = null;
+if (input.categoryId) {
+  category = await assertCategoryInPartner(input.categoryId, org.partnerId);
+}
+
+const slaTargets = resolveSlaTargets({
+  categoryResponseMinutes: category?.responseSlaMinutes ?? null,
+  categoryResolutionMinutes: category?.resolutionSlaMinutes ?? null,
+  priority: input.priority ?? 'normal'
+});
+```
+
+and in `insertValues` add:
+
+```ts
+    responseSlaMinutes: slaTargets.responseMinutes,
+    resolutionSlaMinutes: slaTargets.resolutionMinutes,
+```
+
+(`updateTicketFields` callers that pass `categoryId` do NOT restamp — D2.)
+
+- [ ] **Step 4: Run tests — expect PASS** (same command; also re-run `aiToolsTicketing.test.ts` and `routes/portal/tickets.test.ts` since they exercise `createTicket`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/ticketService.ts apps/api/src/services/ticketService.test.ts
+git commit -m "feat(tickets): stamp effective SLA targets at ticket create (D2 chain)"
+```
+
+---
+
+## Task 3: SLA pause/resume on status change — **Claude**
+
+**Files:**
+- Modify: `apps/api/src/services/ticketService.ts` (`changeTicketStatus` :271-353)
+- Test: `apps/api/src/services/ticketService.test.ts`
+
+- [ ] **Step 1: Write the failing tests** (in the `changeTicketStatus` describe block; mock ticket rows carry `slaPausedAt`/`slaPausedMinutes`):
+
+```ts
+it('sets slaPausedAt when entering pending', async () => {
+  // ticket: status 'open', slaPausedAt null
+  // act: changeTicketStatus(id, 'pending', { pendingReason: 'waiting on customer' }, actor)
+  expect(capturedUpdateSet().slaPausedAt).toBeInstanceOf(Date);
+});
+
+it('folds paused time into slaPausedMinutes when leaving on_hold', async () => {
+  // ticket: status 'on_hold', slaPausedAt = 30 minutes ago, slaPausedMinutes = 10
+  // act: changeTicketStatus(id, 'open', {}, actor)
+  const set = capturedUpdateSet();
+  expect(set.slaPausedAt).toBeNull();
+  expect(set.slaPausedMinutes).toBe(40); // 10 accumulated + 30 elapsed
+});
+
+it('folds pause on resolve directly from pending', async () => {
+  // ticket: status 'pending', slaPausedAt = 5 minutes ago, slaPausedMinutes = 0
+  // act: changeTicketStatus(id, 'resolved', { resolutionNote: 'done' }, actor)
+  const set = capturedUpdateSet();
+  expect(set.slaPausedAt).toBeNull();
+  expect(set.slaPausedMinutes).toBe(5);
+});
+
+it('does not touch pause fields for open -> resolved', async () => {
+  const set = capturedUpdateSet();
+  expect('slaPausedAt' in set).toBe(false);
+  expect('slaPausedMinutes' in set).toBe(false);
+});
+```
+
+Use `vi.useFakeTimers()` / `vi.setSystemTime()` for deterministic elapsed-minute math (the file already imports vitest fake timers in other suites; if not, add it per `breeze-testing` conventions).
+
+- [ ] **Step 2: Run to verify failure** — same vitest command as Task 2. Expected: FAIL (pause fields never set).
+
+- [ ] **Step 3: Implement.** In `changeTicketStatus`, after the existing `patch` if/else chain (after line ~310, before the CAS update):
+
+```ts
+  // SLA clock pause/resume (spec §3, decision D4): the clock pauses while the
+  // ticket sits in pending/on_hold. Fold elapsed pause time on ANY exit —
+  // including resolve/close — so reopen resumes from a consistent ledger.
+  const wasPaused = fromStatus === 'pending' || fromStatus === 'on_hold';
+  const willBePaused = toStatus === 'pending' || toStatus === 'on_hold';
+  if (!wasPaused && willBePaused) {
+    patch.slaPausedAt = now;
+  } else if (wasPaused && !willBePaused) {
+    if (ticket.slaPausedAt) {
+      const elapsedMinutes = Math.max(0, Math.round((now.getTime() - new Date(ticket.slaPausedAt).getTime()) / 60_000));
+      patch.slaPausedMinutes = (ticket.slaPausedMinutes ?? 0) + elapsedMinutes;
+    }
+    patch.slaPausedAt = null;
+  }
+```
+
+(`pending → on_hold` hits neither branch — clock stays paused with the original `slaPausedAt`, which is correct.)
+
+- [ ] **Step 4: Run tests — expect PASS.** Also re-run `routes/tickets/tickets.test.ts` and `routes/tickets/bulk.test.ts` (status routes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/ticketService.ts apps/api/src/services/ticketService.test.ts
+git commit -m "feat(tickets): pause/resume SLA clock on pending/on_hold transitions (D4)"
+```
+
+---
+
+## Task 4: `ticket.sla_breached` event variant — **Codex (low)**
+
+**Files:**
+- Modify: `apps/api/src/services/ticketEvents.ts` (:19-25)
+- Test: `apps/api/src/services/ticketEvents.test.ts` (and `ticketEventsContract.test.ts` if it enumerates event types)
+
+- [ ] **Step 1: Write the failing test** — extend the existing emit test pattern:
+
+```ts
+it('enqueues ticket.sla_breached with target payload', async () => {
+  await emitTicketEvent({
+    type: 'ticket.sla_breached',
+    ticketId: 't1', orgId: 'o1', partnerId: 'p1', actorUserId: null,
+    payload: { target: 'response', internalNumber: 'T-2026-0001', subject: 'Printer on fire', assigneeId: 'u1' }
+  });
+  expect(mockQueueAdd).toHaveBeenCalledWith('ticket.sla_breached', expect.objectContaining({ type: 'ticket.sla_breached' }), expect.anything());
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (type error / union rejects the variant):
+
+```bash
+cd apps/api && npx vitest run src/services/ticketEvents.test.ts src/services/ticketEventsContract.test.ts --pool=forks --poolOptions.forks.singleFork=true
+```
+
+- [ ] **Step 3: Implement** — add to the `TicketEvent` union after `ticket.updated`:
+
+```ts
+  | { type: 'ticket.sla_breached'; payload: { target: 'response' | 'resolution'; internalNumber: string | null; subject: string; assigneeId: string | null } }
+```
+
+If `ticketEventsContract.test.ts` asserts the closed set of event types, add `'ticket.sla_breached'` there too.
+
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/ticketEvents.ts apps/api/src/services/ticketEvents.test.ts apps/api/src/services/ticketEventsContract.test.ts
+git commit -m "feat(tickets): add ticket.sla_breached lifecycle event"
+```
+
+---
+
+## Task 5: SLA monitor worker — **Claude**
+
+**Files:**
+- Create: `apps/api/src/jobs/ticketSlaWorker.ts`
+- Create: `apps/api/src/jobs/ticketSlaWorker.test.ts`
+- Modify: `apps/api/src/index.ts` (worker init/shutdown registration, beside `ticketNotifyWorker` ~:1053)
+
+- [ ] **Step 1: Write the failing tests** — mirror `approvalExpiryReaper`'s test structure (mock `bullmq`, mock `../db` with a captured `db.execute`, mock `ticketEvents`):
+
+```ts
+// apps/api/src/jobs/ticketSlaWorker.test.ts — key cases:
+it('stamps response and resolution breaches and returns rows tagged by target', async () => {
+  // db.execute resolves [{ id, org_id, partner_id, internal_number, subject, assigned_to }] for response, [] for resolution
+  const rows = await sweepTicketSlaBreaches();
+  expect(rows).toHaveLength(1);
+  expect(rows[0].target).toBe('response');
+});
+
+it('emits ticket.sla_breached per stamped row, outside the system DB context', async () => {
+  // run the worker handler; assert emitTicketEvent called with matching payload
+  // and that withSystemDbAccessContext mock resolved BEFORE the first emit call
+});
+
+it('sweep SQL excludes paused, already-breached-target, and non-active tickets', () => {
+  // snapshot/regex the generated SQL: must contain status IN ('new','open'),
+  // sla_paused_at IS NULL, string_to_array guard, FOR UPDATE SKIP LOCKED
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (module not found):
+
+```bash
+cd apps/api && npx vitest run src/jobs/ticketSlaWorker.test.ts --pool=forks --poolOptions.forks.singleFork=true
+```
+
+- [ ] **Step 3: Implement**
+
+```ts
+// apps/api/src/jobs/ticketSlaWorker.ts
+import { Job, Queue, Worker } from 'bullmq';
+import { sql } from 'drizzle-orm';
+import * as dbModule from '../db';
+import { db } from '../db';
+import { getBullMQConnection } from '../services/redis';
+import { captureException } from '../services/sentry';
+import { emitTicketEvent } from '../services/ticketEvents';
+import { getEventBus } from '../services/eventBus';
+
+/**
+ * Ticket SLA monitor (spec §3, Phase 2): every 60s, stamp sla_breached_at /
+ * sla_breach_reason on active tickets whose response or resolution deadline
+ * has passed, then emit ticket.sla_breached per stamped target.
+ *
+ * Targets are one-shot (D3): sla_breach_reason is a CSV of breached targets and
+ * the sweep's WHERE excludes targets already present. Deadlines are wall-clock
+ * (D1): created_at + (target_minutes + sla_paused_minutes). Paused tickets
+ * (sla_paused_at set / status pending|on_hold) are skipped entirely.
+ *
+ * DB work runs inside withSystemDbAccessContext (one short transaction);
+ * event emission happens AFTER the context exits (#1105 pool-poison rule).
+ */
+
+const QUEUE_NAME = 'ticket-sla-monitor';
+const SWEEP_INTERVAL_MS = 60 * 1000;
+const MAX_BREACHES_PER_RUN = 200; // per target per sweep
+
+type SlaSweepJobData = { type: 'sla-sweep'; queuedAt: string };
+
+export type BreachedTicketRow = {
+  id: string;
+  org_id: string;
+  partner_id: string | null;
+  internal_number: string | null;
+  subject: string;
+  assigned_to: string | null;
+};
+
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const withSystem = dbModule.withSystemDbAccessContext;
+  if (typeof withSystem !== 'function') {
+    throw new Error('[TicketSlaWorker] withSystemDbAccessContext not available');
+  }
+  return withSystem(fn);
+};
+
+let slaQueue: Queue<SlaSweepJobData> | null = null;
+let slaWorker: Worker<SlaSweepJobData> | null = null;
+
+function getQueue(): Queue<SlaSweepJobData> {
+  if (!slaQueue) {
+    slaQueue = new Queue<SlaSweepJobData>(QUEUE_NAME, { connection: getBullMQConnection() });
+  }
+  return slaQueue;
+}
+
+function extractRows<T>(result: unknown): T[] {
+  const maybe = result as { rows?: T[] };
+  return maybe.rows ?? (result as T[]);
+}
+
+async function stampBreaches(target: 'response' | 'resolution'): Promise<BreachedTicketRow[]> {
+  const targetColumn = target === 'response' ? sql.raw('response_sla_minutes') : sql.raw('resolution_sla_minutes');
+  const unmetCondition = target === 'response'
+    ? sql.raw('first_response_at IS NULL')
+    : sql.raw('resolved_at IS NULL');
+
+  const result = await db.execute<BreachedTicketRow>(sql`
+    WITH due AS (
+      SELECT id
+      FROM tickets
+      WHERE status IN ('new', 'open')
+        AND sla_paused_at IS NULL
+        AND ${unmetCondition}
+        AND ${targetColumn} IS NOT NULL
+        AND NOT (${sql.raw(`'${target}'`)} = ANY(string_to_array(COALESCE(sla_breach_reason, ''), ',')))
+        AND now() >= created_at
+          + (${targetColumn} + COALESCE(sla_paused_minutes, 0)) * interval '1 minute'
+      ORDER BY created_at ASC
+      LIMIT ${MAX_BREACHES_PER_RUN}
+      FOR UPDATE SKIP LOCKED
+    )
+    UPDATE tickets t
+    SET sla_breached_at = COALESCE(t.sla_breached_at, now()),
+        sla_breach_reason = CASE
+          WHEN COALESCE(t.sla_breach_reason, '') = '' THEN ${target}
+          ELSE t.sla_breach_reason || ',' || ${target}
+        END,
+        updated_at = now()
+    FROM due
+    WHERE t.id = due.id
+    RETURNING t.id, t.org_id, t.partner_id, t.internal_number, t.subject, t.assigned_to;
+  `);
+  return extractRows<BreachedTicketRow>(result);
+}
+
+export async function sweepTicketSlaBreaches(): Promise<Array<BreachedTicketRow & { target: 'response' | 'resolution' }>> {
+  const response = await stampBreaches('response');
+  const resolution = await stampBreaches('resolution');
+  if (response.length === MAX_BREACHES_PER_RUN || resolution.length === MAX_BREACHES_PER_RUN) {
+    console.warn(`[TicketSlaWorker] Hit ${MAX_BREACHES_PER_RUN}-row cap — breach backlog may be growing`);
+  }
+  return [
+    ...response.map((r) => ({ ...r, target: 'response' as const })),
+    ...resolution.map((r) => ({ ...r, target: 'resolution' as const }))
+  ];
+}
+
+async function notifyBreaches(rows: Array<BreachedTicketRow & { target: 'response' | 'resolution' }>): Promise<void> {
+  for (const row of rows) {
+    await emitTicketEvent({
+      type: 'ticket.sla_breached',
+      ticketId: row.id,
+      orgId: row.org_id,
+      partnerId: row.partner_id,
+      actorUserId: null,
+      payload: { target: row.target, internalNumber: row.internal_number, subject: row.subject, assigneeId: row.assigned_to }
+    });
+    try {
+      // Routing-rule hook, mirroring backupSlaWorker's breach publish.
+      // VERIFY the publish() signature against backupSlaWorker.ts before relying on it.
+      getEventBus().publish('ticket.sla_breached', row.org_id, {
+        ticketId: row.id,
+        internalNumber: row.internal_number,
+        subject: row.subject,
+        target: row.target,
+        assigneeId: row.assigned_to
+      }, 'ticket-sla-monitor');
+    } catch (err) {
+      console.error('[TicketSlaWorker] eventBus publish failed:', err instanceof Error ? err.message : err);
+    }
+  }
+}
+
+function createWorker(): Worker<SlaSweepJobData> {
+  return new Worker<SlaSweepJobData>(
+    QUEUE_NAME,
+    async (_job: Job<SlaSweepJobData>) => {
+      try {
+        // DB stamping inside the system context; notifications after it exits.
+        const rows = await runWithSystemDbAccess(sweepTicketSlaBreaches);
+        if (rows.length > 0) {
+          console.log(`[TicketSlaWorker] Stamped ${rows.length} SLA breach(es)`);
+          await notifyBreaches(rows);
+        }
+        return { breached: rows.length };
+      } catch (err) {
+        console.error('[TicketSlaWorker] Sweep failed:', err);
+        captureException(err instanceof Error ? err : new Error(String(err)));
+        throw err;
+      }
+    },
+    { connection: getBullMQConnection(), concurrency: 1 }
+  );
+}
+
+async function scheduleRepeatableJob(): Promise<void> {
+  const queue = getQueue();
+  const repeatables = await queue.getRepeatableJobs();
+  for (const job of repeatables) {
+    if (job.name === 'sla-sweep') {
+      await queue.removeRepeatableByKey(job.key);
+    }
+  }
+  await queue.add(
+    'sla-sweep',
+    { type: 'sla-sweep', queuedAt: new Date().toISOString() },
+    {
+      // jobId rule: '-' separators, 0 colons (BullMQ repeat-key parsing, #1118)
+      jobId: 'ticket-sla-monitor-sweep',
+      repeat: { every: SWEEP_INTERVAL_MS },
+      removeOnComplete: { count: 20 },
+      removeOnFail: { count: 200 }
+    }
+  );
+}
+
+export async function initializeTicketSlaWorker(): Promise<void> {
+  if (slaWorker) return;
+  slaWorker = createWorker();
+  slaWorker.on('error', (error) => {
+    console.error('[TicketSlaWorker] Worker error:', error);
+    captureException(error);
+  });
+  slaWorker.on('failed', (job, error) => {
+    console.error(`[TicketSlaWorker] Job ${job?.id} failed:`, error);
+    captureException(error);
+  });
+  try {
+    await scheduleRepeatableJob();
+  } catch (err) {
+    await slaWorker.close();
+    slaWorker = null;
+    throw err;
+  }
+  console.log('[TicketSlaWorker] Initialized');
+}
+
+export async function shutdownTicketSlaWorker(): Promise<void> {
+  const worker = slaWorker;
+  const queue = slaQueue;
+  slaWorker = null;
+  slaQueue = null;
+  if (worker) {
+    try { await worker.close(); } catch (err) { console.error('[TicketSlaWorker] Error closing worker:', err); }
+  }
+  if (queue) {
+    try { await queue.close(); } catch (err) { console.error('[TicketSlaWorker] Error closing queue:', err); }
+  }
+}
+```
+
+Register in `apps/api/src/index.ts`: import `initializeTicketSlaWorker`/`shutdownTicketSlaWorker` and add them immediately after the `ticketNotifyWorker` entries (init ~:1053 and the corresponding shutdown block — follow exactly how `ticketNotifyWorker` is wired).
+
+- [ ] **Step 4: Run — expect PASS.** Also boot the dev stack briefly and confirm `[TicketSlaWorker] Initialized` in API logs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/jobs/ticketSlaWorker.ts apps/api/src/jobs/ticketSlaWorker.test.ts apps/api/src/index.ts
+git commit -m "feat(tickets): SLA breach monitor worker (60s sweep, one-shot per target)"
+```
+
+---
+
+## Task 6: Breach notifications in `ticketNotifyWorker` — **Codex (high)**
+
+**Files:**
+- Modify: `apps/api/src/jobs/ticketNotifyWorker.ts`
+- Test: `apps/api/src/jobs/ticketNotifyWorker.test.ts`
+
+- [ ] **Step 1: Write the failing tests** (follow the file's existing per-event-type test pattern):
+
+```ts
+it('ticket.sla_breached notifies the assignee in-app and by email', async () => {
+  // ticket row with assignedTo = 'u1'; user row with email
+  // expect userNotifications insert: type/category per the file's existing convention,
+  //   title like 'SLA breached: T-2026-0001', body naming the target ('response')
+  // expect EmailService.sendEmail called once to the assignee's address
+});
+
+it('ticket.sla_breached with no assignee creates no notification and no email', async () => {});
+
+it('ticket.sla_breached throws when the ticket row is missing (retryable, pre-commit contract)', async () => {});
+```
+
+- [ ] **Step 2: Run — expect FAIL:**
+
+```bash
+cd apps/api && npx vitest run src/jobs/ticketNotifyWorker.test.ts --pool=forks --poolOptions.forks.singleFork=true
+```
+
+- [ ] **Step 3: Implement.** Add a `ticket.sla_breached` case to `handleTicketEvent`'s switch, copying the structure of the existing `ticket.assigned` case exactly:
+  - All DB reads + `userNotifications` insert INSIDE `runWithSystemDbAccess`; email payloads accumulated and sent AFTER the context exits (the file's existing #1105 pattern — do not deviate).
+  - Missing ticket → throw (retryable). Missing/null assignee → return without action (terminal, like the existing missing-assignee handling).
+  - Email subject: `` `SLA breached: ${internalNumber ?? ticketId} — ${subject}` ``; body states which target (`response` or `resolution`) breached, using `escapeHtml` from `services/emailLayout` like the file's other emails.
+  - Do NOT email the requester/`submitterEmail` — breach notifications are internal only (spec §7: portal stays unchanged).
+
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/jobs/ticketNotifyWorker.ts apps/api/src/jobs/ticketNotifyWorker.test.ts
+git commit -m "feat(tickets): in-app + email breach notifications to assignee"
+```
+
+---
+
+## Task 7: SLA override via PATCH + validator — **Codex (medium)**
+
+**Files:**
+- Modify: `packages/shared/src/validators/tickets.ts` (`updateTicketSchema` :20-28)
+- Modify: `apps/api/src/services/ticketService.ts` (`UpdateTicketFieldsInput` :355-363, `updateTicketFields` ~:388-470, `UPDATE_FIELD_LABELS` :366)
+- Test: `packages/shared/src/validators/tickets.test.ts`, `apps/api/src/services/ticketService.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// packages/shared/src/validators/tickets.test.ts
+it('updateTicketSchema accepts SLA override minutes', () => {
+  expect(updateTicketSchema.parse({ responseSlaMinutes: 30, resolutionSlaMinutes: 120 }))
+    .toEqual({ responseSlaMinutes: 30, resolutionSlaMinutes: 120 });
+  expect(updateTicketSchema.parse({ responseSlaMinutes: null }).responseSlaMinutes).toBeNull();
+});
+it('updateTicketSchema rejects non-positive SLA minutes', () => {
+  expect(() => updateTicketSchema.parse({ responseSlaMinutes: 0 })).toThrow();
+  expect(() => updateTicketSchema.parse({ resolutionSlaMinutes: -5 })).toThrow();
+});
+
+// apps/api/src/services/ticketService.test.ts
+it('updateTicketFields persists SLA overrides and labels them in the feed comment', async () => {
+  // act: updateTicketFields(id, { responseSlaMinutes: 15 }, actor)
+  // assert update .set() contains responseSlaMinutes: 15
+  // assert system comment content mentions 'response SLA'
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL:**
+
+```bash
+cd packages/shared && npx vitest run src/validators/tickets.test.ts
+cd ../../apps/api && npx vitest run src/services/ticketService.test.ts --pool=forks --poolOptions.forks.singleFork=true
+```
+
+- [ ] **Step 3: Implement.**
+  - Validator — add to `updateTicketSchema`:
+
+```ts
+  responseSlaMinutes: z.number().int().positive().nullable().optional(),
+  resolutionSlaMinutes: z.number().int().positive().nullable().optional()
+```
+
+  - Service — add both fields to `UpdateTicketFieldsInput`, to the field-patch handling in `updateTicketFields` (same null-vs-undefined semantics as `dueDate`), and to `UPDATE_FIELD_LABELS`:
+
+```ts
+  responseSlaMinutes: 'response SLA',
+  resolutionSlaMinutes: 'resolution SLA'
+```
+
+  The PATCH route already passes the validated body through to `updateTicketFields` — verify no route change is needed (`apps/api/src/routes/tickets/tickets.ts:390`).
+
+- [ ] **Step 4: Run — expect PASS** (both suites, plus `routes/tickets/tickets.test.ts`).
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/validators/tickets.ts packages/shared/src/validators/tickets.test.ts apps/api/src/services/ticketService.ts apps/api/src/services/ticketService.test.ts
+git commit -m "feat(tickets): per-ticket SLA override via PATCH (chain link 1)"
+```
+
+---
+
+## Task 8: Queue filter, triage sort, stats — **Codex (high)**
+
+**Files:**
+- Modify: `packages/shared/src/validators/tickets.ts` (`listTicketsQuerySchema` :66-78)
+- Modify: `apps/api/src/routes/tickets/tickets.ts` (stats :158-202, list :205-297)
+- Test: `packages/shared/src/validators/tickets.test.ts`, `apps/api/src/routes/tickets/tickets.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// validators: slaState enum
+it('listTicketsQuerySchema accepts slaState values', () => {
+  for (const v of ['ok', 'at_risk', 'breached', 'breaching']) {
+    expect(listTicketsQuerySchema.parse({ slaState: v }).slaState).toBe(v);
+  }
+  expect(() => listTicketsQuerySchema.parse({ slaState: 'nope' })).toThrow();
+});
+
+// routes (existing Drizzle-mock style): assert the WHERE/ORDER SQL produced
+it('GET /tickets?slaState=breached filters on sla_breached_at IS NOT NULL', async () => {});
+it('GET /tickets?slaState=breaching ORs breached with the at-risk expression', async () => {});
+it('triage sort orders breached first, then at-risk, then priority', async () => {});
+it('GET /tickets projects responseSlaMinutes, slaPausedAt, slaPausedMinutes, slaBreachReason', async () => {});
+it('GET /tickets/stats returns atRisk alongside breached', async () => {});
+```
+
+- [ ] **Step 2: Run — expect FAIL:**
+
+```bash
+cd apps/api && npx vitest run src/routes/tickets/tickets.test.ts --pool=forks --poolOptions.forks.singleFork=true
+```
+
+- [ ] **Step 3: Implement.**
+  - Validator — add to `listTicketsQuerySchema`:
+
+```ts
+  slaState: z.enum(['ok', 'at_risk', 'breached', 'breaching']).optional(),
+```
+
+  - Routes — near the other module-level helpers in `tickets.ts`, define the SQL twins of `ticketSla.ts` (keep this comment):
+
+```ts
+// SQL twins of services/ticketSla.ts rules — change them together.
+// Active elapsed = now - created_at - paused; at-risk at 80% of the tighter target (D7).
+const SLA_BREACHED = sql`${tickets.slaBreachedAt} IS NOT NULL`;
+const SLA_AT_RISK = sql`(
+  ${tickets.slaBreachedAt} IS NULL
+  AND ${tickets.status} IN ('new', 'open')
+  AND ${tickets.slaPausedAt} IS NULL
+  AND (
+    (${tickets.firstResponseAt} IS NULL AND ${tickets.responseSlaMinutes} IS NOT NULL
+      AND now() >= ${tickets.createdAt}
+        + COALESCE(${tickets.slaPausedMinutes}, 0) * interval '1 minute'
+        + ${tickets.responseSlaMinutes} * interval '1 minute' * 0.8)
+    OR (${tickets.resolutionSlaMinutes} IS NOT NULL
+      AND now() >= ${tickets.createdAt}
+        + COALESCE(${tickets.slaPausedMinutes}, 0) * interval '1 minute'
+        + ${tickets.resolutionSlaMinutes} * interval '1 minute' * 0.8)
+  )
+)`;
+```
+
+  In the list handler, after the priority filter:
+
+```ts
+    if (q.slaState === 'breached') conditions.push(SLA_BREACHED);
+    else if (q.slaState === 'at_risk') conditions.push(SLA_AT_RISK);
+    else if (q.slaState === 'breaching') conditions.push(sql`(${SLA_BREACHED} OR ${SLA_AT_RISK})`);
+    else if (q.slaState === 'ok') conditions.push(sql`(NOT ${SLA_BREACHED} AND NOT ${SLA_AT_RISK})`);
+```
+
+  Triage sort (replace the existing triage branch only):
+
+```ts
+      : [desc(SLA_BREACHED), desc(SLA_AT_RISK), PRIORITY_ORDER, asc(tickets.createdAt), asc(tickets.id)]; // triage: breaches surface first
+```
+
+  (If `desc()` rejects raw SQL conditions in this Drizzle version, use `` sql`${SLA_BREACHED} DESC` `` / `` sql`${SLA_AT_RISK} DESC` ``.)
+
+  Projection — add to the list `select({...})`:
+
+```ts
+        responseSlaMinutes: tickets.responseSlaMinutes,
+        slaPausedAt: tickets.slaPausedAt,
+        slaPausedMinutes: tickets.slaPausedMinutes,
+        slaBreachReason: tickets.slaBreachReason,
+```
+
+  Stats — after the existing grouped query, add one aggregate and include `atRisk` in the response:
+
+```ts
+    const slaRows = await db
+      .select({ atRisk: sql<number>`count(*) FILTER (WHERE ${SLA_AT_RISK})` })
+      .from(tickets)
+      .where(whereCondition);
+    const atRisk = Number(slaRows[0]?.atRisk ?? 0);
+    return c.json({ data: { open, unassigned, mine, breached, atRisk } });
+```
+
+- [ ] **Step 4: Run — expect PASS** (routes + validators suites).
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/validators/tickets.ts packages/shared/src/validators/tickets.test.ts apps/api/src/routes/tickets/tickets.ts apps/api/src/routes/tickets/tickets.test.ts
+git commit -m "feat(tickets): SLA-state queue filter, SLA-aware triage sort, at-risk stat"
+```
+
+---
+
+## Task 9: SLA index migration — **Codex (low)**
+
+**Files:**
+- Create: `apps/api/migrations/2026-06-12-a-ticket-sla-indexes.sql` (re-date to the execution date; keep the `-a-` infix only if another ticket migration lands the same day)
+
+- [ ] **Step 1: Write the migration** (idempotent; no inner BEGIN/COMMIT; partial indexes sized to the two hot access paths — the sweep and the breached/at-risk filters):
+
+```sql
+-- Phase 2 SLA engine (spec §8a): index-backed sweep + queue SLA filters.
+-- Sweep scans active, unpaused tickets ordered by created_at.
+CREATE INDEX IF NOT EXISTS tickets_sla_sweep_idx
+  ON tickets (created_at)
+  WHERE status IN ('new', 'open') AND sla_paused_at IS NULL;
+
+-- Breached-queue filter + stats count.
+CREATE INDEX IF NOT EXISTS tickets_sla_breached_idx
+  ON tickets (partner_id, status)
+  WHERE sla_breached_at IS NOT NULL;
+```
+
+- [ ] **Step 2: Apply locally and verify idempotency**
+
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+# restart the API (autoMigrate applies it), or apply manually twice — second run must be a no-op
+docker exec -i breeze-postgres psql -U breeze -d breeze -c "\di tickets_sla*"
+```
+
+Expected: both indexes listed; re-apply produces no errors.
+
+- [ ] **Step 3: Drift check**
+
+```bash
+pnpm db:check-drift
+```
+
+If drift is flagged for the new indexes, add the matching extras block to the `tickets` pgTable in `apps/api/src/db/schema/portal.ts` (note: the Phase-1 ticket indexes exist in SQL without schema extras, so no drift is the likely outcome — match whatever the check demands).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/migrations/2026-06-12-a-ticket-sla-indexes.sql
+git commit -m "feat(tickets): partial indexes for SLA sweep and breached-queue filters"
+```
+
+---
+
+## Task 10: Web — pause-aware `slaState()` + paused chip — **Claude (in-session)**
+
+**Files:**
+- Modify: `apps/web/src/components/tickets/ticketConfig.ts` (`TicketSummary` :5-25, `slaState` :77-98)
+- Modify: `apps/web/src/components/tickets/SlaChip.tsx`
+- Test: `apps/web/src/components/tickets/ticketConfig.test.ts` (or the file's existing test name), `SlaChip.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+const base = { status: 'open' as const, slaBreachedAt: null, createdAt: new Date(Date.now() - 60 * 60_000).toISOString(), firstResponseAt: null };
+
+it('uses the response target when first response is outstanding', () => {
+  // 60m elapsed, response target 90m (66% — ok), resolution 480m
+  const s = slaState({ ...base, responseSlaMinutes: 90, resolutionSlaMinutes: 480 });
+  expect(s.kind).toBe('ok');
+  // 60m elapsed, response target 70m (86% — at-risk)
+  expect(slaState({ ...base, responseSlaMinutes: 70, resolutionSlaMinutes: 480 }).kind).toBe('at-risk');
+});
+
+it('ignores the response target once firstResponseAt is set', () => {
+  const s = slaState({ ...base, firstResponseAt: new Date().toISOString(), responseSlaMinutes: 10, resolutionSlaMinutes: 480 });
+  expect(s.kind).toBe('ok');
+});
+
+it('freezes the clock while paused and reports paused', () => {
+  const s = slaState({ ...base, slaPausedAt: new Date().toISOString(), resolutionSlaMinutes: 90, slaPausedMinutes: 0 });
+  expect(s.kind).toBe('paused');
+});
+
+it('subtracts accumulated pause minutes', () => {
+  // 60m wall elapsed, 30m paused → 30m active; target 90m → ok with 60m left
+  const s = slaState({ ...base, resolutionSlaMinutes: 90, slaPausedMinutes: 30 });
+  expect(s.kind).toBe('ok');
+  if (s.kind === 'ok') expect(Math.round(s.minutesLeft)).toBe(60);
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL:**
+
+```bash
+cd apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/components/tickets/ticketConfig.test.ts src/components/tickets/SlaChip.test.tsx
+```
+
+- [ ] **Step 3: Implement.**
+  - `TicketSummary`: add `responseSlaMinutes?: number | null; slaPausedAt?: string | null; slaPausedMinutes?: number | null; slaBreachReason?: string | null;` (the list endpoint now projects them — Task 8).
+  - `SlaState`: add `| { kind: 'paused'; minutesLeft: number }`.
+  - Rewrite `slaState`:
+
+```ts
+// Client twin of the server SLA rules (services/ticketSla.ts) — change together.
+export function slaState(
+  t: Pick<TicketSummary, 'slaBreachedAt' | 'createdAt' | 'status' | 'firstResponseAt'> &
+     { resolutionSlaMinutes?: number | null; responseSlaMinutes?: number | null; slaPausedAt?: string | null; slaPausedMinutes?: number | null },
+  now: Date = new Date()
+): SlaState {
+  if (t.status === 'resolved' || t.status === 'closed') return { kind: 'none' };
+  if (t.slaBreachedAt) {
+    return { kind: 'breached', minutesAgo: (now.getTime() - new Date(t.slaBreachedAt).getTime()) / 60_000 };
+  }
+  const targets: number[] = [];
+  if (t.responseSlaMinutes && !t.firstResponseAt) targets.push(t.responseSlaMinutes);
+  if (t.resolutionSlaMinutes) targets.push(t.resolutionSlaMinutes);
+  if (targets.length === 0) return { kind: 'none' };
+
+  // Both targets share the createdAt clock, so the smallest target is the most urgent.
+  const target = Math.min(...targets);
+  const clockEnd = t.slaPausedAt ? new Date(t.slaPausedAt) : now; // frozen while paused
+  const activeElapsed = (clockEnd.getTime() - new Date(t.createdAt).getTime()) / 60_000 - (t.slaPausedMinutes ?? 0);
+  const left = target - activeElapsed;
+  if (t.slaPausedAt) return { kind: 'paused', minutesLeft: Math.max(0, left) };
+  if (left <= 0) return { kind: 'breached', minutesAgo: -left };
+  if (activeElapsed >= 0.8 * target) return { kind: 'at-risk', minutesLeft: left };
+  return { kind: 'ok', minutesLeft: left };
+}
+```
+
+  - `SlaChip.tsx`: add a `paused` case rendering a muted chip (`Paused · {formatRelative(minutesLeft)} left`), consistent with the existing per-state styling; keep `data-testid` conventions.
+
+- [ ] **Step 4: Run — expect PASS.** Also run `TicketsPage.test.tsx` / `TicketQueueList.test.tsx` (they consume `slaState`).
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/tickets/ticketConfig.ts apps/web/src/components/tickets/SlaChip.tsx apps/web/src/components/tickets/*.test.ts*
+git commit -m "feat(tickets/web): pause- and response-aware SLA state with paused chip"
+```
+
+---
+
+## Task 11: Web — server-driven breaching tab + countdown — **Claude (in-session)**
+
+**Files:**
+- Modify: `apps/web/src/components/tickets/TicketsPage.tsx` (`tabQuery` :41-48, client breaching filter :191-193, stats badges)
+- Test: `apps/web/src/components/tickets/TicketsPage.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+it('breaching tab requests slaState=breaching from the API', async () => {
+  // select the breaching tab; assert the fetched URL contains 'slaState=breaching'
+  // and does NOT client-filter the returned rows
+});
+it('breaching tab badge shows breached + atRisk from /tickets/stats', async () => {});
+```
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+- [ ] **Step 3: Implement.**
+  - In `tabQuery`, make the `breaching` tab contribute `{ statusGroup: 'open', slaState: 'breaching' }` to the request params and delete the client-side `slaState()` filter at :191-193 (rows now arrive pre-filtered; keep `slaState()` for chip rendering only).
+  - Badge: the breaching tab count = `stats.breached + stats.atRisk` from the extended `/tickets/stats` payload (Task 8).
+  - The queue's SLA column already renders `SlaChip`; confirm it passes the full ticket row (new fields flow through from the API projection) — adjust the row mapping if it cherry-picks fields.
+
+- [ ] **Step 4: Run — expect PASS:**
+
+```bash
+cd apps/web && npx vitest run src/components/tickets/TicketsPage.test.tsx
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/tickets/TicketsPage.tsx apps/web/src/components/tickets/TicketsPage.test.tsx
+git commit -m "feat(tickets/web): server-driven breaching tab with at-risk-aware badge"
+```
+
+---
+
+## Task 12: Web — SLA timers rail — **Claude (in-session)**
+
+**Files:**
+- Create: `apps/web/src/components/tickets/SlaTimers.tsx`
+- Create: `apps/web/src/components/tickets/SlaTimers.test.tsx`
+- Modify: `apps/web/src/components/tickets/TicketWorkbench.tsx` (right rail)
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+it('renders both timers with countdowns', () => {
+  render(<SlaTimers ticket={mkTicket({ responseSlaMinutes: 60, resolutionSlaMinutes: 240 })} />);
+  expect(screen.getByTestId('sla-timer-response')).toHaveTextContent(/left/);
+  expect(screen.getByTestId('sla-timer-resolution')).toHaveTextContent(/left/);
+});
+it('shows response as met once firstResponseAt is set', () => {
+  // expect sla-timer-response to contain 'Met'
+});
+it('shows breached targets from slaBreachReason', () => {
+  // slaBreachReason 'response' → response timer shows 'Breached'
+});
+it('shows a paused note while slaPausedAt is set', () => {
+  expect(screen.getByTestId('sla-timers-paused')).toBeInTheDocument();
+});
+it('renders nothing when the ticket has no SLA targets', () => {
+  expect(screen.queryByTestId('sla-timers')).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (module not found).
+
+- [ ] **Step 3: Implement**
+
+```tsx
+// apps/web/src/components/tickets/SlaTimers.tsx
+import type { TicketDetail } from './ticketConfig';
+import { formatRelative } from './ticketConfig';
+
+type TimerState =
+  | { kind: 'met'; at: string }
+  | { kind: 'breached' }
+  | { kind: 'counting'; minutesLeft: number }
+  | { kind: 'paused'; minutesLeft: number };
+
+function timerState(
+  target: number,
+  metAt: string | null,
+  breached: boolean,
+  createdAt: string,
+  slaPausedAt: string | null | undefined,
+  slaPausedMinutes: number | null | undefined,
+  now: Date
+): TimerState {
+  if (metAt) return { kind: 'met', at: metAt };
+  if (breached) return { kind: 'breached' };
+  const clockEnd = slaPausedAt ? new Date(slaPausedAt) : now;
+  const activeElapsed = (clockEnd.getTime() - new Date(createdAt).getTime()) / 60_000 - (slaPausedMinutes ?? 0);
+  const minutesLeft = Math.max(0, target - activeElapsed);
+  return slaPausedAt ? { kind: 'paused', minutesLeft } : { kind: 'counting', minutesLeft };
+}
+
+function TimerRow({ label, state, testId }: { label: string; state: TimerState; testId: string }) {
+  const text =
+    state.kind === 'met' ? 'Met'
+    : state.kind === 'breached' ? 'Breached'
+    : state.kind === 'paused' ? `Paused · ${formatRelative(state.minutesLeft)} left`
+    : `${formatRelative(state.minutesLeft)} left`;
+  const tone =
+    state.kind === 'breached' ? 'text-red-700 dark:text-red-400'
+    : state.kind === 'met' ? 'text-success'
+    : 'text-muted-foreground';
+  return (
+    <div className="flex items-center justify-between text-sm" data-testid={testId}>
+      <span className="text-muted-foreground">{label}</span>
+      <span className={tone}>{text}</span>
+    </div>
+  );
+}
+
+export function SlaTimers({ ticket, now = new Date() }: { ticket: TicketDetail; now?: Date }) {
+  const breached = new Set((ticket.slaBreachReason ?? '').split(',').map((s) => s.trim()));
+  const hasResponse = !!ticket.responseSlaMinutes;
+  const hasResolution = !!ticket.resolutionSlaMinutes;
+  if (!hasResponse && !hasResolution) return null;
+  const terminal = ticket.status === 'resolved' || ticket.status === 'closed';
+  return (
+    <div className="space-y-2" data-testid="sla-timers">
+      <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">SLA</h3>
+      {hasResponse && (
+        <TimerRow label="First response" testId="sla-timer-response"
+          state={timerState(ticket.responseSlaMinutes!, ticket.firstResponseAt, breached.has('response'),
+            ticket.createdAt, ticket.slaPausedAt, ticket.slaPausedMinutes, now)} />
+      )}
+      {hasResolution && (
+        <TimerRow label="Resolution" testId="sla-timer-resolution"
+          state={timerState(ticket.resolutionSlaMinutes!, terminal ? (ticket.updatedAt ?? null) : null,
+            breached.has('resolution'), ticket.createdAt, ticket.slaPausedAt, ticket.slaPausedMinutes, now)} />
+      )}
+      {ticket.slaPausedAt && !terminal && (
+        <p className="text-xs text-muted-foreground" data-testid="sla-timers-paused">
+          Clock paused while the ticket is {ticket.status === 'on_hold' ? 'on hold' : 'pending'}.
+        </p>
+      )}
+    </div>
+  );
+}
+```
+
+(Resolution "met" display: the API doesn't project `resolvedAt` in `TicketDetail` today — if it does after Task 8's projection pass, prefer `ticket.resolvedAt`; otherwise terminal-status + `updatedAt` is the honest approximation. Check the GET `/:id` projection while wiring and use `resolvedAt` if present.)
+
+Mount in `TicketWorkbench.tsx`'s right rail (with the assignment/priority controls): `<SlaTimers ticket={ticket} />`.
+
+- [ ] **Step 4: Run — expect PASS:**
+
+```bash
+cd apps/web && npx vitest run src/components/tickets/SlaTimers.test.tsx src/components/tickets/TicketWorkbench.test.tsx
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/tickets/SlaTimers.tsx apps/web/src/components/tickets/SlaTimers.test.tsx apps/web/src/components/tickets/TicketWorkbench.tsx
+git commit -m "feat(tickets/web): SLA timers rail on ticket detail"
+```
+
+---
+
+## Task 13: Verification + PR
+
+- [ ] **Step 1: Affected-file test pass** (single-fork, per the known parallel-flakiness note):
+
+```bash
+cd apps/api && npx vitest run \
+  src/services/ticketSla.test.ts src/services/ticketService.test.ts src/services/ticketEvents.test.ts \
+  src/services/ticketEventsContract.test.ts src/services/aiToolsTicketing.test.ts \
+  src/routes/tickets/tickets.test.ts src/routes/tickets/bulk.test.ts src/routes/portal/tickets.test.ts \
+  src/jobs/ticketSlaWorker.test.ts src/jobs/ticketNotifyWorker.test.ts \
+  --pool=forks --poolOptions.forks.singleFork=true
+cd ../../packages/shared && npx vitest run src/validators/tickets.test.ts
+cd ../../apps/web && npx vitest run src/components/tickets/
+```
+
+- [ ] **Step 2: Type check:** `cd apps/api && npx tsc --noEmit` (pre-existing errors in `agents.test.ts`/`apiKeyAuth.test.ts` are known — anything else is yours).
+
+- [ ] **Step 3: Live smoke** (dev stack): create an urgent ticket with a category whose response SLA is 1 minute, post no comment, wait ~2 minutes → `sla_breached_at` stamped, in-app notification for the assignee, breaching tab shows the ticket, SLA timers show "Breached".
+
+- [ ] **Step 4: PR.** Two-PR split: **PR A** = Tasks 1-9 (API engine), **PR B** = Tasks 10-12 (web UI, lands after A). Use `superpowers:requesting-code-review` before each; merge via `gh pr merge --squash --admin` when green.
+
+---
+
+## Self-review notes (spec coverage)
+
+Phase 2 checklist from §8 → tasks: resolution chain (T1+T2+T7), monitor job (T5+T9), pause logic (T3), queue countdown (T10+T11), breaching-soon tab (T11), breach notifications (T4+T5+T6), SLA filters/stats/triage (T8), SLA timers rail (T12), §8a index-backed queries (T9). Deferred with rationale: dashboard widget, business hours, escalations, at-risk notifications, e2e (see "Out of scope").

--- a/packages/shared/src/validators/tickets.test.ts
+++ b/packages/shared/src/validators/tickets.test.ts
@@ -56,6 +56,17 @@ describe('ticket validators', () => {
     expect(listTicketsQuerySchema.safeParse({ deviceId: 'not-a-uuid' }).success).toBe(false);
   });
 
+  it('updateTicketSchema accepts SLA override minutes', () => {
+    expect(updateTicketSchema.parse({ responseSlaMinutes: 30, resolutionSlaMinutes: 120 }))
+      .toEqual({ responseSlaMinutes: 30, resolutionSlaMinutes: 120 });
+    expect(updateTicketSchema.parse({ responseSlaMinutes: null }).responseSlaMinutes).toBeNull();
+  });
+
+  it('updateTicketSchema rejects non-positive SLA minutes', () => {
+    expect(() => updateTicketSchema.parse({ responseSlaMinutes: 0 })).toThrow();
+    expect(() => updateTicketSchema.parse({ resolutionSlaMinutes: -5 })).toThrow();
+  });
+
   it('category validates hex color', () => {
     expect(ticketCategoryInputSchema.safeParse({ name: 'Hardware', color: '#1c8a9e' }).success).toBe(true);
     expect(ticketCategoryInputSchema.safeParse({ name: 'Hardware', color: 'teal' }).success).toBe(false);

--- a/packages/shared/src/validators/tickets.test.ts
+++ b/packages/shared/src/validators/tickets.test.ts
@@ -56,6 +56,13 @@ describe('ticket validators', () => {
     expect(listTicketsQuerySchema.safeParse({ deviceId: 'not-a-uuid' }).success).toBe(false);
   });
 
+  it('listTicketsQuerySchema accepts slaState values', () => {
+    for (const v of ['ok', 'at_risk', 'breached', 'breaching']) {
+      expect(listTicketsQuerySchema.parse({ slaState: v }).slaState).toBe(v);
+    }
+    expect(() => listTicketsQuerySchema.parse({ slaState: 'nope' })).toThrow();
+  });
+
   it('updateTicketSchema accepts SLA override minutes', () => {
     expect(updateTicketSchema.parse({ responseSlaMinutes: 30, resolutionSlaMinutes: 120 }))
       .toEqual({ responseSlaMinutes: 30, resolutionSlaMinutes: 120 });

--- a/packages/shared/src/validators/tickets.ts
+++ b/packages/shared/src/validators/tickets.ts
@@ -75,6 +75,7 @@ export const listTicketsQuerySchema = z.object({
   assignee: z.union([z.literal('me'), z.literal('unassigned'), z.string().uuid()]).optional(),
   categoryId: z.string().uuid().optional(),
   priority: ticketPrioritySchema.optional(),
+  slaState: z.enum(['ok', 'at_risk', 'breached', 'breaching']).optional(),
   search: z.string().max(200).optional(),
   sort: z.enum(['triage', 'newest', 'oldest', 'due']).default('triage')
 });

--- a/packages/shared/src/validators/tickets.ts
+++ b/packages/shared/src/validators/tickets.ts
@@ -23,6 +23,8 @@ export const updateTicketSchema = z.object({
   categoryId: z.string().uuid().nullable().optional(),
   priority: ticketPrioritySchema.optional(),
   dueDate: z.coerce.date().nullable().optional(),
+  responseSlaMinutes: z.number().int().positive().nullable().optional(),
+  resolutionSlaMinutes: z.number().int().positive().nullable().optional(),
   deviceId: z.string().uuid().nullable().optional(),
   tags: z.array(z.string().max(50)).max(20).optional()
 });


### PR DESCRIPTION
## Summary

Phase 2 of native ticketing per `docs/superpowers/specs/2026-06-09-native-ticketing-design.md` — activates the dormant SLA columns shipped in Phase 1. Single PR covering the API engine and the web UI.

**Plan:** `docs/superpowers/plans/2026-06-11-ticketing-sla-engine.md` (committed here, with design decisions D1-D7 resolving spec ambiguities: 24×7 wall-clock, chain collapsed at create, per-target one-shot breaches, priority defaults urgent/high only, assignee+eventBus notifications, computed at-risk at 80%)

### API
- **Targets stamped at create** (`createTicket`): ticket override → category default → priority default (urgent 60/240, high 240/1440)
- **Pause/resume** (`changeTicketStatus`): clock pauses in `pending`/`on_hold`; pause time folds (floored) into `sla_paused_minutes` on any exit
- **SLA monitor worker** (`ticket-sla-monitor`, 60s): CTE `FOR UPDATE SKIP LOCKED` passes stamp breaches one-shot per target; emits `ticket.sla_breached` + eventBus publish after the system DB context exits (#1105 pattern)
- **Breach notifications**: in-app + email to assignee via `ticketNotifyWorker`; internal-only
- **Queue SQL**: `slaState` filter (ok/at_risk/breached/breaching), SLA-aware triage sort, `atRisk` stat, SLA fields projected
- **PATCH override** + migration `2026-06-11-g-ticket-sla-indexes.sql` (two partial indexes, double-apply verified)

### Web
- `slaState()` rewritten pause- and response-target-aware, new `paused` chip state
- "Breaching soon" tab now server-driven (`slaState=breaching`) with `breached + atRisk` badge — replaces the divergent client-side filter
- New `SlaTimers` rail on ticket detail: per-target Met / Not met / Breached / countdown / paused states

## Test plan

- API: 260 tests green across 10 affected files (single-fork; full-suite parallel flakiness is pre-existing — trust CI)
- Web: 95 tests green across 9 ticket component files; `tsc --noEmit` clean both apps
- Migration idempotency proven by double-apply against a live postgres
- Every task went through spec-compliance + code-quality review; review fixes are separate commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)