### PR TITLE
[codex] Fix Network Discovery run feedback

### DIFF
--- a/apps/web/src/components/discovery/DiscoveryPage.test.tsx
+++ b/apps/web/src/components/discovery/DiscoveryPage.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import DiscoveryPage from './DiscoveryPage';
 import { fetchWithAuth } from '../../stores/auth';
+import { navigateTo } from '../../lib/navigation';
 import { showToast } from '../shared/Toast';
 
 vi.mock('../../stores/auth', () => ({
@@ -58,6 +59,19 @@ vi.mock('./NetworkChangesPanel', () => ({
 
 const fetchWithAuthMock = vi.mocked(fetchWithAuth);
 const showToastMock = vi.mocked(showToast);
+const navigateToMock = vi.mocked(navigateTo);
+
+const profilesPayload = {
+  data: [{
+    id: 'profile-1',
+    name: 'HQ sweep',
+    siteId: 'site-1',
+    subnets: ['10.0.0.0/24'],
+    methods: ['icmp'],
+    schedule: { type: 'manual' },
+    lastRunAt: null
+  }]
+};
 
 function makeJsonResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
   return {
@@ -75,19 +89,7 @@ describe('DiscoveryPage', () => {
   });
 
   it('toasts and shows a per-profile loading state while queuing a scan', async () => {
-    fetchWithAuthMock.mockResolvedValueOnce(
-      makeJsonResponse({
-        data: [{
-          id: 'profile-1',
-          name: 'HQ sweep',
-          siteId: 'site-1',
-          subnets: ['10.0.0.0/24'],
-          methods: ['icmp'],
-          schedule: { type: 'manual' },
-          lastRunAt: null
-        }]
-      })
-    );
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse(profilesPayload));
 
     let resolveScan: (response: Response) => void = () => {};
     fetchWithAuthMock.mockImplementationOnce(
@@ -117,5 +119,82 @@ describe('DiscoveryPage', () => {
       });
     });
     expect(await screen.findByTestId('jobs-filter')).toHaveTextContent('profile-1');
+  });
+
+  it('surfaces an error toast and inline message, clears the spinner, and stays on the profiles tab when the scan fails', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse(profilesPayload));
+    fetchWithAuthMock.mockResolvedValueOnce(
+      makeJsonResponse({ error: 'Scan queue is full' }, false, 500)
+    );
+
+    render(<DiscoveryPage />);
+    await screen.findByText('HQ sweep');
+
+    fireEvent.click(screen.getByLabelText('Run HQ sweep'));
+
+    // Error toast fired (runAction surfaces non-401 ActionErrors).
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith({
+        message: 'Scan queue is full',
+        type: 'error'
+      });
+    });
+
+    // Inline banner also rendered for the persistent failure signal.
+    expect(await screen.findByText('Scan queue is full')).toBeInTheDocument();
+
+    // Spinner cleared (finally ran) — button is back to its idle, enabled state.
+    const runButton = await screen.findByLabelText('Run HQ sweep');
+    expect(runButton).not.toBeDisabled();
+
+    // A failed queue must NOT navigate the user to an empty jobs view.
+    expect(screen.queryByTestId('jobs-filter')).not.toBeInTheDocument();
+  });
+
+  it('treats an HTTP-200 {success:false} body as a failure', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse(profilesPayload));
+    fetchWithAuthMock.mockResolvedValueOnce(
+      makeJsonResponse({ success: false, error: 'Agent offline' })
+    );
+
+    render(<DiscoveryPage />);
+    await screen.findByText('HQ sweep');
+
+    fireEvent.click(screen.getByLabelText('Run HQ sweep'));
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith({
+        message: 'Agent offline',
+        type: 'error'
+      });
+    });
+    expect(screen.queryByTestId('jobs-filter')).not.toBeInTheDocument();
+    expect(await screen.findByLabelText('Run HQ sweep')).not.toBeDisabled();
+  });
+
+  it('redirects to login on 401 without showing an inline error or switching tabs', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse(profilesPayload));
+    fetchWithAuthMock.mockResolvedValueOnce(
+      makeJsonResponse({ error: 'Unauthorized' }, false, 401)
+    );
+
+    render(<DiscoveryPage />);
+    await screen.findByText('HQ sweep');
+
+    fireEvent.click(screen.getByLabelText('Run HQ sweep'));
+
+    await waitFor(() => {
+      expect(navigateToMock).toHaveBeenCalledWith('/login', { replace: true });
+    });
+
+    // 401 is handled by the redirect: no error toast, no inline banner, no tab switch.
+    expect(showToastMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error' })
+    );
+    expect(screen.queryByText('Unauthorized')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('jobs-filter')).not.toBeInTheDocument();
+
+    // Spinner still cleared on the early-return path (finally ran).
+    expect(await screen.findByLabelText('Run HQ sweep')).not.toBeDisabled();
   });
 });

--- a/apps/web/src/components/discovery/DiscoveryPage.test.tsx
+++ b/apps/web/src/components/discovery/DiscoveryPage.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DiscoveryPage from './DiscoveryPage';
+import { fetchWithAuth } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn()
+}));
+
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: () => ({
+    currentOrgId: 'org-1',
+    currentSiteId: 'site-1',
+    sites: []
+  })
+}));
+
+vi.mock('../../lib/navigation', () => ({
+  navigateTo: vi.fn()
+}));
+
+vi.mock('../shared/Toast', () => ({
+  showToast: vi.fn()
+}));
+
+vi.mock('./DiscoveryProfileForm', () => ({
+  defaultAlertSettings: {
+    enabled: false,
+    severity: 'warning',
+    channels: []
+  },
+  default: () => null
+}));
+
+vi.mock('./DiscoveryJobList', () => ({
+  default: ({ profileFilter }: { profileFilter: string | null }) => (
+    <div data-testid="jobs-filter">{profileFilter}</div>
+  )
+}));
+
+vi.mock('./DiscoveredAssetList', () => ({
+  default: () => <div>Assets tab</div>
+}));
+
+vi.mock('./AssetDetailModal', () => ({
+  default: () => null
+}));
+
+vi.mock('./NetworkTopologyMap', () => ({
+  default: () => <div>Topology tab</div>
+}));
+
+vi.mock('./NetworkChangesPanel', () => ({
+  default: () => <div>Changes tab</div>
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+const showToastMock = vi.mocked(showToast);
+
+function makeJsonResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload)
+  } as unknown as Response;
+}
+
+describe('DiscoveryPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.pushState({}, '', '/discovery?tab=profiles');
+  });
+
+  it('toasts and shows a per-profile loading state while queuing a scan', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(
+      makeJsonResponse({
+        data: [{
+          id: 'profile-1',
+          name: 'HQ sweep',
+          siteId: 'site-1',
+          subnets: ['10.0.0.0/24'],
+          methods: ['icmp'],
+          schedule: { type: 'manual' },
+          lastRunAt: null
+        }]
+      })
+    );
+
+    let resolveScan: (response: Response) => void = () => {};
+    fetchWithAuthMock.mockImplementationOnce(
+      () => new Promise<Response>(resolve => {
+        resolveScan = resolve;
+      })
+    );
+
+    render(<DiscoveryPage />);
+
+    await screen.findByText('HQ sweep');
+
+    fireEvent.click(screen.getByLabelText('Run HQ sweep'));
+
+    expect(screen.getByLabelText('Running HQ sweep')).toBeDisabled();
+    expect(fetchWithAuthMock).toHaveBeenLastCalledWith('/discovery/scan', {
+      method: 'POST',
+      body: JSON.stringify({ profileId: 'profile-1' })
+    });
+
+    resolveScan(makeJsonResponse({ success: true }));
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith({
+        message: 'Discovery scan queued for "HQ sweep"',
+        type: 'success'
+      });
+    });
+    expect(await screen.findByTestId('jobs-filter')).toHaveTextContent('profile-1');
+  });
+});

--- a/apps/web/src/components/discovery/DiscoveryPage.tsx
+++ b/apps/web/src/components/discovery/DiscoveryPage.tsx
@@ -9,6 +9,8 @@ import NetworkTopologyMap from './NetworkTopologyMap';
 import NetworkChangesPanel from './NetworkChangesPanel';
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
+import { ActionError, runAction } from '../../lib/runAction';
+import { navigateTo } from '../../lib/navigation';
 
 const DISCOVERY_TABS = ['assets', 'profiles', 'jobs', 'topology', 'changes'] as const;
 type DiscoveryTab = (typeof DISCOVERY_TABS)[number];
@@ -268,6 +270,7 @@ export default function DiscoveryPage() {
   const [profilesError, setProfilesError] = useState<string>();
   const [profileFormError, setProfileFormError] = useState<string>();
   const [savingProfile, setSavingProfile] = useState(false);
+  const [runningProfileId, setRunningProfileId] = useState<string | null>(null);
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
   const [editingProfile, setEditingProfile] = useState<ApiDiscoveryProfile | null>(null);
   const [jobsProfileFilter, setJobsProfileFilter] = useState<string | null>(null);
@@ -480,23 +483,31 @@ export default function DiscoveryPage() {
 
   const handleRunProfile = async (profile: DiscoveryProfile) => {
     setProfilesError(undefined);
+    setRunningProfileId(profile.id);
 
     try {
-      const response = await fetchWithAuth('/discovery/scan', {
-        method: 'POST',
-        body: JSON.stringify({ profileId: profile.id })
+      await runAction({
+        request: () => fetchWithAuth('/discovery/scan', {
+          method: 'POST',
+          body: JSON.stringify({ profileId: profile.id })
+        }),
+        errorFallback: `Failed to run discovery profile "${profile.name}"`,
+        successMessage: `Discovery scan queued for "${profile.name}"`,
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
       });
-
-      if (!response.ok) {
-        const data = await response.json().catch(() => null);
-        throw new Error(data?.error ?? 'Failed to run discovery profile');
-      }
 
       // Switch to jobs tab filtered to this profile so user can see the queued scan
       setJobsProfileFilter(profile.id);
       navigateToTab('jobs');
     } catch (err) {
-      setProfilesError(err instanceof Error ? err.message : 'An error occurred');
+      if (err instanceof ActionError) {
+        if (err.status === 401) return;
+        setProfilesError(err.message);
+      } else {
+        setProfilesError(err instanceof Error ? err.message : 'An error occurred');
+      }
+    } finally {
+      setRunningProfileId(null);
     }
   };
 
@@ -610,6 +621,7 @@ export default function DiscoveryPage() {
           onEdit={handleEditProfile}
           onDelete={handleDeleteProfile}
           onRun={handleRunProfile}
+          runningProfileId={runningProfileId}
           onViewJobs={handleNavigateToJobs}
         />
       )}

--- a/apps/web/src/components/discovery/DiscoveryProfileList.test.tsx
+++ b/apps/web/src/components/discovery/DiscoveryProfileList.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import DiscoveryProfileList, { type DiscoveryProfile } from './DiscoveryProfileList';
+
+const profiles: DiscoveryProfile[] = [
+  {
+    id: 'profile-1',
+    name: 'HQ sweep',
+    subnets: ['10.0.0.0/24'],
+    methods: ['icmp'],
+    schedule: 'Manual',
+    status: 'active'
+  },
+  {
+    id: 'profile-2',
+    name: 'Branch sweep',
+    subnets: ['10.1.0.0/24'],
+    methods: ['arp'],
+    schedule: 'Manual',
+    status: 'active'
+  }
+];
+
+describe('DiscoveryProfileList', () => {
+  it('disables only the running profile Run button', () => {
+    render(
+      <DiscoveryProfileList
+        profiles={profiles}
+        runningProfileId="profile-1"
+        onRun={vi.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText('Running HQ sweep')).toBeDisabled();
+    expect(screen.getByLabelText('Run Branch sweep')).not.toBeDisabled();
+  });
+
+  it('passes the selected profile when Run is clicked', () => {
+    const onRun = vi.fn();
+    render(<DiscoveryProfileList profiles={profiles} onRun={onRun} />);
+
+    fireEvent.click(screen.getByLabelText('Run HQ sweep'));
+
+    expect(onRun).toHaveBeenCalledWith(profiles[0]);
+  });
+});

--- a/apps/web/src/components/discovery/DiscoveryProfileList.tsx
+++ b/apps/web/src/components/discovery/DiscoveryProfileList.tsx
@@ -1,4 +1,4 @@
-import { Play, Pencil, Trash2, List } from 'lucide-react';
+import { Loader2, Play, Pencil, Trash2, List } from 'lucide-react';
 
 export type DiscoveryProfileStatus = 'active' | 'paused' | 'draft' | 'error';
 
@@ -20,7 +20,8 @@ type DiscoveryProfileListProps = {
   onRetry?: () => void;
   onEdit?: (profile: DiscoveryProfile) => void;
   onDelete?: (profile: DiscoveryProfile) => void;
-  onRun?: (profile: DiscoveryProfile) => void;
+  onRun?: (profile: DiscoveryProfile) => void | Promise<void>;
+  runningProfileId?: string | null;
   onViewJobs?: (profileId: string) => void;
 };
 
@@ -39,6 +40,7 @@ export default function DiscoveryProfileList({
   onEdit,
   onDelete,
   onRun,
+  runningProfileId,
   onViewJobs
 }: DiscoveryProfileListProps) {
   if (loading) {
@@ -169,10 +171,17 @@ export default function DiscoveryProfileList({
                       <button
                         type="button"
                         onClick={() => onRun?.(profile)}
-                        className="flex h-8 w-8 items-center justify-center rounded-md border hover:bg-muted"
-                        title="Run now"
+                        disabled={runningProfileId === profile.id}
+                        aria-label={runningProfileId === profile.id ? `Running ${profile.name}` : `Run ${profile.name}`}
+                        aria-busy={runningProfileId === profile.id}
+                        className="flex h-8 w-8 items-center justify-center rounded-md border hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                        title={runningProfileId === profile.id ? 'Running...' : 'Run now'}
                       >
-                        <Play className="h-4 w-4" />
+                        {runningProfileId === profile.id ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Play className="h-4 w-4" />
+                        )}
                       </button>
                       <button
                         type="button"


### PR DESCRIPTION
## Summary

Fixes #1258.

- Wraps the Network Discovery profile Run action in `runAction` so success and failure both surface toast feedback.
- Adds a per-profile running state so the clicked Run button disables and shows a spinner while the scan queue request is in flight.
- Adds regression coverage for the Discovery page Run flow and the profile-list running button state.

## Root Cause

`handleRunProfile` called `fetchWithAuth` directly and then silently switched to the Jobs tab on success. Failure was stored inline as `profilesError`, so users did not reliably get visible feedback for the action.

## Validation

- `pnpm --filter=@breeze/web test -- src/components/discovery/DiscoveryPage.test.tsx src/components/discovery/DiscoveryProfileList.test.tsx --run` passed; Vitest ran 137 files / 1036 tests.
- `pnpm --filter=@breeze/web exec eslint src/components/discovery/DiscoveryPage.tsx src/components/discovery/DiscoveryProfileList.tsx src/components/discovery/DiscoveryPage.test.tsx src/components/discovery/DiscoveryProfileList.test.tsx` passed.
- `git diff --check` passed.
