### PR TITLE
[codex] Fix SNMP discovery target selection

### DIFF
--- a/agent/internal/discovery/scanner.go
+++ b/agent/internal/discovery/scanner.go
@@ -60,6 +60,14 @@ type Scanner struct {
 	config ScanConfig
 }
 
+var (
+	scanARP      = ScanARP
+	pingSweep    = PingSweep
+	scanPorts    = ScanPorts
+	discoverSNMP = DiscoverSNMP
+	readARPCache = ReadARPCache
+)
+
 // NewScanner creates a new Scanner with the given configuration.
 func NewScanner(config ScanConfig) *Scanner {
 	return &Scanner{
@@ -113,7 +121,7 @@ func (s *Scanner) Scan() ([]DiscoveredHost, error) {
 	now := time.Now()
 
 	if methods["arp"] {
-		arpResults, err := ScanARP(subnets, exclude, s.config.Timeout)
+		arpResults, err := scanARP(subnets, exclude, s.config.Timeout)
 		if err != nil {
 			slog.Warn("ARP scan failed", "error", err)
 		}
@@ -126,7 +134,7 @@ func (s *Scanner) Scan() ([]DiscoveredHost, error) {
 
 	var aliveTargets []net.IP
 	if methods["ping"] {
-		pingResults := PingSweep(targets, s.config.Timeout, s.config.Concurrency)
+		pingResults := pingSweep(targets, s.config.Timeout, s.config.Concurrency)
 		for _, pr := range pingResults {
 			aliveTargets = append(aliveTargets, pr.IP)
 			host := getOrCreateHost(hosts, pr.IP.String(), now)
@@ -145,7 +153,7 @@ func (s *Scanner) Scan() ([]DiscoveredHost, error) {
 		if err != nil {
 			return nil, err
 		}
-		portResults := ScanPorts(portTargets, portRanges, s.config.Timeout, s.config.Concurrency)
+		portResults := scanPorts(portTargets, portRanges, s.config.Timeout, s.config.Concurrency)
 		for ip, openPorts := range portResults {
 			host := getOrCreateHost(hosts, ip, now)
 			host.OpenPorts = openPorts
@@ -154,7 +162,7 @@ func (s *Scanner) Scan() ([]DiscoveredHost, error) {
 	}
 
 	if methods["snmp"] {
-		snmpResults := DiscoverSNMP(portTargets, s.config.SNMPCommunities, s.config.Timeout, s.config.Concurrency)
+		snmpResults := discoverSNMP(targets, s.config.SNMPCommunities, s.config.Timeout, s.config.Concurrency)
 		for ip, snmpInfo := range snmpResults {
 			host := getOrCreateHost(hosts, ip, now)
 			host.SNMPData = snmpInfo
@@ -165,7 +173,7 @@ func (s *Scanner) Scan() ([]DiscoveredHost, error) {
 	// Fill in missing MACs from the OS ARP cache.
 	// After port scanning, hosts are typically in the kernel ARP table
 	// even if pcap-based ARP scan failed (requires root).
-	arpCache := ReadARPCache()
+	arpCache := readARPCache()
 	for ip, mac := range arpCache {
 		if host, ok := hosts[ip]; ok && host.MAC == "" {
 			host.MAC = mac

--- a/agent/internal/discovery/scanner_test.go
+++ b/agent/internal/discovery/scanner_test.go
@@ -1,6 +1,8 @@
 package discovery
 
 import (
+	"net"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -88,6 +90,70 @@ func TestNormalizeMethodsEmpty(t *testing.T) {
 	result := normalizeMethods(nil)
 	if len(result) != 0 {
 		t.Fatalf("normalizeMethods(nil) should return empty map, got %d entries", len(result))
+	}
+}
+
+func TestScanSNMPUsesAllTargetsWhenPingFindsAliveSubset(t *testing.T) {
+	origPingSweep := pingSweep
+	origDiscoverSNMP := discoverSNMP
+	origReadARPCache := readARPCache
+	t.Cleanup(func() {
+		pingSweep = origPingSweep
+		discoverSNMP = origDiscoverSNMP
+		readARPCache = origReadARPCache
+	})
+
+	pingSweep = func(targets []net.IP, timeout time.Duration, workers int) []PingResult {
+		return []PingResult{{IP: net.ParseIP("192.0.2.10"), RTT: 5 * time.Millisecond}}
+	}
+	readARPCache = func() map[string]string {
+		return map[string]string{}
+	}
+
+	var snmpTargets []string
+	discoverSNMP = func(targets []net.IP, communities []string, timeout time.Duration, workers int) map[string]*SNMPInfo {
+		for _, target := range targets {
+			snmpTargets = append(snmpTargets, target.String())
+		}
+		return map[string]*SNMPInfo{
+			"192.0.2.11": {
+				SysDescr:    "Switch OS",
+				SysObjectID: "1.3.6.1.4.1.9.1.1",
+				SysName:     "edge-switch",
+			},
+		}
+	}
+
+	scanner := NewScanner(ScanConfig{
+		Subnets: []string{"192.0.2.10", "192.0.2.11"},
+		Methods: []string{"ping", "snmp"},
+	})
+
+	hosts, err := scanner.Scan()
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+
+	wantTargets := []string{"192.0.2.10", "192.0.2.11"}
+	if !reflect.DeepEqual(snmpTargets, wantTargets) {
+		t.Fatalf("SNMP targets = %v, want %v", snmpTargets, wantTargets)
+	}
+
+	var snmpOnlyHost *DiscoveredHost
+	for i := range hosts {
+		if hosts[i].IP == "192.0.2.11" {
+			snmpOnlyHost = &hosts[i]
+			break
+		}
+	}
+	if snmpOnlyHost == nil {
+		t.Fatal("expected non-pingable SNMP responder to be included in scan results")
+	}
+	if snmpOnlyHost.SNMPData == nil || snmpOnlyHost.SNMPData.SysName != "edge-switch" {
+		t.Fatalf("SNMP data = %+v, want sysName edge-switch", snmpOnlyHost.SNMPData)
+	}
+	if !reflect.DeepEqual(snmpOnlyHost.Methods, []string{"snmp"}) {
+		t.Fatalf("SNMP-only host methods = %v, want [snmp]", snmpOnlyHost.Methods)
 	}
 }
 

--- a/agent/internal/discovery/scanner_test.go
+++ b/agent/internal/discovery/scanner_test.go
@@ -157,6 +157,92 @@ func TestScanSNMPUsesAllTargetsWhenPingFindsAliveSubset(t *testing.T) {
 	}
 }
 
+// When SNMP is the only method, ping never runs, so aliveTargets is empty and
+// portTargets falls back to the full set. SNMP must still probe every target.
+func TestScanSNMPProbesAllTargetsWithoutPing(t *testing.T) {
+	origDiscoverSNMP := discoverSNMP
+	origReadARPCache := readARPCache
+	t.Cleanup(func() {
+		discoverSNMP = origDiscoverSNMP
+		readARPCache = origReadARPCache
+	})
+	readARPCache = func() map[string]string { return map[string]string{} }
+
+	var snmpTargets []string
+	discoverSNMP = func(targets []net.IP, communities []string, timeout time.Duration, workers int) map[string]*SNMPInfo {
+		for _, target := range targets {
+			snmpTargets = append(snmpTargets, target.String())
+		}
+		return map[string]*SNMPInfo{}
+	}
+
+	scanner := NewScanner(ScanConfig{
+		Subnets: []string{"192.0.2.10", "192.0.2.11"},
+		Methods: []string{"snmp"},
+	})
+	if _, err := scanner.Scan(); err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+
+	wantTargets := []string{"192.0.2.10", "192.0.2.11"}
+	if !reflect.DeepEqual(snmpTargets, wantTargets) {
+		t.Fatalf("SNMP targets = %v, want %v", snmpTargets, wantTargets)
+	}
+}
+
+// The fix decouples SNMP from the port-scan target set. With ping, ports, and
+// snmp all enabled, ports must stay on the ping-alive subset while SNMP probes
+// every target — regressing either direction would be a real defect.
+func TestScanPortsUseAliveSubsetWhileSNMPUsesAllTargets(t *testing.T) {
+	origPingSweep := pingSweep
+	origScanPorts := scanPorts
+	origDiscoverSNMP := discoverSNMP
+	origReadARPCache := readARPCache
+	t.Cleanup(func() {
+		pingSweep = origPingSweep
+		scanPorts = origScanPorts
+		discoverSNMP = origDiscoverSNMP
+		readARPCache = origReadARPCache
+	})
+	readARPCache = func() map[string]string { return map[string]string{} }
+
+	pingSweep = func(targets []net.IP, timeout time.Duration, workers int) []PingResult {
+		return []PingResult{{IP: net.ParseIP("192.0.2.10"), RTT: 5 * time.Millisecond}}
+	}
+
+	var portTargets []string
+	scanPorts = func(targets []net.IP, portRanges []PortRange, timeout time.Duration, workers int) map[string][]OpenPort {
+		for _, target := range targets {
+			portTargets = append(portTargets, target.String())
+		}
+		return map[string][]OpenPort{}
+	}
+
+	var snmpTargets []string
+	discoverSNMP = func(targets []net.IP, communities []string, timeout time.Duration, workers int) map[string]*SNMPInfo {
+		for _, target := range targets {
+			snmpTargets = append(snmpTargets, target.String())
+		}
+		return map[string]*SNMPInfo{}
+	}
+
+	scanner := NewScanner(ScanConfig{
+		Subnets:    []string{"192.0.2.10", "192.0.2.11"},
+		Methods:    []string{"ping", "ports", "snmp"},
+		PortRanges: []string{"22"},
+	})
+	if _, err := scanner.Scan(); err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+
+	if want := []string{"192.0.2.10"}; !reflect.DeepEqual(portTargets, want) {
+		t.Fatalf("port targets = %v, want %v (ping-alive subset)", portTargets, want)
+	}
+	if want := []string{"192.0.2.10", "192.0.2.11"}; !reflect.DeepEqual(snmpTargets, want) {
+		t.Fatalf("SNMP targets = %v, want %v (full set)", snmpTargets, want)
+	}
+}
+
 func TestParseSubnets(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/apps/web/src/components/discovery/DiscoveryProfileForm.test.tsx
+++ b/apps/web/src/components/discovery/DiscoveryProfileForm.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import DiscoveryProfileForm, { type DiscoveryProfileFormValues } from './DiscoveryProfileForm';
+
+const baseProfile: DiscoveryProfileFormValues = {
+  name: 'HQ scan',
+  siteId: 'site-1',
+  subnets: ['192.0.2.0/24'],
+  methods: ['ping'],
+  schedule: {
+    cadence: 'daily',
+    intervalHours: 1,
+    intervalMinutes: 60,
+    time: '02:00',
+    dayOfWeek: 'Monday',
+    dayOfMonth: '1',
+    timezone: 'UTC'
+  },
+  snmp: {
+    version: 'v2c',
+    community: 'public',
+    port: 161,
+    timeout: 2000,
+    retries: 1,
+    username: '',
+    authProtocol: 'sha',
+    authPassphrase: '',
+    privacyProtocol: 'aes',
+    privacyPassphrase: ''
+  },
+  alertSettings: {
+    enabled: false,
+    alertOnNew: true,
+    alertOnDisappeared: true,
+    alertOnChanged: true,
+    changeRetentionDays: 90
+  }
+};
+
+describe('DiscoveryProfileForm', () => {
+  it('shows SNMP settings only when SNMP probe is selected', () => {
+    render(<DiscoveryProfileForm initialValues={baseProfile} sites={[]} onSubmit={vi.fn()} />);
+
+    expect(screen.queryByTestId('discovery-snmp-settings')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('SNMP Probe'));
+    expect(screen.getByTestId('discovery-snmp-settings')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('SNMP Probe'));
+    expect(screen.queryByTestId('discovery-snmp-settings')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/discovery/DiscoveryProfileForm.tsx
+++ b/apps/web/src/components/discovery/DiscoveryProfileForm.tsx
@@ -148,6 +148,7 @@ export default function DiscoveryProfileForm({
   const [formValues, setFormValues] = useState<DiscoveryProfileFormValues>(initialValues ?? defaultValues);
   const [subnetsText, setSubnetsText] = useState((initialValues?.subnets ?? []).join('\n'));
   const [subnetErrors, setSubnetErrors] = useState<string[]>([]);
+  const isSnmpEnabled = formValues.methods.includes('snmp');
 
   useEffect(() => {
     setSubnetErrors([]);
@@ -431,165 +432,167 @@ export default function DiscoveryProfileForm({
         </div>
       </div>
 
-      <div className="rounded-lg border bg-card p-6 shadow-sm">
-        <h2 className="text-lg font-semibold">SNMP Settings</h2>
-        <p className="text-sm text-muted-foreground">Credentials used for SNMP discovery probes.</p>
+      {isSnmpEnabled && (
+        <div className="rounded-lg border bg-card p-6 shadow-sm" data-testid="discovery-snmp-settings">
+          <h2 className="text-lg font-semibold">SNMP Settings</h2>
+          <p className="text-sm text-muted-foreground">Credentials used for SNMP discovery probes.</p>
 
-        <div className="mt-4 grid gap-4 md:grid-cols-2">
-          <div>
-            <label className="text-sm font-medium">SNMP version</label>
-            <select
-              value={formValues.snmp.version}
-              onChange={event =>
-                setFormValues(prev => ({
-                  ...prev,
-                  snmp: { ...prev.snmp, version: event.target.value as SnmpSettings['version'] }
-                }))
-              }
-              className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-            >
-              <option value="v2c">v2c</option>
-              <option value="v3">v3</option>
-            </select>
-          </div>
-          <div>
-            <label className="text-sm font-medium">Port</label>
-            <input
-              type="number"
-              value={formValues.snmp.port}
-              onChange={event =>
-                setFormValues(prev => ({
-                  ...prev,
-                  snmp: { ...prev.snmp, port: Number(event.target.value) }
-                }))
-              }
-              className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-            />
-          </div>
-          <div>
-            <label className="text-sm font-medium">Timeout (ms)</label>
-            <input
-              type="number"
-              value={formValues.snmp.timeout}
-              onChange={event =>
-                setFormValues(prev => ({
-                  ...prev,
-                  snmp: { ...prev.snmp, timeout: Number(event.target.value) }
-                }))
-              }
-              className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-            />
-          </div>
-          <div>
-            <label className="text-sm font-medium">Retries</label>
-            <input
-              type="number"
-              value={formValues.snmp.retries}
-              onChange={event =>
-                setFormValues(prev => ({
-                  ...prev,
-                  snmp: { ...prev.snmp, retries: Number(event.target.value) }
-                }))
-              }
-              className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-            />
-          </div>
-
-          {formValues.snmp.version === 'v2c' ? (
-            <div className="md:col-span-2">
-              <label className="text-sm font-medium">Community string</label>
-              <input
-                type="text"
-                value={formValues.snmp.community}
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <div>
+              <label className="text-sm font-medium">SNMP version</label>
+              <select
+                value={formValues.snmp.version}
                 onChange={event =>
                   setFormValues(prev => ({
                     ...prev,
-                    snmp: { ...prev.snmp, community: event.target.value }
+                    snmp: { ...prev.snmp, version: event.target.value as SnmpSettings['version'] }
+                  }))
+                }
+                className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              >
+                <option value="v2c">v2c</option>
+                <option value="v3">v3</option>
+              </select>
+            </div>
+            <div>
+              <label className="text-sm font-medium">Port</label>
+              <input
+                type="number"
+                value={formValues.snmp.port}
+                onChange={event =>
+                  setFormValues(prev => ({
+                    ...prev,
+                    snmp: { ...prev.snmp, port: Number(event.target.value) }
                   }))
                 }
                 className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
               />
             </div>
-          ) : (
-            <>
-              <div>
-                <label className="text-sm font-medium">Username</label>
+            <div>
+              <label className="text-sm font-medium">Timeout (ms)</label>
+              <input
+                type="number"
+                value={formValues.snmp.timeout}
+                onChange={event =>
+                  setFormValues(prev => ({
+                    ...prev,
+                    snmp: { ...prev.snmp, timeout: Number(event.target.value) }
+                  }))
+                }
+                className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium">Retries</label>
+              <input
+                type="number"
+                value={formValues.snmp.retries}
+                onChange={event =>
+                  setFormValues(prev => ({
+                    ...prev,
+                    snmp: { ...prev.snmp, retries: Number(event.target.value) }
+                  }))
+                }
+                className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </div>
+
+            {formValues.snmp.version === 'v2c' ? (
+              <div className="md:col-span-2">
+                <label className="text-sm font-medium">Community string</label>
                 <input
                   type="text"
-                  value={formValues.snmp.username}
+                  value={formValues.snmp.community}
                   onChange={event =>
                     setFormValues(prev => ({
                       ...prev,
-                      snmp: { ...prev.snmp, username: event.target.value }
+                      snmp: { ...prev.snmp, community: event.target.value }
                     }))
                   }
                   className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                 />
               </div>
-              <div>
-                <label className="text-sm font-medium">Auth protocol</label>
-                <select
-                  value={formValues.snmp.authProtocol}
-                  onChange={event =>
-                    setFormValues(prev => ({
-                      ...prev,
-                      snmp: { ...prev.snmp, authProtocol: event.target.value as SnmpSettings['authProtocol'] }
-                    }))
-                  }
-                  className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                >
-                  <option value="sha">SHA</option>
-                  <option value="md5">MD5</option>
-                </select>
-              </div>
-              <div>
-                <label className="text-sm font-medium">Auth passphrase</label>
-                <input
-                  type="password"
-                  value={formValues.snmp.authPassphrase}
-                  onChange={event =>
-                    setFormValues(prev => ({
-                      ...prev,
-                      snmp: { ...prev.snmp, authPassphrase: event.target.value }
-                    }))
-                  }
-                  className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                />
-              </div>
-              <div>
-                <label className="text-sm font-medium">Privacy protocol</label>
-                <select
-                  value={formValues.snmp.privacyProtocol}
-                  onChange={event =>
-                    setFormValues(prev => ({
-                      ...prev,
-                      snmp: { ...prev.snmp, privacyProtocol: event.target.value as SnmpSettings['privacyProtocol'] }
-                    }))
-                  }
-                  className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                >
-                  <option value="aes">AES</option>
-                  <option value="des">DES</option>
-                </select>
-              </div>
-              <div>
-                <label className="text-sm font-medium">Privacy passphrase</label>
-                <input
-                  type="password"
-                  value={formValues.snmp.privacyPassphrase}
-                  onChange={event =>
-                    setFormValues(prev => ({
-                      ...prev,
-                      snmp: { ...prev.snmp, privacyPassphrase: event.target.value }
-                    }))
-                  }
-                  className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                />
-              </div>
-            </>
-          )}
+            ) : (
+              <>
+                <div>
+                  <label className="text-sm font-medium">Username</label>
+                  <input
+                    type="text"
+                    value={formValues.snmp.username}
+                    onChange={event =>
+                      setFormValues(prev => ({
+                        ...prev,
+                        snmp: { ...prev.snmp, username: event.target.value }
+                      }))
+                    }
+                    className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                  />
+                </div>
+                <div>
+                  <label className="text-sm font-medium">Auth protocol</label>
+                  <select
+                    value={formValues.snmp.authProtocol}
+                    onChange={event =>
+                      setFormValues(prev => ({
+                        ...prev,
+                        snmp: { ...prev.snmp, authProtocol: event.target.value as SnmpSettings['authProtocol'] }
+                      }))
+                    }
+                    className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                  >
+                    <option value="sha">SHA</option>
+                    <option value="md5">MD5</option>
+                  </select>
+                </div>
+                <div>
+                  <label className="text-sm font-medium">Auth passphrase</label>
+                  <input
+                    type="password"
+                    value={formValues.snmp.authPassphrase}
+                    onChange={event =>
+                      setFormValues(prev => ({
+                        ...prev,
+                        snmp: { ...prev.snmp, authPassphrase: event.target.value }
+                      }))
+                    }
+                    className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                  />
+                </div>
+                <div>
+                  <label className="text-sm font-medium">Privacy protocol</label>
+                  <select
+                    value={formValues.snmp.privacyProtocol}
+                    onChange={event =>
+                      setFormValues(prev => ({
+                        ...prev,
+                        snmp: { ...prev.snmp, privacyProtocol: event.target.value as SnmpSettings['privacyProtocol'] }
+                      }))
+                    }
+                    className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                  >
+                    <option value="aes">AES</option>
+                    <option value="des">DES</option>
+                  </select>
+                </div>
+                <div>
+                  <label className="text-sm font-medium">Privacy passphrase</label>
+                  <input
+                    type="password"
+                    value={formValues.snmp.privacyPassphrase}
+                    onChange={event =>
+                      setFormValues(prev => ({
+                        ...prev,
+                        snmp: { ...prev.snmp, privacyPassphrase: event.target.value }
+                      }))
+                    }
+                    className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                  />
+                </div>
+              </>
+            )}
+          </div>
         </div>
-      </div>
+      )}
 
       <div className="rounded-lg border bg-card p-6 shadow-sm">
         <h2 className="text-lg font-semibold">Network Alerting</h2>


### PR DESCRIPTION
## Summary
- scan SNMP across the full discovery target set instead of the ping-alive port-scan subset
- add a Go regression test for SNMP-only devices that do not respond to ping
- hide Discovery Profile SNMP settings unless SNMP Probe is selected, with a React component test

## Root Cause
When ping found any live hosts, `portTargets` was narrowed to the ping-alive subset and reused for SNMP. Devices with ICMP filtered but SNMP open were never probed.

Fixes #1260

## Validation
- `go test -race ./internal/discovery`
- `corepack pnpm --filter=@breeze/web exec vitest run src/components/discovery/DiscoveryProfileForm.test.tsx`
- attempted `go test -race ./...`; full run had a transient `internal/monitoring` failure, and `go test -race ./internal/monitoring -count=1 -v` passed on rerun.