### PR TITLE
[codex] Separate approved pending patches

### DIFF
--- a/apps/api/src/routes/devices/patches.test.ts
+++ b/apps/api/src/routes/devices/patches.test.ts
@@ -8,6 +8,7 @@ const PATCH_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
 const USER_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
 
 vi.mock('drizzle-orm', () => ({
+  and: (...conditions: unknown[]) => ({ op: 'and', conditions }),
   eq: (left: unknown, right: unknown) => ({ op: 'eq', left, right }),
   inArray: (left: unknown, right: unknown) => ({ op: 'inArray', left, right }),
   desc: (value: unknown) => ({ op: 'desc', value })
@@ -45,6 +46,11 @@ vi.mock('../../db/schema', () => ({
     failureCount: 'devicePatches.failureCount',
     lastError: 'devicePatches.lastError',
     deviceId: 'devicePatches.deviceId'
+  },
+  patchApprovals: {
+    orgId: 'patchApprovals.orgId',
+    patchId: 'patchApprovals.patchId',
+    status: 'patchApprovals.status'
   }
 }));
 
@@ -77,7 +83,7 @@ vi.mock('../../services/commandQueue', () => ({
 }));
 
 import { db } from '../../db';
-import { getDeviceWithOrgCheck, getDeviceWithOrgAndSiteCheck } from './helpers';
+import { getDeviceWithOrgAndSiteCheck } from './helpers';
 import { queueCommandForExecution } from '../../services/commandQueue';
 
 function selectWhereResult(rows: unknown[]) {
@@ -121,7 +127,8 @@ describe('device patch routes', () => {
 
   it('separates actionable pending patches from missing records', async () => {
     vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: '11111111-1111-1111-1111-111111111111' } as any);
-    vi.mocked(db.select).mockReturnValueOnce(selectPatchStatusResult([
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectPatchStatusResult([
       {
         id: 'dp-1',
         patchId: '11111111-1111-4111-8111-111111111111',
@@ -173,7 +180,10 @@ describe('device patch routes', () => {
         releaseDate: '2026-02-03',
         requiresReboot: false
       }
-    ]) as any);
+      ]) as any)
+      .mockReturnValueOnce(selectWhereResult([
+        { patchId: '11111111-1111-4111-8111-111111111111' }
+      ]) as any);
 
     const res = await app.request(`/devices/${DEVICE_ID}/patches`, {
       method: 'GET',
@@ -186,6 +196,7 @@ describe('device patch routes', () => {
     expect(body.data.pending).toHaveLength(1);
     expect(body.data.pending[0].id).toBe('11111111-1111-4111-8111-111111111111');
     expect(body.data.pending[0].status).toBe('pending');
+    expect(body.data.pending[0].approvalStatus).toBe('approved');
     expect(body.data.pending[0].externalId).toBe('apple:OS Update A:1.0.1');
     expect(body.data.pending[0].description).toBe('Pending update');
 
@@ -198,10 +209,14 @@ describe('device patch routes', () => {
   });
 
   it('queues install_patches command with patch metadata', async () => {
-    vi.mocked(getDeviceWithOrgCheck).mockResolvedValue({ id: DEVICE_ID, orgId: '11111111-1111-1111-1111-111111111111' } as any);
-    vi.mocked(db.select).mockReturnValueOnce(selectWhereResult([
-      { id: PATCH_ID, source: 'linux', externalId: 'apt:openssl', title: 'OpenSSL' }
-    ]) as any);
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: '11111111-1111-1111-1111-111111111111' } as any);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectWhereResult([
+        { id: PATCH_ID, source: 'linux', externalId: 'apt:openssl', title: 'OpenSSL' }
+      ]) as any)
+      .mockReturnValueOnce(selectWhereResult([
+        { patchId: PATCH_ID }
+      ]) as any);
     vi.mocked(queueCommandForExecution).mockResolvedValue({
       command: {
         id: 'cmd-install-1',
@@ -234,8 +249,29 @@ describe('device patch routes', () => {
     );
   });
 
+  it('rejects install when any requested patch is not approved', async () => {
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: '11111111-1111-1111-1111-111111111111' } as any);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectWhereResult([
+        { id: PATCH_ID, source: 'linux', externalId: 'apt:openssl', title: 'OpenSSL' }
+      ]) as any)
+      .mockReturnValueOnce(selectWhereResult([]) as any);
+
+    const res = await app.request(`/devices/${DEVICE_ID}/patches/install`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ patchIds: [PATCH_ID] })
+    });
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe('Only approved patches can be installed');
+    expect(body.unapprovedPatchIds).toEqual([PATCH_ID]);
+    expect(queueCommandForExecution).not.toHaveBeenCalled();
+  });
+
   it('returns 404 when install patch IDs do not resolve to patch records', async () => {
-    vi.mocked(getDeviceWithOrgCheck).mockResolvedValue({ id: DEVICE_ID, orgId: '11111111-1111-1111-1111-111111111111' } as any);
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: '11111111-1111-1111-1111-111111111111' } as any);
     vi.mocked(db.select).mockReturnValueOnce(selectWhereResult([]) as any);
 
     const res = await app.request(`/devices/${DEVICE_ID}/patches/install`, {
@@ -250,7 +286,7 @@ describe('device patch routes', () => {
   });
 
   it('queues rollback_patches command for a device patch', async () => {
-    vi.mocked(getDeviceWithOrgCheck).mockResolvedValue({ id: DEVICE_ID, orgId: '11111111-1111-1111-1111-111111111111' } as any);
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: '11111111-1111-1111-1111-111111111111' } as any);
     vi.mocked(db.select).mockReturnValueOnce(selectWhereLimitResult([
       { id: PATCH_ID, source: 'apple', externalId: 'apple:example', title: 'Example Patch' }
     ]) as any);

--- a/apps/api/src/routes/devices/patches.test.ts
+++ b/apps/api/src/routes/devices/patches.test.ts
@@ -285,6 +285,52 @@ describe('device patch routes', () => {
     expect(body.error).toContain('No matching patches');
   });
 
+  it('returns 404 with missingPatchIds when only some install patch IDs resolve', async () => {
+    const RESOLVED_PATCH_ID = '11111111-1111-4111-8111-111111111111';
+    const MISSING_PATCH_ID = '22222222-2222-4222-8222-222222222222';
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: '11111111-1111-1111-1111-111111111111' } as any);
+    // Only the first patch resolves in patchRefs; the second is missing.
+    vi.mocked(db.select).mockReturnValueOnce(selectWhereResult([
+      { id: RESOLVED_PATCH_ID, source: 'linux', externalId: 'apt:openssl', title: 'OpenSSL' }
+    ]) as any);
+
+    const res = await app.request(`/devices/${DEVICE_ID}/patches/install`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ patchIds: [RESOLVED_PATCH_ID, MISSING_PATCH_ID] })
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe('Some patches were not found');
+    expect(body.missingPatchIds).toEqual([MISSING_PATCH_ID]);
+    // The missing-patch check short-circuits before the approval query and the queue.
+    expect(db.select).toHaveBeenCalledTimes(1);
+    expect(queueCommandForExecution).not.toHaveBeenCalled();
+  });
+
+  it('does not issue the approvals query when a device has no patches', async () => {
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: '11111111-1111-1111-1111-111111111111' } as any);
+    // Device-patch list resolves to an empty array → patchIds is empty →
+    // getApprovedPatchIdsForOrg short-circuits without a second db.select call.
+    vi.mocked(db.select).mockReturnValueOnce(selectPatchStatusResult([]) as any);
+
+    const res = await app.request(`/devices/${DEVICE_ID}/patches`, {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.data.pending).toEqual([]);
+    expect(body.data.missing).toEqual([]);
+    expect(body.data.installed).toEqual([]);
+    expect(body.data.compliancePercent).toBe(100);
+    // Only the device-patch list query ran; the approvals query was skipped.
+    expect(db.select).toHaveBeenCalledTimes(1);
+  });
+
   it('queues rollback_patches command for a device patch', async () => {
     vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: '11111111-1111-1111-1111-111111111111' } as any);
     vi.mocked(db.select).mockReturnValueOnce(selectWhereLimitResult([

--- a/apps/api/src/routes/devices/patches.ts
+++ b/apps/api/src/routes/devices/patches.ts
@@ -3,7 +3,7 @@ import { eq, desc, inArray, and, sql } from 'drizzle-orm';
 import { z } from 'zod';
 import { zValidator } from '@hono/zod-validator';
 import { db } from '../../db';
-import { patches, devicePatches, deviceCommands, users } from '../../db/schema';
+import { patches, devicePatches, patchApprovals, deviceCommands, users } from '../../db/schema';
 import { authMiddleware, requireMfa, requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
 import { getDeviceWithOrgAndSiteCheck, SITE_ACCESS_DENIED } from './helpers';
@@ -98,6 +98,23 @@ function safeParsePatchResult(result: unknown): unknown {
   }
 
   return raw;
+}
+
+async function getApprovedPatchIdsForOrg(orgId: string, patchIds: string[]): Promise<Set<string>> {
+  if (patchIds.length === 0) return new Set();
+
+  const approvals = await db
+    .select({ patchId: patchApprovals.patchId })
+    .from(patchApprovals)
+    .where(
+      and(
+        eq(patchApprovals.orgId, orgId),
+        inArray(patchApprovals.patchId, patchIds),
+        eq(patchApprovals.status, 'approved')
+      )
+    );
+
+  return new Set(approvals.map((approval) => approval.patchId));
 }
 
 // GET /devices/:id/patches/history - Get patch operation history for a device
@@ -213,6 +230,9 @@ patchesRoutes.get(
       .where(eq(devicePatches.deviceId, deviceId))
       .orderBy(desc(devicePatches.lastCheckedAt));
 
+    const patchIds = [...new Set(devicePatchList.map((patch) => patch.patchId))];
+    const approvedPatchIds = await getApprovedPatchIdsForOrg(device.orgId, patchIds);
+
     // Separate actionable pending updates from stale missing records.
     const pending = devicePatchList
       .filter(p => p.status === 'pending')
@@ -227,7 +247,8 @@ patchesRoutes.get(
         releaseDate: p.releaseDate,
         category: p.category,
         source: p.source,
-        requiresReboot: p.requiresReboot
+        requiresReboot: p.requiresReboot,
+        approvalStatus: approvedPatchIds.has(p.patchId) ? 'approved' : 'pending'
       }));
 
     const missing = devicePatchList
@@ -243,7 +264,8 @@ patchesRoutes.get(
         releaseDate: p.releaseDate,
         category: p.category,
         source: p.source,
-        requiresReboot: p.requiresReboot
+        requiresReboot: p.requiresReboot,
+        approvalStatus: approvedPatchIds.has(p.patchId) ? 'approved' : 'pending'
       }));
 
     const installed = devicePatchList
@@ -258,7 +280,8 @@ patchesRoutes.get(
         status: p.status,
         installedAt: p.installedAt,
         category: p.category,
-        source: p.source
+        source: p.source,
+        approvalStatus: approvedPatchIds.has(p.patchId) ? 'approved' : 'pending'
       }));
 
     const failed = devicePatchList
@@ -296,7 +319,8 @@ patchesRoutes.get(
           severity: p.severity,
           status: p.status,
           releaseDate: p.releaseDate,
-          installedAt: p.installedAt
+          installedAt: p.installedAt,
+          approvalStatus: approvedPatchIds.has(p.patchId) ? 'approved' : 'pending'
         }))
       }
     });
@@ -335,6 +359,23 @@ patchesRoutes.post(
 
     if (patchRefs.length === 0) {
       return c.json({ error: 'No matching patches found' }, 404);
+    }
+    const foundPatchIds = new Set(patchRefs.map((patch) => patch.id));
+    const missingPatchIds = data.patchIds.filter((patchId) => !foundPatchIds.has(patchId));
+    if (missingPatchIds.length > 0) {
+      return c.json({
+        error: 'Some patches were not found',
+        missingPatchIds
+      }, 404);
+    }
+
+    const approvedPatchIds = await getApprovedPatchIdsForOrg(device.orgId, data.patchIds);
+    const unapprovedPatchIds = data.patchIds.filter((patchId) => !approvedPatchIds.has(patchId));
+    if (unapprovedPatchIds.length > 0) {
+      return c.json({
+        error: 'Only approved patches can be installed',
+        unapprovedPatchIds
+      }, 409);
     }
 
     const queued = await queueCommandForExecution(

--- a/apps/api/src/routes/devices/patches.ts
+++ b/apps/api/src/routes/devices/patches.ts
@@ -100,6 +100,20 @@ function safeParsePatchResult(result: unknown): unknown {
   return raw;
 }
 
+/**
+ * Resolve which of the given patch IDs carry an explicit org-wide manual-approval
+ * record (`patchApprovals.status = 'approved'`) for the org.
+ *
+ * This is intentionally only the org-wide manual-approval gate. It does NOT consider
+ * the device's effective patch ring or category/auto-approve rules — for the full
+ * ring + category-aware evaluation see `resolveApprovedPatchesForDevice` in
+ * `services/patchApprovalEvaluator.ts`.
+ *
+ * Known limitation: because this gate is org-wide and ring-agnostic, a patch that is
+ * approved for ring A passes this gate for a device in ring B. Wiring the install
+ * endpoint through the full evaluator (`resolveApprovedPatchesForDevice`) is a tracked
+ * follow-up.
+ */
 async function getApprovedPatchIdsForOrg(orgId: string, patchIds: string[]): Promise<Set<string>> {
   if (patchIds.length === 0) return new Set();
 

--- a/apps/api/src/routes/patches/compliance.test.ts
+++ b/apps/api/src/routes/patches/compliance.test.ts
@@ -18,6 +18,7 @@ vi.mock('../../db/schema', () => ({
   },
   devicePatches: {
     deviceId: 'devicePatches.deviceId',
+    orgId: 'devicePatches.orgId',
     patchId: 'devicePatches.patchId',
     status: 'devicePatches.status',
     installedAt: 'devicePatches.installedAt',

--- a/apps/api/src/routes/patches/compliance.ts
+++ b/apps/api/src/routes/patches/compliance.ts
@@ -135,6 +135,18 @@ complianceRoutes.get(
       complianceConditions.push(eq(patches.severity, query.severity));
     }
 
+    const approvalRingScope = query.ringId
+      ? sql`and (pa.ring_id = ${query.ringId}::uuid or pa.ring_id is null)`
+      : sql``;
+    const isApprovedForInstall = sql`exists (
+      select 1
+      from patch_approvals pa
+      where pa.org_id = ${devicePatches.orgId}
+        and pa.patch_id = ${devicePatches.patchId}
+        and pa.status = 'approved'
+        ${approvalRingScope}
+    )`;
+
     const statusCounts = await db
       .select({
         status: devicePatches.status,
@@ -179,6 +191,8 @@ complianceRoutes.get(
         osType: devices.osType,
         lastSeenAt: devices.lastSeenAt,
         missingCount: sql<number>`count(*) filter (where ${isOutstanding})`,
+        approvedMissing: sql<number>`count(*) filter (where ${isOutstanding} and ${isApprovedForInstall})`,
+        unapprovedMissing: sql<number>`count(*) filter (where ${isOutstanding} and not ${isApprovedForInstall})`,
         criticalCount: sql<number>`count(*) filter (where ${isOutstanding} and ${patches.severity} = 'critical')`,
         importantCount: sql<number>`count(*) filter (where ${isOutstanding} and ${patches.severity} = 'important')`,
         osMissing: sql<number>`count(*) filter (where ${isOutstanding} and ${patches.source} in ('microsoft', 'apple', 'linux'))`,
@@ -200,6 +214,8 @@ complianceRoutes.get(
       name: row.hostname,
       os: row.osType,
       missingCount: Number(row.missingCount),
+      approvedMissing: Number(row.approvedMissing),
+      unapprovedMissing: Number(row.unapprovedMissing),
       criticalCount: Number(row.criticalCount),
       importantCount: Number(row.importantCount),
       osMissing: Number(row.osMissing),

--- a/apps/api/src/routes/patches/index.test.ts
+++ b/apps/api/src/routes/patches/index.test.ts
@@ -70,6 +70,7 @@ vi.mock('../../db/schema', () => ({
   },
   devicePatches: {
     deviceId: 'devicePatches.deviceId',
+    orgId: 'devicePatches.orgId',
     patchId: 'devicePatches.patchId',
     status: 'devicePatches.status',
     lastCheckedAt: 'devicePatches.lastCheckedAt'

--- a/apps/web/src/components/devices/DevicePatchStatusTab.test.tsx
+++ b/apps/web/src/components/devices/DevicePatchStatusTab.test.tsx
@@ -273,4 +273,97 @@ describe('DevicePatchStatusTab', () => {
     expect((installThirdPartyButton as HTMLButtonElement).disabled).toBe(true);
     await screen.findByText(/1 stale missing records are excluded from pending install counts\./i);
   });
+
+  it('sends only approved pending OS patch ids to the install endpoint', async () => {
+    const patchData = {
+      data: {
+        compliancePercent: 10,
+        pending: [
+          {
+            id: 'approved-1',
+            title: '2026-01 Cumulative Update (KB5050001)',
+            source: 'microsoft',
+            category: 'security',
+            status: 'pending',
+            approvalStatus: 'approved'
+          },
+          {
+            id: 'pending-1',
+            title: '2026-01 Feature Update (KB5050099)',
+            source: 'microsoft',
+            category: 'security',
+            status: 'pending',
+            approvalStatus: 'pending'
+          }
+        ],
+        installed: []
+      }
+    };
+
+    fetchWithAuthMock.mockImplementation(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/patches/install')) {
+        return makeJsonResponse({ success: true, commandId: 'cmd-install-1', patchCount: 1 });
+      }
+      return makeJsonResponse(patchData);
+    });
+
+    render(<DevicePatchStatusTab deviceId={deviceId} osType="windows" />);
+
+    // Button count reflects only the approved patch, and surfaces the pending one.
+    const installButton = await screen.findByRole('button', { name: /Install pending OS patches \(1\)/i });
+    expect(installButton.textContent).toMatch(/1 pending approval/i);
+
+    fireEvent.click(installButton);
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        `/devices/${deviceId}/patches/install`,
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ patchIds: ['approved-1'] })
+        })
+      );
+    });
+  });
+
+  it('surfaces unapproved patch count when install returns 409', async () => {
+    const patchData = {
+      data: {
+        compliancePercent: 10,
+        pending: [
+          {
+            id: 'approved-1',
+            title: '2026-01 Cumulative Update (KB5050001)',
+            source: 'microsoft',
+            category: 'security',
+            status: 'pending',
+            approvalStatus: 'approved'
+          }
+        ],
+        installed: []
+      }
+    };
+
+    fetchWithAuthMock.mockImplementation(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/patches/install')) {
+        return makeJsonResponse(
+          {
+            error: 'Only approved patches can be installed',
+            unapprovedPatchIds: ['approved-1']
+          },
+          false,
+          409
+        );
+      }
+      return makeJsonResponse(patchData);
+    });
+
+    render(<DevicePatchStatusTab deviceId={deviceId} osType="windows" />);
+
+    const installButton = await screen.findByRole('button', { name: /Install pending OS patches \(1\)/i });
+    fireEvent.click(installButton);
+
+    await screen.findByText(/pending approval/i);
+    expect(screen.queryByText(/Only approved patches can be installed/i)).not.toBeNull();
+  });
 });

--- a/apps/web/src/components/devices/DevicePatchStatusTab.tsx
+++ b/apps/web/src/components/devices/DevicePatchStatusTab.tsx
@@ -35,6 +35,7 @@ type PatchItem = {
   installedAt?: string;
   requiresReboot?: boolean;
   isDownloaded?: boolean;
+  approvalStatus?: string;
 };
 
 type PatchPayload = {
@@ -184,6 +185,19 @@ function readPatchIds(patches: PatchItem[]): string[] {
     }
   }
   return [...unique];
+}
+
+// A patch is awaiting approval only when the API explicitly says so. The
+// device-patches endpoint always sends approvalStatus ('approved' | 'pending'),
+// so an absent value (older payloads / tests) is treated as installable.
+function isAwaitingApproval(patch: PatchItem): boolean {
+  return patch.approvalStatus === 'pending';
+}
+
+// Only approved pending patches may be sent to the install endpoint. Mixing in
+// an unapproved id makes the server reject the whole batch with 409.
+function readApprovedPatchIds(patches: PatchItem[]): string[] {
+  return readPatchIds(patches.filter(patch => !isAwaitingApproval(patch)));
 }
 
 function getCategoryBadge(patch: PatchItem, osType: OSType) {
@@ -562,8 +576,12 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
     };
   }, [payload, normalizedOsType]);
 
-  const nativePendingIds = useMemo(() => readPatchIds(pendingNative), [pendingNative]);
-  const thirdPartyPendingIds = useMemo(() => readPatchIds(pendingOther), [pendingOther]);
+  // Only approved pending patches are eligible for the batch install buttons;
+  // sending an unapproved id would make the server 409 the entire batch.
+  const nativePendingIds = useMemo(() => readApprovedPatchIds(pendingNative), [pendingNative]);
+  const thirdPartyPendingIds = useMemo(() => readApprovedPatchIds(pendingOther), [pendingOther]);
+  const nativeAwaitingApproval = useMemo(() => pendingNative.filter(isAwaitingApproval).length, [pendingNative]);
+  const thirdPartyAwaitingApproval = useMemo(() => pendingOther.filter(isAwaitingApproval).length, [pendingOther]);
 
   // -------------------------------------------------------------------------
   // Post-install polling: poll every 5s for up to 90s watching pending count
@@ -677,9 +695,18 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
         method: 'POST',
         body: JSON.stringify({ patchIds })
       });
-      const body = await response.json().catch(() => ({})) as PatchInstallResponse & { error?: string };
+      const body = await response.json().catch(() => ({})) as PatchInstallResponse & {
+        error?: string;
+        unapprovedPatchIds?: string[];
+        missingPatchIds?: string[];
+      };
       if (!response.ok) {
-        throw new Error(body.error || `Failed to queue ${label.toLowerCase()}`);
+        let message = body.error || `Failed to queue ${label.toLowerCase()}`;
+        const unapprovedCount = Array.isArray(body.unapprovedPatchIds) ? body.unapprovedPatchIds.length : 0;
+        if (response.status === 409 && unapprovedCount > 0) {
+          message += ` (${unapprovedCount} ${unapprovedCount === 1 ? 'patch' : 'patches'} still pending approval - approve them first or refresh)`;
+        }
+        throw new Error(message);
       }
 
       const commandSuffix = body.commandId ? ` (command ${body.commandId})` : '';
@@ -799,6 +826,11 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
           >
             {controlAction === 'install-native' ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle className="h-4 w-4 text-green-500" />}
             Install pending OS patches ({nativePendingIds.length})
+            {nativeAwaitingApproval > 0 && (
+              <span className="text-xs font-normal text-muted-foreground">
+                ({nativeAwaitingApproval} pending approval)
+              </span>
+            )}
           </button>
 
           <button
@@ -829,6 +861,11 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
           >
             {controlAction === 'install-third-party' ? <Loader2 className="h-4 w-4 animate-spin" /> : <Package className="h-4 w-4 text-blue-500" />}
             Install 3rd-party patches ({thirdPartyPendingIds.length})
+            {thirdPartyAwaitingApproval > 0 && (
+              <span className="text-xs font-normal text-muted-foreground">
+                ({thirdPartyAwaitingApproval} pending approval)
+              </span>
+            )}
           </button>
         </div>
 

--- a/apps/web/src/components/patches/PatchComplianceView.test.tsx
+++ b/apps/web/src/components/patches/PatchComplianceView.test.tsx
@@ -23,7 +23,7 @@ describe('PatchComplianceView', () => {
     vi.clearAllMocks();
   });
 
-  it('resolves pending patch ids before queuing bulk install', async () => {
+  it('resolves approved pending patch ids before queuing bulk install', async () => {
     fetchMock.mockImplementation(async (input) => {
       const url = String(input);
       if (url === '/patches/compliance') {
@@ -41,6 +41,8 @@ describe('PatchComplianceView', () => {
                 name: 'Workstation-1',
                 os: 'windows',
                 missingCount: 2,
+                approvedMissing: 2,
+                unapprovedMissing: 0,
                 criticalCount: 1,
                 importantCount: 1,
                 osMissing: 2,
@@ -70,8 +72,8 @@ describe('PatchComplianceView', () => {
         return makeJsonResponse({
           data: {
             pending: [
-              { id: '22222222-2222-2222-2222-222222222222', title: 'KB5050001' },
-              { id: '33333333-3333-3333-3333-333333333333', title: 'KB5050002' },
+              { id: '22222222-2222-2222-2222-222222222222', title: 'KB5050001', approvalStatus: 'approved' },
+              { id: '33333333-3333-3333-3333-333333333333', title: 'KB5050002', approvalStatus: 'approved' },
             ],
           },
         });

--- a/apps/web/src/components/patches/PatchComplianceView.test.tsx
+++ b/apps/web/src/components/patches/PatchComplianceView.test.tsx
@@ -116,4 +116,171 @@ describe('PatchComplianceView', () => {
 
     expect(await screen.findByText('Patch install queued on 1 device')).toBeTruthy();
   });
+
+  it('sends only approved patch ids when a device has mixed approval state', async () => {
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === '/patches/compliance') {
+        return makeJsonResponse({
+          data: {
+            totalDevices: 1,
+            compliantDevices: 0,
+            devicesNeedingPatches: [
+              {
+                id: '11111111-1111-1111-1111-111111111111',
+                name: 'Workstation-1',
+                os: 'windows',
+                missingCount: 2,
+                approvedMissing: 1,
+                unapprovedMissing: 1,
+                criticalCount: 0,
+                importantCount: 0,
+                osMissing: 2,
+                thirdPartyMissing: 0,
+                pendingReboot: false,
+                lastSeen: '2026-04-01T18:00:00.000Z',
+              },
+            ],
+          },
+        });
+      }
+
+      if (url === '/devices?limit=200') {
+        return makeJsonResponse({
+          devices: [
+            {
+              id: '11111111-1111-1111-1111-111111111111',
+              hostname: 'Workstation-1',
+              osType: 'windows',
+              lastSeenAt: '2026-04-01T18:00:00.000Z',
+            },
+          ],
+        });
+      }
+
+      if (url === '/devices/11111111-1111-1111-1111-111111111111/patches') {
+        return makeJsonResponse({
+          data: {
+            pending: [
+              { id: '22222222-2222-2222-2222-222222222222', title: 'KB5050001', approvalStatus: 'approved' },
+              { id: '33333333-3333-3333-3333-333333333333', title: 'KB5050002', approvalStatus: 'pending' },
+            ],
+          },
+        });
+      }
+
+      if (url === '/devices/11111111-1111-1111-1111-111111111111/patches/install') {
+        return makeJsonResponse({
+          success: true,
+          commandId: 'cmd-install-1',
+          commandStatus: 'sent',
+          patchCount: 1,
+        });
+      }
+
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(<PatchComplianceView ringId={null} />);
+
+    await screen.findByText('Workstation-1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select Workstation-1' }));
+    fireEvent.click(screen.getByRole('button', { name: /Install \(1\)/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/devices/11111111-1111-1111-1111-111111111111/patches/install',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            patchIds: ['22222222-2222-2222-2222-222222222222'],
+          }),
+        })
+      );
+    });
+
+    // The unapproved patch was dropped — surface that in the result message.
+    expect(
+      await screen.findByText(/skipped pending approval/i)
+    ).toBeTruthy();
+  });
+
+  it('surfaces a distinct message when the install endpoint returns 409 approval failure', async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === '/patches/compliance') {
+        return makeJsonResponse({
+          data: {
+            totalDevices: 1,
+            compliantDevices: 0,
+            devicesNeedingPatches: [
+              {
+                id: '11111111-1111-1111-1111-111111111111',
+                name: 'Workstation-1',
+                os: 'windows',
+                missingCount: 1,
+                approvedMissing: 1,
+                unapprovedMissing: 0,
+                criticalCount: 0,
+                importantCount: 0,
+                osMissing: 1,
+                thirdPartyMissing: 0,
+                pendingReboot: false,
+                lastSeen: '2026-04-01T18:00:00.000Z',
+              },
+            ],
+          },
+        });
+      }
+
+      if (url === '/devices?limit=200') {
+        return makeJsonResponse({
+          devices: [
+            {
+              id: '11111111-1111-1111-1111-111111111111',
+              hostname: 'Workstation-1',
+              osType: 'windows',
+              lastSeenAt: '2026-04-01T18:00:00.000Z',
+            },
+          ],
+        });
+      }
+
+      if (url === '/devices/11111111-1111-1111-1111-111111111111/patches' && !init) {
+        return makeJsonResponse({
+          data: {
+            pending: [
+              { id: '22222222-2222-2222-2222-222222222222', title: 'KB5050001', approvalStatus: 'approved' },
+            ],
+          },
+        });
+      }
+
+      if (url === '/devices/11111111-1111-1111-1111-111111111111/patches/install') {
+        return makeJsonResponse(
+          {
+            error: 'Only approved patches can be installed',
+            unapprovedPatchIds: ['22222222-2222-2222-2222-222222222222'],
+          },
+          false,
+          409
+        );
+      }
+
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(<PatchComplianceView ringId={null} />);
+
+    await screen.findByText('Workstation-1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select Workstation-1' }));
+    fireEvent.click(screen.getByRole('button', { name: /Install \(1\)/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    expect(await screen.findByText(/pending approval/i)).toBeTruthy();
+    expect(screen.queryByText(/^Install failed/)).toBeNull();
+  });
 });

--- a/apps/web/src/components/patches/PatchComplianceView.tsx
+++ b/apps/web/src/components/patches/PatchComplianceView.tsx
@@ -19,7 +19,7 @@ import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { formatRelativeTime, lastActivity, toNumber, type DevicePatchRow } from './patchHelpers';
 import { usePatchSelection } from './usePatchSelection';
-import { useBulkActions } from './useBulkActions';
+import { useBulkActions, type ResolvedInstallPatchIds } from './useBulkActions';
 
 type ComplianceSummary = {
   totalDevices: number;
@@ -91,7 +91,10 @@ export default function PatchComplianceView({ ringId }: PatchComplianceViewProps
             lastSeenAt: (n?.lastSeen ?? raw.lastSeenAt) ? String(n?.lastSeen ?? raw.lastSeenAt) : undefined,
             pendingPatches,
             approvedMissing,
-            unapprovedMissing: toNumber(n?.unapprovedMissing ?? Math.max(0, pendingPatches - approvedMissing)),
+            // The compliance API always returns both approved/unapproved counts.
+            // Read it directly rather than synthesizing from (pending - approved),
+            // which produced a misleading count when the field was absent.
+            unapprovedMissing: toNumber(n?.unapprovedMissing ?? 0),
             criticalMissing: toNumber(n?.criticalCount ?? 0),
             importantMissing: toNumber(n?.importantCount ?? 0),
             osMissing: toNumber(n?.osMissing ?? 0),
@@ -151,12 +154,12 @@ export default function PatchComplianceView({ ringId }: PatchComplianceViewProps
 
   const hasActiveFilters = searchQuery !== '' || statusFilter !== 'all';
 
-  const resolveInstallPatchIds = useCallback(async (deviceId: string) => {
+  const resolveInstallPatchIds = useCallback(async (deviceId: string): Promise<ResolvedInstallPatchIds> => {
     const response = await fetchWithAuth(`/devices/${deviceId}/patches`);
     if (!response.ok) {
       if (response.status === 401) {
         void navigateTo('/login', { replace: true });
-        return [];
+        return { patchIds: [] };
       }
       throw new Error(`Failed to load pending patches for device ${deviceId}`);
     }
@@ -165,14 +168,25 @@ export default function PatchComplianceView({ ringId }: PatchComplianceViewProps
     const data = payload?.data ?? payload;
     const pending = data?.pending ?? data?.pendingPatches ?? data?.available ?? [];
     if (!Array.isArray(pending)) {
-      return [];
+      return { patchIds: [] };
     }
 
-    return pending.flatMap((patch: unknown) => {
-      if (!patch || typeof patch !== 'object') return [];
+    const patchIds: string[] = [];
+    let skippedPendingApproval = 0;
+    for (const patch of pending) {
+      if (!patch || typeof patch !== 'object') continue;
       const row = patch as { id?: unknown; approvalStatus?: unknown };
-      return row.id && row.approvalStatus === 'approved' ? [String(row.id)] : [];
-    });
+      if (!row.id) continue;
+      if (row.approvalStatus === 'approved') {
+        patchIds.push(String(row.id));
+      } else {
+        // Awaiting approval — drop it, but track so the caller can report it
+        // rather than silently swallowing the patch.
+        skippedPendingApproval += 1;
+      }
+    }
+
+    return { patchIds, skippedPendingApproval };
   }, []);
 
   const filteredIds = useMemo(() => filteredDevices.map(d => d.id), [filteredDevices]);

--- a/apps/web/src/components/patches/PatchComplianceView.tsx
+++ b/apps/web/src/components/patches/PatchComplianceView.tsx
@@ -82,12 +82,16 @@ export default function PatchComplianceView({ ringId }: PatchComplianceViewProps
         for (const raw of allDevices) {
           const id = String(raw.id ?? '');
           const n = needingMap.get(id);
+          const pendingPatches = toNumber(n?.missingCount ?? 0);
+          const approvedMissing = toNumber(n?.approvedMissing ?? 0);
           merged.push({
             id,
             hostname: String(n?.name ?? n?.hostname ?? raw.hostname ?? 'Unknown'),
             osType: String(n?.os ?? n?.osType ?? raw.osType ?? raw.os_type ?? 'unknown'),
             lastSeenAt: (n?.lastSeen ?? raw.lastSeenAt) ? String(n?.lastSeen ?? raw.lastSeenAt) : undefined,
-            pendingPatches: toNumber(n?.missingCount ?? 0),
+            pendingPatches,
+            approvedMissing,
+            unapprovedMissing: toNumber(n?.unapprovedMissing ?? Math.max(0, pendingPatches - approvedMissing)),
             criticalMissing: toNumber(n?.criticalCount ?? 0),
             importantMissing: toNumber(n?.importantCount ?? 0),
             osMissing: toNumber(n?.osMissing ?? 0),
@@ -164,9 +168,11 @@ export default function PatchComplianceView({ ringId }: PatchComplianceViewProps
       return [];
     }
 
-    return pending
-      .map((patch: unknown) => (patch && typeof patch === 'object' && 'id' in patch && patch.id ? String(patch.id) : ''))
-      .filter((patchId) => patchId.length > 0);
+    return pending.flatMap((patch: unknown) => {
+      if (!patch || typeof patch !== 'object') return [];
+      const row = patch as { id?: unknown; approvalStatus?: unknown };
+      return row.id && row.approvalStatus === 'approved' ? [String(row.id)] : [];
+    });
   }, []);
 
   const filteredIds = useMemo(() => filteredDevices.map(d => d.id), [filteredDevices]);
@@ -245,10 +251,18 @@ export default function PatchComplianceView({ ringId }: PatchComplianceViewProps
   const selectedPatchDeviceIds = useMemo(() => {
     return Array.from(selectedIds).filter(id => {
       const d = devices.find(dev => dev.id === id);
-      return d && d.pendingPatches > 0;
+      return d && d.approvedMissing > 0;
     });
   }, [selectedIds, devices]);
   const selectedWithPatches = selectedPatchDeviceIds.length;
+  const approvedPendingPatches = useMemo(
+    () => devices.reduce((sum, d) => sum + d.approvedMissing, 0),
+    [devices]
+  );
+  const unapprovedPendingPatches = useMemo(
+    () => devices.reduce((sum, d) => sum + d.unapprovedMissing, 0),
+    [devices]
+  );
 
   // Precomputed filter counts
   const filterCounts = useMemo(() => ({
@@ -302,8 +316,14 @@ export default function PatchComplianceView({ ringId }: PatchComplianceViewProps
           {nonCompliantCount > 0 && (
             <span className="flex items-center gap-1 text-orange-600">
               <AlertTriangle className="h-3.5 w-3.5" />
-              {nonCompliantCount} need patches
+              {nonCompliantCount} have pending patches
             </span>
+          )}
+          {approvedPendingPatches > 0 && (
+            <span className="text-green-700 font-medium">{approvedPendingPatches} approved</span>
+          )}
+          {unapprovedPendingPatches > 0 && (
+            <span className="text-orange-600 font-medium">{unapprovedPendingPatches} pending approval</span>
           )}
           {summary.criticalPatches > 0 && (
             <span className="text-red-600 font-medium">{summary.criticalPatches} critical</span>
@@ -355,10 +375,10 @@ export default function PatchComplianceView({ ringId }: PatchComplianceViewProps
           className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
         >
           <option value="all">All Devices ({devices.length})</option>
-          <option value="needs-patches">Needs Patches ({nonCompliantCount})</option>
+          <option value="needs-patches">Pending Patches ({nonCompliantCount})</option>
           <option value="critical">Critical ({filterCounts.critical})</option>
           <option value="reboot">Pending Reboot ({summary.rebootPending})</option>
-          <option value="3rd-party">3rd-Party Missing ({filterCounts.thirdParty})</option>
+          <option value="3rd-party">3rd-Party Pending ({filterCounts.thirdParty})</option>
           <option value="compliant">Compliant ({summary.compliantDevices})</option>
         </select>
         {hasActiveFilters && (
@@ -406,7 +426,7 @@ export default function PatchComplianceView({ ringId }: PatchComplianceViewProps
           )}
           {confirmInstall && (
             <div className="flex items-center gap-2 rounded-md border border-orange-500/40 bg-orange-500/10 px-3 py-1">
-              <span className="text-xs text-orange-700">Install patches on {selectedWithPatches} devices?</span>
+              <span className="text-xs text-orange-700">Install approved patches on {selectedWithPatches} devices?</span>
               <button
                 type="button"
                 onClick={() => { setConfirmInstall(false); void handleBulkInstall(selectedPatchDeviceIds); }}
@@ -463,9 +483,11 @@ export default function PatchComplianceView({ ringId }: PatchComplianceViewProps
               </th>
               <th className="px-3 py-3">Device</th>
               <th className="px-3 py-3">Status</th>
-              <th className="px-3 py-3" title="Missing updates from Windows Update, Apple, or Linux package managers">OS Patches</th>
-              <th className="px-3 py-3" title="Missing updates from third-party or custom sources">3rd-Party</th>
-              <th className="px-3 py-3" title="Missing patches rated critical severity">Critical</th>
+              <th className="px-3 py-3" title="Outstanding patches approved for installation">Approved</th>
+              <th className="px-3 py-3" title="Outstanding patches still awaiting approval">Pending Approval</th>
+              <th className="px-3 py-3" title="Outstanding updates from Windows Update, Apple, or Linux package managers">OS Patches</th>
+              <th className="px-3 py-3" title="Outstanding updates from third-party or custom sources">3rd-Party</th>
+              <th className="px-3 py-3" title="Outstanding patches rated critical severity">Critical</th>
               <th className="px-3 py-3" title="Most recent patch install or scan activity">Last Activity</th>
               <th className="px-3 py-3" title="Device needs a reboot to complete patch installation">Reboot</th>
               <th className="px-3 py-3 text-right">Actions</th>
@@ -474,7 +496,7 @@ export default function PatchComplianceView({ ringId }: PatchComplianceViewProps
           <tbody className="divide-y">
             {filteredDevices.length === 0 ? (
               <tr>
-                <td colSpan={9} className="px-4 py-8 text-center text-sm text-muted-foreground">
+                <td colSpan={11} className="px-4 py-8 text-center text-sm text-muted-foreground">
                   {hasActiveFilters ? 'No devices match your filters.' : 'No devices found.'}
                 </td>
               </tr>
@@ -522,16 +544,34 @@ export default function PatchComplianceView({ ringId }: PatchComplianceViewProps
                         </span>
                       ) : device.criticalMissing > 0 ? (
                         <span className="inline-flex items-center rounded-full border border-red-500/40 bg-red-500/10 px-2 py-0.5 text-xs font-medium text-red-700">
-                          {device.pendingPatches} missing
+                          {device.pendingPatches} outstanding
                         </span>
                       ) : (
                         <span className="inline-flex items-center rounded-full border border-orange-500/40 bg-orange-500/10 px-2 py-0.5 text-xs font-medium text-orange-700">
-                          {device.pendingPatches} missing
+                          {device.pendingPatches} outstanding
                         </span>
                       )}
                     </td>
                     <td className="px-3 py-2.5 tabular-nums">
-                      {device.osMissing > 0 ? device.osMissing : <span className="text-muted-foreground">—</span>}
+                      {device.approvedMissing > 0 ? (
+                        <span className="inline-flex items-center rounded-full border border-green-500/40 bg-green-500/10 px-2 py-0.5 text-xs font-medium text-green-700">
+                          {device.approvedMissing}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground">-</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2.5 tabular-nums">
+                      {device.unapprovedMissing > 0 ? (
+                        <span className="inline-flex items-center rounded-full border border-orange-500/40 bg-orange-500/10 px-2 py-0.5 text-xs font-medium text-orange-700">
+                          {device.unapprovedMissing}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground">-</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2.5 tabular-nums">
+                      {device.osMissing > 0 ? device.osMissing : <span className="text-muted-foreground">-</span>}
                     </td>
                     <td className="px-3 py-2.5 tabular-nums">
                       {device.thirdPartyMissing > 0 ? (
@@ -539,7 +579,7 @@ export default function PatchComplianceView({ ringId }: PatchComplianceViewProps
                           {device.thirdPartyMissing}
                         </span>
                       ) : (
-                        <span className="text-muted-foreground">—</span>
+                        <span className="text-muted-foreground">-</span>
                       )}
                     </td>
                     <td className="px-3 py-2.5">
@@ -548,7 +588,7 @@ export default function PatchComplianceView({ ringId }: PatchComplianceViewProps
                           {device.criticalMissing}
                         </span>
                       ) : (
-                        <span className="text-muted-foreground">—</span>
+                        <span className="text-muted-foreground">-</span>
                       )}
                     </td>
                     <td className="px-3 py-2.5 text-xs text-muted-foreground" title={lastActivity(device.lastInstalledAt, device.lastScannedAt).tooltip}>
@@ -561,7 +601,7 @@ export default function PatchComplianceView({ ringId }: PatchComplianceViewProps
                           Yes
                         </span>
                       ) : (
-                        <span className="text-muted-foreground">—</span>
+                        <span className="text-muted-foreground">-</span>
                       )}
                     </td>
                     <td className="px-3 py-2.5">

--- a/apps/web/src/components/patches/patchHelpers.ts
+++ b/apps/web/src/components/patches/patchHelpers.ts
@@ -105,6 +105,8 @@ export type DevicePatchRow = {
   osType: string;
   lastSeenAt?: string;
   pendingPatches: number;
+  approvedMissing: number;
+  unapprovedMissing: number;
   criticalMissing: number;
   importantMissing: number;
   osMissing: number;
@@ -157,6 +159,8 @@ export type DevicePatchNeed = {
   name: string;
   os: string;
   missingCount: number;
+  approvedMissing: number;
+  unapprovedMissing: number;
   criticalCount: number;
   importantCount: number;
   osMissing: number;
@@ -197,6 +201,8 @@ export function normalizeDeviceNeed(raw: Record<string, unknown>, index: number)
     name: String(name),
     os: String(os),
     missingCount: toNumber(raw.missingCount ?? raw.missing ?? raw.patchesMissing),
+    approvedMissing: toNumber(raw.approvedMissing ?? raw.approved_missing ?? 0),
+    unapprovedMissing: toNumber(raw.unapprovedMissing ?? raw.unapproved_missing ?? 0),
     criticalCount: toNumber(raw.criticalCount ?? raw.critical ?? raw.criticalMissing),
     importantCount: toNumber(raw.importantCount ?? raw.important ?? raw.importantMissing),
     osMissing: toNumber(raw.osMissing ?? raw.os_missing ?? 0),

--- a/apps/web/src/components/patches/useBulkActions.test.ts
+++ b/apps/web/src/components/patches/useBulkActions.test.ts
@@ -1,0 +1,96 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useBulkActions } from './useBulkActions';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('@/lib/navigation', () => ({
+  navigateTo: vi.fn(),
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+const deviceId = '11111111-1111-1111-1111-111111111111';
+
+describe('useBulkActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('surfaces a distinct approval message when install returns 409', async () => {
+    fetchMock.mockResolvedValue(
+      makeJsonResponse(
+        { error: 'Only approved patches can be installed', unapprovedPatchIds: ['p-1'] },
+        false,
+        409
+      )
+    );
+
+    const { result } = renderHook(() =>
+      useBulkActions(new Set([deviceId]), vi.fn(), vi.fn(), {
+        resolveInstallPatchIds: async () => ({ patchIds: ['p-1'] }),
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleBulkInstall([deviceId]);
+    });
+
+    await waitFor(() => {
+      expect(result.current.bulkError).toMatch(/pending approval, refresh and retry/i);
+    });
+    // Should NOT be reported as a generic failure.
+    expect(result.current.bulkError).not.toMatch(/^Install failed/);
+  });
+
+  it('reports patches skipped pending approval in the success message', async () => {
+    fetchMock.mockResolvedValue(
+      makeJsonResponse({ success: true, commandId: 'cmd-1' })
+    );
+
+    const { result } = renderHook(() =>
+      useBulkActions(new Set([deviceId]), vi.fn(), vi.fn(), {
+        resolveInstallPatchIds: async () => ({ patchIds: ['p-1'], skippedPendingApproval: 2 }),
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleBulkInstall([deviceId]);
+    });
+
+    await waitFor(() => {
+      expect(result.current.bulkSuccess).toMatch(/queued on 1 device/i);
+    });
+    expect(result.current.bulkSuccess).toMatch(/2 patches across 1 device skipped pending approval/i);
+  });
+
+  it('falls back to a generic failure message for non-409 errors', async () => {
+    fetchMock.mockResolvedValue(makeJsonResponse({ error: 'boom' }, false, 500));
+
+    const { result } = renderHook(() =>
+      useBulkActions(new Set([deviceId]), vi.fn(), vi.fn(), {
+        resolveInstallPatchIds: async () => ({ patchIds: ['p-1'] }),
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleBulkInstall([deviceId]);
+    });
+
+    await waitFor(() => {
+      expect(result.current.bulkError).toMatch(/Install failed on 1 of 1 devices/i);
+    });
+  });
+});

--- a/apps/web/src/components/patches/useBulkActions.ts
+++ b/apps/web/src/components/patches/useBulkActions.ts
@@ -2,9 +2,23 @@ import { useState, useCallback } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 
-type UseBulkActionsOptions = {
-  resolveInstallPatchIds?: (deviceId: string) => Promise<string[]>;
+export type ResolvedInstallPatchIds = {
+  /** Patch ids approved for install. */
+  patchIds: string[];
+  /** Count of pending patches dropped because they are awaiting approval. */
+  skippedPendingApproval?: number;
 };
+
+type UseBulkActionsOptions = {
+  resolveInstallPatchIds?: (deviceId: string) => Promise<string[] | ResolvedInstallPatchIds>;
+};
+
+function normalizeResolved(value: string[] | ResolvedInstallPatchIds): ResolvedInstallPatchIds {
+  if (Array.isArray(value)) {
+    return { patchIds: value };
+  }
+  return { patchIds: value.patchIds, skippedPendingApproval: value.skippedPendingApproval };
+}
 
 export function useBulkActions(
   selectedIds: Set<string>,
@@ -50,11 +64,25 @@ export function useBulkActions(
     setBulkSuccess(undefined);
     const failed: string[] = [];
     const skipped: string[] = [];
+    // Devices that hit a 409 approval-state failure on install.
+    const approvalFailed: string[] = [];
+    // Distinct generic (non-approval) error messages read off the response body.
+    const genericErrors = new Set<string>();
+    // Count of patches silently dropped because they were awaiting approval,
+    // and how many devices had at least one such patch dropped.
+    let patchesSkippedPendingApproval = 0;
+    let devicesWithSkippedPatches = 0;
     try {
       for (const deviceId of ids) {
         let patchIds: string[] = [];
         if (resolveInstallPatchIds) {
-          patchIds = await resolveInstallPatchIds(deviceId);
+          const resolved = normalizeResolved(await resolveInstallPatchIds(deviceId));
+          patchIds = resolved.patchIds;
+          const droppedHere = resolved.skippedPendingApproval ?? 0;
+          if (droppedHere > 0) {
+            patchesSkippedPendingApproval += droppedHere;
+            devicesWithSkippedPatches += 1;
+          }
           if (patchIds.length === 0) {
             skipped.push(deviceId);
             continue;
@@ -67,25 +95,46 @@ export function useBulkActions(
         });
         if (!response.ok) {
           if (response.status === 401) { void navigateTo('/login', { replace: true }); return; }
-          failed.push(deviceId);
+          // Read the error body so we can distinguish an approval-state
+          // rejection (409) from a generic failure. Be defensive: the body
+          // may not be JSON.
+          const body = await response.json().catch(() => null) as
+            | { error?: string; unapprovedPatchIds?: unknown; missingPatchIds?: unknown }
+            | null;
+          if (response.status === 409) {
+            approvalFailed.push(deviceId);
+          } else {
+            failed.push(deviceId);
+            if (body && typeof body.error === 'string' && body.error.trim()) {
+              genericErrors.add(body.error.trim());
+            }
+          }
         }
       }
 
-      const queuedCount = ids.length - failed.length - skipped.length;
+      const queuedCount = ids.length - failed.length - approvalFailed.length - skipped.length;
       if (queuedCount > 0) {
-        setBulkSuccess(`Patch install queued on ${queuedCount} ${queuedCount === 1 ? 'device' : 'devices'}`);
+        let success = `Patch install queued on ${queuedCount} ${queuedCount === 1 ? 'device' : 'devices'}`;
+        if (patchesSkippedPendingApproval > 0) {
+          success += `; ${patchesSkippedPendingApproval} ${patchesSkippedPendingApproval === 1 ? 'patch' : 'patches'} across ${devicesWithSkippedPatches} ${devicesWithSkippedPatches === 1 ? 'device' : 'devices'} skipped pending approval`;
+        }
+        setBulkSuccess(success);
       }
 
-      if (failed.length > 0 || skipped.length > 0) {
+      if (failed.length > 0 || approvalFailed.length > 0 || skipped.length > 0) {
         const parts: string[] = [];
+        if (approvalFailed.length > 0) {
+          parts.push(`${approvalFailed.length} of ${ids.length} devices had patches pending approval, refresh and retry`);
+        }
         if (failed.length > 0) {
-          parts.push(`Install failed on ${failed.length} of ${ids.length} devices`);
+          const detail = genericErrors.size > 0 ? ` (${[...genericErrors].join('; ')})` : '';
+          parts.push(`Install failed on ${failed.length} of ${ids.length} devices${detail}`);
         }
         if (skipped.length > 0) {
           parts.push(`Skipped ${skipped.length} ${skipped.length === 1 ? 'device' : 'devices'} with no approved pending patches`);
         }
         setBulkError(parts.join('. '));
-      } else if (queuedCount === 0) {
+      } else if (queuedCount === 0 && patchesSkippedPendingApproval === 0) {
         setBulkError('No approved pending patches found for the selected devices');
       }
 

--- a/apps/web/src/components/patches/useBulkActions.ts
+++ b/apps/web/src/components/patches/useBulkActions.ts
@@ -82,11 +82,11 @@ export function useBulkActions(
           parts.push(`Install failed on ${failed.length} of ${ids.length} devices`);
         }
         if (skipped.length > 0) {
-          parts.push(`Skipped ${skipped.length} ${skipped.length === 1 ? 'device' : 'devices'} with no installable pending patches`);
+          parts.push(`Skipped ${skipped.length} ${skipped.length === 1 ? 'device' : 'devices'} with no approved pending patches`);
         }
         setBulkError(parts.join('. '));
       } else if (queuedCount === 0) {
-        setBulkError('No installable pending patches found for the selected devices');
+        setBulkError('No approved pending patches found for the selected devices');
       }
 
       clearSelection();


### PR DESCRIPTION
## Summary

- Split patch compliance counts into approved pending patches and pending approval patches.
- Update the compliance table copy so pending/outstanding patches are not confused with approved patches.
- Enforce the approval gate in the device patch install endpoint so unapproved patch IDs cannot be queued.

## Why

The compliance page could show devices with pending patches while the Patches tab showed no approved patches. That was logically possible, but the UI copy made it look inconsistent and the bulk install path could still try to install unapproved pending patches.

## Validation

- `corepack pnpm --filter=@breeze/api exec vitest run src/routes/devices/patches.test.ts src/routes/patches/compliance.test.ts --config vitest.config.ts`
- `corepack pnpm --filter=@breeze/web exec vitest run src/components/patches/PatchComplianceView.test.tsx --config vitest.config.ts`
- `corepack pnpm --filter=@breeze/web exec tsc --noEmit --project tsconfig.json`

API `tsc --noEmit` was also attempted, but it still fails on unrelated existing type errors in email, archiver imports, and urlSafety tests.
