### PR TITLE
fix(tunnels): resolve org from ?orgId= so partner users can manage proxy allowlist

### DIFF
--- a/apps/api/src/routes/tunnels.test.ts
+++ b/apps/api/src/routes/tunnels.test.ts
@@ -7,6 +7,7 @@ const DEVICE_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
 const ORG_ID    = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
 const USER_ID   = 'uuuuuuuu-uuuu-4uuu-8uuu-uuuuuuuuuuuu';
 const SESSION_ID = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
+const PARTNER_ID = 'pppppppp-pppp-4ppp-8ppp-pppppppppppp';
 
 // --- DB mock ---
 vi.mock('../db', () => ({
@@ -31,13 +32,34 @@ vi.mock('../db/schema', () => ({
 // --- Auth middleware ---
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => {
-    c.set('auth', {
-      scope: 'organization',
-      partnerId: null,
-      orgId: ORG_ID,
-      user: { id: USER_ID, email: 'test@example.com' },
-      canAccessOrg: (id: string) => id === ORG_ID,
-    });
+    // Partner-scope callers (MSP users with an org selected in the picker) send
+    // their org via the `?orgId=` query param, NOT a JWT org claim. Tests opt
+    // into that shape with `x-test-scope: partner` + `x-test-accessible-orgs`
+    // (comma-separated), mirroring how the web client scopes API calls.
+    const testScope = c.req.header('x-test-scope');
+    if (testScope === 'partner') {
+      const accessibleOrgIds = (c.req.header('x-test-accessible-orgs') || '')
+        .split(',')
+        .map((s: string) => s.trim())
+        .filter(Boolean);
+      c.set('auth', {
+        scope: 'partner',
+        partnerId: PARTNER_ID,
+        orgId: null,
+        accessibleOrgIds,
+        user: { id: USER_ID, email: 'test@example.com' },
+        canAccessOrg: (id: string) => accessibleOrgIds.includes(id),
+      });
+    } else {
+      c.set('auth', {
+        scope: 'organization',
+        partnerId: null,
+        orgId: ORG_ID,
+        accessibleOrgIds: [ORG_ID],
+        user: { id: USER_ID, email: 'test@example.com' },
+        canAccessOrg: (id: string) => id === ORG_ID,
+      });
+    }
     // NOTE: authMiddleware does NOT populate `permissions` in production — only
     // requirePermission does. Keep it out here so a route relying on permissions
     // for site-scoping but lacking a permission gate fails its tests (not masks).
@@ -647,5 +669,146 @@ describe('POST /vnc-viewer/upgrade-to-webrtc', () => {
       status: 'disconnected',
     }));
     expect(db.insert).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Allowlist routes — partner-scope org resolution ─────────────────────────
+// Regression for "Failed to create allowlist entry" (Enable Proxy Access on the
+// discovery page): partner-scope sessions carry no JWT org claim and pass the
+// target org via `?orgId=`. The routes must resolve that, not reject with 400.
+
+describe('Allowlist routes — partner-scope org resolution', () => {
+  let app: Hono;
+  const ORG_A = 'a1a1a1a1-a1a1-4a1a-8a1a-a1a1a1a1a1a1'; // accessible to the partner
+  const ORG_B = 'b1b1b1b1-b1b1-4b1b-8b1b-b1b1b1b1b1b1'; // NOT accessible
+  const RULE_ID = 'f1f1f1f1-f1f1-4f1f-8f1f-f1f1f1f1f1f1';
+
+  const ruleBody = {
+    direction: 'destination',
+    pattern: '10.1.2.50/32:80-443',
+    description: 'Auto-created for Printer',
+    source: 'discovery',
+    discoveredAssetId: '99999999-9999-4999-8999-999999999999',
+  };
+
+  // Capture the values passed to db.insert(...).values(...) so we can assert the
+  // resolved orgId is persisted.
+  function rigInsertCapture(returned: any) {
+    const valuesSpy = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([returned]),
+    });
+    vi.mocked(db.insert).mockReturnValue({ values: valuesSpy } as any);
+    return valuesSpy;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.select).mockReset();
+    app = new Hono();
+    app.route('/tunnels', tunnelRoutes);
+  });
+
+  it('POST /allowlist resolves the org from ?orgId= for a partner caller (201)', async () => {
+    const valuesSpy = rigInsertCapture({ id: RULE_ID, orgId: ORG_A, ...ruleBody });
+
+    const res = await app.request(`/tunnels/allowlist?orgId=${ORG_A}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-test-scope': 'partner',
+        'x-test-accessible-orgs': ORG_A,
+      },
+      body: JSON.stringify(ruleBody),
+    });
+
+    expect(res.status).toBe(201);
+    expect(valuesSpy).toHaveBeenCalledTimes(1);
+    expect(valuesSpy.mock.calls[0]![0]).toEqual(expect.objectContaining({ orgId: ORG_A }));
+  });
+
+  it('POST /allowlist returns 403 when the partner cannot access the requested org', async () => {
+    rigInsertCapture({ id: RULE_ID });
+
+    const res = await app.request(`/tunnels/allowlist?orgId=${ORG_B}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-test-scope': 'partner',
+        'x-test-accessible-orgs': ORG_A,
+      },
+      body: JSON.stringify(ruleBody),
+    });
+
+    expect(res.status).toBe(403);
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('POST /allowlist auto-resolves the single accessible org when no ?orgId= is given', async () => {
+    const valuesSpy = rigInsertCapture({ id: RULE_ID, orgId: ORG_A, ...ruleBody });
+
+    const res = await app.request('/tunnels/allowlist', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-test-scope': 'partner',
+        'x-test-accessible-orgs': ORG_A,
+      },
+      body: JSON.stringify(ruleBody),
+    });
+
+    expect(res.status).toBe(201);
+    expect(valuesSpy.mock.calls[0]![0]).toEqual(expect.objectContaining({ orgId: ORG_A }));
+  });
+
+  it('POST /allowlist returns 400 when a multi-org partner omits ?orgId=', async () => {
+    rigInsertCapture({ id: RULE_ID });
+
+    const res = await app.request('/tunnels/allowlist', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-test-scope': 'partner',
+        'x-test-accessible-orgs': `${ORG_A},${ORG_B}`,
+      },
+      body: JSON.stringify(ruleBody),
+    });
+
+    expect(res.status).toBe(400);
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('GET /allowlist scopes to the resolved org for a partner caller (200)', async () => {
+    const where = vi.fn().mockReturnValue({
+      orderBy: vi.fn().mockResolvedValue([{ id: RULE_ID, orgId: ORG_A }]),
+    });
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({ where }),
+    } as any);
+
+    const res = await app.request(`/tunnels/allowlist?orgId=${ORG_A}`, {
+      method: 'GET',
+      headers: {
+        'x-test-scope': 'partner',
+        'x-test-accessible-orgs': ORG_A,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toHaveLength(1);
+  });
+
+  it('DELETE /allowlist/:id resolves the org for a partner caller (404 when no row)', async () => {
+    // No matching row in the resolved org → 404 (NOT the old 400 org-context error).
+    vi.mocked(db.select).mockReturnValue(makeSelectChain([]) as any);
+
+    const res = await app.request(`/tunnels/allowlist/${RULE_ID}?orgId=${ORG_A}`, {
+      method: 'DELETE',
+      headers: {
+        'x-test-scope': 'partner',
+        'x-test-accessible-orgs': ORG_A,
+      },
+    });
+
+    expect(res.status).toBe(404);
   });
 });

--- a/apps/api/src/routes/tunnels.test.ts
+++ b/apps/api/src/routes/tunnels.test.ts
@@ -777,7 +777,11 @@ describe('Allowlist routes — partner-scope org resolution', () => {
     expect(db.insert).not.toHaveBeenCalled();
   });
 
-  it('GET /allowlist scopes to the resolved org for a partner caller (200)', async () => {
+  it('GET /allowlist binds the RESOLVED org (not the null JWT org) into the WHERE clause', async () => {
+    // drizzle-orm is unmocked and schema columns are mocked as strings, so the
+    // org value is inlined as a raw chunk — JSON of the WHERE node contains it.
+    // This proves the route filters by the resolved ORG_A, not auth.orgId (null
+    // for partners), which a status-only assertion can't distinguish.
     const where = vi.fn().mockReturnValue({
       orderBy: vi.fn().mockResolvedValue([{ id: RULE_ID, orgId: ORG_A }]),
     });
@@ -795,6 +799,81 @@ describe('Allowlist routes — partner-scope org resolution', () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toHaveLength(1);
+    expect(where).toHaveBeenCalledTimes(1);
+    const whereSql = JSON.stringify(where.mock.calls[0]![0]);
+    expect(whereSql).toContain(ORG_A);
+  });
+
+  it('POST /allowlist rejects an ORG-scope caller passing a foreign ?orgId= (403)', async () => {
+    // Regression guard for resolveOrgId's org-scope branch: an org-scoped user
+    // must not be able to redirect a write into another org via the query param.
+    // Default auth mock (no x-test-scope header) is org-scoped to ORG_ID.
+    rigInsertCapture({ id: RULE_ID });
+
+    const res = await app.request(`/tunnels/allowlist?orgId=${ORG_B}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(ruleBody),
+    });
+
+    expect(res.status).toBe(403);
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('POST /allowlist resolves an explicit ?orgId= for a MULTI-org partner (201, binds ORG_A)', async () => {
+    // Distinct from the single-org auto-resolve path: a partner managing many
+    // orgs picks one in the UI. canAccessOrg must admit it and it must persist.
+    const valuesSpy = rigInsertCapture({ id: RULE_ID, orgId: ORG_A, ...ruleBody });
+
+    const res = await app.request(`/tunnels/allowlist?orgId=${ORG_A}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-test-scope': 'partner',
+        'x-test-accessible-orgs': `${ORG_A},${ORG_B}`,
+      },
+      body: JSON.stringify(ruleBody),
+    });
+
+    expect(res.status).toBe(201);
+    expect(valuesSpy.mock.calls[0]![0]).toEqual(expect.objectContaining({ orgId: ORG_A }));
+  });
+
+  it('PUT /allowlist/:id resolves the org for a partner caller, binding ORG_A (404 when no row)', async () => {
+    // PUT got the identical resolveOrgId treatment as POST/GET/DELETE; cover its
+    // partner path and prove the existence check filters by the resolved org.
+    const existsWhere = vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) });
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({ where: existsWhere }),
+    } as any);
+
+    const res = await app.request(`/tunnels/allowlist/${RULE_ID}?orgId=${ORG_A}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-test-scope': 'partner',
+        'x-test-accessible-orgs': ORG_A,
+      },
+      body: JSON.stringify({ pattern: '10.1.2.50/32:80-443' }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(JSON.stringify(existsWhere.mock.calls[0]![0])).toContain(ORG_A);
+  });
+
+  it('PUT /allowlist/:id rejects a partner passing an inaccessible ?orgId= (403)', async () => {
+    const res = await app.request(`/tunnels/allowlist/${RULE_ID}?orgId=${ORG_B}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-test-scope': 'partner',
+        'x-test-accessible-orgs': ORG_A,
+      },
+      body: JSON.stringify({ pattern: '10.1.2.50/32:80-443' }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(db.select).not.toHaveBeenCalled();
   });
 
   it('DELETE /allowlist/:id resolves the org for a partner caller (404 when no row)', async () => {

--- a/apps/api/src/routes/tunnels.ts
+++ b/apps/api/src/routes/tunnels.ts
@@ -55,9 +55,13 @@ const updateAllowlistSchema = z.object({
 
 // Resolve the org a request acts on, from auth scope + an optional `?orgId=`.
 // Partner/system callers carry no JWT org claim — the web client passes the
-// selected org as a query param (see fetchWithAuth's auto-injection). Mirrors
-// the helper in discovery.ts / monitors.ts so the allowlist routes scope the
-// same way the rest of the discovery surface does.
+// selected org as a query param (see fetchWithAuth's auto-injection).
+//
+// Adapted from the resolveOrgId helpers in discovery.ts / monitors.ts, minus
+// their `requireForNonOrg` mode and permissive system-scope fall-through: these
+// routes always require a single resolvable org, so any unresolvable caller
+// (system or multi-org partner without `?orgId=`) gets a hard 400 and no
+// success branch can return a null org. Not kept in lockstep with those copies.
 function resolveOrgId(
   auth: { scope: string; orgId: string | null; canAccessOrg: (orgId: string) => boolean; accessibleOrgIds: string[] | null },
   requestedOrgId?: string,

--- a/apps/api/src/routes/tunnels.ts
+++ b/apps/api/src/routes/tunnels.ts
@@ -53,6 +53,32 @@ const updateAllowlistSchema = z.object({
 
 // --- Helpers ---
 
+// Resolve the org a request acts on, from auth scope + an optional `?orgId=`.
+// Partner/system callers carry no JWT org claim — the web client passes the
+// selected org as a query param (see fetchWithAuth's auto-injection). Mirrors
+// the helper in discovery.ts / monitors.ts so the allowlist routes scope the
+// same way the rest of the discovery surface does.
+function resolveOrgId(
+  auth: { scope: string; orgId: string | null; canAccessOrg: (orgId: string) => boolean; accessibleOrgIds: string[] | null },
+  requestedOrgId?: string,
+) {
+  if (auth.scope === 'organization') {
+    if (!auth.orgId) return { error: 'Organization context required', status: 403 } as const;
+    if (requestedOrgId && requestedOrgId !== auth.orgId) return { error: 'Access to this organization denied', status: 403 } as const;
+    return { orgId: auth.orgId } as const;
+  }
+  if (requestedOrgId) {
+    if (!auth.canAccessOrg(requestedOrgId)) return { error: 'Access to this organization denied', status: 403 } as const;
+    return { orgId: requestedOrgId } as const;
+  }
+  if (auth.scope === 'partner') {
+    const accessibleOrgIds = auth.accessibleOrgIds ?? [];
+    if (accessibleOrgIds.length === 1) return { orgId: accessibleOrgIds[0]! } as const;
+    return { error: 'orgId is required when partner has multiple organizations', status: 400 } as const;
+  }
+  return { error: 'orgId is required', status: 400 } as const;
+}
+
 // Hardcoded blocked CIDRs (mirrors agent-side allowlist.go)
 const BLOCKED_CIDRS = [
   { cidr: '127.0.0.0/8', reason: 'localhost' },
@@ -374,12 +400,12 @@ tunnelRoutes.get(
   async (c) => {
     const auth = c.get('auth') as AuthContext;
     const perms = c.get('permissions') as UserPermissions | undefined;
-    if (!auth.orgId) {
-      return c.json({ error: 'Org context required' }, 400);
-    }
+    const orgResult = resolveOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const orgId = orgResult.orgId;
 
     const { siteId } = c.req.valid('query');
-    const conditions: ReturnType<typeof eq>[] = [eq(tunnelAllowlists.orgId, auth.orgId)];
+    const conditions: ReturnType<typeof eq>[] = [eq(tunnelAllowlists.orgId, orgId)];
     if (siteId) {
       if (perms?.allowedSiteIds && !canAccessSite(perms, siteId)) {
         return c.json({ error: 'Access to this site denied' }, 403);
@@ -409,16 +435,16 @@ tunnelRoutes.post(
   zValidator('json', allowlistRuleSchema),
   async (c) => {
     const auth = c.get('auth') as AuthContext;
-    if (!auth.orgId) {
-      return c.json({ error: 'Org context required' }, 400);
-    }
+    const orgResult = resolveOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const orgId = orgResult.orgId;
 
     const body = c.req.valid('json');
 
     const [rule] = await db
       .insert(tunnelAllowlists)
       .values({
-        orgId: auth.orgId,
+        orgId,
         siteId: body.siteId || null,
         direction: body.direction,
         pattern: body.pattern,
@@ -442,16 +468,16 @@ tunnelRoutes.put(
   async (c) => {
     const auth = c.get('auth') as AuthContext;
     const { id } = c.req.valid('param');
-    if (!auth.orgId) {
-      return c.json({ error: 'Org context required' }, 400);
-    }
+    const orgResult = resolveOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const orgId = orgResult.orgId;
 
     const body = c.req.valid('json');
 
     const [existing] = await db
       .select()
       .from(tunnelAllowlists)
-      .where(and(eq(tunnelAllowlists.id, id), eq(tunnelAllowlists.orgId, auth.orgId)))
+      .where(and(eq(tunnelAllowlists.id, id), eq(tunnelAllowlists.orgId, orgId)))
       .limit(1);
 
     if (!existing) {
@@ -466,7 +492,7 @@ tunnelRoutes.put(
     const [updated] = await db
       .update(tunnelAllowlists)
       .set(updates)
-      .where(and(eq(tunnelAllowlists.id, id), eq(tunnelAllowlists.orgId, auth.orgId)))
+      .where(and(eq(tunnelAllowlists.id, id), eq(tunnelAllowlists.orgId, orgId)))
       .returning();
 
     return c.json(updated);
@@ -481,14 +507,14 @@ tunnelRoutes.delete(
   async (c) => {
     const auth = c.get('auth') as AuthContext;
     const { id } = c.req.valid('param');
-    if (!auth.orgId) {
-      return c.json({ error: 'Org context required' }, 400);
-    }
+    const orgResult = resolveOrgId(auth, c.req.query('orgId'));
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+    const orgId = orgResult.orgId;
 
     const [existing] = await db
       .select()
       .from(tunnelAllowlists)
-      .where(and(eq(tunnelAllowlists.id, id), eq(tunnelAllowlists.orgId, auth.orgId)))
+      .where(and(eq(tunnelAllowlists.id, id), eq(tunnelAllowlists.orgId, orgId)))
       .limit(1);
 
     if (!existing) {
@@ -497,7 +523,7 @@ tunnelRoutes.delete(
 
     await db
       .delete(tunnelAllowlists)
-      .where(and(eq(tunnelAllowlists.id, id), eq(tunnelAllowlists.orgId, auth.orgId)));
+      .where(and(eq(tunnelAllowlists.id, id), eq(tunnelAllowlists.orgId, orgId)));
 
     return c.json({ deleted: true });
   }

--- a/apps/web/src/components/discovery/AssetDetailModal.tsx
+++ b/apps/web/src/components/discovery/AssetDetailModal.tsx
@@ -174,7 +174,8 @@ export default function AssetDetailModal({
         }),
       });
       if (!response.ok) {
-        throw new Error('Failed to create allowlist entry');
+        const detail = await response.json().catch(() => null);
+        throw new Error(detail?.error || 'Failed to create allowlist entry');
       }
       setProxyEnabled(true);
       onUpdated?.(asset.id);


### PR DESCRIPTION
## Problem

Clicking **Enable Proxy Access** on a discovery asset from a partner (MSP) session fails with **"Failed to create allowlist entry"**. Reproduced and root-caused against US prod logs:

```
POST /api/v1/tunnels/allowlist?orgId=7a4eab04-… → 400   (x2, the two clicks)
```

Partner-scope sessions carry no JWT org claim (`auth.orgId` is null). The web client passes the selected org via `?orgId=` (auto-injected by `fetchWithAuth`), but all four `/tunnels/allowlist` routes (GET/POST/PUT/DELETE) read **only** `auth.orgId` and returned `400 "Org context required"`. The UI masked the 400 behind a hardcoded fallback string.

Net effect: the entire Proxy Access feature — plus listing/editing/deleting allowlist rules — was unusable from any MSP session. It only worked under a plain org-scoped login.

## Fix

- **`apps/api/src/routes/tunnels.ts`** — Adopt the `resolveOrgId(auth, ?orgId=)` helper already used by `discovery.ts` / `monitors.ts`, applied to all four allowlist routes. Org-scope keeps using the JWT org; partner/system resolves the requested org through `canAccessOrg` (or a partner's single org). A partner requesting an inaccessible org now gets a clean **403** instead of a silent failure.
- **`apps/web/src/components/discovery/AssetDetailModal.tsx`** — Surface the API's real error message instead of the generic `"Failed to create allowlist entry"` fallback.
- **`apps/api/src/routes/tunnels.test.ts`** — Partner-scope coverage (resolve from `?orgId=`, auto-resolve single org, 403 on inaccessible org, 400 for multi-org partner without `orgId`, GET/DELETE). Written failing first, then made to pass.

## Why no migration

`tunnel_allowlists` has org-axis RLS (`breeze_has_org_access(org_id)`). Inserts always carry a concrete, access-checked `org_id` — never partner-wide NULL rows — so the existing policy passes. A partner session's `breeze.accessible_org_ids` GUC and the route's `canAccessOrg` both derive from the same `computeAccessibleOrgIds`, so a route-resolved org is guaranteed to satisfy the RLS `WITH CHECK`. (Unlike the `custom_field_definitions` dual-axis case from #1026.)

## Verification

- 37/37 tunnels tests pass; `tsc --noEmit` clean for both changed files; web `no-silent-mutations` guard still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)