### PR TITLE
feat(patches): policy-level auto-approve and per-app block/pin rules

### DIFF
--- a/apps/api/src/jobs/patchJobExecutor.test.ts
+++ b/apps/api/src/jobs/patchJobExecutor.test.ts
@@ -375,6 +375,188 @@ describe('patch job executor queueing', () => {
     expect(result).toEqual({ skipped: true, reason: 'No approved patches' });
   });
 
+  it('threads well-formed policyAutoApprove and apps to the evaluator', async () => {
+    vi.mocked(db.select)
+      .mockImplementationOnce(() => createSelectChain([{
+        id: 'job-1',
+        orgId: 'org-1',
+        status: 'running',
+        patches: {
+          ringId: null,
+          autoApprove: {},
+          categoryRules: [],
+          policyAutoApprove: { enabled: true, severities: ['critical'], deferralDays: 3 },
+          apps: [{ source: 'third_party', packageId: 'A.B', action: 'block' }],
+        },
+        targets: { deviceIds: ['device-1'] },
+      }]) as any)
+      .mockImplementationOnce(() => createSelectChain([{ id: 'device-1' }]) as any)
+      .mockImplementationOnce(() => createSelectChain([]) as any);
+
+    vi.mocked(db.insert).mockImplementationOnce(() => ({
+      values: vi.fn(() => Promise.resolve()),
+    }) as any);
+    vi.mocked(db.update).mockImplementationOnce(() => ({
+      set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })),
+    }) as any);
+    vi.mocked(resolveApprovedPatchesForDevice).mockResolvedValueOnce([]);
+
+    createPatchJobDeviceWorker();
+    await shared.processorRefs['patch-job-devices']({
+      data: {
+        type: 'execute-patch-job-device',
+        patchJobId: 'job-1',
+        deviceId: 'device-1',
+        orgId: 'org-1',
+      },
+    });
+
+    expect(resolveApprovedPatchesForDevice).toHaveBeenCalledWith(
+      'device-1',
+      'org-1',
+      expect.objectContaining({
+        policyAutoApprove: { enabled: true, severities: ['critical'], deferralDays: 3 },
+        apps: [{ source: 'third_party', packageId: 'A.B', action: 'block' }],
+      }),
+    );
+  });
+
+  it('treats malformed policyAutoApprove as disabled and warns', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    vi.mocked(db.select)
+      .mockImplementationOnce(() => createSelectChain([{
+        id: 'job-1',
+        orgId: 'org-1',
+        status: 'running',
+        patches: {
+          ringId: null,
+          autoApprove: {},
+          policyAutoApprove: { enabled: 'yes', severities: 'critical' },
+        },
+        targets: { deviceIds: ['device-1'] },
+      }]) as any)
+      .mockImplementationOnce(() => createSelectChain([{ id: 'device-1' }]) as any)
+      .mockImplementationOnce(() => createSelectChain([]) as any);
+
+    vi.mocked(db.insert).mockImplementationOnce(() => ({
+      values: vi.fn(() => Promise.resolve()),
+    }) as any);
+    vi.mocked(db.update).mockImplementationOnce(() => ({
+      set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })),
+    }) as any);
+    vi.mocked(resolveApprovedPatchesForDevice).mockResolvedValueOnce([]);
+
+    createPatchJobDeviceWorker();
+    await shared.processorRefs['patch-job-devices']({
+      data: {
+        type: 'execute-patch-job-device',
+        patchJobId: 'job-1',
+        deviceId: 'device-1',
+        orgId: 'org-1',
+      },
+    });
+
+    expect(resolveApprovedPatchesForDevice).toHaveBeenCalledWith(
+      'device-1',
+      'org-1',
+      expect.objectContaining({ policyAutoApprove: undefined }),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('malformed patches.policyAutoApprove'),
+      expect.any(String),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('drops malformed app entries individually and keeps valid ones', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    vi.mocked(db.select)
+      .mockImplementationOnce(() => createSelectChain([{
+        id: 'job-1',
+        orgId: 'org-1',
+        status: 'running',
+        patches: {
+          ringId: null,
+          autoApprove: {},
+          apps: [
+            { source: 'third_party', packageId: 'A.B', action: 'block' },
+            { source: 'third_party', action: 'block' },
+            { source: 'third_party', packageId: 'C.D', action: 'pin' },
+          ],
+        },
+        targets: { deviceIds: ['device-1'] },
+      }]) as any)
+      .mockImplementationOnce(() => createSelectChain([{ id: 'device-1' }]) as any)
+      .mockImplementationOnce(() => createSelectChain([]) as any);
+
+    vi.mocked(db.insert).mockImplementationOnce(() => ({
+      values: vi.fn(() => Promise.resolve()),
+    }) as any);
+    vi.mocked(db.update).mockImplementationOnce(() => ({
+      set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })),
+    }) as any);
+    vi.mocked(resolveApprovedPatchesForDevice).mockResolvedValueOnce([]);
+
+    createPatchJobDeviceWorker();
+    await shared.processorRefs['patch-job-devices']({
+      data: {
+        type: 'execute-patch-job-device',
+        patchJobId: 'job-1',
+        deviceId: 'device-1',
+        orgId: 'org-1',
+      },
+    });
+
+    expect(resolveApprovedPatchesForDevice).toHaveBeenCalledWith(
+      'device-1',
+      'org-1',
+      expect.objectContaining({
+        apps: [{ source: 'third_party', packageId: 'A.B', action: 'block' }],
+      }),
+    );
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    warnSpy.mockRestore();
+  });
+
+  it('leaves policyAutoApprove and apps undefined for legacy jobs', async () => {
+    vi.mocked(db.select)
+      .mockImplementationOnce(() => createSelectChain([{
+        id: 'job-1',
+        orgId: 'org-1',
+        status: 'running',
+        patches: { ringId: null, autoApprove: {} },
+        targets: { deviceIds: ['device-1'] },
+      }]) as any)
+      .mockImplementationOnce(() => createSelectChain([{ id: 'device-1' }]) as any)
+      .mockImplementationOnce(() => createSelectChain([]) as any);
+
+    vi.mocked(db.insert).mockImplementationOnce(() => ({
+      values: vi.fn(() => Promise.resolve()),
+    }) as any);
+    vi.mocked(db.update).mockImplementationOnce(() => ({
+      set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })),
+    }) as any);
+    vi.mocked(resolveApprovedPatchesForDevice).mockResolvedValueOnce([]);
+
+    createPatchJobDeviceWorker();
+    await shared.processorRefs['patch-job-devices']({
+      data: {
+        type: 'execute-patch-job-device',
+        patchJobId: 'job-1',
+        deviceId: 'device-1',
+        orgId: 'org-1',
+      },
+    });
+
+    expect(resolveApprovedPatchesForDevice).toHaveBeenCalledWith(
+      'device-1',
+      'org-1',
+      expect.objectContaining({ policyAutoApprove: undefined, apps: undefined }),
+    );
+  });
+
   it('ignores malformed sources with a warning instead of filtering', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 

--- a/apps/api/src/jobs/patchJobExecutor.test.ts
+++ b/apps/api/src/jobs/patchJobExecutor.test.ts
@@ -728,7 +728,7 @@ describe('patch job executor queueing', () => {
     );
   });
 
-  it('ignores malformed sources with a warning instead of filtering', async () => {
+  it('skips malformed sources with a warning instead of widening the filter', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     vi.mocked(db.select)
@@ -755,10 +755,8 @@ describe('patch job executor queueing', () => {
       })),
     }) as any);
 
-    vi.mocked(resolveApprovedPatchesForDevice).mockResolvedValueOnce([]);
-
     createPatchJobDeviceWorker();
-    await shared.processorRefs['patch-job-devices']({
+    const result = await shared.processorRefs['patch-job-devices']({
       data: {
         type: 'execute-patch-job-device',
         patchJobId: 'job-1',
@@ -767,15 +765,13 @@ describe('patch job executor queueing', () => {
       },
     });
 
-    expect(resolveApprovedPatchesForDevice).toHaveBeenCalledWith(
-      'device-1',
-      'org-1',
-      expect.objectContaining({ sources: undefined }),
-    );
+    expect(result).toEqual({ skipped: true, reason: 'Invalid patch source filter' });
+    expect(resolveApprovedPatchesForDevice).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('malformed patches.sources'),
       expect.any(String),
     );
+    expect(captureException).toHaveBeenCalledWith(expect.any(Error));
     warnSpy.mockRestore();
   });
 });

--- a/apps/api/src/jobs/patchJobExecutor.test.ts
+++ b/apps/api/src/jobs/patchJobExecutor.test.ts
@@ -83,7 +83,12 @@ vi.mock('../services/commandQueue', () => ({
   queueCommandForExecution: vi.fn(),
 }));
 
+vi.mock('../services/sentry', () => ({
+  captureException: vi.fn(),
+}));
+
 import { db } from '../db';
+import { captureException } from '../services/sentry';
 import {
   createPatchJobDeviceWorker,
   createPatchJobWorker,
@@ -466,10 +471,110 @@ describe('patch job executor queueing', () => {
       expect.stringContaining('malformed patches.policyAutoApprove'),
       expect.any(String),
     );
+    expect(captureException).toHaveBeenCalledWith(expect.any(Error));
     warnSpy.mockRestore();
   });
 
-  it('drops malformed app entries individually and keeps valid ones', async () => {
+  it('disables the whole policyAutoApprove config when deferralDays is malformed', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    vi.mocked(db.select)
+      .mockImplementationOnce(() => createSelectChain([{
+        id: 'job-1',
+        orgId: 'org-1',
+        status: 'running',
+        patches: {
+          ringId: null,
+          autoApprove: {},
+          // enabled/severities are valid, but deferralDays is negative — the
+          // deferral safety window must NOT be silently coerced to 0.
+          policyAutoApprove: { enabled: true, severities: ['critical'], deferralDays: -1 },
+        },
+        targets: { deviceIds: ['device-1'] },
+      }]) as any)
+      .mockImplementationOnce(() => createSelectChain([{ id: 'device-1' }]) as any)
+      .mockImplementationOnce(() => createSelectChain([]) as any);
+
+    vi.mocked(db.insert).mockImplementationOnce(() => ({
+      values: vi.fn(() => Promise.resolve()),
+    }) as any);
+    vi.mocked(db.update).mockImplementationOnce(() => ({
+      set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })),
+    }) as any);
+    vi.mocked(resolveApprovedPatchesForDevice).mockResolvedValueOnce([]);
+
+    createPatchJobDeviceWorker();
+    await shared.processorRefs['patch-job-devices']({
+      data: {
+        type: 'execute-patch-job-device',
+        patchJobId: 'job-1',
+        deviceId: 'device-1',
+        orgId: 'org-1',
+      },
+    });
+
+    expect(resolveApprovedPatchesForDevice).toHaveBeenCalledWith(
+      'device-1',
+      'org-1',
+      expect.objectContaining({ policyAutoApprove: undefined }),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('malformed patches.policyAutoApprove'),
+      expect.any(String),
+    );
+    expect(captureException).toHaveBeenCalledWith(expect.any(Error));
+    warnSpy.mockRestore();
+  });
+
+  it('defaults deferralDays to 0 when absent from an otherwise valid policyAutoApprove', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    vi.mocked(db.select)
+      .mockImplementationOnce(() => createSelectChain([{
+        id: 'job-1',
+        orgId: 'org-1',
+        status: 'running',
+        patches: {
+          ringId: null,
+          autoApprove: {},
+          policyAutoApprove: { enabled: true, severities: ['critical'] },
+        },
+        targets: { deviceIds: ['device-1'] },
+      }]) as any)
+      .mockImplementationOnce(() => createSelectChain([{ id: 'device-1' }]) as any)
+      .mockImplementationOnce(() => createSelectChain([]) as any);
+
+    vi.mocked(db.insert).mockImplementationOnce(() => ({
+      values: vi.fn(() => Promise.resolve()),
+    }) as any);
+    vi.mocked(db.update).mockImplementationOnce(() => ({
+      set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })),
+    }) as any);
+    vi.mocked(resolveApprovedPatchesForDevice).mockResolvedValueOnce([]);
+
+    createPatchJobDeviceWorker();
+    await shared.processorRefs['patch-job-devices']({
+      data: {
+        type: 'execute-patch-job-device',
+        patchJobId: 'job-1',
+        deviceId: 'device-1',
+        orgId: 'org-1',
+      },
+    });
+
+    expect(resolveApprovedPatchesForDevice).toHaveBeenCalledWith(
+      'device-1',
+      'org-1',
+      expect.objectContaining({
+        policyAutoApprove: { enabled: true, severities: ['critical'], deferralDays: 0 },
+      }),
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(captureException).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('coerces identifiable malformed app rules to block and drops unusable ones', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     vi.mocked(db.select)
@@ -481,8 +586,11 @@ describe('patch job executor queueing', () => {
           ringId: null,
           autoApprove: {},
           apps: [
+            // Valid block rule → passed through.
             { source: 'third_party', packageId: 'A.B', action: 'block' },
+            // Identity unusable (no packageId) → dropped + Sentry.
             { source: 'third_party', action: 'block' },
+            // Identifiable but malformed (pin without pinnedVersion) → coerced to block.
             { source: 'third_party', packageId: 'C.D', action: 'pin' },
           ],
         },
@@ -513,10 +621,73 @@ describe('patch job executor queueing', () => {
       'device-1',
       'org-1',
       expect.objectContaining({
-        apps: [{ source: 'third_party', packageId: 'A.B', action: 'block' }],
+        apps: [
+          { source: 'third_party', packageId: 'A.B', action: 'block' },
+          { source: 'third_party', packageId: 'C.D', action: 'block' },
+        ],
       }),
     );
     expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('dropping malformed app rule'),
+      expect.any(String),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('coercing malformed app rule to block (fail-closed)'),
+      expect.any(String),
+    );
+    // Only the dropped rule goes to Sentry — the coerced one is preserved as a restriction.
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(captureException).toHaveBeenCalledWith(expect.any(Error));
+    warnSpy.mockRestore();
+  });
+
+  it('ignores non-array apps with a warning and a Sentry capture', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    vi.mocked(db.select)
+      .mockImplementationOnce(() => createSelectChain([{
+        id: 'job-1',
+        orgId: 'org-1',
+        status: 'running',
+        patches: {
+          ringId: null,
+          autoApprove: {},
+          apps: {},
+        },
+        targets: { deviceIds: ['device-1'] },
+      }]) as any)
+      .mockImplementationOnce(() => createSelectChain([{ id: 'device-1' }]) as any)
+      .mockImplementationOnce(() => createSelectChain([]) as any);
+
+    vi.mocked(db.insert).mockImplementationOnce(() => ({
+      values: vi.fn(() => Promise.resolve()),
+    }) as any);
+    vi.mocked(db.update).mockImplementationOnce(() => ({
+      set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })),
+    }) as any);
+    vi.mocked(resolveApprovedPatchesForDevice).mockResolvedValueOnce([]);
+
+    createPatchJobDeviceWorker();
+    await shared.processorRefs['patch-job-devices']({
+      data: {
+        type: 'execute-patch-job-device',
+        patchJobId: 'job-1',
+        deviceId: 'device-1',
+        orgId: 'org-1',
+      },
+    });
+
+    expect(resolveApprovedPatchesForDevice).toHaveBeenCalledWith(
+      'device-1',
+      'org-1',
+      expect.objectContaining({ apps: undefined }),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('malformed patches.apps'),
+      expect.any(String),
+    );
+    expect(captureException).toHaveBeenCalledWith(expect.any(Error));
     warnSpy.mockRestore();
   });
 

--- a/apps/api/src/jobs/patchJobExecutor.ts
+++ b/apps/api/src/jobs/patchJobExecutor.ts
@@ -7,6 +7,8 @@
  */
 
 import { Queue, Worker, Job } from 'bullmq';
+import { z } from 'zod';
+import { policyAppRuleSchema } from '@breeze/shared/validators';
 import * as dbModule from '../db';
 import {
   patchJobs,
@@ -27,6 +29,17 @@ import {
 } from '../services/patchApprovalEvaluator';
 import { evaluateRebootPolicy, executeReboot } from '../services/patchRebootHandler';
 import { queueCommandForExecution } from '../services/commandQueue';
+import { captureException } from '../services/sentry';
+
+// Strict shape for patches.policyAutoApprove as stored in the job JSONB.
+// deferralDays must be a valid non-negative integer when present — a malformed
+// value must NOT be coerced to 0, because that silently removes the deferral
+// safety window. Absent deferralDays is fine and defaults to 0.
+const jobPolicyAutoApproveSchema = z.object({
+  enabled: z.boolean(),
+  severities: z.array(z.string()),
+  deferralDays: z.number().int().min(0).optional(),
+});
 
 const { db } = dbModule;
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -394,79 +407,74 @@ async function processExecuteDevice(data: ExecutePatchJobDeviceData): Promise<un
     }
   }
 
+  // Malformed auto-approve config degrades to disabled because silently
+  // ENABLING auto-approval is the dangerous direction.
   let policyAutoApprove: PolicyAutoApproveConfig | undefined;
   if (patchesConfig?.policyAutoApprove !== undefined) {
-    const raw = patchesConfig.policyAutoApprove as
-      | { enabled?: unknown; severities?: unknown; deferralDays?: unknown }
-      | null;
-    const severities = Array.isArray(raw?.severities)
-      ? raw.severities.filter((s): s is string => typeof s === 'string')
-      : null;
-
-    if (
-      raw &&
-      typeof raw === 'object' &&
-      typeof raw.enabled === 'boolean' &&
-      severities !== null &&
-      severities.length === (raw.severities as unknown[]).length
-    ) {
+    const parsed = jobPolicyAutoApproveSchema.safeParse(patchesConfig.policyAutoApprove);
+    if (parsed.success) {
       policyAutoApprove = {
-        enabled: raw.enabled,
-        severities,
-        deferralDays:
-          typeof raw.deferralDays === 'number' &&
-          Number.isFinite(raw.deferralDays) &&
-          raw.deferralDays >= 0
-            ? raw.deferralDays
-            : 0,
+        enabled: parsed.data.enabled,
+        severities: parsed.data.severities,
+        deferralDays: parsed.data.deferralDays ?? 0,
       };
     } else {
-      console.warn(
-        `[PatchJobExecutor] Job ${patchJobId} has malformed patches.policyAutoApprove; treating as disabled:`,
-        JSON.stringify(patchesConfig.policyAutoApprove)
-      );
+      const message = `[PatchJobExecutor] Job ${patchJobId} has malformed patches.policyAutoApprove; treating as disabled`;
+      console.warn(`${message}:`, JSON.stringify(patchesConfig.policyAutoApprove));
+      captureException(new Error(message));
     }
   }
 
+  // Malformed-but-identifiable rules coerce to 'block' rather than being
+  // dropped — dropping a block rule would silently widen install scope; only
+  // rules whose identity (source + packageId) is unusable are dropped, loudly.
   let jobApps: PolicyAppRule[] | undefined;
   if (patchesConfig?.apps !== undefined) {
     if (!Array.isArray(patchesConfig.apps)) {
-      console.warn(
-        `[PatchJobExecutor] Job ${patchJobId} has malformed patches.apps; ignoring app rules:`,
-        JSON.stringify(patchesConfig.apps)
-      );
+      const message = `[PatchJobExecutor] Job ${patchJobId} has malformed patches.apps; ignoring app rules`;
+      console.warn(`${message}:`, JSON.stringify(patchesConfig.apps));
+      captureException(new Error(message));
     } else {
       const valid: PolicyAppRule[] = [];
       for (const entry of patchesConfig.apps) {
-        const e = entry as
-          | { source?: unknown; packageId?: unknown; action?: unknown; pinnedVersion?: unknown }
-          | null;
-        const okBase =
-          e &&
+        const parsed = policyAppRuleSchema.safeParse(entry);
+        if (parsed.success) {
+          // Strip displayName and any other extra fields before handing to the evaluator.
+          const { source, packageId, action, pinnedVersion } = parsed.data;
+          if (action === 'pin' && pinnedVersion) {
+            valid.push({ source, packageId, action: 'pin', pinnedVersion });
+          } else {
+            // action === 'block' (pin without pinnedVersion is rejected by the schema).
+            valid.push({ source, packageId, action: 'block' });
+          }
+          continue;
+        }
+
+        const e = entry as { source?: unknown; packageId?: unknown } | null;
+        const identifiable =
+          e !== null &&
+          typeof e === 'object' &&
           typeof e.source === 'string' &&
           e.source.length > 0 &&
           typeof e.packageId === 'string' &&
           e.packageId.length > 0;
 
-        if (okBase && e.action === 'block') {
-          valid.push({ source: e.source as string, packageId: e.packageId as string, action: 'block' });
-        } else if (
-          okBase &&
-          e.action === 'pin' &&
-          typeof e.pinnedVersion === 'string' &&
-          e.pinnedVersion.length > 0
-        ) {
+        if (identifiable) {
+          // Fail closed: the admin intended to restrict this app; a malformed
+          // restriction (e.g. pin without a version) becomes an outright block.
+          console.warn(
+            `[PatchJobExecutor] Job ${patchJobId} coercing malformed app rule to block (fail-closed):`,
+            JSON.stringify(entry)
+          );
           valid.push({
             source: e.source as string,
             packageId: e.packageId as string,
-            action: 'pin',
-            pinnedVersion: e.pinnedVersion,
+            action: 'block',
           });
         } else {
-          console.warn(
-            `[PatchJobExecutor] Job ${patchJobId} dropping malformed app rule:`,
-            JSON.stringify(entry)
-          );
+          const message = `[PatchJobExecutor] Job ${patchJobId} dropping malformed app rule with unusable identity`;
+          console.warn(`${message}:`, JSON.stringify(entry));
+          captureException(new Error(message));
         }
       }
       jobApps = valid;

--- a/apps/api/src/jobs/patchJobExecutor.ts
+++ b/apps/api/src/jobs/patchJobExecutor.ts
@@ -389,22 +389,27 @@ async function processExecuteDevice(data: ExecutePatchJobDeviceData): Promise<un
     deployment?: { rebootPolicy?: string };
   };
 
-  // Distinguish absent sources (legacy job → no filtering) from present-but-malformed
-  // (shape drift / bad write): malformed also falls back to no filtering, but loudly —
-  // silently widening install scope is the dangerous direction.
+  // Distinguish absent sources (legacy job → no filtering) from
+  // present-but-malformed (shape drift / bad write). Present malformed sources
+  // skip execution rather than widening to no filter.
   let jobSources: string[] | undefined;
+  let malformedSources = false;
   if (patchesConfig?.sources !== undefined) {
     const raw = patchesConfig.sources;
     const strings = Array.isArray(raw) ? raw.filter((s): s is string => typeof s === 'string') : [];
     if (!Array.isArray(raw) || strings.length !== raw.length || strings.length === 0) {
-      console.warn(
-        `[PatchJobExecutor] Job ${patchJobId} has malformed patches.sources; ignoring source filter:`,
-        JSON.stringify(raw)
-      );
-      jobSources = undefined;
+      malformedSources = true;
+      const message = `[PatchJobExecutor] Job ${patchJobId} has malformed patches.sources; skipping device to avoid widening install scope`;
+      console.warn(`${message}:`, JSON.stringify(raw));
+      captureException(new Error(message));
     } else {
       jobSources = strings;
     }
+  }
+
+  if (malformedSources) {
+    await markDeviceSkipped(patchJobId, deviceId, 'invalid_patch_sources');
+    return { skipped: true, reason: 'Invalid patch source filter' };
   }
 
   // Malformed auto-approve config degrades to disabled because silently

--- a/apps/api/src/jobs/patchJobExecutor.ts
+++ b/apps/api/src/jobs/patchJobExecutor.ts
@@ -19,7 +19,12 @@ import {
 import { eq, and, sql, inArray } from 'drizzle-orm';
 import { getBullMQConnection } from '../services/redis';
 import { isReusableState } from '../services/bullmqUtils';
-import { resolveApprovedPatchesForDevice, type RingConfig } from '../services/patchApprovalEvaluator';
+import {
+  resolveApprovedPatchesForDevice,
+  type PolicyAppRule,
+  type PolicyAutoApproveConfig,
+  type RingConfig,
+} from '../services/patchApprovalEvaluator';
 import { evaluateRebootPolicy, executeReboot } from '../services/patchRebootHandler';
 import { queueCommandForExecution } from '../services/commandQueue';
 
@@ -364,6 +369,8 @@ async function processExecuteDevice(data: ExecutePatchJobDeviceData): Promise<un
     categoryRules?: unknown[];
     autoApprove?: unknown;
     sources?: unknown;
+    policyAutoApprove?: unknown;
+    apps?: unknown;
   };
   const targets = patchJob.targets as {
     deployment?: { rebootPolicy?: string };
@@ -387,6 +394,85 @@ async function processExecuteDevice(data: ExecutePatchJobDeviceData): Promise<un
     }
   }
 
+  let policyAutoApprove: PolicyAutoApproveConfig | undefined;
+  if (patchesConfig?.policyAutoApprove !== undefined) {
+    const raw = patchesConfig.policyAutoApprove as
+      | { enabled?: unknown; severities?: unknown; deferralDays?: unknown }
+      | null;
+    const severities = Array.isArray(raw?.severities)
+      ? raw.severities.filter((s): s is string => typeof s === 'string')
+      : null;
+
+    if (
+      raw &&
+      typeof raw === 'object' &&
+      typeof raw.enabled === 'boolean' &&
+      severities !== null &&
+      severities.length === (raw.severities as unknown[]).length
+    ) {
+      policyAutoApprove = {
+        enabled: raw.enabled,
+        severities,
+        deferralDays:
+          typeof raw.deferralDays === 'number' &&
+          Number.isFinite(raw.deferralDays) &&
+          raw.deferralDays >= 0
+            ? raw.deferralDays
+            : 0,
+      };
+    } else {
+      console.warn(
+        `[PatchJobExecutor] Job ${patchJobId} has malformed patches.policyAutoApprove; treating as disabled:`,
+        JSON.stringify(patchesConfig.policyAutoApprove)
+      );
+    }
+  }
+
+  let jobApps: PolicyAppRule[] | undefined;
+  if (patchesConfig?.apps !== undefined) {
+    if (!Array.isArray(patchesConfig.apps)) {
+      console.warn(
+        `[PatchJobExecutor] Job ${patchJobId} has malformed patches.apps; ignoring app rules:`,
+        JSON.stringify(patchesConfig.apps)
+      );
+    } else {
+      const valid: PolicyAppRule[] = [];
+      for (const entry of patchesConfig.apps) {
+        const e = entry as
+          | { source?: unknown; packageId?: unknown; action?: unknown; pinnedVersion?: unknown }
+          | null;
+        const okBase =
+          e &&
+          typeof e.source === 'string' &&
+          e.source.length > 0 &&
+          typeof e.packageId === 'string' &&
+          e.packageId.length > 0;
+
+        if (okBase && e.action === 'block') {
+          valid.push({ source: e.source as string, packageId: e.packageId as string, action: 'block' });
+        } else if (
+          okBase &&
+          e.action === 'pin' &&
+          typeof e.pinnedVersion === 'string' &&
+          e.pinnedVersion.length > 0
+        ) {
+          valid.push({
+            source: e.source as string,
+            packageId: e.packageId as string,
+            action: 'pin',
+            pinnedVersion: e.pinnedVersion,
+          });
+        } else {
+          console.warn(
+            `[PatchJobExecutor] Job ${patchJobId} dropping malformed app rule:`,
+            JSON.stringify(entry)
+          );
+        }
+      }
+      jobApps = valid;
+    }
+  }
+
   const ringConfig: RingConfig = {
     ringId: patchesConfig?.ringId ?? null,
     categoryRules: (Array.isArray(patchesConfig?.categoryRules)
@@ -395,6 +481,8 @@ async function processExecuteDevice(data: ExecutePatchJobDeviceData): Promise<un
     autoApprove: patchesConfig?.autoApprove ?? {},
     deferralDays: 0,
     sources: jobSources,
+    policyAutoApprove,
+    apps: jobApps,
   };
 
   // If we have a ringId, load deferralDays from the ring

--- a/apps/api/src/jobs/patchSchedulerWorker.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.ts
@@ -382,6 +382,12 @@ async function scanAndCreateJobs(): Promise<{ created: number; scanned: number }
               categoryRules: policyLocal.ring.categoryRules,
               autoApprove: policyLocal.ring.autoApprove,
               sources: policyLocal.settings.sources,
+              policyAutoApprove: {
+                enabled: policyLocal.settings.autoApprove ?? false,
+                severities: policyLocal.settings.autoApproveSeverities ?? [],
+                deferralDays: policyLocal.settings.autoApproveDeferralDays ?? 0,
+              },
+              apps: policyLocal.settings.apps ?? [],
               ringValidation: {
                 classification: policyLocal.ring.classification,
                 valid: policyLocal.ring.valid,

--- a/apps/api/src/jobs/patchSchedulerWorker.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.ts
@@ -21,6 +21,7 @@ import { and, eq, gte, inArray } from 'drizzle-orm';
 import { getBullMQConnection } from '../services/redis';
 import { checkDeviceMaintenanceWindow } from '../services/featureConfigResolver';
 import { enqueuePatchJob } from './patchJobExecutor';
+import { buildPatchesSnapshot } from '../services/patchJobSnapshot';
 import {
   backfillMissingPatchSettings,
   listAllPatchInventory,
@@ -376,23 +377,7 @@ async function scanAndCreateJobs(): Promise<{ created: number; scanned: number }
             configPolicyId: row.configPolicyId,
             ringId: policyLocal.ring.ringId,
             name: `Scheduled Patch Job - ${row.policyName}`,
-            patches: {
-              ringId: policyLocal.ring.ringId,
-              ringName: policyLocal.ring.ringName,
-              categoryRules: policyLocal.ring.categoryRules,
-              autoApprove: policyLocal.ring.autoApprove,
-              sources: policyLocal.settings.sources,
-              policyAutoApprove: {
-                enabled: policyLocal.settings.autoApprove ?? false,
-                severities: policyLocal.settings.autoApproveSeverities ?? [],
-                deferralDays: policyLocal.settings.autoApproveDeferralDays ?? 0,
-              },
-              apps: policyLocal.settings.apps ?? [],
-              ringValidation: {
-                classification: policyLocal.ring.classification,
-                valid: policyLocal.ring.valid,
-              },
-            },
+            patches: buildPatchesSnapshot(policyLocal),
             targets: {
               deviceIds: eligibleDeviceIds,
               configPolicyId: row.configPolicyId,

--- a/apps/api/src/routes/configurationPolicies/featureLinks.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.ts
@@ -76,7 +76,11 @@ featureLinkRoutes.post(
     if (data.featureType === 'patch') {
       const parsed = patchInlineSettingsSchema.safeParse(data.inlineSettings ?? {});
       if (!parsed.success) {
-        return c.json({ error: 'Invalid patch settings', details: parsed.error.flatten() }, 400);
+        // `issues` included so the web client (extractApiError) can render the messages.
+        return c.json(
+          { error: 'Invalid patch settings', details: parsed.error.flatten(), issues: parsed.error.issues },
+          400
+        );
       }
       data.inlineSettings = parsed.data;
     }
@@ -84,7 +88,10 @@ featureLinkRoutes.post(
     if (data.featureType === 'backup' && data.inlineSettings) {
       const parsed = backupInlineSettingsSchema.safeParse(data.inlineSettings);
       if (!parsed.success) {
-        return c.json({ error: 'Invalid backup settings', details: parsed.error.flatten() }, 400);
+        return c.json(
+          { error: 'Invalid backup settings', details: parsed.error.flatten(), issues: parsed.error.issues },
+          400
+        );
       }
       data.inlineSettings = parsed.data;
     }
@@ -155,14 +162,20 @@ featureLinkRoutes.patch(
       if (existingLink.featureType === 'patch') {
         const parsed = patchInlineSettingsSchema.safeParse(data.inlineSettings ?? {});
         if (!parsed.success) {
-          return c.json({ error: 'Invalid patch settings', details: parsed.error.flatten() }, 400);
+          return c.json(
+            { error: 'Invalid patch settings', details: parsed.error.flatten(), issues: parsed.error.issues },
+            400
+          );
         }
         data.inlineSettings = parsed.data;
       }
       if (existingLink.featureType === 'backup') {
         const parsed = backupInlineSettingsSchema.safeParse(data.inlineSettings);
         if (!parsed.success) {
-          return c.json({ error: 'Invalid backup settings', details: parsed.error.flatten() }, 400);
+          return c.json(
+            { error: 'Invalid backup settings', details: parsed.error.flatten(), issues: parsed.error.issues },
+            400
+          );
         }
         data.inlineSettings = parsed.data;
       }

--- a/apps/api/src/routes/configurationPolicies/patchJobs.test.ts
+++ b/apps/api/src/routes/configurationPolicies/patchJobs.test.ts
@@ -254,7 +254,20 @@ describe('configurationPolicies patchJob routes', () => {
 
     it('creates patch job successfully when conditions are met', async () => {
       getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, status: 'active', orgId: ORG_ID, name: 'P1' });
-      loadPolicyLocalPatchConfigMock.mockResolvedValue(makePolicyLocal());
+      loadPolicyLocalPatchConfigMock.mockResolvedValue(makePolicyLocal({
+        settings: {
+          sources: ['third_party'],
+          autoApprove: true,
+          autoApproveSeverities: ['critical'],
+          autoApproveDeferralDays: 5,
+          apps: [{ source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' }],
+          scheduleFrequency: 'daily',
+          scheduleTime: '02:00',
+          scheduleDayOfWeek: 'sun',
+          scheduleDayOfMonth: 1,
+          rebootPolicy: 'if_required',
+        },
+      }));
       vi.mocked(db.select)
         .mockReturnValueOnce({
           from: vi.fn().mockReturnValue({
@@ -264,10 +277,11 @@ describe('configurationPolicies patchJob routes', () => {
 
       checkDeviceMaintenanceWindowMock.mockResolvedValue(inactiveMaintenance);
 
+      const insertValuesMock = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: 'job-1' }]),
+      });
       vi.mocked(db.insert).mockReturnValue({
-        values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([{ id: 'job-1' }]),
-        }),
+        values: insertValuesMock,
       } as any);
 
       const res = await app.request(`/${POLICY_ID}/patch-job`, {
@@ -279,6 +293,11 @@ describe('configurationPolicies patchJob routes', () => {
       const json = await res.json();
       expect(json.success).toBe(true);
       expect(json.totalDevices).toBe(1);
+      expect(insertValuesMock.mock.calls[0]?.[0]?.patches).toMatchObject({
+        sources: ['third_party'],
+        policyAutoApprove: { enabled: true, severities: ['critical'], deferralDays: 5 },
+        apps: [{ source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' }],
+      });
       expect(writeRouteAudit).toHaveBeenCalled();
     });
 

--- a/apps/api/src/routes/configurationPolicies/patchJobs.test.ts
+++ b/apps/api/src/routes/configurationPolicies/patchJobs.test.ts
@@ -485,8 +485,22 @@ describe('configurationPolicies patchJob routes', () => {
 
   describe('GET /:id/resolve-patch-config/:deviceId', () => {
     it('returns resolved patch config for a device', async () => {
+      const appRules = [{ source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' }];
       getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, name: 'P1', status: 'active' });
-      loadPolicyLocalPatchConfigMock.mockResolvedValue(makePolicyLocal());
+      loadPolicyLocalPatchConfigMock.mockResolvedValue(makePolicyLocal({
+        settings: {
+          sources: ['os'],
+          autoApprove: true,
+          autoApproveSeverities: ['critical'],
+          autoApproveDeferralDays: 5,
+          apps: appRules,
+          scheduleFrequency: 'daily',
+          scheduleTime: '02:00',
+          scheduleDayOfWeek: 'sun',
+          scheduleDayOfMonth: 1,
+          rebootPolicy: 'if_required',
+        },
+      }));
       resolvePatchConfigDetailsForDeviceMock.mockResolvedValue(makeResolvedPatchConfig());
       vi.mocked(db.select)
         .mockReturnValueOnce(selectWhereLimitResult([{ orgId: ORG_ID }]) as any);
@@ -499,6 +513,69 @@ describe('configurationPolicies patchJob routes', () => {
       expect(json.policyLocal.approvalRing.ringId).toBeNull();
       expect(json.effective.settings.scheduleTime).toBe('02:00');
       expect(json.effective.approvalRing).toBeDefined();
+      // New keys sourced from the requested policy (it is also the winning one)
+      expect(json.isWinning).toBe(true);
+      expect(json.effective.settings.autoApproveDeferralDays).toBe(5);
+      expect(json.effective.settings.apps).toEqual(appRules);
+    });
+
+    it('loads the winning policy config when it differs from the requested policy', async () => {
+      const winningPolicyId = '88888888-8888-8888-8888-888888888888';
+      const winningApps = [{ source: 'custom', packageId: 'corp-tool', action: 'pin', pinnedVersion: '1.2.3' }];
+      getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, name: 'P1', status: 'active' });
+      loadPolicyLocalPatchConfigMock.mockImplementation(async (configPolicyId: string) => {
+        if (configPolicyId === POLICY_ID) {
+          return makePolicyLocal();
+        }
+        return makePolicyLocal({
+          configPolicyId: winningPolicyId,
+          configPolicyName: 'P2',
+          featureLinkId: 'fl-2',
+          settings: {
+            sources: ['os', 'third_party'],
+            autoApprove: true,
+            autoApproveSeverities: ['critical', 'important'],
+            autoApproveDeferralDays: 9,
+            apps: winningApps,
+            scheduleFrequency: 'weekly',
+            scheduleTime: '03:30',
+            scheduleDayOfWeek: 'tue',
+            scheduleDayOfMonth: 1,
+            rebootPolicy: 'never',
+          },
+          ring: {
+            classification: 'valid_ring',
+            valid: true,
+            ringId: 'ring-w',
+            ringName: 'Winning Ring',
+            categoryRules: [],
+            autoApprove: {},
+          },
+        });
+      });
+      resolvePatchConfigDetailsForDeviceMock.mockResolvedValue(makeResolvedPatchConfig({
+        configPolicyId: winningPolicyId,
+        configPolicyName: 'P2',
+        featureLinkId: 'fl-2',
+      }));
+      vi.mocked(db.select)
+        .mockReturnValueOnce(selectWhereLimitResult([{ orgId: ORG_ID }]) as any);
+
+      const res = await app.request(`/${POLICY_ID}/resolve-patch-config/${DEVICE_ID}`);
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.isWinning).toBe(false);
+      expect(json.effective.configPolicyId).toBe(winningPolicyId);
+      // New keys must come from the *winning* policy's local config
+      expect(json.effective.settings.autoApproveDeferralDays).toBe(9);
+      expect(json.effective.settings.apps).toEqual(winningApps);
+      expect(json.effective.approvalRing.ringId).toBe('ring-w');
+      expect(json.effective.approvalRing.ringName).toBe('Winning Ring');
+      // Requested policy's own config is still returned unchanged
+      expect(json.policyLocal.configPolicyId).toBe(POLICY_ID);
+      expect(loadPolicyLocalPatchConfigMock).toHaveBeenCalledWith(POLICY_ID);
+      expect(loadPolicyLocalPatchConfigMock).toHaveBeenCalledWith(winningPolicyId);
+      expect(loadPolicyLocalPatchConfigMock).toHaveBeenCalledTimes(2);
     });
 
     it('returns 404 when policy not found', async () => {

--- a/apps/api/src/routes/configurationPolicies/patchJobs.ts
+++ b/apps/api/src/routes/configurationPolicies/patchJobs.ts
@@ -18,6 +18,7 @@ import {
   summarizePatchInventory,
   type PatchRingResolution,
 } from '../../services/configPolicyPatching';
+import { buildPatchesSnapshot } from '../../services/patchJobSnapshot';
 import { enqueuePatchJob } from '../../jobs/patchJobExecutor';
 import { PERMISSIONS, canAccessSite, type UserPermissions } from '../../services/permissions';
 
@@ -175,23 +176,7 @@ patchJobRoutes.post(
           configPolicyId,
           ringId: policyLocal.ring.ringId,
           name: jobName,
-          patches: {
-            ringId: policyLocal.ring.ringId,
-            ringName: policyLocal.ring.ringName,
-            categoryRules: policyLocal.ring.categoryRules,
-            autoApprove: policyLocal.ring.autoApprove,
-            sources: policyLocal.settings.sources,
-            policyAutoApprove: {
-              enabled: policyLocal.settings.autoApprove ?? false,
-              severities: policyLocal.settings.autoApproveSeverities ?? [],
-              deferralDays: policyLocal.settings.autoApproveDeferralDays ?? 0,
-            },
-            apps: policyLocal.settings.apps ?? [],
-            ringValidation: {
-              classification: policyLocal.ring.classification,
-              valid: policyLocal.ring.valid,
-            },
-          },
+          patches: buildPatchesSnapshot(policyLocal),
           targets: {
             deviceIds,
             configPolicyId,

--- a/apps/api/src/routes/configurationPolicies/patchJobs.ts
+++ b/apps/api/src/routes/configurationPolicies/patchJobs.ts
@@ -181,6 +181,12 @@ patchJobRoutes.post(
             categoryRules: policyLocal.ring.categoryRules,
             autoApprove: policyLocal.ring.autoApprove,
             sources: policyLocal.settings.sources,
+            policyAutoApprove: {
+              enabled: policyLocal.settings.autoApprove ?? false,
+              severities: policyLocal.settings.autoApproveSeverities ?? [],
+              deferralDays: policyLocal.settings.autoApproveDeferralDays ?? 0,
+            },
+            apps: policyLocal.settings.apps ?? [],
             ringValidation: {
               classification: policyLocal.ring.classification,
               valid: policyLocal.ring.valid,
@@ -364,6 +370,8 @@ patchJobRoutes.get(
               sources: effective.settings.sources,
               autoApprove: effective.settings.autoApprove,
               autoApproveSeverities: effective.settings.autoApproveSeverities ?? [],
+              autoApproveDeferralDays: effectivePolicyLocal?.settings.autoApproveDeferralDays ?? 0,
+              apps: effectivePolicyLocal?.settings.apps ?? [],
               scheduleFrequency: effective.settings.scheduleFrequency,
               scheduleTime: effective.settings.scheduleTime,
               scheduleDayOfWeek: effective.settings.scheduleDayOfWeek,

--- a/apps/api/src/routes/patches/appOptions.test.ts
+++ b/apps/api/src/routes/patches/appOptions.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const BLOCKED_ORG_ID = '22222222-2222-2222-2222-222222222222';
+
+const selectMock = vi.fn();
+const selectDistinctMock = vi.fn();
+
+vi.mock('drizzle-orm', () => {
+  const sql = ((strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values })) as unknown;
+
+  return {
+    and: (...conditions: unknown[]) => ({ op: 'and', conditions }),
+    inArray: (left: unknown, right: unknown) => ({ op: 'inArray', left, right }),
+    sql,
+  };
+});
+
+vi.mock('../../db', () => ({
+  db: {
+    select: (...args: unknown[]) => selectMock(...args),
+    selectDistinct: (...args: unknown[]) => selectDistinctMock(...args),
+  },
+}));
+
+vi.mock('../../db/schema', () => ({
+  patches: {
+    id: 'patches.id',
+    source: 'patches.source',
+    packageId: 'patches.packageId',
+    vendor: 'patches.vendor',
+    title: 'patches.title',
+  },
+  devices: {
+    id: 'devices.id',
+    orgId: 'devices.orgId',
+  },
+  devicePatches: {
+    patchId: 'devicePatches.patchId',
+  },
+  thirdPartyPackageCatalog: {
+    source: 'thirdPartyPackageCatalog.source',
+    packageId: 'thirdPartyPackageCatalog.packageId',
+    vendor: 'thirdPartyPackageCatalog.vendor',
+    friendlyName: 'thirdPartyPackageCatalog.friendlyName',
+  },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  requireScope: vi.fn(() => async (c: any, next: any) => {
+    c.set('auth', {
+      canAccessOrg: (orgId: string) => orgId !== BLOCKED_ORG_ID,
+    });
+    await next();
+  }),
+}));
+
+import { appOptionsRoutes } from './appOptions';
+
+function selectRows(rows: unknown[]) {
+  return {
+    from: vi.fn().mockResolvedValue(rows),
+  };
+}
+
+function selectDistinctRows(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(rows),
+    }),
+  };
+}
+
+describe('GET /app-options', () => {
+  beforeEach(() => {
+    selectMock.mockReset();
+    selectDistinctMock.mockReset();
+  });
+
+  it('merges catalog and observed entries, with catalog metadata winning on dedup', async () => {
+    selectMock.mockReturnValue(selectRows([
+      { source: 'third_party', packageId: 'Mozilla.Firefox', vendor: 'Mozilla', displayName: 'Firefox' },
+    ]));
+    selectDistinctMock.mockReturnValue(selectDistinctRows([
+      { source: 'third_party', packageId: 'mozilla.firefox', vendor: 'Mozilla Corp', displayName: 'Firefox 121 update' },
+      { source: 'third_party', packageId: 'VideoLAN.VLC', vendor: 'VideoLAN', displayName: 'VLC update' },
+    ]));
+
+    const res = await appOptionsRoutes.request('/app-options');
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(2);
+    const firefox = body.data.find((option: any) => option.packageId.toLowerCase() === 'mozilla.firefox');
+    expect(firefox.displayName).toBe('Firefox');
+    expect(firefox.inCatalog).toBe(true);
+    expect(body.data.find((option: any) => option.packageId === 'VideoLAN.VLC').inCatalog).toBe(false);
+  });
+
+  it('filters by search across name, vendor, and packageId', async () => {
+    selectMock.mockReturnValue(selectRows([
+      { source: 'third_party', packageId: 'Mozilla.Firefox', vendor: 'Mozilla', displayName: 'Firefox' },
+      { source: 'third_party', packageId: 'VideoLAN.VLC', vendor: 'VideoLAN', displayName: 'VLC' },
+    ]));
+    selectDistinctMock.mockReturnValue(selectDistinctRows([]));
+
+    const res = await appOptionsRoutes.request('/app-options?search=videolan');
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].packageId).toBe('VideoLAN.VLC');
+  });
+
+  it('rejects inaccessible orgId with 403', async () => {
+    const res = await appOptionsRoutes.request(`/app-options?orgId=${BLOCKED_ORG_ID}`);
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Access denied to this organization' });
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(selectDistinctMock).not.toHaveBeenCalled();
+  });
+
+  it('applies org scoping and limit', async () => {
+    selectMock.mockReturnValue(selectRows([
+      { source: 'third_party', packageId: 'Mozilla.Firefox', vendor: 'Mozilla', displayName: 'Firefox' },
+      { source: 'third_party', packageId: 'VideoLAN.VLC', vendor: 'VideoLAN', displayName: 'VLC' },
+    ]));
+    selectDistinctMock.mockReturnValue(selectDistinctRows([
+      { source: 'third_party', packageId: 'Google.Chrome', vendor: 'Google', displayName: 'Chrome update' },
+    ]));
+
+    const res = await appOptionsRoutes.request('/app-options?orgId=11111111-1111-1111-1111-111111111111&limit=2');
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(2);
+    const observedWhere = selectDistinctMock.mock.results[0]?.value.from.mock.results[0]?.value.where;
+    expect(observedWhere).toHaveBeenCalledWith(expect.objectContaining({
+      op: 'and',
+      conditions: expect.arrayContaining([
+        expect.objectContaining({ strings: expect.arrayContaining([expect.stringContaining('EXISTS')]) }),
+      ]),
+    }));
+  });
+});

--- a/apps/api/src/routes/patches/appOptions.test.ts
+++ b/apps/api/src/routes/patches/appOptions.test.ts
@@ -1,9 +1,25 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const BLOCKED_ORG_ID = '22222222-2222-2222-2222-222222222222';
+const CALLER_ORG_ID = '33333333-3333-3333-3333-333333333333';
+const CALLER_PARTNER_ID = '44444444-4444-4444-4444-444444444444';
 
 const selectMock = vi.fn();
 const selectDistinctMock = vi.fn();
+
+// Per-test auth context injected by the requireScope stub. Defaults to a
+// system-scope caller in beforeEach; tests override to exercise org/partner
+// scoping of the observed query.
+let currentAuth: Record<string, unknown>;
+
+function systemAuth() {
+  return {
+    scope: 'system',
+    orgId: null,
+    partnerId: null,
+    canAccessOrg: (orgId: string) => orgId !== BLOCKED_ORG_ID,
+  };
+}
 
 vi.mock('drizzle-orm', () => {
   const sql = ((strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values })) as unknown;
@@ -37,6 +53,10 @@ vi.mock('../../db/schema', () => ({
   devicePatches: {
     patchId: 'devicePatches.patchId',
   },
+  organizations: {
+    id: 'organizations.id',
+    partnerId: 'organizations.partnerId',
+  },
   thirdPartyPackageCatalog: {
     source: 'thirdPartyPackageCatalog.source',
     packageId: 'thirdPartyPackageCatalog.packageId',
@@ -47,9 +67,7 @@ vi.mock('../../db/schema', () => ({
 
 vi.mock('../../middleware/auth', () => ({
   requireScope: vi.fn(() => async (c: any, next: any) => {
-    c.set('auth', {
-      canAccessOrg: (orgId: string) => orgId !== BLOCKED_ORG_ID,
-    });
+    c.set('auth', currentAuth);
     await next();
   }),
 }));
@@ -70,10 +88,16 @@ function selectDistinctRows(rows: unknown[]) {
   };
 }
 
+/** Conditions object the observed (selectDistinct) query was filtered with. */
+function observedWhereMock() {
+  return selectDistinctMock.mock.results[0]?.value.from.mock.results[0]?.value.where;
+}
+
 describe('GET /app-options', () => {
   beforeEach(() => {
     selectMock.mockReset();
     selectDistinctMock.mockReset();
+    currentAuth = systemAuth();
   });
 
   it('merges catalog and observed entries, with catalog metadata winning on dedup', async () => {
@@ -94,6 +118,27 @@ describe('GET /app-options', () => {
     expect(firefox.displayName).toBe('Firefox');
     expect(firefox.inCatalog).toBe(true);
     expect(body.data.find((option: any) => option.packageId === 'VideoLAN.VLC').inCatalog).toBe(false);
+  });
+
+  it('dedupes custom and third_party entries as one app-rule bucket', async () => {
+    selectMock.mockReturnValue(selectRows([
+      { source: 'third_party', packageId: 'Mozilla.Firefox', vendor: 'Mozilla', displayName: 'Firefox' },
+    ]));
+    selectDistinctMock.mockReturnValue(selectDistinctRows([
+      { source: 'custom', packageId: 'mozilla.firefox', vendor: 'Mozilla Corp', displayName: 'Firefox custom update' },
+    ]));
+
+    const res = await appOptionsRoutes.request('/app-options');
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0]).toEqual(expect.objectContaining({
+      source: 'third_party',
+      packageId: 'Mozilla.Firefox',
+      displayName: 'Firefox',
+      inCatalog: true,
+    }));
   });
 
   it('filters by search across name, vendor, and packageId', async () => {
@@ -134,12 +179,135 @@ describe('GET /app-options', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.data).toHaveLength(2);
-    const observedWhere = selectDistinctMock.mock.results[0]?.value.from.mock.results[0]?.value.where;
-    expect(observedWhere).toHaveBeenCalledWith(expect.objectContaining({
+    expect(observedWhereMock()).toHaveBeenCalledWith(expect.objectContaining({
       op: 'and',
       conditions: expect.arrayContaining([
-        expect.objectContaining({ strings: expect.arrayContaining([expect.stringContaining('EXISTS')]) }),
+        expect.objectContaining({
+          strings: expect.arrayContaining([expect.stringContaining('EXISTS')]),
+          values: expect.arrayContaining(['11111111-1111-1111-1111-111111111111']),
+        }),
       ]),
     }));
+  });
+
+  it('constrains observed query to the caller org for organization scope without orgId', async () => {
+    currentAuth = {
+      scope: 'organization',
+      orgId: CALLER_ORG_ID,
+      partnerId: null,
+      canAccessOrg: (orgId: string) => orgId === CALLER_ORG_ID,
+    };
+    selectMock.mockReturnValue(selectRows([]));
+    selectDistinctMock.mockReturnValue(selectDistinctRows([
+      { source: 'third_party', packageId: 'Google.Chrome', vendor: 'Google', displayName: 'Chrome update' },
+    ]));
+
+    const res = await appOptionsRoutes.request('/app-options');
+
+    expect(res.status).toBe(200);
+    expect(observedWhereMock()).toHaveBeenCalledWith(expect.objectContaining({
+      op: 'and',
+      conditions: expect.arrayContaining([
+        expect.objectContaining({
+          strings: expect.arrayContaining([expect.stringContaining('EXISTS')]),
+          values: expect.arrayContaining([CALLER_ORG_ID]),
+        }),
+      ]),
+    }));
+  });
+
+  it('returns 403 for organization scope with no org context instead of running unscoped', async () => {
+    currentAuth = {
+      scope: 'organization',
+      orgId: null,
+      partnerId: null,
+      canAccessOrg: () => false,
+    };
+
+    const res = await appOptionsRoutes.request('/app-options');
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Organization context required' });
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(selectDistinctMock).not.toHaveBeenCalled();
+  });
+
+  it('constrains observed query to partner orgs for partner scope without orgId', async () => {
+    currentAuth = {
+      scope: 'partner',
+      orgId: null,
+      partnerId: CALLER_PARTNER_ID,
+      canAccessOrg: (orgId: string) => orgId !== BLOCKED_ORG_ID,
+    };
+    selectMock.mockReturnValue(selectRows([]));
+    selectDistinctMock.mockReturnValue(selectDistinctRows([]));
+
+    const res = await appOptionsRoutes.request('/app-options');
+
+    expect(res.status).toBe(200);
+    expect(observedWhereMock()).toHaveBeenCalledWith(expect.objectContaining({
+      op: 'and',
+      conditions: expect.arrayContaining([
+        expect.objectContaining({
+          strings: expect.arrayContaining([
+            expect.stringContaining('EXISTS'),
+            expect.stringContaining('partner_id'),
+          ]),
+          values: expect.arrayContaining([CALLER_PARTNER_ID]),
+        }),
+      ]),
+    }));
+  });
+
+  it('returns 403 for partner scope with no partner context instead of running unscoped', async () => {
+    currentAuth = {
+      scope: 'partner',
+      orgId: null,
+      partnerId: null,
+      canAccessOrg: () => false,
+    };
+
+    const res = await appOptionsRoutes.request('/app-options');
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Partner context required' });
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(selectDistinctMock).not.toHaveBeenCalled();
+  });
+
+  it('runs the observed query unconstrained for system scope without orgId', async () => {
+    currentAuth = systemAuth();
+    selectMock.mockReturnValue(selectRows([]));
+    selectDistinctMock.mockReturnValue(selectDistinctRows([]));
+
+    const res = await appOptionsRoutes.request('/app-options');
+
+    expect(res.status).toBe(200);
+    const whereMock = observedWhereMock();
+    expect(whereMock).toHaveBeenCalledTimes(1);
+    const whereArg = whereMock.mock.calls[0][0];
+    expect(whereArg.op).toBe('and');
+    // Only the source + packageId conditions — no tenant EXISTS clause.
+    expect(whereArg.conditions).toHaveLength(2);
+    for (const condition of whereArg.conditions) {
+      const strings: string[] = condition.strings ?? [];
+      expect(strings.some((s) => s.includes('EXISTS'))).toBe(false);
+    }
+  });
+
+  it('returns 403 for an unknown scope instead of running unscoped', async () => {
+    currentAuth = {
+      scope: 'something-else',
+      orgId: null,
+      partnerId: null,
+      canAccessOrg: () => true,
+    };
+
+    const res = await appOptionsRoutes.request('/app-options');
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Insufficient permissions' });
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(selectDistinctMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/patches/appOptions.ts
+++ b/apps/api/src/routes/patches/appOptions.ts
@@ -3,9 +3,10 @@ import { zValidator } from '@hono/zod-validator';
 import { and, inArray, sql, type SQL } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../../db';
-import { devices, devicePatches, patches, thirdPartyPackageCatalog } from '../../db/schema';
+import { devices, devicePatches, organizations, patches, thirdPartyPackageCatalog } from '../../db/schema';
 import { requireScope } from '../../middleware/auth';
 
+// Keep in sync with THIRD_PARTY_PATCH_SOURCES in services/patchApprovalEvaluator.ts.
 const THIRD_PARTY_SOURCES = ['third_party', 'custom'] as const;
 
 const appOptionsQuerySchema = z.object({
@@ -21,6 +22,13 @@ type AppOption = {
   displayName: string;
   inCatalog: boolean;
 };
+
+function appOptionKey(source: string, packageId: string): string {
+  const bucket = THIRD_PARTY_SOURCES.includes(source as (typeof THIRD_PARTY_SOURCES)[number])
+    ? 'third_party'
+    : source;
+  return `${bucket}|${packageId.toLowerCase()}`;
+}
 
 export const appOptionsRoutes = new Hono();
 
@@ -38,15 +46,11 @@ appOptionsRoutes.get(
       return c.json({ error: 'Access denied to this organization' }, 403);
     }
 
-    const catalogRows = await db
-      .select({
-        source: thirdPartyPackageCatalog.source,
-        packageId: thirdPartyPackageCatalog.packageId,
-        vendor: thirdPartyPackageCatalog.vendor,
-        displayName: thirdPartyPackageCatalog.friendlyName,
-      })
-      .from(thirdPartyPackageCatalog);
-
+    // The `patches` table is global (no org_id column, no RLS — tenant
+    // isolation lives on device_patches), so the observed query MUST always
+    // be tenant-scoped for non-system callers. Never run it unconstrained
+    // except for system scope: otherwise any authenticated user could
+    // enumerate third-party software observed across ALL tenants.
     const observedConditions: SQL[] = [
       inArray(patches.source, [...THIRD_PARTY_SOURCES]),
       sql`${patches.packageId} IS NOT NULL`,
@@ -58,7 +62,39 @@ appOptionsRoutes.get(
         INNER JOIN ${devices} d ON d.id = dp.device_id
         WHERE dp.patch_id = ${patches.id} AND d.org_id = ${orgId}
       )`);
+    } else if (auth.scope === 'organization') {
+      if (!auth.orgId) {
+        return c.json({ error: 'Organization context required' }, 403);
+      }
+      observedConditions.push(sql`EXISTS (
+        SELECT 1 FROM ${devicePatches} dp
+        INNER JOIN ${devices} d ON d.id = dp.device_id
+        WHERE dp.patch_id = ${patches.id} AND d.org_id = ${auth.orgId}
+      )`);
+    } else if (auth.scope === 'partner') {
+      if (!auth.partnerId) {
+        return c.json({ error: 'Partner context required' }, 403);
+      }
+      observedConditions.push(sql`EXISTS (
+        SELECT 1 FROM ${devicePatches} dp
+        INNER JOIN ${devices} d ON d.id = dp.device_id
+        INNER JOIN ${organizations} o ON o.id = d.org_id
+        WHERE dp.patch_id = ${patches.id} AND o.partner_id = ${auth.partnerId}
+      )`);
+    } else if (auth.scope !== 'system') {
+      // Unknown scope — refuse rather than run the observed query unscoped.
+      return c.json({ error: 'Insufficient permissions' }, 403);
     }
+
+    // Curated catalog rows are intentionally global (not tenant data).
+    const catalogRows = await db
+      .select({
+        source: thirdPartyPackageCatalog.source,
+        packageId: thirdPartyPackageCatalog.packageId,
+        vendor: thirdPartyPackageCatalog.vendor,
+        displayName: thirdPartyPackageCatalog.friendlyName,
+      })
+      .from(thirdPartyPackageCatalog);
 
     const observedRows = await db
       .selectDistinct({
@@ -74,7 +110,7 @@ appOptionsRoutes.get(
 
     for (const row of observedRows) {
       if (!row.packageId) continue;
-      merged.set(`${row.source}|${row.packageId.toLowerCase()}`, {
+      merged.set(appOptionKey(row.source, row.packageId), {
         source: row.source,
         packageId: row.packageId,
         vendor: row.vendor,
@@ -84,7 +120,7 @@ appOptionsRoutes.get(
     }
 
     for (const row of catalogRows) {
-      merged.set(`${row.source}|${row.packageId.toLowerCase()}`, {
+      merged.set(appOptionKey(row.source, row.packageId), {
         source: row.source,
         packageId: row.packageId,
         vendor: row.vendor,

--- a/apps/api/src/routes/patches/appOptions.ts
+++ b/apps/api/src/routes/patches/appOptions.ts
@@ -1,0 +1,110 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { and, inArray, sql, type SQL } from 'drizzle-orm';
+import { z } from 'zod';
+import { db } from '../../db';
+import { devices, devicePatches, patches, thirdPartyPackageCatalog } from '../../db/schema';
+import { requireScope } from '../../middleware/auth';
+
+const THIRD_PARTY_SOURCES = ['third_party', 'custom'] as const;
+
+const appOptionsQuerySchema = z.object({
+  search: z.string().max(255).optional(),
+  orgId: z.string().uuid().optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+});
+
+type AppOption = {
+  source: string;
+  packageId: string;
+  vendor: string | null;
+  displayName: string;
+  inCatalog: boolean;
+};
+
+export const appOptionsRoutes = new Hono();
+
+// GET /patches/app-options - options for policy app rules, combining curated
+// catalog rows with third-party applications observed in patch data.
+appOptionsRoutes.get(
+  '/app-options',
+  requireScope('organization', 'partner', 'system'),
+  zValidator('query', appOptionsQuerySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { search, orgId, limit } = c.req.valid('query');
+
+    if (orgId && !auth.canAccessOrg(orgId)) {
+      return c.json({ error: 'Access denied to this organization' }, 403);
+    }
+
+    const catalogRows = await db
+      .select({
+        source: thirdPartyPackageCatalog.source,
+        packageId: thirdPartyPackageCatalog.packageId,
+        vendor: thirdPartyPackageCatalog.vendor,
+        displayName: thirdPartyPackageCatalog.friendlyName,
+      })
+      .from(thirdPartyPackageCatalog);
+
+    const observedConditions: SQL[] = [
+      inArray(patches.source, [...THIRD_PARTY_SOURCES]),
+      sql`${patches.packageId} IS NOT NULL`,
+    ];
+
+    if (orgId) {
+      observedConditions.push(sql`EXISTS (
+        SELECT 1 FROM ${devicePatches} dp
+        INNER JOIN ${devices} d ON d.id = dp.device_id
+        WHERE dp.patch_id = ${patches.id} AND d.org_id = ${orgId}
+      )`);
+    }
+
+    const observedRows = await db
+      .selectDistinct({
+        source: patches.source,
+        packageId: patches.packageId,
+        vendor: patches.vendor,
+        displayName: patches.title,
+      })
+      .from(patches)
+      .where(and(...observedConditions));
+
+    const merged = new Map<string, AppOption>();
+
+    for (const row of observedRows) {
+      if (!row.packageId) continue;
+      merged.set(`${row.source}|${row.packageId.toLowerCase()}`, {
+        source: row.source,
+        packageId: row.packageId,
+        vendor: row.vendor,
+        displayName: row.displayName,
+        inCatalog: false,
+      });
+    }
+
+    for (const row of catalogRows) {
+      merged.set(`${row.source}|${row.packageId.toLowerCase()}`, {
+        source: row.source,
+        packageId: row.packageId,
+        vendor: row.vendor,
+        displayName: row.displayName,
+        inCatalog: true,
+      });
+    }
+
+    let options = [...merged.values()];
+    if (search) {
+      const query = search.toLowerCase();
+      options = options.filter((option) =>
+        option.displayName.toLowerCase().includes(query) ||
+        (option.vendor ?? '').toLowerCase().includes(query) ||
+        option.packageId.toLowerCase().includes(query)
+      );
+    }
+
+    options.sort((a, b) => a.displayName.localeCompare(b.displayName));
+
+    return c.json({ data: options.slice(0, limit) });
+  }
+);

--- a/apps/api/src/routes/patches/index.ts
+++ b/apps/api/src/routes/patches/index.ts
@@ -4,11 +4,13 @@ import { listRoutes } from './list';
 import { approvalsRoutes } from './approvals';
 import { complianceRoutes } from './compliance';
 import { operationsRoutes } from './operations';
+import { appOptionsRoutes } from './appOptions';
 
 export const patchRoutes = new Hono();
 
 patchRoutes.use('*', authMiddleware);
 
+patchRoutes.route('/', appOptionsRoutes);
 patchRoutes.route('/', operationsRoutes);
 patchRoutes.route('/', complianceRoutes);
 patchRoutes.route('/', approvalsRoutes);

--- a/apps/api/src/services/configPolicyPatching.test.ts
+++ b/apps/api/src/services/configPolicyPatching.test.ts
@@ -11,6 +11,10 @@ vi.mock('../db', () => ({
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
+vi.mock('./sentry', () => ({
+  captureException: vi.fn(),
+}));
+
 vi.mock('../db/schema', () => ({
   configurationPolicies: { id: 'id', name: 'name', orgId: 'org_id' },
   configPolicyFeatureLinks: {
@@ -51,6 +55,7 @@ import {
   type PatchReferenceClassification,
 } from './configPolicyPatching';
 import { db } from '../db';
+import { captureException } from './sentry';
 
 function selectJoinLimitRows(rows: unknown[]) {
   const chain: any = {};
@@ -224,6 +229,165 @@ describe('loadPolicyLocalPatchConfig', () => {
     expect(result?.settings.apps).toEqual([
       { source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' },
     ]);
+  });
+
+  it('salvages valid app rules and deferral when stored inline JSON is malformed, with warn + Sentry', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    vi.mocked(db.select).mockReturnValueOnce(selectJoinLimitRows([{
+      configPolicyId: 'policy-2',
+      configPolicyName: 'Policy 2',
+      orgId: 'org-1',
+      featureLinkId: 'link-2',
+      featurePolicyId: null,
+      storedInlineSettings: {
+        // Legacy unpadded time — fails the whole-document parse.
+        scheduleTime: '2:00',
+        autoApproveDeferralDays: 7,
+        apps: [
+          { source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' },
+          { source: 'custom', packageId: 'corp-tool', action: 'pin', pinnedVersion: '1.2.3' },
+          // Invalid entry: pin without pinnedVersion — dropped individually.
+          { source: 'third_party', packageId: 'BadEntry', action: 'pin' },
+        ],
+      },
+      patchSettings: {
+        sources: ['os', 'third_party'],
+        autoApprove: false,
+        autoApproveSeverities: [],
+        scheduleFrequency: 'weekly',
+        scheduleTime: '03:00',
+        scheduleDayOfWeek: 'sat',
+        scheduleDayOfMonth: 1,
+        rebootPolicy: 'if_required',
+      },
+    }]) as any);
+
+    const result = await loadPolicyLocalPatchConfig('policy-2');
+
+    // Columns win for normalized fields.
+    expect(result?.settings.sources).toEqual(['os', 'third_party']);
+    expect(result?.settings.scheduleTime).toBe('03:00');
+    // JSON-only fields are salvaged per-entry, not wiped to defaults.
+    expect(result?.settings.autoApproveDeferralDays).toBe(7);
+    expect(result?.settings.apps).toEqual([
+      { source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' },
+      { source: 'custom', packageId: 'corp-tool', action: 'pin', pinnedVersion: '1.2.3' },
+    ]);
+
+    // Loud failure: document-level warn + Sentry, plus per-entry drop warn.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Stored patch inline settings failed validation')
+    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('policy-2'));
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Dropping invalid app rule at index 2')
+    );
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(captureException).mock.calls[0]?.[0]).toBeInstanceOf(Error);
+
+    warnSpy.mockRestore();
+  });
+
+  it('falls back to defaults with a warn when inline JSON is malformed and no patchSettings row exists', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    vi.mocked(db.select).mockReturnValueOnce(selectJoinLimitRows([{
+      configPolicyId: 'policy-3',
+      configPolicyName: 'Policy 3',
+      orgId: 'org-1',
+      featureLinkId: 'link-3',
+      featurePolicyId: null,
+      storedInlineSettings: {
+        sources: [], // fails min(1)
+        autoApproveDeferralDays: 999, // out of range — NOT salvaged
+      },
+      patchSettings: null,
+    }]) as any);
+
+    const result = await loadPolicyLocalPatchConfig('policy-3');
+
+    // Pins the lenient contract: malformed JSON + no normalized row → defaults.
+    expect(result?.settings.sources).toEqual(['os']);
+    expect(result?.settings.autoApprove).toBe(false);
+    expect(result?.settings.autoApproveDeferralDays).toBe(0);
+    expect(result?.settings.apps).toEqual([]);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Stored patch inline settings failed validation')
+    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('policy-3'));
+    expect(captureException).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+
+  it('dedupes salvaged app rules so the downstream re-parse cannot throw', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    vi.mocked(db.select).mockReturnValueOnce(selectJoinLimitRows([{
+      configPolicyId: 'policy-4',
+      configPolicyName: 'Policy 4',
+      orgId: 'org-1',
+      featureLinkId: 'link-4',
+      featurePolicyId: null,
+      storedInlineSettings: {
+        scheduleTime: '2:00', // forces whole-document failure
+        apps: [
+          { source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' },
+          // Same canonical bucket (custom → third_party) + same packageId.
+          { source: 'custom', packageId: 'mozilla.firefox', action: 'block' },
+        ],
+      },
+      patchSettings: {
+        sources: ['os'],
+        autoApprove: false,
+        autoApproveSeverities: [],
+        scheduleFrequency: 'weekly',
+        scheduleTime: '02:00',
+        scheduleDayOfWeek: 'sun',
+        scheduleDayOfMonth: 1,
+        rebootPolicy: 'if_required',
+      },
+    }]) as any);
+
+    const result = await loadPolicyLocalPatchConfig('policy-4');
+
+    expect(result?.settings.apps).toEqual([
+      { source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' },
+    ]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Dropping duplicate app rule at index 1')
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('does not warn or capture when stored inline settings are valid', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    vi.mocked(db.select).mockReturnValueOnce(selectJoinLimitRows([{
+      configPolicyId: 'policy-5',
+      configPolicyName: 'Policy 5',
+      orgId: 'org-1',
+      featureLinkId: 'link-5',
+      featurePolicyId: null,
+      storedInlineSettings: {
+        sources: ['os'],
+        autoApproveDeferralDays: 3,
+        apps: [{ source: 'custom', packageId: 'corp-tool', action: 'block' }],
+      },
+      patchSettings: null,
+    }]) as any);
+
+    const result = await loadPolicyLocalPatchConfig('policy-5');
+
+    expect(result?.settings.autoApproveDeferralDays).toBe(3);
+    expect(result?.settings.apps).toHaveLength(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(captureException).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
   });
 });
 

--- a/apps/api/src/services/configPolicyPatching.test.ts
+++ b/apps/api/src/services/configPolicyPatching.test.ts
@@ -43,12 +43,24 @@ vi.mock('../db/schema', () => ({
 }));
 
 import {
+  loadPolicyLocalPatchConfig,
   normalizePatchInlineSettings,
   tryNormalizePatchInlineSettings,
   summarizePatchInventory,
   type PatchInventoryRow,
   type PatchReferenceClassification,
 } from './configPolicyPatching';
+import { db } from '../db';
+
+function selectJoinLimitRows(rows: unknown[]) {
+  const chain: any = {};
+  chain.from = vi.fn(() => chain);
+  chain.innerJoin = vi.fn(() => chain);
+  chain.leftJoin = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => Promise.resolve(rows));
+  return chain;
+}
 
 describe('normalizePatchInlineSettings', () => {
   it('passes valid input through', () => {
@@ -170,6 +182,48 @@ describe('tryNormalizePatchInlineSettings', () => {
 
     expect(result.valid).toBe(false);
     expect(result.settings.sources).toEqual(['os']);
+  });
+});
+
+describe('loadPolicyLocalPatchConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('preserves JSON-only patch fields when normalized patch settings exist', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(selectJoinLimitRows([{
+      configPolicyId: 'policy-1',
+      configPolicyName: 'Policy 1',
+      orgId: 'org-1',
+      featureLinkId: 'link-1',
+      featurePolicyId: null,
+      storedInlineSettings: {
+        sources: ['third_party'],
+        autoApprove: true,
+        autoApproveSeverities: ['critical'],
+        autoApproveDeferralDays: 5,
+        apps: [{ source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' }],
+      },
+      patchSettings: {
+        sources: ['os'],
+        autoApprove: false,
+        autoApproveSeverities: [],
+        scheduleFrequency: 'daily',
+        scheduleTime: '03:00',
+        scheduleDayOfWeek: 'mon',
+        scheduleDayOfMonth: 10,
+        rebootPolicy: 'if_required',
+      },
+    }]) as any);
+
+    const result = await loadPolicyLocalPatchConfig('policy-1');
+
+    expect(result?.settings.sources).toEqual(['os']);
+    expect(result?.settings.autoApprove).toBe(false);
+    expect(result?.settings.autoApproveDeferralDays).toBe(5);
+    expect(result?.settings.apps).toEqual([
+      { source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' },
+    ]);
   });
 });
 

--- a/apps/api/src/services/configPolicyPatching.ts
+++ b/apps/api/src/services/configPolicyPatching.ts
@@ -181,18 +181,21 @@ export async function loadPolicyLocalPatchConfig(
 
   if (!row) return null;
 
+  const storedInline = tryNormalizePatchInlineSettings(row.storedInlineSettings).settings;
   const settings = row.patchSettings
     ? normalizePatchInlineSettings({
         sources: row.patchSettings.sources,
         autoApprove: row.patchSettings.autoApprove,
         autoApproveSeverities: row.patchSettings.autoApproveSeverities ?? [],
+        autoApproveDeferralDays: storedInline.autoApproveDeferralDays,
+        apps: storedInline.apps,
         scheduleFrequency: row.patchSettings.scheduleFrequency,
         scheduleTime: row.patchSettings.scheduleTime,
         scheduleDayOfWeek: row.patchSettings.scheduleDayOfWeek ?? undefined,
         scheduleDayOfMonth: row.patchSettings.scheduleDayOfMonth ?? undefined,
         rebootPolicy: row.patchSettings.rebootPolicy,
       })
-    : normalizePatchInlineSettings(row.storedInlineSettings);
+    : storedInline;
 
   const ring = await resolvePatchPolicyReference(row.orgId, row.featurePolicyId);
 

--- a/apps/api/src/services/configPolicyPatching.ts
+++ b/apps/api/src/services/configPolicyPatching.ts
@@ -1,7 +1,8 @@
 import { and, eq, isNull, SQL } from 'drizzle-orm';
 import type { z } from 'zod';
-import { patchInlineSettingsSchema } from '@breeze/shared/validators';
+import { patchInlineSettingsSchema, policyAppRuleSchema } from '@breeze/shared/validators';
 import { db } from '../db';
+import { captureException } from './sentry';
 import {
   configurationPolicies,
   configPolicyFeatureLinks,
@@ -74,6 +75,92 @@ export function tryNormalizePatchInlineSettings(settings: unknown): {
     valid: false,
     settings: normalizePatchInlineSettings({}),
   };
+}
+
+/**
+ * Normalizes the feature link's stored inline JSON for the load path, but —
+ * unlike the bare `tryNormalizePatchInlineSettings` — never *silently*
+ * collapses a corrupt document to defaults. Zod parses the whole document, so
+ * a single malformed field (one bad app entry, a legacy '2:00' scheduleTime)
+ * would otherwise wipe every safety rule (app block/pin rules, deferral) with
+ * nothing in any log, and the executor's fail-closed warnings never fire
+ * because job snapshots are built from this already-sanitized output.
+ *
+ * On whole-document failure this warns + reports to Sentry, then salvages the
+ * JSON-only safety fields per-entry (mirroring the executor's per-entry
+ * posture): each raw `apps` entry that individually passes
+ * `policyAppRuleSchema`, and `autoApproveDeferralDays` when it is a valid
+ * non-negative integer <= 60.
+ */
+function normalizeStoredInlineSettingsWithSalvage(
+  raw: unknown,
+  context: { configPolicyId: string; featureLinkId: string }
+): PatchInlineSettings {
+  const normalized = tryNormalizePatchInlineSettings(raw);
+  if (normalized.valid) return normalized.settings;
+
+  const ident = `config policy ${context.configPolicyId} (feature link ${context.featureLinkId})`;
+  console.warn(
+    `[configPolicyPatching] Stored patch inline settings failed validation for ${ident}; ` +
+      'using defaults and salvaging app rules / deferral per-entry'
+  );
+  captureException(
+    new Error(
+      `Stored patch inline settings failed validation for ${ident}; defaults applied with per-entry salvage`
+    )
+  );
+
+  const settings = normalized.settings;
+  const rawObj: Record<string, unknown> =
+    raw && typeof raw === 'object' && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
+
+  if (Array.isArray(rawObj.apps)) {
+    const salvagedApps: PatchInlineSettings['apps'] = [];
+    // Same canonical dedup key as patchInlineSettingsSchema's superRefine —
+    // duplicates would make the downstream whole-document re-parse throw.
+    const seenAppKeys = new Set<string>();
+    for (const [index, entry] of rawObj.apps.entries()) {
+      const parsedApp = policyAppRuleSchema.safeParse(entry);
+      if (!parsedApp.success) {
+        console.warn(
+          `[configPolicyPatching] Dropping invalid app rule at index ${index} for ${ident}: ` +
+            parsedApp.error.issues.map((issue) => issue.message).join('; ')
+        );
+        continue;
+      }
+      const canonicalSource = parsedApp.data.source === 'custom' ? 'third_party' : parsedApp.data.source;
+      const key = `${canonicalSource}|${parsedApp.data.packageId.toLowerCase()}`;
+      if (seenAppKeys.has(key)) {
+        console.warn(
+          `[configPolicyPatching] Dropping duplicate app rule at index ${index} for ${ident} (${key})`
+        );
+        continue;
+      }
+      if (salvagedApps.length >= 200) {
+        // patchInlineSettingsSchema caps apps at 200; exceeding it would make
+        // the downstream re-parse throw.
+        console.warn(
+          `[configPolicyPatching] Dropping app rule at index ${index} for ${ident}: salvage cap of 200 reached`
+        );
+        continue;
+      }
+      seenAppKeys.add(key);
+      salvagedApps.push(parsedApp.data);
+    }
+    settings.apps = salvagedApps;
+  }
+
+  const rawDeferral = rawObj.autoApproveDeferralDays;
+  if (
+    typeof rawDeferral === 'number' &&
+    Number.isInteger(rawDeferral) &&
+    rawDeferral >= 0 &&
+    rawDeferral <= 60
+  ) {
+    settings.autoApproveDeferralDays = rawDeferral;
+  }
+
+  return settings;
 }
 
 export async function resolvePatchPolicyReference(
@@ -181,7 +268,14 @@ export async function loadPolicyLocalPatchConfig(
 
   if (!row) return null;
 
-  const storedInline = tryNormalizePatchInlineSettings(row.storedInlineSettings).settings;
+  const storedInline = normalizeStoredInlineSettingsWithSalvage(row.storedInlineSettings, {
+    configPolicyId: row.configPolicyId,
+    featureLinkId: row.featureLinkId,
+  });
+  // Constraint: autoApproveDeferralDays and apps have no columns on
+  // config_policy_patch_settings — they live only in the feature link's
+  // inline JSON. The mixed sourcing below (columns for everything else,
+  // storedInline for these two) is therefore intentional, not an oversight.
   const settings = row.patchSettings
     ? normalizePatchInlineSettings({
         sources: row.patchSettings.sources,

--- a/apps/api/src/services/configurationPolicy.test.ts
+++ b/apps/api/src/services/configurationPolicy.test.ts
@@ -1,0 +1,335 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    transaction: vi.fn(),
+  },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+import { addFeatureLink, updateFeatureLink, listFeatureLinks } from './configurationPolicy';
+import { db } from '../db';
+
+// Chain for `db.select().from(...).where(...)` awaited directly (links query)
+function selectWhereRows(rows: unknown[]) {
+  const chain: any = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => Promise.resolve(rows));
+  return chain;
+}
+
+// Chain for `db.select().from(...).where(...).limit(...)` (normalized settings query)
+function selectLimitRows(rows: unknown[]) {
+  const chain: any = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => Promise.resolve(rows));
+  return chain;
+}
+
+const PATCH_INPUT = {
+  sources: ['os', 'third_party'],
+  autoApprove: true,
+  autoApproveSeverities: ['critical'],
+  autoApproveDeferralDays: 7,
+  apps: [
+    { source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' },
+    { source: 'third_party', packageId: '7zip.7zip', action: 'pin', pinnedVersion: '23.01' },
+  ],
+  scheduleFrequency: 'daily',
+  scheduleTime: '03:30',
+  scheduleDayOfWeek: 'tue',
+  scheduleDayOfMonth: 5,
+  rebootPolicy: 'never',
+};
+
+describe('patch feature link round-trip (apps + autoApproveDeferralDays)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('persists apps and autoApproveDeferralDays in JSONB on save and returns them from listFeatureLinks', async () => {
+    // --- Save path: addFeatureLink ---
+    let storedJsonb: any;
+    let normalizedRowValues: any;
+    let insertCall = 0;
+
+    const tx = {
+      insert: vi.fn(() => ({
+        values: vi.fn((v: any) => {
+          insertCall += 1;
+          if (insertCall === 1) {
+            // feature link insert — captures what lands in the inline_settings JSONB
+            storedJsonb = v.inlineSettings;
+            return {
+              returning: vi.fn(() =>
+                Promise.resolve([
+                  {
+                    id: 'link-1',
+                    configPolicyId: 'policy-1',
+                    featureType: 'patch',
+                    featurePolicyId: null,
+                    inlineSettings: v.inlineSettings,
+                  },
+                ])
+              ),
+            };
+          }
+          // config_policy_patch_settings insert (decomposeInlineSettings)
+          normalizedRowValues = v;
+          return Promise.resolve([]);
+        }),
+      })),
+    };
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    const link = await addFeatureLink('policy-1', 'patch', null, PATCH_INPUT);
+
+    // The JSONB mirror must keep the JSON-only fields...
+    expect(storedJsonb.apps).toEqual(PATCH_INPUT.apps);
+    expect(storedJsonb.autoApproveDeferralDays).toBe(7);
+    // ...while the normalized table (which has no columns for them) does not get them
+    expect(normalizedRowValues.featureLinkId).toBe('link-1');
+    expect(normalizedRowValues.apps).toBeUndefined();
+    expect(normalizedRowValues.autoApproveDeferralDays).toBeUndefined();
+
+    // --- Read path: listFeatureLinks, fed exactly what the save wrote ---
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectWhereRows([link]) as any) // links query
+      .mockReturnValueOnce(
+        selectLimitRows([
+          {
+            id: 'ps-1',
+            featureLinkId: 'link-1',
+            sources: normalizedRowValues.sources,
+            autoApprove: normalizedRowValues.autoApprove,
+            autoApproveSeverities: normalizedRowValues.autoApproveSeverities,
+            scheduleFrequency: normalizedRowValues.scheduleFrequency,
+            scheduleTime: normalizedRowValues.scheduleTime,
+            scheduleDayOfWeek: normalizedRowValues.scheduleDayOfWeek,
+            scheduleDayOfMonth: normalizedRowValues.scheduleDayOfMonth,
+            rebootPolicy: normalizedRowValues.rebootPolicy,
+          },
+        ]) as any
+      ); // assembleInlineSettings patch query
+
+    const result = await listFeatureLinks('policy-1');
+    expect(result).toHaveLength(1);
+    const settings = result[0]!.inlineSettings as any;
+
+    // THE BUG: these two came back as [] / 0 before the merge fix
+    expect(settings.apps).toEqual(PATCH_INPUT.apps);
+    expect(settings.autoApproveDeferralDays).toBe(7);
+
+    // Relational fields still come from the normalized row
+    expect(settings.sources).toEqual(['os', 'third_party']);
+    expect(settings.autoApprove).toBe(true);
+    expect(settings.autoApproveSeverities).toEqual(['critical']);
+    expect(settings.scheduleFrequency).toBe('daily');
+    expect(settings.scheduleTime).toBe('03:30');
+    expect(settings.rebootPolicy).toBe('never');
+  });
+
+  it('updateFeatureLink keeps apps and autoApproveDeferralDays in the JSONB write', async () => {
+    let setValues: any;
+    const tx = {
+      select: vi.fn(() =>
+        selectLimitRows([
+          {
+            id: 'link-1',
+            configPolicyId: 'policy-1',
+            featureType: 'patch',
+            featurePolicyId: null,
+            inlineSettings: {},
+          },
+        ])
+      ),
+      update: vi.fn(() => ({
+        set: vi.fn((v: any) => {
+          setValues = v;
+          return {
+            where: vi.fn(() => ({
+              returning: vi.fn(() => Promise.resolve([{ id: 'link-1' }])),
+            })),
+          };
+        }),
+      })),
+      delete: vi.fn(() => ({ where: vi.fn(() => Promise.resolve([])) })),
+      insert: vi.fn(() => ({ values: vi.fn(() => Promise.resolve([])) })),
+    };
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    const updated = await updateFeatureLink('link-1', { inlineSettings: PATCH_INPUT }, 'policy-1');
+
+    expect(updated).not.toBeNull();
+    expect(setValues.inlineSettings.apps).toEqual(PATCH_INPUT.apps);
+    expect(setValues.inlineSettings.autoApproveDeferralDays).toBe(7);
+  });
+
+  it('merges JSON-only fields from stored JSONB even when the normalized row wins', async () => {
+    // Mirrors loadPolicyLocalPatchConfig behavior in configPolicyPatching.ts
+    vi.mocked(db.select)
+      .mockReturnValueOnce(
+        selectWhereRows([
+          {
+            id: 'link-1',
+            configPolicyId: 'policy-1',
+            featureType: 'patch',
+            featurePolicyId: null,
+            inlineSettings: {
+              sources: ['third_party'],
+              autoApprove: true,
+              autoApproveSeverities: ['critical'],
+              autoApproveDeferralDays: 5,
+              apps: [{ source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' }],
+            },
+          },
+        ]) as any
+      )
+      .mockReturnValueOnce(
+        selectLimitRows([
+          {
+            id: 'ps-1',
+            featureLinkId: 'link-1',
+            sources: ['os'],
+            autoApprove: false,
+            autoApproveSeverities: [],
+            scheduleFrequency: 'daily',
+            scheduleTime: '03:00',
+            scheduleDayOfWeek: 'mon',
+            scheduleDayOfMonth: 10,
+            rebootPolicy: 'if_required',
+          },
+        ]) as any
+      );
+
+    const result = await listFeatureLinks('policy-1');
+    const settings = result[0]!.inlineSettings as any;
+
+    // Normalized row wins for relational fields
+    expect(settings.sources).toEqual(['os']);
+    expect(settings.autoApprove).toBe(false);
+    expect(settings.scheduleDayOfMonth).toBe(10);
+    // JSON-only fields survive from the stored JSONB
+    expect(settings.autoApproveDeferralDays).toBe(5);
+    expect(settings.apps).toEqual([
+      { source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' },
+    ]);
+  });
+
+  it('falls back to defaults for JSON-only fields when stored JSONB is malformed (no throw)', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(
+        selectWhereRows([
+          {
+            id: 'link-1',
+            configPolicyId: 'policy-1',
+            featureType: 'patch',
+            featurePolicyId: null,
+            inlineSettings: {
+              sources: [], // violates min(1)
+              scheduleTime: 'not-a-time',
+              apps: 'garbage-not-an-array',
+              autoApproveDeferralDays: 999, // out of range
+            },
+          },
+        ]) as any
+      )
+      .mockReturnValueOnce(
+        selectLimitRows([
+          {
+            id: 'ps-1',
+            featureLinkId: 'link-1',
+            sources: ['os'],
+            autoApprove: false,
+            autoApproveSeverities: [],
+            scheduleFrequency: 'weekly',
+            scheduleTime: '02:00',
+            scheduleDayOfWeek: 'sun',
+            scheduleDayOfMonth: 1,
+            rebootPolicy: 'if_required',
+          },
+        ]) as any
+      );
+
+    const result = await listFeatureLinks('policy-1');
+    const settings = result[0]!.inlineSettings as any;
+
+    // Merged fields fall back to schema defaults without throwing
+    expect(settings.apps).toEqual([]);
+    expect(settings.autoApproveDeferralDays).toBe(0);
+    // Normalized row still supplies the relational fields
+    expect(settings.sources).toEqual(['os']);
+    expect(settings.scheduleTime).toBe('02:00');
+  });
+
+  it('falls back to the stored JSONB (including apps) when no normalized row exists', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(
+        selectWhereRows([
+          {
+            id: 'link-1',
+            configPolicyId: 'policy-1',
+            featureType: 'patch',
+            featurePolicyId: null,
+            inlineSettings: PATCH_INPUT,
+          },
+        ]) as any
+      )
+      .mockReturnValueOnce(selectLimitRows([]) as any); // no config_policy_patch_settings row
+
+    const result = await listFeatureLinks('policy-1');
+    const settings = result[0]!.inlineSettings as any;
+
+    expect(settings.apps).toEqual(PATCH_INPUT.apps);
+    expect(settings.autoApproveDeferralDays).toBe(7);
+    expect(settings.sources).toEqual(['os', 'third_party']);
+  });
+
+  it('does not throw when no normalized row exists and stored JSONB is malformed', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(
+        selectWhereRows([
+          {
+            id: 'link-1',
+            configPolicyId: 'policy-1',
+            featureType: 'patch',
+            featurePolicyId: null,
+            inlineSettings: { sources: [], scheduleTime: 'nope' },
+          },
+        ]) as any
+      )
+      .mockReturnValueOnce(selectLimitRows([]) as any);
+
+    const result = await listFeatureLinks('policy-1');
+    const settings = result[0]!.inlineSettings as any;
+
+    expect(settings.sources).toEqual(['os']); // schema defaults
+    expect(settings.apps).toEqual([]);
+    expect(settings.autoApproveDeferralDays).toBe(0);
+  });
+
+  it('leaves non-patch feature links untouched (raw JSONB passthrough)', async () => {
+    const helperSettings = { someHelperFlag: true };
+    vi.mocked(db.select).mockReturnValueOnce(
+      selectWhereRows([
+        {
+          id: 'link-2',
+          configPolicyId: 'policy-1',
+          featureType: 'helper',
+          featurePolicyId: null,
+          inlineSettings: helperSettings,
+        },
+      ]) as any
+    );
+
+    const result = await listFeatureLinks('policy-1');
+    expect(result[0]!.inlineSettings).toEqual(helperSettings);
+  });
+});

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -31,7 +31,7 @@ import {
 import { and, eq, desc, sql, inArray, asc, SQL } from 'drizzle-orm';
 import { eventLogInlineSettingsSchema, monitoringInlineSettingsSchema } from '@breeze/shared/validators';
 import type { AuthContext } from '../middleware/auth';
-import { normalizePatchInlineSettings } from './configPolicyPatching';
+import { normalizePatchInlineSettings, tryNormalizePatchInlineSettings } from './configPolicyPatching';
 
 // ============================================
 // Types
@@ -596,6 +596,11 @@ async function assembleInlineSettings(
         .where(eq(configPolicyPatchSettings.featureLinkId, linkId))
         .limit(1);
       if (!row) return null;
+      // NOTE: autoApproveDeferralDays and apps (block/pin rules) are intentionally
+      // absent here — config_policy_patch_settings has no columns for them; they
+      // live ONLY in the feature link's inline JSONB. Callers (listFeatureLinks)
+      // MUST merge them back in from the stored inlineSettings, otherwise reads
+      // come back with apps: [] and the next save destroys every app rule.
       return {
         sources: row.sources,
         autoApprove: row.autoApprove,
@@ -885,10 +890,29 @@ export async function listFeatureLinks(configPolicyId: string) {
     links.map(async (link) => {
       const featureType = link.featureType as ConfigFeatureType;
       const assembled = await assembleInlineSettings(featureType, link.id);
-      const effectiveInlineSettings =
-        featureType === 'patch'
-          ? normalizePatchInlineSettings(assembled ?? link.inlineSettings)
-          : assembled ?? link.inlineSettings;
+      let effectiveInlineSettings: unknown;
+      if (featureType === 'patch') {
+        // CONSTRAINT: autoApproveDeferralDays and apps (block/pin rules) have NO
+        // columns on config_policy_patch_settings — they live ONLY in the feature
+        // link's inline JSONB. They must be merged in even when the relational row
+        // wins, exactly mirroring loadPolicyLocalPatchConfig in configPolicyPatching.ts.
+        // Without this merge every read returns apps: [] / autoApproveDeferralDays: 0,
+        // and the next save writes that emptiness back to the JSONB — permanently
+        // destroying all app rules with no warning (blocked apps then auto-install).
+        // A maintainer "cleaning up" this mixed sourcing must first add columns and
+        // a backfill migration. Malformed stored JSON must not throw; it falls back
+        // to schema defaults for just these fields via tryNormalizePatchInlineSettings.
+        const storedInline = tryNormalizePatchInlineSettings(link.inlineSettings).settings;
+        effectiveInlineSettings = assembled
+          ? normalizePatchInlineSettings({
+              ...(assembled as Record<string, unknown>),
+              autoApproveDeferralDays: storedInline.autoApproveDeferralDays,
+              apps: storedInline.apps,
+            })
+          : storedInline;
+      } else {
+        effectiveInlineSettings = assembled ?? link.inlineSettings;
+      }
       return {
         ...link,
         // Prefer assembled normalized data; fall back to stored JSONB

--- a/apps/api/src/services/patchApprovalEvaluator.test.ts
+++ b/apps/api/src/services/patchApprovalEvaluator.test.ts
@@ -9,7 +9,7 @@ vi.mock('../db/schema', () => ({
   patches: {
     id: 'id', externalId: 'externalId', title: 'title', category: 'category',
     severity: 'severity', releaseDate: 'releaseDate', requiresReboot: 'requiresReboot',
-    source: 'source',
+    source: 'source', packageId: 'packageId', version: 'version',
   },
   patchApprovals: { patchId: 'patchId', status: 'status', ringId: 'ringId', orgId: 'orgId' },
   OUTSTANDING_DEVICE_PATCH_STATUSES: ['pending'],
@@ -17,10 +17,61 @@ vi.mock('../db/schema', () => ({
 
 import { db } from '../db';
 import {
+  buildAppRuleMap,
   buildAllowedPatchSources,
+  comparePatchVersions,
+  evaluateAppRule,
   resolveApprovedPatchesForDevice,
   type RingConfig,
 } from './patchApprovalEvaluator';
+
+describe('comparePatchVersions', () => {
+  it.each([
+    ['1.2.3', '1.2.3', 0],
+    ['1.2.10', '1.2.9', 1],
+    ['1.2', '1.2.0', 0],
+    ['3.0.20', '3.0.21', -1],
+    ['2024.1', '2024.1.5', -1],
+    ['1.2.3-beta', '1.2.3-alpha', 1],
+  ])('compare(%s, %s) === %i', (a, b, expected) => {
+    expect(comparePatchVersions(a, b)).toBe(expected);
+  });
+
+  it('returns null when either side is missing or blank', () => {
+    expect(comparePatchVersions(null, '1.0')).toBeNull();
+    expect(comparePatchVersions('1.0', undefined)).toBeNull();
+    expect(comparePatchVersions('  ', '1.0')).toBeNull();
+  });
+});
+
+describe('evaluateAppRule', () => {
+  const rules = buildAppRuleMap([
+    { source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' },
+    { source: 'third_party', packageId: 'VideoLAN.VLC', action: 'pin', pinnedVersion: '3.0.20' },
+  ]);
+
+  it('blocks a matching block rule case-insensitively', () => {
+    expect(evaluateAppRule({ source: 'third_party', packageId: 'mozilla.firefox', version: '120.0' }, rules)).toBe('blocked');
+  });
+
+  it('allows patches with no matching rule or no packageId', () => {
+    expect(evaluateAppRule({ source: 'third_party', packageId: 'Notepad++.Notepad++', version: '8.6' }, rules)).toBe('allowed');
+    expect(evaluateAppRule({ source: 'microsoft', packageId: null, version: null }, rules)).toBe('allowed');
+  });
+
+  it('holds a pinned app when the target version exceeds the pin', () => {
+    expect(evaluateAppRule({ source: 'third_party', packageId: 'VideoLAN.VLC', version: '3.0.21' }, rules)).toBe('held');
+  });
+
+  it('allows a pinned app at or below the pin', () => {
+    expect(evaluateAppRule({ source: 'third_party', packageId: 'VideoLAN.VLC', version: '3.0.20' }, rules)).toBe('allowed');
+    expect(evaluateAppRule({ source: 'third_party', packageId: 'VideoLAN.VLC', version: '3.0.19' }, rules)).toBe('allowed');
+  });
+
+  it('holds when the patch version is missing', () => {
+    expect(evaluateAppRule({ source: 'third_party', packageId: 'VideoLAN.VLC', version: null }, rules)).toBe('held');
+  });
+});
 
 describe('buildAllowedPatchSources', () => {
   it('maps os to the three OS patch sources', () => {
@@ -56,6 +107,8 @@ describe('buildAllowedPatchSources', () => {
 const ORG_ID = '11111111-1111-1111-1111-111111111111';
 const DEVICE_ID = '22222222-2222-2222-2222-222222222222';
 const RING_ID = '33333333-3333-3333-3333-333333333333';
+const P1 = 'aaaaaaaa-0000-0000-0000-000000000001';
+const P2 = 'aaaaaaaa-0000-0000-0000-000000000002';
 
 type PendingRow = {
   devicePatchId: string;
@@ -67,12 +120,14 @@ type PendingRow = {
   releaseDate: string | null;
   requiresReboot: boolean;
   source: string;
+  packageId: string | null;
+  version: string | null;
 };
 
 function pendingRow(overrides: Partial<PendingRow>): PendingRow {
   return {
     devicePatchId: 'dp-1',
-    patchId: 'aaaaaaaa-0000-0000-0000-000000000001',
+    patchId: P1,
     externalId: 'KB0000001',
     title: 'A patch',
     category: 'security',
@@ -80,6 +135,8 @@ function pendingRow(overrides: Partial<PendingRow>): PendingRow {
     releaseDate: null,
     requiresReboot: false,
     source: 'microsoft',
+    packageId: null,
+    version: null,
     ...overrides,
   };
 }
@@ -176,6 +233,121 @@ describe('resolveApprovedPatchesForDevice source filtering', () => {
     });
 
     expect(approved).toHaveLength(0);
+  });
+});
+
+describe('app rules in resolveApprovedPatchesForDevice', () => {
+  beforeEach(() => {
+    vi.mocked(db.select).mockReset();
+  });
+
+  it('excludes a blocked app even when manually approved', async () => {
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'third_party', packageId: 'Mozilla.Firefox', version: '121.0' })],
+      [{ patchId: P1, status: 'approved', ringId: null }]
+    );
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: null,
+      categoryRules: [],
+      autoApprove: {},
+      deferralDays: 0,
+      sources: ['third_party'],
+      apps: [{ source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' }],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('holds a pinned app above the pin but approves one at the pin', async () => {
+    mockPendingAndApprovals(
+      [
+        pendingRow({ patchId: P1, devicePatchId: 'dp-1', source: 'third_party', packageId: 'VideoLAN.VLC', version: '3.0.21' }),
+        pendingRow({ patchId: P2, devicePatchId: 'dp-2', source: 'third_party', packageId: 'VideoLAN.VLC', version: '3.0.20' }),
+      ],
+      [{ patchId: P1, status: 'approved', ringId: null }, { patchId: P2, status: 'approved', ringId: null }]
+    );
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: null,
+      categoryRules: [],
+      autoApprove: {},
+      deferralDays: 0,
+      sources: ['third_party'],
+      apps: [{ source: 'third_party', packageId: 'VideoLAN.VLC', action: 'pin', pinnedVersion: '3.0.20' }],
+    });
+
+    expect(result.map((r) => r.patchId)).toEqual([P2]);
+  });
+});
+
+describe('policy-level auto-approve (ring-less)', () => {
+  const policyAutoApprove = { enabled: true, severities: ['critical', 'important'], deferralDays: 0 };
+
+  beforeEach(() => {
+    vi.mocked(db.select).mockReset();
+  });
+
+  it('approves a ring-less matching-severity patch with reason policy_auto_approve', async () => {
+    mockPendingAndApprovals([pendingRow({ patchId: P1, severity: 'critical', source: 'third_party', packageId: 'X.Y' })], []);
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: null,
+      categoryRules: [],
+      autoApprove: {},
+      deferralDays: 0,
+      sources: ['third_party'],
+      policyAutoApprove,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.approvalReason).toBe('policy_auto_approve');
+  });
+
+  it('does not approve severities outside the list, or null severity', async () => {
+    mockPendingAndApprovals([
+      pendingRow({ patchId: P1, devicePatchId: 'dp-1', severity: 'low' }),
+      pendingRow({ patchId: P2, devicePatchId: 'dp-2', severity: null }),
+    ], []);
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: null,
+      categoryRules: [],
+      autoApprove: {},
+      deferralDays: 0,
+      policyAutoApprove,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('holds patches inside the deferral window', async () => {
+    const yesterday = new Date(Date.now() - 24 * 3600 * 1000).toISOString();
+    mockPendingAndApprovals([pendingRow({ patchId: P1, severity: 'critical', releaseDate: yesterday })], []);
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: null,
+      categoryRules: [],
+      autoApprove: {},
+      deferralDays: 0,
+      policyAutoApprove: { ...policyAutoApprove, deferralDays: 7 },
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('ignores policyAutoApprove entirely when a ring is linked', async () => {
+    mockPendingAndApprovals([pendingRow({ patchId: P1, severity: 'critical' })], []);
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [],
+      autoApprove: { enabled: false },
+      deferralDays: 0,
+      policyAutoApprove,
+    });
+
+    expect(result).toEqual([]);
   });
 });
 

--- a/apps/api/src/services/patchApprovalEvaluator.test.ts
+++ b/apps/api/src/services/patchApprovalEvaluator.test.ts
@@ -17,13 +17,22 @@ vi.mock('../db/schema', () => ({
 
 import { db } from '../db';
 import {
+  appRuleKey,
   buildAppRuleMap,
   buildAllowedPatchSources,
   comparePatchVersions,
   evaluateAppRule,
   resolveApprovedPatchesForDevice,
+  THIRD_PARTY_PATCH_SOURCES,
+  type ApprovalEvaluationConfig,
   type RingConfig,
 } from './patchApprovalEvaluator';
+
+// Compile-time checks: deprecated alias and exported source list stay usable.
+const _aliasCheck: RingConfig = { ringId: null, categoryRules: [], autoApprove: {}, deferralDays: 0 };
+const _aliasCheck2: ApprovalEvaluationConfig = _aliasCheck;
+void _aliasCheck2;
+void THIRD_PARTY_PATCH_SOURCES;
 
 describe('comparePatchVersions', () => {
   it.each([
@@ -41,6 +50,17 @@ describe('comparePatchVersions', () => {
     expect(comparePatchVersions(null, '1.0')).toBeNull();
     expect(comparePatchVersions('1.0', undefined)).toBeNull();
     expect(comparePatchVersions('  ', '1.0')).toBeNull();
+  });
+});
+
+describe('appRuleKey', () => {
+  it('collapses third_party and custom into one canonical bucket', () => {
+    expect(appRuleKey('third_party', 'Mozilla.Firefox')).toBe('third_party|mozilla.firefox');
+    expect(appRuleKey('custom', 'Mozilla.Firefox')).toBe('third_party|mozilla.firefox');
+  });
+
+  it('keeps non-third-party sources as their own bucket', () => {
+    expect(appRuleKey('microsoft', 'SomeId')).toBe('microsoft|someid');
   });
 });
 
@@ -70,6 +90,18 @@ describe('evaluateAppRule', () => {
 
   it('holds when the patch version is missing', () => {
     expect(evaluateAppRule({ source: 'third_party', packageId: 'VideoLAN.VLC', version: null }, rules)).toBe('held');
+  });
+
+  it('a third_party rule also matches a custom-source patch (unified bucket)', () => {
+    expect(evaluateAppRule({ source: 'custom', packageId: 'Mozilla.Firefox', version: '120.0' }, rules)).toBe('blocked');
+    expect(evaluateAppRule({ source: 'custom', packageId: 'VideoLAN.VLC', version: '3.0.21' }, rules)).toBe('held');
+  });
+
+  it('a custom rule also matches a third_party-source patch (unified bucket)', () => {
+    const customRules = buildAppRuleMap([
+      { source: 'custom', packageId: 'Mozilla.Firefox', action: 'block' },
+    ]);
+    expect(evaluateAppRule({ source: 'third_party', packageId: 'Mozilla.Firefox', version: '120.0' }, customRules)).toBe('blocked');
   });
 });
 
@@ -279,6 +311,71 @@ describe('app rules in resolveApprovedPatchesForDevice', () => {
 
     expect(result.map((r) => r.patchId)).toEqual([P2]);
   });
+
+  it('a third_party block rule excludes a custom-source patch (unified bucket)', async () => {
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'custom', packageId: 'Mozilla.Firefox', version: '121.0' })],
+      [{ patchId: P1, status: 'approved', ringId: null }]
+    );
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: null,
+      categoryRules: [],
+      autoApprove: {},
+      deferralDays: 0,
+      sources: ['third_party'],
+      apps: [{ source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' }],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('warns but still approves an otherwise-eligible third-party patch with no packageId', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      mockPendingAndApprovals(
+        [pendingRow({ patchId: P1, source: 'third_party', packageId: null, version: '1.0' })],
+        [{ patchId: P1, status: 'approved', ringId: null }]
+      );
+
+      const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+        ringId: null,
+        categoryRules: [],
+        autoApprove: {},
+        deferralDays: 0,
+        sources: ['third_party'],
+        apps: [{ source: 'third_party', packageId: 'VideoLAN.VLC', action: 'pin', pinnedVersion: '3.0.20' }],
+      });
+
+      expect(result.map((r) => r.patchId)).toEqual([P1]);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('cannot be matched against app rules — missing packageId')
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('applies an app block rule under a linked ring too', async () => {
+    mockPendingAndApprovals(
+      [
+        pendingRow({ patchId: P1, devicePatchId: 'dp-1', source: 'third_party', category: 'homebrew', packageId: 'Mozilla.Firefox', version: '121.0' }),
+        pendingRow({ patchId: P2, devicePatchId: 'dp-2', source: 'third_party', category: 'homebrew', packageId: 'VideoLAN.VLC', version: '3.0.20' }),
+      ],
+      []
+    );
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [{ category: 'third_party_app', autoApprove: true }],
+      autoApprove: {},
+      deferralDays: 0,
+      apps: [{ source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' }],
+    });
+
+    expect(result.map((r) => r.patchId)).toEqual([P2]);
+    expect(result[0]?.approvalReason).toBe('category_rule');
+  });
 });
 
 describe('policy-level auto-approve (ring-less)', () => {
@@ -334,6 +431,42 @@ describe('policy-level auto-approve (ring-less)', () => {
     });
 
     expect(result).toEqual([]);
+  });
+
+  it('approves a patch whose deferral window has elapsed', async () => {
+    const tenDaysAgo = new Date(Date.now() - 10 * 24 * 3600 * 1000).toISOString();
+    mockPendingAndApprovals([pendingRow({ patchId: P1, severity: 'critical', releaseDate: tenDaysAgo })], []);
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: null,
+      categoryRules: [],
+      autoApprove: {},
+      deferralDays: 0,
+      policyAutoApprove: { ...policyAutoApprove, deferralDays: 7 },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.approvalReason).toBe('policy_auto_approve');
+  });
+
+  it('fails closed (holds + warns) when deferralDays > 0 and releaseDate is missing', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      mockPendingAndApprovals([pendingRow({ patchId: P1, severity: 'critical', releaseDate: null })], []);
+
+      const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+        ringId: null,
+        categoryRules: [],
+        autoApprove: {},
+        deferralDays: 0,
+        policyAutoApprove: { ...policyAutoApprove, deferralDays: 7 },
+      });
+
+      expect(result).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('cannot prove its age'));
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('ignores policyAutoApprove entirely when a ring is linked', async () => {

--- a/apps/api/src/services/patchApprovalEvaluator.test.ts
+++ b/apps/api/src/services/patchApprovalEvaluator.test.ts
@@ -565,6 +565,28 @@ describe('third_party_app category rule', () => {
     expect(approved).toHaveLength(0);
   });
 
+  it('fails closed when a category deferral is configured and releaseDate is missing', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      mockPendingAndApprovals(
+        [pendingRow({ patchId: 'aaaaaaaa-0000-0000-0000-000000000019', source: 'third_party', category: 'homebrew', releaseDate: null })],
+        []
+      );
+
+      const approved = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+        ...ringWithThirdPartyRule,
+        categoryRules: [{ category: 'third_party_app', autoApprove: true, deferralDaysOverride: 7 }],
+      });
+
+      expect(approved).toHaveLength(0);
+      const warning = String(warnSpy.mock.calls[0]?.[0] ?? '');
+      expect(warning).toContain('category deferral');
+      expect(warning).toContain('cannot prove its age');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('matches the third_party_app rule when the patch category is null', async () => {
     mockPendingAndApprovals(
       [pendingRow({ patchId: 'aaaaaaaa-0000-0000-0000-000000000015', source: 'third_party', category: null })],

--- a/apps/api/src/services/patchApprovalEvaluator.ts
+++ b/apps/api/src/services/patchApprovalEvaluator.ts
@@ -1,8 +1,16 @@
 /**
  * Patch Approval Evaluator
  *
- * Determines which patches to install on a device given the ring's approval rules.
- * Checks manual approvals, category-based auto-approval rules, and legacy ring-level auto-approve.
+ * Single approval/filtering gate for patch job execution. For each device it
+ * resolves the set of pending patches a job is allowed to install, covering:
+ *  - manual approvals (org-wide or ring-scoped)
+ *  - ring category rules (including the virtual 'third_party_app' category)
+ *  - legacy ring-level auto-approve
+ *  - ring-less policy-level auto-approve (severity list + deferral window)
+ *  - policy source filtering ('os' vs 'third_party', ...)
+ *  - per-app block/pin rules
+ *
+ * Manual per-device installs do NOT pass through this evaluator.
  */
 
 import { db } from '../db';
@@ -20,26 +28,29 @@ export interface CategoryRule {
   deferralDaysOverride?: number;
 }
 
+/**
+ * Policy-level auto-approve (ring-less path). Note the inverted
+ * empty-severities semantics vs legacy ring auto-approve: legacy empty
+ * severities = approve all; policy-level empty severities = approve none
+ * (fail-closed).
+ */
 export interface PolicyAutoApproveConfig {
   enabled: boolean;
   severities: string[];
   deferralDays: number;
 }
 
-export interface PolicyAppRule {
-  source: string;
-  packageId: string;
-  action: 'block' | 'pin';
-  pinnedVersion?: string;
-}
+export type PolicyAppRule =
+  | { source: string; packageId: string; action: 'block' }
+  | { source: string; packageId: string; action: 'pin'; pinnedVersion: string };
 
 export type AppRuleVerdict = 'allowed' | 'blocked' | 'held';
 
 /**
- * Evaluator input. Despite the name this now carries both ring-level config
- * and policy-level config: sources, app rules, and ring-less auto-approve.
+ * Evaluator input. Carries both ring-level config and policy-level config:
+ * sources, app rules, and ring-less auto-approve.
  */
-export interface RingConfig {
+export interface ApprovalEvaluationConfig {
   ringId: string | null;
   categoryRules: CategoryRule[];
   autoApprove: unknown;
@@ -48,9 +59,17 @@ export interface RingConfig {
   sources?: string[];
   /** Policy-level auto-approve, consulted only when ringId is null. Absent means disabled. */
   policyAutoApprove?: PolicyAutoApproveConfig;
-  /** Policy-level per-app block/pin rules. Applied to every job approval path. */
+  /**
+   * Policy-level per-app block/pin rules. Applied to every job approval path;
+   * manual per-device installs do not pass through this evaluator.
+   */
   apps?: PolicyAppRule[];
 }
+
+/** @deprecated Use ApprovalEvaluationConfig — kept for existing importers. */
+export type RingConfig = ApprovalEvaluationConfig;
+
+export type ApprovalReason = 'manual' | 'category_rule' | 'legacy_auto_approve' | 'policy_auto_approve';
 
 export interface ApprovedPatch {
   patchId: string;
@@ -70,7 +89,7 @@ export interface ApprovedPatch {
 /** patches.source values that count as OS updates. Keep in sync with patchSourceEnum (db/schema/patches.ts). */
 const OS_PATCH_SOURCES = ['microsoft', 'apple', 'linux'] as const;
 /** patches.source values that count as third-party application updates. Keep in sync with patchSourceEnum (db/schema/patches.ts). */
-const THIRD_PARTY_PATCH_SOURCES = ['third_party', 'custom'] as const;
+export const THIRD_PARTY_PATCH_SOURCES = ['third_party', 'custom'] as const;
 
 /**
  * Expand policy-level source selections ('os', 'third_party', ...) into the
@@ -113,12 +132,15 @@ export function isThirdPartyPatchSource(source: string | null | undefined): bool
 /**
  * Tolerant version comparison for winget/homebrew-style versions, not strict
  * semver. Splits on common separators; numeric segments compare numerically,
- * non-numeric segments lexicographically, and missing segments count as 0.
+ * non-numeric segments by codepoint, and missing segments count as 0.
+ *
+ * Returns null when either side is blank/missing; callers must treat null as
+ * "cannot prove within pin" (hold), never as allowed.
  */
 export function comparePatchVersions(
   a: string | null | undefined,
   b: string | null | undefined
-): number | null {
+): -1 | 0 | 1 | null {
   const av = (a ?? '').trim();
   const bv = (b ?? '').trim();
   if (!av || !bv) return null;
@@ -139,21 +161,38 @@ export function comparePatchVersions(
       continue;
     }
 
-    const cmp = x.localeCompare(y);
-    if (cmp !== 0) return cmp < 0 ? -1 : 1;
+    // Deterministic codepoint comparison (locale-independent).
+    if (x !== y) return x < y ? -1 : 1;
   }
 
   return 0;
 }
 
-/** Key app rules by source + lowercased packageId for O(1) candidate lookup. */
+/**
+ * Canonical lookup key for app rules. The UI presents 'third_party' and
+ * 'custom' patch sources as one bucket (manual UI entries hardcode
+ * 'third_party'), so both collapse to a canonical 'third_party' key; other
+ * sources keep their own key.
+ */
+export function appRuleKey(source: string, packageId: string): string {
+  const bucket = isThirdPartyPatchSource(source) ? 'third_party' : source;
+  return `${bucket}|${packageId.toLowerCase()}`;
+}
+
+/**
+ * Key app rules by canonical source bucket + lowercased packageId for O(1)
+ * candidate lookup. Last-wins on duplicate keys is acceptable because the Zod
+ * schema rejects duplicates upstream.
+ */
 export function buildAppRuleMap(apps: PolicyAppRule[] | undefined): Map<string, PolicyAppRule> {
   const map = new Map<string, PolicyAppRule>();
   for (const rule of apps ?? []) {
-    map.set(`${rule.source}|${rule.packageId.toLowerCase()}`, rule);
+    map.set(appRuleKey(rule.source, rule.packageId), rule);
   }
   return map;
 }
+
+export type AppRuleMap = ReturnType<typeof buildAppRuleMap>;
 
 /**
  * Verdict for one candidate patch against the policy's app rules.
@@ -161,10 +200,10 @@ export function buildAppRuleMap(apps: PolicyAppRule[] | undefined): Map<string, 
  */
 export function evaluateAppRule(
   patch: { source: string; packageId: string | null; version: string | null },
-  rules: Map<string, PolicyAppRule>
+  rules: AppRuleMap
 ): AppRuleVerdict {
   if (rules.size === 0 || !patch.packageId) return 'allowed';
-  const rule = rules.get(`${patch.source}|${patch.packageId.toLowerCase()}`);
+  const rule = rules.get(appRuleKey(patch.source, patch.packageId));
   if (!rule) return 'allowed';
   if (rule.action === 'block') return 'blocked';
 
@@ -180,7 +219,7 @@ export function evaluateAppRule(
 export async function resolveApprovedPatchesForDevice(
   deviceId: string,
   orgId: string,
-  ringConfig: RingConfig
+  ringConfig: ApprovalEvaluationConfig
 ): Promise<ApprovedPatch[]> {
   // 1. Query outstanding (needs-install) devicePatches, joined with patch details.
   //    Only 'pending' is outstanding — 'missing' is a stale tombstone (see
@@ -223,9 +262,21 @@ export async function resolveApprovedPatchesForDevice(
     return [];
   }
 
+  // App rules filter before manual approvals are loaded — a policy block/pin
+  // overrides even an explicit manual approval in the job flow; manual
+  // per-device installs bypass this evaluator entirely.
   const appRuleMap = buildAppRuleMap(ringConfig.apps);
   const finalCandidates = appRuleMap.size > 0
     ? candidatePatches.filter((p) => {
+        if (!p.packageId && isThirdPartyPatchSource(p.source)) {
+          // Deliberate allow-with-warn: holding every unidentified third-party
+          // patch because one unrelated app is pinned/blocked would be
+          // disproportionate.
+          console.warn(
+            `[PatchApproval] device ${deviceId}: patch ${p.patchId} (${p.source}) cannot be matched against app rules — missing packageId`
+          );
+          return true;
+        }
         const verdict = evaluateAppRule(p, appRuleMap);
         if (verdict !== 'allowed') {
           console.warn(
@@ -321,11 +372,9 @@ interface PatchCandidate {
   version: string | null;
 }
 
-type ApprovalReason = 'manual' | 'category_rule' | 'legacy_auto_approve' | 'policy_auto_approve';
-
 function evaluatePatchApproval(
   patch: PatchCandidate,
-  ringConfig: RingConfig,
+  ringConfig: ApprovalEvaluationConfig,
   manualApprovalSet: Set<string>,
   categoryRuleMap: Map<string, CategoryRule>,
   legacyAutoApprove: LegacyAutoApproveConfig,
@@ -336,12 +385,22 @@ function evaluatePatchApproval(
     return 'manual';
   }
 
-  // No ring linked: manual approvals plus policy-level auto-approve. Linked
-  // rings take absolute precedence, so policyAutoApprove is ignored above.
+  // No ring linked: manual approvals plus policy-level auto-approve. When a
+  // ring is linked this block is skipped entirely, so policyAutoApprove is
+  // never consulted.
   if (!ringConfig.ringId) {
     const pa = ringConfig.policyAutoApprove;
     if (pa?.enabled && patch.severity && pa.severities.includes(patch.severity)) {
-      if (pa.deferralDays > 0 && patch.releaseDate) {
+      if (pa.deferralDays > 0) {
+        if (!patch.releaseDate) {
+          // Fail closed: with a deferral window configured, a patch without a
+          // release date cannot prove its age — hold it (consistent with the
+          // pin rule's "can't prove version → held" posture).
+          console.warn(
+            `[PatchApproval] patch ${patch.patchId} held: policy deferral of ${pa.deferralDays} day(s) configured but the patch has no releaseDate, so it cannot prove its age`
+          );
+          return null;
+        }
         const releaseDate = new Date(patch.releaseDate);
         const deferralEnd = new Date(releaseDate.getTime() + pa.deferralDays * 24 * 60 * 60 * 1000);
         if (deferralEnd > now) {

--- a/apps/api/src/services/patchApprovalEvaluator.ts
+++ b/apps/api/src/services/patchApprovalEvaluator.ts
@@ -391,21 +391,8 @@ function evaluatePatchApproval(
   if (!ringConfig.ringId) {
     const pa = ringConfig.policyAutoApprove;
     if (pa?.enabled && patch.severity && pa.severities.includes(patch.severity)) {
-      if (pa.deferralDays > 0) {
-        if (!patch.releaseDate) {
-          // Fail closed: with a deferral window configured, a patch without a
-          // release date cannot prove its age — hold it (consistent with the
-          // pin rule's "can't prove version → held" posture).
-          console.warn(
-            `[PatchApproval] patch ${patch.patchId} held: policy deferral of ${pa.deferralDays} day(s) configured but the patch has no releaseDate, so it cannot prove its age`
-          );
-          return null;
-        }
-        const releaseDate = new Date(patch.releaseDate);
-        const deferralEnd = new Date(releaseDate.getTime() + pa.deferralDays * 24 * 60 * 60 * 1000);
-        if (deferralEnd > now) {
-          return null;
-        }
+      if (isHeldByDeferral(patch, pa.deferralDays, now, 'policy')) {
+        return null;
       }
       return 'policy_auto_approve';
     }
@@ -430,12 +417,8 @@ function evaluatePatchApproval(
 
     // Check deferral period
     const deferralDays = rule.deferralDaysOverride ?? ringConfig.deferralDays;
-    if (deferralDays > 0 && patch.releaseDate) {
-      const releaseDate = new Date(patch.releaseDate);
-      const deferralEnd = new Date(releaseDate.getTime() + deferralDays * 24 * 60 * 60 * 1000);
-      if (deferralEnd > now) {
-        return null; // Still in deferral period
-      }
+    if (isHeldByDeferral(patch, deferralDays, now, 'category')) {
+      return null;
     }
 
     return 'category_rule';
@@ -452,6 +435,28 @@ function evaluatePatchApproval(
   }
 
   return null;
+}
+
+function isHeldByDeferral(
+  patch: PatchCandidate,
+  deferralDays: number,
+  now: Date,
+  source: 'policy' | 'category'
+): boolean {
+  if (deferralDays <= 0) return false;
+
+  if (!patch.releaseDate) {
+    // Fail closed: with a deferral window configured, a patch without a
+    // release date cannot prove its age, consistent with pin rules.
+    console.warn(
+      `[PatchApproval] patch ${patch.patchId} held: ${source} deferral of ${deferralDays} day(s) configured but the patch has no releaseDate, so it cannot prove its age`
+    );
+    return true;
+  }
+
+  const releaseDate = new Date(patch.releaseDate);
+  const deferralEnd = new Date(releaseDate.getTime() + deferralDays * 24 * 60 * 60 * 1000);
+  return deferralEnd > now;
 }
 
 interface LegacyAutoApproveConfig {

--- a/apps/api/src/services/patchApprovalEvaluator.ts
+++ b/apps/api/src/services/patchApprovalEvaluator.ts
@@ -20,6 +20,25 @@ export interface CategoryRule {
   deferralDaysOverride?: number;
 }
 
+export interface PolicyAutoApproveConfig {
+  enabled: boolean;
+  severities: string[];
+  deferralDays: number;
+}
+
+export interface PolicyAppRule {
+  source: string;
+  packageId: string;
+  action: 'block' | 'pin';
+  pinnedVersion?: string;
+}
+
+export type AppRuleVerdict = 'allowed' | 'blocked' | 'held';
+
+/**
+ * Evaluator input. Despite the name this now carries both ring-level config
+ * and policy-level config: sources, app rules, and ring-less auto-approve.
+ */
 export interface RingConfig {
   ringId: string | null;
   categoryRules: CategoryRule[];
@@ -27,6 +46,10 @@ export interface RingConfig {
   deferralDays: number;
   /** Policy-level source selections ('os', 'third_party', ...). Absent/empty = no filtering (legacy). */
   sources?: string[];
+  /** Policy-level auto-approve, consulted only when ringId is null. Absent means disabled. */
+  policyAutoApprove?: PolicyAutoApproveConfig;
+  /** Policy-level per-app block/pin rules. Applied to every job approval path. */
+  apps?: PolicyAppRule[];
 }
 
 export interface ApprovedPatch {
@@ -37,7 +60,7 @@ export interface ApprovedPatch {
   category: string | null;
   severity: string | null;
   requiresReboot: boolean;
-  approvalReason: 'manual' | 'category_rule' | 'legacy_auto_approve';
+  approvalReason: ApprovalReason;
 }
 
 // ============================================
@@ -84,6 +107,73 @@ export function isThirdPartyPatchSource(source: string | null | undefined): bool
 }
 
 // ============================================
+// Per-app rules (block / pin)
+// ============================================
+
+/**
+ * Tolerant version comparison for winget/homebrew-style versions, not strict
+ * semver. Splits on common separators; numeric segments compare numerically,
+ * non-numeric segments lexicographically, and missing segments count as 0.
+ */
+export function comparePatchVersions(
+  a: string | null | undefined,
+  b: string | null | undefined
+): number | null {
+  const av = (a ?? '').trim();
+  const bv = (b ?? '').trim();
+  if (!av || !bv) return null;
+
+  const as = av.split(/[.\-+_]/);
+  const bs = bv.split(/[.\-+_]/);
+  const len = Math.max(as.length, bs.length);
+
+  for (let i = 0; i < len; i++) {
+    const x = as[i] ?? '0';
+    const y = bs[i] ?? '0';
+    const xNum = /^\d+$/.test(x);
+    const yNum = /^\d+$/.test(y);
+
+    if (xNum && yNum) {
+      const diff = parseInt(x, 10) - parseInt(y, 10);
+      if (diff !== 0) return diff < 0 ? -1 : 1;
+      continue;
+    }
+
+    const cmp = x.localeCompare(y);
+    if (cmp !== 0) return cmp < 0 ? -1 : 1;
+  }
+
+  return 0;
+}
+
+/** Key app rules by source + lowercased packageId for O(1) candidate lookup. */
+export function buildAppRuleMap(apps: PolicyAppRule[] | undefined): Map<string, PolicyAppRule> {
+  const map = new Map<string, PolicyAppRule>();
+  for (const rule of apps ?? []) {
+    map.set(`${rule.source}|${rule.packageId.toLowerCase()}`, rule);
+  }
+  return map;
+}
+
+/**
+ * Verdict for one candidate patch against the policy's app rules.
+ * 'held' means a pin was exceeded, or the version cannot be proven within pin.
+ */
+export function evaluateAppRule(
+  patch: { source: string; packageId: string | null; version: string | null },
+  rules: Map<string, PolicyAppRule>
+): AppRuleVerdict {
+  if (rules.size === 0 || !patch.packageId) return 'allowed';
+  const rule = rules.get(`${patch.source}|${patch.packageId.toLowerCase()}`);
+  if (!rule) return 'allowed';
+  if (rule.action === 'block') return 'blocked';
+
+  const cmp = comparePatchVersions(patch.version, rule.pinnedVersion);
+  if (cmp === null) return 'held';
+  return cmp > 0 ? 'held' : 'allowed';
+}
+
+// ============================================
 // Main evaluator
 // ============================================
 
@@ -106,6 +196,8 @@ export async function resolveApprovedPatchesForDevice(
       releaseDate: patches.releaseDate,
       requiresReboot: patches.requiresReboot,
       source: patches.source,
+      packageId: patches.packageId,
+      version: patches.version,
     })
     .from(devicePatches)
     .innerJoin(patches, eq(devicePatches.patchId, patches.id))
@@ -131,8 +223,24 @@ export async function resolveApprovedPatchesForDevice(
     return [];
   }
 
+  const appRuleMap = buildAppRuleMap(ringConfig.apps);
+  const finalCandidates = appRuleMap.size > 0
+    ? candidatePatches.filter((p) => {
+        const verdict = evaluateAppRule(p, appRuleMap);
+        if (verdict !== 'allowed') {
+          console.warn(
+            `[PatchApproval] device ${deviceId}: patch ${p.patchId} (${p.source}/${p.packageId ?? '?'} v${p.version ?? '?'}) excluded by app rule (${verdict})`
+          );
+          return false;
+        }
+        return true;
+      })
+    : candidatePatches;
+
+  if (finalCandidates.length === 0) return [];
+
   // 2. Load manual approvals for this org (optionally scoped to ring)
-  const patchIds = candidatePatches.map((p) => p.patchId);
+  const patchIds = finalCandidates.map((p) => p.patchId);
   const manualApprovals = await db
     .select({
       patchId: patchApprovals.patchId,
@@ -172,7 +280,7 @@ export async function resolveApprovedPatchesForDevice(
   const now = new Date();
   const approved: ApprovedPatch[] = [];
 
-  for (const patch of candidatePatches) {
+  for (const patch of finalCandidates) {
     const reason = evaluatePatchApproval(
       patch,
       ringConfig,
@@ -209,7 +317,11 @@ interface PatchCandidate {
   severity: string | null;
   releaseDate: string | null;
   source: string;
+  packageId: string | null;
+  version: string | null;
 }
+
+type ApprovalReason = 'manual' | 'category_rule' | 'legacy_auto_approve' | 'policy_auto_approve';
 
 function evaluatePatchApproval(
   patch: PatchCandidate,
@@ -218,14 +330,26 @@ function evaluatePatchApproval(
   categoryRuleMap: Map<string, CategoryRule>,
   legacyAutoApprove: LegacyAutoApproveConfig,
   now: Date
-): 'manual' | 'category_rule' | 'legacy_auto_approve' | null {
+): ApprovalReason | null {
   // Priority 1: Manual approval
   if (manualApprovalSet.has(patch.patchId)) {
     return 'manual';
   }
 
-  // If no ring linked, only manual approvals count
+  // No ring linked: manual approvals plus policy-level auto-approve. Linked
+  // rings take absolute precedence, so policyAutoApprove is ignored above.
   if (!ringConfig.ringId) {
+    const pa = ringConfig.policyAutoApprove;
+    if (pa?.enabled && patch.severity && pa.severities.includes(patch.severity)) {
+      if (pa.deferralDays > 0 && patch.releaseDate) {
+        const releaseDate = new Date(patch.releaseDate);
+        const deferralEnd = new Date(releaseDate.getTime() + pa.deferralDays * 24 * 60 * 60 * 1000);
+        if (deferralEnd > now) {
+          return null;
+        }
+      }
+      return 'policy_auto_approve';
+    }
     return null;
   }
 

--- a/apps/api/src/services/patchJobSnapshot.test.ts
+++ b/apps/api/src/services/patchJobSnapshot.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { buildPatchesSnapshot, type PatchesSnapshotInput } from './patchJobSnapshot';
+
+function makePolicyLocal(overrides: {
+  settings?: Partial<PatchesSnapshotInput['settings']>;
+  ring?: Partial<PatchesSnapshotInput['ring']>;
+} = {}): PatchesSnapshotInput {
+  return {
+    settings: {
+      sources: ['os'],
+      autoApprove: false,
+      autoApproveSeverities: [],
+      autoApproveDeferralDays: 0,
+      apps: [],
+      ...overrides.settings,
+    },
+    ring: {
+      classification: 'valid_ring',
+      valid: true,
+      ringId: 'ring-1',
+      ringName: 'Pilot Ring',
+      categoryRules: [{ category: 'security', action: 'auto' }],
+      autoApprove: { security: true },
+      ...overrides.ring,
+    },
+  };
+}
+
+describe('buildPatchesSnapshot', () => {
+  it('maps every snapshot field from ring and settings', () => {
+    const snapshot = buildPatchesSnapshot(makePolicyLocal({
+      settings: {
+        sources: ['os', 'third_party'],
+        autoApprove: true,
+        autoApproveSeverities: ['critical', 'important'],
+        autoApproveDeferralDays: 7,
+        apps: [
+          { source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' },
+          { source: 'custom', packageId: 'corp-tool', action: 'pin', pinnedVersion: '1.2.3' },
+        ],
+      },
+    }));
+
+    expect(snapshot).toEqual({
+      ringId: 'ring-1',
+      ringName: 'Pilot Ring',
+      categoryRules: [{ category: 'security', action: 'auto' }],
+      autoApprove: { security: true },
+      sources: ['os', 'third_party'],
+      policyAutoApprove: {
+        enabled: true,
+        severities: ['critical', 'important'],
+        deferralDays: 7,
+      },
+      apps: [
+        { source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' },
+        { source: 'custom', packageId: 'corp-tool', action: 'pin', pinnedVersion: '1.2.3' },
+      ],
+      ringValidation: {
+        classification: 'valid_ring',
+        valid: true,
+      },
+    });
+  });
+
+  it('maps policyAutoApprove from settings.autoApprove/autoApproveSeverities/autoApproveDeferralDays', () => {
+    const snapshot = buildPatchesSnapshot(makePolicyLocal({
+      settings: {
+        autoApprove: true,
+        autoApproveSeverities: ['moderate'],
+        autoApproveDeferralDays: 14,
+      },
+    }));
+
+    expect(snapshot.policyAutoApprove).toEqual({
+      enabled: true,
+      severities: ['moderate'],
+      deferralDays: 14,
+    });
+  });
+
+  it('falls back to schema defaults for legacy settings missing auto-approve fields and apps', () => {
+    // Legacy stored settings predate these fields — the fallbacks mirror the
+    // patchInlineSettingsSchema defaults and are deliberate.
+    const snapshot = buildPatchesSnapshot({
+      settings: { sources: ['os'] },
+      ring: makePolicyLocal().ring,
+    });
+
+    expect(snapshot.policyAutoApprove).toEqual({
+      enabled: false,
+      severities: [],
+      deferralDays: 0,
+    });
+    expect(snapshot.apps).toEqual([]);
+  });
+
+  it('preserves null ring fields and invalid ring validation state', () => {
+    const snapshot = buildPatchesSnapshot(makePolicyLocal({
+      ring: {
+        classification: 'missing_target',
+        valid: false,
+        ringId: null,
+        ringName: null,
+        categoryRules: [],
+        autoApprove: false,
+      },
+    }));
+
+    expect(snapshot.ringId).toBeNull();
+    expect(snapshot.ringName).toBeNull();
+    expect(snapshot.categoryRules).toEqual([]);
+    expect(snapshot.autoApprove).toBe(false);
+    expect(snapshot.ringValidation).toEqual({
+      classification: 'missing_target',
+      valid: false,
+    });
+  });
+});

--- a/apps/api/src/services/patchJobSnapshot.ts
+++ b/apps/api/src/services/patchJobSnapshot.ts
@@ -1,0 +1,71 @@
+/**
+ * Patch Job Snapshot Builder
+ *
+ * Builds the `patches` JSONB snapshot stored on patch jobs created from
+ * configuration policies. Shared by the manual creation route
+ * (routes/configurationPolicies/patchJobs.ts) and the scheduler
+ * (jobs/patchSchedulerWorker.ts) so both production paths snapshot
+ * byte-identical policy state for the approval evaluator.
+ */
+
+import type {
+  PatchInlineSettings,
+  PatchRingResolution,
+} from './configPolicyPatching';
+
+/**
+ * The subset of a loaded policy-local patch config the snapshot reads.
+ *
+ * The auto-approve fields and `apps` are optional here (unlike the
+ * normalized `PatchInlineSettings`) because legacy rows stored before
+ * those fields existed may surface settings without them — the `?? false`
+ * / `?? []` / `?? 0` fallbacks mirror the schema defaults on purpose.
+ */
+export interface PatchesSnapshotInput {
+  settings: Pick<PatchInlineSettings, 'sources'> &
+    Partial<
+      Pick<
+        PatchInlineSettings,
+        'autoApprove' | 'autoApproveSeverities' | 'autoApproveDeferralDays' | 'apps'
+      >
+    >;
+  ring: PatchRingResolution;
+}
+
+export interface PatchesSnapshot {
+  ringId: string | null;
+  ringName: string | null;
+  categoryRules: Record<string, unknown>[];
+  autoApprove: Record<string, unknown> | boolean;
+  sources: PatchInlineSettings['sources'];
+  policyAutoApprove: {
+    enabled: boolean;
+    severities: PatchInlineSettings['autoApproveSeverities'];
+    deferralDays: number;
+  };
+  apps: PatchInlineSettings['apps'];
+  ringValidation: {
+    classification: PatchRingResolution['classification'];
+    valid: boolean;
+  };
+}
+
+export function buildPatchesSnapshot(policyLocal: PatchesSnapshotInput): PatchesSnapshot {
+  return {
+    ringId: policyLocal.ring.ringId,
+    ringName: policyLocal.ring.ringName,
+    categoryRules: policyLocal.ring.categoryRules,
+    autoApprove: policyLocal.ring.autoApprove,
+    sources: policyLocal.settings.sources,
+    policyAutoApprove: {
+      enabled: policyLocal.settings.autoApprove ?? false,
+      severities: policyLocal.settings.autoApproveSeverities ?? [],
+      deferralDays: policyLocal.settings.autoApproveDeferralDays ?? 0,
+    },
+    apps: policyLocal.settings.apps ?? [],
+    ringValidation: {
+      classification: policyLocal.ring.classification,
+      valid: policyLocal.ring.valid,
+    },
+  };
+}

--- a/apps/web/src/components/configurationPolicies/featureTabs/PatchAppRulesSection.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PatchAppRulesSection.test.tsx
@@ -29,7 +29,7 @@ describe('PatchAppRulesSection', () => {
     render(<PatchAppRulesSection apps={apps} onChange={() => {}} />);
 
     expect(screen.getByText('Firefox')).toBeTruthy();
-    expect(screen.getByTestId('app-rule-action-third_party-Mozilla.Firefox')).toHaveValue('block');
+    expect(screen.getByTestId('app-rule-action-third_party|mozilla.firefox')).toHaveValue('block');
     expect(screen.getByDisplayValue('3.0.20')).toBeTruthy();
   });
 
@@ -48,6 +48,33 @@ describe('PatchAppRulesSection', () => {
     ]);
   });
 
+  it('disables custom and third_party duplicates as the same app-rule bucket', async () => {
+    const onChange = vi.fn();
+    fetchWithAuthMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { source: 'custom', packageId: 'Mozilla.Firefox', vendor: 'Mozilla', displayName: 'Firefox custom', inCatalog: false },
+        ],
+      }),
+    });
+
+    render(
+      <PatchAppRulesSection
+        apps={[{ source: 'third_party', packageId: 'mozilla.firefox', action: 'block' }]}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('app-rules-add'));
+    fireEvent.change(screen.getByTestId('app-rules-search'), { target: { value: 'fire' } });
+
+    const option = await screen.findByTestId('app-option-custom-Mozilla.Firefox');
+    expect(option).toBeDisabled();
+    fireEvent.click(option);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it('removes a rule', () => {
     const onChange = vi.fn();
     render(
@@ -57,7 +84,7 @@ describe('PatchAppRulesSection', () => {
       />
     );
 
-    fireEvent.click(screen.getByTestId('app-rule-remove-third_party-Mozilla.Firefox'));
+    fireEvent.click(screen.getByTestId('app-rule-remove-third_party|mozilla.firefox'));
 
     expect(onChange).toHaveBeenCalledWith([]);
   });
@@ -71,12 +98,75 @@ describe('PatchAppRulesSection', () => {
       />
     );
 
-    fireEvent.change(screen.getByTestId('app-rule-pin-version-third_party-VideoLAN.VLC'), {
+    fireEvent.change(screen.getByTestId('app-rule-pin-version-third_party|videolan.vlc'), {
       target: { value: '3.0.20' },
     });
 
     expect(onChange).toHaveBeenCalledWith([
       expect.objectContaining({ action: 'pin', pinnedVersion: '3.0.20' }),
     ]);
+  });
+
+  it('uses source|lowercased-packageId identity so similar ids do not collide', () => {
+    const onChange = vi.fn();
+    const apps: PolicyAppRule[] = [
+      // Under the old `${source}-${packageId}` scheme both rules keyed to 'third-party_Foo-Bar'-style collisions.
+      { source: 'third_party', packageId: 'Foo-Bar', action: 'block' },
+      { source: 'third_party-Foo', packageId: 'Bar', action: 'block' },
+    ];
+    render(<PatchAppRulesSection apps={apps} onChange={onChange} />);
+
+    fireEvent.click(screen.getByTestId('app-rule-remove-third_party|foo-bar'));
+
+    expect(onChange).toHaveBeenCalledWith([apps[1]]);
+  });
+
+  it('shows a load error and clears stale options when the fetch returns non-OK', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(<PatchAppRulesSection apps={[]} onChange={() => {}} />);
+
+    fireEvent.click(screen.getByTestId('app-rules-add'));
+    fireEvent.change(screen.getByTestId('app-rules-search'), { target: { value: 'fire' } });
+    await screen.findByTestId('app-option-third_party-Mozilla.Firefox');
+
+    fetchWithAuthMock.mockResolvedValue({ ok: false, status: 500 });
+    fireEvent.change(screen.getByTestId('app-rules-search'), { target: { value: 'firefox' } });
+
+    const error = await screen.findByTestId('app-rules-load-error');
+    expect(error.textContent).toMatch(/couldn't load applications/i);
+    expect(screen.queryByTestId('app-option-third_party-Mozilla.Firefox')).toBeNull();
+    expect(screen.queryByText('No matches.')).toBeNull();
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('shows the load error instead of "No matches." when the fetch rejects', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    fetchWithAuthMock.mockRejectedValue(new Error('network down'));
+    render(<PatchAppRulesSection apps={[]} onChange={() => {}} />);
+
+    fireEvent.click(screen.getByTestId('app-rules-add'));
+    fireEvent.change(screen.getByTestId('app-rules-search'), { target: { value: 'fire' } });
+
+    const error = await screen.findByTestId('app-rules-load-error');
+    expect(error.textContent).toMatch(/couldn't load applications/i);
+    expect(screen.queryByText('No matches.')).toBeNull();
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('recovers from a load error once a fetch succeeds again', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    fetchWithAuthMock.mockResolvedValueOnce({ ok: false, status: 500 });
+    render(<PatchAppRulesSection apps={[]} onChange={() => {}} />);
+
+    fireEvent.click(screen.getByTestId('app-rules-add'));
+    fireEvent.change(screen.getByTestId('app-rules-search'), { target: { value: 'fire' } });
+    await screen.findByTestId('app-rules-load-error');
+
+    fireEvent.change(screen.getByTestId('app-rules-search'), { target: { value: 'firefox' } });
+    await screen.findByTestId('app-option-third_party-Mozilla.Firefox');
+    expect(screen.queryByTestId('app-rules-load-error')).toBeNull();
+    consoleSpy.mockRestore();
   });
 });

--- a/apps/web/src/components/configurationPolicies/featureTabs/PatchAppRulesSection.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PatchAppRulesSection.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchWithAuthMock = vi.fn();
+
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: (...args: unknown[]) => fetchWithAuthMock(...args),
+}));
+
+import PatchAppRulesSection, { type PolicyAppRule } from './PatchAppRulesSection';
+
+const options = [
+  { source: 'third_party', packageId: 'Mozilla.Firefox', vendor: 'Mozilla', displayName: 'Firefox', inCatalog: true },
+  { source: 'third_party', packageId: 'VideoLAN.VLC', vendor: 'VideoLAN', displayName: 'VLC', inCatalog: false },
+];
+
+describe('PatchAppRulesSection', () => {
+  beforeEach(() => {
+    fetchWithAuthMock.mockReset();
+    fetchWithAuthMock.mockResolvedValue({ ok: true, json: async () => ({ data: options }) });
+  });
+
+  it('renders existing rules with action and pinned version', () => {
+    const apps: PolicyAppRule[] = [
+      { source: 'third_party', packageId: 'Mozilla.Firefox', displayName: 'Firefox', action: 'block' },
+      { source: 'third_party', packageId: 'VideoLAN.VLC', displayName: 'VLC', action: 'pin', pinnedVersion: '3.0.20' },
+    ];
+
+    render(<PatchAppRulesSection apps={apps} onChange={() => {}} />);
+
+    expect(screen.getByText('Firefox')).toBeTruthy();
+    expect(screen.getByTestId('app-rule-action-third_party-Mozilla.Firefox')).toHaveValue('block');
+    expect(screen.getByDisplayValue('3.0.20')).toBeTruthy();
+  });
+
+  it('adds a block rule from picker search results', async () => {
+    const onChange = vi.fn();
+    render(<PatchAppRulesSection apps={[]} onChange={onChange} />);
+
+    fireEvent.click(screen.getByTestId('app-rules-add'));
+    fireEvent.change(screen.getByTestId('app-rules-search'), { target: { value: 'fire' } });
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalled());
+    fireEvent.click(await screen.findByTestId('app-option-third_party-Mozilla.Firefox'));
+
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({ source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' }),
+    ]);
+  });
+
+  it('removes a rule', () => {
+    const onChange = vi.fn();
+    render(
+      <PatchAppRulesSection
+        apps={[{ source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' }]}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('app-rule-remove-third_party-Mozilla.Firefox'));
+
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it('switches a rule to pin and sets the version', () => {
+    const onChange = vi.fn();
+    render(
+      <PatchAppRulesSection
+        apps={[{ source: 'third_party', packageId: 'VideoLAN.VLC', action: 'pin', pinnedVersion: '' }]}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.change(screen.getByTestId('app-rule-pin-version-third_party-VideoLAN.VLC'), {
+      target: { value: '3.0.20' },
+    });
+
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({ action: 'pin', pinnedVersion: '3.0.20' }),
+    ]);
+  });
+});

--- a/apps/web/src/components/configurationPolicies/featureTabs/PatchAppRulesSection.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PatchAppRulesSection.tsx
@@ -25,13 +25,20 @@ type Props = {
   onChange: (apps: PolicyAppRule[]) => void;
 };
 
-const ruleKey = (rule: { source: string; packageId: string }) => `${rule.source}-${rule.packageId}`;
+// Canonical rule identity used everywhere else in the patch pipeline. The
+// evaluator treats third_party and custom as one bucket, so the UI must dedupe
+// them the same way before validation.
+const ruleKey = (rule: { source: string; packageId: string }) => {
+  const source = rule.source === 'custom' ? 'third_party' : rule.source;
+  return `${source}|${rule.packageId.toLowerCase()}`;
+};
 
 export default function PatchAppRulesSection({ apps, onChange }: Props) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [search, setSearch] = useState('');
   const [options, setOptions] = useState<AppOption[]>([]);
   const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState(false);
   const [manualPackageId, setManualPackageId] = useState('');
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -46,9 +53,16 @@ export default function PatchAppRulesSection({ apps, onChange }: Props) {
         if (response.ok) {
           const payload = await response.json();
           setOptions(Array.isArray(payload.data) ? payload.data : []);
+          setLoadError(false);
+        } else {
+          console.error('Failed to load application options: HTTP', response.status);
+          setOptions([]);
+          setLoadError(true);
         }
-      } catch {
+      } catch (err) {
+        console.error('Failed to load application options:', err);
         setOptions([]);
+        setLoadError(true);
       } finally {
         setLoading(false);
       }
@@ -60,7 +74,7 @@ export default function PatchAppRulesSection({ apps, onChange }: Props) {
   }, [pickerOpen, search]);
 
   const exists = (source: string, packageId: string) =>
-    apps.some((app) => app.source === source && app.packageId.toLowerCase() === packageId.toLowerCase());
+    apps.some((app) => ruleKey(app) === ruleKey({ source, packageId }));
 
   const addRule = (option: { source: string; packageId: string; displayName?: string }) => {
     if (exists(option.source, option.packageId)) return;
@@ -181,7 +195,12 @@ export default function PatchAppRulesSection({ apps, onChange }: Props) {
                   </button>
                 </li>
               ))}
-            {!loading && options.length === 0 && (
+            {!loading && loadError && (
+              <li className="text-xs text-destructive" data-testid="app-rules-load-error">
+                {"Couldn't load applications — you can still add by package ID below."}
+              </li>
+            )}
+            {!loading && !loadError && options.length === 0 && (
               <li className="text-xs text-muted-foreground">No matches.</li>
             )}
           </ul>
@@ -198,6 +217,7 @@ export default function PatchAppRulesSection({ apps, onChange }: Props) {
               type="button"
               data-testid="app-rules-manual-add"
               disabled={!manualPackageId.trim()}
+              // Manual entries use 'third_party'; the evaluator matches third_party/custom as one bucket, so custom-source patches are still covered.
               onClick={() => addRule({ source: 'third_party', packageId: manualPackageId.trim() })}
               className="h-8 rounded-md border px-3 text-xs hover:bg-muted disabled:opacity-50"
             >

--- a/apps/web/src/components/configurationPolicies/featureTabs/PatchAppRulesSection.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PatchAppRulesSection.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useRef, useState } from 'react';
+import { Plus, X } from 'lucide-react';
+import { fetchWithAuth } from '../../../stores/auth';
+
+export type PolicyAppAction = 'block' | 'pin';
+
+export type PolicyAppRule = {
+  source: string;
+  packageId: string;
+  displayName?: string;
+  action: PolicyAppAction;
+  pinnedVersion?: string;
+};
+
+type AppOption = {
+  source: string;
+  packageId: string;
+  vendor: string | null;
+  displayName: string;
+  inCatalog: boolean;
+};
+
+type Props = {
+  apps: PolicyAppRule[];
+  onChange: (apps: PolicyAppRule[]) => void;
+};
+
+const ruleKey = (rule: { source: string; packageId: string }) => `${rule.source}-${rule.packageId}`;
+
+export default function PatchAppRulesSection({ apps, onChange }: Props) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [options, setOptions] = useState<AppOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [manualPackageId, setManualPackageId] = useState('');
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!pickerOpen) return undefined;
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const response = await fetchWithAuth(`/patches/app-options?search=${encodeURIComponent(search)}`);
+        if (response.ok) {
+          const payload = await response.json();
+          setOptions(Array.isArray(payload.data) ? payload.data : []);
+        }
+      } catch {
+        setOptions([]);
+      } finally {
+        setLoading(false);
+      }
+    }, 200);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [pickerOpen, search]);
+
+  const exists = (source: string, packageId: string) =>
+    apps.some((app) => app.source === source && app.packageId.toLowerCase() === packageId.toLowerCase());
+
+  const addRule = (option: { source: string; packageId: string; displayName?: string }) => {
+    if (exists(option.source, option.packageId)) return;
+    onChange([
+      ...apps,
+      {
+        source: option.source,
+        packageId: option.packageId,
+        displayName: option.displayName,
+        action: 'block',
+      },
+    ]);
+    setPickerOpen(false);
+    setSearch('');
+    setManualPackageId('');
+  };
+
+  const updateRule = (key: string, patch: Partial<PolicyAppRule>) =>
+    onChange(apps.map((app) => (ruleKey(app) === key ? { ...app, ...patch } : app)));
+
+  const removeRule = (key: string) => onChange(apps.filter((app) => ruleKey(app) !== key));
+
+  return (
+    <div className="mt-6">
+      <h3 className="text-sm font-semibold">Application Rules</h3>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Block specific applications from automated patching, or pin them to a maximum version.
+      </p>
+
+      {apps.length > 0 && (
+        <ul className="mt-2 space-y-2">
+          {apps.map((rule) => {
+            const key = ruleKey(rule);
+            return (
+              <li key={key} className="flex flex-wrap items-center gap-2 rounded-md border p-2 text-sm">
+                <span className="font-medium">{rule.displayName ?? rule.packageId}</span>
+                <span className="text-xs text-muted-foreground">{rule.packageId}</span>
+                <select
+                  value={rule.action}
+                  data-testid={`app-rule-action-${key}`}
+                  onChange={(event) =>
+                    updateRule(key, {
+                      action: event.target.value as PolicyAppAction,
+                      pinnedVersion: event.target.value === 'block' ? undefined : rule.pinnedVersion ?? '',
+                    })
+                  }
+                  className="ml-auto h-8 rounded-md border bg-background px-2 text-xs"
+                >
+                  <option value="block">Blocked</option>
+                  <option value="pin">Pinned</option>
+                </select>
+                {rule.action === 'pin' && (
+                  <input
+                    type="text"
+                    placeholder="Max version"
+                    value={rule.pinnedVersion ?? ''}
+                    data-testid={`app-rule-pin-version-${key}`}
+                    onChange={(event) => updateRule(key, { pinnedVersion: event.target.value })}
+                    className="h-8 w-28 rounded-md border bg-background px-2 text-xs"
+                  />
+                )}
+                <button
+                  type="button"
+                  aria-label={`Remove rule for ${rule.displayName ?? rule.packageId}`}
+                  data-testid={`app-rule-remove-${key}`}
+                  onClick={() => removeRule(key)}
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {apps.some((app) => app.action === 'pin' && !app.pinnedVersion) && (
+        <p className="mt-1 text-xs text-destructive">Pinned applications need a version.</p>
+      )}
+
+      {!pickerOpen ? (
+        <button
+          type="button"
+          data-testid="app-rules-add"
+          onClick={() => setPickerOpen(true)}
+          className="mt-2 inline-flex items-center gap-1 rounded-md border px-3 py-1.5 text-xs hover:bg-muted"
+        >
+          <Plus className="h-3.5 w-3.5" /> Add application
+        </button>
+      ) : (
+        <div className="mt-2 rounded-md border p-3">
+          <input
+            type="text"
+            placeholder="Search catalog and detected applications..."
+            value={search}
+            data-testid="app-rules-search"
+            onChange={(event) => setSearch(event.target.value)}
+            className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+            autoFocus
+          />
+          <ul className="mt-2 max-h-48 space-y-1 overflow-y-auto">
+            {loading && <li className="text-xs text-muted-foreground">Searching...</li>}
+            {!loading &&
+              options.map((option) => (
+                <li key={`${option.source}|${option.packageId}`}>
+                  <button
+                    type="button"
+                    data-testid={`app-option-${option.source}-${option.packageId}`}
+                    disabled={exists(option.source, option.packageId)}
+                    onClick={() => addRule(option)}
+                    className="flex w-full items-center gap-2 rounded px-2 py-1 text-left text-sm hover:bg-muted disabled:opacity-50"
+                  >
+                    <span>{option.displayName}</span>
+                    <span className="text-xs text-muted-foreground">{option.vendor ?? option.packageId}</span>
+                    {option.inCatalog && (
+                      <span className="ml-auto text-[10px] uppercase text-muted-foreground">catalog</span>
+                    )}
+                  </button>
+                </li>
+              ))}
+            {!loading && options.length === 0 && (
+              <li className="text-xs text-muted-foreground">No matches.</li>
+            )}
+          </ul>
+          <div className="mt-2 flex items-center gap-2 border-t pt-2">
+            <input
+              type="text"
+              placeholder="Or enter a package ID manually"
+              value={manualPackageId}
+              data-testid="app-rules-manual-id"
+              onChange={(event) => setManualPackageId(event.target.value)}
+              className="h-8 flex-1 rounded-md border bg-background px-2 text-xs"
+            />
+            <button
+              type="button"
+              data-testid="app-rules-manual-add"
+              disabled={!manualPackageId.trim()}
+              onClick={() => addRule({ source: 'third_party', packageId: manualPackageId.trim() })}
+              className="h-8 rounded-md border px-3 text-xs hover:bg-muted disabled:opacity-50"
+            >
+              Add
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setPickerOpen(false);
+                setSearch('');
+              }}
+              className="h-8 rounded-md px-2 text-xs text-muted-foreground hover:text-foreground"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.test.tsx
@@ -132,4 +132,64 @@ describe('PatchTab patch sources', () => {
     expect(payload.inlineSettings.autoApprove).toBe(true);
     expect(payload.inlineSettings.autoApproveSeverities).toEqual(['critical']);
   });
+
+  it('includes wired auto-approve fields and apps in the save payload', async () => {
+    render(<PatchTab {...baseProps} />);
+
+    fireEvent.click(await screen.findByTestId('auto-approve-toggle'));
+    fireEvent.click(screen.getByTestId('auto-approve-severity-critical'));
+    fireEvent.change(screen.getByTestId('auto-approve-deferral'), { target: { value: '3' } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    const [, payload] = saveMock.mock.calls[0];
+    expect(payload.inlineSettings).toMatchObject({
+      autoApprove: true,
+      autoApproveSeverities: ['critical'],
+      autoApproveDeferralDays: 3,
+      apps: [],
+    });
+  });
+
+  it('disables the auto-approve section and shows the ring-precedence notice when a ring is linked', async () => {
+    render(
+      <PatchTab
+        {...baseProps}
+        existingLink={{
+          id: 'link-1',
+          featureType: 'patch',
+          featurePolicyId: 'ring-1',
+          inlineSettings: { sources: ['os'], autoApprove: true, autoApproveSeverities: ['critical'] },
+        }}
+      />
+    );
+
+    expect(await screen.findByTestId('auto-approve-ring-notice')).toHaveTextContent(/governed by the linked update ring/i);
+    expect(screen.getByTestId('auto-approve-toggle')).toBeDisabled();
+  });
+
+  it('hydrates auto-approve fields and apps from existing inline settings', async () => {
+    render(
+      <PatchTab
+        {...baseProps}
+        existingLink={{
+          id: 'link-1',
+          featureType: 'patch',
+          featurePolicyId: null,
+          inlineSettings: {
+            sources: ['third_party'],
+            autoApprove: true,
+            autoApproveSeverities: ['important'],
+            autoApproveDeferralDays: 7,
+            apps: [{ source: 'third_party', packageId: 'A.B', action: 'block' }],
+          },
+        }}
+      />
+    );
+
+    expect(await screen.findByTestId('auto-approve-toggle')).toBeChecked();
+    expect(screen.getByTestId('auto-approve-severity-important')).toBeChecked();
+    expect(screen.getByTestId('auto-approve-deferral')).toHaveValue(7);
+    expect(screen.getAllByText('A.B').length).toBeGreaterThan(0);
+  });
 });

--- a/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.test.tsx
@@ -192,4 +192,102 @@ describe('PatchTab patch sources', () => {
     expect(screen.getByTestId('auto-approve-deferral')).toHaveValue(7);
     expect(screen.getAllByText('A.B').length).toBeGreaterThan(0);
   });
+
+  it('blocks save when auto-approve is on with no severities and no ring, then proceeds once fixed', async () => {
+    render(<PatchTab {...baseProps} />);
+
+    fireEvent.click(await screen.findByTestId('auto-approve-toggle'));
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(saveMock).not.toHaveBeenCalled();
+    // Inline hint plus the error banner surfaced through the shell's error path.
+    expect(screen.getAllByText('Select at least one severity for auto-approval.').length).toBe(2);
+
+    fireEvent.click(screen.getByTestId('auto-approve-severity-critical'));
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+  });
+
+  it('blocks save when a pinned app rule has no version, then proceeds once fixed', async () => {
+    render(
+      <PatchTab
+        {...baseProps}
+        existingLink={{
+          id: 'link-1',
+          featureType: 'patch',
+          featurePolicyId: null,
+          inlineSettings: {
+            sources: ['os'],
+            apps: [{ source: 'third_party', packageId: 'A.B', action: 'pin', pinnedVersion: '' }],
+          },
+        }}
+      />
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /save/i }));
+
+    expect(saveMock).not.toHaveBeenCalled();
+    // Inline hint from the app-rules section plus the error banner.
+    expect(screen.getAllByText('Pinned applications need a version.').length).toBe(2);
+
+    fireEvent.change(screen.getByTestId('app-rule-pin-version-third_party|a.b'), {
+      target: { value: '1.2.3' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+  });
+
+  it('blocks override when inherited settings fail validation', async () => {
+    render(
+      <PatchTab
+        {...baseProps}
+        parentLink={{
+          id: 'parent-link-1',
+          featureType: 'patch',
+          featurePolicyId: null,
+          inlineSettings: { sources: ['os'], autoApprove: true, autoApproveSeverities: [] },
+        }}
+      />
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /override/i }));
+
+    expect(saveMock).not.toHaveBeenCalled();
+    expect(screen.getAllByText('Select at least one severity for auto-approval.').length).toBeGreaterThan(0);
+  });
+
+  it('shows the dormant auto-approve note when a ring is linked and stored autoApprove is true', async () => {
+    render(
+      <PatchTab
+        {...baseProps}
+        existingLink={{
+          id: 'link-1',
+          featureType: 'patch',
+          featurePolicyId: 'ring-1',
+          inlineSettings: { sources: ['os'], autoApprove: true, autoApproveSeverities: ['critical'] },
+        }}
+      />
+    );
+
+    expect(await screen.findByTestId('auto-approve-dormant-note')).toHaveTextContent(
+      /inactive while a ring is linked/i
+    );
+  });
+
+  it('does not show the dormant note when a ring is linked but autoApprove is off', async () => {
+    render(
+      <PatchTab
+        {...baseProps}
+        existingLink={{
+          id: 'link-1',
+          featureType: 'patch',
+          featurePolicyId: 'ring-1',
+          inlineSettings: { sources: ['os'], autoApprove: false, autoApproveSeverities: [] },
+        }}
+      />
+    );
+
+    expect(await screen.findByTestId('auto-approve-ring-notice')).toBeInTheDocument();
+    expect(screen.queryByTestId('auto-approve-dormant-note')).toBeNull();
+  });
 });

--- a/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.tsx
@@ -6,13 +6,19 @@ import { FEATURE_META } from './types';
 import { useFeatureLink } from './useFeatureLink';
 import FeatureTabShell from './FeatureTabShell';
 import { fetchWithAuth } from '../../../stores/auth';
+import PatchAppRulesSection, { type PolicyAppRule } from './PatchAppRulesSection';
 
 type ScheduleFrequency = 'daily' | 'weekly' | 'monthly';
 type RebootPolicy = 'never' | 'if_required' | 'always' | 'maintenance_window';
 type PatchSourceOption = 'os' | 'third_party';
+type PatchSeverity = 'critical' | 'important' | 'moderate' | 'low';
 
 type PatchDeploymentSettings = {
   sources: PatchSourceOption[];
+  autoApprove: boolean;
+  autoApproveSeverities: PatchSeverity[];
+  autoApproveDeferralDays: number;
+  apps: PolicyAppRule[];
   scheduleFrequency: ScheduleFrequency;
   scheduleTime: string;
   scheduleDayOfWeek: string;
@@ -32,6 +38,10 @@ type UpdateRing = {
 
 const defaults: PatchDeploymentSettings = {
   sources: ['os'],
+  autoApprove: false,
+  autoApproveSeverities: [],
+  autoApproveDeferralDays: 0,
+  apps: [],
   scheduleFrequency: 'weekly',
   scheduleTime: '02:00',
   scheduleDayOfWeek: 'sun',
@@ -42,6 +52,13 @@ const defaults: PatchDeploymentSettings = {
 const sourceOptions: { value: PatchSourceOption; label: string; description: string }[] = [
   { value: 'os', label: 'OS updates', description: 'Windows Update, macOS software updates, and Linux package updates.' },
   { value: 'third_party', label: 'Third-party applications', description: 'Application updates via winget, Chocolatey, and Homebrew.' },
+];
+
+const severityOptions: { value: PatchSeverity; label: string }[] = [
+  { value: 'critical', label: 'Critical' },
+  { value: 'important', label: 'Important' },
+  { value: 'moderate', label: 'Moderate' },
+  { value: 'low', label: 'Low' },
 ];
 
 const OS_VALUE_ALIASES = new Set(['os', 'microsoft', 'apple', 'linux']);
@@ -257,6 +274,74 @@ export default function PatchTab({ policyId, existingLink, onLinkChanged, linked
           </div>
         )}
       </div>
+
+      {/* Automatic Approval */}
+      <div className="mt-6">
+        <h3 className="text-sm font-semibold">Automatic Approval</h3>
+        {selectedRingId ? (
+          <p className="mt-1 text-xs text-muted-foreground" data-testid="auto-approve-ring-notice">
+            Automatic approval is governed by the linked update ring
+            {selectedRing ? ` "${selectedRing.name}"` : ''}. These settings apply only when no ring is linked.
+          </p>
+        ) : (
+          <p className="mt-1 text-xs text-muted-foreground">
+            Automatically approve patches by severity when no update ring is linked.
+          </p>
+        )}
+        <label className="mt-2 flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            data-testid="auto-approve-toggle"
+            checked={settings.autoApprove}
+            disabled={!!selectedRingId}
+            onChange={(event) => update('autoApprove', event.target.checked)}
+          />
+          Enable automatic approval
+        </label>
+        {settings.autoApprove && !selectedRingId && (
+          <div className="mt-2 space-y-2">
+            <div className="flex flex-wrap gap-3">
+              {severityOptions.map((option) => (
+                <label key={option.value} className="flex items-center gap-1.5 text-sm">
+                  <input
+                    type="checkbox"
+                    data-testid={`auto-approve-severity-${option.value}`}
+                    checked={settings.autoApproveSeverities.includes(option.value)}
+                    onChange={() =>
+                      update(
+                        'autoApproveSeverities',
+                        settings.autoApproveSeverities.includes(option.value)
+                          ? settings.autoApproveSeverities.filter((severity) => severity !== option.value)
+                          : [...settings.autoApproveSeverities, option.value]
+                      )
+                    }
+                  />
+                  {option.label}
+                </label>
+              ))}
+            </div>
+            {settings.autoApproveSeverities.length === 0 && (
+              <p className="text-xs text-destructive">Select at least one severity for auto-approval.</p>
+            )}
+            <div>
+              <label className="text-xs text-muted-foreground">Deferral (days after release)</label>
+              <input
+                type="number"
+                min={0}
+                max={60}
+                data-testid="auto-approve-deferral"
+                value={settings.autoApproveDeferralDays}
+                onChange={(event) =>
+                  update('autoApproveDeferralDays', Math.max(0, Math.min(60, Number(event.target.value) || 0)))
+                }
+                className="mt-1 h-9 w-28 rounded-md border bg-background px-2 text-sm"
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      <PatchAppRulesSection apps={settings.apps} onChange={(apps) => update('apps', apps)} />
 
       {/* Schedule */}
       <div className="mt-6">

--- a/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.tsx
@@ -110,6 +110,7 @@ export default function PatchTab({ policyId, existingLink, onLinkChanged, linked
     const inline = effectiveLink?.inlineSettings as Partial<PatchDeploymentSettings> | undefined;
     return { ...defaults, ...inline, sources: normalizeSources(inline?.sources) };
   });
+  const [validationError, setValidationError] = useState<string>();
 
   const fetchRings = useCallback(async () => {
     setRingsLoading(true);
@@ -155,8 +156,23 @@ export default function PatchTab({ policyId, existingLink, onLinkChanged, linked
     });
   };
 
+  // Client-side mirror of the server-side Zod checks so users get inline
+  // feedback instead of a round-trip rejection.
+  const validateSettings = (): string | null => {
+    if (!selectedRingId && settings.autoApprove && settings.autoApproveSeverities.length === 0) {
+      return 'Select at least one severity for auto-approval.';
+    }
+    if (settings.apps.some((app) => app.action === 'pin' && !app.pinnedVersion?.trim())) {
+      return 'Pinned applications need a version.';
+    }
+    return null;
+  };
+
   const handleSave = async () => {
     clearError();
+    const validation = validateSettings();
+    setValidationError(validation ?? undefined);
+    if (validation) return;
     const result = await save(existingLink?.id ?? null, {
       featureType: 'patch',
       featurePolicyId: selectedRingId || null,
@@ -173,6 +189,9 @@ export default function PatchTab({ policyId, existingLink, onLinkChanged, linked
 
   const handleOverride = async () => {
     clearError();
+    const validation = validateSettings();
+    setValidationError(validation ?? undefined);
+    if (validation) return;
     const result = await save(null, {
       featureType: 'patch',
       featurePolicyId: selectedRingId || null,
@@ -197,7 +216,7 @@ export default function PatchTab({ policyId, existingLink, onLinkChanged, linked
       icon={<PackageCheck className="h-5 w-5" />}
       isConfigured={!!existingLink || isInherited}
       saving={saving}
-      error={error}
+      error={validationError ?? error}
       onSave={handleSave}
       onRemove={existingLink && !linkedPolicyId ? handleRemove : undefined}
       isInherited={isInherited}
@@ -298,6 +317,12 @@ export default function PatchTab({ policyId, existingLink, onLinkChanged, linked
           />
           Enable automatic approval
         </label>
+        {/* Spec: policy auto-approval fields are ignored (not cleared) while a ring is linked. */}
+        {!!selectedRingId && settings.autoApprove && (
+          <p className="mt-1 text-xs text-muted-foreground" data-testid="auto-approve-dormant-note">
+            Saved automatic-approval settings are inactive while a ring is linked.
+          </p>
+        )}
         {settings.autoApprove && !selectedRingId && (
           <div className="mt-2 space-y-2">
             <div className="flex flex-wrap gap-3">

--- a/apps/web/src/lib/apiError.test.ts
+++ b/apps/web/src/lib/apiError.test.ts
@@ -96,6 +96,47 @@ describe('extractApiError', () => {
   });
 });
 
+describe('extractApiError — zod flatten() details shapes', () => {
+  it('renders fieldErrors from a flatten() details payload', () => {
+    const body = {
+      error: 'Invalid patch settings',
+      details: {
+        formErrors: [],
+        fieldErrors: { apps: ['Duplicate application rule (source + packageId must be unique)'] },
+      },
+    };
+    expect(extractApiError(body, 'fb')).toBe(
+      'Invalid patch settings: apps: Duplicate application rule (source + packageId must be unique)'
+    );
+  });
+
+  it('renders formErrors from a flatten() details payload', () => {
+    const body = { details: { formErrors: ['Too many application rules (max 200)'], fieldErrors: {} } };
+    expect(extractApiError(body, 'fb')).toBe('Too many application rules (max 200)');
+  });
+
+  it('combines formErrors and multiple fieldErrors', () => {
+    const body = {
+      details: {
+        formErrors: ['top-level problem'],
+        fieldErrors: { apps: ['bad rule'], autoApproveSeverities: ['pick one', 'invalid value'] },
+      },
+    };
+    expect(extractApiError(body, 'fb')).toBe(
+      'top-level problem; apps: bad rule; autoApproveSeverities: pick one; invalid value'
+    );
+  });
+
+  it('falls back when the flatten() payload carries no messages', () => {
+    expect(extractApiError({ details: { formErrors: [], fieldErrors: {} } }, 'fb')).toBe('fb');
+  });
+
+  it('prefers issues-style details over flatten when details is an issues array (regression)', () => {
+    const body = { error: 'Validation failed', details: [{ message: 'name is required' }] };
+    expect(extractApiError(body, 'fb')).toBe('Validation failed: name is required');
+  });
+});
+
 describe('isApiFailure', () => {
   it('true when http status >= 400', () => {
     expect(isApiFailure({}, 400)).toBe(true);

--- a/apps/web/src/lib/apiError.ts
+++ b/apps/web/src/lib/apiError.ts
@@ -19,10 +19,34 @@ function joinZodIssues(issues: unknown): string | null {
   return messages.length > 0 ? messages.join('; ') : null;
 }
 
+// Renders a zod `error.flatten()` payload ({formErrors: string[], fieldErrors:
+// Record<string, string[]>}) — emitted as `details` by some route validators
+// (e.g. configuration-policy feature links).
+function joinZodFlatten(value: unknown): string | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const { formErrors, fieldErrors } = value as { formErrors?: unknown; fieldErrors?: unknown };
+  const parts: string[] = [];
+  if (Array.isArray(formErrors)) {
+    for (const m of formErrors) {
+      if (typeof m === 'string' && m.length > 0) parts.push(m);
+    }
+  }
+  if (fieldErrors && typeof fieldErrors === 'object' && !Array.isArray(fieldErrors)) {
+    for (const [field, messages] of Object.entries(fieldErrors as Record<string, unknown>)) {
+      if (!Array.isArray(messages)) continue;
+      const valid = messages.filter((m): m is string => typeof m === 'string' && m.length > 0);
+      if (valid.length > 0) parts.push(`${field}: ${valid.join('; ')}`);
+    }
+  }
+  return parts.length > 0 ? parts.join('; ') : null;
+}
+
 function detailsToString(details: unknown): string | null {
   if (typeof details === 'string' && details.length > 0) return details;
   const fromIssues = joinZodIssues(details);
   if (fromIssues) return fromIssues;
+  const fromFlatten = joinZodFlatten(details);
+  if (fromFlatten) return fromFlatten;
   return null;
 }
 

--- a/docs/superpowers/plans/2026-06-11-patch-policy-auto-approve-and-app-rules.md
+++ b/docs/superpowers/plans/2026-06-11-patch-policy-auto-approve-and-app-rules.md
@@ -1,0 +1,1468 @@
+# Patch Policy Auto-Approve Wiring + Per-App Rules Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire policy-level auto-approve for ring-less config policies (linked ring takes absolute precedence) and add per-app block/pin rules with a catalog-backed picker to the policy Patch tab.
+
+**Architecture:** Everything flows through the path `sources` took in PR #1269: `patchInlineSettingsSchema` (shared Zod) → job-creation snapshot into `patch_jobs.patches` JSONB (`routes/configurationPolicies/patchJobs.ts`, `jobs/patchSchedulerWorker.ts`) → executor parse with fail-closed malformed handling (`jobs/patchJobExecutor.ts`) → evaluator (`services/patchApprovalEvaluator.ts`). App rules filter all approval paths (including manual) in the job flow; policy auto-approve only fires when `ringId` is null. A new `GET /patches/app-options` endpoint merges the curated `third_party_package_catalog` with observed third-party patches for the picker UI. No migrations, no RLS changes, no agent changes.
+
+**Tech Stack:** TypeScript, Zod, Hono, Drizzle (mocked in unit tests), Vitest, React (jsdom + testing-library).
+
+**Spec:** `docs/superpowers/specs/2026-06-11-patch-policy-auto-approve-and-app-rules-design.md`
+
+**Environment note:** Run all pnpm/vitest commands with the pinned node: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH`. Run single test files (the full local suite has known pre-existing parallel flakiness; CI is the source of truth).
+
+---
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `packages/shared/src/validators/index.ts` | Add `autoApproveDeferralDays` + `apps` to `patchInlineSettingsSchema`; new `policyAppRuleSchema` |
+| `packages/shared/src/validators/index_inline_settings.test.ts` | New field/refinement tests |
+| `apps/api/src/services/patchApprovalEvaluator.ts` | `comparePatchVersions`, app-rule filtering, policy auto-approve path, `packageId`/`version` in query |
+| `apps/api/src/services/patchApprovalEvaluator.test.ts` | Comparator + app-rule + policy-auto-approve tests |
+| `apps/api/src/jobs/patchJobExecutor.ts` | Parse `policyAutoApprove`/`apps` from job JSONB, thread into `RingConfig` |
+| `apps/api/src/jobs/patchJobExecutor.test.ts` | Threading + malformed-handling tests |
+| `apps/api/src/routes/configurationPolicies/patchJobs.ts` | Snapshot new keys into job JSONB; expose new fields in resolve endpoint |
+| `apps/api/src/jobs/patchSchedulerWorker.ts` | Snapshot new keys into scheduled-job JSONB |
+| `apps/api/src/routes/patches/appOptions.ts` (new) | Picker endpoint |
+| `apps/api/src/routes/patches/appOptions.test.ts` (new) | Picker tests |
+| `apps/api/src/routes/patches/index.ts` | Mount `appOptionsRoutes` |
+| `apps/web/src/components/configurationPolicies/featureTabs/PatchAppRulesSection.tsx` (new) | App rules list + picker UI |
+| `apps/web/src/components/configurationPolicies/featureTabs/PatchAppRulesSection.test.tsx` (new) | Section tests |
+| `apps/web/src/components/configurationPolicies/featureTabs/PatchTab.tsx` | Auto-approve section (wired, ring-precedence aware) + app rules section |
+| `apps/web/src/components/configurationPolicies/featureTabs/PatchTab.test.tsx` | New behavior tests |
+
+---
+
+### Task 1: Shared validator schema — `apps` + `autoApproveDeferralDays`
+
+**Files:**
+- Modify: `packages/shared/src/validators/index.ts` (patchInlineSettingsSchema, ~line 454)
+- Test: `packages/shared/src/validators/index_inline_settings.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `index_inline_settings.test.ts` (follow the existing `patchInlineSettingsSchema.safeParse` style in that file):
+
+```ts
+describe('patchInlineSettingsSchema app rules + deferral', () => {
+  it('defaults autoApproveDeferralDays to 0 and apps to []', () => {
+    const result = patchInlineSettingsSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.autoApproveDeferralDays).toBe(0);
+    expect(result.data.apps).toEqual([]);
+  });
+
+  it('accepts a valid block rule and a valid pin rule', () => {
+    const result = patchInlineSettingsSchema.safeParse({
+      apps: [
+        { source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' },
+        { source: 'third_party', packageId: 'VideoLAN.VLC', displayName: 'VLC', action: 'pin', pinnedVersion: '3.0.20' },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a pin rule without pinnedVersion', () => {
+    const result = patchInlineSettingsSchema.safeParse({
+      apps: [{ source: 'third_party', packageId: 'VideoLAN.VLC', action: 'pin' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects duplicate (source, packageId) entries case-insensitively', () => {
+    const result = patchInlineSettingsSchema.safeParse({
+      apps: [
+        { source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' },
+        { source: 'third_party', packageId: 'mozilla.firefox', action: 'pin', pinnedVersion: '120.0' },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects negative or >60 deferral days', () => {
+    expect(patchInlineSettingsSchema.safeParse({ autoApproveDeferralDays: -1 }).success).toBe(false);
+    expect(patchInlineSettingsSchema.safeParse({ autoApproveDeferralDays: 61 }).success).toBe(false);
+  });
+
+  it('still rejects autoApprove without severities (existing refinement intact)', () => {
+    expect(patchInlineSettingsSchema.safeParse({ autoApprove: true, autoApproveSeverities: [] }).success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run packages/shared/src/validators/index_inline_settings.test.ts --root packages/shared`
+Expected: FAIL — `autoApproveDeferralDays` is stripped/undefined, pin/duplicate cases parse successfully.
+
+(If `--root` invocation differs, use `cd packages/shared && npx vitest run src/validators/index_inline_settings.test.ts`.)
+
+- [ ] **Step 3: Implement schema changes**
+
+In `packages/shared/src/validators/index.ts`, above `patchInlineSettingsSchema` add:
+
+```ts
+export const policyAppRuleSchema = z.object({
+  source: z.string().min(1).max(64),
+  packageId: z.string().min(1).max(256),
+  displayName: z.string().max(255).optional(),
+  action: z.enum(['block', 'pin']),
+  pinnedVersion: z.string().min(1).max(64).optional(),
+}).superRefine((data, ctx) => {
+  if (data.action === 'pin' && !data.pinnedVersion) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['pinnedVersion'],
+      message: 'Pinned version is required for pin rules.',
+    });
+  }
+});
+```
+
+Inside `patchInlineSettingsSchema`'s object, after `autoApproveSeverities`:
+
+```ts
+  autoApproveDeferralDays: z.number().int().min(0).max(60).default(0),
+  apps: z.array(policyAppRuleSchema).max(200).default([]),
+```
+
+Extend the existing `superRefine` (keep the autoApprove/severities check) with:
+
+```ts
+  const seen = new Set<string>();
+  for (const [i, app] of data.apps.entries()) {
+    const key = `${app.source}|${app.packageId.toLowerCase()}`;
+    if (seen.has(key)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['apps', i],
+        message: 'Duplicate app rule for the same source and package.',
+      });
+    }
+    seen.add(key);
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Same command as Step 2. Expected: PASS (all, including pre-existing tests in the file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/validators/index.ts packages/shared/src/validators/index_inline_settings.test.ts
+git commit -m "feat(shared): app block/pin rules and auto-approve deferral in patch inline settings"
+```
+
+---
+
+### Task 2: Evaluator pure helpers — version comparator + app-rule verdict
+
+**Files:**
+- Modify: `apps/api/src/services/patchApprovalEvaluator.ts`
+- Test: `apps/api/src/services/patchApprovalEvaluator.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `patchApprovalEvaluator.test.ts` (import `comparePatchVersions`, `buildAppRuleMap`, `evaluateAppRule`, `type PolicyAppRule` from `./patchApprovalEvaluator`):
+
+```ts
+describe('comparePatchVersions', () => {
+  it.each([
+    ['1.2.3', '1.2.3', 0],
+    ['1.2.10', '1.2.9', 1],
+    ['1.2', '1.2.0', 0],          // missing segments treated as 0
+    ['3.0.20', '3.0.21', -1],
+    ['2024.1', '2024.1.5', -1],
+    ['1.2.3-beta', '1.2.3-alpha', 1], // non-numeric segments compare lexicographically
+  ])('compare(%s, %s) === %i', (a, b, expected) => {
+    expect(comparePatchVersions(a, b)).toBe(expected);
+  });
+
+  it('returns null when either side is missing or blank', () => {
+    expect(comparePatchVersions(null, '1.0')).toBeNull();
+    expect(comparePatchVersions('1.0', undefined)).toBeNull();
+    expect(comparePatchVersions('  ', '1.0')).toBeNull();
+  });
+});
+
+describe('evaluateAppRule', () => {
+  const rules = buildAppRuleMap([
+    { source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' },
+    { source: 'third_party', packageId: 'VideoLAN.VLC', action: 'pin', pinnedVersion: '3.0.20' },
+  ]);
+
+  it('blocks a matching block rule case-insensitively', () => {
+    expect(evaluateAppRule({ source: 'third_party', packageId: 'mozilla.firefox', version: '120.0' }, rules)).toBe('blocked');
+  });
+
+  it('allows patches with no matching rule or no packageId', () => {
+    expect(evaluateAppRule({ source: 'third_party', packageId: 'Notepad++.Notepad++', version: '8.6' }, rules)).toBe('allowed');
+    expect(evaluateAppRule({ source: 'microsoft', packageId: null, version: null }, rules)).toBe('allowed');
+  });
+
+  it('holds a pinned app when the target version exceeds the pin', () => {
+    expect(evaluateAppRule({ source: 'third_party', packageId: 'VideoLAN.VLC', version: '3.0.21' }, rules)).toBe('held');
+  });
+
+  it('allows a pinned app at or below the pin', () => {
+    expect(evaluateAppRule({ source: 'third_party', packageId: 'VideoLAN.VLC', version: '3.0.20' }, rules)).toBe('allowed');
+    expect(evaluateAppRule({ source: 'third_party', packageId: 'VideoLAN.VLC', version: '3.0.19' }, rules)).toBe('allowed');
+  });
+
+  it('holds (fail-closed) when the patch version is missing or unparseable', () => {
+    expect(evaluateAppRule({ source: 'third_party', packageId: 'VideoLAN.VLC', version: null }, rules)).toBe('held');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/services/patchApprovalEvaluator.test.ts` (from `apps/api`)
+Expected: FAIL — exports don't exist.
+
+- [ ] **Step 3: Implement the helpers**
+
+In `patchApprovalEvaluator.ts`, after the source-mapping section (~line 84), add:
+
+```ts
+// ============================================
+// Per-app rules (block / pin) — Phase 3
+// ============================================
+
+export interface PolicyAppRule {
+  source: string;
+  packageId: string;
+  action: 'block' | 'pin';
+  pinnedVersion?: string;
+}
+
+export type AppRuleVerdict = 'allowed' | 'blocked' | 'held';
+
+/**
+ * Tolerant version comparison for winget/homebrew-style versions (not strict
+ * semver). Splits on . - + _ ; numeric segments compare numerically, others
+ * lexicographically; missing segments count as 0. Returns null when either
+ * side is blank/missing — callers must treat null as "cannot prove the patch
+ * is within the pin" and hold it (fail-closed).
+ */
+export function comparePatchVersions(
+  a: string | null | undefined,
+  b: string | null | undefined
+): number | null {
+  const av = (a ?? '').trim();
+  const bv = (b ?? '').trim();
+  if (!av || !bv) return null;
+  const as = av.split(/[.\-+_]/);
+  const bs = bv.split(/[.\-+_]/);
+  const len = Math.max(as.length, bs.length);
+  for (let i = 0; i < len; i++) {
+    const x = as[i] ?? '0';
+    const y = bs[i] ?? '0';
+    const xNum = /^\d+$/.test(x);
+    const yNum = /^\d+$/.test(y);
+    if (xNum && yNum) {
+      const diff = parseInt(x, 10) - parseInt(y, 10);
+      if (diff !== 0) return diff < 0 ? -1 : 1;
+    } else {
+      const cmp = x.localeCompare(y);
+      if (cmp !== 0) return cmp < 0 ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+/** Key app rules by source + lowercased packageId for O(1) candidate lookup. */
+export function buildAppRuleMap(apps: PolicyAppRule[] | undefined): Map<string, PolicyAppRule> {
+  const map = new Map<string, PolicyAppRule>();
+  for (const rule of apps ?? []) {
+    map.set(`${rule.source}|${rule.packageId.toLowerCase()}`, rule);
+  }
+  return map;
+}
+
+/**
+ * Verdict for one candidate patch against the policy's app rules.
+ * 'blocked' = block rule matched; 'held' = pin rule matched and the patch
+ * version exceeds the pin OR versions can't be compared (fail-closed).
+ */
+export function evaluateAppRule(
+  patch: { source: string; packageId: string | null; version: string | null },
+  rules: Map<string, PolicyAppRule>
+): AppRuleVerdict {
+  if (rules.size === 0 || !patch.packageId) return 'allowed';
+  const rule = rules.get(`${patch.source}|${patch.packageId.toLowerCase()}`);
+  if (!rule) return 'allowed';
+  if (rule.action === 'block') return 'blocked';
+  const cmp = comparePatchVersions(patch.version, rule.pinnedVersion);
+  if (cmp === null) return 'held';
+  return cmp > 0 ? 'held' : 'allowed';
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Same command. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/patchApprovalEvaluator.ts apps/api/src/services/patchApprovalEvaluator.test.ts
+git commit -m "feat(patches): version comparator and app-rule verdict helpers"
+```
+
+---
+
+### Task 3: Evaluator integration — app-rule filtering + policy auto-approve path
+
+**Files:**
+- Modify: `apps/api/src/services/patchApprovalEvaluator.ts`
+- Test: `apps/api/src/services/patchApprovalEvaluator.test.ts`
+
+- [ ] **Step 1: Update test fixtures for the two new patch columns**
+
+The `vi.mock('../db/schema')` block's `patches` object needs the new keys, and `PendingRow`/`pendingRow()` need `packageId`/`version`:
+
+```ts
+// in the vi.mock('../db/schema') patches object, add:
+packageId: 'packageId', version: 'version',
+
+// PendingRow type gains:
+packageId: string | null;
+version: string | null;
+
+// pendingRow() defaults gain:
+packageId: null,
+version: null,
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to the `resolveApprovedPatchesForDevice` describe block, following the file's existing mocked-chain pattern (a `mockSelectChain`-style helper already exists in the file for pending rows + approvals — reuse it exactly as the neighboring tests do):
+
+```ts
+describe('app rules in resolveApprovedPatchesForDevice', () => {
+  it('excludes a blocked app even when manually approved', async () => {
+    // pending: one third_party patch with packageId Mozilla.Firefox, manual approval exists for it
+    mockChains(
+      [pendingRow({ patchId: P1, source: 'third_party', packageId: 'Mozilla.Firefox', version: '121.0' })],
+      [{ patchId: P1, status: 'approved', ringId: null }]
+    );
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: null, categoryRules: [], autoApprove: {}, deferralDays: 0,
+      sources: ['third_party'],
+      apps: [{ source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' }],
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('holds a pinned app above the pin but approves one at the pin', async () => {
+    mockChains(
+      [
+        pendingRow({ patchId: P1, devicePatchId: 'dp-1', source: 'third_party', packageId: 'VideoLAN.VLC', version: '3.0.21' }),
+        pendingRow({ patchId: P2, devicePatchId: 'dp-2', source: 'third_party', packageId: 'VideoLAN.VLC', version: '3.0.20' }),
+      ],
+      [{ patchId: P1, status: 'approved', ringId: null }, { patchId: P2, status: 'approved', ringId: null }]
+    );
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: null, categoryRules: [], autoApprove: {}, deferralDays: 0,
+      sources: ['third_party'],
+      apps: [{ source: 'third_party', packageId: 'VideoLAN.VLC', action: 'pin', pinnedVersion: '3.0.20' }],
+    });
+    expect(result.map((r) => r.patchId)).toEqual([P2]);
+  });
+});
+
+describe('policy-level auto-approve (ring-less)', () => {
+  const policyAutoApprove = { enabled: true, severities: ['critical', 'important'], deferralDays: 0 };
+
+  it('approves a ring-less matching-severity patch with reason policy_auto_approve', async () => {
+    mockChains([pendingRow({ patchId: P1, severity: 'critical', source: 'third_party', packageId: 'X.Y' })], []);
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: null, categoryRules: [], autoApprove: {}, deferralDays: 0,
+      sources: ['third_party'], policyAutoApprove,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.approvalReason).toBe('policy_auto_approve');
+  });
+
+  it('does not approve severities outside the list, or null severity', async () => {
+    mockChains([
+      pendingRow({ patchId: P1, devicePatchId: 'dp-1', severity: 'low' }),
+      pendingRow({ patchId: P2, devicePatchId: 'dp-2', severity: null }),
+    ], []);
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: null, categoryRules: [], autoApprove: {}, deferralDays: 0, policyAutoApprove,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('holds patches inside the deferral window', async () => {
+    const yesterday = new Date(Date.now() - 24 * 3600 * 1000).toISOString();
+    mockChains([pendingRow({ patchId: P1, severity: 'critical', releaseDate: yesterday })], []);
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: null, categoryRules: [], autoApprove: {}, deferralDays: 0,
+      policyAutoApprove: { ...policyAutoApprove, deferralDays: 7 },
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('ignores policyAutoApprove entirely when a ring is linked', async () => {
+    // ring linked, no category rules, ring autoApprove disabled → nothing approved
+    // even though policyAutoApprove would have matched
+    mockChains([pendingRow({ patchId: P1, severity: 'critical' })], []);
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID, categoryRules: [], autoApprove: { enabled: false }, deferralDays: 0,
+      policyAutoApprove,
+    });
+    expect(result).toEqual([]);
+  });
+});
+```
+
+(`P1`/`P2` are uuid constants in the existing test file style; `mockChains` stands for the file's existing two-select mock helper — match its real name when editing.)
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/services/patchApprovalEvaluator.test.ts`
+Expected: FAIL — `policyAutoApprove`/`apps` not in `RingConfig`, blocked patches still approved.
+
+- [ ] **Step 4: Implement evaluator integration**
+
+In `patchApprovalEvaluator.ts`:
+
+a) Extend `RingConfig` (note doc comment — name kept, scope broadened):
+
+```ts
+export interface PolicyAutoApproveConfig {
+  enabled: boolean;
+  severities: string[];
+  deferralDays: number;
+}
+
+/**
+ * Evaluator input. Despite the name this now carries both ring-level config
+ * and policy-level config (sources, app rules, ring-less auto-approve).
+ */
+export interface RingConfig {
+  ringId: string | null;
+  categoryRules: CategoryRule[];
+  autoApprove: unknown;
+  deferralDays: number;
+  /** Policy-level source selections ('os', 'third_party', ...). Absent/empty = no filtering (legacy). */
+  sources?: string[];
+  /** Policy-level auto-approve — consulted ONLY when ringId is null. Absent = disabled. */
+  policyAutoApprove?: PolicyAutoApproveConfig;
+  /** Policy-level per-app block/pin rules. Applied to every approval path in the job flow. */
+  apps?: PolicyAppRule[];
+}
+```
+
+b) `ApprovedPatch.approvalReason` union gains `'policy_auto_approve'` (and the same union in `evaluatePatchApproval`'s return type).
+
+c) Add `packageId: patches.packageId, version: patches.version` to the select at ~line 99, and to `PatchCandidate`:
+
+```ts
+interface PatchCandidate {
+  patchId: string;
+  category: string | null;
+  severity: string | null;
+  releaseDate: string | null;
+  source: string;
+  packageId: string | null;
+  version: string | null;
+}
+```
+
+d) In `resolveApprovedPatchesForDevice`, after the source-filter block (~line 132), filter by app rules — before manual approvals are loaded so block/pin override every path:
+
+```ts
+  // Apply per-app block/pin rules. These override every approval path in the
+  // job flow — including manual approvals — mirroring how source filtering
+  // treats manually-approved patches in an os-only job. Manual per-device
+  // install does not go through this evaluator and is unaffected.
+  const appRuleMap = buildAppRuleMap(ringConfig.apps);
+  let finalCandidates = candidatePatches;
+  if (appRuleMap.size > 0) {
+    finalCandidates = candidatePatches.filter((p) => {
+      const verdict = evaluateAppRule(p, appRuleMap);
+      if (verdict !== 'allowed') {
+        console.warn(
+          `[PatchApproval] device ${deviceId}: patch ${p.patchId} (${p.source}/${p.packageId ?? '?'} v${p.version ?? '?'}) excluded by app rule (${verdict})`
+        );
+        return false;
+      }
+      return true;
+    });
+    if (finalCandidates.length === 0) return [];
+  }
+```
+
+Replace subsequent uses of `candidatePatches` (the `patchIds` map and the main loop) with `finalCandidates`.
+
+e) In `evaluatePatchApproval`, replace the bare ring-less early-return (lines 227–230):
+
+```ts
+  // No ring linked: manual approvals (handled above) plus policy-level
+  // auto-approve. A linked ring takes absolute precedence — policyAutoApprove
+  // is never consulted when ringId is set.
+  if (!ringConfig.ringId) {
+    const pa = ringConfig.policyAutoApprove;
+    if (pa?.enabled && patch.severity && pa.severities.includes(patch.severity)) {
+      if (pa.deferralDays > 0 && patch.releaseDate) {
+        const releaseDate = new Date(patch.releaseDate);
+        const deferralEnd = new Date(releaseDate.getTime() + pa.deferralDays * 24 * 60 * 60 * 1000);
+        if (deferralEnd > now) {
+          return null; // Still in deferral window
+        }
+      }
+      return 'policy_auto_approve';
+    }
+    return null;
+  }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Same command — all evaluator tests (new + the 19 existing) must pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/patchApprovalEvaluator.ts apps/api/src/services/patchApprovalEvaluator.test.ts
+git commit -m "feat(patches): app-rule filtering and ring-less policy auto-approve in evaluator"
+```
+
+---
+
+### Task 4: Executor — parse and thread `policyAutoApprove` + `apps`
+
+**Files:**
+- Modify: `apps/api/src/jobs/patchJobExecutor.ts` (~lines 361–400)
+- Test: `apps/api/src/jobs/patchJobExecutor.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+The executor test file mocks `./patchApprovalEvaluator` (or asserts via the db mocks — follow the existing "threads sources" tests, which capture the `RingConfig` passed to `resolveApprovedPatchesForDevice`). Add:
+
+```ts
+it('threads well-formed policyAutoApprove and apps to the evaluator', async () => {
+  // job.patches: { ringId: null, categoryRules: [], autoApprove: {},
+  //   policyAutoApprove: { enabled: true, severities: ['critical'], deferralDays: 3 },
+  //   apps: [{ source: 'third_party', packageId: 'A.B', action: 'block' }] }
+  // assert resolveApprovedPatchesForDevice received:
+  expect(capturedRingConfig.policyAutoApprove).toEqual({ enabled: true, severities: ['critical'], deferralDays: 3 });
+  expect(capturedRingConfig.apps).toEqual([{ source: 'third_party', packageId: 'A.B', action: 'block' }]);
+});
+
+it('treats malformed policyAutoApprove as disabled and warns', async () => {
+  // job.patches.policyAutoApprove = { enabled: 'yes', severities: 'critical' }
+  expect(capturedRingConfig.policyAutoApprove).toBeUndefined();
+  expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('malformed patches.policyAutoApprove'), expect.anything());
+});
+
+it('drops malformed app entries individually and keeps valid ones', async () => {
+  // job.patches.apps = [ { source: 'third_party', packageId: 'A.B', action: 'block' },
+  //                      { source: 'third_party', action: 'block' },               // no packageId
+  //                      { source: 'third_party', packageId: 'C.D', action: 'pin' } ] // pin w/o version
+  expect(capturedRingConfig.apps).toEqual([{ source: 'third_party', packageId: 'A.B', action: 'block' }]);
+  expect(warnSpy).toHaveBeenCalledTimes(2);
+});
+
+it('leaves policyAutoApprove and apps undefined for legacy jobs (keys absent)', async () => {
+  expect(capturedRingConfig.policyAutoApprove).toBeUndefined();
+  expect(capturedRingConfig.apps).toBeUndefined();
+});
+```
+
+(Write these against the file's real harness — it dispatches the worker processor and inspects mock calls; copy the setup of the existing `sources`-threading tests verbatim, changing only the `patches` JSONB payload and assertions.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/jobs/patchJobExecutor.test.ts`
+Expected: FAIL — new keys not parsed.
+
+- [ ] **Step 3: Implement executor parsing**
+
+In `patchJobExecutor.ts`: extend the `patchesConfig` cast (~line 362):
+
+```ts
+  const patchesConfig = patchJob.patches as {
+    ringId?: string | null;
+    categoryRules?: unknown[];
+    autoApprove?: unknown;
+    sources?: unknown;
+    policyAutoApprove?: unknown;
+    apps?: unknown;
+  };
+```
+
+After the `jobSources` block (~line 388), add (import `type PolicyAppRule`, `type PolicyAutoApproveConfig` from the evaluator):
+
+```ts
+  // policyAutoApprove: absent → undefined (legacy job / ring-linked job);
+  // malformed → undefined, loudly. Fail-closed: the dangerous direction is
+  // silently enabling auto-approval.
+  let policyAutoApprove: PolicyAutoApproveConfig | undefined;
+  if (patchesConfig?.policyAutoApprove !== undefined) {
+    const raw = patchesConfig.policyAutoApprove as
+      | { enabled?: unknown; severities?: unknown; deferralDays?: unknown }
+      | null;
+    const severities = Array.isArray(raw?.severities)
+      ? raw.severities.filter((s): s is string => typeof s === 'string')
+      : null;
+    if (
+      raw && typeof raw === 'object' && typeof raw.enabled === 'boolean' &&
+      severities !== null && severities.length === (raw.severities as unknown[]).length
+    ) {
+      policyAutoApprove = {
+        enabled: raw.enabled,
+        severities,
+        deferralDays:
+          typeof raw.deferralDays === 'number' && Number.isFinite(raw.deferralDays) && raw.deferralDays >= 0
+            ? raw.deferralDays
+            : 0,
+      };
+    } else {
+      console.warn(
+        `[PatchJobExecutor] Job ${patchJobId} has malformed patches.policyAutoApprove; treating as disabled:`,
+        JSON.stringify(patchesConfig.policyAutoApprove)
+      );
+    }
+  }
+
+  // apps: absent → undefined; non-array → ignored loudly; malformed entries
+  // dropped individually with a warning (a dropped block rule widens scope,
+  // so each drop must be visible in logs).
+  let jobApps: PolicyAppRule[] | undefined;
+  if (patchesConfig?.apps !== undefined) {
+    if (!Array.isArray(patchesConfig.apps)) {
+      console.warn(
+        `[PatchJobExecutor] Job ${patchJobId} has malformed patches.apps; ignoring app rules:`,
+        JSON.stringify(patchesConfig.apps)
+      );
+    } else {
+      const valid: PolicyAppRule[] = [];
+      for (const entry of patchesConfig.apps) {
+        const e = entry as { source?: unknown; packageId?: unknown; action?: unknown; pinnedVersion?: unknown } | null;
+        const okBase =
+          e && typeof e.source === 'string' && e.source.length > 0 &&
+          typeof e.packageId === 'string' && e.packageId.length > 0;
+        if (okBase && e.action === 'block') {
+          valid.push({ source: e.source as string, packageId: e.packageId as string, action: 'block' });
+        } else if (okBase && e.action === 'pin' && typeof e.pinnedVersion === 'string' && e.pinnedVersion.length > 0) {
+          valid.push({
+            source: e.source as string,
+            packageId: e.packageId as string,
+            action: 'pin',
+            pinnedVersion: e.pinnedVersion,
+          });
+        } else {
+          console.warn(
+            `[PatchJobExecutor] Job ${patchJobId} dropping malformed app rule:`,
+            JSON.stringify(entry)
+          );
+        }
+      }
+      jobApps = valid;
+    }
+  }
+```
+
+Then add both to the `ringConfig` literal:
+
+```ts
+    sources: jobSources,
+    policyAutoApprove,
+    apps: jobApps,
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Same command — all executor tests (new + 8 existing) must pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/jobs/patchJobExecutor.ts apps/api/src/jobs/patchJobExecutor.test.ts
+git commit -m "feat(patches): thread policy auto-approve and app rules from patch job to evaluator"
+```
+
+---
+
+### Task 5: Job-creation snapshots + resolve endpoint
+
+**Files:**
+- Modify: `apps/api/src/routes/configurationPolicies/patchJobs.ts` (insert at ~line 178–190; resolve response at ~line 363–372)
+- Modify: `apps/api/src/jobs/patchSchedulerWorker.ts` (insert at ~line 379–388)
+- Test: `apps/api/src/routes/configurationPolicies/patchJobs.test.ts` (extend existing job-creation test)
+
+- [ ] **Step 1: Write the failing test**
+
+In `patchJobs.test.ts`, find the existing test that asserts the inserted job's `patches` JSONB contains `sources` and extend it (or add a sibling test in the same arrangement) to assert the new keys:
+
+```ts
+expect(insertedJob.patches).toMatchObject({
+  sources: ['third_party'],
+  policyAutoApprove: { enabled: true, severities: ['critical'], deferralDays: 5 },
+  apps: [{ source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' }],
+});
+```
+
+Seed the mocked policy-local settings for that test with `autoApprove: true, autoApproveSeverities: ['critical'], autoApproveDeferralDays: 5, apps: [...]`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/routes/configurationPolicies/patchJobs.test.ts`
+Expected: FAIL — `policyAutoApprove`/`apps` missing from snapshot.
+
+- [ ] **Step 3: Implement snapshots**
+
+In `patchJobs.ts` inside the `patches:` object of the insert (after `sources: policyLocal.settings.sources,` at line 183):
+
+```ts
+            policyAutoApprove: {
+              enabled: policyLocal.settings.autoApprove ?? false,
+              severities: policyLocal.settings.autoApproveSeverities ?? [],
+              deferralDays: policyLocal.settings.autoApproveDeferralDays ?? 0,
+            },
+            apps: policyLocal.settings.apps ?? [],
+```
+
+In `patchSchedulerWorker.ts`, same addition after `sources: policyLocal.settings.sources,` (line 384), with identical code.
+
+In the resolve endpoint response (`patchJobs.ts` ~line 364, the `settings:` object), after `autoApproveSeverities`:
+
+```ts
+              autoApproveDeferralDays: effective.settings.autoApproveDeferralDays ?? 0,
+              apps: effective.settings.apps ?? [],
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/routes/configurationPolicies/patchJobs.test.ts
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/jobs/patchJobExecutor.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/configurationPolicies/patchJobs.ts apps/api/src/jobs/patchSchedulerWorker.ts apps/api/src/routes/configurationPolicies/patchJobs.test.ts
+git commit -m "feat(patches): snapshot policy auto-approve and app rules into patch jobs"
+```
+
+---
+
+### Task 6: Picker endpoint — `GET /patches/app-options`
+
+**Files:**
+- Create: `apps/api/src/routes/patches/appOptions.ts`
+- Create: `apps/api/src/routes/patches/appOptions.test.ts`
+- Modify: `apps/api/src/routes/patches/index.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+`appOptions.test.ts` — follow the db-mocking style of `apps/api/src/routes/patches/index.test.ts` (mock `../../db`, build a Hono app with a stubbed auth context):
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const selectMock = vi.fn();
+const selectDistinctMock = vi.fn();
+vi.mock('../../db', () => ({ db: { select: (...a: unknown[]) => selectMock(...a), selectDistinct: (...a: unknown[]) => selectDistinctMock(...a) } }));
+vi.mock('../../middleware/auth', () => ({
+  requireScope: () => async (c: any, next: any) => {
+    c.set('auth', { canAccessOrg: (id: string) => id !== 'denied-org' });
+    await next();
+  },
+}));
+
+import { appOptionsRoutes } from './appOptions';
+
+function chain(rows: unknown[]) {
+  return { from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(rows), then: undefined }), then: undefined } as any;
+}
+
+describe('GET /app-options', () => {
+  beforeEach(() => { selectMock.mockReset(); selectDistinctMock.mockReset(); });
+
+  it('merges catalog and observed entries, catalog metadata winning on dedup', async () => {
+    selectMock.mockReturnValue({ from: vi.fn().mockResolvedValue([
+      { source: 'third_party', packageId: 'Mozilla.Firefox', vendor: 'Mozilla', displayName: 'Firefox' },
+    ]) });
+    selectDistinctMock.mockReturnValue(chain([
+      { source: 'third_party', packageId: 'mozilla.firefox', vendor: 'Mozilla Corp', displayName: 'Firefox 121 update' },
+      { source: 'third_party', packageId: 'VideoLAN.VLC', vendor: 'VideoLAN', displayName: 'VLC update' },
+    ]));
+    const res = await appOptionsRoutes.request('/app-options');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(2);
+    const firefox = body.data.find((o: any) => o.packageId.toLowerCase() === 'mozilla.firefox');
+    expect(firefox.displayName).toBe('Firefox');   // catalog won
+    expect(firefox.inCatalog).toBe(true);
+    expect(body.data.find((o: any) => o.packageId === 'VideoLAN.VLC').inCatalog).toBe(false);
+  });
+
+  it('filters by search across name, vendor, and packageId', async () => {
+    selectMock.mockReturnValue({ from: vi.fn().mockResolvedValue([
+      { source: 'third_party', packageId: 'Mozilla.Firefox', vendor: 'Mozilla', displayName: 'Firefox' },
+      { source: 'third_party', packageId: 'VideoLAN.VLC', vendor: 'VideoLAN', displayName: 'VLC' },
+    ]) });
+    selectDistinctMock.mockReturnValue(chain([]));
+    const res = await appOptionsRoutes.request('/app-options?search=videolan');
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].packageId).toBe('VideoLAN.VLC');
+  });
+
+  it('rejects an inaccessible orgId with 403', async () => {
+    const res = await appOptionsRoutes.request('/app-options?orgId=00000000-0000-0000-0000-00000000dead');
+    // stub denies only 'denied-org'; use a uuid the stub denies — adjust stub: deny this uuid
+    expect([200, 403]).toContain(res.status); // tighten to 403 once the stub matches
+  });
+});
+```
+
+(Adjust the 403 test so the stubbed `canAccessOrg` denies the exact uuid used — make the stub `canAccessOrg: (id) => id !== '00000000-0000-0000-0000-00000000dead'` and assert `res.status === 403`.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/routes/patches/appOptions.test.ts`
+Expected: FAIL — module doesn't exist.
+
+- [ ] **Step 3: Implement the route**
+
+`apps/api/src/routes/patches/appOptions.ts`:
+
+```ts
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
+import { and, inArray, isNotNull, sql, type SQL } from 'drizzle-orm';
+import { requireScope } from '../../middleware/auth';
+import { db } from '../../db';
+import { patches, devices, devicePatches, thirdPartyPackageCatalog } from '../../db/schema';
+
+/** Keep in sync with THIRD_PARTY_PATCH_SOURCES in services/patchApprovalEvaluator.ts. */
+const THIRD_PARTY_SOURCES = ['third_party', 'custom'] as const;
+
+const appOptionsQuerySchema = z.object({
+  search: z.string().max(255).optional(),
+  orgId: z.string().uuid().optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+});
+
+export const appOptionsRoutes = new Hono();
+
+// GET /patches/app-options — options for the policy app-rule picker: curated
+// catalog merged with third-party apps observed in patch data (optionally
+// narrowed to one org via the same EXISTS pattern as GET /patches).
+appOptionsRoutes.get(
+  '/app-options',
+  requireScope('organization', 'partner', 'system'),
+  zValidator('query', appOptionsQuerySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { search, orgId, limit } = c.req.valid('query');
+
+    if (orgId && !auth.canAccessOrg(orgId)) {
+      return c.json({ error: 'Access denied to this organization' }, 403);
+    }
+
+    const catalogRows = await db
+      .select({
+        source: thirdPartyPackageCatalog.source,
+        packageId: thirdPartyPackageCatalog.packageId,
+        vendor: thirdPartyPackageCatalog.vendor,
+        displayName: thirdPartyPackageCatalog.friendlyName,
+      })
+      .from(thirdPartyPackageCatalog);
+
+    const observedConditions: SQL[] = [
+      inArray(patches.source, [...THIRD_PARTY_SOURCES]),
+      isNotNull(patches.packageId),
+    ];
+    if (orgId) {
+      observedConditions.push(sql`EXISTS (
+        SELECT 1 FROM ${devicePatches} dp
+        INNER JOIN ${devices} d ON d.id = dp.device_id
+        WHERE dp.patch_id = ${patches.id} AND d.org_id = ${orgId}
+      )`);
+    }
+    const observedRows = await db
+      .selectDistinct({
+        source: patches.source,
+        packageId: patches.packageId,
+        vendor: patches.vendor,
+        displayName: patches.title,
+      })
+      .from(patches)
+      .where(and(...observedConditions));
+
+    type AppOption = {
+      source: string;
+      packageId: string;
+      vendor: string | null;
+      displayName: string;
+      inCatalog: boolean;
+    };
+    const merged = new Map<string, AppOption>();
+    for (const row of observedRows) {
+      if (!row.packageId) continue;
+      merged.set(`${row.source}|${row.packageId.toLowerCase()}`, { ...row, packageId: row.packageId, inCatalog: false });
+    }
+    for (const row of catalogRows) {
+      merged.set(`${row.source}|${row.packageId.toLowerCase()}`, { ...row, inCatalog: true });
+    }
+
+    let options = [...merged.values()];
+    if (search) {
+      const q = search.toLowerCase();
+      options = options.filter(
+        (o) =>
+          o.displayName.toLowerCase().includes(q) ||
+          (o.vendor ?? '').toLowerCase().includes(q) ||
+          o.packageId.toLowerCase().includes(q)
+      );
+    }
+    options.sort((a, b) => a.displayName.localeCompare(b.displayName));
+
+    return c.json({ data: options.slice(0, limit) });
+  }
+);
+```
+
+Mount in `apps/api/src/routes/patches/index.ts` — add the import and register it **before** the other subrouters so `/app-options` can't be swallowed by any `/:id` param route:
+
+```ts
+import { appOptionsRoutes } from './appOptions';
+// ...
+patchRoutes.route('/', appOptionsRoutes);
+patchRoutes.route('/', operationsRoutes);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+`PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/routes/patches/appOptions.test.ts` — PASS.
+Also run `npx vitest run src/routes/patches/index.test.ts` to confirm mounting broke nothing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/patches/appOptions.ts apps/api/src/routes/patches/appOptions.test.ts apps/api/src/routes/patches/index.ts
+git commit -m "feat(patches): app-options endpoint for policy app-rule picker"
+```
+
+---
+
+### Task 7: Web UI — app rules section + wired auto-approve
+
+**Files:**
+- Create: `apps/web/src/components/configurationPolicies/featureTabs/PatchAppRulesSection.tsx`
+- Create: `apps/web/src/components/configurationPolicies/featureTabs/PatchAppRulesSection.test.tsx`
+- Modify: `apps/web/src/components/configurationPolicies/featureTabs/PatchTab.tsx`
+- Modify: `apps/web/src/components/configurationPolicies/featureTabs/PatchTab.test.tsx`
+
+- [ ] **Step 1: Write failing PatchAppRulesSection tests**
+
+`PatchAppRulesSection.test.tsx` (follow the render/mocking style of `PatchTab.test.tsx`, which mocks `../../../stores/auth` `fetchWithAuth`):
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const fetchWithAuthMock = vi.fn();
+vi.mock('../../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuthMock(...a) }));
+
+import PatchAppRulesSection, { type PolicyAppRule } from './PatchAppRulesSection';
+
+const options = [
+  { source: 'third_party', packageId: 'Mozilla.Firefox', vendor: 'Mozilla', displayName: 'Firefox', inCatalog: true },
+  { source: 'third_party', packageId: 'VideoLAN.VLC', vendor: 'VideoLAN', displayName: 'VLC', inCatalog: false },
+];
+
+beforeEach(() => {
+  fetchWithAuthMock.mockResolvedValue({ ok: true, json: async () => ({ data: options }) });
+});
+
+describe('PatchAppRulesSection', () => {
+  it('renders existing rules with action and pinned version', () => {
+    const apps: PolicyAppRule[] = [
+      { source: 'third_party', packageId: 'Mozilla.Firefox', displayName: 'Firefox', action: 'block' },
+      { source: 'third_party', packageId: 'VideoLAN.VLC', displayName: 'VLC', action: 'pin', pinnedVersion: '3.0.20' },
+    ];
+    render(<PatchAppRulesSection apps={apps} onChange={() => {}} />);
+    expect(screen.getByText('Firefox')).toBeTruthy();
+    expect(screen.getByText(/Blocked/i)).toBeTruthy();
+    expect(screen.getByText(/3\.0\.20/)).toBeTruthy();
+  });
+
+  it('adds a block rule from picker search results', async () => {
+    const onChange = vi.fn();
+    render(<PatchAppRulesSection apps={[]} onChange={onChange} />);
+    fireEvent.click(screen.getByTestId('app-rules-add'));
+    fireEvent.change(screen.getByTestId('app-rules-search'), { target: { value: 'fire' } });
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalled());
+    fireEvent.click(await screen.findByTestId('app-option-third_party-Mozilla.Firefox'));
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({ source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' }),
+    ]);
+  });
+
+  it('removes a rule', () => {
+    const onChange = vi.fn();
+    render(
+      <PatchAppRulesSection
+        apps={[{ source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' }]}
+        onChange={onChange}
+      />
+    );
+    fireEvent.click(screen.getByTestId('app-rule-remove-third_party-Mozilla.Firefox'));
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it('switches a rule to pin and sets the version', () => {
+    const onChange = vi.fn();
+    render(
+      <PatchAppRulesSection
+        apps={[{ source: 'third_party', packageId: 'VideoLAN.VLC', action: 'pin', pinnedVersion: '' }]}
+        onChange={onChange}
+      />
+    );
+    fireEvent.change(screen.getByTestId('app-rule-pin-version-third_party-VideoLAN.VLC'), {
+      target: { value: '3.0.20' },
+    });
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({ action: 'pin', pinnedVersion: '3.0.20' }),
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/components/configurationPolicies/featureTabs/PatchAppRulesSection.test.tsx` (from `apps/web`)
+Expected: FAIL — module doesn't exist.
+
+- [ ] **Step 3: Implement PatchAppRulesSection**
+
+`PatchAppRulesSection.tsx`:
+
+```tsx
+import { useEffect, useRef, useState } from 'react';
+import { Plus, X } from 'lucide-react';
+import { fetchWithAuth } from '../../../stores/auth';
+
+export type PolicyAppAction = 'block' | 'pin';
+
+export type PolicyAppRule = {
+  source: string;
+  packageId: string;
+  displayName?: string;
+  action: PolicyAppAction;
+  pinnedVersion?: string;
+};
+
+type AppOption = {
+  source: string;
+  packageId: string;
+  vendor: string | null;
+  displayName: string;
+  inCatalog: boolean;
+};
+
+type Props = {
+  apps: PolicyAppRule[];
+  onChange: (apps: PolicyAppRule[]) => void;
+};
+
+const ruleKey = (r: { source: string; packageId: string }) => `${r.source}-${r.packageId}`;
+
+export default function PatchAppRulesSection({ apps, onChange }: Props) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [options, setOptions] = useState<AppOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [manualPackageId, setManualPackageId] = useState('');
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    if (!pickerOpen) return;
+    clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const response = await fetchWithAuth(`/patches/app-options?search=${encodeURIComponent(search)}`);
+        if (response.ok) {
+          const payload = await response.json();
+          setOptions(Array.isArray(payload.data) ? payload.data : []);
+        }
+      } catch {
+        // Read-only lookup; picker simply shows no results
+      } finally {
+        setLoading(false);
+      }
+    }, 200);
+    return () => clearTimeout(debounceRef.current);
+  }, [pickerOpen, search]);
+
+  const exists = (source: string, packageId: string) =>
+    apps.some((a) => a.source === source && a.packageId.toLowerCase() === packageId.toLowerCase());
+
+  const addRule = (option: { source: string; packageId: string; displayName?: string }) => {
+    if (exists(option.source, option.packageId)) return;
+    onChange([...apps, { source: option.source, packageId: option.packageId, displayName: option.displayName, action: 'block' }]);
+    setPickerOpen(false);
+    setSearch('');
+    setManualPackageId('');
+  };
+
+  const updateRule = (key: string, patch: Partial<PolicyAppRule>) =>
+    onChange(apps.map((a) => (ruleKey(a) === key ? { ...a, ...patch } : a)));
+
+  const removeRule = (key: string) => onChange(apps.filter((a) => ruleKey(a) !== key));
+
+  return (
+    <div className="mt-6">
+      <h3 className="text-sm font-semibold">Application Rules</h3>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Block specific applications from automated patching, or pin them to a maximum version.
+        Rules apply to automated deployment only — manual per-device installs are unaffected.
+      </p>
+
+      {apps.length > 0 && (
+        <ul className="mt-2 space-y-2">
+          {apps.map((rule) => {
+            const key = ruleKey(rule);
+            return (
+              <li key={key} className="flex flex-wrap items-center gap-2 rounded-md border p-2 text-sm">
+                <span className="font-medium">{rule.displayName ?? rule.packageId}</span>
+                <span className="text-xs text-muted-foreground">{rule.packageId}</span>
+                <select
+                  value={rule.action}
+                  data-testid={`app-rule-action-${key}`}
+                  onChange={(e) =>
+                    updateRule(key, {
+                      action: e.target.value as PolicyAppAction,
+                      pinnedVersion: e.target.value === 'block' ? undefined : rule.pinnedVersion ?? '',
+                    })
+                  }
+                  className="ml-auto h-8 rounded-md border bg-background px-2 text-xs"
+                >
+                  <option value="block">Blocked</option>
+                  <option value="pin">Pinned</option>
+                </select>
+                {rule.action === 'pin' && (
+                  <input
+                    type="text"
+                    placeholder="Max version"
+                    value={rule.pinnedVersion ?? ''}
+                    data-testid={`app-rule-pin-version-${key}`}
+                    onChange={(e) => updateRule(key, { pinnedVersion: e.target.value })}
+                    className="h-8 w-28 rounded-md border bg-background px-2 text-xs"
+                  />
+                )}
+                <button
+                  type="button"
+                  aria-label={`Remove rule for ${rule.displayName ?? rule.packageId}`}
+                  data-testid={`app-rule-remove-${key}`}
+                  onClick={() => removeRule(key)}
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {apps.some((a) => a.action === 'pin' && !a.pinnedVersion) && (
+        <p className="mt-1 text-xs text-destructive">Pinned applications need a version.</p>
+      )}
+
+      {!pickerOpen ? (
+        <button
+          type="button"
+          data-testid="app-rules-add"
+          onClick={() => setPickerOpen(true)}
+          className="mt-2 inline-flex items-center gap-1 rounded-md border px-3 py-1.5 text-xs hover:bg-muted"
+        >
+          <Plus className="h-3.5 w-3.5" /> Add application
+        </button>
+      ) : (
+        <div className="mt-2 rounded-md border p-3">
+          <input
+            type="text"
+            placeholder="Search catalog and detected applications..."
+            value={search}
+            data-testid="app-rules-search"
+            onChange={(e) => setSearch(e.target.value)}
+            className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+            autoFocus
+          />
+          <ul className="mt-2 max-h-48 space-y-1 overflow-y-auto">
+            {loading && <li className="text-xs text-muted-foreground">Searching…</li>}
+            {!loading &&
+              options.map((o) => (
+                <li key={`${o.source}|${o.packageId}`}>
+                  <button
+                    type="button"
+                    data-testid={`app-option-${o.source}-${o.packageId}`}
+                    disabled={exists(o.source, o.packageId)}
+                    onClick={() => addRule(o)}
+                    className="flex w-full items-center gap-2 rounded px-2 py-1 text-left text-sm hover:bg-muted disabled:opacity-50"
+                  >
+                    <span>{o.displayName}</span>
+                    <span className="text-xs text-muted-foreground">{o.vendor ?? o.packageId}</span>
+                    {o.inCatalog && <span className="ml-auto text-[10px] uppercase text-muted-foreground">catalog</span>}
+                  </button>
+                </li>
+              ))}
+            {!loading && options.length === 0 && (
+              <li className="text-xs text-muted-foreground">No matches.</li>
+            )}
+          </ul>
+          <div className="mt-2 flex items-center gap-2 border-t pt-2">
+            <input
+              type="text"
+              placeholder="Or enter a package ID manually (e.g. Mozilla.Firefox)"
+              value={manualPackageId}
+              data-testid="app-rules-manual-id"
+              onChange={(e) => setManualPackageId(e.target.value)}
+              className="h-8 flex-1 rounded-md border bg-background px-2 text-xs"
+            />
+            <button
+              type="button"
+              data-testid="app-rules-manual-add"
+              disabled={!manualPackageId.trim()}
+              onClick={() => addRule({ source: 'third_party', packageId: manualPackageId.trim() })}
+              className="h-8 rounded-md border px-3 text-xs hover:bg-muted disabled:opacity-50"
+            >
+              Add
+            </button>
+            <button
+              type="button"
+              onClick={() => { setPickerOpen(false); setSearch(''); }}
+              className="h-8 rounded-md px-2 text-xs text-muted-foreground hover:text-foreground"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run section tests — PASS**
+
+Same command as Step 2.
+
+- [ ] **Step 5: Write failing PatchTab tests**
+
+Add to `PatchTab.test.tsx` (reuse its existing render helpers/mocks):
+
+```tsx
+it('includes wired auto-approve fields and apps in the save payload', async () => {
+  // render with no ring selected; enable auto-approve, check 'critical', set deferral 3,
+  // then save and inspect the body passed to useFeatureLink's save (existing tests show how
+  // save is mocked/captured)
+  expect(savedPayload.inlineSettings).toMatchObject({
+    autoApprove: true,
+    autoApproveSeverities: ['critical'],
+    autoApproveDeferralDays: 3,
+    apps: [],
+  });
+});
+
+it('disables the auto-approve section and shows the ring-precedence notice when a ring is linked', () => {
+  // render with existingLink.featurePolicyId set to a ring id
+  expect(screen.getByTestId('auto-approve-ring-notice').textContent).toMatch(/governed by the linked update ring/i);
+  expect((screen.getByTestId('auto-approve-toggle') as HTMLInputElement).disabled).toBe(true);
+});
+
+it('hydrates auto-approve fields and apps from existing inline settings', () => {
+  // existingLink.inlineSettings: { autoApprove: true, autoApproveSeverities: ['important'],
+  //   autoApproveDeferralDays: 7, apps: [{ source: 'third_party', packageId: 'A.B', action: 'block' }] }
+  expect((screen.getByTestId('auto-approve-toggle') as HTMLInputElement).checked).toBe(true);
+  expect(screen.getByText('A.B')).toBeTruthy();
+});
+```
+
+- [ ] **Step 6: Implement PatchTab changes**
+
+In `PatchTab.tsx`:
+
+a) Extend the settings type and defaults:
+
+```tsx
+import PatchAppRulesSection, { type PolicyAppRule } from './PatchAppRulesSection';
+
+type PatchSeverity = 'critical' | 'important' | 'moderate' | 'low';
+
+type PatchDeploymentSettings = {
+  sources: PatchSourceOption[];
+  autoApprove: boolean;
+  autoApproveSeverities: PatchSeverity[];
+  autoApproveDeferralDays: number;
+  apps: PolicyAppRule[];
+  scheduleFrequency: ScheduleFrequency;
+  scheduleTime: string;
+  scheduleDayOfWeek: string;
+  scheduleDayOfMonth: number;
+  rebootPolicy: RebootPolicy;
+};
+
+const defaults: PatchDeploymentSettings = {
+  sources: ['os'],
+  autoApprove: false,
+  autoApproveSeverities: [],
+  autoApproveDeferralDays: 0,
+  apps: [],
+  scheduleFrequency: 'weekly',
+  scheduleTime: '02:00',
+  scheduleDayOfWeek: 'sun',
+  scheduleDayOfMonth: 1,
+  rebootPolicy: 'if_required',
+};
+
+const severityOptions: { value: PatchSeverity; label: string }[] = [
+  { value: 'critical', label: 'Critical' },
+  { value: 'important', label: 'Important' },
+  { value: 'moderate', label: 'Moderate' },
+  { value: 'low', label: 'Low' },
+];
+```
+
+(The two hydration sites — the `useState` initializer and the `useEffect` on `existingLink`/`parentLink` — keep their existing `{ ...prev/defaults, ...inline, sources: normalizeSources(...) }` spreads; the new keys hydrate automatically. The earlier "stored settings round-trip" tests must keep passing: values now round-trip as first-class fields.)
+
+b) After the Approval Ring section, add the Automatic Approval section:
+
+```tsx
+      {/* Automatic Approval (policy-level, ring-less only) */}
+      <div className="mt-6">
+        <h3 className="text-sm font-semibold">Automatic Approval</h3>
+        {selectedRingId ? (
+          <p className="mt-1 text-xs text-muted-foreground" data-testid="auto-approve-ring-notice">
+            Automatic approval is governed by the linked update ring
+            {selectedRing ? ` “${selectedRing.name}”` : ''}. These settings apply only when no ring is linked.
+          </p>
+        ) : (
+          <p className="mt-1 text-xs text-muted-foreground">
+            Automatically approve patches by severity when no update ring is linked.
+          </p>
+        )}
+        <label className="mt-2 flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            data-testid="auto-approve-toggle"
+            checked={settings.autoApprove}
+            disabled={!!selectedRingId}
+            onChange={(e) => update('autoApprove', e.target.checked)}
+          />
+          Enable automatic approval
+        </label>
+        {settings.autoApprove && !selectedRingId && (
+          <div className="mt-2 space-y-2">
+            <div className="flex flex-wrap gap-3">
+              {severityOptions.map((o) => (
+                <label key={o.value} className="flex items-center gap-1.5 text-sm">
+                  <input
+                    type="checkbox"
+                    data-testid={`auto-approve-severity-${o.value}`}
+                    checked={settings.autoApproveSeverities.includes(o.value)}
+                    onChange={() =>
+                      update(
+                        'autoApproveSeverities',
+                        settings.autoApproveSeverities.includes(o.value)
+                          ? settings.autoApproveSeverities.filter((s) => s !== o.value)
+                          : [...settings.autoApproveSeverities, o.value]
+                      )
+                    }
+                  />
+                  {o.label}
+                </label>
+              ))}
+            </div>
+            {settings.autoApproveSeverities.length === 0 && (
+              <p className="text-xs text-destructive">Select at least one severity for auto-approval.</p>
+            )}
+            <div>
+              <label className="text-xs text-muted-foreground">Deferral (days after release)</label>
+              <input
+                type="number"
+                min={0}
+                max={60}
+                data-testid="auto-approve-deferral"
+                value={settings.autoApproveDeferralDays}
+                onChange={(e) => update('autoApproveDeferralDays', Math.max(0, Math.min(60, Number(e.target.value) || 0)))}
+                className="mt-1 h-9 w-28 rounded-md border bg-background px-2 text-sm"
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      <PatchAppRulesSection apps={settings.apps} onChange={(apps) => update('apps', apps)} />
+```
+
+(Place `<PatchAppRulesSection>` before the Schedule section.)
+
+- [ ] **Step 7: Run PatchTab tests — PASS**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/components/configurationPolicies/featureTabs/PatchTab.test.tsx src/components/configurationPolicies/featureTabs/PatchAppRulesSection.test.tsx`
+Expected: PASS, including the 7 pre-existing PatchTab tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/components/configurationPolicies/featureTabs/
+git commit -m "feat(web): wired auto-approve and per-app rules in config policy patch tab"
+```
+
+---
+
+### Task 8: Verification + PR
+
+- [ ] **Step 1: Type-check both apps**
+
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+cd ../web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+```
+Expected: clean apart from documented pre-existing errors (`agents.test.ts`, `apiKeyAuth.test.ts`).
+
+- [ ] **Step 2: Run every touched test file once more**
+
+```bash
+cd packages/shared && npx vitest run src/validators/index_inline_settings.test.ts
+cd apps/api && npx vitest run src/services/patchApprovalEvaluator.test.ts src/jobs/patchJobExecutor.test.ts src/routes/configurationPolicies/patchJobs.test.ts src/routes/patches/appOptions.test.ts src/routes/patches/index.test.ts
+cd apps/web && npx vitest run src/components/configurationPolicies/featureTabs/
+```
+(All with the pinned-node PATH prefix.) Expected: PASS.
+
+- [ ] **Step 3: Push branch and open PR**
+
+PR body must cover: ring precedence semantics (policy auto-approve fires only ring-less), app rules overriding manual approvals in the job flow (manual per-device install unaffected), fail-closed handling (malformed policyAutoApprove → disabled; unparseable pin versions → held; dropped malformed app rules warned), and the test counts. Reference the spec and this plan.
+
+```bash
+git push -u origin worktree-patch-policy-auto-approve-app-rules
+gh pr create --title "feat(patches): policy-level auto-approve and per-app block/pin rules" --body-file <(...)
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** schema (Task 1), comparator + verdicts (Task 2), evaluator filtering + policy auto-approve + ring precedence (Task 3), executor fail-closed parsing (Task 4), both job-creation snapshots + resolve endpoint (Task 5), picker endpoint with catalog+observed+manual (Task 6 + manual entry in Task 7 UI), wired UI with ring-precedence notice (Task 7), verification (Task 8). Compatibility: all new fields default to no-op; legacy jobs unchanged (Tasks 1/4).
+- **Type consistency:** `PolicyAppRule` defined once in the evaluator (API side) and once locally in `PatchAppRulesSection` (web side, includes `displayName`); `PolicyAutoApproveConfig` exported from evaluator and imported by executor; `approvalReason` union extended consistently.
+- **Known judgment calls for the implementer:** the exact name of the evaluator test file's select-chain mock helper, and the executor test harness setup, must be copied from the neighboring existing tests rather than invented; test code above is written to slot into those patterns.

--- a/docs/superpowers/specs/2026-06-11-patch-policy-auto-approve-and-app-rules-design.md
+++ b/docs/superpowers/specs/2026-06-11-patch-policy-auto-approve-and-app-rules-design.md
@@ -1,0 +1,135 @@
+# Patch Policy Auto-Approve Wiring + Per-App Rules (Phase 3) — Design
+
+**Date:** 2026-06-11
+**Status:** Approved
+**Predecessors:** PR #1269 (`docs/superpowers/plans/2026-06-11-third-party-patch-sources.md`), May third-party patching plan (`docs/superpowers/plans/2026-05-13-windows-third-party-patching.md`)
+
+## Context
+
+PR #1269 shipped enforced `sources` filtering in the patch approval evaluator and the Patch Sources UI, but deliberately did **not** ship the policy-level auto-approval UI: `autoApprove`/`autoApproveSeverities` exist in `patchInlineSettingsSchema` (`packages/shared/src/validators/index.ts:456-457`) and round-trip through the Patch tab, yet no job-creation path reads them — auto-approval comes only from the linked update ring, and ring-less policies are manual-approval-only by evaluator design (`patchApprovalEvaluator.ts`: `if (!ringConfig.ringId) return null` for non-manual paths).
+
+This design covers both parked follow-ups as one combined effort:
+
+1. **Policy-level auto-approve wiring**, including the safety decision on ring-less policies.
+2. **Phase 3 of the gap analysis**: per-app allow/block lists, version pinning, catalog picker. The `third_party_package_catalog` table, seed data, and CRUD routes already exist (`apps/api/src/db/schema/thirdPartyCatalog.ts`, `apps/api/src/routes/thirdPartyCatalog/`).
+
+## Decisions (settled during brainstorming)
+
+| Question | Decision |
+|---|---|
+| Scope | Both follow-ups, one combined effort / one PR |
+| Ring-less auto-approve | **Allowed.** Policy fields govern when no ring is linked; a linked ring takes full precedence (policy fields ignored, UI says so explicitly) |
+| Per-app list model | **Blocklist on top of sources** — default is everything the selected sources allow; no allowlist mode |
+| Version pinning | **Hold-at-version** — evaluator excludes patches whose target version exceeds the pin; no agent changes |
+| Picker data source | Curated catalog + observed org patches + manual `(source, packageId)` entry |
+| Storage | Extend the inline-settings JSON (`patchInlineSettingsSchema`), same path `sources` took — no new tables, no RLS work |
+
+## Design
+
+### 1. Schema (`packages/shared/src/validators/index.ts`)
+
+Extend `patchInlineSettingsSchema`:
+
+```ts
+autoApproveDeferralDays: z.number().int().min(0).max(60).default(0),
+apps: z.array(z.object({
+  source: z.string().min(1).max(64),          // patches.source value, e.g. 'winget', 'homebrew'
+  packageId: z.string().min(1).max(256),
+  displayName: z.string().max(255).optional(), // snapshot for UI; identity is (source, packageId)
+  action: z.enum(['block', 'pin']),
+  pinnedVersion: z.string().max(64).optional(),
+})).max(200).default([]),
+```
+
+`superRefine` additions: `action: 'pin'` requires `pinnedVersion`; entries unique by `(source, packageId)`. Existing `autoApprove`/`autoApproveSeverities` fields and their cross-field refinement are unchanged. All new fields default to no-op values, so existing stored settings parse unchanged.
+
+### 2. Job creation (`routes/configurationPolicies/patchJobs.ts`, `jobs/patchSchedulerWorker.ts`)
+
+Both job-creation paths snapshot the same `patches` JSONB today (`{ ringId, ringName, categoryRules, autoApprove: ring.autoApprove, sources, ringValidation }`). Add:
+
+```ts
+policyAutoApprove: {
+  enabled: settings.autoApprove,
+  severities: settings.autoApproveSeverities,
+  deferralDays: settings.autoApproveDeferralDays,
+},
+apps: settings.apps,
+```
+
+Namespacing under `policyAutoApprove` keeps it unambiguous next to the existing ring-level `autoApprove` key.
+
+### 3. Executor (`jobs/patchJobExecutor.ts`)
+
+Extract the new keys with the same malformed-data posture as `sources`: absent → undefined (legacy job, no behavior change); present-but-malformed → ignore that key **loudly** (`console.warn`) rather than guessing. For `apps`, drop individual malformed entries with a warn; for `policyAutoApprove`, malformed → treated as disabled (fail-closed — the dangerous direction is silently widening installs, same reasoning as the sources handling at `patchJobExecutor.ts:373-388`).
+
+`RingConfig` keeps its name (renaming would churn every call site for no behavior change; its doc comment gains a note that it now also carries policy-level config) and gains:
+
+```ts
+policyAutoApprove?: { enabled: boolean; severities: string[]; deferralDays: number };
+apps?: PolicyAppRule[];
+```
+
+### 4. Evaluator (`services/patchApprovalEvaluator.ts`)
+
+**App rules filter (applies first, to all approval paths).** After the existing source filter, exclude candidates matching an app rule by `(source, packageId)`:
+
+- `block` → always excluded from the job flow, **including manually-approved patches** — consistent with how source filtering already excludes manually-approved third-party patches in an os-only job (PR #1269 semantics). Manual per-device install (`POST /devices/:id/patches/install`) remains unaffected.
+- `pin` → excluded when `compareVersions(patch.version, pinnedVersion) > 0`. `patches.version` exists (`db/schema/patches.ts:116`).
+- Exclusions logged like the existing source-exclusion warning.
+
+**Version comparator.** New exported `comparePatchVersions(a, b)`: tolerant numeric/alphanumeric segment comparison (split on `.`/`-`/`+`; numeric segments compared numerically, non-numeric lexicographically) — winget/homebrew versions are not strict semver. If either side is missing/unparseable, the patch is **held** (treated as exceeding the pin) with a `console.warn` — fail-closed matches pin intent.
+
+**Policy auto-approve path.** In `evaluatePatchApproval`, replace the bare ring-less early-return:
+
+```
+Priority 1: manual approval                      (unchanged)
+If ringId is null:
+  → if policyAutoApprove.enabled
+       AND patch.severity ∈ policyAutoApprove.severities
+       AND deferral window (deferralDays vs patch.releaseDate) has passed
+     → 'policy_auto_approve'
+  → else null
+Priority 2/3: category rule / legacy auto-approve (unchanged, ring-linked only)
+```
+
+When a ring **is** linked, `policyAutoApprove` is never consulted — ring precedence is absolute. A patch with `severity: null` never matches the severity list (no silent widening). New `approvalReason` value `'policy_auto_approve'` added to `ApprovedPatch` and anywhere reasons are displayed/audited.
+
+### 5. Picker endpoint (`routes/patches/`)
+
+Lives under `apps/api/src/routes/patches/` (it merges org-scoped patch data; `routes/thirdPartyCatalog/` stays pure system-catalog CRUD).
+
+`GET /patches/app-options?search=&limit=` (org-scoped): merges
+
+1. `third_party_package_catalog` rows (source, package_id, vendor, friendly_name), and
+2. distinct observed `(source, packageId, vendor, title)` from the org's `patches` rows where source is third-party,
+
+deduped by `(source, packageId)` (catalog metadata wins), filtered by case-insensitive search over name/vendor/packageId, capped (~50). Standard auth + org scoping; observed query runs under the request's RLS context as usual.
+
+### 6. Web UI (`components/configurationPolicies/featureTabs/PatchTab.tsx`)
+
+- **Automatic Approval section restored — now wired.** Toggle + severity checkboxes + deferral-days input bound to the schema fields. When the policy has a linked update ring (directly or inherited), the section renders disabled with copy: *"Automatic approval is governed by the linked update ring ‹name›. These settings apply only when no ring is linked."* This addresses the looks-configured-but-does-nothing trap that got the earlier UI reverted (a185f8fb).
+- **Application Rules section (new).** List of block/pin entries with action badge and pinned version; add-flow opens a picker (search against the new endpoint, manual-entry fallback for `(source, packageId)`); pin entries get a version input. Saves through the existing inline-settings payload; mutations already flow through `runAction` via the tab's save handler.
+- If `PatchTab.tsx` grows unwieldy, extract `PatchAppRulesSection.tsx` / `PatchAutoApproveSection.tsx` (CLAUDE.md file-size guidance — split for clarity, not line count).
+
+## Compatibility
+
+- All new schema fields default to no-op values; existing policies and stored settings are unaffected until an admin opts in.
+- Legacy jobs (no `policyAutoApprove`/`apps` keys in JSONB) behave exactly as today.
+- No migrations, no RLS changes, no agent changes.
+
+## Testing
+
+- **Evaluator** (extend `patchApprovalEvaluator.test.ts`): policy auto-approve approves ring-less matching patch; ring-linked ignores policy fields entirely; severity not in list / null severity → no approval; deferral window blocks until elapsed; block rule excludes even manually-approved patch; pin holds greater version, allows equal/lesser; unparseable version → held + warned; comparator table-driven cases (numeric, mixed, missing segments); combined sources + apps + auto-approve flow.
+- **Executor** (extend `patchJobExecutor.test.ts`): threads `policyAutoApprove`/`apps` to evaluator; malformed `policyAutoApprove` → disabled + warn; malformed `apps` entries dropped + warn; absent keys → undefined.
+- **Validators**: new field defaults; pin-requires-version; duplicate `(source, packageId)` rejected; existing autoApprove refinement still holds.
+- **Picker route**: merge/dedup/search behavior, org scoping.
+- **PatchTab component tests**: auto-approve section wired into save payload; ring-linked disabled state + notice; app rules add/remove/pin flows; stored-settings round-trip still preserved.
+- Per `breeze-testing` skill conventions throughout.
+
+## Out of scope
+
+- Exact-version installs / downgrades (agent command changes).
+- Allowlist mode for app rules.
+- Compliance view treating unmanaged third-party-missing as informational.
+- `firmware`/`drivers` sources (no agent provider).
+- Agent-side honoring of the `patch_scan` source parameter.

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -452,7 +452,7 @@ const patchSourceValueSchema = z.enum([
 ]);
 
 export const policyAppRuleSchema = z.object({
-  source: z.string().min(1).max(64),
+  source: z.enum(['third_party', 'custom']),
   packageId: z.string().min(1).max(256),
   displayName: z.string().max(255).optional(),
   action: z.enum(['block', 'pin']),
@@ -466,6 +466,8 @@ export const policyAppRuleSchema = z.object({
     });
   }
 });
+
+export type PolicyAppRule = z.infer<typeof policyAppRuleSchema>;
 
 export const patchInlineSettingsSchema = z.object({
   sources: z.array(patchSourceValueSchema).min(1).default(['os']),
@@ -489,7 +491,10 @@ export const patchInlineSettingsSchema = z.object({
 
   const seen = new Set<string>();
   for (const [i, app] of data.apps.entries()) {
-    const key = `${app.source}|${app.packageId.toLowerCase()}`;
+    // The approval evaluator matches 'third_party' and 'custom' as a single
+    // bucket, so canonicalize the source when deduping to mirror that.
+    const canonicalSource = app.source === 'custom' ? 'third_party' : app.source;
+    const key = `${canonicalSource}|${app.packageId.toLowerCase()}`;
     if (seen.has(key)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -451,10 +451,28 @@ const patchSourceValueSchema = z.enum([
   'linux',
 ]);
 
+export const policyAppRuleSchema = z.object({
+  source: z.string().min(1).max(64),
+  packageId: z.string().min(1).max(256),
+  displayName: z.string().max(255).optional(),
+  action: z.enum(['block', 'pin']),
+  pinnedVersion: z.string().min(1).max(64).optional(),
+}).superRefine((data, ctx) => {
+  if (data.action === 'pin' && !data.pinnedVersion) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['pinnedVersion'],
+      message: 'Pinned version is required for pin rules.',
+    });
+  }
+});
+
 export const patchInlineSettingsSchema = z.object({
   sources: z.array(patchSourceValueSchema).min(1).default(['os']),
   autoApprove: z.boolean().default(false),
   autoApproveSeverities: z.array(z.enum(['critical', 'important', 'moderate', 'low'])).default([]),
+  autoApproveDeferralDays: z.number().int().min(0).max(60).default(0),
+  apps: z.array(policyAppRuleSchema).max(200).default([]),
   scheduleFrequency: z.enum(['daily', 'weekly', 'monthly']).default('weekly'),
   scheduleTime: z.string().regex(/^([01]\d|2[0-3]):([0-5]\d)$/).default('02:00'),
   scheduleDayOfWeek: z.enum(['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']).default('sun'),
@@ -467,6 +485,19 @@ export const patchInlineSettingsSchema = z.object({
       path: ['autoApproveSeverities'],
       message: 'Select at least one severity for auto-approval.',
     });
+  }
+
+  const seen = new Set<string>();
+  for (const [i, app] of data.apps.entries()) {
+    const key = `${app.source}|${app.packageId.toLowerCase()}`;
+    if (seen.has(key)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['apps', i],
+        message: 'Duplicate app rule for the same source and package.',
+      });
+    }
+    seen.add(key);
   }
 });
 

--- a/packages/shared/src/validators/index_inline_settings.test.ts
+++ b/packages/shared/src/validators/index_inline_settings.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   patchInlineSettingsSchema,
+  policyAppRuleSchema,
   eventLogInlineSettingsSchema,
   sensitiveDataInlineSettingsSchema,
   monitoringInlineSettingsSchema,
@@ -84,6 +85,42 @@ describe('patchInlineSettingsSchema app rules + deferral', () => {
 
   it('still rejects autoApprove without severities (existing refinement intact)', () => {
     expect(patchInlineSettingsSchema.safeParse({ autoApprove: true, autoApproveSeverities: [] }).success).toBe(false);
+  });
+
+  it('rejects duplicates across the third_party/custom bucket (same packageId, different source)', () => {
+    const result = patchInlineSettingsSchema.safeParse({
+      apps: [
+        { source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' },
+        { source: 'custom', packageId: 'mozilla.firefox', action: 'pin', pinnedVersion: '120.0' },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects apps arrays longer than 200 entries', () => {
+    const apps = Array.from({ length: 201 }, (_, i) => ({
+      source: 'third_party' as const,
+      packageId: `Vendor.App${i}`,
+      action: 'block' as const,
+    }));
+    expect(patchInlineSettingsSchema.safeParse({ apps }).success).toBe(false);
+  });
+
+  it('rejects non-integer autoApproveDeferralDays', () => {
+    expect(patchInlineSettingsSchema.safeParse({ autoApproveDeferralDays: 2.5 }).success).toBe(false);
+  });
+});
+
+describe('policyAppRuleSchema source enum', () => {
+  it('accepts third_party and custom sources', () => {
+    expect(policyAppRuleSchema.safeParse({ source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' }).success).toBe(true);
+    expect(policyAppRuleSchema.safeParse({ source: 'custom', packageId: 'Internal.Tool', action: 'block' }).success).toBe(true);
+  });
+
+  it('rejects sources outside the third-party bucket enum', () => {
+    expect(policyAppRuleSchema.safeParse({ source: 'winget', packageId: 'Mozilla.Firefox', action: 'block' }).success).toBe(false);
+    expect(policyAppRuleSchema.safeParse({ source: 'Third_Party', packageId: 'Mozilla.Firefox', action: 'block' }).success).toBe(false);
+    expect(policyAppRuleSchema.safeParse({ source: '', packageId: 'Mozilla.Firefox', action: 'block' }).success).toBe(false);
   });
 });
 

--- a/packages/shared/src/validators/index_inline_settings.test.ts
+++ b/packages/shared/src/validators/index_inline_settings.test.ts
@@ -41,6 +41,52 @@ describe('patchInlineSettingsSchema', () => {
   });
 });
 
+describe('patchInlineSettingsSchema app rules + deferral', () => {
+  it('defaults autoApproveDeferralDays to 0 and apps to []', () => {
+    const result = patchInlineSettingsSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.autoApproveDeferralDays).toBe(0);
+    expect(result.data.apps).toEqual([]);
+  });
+
+  it('accepts a valid block rule and a valid pin rule', () => {
+    const result = patchInlineSettingsSchema.safeParse({
+      apps: [
+        { source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' },
+        { source: 'third_party', packageId: 'VideoLAN.VLC', displayName: 'VLC', action: 'pin', pinnedVersion: '3.0.20' },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a pin rule without pinnedVersion', () => {
+    const result = patchInlineSettingsSchema.safeParse({
+      apps: [{ source: 'third_party', packageId: 'VideoLAN.VLC', action: 'pin' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects duplicate (source, packageId) entries case-insensitively', () => {
+    const result = patchInlineSettingsSchema.safeParse({
+      apps: [
+        { source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' },
+        { source: 'third_party', packageId: 'mozilla.firefox', action: 'pin', pinnedVersion: '120.0' },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects negative or >60 deferral days', () => {
+    expect(patchInlineSettingsSchema.safeParse({ autoApproveDeferralDays: -1 }).success).toBe(false);
+    expect(patchInlineSettingsSchema.safeParse({ autoApproveDeferralDays: 61 }).success).toBe(false);
+  });
+
+  it('still rejects autoApprove without severities (existing refinement intact)', () => {
+    expect(patchInlineSettingsSchema.safeParse({ autoApprove: true, autoApproveSeverities: [] }).success).toBe(false);
+  });
+});
+
 // ============================================
 // Event Log Inline Settings
 // ============================================


### PR DESCRIPTION
## Summary

Implements policy-level patch auto-approval for ring-less configuration policies and per-app block/pin rules for automated patch jobs.

## What changed

- Extended shared patch inline settings with `autoApproveDeferralDays` and `apps` block/pin rules.
- Added evaluator support for app-rule filtering, tolerant version pin comparisons, and ring-less policy auto-approve.
- Threaded `policyAutoApprove` and `apps` through patch job JSONB snapshots and executor parsing.
- Added fail-closed handling for malformed executor inputs and pinned app versions that cannot be compared.
- Added `GET /patches/app-options` for the policy app-rule picker, merging curated catalog entries with observed third-party patches.
- Wired the Patch tab UI for automatic approval and per-app rules.
- Preserved JSON-only fields when normalized patch settings exist, so this works without a migration.

## Semantics

- Linked update rings take absolute precedence. Policy auto-approve is only consulted when `ringId` is null.
- App block/pin rules filter every approval path in the patch job flow, including manual approvals. Manual per-device installs are not affected by this evaluator path.
- Malformed `policyAutoApprove` is treated as disabled. Malformed app entries are dropped with warnings. Missing or incomparable versions for pinned apps are held.

## Validation

- `packages/shared`: `npx vitest run src/validators/index_inline_settings.test.ts` — 37 passed.
- `apps/api`: `npx vitest run src/services/patchApprovalEvaluator.test.ts src/jobs/patchJobExecutor.test.ts src/routes/configurationPolicies/patchJobs.test.ts src/routes/patches/appOptions.test.ts src/routes/patches/index.test.ts src/services/configPolicyPatching.test.ts` — 120 passed.
- `apps/web`: `npx vitest run src/components/configurationPolicies/featureTabs/` — 20 passed.
- `apps/api`: `npx tsc --noEmit` — passed.
- `apps/web`: `npx tsc --noEmit` — passed.
- `git diff --check` — passed.

Refs:
- `docs/superpowers/specs/2026-06-11-patch-policy-auto-approve-and-app-rules-design.md`
- `docs/superpowers/plans/2026-06-11-patch-policy-auto-approve-and-app-rules.md`