### PR TITLE
feat(software): gate Software-tab Update on real available updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ target/
 # Playwright MCP screenshots
 .playwright-mcp/
 
+# impeccable design-critique plugin artifacts
+.impeccable/
+
 # Claude Code
 CLAUDE.md
 .claude/plans/

--- a/agent/internal/remote/tools/software.go
+++ b/agent/internal/remote/tools/software.go
@@ -83,6 +83,25 @@ func validateSoftwareName(name string) error {
 	return nil
 }
 
+// validWingetPackageIDPattern mirrors the agent's patching.validWingetPkgID and
+// the API's softwareActions packageId regex: a winget identifier such as
+// "Mozilla.Firefox". Empty is allowed (the field is optional).
+var validWingetPackageIDPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+
+func validateSoftwarePackageID(packageID string) error {
+	trimmed := strings.TrimSpace(packageID)
+	if trimmed == "" {
+		return nil
+	}
+	if len(trimmed) > 256 {
+		return fmt.Errorf("software packageId exceeds 256 characters")
+	}
+	if !validWingetPackageIDPattern.MatchString(trimmed) {
+		return fmt.Errorf("software packageId contains unsafe characters")
+	}
+	return nil
+}
+
 func validateSoftwareVersion(version string) error {
 	trimmed := strings.TrimSpace(version)
 	if trimmed == "" {

--- a/agent/internal/remote/tools/software_update.go
+++ b/agent/internal/remote/tools/software_update.go
@@ -75,89 +75,55 @@ func updateSoftwareOS(name, version, packageID string) error {
 }
 
 func updateSoftwareWindows(name, version, packageID string) error {
-	// Two-tier match strategy mirrors uninstallSoftwareWindows: try
-	// --name first (matches the human-readable name the user sees in
-	// the Software tab), then --id as a fallback (winget's stable
-	// identifier, used when the display name is ambiguous).
-	attempts := []updateAttempt{
-		{
-			command: "winget",
-			args: []string{
-				"upgrade",
-				"--name", name,
-				"--silent",
-				"--accept-source-agreements",
-				"--accept-package-agreements",
-				"--disable-interactivity",
-			},
-		},
-		{
-			command: "winget",
-			args: []string{
-				"upgrade",
-				"--id", name,
-				"--silent",
-				"--accept-source-agreements",
-				"--accept-package-agreements",
-				"--disable-interactivity",
-			},
-		},
+	return runUpdateAttempts(name, buildWindowsUpdateAttempts(name, version, packageID))
+}
+
+// wingetUpgradeAttempt builds a single `winget upgrade` attempt selecting the
+// package by the given flag (--name or --id), optionally version-pinned.
+func wingetUpgradeAttempt(selector, value, version string) updateAttempt {
+	args := []string{"upgrade", selector, value}
+	if version != "" {
+		args = append(args, "--version", version)
+	}
+	args = append(args,
+		"--silent",
+		"--accept-source-agreements",
+		"--accept-package-agreements",
+		"--disable-interactivity",
+	)
+	return updateAttempt{command: "winget", args: args}
+}
+
+// buildWindowsUpdateAttempts returns the ordered list of winget attempts.
+// Ordering is significant — the first attempt whose binary is present and whose
+// invocation succeeds wins (see runUpdateAttempts):
+//
+//  1. --id <packageID>  (when a known winget Id is supplied) — the most reliable
+//     selector, so it's tried first ahead of the display-name heuristics.
+//  2. --name <name>     (the human-readable name from the Software tab)
+//  3. --id <name>       (display name as a fallback id, for ambiguous names)
+//
+// A version-pinned variant is prepended within each tier when a target version
+// is supplied (winget treats --version as "upgrade to this exact version").
+func buildWindowsUpdateAttempts(name, version, packageID string) []updateAttempt {
+	var attempts []updateAttempt
+
+	if packageID != "" {
+		if version != "" {
+			attempts = append(attempts, wingetUpgradeAttempt("--id", packageID, version))
+		}
+		attempts = append(attempts, wingetUpgradeAttempt("--id", packageID, ""))
 	}
 
 	if version != "" {
-		// When a target version is supplied, prepend version-pinned
-		// variants. winget treats --version as "upgrade to this exact
-		// version" — useful for compliance pinning.
-		attempts = append([]updateAttempt{
-			{
-				command: "winget",
-				args: []string{
-					"upgrade",
-					"--name", name,
-					"--version", version,
-					"--silent",
-					"--accept-source-agreements",
-					"--accept-package-agreements",
-					"--disable-interactivity",
-				},
-			},
-		}, attempts...)
+		attempts = append(attempts, wingetUpgradeAttempt("--name", name, version))
 	}
+	attempts = append(attempts,
+		wingetUpgradeAttempt("--name", name, ""),
+		wingetUpgradeAttempt("--id", name, ""),
+	)
 
-	if packageID != "" {
-		// A known winget Id is the most reliable selector — prepend it so it's
-		// tried first, ahead of the display-name heuristics. Include a
-		// version-pinned variant when a target version is also supplied.
-		idAttempts := []updateAttempt{}
-		if version != "" {
-			idAttempts = append(idAttempts, updateAttempt{
-				command: "winget",
-				args: []string{
-					"upgrade",
-					"--id", packageID,
-					"--version", version,
-					"--silent",
-					"--accept-source-agreements",
-					"--accept-package-agreements",
-					"--disable-interactivity",
-				},
-			})
-		}
-		idAttempts = append(idAttempts, updateAttempt{
-			command: "winget",
-			args: []string{
-				"upgrade",
-				"--id", packageID,
-				"--silent",
-				"--accept-source-agreements",
-				"--accept-package-agreements",
-				"--disable-interactivity",
-			},
-		})
-		attempts = append(idAttempts, attempts...)
-	}
-
-	return runUpdateAttempts(name, attempts)
+	return attempts
 }
 
 func updateSoftwareMacOS(name string) error {

--- a/agent/internal/remote/tools/software_update.go
+++ b/agent/internal/remote/tools/software_update.go
@@ -30,6 +30,11 @@ func UpdateSoftware(payload map[string]any) CommandResult {
 
 	name := strings.TrimSpace(GetPayloadString(payload, "name", ""))
 	version := strings.TrimSpace(GetPayloadString(payload, "version", ""))
+	// packageId is the winget identifier (e.g. "Mozilla.Firefox"). When the
+	// Software tab has correlated the row to an available third-party update it
+	// sends this so we can upgrade by `--id` — far more reliable than guessing
+	// from the registry display name. Optional and Windows-only.
+	packageID := strings.TrimSpace(GetPayloadString(payload, "packageId", ""))
 
 	if err := validateSoftwareName(name); err != nil {
 		return NewErrorResult(err, time.Since(startTime).Milliseconds())
@@ -37,25 +42,29 @@ func UpdateSoftware(payload map[string]any) CommandResult {
 	if err := validateSoftwareVersion(version); err != nil {
 		return NewErrorResult(err, time.Since(startTime).Milliseconds())
 	}
+	if err := validateSoftwarePackageID(packageID); err != nil {
+		return NewErrorResult(err, time.Since(startTime).Milliseconds())
+	}
 
-	if err := updateSoftwareOS(name, version); err != nil {
+	if err := updateSoftwareOS(name, version, packageID); err != nil {
 		return NewErrorResult(err, time.Since(startTime).Milliseconds())
 	}
 
 	result := map[string]any{
-		"name":    name,
-		"version": version,
-		"action":  "update",
-		"success": true,
+		"name":      name,
+		"version":   version,
+		"packageId": packageID,
+		"action":    "update",
+		"success":   true,
 	}
 
 	return NewSuccessResult(result, time.Since(startTime).Milliseconds())
 }
 
-func updateSoftwareOS(name, version string) error {
+func updateSoftwareOS(name, version, packageID string) error {
 	switch runtime.GOOS {
 	case "windows":
-		return updateSoftwareWindows(name, version)
+		return updateSoftwareWindows(name, version, packageID)
 	case "darwin":
 		return updateSoftwareMacOS(name)
 	case "linux":
@@ -65,7 +74,7 @@ func updateSoftwareOS(name, version string) error {
 	}
 }
 
-func updateSoftwareWindows(name, version string) error {
+func updateSoftwareWindows(name, version, packageID string) error {
 	// Two-tier match strategy mirrors uninstallSoftwareWindows: try
 	// --name first (matches the human-readable name the user sees in
 	// the Software tab), then --id as a fallback (winget's stable
@@ -113,6 +122,39 @@ func updateSoftwareWindows(name, version string) error {
 				},
 			},
 		}, attempts...)
+	}
+
+	if packageID != "" {
+		// A known winget Id is the most reliable selector — prepend it so it's
+		// tried first, ahead of the display-name heuristics. Include a
+		// version-pinned variant when a target version is also supplied.
+		idAttempts := []updateAttempt{}
+		if version != "" {
+			idAttempts = append(idAttempts, updateAttempt{
+				command: "winget",
+				args: []string{
+					"upgrade",
+					"--id", packageID,
+					"--version", version,
+					"--silent",
+					"--accept-source-agreements",
+					"--accept-package-agreements",
+					"--disable-interactivity",
+				},
+			})
+		}
+		idAttempts = append(idAttempts, updateAttempt{
+			command: "winget",
+			args: []string{
+				"upgrade",
+				"--id", packageID,
+				"--silent",
+				"--accept-source-agreements",
+				"--accept-package-agreements",
+				"--disable-interactivity",
+			},
+		})
+		attempts = append(idAttempts, attempts...)
 	}
 
 	return runUpdateAttempts(name, attempts)

--- a/agent/internal/remote/tools/software_update_test.go
+++ b/agent/internal/remote/tools/software_update_test.go
@@ -73,6 +73,63 @@ func TestUpdateSoftwareRejectsUnsafePackageID(t *testing.T) {
 	}
 }
 
+// argsHave reports whether the attempt's args contain the given flag immediately
+// followed by the given value (e.g. "--id" then "Mozilla.Firefox").
+func argsHave(a updateAttempt, flag, value string) bool {
+	for i := 0; i+1 < len(a.args); i++ {
+		if a.args[i] == flag && a.args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBuildWindowsUpdateAttemptsPrefersPackageID(t *testing.T) {
+	t.Parallel()
+	attempts := buildWindowsUpdateAttempts("Mozilla Firefox", "", "Mozilla.Firefox")
+	if len(attempts) == 0 {
+		t.Fatal("expected at least one attempt")
+	}
+	// The --id <packageID> attempt must come first, ahead of any --name attempt.
+	if !argsHave(attempts[0], "--id", "Mozilla.Firefox") {
+		t.Fatalf("expected first attempt to select --id Mozilla.Firefox, got %v", attempts[0].args)
+	}
+	firstName, firstID := -1, -1
+	for i, a := range attempts {
+		if firstName == -1 && argsHave(a, "--name", "Mozilla Firefox") {
+			firstName = i
+		}
+		if firstID == -1 && argsHave(a, "--id", "Mozilla.Firefox") {
+			firstID = i
+		}
+	}
+	if firstID == -1 || firstName == -1 || firstID >= firstName {
+		t.Fatalf("expected --id packageID before --name; firstID=%d firstName=%d", firstID, firstName)
+	}
+}
+
+func TestBuildWindowsUpdateAttemptsVersionPinnedIDFirst(t *testing.T) {
+	t.Parallel()
+	attempts := buildWindowsUpdateAttempts("Mozilla Firefox", "131.0", "Mozilla.Firefox")
+	if !argsHave(attempts[0], "--id", "Mozilla.Firefox") || !argsHave(attempts[0], "--version", "131.0") {
+		t.Fatalf("expected first attempt to be version-pinned --id, got %v", attempts[0].args)
+	}
+}
+
+func TestBuildWindowsUpdateAttemptsNameFirstWithoutPackageID(t *testing.T) {
+	t.Parallel()
+	attempts := buildWindowsUpdateAttempts("Mozilla Firefox", "", "")
+	// Without a packageID, behavior is unchanged: --name is tried first.
+	if !argsHave(attempts[0], "--name", "Mozilla Firefox") {
+		t.Fatalf("expected first attempt to select --name when no packageID, got %v", attempts[0].args)
+	}
+	for _, a := range attempts {
+		if argsHave(a, "--id", "Mozilla.Firefox") {
+			t.Fatal("did not expect a packageID attempt when none was supplied")
+		}
+	}
+}
+
 func TestValidateSoftwarePackageID(t *testing.T) {
 	t.Parallel()
 	// Empty is allowed (the field is optional).

--- a/agent/internal/remote/tools/software_update_test.go
+++ b/agent/internal/remote/tools/software_update_test.go
@@ -61,3 +61,34 @@ func TestUpdateSoftwareUnsupportedVersionFormat(t *testing.T) {
 		t.Fatalf("expected failed status for unsafe version, got %s", result.Status)
 	}
 }
+
+func TestUpdateSoftwareRejectsUnsafePackageID(t *testing.T) {
+	t.Parallel()
+	result := UpdateSoftware(map[string]any{"name": "Firefox", "packageId": "Mozilla.Firefox;rm -rf /"})
+	if result.Status != "failed" {
+		t.Fatalf("expected failed status for unsafe packageId, got %s", result.Status)
+	}
+	if !strings.Contains(result.Error, "packageId contains unsafe characters") {
+		t.Fatalf("expected packageId validation error, got %q", result.Error)
+	}
+}
+
+func TestValidateSoftwarePackageID(t *testing.T) {
+	t.Parallel()
+	// Empty is allowed (the field is optional).
+	if err := validateSoftwarePackageID(""); err != nil {
+		t.Fatalf("expected empty packageId to be allowed, got %v", err)
+	}
+	// Canonical winget identifiers pass.
+	for _, ok := range []string{"Mozilla.Firefox", "Google.Chrome", "7zip.7zip", "Microsoft.VisualStudioCode"} {
+		if err := validateSoftwarePackageID(ok); err != nil {
+			t.Fatalf("expected %q to be valid, got %v", ok, err)
+		}
+	}
+	// Shell metacharacters / spaces / leading dash are rejected.
+	for _, bad := range []string{"Mozilla Firefox", "Foo;bar", "-rf", "a/b", "x$y"} {
+		if err := validateSoftwarePackageID(bad); err == nil {
+			t.Fatalf("expected %q to be rejected", bad)
+		}
+	}
+}

--- a/apps/api/src/routes/devices/software.ts
+++ b/apps/api/src/routes/devices/software.ts
@@ -6,6 +6,7 @@ import { softwareInventory, patches, devicePatches } from '../../db/schema';
 import { authMiddleware, requirePermission, requireScope } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
 import { resolvePatchConfigForDevice } from '../../services/featureConfigResolver';
+import { captureException } from '../../services/sentry';
 import { getPagination, getDeviceWithOrgAndSiteCheck, SITE_ACCESS_DENIED } from './helpers';
 import { softwareQuerySchema } from './schemas';
 import { buildUpdateIndex, annotateSoftwareRow } from './softwareUpdateMatch';
@@ -50,47 +51,64 @@ softwareRoutes.get(
       .where(whereCondition);
     const total = Number(countResult[0]?.count ?? 0);
 
-    // Get software list, plus the available third-party updates the agent
-    // already reports through the patch pipeline and the device's patch policy
-    // (to tell the UI whether third-party updates are policy-managed).
-    const [software, updateRows, patchPolicy] = await Promise.all([
-      db
-        .select()
-        .from(softwareInventory)
-        .where(whereCondition)
-        .orderBy(asc(softwareInventory.name))
-        .limit(limit)
-        .offset(offset),
-      db
-        .select({
-          title: patches.title,
-          packageId: patches.packageId,
-          version: patches.version,
-          source: patches.source,
-        })
-        .from(devicePatches)
-        .innerJoin(patches, eq(devicePatches.patchId, patches.id))
-        .where(
-          and(
-            eq(devicePatches.deviceId, deviceId),
-            eq(devicePatches.status, 'pending'),
-            eq(patches.source, 'third_party')
-          )
-        ),
-      resolvePatchConfigForDevice(deviceId),
-    ]);
+    // The core software list is the load-bearing data and is fetched on its
+    // own so it can never be taken down by the optional update annotation.
+    const software = await db
+      .select()
+      .from(softwareInventory)
+      .where(whereCondition)
+      .orderBy(asc(softwareInventory.name))
+      .limit(limit)
+      .offset(offset);
 
-    const updateIndex = buildUpdateIndex(updateRows);
-    const data = software.map((row) => ({
-      ...row,
-      ...annotateSoftwareRow(row, updateIndex),
-    }));
+    // Best-effort: annotate each row with the available third-party updates the
+    // agent already reports through the patch pipeline, plus whether the device's
+    // patch policy manages third-party updates. This is additive UI sugar (an
+    // Update-button gate + a nudge banner), so a failure in the patch/policy
+    // subsystem degrades to an unannotated list rather than 500-ing a request
+    // whose primary job is "show me what's installed". Mirrors the graceful
+    // degradation pattern used for remote-access policy resolution in core.ts.
+    let data: Array<Record<string, unknown>> = software;
+    let thirdPartyUpdatesManaged = false;
+    try {
+      const [updateRows, patchPolicy] = await Promise.all([
+        db
+          .select({
+            title: patches.title,
+            packageId: patches.packageId,
+            version: patches.version,
+            source: patches.source,
+          })
+          .from(devicePatches)
+          .innerJoin(patches, eq(devicePatches.patchId, patches.id))
+          .where(
+            and(
+              eq(devicePatches.deviceId, deviceId),
+              eq(devicePatches.status, 'pending'),
+              eq(patches.source, 'third_party')
+            )
+          ),
+        resolvePatchConfigForDevice(deviceId),
+      ]);
 
-    // A patch policy whose `sources` includes 'third_party' means these updates
-    // are managed (eligible for policy-driven jobs/auto-approve). The per-row
-    // manual Update button stays available regardless — it's an admin escape
-    // hatch — but the UI uses this to nudge toward policy management.
-    const thirdPartyUpdatesManaged = !!patchPolicy?.sources?.includes('third_party');
+      const updateIndex = buildUpdateIndex(updateRows);
+      data = software.map((row) => ({
+        ...row,
+        ...annotateSoftwareRow(row, updateIndex),
+      }));
+
+      // A patch policy whose `sources` includes 'third_party' means these updates
+      // are managed (eligible for policy-driven jobs/auto-approve). This only
+      // drives the nudge banner; the per-row manual Update button is gated on
+      // actual update availability, not on policy-managed state.
+      thirdPartyUpdatesManaged = !!patchPolicy?.sources?.includes('third_party');
+    } catch (err) {
+      captureException(err, c);
+      console.error(
+        `[Software] update annotation failed for device ${deviceId}; serving unannotated list:`,
+        err
+      );
+    }
 
     return c.json({
       data,

--- a/apps/api/src/routes/devices/software.ts
+++ b/apps/api/src/routes/devices/software.ts
@@ -2,11 +2,13 @@ import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { and, eq, like, sql, asc } from 'drizzle-orm';
 import { db } from '../../db';
-import { softwareInventory } from '../../db/schema';
+import { softwareInventory, patches, devicePatches } from '../../db/schema';
 import { authMiddleware, requirePermission, requireScope } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
+import { resolvePatchConfigForDevice } from '../../services/featureConfigResolver';
 import { getPagination, getDeviceWithOrgAndSiteCheck, SITE_ACCESS_DENIED } from './helpers';
 import { softwareQuerySchema } from './schemas';
+import { buildUpdateIndex, annotateSoftwareRow } from './softwareUpdateMatch';
 
 export const softwareRoutes = new Hono();
 
@@ -48,17 +50,51 @@ softwareRoutes.get(
       .where(whereCondition);
     const total = Number(countResult[0]?.count ?? 0);
 
-    // Get software list
-    const software = await db
-      .select()
-      .from(softwareInventory)
-      .where(whereCondition)
-      .orderBy(asc(softwareInventory.name))
-      .limit(limit)
-      .offset(offset);
+    // Get software list, plus the available third-party updates the agent
+    // already reports through the patch pipeline and the device's patch policy
+    // (to tell the UI whether third-party updates are policy-managed).
+    const [software, updateRows, patchPolicy] = await Promise.all([
+      db
+        .select()
+        .from(softwareInventory)
+        .where(whereCondition)
+        .orderBy(asc(softwareInventory.name))
+        .limit(limit)
+        .offset(offset),
+      db
+        .select({
+          title: patches.title,
+          packageId: patches.packageId,
+          version: patches.version,
+          source: patches.source,
+        })
+        .from(devicePatches)
+        .innerJoin(patches, eq(devicePatches.patchId, patches.id))
+        .where(
+          and(
+            eq(devicePatches.deviceId, deviceId),
+            eq(devicePatches.status, 'pending'),
+            eq(patches.source, 'third_party')
+          )
+        ),
+      resolvePatchConfigForDevice(deviceId),
+    ]);
+
+    const updateIndex = buildUpdateIndex(updateRows);
+    const data = software.map((row) => ({
+      ...row,
+      ...annotateSoftwareRow(row, updateIndex),
+    }));
+
+    // A patch policy whose `sources` includes 'third_party' means these updates
+    // are managed (eligible for policy-driven jobs/auto-approve). The per-row
+    // manual Update button stays available regardless — it's an admin escape
+    // hatch — but the UI uses this to nudge toward policy management.
+    const thirdPartyUpdatesManaged = !!patchPolicy?.sources?.includes('third_party');
 
     return c.json({
-      data: software,
+      data,
+      thirdPartyUpdatesManaged,
       pagination: { page, limit, total }
     });
   }

--- a/apps/api/src/routes/devices/softwareActions.test.ts
+++ b/apps/api/src/routes/devices/softwareActions.test.ts
@@ -155,6 +155,73 @@ describe('device software actions routes', () => {
       );
     });
 
+    it('passes a winget packageId through to the agent payload on Windows', async () => {
+      (getDeviceWithOrgCheck as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'device-1',
+        orgId: 'org-123',
+        siteId: null,
+        hostname: 'host-1',
+        status: 'online',
+        osType: 'windows',
+      });
+      queueCommandForExecutionMock.mockResolvedValue({
+        command: { id: 'cmd-pkg', status: 'pending' },
+      });
+
+      const res = await app.request('/devices/device-1/software/update', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Mozilla Firefox', packageId: 'Mozilla.Firefox' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(queueCommandForExecutionMock).toHaveBeenCalledWith(
+        'device-1',
+        'software_update',
+        { name: 'Mozilla Firefox', packageId: 'Mozilla.Firefox', source: 'device_software_tab' },
+        expect.objectContaining({ userId: 'user-123' })
+      );
+    });
+
+    it('does not forward packageId on a non-Windows device', async () => {
+      (getDeviceWithOrgCheck as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'device-1',
+        orgId: 'org-123',
+        siteId: null,
+        hostname: 'host-1',
+        status: 'online',
+        osType: 'macos',
+      });
+      queueCommandForExecutionMock.mockResolvedValue({
+        command: { id: 'cmd-pkg2', status: 'sent' },
+      });
+
+      const res = await app.request('/devices/device-1/software/update', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Mozilla Firefox', packageId: 'Mozilla.Firefox' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(queueCommandForExecutionMock).toHaveBeenCalledWith(
+        'device-1',
+        'software_update',
+        { name: 'Mozilla Firefox', source: 'device_software_tab' },
+        expect.objectContaining({ userId: 'user-123' })
+      );
+    });
+
+    it('rejects a malformed packageId before queueing', async () => {
+      const res = await app.request('/devices/device-1/software/update', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Firefox', packageId: 'Mozilla.Firefox;rm -rf /' }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(queueCommandForExecutionMock).not.toHaveBeenCalled();
+    });
+
     it.each(['macos', 'linux'])(
       'rejects a version pin with 422 on a %s device (agent ignores it)',
       async (osType) => {

--- a/apps/api/src/routes/devices/softwareActions.ts
+++ b/apps/api/src/routes/devices/softwareActions.ts
@@ -49,6 +49,15 @@ const softwareActionPayloadSchema = z
         { message: 'version contains unsafe characters' }
       )
       .optional(),
+    // Optional winget package identifier (e.g. "Mozilla.Firefox"). When the
+    // Software tab has correlated the row to an available third-party update it
+    // sends the winget Id so the agent can upgrade by `--id` (reliable) instead
+    // of guessing from the display name. Matches the agent's validWingetPkgID.
+    packageId: z
+      .string()
+      .max(256, 'packageId exceeds 256 characters')
+      .regex(/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/, { message: 'packageId contains invalid characters' })
+      .optional(),
   })
   .strict();
 
@@ -89,6 +98,7 @@ softwareActionsRoutes.post(
 
     const payload: Record<string, unknown> = { name: data.name, source: 'device_software_tab' };
     if (data.version) payload.version = data.version;
+    if (data.packageId) payload.packageId = data.packageId;
 
     const queued = await queueCommandForExecution(deviceId, CommandTypes.SOFTWARE_UPDATE, payload, {
       userId: auth.user.id,

--- a/apps/api/src/routes/devices/softwareActions.ts
+++ b/apps/api/src/routes/devices/softwareActions.ts
@@ -98,7 +98,11 @@ softwareActionsRoutes.post(
 
     const payload: Record<string, unknown> = { name: data.name, source: 'device_software_tab' };
     if (data.version) payload.version = data.version;
-    if (data.packageId) payload.packageId = data.packageId;
+    // packageId drives winget's `--id` upgrade and is meaningless to the macOS /
+    // Linux agent paths (which upgrade by name). Forward it only on Windows so a
+    // stray id can never reach a non-winget package manager — consistent with the
+    // Windows-only version-pin gate above.
+    if (data.packageId && device.osType === 'windows') payload.packageId = data.packageId;
 
     const queued = await queueCommandForExecution(deviceId, CommandTypes.SOFTWARE_UPDATE, payload, {
       userId: auth.user.id,

--- a/apps/api/src/routes/devices/softwareUpdateMatch.test.ts
+++ b/apps/api/src/routes/devices/softwareUpdateMatch.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeSoftwareName,
+  buildUpdateIndex,
+  annotateSoftwareRow,
+} from './softwareUpdateMatch';
+
+describe('normalizeSoftwareName', () => {
+  it('lowercases, strips parenthetical qualifiers and bitness, collapses spaces', () => {
+    expect(normalizeSoftwareName('Adobe Acrobat (64-bit)')).toBe('adobe acrobat');
+    expect(normalizeSoftwareName('Mozilla Firefox (x64 en-US)')).toBe('mozilla firefox');
+    expect(normalizeSoftwareName('7-Zip 24.07 (x64)')).toBe('7 zip 24 07');
+    expect(normalizeSoftwareName('Google Chrome™')).toBe('google chrome');
+  });
+
+  it('returns empty string for nullish input', () => {
+    expect(normalizeSoftwareName(undefined)).toBe('');
+    expect(normalizeSoftwareName(null)).toBe('');
+    expect(normalizeSoftwareName('')).toBe('');
+  });
+
+  it('matches the same package reported with different qualifiers', () => {
+    expect(normalizeSoftwareName('Mozilla Firefox (x64 en-US)')).toBe(
+      normalizeSoftwareName('Mozilla Firefox')
+    );
+  });
+});
+
+const patch = (title: string, version: string | null, packageId: string | null = null) => ({
+  title,
+  version,
+  packageId,
+  source: 'third_party',
+});
+
+describe('buildUpdateIndex', () => {
+  it('keys updates by normalized name', () => {
+    const index = buildUpdateIndex([patch('Mozilla Firefox', '130.0', 'Mozilla.Firefox')]);
+    expect(index.get('mozilla firefox')).toMatchObject({
+      availableVersion: '130.0',
+      packageId: 'Mozilla.Firefox',
+      source: 'third_party',
+    });
+  });
+
+  it('keeps the first entry when two updates normalize to the same name', () => {
+    const index = buildUpdateIndex([
+      patch('Mozilla Firefox', '130.0', 'Mozilla.Firefox'),
+      patch('Mozilla Firefox (x64 en-US)', '131.0', 'Mozilla.FirefoxESR'),
+    ]);
+    expect(index.size).toBe(1);
+    expect(index.get('mozilla firefox')?.availableVersion).toBe('130.0');
+  });
+
+  it('skips entries with unnormalizable titles', () => {
+    const index = buildUpdateIndex([patch('', '1.0')]);
+    expect(index.size).toBe(0);
+  });
+});
+
+describe('annotateSoftwareRow', () => {
+  const index = buildUpdateIndex([
+    patch('Mozilla Firefox', '130.0', 'Mozilla.Firefox'),
+    patch('Adobe Acrobat', '25.002', 'Adobe.Acrobat'),
+  ]);
+
+  it('flags a row that matches an available update by normalized name', () => {
+    const result = annotateSoftwareRow(
+      { name: 'Mozilla Firefox (x64 en-US)', version: '128.0' },
+      index
+    );
+    expect(result).toEqual({
+      updateAvailable: true,
+      availableVersion: '130.0',
+      updatePackageId: 'Mozilla.Firefox',
+      updateSource: 'third_party',
+    });
+  });
+
+  it('returns no-update for a row with no matching update', () => {
+    const result = annotateSoftwareRow({ name: 'Some Random App', version: '1.0' }, index);
+    expect(result.updateAvailable).toBe(false);
+    expect(result.updatePackageId).toBeNull();
+  });
+
+  it('does not flag an update when the available version equals the installed version', () => {
+    const result = annotateSoftwareRow(
+      { name: 'Adobe Acrobat (64-bit)', version: '25.002' },
+      index
+    );
+    expect(result.updateAvailable).toBe(false);
+  });
+
+  it('flags an update when versions differ even after whitespace', () => {
+    const result = annotateSoftwareRow({ name: 'Adobe Acrobat', version: ' 24.001 ' }, index);
+    expect(result.updateAvailable).toBe(true);
+    expect(result.availableVersion).toBe('25.002');
+  });
+});

--- a/apps/api/src/routes/devices/softwareUpdateMatch.test.ts
+++ b/apps/api/src/routes/devices/softwareUpdateMatch.test.ts
@@ -30,7 +30,7 @@ const patch = (title: string, version: string | null, packageId: string | null =
   title,
   version,
   packageId,
-  source: 'third_party',
+  source: 'third_party' as const,
 });
 
 describe('buildUpdateIndex', () => {
@@ -43,13 +43,23 @@ describe('buildUpdateIndex', () => {
     });
   });
 
-  it('keeps the first entry when two updates normalize to the same name', () => {
+  it('keeps the first entry when the same package is reported twice', () => {
     const index = buildUpdateIndex([
       patch('Mozilla Firefox', '130.0', 'Mozilla.Firefox'),
-      patch('Mozilla Firefox (x64 en-US)', '131.0', 'Mozilla.FirefoxESR'),
+      patch('Mozilla Firefox (x64 en-US)', '131.0', 'Mozilla.Firefox'),
     ]);
     expect(index.size).toBe(1);
     expect(index.get('mozilla firefox')?.availableVersion).toBe('130.0');
+  });
+
+  it('drops an ambiguous name shared by two different packages (x64 + x86)', () => {
+    const index = buildUpdateIndex([
+      patch('Microsoft Visual C++ 2015-2022 Redistributable (x64)', '14.40', 'Microsoft.VCRedist.2015+.x64'),
+      patch('Microsoft Visual C++ 2015-2022 Redistributable (x86)', '14.40', 'Microsoft.VCRedist.2015+.x86'),
+    ]);
+    // Both normalize to the same key but point at different packages — neither
+    // wins, so no inventory row gets a wrong-architecture update.
+    expect(index.size).toBe(0);
   });
 
   it('skips entries with unnormalizable titles', () => {

--- a/apps/api/src/routes/devices/softwareUpdateMatch.ts
+++ b/apps/api/src/routes/devices/softwareUpdateMatch.ts
@@ -1,29 +1,43 @@
+import { patchSourceEnum } from '../../db/schema';
+
+/** A patch `source` bucket as constrained by the DB enum. */
+export type PatchSource = (typeof patchSourceEnum.enumValues)[number];
+
 /**
  * Correlates installed-software inventory rows with the available third-party
  * updates that the agent already reports through the patch pipeline.
  *
- * The agent's WingetProvider runs `winget upgrade` and submits each available
- * upgrade as a patch with `source='third_party'`, `packageId=<winget Id>` and
- * `version=<available version>` (see agent heartbeat.go availablePatchesToMaps +
- * mapPatchProviderSource). Those land in `patches`/`device_patches` and already
- * power the Patches tab. This module joins that same data back onto the Software
- * tab so the per-row "Update" button can be gated on a *real* available update
- * instead of firing a blind `winget upgrade` that silently no-ops.
+ * The agent submits each available upgrade as a patch with `source='third_party'`,
+ * `packageId=<provider id>` and `version=<available version>` (see agent
+ * heartbeat.go availablePatchesToMaps + mapPatchProviderSource). Those land in
+ * `patches`/`device_patches` and already power the Patches tab. This module joins
+ * that same data back onto the Software tab so the per-row "Update" button can be
+ * gated on a *real* available update instead of firing a blind upgrade that
+ * silently no-ops.
  *
- * Matching is by normalized name. `winget upgrade`'s Name column is derived from
- * the installed (ARP) package, so it usually equals the registry DisplayName we
- * store as `software_inventory.name` — exact-normalized equality is the common
- * case. We deliberately avoid fuzzy substring matching to keep false positives
- * (which would re-introduce the "button does nothing" problem) out.
+ * The `third_party` bucket spans providers: winget on Windows, and Homebrew /
+ * Chocolatey elsewhere — so this matching is intentionally source-agnostic and
+ * runs for macOS rows too (Homebrew). The route caller is responsible for not
+ * forwarding a non-winget packageId (e.g. Homebrew's "homebrew:cask:foo", which
+ * contains colons) to the winget-only `--id` update path.
+ *
+ * Matching is by normalized name. The provider's reported Name is derived from
+ * the installed package, so it usually equals the display name we store as
+ * `software_inventory.name` — exact-normalized equality is the common case. We
+ * deliberately avoid fuzzy substring matching to keep false positives (which
+ * would re-introduce the "button does nothing" problem) out. Dual-architecture
+ * packages whose names collide after normalization (most notably the Visual C++
+ * redistributables, x64 + x86 side by side) are dropped as ambiguous rather than
+ * annotated with a guessed architecture — see `buildUpdateIndex`.
  */
 
 export interface AvailableUpdate {
-  /** Winget package identifier, e.g. "Mozilla.Firefox". Used to upgrade by --id. */
+  /** Provider package identifier, e.g. "Mozilla.Firefox" (winget). Used to upgrade by --id. */
   packageId: string | null;
   /** Target version the update would install. */
   availableVersion: string | null;
-  /** Provider bucket the update came from (currently always winget on Windows). */
-  source: string;
+  /** Patch source bucket — always 'third_party' here (winget / Homebrew / Chocolatey). */
+  source: PatchSource;
   /** Normalized patch title used for matching. */
   normalizedName: string;
 }
@@ -32,7 +46,7 @@ export interface SoftwareUpdateAnnotation {
   updateAvailable: boolean;
   availableVersion: string | null;
   updatePackageId: string | null;
-  updateSource: string | null;
+  updateSource: PatchSource | null;
 }
 
 const NO_UPDATE: SoftwareUpdateAnnotation = {
@@ -46,6 +60,13 @@ const NO_UPDATE: SoftwareUpdateAnnotation = {
  * Normalize a software/package name for cross-source matching. Lowercases,
  * strips parenthetical qualifiers (architecture/locale like "(x64 en-US)"),
  * drops trademark glyphs and bitness tokens, then collapses to single spaces.
+ *
+ * Bitness is intentionally stripped: a provider's reported Name is inconsistent
+ * about it (winget says "Mozilla Firefox" while the registry DisplayName is
+ * "Mozilla Firefox (x64 en-US)"), so keeping it would break the common case.
+ * The dual-architecture collision it creates (e.g. the x64 and x86 Visual C++
+ * redistributables both normalizing to one key) is instead handled in
+ * `buildUpdateIndex`, which drops ambiguous keys rather than guess an arch.
  */
 export function normalizeSoftwareName(name: string | null | undefined): string {
   if (!name) return '';
@@ -53,7 +74,7 @@ export function normalizeSoftwareName(name: string | null | undefined): string {
     .toLowerCase()
     .replace(/\([^)]*\)/g, ' ') // drop "(x64 en-US)" style qualifiers
     .replace(/[®™©]/g, ' ')
-    .replace(/\b(?:x64|x86|amd64|arm64|64[\s-]?bit|32[\s-]?bit)\b/g, ' ')
+    .replace(/\b(?:x64|x86|amd64|arm64|aarch64|64[\s-]?bit|32[\s-]?bit)\b/g, ' ')
     .replace(/[^a-z0-9]+/g, ' ')
     .trim()
     .replace(/\s+/g, ' ');
@@ -61,17 +82,28 @@ export function normalizeSoftwareName(name: string | null | undefined): string {
 
 /**
  * Build a name → update index from the device's pending third-party patches.
- * When several updates normalize to the same name, the first one wins (the
- * scan rarely produces dupes; if it does, either is a valid upgrade target).
+ *
+ * If two patches normalize to the same name but point at *different* packages
+ * (different packageId), the name is ambiguous — typically the x64 and x86 builds
+ * of the same product — and is dropped entirely, so neither inventory row gets a
+ * wrong-architecture annotation. Repeated entries for the *same* package (same
+ * packageId, e.g. a duplicated scan row) are harmless and keep the first.
  */
 export function buildUpdateIndex(
-  patches: Array<{ title: string; packageId: string | null; version: string | null; source: string }>
+  patches: Array<{ title: string; packageId: string | null; version: string | null; source: PatchSource }>
 ): Map<string, AvailableUpdate> {
   const index = new Map<string, AvailableUpdate>();
+  const ambiguous = new Set<string>();
   for (const patch of patches) {
     const normalizedName = normalizeSoftwareName(patch.title);
     if (!normalizedName) continue;
-    if (index.has(normalizedName)) continue;
+    const existing = index.get(normalizedName);
+    if (existing) {
+      if ((existing.packageId ?? '') !== (patch.packageId ?? '')) {
+        ambiguous.add(normalizedName);
+      }
+      continue;
+    }
     index.set(normalizedName, {
       packageId: patch.packageId,
       availableVersion: patch.version,
@@ -79,6 +111,7 @@ export function buildUpdateIndex(
       normalizedName,
     });
   }
+  for (const name of ambiguous) index.delete(name);
   return index;
 }
 

--- a/apps/api/src/routes/devices/softwareUpdateMatch.ts
+++ b/apps/api/src/routes/devices/softwareUpdateMatch.ts
@@ -1,0 +1,113 @@
+/**
+ * Correlates installed-software inventory rows with the available third-party
+ * updates that the agent already reports through the patch pipeline.
+ *
+ * The agent's WingetProvider runs `winget upgrade` and submits each available
+ * upgrade as a patch with `source='third_party'`, `packageId=<winget Id>` and
+ * `version=<available version>` (see agent heartbeat.go availablePatchesToMaps +
+ * mapPatchProviderSource). Those land in `patches`/`device_patches` and already
+ * power the Patches tab. This module joins that same data back onto the Software
+ * tab so the per-row "Update" button can be gated on a *real* available update
+ * instead of firing a blind `winget upgrade` that silently no-ops.
+ *
+ * Matching is by normalized name. `winget upgrade`'s Name column is derived from
+ * the installed (ARP) package, so it usually equals the registry DisplayName we
+ * store as `software_inventory.name` — exact-normalized equality is the common
+ * case. We deliberately avoid fuzzy substring matching to keep false positives
+ * (which would re-introduce the "button does nothing" problem) out.
+ */
+
+export interface AvailableUpdate {
+  /** Winget package identifier, e.g. "Mozilla.Firefox". Used to upgrade by --id. */
+  packageId: string | null;
+  /** Target version the update would install. */
+  availableVersion: string | null;
+  /** Provider bucket the update came from (currently always winget on Windows). */
+  source: string;
+  /** Normalized patch title used for matching. */
+  normalizedName: string;
+}
+
+export interface SoftwareUpdateAnnotation {
+  updateAvailable: boolean;
+  availableVersion: string | null;
+  updatePackageId: string | null;
+  updateSource: string | null;
+}
+
+const NO_UPDATE: SoftwareUpdateAnnotation = {
+  updateAvailable: false,
+  availableVersion: null,
+  updatePackageId: null,
+  updateSource: null,
+};
+
+/**
+ * Normalize a software/package name for cross-source matching. Lowercases,
+ * strips parenthetical qualifiers (architecture/locale like "(x64 en-US)"),
+ * drops trademark glyphs and bitness tokens, then collapses to single spaces.
+ */
+export function normalizeSoftwareName(name: string | null | undefined): string {
+  if (!name) return '';
+  return name
+    .toLowerCase()
+    .replace(/\([^)]*\)/g, ' ') // drop "(x64 en-US)" style qualifiers
+    .replace(/[®™©]/g, ' ')
+    .replace(/\b(?:x64|x86|amd64|arm64|64[\s-]?bit|32[\s-]?bit)\b/g, ' ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+/**
+ * Build a name → update index from the device's pending third-party patches.
+ * When several updates normalize to the same name, the first one wins (the
+ * scan rarely produces dupes; if it does, either is a valid upgrade target).
+ */
+export function buildUpdateIndex(
+  patches: Array<{ title: string; packageId: string | null; version: string | null; source: string }>
+): Map<string, AvailableUpdate> {
+  const index = new Map<string, AvailableUpdate>();
+  for (const patch of patches) {
+    const normalizedName = normalizeSoftwareName(patch.title);
+    if (!normalizedName) continue;
+    if (index.has(normalizedName)) continue;
+    index.set(normalizedName, {
+      packageId: patch.packageId,
+      availableVersion: patch.version,
+      source: patch.source,
+      normalizedName,
+    });
+  }
+  return index;
+}
+
+/**
+ * Resolve the update annotation for a single installed-software row. Returns a
+ * no-update annotation unless a third-party update matches by normalized name
+ * AND the target version actually differs from what's installed (guards against
+ * a stale patch row that's already at the installed version).
+ */
+export function annotateSoftwareRow(
+  row: { name: string | null; version: string | null },
+  index: Map<string, AvailableUpdate>
+): SoftwareUpdateAnnotation {
+  const match = index.get(normalizeSoftwareName(row.name));
+  if (!match) return NO_UPDATE;
+
+  // If we know both versions and they're equal, there's nothing to do.
+  if (
+    match.availableVersion &&
+    row.version &&
+    match.availableVersion.trim() === row.version.trim()
+  ) {
+    return NO_UPDATE;
+  }
+
+  return {
+    updateAvailable: true,
+    availableVersion: match.availableVersion,
+    updatePackageId: match.packageId,
+    updateSource: match.source,
+  };
+}

--- a/apps/web/src/components/devices/DeviceSoftwareInventory.test.tsx
+++ b/apps/web/src/components/devices/DeviceSoftwareInventory.test.tsx
@@ -27,6 +27,7 @@ const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500):
 const deviceId = '11111111-1111-1111-1111-111111111111';
 
 const SOFTWARE_FIXTURE = {
+  thirdPartyUpdatesManaged: false,
   data: [
     {
       id: 'sw-chrome',
@@ -34,6 +35,10 @@ const SOFTWARE_FIXTURE = {
       version: '125.0.6422.142',
       publisher: 'Google LLC',
       installDate: '2026-02-01',
+      updateAvailable: true,
+      availableVersion: '131.0.6778.86',
+      updatePackageId: 'Google.Chrome',
+      updateSource: 'third_party',
     },
     {
       id: 'sw-safari',
@@ -41,6 +46,14 @@ const SOFTWARE_FIXTURE = {
       version: '17.5',
       publisher: 'Apple Inc.',
       installDate: '2026-01-01',
+    },
+    {
+      // Windows row with no known update — the Update button must be disabled.
+      id: 'sw-noupdate',
+      name: 'Legacy Tool',
+      version: '1.0.0',
+      publisher: 'Acme Corp',
+      installDate: '2024-05-01',
     },
   ],
 };
@@ -88,16 +101,47 @@ describe('DeviceSoftwareInventory action buttons', () => {
         `/devices/${deviceId}/software/update`,
         expect.objectContaining({
           method: 'POST',
-          body: JSON.stringify({ name: 'Google Chrome', version: '125.0.6422.142' }),
+          // Updates send the winget packageId (not a pinned version) so the
+          // agent upgrades by --id to the latest available.
+          body: JSON.stringify({ name: 'Google Chrome', packageId: 'Google.Chrome' }),
         })
       );
     });
 
     await waitFor(() => {
       expect(showToastMock).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'success', message: expect.stringContaining('Update queued') })
+        expect.objectContaining({
+          type: 'success',
+          message: expect.stringContaining('Update to 131.0.6778.86 queued'),
+        })
       );
     });
+  });
+
+  it('disables Update for a Windows row with no available update', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse(SOFTWARE_FIXTURE));
+
+    render(<DeviceSoftwareInventory deviceId={deviceId} osType="windows" />);
+
+    const updateBtn = await screen.findByTestId('software-update-sw-noupdate');
+    const uninstallBtn = await screen.findByTestId('software-uninstall-sw-noupdate');
+    // Uninstall stays available; Update is gated on a real available update.
+    expect(updateBtn).toBeDisabled();
+    expect(uninstallBtn).not.toBeDisabled();
+    expect(updateBtn.getAttribute('title')).toContain('No update available');
+  });
+
+  it('shows the available version delta and an updates-available banner', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse(SOFTWARE_FIXTURE));
+
+    render(<DeviceSoftwareInventory deviceId={deviceId} osType="windows" />);
+
+    // Banner reflects the single updatable row in the fixture.
+    expect(await screen.findByText(/1 update available/i)).toBeTruthy();
+    // Not policy-managed → nudge toward enabling third-party patching.
+    expect(screen.getByText(/configuration policy/i)).toBeTruthy();
+    // The Chrome row shows current → available.
+    expect(screen.getByText('131.0.6778.86')).toBeTruthy();
   });
 
   it('shows confirmation dialog for Uninstall and only POSTs after confirm', async () => {

--- a/apps/web/src/components/devices/DeviceSoftwareInventory.test.tsx
+++ b/apps/web/src/components/devices/DeviceSoftwareInventory.test.tsx
@@ -118,6 +118,44 @@ describe('DeviceSoftwareInventory action buttons', () => {
     });
   });
 
+  it('does not forward a non-winget (Homebrew) packageId; updates by name', async () => {
+    const macFixture = {
+      thirdPartyUpdatesManaged: false,
+      data: [
+        {
+          id: 'sw-brewchrome',
+          name: 'Google Chrome',
+          version: '125.0',
+          publisher: 'Google LLC',
+          installDate: '2026-02-01',
+          updateAvailable: true,
+          availableVersion: '131.0',
+          updatePackageId: 'homebrew:cask:google-chrome', // colons → must NOT be forwarded
+          updateSource: 'third_party',
+        },
+      ],
+    };
+    fetchWithAuthMock
+      .mockResolvedValueOnce(makeJsonResponse(macFixture))
+      .mockResolvedValueOnce(makeJsonResponse({ success: true, commandId: 'c', action: 'update' }));
+
+    render(<DeviceSoftwareInventory deviceId={deviceId} osType="macos" />);
+
+    const btn = await screen.findByTestId('software-update-sw-brewchrome');
+    expect(btn).not.toBeDisabled();
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        `/devices/${deviceId}/software/update`,
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ name: 'Google Chrome' }),
+        })
+      );
+    });
+  });
+
   it('disables Update for a Windows row with no available update', async () => {
     fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse(SOFTWARE_FIXTURE));
 

--- a/apps/web/src/components/devices/DeviceSoftwareInventory.tsx
+++ b/apps/web/src/components/devices/DeviceSoftwareInventory.tsx
@@ -16,6 +16,10 @@ import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
 import { showToast } from '../shared/Toast';
 
+// Mirrors the API's softwareActions packageId regex. Used to decide whether a
+// correlated update's packageId can be sent to the winget-only `--id` path.
+const WINGET_PACKAGE_ID = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+
 function isApplePublisher(publisher: string): boolean {
   const p = publisher.toLowerCase();
   return p === 'apple' || p === 'apple inc.' || p === 'apple inc' || p === 'com.apple' || p.startsWith('com.apple.');
@@ -185,9 +189,14 @@ export default function DeviceSoftwareInventory({ deviceId, timezone, osType }: 
       const verb = action === 'update' ? 'Update' : 'Uninstall';
       // Updates send the winget packageId (when known) so the agent upgrades by
       // --id, and never pin a version — we always want the latest available.
+      // Only a winget-shaped id is forwarded: the third_party patch bucket also
+      // carries Homebrew ids like "homebrew:cask:foo" whose colons the API
+      // rejects — those fall back to a name-based upgrade (which brew uses anyway).
       const body: Record<string, string> = { name };
       if (action === 'update') {
-        if (opts?.packageId) body.packageId = opts.packageId;
+        if (opts?.packageId && WINGET_PACKAGE_ID.test(opts.packageId)) {
+          body.packageId = opts.packageId;
+        }
       } else if (version) {
         body.version = version;
       }

--- a/apps/web/src/components/devices/DeviceSoftwareInventory.tsx
+++ b/apps/web/src/components/devices/DeviceSoftwareInventory.tsx
@@ -39,6 +39,13 @@ type SoftwareItem = {
   installDate?: string;
   installedAt?: string;
   install_date?: string;
+  // Available-update correlation, populated server-side from the third-party
+  // patch data the agent already reports (winget upgrade). Absent/false means
+  // no managed update is known for this row.
+  updateAvailable?: boolean;
+  availableVersion?: string | null;
+  updatePackageId?: string | null;
+  updateSource?: string | null;
 };
 
 type DeviceSoftwareInventoryProps = {
@@ -54,20 +61,38 @@ type SoftwareAction = 'update' | 'uninstall';
 // expressible to `brew upgrade`/`brew uninstall`. The agent would just
 // return "no supported update command" — better to disable upfront and
 // explain why than to queue a guaranteed-to-fail command.
-function actionsAreSupported(osType: string | undefined, isApple: boolean): {
+//
+// The Update button is *additionally* gated on `updateAvailable`: a row only
+// gets an actionable Update when the server has correlated it to a real
+// available update (from the third-party patch scan). This is what stops the
+// old "click Update, winget finds nothing, silent no-op" behavior — if no
+// update is known we disable with an explanatory tooltip instead.
+function actionsAreSupported(
+  osType: string | undefined,
+  isApple: boolean,
+  updateAvailable: boolean
+): {
   update: { allowed: boolean; reason?: string };
   uninstall: { allowed: boolean; reason?: string };
 } {
   const os = (osType || '').toLowerCase();
+  const noUpdateReason = 'No update available — this package is up to date or not tracked by a package manager.';
+
   if (os === 'macos' || os === 'darwin') {
     if (isApple) {
       const reason = 'Apple-signed apps are managed by macOS — uninstall via Settings, update via Software Update.';
       return { update: { allowed: false, reason }, uninstall: { allowed: false, reason } };
     }
-    return { update: { allowed: true }, uninstall: { allowed: true } };
+    return {
+      update: updateAvailable ? { allowed: true } : { allowed: false, reason: noUpdateReason },
+      uninstall: { allowed: true },
+    };
   }
   if (os === 'windows' || os === 'linux') {
-    return { update: { allowed: true }, uninstall: { allowed: true } };
+    return {
+      update: updateAvailable ? { allowed: true } : { allowed: false, reason: noUpdateReason },
+      uninstall: { allowed: true },
+    };
   }
   const reason = `Software actions are not supported on ${osType || 'this OS'}.`;
   return { update: { allowed: false, reason }, uninstall: { allowed: false, reason } };
@@ -96,6 +121,10 @@ export default function DeviceSoftwareInventory({ deviceId, timezone, osType }: 
   const [, setTotal] = useState(0);
   const [publisherFilter, setPublisherFilter] = useState<string>('all');
   const [typeFilter, setTypeFilter] = useState<'all' | 'apple' | 'third-party'>('all');
+  // True when a patch policy with third_party in its sources governs this
+  // device — i.e. these updates can be managed/auto-approved by policy. Drives
+  // the "manage these automatically" nudge banner.
+  const [thirdPartyManaged, setThirdPartyManaged] = useState(false);
   // Rows currently in-flight (keyed by row id) so the table can show a
   // per-row spinner and disable other actions on that row without disabling
   // the entire grid.
@@ -129,6 +158,7 @@ export default function DeviceSoftwareInventory({ deviceId, timezone, osType }: 
       const payload = json?.data ?? json;
       setSoftware(Array.isArray(payload) ? payload : []);
       setTotal(json?.pagination?.total ?? (Array.isArray(payload) ? payload.length : 0));
+      setThirdPartyManaged(json?.thirdPartyUpdatesManaged === true);
       if (json?.timezone || json?.siteTimezone) {
         setSiteTimezone(json.timezone ?? json.siteTimezone);
       }
@@ -144,18 +174,36 @@ export default function DeviceSoftwareInventory({ deviceId, timezone, osType }: 
   }, [fetchSoftware]);
 
   const queueSoftwareAction = useCallback(
-    async (rowId: string, action: SoftwareAction, name: string, version: string) => {
+    async (
+      rowId: string,
+      action: SoftwareAction,
+      name: string,
+      version: string,
+      opts?: { packageId?: string | null; availableVersion?: string | null }
+    ) => {
       setPendingActions((prev) => ({ ...prev, [rowId]: action }));
       const verb = action === 'update' ? 'Update' : 'Uninstall';
+      // Updates send the winget packageId (when known) so the agent upgrades by
+      // --id, and never pin a version — we always want the latest available.
+      const body: Record<string, string> = { name };
+      if (action === 'update') {
+        if (opts?.packageId) body.packageId = opts.packageId;
+      } else if (version) {
+        body.version = version;
+      }
+      const successMessage =
+        action === 'update' && opts?.availableVersion
+          ? `Update to ${opts.availableVersion} queued for "${name}"`
+          : `${verb} queued for "${name}"`;
       try {
         await runAction({
           request: () =>
             fetchWithAuth(`/devices/${deviceId}/software/${action}`, {
               method: 'POST',
-              body: JSON.stringify(version ? { name, version } : { name }),
+              body: JSON.stringify(body),
             }),
           errorFallback: `${verb} could not be queued`,
-          successMessage: `${verb} queued for "${name}"`,
+          successMessage,
         });
       } catch (err) {
         if (err instanceof ActionError && err.status === 401) {
@@ -189,6 +237,7 @@ export default function DeviceSoftwareInventory({ deviceId, timezone, osType }: 
     return software.map((item, index) => {
       const publisher = item.publisher ?? item.vendor ?? '-';
       const isApple = isApplePublisher(publisher);
+      const updateAvailable = item.updateAvailable === true;
       return {
         id: item.id ?? `${item.name ?? item.title ?? 'software'}-${index}`,
         name: item.name ?? item.title ?? 'Unknown software',
@@ -196,8 +245,11 @@ export default function DeviceSoftwareInventory({ deviceId, timezone, osType }: 
         rawVersion: item.version || '',
         publisher,
         isApple,
+        updateAvailable,
+        availableVersion: item.availableVersion ?? null,
+        updatePackageId: item.updatePackageId ?? null,
         installDate: formatDate(item.installDate ?? item.installedAt ?? item.install_date, effectiveTimezone),
-        capabilities: actionsAreSupported(osType, isApple),
+        capabilities: actionsAreSupported(osType, isApple, updateAvailable),
       };
     });
   }, [software, effectiveTimezone, osType]);
@@ -241,6 +293,10 @@ export default function DeviceSoftwareInventory({ deviceId, timezone, osType }: 
 
   const isMac = osType?.toLowerCase() === 'macos' || osType?.toLowerCase() === 'darwin';
   const hasActiveFilters = search || publisherFilter !== 'all' || typeFilter !== 'all';
+  const updatesAvailableCount = useMemo(
+    () => rows.filter((r) => r.updateAvailable).length,
+    [rows]
+  );
 
   if (loading) {
     return (
@@ -354,6 +410,29 @@ export default function DeviceSoftwareInventory({ deviceId, timezone, osType }: 
         )}
       </div>
 
+      {/* Available-updates summary + policy nudge */}
+      {updatesAvailableCount > 0 && (
+        <div className="mt-4 flex items-start gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-sm">
+          <ArrowUpCircle className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" />
+          <div className="text-foreground">
+            <span className="font-medium">
+              {updatesAvailableCount} update{updatesAvailableCount === 1 ? '' : 's'} available
+            </span>
+            {thirdPartyManaged ? (
+              <span className="text-muted-foreground">
+                {' '}
+                — third-party updates are policy-managed on this device.
+              </span>
+            ) : (
+              <span className="text-muted-foreground">
+                {' '}
+                — update individually below, or enable third-party patching in a configuration policy to manage these automatically.
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
       {/* Table */}
       <div className="mt-4 overflow-hidden rounded-md border">
         <div className="max-h-[500px] overflow-auto">
@@ -394,7 +473,17 @@ export default function DeviceSoftwareInventory({ deviceId, timezone, osType }: 
                           {item.name}
                         </span>
                       </td>
-                      <td className="px-4 py-3 font-mono text-xs text-muted-foreground">{item.version}</td>
+                      <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
+                        {item.updateAvailable && item.availableVersion ? (
+                          <span className="inline-flex items-center gap-1">
+                            <span>{item.version}</span>
+                            <ArrowUpCircle className="h-3 w-3 text-emerald-600" />
+                            <span className="font-semibold text-emerald-600">{item.availableVersion}</span>
+                          </span>
+                        ) : (
+                          item.version
+                        )}
+                      </td>
                       <td className="px-4 py-3 text-muted-foreground">{item.publisher}</td>
                       <td className="px-4 py-3 text-muted-foreground">{item.installDate}</td>
                       <td className="px-4 py-3 text-right">
@@ -404,7 +493,12 @@ export default function DeviceSoftwareInventory({ deviceId, timezone, osType }: 
                             data-testid={`software-update-${item.id}`}
                             disabled={!item.capabilities.update.allowed || anyPending}
                             title={item.capabilities.update.reason ?? 'Queue an update for this package'}
-                            onClick={() => queueSoftwareAction(item.id, 'update', item.name, item.rawVersion)}
+                            onClick={() =>
+                              queueSoftwareAction(item.id, 'update', item.name, item.rawVersion, {
+                                packageId: item.updatePackageId,
+                                availableVersion: item.availableVersion,
+                              })
+                            }
                             className="inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
                           >
                             {isUpdatePending ? (

--- a/docs/superpowers/specs/2026-06-07-process-level-resource-drilldown-design.md
+++ b/docs/superpowers/specs/2026-06-07-process-level-resource-drilldown-design.md
@@ -1,0 +1,204 @@
+# Process-Level Resource Drill-Down — Design
+
+**Date:** 2026-06-07
+**Status:** Approved (brainstorm) — ready for implementation plan
+**Author:** Todd Hebebrand (with Claude)
+
+## Problem / Feature Request
+
+On a device's Performance screen you can see aggregate resource usage (CPU %, RAM %,
+disk, network) over time, but you cannot see **which processes** are responsible for
+that usage. When RAM is at 70% or CPU spikes, the operator wants to drill down and see
+the top processes consuming that resource — including the ability to scrub **back in
+time** to a past spike and see what caused it. This is a familiar and heavily-used
+capability for operators coming from N-Central.
+
+## Goals
+
+- From the device Performance screen, click a point on the CPU/RAM chart and see the
+  **top processes at that moment**, sortable by resource.
+- Support **historical** scrubbing — not just "right now" — so past spikes can be
+  investigated after the fact.
+- Cover **CPU, RAM, disk I/O, and network** per process (phased by collection difficulty).
+- Stay affordable at **10,000+ agent** scale on DigitalOcean-managed PostgreSQL
+  (no TimescaleDB in production).
+
+## Non-Goals (this iteration)
+
+- Per-process **trend lines** over time (e.g. "chrome's memory across the whole day").
+  The point-in-time snapshot model does not serve this well; it would require the
+  normalized storage approach (Approach B, rejected below).
+- Spike-triggered extra capture (listed as a future option).
+- Changing the existing aggregate `deviceMetrics` pipeline.
+
+## Key Decisions (from brainstorm)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Time window | **Historical** drill-down (scrub to past spikes), not live-only | Core operator need: investigate spikes after the fact |
+| Resources | CPU, RAM, **disk I/O, network** | Full parity with N-Central; phased by difficulty |
+| UI entry point | **Click the chart/gauge** on the Performance tab | Keeps drill-down contextual to the resource clicked |
+| Storage | **Approach A** — snapshot table, decoupled sampler cadence | ~1 row/device/sample; matches point-in-time UI; cheap at scale |
+
+## Current State (what already exists)
+
+- **Agent** (`agent/`, *not* `apps/agent/`) already enumerates processes on demand via
+  WebSocket commands `list_processes` / `get_process` / `kill_process` using gopsutil v3
+  (`agent/internal/remote/tools/processes.go`, `ListProcesses()`). Returns per-process
+  `PID, Name, User, CPUPercent, MemoryMB` (plus detail fields on demand). gopsutil
+  `process` sub-package already imported.
+- **Metrics collection**: `agent/internal/collectors/metrics.go` (`SystemMetrics`,
+  `MetricsCollector.Collect()`) gathers aggregate CPU/RAM/disk/network + an aggregate
+  `ProcessCount`, sent on the heartbeat (default 60s) to `POST /agents/:id/heartbeat`.
+- **DB**: `deviceMetrics` (`apps/api/src/db/schema/devices.ts`) stores aggregate
+  time-series; only `processCount` (count, no breakdown).
+- **API**: `GET /devices/:id/metrics` (`apps/api/src/routes/devices/metrics.ts`) serves
+  bucketed history; `GET /devices/:id/processes`
+  (`apps/api/src/routes/systemTools/processes.ts`) serves the live, on-demand list.
+- **Web**: `DeviceDetails.tsx` (tab-based, hash state) → Performance tab renders
+  `DevicePerformanceGraphs.tsx` (Recharts line/area charts, fetch-on-mount, no live
+  poll). Reusable `ProcessManager.tsx` table (sort/filter/search/kill) and `Dialog.tsx`
+  drawer/modal exist.
+
+**The gap:** process data and the performance charts are not connected, and no
+per-process data is stored historically.
+
+## Architecture
+
+A new **process-sample pipeline** runs alongside (not inside) the 60s heartbeat:
+
+```
+Agent process-sampler ticker (default ~180s)
+  → build top-N process snapshot (CPU/RAM in Phase 1; disk, net later)
+  → POST /agents/:id/process-sample   (agentAuth bearer; org_id derived server-side)
+  → INSERT into device_process_samples (1 row/device/sample, JSONB array of processes)
+
+Web Performance tab → click a point on the CPU/RAM chart
+  → GET /devices/:id/process-samples?at=<ts>   (nearest snapshot)
+  → drill-down panel: sortable process table + time scrubber synced to chart range
+```
+
+The existing `deviceMetrics` (incl. `processCount`) is unchanged; this work is purely
+additive.
+
+### Component boundaries
+
+- **Agent process sampler** — owns: building the periodic top-N snapshot and POSTing it.
+  Depends on the existing `ListProcesses` collection logic. Testable via the top-N
+  selector unit and per-OS collector interfaces (fakes for disk/net).
+- **Ingest route** — owns: validating + persisting a snapshot. Depends on `agentAuth`
+  and the device record (for `org_id`). No business logic beyond validation/insert.
+- **Read route** — owns: nearest-snapshot lookup + sample-existence query. Depends on
+  RLS context. Pure read.
+- **Drill-down panel (web)** — owns: click→fetch→render, sort-by-clicked-resource, time
+  scrubber, Live toggle. Depends on the read route and (for Live) the existing
+  `GET /devices/:id/processes`.
+
+## Agent (Go)
+
+- **Reuse** `agent/internal/remote/tools/processes.go` (`ListProcesses`) for per-process
+  collection — do not write a second enumerator.
+- **Top-N selector**: union of top-N by CPU and top-N by RAM, dedupe by PID, cap at
+  ~10–12 entries. Each entry: `{name, pid, cpu, ramMb, diskBps?, netBps?}`. Disk/net
+  fields are nullable and omitted on OSes that cannot supply them.
+- **Sampler ticker**: new config `ProcessSampleIntervalSeconds`, default **180s**,
+  min 60, max 3600 — a dedicated goroutine decoupled from the heartbeat. Trade-off:
+  shorter interval catches briefer spikes but costs more storage.
+- **Send path**: `POST /agents/:id/process-sample` with `{timestamp, processes: [...]}`,
+  using the same bearer auth as the heartbeat.
+
+### Per-resource phasing (collection difficulty)
+
+1. **CPU% + RAM** — already cheap and cross-platform via gopsutil.
+2. **Disk I/O per process** — Linux `/proc/[pid]/io`; Windows IO counters; macOS
+   degrades gracefully (field omitted).
+3. **Network per process** — Linux socket→PID mapping (reuse `connections_linux.go`);
+   Windows `GetExtendedTcpTable`; macOS best-effort. Hardest/most privileged; ships last.
+
+Disk/net collectors should sit behind small interfaces so they can be faked in tests
+and so an unsupported OS cleanly returns "no data" rather than erroring.
+
+## API / DB
+
+### New table `device_process_samples`
+
+| Column | Type | Notes |
+|---|---|---|
+| `device_id` | uuid | FK → devices |
+| `org_id` | uuid | FK → organizations; **set server-side**, not from agent |
+| `timestamp` | timestamptz | sample time |
+| `top_processes` | jsonb | array of `{name, pid, cpu, ramMb, diskBps?, netBps?}` |
+
+- **PK** `(device_id, timestamp)`; index `(device_id, timestamp DESC)`.
+- **RLS shape #1** (direct `org_id`): `breeze_has_org_access(org_id)`, RLS **enabled +
+  forced + policies** created in the **same idempotent migration** that creates the
+  table (per CLAUDE.md tenancy rules). Mirrors how `deviceMetrics` is scoped.
+- Migration is idempotent (`CREATE TABLE IF NOT EXISTS`, `pg_policies` existence checks),
+  no inner `BEGIN/COMMIT`, named `2026-MM-DD-<slug>.sql`.
+- Add Drizzle definition to `apps/api/src/db/schema/devices.ts`.
+
+### Routes
+
+- **`POST /agents/:id/process-sample`** (in `apps/api/src/routes/agents/`): Zod-validated
+  payload, `agentAuth` bearer. **`org_id` is derived server-side from the authenticated
+  device record — the agent payload is never trusted for tenancy.** Inserts one row.
+- **`GET /devices/:id/process-samples?at=<ts>`**: returns the snapshot nearest to `<ts>`.
+  Also supports `?from&to` returning lightweight `(timestamp)` markers so the scrubber
+  knows which samples exist in a range. Runs through `withDbAccessContext` (RLS enforced).
+
+### Retention
+
+Hook into the existing metrics cleanup job with a **separate, shorter window**
+(default **14 days**), independent of aggregate-metric retention. Per-process snapshots
+are heavier and only needed for recent forensic investigation.
+
+## Web UI
+
+- In `DevicePerformanceGraphs.tsx`, make CPU/RAM chart points clickable. On click, fetch
+  the nearest process sample and open a drill-down panel (reuse `Dialog.tsx` drawer +
+  `ProcessManager.tsx` table styling).
+- Panel contents:
+  - Sortable process table, **pre-sorted by the resource clicked** (click CPU → CPU desc;
+    click RAM → RAM desc).
+  - **Time scrubber** synced to the chart's current range; moving it re-fetches the
+    nearest snapshot.
+  - **"Live" toggle** that switches to the existing on-demand
+    `GET /devices/:id/processes` for "right now."
+- Disk/net columns appear once their phases ship; show "—" / "not available" where an OS
+  or phase has no data.
+
+## Scale Notes
+
+- Approach A keeps row volume at roughly **1 row per device per sample**, the same order
+  of magnitude as the existing `deviceMetrics` table — not the ~10× of a per-process
+  normalized table (Approach B).
+- At 10k agents × 180s cadence ≈ 10k × 480 samples/day ≈ **4.8M rows/day**, each a small
+  JSONB blob, pruned at 14 days. Comparable to existing metrics load; viable on
+  DO-managed Postgres without TimescaleDB.
+
+## Testing (per `breeze-testing`)
+
+- **API**: route tests for ingest (Zod validation, auth, **server-side org_id
+  derivation**) and read (nearest-snapshot, range markers). **RLS contract test** for
+  `device_process_samples` (`rls-coverage.integration.test.ts`) — verify cross-tenant
+  insert/select is blocked as `breeze_app`.
+- **Agent**: table-driven tests for the top-N union/dedupe selector; per-OS disk/net
+  collectors behind interfaces, tested with fakes; unsupported-OS returns "no data".
+- **Web**: component test for click→fetch→sorted-table, the time scrubber re-fetch, and
+  the Live toggle.
+
+## Rejected Alternatives
+
+- **Approach B — normalized per-process rows** `(device_id, timestamp, process_name, pid,
+  cpu, ram, disk, net)`: enables per-process trend lines but ~10× storage and higher
+  operational risk at 10k agents without TimescaleDB. Rejected; revisit only if
+  per-process trends become a hard requirement.
+- **Live-only drill-down** (reuse existing on-demand process list, no storage): cheapest,
+  but cannot investigate past spikes — the core requirement. Kept as the "Live" toggle.
+
+## Future Options (out of scope)
+
+- **Spike-triggered capture**: in addition to the steady cadence, capture an extra
+  snapshot when CPU/RAM crosses a threshold, so short spikes between samples are always
+  covered.
+- **Per-process trend lines** (would require Approach B storage).

--- a/docs/testing/e2e-coverage-index.md
+++ b/docs/testing/e2e-coverage-index.md
@@ -1,0 +1,15 @@
+# E2E Coverage Index
+
+Living pointer for the `e2e-coverage` skill. Each sweep reads the most recent row to find its baseline and what's already covered, then adds a row when done. Most-recent first.
+
+| Baseline | Last swept commit | Date | Plan / Results | Coverage |
+|---|---|---|---|---|
+| `v0.68.2` | `cba95590` (branch `feat/google-identity-device-tasks`) | 2026-06-01 | [results](./FEATURE_TEST_LOG.md) (entry "Since-Release E2E Sweep") | Partial — credential-free items only. PASS: identity route auth, devices columns/filters, Google/M365 connection UIs, org-axis RBAC, patch-pin, notif-link. FAIL→FIXED: Fix-with-AI org binding (branch `fix/ai-session-device-org-binding`). NEEDS-CREDS: Google/M365 tenant flows, live-agent items, SSRF egress. DEFERRED: intra-org site-axis (seed). |
+| `v0.66.1` | `2719f10d` (main) | 2026-05-26 | [plan](./v0.66.1-to-HEAD-test-plan.md) · [results](./v0.66.1-to-HEAD-test-results.md) | Full P0/P1 sweep. 1 bug found+fixed (`/devices` list dropped `watchdogStatus`/`mainAgentSilentSince`). |
+
+## Carry-forward (open across sweeps)
+
+Recheck these at the start of the next sweep — clear them when creds/agents/data become available:
+
+- **NEEDS-CREDS** — Google Workspace + M365 real-tenant flows (connect, offboard/wipe, drift dashboard, helpdesk tools, OData escaping on live data); live Win/macOS agent items (macOS `.pkg` sig verify, quarantine re-enroll, remote-desktop self-heal/revocation); SSRF live egress trigger.
+- **DEFERRED — seed** — intra-org site-axis RBAC (needs a 2nd site with devices in one org).


### PR DESCRIPTION
## Problem

The per-row **Update** button in the device Software tab fired a blind `winget upgrade --name <display name>` for every row, regardless of whether an update actually existed. winget can't see most OEM/vendor-installed software by display name, and the agent maps "no available upgrade" to **success** — so clicking Update produced a "queued" toast and then a silent no-op. The button looked broken because, for most rows, it did nothing.

## Approach

The agent **already** scans `winget upgrade` (`WingetProvider.Scan()`) and submits each available upgrade as a `source='third_party'` patch carrying the winget `packageId` and target version — that data already powers the Patches tab. Nothing connected it to the Software tab, and the patch policy's `third_party` source toggle didn't gate winget. So this is **wiring existing data**, not a new scan.

## Changes

- **`GET /devices/:id/software`** (+ new `softwareUpdateMatch.ts`): joins the device's pending `third_party` patches and annotates each row with `updateAvailable`, `availableVersion`, `updatePackageId`, `updateSource` (matched by normalized name — winget's Name tracks the ARP display name, so exact-normalized equality hits the common case without fuzzy false positives). Returns `thirdPartyUpdatesManaged` from the resolved patch policy.
- **`POST /devices/:id/software/update`** (`softwareActions.ts`): accepts an optional winget `packageId`, validated and passed through.
- **Agent `software_update.go`**: when `packageId` is present, prefers `winget upgrade --id <packageId>` ahead of display-name heuristics. Backward compatible (ignored when absent / non-Windows).
- **`DeviceSoftwareInventory.tsx`**: Update is disabled unless an update is genuinely available (tooltip explains why); the Version cell shows `current → available`; the POST sends `packageId` (no version pin → latest); the success toast names the target version; a banner summarizes available updates and nudges toward policy management when third-party updates are unmanaged.

## Design note

The Software-tab fields are computed via a **read-time join** over the existing third-party patch data — **no new `software_inventory` columns, no migration** — so the fix works against already-deployed agents (incl. 0.69.0). Stored columns remain a clean fast-follow for cross-device queryability.

Scope this pass: **Windows/winget, scan + manual update, policy-gated surfacing** — no auto-install. The `--id` reliability tweak needs an agent build to take effect; everything else is API + web only.

## Tests

- `softwareUpdateMatch.test.ts` — 10 matching/normalization unit tests
- `DeviceSoftwareInventory.test.tsx` — 8 component tests (disabled-when-no-update, version delta, banner, `packageId` in POST body, existing flows updated)
- `software_update_test.go` — `packageId` validator + rejection tests

All passing. API/web type-check clean (only pre-existing unrelated errors remain).

## Follow-ups (intentionally out of scope)

- Auto-approve + scheduled install via the patch-job system
- Gate the Patches-tab *read* on policy `sources` (jobs already respect it; read surfaces all)
- macOS (`brew outdated`) / Linux scanners
- Stored `software_inventory` update columns for cross-device queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)