### PR TITLE
Add passkey MFA

### DIFF
--- a/apps/api/migrations/2026-06-11-j-user-passkeys.sql
+++ b/apps/api/migrations/2026-06-11-j-user-passkeys.sql
@@ -1,0 +1,48 @@
+-- Passkey MFA credentials for WebAuthn.
+--
+-- Idempotent: safe to re-apply on databases that already have the enum value,
+-- table, indexes, or policy.
+
+DO $$ BEGIN
+  ALTER TYPE mfa_method ADD VALUE 'passkey';
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+CREATE TABLE IF NOT EXISTS user_passkeys (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  credential_id text NOT NULL UNIQUE,
+  public_key    text NOT NULL,
+  counter       bigint NOT NULL DEFAULT 0,
+  device_type   varchar(32) NOT NULL,
+  backed_up     boolean NOT NULL DEFAULT false,
+  transports    jsonb,
+  name          varchar(255),
+  aaguid        varchar(36),
+  last_used_at  timestamptz,
+  disabled_at   timestamptz,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS user_passkeys_user_id_idx
+  ON user_passkeys(user_id);
+
+ALTER TABLE user_passkeys ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_passkeys FORCE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename  = 'user_passkeys'
+      AND policyname = 'user_passkeys_user_scope'
+  ) THEN
+    CREATE POLICY user_passkeys_user_scope ON user_passkeys
+      FOR ALL
+      TO breeze_app
+      USING     (user_id = breeze_current_user_id() OR breeze_current_scope() = 'system')
+      WITH CHECK (user_id = breeze_current_user_id() OR breeze_current_scope() = 'system');
+  END IF;
+END $$;

--- a/apps/api/migrations/2026-06-11-j-user-passkeys.sql
+++ b/apps/api/migrations/2026-06-11-j-user-passkeys.sql
@@ -3,11 +3,7 @@
 -- Idempotent: safe to re-apply on databases that already have the enum value,
 -- table, indexes, or policy.
 
-DO $$ BEGIN
-  ALTER TYPE mfa_method ADD VALUE 'passkey';
-EXCEPTION
-  WHEN duplicate_object THEN null;
-END $$;
+ALTER TYPE mfa_method ADD VALUE IF NOT EXISTS 'passkey';
 
 CREATE TABLE IF NOT EXISTS user_passkeys (
   id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -40,6 +40,7 @@
     "@hono/zod-validator": "^0.8.0",
     "@network-utils/vendor-lookup": "^1.0.12",
     "@sentry/node": "^10.54.0",
+    "@simplewebauthn/server": "^13.3.1",
     "@types/qrcode": "^1.5.6",
     "archiver": "^7.0.1",
     "argon2": "^0.44.0",

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -191,6 +191,10 @@ const USER_ID_SCOPED_TABLES: ReadonlySet<string> = new Set<string>([
   // the token owner via breeze_current_user_id(). System-initiated revocation
   // (reuse detection in /auth/refresh) uses withSystemDbAccessContext.
   'refresh_token_families',
+  // user_passkeys: WebAuthn passkey credentials, scoped to the owning user
+  // via breeze_current_user_id(), with an OR breeze_current_scope() = 'system'
+  // branch for system-scope access (Shape 6).
+  'user_passkeys',
 ]);
 
 const REQUIRED_CMDS = ['SELECT', 'INSERT', 'UPDATE', 'DELETE'] as const;

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -5,6 +5,7 @@ export * from './pam';
 export * from './orgs';
 export * from './oauth';
 export * from './users';
+export * from './userPasskeys';
 export * from './devices';
 export * from './scripts';
 export * from './alerts';

--- a/apps/api/src/db/schema/userPasskeys.ts
+++ b/apps/api/src/db/schema/userPasskeys.ts
@@ -1,0 +1,27 @@
+import { pgTable, uuid, varchar, text, timestamp, bigint, boolean, jsonb, index } from 'drizzle-orm/pg-core';
+import { users } from './users';
+
+export type PasskeyTransport = 'ble' | 'cable' | 'hybrid' | 'internal' | 'nfc' | 'smart-card' | 'usb';
+
+export const userPasskeys = pgTable(
+  'user_passkeys',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    credentialId: text('credential_id').notNull().unique(),
+    publicKey: text('public_key').notNull(),
+    counter: bigint('counter', { mode: 'number' }).notNull().default(0),
+    deviceType: varchar('device_type', { length: 32 }).notNull(),
+    backedUp: boolean('backed_up').notNull().default(false),
+    transports: jsonb('transports').$type<PasskeyTransport[]>(),
+    name: varchar('name', { length: 255 }),
+    aaguid: varchar('aaguid', { length: 36 }),
+    lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
+    disabledAt: timestamp('disabled_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull()
+  },
+  (t) => ({
+    userIdx: index('user_passkeys_user_id_idx').on(t.userId)
+  })
+);

--- a/apps/api/src/db/schema/users.ts
+++ b/apps/api/src/db/schema/users.ts
@@ -4,7 +4,7 @@ import { partners, organizations } from './orgs';
 export const userStatusEnum = pgEnum('user_status', ['active', 'invited', 'disabled']);
 export const roleScopeEnum = pgEnum('role_scope', ['system', 'partner', 'organization']);
 export const orgAccessEnum = pgEnum('org_access', ['all', 'selected', 'none']);
-export const mfaMethodEnum = pgEnum('mfa_method', ['totp', 'sms']);
+export const mfaMethodEnum = pgEnum('mfa_method', ['totp', 'sms', 'passkey']);
 
 export const users = pgTable('users', {
   id: uuid('id').primaryKey().defaultRandom(),
@@ -105,4 +105,3 @@ export const sessions = pgTable('sessions', {
   expiresAt: timestamp('expires_at').notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull()
 });
-

--- a/apps/api/src/middleware/cfAccessLogin.test.ts
+++ b/apps/api/src/middleware/cfAccessLogin.test.ts
@@ -425,6 +425,27 @@ describe('cfAccessLoginMiddleware', () => {
     expect(tokenState.lastPayload).toBeNull(); // no full token mint yet
   });
 
+  it('issues an MFA temp token when user has passkey MFA and TRUSTS_MFA is false', async () => {
+    envState.enabled = true;
+    envState.trustsMfa = false;
+    verifyState.next = {
+      kind: 'claims',
+      claims: { email: activeUser.email, sub: 'cf-1', aud: envState.audience, iss: `https://${envState.teamDomain}`, exp: 999, iat: 1 },
+    };
+    dbState.userRow = { ...activeUser, mfaEnabled: true, mfaSecret: null, mfaMethod: 'passkey' };
+    const { next, called } = createNext();
+    const res = await cfAccessLoginMiddleware(
+      createContext({ 'Cf-Access-Jwt-Assertion': 'tok' }),
+      next
+    );
+    expect(called()).toBe(false);
+    const body = await (res as Response).json();
+    expect(body.mfaRequired).toBe(true);
+    expect(body.mfaMethod).toBe('passkey');
+    expect(body.tokens).toBeNull();
+    expect(tokenState.lastPayload).toBeNull();
+  });
+
   it('mints tokens with mfa=true when TRUSTS_MFA is true even if user has MFA enabled', async () => {
     envState.enabled = true;
     envState.trustsMfa = true;

--- a/apps/api/src/middleware/cfAccessLogin.ts
+++ b/apps/api/src/middleware/cfAccessLogin.ts
@@ -140,7 +140,7 @@ export async function cfAccessLoginMiddleware(c: Context, next: Next): Promise<R
   // MFA, issue a temp token and require the user to complete TOTP, same
   // shape the password handler uses.
   const trustsMfa = cfAccessTrustsMfa();
-  if (ENABLE_2FA && user.mfaEnabled && (user.mfaSecret || user.mfaMethod === 'sms') && !trustsMfa) {
+  if (ENABLE_2FA && user.mfaEnabled && (user.mfaSecret || user.mfaMethod === 'sms' || user.mfaMethod === 'passkey') && !trustsMfa) {
     const redis = getRedis();
     if (!redis) {
       console.error('[cf-access-login] redis unavailable; cannot issue MFA temp token, falling through');

--- a/apps/api/src/routes/auth.passkeys.test.ts
+++ b/apps/api/src/routes/auth.passkeys.test.ts
@@ -1,0 +1,543 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { authRoutes } from './auth';
+
+const {
+  dbState,
+  redisMock,
+  passkeyMocks,
+  authState,
+} = vi.hoisted(() => {
+  const makeSelectChain = (rows: unknown[]) => {
+    const chain: any = {
+      from: vi.fn(() => chain),
+      leftJoin: vi.fn(() => chain),
+      innerJoin: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+      orderBy: vi.fn(() => chain),
+      limit: vi.fn(() => Promise.resolve(rows)),
+    };
+    return chain;
+  };
+
+  return {
+    dbState: {
+      selectQueue: [] as unknown[][],
+      updateSets: [] as Record<string, unknown>[],
+      makeSelectChain,
+    },
+    redisMock: {
+      setex: vi.fn(),
+      get: vi.fn(),
+      del: vi.fn(),
+    },
+    passkeyMocks: {
+      generatePasskeyRegistrationOptions: vi.fn(),
+      verifyPasskeyRegistration: vi.fn(),
+      registrationInfoToPasskeyFields: vi.fn(),
+      generatePasskeyAuthenticationOptions: vi.fn(),
+      verifyPasskeyAuthentication: vi.fn(),
+      authenticationInfoToPasskeyUpdateFields: vi.fn(),
+    },
+    authState: {
+      requireAuthorizationHeader: true,
+      mfaSatisfied: true,
+    },
+  };
+});
+
+vi.mock('../services', () => ({
+  hashPassword: vi.fn().mockResolvedValue('$argon2id$hashed'),
+  verifyPassword: vi.fn().mockResolvedValue(true),
+  isPasswordStrong: vi.fn().mockReturnValue({ valid: true, errors: [] }),
+  createTokenPair: vi.fn().mockResolvedValue({
+    accessToken: 'access-token',
+    refreshToken: 'refresh-token',
+    refreshJti: 'refresh-jti',
+    expiresInSeconds: 900,
+  }),
+  verifyToken: vi.fn(),
+  generateMFASecret: vi.fn(),
+  verifyMFAToken: vi.fn(),
+  generateOTPAuthURL: vi.fn(),
+  generateQRCode: vi.fn(),
+  generateRecoveryCodes: vi.fn(),
+  createSession: vi.fn(),
+  invalidateSession: vi.fn(),
+  invalidateAllUserSessions: vi.fn(),
+  isUserTokenRevoked: vi.fn().mockResolvedValue(false),
+  revokeAllUserTokens: vi.fn().mockResolvedValue(undefined),
+  isRefreshTokenJtiRevoked: vi.fn().mockResolvedValue(false),
+  revokeRefreshTokenJti: vi.fn().mockResolvedValue(true),
+  markRefreshTokenJtiRotated: vi.fn().mockResolvedValue(undefined),
+  wasRefreshTokenJtiRecentlyRotated: vi.fn().mockResolvedValue(false),
+  rememberJtiFamily: vi.fn().mockResolvedValue(undefined),
+  getFamilyForJti: vi.fn().mockResolvedValue(null),
+  revokeFamily: vi.fn().mockResolvedValue(undefined),
+  isFamilyRevoked: vi.fn().mockResolvedValue(false),
+  touchFamilyLastUsed: vi.fn().mockResolvedValue(undefined),
+  mintRefreshTokenFamily: vi.fn().mockResolvedValue('family-passkey'),
+  bindRefreshJtiToFamily: vi.fn().mockResolvedValue(undefined),
+  rateLimiter: vi.fn().mockResolvedValue({ allowed: true, remaining: 4, resetAt: new Date() }),
+  loginLimiter: { limit: 5, windowSeconds: 300 },
+  forgotPasswordLimiter: { limit: 3, windowSeconds: 3600 },
+  mfaLimiter: { limit: 5, windowSeconds: 300 },
+  recordAccountFailure: vi.fn().mockResolvedValue({ count: 1, locked: false, newlyLocked: false }),
+  clearAccountFailures: vi.fn().mockResolvedValue(undefined),
+  isAccountLocked: vi.fn().mockResolvedValue(false),
+  ACCOUNT_LOCKOUT_MAX: 5,
+  ACCOUNT_LOCKOUT_WINDOW_SECONDS: 15 * 60,
+  getAccountLockoutMax: vi.fn(() => 5),
+  getAccountLockoutWindowSeconds: vi.fn(() => 15 * 60),
+  getTrustedClientIp: vi.fn(() => '127.0.0.1'),
+  getRedis: vi.fn(() => redisMock),
+  ...passkeyMocks,
+}));
+
+vi.mock('../services/passkeys', () => ({
+  PasskeyChallengeError: class PasskeyChallengeError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'PasskeyChallengeError';
+    }
+  },
+  ...passkeyMocks,
+}));
+
+vi.mock('../services/email', () => ({
+  getEmailService: vi.fn(() => ({
+    sendAccountLocked: vi.fn().mockResolvedValue(undefined),
+    sendPasswordReset: vi.fn().mockResolvedValue(undefined),
+    sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
+    sendInvite: vi.fn().mockResolvedValue(undefined),
+    sendAlertNotification: vi.fn().mockResolvedValue(undefined),
+    sendEmail: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+vi.mock('../services/twilio', () => ({
+  getTwilioService: vi.fn(() => ({
+    sendVerificationCode: vi.fn().mockResolvedValue({ success: true }),
+    checkVerificationCode: vi.fn().mockResolvedValue({ valid: true }),
+  })),
+}));
+
+vi.mock('../services/tenantStatus', () => ({
+  TenantInactiveError: class TenantInactiveError extends Error {},
+  assertActiveTenantContext: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./auth/ssoPolicy', () => ({
+  SsoPasswordAuthRequiredError: class SsoPasswordAuthRequiredError extends Error {},
+  assertPasswordAuthAllowedBySso: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../services/passwordResetEligibility', () => ({
+  getPasswordResetEligibility: vi.fn().mockResolvedValue({ allowed: false, reason: 'unknown_user' }),
+  getPasswordResetEligibilityForUser: vi.fn().mockResolvedValue({
+    allowed: true,
+    userId: 'user-123',
+    email: 'test@example.com',
+  }),
+}));
+
+vi.mock('../services/ipAllowlist', () => ({
+  enforceIpAllowlist: vi.fn().mockResolvedValue({ allowed: true }),
+  IP_NOT_ALLOWED_BODY: { error: 'IP address is not allowed' },
+  isBlocked: vi.fn(() => false),
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => dbState.makeSelectChain(dbState.selectQueue.shift() ?? [])),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        returning: vi.fn(() => Promise.resolve([{ id: 'passkey-credential-1' }])),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn((values: Record<string, unknown>) => {
+        dbState.updateSets.push(values);
+        return {
+          where: vi.fn(() => Promise.resolve(undefined)),
+        };
+      }),
+    })),
+    delete: vi.fn(() => ({
+      where: vi.fn(() => Promise.resolve(undefined)),
+    })),
+  },
+  withSystemDbAccessContext: vi.fn(async <T>(fn: () => Promise<T>) => fn()),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  users: {
+    id: 'users.id',
+    email: 'users.email',
+    passwordHash: 'users.passwordHash',
+    mfaEnabled: 'users.mfaEnabled',
+    mfaMethod: 'users.mfaMethod',
+    mfaSecret: 'users.mfaSecret',
+    phoneVerified: 'users.phoneVerified',
+    forceMfa: 'users.forceMfa',
+  },
+  organizations: {
+    id: 'organizations.id',
+    partnerId: 'organizations.partnerId',
+    name: 'organizations.name',
+    forceMfa: 'organizations.forceMfa',
+  },
+  partners: {
+    id: 'partners.id',
+    name: 'partners.name',
+  },
+  partnerUsers: {
+    userId: 'partnerUsers.userId',
+    partnerId: 'partnerUsers.partnerId',
+    roleId: 'partnerUsers.roleId',
+  },
+  organizationUsers: {
+    userId: 'organizationUsers.userId',
+    orgId: 'organizationUsers.orgId',
+    roleId: 'organizationUsers.roleId',
+  },
+  refreshTokenFamilies: {
+    familyId: 'refreshTokenFamilies.familyId',
+    userId: 'refreshTokenFamilies.userId',
+  },
+  userPasskeys: {
+    id: 'userPasskeys.id',
+    userId: 'userPasskeys.userId',
+    credentialId: 'userPasskeys.credentialId',
+    publicKey: 'userPasskeys.publicKey',
+    counter: 'userPasskeys.counter',
+    transports: 'userPasskeys.transports',
+    name: 'userPasskeys.name',
+    lastUsedAt: 'userPasskeys.lastUsedAt',
+    disabledAt: 'userPasskeys.disabledAt',
+  },
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    if (authState.requireAuthorizationHeader && !c.req.header('authorization')) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+    c.set('auth', {
+      user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+      orgId: 'org-123',
+      partnerId: 'partner-123',
+      token: { mfa: authState.mfaSatisfied },
+    });
+    return next();
+  }),
+  requireMfa: vi.fn(() => (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => (_c: any, next: any) => next()),
+}));
+
+import { createTokenPair, verifyPassword } from '../services';
+import { PasskeyChallengeError } from '../services/passkeys';
+import { withSystemDbAccessContext } from '../db';
+
+const user = {
+  id: 'user-123',
+  email: 'test@example.com',
+  name: 'Test User',
+  passwordHash: '$argon2id$hash',
+  status: 'active',
+  mfaEnabled: true,
+  mfaMethod: 'passkey',
+};
+
+describe('passkey MFA auth routes', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbState.selectQueue = [];
+    dbState.updateSets = [];
+    redisMock.get.mockReset();
+    redisMock.setex.mockReset();
+    redisMock.del.mockReset();
+    authState.requireAuthorizationHeader = true;
+    authState.mfaSatisfied = true;
+    passkeyMocks.generatePasskeyRegistrationOptions.mockResolvedValue({
+      challenge: 'register-challenge',
+      rp: { name: 'Breeze' },
+    });
+    passkeyMocks.verifyPasskeyRegistration.mockResolvedValue({
+      verified: true,
+      registrationInfo: {},
+    });
+    passkeyMocks.registrationInfoToPasskeyFields.mockReturnValue({
+      credentialId: 'credential-1',
+      publicKey: 'public-key',
+      counter: 0,
+      deviceType: 'singleDevice',
+      backedUp: false,
+      transports: ['internal'],
+      aaguid: null,
+    });
+    passkeyMocks.generatePasskeyAuthenticationOptions.mockResolvedValue({
+      challenge: 'login-challenge',
+      allowCredentials: [{ id: 'credential-1', type: 'public-key' }],
+    });
+    passkeyMocks.verifyPasskeyAuthentication.mockResolvedValue({
+      verified: true,
+      authenticationInfo: {
+        newCounter: 2,
+        credentialDeviceType: 'singleDevice',
+        credentialBackedUp: false,
+      },
+    });
+    passkeyMocks.authenticationInfoToPasskeyUpdateFields.mockReturnValue({
+      counter: 2,
+      deviceType: 'singleDevice',
+      backedUp: false,
+      lastUsedAt: new Date('2026-06-11T00:00:00.000Z'),
+    });
+    app = new Hono();
+    app.route('/auth', authRoutes);
+  });
+
+  it('requires an authenticated password step-up before starting passkey registration', async () => {
+    let res = await app.request('/auth/passkeys/register/options', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ currentPassword: 'correct-password' }),
+    });
+    expect(res.status).toBe(401);
+    expect(passkeyMocks.generatePasskeyRegistrationOptions).not.toHaveBeenCalled();
+
+    vi.mocked(verifyPassword).mockResolvedValueOnce(false);
+    dbState.selectQueue.push([{ passwordHash: '$argon2id$hash' }]);
+
+    res = await app.request('/auth/passkeys/register/options', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+      body: JSON.stringify({ currentPassword: 'wrong-password' }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(passkeyMocks.generatePasskeyRegistrationOptions).not.toHaveBeenCalled();
+  });
+
+  it('returns registration options only after the current password is verified', async () => {
+    vi.mocked(verifyPassword).mockResolvedValueOnce(true);
+    dbState.selectQueue.push([{ passwordHash: '$argon2id$hash' }]);
+
+    const res = await app.request('/auth/passkeys/register/options', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+      body: JSON.stringify({ currentPassword: 'correct-password' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      options: { challenge: 'register-challenge' },
+    });
+    expect(passkeyMocks.generatePasskeyRegistrationOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user: expect.objectContaining({ id: 'user-123', email: 'test@example.com' }),
+      }),
+    );
+  });
+
+  it('rejects invalid or expired passkey registration challenges', async () => {
+    passkeyMocks.verifyPasskeyRegistration.mockRejectedValueOnce(
+      new PasskeyChallengeError('Passkey challenge is missing or expired'),
+    );
+
+    const res = await app.request('/auth/passkeys/register/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+      body: JSON.stringify({
+        credential: { id: 'credential-1', response: {} },
+      }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ error: expect.stringMatching(/challenge|expired|invalid/i) });
+  });
+
+  it('returns passkey MFA state after password login for passkey-enrolled users', async () => {
+    authState.requireAuthorizationHeader = false;
+    vi.mocked(verifyPassword).mockResolvedValueOnce(true);
+    dbState.selectQueue.push([user]);
+
+    const res = await app.request('/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'test@example.com', password: 'correct-password' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      mfaRequired: true,
+      mfaMethod: 'passkey',
+      user: null,
+      tokens: null,
+    });
+    expect(redisMock.setex).toHaveBeenCalledWith(
+      expect.stringMatching(/^mfa:pending:/),
+      300,
+      expect.stringContaining('"mfaMethod":"passkey"'),
+    );
+  });
+
+  it('returns passkey authentication options for a pending passkey MFA login', async () => {
+    redisMock.get.mockResolvedValueOnce(JSON.stringify({
+      userId: 'user-123',
+      mfaMethod: 'passkey',
+    }));
+    dbState.selectQueue.push([
+      {
+        id: 'credential-row-1',
+        userId: 'user-123',
+        credentialId: 'credential-1',
+        publicKey: 'public-key',
+        counter: 0,
+        transports: ['internal'],
+      },
+    ]);
+
+    const res = await app.request('/auth/mfa/passkey/options', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tempToken: 'temp-token' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      options: {
+        challenge: 'login-challenge',
+        allowCredentials: [{ id: 'credential-1', type: 'public-key' }],
+      },
+    });
+    expect(passkeyMocks.generatePasskeyAuthenticationOptions).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-123' }),
+    );
+    expect(withSystemDbAccessContext).toHaveBeenCalled();
+  });
+
+  it('verifies a passkey MFA challenge and mints MFA-satisfied tokens', async () => {
+    redisMock.get.mockResolvedValueOnce(JSON.stringify({
+      userId: 'user-123',
+      mfaMethod: 'passkey',
+    }));
+    dbState.selectQueue.push(
+      [user],
+      [{
+        id: 'credential-row-1',
+        userId: 'user-123',
+        credentialId: 'credential-1',
+        publicKey: 'public-key',
+        counter: 0,
+        transports: ['internal'],
+      }],
+      [{ partnerId: 'partner-123', roleId: 'role-123' }],
+    );
+
+    const res = await app.request('/auth/mfa/passkey/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tempToken: 'temp-token',
+        credential: { id: 'credential-1', response: {} },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(createTokenPair).toHaveBeenCalledWith(
+      expect.objectContaining({ sub: 'user-123', email: 'test@example.com', mfa: true }),
+      expect.objectContaining({ refreshFam: 'family-passkey' }),
+    );
+    expect(await res.json()).toMatchObject({
+      mfaRequired: false,
+      tokens: { accessToken: 'access-token', expiresInSeconds: 900 },
+      user: { id: 'user-123', mfaEnabled: true },
+    });
+    expect(redisMock.del).toHaveBeenCalledWith('mfa:pending:temp-token');
+    expect(vi.mocked(withSystemDbAccessContext).mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('rejects a passkey credential that belongs to another user', async () => {
+    redisMock.get.mockResolvedValueOnce(JSON.stringify({
+      userId: 'user-123',
+      mfaMethod: 'passkey',
+    }));
+    dbState.selectQueue.push(
+      [user],
+      [{ id: 'passkey-2', userId: 'user-456', credentialId: 'credential-2' }],
+    );
+
+    const res = await app.request('/auth/mfa/passkey/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tempToken: 'temp-token',
+        credential: { id: 'credential-2', response: {} },
+      }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(createTokenPair).not.toHaveBeenCalled();
+    expect(redisMock.del).not.toHaveBeenCalled();
+  });
+
+  it('blocks deleting the last MFA factor when MFA is required', async () => {
+    vi.mocked(verifyPassword).mockResolvedValueOnce(true);
+    dbState.selectQueue.push(
+      [{ passwordHash: '$argon2id$hash' }],
+      [{ id: 'credential-1', userId: 'user-123' }],
+      [{ passkeyCount: 1, hasTotp: false, hasSms: false, forceMfa: true }],
+    );
+
+    const res = await app.request('/auth/passkeys/credential-1', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+      body: JSON.stringify({ currentPassword: 'correct-password' }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: expect.stringMatching(/last.*factor|requires mfa/i) });
+  });
+
+  it('requires an MFA-satisfied session before deleting a passkey', async () => {
+    authState.mfaSatisfied = false;
+
+    const res = await app.request('/auth/passkeys/credential-1', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+      body: JSON.stringify({ currentPassword: 'correct-password' }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: expect.stringMatching(/mfa.*required/i) });
+    expect(verifyPassword).not.toHaveBeenCalled();
+  });
+
+  it('falls back to TOTP preference when deleting the last passkey and TOTP remains', async () => {
+    vi.mocked(verifyPassword).mockResolvedValueOnce(true);
+    dbState.selectQueue.push(
+      [{ passwordHash: '$argon2id$hash' }],
+      [{ id: 'credential-1', userId: 'user-123' }],
+      [{ passkeyCount: 1, hasTotp: true, hasSms: false, currentMfaMethod: 'passkey', forceMfa: false }],
+    );
+
+    const res = await app.request('/auth/passkeys/credential-1', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+      body: JSON.stringify({ currentPassword: 'correct-password' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(dbState.updateSets).toContainEqual(expect.objectContaining({
+      mfaEnabled: true,
+      mfaMethod: 'totp',
+    }));
+  });
+});

--- a/apps/api/src/routes/auth.passkeys.test.ts
+++ b/apps/api/src/routes/auth.passkeys.test.ts
@@ -249,7 +249,7 @@ vi.mock('../middleware/auth', () => ({
   requirePermission: vi.fn(() => (_c: any, next: any) => next()),
 }));
 
-import { createTokenPair, rateLimiter, verifyPassword } from '../services';
+import { createTokenPair, getRedis, rateLimiter, verifyPassword } from '../services';
 import { PasskeyChallengeError } from '../services/passkeys';
 import { withSystemDbAccessContext } from '../db';
 
@@ -667,6 +667,26 @@ describe('passkey MFA auth routes', () => {
     expect(res.status).toBe(429);
     expect(await res.json()).toMatchObject({ error: expect.stringMatching(/too many/i) });
     expect(createTokenPair).not.toHaveBeenCalled();
+    // The limiter must short-circuit before any credential lookup/verification.
+    expect(passkeyMocks.verifyPasskeyAuthentication).not.toHaveBeenCalled();
+  });
+
+  it('returns 503 from passkey verify when Redis is unavailable', async () => {
+    vi.mocked(getRedis).mockReturnValueOnce(null);
+
+    const res = await app.request('/auth/mfa/passkey/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tempToken: 'temp-token',
+        credential: { id: 'credential-1', response: {} },
+      }),
+    });
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({ error: expect.stringMatching(/unavailable/i) });
+    expect(createTokenPair).not.toHaveBeenCalled();
+    expect(rateLimiter).not.toHaveBeenCalled();
   });
 
   // (d) A suspended user cannot complete passkey MFA even with a valid assertion.
@@ -842,5 +862,35 @@ describe('passkey MFA auth routes', () => {
     expect(res.status).toBe(400);
     expect(await res.json()).toMatchObject({ error: expect.stringMatching(/use passkey verification/i) });
     expect(createTokenPair).not.toHaveBeenCalled();
+  });
+
+  // PATCH /passkeys/:id rename.
+  it('renames a passkey and returns the updated row', async () => {
+    dbState.selectQueue.push([{ ...insertedPasskeyRow, name: 'Old Name' }]);
+    dbState.updateReturningQueue.push([{ ...insertedPasskeyRow, name: 'New Name' }]);
+
+    const res = await app.request('/auth/passkeys/passkey-credential-1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+      body: JSON.stringify({ name: 'New Name' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true, passkey: { name: 'New Name' } });
+    expect(dbState.updateSets).toContainEqual(expect.objectContaining({ name: 'New Name' }));
+  });
+
+  it('returns 404 renaming a passkey the user does not own', async () => {
+    dbState.selectQueue.push([]);
+
+    const res = await app.request('/auth/passkeys/passkey-credential-1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+      body: JSON.stringify({ name: 'New Name' }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ error: expect.stringMatching(/not found/i) });
+    expect(dbState.updateSets).toHaveLength(0);
   });
 });

--- a/apps/api/src/routes/auth.passkeys.test.ts
+++ b/apps/api/src/routes/auth.passkeys.test.ts
@@ -24,6 +24,8 @@ const {
     dbState: {
       selectQueue: [] as unknown[][],
       updateSets: [] as Record<string, unknown>[],
+      insertReturning: [{ id: 'passkey-credential-1' }] as unknown[],
+      updateReturningQueue: [] as unknown[][],
       makeSelectChain,
     },
     redisMock: {
@@ -152,14 +154,21 @@ vi.mock('../db', () => ({
     select: vi.fn(() => dbState.makeSelectChain(dbState.selectQueue.shift() ?? [])),
     insert: vi.fn(() => ({
       values: vi.fn(() => ({
-        returning: vi.fn(() => Promise.resolve([{ id: 'passkey-credential-1' }])),
+        returning: vi.fn(() => Promise.resolve(dbState.insertReturning)),
       })),
     })),
     update: vi.fn(() => ({
       set: vi.fn((values: Record<string, unknown>) => {
         dbState.updateSets.push(values);
+        // `.where()` is awaited directly by most callers (verify/delete), but the
+        // rename PATCH route chains `.where(...).returning()`. Return a thenable
+        // that also exposes `.returning()` so both shapes work.
+        const whereResult: any = Promise.resolve(undefined);
+        whereResult.returning = vi.fn(() =>
+          Promise.resolve(dbState.updateReturningQueue.shift() ?? [])
+        );
         return {
-          where: vi.fn(() => Promise.resolve(undefined)),
+          where: vi.fn(() => whereResult),
         };
       }),
     })),
@@ -176,6 +185,7 @@ vi.mock('../db/schema', () => ({
     id: 'users.id',
     email: 'users.email',
     passwordHash: 'users.passwordHash',
+    status: 'users.status',
     mfaEnabled: 'users.mfaEnabled',
     mfaMethod: 'users.mfaMethod',
     mfaSecret: 'users.mfaSecret',
@@ -212,8 +222,11 @@ vi.mock('../db/schema', () => ({
     credentialId: 'userPasskeys.credentialId',
     publicKey: 'userPasskeys.publicKey',
     counter: 'userPasskeys.counter',
+    deviceType: 'userPasskeys.deviceType',
+    backedUp: 'userPasskeys.backedUp',
     transports: 'userPasskeys.transports',
     name: 'userPasskeys.name',
+    aaguid: 'userPasskeys.aaguid',
     lastUsedAt: 'userPasskeys.lastUsedAt',
     disabledAt: 'userPasskeys.disabledAt',
   },
@@ -236,7 +249,7 @@ vi.mock('../middleware/auth', () => ({
   requirePermission: vi.fn(() => (_c: any, next: any) => next()),
 }));
 
-import { createTokenPair, verifyPassword } from '../services';
+import { createTokenPair, rateLimiter, verifyPassword } from '../services';
 import { PasskeyChallengeError } from '../services/passkeys';
 import { withSystemDbAccessContext } from '../db';
 
@@ -250,6 +263,27 @@ const user = {
   mfaMethod: 'passkey',
 };
 
+// Full row shape returned by the passkey INSERT `.returning()`. The
+// register/verify route now passes the inserted row straight to
+// `toPublicPasskey(...)`, which reads name/deviceType/backedUp/transports plus
+// the `.toISOString()`-able timestamps — so the fixture must carry real Dates.
+const insertedPasskeyRow = {
+  id: 'passkey-credential-1',
+  userId: 'user-123',
+  credentialId: 'credential-1',
+  publicKey: 'public-key',
+  counter: 0,
+  deviceType: 'singleDevice',
+  backedUp: false,
+  transports: ['internal'],
+  name: 'Passkey',
+  aaguid: null,
+  lastUsedAt: null,
+  disabledAt: null,
+  createdAt: new Date('2026-06-11T00:00:00.000Z'),
+  updatedAt: new Date('2026-06-11T00:00:00.000Z'),
+};
+
 describe('passkey MFA auth routes', () => {
   let app: Hono;
 
@@ -257,6 +291,8 @@ describe('passkey MFA auth routes', () => {
     vi.clearAllMocks();
     dbState.selectQueue = [];
     dbState.updateSets = [];
+    dbState.insertReturning = [insertedPasskeyRow];
+    dbState.updateReturningQueue = [];
     redisMock.get.mockReset();
     redisMock.setex.mockReset();
     redisMock.del.mockReset();
@@ -539,5 +575,272 @@ describe('passkey MFA auth routes', () => {
       mfaEnabled: true,
       mfaMethod: 'totp',
     }));
+  });
+
+  // (a) Failed assertion must not mint a session.
+  it('rejects a passkey MFA challenge that fails WebAuthn verification without minting tokens', async () => {
+    redisMock.get.mockResolvedValueOnce(JSON.stringify({
+      userId: 'user-123',
+      mfaMethod: 'passkey',
+    }));
+    dbState.selectQueue.push(
+      [user],
+      [{
+        id: 'credential-row-1',
+        userId: 'user-123',
+        credentialId: 'credential-1',
+        publicKey: 'public-key',
+        counter: 0,
+        transports: ['internal'],
+        disabledAt: null,
+      }],
+    );
+    passkeyMocks.verifyPasskeyAuthentication.mockResolvedValueOnce({ verified: false });
+
+    const res = await app.request('/auth/mfa/passkey/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tempToken: 'temp-token',
+        credential: { id: 'credential-1', response: {} },
+      }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ error: expect.stringMatching(/verification failed/i) });
+    expect(createTokenPair).not.toHaveBeenCalled();
+    expect(redisMock.del).not.toHaveBeenCalled();
+  });
+
+  // (b) A disabled credential owned by the user is still rejected (403).
+  it('rejects a disabled passkey credential even when the userId matches', async () => {
+    redisMock.get.mockResolvedValueOnce(JSON.stringify({
+      userId: 'user-123',
+      mfaMethod: 'passkey',
+    }));
+    dbState.selectQueue.push(
+      [user],
+      [{
+        id: 'credential-row-1',
+        userId: 'user-123',
+        credentialId: 'credential-1',
+        disabledAt: new Date('2026-06-01T00:00:00.000Z'),
+      }],
+    );
+
+    const res = await app.request('/auth/mfa/passkey/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tempToken: 'temp-token',
+        credential: { id: 'credential-1', response: {} },
+      }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(createTokenPair).not.toHaveBeenCalled();
+    expect(passkeyMocks.verifyPasskeyAuthentication).not.toHaveBeenCalled();
+    expect(redisMock.del).not.toHaveBeenCalled();
+  });
+
+  // (c) Rate limiter denial → 429, before any DB / credential work.
+  it('returns 429 when the MFA rate limiter denies a passkey verify attempt', async () => {
+    redisMock.get.mockResolvedValueOnce(JSON.stringify({
+      userId: 'user-123',
+      mfaMethod: 'passkey',
+    }));
+    vi.mocked(rateLimiter).mockResolvedValueOnce({
+      allowed: false,
+      remaining: 0,
+      resetAt: new Date(),
+    });
+
+    const res = await app.request('/auth/mfa/passkey/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tempToken: 'temp-token',
+        credential: { id: 'credential-1', response: {} },
+      }),
+    });
+
+    expect(res.status).toBe(429);
+    expect(await res.json()).toMatchObject({ error: expect.stringMatching(/too many/i) });
+    expect(createTokenPair).not.toHaveBeenCalled();
+  });
+
+  // (d) A suspended user cannot complete passkey MFA even with a valid assertion.
+  it('rejects passkey verify when the user account is no longer active', async () => {
+    redisMock.get.mockResolvedValueOnce(JSON.stringify({
+      userId: 'user-123',
+      mfaMethod: 'passkey',
+    }));
+    dbState.selectQueue.push([{ ...user, status: 'suspended' }]);
+
+    const res = await app.request('/auth/mfa/passkey/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tempToken: 'temp-token',
+        credential: { id: 'credential-1', response: {} },
+      }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ error: expect.stringMatching(/invalid or expired/i) });
+    expect(createTokenPair).not.toHaveBeenCalled();
+    expect(redisMock.del).not.toHaveBeenCalled();
+  });
+
+  // (e) /mfa/passkey/options guards.
+  it('returns 400 from passkey options when the pending session is not a passkey session', async () => {
+    redisMock.get.mockResolvedValueOnce(JSON.stringify({
+      userId: 'user-123',
+      mfaMethod: 'totp',
+    }));
+
+    const res = await app.request('/auth/mfa/passkey/options', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tempToken: 'temp-token' }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: expect.stringMatching(/passkey mfa is not configured/i) });
+    expect(passkeyMocks.generatePasskeyAuthenticationOptions).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 from passkey options when the account has no registered passkeys', async () => {
+    redisMock.get.mockResolvedValueOnce(JSON.stringify({
+      userId: 'user-123',
+      mfaMethod: 'passkey',
+    }));
+    dbState.selectQueue.push([]);
+
+    const res = await app.request('/auth/mfa/passkey/options', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tempToken: 'temp-token' }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: expect.stringMatching(/no passkeys/i) });
+    expect(passkeyMocks.generatePasskeyAuthenticationOptions).not.toHaveBeenCalled();
+  });
+
+  // (f) register/verify must NOT clobber an existing TOTP/SMS factor's method.
+  it('does not overwrite an existing TOTP factor method when registering a passkey', async () => {
+    // Current MFA select returns an existing TOTP factor.
+    dbState.selectQueue.push([{ mfaSecret: 'enc-secret', mfaMethod: 'totp' }]);
+
+    const res = await app.request('/auth/passkeys/register/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+      body: JSON.stringify({ credential: { id: 'credential-1', response: {} } }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      success: true,
+      passkey: { id: 'passkey-credential-1', name: 'Passkey' },
+    });
+    // The users UPDATE enables MFA but must leave mfaMethod untouched.
+    const userUpdate = dbState.updateSets.find((set) => 'mfaEnabled' in set);
+    expect(userUpdate).toBeDefined();
+    expect(userUpdate).toMatchObject({ mfaEnabled: true });
+    expect(userUpdate).not.toHaveProperty('mfaMethod');
+  });
+
+  it('makes passkey the primary MFA method when the user has no existing factor', async () => {
+    dbState.selectQueue.push([{ mfaSecret: null, mfaMethod: null }]);
+
+    const res = await app.request('/auth/passkeys/register/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+      body: JSON.stringify({ credential: { id: 'credential-1', response: {} } }),
+    });
+
+    expect(res.status).toBe(200);
+    const userUpdate = dbState.updateSets.find((set) => 'mfaEnabled' in set);
+    expect(userUpdate).toMatchObject({ mfaEnabled: true, mfaMethod: 'passkey' });
+  });
+
+  // (g) DELETE branches.
+  it('blocks deleting a passkey when the current-password step-up fails', async () => {
+    vi.mocked(verifyPassword).mockResolvedValueOnce(false);
+    dbState.selectQueue.push([{ passwordHash: '$argon2id$hash' }]);
+
+    const res = await app.request('/auth/passkeys/credential-1', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+      body: JSON.stringify({ currentPassword: 'wrong-password' }),
+    });
+
+    expect(res.status).toBe(401);
+    // No passkey delete and no users update should run when the password is wrong.
+    expect(dbState.updateSets).toHaveLength(0);
+  });
+
+  it('switches the primary method to SMS when deleting the last passkey and SMS remains', async () => {
+    vi.mocked(verifyPassword).mockResolvedValueOnce(true);
+    dbState.selectQueue.push(
+      [{ passwordHash: '$argon2id$hash' }],
+      [{ id: 'credential-1', userId: 'user-123' }],
+      [{ passkeyCount: 1, hasTotp: false, hasSms: true, currentMfaMethod: 'passkey', forceMfa: false, orgRequiresMfa: false }],
+    );
+
+    const res = await app.request('/auth/passkeys/credential-1', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+      body: JSON.stringify({ currentPassword: 'correct-password' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(dbState.updateSets).toContainEqual(expect.objectContaining({
+      mfaEnabled: true,
+      mfaMethod: 'sms',
+    }));
+  });
+
+  it('disables MFA when deleting the only passkey and no other factor remains', async () => {
+    vi.mocked(verifyPassword).mockResolvedValueOnce(true);
+    dbState.selectQueue.push(
+      [{ passwordHash: '$argon2id$hash' }],
+      [{ id: 'credential-1', userId: 'user-123' }],
+      [{ passkeyCount: 1, hasTotp: false, hasSms: false, currentMfaMethod: 'passkey', forceMfa: false, orgRequiresMfa: false }],
+    );
+
+    const res = await app.request('/auth/passkeys/credential-1', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+      body: JSON.stringify({ currentPassword: 'correct-password' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(dbState.updateSets).toContainEqual(expect.objectContaining({
+      mfaEnabled: false,
+      mfaMethod: null,
+    }));
+  });
+
+  // mfa.ts guard: a passkey pending session must be routed to passkey verification.
+  it('rejects /mfa/verify (TOTP path) for a pending passkey MFA session', async () => {
+    redisMock.get.mockResolvedValueOnce(JSON.stringify({
+      userId: 'user-123',
+      mfaMethod: 'passkey',
+    }));
+    // user lookup inside /mfa/verify happens before the passkey guard returns,
+    // so provide the user row.
+    dbState.selectQueue.push([user]);
+
+    const res = await app.request('/auth/mfa/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tempToken: 'temp-token', code: '123456' }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: expect.stringMatching(/use passkey verification/i) });
+    expect(createTokenPair).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/auth/cfAccessRedirectLogin.test.ts
+++ b/apps/api/src/routes/auth/cfAccessRedirectLogin.test.ts
@@ -280,6 +280,25 @@ describe('GET /cf-access-login', () => {
     expect(res.headers.get('Location')).toContain('reason=mfa-required');
   });
 
+  it('redirects to /login with error=mfa-required when user has passkey MFA and TRUSTS_MFA is false', async () => {
+    envState.enabled = true;
+    envState.trustsMfa = false;
+    verifyState.next = {
+      kind: 'claims',
+      claims: {
+        email: activeUser.email,
+        sub: 'cf-1',
+        aud: envState.audience,
+        iss: `https://${envState.teamDomain}`,
+        exp: 999,
+        iat: 1,
+      },
+    };
+    dbState.userRow = { ...activeUser, mfaEnabled: true, mfaSecret: null, mfaMethod: 'passkey' };
+    const res = await callGet('/cf-access-login', { 'Cf-Access-Jwt-Assertion': 'tok' });
+    expect(res.headers.get('Location')).toContain('reason=mfa-required');
+  });
+
   it('mints a session and redirects to / with cf-access-login=success on success', async () => {
     envState.enabled = true;
     verifyState.next = {

--- a/apps/api/src/routes/auth/cfAccessRedirectLogin.ts
+++ b/apps/api/src/routes/auth/cfAccessRedirectLogin.ts
@@ -155,7 +155,7 @@ cfAccessRedirectLoginRoutes.get('/cf-access-login', async (c) => {
   }
 
   const trustsMfa = cfAccessTrustsMfa();
-  if (ENABLE_2FA && user.mfaEnabled && (user.mfaSecret || user.mfaMethod === 'sms') && !trustsMfa) {
+  if (ENABLE_2FA && user.mfaEnabled && (user.mfaSecret || user.mfaMethod === 'sms' || user.mfaMethod === 'passkey') && !trustsMfa) {
     // POC: MFA flow over redirect is deferred. For now, surface a clear
     // error so the user falls back to password login (which CAN do MFA).
     // Pre-PR follow-up: emit ?mfa=<tempToken>&mfaMethod=... and have the

--- a/apps/api/src/routes/auth/index.ts
+++ b/apps/api/src/routes/auth/index.ts
@@ -9,6 +9,7 @@ import { verifyEmailRoutes } from './verifyEmail';
 import { accountDeletionRoutes } from './accountDeletion';
 import { testApprovalRoutes } from './testApproval';
 import { cfAccessRedirectLoginRoutes } from './cfAccessRedirectLogin';
+import { passkeyRoutes } from './passkeys';
 
 export const authRoutes = new Hono();
 
@@ -18,6 +19,7 @@ export const authRoutes = new Hono();
 authRoutes.route('/', registerRoutes);
 authRoutes.route('/', loginRoutes);
 authRoutes.route('/', mfaRoutes);
+authRoutes.route('/', passkeyRoutes);
 authRoutes.route('/', phoneRoutes);
 authRoutes.route('/', passwordRoutes);
 authRoutes.route('/', inviteRoutes);
@@ -25,4 +27,3 @@ authRoutes.route('/', verifyEmailRoutes);
 authRoutes.route('/', accountDeletionRoutes);
 authRoutes.route('/', testApprovalRoutes);
 authRoutes.route('/', cfAccessRedirectLoginRoutes);
-

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -395,7 +395,7 @@ loginRoutes.post('/login', cfAccessLoginMiddleware, zValidator('json', loginSche
 
   // Check if MFA is required. This happens after the SSO-only check so an
   // org-enforced SSO user cannot obtain an MFA temp token through password auth.
-  if (ENABLE_2FA && user.mfaEnabled && (user.mfaSecret || user.mfaMethod === 'sms')) {
+  if (ENABLE_2FA && user.mfaEnabled && (user.mfaSecret || user.mfaMethod === 'sms' || user.mfaMethod === 'passkey')) {
     const tempToken = nanoid(32);
     const mfaMethod = user.mfaMethod || 'totp';
     await getRedis()!.setex(`mfa:pending:${tempToken}`, 300, JSON.stringify({

--- a/apps/api/src/routes/auth/mfa.ts
+++ b/apps/api/src/routes/auth/mfa.ts
@@ -166,6 +166,10 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
 
     let valid = false;
     let migratedMfaSecret: string | null = null;
+    if (effectiveMethod === 'passkey') {
+      return c.json({ error: 'Use passkey verification for this MFA session' }, 400);
+    }
+
     if (effectiveMethod === 'sms') {
       const phone = user.phoneNumber;
       if (!phone) {

--- a/apps/api/src/routes/auth/passkeys.ts
+++ b/apps/api/src/routes/auth/passkeys.ts
@@ -1,0 +1,531 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import { z } from 'zod';
+import * as dbModule from '../../db';
+import { userPasskeys, users } from '../../db/schema';
+import { authMiddleware, type AuthContext } from '../../middleware/auth';
+import {
+  bindRefreshJtiToFamily,
+  createTokenPair,
+  getRedis,
+  mintRefreshTokenFamily
+} from '../../services';
+import {
+  PasskeyChallengeError,
+  authenticationInfoToPasskeyUpdateFields,
+  generatePasskeyAuthenticationOptions,
+  generatePasskeyRegistrationOptions,
+  registrationInfoToPasskeyFields,
+  verifyPasskeyAuthentication,
+  verifyPasskeyRegistration
+} from '../../services/passkeys';
+import { readMobileDeviceId } from '../../services/mobileDeviceBinding';
+import { ENABLE_2FA } from './schemas';
+import {
+  auditLogin,
+  getClientIP,
+  mfaDisabledResponse,
+  requireCurrentPasswordStepUp,
+  resolveCurrentUserTokenContext,
+  setRefreshTokenCookie,
+  toPublicTokens,
+  userRequiresSetup,
+  writeAuthAudit
+} from './helpers';
+
+const { db, withSystemDbAccessContext } = dbModule;
+
+const passkeyNameSchema = z.string().trim().min(1).max(255);
+const registerOptionsSchema = z.object({
+  currentPassword: z.string().min(1).max(256),
+  name: passkeyNameSchema.optional()
+});
+const registerVerifySchema = z.object({
+  credential: z.any(),
+  name: passkeyNameSchema.optional()
+});
+const passkeyMfaOptionsSchema = z.object({
+  tempToken: z.string().min(1)
+});
+const passkeyMfaVerifySchema = z.object({
+  tempToken: z.string().min(1),
+  credential: z.any()
+});
+const renamePasskeySchema = z.object({
+  name: passkeyNameSchema
+});
+const deletePasskeySchema = z.object({
+  currentPassword: z.string().min(1).max(256)
+});
+
+type PendingPasskeyMfa = {
+  userId: string;
+  mfaMethod: string;
+};
+
+type PasskeyRow = typeof userPasskeys.$inferSelect;
+
+export const passkeyRoutes = new Hono();
+
+passkeyRoutes.get('/passkeys', authMiddleware, async (c) => {
+  if (!ENABLE_2FA) {
+    return mfaDisabledResponse(c);
+  }
+
+  const auth = c.get('auth');
+  const rows = await listActivePasskeys(auth.user.id);
+  return c.json({ passkeys: rows.map(toPublicPasskey) });
+});
+
+passkeyRoutes.post('/passkeys/register/options', authMiddleware, zValidator('json', registerOptionsSchema), async (c) => {
+  if (!ENABLE_2FA) {
+    return mfaDisabledResponse(c);
+  }
+
+  const auth = c.get('auth');
+  const { currentPassword } = c.req.valid('json');
+
+  const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'passkey:pwd');
+  if (passwordError) return passwordError;
+
+  const existingPasskeys = await listActivePasskeys(auth.user.id);
+  const options = await generatePasskeyRegistrationOptions({
+    user: auth.user,
+    existingPasskeys: existingPasskeys.map(toStoredCredential)
+  });
+
+  return c.json({ options });
+});
+
+passkeyRoutes.post('/passkeys/register/verify', authMiddleware, zValidator('json', registerVerifySchema), async (c) => {
+  if (!ENABLE_2FA) {
+    return mfaDisabledResponse(c);
+  }
+
+  const auth = c.get('auth');
+  const { credential, name } = c.req.valid('json');
+
+  let verification;
+  try {
+    verification = await verifyPasskeyRegistration({
+      userId: auth.user.id,
+      response: credential
+    });
+  } catch (err) {
+    if (err instanceof PasskeyChallengeError) {
+      return c.json({ error: err.message }, 401);
+    }
+    throw err;
+  }
+
+  if (!verification.verified) {
+    writeAuthAudit(c, {
+      orgId: auth.orgId ?? undefined,
+      action: 'auth.mfa.passkey.register.failed',
+      result: 'failure',
+      reason: 'invalid_passkey_registration',
+      userId: auth.user.id,
+      email: auth.user.email,
+      details: { method: 'passkey' }
+    });
+    return c.json({ error: 'Passkey registration failed' }, 401);
+  }
+
+  const fields = registrationInfoToPasskeyFields(verification, credential);
+  const [inserted] = await db
+    .insert(userPasskeys)
+    .values({
+      userId: auth.user.id,
+      credentialId: fields.credentialId,
+      publicKey: fields.publicKey,
+      counter: fields.counter,
+      deviceType: fields.deviceType,
+      backedUp: fields.backedUp,
+      transports: fields.transports,
+      name: name ?? 'Passkey',
+      aaguid: fields.aaguid,
+      updatedAt: new Date()
+    })
+    .returning();
+
+  await db
+    .update(users)
+    .set({
+      mfaEnabled: true,
+      mfaMethod: 'passkey',
+      updatedAt: new Date()
+    })
+    .where(eq(users.id, auth.user.id));
+
+  writeAuthAudit(c, {
+    orgId: auth.orgId ?? undefined,
+    action: 'auth.mfa.passkey.register',
+    result: 'success',
+    userId: auth.user.id,
+    email: auth.user.email,
+    details: { method: 'passkey', credentialId: fields.credentialId }
+  });
+
+  return c.json({
+    success: true,
+    passkey: toPublicPasskey({
+      id: inserted?.id ?? fields.credentialId,
+      userId: auth.user.id,
+      credentialId: fields.credentialId,
+      publicKey: fields.publicKey,
+      counter: fields.counter,
+      deviceType: fields.deviceType,
+      backedUp: fields.backedUp,
+      transports: fields.transports,
+      name: name ?? 'Passkey',
+      aaguid: fields.aaguid,
+      lastUsedAt: null,
+      disabledAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    })
+  });
+});
+
+passkeyRoutes.post('/mfa/passkey/options', zValidator('json', passkeyMfaOptionsSchema), async (c) => {
+  if (!ENABLE_2FA) {
+    return mfaDisabledResponse(c);
+  }
+
+  const { tempToken } = c.req.valid('json');
+  const pending = await readPendingPasskeyMfa(tempToken);
+  if (!pending) {
+    return c.json({ error: 'Invalid or expired MFA session' }, 401);
+  }
+  if (pending.mfaMethod !== 'passkey') {
+    return c.json({ error: 'Passkey MFA is not configured for this session' }, 400);
+  }
+
+  const passkeys = await withSystemDbAccessContext(() => listActivePasskeys(pending.userId));
+  if (passkeys.length === 0) {
+    return c.json({ error: 'No passkeys are registered for this account' }, 400);
+  }
+
+  const options = await generatePasskeyAuthenticationOptions({
+    userId: pending.userId,
+    passkeys: passkeys.map(toStoredCredential)
+  });
+
+  return c.json({ options });
+});
+
+passkeyRoutes.post('/mfa/passkey/verify', zValidator('json', passkeyMfaVerifySchema), async (c) => {
+  if (!ENABLE_2FA) {
+    return mfaDisabledResponse(c);
+  }
+
+  const { tempToken, credential } = c.req.valid('json');
+  const pending = await readPendingPasskeyMfa(tempToken);
+  if (!pending) {
+    return c.json({ error: 'Invalid or expired MFA session' }, 401);
+  }
+  if (pending.mfaMethod !== 'passkey') {
+    return c.json({ error: 'Passkey MFA is not configured for this session' }, 400);
+  }
+
+  const [user] = await withSystemDbAccessContext(async () =>
+    db
+      .select()
+      .from(users)
+      .where(eq(users.id, pending.userId))
+      .limit(1)
+  );
+  if (!user) {
+    return c.json({ error: 'Invalid MFA configuration' }, 400);
+  }
+
+  const [passkey] = await withSystemDbAccessContext(() =>
+    db
+      .select()
+      .from(userPasskeys)
+      .where(eq(userPasskeys.credentialId, credential?.id))
+      .limit(1)
+  );
+
+  if (!passkey || passkey.userId !== pending.userId || passkey.disabledAt) {
+    return c.json({ error: 'Passkey is not registered for this account' }, 403);
+  }
+
+  let verification;
+  try {
+    verification = await verifyPasskeyAuthentication({
+      userId: pending.userId,
+      response: credential,
+      passkey: toStoredCredential(passkey)
+    });
+  } catch (err) {
+    if (err instanceof PasskeyChallengeError) {
+      return c.json({ error: err.message }, 401);
+    }
+    throw err;
+  }
+
+  if (!verification.verified) {
+    return c.json({ error: 'Passkey verification failed' }, 401);
+  }
+
+  const updateFields = authenticationInfoToPasskeyUpdateFields(verification);
+  await db
+    .update(userPasskeys)
+    .set({
+      counter: updateFields.counter,
+      deviceType: updateFields.deviceType,
+      backedUp: updateFields.backedUp,
+      lastUsedAt: updateFields.lastUsedAt,
+      updatedAt: new Date()
+    })
+    .where(eq(userPasskeys.id, passkey.id));
+
+  await getRedis()?.del(`mfa:pending:${tempToken}`);
+
+  const context = await resolveCurrentUserTokenContext(user.id);
+  const familyId = await mintRefreshTokenFamily(user.id);
+  const tokens = await createTokenPair({
+    sub: user.id,
+    email: user.email,
+    roleId: context.roleId,
+    orgId: context.orgId,
+    partnerId: context.partnerId,
+    scope: context.scope,
+    mfa: true,
+    mdid: readMobileDeviceId(c) ?? undefined
+  }, { refreshFam: familyId });
+  await bindRefreshJtiToFamily(tokens.refreshJti, familyId);
+
+  await db
+    .update(users)
+    .set({ lastLoginAt: new Date() })
+    .where(eq(users.id, user.id));
+
+  auditLogin(c, {
+    orgId: context.orgId ?? null,
+    userId: user.id,
+    email: user.email,
+    name: user.name,
+    mfa: true,
+    scope: context.scope,
+    ip: getClientIP(c)
+  });
+
+  setRefreshTokenCookie(c, tokens.refreshToken);
+
+  return c.json({
+    user: {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      mfaEnabled: true
+    },
+    tokens: toPublicTokens(tokens),
+    mfaRequired: false,
+    requiresSetup: userRequiresSetup(user)
+  });
+});
+
+passkeyRoutes.patch('/passkeys/:id', authMiddleware, zValidator('json', renamePasskeySchema), async (c) => {
+  if (!ENABLE_2FA) {
+    return mfaDisabledResponse(c);
+  }
+
+  const auth = c.get('auth');
+  const id = c.req.param('id');
+  const { name } = c.req.valid('json');
+
+  const [passkey] = await findOwnedPasskey(id, auth.user.id);
+  if (!passkey) {
+    return c.json({ error: 'Passkey not found' }, 404);
+  }
+
+  await db
+    .update(userPasskeys)
+    .set({ name, updatedAt: new Date() })
+    .where(eq(userPasskeys.id, id));
+
+  return c.json({ success: true, passkey: { ...toPublicPasskey(passkey), name } });
+});
+
+passkeyRoutes.delete('/passkeys/:id', authMiddleware, zValidator('json', deletePasskeySchema), async (c) => {
+  if (!ENABLE_2FA) {
+    return mfaDisabledResponse(c);
+  }
+
+  const auth = c.get('auth');
+  const id = c.req.param('id');
+  const { currentPassword } = c.req.valid('json');
+
+  if (auth.token.mfa !== true) {
+    return c.json({ error: 'MFA verification is required to delete a passkey' }, 403);
+  }
+
+  const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'passkey:pwd');
+  if (passwordError) return passwordError;
+
+  const [passkey] = await findOwnedPasskey(id, auth.user.id);
+  if (!passkey) {
+    return c.json({ error: 'Passkey not found' }, 404);
+  }
+
+  const factorState = await getMfaFactorState(auth);
+  const remainingFactorCount =
+    Math.max(0, factorState.passkeyCount - 1)
+    + (factorState.hasTotp ? 1 : 0)
+    + (factorState.hasSms ? 1 : 0);
+
+  if (factorState.mfaRequired && remainingFactorCount === 0) {
+    return c.json({ error: 'Cannot remove the last MFA factor while your role or organization requires MFA' }, 403);
+  }
+
+  await db
+    .delete(userPasskeys)
+    .where(eq(userPasskeys.id, id));
+
+  if (remainingFactorCount === 0) {
+    await db
+      .update(users)
+      .set({
+        mfaEnabled: false,
+        mfaMethod: null,
+        updatedAt: new Date()
+      })
+      .where(eq(users.id, auth.user.id));
+  } else if (factorState.currentMfaMethod === 'passkey' && factorState.passkeyCount - 1 === 0) {
+    await db
+      .update(users)
+      .set({
+        mfaEnabled: true,
+        mfaMethod: factorState.hasTotp ? 'totp' : 'sms',
+        updatedAt: new Date()
+      })
+      .where(eq(users.id, auth.user.id));
+  }
+
+  writeAuthAudit(c, {
+    orgId: auth.orgId ?? undefined,
+    action: 'auth.mfa.passkey.delete',
+    result: 'success',
+    userId: auth.user.id,
+    email: auth.user.email,
+    details: { method: 'passkey', passkeyId: id }
+  });
+
+  return c.json({ success: true });
+});
+
+async function readPendingPasskeyMfa(tempToken: string): Promise<PendingPasskeyMfa | null> {
+  const redis = getRedis();
+  if (!redis) {
+    return null;
+  }
+
+  const raw = await redis.get(`mfa:pending:${tempToken}`);
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<PendingPasskeyMfa>;
+    if (typeof parsed.userId !== 'string') return null;
+    return {
+      userId: parsed.userId,
+      mfaMethod: parsed.mfaMethod || 'totp'
+    };
+  } catch {
+    return {
+      userId: raw,
+      mfaMethod: 'totp'
+    };
+  }
+}
+
+async function listActivePasskeys(userId: string): Promise<PasskeyRow[]> {
+  return db
+    .select()
+    .from(userPasskeys)
+    .where(and(eq(userPasskeys.userId, userId), isNull(userPasskeys.disabledAt)))
+    .limit(100);
+}
+
+function findOwnedPasskey(id: string, userId: string): Promise<PasskeyRow[]> {
+  return db
+    .select()
+    .from(userPasskeys)
+    .where(and(eq(userPasskeys.id, id), eq(userPasskeys.userId, userId), isNull(userPasskeys.disabledAt)))
+    .limit(1);
+}
+
+async function getMfaFactorState(auth: AuthContext): Promise<{
+  passkeyCount: number;
+  hasTotp: boolean;
+  hasSms: boolean;
+  currentMfaMethod: 'totp' | 'sms' | 'passkey' | null;
+  mfaRequired: boolean;
+}> {
+  const [state] = await withSystemDbAccessContext(async () =>
+    db
+      .select({
+        passkeyCount: sql<number>`(
+          SELECT COUNT(*)::int
+          FROM user_passkeys
+          WHERE user_id = ${auth.user.id}
+            AND disabled_at IS NULL
+        )`,
+        hasTotp: sql<boolean>`${users.mfaSecret} IS NOT NULL`,
+        hasSms: sql<boolean>`${users.mfaMethod} = 'sms' AND ${users.phoneVerified} = true`,
+        currentMfaMethod: users.mfaMethod,
+        forceMfa: sql<boolean>`EXISTS (
+          SELECT 1
+          FROM roles r
+          LEFT JOIN partner_users pu ON pu.role_id = r.id
+          LEFT JOIN organization_users ou ON ou.role_id = r.id
+          WHERE (pu.user_id = ${auth.user.id} OR ou.user_id = ${auth.user.id})
+            AND r.force_mfa = true
+        )`,
+        orgRequiresMfa: auth.orgId
+          ? sql<boolean>`EXISTS (
+              SELECT 1
+              FROM organizations o
+              WHERE o.id = ${auth.orgId}
+                AND COALESCE((o.settings->'security'->>'requireMfa')::boolean, false) = true
+            )`
+          : sql<boolean>`false`
+      })
+      .from(users)
+      .where(eq(users.id, auth.user.id))
+      .limit(1)
+  );
+
+  return {
+    passkeyCount: Number(state?.passkeyCount ?? 0),
+    hasTotp: Boolean(state?.hasTotp),
+    hasSms: Boolean(state?.hasSms),
+    currentMfaMethod: state?.currentMfaMethod ?? null,
+    mfaRequired: Boolean((state as { forceMfa?: boolean; orgRequiresMfa?: boolean } | undefined)?.forceMfa || (state as { forceMfa?: boolean; orgRequiresMfa?: boolean } | undefined)?.orgRequiresMfa)
+  };
+}
+
+function toStoredCredential(passkey: Pick<PasskeyRow, 'credentialId' | 'publicKey' | 'counter' | 'transports'>) {
+  return {
+    credentialId: passkey.credentialId,
+    publicKey: passkey.publicKey,
+    counter: passkey.counter,
+    transports: passkey.transports
+  };
+}
+
+function toPublicPasskey(passkey: Pick<PasskeyRow, 'id'> & Partial<PasskeyRow>) {
+  return {
+    id: passkey.id,
+    name: passkey.name ?? 'Passkey',
+    deviceType: passkey.deviceType,
+    backedUp: passkey.backedUp,
+    transports: passkey.transports ?? [],
+    lastUsedAt: passkey.lastUsedAt?.toISOString() ?? null,
+    createdAt: passkey.createdAt?.toISOString() ?? null
+  };
+}

--- a/apps/api/src/routes/auth/passkeys.ts
+++ b/apps/api/src/routes/auth/passkeys.ts
@@ -9,7 +9,9 @@ import {
   bindRefreshJtiToFamily,
   createTokenPair,
   getRedis,
-  mintRefreshTokenFamily
+  mfaLimiter,
+  mintRefreshTokenFamily,
+  rateLimiter
 } from '../../services';
 import {
   PasskeyChallengeError,
@@ -34,7 +36,20 @@ import {
   writeAuthAudit
 } from './helpers';
 
-const { db, withSystemDbAccessContext } = dbModule;
+const { db, withSystemDbAccessContext, runOutsideDbContext } = dbModule;
+
+// WebAuthn assertion/attestation payloads are large nested objects validated
+// structurally by @simplewebauthn; at this layer we only need a string `id` to
+// look up the stored credential. Require it so a malformed body is rejected at
+// validation (400) instead of falling through to a confusing "passkey not
+// registered" (403). Output type stays `any` so it forwards to the WebAuthn
+// library's typed verifiers unchanged.
+const webAuthnCredentialSchema = z
+  .any()
+  .refine(
+    (value): boolean => typeof value?.id === 'string' && value.id.length > 0,
+    { message: 'credential.id is required' }
+  );
 
 const passkeyNameSchema = z.string().trim().min(1).max(255);
 const registerOptionsSchema = z.object({
@@ -42,7 +57,7 @@ const registerOptionsSchema = z.object({
   name: passkeyNameSchema.optional()
 });
 const registerVerifySchema = z.object({
-  credential: z.any(),
+  credential: webAuthnCredentialSchema,
   name: passkeyNameSchema.optional()
 });
 const passkeyMfaOptionsSchema = z.object({
@@ -50,7 +65,7 @@ const passkeyMfaOptionsSchema = z.object({
 });
 const passkeyMfaVerifySchema = z.object({
   tempToken: z.string().min(1),
-  credential: z.any()
+  credential: webAuthnCredentialSchema
 });
 const renamePasskeySchema = z.object({
   name: passkeyNameSchema
@@ -149,11 +164,27 @@ passkeyRoutes.post('/passkeys/register/verify', authMiddleware, zValidator('json
     })
     .returning();
 
+  if (!inserted) {
+    throw new Error('Passkey insert returned no row');
+  }
+
+  // Enable MFA, but do NOT overwrite an existing TOTP/SMS factor's method.
+  // `mfaMethod` is single-valued and drives login routing (login.ts/mfa.ts);
+  // clobbering it to 'passkey' would strand a user's working authenticator
+  // and risk lockout if they later lose the passkey device. Only make passkey
+  // the primary method when the user has no other factor configured.
+  const [currentMfa] = await db
+    .select({ mfaSecret: users.mfaSecret, mfaMethod: users.mfaMethod })
+    .from(users)
+    .where(eq(users.id, auth.user.id))
+    .limit(1);
+  const hasExistingFactor = Boolean(currentMfa?.mfaSecret) || currentMfa?.mfaMethod === 'sms';
+
   await db
     .update(users)
     .set({
       mfaEnabled: true,
-      mfaMethod: 'passkey',
+      ...(hasExistingFactor ? {} : { mfaMethod: 'passkey' }),
       updatedAt: new Date()
     })
     .where(eq(users.id, auth.user.id));
@@ -169,22 +200,7 @@ passkeyRoutes.post('/passkeys/register/verify', authMiddleware, zValidator('json
 
   return c.json({
     success: true,
-    passkey: toPublicPasskey({
-      id: inserted?.id ?? fields.credentialId,
-      userId: auth.user.id,
-      credentialId: fields.credentialId,
-      publicKey: fields.publicKey,
-      counter: fields.counter,
-      deviceType: fields.deviceType,
-      backedUp: fields.backedUp,
-      transports: fields.transports,
-      name: name ?? 'Passkey',
-      aaguid: fields.aaguid,
-      lastUsedAt: null,
-      disabledAt: null,
-      createdAt: new Date(),
-      updatedAt: new Date()
-    })
+    passkey: toPublicPasskey(inserted)
   });
 });
 
@@ -200,6 +216,13 @@ passkeyRoutes.post('/mfa/passkey/options', zValidator('json', passkeyMfaOptionsS
   }
   if (pending.mfaMethod !== 'passkey') {
     return c.json({ error: 'Passkey MFA is not configured for this session' }, 400);
+  }
+
+  // Throttle the unauthenticated MFA-continuation surface, mirroring the TOTP
+  // path in mfa.ts so challenge issuance can't be hammered.
+  const rateCheck = await rateLimiter(getRedis(), `mfa:${pending.userId}`, mfaLimiter.limit, mfaLimiter.windowSeconds);
+  if (!rateCheck.allowed) {
+    return c.json({ error: 'Too many MFA attempts' }, 429);
   }
 
   const passkeys = await withSystemDbAccessContext(() => listActivePasskeys(pending.userId));
@@ -220,6 +243,11 @@ passkeyRoutes.post('/mfa/passkey/verify', zValidator('json', passkeyMfaVerifySch
     return mfaDisabledResponse(c);
   }
 
+  const redis = getRedis();
+  if (!redis) {
+    return c.json({ error: 'MFA verification unavailable. Please try again later.' }, 503);
+  }
+
   const { tempToken, credential } = c.req.valid('json');
   const pending = await readPendingPasskeyMfa(tempToken);
   if (!pending) {
@@ -227,6 +255,12 @@ passkeyRoutes.post('/mfa/passkey/verify', zValidator('json', passkeyMfaVerifySch
   }
   if (pending.mfaMethod !== 'passkey') {
     return c.json({ error: 'Passkey MFA is not configured for this session' }, 400);
+  }
+
+  // Rate limit assertion attempts, mirroring the TOTP path in mfa.ts.
+  const rateCheck = await rateLimiter(redis, `mfa:${pending.userId}`, mfaLimiter.limit, mfaLimiter.windowSeconds);
+  if (!rateCheck.allowed) {
+    return c.json({ error: 'Too many MFA attempts' }, 429);
   }
 
   const [user] = await withSystemDbAccessContext(async () =>
@@ -238,6 +272,11 @@ passkeyRoutes.post('/mfa/passkey/verify', zValidator('json', passkeyMfaVerifySch
   );
   if (!user) {
     return c.json({ error: 'Invalid MFA configuration' }, 400);
+  }
+  // Re-check account status before minting tokens — the user could have been
+  // suspended during the 5-minute MFA window after the pending token was issued.
+  if (user.status !== 'active') {
+    return c.json({ error: 'Invalid or expired MFA session' }, 401);
   }
 
   const [passkey] = await withSystemDbAccessContext(() =>
@@ -282,7 +321,9 @@ passkeyRoutes.post('/mfa/passkey/verify', zValidator('json', passkeyMfaVerifySch
     })
     .where(eq(userPasskeys.id, passkey.id));
 
-  await getRedis()?.del(`mfa:pending:${tempToken}`);
+  // Single-use: consume the pending token. `redis` is guarded non-null above,
+  // so this can't silently no-op the way `getRedis()?.del(...)` would.
+  await redis.del(`mfa:pending:${tempToken}`);
 
   const context = await resolveCurrentUserTokenContext(user.id);
   const familyId = await mintRefreshTokenFamily(user.id);
@@ -342,12 +383,13 @@ passkeyRoutes.patch('/passkeys/:id', authMiddleware, zValidator('json', renamePa
     return c.json({ error: 'Passkey not found' }, 404);
   }
 
-  await db
+  const [updated] = await db
     .update(userPasskeys)
     .set({ name, updatedAt: new Date() })
-    .where(eq(userPasskeys.id, id));
+    .where(eq(userPasskeys.id, id))
+    .returning();
 
-  return c.json({ success: true, passkey: { ...toPublicPasskey(passkey), name } });
+  return c.json({ success: true, passkey: toPublicPasskey(updated ?? passkey) });
 });
 
 passkeyRoutes.delete('/passkeys/:id', authMiddleware, zValidator('json', deletePasskeySchema), async (c) => {
@@ -466,7 +508,13 @@ async function getMfaFactorState(auth: AuthContext): Promise<{
   currentMfaMethod: 'totp' | 'sms' | 'passkey' | null;
   mfaRequired: boolean;
 }> {
-  const [state] = await withSystemDbAccessContext(async () =>
+  // This runs inside the DELETE handler's request (user-scoped) context, where
+  // a bare `withSystemDbAccessContext` would be a no-op. Escape the active
+  // context first so the roles / partner_users / organization_users /
+  // organizations reads that decide `mfaRequired` actually run under system
+  // scope — otherwise user-scoped RLS could hide a force_mfa role/org-setting
+  // row, under-count factors, and let the last MFA factor be removed.
+  const [state] = await runOutsideDbContext(() => withSystemDbAccessContext(async () =>
     db
       .select({
         passkeyCount: sql<number>`(
@@ -498,7 +546,7 @@ async function getMfaFactorState(auth: AuthContext): Promise<{
       .from(users)
       .where(eq(users.id, auth.user.id))
       .limit(1)
-  );
+  ));
 
   return {
     passkeyCount: Number(state?.passkeyCount ?? 0),

--- a/apps/api/src/routes/auth/passkeys.ts
+++ b/apps/api/src/routes/auth/passkeys.ts
@@ -218,9 +218,17 @@ passkeyRoutes.post('/mfa/passkey/options', zValidator('json', passkeyMfaOptionsS
     return c.json({ error: 'Passkey MFA is not configured for this session' }, 400);
   }
 
-  // Throttle the unauthenticated MFA-continuation surface, mirroring the TOTP
-  // path in mfa.ts so challenge issuance can't be hammered.
-  const rateCheck = await rateLimiter(getRedis(), `mfa:${pending.userId}`, mfaLimiter.limit, mfaLimiter.windowSeconds);
+  // Throttle challenge issuance so it can't be hammered, but on a SEPARATE
+  // bucket from /verify. A legitimate retry issues one /options + one /verify;
+  // sharing the bucket would let challenge issuance consume the verify
+  // brute-force budget and 429 a user after ~2 attempts. Keep this bucket
+  // generous (issuing a challenge verifies no secret).
+  const rateCheck = await rateLimiter(
+    getRedis(),
+    `mfa:passkey-options:${pending.userId}`,
+    mfaLimiter.limit * 4,
+    mfaLimiter.windowSeconds
+  );
   if (!rateCheck.allowed) {
     return c.json({ error: 'Too many MFA attempts' }, 429);
   }

--- a/apps/api/src/services/index.ts
+++ b/apps/api/src/services/index.ts
@@ -1,6 +1,7 @@
 export * from './password';
 export * from './jwt';
 export * from './mfa';
+export * from './passkeys';
 export * from './session';
 export * from './rate-limit';
 export * from './redis';

--- a/apps/api/src/services/passkeys.test.ts
+++ b/apps/api/src/services/passkeys.test.ts
@@ -1,0 +1,325 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { redisMock, webauthnMocks } = vi.hoisted(() => ({
+  redisMock: {
+    getdel: vi.fn(),
+    setex: vi.fn(),
+  },
+  webauthnMocks: {
+    generateRegistrationOptions: vi.fn(),
+    generateAuthenticationOptions: vi.fn(),
+    verifyRegistrationResponse: vi.fn(),
+    verifyAuthenticationResponse: vi.fn(),
+  },
+}));
+
+vi.mock('./redis', () => ({
+  getRedis: vi.fn(() => redisMock),
+}));
+
+vi.mock('@simplewebauthn/server', () => webauthnMocks);
+
+import { getRedis } from './redis';
+import {
+  PasskeyChallengeError,
+  authenticationInfoToPasskeyUpdateFields,
+  generatePasskeyAuthenticationOptions,
+  generatePasskeyRegistrationOptions,
+  passkeyToWebAuthnCredential,
+  registrationInfoToPasskeyFields,
+  resolveWebAuthnConfig,
+  verifyPasskeyAuthentication,
+  verifyPasskeyRegistration,
+  type StoredPasskeyCredential,
+} from './passkeys';
+
+const getRedisMock = vi.mocked(getRedis);
+
+function challengeRecord(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    purpose: 'authentication',
+    userId: 'u1',
+    challenge: 'stored-challenge',
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  });
+}
+
+const fakePasskey: StoredPasskeyCredential = {
+  credentialId: 'cred-1',
+  publicKey: 'AQID', // base64url of [1,2,3]
+  counter: 0,
+  transports: ['internal'],
+};
+
+const savedEnv = { ...process.env };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getRedisMock.mockReturnValue(redisMock as never);
+  redisMock.setex.mockResolvedValue('OK');
+  // Default: env unset so config derives from defaults
+  delete process.env.WEBAUTHN_RP_ID;
+  delete process.env.WEBAUTHN_ORIGIN;
+  delete process.env.WEBAUTHN_RP_NAME;
+  delete process.env.PUBLIC_APP_URL;
+  delete process.env.DASHBOARD_URL;
+});
+
+afterEach(() => {
+  process.env = { ...savedEnv };
+});
+
+describe('consumePasskeyChallenge (via verify fns)', () => {
+  it('passes the stored challenge to @simplewebauthn for authentication', async () => {
+    redisMock.getdel.mockResolvedValue(challengeRecord());
+    webauthnMocks.verifyAuthenticationResponse.mockResolvedValue({ verified: true });
+
+    await verifyPasskeyAuthentication({
+      userId: 'u1',
+      response: { id: 'cred-1' } as never,
+      passkey: fakePasskey,
+    });
+
+    expect(redisMock.getdel).toHaveBeenCalledWith('passkey:challenge:authentication:u1');
+    expect(webauthnMocks.verifyAuthenticationResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ expectedChallenge: 'stored-challenge' })
+    );
+  });
+
+  it('passes the stored challenge to @simplewebauthn for registration', async () => {
+    redisMock.getdel.mockResolvedValue(
+      challengeRecord({ purpose: 'registration', challenge: 'reg-challenge' })
+    );
+    webauthnMocks.verifyRegistrationResponse.mockResolvedValue({ verified: true });
+
+    await verifyPasskeyRegistration({ userId: 'u1', response: {} as never });
+
+    expect(redisMock.getdel).toHaveBeenCalledWith('passkey:challenge:registration:u1');
+    expect(webauthnMocks.verifyRegistrationResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ expectedChallenge: 'reg-challenge' })
+    );
+  });
+
+  it('throws on purpose mismatch (stored registration, requested authentication)', async () => {
+    redisMock.getdel.mockResolvedValue(challengeRecord({ purpose: 'registration' }));
+
+    await expect(
+      verifyPasskeyAuthentication({
+        userId: 'u1',
+        response: {} as never,
+        passkey: fakePasskey,
+      })
+    ).rejects.toThrow(PasskeyChallengeError);
+    await expect(
+      verifyPasskeyAuthentication({
+        userId: 'u1',
+        response: {} as never,
+        passkey: fakePasskey,
+      })
+    ).rejects.toThrow(/mismatched challenge record/);
+    expect(webauthnMocks.verifyAuthenticationResponse).not.toHaveBeenCalled();
+  });
+
+  it('throws on userId mismatch (stored u2, requested u1)', async () => {
+    redisMock.getdel.mockResolvedValue(challengeRecord({ userId: 'u2' }));
+
+    await expect(
+      verifyPasskeyAuthentication({
+        userId: 'u1',
+        response: {} as never,
+        passkey: fakePasskey,
+      })
+    ).rejects.toThrow(/mismatched challenge record/);
+  });
+
+  it('throws missing-or-expired when getdel returns null', async () => {
+    redisMock.getdel.mockResolvedValue(null);
+
+    await expect(
+      verifyPasskeyAuthentication({
+        userId: 'u1',
+        response: {} as never,
+        passkey: fakePasskey,
+      })
+    ).rejects.toThrow('Passkey challenge is missing or expired');
+  });
+
+  it('wraps a corrupt (non-JSON) record as PasskeyChallengeError', async () => {
+    redisMock.getdel.mockResolvedValue('not-json{');
+
+    const err = await verifyPasskeyAuthentication({
+      userId: 'u1',
+      response: {} as never,
+      passkey: fakePasskey,
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(PasskeyChallengeError);
+    expect(err.message).toMatch(/Invalid passkey challenge record/);
+  });
+
+  it('throws "reading" error when redis unavailable on consume path', async () => {
+    getRedisMock.mockReturnValue(null as never);
+
+    await expect(
+      verifyPasskeyAuthentication({
+        userId: 'u1',
+        response: {} as never,
+        passkey: fakePasskey,
+      })
+    ).rejects.toThrow('Redis unavailable while reading passkey challenge');
+  });
+});
+
+describe('storePasskeyChallenge (via generate fns)', () => {
+  it('throws "storing" error when redis unavailable (registration)', async () => {
+    getRedisMock.mockReturnValue(null as never);
+    webauthnMocks.generateRegistrationOptions.mockResolvedValue({ challenge: 'c' });
+
+    await expect(
+      generatePasskeyRegistrationOptions({
+        user: { id: 'u1', email: 'a@b.co' },
+      })
+    ).rejects.toThrow('Redis unavailable while storing passkey challenge');
+  });
+
+  it('throws "storing" error when redis unavailable (authentication)', async () => {
+    getRedisMock.mockReturnValue(null as never);
+    webauthnMocks.generateAuthenticationOptions.mockResolvedValue({ challenge: 'c' });
+
+    await expect(
+      generatePasskeyAuthenticationOptions({ userId: 'u1' })
+    ).rejects.toThrow('Redis unavailable while storing passkey challenge');
+  });
+
+  it('stores the generated challenge with setex on success', async () => {
+    webauthnMocks.generateAuthenticationOptions.mockResolvedValue({ challenge: 'gen-c' });
+
+    await generatePasskeyAuthenticationOptions({ userId: 'u1' });
+
+    expect(redisMock.setex).toHaveBeenCalledWith(
+      'passkey:challenge:authentication:u1',
+      expect.any(Number),
+      expect.stringContaining('"challenge":"gen-c"')
+    );
+  });
+});
+
+describe('user-verification is required (no silent downgrade)', () => {
+  it('generateRegistrationOptions requests userVerification: required', async () => {
+    webauthnMocks.generateRegistrationOptions.mockResolvedValue({ challenge: 'c' });
+
+    await generatePasskeyRegistrationOptions({ user: { id: 'u1', email: 'a@b.co' } });
+
+    expect(webauthnMocks.generateRegistrationOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authenticatorSelection: expect.objectContaining({ userVerification: 'required' }),
+      })
+    );
+  });
+
+  it('generateAuthenticationOptions requests userVerification: required', async () => {
+    webauthnMocks.generateAuthenticationOptions.mockResolvedValue({ challenge: 'c' });
+
+    await generatePasskeyAuthenticationOptions({ userId: 'u1' });
+
+    expect(webauthnMocks.generateAuthenticationOptions).toHaveBeenCalledWith(
+      expect.objectContaining({ userVerification: 'required' })
+    );
+  });
+
+  it('verifyRegistration requires user verification', async () => {
+    redisMock.getdel.mockResolvedValue(challengeRecord({ purpose: 'registration' }));
+    webauthnMocks.verifyRegistrationResponse.mockResolvedValue({ verified: true });
+
+    await verifyPasskeyRegistration({ userId: 'u1', response: {} as never });
+
+    expect(webauthnMocks.verifyRegistrationResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ requireUserVerification: true })
+    );
+  });
+
+  it('verifyAuthentication requires user verification', async () => {
+    redisMock.getdel.mockResolvedValue(challengeRecord());
+    webauthnMocks.verifyAuthenticationResponse.mockResolvedValue({ verified: true });
+
+    await verifyPasskeyAuthentication({
+      userId: 'u1',
+      response: {} as never,
+      passkey: fakePasskey,
+    });
+
+    expect(webauthnMocks.verifyAuthenticationResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requireUserVerification: true,
+        advancedFIDOConfig: expect.objectContaining({ userVerification: 'required' }),
+      })
+    );
+  });
+});
+
+describe('public key base64url round-trip', () => {
+  it('survives registrationInfoToPasskeyFields -> passkeyToWebAuthnCredential', () => {
+    const knownBytes = new Uint8Array([0, 1, 2, 250, 251, 252, 253, 254, 255]);
+
+    const fields = registrationInfoToPasskeyFields({
+      verified: true,
+      registrationInfo: {
+        credential: {
+          id: 'cred-x',
+          publicKey: knownBytes,
+          counter: 7,
+        },
+        credentialDeviceType: 'singleDevice',
+        credentialBackedUp: false,
+        aaguid: 'aaguid-1',
+      },
+    } as never);
+
+    const credential = passkeyToWebAuthnCredential({
+      credentialId: fields.credentialId,
+      publicKey: fields.publicKey,
+      counter: fields.counter,
+      transports: null,
+    });
+
+    expect(Array.from(credential.publicKey)).toEqual(Array.from(knownBytes));
+  });
+});
+
+describe('unverified responses are rejected', () => {
+  it('registrationInfoToPasskeyFields throws when verified: false', () => {
+    expect(() => registrationInfoToPasskeyFields({ verified: false } as never)).toThrow(
+      /unverified registration response/
+    );
+  });
+
+  it('authenticationInfoToPasskeyUpdateFields throws when verified: false', () => {
+    expect(() =>
+      authenticationInfoToPasskeyUpdateFields({ verified: false } as never)
+    ).toThrow(/unverified authentication response/);
+  });
+});
+
+describe('resolveWebAuthnConfig', () => {
+  it('derives rpID from the origin hostname by default', () => {
+    process.env.WEBAUTHN_ORIGIN = 'https://app.example.com';
+    const config = resolveWebAuthnConfig();
+    expect(config.origin).toBe('https://app.example.com');
+    expect(config.rpID).toBe('app.example.com');
+  });
+
+  it('honors WEBAUTHN_RP_ID override', () => {
+    process.env.WEBAUTHN_ORIGIN = 'https://app.example.com';
+    process.env.WEBAUTHN_RP_ID = 'example.com';
+    const config = resolveWebAuthnConfig();
+    expect(config.rpID).toBe('example.com');
+  });
+
+  it('trims trailing slashes from the origin', () => {
+    process.env.WEBAUTHN_ORIGIN = 'https://app.example.com///';
+    const config = resolveWebAuthnConfig();
+    expect(config.origin).toBe('https://app.example.com');
+    expect(config.rpID).toBe('app.example.com');
+  });
+});

--- a/apps/api/src/services/passkeys.ts
+++ b/apps/api/src/services/passkeys.ts
@@ -1,0 +1,289 @@
+import {
+  generateAuthenticationOptions,
+  generateRegistrationOptions,
+  verifyAuthenticationResponse,
+  verifyRegistrationResponse,
+  type GenerateAuthenticationOptionsOpts,
+  type GenerateRegistrationOptionsOpts,
+  type VerifyAuthenticationResponseOpts,
+  type VerifyRegistrationResponseOpts
+} from '@simplewebauthn/server';
+import { getRedis } from './redis';
+
+const DEFAULT_RP_NAME = 'Breeze RMM';
+const DEFAULT_DEV_ORIGIN = 'http://localhost:4321';
+const CHALLENGE_TTL_SECONDS = 5 * 60;
+
+export type PasskeyPurpose = 'registration' | 'authentication';
+export type PasskeyTransport = 'ble' | 'cable' | 'hybrid' | 'internal' | 'nfc' | 'smart-card' | 'usb';
+export type PasskeyDeviceType = 'singleDevice' | 'multiDevice';
+
+export type WebAuthnConfig = {
+  rpID: string;
+  rpName: string;
+  origin: string;
+};
+
+export type PasskeyUser = {
+  id: string;
+  email: string;
+  name?: string | null;
+};
+
+export type StoredPasskeyCredential = {
+  credentialId: string;
+  publicKey: string;
+  counter: number;
+  transports?: PasskeyTransport[] | null;
+};
+
+export type PasskeyRegistrationStoreFields = {
+  credentialId: string;
+  publicKey: string;
+  counter: number;
+  deviceType: PasskeyDeviceType;
+  backedUp: boolean;
+  transports: PasskeyTransport[] | null;
+  aaguid: string | null;
+};
+
+export type PasskeyAuthenticationUpdateFields = {
+  counter: number;
+  deviceType: PasskeyDeviceType;
+  backedUp: boolean;
+  lastUsedAt: Date;
+};
+
+type ChallengeRecord = {
+  purpose: PasskeyPurpose;
+  userId: string;
+  challenge: string;
+  createdAt: string;
+};
+
+export class PasskeyChallengeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PasskeyChallengeError';
+  }
+}
+
+export function resolveWebAuthnConfig(): WebAuthnConfig {
+  const origin = trimTrailingSlash(
+    envString('WEBAUTHN_ORIGIN')
+      || envString('PUBLIC_APP_URL')
+      || envString('DASHBOARD_URL')
+      || DEFAULT_DEV_ORIGIN
+  );
+
+  return {
+    rpID: envString('WEBAUTHN_RP_ID') || new URL(origin).hostname,
+    rpName: envString('WEBAUTHN_RP_NAME') || DEFAULT_RP_NAME,
+    origin
+  };
+}
+
+export async function generatePasskeyRegistrationOptions(input: {
+  user: PasskeyUser;
+  existingPasskeys?: StoredPasskeyCredential[];
+  timeout?: number;
+}): Promise<Awaited<ReturnType<typeof generateRegistrationOptions>>> {
+  const config = resolveWebAuthnConfig();
+  const options = await generateRegistrationOptions({
+    rpName: config.rpName,
+    rpID: config.rpID,
+    userID: Buffer.from(input.user.id),
+    userName: input.user.email,
+    userDisplayName: input.user.name || input.user.email,
+    timeout: input.timeout,
+    attestationType: 'none',
+    excludeCredentials: (input.existingPasskeys ?? []).map((passkey) => ({
+      id: passkey.credentialId,
+      transports: passkey.transports ?? undefined
+    })),
+    authenticatorSelection: {
+      residentKey: 'preferred',
+      userVerification: 'required'
+    }
+  } satisfies GenerateRegistrationOptionsOpts);
+
+  await storePasskeyChallenge('registration', input.user.id, options.challenge);
+  return options;
+}
+
+export async function verifyPasskeyRegistration(input: {
+  userId: string;
+  response: VerifyRegistrationResponseOpts['response'];
+}): Promise<Awaited<ReturnType<typeof verifyRegistrationResponse>>> {
+  const config = resolveWebAuthnConfig();
+  const challenge = await consumePasskeyChallenge('registration', input.userId);
+
+  return verifyRegistrationResponse({
+    response: input.response,
+    expectedChallenge: challenge,
+    expectedOrigin: config.origin,
+    expectedRPID: config.rpID,
+    requireUserVerification: true
+  });
+}
+
+export function registrationInfoToPasskeyFields(
+  verification: Awaited<ReturnType<typeof verifyRegistrationResponse>>,
+  response?: VerifyRegistrationResponseOpts['response']
+): PasskeyRegistrationStoreFields {
+  if (!verification.verified) {
+    throw new Error('Cannot build passkey fields from an unverified registration response');
+  }
+
+  const info = verification.registrationInfo;
+
+  return {
+    credentialId: info.credential.id,
+    publicKey: encodeBase64Url(info.credential.publicKey),
+    counter: info.credential.counter,
+    deviceType: info.credentialDeviceType,
+    backedUp: info.credentialBackedUp,
+    transports: response?.response.transports ?? null,
+    aaguid: info.aaguid || null
+  };
+}
+
+export async function generatePasskeyAuthenticationOptions(input: {
+  userId: string;
+  passkeys?: StoredPasskeyCredential[];
+  timeout?: number;
+}): Promise<Awaited<ReturnType<typeof generateAuthenticationOptions>>> {
+  const config = resolveWebAuthnConfig();
+  const allowCredentials = input.passkeys?.map((passkey) => ({
+    id: passkey.credentialId,
+    transports: passkey.transports ?? undefined
+  }));
+
+  const options = await generateAuthenticationOptions({
+    rpID: config.rpID,
+    timeout: input.timeout,
+    userVerification: 'required',
+    allowCredentials: allowCredentials && allowCredentials.length > 0 ? allowCredentials : undefined
+  } satisfies GenerateAuthenticationOptionsOpts);
+
+  await storePasskeyChallenge('authentication', input.userId, options.challenge);
+  return options;
+}
+
+export async function verifyPasskeyAuthentication(input: {
+  userId: string;
+  response: VerifyAuthenticationResponseOpts['response'];
+  passkey: StoredPasskeyCredential;
+}): Promise<Awaited<ReturnType<typeof verifyAuthenticationResponse>>> {
+  const config = resolveWebAuthnConfig();
+  const challenge = await consumePasskeyChallenge('authentication', input.userId);
+
+  return verifyAuthenticationResponse({
+    response: input.response,
+    expectedChallenge: challenge,
+    expectedOrigin: config.origin,
+    expectedRPID: config.rpID,
+    credential: passkeyToWebAuthnCredential(input.passkey),
+    requireUserVerification: true,
+    advancedFIDOConfig: {
+      userVerification: 'required'
+    }
+  });
+}
+
+export function authenticationInfoToPasskeyUpdateFields(
+  verification: Awaited<ReturnType<typeof verifyAuthenticationResponse>>
+): PasskeyAuthenticationUpdateFields {
+  if (!verification.verified) {
+    throw new Error('Cannot build passkey update fields from an unverified authentication response');
+  }
+
+  return {
+    counter: verification.authenticationInfo.newCounter,
+    deviceType: verification.authenticationInfo.credentialDeviceType,
+    backedUp: verification.authenticationInfo.credentialBackedUp,
+    lastUsedAt: new Date()
+  };
+}
+
+export function passkeyToWebAuthnCredential(
+  passkey: StoredPasskeyCredential
+): VerifyAuthenticationResponseOpts['credential'] {
+  return {
+    id: passkey.credentialId,
+    publicKey: decodeBase64Url(passkey.publicKey),
+    counter: passkey.counter,
+    transports: passkey.transports ?? undefined
+  };
+}
+
+async function storePasskeyChallenge(
+  purpose: PasskeyPurpose,
+  userId: string,
+  challenge: string
+): Promise<void> {
+  const redis = getRedis();
+  if (!redis) {
+    throw new PasskeyChallengeError('Redis unavailable while storing passkey challenge');
+  }
+
+  const record: ChallengeRecord = {
+    purpose,
+    userId,
+    challenge,
+    createdAt: new Date().toISOString()
+  };
+
+  await redis.setex(passkeyChallengeKey(purpose, userId), CHALLENGE_TTL_SECONDS, JSON.stringify(record));
+}
+
+async function consumePasskeyChallenge(purpose: PasskeyPurpose, userId: string): Promise<string> {
+  const redis = getRedis();
+  if (!redis) {
+    throw new PasskeyChallengeError('Redis unavailable while reading passkey challenge');
+  }
+
+  const key = passkeyChallengeKey(purpose, userId);
+  const raw = await redis.get(key);
+  await redis.del(key);
+
+  if (!raw) {
+    throw new PasskeyChallengeError('Passkey challenge is missing or expired');
+  }
+
+  try {
+    const record = JSON.parse(raw) as ChallengeRecord;
+    if (record.purpose !== purpose || record.userId !== userId || typeof record.challenge !== 'string') {
+      throw new Error('mismatched challenge record');
+    }
+    return record.challenge;
+  } catch (err) {
+    throw new PasskeyChallengeError(
+      `Invalid passkey challenge record: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
+
+function passkeyChallengeKey(purpose: PasskeyPurpose, userId: string): string {
+  return `passkey:challenge:${purpose}:${userId}`;
+}
+
+function encodeBase64Url(value: Uint8Array): string {
+  return Buffer.from(value).toString('base64url');
+}
+
+function decodeBase64Url(value: string): Uint8Array<ArrayBuffer> {
+  const bytes = Buffer.from(value, 'base64url');
+  const copy = new Uint8Array(new ArrayBuffer(bytes.byteLength));
+  copy.set(bytes);
+  return copy;
+}
+
+function envString(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value || undefined;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '');
+}

--- a/apps/api/src/services/passkeys.ts
+++ b/apps/api/src/services/passkeys.ts
@@ -244,8 +244,9 @@ async function consumePasskeyChallenge(purpose: PasskeyPurpose, userId: string):
   }
 
   const key = passkeyChallengeKey(purpose, userId);
-  const raw = await redis.get(key);
-  await redis.del(key);
+  // Atomic read-and-delete: prevents a TOCTOU race where two concurrent
+  // verifies could both read the same challenge before either deletes it.
+  const raw = await redis.getdel(key);
 
   if (!raw) {
     throw new PasskeyChallengeError('Passkey challenge is missing or expired');

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
     "@monaco-editor/react": "^4.6.0",
     "@novnc/novnc": "1.7.0",
     "@sentry/astro": "^10.56.0",
+    "@simplewebauthn/browser": "^13.3.0",
     "@tanstack/react-query": "^5.101.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",

--- a/apps/web/src/components/auth/LoginPage.passkeys.test.tsx
+++ b/apps/web/src/components/auth/LoginPage.passkeys.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { apiVerifyPasskeyMFAMock } = vi.hoisted(() => ({
+  apiVerifyPasskeyMFAMock: vi.fn(),
+}));
+
+vi.mock('../../stores/auth', () => ({
+  useAuthStore: Object.assign(
+    (selector: (s: { login: ReturnType<typeof vi.fn> }) => unknown) =>
+      selector({ login: vi.fn() }),
+    {},
+  ),
+  apiLogin: vi.fn(),
+  apiVerifyMFA: vi.fn(),
+  apiVerifyPasskeyMFA: apiVerifyPasskeyMFAMock,
+  apiSendSmsMfaCode: vi.fn(),
+  fetchAndApplyPreferences: vi.fn(),
+}));
+
+vi.mock('../../lib/navigation', () => ({
+  navigateTo: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      new Response(JSON.stringify({ cfAccessLogin: { enabled: false } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+});
+
+import LoginPage from './LoginPage';
+import { apiLogin } from '../../stores/auth';
+import { navigateTo } from '../../lib/navigation';
+
+const baseLoginSuccess = {
+  success: true,
+  user: { id: 'u1', email: 'jane@example.com', name: 'Jane', mfaEnabled: true },
+  tokens: { accessToken: 'a', expiresInSeconds: 900 },
+  requiresSetup: false,
+};
+
+async function fillAndSubmit(email = 'jane@example.com', password = 'Sup3rSecure!') {
+  await waitFor(() => screen.getByLabelText(/email/i));
+  fireEvent.change(screen.getByLabelText(/email/i), { target: { value: email } });
+  fireEvent.change(screen.getByLabelText(/password/i), { target: { value: password } });
+  fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+}
+
+describe('LoginPage passkey MFA', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses a passkey assertion instead of the six-digit MFA form when login returns mfaMethod passkey', async () => {
+    vi.mocked(apiLogin).mockResolvedValueOnce({
+      success: true,
+      mfaRequired: true,
+      tempToken: 'temp-passkey',
+      mfaMethod: 'passkey',
+    } as any);
+    apiVerifyPasskeyMFAMock.mockResolvedValueOnce(baseLoginSuccess);
+
+    render(<LoginPage next="/oauth/consent?uid=abc" />);
+
+    await fillAndSubmit();
+
+    expect(await screen.findByText(/Use your passkey/i)).toBeTruthy();
+    expect(screen.queryByTestId('mfa-digit-0')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('mfa-passkey-submit'));
+
+    await waitFor(() => expect(apiVerifyPasskeyMFAMock).toHaveBeenCalled());
+    expect(apiVerifyPasskeyMFAMock).toHaveBeenCalledWith('temp-passkey');
+    expect(navigateTo).toHaveBeenCalledWith('/oauth/consent?uid=abc');
+  });
+});

--- a/apps/web/src/components/auth/LoginPage.test.tsx
+++ b/apps/web/src/components/auth/LoginPage.test.tsx
@@ -9,6 +9,7 @@ vi.mock('../../stores/auth', () => ({
   ),
   apiLogin: vi.fn(),
   apiVerifyMFA: vi.fn(),
+  apiVerifyPasskeyMFA: vi.fn(),
   apiSendSmsMfaCode: vi.fn(),
   fetchAndApplyPreferences: vi.fn(),
 }));

--- a/apps/web/src/components/auth/LoginPage.tsx
+++ b/apps/web/src/components/auth/LoginPage.tsx
@@ -2,7 +2,14 @@ import { useEffect, useState } from 'react';
 import LoginForm from './LoginForm';
 import MFAVerifyForm from './MFAVerifyForm';
 import McpUrlCard from '../shared/McpUrlCard';
-import { useAuthStore, apiLogin, apiVerifyMFA, apiSendSmsMfaCode, fetchAndApplyPreferences } from '../../stores/auth';
+import {
+  useAuthStore,
+  apiLogin,
+  apiVerifyMFA,
+  apiVerifyPasskeyMFA,
+  apiSendSmsMfaCode,
+  fetchAndApplyPreferences
+} from '../../stores/auth';
 import type { MfaMethod } from '../../stores/auth';
 import { navigateTo } from '../../lib/navigation';
 import { getSafeNext } from '../../lib/authNext';
@@ -140,6 +147,30 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
     setLoading(false);
   };
 
+  const handlePasskeyMfaVerify = async () => {
+    if (!tempToken) return;
+
+    setLoading(true);
+    setError(undefined);
+
+    const result = await apiVerifyPasskeyMFA(tempToken);
+
+    if (!result.success) {
+      setError(result.error);
+      setLoading(false);
+      return;
+    }
+
+    if (result.user && result.tokens) {
+      login(result.user, result.tokens);
+      fetchAndApplyPreferences();
+      await navigateTo(result.requiresSetup ? '/setup' : safeNext);
+      return;
+    }
+
+    setLoading(false);
+  };
+
   const handleSendSmsCode = async () => {
     if (!tempToken) return;
 
@@ -172,6 +203,7 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
         </div>
         <MFAVerifyForm
           onSubmit={handleMfaVerify}
+          onPasskeyVerify={handlePasskeyMfaVerify}
           errorMessage={error}
           loading={loading}
           mfaMethod={mfaMethod}

--- a/apps/web/src/components/auth/MFAVerifyForm.tsx
+++ b/apps/web/src/components/auth/MFAVerifyForm.tsx
@@ -6,6 +6,7 @@ const DIGIT_COUNT = 6;
 
 type MFAVerifyFormProps = {
   onSubmit?: (code: string) => void | Promise<void>;
+  onPasskeyVerify?: () => void | Promise<void>;
   errorMessage?: string;
   submitLabel?: string;
   loading?: boolean;
@@ -18,6 +19,7 @@ type MFAVerifyFormProps = {
 
 export default function MFAVerifyForm({
   onSubmit,
+  onPasskeyVerify,
   errorMessage,
   submitLabel = 'Verify',
   loading,
@@ -35,6 +37,7 @@ export default function MFAVerifyForm({
   const isLoading = useMemo(() => loading ?? isSubmitting, [loading, isSubmitting]);
   const code = digits.join('');
   const isSms = mfaMethod === 'sms';
+  const isPasskey = mfaMethod === 'passkey';
 
   // Resend cooldown timer
   useEffect(() => {
@@ -101,6 +104,45 @@ export default function MFAVerifyForm({
     await onSendSmsCode?.();
     setResendCooldown(60);
   };
+
+  const handlePasskeyVerify = async () => {
+    if (isLoading) return;
+    try {
+      setIsSubmitting(true);
+      await onPasskeyVerify?.();
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isPasskey) {
+    return (
+      <div className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-lg font-semibold">Use your passkey</h2>
+          <p className="text-sm text-muted-foreground">
+            Continue with the passkey registered to your account.
+          </p>
+        </div>
+
+        {errorMessage && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {errorMessage}
+          </div>
+        )}
+
+        <button
+          type="button"
+          data-testid="mfa-passkey-submit"
+          onClick={handlePasskeyVerify}
+          disabled={isLoading}
+          className="flex h-11 w-full items-center justify-center rounded-md bg-primary text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isLoading ? 'Verifying...' : submitLabel}
+        </button>
+      </div>
+    );
+  }
 
   return (
     <form

--- a/apps/web/src/components/settings/ProfilePage.passkeys.test.tsx
+++ b/apps/web/src/components/settings/ProfilePage.passkeys.test.tsx
@@ -1,0 +1,138 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { fetchWithAuthMock, createPasskeyCredentialMock } = vi.hoisted(() => ({
+  fetchWithAuthMock: vi.fn(),
+  createPasskeyCredentialMock: vi.fn(),
+}));
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: fetchWithAuthMock,
+  createPasskeyCredential: createPasskeyCredentialMock,
+  useAuthStore: Object.assign(
+    (selector: any) => selector({ updateUser: vi.fn() }),
+    { getState: () => ({ updateUser: vi.fn() }) },
+  ),
+}));
+
+vi.mock('@/lib/avatarBlobCache', () => ({
+  useAvatarBlobUrl: (url: string | null | undefined) => url ?? null,
+}));
+
+import ProfilePage from './ProfilePage';
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+describe('ProfilePage passkey management', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalThis.URL.createObjectURL = vi.fn(() => 'blob:fake');
+    globalThis.URL.revokeObjectURL = vi.fn();
+  });
+
+  it('starts passkey registration with currentPassword and verifies the browser credential', async () => {
+    const registrationOptions = {
+      challenge: 'register-challenge',
+      rp: { name: 'Breeze' },
+      user: { id: 'user-1', name: 'casey@example.com', displayName: 'Casey Admin' },
+      pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+    };
+    const credential = {
+      id: 'credential-1',
+      rawId: 'credential-1',
+      type: 'public-key',
+      response: {
+        attestationObject: 'attestation',
+        clientDataJSON: 'client-data',
+      },
+    };
+    fetchWithAuthMock
+      .mockResolvedValueOnce(makeJsonResponse({ passkeys: [] }))
+      .mockResolvedValueOnce(makeJsonResponse({ options: registrationOptions }))
+      .mockResolvedValueOnce(makeJsonResponse({ passkey: { id: 'credential-1', name: 'MacBook Touch ID' } }))
+      .mockResolvedValueOnce(makeJsonResponse({
+        passkeys: [{ id: 'credential-1', name: 'MacBook Touch ID', lastUsedAt: null }],
+      }));
+    createPasskeyCredentialMock.mockResolvedValueOnce(credential);
+
+    render(
+      <ProfilePage
+        initialUser={{
+          id: 'user-1',
+          name: 'Casey Admin',
+          email: 'casey@example.com',
+          mfaEnabled: true,
+        }}
+      />,
+    );
+
+    await screen.findByText(/No passkeys are registered/i);
+    fireEvent.change(screen.getByLabelText(/Passkey name/i), {
+      target: { value: 'MacBook Touch ID' },
+    });
+    fireEvent.change(screen.getByLabelText(/Current password/i, { selector: '#passkey-password' }), {
+      target: { value: 'current-password' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Add passkey' }));
+
+    await screen.findByText('Passkey added');
+
+    expect(fetchWithAuthMock.mock.calls[1]).toEqual([
+      '/auth/passkeys/register/options',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ currentPassword: 'current-password', name: 'MacBook Touch ID' }),
+      }),
+    ]);
+    expect(createPasskeyCredentialMock).toHaveBeenCalledWith(registrationOptions);
+    expect(fetchWithAuthMock.mock.calls[2]).toEqual([
+      '/auth/passkeys/register/verify',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ name: 'MacBook Touch ID', credential }),
+      }),
+    ]);
+    await waitFor(() => expect(screen.getByText('MacBook Touch ID')).toBeTruthy());
+  });
+
+  it('sends currentPassword when deleting a passkey', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(makeJsonResponse({
+        passkeys: [{ id: 'credential-1', name: 'MacBook Touch ID', lastUsedAt: null }],
+      }))
+      .mockResolvedValueOnce(makeJsonResponse({ success: true }));
+
+    render(
+      <ProfilePage
+        initialUser={{
+          id: 'user-1',
+          name: 'Casey Admin',
+          email: 'casey@example.com',
+          mfaEnabled: true,
+        }}
+      />,
+    );
+
+    await screen.findByText('MacBook Touch ID');
+    fireEvent.change(screen.getByLabelText(/Current password/i, { selector: '#passkey-password' }), {
+      target: { value: 'current-password' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await screen.findByText('Passkey deleted');
+
+    expect(fetchWithAuthMock.mock.calls[1]).toEqual([
+      '/auth/passkeys/credential-1',
+      expect.objectContaining({
+        method: 'DELETE',
+        body: JSON.stringify({ currentPassword: 'current-password' }),
+      }),
+    ]);
+  });
+});

--- a/apps/web/src/components/settings/ProfilePage.test.tsx
+++ b/apps/web/src/components/settings/ProfilePage.test.tsx
@@ -5,6 +5,7 @@ import ProfilePage from './ProfilePage';
 import { fetchWithAuth } from '../../stores/auth';
 
 vi.mock('../../stores/auth', () => ({
+  createPasskeyCredential: vi.fn(),
   fetchWithAuth: vi.fn(),
   useAuthStore: Object.assign(
     (selector: any) => selector({ updateUser: vi.fn() }),
@@ -40,6 +41,12 @@ beforeEach(() => {
 describe('ProfilePage avatar settings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    fetchWithAuthMock.mockImplementation(async (url) => {
+      if (String(url) === '/auth/passkeys') {
+        return makeJsonResponse({ passkeys: [] });
+      }
+      return undefined as unknown as Response;
+    });
   });
 
   it('does NOT render the old Avatar image URL input', () => {
@@ -60,14 +67,20 @@ describe('ProfilePage avatar settings', () => {
   });
 
   it('uploads a PNG file, updates the avatar, and shows success', async () => {
-    fetchWithAuthMock.mockResolvedValueOnce(
-      makeJsonResponse({
-        avatarUrl: '/api/v1/users/user-1/avatar',
-        size: 1234,
-        mime: 'image/png',
-        updatedAt: new Date().toISOString()
-      })
-    );
+    fetchWithAuthMock.mockImplementation(async (url) => {
+      if (String(url) === '/auth/passkeys') {
+        return makeJsonResponse({ passkeys: [] });
+      }
+      if (String(url) === '/users/me/avatar') {
+        return makeJsonResponse({
+          avatarUrl: '/api/v1/users/user-1/avatar',
+          size: 1234,
+          mime: 'image/png',
+          updatedAt: new Date().toISOString()
+        });
+      }
+      return undefined as unknown as Response;
+    });
 
     render(
       <ProfilePage
@@ -125,7 +138,15 @@ describe('ProfilePage avatar settings', () => {
   });
 
   it('deletes the current avatar via the Remove button', async () => {
-    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ avatarUrl: null }));
+    fetchWithAuthMock.mockImplementation(async (url) => {
+      if (String(url) === '/auth/passkeys') {
+        return makeJsonResponse({ passkeys: [] });
+      }
+      if (String(url) === '/users/me/avatar') {
+        return makeJsonResponse({ avatarUrl: null });
+      }
+      return undefined as unknown as Response;
+    });
 
     render(
       <ProfilePage
@@ -160,6 +181,12 @@ describe('ProfilePage avatar settings', () => {
 describe('ProfilePage MFA setup', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    fetchWithAuthMock.mockImplementation(async (url) => {
+      if (String(url) === '/auth/passkeys') {
+        return makeJsonResponse({ passkeys: [] });
+      }
+      return undefined as unknown as Response;
+    });
   });
 
   // Regression guard for the bug fixed in PR #543: server requires
@@ -168,9 +195,15 @@ describe('ProfilePage MFA setup', () => {
   // server/client schema drift was silent — tsc passed, the page rendered,
   // requests just 400'd in production.
   it('sends currentPassword in the body when starting MFA setup', async () => {
-    fetchWithAuthMock.mockResolvedValueOnce(
-      makeJsonResponse({ qrCodeDataUrl: 'data:image/png;base64,abc' })
-    );
+    fetchWithAuthMock.mockImplementation(async (url) => {
+      if (String(url) === '/auth/passkeys') {
+        return makeJsonResponse({ passkeys: [] });
+      }
+      if (String(url) === '/auth/mfa/setup') {
+        return makeJsonResponse({ qrCodeDataUrl: 'data:image/png;base64,abc' });
+      }
+      return undefined as unknown as Response;
+    });
 
     render(
       <ProfilePage

--- a/apps/web/src/components/settings/ProfilePage.tsx
+++ b/apps/web/src/components/settings/ProfilePage.tsx
@@ -4,7 +4,8 @@ import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import ChangePasswordForm from './ChangePasswordForm';
 import MFASettings from './MFASettings';
-import { fetchWithAuth, useAuthStore } from '../../stores/auth';
+import { createPasskeyCredential, fetchWithAuth, useAuthStore } from '../../stores/auth';
+import type { PasskeyRegistrationOptions } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { useAvatarBlobUrl } from '@/lib/avatarBlobCache';
 
@@ -22,6 +23,13 @@ type User = {
   mfaEnabled?: boolean;
 };
 
+type PasskeySummary = {
+  id: string;
+  name: string;
+  createdAt?: string;
+  lastUsedAt?: string | null;
+};
+
 const ALLOWED_AVATAR_MIMES = ['image/png', 'image/jpeg', 'image/webp'];
 const MAX_AVATAR_BYTES = 5 * 1024 * 1024;
 
@@ -29,6 +37,13 @@ function formatBytes(n: number): string {
   if (n < 1024) return `${n} B`;
   if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
   return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatPasskeyDate(value?: string | null): string {
+  if (!value) return 'Never';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Unknown';
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
 }
 
 type ProfilePageProps = {
@@ -47,6 +62,16 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
   const [mfaSuccess, setMfaSuccess] = useState<string | undefined>();
   const [qrCodeDataUrl, setQrCodeDataUrl] = useState<string | undefined>();
   const [recoveryCodes, setRecoveryCodes] = useState<string[] | undefined>();
+  const [passkeys, setPasskeys] = useState<PasskeySummary[]>([]);
+  const [passkeyName, setPasskeyName] = useState('');
+  const [passkeyPassword, setPasskeyPassword] = useState('');
+  const [passkeyError, setPasskeyError] = useState<string | undefined>();
+  const [passkeySuccess, setPasskeySuccess] = useState<string | undefined>();
+  const [isLoadingPasskeys, setIsLoadingPasskeys] = useState(false);
+  const [isAddingPasskey, setIsAddingPasskey] = useState(false);
+  const [editingPasskeyId, setEditingPasskeyId] = useState<string | null>(null);
+  const [editingPasskeyName, setEditingPasskeyName] = useState('');
+  const [mutatingPasskeyId, setMutatingPasskeyId] = useState<string | null>(null);
   const [isUpdatingProfile, setIsUpdatingProfile] = useState(false);
   const [isChangingPassword, setIsChangingPassword] = useState(false);
   const [mfaLoading, setMfaLoading] = useState(false);
@@ -116,6 +141,27 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
 
     fetchUser();
   }, [initialUser, reset]);
+
+  const loadPasskeys = useCallback(async () => {
+    try {
+      setIsLoadingPasskeys(true);
+      const response = await fetchWithAuth('/auth/passkeys');
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.error ?? errorData.message ?? 'Failed to load passkeys');
+      }
+      const data = await response.json();
+      setPasskeys(Array.isArray(data) ? data : data.passkeys ?? []);
+    } catch (error) {
+      setPasskeyError(error instanceof Error ? error.message : 'Failed to load passkeys');
+    } finally {
+      setIsLoadingPasskeys(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadPasskeys();
+  }, [loadPasskeys]);
 
   const clearMessages = useCallback(() => {
     setProfileError(undefined);
@@ -417,6 +463,114 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
     }
   };
 
+  const handleAddPasskey = async () => {
+    if (!passkeyPassword || isAddingPasskey) return;
+    setPasskeyError(undefined);
+    setPasskeySuccess(undefined);
+    try {
+      setIsAddingPasskey(true);
+      const label = passkeyName.trim() || 'Passkey';
+      const optionsResponse = await fetchWithAuth('/auth/passkeys/register/options', {
+        method: 'POST',
+        body: JSON.stringify({ currentPassword: passkeyPassword, name: label })
+      });
+
+      const optionsData = await optionsResponse.json().catch(() => ({}));
+      if (!optionsResponse.ok) {
+        throw new Error(
+          optionsData.error ?? optionsData.message ?? `Failed to start passkey setup (HTTP ${optionsResponse.status})`
+        );
+      }
+
+      const optionsJSON = (optionsData.options ?? optionsData.optionsJSON) as PasskeyRegistrationOptions;
+      const credential = await createPasskeyCredential(optionsJSON);
+      const verifyResponse = await fetchWithAuth('/auth/passkeys/register/verify', {
+        method: 'POST',
+        body: JSON.stringify({ name: label, credential })
+      });
+
+      const verifyData = await verifyResponse.json().catch(() => ({}));
+      if (!verifyResponse.ok) {
+        throw new Error(
+          verifyData.error ?? verifyData.message ?? `Failed to save passkey (HTTP ${verifyResponse.status})`
+        );
+      }
+
+      setUser(prev => (prev ? { ...prev, mfaEnabled: true } : null));
+      setPasskeyName('');
+      setPasskeyPassword('');
+      if (Array.isArray(verifyData.recoveryCodes)) {
+        setRecoveryCodes(verifyData.recoveryCodes);
+      }
+      setPasskeySuccess('Passkey added');
+      await loadPasskeys();
+    } catch (error) {
+      if (error instanceof Error && error.name === 'NotAllowedError') {
+        setPasskeyError('Passkey setup was canceled or timed out');
+      } else {
+        setPasskeyError(error instanceof Error ? error.message : 'Failed to add passkey');
+      }
+    } finally {
+      setIsAddingPasskey(false);
+    }
+  };
+
+  const handleRenamePasskey = async (passkeyId: string) => {
+    const name = editingPasskeyName.trim();
+    if (!name || mutatingPasskeyId) return;
+    setPasskeyError(undefined);
+    setPasskeySuccess(undefined);
+    try {
+      setMutatingPasskeyId(passkeyId);
+      const response = await fetchWithAuth(`/auth/passkeys/${encodeURIComponent(passkeyId)}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ name })
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(data.error ?? data.message ?? `Failed to rename passkey (HTTP ${response.status})`);
+      }
+      setPasskeys(prev => prev.map(passkey => (
+        passkey.id === passkeyId ? { ...passkey, name: data.passkey?.name ?? name } : passkey
+      )));
+      setEditingPasskeyId(null);
+      setEditingPasskeyName('');
+      setPasskeySuccess('Passkey renamed');
+    } catch (error) {
+      setPasskeyError(error instanceof Error ? error.message : 'Failed to rename passkey');
+    } finally {
+      setMutatingPasskeyId(null);
+    }
+  };
+
+  const handleDeletePasskey = async (passkeyId: string) => {
+    if (mutatingPasskeyId) return;
+    setPasskeyError(undefined);
+    setPasskeySuccess(undefined);
+    if (!passkeyPassword) {
+      setPasskeyError('Current password is required to delete a passkey');
+      return;
+    }
+    try {
+      setMutatingPasskeyId(passkeyId);
+      const response = await fetchWithAuth(`/auth/passkeys/${encodeURIComponent(passkeyId)}`, {
+        method: 'DELETE',
+        body: JSON.stringify({ currentPassword: passkeyPassword })
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(data.error ?? data.message ?? `Failed to delete passkey (HTTP ${response.status})`);
+      }
+      setPasskeys(prev => prev.filter(passkey => passkey.id !== passkeyId));
+      setPasskeyPassword('');
+      setPasskeySuccess('Passkey deleted');
+    } catch (error) {
+      setPasskeyError(error instanceof Error ? error.message : 'Failed to delete passkey');
+    } finally {
+      setMutatingPasskeyId(null);
+    }
+  };
+
   if (isLoadingUser) {
     return (
       <div className="flex min-h-[400px] items-center justify-center">
@@ -607,6 +761,157 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
         successMessage={mfaSuccess}
         loading={mfaLoading}
       />
+
+      {/* Passkeys */}
+      <div className="space-y-6 rounded-lg border bg-card p-6 shadow-sm">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold">Passkeys</h2>
+          <p className="text-sm text-muted-foreground">
+            Manage passkeys that can be used as multi-factor authentication for your account.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          {isLoadingPasskeys ? (
+            <div className="rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
+              Loading passkeys...
+            </div>
+          ) : passkeys.length ? (
+            passkeys.map(passkey => (
+              <div key={passkey.id} className="rounded-md border bg-muted/30 p-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div className="min-w-0 space-y-1">
+                    {editingPasskeyId === passkey.id ? (
+                      <input
+                        type="text"
+                        value={editingPasskeyName}
+                        onChange={event => setEditingPasskeyName(event.target.value)}
+                        className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+                        disabled={mutatingPasskeyId === passkey.id}
+                        autoFocus
+                      />
+                    ) : (
+                      <p className="truncate text-sm font-medium">{passkey.name || 'Passkey'}</p>
+                    )}
+                    <p className="text-xs text-muted-foreground">
+                      Last used: {formatPasskeyDate(passkey.lastUsedAt)}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {editingPasskeyId === passkey.id ? (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() => handleRenamePasskey(passkey.id)}
+                          disabled={!editingPasskeyName.trim() || mutatingPasskeyId === passkey.id}
+                          className="h-9 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          {mutatingPasskeyId === passkey.id ? 'Saving...' : 'Save'}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setEditingPasskeyId(null);
+                            setEditingPasskeyName('');
+                          }}
+                          disabled={mutatingPasskeyId === passkey.id}
+                          className="h-9 rounded-md border px-3 text-sm font-medium text-muted-foreground transition hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          Cancel
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setEditingPasskeyId(passkey.id);
+                            setEditingPasskeyName(passkey.name || 'Passkey');
+                            setPasskeyError(undefined);
+                            setPasskeySuccess(undefined);
+                          }}
+                          disabled={!!mutatingPasskeyId}
+                          className="h-9 rounded-md border px-3 text-sm font-medium text-muted-foreground transition hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          Rename
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDeletePasskey(passkey.id)}
+                          disabled={!!mutatingPasskeyId}
+                          className="h-9 rounded-md border border-destructive/40 px-3 text-sm font-medium text-destructive transition hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          {mutatingPasskeyId === passkey.id ? 'Deleting...' : 'Delete'}
+                        </button>
+                      </>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
+              No passkeys are registered for this account.
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-4 rounded-md border p-4">
+          <div className="space-y-1">
+            <h3 className="text-sm font-medium">Add passkey</h3>
+            <p className="text-xs text-muted-foreground">
+              Re-enter your account password before adding or deleting a passkey.
+            </p>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="passkey-name">
+              Passkey name
+            </label>
+            <input
+              id="passkey-name"
+              type="text"
+              value={passkeyName}
+              onChange={event => setPasskeyName(event.target.value)}
+              placeholder="MacBook Touch ID"
+              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              disabled={isAddingPasskey}
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="passkey-password">
+              Current password
+            </label>
+            <input
+              id="passkey-password"
+              type="password"
+              autoComplete="current-password"
+              value={passkeyPassword}
+              onChange={event => setPasskeyPassword(event.target.value)}
+              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              disabled={isAddingPasskey}
+            />
+          </div>
+          <button
+            type="button"
+            onClick={handleAddPasskey}
+            disabled={isAddingPasskey || !passkeyPassword}
+            className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isAddingPasskey ? 'Adding...' : 'Add passkey'}
+          </button>
+        </div>
+
+        {passkeySuccess && (
+          <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-600">
+            {passkeySuccess}
+          </div>
+        )}
+        {passkeyError && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {passkeyError}
+          </div>
+        )}
+      </div>
 
       {/* Onboarding */}
       <div className="rounded-lg border bg-card p-6 shadow-sm">

--- a/apps/web/src/stores/auth.passkeys.test.ts
+++ b/apps/web/src/stores/auth.passkeys.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Tokens, User } from './auth';
+
+const { webauthnMocks } = vi.hoisted(() => ({
+  webauthnMocks: {
+    startAuthentication: vi.fn(),
+    startRegistration: vi.fn(),
+  },
+}));
+
+vi.mock('@simplewebauthn/browser', () => ({
+  startAuthentication: webauthnMocks.startAuthentication,
+  startRegistration: webauthnMocks.startRegistration,
+}));
+
+import { apiLogin, apiVerifyPasskeyMFA, useAuthStore } from './auth';
+
+const makeResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+const baseUser: User = {
+  id: 'user-1',
+  email: 'user@example.com',
+  name: 'User One',
+  mfaEnabled: true,
+};
+
+const baseTokens: Tokens = {
+  accessToken: 'access-passkey',
+  expiresInSeconds: 3600,
+};
+
+describe('auth store passkey MFA helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.removeItem('breeze-auth');
+    useAuthStore.setState({
+      user: null,
+      tokens: null,
+      isAuthenticated: false,
+      isLoading: false,
+      mfaPending: false,
+      mfaTempToken: null,
+    });
+  });
+
+  it('apiLogin preserves the passkey MFA method so the login page can branch to WebAuthn', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      makeResponse({
+        mfaRequired: true,
+        tempToken: 'temp-passkey',
+        mfaMethod: 'passkey',
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await apiLogin('user@example.com', 'password');
+
+    expect(result).toEqual({
+      success: true,
+      mfaRequired: true,
+      tempToken: 'temp-passkey',
+      mfaMethod: 'passkey',
+      phoneLast4: undefined,
+    });
+  });
+
+  it('apiVerifyPasskeyMFA fetches options, posts the assertion, and returns MFA-satisfied session data', async () => {
+    const credential = {
+      id: 'credential-1',
+      rawId: 'credential-1',
+      type: 'public-key',
+      response: {
+        authenticatorData: 'auth-data',
+        clientDataJSON: 'client-data',
+        signature: 'signature',
+      },
+    };
+    webauthnMocks.startAuthentication.mockResolvedValueOnce(credential);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse({
+        options: {
+          challenge: 'challenge-b64url',
+          allowCredentials: [{ id: 'credential-1', type: 'public-key' }],
+        },
+      }))
+      .mockResolvedValueOnce(makeResponse({
+        user: baseUser,
+        tokens: baseTokens,
+        requiresSetup: false,
+      }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await apiVerifyPasskeyMFA('temp-passkey');
+
+    expect(result).toEqual({
+      success: true,
+      user: { ...baseUser, requiresSetup: false },
+      tokens: baseTokens,
+      requiresSetup: false,
+    });
+    expect(webauthnMocks.startAuthentication).toHaveBeenCalledWith({
+      optionsJSON: {
+        challenge: 'challenge-b64url',
+        allowCredentials: [{ id: 'credential-1', type: 'public-key' }],
+      },
+    });
+    expect(fetchMock.mock.calls[0]).toEqual([
+      '/api/v1/auth/mfa/passkey/options',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        body: JSON.stringify({ tempToken: 'temp-passkey' }),
+      }),
+    ]);
+    expect(fetchMock.mock.calls[1]).toEqual([
+      '/api/v1/auth/mfa/passkey/verify',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        body: JSON.stringify({ tempToken: 'temp-passkey', credential }),
+      }),
+    ]);
+  });
+});

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -1,5 +1,13 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import {
+  startAuthentication,
+  startRegistration,
+  type AuthenticationResponseJSON,
+  type PublicKeyCredentialCreationOptionsJSON,
+  type PublicKeyCredentialRequestOptionsJSON,
+  type RegistrationResponseJSON
+} from '@simplewebauthn/browser';
 import { extractApiError } from '@/lib/apiError';
 
 export interface UserPreferences {
@@ -503,7 +511,32 @@ export async function fetchWithAuth(rawUrl: string, options: RequestInit = {}): 
   return response;
 }
 
-export type MfaMethod = 'totp' | 'sms';
+export type MfaMethod = 'totp' | 'sms' | 'passkey';
+
+type ApiAuthSuccess = {
+  success: boolean;
+  user?: User;
+  tokens?: Tokens;
+  requiresSetup?: boolean;
+  error?: string;
+};
+
+export type PasskeyRegistrationOptions = PublicKeyCredentialCreationOptionsJSON;
+export type PasskeyAuthenticationOptions = PublicKeyCredentialRequestOptionsJSON;
+export type PasskeyRegistrationResponse = RegistrationResponseJSON;
+export type PasskeyAuthenticationResponse = AuthenticationResponseJSON;
+
+export async function createPasskeyCredential(
+  optionsJSON: PasskeyRegistrationOptions
+): Promise<PasskeyRegistrationResponse> {
+  return startRegistration({ optionsJSON });
+}
+
+export async function getPasskeyCredential(
+  optionsJSON: PasskeyAuthenticationOptions
+): Promise<PasskeyAuthenticationResponse> {
+  return startAuthentication({ optionsJSON });
+}
 
 export async function apiLogin(email: string, password: string): Promise<{
   success: boolean;
@@ -553,13 +586,7 @@ export async function apiLogin(email: string, password: string): Promise<{
   }
 }
 
-export async function apiVerifyMFA(code: string, tempToken: string, method?: MfaMethod): Promise<{
-  success: boolean;
-  user?: User;
-  tokens?: Tokens;
-  requiresSetup?: boolean;
-  error?: string;
-}> {
+export async function apiVerifyMFA(code: string, tempToken: string, method?: MfaMethod): Promise<ApiAuthSuccess> {
   try {
     const response = await fetch(buildApiUrl('/auth/mfa/verify'), {
       method: 'POST',
@@ -583,6 +610,55 @@ export async function apiVerifyMFA(code: string, tempToken: string, method?: Mfa
       requiresSetup: !!data.requiresSetup
     };
   } catch {
+    return { success: false, error: 'Network error' };
+  }
+}
+
+export async function apiVerifyPasskeyMFA(tempToken: string): Promise<ApiAuthSuccess> {
+  try {
+    const optionsResponse = await fetch(buildApiUrl('/auth/mfa/passkey/options'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ tempToken })
+    });
+
+    const optionsData = await optionsResponse.json();
+
+    if (!optionsResponse.ok) {
+      return { success: false, error: extractApiError(optionsData, 'Failed to start passkey verification') };
+    }
+
+    const optionsJSON = optionsData.options ?? optionsData.optionsJSON;
+    const credential = await getPasskeyCredential(optionsJSON);
+
+    const verifyResponse = await fetch(buildApiUrl('/auth/mfa/passkey/verify'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ tempToken, credential })
+    });
+
+    const verifyData = await verifyResponse.json();
+
+    if (!verifyResponse.ok) {
+      return { success: false, error: extractApiError(verifyData, 'Passkey verification failed') };
+    }
+
+    const user = verifyData.user
+      ? { ...verifyData.user, requiresSetup: !!verifyData.requiresSetup }
+      : verifyData.user;
+
+    return {
+      success: true,
+      user,
+      tokens: verifyData.tokens,
+      requiresSetup: !!verifyData.requiresSetup
+    };
+  } catch (error) {
+    if (error instanceof Error && error.name === 'NotAllowedError') {
+      return { success: false, error: 'Passkey verification was canceled or timed out' };
+    }
     return { success: false, error: 'Network error' };
   }
 }

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -659,6 +659,7 @@ export async function apiVerifyPasskeyMFA(tempToken: string): Promise<ApiAuthSuc
     if (error instanceof Error && error.name === 'NotAllowedError') {
       return { success: false, error: 'Passkey verification was canceled or timed out' };
     }
+    console.warn('[apiVerifyPasskeyMFA] passkey MFA verification failed:', error);
     return { success: false, error: 'Network error' };
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@sentry/node':
         specifier: ^10.54.0
         version: 10.54.0
+      '@simplewebauthn/server':
+        specifier: ^13.3.1
+        version: 13.3.1
       '@types/qrcode':
         specifier: ^1.5.6
         version: 1.5.6
@@ -524,6 +527,9 @@ importers:
       '@sentry/astro':
         specifier: ^10.56.0
         version: 10.56.0(astro@6.4.5(@types/node@25.9.2)(ioredis@5.10.1)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.61.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(rollup@4.61.1)
+      '@simplewebauthn/browser':
+        specifier: ^13.3.0
+        version: 13.3.0
       '@tanstack/react-query':
         specifier: ^5.101.0
         version: 5.101.0(react@19.2.7)
@@ -2321,6 +2327,9 @@ packages:
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
 
+  '@hexagon/base64@1.1.28':
+    resolution: {integrity: sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==}
+
   '@hono/node-server@2.0.4':
     resolution: {integrity: sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==}
     engines: {node: '>=20'}
@@ -2569,6 +2578,9 @@ packages:
     peerDependencies:
       koa: ^2.0.0 || ^3.0.0
 
+  '@levischuck/tiny-cbor@0.2.11':
+    resolution: {integrity: sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==}
+
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
@@ -2750,6 +2762,46 @@ packages:
     resolution: {integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==}
     cpu: [x64]
     os: [win32]
+
+  '@peculiar/asn1-android@2.8.0':
+    resolution: {integrity: sha512-skLbS+IOGv1lUgDqtChr8xvtvEr3HMse/JGBaL2r1J1o/n7a8wqOrovMtlRq/UXLhxvmLaONP67hwtshgzwfzA==}
+
+  '@peculiar/asn1-cms@2.8.0':
+    resolution: {integrity: sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==}
+
+  '@peculiar/asn1-csr@2.8.0':
+    resolution: {integrity: sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==}
+
+  '@peculiar/asn1-ecc@2.8.0':
+    resolution: {integrity: sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==}
+
+  '@peculiar/asn1-pfx@2.8.0':
+    resolution: {integrity: sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==}
+
+  '@peculiar/asn1-pkcs8@2.8.0':
+    resolution: {integrity: sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==}
+
+  '@peculiar/asn1-pkcs9@2.8.0':
+    resolution: {integrity: sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==}
+
+  '@peculiar/asn1-rsa@2.8.0':
+    resolution: {integrity: sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==}
+
+  '@peculiar/asn1-schema@2.8.0':
+    resolution: {integrity: sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==}
+
+  '@peculiar/asn1-x509-attr@2.8.0':
+    resolution: {integrity: sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==}
+
+  '@peculiar/asn1-x509@2.8.0':
+    resolution: {integrity: sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==}
+
+  '@peculiar/utils@2.0.3':
+    resolution: {integrity: sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==}
+
+  '@peculiar/x509@1.14.3':
+    resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
+    engines: {node: '>=20.0.0'}
 
   '@petamoriken/float16@3.9.3':
     resolution: {integrity: sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==}
@@ -3723,6 +3775,13 @@ packages:
   '@sideway/pinpoint@2.0.0':
     resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
 
+  '@simplewebauthn/browser@13.3.0':
+    resolution: {integrity: sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==}
+
+  '@simplewebauthn/server@13.3.1':
+    resolution: {integrity: sha512-GV/oM/qeycWn8p42JZIMJBsXWQcNFg+nJFzeQTnMA4gN8mXg0+HZFWJerHg8ZN/zlveMS3iV1wzuFpOVWS/46w==}
+    engines: {node: '>=20.0.0'}
+
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
@@ -4589,6 +4648,10 @@ packages:
 
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
+  asn1js@3.0.10:
+    resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
+    engines: {node: '>=12.0.0'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -8052,6 +8115,13 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  pvtsutils@1.3.6:
+    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
+
+  pvutils@1.1.5:
+    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
+    engines: {node: '>=16.0.0'}
+
   qrcode@1.5.4:
     resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
     engines: {node: '>=10.13.0'}
@@ -8314,6 +8384,9 @@ packages:
 
   redux@5.0.1:
     resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
   regenerate-unicode-properties@10.2.2:
     resolution: {integrity: sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==}
@@ -8980,6 +9053,9 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -9010,6 +9086,10 @@ packages:
     resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tsyringe@4.10.0:
+    resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
+    engines: {node: '>= 6.0.0'}
 
   turbo@2.9.17:
     resolution: {integrity: sha512-91Q3KxfHJn7esFu2Ic6j9pkvQqWjncQCOp7r1gCKChRSb/+T/yIjsavAmbGLmFRKAzSjmWW/FMrcknmJ4hEOPA==}
@@ -11678,6 +11758,8 @@ snapshots:
       '@hapi/hoek': 9.3.0
     optional: true
 
+  '@hexagon/base64@1.1.28': {}
+
   '@hono/node-server@2.0.4(hono@4.12.25)':
     dependencies:
       hono: 4.12.25
@@ -11880,6 +11962,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@levischuck/tiny-cbor@0.2.11': {}
+
   '@mdx-js/mdx@3.1.1':
     dependencies:
       '@types/estree': 1.0.9
@@ -12062,6 +12146,106 @@ snapshots:
 
   '@pagefind/windows-x64@1.5.2':
     optional: true
+
+  '@peculiar/asn1-android@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-cms@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      '@peculiar/asn1-x509-attr': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-csr@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-ecc@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pfx@2.8.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-pkcs8': 2.8.0
+      '@peculiar/asn1-rsa': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs8@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs9@2.8.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-pfx': 2.8.0
+      '@peculiar/asn1-pkcs8': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      '@peculiar/asn1-x509-attr': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-rsa@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-schema@2.8.0':
+    dependencies:
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509-attr@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/utils@2.0.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@peculiar/x509@1.14.3':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-csr': 2.8.0
+      '@peculiar/asn1-ecc': 2.8.0
+      '@peculiar/asn1-pkcs9': 2.8.0
+      '@peculiar/asn1-rsa': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      pvtsutils: 1.3.6
+      reflect-metadata: 0.2.2
+      tslib: 2.8.1
+      tsyringe: 4.10.0
 
   '@petamoriken/float16@3.9.3':
     optional: true
@@ -13093,6 +13277,19 @@ snapshots:
   '@sideway/pinpoint@2.0.0':
     optional: true
 
+  '@simplewebauthn/browser@13.3.0': {}
+
+  '@simplewebauthn/server@13.3.1':
+    dependencies:
+      '@hexagon/base64': 1.1.28
+      '@levischuck/tiny-cbor': 0.2.11
+      '@peculiar/asn1-android': 2.8.0
+      '@peculiar/asn1-ecc': 2.8.0
+      '@peculiar/asn1-rsa': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      '@peculiar/x509': 1.14.3
+
   '@sinclair/typebox@0.27.10': {}
 
   '@smithy/core@3.24.6':
@@ -13866,7 +14063,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.12(@types/node@25.9.2)(esbuild@0.27.2)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.12(@types/node@25.9.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -14119,6 +14316,12 @@ snapshots:
     optional: true
 
   asap@2.0.6: {}
+
+  asn1js@3.0.10:
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
+      tslib: 2.8.1
 
   assertion-error@2.0.1: {}
 
@@ -18379,6 +18582,12 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  pvtsutils@1.3.6:
+    dependencies:
+      tslib: 2.8.1
+
+  pvutils@1.1.5: {}
+
   qrcode@1.5.4:
     dependencies:
       dijkstrajs: 1.0.3
@@ -18736,6 +18945,8 @@ snapshots:
       redux: 5.0.1
 
   redux@5.0.1: {}
+
+  reflect-metadata@0.2.2: {}
 
   regenerate-unicode-properties@10.2.2:
     dependencies:
@@ -19606,6 +19817,8 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  tslib@1.14.1: {}
+
   tslib@2.8.1: {}
 
   tsscmp@1.0.6: {}
@@ -19643,6 +19856,10 @@ snapshots:
       esbuild: 0.28.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  tsyringe@4.10.0:
+    dependencies:
+      tslib: 1.14.1
 
   turbo@2.9.17:
     optionalDependencies:


### PR DESCRIPTION
## Summary

- Add WebAuthn passkey MFA storage, migration, Redis challenge service, and auth routes.
- Wire passkey MFA into password login, existing MFA token minting, CF Access MFA checks, and profile/login UI.
- Add focused API and web regression tests for registration, assertion, challenge handling, and UI states.

## Verification

- `PATH=/Users/toddhebebrand/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH corepack pnpm --filter @breeze/api exec vitest run src/routes/auth.test.ts src/routes/auth.passkeys.test.ts src/middleware/cfAccessLogin.test.ts src/routes/auth/cfAccessRedirectLogin.test.ts`
- `PATH=/Users/toddhebebrand/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH corepack pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json`
- `PATH=/Users/toddhebebrand/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH corepack pnpm --filter @breeze/web exec tsc --noEmit -p tsconfig.json`
- `PATH=/Users/toddhebebrand/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH corepack pnpm --filter @breeze/web exec vitest run src/stores/auth.passkeys.test.ts src/components/auth/LoginPage.passkeys.test.tsx src/components/settings/ProfilePage.passkeys.test.tsx`
- `git diff --check`

## Notes

- `pnpm db:check-drift` could not complete locally because `DATABASE_URL` was not set in this environment.
- A full `@breeze/api` run was not green due unrelated existing failures/timeouts in MCP/OAuth/discovery/reports specs; the focused auth/passkey API coverage above passed.
