### PR TITLE
feat(mobile): render uac_intercept PAM elevations on the approval surface (#1154)

### DIFF
--- a/apps/mobile/src/screens/approvals/ApprovalScreen.tsx
+++ b/apps/mobile/src/screens/approvals/ApprovalScreen.tsx
@@ -19,9 +19,12 @@ import { CountdownRing } from './components/CountdownRing';
 import { RequesterRow } from './components/RequesterRow';
 import { ActionHeadline } from './components/ActionHeadline';
 import { DetailsCollapse } from './components/DetailsCollapse';
+import { UacInterceptDetails } from './components/UacInterceptDetails';
 import { RiskBand } from './components/RiskBand';
 import { CustomerTenantBadge } from './components/CustomerTenantBadge';
 import { ApprovalButtons } from './components/ApprovalButtons';
+import { resolveApprovalFlowType } from './approvalFlow';
+import { getApprovalCopy } from './approvalCopy';
 import { decisionTarget, type CapturedRequestId } from './decisionTarget';
 import { SuspiciousReportSheet } from './components/SuspiciousReportSheet';
 import { Toast } from '../../components/Toast';
@@ -216,6 +219,12 @@ export function ApprovalScreen() {
   // 5s hold-to-confirm self-approval UX.
   const isRecursive = focused.isRecursive;
 
+  // Flow-type-aware copy + details (#1154). uac_intercept (PAM elevation) gets
+  // an "Allow {exe} to run as admin" headline + a structured detail card; every
+  // other flow keeps the existing actionLabel + generic JSON details.
+  const flowType = resolveApprovalFlowType(focused);
+  const copy = getApprovalCopy(focused);
+
   return (
     <View style={{ flex: 1, backgroundColor: theme.bg0 }}>
       <Animated.View style={[{ flex: 1 }, enterStyle, shakeStyle]}>
@@ -248,12 +257,16 @@ export function ApprovalScreen() {
             machineLabel={focused.requestingMachineLabel}
             createdAt={focused.createdAt}
           />
-          <ActionHeadline action={focused.actionLabel} />
+          <ActionHeadline action={copy.headline} />
           {focused.customerTenant ? (
             <CustomerTenantBadge tenant={focused.customerTenant} />
           ) : null}
           <RiskBand tier={focused.riskTier} summary={focused.riskSummary} />
-          <DetailsCollapse toolName={focused.actionToolName} args={focused.actionArguments} />
+          {flowType === 'uac_intercept' ? (
+            <UacInterceptDetails args={focused.actionArguments} />
+          ) : (
+            <DetailsCollapse toolName={focused.actionToolName} args={focused.actionArguments} />
+          )}
         </ScrollView>
 
         <View style={{ paddingBottom: insets.bottom + spacing[5] }}>
@@ -261,6 +274,8 @@ export function ApprovalScreen() {
             requestId={focused.id}
             isRecursive={isRecursive}
             inFlight={inFlight}
+            approveLabel={copy.approveLabel}
+            holdLabel={copy.holdLabel}
             onApprove={handleApprove}
             onDeny={handleDeny}
           />

--- a/apps/mobile/src/screens/approvals/approvalCopy.test.ts
+++ b/apps/mobile/src/screens/approvals/approvalCopy.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { extractUacDetails, executableName, getApprovalCopy } from './approvalCopy';
+
+describe('extractUacDetails', () => {
+  it('reads the elevation schema camelCase fields', () => {
+    expect(
+      extractUacDetails({
+        targetExecutablePath: 'C:\\Windows\\System32\\cmd.exe',
+        targetExecutableSigner: 'Microsoft Windows',
+        targetExecutableHash: 'abc123',
+        parentProcess: 'explorer.exe',
+        requesterReason: 'install printer',
+        intentSummary: 'runs an installer',
+      }),
+    ).toEqual({
+      exePath: 'C:\\Windows\\System32\\cmd.exe',
+      signer: 'Microsoft Windows',
+      hash: 'abc123',
+      parentProcess: 'explorer.exe',
+      reason: 'install printer',
+      intentSummary: 'runs an installer',
+    });
+  });
+
+  it('tolerates server aliases and falls back to publisher / parentImage / reason', () => {
+    const d = extractUacDetails({
+      exePath: 'D:\\tools\\setup.exe',
+      targetPublisher: 'Acme Corp',
+      hash: 'deadbeef',
+      parentImage: 'powershell.exe',
+      reason: 'because',
+    });
+    expect(d.exePath).toBe('D:\\tools\\setup.exe');
+    expect(d.signer).toBe('Acme Corp');
+    expect(d.parentProcess).toBe('powershell.exe');
+    expect(d.reason).toBe('because');
+  });
+
+  it('returns nulls for missing / blank / non-string fields', () => {
+    expect(extractUacDetails({ targetExecutablePath: '   ', targetExecutableHash: 42 })).toEqual({
+      exePath: null,
+      signer: null,
+      hash: null,
+      parentProcess: null,
+      reason: null,
+      intentSummary: null,
+    });
+    expect(extractUacDetails(null)).toEqual({
+      exePath: null,
+      signer: null,
+      hash: null,
+      parentProcess: null,
+      reason: null,
+      intentSummary: null,
+    });
+  });
+});
+
+describe('executableName', () => {
+  it('takes the basename of a Windows path', () => {
+    expect(executableName('C:\\Program Files\\Acme\\thing.exe')).toBe('thing.exe');
+  });
+  it('takes the basename of a POSIX path', () => {
+    expect(executableName('/usr/local/bin/tool')).toBe('tool');
+  });
+  it('returns null for null/empty', () => {
+    expect(executableName(null)).toBeNull();
+    expect(executableName('')).toBeNull();
+  });
+});
+
+describe('getApprovalCopy', () => {
+  it('builds uac_intercept copy from the executable name', () => {
+    const copy = getApprovalCopy({
+      actionToolName: 'uac_intercept',
+      actionLabel: 'ignored for uac',
+      actionArguments: { targetExecutablePath: 'C:\\Windows\\System32\\cmd.exe' },
+    });
+    expect(copy).toEqual({
+      headline: 'Allow cmd.exe to run as admin',
+      approveLabel: 'Allow',
+      holdLabel: 'Hold to allow',
+    });
+  });
+
+  it('falls back to a generic uac headline when no exe path is present', () => {
+    const copy = getApprovalCopy({
+      flowType: 'uac_intercept',
+      actionToolName: 'uac_intercept',
+      actionLabel: 'x',
+      actionArguments: {},
+    });
+    expect(copy.headline).toBe('Allow admin elevation');
+    expect(copy.approveLabel).toBe('Allow');
+  });
+
+  it('uses the actionLabel and generic verbs for standard approvals', () => {
+    const copy = getApprovalCopy({
+      actionToolName: 'm365_reset_password',
+      actionLabel: 'Reset M365 password',
+      actionArguments: { userId: 'u1' },
+    });
+    expect(copy).toEqual({
+      headline: 'Reset M365 password',
+      approveLabel: 'Approve',
+      holdLabel: 'Hold to approve',
+    });
+  });
+});

--- a/apps/mobile/src/screens/approvals/approvalCopy.ts
+++ b/apps/mobile/src/screens/approvals/approvalCopy.ts
@@ -1,0 +1,89 @@
+/**
+ * Per-flow-type copy + detail extraction for the mobile approval surface (#1154).
+ *
+ * Pure module — no React Native / Expo imports — so it is unit-testable in the
+ * Vitest node environment. The UI (ActionHeadline, ApprovalButtons,
+ * UacInterceptDetails) reads from here so all flow-type-specific wording lives
+ * in one place.
+ */
+
+import { resolveApprovalFlowType, type FlowTypeInput } from './approvalFlow';
+
+export interface ApprovalCopy {
+  /** Large headline shown by ActionHeadline. */
+  headline: string;
+  /** Quick-tap approve button label. */
+  approveLabel: string;
+  /** Hold-to-confirm label (self-approval / recursive). */
+  holdLabel: string;
+}
+
+/** Defensive, normalised view of a uac_intercept approval's actionArguments. */
+export interface UacInterceptDetails {
+  exePath: string | null;
+  signer: string | null;
+  hash: string | null;
+  parentProcess: string | null;
+  reason: string | null;
+  intentSummary: string | null;
+}
+
+function str(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function firstStr(...values: unknown[]): string | null {
+  for (const v of values) {
+    const s = str(v);
+    if (s) return s;
+  }
+  return null;
+}
+
+/**
+ * Read the uac fields, tolerating both the elevation schema's camelCase names
+ * (targetExecutablePath / targetExecutableSigner / …) and a few likely server
+ * aliases, so the renderer stays resilient to the exact payload shape the PAM
+ * control plane settles on.
+ */
+export function extractUacDetails(args: Record<string, unknown> | null | undefined): UacInterceptDetails {
+  const a = args ?? {};
+  return {
+    exePath: firstStr(a.targetExecutablePath, a.exePath, a.executablePath),
+    signer: firstStr(a.targetExecutableSigner, a.signer, a.targetPublisher, a.publisher),
+    hash: firstStr(a.targetExecutableHash, a.hash),
+    parentProcess: firstStr(a.parentProcess, a.parentImage),
+    reason: firstStr(a.requesterReason, a.reason),
+    intentSummary: firstStr(a.intentSummary),
+  };
+}
+
+/** Basename of a Windows (`\\`) or POSIX (`/`) path. */
+export function executableName(exePath: string | null): string | null {
+  if (!exePath) return null;
+  const parts = exePath.split(/[\\/]/).filter(Boolean);
+  return parts.length > 0 ? parts[parts.length - 1]! : null;
+}
+
+export interface ApprovalCopyInput extends FlowTypeInput {
+  actionLabel: string;
+  actionArguments: Record<string, unknown>;
+}
+
+export function getApprovalCopy(approval: ApprovalCopyInput): ApprovalCopy {
+  if (resolveApprovalFlowType(approval) === 'uac_intercept') {
+    const name = executableName(extractUacDetails(approval.actionArguments).exePath);
+    return {
+      headline: name ? `Allow ${name} to run as admin` : 'Allow admin elevation',
+      approveLabel: 'Allow',
+      holdLabel: 'Hold to allow',
+    };
+  }
+  return {
+    headline: approval.actionLabel,
+    approveLabel: 'Approve',
+    holdLabel: 'Hold to approve',
+  };
+}

--- a/apps/mobile/src/screens/approvals/approvalFlow.test.ts
+++ b/apps/mobile/src/screens/approvals/approvalFlow.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { resolveApprovalFlowType, UAC_INTERCEPT_TOOL } from './approvalFlow';
+
+describe('resolveApprovalFlowType', () => {
+  it('prefers the server-issued flowType when present', () => {
+    expect(
+      resolveApprovalFlowType({ flowType: 'uac_intercept', actionToolName: 'something_else' }),
+    ).toBe('uac_intercept');
+    expect(
+      resolveApprovalFlowType({ flowType: 'mcp_tool', actionToolName: UAC_INTERCEPT_TOOL }),
+    ).toBe('standard');
+  });
+
+  it('falls back to actionToolName when flowType is absent/blank', () => {
+    expect(resolveApprovalFlowType({ actionToolName: UAC_INTERCEPT_TOOL })).toBe('uac_intercept');
+    expect(resolveApprovalFlowType({ flowType: '   ', actionToolName: UAC_INTERCEPT_TOOL })).toBe(
+      'uac_intercept',
+    );
+    expect(resolveApprovalFlowType({ flowType: null, actionToolName: UAC_INTERCEPT_TOOL })).toBe(
+      'uac_intercept',
+    );
+  });
+
+  it('defaults to standard for any other tool', () => {
+    expect(resolveApprovalFlowType({ actionToolName: 'm365_reset_password' })).toBe('standard');
+    expect(resolveApprovalFlowType({ actionToolName: '' })).toBe('standard');
+  });
+});

--- a/apps/mobile/src/screens/approvals/approvalFlow.ts
+++ b/apps/mobile/src/screens/approvals/approvalFlow.ts
@@ -1,0 +1,35 @@
+/**
+ * Approval flow-type discriminant for the mobile approval surface (#1154).
+ *
+ * Pure module — no React Native / Expo imports — so it is unit-testable in the
+ * Vitest node environment, mirroring authOutcome.ts / decisionTarget.ts.
+ *
+ * A `uac_intercept` approval is a PAM elevation: an end user hit a Windows UAC
+ * prompt and the agent surfaced it for human approval. It carries executable
+ * metadata (path / signer / hash / parent / reason) in actionArguments and gets
+ * its own headline + a structured detail renderer instead of the generic JSON
+ * dump. Everything else is `standard` and keeps the existing behaviour.
+ */
+
+export type ApprovalFlowType = 'uac_intercept' | 'standard';
+
+/** Tool name the PAM control plane stamps on a UAC-intercept elevation approval. */
+export const UAC_INTERCEPT_TOOL = 'uac_intercept';
+
+export interface FlowTypeInput {
+  /**
+   * Server-issued flow_type. Preferred when present so the discriminant is a
+   * forward-compatible contract rather than a coincidence of the tool name.
+   */
+  flowType?: string | null;
+  /** Fallback discriminant: the approval's tool name. */
+  actionToolName: string;
+}
+
+export function resolveApprovalFlowType(input: FlowTypeInput): ApprovalFlowType {
+  const explicit = input.flowType?.trim();
+  if (explicit) {
+    return explicit === UAC_INTERCEPT_TOOL ? 'uac_intercept' : 'standard';
+  }
+  return input.actionToolName === UAC_INTERCEPT_TOOL ? 'uac_intercept' : 'standard';
+}

--- a/apps/mobile/src/screens/approvals/components/ApprovalButtons.tsx
+++ b/apps/mobile/src/screens/approvals/components/ApprovalButtons.tsx
@@ -18,13 +18,25 @@ interface Props {
   requestId: string;
   isRecursive: boolean;
   inFlight: 'approve' | 'deny' | null;
+  /** Approve button label — flow-type aware (e.g. "Allow" for uac_intercept). */
+  approveLabel?: string;
+  /** Hold-to-confirm label for the recursive self-approval path. */
+  holdLabel?: string;
   onApprove: (requestId: CapturedRequestId) => void;
   onDeny: (requestId: CapturedRequestId, reason?: string) => void;
 }
 
 const PASSCODE_FALLBACK_CODES = new Set(['not_enrolled', 'passcode_not_set']);
 
-export function ApprovalButtons({ requestId, isRecursive, inFlight, onApprove, onDeny }: Props) {
+export function ApprovalButtons({
+  requestId,
+  isRecursive,
+  inFlight,
+  approveLabel = 'Approve',
+  holdLabel = 'Hold to approve',
+  onApprove,
+  onDeny,
+}: Props) {
   const theme = useApprovalTheme('dark');
   const [denyOpen, setDenyOpen] = useState(false);
   const [authMessage, setAuthMessage] = useState<string | null>(null);
@@ -133,7 +145,7 @@ export function ApprovalButtons({ requestId, isRecursive, inFlight, onApprove, o
 
         {isRecursive ? (
           <View style={{ flex: 1.4 }}>
-            <HoldToConfirm label="Hold to approve" onComplete={handleApprovePress} />
+            <HoldToConfirm label={holdLabel} onComplete={handleApprovePress} />
           </View>
         ) : (
           <Pressable
@@ -148,7 +160,7 @@ export function ApprovalButtons({ requestId, isRecursive, inFlight, onApprove, o
               opacity: inFlight === 'approve' ? 0.6 : 1,
             })}
           >
-            <Text style={[type.bodyMd, { color: palette.approve.onBase }]}>Approve</Text>
+            <Text style={[type.bodyMd, { color: palette.approve.onBase }]}>{approveLabel}</Text>
           </Pressable>
         )}
       </View>

--- a/apps/mobile/src/screens/approvals/components/UacInterceptDetails.tsx
+++ b/apps/mobile/src/screens/approvals/components/UacInterceptDetails.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { Pressable, Text, View } from 'react-native';
+import { useApprovalTheme, type, spacing, radii } from '../../../theme';
+import { extractUacDetails } from '../approvalCopy';
+
+interface Props {
+  args: Record<string, unknown>;
+}
+
+interface DetailRow {
+  label: string;
+  value: string;
+}
+
+/**
+ * Structured detail card for a uac_intercept elevation approval (#1154).
+ *
+ * Replaces the generic raw-JSON DetailsCollapse for this flow: the most
+ * decision-relevant fact (the signer) stays visible on the collapsed card, and
+ * expanding reveals the full mono details — executable path, SHA-256, parent
+ * process, and the requester's reason — so the approver can judge the elevation
+ * without parsing JSON.
+ */
+export function UacInterceptDetails({ args }: Props) {
+  const theme = useApprovalTheme('dark');
+  const [open, setOpen] = useState(false);
+  const d = extractUacDetails(args);
+
+  const rows: DetailRow[] = [
+    { label: 'EXECUTABLE', value: d.exePath ?? 'Unknown' },
+    { label: 'SIGNER', value: d.signer ?? 'Unsigned' },
+    { label: 'HASH (SHA-256)', value: d.hash ?? 'Unknown' },
+    { label: 'PARENT PROCESS', value: d.parentProcess ?? 'Unknown' },
+  ];
+  if (d.reason) rows.push({ label: 'REQUESTER REASON', value: d.reason });
+  if (d.intentSummary) rows.push({ label: 'INTENT', value: d.intentSummary });
+
+  return (
+    <View
+      style={{
+        marginHorizontal: spacing[6],
+        marginTop: spacing[5],
+        borderRadius: radii.md,
+        backgroundColor: theme.bg2,
+        borderColor: theme.border,
+        borderWidth: 1,
+      }}
+    >
+      <Pressable
+        onPress={() => setOpen((v) => !v)}
+        style={{ padding: spacing[4], flexDirection: 'row', justifyContent: 'space-between' }}
+      >
+        <View style={{ flex: 1, marginRight: spacing[3] }}>
+          <Text style={[type.metaCaps, { color: theme.textLo }]}>ELEVATION</Text>
+          <Text
+            style={[type.monoMd, { color: theme.textHi, marginTop: spacing[1] }]}
+            numberOfLines={1}
+          >
+            {d.signer ?? 'Unsigned executable'}
+          </Text>
+        </View>
+        <Text style={[type.meta, { color: theme.textMd }]}>{open ? 'Hide' : 'Show'} details</Text>
+      </Pressable>
+      {open ? (
+        <View
+          style={{
+            paddingHorizontal: spacing[4],
+            paddingBottom: spacing[4],
+            borderTopColor: theme.border,
+            borderTopWidth: 1,
+          }}
+        >
+          {rows.map((row) => (
+            <View key={row.label} style={{ marginTop: spacing[3] }}>
+              <Text style={[type.metaCaps, { color: theme.textLo }]}>{row.label}</Text>
+              <Text style={[type.mono, { color: theme.textHi, marginTop: spacing[1] }]} selectable>
+                {row.value}
+              </Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+    </View>
+  );
+}

--- a/apps/mobile/src/services/approvals.ts
+++ b/apps/mobile/src/services/approvals.ts
@@ -17,6 +17,14 @@ export interface ApprovalRequest {
   requestingMachineLabel: string | null;
   actionLabel: string;
   actionToolName: string;
+  /**
+   * Server-issued approval flow discriminant (#1154). `'uac_intercept'` is a
+   * PAM elevation surfaced for human approval; absent/other values render as a
+   * standard approval. Optional for forward-compatibility — when the server
+   * omits it, the flow type is derived from {@link actionToolName}
+   * (see screens/approvals/approvalFlow.ts).
+   */
+  flowType?: string | null;
   actionArguments: Record<string, unknown>;
   riskTier: RiskTier;
   riskSummary: string;


### PR DESCRIPTION
## Summary

Teaches the existing Expo approval mode to recognise and render a **`flow_type='uac_intercept'`** approval — a PAM Windows UAC elevation surfaced for human approval — reusing every existing primitive. Biometric step-up, `CountdownRing`, `HoldToConfirm`, the `decisionTarget` consent-binding guard, and the lock-screen-safe push path are all flow-agnostic and **unchanged**. Closes #1154.

## What's here

- **`approvalFlow.ts`** (pure): `resolveApprovalFlowType` — prefers a server-issued `flowType`, falls back to `actionToolName === 'uac_intercept'`.
- **`approvalCopy.ts`** (pure): `getApprovalCopy` — uac_intercept gets an **"Allow {exe} to run as admin"** headline and **"Allow" / "Hold to allow"** button verbs; every other flow keeps `actionLabel` + "Approve". `extractUacDetails` tolerates the elevation schema's camelCase fields (`targetExecutablePath`/`targetExecutableSigner`/…) plus a few likely server aliases.
- **`UacInterceptDetails.tsx`**: structured mono detail card — executable path, signer, SHA-256, parent process, requester reason, intent — with the **signer surfaced on the collapsed card** (the single most decision-relevant fact). Replaces the generic raw-JSON `DetailsCollapse` for this flow only.
- **Wiring**: `ApprovalScreen` derives flow type → headline / details / button labels; `ApprovalButtons` gains optional `approveLabel`/`holdLabel` (defaulting to the existing strings — backward compatible). `ApprovalRequest` gains an optional server-issued `flowType`.

## Already shipped, not re-done

The issue also lists *"replace the label-prefix heuristic with a server-issued recursive flag"* — that's already in main (`deriveIsRecursive` → `isRecursive`), so no change there.

## Scope

This is the **mobile rendering** half (the issue is titled "Mobile:"). The backend bridge that creates `approval_requests` rows from `uac_intercept` `elevation_requests`, dispatches the push, and mirrors the approve/deny decision back to the elevation is **separate PAM control-plane work** — the dependency for the end-to-end flow, tracked outside this PR.

## Testing

- `approvalFlow` + `approvalCopy` pure unit suites (23 assertions: flow resolution, exe-basename extraction from Windows/POSIX paths, camelCase/alias tolerance, per-flow copy).
- Full mobile `vitest` green (**156 passed / 3 pre-existing skips**), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)