### PR TITLE
fix(web): opaque modal headers + default site timezone to partner's

### DIFF
--- a/apps/web/src/components/settings/OrganizationsPage.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.tsx
@@ -59,6 +59,9 @@ export default function OrganizationsPage() {
   // True when the site-add modal was auto-opened right after creating an org —
   // drives first-site guidance copy and a Skip-for-now affordance.
   const [guidingFirstSite, setGuidingFirstSite] = useState(false);
+  // Partner's configured timezone, used to pre-select the timezone for new sites
+  // instead of falling back to UTC. Undefined until loaded / if unavailable.
+  const [partnerTimezone, setPartnerTimezone] = useState<string>();
 
   const filteredOrgs = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
@@ -126,6 +129,26 @@ export default function OrganizationsPage() {
   useEffect(() => {
     fetchOrganizations();
   }, [fetchOrganizations]);
+
+  // Load the partner's default timezone once so new sites pre-select it.
+  // Best-effort: on any failure we silently fall back to the form's UTC default.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const response = await fetchWithAuth('/orgs/partners/me');
+        if (!response.ok) return;
+        const data = await response.json();
+        const tz = data?.settings?.timezone;
+        if (!cancelled && typeof tz === 'string' && tz) setPartnerTimezone(tz);
+      } catch {
+        /* best-effort; keep UTC default */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Auto-select org from URL param on initial load
   useEffect(() => {
@@ -647,7 +670,7 @@ export default function OrganizationsPage() {
       {modalMode === 'add' && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 py-8">
           <div className="w-full max-w-2xl max-h-[90vh] overflow-y-auto">
-            <div className="mb-4">
+            <div className="mb-4 rounded-lg border bg-card p-6 shadow-sm">
               <h2 className="text-lg font-semibold">Add Organization</h2>
               <p className="text-sm text-muted-foreground">
                 Create a new organization with the details below.
@@ -697,7 +720,7 @@ export default function OrganizationsPage() {
       {(siteModalMode === 'add' || siteModalMode === 'edit') && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 py-8">
           <div className="w-full max-w-2xl max-h-[90vh] overflow-y-auto">
-            <div className="mb-4 flex items-start justify-between gap-4">
+            <div className="mb-4 flex items-start justify-between gap-4 rounded-lg border bg-card p-6 shadow-sm">
               <div>
                 <h2 className="text-lg font-semibold">
                   {siteModalMode === 'edit'
@@ -730,7 +753,9 @@ export default function OrganizationsPage() {
               defaultValues={
                 selectedSite
                   ? getSiteFormDefaults(selectedSite as Site & { address?: Record<string, string>; contact?: Record<string, string> })
-                  : undefined
+                  : partnerTimezone
+                    ? { timezone: partnerTimezone }
+                    : undefined
               }
               submitLabel={
                 siteModalMode === 'edit'

--- a/apps/web/src/components/settings/SiteForm.tsx
+++ b/apps/web/src/components/settings/SiteForm.tsx
@@ -75,6 +75,16 @@ export default function SiteForm({
 
   const isLoading = useMemo(() => loading ?? isSubmitting, [loading, isSubmitting]);
 
+  // Ensure the selected/default timezone is always a real <option>, otherwise a
+  // native select silently falls back to its first option (e.g. a partner tz
+  // like "Europe/Paris" that isn't in the short list above).
+  const zones = useMemo(() => {
+    const selected = defaultValues?.timezone;
+    return selected && !timezoneOptions.includes(selected)
+      ? [selected, ...timezoneOptions]
+      : timezoneOptions;
+  }, [defaultValues?.timezone]);
+
   return (
     <form
       onSubmit={handleSubmit(async values => {
@@ -108,7 +118,7 @@ export default function SiteForm({
             className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
             {...register('timezone')}
           >
-            {timezoneOptions.map(zone => (
+            {zones.map(zone => (
               <option key={zone} value={zone}>
                 {zone}
               </option>


### PR DESCRIPTION
## Summary

Two fixes in the Organizations & Sites settings UI (`apps/web`):

**1. Transparent modal headers**
The *Add Organization* and *Add/Edit Site* modals rendered their header block (title + description + "Skip for now") above the form card with no background of its own. The overlay is `bg-background/80`, so the page content behind it bled through the header area. Each header now gets its own opaque `bg-card` panel matching the form below it. (The delete-confirm modals were already wrapped in `bg-card` and were unaffected.)

**2. Default new-site timezone to the partner's timezone**
New sites defaulted to `UTC`. They now pre-select the partner's configured timezone (`settings.timezone` from `/orgs/partners/me`, best-effort with a `UTC` fallback if the fetch fails or the field is unset). Editing an existing site still uses that site's own timezone.

`SiteForm` previously had a short hardcoded timezone list; a partner tz outside it (e.g. `Europe/Paris`) would have silently snapped the native `<select>` to its first option. It now prepends the selected timezone to the option list when it isn't already present, so the partner's value always displays and submits correctly.

## Test plan
- [ ] Open **Add Site** modal → header is solid (no bleed-through), timezone pre-selects the partner's configured tz
- [ ] Open **Add Organization** modal → header is solid
- [ ] Edit an existing site → timezone shows that site's own value, not the partner default
- [ ] Partner with a tz outside the short list → it still displays selected

`tsc --noEmit` passes clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)