### PR TITLE
[codex] Fix Huntress integration setup and sync

### DIFF
--- a/apps/api/src/services/urlSafety.test.ts
+++ b/apps/api/src/services/urlSafety.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import http from 'http';
 import { EventEmitter } from 'events';
-import type { AddressInfo } from 'net';
+import type { AddressInfo, LookupAddress } from 'net';
 import {
   safeFetch,
   isPrivateIp,
@@ -214,6 +214,43 @@ describe('safeFetch — SSRF policy', () => {
       Host: 'tenant.example.test',
       'X-Test': 'ok'
     });
+    requestSpy.mockRestore();
+  });
+
+  it('returns the pinned record as an array when Node requests lookup all-mode', async () => {
+    __setLookupForTests(async () => [{ address: '8.8.8.8', family: 4 }]);
+    let pinnedRecords: LookupAddress[] | undefined;
+    const requestSpy = vi.spyOn(http, 'request').mockImplementation((options: any, callback?: any) => {
+      const req = new EventEmitter() as any;
+      req.write = vi.fn();
+      req.destroy = vi.fn();
+      req.setTimeout = vi.fn();
+      req.end = vi.fn(() => {
+        options.lookup(options.host, { all: true }, (err: Error | null, addresses: LookupAddress[] | string) => {
+          if (err) {
+            req.emit('error', err);
+            return;
+          }
+          if (!Array.isArray(addresses)) {
+            req.emit('error', new Error(`Invalid IP address: ${(addresses as LookupAddress[])[0]?.address}`));
+            return;
+          }
+          pinnedRecords = addresses;
+          const res = new EventEmitter() as any;
+          res.statusCode = 200;
+          res.statusMessage = 'OK';
+          res.headers = {};
+          callback?.(res);
+          res.emit('end');
+        });
+      });
+      return req;
+    });
+
+    const response = await safeFetch('http://tenant.example.test/path');
+
+    expect(response.status).toBe(200);
+    expect(pinnedRecords).toEqual([{ address: '8.8.8.8', family: 4 }]);
     requestSpy.mockRestore();
   });
 });

--- a/apps/api/src/services/urlSafety.test.ts
+++ b/apps/api/src/services/urlSafety.test.ts
@@ -253,6 +253,80 @@ describe('safeFetch — SSRF policy', () => {
     expect(pinnedRecords).toEqual([{ address: '8.8.8.8', family: 4 }]);
     requestSpy.mockRestore();
   });
+
+  it('returns a scalar (address, family) when lookup is called in non-all mode', async () => {
+    __setLookupForTests(async () => [{ address: '8.8.8.8', family: 4 }]);
+    let pinnedAddress: unknown;
+    let pinnedFamily: unknown;
+    const requestSpy = vi.spyOn(http, 'request').mockImplementation((options: any, callback?: any) => {
+      const req = new EventEmitter() as any;
+      req.write = vi.fn();
+      req.destroy = vi.fn();
+      req.setTimeout = vi.fn();
+      req.end = vi.fn(() => {
+        // Node's default connect path uses options-object mode without `all`.
+        options.lookup(options.host, { all: false }, (err: Error | null, address: string, family: number) => {
+          if (err) {
+            req.emit('error', err);
+            return;
+          }
+          pinnedAddress = address;
+          pinnedFamily = family;
+          const res = new EventEmitter() as any;
+          res.statusCode = 200;
+          res.statusMessage = 'OK';
+          res.headers = {};
+          callback?.(res);
+          res.emit('end');
+        });
+      });
+      return req;
+    });
+
+    const response = await safeFetch('http://tenant.example.test/path');
+
+    expect(response.status).toBe(200);
+    expect(pinnedAddress).toBe('8.8.8.8');
+    expect(pinnedFamily).toBe(4);
+    requestSpy.mockRestore();
+  });
+
+  it('supports the (hostname, callback) lookup overload where options is omitted', async () => {
+    __setLookupForTests(async () => [{ address: '8.8.8.8', family: 4 }]);
+    let pinnedAddress: unknown;
+    let pinnedFamily: unknown;
+    const requestSpy = vi.spyOn(http, 'request').mockImplementation((options: any, callback?: any) => {
+      const req = new EventEmitter() as any;
+      req.write = vi.fn();
+      req.destroy = vi.fn();
+      req.setTimeout = vi.fn();
+      req.end = vi.fn(() => {
+        // Two-arg overload: callback is passed in the options position.
+        options.lookup(options.host, (err: Error | null, address: string, family: number) => {
+          if (err) {
+            req.emit('error', err);
+            return;
+          }
+          pinnedAddress = address;
+          pinnedFamily = family;
+          const res = new EventEmitter() as any;
+          res.statusCode = 200;
+          res.statusMessage = 'OK';
+          res.headers = {};
+          callback?.(res);
+          res.emit('end');
+        });
+      });
+      return req;
+    });
+
+    const response = await safeFetch('http://tenant.example.test/path');
+
+    expect(response.status).toBe(200);
+    expect(pinnedAddress).toBe('8.8.8.8');
+    expect(pinnedFamily).toBe(4);
+    requestSpy.mockRestore();
+  });
 });
 
 describe('safeFetch — DNS pinning & rebinding defense', () => {

--- a/apps/api/src/services/urlSafety.test.ts
+++ b/apps/api/src/services/urlSafety.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import http from 'http';
 import { EventEmitter } from 'events';
-import type { AddressInfo, LookupAddress } from 'net';
+import type { AddressInfo } from 'net';
+import type { LookupAddress } from 'dns';
 import {
   safeFetch,
   isPrivateIp,
@@ -232,7 +233,7 @@ describe('safeFetch — SSRF policy', () => {
             return;
           }
           if (!Array.isArray(addresses)) {
-            req.emit('error', new Error(`Invalid IP address: ${(addresses as LookupAddress[])[0]?.address}`));
+            req.emit('error', new Error(`Invalid IP address: ${addresses}`));
             return;
           }
           pinnedRecords = addresses;

--- a/apps/api/src/services/urlSafety.ts
+++ b/apps/api/src/services/urlSafety.ts
@@ -252,9 +252,20 @@ export async function safeFetch(urlStr: string, init: SafeFetchInit = {}): Promi
 
   // Build a `lookup` that always hands back the validated record, so a DNS
   // rebind between now and the TCP connect cannot redirect us.
-  const pinnedLookup: LookupFunction = (_hn, _opts, cb) => {
-    // Node's LookupFunction callback is overloaded; runtime accepts (err, addr, family)
-    (cb as (e: NodeJS.ErrnoException | null, addr: string, family: number) => void)(
+  const pinnedLookup: LookupFunction = (_hn, opts, cb) => {
+    const callback = (typeof opts === 'function' ? opts : cb) as
+      | ((e: NodeJS.ErrnoException | null, addr: string, family: number) => void)
+      | ((e: NodeJS.ErrnoException | null, addresses: LookupAddress[]) => void)
+      | undefined;
+
+    if (!callback) return;
+
+    if (typeof opts === 'object' && opts !== null && 'all' in opts && opts.all === true) {
+      (callback as (e: NodeJS.ErrnoException | null, addresses: LookupAddress[]) => void)(null, [safeRecord]);
+      return;
+    }
+
+    (callback as (e: NodeJS.ErrnoException | null, addr: string, family: number) => void)(
       null,
       safeRecord.address,
       safeRecord.family

--- a/apps/api/src/services/urlSafety.ts
+++ b/apps/api/src/services/urlSafety.ts
@@ -258,7 +258,10 @@ export async function safeFetch(urlStr: string, init: SafeFetchInit = {}): Promi
       | ((e: NodeJS.ErrnoException | null, addresses: LookupAddress[]) => void)
       | undefined;
 
-    if (!callback) return;
+    // Unreachable via Node's connect path (it always supplies a callback), but
+    // if it ever happened, silently returning would hang the request forever
+    // when no timeoutMs is set — throw so it surfaces as a connection error.
+    if (!callback) throw new Error('pinnedLookup invoked without a callback');
 
     if (typeof opts === 'object' && opts !== null && 'all' in opts && opts.all === true) {
       (callback as (e: NodeJS.ErrnoException | null, addresses: LookupAddress[]) => void)(null, [safeRecord]);

--- a/apps/web/src/components/integrations/HuntressIntegration.test.tsx
+++ b/apps/web/src/components/integrations/HuntressIntegration.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import HuntressIntegration from './HuntressIntegration';
+import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn()
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+function makeResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Error',
+    json: vi.fn().mockResolvedValue(payload)
+  } as unknown as Response;
+}
+
+describe('HuntressIntegration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useOrgStore.setState({
+      currentOrgId: '00000000-0000-4000-8000-000000000001',
+      orgScope: 'current'
+    });
+  });
+
+  it('shows single-organization guidance and does not call Huntress APIs in all-orgs scope', async () => {
+    useOrgStore.setState({ orgScope: 'all' });
+
+    render(<HuntressIntegration />);
+
+    expect(screen.getByText('Huntress Integration')).toBeInTheDocument();
+    expect(screen.getByText(/The Huntress integration is configured per organization/)).toBeInTheDocument();
+    expect(screen.getByText('All orgs')).toBeInTheDocument();
+
+    await Promise.resolve();
+    expect(fetchWithAuthMock).not.toHaveBeenCalled();
+  });
+
+  it('loads Huntress resources when scoped to a current organization', async () => {
+    fetchWithAuthMock.mockImplementation(async (url) => {
+      if (url === '/huntress/integration') return makeResponse({ data: null });
+      if (url === '/huntress/status') {
+        return makeResponse({
+          coverage: { totalAgents: 0, mappedAgents: 0, unmappedAgents: 0, offlineAgents: 0 },
+          incidents: { open: 0, bySeverity: [], byStatus: [] }
+        });
+      }
+      if (url === '/huntress/incidents?limit=5') return makeResponse({ data: [] });
+      return makeResponse({}, false, 404);
+    });
+
+    render(<HuntressIntegration />);
+
+    await waitFor(() => expect(screen.getByText('Connection')).toBeInTheDocument());
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/huntress/integration');
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/huntress/status');
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/huntress/incidents?limit=5');
+  });
+
+  it('collects Huntress API Key and API Secret separately and submits them as one credential pair', async () => {
+    const user = userEvent.setup();
+    fetchWithAuthMock.mockImplementation(async (url, init) => {
+      if (url === '/huntress/integration' && init?.method === 'POST') {
+        return makeResponse({ id: 'huntress-1' }, true, 201);
+      }
+      if (url === '/huntress/integration') return makeResponse({ data: null });
+      if (url === '/huntress/status') {
+        return makeResponse({
+          coverage: { totalAgents: 0, mappedAgents: 0, unmappedAgents: 0, offlineAgents: 0 },
+          incidents: { open: 0, bySeverity: [], byStatus: [] }
+        });
+      }
+      if (url === '/huntress/incidents?limit=5') return makeResponse({ data: [] });
+      return makeResponse({}, false, 404);
+    });
+
+    render(<HuntressIntegration />);
+
+    await waitFor(() => expect(screen.getByText('Connection')).toBeInTheDocument());
+    expect(screen.getByText(/Do not paste the Base 64 encoded version of Key and Secret/)).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText('My Huntress Integration'), 'Production Huntress');
+    await user.type(screen.getByPlaceholderText('hk_...'), 'hk_14b7a762d4770fe29e47');
+    await user.type(screen.getByPlaceholderText('hs_...'), 'hs_9d3e49c689f781a453d028374ff665ab');
+    await user.click(screen.getByRole('button', { name: /Save & Connect/i }));
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock.mock.calls.some(([url, init]) => url === '/huntress/integration' && init?.method === 'POST')).toBe(true);
+    });
+
+    const postCall = fetchWithAuthMock.mock.calls.find(
+      ([url, init]) => url === '/huntress/integration' && init?.method === 'POST'
+    );
+    expect(JSON.parse(String(postCall?.[1]?.body))).toMatchObject({
+      name: 'Production Huntress',
+      apiKey: 'hk_14b7a762d4770fe29e47:hs_9d3e49c689f781a453d028374ff665ab',
+      isActive: true
+    });
+  });
+});

--- a/apps/web/src/components/integrations/HuntressIntegration.test.tsx
+++ b/apps/web/src/components/integrations/HuntressIntegration.test.tsx
@@ -21,6 +21,26 @@ function makeResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Res
   } as unknown as Response;
 }
 
+const existingIntegration = {
+  id: 'huntress-1',
+  orgId: '00000000-0000-4000-8000-000000000001',
+  name: 'Existing Huntress',
+  accountId: 'acct-123',
+  apiBaseUrl: 'https://api.huntress.io',
+  isActive: true,
+  lastSyncAt: null,
+  lastSyncStatus: 'success',
+  lastSyncError: null,
+  hasWebhookSecret: false,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z'
+};
+
+const emptyStatus = {
+  coverage: { totalAgents: 0, mappedAgents: 0, unmappedAgents: 0, offlineAgents: 0 },
+  incidents: { open: 0, bySeverity: [], byStatus: [] }
+};
+
 describe('HuntressIntegration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -103,5 +123,101 @@ describe('HuntressIntegration', () => {
       apiKey: 'hk_14b7a762d4770fe29e47:hs_9d3e49c689f781a453d028374ff665ab',
       isActive: true
     });
+  });
+
+  it('blocks a half-credential (key without secret): shows an error, disables Save, and never POSTs', async () => {
+    const user = userEvent.setup();
+    fetchWithAuthMock.mockImplementation(async (url) => {
+      if (url === '/huntress/integration') return makeResponse({ data: null });
+      if (url === '/huntress/status') return makeResponse(emptyStatus);
+      if (url === '/huntress/incidents?limit=5') return makeResponse({ data: [] });
+      return makeResponse({}, false, 404);
+    });
+
+    render(<HuntressIntegration />);
+    await waitFor(() => expect(screen.getByText('Connection')).toBeInTheDocument());
+
+    await user.type(screen.getByPlaceholderText('My Huntress Integration'), 'Production Huntress');
+    await user.type(screen.getByPlaceholderText('hk_...'), 'hk_only_the_key');
+
+    expect(screen.getByText(/Enter both the API Key and API Secret from Huntress/)).toBeInTheDocument();
+
+    const saveButton = screen.getByRole('button', { name: /Save & Connect/i });
+    expect(saveButton).toBeDisabled();
+
+    await user.click(saveButton);
+    expect(
+      fetchWithAuthMock.mock.calls.some(([url, init]) => url === '/huntress/integration' && init?.method === 'POST')
+    ).toBe(false);
+  });
+
+  it('updates an existing integration without re-entering credentials and omits apiKey from the POST', async () => {
+    const user = userEvent.setup();
+    fetchWithAuthMock.mockImplementation(async (url, init) => {
+      if (url === '/huntress/integration' && init?.method === 'POST') {
+        return makeResponse({ id: 'huntress-1' }, true, 200);
+      }
+      if (url === '/huntress/integration') return makeResponse({ data: existingIntegration });
+      if (url === '/huntress/status') return makeResponse(emptyStatus);
+      if (url === '/huntress/incidents?limit=5') return makeResponse({ data: [] });
+      return makeResponse({}, false, 404);
+    });
+
+    render(<HuntressIntegration />);
+    await waitFor(() => expect(screen.getByText('Connection')).toBeInTheDocument());
+
+    // Name is prefilled from the existing integration; Update is enabled with no credential input.
+    const updateButton = screen.getByRole('button', { name: /Update/i });
+    expect(updateButton).toBeEnabled();
+    await user.click(updateButton);
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock.mock.calls.some(([url, init]) => url === '/huntress/integration' && init?.method === 'POST')).toBe(true);
+    });
+
+    const postCall = fetchWithAuthMock.mock.calls.find(
+      ([url, init]) => url === '/huntress/integration' && init?.method === 'POST'
+    );
+    const body = JSON.parse(String(postCall?.[1]?.body));
+    expect(body).not.toHaveProperty('apiKey');
+    expect(body).toMatchObject({ name: 'Existing Huntress', isActive: true });
+  });
+
+  it('surfaces a save failure to the user', async () => {
+    const user = userEvent.setup();
+    fetchWithAuthMock.mockImplementation(async (url, init) => {
+      if (url === '/huntress/integration' && init?.method === 'POST') {
+        return makeResponse({ error: 'Invalid Huntress credentials' }, false, 400);
+      }
+      if (url === '/huntress/integration') return makeResponse({ data: null });
+      if (url === '/huntress/status') return makeResponse(emptyStatus);
+      if (url === '/huntress/incidents?limit=5') return makeResponse({ data: [] });
+      return makeResponse({}, false, 404);
+    });
+
+    render(<HuntressIntegration />);
+    await waitFor(() => expect(screen.getByText('Connection')).toBeInTheDocument());
+
+    await user.type(screen.getByPlaceholderText('My Huntress Integration'), 'Production Huntress');
+    await user.type(screen.getByPlaceholderText('hk_...'), 'hk_14b7a762d4770fe29e47');
+    await user.type(screen.getByPlaceholderText('hs_...'), 'hs_9d3e49c689f781a453d028374ff665ab');
+    await user.click(screen.getByRole('button', { name: /Save & Connect/i }));
+
+    await waitFor(() => expect(screen.getByText('Invalid Huntress credentials')).toBeInTheDocument());
+  });
+
+  it('warns when live status fails to load instead of rendering an all-clear', async () => {
+    fetchWithAuthMock.mockImplementation(async (url) => {
+      if (url === '/huntress/integration') return makeResponse({ data: existingIntegration });
+      if (url === '/huntress/status') return makeResponse({ error: 'upstream error' }, false, 502);
+      if (url === '/huntress/incidents?limit=5') return makeResponse({ data: [] });
+      return makeResponse({}, false, 404);
+    });
+
+    render(<HuntressIntegration />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Live Huntress status could not be fully loaded/)).toBeInTheDocument()
+    );
   });
 });

--- a/apps/web/src/components/integrations/HuntressIntegration.tsx
+++ b/apps/web/src/components/integrations/HuntressIntegration.tsx
@@ -12,6 +12,7 @@ import {
   Unplug
 } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
 
 type Integration = {
   id: string;
@@ -78,16 +79,29 @@ export default function HuntressIntegration() {
 
   const [name, setName] = useState('');
   const [apiKey, setApiKey] = useState('');
+  const [apiSecret, setApiSecret] = useState('');
   const [accountId, setAccountId] = useState('');
   const [webhookSecret, setWebhookSecret] = useState('');
 
   const [showApiKey, setShowApiKey] = useState(false);
+  const [showApiSecret, setShowApiSecret] = useState(false);
   const [showWebhookSecret, setShowWebhookSecret] = useState(false);
 
   const [saveState, setSaveState] = useState<SaveState>({ status: 'idle' });
   const [syncState, setSyncState] = useState<SyncState>({ status: 'idle' });
 
-  const canSave = name.trim().length > 0 && (apiKey.trim().length > 0 || !!integration);
+  // Huntress integrations are per organization. In "All orgs" scope there is
+  // no single org to load/save, and the API correctly rejects the request.
+  const currentOrgId = useOrgStore((s) => s.currentOrgId);
+  const orgScope = useOrgStore((s) => s.orgScope);
+  const isAllOrgs = orgScope === 'all';
+
+  const hasCredentialInput = apiKey.trim().length > 0 || apiSecret.trim().length > 0;
+  const hasCompleteCredential = apiKey.trim().length > 0 && apiSecret.trim().length > 0;
+  const canSave = name.trim().length > 0 && (integration ? !hasCredentialInput || hasCompleteCredential : hasCompleteCredential);
+  const credentialPairError = hasCredentialInput && !hasCompleteCredential
+    ? 'Enter both the API Key and API Secret from Huntress, or leave both blank to keep the existing credential.'
+    : null;
 
   const fetchIntegration = useCallback(async () => {
     try {
@@ -104,6 +118,7 @@ export default function HuntressIntegration() {
         setName(data.name);
         setAccountId(data.accountId ?? '');
         setApiKey('');
+        setApiSecret('');
       }
     } catch (err) {
       setLoadError(`Failed to load integration: ${err instanceof Error ? err.message : 'Network error'}`);
@@ -140,20 +155,55 @@ export default function HuntressIntegration() {
   }, []);
 
   useEffect(() => {
+    if (isAllOrgs) {
+      setLoading(false);
+      setLoadError(null);
+      return;
+    }
+
     const load = async () => {
       setLoading(true);
+      setLoadError(null);
       await fetchIntegration();
       await Promise.all([fetchStatus(), fetchRecentIncidents()]);
       setLoading(false);
     };
     load();
-  }, [fetchIntegration, fetchStatus, fetchRecentIncidents]);
+  }, [fetchIntegration, fetchStatus, fetchRecentIncidents, isAllOrgs, currentOrgId]);
+
+  if (isAllOrgs) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+            <Shield className="h-5 w-5" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold">Huntress Integration</h1>
+            <p className="text-sm text-muted-foreground">
+              Connect Huntress managed EDR for agent sync, incident detection, and threat response.
+            </p>
+          </div>
+        </div>
+        <div className="rounded-md border bg-muted/40 p-4 text-sm text-muted-foreground">
+          The Huntress integration is configured per organization. Switch the scope in the top bar
+          from <span className="font-medium text-foreground">All orgs</span> to a single organization
+          to view or edit its connection.
+        </div>
+      </div>
+    );
+  }
 
   const handleSave = async () => {
     setSaveState({ status: 'saving' });
     try {
+      if (credentialPairError) {
+        setSaveState({ status: 'error', message: credentialPairError });
+        return;
+      }
+
       const body: Record<string, unknown> = { name, isActive: true };
-      if (apiKey.trim()) body.apiKey = apiKey;
+      if (hasCompleteCredential) body.apiKey = `${apiKey.trim()}:${apiSecret.trim()}`;
       if (accountId.trim()) body.accountId = accountId;
       if (webhookSecret.trim()) body.webhookSecret = webhookSecret;
 
@@ -168,6 +218,7 @@ export default function HuntressIntegration() {
       }
       setSaveState({ status: 'saved', message: json.syncWarning ?? 'Integration saved' });
       setApiKey('');
+      setApiSecret('');
       setWebhookSecret('');
       await fetchIntegration();
       await Promise.all([fetchStatus(), fetchRecentIncidents()]);
@@ -271,7 +322,7 @@ export default function HuntressIntegration() {
       <div className="rounded-xl border bg-card p-6 shadow-sm">
         <h2 className="text-lg font-semibold">Connection</h2>
         <p className="mb-4 text-sm text-muted-foreground">
-          Configure your Huntress API credentials and webhook secret.
+          Configure your Huntress API Key, API Secret, and webhook secret.
           {!integration && ' Saving requires MFA verification.'}
         </p>
 
@@ -289,19 +340,30 @@ export default function HuntressIntegration() {
 
           <div>
             <label className="mb-1 block text-sm font-medium">
-              API Key
-              {integration && <span className="ml-1 text-xs text-muted-foreground">(leave blank to keep existing)</span>}
+              Account ID <span className="text-xs text-muted-foreground">(optional)</span>
             </label>
+            <input
+              type="text"
+              value={accountId}
+              onChange={(e) => setAccountId(e.target.value)}
+              placeholder="Huntress account ID"
+              className="h-10 w-full rounded-md border bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+            />
+          </div>
+
+          <div>
+            <label className="mb-1 block text-sm font-medium">API Key</label>
             <div className="relative">
               <input
                 type={showApiKey ? 'text' : 'password'}
                 value={apiKey}
                 onChange={(e) => setApiKey(e.target.value)}
-                placeholder={integration ? '••••••••••••' : 'Enter API key'}
+                placeholder={integration ? 'hk_••••••••••••' : 'hk_...'}
                 className="h-10 w-full rounded-md border bg-background px-3 pr-10 text-sm outline-none focus:ring-2 focus:ring-primary/30"
               />
               <button
                 type="button"
+                aria-label={showApiKey ? 'Hide API Key' : 'Show API Key'}
                 onClick={() => setShowApiKey(!showApiKey)}
                 className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
               >
@@ -312,15 +374,35 @@ export default function HuntressIntegration() {
 
           <div>
             <label className="mb-1 block text-sm font-medium">
-              Account ID <span className="text-xs text-muted-foreground">(optional)</span>
+              API Secret
+              {integration && <span className="ml-1 text-xs text-muted-foreground">(leave key and secret blank to keep existing)</span>}
             </label>
-            <input
-              type="text"
-              value={accountId}
-              onChange={(e) => setAccountId(e.target.value)}
-              placeholder="Huntress account ID"
-              className="h-10 w-full rounded-md border bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-primary/30"
-            />
+            <div className="relative">
+              <input
+                type={showApiSecret ? 'text' : 'password'}
+                value={apiSecret}
+                onChange={(e) => setApiSecret(e.target.value)}
+                placeholder={integration ? 'hs_••••••••••••' : 'hs_...'}
+                className="h-10 w-full rounded-md border bg-background px-3 pr-10 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+              />
+              <button
+                type="button"
+                aria-label={showApiSecret ? 'Hide API Secret' : 'Show API Secret'}
+                onClick={() => setShowApiSecret(!showApiSecret)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              >
+                {showApiSecret ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+            </div>
+          </div>
+
+          <div className="md:col-span-2">
+            <p className="text-xs text-muted-foreground">
+              Copy the API Key and API Secret from Huntress. Do not paste the Base 64 encoded version of Key and Secret; Breeze formats the request automatically.
+            </p>
+            {credentialPairError && (
+              <p className="mt-1 text-xs text-red-600">{credentialPairError}</p>
+            )}
           </div>
 
           <div>

--- a/apps/web/src/components/integrations/HuntressIntegration.tsx
+++ b/apps/web/src/components/integrations/HuntressIntegration.tsx
@@ -72,6 +72,10 @@ function SeverityBadge({ severity }: { severity: string }) {
 export default function HuntressIntegration() {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+  // Live status (coverage + incidents) loads separately from the integration
+  // config. A failure here must NOT be silent: rendering zeroed coverage as if
+  // it were a successful read would mask a monitoring gap as an all-clear.
+  const [statusError, setStatusError] = useState<string | null>(null);
   const [integration, setIntegration] = useState<Integration | null>(null);
   const [coverage, setCoverage] = useState<StatusSummary | null>(null);
   const [incidents, setIncidents] = useState<IncidentSummary | null>(null);
@@ -125,11 +129,15 @@ export default function HuntressIntegration() {
     }
   }, []);
 
+  const LIVE_STATUS_ERROR =
+    'Live Huntress status could not be fully loaded. Coverage and incident data below may be incomplete or out of date — try Sync Now or reload.';
+
   const fetchStatus = useCallback(async () => {
     try {
       const res = await fetchWithAuth('/huntress/status');
       if (!res.ok) {
         console.error(`[HuntressIntegration] Status fetch failed: ${res.status} ${res.statusText}`);
+        setStatusError(LIVE_STATUS_ERROR);
         return;
       }
       const json = await res.json();
@@ -137,6 +145,7 @@ export default function HuntressIntegration() {
       setIncidents(json.incidents);
     } catch (err) {
       console.error('[HuntressIntegration] Failed to fetch status:', err);
+      setStatusError(LIVE_STATUS_ERROR);
     }
   }, []);
 
@@ -145,12 +154,14 @@ export default function HuntressIntegration() {
       const res = await fetchWithAuth('/huntress/incidents?limit=5');
       if (!res.ok) {
         console.error(`[HuntressIntegration] Incidents fetch failed: ${res.status} ${res.statusText}`);
+        setStatusError(LIVE_STATUS_ERROR);
         return;
       }
       const json = await res.json();
       setRecentIncidents(json.data ?? []);
     } catch (err) {
       console.error('[HuntressIntegration] Failed to fetch incidents:', err);
+      setStatusError(LIVE_STATUS_ERROR);
     }
   }, []);
 
@@ -164,6 +175,7 @@ export default function HuntressIntegration() {
     const load = async () => {
       setLoading(true);
       setLoadError(null);
+      setStatusError(null);
       await fetchIntegration();
       await Promise.all([fetchStatus(), fetchRecentIncidents()]);
       setLoading(false);
@@ -220,6 +232,7 @@ export default function HuntressIntegration() {
       setApiKey('');
       setApiSecret('');
       setWebhookSecret('');
+      setStatusError(null);
       await fetchIntegration();
       await Promise.all([fetchStatus(), fetchRecentIncidents()]);
     } catch (err) {
@@ -242,6 +255,7 @@ export default function HuntressIntegration() {
       setSyncState({ status: 'done', message: 'Sync triggered' });
       setTimeout(async () => {
         try {
+          setStatusError(null);
           await fetchIntegration();
           await Promise.all([fetchStatus(), fetchRecentIncidents()]);
         } catch (refreshErr) {
@@ -449,6 +463,13 @@ export default function HuntressIntegration() {
       </div>
 
       {/* Sync Status + Coverage — only shown when integration exists */}
+      {integration && statusError && (
+        <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-700">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>{statusError}</span>
+        </div>
+      )}
+
       {integration && (
         <div className="grid gap-6 lg:grid-cols-[1fr_1fr]">
           {/* Sync Status */}

--- a/apps/web/src/components/integrations/HuntressIntegration.tsx
+++ b/apps/web/src/components/integrations/HuntressIntegration.tsx
@@ -223,9 +223,12 @@ export default function HuntressIntegration() {
         method: 'POST',
         body: JSON.stringify(body)
       });
-      const json = await res.json();
+      // Guard against non-JSON bodies (gateway HTML error pages, empty 504s) so
+      // the user sees the HTTP status, not a JSON parse error — and so a
+      // non-JSON 2xx can't masquerade as a failed save.
+      const json = await res.json().catch(() => ({}));
       if (!res.ok) {
-        setSaveState({ status: 'error', message: json.error ?? 'Failed to save' });
+        setSaveState({ status: 'error', message: json.error ?? `Failed to save (${res.status})` });
         return;
       }
       setSaveState({ status: 'saved', message: json.syncWarning ?? 'Integration saved' });
@@ -248,8 +251,8 @@ export default function HuntressIntegration() {
         body: JSON.stringify({})
       });
       if (!res.ok) {
-        const json = await res.json();
-        setSyncState({ status: 'error', message: json.error ?? 'Sync failed' });
+        const json = await res.json().catch(() => ({}));
+        setSyncState({ status: 'error', message: json.error ?? `Sync failed (${res.status})` });
         return;
       }
       setSyncState({ status: 'done', message: 'Sync triggered' });


### PR DESCRIPTION
## Summary
- Update the Huntress integration form to collect Huntress `API Key` and `API Secret` separately, matching Huntress portal terminology, while preserving the backend `key:secret` credential format.
- Guard the Huntress integration page in `All orgs` scope so org-specific requests are not fired without an `orgId`.
- Fix `safeFetch` DNS pinning so the custom lookup callback supports Node's `{ all: true }` mode and avoids `Invalid IP address: undefined` during scheduled Huntress syncs.

## Root Cause
- The Huntress UI previously asked for a single API key even though Huntress exposes a key and secret pair.
- The Huntress page did not mirror other per-org integrations when the top-level scope was `All orgs`, so it surfaced backend validation errors.
- `safeFetch` returned only scalar lookup results to Node's pinned lookup callback. Newer Node HTTP/TLS paths can request all-mode lookup results, which expect an address array.

## Validation
- `corepack pnpm --filter=@breeze/api exec vitest run src/services/urlSafety.test.ts`
- `corepack pnpm --filter=@breeze/api exec vitest run src/services/huntressClient.test.ts`
- `corepack pnpm --filter=@breeze/api exec eslint src/services/urlSafety.ts src/services/urlSafety.test.ts`
- `corepack pnpm --filter=@breeze/web exec vitest run src/components/integrations/HuntressIntegration.test.tsx`
- `corepack pnpm --filter=@breeze/web exec eslint src/components/integrations/HuntressIntegration.tsx src/components/integrations/HuntressIntegration.test.tsx`
