### PR TITLE
feat: show real user idle time on device detail

### DIFF
--- a/agent/internal/collectors/sessions.go
+++ b/agent/internal/collectors/sessions.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	sessionRefreshInterval = 5 * time.Minute
+	maxIdleMinutes         = 10080 // submitSessionsSchema caps idleMinutes at 7 days
 )
 
 type UserSession struct {
@@ -19,7 +20,7 @@ type UserSession struct {
 	SessionType             string    `json:"sessionType"`
 	SessionID               string    `json:"sessionId,omitempty"`
 	LoginAt                 time.Time `json:"loginAt"`
-	IdleMinutes             int       `json:"idleMinutes,omitempty"`
+	IdleMinutes             *int      `json:"idleMinutes,omitempty"`
 	ActivityState           string    `json:"activityState,omitempty"`
 	LoginPerformanceSeconds int       `json:"loginPerformanceSeconds,omitempty"`
 	IsActive                bool      `json:"isActive"`
@@ -176,19 +177,38 @@ func (c *SessionCollector) refreshSessions(now time.Time) {
 			loginAt = existing.LoginAt
 		}
 
+		idleMinutes, lastActivityAt := idleFields(detected, now)
 		next[key] = UserSession{
 			Username:       detected.Username,
 			SessionType:    inferSessionType(detected),
 			SessionID:      detected.Session,
 			LoginAt:        loginAt,
-			IdleMinutes:    0,
+			IdleMinutes:    idleMinutes,
 			ActivityState:  mapDetectedState(detected.State),
 			IsActive:       true,
-			LastActivityAt: now,
+			LastActivityAt: lastActivityAt,
 		}
 	}
 
 	c.sessions = next
+}
+
+// idleFields converts a detected session's idle measurement into the wire
+// representation: a nil pointer when unknown (so old agents and unmeasurable
+// platforms read as "no data", never "0 minutes"), and a LastActivityAt
+// anchored to the actual last input rather than the refresh tick.
+func idleFields(detected sessionbroker.DetectedSession, now time.Time) (*int, time.Time) {
+	if !detected.IdleKnown {
+		return nil, now
+	}
+	minutes := int(detected.IdleFor / time.Minute)
+	if minutes < 0 {
+		minutes = 0
+	}
+	if minutes > maxIdleMinutes {
+		minutes = maxIdleMinutes
+	}
+	return &minutes, now.Add(-detected.IdleFor)
 }
 
 func (c *SessionCollector) applyEvent(event sessionbroker.SessionEvent, now time.Time) {
@@ -216,7 +236,6 @@ func (c *SessionCollector) applyEvent(event sessionbroker.SessionEvent, now time
 			SessionType:    sessionType,
 			SessionID:      event.Session,
 			LoginAt:        loginAt,
-			IdleMinutes:    0,
 			ActivityState:  "active",
 			IsActive:       true,
 			LastActivityAt: now,

--- a/agent/internal/collectors/sessions_test.go
+++ b/agent/internal/collectors/sessions_test.go
@@ -124,6 +124,10 @@ func TestRefreshSessionsIdleMinutes(t *testing.T) {
 	if carol.IdleMinutes == nil || *carol.IdleMinutes != 10080 {
 		t.Fatalf("carol IdleMinutes = %v, want 10080 (clamped)", carol.IdleMinutes)
 	}
+	// The clamp bounds the minutes metric only; the timestamp stays honest.
+	if !carol.LastActivityAt.Equal(now.Add(-30 * 24 * time.Hour)) {
+		t.Fatalf("carol LastActivityAt = %v, want now-30d", carol.LastActivityAt)
+	}
 }
 
 func TestUserSessionIdleMinutesJSON(t *testing.T) {

--- a/agent/internal/collectors/sessions_test.go
+++ b/agent/internal/collectors/sessions_test.go
@@ -1,7 +1,11 @@
 package collectors
 
 import (
+	"context"
+	"encoding/json"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/breeze-rmm/agent/internal/sessionbroker"
 )
@@ -65,5 +69,78 @@ func TestMapDetectedState(t *testing.T) {
 		if got := mapDetectedState(input); got != expected {
 			t.Fatalf("mapDetectedState(%q) = %q, want %q", input, got, expected)
 		}
+	}
+}
+
+type fakeDetector struct {
+	sessions []sessionbroker.DetectedSession
+}
+
+func (f *fakeDetector) ListSessions() ([]sessionbroker.DetectedSession, error) {
+	return f.sessions, nil
+}
+
+func (f *fakeDetector) WatchSessions(ctx context.Context) <-chan sessionbroker.SessionEvent {
+	ch := make(chan sessionbroker.SessionEvent)
+	close(ch)
+	return ch
+}
+
+func TestRefreshSessionsIdleMinutes(t *testing.T) {
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	c := &SessionCollector{
+		detector: &fakeDetector{sessions: []sessionbroker.DetectedSession{
+			{Username: "alice", Session: "2", State: "active", IdleFor: 23 * time.Minute, IdleKnown: true},
+			{Username: "bob", Session: "3", State: "active"}, // idle unknown
+			{Username: "carol", Session: "4", State: "active", IdleFor: 30 * 24 * time.Hour, IdleKnown: true}, // clamps
+		}},
+		sessions: make(map[string]UserSession),
+	}
+
+	c.refreshSessions(now)
+
+	byUser := make(map[string]UserSession)
+	for _, s := range c.sessions {
+		byUser[s.Username] = s
+	}
+
+	alice := byUser["alice"]
+	if alice.IdleMinutes == nil || *alice.IdleMinutes != 23 {
+		t.Fatalf("alice IdleMinutes = %v, want 23", alice.IdleMinutes)
+	}
+	if !alice.LastActivityAt.Equal(now.Add(-23 * time.Minute)) {
+		t.Fatalf("alice LastActivityAt = %v, want %v", alice.LastActivityAt, now.Add(-23*time.Minute))
+	}
+
+	bob := byUser["bob"]
+	if bob.IdleMinutes != nil {
+		t.Fatalf("bob IdleMinutes = %v, want nil (unknown)", *bob.IdleMinutes)
+	}
+	if !bob.LastActivityAt.Equal(now) {
+		t.Fatalf("bob LastActivityAt = %v, want %v", bob.LastActivityAt, now)
+	}
+
+	carol := byUser["carol"]
+	if carol.IdleMinutes == nil || *carol.IdleMinutes != 10080 {
+		t.Fatalf("carol IdleMinutes = %v, want 10080 (clamped)", carol.IdleMinutes)
+	}
+}
+
+func TestUserSessionIdleMinutesJSON(t *testing.T) {
+	zero := 0
+	withZero, err := json.Marshal(UserSession{Username: "a", SessionType: "console", IdleMinutes: &zero})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(withZero), `"idleMinutes":0`) {
+		t.Fatalf("measured-zero idle must serialize explicitly, got %s", withZero)
+	}
+
+	unknown, err := json.Marshal(UserSession{Username: "a", SessionType: "console"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(unknown), "idleMinutes") {
+		t.Fatalf("unknown idle must be omitted from the wire, got %s", unknown)
 	}
 }

--- a/agent/internal/sessionbroker/detector.go
+++ b/agent/internal/sessionbroker/detector.go
@@ -1,6 +1,9 @@
 package sessionbroker
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // SessionEventType identifies login/logout/switch events.
 type SessionEventType string
@@ -33,6 +36,12 @@ type DetectedSession struct {
 	Seat     string `json:"seat,omitempty"`
 	State    string `json:"state,omitempty"` // "active", "online", "closing"
 	Type     string `json:"type,omitempty"`  // "console", "rdp", "services"
+
+	// IdleFor is how long the session has gone without user input. Only
+	// meaningful when IdleKnown is true; platforms that cannot measure input
+	// idle (or fail to) leave IdleKnown false.
+	IdleFor   time.Duration `json:"-"`
+	IdleKnown bool          `json:"-"`
 }
 
 // SessionDetector detects user sessions and monitors login/logout events.

--- a/agent/internal/sessionbroker/detector_darwin.go
+++ b/agent/internal/sessionbroker/detector_darwin.go
@@ -3,9 +3,10 @@
 package sessionbroker
 
 /*
-#cgo LDFLAGS: -framework SystemConfiguration -framework CoreFoundation
+#cgo LDFLAGS: -framework SystemConfiguration -framework CoreFoundation -framework IOKit
 #include <SystemConfiguration/SystemConfiguration.h>
 #include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/IOKitLib.h>
 
 // getConsoleUser returns the current console user's username and UID.
 static int getConsoleUser(char *buf, int bufsize, unsigned int *uid) {
@@ -14,6 +15,24 @@ static int getConsoleUser(char *buf, int bufsize, unsigned int *uid) {
     Boolean ok = CFStringGetCString(username, buf, bufsize, kCFStringEncodingUTF8);
     CFRelease(username);
     return ok ? 1 : 0;
+}
+
+// getHIDIdleNanos reads the system-wide HID idle time (nanoseconds since last
+// keyboard/mouse input) from the IOHIDSystem registry entry. Returns 0 on
+// failure, 1 on success. Passing 0 as the master port targets the default
+// port on all supported macOS versions.
+static int getHIDIdleNanos(long long *ns) {
+    io_service_t svc = IOServiceGetMatchingService(0, IOServiceMatching("IOHIDSystem"));
+    if (!svc) return 0;
+    CFTypeRef prop = IORegistryEntryCreateCFProperty(svc, CFSTR("HIDIdleTime"), kCFAllocatorDefault, 0);
+    IOObjectRelease(svc);
+    if (!prop) return 0;
+    int ok = 0;
+    if (CFGetTypeID(prop) == CFNumberGetTypeID()) {
+        ok = CFNumberGetValue((CFNumberRef)prop, kCFNumberSInt64Type, ns);
+    }
+    CFRelease(prop);
+    return ok;
 }
 */
 import "C"
@@ -54,6 +73,12 @@ func (d *darwinDetector) ListSessions() ([]DetectedSession, error) {
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	var idleNs C.longlong
+	if C.getHIDIdleNanos(&idleNs) != 0 && idleNs >= 0 {
+		session.IdleFor = time.Duration(idleNs)
+		session.IdleKnown = true
 	}
 
 	return []DetectedSession{session}, nil

--- a/agent/internal/sessionbroker/detector_darwin_idle_test.go
+++ b/agent/internal/sessionbroker/detector_darwin_idle_test.go
@@ -1,0 +1,24 @@
+//go:build darwin && cgo
+
+package sessionbroker
+
+import "testing"
+
+// TestDarwinIdleKnown asserts that when a console user is present, the darwin
+// detector reports a known, non-negative idle duration from HIDIdleTime.
+func TestDarwinIdleKnown(t *testing.T) {
+	sessions, err := NewSessionDetector().ListSessions()
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(sessions) == 0 {
+		t.Skip("no console user logged in")
+	}
+	s := sessions[0]
+	if !s.IdleKnown {
+		t.Fatal("expected IdleKnown=true for console session on darwin cgo build")
+	}
+	if s.IdleFor < 0 {
+		t.Fatalf("expected non-negative idle, got %v", s.IdleFor)
+	}
+}

--- a/agent/internal/sessionbroker/detector_linux.go
+++ b/agent/internal/sessionbroker/detector_linux.go
@@ -88,6 +88,10 @@ func (d *linuxDetector) ListSessions() ([]DetectedSession, error) {
 			if err := propScanner.Err(); err != nil {
 				return nil, fmt.Errorf("parse loginctl show-session output for %s: %w", sessionID, err)
 			}
+			// Idle is only reported when the DE actively asserts IdleHint=yes.
+			// IdleHint=no must stay unknown, not "active": most DEs and all
+			// headless sessions never call SetIdleHint, so "no" is
+			// indistinguishable from "nobody reports it".
 			if idleHint {
 				if since, ok := parseIdleSinceHint(idleSinceRaw); ok {
 					sess.IdleFor, sess.IdleKnown = idleSince(time.Now(), since)

--- a/agent/internal/sessionbroker/detector_linux.go
+++ b/agent/internal/sessionbroker/detector_linux.go
@@ -57,9 +57,11 @@ func (d *linuxDetector) ListSessions() ([]DetectedSession, error) {
 		// Query session properties
 		propCtx, propCancel := context.WithTimeout(context.Background(), detectorCommandTimeout)
 		propOut, propErr := exec.CommandContext(propCtx, "loginctl", "show-session", sessionID,
-			"--property=Type,Remote,Display,Seat,State").Output()
+			"--property=Type,Remote,Display,Seat,State,IdleHint,IdleSinceHint").Output()
 		propCancel()
 		if propErr == nil {
+			var idleHint bool
+			var idleSinceRaw string
 			propScanner := newDetectorScanner(string(propOut))
 			for propScanner.Scan() {
 				parts := strings.SplitN(strings.TrimSpace(propScanner.Text()), "=", 2)
@@ -77,10 +79,19 @@ func (d *linuxDetector) ListSessions() ([]DetectedSession, error) {
 					sess.Seat = parts[1]
 				case "State":
 					sess.State = parts[1]
+				case "IdleHint":
+					idleHint = parts[1] == "yes"
+				case "IdleSinceHint":
+					idleSinceRaw = parts[1]
 				}
 			}
 			if err := propScanner.Err(); err != nil {
 				return nil, fmt.Errorf("parse loginctl show-session output for %s: %w", sessionID, err)
+			}
+			if idleHint {
+				if since, ok := parseIdleSinceHint(idleSinceRaw); ok {
+					sess.IdleFor, sess.IdleKnown = idleSince(time.Now(), since)
+				}
 			}
 		}
 

--- a/agent/internal/sessionbroker/detector_windows.go
+++ b/agent/internal/sessionbroker/detector_windows.go
@@ -33,6 +33,7 @@ const (
 	wtsUserName            = 5
 	wtsDomainName          = 7
 	wtsClientProtocolType  = 16
+	wtsSessionInfoEx       = 25 // WTSInfoClass: WTSSessionInfoEx
 
 	wtsDisconnected = 4 // WTS_CONNECTSTATE_CLASS: WTSDisconnected
 )
@@ -41,6 +42,65 @@ type wtsSessionInfo struct {
 	SessionID      uint32
 	WinStationName *uint16
 	State          uint32
+}
+
+// wtsInfoExLevel1 mirrors WTSINFOEX_LEVEL1_W from wtsapi32.h. Field order and
+// the explicit padding before LogonTime must match the C layout exactly:
+// 12 bytes of DWORDs + 72 UTF-16 chars (144 bytes) = 156, padded to 160 so the
+// LARGE_INTEGER block is 8-aligned.
+type wtsInfoExLevel1 struct {
+	SessionID               uint32
+	SessionState            int32
+	SessionFlags            int32
+	WinStationName          [33]uint16
+	UserName                [21]uint16
+	DomainName              [18]uint16
+	_                       [4]byte
+	LogonTime               int64
+	ConnectTime             int64
+	DisconnectTime          int64
+	LastInputTime           int64 // FILETIME; 0 = no input recorded
+	CurrentTime             int64
+	IncomingBytes           uint32
+	OutgoingBytes           uint32
+	IncomingFrames          uint32
+	OutgoingFrames          uint32
+	IncomingCompressedBytes uint32
+	OutgoingCompressedBytes uint32
+}
+
+// wtsInfoEx mirrors WTSINFOEXW: a DWORD level then a union whose only level-1
+// member is 8-aligned, so Data sits at offset 8.
+type wtsInfoEx struct {
+	Level uint32
+	_     [4]byte
+	Data  wtsInfoExLevel1
+}
+
+// querySessionLastInput returns the time of last user input for a session via
+// WTSSessionInfoEx. ok=false when the query fails or returns a short/unknown
+// payload. A zero LastInputTime yields the zero time (treated as unknown by
+// idleSince) — this is the documented console-session quirk.
+func (d *windowsDetector) querySessionLastInput(sessionID uint32) (time.Time, bool) {
+	var buf *wtsInfoEx
+	var bytesReturned uint32
+
+	r1, _, _ := procWTSQuerySessionInfo.Call(
+		wtsCurrentServerHandle,
+		uintptr(sessionID),
+		wtsSessionInfoEx,
+		uintptr(unsafe.Pointer(&buf)),
+		uintptr(unsafe.Pointer(&bytesReturned)),
+	)
+	if r1 == 0 || buf == nil {
+		return time.Time{}, false
+	}
+	defer procWTSFreeMemory.Call(uintptr(unsafe.Pointer(buf)))
+
+	if uintptr(bytesReturned) < unsafe.Sizeof(wtsInfoEx{}) || buf.Level != 1 {
+		return time.Time{}, false
+	}
+	return filetimeToTime(uint64(buf.Data.LastInputTime)), true
 }
 
 func (d *windowsDetector) ListSessions() ([]DetectedSession, error) {
@@ -93,6 +153,11 @@ func (d *windowsDetector) ListSessions() ([]DetectedSession, error) {
 			State:    wtsStateString(info.State),
 			Display:  "windows",
 			Type:     sessionType,
+		}
+		if sessionType != "services" {
+			if lastInput, ok := d.querySessionLastInput(info.SessionID); ok {
+				session.IdleFor, session.IdleKnown = idleSince(time.Now(), lastInput)
+			}
 		}
 		var err error
 		session.Session, err = sanitizeDetectedField(session.Session, true)

--- a/agent/internal/sessionbroker/idle.go
+++ b/agent/internal/sessionbroker/idle.go
@@ -1,6 +1,7 @@
 package sessionbroker
 
 import (
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -45,6 +46,9 @@ func parseIdleSinceHint(value string) (time.Time, bool) {
 		return time.Time{}, false
 	}
 	if usec, err := strconv.ParseUint(value, 10, 64); err == nil {
+		if usec > math.MaxInt64/1000 {
+			return time.Time{}, false
+		}
 		return time.Unix(0, int64(usec)*1000).UTC(), true
 	}
 	if t, err := time.Parse("Mon 2006-01-02 15:04:05 MST", value); err == nil {

--- a/agent/internal/sessionbroker/idle.go
+++ b/agent/internal/sessionbroker/idle.go
@@ -1,0 +1,54 @@
+package sessionbroker
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+// filetimeEpochDiff100ns is the number of 100ns intervals between the Windows
+// FILETIME epoch (1601-01-01 UTC) and the Unix epoch (1970-01-01 UTC).
+const filetimeEpochDiff100ns = 116444736000000000
+
+// filetimeToTime converts a Windows FILETIME value (100ns intervals since
+// 1601-01-01 UTC) to a time.Time. A zero FILETIME — which WTSSessionInfoEx
+// reports for sessions with no recorded input, notably the physical console on
+// some Windows versions — maps to the zero time so callers treat it as
+// unknown rather than "idle since 1601".
+func filetimeToTime(ft uint64) time.Time {
+	if ft == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, (int64(ft)-filetimeEpochDiff100ns)*100).UTC()
+}
+
+// idleSince computes how long a session has been idle given the current wall
+// clock and the time of last user input. known=false means no idle data —
+// callers must never conflate that with "0 minutes idle".
+func idleSince(now, lastInput time.Time) (idle time.Duration, known bool) {
+	if lastInput.IsZero() {
+		return 0, false
+	}
+	d := now.Sub(lastInput)
+	if d < 0 {
+		d = 0
+	}
+	return d, true
+}
+
+// parseIdleSinceHint parses loginctl's IdleSinceHint property, which systemd
+// prints either as raw microseconds since the Unix epoch or, in some
+// versions, as a formatted timestamp.
+func parseIdleSinceHint(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" || value == "0" {
+		return time.Time{}, false
+	}
+	if usec, err := strconv.ParseUint(value, 10, 64); err == nil {
+		return time.Unix(0, int64(usec)*1000).UTC(), true
+	}
+	if t, err := time.Parse("Mon 2006-01-02 15:04:05 MST", value); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
+}

--- a/agent/internal/sessionbroker/idle_test.go
+++ b/agent/internal/sessionbroker/idle_test.go
@@ -67,6 +67,7 @@ func TestParseIdleSinceHint(t *testing.T) {
 		{name: "formatted_timestamp", value: "Thu 2026-06-11 10:30:00 UTC",
 			want: time.Date(2026, 6, 11, 10, 30, 0, 0, time.UTC), wantOK: true},
 		{name: "garbage_is_unknown", value: "not-a-time", wantOK: false},
+		{name: "usec_overflow_is_unknown", value: "18446744073709551615", wantOK: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/agent/internal/sessionbroker/idle_test.go
+++ b/agent/internal/sessionbroker/idle_test.go
@@ -1,0 +1,82 @@
+package sessionbroker
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFiletimeToTime(t *testing.T) {
+	tests := []struct {
+		name string
+		ft   uint64
+		want time.Time
+	}{
+		// Zero FILETIME means "no input recorded" (known console-session quirk);
+		// must map to the zero time, never to 1601-01-01.
+		{name: "zero_is_zero_time", ft: 0, want: time.Time{}},
+		// 116444736000000000 = 100ns intervals between 1601-01-01 and 1970-01-01.
+		{name: "unix_epoch", ft: 116444736000000000, want: time.Unix(0, 0).UTC()},
+		// One second past the unix epoch (10_000_000 * 100ns = 1s).
+		{name: "epoch_plus_1s", ft: 116444736000000000 + 10_000_000, want: time.Unix(1, 0).UTC()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filetimeToTime(tt.ft)
+			if !got.Equal(tt.want) {
+				t.Fatalf("filetimeToTime(%d) = %v, want %v", tt.ft, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIdleSince(t *testing.T) {
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		lastInput time.Time
+		wantIdle  time.Duration
+		wantKnown bool
+	}{
+		{name: "zero_last_input_is_unknown", lastInput: time.Time{}, wantIdle: 0, wantKnown: false},
+		{name: "23_minutes_ago", lastInput: now.Add(-23 * time.Minute), wantIdle: 23 * time.Minute, wantKnown: true},
+		{name: "future_input_clamps_to_zero", lastInput: now.Add(5 * time.Minute), wantIdle: 0, wantKnown: true},
+		{name: "exactly_now", lastInput: now, wantIdle: 0, wantKnown: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idle, known := idleSince(now, tt.lastInput)
+			if idle != tt.wantIdle || known != tt.wantKnown {
+				t.Fatalf("idleSince() = (%v, %v), want (%v, %v)", idle, known, tt.wantIdle, tt.wantKnown)
+			}
+		})
+	}
+}
+
+func TestParseIdleSinceHint(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  string
+		want   time.Time
+		wantOK bool
+	}{
+		{name: "empty_is_unknown", value: "", wantOK: false},
+		{name: "zero_is_unknown", value: "0", wantOK: false},
+		// systemd usually prints the raw dbus value: microseconds since epoch.
+		{name: "usec_integer", value: "1781265600000000", want: time.Unix(1781265600, 0).UTC(), wantOK: true},
+		// Some loginctl versions print a formatted timestamp instead.
+		{name: "formatted_timestamp", value: "Thu 2026-06-11 10:30:00 UTC",
+			want: time.Date(2026, 6, 11, 10, 30, 0, 0, time.UTC), wantOK: true},
+		{name: "garbage_is_unknown", value: "not-a-time", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseIdleSinceHint(tt.value)
+			if ok != tt.wantOK {
+				t.Fatalf("parseIdleSinceHint(%q) ok = %v, want %v", tt.value, ok, tt.wantOK)
+			}
+			if ok && !got.Equal(tt.want) {
+				t.Fatalf("parseIdleSinceHint(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}

--- a/apps/api/src/routes/agents/sessions.test.ts
+++ b/apps/api/src/routes/agents/sessions.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const AGENT_ID = 'agent-001';
+const DEVICE_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(),
+    transaction: vi.fn(),
+  },
+}));
+
+vi.mock('../../db/schema', () => ({
+  devices: { id: 'id', agentId: 'agent_id', orgId: 'org_id', hostname: 'hostname' },
+  deviceSessions: {
+    id: 'id',
+    orgId: 'org_id',
+    deviceId: 'device_id',
+    username: 'username',
+    sessionType: 'session_type',
+    osSessionId: 'os_session_id',
+    loginAt: 'login_at',
+    logoutAt: 'logout_at',
+    durationSeconds: 'duration_seconds',
+    idleMinutes: 'idle_minutes',
+    activityState: 'activity_state',
+    loginPerformanceSeconds: 'login_performance_seconds',
+    isActive: 'is_active',
+    lastActivityAt: 'last_activity_at',
+    updatedAt: 'updated_at',
+  },
+}));
+
+vi.mock('../../services/auditEvents', () => ({
+  writeAuditEvent: vi.fn(),
+}));
+
+vi.mock('../../services/eventBus', () => ({
+  publishEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../middleware/requireAgentRole', () => ({
+  requireAgentRole: vi.fn((_c: unknown, next: () => Promise<void>) => next()),
+}));
+
+vi.mock('./helpers', () => ({
+  sanitizeTimestamp: vi.fn((value: string | undefined) => (value ? new Date(value) : null)),
+}));
+
+import { db } from '../../db';
+import { sessionsRoutes } from './sessions';
+
+function mockDeviceLookup() {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue([{ id: DEVICE_ID, orgId: 'org-1', hostname: 'host-1' }]),
+      }),
+    }),
+  } as any);
+}
+
+describe('PUT /agents/:id/sessions', () => {
+  let app: Hono;
+  let insertedValues: any[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insertedValues = [];
+    app = new Hono();
+    app.route('/agents', sessionsRoutes);
+
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
+      const tx = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([]), // no existing active sessions
+          }),
+        }),
+        insert: vi.fn().mockReturnValue({
+          values: vi.fn().mockImplementation((vals: any) => {
+            insertedValues.push(vals);
+            return Promise.resolve(undefined);
+          }),
+        }),
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(undefined),
+          }),
+        }),
+      };
+      return fn(tx);
+    });
+  });
+
+  it('stores null idleMinutes when the agent omits it (unknown ≠ 0)', async () => {
+    mockDeviceLookup();
+
+    const res = await app.request(`/agents/${AGENT_ID}/sessions`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessions: [{ username: 'alice', sessionType: 'console', isActive: true }],
+        events: [],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(insertedValues).toHaveLength(1);
+    expect(insertedValues[0].idleMinutes).toBeNull();
+  });
+
+  it('stores explicit idleMinutes 0 as 0 (measured active)', async () => {
+    mockDeviceLookup();
+
+    const res = await app.request(`/agents/${AGENT_ID}/sessions`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessions: [{ username: 'alice', sessionType: 'console', isActive: true, idleMinutes: 0 }],
+        events: [],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(insertedValues).toHaveLength(1);
+    expect(insertedValues[0].idleMinutes).toBe(0);
+  });
+
+  it('stores measured idleMinutes as provided', async () => {
+    mockDeviceLookup();
+
+    const res = await app.request(`/agents/${AGENT_ID}/sessions`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessions: [{ username: 'alice', sessionType: 'console', isActive: true, idleMinutes: 23 }],
+        events: [],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(insertedValues[0].idleMinutes).toBe(23);
+  });
+});

--- a/apps/api/src/routes/agents/sessions.test.ts
+++ b/apps/api/src/routes/agents/sessions.test.ts
@@ -64,18 +64,14 @@ function mockDeviceLookup() {
 describe('PUT /agents/:id/sessions', () => {
   let app: Hono;
   let insertedValues: any[];
+  let updatedValues: any[];
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-    insertedValues = [];
-    app = new Hono();
-    app.route('/agents', sessionsRoutes);
-
+  function mockTransaction(existingActive: any[] = []) {
     vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
       const tx = {
         select: vi.fn().mockReturnValue({
           from: vi.fn().mockReturnValue({
-            where: vi.fn().mockResolvedValue([]), // no existing active sessions
+            where: vi.fn().mockResolvedValue(existingActive),
           }),
         }),
         insert: vi.fn().mockReturnValue({
@@ -85,13 +81,23 @@ describe('PUT /agents/:id/sessions', () => {
           }),
         }),
         update: vi.fn().mockReturnValue({
-          set: vi.fn().mockReturnValue({
-            where: vi.fn().mockResolvedValue(undefined),
+          set: vi.fn().mockImplementation((vals: any) => {
+            updatedValues.push(vals);
+            return { where: vi.fn().mockResolvedValue(undefined) };
           }),
         }),
       };
       return fn(tx);
     });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insertedValues = [];
+    updatedValues = [];
+    app = new Hono();
+    app.route('/agents', sessionsRoutes);
+    mockTransaction();
   });
 
   it('stores null idleMinutes when the agent omits it (unknown ≠ 0)', async () => {
@@ -142,5 +148,33 @@ describe('PUT /agents/:id/sessions', () => {
 
     expect(res.status).toBe(200);
     expect(insertedValues[0].idleMinutes).toBe(23);
+  });
+
+  it('stores null idleMinutes on the update path too (existing session, agent omits it)', async () => {
+    mockDeviceLookup();
+    mockTransaction([
+      {
+        id: 'sess-1',
+        username: 'alice',
+        sessionType: 'console',
+        osSessionId: null,
+        loginAt: new Date('2026-06-11T08:00:00Z'),
+      },
+    ]);
+
+    const res = await app.request(`/agents/${AGENT_ID}/sessions`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessions: [{ username: 'alice', sessionType: 'console', isActive: true }],
+        events: [],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(insertedValues).toHaveLength(0);
+    const sessionUpdate = updatedValues.find((v) => 'idleMinutes' in v);
+    expect(sessionUpdate).toBeDefined();
+    expect(sessionUpdate.idleMinutes).toBeNull();
   });
 });

--- a/apps/api/src/routes/agents/sessions.ts
+++ b/apps/api/src/routes/agents/sessions.ts
@@ -95,7 +95,7 @@ sessionsRoutes.put('/:id/sessions', zValidator('json', submitSessionsSchema), as
             sessionType: session.sessionType,
             osSessionId,
             loginAt,
-            idleMinutes: session.idleMinutes ?? 0,
+            idleMinutes: session.idleMinutes ?? null,
             activityState: session.activityState ?? 'active',
             loginPerformanceSeconds: session.loginPerformanceSeconds ?? null,
             isActive: true,
@@ -108,7 +108,7 @@ sessionsRoutes.put('/:id/sessions', zValidator('json', submitSessionsSchema), as
       await tx
         .update(deviceSessions)
         .set({
-          idleMinutes: session.idleMinutes ?? 0,
+          idleMinutes: session.idleMinutes ?? null,
           activityState: session.activityState ?? 'active',
           loginPerformanceSeconds: session.loginPerformanceSeconds ?? null,
           isActive: true,

--- a/apps/api/src/routes/devices/sessions.ts
+++ b/apps/api/src/routes/devices/sessions.ts
@@ -60,6 +60,7 @@ sessionsRoutes.get(
         activityState: deviceSessions.activityState,
         loginPerformanceSeconds: deviceSessions.loginPerformanceSeconds,
         lastActivityAt: deviceSessions.lastActivityAt,
+        updatedAt: deviceSessions.updatedAt,
       })
       .from(deviceSessions)
       .where(

--- a/apps/web/src/components/devices/DeviceDetails.tsx
+++ b/apps/web/src/components/devices/DeviceDetails.tsx
@@ -47,6 +47,7 @@ import DeviceBootPerformanceTab from './DeviceBootPerformanceTab';
 import DevicePlaybookHistory from './DevicePlaybookHistory';
 import DevicePeripheralsTab from './DevicePeripheralsTab';
 import DeviceWarrantyCard from './DeviceWarrantyCard';
+import DeviceUserIdleStat from './DeviceUserIdleStat';
 import MacOSPermissionsBanner from './MacOSPermissionsBanner';
 import { navigateTo } from '@/lib/navigation';
 import { OverflowTabs } from '../shared/OverflowTabs';
@@ -288,6 +289,7 @@ export default function DeviceDetails({ device, timezone, onBack, onAction }: De
                 </div>
                 <p className="mt-1 text-lg font-semibold truncate" title={device.lastUser || undefined}>{device.lastUser || '—'}</p>
               </div>
+              <DeviceUserIdleStat deviceId={device.id} />
             </div>
 
             <DevicePerformanceGraphs deviceId={device.id} compact />

--- a/apps/web/src/components/devices/DeviceUserIdleStat.test.tsx
+++ b/apps/web/src/components/devices/DeviceUserIdleStat.test.tsx
@@ -65,6 +65,10 @@ describe('formatIdle', () => {
   it('formats hours and minutes', () => {
     expect(formatIdle(session({ idleMinutes: 65 }))).toBe('1h 5m');
   });
+
+  it('drops the zero-minute remainder at exact hours', () => {
+    expect(formatIdle(session({ idleMinutes: 60 }))).toBe('1h');
+  });
 });
 
 describe('DeviceUserIdleStat', () => {

--- a/apps/web/src/components/devices/DeviceUserIdleStat.test.tsx
+++ b/apps/web/src/components/devices/DeviceUserIdleStat.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import DeviceUserIdleStat, { selectIdleSession, formatIdle, type ActiveSession } from './DeviceUserIdleStat';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+import { fetchWithAuth } from '../../stores/auth';
+
+function session(overrides: Partial<ActiveSession>): ActiveSession {
+  return {
+    id: 's-1',
+    username: 'alice',
+    sessionType: 'console',
+    osSessionId: '2',
+    loginAt: '2026-06-11T08:00:00Z',
+    idleMinutes: null,
+    activityState: 'active',
+    lastActivityAt: null,
+    updatedAt: '2026-06-11T12:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('selectIdleSession', () => {
+  it('returns null for no sessions', () => {
+    expect(selectIdleSession([])).toBeNull();
+  });
+
+  it('prefers the console session over less-idle remote sessions', () => {
+    const console_ = session({ id: 'c', sessionType: 'console', idleMinutes: 60 });
+    const rdp = session({ id: 'r', sessionType: 'rdp', idleMinutes: 1 });
+    expect(selectIdleSession([rdp, console_])?.id).toBe('c');
+  });
+
+  it('falls back to the least-idle session when no console session exists', () => {
+    const a = session({ id: 'a', sessionType: 'rdp', idleMinutes: 45 });
+    const b = session({ id: 'b', sessionType: 'ssh', idleMinutes: 5 });
+    expect(selectIdleSession([a, b])?.id).toBe('b');
+  });
+});
+
+describe('formatIdle', () => {
+  it('shows em dash for no session', () => {
+    expect(formatIdle(null)).toBe('—');
+  });
+
+  it('shows Locked for locked sessions regardless of idle', () => {
+    expect(formatIdle(session({ activityState: 'locked', idleMinutes: 42 }))).toBe('Locked');
+  });
+
+  it('shows em dash when idle is unknown', () => {
+    expect(formatIdle(session({ idleMinutes: null }))).toBe('—');
+  });
+
+  it('shows Active for under a minute', () => {
+    expect(formatIdle(session({ idleMinutes: 0 }))).toBe('Active');
+  });
+
+  it('formats minutes', () => {
+    expect(formatIdle(session({ idleMinutes: 23 }))).toBe('23m');
+  });
+
+  it('formats hours and minutes', () => {
+    expect(formatIdle(session({ idleMinutes: 65 }))).toBe('1h 5m');
+  });
+});
+
+describe('DeviceUserIdleStat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the idle duration from the active sessions endpoint', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { activeUsers: [session({ idleMinutes: 23 })], count: 1 } }),
+    } as Response);
+
+    render(<DeviceUserIdleStat deviceId="dev-1" />);
+
+    await waitFor(() => expect(screen.getByText('23m')).toBeTruthy());
+    expect(vi.mocked(fetchWithAuth)).toHaveBeenCalledWith('/devices/dev-1/sessions/active');
+  });
+
+  it('renders em dash when the fetch fails', async () => {
+    vi.mocked(fetchWithAuth).mockRejectedValue(new Error('network'));
+
+    render(<DeviceUserIdleStat deviceId="dev-1" />);
+
+    await waitFor(() => expect(screen.getByText('—')).toBeTruthy());
+  });
+});

--- a/apps/web/src/components/devices/DeviceUserIdleStat.tsx
+++ b/apps/web/src/components/devices/DeviceUserIdleStat.tsx
@@ -1,0 +1,94 @@
+import { useState, useEffect } from 'react';
+import { Timer } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+
+export type ActiveSession = {
+  id: string;
+  username: string;
+  sessionType: 'console' | 'rdp' | 'ssh' | 'other' | null;
+  osSessionId: string | null;
+  loginAt: string | null;
+  idleMinutes: number | null;
+  activityState: 'active' | 'idle' | 'locked' | 'away' | 'disconnected' | null;
+  lastActivityAt: string | null;
+  updatedAt: string | null;
+};
+
+// The session that best represents "the user at this device": the console
+// session when present, otherwise the least-idle active session.
+export function selectIdleSession(sessions: ActiveSession[]): ActiveSession | null {
+  if (sessions.length === 0) return null;
+  const consoleSession = sessions.find((s) => s.sessionType === 'console');
+  if (consoleSession) return consoleSession;
+  return [...sessions].sort(
+    (a, b) => (a.idleMinutes ?? Number.POSITIVE_INFINITY) - (b.idleMinutes ?? Number.POSITIVE_INFINITY)
+  )[0];
+}
+
+export function formatIdle(session: ActiveSession | null): string {
+  if (!session) return '—';
+  if (session.activityState === 'locked') return 'Locked';
+  if (session.idleMinutes === null || session.idleMinutes === undefined) return '—';
+  if (session.idleMinutes < 1) return 'Active';
+  const hours = Math.floor(session.idleMinutes / 60);
+  const minutes = session.idleMinutes % 60;
+  return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+}
+
+function tooltip(sessions: ActiveSession[]): string | undefined {
+  if (sessions.length === 0) return undefined;
+  const lines = sessions.map(
+    (s) => `${s.username} (${s.sessionType ?? 'unknown'}): ${formatIdle(s)}`
+  );
+  const updatedAt = sessions
+    .map((s) => s.updatedAt)
+    .filter((v): v is string => Boolean(v))
+    .sort()
+    .pop();
+  if (updatedAt) {
+    const d = new Date(updatedAt);
+    if (!isNaN(d.getTime())) {
+      lines.push(`As of ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+type DeviceUserIdleStatProps = {
+  deviceId: string;
+};
+
+export default function DeviceUserIdleStat({ deviceId }: DeviceUserIdleStatProps) {
+  const [sessions, setSessions] = useState<ActiveSession[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetchWithAuth(`/devices/${deviceId}/sessions/active`);
+        if (!res.ok) return;
+        const body = await res.json();
+        if (!cancelled) setSessions(body?.data?.activeUsers ?? []);
+      } catch {
+        // Read-only stat: on failure leave the em-dash placeholder.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [deviceId]);
+
+  const selected = selectIdleSession(sessions);
+
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+        <Timer className="h-3.5 w-3.5" />
+        User Idle
+      </div>
+      <p className="mt-1 text-lg font-semibold" title={tooltip(sessions)}>
+        {formatIdle(selected)}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/devices/DeviceUserIdleStat.tsx
+++ b/apps/web/src/components/devices/DeviceUserIdleStat.tsx
@@ -31,8 +31,9 @@ export function formatIdle(session: ActiveSession | null): string {
   if (session.idleMinutes === null || session.idleMinutes === undefined) return '—';
   if (session.idleMinutes < 1) return 'Active';
   const hours = Math.floor(session.idleMinutes / 60);
-  const minutes = session.idleMinutes % 60;
-  return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+  const minutes = Math.floor(session.idleMinutes % 60);
+  if (hours > 0) return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  return `${minutes}m`;
 }
 
 function tooltip(sessions: ActiveSession[]): string | undefined {

--- a/docs/superpowers/plans/2026-06-11-device-user-idle-time.md
+++ b/docs/superpowers/plans/2026-06-11-device-user-idle-time.md
@@ -1,0 +1,1187 @@
+# Device User Idle Time Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The Go agent measures real per-session user input idle time and the device detail overview shows it as a "User Idle" stat.
+
+**Architecture:** The agent's existing session detector gains platform-specific idle measurement (Windows `WTSSessionInfoEx.LastInputTime` from the service, macOS `HIDIdleTime` via IOKit cgo, Linux `loginctl IdleSinceHint` best-effort). The collector populates the existing-but-hardcoded `idleMinutes` wire field, now a `*int` so unknown ≠ 0. API/DB plumbing already exists except two one-line route fixes. A new small React component renders the stat in the device detail overview strip.
+
+**Tech Stack:** Go (agent, `golang.org/x/sys/windows`, cgo on darwin), Hono + Drizzle (API), React + Vitest (web).
+
+**Spec:** `docs/superpowers/specs/2026-06-11-device-user-idle-time-design.md`
+
+**Worktree note:** fresh worktrees need `pnpm install`, and pnpm/vitest need Node 22: prefix commands with `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH`.
+
+**Before Task 1:** create the feature branch — `git checkout -b feat/device-user-idle-time` (all task commits land on it; Task 8 pushes it and opens the PR).
+
+---
+
+### Task 1: Pure idle helpers in sessionbroker (cross-platform, fully testable)
+
+These helpers hold all the parseable/convertible logic so it can be tested on any dev OS (the platform detectors themselves only compile on their own GOOS).
+
+**Files:**
+- Create: `agent/internal/sessionbroker/idle.go`
+- Create: `agent/internal/sessionbroker/idle_test.go`
+- Modify: `agent/internal/sessionbroker/detector.go` (add idle fields to `DetectedSession`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `agent/internal/sessionbroker/idle_test.go`:
+
+```go
+package sessionbroker
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFiletimeToTime(t *testing.T) {
+	tests := []struct {
+		name string
+		ft   uint64
+		want time.Time
+	}{
+		// Zero FILETIME means "no input recorded" (known console-session quirk);
+		// must map to the zero time, never to 1601-01-01.
+		{name: "zero_is_zero_time", ft: 0, want: time.Time{}},
+		// 116444736000000000 = 100ns intervals between 1601-01-01 and 1970-01-01.
+		{name: "unix_epoch", ft: 116444736000000000, want: time.Unix(0, 0).UTC()},
+		// One second past the unix epoch (10_000_000 * 100ns = 1s).
+		{name: "epoch_plus_1s", ft: 116444736000000000 + 10_000_000, want: time.Unix(1, 0).UTC()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filetimeToTime(tt.ft)
+			if !got.Equal(tt.want) {
+				t.Fatalf("filetimeToTime(%d) = %v, want %v", tt.ft, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIdleSince(t *testing.T) {
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		lastInput time.Time
+		wantIdle  time.Duration
+		wantKnown bool
+	}{
+		{name: "zero_last_input_is_unknown", lastInput: time.Time{}, wantIdle: 0, wantKnown: false},
+		{name: "23_minutes_ago", lastInput: now.Add(-23 * time.Minute), wantIdle: 23 * time.Minute, wantKnown: true},
+		{name: "future_input_clamps_to_zero", lastInput: now.Add(5 * time.Minute), wantIdle: 0, wantKnown: true},
+		{name: "exactly_now", lastInput: now, wantIdle: 0, wantKnown: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idle, known := idleSince(now, tt.lastInput)
+			if idle != tt.wantIdle || known != tt.wantKnown {
+				t.Fatalf("idleSince() = (%v, %v), want (%v, %v)", idle, known, tt.wantIdle, tt.wantKnown)
+			}
+		})
+	}
+}
+
+func TestParseIdleSinceHint(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  string
+		want   time.Time
+		wantOK bool
+	}{
+		{name: "empty_is_unknown", value: "", wantOK: false},
+		{name: "zero_is_unknown", value: "0", wantOK: false},
+		// systemd usually prints the raw dbus value: microseconds since epoch.
+		{name: "usec_integer", value: "1781265600000000", want: time.Unix(1781265600, 0).UTC(), wantOK: true},
+		// Some loginctl versions print a formatted timestamp instead.
+		{name: "formatted_timestamp", value: "Thu 2026-06-11 10:30:00 UTC",
+			want: time.Date(2026, 6, 11, 10, 30, 0, 0, time.UTC), wantOK: true},
+		{name: "garbage_is_unknown", value: "not-a-time", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseIdleSinceHint(tt.value)
+			if ok != tt.wantOK {
+				t.Fatalf("parseIdleSinceHint(%q) ok = %v, want %v", tt.value, ok, tt.wantOK)
+			}
+			if ok && !got.Equal(tt.want) {
+				t.Fatalf("parseIdleSinceHint(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/toddhebebrand/breeze/agent && go test -race ./internal/sessionbroker/ -run 'TestFiletimeToTime|TestIdleSince|TestParseIdleSinceHint' -v`
+Expected: FAIL to build — `undefined: filetimeToTime` etc.
+
+- [ ] **Step 3: Implement the helpers**
+
+Create `agent/internal/sessionbroker/idle.go`:
+
+```go
+package sessionbroker
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+// filetimeEpochDiff100ns is the number of 100ns intervals between the Windows
+// FILETIME epoch (1601-01-01 UTC) and the Unix epoch (1970-01-01 UTC).
+const filetimeEpochDiff100ns = 116444736000000000
+
+// filetimeToTime converts a Windows FILETIME value (100ns intervals since
+// 1601-01-01 UTC) to a time.Time. A zero FILETIME — which WTSSessionInfoEx
+// reports for sessions with no recorded input, notably the physical console on
+// some Windows versions — maps to the zero time so callers treat it as
+// unknown rather than "idle since 1601".
+func filetimeToTime(ft uint64) time.Time {
+	if ft == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, (int64(ft)-filetimeEpochDiff100ns)*100).UTC()
+}
+
+// idleSince computes how long a session has been idle given the current wall
+// clock and the time of last user input. known=false means no idle data —
+// callers must never conflate that with "0 minutes idle".
+func idleSince(now, lastInput time.Time) (idle time.Duration, known bool) {
+	if lastInput.IsZero() {
+		return 0, false
+	}
+	d := now.Sub(lastInput)
+	if d < 0 {
+		d = 0
+	}
+	return d, true
+}
+
+// parseIdleSinceHint parses loginctl's IdleSinceHint property, which systemd
+// prints either as raw microseconds since the Unix epoch or, in some
+// versions, as a formatted timestamp.
+func parseIdleSinceHint(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" || value == "0" {
+		return time.Time{}, false
+	}
+	if usec, err := strconv.ParseUint(value, 10, 64); err == nil {
+		return time.Unix(0, int64(usec)*1000).UTC(), true
+	}
+	if t, err := time.Parse("Mon 2006-01-02 15:04:05 MST", value); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
+}
+```
+
+In `agent/internal/sessionbroker/detector.go`, extend `DetectedSession` (the `json:"-"` tags keep these off the IPC/helper wire — they only feed the collector in-process):
+
+```go
+// DetectedSession is a snapshot of a currently logged-in session.
+type DetectedSession struct {
+	UID      uint32 `json:"uid"`
+	Username string `json:"username"`
+	Session  string `json:"session"`
+	IsRemote bool   `json:"isRemote"`
+	Display  string `json:"display,omitempty"`
+	Seat     string `json:"seat,omitempty"`
+	State    string `json:"state,omitempty"` // "active", "online", "closing"
+	Type     string `json:"type,omitempty"`  // "console", "rdp", "services"
+
+	// IdleFor is how long the session has gone without user input. Only
+	// meaningful when IdleKnown is true; platforms that cannot measure input
+	// idle (or fail to) leave IdleKnown false.
+	IdleFor   time.Duration `json:"-"`
+	IdleKnown bool          `json:"-"`
+}
+```
+
+Add `"time"` to detector.go's imports (currently only `"context"`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/toddhebebrand/breeze/agent && go test -race ./internal/sessionbroker/ -run 'TestFiletimeToTime|TestIdleSince|TestParseIdleSinceHint' -v`
+Expected: PASS (all subtests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add agent/internal/sessionbroker/idle.go agent/internal/sessionbroker/idle_test.go agent/internal/sessionbroker/detector.go
+git commit -m "feat(agent): add idle-time helpers and DetectedSession idle fields"
+```
+
+---
+
+### Task 2: Windows — read LastInputTime via WTSSessionInfoEx
+
+The agent service runs in Session 0 and cannot call `GetLastInputInfo` (per-session API). `WTSQuerySessionInformationW` with info class `WTSSessionInfoEx` (25) returns a `WTSINFOEX` whose `LastInputTime` is a FILETIME — callable from Session 0 for any session. No unit test (windows-only code; CI runs ubuntu); verified by cross-compile here and on the real Windows device in Task 8.
+
+**Files:**
+- Modify: `agent/internal/sessionbroker/detector_windows.go`
+
+- [ ] **Step 1: Add the WTSINFOEX structs and query helper**
+
+In `detector_windows.go`, extend the consts block:
+
+```go
+const (
+	wtsCurrentServerHandle = 0
+	wtsConnectState        = 4 // WTSInfoClass: WTSConnectState
+	wtsUserName            = 5
+	wtsDomainName          = 7
+	wtsClientProtocolType  = 16
+	wtsSessionInfoEx       = 25 // WTSInfoClass: WTSSessionInfoEx
+
+	wtsDisconnected = 4 // WTS_CONNECTSTATE_CLASS: WTSDisconnected
+)
+```
+
+Add below `wtsSessionInfo`:
+
+```go
+// wtsInfoExLevel1 mirrors WTSINFOEX_LEVEL1_W from wtsapi32.h. Field order and
+// the explicit padding before LogonTime must match the C layout exactly:
+// 12 bytes of DWORDs + 72 UTF-16 chars (144 bytes) = 156, padded to 160 so the
+// LARGE_INTEGER block is 8-aligned.
+type wtsInfoExLevel1 struct {
+	SessionID               uint32
+	SessionState            int32
+	SessionFlags            int32
+	WinStationName          [33]uint16
+	UserName                [21]uint16
+	DomainName              [18]uint16
+	_                       [4]byte
+	LogonTime               int64
+	ConnectTime             int64
+	DisconnectTime          int64
+	LastInputTime           int64 // FILETIME; 0 = no input recorded
+	CurrentTime             int64
+	IncomingBytes           uint32
+	OutgoingBytes           uint32
+	IncomingFrames          uint32
+	OutgoingFrames          uint32
+	IncomingCompressedBytes uint32
+	OutgoingCompressedBytes uint32
+}
+
+// wtsInfoEx mirrors WTSINFOEXW: a DWORD level then a union whose only level-1
+// member is 8-aligned, so Data sits at offset 8.
+type wtsInfoEx struct {
+	Level uint32
+	_     [4]byte
+	Data  wtsInfoExLevel1
+}
+
+// querySessionLastInput returns the time of last user input for a session via
+// WTSSessionInfoEx. ok=false when the query fails or returns a short/unknown
+// payload. A zero LastInputTime yields the zero time (treated as unknown by
+// idleSince) — this is the documented console-session quirk.
+func (d *windowsDetector) querySessionLastInput(sessionID uint32) (time.Time, bool) {
+	var buf *wtsInfoEx
+	var bytesReturned uint32
+
+	r1, _, _ := procWTSQuerySessionInfo.Call(
+		wtsCurrentServerHandle,
+		uintptr(sessionID),
+		wtsSessionInfoEx,
+		uintptr(unsafe.Pointer(&buf)),
+		uintptr(unsafe.Pointer(&bytesReturned)),
+	)
+	if r1 == 0 || buf == nil {
+		return time.Time{}, false
+	}
+	defer procWTSFreeMemory.Call(uintptr(unsafe.Pointer(buf)))
+
+	if uintptr(bytesReturned) < unsafe.Sizeof(wtsInfoEx{}) || buf.Level != 1 {
+		return time.Time{}, false
+	}
+	return filetimeToTime(uint64(buf.Data.LastInputTime)), true
+}
+```
+
+- [ ] **Step 2: Wire it into ListSessions**
+
+In `ListSessions`, after the `sessionType` is determined and before the `session := DetectedSession{...}` literal, no change; instead, immediately after the literal (before the sanitize block), add:
+
+```go
+		if sessionType != "services" {
+			if lastInput, ok := d.querySessionLastInput(info.SessionID); ok {
+				session.IdleFor, session.IdleKnown = idleSince(time.Now(), lastInput)
+			}
+		}
+```
+
+- [ ] **Step 3: Cross-compile to verify it builds**
+
+Run: `cd /Users/toddhebebrand/breeze/agent && GOOS=windows GOARCH=amd64 go build ./... && go vet ./internal/sessionbroker/`
+Expected: clean build, no vet errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add agent/internal/sessionbroker/detector_windows.go
+git commit -m "feat(agent): measure Windows session idle via WTSSessionInfoEx LastInputTime"
+```
+
+---
+
+### Task 3: macOS — HIDIdleTime via IOKit (cgo path)
+
+System-wide HID idle from the `IOHIDSystem` IORegistry entry, readable by the root daemon without being in the user session. Applied to the console session (the only kind the darwin detector reports). The `!cgo` fallback (`detector_darwin_nocgo.go`) intentionally leaves idle unknown — do not touch it.
+
+**Files:**
+- Modify: `agent/internal/sessionbroker/detector_darwin.go`
+- Create: `agent/internal/sessionbroker/detector_darwin_idle_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agent/internal/sessionbroker/detector_darwin_idle_test.go` (runs on local macOS dev machines; CI is ubuntu so it never runs there):
+
+```go
+//go:build darwin && cgo
+
+package sessionbroker
+
+import "testing"
+
+// TestDarwinIdleKnown asserts that when a console user is present, the darwin
+// detector reports a known, non-negative idle duration from HIDIdleTime.
+func TestDarwinIdleKnown(t *testing.T) {
+	sessions, err := NewSessionDetector().ListSessions()
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(sessions) == 0 {
+		t.Skip("no console user logged in")
+	}
+	s := sessions[0]
+	if !s.IdleKnown {
+		t.Fatal("expected IdleKnown=true for console session on darwin cgo build")
+	}
+	if s.IdleFor < 0 {
+		t.Fatalf("expected non-negative idle, got %v", s.IdleFor)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/toddhebebrand/breeze/agent && go test -race ./internal/sessionbroker/ -run TestDarwinIdleKnown -v`
+Expected: FAIL — `expected IdleKnown=true for console session on darwin cgo build` (or Skip if no console user — if it skips, proceed; the assertion is re-checked in Task 8 manual verification).
+
+- [ ] **Step 3: Implement HIDIdleTime read**
+
+In `detector_darwin.go`, replace the cgo preamble's LDFLAGS line and add the IOKit include + helper:
+
+```c
+#cgo LDFLAGS: -framework SystemConfiguration -framework CoreFoundation -framework IOKit
+#include <SystemConfiguration/SystemConfiguration.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/IOKitLib.h>
+
+// getConsoleUser returns the current console user's username and UID.
+static int getConsoleUser(char *buf, int bufsize, unsigned int *uid) {
+    CFStringRef username = SCDynamicStoreCopyConsoleUser(NULL, (uid_t *)uid, NULL);
+    if (username == NULL) return 0;
+    Boolean ok = CFStringGetCString(username, buf, bufsize, kCFStringEncodingUTF8);
+    CFRelease(username);
+    return ok ? 1 : 0;
+}
+
+// getHIDIdleNanos reads the system-wide HID idle time (nanoseconds since last
+// keyboard/mouse input) from the IOHIDSystem registry entry. Returns 0 on
+// failure, 1 on success. Passing 0 as the master port targets the default
+// port on all supported macOS versions.
+static int getHIDIdleNanos(long long *ns) {
+    io_service_t svc = IOServiceGetMatchingService(0, IOServiceMatching("IOHIDSystem"));
+    if (!svc) return 0;
+    CFTypeRef prop = IORegistryEntryCreateCFProperty(svc, CFSTR("HIDIdleTime"), kCFAllocatorDefault, 0);
+    IOObjectRelease(svc);
+    if (!prop) return 0;
+    int ok = 0;
+    if (CFGetTypeID(prop) == CFNumberGetTypeID()) {
+        ok = CFNumberGetValue((CFNumberRef)prop, kCFNumberSInt64Type, ns);
+    }
+    CFRelease(prop);
+    return ok;
+}
+```
+
+In `ListSessions`, after the `session, err := sanitizeDetectedSession(...)` block succeeds and before `return []DetectedSession{session}, nil`, add:
+
+```go
+	var idleNs C.longlong
+	if C.getHIDIdleNanos(&idleNs) != 0 && idleNs >= 0 {
+		session.IdleFor = time.Duration(idleNs)
+		session.IdleKnown = true
+	}
+```
+
+(`time` is already imported in this file.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/toddhebebrand/breeze/agent && go test -race ./internal/sessionbroker/ -run TestDarwinIdleKnown -v`
+Expected: PASS (you are logged in at the console of your dev Mac).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add agent/internal/sessionbroker/detector_darwin.go agent/internal/sessionbroker/detector_darwin_idle_test.go
+git commit -m "feat(agent): measure macOS console idle via IOHIDSystem HIDIdleTime"
+```
+
+---
+
+### Task 4: Linux — loginctl IdleHint/IdleSinceHint (best-effort)
+
+Only reports idle when the desktop environment actively sets `IdleHint=yes`; `IdleHint=no` stays **unknown** (many DEs and all headless sessions never set the hint, so "no" cannot be distinguished from "nobody reports it" — treating it as active would show a false "Active").
+
+**Files:**
+- Modify: `agent/internal/sessionbroker/detector_linux.go`
+
+- [ ] **Step 1: Extend the property query and parse**
+
+In `detector_linux.go` `ListSessions`, change the `show-session` property list:
+
+```go
+			propOut, propErr := exec.CommandContext(propCtx, "loginctl", "show-session", sessionID,
+				"--property=Type,Remote,Display,Seat,State,IdleHint,IdleSinceHint").Output()
+```
+
+Above the property scan loop (just after `if propErr == nil {`), declare:
+
+```go
+			var idleHint bool
+			var idleSinceRaw string
+```
+
+Add two cases to the `switch parts[0]` block:
+
+```go
+				case "IdleHint":
+					idleHint = parts[1] == "yes"
+				case "IdleSinceHint":
+					idleSinceRaw = parts[1]
+```
+
+After the property scan loop's error check (still inside `if propErr == nil`, before the closing brace), add:
+
+```go
+			if idleHint {
+				if since, ok := parseIdleSinceHint(idleSinceRaw); ok {
+					sess.IdleFor, sess.IdleKnown = idleSince(time.Now(), since)
+				}
+			}
+```
+
+- [ ] **Step 2: Cross-compile and run package tests**
+
+Run: `cd /Users/toddhebebrand/breeze/agent && GOOS=linux GOARCH=amd64 go build ./... && go test -race ./internal/sessionbroker/`
+Expected: clean build; existing + Task 1 tests PASS (linux detector code itself doesn't compile on darwin — the build check covers it; `parseIdleSinceHint` is covered by Task 1's tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add agent/internal/sessionbroker/detector_linux.go
+git commit -m "feat(agent): best-effort Linux session idle via loginctl IdleSinceHint"
+```
+
+---
+
+### Task 5: Collector — populate IdleMinutes as *int, fix LastActivityAt
+
+`UserSession.IdleMinutes` becomes `*int` so "measured 0" serializes as `0` while "unknown" is omitted (with plain `int`+`omitempty` they're indistinguishable, and old agents' omission must read as unknown). `LastActivityAt` becomes `now − idle` when idle is known instead of always `now`.
+
+**Files:**
+- Modify: `agent/internal/collectors/sessions.go`
+- Modify: `agent/internal/collectors/sessions_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `agent/internal/collectors/sessions_test.go`:
+
+```go
+type fakeDetector struct {
+	sessions []sessionbroker.DetectedSession
+}
+
+func (f *fakeDetector) ListSessions() ([]sessionbroker.DetectedSession, error) {
+	return f.sessions, nil
+}
+
+func (f *fakeDetector) WatchSessions(ctx context.Context) <-chan sessionbroker.SessionEvent {
+	ch := make(chan sessionbroker.SessionEvent)
+	close(ch)
+	return ch
+}
+
+func TestRefreshSessionsIdleMinutes(t *testing.T) {
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	c := &SessionCollector{
+		detector: &fakeDetector{sessions: []sessionbroker.DetectedSession{
+			{Username: "alice", Session: "2", State: "active", IdleFor: 23 * time.Minute, IdleKnown: true},
+			{Username: "bob", Session: "3", State: "active"}, // idle unknown
+			{Username: "carol", Session: "4", State: "active", IdleFor: 30 * 24 * time.Hour, IdleKnown: true}, // clamps
+		}},
+		sessions: make(map[string]UserSession),
+	}
+
+	c.refreshSessions(now)
+
+	byUser := make(map[string]UserSession)
+	for _, s := range c.sessions {
+		byUser[s.Username] = s
+	}
+
+	alice := byUser["alice"]
+	if alice.IdleMinutes == nil || *alice.IdleMinutes != 23 {
+		t.Fatalf("alice IdleMinutes = %v, want 23", alice.IdleMinutes)
+	}
+	if !alice.LastActivityAt.Equal(now.Add(-23 * time.Minute)) {
+		t.Fatalf("alice LastActivityAt = %v, want %v", alice.LastActivityAt, now.Add(-23*time.Minute))
+	}
+
+	bob := byUser["bob"]
+	if bob.IdleMinutes != nil {
+		t.Fatalf("bob IdleMinutes = %v, want nil (unknown)", *bob.IdleMinutes)
+	}
+	if !bob.LastActivityAt.Equal(now) {
+		t.Fatalf("bob LastActivityAt = %v, want %v", bob.LastActivityAt, now)
+	}
+
+	carol := byUser["carol"]
+	if carol.IdleMinutes == nil || *carol.IdleMinutes != 10080 {
+		t.Fatalf("carol IdleMinutes = %v, want 10080 (clamped)", carol.IdleMinutes)
+	}
+}
+
+func TestUserSessionIdleMinutesJSON(t *testing.T) {
+	zero := 0
+	withZero, err := json.Marshal(UserSession{Username: "a", SessionType: "console", IdleMinutes: &zero})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(withZero), `"idleMinutes":0`) {
+		t.Fatalf("measured-zero idle must serialize explicitly, got %s", withZero)
+	}
+
+	unknown, err := json.Marshal(UserSession{Username: "a", SessionType: "console"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(unknown), "idleMinutes") {
+		t.Fatalf("unknown idle must be omitted from the wire, got %s", unknown)
+	}
+}
+```
+
+Add to the test file's imports: `"context"`, `"encoding/json"`, `"strings"`, `"time"` (keep existing `"testing"` and `sessionbroker` imports).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/toddhebebrand/breeze/agent && go test -race ./internal/collectors/ -run 'TestRefreshSessionsIdleMinutes|TestUserSessionIdleMinutesJSON' -v`
+Expected: FAIL to build — `cannot use &zero (value of type *int) as int value` (field is still `int`).
+
+- [ ] **Step 3: Implement**
+
+In `agent/internal/collectors/sessions.go`:
+
+Change the struct field:
+
+```go
+	IdleMinutes             *int      `json:"idleMinutes,omitempty"`
+```
+
+Add near the consts:
+
+```go
+const maxIdleMinutes = 10080 // submitSessionsSchema caps idleMinutes at 7 days
+```
+
+Add a helper (below `refreshSessions`):
+
+```go
+// idleFields converts a detected session's idle measurement into the wire
+// representation: a nil pointer when unknown (so old agents and unmeasurable
+// platforms read as "no data", never "0 minutes"), and a LastActivityAt
+// anchored to the actual last input rather than the refresh tick.
+func idleFields(detected sessionbroker.DetectedSession, now time.Time) (*int, time.Time) {
+	if !detected.IdleKnown {
+		return nil, now
+	}
+	minutes := int(detected.IdleFor / time.Minute)
+	if minutes < 0 {
+		minutes = 0
+	}
+	if minutes > maxIdleMinutes {
+		minutes = maxIdleMinutes
+	}
+	return &minutes, now.Add(-detected.IdleFor)
+}
+```
+
+In `refreshSessions`, replace the session literal:
+
+```go
+		idleMinutes, lastActivityAt := idleFields(detected, now)
+		next[key] = UserSession{
+			Username:       detected.Username,
+			SessionType:    inferSessionType(detected),
+			SessionID:      detected.Session,
+			LoginAt:        loginAt,
+			IdleMinutes:    idleMinutes,
+			ActivityState:  mapDetectedState(detected.State),
+			IsActive:       true,
+			LastActivityAt: lastActivityAt,
+		}
+```
+
+In `applyEvent`'s `SessionLogin` case, drop the `IdleMinutes: 0,` line entirely (nil = unknown until the next refresh measures it):
+
+```go
+		c.sessions[key] = UserSession{
+			Username:       event.Username,
+			SessionType:    sessionType,
+			SessionID:      event.Session,
+			LoginAt:        loginAt,
+			ActivityState:  "active",
+			IsActive:       true,
+			LastActivityAt: now,
+		}
+```
+
+- [ ] **Step 4: Run the full agent test suite**
+
+Run: `cd /Users/toddhebebrand/breeze/agent && go test -race ./internal/collectors/ ./internal/sessionbroker/ ./internal/heartbeat/`
+Expected: PASS (heartbeat marshals `UserSession` as-is, so the type change is wire-compatible; this run proves nothing else referenced the field as `int`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add agent/internal/collectors/sessions.go agent/internal/collectors/sessions_test.go
+git commit -m "feat(agent): populate session idleMinutes from detector, fix lastActivityAt"
+```
+
+---
+
+### Task 6: API — preserve null idleMinutes, expose updatedAt
+
+Two one-line route fixes plus a new route test (the ingestion route currently has none).
+
+**Files:**
+- Modify: `apps/api/src/routes/agents/sessions.ts:98,111`
+- Modify: `apps/api/src/routes/devices/sessions.ts` (active select)
+- Create: `apps/api/src/routes/agents/sessions.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/routes/agents/sessions.test.ts` (mock pattern mirrors `connections.test.ts`; `./helpers` is mocked because the real module pulls in `db` and dozens of schema tables):
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const AGENT_ID = 'agent-001';
+const DEVICE_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(),
+    transaction: vi.fn(),
+  },
+}));
+
+vi.mock('../../db/schema', () => ({
+  devices: { id: 'id', agentId: 'agent_id', orgId: 'org_id', hostname: 'hostname' },
+  deviceSessions: {
+    id: 'id',
+    orgId: 'org_id',
+    deviceId: 'device_id',
+    username: 'username',
+    sessionType: 'session_type',
+    osSessionId: 'os_session_id',
+    loginAt: 'login_at',
+    logoutAt: 'logout_at',
+    durationSeconds: 'duration_seconds',
+    idleMinutes: 'idle_minutes',
+    activityState: 'activity_state',
+    loginPerformanceSeconds: 'login_performance_seconds',
+    isActive: 'is_active',
+    lastActivityAt: 'last_activity_at',
+    updatedAt: 'updated_at',
+  },
+}));
+
+vi.mock('../../services/auditEvents', () => ({
+  writeAuditEvent: vi.fn(),
+}));
+
+vi.mock('../../services/eventBus', () => ({
+  publishEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../middleware/requireAgentRole', () => ({
+  requireAgentRole: vi.fn((_c: unknown, next: () => Promise<void>) => next()),
+}));
+
+vi.mock('./helpers', () => ({
+  sanitizeTimestamp: vi.fn((value: string | undefined) => (value ? new Date(value) : null)),
+}));
+
+import { db } from '../../db';
+import { sessionsRoutes } from './sessions';
+
+function mockDeviceLookup() {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue([{ id: DEVICE_ID, orgId: 'org-1', hostname: 'host-1' }]),
+      }),
+    }),
+  } as any);
+}
+
+describe('PUT /agents/:id/sessions', () => {
+  let app: Hono;
+  let insertedValues: any[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insertedValues = [];
+    app = new Hono();
+    app.route('/agents', sessionsRoutes);
+
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
+      const tx = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([]), // no existing active sessions
+          }),
+        }),
+        insert: vi.fn().mockReturnValue({
+          values: vi.fn().mockImplementation((vals: any) => {
+            insertedValues.push(vals);
+            return Promise.resolve(undefined);
+          }),
+        }),
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(undefined),
+          }),
+        }),
+      };
+      return fn(tx);
+    });
+  });
+
+  it('stores null idleMinutes when the agent omits it (unknown ≠ 0)', async () => {
+    mockDeviceLookup();
+
+    const res = await app.request(`/agents/${AGENT_ID}/sessions`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessions: [{ username: 'alice', sessionType: 'console', isActive: true }],
+        events: [],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(insertedValues).toHaveLength(1);
+    expect(insertedValues[0].idleMinutes).toBeNull();
+  });
+
+  it('stores explicit idleMinutes 0 as 0 (measured active)', async () => {
+    mockDeviceLookup();
+
+    const res = await app.request(`/agents/${AGENT_ID}/sessions`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessions: [{ username: 'alice', sessionType: 'console', isActive: true, idleMinutes: 0 }],
+        events: [],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(insertedValues).toHaveLength(1);
+    expect(insertedValues[0].idleMinutes).toBe(0);
+  });
+
+  it('stores measured idleMinutes as provided', async () => {
+    mockDeviceLookup();
+
+    const res = await app.request(`/agents/${AGENT_ID}/sessions`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessions: [{ username: 'alice', sessionType: 'console', isActive: true, idleMinutes: 23 }],
+        events: [],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(insertedValues[0].idleMinutes).toBe(23);
+  });
+});
+```
+
+(The handler ends with `return c.json({ success: true, ... })` — HTTP 200 — and calls `writeAuditEvent` unconditionally plus `publishEvent` only for login/logout events, so the mocks above are exactly sufficient with an empty `events` array.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/routes/agents/sessions.test.ts --pool=forks --poolOptions.forks.singleFork=true`
+Expected: FAIL — first test asserts `idleMinutes` to be null but receives `0` (the `?? 0` coercion). Tests 2 and 3 PASS.
+
+- [ ] **Step 3: Fix the routes**
+
+In `apps/api/src/routes/agents/sessions.ts`, both the insert (line ~98) and update (line ~111) blocks:
+
+```typescript
+          idleMinutes: session.idleMinutes ?? null,
+```
+
+In `apps/api/src/routes/devices/sessions.ts`, the `/:id/sessions/active` select (after `lastActivityAt`):
+
+```typescript
+        lastActivityAt: deviceSessions.lastActivityAt,
+        updatedAt: deviceSessions.updatedAt,
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/routes/agents/sessions.test.ts src/routes/devices/core.permissions.test.ts --pool=forks --poolOptions.forks.singleFork=true`
+Expected: PASS (core.permissions covers the devices sessions routes' auth and catches select-shape breakage). Note: do NOT run the full API suite to judge this change — it has known parallel-run flakiness; affected files single-fork is the verification standard, CI is the arbiter.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add apps/api/src/routes/agents/sessions.ts apps/api/src/routes/agents/sessions.test.ts apps/api/src/routes/devices/sessions.ts
+git commit -m "fix(api): preserve null idleMinutes on session ingest, expose updatedAt on active sessions"
+```
+
+---
+
+### Task 7: Web — User Idle stat on device detail overview
+
+A small self-contained component with exported pure helpers (testable without DOM fixtures), rendered in the overview stat strip next to Logged-in User.
+
+**Files:**
+- Create: `apps/web/src/components/devices/DeviceUserIdleStat.tsx`
+- Create: `apps/web/src/components/devices/DeviceUserIdleStat.test.tsx`
+- Modify: `apps/web/src/components/devices/DeviceDetails.tsx` (import + one render line)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/web/src/components/devices/DeviceUserIdleStat.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import DeviceUserIdleStat, { selectIdleSession, formatIdle, type ActiveSession } from './DeviceUserIdleStat';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+import { fetchWithAuth } from '../../stores/auth';
+
+function session(overrides: Partial<ActiveSession>): ActiveSession {
+  return {
+    id: 's-1',
+    username: 'alice',
+    sessionType: 'console',
+    osSessionId: '2',
+    loginAt: '2026-06-11T08:00:00Z',
+    idleMinutes: null,
+    activityState: 'active',
+    lastActivityAt: null,
+    updatedAt: '2026-06-11T12:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('selectIdleSession', () => {
+  it('returns null for no sessions', () => {
+    expect(selectIdleSession([])).toBeNull();
+  });
+
+  it('prefers the console session over less-idle remote sessions', () => {
+    const console_ = session({ id: 'c', sessionType: 'console', idleMinutes: 60 });
+    const rdp = session({ id: 'r', sessionType: 'rdp', idleMinutes: 1 });
+    expect(selectIdleSession([rdp, console_])?.id).toBe('c');
+  });
+
+  it('falls back to the least-idle session when no console session exists', () => {
+    const a = session({ id: 'a', sessionType: 'rdp', idleMinutes: 45 });
+    const b = session({ id: 'b', sessionType: 'ssh', idleMinutes: 5 });
+    expect(selectIdleSession([a, b])?.id).toBe('b');
+  });
+});
+
+describe('formatIdle', () => {
+  it('shows em dash for no session', () => {
+    expect(formatIdle(null)).toBe('—');
+  });
+
+  it('shows Locked for locked sessions regardless of idle', () => {
+    expect(formatIdle(session({ activityState: 'locked', idleMinutes: 42 }))).toBe('Locked');
+  });
+
+  it('shows em dash when idle is unknown', () => {
+    expect(formatIdle(session({ idleMinutes: null }))).toBe('—');
+  });
+
+  it('shows Active for under a minute', () => {
+    expect(formatIdle(session({ idleMinutes: 0 }))).toBe('Active');
+  });
+
+  it('formats minutes', () => {
+    expect(formatIdle(session({ idleMinutes: 23 }))).toBe('23m');
+  });
+
+  it('formats hours and minutes', () => {
+    expect(formatIdle(session({ idleMinutes: 65 }))).toBe('1h 5m');
+  });
+});
+
+describe('DeviceUserIdleStat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the idle duration from the active sessions endpoint', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { activeUsers: [session({ idleMinutes: 23 })], count: 1 } }),
+    } as Response);
+
+    render(<DeviceUserIdleStat deviceId="dev-1" />);
+
+    await waitFor(() => expect(screen.getByText('23m')).toBeTruthy());
+    expect(vi.mocked(fetchWithAuth)).toHaveBeenCalledWith('/devices/dev-1/sessions/active');
+  });
+
+  it('renders em dash when the fetch fails', async () => {
+    vi.mocked(fetchWithAuth).mockRejectedValue(new Error('network'));
+
+    render(<DeviceUserIdleStat deviceId="dev-1" />);
+
+    await waitFor(() => expect(screen.getByText('—')).toBeTruthy());
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/components/devices/DeviceUserIdleStat.test.tsx`
+Expected: FAIL — cannot resolve `./DeviceUserIdleStat`.
+
+- [ ] **Step 3: Implement the component**
+
+Create `apps/web/src/components/devices/DeviceUserIdleStat.tsx`:
+
+```tsx
+import { useState, useEffect } from 'react';
+import { Timer } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+
+export type ActiveSession = {
+  id: string;
+  username: string;
+  sessionType: 'console' | 'rdp' | 'ssh' | 'other' | null;
+  osSessionId: string | null;
+  loginAt: string | null;
+  idleMinutes: number | null;
+  activityState: 'active' | 'idle' | 'locked' | 'away' | 'disconnected' | null;
+  lastActivityAt: string | null;
+  updatedAt: string | null;
+};
+
+// The session that best represents "the user at this device": the console
+// session when present, otherwise the least-idle active session.
+export function selectIdleSession(sessions: ActiveSession[]): ActiveSession | null {
+  if (sessions.length === 0) return null;
+  const consoleSession = sessions.find((s) => s.sessionType === 'console');
+  if (consoleSession) return consoleSession;
+  return [...sessions].sort(
+    (a, b) => (a.idleMinutes ?? Number.POSITIVE_INFINITY) - (b.idleMinutes ?? Number.POSITIVE_INFINITY)
+  )[0];
+}
+
+export function formatIdle(session: ActiveSession | null): string {
+  if (!session) return '—';
+  if (session.activityState === 'locked') return 'Locked';
+  if (session.idleMinutes === null || session.idleMinutes === undefined) return '—';
+  if (session.idleMinutes < 1) return 'Active';
+  const hours = Math.floor(session.idleMinutes / 60);
+  const minutes = session.idleMinutes % 60;
+  return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+}
+
+function tooltip(sessions: ActiveSession[]): string | undefined {
+  if (sessions.length === 0) return undefined;
+  const lines = sessions.map(
+    (s) => `${s.username} (${s.sessionType ?? 'unknown'}): ${formatIdle(s)}`
+  );
+  const updatedAt = sessions
+    .map((s) => s.updatedAt)
+    .filter(Boolean)
+    .sort()
+    .pop();
+  if (updatedAt) {
+    const d = new Date(updatedAt);
+    if (!isNaN(d.getTime())) {
+      lines.push(`As of ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+type DeviceUserIdleStatProps = {
+  deviceId: string;
+};
+
+export default function DeviceUserIdleStat({ deviceId }: DeviceUserIdleStatProps) {
+  const [sessions, setSessions] = useState<ActiveSession[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetchWithAuth(`/devices/${deviceId}/sessions/active`);
+        if (!res.ok) return;
+        const body = await res.json();
+        if (!cancelled) setSessions(body?.data?.activeUsers ?? []);
+      } catch {
+        // Read-only stat: on failure leave the em-dash placeholder.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [deviceId]);
+
+  const selected = selectIdleSession(sessions);
+
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+        <Timer className="h-3.5 w-3.5" />
+        User Idle
+      </div>
+      <p className="mt-1 text-lg font-semibold" title={tooltip(sessions)}>
+        {formatIdle(selected)}
+      </p>
+    </div>
+  );
+}
+```
+
+In `apps/web/src/components/devices/DeviceDetails.tsx`:
+
+Add to the component imports (after the `DeviceWarrantyCard` import):
+
+```tsx
+import DeviceUserIdleStat from './DeviceUserIdleStat';
+```
+
+In the overview stat strip, after the Logged-in User `<div>...</div>` block (the one ending with `{device.lastUser || '—'}</p>` around line 290), add:
+
+```tsx
+              <DeviceUserIdleStat deviceId={device.id} />
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/components/devices/DeviceUserIdleStat.test.tsx`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Type-check the web app**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit`
+Expected: no new errors (compare against a pre-change run if anything appears).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add apps/web/src/components/devices/DeviceUserIdleStat.tsx apps/web/src/components/devices/DeviceUserIdleStat.test.tsx apps/web/src/components/devices/DeviceDetails.tsx
+git commit -m "feat(web): show user idle time on device detail overview"
+```
+
+---
+
+### Task 8: Verification, Windows risk checkpoint, PR
+
+- [ ] **Step 1: Full agent test run + cross-compiles**
+
+```bash
+cd /Users/toddhebebrand/breeze/agent
+go test -race ./...
+GOOS=windows GOARCH=amd64 go build ./...
+GOOS=linux GOARCH=amd64 go build ./...
+CGO_ENABLED=0 go build ./...   # exercises the darwin nocgo detector path
+```
+Expected: all PASS / clean builds.
+
+- [ ] **Step 2: Affected web/API tests once more, single-fork**
+
+```bash
+cd /Users/toddhebebrand/breeze
+(cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/routes/agents/sessions.test.ts --pool=forks --poolOptions.forks.singleFork=true)
+(cd apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/components/devices/DeviceUserIdleStat.test.tsx)
+```
+Expected: PASS. (Do not gate on a full local API suite run — known parallel flakiness; CI is the arbiter.)
+
+- [ ] **Step 3: Windows console-session risk checkpoint (spec's single platform risk)**
+
+Build and push the agent to the e2e Windows device (`E2E_WINDOWS_DEVICE_ID` in `.env`), let one session refresh elapse (≤5 min), then check the stored value from local Postgres:
+
+```bash
+docker exec -i breeze-postgres psql -U breeze -d breeze -c \
+  "SELECT username, session_type, idle_minutes, activity_state, last_activity_at, updated_at \
+   FROM device_sessions WHERE is_active = true ORDER BY updated_at DESC LIMIT 5;"
+```
+
+Expected: the Windows console session row has non-null `idle_minutes` that increases while the device is untouched. **If `idle_minutes` stays null for the console session**, the WTS `LastInputTime` quirk is real on this hardware — record the finding in the spec and file the helper-IPC fallback as a follow-up issue; the feature still ships (UI shows "—" for affected sessions, real values for RDP/macOS/Linux-with-DE).
+
+Also verify the UI: open the device detail page for the Windows device and for the macOS device, confirm the "User Idle" stat shows a real duration (macOS should work via HIDIdleTime), goes to "Active" right after wiggling the mouse (after the next 5-minute refresh), and shows "Locked" when the machine is locked.
+
+- [ ] **Step 4: Create the PR**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git checkout -b feat/device-user-idle-time   # if not already on a branch — do this BEFORE Task 1 ideally
+git push -u origin feat/device-user-idle-time
+gh pr create --title "feat: show real user idle time on device detail" --body "$(cat <<'EOF'
+**What:** Device detail overview now shows a "User Idle" stat next to Logged-in User, backed by real agent-side idle measurement.
+
+**Why:** Session tracking shipped the `idleMinutes` plumbing end-to-end in Feb 2026, but the agent hardcoded it to 0 and no UI displayed it.
+
+**How:**
+- Agent: Windows `WTSSessionInfoEx.LastInputTime` (callable from Session 0), macOS `HIDIdleTime` via IOKit, Linux `loginctl IdleSinceHint` best-effort; `UserSession.IdleMinutes` is now `*int` so unknown ≠ 0
+- API: `?? 0` → `?? null` on session ingest (2 lines), `updatedAt` added to the active-sessions response (1 line)
+- Web: new `DeviceUserIdleStat` component in the overview stat strip
+
+Spec: `docs/superpowers/specs/2026-06-11-device-user-idle-time-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Note: requires an agent release to produce real data in production; old agents render as "—".

--- a/docs/superpowers/plans/2026-06-11-pending-reboot-indicator.md
+++ b/docs/superpowers/plans/2026-06-11-pending-reboot-indicator.md
@@ -1,0 +1,805 @@
+# Pending Reboot Indicator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist the agent's OS-level `pendingReboot` heartbeat flag to `devices.pending_reboot`, extend detection to Linux, and surface a "Reboot pending" badge/column in the device list and detail views.
+
+**Architecture:** The Go agent already detects pending reboots on Windows and sends `pendingReboot` in every heartbeat; the API validates the field but drops it. This plan adds a Linux detector (marker files + cached `needs-restarting -r`), persists the flag in the main-agent heartbeat handler, exposes it through the device list/detail endpoints, re-points the `system.rebootRequired` filter at the new column, and renders amber badges in the web UI.
+
+**Tech Stack:** Go (agent), Hono + Drizzle + Vitest (API), hand-written SQL migrations, Astro/React + Vitest/jsdom (web).
+
+**Spec:** `docs/superpowers/specs/2026-06-11-pending-reboot-indicator-design.md`
+
+**Environment notes (read first):**
+- Node toolchain: prefix every pnpm/vitest/tsc command with `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH` (default node 23 breaks pnpm engine-strict).
+- The full API vitest suite is flaky when run in parallel — verify by running affected test files individually; trust CI for the full sweep.
+- Go agent code lives in `agent/`, NOT `apps/agent/`.
+
+---
+
+### Task 1: Agent — restructure `DetectPendingReboot` per platform and add Linux detection
+
+The function currently lives in two files: `reboot_detect_windows.go` (`//go:build windows`) and `reboot_other.go` (`//go:build !windows`, which ALSO contains `RebootState`/`RebootManager` stubs that must stay `!windows`). Adding a Linux implementation means moving the function out of `reboot_other.go` into per-platform files. The Linux detection logic goes in an **untagged** file with injected dependencies (matching the `winget.go`/`UserExecFunc` pattern in this package) so its tests run on any dev platform (macOS locally, Linux in CI).
+
+**Files:**
+- Create: `agent/internal/patching/reboot_detect_unix.go` (untagged core logic)
+- Create: `agent/internal/patching/reboot_detect_unix_test.go` (untagged tests)
+- Create: `agent/internal/patching/reboot_detect_linux.go` (`//go:build linux` wrapper)
+- Create: `agent/internal/patching/reboot_detect_other.go` (`//go:build !windows && !linux` stub)
+- Modify: `agent/internal/patching/reboot_other.go` (delete the `DetectPendingReboot` function only)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agent/internal/patching/reboot_detect_unix_test.go` (no build tag — table-driven, matching `winget_test.go` style):
+
+```go
+package patching
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestDetectPendingRebootLinux(t *testing.T) {
+	marker := linuxRebootMarkers[0]
+	statHit := func(p string) (os.FileInfo, error) {
+		if p == marker {
+			return nil, nil // FileInfo value is never inspected
+		}
+		return nil, os.ErrNotExist
+	}
+	statMiss := func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+
+	tests := []struct {
+		name string
+		stat func(string) (os.FileInfo, error)
+		nr   func() (bool, bool)
+		want bool
+	}{
+		{"marker file present", statHit, func() (bool, bool) { return false, false }, true},
+		{"needs-restarting reports reboot needed", statMiss, func() (bool, bool) { return true, true }, true},
+		{"needs-restarting reports clean", statMiss, func() (bool, bool) { return false, true }, false},
+		{"no signal available", statMiss, func() (bool, bool) { return false, false }, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, reasons := detectPendingRebootLinux(tt.stat, tt.nr)
+			if got != tt.want {
+				t.Errorf("got %v, want %v (reasons: %v)", got, tt.want, reasons)
+			}
+			if got && len(reasons) == 0 {
+				t.Error("expected at least one reason when reboot is pending")
+			}
+			if !got && len(reasons) != 0 {
+				t.Errorf("expected no reasons when not pending, got %v", reasons)
+			}
+		})
+	}
+}
+
+func TestNeedsRestartingCache(t *testing.T) {
+	calls := 0
+	c := &nrCache{ttl: time.Hour, run: func() (bool, bool) { calls++; return true, true }}
+
+	if got, ok := c.get(); !got || !ok {
+		t.Fatalf("first get: got (%v,%v), want (true,true)", got, ok)
+	}
+	c.get()
+	if calls != 1 {
+		t.Errorf("expected 1 underlying call while cached, got %d", calls)
+	}
+
+	c.at = time.Now().Add(-2 * time.Hour) // expire the cache
+	c.get()
+	if calls != 2 {
+		t.Errorf("expected refresh after TTL expiry, got %d calls", calls)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd /Users/toddhebebrand/breeze/agent && go test ./internal/patching/ -run 'TestDetectPendingRebootLinux|TestNeedsRestartingCache' -v
+```
+Expected: compile FAILURE — `undefined: linuxRebootMarkers`, `undefined: detectPendingRebootLinux`, `undefined: nrCache`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `agent/internal/patching/reboot_detect_unix.go` (no build tag):
+
+```go
+package patching
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+// linuxRebootMarkers are distro-written marker files whose presence means a
+// reboot is required (Debian/Ubuntu apt writes /var/run/reboot-required).
+var linuxRebootMarkers = []string{
+	"/var/run/reboot-required",
+}
+
+// nrCache memoizes the needs-restarting result: the command can take seconds
+// on RHEL-family systems and heartbeats run every cycle.
+type nrCache struct {
+	mu  sync.Mutex
+	ttl time.Duration
+	at  time.Time
+	val bool
+	ok  bool
+	run func() (bool, bool)
+}
+
+func (c *nrCache) get() (bool, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.at.IsZero() && time.Since(c.at) < c.ttl {
+		return c.val, c.ok
+	}
+	c.val, c.ok = c.run()
+	c.at = time.Now()
+	return c.val, c.ok
+}
+
+// detectPendingRebootLinux is the testable core of the Linux detector. Kept
+// untagged with injected deps so its tests run on any dev platform; the
+// //go:build linux wrapper in reboot_detect_linux.go wires the real deps.
+func detectPendingRebootLinux(stat func(string) (os.FileInfo, error), nr func() (bool, bool)) (bool, []string) {
+	var reasons []string
+	for _, p := range linuxRebootMarkers {
+		if _, err := stat(p); err == nil {
+			reasons = append(reasons, "reboot-required marker present: "+p)
+		}
+	}
+	if len(reasons) == 0 {
+		if needed, ok := nr(); ok && needed {
+			reasons = append(reasons, "needs-restarting reports reboot required")
+		}
+	}
+	return len(reasons) > 0, reasons
+}
+
+// runNeedsRestarting executes `needs-restarting -r` (RHEL/dnf-utils).
+// Exit 0 = no reboot needed, exit 1 = reboot needed, anything else (or the
+// tool being absent) = no signal.
+func runNeedsRestarting() (bool, bool) {
+	path, err := exec.LookPath("needs-restarting")
+	if err != nil {
+		return false, false
+	}
+	if err := exec.Command(path, "-r").Run(); err == nil {
+		return false, true
+	} else {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return true, true
+		}
+	}
+	return false, false
+}
+```
+
+Create `agent/internal/patching/reboot_detect_linux.go`:
+
+```go
+//go:build linux
+
+package patching
+
+import (
+	"os"
+	"time"
+)
+
+var linuxNeedsRestarting = &nrCache{ttl: 30 * time.Minute, run: runNeedsRestarting}
+
+// DetectPendingReboot reports whether the OS indicates a pending reboot.
+func DetectPendingReboot() (bool, []string) {
+	return detectPendingRebootLinux(os.Stat, linuxNeedsRestarting.get)
+}
+```
+
+Create `agent/internal/patching/reboot_detect_other.go`:
+
+```go
+//go:build !windows && !linux
+
+package patching
+
+// DetectPendingReboot is a no-op on macOS — there is no reliable cheap
+// pending-reboot signal short of querying softwareupdate.
+func DetectPendingReboot() (bool, []string) {
+	return false, nil
+}
+```
+
+Modify `agent/internal/patching/reboot_other.go` — delete ONLY this function (lines ~7-10); everything else in the file (`RebootState`, `NotifyFunc`, `RebootManager` and its methods) stays, with the `//go:build !windows` tag unchanged:
+
+```go
+// DELETE these lines:
+// DetectPendingReboot is a no-op on non-Windows platforms.
+func DetectPendingReboot() (bool, []string) {
+	return false, nil
+}
+```
+
+- [ ] **Step 4: Run the tests and cross-compile checks**
+
+```bash
+cd /Users/toddhebebrand/breeze/agent && go test ./internal/patching/ -run 'TestDetectPendingRebootLinux|TestNeedsRestartingCache' -v
+GOOS=linux go build ./... && GOOS=darwin go build ./... && GOOS=windows go build ./...
+```
+Expected: tests PASS; all three GOOS builds succeed (proves no duplicate/missing `DetectPendingReboot` symbol on any platform).
+
+- [ ] **Step 5: Run the full patching package test suite with race detection**
+
+```bash
+cd /Users/toddhebebrand/breeze/agent && go test -race ./internal/patching/...
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add agent/internal/patching/reboot_detect_unix.go agent/internal/patching/reboot_detect_unix_test.go agent/internal/patching/reboot_detect_linux.go agent/internal/patching/reboot_detect_other.go agent/internal/patching/reboot_other.go
+git commit -m "feat(agent): Linux pending-reboot detection via markers + needs-restarting"
+```
+
+---
+
+### Task 2: Agent — send `pendingReboot: false` explicitly (remove `omitempty`)
+
+With `omitempty`, the flag clearing after a reboot means the field vanishes from the wire instead of being sent as `false`. The API treats absent as false anyway, but explicit is unambiguous.
+
+**Files:**
+- Modify: `agent/internal/heartbeat/heartbeat.go:68`
+
+- [ ] **Step 1: Edit the struct tag**
+
+In `agent/internal/heartbeat/heartbeat.go` line 68, change:
+
+```go
+	PendingReboot    bool                      `json:"pendingReboot,omitempty"`
+```
+to:
+```go
+	PendingReboot    bool                      `json:"pendingReboot"`
+```
+
+- [ ] **Step 2: Build and test the heartbeat package**
+
+```bash
+cd /Users/toddhebebrand/breeze/agent && go build ./... && go test -race ./internal/heartbeat/...
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add agent/internal/heartbeat/heartbeat.go
+git commit -m "fix(agent): send pendingReboot=false explicitly in heartbeat"
+```
+
+---
+
+### Task 3: DB — migration + Drizzle schema for `devices.pending_reboot`
+
+**Files:**
+- Create: `apps/api/migrations/2026-06-11-j-device-pending-reboot.sql` (next free slot after `2026-06-11-i-devices-site-id-index.sql`; lexicographic ordering matters)
+- Modify: `apps/api/src/db/schema/devices.ts:67` (after `isHeadless`)
+
+- [ ] **Step 1: Write the migration**
+
+Create `apps/api/migrations/2026-06-11-j-device-pending-reboot.sql` (idempotent, NO inner BEGIN/COMMIT — autoMigrate wraps each file in a transaction):
+
+```sql
+-- OS-level pending-reboot flag reported by the agent in every main-agent
+-- heartbeat (Windows registry checks; Linux reboot-required markers /
+-- needs-restarting). Self-clears on the first post-reboot heartbeat.
+-- Backs the system.rebootRequired device filter and the "Reboot pending"
+-- UI badge. Spec: docs/superpowers/specs/2026-06-11-pending-reboot-indicator-design.md
+ALTER TABLE devices ADD COLUMN IF NOT EXISTS pending_reboot boolean NOT NULL DEFAULT false;
+
+-- Partial index: the fleet-wide system.rebootRequired filter only ever looks
+-- for pending_reboot = true, which is a small minority of rows.
+CREATE INDEX IF NOT EXISTS devices_pending_reboot_idx ON devices (pending_reboot) WHERE pending_reboot = true;
+```
+
+- [ ] **Step 2: Add the column to the Drizzle schema**
+
+In `apps/api/src/db/schema/devices.ts`, directly after the `isHeadless` line (line 67):
+
+```typescript
+  isHeadless: boolean('is_headless').notNull().default(false),
+  // OS-level pending-reboot flag from the agent heartbeat (Windows registry
+  // checks; Linux reboot-required markers / needs-restarting). Self-clears
+  // on the first post-reboot heartbeat. Backs the system.rebootRequired
+  // filter and the "Reboot pending" UI badge.
+  pendingReboot: boolean('pending_reboot').notNull().default(false),
+```
+
+- [ ] **Step 3: Verify no schema drift**
+
+```bash
+cd /Users/toddhebebrand/breeze && export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm db:check-drift
+```
+Expected: no drift. Note: `2026-06-11-i-devices-site-id-index.sql` added an index with no schema-side declaration and passes drift check, so the partial index needs no Drizzle representation. If drift IS flagged for the index, mirror it in the schema by adding a third argument to the `pgTable` call: `(t) => [index('devices_pending_reboot_idx').on(t.pendingReboot).where(sql\`pending_reboot = true\`)]`.
+
+- [ ] **Step 4: Apply locally and verify the column exists**
+
+```bash
+docker exec -i breeze-postgres psql -U breeze -d breeze -c "\d devices" | grep pending_reboot || echo "COLUMN MISSING — start the API once to run autoMigrate, then re-check"
+```
+Expected: `pending_reboot | boolean | not null | default false` (run the API dev server briefly if autoMigrate hasn't applied it yet).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/migrations/2026-06-11-j-device-pending-reboot.sql apps/api/src/db/schema/devices.ts
+git commit -m "feat(db): devices.pending_reboot column + partial index"
+```
+
+---
+
+### Task 4: API — persist the heartbeat flag (main-agent branch only)
+
+**Files:**
+- Modify: `apps/api/src/routes/agents/heartbeat.ts:310-317` (the `deviceUpdates` literal)
+- Test: `apps/api/src/routes/agents/heartbeat.test.ts`
+
+The Zod schema already parses the field (`apps/api/src/routes/agents/schemas.ts:137`: `pendingReboot: z.boolean().optional().catch(undefined)`) — no schema change needed. The watchdog branch (lines 161-177, `watchdogUpdates`) must NOT be touched.
+
+- [ ] **Step 1: Read the existing test file to learn its helpers**
+
+Read `apps/api/src/routes/agents/heartbeat.test.ts` (786 lines) — note how existing tests build a heartbeat request, how `updateMock`/`selectChainResolving` capture the `.set()` payload, and how main-agent vs watchdog heartbeats are distinguished (the `role: 'watchdog'` payload field). The new tests below must reuse those exact helpers.
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to `heartbeat.test.ts`, following the file's existing pattern for asserting fields in the captured `db.update(devices).set(...)` argument (adapt helper/mock names to what Step 1 found — the assertions are the contract):
+
+```typescript
+describe('pendingReboot persistence', () => {
+  it('persists pendingReboot=true from the main-agent heartbeat', async () => {
+    // Build a standard main-agent heartbeat request (existing helper) with
+    // payload { ...validHeartbeat, pendingReboot: true }
+    // Assert the captured devices update payload:
+    expect(capturedDeviceUpdate).toMatchObject({ pendingReboot: true });
+  });
+
+  it('clears pendingReboot when the field is absent (old agents / post-reboot)', async () => {
+    // Same request WITHOUT a pendingReboot key in the payload.
+    expect(capturedDeviceUpdate).toMatchObject({ pendingReboot: false });
+  });
+
+  it('watchdog heartbeats never touch pendingReboot', async () => {
+    // Build a watchdog heartbeat request (role: 'watchdog', existing helper).
+    expect(capturedWatchdogUpdate).not.toHaveProperty('pendingReboot');
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests to verify the first two fail**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/routes/agents/heartbeat.test.ts
+```
+Expected: the two persistence tests FAIL (no `pendingReboot` key in the update payload); the watchdog test passes already.
+
+- [ ] **Step 4: Implement**
+
+In `apps/api/src/routes/agents/heartbeat.ts`, add one line to the `deviceUpdates` literal (after `uptimeSeconds`, line 315):
+
+```typescript
+  const deviceUpdates: Record<string, unknown> = {
+    lastSeenAt: new Date(),
+    status: 'online',
+    agentVersion: data.agentVersion,
+    lastUser: data.lastUser ?? null,
+    uptimeSeconds: data.uptime ?? null,
+    // OS-level pending-reboot flag. Absent (old agents) means false — the
+    // conservative default — and writing unconditionally lets the flag
+    // self-clear on the first post-reboot heartbeat.
+    pendingReboot: data.pendingReboot ?? false,
+    updatedAt: new Date()
+  };
+```
+
+- [ ] **Step 5: Run the test file again**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/routes/agents/heartbeat.test.ts
+```
+Expected: ALL tests in the file PASS (including pre-existing ones).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/agents/heartbeat.ts apps/api/src/routes/agents/heartbeat.test.ts
+git commit -m "feat(api): persist agent pendingReboot heartbeat flag to devices"
+```
+
+---
+
+### Task 5: API — expose `pendingReboot` in device list + shared type
+
+**Files:**
+- Modify: `apps/api/src/routes/devices/core.ts:525` (list SELECT)
+- Modify: `packages/shared/src/types/index.ts:152` (Device interface)
+
+The detail route (`coreRoutes.get` at core.ts:678) fetches the device with a bare `.select()` — all columns — so it picks up `pendingReboot` automatically once the schema column exists. Only the list endpoint's explicit field list needs editing.
+
+- [ ] **Step 1: Add the field to the list SELECT**
+
+In `apps/api/src/routes/devices/core.ts`, in the `.select({...})` starting at line 501, after `isHeadless` (line 525):
+
+```typescript
+        isHeadless: devices.isHeadless,
+        pendingReboot: devices.pendingReboot,
+```
+
+- [ ] **Step 2: Add the field to the shared Device interface**
+
+In `packages/shared/src/types/index.ts`, after `isHeadless` (line 152):
+
+```typescript
+  isHeadless: boolean;
+  pendingReboot: boolean;
+```
+
+- [ ] **Step 3: Check the OpenAPI doc**
+
+```bash
+grep -n "isHeadless" /Users/toddhebebrand/breeze/apps/api/src/openapi.ts
+```
+If the device response schema in `openapi.ts` documents `isHeadless`, add `pendingReboot: { type: 'boolean' }` alongside it in the same object. If devices responses aren't documented there (only the heartbeat request is, at line 656), skip.
+
+- [ ] **Step 4: Type-check both packages**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+cd /Users/toddhebebrand/breeze/packages/shared && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+```
+Expected: no NEW errors (pre-existing failures in `agents.test.ts` / `apiKeyAuth.test.ts` are known).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/devices/core.ts packages/shared/src/types/index.ts apps/api/src/openapi.ts
+git commit -m "feat(api): return pendingReboot in device list response"
+```
+
+---
+
+### Task 6: API — re-point `system.rebootRequired` filter at the new column
+
+**Files:**
+- Modify: `apps/api/src/services/filterEngine.ts:119` (field definition) and `:217-229` (SQL rendering)
+- Test: `apps/api/src/services/filterEngine.test.ts:94-99`
+
+- [ ] **Step 1: Update the failing test first**
+
+Replace the existing test at `filterEngine.test.ts:94-99`:
+
+```typescript
+    it('system.rebootRequired → devices.pending_reboot column', () => {
+      const sql = render({ field: 'system.rebootRequired', operator: 'equals', value: 'yes' });
+      expect(sql).toMatch(/pending_reboot/i);
+      expect(sql).not.toMatch(/patch_job_results/i);
+    });
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/services/filterEngine.test.ts
+```
+Expected: FAIL — rendered SQL still references `patch_job_results`.
+
+- [ ] **Step 3: Implement**
+
+In `apps/api/src/services/filterEngine.ts`:
+
+(a) Field definition, line 119 — update the description:
+
+```typescript
+  { key: 'system.rebootRequired', label: 'Reboot Required', category: 'core', type: 'boolean', operators: ['equals', 'notEquals'], description: 'Device OS reports a reboot is pending' },
+```
+
+(b) SQL rendering, lines 217-229 — swap the `patch_job_results` EXISTS subquery for the column predicate. The surrounding equals/notEquals negation logic is shared and stays untouched:
+
+```typescript
+  if (field === 'patches.pending' || field === 'alerts.critical' || field === 'system.rebootRequired') {
+    let inner: SQL<unknown>;
+    if (field === 'patches.pending') {
+      inner = sql`EXISTS (SELECT 1 FROM device_patches WHERE device_id = ${devices.id} AND status = 'pending')`;
+    } else if (field === 'alerts.critical') {
+      inner = sql`EXISTS (SELECT 1 FROM alerts WHERE device_id = ${devices.id} AND status = 'active' AND severity = 'critical')`;
+    } else {
+      // OS-level flag persisted from the agent heartbeat. Intentionally
+      // broader than the old patch_job_results subquery: matches reboots
+      // from any cause, so the filter agrees with the "Reboot pending"
+      // badge. (Spec 2026-06-11-pending-reboot-indicator-design.md)
+      inner = sql`${devices.pendingReboot} = true`;
+    }
+    const negative = value === false || value === 'no' || value === 'false';
+    const negate = (operator === 'notEquals') !== negative;
+    return negate ? sql`NOT (${inner})` : inner;
+  }
+```
+
+- [ ] **Step 4: Run the test file**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/services/filterEngine.test.ts
+```
+Expected: ALL tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/filterEngine.ts apps/api/src/services/filterEngine.test.ts
+git commit -m "feat(api): re-point system.rebootRequired filter at devices.pending_reboot"
+```
+
+---
+
+### Task 7: Web — add `pendingReboot` to the Device type and both API→UI mappings
+
+**Files:**
+- Modify: `apps/web/src/components/devices/DeviceList.tsx:36-83` (local `Device` type)
+- Modify: `apps/web/src/components/devices/DevicesPage.tsx:~187` (list transform)
+- Modify: `apps/web/src/components/devices/DeviceDetailPage.tsx:~83` (detail transform)
+
+- [ ] **Step 1: Extend the Device type**
+
+In `DeviceList.tsx`, in the exported `Device` type, after `isHeadless?: boolean;`:
+
+```typescript
+  isHeadless?: boolean;
+  /**
+   * OS-level pending-reboot flag persisted from the agent heartbeat
+   * (devices.pending_reboot). True when Windows registry / Linux
+   * reboot-required markers say a reboot is outstanding. Absent on
+   * responses from older API versions.
+   */
+  pendingReboot?: boolean;
+```
+
+- [ ] **Step 2: Map it in DevicesPage**
+
+In `DevicesPage.tsx`, in the `transformedDevices` map (the `isHeadless` line is at 187), add alongside:
+
+```typescript
+          isHeadless: typeof d.isHeadless === 'boolean' ? d.isHeadless : undefined,
+          pendingReboot: d.pendingReboot === true,
+```
+
+- [ ] **Step 3: Map it in DeviceDetailPage**
+
+In `DeviceDetailPage.tsx`, in the `transformedDevice` literal (the `isHeadless` line is at 83), add alongside:
+
+```typescript
+        isHeadless: data.isHeadless ?? undefined,
+        pendingReboot: data.pendingReboot === true,
+```
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+```
+Expected: no NEW errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/devices/DeviceList.tsx apps/web/src/components/devices/DevicesPage.tsx apps/web/src/components/devices/DeviceDetailPage.tsx
+git commit -m "feat(web): thread pendingReboot through device type and page mappings"
+```
+
+---
+
+### Task 8: Web — device list badge + toggleable column
+
+**Files:**
+- Modify: `apps/web/src/components/devices/DeviceList.tsx` (status cell ~line 590-613; column registry near `agentVersion` def at ~668)
+- Modify: `apps/web/src/components/devices/columnVisibility.ts` (COLUMN_IDS at 9-33, COLUMN_LABELS at 36-61; do NOT touch DEFAULT_VISIBLE_COLUMNS — the column ships hidden by default)
+- Test: `apps/web/src/components/devices/DeviceList.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `DeviceList.test.tsx`, reusing the existing `baseDevice` fixture (lines 16-31) and following the agent-silent badge test style (lines 34-49):
+
+```tsx
+describe('DeviceList — pending reboot badge', () => {
+  it('renders the amber badge when pendingReboot is true', () => {
+    const device: Device = {
+      ...baseDevice,
+      id: '33333333-3333-3333-3333-333333333333',
+      hostname: 'host-needs-reboot',
+      pendingReboot: true,
+    };
+
+    render(<DeviceList devices={[device]} />);
+
+    const badge = screen.getByTestId(`device-${device.id}-pending-reboot-badge`);
+    expect(badge.textContent).toMatch(/Reboot pending/i);
+  });
+
+  it('renders no badge when pendingReboot is false or absent', () => {
+    const explicitFalse: Device = {
+      ...baseDevice,
+      id: '44444444-4444-4444-4444-444444444444',
+      pendingReboot: false,
+    };
+
+    render(<DeviceList devices={[explicitFalse, baseDevice]} />);
+
+    expect(
+      screen.queryByTestId(`device-${explicitFalse.id}-pending-reboot-badge`)
+    ).toBeNull();
+    expect(
+      screen.queryByTestId(`device-${baseDevice.id}-pending-reboot-badge`)
+    ).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/components/devices/DeviceList.test.tsx
+```
+Expected: the first new test FAILS (`Unable to find an element by: [data-testid="device-...-pending-reboot-badge"]`).
+
+- [ ] **Step 3: Add the badge to the status cell**
+
+In `DeviceList.tsx`, in the `status` column cell (lines 590-613), after the agent-silent badge block and inside the same flex wrapper:
+
+```tsx
+        {shouldShowAgentSilentBadge(device) && (
+          /* ...existing agent-silent badge unchanged... */
+        )}
+        {device.pendingReboot && (
+          <span
+            data-testid={`device-${device.id}-pending-reboot-badge`}
+            title="The OS reports a pending reboot (Windows registry / Linux reboot-required markers)."
+            className="inline-flex items-center whitespace-nowrap rounded-full border px-2 py-0.5 text-[10px] font-medium bg-warning/15 text-warning border-warning/30"
+          >
+            Reboot pending
+          </span>
+        )}
+```
+
+- [ ] **Step 4: Register the toggleable column**
+
+In `columnVisibility.ts`, add `'pendingReboot'` to `COLUMN_IDS` directly after `'status'`:
+
+```typescript
+  'status',
+  'pendingReboot',
+```
+
+and to `COLUMN_LABELS`:
+
+```typescript
+  status: 'Status',
+  pendingReboot: 'Pending Reboot',
+```
+
+In `DeviceList.tsx`, add a column definition to the column registry (same object as the `status` and `agentVersion` definitions; place it after `status`):
+
+```tsx
+pendingReboot: {
+  header: () => <th key="pendingReboot" className="px-3 py-3">Pending Reboot</th>,
+  cell: (device) => (
+    <td key="pendingReboot" className="px-3 py-3 text-sm whitespace-nowrap">
+      {device.pendingReboot ? (
+        <span className="inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium bg-warning/15 text-warning border-warning/30">
+          Reboot pending
+        </span>
+      ) : (
+        dash
+      )}
+    </td>
+  ),
+},
+```
+
+(Display-only — no `sortHeader`, matching the spec; the advanced filter covers querying. If the registry's TypeScript type requires every `ColumnId` to have a definition, the compiler will flag any miss — fix until `tsc` is clean.)
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/components/devices/DeviceList.test.tsx && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+```
+Expected: all DeviceList tests PASS; no new type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/devices/DeviceList.tsx apps/web/src/components/devices/columnVisibility.ts apps/web/src/components/devices/DeviceList.test.tsx
+git commit -m "feat(web): pending-reboot badge and toggleable column in device list"
+```
+
+---
+
+### Task 9: Web — device detail header badge
+
+**Files:**
+- Modify: `apps/web/src/components/devices/DeviceDetails.tsx:~212-216` (header, next to the status badge)
+
+- [ ] **Step 1: Add the badge**
+
+In `DeviceDetails.tsx`, inside the header flex row (lines 211-216), directly after the status `<span>`:
+
+```tsx
+              <span className={`inline-flex shrink-0 items-center rounded-full border px-2.5 py-1 text-xs font-medium ${statusColors[device.status]}`}>
+                {statusLabels[device.status]}
+              </span>
+              {device.pendingReboot && (
+                <span
+                  data-testid="device-pending-reboot-badge"
+                  title="The OS reports a pending reboot (Windows registry / Linux reboot-required markers)."
+                  className="inline-flex shrink-0 items-center rounded-full border px-2.5 py-1 text-xs font-medium bg-warning/15 text-warning border-warning/30"
+                >
+                  Reboot pending
+                </span>
+              )}
+```
+
+- [ ] **Step 2: Type-check and run the devices component tests**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/components/devices/
+```
+Expected: PASS. (If a `DeviceDetails.test.tsx` exists, add a badge render test mirroring the Task 8 Step 1 pattern with `data-testid="device-pending-reboot-badge"`; if none exists, do not create one just for this — the DeviceList tests cover the badge logic and the detail badge is the same one-line conditional.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/devices/DeviceDetails.tsx
+git commit -m "feat(web): pending-reboot badge on device detail header"
+```
+
+---
+
+### Task 10: Final verification sweep
+
+- [ ] **Step 1: Re-run every affected test file individually** (full parallel vitest run is known-flaky locally; trust CI for the sweep)
+
+```bash
+cd /Users/toddhebebrand/breeze/agent && go test -race ./internal/patching/... ./internal/heartbeat/...
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/routes/agents/heartbeat.test.ts src/services/filterEngine.test.ts
+cd /Users/toddhebebrand/breeze/apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/components/devices/
+```
+Expected: all PASS.
+
+- [ ] **Step 2: Drift + type checks**
+
+```bash
+cd /Users/toddhebebrand/breeze && export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm db:check-drift
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+cd /Users/toddhebebrand/breeze/apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+```
+Expected: no drift, no new type errors (known pre-existing: `agents.test.ts`, `apiKeyAuth.test.ts`).
+
+- [ ] **Step 3: End-to-end smoke (optional but recommended)**
+
+With local docker compose dev stack running and a Windows or Linux test agent enrolled: trigger a heartbeat, then
+
+```bash
+docker exec -i breeze-postgres psql -U breeze -d breeze -c "SELECT hostname, pending_reboot FROM devices ORDER BY last_seen_at DESC LIMIT 5;"
+```
+Expected: column populated (false is fine — it proves the write path). On a Linux test box, `sudo touch /var/run/reboot-required` and wait one heartbeat to see it flip to true, then check the badge renders in the device list UI.
+
+- [ ] **Step 4: Done — hand off**
+
+Use the superpowers:finishing-a-development-branch skill (or open a PR per the repo's `gh pr merge --squash --admin` flow) once everything is green.

--- a/docs/superpowers/specs/2026-06-11-device-user-idle-time-design.md
+++ b/docs/superpowers/specs/2026-06-11-device-user-idle-time-design.md
@@ -34,9 +34,12 @@ Per platform:
 - `LastActivityAt` is set to `now − idle` when idle is known (today it is overwritten to `now` on every 5-minute refresh, making it useless as an idle signal). When idle is unknown, keep current behavior.
 - `activityState` semantics are unchanged — it remains OS session connect state (active/locked/disconnected/away). No derived "idle" state from thresholds in this iteration.
 
-### 2. API / DB — no changes
+### 2. API / DB — two one-line tweaks, no migration
 
-`submitSessionsSchema` already accepts optional `idleMinutes` (int, 0–10080). The sessions route already upserts `idle_minutes` on each report. `GET /devices/:id/sessions/active` already returns it. No migration, no RLS work, no new endpoints.
+`submitSessionsSchema` already accepts optional `idleMinutes` (int, 0–10080). `GET /devices/:id/sessions/active` already returns it. No migration, no RLS work, no new endpoints. Two small route fixes are required:
+
+- The ingestion route (`apps/api/src/routes/agents/sessions.ts:98,111`) coerces a missing `idleMinutes` to `0`, which would erase the null-means-unknown semantics. Change `?? 0` to `?? null` at both sites.
+- The active-sessions endpoint (`apps/api/src/routes/devices/sessions.ts`) doesn't select `updatedAt`; add it to the response so the UI tooltip can show report freshness.
 
 ### 3. Web UI — one stat in the overview strip
 

--- a/docs/superpowers/specs/2026-06-11-device-user-idle-time-design.md
+++ b/docs/superpowers/specs/2026-06-11-device-user-idle-time-design.md
@@ -1,0 +1,72 @@
+# Device User Idle Time — Design
+
+**Date:** 2026-06-11
+**Status:** Approved
+
+## Problem
+
+The device detail page shows Logged-in User but gives no indication of whether that user is actually at the machine. Session tracking shipped in Feb 2026 (commit 832f96bf) with full plumbing for `idleMinutes` — agent struct field, API schema (`submitSessionsSchema`), `device_sessions.idle_minutes` column, and the `GET /devices/:id/sessions/active` endpoint — but the agent hardcodes `IdleMinutes: 0` (`agent/internal/collectors/sessions.go:184,219`) and no UI displays it. The agent does not call any OS input-idle API anywhere.
+
+## Goal
+
+Show real user idle time (e.g. "Idle 23m") on the device detail overview, measured by the agent per session.
+
+## Decision
+
+Measure idle in the agent's existing session detector (Approach A — service-side WTS query on Windows), not via the user helper. The helper-IPC path (`GetLastInputInfo` reported over the named pipe) is the fallback if Windows console-session measurement proves unreliable in practice; it is explicitly out of scope for this iteration.
+
+## Design
+
+### 1. Agent — measure idle per session (the only new plumbing)
+
+`DetectedSession` (`agent/internal/sessionbroker/detector.go`) gains an idle field with explicit unknown-ness, e.g. `IdleFor time.Duration` + `IdleKnown bool`.
+
+Per platform:
+
+- **Windows** (`detector_windows.go`): alongside the existing `WTSConnectState` query (info class 4), also query `WTSSessionInfoEx` (info class 25) and read `WTSINFOEX.Data.WTSInfoExLevel1.LastInputTime` (FILETIME). Idle = now − LastInputTime. A zero FILETIME — a known quirk for the console session on some Windows versions — means **unknown**, never "0 minutes". Callable from Session 0; no helper involvement.
+- **macOS** (`detector_darwin.go`): read `HIDIdleTime` (nanoseconds) from the `IOHIDSystem` IORegistry entry via the existing cgo path. The value is system-wide; apply it to the console session (the only kind the darwin detector reports today). The `detector_darwin_nocgo.go` variant leaves idle unknown.
+- **Linux** (`detector_linux.go`): add `IdleHint,IdleSinceHint` to the existing `loginctl show-session --property=...` invocation. Idle = now − IdleSinceHint when `IdleHint=yes`; otherwise unknown. Headless/Wayland sessions that don't populate the hint stay unknown. Best-effort by design.
+
+`collectors/sessions.go` changes:
+
+- `UserSession.IdleMinutes` becomes `*int` (`json:"idleMinutes,omitempty"`). Rationale: with plain `int`+`omitempty`, "measured 0" and "unknown" are indistinguishable on the wire. As a pointer, measured-active serializes as `0`, unknown is omitted. Old agents (which always had the zero value omitted) therefore read as unknown, and the UI shows "—" instead of a false "Active".
+- The two hardcoded `IdleMinutes: 0` sites populate from the detector (nil when unknown), clamped to the API max of 10080 minutes.
+- `LastActivityAt` is set to `now − idle` when idle is known (today it is overwritten to `now` on every 5-minute refresh, making it useless as an idle signal). When idle is unknown, keep current behavior.
+- `activityState` semantics are unchanged — it remains OS session connect state (active/locked/disconnected/away). No derived "idle" state from thresholds in this iteration.
+
+### 2. API / DB — no changes
+
+`submitSessionsSchema` already accepts optional `idleMinutes` (int, 0–10080). The sessions route already upserts `idle_minutes` on each report. `GET /devices/:id/sessions/active` already returns it. No migration, no RLS work, no new endpoints.
+
+### 3. Web UI — one stat in the overview strip
+
+`apps/web/src/components/devices/DeviceDetails.tsx`, overview tab stat strip (CPU / RAM / Last Seen / Uptime / Logged-in User): add a **User Idle** stat next to Logged-in User.
+
+- Data source: `GET /devices/:id/sessions/active`, fetched when the overview tab renders. Read-only GET — `runAction` does not apply (mutations only).
+- Session selection: prefer the `console` session; if none, the least-idle active session.
+- Display rules:
+  - no active sessions, or `idleMinutes` null → `—`
+  - selected session `activityState === 'locked'` → `Locked`
+  - `idleMinutes` 0 (i.e. <1m) → `Active`
+  - otherwise a compact duration: `23m`, `1h 5m`
+- Tooltip: per-session breakdown (username, type, state, idle) when multiple sessions exist, plus report freshness ("as of <time>") — the agent reports sessions every 5 minutes, so the value is up to ~5 minutes stale.
+
+### 4. Testing
+
+Per `breeze-testing` conventions, tests alongside source:
+
+- **Go** (table-driven): FILETIME→duration conversion incl. zero-FILETIME→unknown; loginctl `IdleHint`/`IdleSinceHint` parsing incl. missing/`no` cases; collector test asserting `IdleMinutes` pointer population and `LastActivityAt = now − idle`.
+- **Web** (Vitest + jsdom): display-rule formatting — unknown→`—`, locked→`Locked`, 0→`Active`, durations, console-session preference.
+- Validator bounds for `idleMinutes` are already covered by existing schema tests.
+- **Manual verification, early**: Windows console-session `LastInputTime` on the e2e Windows device (`E2E_WINDOWS_DEVICE_ID` env). This is the single platform risk; if it reads zero, the helper-IPC fallback becomes a follow-up.
+
+## Rollout
+
+Requires an agent release for real data. Until a device's agent upgrades, its `idleMinutes` stays null and the UI shows `—` — stale-correct, never wrong. No env vars, no config, no migration.
+
+## Out of scope
+
+- Helper-IPC idle reporting (fallback if WTS console measurement fails verification)
+- Deriving `activityState: 'idle'` from idle thresholds
+- Idle time in the device list / fleet views
+- Idle-based alerting or automation triggers

--- a/docs/superpowers/specs/2026-06-11-pending-reboot-indicator-design.md
+++ b/docs/superpowers/specs/2026-06-11-pending-reboot-indicator-design.md
@@ -1,0 +1,69 @@
+# Pending Reboot Indicator — Design
+
+**Date:** 2026-06-11
+**Status:** Approved
+
+## Summary
+
+Surface a "Reboot pending" indicator on the device list and device detail view, driven by the OS-level pending-reboot flag the agent already collects. The agent has shipped `pendingReboot` in every heartbeat since the Windows patching work, but the API validates the field (`routes/agents/schemas.ts:137`) and then drops it — nothing persists or displays it. This feature completes the pipeline and extends detection to Linux.
+
+## Source of truth
+
+The **OS-level heartbeat flag**, persisted to a new `devices.pending_reboot` column.
+
+Rationale: it catches all reboot causes (Windows Update outside Breeze, third-party installers, pending file renames), refreshes every heartbeat, and self-clears after reboot. The alternative — the existing `patch_job_results.reboot_required AND rebooted_at IS NULL` query backing the `system.rebootRequired` filter (#968) — only sees Breeze-managed patch jobs.
+
+The `patch_job_results` columns and the patch-reboot policy machinery (`patchRebootHandler`) are **not** changed by this feature.
+
+## Agent (Go) — `agent/` (not `apps/agent/`)
+
+Windows detection already exists: `agent/internal/patching/reboot_detect_windows.go` checks the four standard registry locations (WindowsUpdate `RebootRequired`, CBS `RebootPending`, `PendingFileRenameOperations` ×2) and `heartbeat.go` sends it every cycle.
+
+Changes:
+
+1. **New `agent/internal/patching/reboot_detect_linux.go`** (build tag `linux`):
+   - Return `true` if `/var/run/reboot-required` exists (Debian/Ubuntu marker).
+   - RHEL-family fallback: if `needs-restarting` is on PATH, run `needs-restarting -r`; exit code 1 means reboot needed. Cache the result for ~30 minutes — the command can take seconds and heartbeats are frequent. Marker-file check is cheap and runs every time; only the exec path is cached.
+   - Errors (exec failure, unexpected exit codes other than 0/1) → return `false` with the error; caller already discards it (`pendingReboot, _ :=`).
+2. **`agent/internal/patching/reboot_other.go`**: narrow build tag from `!windows` to darwin-only stub returning `(false, nil)`. macOS has no reliable cheap signal; it stays unsupported.
+3. **`agent/internal/heartbeat/heartbeat.go`**: remove `,omitempty` from `PendingReboot` so `false` is sent explicitly. Makes the clear-after-reboot transition unambiguous on the wire instead of relying on absent-means-false.
+
+## API + DB
+
+1. **Migration** `apps/api/migrations/2026-06-12-device-pending-reboot.sql` (idempotent, no inner BEGIN/COMMIT):
+   - `ALTER TABLE devices ADD COLUMN IF NOT EXISTS pending_reboot boolean NOT NULL DEFAULT false;`
+   - Partial index `CREATE INDEX IF NOT EXISTS idx_devices_pending_reboot ON devices (pending_reboot) WHERE pending_reboot = true;` — cheap, supports the fleet-wide filter.
+   - Existing tenant-scoped table → existing RLS policies apply; no new RLS work.
+2. **Schema**: add `pendingReboot` to `apps/api/src/db/schema/devices.ts`; verify with `pnpm db:check-drift`.
+3. **Heartbeat handler** (`apps/api/src/routes/agents/heartbeat.ts`): in the **main-agent branch only** (watchdog heartbeats must not touch the flag), include `pendingReboot: payload.pendingReboot ?? false` in the device update. Absent field (older agents) → `false`, the correct conservative default. The flag self-clears on the first post-reboot heartbeat.
+4. **Device list endpoint** (`apps/api/src/routes/devices/core.ts`): add `pendingReboot` to the SELECT. Add the field to the shared `Device` type in `packages/shared/src/types/`.
+5. **Filter re-point** (`apps/api/src/services/filterEngine.ts`): change `system.rebootRequired` SQL from the `patch_job_results` EXISTS subquery to `devices.pending_reboot = true`. Update the field description to "Device OS reports a reboot is pending". Semantic change: the filter now also matches reboots not caused by Breeze patch jobs — this is intentional so the filter agrees with the indicator.
+
+## Web
+
+1. **Device list** (`apps/web/src/components/devices/DeviceList.tsx`):
+   - Amber "Reboot pending" pill in the Status cell when `device.pendingReboot`, following the existing "Agent silent" badge pattern (warning-tinted, sits beside the status badge).
+   - New toggleable "Pending reboot" column in `apps/web/src/components/devices/columnVisibility.ts` — hidden by default, display-only (not sortable; the advanced filter covers querying).
+2. **Device detail** (`apps/web/src/components/devices/DeviceDetails.tsx`): same amber badge in the header next to the status badge. Informational only — no reboot action on this surface; rebooting stays in the existing device actions.
+
+## Edge cases
+
+- **Old agents** that never send the field: column stays `false`. Correct default.
+- **Watchdog heartbeats**: handler only writes the flag on main-agent heartbeats.
+- **macOS**: always `false`; badge never shows.
+- **Stale flag while device offline**: badge reflects the last heartbeat, same as every other heartbeat-derived field. Acceptable.
+- **Read-only mutation surface**: this feature adds no web mutations, so `runAction` is not involved.
+
+## Testing
+
+- **Go** (`reboot_detect_linux_test.go`, table-driven): marker file present/absent via temp-dir path override; `needs-restarting` exit codes 0/1/other via injected exec; cache behavior.
+- **API** (heartbeat handler tests): persists `true`; clears on `false` and on absent field; watchdog heartbeat leaves the column untouched. FilterEngine test updated for the re-pointed `system.rebootRequired` SQL.
+- **Web** (Vitest + jsdom): DeviceList renders the badge when `pendingReboot` is true, hides it otherwise; column toggle shows the new column.
+- Coverage checklist per the `breeze-testing` skill during implementation.
+
+## Out of scope
+
+- macOS detection.
+- "Reboot now" action from the indicator.
+- `pending_reboot_since` timestamp / duration display.
+- Changes to patch-reboot policy handling or `patch_job_results`.


### PR DESCRIPTION
**What:** Device detail overview now shows a "User Idle" stat next to Logged-in User, backed by real agent-side idle measurement.

**Why:** Session tracking shipped the `idleMinutes` plumbing end-to-end in Feb 2026 (832f96bf), but the agent hardcoded it to 0 and no UI ever displayed it.

**How:**
- **Agent:** Windows `WTSSessionInfoEx.LastInputTime` (callable from Session 0, struct layout verified byte-for-byte against wtsapi32.h), macOS `HIDIdleTime` via IOKit cgo, Linux `loginctl IdleSinceHint` best-effort (only when the DE asserts `IdleHint=yes`). `UserSession.IdleMinutes` is now `*int` so unknown ≠ 0 on the wire; `LastActivityAt` is anchored to actual last input instead of the refresh tick; clamped to the schema max (10080).
- **API:** session ingest preserves `null` idleMinutes instead of coercing to 0 (`apps/api/src/routes/agents/sessions.ts:98,111`); `/devices/:id/sessions/active` now returns `updatedAt` for the freshness tooltip. No migration — the column was already nullable.
- **Web:** new `DeviceUserIdleStat` component in the overview stat strip. Display rules: console session preferred, `Locked` wins, measured 0 → `Active`, durations as `23m` / `1h 5m` / `1h`, unknown → `—`.

**Tests:** 18 new Go subtests (FILETIME conversion, IdleSinceHint parsing incl. overflow, collector pointer semantics + clamp + JSON wire shape), 4 new API route tests covering both ingest coercion sites (mutation-checked), 12 web tests (selection + formatting + fetch). Full agent suite passes with `-race`; windows/linux/nocgo cross-compiles clean; `tsc --noEmit` clean.

**Rollout:** requires an agent release for real data; old agents render as `—` (never wrong data). Pending manual check: Windows console-session `LastInputTime` on the e2e Windows device (currently offline) — if it reads zero there (known quirk on some Windows versions), the helper-IPC fallback is the documented follow-up; the UI already degrades to `—` in that case.

Spec: `docs/superpowers/specs/2026-06-11-device-user-idle-time-design.md`
Plan: `docs/superpowers/plans/2026-06-11-device-user-idle-time.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)