### PR TITLE
fix(users): store avatars as bytea in DB + login hydration & badge-403 polish

### DIFF
--- a/apps/api/migrations/2026-06-11-j-avatar-bytea-columns.sql
+++ b/apps/api/migrations/2026-06-11-j-avatar-bytea-columns.sql
@@ -1,0 +1,37 @@
+-- Move user avatars from the filesystem (/data/avatars/<id>.<ext>) into the
+-- database as a bytea blob on the users row. The old filesystem path depended
+-- on a writable `api_data` volume owned by the API's runtime uid; when that
+-- volume was root-owned the upload failed with EACCES and a 500. Storing the
+-- bytes in Postgres removes the volume dependency and works across replicas.
+--
+-- Columns:
+--   avatar_data       bytea  — the raw image bytes (PNG/JPEG/WebP, ≤ 5 MB).
+--                              Postgres TOASTs this out-of-line so the base row
+--                              stays lean and SELECTs that don't reference it
+--                              don't pay for it.
+--   avatar_mime       text   — sniffed content type (image/png|jpeg|webp).
+--   avatar_updated_at timestamptz — bump on each write; powers a cheap weak
+--                              ETag (size + mtime) without hashing the bytes.
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar_data bytea;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar_mime text;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar_updated_at timestamptz;
+
+-- Any pre-existing avatar_url pointed at a filesystem-backed avatar that this
+-- migration does NOT carry over (the bytes stay on the old volume and are not
+-- migrated). Clear the now-dangling URLs so the UI falls back to initials
+-- instead of rendering a broken image / 404; affected users simply re-upload.
+-- Report the count so the operation is visible in the Postgres log.
+DO $$
+DECLARE
+  n integer;
+BEGIN
+  UPDATE users
+     SET avatar_url = NULL
+   WHERE avatar_url IS NOT NULL
+     AND avatar_data IS NULL;
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN
+    RAISE WARNING 'cleared % dangling filesystem avatar_url(s) during bytea migration', n;
+  END IF;
+END $$;

--- a/apps/api/migrations/2026-06-11-j-avatar-bytea-columns.sql
+++ b/apps/api/migrations/2026-06-11-j-avatar-bytea-columns.sql
@@ -6,9 +6,9 @@
 --
 -- Columns:
 --   avatar_data       bytea  — the raw image bytes (PNG/JPEG/WebP, ≤ 5 MB).
---                              Postgres TOASTs this out-of-line so the base row
---                              stays lean and SELECTs that don't reference it
---                              don't pay for it.
+--                              Postgres TOASTs values over ~2 KB out-of-line,
+--                              so the base row stays lean; size-only reads use
+--                              octet_length() to avoid pulling the blob.
 --   avatar_mime       text   — sniffed content type (image/png|jpeg|webp).
 --   avatar_updated_at timestamptz — bump on each write; powers a cheap weak
 --                              ETag (size + mtime) without hashing the bytes.
@@ -17,21 +17,21 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar_data bytea;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar_mime text;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar_updated_at timestamptz;
 
--- Any pre-existing avatar_url pointed at a filesystem-backed avatar that this
--- migration does NOT carry over (the bytes stay on the old volume and are not
--- migrated). Clear the now-dangling URLs so the UI falls back to initials
--- instead of rendering a broken image / 404; affected users simply re-upload.
--- Report the count so the operation is visible in the Postgres log.
+-- A pre-existing INTERNAL avatar_url ('/api/v1/users/<id>/avatar') pointed at
+-- a filesystem-backed avatar that this migration does NOT carry over (the
+-- bytes stay on the old volume). Clear those now-dangling URLs so the UI falls
+-- back to initials instead of a broken image; affected users simply re-upload.
+-- External URLs (the pre-upload era let users set arbitrary avatar URLs) are
+-- deliberately left alone — they still resolve.
+-- Always log the count (even 0) so the run leaves a forensic trail.
 DO $$
 DECLARE
   n integer;
 BEGIN
   UPDATE users
      SET avatar_url = NULL
-   WHERE avatar_url IS NOT NULL
+   WHERE avatar_url LIKE '/api/v1/users/%/avatar'
      AND avatar_data IS NULL;
   GET DIAGNOSTICS n = ROW_COUNT;
-  IF n > 0 THEN
-    RAISE WARNING 'cleared % dangling filesystem avatar_url(s) during bytea migration', n;
-  END IF;
+  RAISE WARNING 'cleared % dangling filesystem avatar_url(s) during bytea migration', n;
 END $$;

--- a/apps/api/src/__tests__/integration/avatar-bytea-roundtrip.integration.test.ts
+++ b/apps/api/src/__tests__/integration/avatar-bytea-roundtrip.integration.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Avatar bytea storage — real-driver round-trip + RLS enforcement.
+ *
+ * Migration under test: 2026-06-11-j-avatar-bytea-columns.sql
+ * Service under test:   services/avatarStorage.ts (DB-backed rewrite)
+ *
+ * The route tests in routes/users.test.ts mock the avatarStorage I/O behind an
+ * in-memory Map, so nothing there proves that:
+ *   1. postgres.js round-trips `bytea` byte-exactly as a Node Buffer (the
+ *      schema's customType assumes Buffer in/out), and
+ *   2. the UPDATE/SELECT on one's own `users` row actually passes the table's
+ *      RLS policies as the unprivileged breeze_app role — the exact failure
+ *      mode custom_field_definitions hit (#1257): policies looked fine in
+ *      metadata, real writes 42501'd.
+ * These tests run through the REAL driver inside withDbAccessContext.
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { users } from '../../db/schema';
+import { createPartner, createUser } from './db-utils';
+import { deleteAvatar, readAvatarBuffer, statAvatar, writeAvatar } from '../../services/avatarStorage';
+
+// Valid PNG magic + every byte value 0..255 — catches any encoding/escaping
+// mangling in the bytea path (e.g. the text::bytea class of bug from #994).
+const PNG_BYTES = Buffer.concat([
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  Buffer.from(Array.from({ length: 256 }, (_, i) => i)),
+]);
+
+const JPEG_BYTES = Buffer.concat([
+  Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+  Buffer.alloc(64, 0x42),
+]);
+
+/** Request-shaped context for an MSP-staff user acting as themselves. */
+function selfContext(partnerId: string, userId: string): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: [],
+    accessiblePartnerIds: [partnerId],
+    userId,
+  };
+}
+
+describe('avatar bytea round-trip (real driver, RLS enforced)', () => {
+  it('write → stat → read → delete round-trips byte-exactly in the user\'s own context', async () => {
+    const partner = await createPartner();
+    const user = await createUser({ partnerId: partner.id });
+    const ctx = selfContext(partner.id, user.id);
+
+    await withDbAccessContext(ctx, async () => {
+      const written = await writeAvatar(user.id, 'image/png', PNG_BYTES);
+      expect(written).not.toBeNull();
+      expect(written!.avatarUrl).toBe(`/api/v1/users/${user.id}/avatar`);
+      expect(written!.size).toBe(PNG_BYTES.length);
+
+      // statAvatar computes size via octet_length — must match without
+      // transferring the blob.
+      const stat = await statAvatar(user.id);
+      expect(stat).not.toBeNull();
+      expect(stat!.mime).toBe('image/png');
+      expect(stat!.size).toBe(PNG_BYTES.length);
+      expect(stat!.mtimeMs).toBeGreaterThan(0);
+
+      const opened = await readAvatarBuffer(user.id);
+      expect(opened).not.toBeNull();
+      expect(Buffer.isBuffer(opened!.buffer)).toBe(true);
+      expect(opened!.buffer.equals(PNG_BYTES)).toBe(true);
+      expect(opened!.mime).toBe('image/png');
+
+      // avatar_url landed on the row in the same UPDATE.
+      const [row] = await db.select({ avatarUrl: users.avatarUrl }).from(users).where(eq(users.id, user.id)).limit(1);
+      expect(row?.avatarUrl).toBe(`/api/v1/users/${user.id}/avatar`);
+
+      expect(await deleteAvatar(user.id)).toBe(true);
+      expect(await statAvatar(user.id)).toBeNull();
+      const [after] = await db.select({ avatarUrl: users.avatarUrl }).from(users).where(eq(users.id, user.id)).limit(1);
+      expect(after?.avatarUrl).toBeNull();
+    });
+  });
+
+  it('overwriting replaces bytes and mime in place', async () => {
+    const partner = await createPartner();
+    const user = await createUser({ partnerId: partner.id });
+    const ctx = selfContext(partner.id, user.id);
+
+    await withDbAccessContext(ctx, async () => {
+      await writeAvatar(user.id, 'image/png', PNG_BYTES);
+      await writeAvatar(user.id, 'image/jpeg', JPEG_BYTES);
+
+      const opened = await readAvatarBuffer(user.id);
+      expect(opened!.mime).toBe('image/jpeg');
+      expect(opened!.buffer.equals(JPEG_BYTES)).toBe(true);
+    });
+  });
+
+  it('RLS fails closed: a foreign-partner context sees no avatar and cannot write one', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const userA = await createUser({ partnerId: partnerA.id });
+    const userB = await createUser({ partnerId: partnerB.id });
+
+    await withDbAccessContext(selfContext(partnerA.id, userA.id), async () => {
+      await writeAvatar(userA.id, 'image/png', PNG_BYTES);
+    });
+
+    // userB (different partner) can neither see userA's avatar nor write over
+    // it — the UPDATE matches no visible row and writeAvatar reports null.
+    await withDbAccessContext(selfContext(partnerB.id, userB.id), async () => {
+      expect(await statAvatar(userA.id)).toBeNull();
+      expect(await readAvatarBuffer(userA.id)).toBeNull();
+      expect(await writeAvatar(userA.id, 'image/jpeg', JPEG_BYTES)).toBeNull();
+    });
+
+    // userA's avatar is untouched.
+    await withDbAccessContext(selfContext(partnerA.id, userA.id), async () => {
+      const opened = await readAvatarBuffer(userA.id);
+      expect(opened!.mime).toBe('image/png');
+      expect(opened!.buffer.equals(PNG_BYTES)).toBe(true);
+    });
+  });
+});

--- a/apps/api/src/db/schema/users.ts
+++ b/apps/api/src/db/schema/users.ts
@@ -1,5 +1,15 @@
-import { pgTable, uuid, varchar, text, timestamp, boolean, jsonb, pgEnum } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, varchar, text, timestamp, boolean, jsonb, pgEnum, customType } from 'drizzle-orm/pg-core';
 import { partners, organizations } from './orgs';
+
+// Postgres `bytea` mapped to a Node Buffer. postgres.js returns bytea columns
+// as Buffers and accepts Buffers/Uint8Arrays on write, so this is a thin
+// pass-through. Used for small, capped binary blobs (avatars ≤ 5 MB) stored
+// inline; Postgres TOASTs large values out-of-line so the base row stays lean.
+export const bytea = customType<{ data: Buffer; driverData: Buffer }>({
+  dataType() {
+    return 'bytea';
+  },
+});
 
 export const userStatusEnum = pgEnum('user_status', ['active', 'invited', 'disabled']);
 export const roleScopeEnum = pgEnum('role_scope', ['system', 'partner', 'organization']);
@@ -30,7 +40,14 @@ export const users = pgTable('users', {
   // other reason (compromise, off-boarding, manual admin action) and unsuspend
   // must leave them alone. See #917 (L-5).
   disabledReason: text('disabled_reason'),
+  // avatarUrl holds the internal serving URL (`/api/v1/users/<id>/avatar`) when
+  // an avatar exists, NULL otherwise. The bytes live in avatarData (bytea) on
+  // this same row — stored in the DB rather than a filesystem volume so uploads
+  // work across replicas and don't depend on volume permissions (#1059).
   avatarUrl: text('avatar_url'),
+  avatarData: bytea('avatar_data'),
+  avatarMime: text('avatar_mime'),
+  avatarUpdatedAt: timestamp('avatar_updated_at'),
   lastLoginAt: timestamp('last_login_at'),
   passwordChangedAt: timestamp('password_changed_at'),
   setupCompletedAt: timestamp('setup_completed_at'),

--- a/apps/api/src/db/schema/users.ts
+++ b/apps/api/src/db/schema/users.ts
@@ -3,8 +3,9 @@ import { partners, organizations } from './orgs';
 
 // Postgres `bytea` mapped to a Node Buffer. postgres.js returns bytea columns
 // as Buffers and accepts Buffers/Uint8Arrays on write, so this is a thin
-// pass-through. Used for small, capped binary blobs (avatars ≤ 5 MB) stored
-// inline; Postgres TOASTs large values out-of-line so the base row stays lean.
+// pass-through. Postgres TOASTs values over ~2 KB out-of-line, so wide blobs
+// don't bloat the base row — but SELECTs naming the column still pay the full
+// read; size-only checks should use octet_length() instead.
 export const bytea = customType<{ data: Buffer; driverData: Buffer }>({
   dataType() {
     return 'bytea';
@@ -47,7 +48,9 @@ export const users = pgTable('users', {
   avatarUrl: text('avatar_url'),
   avatarData: bytea('avatar_data'),
   avatarMime: text('avatar_mime'),
-  avatarUpdatedAt: timestamp('avatar_updated_at'),
+  // timestamptz in the migration — withTimezone must match or db:check-drift
+  // flags it (the sibling users timestamps are legacy timestamp-without-tz).
+  avatarUpdatedAt: timestamp('avatar_updated_at', { withTimezone: true }),
   lastLoginAt: timestamp('last_login_at'),
   passwordChangedAt: timestamp('password_changed_at'),
   setupCompletedAt: timestamp('setup_completed_at'),

--- a/apps/api/src/routes/auth/login.test.ts
+++ b/apps/api/src/routes/auth/login.test.ts
@@ -195,4 +195,38 @@ describe('POST /login — IP allowlist', () => {
     expect(await res.json()).toMatchObject({ error: 'Invalid email or password' });
     expect(createTokenPair).not.toHaveBeenCalled();
   });
+
+  // The web auth store is seeded from THIS payload on password login; the
+  // sidebar gates platform-admin-only nav (deletion requests) on the flag.
+  // If it ever drops out of the payload, platform admins silently lose that
+  // nav (the /users/me copy only reaches the store on a later refresh).
+  it('includes isPlatformAdmin in the success payload', async () => {
+    vi.mocked(db.select).mockReturnValue(selectChain([{
+      id: 'user-1',
+      email: 'admin@msp.com',
+      name: 'Admin User',
+      passwordHash: 'password-hash',
+      status: 'active',
+      mfaEnabled: false,
+      mfaSecret: null,
+      mfaMethod: null,
+      phoneNumber: null,
+      avatarUrl: null,
+      isPlatformAdmin: true,
+    }]) as any);
+
+    const res = await postLogin({ email: 'admin@msp.com', password: 'correct-horse' });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { user: { isPlatformAdmin?: boolean } };
+    expect(body.user.isPlatformAdmin).toBe(true);
+  });
+
+  it('coerces a missing isPlatformAdmin to false in the success payload', async () => {
+    const res = await postLogin({ email: 'admin@msp.com', password: 'correct-horse' });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { user: { isPlatformAdmin?: boolean } };
+    expect(body.user.isPlatformAdmin).toBe(false);
+  });
 });

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -505,7 +505,11 @@ loginRoutes.post('/login', cfAccessLoginMiddleware, zValidator('json', loginSche
       email: user.email,
       name: user.name,
       mfaEnabled: ENABLE_2FA ? user.mfaEnabled : false,
-      avatarUrl: user.avatarUrl
+      avatarUrl: user.avatarUrl,
+      // The web sidebar gates platform-admin-only nav (and its badge fetch) on
+      // this flag from the auth store, which is seeded from THIS payload on
+      // password login — omit it and platform admins lose that nav entirely.
+      isPlatformAdmin: user.isPlatformAdmin === true
     },
     tokens: toPublicTokens(tokens),
     mfaRequired: false,

--- a/apps/api/src/routes/auth/mfa.ts
+++ b/apps/api/src/routes/auth/mfa.ts
@@ -252,7 +252,12 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
         id: user.id,
         email: user.email,
         name: user.name,
-        mfaEnabled: true
+        mfaEnabled: true,
+        avatarUrl: user.avatarUrl,
+        // Mirrors the password-login payload — the auth store is seeded from
+        // whichever of the two completes the login, and the sidebar gates
+        // platform-admin-only nav on this flag.
+        isPlatformAdmin: user.isPlatformAdmin === true
       },
       tokens: toPublicTokens(tokens),
       mfaRequired: false,

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,13 +1,38 @@
-import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
-import { mkdtempSync, rmSync, existsSync } from 'fs';
-import { tmpdir } from 'os';
-import { join } from 'path';
 
-// Set the avatar storage dir to a per-test-run tmp path BEFORE importing the
-// service (the service reads process.env.AVATAR_STORAGE_PATH at module load).
-const TMP_AVATAR_DIR = mkdtempSync(join(tmpdir(), 'breeze-avatar-test-'));
-process.env.AVATAR_STORAGE_PATH = TMP_AVATAR_DIR;
+// Avatars are stored as a bytea blob on the user row via avatarStorage, which
+// hits the DB. The DB is fully mocked here, so back the I/O functions with a
+// tiny in-memory store that mimics the POST→GET round-trip. The pure helpers
+// (sniffImageMime, weakEtagFor, MAX_AVATAR_SIZE_BYTES, …) stay real so upload
+// validation is exercised for real.
+const { avatarStore } = vi.hoisted(() => ({
+  avatarStore: new Map<string, { mime: 'image/png' | 'image/jpeg' | 'image/webp'; data: Buffer }>(),
+}));
+
+vi.mock('../services/avatarStorage', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/avatarStorage')>();
+  const FIXED_MTIME = 1_700_000_000_000;
+  return {
+    ...actual,
+    writeAvatar: vi.fn(async (userId: string, mime: 'image/png' | 'image/jpeg' | 'image/webp', data: Buffer) => {
+      avatarStore.set(userId, { mime, data });
+      return { ext: actual.extForMime(mime), size: data.length, avatarUrl: `/api/v1/users/${userId}/avatar`, updatedAt: new Date() };
+    }),
+    statAvatar: vi.fn(async (userId: string) => {
+      const a = avatarStore.get(userId);
+      return a ? { mime: a.mime, size: a.data.length, mtimeMs: FIXED_MTIME } : null;
+    }),
+    readAvatarBuffer: vi.fn(async (userId: string) => {
+      const a = avatarStore.get(userId);
+      return a ? { buffer: a.data, mime: a.mime, size: a.data.length, mtimeMs: FIXED_MTIME } : null;
+    }),
+    deleteAvatar: vi.fn(async (userId: string) => {
+      avatarStore.delete(userId);
+      return true;
+    }),
+  };
+});
 
 import { userRoutes } from './users';
 
@@ -194,14 +219,9 @@ import { terminateUserRemoteSessions } from '../services/remoteSessionTeardown';
 describe('user routes', () => {
   let app: Hono;
 
-  afterAll(() => {
-    if (existsSync(TMP_AVATAR_DIR)) {
-      rmSync(TMP_AVATAR_DIR, { recursive: true, force: true });
-    }
-  });
-
   beforeEach(() => {
     vi.clearAllMocks();
+    avatarStore.clear();
     // clearAllMocks only clears call history — it does NOT drain queued
     // mockReturnValueOnce implementations or reset mockReturnValue. Re-seed the
     // db builders to safe defaults so each test starts from a clean chain and is
@@ -452,6 +472,53 @@ describe('user routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.success).toBe(true);
+    });
+  });
+
+  describe('GET /users/me', () => {
+    beforeEach(() => {
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          scope: 'partner',
+          partnerId: 'partner-123',
+          orgId: null,
+          user: { id: 'user-123', email: 'admin@example.com' }
+        });
+        return next();
+      });
+    });
+
+    // The web sidebar gates platform-admin-only nav (account-deletion-requests)
+    // and skips its badge fetch off this flag; if it ever stops being returned,
+    // that fetch starts 403-spamming the console for every ordinary user again.
+    it('returns isPlatformAdmin so the web can gate platform-admin-only nav', async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: 'user-123',
+              email: 'admin@example.com',
+              name: 'Admin',
+              avatarUrl: null,
+              status: 'active',
+              mfaEnabled: false,
+              isPlatformAdmin: true,
+              createdAt: new Date(),
+              lastLoginAt: new Date(),
+              setupCompletedAt: new Date(),
+              passwordChangedAt: new Date(),
+              preferences: {}
+            }])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/users/me', {
+        headers: { Authorization: 'Bearer token' }
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json() as { isPlatformAdmin?: boolean };
+      expect(body.isPlatformAdmin).toBe(true);
     });
   });
 
@@ -1626,8 +1693,8 @@ describe('user routes', () => {
         expect(res.status).toBe(200);
       }
 
-      it('blocks a cross-tenant read — another user not in the caller\'s scope returns 404 even though the avatar file exists', async () => {
-        // A real avatar file now exists on disk for other-456.
+      it('blocks a cross-tenant read — another user not in the caller\'s scope returns 404 even though the avatar exists', async () => {
+        // An avatar is stored for other-456 (in the in-memory backing store).
         await uploadAvatarFor(OTHER_ID, 'partner-999');
 
         // Caller is in a DIFFERENT partner; getScopedUser resolves to nothing.

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -215,6 +215,8 @@ import { clearPermissionCache, getUserPermissions } from '../services/permission
 import { authMiddleware } from '../middleware/auth';
 import { revokeAllUserTokens } from '../services/tokenRevocation';
 import { terminateUserRemoteSessions } from '../services/remoteSessionTeardown';
+// Mocked above — imported to drive failure paths via mockResolvedValueOnce.
+import { writeAvatar, deleteAvatar, readAvatarBuffer } from '../services/avatarStorage';
 
 describe('user routes', () => {
   let app: Hono;
@@ -1540,16 +1542,6 @@ describe('user routes', () => {
     // SVG with a small XML preamble
     const SVG_BYTES = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>', 'utf-8');
 
-    function makeUpdateMock(returning: unknown[]) {
-      vi.mocked(db.update).mockReturnValue({
-        set: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            returning: vi.fn().mockResolvedValue(returning)
-          })
-        })
-      } as any);
-    }
-
     function makeMultipart(field: string, bytes: Buffer, mime: string, filename: string): { body: BodyInit; headers: HeadersInit } {
       const formData = new FormData();
       // Buffer's polymorphic ArrayBufferLike confuses the Blob constructor type;
@@ -1568,7 +1560,6 @@ describe('user routes', () => {
 
     describe('POST /users/me/avatar', () => {
       it('accepts a PNG upload and writes /api/v1/users/<id>/avatar to users.avatar_url', async () => {
-        makeUpdateMock([{ id: ME_ID, avatarUrl: `/api/v1/users/${ME_ID}/avatar`, updatedAt: new Date() }]);
 
         const { body, headers } = makeMultipart('file', PNG_BYTES, 'image/png', 'a.png');
         const res = await app.request('/users/me/avatar', { method: 'POST', body, headers });
@@ -1581,7 +1572,6 @@ describe('user routes', () => {
       });
 
       it('accepts a JPEG upload', async () => {
-        makeUpdateMock([{ id: ME_ID, avatarUrl: `/api/v1/users/${ME_ID}/avatar`, updatedAt: new Date() }]);
         const { body, headers } = makeMultipart('file', JPEG_BYTES, 'image/jpeg', 'a.jpg');
         const res = await app.request('/users/me/avatar', { method: 'POST', body, headers });
         expect(res.status).toBe(200);
@@ -1590,7 +1580,6 @@ describe('user routes', () => {
       });
 
       it('accepts a WebP upload', async () => {
-        makeUpdateMock([{ id: ME_ID, avatarUrl: `/api/v1/users/${ME_ID}/avatar`, updatedAt: new Date() }]);
         const { body, headers } = makeMultipart('file', WEBP_BYTES, 'image/webp', 'a.webp');
         const res = await app.request('/users/me/avatar', { method: 'POST', body, headers });
         expect(res.status).toBe(200);
@@ -1627,7 +1616,6 @@ describe('user routes', () => {
 
     describe('DELETE /users/me/avatar', () => {
       it('clears avatar_url and returns avatarUrl: null', async () => {
-        makeUpdateMock([{ id: ME_ID, avatarUrl: null }]);
         const res = await app.request('/users/me/avatar', { method: 'DELETE' });
         expect(res.status).toBe(200);
         const data = await res.json();
@@ -1637,7 +1625,6 @@ describe('user routes', () => {
 
     describe('POST then GET roundtrip', () => {
       it('uploads a PNG and serves it back from GET /users/:id/avatar with image/png + cache headers', async () => {
-        makeUpdateMock([{ id: ME_ID, avatarUrl: `/api/v1/users/${ME_ID}/avatar`, updatedAt: new Date() }]);
 
         const { body, headers } = makeMultipart('file', PNG_BYTES, 'image/png', 'a.png');
         const postRes = await app.request('/users/me/avatar', { method: 'POST', body, headers });
@@ -1650,6 +1637,60 @@ describe('user routes', () => {
         expect(getRes.headers.get('etag')).toMatch(/^W\//);
         const body2 = Buffer.from(await getRes.arrayBuffer());
         expect(body2.equals(PNG_BYTES)).toBe(true);
+      });
+
+      it('answers a conditional GET with 304 when If-None-Match matches, and 200 when it does not', async () => {
+        const { body, headers } = makeMultipart('file', PNG_BYTES, 'image/png', 'a.png');
+        await app.request('/users/me/avatar', { method: 'POST', body, headers });
+
+        const first = await app.request(`/users/${ME_ID}/avatar`, { method: 'GET' });
+        const etag = first.headers.get('etag')!;
+
+        const hit = await app.request(`/users/${ME_ID}/avatar`, {
+          method: 'GET',
+          headers: { 'If-None-Match': etag },
+        });
+        expect(hit.status).toBe(304);
+        expect(hit.headers.get('etag')).toBe(etag);
+        expect((await hit.arrayBuffer()).byteLength).toBe(0);
+
+        const miss = await app.request(`/users/${ME_ID}/avatar`, {
+          method: 'GET',
+          headers: { 'If-None-Match': 'W/"somethingelse"' },
+        });
+        expect(miss.status).toBe(200);
+      });
+    });
+
+    describe('avatar storage failure paths', () => {
+      it('POST returns 500 when the write matches no row (deleted/RLS-invisible user)', async () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        vi.mocked(writeAvatar).mockResolvedValueOnce(null);
+
+        const { body, headers } = makeMultipart('file', PNG_BYTES, 'image/png', 'a.png');
+        const res = await app.request('/users/me/avatar', { method: 'POST', body, headers });
+        expect(res.status).toBe(500);
+      });
+
+      it('DELETE returns 500 when the clear matches no row', async () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        vi.mocked(deleteAvatar).mockResolvedValueOnce(false);
+
+        const res = await app.request('/users/me/avatar', { method: 'DELETE' });
+        expect(res.status).toBe(500);
+      });
+
+      it('GET returns 500 (not 404) when the read fails after a successful stat', async () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        const { body, headers } = makeMultipart('file', PNG_BYTES, 'image/png', 'a.png');
+        await app.request('/users/me/avatar', { method: 'POST', body, headers });
+
+        // statAvatar succeeds (avatar exists); the subsequent read races a
+        // delete (or hits corrupted mime) and returns null.
+        vi.mocked(readAvatarBuffer).mockResolvedValueOnce(null);
+
+        const res = await app.request(`/users/${ME_ID}/avatar`, { method: 'GET' });
+        expect(res.status).toBe(500);
       });
     });
 
@@ -1687,7 +1728,6 @@ describe('user routes', () => {
 
       async function uploadAvatarFor(userId: string, partnerId: string) {
         authAs(userId, partnerId);
-        makeUpdateMock([{ id: userId, avatarUrl: `/api/v1/users/${userId}/avatar`, updatedAt: new Date() }]);
         const { body, headers } = makeMultipart('file', PNG_BYTES, 'image/png', 'a.png');
         const res = await app.request('/users/me/avatar', { method: 'POST', body, headers });
         expect(res.status).toBe(200);

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -719,17 +719,26 @@ userRoutes.post(
       );
     }
 
-    // writeAvatar persists the bytes + mime + avatar_url atomically on the user
-    // row and returns the serving URL / size / updatedAt.
+    // avatar_url is set inside writeAvatar (single UPDATE) — no follow-up
+    // users update here.
     let written;
     try {
       written = await writeAvatar(userId, sniffedMime, buffer);
     } catch (err) {
-      console.error('[users/avatar] failed to write avatar:', err);
+      // This catch runs before app.onError, which would otherwise be the only
+      // Sentry reporter — capture explicitly or storage failures go dark
+      // (how the original EACCES bug stayed invisible).
+      console.error(`[users/avatar] failed to write avatar (user ${userId}, ${buffer.length} bytes):`, err);
+      captureException(err, c);
       return c.json({ error: 'Failed to store avatar' }, 500);
     }
 
     if (!written) {
+      // Own row missing or invisible under RLS — either way an anomaly for an
+      // authenticated caller; log it so the 500 is traceable.
+      const err = new Error(`[users/avatar] write matched no row for authenticated user ${userId}`);
+      console.error(err.message);
+      captureException(err, c);
       return c.json({ error: 'Failed to update profile' }, 500);
     }
 
@@ -764,10 +773,13 @@ userRoutes.delete('/me/avatar', async (c) => {
   const auth = c.get('auth');
   const userId = auth.user.id;
 
-  // Clears the bytes, mime, timestamp, and avatar_url on the user row in one
-  // write. Returns false only if the row doesn't exist.
   const cleared = await deleteAvatar(userId);
   if (!cleared) {
+    // Own row missing or invisible under RLS — anomaly for an authenticated
+    // caller; log it so the 500 is traceable.
+    const err = new Error(`[users/avatar] delete matched no row for authenticated user ${userId}`);
+    console.error(err.message);
+    captureException(err, c);
     return c.json({ error: 'Failed to clear avatar' }, 500);
   }
 
@@ -829,13 +841,15 @@ userRoutes.get('/:id/avatar', async (c) => {
     return c.body(null, 304);
   }
 
-  // Read the whole blob (avatars are capped at MAX_AVATAR_SIZE_BYTES) before
-  // sending any headers, so a read error is a clean 500 rather than a 200 with
-  // a truncated body under a full Content-Length (Todd's #1059 review).
+  // Avatars are capped at MAX_AVATAR_SIZE_BYTES, so buffering is bounded and
+  // Content-Length is exact.
   const opened = await readAvatarBuffer(userId);
   if (!opened) {
-    // statAvatar passed just above, so a null here is a real read failure (or a
-    // delete race), not a "no avatar" — surface it as a 500 rather than a 404.
+    // statAvatar passed just above, so a null here is a delete race (or
+    // corrupted avatar_mime — logged inside readAvatarBuffer), not "no
+    // avatar" — surface as 500 rather than 404. A genuine DB error throws
+    // and lands in app.onError, never this branch.
+    console.error(`[users/avatar] read returned null after successful stat (user ${userId})`);
     return c.json({ error: 'Failed to read avatar' }, 500);
   }
 

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -420,6 +420,11 @@ userRoutes.get('/me', async (c) => {
       avatarUrl: users.avatarUrl,
       status: users.status,
       mfaEnabled: users.mfaEnabled,
+      // Exposed so the web sidebar can hide platform-admin-only nav (e.g.
+      // account-deletion-requests) and skip its badge fetch — otherwise that
+      // fetch 403s ("platform admin access required") on every page load for
+      // ordinary partner/org users and spams the console.
+      isPlatformAdmin: users.isPlatformAdmin,
       createdAt: users.createdAt,
       lastLoginAt: users.lastLoginAt,
       setupCompletedAt: users.setupCompletedAt,
@@ -655,13 +660,12 @@ userRoutes.patch('/me', zValidator('json', updateMeSchema), async (c) => {
 // --- Avatars ---
 //
 // POST /users/me/avatar     multipart upload of png/jpeg/webp, 5 MB max
-// GET  /users/:id/avatar    stream the bytes (auth required)
-// DELETE /users/me/avatar   unlink + clear users.avatar_url
+// GET  /users/:id/avatar    serve the bytes (auth required)
+// DELETE /users/me/avatar   clear the bytes + users.avatar_url
 //
-// Storage: filesystem, /data/avatars/<userId>.<ext> on the api_data volume.
-// Magic-byte verification is required because we don't trust the
-// browser-supplied Content-Type. Filenames are derived from the auth'd user
-// id, so path traversal is impossible.
+// Storage: a `bytea` blob on the user's own row (users.avatar_data), in the DB
+// — no filesystem volume dependency (#1059). Magic-byte verification is
+// required because we don't trust the browser-supplied Content-Type.
 
 const ALLOWED_AVATAR_MIMES = new Set(['image/png', 'image/jpeg', 'image/webp']);
 
@@ -715,6 +719,8 @@ userRoutes.post(
       );
     }
 
+    // writeAvatar persists the bytes + mime + avatar_url atomically on the user
+    // row and returns the serving URL / size / updatedAt.
     let written;
     try {
       written = await writeAvatar(userId, sniffedMime, buffer);
@@ -723,18 +729,7 @@ userRoutes.post(
       return c.json({ error: 'Failed to store avatar' }, 500);
     }
 
-    const avatarUrl = `/api/v1/users/${userId}/avatar`;
-    const [updated] = await db
-      .update(users)
-      .set({ avatarUrl, updatedAt: new Date() })
-      .where(eq(users.id, userId))
-      .returning({
-        id: users.id,
-        avatarUrl: users.avatarUrl,
-        updatedAt: users.updatedAt,
-      });
-
-    if (!updated) {
+    if (!written) {
       return c.json({ error: 'Failed to update profile' }, 500);
     }
 
@@ -757,10 +752,10 @@ userRoutes.post(
     });
 
     return c.json({
-      avatarUrl: updated.avatarUrl,
+      avatarUrl: written.avatarUrl,
       size: written.size,
       mime: sniffedMime,
-      updatedAt: updated.updatedAt
+      updatedAt: written.updatedAt
     });
   }
 );
@@ -769,18 +764,10 @@ userRoutes.delete('/me/avatar', async (c) => {
   const auth = c.get('auth');
   const userId = auth.user.id;
 
-  deleteAvatar(userId);
-
-  const [updated] = await db
-    .update(users)
-    .set({ avatarUrl: null, updatedAt: new Date() })
-    .where(eq(users.id, userId))
-    .returning({
-      id: users.id,
-      avatarUrl: users.avatarUrl,
-    });
-
-  if (!updated) {
+  // Clears the bytes, mime, timestamp, and avatar_url on the user row in one
+  // write. Returns false only if the row doesn't exist.
+  const cleared = await deleteAvatar(userId);
+  if (!cleared) {
     return c.json({ error: 'Failed to clear avatar' }, 500);
   }
 
@@ -811,11 +798,9 @@ userRoutes.get('/:id/avatar', async (c) => {
   const auth = c.get('auth');
   const userId = c.req.param('id')!;
 
-  // Basic shape check — userId comes from the URL and is fed straight to the
-  // filesystem (after concatenation with the extension). The filesystem layer
-  // joins it via path.join, so traversal isn't possible, but rejecting obviously
-  // bogus values up-front avoids confusing errors and keeps the on-disk listing
-  // tidy.
+  // Basic shape check — userId comes from the URL and is used as a DB lookup
+  // key (parameterized, so no injection risk); rejecting obviously bogus values
+  // up-front avoids confusing errors.
   if (!/^[a-zA-Z0-9_-]+$/.test(userId)) {
     return c.json({ error: 'Invalid user id' }, 400);
   }
@@ -831,7 +816,7 @@ userRoutes.get('/:id/avatar', async (c) => {
     }
   }
 
-  const stat = statAvatar(userId);
+  const stat = await statAvatar(userId);
   if (!stat) {
     return c.json({ error: 'No avatar' }, 404);
   }
@@ -844,10 +829,10 @@ userRoutes.get('/:id/avatar', async (c) => {
     return c.body(null, 304);
   }
 
-  // Read the whole file (avatars are capped at MAX_AVATAR_SIZE_BYTES) before
-  // sending any headers, so an I/O error is a clean 500 rather than a 200 with
+  // Read the whole blob (avatars are capped at MAX_AVATAR_SIZE_BYTES) before
+  // sending any headers, so a read error is a clean 500 rather than a 200 with
   // a truncated body under a full Content-Length (Todd's #1059 review).
-  const opened = readAvatarBuffer(userId);
+  const opened = await readAvatarBuffer(userId);
   if (!opened) {
     // statAvatar passed just above, so a null here is a real read failure (or a
     // delete race), not a "no avatar" — surface it as a 500 rather than a 404.

--- a/apps/api/src/services/avatarStorage.ts
+++ b/apps/api/src/services/avatarStorage.ts
@@ -1,21 +1,23 @@
-import { existsSync, mkdirSync, readdirSync, renameSync, statSync, unlinkSync, createReadStream, readFileSync } from 'fs';
-import { writeFile } from 'fs/promises';
-import { join } from 'path';
 import { createHash } from 'crypto';
-import type { Readable } from 'stream';
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { users } from '../db/schema';
 
 /**
- * Avatar storage service.
+ * Avatar storage service (database-backed).
  *
- * Mirrors the filesystem-backed pattern used by `fileStorage.ts` for remote
- * transfers. One file per user, named `<userId>.<ext>`. New uploads overwrite.
+ * Avatars live as a `bytea` blob on the user's row (`users.avatar_data`),
+ * alongside `avatar_mime` and `avatar_updated_at`. This replaced the previous
+ * filesystem implementation (`/data/avatars/<id>.<ext>`), which depended on a
+ * writable `api_data` volume owned by the API's runtime uid — a root-owned
+ * volume failed uploads with EACCES → 500 (#1059). Storing the bytes in
+ * Postgres removes the volume dependency and works across replicas.
  *
- * Storage path defaults to /data/avatars (Docker named volume api_data is
- * mounted at /data on the api container, same volume used for transfers and
- * patch-reports).
+ * All operations run in the caller's DB context, so the `users` table's
+ * row-level security is the access boundary: a user can read/write their own
+ * row, and cross-user reads (GET /users/:id/avatar) are gated both by the
+ * route's explicit `getScopedUser` check and by the same RLS.
  */
-
-const STORAGE_PATH = process.env.AVATAR_STORAGE_PATH || './data/avatars';
 
 export const MAX_AVATAR_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
 
@@ -43,6 +45,14 @@ export function extForMime(mime: AvatarMime): AvatarExt {
 export function mimeForExt(ext: string): AvatarMime | null {
   if (ext in EXT_TO_MIME) {
     return EXT_TO_MIME[ext as AvatarExt];
+  }
+  return null;
+}
+
+/** Narrow an arbitrary DB-stored mime string back to a known AvatarMime. */
+function asAvatarMime(mime: string | null): AvatarMime | null {
+  if (mime === 'image/png' || mime === 'image/jpeg' || mime === 'image/webp') {
+    return mime;
   }
   return null;
 }
@@ -91,157 +101,145 @@ export function sniffImageMime(buf: Buffer): AvatarMime | null {
   return null;
 }
 
-function ensureStorageDir(): void {
-  if (!existsSync(STORAGE_PATH)) {
-    mkdirSync(STORAGE_PATH, { recursive: true });
-  }
+function avatarUrlFor(userId: string): string {
+  return `/api/v1/users/${userId}/avatar`;
 }
 
-function avatarPath(userId: string, ext: AvatarExt): string {
-  return join(STORAGE_PATH, `${userId}.${ext}`);
-}
-
-/**
- * Find the on-disk file for a user's avatar, regardless of extension.
- * Returns null if no avatar exists for this user.
- */
-export function findAvatar(userId: string): { path: string; ext: AvatarExt; mime: AvatarMime } | null {
-  if (!existsSync(STORAGE_PATH)) return null;
-  for (const ext of ALL_EXTS) {
-    const path = avatarPath(userId, ext);
-    if (existsSync(path)) {
-      return { path, ext, mime: EXT_TO_MIME[ext] };
-    }
-  }
-  return null;
+export interface WriteAvatarResult {
+  ext: AvatarExt;
+  size: number;
+  avatarUrl: string;
+  updatedAt: Date;
 }
 
 /**
- * Write avatar bytes atomically. Removes any pre-existing avatar for the same
- * user at a different extension.
+ * Persist the avatar bytes + metadata on the user's row, atomically, and point
+ * `avatar_url` at the serving endpoint. Returns null if the user row does not
+ * exist (or is not visible to the caller under RLS).
  */
-export async function writeAvatar(userId: string, mime: AvatarMime, data: Buffer): Promise<{ path: string; ext: AvatarExt; size: number }> {
-  ensureStorageDir();
-  const ext = extForMime(mime);
-  const finalPath = avatarPath(userId, ext);
-  const tmpPath = `${finalPath}.tmp`;
+export async function writeAvatar(
+  userId: string,
+  mime: AvatarMime,
+  data: Buffer
+): Promise<WriteAvatarResult | null> {
+  const now = new Date();
+  const avatarUrl = avatarUrlFor(userId);
 
-  await writeFile(tmpPath, data);
-  renameSync(tmpPath, finalPath);
+  const [updated] = await db
+    .update(users)
+    .set({
+      avatarData: data,
+      avatarMime: mime,
+      avatarUpdatedAt: now,
+      avatarUrl,
+      updatedAt: now,
+    })
+    .where(eq(users.id, userId))
+    .returning({ id: users.id, updatedAt: users.updatedAt });
 
-  // Clean up any avatar at a different extension so we don't accumulate.
-  for (const otherExt of ALL_EXTS) {
-    if (otherExt === ext) continue;
-    const otherPath = avatarPath(userId, otherExt);
-    if (existsSync(otherPath)) {
-      try {
-        unlinkSync(otherPath);
-      } catch {
-        // Best-effort cleanup; ignore.
-      }
-    }
-  }
+  if (!updated) return null;
 
-  return { path: finalPath, ext, size: data.length };
+  return { ext: extForMime(mime), size: data.length, avatarUrl, updatedAt: updated.updatedAt };
+}
+
+export interface AvatarStat {
+  mime: AvatarMime;
+  size: number;
+  mtimeMs: number;
 }
 
 /**
- * Open a readable stream for the user's avatar file. Returns null if no
- * avatar exists.
+ * Lightweight metadata (mime, byte length, mtime) for a user's avatar without
+ * pulling the bytes — used to build the ETag and answer conditional GETs.
+ * Returns null if no avatar is stored.
  */
-export function readAvatarStream(userId: string): { stream: Readable; mime: AvatarMime; size: number; mtimeMs: number } | null {
-  const found = findAvatar(userId);
-  if (!found) return null;
+export async function statAvatar(userId: string): Promise<AvatarStat | null> {
+  const [row] = await db
+    .select({
+      mime: users.avatarMime,
+      data: users.avatarData,
+      updatedAt: users.avatarUpdatedAt,
+    })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
 
-  let stat;
-  try {
-    stat = statSync(found.path);
-  } catch {
-    return null;
-  }
+  if (!row || !row.data) return null;
+  const mime = asAvatarMime(row.mime);
+  if (!mime) return null;
 
   return {
-    stream: createReadStream(found.path),
-    mime: found.mime,
-    size: stat.size,
-    mtimeMs: stat.mtimeMs,
+    mime,
+    size: row.data.length,
+    mtimeMs: row.updatedAt ? row.updatedAt.getTime() : 0,
   };
+}
+
+export interface AvatarBuffer {
+  buffer: Buffer;
+  mime: AvatarMime;
+  size: number;
+  mtimeMs: number;
 }
 
 /**
  * Read a user's avatar fully into a Buffer. Avatars are capped at
- * MAX_AVATAR_SIZE_BYTES on write, so buffering is bounded and lets the
- * caller send an exact Content-Length with no risk of a truncated body
- * (a mid-stream read error becomes a clean failure before any bytes or
- * headers are sent, rather than a 200 with a short body).
+ * MAX_AVATAR_SIZE_BYTES on write, so buffering is bounded and lets the caller
+ * send an exact Content-Length. Returns null if no avatar is stored.
  */
-export function readAvatarBuffer(userId: string): { buffer: Buffer; mime: AvatarMime; size: number; mtimeMs: number } | null {
-  const found = findAvatar(userId);
-  if (!found) return null;
+export async function readAvatarBuffer(userId: string): Promise<AvatarBuffer | null> {
+  const [row] = await db
+    .select({
+      data: users.avatarData,
+      mime: users.avatarMime,
+      updatedAt: users.avatarUpdatedAt,
+    })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
 
-  try {
-    const stat = statSync(found.path);
-    const buffer = readFileSync(found.path);
-    return {
-      buffer,
-      mime: found.mime,
-      size: stat.size,
-      mtimeMs: stat.mtimeMs,
-    };
-  } catch {
-    return null;
-  }
+  if (!row || !row.data) return null;
+  const mime = asAvatarMime(row.mime);
+  if (!mime) return null;
+
+  return {
+    buffer: row.data,
+    mime,
+    size: row.data.length,
+    mtimeMs: row.updatedAt ? row.updatedAt.getTime() : 0,
+  };
 }
 
 /**
- * Get file stat (size + mtimeMs) for a user's avatar without opening it.
+ * Clear the user's avatar (bytes, mime, timestamp, and serving URL). Returns
+ * true if the user row was updated, false if no such row exists.
+ *
+ * The route already validated the user exists and always nulls avatar_url
+ * afterward, so it doesn't need to distinguish "cleared something" from
+ * "already empty" — only that the write landed.
  */
-export function statAvatar(userId: string): { mime: AvatarMime; size: number; mtimeMs: number } | null {
-  const found = findAvatar(userId);
-  if (!found) return null;
-  try {
-    const stat = statSync(found.path);
-    return { mime: found.mime, size: stat.size, mtimeMs: stat.mtimeMs };
-  } catch {
-    return null;
-  }
+export async function deleteAvatar(userId: string): Promise<boolean> {
+  const [updated] = await db
+    .update(users)
+    .set({
+      avatarData: null,
+      avatarMime: null,
+      avatarUpdatedAt: null,
+      avatarUrl: null,
+      updatedAt: new Date(),
+    })
+    .where(eq(users.id, userId))
+    .returning({ id: users.id });
+
+  return Boolean(updated);
 }
 
 /**
- * Compute a weak ETag from size + mtimeMs. Cheap, avoids hashing file bytes
- * on every read. Format follows RFC 7232 weak ETag syntax.
+ * Compute a weak ETag from size + mtimeMs. Cheap, avoids hashing the bytes on
+ * every read. Format follows RFC 7232 weak ETag syntax.
  */
 export function weakEtagFor(size: number, mtimeMs: number): string {
   const hash = createHash('sha1');
   hash.update(`${size}:${Math.floor(mtimeMs)}`);
   return `W/"${hash.digest('hex').slice(0, 16)}"`;
-}
-
-/**
- * Delete the user's avatar file (any extension). Returns true if a file was
- * removed, false if no avatar existed.
- */
-export function deleteAvatar(userId: string): boolean {
-  if (!existsSync(STORAGE_PATH)) return false;
-  let removed = false;
-  for (const ext of ALL_EXTS) {
-    const path = avatarPath(userId, ext);
-    if (existsSync(path)) {
-      try {
-        unlinkSync(path);
-        removed = true;
-      } catch {
-        // ignore
-      }
-    }
-  }
-  return removed;
-}
-
-/**
- * Test-only helper: list all avatar filenames currently on disk.
- */
-export function listAvatarsForTest(): string[] {
-  if (!existsSync(STORAGE_PATH)) return [];
-  return readdirSync(STORAGE_PATH);
 }

--- a/apps/api/src/services/avatarStorage.ts
+++ b/apps/api/src/services/avatarStorage.ts
@@ -1,7 +1,8 @@
 import { createHash } from 'crypto';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { db } from '../db';
 import { users } from '../db/schema';
+import { captureException } from './sentry';
 
 /**
  * Avatar storage service (database-backed).
@@ -13,10 +14,12 @@ import { users } from '../db/schema';
  * volume failed uploads with EACCES → 500 (#1059). Storing the bytes in
  * Postgres removes the volume dependency and works across replicas.
  *
- * All operations run in the caller's DB context, so the `users` table's
- * row-level security is the access boundary: a user can read/write their own
- * row, and cross-user reads (GET /users/:id/avatar) are gated both by the
- * route's explicit `getScopedUser` check and by the same RLS.
+ * The `users` table's row-level security is the access boundary: a user can
+ * read/write their own row, and cross-user reads (GET /users/:id/avatar) are
+ * gated both by the route's explicit `getScopedUser` check and by the same
+ * RLS. Callers must be inside a request/system DB access context — outside one
+ * RLS fails closed and these functions return null/false ("no avatar"), not an
+ * error.
  */
 
 export const MAX_AVATAR_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
@@ -54,6 +57,20 @@ function asAvatarMime(mime: string | null): AvatarMime | null {
   if (mime === 'image/png' || mime === 'image/jpeg' || mime === 'image/webp') {
     return mime;
   }
+  return null;
+}
+
+/**
+ * Bytes exist but avatar_mime doesn't narrow — impossible via writeAvatar
+ * (which sets both atomically), so it means corruption or a bad backfill.
+ * Loudly flag it; the caller still degrades to "no avatar".
+ */
+function reportInvalidMime(userId: string, mime: string | null): null {
+  const err = new Error(
+    `[avatarStorage] avatar bytes present but avatar_mime invalid (user ${userId}, mime ${JSON.stringify(mime)})`
+  );
+  console.error(err.message);
+  captureException(err);
   return null;
 }
 
@@ -150,27 +167,30 @@ export interface AvatarStat {
 
 /**
  * Lightweight metadata (mime, byte length, mtime) for a user's avatar without
- * pulling the bytes — used to build the ETag and answer conditional GETs.
- * Returns null if no avatar is stored.
+ * pulling the bytes — `octet_length` computes the size in Postgres, so the
+ * conditional-GET 304 fast path never transfers the blob. Returns null if no
+ * avatar is stored. (`mtimeMs` is `avatar_updated_at` in epoch ms; the name is
+ * kept from the filesystem era for ETag-contract compatibility.)
  */
 export async function statAvatar(userId: string): Promise<AvatarStat | null> {
   const [row] = await db
     .select({
       mime: users.avatarMime,
-      data: users.avatarData,
+      size: sql<number | null>`octet_length(${users.avatarData})`,
       updatedAt: users.avatarUpdatedAt,
     })
     .from(users)
     .where(eq(users.id, userId))
     .limit(1);
 
-  if (!row || !row.data) return null;
+  if (!row || row.size === null) return null;
   const mime = asAvatarMime(row.mime);
-  if (!mime) return null;
+  if (!mime) return reportInvalidMime(userId, row.mime);
 
   return {
     mime,
-    size: row.data.length,
+    // postgres.js may hand integers back as strings depending on parser config.
+    size: Number(row.size),
     mtimeMs: row.updatedAt ? row.updatedAt.getTime() : 0,
   };
 }
@@ -200,7 +220,7 @@ export async function readAvatarBuffer(userId: string): Promise<AvatarBuffer | n
 
   if (!row || !row.data) return null;
   const mime = asAvatarMime(row.mime);
-  if (!mime) return null;
+  if (!mime) return reportInvalidMime(userId, row.mime);
 
   return {
     buffer: row.data,
@@ -211,12 +231,11 @@ export async function readAvatarBuffer(userId: string): Promise<AvatarBuffer | n
 }
 
 /**
- * Clear the user's avatar (bytes, mime, timestamp, and serving URL). Returns
- * true if the user row was updated, false if no such row exists.
- *
- * The route already validated the user exists and always nulls avatar_url
- * afterward, so it doesn't need to distinguish "cleared something" from
- * "already empty" — only that the write landed.
+ * Clear the user's avatar (bytes, mime, timestamp, and serving URL) in one
+ * UPDATE. Returns true if the user row was updated, false if no such row
+ * exists (or it's invisible under RLS). Unlike the filesystem version, this
+ * does NOT report whether an avatar previously existed — clearing is
+ * idempotent and callers only need to know the write landed.
  */
 export async function deleteAvatar(userId: string): Promise<boolean> {
   const [updated] = await db

--- a/apps/web/src/components/auth/LoginPage.test.tsx
+++ b/apps/web/src/components/auth/LoginPage.test.tsx
@@ -53,6 +53,33 @@ async function fillAndSubmit(email = 'jane@example.com', password = 'Sup3rSecure
   fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
 }
 
+describe('LoginPage hydration safety', () => {
+  // Regression for React #418 on /login: the initial render must NOT depend on
+  // `typeof window` (or any window-only signal), or the server render (no
+  // window) and the client's first render disagree and React tears the tree
+  // down. `cfAccessRedirectChecked`'s initial value used to be
+  // `shouldSkipCfAccessRedirect()`, which returns true on the server (renders
+  // the form) and false on a plain client load (renders the placeholder).
+  it('renders identically with and without `window` (no SSR/CSR divergence)', async () => {
+    const { renderToString } = await import('react-dom/server');
+
+    const clientHtml = renderToString(<LoginPage />);
+
+    const realWindow = globalThis.window;
+    // Simulate the server environment where `window` is undefined.
+    // @ts-expect-error intentionally removing the global for this assertion
+    delete globalThis.window;
+    let serverHtml: string;
+    try {
+      serverHtml = renderToString(<LoginPage />);
+    } finally {
+      globalThis.window = realWindow;
+    }
+
+    expect(serverHtml).toBe(clientHtml);
+  });
+});
+
 describe('LoginPage navigation after login', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/web/src/components/auth/LoginPage.tsx
+++ b/apps/web/src/components/auth/LoginPage.tsx
@@ -58,7 +58,14 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
   const [phoneLast4, setPhoneLast4] = useState<string>();
   const [smsSending, setSmsSending] = useState(false);
   const [smsSent, setSmsSent] = useState(false);
-  const [cfAccessRedirectChecked, setCfAccessRedirectChecked] = useState(shouldSkipCfAccessRedirect());
+  // MUST start `false` (a constant), not `shouldSkipCfAccessRedirect()`: that
+  // helper returns true on the server (no `window`) and false on a plain client
+  // load, so seeding the initial state with it made the SSR render the form
+  // while the client's first render produced the placeholder below — a React
+  // #418 hydration mismatch on every /login visit. The skip decision now lives
+  // entirely in the effect (client-only), keeping SSR and CSR initial output
+  // identical (both render the placeholder).
+  const [cfAccessRedirectChecked, setCfAccessRedirectChecked] = useState(false);
 
   const login = useAuthStore((state) => state.login);
 
@@ -69,6 +76,13 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
   // the user has an active session at the root app with the same IdP.
   useEffect(() => {
     if (cfAccessRedirectChecked) return;
+    // Post-redirect bounce / explicit sign-out: skip the check and show the
+    // form immediately (one tick after mount, so SSR and CSR still agree on the
+    // initial placeholder render).
+    if (shouldSkipCfAccessRedirect()) {
+      setCfAccessRedirectChecked(true);
+      return;
+    }
     let cancelled = false;
     void checkCfAccessLoginEnabled().then((enabled) => {
       if (cancelled) return;

--- a/apps/web/src/components/auth/LoginPage.tsx
+++ b/apps/web/src/components/auth/LoginPage.tsx
@@ -31,14 +31,21 @@ function shouldSkipCfAccessRedirect(): boolean {
 async function checkCfAccessLoginEnabled(): Promise<boolean> {
   try {
     const apiHost = import.meta.env.PUBLIC_API_URL || '';
+    // This fetch gates the entire login form behind an empty placeholder, so a
+    // hung request (black-holed proxy, captive portal) must not stall login
+    // forever — time out and fall back to the password form.
     const res = await fetch(`${apiHost}/api/v1/config`, {
       method: 'GET',
       credentials: 'include',
+      signal: AbortSignal.timeout(4000),
     });
     if (!res.ok) return false;
     const body = (await res.json()) as { cfAccessLogin?: { enabled?: boolean } };
     return !!body.cfAccessLogin?.enabled;
-  } catch {
+  } catch (err) {
+    // Fail open to the password form — but leave a trace, or a deployment-wide
+    // config/CORS regression silently disables CF Access SSO with no signal.
+    console.warn('[login] CF Access config check failed; falling back to password form', err);
     return false;
   }
 }

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -41,7 +41,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useUiStore } from '../../stores/uiStore';
-import { fetchWithAuth } from '../../stores/auth';
+import { fetchWithAuth, useAuthStore } from '../../stores/auth';
 import { WEB_VERSION } from '../../lib/version';
 import { semverCompare } from '@breeze/shared';
 import { getJwtClaims } from '../../lib/authScope';
@@ -81,6 +81,9 @@ type NavItem = {
   href: string;
   icon: React.ComponentType<{ className?: string }>;
   badgeKind?: 'deletion-requests';
+  // Hidden unless the current user is a platform admin. Keeps cross-tenant
+  // platform-operator nav (and its badge fetch) out of ordinary users' UI.
+  platformAdminOnly?: boolean;
 };
 
 // ---------------------------------------------------------------------------
@@ -172,7 +175,7 @@ const navSections: NavSection[] = [
       { name: 'Users', href: '/settings/users', icon: Users },
       { name: 'Roles', href: '/settings/roles', icon: KeyRound },
       { name: 'Enrollment Keys', href: '/settings/enrollment-keys', icon: Key },
-      { name: 'Deletion requests', href: '/admin/account-deletion-requests', icon: UserX, badgeKind: 'deletion-requests' },
+      { name: 'Deletion requests', href: '/admin/account-deletion-requests', icon: UserX, badgeKind: 'deletion-requests', platformAdminOnly: true },
     ],
   },
 ];
@@ -232,9 +235,13 @@ function sectionForHref(href: string): string | null {
 // Badge counts (admin-only nav signals). Returns undefined while loading or
 // when the caller has no permission (silently swallowed).
 // ---------------------------------------------------------------------------
-function useDeletionRequestsBadge(): number | undefined {
+function useDeletionRequestsBadge(enabled: boolean): number | undefined {
   const [count, setCount] = useState<number | undefined>(undefined);
   useEffect(() => {
+    // The endpoint requires platform-admin access; firing it for ordinary users
+    // 403s on every page and logs a console error. Skip it unless the caller
+    // is a platform admin.
+    if (!enabled) return;
     let cancelled = false;
     fetchWithAuth('/admin/account-deletion-requests/pending-count')
       .then(async (r) => {
@@ -245,7 +252,7 @@ function useDeletionRequestsBadge(): number | undefined {
       })
       .catch(() => { /* network error — leave badge hidden */ });
     return () => { cancelled = true; };
-  }, []);
+  }, [enabled]);
   return count;
 }
 
@@ -253,6 +260,7 @@ export default function Sidebar({ currentPath: initialPath = '/' }: SidebarProps
   const [mode, setMode] = useState<SidebarMode>(readSavedMode);
   const [hovered, setHovered] = useState(false);
   const currentPath = useCurrentPath(initialPath);
+  const isPlatformAdmin = useAuthStore((s) => s.user?.isPlatformAdmin === true);
 
   // --- Responsive breakpoints -----------------------------------------------
   // Track whether viewport is below lg (1024px) or md (768px) to override mode
@@ -402,12 +410,16 @@ export default function Sidebar({ currentPath: initialPath = '/' }: SidebarProps
     return sectionId === activeSectionId;
   }, [expandedSections, activeSectionId]);
 
-  // Pending deletion-requests count for the admin badge. Hook is unconditional,
-  // but the badge is only rendered next to nav items that opt in via badgeKind.
-  const deletionRequestsCount = useDeletionRequestsBadge();
+  // Pending deletion-requests count for the admin badge. Only fetched for
+  // platform admins (the endpoint 403s otherwise); rendered next to nav items
+  // that opt in via badgeKind.
+  const deletionRequestsCount = useDeletionRequestsBadge(isPlatformAdmin);
 
   // --- Render a single nav item -------------------------------------------
   const renderNavItem = (item: NavItem, forMobileOverlay = false) => {
+    // Platform-admin-only items (e.g. account-deletion-requests) are hidden
+    // from ordinary users — keeps cross-tenant operator nav out of their UI.
+    if (item.platformAdminOnly && !isPlatformAdmin) return null;
     const isActive = item.href === activeHref;
     const labels = forMobileOverlay ? true : showLabels;
     const narrow = forMobileOverlay ? false : isNarrow;

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -233,20 +233,25 @@ function sectionForHref(href: string): string | null {
 // ---------------------------------------------------------------------------
 // ---------------------------------------------------------------------------
 // Badge counts (admin-only nav signals). Returns undefined while loading or
-// when the caller has no permission (silently swallowed).
+// disabled. Only fetched when `enabled` (= platform admin) — the endpoint
+// requires platform-admin access, so firing it for ordinary users 403s on
+// every page load and spams the console.
 // ---------------------------------------------------------------------------
 function useDeletionRequestsBadge(enabled: boolean): number | undefined {
   const [count, setCount] = useState<number | undefined>(undefined);
   useEffect(() => {
-    // The endpoint requires platform-admin access; firing it for ordinary users
-    // 403s on every page and logs a console error. Skip it unless the caller
-    // is a platform admin.
     if (!enabled) return;
     let cancelled = false;
     fetchWithAuth('/admin/account-deletion-requests/pending-count')
       .then(async (r) => {
         if (cancelled) return;
-        if (!r.ok) return; // 401/403 quietly suppresses the badge
+        if (!r.ok) {
+          // Only platform admins reach here now, so a failure is a genuine
+          // error, not the old expected 403 — degrade to no badge but leave a
+          // trace.
+          console.warn('[sidebar] deletion-requests badge fetch failed', r.status);
+          return;
+        }
         const data = (await r.json().catch(() => ({}))) as { count?: number };
         if (!cancelled) setCount(typeof data.count === 'number' ? data.count : 0);
       })
@@ -410,15 +415,10 @@ export default function Sidebar({ currentPath: initialPath = '/' }: SidebarProps
     return sectionId === activeSectionId;
   }, [expandedSections, activeSectionId]);
 
-  // Pending deletion-requests count for the admin badge. Only fetched for
-  // platform admins (the endpoint 403s otherwise); rendered next to nav items
-  // that opt in via badgeKind.
   const deletionRequestsCount = useDeletionRequestsBadge(isPlatformAdmin);
 
   // --- Render a single nav item -------------------------------------------
   const renderNavItem = (item: NavItem, forMobileOverlay = false) => {
-    // Platform-admin-only items (e.g. account-deletion-requests) are hidden
-    // from ordinary users — keeps cross-tenant operator nav out of their UI.
     if (item.platformAdminOnly && !isPlatformAdmin) return null;
     const isActive = item.href === activeHref;
     const labels = forMobileOverlay ? true : showLabels;

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -724,6 +724,13 @@ export async function fetchAndApplyPreferences(): Promise<void> {
     if (!response.ok) return;
 
     const data = await response.json();
+    // isPlatformAdmin rides along with this refresh: fresh logins carry it in
+    // the login payload, but sessions persisted before the field existed only
+    // learn it here — without the merge, the platform-admin nav stays hidden
+    // until the next re-login.
+    if (typeof data.isPlatformAdmin === 'boolean') {
+      useAuthStore.getState().updateUser({ isPlatformAdmin: data.isPlatformAdmin });
+    }
     if (data.preferences) {
       useAuthStore.getState().updateUser({ preferences: data.preferences });
       applyThemePreference(data.preferences.theme);

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -13,6 +13,10 @@ export interface User {
   mfaEnabled: boolean;
   avatarUrl?: string;
   requiresSetup?: boolean;
+  // True only for platform operators. Gates platform-admin-only nav (e.g.
+  // account-deletion-requests) so ordinary users don't trigger its 403 badge
+  // fetch. Absent/false for partner & org users.
+  isPlatformAdmin?: boolean;
   preferences?: UserPreferences;
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,6 @@ services:
       MFA_RECOVERY_CODE_PEPPER: ${MFA_RECOVERY_CODE_PEPPER:?Set MFA_RECOVERY_CODE_PEPPER in .env}
       TRANSFER_STORAGE_PATH: /data/transfers
       PATCH_REPORT_STORAGE_PATH: /data/patch-reports
-      AVATAR_STORAGE_PATH: /data/avatars
       LOG_LEVEL: ${LOG_LEVEL:-info}
       LOG_JSON: ${LOG_JSON:-true}
       METRICS_SCRAPE_TOKEN: ${METRICS_SCRAPE_TOKEN:-}


### PR DESCRIPTION
## What

Three fixes that came out of the v0.70 release-checklist testing pass, hardened by a multi-agent review round.

**1. Avatar storage → DB bytea (the headline fix).** `POST /users/me/avatar` 500'd with `EACCES: permission denied, open '/data/avatars/….png.tmp'` — the API runs as `uid=1001(hono)` but the `api_data` volume's `/data/avatars` is `root:root 0755`, so filesystem avatar storage (#1059) was broken in any deployment with that ownership, prod included. Avatars now live on the user's own row as `avatar_data bytea` + `avatar_mime` + `avatar_updated_at` (migration `2026-06-11-j`): no volume dependency, works across replicas, and the existing dual-axis `users` RLS is the access boundary. `statAvatar` sizes via `octet_length()` so the conditional-GET 304 path never transfers the blob. The migration clears only dangling *internal* `/api/v1/users/%/avatar` URLs (external pre-upload-era URLs still resolve) and always logs the count.

**2. React #418 hydration error on `/login`.** `cfAccessRedirectChecked` was seeded from a `typeof window` helper — `true` on the server (renders the form), `false` on a clean client load (renders the placeholder) — so every login visit hydrated mismatched trees. Now a constant `false` with the skip decision inside the effect; a regression test asserts `renderToString` output is identical with and without `window`. The CF-config fetch that gates the form also gets a 4s `AbortSignal.timeout` so a hung request can't pin login behind an empty placeholder.

**3. Per-page 403 console error.** The sidebar fired `GET /admin/account-deletion-requests/pending-count` for every user, but the endpoint requires **platform admin** — so every page load logged a 403 for everyone (no platform admin exists in prod). `/users/me` and the login/MFA payloads now expose `isPlatformAdmin`, the store merges it on the preferences refresh (heals persisted pre-field sessions), and the sidebar hides the nav item + skips the badge fetch without it.

## Review round (multi-agent, both commits)

The second commit addresses the findings: the **critical** one was that `isPlatformAdmin` initially only rode the `/users/me` response, which never reaches the store on password login — the gate would have hidden the nav from the exact users it serves. Also fixed there: schema/migration `timestamptz` drift, Sentry capture on the avatar write catch + soft-500 branches, invalid-`avatar_mime` detection (corruption no longer masquerades as "no avatar"), and stale filesystem-era comments.

## Testing

- `users.test.ts` 53/53 — avatar I/O mocked behind an in-memory store with the real sniffing/ETag helpers kept live; new 304 conditional-GET and 500-path tests; vestigial `db.update` mocks removed
- **New integration test** `avatar-bytea-roundtrip` 3/3 against the real driver as `breeze_app`: byte-exact round-trip (all 256 byte values), `octet_length` sizing, RLS fail-closed across partners (the #1257 class of gap mocked suites can't see)
- `login.test.ts` 4/4 incl. new payload regression tests; `LoginPage.test.tsx` 8/8 incl. the hydration-invariant test
- `pnpm db:check-drift` clean (237 files); web + api `tsc` clean
- Not yet done: live browser verify of the upload (needs the API image rebuilt from this branch — the running local container predates it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)