### PR TITLE
fix(security): close intra-tenant isolation, RBAC & audit gaps from authz review

### DIFF
--- a/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
@@ -345,6 +345,12 @@ describe('site-scope coverage — input-sourced / list-style', () => {
 // Vetted-safe: confirmed NOT a dead gate despite matching the static shape.
 // Each entry MUST carry a one-line justification.
 const DEAD_PERMS_GATE_EXEMPT: ReadonlySet<string> = new Set<string>([
+  // ws-ticket mint route sources its site gate from `auth.allowedSiteIds`
+  // (set unconditionally by authMiddleware via getUserPermissions — the same
+  // source as `permissions.allowedSiteIds`), not the `permissions` context, so
+  // the gate is live without requirePermission. Gating event-ticket minting
+  // behind DEVICES_READ would lock non-device roles out of org-level events.
+  'routes/eventWs.ts:POST /ws-ticket',
 ]);
 
 // BASELINE RATCHET — routes whose perms-sourced site gate is dead RIGHT NOW,

--- a/apps/api/src/routes/alertTemplates.test.ts
+++ b/apps/api/src/routes/alertTemplates.test.ts
@@ -130,6 +130,8 @@ vi.mock('../middleware/auth', () => ({
     return next();
   }),
   requireScope: vi.fn(() => (c: any, next: any) => next()),
+  requirePermission: vi.fn(() => (c: any, next: any) => next()),
+  requireMfa: vi.fn(() => (c: any, next: any) => next()),
 }));
 
 import { authMiddleware } from '../middleware/auth';

--- a/apps/api/src/routes/alertTemplates/rules.authz.test.ts
+++ b/apps/api/src/routes/alertTemplates/rules.authz.test.ts
@@ -76,6 +76,15 @@ describe('alert-template rules authz (Finding #6)', () => {
     expect(res.status).toBe(403);
   });
 
+  it('403 on PATCH /alert-templates/rules/:id without ALERTS_WRITE', async () => {
+    const res = await makeApp().request(`/alert-templates/rules/${RULE_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'r' }),
+    });
+    expect(res.status).toBe(403);
+  });
+
   it('403 on DELETE /alert-templates/rules/:id without ALERTS_WRITE', async () => {
     const res = await makeApp().request(`/alert-templates/rules/${RULE_ID}`, { method: 'DELETE' });
     expect(res.status).toBe(403);
@@ -96,6 +105,16 @@ describe('alert-template rules authz (Finding #6)', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({}),
+    });
+    expect(res.status).not.toBe(403);
+  });
+
+  it('passes the permission gate on PATCH when ALERTS_WRITE is granted', async () => {
+    grantedRef.current.add(ALERTS_WRITE);
+    const res = await makeApp().request(`/alert-templates/rules/${RULE_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'r' }),
     });
     expect(res.status).not.toBe(403);
   });

--- a/apps/api/src/routes/alertTemplates/rules.authz.test.ts
+++ b/apps/api/src/routes/alertTemplates/rules.authz.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Regression for Finding #6 (MEDIUM): alert-template rule mutations (create/
+// update/delete/toggle) must gate on ALERTS_WRITE in addition to scope tier.
+
+const { authRef, grantedRef } = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      scope: 'organization' as string,
+      user: { id: 'u-1', name: 'Reed Only', email: 'reed@org.example' },
+      partnerId: null as string | null,
+      orgId: 'org-1' as string | null,
+      accessibleOrgIds: null as string[] | null,
+      canAccessOrg: (_id: string) => true as boolean,
+    },
+  },
+  grantedRef: { current: new Set<string>() },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (_c: any, next: any) => next()),
+  requireScope: () => async (c: any, next: any) => {
+    if (!authRef.current) return c.json({ error: 'Not authenticated' }, 401);
+    c.set('auth', authRef.current);
+    await next();
+  },
+  requirePermission: (resource: string, action: string) => async (c: any, next: any) => {
+    if (!grantedRef.current.has(`${resource}:${action}`)) {
+      return c.json({ error: 'Forbidden' }, 403);
+    }
+    await next();
+  },
+  requireMfa: () => async (_c: any, next: any) => next(),
+}));
+
+vi.mock('../../db', () => ({ db: {} }));
+vi.mock('../../db/schema', () => ({ alertRules: {}, alertTemplates: {} }));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('./helpers', () => ({
+  resolveScopedOrgId: vi.fn(() => 'org-1'),
+  parseBoolean: vi.fn(() => undefined),
+}));
+vi.mock('../../utils/pagination', () => ({
+  getPagination: vi.fn(() => ({ page: 1, limit: 50, offset: 0 })),
+}));
+
+import { ruleRoutes } from './rules';
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/alert-templates', ruleRoutes);
+  return app;
+}
+
+const RULE_ID = '5d4c3b2a-1111-4222-8333-444455556666';
+const ALERTS_WRITE = 'alerts:write';
+
+describe('alert-template rules authz (Finding #6)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    grantedRef.current = new Set<string>();
+    authRef.current = {
+      scope: 'organization',
+      user: { id: 'u-1', name: 'Reed Only', email: 'reed@org.example' },
+      partnerId: null, orgId: 'org-1', accessibleOrgIds: null, canAccessOrg: () => true,
+    } as typeof authRef.current;
+  });
+
+  it('403 on POST /alert-templates/rules without ALERTS_WRITE', async () => {
+    const res = await makeApp().request('/alert-templates/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'r' }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('403 on DELETE /alert-templates/rules/:id without ALERTS_WRITE', async () => {
+    const res = await makeApp().request(`/alert-templates/rules/${RULE_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(403);
+  });
+
+  it('403 on POST /alert-templates/rules/:id/toggle without ALERTS_WRITE', async () => {
+    const res = await makeApp().request(`/alert-templates/rules/${RULE_ID}/toggle`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled: true }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('passes the permission gate on POST when ALERTS_WRITE is granted', async () => {
+    grantedRef.current.add(ALERTS_WRITE);
+    const res = await makeApp().request('/alert-templates/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).not.toBe(403);
+  });
+
+  it('passes the permission gate on DELETE when ALERTS_WRITE is granted', async () => {
+    grantedRef.current.add(ALERTS_WRITE);
+    const res = await makeApp().request(`/alert-templates/rules/${RULE_ID}`, { method: 'DELETE' });
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/apps/api/src/routes/alertTemplates/rules.ts
+++ b/apps/api/src/routes/alertTemplates/rules.ts
@@ -3,13 +3,16 @@ import { zValidator } from '@hono/zod-validator';
 import { db } from '../../db';
 import { alertRules, alertTemplates } from '../../db/schema';
 import { eq, and, like, or, desc } from 'drizzle-orm';
-import { requireScope } from '../../middleware/auth';
+import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { listRulesSchema, createRuleSchema, updateRuleSchema, toggleRuleSchema } from './schemas';
 import { resolveScopedOrgId, parseBoolean } from './helpers';
 import { getPagination } from '../../utils/pagination';
+import { PERMISSIONS } from '../../services/permissions';
 
 export const ruleRoutes = new Hono();
+
+const requireAlertWrite = requirePermission(PERMISSIONS.ALERTS_WRITE.resource, PERMISSIONS.ALERTS_WRITE.action);
 
 ruleRoutes.get(
   '/rules',
@@ -92,6 +95,8 @@ ruleRoutes.get(
 ruleRoutes.post(
   '/rules',
   requireScope('organization', 'partner', 'system'),
+  requireAlertWrite,
+  requireMfa(),
   zValidator('json', createRuleSchema),
   async (c) => {
     try {
@@ -216,6 +221,8 @@ ruleRoutes.get(
 ruleRoutes.patch(
   '/rules/:id',
   requireScope('organization', 'partner', 'system'),
+  requireAlertWrite,
+  requireMfa(),
   zValidator('json', updateRuleSchema),
   async (c) => {
     try {
@@ -278,6 +285,8 @@ ruleRoutes.patch(
 ruleRoutes.delete(
   '/rules/:id',
   requireScope('organization', 'partner', 'system'),
+  requireAlertWrite,
+  requireMfa(),
   async (c) => {
     try {
       const auth = c.get('auth');
@@ -316,6 +325,8 @@ ruleRoutes.delete(
 ruleRoutes.post(
   '/rules/:id/toggle',
   requireScope('organization', 'partner', 'system'),
+  requireAlertWrite,
+  requireMfa(),
   zValidator('json', toggleRuleSchema),
   async (c) => {
     try {

--- a/apps/api/src/routes/alertTemplates/templates.authz.test.ts
+++ b/apps/api/src/routes/alertTemplates/templates.authz.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Regression for Finding #6 (MEDIUM): alert-template mutations must gate on
+// ALERTS_WRITE in addition to scope tier.
+
+const { authRef, grantedRef } = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      scope: 'organization' as string,
+      user: { id: 'u-1', name: 'Reed Only', email: 'reed@org.example' },
+      partnerId: null as string | null,
+      orgId: 'org-1' as string | null,
+      accessibleOrgIds: null as string[] | null,
+      canAccessOrg: (_id: string) => true as boolean,
+    },
+  },
+  grantedRef: { current: new Set<string>() },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (_c: any, next: any) => next()),
+  requireScope: () => async (c: any, next: any) => {
+    if (!authRef.current) return c.json({ error: 'Not authenticated' }, 401);
+    c.set('auth', authRef.current);
+    await next();
+  },
+  requirePermission: (resource: string, action: string) => async (c: any, next: any) => {
+    if (!grantedRef.current.has(`${resource}:${action}`)) {
+      return c.json({ error: 'Forbidden' }, 403);
+    }
+    await next();
+  },
+  requireMfa: () => async (_c: any, next: any) => next(),
+}));
+
+vi.mock('../../db', () => ({ db: {} }));
+vi.mock('../../db/schema', () => ({ alertTemplates: {} }));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('./helpers', () => ({
+  resolveScopedOrgId: vi.fn(() => 'org-1'),
+  parseBoolean: vi.fn(() => undefined),
+}));
+vi.mock('../../utils/pagination', () => ({
+  getPagination: vi.fn(() => ({ page: 1, limit: 50, offset: 0 })),
+}));
+
+import { templateRoutes } from './templates';
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/alert-templates', templateRoutes);
+  return app;
+}
+
+const TEMPLATE_ID = '5d4c3b2a-1111-4222-8333-444455556666';
+const ALERTS_WRITE = 'alerts:write';
+
+describe('alert templates authz (Finding #6)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    grantedRef.current = new Set<string>();
+    authRef.current = {
+      scope: 'organization',
+      user: { id: 'u-1', name: 'Reed Only', email: 'reed@org.example' },
+      partnerId: null, orgId: 'org-1', accessibleOrgIds: null, canAccessOrg: () => true,
+    } as typeof authRef.current;
+  });
+
+  it('403 on POST /alert-templates/templates without ALERTS_WRITE', async () => {
+    const res = await makeApp().request('/alert-templates/templates', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 't' }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('403 on DELETE /alert-templates/templates/:id without ALERTS_WRITE', async () => {
+    const res = await makeApp().request(`/alert-templates/templates/${TEMPLATE_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(403);
+  });
+
+  it('passes the permission gate on POST when ALERTS_WRITE is granted', async () => {
+    grantedRef.current.add(ALERTS_WRITE);
+    const res = await makeApp().request('/alert-templates/templates', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).not.toBe(403);
+  });
+
+  it('passes the permission gate on DELETE when ALERTS_WRITE is granted', async () => {
+    grantedRef.current.add(ALERTS_WRITE);
+    const res = await makeApp().request(`/alert-templates/templates/${TEMPLATE_ID}`, { method: 'DELETE' });
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/apps/api/src/routes/alertTemplates/templates.ts
+++ b/apps/api/src/routes/alertTemplates/templates.ts
@@ -3,13 +3,16 @@ import { zValidator } from '@hono/zod-validator';
 import { db } from '../../db';
 import { alertTemplates } from '../../db/schema';
 import { eq, and, or, ilike, desc } from 'drizzle-orm';
-import { requireScope } from '../../middleware/auth';
+import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { listTemplatesSchema, createTemplateSchema, updateTemplateSchema } from './schemas';
 import { resolveScopedOrgId, parseBoolean } from './helpers';
 import { getPagination } from '../../utils/pagination';
+import { PERMISSIONS } from '../../services/permissions';
 
 export const templateRoutes = new Hono();
+
+const requireAlertWrite = requirePermission(PERMISSIONS.ALERTS_WRITE.resource, PERMISSIONS.ALERTS_WRITE.action);
 
 templateRoutes.get(
   '/templates',
@@ -121,6 +124,8 @@ templateRoutes.get(
 templateRoutes.post(
   '/templates',
   requireScope('organization', 'partner', 'system'),
+  requireAlertWrite,
+  requireMfa(),
   zValidator('json', createTemplateSchema),
   async (c) => {
     try {
@@ -214,6 +219,8 @@ templateRoutes.get(
 templateRoutes.patch(
   '/templates/:id',
   requireScope('organization', 'partner', 'system'),
+  requireAlertWrite,
+  requireMfa(),
   zValidator('json', updateTemplateSchema),
   async (c) => {
     try {
@@ -282,6 +289,8 @@ templateRoutes.patch(
 templateRoutes.delete(
   '/templates/:id',
   requireScope('organization', 'partner', 'system'),
+  requireAlertWrite,
+  requireMfa(),
   async (c) => {
     try {
       const auth = c.get('auth');

--- a/apps/api/src/routes/alerts/alerts.authz.test.ts
+++ b/apps/api/src/routes/alerts/alerts.authz.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Regression for Finding #6 (MEDIUM): alert state-change endpoints
+// (acknowledge/resolve/suppress/bulk) must gate on an alert RBAC permission in
+// addition to scope tier. acknowledge -> ALERTS_ACKNOWLEDGE; resolve/suppress/
+// bulk -> ALERTS_WRITE (mirrors the mobile alert routes).
+
+const { authRef, grantedRef } = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      scope: 'organization' as string,
+      user: { id: 'u-1', name: 'Reed Only', email: 'reed@org.example' },
+      partnerId: null as string | null,
+      orgId: 'org-1' as string | null,
+      accessibleOrgIds: null as string[] | null,
+      canAccessOrg: (_id: string) => true as boolean,
+    },
+  },
+  grantedRef: { current: new Set<string>() },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (_c: any, next: any) => next()),
+  requireScope: () => async (c: any, next: any) => {
+    if (!authRef.current) return c.json({ error: 'Not authenticated' }, 401);
+    c.set('auth', authRef.current);
+    await next();
+  },
+  requirePermission: (resource: string, action: string) => async (c: any, next: any) => {
+    if (!grantedRef.current.has(`${resource}:${action}`)) {
+      return c.json({ error: 'Forbidden' }, 403);
+    }
+    c.set('permissions', {});
+    await next();
+  },
+  requireMfa: () => async (_c: any, next: any) => next(),
+}));
+
+vi.mock('../../db', () => ({ db: {} }));
+vi.mock('../../db/schema', () => ({
+  alertRules: {}, alertTemplates: {}, alerts: {}, notificationChannels: {},
+  alertNotifications: {}, devices: {}, tickets: {}, ticketAlertLinks: {},
+}));
+vi.mock('../../services/alertCooldown', () => ({
+  setCooldown: vi.fn(), markConfigPolicyRuleCooldown: vi.fn(),
+}));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../../services/eventBus', () => ({ publishEvent: vi.fn() }));
+vi.mock('../../services/ticketService', () => ({
+  createTicketFromAlert: vi.fn(),
+  TicketServiceError: class TicketServiceError extends Error { status = 400; },
+}));
+vi.mock('./helpers', () => ({
+  getPagination: vi.fn(() => ({ page: 1, limit: 50, offset: 0 })),
+  ensureOrgAccess: vi.fn(() => true),
+  getAlertWithOrgCheck: vi.fn(),
+}));
+
+import { alertsRoutes } from './alerts';
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/alerts', alertsRoutes);
+  return app;
+}
+
+const ALERT_ID = '5d4c3b2a-1111-4222-8333-444455556666';
+const ALERTS_WRITE = 'alerts:write';
+const ALERTS_ACKNOWLEDGE = 'alerts:acknowledge';
+
+describe('alert state-change authz (Finding #6)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    grantedRef.current = new Set<string>();
+    authRef.current = {
+      scope: 'organization',
+      user: { id: 'u-1', name: 'Reed Only', email: 'reed@org.example' },
+      partnerId: null, orgId: 'org-1', accessibleOrgIds: null, canAccessOrg: () => true,
+    } as typeof authRef.current;
+  });
+
+  it('403 on POST /alerts/:id/acknowledge without ALERTS_ACKNOWLEDGE', async () => {
+    const res = await makeApp().request(`/alerts/${ALERT_ID}/acknowledge`, { method: 'POST' });
+    expect(res.status).toBe(403);
+  });
+
+  it('403 on POST /alerts/:id/resolve without ALERTS_WRITE', async () => {
+    const res = await makeApp().request(`/alerts/${ALERT_ID}/resolve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('403 on POST /alerts/:id/suppress without ALERTS_WRITE', async () => {
+    const res = await makeApp().request(`/alerts/${ALERT_ID}/suppress`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ until: '2030-01-01T00:00:00.000Z' }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('403 on POST /alerts/bulk without ALERTS_WRITE', async () => {
+    const res = await makeApp().request('/alerts/bulk', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ alertIds: [ALERT_ID], action: 'acknowledge' }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('passes the acknowledge gate when ALERTS_ACKNOWLEDGE is granted', async () => {
+    grantedRef.current.add(ALERTS_ACKNOWLEDGE);
+    const res = await makeApp().request(`/alerts/${ALERT_ID}/acknowledge`, { method: 'POST' });
+    expect(res.status).not.toBe(403);
+  });
+
+  it('passes the bulk gate when ALERTS_WRITE is granted', async () => {
+    grantedRef.current.add(ALERTS_WRITE);
+    const res = await makeApp().request('/alerts/bulk', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/apps/api/src/routes/alerts/alerts.ts
+++ b/apps/api/src/routes/alerts/alerts.ts
@@ -25,6 +25,15 @@ import { deviceInSiteScope } from '../tickets/siteScope';
 
 export const alertsRoutes = new Hono();
 
+// State-change handlers (acknowledge/resolve/suppress/bulk) gate on an alert
+// write/acknowledge RBAC permission in addition to scope tier. RLS enforces
+// tenancy but NOT intra-org role, so a read-only org user otherwise passes
+// requireScope('organization') + own-org RLS and could mutate alert state.
+// Mirrors the mobile alert routes: acknowledge → ALERTS_ACKNOWLEDGE,
+// resolve/suppress/bulk → ALERTS_WRITE.
+const requireAlertWrite = requirePermission(PERMISSIONS.ALERTS_WRITE.resource, PERMISSIONS.ALERTS_WRITE.action);
+const requireAlertAcknowledge = requirePermission(PERMISSIONS.ALERTS_ACKNOWLEDGE.resource, PERMISSIONS.ALERTS_ACKNOWLEDGE.action);
+
 const alertIdParamSchema = z.object({ id: z.string().uuid() });
 
 // GET /alerts - List alerts with filters
@@ -271,6 +280,7 @@ alertsRoutes.get(
 alertsRoutes.post(
   '/bulk',
   requireScope('organization', 'partner', 'system'),
+  requireAlertWrite,
   zValidator('json', bulkAlertActionSchema),
   async (c) => {
     const auth = c.get('auth');
@@ -380,6 +390,7 @@ alertsRoutes.post(
 alertsRoutes.post(
   '/:id/acknowledge',
   requireScope('organization', 'partner', 'system'),
+  requireAlertAcknowledge,
   zValidator('param', alertIdParamSchema),
   async (c) => {
     const auth = c.get('auth');
@@ -444,6 +455,7 @@ alertsRoutes.post(
 alertsRoutes.post(
   '/:id/resolve',
   requireScope('organization', 'partner', 'system'),
+  requireAlertWrite,
   zValidator('param', alertIdParamSchema),
   zValidator('json', resolveAlertSchema),
   async (c) => {
@@ -540,6 +552,7 @@ alertsRoutes.post(
 alertsRoutes.post(
   '/:id/suppress',
   requireScope('organization', 'partner', 'system'),
+  requireAlertWrite,
   zValidator('param', alertIdParamSchema),
   zValidator('json', suppressAlertSchema),
   async (c) => {

--- a/apps/api/src/routes/alerts/policies.authz.test.ts
+++ b/apps/api/src/routes/alerts/policies.authz.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Regression for Finding #6 (MEDIUM): escalation-policy mutations must gate on
+// ALERTS_WRITE in addition to scope tier.
+
+const { authRef, grantedRef } = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      scope: 'organization' as string,
+      user: { id: 'u-1', name: 'Reed Only', email: 'reed@org.example' },
+      partnerId: null as string | null,
+      orgId: 'org-1' as string | null,
+      accessibleOrgIds: null as string[] | null,
+      canAccessOrg: (_id: string) => true as boolean,
+    },
+  },
+  grantedRef: { current: new Set<string>() },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (_c: any, next: any) => next()),
+  requireScope: () => async (c: any, next: any) => {
+    if (!authRef.current) return c.json({ error: 'Not authenticated' }, 401);
+    c.set('auth', authRef.current);
+    await next();
+  },
+  requirePermission: (resource: string, action: string) => async (c: any, next: any) => {
+    if (!grantedRef.current.has(`${resource}:${action}`)) {
+      return c.json({ error: 'Forbidden' }, 403);
+    }
+    await next();
+  },
+  requireMfa: () => async (_c: any, next: any) => next(),
+}));
+
+vi.mock('../../db', () => ({ db: {} }));
+vi.mock('../../db/schema', () => ({ escalationPolicies: {} }));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('./helpers', () => ({
+  getPagination: vi.fn(() => ({ page: 1, limit: 50, offset: 0 })),
+  ensureOrgAccess: vi.fn(() => true),
+  getEscalationPolicyWithOrgCheck: vi.fn(),
+}));
+
+import { policiesRoutes } from './policies';
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/alerts', policiesRoutes);
+  return app;
+}
+
+const POLICY_ID = '5d4c3b2a-1111-4222-8333-444455556666';
+const ALERTS_WRITE = 'alerts:write';
+
+describe('escalation policies authz (Finding #6)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    grantedRef.current = new Set<string>();
+    authRef.current = {
+      scope: 'organization',
+      user: { id: 'u-1', name: 'Reed Only', email: 'reed@org.example' },
+      partnerId: null, orgId: 'org-1', accessibleOrgIds: null, canAccessOrg: () => true,
+    } as typeof authRef.current;
+  });
+
+  it('403 on POST /alerts/policies without ALERTS_WRITE', async () => {
+    const res = await makeApp().request('/alerts/policies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'p' }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('403 on DELETE /alerts/policies/:id without ALERTS_WRITE', async () => {
+    const res = await makeApp().request(`/alerts/policies/${POLICY_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(403);
+  });
+
+  it('passes the permission gate on POST when ALERTS_WRITE is granted', async () => {
+    grantedRef.current.add(ALERTS_WRITE);
+    const res = await makeApp().request('/alerts/policies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).not.toBe(403);
+  });
+
+  it('passes the permission gate on DELETE when ALERTS_WRITE is granted', async () => {
+    grantedRef.current.add(ALERTS_WRITE);
+    const res = await makeApp().request(`/alerts/policies/${POLICY_ID}`, { method: 'DELETE' });
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/apps/api/src/routes/alerts/policies.ts
+++ b/apps/api/src/routes/alerts/policies.ts
@@ -3,12 +3,15 @@ import { zValidator } from '@hono/zod-validator';
 import { and, eq, sql, desc, inArray } from 'drizzle-orm';
 import { db } from '../../db';
 import { escalationPolicies } from '../../db/schema';
-import { requireScope } from '../../middleware/auth';
+import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { listPoliciesSchema, createPolicySchema, updatePolicySchema } from './schemas';
 import { getPagination, ensureOrgAccess, getEscalationPolicyWithOrgCheck } from './helpers';
+import { PERMISSIONS } from '../../services/permissions';
 
 export const policiesRoutes = new Hono();
+
+const requireAlertWrite = requirePermission(PERMISSIONS.ALERTS_WRITE.resource, PERMISSIONS.ALERTS_WRITE.action);
 
 // GET /alerts/policies - List escalation policies
 policiesRoutes.get(
@@ -79,6 +82,8 @@ policiesRoutes.get(
 policiesRoutes.post(
   '/policies',
   requireScope('organization', 'partner', 'system'),
+  requireAlertWrite,
+  requireMfa(),
   zValidator('json', createPolicySchema),
   async (c) => {
     const auth = c.get('auth');
@@ -140,6 +145,8 @@ policiesRoutes.post(
 policiesRoutes.put(
   '/policies/:id',
   requireScope('organization', 'partner', 'system'),
+  requireAlertWrite,
+  requireMfa(),
   zValidator('json', updatePolicySchema),
   async (c) => {
     const auth = c.get('auth');
@@ -189,6 +196,8 @@ policiesRoutes.put(
 policiesRoutes.delete(
   '/policies/:id',
   requireScope('organization', 'partner', 'system'),
+  requireAlertWrite,
+  requireMfa(),
   async (c) => {
     const auth = c.get('auth');
     const policyId = c.req.param('id')!;

--- a/apps/api/src/routes/alerts/routing.authz.test.ts
+++ b/apps/api/src/routes/alerts/routing.authz.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Regression for Finding #6 (MEDIUM): notification routing-rule mutations must
+// gate on ALERTS_WRITE in addition to scope tier.
+
+const { authRef, grantedRef } = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      scope: 'organization' as string,
+      user: { id: 'u-1', name: 'Reed Only', email: 'reed@org.example' },
+      partnerId: null as string | null,
+      orgId: 'org-1' as string | null,
+      accessibleOrgIds: null as string[] | null,
+      canAccessOrg: (_id: string) => true as boolean,
+    },
+  },
+  grantedRef: { current: new Set<string>() },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (_c: any, next: any) => next()),
+  requireScope: () => async (c: any, next: any) => {
+    if (!authRef.current) return c.json({ error: 'Not authenticated' }, 401);
+    c.set('auth', authRef.current);
+    await next();
+  },
+  requirePermission: (resource: string, action: string) => async (c: any, next: any) => {
+    if (!grantedRef.current.has(`${resource}:${action}`)) {
+      return c.json({ error: 'Forbidden' }, 403);
+    }
+    await next();
+  },
+  requireMfa: () => async (_c: any, next: any) => next(),
+}));
+
+vi.mock('../../db', () => ({ db: {} }));
+vi.mock('../../db/schema', () => ({ notificationRoutingRules: {} }));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+
+import { routingRoutes } from './routing';
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/alerts', routingRoutes);
+  return app;
+}
+
+const RULE_ID = '5d4c3b2a-1111-4222-8333-444455556666';
+const ALERTS_WRITE = 'alerts:write';
+
+describe('notification routing rules authz (Finding #6)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    grantedRef.current = new Set<string>();
+    authRef.current = {
+      scope: 'organization',
+      user: { id: 'u-1', name: 'Reed Only', email: 'reed@org.example' },
+      partnerId: null, orgId: 'org-1', accessibleOrgIds: null, canAccessOrg: () => true,
+    } as typeof authRef.current;
+  });
+
+  it('403 on POST /alerts/routing-rules without ALERTS_WRITE', async () => {
+    const res = await makeApp().request('/alerts/routing-rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'r', priority: 0, conditions: {}, channelIds: ['x'] }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('403 on DELETE /alerts/routing-rules/:id without ALERTS_WRITE', async () => {
+    const res = await makeApp().request(`/alerts/routing-rules/${RULE_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(403);
+  });
+
+  it('passes the permission gate on POST when ALERTS_WRITE is granted', async () => {
+    grantedRef.current.add(ALERTS_WRITE);
+    const res = await makeApp().request('/alerts/routing-rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).not.toBe(403);
+  });
+
+  it('passes the permission gate on DELETE when ALERTS_WRITE is granted', async () => {
+    grantedRef.current.add(ALERTS_WRITE);
+    const res = await makeApp().request(`/alerts/routing-rules/${RULE_ID}`, { method: 'DELETE' });
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/apps/api/src/routes/alerts/routing.ts
+++ b/apps/api/src/routes/alerts/routing.ts
@@ -4,8 +4,9 @@ import { z } from 'zod';
 import { db } from '../../db';
 import { notificationRoutingRules } from '../../db/schema';
 import { eq, and, asc } from 'drizzle-orm';
-import { requireScope } from '../../middleware/auth';
+import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
+import { PERMISSIONS } from '../../services/permissions';
 
 const createRoutingRuleSchema = z.object({
   name: z.string().min(1).max(255),
@@ -35,6 +36,8 @@ const updateRoutingRuleSchema = z.object({
 
 export const routingRoutes = new Hono();
 
+const requireAlertWrite = requirePermission(PERMISSIONS.ALERTS_WRITE.resource, PERMISSIONS.ALERTS_WRITE.action);
+
 routingRoutes.get(
   '/routing-rules',
   requireScope('organization', 'partner', 'system'),
@@ -63,6 +66,8 @@ routingRoutes.get(
 routingRoutes.post(
   '/routing-rules',
   requireScope('organization', 'partner', 'system'),
+  requireAlertWrite,
+  requireMfa(),
   zValidator('json', createRoutingRuleSchema),
   async (c) => {
     try {
@@ -106,6 +111,8 @@ routingRoutes.post(
 routingRoutes.patch(
   '/routing-rules/:id',
   requireScope('organization', 'partner', 'system'),
+  requireAlertWrite,
+  requireMfa(),
   zValidator('json', updateRoutingRuleSchema),
   async (c) => {
     try {
@@ -161,6 +168,8 @@ routingRoutes.patch(
 routingRoutes.delete(
   '/routing-rules/:id',
   requireScope('organization', 'partner', 'system'),
+  requireAlertWrite,
+  requireMfa(),
   async (c) => {
     try {
       const auth = c.get('auth');

--- a/apps/api/src/routes/alerts/rules.authz.test.ts
+++ b/apps/api/src/routes/alerts/rules.authz.test.ts
@@ -85,6 +85,15 @@ describe('alert rules authz (Finding #6)', () => {
     expect(res.status).toBe(403);
   });
 
+  it('403 on PUT /alerts/rules/:id without ALERTS_WRITE', async () => {
+    const res = await makeApp().request(`/alerts/rules/${RULE_ID}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'r' }),
+    });
+    expect(res.status).toBe(403);
+  });
+
   it('403 on DELETE /alerts/rules/:id without ALERTS_WRITE', async () => {
     const res = await makeApp().request(`/alerts/rules/${RULE_ID}`, { method: 'DELETE' });
     expect(res.status).toBe(403);
@@ -99,6 +108,18 @@ describe('alert rules authz (Finding #6)', () => {
     });
     // Past the gate: a zValidator 400 (bad body) proves we are no longer blocked
     // by a permission 403.
+    expect(res.status).not.toBe(403);
+  });
+
+  it('passes the permission gate on PUT when ALERTS_WRITE is granted', async () => {
+    grantedRef.current.add(ALERTS_WRITE);
+    const res = await makeApp().request(`/alerts/rules/${RULE_ID}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'r' }),
+    });
+    // Past the gate: getAlertRuleWithOrgCheck mock returns undefined → 404
+    // (not found), proving we are no longer blocked by a permission 403.
     expect(res.status).not.toBe(403);
   });
 

--- a/apps/api/src/routes/alerts/rules.authz.test.ts
+++ b/apps/api/src/routes/alerts/rules.authz.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Regression test for Finding #6 (MEDIUM): alert-rule mutation endpoints must
+// gate on the ALERTS_WRITE RBAC permission in addition to scope tier. RLS
+// enforces tenancy but NOT intra-org role, so without this gate a read-only
+// org user (who passes requireScope('organization') + own-org RLS) could
+// create/update/delete alert rules.
+
+const { authRef, grantedRef } = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      scope: 'organization' as string,
+      user: { id: 'u-1', name: 'Reed Only', email: 'reed@org.example' },
+      partnerId: null as string | null,
+      orgId: 'org-1' as string | null,
+      accessibleOrgIds: null as string[] | null,
+      canAccessOrg: (_id: string) => true as boolean,
+    },
+  },
+  // Permission keys the caller currently holds (resource:action).
+  grantedRef: { current: new Set<string>() },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (_c: any, next: any) => next()),
+  requireScope: () => async (c: any, next: any) => {
+    if (!authRef.current) return c.json({ error: 'Not authenticated' }, 401);
+    c.set('auth', authRef.current);
+    await next();
+  },
+  // Real requirePermission returns 403 when the caller lacks the grant. The mock
+  // mirrors that so the regression actually exercises the gate.
+  requirePermission: (resource: string, action: string) => async (c: any, next: any) => {
+    if (!grantedRef.current.has(`${resource}:${action}`)) {
+      return c.json({ error: 'Forbidden' }, 403);
+    }
+    await next();
+  },
+  requireMfa: () => async (_c: any, next: any) => next(),
+}));
+
+vi.mock('../../db', () => ({ db: {} }));
+vi.mock('../../db/schema', () => ({
+  alertRules: {}, alertTemplates: {}, alerts: {}, devices: {},
+}));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('./helpers', () => ({
+  getPagination: vi.fn(() => ({ page: 1, limit: 50, offset: 0 })),
+  ensureOrgAccess: vi.fn(() => true),
+  getAlertRuleWithOrgCheck: vi.fn(),
+  normalizeTargetsForRule: vi.fn(() => ({ targetType: 'device', targetId: 'd-1', targetIds: ['d-1'], targets: [] })),
+  formatAlertRuleResponse: vi.fn((r: unknown) => r),
+  resolveAlertTemplate: vi.fn(),
+}));
+
+import { rulesRoutes } from './rules';
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/alerts', rulesRoutes);
+  return app;
+}
+
+const RULE_ID = '5d4c3b2a-1111-4222-8333-444455556666';
+const ALERTS_WRITE = 'alerts:write';
+
+describe('alert rules authz (Finding #6)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    grantedRef.current = new Set<string>();
+    authRef.current = {
+      scope: 'organization',
+      user: { id: 'u-1', name: 'Reed Only', email: 'reed@org.example' },
+      partnerId: null, orgId: 'org-1', accessibleOrgIds: null, canAccessOrg: () => true,
+    } as typeof authRef.current;
+  });
+
+  it('403 on POST /alerts/rules without ALERTS_WRITE', async () => {
+    const res = await makeApp().request('/alerts/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'r', severity: 'high' }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('403 on DELETE /alerts/rules/:id without ALERTS_WRITE', async () => {
+    const res = await makeApp().request(`/alerts/rules/${RULE_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(403);
+  });
+
+  it('passes the permission gate on POST when ALERTS_WRITE is granted', async () => {
+    grantedRef.current.add(ALERTS_WRITE);
+    const res = await makeApp().request('/alerts/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    // Past the gate: a zValidator 400 (bad body) proves we are no longer blocked
+    // by a permission 403.
+    expect(res.status).not.toBe(403);
+  });
+
+  it('passes the permission gate on DELETE when ALERTS_WRITE is granted', async () => {
+    grantedRef.current.add(ALERTS_WRITE);
+    const res = await makeApp().request(`/alerts/rules/${RULE_ID}`, { method: 'DELETE' });
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/apps/api/src/routes/alerts/rules.ts
+++ b/apps/api/src/routes/alerts/rules.ts
@@ -3,8 +3,9 @@ import { zValidator } from '@hono/zod-validator';
 import { and, eq, sql, desc, inArray } from 'drizzle-orm';
 import { db } from '../../db';
 import { alertRules, alertTemplates, alerts, devices } from '../../db/schema';
-import { requireScope } from '../../middleware/auth';
+import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
+import { PERMISSIONS } from '../../services/permissions';
 import {
   listAlertRulesSchema,
   createAlertRuleSchema,
@@ -26,6 +27,8 @@ import {
 } from './helpers';
 
 export const rulesRoutes = new Hono();
+
+const requireAlertWrite = requirePermission(PERMISSIONS.ALERTS_WRITE.resource, PERMISSIONS.ALERTS_WRITE.action);
 
 // GET /alerts/rules - List alert rules with pagination
 rulesRoutes.get(
@@ -130,6 +133,8 @@ rulesRoutes.get(
 rulesRoutes.post(
   '/rules',
   requireScope('organization', 'partner', 'system'),
+  requireAlertWrite,
+  requireMfa(),
   zValidator('json', createAlertRuleSchema),
   async (c) => {
     const auth = c.get('auth');
@@ -251,6 +256,8 @@ rulesRoutes.post(
 rulesRoutes.put(
   '/rules/:id',
   requireScope('organization', 'partner', 'system'),
+  requireAlertWrite,
+  requireMfa(),
   zValidator('json', updateAlertRuleSchema),
   async (c) => {
     const auth = c.get('auth');
@@ -431,6 +438,8 @@ rulesRoutes.put(
 rulesRoutes.delete(
   '/rules/:id',
   requireScope('organization', 'partner', 'system'),
+  requireAlertWrite,
+  requireMfa(),
   async (c) => {
     const auth = c.get('auth');
     const ruleId = c.req.param('id')!;

--- a/apps/api/src/routes/cisHardening.ts
+++ b/apps/api/src/routes/cisHardening.ts
@@ -792,6 +792,7 @@ cisHardeningRoutes.post(
       .select({
         id: cisRemediationActions.id,
         orgId: cisRemediationActions.orgId,
+        deviceId: cisRemediationActions.deviceId,
         status: cisRemediationActions.status,
         approvalStatus: cisRemediationActions.approvalStatus,
       })
@@ -805,6 +806,36 @@ cisHardeningRoutes.post(
         error: 'One or more remediation actions were not found or are outside your scope',
         missingIds,
       }, 404);
+    }
+
+    // Site-scope re-check (FINDING #11): RLS only defends the org axis. A
+    // site-restricted user could otherwise approve/queue pending actions another
+    // tech created for devices outside their site allowlist, dispatching CIS
+    // hardening/rollback commands to endpoints beyond their authority. Mirror the
+    // `assertDeviceAccess` / `POST /cis/remediate` site check on each action's
+    // target device before any status flip. Empty/unset allowlist = full org access.
+    const permissions = c.get('permissions') as UserPermissions | undefined;
+    if (permissions?.allowedSiteIds) {
+      const targetDeviceIds = Array.from(new Set(actions.map((action) => action.deviceId)));
+      const deviceRows = await db
+        .select({ id: devices.id, siteId: devices.siteId })
+        .from(devices)
+        .where(inArray(devices.id, targetDeviceIds));
+      const deviceSiteById = new Map(deviceRows.map((row) => [row.id, row.siteId]));
+
+      const deniedActionIds = actions
+        .filter((action) => {
+          const siteId = deviceSiteById.get(action.deviceId);
+          return typeof siteId !== 'string' || !canAccessSite(permissions, siteId);
+        })
+        .map((action) => action.id);
+
+      if (deniedActionIds.length > 0) {
+        return c.json({
+          error: 'One or more remediation actions target a device outside your site scope',
+          deniedActionIds,
+        }, 403);
+      }
     }
 
     const pendingIds = actions

--- a/apps/api/src/routes/cisHardening.ts
+++ b/apps/api/src/routes/cisHardening.ts
@@ -808,7 +808,7 @@ cisHardeningRoutes.post(
       }, 404);
     }
 
-    // Site-scope re-check (FINDING #11): RLS only defends the org axis. A
+    // Site-scope re-check: RLS only defends the org axis. A
     // site-restricted user could otherwise approve/queue pending actions another
     // tech created for devices outside their site allowlist, dispatching CIS
     // hardening/rollback commands to endpoints beyond their authority. Mirror the

--- a/apps/api/src/routes/cisHardening_site_scope.test.ts
+++ b/apps/api/src/routes/cisHardening_site_scope.test.ts
@@ -120,6 +120,7 @@ vi.mock('./networkShared', () => ({
 
 import { cisHardeningRoutes } from './cisHardening';
 import { db } from '../db';
+import { scheduleCisRemediationWithResult } from '../jobs/cisJobs';
 
 const ORG_ID = 'org-111';
 const DEVICE_ID = '22222222-2222-2222-2222-222222222222';
@@ -436,6 +437,100 @@ describe('CIS hardening — site-scope enforcement', () => {
 
       expect(res.status).toBe(200);
       expect(conditionText(countWhere)).not.toContain('devices.siteId');
+    });
+  });
+
+  describe('POST /cis/remediate/approve', () => {
+    const ACTION_ID = '44444444-4444-4444-4444-444444444444';
+
+    // Approve handler issues: (1) select actions, (2) select devices for the
+    // site re-check (only when allowedSiteIds is set), (3) update + queue.
+    function rigActionsLookup(rows: unknown[]) {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(rows),
+        }),
+      } as never);
+    }
+
+    function rigDevicesSiteLookup(rows: unknown[]) {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(rows),
+        }),
+      } as never);
+    }
+
+    it('returns 403 when an action targets a device outside the site allowlist', async () => {
+      rigActionsLookup([
+        {
+          id: ACTION_ID,
+          orgId: ORG_ID,
+          deviceId: DEVICE_ID,
+          status: 'pending_approval',
+          approvalStatus: 'pending',
+        },
+      ]);
+      // Target device lives in the FORBIDDEN site
+      rigDevicesSiteLookup([{ id: DEVICE_ID, siteId: FORBIDDEN_SITE_ID }]);
+
+      const res = await app.request('/cis/remediate/approve', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer t',
+          'Content-Type': 'application/json',
+          'x-restrict-site': DEVICE_SITE_ID,
+        },
+        body: JSON.stringify({ actionIds: [ACTION_ID], approved: true }),
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toMatch(/site/i);
+      expect(body.deniedActionIds).toEqual([ACTION_ID]);
+      // No status flip / queue dispatch should have occurred
+      expect(scheduleCisRemediationWithResult).not.toHaveBeenCalled();
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('approves and queues when the action device is within the site allowlist', async () => {
+      rigActionsLookup([
+        {
+          id: ACTION_ID,
+          orgId: ORG_ID,
+          deviceId: DEVICE_ID,
+          status: 'pending_approval',
+          approvalStatus: 'pending',
+        },
+      ]);
+      // Target device lives in the ALLOWED site
+      rigDevicesSiteLookup([{ id: DEVICE_ID, siteId: DEVICE_SITE_ID }]);
+      // Approval update
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      } as never);
+      vi.mocked(scheduleCisRemediationWithResult).mockResolvedValueOnce({
+        queuedActionIds: [ACTION_ID],
+        failedActionIds: [],
+      } as never);
+
+      const res = await app.request('/cis/remediate/approve', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer t',
+          'Content-Type': 'application/json',
+          'x-restrict-site': DEVICE_SITE_ID,
+        },
+        body: JSON.stringify({ actionIds: [ACTION_ID], approved: true }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.approved).toBe(true);
+      expect(body.queued).toBe(1);
+      expect(scheduleCisRemediationWithResult).toHaveBeenCalledWith([ACTION_ID]);
     });
   });
 

--- a/apps/api/src/routes/eventWs.test.ts
+++ b/apps/api/src/routes/eventWs.test.ts
@@ -37,6 +37,7 @@ import {
   createEventWsTicket,
   consumeTicket,
   createEventWsTicketRoute,
+  buildSiteFilter,
   _clearTicketStore,
 } from './eventWs';
 
@@ -76,6 +77,115 @@ describe('createEventWsTicket', () => {
 
   it('rejects an empty orgIds array', async () => {
     await expect(createEventWsTicket('user-1', [])).rejects.toThrow();
+  });
+
+  it('carries allowedSiteIds onto the consumed identity', async () => {
+    const { ticket } = await createEventWsTicket('user-1', 'org-1', ['site-a', 'site-b']);
+    const identity = await consumeTicket(ticket);
+    expect(identity).toEqual({
+      userId: 'user-1',
+      orgIds: ['org-1'],
+      allowedSiteIds: ['site-a', 'site-b'],
+    });
+  });
+
+  it('treats an empty allowedSiteIds array as unrestricted (full org access)', async () => {
+    const { ticket } = await createEventWsTicket('user-1', 'org-1', []);
+    const identity = await consumeTicket(ticket);
+    expect(identity).toEqual({ userId: 'user-1', orgIds: ['org-1'], allowedSiteIds: undefined });
+  });
+
+  it('omits allowedSiteIds when not provided (unrestricted)', async () => {
+    const { ticket } = await createEventWsTicket('user-1', 'org-1');
+    const identity = await consumeTicket(ticket);
+    expect(identity?.allowedSiteIds).toBeUndefined();
+  });
+});
+
+// -------------------------------------------------------------------
+// Tests: site-scope delivery predicate (Finding #8)
+//
+// A site-restricted client must NOT receive live events for devices/sites
+// outside its allowlist. Events are delivered over Redis pub/sub with no DB
+// backstop, so the WS layer is the only enforcement point.
+// -------------------------------------------------------------------
+
+describe('buildSiteFilter', () => {
+  it('returns undefined for an unrestricted user (no allowlist)', () => {
+    expect(buildSiteFilter(undefined)).toBeUndefined();
+    expect(buildSiteFilter([])).toBeUndefined();
+  });
+
+  it('delivers an in-site event (siteId on payload)', () => {
+    const filter = buildSiteFilter(['site-a']);
+    expect(filter).toBeTypeOf('function');
+    const event = { type: 'alert.triggered', payload: { deviceId: 'dev-1', siteId: 'site-a' } };
+    expect(filter!(event)).toBe(true);
+  });
+
+  it('delivers an in-site event (siteId at top level)', () => {
+    const filter = buildSiteFilter(['site-a']);
+    const event = { type: 'device.offline', siteId: 'site-a', payload: { deviceId: 'dev-1' } };
+    expect(filter!(event)).toBe(true);
+  });
+
+  it('drops an out-of-site event for a site-restricted client', () => {
+    const filter = buildSiteFilter(['site-a']);
+    const event = { type: 'alert.triggered', payload: { deviceId: 'dev-2', siteId: 'site-b' } };
+    expect(filter!(event)).toBe(false);
+  });
+
+  it('fails closed: drops an event with no attributable siteId', () => {
+    const filter = buildSiteFilter(['site-a']);
+    // deviceId-only payload (the current real-world shape — publishers emit no
+    // siteId), and a fully org-level event with no device context.
+    expect(filter!({ type: 'alert.triggered', payload: { deviceId: 'dev-1' } })).toBe(false);
+    expect(filter!({ type: 'incident.created', payload: { userId: 'user-9' } })).toBe(false);
+    expect(filter!({ type: 'user.login' })).toBe(false);
+  });
+
+  it('matches any one of multiple allowed sites', () => {
+    const filter = buildSiteFilter(['site-a', 'site-c']);
+    expect(filter!({ type: 'device.online', payload: { siteId: 'site-c' } })).toBe(true);
+    expect(filter!({ type: 'device.online', payload: { siteId: 'site-b' } })).toBe(false);
+  });
+});
+
+// -------------------------------------------------------------------
+// Tests: the filter built for a registered client enforces site scope
+//
+// Models how the dispatcher consults `client.filter` at send time: an
+// in-site event is delivered, an out-of-site / unattributable event is
+// dropped, and an unrestricted client (no filter) receives everything.
+// (End-to-end dispatch wiring is covered in eventDispatcher.test.ts.)
+// -------------------------------------------------------------------
+
+describe('registered-client site filter enforcement', () => {
+  // Mirrors EventDispatcher.dispatch(): subscription-type match AND, when a
+  // per-client predicate is present, predicate match.
+  function delivers(client: { subscribedTypes: Set<string>; filter?: (e: any) => boolean }, event: any): boolean {
+    const matchesType = client.subscribedTypes.has('*') || client.subscribedTypes.has(event.type);
+    if (!matchesType) return false;
+    return client.filter ? client.filter(event) : true;
+  }
+
+  const inSite = { type: 'alert.triggered', payload: { deviceId: 'd1', siteId: 'site-a' } };
+  const outOfSite = { type: 'alert.triggered', payload: { deviceId: 'd2', siteId: 'site-b' } };
+  const noSite = { type: 'alert.triggered', payload: { deviceId: 'd3' } };
+
+  it('site-restricted client receives in-site events only', () => {
+    const client = { subscribedTypes: new Set(['*']), filter: buildSiteFilter(['site-a']) };
+    expect(delivers(client, inSite)).toBe(true);
+    expect(delivers(client, outOfSite)).toBe(false);
+    expect(delivers(client, noSite)).toBe(false); // fail closed
+  });
+
+  it('unrestricted client receives all events', () => {
+    const client = { subscribedTypes: new Set(['*']), filter: buildSiteFilter(undefined) };
+    expect(client.filter).toBeUndefined();
+    expect(delivers(client, inSite)).toBe(true);
+    expect(delivers(client, outOfSite)).toBe(true);
+    expect(delivers(client, noSite)).toBe(true);
   });
 });
 

--- a/apps/api/src/routes/eventWs.test.ts
+++ b/apps/api/src/routes/eventWs.test.ts
@@ -360,4 +360,71 @@ describe('createEventWsTicketRoute', () => {
     const identity = await consumeTicket(body.ticket);
     expect(identity).toEqual({ userId: 'user-abc', orgIds: ['org-xyz'] });
   });
+
+  // Regression guard (Finding #8): the SITE-scope restriction must be sourced
+  // from the authenticated identity (`auth.allowedSiteIds`, set by
+  // authMiddleware) and threaded into the minted ticket — NOT from
+  // `c.get('permissions')`, which is only populated by `requirePermission` and
+  // never runs on this route. This test exercises the real route handler end to
+  // end (auth context → route → minted ticket → consumed identity), so it goes
+  // red if the handler is reverted to read `permissions` (which would be
+  // undefined here, dropping the restriction).
+  it('threads allowedSiteIds from the authenticated identity into the minted ticket', async () => {
+    const { Hono } = await import('hono');
+    const app = new Hono();
+
+    app.use('*', async (c, next) => {
+      c.set('auth', {
+        user: { id: 'user-abc', email: 'a@b.com', name: 'A' },
+        orgId: 'org-xyz',
+        // Site restriction lives on the auth identity (authMiddleware), not on
+        // `permissions`. The route MUST read this field.
+        allowedSiteIds: ['site-a'],
+      } as any);
+      // Defensive: even if `permissions` carried a different value, the route
+      // must ignore it. A reverted handler reading `permissions.allowedSiteIds`
+      // would pick up the wrong restriction and fail the assertion below.
+      c.set('permissions', { allowedSiteIds: ['site-WRONG'] } as any);
+      await next();
+    });
+
+    const ticketApp = createEventWsTicketRoute();
+    app.route('/events', ticketApp);
+
+    const res = await app.request('/events/ws-ticket', { method: 'POST' });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    const identity = await consumeTicket(body.ticket);
+    expect(identity).toEqual({
+      userId: 'user-abc',
+      orgIds: ['org-xyz'],
+      allowedSiteIds: ['site-a'],
+    });
+  });
+
+  it('mints an unrestricted ticket when the identity carries no allowedSiteIds', async () => {
+    const { Hono } = await import('hono');
+    const app = new Hono();
+
+    app.use('*', async (c, next) => {
+      c.set('auth', {
+        user: { id: 'user-abc', email: 'a@b.com', name: 'A' },
+        orgId: 'org-xyz',
+        // No allowedSiteIds → unrestricted (full org access).
+      } as any);
+      await next();
+    });
+
+    const ticketApp = createEventWsTicketRoute();
+    app.route('/events', ticketApp);
+
+    const res = await app.request('/events/ws-ticket', { method: 'POST' });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    const identity = await consumeTicket(body.ticket);
+    expect(identity).toEqual({ userId: 'user-abc', orgIds: ['org-xyz'] });
+    expect(identity?.allowedSiteIds).toBeUndefined();
+  });
 });

--- a/apps/api/src/routes/eventWs.ts
+++ b/apps/api/src/routes/eventWs.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { getRedis } from '../services/redis';
 import { getEventDispatcher, type ClientEntry } from '../services/eventDispatcher';
 import { authMiddleware, resolveOrgAccess } from '../middleware/auth';
+import type { UserPermissions } from '../services/permissions';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -30,6 +31,13 @@ interface TicketRecord {
   // in-memory across a deploy) still parse cleanly. New writes always
   // populate orgIds.
   orgId?: string;
+  // App-layer-only SITE-scope axis (`permissions.allowedSiteIds`). RLS only
+  // enforces ORG; events are delivered over Redis pub/sub with no DB backstop,
+  // so a site-restricted user's connection must be filtered in the WS layer
+  // (see `buildSiteFilter` / the dispatch-time predicate). `undefined` or
+  // empty = full org access (no site restriction). Captured at mint time so
+  // the restriction is bound to the ticket, not re-derived at connect time.
+  allowedSiteIds?: string[];
   expiresAt: number;
 }
 
@@ -58,6 +66,7 @@ function purgeExpired(): void {
 export async function createEventWsTicket(
   userId: string,
   orgIdOrIds: string | string[],
+  allowedSiteIds?: string[],
 ): Promise<{ ticket: string; expiresInSeconds: number }> {
   purgeExpired();
 
@@ -66,6 +75,12 @@ export async function createEventWsTicket(
     throw new Error('createEventWsTicket requires at least one orgId');
   }
 
+  // Only persist a site restriction when one is actually present. An empty or
+  // undefined allowlist means "no site restriction" (full org access) and is
+  // dropped so the ticket carries no `allowedSiteIds` key.
+  const normalisedSiteIds =
+    allowedSiteIds && allowedSiteIds.length > 0 ? [...new Set(allowedSiteIds)] : undefined;
+
   const ticket = randomBytes(32).toString('base64url');
   const record: TicketRecord = {
     userId,
@@ -73,6 +88,7 @@ export async function createEventWsTicket(
     // Populate the legacy field for forward compat with any reader that
     // hasn't been redeployed yet. Pick the first id deterministically.
     orgId: orgIds[0],
+    ...(normalisedSiteIds ? { allowedSiteIds: normalisedSiteIds } : {}),
     expiresAt: Date.now() + TICKET_TTL_MS,
   };
 
@@ -105,7 +121,16 @@ const CONSUME_LUA = `
   return v
 `;
 
-function normaliseTicketRecord(record: TicketRecord): { userId: string; orgIds: string[] } | null {
+export interface TicketIdentity {
+  userId: string;
+  orgIds: string[];
+  // Carried from the ticket. `undefined` = no site restriction (full org
+  // access); a non-empty array means the connection may only receive events
+  // positively attributable to one of these sites.
+  allowedSiteIds?: string[];
+}
+
+function normaliseTicketRecord(record: TicketRecord): TicketIdentity | null {
   // Backward-compat: an older record might only carry orgId.
   const ids = record.orgIds && record.orgIds.length > 0
     ? record.orgIds
@@ -113,10 +138,12 @@ function normaliseTicketRecord(record: TicketRecord): { userId: string; orgIds: 
       ? [record.orgId]
       : [];
   if (ids.length === 0) return null;
-  return { userId: record.userId, orgIds: ids };
+  const allowedSiteIds =
+    record.allowedSiteIds && record.allowedSiteIds.length > 0 ? record.allowedSiteIds : undefined;
+  return { userId: record.userId, orgIds: ids, allowedSiteIds };
 }
 
-export async function consumeTicket(ticket: string): Promise<{ userId: string; orgIds: string[] } | null> {
+export async function consumeTicket(ticket: string): Promise<TicketIdentity | null> {
   if (shouldUseRedis()) {
     const redis = getRedis();
     if (!redis) {
@@ -166,6 +193,64 @@ export type ClientMessage = z.infer<typeof clientMessageSchema>;
 // Server → Client message helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Build the per-client SITE-scope delivery predicate for a site-restricted
+ * connection. Returns `undefined` when the user is unrestricted (full org
+ * access — no filtering, no behaviour change).
+ *
+ * The predicate runs synchronously in the dispatcher's hot path, so it can
+ * only inspect fields already on the event message — it cannot do a DB lookup
+ * to resolve a device's site. Today the event bus (`eventBus.ts`) publishes a
+ * generic `BreezeEvent` whose payload carries `deviceId` for ~62% of events
+ * but NEVER a `siteId` (0/56 publishers). Without a `siteId` on the wire there
+ * is no synchronous, correct way to attribute an event to a site.
+ *
+ * We therefore FAIL CLOSED: a site-restricted client only receives an event we
+ * can POSITIVELY attribute to one of its allowed sites — i.e. the event must
+ * carry a `siteId` (top-level or in `payload`) that is in the allowlist.
+ * Because no publisher currently emits `siteId`, the practical effect is that
+ * site-restricted users receive no live events until publishers are updated to
+ * include `siteId` — strictly safer than the prior behaviour, which leaked
+ * every org event (incl. other sites' devices/alerts) to them.
+ *
+ * RESIDUAL LIMITATION / FOLLOW-UP: add `siteId` to the event payload at publish
+ * time (eventBus publishers) so in-site events are delivered. Once present,
+ * this predicate starts allowing them with no further change here. A
+ * deviceId→siteId map could alternatively be threaded in, but that needs a
+ * synchronous cache and is out of scope for this WS-layer fix.
+ */
+export function buildSiteFilter(
+  allowedSiteIds: string[] | undefined,
+): ((event: Record<string, unknown>) => boolean) | undefined {
+  if (!allowedSiteIds || allowedSiteIds.length === 0) return undefined;
+
+  const allowed = new Set(allowedSiteIds);
+
+  return (event: Record<string, unknown>): boolean => {
+    const siteId = extractEventSiteId(event);
+    // Fail closed: deliver only when we can positively attribute the event to
+    // an allowed site. No attributable siteId ⇒ drop.
+    return typeof siteId === 'string' && allowed.has(siteId);
+  };
+}
+
+/**
+ * Pull a `siteId` off an event message if one is present. Checks the top level
+ * first, then the nested `payload` object (publishers attach domain fields
+ * under `payload`). Returns `undefined` when no string siteId is found.
+ */
+function extractEventSiteId(event: Record<string, unknown>): string | undefined {
+  const top = event.siteId;
+  if (typeof top === 'string' && top.length > 0) return top;
+
+  const payload = event.payload;
+  if (payload && typeof payload === 'object') {
+    const inner = (payload as Record<string, unknown>).siteId;
+    if (typeof inner === 'string' && inner.length > 0) return inner;
+  }
+  return undefined;
+}
+
 function sendJson(ws: WSContext, payload: Record<string, unknown>): void {
   try {
     ws.send(JSON.stringify(payload));
@@ -210,7 +295,14 @@ export function createEventWsTicketRoute(): Hono {
       return c.json({ error: 'Organization context required — select an org first' }, 400);
     }
 
-    const result = await createEventWsTicket(auth.user.id, orgIds);
+    // Capture the SITE-scope restriction (app-layer-only axis) so it's bound to
+    // the ticket. A site-restricted org user must not receive live events for
+    // sites outside their allowlist — RLS doesn't defend this and events are
+    // pub/sub, not Postgres. `undefined`/empty = unrestricted (full org access).
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    const allowedSiteIds = perms?.allowedSiteIds;
+
+    const result = await createEventWsTicket(auth.user.id, orgIds, allowedSiteIds);
     return c.json(result);
   });
 
@@ -288,6 +380,9 @@ function createEventWsHandlers(ticket: string | undefined) {
           ws,
           userId: identity.userId,
           subscribedTypes: new Set<string>(),
+          // Site-scope (app-layer-only) delivery gate. Undefined for
+          // unrestricted users — no filtering, no behaviour change.
+          filter: buildSiteFilter(identity.allowedSiteIds),
         };
 
         const dispatcher = getEventDispatcher();

--- a/apps/api/src/routes/eventWs.ts
+++ b/apps/api/src/routes/eventWs.ts
@@ -5,7 +5,6 @@ import { z } from 'zod';
 import { getRedis } from '../services/redis';
 import { getEventDispatcher, type ClientEntry } from '../services/eventDispatcher';
 import { authMiddleware, resolveOrgAccess } from '../middleware/auth';
-import type { UserPermissions } from '../services/permissions';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -200,10 +199,9 @@ export type ClientMessage = z.infer<typeof clientMessageSchema>;
  *
  * The predicate runs synchronously in the dispatcher's hot path, so it can
  * only inspect fields already on the event message — it cannot do a DB lookup
- * to resolve a device's site. Today the event bus (`eventBus.ts`) publishes a
- * generic `BreezeEvent` whose payload carries `deviceId` for ~62% of events
- * but NEVER a `siteId` (0/56 publishers). Without a `siteId` on the wire there
- * is no synchronous, correct way to attribute an event to a site.
+ * to resolve a device's site. The published `BreezeEvent` (`eventBus.ts`)
+ * carries no `siteId` on the wire — neither top-level nor in `payload` — so
+ * there is no synchronous, correct way to attribute most events to a site.
  *
  * We therefore FAIL CLOSED: a site-restricted client only receives an event we
  * can POSITIVELY attribute to one of its allowed sites — i.e. the event must
@@ -299,8 +297,11 @@ export function createEventWsTicketRoute(): Hono {
     // the ticket. A site-restricted org user must not receive live events for
     // sites outside their allowlist — RLS doesn't defend this and events are
     // pub/sub, not Postgres. `undefined`/empty = unrestricted (full org access).
-    const perms = c.get('permissions') as UserPermissions | undefined;
-    const allowedSiteIds = perms?.allowedSiteIds;
+    // Sourced from `auth.allowedSiteIds` (set by authMiddleware), NOT
+    // `c.get('permissions')` — this route mints a ticket behind authMiddleware
+    // only, and `permissions` is populated solely by requirePermission, which
+    // does not run here.
+    const allowedSiteIds = auth.allowedSiteIds;
 
     const result = await createEventWsTicket(auth.user.id, orgIds, allowedSiteIds);
     return c.json(result);

--- a/apps/api/src/routes/patches/approvals.test.ts
+++ b/apps/api/src/routes/patches/approvals.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
 
 vi.mock('../../db', () => ({
   db: {
@@ -21,18 +22,36 @@ vi.mock('../../db/schema', () => ({
 
 // Mirror prod gate semantics:
 // - requireScope: tier gate (always passes in these tests)
-// - requirePermission: RBAC gate — returns 403 when the caller lacks the perm
-// - requireMfa: MFA gate — passes here; we exercise the RBAC gap specifically
+// - requirePermission: RBAC gate — returns 403 when the caller lacks the perm.
+//   The mock enforces against the SPECIFIC permission the route wires it with
+//   (devices:execute). A gate mistakenly wired to a different permission
+//   (e.g. devices:read) is treated as an ungranted permission and 403s even
+//   when the caller "has" devices:execute — so the allow-path tests fail,
+//   catching the wrong-permission regression.
+// - requireMfa: MFA gate — controllable via mfaSatisfied; default pass-through.
 let hasPermission = true;
+let mfaSatisfied = true;
+// The single permission the caller is treated as holding when hasPermission is true.
+const GRANTED_PERMISSION = 'devices:execute';
 vi.mock('../../middleware/auth', () => ({
   requireScope: vi.fn(() => async (_c: any, next: any) => next()),
-  requirePermission: vi.fn(() => async (c: any, next: any) => {
-    if (!hasPermission) {
+  requirePermission: vi.fn((resource: string, action: string) => async (c: any, next: any) => {
+    const required = `${resource}:${action}`;
+    // 403 if the caller lacks the grant OR the gate is wired to a permission
+    // other than the one the caller holds (devices:execute).
+    if (!hasPermission || required !== GRANTED_PERMISSION) {
       return c.json({ error: 'Forbidden' }, 403);
     }
     return next();
   }),
-  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+  // Mirror the real requireMfa(), which throws HTTPException(403) when MFA is
+  // required. Hono's default error handler renders that as a 403 response.
+  requireMfa: vi.fn(() => async (_c: any, next: any) => {
+    if (!mfaSatisfied) {
+      throw new HTTPException(403, { message: 'MFA required' });
+    }
+    return next();
+  }),
 }));
 
 vi.mock('../../services/permissions', () => ({
@@ -85,6 +104,7 @@ describe('patch approvals RBAC gating', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     hasPermission = true;
+    mfaSatisfied = true;
   });
 
   describe('without the devices:execute permission', () => {
@@ -152,6 +172,25 @@ describe('patch approvals RBAC gating', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.status).toBe('approved');
+    });
+  });
+
+  // Guards the requireMfa() gate: with the RBAC permission granted but MFA
+  // unsatisfied, the mutating route must still 403. Drops the requireMfa()
+  // line from the route and this test fails.
+  describe('with the permission but MFA unsatisfied', () => {
+    beforeEach(() => {
+      hasPermission = true;
+      mfaSatisfied = false;
+    });
+
+    it('rejects POST /patches/bulk-approve with 403', async () => {
+      const res = await mountApp().request('/patches/bulk-approve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer t' },
+        body: JSON.stringify({ patchIds: [PATCH_ID] }),
+      });
+      expect(res.status).toBe(403);
     });
   });
 });

--- a/apps/api/src/routes/patches/approvals.test.ts
+++ b/apps/api/src/routes/patches/approvals.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+  },
+}));
+
+vi.mock('../../db/schema', () => ({
+  patches: { id: 'patches.id' },
+  patchApprovals: {
+    orgId: 'patchApprovals.orgId',
+    ringId: 'patchApprovals.ringId',
+    patchId: 'patchApprovals.patchId',
+    status: 'patchApprovals.status',
+    createdAt: 'patchApprovals.createdAt',
+  },
+}));
+
+// Mirror prod gate semantics:
+// - requireScope: tier gate (always passes in these tests)
+// - requirePermission: RBAC gate — returns 403 when the caller lacks the perm
+// - requireMfa: MFA gate — passes here; we exercise the RBAC gap specifically
+let hasPermission = true;
+vi.mock('../../middleware/auth', () => ({
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (c: any, next: any) => {
+    if (!hasPermission) {
+      return c.json({ error: 'Forbidden' }, 403);
+    }
+    return next();
+  }),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+vi.mock('../../services/permissions', () => ({
+  PERMISSIONS: {
+    DEVICES_EXECUTE: { resource: 'devices', action: 'execute' },
+  },
+}));
+
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+
+vi.mock('./helpers', () => ({
+  getPagination: vi.fn(() => ({ page: 1, limit: 50, offset: 0 })),
+  resolvePatchApprovalOrgId: vi.fn(() => ({ orgId: ORG_ID })),
+  upsertPatchApproval: vi.fn(async () => undefined),
+}));
+
+import { approvalsRoutes } from './approvals';
+import { db } from '../../db';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const PATCH_ID = '22222222-2222-4222-8222-222222222222';
+
+function mountApp() {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    (c as any).set('auth', {
+      user: { id: 'user-1' },
+      scope: 'organization',
+      orgId: ORG_ID,
+      canAccessOrg: (orgId: string) => orgId === ORG_ID,
+      orgCondition: (column: unknown) => ({ orgCondition: column, orgId: ORG_ID }),
+    });
+    await next();
+  });
+  app.route('/patches', approvalsRoutes);
+  return app;
+}
+
+function mockPatchLookup(found = true) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(found ? [{ id: PATCH_ID }] : []),
+      }),
+    }),
+  } as never);
+}
+
+describe('patch approvals RBAC gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hasPermission = true;
+  });
+
+  describe('without the devices:execute permission', () => {
+    beforeEach(() => {
+      hasPermission = false;
+    });
+
+    it('rejects POST /patches/bulk-approve with 403', async () => {
+      const res = await mountApp().request('/patches/bulk-approve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer t' },
+        body: JSON.stringify({ patchIds: [PATCH_ID] }),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it('rejects POST /patches/:id/approve with 403', async () => {
+      const res = await mountApp().request(`/patches/${PATCH_ID}/approve`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer t' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it('rejects POST /patches/:id/decline with 403', async () => {
+      const res = await mountApp().request(`/patches/${PATCH_ID}/decline`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer t' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it('rejects POST /patches/:id/defer with 403', async () => {
+      const res = await mountApp().request(`/patches/${PATCH_ID}/defer`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer t' },
+        body: JSON.stringify({ deferUntil: '2030-01-01T00:00:00.000Z' }),
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('with the devices:execute permission', () => {
+    it('allows POST /patches/bulk-approve', async () => {
+      const res = await mountApp().request('/patches/bulk-approve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer t' },
+        body: JSON.stringify({ patchIds: [PATCH_ID] }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(body.approved).toContain(PATCH_ID);
+    });
+
+    it('allows POST /patches/:id/approve', async () => {
+      mockPatchLookup(true);
+      const res = await mountApp().request(`/patches/${PATCH_ID}/approve`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer t' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.status).toBe('approved');
+    });
+  });
+});

--- a/apps/api/src/routes/patches/approvals.ts
+++ b/apps/api/src/routes/patches/approvals.ts
@@ -1,8 +1,9 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { and, eq, sql, desc } from 'drizzle-orm';
-import { requireScope } from '../../middleware/auth';
+import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { db } from '../../db';
+import { PERMISSIONS } from '../../services/permissions';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { patches, patchApprovals } from '../../db/schema';
 import {
@@ -66,6 +67,8 @@ approvalsRoutes.get(
 approvalsRoutes.post(
   '/bulk-approve',
   requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_EXECUTE.resource, PERMISSIONS.DEVICES_EXECUTE.action),
+  requireMfa(),
   zValidator('json', bulkApproveSchema),
   async (c) => {
     const auth = c.get('auth');
@@ -123,6 +126,8 @@ approvalsRoutes.post(
 approvalsRoutes.post(
   '/:id/approve',
   requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_EXECUTE.resource, PERMISSIONS.DEVICES_EXECUTE.action),
+  requireMfa(),
   zValidator('param', patchIdParamSchema),
   zValidator('json', approvalActionSchema),
   async (c) => {
@@ -182,6 +187,8 @@ approvalsRoutes.post(
 approvalsRoutes.post(
   '/:id/decline',
   requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_EXECUTE.resource, PERMISSIONS.DEVICES_EXECUTE.action),
+  requireMfa(),
   zValidator('param', patchIdParamSchema),
   zValidator('json', approvalActionSchema),
   async (c) => {
@@ -238,6 +245,8 @@ approvalsRoutes.post(
 approvalsRoutes.post(
   '/:id/defer',
   requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_EXECUTE.resource, PERMISSIONS.DEVICES_EXECUTE.action),
+  requireMfa(),
   zValidator('param', patchIdParamSchema),
   zValidator('json', deferSchema),
   async (c) => {

--- a/apps/api/src/routes/sensitiveData.test.ts
+++ b/apps/api/src/routes/sensitiveData.test.ts
@@ -42,7 +42,15 @@ vi.mock('../middleware/auth', () => ({
     });
     return next();
   }),
-  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (c: any, next: any) => {
+    // Mirror the real middleware: populate permissions.allowedSiteIds when the
+    // caller is site-restricted (signalled here via the x-restrict-site header).
+    const restrict = c.req.header('x-restrict-site');
+    if (restrict) {
+      c.set('permissions', { allowedSiteIds: [restrict] });
+    }
+    return next();
+  }),
   requireMfa: vi.fn(() => async (_c: any, next: any) => next())
 }));
 
@@ -299,6 +307,102 @@ describe('sensitive data routes', () => {
     expect(body.data.dryRun).toBe(true);
     expect(body.data.eligible).toBe(1);
     expect(queueCommand).not.toHaveBeenCalled();
+  });
+
+  // --- Site-axis (app-layer) enforcement ---
+
+  describe('site-scope enforcement', () => {
+    const allowedSite = 'site-a';
+    const forbiddenSite = 'site-b';
+    const findingId = '33333333-3333-3333-3333-333333333333';
+    const orgId = '11111111-1111-1111-1111-111111111111';
+
+    // db.select({id, siteId}).from(devices).where(...) — remediate site lookup
+    function mockDeviceSiteLookup(rows: any[]) {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(rows)
+        })
+      } as any);
+    }
+
+    it('blocks a site-restricted user from remediating an out-of-site finding (403)', async () => {
+      // 1) findings lookup, 2) device-site lookup (device in forbidden site)
+      mockSelectFromWhere([
+        { id: findingId, orgId, deviceId, filePath: '/tmp/secret.txt', status: 'open' }
+      ]);
+      mockDeviceSiteLookup([{ id: deviceId, siteId: forbiddenSite }]);
+
+      const res = await app.request('/sensitive-data/remediate', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer token',
+          'Content-Type': 'application/json',
+          'x-restrict-site': allowedSite
+        },
+        body: JSON.stringify({
+          findingIds: [findingId],
+          action: 'quarantine',
+          confirm: true
+        })
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toMatch(/site/i);
+      // No command queued, no status flip for the out-of-site device.
+      expect(queueCommand).not.toHaveBeenCalled();
+    });
+
+    it('allows remediation when the finding device is within the site allowlist', async () => {
+      mockSelectFromWhere([
+        { id: findingId, orgId, deviceId, filePath: '/tmp/secret.txt', status: 'open' }
+      ]);
+      mockDeviceSiteLookup([{ id: deviceId, siteId: allowedSite }]);
+      mockUpdateSetWhere();
+
+      const res = await app.request('/sensitive-data/remediate', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer token',
+          'Content-Type': 'application/json',
+          'x-restrict-site': allowedSite
+        },
+        body: JSON.stringify({
+          findingIds: [findingId],
+          action: 'quarantine',
+          confirm: true
+        })
+      });
+
+      expect(res.status).toBe(202);
+      expect(queueCommand).toHaveBeenCalledTimes(1);
+    });
+
+    it('dashboard excludes out-of-site findings for a site-restricted user', async () => {
+      // Site-restricted path adds an innerJoin before .where(); the join filters
+      // out the forbidden-site finding, so only the allowed-site row is returned.
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([
+              { dataType: 'pci', risk: 'high', status: 'open', lastSeenAt: new Date() }
+            ])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/sensitive-data/dashboard', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token', 'x-restrict-site': allowedSite }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Only the in-site finding is counted; the forbidden-site PCI total leaks nothing.
+      expect(body.data.totals.findings).toBe(1);
+      expect(body.data.byDataType.pci).toBe(1);
+    });
   });
 
   // --- SOC2 audit coverage ---

--- a/apps/api/src/routes/sensitiveData.test.ts
+++ b/apps/api/src/routes/sensitiveData.test.ts
@@ -354,6 +354,74 @@ describe('sensitive data routes', () => {
       expect(queueCommand).not.toHaveBeenCalled();
     });
 
+    it('blocks secure_delete (most destructive) for an out-of-site finding (403, no command queued)', async () => {
+      // The destructive-path deny must hold for the most dangerous action too:
+      // a site-restricted user cannot secure_delete a finding on a device
+      // outside their allowed sites. 1) findings lookup, 2) device-site lookup.
+      mockSelectFromWhere([
+        { id: findingId, orgId, deviceId, filePath: '/tmp/secret.txt', status: 'open' }
+      ]);
+      mockDeviceSiteLookup([{ id: deviceId, siteId: forbiddenSite }]);
+
+      const res = await app.request('/sensitive-data/remediate', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer token',
+          'Content-Type': 'application/json',
+          'x-restrict-site': allowedSite
+        },
+        body: JSON.stringify({
+          findingIds: [findingId],
+          action: 'secure_delete',
+          confirm: true
+        })
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toMatch(/site/i);
+      // The most destructive command must NOT be dispatched.
+      expect(queueCommand).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when a finding device row does not resolve (dangling deviceId, 403)', async () => {
+      // The site-axis guard loads the distinct finding device ids and rejects if
+      // any device row fails to resolve (findingDevices.length !== deviceIds.length)
+      // — e.g. a dangling / cross-org deviceId. Rig the device lookup to return
+      // FEWER rows than the findings' distinct device ids: two findings on two
+      // distinct devices, but only one device row comes back.
+      const findingId2 = '55555555-5555-5555-5555-555555555555';
+      const deviceId2 = '66666666-6666-6666-6666-666666666666';
+      mockSelectFromWhere([
+        { id: findingId, orgId, deviceId, filePath: '/tmp/secret.txt', status: 'open' },
+        { id: findingId2, orgId, deviceId: deviceId2, filePath: '/tmp/secret2.txt', status: 'open' }
+      ]);
+      // Only ONE of the two distinct device ids resolves (the other is in the
+      // allowed site to prove it's the missing-row check, not a site deny, that
+      // trips the 403).
+      mockDeviceSiteLookup([{ id: deviceId, siteId: allowedSite }]);
+
+      const res = await app.request('/sensitive-data/remediate', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer token',
+          'Content-Type': 'application/json',
+          'x-restrict-site': allowedSite
+        },
+        body: JSON.stringify({
+          findingIds: [findingId, findingId2],
+          action: 'quarantine',
+          confirm: true
+        })
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toMatch(/site/i);
+      // Fail-closed: no command queued when a device row can't be resolved.
+      expect(queueCommand).not.toHaveBeenCalled();
+    });
+
     it('allows remediation when the finding device is within the site allowlist', async () => {
       mockSelectFromWhere([
         { id: findingId, orgId, deviceId, filePath: '/tmp/secret.txt', status: 'open' }

--- a/apps/api/src/routes/sensitiveData.ts
+++ b/apps/api/src/routes/sensitiveData.ts
@@ -623,17 +623,27 @@ sensitiveDataRoutes.get(
     const conditions: SQL[] = [];
     const orgCondition = auth.orgCondition(sensitiveDataFindings.orgId);
     if (orgCondition) conditions.push(orgCondition);
+    // Site-axis enforcement: narrow the aggregate to devices in the caller's
+    // allowed sites so site-restricted users don't see cross-site PII/PCI/PHI
+    // totals (mirrors GET /report).
+    const permissions = c.get('permissions') as UserPermissions | undefined;
+    if (permissions?.allowedSiteIds) conditions.push(inArray(devices.siteId, permissions.allowedSiteIds));
     const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
 
-    const rows = await db
+    const baseQuery = db
       .select({
         dataType: sensitiveDataFindings.dataType,
         risk: sensitiveDataFindings.risk,
         status: sensitiveDataFindings.status,
         lastSeenAt: sensitiveDataFindings.lastSeenAt,
       })
-      .from(sensitiveDataFindings)
-      .where(whereClause);
+      .from(sensitiveDataFindings);
+
+    const rows = permissions?.allowedSiteIds
+      ? await baseQuery
+        .innerJoin(devices, eq(devices.id, sensitiveDataFindings.deviceId))
+        .where(whereClause)
+      : await baseQuery.where(whereClause);
 
     const now = Date.now();
     let openTotal = 0;
@@ -718,6 +728,23 @@ sensitiveDataRoutes.post(
 
     if (findings.length === 0) {
       return c.json({ error: 'No findings found' }, 404);
+    }
+
+    // Site-axis enforcement (app-layer; RLS only covers the org axis). A
+    // site-restricted user must not remediate findings on devices outside
+    // their allowed sites. Load the distinct device sites and reject if any
+    // matched finding is on an out-of-site device.
+    const permissions = c.get('permissions') as UserPermissions | undefined;
+    if (permissions?.allowedSiteIds) {
+      const deviceIds = Array.from(new Set(findings.map((finding) => finding.deviceId)));
+      const findingDevices = await db
+        .select({ id: devices.id, siteId: devices.siteId })
+        .from(devices)
+        .where(inArray(devices.id, deviceIds));
+      const siteDenied = findingDevices.some((device) => !canAccessDeviceSite(device, permissions));
+      if (siteDenied || findingDevices.length !== deviceIds.length) {
+        return c.json({ error: 'Access to one or more device sites denied' }, 403);
+      }
     }
 
     if (payload.dryRun) {

--- a/apps/api/src/routes/softwareInventory.ts
+++ b/apps/api/src/routes/softwareInventory.ts
@@ -13,6 +13,8 @@ import {
 } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import { PERMISSIONS, type UserPermissions } from '../services/permissions';
+import { writeRouteAudit } from '../services/auditEvents';
+import { recordSoftwarePolicyAudit } from '../services/softwarePolicyService';
 
 export const softwareInventoryRoutes = new Hono();
 const requireSoftwareInventoryRead = requirePermission(
@@ -348,6 +350,26 @@ softwareInventoryRoutes.post('/approve', requireSoftwareInventoryWrite, requireM
       console.warn('[softwareInventory] Failed to auto-link config policy for Default Allowlist:', err);
     }
 
+    recordSoftwarePolicyAudit({
+      orgId,
+      policyId: existing.id,
+      action: 'inventory_approve',
+      actor: 'user',
+      actorId: auth.user?.id ?? null,
+      details: { softwareName, vendor: vendor || null, mode: 'allowlist' },
+    }).catch((err) => {
+      console.error('[softwareInventory] Audit write failed for inventory_approve:', err);
+    });
+
+    writeRouteAudit(c, {
+      orgId,
+      action: 'software_policy.inventory_approve',
+      resourceType: 'software_policy',
+      resourceId: existing.id,
+      resourceName: existing.name,
+      details: { softwareName, vendor: vendor || null, mode: 'allowlist' },
+    });
+
     return c.json({ success: true, policyId: existing.id });
   }
 
@@ -375,6 +397,26 @@ softwareInventoryRoutes.post('/approve', requireSoftwareInventoryWrite, requireM
   } catch (err) {
     console.warn('[softwareInventory] Failed to auto-link config policy for Default Allowlist:', err);
   }
+
+  recordSoftwarePolicyAudit({
+    orgId,
+    policyId: created!.id,
+    action: 'inventory_approve',
+    actor: 'user',
+    actorId: auth.user?.id ?? null,
+    details: { softwareName, vendor: vendor || null, mode: 'allowlist', created: true },
+  }).catch((err) => {
+    console.error('[softwareInventory] Audit write failed for inventory_approve:', err);
+  });
+
+  writeRouteAudit(c, {
+    orgId,
+    action: 'software_policy.inventory_approve',
+    resourceType: 'software_policy',
+    resourceId: created!.id,
+    resourceName: created!.name,
+    details: { softwareName, vendor: vendor || null, mode: 'allowlist', created: true },
+  });
 
   return c.json({ success: true, policyId: created!.id }, 201);
 });
@@ -428,6 +470,26 @@ softwareInventoryRoutes.post('/deny', requireSoftwareInventoryWrite, requireMfa(
       console.warn('[softwareInventory] Failed to auto-link config policy for Default Blocklist:', err);
     }
 
+    recordSoftwarePolicyAudit({
+      orgId,
+      policyId: existing.id,
+      action: 'inventory_deny',
+      actor: 'user',
+      actorId: auth.user?.id ?? null,
+      details: { softwareName, vendor: vendor || null, mode: 'blocklist' },
+    }).catch((err) => {
+      console.error('[softwareInventory] Audit write failed for inventory_deny:', err);
+    });
+
+    writeRouteAudit(c, {
+      orgId,
+      action: 'software_policy.inventory_deny',
+      resourceType: 'software_policy',
+      resourceId: existing.id,
+      resourceName: existing.name,
+      details: { softwareName, vendor: vendor || null, mode: 'blocklist' },
+    });
+
     return c.json({ success: true, policyId: existing.id });
   }
 
@@ -453,6 +515,26 @@ softwareInventoryRoutes.post('/deny', requireSoftwareInventoryWrite, requireMfa(
   } catch (err) {
     console.warn('[softwareInventory] Failed to auto-link config policy for Default Blocklist:', err);
   }
+
+  recordSoftwarePolicyAudit({
+    orgId,
+    policyId: created!.id,
+    action: 'inventory_deny',
+    actor: 'user',
+    actorId: auth.user?.id ?? null,
+    details: { softwareName, vendor: vendor || null, mode: 'blocklist', created: true },
+  }).catch((err) => {
+    console.error('[softwareInventory] Audit write failed for inventory_deny:', err);
+  });
+
+  writeRouteAudit(c, {
+    orgId,
+    action: 'software_policy.inventory_deny',
+    resourceType: 'software_policy',
+    resourceId: created!.id,
+    resourceName: created!.name,
+    details: { softwareName, vendor: vendor || null, mode: 'blocklist', created: true },
+  });
 
   return c.json({ success: true, policyId: created!.id }, 201);
 });
@@ -501,6 +583,26 @@ softwareInventoryRoutes.post('/clear', requireSoftwareInventoryWrite, requireMfa
         .update(softwarePolicies)
         .set({ rules, updatedAt: new Date() })
         .where(eq(softwarePolicies.id, policy.id));
+
+      recordSoftwarePolicyAudit({
+        orgId,
+        policyId: policy.id,
+        action: 'inventory_clear',
+        actor: 'user',
+        actorId: auth.user?.id ?? null,
+        details: { softwareName, vendor: vendor || null, mode: policy.mode },
+      }).catch((err) => {
+        console.error('[softwareInventory] Audit write failed for inventory_clear:', err);
+      });
+
+      writeRouteAudit(c, {
+        orgId,
+        action: 'software_policy.inventory_clear',
+        resourceType: 'software_policy',
+        resourceId: policy.id,
+        resourceName: policy.name,
+        details: { softwareName, vendor: vendor || null, mode: policy.mode },
+      });
     }
   }
 

--- a/apps/api/src/routes/softwareInventory_deny_clear_devices.test.ts
+++ b/apps/api/src/routes/softwareInventory_deny_clear_devices.test.ts
@@ -72,8 +72,18 @@ vi.mock('../middleware/auth', () => ({
   requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
 }));
 
+vi.mock('../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn(),
+}));
+
+vi.mock('../services/softwarePolicyService', () => ({
+  recordSoftwarePolicyAudit: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { softwareInventoryRoutes } from './softwareInventory';
 import { db } from '../db';
+import { writeRouteAudit } from '../services/auditEvents';
+import { recordSoftwarePolicyAudit } from '../services/softwarePolicyService';
 
 const ORG_ID = 'org-111';
 const POLICY_ID = '11111111-1111-1111-1111-111111111111';
@@ -191,6 +201,20 @@ describe('software inventory routes', () => {
       const body = await res.json();
       expect(body.success).toBe(true);
       expect(body.policyId).toBe(POLICY_ID);
+
+      // Audit chain must record the denial
+      expect(writeRouteAudit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          orgId: ORG_ID,
+          action: 'software_policy.inventory_deny',
+          resourceType: 'software_policy',
+          resourceId: POLICY_ID,
+        }),
+      );
+      expect(recordSoftwarePolicyAudit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'inventory_deny', policyId: POLICY_ID }),
+      );
     });
 
     it('adds to existing blocklist', async () => {
@@ -267,6 +291,20 @@ describe('software inventory routes', () => {
       const body = await res.json();
       expect(body.success).toBe(true);
       expect(body.cleared).toBe(true);
+
+      // Audit chain must record the clear on the affected policy
+      expect(writeRouteAudit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          orgId: ORG_ID,
+          action: 'software_policy.inventory_clear',
+          resourceType: 'software_policy',
+          resourceId: 'policy-1',
+        }),
+      );
+      expect(recordSoftwarePolicyAudit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'inventory_clear', policyId: 'policy-1' }),
+      );
     });
 
     it('returns cleared=false when software not found in any policy', async () => {

--- a/apps/api/src/routes/softwareInventory_list_approve.test.ts
+++ b/apps/api/src/routes/softwareInventory_list_approve.test.ts
@@ -72,8 +72,18 @@ vi.mock('../middleware/auth', () => ({
   requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
 }));
 
+vi.mock('../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn(),
+}));
+
+vi.mock('../services/softwarePolicyService', () => ({
+  recordSoftwarePolicyAudit: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { softwareInventoryRoutes } from './softwareInventory';
 import { db } from '../db';
+import { writeRouteAudit } from '../services/auditEvents';
+import { recordSoftwarePolicyAudit } from '../services/softwarePolicyService';
 
 const ORG_ID = 'org-111';
 const POLICY_ID = '11111111-1111-1111-1111-111111111111';
@@ -311,6 +321,24 @@ describe('software inventory routes', () => {
       const body = await res.json();
       expect(body.success).toBe(true);
       expect(body.policyId).toBe(POLICY_ID);
+
+      // Audit chain must record the approval
+      expect(writeRouteAudit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          orgId: ORG_ID,
+          action: 'software_policy.inventory_approve',
+          resourceType: 'software_policy',
+          resourceId: POLICY_ID,
+        }),
+      );
+      expect(recordSoftwarePolicyAudit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orgId: ORG_ID,
+          policyId: POLICY_ID,
+          action: 'inventory_approve',
+        }),
+      );
     });
 
     it('adds to existing allowlist if one exists', async () => {
@@ -352,6 +380,19 @@ describe('software inventory routes', () => {
       const body = await res.json();
       expect(body.success).toBe(true);
       expect(body.policyId).toBe(POLICY_ID);
+
+      // Audit chain must record the approval on the existing policy
+      expect(writeRouteAudit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: 'software_policy.inventory_approve',
+          resourceType: 'software_policy',
+          resourceId: POLICY_ID,
+        }),
+      );
+      expect(recordSoftwarePolicyAudit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'inventory_approve', policyId: POLICY_ID }),
+      );
     });
 
     it('returns 400 when org context missing', async () => {

--- a/apps/api/src/routes/tags.test.ts
+++ b/apps/api/src/routes/tags.test.ts
@@ -439,6 +439,19 @@ describe('tag routes', () => {
     return where;
   }
 
+  // Serialize the drizzle WHERE condition the handler passes to .where() so we
+  // can assert the constructed SQL actually contains the site-axis narrowing
+  // (the mock DB ignores the WHERE, so an `expect.anything()` check would still
+  // pass even if the `inArray(devices.siteId, ...)` push were removed). Mirrors
+  // the `conditionText` technique in cisHardening_site_scope.test.ts. The
+  // schema mock maps `devices.siteId -> 'siteId'`, so an in-site filter
+  // serializes to include that column token and the site id.
+  function conditionText(value: unknown): string {
+    return JSON.stringify(value, (_key, nested) =>
+      typeof nested === 'function' ? '[function]' : nested
+    );
+  }
+
   describe('site-scope enforcement', () => {
     it('GET /tags narrows the taxonomy to the site allowlist', async () => {
       // Only the allowed-site device's tags come back from the (narrowed) query.
@@ -453,9 +466,13 @@ describe('tag routes', () => {
       const body = await res.json();
       expect(body.total).toBe(1);
       expect(body.data[0].tag).toBe('finance');
-      // The handler must have built a WHERE (org + site narrowing), not run unfiltered.
+      // The handler must have built a WHERE that actually narrows by site —
+      // serialize the condition and assert it carries the site-axis filter
+      // (column + allowed site id), not just "some object".
       expect(where).toHaveBeenCalledTimes(1);
-      expect(where).toHaveBeenCalledWith(expect.anything());
+      const whereText = conditionText(where.mock.calls[0]?.[0]);
+      expect(whereText).toContain('siteId');
+      expect(whereText).toContain(ALLOWED_SITE_ID);
     });
 
     it('GET /tags/devices excludes out-of-site devices via the site allowlist', async () => {
@@ -474,7 +491,9 @@ describe('tag routes', () => {
       expect(body.total).toBe(1);
       expect(body.data[0].id).toBe('dev-a');
       expect(where).toHaveBeenCalledTimes(1);
-      expect(where).toHaveBeenCalledWith(expect.anything());
+      const whereText = conditionText(where.mock.calls[0]?.[0]);
+      expect(whereText).toContain('siteId');
+      expect(whereText).toContain(ALLOWED_SITE_ID);
     });
 
     it('GET /tags emits a never-true (sql`false`) condition when the allowlist is empty', async () => {
@@ -512,6 +531,9 @@ describe('tag routes', () => {
       const body = await res.json();
       expect(body.total).toBe(2);
       expect(where).toHaveBeenCalledTimes(1);
+      // Unset allowlist = full org access: the WHERE must NOT carry a site
+      // filter (only the org-axis condition).
+      expect(conditionText(where.mock.calls[0]?.[0])).not.toContain('siteId');
     });
   });
 });

--- a/apps/api/src/routes/tags.test.ts
+++ b/apps/api/src/routes/tags.test.ts
@@ -22,6 +22,7 @@ vi.mock('../db/schema', () => ({
   devices: {
     id: 'id',
     orgId: 'orgId',
+    siteId: 'siteId',
     hostname: 'hostname',
     displayName: 'displayName',
     status: 'status',
@@ -42,7 +43,24 @@ vi.mock('../middleware/auth', () => ({
     });
     return next();
   }),
-  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  // `x-restrict-site` -> single-site allowlist; `x-restrict-site-empty` ->
+  // empty allowlist (zero accessible sites). Absent -> unset (full org access).
+  requirePermission: vi.fn(() => async (c: any, next: any) => {
+    const restrictSite = c.req.header('x-restrict-site');
+    const emptyAllowlist = c.req.header('x-restrict-site-empty');
+    let allowedSiteIds: string[] | undefined;
+    if (emptyAllowlist) allowedSiteIds = [];
+    else if (restrictSite) allowedSiteIds = [restrictSite];
+    c.set('permissions', {
+      permissions: [{ resource: 'devices', action: 'read' }],
+      partnerId: null,
+      orgId: ORG_ID,
+      roleId: 'role-1',
+      scope: 'organization',
+      ...(allowedSiteIds !== undefined ? { allowedSiteIds } : {})
+    });
+    return next();
+  }),
   requireScope: vi.fn(() => async (_c: any, next: any) => next())
 }));
 
@@ -396,6 +414,104 @@ describe('tag routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.total).toBe(1);
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // Site-scope enforcement (Finding #2)
+  //
+  // RLS enforces the org axis only; the site axis (permissions.allowedSiteIds)
+  // is app-layer. A site-restricted user must not see the tag taxonomy or the
+  // device list for devices in sites outside their allowlist. Mirrors the
+  // devices/core.ts semantics: empty allowlist -> no rows; unset -> full org.
+  //
+  // The mock DB ignores the WHERE clause (it just resolves the rows we rig),
+  // so these tests assert on the WHERE *condition* the handler builds — the
+  // narrowing must be present — and on the empty-allowlist short-circuit.
+  // ----------------------------------------------------------------
+  const ALLOWED_SITE_ID = 'site-a';
+
+  function captureWhere(rows: unknown[]) {
+    const where = vi.fn().mockResolvedValue(rows);
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({ where })
+    } as any);
+    return where;
+  }
+
+  describe('site-scope enforcement', () => {
+    it('GET /tags narrows the taxonomy to the site allowlist', async () => {
+      // Only the allowed-site device's tags come back from the (narrowed) query.
+      const where = captureWhere([{ tags: ['finance'] }]);
+
+      const res = await app.request('/tags', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token', 'x-restrict-site': ALLOWED_SITE_ID }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.total).toBe(1);
+      expect(body.data[0].tag).toBe('finance');
+      // The handler must have built a WHERE (org + site narrowing), not run unfiltered.
+      expect(where).toHaveBeenCalledTimes(1);
+      expect(where).toHaveBeenCalledWith(expect.anything());
+    });
+
+    it('GET /tags/devices excludes out-of-site devices via the site allowlist', async () => {
+      // The narrowed query only returns the in-site device.
+      const where = captureWhere([
+        { id: 'dev-a', hostname: 'host-a', displayName: 'A', status: 'online', osType: 'linux', tags: ['finance'] }
+      ]);
+
+      const res = await app.request('/tags/devices?tag=finance', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token', 'x-restrict-site': ALLOWED_SITE_ID }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.total).toBe(1);
+      expect(body.data[0].id).toBe('dev-a');
+      expect(where).toHaveBeenCalledTimes(1);
+      expect(where).toHaveBeenCalledWith(expect.anything());
+    });
+
+    it('GET /tags emits a never-true (sql`false`) condition when the allowlist is empty', async () => {
+      // Empty allowlist = zero accessible sites. The handler can't know which
+      // rows Postgres would drop (the unit mock ignores WHERE), so we assert the
+      // contract that guarantees zero rows in real PG: a `sql\`false\`` fragment
+      // is pushed into the WHERE. Mirrors devices/core.ts' `sql\`false\`` branch.
+      const where = captureWhere([]);
+
+      const res = await app.request('/tags', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token', 'x-restrict-site-empty': '1' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toEqual([]);
+      // Inspect the constructed WHERE: an `and(...)` of real drizzle conditions.
+      // The serialized SQL must contain the literal `false` short-circuit.
+      expect(where).toHaveBeenCalledTimes(1);
+      const whereArg = where.mock.calls[0]?.[0];
+      expect(JSON.stringify(whereArg)).toContain('false');
+    });
+
+    it('GET /tags applies no site filter when allowlist is unset (full org access)', async () => {
+      const where = captureWhere([{ tags: ['a'] }, { tags: ['b'] }]);
+
+      // No x-restrict-site header -> allowedSiteIds undefined.
+      const res = await app.request('/tags', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.total).toBe(2);
+      expect(where).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/api/src/routes/tags.ts
+++ b/apps/api/src/routes/tags.ts
@@ -5,7 +5,7 @@ import { and, eq, inArray, sql } from 'drizzle-orm';
 import { db } from '../db';
 import { devices } from '../db/schema';
 import { authMiddleware, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
-import { PERMISSIONS } from '../services/permissions';
+import { PERMISSIONS, type UserPermissions } from '../services/permissions';
 
 export const tagRoutes = new Hono();
 const requireTagRead = requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action);
@@ -57,6 +57,16 @@ tagRoutes.get(
     const conditions = [] as ReturnType<typeof eq>[];
     if (orgIds) {
       conditions.push(inArray(devices.orgId, orgIds));
+    }
+
+    // Site-axis narrowing — RLS only enforces the org axis, so site-restricted
+    // users must be narrowed app-layer. Mirror devices/core.ts: an empty
+    // allowlist short-circuits to no rows; unset = full org access.
+    const allowedSiteIds = (c.get('permissions') as UserPermissions | undefined)?.allowedSiteIds;
+    if (allowedSiteIds) {
+      conditions.push(allowedSiteIds.length > 0
+        ? inArray(devices.siteId, allowedSiteIds)
+        : sql`false`);
     }
 
     const whereCondition = conditions.length ? and(...conditions) : undefined;
@@ -116,6 +126,16 @@ tagRoutes.get(
     const conditions = [] as ReturnType<typeof eq>[];
     if (orgIds) {
       conditions.push(inArray(devices.orgId, orgIds));
+    }
+
+    // Site-axis narrowing — RLS only enforces the org axis, so site-restricted
+    // users must be narrowed app-layer. Mirror devices/core.ts: an empty
+    // allowlist short-circuits to no rows; unset = full org access.
+    const allowedSiteIds = (c.get('permissions') as UserPermissions | undefined)?.allowedSiteIds;
+    if (allowedSiteIds) {
+      conditions.push(allowedSiteIds.length > 0
+        ? inArray(devices.siteId, allowedSiteIds)
+        : sql`false`);
     }
 
     // Filter by tag - PostgreSQL array contains (use sql.param for safety)

--- a/apps/api/src/routes/tunnels.test.ts
+++ b/apps/api/src/routes/tunnels.test.ts
@@ -27,6 +27,7 @@ vi.mock('../db/schema', () => ({
   devices: {},
   users: {},
   remoteSessions: {},
+  sites: { id: 'sites.id', orgId: 'sites.orgId' },
 }));
 
 // --- Auth middleware ---
@@ -66,8 +67,14 @@ vi.mock('../middleware/auth', () => ({
     return next();
   }),
   requireScope: vi.fn(() => async (_c: any, next: any) => next()),
-  requirePermission: vi.fn(() => async (c: any, next: any) => {
+  requirePermission: vi.fn((resource: string, action: string) => async (c: any, next: any) => {
     // Mirror prod: requirePermission is the gate that populates `permissions`.
+    // A caller lacking the required grant is rejected with 403. Tests opt into
+    // that via `x-deny-permission: <resource>:<action>` (e.g. devices:execute).
+    const denied = c.req.header('x-deny-permission');
+    if (denied && denied === `${resource}:${action}`) {
+      return c.json({ error: 'Insufficient permissions' }, 403);
+    }
     const restrict = c.req.header('x-restrict-site');
     c.set('permissions', restrict ? {
       permissions: [{ resource: 'devices', action: 'read' }],
@@ -889,5 +896,174 @@ describe('Allowlist routes — partner-scope org resolution', () => {
     });
 
     expect(res.status).toBe(404);
+  });
+});
+
+// ─── Allowlist mutation routes — RBAC (DEVICES_EXECUTE) + MFA gate ────────────
+// Finding #7: the allowlist is consulted by isTargetAllowed() when a proxy
+// tunnel opens. A low-privilege same-org user must NOT be able to widen,
+// disable, or delete rules — those routes now require DEVICES_EXECUTE + MFA,
+// matching POST /tunnels.
+
+describe('Allowlist mutation routes — DEVICES_EXECUTE gate', () => {
+  let app: Hono;
+  const RULE_ID = 'f1f1f1f1-f1f1-4f1f-8f1f-f1f1f1f1f1f1';
+  const DENY = 'devices:execute';
+
+  const ruleBody = {
+    direction: 'destination',
+    pattern: '10.0.0.0/8:*',
+    description: 'overly broad rule',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.select).mockReset();
+    app = new Hono();
+    app.route('/tunnels', tunnelRoutes);
+  });
+
+  it('POST /allowlist returns 403 when caller lacks DEVICES_EXECUTE', async () => {
+    const res = await app.request('/tunnels/allowlist', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-deny-permission': DENY },
+      body: JSON.stringify(ruleBody),
+    });
+
+    expect(res.status).toBe(403);
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('POST /allowlist succeeds (201) for a caller WITH DEVICES_EXECUTE', async () => {
+    vi.mocked(db.insert).mockReturnValue(makeInsertChain([{ id: RULE_ID, orgId: ORG_ID, ...ruleBody }]) as any);
+
+    const res = await app.request('/tunnels/allowlist', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(ruleBody),
+    });
+
+    expect(res.status).toBe(201);
+    expect(db.insert).toHaveBeenCalledTimes(1);
+  });
+
+  it('PUT /allowlist/:id returns 403 when caller lacks DEVICES_EXECUTE', async () => {
+    const res = await app.request(`/tunnels/allowlist/${RULE_ID}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', 'x-deny-permission': DENY },
+      body: JSON.stringify({ enabled: false }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('PUT /allowlist/:id succeeds for a caller WITH DEVICES_EXECUTE', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([{ id: RULE_ID, orgId: ORG_ID }]) as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: RULE_ID, enabled: false }]),
+        }),
+      }),
+    } as any);
+
+    const res = await app.request(`/tunnels/allowlist/${RULE_ID}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled: false }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(db.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('DELETE /allowlist/:id returns 403 when caller lacks DEVICES_EXECUTE', async () => {
+    const res = await app.request(`/tunnels/allowlist/${RULE_ID}`, {
+      method: 'DELETE',
+      headers: { 'x-deny-permission': DENY },
+    });
+
+    expect(res.status).toBe(403);
+    expect(db.select).not.toHaveBeenCalled();
+    expect(db.delete).not.toHaveBeenCalled();
+  });
+
+  it('DELETE /allowlist/:id succeeds for a caller WITH DEVICES_EXECUTE', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([{ id: RULE_ID, orgId: ORG_ID }]) as any);
+    vi.mocked(db.delete).mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    } as any);
+
+    const res = await app.request(`/tunnels/allowlist/${RULE_ID}`, { method: 'DELETE' });
+
+    expect(res.status).toBe(200);
+    expect(db.delete).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── POST /allowlist — siteId cross-org validation ───────────────────────────
+// Secondary hardening for Finding #7: a body.siteId is an arbitrary uuid until
+// proven to belong to the resolved org. A site from another org is rejected
+// before any rule is inserted.
+
+describe('POST /allowlist — siteId belongs-to-org validation', () => {
+  let app: Hono;
+  const RULE_ID = 'f1f1f1f1-f1f1-4f1f-8f1f-f1f1f1f1f1f1';
+  const SITE_IN_ORG = 'a0a0a0a0-a0a0-4a0a-8a0a-a0a0a0a0a0a0';
+  const FOREIGN_SITE = 'c9c9c9c9-c9c9-4c9c-8c9c-c9c9c9c9c9c9';
+
+  const baseBody = {
+    direction: 'destination',
+    pattern: '10.1.2.50/32:80-443',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.select).mockReset();
+    app = new Hono();
+    app.route('/tunnels', tunnelRoutes);
+  });
+
+  it('rejects a siteId that does not belong to the resolved org (404, no insert)', async () => {
+    // siteBelongsToOrg select returns no rows → site not in this org.
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([]) as any);
+
+    const res = await app.request('/tunnels/allowlist', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...baseBody, siteId: FOREIGN_SITE }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('accepts a siteId that belongs to the resolved org (201)', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([{ id: SITE_IN_ORG }]) as any);
+    vi.mocked(db.insert).mockReturnValue(makeInsertChain([{ id: RULE_ID, orgId: ORG_ID, siteId: SITE_IN_ORG }]) as any);
+
+    const res = await app.request('/tunnels/allowlist', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...baseBody, siteId: SITE_IN_ORG }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(db.insert).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the site lookup entirely when no siteId is provided (201)', async () => {
+    vi.mocked(db.insert).mockReturnValue(makeInsertChain([{ id: RULE_ID, orgId: ORG_ID }]) as any);
+
+    const res = await app.request('/tunnels/allowlist', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(baseBody),
+    });
+
+    expect(res.status).toBe(201);
+    expect(db.select).not.toHaveBeenCalled();
+    expect(db.insert).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/routes/tunnels.ts
+++ b/apps/api/src/routes/tunnels.ts
@@ -3,7 +3,7 @@ import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { and, eq, desc, inArray, isNull, or } from 'drizzle-orm';
 import { db, withSystemDbAccessContext } from '../db';
-import { tunnelSessions, tunnelAllowlists, devices, users, remoteSessions } from '../db/schema';
+import { tunnelSessions, tunnelAllowlists, devices, users, remoteSessions, sites } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { sendCommandToAgent, isAgentConnected } from './agentWs';
 import { checkRemoteAccess } from '../services/remoteAccessPolicy';
@@ -226,6 +226,19 @@ async function isTunnelDeviceSiteDenied(deviceId: string, perms: UserPermissions
   return !device || typeof device.siteId !== 'string' || !canAccessSite(perms, device.siteId);
 }
 
+// Confirm a siteId belongs to the resolved org before it is stored on an
+// allowlist rule. Mirrors the site-belongs-to-org checks in networkBaselines.ts
+// / groups.ts. RLS does NOT defend the site axis, so an unchecked body.siteId
+// could otherwise scope (or mask) a rule against an arbitrary site uuid.
+async function siteBelongsToOrg(siteId: string, orgId: string): Promise<boolean> {
+  const [site] = await db
+    .select({ id: sites.id })
+    .from(sites)
+    .where(and(eq(sites.id, siteId), eq(sites.orgId, orgId)))
+    .limit(1);
+  return !!site;
+}
+
 async function getActiveAllowlistPatterns(orgId: string): Promise<string[]> {
   const rules = await db
     .select({ pattern: tunnelAllowlists.pattern })
@@ -436,6 +449,8 @@ tunnelRoutes.get(
 tunnelRoutes.post(
   '/allowlist',
   requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_EXECUTE.resource, PERMISSIONS.DEVICES_EXECUTE.action),
+  requireMfa(),
   zValidator('json', allowlistRuleSchema),
   async (c) => {
     const auth = c.get('auth') as AuthContext;
@@ -444,6 +459,12 @@ tunnelRoutes.post(
     const orgId = orgResult.orgId;
 
     const body = c.req.valid('json');
+
+    // A body.siteId is an arbitrary uuid until proven to belong to the resolved
+    // org — RLS does not defend the site axis. Reject cross-org site ids.
+    if (body.siteId && !(await siteBelongsToOrg(body.siteId, orgId))) {
+      return c.json({ error: 'Site not found for this organization' }, 404);
+    }
 
     const [rule] = await db
       .insert(tunnelAllowlists)
@@ -467,6 +488,8 @@ tunnelRoutes.post(
 tunnelRoutes.put(
   '/allowlist/:id',
   requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_EXECUTE.resource, PERMISSIONS.DEVICES_EXECUTE.action),
+  requireMfa(),
   zValidator('param', allowlistIdParamSchema),
   zValidator('json', updateAllowlistSchema),
   async (c) => {
@@ -507,6 +530,8 @@ tunnelRoutes.put(
 tunnelRoutes.delete(
   '/allowlist/:id',
   requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_EXECUTE.resource, PERMISSIONS.DEVICES_EXECUTE.action),
+  requireMfa(),
   zValidator('param', allowlistIdParamSchema),
   async (c) => {
     const auth = c.get('auth') as AuthContext;

--- a/apps/api/src/services/aiToolsTicketing.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsTicketing.siteScope.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('./ticketService', () => ({
+  createTicket: vi.fn(async () => ({ id: 't-new' })),
+  changeTicketStatus: vi.fn(async () => ({ id: 't1', status: 'resolved' })),
+  assignTicket: vi.fn(async () => ({ id: 't1', assignedTo: 'u2' })),
+  addTicketComment: vi.fn(async () => ({ comment: { id: 'c1' } })),
+}));
+
+import { db } from '../db';
+import * as ticketService from './ticketService';
+import { registerTicketingTools } from './aiToolsTicketing';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerTicketingTools(reg);
+  return reg.get(name)!.handler;
+}
+
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any,
+    partnerId: null,
+    orgId: 'org-1',
+    scope: 'organization',
+    accessibleOrgIds: ['org-1'],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+    allowedSiteIds,
+    canAccessSite: (s: string | null) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  } as unknown as AuthContext;
+}
+
+// Mock select so that:
+//  - call 1 (findTicketWithAccess ticket load) -> returns the given ticket row
+//  - call 2 (deviceInSiteScope device load)   -> returns { siteId }
+function mockTicketThenDevice(ticket: Record<string, unknown>, deviceSiteId: string | null) {
+  let call = 0;
+  mockDb.select.mockImplementation(() => {
+    call++;
+    if (call === 1) {
+      return { from: () => ({ where: () => ({ limit: () => Promise.resolve([ticket]) }) }) };
+    }
+    return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ siteId: deviceSiteId }]) }) }) };
+  });
+}
+
+const handler = () => handlerFor('manage_tickets');
+
+describe('manage_tickets — by-id site scoping (out-of-site device denied)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('get denies a ticket whose device is in a forbidden site', async () => {
+    mockTicketThenDevice({ id: 't1', orgId: 'org-1', deviceId: 'd1' }, 'site-B');
+    const r = await handler()({ action: 'get', ticketId: 't1' }, makeAuth(['site-A']));
+    expect(JSON.parse(r).error).toBe('Ticket not found');
+  });
+
+  it('comment denies + does not mutate for an out-of-site device ticket', async () => {
+    mockTicketThenDevice({ id: 't1', orgId: 'org-1', deviceId: 'd1' }, 'site-B');
+    const r = await handler()(
+      { action: 'comment', ticketId: 't1', content: 'hi' },
+      makeAuth(['site-A'])
+    );
+    expect(JSON.parse(r).error).toBe('Ticket not found');
+    expect(ticketService.addTicketComment).not.toHaveBeenCalled();
+  });
+
+  it('assign denies + does not mutate for an out-of-site device ticket', async () => {
+    mockTicketThenDevice({ id: 't1', orgId: 'org-1', deviceId: 'd1' }, 'site-B');
+    const r = await handler()(
+      { action: 'assign', ticketId: 't1', assigneeId: 'u2' },
+      makeAuth(['site-A'])
+    );
+    expect(JSON.parse(r).error).toBe('Ticket not found');
+    expect(ticketService.assignTicket).not.toHaveBeenCalled();
+  });
+
+  it('update_status denies + does not mutate for an out-of-site device ticket', async () => {
+    mockTicketThenDevice({ id: 't1', orgId: 'org-1', deviceId: 'd1' }, 'site-B');
+    const r = await handler()(
+      { action: 'update_status', ticketId: 't1', status: 'resolved', resolutionNote: 'done' },
+      makeAuth(['site-A'])
+    );
+    expect(JSON.parse(r).error).toBe('Ticket not found');
+    expect(ticketService.changeTicketStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe('manage_tickets — by-id site scoping (in-site device allowed)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('get succeeds when the device is in an allowed site', async () => {
+    mockTicketThenDevice({ id: 't1', orgId: 'org-1', deviceId: 'd1' }, 'site-A');
+    const r = await handler()({ action: 'get', ticketId: 't1' }, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.ticket.id).toBe('t1');
+  });
+
+  it('update_status mutates when the device is in an allowed site', async () => {
+    mockTicketThenDevice({ id: 't1', orgId: 'org-1', deviceId: 'd1' }, 'site-A');
+    const r = await handler()(
+      { action: 'update_status', ticketId: 't1', status: 'resolved', resolutionNote: 'done' },
+      makeAuth(['site-A'])
+    );
+    expect(JSON.parse(r).error).toBeUndefined();
+    expect(ticketService.changeTicketStatus).toHaveBeenCalled();
+  });
+});
+
+describe('manage_tickets — by-id site scoping (null-device ticket = org scope)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('get on a deviceless ticket stays accessible to a site-restricted caller', async () => {
+    // Only the ticket load happens; deviceInSiteScope is skipped for null deviceId.
+    mockDb.select.mockReturnValue({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 't1', orgId: 'org-1', deviceId: null }]) }) }),
+    });
+    const r = await handler()({ action: 'get', ticketId: 't1' }, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.ticket.id).toBe('t1');
+  });
+
+  it('update_status on a deviceless ticket mutates for a site-restricted caller', async () => {
+    mockDb.select.mockReturnValue({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 't1', orgId: 'org-1', deviceId: null }]) }) }),
+    });
+    const r = await handler()(
+      { action: 'update_status', ticketId: 't1', status: 'resolved', resolutionNote: 'done' },
+      makeAuth(['site-A'])
+    );
+    expect(JSON.parse(r).error).toBeUndefined();
+    expect(ticketService.changeTicketStatus).toHaveBeenCalled();
+  });
+});
+
+describe('manage_tickets — unrestricted caller unaffected', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('get succeeds for an unrestricted caller even with a device-bound ticket', async () => {
+    // allowedSiteIds undefined → deviceInSiteScope short-circuits true (no device load).
+    mockDb.select.mockReturnValue({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 't1', orgId: 'org-1', deviceId: 'd1' }]) }) }),
+    });
+    const r = await handler()({ action: 'get', ticketId: 't1' }, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.ticket.id).toBe('t1');
+  });
+});

--- a/apps/api/src/services/aiToolsTicketing.ts
+++ b/apps/api/src/services/aiToolsTicketing.ts
@@ -31,7 +31,7 @@ function actorFrom(auth: AuthContext) {
  * (getScopedTicketOr404) — build orgCondition-scoped conditions so neither
  * a cross-org nor a cross-partner ticket ID resolves.
  *
- * Site axis (#1047 class): RLS enforces only the org axis, so a site-restricted
+ * Site axis: RLS enforces only the org axis, so a site-restricted
  * org user must also be gated on the SITE axis here. After the org-scoped load,
  * a device-bound ticket is resolved only when its device's site is in the
  * caller's allowlist (deviceInSiteScope); deviceless (org-level) tickets stay

--- a/apps/api/src/services/aiToolsTicketing.ts
+++ b/apps/api/src/services/aiToolsTicketing.ts
@@ -10,7 +10,7 @@ import { and, desc, eq, type SQL } from 'drizzle-orm';
 import { db } from '../db';
 import { tickets } from '../db/schema';
 import type { AuthContext } from '../middleware/auth';
-import { ticketSiteScopeCondition } from '../routes/tickets/siteScope';
+import { deviceInSiteScope, ticketSiteScopeCondition } from '../routes/tickets/siteScope';
 import type { AiTool, AiToolTier } from './aiTools';
 import {
   createTicket,
@@ -31,14 +31,24 @@ function actorFrom(auth: AuthContext) {
  * (getScopedTicketOr404) — build orgCondition-scoped conditions so neither
  * a cross-org nor a cross-partner ticket ID resolves.
  *
- * Returns the ticket row, or null when not found in the caller's scope.
+ * Site axis (#1047 class): RLS enforces only the org axis, so a site-restricted
+ * org user must also be gated on the SITE axis here. After the org-scoped load,
+ * a device-bound ticket is resolved only when its device's site is in the
+ * caller's allowlist (deviceInSiteScope); deviceless (org-level) tickets stay
+ * accessible at org scope — matching getScopedTicketOr404 in the HTTP route.
+ *
+ * Returns the ticket row, or null when not found / out of the caller's scope.
  */
 async function findTicketWithAccess(ticketId: string, auth: AuthContext) {
   const conditions: SQL[] = [eq(tickets.id, ticketId)];
   const orgCond = auth.orgCondition(tickets.orgId);
   if (orgCond) conditions.push(orgCond);
   const [ticket] = await db.select().from(tickets).where(and(...conditions)).limit(1);
-  return ticket ?? null;
+  if (!ticket) return null;
+  if (ticket.deviceId && !(await deviceInSiteScope(auth, ticket.deviceId))) {
+    return null;
+  }
+  return ticket;
 }
 
 export function registerTicketingTools(aiTools: Map<string, AiTool>): void {

--- a/apps/api/src/services/eventDispatcher.test.ts
+++ b/apps/api/src/services/eventDispatcher.test.ts
@@ -171,6 +171,94 @@ describe('EventDispatcher', () => {
     dispatcher.unregister('org-1', client);
   });
 
+  // -------------------------------------------------------------------
+  // Per-client `filter` predicate (site-scope authz hook).
+  //
+  // The dispatch loop consults `client.filter` after the subscription-type
+  // match: deliver only when the predicate returns true, and FAIL CLOSED on
+  // throw (drop the event for that client without crashing dispatch or
+  // affecting other clients). Exercised through the real `dispatch()`.
+  // -------------------------------------------------------------------
+
+  it('delivers an event the per-client filter accepts', () => {
+    const dispatcher = getEventDispatcher();
+    const ws = mockWs();
+    const client = {
+      ws,
+      userId: 'user-1',
+      subscribedTypes: new Set(['device.*']),
+      filter: (e: Record<string, unknown>) => (e as any).payload?.siteId === 'site-a',
+    };
+    dispatcher.register('org-1', client);
+
+    (dispatcher as any).dispatch(
+      'org-1',
+      JSON.stringify({ type: 'device.online', orgId: 'org-1', payload: { siteId: 'site-a' } }),
+    );
+    expect(ws.send).toHaveBeenCalledTimes(1);
+
+    dispatcher.unregister('org-1', client);
+  });
+
+  it('drops an event the per-client filter rejects', () => {
+    const dispatcher = getEventDispatcher();
+    const ws = mockWs();
+    const client = {
+      ws,
+      userId: 'user-1',
+      subscribedTypes: new Set(['device.*']),
+      filter: (e: Record<string, unknown>) => (e as any).payload?.siteId === 'site-a',
+    };
+    dispatcher.register('org-1', client);
+
+    // Event subscribed-type matches, but the filter rejects it (wrong site).
+    (dispatcher as any).dispatch(
+      'org-1',
+      JSON.stringify({ type: 'device.online', orgId: 'org-1', payload: { siteId: 'site-b' } }),
+    );
+    expect(ws.send).not.toHaveBeenCalled();
+
+    dispatcher.unregister('org-1', client);
+  });
+
+  it('fails closed when a filter throws: drops the event for that client without affecting others', () => {
+    const dispatcher = getEventDispatcher();
+    const filteredWs = mockWs();
+    const plainWs = mockWs();
+
+    const throwingClient = {
+      ws: filteredWs,
+      userId: 'user-throws',
+      subscribedTypes: new Set(['device.*']),
+      filter: () => {
+        throw new Error('boom');
+      },
+    };
+    // Second client on the SAME org with no filter — must still receive the event.
+    const plainClient = {
+      ws: plainWs,
+      userId: 'user-plain',
+      subscribedTypes: new Set(['device.*']),
+    };
+    dispatcher.register('org-1', throwingClient);
+    dispatcher.register('org-1', plainClient);
+
+    expect(() =>
+      (dispatcher as any).dispatch(
+        'org-1',
+        JSON.stringify({ type: 'device.online', orgId: 'org-1', payload: { siteId: 'site-a' } }),
+      ),
+    ).not.toThrow();
+
+    // Fail closed: the throwing client's event is dropped.
+    expect(filteredWs.send).not.toHaveBeenCalled();
+    // The unfiltered client on the same org is unaffected.
+    expect(plainWs.send).toHaveBeenCalledTimes(1);
+
+    dispatcher.unregister('org-1', throwingClient);
+    dispatcher.unregister('org-1', plainClient);
+  });
+
   it('unsubscribes from Redis when last client for org disconnects', () => {
     const dispatcher = getEventDispatcher();
     const ws = mockWs();

--- a/apps/api/src/services/eventDispatcher.ts
+++ b/apps/api/src/services/eventDispatcher.ts
@@ -20,6 +20,19 @@ export interface ClientEntry {
   ws: WSContext;
   userId: string;
   subscribedTypes: Set<string>;
+  /**
+   * Optional per-client delivery predicate. When present, an event is only
+   * delivered to this client if `filter(event)` returns true (in addition to
+   * the event-type subscription match). The dispatcher stays generic — it
+   * knows nothing about *why* a client filters; the authz semantics
+   * (e.g. site-scope restriction) are owned entirely by the registrant
+   * (see `eventWs.ts`). Unset = no extra filtering (full org access).
+   *
+   * `event` is the parsed `BreezeEvent` payload published on
+   * `breeze:events:live:<orgId>`. The predicate must be synchronous and
+   * must not throw (the dispatch loop fails closed on throw).
+   */
+  filter?: (event: Record<string, unknown>) => boolean;
 }
 
 class EventDispatcher {
@@ -105,6 +118,18 @@ class EventDispatcher {
         if (matchesEventType(eventType, pattern)) {
           matches = true;
           break;
+        }
+      }
+
+      // Per-client delivery predicate (e.g. site-scope authz, set by the WS
+      // registrant). Generic hook — the dispatcher carries no site knowledge.
+      // Fail closed: a throwing predicate drops the event for this client.
+      if (matches && client.filter) {
+        try {
+          matches = client.filter(parsed);
+        } catch (err) {
+          console.warn(`[EventDispatcher] Client ${client.userId} filter threw for ${eventType}, dropping event:`, err instanceof Error ? err.message : err);
+          matches = false;
         }
       }
 

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -1191,3 +1191,100 @@ describe('changeTicketStatus — SLA pause/resume (D4)', () => {
     expect(updatePayload.slaPausedMinutes).toBe(1); // floor(1.5) = 1
   });
 });
+
+// Finding #9: these mutations previously emitted only a BullMQ event and left no
+// tamper-evident audit_logs row. Each must now write an audit row mirroring the
+// createTicket/changeTicketStatus/updateTicketFields reference pattern.
+describe('Finding #9 — audit-log coverage for mutating ticket actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    valuesMock.mockClear();
+    setMock.mockClear();
+  });
+
+  it('assignTicket writes a ticket.assign audit row with previous/new assignee', async () => {
+    dbMocks.selectResult
+      .mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', partnerId: 'p-1', status: 'new', assignedTo: 'u-old' }]) // ticket
+      .mockResolvedValueOnce([{ id: 'u-2', partnerId: 'p-1' }]);                                                   // assignee
+    dbMocks.updateReturning.mockResolvedValue([{ id: 't-1', assignedTo: 'u-2', status: 'open' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+
+    await assignTicket('t-1', 'u-2', actor);
+
+    expect(auditMock).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: 'o-1',
+      actorId: 'u-1',
+      action: 'ticket.assign',
+      resourceType: 'ticket',
+      resourceId: 't-1',
+      details: { from: 'u-old', to: 'u-2' },
+      result: 'success'
+    }));
+  });
+
+  it('addTicketComment writes a ticket.comment audit row with commentId + isInternal (no body)', async () => {
+    dbMocks.selectResult.mockResolvedValue([{ id: 't-1', orgId: 'o-1', partnerId: 'p-1', status: 'open', firstResponseAt: new Date() }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-9', isPublic: false }]);
+
+    await addTicketComment('t-1', { content: 'secret internal note', isPublic: false }, actor);
+
+    expect(auditMock).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: 'o-1',
+      actorId: 'u-1',
+      action: 'ticket.comment',
+      resourceType: 'ticket',
+      resourceId: 't-1',
+      details: { commentId: 'c-9', isInternal: true },
+      result: 'success'
+    }));
+    // The comment body must never be dumped into the audit details.
+    const auditArg = auditMock.mock.calls[0]![0];
+    expect(JSON.stringify(auditArg)).not.toContain('secret internal note');
+  });
+
+  it('linkAlertToTicket writes a ticket.alert_link audit row with the alertId', async () => {
+    dbMocks.selectResult
+      .mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', partnerId: 'p-1', status: 'open' }])
+      .mockResolvedValueOnce([{ id: 'a-1', orgId: 'o-1', title: 'CPU high' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'link-1' }]);
+
+    await linkAlertToTicket('t-1', 'a-1', actor);
+
+    expect(auditMock).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: 'o-1',
+      actorId: 'u-1',
+      action: 'ticket.alert_link',
+      resourceType: 'ticket',
+      resourceId: 't-1',
+      details: { alertId: 'a-1' },
+      result: 'success'
+    }));
+  });
+
+  it('unlinkAlertFromTicket writes a ticket.alert_unlink audit row with the alertId', async () => {
+    dbMocks.selectResult.mockResolvedValue([{ id: 't-1', orgId: 'o-1', partnerId: 'p-1', status: 'open' }]);
+    dbMocks.insertReturning.mockResolvedValueOnce([{ id: 'link-1' }]).mockResolvedValue([{ id: 'c-1' }]);
+
+    await unlinkAlertFromTicket('t-1', 'a-1', actor);
+
+    expect(auditMock).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: 'o-1',
+      actorId: 'u-1',
+      action: 'ticket.alert_unlink',
+      resourceType: 'ticket',
+      resourceId: 't-1',
+      details: { alertId: 'a-1' },
+      result: 'success'
+    }));
+  });
+
+  it('does NOT audit when the mutation fails (e.g. concurrent assign conflict)', async () => {
+    dbMocks.selectResult
+      .mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', partnerId: 'p-1', status: 'open', assignedTo: null }])
+      .mockResolvedValueOnce([{ id: 'u-2', partnerId: 'p-1' }]);
+    dbMocks.updateReturning.mockResolvedValue([]); // concurrent modification → throws before audit
+
+    await assignTicket('t-1', 'u-2', actor).catch(() => {});
+    expect(auditMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -548,6 +548,15 @@ export async function assignTicket(ticketId: string, assigneeId: string | null, 
     actorUserId: actor.userId,
     payload: { assigneeId }
   });
+  await createAuditLogAsync({
+    orgId: ticket.orgId,
+    actorId: actor.userId,
+    action: 'ticket.assign',
+    resourceType: 'ticket',
+    resourceId: ticketId,
+    details: { from: prevAssignedTo ?? null, to: assigneeId },
+    result: 'success'
+  });
   return updated[0];
 }
 
@@ -588,6 +597,18 @@ export async function addTicketComment(ticketId: string, input: AddCommentInput,
     partnerId: ticket.partnerId ?? null,
     actorUserId: actor.userId,
     payload: { commentId: comment.id, isPublic: input.isPublic }
+  });
+  // Record the comment id + visibility only — the comment body can carry
+  // sensitive/large content, so it stays out of the audit details (matching the
+  // sibling pattern of keeping details lean).
+  await createAuditLogAsync({
+    orgId: ticket.orgId,
+    actorId: actor.userId,
+    action: 'ticket.comment',
+    resourceType: 'ticket',
+    resourceId: ticketId,
+    details: { commentId: comment.id, isInternal: !input.isPublic },
+    result: 'success'
   });
 
   return { comment, firstResponseStamped };
@@ -642,6 +663,16 @@ export async function linkAlertToTicket(
     newValue: alertId
   });
 
+  await createAuditLogAsync({
+    orgId: ticket.orgId,
+    actorId: actor.userId,
+    action: 'ticket.alert_link',
+    resourceType: 'ticket',
+    resourceId: ticketId,
+    details: { alertId },
+    result: 'success'
+  });
+
   return inserted[0];
 }
 
@@ -664,6 +695,16 @@ export async function unlinkAlertFromTicket(ticketId: string, alertId: string, a
     content: 'Unlinked alert',
     isPublic: false,
     oldValue: alertId
+  });
+
+  await createAuditLogAsync({
+    orgId: ticket.orgId,
+    actorId: actor.userId,
+    action: 'ticket.alert_unlink',
+    resourceType: 'ticket',
+    resourceId: ticketId,
+    details: { alertId },
+    result: 'success'
   });
   return { ticketId, alertId, orgId: ticket.orgId };
 }

--- a/docs/superpowers/specs/2026-06-12-security-review-tenant-authz-results.md
+++ b/docs/superpowers/specs/2026-06-12-security-review-tenant-authz-results.md
@@ -1,0 +1,62 @@
+# Security Review — Multi-Tenant Isolation + AuthZ (All API Routes)
+
+**Date:** 2026-06-12
+**Scope:** Multi-tenant isolation + authorization across all `apps/api/src/routes/` (and parallel `services/aiTools*.ts` paths). Two-pass fan-out: 15 resource-group finder agents → one adversarial read-only verifier per candidate → drop < 8/10.
+**Coverage:** 795 endpoints audited, 15 groups, 34 candidates generated, 11 confirmed, 23 dropped.
+
+## Headline
+
+**No cross-tenant (cross-org / cross-partner) read, write, or privilege-escalation hole was found.** Org-axis RLS (`breeze_has_org_access` / `breeze_has_partner_access`, ENABLE+FORCE) holds on every tenant table touched, and forged cross-org ids are rejected at the database independent of the app-layer WHERE. The previously-fixed nested-EXISTS bug class (`script_execution_batches`) and the dual-axis blindspot (`custom_field_definitions`, fixed 2026-06-11-i) are both confirmed remediated.
+
+**Every confirmed finding is one of three intra-tenant classes:**
+1. **Site sub-axis bypass** — RLS deliberately does not model `site`; several routes omit the app-layer `allowedSiteIds` check their siblings enforce. (6 findings)
+2. **Intra-tenant RBAC gap** — mutating routes gate on `requireScope` (tier) only, missing `requirePermission`/`requireMfa`. (3 findings)
+3. **Missing audit trail** — mutating actions not written to the tamper-evident `audit_logs` hash chain. (2 findings)
+
+## Confirmed Findings
+
+| # | Sev | Group | File:Line | Endpoint | Finding |
+|---|-----|-------|-----------|----------|---------|
+| 1 | **HIGH** | security-compliance | `routes/sensitiveData.ts:704` | POST `/sensitive-data/remediate` | Destructive remediation (encrypt/quarantine/secure_delete) matches findings on org only — site-restricted insider can destroy files on out-of-site devices |
+| 2 | MEDIUM | devices | `routes/tags.ts:65` | GET `/tags`, GET `/tags/devices` | Omits `allowedSiteIds` — site-restricted user reads device id/hostname/OS/status/tags across all sites in the org |
+| 3 | MEDIUM | patching | `routes/patches/approvals.ts:66` | POST `/patches/bulk-approve`,`/:id/approve`,`/decline`,`/defer` | No `requirePermission`/`requireMfa`; read-only org role can approve/decline/defer patch deployment |
+| 4 | MEDIUM | ai-mcp | `services/aiToolsTicketing.ts:36` | `manage_tickets` (MCP + SDK) get/comment/assign/update_status | Parallel-path site-axis gap — site-restricted caller reads/mutates tickets bound to out-of-site devices (#1047 class) |
+| 5 | MEDIUM | software | `routes/softwareInventory.ts:305` | POST `/software-inventory/approve`,`/deny`,`/clear` | Allow/blocklist policy mutations write no audit log (sibling `softwarePolicies.ts` does) |
+| 6 | MEDIUM | alerts | `routes/alerts/rules.ts:130` | POST/PUT/DELETE alert rules, policies, routing-rules, templates | Gate `requireScope` only, not `ALERTS_WRITE`; read-only org user can edit/delete alerting (channels.ts gates correctly) |
+| 7 | MEDIUM | remote-access | `routes/tunnels.ts:436` | POST/PUT/DELETE `/tunnels/allowlist(/:id)` | Allowlist mutation needs no RBAC permission/MFA; any org member can widen the tunnel-target allowlist to RFC1918 /8 |
+| 8 | MEDIUM | remote-access | `routes/eventWs.ts:202` | POST `/events/ws-ticket` + GET `/events/ws` | Event stream scoped to org only (Redis pub/sub); site-restricted user receives live device/alert/session events for other sites |
+| 9 | MEDIUM | tickets-incidents | `services/ticketService.ts:543` | POST `/tickets/:id/assign`,`/comments`,`/alerts`; DELETE `/alerts/:alertId` | Assign/comment/alert-link write no `audit_logs` entry (create/status/field-update do) |
+| 10 | MEDIUM | security-compliance | `routes/sensitiveData.ts:617` | GET `/sensitive-data/dashboard` | Aggregates PII/PCI/PHI counts across all sites for site-restricted users (intra-org count leak) |
+| 11 | MEDIUM | security-compliance | `routes/cisHardening.ts:787` | POST `/cis/remediate/approve` | Approval dispatches agent remediation without re-checking device site scope |
+
+### Statistics
+- **CRITICAL: 0**
+- **HIGH: 1** (#1)
+- **MEDIUM: 10**
+- **LOW: 0** (confirmed; several LOWs dropped < 8)
+- **PASS:** org/partner cross-tenant isolation across all 15 groups; agent/WS ticket ownership; SSO callback; admin/system scope gating; secret encryption-at-rest; the two known historical RLS bug classes.
+
+## Top Priority Actions
+
+1. **#1 (HIGH) — sensitive-data remediate site scope.** This is the only finding with a *destructive* + *cross-site* combination. Add device→site gating before queuing `ENCRYPT_FILE`/`QUARANTINE_FILE`/`SECURE_DELETE_FILE`, mirroring the `POST /scan` handler (sensitiveData.ts:312-318). Same-PR companions: #10 (dashboard) and #11 (CIS approve) are the same site-axis omission in the security-compliance group.
+2. **Site-axis sweep.** Findings #1, #2, #4, #8, #10, #11 are all the same root cause — a route reads/acts on `org` alone where a sibling enforces `allowedSiteIds`. Worth a single sweep (extend the route/aiTools scanner to flag device-touching handlers that don't call `canAccessSite`/`deviceInSiteScope`), because RLS provides *no* backstop on this axis. This is the recurring #864/#868 + #1047 class.
+3. **RBAC permission gates on mutating routes.** Findings #3, #6, #7 each gate on `requireScope` tier instead of `requirePermission`. A read-only org role should not approve patches, edit alert rules, or widen tunnel allowlists. Add the missing `requirePermission(...)` (+ `requireMfa()` where siblings have it).
+4. **Audit-log gaps.** #5 (software policy) and #9 (ticket assign/comment/link) bypass the tamper-evident chain. Add `writeRouteAudit`/`createAuditLogAsync` mirroring the audited sibling mutations.
+
+## Dropped (< 8) — human-review triggers, not dismissals
+
+The methodology treats dismissals as review triggers. Of the 23 dropped, one coherent class is worth a tracking ticket even though each scored 4-7 (currently guarded app-layer, so not independently exploitable today): **tenant child tables with NO RLS at all, invisible to the rls-coverage contract test** (app-layer-only isolation, defense-in-depth gap):
+
+- `maintenance_occurrences` (`0001-baseline.sql:3928`)
+- `network_monitor_results`, `network_monitor_alert_rules` (`0001-baseline.sql:4092`)
+- `webhook_deliveries` (`0001-baseline.sql:6034`)
+- `role_permissions` (RBAC join table)
+- `dashboard_widgets` (`analytics.ts:748`)
+
+Each should either get RLS in the right tenancy shape or be explicitly added to `INTENTIONAL_UNSCOPED` with justification, and the contract test extended to catch un-RLS'd FK-child tables.
+
+Other dropped items (all MEDIUM/LOW, verifier conf 2-7): script execution-list relying solely on RLS (holds today), in-memory script-library mock (no persistence), `network_known_guests` org-tree EXISTS vs flat partner helper (latent), DNS read endpoints lacking `requirePermission`, access-review/incident-AI MFA step-up inconsistencies, portal asset cross-checkin, `POST /support` external forward without audit. Full per-finding verdicts in the workflow result.
+
+## Method note
+
+Verification was read-only (no DB connection) per methodology. Several findings include a reasoned `proofStatement` — the exact SQL the RLS policy would *permit* for the attacker's own org — demonstrating that on the site axis the database has no predicate to reason against. These were not executed. For the HIGH (#1) and the RBAC findings, confirm with a live `breeze_app` repro before/after the fix.


### PR DESCRIPTION
## Summary

Two-pass multi-tenant security review (15 resource groups, **795 endpoints audited**) found **no cross-tenant read/write or privilege-escalation hole** — org-axis RLS (`breeze_has_org_access`/`breeze_has_partner_access`, enabled+forced) holds everywhere, and forged cross-org ids are rejected at the DB. The two historical RLS bug classes (nested-EXISTS bound-param on `script_execution_batches`; dual-axis blindspot on `custom_field_definitions`) are confirmed remediated.

This PR closes the **11 confirmed intra-tenant findings**. Each fix mirrors an already-correct sibling and ships a regression test.

## Findings fixed

| # | Sev | File | Fix |
|---|-----|------|-----|
| 1 | **HIGH** | `routes/sensitiveData.ts` | Gate `POST /remediate` destructive actions (encrypt/quarantine/secure_delete) by `allowedSiteIds` before queuing agent commands |
| 2 | MED | `routes/tags.ts` | Narrow `GET /tags` + `/tags/devices` by `allowedSiteIds` |
| 3 | MED | `routes/patches/approvals.ts` | `requirePermission(devices:execute)` + `requireMfa` on approve/decline/defer/bulk-approve |
| 4 | MED | `services/aiToolsTicketing.ts` | Site-gate `manage_tickets` by-id actions via `deviceInSiteScope` |
| 5 | MED | `routes/softwareInventory.ts` | Audit approve/deny/clear software-policy mutations |
| 6 | MED | `routes/alerts/*`, `alertTemplates/*` | `ALERTS_WRITE`/`ALERTS_ACKNOWLEDGE` (+MFA) on rule/policy/routing/template/state-change mutations |
| 7 | MED | `routes/tunnels.ts` | `devices:execute`+MFA on allowlist mutations; validate `body.siteId` belongs to org |
| 8 | MED | `routes/eventWs.ts` | Carry `allowedSiteIds` onto ws ticket + per-client fail-closed dispatch filter |
| 9 | MED | `services/ticketService.ts` | Audit assign/comment/alert_link/alert_unlink |
| 10 | MED | `routes/sensitiveData.ts` | Site-narrow `GET /dashboard` aggregate |
| 11 | MED | `routes/cisHardening.ts` | Re-check device site scope in `POST /remediate/approve` |

**Three classes:** site sub-axis (RLS does not model `site` — app-layer-only, 6 fixes), RBAC tier-vs-permission gaps (3), missing tamper-evident audit writes (2).

## ⚠️ Reviewer notes

1. **`eventWs` (#8) fails closed — behavior change.** No event publisher currently emits `siteId` (all 56 publish sites checked). The fix delivers only on a positive site match, so **site-restricted users receive no live events** until publishers add `siteId`. Strictly safer than the prior cross-site leak, but it degrades the live feed for those users. Tracked as a follow-up (see linked issue); unrestricted users unaffected. The one cross-file edit lives here: a generic, site-agnostic `filter` predicate on `eventDispatcher.ts`.
2. **Tests use Drizzle mocks** — they assert the gate is invoked, not real RLS/permission resolution. Recommend a live `breeze_app` repro for the HIGH (#1) and the RBAC findings before release.

## Verification

- `tsc --noEmit -p apps/api` clean (only the two known pre-existing `agents.test.ts`/`apiKeyAuth.test.ts` errors).
- Affected suites: **267 tests / 17 files** pass.
- Sibling regression suites: **94 tests / 10 files** pass.
- 24 files changed, disjoint ownership (one subagent per file set).

Full review write-up: `docs/superpowers/specs/2026-06-12-security-review-tenant-authz-results.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)