### PR TITLE
fix(tickets): residual pickups — own-org read, site gates, hard-delete detach, queue UX

### DIFF
--- a/apps/api/migrations/2026-06-11-i-devices-site-id-index.sql
+++ b/apps/api/migrations/2026-06-11-i-devices-site-id-index.sql
@@ -1,0 +1,3 @@
+-- Site-axis queries (ticket site scoping, site device lists) filter on
+-- devices.site_id; the FK alone creates no index.
+CREATE INDEX IF NOT EXISTS devices_site_id_idx ON devices (site_id);

--- a/apps/api/src/__tests__/helpers/routeScan.ts
+++ b/apps/api/src/__tests__/helpers/routeScan.ts
@@ -96,6 +96,12 @@ const CANONICAL_GATE_NAMES = [
   'resolveSiteAllowedDeviceIds',
   'hasDeniedDeviceSite',
   'hasDeniedThreatDeviceSite',
+  // Ticket site-axis gates, extracted to routes/tickets/siteScope.ts (#1238
+  // follow-up). Previously file-local to routes/tickets/tickets.ts and picked
+  // up via findLocalGateWrappers; now cross-file canonical gates used by the
+  // tickets routes, alerts create-from-alert, and aiToolsTicketing.
+  'ticketSiteScopeCondition',
+  'deviceInSiteScope',
   // NOTE: `getDeviceWithOrgCheck` (routes/remote/helpers.ts) is a cross-file
   // site-aware resolver, but it is deliberately NOT listed as a gate token.
   // It gates only the code path where a deviceId is supplied — e.g.

--- a/apps/api/src/routes/alerts.test.ts
+++ b/apps/api/src/routes/alerts.test.ts
@@ -109,15 +109,24 @@ vi.mock('../db/schema', () => ({
   partners: {}
 }));
 
-vi.mock('../middleware/auth', () => ({
+vi.mock('../middleware/auth', async () => ({
+  // Real implementation (single source of truth for site-allowlist semantics) —
+  // the create-ticket site gate resolves through it via tickets/siteScope.ts.
+  siteAccessCheck: (await vi.importActual<typeof import('../middleware/auth')>('../middleware/auth')).siteAccessCheck,
   authMiddleware: vi.fn((c: any, next: any) => {
+    // Opt-in site restriction on the AUTH context (deviceInSiteScope reads
+    // auth.allowedSiteIds, unlike the list narrowing which reads permissions).
+    const restrictAuth = c.req.header('x-auth-allowed-sites');
     c.set('auth', {
       scope: 'organization',
       orgId: '11111111-1111-1111-1111-111111111111',
       partnerId: null,
       user: { id: 'user-123', email: 'test@example.com' },
       accessibleOrgIds: ['11111111-1111-1111-1111-111111111111'],
-      canAccessOrg: (orgId: string) => orgId === '11111111-1111-1111-1111-111111111111'
+      canAccessOrg: (orgId: string) => orgId === '11111111-1111-1111-1111-111111111111',
+      allowedSiteIds: restrictAuth === undefined
+        ? undefined
+        : (restrictAuth === '__empty__' ? [] : restrictAuth.split(','))
     });
     // NOTE: authMiddleware does NOT populate `permissions` in production — only
     // requirePermission does. Keep it out here so a route relying on permissions
@@ -164,13 +173,19 @@ describe('alert routes', () => {
       failedCount: 0
     });
     vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+      // Opt-in site restriction on the AUTH context (deviceInSiteScope reads
+      // auth.allowedSiteIds, unlike the list narrowing which reads permissions).
+      const restrictAuth = c.req.header('x-auth-allowed-sites');
       c.set('auth', {
         scope: 'organization',
         orgId: '11111111-1111-1111-1111-111111111111',
         partnerId: null,
         user: { id: 'user-123', email: 'test@example.com' },
         accessibleOrgIds: ['11111111-1111-1111-1111-111111111111'],
-        canAccessOrg: (orgId: string) => orgId === '11111111-1111-1111-1111-111111111111'
+        canAccessOrg: (orgId: string) => orgId === '11111111-1111-1111-1111-111111111111',
+        allowedSiteIds: restrictAuth === undefined
+          ? undefined
+          : (restrictAuth === '__empty__' ? [] : restrictAuth.split(','))
       });
       // permissions is populated by requirePermission (mirrors prod), not here.
       return next();
@@ -1191,6 +1206,77 @@ describe('alert routes', () => {
         ALERT_ID,
         expect.objectContaining({ userId: 'user-123' }),
         expect.objectContaining({ subject: 'Custom subject', priority: 'urgent' })
+      );
+    });
+
+    it('returns 404 for out-of-site alert devices (site-restricted caller)', async () => {
+      // Alert visibility check returns an alert bound to a device...
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: ALERT_ID,
+              orgId: '11111111-1111-1111-1111-111111111111',
+              deviceId: 'device-1',
+              status: 'active'
+            }])
+          })
+        })
+      } as any);
+      // ...whose site is outside the caller's allowlist.
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ siteId: 'site-OTHER' }])
+          })
+        })
+      } as any);
+
+      const res = await app.request(`/alerts/${ALERT_ID}/create-ticket`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-auth-allowed-sites': 'site-1' },
+        body: JSON.stringify({})
+      });
+
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.error).toBe('Alert not found');
+      expect(createTicketFromAlertMock).not.toHaveBeenCalled();
+    });
+
+    it('creates the ticket when the alert device is inside the caller site scope', async () => {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: ALERT_ID,
+              orgId: '11111111-1111-1111-1111-111111111111',
+              deviceId: 'device-1',
+              status: 'active'
+            }])
+          })
+        })
+      } as any);
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ siteId: 'site-1' }])
+          })
+        })
+      } as any);
+      createTicketFromAlertMock.mockResolvedValue({ id: 't-11', internalNumber: 'T-2026-0044' });
+
+      const res = await app.request(`/alerts/${ALERT_ID}/create-ticket`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-auth-allowed-sites': 'site-1' },
+        body: JSON.stringify({})
+      });
+
+      expect(res.status).toBe(201);
+      expect(createTicketFromAlertMock).toHaveBeenCalledWith(
+        ALERT_ID,
+        expect.objectContaining({ userId: 'user-123' }),
+        expect.any(Object)
       );
     });
 

--- a/apps/api/src/routes/alerts/alerts.ts
+++ b/apps/api/src/routes/alerts/alerts.ts
@@ -21,6 +21,7 @@ import { listAlertsSchema, resolveAlertSchema, suppressAlertSchema, bulkAlertAct
 import { getPagination, ensureOrgAccess, getAlertWithOrgCheck } from './helpers';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../../services/permissions';
 import { createTicketFromAlert, TicketServiceError } from '../../services/ticketService';
+import { deviceInSiteScope } from '../tickets/siteScope';
 
 export const alertsRoutes = new Hono();
 
@@ -680,6 +681,13 @@ alertsRoutes.post(
     // (defense-in-depth: service also re-checks via createTicket org access).
     const alert = await getAlertWithOrgCheck(id, auth);
     if (!alert) {
+      return c.json({ error: 'Alert not found' }, 404);
+    }
+
+    // Site-axis gate (R2): a site-restricted caller must not create tickets
+    // from alerts whose device is outside their allowed sites. Out-of-site
+    // alerts are invisible, not forbidden — same shape as the ticket-side gate.
+    if (alert.deviceId && !(await deviceInSiteScope(auth, alert.deviceId))) {
       return c.json({ error: 'Alert not found' }, 404);
     }
 

--- a/apps/api/src/routes/devices/cascadeDelete.test.ts
+++ b/apps/api/src/routes/devices/cascadeDelete.test.ts
@@ -1,8 +1,94 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
 import { getTableName } from 'drizzle-orm';
 import { PgTable } from 'drizzle-orm/pg-core';
+
+// ---------------------------------------------------------------------------
+// Mocks for the behavior suite (hoisted above all imports). The static
+// contract tests below only read exported constants + the real schema, so
+// these mocks don't affect them. Mock shapes mirror core.permissions.test.ts.
+// ---------------------------------------------------------------------------
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    execute: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    transaction: vi.fn(),
+  },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', {
+      user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+      scope: 'organization',
+      orgId: 'org-123',
+      partnerId: null,
+      accessibleOrgIds: ['org-123'],
+      canAccessOrg: (orgId: string) => orgId === 'org-123',
+      orgCondition: () => undefined,
+      token: { mfa: true },
+    });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn((resource: string, action: string) => async (c: any, next: any) => {
+    c.set('permissions', {
+      permissions: [{ resource, action }],
+      partnerId: null,
+      orgId: 'org-123',
+      roleId: 'role-123',
+      scope: 'organization',
+    });
+    return next();
+  }),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+vi.mock('../../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn(),
+}));
+
+vi.mock('../../services/sentry', () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock('../../services/remoteAccessPolicy', () => ({
+  resolveRemoteAccessForDevice: vi.fn().mockResolvedValue({ policyId: null, settings: {} }),
+}));
+
+vi.mock('../../services/remoteAccessLauncher', () => ({
+  resolveRemoteAccessLaunch: vi.fn().mockReturnValue({ launchUrl: null, skipReason: 'no_provider_configured' }),
+}));
+
+vi.mock('../agentWs', () => ({
+  sendCommandToAgent: vi.fn(),
+  isAgentConnected: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../../services/commandQueue', () => ({
+  CommandTypes: { SELF_UNINSTALL: 'self_uninstall' },
+  queueCommandForExecution: vi.fn(),
+}));
+
+vi.mock('../agents/enrollment', () => ({
+  getGlobalEnrollmentSecret: vi.fn().mockReturnValue(null),
+}));
+
 import * as schema from '../../db/schema';
-import { DEVICE_CASCADE_DELETE_TABLES, DEVICE_LINKED_DEVICE_ID_TABLES } from './core';
+import {
+  coreRoutes,
+  DEVICE_CASCADE_DELETE_TABLES,
+  DEVICE_DETACH_DEVICE_ID_TABLES,
+  DEVICE_LINKED_DEVICE_ID_TABLES,
+} from './core';
+import { db } from '../../db';
 
 /**
  * Tables that have a column named `device_id` but it does NOT reference devices.id.
@@ -20,44 +106,61 @@ function getTableColumns(table: PgTable<any>): any[] {
   );
 }
 
-describe('DEVICE_CASCADE_DELETE_TABLES coverage', () => {
-  it('includes every table whose device_id FK references devices.id', () => {
+function allSchemaTables(): PgTable<any>[] {
+  return Object.values(schema).filter((v) => v instanceof PgTable) as PgTable<any>[];
+}
+
+describe('device hard-delete table coverage contract', () => {
+  it('every table with a device_id FK to devices.id is in exactly one of cascade/detach/linked sets', () => {
     const cascadeSet = new Set<string>(DEVICE_CASCADE_DELETE_TABLES);
-    const allTables = Object.values(schema).filter(
-      (v) => v instanceof PgTable
-    ) as PgTable<any>[];
+    const detachSet = new Set<string>(DEVICE_DETACH_DEVICE_ID_TABLES);
+    const linkedSet = new Set<string>(DEVICE_LINKED_DEVICE_ID_TABLES);
 
-    const missing: string[] = [];
+    const problems: string[] = [];
 
-    for (const table of allTables) {
+    for (const table of allSchemaTables()) {
       const tableName = getTableName(table);
       if (NOT_DEVICES_FK.has(tableName)) continue;
 
       const hasDeviceId = getTableColumns(table).some((col) => col.name === 'device_id');
+      if (!hasDeviceId) continue;
 
-      if (hasDeviceId && !cascadeSet.has(tableName)) {
-        missing.push(tableName);
+      const memberships = [
+        cascadeSet.has(tableName) ? 'DEVICE_CASCADE_DELETE_TABLES' : null,
+        detachSet.has(tableName) ? 'DEVICE_DETACH_DEVICE_ID_TABLES' : null,
+        linkedSet.has(tableName) ? 'DEVICE_LINKED_DEVICE_ID_TABLES' : null,
+      ].filter((m): m is string => m !== null);
+
+      if (memberships.length === 0) {
+        problems.push(`${tableName}: in NO set`);
+      } else if (memberships.length > 1) {
+        problems.push(`${tableName}: in MULTIPLE sets (${memberships.join(', ')})`);
       }
     }
 
     expect(
-      missing,
-      `These tables have a device_id FK but are missing from DEVICE_CASCADE_DELETE_TABLES in core.ts. ` +
-        `Add them to the array (order matters — children before parents). ` +
-        `If the device_id column references a table other than devices, add to NOT_DEVICES_FK in this test instead.\n\n` +
-        `Missing: ${missing.join(', ')}`
+      problems,
+      `Every table with a device_id FK to devices.id must appear in EXACTLY ONE of ` +
+        `DEVICE_CASCADE_DELETE_TABLES (rows deleted; order matters — children before parents), ` +
+        `DEVICE_DETACH_DEVICE_ID_TABLES (tenant business records — device_id SET NULL), or ` +
+        `DEVICE_LINKED_DEVICE_ID_TABLES (linked_device_id SET NULL) in core.ts. ` +
+        `If the device_id column references a table other than devices, add it to NOT_DEVICES_FK ` +
+        `in this test instead.\n\nProblems: ${problems.join('; ')}`
     ).toEqual([]);
+  });
+
+  it('tickets is in the detach set, not the cascade set', () => {
+    // Tickets are tenant business records — hard-deleting a device must
+    // preserve ticket history and detach the device, never destroy tickets.
+    expect(DEVICE_DETACH_DEVICE_ID_TABLES).toContain('tickets');
+    expect(DEVICE_CASCADE_DELETE_TABLES).not.toContain('tickets');
   });
 
   it('includes every table whose linked_device_id FK references devices.id', () => {
     const linkedSet = new Set<string>(DEVICE_LINKED_DEVICE_ID_TABLES);
-    const allTables = Object.values(schema).filter(
-      (v) => v instanceof PgTable
-    ) as PgTable<any>[];
-
     const missing: string[] = [];
 
-    for (const table of allTables) {
+    for (const table of allSchemaTables()) {
       const tableName = getTableName(table);
       const hasLinkedDeviceId = getTableColumns(table).some(
         (col) => col.name === 'linked_device_id'
@@ -77,12 +180,12 @@ describe('DEVICE_CASCADE_DELETE_TABLES coverage', () => {
   });
 
   it('does not list tables that no longer exist in the schema', () => {
-    const allTableNames = new Set(
-      (Object.values(schema).filter((v) => v instanceof PgTable) as PgTable<any>[])
-        .map((t) => getTableName(t))
-    );
+    const allTableNames = new Set(allSchemaTables().map((t) => getTableName(t)));
 
     const staleCascade = DEVICE_CASCADE_DELETE_TABLES.filter(
+      (t) => !allTableNames.has(t)
+    );
+    const staleDetach = DEVICE_DETACH_DEVICE_ID_TABLES.filter(
       (t) => !allTableNames.has(t)
     );
     const staleLinked = DEVICE_LINKED_DEVICE_ID_TABLES.filter(
@@ -94,8 +197,115 @@ describe('DEVICE_CASCADE_DELETE_TABLES coverage', () => {
       `These tables are in DEVICE_CASCADE_DELETE_TABLES but no longer exist in the schema. Remove them.`
     ).toEqual([]);
     expect(
+      staleDetach,
+      `These tables are in DEVICE_DETACH_DEVICE_ID_TABLES but no longer exist in the schema. Remove them.`
+    ).toEqual([]);
+    expect(
       staleLinked,
       `These tables are in DEVICE_LINKED_DEVICE_ID_TABLES but no longer exist in the schema. Remove them.`
     ).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Behavior: DELETE /devices/:id/permanent must DETACH tickets, not delete them.
+// ---------------------------------------------------------------------------
+
+/**
+ * Flatten a Drizzle sql`` object into readable text. StringChunks carry a
+ * string[] `value`, sql.identifier Names carry a string `value`, nested SQL
+ * (subqueries) carries its own queryChunks, and raw bound params are pushed
+ * as-is (same chunk shapes as documented in core.permissions.test.ts).
+ */
+function sqlToText(q: any): string {
+  const chunks = q?.queryChunks ?? [];
+  return chunks
+    .map((ch: any) => {
+      if (ch !== null && typeof ch === 'object') {
+        if (Array.isArray(ch.queryChunks)) return sqlToText(ch);
+        if (Array.isArray(ch.value)) return ch.value.join('');
+        if ('value' in ch) return String(ch.value);
+      }
+      return String(ch);
+    })
+    .join('');
+}
+
+describe('DELETE /devices/:id/permanent — tickets are detached, not destroyed', () => {
+  const DEVICE = {
+    id: '11111111-1111-4111-8111-111111111111',
+    orgId: 'org-123',
+    siteId: 'site-1',
+    hostname: 'host-1',
+    displayName: 'Host 1',
+    agentId: null,
+    status: 'decommissioned' as const,
+  };
+
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/devices', coreRoutes);
+  });
+
+  function rigDeviceLookup(device: unknown) {
+    const limit = vi.fn().mockResolvedValue(device ? [device] : []);
+    const where = vi.fn().mockReturnValue({ limit });
+    const from = vi.fn().mockReturnValue({ where });
+    vi.mocked(db.select).mockReturnValue({ from } as never);
+  }
+
+  function rigDeleteTransaction(): string[] {
+    const statements: string[] = [];
+    vi.mocked(db.transaction).mockImplementation(async (cb: any) => {
+      const tx = {
+        execute: vi.fn().mockImplementation(async (q: any) => {
+          statements.push(sqlToText(q));
+          return [];
+        }),
+        delete: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      };
+      await cb(tx);
+    });
+    return statements;
+  }
+
+  it('hard delete detaches tickets (device_id -> NULL) instead of deleting them', async () => {
+    rigDeviceLookup(DEVICE);
+    const statements = rigDeleteTransaction();
+
+    const res = await app.request(`/devices/${DEVICE.id}/permanent`, {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer t' },
+    });
+
+    // Previously this scenario 409'd: tickets with comments hit the
+    // ticket_comments.ticket_id FK (no cascade) when DELETE FROM tickets ran.
+    expect(res.status).toBe(200);
+
+    const detachTickets = statements.filter((s) =>
+      s.startsWith('UPDATE tickets SET device_id = NULL WHERE device_id = ')
+    );
+    expect(
+      detachTickets,
+      `Expected exactly one "UPDATE tickets SET device_id = NULL" statement.\nStatements:\n${statements.join('\n')}`
+    ).toHaveLength(1);
+
+    const deleteTickets = statements.filter((s) =>
+      s.startsWith('DELETE FROM tickets WHERE')
+    );
+    expect(
+      deleteTickets,
+      `Tickets must never be deleted during device hard-delete.\nStatements:\n${statements.join('\n')}`
+    ).toEqual([]);
+
+    // psa_ticket_mappings (device-scoped integration rows) still cascade.
+    expect(
+      statements.some((s) => s.startsWith('DELETE FROM psa_ticket_mappings WHERE'))
+    ).toBe(true);
   });
 });

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -120,6 +120,22 @@ export const DEVICE_ORG_DENORMALIZED_TABLES = [
 ] as const;
 
 /**
+ * Tables that denormalize `org_id` for RLS but have NO `device_id` column,
+ * so the generic {@link DEVICE_ORG_DENORMALIZED_TABLES} rewrite loop in
+ * moveOrg.ts (which keys on `WHERE device_id = ...`) cannot reach them.
+ * Each table here gets a dedicated, hand-written UPDATE inside the move-org
+ * transaction — e.g. `ticket_alert_links` is rewritten via its alert_id
+ * join to alerts.device_id.
+ *
+ * moveOrg.coverage.test.ts asserts this list is disjoint from the generic
+ * lists (a table with a device_id column belongs there instead) and that
+ * every entry exists with org_id but without device_id, so a future table
+ * can't silently skip both paths. The dedicated statements themselves are
+ * covered by behavior tests in moveOrg.test.ts.
+ */
+export const CUSTOM_ORG_REWRITE_TABLES = ['ticket_alert_links'] as const;
+
+/**
  * Tables that are both device-id scoped AND denormalize site_id for query-perf.
  * EVERY write path that changes devices.site_id must rewrite each row's
  * site_id in the same transaction, or those rows strand under the OLD

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -61,7 +61,16 @@ export const DEVICE_LINKED_DEVICE_ID_TABLES = [
 ] as const;
 
 /**
- * Subset of {@link DEVICE_CASCADE_DELETE_TABLES} whose rows denormalize
+ * Tables with a device_id FK to devices.id whose rows are tenant business
+ * records — preserve history, detach the device (device_id SET NULL) instead
+ * of cascade-deleting during permanent device deletion. Deviceless tickets
+ * are first-class (tickets.device_id is nullable).
+ */
+export const DEVICE_DETACH_DEVICE_ID_TABLES = ['tickets'] as const;
+
+/**
+ * Subset of {@link DEVICE_CASCADE_DELETE_TABLES} ∪
+ * {@link DEVICE_DETACH_DEVICE_ID_TABLES} whose rows denormalize
  * `org_id` for RLS performance. When a device moves between orgs, every
  * one of these tables must have its `org_id` rewritten inside the same
  * transaction that flips `devices.org_id`, otherwise pre-existing rows
@@ -174,8 +183,9 @@ export const DEVICE_CASCADE_DELETE_TABLES = [
   // Analytics & reliability
   'device_reliability_history', 'device_reliability',
   'playbook_executions', 'time_series_metrics', 'capacity_predictions',
-  // Portal & integrations
-  'psa_ticket_mappings', 'tickets', 'asset_checkouts',
+  // Portal & integrations (tickets are detached, not deleted —
+  // see DEVICE_DETACH_DEVICE_ID_TABLES)
+  'psa_ticket_mappings', 'asset_checkouts',
   // Filesystem
   'device_filesystem_snapshots', 'device_filesystem_cleanup_runs', 'device_filesystem_scan_state',
   // Backup verification
@@ -1266,6 +1276,10 @@ coreRoutes.delete(
         await tx.execute(sql`UPDATE network_change_events SET alert_id = NULL WHERE alert_id IN ${deviceAlertIds}`);
         for (const linkedTable of DEVICE_LINKED_DEVICE_ID_TABLES) {
           await tx.execute(sql`UPDATE ${sql.identifier(linkedTable)} SET linked_device_id = NULL WHERE linked_device_id = ${deviceId}`);
+        }
+        // Tenant business records (tickets): preserve history, detach the device.
+        for (const detachTable of DEVICE_DETACH_DEVICE_ID_TABLES) {
+          await tx.execute(sql`UPDATE ${sql.identifier(detachTable)} SET device_id = NULL WHERE device_id = ${deviceId}`);
         }
 
         const tables = DEVICE_CASCADE_DELETE_TABLES;

--- a/apps/api/src/routes/devices/moveOrg.coverage.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.coverage.test.ts
@@ -3,6 +3,7 @@ import { getTableName } from 'drizzle-orm';
 import { PgTable } from 'drizzle-orm/pg-core';
 import * as schema from '../../db/schema';
 import {
+  CUSTOM_ORG_REWRITE_TABLES,
   DEVICE_CASCADE_DELETE_TABLES,
   DEVICE_DETACH_DEVICE_ID_TABLES,
   DEVICE_ORG_DENORMALIZED_TABLES,
@@ -118,6 +119,82 @@ describe('DEVICE_ORG_DENORMALIZED_TABLES coverage', () => {
       `These tables are in DEVICE_ORG_DENORMALIZED_TABLES but missing from both ` +
         `DEVICE_CASCADE_DELETE_TABLES and DEVICE_DETACH_DEVICE_ID_TABLES.`,
     ).toEqual([]);
+  });
+});
+
+/**
+ * CUSTOM_ORG_REWRITE_TABLES — documented exemption from the generic loop.
+ *
+ * These tables denormalize `org_id` for RLS but have NO `device_id` column,
+ * so the generic DEVICE_ORG_DENORMALIZED_TABLES loop in moveOrg.ts (which
+ * keys on `WHERE device_id = ...`) cannot reach them. Each gets a dedicated,
+ * hand-written UPDATE inside the move-org transaction — e.g.
+ * `ticket_alert_links` is rewritten via its alert_id join to alerts.device_id.
+ *
+ * The dedicated statements are covered by behavior tests in moveOrg.test.ts.
+ * This block only guards the list shape, so a future table can't silently
+ * skip BOTH the generic loop and the custom-rewrite path:
+ *   - it must be disjoint from the generic / device-managed lists (a table
+ *     with a device_id column belongs in the generic loop instead), and
+ *   - every entry must exist in the schema with org_id but without device_id.
+ */
+describe('CUSTOM_ORG_REWRITE_TABLES coverage', () => {
+  const customSet = new Set<string>(CUSTOM_ORG_REWRITE_TABLES);
+
+  const allTables = Object.values(schema).filter(
+    (v) => v instanceof PgTable,
+  ) as PgTable<any>[];
+  const tableByName = new Map(allTables.map((t) => [getTableName(t), t] as const));
+
+  it('contains ticket_alert_links (the known no-device_id org-denormalized table)', () => {
+    expect(CUSTOM_ORG_REWRITE_TABLES).toContain('ticket_alert_links');
+  });
+
+  it('is disjoint from the generic denorm, device-managed, and intentional-exclusion lists', () => {
+    const overlapping = [
+      ...DEVICE_ORG_DENORMALIZED_TABLES.filter((t) => customSet.has(t)).map(
+        (t) => `${t} (also in DEVICE_ORG_DENORMALIZED_TABLES)`,
+      ),
+      ...DEVICE_CASCADE_DELETE_TABLES.filter((t) => customSet.has(t)).map(
+        (t) => `${t} (also in DEVICE_CASCADE_DELETE_TABLES)`,
+      ),
+      ...DEVICE_DETACH_DEVICE_ID_TABLES.filter((t) => customSet.has(t)).map(
+        (t) => `${t} (also in DEVICE_DETACH_DEVICE_ID_TABLES)`,
+      ),
+      ...[...INTENTIONALLY_NO_ORG_ID].filter((t) => customSet.has(t)).map(
+        (t) => `${t} (also in INTENTIONALLY_NO_ORG_ID)`,
+      ),
+    ];
+    expect(
+      overlapping,
+      `CUSTOM_ORG_REWRITE_TABLES must be disjoint from the generic move-org ` +
+        `lists — a table is rewritten by exactly one path. If the table has a ` +
+        `device_id column it belongs in DEVICE_ORG_DENORMALIZED_TABLES, not here.`,
+    ).toEqual([]);
+  });
+
+  it('only lists tables that exist with an org_id column and WITHOUT a device_id column', () => {
+    const invalid: string[] = [];
+
+    for (const name of CUSTOM_ORG_REWRITE_TABLES) {
+      const table = tableByName.get(name);
+      if (!table) {
+        invalid.push(`${name} (table no longer exists in the schema)`);
+        continue;
+      }
+      const cols = getColumns(table);
+      if (!cols.some((c) => c.name === 'org_id')) {
+        invalid.push(`${name} (has no org_id column — nothing to rewrite)`);
+      }
+      if (cols.some((c) => c.name === 'device_id')) {
+        invalid.push(
+          `${name} (has a device_id column — move it to DEVICE_ORG_DENORMALIZED_TABLES; ` +
+            `the generic loop can reach it)`,
+        );
+      }
+    }
+
+    expect(invalid, `Stale or misplaced entries in CUSTOM_ORG_REWRITE_TABLES (core.ts).`).toEqual([]);
   });
 });
 

--- a/apps/api/src/routes/devices/moveOrg.coverage.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.coverage.test.ts
@@ -4,6 +4,7 @@ import { PgTable } from 'drizzle-orm/pg-core';
 import * as schema from '../../db/schema';
 import {
   DEVICE_CASCADE_DELETE_TABLES,
+  DEVICE_DETACH_DEVICE_ID_TABLES,
   DEVICE_ORG_DENORMALIZED_TABLES,
   DEVICE_SITE_DENORMALIZED_TABLES,
 } from './core';
@@ -44,18 +45,23 @@ function getColumns(table: PgTable<any>): any[] {
 
 describe('DEVICE_ORG_DENORMALIZED_TABLES coverage', () => {
   const denormSet = new Set<string>(DEVICE_ORG_DENORMALIZED_TABLES);
-  const cascadeSet = new Set<string>(DEVICE_CASCADE_DELETE_TABLES);
+  // Device-managed tables = cascade-deleted ∪ detached (device_id SET NULL,
+  // e.g. tickets). Both kinds must keep org_id in sync on cross-org moves.
+  const managedSet = new Set<string>([
+    ...DEVICE_CASCADE_DELETE_TABLES,
+    ...DEVICE_DETACH_DEVICE_ID_TABLES,
+  ]);
 
   const allTables = Object.values(schema).filter(
     (v) => v instanceof PgTable,
   ) as PgTable<any>[];
 
-  it('includes every cascade-delete table that also has an org_id column', () => {
+  it('includes every device-managed table that also has an org_id column', () => {
     const missing: string[] = [];
 
     for (const table of allTables) {
       const name = getTableName(table);
-      if (!cascadeSet.has(name)) continue;
+      if (!managedSet.has(name)) continue;
       if (INTENTIONALLY_NO_ORG_ID.has(name)) continue;
 
       const cols = getColumns(table);
@@ -67,7 +73,7 @@ describe('DEVICE_ORG_DENORMALIZED_TABLES coverage', () => {
 
     expect(
       missing,
-      `These tables are in DEVICE_CASCADE_DELETE_TABLES and have an org_id column ` +
+      `These tables are in DEVICE_CASCADE_DELETE_TABLES or DEVICE_DETACH_DEVICE_ID_TABLES and have an org_id column ` +
         `but are missing from DEVICE_ORG_DENORMALIZED_TABLES in core.ts. ` +
         `Add them, or — if their org_id is intentionally not denormalized for ` +
         `move purposes — add them to INTENTIONALLY_NO_ORG_ID in this test ` +
@@ -102,13 +108,15 @@ describe('DEVICE_ORG_DENORMALIZED_TABLES coverage', () => {
     ).toEqual([]);
   });
 
-  it('all listed tables are also in DEVICE_CASCADE_DELETE_TABLES', () => {
-    // Sanity: a denormalized device table that isn't cascade-deleted is
-    // a bug elsewhere; flag it here so we don't ship a half-managed table.
-    const orphans = DEVICE_ORG_DENORMALIZED_TABLES.filter((t) => !cascadeSet.has(t));
+  it('all listed tables are also device-managed (cascade-deleted or detached)', () => {
+    // Sanity: a denormalized device table that is neither cascade-deleted
+    // nor detached on permanent delete is a bug elsewhere; flag it here so
+    // we don't ship a half-managed table.
+    const orphans = DEVICE_ORG_DENORMALIZED_TABLES.filter((t) => !managedSet.has(t));
     expect(
       orphans,
-      `These tables are in DEVICE_ORG_DENORMALIZED_TABLES but missing from DEVICE_CASCADE_DELETE_TABLES.`,
+      `These tables are in DEVICE_ORG_DENORMALIZED_TABLES but missing from both ` +
+        `DEVICE_CASCADE_DELETE_TABLES and DEVICE_DETACH_DEVICE_ID_TABLES.`,
     ).toEqual([]);
   });
 });

--- a/apps/api/src/routes/devices/moveOrg.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.test.ts
@@ -51,7 +51,11 @@ import { getDeviceWithOrgAndSiteCheck } from './helpers';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { disconnectAgent } from '../agentWs';
 import { moveOrgRoutes } from './moveOrg';
-import { DEVICE_ORG_DENORMALIZED_TABLES, DEVICE_SITE_DENORMALIZED_TABLES } from './core';
+import {
+  CUSTOM_ORG_REWRITE_TABLES,
+  DEVICE_ORG_DENORMALIZED_TABLES,
+  DEVICE_SITE_DENORMALIZED_TABLES,
+} from './core';
 
 // Snapshot the gate registration BEFORE any `vi.clearAllMocks()` runs.
 // requireScope/requirePermission/requireMfa run at module-import time as the
@@ -126,11 +130,33 @@ function rigOrgAndSiteSelects(opts: {
   });
 }
 
+/**
+ * Flatten a Drizzle sql`` object into readable text. StringChunks carry a
+ * string[] `value`, sql.identifier Names carry a string `value`, nested SQL
+ * (subqueries) carries its own queryChunks, and raw bound params are pushed
+ * as-is (same chunk shapes as documented in cascadeDelete.test.ts).
+ */
+function sqlToText(q: any): string {
+  const chunks = q?.queryChunks ?? [];
+  return chunks
+    .map((ch: any) => {
+      if (ch !== null && typeof ch === 'object') {
+        if (Array.isArray(ch.queryChunks)) return sqlToText(ch);
+        if (Array.isArray(ch.value)) return ch.value.join('');
+        if ('value' in ch) return String(ch.value);
+      }
+      return String(ch);
+    })
+    .join('');
+}
+
 function rigTransactionSuccess(updatedRow: any = { ...SAMPLE_DEVICE, orgId: TARGET_ORG, siteId: TARGET_SITE }) {
   // Each tx.execute() call captures the identifier name being UPDATEd (the
   // second chunk in our `UPDATE ${sql.identifier(table)} SET org_id = ...`
-  // template — Drizzle exposes it as queryChunks[1].value).
+  // template — Drizzle exposes it as queryChunks[1].value) plus the full
+  // flattened statement text for shape assertions.
   const updatedTables: string[] = [];
+  const statements: string[] = [];
   const deviceUpdateSets: any[] = [];
 
   vi.mocked(db.transaction).mockImplementation(async (cb: any) => {
@@ -150,13 +176,14 @@ function rigTransactionSuccess(updatedRow: any = { ...SAMPLE_DEVICE, orgId: TARG
         if (tableChunk && typeof tableChunk.value === 'string') {
           updatedTables.push(tableChunk.value);
         }
+        statements.push(sqlToText(sqlVal));
         return [];
       }),
     };
     await cb(tx);
     return updatedRow;
   });
-  return { updatedTables, deviceUpdateSets };
+  return { updatedTables, statements, deviceUpdateSets };
 }
 
 describe('POST /devices/:id/move-org', () => {
@@ -224,11 +251,14 @@ describe('POST /devices/:id/move-org', () => {
       // Every denormalized table got an UPDATE issued in the transaction.
       // This is the unit-test proxy for "RLS will read from the new org
       // only post-move": each row in those tables has its org_id rewritten
-      // to the new org, so RLS in the OLD org no longer matches it. The
-      // SITE loop runs second and any table in DEVICE_SITE_DENORMALIZED_TABLES
+      // to the new org, so RLS in the OLD org no longer matches it.
+      // CUSTOM_ORG_REWRITE_TABLES (ticket_alert_links — no device_id column,
+      // rewritten via the alert join) follow the generic org loop. The SITE
+      // loop runs last and any table in DEVICE_SITE_DENORMALIZED_TABLES
       // appears in updatedTables a second time for the site_id rewrite.
       expect(updatedTables).toEqual([
         ...DEVICE_ORG_DENORMALIZED_TABLES,
+        ...CUSTOM_ORG_REWRITE_TABLES,
         ...DEVICE_SITE_DENORMALIZED_TABLES,
       ]);
 
@@ -241,6 +271,39 @@ describe('POST /devices/:id/move-org', () => {
         expect.any(Number),
         expect.stringContaining('different organization'),
       );
+    });
+
+    it('rewrites ticket_alert_links org_id via the alert join inside the transaction', async () => {
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(SAMPLE_DEVICE as never);
+      rigOrgAndSiteSelects({
+        orgRows: [
+          { id: SOURCE_ORG, partnerId: 'partner-1' },
+          { id: TARGET_ORG, partnerId: 'partner-1' },
+        ],
+        siteRow: { id: TARGET_SITE },
+      });
+      const { statements } = rigTransactionSuccess();
+
+      const res = await app.request(`/devices/${DEVICE_ID}/move-org`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId: TARGET_ORG, siteId: TARGET_SITE }),
+      });
+      expect(res.status).toBe(200);
+
+      // ticket_alert_links denormalizes org_id for RLS but has NO device_id
+      // column, so the generic DEVICE_ORG_DENORMALIZED_TABLES loop can't
+      // reach it. Without this dedicated rewrite, links for the moved
+      // device's alerts stay under the OLD org's RLS and disappear from the
+      // new org's ticket views (tenant-isolation bug).
+      const linkRewrites = statements.filter((s) => s.startsWith('UPDATE ticket_alert_links '));
+      expect(
+        linkRewrites,
+        `Expected exactly one ticket_alert_links org_id rewrite.\nStatements:\n${statements.join('\n')}`,
+      ).toEqual([
+        `UPDATE ticket_alert_links SET org_id = ${TARGET_ORG}::uuid ` +
+          `WHERE alert_id IN (SELECT id FROM alerts WHERE device_id = ${DEVICE_ID}::uuid)`,
+      ]);
     });
 
     it('writes device.move_org.failed audit when the transaction rolls back', async () => {

--- a/apps/api/src/routes/devices/moveOrg.ts
+++ b/apps/api/src/routes/devices/moveOrg.ts
@@ -46,7 +46,10 @@ moveOrgRoutes.use('*', authMiddleware);
  * RLS hazard: 64 device-scoped tables denormalize `org_id` for RLS perf
  * (see DEVICE_ORG_DENORMALIZED_TABLES). All of them MUST be rewritten in
  * the same transaction or pre-existing rows for this device will be
- * visible only to the OLD org and invisible to the NEW one.
+ * visible only to the OLD org and invisible to the NEW one. Tables that
+ * denormalize org_id but have no device_id column (CUSTOM_ORG_REWRITE_TABLES,
+ * currently ticket_alert_links) get dedicated rewrites in the same
+ * transaction.
  *
  * Audit: writes ONE audit row per org (source + target) so the move shows
  * up in both audit feeds.
@@ -147,6 +150,15 @@ moveOrgRoutes.post(
             sql`UPDATE ${sql.identifier(table)} SET org_id = ${targetOrgId}::uuid WHERE device_id = ${deviceId}::uuid`,
           );
         }
+
+        // ticket_alert_links denormalizes org_id for RLS but has no
+        // device_id column, so the generic loop above can't reach it —
+        // rewrite via the alert join instead. Excluded from
+        // DEVICE_ORG_DENORMALIZED_TABLES; tracked in
+        // CUSTOM_ORG_REWRITE_TABLES (core.ts).
+        await tx.execute(
+          sql`UPDATE ${sql.identifier('ticket_alert_links')} SET org_id = ${targetOrgId}::uuid WHERE alert_id IN (SELECT id FROM alerts WHERE device_id = ${deviceId}::uuid)`,
+        );
 
         // Rewrite denormalized site_id on every device-scoped table that has
         // one (currently elevation_requests — see DEVICE_SITE_DENORMALIZED_TABLES

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -654,6 +654,26 @@ describe('org routes', () => {
 
       expect(res.status).toBe(403);
     });
+
+    // The partner happy-path (permission granted → 200) is already covered by
+    // the 'should return organizations with pagination' test above, which runs
+    // with permissionMockState.granted = true (the beforeEach default) and
+    // scope: 'partner'. Adding a duplicate would be noise.
+
+    it('returns empty data when org-scope token has null orgId (null-guard path)', async () => {
+      // Exercises the `if (!auth.orgId)` guard at ~line 715 of orgs.ts.
+      // The org-scope branch short-circuits before any DB call and must return
+      // 200 with an empty data array, not a 4xx or 5xx.
+      permissionMockState.granted = false;
+      setAuthContext({ scope: 'organization', orgId: null });
+
+      const res = await app.request('/orgs/organizations');
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toEqual([]);
+      expect(body.pagination.total).toBe(0);
+    });
   });
 
   describe('POST /orgs/organizations', () => {

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -95,6 +95,12 @@ vi.mock('drizzle-orm', async (importActual) => {
   };
 });
 
+// Mutable switch for the requirePermission mock so individual tests can
+// simulate a caller whose role LACKS the gated permission (the real middleware
+// 403s). Hoisted because the vi.mock factory below references it. Reset to
+// granted in beforeEach.
+const permissionMockState = vi.hoisted(() => ({ granted: true }));
+
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => {
     c.set('auth', {
@@ -117,7 +123,12 @@ vi.mock('../middleware/auth', () => ({
     return next();
   }),
   requirePartner: vi.fn((c: any, next: any) => next()),
-  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (c: any, next: any) => {
+    if (!permissionMockState.granted) {
+      return c.json({ error: 'Permission denied' }, 403);
+    }
+    return next();
+  }),
   requireMfa: vi.fn(() => async (_c: any, next: any) => next())
 }));
 
@@ -182,6 +193,7 @@ describe('org routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    permissionMockState.granted = true;
     setAuthContext();
     app = new Hono();
     app.route('/orgs', orgRoutes);
@@ -554,6 +566,93 @@ describe('org routes', () => {
       const body = await res.json();
       expect(body.data).toHaveLength(1);
       expect(body.pagination.total).toBe(1);
+    });
+
+    // #1245 residual: org-scope users (Org Admin/Technician/Viewer) lack the
+    // organizations:read permission, but the tickets UI needs this route on
+    // cold load just to render their own org's name. The route skips the
+    // permission check for organization scope ONLY, and returns a projected
+    // name-level row instead of the full org row.
+    it('allows an org-scope user without organizations:read to read their own org', async () => {
+      permissionMockState.granted = false;
+      setAuthContext({ scope: 'organization', orgId: 'org-123' });
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 1 }])
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                offset: vi.fn().mockReturnValue({
+                  orderBy: vi.fn().mockResolvedValue([
+                    { id: 'org-123', name: 'Acme Corp', slug: 'acme', status: 'active' }
+                  ])
+                })
+              })
+            })
+          })
+        } as any);
+
+      const res = await app.request('/orgs/organizations');
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].id).toBe('org-123');
+      expect(body.pagination.total).toBe(1);
+    });
+
+    it('projects the org-scope row to id/name/slug/status only (no privileged fields)', async () => {
+      permissionMockState.granted = false;
+      setAuthContext({ scope: 'organization', orgId: 'org-123' });
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 1 }])
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                offset: vi.fn().mockReturnValue({
+                  orderBy: vi.fn().mockResolvedValue([
+                    { id: 'org-123', name: 'Acme Corp', slug: 'acme', status: 'active' }
+                  ])
+                })
+              })
+            })
+          })
+        } as any);
+
+      const res = await app.request('/orgs/organizations');
+      expect(res.status).toBe(200);
+
+      // The data query (second db.select call, after the count) must pass an
+      // explicit projection of exactly the safe fields — an unprojected
+      // select() would return full rows incl. ssoConfig/billingContact.
+      const dataSelectArg = vi.mocked(db.select).mock.calls[1]?.[0];
+      expect(dataSelectArg).toBeDefined();
+      expect(Object.keys(dataSelectArg as Record<string, unknown>).sort())
+        .toEqual(['id', 'name', 'slug', 'status']);
+
+      const row = (await res.json()).data[0];
+      expect(row).not.toHaveProperty('ssoConfig');
+      expect(row).not.toHaveProperty('billingContact');
+      expect(row).not.toHaveProperty('settings');
+      expect(row).not.toHaveProperty('maxDevices');
+    });
+
+    it('still requires organizations:read for partner scope', async () => {
+      permissionMockState.granted = false;
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+
+      const res = await app.request('/orgs/organizations');
+
+      expect(res.status).toBe(403);
     });
   });
 

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
 import type { Context, Next } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
@@ -697,7 +698,8 @@ const listOrganizationsSchema = z.object({
 // auth.orgId and projects to safe fields only.
 const requireOrgReadUnlessOwnOrg = async (c: Context, next: Next) => {
   const auth = c.get('auth') as AuthContext | undefined;
-  if (auth?.scope === 'organization') return next();
+  if (!auth) throw new HTTPException(401, { message: 'Not authenticated' });
+  if (auth.scope === 'organization') return next();
   return requireOrgRead(c, next);
 };
 

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import type { Context, Next } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
@@ -688,19 +689,57 @@ const listOrganizationsSchema = z.object({
   limit: z.string().optional()
 });
 
-orgRoutes.get('/organizations', requireScope('organization', 'partner', 'system'), requireOrgRead, zValidator('query', listOrganizationsSchema), async (c) => {
+// Org-scope callers may read their OWN org's name-level row without the
+// organizations:read permission (UI shell / tickets cold load, #1245 residual)
+// — every org user implicitly needs their org's name to render the app shell.
+// Partner/system scope still requires the permission: they list many orgs and
+// receive full rows. The handler's organization branch is hard-scoped to
+// auth.orgId and projects to safe fields only.
+const requireOrgReadUnlessOwnOrg = async (c: Context, next: Next) => {
+  const auth = c.get('auth') as AuthContext | undefined;
+  if (auth?.scope === 'organization') return next();
+  return requireOrgRead(c, next);
+};
+
+orgRoutes.get('/organizations', requireScope('organization', 'partner', 'system'), requireOrgReadUnlessOwnOrg, zValidator('query', listOrganizationsSchema), async (c) => {
   const auth = c.get('auth') as AuthContext;
   const { partnerId: queryPartnerId, ...pagination } = c.req.valid('query');
   const { page, limit, offset } = getPagination(pagination);
 
-  let conditions;
   if (auth.scope === 'organization') {
-    // Organization-scoped users can only see their own organization
+    // Organization-scoped users can only see their own organization, and —
+    // because they reach this route without organizations:read (see
+    // requireOrgReadUnlessOwnOrg above) — only a name-level projection of it.
+    // An unprojected select() here would leak ssoConfig, billingContact,
+    // settings, maxDevices, etc. to roles that never held the permission.
     if (!auth.orgId) {
       return c.json({ data: [], pagination: { page, limit, total: 0 } });
     }
-    conditions = and(eq(organizations.id, auth.orgId), isNull(organizations.deletedAt));
-  } else if (auth.scope === 'partner') {
+    const ownOrgCondition = and(eq(organizations.id, auth.orgId), isNull(organizations.deletedAt));
+    const countResult = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(organizations)
+      .where(ownOrgCondition);
+    const data = await db
+      .select({
+        id: organizations.id,
+        name: organizations.name,
+        slug: organizations.slug,
+        status: organizations.status
+      })
+      .from(organizations)
+      .where(ownOrgCondition)
+      .limit(limit)
+      .offset(offset)
+      .orderBy(organizations.createdAt);
+    return c.json({
+      data,
+      pagination: { page, limit, total: Number(countResult[0]?.count ?? 0) }
+    });
+  }
+
+  let conditions;
+  if (auth.scope === 'partner') {
     const orgIds = auth.accessibleOrgIds ?? [];
     if (orgIds.length === 0) {
       return c.json({
@@ -732,7 +771,7 @@ orgRoutes.get('/organizations', requireScope('organization', 'partner', 'system'
   // Apply the partner's preferred organization order, when one is set.
   // - partner scope: load own partner settings.
   // - system scope: only when a partnerId filter is in the query.
-  // - organization scope: list is at most one row, nothing to reorder.
+  // (organization scope already returned above — at most one row anyway.)
   let ordered = data;
   let orderPartnerId: string | null = null;
   if (auth.scope === 'partner' && auth.partnerId) orderPartnerId = auth.partnerId;

--- a/apps/api/src/routes/tickets/siteScope.ts
+++ b/apps/api/src/routes/tickets/siteScope.ts
@@ -1,0 +1,47 @@
+import { eq, inArray, isNull, or, type SQL } from 'drizzle-orm';
+import { db } from '../../db';
+import { tickets, devices } from '../../db/schema';
+import { siteAccessCheck } from '../../middleware/auth';
+import type { AuthContext } from '../../middleware/auth';
+
+/**
+ * Site-axis (sub-org) device gate. `auth.allowedSiteIds` is only populated for
+ * organization-scope users with a site restriction — everyone else passes.
+ * A restricted caller is denied for a device with no site assignment
+ * (matches siteAccessCheck semantics in middleware/auth.ts).
+ *
+ * This is a site gate, not an existence check: a nonexistent deviceId is
+ * denied for restricted callers but passes for unrestricted ones — device
+ * existence is enforced in the service layer.
+ */
+export async function deviceInSiteScope(auth: AuthContext, deviceId: string): Promise<boolean> {
+  if (!auth.allowedSiteIds) return true;
+  const rows = await db
+    .select({ siteId: devices.siteId })
+    .from(devices)
+    .where(eq(devices.id, deviceId))
+    .limit(1);
+  return siteAccessCheck(auth.allowedSiteIds)(rows[0]?.siteId);
+}
+
+/**
+ * Site-axis list condition (spec §7): device-bound tickets are limited to
+ * devices in the caller's allowed sites; deviceless (org-level) tickets stay
+ * visible. Uses an IN-subquery on devices instead of a join so the same
+ * condition works for the list, count, and stats queries unchanged. Empty
+ * allowlist = deviceless tickets only. Returns undefined for unrestricted
+ * callers (partner/system scope, or org users without a site restriction).
+ * Exported for direct unit testing of the tri-state contract.
+ */
+export function ticketSiteScopeCondition(auth: AuthContext): SQL | undefined {
+  const allowed = auth.allowedSiteIds;
+  if (!allowed) return undefined;
+  if (allowed.length === 0) return isNull(tickets.deviceId);
+  return or(
+    isNull(tickets.deviceId),
+    inArray(
+      tickets.deviceId,
+      db.select({ id: devices.id }).from(devices).where(inArray(devices.siteId, allowed))
+    )
+  )!;
+}

--- a/apps/api/src/routes/tickets/tickets.test.ts
+++ b/apps/api/src/routes/tickets/tickets.test.ts
@@ -139,7 +139,7 @@ vi.mock('../../db/schema', () => ({
   ticketComments: { ticketId: 'ticketId', deletedAt: 'deletedAt', createdAt: 'createdAt' },
   ticketCategories: {},
   ticketAlertLinks: { ticketId: 'ticketId', alertId: 'alertId', id: 'id', linkType: 'linkType' },
-  alerts: { id: 'id', title: 'title', severity: 'severity', status: 'status' },
+  alerts: { id: 'id', title: 'title', severity: 'severity', status: 'status', deviceId: 'deviceId' },
   devices: { id: 'id', hostname: 'hostname', orgId: 'orgId', siteId: 'siteId' },
   organizations: { id: 'id', name: 'name' },
   users: { id: 'id', name: 'name' }
@@ -608,7 +608,9 @@ describe('POST /tickets/:id/alerts', () => {
 
   it('calls linkAlertToTicket and returns 201', async () => {
     const ALERT_ID = '4f3f2e9f-2222-4333-9444-555566667777';
-    dbSelectMock.mockResolvedValueOnce([STUB_TICKET]);
+    dbSelectMock
+      .mockResolvedValueOnce([STUB_TICKET])          // ticket fetch
+      .mockResolvedValueOnce([{ deviceId: null }]);  // alert row (site gate)
     serviceMocks.linkAlertToTicket.mockResolvedValue({ id: 'link-1', ticketId: TICKET_ID, alertId: ALERT_ID });
 
     const res = await makeApp().request(`/tickets/${TICKET_ID}/alerts`, {
@@ -643,7 +645,9 @@ describe('DELETE /tickets/:id/alerts/:alertId', () => {
   const ALERT_ID = '4f3f2e9f-2222-4333-9444-555566667777';
 
   it('calls unlinkAlertFromTicket and returns 200', async () => {
-    dbSelectMock.mockResolvedValueOnce([STUB_TICKET]);
+    dbSelectMock
+      .mockResolvedValueOnce([STUB_TICKET])          // ticket fetch
+      .mockResolvedValueOnce([{ deviceId: null }]);  // alert row (site gate)
     serviceMocks.unlinkAlertFromTicket.mockResolvedValue({ ticketId: TICKET_ID, alertId: ALERT_ID });
 
     const res = await makeApp().request(`/tickets/${TICKET_ID}/alerts/${ALERT_ID}`, {
@@ -1093,6 +1097,94 @@ describe('site-axis scoping — per-ticket routes', () => {
     const body = await res.json();
     expect(body.data).toEqual({ updated: 0, skipped: 1, failed: 0, skippedReasons: { OUT_OF_SCOPE: 1 }, total: 1 });
     expect(serviceMocks.changeTicketStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe('site-axis scoping — alert-link routes gate on the ALERT device', () => {
+  const SITE_AUTH = {
+    ...DEFAULT_AUTH,
+    scope: 'organization' as string,
+    orgId: 'org-1' as string | null,
+    partnerId: null as string | null,
+    allowedSiteIds: ['site-1']
+  };
+  const ALERT_ID = '4f3f2e9f-2222-4333-9444-555566667777';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authRef.current = SITE_AUTH as typeof authRef.current;
+  });
+
+  it('POST /tickets/:id/alerts returns 404 when the alert device is outside the caller site scope', async () => {
+    dbSelectMock
+      .mockResolvedValueOnce([{ ...STUB_TICKET, orgId: 'org-1', deviceId: null }]) // ticket fetch (deviceless, in scope)
+      .mockResolvedValueOnce([{ deviceId: 'd-2' }])                                // alert row
+      .mockResolvedValueOnce([{ siteId: 'site-OTHER' }]);                          // alert device fetch
+    const res = await makeApp().request(`/tickets/${TICKET_ID}/alerts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ alertId: ALERT_ID })
+    });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toHaveProperty('error', 'Alert not found');
+    expect(serviceMocks.linkAlertToTicket).not.toHaveBeenCalled();
+  });
+
+  it('DELETE /tickets/:id/alerts/:alertId applies the same gate', async () => {
+    dbSelectMock
+      .mockResolvedValueOnce([{ ...STUB_TICKET, orgId: 'org-1', deviceId: null }]) // ticket fetch (deviceless, in scope)
+      .mockResolvedValueOnce([{ deviceId: 'd-2' }])                                // alert row
+      .mockResolvedValueOnce([{ siteId: 'site-OTHER' }]);                          // alert device fetch
+    const res = await makeApp().request(`/tickets/${TICKET_ID}/alerts/${ALERT_ID}`, {
+      method: 'DELETE'
+    });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toHaveProperty('error', 'Alert not found');
+    expect(serviceMocks.unlinkAlertFromTicket).not.toHaveBeenCalled();
+  });
+
+  it('alert links for in-site devices still work for restricted users', async () => {
+    dbSelectMock
+      .mockResolvedValueOnce([{ ...STUB_TICKET, orgId: 'org-1', deviceId: null }]) // ticket fetch (deviceless, in scope)
+      .mockResolvedValueOnce([{ deviceId: 'd-2' }])                                // alert row
+      .mockResolvedValueOnce([{ siteId: 'site-1' }]);                              // alert device fetch (allowed)
+    serviceMocks.linkAlertToTicket.mockResolvedValue({ id: 'link-1', ticketId: TICKET_ID, alertId: ALERT_ID });
+    const res = await makeApp().request(`/tickets/${TICKET_ID}/alerts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ alertId: ALERT_ID })
+    });
+    expect(res.status).toBe(201);
+    expect(serviceMocks.linkAlertToTicket).toHaveBeenCalledWith(
+      TICKET_ID, ALERT_ID, expect.objectContaining({ userId: 'u-1' })
+    );
+  });
+
+  it('deviceless alerts stay linkable for restricted users (no device lookup)', async () => {
+    dbSelectMock
+      .mockResolvedValueOnce([{ ...STUB_TICKET, orgId: 'org-1', deviceId: null }]) // ticket fetch
+      .mockResolvedValueOnce([{ deviceId: null }]);                                // alert row (deviceless)
+    serviceMocks.linkAlertToTicket.mockResolvedValue({ id: 'link-1', ticketId: TICKET_ID, alertId: ALERT_ID });
+    const res = await makeApp().request(`/tickets/${TICKET_ID}/alerts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ alertId: ALERT_ID })
+    });
+    expect(res.status).toBe(201);
+  });
+
+  it('a nonexistent alert row 404s before the service call', async () => {
+    dbSelectMock
+      .mockResolvedValueOnce([{ ...STUB_TICKET, orgId: 'org-1', deviceId: null }]) // ticket fetch
+      .mockResolvedValueOnce([]);                                                  // alert row: missing
+    const res = await makeApp().request(`/tickets/${TICKET_ID}/alerts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ alertId: ALERT_ID })
+    });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toHaveProperty('error', 'Alert not found');
+    expect(serviceMocks.linkAlertToTicket).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -4,7 +4,8 @@ import { z } from 'zod';
 import { and, asc, desc, eq, ilike, inArray, isNull, or, sql, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
 import { tickets, ticketComments, ticketAlertLinks, devices, organizations, users, alerts } from '../../db/schema';
-import { requireScope, requirePermission, siteAccessCheck } from '../../middleware/auth';
+import { requireScope, requirePermission } from '../../middleware/auth';
+import { deviceInSiteScope, ticketSiteScopeCondition } from './siteScope';
 import { PERMISSIONS } from '../../services/permissions';
 import {
   createTicketSchema, updateTicketSchema, changeTicketStatusSchema,
@@ -109,47 +110,10 @@ export async function getScopedTicketOr404(
   return ticket;
 }
 
-/**
- * Site-axis (sub-org) device gate. `auth.allowedSiteIds` is only populated for
- * organization-scope users with a site restriction — everyone else passes.
- * A restricted caller is denied for a device with no site assignment
- * (matches siteAccessCheck semantics in middleware/auth.ts).
- *
- * This is a site gate, not an existence check: a nonexistent deviceId is
- * denied for restricted callers but passes for unrestricted ones — device
- * existence is enforced in the service layer.
- */
-async function deviceInSiteScope(auth: AuthContext, deviceId: string): Promise<boolean> {
-  if (!auth.allowedSiteIds) return true;
-  const rows = await db
-    .select({ siteId: devices.siteId })
-    .from(devices)
-    .where(eq(devices.id, deviceId))
-    .limit(1);
-  return siteAccessCheck(auth.allowedSiteIds)(rows[0]?.siteId);
-}
-
-/**
- * Site-axis list condition (spec §7): device-bound tickets are limited to
- * devices in the caller's allowed sites; deviceless (org-level) tickets stay
- * visible. Uses an IN-subquery on devices instead of a join so the same
- * condition works for the list, count, and stats queries unchanged. Empty
- * allowlist = deviceless tickets only. Returns undefined for unrestricted
- * callers (partner/system scope, or org users without a site restriction).
- * Exported for direct unit testing of the tri-state contract.
- */
-export function ticketSiteScopeCondition(auth: AuthContext): SQL | undefined {
-  const allowed = auth.allowedSiteIds;
-  if (!allowed) return undefined;
-  if (allowed.length === 0) return isNull(tickets.deviceId);
-  return or(
-    isNull(tickets.deviceId),
-    inArray(
-      tickets.deviceId,
-      db.select({ id: devices.id }).from(devices).where(inArray(devices.siteId, allowed))
-    )
-  )!;
-}
+// Site-axis helpers (deviceInSiteScope, ticketSiteScopeCondition) live in
+// ./siteScope so the alerts routes can share them; re-exported here for
+// existing consumers (tests pin the tri-state contract via this path).
+export { deviceInSiteScope, ticketSiteScopeCondition };
 
 /** Sentinel returned by buildScopeConditions when the caller context is broken. */
 const SCOPE_MISSING = Symbol('SCOPE_MISSING');
@@ -566,6 +530,22 @@ ticketsRoutes.post(
     const found = await getScopedTicketOr404(auth, id);
     if (!found) return c.json({ error: 'Ticket not found' }, 404);
 
+    // Site-axis gate on the ALERT's device (the ticket's device was already
+    // gated above): a site-restricted caller must not link alerts for devices
+    // outside their allowed sites. The service's same-org check stays in
+    // linkAlertToTicket — the route layer owns the site axis.
+    const alertRows = await db
+      .select({ deviceId: alerts.deviceId })
+      .from(alerts)
+      .where(eq(alerts.id, alertId))
+      .limit(1);
+    const alertRow = alertRows[0];
+    if (!alertRow) return c.json({ error: 'Alert not found' }, 404);
+    if (alertRow.deviceId && !(await deviceInSiteScope(auth, alertRow.deviceId))) {
+      // Out-of-site alerts are invisible, not forbidden — same shape as the ticket gate.
+      return c.json({ error: 'Alert not found' }, 404);
+    }
+
     try {
       const link = await linkAlertToTicket(id, alertId, actorFrom(c));
       return c.json({ data: link }, 201);
@@ -590,6 +570,19 @@ ticketsRoutes.delete(
     }
     const found = await getScopedTicketOr404(auth, id);
     if (!found) return c.json({ error: 'Ticket not found' }, 404);
+
+    // Same site-axis gate as the link route: an out-of-site alert must be
+    // invisible to a restricted caller even for unlink.
+    const alertRows = await db
+      .select({ deviceId: alerts.deviceId })
+      .from(alerts)
+      .where(eq(alerts.id, alertId))
+      .limit(1);
+    const alertRow = alertRows[0];
+    if (!alertRow) return c.json({ error: 'Alert not found' }, 404);
+    if (alertRow.deviceId && !(await deviceInSiteScope(auth, alertRow.deviceId))) {
+      return c.json({ error: 'Alert not found' }, 404);
+    }
 
     try {
       await unlinkAlertFromTicket(id, alertId, actorFrom(c));

--- a/apps/api/src/services/aiToolsTicketing.test.ts
+++ b/apps/api/src/services/aiToolsTicketing.test.ts
@@ -14,21 +14,37 @@ vi.mock('./ticketService', async () => {
   return { ...actual, ...serviceMocks };
 });
 
-// Mutable handle so individual tests can override the limit() return value.
-// Typed as returning unknown[] so mockResolvedValue(TICKET_ROW) compiles.
-const mockLimit = vi.fn<() => Promise<unknown[]>>(() => Promise.resolve([]));
+// Mutable handle so individual tests can override the limit() return value
+// (typed as returning unknown[] so mockResolvedValue(TICKET_ROW) compiles),
+// plus shared spies so the site-scope tests can assert on (a) how many
+// selects a list call issues (the devices IN-subquery is a second select)
+// and (b) the condition the list query hands to .where(). The returned shape
+// supports both the list chain (where → orderBy → limit) and the by-id chain
+// (where → limit). Hoisted because the vi.mock factory references them.
+const { mockLimit, mockWhere, mockSelect } = vi.hoisted(() => {
+  const mockLimit = vi.fn<() => Promise<unknown[]>>(() => Promise.resolve([]));
+  const mockWhere = vi.fn((..._args: unknown[]) => ({
+    orderBy: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([])) })),
+    limit: mockLimit
+  }));
+  const mockSelect = vi.fn(() => ({
+    from: vi.fn(() => ({ where: mockWhere }))
+  }));
+  return { mockLimit, mockWhere, mockSelect };
+});
 
 vi.mock('../db', () => ({
-  db: {
-    select: vi.fn(() => ({
-      from: vi.fn(() => ({
-        where: vi.fn(() => ({
-          orderBy: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([])) })),
-          limit: mockLimit
-        }))
-      }))
-    }))
-  }
+  db: { select: mockSelect }
+}));
+
+// The REAL routes/tickets/siteScope module is exercised below (the list
+// action must route through ticketSiteScopeCondition), but it imports
+// siteAccessCheck from middleware/auth at module load. ticketSiteScopeCondition
+// never calls it — stub the module so this unit test doesn't drag in the full
+// auth middleware dependency tree (jwt/permissions/token revocation).
+vi.mock('../middleware/auth', () => ({
+  siteAccessCheck: (allowed: string[]) => (siteId?: string | null) =>
+    !!siteId && allowed.includes(siteId)
 }));
 
 vi.mock('../db/schema', async (importOriginal) => {
@@ -71,6 +87,19 @@ const authNoOrg: AuthContext = {
   ...auth,
   canAccessOrg: vi.fn(() => false),
 };
+
+// Site-restricted org-scope caller (mirrors makeAuth in the sibling
+// aiTools*.siteScope.test.ts files).
+function makeSiteAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    ...auth,
+    scope: 'organization',
+    partnerId: null,
+    orgId: 'o-1',
+    allowedSiteIds,
+    canAccessSite: (s) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  };
+}
 
 const TICKET_ROW = [{ id: 't-1', orgId: 'o-1', subject: 'Disk full', status: 'open', priority: 'normal' }];
 
@@ -270,6 +299,51 @@ describe('manage_tickets tool', () => {
     expect(parsed).toHaveProperty('error');
     expect(parsed.error).toMatch(/orgId is required/i);
     expect(serviceMocks.createTicket).not.toHaveBeenCalled();
+  });
+});
+
+// ── list — site-axis scoping ──────────────────────────────────────────────
+//
+// The list action must mirror the HTTP list route (routes/tickets/tickets.ts)
+// and apply ticketSiteScopeCondition, so a site-restricted caller cannot read
+// device-bound tickets outside their allowed sites. These tests exercise the
+// REAL siteScope module (not a mock) and assert on the condition handed to
+// the list query's .where(); the semantic shape of the condition itself is
+// pinned by the tri-state contract tests in routes/tickets/tickets.test.ts.
+describe('manage_tickets list — site-axis scoping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLimit.mockResolvedValue([]);
+  });
+
+  it('applies the site condition (devices IN-subquery) for a site-restricted caller', async () => {
+    const out = await getTool().handler({ action: 'list' }, makeSiteAuth(['site-1']));
+    expect(JSON.parse(out)).toHaveProperty('tickets');
+    // The site allowlist builds a devices subquery — plus the list query itself.
+    expect(mockSelect).toHaveBeenCalledTimes(2);
+    // With no org/status/device filters and orgCondition undefined, the ONLY
+    // possible condition is the site-axis one. Pre-fix the list query ran
+    // with where(undefined), returning every org ticket to a site-restricted
+    // caller.
+    const whereArg = mockWhere.mock.calls.at(-1)?.[0];
+    expect(whereArg).toBeDefined();
+  });
+
+  it('restricts an empty allowlist to deviceless tickets only', async () => {
+    await getTool().handler({ action: 'list' }, makeSiteAuth([]));
+    // Empty allowlist short-circuits to isNull(tickets.deviceId) — no devices
+    // subquery is built, just the list query itself.
+    expect(mockSelect).toHaveBeenCalledTimes(1);
+    const whereArg = mockWhere.mock.calls.at(-1)?.[0];
+    expect(whereArg).toBeDefined();
+    expect(JSON.stringify(whereArg)).toContain('is null');
+  });
+
+  it("leaves an unrestricted caller's list unchanged (no site condition)", async () => {
+    const out = await getTool().handler({ action: 'list' }, auth);
+    expect(JSON.parse(out)).toHaveProperty('tickets');
+    expect(mockSelect).toHaveBeenCalledTimes(1);
+    expect(mockWhere.mock.calls.at(-1)?.[0]).toBeUndefined();
   });
 });
 

--- a/apps/api/src/services/aiToolsTicketing.ts
+++ b/apps/api/src/services/aiToolsTicketing.ts
@@ -10,6 +10,7 @@ import { and, desc, eq, type SQL } from 'drizzle-orm';
 import { db } from '../db';
 import { tickets } from '../db/schema';
 import type { AuthContext } from '../middleware/auth';
+import { ticketSiteScopeCondition } from '../routes/tickets/siteScope';
 import type { AiTool, AiToolTier } from './aiTools';
 import {
   createTicket,
@@ -117,6 +118,11 @@ export function registerTicketingTools(aiTools: Map<string, AiTool>): void {
         const conditions: SQL[] = [];
         const orgCond = auth.orgCondition(tickets.orgId);
         if (orgCond) conditions.push(orgCond);
+        // Site axis: mirror the HTTP list route (routes/tickets/tickets.ts) —
+        // a site-restricted caller must not see device-bound tickets outside
+        // their allowed sites (deviceless org-level tickets stay visible).
+        const siteCondition = ticketSiteScopeCondition(auth);
+        if (siteCondition) conditions.push(siteCondition);
         if (input.orgId) conditions.push(eq(tickets.orgId, input.orgId as string));
         if (input.deviceId) conditions.push(eq(tickets.deviceId, input.deviceId as string));
         if (input.status) conditions.push(eq(tickets.status, input.status as TicketStatus));

--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -585,7 +585,7 @@ describe('TicketWorkbench sticky composer across refreshes', () => {
 
     // After the refresh settles the composer is still on the internal tab.
     await waitFor(() => {
-      expect(screen.getByTestId('ticket-workbench')).not.toHaveAttribute('aria-busy', 'true');
+      expect(screen.getByTestId('ticket-workbench')).not.toHaveAttribute('aria-busy');
     });
     expect(screen.getByTestId('ticket-composer-tab-internal')).toHaveAttribute('aria-selected', 'true');
   });

--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -533,6 +533,85 @@ describe('TicketWorkbench forms keep input when the status POST fails', () => {
   });
 });
 
+describe('TicketWorkbench sticky composer across refreshes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps the composer mounted (and its internal-note tab selected) across a refresh after send', async () => {
+    // The first GET resolves immediately; the reload GET after send stays
+    // pending until we release it, so the in-flight refresh state commits
+    // (instant mocks never let the loading=true render reach the DOM).
+    let releaseReload: (() => void) | null = null;
+    let ticketGets = 0;
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === '/users') return makeJsonResponse({ data: [] });
+      if ((!init?.method || init.method === 'GET') && url === '/tickets/tk-1') {
+        ticketGets += 1;
+        if (ticketGets === 1) return makeJsonResponse({ data: makeTicket() });
+        return new Promise<Response>((resolve) => {
+          releaseReload = () => resolve(makeJsonResponse({ data: makeTicket() }));
+        });
+      }
+      return makeJsonResponse({ success: true });
+    });
+
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    await screen.findByTestId('ticket-workbench');
+    fireEvent.click(screen.getByTestId('ticket-composer-tab-internal'));
+    expect(screen.getByTestId('ticket-composer-tab-internal')).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.change(screen.getByTestId('ticket-composer-input'), { target: { value: 'internal note body' } });
+    fireEvent.click(screen.getByTestId('ticket-composer-send'));
+
+    // Send landed and the reload GET is now in flight (held open by the mock).
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/comments',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+    await waitFor(() => {
+      expect(releaseReload).not.toBeNull();
+    });
+
+    // Mid-refresh: the skeleton must NOT replace the mounted tree.
+    expect(screen.queryByTestId('ticket-workbench-loading')).toBeNull();
+    expect(screen.getByTestId('ticket-composer-tab-internal')).toHaveAttribute('aria-selected', 'true');
+
+    releaseReload!();
+
+    // After the refresh settles the composer is still on the internal tab.
+    await waitFor(() => {
+      expect(screen.getByTestId('ticket-workbench')).not.toHaveAttribute('aria-busy', 'true');
+    });
+    expect(screen.getByTestId('ticket-composer-tab-internal')).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('switching tickets still shows the skeleton and resets the composer (no draft/mode leak)', async () => {
+    mockTicketApiWithUsers({
+      'tk-a': makeTicket({ id: 'tk-a', internalNumber: 'T-2026-0001' }),
+      'tk-b': makeTicket({ id: 'tk-b', internalNumber: 'T-2026-0002' })
+    });
+    const { rerender } = render(<TicketWorkbench ticketId="tk-a" />);
+
+    await screen.findByTestId('ticket-workbench');
+    fireEvent.click(screen.getByTestId('ticket-composer-tab-internal'));
+    fireEvent.change(screen.getByTestId('ticket-composer-input'), { target: { value: 'draft for ticket A' } });
+
+    rerender(<TicketWorkbench ticketId="tk-b" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ticket-workbench-number')).toHaveTextContent('T-2026-0002');
+    });
+    // Ticket B must not inherit ticket A's draft or internal mode.
+    expect(screen.getByTestId('ticket-composer-input')).toHaveValue('');
+    expect(screen.getByTestId('ticket-composer-tab-reply')).toHaveAttribute('aria-selected', 'true');
+  });
+});
+
 describe('TicketWorkbench host-supplied assignees prop', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -83,7 +83,11 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
 
   // Reset the inline resolve form when switching tickets — otherwise ticket B
   // could be resolved with ticket A's note (`e` on A, then `j` to B).
+  // Dropping the ticket also brings back the first-load skeleton for the new
+  // ticket, unmounting the composer so its draft/mode can't leak across
+  // tickets — same-ticket refreshes keep the tree mounted (see render below).
   useEffect(() => {
+    setTicket(null);
     setResolveOpen(false);
     setResolutionNote('');
     setPendingOpen(null);
@@ -164,7 +168,10 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
     onChanged?.();
   }, [ticketId, load, onChanged]);
 
-  if (loading) {
+  // Skeleton only on the first load of a ticket. Refreshes (send, status
+  // change, refreshToken bump) keep the tree mounted so composer state —
+  // the public/internal tab in particular — survives; aria-busy marks them.
+  if (loading && !ticket) {
     return <div className="p-6 animate-pulse space-y-3" data-testid="ticket-workbench-loading">
       <div className="h-5 w-2/3 rounded bg-muted" /><div className="h-4 w-1/3 rounded bg-muted/60" /><div className="h-40 rounded bg-muted/40" />
     </div>;
@@ -183,7 +190,7 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-col" data-testid="ticket-workbench">
+    <div className="flex h-full min-h-0 flex-col" data-testid="ticket-workbench" aria-busy={loading}>
       {/* Header */}
       <div className="border-b px-4 py-3">
         <div className="flex items-center gap-2">

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -190,7 +190,7 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-col" data-testid="ticket-workbench" aria-busy={loading}>
+    <div className="flex h-full min-h-0 flex-col" data-testid="ticket-workbench" aria-busy={loading || undefined}>
       {/* Header */}
       <div className="border-b px-4 py-3">
         <div className="flex items-center gap-2">

--- a/apps/web/src/components/tickets/TicketsPage.test.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.test.tsx
@@ -389,7 +389,28 @@ describe('TicketsPage', () => {
       });
     });
 
-    it('switching tabs clears the selection and hides the bulk bar', async () => {
+    it('keeps selections when switching tabs (count includes off-view rows)', async () => {
+      // The unassigned tab returns a list that excludes both selected rows —
+      // the selection (and its count) must survive anyway: POST /tickets/bulk
+      // takes raw ids and doesn't care about tabs.
+      mockListApi((url) => (url.includes('assignee=unassigned') ? [breached] : [healthy, atRisk, breached]));
+      render(<TicketsPage />);
+
+      await screen.findByTestId('ticket-row-tk-healthy');
+      fireEvent.click(screen.getByTestId('ticket-select-tk-healthy'));
+      fireEvent.click(screen.getByTestId('ticket-select-tk-risk'));
+      expect(screen.getByTestId('tickets-bulk-bar')).toHaveTextContent('2 selected');
+
+      fireEvent.click(screen.getByTestId('tickets-tab-unassigned'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('ticket-row-tk-healthy')).toBeNull();
+      });
+      // Both selected rows are off-view now; the bar still reports them.
+      expect(screen.getByTestId('tickets-bulk-bar')).toHaveTextContent('2 selected');
+    });
+
+    it('clears selections when filters change', async () => {
       mockListApi([healthy, atRisk, breached]);
       render(<TicketsPage />);
 
@@ -397,11 +418,47 @@ describe('TicketsPage', () => {
       fireEvent.click(screen.getByTestId('ticket-select-tk-healthy'));
       expect(screen.getByTestId('tickets-bulk-bar')).toBeInTheDocument();
 
-      fireEvent.click(screen.getByTestId('tickets-tab-unassigned'));
+      fireEvent.change(screen.getByTestId('tickets-filter-priority'), { target: { value: 'high' } });
 
       await waitFor(() => {
         expect(screen.queryByTestId('tickets-bulk-bar')).toBeNull();
       });
+    });
+
+    it('Clear empties a cross-tab selection spanning hidden rows', async () => {
+      mockListApi((url) => (url.includes('assignee=unassigned') ? [breached] : [healthy, atRisk, breached]));
+      render(<TicketsPage />);
+
+      await screen.findByTestId('ticket-row-tk-healthy');
+      fireEvent.click(screen.getByTestId('ticket-select-tk-healthy'));
+      fireEvent.click(screen.getByTestId('ticket-select-tk-risk'));
+
+      fireEvent.click(screen.getByTestId('tickets-tab-unassigned'));
+      await waitFor(() => {
+        expect(screen.queryByTestId('ticket-row-tk-healthy')).toBeNull();
+      });
+      expect(screen.getByTestId('tickets-bulk-bar')).toHaveTextContent('2 selected');
+
+      fireEvent.click(screen.getByTestId('tickets-bulk-clear'));
+      await waitFor(() => {
+        expect(screen.queryByTestId('tickets-bulk-bar')).toBeNull();
+      });
+    });
+
+    it('Select all adds the visible rows without dropping off-view selections', async () => {
+      mockListApi((url) => (url.includes('assignee=unassigned') ? [breached] : [healthy, atRisk]));
+      render(<TicketsPage />);
+
+      await screen.findByTestId('ticket-row-tk-healthy');
+      fireEvent.click(screen.getByTestId('ticket-select-tk-healthy'));
+      fireEvent.click(screen.getByTestId('ticket-select-tk-risk'));
+
+      fireEvent.click(screen.getByTestId('tickets-tab-unassigned'));
+      await screen.findByTestId('ticket-row-tk-breach');
+
+      fireEvent.click(screen.getByTestId('tickets-bulk-select-all'));
+      // 2 off-view (open tab) + 1 visible = 3, not a replace-with-visible.
+      expect(screen.getByTestId('tickets-bulk-bar')).toHaveTextContent('3 selected');
     });
 
     it('Clear empties the selection; Select all selects every visible row', async () => {

--- a/apps/web/src/components/tickets/TicketsPage.test.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.test.tsx
@@ -476,6 +476,24 @@ describe('TicketsPage', () => {
         expect(screen.queryByTestId('tickets-bulk-bar')).toBeNull();
       });
     });
+
+    it('header select-all is reachable with zero selections and selects all visible rows', async () => {
+      mockListApi([healthy, atRisk, breached]);
+      render(<TicketsPage />);
+
+      await screen.findByTestId('ticket-row-tk-healthy');
+      // Confirm no bulk bar at zero selections.
+      expect(screen.queryByTestId('tickets-bulk-bar')).toBeNull();
+
+      // The header affordance must be present without any prior selection.
+      const headerSelectAll = screen.getByTestId('tickets-select-all-header');
+      expect(headerSelectAll).toBeInTheDocument();
+
+      fireEvent.click(headerSelectAll);
+
+      // All 3 visible rows should be selected and the bulk bar shows the count.
+      expect(screen.getByTestId('tickets-bulk-bar')).toHaveTextContent('3 selected');
+    });
   });
 
   it('active filter with empty results shows clear-filters; clicking resets and refetches', async () => {

--- a/apps/web/src/components/tickets/TicketsPage.test.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.test.tsx
@@ -275,6 +275,51 @@ describe('TicketsPage', () => {
     expect(screen.getByTestId('tickets-filter-assignee')).toHaveAttribute('title', 'Tab already filters by assignee');
   });
 
+  describe('queue sort control', () => {
+    it('sort select passes sort=newest to the API and persists in the location hash', async () => {
+      mockListApi([healthy, atRisk, breached]);
+      render(<TicketsPage />);
+
+      await screen.findByTestId('ticket-row-tk-healthy');
+      // Auto-select writes the selection hash first; sort must coexist with it.
+      await waitFor(() => {
+        expect(window.location.hash).toContain('T-2026-0001');
+      });
+
+      fireEvent.change(screen.getByTestId('ticket-sort'), { target: { value: 'newest' } });
+
+      await waitFor(() => {
+        expect(ticketFetchUrls().at(-1)).toContain('sort=newest');
+      });
+      expect(window.location.hash).toContain('sort=newest');
+      expect(window.location.hash).toContain('T-2026-0001');
+    });
+
+    it('restores sort and selection from a combined hash on load', async () => {
+      window.location.hash = '#T-2026-0002&sort=oldest';
+      mockListApi([healthy, atRisk, breached]);
+      render(<TicketsPage />);
+
+      await screen.findByTestId('ticket-row-tk-risk');
+
+      expect(ticketFetchUrls().at(0)).toContain('sort=oldest');
+      expect(screen.getByTestId('ticket-sort')).toHaveValue('oldest');
+      await waitFor(() => {
+        expect(screen.getByTestId('ticket-row-tk-risk')).toHaveAttribute('aria-selected', 'true');
+      });
+    });
+
+    it('defaults to triage and omits the sort param (server default order)', async () => {
+      mockListApi([healthy]);
+      render(<TicketsPage />);
+
+      await screen.findByTestId('ticket-row-tk-healthy');
+
+      expect(screen.getByTestId('ticket-sort')).toHaveValue('triage');
+      expect(ticketFetchUrls().at(0)).not.toContain('sort=');
+    });
+  });
+
   describe('bulk selection', () => {
     it('selecting two rows shows the bulk bar with "2 selected" without changing the workbench selection', async () => {
       mockListApi([healthy, atRisk, breached]);

--- a/apps/web/src/components/tickets/TicketsPage.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.tsx
@@ -23,6 +23,17 @@ const SKIP_REASON_LABELS: Record<string, string> = {
 };
 
 type Tab = 'mine' | 'unassigned' | 'open' | 'breaching' | 'closed';
+type TicketSort = 'triage' | 'newest' | 'oldest' | 'due';
+
+const SORT_OPTIONS: Array<{ value: TicketSort; label: string }> = [
+  { value: 'triage', label: 'Triage order' },
+  { value: 'newest', label: 'Newest first' },
+  { value: 'oldest', label: 'Oldest first' },
+  { value: 'due', label: 'Due date' }
+];
+
+const isTicketSort = (value: string): value is TicketSort =>
+  SORT_OPTIONS.some((o) => o.value === value);
 
 const PRIORITY_ORDER: TicketPriority[] = ['low', 'normal', 'high', 'urgent'];
 
@@ -50,9 +61,31 @@ function tabQuery(tab: Tab): string {
   }
 }
 
-function selectionFromHash(): string | null {
-  if (typeof window === 'undefined') return null;
-  return window.location.hash.replace('#', '') || null;
+// Hash layout (hash-based UI state per CLAUDE.md): `#<selection>&sort=<sort>`.
+// The bare segment is the selected ticket key (internal number or id); the
+// `sort=` segment carries the queue sort. Both are optional, and the default
+// sort ('triage') is omitted so plain `#T-2026-0001` hashes keep working.
+function parseHash(): { selection: string | null; sort: TicketSort } {
+  if (typeof window === 'undefined') return { selection: null, sort: 'triage' };
+  let selection: string | null = null;
+  let sort: TicketSort = 'triage';
+  for (const part of window.location.hash.replace('#', '').split('&')) {
+    if (!part) continue;
+    if (part.startsWith('sort=')) {
+      const value = part.slice('sort='.length);
+      if (isTicketSort(value)) sort = value;
+    } else {
+      selection = part;
+    }
+  }
+  return { selection, sort };
+}
+
+function hashFor(selection: string | null, sort: TicketSort): string {
+  const parts: string[] = [];
+  if (selection) parts.push(selection);
+  if (sort !== 'triage') parts.push(`sort=${sort}`);
+  return parts.length > 0 ? `#${parts.join('&')}` : '';
 }
 
 export default function TicketsPage() {
@@ -70,7 +103,8 @@ export default function TicketsPage() {
   const [stats, setStats] = useState<{ open: number; unassigned: number; mine: number; breached: number; atRisk?: number } | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
-  const [selectedNumber, setSelectedNumber] = useState<string | null>(selectionFromHash);
+  const [selectedNumber, setSelectedNumber] = useState<string | null>(() => parseHash().selection);
+  const [sort, setSort] = useState<TicketSort>(() => parseHash().sort);
   const [search, setSearch] = useState('');
   const [orgFilter, setOrgFilter] = useState('');
   const [priorityFilter, setPriorityFilter] = useState('');
@@ -145,6 +179,9 @@ export default function TicketsPage() {
       if (categoryFilter) params.set('categoryId', categoryFilter);
       // The 'mine'/'unassigned' tabs already set assignee; the filter applies only on the other tabs.
       if (assigneeFilter && tab !== 'mine' && tab !== 'unassigned') params.set('assignee', assigneeFilter);
+      // 'triage' is the server default, so it's omitted — which also lets the
+      // closed tab keep its tabQuery() sort=newest until the user picks a sort.
+      if (sort !== 'triage') params.set('sort', sort);
       params.set('limit', '100');
       const res = await fetchWithAuth(`/tickets?${params.toString()}`);
       if (!res.ok) {
@@ -160,7 +197,7 @@ export default function TicketsPage() {
     } finally {
       if (seq === fetchSeq.current) setLoading(false);
     }
-  }, [tab, search, orgFilter, priorityFilter, categoryFilter, assigneeFilter]);
+  }, [tab, search, orgFilter, priorityFilter, categoryFilter, assigneeFilter, sort]);
 
   const fetchStats = useCallback(async () => {
     try {
@@ -184,9 +221,18 @@ export default function TicketsPage() {
   }, [tab, search, orgFilter, priorityFilter, categoryFilter, assigneeFilter]);
 
   useEffect(() => {
-    const onHash = () => setSelectedNumber(selectionFromHash());
+    const onHash = () => {
+      const parsed = parseHash();
+      setSelectedNumber(parsed.selection);
+      setSort(parsed.sort);
+    };
     window.addEventListener('hashchange', onHash);
     return () => window.removeEventListener('hashchange', onHash);
+  }, []);
+
+  // Single writer for the hash so selection and sort never clobber each other.
+  const writeHash = useCallback((selection: string | null, sortValue: TicketSort) => {
+    history.replaceState(null, '', hashFor(selection, sortValue) || window.location.pathname + window.location.search);
   }, []);
 
   const selected = useMemo(
@@ -199,10 +245,10 @@ export default function TicketsPage() {
     if (!loading && tickets.length > 0 && !selected) {
       const first = tickets[0];
       const key = first.internalNumber ?? first.id;
-      history.replaceState(null, '', `#${key}`);
+      writeHash(key, sort);
       setSelectedNumber(key);
     }
-  }, [loading, tickets, selected]);
+  }, [loading, tickets, selected, sort, writeHash]);
 
   const select = useCallback((t: TicketSummary) => {
     // Below the split-pane breakpoint the workbench pane is hidden; navigate
@@ -212,9 +258,9 @@ export default function TicketsPage() {
       return;
     }
     const key = t.internalNumber ?? t.id;
-    history.replaceState(null, '', `#${key}`);
+    writeHash(key, sort);
     setSelectedNumber(key);
-  }, []);
+  }, [sort, writeHash]);
 
   const move = useCallback((delta: 1 | -1) => {
     if (tickets.length === 0) return;
@@ -424,6 +470,22 @@ export default function TicketsPage() {
             ))}
           </select>
         )}
+        <select
+          value={sort}
+          onChange={(e) => {
+            const value = e.target.value;
+            if (!isTicketSort(value)) return;
+            setSort(value);
+            writeHash(selectedNumber, value);
+          }}
+          aria-label="Sort tickets"
+          data-testid="ticket-sort"
+          className={filterSelectClass(sort !== 'triage')}
+        >
+          {SORT_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>{o.label}</option>
+          ))}
+        </select>
       </div>
 
       {trueEmpty ? (

--- a/apps/web/src/components/tickets/TicketsPage.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.tsx
@@ -213,12 +213,14 @@ export default function TicketsPage() {
 
   useEffect(() => { void fetchTickets(); void fetchStats(); }, [fetchTickets, fetchStats]);
 
-  // Selection is per-view: switching tab or changing any filter/search clears it.
+  // Selection survives tab switches (POST /tickets/bulk takes raw ids; the bar's
+  // count chip reports off-view rows) but clears when a filter or the search
+  // changes — those genuinely change what the result set means.
   useEffect(() => {
     setBulkSelectedIds(new Set());
     setBulkAssignee('');
     setBulkStatus('');
-  }, [tab, search, orgFilter, priorityFilter, categoryFilter, assigneeFilter]);
+  }, [search, orgFilter, priorityFilter, categoryFilter, assigneeFilter]);
 
   useEffect(() => {
     const onHash = () => {
@@ -531,7 +533,8 @@ export default function TicketsPage() {
                   <span className="text-sm font-medium tabular-nums">{bulkSelectedIds.size} selected</span>
                   <button
                     type="button"
-                    onClick={() => setBulkSelectedIds(new Set(tickets.map((t) => t.id)))}
+                    // Union, not replace: cross-tab selections off-view must survive.
+                    onClick={() => setBulkSelectedIds((prev) => new Set([...prev, ...tickets.map((t) => t.id)]))}
                     data-testid="tickets-bulk-select-all"
                     className="text-sm text-primary hover:underline"
                   >

--- a/apps/web/src/components/tickets/TicketsPage.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.tsx
@@ -511,6 +511,16 @@ export default function TicketsPage() {
       ) : (
         <div className="flex min-h-0 flex-1 overflow-hidden rounded-lg border">
           <div className="relative flex w-full flex-col min-[1100px]:w-2/5 min-[1100px]:min-w-[320px] min-[1100px]:max-w-[480px] min-[1100px]:border-r">
+            <div className="flex items-center gap-2 border-b px-3 py-1.5">
+              <button
+                type="button"
+                onClick={() => setBulkSelectedIds((prev) => new Set([...prev, ...tickets.map((t) => t.id)]))}
+                data-testid="tickets-select-all-header"
+                className="text-xs text-muted-foreground hover:text-foreground hover:underline"
+              >
+                Select all
+              </button>
+            </div>
             <div className="min-h-0 flex-1 overflow-y-auto">
               <TicketQueueList
                 tickets={tickets}

--- a/docs/superpowers/plans/2026-06-11-ticketing-residual-pickups.md
+++ b/docs/superpowers/plans/2026-06-11-ticketing-residual-pickups.md
@@ -34,6 +34,9 @@ Codex template: see the SLA plan's "Codex invocation template" — identical, po
 
 ## Task R1: Grant `organizations:read` to org-scope system roles — **Claude**
 
+> **SUPERSEDED during execution (2026-06-11).** The Step-1 blast-radius audit found `organizations:read` gates a wide dormant surface for org-scope users (full org rows incl. `ssoConfig`/`billingContact` JSONB on two list routes, raw integration settings, the AI route surface, enrollment-key short codes) — granting it to the three org roles would switch all of that on at once. Implemented instead as a route-level fix: `GET /orgs/organizations` lets org-scope callers read their OWN org as a projected `{id, name, slug, status}` row without the permission (inline `requireOrgReadUnlessOwnOrg` middleware, fail-closed); partner/system unchanged. No migration, no seed change, no role grants. If org roles ever do need `organizations:read`, the audit findings below must be addressed first (column projection / serializer on the org-row routes, decision per newly-opened surface).
+
+
 The deep fix for the cold-load orgs 403: `GET /orgs/organizations` (orgs.ts:690) already supports org scope but is gated by `requirePermission('organizations','read')` (orgs.ts:28), which the seeded `Org Admin`/`Org Technician`/`Org Viewer` roles lack (`apps/api/src/db/seed.ts` SYSTEM_ROLES ~:161-240). PR #1245 shipped a client-side skip; this makes the permission real.
 
 **Files:**


### PR DESCRIPTION
## Summary

Closes out the ticketing residuals left after PR #1245 / #1238, per `docs/superpowers/plans/2026-06-11-ticketing-residual-pickups.md` (committed in #1250; the R1 re-scope note is in this branch).

### API / data safety
- **Org-scope cold-load 403 (deep fix, re-scoped):** the planned `organizations:read` role grant was rejected after a blast-radius audit (the permission gates full org rows incl. `ssoConfig`/`billingContact`, raw integration settings, the AI route surface). Instead, `GET /orgs/organizations` now serves org-scope callers their **own** org as a projected `{id, name, slug, status}` row without the permission (fail-closed inline middleware); partner/system unchanged.
- **Site-gating (#1238):** alert link/unlink and create-ticket-from-alert now 404 for alerts whose device is outside the caller's site scope; `deviceInSiteScope`/`ticketSiteScopeCondition` extracted to `routes/tickets/siteScope.ts`. Review also caught and fixed the same gap in the `manage_tickets` AI tool's `list` action (the known aiTools site-axis pattern).
- **Device hard-delete preserves tickets (#1238):** `tickets` moved from the cascade-delete list to a new detach list (`device_id → NULL`); also fixes the pre-existing 409 on deleting devices whose tickets have comments. Contract test now enforces an exactly-one-of-three partition (cascade/detach/linked-null-out).
- **Cross-org move fix (found in review):** `ticket_alert_links.org_id` is now rewritten on device move-org via a dedicated alert-join UPDATE (`CUSTOM_ORG_REWRITE_TABLES`); previously stranded under the old org's RLS.
- **`devices(site_id)` index** — migration `2026-06-11-i` (FKs don't create indexes; every site-scoped ticket query subqueries this column).

### Queue UX
- Sort control (triage/newest/oldest/due) persisted in the location hash (`#<selection>&sort=<sort>`, back-compatible)
- Composer tab no longer resets after sending (skeleton only on first load; `aria-busy` while refreshing)
- Bulk selection survives tab switches (still clears on filter changes); header-level Select all reachable from zero selection; select-all unions instead of replacing

## Test plan

- API: 576 tests green across 30 files (orgs, tickets, alerts, devices, aiToolsTicketing, autoMigrate) single-fork; web: 104 tests across 9 files; `tsc --noEmit` clean both apps
- Migration double-applied against live postgres (idempotent)
- Every fix went through spec-compliance + security/quality review; the final integration review verified bulk-selection × site-gating composition (server re-scopes every bulk id — widened client selections cannot escalate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)