### PR TITLE
Expose EDR security events in automation builder + fix EDR docs drift

### DIFF
--- a/apps/docs/src/content/docs/features/automations.mdx
+++ b/apps/docs/src/content/docs/features/automations.mdx
@@ -223,6 +223,12 @@ Fires when a matching platform event is emitted. The `eventType` field is case-s
 | `device.offline` | A device stops sending heartbeats |
 | `device.enrolled` | A new device completes enrollment |
 | `patch.failed` | A patch deployment fails on a device |
+| `huntress.incident_created` | A new Huntress incident is reported (see [EDR Integrations](/features/edr-integrations/)) |
+| `huntress.incident_updated` | A Huntress incident changes severity, status, or resolution |
+| `huntress.agent_offline` | A Huntress agent goes offline |
+| `s1.threat_detected` | A new SentinelOne threat is detected |
+| `s1.device_isolated` | A Breeze-initiated SentinelOne isolation completes |
+| `s1.threat_action_completed` | A Breeze-initiated SentinelOne threat action completes |
 
 ### Webhook
 

--- a/apps/docs/src/content/docs/features/edr-integrations.mdx
+++ b/apps/docs/src/content/docs/features/edr-integrations.mdx
@@ -37,13 +37,17 @@ The Huntress integration syncs agent inventory and incident reports from your Hu
 ### Setting Up Huntress
 
 <Steps>
-1. In the Breeze dashboard, navigate to **Settings > Integrations > Huntress**.
+1. In the Breeze dashboard, navigate to **Integrations**, open the **Security** tab, and select **Huntress**.
 2. Provide a **name** for the integration (e.g., "Production Huntress").
-3. Enter your **Huntress API key**. This is encrypted at rest using AES before being stored.
-4. Optionally provide your **Huntress account ID** and **API base URL** (defaults to `https://api.huntress.io/v1`).
+3. Enter your **Huntress API Key** and **API Secret** as shown in the Huntress portal. Paste each value into its own field — do not paste a Base64-encoded combination of the two; Breeze formats the API request automatically. Both values are encrypted at rest using AES before being stored.
+4. Optionally provide your **Huntress account ID**. (A custom API base URL can be set via the Breeze API; the default is `https://api.huntress.io/v1`.)
 5. Optionally provide a **webhook secret** for signature verification on incoming webhook payloads.
-6. Click **Save**. An initial sync is automatically scheduled.
+6. Click **Save & Connect**. An initial sync is automatically scheduled.
 </Steps>
+
+<Aside>
+  The Huntress integration is configured per organization. If your scope selector is set to **All orgs**, switch to a single organization before configuring or viewing the integration.
+</Aside>
 
 <Aside>
   Creating or updating a Huntress integration requires the `orgs:write` permission and MFA verification.
@@ -150,7 +154,7 @@ The SentinelOne integration provides deeper operational capabilities beyond data
 ### Setting Up SentinelOne
 
 <Steps>
-1. In the Breeze dashboard, navigate to **Settings > Integrations > SentinelOne**.
+1. In the Breeze dashboard, navigate to **Integrations**, open the **Security** tab, and select **SentinelOne**.
 2. Provide a **name** for the integration.
 3. Enter your **SentinelOne management console URL** (e.g., `https://usea1.sentinelone.net`).
 4. Enter your **SentinelOne API token**. This is encrypted at rest before being stored.
@@ -363,6 +367,21 @@ All endpoints require authentication with `organization`, `partner`, or `system`
 | `POST` | `/sync` | Yes | Trigger a manual SentinelOne sync |
 | `GET` | `/sites` | Yes | List SentinelOne sites with agent counts and org mappings |
 | `POST` | `/sites/map` | Yes | Map or unmap a SentinelOne site to a Breeze organization |
+
+---
+
+## Automation Events
+
+Both integrations emit platform events that can trigger [automations](/features/automations/) and outbound webhooks. Select these event types in the automation builder (**Automations > Create > Event** trigger) to react to security activity — for example, creating a ticket when a critical incident is reported, or notifying the on-call channel when an endpoint is isolated.
+
+| Event type | Fires when |
+|------------|------------|
+| `huntress.incident_created` | A new Huntress incident is synced or received via webhook |
+| `huntress.incident_updated` | An existing incident changes severity, status, or resolution |
+| `huntress.agent_offline` | A Huntress agent transitions from online to offline |
+| `s1.threat_detected` | A new SentinelOne threat is detected |
+| `s1.device_isolated` | A device isolation initiated from Breeze completes in SentinelOne |
+| `s1.threat_action_completed` | A threat action initiated from Breeze (kill, quarantine, rollback) completes |
 
 ---
 

--- a/apps/web/src/components/automations/AutomationForm.tsx
+++ b/apps/web/src/components/automations/AutomationForm.tsx
@@ -132,7 +132,13 @@ const eventTypeOptions = [
   { value: 'alert.resolved', label: 'Alert Resolved' },
   { value: 'script.completed', label: 'Script Completed' },
   { value: 'script.failed', label: 'Script Failed' },
-  { value: 'policy.violation', label: 'Policy Violation' }
+  { value: 'policy.violation', label: 'Policy Violation' },
+  { value: 'huntress.incident_created', label: 'Huntress Incident Created' },
+  { value: 'huntress.incident_updated', label: 'Huntress Incident Updated' },
+  { value: 'huntress.agent_offline', label: 'Huntress Agent Offline' },
+  { value: 's1.threat_detected', label: 'SentinelOne Threat Detected' },
+  { value: 's1.device_isolated', label: 'SentinelOne Device Isolated' },
+  { value: 's1.threat_action_completed', label: 'SentinelOne Threat Action Completed' }
 ];
 
 const conditionTypeOptions = [

--- a/scripts/docs-review/mapping.json
+++ b/scripts/docs-review/mapping.json
@@ -285,6 +285,36 @@
       ]
     },
     {
+      "pattern": "apps/web/src/components/automations/AutomationForm.tsx",
+      "docs": [
+        "features/automations.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/routes/huntress.ts",
+      "docs": [
+        "features/edr-integrations.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/jobs/huntressSync.ts",
+      "docs": [
+        "features/edr-integrations.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/routes/sentinelOne.ts",
+      "docs": [
+        "features/edr-integrations.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/jobs/s1Sync.ts",
+      "docs": [
+        "features/edr-integrations.mdx"
+      ]
+    },
+    {
       "pattern": "apps/api/src/routes/deployments.ts",
       "docs": [
         "features/deployments.mdx"


### PR DESCRIPTION
## Summary
- Add the six `huntress.*` / `s1.*` security events to the automation builder's event-trigger dropdown. The events were already published by the sync jobs and consumable by API-created automations and outbound webhooks, but could not be selected from the UI.
- Fix EDR docs drift in `edr-integrations.mdx`: correct the setup nav path for both vendors (**Integrations → Security tab**, not the nonexistent "Settings > Integrations" path), document the split API Key / API Secret fields shipped in #1264, note the per-organization scope requirement, and add an **Automation Events** section.
- Add the security events to the common event types table in `automations.mdx`.
- Map `huntress.ts` / `huntressSync.ts` / `sentinelOne.ts` / `s1Sync.ts` / `AutomationForm.tsx` in `docs-review/mapping.json` so future diff-mode doc sweeps catch changes to these files.

## Context
Follow-ups from the post-merge verification audit of the Huntress integration (#1264): the integration plumbing verified complete end-to-end, but the events were UI-undiscoverable and the docs referenced a nav path and credential flow that no longer exist.

## Validation
- `apps/docs`: `astro build` — 118 pages, clean
- `eslint src/components/automations/AutomationForm.tsx` — clean
- Event names/semantics verified against `eventBus.ts` and the publish sites in `huntressSync.ts` / `s1Sync.ts` (the two `s1` action events fire on completion of Breeze-initiated actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
