### PR TITLE
fix(install): clear errors for partial-connectivity agent installs

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -307,6 +307,9 @@ app.use(
 const startedAt = Date.now();
 
 // Health check — basic liveness with version and uptime
+// NOTE: the agent install.sh connectivity pre-flight greps this body for
+// "status":"ok" (see routes/agents/download.ts) — keep that contract if
+// changing the payload, or healthy installs will report a captive portal.
 app.get('/health', (c) => {
   const uptimeSeconds = Math.floor((Date.now() - startedAt) / 1000);
   return c.json({

--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -17,7 +17,10 @@ vi.mock('../../services/binarySource', () => ({
   },
 }));
 
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { execFile, execFileSync } from 'node:child_process';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { downloadRoutes } from './download';
@@ -169,5 +172,131 @@ describe('public agent .pkg downloads — per-arch serving', () => {
       expect.stringContaining('[pkg-download] S3 presign failed'),
       expect.anything(),
     );
+  });
+});
+
+describe('GET /install.sh — generated installer script', () => {
+  async function fetchScript(): Promise<string> {
+    const res = await downloadRoutes.request('/install.sh');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/plain');
+    return res.text();
+  }
+
+  it('is valid bash (bash -n syntax check)', async () => {
+    const script = await fetchScript();
+    const tmp = mkdtempSync(join(tmpdir(), 'breeze-install-sh-'));
+    const file = join(tmp, 'install.sh');
+    try {
+      writeFileSync(file, script);
+      // Throws (failing the test) on any syntax error.
+      execFileSync('bash', ['-n', file]);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts a --token argument for enrollment-key based enrollment', async () => {
+    const script = await fetchScript();
+    // Argument parser handles --token and forwards it to `enroll` as the
+    // positional enrollment key (the flow the Add Device UI uses).
+    expect(script).toContain('--token)');
+    expect(script).toContain('BREEZE_ENROLL_TOKEN');
+    expect(script).toContain('ENROLL_ARGS=(enroll)');
+  });
+
+  it('requires a token OR an enrollment secret, not unconditionally the secret', async () => {
+    const script = await fetchScript();
+    expect(script).toContain('Pass --token TOKEN or --enrollment-secret SECRET');
+    // The old unconditional secret check must be gone.
+    expect(script).not.toContain('BREEZE_ENROLLMENT_SECRET is required');
+  });
+
+  it('pre-flights server connectivity via /health before downloading anything', async () => {
+    const script = await fetchScript();
+    expect(script).toContain('/health"');
+    expect(script).toContain('Cannot reach the Breeze server');
+  });
+
+  it('flags intercepted responses (captive portal / wrong responder) distinctly', async () => {
+    const script = await fetchScript();
+    // A 200 whose body is not Breeze's health JSON means some other device
+    // answered (captive portal, router, web filter) — the SemoTech guest-VLAN
+    // case. The message must say so instead of letting `installer` fail cryptically.
+    expect(script).toContain('captive portal');
+  });
+
+  it('documents --token usage in the script header', async () => {
+    const script = await fetchScript();
+    expect(script).toContain('--token YOUR_ENROLLMENT_TOKEN');
+  });
+});
+
+describe('install.sh functional pre-flight behavior', () => {
+  // Runs the real generated script with bash. An `id` PATH shim makes the
+  // root check pass so execution reaches the connectivity pre-flight.
+  let tmp: string;
+  let scriptFile: string;
+  let shimDir: string;
+
+  beforeEach(async () => {
+    tmp = mkdtempSync(join(tmpdir(), 'breeze-install-fn-'));
+    scriptFile = join(tmp, 'install.sh');
+    shimDir = join(tmp, 'bin');
+    const res = await downloadRoutes.request('/install.sh');
+    writeFileSync(scriptFile, await res.text());
+    mkdirSync(shimDir);
+    writeFileSync(join(shimDir, 'id'), '#!/bin/sh\necho 0\n', { mode: 0o755 });
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function runScript(args: string[]): Promise<{ code: number; output: string }> {
+    return new Promise((resolve) => {
+      execFile(
+        'bash',
+        [scriptFile, ...args],
+        { env: { ...process.env, PATH: `${shimDir}:${process.env.PATH}` }, timeout: 30_000 },
+        (err, stdout, stderr) => {
+          const code = err && typeof err.code === 'number' ? err.code : err ? 1 : 0;
+          resolve({ code, output: `${stdout}${stderr}` });
+        },
+      );
+    });
+  }
+
+  it('fails fast with a clear message when the server is unreachable', async () => {
+    // Port 1 on localhost → immediate connection refused.
+    const { code, output } = await runScript(['--server', 'http://127.0.0.1:1', '--token', 'tok']);
+    expect(code).not.toBe(0);
+    expect(output).toContain('Cannot reach the Breeze server');
+    expect(output).toContain('no response');
+  });
+
+  it('flags a captive portal that answers 200 with a non-Breeze body', async () => {
+    // The SemoTech guest-VLAN case: an intercepting device returns 200 HTML,
+    // which previously sailed past `curl -f` and died inside `installer`.
+    const portal = createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end('<html><body>Guest network portal</body></html>');
+    });
+    await new Promise<void>((resolve) => portal.listen(0, '127.0.0.1', resolve));
+    const { port } = portal.address() as AddressInfo;
+    try {
+      const { code, output } = await runScript(['--server', `http://127.0.0.1:${port}`, '--token', 'tok']);
+      expect(code).not.toBe(0);
+      expect(output).toContain('captive portal');
+      expect(output).not.toContain('Downloading');
+    } finally {
+      portal.close();
+    }
+  });
+
+  it('rejects a missing enrollment credential with guidance', async () => {
+    const { code, output } = await runScript(['--server', 'http://127.0.0.1:1']);
+    expect(code).not.toBe(0);
+    expect(output).toContain('Pass --token TOKEN or --enrollment-secret SECRET');
   });
 });

--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -223,6 +223,14 @@ describe('GET /install.sh — generated installer script', () => {
     expect(script).toContain('Cannot reach the Breeze server');
   });
 
+  it('diagnoses TLS failures distinctly from generic unreachability', async () => {
+    const script = await fetchScript();
+    // curl exit 60 (cert verify) / 35 (handshake) are the signature of both
+    // self-signed-cert misconfigurations and TLS-intercepting middleboxes —
+    // "check DNS/firewall" would be the wrong advice for either.
+    expect(script).toContain('TLS problem connecting to');
+  });
+
   it('flags intercepted responses (captive portal / wrong responder) distinctly', async () => {
     const script = await fetchScript();
     // A 200 whose body is not Breeze's health JSON almost always means an
@@ -262,7 +270,9 @@ describe('install.sh functional pre-flight behavior', () => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  function runScript(args: string[]): Promise<{ code: number; output: string }> {
+  function runScript(
+    args: string[],
+  ): Promise<{ code: number; killed: boolean; output: string }> {
     return new Promise((resolve) => {
       execFile(
         'bash',
@@ -280,7 +290,11 @@ describe('install.sh functional pre-flight behavior', () => {
         },
         (err, stdout, stderr) => {
           const code = err && typeof err.code === 'number' ? err.code : err ? 1 : 0;
-          resolve({ code, output: `${stdout}${stderr}` });
+          // A timeout kill also lands here with code mapped to 1 — expose it
+          // so "fails fast" tests can't pass on a script that printed the
+          // right message but then hung.
+          const killed = Boolean(err && (err.killed || err.signal));
+          resolve({ code, killed, output: `${stdout}${stderr}` });
         },
       );
     });
@@ -288,7 +302,13 @@ describe('install.sh functional pre-flight behavior', () => {
 
   it('fails fast with a clear message when the server is unreachable', async () => {
     // Port 1 on localhost → immediate connection refused.
-    const { code, output } = await runScript(['--server', 'http://127.0.0.1:1', '--token', 'tok']);
+    const { code, killed, output } = await runScript([
+      '--server',
+      'http://127.0.0.1:1',
+      '--token',
+      'tok',
+    ]);
+    expect(killed).toBe(false);
     expect(code).not.toBe(0);
     expect(output).toContain('Cannot reach the Breeze server');
     expect(output).toContain('no response');
@@ -304,12 +324,54 @@ describe('install.sh functional pre-flight behavior', () => {
     await new Promise<void>((resolve) => portal.listen(0, '127.0.0.1', resolve));
     const { port } = portal.address() as AddressInfo;
     try {
-      const { code, output } = await runScript(['--server', `http://127.0.0.1:${port}`, '--token', 'tok']);
+      const { code, killed, output } = await runScript([
+        '--server',
+        `http://127.0.0.1:${port}`,
+        '--token',
+        'tok',
+      ]);
+      expect(killed).toBe(false);
       expect(code).not.toBe(0);
       expect(output).toContain('captive portal');
       expect(output).not.toContain('Downloading');
     } finally {
       portal.close();
+    }
+  });
+
+  it('attributes an intercepted download to the network when /health is clean', async () => {
+    // A path-selective middlebox (web filter allowlisting /health, or a
+    // portal that whitelists short URLs) passes the pre-flight and then
+    // serves HTML where the pkg/metadata should be. The failure must still
+    // point at interception — not at Gatekeeper or "missing checksum".
+    const filter = createServer((req, res) => {
+      if (req.url === '/health') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'ok', version: 'test', uptime: 1 }));
+      } else {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end('<html><body>Filtered</body></html>');
+      }
+    });
+    await new Promise<void>((resolve) => filter.listen(0, '127.0.0.1', resolve));
+    const { port } = filter.address() as AddressInfo;
+    try {
+      const { code, killed, output } = await runScript([
+        '--server',
+        `http://127.0.0.1:${port}`,
+        '--token',
+        'tok',
+      ]);
+      expect(killed).toBe(false);
+      expect(code).not.toBe(0);
+      expect(output).toContain('Breeze server is reachable');
+      // Both platform branches must blame the network: darwin downloads the
+      // HTML as a .pkg (caught by the xar magic check), linux gets HTML as
+      // release metadata (caught before the checksum-extraction error).
+      expect(output).toContain('intercepting');
+      expect(output).not.toContain('Gatekeeper');
+    } finally {
+      filter.close();
     }
   });
 

--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -201,8 +201,13 @@ describe('GET /install.sh — generated installer script', () => {
     // Argument parser handles --token and forwards it to `enroll` as the
     // positional enrollment key (the flow the Add Device UI uses).
     expect(script).toContain('--token)');
-    expect(script).toContain('BREEZE_ENROLL_TOKEN');
-    expect(script).toContain('ENROLL_ARGS=(enroll)');
+    expect(script.match(/ENROLL_ARGS=\(enroll\)/g)).toHaveLength(2);
+    // The token and conditional secret must be appended in BOTH the darwin
+    // and linux branches — a single match means one platform lost enrollment.
+    expect(script.match(/ENROLL_ARGS\+=\("\$BREEZE_ENROLL_TOKEN"\)/g)).toHaveLength(2);
+    expect(
+      script.match(/ENROLL_ARGS\+=\(--enrollment-secret "\$BREEZE_ENROLLMENT_SECRET"\)/g),
+    ).toHaveLength(2);
   });
 
   it('requires a token OR an enrollment secret, not unconditionally the secret', async () => {
@@ -220,9 +225,10 @@ describe('GET /install.sh — generated installer script', () => {
 
   it('flags intercepted responses (captive portal / wrong responder) distinctly', async () => {
     const script = await fetchScript();
-    // A 200 whose body is not Breeze's health JSON means some other device
-    // answered (captive portal, router, web filter) — the SemoTech guest-VLAN
-    // case. The message must say so instead of letting `installer` fail cryptically.
+    // A 200 whose body is not Breeze's health JSON almost always means an
+    // intercepting device answered (captive portal, router, web filter) —
+    // the guest-VLAN field report behind this feature. The message must say
+    // so instead of letting `installer` fail cryptically.
     expect(script).toContain('captive portal');
   });
 
@@ -233,8 +239,11 @@ describe('GET /install.sh — generated installer script', () => {
 });
 
 describe('install.sh functional pre-flight behavior', () => {
-  // Runs the real generated script with bash. An `id` PATH shim makes the
-  // root check pass so execution reaches the connectivity pre-flight.
+  // Runs the real generated script with bash. An `id` PATH shim (always
+  // prints 0, emulating `id -u` under root) makes the script's root check
+  // pass so execution reaches the connectivity pre-flight. If the root check
+  // ever stops using `id`, these tests fail on the root-check fatal — update
+  // the shim to match.
   let tmp: string;
   let scriptFile: string;
   let shimDir: string;
@@ -258,7 +267,17 @@ describe('install.sh functional pre-flight behavior', () => {
       execFile(
         'bash',
         [scriptFile, ...args],
-        { env: { ...process.env, PATH: `${shimDir}:${process.env.PATH}` }, timeout: 30_000 },
+        {
+          env: {
+            ...process.env,
+            PATH: `${shimDir}:${process.env.PATH}`,
+            // curl must hit 127.0.0.1 directly — a developer/CI proxy would
+            // turn "connection refused" into a proxy response.
+            no_proxy: '*',
+            NO_PROXY: '*',
+          },
+          timeout: 30_000,
+        },
         (err, stdout, stderr) => {
           const code = err && typeof err.code === 'number' ? err.code : err ? 1 : 0;
           resolve({ code, output: `${stdout}${stderr}` });
@@ -276,7 +295,7 @@ describe('install.sh functional pre-flight behavior', () => {
   });
 
   it('flags a captive portal that answers 200 with a non-Breeze body', async () => {
-    // The SemoTech guest-VLAN case: an intercepting device returns 200 HTML,
+    // The guest-VLAN field report: an intercepting device returns 200 HTML,
     // which previously sailed past `curl -f` and died inside `installer`.
     const portal = createServer((_req, res) => {
       res.writeHead(200, { 'Content-Type': 'text/html' });
@@ -298,5 +317,50 @@ describe('install.sh functional pre-flight behavior', () => {
     const { code, output } = await runScript(['--server', 'http://127.0.0.1:1']);
     expect(code).not.toBe(0);
     expect(output).toContain('Pass --token TOKEN or --enrollment-secret SECRET');
+  });
+
+  it('accepts --enrollment-secret alone (legacy flow) past credential validation', async () => {
+    const { code, output } = await runScript([
+      '--server',
+      'http://127.0.0.1:1',
+      '--enrollment-secret',
+      'sec',
+    ]);
+    // Dies at the connectivity pre-flight (nothing listening), proving the
+    // token-OR-secret check let the secret-only invocation through.
+    expect(code).not.toBe(0);
+    expect(output).not.toContain('enrollment credential is required');
+    expect(output).toContain('Cannot reach the Breeze server');
+  });
+
+  it('proceeds past the pre-flight when /health returns the real Breeze body', async () => {
+    // Guards the cross-file contract between the script's grep and the
+    // GET /health payload in apps/api/src/index.ts: if either side drifts,
+    // a pre-flight that ALWAYS fails would still pass the failure-oriented
+    // tests above while bricking every real install.
+    const breeze = createServer((req, res) => {
+      if (req.url === '/health') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        // Mirrors the exact body shape of GET /health in index.ts.
+        res.end(JSON.stringify({ status: 'ok', version: 'test', uptime: 1 }));
+      } else {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+      }
+    });
+    await new Promise<void>((resolve) => breeze.listen(0, '127.0.0.1', resolve));
+    const { port } = breeze.address() as AddressInfo;
+    try {
+      const { code, output } = await runScript(['--server', `http://127.0.0.1:${port}`, '--token', 'tok']);
+      expect(output).toContain('Breeze server is reachable');
+      expect(output).not.toContain('Cannot reach the Breeze server');
+      expect(output).not.toContain('captive portal');
+      // It then fails at the download step (the fake server 404s everything
+      // else) — beyond the pre-flight under test, but proof it got there.
+      expect(code).not.toBe(0);
+      expect(output).toContain('Failed to');
+    } finally {
+      breeze.close();
+    }
   });
 });

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -320,10 +320,10 @@ function generateInstallScript(serverUrl: string): string {
 #     --server ${serverUrl} \\
 #     --enrollment-secret YOUR_SECRET
 #
-# Or with environment variables:
-#   export BREEZE_SERVER="${serverUrl}"
-#   export BREEZE_ENROLLMENT_SECRET="YOUR_SECRET"
-#   curl -fsSL ${serverUrl}/api/v1/agents/install.sh | sudo bash
+# Or with environment variables — pass them through sudo, since a plain
+# \`export\` is stripped by sudo's env_reset:
+#   curl -fsSL ${serverUrl}/api/v1/agents/install.sh | \\
+#     sudo BREEZE_SERVER="${serverUrl}" BREEZE_ENROLLMENT_SECRET="YOUR_SECRET" bash
 # ============================================
 
 set -euo pipefail
@@ -371,7 +371,7 @@ if [[ -z "\$BREEZE_SERVER" ]]; then
 fi
 
 if [[ -z "\$BREEZE_ENROLL_TOKEN" && -z "\$BREEZE_ENROLLMENT_SECRET" ]]; then
-  fatal "An enrollment credential is required. Pass --token TOKEN or --enrollment-secret SECRET (or export BREEZE_ENROLL_TOKEN / BREEZE_ENROLLMENT_SECRET)."
+  fatal "An enrollment credential is required. Pass --token TOKEN or --enrollment-secret SECRET (or pass BREEZE_ENROLL_TOKEN / BREEZE_ENROLLMENT_SECRET through sudo)."
 fi
 
 # Strip trailing slash from server URL
@@ -444,6 +444,9 @@ elif [[ "\$HEALTH_CODE" != "200" ]]; then
   fatal "Cannot reach the Breeze server at \$BREEZE_SERVER (HTTP \$HEALTH_CODE). Verify the server URL is correct and this machine has network access to it."
 fi
 
+# NOTE: stays in lockstep with GET /health in apps/api/src/index.ts — the
+# body must contain "status":"ok". If that payload changes, healthy installs
+# would start failing with the (misleading) interception message below.
 if ! grep -q '"status"[[:space:]]*:[[:space:]]*"ok"' "\$HEALTH_FILE"; then
   fatal "Got an unexpected response from \$BREEZE_SERVER/health — something other than the Breeze server answered. A captive portal, router, or web filter may be intercepting traffic on this network."
 fi

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -436,11 +436,22 @@ fi
 info "Checking connectivity to \$BREEZE_SERVER..."
 HEALTH_FILE="$(mktemp)"
 trap 'rm -f "\$HEALTH_FILE"' EXIT
-HEALTH_CODE="$(curl -fsSL -m 20 -w '%{http_code}' -o "\$HEALTH_FILE" "\$BREEZE_SERVER/health" 2>/dev/null)" || true
+CURL_RC=0
+HEALTH_CODE="$(curl -fsSL -m 20 -w '%{http_code}' -o "\$HEALTH_FILE" "\$BREEZE_SERVER/health" 2>/dev/null)" || CURL_RC=\$?
+HEALTH_CODE="\${HEALTH_CODE:-000}"
 
-if [[ "\$HEALTH_CODE" == "000" ]]; then
-  fatal "Cannot reach the Breeze server at \$BREEZE_SERVER (no response). Verify this machine has network access to the server — check DNS, firewall rules, and VLAN restrictions."
-elif [[ "\$HEALTH_CODE" != "200" ]]; then
+if [[ "\$HEALTH_CODE" != "200" ]]; then
+  # curl's exit code names the transport failure precisely — branch on the
+  # ones whose remediation differs from generic "check your network".
+  case "\$CURL_RC" in
+    35|60)
+      fatal "TLS problem connecting to \$BREEZE_SERVER — the server certificate could not be verified, or something is intercepting HTTPS on this network." ;;
+    28)
+      fatal "Connection to \$BREEZE_SERVER timed out. Verify this machine has network access to the server — check DNS, firewall rules, and VLAN restrictions." ;;
+  esac
+  if [[ "\$HEALTH_CODE" == "000" ]]; then
+    fatal "Cannot reach the Breeze server at \$BREEZE_SERVER (no response). Verify this machine has network access to the server — check DNS, firewall rules, and VLAN restrictions."
+  fi
   fatal "Cannot reach the Breeze server at \$BREEZE_SERVER (HTTP \$HEALTH_CODE). Verify the server URL is correct and this machine has network access to it."
 fi
 
@@ -505,6 +516,14 @@ if [[ "\$OS" == "darwin" ]]; then
 
   success "Downloaded installer package ($(wc -c < "\$TMPPKG" | tr -d ' ') bytes)"
 
+  # A path-selective middlebox can pass the /health pre-flight and still
+  # intercept the download path. macOS .pkg files are xar archives — anything
+  # else (typically a portal's HTML) must be blamed on the network, not on
+  # Gatekeeper below.
+  if [[ "$(head -c 4 "\$TMPPKG")" != 'xar!' ]]; then
+    fatal "Downloaded file is not a macOS installer package — something on this network may be intercepting requests to \$BREEZE_SERVER (captive portal, proxy, or web filter)."
+  fi
+
   # Verify Apple notarization/signature before installing as root — the installer
   # CLI does not enforce Gatekeeper on its own, so a tampered/MITM'd download
   # would otherwise be installed with full privileges.
@@ -566,6 +585,12 @@ trap 'rm -f "\$METADATA_FILE"' EXIT
 METADATA_HTTP_CODE="$(curl -fsSL -w '%{http_code}' -o "\$METADATA_FILE" "\$VERSION_METADATA_URL" 2>/dev/null)" || true
 if [[ "\$METADATA_HTTP_CODE" != "200" ]]; then
   fatal "Failed to fetch release integrity metadata (HTTP \$METADATA_HTTP_CODE). Refusing to install without a trusted checksum."
+fi
+
+# Same path-selective interception guard as the macOS branch: a 200 whose
+# body is HTML is a middlebox answering for the metadata endpoint.
+if grep -qiE '<html|<!doctype' "\$METADATA_FILE"; then
+  fatal "Got a web page instead of release metadata from \$BREEZE_SERVER — something on this network may be intercepting requests (captive portal, proxy, or web filter)."
 fi
 
 EXPECTED_SHA256="$(extract_checksum "\$METADATA_FILE")"

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -310,7 +310,12 @@ function generateInstallScript(serverUrl: string): string {
 # ============================================
 # Breeze RMM Agent - One-Line Installer
 # ============================================
-# Usage:
+# Usage (enrollment token from the Add Device dialog):
+#   curl -fsSL ${serverUrl}/api/v1/agents/install.sh | sudo bash -s -- \\
+#     --server ${serverUrl} \\
+#     --token YOUR_ENROLLMENT_TOKEN
+#
+# Or with an org enrollment secret:
 #   curl -fsSL ${serverUrl}/api/v1/agents/install.sh | sudo bash -s -- \\
 #     --server ${serverUrl} \\
 #     --enrollment-secret YOUR_SECRET
@@ -338,6 +343,7 @@ fatal()   { error "$*"; exit 1; }
 
 # ----- Parse arguments -----
 BREEZE_SERVER="\${BREEZE_SERVER:-}"
+BREEZE_ENROLL_TOKEN="\${BREEZE_ENROLL_TOKEN:-}"
 BREEZE_ENROLLMENT_SECRET="\${BREEZE_ENROLLMENT_SECRET:-}"
 BREEZE_SITE_ID="\${BREEZE_SITE_ID:-}"
 BREEZE_DEVICE_ROLE="\${BREEZE_DEVICE_ROLE:-}"
@@ -346,6 +352,8 @@ while [[ \$# -gt 0 ]]; do
   case "\$1" in
     --server)
       BREEZE_SERVER="\$2"; shift 2 ;;
+    --token)
+      BREEZE_ENROLL_TOKEN="\$2"; shift 2 ;;
     --enrollment-secret)
       BREEZE_ENROLLMENT_SECRET="\$2"; shift 2 ;;
     --site-id)
@@ -362,8 +370,8 @@ if [[ -z "\$BREEZE_SERVER" ]]; then
   fatal "BREEZE_SERVER is required. Pass --server URL or export BREEZE_SERVER."
 fi
 
-if [[ -z "\$BREEZE_ENROLLMENT_SECRET" ]]; then
-  fatal "BREEZE_ENROLLMENT_SECRET is required. Pass --enrollment-secret SECRET or export BREEZE_ENROLLMENT_SECRET."
+if [[ -z "\$BREEZE_ENROLL_TOKEN" && -z "\$BREEZE_ENROLLMENT_SECRET" ]]; then
+  fatal "An enrollment credential is required. Pass --token TOKEN or --enrollment-secret SECRET (or export BREEZE_ENROLL_TOKEN / BREEZE_ENROLLMENT_SECRET)."
 fi
 
 # Strip trailing slash from server URL
@@ -420,6 +428,29 @@ fi
 if ! command -v curl &>/dev/null; then
   fatal "curl is required but not installed. Install it and try again."
 fi
+
+# ----- Pre-flight: verify this machine can actually reach the Breeze server -----
+# Catches split-connectivity setups (guest VLANs, no NAT hairpinning, web
+# filters) up front, instead of letting a later step fail with a cryptic
+# OS-level error after downloading garbage.
+info "Checking connectivity to \$BREEZE_SERVER..."
+HEALTH_FILE="$(mktemp)"
+trap 'rm -f "\$HEALTH_FILE"' EXIT
+HEALTH_CODE="$(curl -fsSL -m 20 -w '%{http_code}' -o "\$HEALTH_FILE" "\$BREEZE_SERVER/health" 2>/dev/null)" || true
+
+if [[ "\$HEALTH_CODE" == "000" ]]; then
+  fatal "Cannot reach the Breeze server at \$BREEZE_SERVER (no response). Verify this machine has network access to the server — check DNS, firewall rules, and VLAN restrictions."
+elif [[ "\$HEALTH_CODE" != "200" ]]; then
+  fatal "Cannot reach the Breeze server at \$BREEZE_SERVER (HTTP \$HEALTH_CODE). Verify the server URL is correct and this machine has network access to it."
+fi
+
+if ! grep -q '"status"[[:space:]]*:[[:space:]]*"ok"' "\$HEALTH_FILE"; then
+  fatal "Got an unexpected response from \$BREEZE_SERVER/health — something other than the Breeze server answered. A captive portal, router, or web filter may be intercepting traffic on this network."
+fi
+
+rm -f "\$HEALTH_FILE"
+trap - EXIT
+success "Breeze server is reachable"
 
 sha256_file() {
   if command -v sha256sum &>/dev/null; then
@@ -489,11 +520,14 @@ if [[ "\$OS" == "darwin" ]]; then
 
   # Enroll agent
   info "Enrolling agent with Breeze server..."
-  ENROLL_ARGS=(
-    enroll
-    --server "\$BREEZE_SERVER"
-    --enrollment-secret "\$BREEZE_ENROLLMENT_SECRET"
-  )
+  ENROLL_ARGS=(enroll)
+  if [[ -n "\$BREEZE_ENROLL_TOKEN" ]]; then
+    ENROLL_ARGS+=("\$BREEZE_ENROLL_TOKEN")
+  fi
+  ENROLL_ARGS+=(--server "\$BREEZE_SERVER")
+  if [[ -n "\$BREEZE_ENROLLMENT_SECRET" ]]; then
+    ENROLL_ARGS+=(--enrollment-secret "\$BREEZE_ENROLLMENT_SECRET")
+  fi
   if [[ -n "\$BREEZE_SITE_ID" ]]; then
     ENROLL_ARGS+=(--site-id "\$BREEZE_SITE_ID")
   fi
@@ -580,11 +614,14 @@ success "Config directory ready"
 
 # ----- Enroll agent -----
 info "Enrolling agent with Breeze server..."
-ENROLL_ARGS=(
-  enroll
-  --server "\$BREEZE_SERVER"
-  --enrollment-secret "\$BREEZE_ENROLLMENT_SECRET"
-)
+ENROLL_ARGS=(enroll)
+if [[ -n "\$BREEZE_ENROLL_TOKEN" ]]; then
+  ENROLL_ARGS+=("\$BREEZE_ENROLL_TOKEN")
+fi
+ENROLL_ARGS+=(--server "\$BREEZE_SERVER")
+if [[ -n "\$BREEZE_ENROLLMENT_SECRET" ]]; then
+  ENROLL_ARGS+=(--enrollment-secret "\$BREEZE_ENROLLMENT_SECRET")
+fi
 if [[ -n "\$BREEZE_SITE_ID" ]]; then
   ENROLL_ARGS+=(--site-id "\$BREEZE_SITE_ID")
 fi

--- a/apps/web/src/components/devices/AddDeviceModal.tsx
+++ b/apps/web/src/components/devices/AddDeviceModal.tsx
@@ -5,6 +5,7 @@ import { showToast } from '../shared/Toast';
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
 import { fallbackInstallerFilename, filenameFromContentDisposition } from '@/lib/downloadFilename';
+import { buildInstallCommands } from '@/lib/installCommands';
 import { navigateTo } from '@/lib/navigation';
 
 function detectUserOS(): 'windows' | 'macos' | 'linux' {
@@ -811,23 +812,14 @@ export default function AddDeviceModal({ isOpen, onClose }: AddDeviceModalProps)
 
             {/* Commands section */}
             {(() => {
-              const apiUrl = (
-                import.meta.env.PUBLIC_API_URL || window.location.origin
-              ).replace(/\/$/, '');
-              const ghBase = (
-                import.meta.env.PUBLIC_AGENT_DOWNLOAD_URL ||
-                'https://github.com/lanternops/breeze/releases/latest/download'
-              ).replace(/\/$/, '');
-              const token = onboardingToken || '<TOKEN>';
-              const secretFlag = enrollmentSecret
-                ? ` --enrollment-secret "${enrollmentSecret}"`
-                : '';
-
-              const winCmd = `Invoke-WebRequest -Uri "${ghBase}/breeze-agent-windows-amd64.exe" -OutFile breeze-agent.exe; .\\breeze-agent.exe service install; .\\breeze-agent.exe enroll "${token}" --server "${apiUrl}"${secretFlag}; .\\breeze-agent.exe service start`;
-              const macCmd = `curl -fsSL -o /tmp/breeze-agent.pkg "${apiUrl}/api/v1/agents/download/darwin/$(uname -m | sed 's/x86_64/amd64/;s/arm64/arm64/')/pkg" && sudo installer -pkg /tmp/breeze-agent.pkg -target / && sudo breeze-agent enroll "${token}" --server "${apiUrl}"${secretFlag} && sudo launchctl kickstart -k system/com.breeze.agent`;
-              const linuxCmd = `curl -fsSL -o breeze-agent "${ghBase}/breeze-agent-linux-$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" && chmod +x breeze-agent && sudo mv breeze-agent /usr/local/bin/ && sudo breeze-agent service install && sudo breeze-agent enroll "${token}" --server "${apiUrl}"${secretFlag} && sudo breeze-agent service start`;
-
-              const commands = { windows: winCmd, macos: macCmd, linux: linuxCmd };
+              const commands = buildInstallCommands({
+                apiUrl: import.meta.env.PUBLIC_API_URL || window.location.origin,
+                ghBase:
+                  import.meta.env.PUBLIC_AGENT_DOWNLOAD_URL ||
+                  'https://github.com/lanternops/breeze/releases/latest/download',
+                token: onboardingToken || '<TOKEN>',
+                enrollmentSecret: enrollmentSecret || undefined,
+              });
 
               return (
                 <div>

--- a/apps/web/src/components/setup/EnrollDeviceStep.tsx
+++ b/apps/web/src/components/setup/EnrollDeviceStep.tsx
@@ -3,6 +3,7 @@ import { Check, Copy, Loader2, Download, Link, ArrowLeft, Info } from 'lucide-re
 import { fetchWithAuth } from '../../stores/auth';
 import { extractApiError } from '@/lib/apiError';
 import { fallbackInstallerFilename, filenameFromContentDisposition } from '@/lib/downloadFilename';
+import { buildInstallCommands } from '@/lib/installCommands';
 import { showToast } from '../shared/Toast';
 
 type Platform = 'windows' | 'macos' | 'linux';
@@ -462,16 +463,14 @@ export default function EnrollDeviceStep({ orgId, siteId, onBack, onFinish: _onF
 
           {/* Commands */}
           {(() => {
-            const apiUrl = (import.meta.env.PUBLIC_API_URL || window.location.origin).replace(/\/$/, '');
-            const ghBase = (import.meta.env.PUBLIC_AGENT_DOWNLOAD_URL || 'https://github.com/lanternops/breeze/releases/latest/download').replace(/\/$/, '');
-            const token = onboardingToken || '<TOKEN>';
-            const secretFlag = enrollmentSecret ? ` --enrollment-secret "${enrollmentSecret}"` : '';
-
-            const commands: Record<Platform, string> = {
-              windows: `Invoke-WebRequest -Uri "${ghBase}/breeze-agent-windows-amd64.exe" -OutFile breeze-agent.exe; .\\breeze-agent.exe service install; .\\breeze-agent.exe enroll "${token}" --server "${apiUrl}"${secretFlag}; .\\breeze-agent.exe service start`,
-              macos: `curl -fsSL -o /tmp/breeze-agent.pkg "${apiUrl}/api/v1/agents/download/darwin/$(uname -m | sed 's/x86_64/amd64/;s/arm64/arm64/')/pkg" && sudo installer -pkg /tmp/breeze-agent.pkg -target / && sudo breeze-agent enroll "${token}" --server "${apiUrl}"${secretFlag} && sudo launchctl kickstart -k system/com.breeze.agent`,
-              linux: `curl -fsSL -o breeze-agent "${ghBase}/breeze-agent-linux-$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" && chmod +x breeze-agent && sudo mv breeze-agent /usr/local/bin/ && sudo breeze-agent service install && sudo breeze-agent enroll "${token}" --server "${apiUrl}"${secretFlag} && sudo breeze-agent service start`,
-            };
+            const commands: Record<Platform, string> = buildInstallCommands({
+              apiUrl: import.meta.env.PUBLIC_API_URL || window.location.origin,
+              ghBase:
+                import.meta.env.PUBLIC_AGENT_DOWNLOAD_URL ||
+                'https://github.com/lanternops/breeze/releases/latest/download',
+              token: onboardingToken || '<TOKEN>',
+              enrollmentSecret: enrollmentSecret || undefined,
+            });
 
             return (
               <div>

--- a/apps/web/src/lib/installCommands.test.ts
+++ b/apps/web/src/lib/installCommands.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { buildInstallCommands } from './installCommands';
+
+const base = {
+  apiUrl: 'https://rmm.example.com',
+  ghBase: 'https://github.com/lanternops/breeze/releases/latest/download',
+  token: 'enroll_abc123',
+};
+
+describe('buildInstallCommands', () => {
+  describe('macOS / Linux (install.sh based)', () => {
+    it('routes through the server-generated install.sh for both platforms', () => {
+      const cmds = buildInstallCommands(base);
+      for (const cmd of [cmds.macos, cmds.linux]) {
+        expect(cmd).toContain('https://rmm.example.com/api/v1/agents/install.sh');
+        expect(cmd).toContain('--server "https://rmm.example.com"');
+        expect(cmd).toContain('--token "enroll_abc123"');
+      }
+      // The script auto-detects the OS; both platforms get the same command.
+      expect(cmds.macos).toBe(cmds.linux);
+    });
+
+    it('downloads to a mktemp path and verifies the shebang before sudo bash', () => {
+      const { macos } = buildInstallCommands(base);
+      // Guards against an intercepting device serving HTML where the script
+      // should be: never pipe straight into bash, check for #! first.
+      expect(macos).toContain('mktemp');
+      expect(macos).toContain("grep -q '^#!'");
+      expect(macos).not.toContain('| sudo bash');
+    });
+
+    it('prints a connectivity-oriented error when the chain fails', () => {
+      const { macos } = buildInstallCommands(base);
+      expect(macos).toContain('could not reach https://rmm.example.com');
+      // Must surface a failing exit code without closing the user's shell.
+      expect(macos).toContain('false; }');
+      expect(macos).not.toContain('exit 1');
+    });
+
+    it('appends --enrollment-secret only when a secret is provided', () => {
+      const withSecret = buildInstallCommands({ ...base, enrollmentSecret: 's3cret' });
+      expect(withSecret.macos).toContain('--enrollment-secret "s3cret"');
+      expect(buildInstallCommands(base).macos).not.toContain('--enrollment-secret');
+    });
+  });
+
+  describe('Windows (PowerShell)', () => {
+    it('stops on download failure via $ErrorActionPreference', () => {
+      const { windows } = buildInstallCommands(base);
+      expect(windows.startsWith("$ErrorActionPreference='Stop';")).toBe(true);
+      expect(windows).toContain('Invoke-WebRequest');
+      expect(windows).toContain('breeze-agent-windows-amd64.exe');
+    });
+
+    it('checks $LASTEXITCODE after every agent invocation', () => {
+      const { windows } = buildInstallCommands(base);
+      // Native exe failures do not throw in PowerShell — each of the three
+      // agent steps (service install, enroll, service start) needs a check.
+      expect(windows.match(/if\(\$LASTEXITCODE\)\{throw/g)).toHaveLength(3);
+      expect(windows).toContain('enroll "enroll_abc123" --server "https://rmm.example.com"');
+    });
+
+    it('appends --enrollment-secret only when a secret is provided', () => {
+      const withSecret = buildInstallCommands({ ...base, enrollmentSecret: 's3cret' });
+      expect(withSecret.windows).toContain('--enrollment-secret "s3cret"');
+      expect(buildInstallCommands(base).windows).not.toContain('--enrollment-secret');
+    });
+  });
+
+  it('strips trailing slashes from apiUrl and ghBase', () => {
+    const cmds = buildInstallCommands({
+      ...base,
+      apiUrl: 'https://rmm.example.com/',
+      ghBase: 'https://gh.example.com/dl/',
+    });
+    expect(cmds.macos).toContain('https://rmm.example.com/api/v1/agents/install.sh');
+    expect(cmds.macos).not.toContain('com//');
+    expect(cmds.windows).toContain('https://gh.example.com/dl/breeze-agent-windows-amd64.exe');
+  });
+});

--- a/apps/web/src/lib/installCommands.test.ts
+++ b/apps/web/src/lib/installCommands.test.ts
@@ -41,6 +41,16 @@ describe('buildInstallCommands', () => {
       expect(macos).not.toContain('exit 1');
     });
 
+    it('sends the error to stderr and bounds the bootstrap fetch', () => {
+      const { macos } = buildInstallCommands(base);
+      // MDM/RMM log collectors split streams — the actionable message must
+      // land on stderr like install.sh's own errors do.
+      expect(macos).toContain('>&2');
+      // Against a DROP-style firewall the user should not stare at a silent
+      // prompt for curl's ~2min default connect timeout.
+      expect(macos).toContain('--connect-timeout 10');
+    });
+
     it('appends --enrollment-secret only when a secret is provided', () => {
       const withSecret = buildInstallCommands({ ...base, enrollmentSecret: 's3cret' });
       expect(withSecret.macos).toContain('--enrollment-secret "s3cret"');
@@ -62,6 +72,18 @@ describe('buildInstallCommands', () => {
       // agent steps (service install, enroll, service start) needs a check.
       expect(windows.match(/if\(\$LASTEXITCODE\)\{throw/g)).toHaveLength(3);
       expect(windows).toContain('enroll "enroll_abc123" --server "https://rmm.example.com"');
+    });
+
+    it('verifies the download is a real PE executable before running it', () => {
+      const { windows } = buildInstallCommands(base);
+      // The Windows analog of the unix shebang check: a captive portal's 200
+      // HTML saved as breeze-agent.exe must be blamed on the network, not
+      // surface as PowerShell's raw "not a valid application" exception.
+      expect(windows).toContain('0x4D');
+      expect(windows).toContain('0x5A');
+      expect(windows).toContain('captive portal or web filter');
+      // The MZ check must run before the first agent invocation.
+      expect(windows.indexOf('0x4D')).toBeLessThan(windows.indexOf('service install'));
     });
 
     it('appends --enrollment-secret only when a secret is provided', () => {

--- a/apps/web/src/lib/installCommands.test.ts
+++ b/apps/web/src/lib/installCommands.test.ts
@@ -29,9 +29,13 @@ describe('buildInstallCommands', () => {
       expect(macos).not.toContain('| sudo bash');
     });
 
-    it('prints a connectivity-oriented error when the chain fails', () => {
+    it('scopes the connectivity error to the fetch + shebang check', () => {
       const { macos } = buildInstallCommands(base);
-      expect(macos).toContain('could not reach https://rmm.example.com');
+      expect(macos).toContain('Could not fetch the Breeze installer from https://rmm.example.com');
+      // The fallback must wrap only the fetch/verify group: install.sh prints
+      // its own precise errors, so a failure inside `sudo bash` must NOT
+      // trigger the "could not fetch" message.
+      expect(macos.indexOf('Could not fetch')).toBeLessThan(macos.indexOf('sudo bash'));
       // Must surface a failing exit code without closing the user's shell.
       expect(macos).toContain('false; }');
       expect(macos).not.toContain('exit 1');

--- a/apps/web/src/lib/installCommands.ts
+++ b/apps/web/src/lib/installCommands.ts
@@ -23,22 +23,30 @@ export interface InstallCommands {
  * connectivity to the server (distinguishing "unreachable" from "intercepted
  * by a captive portal/router"), verifies the download, and surfaces enrollment
  * failures — instead of letting `installer`/`bash` die with a cryptic OS error
- * (the guest-VLAN report from v0.69.0). The one-liner itself only trusts the
- * fetched file after a shebang check, so an intercepting device serving HTML
- * is reported as a connectivity problem rather than executed.
+ * (see PR #1271 for the original field report). The one-liner itself only
+ * trusts the fetched file after a shebang check, so an intercepting device
+ * serving HTML is reported as a connectivity problem rather than executed.
  */
 export function buildInstallCommands(opts: InstallCommandOptions): InstallCommands {
   const apiUrl = opts.apiUrl.replace(/\/+$/, '');
   const ghBase = opts.ghBase.replace(/\/+$/, '');
   const { token, enrollmentSecret } = opts;
 
+  // The connectivity message is scoped to the fetch + shebang check only —
+  // once install.sh runs it reports its own failures precisely, and appending
+  // a "could not reach" hint after e.g. an enrollment error would mislead.
   const unixSecretFlag = enrollmentSecret ? ` --enrollment-secret "${enrollmentSecret}"` : '';
   const unixCmd =
-    `f="$(mktemp)" && curl -fsSL -o "$f" "${apiUrl}/api/v1/agents/install.sh" && ` +
-    `head -n1 "$f" | grep -q '^#!' && ` +
-    `sudo bash "$f" --server "${apiUrl}" --token "${token}"${unixSecretFlag} || ` +
-    `{ echo "[ERROR] Breeze install did not complete. If no error is shown above, this machine could not reach ${apiUrl} — verify it has network access to your Breeze server."; false; }`;
+    `f="$(mktemp)" && ` +
+    `{ curl -fsSL -o "$f" "${apiUrl}/api/v1/agents/install.sh" && head -n1 "$f" | grep -q '^#!' || ` +
+    `{ echo "[ERROR] Could not fetch the Breeze installer from ${apiUrl} — verify this machine has network access to your Breeze server."; false; }; } && ` +
+    `sudo bash "$f" --server "${apiUrl}" --token "${token}"${unixSecretFlag}`;
 
+  // No captive-portal detection on Windows: a 200 HTML page saved as
+  // breeze-agent.exe surfaces as a failed "service install" step instead.
+  // PowerShell has no cheap shebang-check equivalent; the $LASTEXITCODE
+  // throws at least stop the chain (native exe failures do not trip
+  // $ErrorActionPreference on their own).
   const winSecretFlag = enrollmentSecret ? ` --enrollment-secret "${enrollmentSecret}"` : '';
   const winThrow = (step: string) => `if($LASTEXITCODE){throw "Breeze: ${step} failed (exit code $LASTEXITCODE)"}`;
   const windows =

--- a/apps/web/src/lib/installCommands.ts
+++ b/apps/web/src/lib/installCommands.ts
@@ -1,0 +1,52 @@
+export interface InstallCommandOptions {
+  /** Breeze API origin, e.g. https://eu.2breeze.app */
+  apiUrl: string;
+  /** Base URL for direct Windows binary downloads (GitHub releases) */
+  ghBase: string;
+  /** Enrollment token from the Add Device / setup flow */
+  token: string;
+  /** Optional org enrollment secret */
+  enrollmentSecret?: string;
+}
+
+export interface InstallCommands {
+  windows: string;
+  macos: string;
+  linux: string;
+}
+
+/**
+ * Builds the copy-paste agent install commands shown in the Add Device modal
+ * and the setup wizard.
+ *
+ * macOS/Linux route through the server-generated install.sh, which pre-flights
+ * connectivity to the server (distinguishing "unreachable" from "intercepted
+ * by a captive portal/router"), verifies the download, and surfaces enrollment
+ * failures — instead of letting `installer`/`bash` die with a cryptic OS error
+ * (the guest-VLAN report from v0.69.0). The one-liner itself only trusts the
+ * fetched file after a shebang check, so an intercepting device serving HTML
+ * is reported as a connectivity problem rather than executed.
+ */
+export function buildInstallCommands(opts: InstallCommandOptions): InstallCommands {
+  const apiUrl = opts.apiUrl.replace(/\/+$/, '');
+  const ghBase = opts.ghBase.replace(/\/+$/, '');
+  const { token, enrollmentSecret } = opts;
+
+  const unixSecretFlag = enrollmentSecret ? ` --enrollment-secret "${enrollmentSecret}"` : '';
+  const unixCmd =
+    `f="$(mktemp)" && curl -fsSL -o "$f" "${apiUrl}/api/v1/agents/install.sh" && ` +
+    `head -n1 "$f" | grep -q '^#!' && ` +
+    `sudo bash "$f" --server "${apiUrl}" --token "${token}"${unixSecretFlag} || ` +
+    `{ echo "[ERROR] Breeze install did not complete. If no error is shown above, this machine could not reach ${apiUrl} — verify it has network access to your Breeze server."; false; }`;
+
+  const winSecretFlag = enrollmentSecret ? ` --enrollment-secret "${enrollmentSecret}"` : '';
+  const winThrow = (step: string) => `if($LASTEXITCODE){throw "Breeze: ${step} failed (exit code $LASTEXITCODE)"}`;
+  const windows =
+    `$ErrorActionPreference='Stop'; ` +
+    `Invoke-WebRequest -Uri "${ghBase}/breeze-agent-windows-amd64.exe" -OutFile breeze-agent.exe; ` +
+    `.\\breeze-agent.exe service install; ${winThrow('service install')}; ` +
+    `.\\breeze-agent.exe enroll "${token}" --server "${apiUrl}"${winSecretFlag}; ${winThrow('enrollment')}; ` +
+    `.\\breeze-agent.exe service start; ${winThrow('service start')}`;
+
+  return { windows, macos: unixCmd, linux: unixCmd };
+}

--- a/apps/web/src/lib/installCommands.ts
+++ b/apps/web/src/lib/installCommands.ts
@@ -38,20 +38,26 @@ export function buildInstallCommands(opts: InstallCommandOptions): InstallComman
   const unixSecretFlag = enrollmentSecret ? ` --enrollment-secret "${enrollmentSecret}"` : '';
   const unixCmd =
     `f="$(mktemp)" && ` +
-    `{ curl -fsSL -o "$f" "${apiUrl}/api/v1/agents/install.sh" && head -n1 "$f" | grep -q '^#!' || ` +
-    `{ echo "[ERROR] Could not fetch the Breeze installer from ${apiUrl} — verify this machine has network access to your Breeze server."; false; }; } && ` +
+    `{ curl -fsSL --connect-timeout 10 -o "$f" "${apiUrl}/api/v1/agents/install.sh" && head -n1 "$f" | grep -q '^#!' || ` +
+    `{ echo "[ERROR] Could not fetch the Breeze installer from ${apiUrl} — verify this machine has network access to your Breeze server." >&2; false; }; } && ` +
     `sudo bash "$f" --server "${apiUrl}" --token "${token}"${unixSecretFlag}`;
 
-  // No captive-portal detection on Windows: a 200 HTML page saved as
-  // breeze-agent.exe surfaces as a failed "service install" step instead.
-  // PowerShell has no cheap shebang-check equivalent; the $LASTEXITCODE
-  // throws at least stop the chain (native exe failures do not trip
-  // $ErrorActionPreference on their own).
+  // The MZ-magic check is the Windows analog of the unix shebang check: a
+  // captive portal's 200 HTML saved as breeze-agent.exe would otherwise stop
+  // the chain with PowerShell's raw "not a valid application" exception
+  // (which never sets $LASTEXITCODE — the process fails to start). The
+  // $LASTEXITCODE throws cover agent steps that DO run but fail, since
+  // native exe exit codes do not trip $ErrorActionPreference.
   const winSecretFlag = enrollmentSecret ? ` --enrollment-secret "${enrollmentSecret}"` : '';
   const winThrow = (step: string) => `if($LASTEXITCODE){throw "Breeze: ${step} failed (exit code $LASTEXITCODE)"}`;
+  const winMzCheck =
+    `$b=[IO.File]::ReadAllBytes("$pwd\\breeze-agent.exe"); ` +
+    `if($b.Length -lt 2 -or $b[0] -ne 0x4D -or $b[1] -ne 0x5A)` +
+    `{throw "Breeze: downloaded file is not a Windows executable - a captive portal or web filter may be intercepting this network"}`;
   const windows =
     `$ErrorActionPreference='Stop'; ` +
     `Invoke-WebRequest -Uri "${ghBase}/breeze-agent-windows-amd64.exe" -OutFile breeze-agent.exe; ` +
+    `${winMzCheck}; ` +
     `.\\breeze-agent.exe service install; ${winThrow('service install')}; ` +
     `.\\breeze-agent.exe enroll "${token}" --server "${apiUrl}"${winSecretFlag}; ${winThrow('enrollment')}; ` +
     `.\\breeze-agent.exe service start; ${winThrow('service start')}`;


### PR DESCRIPTION
## Summary

A user testing the v0.69.0 macOS CLI install hit a confusing failure on a guest VLAN: the machine could reach GitHub but not the Breeze server FQDN (no NAT hairpinning), and the install died with Apple's cryptic `installer: Error - the package path specified was invalid: '/tmp/breeze-agent.pkg'`.

**Root cause:** an intercepting device answered the download request with HTTP 200 + HTML, which sailed past `curl -f`, got saved as the .pkg, and the `&&` chain happily ran `sudo installer` on it. The UI-generated one-liners had no HTTP-code, content, or signature validation — while the hardened `/api/v1/agents/install.sh` (HTTP-code capture, empty-file check, Gatekeeper `spctl --assess`, enrollment error messages) already existed but was bypassed by the UI.

## Changes

**`install.sh` generator (`apps/api/src/routes/agents/download.ts`)**
- New `--token` argument (positional enrollment key for `breeze-agent enroll`) so the Add Device token flow can use the script; the credential check now requires token OR enrollment secret instead of unconditionally requiring the secret
- Connectivity pre-flight against `GET /health` before any download, with three distinct outcomes:
  - no response → "Cannot reach the Breeze server … check DNS, firewall rules, and VLAN restrictions"
  - HTTP ≠ 200 → "Cannot reach the Breeze server (HTTP xxx) …"
  - 200 but non-Breeze body → "something other than the Breeze server answered. A captive portal, router, or web filter may be intercepting traffic" (the exact failure mode from the report)

**Web UI (`apps/web/src/lib/installCommands.ts`, Add Device modal + setup wizard)**
- New shared `buildInstallCommands()` helper replaces the duplicated inline command templates
- macOS/Linux commands now fetch `install.sh` to a `mktemp` path, verify the shebang before `sudo bash` (never pipe straight into bash), and print a connectivity-oriented error if the chain fails — surfacing a non-zero exit without closing the user's shell
- macOS installs gain the script's Gatekeeper notarization check and Linux installs gain SHA-256 verification, which the old one-liners skipped
- Windows command now sets `$ErrorActionPreference='Stop'` and checks `$LASTEXITCODE` after each agent step (previously `;`-chained, so every step ran even after a failed download)

## Tests

- `bash -n` syntax guard over the generated script
- Script-content contract tests (`--token` parsing, token-or-secret validation, pre-flight messages)
- Functional tests that execute the real generated script (root check bypassed via an `id` PATH shim) against a refused connection and a fake captive-portal HTTP server, asserting the new error messages and that nothing is downloaded
- New unit tests for `buildInstallCommands()` (16 web assertions); API `download.test.ts` 17/17, web type-check and API type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Behavior change for self-hosters

Routing the UI's macOS command through `install.sh` means UI-driven macOS installs now enforce the script's existing Gatekeeper check (`spctl --assess --type install`). Official tagged releases are notarized, so hosted users are unaffected — but a self-hosted instance serving a locally built, non-notarized `.pkg` will now refuse to install where the old bare `installer -pkg` one-liner silently accepted it. This is the intended hardening (it's what blocks the MITM/intercepted-download case), but it deserves a release-note line.

Linux installs similarly gain the script's SHA-256 verification, which requires the `/api/v1/agent-versions/latest` metadata endpoint to be populated (standard on github/S3 binary sources).
